### PR TITLE
test(export): pin the MapConversion branch's georeferencing nomination

### DIFF
--- a/packages/export/src/attribute-nomination-effect.test.ts
+++ b/packages/export/src/attribute-nomination-effect.test.ts
@@ -42,9 +42,12 @@ function headerClaimedModifications(stepText: string): number | null {
 const WALL_ID = 8;
 const WALL_TYPE_ID = 5;
 const CRS_ID = 40;
+const MAP_CONVERSION_ID = 41;
 const WALL_NAME = 'Existing Wall';
 /** The `Name` an IfcProjectedCRS is already carrying in {@link BASE_IFC}. */
 const CRS_NAME = 'EPSG:1000';
+/** The `Eastings` an IfcMapConversion is already carrying in {@link BASE_IFC}. */
+const MAP_CONVERSION_EASTINGS = 1000;
 
 const BASE_IFC = `ISO-10303-21;
 HEADER;
@@ -59,6 +62,7 @@ DATA;
 #30=IFCPROPERTYSET('0OSuGGYUFyIf0LtE29OSuP',$,'Pset_TypeOwned',$,(#31));
 #31=IFCPROPERTYSINGLEVALUE('Foo',$,IFCTEXT('old'),$);
 #40=IFCPROJECTEDCRS('${CRS_NAME}',$,$,$,$,$,$);
+#41=IFCMAPCONVERSION($,#40,${MAP_CONVERSION_EASTINGS}.,2000.,0.,$,$,$);
 ENDSEC;
 END-ISO-10303-21;`;
 
@@ -166,6 +170,24 @@ describe('a georeferencing edit is the same site with the same signal', () => {
     const text = new TextDecoder().decode(result.content);
 
     expect(text).toContain(`#${CRS_ID}=IFCPROJECTEDCRS('EPSG:2056'`);
+    expect(result.stats.modifiedEntityCount).toBe(1);
+  });
+
+  it('writing a DIFFERENT Eastings on IfcMapConversion still counts and still lands', async () => {
+    // The MapConversion branch queues into the same `modifiedAttributes` map
+    // as the CRS branch above and gates its nomination the same way
+    // (`hasEmittableHostBytes`) — this is that branch's own sibling case,
+    // parallel to the CRS one directly above it.
+    const store = await parseBase();
+    const view = new MutablePropertyView(null, 'test-model');
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      georefMutations: { mapConversion: { eastings: MAP_CONVERSION_EASTINGS + 500 } },
+    });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).toContain(`#${MAP_CONVERSION_ID}=IFCMAPCONVERSION($,#${CRS_ID},1500.`);
     expect(result.stats.modifiedEntityCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Confirmed one dead mutation site named in #2475's measurement (https://github.com/LTplus-AG/ifc-lite/issues/2475#issuecomment-5323607661) and closes it.

In `packages/export/src/step-exporter.ts`, the MapConversion branch's georeferencing nomination call — `inPlaceNominees.georeferencing.add(entityId)` inside the "Modify existing IfcMapConversion" block — was reachable but unpinned: nothing in the repo exercised a full (non-delta) export that modifies an **existing `IfcMapConversion`**. Its `IfcProjectedCRS` sibling three lines above is already pinned by two named tests (`attribute-nomination-effect.test.ts` and `delta-modification-count.test.ts`). The asymmetry was the defect.

This PR adds the MapConversion branch's own case, following the same shape as its CRS sibling in `attribute-nomination-effect.test.ts` (`writing a DIFFERENT Name still counts and still lands`), so the pair reads as parallel: `writing a DIFFERENT Eastings on IfcMapConversion still counts and still lands`. It calls `.export({ schema: 'IFC4', georefMutations: { mapConversion: { eastings: <new value> } } })` with no `deltaOnly`, asserting the `IFCMAPCONVERSION` line changed and that `modifiedEntityCount` includes it.

The fixture (`BASE_IFC` in `attribute-nomination-effect.test.ts`) gains an `IFCMAPCONVERSION` entity referencing the existing `IFCPROJECTEDCRS`, matching the shape already used in `delta-modification-count.test.ts`.

## Evidence

**Step 1 — reproduce deadness, both branches (before adding the test):**
- MapConversion branch (`add(entityId)` deleted): full `packages/export` suite — **708 passed, 30 skipped, 0 failed**. Kills nothing.
- CRS branch sibling (`add(entityId)` deleted): full `packages/export` suite — **2 failed** (`attribute-nomination-effect.test.ts > ... writing a DIFFERENT Name still counts and still lands`, `delta-modification-count.test.ts > ... a georeferencing edit to an existing CRS still counts and still lands`), 706 passed, 30 skipped. Confirms the asymmetry.

**Step 3 — RED/GREEN on the new test:**
- RED (MapConversion `add(entityId)` removed): `writing a DIFFERENT Eastings on IfcMapConversion still counts and still lands` fails — `expect(result.stats.modifiedEntityCount).toBe(1)` gets `0`. (The file-content assertion still passes; only the count assertion catches the mutation, matching the description of the site.)
- GREEN (call restored): full suite — **709 passed, 30 skipped, 0 failed** (up one from baseline).

Typecheck: both `pnpm typecheck` (root, includes `scripts/typecheck-tests.mjs`) and package-scoped `npx tsc --noEmit` in `packages/export` pass clean. `pnpm lint`: 0 errors (pre-existing unrelated warnings only).

## Scope

This closes **one** dead site. The linked measurement counted 13 dead mutation sites across `export()`; roughly 11 remain unlocated and are out of scope here.

No changeset: test-only, no behaviour change.

## Test plan
- [x] `pnpm --filter @ifc-lite/export test` — 709 passed, 30 skipped
- [x] `pnpm typecheck` (root)
- [x] `npx tsc --noEmit` in `packages/export`
- [x] `pnpm lint`
- [x] `git diff upstream/main` contains only the new test (no production changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)