### PR TITLE
test: break four fixtures where two distinct things were accidentally identical

### DIFF
--- a/apps/viewer/src/store/slices/clashSlice.exclusions.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.exclusions.test.ts
@@ -86,6 +86,43 @@ function sampleResult(): ClashResult {
   };
 }
 
+/**
+ * A run whose cluster radius is observable AND whose exclusions bite: two
+ * IfcRail-vs-IfcCourse clashes 5m apart (so 1.5m vs 10m radius groups them
+ * differently) plus one IfcBeam-vs-IfcBeam clash for a rule to match.
+ *
+ * The beam clash is what the three settings-change tests below were missing.
+ * With NO rule in play, `clashRawResult` and `clashResult` are the SAME object
+ * — `applyClashExclusions` returns its input by reference when nothing is
+ * suppressed (exclusions.ts) — so the three `deriveGroups(state,
+ * state.clashRawResult, ...)` call sites in `setClashClusterEpsilon`,
+ * `resetClashSettings` and `applyClashFlavorConfig` could each be swapped to
+ * `state.clashResult` with every test still green. Under that swap the
+ * re-derivation runs against the already-filtered set, so `clashSuppressedCount`
+ * and every per-rule count collapse to zero the moment the user nudges the
+ * cluster radius with an exclusion active — the clash list stays right
+ * (re-filtering is idempotent), but the "· N hidden" badge and the per-rule
+ * reach silently vanish.
+ */
+function epsilonResult(): ClashResult {
+  const clashes = [
+    clashAt(rail1, ballast, [0, 0, 0]),
+    clashAt(rail2, ballast, [5, 0, 0]),
+    clashAt(beam1, beam2, [0, 0, 0]),
+  ];
+  return {
+    clashes,
+    summary: {
+      total: 3,
+      byRule: { 'all-clashes': 3 },
+      byTypePair: { 'IfcCourse vs IfcRail': 2, 'IfcBeam vs IfcBeam': 1 },
+      bySeverity: { critical: 0, major: 3, minor: 0, info: 0 },
+    },
+    rulesRun: [],
+    settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
+  };
+}
+
 /** Build a live slice whose actions see their own committed state. */
 function slice(): { get: () => ClashSlice; storage: MemoryStorage } {
   const storage = new MemoryStorage();
@@ -144,22 +181,13 @@ describe('user-defined clash exclusions (store)', () => {
     // never call it, so the control changed the persisted setting but the
     // Issues view never regrouped.
     const s = slice();
-    const clashes = [
-      clashAt(rail1, ballast, [0, 0, 0]),
-      clashAt(rail2, ballast, [5, 0, 0]),
-    ];
-    const result: ClashResult = {
-      clashes,
-      summary: {
-        total: 2,
-        byRule: { 'all-clashes': 2 },
-        byTypePair: { 'IfcCourse vs IfcRail': 2 },
-        bySeverity: { critical: 0, major: 2, minor: 0, info: 0 },
-      },
-      rulesRun: [],
-      settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
-    };
-    s.get().setClashResult(result);
+    s.get().setClashResult(epsilonResult());
+    // An exclusion that actually matches, so the re-derivation has to run
+    // against the RAW run rather than its own previous output.
+    const rule = typePairExclusion('IfcBeam', 'IfcBeam');
+    assert.deepStrictEqual(s.get().addClashExclusion(rule), { ok: true });
+    assert.strictEqual(s.get().clashSuppressedCount, 1, 'precondition: the beam pair is hidden');
+    assert.strictEqual(s.get().clashExclusionCounts.get(rule.id), 1);
     assert.strictEqual(s.get().clashClusterEpsilon, 1.5, 'default radius');
     assert.strictEqual(s.get().clashGroups?.length, 2, 'default 1.5m radius keeps the two clashes apart');
 
@@ -173,6 +201,17 @@ describe('user-defined clash exclusions (store)', () => {
     );
     // The filtered result itself must be untouched by a pure view-setting change.
     assert.strictEqual(s.get().clashResult?.clashes.length, 2);
+    assert.strictEqual(s.get().clashRawResult?.clashes.length, 3, 'the raw run is never re-filtered in place');
+    assert.strictEqual(
+      s.get().clashSuppressedCount,
+      1,
+      'the hidden-clash count must survive a radius change — re-deriving from the FILTERED result would zero it',
+    );
+    assert.strictEqual(
+      s.get().clashExclusionCounts.get(rule.id),
+      1,
+      "the rule's own reach must survive a radius change too",
+    );
   });
 
   it('resetClashSettings re-derives clashGroups with the default radius (#2535)', () => {
@@ -182,22 +221,9 @@ describe('user-defined clash exclusions (store)', () => {
     // Issues view kept the clusters computed at the old radius until the next
     // run.
     const s = slice();
-    const clashes = [
-      clashAt(rail1, ballast, [0, 0, 0]),
-      clashAt(rail2, ballast, [5, 0, 0]),
-    ];
-    const result: ClashResult = {
-      clashes,
-      summary: {
-        total: 2,
-        byRule: { 'all-clashes': 2 },
-        byTypePair: { 'IfcCourse vs IfcRail': 2 },
-        bySeverity: { critical: 0, major: 2, minor: 0, info: 0 },
-      },
-      rulesRun: [],
-      settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
-    };
-    s.get().setClashResult(result);
+    s.get().setClashResult(epsilonResult());
+    const rule = typePairExclusion('IfcBeam', 'IfcBeam');
+    assert.deepStrictEqual(s.get().addClashExclusion(rule), { ok: true });
     s.get().setClashClusterEpsilon(10);
     assert.strictEqual(s.get().clashGroups?.length, 1, 'precondition: 10m radius merges the 5m-apart pair');
 
@@ -209,26 +235,19 @@ describe('user-defined clash exclusions (store)', () => {
       2,
       'the derived grouping must follow the reset radius immediately, without a re-run',
     );
+    // Resetting the DETECTION settings must not silently reset the user's
+    // exclusion bookkeeping: the rules themselves are untouched, so their
+    // counts must be recomputed from the raw run, not from the filtered one.
+    assert.strictEqual(s.get().clashRawResult?.clashes.length, 3);
+    assert.strictEqual(s.get().clashSuppressedCount, 1);
+    assert.strictEqual(s.get().clashExclusionCounts.get(rule.id), 1);
   });
 
   it('applyClashFlavorConfig re-derives clashGroups with the flavor radius (#2535)', () => {
     const s = slice();
-    const clashes = [
-      clashAt(rail1, ballast, [0, 0, 0]),
-      clashAt(rail2, ballast, [5, 0, 0]),
-    ];
-    const result: ClashResult = {
-      clashes,
-      summary: {
-        total: 2,
-        byRule: { 'all-clashes': 2 },
-        byTypePair: { 'IfcCourse vs IfcRail': 2 },
-        bySeverity: { critical: 0, major: 2, minor: 0, info: 0 },
-      },
-      rulesRun: [],
-      settings: { tolerance: 0.002, excludeVoidsAndHosts: true },
-    };
-    s.get().setClashResult(result);
+    s.get().setClashResult(epsilonResult());
+    const rule = typePairExclusion('IfcBeam', 'IfcBeam');
+    assert.deepStrictEqual(s.get().addClashExclusion(rule), { ok: true });
     assert.strictEqual(s.get().clashGroups?.length, 2, 'precondition: default 1.5m radius keeps the pair apart');
 
     s.get().applyClashFlavorConfig({
@@ -242,6 +261,11 @@ describe('user-defined clash exclusions (store)', () => {
       1,
       'activating a flavor must regroup at its radius immediately, without a re-run',
     );
+    // A flavor carries detection settings, not exclusions — so the user's
+    // rules and their reported reach must come through the switch intact.
+    assert.strictEqual(s.get().clashRawResult?.clashes.length, 3);
+    assert.strictEqual(s.get().clashSuppressedCount, 1);
+    assert.strictEqual(s.get().clashExclusionCounts.get(rule.id), 1);
   });
 
   it('a settings change leaves a manual duplicate-scan grouping alone (#2535)', () => {

--- a/packages/drawing-2d/src/projection-bands.test.ts
+++ b/packages/drawing-2d/src/projection-bands.test.ts
@@ -62,6 +62,35 @@ describe('classifyDepthRange', () => {
     expect(classifyDepthRange(3, 5, bands)).toBe('overhead');
   });
 
+  // Every other `depths` fixture in this file is symmetric ({below: 3, above: 3},
+  // {below: 5, above: 5}, and the zero/epsilon pair), which makes `depths.below`
+  // and `depths.above` interchangeable: swapping the two field reads inside
+  // classifyDepthRange left this whole describe green. The asymmetric bands
+  // below pin each band against its OWN half-space.
+  describe('asymmetric bands (below ≠ above)', () => {
+    const bands = { below: 2, above: 6 };
+
+    it('a range inside the deep overhead band is overhead, not culled', () => {
+      // 4..5 sits above the cut and within above = 6, but well past below = 2.
+      // Reading `below` here instead of `above` would cull real overhead
+      // geometry — the roof/soffit case in a plan view with a tall storey.
+      expect(classifyDepthRange(4, 5, bands)).toBe('overhead');
+    });
+
+    it('a range past the shallow below band is culled, not made visible', () => {
+      // -5..-4 is below the cut but past below = 2. Reading `above` (6) here
+      // would keep a whole storey's worth of floor-below geometry visible.
+      expect(classifyDepthRange(-5, -4, bands)).toBe('cull');
+    });
+
+    it('the two bands stay independent for a range straddling the cut', () => {
+      // -1..5 is inside below = 2 on one side and inside above = 6 on the
+      // other, so it must span; with the fields swapped, -1 ≥ -6 still holds
+      // but 5 ≤ 2 does not, and it would degrade to 'visible'.
+      expect(classifyDepthRange(-1, 5, bands)).toBe('spanning');
+    });
+  });
+
   it('zero-width bands cull a near-plane element; the 1mm floor keeps it (R1)', () => {
     const dNearBelow = -0.0005; // just below the cut
     expect(classifyDepthRange(dNearBelow, dNearBelow, { below: 0, above: 0 })).toBe('cull');

--- a/packages/ids/src/constraints/constraints.test.ts
+++ b/packages/ids/src/constraints/constraints.test.ts
@@ -51,6 +51,21 @@ describe('matchConstraint — simpleValue', () => {
     expect(matchConstraint(sv('42'), '42.0000005')).toBe(true); // within tolerance
   });
 
+  it('scales the numeric tolerance with the magnitude of the IDS value', () => {
+    // Every other numeric fixture here has |value| <= 42 and a delta of 5e-7,
+    // so a FLAT 1e-6 passes all of them and the relative term
+    // `1e-6 * (1 + |castValue|)` in numericEpsilon is unexercised. At 1e6 the
+    // two differ by six orders of magnitude: relative gives ~1.0, flat gives
+    // 1e-6. This is the real case — a length in millimetres round-tripped
+    // through text loses more than 1e-6 absolute.
+    expect(matchConstraint(sv('1000000'), 1000000.5)).toBe(true);
+    // ...and the tolerance must stay a tolerance: still bounded, not open.
+    expect(matchConstraint(sv('1000000'), 1000002)).toBe(false);
+    // The scaling is relative, so a small value keeps a small window: 0.5 is
+    // nowhere near 1, even though 0.5 was accepted as slack at 1e6 above.
+    expect(matchConstraint(sv('1'), 1.5)).toBe(false);
+  });
+
   it('matches boolean true (strict lowercase per IDS spec)', () => {
     expect(matchConstraint(sv('true'), true)).toBe(true);
     // Numeric `1` / `0` are NOT valid boolean literals per IDS 1.0.

--- a/packages/pointcloud/src/formats/e57.test.ts
+++ b/packages/pointcloud/src/formats/e57.test.ts
@@ -776,6 +776,74 @@ describe('applyPoseInPlace', () => {
     applyPoseInPlace(b, 1, pose, undefined);
     expect(Array.from(a)).toEqual(Array.from(b));
   });
+
+  // Every other rotation fixture in this file is pure-Z or identity, i.e.
+  // x = y = 0. That leaves six of the nine matrix entries unconstrained:
+  // r02/r12/r20/r21 are all identically zero, and r00 = r11 = 1 - 2z². A sign
+  // flip in r02 or r20, an x/y swap in any term, or swapping r00 with r11 all
+  // stayed green. The two tests below pin the off-axis half of the matrix.
+
+  it('a 120° rotation about (1,1,1) cyclically permutes the axes (x→y→z→x)', () => {
+    // q = (0.5, 0.5, 0.5, 0.5) is the 120° rotation about the body diagonal.
+    // Its matrix is the cyclic permutation [[0,0,1],[1,0,0],[0,1,0]], which is
+    // asymmetric: it pins r02, r10 and r21 as the nonzero entries and every
+    // other entry as zero, so no transpose-like mutation of the off-diagonal
+    // terms survives. Chosen because the expected outputs are exact — the
+    // basis vectors map onto other basis vectors, with no rounding to hide in.
+    const positions = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
+    applyPoseInPlace(positions, 3, {
+      rotation: { w: 0.5, x: 0.5, y: 0.5, z: 0.5 },
+      translation: { x: 0, y: 0, z: 0 },
+    });
+    expect(Array.from(positions.subarray(0, 3))).toEqual([0, 1, 0]); // x → y
+    expect(Array.from(positions.subarray(3, 6))).toEqual([0, 0, 1]); // y → z
+    expect(Array.from(positions.subarray(6, 9))).toEqual([1, 0, 0]); // z → x
+  });
+
+  it('matches the quaternion sandwich product for a fully asymmetric rotation', () => {
+    // The cyclic case above still has w = x = y = z, so an x/y swap inside a
+    // term is invisible to it. This one uses a quaternion whose four
+    // components are all distinct, which makes all nine matrix entries
+    // distinct and nonzero, and checks against q ⊗ (0,v) ⊗ q* — an
+    // independent formulation (quaternion multiplication, no 3x3 matrix), so
+    // the reference cannot inherit a bug from the code under test.
+    const n = Math.hypot(1, 2, 3, 4);
+    const q = { w: 1 / n, x: 2 / n, y: 3 / n, z: 4 / n };
+
+    /** Rotate `v` by unit quaternion `q` via q ⊗ (0,v) ⊗ q⁻¹ (= q* for unit q). */
+    const sandwich = (v: readonly [number, number, number]): [number, number, number] => {
+      // t = q ⊗ (0, v)
+      const tw = -(q.x * v[0] + q.y * v[1] + q.z * v[2]);
+      const tx = q.w * v[0] + q.y * v[2] - q.z * v[1];
+      const ty = q.w * v[1] + q.z * v[0] - q.x * v[2];
+      const tz = q.w * v[2] + q.x * v[1] - q.y * v[0];
+      // t ⊗ q*  (conjugate: negate the vector part)
+      return [
+        tw * -q.x + tx * q.w + ty * -q.z - tz * -q.y,
+        tw * -q.y + ty * q.w + tz * -q.x - tx * -q.z,
+        tw * -q.z + tz * q.w + tx * -q.y - ty * -q.x,
+      ];
+    };
+
+    const samples: Array<[number, number, number]> = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+      [1.5, -2.25, 3.75],
+    ];
+    const positions = new Float32Array(samples.flat());
+    applyPoseInPlace(positions, samples.length, {
+      rotation: q,
+      translation: { x: 0, y: 0, z: 0 },
+    });
+
+    samples.forEach((v, i) => {
+      const want = sandwich(v);
+      expect(positions[i * 3]).toBeCloseTo(want[0], 5);
+      expect(positions[i * 3 + 1]).toBeCloseTo(want[1], 5);
+      expect(positions[i * 3 + 2]).toBeCloseTo(want[2], 5);
+    });
+  });
 });
 
 describe('originOffset (extends #1804 to E57)', () => {


### PR DESCRIPTION
Third batch of "two distinct things are accidentally identical" findings, after #2710 and #2715. Same method: find a suite that is green under a mutation that changes real behaviour, because every fixture happens to make the two sides of the decision equal.

**Test-only.** No production code changed. Every finding was proven by applying the named mutation to production, watching the new test go RED, restoring from a backup, and confirming GREEN.

---

### 1. E57 pose — six of nine rotation-matrix entries were unconstrained

`packages/pointcloud/src/formats/e57.ts` builds a 3x3 from `{w,x,y,z}`. Every rotation fixture in `e57.test.ts` was pure-Z (`{w: SQRT1_2, x: 0, y: 0, z: SQRT1_2}`) or identity. With `x = y = 0`, `r02`/`r12`/`r20`/`r21` are all identically zero and `r00 = 1 − 2z²` equals `r11`.

Mutations that were green before, RED after:

| mutation | before | after |
| --- | --- | --- |
| `r02 = 2*(x*z + w*y)` → `2*(x*z − w*y)` (sign flip) | 33 pass | 2 fail |
| `r00` ↔ `r11` (swap the two body expressions) | 33 pass | 1 fail |
| `r12 = 2*(y*z − w*x)` → `2*(x*z − w*y)` (x/y swap) | 33 pass | 1 fail |

Two new tests. The first is the 120° rotation about `(1,1,1)/√3` — `{w: .5, x: .5, y: .5, z: .5}` — whose matrix is the exact cyclic permutation `[[0,0,1],[1,0,0],[0,1,0]]`, so basis vectors map onto basis vectors with no rounding to hide in. That one alone does **not** catch an x/y swap (its four components are equal), which is why the second test uses a quaternion with four distinct components and checks against the **quaternion sandwich product** `q ⊗ (0,v) ⊗ q*` — an independent formulation with no 3x3 in it, so the reference cannot inherit a bug from the code under test.

### 2. `clashRawResult` / `clashResult` were one object in every fixture

`apps/viewer/src/lib/clash/exclusions.ts` returns its **input by reference** when `suppressed === 0`:

```ts
if (suppressed === 0) return { result, counts, suppressed: 0 };
```

Four sites feed `state.clashRawResult` into `deriveGroups`. Only `commitExclusions` was covered. The other three — `setClashClusterEpsilon`, `resetClashSettings`, `applyClashFlavorConfig` — could each be swapped to `state.clashResult` with the whole suite green, because none of their fixtures had a rule that matched anything.

**Real consequence under the swap:** the clash list stays correct (re-filtering is idempotent), but the counts are recomputed against the already-filtered set and collapse to zero. So `ClashPanel`'s `· N hidden` badge and every per-rule count silently vanish for a user who nudges the cluster radius with an exclusion active.

The three tests now share an `epsilonResult()` fixture — the same two 5m-apart rail/ballast clashes that make the radius observable, plus one `IfcBeam`-vs-`IfcBeam` clash for a rule to bite on — add that rule before the settings change, and assert `clashSuppressedCount`, `clashExclusionCounts.get(rule.id)` and the raw run's length all survive it. Each of the three swaps now fails exactly its own test.

### 3. `projection-bands` — `below`/`above` were interchangeable

Every `depths` fixture in `projection-bands.test.ts` was symmetric (`{below: 3, above: 3}`, `{below: 5, above: 5}`, and a zero/epsilon pair), so both field reads in `classifyDepthRange` could be swapped with the file green.

One correction to the original write-up: swapping line 180's `depths.above` → `depths.below` **is** caught today, by `storey-bands.test.ts:102`. But only by accident — that case survives on `lo` and `below` differing in the last ulp of a 0.1 storey gap (`2.9 − 2.8` vs `2.8 − 2.7`), which is a coin flip, not a test. The new `asymmetric bands (below ≠ above)` describe uses `{below: 2, above: 6}` and holds by construction with a 4-unit margin, covering both swaps and the straddling case.

### 4. IDS numeric epsilon — the relative term was never exercised

`packages/ids/src/constraints/comparators.ts`:

```ts
const relative = RELATIVE_TOLERANCE * (1 + Math.abs(castValue));
```

Every numeric fixture used magnitude ≤ 42 with a delta of 5e-7, so replacing that whole expression with a **flat `1e-6`** passed all 42 tests. `NUMERIC_TOLERANCE = 1e-6` in `constraints/index.ts` is a different quantity carrying the same literal, which made the swap doubly invisible.

New test at magnitude 1e6, where the two differ by six orders of magnitude, pinning the scaling in **both** directions — `1000000.5` accepted (flat 1e-6 rejects it), `1000002` still rejected (a loosened `RELATIVE_TOLERANCE = 1e-3` accepts it), and `matchConstraint(sv('1'), 1.5)` still false so the window stays proportional. Both mutations are RED.

While there: the `ulp` term in `numericEpsilon` (`16 * EPSILON * max(...)`, ≈3.55e-15·M) can never exceed `relative` (≥1e-6·(1+M)) for any M, so it is dead in every reachable case. Left alone — that is a production question, not a test one.

---

### Report-only: `HOST_CONTAINMENT_TOLERANCE_M`

`packages/provenance/src/merge-model.ts` documents `1e-9` as slack so an opening flush with a host face is contained "rather than a floating-point coin flip". The flush fixture in `merge-battery.ts` sets the opening's origin z to `hostBox.min[2]` — the same value **copied**, not recomputed — so `aabbContains`'s test reduces to `v < v − tol`, false for any `tol ≥ 0`.

Settled as instructed: set the constant to `0` and ran the whole `packages/provenance` suite. **267/267 pass.** No fixture exercises the slack the constant exists to provide, so its value is currently unverified by any test. The constant is unchanged in this PR.

---

### Gates

`pnpm lint` (0 errors), `pnpm typecheck` (1183/1183 test files in a program), `pnpm test` — all green. No changeset: `scripts/check-changesets.mjs` only validates that a changeset names a workspace member, it does not require one, and this touches no publishable behaviour.

Cross-refs: #2710, #2715. The FOV finding in `contribution-cull.test.ts` is deliberately untouched — it is already fixed in #2715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
