### PR TITLE
test(clash): pin the join between clashSolidRequestSeq and the compute that reads it

### DIFF
--- a/apps/viewer/src/hooks/useClash.solid-inflight-invalidation.test.tsx
+++ b/apps/viewer/src/hooks/useClash.solid-inflight-invalidation.test.tsx
@@ -1,0 +1,382 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The JOIN between the `clashSolidRequestSeq` producers and the consumer that
+ * reads it.
+ *
+ * Four sibling suites pin the PRODUCER side — that Home reset, the clash tour
+ * cleanup, `clearClashFocus` and the model-lifecycle teardowns each bump
+ * `clashSolidRequestSeq`:
+ *
+ *   - `store/homeView.solid-teardown.test.ts`
+ *   - `store/slices/clashSlice.solid.test.ts`
+ *   - `lib/tours/tours/clash.solid-teardown.test.ts`
+ *   - `store/modelLifecycle.solid-teardown.test.ts`
+ *
+ * `lib/clash/intersection-solid.test.ts` pins the CALLEE — the wasm kernel
+ * wrapper — by calling it directly. Nothing pinned the line that connects
+ * them: the staleness check in `useClash.ts` that compares the seq captured
+ * before `computeClashIntersectionSolid()` against the seq at resolve time and
+ * drops the result if they differ. Deleting BOTH copies of that check (the
+ * `.then` and the `.catch`) left all four producer suites, the callee suite,
+ * `useClash.solid-invalidation.test.tsx`, `ClashPanel.focus-teardown.test.tsx`
+ * and `modelLifecycle.visibility-ownership.test.ts` green — 36 tests, zero
+ * failures. Those suites write `clashSolidStatus: 'computing'` as a plain
+ * string and assert only that the seq CHANGED; no compute was ever in flight,
+ * so nothing observed whether a stale one still painted.
+ *
+ * This file drives the REAL hook over the REAL wasm kernel and lets a genuine
+ * compute be in flight across each teardown.
+ *
+ * ## The interleaving is real, not simulated
+ *
+ * `focusClash` calls `setClashSolidComputing()` synchronously, one statement
+ * before it launches `computeClashIntersectionSolid(...)` and after it has
+ * already captured its request seq. A store subscription on that status
+ * transition therefore fires INSIDE `focusClash`, with the compute about to be
+ * launched under an already-captured seq — the exact window. There is
+ * deliberately NO `await flush()` / `tick()` / `Promise.resolve()` between the
+ * teardown firing and the compute landing: such a flush would let the compute
+ * resolve and paint first, the teardown would then clear the painted solid
+ * itself, and every assertion below would pass against a hook with no
+ * staleness check at all.
+ *
+ * The companion suite at the bottom pins that an UNDISTURBED focus still
+ * paints its solid, so a guard that discarded every result cannot pass this
+ * file.
+ *
+ * ## Known residual
+ *
+ * Only the `.then` copy of the staleness check is covered here. The `.catch`
+ * copy needs the kernel to REJECT, and it does not reject on any input reached
+ * from the hook: a malformed operand comes back as a resolved
+ * `{ isSolid: false }` (verified against the real wasm binding), not a thrown
+ * error. Forcing a rejection would mean mocking the kernel — a production seam
+ * that does not exist today — so the `.catch` guard stays unpinned rather than
+ * being pinned by reshaping the hook to suit a test.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { initSync } from '@ifc-lite/wasm';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import type { Clash, ClashRule } from '@ifc-lite/clash';
+import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
+
+import { useViewerStore, type FederatedModel } from '@/store';
+import { resetVisibilityForHomeFromStore } from '@/store/homeView';
+import { CLASH_TOUR } from '@/lib/tours/tours/clash';
+import { useClash } from './useClash.js';
+
+// ─── Real wasm, loaded from disk ────────────────────────────────────────────
+// Same rationale and pattern as `lib/clash/intersection-solid.test.ts`: the
+// wrapper's own `init()` resolves the binary through `fetch()`, which this
+// runner has no answer for, and `initSync` shares the same module singleton so
+// pre-loading it here makes that `init()` a no-op. Skipped per-test when the
+// build artifact is absent, so a missing `bash scripts/build-wasm.sh` skips
+// visibly instead of throwing before the first test.
+
+const wasmPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..', '..', '..', '..', 'packages', 'wasm', 'pkg', 'ifc-lite_bg.wasm',
+);
+
+let wasmReady = false;
+function ensureWasm(t: { skip: (msg: string) => void }): boolean {
+  if (wasmReady) return true;
+  if (!existsSync(wasmPath)) {
+    t.skip('wasm bundle not built — run `bash scripts/build-wasm.sh` first');
+    return false;
+  }
+  initSync({ module: readFileSync(wasmPath) });
+  wasmReady = true;
+  return true;
+}
+
+// ─── Fixture: two overlapping unit boxes in one model ───────────────────────
+// Lifted from `useClash.stale-run-teardown.test.tsx`; the 0.5 m overlap is deep
+// enough that the kernel resolves a real intersection solid (asserted by the
+// companion suite), so "a stale compute painted" is observable, not vacuous.
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    body,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+const TWO_WALLS = [
+  "#1=IFCWALL('0aaaaaaaaaaaaaaaaaaaaa',$,'Wall A',$,$,$,$,$,.STANDARD.);",
+  "#2=IFCWALL('0bbbbbbbbbbbbbbbbbbbbb',$,'Wall B',$,$,$,$,$,.STANDARD.);",
+].join('\n');
+
+async function parse(body: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc4(body));
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+/** A unit box (12 triangles) with its min corner at `(dx, 0, 0)`. */
+function boxMesh(expressId: number, dx: number): MeshData {
+  const positions = new Float32Array([
+    dx, 0, 0, dx + 1, 0, 0, dx + 1, 1, 0, dx, 1, 0,
+    dx, 0, 1, dx + 1, 0, 1, dx + 1, 1, 1, dx, 1, 1,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6,
+    0, 4, 5, 0, 5, 1, 1, 5, 6, 1, 6, 2,
+    2, 6, 7, 2, 7, 3, 3, 7, 4, 3, 4, 0,
+  ]);
+  return {
+    expressId,
+    ifcType: 'IfcWall',
+    positions,
+    normals: new Float32Array(positions.length),
+    indices,
+    color: [0.5, 0.5, 0.5, 1],
+  };
+}
+
+function geometry(meshes: MeshData[]): GeometryResult {
+  const bounds = { min: { x: 0, y: 0, z: 0 }, max: { x: 2, y: 1, z: 1 } };
+  const coordinateInfo: CoordinateInfo = {
+    originShift: { x: 0, y: 0, z: 0 },
+    originalBounds: bounds,
+    shiftedBounds: bounds,
+    hasLargeCoordinates: false,
+  };
+  return { meshes, totalTriangles: 12 * meshes.length, totalVertices: 8 * meshes.length, coordinateInfo };
+}
+
+function model(id: string, store: IfcDataStore, meshes: MeshData[]): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore: store,
+    geometryResult: geometry(meshes),
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 0,
+    fileSize: 0,
+    idOffset: 0,
+    maxExpressId: 2,
+  };
+}
+
+/** The rule `runAll` builds: every element vs every other, hard clash. */
+const ALL_RULE: ClashRule = { id: 'all-clashes', name: 'All elements', a: '*', mode: 'hard' };
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+type ClashApi = ReturnType<typeof useClash>;
+
+let api: ClashApi | null = null;
+let root: Root | null = null;
+
+function Probe(): null {
+  api = useClash();
+  return null;
+}
+
+/**
+ * Mount the real hook over one model of two overlapping walls, run detection,
+ * and return the clash a user would click. `elementsByRef` — the map
+ * `focusClash` resolves its two operand meshes through — is populated by
+ * `run()`, so the run is not optional set-up dressing: without it `focusClash`
+ * never reaches the compute at all.
+ */
+async function seedAndRun(): Promise<Clash> {
+  const store = await parse(TWO_WALLS);
+  useViewerStore.setState({
+    models: new Map([['A', model('A', store, [boxMesh(1, 0), boxMesh(2, 0.5)])]]),
+    activeModelId: 'A',
+    clashResult: null,
+    clashRawResult: null,
+    clashGroups: null,
+    clashError: null,
+    clashRunning: false,
+    clashSelectedId: null,
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    clashSolidStatus: 'none',
+    clashSolidMesh: null,
+    clashSolidVolumeM3: 0,
+  });
+  useViewerStore.getState().registerModelOffset('A', 100);
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => { root!.render(<Probe />); });
+  assert.ok(api, 'useClash must be mounted');
+
+  await act(async () => { await api!.run([ALL_RULE]); });
+  const clash = useViewerStore.getState().clashResult?.clashes[0];
+  assert.ok(clash, 'setup: the two overlapping walls must produce a clash to focus');
+  return clash;
+}
+
+/**
+ * Fire `action` the instant `focusClash` marks the solid compute as started —
+ * `setClashSolidComputing()`, one statement after the request seq is captured
+ * and one before `computeClashIntersectionSolid()` is called. The subscription
+ * runs synchronously inside `focusClash`, so nothing awaits between the
+ * teardown and the compute landing. That is the whole window under test.
+ */
+function tearDownMidCompute(action: () => void): () => void {
+  let fired = false;
+  return useViewerStore.subscribe((s) => {
+    if (fired || s.clashSolidStatus !== 'computing') return;
+    fired = true;
+    action();
+  });
+}
+
+/**
+ * Focus `clash`, letting the compute launched by that focus settle. `act`
+ * drains the microtask queue the compute's `.then` lives on, so by the time
+ * this returns the compute has either painted or been dropped.
+ */
+async function focusAndSettle(clash: Clash): Promise<void> {
+  await act(async () => { api!.focusClash(clash, 'ghost'); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+/** Everything the resolved-solid branch of the compute writes. Nothing here
+ *  may be set by a compute that was superseded before it landed. */
+function assertNoSolidPainted(where: string): void {
+  const s = useViewerStore.getState();
+  assert.notEqual(s.clashSolidStatus, 'solid',
+    `${where}: a superseded compute must not paint the intersection solid`);
+  assert.equal(s.clashSolidMesh, null,
+    `${where}: a superseded compute must not install its mesh`);
+  assert.equal(s.clashSolidVolumeM3, 0,
+    `${where}: a superseded compute must not publish its volume`);
+  assert.notEqual(s.clashSolidStatus, 'unavailable',
+    `${where}: a superseded compute must not report its degenerate reason either — ` +
+    'the panel would say "no solid" about a clash the user is no longer looking at');
+}
+
+beforeEach(() => { api = null; });
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  useViewerStore.setState({ models: new Map(), clashResult: null, clashRawResult: null, clashGroups: null });
+});
+
+// ─── RED: a compute that lands after its focus was torn down paints nothing ──
+
+describe('an intersection-solid compute in flight across a teardown must not paint', () => {
+  it('Home / "Show all" mid-compute: the landing compute must not paint the solid', async (t) => {
+    if (!ensureWasm(t)) return;
+    const clash = await seedAndRun();
+    const unsub = tearDownMidCompute(() => resetVisibilityForHomeFromStore());
+
+    await focusAndSettle(clash);
+    unsub();
+
+    assert.equal(useViewerStore.getState().clashSelectedId, null,
+      'setup sanity: the Home reset really ran while the compute was in flight');
+    assertNoSolidPainted('Home reset mid-compute');
+  });
+
+  it('clash-tour cleanup mid-compute: the landing compute must not paint the solid', async (t) => {
+    if (!ensureWasm(t)) return;
+    const zoomStep = CLASH_TOUR.steps.find((s) => s.id === 'zoom-to-clash');
+    assert.ok(zoomStep?.cleanup, 'zoom-to-clash step must have a cleanup()');
+    const clash = await seedAndRun();
+    const unsub = tearDownMidCompute(() => {
+      zoomStep!.cleanup!(useViewerStore, { baseline: { hadResultAtEntry: 0 }, artifacts: new Map() });
+    });
+
+    await focusAndSettle(clash);
+    unsub();
+
+    assert.equal(useViewerStore.getState().clashSelectedId, null,
+      'setup sanity: the tour cleanup really ran while the compute was in flight');
+    assertNoSolidPainted('tour cleanup mid-compute');
+  });
+
+  it('clearClashFocus mid-compute: the landing compute must not paint the solid', async (t) => {
+    if (!ensureWasm(t)) return;
+    const clash = await seedAndRun();
+    const unsub = tearDownMidCompute(() => useViewerStore.getState().clearClashFocus());
+
+    await focusAndSettle(clash);
+    unsub();
+
+    assert.equal(useViewerStore.getState().clashSelectedId, null,
+      'setup sanity: the focus was really ended while the compute was in flight');
+    assertNoSolidPainted('clearClashFocus mid-compute');
+  });
+
+  it('"Clear all" mid-compute: the landing compute must not paint a solid for a model that is gone', async (t) => {
+    if (!ensureWasm(t)) return;
+    const clash = await seedAndRun();
+    const unsub = tearDownMidCompute(() => useViewerStore.getState().clearAllModels());
+
+    await focusAndSettle(clash);
+    unsub();
+
+    assert.equal(useViewerStore.getState().models.size, 0,
+      'setup sanity: the models really went away while the compute was in flight');
+    assertNoSolidPainted('clearAllModels mid-compute');
+  });
+
+  it('a SECOND focus mid-compute: the first compute must not paint over the second focus', async (t) => {
+    if (!ensureWasm(t)) return;
+    const clash = await seedAndRun();
+    // The narrowest case: no teardown at all, just the user clicking another
+    // row. `setClashSelectedId` bumps the seq, so the first compute is stale
+    // even though the second focus leaves a perfectly valid presentation
+    // standing — only the SEQ distinguishes them, nothing else does.
+    const unsub = tearDownMidCompute(() => {
+      useViewerStore.getState().setClashSelectedId('clash-other');
+    });
+
+    await focusAndSettle(clash);
+    unsub();
+
+    assert.equal(useViewerStore.getState().clashSelectedId, 'clash-other',
+      'setup sanity: the selection really moved on while the compute was in flight');
+    assertNoSolidPainted('superseded by a second focus');
+  });
+});
+
+// ─── GREEN companion: a guard that discarded everything must fail here ──────
+
+describe('an undisturbed intersection-solid compute still paints', () => {
+  it('focusClash with no teardown resolves and paints the solid', async (t) => {
+    if (!ensureWasm(t)) return;
+    const clash = await seedAndRun();
+
+    await focusAndSettle(clash);
+
+    const s = useViewerStore.getState();
+    assert.equal(s.clashSolidStatus, 'solid',
+      'the 0.5 m deep overlap must resolve to a real solid — without this, every ' +
+      'assertion in the suite above would pass against a hook that discards everything');
+    assert.ok(s.clashSolidMesh && s.clashSolidMesh.indices.length > 0,
+      'the resolved solid must install a non-empty mesh');
+    assert.ok(s.clashSolidVolumeM3 > 0, 'the resolved solid must publish its volume');
+  });
+});

--- a/apps/viewer/src/lib/tours/tours/clash.solid-teardown.test.ts
+++ b/apps/viewer/src/lib/tours/tours/clash.solid-teardown.test.ts
@@ -66,7 +66,10 @@ describe('clash tour "zoom-to-clash" cleanup drops the intersection-solid presen
     assert.equal(s.clashSolidMesh, null, 'the stale solid mesh must not survive tour cleanup');
   });
 
-  it('cleanup() invalidates an in-flight solid compute (clashSolidRequestSeq bumps)', () => {
+  // Producer half only — see the note in `store/homeView.solid-teardown.test.ts`.
+  // The end-to-end join (a real compute in flight across this cleanup) is in
+  // `hooks/useClash.solid-inflight-invalidation.test.tsx`.
+  it('cleanup() bumps clashSolidRequestSeq, the token an in-flight solid compute is checked against', () => {
     const zoomStep = CLASH_TOUR.steps.find((s) => s.id === 'zoom-to-clash');
     assert.ok(zoomStep?.cleanup);
 

--- a/apps/viewer/src/store/homeView.solid-teardown.test.ts
+++ b/apps/viewer/src/store/homeView.solid-teardown.test.ts
@@ -60,7 +60,12 @@ describe('resetVisibilityForHomeFromStore drops the intersection-solid presentat
     assert.equal(s.clashSolidMesh, null, 'the stale solid mesh must not survive the Home reset');
   });
 
-  it('invalidates an in-flight solid compute (clashSolidRequestSeq bumps)', () => {
+  // Producer half only: this seeds `clashSolidStatus: 'computing'` as a plain
+  // string, so no compute is in flight and nothing here can observe whether a
+  // stale one still paints. It pins that the reset BUMPS the token; that the
+  // bump actually stops a real landing compute is pinned end-to-end in
+  // `hooks/useClash.solid-inflight-invalidation.test.tsx`.
+  it('bumps clashSolidRequestSeq, the token an in-flight solid compute is checked against', () => {
     useViewerStore.setState({ clashSelectedId: 'clash-old', clashSolidStatus: 'computing', clashSolidMesh: null });
     const seqBefore = useViewerStore.getState().clashSolidRequestSeq;
 

--- a/apps/viewer/src/store/modelLifecycle.solid-teardown.test.ts
+++ b/apps/viewer/src/store/modelLifecycle.solid-teardown.test.ts
@@ -150,6 +150,10 @@ function assertPresentationGone(where: string): void {
   assert.equal(s.ghostExceptEntities, null, `${where} must not leave the scene ghosted with nothing selected`);
 }
 
+// The seq assertions below are the PRODUCER half only: this file seeds a
+// resolved presentation with no hook and no kernel, so no compute is ever in
+// flight here. That the bump actually stops a landing compute is pinned
+// end-to-end in `hooks/useClash.solid-inflight-invalidation.test.tsx`.
 describe('model-lifecycle teardown drops the intersection-solid presentation (#2654 review)', () => {
   beforeEach(() => {
     seedResolvedSolidPresentation();
@@ -162,7 +166,7 @@ describe('model-lifecycle teardown drops the intersection-solid presentation (#2
     assertPresentationGone('opening another file (resetViewerState)');
     assert.ok(
       useViewerStore.getState().clashSolidRequestSeq > seq,
-      'resetViewerState must also invalidate an in-flight compute (seq bump)',
+      'resetViewerState must also bump clashSolidRequestSeq, the token a landing compute is checked against',
     );
   });
 
@@ -172,7 +176,7 @@ describe('model-lifecycle teardown drops the intersection-solid presentation (#2
     assertPresentationGone('clearAllModels');
     assert.ok(
       useViewerStore.getState().clashSolidRequestSeq > seq,
-      'clearAllModels must also invalidate an in-flight compute (seq bump)',
+      'clearAllModels must also bump clashSolidRequestSeq, the token a landing compute is checked against',
     );
   });
 
@@ -188,7 +192,7 @@ describe('model-lifecycle teardown drops the intersection-solid presentation (#2
     assertPaintChannelReleased('removeModel');
     assert.ok(
       useViewerStore.getState().clashSolidRequestSeq > seq,
-      'removeModel must also invalidate an in-flight compute (seq bump)',
+      'removeModel must also bump clashSolidRequestSeq, the token a landing compute is checked against',
     );
   });
 

--- a/apps/viewer/src/store/slices/clashSlice.solid.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.solid.test.ts
@@ -140,13 +140,18 @@ describe('ClashSlice focused-clash presentation teardown', () => {
     assertNothingDrawn('clearClashFocus');
   });
 
-  it('clearClashFocus invalidates an in-flight solid compute (seq bump)', () => {
+  // Producer half only: this slice is exercised in isolation, with no hook and
+  // no kernel, so "a compute resolves after teardown" is not a state it can
+  // reach. It pins the token bump; the join — a real compute in flight across
+  // `clearClashFocus` — is in
+  // `hooks/useClash.solid-inflight-invalidation.test.tsx`.
+  it('clearClashFocus bumps clashSolidRequestSeq, the token an in-flight solid compute is checked against', () => {
     const seq = state.clashSolidRequestSeq;
     state.setClashSolidComputing();
     state.clearClashFocus();
     assert.ok(
       state.clashSolidRequestSeq > seq,
-      'a compute that resolves after teardown must be dropped, not painted',
+      'without the bump, a compute that resolves after teardown keeps its request token valid and paints',
     );
   });
 


### PR DESCRIPTION
## The gap

Four suites are named for invalidating an **in-flight solid compute**:

- `apps/viewer/src/store/homeView.solid-teardown.test.ts`
- `apps/viewer/src/store/slices/clashSlice.solid.test.ts`
- `apps/viewer/src/lib/tours/tours/clash.solid-teardown.test.ts`
- `apps/viewer/src/store/modelLifecycle.solid-teardown.test.ts`

Each writes `clashSolidStatus: 'computing'` as a plain string and asserts only that `clashSolidRequestSeq` changed. No compute is in flight, so nothing observes whether a superseded one still paints. `lib/clash/intersection-solid.test.ts` pins the callee by calling the kernel directly, never through the hook. The producer was pinned, the callee was pinned, **the join was not**.

## What breaks today

Replacing both copies of the staleness check in `apps/viewer/src/hooks/useClash.ts` (`:668` in the `.then`, `:717` in the `.catch`) with nothing:

```
# tests 36 / # pass 36 / # fail 0
```

across all four suites above plus `useClash.solid-invalidation.test.tsx`, `ClashPanel.focus-teardown.test.tsx`, `modelLifecycle.visibility-ownership.test.ts` and `intersection-solid.test.ts`. The guard is entirely deletable-and-green.

## The fix

`apps/viewer/src/hooks/useClash.solid-inflight-invalidation.test.tsx` drives the **real** hook over the **real** wasm kernel, parks a genuine compute across each teardown, and asserts nothing is painted:

| case | teardown fired mid-compute |
|---|---|
| Home / "Show all" | `resetVisibilityForHomeFromStore()` |
| clash tour | `zoom-to-clash` step `cleanup()` |
| focus end | `clearClashFocus()` |
| federation teardown | `clearAllModels()` |
| second focus | `setClashSelectedId('clash-other')` |

The teardown fires from a store subscription on the `setClashSolidComputing()` transition — synchronously inside `focusClash`, one statement after the request seq is captured and one before `computeClashIntersectionSolid()` is launched. There is deliberately **no** `await flush()` / `tick()` / `Promise.resolve()` between the bump and the compute landing: such a flush would let the compute paint first, the teardown would then clear the painted solid itself, and every assertion would pass against a hook with no staleness check at all.

A companion suite pins that an **undisturbed** focus still resolves and paints its solid (the 0.5 m overlap produces a real intersection volume), so a guard that discarded every result cannot pass this file.

### RED / GREEN

Against the mutated guard:

```
not ok 1 - Home / "Show all" mid-compute: the landing compute must not paint the solid
not ok 2 - clash-tour cleanup mid-compute: the landing compute must not paint the solid
not ok 3 - clearClashFocus mid-compute: the landing compute must not paint the solid
not ok 4 - "Clear all" mid-compute: the landing compute must not paint a solid for a model that is gone
not ok 5 - a SECOND focus mid-compute: the first compute must not paint over the second focus
    ok 1 - focusClash with no teardown resolves and paints the solid
# tests 6 / # pass 1 / # fail 5
```

Guard restored: 6/6 pass.

## Renames

No assertion was weakened. The four producer suites keep every assertion; their names and messages now say what they can actually see — that the teardown **bumps the token an in-flight compute is checked against** — each with a pointer to the join file for the end-to-end property.

## Known residual

Only the `.then` copy of the guard is covered. The `.catch` copy needs the kernel to reject, and it does not reject on any input reachable from the hook: a malformed operand comes back as a resolved `{ isSolid: false, reason: 'malformed-operand' }` (verified against the real wasm binding). Forcing a rejection would mean a mocking seam the production code does not have, so the `.catch` guard is documented as unpinned rather than the hook being reshaped to suit a test.

Incidentally: `'malformed-operand'` is returned by the kernel but is **not** a member of the `ClashSolidDegenerateReason` union in `apps/viewer/src/lib/clash/intersection-solid.ts`. Not touched here — flagging it.

## Scope

Test-only. No production change. `check-changesets.mjs` states a tests-only change needs no changeset.

## Gates

- `apps/viewer` full suite: **4954 tests, 0 fail** (6 pre-existing skips)
- `pnpm --filter viewer typecheck`: clean
- `pnpm lint`: clean
- `pnpm check:test-wiring`, `check:source-text-assertions`, `check:test-typecheck`: clean

Rust-side counterpart: #2710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved clash detection reliability when users reset the view, exit tours, clear focus, remove models, or change selections during processing.
  - Prevented outdated solid-computation results from overwriting current clash status, meshes, volumes, or availability indicators.
  - Preserved correct solid results when processing completes without interruption.

- **Tests**
  - Added end-to-end coverage for interrupted and uninterrupted clash computations using real WASM processing.
  - Clarified existing test coverage and assertions for state changes during solid computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->