### PR TITLE
fix(clash): declare the kernel's 'malformed-operand' degenerate reason

### DIFF
--- a/.changeset/clash-solid-malformed-operand-reason.md
+++ b/.changeset/clash-solid-malformed-operand-reason.md
@@ -1,0 +1,27 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Add the missing `'malformed-operand'` member to `ClashSolidDegenerateReason`.
+
+The wasm binding `clashIntersectionSolid` returns five degenerate reason
+strings, but the viewer's union declared only four. `'malformed-operand'` — the
+binding's own verdict when an operand has a positions/indices length that is not
+a multiple of 3, an index past its own operand's vertex count, or a non-finite
+coordinate — was absent. The union's doc comment said it mirrored
+`DegenerateReason` in `clash_solid.rs`, and it did: that reason is produced by
+the binding's `mesh_from` guard and has no enum variant behind it, so mirroring
+the enum missed it. Because the reason crosses the wasm boundary as an untyped
+string and is cast on arrival, TypeScript could not catch the gap.
+
+No UI copy changes: the clash panel's reason chain already ends in a generic
+"No solid could be computed for this pair" fallback, which is accurate for a
+rejected operand, and every consumer of the union either handles the reason
+positionally or falls through to that string. The defect was that the type
+claimed a value the runtime can produce is impossible, so any future
+exhaustiveness check over it would have been built on a set that is short by one.
+
+A new test pins the union against `clash_solid.rs` itself, comparing the two
+sets in both directions, so adding a reason on either side without the other now
+fails; a second test confirms through the real wasm kernel that a
+malformed operand does come back as `'malformed-operand'`.

--- a/.changeset/clash-solid-malformed-operand-reason.md
+++ b/.changeset/clash-solid-malformed-operand-reason.md
@@ -21,7 +21,12 @@ positionally or falls through to that string. The defect was that the type
 claimed a value the runtime can produce is impossible, so any future
 exhaustiveness check over it would have been built on a set that is short by one.
 
-A new test pins the union against `clash_solid.rs` itself, comparing the two
-sets in both directions, so adding a reason on either side without the other now
-fails; a second test confirms through the real wasm kernel that a
-malformed operand does come back as `'malformed-operand'`.
+A new test confirms through the real wasm kernel that a malformed operand does
+come back as `'malformed-operand'`. Declaration parity — that the union lists
+exactly the reasons `clash_solid.rs` can emit, in both directions — can only be
+claimed by reading both sources, which is a source-text assertion and banned in
+test files, so it is a CI lint instead:
+`scripts/check-clash-degenerate-reason-parity.mjs`. It refuses to pass on two
+empty sets, and its own regression harness
+(`scripts/check-clash-degenerate-reason-parity.test.mjs`) turns each drift and
+each vacuity mode red against mutated copies of the real sources.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,6 +417,20 @@ jobs:
       # viewer's canonical load path, which fires on every IFC load.
       - name: Check WASM handle disposal
         run: node scripts/check-wasm-disposal.mjs
+      # `degenerateReason` crosses the wasm boundary as an untyped string and is
+      # cast to `ClashSolidDegenerateReason` on arrival, so TypeScript cannot see
+      # a union that has drifted from the kernel -- `'malformed-operand'` was
+      # missing exactly that way (#2717). Cross-language declaration parity can
+      # only be claimed by reading both SOURCES, which is banned in test files
+      # by the source-text gate above, so it is a lint here instead.
+      - name: Check clash degenerate-reason parity
+        run: node scripts/check-clash-degenerate-reason-parity.mjs
+      # Executable proof the parity gate cannot pass vacuously: two empty sets
+      # are "equal", so a broken extractor would otherwise turn it green. Each
+      # drift direction and each vacuity mode runs against mutated copies of the
+      # real sources in a temp tree and must turn the gate red.
+      - name: Check clash degenerate-reason parity gate regressions
+        run: node --test scripts/check-clash-degenerate-reason-parity.test.mjs
       # Guard the published API surface: the exported names of every
       # non-private packages/* package (read from the dist d.ts in the
       # build artifact downloaded above) must match the committed

--- a/apps/viewer/src/lib/clash/intersection-solid.test.ts
+++ b/apps/viewer/src/lib/clash/intersection-solid.test.ts
@@ -138,4 +138,93 @@ describe('computeClashIntersectionSolid (real wasm)', () => {
     if (result.isSolid) return;
     assert.equal(result.reason, 'empty-operand');
   });
+
+  it('reports malformed-operand when an index points past its own operand', async (t) => {
+    if (!ensureWasm(t)) return;
+    const a = boxMesh([0, 0, 0], [2, 2, 2]);
+    const b = boxMesh([1, 1, 1], [3, 3, 3]);
+    // Deeply overlapping pair — so the ONLY thing that can make this degenerate
+    // is the malformation, not the geometry. Point one index past the end of
+    // B's own vertex list: the kernel's `mesh_from` rejects the whole operand
+    // rather than silently dropping the triangle.
+    const badIndices = Uint32Array.from(b.indices);
+    badIndices[0] = b.positions.length / 3;
+    const result = await computeClashIntersectionSolid(a.positions, a.indices, b.positions, badIndices);
+    assert.equal(result.isSolid, false);
+    if (result.isSolid) return;
+    assert.equal(result.reason, 'malformed-operand');
+  });
+});
+
+/**
+ * The reason strings cross the wasm boundary as an untyped string and are cast
+ * (`as ClashSolidDegenerateReason`) on arrival, so TypeScript cannot catch a
+ * union that has drifted from the kernel. `'malformed-operand'` was missing for
+ * exactly that reason: it is produced by the BINDING's own operand validation
+ * (`mesh_from`), not by the geometry crate's `DegenerateReason` enum the union's
+ * doc comment says it mirrors — so mirroring the enum silently missed it.
+ *
+ * This reads both sources and asserts the two sets are equal, in BOTH
+ * directions: a reason added on the Rust side without a union member fails
+ * here, and so does a phantom union member the kernel can never emit.
+ */
+describe('ClashSolidDegenerateReason ↔ clash_solid.rs parity', () => {
+  const rustPath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..', '..', '..', '..', '..', 'rust', 'wasm-bindings', 'src', 'api', 'clash_solid.rs',
+  );
+  const tsPath = join(dirname(fileURLToPath(import.meta.url)), 'intersection-solid.ts');
+
+  /** Every non-empty `reason` string literal the binding can assign, from its
+   *  CODE only — comments are stripped first so prose can never satisfy this. */
+  function kernelReasons(rustSource: string): Set<string> {
+    const testMod = rustSource.indexOf('#[cfg(test)]');
+    const code = (testMod === -1 ? rustSource : rustSource.slice(0, testMod))
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('//'))
+      .join('\n');
+    const found = new Set<string>();
+    // `reason: "malformed-operand"` — the binding-level rejections.
+    for (const m of code.matchAll(/reason:\s*"([a-z-]+)"/g)) found.add(m[1]);
+    // `DegenerateReason::NoOverlap => ("no-overlap", …)` — the enum mapping,
+    // including the braced `BelowKernelResolution { … } => (…)` arm.
+    for (const m of code.matchAll(/DegenerateReason::\w+(?:\s*\{[^}]*\})?\s*=>\s*\(\s*"([a-z-]+)"/g)) {
+      found.add(m[1]);
+    }
+    return found;
+  }
+
+  /** The union's members, read from the .ts SOURCE — a type is erased at runtime.
+   *  Comments are stripped first, symmetrically with `kernelReasons`, so a
+   *  member named only in a doc comment cannot stand in for a real one. */
+  function declaredReasons(tsSource: string): Set<string> {
+    const code = tsSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    const block = /export type ClashSolidDegenerateReason =([\s\S]*?);/.exec(code);
+    assert.ok(block, 'ClashSolidDegenerateReason declaration not found');
+    return new Set([...block[1].matchAll(/'([a-z-]+)'/g)].map((m) => m[1]));
+  }
+
+  it('declares exactly the reasons the kernel can emit', () => {
+    const kernel = kernelReasons(readFileSync(rustPath, 'utf8'));
+    const declared = declaredReasons(readFileSync(tsPath, 'utf8'));
+    // Neither extractor may come back empty — two empty sets are "equal" and
+    // would turn this into a test that passes by finding nothing.
+    assert.ok(kernel.size > 0, 'no reason strings extracted from clash_solid.rs');
+    assert.ok(declared.size > 0, 'no members extracted from the union');
+    assert.deepEqual(
+      [...declared].sort(),
+      [...kernel].sort(),
+      'ClashSolidDegenerateReason has drifted from clash_solid.rs',
+    );
+  });
+
+  it('extracts nothing from a comment that merely mentions a reason', () => {
+    assert.deepEqual([...kernelReasons('    // - `"invented-reason"` — prose only.\n')], []);
+    assert.deepEqual(
+      [...declaredReasons(
+        "export type ClashSolidDegenerateReason =\n  /** prose about 'invented-reason' */\n  | 'no-overlap';",
+      )],
+      ['no-overlap'],
+    );
+  });
 });

--- a/apps/viewer/src/lib/clash/intersection-solid.test.ts
+++ b/apps/viewer/src/lib/clash/intersection-solid.test.ts
@@ -7,9 +7,17 @@
  * the wasm binding's own contract, `isSolid` / `degenerateReason` /
  * `thicknessM` / `requiredM`, is exactly what the viewer's fallback UI reads,
  * so a mocked kernel would test our own assumptions about the contract
- * instead of the contract). Two fixtures: a deep box overlap (must resolve a
- * solid with the right volume) and two disjoint boxes (must fall back
- * cleanly with `no-overlap` and zero geometry).
+ * instead of the contract). Four fixtures: a deep box overlap (must resolve a
+ * solid with the right volume), two disjoint boxes (`no-overlap`), an empty
+ * operand (`empty-operand`), and an operand whose index points past its own
+ * vertex list (`malformed-operand`).
+ *
+ * The DECLARATION-parity half — that `ClashSolidDegenerateReason` lists exactly
+ * the reasons `clash_solid.rs` can emit — is not here. It can only be made by
+ * reading both sources, which is a source-text assertion and banned in test
+ * files; it lives as a lint in
+ * `scripts/check-clash-degenerate-reason-parity.mjs`, with its own regression
+ * harness alongside it.
  */
 
 import { describe, it } from 'node:test';
@@ -153,78 +161,5 @@ describe('computeClashIntersectionSolid (real wasm)', () => {
     assert.equal(result.isSolid, false);
     if (result.isSolid) return;
     assert.equal(result.reason, 'malformed-operand');
-  });
-});
-
-/**
- * The reason strings cross the wasm boundary as an untyped string and are cast
- * (`as ClashSolidDegenerateReason`) on arrival, so TypeScript cannot catch a
- * union that has drifted from the kernel. `'malformed-operand'` was missing for
- * exactly that reason: it is produced by the BINDING's own operand validation
- * (`mesh_from`), not by the geometry crate's `DegenerateReason` enum the union's
- * doc comment says it mirrors — so mirroring the enum silently missed it.
- *
- * This reads both sources and asserts the two sets are equal, in BOTH
- * directions: a reason added on the Rust side without a union member fails
- * here, and so does a phantom union member the kernel can never emit.
- */
-describe('ClashSolidDegenerateReason ↔ clash_solid.rs parity', () => {
-  const rustPath = join(
-    dirname(fileURLToPath(import.meta.url)),
-    '..', '..', '..', '..', '..', 'rust', 'wasm-bindings', 'src', 'api', 'clash_solid.rs',
-  );
-  const tsPath = join(dirname(fileURLToPath(import.meta.url)), 'intersection-solid.ts');
-
-  /** Every non-empty `reason` string literal the binding can assign, from its
-   *  CODE only — comments are stripped first so prose can never satisfy this. */
-  function kernelReasons(rustSource: string): Set<string> {
-    const testMod = rustSource.indexOf('#[cfg(test)]');
-    const code = (testMod === -1 ? rustSource : rustSource.slice(0, testMod))
-      .split('\n')
-      .filter((line) => !line.trimStart().startsWith('//'))
-      .join('\n');
-    const found = new Set<string>();
-    // `reason: "malformed-operand"` — the binding-level rejections.
-    for (const m of code.matchAll(/reason:\s*"([a-z-]+)"/g)) found.add(m[1]);
-    // `DegenerateReason::NoOverlap => ("no-overlap", …)` — the enum mapping,
-    // including the braced `BelowKernelResolution { … } => (…)` arm.
-    for (const m of code.matchAll(/DegenerateReason::\w+(?:\s*\{[^}]*\})?\s*=>\s*\(\s*"([a-z-]+)"/g)) {
-      found.add(m[1]);
-    }
-    return found;
-  }
-
-  /** The union's members, read from the .ts SOURCE — a type is erased at runtime.
-   *  Comments are stripped first, symmetrically with `kernelReasons`, so a
-   *  member named only in a doc comment cannot stand in for a real one. */
-  function declaredReasons(tsSource: string): Set<string> {
-    const code = tsSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-    const block = /export type ClashSolidDegenerateReason =([\s\S]*?);/.exec(code);
-    assert.ok(block, 'ClashSolidDegenerateReason declaration not found');
-    return new Set([...block[1].matchAll(/'([a-z-]+)'/g)].map((m) => m[1]));
-  }
-
-  it('declares exactly the reasons the kernel can emit', () => {
-    const kernel = kernelReasons(readFileSync(rustPath, 'utf8'));
-    const declared = declaredReasons(readFileSync(tsPath, 'utf8'));
-    // Neither extractor may come back empty — two empty sets are "equal" and
-    // would turn this into a test that passes by finding nothing.
-    assert.ok(kernel.size > 0, 'no reason strings extracted from clash_solid.rs');
-    assert.ok(declared.size > 0, 'no members extracted from the union');
-    assert.deepEqual(
-      [...declared].sort(),
-      [...kernel].sort(),
-      'ClashSolidDegenerateReason has drifted from clash_solid.rs',
-    );
-  });
-
-  it('extracts nothing from a comment that merely mentions a reason', () => {
-    assert.deepEqual([...kernelReasons('    // - `"invented-reason"` — prose only.\n')], []);
-    assert.deepEqual(
-      [...declaredReasons(
-        "export type ClashSolidDegenerateReason =\n  /** prose about 'invented-reason' */\n  | 'no-overlap';",
-      )],
-      ['no-overlap'],
-    );
   });
 });

--- a/apps/viewer/src/lib/clash/intersection-solid.ts
+++ b/apps/viewer/src/lib/clash/intersection-solid.ts
@@ -20,7 +20,9 @@ import init, { clashIntersectionSolid } from '@ifc-lite/wasm';
 /**
  * Why the kernel could not resolve a solid — the full set of `degenerateReason`
  * strings `clashIntersectionSolid` can return, pinned against the Rust source by
- * `intersection-solid.test.ts`.
+ * `scripts/check-clash-degenerate-reason-parity.mjs`. (`intersection-solid.test.ts`
+ * exercises the kernel's BEHAVIOUR; a declaration-parity claim needs both
+ * SOURCES, which is banned in test files, so it lives as a lint.)
  *
  * That is a wider set than the geometry crate's `DegenerateReason` enum:
  * `'malformed-operand'` is the wasm BINDING's own verdict, produced by

--- a/apps/viewer/src/lib/clash/intersection-solid.ts
+++ b/apps/viewer/src/lib/clash/intersection-solid.ts
@@ -17,8 +17,24 @@
 
 import init, { clashIntersectionSolid } from '@ifc-lite/wasm';
 
-/** Why the kernel could not resolve a solid — mirrors `DegenerateReason` in `clash_solid.rs`. */
+/**
+ * Why the kernel could not resolve a solid — the full set of `degenerateReason`
+ * strings `clashIntersectionSolid` can return, pinned against the Rust source by
+ * `intersection-solid.test.ts`.
+ *
+ * That is a wider set than the geometry crate's `DegenerateReason` enum:
+ * `'malformed-operand'` is the wasm BINDING's own verdict, produced by
+ * `mesh_from` in `clash_solid.rs` before the boolean ever runs, and has no enum
+ * variant behind it. The reason crosses the wasm boundary as an untyped string
+ * and is cast on arrival, so TypeScript cannot catch a member missing here.
+ */
 export type ClashSolidDegenerateReason =
+  /**
+   * The binding rejected an operand rather than computing on it: a positions or
+   * indices length that is not a multiple of 3, an index past its own operand's
+   * vertex count, or a non-finite (NaN/infinity) coordinate.
+   */
+  | 'malformed-operand'
   | 'empty-operand'
   | 'no-overlap'
   | 'below-kernel-resolution'

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check:source-text-assertions": "node scripts/check-source-text-assertions.mjs",
     "check:unbounded-frame-wait": "node scripts/check-unbounded-frame-wait.mjs",
     "check:wasm-disposal": "node scripts/check-wasm-disposal.mjs",
+    "check:clash-degenerate-reason-parity": "node scripts/check-clash-degenerate-reason-parity.mjs",
     "check:api-surface": "node scripts/check-api-surface.mjs",
     "api-surface:update": "node scripts/check-api-surface.mjs --update",
     "check:git-lfs": "node scripts/check-git-lfs.mjs",

--- a/scripts/check-clash-degenerate-reason-parity.mjs
+++ b/scripts/check-clash-degenerate-reason-parity.mjs
@@ -56,10 +56,17 @@ const TS_REL = 'apps/viewer/src/lib/clash/intersection-solid.ts';
  */
 export function kernelReasons(rustSource) {
   const testMod = rustSource.indexOf('#[cfg(test)]');
+  // Comments go FIRST, and all three forms of them: `/* … */` blocks, trailing
+  // `//`, and full-line `//` (`//!` and `///` included, both being `//`-led).
+  // Dropping only full-line comments left a false-GREEN: comment an arm OUT and
+  // a comment-blind extractor still "finds" its literal, so the kernel set keeps
+  // a reason the binding can no longer emit and the phantom check never fires.
+  // Same naive strip the TS side uses below — symmetric by construction. No
+  // string literal in the binding contains `//`, so nothing real is eaten; if a
+  // future strip ever over-reached, the vacuity guard fails the check closed.
   const code = (testMod === -1 ? rustSource : rustSource.slice(0, testMod))
-    .split('\n')
-    .filter((line) => !line.trimStart().startsWith('//'))
-    .join('\n');
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
   const found = new Set();
   // `reason: "malformed-operand"` — the binding-level rejections.
   for (const m of code.matchAll(/reason:\s*"([a-z-]+)"/g)) found.add(m[1]);

--- a/scripts/check-clash-degenerate-reason-parity.mjs
+++ b/scripts/check-clash-degenerate-reason-parity.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Lint: `ClashSolidDegenerateReason` (TypeScript) must declare exactly the
+ * `degenerateReason` strings the wasm binding `clash_solid.rs` can emit.
+ *
+ * The reason crosses the wasm boundary as an untyped string and is cast
+ * (`as ClashSolidDegenerateReason`) on arrival, so TypeScript cannot catch a
+ * union that has drifted from the kernel. `'malformed-operand'` was missing for
+ * exactly that reason: it is produced by the BINDING's own operand validation
+ * (`mesh_from`), not by the geometry crate's `DegenerateReason` enum the
+ * union's doc comment says it mirrors — so mirroring the enum silently missed
+ * it.
+ *
+ * THIS is a lint, not a test, and it started life inside
+ * `apps/viewer/src/lib/clash/intersection-solid.test.ts` until the repo's own
+ * `check-source-text-assertions` gate caught it there. The gate was right: a
+ * cross-language declaration parity claim can only ever be made by reading both
+ * SOURCES, which is precisely the shape banned in test files. Naming it a check
+ * makes the shape honest and leaves the test file executable end to end — the
+ * behavioural half (a malformed operand really does yield `'malformed-operand'`
+ * from the real wasm kernel) stays there, where it belongs.
+ *
+ * VACUITY GUARD: both extractors must come back non-empty. Two empty sets are
+ * "equal", so an extractor broken by a refactor would otherwise turn this into
+ * a check that passes by finding nothing.
+ *
+ * COMMENTS ARE STRIPPED FIRST on both sides, symmetrically: a reason named only
+ * in prose must not stand in for a real one, in either language.
+ *
+ * Run via `node scripts/check-clash-degenerate-reason-parity.mjs` (CI node-test
+ * job). `--root <dir>` points it at a mutated copy of the tree; that is how
+ * `check-clash-degenerate-reason-parity.test.mjs` proves it fires.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootFlag = process.argv.indexOf('--root');
+const ROOT =
+  rootFlag !== -1 && process.argv[rootFlag + 1]
+    ? process.argv[rootFlag + 1]
+    : join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const RUST_REL = 'rust/wasm-bindings/src/api/clash_solid.rs';
+const TS_REL = 'apps/viewer/src/lib/clash/intersection-solid.ts';
+
+/**
+ * Every non-empty `reason` string literal the binding can assign, from its CODE
+ * only. `#[cfg(test)]` and below is dropped: a reason named only in a Rust unit
+ * test is not something the binding emits to JS.
+ */
+export function kernelReasons(rustSource) {
+  const testMod = rustSource.indexOf('#[cfg(test)]');
+  const code = (testMod === -1 ? rustSource : rustSource.slice(0, testMod))
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+  const found = new Set();
+  // `reason: "malformed-operand"` — the binding-level rejections.
+  for (const m of code.matchAll(/reason:\s*"([a-z-]+)"/g)) found.add(m[1]);
+  // `DegenerateReason::NoOverlap => ("no-overlap", …)` — the enum mapping,
+  // including the braced `BelowKernelResolution { … } => (…)` arm.
+  for (const m of code.matchAll(/DegenerateReason::\w+(?:\s*\{[^}]*\})?\s*=>\s*\(\s*"([a-z-]+)"/g)) {
+    found.add(m[1]);
+  }
+  return found;
+}
+
+/** The union's members, read from the .ts SOURCE — a type is erased at runtime. */
+export function declaredReasons(tsSource) {
+  const code = tsSource.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  const block = /export type ClashSolidDegenerateReason =([\s\S]*?);/.exec(code);
+  if (!block) return new Set();
+  return new Set([...block[1].matchAll(/'([a-z-]+)'/g)].map((m) => m[1]));
+}
+
+/**
+ * @returns {string[]} human-readable failures; empty means parity holds.
+ */
+export function checkParity(rustSource, tsSource) {
+  const kernel = kernelReasons(rustSource);
+  const declared = declaredReasons(tsSource);
+  const failures = [];
+
+  // Vacuity guard FIRST: an empty set makes every later comparison meaningless.
+  if (kernel.size === 0) {
+    failures.push(
+      `no reason strings extracted from ${RUST_REL} — the extractor has drifted from the Rust source`,
+    );
+  }
+  if (declared.size === 0) {
+    failures.push(
+      `no members extracted from ClashSolidDegenerateReason in ${TS_REL} — the extractor has drifted from the TS source`,
+    );
+  }
+  if (failures.length > 0) return failures;
+
+  const missing = [...kernel].filter((r) => !declared.has(r)).sort();
+  const phantom = [...declared].filter((r) => !kernel.has(r)).sort();
+  if (missing.length > 0) {
+    failures.push(
+      `the kernel can emit ${missing.map((r) => `'${r}'`).join(', ')} but ClashSolidDegenerateReason does not declare it`,
+    );
+  }
+  if (phantom.length > 0) {
+    failures.push(
+      `ClashSolidDegenerateReason declares ${phantom.map((r) => `'${r}'`).join(', ')} but the kernel can never emit it`,
+    );
+  }
+  return failures;
+}
+
+// Only run the gate when invoked as a script; the self-test imports the helpers.
+if (process.argv[1] && process.argv[1].endsWith('check-clash-degenerate-reason-parity.mjs')) {
+  // Fail closed: a renamed or moved file must break this check rather than
+  // silently reduce it to zero comparisons.
+  const rustSource = readFileSync(join(ROOT, RUST_REL), 'utf8');
+  const tsSource = readFileSync(join(ROOT, TS_REL), 'utf8');
+  const failures = checkParity(rustSource, tsSource);
+
+  if (failures.length > 0) {
+    console.error('\nClashSolidDegenerateReason has drifted from clash_solid.rs:\n');
+    for (const f of failures) console.error(`  ${f}`);
+    console.error(`
+The reason crosses the wasm boundary as an untyped string and is cast on
+arrival, so TypeScript cannot catch this. Update the union in
+${TS_REL}
+to match ${RUST_REL} exactly, in both directions.
+`);
+    process.exit(1);
+  }
+
+  const n = kernelReasons(rustSource).size;
+  console.log(`check-clash-degenerate-reason-parity: OK (${n} reasons, TS union and Rust binding agree)`);
+}

--- a/scripts/check-clash-degenerate-reason-parity.test.mjs
+++ b/scripts/check-clash-degenerate-reason-parity.test.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for scripts/check-clash-degenerate-reason-parity.mjs.
+ *
+ * A parity gate that silently matches nothing is worse than no gate, so each
+ * way it could go false-green is an executable case here: a reason removed from
+ * the TS union, a reason added on the Rust side, and either extractor broken so
+ * it returns the empty set (the vacuity guard — two empty sets are "equal").
+ *
+ * Method matches scripts/check-server-bin-targets.test.mjs: mutate a copy of
+ * the REAL sources in a temp tree outside the repo, run the UNMODIFIED checker
+ * against it via `--root`, and assert exit code plus message. Every mutation
+ * anchor is asserted to exist in the real input first, so a drifted anchor
+ * fails the suite instead of quietly testing nothing.
+ *
+ * Run: node --test scripts/check-clash-degenerate-reason-parity.test.mjs
+ * (wired as a step of the CI node-test job in .github/workflows/test.yml).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { kernelReasons, declaredReasons } from './check-clash-degenerate-reason-parity.mjs';
+
+const SCRIPTS = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SCRIPTS, '..');
+const CHECKER = join(SCRIPTS, 'check-clash-degenerate-reason-parity.mjs');
+
+const RUST_REL = 'rust/wasm-bindings/src/api/clash_solid.rs';
+const TS_REL = 'apps/viewer/src/lib/clash/intersection-solid.ts';
+
+const realRust = readFileSync(join(ROOT, RUST_REL), 'utf8');
+const realTs = readFileSync(join(ROOT, TS_REL), 'utf8');
+
+/** Writes a (possibly mutated) tree to a temp dir and runs the checker on it. */
+function runOn({ rust = realRust, ts = realTs }) {
+  const dir = mkdtempSync(join(tmpdir(), 'clash-reason-parity-'));
+  try {
+    for (const [rel, content] of [[RUST_REL, rust], [TS_REL, ts]]) {
+      const abs = join(dir, rel);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, content);
+    }
+    const r = spawnSync(process.execPath, [CHECKER, '--root', dir], { encoding: 'utf8' });
+    return { status: r.status, out: `${r.stdout}${r.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** Asserts an anchor really exists before a mutation is built on it. */
+function replaceOnce(source, anchor, replacement) {
+  assert.ok(source.includes(anchor), `mutation anchor drifted, not found in source: ${anchor}`);
+  return source.replace(anchor, replacement);
+}
+
+test('the unmutated repo passes', () => {
+  const { status, out } = runOn({});
+  assert.equal(status, 0, out);
+  assert.match(out, /check-clash-degenerate-reason-parity: OK/);
+});
+
+test('RED when a member is removed from the TS union', () => {
+  const ts = replaceOnce(realTs, "  | 'malformed-operand'\n", '');
+  const { status, out } = runOn({ ts });
+  assert.equal(status, 1, out);
+  assert.match(out, /kernel can emit 'malformed-operand' but ClashSolidDegenerateReason does not declare it/);
+});
+
+test('RED when a reason literal is added on the Rust side', () => {
+  const rust = replaceOnce(
+    realRust,
+    'DegenerateReason::NoOverlap => ("no-overlap", 0.0, 0.0),',
+    'DegenerateReason::NoOverlap => ("no-overlap", 0.0, 0.0),\n                DegenerateReason::Invented => ("invented-reason", 0.0, 0.0),',
+  );
+  const { status, out } = runOn({ rust });
+  assert.equal(status, 1, out);
+  assert.match(out, /kernel can emit 'invented-reason' but ClashSolidDegenerateReason does not declare it/);
+});
+
+test('RED when the union declares a reason the kernel cannot emit', () => {
+  const ts = replaceOnce(realTs, "  | 'no-overlap'\n", "  | 'no-overlap'\n  | 'phantom-reason'\n");
+  const { status, out } = runOn({ ts });
+  assert.equal(status, 1, out);
+  assert.match(out, /declares 'phantom-reason' but the kernel can never emit it/);
+});
+
+test('RED (vacuity guard) when the Rust extractor finds nothing', () => {
+  // Nothing left for either Rust pattern to match: the gate must fail rather
+  // than compare an empty set against an empty set and call that parity.
+  const { status, out } = runOn({ rust: '// no reasons here at all\n' });
+  assert.equal(status, 1, out);
+  assert.match(out, /no reason strings extracted from/);
+});
+
+test('RED (vacuity guard) when the TS extractor finds nothing', () => {
+  const { status, out } = runOn({ ts: '// the union has been renamed away\n' });
+  assert.equal(status, 1, out);
+  assert.match(out, /no members extracted from ClashSolidDegenerateReason/);
+});
+
+test('RED (vacuity guard) when BOTH extractors find nothing — two empty sets are not parity', () => {
+  const { status, out } = runOn({ rust: '// nothing\n', ts: '// nothing\n' });
+  assert.equal(status, 1, out);
+  assert.match(out, /no reason strings extracted from/);
+  assert.match(out, /no members extracted from ClashSolidDegenerateReason/);
+});
+
+test('a reason named only in a comment does not count, on either side', () => {
+  assert.deepEqual([...kernelReasons('    // - `"invented-reason"` — prose only.\n')], []);
+  assert.deepEqual(
+    [...declaredReasons(
+      "export type ClashSolidDegenerateReason =\n  /** prose about 'invented-reason' */\n  | 'no-overlap';",
+    )],
+    ['no-overlap'],
+  );
+});
+
+test('a reason named only in a Rust #[cfg(test)] module does not count', () => {
+  const rust = `${realRust}\n#[cfg(test)]\nmod tests {\n    const X: &str = "test-only-reason";\n}\n`;
+  const { status, out } = runOn({ rust });
+  assert.equal(status, 0, out);
+});

--- a/scripts/check-clash-degenerate-reason-parity.test.mjs
+++ b/scripts/check-clash-degenerate-reason-parity.test.mjs
@@ -116,12 +116,34 @@ test('RED (vacuity guard) when BOTH extractors find nothing — two empty sets a
 
 test('a reason named only in a comment does not count, on either side', () => {
   assert.deepEqual([...kernelReasons('    // - `"invented-reason"` — prose only.\n')], []);
+  // Not just FULL-LINE `//`: a trailing comment and a `/* … */` block are prose
+  // too, and the Rust side must drop them exactly as the TS side already does.
+  assert.deepEqual([...kernelReasons('let x = 1; // reason: "trailing-reason"\n')], []);
+  assert.deepEqual(
+    [...kernelReasons('/*\n    reason: "commented-out-reason",\n*/\nlet x = 1;\n')],
+    [],
+  );
   assert.deepEqual(
     [...declaredReasons(
       "export type ClashSolidDegenerateReason =\n  /** prose about 'invented-reason' */\n  | 'no-overlap';",
     )],
     ['no-overlap'],
   );
+});
+
+test('RED when a Rust arm is COMMENTED OUT but the union still declares it', () => {
+  // The false-GREEN this guards: delete a reason from the binding by commenting
+  // its arm out, and a comment-blind extractor still "finds" it in the block
+  // comment — so the phantom check never fires and the TS union keeps a member
+  // the kernel can no longer emit.
+  const rust = replaceOnce(
+    realRust,
+    'DegenerateReason::NoOverlap => ("no-overlap", 0.0, 0.0),',
+    '/* DegenerateReason::NoOverlap => ("no-overlap", 0.0, 0.0), */',
+  );
+  const { status, out } = runOn({ rust });
+  assert.equal(status, 1, out);
+  assert.match(out, /declares 'no-overlap' but the kernel can never emit it/);
 });
 
 test('a reason named only in a Rust #[cfg(test)] module does not count', () => {


### PR DESCRIPTION
## The defect

The wasm binding `clashIntersectionSolid` can return **five** non-empty `degenerateReason` strings. The viewer's union declared **four**.

Kernel side — `rust/wasm-bindings/src/api/clash_solid.rs`:

```rust
fn malformed_operand_result() -> ClashIntersectionSolidJs {
    ClashIntersectionSolidJs { …, reason: "malformed-operand", … }
}
…
DegenerateReason::EmptyOperand => ("empty-operand", 0.0, 0.0),
DegenerateReason::NoOverlap => ("no-overlap", 0.0, 0.0),
DegenerateReason::BudgetExhausted => ("budget-exhausted", 0.0, 0.0),
DegenerateReason::BelowKernelResolution { … } => ("below-kernel-resolution", …),
```

TypeScript side — `apps/viewer/src/lib/clash/intersection-solid.ts`, before this PR:

```ts
/** Why the kernel could not resolve a solid — mirrors `DegenerateReason` in `clash_solid.rs`. */
export type ClashSolidDegenerateReason =
  | 'empty-operand'
  | 'no-overlap'
  | 'below-kernel-resolution'
  | 'budget-exhausted';
```

**Diff, kernel → union:** `'malformed-operand'` is missing.
**Diff, union → kernel:** nothing — no phantom member; all four declared reasons are really emitted.

The doc comment explains how it happened and is *literally accurate*: the union mirrors the geometry crate's `DegenerateReason` enum, and `'malformed-operand'` has no enum variant behind it. It is the **binding's own** verdict, produced by `mesh_from` before the boolean runs, for any of: a `positions`/`indices` length that is not a multiple of 3, an index past its own operand's vertex count, or a non-finite (NaN/infinity) coordinate. Mirroring the enum was the wrong reference set.

TypeScript cannot catch this: the reason crosses the wasm boundary as an untyped string and is cast on arrival —

```ts
reason: solid.degenerateReason as ClashSolidDegenerateReason,
```

## What a user sees

Nothing is broken today, and this PR does not change any UI copy. The only consumer that reads the reason's *value* is `ClashPanel.tsx`, a ternary chain over `below-kernel-resolution` / `no-overlap` / `empty-operand` ending in a catch-all:

> No solid could be computed for this pair; showing the contact marker instead.

`'malformed-operand'` lands there — which is accurate for a rejected operand, and is the same string `budget-exhausted` and the JS-only `compute-error` already produce. There is no `switch`, no exhaustiveness check, and no blank message. `ClashSolidUnavailableReason` in `clashSlice.ts` widens by one member and nothing narrows on it.

So the defect is not a visible misbehaviour: **the type claims a value the runtime really produces is impossible.** Any exhaustiveness check someone writes over this union tomorrow would be built on a set that is short by one, and would compile clean while missing a live case.

## Reachability

Verified the kernel emits it — `cargo test -p ifc-lite-wasm clash_solid`, 7 tests pass, 5 of them asserting `degenerate_reason() == "malformed-operand"` (out-of-range index, positions length not a multiple of 3, NaN on and off the overlap face, infinite corner). Verified it reaches the viewer's wrapper — the new real-wasm test in this PR returns `'malformed-operand'` end to end.

From the app: `useClash.ts` passes `elA.positions` / `elA.indices` straight from the loaded model's meshes, with no finiteness or range check between the mesh source and the call. A model whose parsed geometry carries a non-finite coordinate therefore reaches this branch. I have **not** produced an IFC file that does so — I am reporting the absent guard, not a confirmed field repro.

## The fix

Add the member, with a doc comment that says where it comes from and why the enum is the wrong thing to mirror.

Pinned by `ClashSolidDegenerateReason ↔ clash_solid.rs parity`, which reads the union out of the `.ts` source and the reason literals out of the `.rs` source and asserts set equality **in both directions**, so adding a reason on either side without the other fails here. Both extractors strip comments first (a second test proves prose mentioning a reason contributes nothing), and both are asserted non-empty — otherwise two empty sets would compare equal and the test would pass by finding nothing.

RED before the one-line union change: `actual` was the four declared, `expected` the five extracted from Rust. GREEN after.

## Gates

- `cargo test -p ifc-lite-wasm clash_solid` — 7 passed
- `bash scripts/build-wasm.sh` — clean (needed; the wasm glue is a build artifact)
- `apps/viewer` `tsc --noEmit` — clean, 0 errors
- 14 clash suites in `apps/viewer` (ClashPanel ×5, useClash solid-invalidation, intersection-solid, clashSlice.solid, volume format, solid-teardown tour) — 42 tests, 42 pass
- The viewer has no eslint config, so no lint step applies to these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clash detection now reports malformed mesh data as `malformed-operand` instead of incorrectly returning a solid result.
  - Added coverage for empty, malformed, and other degenerate intersection scenarios.

- **Quality Improvements**
  - Added automated checks to keep reported clash reasons consistent across the application and processing engine.
  - CI now detects missing, unexpected, or invalid reason values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->