### PR TITLE
test(export): pin 13 dead georeferencing field-setters

### DIFF
--- a/packages/export/src/delta-modification-count.test.ts
+++ b/packages/export/src/delta-modification-count.test.ts
@@ -77,7 +77,7 @@ DATA;
 #51=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
 #52=IFCRELDEFINESBYPROPERTIES('0OSuGGYUFyIf0LtE29OSuR',$,$,$,(#8),#50);
 #40=IFCPROJECTEDCRS('EPSG:1000',$,$,$,$,$,$);
-#41=IFCMAPCONVERSION($,#40,1000.,2000.,0.,$,$,$);
+#41=IFCMAPCONVERSION($,#40,1000.,2000.,0.,0.,0.,0.);
 ENDSEC;
 END-ISO-10303-21;`;
 
@@ -393,13 +393,53 @@ describe('full (non-delta) export is unchanged by the delta fix', () => {
     const store = await parseBase();
     const { view } = newSession(store);
 
+    // Every field the modify-existing-CRS branch can set, each a distinct
+    // non-interchangeable value so a positional swap would be observable.
     const result = new StepExporter(store, view).export({
       schema: 'IFC4',
-      georefMutations: { projectedCRS: { name: 'EPSG:2056' } },
+      georefMutations: {
+        projectedCRS: {
+          name: 'EPSG:2056',
+          description: 'LV95 Modified',
+          geodeticDatum: 'CH1903+',
+          verticalDatum: 'LN02',
+          mapProjection: 'Swiss Oblique Mercator 1995',
+          mapZone: '32N',
+        },
+      },
     });
     const text = new TextDecoder().decode(result.content);
 
-    expect(text).toContain(`#${CRS_ID}=IFCPROJECTEDCRS('EPSG:2056'`);
+    expect(text).toContain(
+      `#${CRS_ID}=IFCPROJECTEDCRS('EPSG:2056','LV95 Modified','CH1903+','LN02','Swiss Oblique Mercator 1995','32N',$);`,
+    );
+    expect(result.stats.modifiedEntityCount).toBe(1);
+  });
+
+  it('a georeferencing edit to an existing IfcMapConversion still counts and still lands', async () => {
+    const store = await parseBase();
+    const { view } = newSession(store);
+
+    // Same shape as the CRS case above, for the sibling modify branch: every
+    // settable field, each a distinct value so a transposed pair would fail.
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      georefMutations: {
+        mapConversion: {
+          eastings: 2650000,
+          northings: 1250000,
+          orthogonalHeight: 555,
+          xAxisAbscissa: 0.1,
+          xAxisOrdinate: 0.2,
+          scale: 0.9999,
+        },
+      },
+    });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).toContain(
+      `#${MAP_CONVERSION_ID}=IFCMAPCONVERSION($,#${CRS_ID},2650000.,1250000.,555.,0.1,0.2,0.9999);`,
+    );
     expect(result.stats.modifiedEntityCount).toBe(1);
   });
 

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -257,7 +257,9 @@ describe('StepExporter', () => {
           name: 'EPSG:2056',
           description: 'CH1903+ / LV95',
           geodeticDatum: 'CH1903+',
+          verticalDatum: 'LN02',
           mapProjection: 'Swiss Oblique Mercator 1995',
+          mapZone: '32N',
           mapUnit: 'METRE',
         },
         mapConversion: {
@@ -272,7 +274,9 @@ describe('StepExporter', () => {
     });
 
     const content = decode(result.content);
-    expect(content).toContain("IFCPROJECTEDCRS('EPSG:2056','CH1903+ / LV95','CH1903+',$,'Swiss Oblique Mercator 1995',$,#");
+    expect(content).toContain(
+      "IFCPROJECTEDCRS('EPSG:2056','CH1903+ / LV95','CH1903+','LN02','Swiss Oblique Mercator 1995','32N',#",
+    );
     expect(content).toMatch(/IFCMAPCONVERSION\(#14,#\d+,2600000\.,1200000\.,500\.,0\.,1\.,1\.\);/);
     expect(content).toContain('IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.)');
     // A surviving context means nothing was refused — no spurious warning.


### PR DESCRIPTION
## Summary

A mutation sweep (#2475, [sweep comment](https://github.com/LTplus-AG/ifc-lite/issues/2475#issuecomment-5323726243)) found 16 sites in `packages/export/src/step-exporter.ts`'s `export()` that kill no tests. This PR closes 13 of them: georeferencing field-setters, all in the same shape across three branches — only the first field of each branch was pinned, the rest could be deleted with the suite green.

This closes **13 of ≥16** known dead sites in `export()` from that sweep; the sweep itself covered only 33 of a much larger candidate set, so the true dead-site count in this file is not known.

## Site locations (main, by content — PR #2721's line numbers don't apply since it hasn't merged)

`packages/export/src/step-exporter.ts`:
- Create `IfcProjectedCRS` branch, lines 976 & 978 (`vDatum`, `zone`)
- Modify existing CRS branch, lines 912–916 (`Description`, `GeodeticDatum`, `VerticalDatum`, `MapProjection`, `MapZone`)
- Modify existing `IfcMapConversion` branch, lines 952–957 (`Eastings`, `Northings`, `OrthogonalHeight`, `XAxisAbscissa`, `XAxisOrdinate`, `Scale`)

## Reproduce-first evidence

Each of the 13 sites was mutated alone (setter forced to its dead-value / commented out) against `main` and the `packages/export` suite stayed green — 708 passed / 30 skipped, identical to baseline, for all 13. None were already pinned.

## Site → test mapping (RED→GREEN, re-run after the fix)

| Site (field) | Test that now kills it |
| --- | --- |
| create-CRS `VerticalDatum` (line 976) | `step-exporter.test.ts > StepExporter > creates IfcProjectedCRS and IfcMapConversion from scratch when georeferencing is added` |
| create-CRS `MapZone` (line 978) | same |
| modify-CRS `Description` (912) | `delta-modification-count.test.ts > full (non-delta) export is unchanged by the delta fix > a georeferencing edit to an existing CRS still counts and still lands` |
| modify-CRS `GeodeticDatum` (913) | same |
| modify-CRS `VerticalDatum` (914) | same |
| modify-CRS `MapProjection` (915) | same |
| modify-CRS `MapZone` (916) | same |
| modify-MapConversion `Eastings` (952) | `delta-modification-count.test.ts > full (non-delta) export is unchanged by the delta fix > a georeferencing edit to an existing IfcMapConversion still counts and still lands` (new test) |
| modify-MapConversion `Northings` (953) | same |
| modify-MapConversion `OrthogonalHeight` (954) | same |
| modify-MapConversion `XAxisAbscissa` (955) | same |
| modify-MapConversion `XAxisOrdinate` (956) | same |
| modify-MapConversion `Scale` (957) | same |

Confirmed by re-mutating each site individually post-fix: each produced exactly 1 failing test, in the named test above, with the suite otherwise green (708 passed / 1 failed / 30 skipped).

## Method

- Extended the existing fixtures already covering each branch rather than adding parallel test files.
- Each assertion pins the full ordered `IFCPROJECTEDCRS(...)` / `IFCMAPCONVERSION(...)` argument list with distinct, non-interchangeable values per field, so a transposed pair of fields would fail — not just presence-of-value checks.
- Production code (`step-exporter.ts`) is unchanged — this is test-only.

## Verify

- `packages/export` suite: 49 test files (48→49? no — 49 passed / 2 skipped both before/after), tests 708 passed / 30 skipped before → 709 passed / 30 skipped after (net +1 `it()`). `lod1-generator.test.ts` loaded and passed; no wasm-resolution issue observed.
- Both typecheck scopes green: `pnpm turbo build --filter=@ifc-lite/export` (src `tsc`) and `pnpm turbo typecheck --filter=@ifc-lite/export` (`scripts/typecheck-tests.mjs`, "packages/export OK (51 test files)").
- `pnpm lint`: 0 errors (pre-existing warnings elsewhere, unrelated to this change).

No changeset — test-only change, no published-package API surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)