### PR TITLE
test: harden three fixtures that cannot observe the property they assert

### DIFF
--- a/.changeset/fixtures-that-cannot-observe-their-property.md
+++ b/.changeset/fixtures-that-cannot-observe-their-property.md
@@ -1,0 +1,35 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+Harden three Rust fixtures that could not observe the property they asserted.
+
+Test-only; no production code changed. Each of the three was verified by
+mutating production, confirming the old fixture still passed, and confirming
+the new one fails.
+
+- `rust/processing/src/simplify_session_tests.rs` — the only `y_up: true` test
+  passed `origin: [0.0; 3]`, and `yup_to_zup` of zero is zero, so
+  `simplify_element`'s `yup_to_zup(rec.origin)` branch was unobservable:
+  replacing it with `let origin = rec.origin;` kept the crate green. The
+  record now carries a Z-up origin of (1, 2, 3), fed in as the boundary's Y-up
+  swap, and both the local and render extents are pinned at min and max.
+
+- `rust/ffi/src/tests.rs` — `normalize_to_site_local`'s guard skips the shift
+  only when all three site-translation components are inside
+  `LARGE_COORD_THRESHOLD`, but the only fixture exercising it put all three
+  past 1 km, so rewriting `&&` as `||` still shifted. The fixture now uses a
+  realistic georeferenced placement (large easting and northing, a 2 m
+  elevation), and a second test brackets the constant itself, which the
+  previous 1.0-vs-123456.0 pair left free anywhere in between.
+
+- `rust/geometry/src/router/voids/bool2d_path_tests.rs` — `hm_inv()` returned
+  the identity and was the argument to every `opening_solid_footprint` call in
+  the crate, so production's `let to_host = hm_inv * op.m;` was
+  indistinguishable from `let to_host = op.m;`. The host is now placed at
+  (3, -2, 5) rotated about Z, `hm_inv()` is its real inverse, and opening
+  placements are given in world space as `host_m() * (host-local placement)`.
+
+Scope: these three fixtures only. The sweep that found them did not cover most
+of `rust/export`, about 40 files under `rust/processing/tests/`, or the 90-plus
+files under `rust/geometry/tests/`; nothing is claimed about those.

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -61,7 +61,12 @@ fn transform_with_translation(tx: f64, ty: f64, tz: f64) -> [f64; 16] {
 /// `site_local` (see `normalize_to_site_local` doc comment, lib.rs:~110-135).
 #[test]
 fn raw_ifc_with_large_site_translation_shifts_all_meshes_and_relabels() {
-    let (tx, ty, tz) = (123456.0, -7000.5, 2000.0);
+    // A realistic georeferenced placement: easting/northing far from the
+    // origin, elevation a normal building height. The Z component must stay
+    // *below* `LARGE_COORD_THRESHOLD`, otherwise all three components exceed
+    // it and the guard's `&&` is indistinguishable from `||` — the shift
+    // happens either way and the conjunction goes untested.
+    let (tx, ty, tz) = (123456.0, -7000.5, 2.0);
     let mut result = processing_result(
         Some(RAW_IFC_MESH_COORDINATE_SPACE),
         Some(transform_with_translation(tx, ty, tz)),
@@ -113,6 +118,54 @@ fn raw_ifc_with_near_origin_site_translation_is_left_untouched() {
     );
     assert_eq!(result.meshes[0].positions, original_positions_a);
     assert_eq!(result.meshes[1].positions, original_positions_b);
+}
+
+/// Pin `LARGE_COORD_THRESHOLD` itself. The other two fixtures straddle it by
+/// two orders of magnitude (1.0 vs 123456.0), so any threshold anywhere in
+/// between would satisfy them both. Bracket the constant instead: a single
+/// axis just *above* 1 km must shift, the same axis just *below* must not.
+#[test]
+fn the_large_coordinate_threshold_is_bracketed_on_both_sides() {
+    for (translation, should_shift) in [
+        ([LARGE_COORD_THRESHOLD + 0.5, 0.0, 0.0], true),
+        ([LARGE_COORD_THRESHOLD - 0.5, 0.0, 0.0], false),
+    ] {
+        let [tx, ty, tz] = translation;
+        let original = processing_result(
+            Some(RAW_IFC_MESH_COORDINATE_SPACE),
+            Some(transform_with_translation(tx, ty, tz)),
+        );
+        let original_positions_a = original.meshes[0].positions.clone();
+
+        let mut result = original;
+        normalize_to_site_local(&mut result);
+
+        if should_shift {
+            assert_eq!(
+                result.mesh_coordinate_space.as_deref(),
+                Some(SITE_LOCAL_MESH_COORDINATE_SPACE),
+                "tx={tx} is past the threshold and must be shifted"
+            );
+            let expected_a: Vec<f32> = original_positions_a
+                .chunks_exact(3)
+                .flat_map(|c| {
+                    [
+                        (c[0] as f64 - tx) as f32,
+                        (c[1] as f64 - ty) as f32,
+                        (c[2] as f64 - tz) as f32,
+                    ]
+                })
+                .collect();
+            assert_eq!(result.meshes[0].positions, expected_a);
+        } else {
+            assert_eq!(
+                result.mesh_coordinate_space.as_deref(),
+                Some(RAW_IFC_MESH_COORDINATE_SPACE),
+                "tx={tx} is inside the threshold and must be left alone"
+            );
+            assert_eq!(result.meshes[0].positions, original_positions_a);
+        }
+    }
 }
 
 /// `site_local`, `model_rtc`, and `None` are all coordinate spaces the

--- a/rust/geometry/src/router/voids/bool2d_path_tests.rs
+++ b/rust/geometry/src/router/voids/bool2d_path_tests.rs
@@ -10,8 +10,47 @@
 use super::*;
 use nalgebra::Rotation3;
 
+// Host: extruded +Z over [0, 4] in its own profile frame, placed in the world
+// by a translation and a rotation about Z.
+//
+// The host placement is deliberately NOT the identity. With `host_m == I` the
+// host frame coincides with world, `hm_inv` is the identity, and production's
+// `let to_host = hm_inv * op.m;` (bool2d_path.rs) is indistinguishable from
+// `let to_host = op.m;` — the inverse that the real caller passes
+// (`host.m.try_inverse()`) is then never exercised by any test in the crate.
+const HZ_MIN: f64 = 0.0;
+const HZ_MAX: f64 = 4.0;
+
+/// The host's object placement: translate to (3, -2, 5), rotated 30° about Z.
+/// Rotating about Z keeps the host's extrusion direction on world +Z (see
+/// [`host_axis`]) while making the host frame differ from world in every
+/// component the footprint projection reads.
+fn host_m() -> Matrix4<f64> {
+    Matrix4::new_translation(&Vector3::new(3.0, -2.0, 5.0))
+        * Rotation3::from_axis_angle(&Vector3::z_axis(), 30.0_f64.to_radians()).to_homogeneous()
+}
+
+/// The inverse the real caller computes (`host.m.try_inverse()`,
+/// bool2d_path.rs) — a genuine inverse of [`host_m`], not the identity.
+fn hm_inv() -> Matrix4<f64> {
+    let m = host_m();
+    m.try_inverse().expect("host placement is invertible")
+}
+
+/// The host extrusion direction in WORLD space, as production derives it
+/// (`host_rot * (0, 0, dir_sign)`). [`host_m`]'s rotation is about Z, so this
+/// stays +Z even though the placement is non-identity.
+fn host_axis() -> Vector3<f64> {
+    Vector3::new(0.0, 0.0, 1.0)
+}
+
 /// A unit-square opening solid at `center` (host-local XY), swept `depth`
 /// along `axis` (host-local), with `dir_sign`.
+///
+/// The returned placement is in WORLD space — `host_m() * (host-local
+/// placement)` — exactly as `opening.m` reaches production from the decoder.
+/// The same host-local footprint is therefore recovered only if
+/// `opening_solid_footprint` really applies `hm_inv`.
 fn opening(
     center: (f64, f64, f64),
     axis: Vector3<f64>,
@@ -23,7 +62,7 @@ fn opening(
     let rot = Rotation3::rotation_between(&z, &axis)
         .unwrap_or_else(Rotation3::identity)
         .to_homogeneous();
-    let m = Matrix4::new_translation(&Vector3::new(center.0, center.1, center.2)) * rot;
+    let m = host_m() * Matrix4::new_translation(&Vector3::new(center.0, center.1, center.2)) * rot;
     let profile = Profile2D::new(vec![
         Point2::new(-0.5, -0.5),
         Point2::new(0.5, -0.5),
@@ -38,16 +77,6 @@ fn opening(
     }
 }
 
-// Host: extruded +Z over [0, 4], identity placement → host frame == world.
-const HZ_MIN: f64 = 0.0;
-const HZ_MAX: f64 = 4.0;
-fn host_axis() -> Vector3<f64> {
-    Vector3::new(0.0, 0.0, 1.0)
-}
-fn hm_inv() -> Matrix4<f64> {
-    Matrix4::identity()
-}
-
 #[test]
 fn parallel_through_opening_is_eligible() {
     // +Z, full host depth: a clean through-cut → footprint recovered.
@@ -57,7 +86,36 @@ fn parallel_through_opening_is_eligible() {
         fp.is_some(),
         "a parallel full-depth opening must be eligible"
     );
-    assert_eq!(fp.unwrap().len(), 4);
+    let fp = fp.unwrap();
+    assert_eq!(fp.len(), 4);
+    // The footprint must come back in HOST-LOCAL coordinates: the unit square
+    // around the host-local centre (1, 1). Without `hm_inv` it would still be
+    // in world space, carrying the host's 30° rotation and (3, -2) offset.
+    let expected = [(0.5, 0.5), (1.5, 0.5), (1.5, 1.5), (0.5, 1.5)];
+    for (i, (ex, ey)) in expected.iter().enumerate() {
+        assert!(
+            (fp[i].x - ex).abs() < 1e-9 && (fp[i].y - ey).abs() < 1e-9,
+            "footprint vertex {i}: {:?} != ({ex}, {ey})",
+            fp[i]
+        );
+    }
+}
+
+#[test]
+fn opening_outside_the_host_span_in_host_local_defers() {
+    // The through-cut span gate is evaluated in the HOST-LOCAL frame against
+    // [HZ_MIN, HZ_MAX]. This opening is full-depth and parallel, but sits at
+    // host-local z in [-5, -1] — entirely below the host — so it must defer.
+    //
+    // The host is translated +5 in Z, so in WORLD space this same solid spans
+    // exactly [0, 4]: dropping `hm_inv` (`let to_host = op.m;`) makes the span
+    // gate pass and this opening wrongly eligible. That is the point of the
+    // fixture — an `is_none()` case that the missing inverse can actually flip.
+    let op = opening((1.0, 1.0, -5.0), host_axis(), HZ_MAX, 1.0);
+    assert!(
+        opening_solid_footprint(&op, &hm_inv(), &host_axis(), HZ_MIN, HZ_MAX, 0.04).is_none(),
+        "an opening outside the host's own extrusion span must defer"
+    );
 }
 
 #[test]
@@ -129,7 +187,8 @@ fn degenerate_zero_area_footprint_defers() {
     // branch is the exact `== 0.0` case; weakening `<= 0.0` to `< 0.0` turns
     // it into dead code that never fires.
     let z = Vector3::new(0.0, 0.0, 1.0);
-    let m = Matrix4::new_translation(&Vector3::new(1.0, 1.0, 0.0));
+    // World placement, like `opening()`: host frame composed on the outside.
+    let m = host_m() * Matrix4::new_translation(&Vector3::new(1.0, 1.0, 0.0));
     let profile = Profile2D::new(vec![
         Point2::new(0.0, 0.0),
         Point2::new(1.0, 0.0),

--- a/rust/processing/src/simplify_session_tests.rs
+++ b/rust/processing/src/simplify_session_tests.rs
@@ -119,17 +119,25 @@ fn yup_frame_round_trips_and_restores_winding() {
         tri.swap(1, 2);
     }
     let normals_y = vec![0.0; positions_y.len()];
+    // A non-zero per-mesh origin with three distinct components, so the
+    // `yup_to_zup(rec.origin)` swap is observable: with `origin: [0; 3]`
+    // (or any origin whose components coincide) dropping the swap moves
+    // nothing, and `let origin = rec.origin;` passes unnoticed.
+    let origin_z = [1.0, 2.0, 3.0];
+    let origin_y = zup_to_yup(origin_z);
     let rec = SimplifyRecordInput {
         positions: &positions_y,
         normals: &normals_y,
         indices: &indices_y,
-        origin: [0.0; 3],
+        origin: origin_y,
         // Identity conjugates to identity.
         local_to_world: Some(IDENTITY),
     };
     let out = simplify_element(&[rec], 5, [0.0; 3], 1.0, true).unwrap();
 
-    // IFC-local output must be back in Z-up: extents match the Z-up box.
+    // IFC-local output must be back in Z-up: the Z-up box [0,2]x[0,3]x[0,4]
+    // offset by the Z-up origin (1,2,3) => [1,3]x[2,5]x[3,7]. Skipping the
+    // origin swap would place it at [1,3]x[3,6]x[2,6] instead.
     let (mut lmin, mut lmax) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
     for c in out.local_positions.chunks_exact(3) {
         for k in 0..3 {
@@ -137,12 +145,25 @@ fn yup_frame_round_trips_and_restores_winding() {
             lmax[k] = lmax[k].max(c[k]);
         }
     }
-    assert!((lmax[0] - 2.0).abs() < 1e-6);
-    assert!((lmax[1] - 3.0).abs() < 1e-6);
-    assert!((lmax[2] - 4.0).abs() < 1e-6);
+    let expect_lmin = [1.0, 2.0, 3.0];
+    let expect_lmax = [3.0, 5.0, 7.0];
+    for k in 0..3 {
+        assert!(
+            (lmin[k] - expect_lmin[k]).abs() < 1e-6,
+            "local min axis {k}: {} != {}",
+            lmin[k],
+            expect_lmin[k]
+        );
+        assert!(
+            (lmax[k] - expect_lmax[k]).abs() < 1e-6,
+            "local max axis {k}: {} != {}",
+            lmax[k],
+            expect_lmax[k]
+        );
+    }
 
-    // Render output stays in the caller's Y-up frame: the Z-up box
-    // [0,2]x[0,3]x[0,4] swaps to x[0,2], y[0,4], z[-3,0]; positions are
+    // Render output stays in the caller's Y-up frame: the Z-up world box
+    // [1,3]x[2,5]x[3,7] swaps to x[1,3], y[3,7], z[-5,-2]; positions are
     // relative to render_origin, so reconstruct world = origin + p.
     let (mut rmin, mut rmax) = ([f64::INFINITY; 3], [f64::NEG_INFINITY; 3]);
     for c in out.render_positions.chunks_exact(3) {
@@ -152,10 +173,22 @@ fn yup_frame_round_trips_and_restores_winding() {
             rmax[k] = rmax[k].max(w);
         }
     }
-    assert!((rmax[0] - 2.0).abs() < 1e-5);
-    assert!((rmax[1] - 4.0).abs() < 1e-5);
-    assert!((rmin[2] - -3.0).abs() < 1e-5);
-    assert!(rmax[2].abs() < 1e-5);
+    let expect_rmin = [1.0, 3.0, -5.0];
+    let expect_rmax = [3.0, 7.0, -2.0];
+    for k in 0..3 {
+        assert!(
+            (rmin[k] - expect_rmin[k]).abs() < 1e-5,
+            "render min axis {k}: {} != {}",
+            rmin[k],
+            expect_rmin[k]
+        );
+        assert!(
+            (rmax[k] - expect_rmax[k]).abs() < 1e-5,
+            "render max axis {k}: {} != {}",
+            rmax[k],
+            expect_rmax[k]
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Test-only. Three Rust fixtures asserted a property their inputs made unobservable: in each case the input was chosen so that the production branch under test is a no-op, and deleting that branch left the whole crate green. Each fix is proved by mutating production, confirming the old fixture still passed and the new one fails, then reverting the mutation.

`git diff upstream/main --stat` is test files plus the changeset; no production code is changed.

## 1. `rust/processing/src/simplify_session_tests.rs` — the Y-up origin swap

`simplify_element` converts the per-mesh origin with `yup_to_zup(rec.origin)` when `y_up` is set. The only `y_up: true` test passed `origin: [0.0; 3]`, and `yup_to_zup` of zero is zero; the only non-zero-origin test ran `y_up: false`.

Mutation:

```diff
-        let origin = if y_up {
-            yup_to_zup(rec.origin)
-        } else {
-            rec.origin
-        };
+        let origin = rec.origin;
```

| | old fixture | new fixture |
|---|---|---|
| unmutated production | pass (8 passed) | pass (8 passed) |
| mutated production | **pass (8 passed)** ← the defect | **fail (7 passed, 1 failed)** ← the fix |

New-fixture failure under the mutation:

```
thread 'simplify_session_tests::yup_frame_round_trips_and_restores_winding'
panicked at rust/processing/src/simplify_session_tests.rs:151:9:
local min axis 1: 3 != 2
```

The record now carries a Z-up origin of (1, 2, 3), fed in as the boundary's Y-up swap, and both the local (Z-up) and render (Y-up) extents are pinned at min and max.

## 2. `rust/ffi/src/tests.rs` — the large-site guard

`normalize_to_site_local` skips the shift only when *all three* site-translation components are inside `LARGE_COORD_THRESHOLD`. The single fixture exercising it used `(123456.0, -7000.5, 2000.0)` — all three past 1 km — so `&&` and `||` behave identically. The threshold constant was also unpinned: the two fixtures straddled it as 1.0 vs 123456.0, satisfied by any threshold in between.

Mutation:

```diff
     if site_tx.abs() < LARGE_COORD_THRESHOLD
-        && site_ty.abs() < LARGE_COORD_THRESHOLD
-        && site_tz.abs() < LARGE_COORD_THRESHOLD
+        || site_ty.abs() < LARGE_COORD_THRESHOLD
+        || site_tz.abs() < LARGE_COORD_THRESHOLD
```

| | old fixture | new fixture |
|---|---|---|
| unmutated production | pass (10 passed) | pass (11 passed) |
| mutated production | **pass (10 passed)** ← the defect | **fail (9 passed, 2 failed)** ← the fix |

New-fixture failures under the mutation:

```
---- tests::raw_ifc_with_large_site_translation_shifts_all_meshes_and_relabels
assertion `left == right` failed: raw_ifc meshes shifted by the site translation must be relabeled site_local
  left: Some("raw_ifc")
 right: Some("site_local")

---- tests::the_large_coordinate_threshold_is_bracketed_on_both_sides
assertion `left == right` failed: tx=1000.5 is past the threshold and must be shifted
  left: Some("raw_ifc")
 right: Some("site_local")
```

The fixture now uses a realistic georeferenced placement — large easting and northing, a 2 m elevation — so the guard is false only because of the conjunction. A second test brackets the constant: one axis at `threshold + 0.5` must shift, the same axis at `threshold - 0.5` must not.

### For the maintainer — not acted on here

Three different large-coordinate thresholds coexist in the tree, and nothing ties them together:

- `rust/ffi/src/lib.rs:107` — `LARGE_COORD_THRESHOLD = 1000.0`
- `rust/geometry/src/lib.rs:223` — `10000.0`
- `rust/core/src/model_bounds.rs:81` — `10000.0`

Flagging only; this PR does not unify them, and I have not established whether they are meant to agree.

## 3. `rust/geometry/src/router/voids/bool2d_path_tests.rs` — the host inverse

`hm_inv()` returned `Matrix4::identity()` and was the argument to every `opening_solid_footprint` call in the crate. Production computes `let to_host = hm_inv * op.m;` (bool2d_path.rs:339) and the real caller passes `host.m.try_inverse()` (bool2d_path.rs:137/176), so with an identity host frame `to_host == op.m` and the inverse was never exercised. Aggravating: six of the seven tests asserted `is_none()`, where a missing transform tends to keep the answer `None` anyway.

Mutation:

```diff
-    let to_host = hm_inv * op.m;
+    let to_host = op.m;
```

| | old fixture | new fixture |
|---|---|---|
| unmutated production | pass (9 passed) | pass (10 passed) |
| mutated production | **pass (9 passed)** ← the defect | **fail (8 passed, 2 failed)** ← the fix |

New-fixture failures under the mutation:

```
---- router::voids::bool2d_path::tests::parallel_through_opening_is_eligible
panicked at bool2d_path_tests.rs:84:5:
a parallel full-depth opening must be eligible

---- router::voids::bool2d_path::tests::opening_outside_the_host_span_in_host_local_defers
panicked at bool2d_path_tests.rs:114:5:
an opening outside the host's own extrusion span must defer
```

All seven existing tests are converted, not a subset: the host is placed at (3, -2, 5) rotated 30 degrees about Z, `hm_inv()` is that placement's genuine inverse, and every opening placement is now given in world space as `host_m() * (host-local placement)`. Rotating about Z keeps the host extrusion axis on world +Z, exactly as production derives it (`host_rot * (0, 0, dir_sign)`), so the existing parallelism, lateral-drift and span expectations are unchanged — only the frame is non-trivial.

Two tests actually observe the inverse:

- `parallel_through_opening_is_eligible` additionally pins the returned footprint's host-local coordinates, which without `hm_inv` still carry the host's rotation and offset.
- a new `opening_outside_the_host_span_in_host_local_defers` places a full-depth parallel opening at host-local z in [-5, -1] — outside the host span — which is exactly [0, 4] in world, so the through-cut gate rejects it only if the inverse is applied.

The other five remain `is_none()` cases that this particular mutation cannot flip (dropping the transform moves them further from eligibility, not closer). They are no longer identity-framed, but I am not claiming they detect it.

## Checked and dropped: `rust/clash/src/obb_tests.rs`

`a.half` and `b.half` are the same array in every fixture there (`obb_tests.rs:55`, `:113`, `:118`), so on that file's evidence alone `r_b` reading `a.half` looks untested. Running the mutation says otherwise:

```diff
-        let r_b = b.half[0] * dot(b.axes[0], u).abs()
-            + b.half[1] * dot(b.axes[1], u).abs()
-            + b.half[2] * dot(b.axes[2], u).abs();
+        let r_b = a.half[0] * dot(b.axes[0], u).abs()
+            + a.half[1] * dot(b.axes[1], u).abs()
+            + a.half[2] * dot(b.axes[2], u).abs();
```

`cargo test -p ifc-lite-clash` → 63 passed, 3 failed:

```
tests::a_genuine_crossing_is_labelled_mesh_measured
tests::an_enclosed_layer_is_labelled_mesh_measured
tests::penetrating_pair_reports_mesh_depth_not_bar_thickness
    depth must be the mesh penetration 0.5, got -0.25
```

Coverage comes from `rust/clash/src/tests.rs`, not from `obb_tests.rs`. Already covered — no change made. The mutation was reverted.

## Verification

- `cargo test -p ifc-lite-processing -p ifc-lite-ffi -p ifc-lite-geometry -p ifc-lite-clash`: **1194 passed, 0 failed, 19 ignored**.
- `cargo clippy -p ifc-lite-processing -p ifc-lite-ffi -p ifc-lite-geometry -p ifc-lite-clash --all-targets` on the pinned `nightly-2025-11-15`: clean, 0 warnings, 0 errors.
- `rustfmt --check` on the pinned toolchain: the three touched files produce the same hunk counts as their `upstream/main` versions (5 total, all in regions this PR does not touch), so no new formatting drift. Reported per-file rather than as `cargo fmt --all` because the tree is not fmt-clean at that toolchain today (`rust/AGENTS.md` says as much: "no blanket `cargo fmt`") and no workflow runs it.
- Every production mutation above was reverted before committing.

## What this does not cover

Only these three fixtures. The read-only sweep that found them did not cover most of `rust/export`, roughly 40 files under `rust/processing/tests/`, or the 90-plus files under `rust/geometry/tests/`. Nothing here says anything about whether those observe what they assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened coverage for translated and rotated geometry fixtures.
  * Added boundary checks for large-coordinate translations and mesh relabeling.
  * Improved validation of Y-up and Z-up coordinate conversions with non-zero origins.
  * Added coverage for openings outside host spans and degenerate footprints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->