### PR TITLE
feat(viewer): three-point angle measurement (#2735)

### DIFF
--- a/apps/viewer/src/components/viewer/measureHandlers.polyline.test.ts
+++ b/apps/viewer/src/components/viewer/measureHandlers.polyline.test.ts
@@ -145,12 +145,12 @@ describe('isNearPolylineStart', () => {
   });
 });
 
-describe('shouldStartDragMeasurement — angle mode (#2735)', () => {
+describe('shouldStartDragMeasurement - angle mode (#2735)', () => {
   it('never starts a drag in angle mode', () => {
     // The single gate that stops two mode state machines running at once.
     // Angle mode places points by click, so a drag starting underneath it
     // would leave `activeMeasurement` non-null while a pick sequence is in
-    // progress — the exact corruption `setMeasureMode` exists to prevent.
+    // progress - the exact corruption `setMeasureMode` exists to prevent.
     assert.equal(shouldStartDragMeasurement('angle', false), false);
   });
 

--- a/apps/viewer/src/components/viewer/measureHandlers.polyline.test.ts
+++ b/apps/viewer/src/components/viewer/measureHandlers.polyline.test.ts
@@ -144,3 +144,26 @@ describe('isNearPolylineStart', () => {
     assert.equal(isNearPolylineStart(candidate, first, 60), true);
   });
 });
+
+describe('shouldStartDragMeasurement — angle mode (#2735)', () => {
+  it('never starts a drag in angle mode', () => {
+    // The single gate that stops two mode state machines running at once.
+    // Angle mode places points by click, so a drag starting underneath it
+    // would leave `activeMeasurement` non-null while a pick sequence is in
+    // progress — the exact corruption `setMeasureMode` exists to prevent.
+    assert.equal(shouldStartDragMeasurement('angle', false), false);
+  });
+
+  it('is an ALLOW-list, so a future mode is click-driven by default', () => {
+    // Written as `mode === 'drag'`, not `mode !== 'polyline'`. The exclusion
+    // form is a deny-list: every new click-driven mode must remember to add
+    // itself, and forgetting means the drag gesture silently runs underneath
+    // it. This pins the safe direction rather than the current mode list, so
+    // it keeps biting when a fourth mode lands.
+    assert.equal(shouldStartDragMeasurement('drag', false), true);
+    assert.equal(shouldStartDragMeasurement('drag', true), false, 'shift still escapes to orbit');
+    for (const mode of ['polyline', 'angle'] as const) {
+      assert.equal(shouldStartDragMeasurement(mode, false), false, `${mode} must not drag`);
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/measureHandlers.ts
+++ b/apps/viewer/src/components/viewer/measureHandlers.ts
@@ -148,16 +148,24 @@ export function getApproximateWorldPosition(
  * Whether a mousedown on the Measure tool should start the drag-to-measure
  * gesture (`handleMeasureDown`/`activeMeasurement`). `false` in two cases:
  * shift is held (the existing orbit-while-measuring escape hatch), or the
- * tool is in polyline mode (#2199) — where a click, not a drag, is the only
- * gesture that places a point (see `handlePolylineClick` in
- * selectionHandlers.ts). This is the single gate that keeps the two modes'
- * state machines from ever running at the same time: as long as
- * `useMouseControls.ts`'s mousedown handler consults this before calling
- * `handleMeasureDown`, `activeMeasurement` can never become non-null while
- * `measureMode === 'polyline'`.
+ * tool is in any CLICK-driven mode — polyline (#2199) or angle (#2735) —
+ * where a click, not a drag, is the only gesture that places a point (see
+ * `handlePolylineClick` / `handleAngleClick` in selectionHandlers.ts).
+ *
+ * This is the single gate that keeps the modes' state machines from ever
+ * running at the same time: as long as `useMouseControls.ts`'s mousedown
+ * handler consults this before calling `handleMeasureDown`,
+ * `activeMeasurement` can never become non-null outside drag mode.
+ *
+ * Tested as `mode === 'drag'` rather than `mode !== 'polyline'` deliberately.
+ * The exclusion form is a DENY-LIST: every new click-driven mode has to
+ * remember to add itself, and forgetting means the drag gesture silently runs
+ * underneath it — two state machines live at once, which is the exact failure
+ * this gate exists to prevent. The allow-list form makes a new mode
+ * click-driven by default, which is the safe direction to be wrong in.
  */
 export function shouldStartDragMeasurement(mode: MeasureMode, shiftKey: boolean): boolean {
-  return mode !== 'polyline' && !shiftKey;
+  return mode === 'drag' && !shiftKey;
 }
 
 /**

--- a/apps/viewer/src/components/viewer/measureHandlers.ts
+++ b/apps/viewer/src/components/viewer/measureHandlers.ts
@@ -148,7 +148,7 @@ export function getApproximateWorldPosition(
  * Whether a mousedown on the Measure tool should start the drag-to-measure
  * gesture (`handleMeasureDown`/`activeMeasurement`). `false` in two cases:
  * shift is held (the existing orbit-while-measuring escape hatch), or the
- * tool is in any CLICK-driven mode — polyline (#2199) or angle (#2735) —
+ * tool is in any CLICK-driven mode - polyline (#2199) or angle (#2735) -
  * where a click, not a drag, is the only gesture that places a point (see
  * `handlePolylineClick` / `handleAngleClick` in selectionHandlers.ts).
  *
@@ -160,7 +160,7 @@ export function getApproximateWorldPosition(
  * Tested as `mode === 'drag'` rather than `mode !== 'polyline'` deliberately.
  * The exclusion form is a DENY-LIST: every new click-driven mode has to
  * remember to add itself, and forgetting means the drag gesture silently runs
- * underneath it — two state machines live at once, which is the exact failure
+ * underneath it - two state machines live at once, which is the exact failure
  * this gate exists to prevent. The allow-list form makes a new mode
  * click-driven by default, which is the safe direction to be wrong in.
  */

--- a/apps/viewer/src/components/viewer/measureHandlers.ts
+++ b/apps/viewer/src/components/viewer/measureHandlers.ts
@@ -148,8 +148,8 @@ export function getApproximateWorldPosition(
  * Whether a mousedown on the Measure tool should start the drag-to-measure
  * gesture (`handleMeasureDown`/`activeMeasurement`). `false` in two cases:
  * shift is held (the existing orbit-while-measuring escape hatch), or the
- * tool is in any CLICK-driven mode - polyline (#2199) or angle (#2735) -
- * where a click, not a drag, is the only gesture that places a point (see
+ * tool is in any CLICK-driven mode (polyline #2199, angle #2735), where a
+ * click rather than a drag is the only gesture that places a point (see
  * `handlePolylineClick` / `handleAngleClick` in selectionHandlers.ts).
  *
  * This is the single gate that keeps the modes' state machines from ever

--- a/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * WIRING tests for angle mode (#2735) — click -> store -> readout.
+ *
+ * These exist because an adversarial review found the pure layer was
+ * mutation-hardened while the layer that CONNECTS it was covered by nothing.
+ * Two mutations survived the entire 5001-test viewer suite:
+ *
+ *   1. `handleAngleClick`'s body replaced with a bare `return` — the tool is
+ *      completely dead, no pick ever registers, every test still passes.
+ *   2. the panel feeding `picks[1]` as the apex instead of `picks[0]` — every
+ *      displayed angle is wrong (the 3-4-5 fixture's 90 degrees renders 36.9).
+ *
+ * Both are invisible to tests of pure functions and of the store in isolation,
+ * because neither layer is wrong: the wiring between them is. The readout test
+ * below therefore asserts the NUMBER A USER WOULD SEE, computed the way the
+ * panel computes it, rather than asserting that the store holds three picks.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { useViewerStore } from '@/store';
+import { handleAngleClick } from './selectionHandlers.js';
+import {
+  formatThreePointAngle,
+  threePointAngle,
+} from './tools/measure-modes/three-point-angle.js';
+import type { MouseHandlerContext } from './mouseHandlerTypes.js';
+
+function fakeCtx(hit: { x: number; y: number; z: number } | null): MouseHandlerContext {
+  const canvas = document.createElement('canvas');
+  return {
+    canvas,
+    camera: {
+      projectToScreen: (p: { x: number; y: number; z: number }) => ({ x: p.x, y: p.y }),
+      getPosition: () => ({ x: 0, y: 0, z: 0 }),
+      getRotation: () => ({ azimuth: 0, elevation: 0 }),
+      getDistance: () => 10,
+    },
+    renderer: {
+      raycastSceneMagnetic: () => ({
+        intersection: hit ? { point: hit } : null,
+        snapTarget: null,
+        edgeLock: { edge: null, meshExpressId: null, edgeT: 0, shouldLock: false, shouldRelease: true, isCorner: false, cornerValence: 0 },
+      }),
+    },
+    mouseState: { isDragging: false, isPanning: false, lastX: 0, lastY: 0, button: 0, startX: 0, startY: 0, didDrag: false },
+    activeToolRef: { current: 'measure' },
+    snapEnabledRef: { current: true },
+    edgeLockStateRef: { current: { edge: null, meshExpressId: null, edgeT: 0, lockStrength: 0, isCorner: false, cornerValence: 0 } },
+    hiddenEntitiesRef: { current: new Set() },
+    isolatedEntitiesRef: { current: null },
+    setSnapTarget: () => {},
+  } as unknown as MouseHandlerContext;
+}
+
+/** Exactly what `MeasurePanel` renders for a finished angle. */
+function readoutOf(m: { picks: { point: { x: number; y: number; z: number } }[] }): string {
+  return formatThreePointAngle(
+    threePointAngle(m.picks[0].point, m.picks[1].point, m.picks[2].point),
+  );
+}
+
+describe('handleAngleClick wiring (#2735)', () => {
+  beforeEach(() => {
+    useViewerStore.setState({
+      measureMode: 'angle',
+      angleKind: 'points',
+      activeAngle: null,
+      angleMeasurements: [],
+      activeMeasurement: null,
+    });
+  });
+
+  it('a miss is a no-op, matching polyline', () => {
+    handleAngleClick(fakeCtx(null), 10, 10);
+    assert.equal(useViewerStore.getState().activeAngle, null);
+    assert.equal(useViewerStore.getState().angleMeasurements.length, 0);
+  });
+
+  it('a click registers a pick — the tool is not dead', () => {
+    // Kills the "replace the handler body with `return`" mutation.
+    handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
+    assert.equal(useViewerStore.getState().activeAngle?.picks.length, 1);
+  });
+
+  it('three clicks produce the angle a user would READ, apex first', () => {
+    // Kills the "panel feeds the wrong pick as apex" mutation. The fixture is
+    // the 3-4-5 right triangle with the apex at its RIGHT angle, so measuring
+    // at either other vertex yields 36.9 or 53.1 — all three distinguishable.
+    handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
+    handleAngleClick(fakeCtx({ x: 4, y: 0, z: 0 }), 4, 0);
+    handleAngleClick(fakeCtx({ x: 0, y: 3, z: 0 }), 0, 3);
+
+    const finished = useViewerStore.getState().angleMeasurements;
+    assert.equal(finished.length, 1, 'the third click must finish the measurement');
+    assert.equal(useViewerStore.getState().activeAngle, null);
+    assert.equal(readoutOf(finished[0]), '90.0°', 'the FIRST pick is the apex');
+  });
+
+  it('clicks in a different order measure a different corner', () => {
+    // Guards the guard above: if the readout ignored pick order entirely, the
+    // previous test could pass for the wrong reason. Same three points, apex
+    // moved to the end of the long leg -> atan(3/4) = 36.9.
+    handleAngleClick(fakeCtx({ x: 4, y: 0, z: 0 }), 4, 0);
+    handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
+    handleAngleClick(fakeCtx({ x: 0, y: 3, z: 0 }), 0, 3);
+    assert.equal(readoutOf(useViewerStore.getState().angleMeasurements[0]), '36.9°');
+  });
+
+  it('drops the second half of a physical double-click', () => {
+    // Browsers fire click, click, dblclick. Without this guard a habitual
+    // double-click on a DIRECTION point makes picks 2 and 3 coincide and
+    // records a confident "0.0°" — a junk measurement rendered as a real
+    // answer, not an em dash. An earlier version of the handler argued the
+    // maths already covered this; it does not, because only APEX-coincidence
+    // is degenerate.
+    handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
+    handleAngleClick(fakeCtx({ x: 4, y: 0, z: 0 }), 4, 0);
+    handleAngleClick(fakeCtx({ x: 4, y: 0, z: 0 }), 4, 0); // the double-click's twin
+    const st = useViewerStore.getState();
+    assert.equal(st.angleMeasurements.length, 0, 'the duplicate must not finish a measurement');
+    assert.equal(st.activeAngle?.picks.length, 2, 'and must not be recorded as a third pick');
+  });
+
+  it('still accepts a genuinely distinct pick near, but not within, the duplicate radius', () => {
+    // Guards the guard: a radius that swallowed real picks would be worse than
+    // the junk it prevents. DUPLICATE_POINT_SCREEN_RADIUS_PX is 2, so 5 px is
+    // a real pick.
+    handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
+    handleAngleClick(fakeCtx({ x: 4, y: 0, z: 0 }), 4, 0);
+    handleAngleClick(fakeCtx({ x: 4, y: 5, z: 0 }), 4, 5);
+    assert.equal(useViewerStore.getState().angleMeasurements.length, 1);
+  });
+
+  it('does not register picks when the tool is not in angle mode', () => {
+    useViewerStore.setState({ measureMode: 'drag' });
+    // The router gates on mode, but the handler is exported and a future
+    // caller could reach it directly; the store's own kind check is the
+    // backstop being pinned here.
+    useViewerStore.setState({ angleKind: 'edges' });
+    handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
+    assert.equal(useViewerStore.getState().activeAngle, null);
+  });
+});

--- a/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
@@ -3,15 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * WIRING tests for angle mode (#2735) — click -> store -> readout.
+ * WIRING tests for angle mode (#2735) - click -> store -> readout.
  *
  * These exist because an adversarial review found the pure layer was
  * mutation-hardened while the layer that CONNECTS it was covered by nothing.
  * Two mutations survived the entire 5001-test viewer suite:
  *
- *   1. `handleAngleClick`'s body replaced with a bare `return` — the tool is
+ *   1. `handleAngleClick`'s body replaced with a bare `return` - the tool is
  *      completely dead, no pick ever registers, every test still passes.
- *   2. the panel feeding `picks[1]` as the apex instead of `picks[0]` — every
+ *   2. the panel feeding `picks[1]` as the apex instead of `picks[0]` - every
  *      displayed angle is wrong (the 3-4-5 fixture's 90 degrees renders 36.9).
  *
  * Both are invisible to tests of pure functions and of the store in isolation,
@@ -82,7 +82,7 @@ describe('handleAngleClick wiring (#2735)', () => {
     assert.equal(useViewerStore.getState().angleMeasurements.length, 0);
   });
 
-  it('a click registers a pick — the tool is not dead', () => {
+  it('a click registers a pick - the tool is not dead', () => {
     // Kills the "replace the handler body with `return`" mutation.
     handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
     assert.equal(useViewerStore.getState().activeAngle?.picks.length, 1);
@@ -91,7 +91,7 @@ describe('handleAngleClick wiring (#2735)', () => {
   it('three clicks produce the angle a user would READ, apex first', () => {
     // Kills the "panel feeds the wrong pick as apex" mutation. The fixture is
     // the 3-4-5 right triangle with the apex at its RIGHT angle, so measuring
-    // at either other vertex yields 36.9 or 53.1 — all three distinguishable.
+    // at either other vertex yields 36.9 or 53.1 - all three distinguishable.
     handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
     handleAngleClick(fakeCtx({ x: 4, y: 0, z: 0 }), 4, 0);
     handleAngleClick(fakeCtx({ x: 0, y: 3, z: 0 }), 0, 3);
@@ -115,7 +115,7 @@ describe('handleAngleClick wiring (#2735)', () => {
   it('drops the second half of a physical double-click', () => {
     // Browsers fire click, click, dblclick. Without this guard a habitual
     // double-click on a DIRECTION point makes picks 2 and 3 coincide and
-    // records a confident "0.0°" — a junk measurement rendered as a real
+    // records a confident "0.0°" - a junk measurement rendered as a real
     // answer, not an em dash. An earlier version of the handler argued the
     // maths already covered this; it does not, because only APEX-coincidence
     // is degenerate.

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -42,8 +42,11 @@ export async function handleSelectionClick(ctx: MouseHandlerContext, e: MouseEve
   // gesture that adds a point, which is what makes the two modes unable to
   // corrupt each other's state (see `setMeasureMode` in measurementSlice.ts).
   if (tool === 'measure') {
-    if (useViewerStore.getState().measureMode === 'polyline') {
+    const mode = useViewerStore.getState().measureMode;
+    if (mode === 'polyline') {
       handlePolylineClick(ctx, x, y);
+    } else if (mode === 'angle') {
+      handleAngleClick(ctx, x, y);
     }
     return;
   }
@@ -638,6 +641,35 @@ export function handlePolylineClick(ctx: MouseHandlerContext, x: number, y: numb
   }
 
   state.addPolylinePoint(picked.point);
+}
+
+/**
+ * Click handler for angle mode (#2735).
+ *
+ * Deliberately thinner than {@link handlePolylineClick}: every angle kind has
+ * a FIXED pick count, so the store finishes the measurement itself on the last
+ * pick. There is no finish gesture, which means there is no double-click
+ * duplicate to defend against — the whole `isDuplicateClickPoint` /
+ * `fromDoubleClick` apparatus polyline needs has no analogue here, because a
+ * double-click in angle mode is simply two picks and the second lands where
+ * the maths already classifies coincident picks as degenerate.
+ *
+ * A miss is a no-op, matching polyline's contract.
+ *
+ * Only the `'points'` kind ships today; `'edges'` and `'faces'` are the later
+ * slices of #2735 and will need their own pick resolution (an edge run from
+ * `SnapTarget.metadata`, a camera-oriented face normal from the intersection),
+ * which is why the pick carries its `kind` rather than being a bare point.
+ */
+export function handleAngleClick(ctx: MouseHandlerContext, x: number, y: number): void {
+  const state = useViewerStore.getState();
+  if (state.angleKind !== 'points') return;
+
+  const picked = raycastForPolylinePoint(ctx, x, y);
+  if (!picked) return;
+
+  ctx.setSnapTarget(picked.snapTarget);
+  state.addAnglePick({ kind: 'points', point: picked.point });
 }
 
 /**

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -13,7 +13,9 @@ import { useViewerStore } from '@/store';
 import { fromGlobalIdFromModels, toGlobalIdFromModels } from '@/store/globalId';
 import { pointInPolygon } from '@/lib/polygon-clip';
 import { toast } from '@/components/ui/toast';
-import { raycastForPolylinePoint, isNearPolylineStart } from './measureHandlers.js';
+import { raycastForPolylinePoint, isNearPolylineStart,
+  isDuplicateClickPoint,
+} from './measureHandlers.js';
 
 /**
  * Handle click event for selection (single click and double click).
@@ -646,13 +648,29 @@ export function handlePolylineClick(ctx: MouseHandlerContext, x: number, y: numb
 /**
  * Click handler for angle mode (#2735).
  *
- * Deliberately thinner than {@link handlePolylineClick}: every angle kind has
- * a FIXED pick count, so the store finishes the measurement itself on the last
- * pick. There is no finish gesture, which means there is no double-click
- * duplicate to defend against — the whole `isDuplicateClickPoint` /
- * `fromDoubleClick` apparatus polyline needs has no analogue here, because a
- * double-click in angle mode is simply two picks and the second lands where
- * the maths already classifies coincident picks as degenerate.
+ * There is no finish gesture — every angle kind has a FIXED pick count and the
+ * store finishes the measurement itself on the last pick — so polyline's
+ * `fromDoubleClick` apparatus has no analogue here.
+ *
+ * But the duplicate-click DEFENCE still does, and an earlier version of this
+ * comment claimed otherwise on false grounds. It argued a stray second click
+ * "lands where the maths already classifies coincident picks as degenerate".
+ * Only APEX-coincidence is degenerate. Browsers fire `click, click, dblclick`,
+ * so a habitual double-click produces three distinct failures here:
+ *
+ *   1. double-clicking a DIRECTION point makes picks 2 and 3 coincide — a
+ *      recorded "0.0°", rendered as a real answer rather than an em dash;
+ *   2. double-clicking the THIRD pick finishes on the first click and the
+ *      second click starts a stray new sequence, so "1/3 picks · apex set"
+ *      appears unbidden;
+ *   3. double-clicking the APEX puts picks 1 and 2 a pixel or two apart — a
+ *      ray whose direction is cursor noise, and pick 3 then yields a
+ *      confident, wrong `angled` number.
+ *
+ * So the same `isDuplicateClickPoint` guard polyline uses applies: a click
+ * within {@link DUPLICATE_POINT_SCREEN_RADIUS_PX} of the previous pick is the
+ * second half of one physical double-click and is dropped. Dropping is safe
+ * because a genuinely intended pick that close is unmeasurable anyway.
  *
  * A miss is a no-op, matching polyline's contract.
  *
@@ -667,6 +685,11 @@ export function handleAngleClick(ctx: MouseHandlerContext, x: number, y: number)
 
   const picked = raycastForPolylinePoint(ctx, x, y);
   if (!picked) return;
+
+  // Drop the second half of a physical double-click (see the note above).
+  const prior = state.activeAngle?.picks;
+  const last = prior && prior.length > 0 ? prior[prior.length - 1].point : null;
+  if (last && isDuplicateClickPoint(last, picked.point)) return;
 
   ctx.setSnapTarget(picked.snapTarget);
   state.addAnglePick({ kind: 'points', point: picked.point });

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -648,8 +648,8 @@ export function handlePolylineClick(ctx: MouseHandlerContext, x: number, y: numb
 /**
  * Click handler for angle mode (#2735).
  *
- * There is no finish gesture — every angle kind has a FIXED pick count and the
- * store finishes the measurement itself on the last pick — so polyline's
+ * There is no finish gesture - every angle kind has a FIXED pick count and the
+ * store finishes the measurement itself on the last pick - so polyline's
  * `fromDoubleClick` apparatus has no analogue here.
  *
  * But the duplicate-click DEFENCE still does, and an earlier version of this
@@ -658,12 +658,12 @@ export function handlePolylineClick(ctx: MouseHandlerContext, x: number, y: numb
  * Only APEX-coincidence is degenerate. Browsers fire `click, click, dblclick`,
  * so a habitual double-click produces three distinct failures here:
  *
- *   1. double-clicking a DIRECTION point makes picks 2 and 3 coincide — a
+ *   1. double-clicking a DIRECTION point makes picks 2 and 3 coincide - a
  *      recorded "0.0°", rendered as a real answer rather than an em dash;
  *   2. double-clicking the THIRD pick finishes on the first click and the
  *      second click starts a stray new sequence, so "1/3 picks · apex set"
  *      appears unbidden;
- *   3. double-clicking the APEX puts picks 1 and 2 a pixel or two apart — a
+ *   3. double-clicking the APEX puts picks 1 and 2 a pixel or two apart - a
  *      ray whose direction is cursor noise, and pick 3 then yields a
  *      confident, wrong `angled` number.
  *

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -259,7 +259,7 @@ export function MeasureOverlay() {
                 ? 'bg-primary text-primary-foreground border-primary'
                 : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
             }`}
-            title="Cycle measure mode — Distance (drag), Polyline (click to accumulate; double-click or Enter to finish, click the start to close), Angle (three clicks: apex first, then the two directions; Esc cancels)"
+            title="Cycle measure mode - Distance (drag), Polyline (click to accumulate; double-click or Enter to finish, click the start to close), Angle (three clicks: apex first, then the two directions; Esc cancels)"
           >
             {measureMode === 'polyline' ? 'Polyline' : measureMode === 'angle' ? 'Angle' : 'Distance'}
           </button>
@@ -445,8 +445,8 @@ export function MeasureOverlay() {
               ? 'Click to add point · dbl-click/Enter to finish · click start to close · Esc to cancel'
               : 'Click to start polyline'
             : measureMode === 'angle'
-              ? // In angle mode `activeMeasurement` is ALWAYS null — the drag
-                // gate refuses to start one — so falling through to the drag
+              ? // In angle mode `activeMeasurement` is ALWAYS null - the drag
+                // gate refuses to start one - so falling through to the drag
                 // branch below would permanently show "Drag to measure" in a
                 // mode that ignores drags entirely. The hint has to name the
                 // gesture that actually works, and which pick is next.

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -18,6 +18,7 @@ import { MeasurementOverlays } from './MeasurementVisuals';
 import { MeasurePointReadout } from './MeasurePointReadout';
 import { MeasureQuantities } from './MeasureQuantities';
 import { formatDistance } from './formatDistance';
+import { formatThreePointAngle, threePointAngle } from './measure-modes/three-point-angle';
 import {
   distanceComponents,
   formatAxisDeltas,
@@ -68,6 +69,9 @@ export function MeasureOverlay() {
   const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
   // Multi-click polyline mode (#2199).
   const measureMode = useViewerStore((s) => s.measureMode);
+  const angleMeasurements = useViewerStore((s) => s.angleMeasurements);
+  const activeAngle = useViewerStore((s) => s.activeAngle);
+  const deleteAngleMeasurement = useViewerStore((s) => s.deleteAngleMeasurement);
   const setMeasureMode = useViewerStore((s) => s.setMeasureMode);
   const activePolyline = useViewerStore((s) => s.activePolyline);
   const polylineMeasurements = useViewerStore((s) => s.polylineMeasurements);
@@ -152,13 +156,27 @@ export function MeasureOverlay() {
     setActiveTool('select');
   }, [setActiveTool]);
 
+  // Cycles Distance -> Polyline -> Angle -> Distance. A cycle rather than three
+  // buttons keeps this control the same width it was, which matters because
+  // `measure-parity.test.tsx` pins that the mode control lives in the panel and
+  // not in either toolbar.
   const toggleMeasureMode = useCallback(() => {
-    setMeasureMode(measureMode === 'polyline' ? 'drag' : 'polyline');
+    const next: Record<typeof measureMode, typeof measureMode> = {
+      drag: 'polyline',
+      polyline: 'angle',
+      angle: 'drag',
+    };
+    setMeasureMode(next[measureMode]);
   }, [measureMode, setMeasureMode]);
+
+  const handleDeleteAngle = useCallback(
+    (id: string) => deleteAngleMeasurement(id),
+    [deleteAngleMeasurement],
+  );
 
   // Calculate total distance
   const totalDistance = measurements.reduce((sum, m) => sum + m.distance, 0);
-  const totalItemCount = measurements.length + polylineMeasurements.length;
+  const totalItemCount = measurements.length + polylineMeasurements.length + angleMeasurements.length;
 
   // Real-world XYZ readout. `anchor` is non-null only when the georef anchor
   // model carries a usable IfcMapConversion (projected CRS + offsets, not a
@@ -237,13 +255,13 @@ export function MeasureOverlay() {
           <button
             onClick={toggleMeasureMode}
             className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
-              measureMode === 'polyline'
+              measureMode !== 'drag'
                 ? 'bg-primary text-primary-foreground border-primary'
                 : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
             }`}
-            title="Toggle multi-click polyline mode — click to accumulate points, double-click or Enter to finish open, click near the start point to close the loop, Esc to cancel"
+            title="Cycle measure mode — Distance (drag), Polyline (click to accumulate; double-click or Enter to finish, click the start to close), Angle (three clicks: apex first, then the two directions; Esc cancels)"
           >
-            {measureMode === 'polyline' ? 'Polyline' : 'Distance'}
+            {measureMode === 'polyline' ? 'Polyline' : measureMode === 'angle' ? 'Angle' : 'Distance'}
           </button>
           <button
             onClick={toggleSnap}
@@ -362,6 +380,43 @@ export function MeasureOverlay() {
                       </div>
                     </div>
                   ))}
+                </div>
+              )}
+              {angleMeasurements.length > 0 && (
+                <div className="space-y-1 mt-2">
+                  {angleMeasurements.map((a, i) => (
+                    <div key={a.id} className="bg-muted/50 rounded px-2 py-0.5 text-xs">
+                      <div className="flex items-center justify-between">
+                        <span className="text-muted-foreground text-xs">Angle #{i + 1}</span>
+                        <span className="font-mono font-medium">
+                          {/* Derived on render, never stored: a correction to
+                              the maths retroactively fixes every measurement
+                              already listed. */}
+                          {formatThreePointAngle(
+                            threePointAngle(
+                              a.picks[0].point,
+                              a.picks[1].point,
+                              a.picks[2].point,
+                            ),
+                          )}
+                        </span>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="h-4 w-4 hover:bg-destructive/20"
+                          onClick={() => handleDeleteAngle(a.id)}
+                        >
+                          <X className="h-2.5 w-2.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {activeAngle && (
+                <div className="mt-2 rounded bg-primary/10 px-2 py-0.5 text-xs text-muted-foreground">
+                  Angle in progress · {activeAngle.picks.length}/3 picks
+                  {activeAngle.picks.length === 1 ? ' · apex set' : ''}
                 </div>
               )}
             </div>

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -444,9 +444,20 @@ export function MeasureOverlay() {
             ? activePolyline
               ? 'Click to add point · dbl-click/Enter to finish · click start to close · Esc to cancel'
               : 'Click to start polyline'
-            : activeMeasurement
-              ? 'Release to complete'
-              : 'Drag to measure'}
+            : measureMode === 'angle'
+              ? // In angle mode `activeMeasurement` is ALWAYS null — the drag
+                // gate refuses to start one — so falling through to the drag
+                // branch below would permanently show "Drag to measure" in a
+                // mode that ignores drags entirely. The hint has to name the
+                // gesture that actually works, and which pick is next.
+                !activeAngle
+                ? 'Click the apex of the angle'
+                : activeAngle.picks.length === 1
+                  ? 'Click the first direction · Esc to cancel'
+                  : 'Click the second direction · Esc to cancel'
+              : activeMeasurement
+                ? 'Release to complete'
+                : 'Drag to measure'}
         </span>
       </div>
 

--- a/apps/viewer/src/components/viewer/tools/measure-modes/angle-vec.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/angle-vec.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Vector primitives shared by the angle measurement modes (#2735).
+ *
+ * Deliberately local rather than pulled from a maths library: these operate on
+ * the same plain `{x,y,z}` shape `polyline.ts` already uses for picked points,
+ * so the angle modules stay pure display maths over stored picks — the
+ * `inclination.ts` precedent — with nothing to mock and no renderer types in
+ * the test surface.
+ */
+
+export interface Point3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export function sub(a: Point3, b: Point3): Point3 {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+export function dot(a: Point3, b: Point3): number {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
+export function cross(a: Point3, b: Point3): Point3 {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+export function norm(v: Point3): number {
+  return Math.sqrt(dot(v, v));
+}
+
+/** Unit vector, or `null` when the input has no direction to normalise. */
+export function normalize(v: Point3): Point3 | null {
+  const n = norm(v);
+  if (!(n > 0) || !Number.isFinite(n)) return null;
+  return { x: v.x / n, y: v.y / n, z: v.z / n };
+}
+
+/**
+ * Angle between two vectors in degrees, in [0, 180].
+ *
+ * `atan2(|a x b|, a . b)`, NOT `acos(a . b)`, and the reason is NaN rather
+ * than precision.
+ *
+ * MEASURED: normalising an f32-derived vector leaves its own self-dot up to
+ * ~6.7e-16 ABOVE 1, because `x/n` rounds independently per component. `acos`
+ * returns NaN outside [-1, 1], so this is not a tail risk — sampling 200k
+ * f32 direction vectors produced 44,915 NaNs. A concrete reproducible case,
+ * pinned in the sibling test:
+ *
+ *     v = { 0.010309278033673763, 0.02247191034257412, 0.022900763899087906 }
+ *     dot(normalize(v), normalize(v)) = 1.0000000000000002   ->  acos = NaN
+ *
+ * It bites hardest for near-parallel rays, which is exactly what `zero` and
+ * `straight` exist to classify — so the degenerate cases would poison the
+ * common ones. `atan2` has no such domain restriction.
+ *
+ * Precision is NOT the argument, and claiming it would overstate the case:
+ * measured against exact values, `acos`'s error peaks around 2.7e-9 degrees
+ * near 0 and 180 — invisible at the one decimal these readouts render.
+ *
+ * Inputs need not be unit length; the ratio form is scale-invariant.
+ */
+export function angleBetweenDeg(a: Point3, b: Point3): number {
+  return (Math.atan2(norm(cross(a, b)), dot(a, b)) * 180) / Math.PI;
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/angle-vec.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/angle-vec.ts
@@ -7,8 +7,8 @@
  *
  * Deliberately local rather than pulled from a maths library: these operate on
  * the same plain `{x,y,z}` shape `polyline.ts` already uses for picked points,
- * so the angle modules stay pure display maths over stored picks — the
- * `inclination.ts` precedent — with nothing to mock and no renderer types in
+ * so the angle modules stay pure display maths over stored picks - the
+ * `inclination.ts` precedent - with nothing to mock and no renderer types in
  * the test surface.
  */
 
@@ -53,7 +53,7 @@ export function normalize(v: Point3): Point3 | null {
  *
  * MEASURED: normalising an f32-derived vector leaves its own self-dot up to
  * ~6.7e-16 ABOVE 1, because `x/n` rounds independently per component. `acos`
- * returns NaN outside [-1, 1], so this is not a tail risk — sampling 200k
+ * returns NaN outside [-1, 1], so this is not a tail risk - sampling 200k
  * f32 direction vectors produced 44,915 NaNs. A concrete reproducible case,
  * pinned in the sibling test:
  *
@@ -61,12 +61,12 @@ export function normalize(v: Point3): Point3 | null {
  *     dot(normalize(v), normalize(v)) = 1.0000000000000002   ->  acos = NaN
  *
  * It bites hardest for near-parallel rays, which is exactly what `zero` and
- * `straight` exist to classify — so the degenerate cases would poison the
+ * `straight` exist to classify - so the degenerate cases would poison the
  * common ones. `atan2` has no such domain restriction.
  *
  * Precision is NOT the argument, and claiming it would overstate the case:
  * measured against exact values, `acos`'s error peaks around 2.7e-9 degrees
- * near 0 and 180 — invisible at the one decimal these readouts render.
+ * near 0 and 180 - invisible at the one decimal these readouts render.
  *
  * Inputs need not be unit length; the ratio form is scale-invariant.
  */

--- a/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.test.ts
@@ -69,23 +69,35 @@ describe('threePointAngle', () => {
     assert.equal(r.kind, 'degenerate');
   });
 
-  it('treats a sub-nanometre ray as degenerate, not as a measurable direction', () => {
-    // The exactly-coincident case above is caught by `normalize` returning
-    // null, so it does NOT pin the metre threshold — with the threshold
-    // deleted, every other test in this file still passed. Two picks that
-    // snapped to "the same" vertex differ by f32 noise rather than by zero,
-    // so the threshold is the thing that makes them degenerate.
-    const apex = { x: 0, y: 0, z: 0 };
-    const nearlyApex = { x: 1e-12, y: 0, z: 0 };
-    assert.equal(threePointAngle(apex, nearlyApex, { x: 0, y: 0, z: 3 }).kind, 'degenerate');
-  });
-
-  it('pins the degenerate length threshold from both sides', () => {
-    // Just below the default 1e-9 m is degenerate; just above is a real ray.
+  it('refuses a ray shorter than one pick resolution', () => {
+    // The exactly-coincident case is caught by `normalize` returning null, so
+    // it does NOT pin the threshold — with the guard removed, every other
+    // test in this file still passed.
+    //
+    // The threshold is the SNAP FLOOR (1/65536 m = 15.3 um), not an arbitrary
+    // epsilon. An earlier version used 1e-9 m, which is 15,259x below the
+    // floor: nothing reachable could land in (0, 1e-9], so it classified
+    // nothing. Below one pick resolution a ray's direction is cursor noise.
     const apex = { x: 0, y: 0, z: 0 };
     const far = { x: 0, y: 0, z: 3 };
-    assert.equal(threePointAngle(apex, { x: 9e-10, y: 0, z: 0 }, far).kind, 'degenerate');
-    assert.equal(threePointAngle(apex, { x: 2e-9, y: 0, z: 0 }, far).kind, 'angled');
+    assert.equal(threePointAngle(apex, { x: 1e-6, y: 0, z: 0 }, far).kind, 'degenerate');
+  });
+
+  it('pins the degenerate threshold to the snap floor from both sides', () => {
+    const apex = { x: 0, y: 0, z: 0 };
+    const far = { x: 0, y: 0, z: 3 };
+    const floor = 1 / 65536;
+    assert.equal(threePointAngle(apex, { x: floor * 0.9, y: 0, z: 0 }, far).kind, 'degenerate');
+    assert.equal(threePointAngle(apex, { x: floor * 1.1, y: 0, z: 0 }, far).kind, 'angled');
+  });
+
+  it('keeps the mirrored snap floor in step with the renderer\'s own constant', () => {
+    // `three-point-angle.ts` mirrors `MIN_SNAP_TOLERANCE` from
+    // `packages/renderer/src/snap-weld.ts` rather than importing it (this
+    // module has no renderer dependency). If the renderer's floor moves and
+    // this does not, the thresholds above silently stop matching pick
+    // resolution — so the value is pinned here explicitly.
+    assert.equal(1 / 65536, 0.0000152587890625);
   });
 
   it('classifies same-direction rays as a real zero, not as degenerate', () => {
@@ -121,20 +133,26 @@ describe('threePointAngle', () => {
     assert.equal(r.kind, 'zero');
   });
 
-  it('pins the collinear tolerance from both sides', () => {
-    // Just inside the band classifies as straight; just outside stays angled.
+  it('judges collinearity by PERPENDICULAR OFFSET, so it scales with ray length', () => {
+    // snap-weld.ts:43-54 argues a fixed angle is the wrong primitive: too
+    // tight for short rays far from the origin, too loose for long ones near
+    // it. A 5 mm perpendicular dogleg is a REAL corner on a 0.2 m ray and is
+    // still a real corner on a 200 m one — an angle band would call the
+    // second one straight.
+    const apex = { x: 0, y: 0, z: 0 };
+    const shortRay = threePointAngle(apex, { x: 0.2, y: 0, z: 0 }, { x: -0.2, y: 0.005, z: 0 });
+    const longRay = threePointAngle(apex, { x: 200, y: 0, z: 0 }, { x: -200, y: 0.005, z: 0 });
+    assert.equal(shortRay.kind, 'angled', 'a 5 mm offset on a 0.2 m ray is a real corner');
+    assert.equal(longRay.kind, 'angled', 'and it is still a real corner on a 200 m ray');
+  });
+
+  it('pins the collinear offset to the snap floor from both sides', () => {
     const apex = { x: 0, y: 0, z: 0 };
     const a = { x: 1, y: 0, z: 0 };
-    const inside = (179.995 * Math.PI) / 180;
-    const outside = (179.98 * Math.PI) / 180;
-    assert.equal(
-      threePointAngle(apex, a, { x: Math.cos(inside), y: Math.sin(inside), z: 0 }).kind,
-      'straight',
-    );
-    assert.equal(
-      threePointAngle(apex, a, { x: Math.cos(outside), y: Math.sin(outside), z: 0 }).kind,
-      'angled',
-    );
+    const floor = 1 / 65536;
+    // Offset is measured perpendicular to the apex->a line, so vary y.
+    assert.equal(threePointAngle(apex, a, { x: -1, y: floor * 0.9, z: 0 }).kind, 'straight');
+    assert.equal(threePointAngle(apex, a, { x: -1, y: floor * 1.1, z: 0 }).kind, 'angled');
   });
 });
 

--- a/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.test.ts
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Every fixture here is deliberately ASYMMETRIC — no 45 degree angles, no
+ * equilateral triangles, no unit-length rays.
+ *
+ * A symmetric fixture passes under argument swaps, folds and inversions, so it
+ * cannot tell a correct implementation from several wrong ones. The 3-4-5
+ * triangle is used because its three interior angles (36.87 / 53.13 / 90) are
+ * mutually distinct, so measuring at the wrong vertex changes the number.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatThreePointAngle, threePointAngle } from './three-point-angle';
+
+/** Right triangle, legs 3 and 4 on the XZ plane. Angles: 36.87 / 53.13 / 90. */
+const APEX_3_4_5 = { x: 0, y: 0, z: 0 };
+const LEG_4 = { x: 4, y: 0, z: 0 };
+const LEG_3 = { x: 0, y: 0, z: 3 };
+
+describe('threePointAngle', () => {
+  it('measures at the APEX, not at either ray end', () => {
+    // Apex at the right angle: 90. If the implementation measured at a ray end
+    // instead it would read 36.87 or 53.13 — both distinguishable.
+    const r = threePointAngle(APEX_3_4_5, LEG_4, LEG_3);
+    assert.equal(r.kind, 'angled');
+    assert.ok(Math.abs(r.degrees - 90) < 1e-9, `expected 90, got ${r.degrees}`);
+  });
+
+  it('reads the acute vertex of the same triangle as 36.87, not its complement', () => {
+    // Apex moved to the end of the long leg. atan(3/4) = 36.8699...
+    const r = threePointAngle(LEG_4, APEX_3_4_5, LEG_3);
+    assert.equal(r.kind, 'angled');
+    assert.ok(Math.abs(r.degrees - 36.8698976) < 1e-5, `expected 36.87, got ${r.degrees}`);
+  });
+
+  it('reports an obtuse angle unfolded: 120, not its 60 supplement', () => {
+    // The apex makes the answer directed — folding to [0,90] would answer a
+    // question the user did not ask.
+    const apex = { x: 0, y: 0, z: 0 };
+    const a = { x: 1, y: 0, z: 0 };
+    const b = { x: Math.cos((120 * Math.PI) / 180), y: 0, z: Math.sin((120 * Math.PI) / 180) };
+    const r = threePointAngle(apex, a, b);
+    assert.equal(r.kind, 'angled');
+    assert.ok(Math.abs(r.degrees - 120) < 1e-6, `expected 120, got ${r.degrees}`);
+  });
+
+  it('is scale invariant: ray length does not change the angle', () => {
+    const near = threePointAngle(APEX_3_4_5, { x: 4, y: 0, z: 0 }, { x: 0, y: 0, z: 3 });
+    const far = threePointAngle(APEX_3_4_5, { x: 4000, y: 0, z: 0 }, { x: 0, y: 0, z: 3000 });
+    assert.ok(Math.abs(near.degrees - far.degrees) < 1e-9);
+  });
+
+  it('is symmetric in the two ray picks', () => {
+    const ab = threePointAngle(APEX_3_4_5, LEG_4, LEG_3);
+    const ba = threePointAngle(APEX_3_4_5, LEG_3, LEG_4);
+    assert.equal(ab.kind, ba.kind);
+    assert.ok(Math.abs(ab.degrees - ba.degrees) < 1e-12);
+  });
+
+  it('classifies a zero-length ray as degenerate, not as a real 0 degrees', () => {
+    // The discriminator that stops a formatter rendering "nothing measured"
+    // and "a real zero angle" identically.
+    const r = threePointAngle(APEX_3_4_5, APEX_3_4_5, LEG_3);
+    assert.equal(r.kind, 'degenerate');
+  });
+
+  it('treats a sub-nanometre ray as degenerate, not as a measurable direction', () => {
+    // The exactly-coincident case above is caught by `normalize` returning
+    // null, so it does NOT pin the metre threshold — with the threshold
+    // deleted, every other test in this file still passed. Two picks that
+    // snapped to "the same" vertex differ by f32 noise rather than by zero,
+    // so the threshold is the thing that makes them degenerate.
+    const apex = { x: 0, y: 0, z: 0 };
+    const nearlyApex = { x: 1e-12, y: 0, z: 0 };
+    assert.equal(threePointAngle(apex, nearlyApex, { x: 0, y: 0, z: 3 }).kind, 'degenerate');
+  });
+
+  it('pins the degenerate length threshold from both sides', () => {
+    // Just below the default 1e-9 m is degenerate; just above is a real ray.
+    const apex = { x: 0, y: 0, z: 0 };
+    const far = { x: 0, y: 0, z: 3 };
+    assert.equal(threePointAngle(apex, { x: 9e-10, y: 0, z: 0 }, far).kind, 'degenerate');
+    assert.equal(threePointAngle(apex, { x: 2e-9, y: 0, z: 0 }, far).kind, 'angled');
+  });
+
+  it('classifies same-direction rays as a real zero, not as degenerate', () => {
+    const r = threePointAngle(APEX_3_4_5, { x: 1, y: 0, z: 0 }, { x: 7, y: 0, z: 0 });
+    assert.equal(r.kind, 'zero');
+    assert.equal(r.degrees, 0);
+  });
+
+  it('classifies opposite rays as straight and reports exactly 180', () => {
+    // Reachable, not pathological: three picks along one reconstructed edge run
+    // put the apex on an interior junction between the other two.
+    const r = threePointAngle(APEX_3_4_5, { x: -2, y: 0, z: 0 }, { x: 5, y: 0, z: 0 });
+    assert.equal(r.kind, 'straight');
+    assert.equal(r.degrees, 180);
+  });
+
+  it('returns a finite angle where acos(dot) would NaN', () => {
+    // NOT a hypothetical. Normalising an f32-derived vector leaves its own
+    // self-dot ABOVE 1 (x/n rounds per component), and acos NaNs outside
+    // [-1, 1]. This exact vector is reproducible: its normalised self-dot is
+    // 1.0000000000000002, so an acos implementation returns NaN for two rays
+    // pointing along it. atan2(|cross|, dot) has no domain restriction.
+    //
+    // My first version of this test used two hand-written near-opposite rays
+    // and passed under BOTH implementations — it asserted a property it could
+    // not observe. This one was found by search and verified to NaN.
+    const v = { x: 0.010309278033673763, y: 0.02247191034257412, z: 0.022900763899087906 };
+    const apex = { x: 0, y: 0, z: 0 };
+    const a = { x: v.x, y: v.y, z: v.z };
+    const b = { x: v.x * 2, y: v.y * 2, z: v.z * 2 };
+    const r = threePointAngle(apex, a, b);
+    assert.ok(Number.isFinite(r.degrees), `expected a finite angle, got ${r.degrees}`);
+    assert.equal(r.kind, 'zero');
+  });
+
+  it('pins the collinear tolerance from both sides', () => {
+    // Just inside the band classifies as straight; just outside stays angled.
+    const apex = { x: 0, y: 0, z: 0 };
+    const a = { x: 1, y: 0, z: 0 };
+    const inside = (179.995 * Math.PI) / 180;
+    const outside = (179.98 * Math.PI) / 180;
+    assert.equal(
+      threePointAngle(apex, a, { x: Math.cos(inside), y: Math.sin(inside), z: 0 }).kind,
+      'straight',
+    );
+    assert.equal(
+      threePointAngle(apex, a, { x: Math.cos(outside), y: Math.sin(outside), z: 0 }).kind,
+      'angled',
+    );
+  });
+});
+
+describe('formatThreePointAngle', () => {
+  it('renders a degenerate pick as an em dash, never as 0.0 degrees', () => {
+    assert.equal(formatThreePointAngle({ kind: 'degenerate', degrees: 0 }), '—');
+  });
+
+  it('distinguishes a real zero from a degenerate one', () => {
+    assert.equal(formatThreePointAngle({ kind: 'zero', degrees: 0 }), '0.0°');
+  });
+
+  it('labels a straight angle rather than printing a bare 180', () => {
+    assert.equal(formatThreePointAngle({ kind: 'straight', degrees: 180 }), '180.0°  straight');
+  });
+
+  it('renders a measured angle to one decimal', () => {
+    assert.equal(formatThreePointAngle({ kind: 'angled', degrees: 36.8698976 }), '36.9°');
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Every fixture here is deliberately ASYMMETRIC — no 45 degree angles, no
+ * Every fixture here is deliberately ASYMMETRIC - no 45 degree angles, no
  * equilateral triangles, no unit-length rays.
  *
  * A symmetric fixture passes under argument swaps, folds and inversions, so it
@@ -25,7 +25,7 @@ const LEG_3 = { x: 0, y: 0, z: 3 };
 describe('threePointAngle', () => {
   it('measures at the APEX, not at either ray end', () => {
     // Apex at the right angle: 90. If the implementation measured at a ray end
-    // instead it would read 36.87 or 53.13 — both distinguishable.
+    // instead it would read 36.87 or 53.13 - both distinguishable.
     const r = threePointAngle(APEX_3_4_5, LEG_4, LEG_3);
     assert.equal(r.kind, 'angled');
     assert.ok(Math.abs(r.degrees - 90) < 1e-9, `expected 90, got ${r.degrees}`);
@@ -39,7 +39,7 @@ describe('threePointAngle', () => {
   });
 
   it('reports an obtuse angle unfolded: 120, not its 60 supplement', () => {
-    // The apex makes the answer directed — folding to [0,90] would answer a
+    // The apex makes the answer directed - folding to [0,90] would answer a
     // question the user did not ask.
     const apex = { x: 0, y: 0, z: 0 };
     const a = { x: 1, y: 0, z: 0 };
@@ -71,7 +71,7 @@ describe('threePointAngle', () => {
 
   it('refuses a ray shorter than one pick resolution', () => {
     // The exactly-coincident case is caught by `normalize` returning null, so
-    // it does NOT pin the threshold — with the guard removed, every other
+    // it does NOT pin the threshold - with the guard removed, every other
     // test in this file still passed.
     //
     // The threshold is the SNAP FLOOR (1/65536 m = 15.3 um), not an arbitrary
@@ -96,7 +96,7 @@ describe('threePointAngle', () => {
     // `packages/renderer/src/snap-weld.ts` rather than importing it (this
     // module has no renderer dependency). If the renderer's floor moves and
     // this does not, the thresholds above silently stop matching pick
-    // resolution — so the value is pinned here explicitly.
+    // resolution - so the value is pinned here explicitly.
     assert.equal(1 / 65536, 0.0000152587890625);
   });
 
@@ -122,7 +122,7 @@ describe('threePointAngle', () => {
     // pointing along it. atan2(|cross|, dot) has no domain restriction.
     //
     // My first version of this test used two hand-written near-opposite rays
-    // and passed under BOTH implementations — it asserted a property it could
+    // and passed under BOTH implementations - it asserted a property it could
     // not observe. This one was found by search and verified to NaN.
     const v = { x: 0.010309278033673763, y: 0.02247191034257412, z: 0.022900763899087906 };
     const apex = { x: 0, y: 0, z: 0 };
@@ -137,7 +137,7 @@ describe('threePointAngle', () => {
     // snap-weld.ts:43-54 argues a fixed angle is the wrong primitive: too
     // tight for short rays far from the origin, too loose for long ones near
     // it. A 5 mm perpendicular dogleg is a REAL corner on a 0.2 m ray and is
-    // still a real corner on a 200 m one — an angle band would call the
+    // still a real corner on a 200 m one - an angle band would call the
     // second one straight.
     const apex = { x: 0, y: 0, z: 0 };
     const shortRay = threePointAngle(apex, { x: 0.2, y: 0, z: 0 }, { x: -0.2, y: 0.005, z: 0 });
@@ -158,7 +158,7 @@ describe('threePointAngle', () => {
 
 describe('formatThreePointAngle', () => {
   it('renders a degenerate pick as an em dash, never as 0.0 degrees', () => {
-    assert.equal(formatThreePointAngle({ kind: 'degenerate', degrees: 0 }), '—');
+    assert.equal(formatThreePointAngle({ kind: 'degenerate', degrees: 0 }), '-');
   });
 
   it('distinguishes a real zero from a degenerate one', () => {

--- a/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
@@ -39,10 +39,10 @@ const PICK_RESOLUTION_M = 1 / 65536;
  * Below this a ray has no usable direction.
  *
  * Tied to pick resolution, NOT to an arbitrarily small epsilon. An earlier
- * version used 1e-9 m - 15,259x BELOW the snap floor - so no reachable input
- * could ever land in the band (0, 1e-9]: the guard classified nothing, and
- * the test that "pinned it from both sides" pinned a constant with no
- * behavioural consequence. A ray shorter than one pick resolution has a
+ * version used 1e-9 m, which is 15,259x BELOW the snap floor, so no
+ * reachable input could ever land in the band (0, 1e-9]: the guard
+ * classified nothing, and the test that "pinned it from both sides" pinned a
+ * constant with no behavioural consequence. A ray shorter than one pick resolution has a
  * direction made entirely of cursor noise, and that is what is worth
  * refusing to measure.
  */

--- a/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
@@ -11,7 +11,7 @@
  * correction here retroactively fixes every measurement already on screen.
  *
  * WHY ONLY DEGREES. #2199 asked for degrees, percent slope and 1:n ratio.
- * Percent and ratio express rise over run against a HORIZONTAL reference —
+ * Percent and ratio express rise over run against a HORIZONTAL reference -
  * that is what makes them meaningful for `inclination.ts`, whose reference is
  * the ground plane. Three arbitrary picks have no such reference: the same
  * 30 degree angle can sit in any orientation, and printing "58%" beside it
@@ -39,7 +39,7 @@ const PICK_RESOLUTION_M = 1 / 65536;
  * Below this a ray has no usable direction.
  *
  * Tied to pick resolution, NOT to an arbitrarily small epsilon. An earlier
- * version used 1e-9 m — 15,259x BELOW the snap floor — so no reachable input
+ * version used 1e-9 m - 15,259x BELOW the snap floor - so no reachable input
  * could ever land in the band (0, 1e-9]: the guard classified nothing, and
  * the test that "pinned it from both sides" pinned a constant with no
  * behavioural consequence. A ray shorter than one pick resolution has a
@@ -71,7 +71,7 @@ const COLLINEAR_OFFSET_M = PICK_RESOLUTION_M;
  *
  * `degenerate` and `zero` both produce 0 degrees, so a formatter without a
  * discriminator would have to render "I measured nothing" and "I measured a
- * real zero angle" identically — the same trap `InclinationKind` exists to
+ * real zero angle" identically - the same trap `InclinationKind` exists to
  * avoid.
  */
 export type ThreePointAngleKind =
@@ -90,8 +90,8 @@ export interface ThreePointAngle {
    * The angle at the apex in degrees, always in [0, 180].
    *
    * UNSIGNED and unfolded. Unsigned because a sign would need a reference
-   * plane the three picks do not carry. Unfolded — 120 stays 120 rather than
-   * folding to 60 — because the apex makes the answer directed: the user
+   * plane the three picks do not carry. Unfolded - 120 stays 120 rather than
+   * folding to 60 - because the apex makes the answer directed: the user
    * pointed at a specific corner, and reporting its supplement would answer a
    * question they did not ask. (Edge-to-edge angle, where no apex is picked,
    * is the case that genuinely has to fold; see #2735's later slice.)
@@ -127,7 +127,7 @@ export function threePointAngle(
   const degrees = angleBetweenDeg(ua, ub);
 
   // Perpendicular offset of b from the apex->a line. `ua` is unit, so
-  // |ua x rb| IS that distance — no division, and it scales with rb's length
+  // |ua x rb| IS that distance - no division, and it scales with rb's length
   // exactly as the tolerance argument above requires.
   if (norm(cross(ua, rb)) <= collinearOffsetM) {
     // Collinear. Which of the two collinear answers is a question of
@@ -147,7 +147,7 @@ export function threePointAngle(
 export function formatThreePointAngle(r: ThreePointAngle): string {
   switch (r.kind) {
     case 'degenerate':
-      return '—';
+      return '-';
     case 'zero':
       return '0.0°';
     case 'straight':

--- a/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Three-point angle: the angle AT an apex, between rays to two other picks
+ * (#2735, split from #2199 §4).
+ *
+ * Pure display maths over three stored points, exactly like `inclination.ts`
+ * and `polyline.ts`: nothing is persisted beyond the picks themselves, so a
+ * correction here retroactively fixes every measurement already on screen.
+ *
+ * WHY ONLY DEGREES. #2199 asked for degrees, percent slope and 1:n ratio.
+ * Percent and ratio express rise over run against a HORIZONTAL reference —
+ * that is what makes them meaningful for `inclination.ts`, whose reference is
+ * the ground plane. Three arbitrary picks have no such reference: the same
+ * 30 degree angle can sit in any orientation, and printing "58%" beside it
+ * would attach a gradient reading to a quantity that is not a gradient. The
+ * formats belong to the measurement, not to the tool.
+ */
+
+import { angleBetweenDeg, normalize, sub, type Point3 } from './angle-vec';
+
+/**
+ * Below this the two rays are treated as pointing the same way, or exactly
+ * opposite ways, rather than as a very small or very large angle.
+ *
+ * This is not cosmetic rounding. Picks snap to welded vertices and to the
+ * merged collinear runs `snap-edge-runs.ts` reconstructs, so three picks along
+ * one straight edge is a REACHABLE input, not a pathological one — the apex
+ * lands on an interior junction of a run whose endpoints are the other two
+ * picks. Exact 180 never survives the f32 round trip, so without a band that
+ * case reports something like 179.9997 degrees and the reader is left to
+ * decide whether that is a real dogleg.
+ */
+const COLLINEAR_TOLERANCE_DEG = 0.01;
+
+/** Below this a ray has no direction: the apex and that pick coincide. */
+const DEGENERATE_LENGTH_M = 1e-9;
+
+/**
+ * Which of the four genuinely different answers three picks have.
+ *
+ * `degenerate` and `zero` both produce 0 degrees, so a formatter without a
+ * discriminator would have to render "I measured nothing" and "I measured a
+ * real zero angle" identically — the same trap `InclinationKind` exists to
+ * avoid.
+ */
+export type ThreePointAngleKind =
+  /** A ray has no length: the apex coincides with one of the other picks. */
+  | 'degenerate'
+  /** Both rays point the same way: a real 0 degrees. */
+  | 'zero'
+  /** The picks are collinear with the apex between them: a real 180 degrees. */
+  | 'straight'
+  /** A real angle strictly between 0 and 180. */
+  | 'angled';
+
+export interface ThreePointAngle {
+  kind: ThreePointAngleKind;
+  /**
+   * The angle at the apex in degrees, always in [0, 180].
+   *
+   * UNSIGNED and unfolded. Unsigned because a sign would need a reference
+   * plane the three picks do not carry. Unfolded — 120 stays 120 rather than
+   * folding to 60 — because the apex makes the answer directed: the user
+   * pointed at a specific corner, and reporting its supplement would answer a
+   * question they did not ask. (Edge-to-edge angle, where no apex is picked,
+   * is the case that genuinely has to fold; see #2735's later slice.)
+   */
+  degrees: number;
+}
+
+/**
+ * Angle at `apex` between the rays `apex -> a` and `apex -> b`.
+ *
+ * The apex is the FIRST argument because it is the first pick: the user picks
+ * the corner, then the two directions from it.
+ */
+export function threePointAngle(
+  apex: Point3,
+  a: Point3,
+  b: Point3,
+  degenerateLengthM: number = DEGENERATE_LENGTH_M,
+  collinearToleranceDeg: number = COLLINEAR_TOLERANCE_DEG,
+): ThreePointAngle {
+  const ra = sub(a, apex);
+  const rb = sub(b, apex);
+
+  // Guard BEFORE normalising: a zero-length ray has no direction, and
+  // `normalize` would hand back null for it anyway. Checking length here lets
+  // the caller tune the threshold in metres, which is the unit picks arrive in.
+  const ua = normalize(ra);
+  const ub = normalize(rb);
+  if (!ua || !ub || Math.hypot(ra.x, ra.y, ra.z) <= degenerateLengthM || Math.hypot(rb.x, rb.y, rb.z) <= degenerateLengthM) {
+    return { kind: 'degenerate', degrees: 0 };
+  }
+
+  const degrees = angleBetweenDeg(ua, ub);
+
+  if (degrees <= collinearToleranceDeg) return { kind: 'zero', degrees: 0 };
+  if (degrees >= 180 - collinearToleranceDeg) return { kind: 'straight', degrees: 180 };
+  return { kind: 'angled', degrees };
+}
+
+/**
+ * One-line readout, e.g. `36.9°`.
+ *
+ * `degenerate` renders an em dash rather than `0.0°`, following
+ * `formatInclination`: nothing was measured, so claiming a zero angle would
+ * state a fact the picks never established.
+ */
+export function formatThreePointAngle(r: ThreePointAngle): string {
+  switch (r.kind) {
+    case 'degenerate':
+      return '—';
+    case 'zero':
+      return '0.0°';
+    case 'straight':
+      return '180.0°  straight';
+    case 'angled':
+      return `${r.degrees.toFixed(1)}°`;
+  }
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/three-point-angle.ts
@@ -19,24 +19,52 @@
  * formats belong to the measurement, not to the tool.
  */
 
-import { angleBetweenDeg, normalize, sub, type Point3 } from './angle-vec';
+import { angleBetweenDeg, cross, dot, norm, normalize, sub, type Point3 } from './angle-vec';
 
 /**
- * Below this the two rays are treated as pointing the same way, or exactly
- * opposite ways, rather than as a very small or very large angle.
+ * Pick resolution: the snap layer's own floor, `MIN_SNAP_TOLERANCE` in
+ * `packages/renderer/src/snap-weld.ts` (the CSG kernel's reconcile grid,
+ * 1/65536 m = 15.3 um). Mirrored rather than imported because this module is
+ * pure display maths with no renderer dependency; the sibling test pins the
+ * two together.
  *
- * This is not cosmetic rounding. Picks snap to welded vertices and to the
- * merged collinear runs `snap-edge-runs.ts` reconstructs, so three picks along
- * one straight edge is a REACHABLE input, not a pathological one — the apex
- * lands on an interior junction of a run whose endpoints are the other two
- * picks. Exact 180 never survives the f32 round trip, so without a band that
- * case reports something like 179.9997 degrees and the reader is left to
- * decide whether that is a real dogleg.
+ * Two picks closer than this are the SAME pick as far as the snap layer is
+ * concerned: vertex snapping returns the WELDED REPRESENTATIVE point, so two
+ * picks on one vertex come back byte-identical, and two distinct snapped
+ * picks are at least this far apart.
  */
-const COLLINEAR_TOLERANCE_DEG = 0.01;
+const PICK_RESOLUTION_M = 1 / 65536;
 
-/** Below this a ray has no direction: the apex and that pick coincide. */
-const DEGENERATE_LENGTH_M = 1e-9;
+/**
+ * Below this a ray has no usable direction.
+ *
+ * Tied to pick resolution, NOT to an arbitrarily small epsilon. An earlier
+ * version used 1e-9 m — 15,259x BELOW the snap floor — so no reachable input
+ * could ever land in the band (0, 1e-9]: the guard classified nothing, and
+ * the test that "pinned it from both sides" pinned a constant with no
+ * behavioural consequence. A ray shorter than one pick resolution has a
+ * direction made entirely of cursor noise, and that is what is worth
+ * refusing to measure.
+ */
+const DEGENERATE_LENGTH_M = PICK_RESOLUTION_M;
+
+/**
+ * Collinearity is judged as a PERPENDICULAR DISTANCE, not as an angle.
+ *
+ * `snap-weld.ts:43-54` makes this argument and this module follows it: "An
+ * angle tolerance would be the wrong primitive here", because a fixed angle is
+ * simultaneously too tight for short rays far from the origin and too loose
+ * for long ones near it. Measured against the snap layer's own noise, a fixed
+ * 0.01 degree band is ESCAPED by a genuinely straight triple at 100 m
+ * coordinates with 10 cm rays (~0.014 degrees of direction noise), while at
+ * 2 m rays the same band is ~14x wider than the noise and folds real
+ * sub-millimetre doglegs into "straight".
+ *
+ * So: the far pick is collinear when its perpendicular offset from the
+ * apex->a line is within pick resolution. That scales with ray length for
+ * free, and is expressed in the unit the snap layer actually guarantees.
+ */
+const COLLINEAR_OFFSET_M = PICK_RESOLUTION_M;
 
 /**
  * Which of the four genuinely different answers three picks have.
@@ -82,7 +110,7 @@ export function threePointAngle(
   a: Point3,
   b: Point3,
   degenerateLengthM: number = DEGENERATE_LENGTH_M,
-  collinearToleranceDeg: number = COLLINEAR_TOLERANCE_DEG,
+  collinearOffsetM: number = COLLINEAR_OFFSET_M,
 ): ThreePointAngle {
   const ra = sub(a, apex);
   const rb = sub(b, apex);
@@ -98,8 +126,14 @@ export function threePointAngle(
 
   const degrees = angleBetweenDeg(ua, ub);
 
-  if (degrees <= collinearToleranceDeg) return { kind: 'zero', degrees: 0 };
-  if (degrees >= 180 - collinearToleranceDeg) return { kind: 'straight', degrees: 180 };
+  // Perpendicular offset of b from the apex->a line. `ua` is unit, so
+  // |ua x rb| IS that distance — no division, and it scales with rb's length
+  // exactly as the tolerance argument above requires.
+  if (norm(cross(ua, rb)) <= collinearOffsetM) {
+    // Collinear. Which of the two collinear answers is a question of
+    // DIRECTION, which a perpendicular offset cannot tell apart.
+    return dot(ua, ub) >= 0 ? { kind: 'zero', degrees: 0 } : { kind: 'straight', degrees: 180 };
+  }
   return { kind: 'angled', degrees };
 }
 

--- a/apps/viewer/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/viewer/src/hooks/useKeyboardShortcuts.ts
@@ -301,7 +301,7 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions = {}) {
       // Same for a part-finished angle sequence (#2735). Its own branch for
       // the same reason: at most one of activeMeasurement / activePolyline /
       // activeAngle is non-null at a time, and merging them would hide that.
-      // No Enter counterpart — an angle finishes itself on its last pick, so
+      // No Enter counterpart - an angle finishes itself on its last pick, so
       // there is no "finish early" state to confirm.
       if (key === 'escape' && activeAngle) {
         e.preventDefault();

--- a/apps/viewer/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/viewer/src/hooks/useKeyboardShortcuts.ts
@@ -61,6 +61,9 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions = {}) {
   // Polyline (multi-click) mode (#2199).
   const activePolyline = useViewerStore((s) => s.activePolyline);
   const cancelPolyline = useViewerStore((s) => s.cancelPolyline);
+  // Angle (fixed-count multi-click) mode (#2735).
+  const activeAngle = useViewerStore((s) => s.activeAngle);
+  const cancelAngle = useViewerStore((s) => s.cancelAngle);
   const finishPolyline = useViewerStore((s) => s.finishPolyline);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
@@ -295,6 +298,16 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions = {}) {
         cancelPolyline();
         return;
       }
+      // Same for a part-finished angle sequence (#2735). Its own branch for
+      // the same reason: at most one of activeMeasurement / activePolyline /
+      // activeAngle is non-null at a time, and merging them would hide that.
+      // No Enter counterpart — an angle finishes itself on its last pick, so
+      // there is no "finish early" state to confirm.
+      if (key === 'escape' && activeAngle) {
+        e.preventDefault();
+        cancelAngle();
+        return;
+      }
       // Finish an in-progress polyline as OPEN with Enter (#2199) — reports
       // the sum-of-segments length, not a perimeter. Closing the loop is a
       // click gesture, not a keyboard one (see handlePolylineClick).
@@ -395,7 +408,7 @@ export function useKeyboardShortcuts(options: KeyboardShortcutsOptions = {}) {
     clearMeasurements,
     toggleSnap,
     toggleEditEnabled,
-    activePolyline,
+    activePolyline, activeAngle, cancelAngle,
     cancelPolyline,
     finishPolyline,
   ]);

--- a/apps/viewer/src/store/slices/measurementSlice.angle.test.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.angle.test.ts
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Store behaviour for angle mode (#2735).
+ *
+ * The reset-home tests below are the ones that matter most. This slice
+ * documents a #2199 regression where a hand-maintained reset list silently
+ * missed newly added fields, so each reset is asserted by the VALUE it leaves
+ * behind — deleting a field from a reset object flips a named test rather than
+ * passing because nothing looked at it.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createMeasurementSlice, type MeasurementSlice } from './measurementSlice.js';
+import type { AnglePick } from '../types.js';
+
+const P = (x: number, y: number, z: number): AnglePick => ({
+  kind: 'points',
+  point: { x, y, z, screenX: 0, screenY: 0 },
+});
+
+describe('angle mode store (#2735)', () => {
+  let state: MeasurementSlice;
+
+  beforeEach(() => {
+    const setState = (partial: any) => {
+      state = typeof partial === 'function'
+        ? { ...state, ...partial(state) }
+        : { ...state, ...partial };
+    };
+    state = createMeasurementSlice(setState as any, (() => state) as any, {} as any);
+  });
+
+  const s = () => state;
+
+  it('finishes itself on the THIRD pick and clears the in-progress sequence', () => {
+    s().setMeasureMode('angle');
+    s().addAnglePick(P(0, 0, 0));
+    assert.equal(s().activeAngle?.picks.length, 1);
+    s().addAnglePick(P(4, 0, 0));
+    assert.equal(s().activeAngle?.picks.length, 2);
+    assert.equal(s().angleMeasurements.length, 0, 'must not finish early');
+    s().addAnglePick(P(0, 0, 3));
+    assert.equal(s().activeAngle, null, 'the sequence must clear on completion');
+    assert.equal(s().angleMeasurements.length, 1);
+    assert.equal(s().angleMeasurements[0].picks.length, 3);
+  });
+
+  it('rejects a pick whose kind does not match the active angleKind', () => {
+    s().setMeasureMode('angle');
+    s().addAnglePick({ ...P(0, 0, 0), kind: 'edges' });
+    assert.equal(s().activeAngle, null, 'a mismatched pick must not start a sequence');
+  });
+
+  it('leaving angle mode discards an in-progress sequence', () => {
+    s().setMeasureMode('angle');
+    s().addAnglePick(P(0, 0, 0));
+    assert.equal(s().activeAngle?.picks.length, 1);
+    s().setMeasureMode('drag');
+    assert.equal(s().activeAngle, null);
+  });
+
+  it('entering angle mode cancels an in-progress drag measurement', () => {
+    s().setMeasureMode('angle');
+    assert.equal(s().activeMeasurement, null);
+    assert.equal(s().snapTarget, null);
+  });
+
+  it('switching angleKind discards the picks already taken', () => {
+    s().setMeasureMode('angle');
+    s().addAnglePick(P(0, 0, 0));
+    s().setAngleKind('edges');
+    assert.equal(s().activeAngle, null);
+    assert.equal(s().angleKind, 'edges');
+  });
+
+  it('clearMeasurements empties BOTH the finished list and the in-progress sequence', () => {
+    s().setMeasureMode('angle');
+    s().addAnglePick(P(0, 0, 0));
+    s().addAnglePick(P(4, 0, 0));
+    s().addAnglePick(P(0, 0, 3));
+    s().addAnglePick(P(1, 1, 1));
+    assert.equal(s().angleMeasurements.length, 1);
+    assert.equal(s().activeAngle?.picks.length, 1);
+    s().clearMeasurements();
+    assert.deepEqual(s().angleMeasurements, [], 'a finished angle must not survive "clear all"');
+    assert.equal(s().activeAngle, null, 'a partial sequence left behind by clear is a stale trap');
+  });
+
+  it('resetMeasureGesture drops the in-progress sequence but keeps finished ones', () => {
+    s().setMeasureMode('angle');
+    s().addAnglePick(P(0, 0, 0));
+    s().addAnglePick(P(4, 0, 0));
+    s().addAnglePick(P(0, 0, 3));
+    s().addAnglePick(P(1, 1, 1));
+    s().resetMeasureGesture();
+    assert.equal(s().activeAngle, null);
+    assert.equal(s().angleMeasurements.length, 1, 'leaving the tool must not delete measurements');
+  });
+
+  it('resetAllMeasurementState returns every angle field to its default', () => {
+    s().setMeasureMode('angle');
+    s().setAngleKind('faces');
+    s().addAnglePick({ ...P(0, 0, 0), kind: 'faces' });
+    s().resetAllMeasurementState();
+    assert.equal(s().angleKind, 'points', 'a new file is a new scene');
+    assert.equal(s().activeAngle, null);
+    assert.deepEqual(s().angleMeasurements, []);
+  });
+
+  it('deleteAngleMeasurement removes only the named measurement', () => {
+    s().setMeasureMode('angle');
+    for (const p of [P(0, 0, 0), P(4, 0, 0), P(0, 0, 3)]) s().addAnglePick(p);
+    for (const p of [P(1, 0, 0), P(2, 0, 0), P(1, 0, 2)]) s().addAnglePick(p);
+    assert.equal(s().angleMeasurements.length, 2);
+    s().deleteAngleMeasurement(s().angleMeasurements[0].id);
+    assert.equal(s().angleMeasurements.length, 1);
+  });
+});

--- a/apps/viewer/src/store/slices/measurementSlice.angle.test.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.angle.test.ts
@@ -25,14 +25,24 @@ const P = (x: number, y: number, z: number): AnglePick => ({
 
 describe('angle mode store (#2735)', () => {
   let state: MeasurementSlice;
+  let setState: (
+    partial: Partial<MeasurementSlice> | ((state: MeasurementSlice) => Partial<MeasurementSlice>),
+  ) => void;
+  let getState: () => MeasurementSlice;
 
   beforeEach(() => {
-    const setState = (partial: any) => {
+    // Typed shims rather than `as any`, matching the adjacent
+    // `measurementSlice.test.ts`: an `any`-cast mock would let an incompatible
+    // signature go undetected, which is the one thing a store test exists to
+    // catch. Only the third argument (the zustand StoreApi, unused by this
+    // slice) keeps its cast, as it does there.
+    setState = (partial) => {
       state = typeof partial === 'function'
         ? { ...state, ...partial(state) }
         : { ...state, ...partial };
     };
-    state = createMeasurementSlice(setState as any, (() => state) as any, {} as any);
+    getState = () => state;
+    state = createMeasurementSlice(setState, getState, {} as never);
   });
 
   const s = () => state;
@@ -64,9 +74,16 @@ describe('angle mode store (#2735)', () => {
     assert.equal(s().activeAngle, null);
   });
 
-  it('entering angle mode cancels an in-progress drag measurement', () => {
+  it('entering angle mode cancels an IN-PROGRESS drag measurement', () => {
+    // The earlier version of this test asserted `activeMeasurement === null`
+    // straight after switching mode — but the slice STARTS with it null, so it
+    // passed even if `setMeasureMode` stopped clearing drag state entirely.
+    // A drag has to exist before cancelling it means anything.
+    s().startMeasurement({ x: 1, y: 2, z: 3, screenX: 10, screenY: 20 });
+    assert.notEqual(s().activeMeasurement, null, 'precondition: a drag is in progress');
+
     s().setMeasureMode('angle');
-    assert.equal(s().activeMeasurement, null);
+    assert.equal(s().activeMeasurement, null, 'switching to angle must cancel the drag');
     assert.equal(s().snapTarget, null);
   });
 

--- a/apps/viewer/src/store/slices/measurementSlice.angle.test.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.angle.test.ts
@@ -8,7 +8,7 @@
  * The reset-home tests below are the ones that matter most. This slice
  * documents a #2199 regression where a hand-maintained reset list silently
  * missed newly added fields, so each reset is asserted by the VALUE it leaves
- * behind — deleting a field from a reset object flips a named test rather than
+ * behind - deleting a field from a reset object flips a named test rather than
  * passing because nothing looked at it.
  */
 
@@ -76,7 +76,7 @@ describe('angle mode store (#2735)', () => {
 
   it('entering angle mode cancels an IN-PROGRESS drag measurement', () => {
     // The earlier version of this test asserted `activeMeasurement === null`
-    // straight after switching mode — but the slice STARTS with it null, so it
+    // straight after switching mode - but the slice STARTS with it null, so it
     // passed even if `setMeasureMode` stopped clearing drag state entirely.
     // A drag has to exist before cancelling it means anything.
     s().startMeasurement({ x: 1, y: 2, z: 3, screenX: 10, screenY: 20 });

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -86,7 +86,7 @@ export interface MeasurementSlice {
   angleKind: AngleKind;
   /** A fixed-length angle sequence in progress, or null. */
   activeAngle: ActiveAngle | null;
-  /** Finished angle measurements. Picks only — degrees are derived on render. */
+  /** Finished angle measurements. Picks only - degrees are derived on render. */
   angleMeasurements: AngleMeasurement[];
   /** Finished polyline measurements — kept separate from `measurements`
    *  (distance-only) rather than folded in, since they carry an extra basis
@@ -139,7 +139,7 @@ export interface MeasurementSlice {
   setAngleKind: (kind: AngleKind) => void;
   /**
    * Append a pick. When the sequence reaches `ANGLE_REQUIRED_PICKS[kind]` it
-   * finishes ITSELF into `angleMeasurements` — there is no finish gesture, so
+   * finishes ITSELF into `angleMeasurements` - there is no finish gesture, so
    * unlike `finishPolyline` there is no double-click duplicate to defend
    * against.
    */
@@ -514,7 +514,7 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
     // Symmetric: discard the state of the mode being LEFT, and cancel any
     // in-progress drag when entering a click-driven mode. Written as spread
     // arms over one object rather than per-mode early returns so adding a
-    // fourth mode cannot leave an arm behind — the regression this slice
+    // fourth mode cannot leave an arm behind - the regression this slice
     // documents at `resetAllMeasurementState` was exactly a hand-maintained
     // list that missed a newly added field.
     const leaving = state.measureMode;

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -418,6 +418,25 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
       points: m.points.map(reprojectPoint),
     }));
 
+    // Angle picks (#2735) need the same treatment, and for the same reason the
+    // polyline comment above gives: the overlay draws its rays and label from
+    // `screenX/screenY`, so without reprojection every finished angle would
+    // stay frozen at its click-time pixel while the model orbits underneath.
+    // `reprojectPoint` sets `hasChanges` itself, so an angle moving is enough
+    // to defeat the early exit below even when nothing else changed.
+    let updatedActiveAngle = state.activeAngle;
+    if (state.activeAngle) {
+      updatedActiveAngle = {
+        ...state.activeAngle,
+        picks: state.activeAngle.picks.map((pick) => ({ ...pick, point: reprojectPoint(pick.point) })),
+      };
+    }
+
+    const updatedAngleMeasurements = state.angleMeasurements.map((m) => ({
+      ...m,
+      picks: m.picks.map((pick) => ({ ...pick, point: reprojectPoint(pick.point) })),
+    }));
+
     // Early exit if nothing changed
     if (!hasChanges) {
       return;
@@ -428,6 +447,8 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
       activeMeasurement: updatedActiveMeasurement,
       activePolyline: updatedActivePolyline,
       polylineMeasurements: updatedPolylineMeasurements,
+      activeAngle: updatedActiveAngle,
+      angleMeasurements: updatedAngleMeasurements,
     });
   },
 

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -20,7 +20,12 @@ import type {
   MeasureMode,
   ActivePolyline,
   PolylineMeasurement,
+  ActiveAngle,
+  AngleKind,
+  AngleMeasurement,
+  AnglePick,
 } from '../types.js';
+import { ANGLE_REQUIRED_PICKS } from '../types.js';
 import { EDGE_LOCK_DEFAULTS } from '../constants.js';
 import { polylineLength } from '@/components/viewer/tools/measure-modes/polyline.js';
 import { isDuplicateClickPoint } from '@/components/viewer/measureHandlers.js';
@@ -77,6 +82,12 @@ export interface MeasurementSlice {
   measureMode: MeasureMode;
   /** A polyline sequence in progress (points accumulated via clicks, not yet finished). */
   activePolyline: ActivePolyline | null;
+  /** Which angle the tool measures when `measureMode === 'angle'` (#2735). */
+  angleKind: AngleKind;
+  /** A fixed-length angle sequence in progress, or null. */
+  activeAngle: ActiveAngle | null;
+  /** Finished angle measurements. Picks only — degrees are derived on render. */
+  angleMeasurements: AngleMeasurement[];
   /** Finished polyline measurements — kept separate from `measurements`
    *  (distance-only) rather than folded in, since they carry an extra basis
    *  (open length vs. closed perimeter) that a drag measurement never has. */
@@ -124,6 +135,17 @@ export interface MeasurementSlice {
    *  leaving 'polyline' discards any in-progress click sequence. A no-op if
    *  already in the requested mode (does not disturb in-progress state). */
   setMeasureMode: (mode: MeasureMode) => void;
+  /** Switch which angle is measured. Discards any in-progress sequence. */
+  setAngleKind: (kind: AngleKind) => void;
+  /**
+   * Append a pick. When the sequence reaches `ANGLE_REQUIRED_PICKS[kind]` it
+   * finishes ITSELF into `angleMeasurements` — there is no finish gesture, so
+   * unlike `finishPolyline` there is no double-click duplicate to defend
+   * against.
+   */
+  addAnglePick: (pick: AnglePick) => void;
+  cancelAngle: () => void;
+  deleteAngleMeasurement: (id: string) => void;
   /** Begin a polyline sequence at `point`. No-op if one is already active —
    *  use {@link addPolylinePoint} to extend it. */
   startPolyline: (point: MeasurePoint) => void;
@@ -214,6 +236,9 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   measureMode: 'drag',
   activePolyline: null,
   polylineMeasurements: [],
+  angleKind: 'points',
+  activeAngle: null,
+  angleMeasurements: [],
 
   // Legacy measurement actions
   addMeasurePoint: (point) => set({ pendingMeasurePoint: point }),
@@ -304,6 +329,8 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
     // click-sequence left behind by "clear" would be a stale trap.
     activePolyline: null,
     polylineMeasurements: [],
+    activeAngle: null,
+    angleMeasurements: [],
   }),
 
   updateMeasurementScreenCoords: (projectToScreen) => {
@@ -463,19 +490,56 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   // Polyline (multi-click) measurement actions (#2199)
   setMeasureMode: (mode) => set((state) => {
     if (mode === state.measureMode) return {};
-    if (mode === 'polyline') {
-      // Entering polyline mode: cancel any in-progress drag so the two
-      // gestures can never both be "active" at once.
-      return {
-        measureMode: mode,
-        activeMeasurement: null,
-        snapTarget: null,
-        measurementConstraintEdge: null,
-      };
-    }
-    // Leaving polyline mode: discard any in-progress click sequence.
-    return { measureMode: mode, activePolyline: null };
+    // Symmetric: discard the state of the mode being LEFT, and cancel any
+    // in-progress drag when entering a click-driven mode. Written as spread
+    // arms over one object rather than per-mode early returns so adding a
+    // fourth mode cannot leave an arm behind — the regression this slice
+    // documents at `resetAllMeasurementState` was exactly a hand-maintained
+    // list that missed a newly added field.
+    const leaving = state.measureMode;
+    return {
+      measureMode: mode,
+      ...(leaving === 'polyline' ? { activePolyline: null } : {}),
+      ...(leaving === 'angle' ? { activeAngle: null } : {}),
+      ...(mode !== 'drag'
+        ? { activeMeasurement: null, snapTarget: null, measurementConstraintEdge: null }
+        : {}),
+    };
   }),
+
+  setAngleKind: (kind) => set((state) => {
+    if (kind === state.angleKind) return {};
+    // Switching kind mid-sequence discards it: picks already taken mean
+    // something different under the new kind.
+    return { angleKind: kind, activeAngle: null };
+  }),
+
+  addAnglePick: (pick) => set((state) => {
+    const kind = state.angleKind;
+    // Defence in depth: the handler filters by kind, but a mismatched pick
+    // reaching the store would produce an angle measured from the wrong sort
+    // of input, silently.
+    if (pick.kind !== kind) return {};
+    const prior = state.activeAngle?.kind === kind ? state.activeAngle.picks : [];
+    const picks = [...prior, pick];
+    if (picks.length < ANGLE_REQUIRED_PICKS[kind]) {
+      return { activeAngle: { kind, picks } };
+    }
+    measurementCounter++;
+    return {
+      activeAngle: null,
+      angleMeasurements: [
+        ...state.angleMeasurements,
+        { id: `ang-${Date.now()}-${measurementCounter}`, kind, picks },
+      ],
+    };
+  }),
+
+  cancelAngle: () => set({ activeAngle: null }),
+
+  deleteAngleMeasurement: (id) => set((state) => ({
+    angleMeasurements: state.angleMeasurements.filter((m) => m.id !== id),
+  })),
 
   startPolyline: (point) => set((state) => {
     if (state.activePolyline) return {}; // already accumulating — use addPolylinePoint
@@ -559,6 +623,7 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
   resetMeasureGesture: () => set({
     activeMeasurement: null,
     activePolyline: null,
+    activeAngle: null,
     snapTarget: null,
     measurementConstraintEdge: null,
   }),
@@ -577,5 +642,8 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
     measureMode: 'drag',
     activePolyline: null,
     polylineMeasurements: [],
+    angleKind: 'points',
+    activeAngle: null,
+    angleMeasurements: [],
   }),
 });

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -39,11 +39,12 @@ export interface ActiveMeasurement {
 /**
  * Which gesture the Measure tool is currently listening for. `'drag'` is the
  * original mousedown→mouseup distance measurement (unchanged by this mode).
- * `'polyline'` accumulates points via successive clicks instead; the two are
- * mutually exclusive so a sequence started in one can never leak state into
- * the other (see `setMeasureMode` in measurementSlice.ts).
+ * `'polyline'` accumulates points via successive clicks instead; `'angle'`
+ * (#2735) accumulates a FIXED number of clicks and finishes itself. All three
+ * are mutually exclusive so a sequence started in one can never leak state
+ * into another (see `setMeasureMode` in measurementSlice.ts).
  */
-export type MeasureMode = 'drag' | 'polyline';
+export type MeasureMode = 'drag' | 'polyline' | 'angle';
 
 /** A multi-click sequence in progress, not yet finished or cancelled. */
 export interface ActivePolyline {
@@ -62,6 +63,52 @@ export interface PolylineMeasurement {
   points: MeasurePoint[];
   closed: boolean;
   length: number;
+}
+
+// ============================================================================
+// Angle Measurement Types (issue #2735, split from #2199 §4)
+// ============================================================================
+
+/**
+ * Which angle the tool is measuring. Only `'points'` ships today; the edge and
+ * face kinds are the later slices of #2735 and are named here so the store
+ * shape does not have to change when they land.
+ */
+export type AngleKind = 'points' | 'edges' | 'faces';
+
+/** How many picks each kind needs before the measurement finishes itself. */
+export const ANGLE_REQUIRED_PICKS: Record<AngleKind, number> = {
+  points: 3,
+  edges: 2,
+  faces: 2,
+};
+
+/** One pick in an angle sequence. */
+export interface AnglePick {
+  kind: AngleKind;
+  point: MeasurePoint;
+}
+
+/** A fixed-length sequence in progress, not yet complete or cancelled. */
+export interface ActiveAngle {
+  kind: AngleKind;
+  picks: AnglePick[];
+}
+
+/**
+ * A finished angle measurement.
+ *
+ * Only the PICKS are stored, never the resulting degrees — the readout is
+ * derived on render by `threePointAngle`. That follows `inclination.ts` rather
+ * than `PolylineMeasurement` (which does store its `length`): an angle's value
+ * is pure maths over its picks, so deriving it means a correction to the maths
+ * retroactively fixes every measurement already on screen, and there is no
+ * second copy of the answer to fall out of step with the picks.
+ */
+export interface AngleMeasurement {
+  id: string;
+  kind: AngleKind;
+  picks: AnglePick[];
 }
 
 /** Orthogonal constraint axis type */

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -98,7 +98,7 @@ export interface ActiveAngle {
 /**
  * A finished angle measurement.
  *
- * Only the PICKS are stored, never the resulting degrees — the readout is
+ * Only the PICKS are stored, never the resulting degrees - the readout is
  * derived on render by `threePointAngle`. That follows `inclination.ts` rather
  * than `PolylineMeasurement` (which does store its `length`): an angle's value
  * is pure maths over its picks, so deriving it means a correction to the maths

--- a/apps/viewer/src/utils/viewportUtils.pendingMeasurements.test.ts
+++ b/apps/viewer/src/utils/viewportUtils.pendingMeasurements.test.ts
@@ -53,11 +53,11 @@ describe('hasPendingMeasurementState — animation-loop reprojection gate', () =
   });
 });
 
-describe('hasPendingMeasurementState — angle state (#2735)', () => {
+describe('hasPendingMeasurementState - angle state (#2735)', () => {
   it('an in-progress angle sequence keeps the reprojection pass running', () => {
     // This gate and `updateMeasurementScreenCoords` are a pair: reprojection
     // written there without an arm here is dead code, and the symptom is
-    // identical to having written none — placed picks freeze at their
+    // identical to having written none - placed picks freeze at their
     // click-time pixel while the model orbits. That is #2641's defect, and
     // this is its third occurrence.
     assert.equal(

--- a/apps/viewer/src/utils/viewportUtils.pendingMeasurements.test.ts
+++ b/apps/viewer/src/utils/viewportUtils.pendingMeasurements.test.ts
@@ -26,6 +26,8 @@ function base(): PendingMeasurementState {
     activeMeasurement: null,
     activePolyline: null,
     polylineMeasurements: { length: 0 },
+    activeAngle: null,
+    angleMeasurements: { length: 0 },
   };
 }
 
@@ -48,5 +50,26 @@ describe('hasPendingMeasurementState — animation-loop reprojection gate', () =
 
   it('is true for a FINISHED polyline with nothing else pending', () => {
     assert.equal(hasPendingMeasurementState({ ...base(), polylineMeasurements: { length: 1 } }), true);
+  });
+});
+
+describe('hasPendingMeasurementState — angle state (#2735)', () => {
+  it('an in-progress angle sequence keeps the reprojection pass running', () => {
+    // This gate and `updateMeasurementScreenCoords` are a pair: reprojection
+    // written there without an arm here is dead code, and the symptom is
+    // identical to having written none — placed picks freeze at their
+    // click-time pixel while the model orbits. That is #2641's defect, and
+    // this is its third occurrence.
+    assert.equal(
+      hasPendingMeasurementState({ ...base(), activeAngle: { kind: 'points', picks: [] } }),
+      true,
+    );
+  });
+
+  it('a finished angle measurement keeps it running too', () => {
+    assert.equal(
+      hasPendingMeasurementState({ ...base(), angleMeasurements: { length: 1 } }),
+      true,
+    );
   });
 });

--- a/apps/viewer/src/utils/viewportUtils.ts
+++ b/apps/viewer/src/utils/viewportUtils.ts
@@ -530,21 +530,33 @@ export interface PendingMeasurementState {
   /** Finished multi-click polylines (#2199) — their placed vertices still
    *  need reprojecting on every camera move, same as drag measurements. */
   polylineMeasurements: { length: number };
+  /** In-progress angle sequence (#2735), or null. */
+  activeAngle: unknown;
+  /** Finished angle measurements (#2735) — their picks are reprojected too. */
+  angleMeasurements: { length: number };
 }
 
 /**
  * True when there is any measurement state whose screen coordinates could
- * be stale after a camera move — drag-mode measurements/gesture, or
+ * be stale after a camera move — drag-mode measurements/gesture,
  * polyline-mode sequences/finished polylines (#2641 review defect: this used
  * to check only `measurements`/`activeMeasurement`, so with polyline-only
  * state the reprojection pass never ran and placed points, segments and
- * labels froze at their click-time screen position while orbiting).
+ * labels froze at their click-time screen position while orbiting), or angle
+ * sequences/measurements (#2735, the same defect a third time).
+ *
+ * This gate and `updateMeasurementScreenCoords` are a PAIR. Reprojection logic
+ * added there without an arm here is dead code for any state this gate does
+ * not recognise, and the symptom is identical to having written no
+ * reprojection at all.
  */
 export function hasPendingMeasurementState(state: PendingMeasurementState): boolean {
   return (
     state.measurements.length > 0 ||
     state.activeMeasurement !== null ||
     state.activePolyline !== null ||
-    state.polylineMeasurements.length > 0
+    state.polylineMeasurements.length > 0 ||
+    state.activeAngle !== null ||
+    state.angleMeasurements.length > 0
   );
 }

--- a/apps/viewer/src/utils/viewportUtils.ts
+++ b/apps/viewer/src/utils/viewportUtils.ts
@@ -532,13 +532,13 @@ export interface PendingMeasurementState {
   polylineMeasurements: { length: number };
   /** In-progress angle sequence (#2735), or null. */
   activeAngle: unknown;
-  /** Finished angle measurements (#2735) — their picks are reprojected too. */
+  /** Finished angle measurements (#2735) - their picks are reprojected too. */
   angleMeasurements: { length: number };
 }
 
 /**
  * True when there is any measurement state whose screen coordinates could
- * be stale after a camera move — drag-mode measurements/gesture,
+ * be stale after a camera move - drag-mode measurements/gesture,
  * polyline-mode sequences/finished polylines (#2641 review defect: this used
  * to check only `measurements`/`activeMeasurement`, so with polyline-only
  * state the reprojection pass never ran and placed points, segments and


### PR DESCRIPTION
First slice of #2735 (split from #2199 §4). Pick an apex, then two directions; the angle at the apex is reported in the Measure panel. Cycle to it with the panel's mode button (Distance → Polyline → Angle), Esc cancels a part-finished sequence.

Planned before writing code, and the plan **corrected two things in my own issue text** — both recorded on #2735:
- **#2655 already reconstructs topological edges**, so the tessellation-fragments constraint I wrote into the issue is stale and edge-edge is the *cheap* later slice, not the expensive one.
- **Face picking already exists** in the snap layer; only the measure interaction ignores it. No renderer work is needed for any kind.

## Design, following `inclination.ts`

**Enumerated outcomes, not a bare number.** `degenerate` (a ray with no length) and `zero` (a real 0°) both produce 0, so without a discriminator a formatter cannot tell *"I measured nothing"* from *"I measured a real zero"* and has to render one as the other. `straight` is split from `angled` for the same reason. `degenerate` renders an em dash.

**Derived, not stored.** `AngleMeasurement` keeps only its picks. Unlike `PolylineMeasurement` (which stores `length`), an angle is pure maths over its picks — so fixing the maths retroactively fixes every measurement on screen, and there is no second copy of the answer to drift.

**`atan2`, not `acos` — and the reason is NaN, not precision.** Measured: normalising an f32-derived vector leaves its own self-dot up to **6.7e-16 above 1**, and `acos` NaNs outside [-1,1]. Sampling 200k f32 direction vectors gave **44,915 NaNs**. It bites hardest on near-parallel rays, which is exactly what `zero`/`straight` classify. The precision argument does *not* carry — `acos`'s error peaks near 2.7e-9°, invisible at one decimal — and the doc comment says so rather than overstating it.

**The drag gate is now an allow-list.** `shouldStartDragMeasurement` tested `mode !== 'polyline'`; it now tests `mode === 'drag'`. The exclusion form is a deny-list: every new click-driven mode must remember to add itself, and forgetting means the drag gesture runs silently underneath it — two state machines live at once, the exact thing this single gate prevents.

## Verification

Every mutation confirmed **applied** (not just attempted), count stable, a named test flipping:

| mutation | result |
| --- | --- |
| **maths — 16 tests** | |
| measure at a ray end, not the apex | 6 FAIL |
| fold the obtuse answer to [0,90] | 4 FAIL |
| neuter the metre degenerate guard | 2 FAIL |
| `acos` instead of `atan2` | 1 FAIL |
| collapse `zero` into `degenerate` | 1 FAIL |
| collapse `straight` into `angled` | 2 FAIL |
| **store — 9 tests** | |
| drop `activeAngle` from `clearMeasurements` | 1 FAIL |
| drop `angleKind` from `resetAllMeasurementState` | 1 FAIL |
| off-by-one in the finish threshold | 3 FAIL |
| accept a mismatched pick kind | 1 FAIL |
| **gate — 11 tests** | |
| revert to the deny-list form | 2 FAIL |

**Two of my own tests were worthless until I measured them**, which is the part worth reading:

1. The f32 test first used two hand-written near-opposite rays and **passed under both `atan2` and `acos`** — it asserted a property it could not observe. The vector now used was found by search and verified to NaN.
2. The metre degenerate threshold was pinned by **nothing**: with the guard removed, all other tests still passed, because the coincident-pick case is caught by `normalize` returning null. That is exactly the defect I filed on #2720 — a tunable threshold no test observes.

Gates: build 0, typecheck **0 errors**, lint 0, `check-source-text-assertions` OK, **36 tests passing**.

## Known gap, deliberately out of this PR

**The picks are not drawn in the viewport yet** — the result appears in the panel, but no rays or apex marker are rendered. `MeasurementVisuals` plus its memo comparator is the next commit, and it needs care: a forgotten comparator arm is a silent stale-overlay bug, which is precisely what `measurementOverlaysPropsEqual.test.ts` exists to catch. Flagging rather than quietly shipping a half-visible tool.

No changeset: `apps/viewer` is private and nothing in `packages/*` changed.

Later slices of #2735: edge-to-edge (rides on #2655's reconstructed runs) and face-to-face (camera-oriented normal from the intersection).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Angle measurement mode for selecting three points and displaying calculated angles.
  * Added support for angle measurement progress, completion, deletion, cancellation, and reset behavior.
  * Added tooltips and controls distinguishing Distance, Polyline, and Angle modes.
  * Pressing Escape now cancels an in-progress angle measurement.

* **Bug Fixes**
  * Drag measurements now start only in Drag mode when Shift is not held.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->