### PR TITLE
test(clash): pin the mergeMeshes vertex-index offset in the IFCX adapter

### DIFF
--- a/packages/clash/src/adapters/ifcx.test.ts
+++ b/packages/clash/src/adapters/ifcx.test.ts
@@ -212,6 +212,64 @@ describe('elementsFromIfcx', () => {
     expect(withExclusions.clashes.length).toBe(1);
   });
 
+  it('offsets each submesh\'s indices by the running vertex count when merging WallC\'s Body+Axis', async () => {
+    // Pins the vertex-index offset applied inside the adapter's internal
+    // `mergeMeshes` (not exported; reached here through the public
+    // `elementsFromIfcx` result, whose `ClashElement.indices` is exactly
+    // `mergeMeshes`'s output). WallC owns two disjoint 8-vertex/36-index cube
+    // submeshes — Body at world x in [10,11] and Axis at world x in [12,13]
+    // (see `buildIfcxFile()` above) — so the merged buffer's second submesh
+    // block must have its indices shifted by the first submesh's vertex
+    // count (8) to address the right half of the concatenated position
+    // array. `bounds` and `isDegenerate` (used by the other tests in this
+    // file) are blind to this: they derive purely from `positions`, which is
+    // never mis-offset, only `indices` is. Coverage gap and mutation
+    // verification are documented in the PR for this test.
+    const { elements } = await elementsFromIfcx({
+      buffer: ifcxBuffer(),
+      modelId: 'ifcx-model',
+    });
+    const wallC = elements.find((e) => e.key === 'Project/WallC');
+    expect(wallC).toBeDefined();
+
+    // Two 8-vertex / 36-index cubes concatenated.
+    expect(wallC!.positions.length).toBe(8 * 3 * 2);
+    expect(wallC!.indices.length).toBe(36 * 2);
+
+    const FACE = cubeMesh(0, 0, 0, 1).faceVertexIndices; // same triangulation pattern for both cubes
+
+    const firstBlock = Array.from(wallC!.indices.slice(0, 36));
+    const secondBlock = Array.from(wallC!.indices.slice(36));
+
+    // The first submesh's vertexBase is always 0, so its indices are the
+    // untouched 0..7 pattern.
+    expect(firstBlock).toEqual(FACE);
+    // The second submesh must be shifted into the 8..15 range — the offset
+    // under test. Dropping `+ vertexBase` in `mergeMeshes` would leave this
+    // identical to `firstBlock`, aliasing the second submesh's triangles
+    // back onto the first submesh's vertices.
+    expect(secondBlock).toEqual(FACE.map((i) => i + 8));
+
+    // Tie the offset to real geometry, not just index numbers: resolve every
+    // index through `positions` and confirm it lands in the right cube's
+    // x-range. World x is preserved by the IFCX Z-up -> Y-up conversion (only
+    // y/z are remapped), so Body's vertices are x in [10,11] and Axis's are
+    // x in [12,13], independent of which submesh the extractor visits first.
+    const xRangeOf = (idx: number) => wallC!.positions[idx * 3];
+    const firstBlockXs = firstBlock.map(xRangeOf);
+    const secondBlockXs = secondBlock.map(xRangeOf);
+    const inBodyRange = (x: number) => x >= 10 && x <= 11;
+    const inAxisRange = (x: number) => x >= 12 && x <= 13;
+    const firstIsBody = firstBlockXs.every(inBodyRange);
+    const firstIsAxis = firstBlockXs.every(inAxisRange);
+    expect(firstIsBody || firstIsAxis).toBe(true);
+    if (firstIsBody) {
+      expect(secondBlockXs.every(inAxisRange)).toBe(true);
+    } else {
+      expect(secondBlockXs.every(inBodyRange)).toBe(true);
+    }
+  });
+
   it('excludes composition parent/child pairs but keeps the set otherwise', async () => {
     const { elements, exclusions } = await elementsFromIfcx({
       buffer: ifcxBuffer(),


### PR DESCRIPTION
## Summary

`mergeMeshes` in `packages/clash/src/adapters/ifcx.ts` concatenates a group of mesh-bearing descendants that share one entity (e.g. `Body` + `Axis`) into a single position/index buffer, offsetting each subsequent mesh's indices by the running vertex count (`mesh.indices[i] + vertexBase`). Nothing in the suite was asserting that offset directly.

**Confirmed by mutation.** Deleting `+ vertexBase` left the full `packages/clash` suite green:

```
Test Files  23 passed | 1 skipped (24)
     Tests  354 passed | 1 skipped (355)
```

Why nothing noticed: `element.bounds` derives from `fromPositions(merged.positions)` only — it never reads the index buffer — and the `WallC` fixture (`src/adapters/ifcx.test.ts`), the only fixture entity with more than one mesh, is geometrically disjoint from every other fixture element, so no narrow-phase test ever samples its triangles either.

## Change

Added a test in `packages/clash/src/adapters/ifcx.test.ts` that, through the public `elementsFromIfcx` result (`ClashElement.indices` is exactly `mergeMeshes`'s output — the function itself isn't exported), asserts WallC's merged `indices` against hand-computed values for its two 8-vertex/36-index cube submeshes, and additionally resolves every index through `positions` to confirm it lands in the correct submesh's world x-range (Body: x in [10,11], Axis: x in [12,13]) rather than aliasing back onto the other submesh's vertices.

With the mutation reapplied, only the new test fails; all 354 pre-existing tests stay green — exactly reproducing the reported blind spot:

```
Test Files  1 failed | 22 passed | 1 skipped (24)
     Tests  1 failed | 354 passed | 1 skipped (356)

 ❯ src/adapters/ifcx.test.ts:251:25
    expect(secondBlock).toEqual(FACE.map((i) => i + 8));
```

With `+ vertexBase` restored, the full suite is green:

```
Test Files  23 passed | 1 skipped (24)
     Tests  355 passed | 1 skipped (356)
```

`git diff upstream/main` touches only the test file — **no production change**. The production offset in `mergeMeshes` is correct; this closes a blind spot in coverage for one offset in one adapter function, not a claim about the adapter generally.

## Test plan

- [x] `pnpm build` at repo root (wasm deps required for tests)
- [x] `packages/clash`: `npx vitest run` — 355 passed / 1 skipped (24 files), up from the documented baseline of 354 passed / 1 skipped
- [x] Package `tsc --noEmit` in `packages/clash` — clean
- [x] `node scripts/typecheck-tests.mjs` from `packages/clash` — `packages/clash OK (24 test files)`
- [x] `npx oxlint packages/clash/src/adapters/ifcx.test.ts` — clean
- [x] `node scripts/check-unused-locals.mjs` — no new unused locals
- [x] No changeset (test-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage to verify merged WallC submeshes use correct vertex offsets.
  * Confirmed geometry remains correctly associated across multiple cubes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->