### PR TITLE
fix(mcp): honour ServerConfig.autoOpenViewer / .viewerPort (#2731 finding 4)

### DIFF
--- a/.changeset/mcp-viewer-config-fields-are-now-honoured.md
+++ b/.changeset/mcp-viewer-config-fields-are-now-honoured.md
@@ -1,0 +1,25 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+Fix `ServerConfig.autoOpenViewer` / `.viewerPort` being declared on the public
+`MCPServer` config type but never read by the server (issue #2731, finding 4).
+
+`MCPServer` takes `config: Partial<ServerConfig>` in its constructor, and the
+sibling fields `readOnly`, `bsddEndpoint`, `samplingEnabled` and
+`allowedPaths` are honoured via `ctx.config.*` — but `autoOpenViewer` and
+`viewerPort` were not. The CLI's own `--viewer` / `--viewer-port` auto-open
+behaviour came entirely from separate local variables (`opts.autoViewer`,
+`opts.viewerPort`) that happened to be written into `config` but never read
+back out of it. An embedder constructing `MCPServer` directly with
+`config: { autoOpenViewer: true }` got nothing, silently.
+
+Adds `MCPServer.maybeAutoOpenViewer(overrides?)`, which opens the in-process
+viewer for the first loaded model when configured to do so and no-ops
+otherwise. Precedence: an explicit `overrides` argument (what a CLI flag
+represents) beats `this.config` (set at construction, e.g. by an embedder)
+beats the built-in default (no auto-open, port 0). The CLI now calls this
+method with `{ autoOpen: opts.autoViewer, port: opts.viewerPort }` instead of
+calling `server.viewer.open()` directly, so its `--viewer` / `--viewer-port`
+behaviour is unchanged but now goes through the same config-aware path any
+other caller gets.

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -171,11 +171,12 @@ async function main(): Promise<void> {
     process.stderr.write(`[ifc-lite-mcp] ready on stdio (read-only=${opts.readOnly})\n`);
 
     if (opts.autoViewer && registry.count() > 0) {
-      const first = registry.list()[0];
       try {
-        const state = await server.viewer.open(first, opts.viewerPort);
-        const adapters = server.viewer.adapters();
-        if (adapters) first.backend.attachStreamingAdapters(adapters.viewer, adapters.visibility);
+        // Explicit CLI flags (--viewer / --viewer-port) always win, so pass
+        // them as the override rather than relying on `server.config` — see
+        // `MCPServer.maybeAutoOpenViewer`'s precedence rule.
+        const state = await server.maybeAutoOpenViewer({ autoOpen: opts.autoViewer, port: opts.viewerPort });
+        if (!state) throw new Error('viewer did not open');
         process.stderr.write(`[ifc-lite-mcp] viewer ready at ${state.url}\n`);
         if (opts.openBrowser) {
           const cmd = process.platform === 'darwin' ? 'open'

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -73,6 +73,7 @@ import { disposeLayerWorkspace } from './tools/layer-store.js';
 import { ToolRegistry } from './tools/types.js';
 import { validateInput } from './validate.js';
 import { ViewerManager } from './viewer-manager.js';
+import type { ViewerState } from './viewer-manager.js';
 
 export const SERVER_NAME = 'ifc-lite-mcp';
 
@@ -178,6 +179,36 @@ export class MCPServer {
   /** Update the auth scope mid-session (e.g. token refresh). */
   setScope(scope: AuthScope): void {
     this.scope = scope;
+  }
+
+  /**
+   * Open the in-process viewer for the first loaded model if configured to
+   * do so, otherwise a no-op. Makes `ServerConfig.autoOpenViewer` /
+   * `.viewerPort` (issue #2731 finding 4) actually take effect for any
+   * caller that constructs `MCPServer` with `config`, not just the CLI.
+   *
+   * Precedence: `overrides` (an explicit, per-call instruction — this is
+   * what a CLI flag like `--viewer` represents) beats `this.config` (set at
+   * construction, e.g. by an embedder) beats the built-in default of "do
+   * not auto-open, port 0". A field left `undefined` at one level falls
+   * through to the next.
+   *
+   * No-ops (returns `null`) when auto-open resolves to `false`/`undefined`,
+   * or when no model is loaded yet. Errors from `ViewerManager.open()`
+   * propagate — callers that already have their own logging/fallback (the
+   * CLI does) can catch and report; callers that don't want that risk can
+   * check `registry.count()` first.
+   */
+  async maybeAutoOpenViewer(overrides?: { autoOpen?: boolean; port?: number }): Promise<ViewerState | null> {
+    const autoOpen = overrides?.autoOpen ?? this.config.autoOpenViewer ?? false;
+    if (!autoOpen) return null;
+    const model = this.registry.list()[0];
+    if (!model) return null;
+    const port = overrides?.port ?? this.config.viewerPort ?? 0;
+    const state = await this.viewer.open(model, port);
+    const adapters = this.viewer.adapters();
+    if (adapters) model.backend.attachStreamingAdapters(adapters.viewer, adapters.visibility);
+    return state;
   }
 
   isInitialized(): boolean {

--- a/packages/mcp/test/viewer-config.test.ts
+++ b/packages/mcp/test/viewer-config.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ServerConfig.autoOpenViewer` / `.viewerPort` — issue #2731 finding 4.
+ *
+ * `MCPServer` is public API and its constructor accepts `config: Partial<ServerConfig>`.
+ * Both fields were declared on the type and written into `config` by the CLI, but nothing
+ * in the server ever read `this.config.autoOpenViewer` / `this.config.viewerPort` — the
+ * CLI's own working behaviour came entirely from separate local variables that bypassed
+ * the config object. An embedder constructing `MCPServer` directly with
+ * `config: { autoOpenViewer: true }` got silently nothing.
+ *
+ * Precedence (see PR body): explicit override argument to `maybeAutoOpenViewer()` > the
+ * `config` object passed to the constructor > built-in defaults (no auto-open, port 0).
+ * These three tests pin all three levels.
+ */
+
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { IfcCreator } from '@ifc-lite/create';
+import {
+  InMemoryModelRegistry,
+  createMCPServer,
+  loadIfcModel,
+  type MCPServer,
+} from '../src/index.js';
+
+let tmp: string;
+let ifcPath: string;
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-viewer-config-'));
+  ifcPath = join(tmp, 'tiny.ifc');
+  const creator = new IfcCreator({ Name: 'Viewer Config Test' });
+  const storey = creator.addIfcBuildingStorey({ Name: 'L1', Elevation: 0 });
+  creator.addIfcWall(storey, { Start: [0, 0, 0], End: [4, 0, 0], Height: 3, Thickness: 0.2 });
+  await writeFile(ifcPath, creator.toIfc().content, 'utf-8');
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+let liveServer: MCPServer | undefined;
+
+afterEach(() => {
+  if (liveServer?.viewer.isOpen()) liveServer.viewer.close();
+  liveServer = undefined;
+});
+
+async function bootServer(config?: { autoOpenViewer?: boolean; viewerPort?: number }): Promise<MCPServer> {
+  const registry = new InMemoryModelRegistry();
+  const loaded = await loadIfcModel(ifcPath);
+  registry.add(loaded);
+  const server = createMCPServer({ version: '0.0.0-test', registry, config });
+  liveServer = server;
+  return server;
+}
+
+describe('ServerConfig.autoOpenViewer / .viewerPort — public API is honoured', () => {
+  it('level 3 — neither flag nor config set: no auto-open, defaults win', async () => {
+    const server = await bootServer();
+    const state = await server.maybeAutoOpenViewer();
+    expect(state).toBeNull();
+    expect(server.viewer.isOpen()).toBe(false);
+  });
+
+  it('level 2 — config set (embedder path), no explicit override: config is honoured', async () => {
+    const server = await bootServer({ autoOpenViewer: true, viewerPort: 0 });
+    const state = await server.maybeAutoOpenViewer();
+    expect(state).not.toBeNull();
+    expect(server.viewer.isOpen()).toBe(true);
+    expect(state!.url).toMatch(/^http:\/\/localhost:\d+\/$/);
+  });
+
+  it('level 1 — explicit override set: wins over a contradicting config value', async () => {
+    // Config says "do not auto-open"; the explicit override (standing in for a CLI flag) must win.
+    const server = await bootServer({ autoOpenViewer: false });
+    const state = await server.maybeAutoOpenViewer({ autoOpen: true, port: 0 });
+    expect(state).not.toBeNull();
+    expect(server.viewer.isOpen()).toBe(true);
+  });
+
+  it('explicit override can also suppress a config that requests auto-open', async () => {
+    const server = await bootServer({ autoOpenViewer: true });
+    const state = await server.maybeAutoOpenViewer({ autoOpen: false });
+    expect(state).toBeNull();
+    expect(server.viewer.isOpen()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `ServerConfig.autoOpenViewer` / `.viewerPort` (issue #2731 finding 4) were declared on the public `MCPServer` config type but never read anywhere in `packages/mcp` — confirmed by grepping the whole package (src + test) for both identifiers: only `context.ts` (declaration) and `cli.ts` (writes into `config`) matched. The CLI's actual auto-open behaviour came from separate local variables (`opts.autoViewer`, `opts.viewerPort`) that bypassed `config` entirely, so an embedder constructing `MCPServer` with `config: { autoOpenViewer: true }` got nothing.
- Adds `MCPServer.maybeAutoOpenViewer(overrides?: { autoOpen?: boolean; port?: number })`, which opens the in-process viewer for the first loaded model when configured to, and no-ops otherwise.
- **Precedence** (documented in JSDoc + changeset): explicit `overrides` argument (what a CLI flag represents) > `this.config` (set at construction — the embedder path) > built-in defaults (no auto-open, port 0). A field left `undefined` at one level falls through to the next.
- `cli.ts` now calls `server.maybeAutoOpenViewer({ autoOpen: opts.autoViewer, port: opts.viewerPort })` instead of calling `server.viewer.open()` directly. This keeps the CLI's `--viewer` / `--viewer-port` behaviour bit-for-bit identical (same gating `if (opts.autoViewer && registry.count() > 0)`, same logging, same browser-open fallback) while routing it through the same config-aware path any embedder now gets automatically.

This closes **finding 4 of #2731 only**. The other findings in that issue (dynamic batch config, geometry quality, scale-bar/north-arrow renderer divergence, and the "smaller ones" table) are untouched.

## RED → GREEN
Before the fix, `packages/mcp/test/viewer-config.test.ts` failed with:
```
TypeError: server.maybeAutoOpenViewer is not a function
```
(4/4 tests failing — the method didn't exist yet).

After the fix, all 4 pass, pinning all three precedence levels:
1. neither flag nor config set → no auto-open (defaults win)
2. config set, no explicit override → config is honoured (this is the bug fix: an embedder-only config now works)
3. explicit override wins over a contradicting config value (both directions — forcing open and forcing closed)

## Verification
- `packages/mcp` full suite: 261 passed (25 files) before → 265 passed (26 files) after.
- Package typecheck (`tsc --noEmit`, covers `src`): clean.
- Test typecheck (`scripts/typecheck-tests.mjs`, covers `test/`): `packages/mcp OK (26 test files)`.
- Lint (`oxlint`): exit 0; five pre-existing warnings elsewhere in the package, none introduced by this diff.
- `scripts/check-api-surface.mjs`: `API surface matches snapshot (41 packages, 62 export surfaces, 4166 exports)` — no regeneration needed, since the snapshot only tracks `MCPServer: class` at the type level, not individual method signatures.

## Not done here
Whether `MCPServer` should also auto-invoke `maybeAutoOpenViewer()` on its own (e.g. right after construction, or in `attach()`) rather than requiring the caller to call it — I left that decision to the caller because opening a viewer is a side effect with real failure modes (port binding, filesystem access) that a constructor shouldn't perform implicitly, and because the CLI needs to log success/failure itself. Any embedder that wants auto-open now gets it with one explicit call: `await server.maybeAutoOpenViewer()`.
