### PR TITLE
fix(cli): enforce mcp --allow under --transport http

### DIFF
--- a/.changeset/mcp-http-allow-enforcement.md
+++ b/.changeset/mcp-http-allow-enforcement.md
@@ -1,0 +1,24 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix `ifc-lite mcp --allow` not being enforced under `--transport http`.
+
+`--allow <dir>` is documented as restricting file-system access for both
+transports, and it worked correctly under the default stdio transport: the
+session config built there carried `allowedPaths`, which `resolveSafePath`
+(`packages/mcp/src/safe-path.ts`) uses to bound every LLM-supplied path,
+including the `load_model` tool's own file read.
+
+Under `--transport http`, the per-session config built by `SessionFactory.build`
+in `packages/cli/src/commands/mcp.ts` omitted `allowedPaths` entirely, even
+when `--allow` was passed. With `allowedPaths` unset, `buildAllowedRoots`
+falls back to its "sensible workspace" default: the directories of any
+currently-loaded models, `process.cwd()`, and `os.tmpdir()` — not the whole
+filesystem, but broader than what `--allow` was supposed to restrict access
+to, and silently so. A user who verified `--allow` under stdio and then
+switched to `--transport http` for the same restriction got no error and no
+narrowing.
+
+The http session config now includes `allowedPaths`, so `--allow` means the
+same thing under both transports.

--- a/packages/cli/src/commands/mcp-http-allow.test.ts
+++ b/packages/cli/src/commands/mcp-http-allow.test.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #2731: `mcp --allow` is enforced under the default stdio transport
+ * via `buildAllowedRoots` (packages/mcp/src/safe-path.ts), which reads
+ * `ctx.config.allowedPaths`. Under `--transport http`, the per-session
+ * config built in `mcpCommand` must carry the same `allowedPaths` so the
+ * flag means the same thing on both transports.
+ *
+ * Spinning a real HTTP listener and driving a full MCP session through it
+ * from this suite would require plumbing the ephemeral bound port back out
+ * of `mcpCommand` (it never exposes the `HttpTransport` instance), so this
+ * test targets the config-construction seam directly: it captures the
+ * `SessionFactory` handed to `HttpTransport` and asserts the config it
+ * builds for a session includes `allowedPaths`. This is a seam test, not
+ * an end-to-end demonstration that a request for a disallowed path is
+ * actually refused.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { resolve } from 'node:path';
+
+const createMCPServerMock = vi.fn((opts: unknown) => ({ __opts: opts }));
+let capturedSessionFactory: { build: (scope: unknown, sessionId: string) => unknown } | undefined;
+
+vi.mock('@ifc-lite/mcp', () => ({
+  StdioTransport: class {
+    connect = vi.fn(async () => {});
+  },
+  HttpTransport: class {
+    constructor(opts: { sessionFactory: { build: (scope: unknown, sessionId: string) => unknown } }) {
+      capturedSessionFactory = opts.sessionFactory;
+    }
+    listen = vi.fn(async () => {});
+  },
+  BearerTokenAuth: class {
+    constructor(public map: unknown) {}
+  },
+  AllowAllAuth: class {
+    constructor(public scope: unknown) {}
+  },
+  loadIfcModel: vi.fn(),
+  createMCPServer: createMCPServerMock,
+  InMemoryModelRegistry: class {
+    add() {}
+    list() {
+      return [];
+    }
+    count() {
+      return 0;
+    }
+  },
+  fullScope: () => ({ scopes: ['read', 'mutate'] }),
+  readOnlyScope: () => ({ scopes: ['read'] }),
+  VERSION: '0.0.0-test',
+}));
+
+describe('mcp --allow under --transport http (#2731)', () => {
+  beforeEach(() => {
+    createMCPServerMock.mockClear();
+    capturedSessionFactory = undefined;
+  });
+
+  it('carries allowedPaths into the per-session config, same as stdio', async () => {
+    const { mcpCommand } = await import('./mcp.js');
+
+    const allowedDir = resolve('/tmp/ifc-lite-allow-test-dir');
+    await mcpCommand(['--transport', 'http', '--port', '0', '--allow', allowedDir]);
+
+    expect(capturedSessionFactory).toBeDefined();
+    // Building a session is exactly what happens on the first HTTP request.
+    capturedSessionFactory!.build({ scopes: ['read', 'mutate'] }, 'test-session-1');
+
+    expect(createMCPServerMock).toHaveBeenCalledTimes(1);
+    const config = (createMCPServerMock.mock.calls[0][0] as { config?: { allowedPaths?: string[] } }).config;
+
+    // This is the assertion that fails before the fix: the http session
+    // config drops `allowedPaths` entirely, so `--allow` under http falls
+    // back to the server's broader implicit allowlist (loaded-model dirs +
+    // process.cwd() + os.tmpdir()) instead of restricting to `allowedDir`.
+    expect(config?.allowedPaths).toEqual([allowedDir]);
+  });
+});

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -156,7 +156,12 @@ export async function mcpCommand(args: string[]): Promise<void> {
           // Keys per-session state (layer workspaces) and its disposal
           // (#1030); the transport rejects servers built without it.
           sessionId,
-          config: { readOnly, bsddEndpoint: bsdd, samplingEnabled: false },
+          config: {
+            readOnly,
+            bsddEndpoint: bsdd,
+            allowedPaths: allowedPaths.length > 0 ? allowedPaths : undefined,
+            samplingEnabled: false,
+          },
         });
       },
     };


### PR DESCRIPTION
## Summary

Fixes the first finding of issue #2731: `mcp --allow` was enforced under the default stdio transport but silently inert under `--transport http`.

**What was enforced before, and what was not.** Under stdio, `mcpCommand` (`packages/cli/src/commands/mcp.ts`) builds the server config with `allowedPaths: allowedPaths.length > 0 ? allowedPaths : undefined`, and `resolveSafePath` (`packages/mcp/src/safe-path.ts:99-125`) uses `ctx.config.allowedPaths` via `buildAllowedRoots` to bound every LLM-supplied path — including the `load_model` tool's own file read (`packages/mcp/src/tools/discovery.ts`). Under `--transport http`, the per-session config built in the `SessionFactory.build` callback was `{ readOnly, bsddEndpoint: bsdd, samplingEnabled: false }` — `allowedPaths` was never included, regardless of whether `--allow` was passed on the command line.

**What the http default allowlist actually permits.** When `allowedPaths` is unset, `buildAllowedRoots` (`packages/mcp/src/safe-path.ts:109-134`) does **not** fall back to "any path the process can read." It falls back to a specific, narrower set: the directories of any currently-loaded models (empty for the http session's fresh `InMemoryModelRegistry`), `process.cwd()` of the running server process, and `os.tmpdir()`. So the practical exposure under http with `--allow` set-but-ignored was: the server's working directory and the OS temp directory, not the whole filesystem. Still a real gap — the operator asked for a narrower restriction and silently didn't get it — but narrower than the worst-case reading.

## Confirm

Traced both code paths by content (not by line number, which drifted from the issue's citations):
- stdio: `packages/cli/src/commands/mcp.ts`, `config: { readOnly, bsddEndpoint: bsdd, allowedPaths: allowedPaths.length > 0 ? allowedPaths : undefined, samplingEnabled: false, autoOpenViewer: autoViewer, viewerPort }`
- http (before fix): `config: { readOnly, bsddEndpoint: bsdd, samplingEnabled: false }` — `allowedPaths` absent.

Confirmed, not refuted.

## RED → GREEN

Spinning a real HTTP listener from this suite and driving a full MCP session through it would require plumbing the ephemeral bound port back out of `mcpCommand` (it never exposes the `HttpTransport` instance to callers), so **this test targets the config-construction seam directly**, not end-to-end HTTP behaviour: it mocks `@ifc-lite/mcp`, captures the `SessionFactory` handed to `HttpTransport`, invokes `build()` (exactly what happens on the first HTTP request), and asserts the config passed to `createMCPServer` carries `allowedPaths`.

New test: `packages/cli/src/commands/mcp-http-allow.test.ts`

RED (before fix):
```
AssertionError: expected undefined to deeply equal [ '/tmp/ifc-lite-allow-test-dir' ]
- Expected: ["/tmp/ifc-lite-allow-test-dir"]
+ Received: undefined
```

GREEN (after fix): test passes.

## Fix

`packages/cli/src/commands/mcp.ts` — added `allowedPaths: allowedPaths.length > 0 ? allowedPaths : undefined` to the http session config, matching the stdio path exactly.

## Same-shape sweep

Compared every field the stdio config carries against the http config. `readOnly`, `bsddEndpoint`, `samplingEnabled` were already present in both. `autoOpenViewer` / `viewerPort` are also absent from the http config, but those are not security-relevant (no restriction being silently dropped) and are the subject of open PR #2734 against `packages/mcp/src/cli.ts` — a different file (the standalone `ifc-lite-mcp` binary, not this package's `mcp` command wrapper), so there is no line overlap or conflict with that PR. Left untouched here to keep this fix scoped to the security finding.

## Verification

- `packages/mcp` suite: 261 passed / 25 files, unchanged before and after (this change does not touch `packages/mcp`).
- `packages/cli` suite: 392 passed, 8 skipped (400 total) / 37 files, including the new test — all green.
- Typecheck: `packages/cli` `tsc --noEmit` clean; `packages/mcp` `tsc --noEmit` clean; `scripts/typecheck-tests.mjs` clean for both packages.
- Lint (`oxlint`) on changed files: clean.
- `check-api-surface`: not run to completion — most of the monorepo's `dist/` is unbuilt in this environment and the check fails on unrelated packages before reaching ours. Not needed regardless: this change adds no new exports and doesn't touch any type signature (`ServerConfig.allowedPaths` already existed) — only a value passed into an existing config object.

Addresses only the `mcp --allow` / http finding from #2731. The other findings in that issue (`lod --quality`, `ids --locale`, `analyze --out`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP MCP sessions now consistently enforce filesystem restrictions configured with `mcp --allow`.
  * Preserved existing read-only, bSDD, and sampling settings for HTTP connections.

* **Tests**
  * Added coverage verifying that allowed paths are retained when creating HTTP MCP sessions.

* **Documentation**
  * Documented the updated HTTP filesystem access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->