### PR TITLE
test(export): cover caller-supplied STEP header overrides

### DIFF
--- a/packages/export/src/header-override.test.ts
+++ b/packages/export/src/header-override.test.ts
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coverage gap (issue #2475): a mutation sweep of `buildHeader` /
+ * `generateHeader` wiring in step-exporter.ts (~:331-357) found that every
+ * caller-supplied `StepExportOptions` header override, plus two
+ * sourceHeader-fallback fields nobody exercised with a non-default value,
+ * were dead code as far as the test suite could tell — mutating each site
+ * alone killed nothing:
+ *
+ *  - `options.description !== undefined` branch (~:332-333)
+ *  - `implementationLevel: sourceHeader?.implementationLevel` (~:347)
+ *  - `options.author ?? sourceHeader?.author` — the `options.author` half (~:348)
+ *  - `options.organization ?? sourceHeader?.organization` — the `options.organization` half (~:349)
+ *  - `options.application` override of `preprocessorVersion` (~:352)
+ *  - `authorization: sourceHeader?.authorization` (~:354)
+ *  - `options.filename ?? 'export.ifc'` — the `options.filename` half (~:355-356)
+ *
+ * Every fixture below gives the source header a value DIFFERENT from both
+ * the caller override (where one applies) and the hardcoded default, so a
+ * passing assertion proves the specific wiring under test, not a
+ * coincidence with a fallback or default that happens to share a string.
+ * FILE_NAME / FILE_DESCRIPTION arguments are positional, so values are
+ * asserted against their exact parsed field, never "appears in the line".
+ *
+ * All fixtures are synthetic and carry no real-world identifiers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser, parseSourceHeader, type IfcDataStore } from '@ifc-lite/parser';
+import { StepExporter } from './step-exporter.js';
+
+const enc = (s: string): ArrayBuffer => new TextEncoder().encode(s).buffer as ArrayBuffer;
+
+/** Source header with distinctive, non-default values in every field this
+ *  suite exercises, so an override or fallback landing in the wrong slot
+ *  (or not landing at all) is unambiguous. */
+const SOURCE_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Source Description Item'),'3;7');
+FILE_NAME('source-file.ifc','2026-01-01T00:00:00',('Source Author'),('Source Organization'),'Source Preprocessor','Source Originating System','source-authorization-token');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCWALL('3wkd_mjInDCfOthy7w_A6V',$,'Sample Wall',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function parse(model: string): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(enc(model));
+}
+
+function exportedHeader(content: Uint8Array) {
+  const header = parseSourceHeader(content);
+  if (!header) throw new Error('exported file had no parseable header');
+  return header;
+}
+
+describe('StepExporter header overrides (options.* wins over source/default)', () => {
+  it('options.description replaces the FILE_DESCRIPTION items entirely (not appended to source)', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({
+      schema: store.schemaVersion,
+      description: 'Caller Override Description',
+    });
+    const out = exportedHeader(result.content);
+    expect(out.description).toEqual(['Caller Override Description']);
+    // Proves it's a replacement, not a merge/append with the source item.
+    expect(out.description).not.toContain('Source Description Item');
+  });
+
+  it('preserves a non-default source implementation_level through export', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({ schema: store.schemaVersion });
+    const out = exportedHeader(result.content);
+    // '3;7' is neither the generateHeader hardcoded default ('2;1') nor
+    // anything a caller option sets — only the sourceHeader fallback wires it.
+    expect(out.implementationLevel).toBe('3;7');
+  });
+
+  it('options.author replaces the FILE_NAME author slot (not merged with source author)', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({
+      schema: store.schemaVersion,
+      author: 'Caller Override Author',
+    });
+    const out = exportedHeader(result.content);
+    expect(out.author).toEqual(['Caller Override Author']);
+    expect(out.author).not.toContain('Source Author');
+  });
+
+  it('options.organization replaces the FILE_NAME organization slot (not merged with source organization)', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({
+      schema: store.schemaVersion,
+      organization: 'Caller Override Organization',
+    });
+    const out = exportedHeader(result.content);
+    expect(out.organization).toEqual(['Caller Override Organization']);
+    expect(out.organization).not.toContain('Source Organization');
+  });
+
+  it('carries a non-default source authorization token through export', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({ schema: store.schemaVersion });
+    const out = exportedHeader(result.content);
+    // '' is generateHeader's hardcoded default and there is no caller
+    // option for authorization at all — only the sourceHeader fallback
+    // wires this field, so a non-empty match proves that wiring.
+    expect(out.authorization).toBe('source-authorization-token');
+  });
+
+  it('options.application overrides preprocessor_version but NOT originating_system', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({
+      schema: store.schemaVersion,
+      application: 'Caller Override Application',
+    });
+    const out = exportedHeader(result.content);
+    // preprocessor_version: the option wins.
+    expect(out.preprocessorVersion).toBe('Caller Override Application');
+    // originating_system: untouched — still the source authoring tool, not
+    // the caller's application and not the default 'ifc-lite'.
+    expect(out.originatingSystem).toBe('Source Originating System');
+  });
+
+  it('options.filename replaces the FILE_NAME filename slot (not the source or default filename)', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({
+      schema: store.schemaVersion,
+      filename: 'caller-override.ifc',
+    });
+    const out = exportedHeader(result.content);
+    expect(out.name).toBe('caller-override.ifc');
+    expect(out.name).not.toBe('source-file.ifc');
+    expect(out.name).not.toBe('export.ifc');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the coverage gap flagged by a mutation sweep of `buildHeader` / the `generateHeader` wiring in `packages/export/src/step-exporter.ts` (~:331-357). Refs #2475.

The sweep claimed every caller-supplied header override was untested, plus two sourceHeader-fallback fields with no non-default assertion anywhere. **Reproduced first**: mutated each of the seven sites individually against the existing `packages/export` suite before writing anything. All seven were confirmed dead (killed nothing); none was already pinned.

Checked for coverage elsewhere first, per the sweep's stated boundary (it only checked `packages/export/src/*.test.ts`): grepped `packages/cli`, `packages/mcp`, `apps/*` for any `.export({ description/author/organization/application/filename: ... })` call with an assertion on the emitted header. Found none — the only other `.export({ author: ... })` in the repo is `packages/ifcx/src/writer.test.ts`, which exercises the unrelated IFCX writer, not the STEP header. So this is a real gap, not merely a per-package one.

## Site → test mapping

All in new `packages/export/src/header-override.test.ts`:

| site (step-exporter.ts) | test | reproduce (before) | RE-mutate (after) |
| --- | --- | --- | --- |
| ~332-333 `options.description !== undefined` | `options.description replaces the FILE_DESCRIPTION items entirely` | 708 passed (no kill) | 1 failed |
| ~347 `implementationLevel: sourceHeader?.implementationLevel` | `preserves a non-default source implementation_level through export` | 708 passed (no kill) | 1 failed |
| ~348 `options.author ?? sourceHeader?.author` | `options.author replaces the FILE_NAME author slot` | 708 passed (no kill) | 1 failed |
| ~349 `options.organization ?? sourceHeader?.organization` | `options.organization replaces the FILE_NAME organization slot` | 708 passed (no kill) | 1 failed |
| ~352 `options.application` → `preprocessorVersion` | `options.application overrides preprocessor_version but NOT originating_system` | 708 passed (no kill) | 1 failed |
| ~354 `authorization: sourceHeader?.authorization` | `carries a non-default source authorization token through export` | 708 passed (no kill) | 1 failed |
| ~355-356 `options.filename ?? 'export.ifc'` | `options.filename replaces the FILE_NAME filename slot` | 708 passed (no kill) | 1 failed |

Two of the seven (`implementationLevel`, `authorization`) aren't caller-supplied overrides — there's no `options.implementationLevel`/`options.authorization` in `StepExportOptions` — they're sourceHeader-fallback paths that no existing fixture exercised with a non-default value (every existing fixture happened to use the default `'2;1'`/`''`). Both are covered here too, with a fixture value distinct from the hardcoded default.

Every fixture gives the source header a value distinct from both the caller override (where one applies) and the hardcoded default, so a passing assertion can't coincide with the wrong field or a fallback. `FILE_NAME`/`FILE_DESCRIPTION` are positional formats — assertions go through `parseSourceHeader` on the exported bytes and check the exact field (`.author`, `.organization`, `.preprocessorVersion`, `.originatingSystem`, `.name`, `.implementationLevel`, `.authorization`), never "appears somewhere in the line".

## Test plan

- [x] Reproduced each of the seven sites individually against the pre-existing suite: all confirmed dead
- [x] Added `header-override.test.ts`; all 7 new tests pass against unmodified code
- [x] RED→GREEN: re-mutated each site individually, confirmed each is now killed by a named test
- [x] Full `packages/export` suite: 708 passed / 30 skipped (49 files) → 715 passed / 30 skipped (50 files)
- [x] `packages/export` package `tsc --noEmit` (src scope): clean
- [x] `packages/export` test typecheck (`scripts/typecheck-tests.mjs`, scoped to the package): `packages/export OK (52 test files)`
- [x] `oxlint` on the new file and repo-wide: no new findings (pre-existing warnings/errors in `apps/viewer` and `examples/*` are unrelated to this change)
- [x] No production code modified
- [x] No changeset — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)