### PR TITLE
test(export): cover the overlay-side includeGeometry:false guard

### DIFF
--- a/packages/export/src/includegeometry-header-count.test.ts
+++ b/packages/export/src/includegeometry-header-count.test.ts
@@ -90,4 +90,23 @@ describe('STEP header modification count vs includeGeometry:false', () => {
       result.stats.newEntityCount + result.stats.modifiedEntityCount,
     );
   });
+
+  it('an overlay-created geometry-classified entity excluded by includeGeometry:false must not appear in DATA', async () => {
+    const store = await parseBase();
+    const view = new MutablePropertyView(null, 'test-model');
+    const editor = new StoreEditor(store, view);
+    // Created purely through the overlay (`getNewEntities()`), not by editing
+    // a source entity — this is the overlay-new-entities pass, the mirror of
+    // the source-iteration pass covered above. IFCSHAPEREPRESENTATION is on
+    // `isGeometryEntity`'s list, so it must be dropped the same way.
+    editor.addEntity('IfcShapeRepresentation', [null, 'Body', 'SweptSolid', [`#21`]]);
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      includeGeometry: false,
+    });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).not.toContain('IFCSHAPEREPRESENTATION');
+  });
 });


### PR DESCRIPTION
## Summary

- Adds test coverage for the overlay new-entities pass's `includeGeometry: false && isGeometryEntity(...)` guard in `packages/export/src/step-exporter.ts`, mirroring the existing source-iteration-pass test in `includegeometry-header-count.test.ts`.
- Test-only change. No changeset (per repo convention for test-only PRs).

## Part 2 — the coverage gap (fixed here)

A sweep found that the identical `includeGeometry === false && isGeometryEntity(...)` guard appears twice in `export()`:
- source-iteration pass (~line 1159) — tested
- overlay new-entities pass (~line 1439) — **zero coverage**

Reproduced directly before writing anything:
- Neutralizing the source-side guard alone (`false && this.isGeometryEntity(entityType)`) kills the existing test `an attribute edit on a geometry-classified host excluded by includeGeometry:false must not claim a modification the DATA section does not contain` in `includegeometry-header-count.test.ts`.
- Neutralizing the overlay-side guard alone left the entire suite green — confirming the gap.

Added `an overlay-created geometry-classified entity excluded by includeGeometry:false must not appear in DATA`, which creates an `IfcShapeRepresentation` purely through `StoreEditor.addEntity` (no source edit), exports with `includeGeometry: false`, and asserts the line is absent from `DATA`. Verified RED (fails under the neutralized overlay guard) and GREEN (passes against unmodified `step-exporter.ts`) with real vitest output.

Production code is untouched — only the test file changed.

## Part 1 — analysis of a separately-claimed dead write (NOT changed here)

A sweep also claimed this line in the source-iteration loop is dead:

```ts
if (mutated.retyped || mutated.positional) modifiedEntities.add(expressId);
```

**Verdict: confirmed dead, and harmless — not a symptom of a missing read.**

Full read inventory for `modifiedEntities` (only declared/used in `packages/export/src/step-exporter.ts`; two test files reference it only in prose comments, not code):
- `step-exporter.ts:516` — declaration (`const modifiedEntities = new Set<number>()`)
- `step-exporter.ts:546`, `:616`, `:759`, `:923`, `:959` — writes, all before the only read
- `step-exporter.ts:1042` — the ONLY read (`modifiedEntities.size === 0`), inside an early-return `if` block that is not a loop and cannot be revisited
- `step-exporter.ts:1216` — the write under discussion, inside the source-iteration `for` loop that starts after line 1042's `if` block, so it always runs strictly after the only read

No other file in the repo references `modifiedEntities`. It is a local `const`, never passed to any function, never returned, never captured by a closure that outlives the call. `export()` is a single non-recursive method — line 1042 executes exactly once per call, always before the loop containing line 1216.

The write is confirmed dead code. Per instructions, not removed here — that is the maintainer's call.

On the "is this a symptom of a missing read" question: no. The `retyped`/`positional` mutations this dead write shadows ARE correctly counted in the final output — via a *separate* call two lines below the dead write:
```ts
if (mutated.retyped || mutated.positional) modifiedEntities.add(expressId);  // dead
if (mutated.retyped) modifications.nominate(expressId, 'retype');
if (mutated.positional) modifications.nominate(expressId, 'positional');
```
The header's `modifiedEntityCount` comes entirely from `modifications.settle()` (a separate `ModificationLedger`, ~line 1529), which these `nominate()` calls feed directly. Nothing is silently dropped from any count. The dead write is residue, most plausibly left over from before the `ModificationLedger` existed, not a bug.

Ref #2475.

## Test plan

- [x] `packages/export` vitest suite: 708 passed / 30 skipped (738) before this change → 709 passed / 30 skipped (739) after — the new test is the only delta.
- [x] `pnpm build` then both typecheck scopes via `pnpm typecheck` (turbo): package `src` scopes and `scripts/typecheck-tests.mjs` test-source scopes both pass, including `packages/export 51/51` test files in program.
- [x] `pnpm lint`: 0 errors (pre-existing warnings unrelated to this change).