### PR TITLE
test(ffi): pin LARGE_COORD_THRESHOLD's value, not just the boundary's sharpness

### DIFF
--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -120,12 +120,13 @@ fn raw_ifc_with_near_origin_site_translation_is_left_untouched() {
     assert_eq!(result.meshes[1].positions, original_positions_b);
 }
 
-/// Pin the boundary's sharpness and per-axis semantics, *relative to
-/// whatever `LARGE_COORD_THRESHOLD` currently is*: a single axis just above
-/// the constant must shift, the same axis just below must not. The other two
-/// fixtures straddle it by two orders of magnitude (1.0 vs 123456.0), so any
-/// threshold anywhere in between would satisfy them both — this fixture
-/// closes that gap for the *boundary behavior*.
+/// Pin the boundary's sharpness on the x-axis, *relative to whatever
+/// `LARGE_COORD_THRESHOLD` currently is*: tx just above the constant must
+/// shift, tx just below must not (ty and tz are held at 0.0 and are not
+/// independently exercised here). The other two fixtures straddle it by
+/// roughly five orders of magnitude (1.0 vs 123456.0), so any threshold
+/// anywhere in between would satisfy them both — this fixture closes that
+/// gap for the *boundary behavior*.
 ///
 /// This does **not** pin the constant's *value*: every value used below is
 /// derived from `LARGE_COORD_THRESHOLD` itself, so the fixture is green for

--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -120,12 +120,26 @@ fn raw_ifc_with_near_origin_site_translation_is_left_untouched() {
     assert_eq!(result.meshes[1].positions, original_positions_b);
 }
 
-/// Pin `LARGE_COORD_THRESHOLD` itself. The other two fixtures straddle it by
-/// two orders of magnitude (1.0 vs 123456.0), so any threshold anywhere in
-/// between would satisfy them both. Bracket the constant instead: a single
-/// axis just *above* 1 km must shift, the same axis just *below* must not.
+/// Pin the boundary's sharpness and per-axis semantics, *relative to
+/// whatever `LARGE_COORD_THRESHOLD` currently is*: a single axis just above
+/// the constant must shift, the same axis just below must not. The other two
+/// fixtures straddle it by two orders of magnitude (1.0 vs 123456.0), so any
+/// threshold anywhere in between would satisfy them both — this fixture
+/// closes that gap for the *boundary behavior*.
+///
+/// This does **not** pin the constant's *value*: every value used below is
+/// derived from `LARGE_COORD_THRESHOLD` itself, so the fixture is green for
+/// any value of the constant. The `assert_eq!` immediately below is what
+/// actually pins the documented 1 km contract (see `LARGE_COORD_THRESHOLD`'s
+/// doc comment on lib.rs) — mutate the constant and this assertion, not the
+/// bracketing below, is what fails.
 #[test]
 fn the_large_coordinate_threshold_is_bracketed_on_both_sides() {
+    assert_eq!(
+        LARGE_COORD_THRESHOLD, 1000.0,
+        "documented contract is 1 km; the bracketing below derives from this constant and would follow it to any value"
+    );
+
     for (translation, should_shift) in [
         ([LARGE_COORD_THRESHOLD + 0.5, 0.0, 0.0], true),
         ([LARGE_COORD_THRESHOLD - 0.5, 0.0, 0.0], false),


### PR DESCRIPTION
## Summary

Follow-up to #2720. `louistrue` [found](https://github.com/LTplus-AG/ifc-lite/pull/2720#issuecomment-5320616064) that mutating `LARGE_COORD_THRESHOLD` from `1000.0` to `100000.0` left the ffi suite GREEN (11/11) — `the_large_coordinate_threshold_is_bracketed_on_both_sides` pins the boundary's *sharpness* and per-axis semantics (every value it uses is `LARGE_COORD_THRESHOLD ± 0.5`, so it's green for any constant value), but its doc comment claimed it pinned "`LARGE_COORD_THRESHOLD` **itself**". Credit to `louistrue` for catching this.

- Reproduced the finding: mutating the constant to `100000.0` on `upstream/main` leaves all 11 ffi tests green.
- Added `assert_eq!(LARGE_COORD_THRESHOLD, 1000.0, ...)` against the documented contract on `rust/ffi/src/lib.rs` ("Threshold in meters below which a site translation is treated as identity").
- Rewrote the doc comment to describe only what the test actually checks (boundary sharpness / per-axis semantics), and to point at the new assertion as the thing that pins the value.
- Re-ran the `100000.0` mutation with the fix in place: it now fails, naming `the_large_coordinate_threshold_is_bracketed_on_both_sides`.

## Investigated, not fixed here (maintainer decision)

The task also asked me to check whether the same blindness affects the other two large-coordinate thresholds in the tree. Report only — no code changes for these:

- `rust/geometry/src/lib.rs`'s `LARGE_COORD_THRESHOLD_METERS = 10000.0`: mutating it to `100000.0` (10x) leaves the *entire* `cargo test -p ifc-lite-geometry` suite green — same blindness, nothing pins this constant's value.
- `rust/core/src/model_bounds.rs`'s local `THRESHOLD = 10000.0` (in `has_large_coordinates`): mutating it 10x to `100000.0` also leaves all `model_bounds` tests green, because the "large coordinate" test fixtures sit at ~2.6M (Swiss UTM), far above even a 10x-mutated threshold. Only a ~300x mutation (to `3000000.0`) is caught, and only incidentally — no assertion pins the constant's documented value.

Whether these three thresholds (`1000.0`, `10000.0`, `10000.0`) are meant to agree, and whether their tests should get the same `assert_eq!` treatment, is left to a maintainer call — not addressed in this PR per the task scope.

## Test plan

- [x] `cargo test -p ifc-lite-ffi`: 11 passed, 0 failed (unmutated).
- [x] Reproduced pre-fix: `LARGE_COORD_THRESHOLD = 100000.0` → 11/11 still green (confirms the defect existed).
- [x] Post-fix: same mutation → `the_large_coordinate_threshold_is_bracketed_on_both_sides` FAILS with `left: 100000.0, right: 1000.0`; other 10 tests still pass.
- [x] Mutation reverted; `git diff upstream/main -- rust/ffi/src/lib.rs` is empty.
- [x] `cargo clippy -p ifc-lite-ffi --all-targets -- -D warnings`: clean.
- [x] No changeset — test-only change, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved boundary test coverage for large-coordinate handling.
  * Added an explicit check that the threshold remains set to 1000.0.
  * Clarified validation of values immediately below and above the threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->