### PR TITLE
fix(export): key named-attribute REAL formatting off schema type, not the replaced token

### DIFF
--- a/.changeset/map-conversion-real-quoting.md
+++ b/.changeset/map-conversion-real-quoting.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/export': patch
+---
+
+Fix named-attribute STEP export writing a quoted string over a REAL-typed slot that was previously `$`.
+
+Setting a numeric georeferencing field for the first time — `IfcMapConversion.OrthogonalHeight`, `XAxisAbscissa`, `XAxisOrdinate`, `Scale`, or any other REAL-backed named attribute previously unset in the file — inferred the STEP output form from the token being replaced. All four fields are OPTIONAL in IFC4, so a real project's file legitimately has `$` there; with no numeric token to read, the fallback fell through to string quoting and wrote e.g. `'12345'` in a slot ISO 10303-21 requires to be the unquoted REAL literal `12345.` — a silently invalid file.
+
+`applyAttributeMutations` (source-buffer named-attribute edits) and `applyOverlayEntityOverrides` (overlay-created entities) now resolve the slot's declared schema type first via `getRealTypedSlots`, the same schema-aware REAL detection positional attribute edits have used since #1839, and only fall back to token inference for slots the schema does not classify. This fixes every named-attribute mutation through a REAL-typed slot, not only `IfcMapConversion` — `IfcProjectedCRS` georeferencing edits and general per-entity attribute edits (`setAttribute`) share the same code path.

--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -492,6 +492,45 @@ describe('StepExporter', () => {
     expect(findDanglingRefs(content)).toEqual([]);
   });
 
+  it('writes an unquoted STEP real when setting a MapConversion field that was previously $ (#2724)', () => {
+    // OrthogonalHeight, XAxisAbscissa, XAxisOrdinate and Scale are all
+    // OPTIONAL in IFC4, so a real file can legally carry `$` there. The
+    // named-attribute rewrite path (`serializeNamedAttribute` ->
+    // `serializeAttributeValue`) infers REAL-vs-string formatting from the
+    // token being replaced; when that token is `$` there is no numeric
+    // token to key off, and the fallback must still emit an unquoted STEP
+    // real, not a quoted string.
+    const dataStore = buildMockDataStore([
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g',$,'Project',$,$,$,$,(#20),#30);"],
+      [2, 'IFCSIUNIT', '#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      [20, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#21,$);"],
+      [21, 'IFCAXIS2PLACEMENT3D', '#21=IFCAXIS2PLACEMENT3D(#22,#23,#24);'],
+      [22, 'IFCCARTESIANPOINT', '#22=IFCCARTESIANPOINT((0.,0.,0.));'],
+      [23, 'IFCDIRECTION', '#23=IFCDIRECTION((0.,0.,1.));'],
+      [24, 'IFCDIRECTION', '#24=IFCDIRECTION((1.,0.,0.));'],
+      [30, 'IFCUNITASSIGNMENT', '#30=IFCUNITASSIGNMENT((#2));'],
+      [40, 'IFCPROJECTEDCRS', "#40=IFCPROJECTEDCRS('EPSG:2056',$,'CH1903+',$,$,$,#2);"],
+      // OrthogonalHeight is `$` in the source file — schema-legal, and the
+      // exact shape a real project's file has before anyone sets it.
+      [41, 'IFCMAPCONVERSION', '#41=IFCMAPCONVERSION(#20,#40,1.,2.,$,1.,0.,1.);'],
+    ]);
+
+    const exporter = new StepExporter(dataStore);
+    const result = exporter.export({
+      schema: 'IFC4',
+      applyMutations: true,
+      georefMutations: {
+        mapConversion: { orthogonalHeight: 12345 },
+      },
+    });
+
+    const content = decode(result.content);
+    const mcLine = content.match(/#41=IFCMAPCONVERSION\([^;]*\);/)?.[0] ?? '';
+    // An unquoted STEP real, not `'12345.'` / `'12345'` — IFC4
+    // OrthogonalHeight is IfcLengthMeasure, a REAL, not a string.
+    expect(mcLine).toBe('#41=IFCMAPCONVERSION(#20,#40,1.,2.,12345.,1.,0.,1.);');
+  });
+
   it('never points new georeferencing at a deleted context or length unit', () => {
     const dataStore = buildMockDataStore([
       [1, 'IFCPROJECT', "#1=IFCPROJECT('g',$,'Project',$,$,$,$,(#20,#25),#30);"],

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -1882,7 +1882,7 @@ export class StepExporter {
     let attributed = false;
     if (attributeMutations && attributeMutations.size > 0) {
       const beforeAttributes = text;
-      text = this.applyAttributeMutations(text, workingType, attributeMutations);
+      text = this.applyAttributeMutations(text, workingType, attributeMutations, sourceSchema);
       attributed = text !== beforeAttributes;
     }
 
@@ -1906,6 +1906,7 @@ export class StepExporter {
     entityText: string,
     entityType: string,
     attributeMutations: Map<string, string>,
+    schemaVersion: IfcSchemaVersion,
   ): string {
     const openParen = entityText.indexOf('(');
     const closeParen = entityText.lastIndexOf(');');
@@ -1928,6 +1929,7 @@ export class StepExporter {
     // argument list here means the file speaks a different schema, and growing
     // a record we did not author would corrupt it.
     let changed = false;
+    const realSlots = getRealTypedSlots(entityType, schemaVersion);
 
     for (const [attrName, value] of attributeMutations) {
       const index = attrNames.indexOf(attrName);
@@ -1935,7 +1937,7 @@ export class StepExporter {
       // The source path shares every `$`-slot hole with the overlay-created
       // path, because a source record has plenty of `$` slots of its own. Both
       // go through the one helper below.
-      args[index] = this.serializeNamedAttribute(entityType, index, value, args[index]);
+      args[index] = this.serializeNamedAttribute(entityType, index, value, args[index], realSlots);
       changed = true;
     }
 
@@ -1957,15 +1959,31 @@ export class StepExporter {
    * with `$`. So the declared type decides first, and inference is the fallback
    * for slots the schema does not classify (references, SELECTs, numerics),
    * where reading the old token is exactly the right heuristic.
+   *
+   * Before this REAL check existed, "the declared type decides first" was true
+   * for enum/string slots only — a REAL-backed slot (`IfcMapConversion.
+   * OrthogonalHeight`, any other `IfcLengthMeasure`/`IfcReal`-typed attribute)
+   * fell straight to `serializeAttributeValue`'s token inference, which quotes
+   * anything it cannot recognize as numeric. A schema-legal `$` placeholder
+   * carries no digits to recognize, so setting such a field for the first time
+   * wrote `'12345'` in a slot ISO 10303-21 requires to be an unquoted REAL —
+   * silently invalid output (#2724, LTplus-AG/ifc-lite#2475).
    */
   private serializeNamedAttribute(
     entityType: string,
     index: number,
     value: string,
     currentToken: string,
+    realSlots: ReadonlySet<number>,
   ): string {
     if (getEnumTypedSlots(entityType).has(index)) return serializeEnumToken(value);
     if (getStringTypedSlots(entityType).has(index)) return serializeStringSlot(value);
+    if (realSlots.has(index)) {
+      const trimmed = value.trim();
+      if (trimmed === '') return '$';
+      const numberValue = Number(trimmed);
+      if (Number.isFinite(numberValue)) return toStepReal(numberValue);
+    }
     return serializeAttributeValue(value, currentToken);
   }
 
@@ -2030,12 +2048,12 @@ export class StepExporter {
 
     // Every `named` index is < attrNames.length by construction, and padding
     // has taken args.length to at least that, so each one lands.
+    const realSlots = getRealTypedSlots(entityType, schemaVersion);
     for (const [index, value] of named) {
-      args[index] = this.serializeNamedAttribute(entityType, index, value, args[index]);
+      args[index] = this.serializeNamedAttribute(entityType, index, value, args[index], realSlots);
     }
 
     if (positionalOverrides && positionalOverrides.size > 0) {
-      const realSlots = getRealTypedSlots(entityType, schemaVersion);
       for (const [index, value] of positionalOverrides) {
         if (index < 0 || index >= args.length) continue;
         args[index] = this.serializePositionalOverride(


### PR DESCRIPTION
## Summary

While pinning georeferencing field-setters (#2724), the workaround was to give the fixture non-`$` placeholder values. That workaround pointed at a real defect: **confirmed**.

`serializeNamedAttribute` (`packages/export/src/step-exporter.ts`) infers a named attribute's STEP output form — quoted string vs. unquoted REAL — by reading the token being replaced. That heuristic is sound only when the replaced token carries numeric information. `OrthogonalHeight`, `XAxisAbscissa`, `XAxisOrdinate` and `Scale` are all `OPTIONAL` in IFC4 `IfcMapConversion`, so a real project's file legitimately has `$` there. With no numeric token to read, the fallback quoted the value as a STEP string.

Repro (before the fix), setting `orthogonalHeight` on an `IfcMapConversion` whose `OrthogonalHeight` was previously `$`:

```
#41=IFCMAPCONVERSION(#20,#40,1.,2.,'12345',1.,0.,1.);
```

`'12345'` is a quoted STEP string in a slot ISO 10303-21 requires to be the unquoted REAL literal `12345.` — a silently invalid file.

## Fix

`applyAttributeMutations` (source-buffer named-attribute edits) and `applyOverlayEntityOverrides` (overlay-created entities) now resolve the slot's declared schema type first via `getRealTypedSlots` — the same schema-aware REAL detection positional attribute edits have used since #1839 — and fall back to token inference only for slots the schema does not classify. This is the single shared function both edit paths route through, so the fix covers **every** named-attribute mutation through a REAL-typed slot, not only `IfcMapConversion` — the `IfcProjectedCRS` modify branch and general per-entity `setAttribute` edits share the same code path (the CRS branch itself has no REAL-typed fields today, so it wasn't observably broken, but is now covered against a future REAL field).

After the fix:

```
#41=IFCMAPCONVERSION(#20,#40,1.,2.,12345.,1.,0.,1.);
```

## Why no existing test caught it

Every fixture exercising the modify-`IfcMapConversion` branch — including `delta-modification-count.test.ts`, which does have `$` in some numeric slots — only ever mutated a field whose existing token was already numeric (`Eastings`/`Northings`). No fixture set a field whose existing token was `$`. Neither the export corpus nor a schema-strictness validation gate exercises this either, since real-world BIM-authored files typically populate `IfcMapConversion` in full.

## Verify

- `packages/export` suite: 708 passed / 30 skipped → 709 passed / 30 skipped (net +1 new regression test, RED→GREEN confirmed against the pre-fix code).
- `tsc --noEmit` (src): clean.
- `scripts/typecheck-tests.mjs` (tests): `packages/export OK (51 test files)`.
- `oxlint` on touched files: only pre-existing, untouched-by-this-diff warnings (confirmed against `HEAD` before this change).

References #2475 (the mutation-sweep issue #2724 stems from) and #2724 itself, whose fixture workaround this makes unnecessary going forward (commented separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed updates to previously unset REAL-valued attributes so numeric values are exported as valid unquoted STEP REAL literals.
  * Improved consistency when editing existing entities or creating entity overlays, including georeferencing data.

* **Tests**
  * Added regression coverage for updating optional `IfcMapConversion.OrthogonalHeight` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->