### PR TITLE
test(export): cover visibleOnly + deltaOnly attribute nomination

### DIFF
--- a/packages/export/src/visibleonly-deltaonly-attribute-nomination.test.ts
+++ b/packages/export/src/visibleonly-deltaonly-attribute-nomination.test.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coverage gap named by github.com/LTplus-AG/ifc-lite/issues/2475: the
+ * `hasEmittableHostBytes` gate in the non-georef attribute mutation
+ * collection loop (`step-exporter.ts`, `for (const [entityId] of
+ * modifiedAttributes)`) has two independent reasons to say "no" for a
+ * source-backed host — no readable source bytes, and exclusion from a
+ * `visibleOnly` closure (`allowedEntityIds`) — but no existing test combined
+ * `visibleOnly` with `deltaOnly` for a plain attribute edit, so the
+ * `visibleOnly` half of that gate was never exercised under `deltaOnly`.
+ *
+ * That combination matters because `deltaOnly`'s per-kind warning exists to
+ * NAME an edit the delta format could not carry (`delta-modification-ledger.ts`).
+ * A host hidden by `visibleOnly` was never going to have its line emitted —
+ * full export or delta, visible or not — so nominating it here would produce
+ * a warning that misattributes the drop to the delta format instead of to the
+ * `hiddenEntityIds` the caller supplied. `hasEmittableHostBytes`'s
+ * `allowedEntityIds` check (unlike its `isGeometryExcluded` check, which is
+ * deliberately `!deltaOnly`-gated — see the block comment above it) runs
+ * unconditionally, so `line 860`'s `continue` is what keeps the hidden host
+ * out of `inPlaceNominees.attribute` and therefore out of the warning.
+ *
+ * Both cases are asserted against the same base file and the same edit, so
+ * the only variable is whether the host is hidden.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+const WALL_ID = 8;
+
+const BASE_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition[DesignTransferView]'),'2;1');
+FILE_NAME('base.ifc','2026-08-08T10:00:00+01:00',(''),(''),'ifc-lite','ifc-lite','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0OSuGGYUFyIf0LtE29OSuG',$,'My Project',$,$,$,$,$,$);
+#8=IFCWALL('0OSuGGYUFyIf0LtE29OSuH',$,'Existing Wall',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function parseBase(): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(toArrayBuffer(new TextEncoder().encode(BASE_IFC)));
+}
+
+function newSession(store: IfcDataStore) {
+  const view = new MutablePropertyView(null, 'test-model');
+  return { view, editor: new StoreEditor(store, view) };
+}
+
+describe('visibleOnly + deltaOnly: attribute nomination on a hidden host', () => {
+  it('a hidden host\'s attribute edit is not nominated and produces no delta warning', async () => {
+    const store = await parseBase();
+    const { view, editor } = newSession(store);
+    editor.setAttribute(WALL_ID, 'Name', 'Renamed Wall');
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      visibleOnly: true,
+      hiddenEntityIds: new Set([WALL_ID]),
+      deltaOnly: true,
+    });
+
+    expect(result.stats.modifiedEntityCount).toBe(0);
+    // The wrong outcome here is a warning that blames deltaOnly for a drop
+    // that was actually caused by hiddenEntityIds.
+    expect(result.stats.warnings).toEqual([]);
+  });
+
+  it('bounding control: the SAME edit on the SAME host, not hidden, still warns under deltaOnly', async () => {
+    const store = await parseBase();
+    const { view, editor } = newSession(store);
+    editor.setAttribute(WALL_ID, 'Name', 'Renamed Wall');
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      deltaOnly: true,
+    });
+
+    expect(result.stats.modifiedEntityCount).toBe(0);
+    expect(result.stats.warnings).toHaveLength(1);
+    expect(result.stats.warnings[0]).toContain(`#${WALL_ID}`);
+    expect(result.stats.warnings[0]).toContain('attribute edits');
+  });
+});


### PR DESCRIPTION
## Summary
- Verifying two claims from a prior sweep (issue #2475) about `hasEmittableHostBytes` / `isOverlayCreated` in `packages/export/src/step-exporter.ts`'s non-georef attribute mutation collection loop (~`:856`-`:860`).
- **Claim 1** (`isOverlayCreated` unreachable, subsumed by `hasEmittableHostBytes`): confirmed. `OverlayIndex.get()` (`effective-index.ts:282`) hardcodes `byteLength: 0` for every overlay-created id, and `createSourceRefReader` (`source-ref-bounds.ts:95`) rejects any ref with `byteLength <= 0`, so `hasEmittableHostBytes` is always `false` for an overlay-created id — the `isOverlayCreated` check can never be the deciding branch there. No code change proposed: removal is a maintainer call, and the two guards encode different intents (double-count prevention vs. byte-availability) that only coincide today through an implementation detail of `OverlayIndex`, so the subsumption is not architecturally guaranteed to stay true.
- **Claim 2** (`hasEmittableHostBytes` guard untested): the sweep's suggested discriminating experiment (`includeGeometry:false` + `deltaOnly:true`) turns out inert — `isGeometryExcluded` inside `hasEmittableHostBytes` is deliberately gated by `!deltaOnly`, so geometry classification makes no difference once `deltaOnly` is set. The *actual* untested path is the `allowedEntityIds` (`visibleOnly`) half of the same guard, which is **not** deltaOnly-gated. No existing test combines `visibleOnly` with `deltaOnly` for an attribute edit. This PR adds that test.

## Test plan
- [x] New test: an attribute edit on a host hidden via `visibleOnly`, exported with `deltaOnly:true`, produces zero warnings and `modifiedEntityCount: 0` (correct — the host was never going to be emitted, hidden or not).
- [x] Bounding control in the same file: the identical edit on the same host, *not* hidden, still produces the standard "deltaOnly could not carry this attribute edit" warning naming the entity.
- [x] RED confirmed locally: temporarily short-circuiting the `hasEmittableHostBytes` check at `step-exporter.ts:860` makes the hidden-host test fail (the warning wrongly appears, misattributing the drop to `deltaOnly` instead of `hiddenEntityIds`); reverted before committing.
- [x] `pnpm --filter @ifc-lite/export test`: 52/52 files, 710 passed / 30 skipped (0 failed) — up from 708 passed / 30 skipped before this PR's 2 new tests.
- [x] `pnpm typecheck` (root, both scopes: package `src` via build and `scripts/typecheck-tests.mjs` test coverage): clean, 1187/1187 test files covered.
- [x] `pnpm lint`: 0 errors (21 pre-existing warnings, all outside this PR's file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)