### PR TITLE
test(export): pin the two dead if(converting) branches in step-exporter

### DIFF
--- a/packages/export/src/step-exporter.test.ts
+++ b/packages/export/src/step-exporter.test.ts
@@ -1673,4 +1673,52 @@ describe('StepExporter', () => {
     expect(content).toContain("#6=IFCQUANTITYLENGTH('Length'");
     expect(findDanglingRefs(content)).toEqual([]);
   });
+
+  // Coverage gap: no test drove `export()` with a source schema genuinely
+  // different from the target `schema` option, so `converting` (schema-converter.ts
+  // `needsConversion`) was always false and both `if (converting)` branches below
+  // were dead code — confirmed by mutation testing (`if (false && converting)`
+  // in either branch alone: 708/708 tests still pass). `schema-converter.test.ts`
+  // only unit-tests `convertStepLine` directly, never through the exporter.
+  //
+  // This pins the SOURCE-ITERATION branch (~line 1225): a source-backed entity
+  // whose type is renamed between IFC2X3 and IFC4 (`IFC2X3_TO_IFC4` map in
+  // schema-converter.ts) must come out under its IFC4 name, not pass through
+  // unconverted under its IFC2X3 name.
+  it('converts a source-backed entity type when exporting to a different schema (IFC2X3 -> IFC4)', () => {
+    const dataStore = buildMockDataStore([
+      [5, 'IFCELECTRICDISTRIBUTIONPOINT', "#5=IFCELECTRICDISTRIBUTIONPOINT('1ys5Xwuxz8gPJk6N$NGhA5',$,'Panel',$,$,$,$,$);"],
+    ]);
+    (dataStore as unknown as { schemaVersion: string }).schemaVersion = 'IFC2X3';
+
+    const result = new StepExporter(dataStore).export({ schema: 'IFC4' });
+    const content = decode(result.content);
+
+    expect(content).toContain('#5=IFCELECTRICDISTRIBUTIONBOARD(');
+    expect(content).not.toContain('IFCELECTRICDISTRIBUTIONPOINT');
+  });
+
+  // Same coverage gap, but for the OVERLAY pass (~line 1511): an entity
+  // created via `mutationView.createEntity` — never source-backed — of a
+  // class that needs conversion must ALSO have its rendered `argsText`
+  // (here just the entity-type token) run through `convertStepLine`,
+  // independently of the source-iteration pass above.
+  it('converts an overlay-created entity type when exporting to a different schema (IFC2X3 -> IFC4)', () => {
+    const dataStore = buildMockDataStore([
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('1ys5Xwuxz8gPJk6N$NGhA1',$,'P',$,$,$,$,$,$);"],
+    ]);
+    (dataStore as unknown as { schemaVersion: string }).schemaVersion = 'IFC2X3';
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.setExpressIdWatermark(1);
+    const created = view.createEntity('IFCELECTRICDISTRIBUTIONPOINT', []);
+
+    const result = new StepExporter(dataStore, view).export({
+      schema: 'IFC4',
+      applyMutations: true,
+    });
+    const content = decode(result.content);
+
+    expect(content).toContain(`#${created.expressId}=IFCELECTRICDISTRIBUTIONBOARD(`);
+    expect(content).not.toContain('IFCELECTRICDISTRIBUTIONPOINT');
+  });
 });


### PR DESCRIPTION
## Summary

A mutation sweep found that **both `if (converting)` branches inside `StepExporter.export()`** (`packages/export/src/step-exporter.ts`) are dead code:

- source-iteration pass, `~:1225`
- overlay-created-entities pass, `~:1511`

Confirmed independently: mutating either branch alone to `if (false && converting)` produces **zero test failures** across all 708 existing tests. Root cause: no test drives `export()` with a source schema genuinely different from the target `schema` option — every apparent IFC2X3 export in the suite sets `dataStore.schemaVersion` **and** `schema` to the same value, so `converting` (`needsConversion(sourceSchema, schema)`) was always `false`. `schema-converter.test.ts` only unit-tests `convertStepLine`/`needsConversion`/`convertEntityType` directly, never through the exporter. I re-verified this grep claim myself by checking every test file in `packages/export` that sets `schemaVersion` and confirming the paired `schema` option always matches (the one seeming exception, `merged-exporter.test.ts`'s IFC2X3 proxy test, goes through `MergedExporter`, which deliberately calls the inner `StepExporter.export()` with `schema: sourceSchema` — see the comment at `merged-exporter.ts:725` — so it bypasses these two branches entirely and does its own separate `convertStepLine` call).

## What this pins

Two new tests in `packages/export/src/step-exporter.test.ts`, using a real schema-converter transformation (`IFCELECTRICDISTRIBUTIONPOINT` → `IFCELECTRICDISTRIBUTIONBOARD`, the `IFC2X3_TO_IFC4` rename map in `schema-converter.ts`), not an identity conversion:

1. **Source-iteration branch**: a source-backed `IFCELECTRICDISTRIBUTIONPOINT` entity, exported IFC2X3 → IFC4, must come out renamed to `IFCELECTRICDISTRIBUTIONBOARD`.
2. **Overlay branch**: the same rename, but for an entity created via `mutationView.createEntity` (never source-backed) — the second, separately-dead branch.

Each test was verified to pin only its own branch: re-mutating branch 1 alone fails test 1 and leaves test 2 green; re-mutating branch 2 alone fails test 2 and leaves test 1 green.

## Was the conversion correct or broken?

**Correct**, for this transformation. Both tests pass against current production code with no changes to `step-exporter.ts` or `schema-converter.ts` — 710/710 tests pass (708 pre-existing + 2 new). Per the task instructions, no assertion was adjusted to match buggy output; if either had failed against honest expectations, this PR would say so instead of shipping green tests.

**Scope note**: this pins the schema-conversion integration path for one specific transformation (an IFC2X3→IFC4 entity-type rename with no attribute-count change). It does not by itself validate every rename, attribute-trim, or padding case in `schema-converter.ts` under a genuine `export()` schema-conversion call — those remain covered only at the unit level.

Refs #2475

## Test plan

- [x] `pnpm test` in `packages/export`: 710 passed, 30 skipped (up from 708/30 baseline)
- [x] Confirmed both branches independently dead via mutation (`if (false && converting)`), before adding tests
- [x] Confirmed each new test RED when its own branch is disabled, GREEN when the other branch is disabled
- [x] `pnpm exec tsc --noEmit` in `packages/export`: clean
- [x] `node scripts/typecheck-tests.mjs` (test-typecheck scope): `packages/export OK (51 test files)`
- [x] `pnpm exec oxlint packages/export/src/step-exporter.test.ts`: clean

No changeset — test-only change, no production code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)