### PR TITLE
fix(parser): handle newline after #id= in buildEntityRefsFromIndex

### DIFF
--- a/.changeset/entity-refs-index-eol-after-eq.md
+++ b/.changeset/entity-refs-index-eol-after-eq.md
@@ -1,0 +1,15 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Fix `buildEntityRefsFromIndex` dropping the entity type when a line break
+follows `#id=` directly (`#1=\nIFCWALL($);`).
+
+This is legal STEP — a newline directly after `#id=` appears in real
+fixtures — and the tokenizer's own `scanEntitiesFast` / `scanEntities`
+already handle it. `buildEntityRefsFromIndex` is the fast path taken when
+the streaming geometry pre-pass has already built the entity index; its
+whitespace skip after `=` only recognised space and tab, so a record
+starting with a newline resolved to `type: ''` and the entity was silently
+misclassified. The skip now also recognises `LF` and `CR`, matching the
+type-end scan a few lines below it in the same function.

--- a/packages/parser/src/entity-refs-from-index.ts
+++ b/packages/parser/src/entity-refs-from-index.ts
@@ -97,7 +97,10 @@ export function buildEntityRefsFromIndex(
     let p = 0;
     while (p < limit && record[p] !== EQ) p++;
     p++;
-    while (p < limit && (record[p] === SPACE || record[p] === TAB)) p++;
+    while (
+      p < limit
+      && (record[p] === SPACE || record[p] === TAB || record[p] === LF || record[p] === CR)
+    ) p++;
     const typeStart = p;
     while (
       p < limit

--- a/packages/parser/test/entity-refs-from-index.test.ts
+++ b/packages/parser/test/entity-refs-from-index.test.ts
@@ -85,6 +85,33 @@ describe('buildEntityRefsFromIndex', () => {
     expect(refs[0].type).toBe('IFCWALL');
   });
 
+  it('tolerates a newline (LF) between `=` and the type token', () => {
+    // Legal STEP: a newline directly after `#id=` is ordinary and appears in
+    // real fixtures (see multiline-entity-records.test.ts / schependomlaan).
+    // scanEntitiesFast / scanEntities already handle it; this fast path,
+    // taken when the streaming geometry pre-pass has already built the
+    // entity index, did not.
+    const padded = new TextEncoder().encode('#1=\nIFCWALL($);');
+    const refs = buildEntityRefsFromIndex(
+      padded,
+      Uint32Array.of(1),
+      Uint32Array.of(0),
+      Uint32Array.of(padded.length),
+    );
+    expect(refs[0].type).toBe('IFCWALL');
+  });
+
+  it('tolerates a CRLF between `=` and the type token', () => {
+    const padded = new TextEncoder().encode('#1=\r\nIFCWALL($);');
+    const refs = buildEntityRefsFromIndex(
+      padded,
+      Uint32Array.of(1),
+      Uint32Array.of(0),
+      Uint32Array.of(padded.length),
+    );
+    expect(refs[0].type).toBe('IFCWALL');
+  });
+
   it('throws when the `lengths` column is shorter than the `ids` column', () => {
     // Each column is checked independently; a guard that only validates
     // `starts` lets a truncated `lengths` column through as undefined spans.

--- a/packages/parser/test/tokenizer.test.ts
+++ b/packages/parser/test/tokenizer.test.ts
@@ -98,6 +98,23 @@ describe('StepTokenizer.scanEntitiesFast', () => {
     const refs = scanFast('#1=IFCWALL(1);\n#2=IFCWALL(1);');
     expect(refs.map((r) => r.type)).toEqual(['IFCWALL', 'IFCWALL']);
   });
+
+  // Coverage gap found while auditing whitespace-around-`=` handling
+  // elsewhere in the parser: nothing exercised the whitespace skip between
+  // the express-id digits and `=` (deleting that skip left all tests green).
+  // Both forms below are legal STEP and were already handled correctly by
+  // this scanner; these tests just make that fact falsifiable.
+  it('tolerates a space between the express-id digits and `=`', () => {
+    const refs = scanFast('#1 =IFCWALL($);');
+    expect(refs.map((r) => r.expressId)).toEqual([1]);
+    expect(refs.map((r) => r.type)).toEqual(['IFCWALL']);
+  });
+
+  it('tolerates a newline between the express-id digits and `=`', () => {
+    const refs = scanFast('#1\n=IFCWALL($);');
+    expect(refs.map((r) => r.expressId)).toEqual([1]);
+    expect(refs.map((r) => r.type)).toEqual(['IFCWALL']);
+  });
 });
 
 describe('StepTokenizer.scanEntities (paren-matching scan)', () => {


### PR DESCRIPTION
## Reproduction (RED)

`buildEntityRefsFromIndex` (`packages/parser/src/entity-refs-from-index.ts`) is the fast path taken when the streaming geometry pre-pass has already built the entity index — it synthesizes `EntityRef[]` from the pre-pass's `ids`/`starts`/`lengths` columns without re-scanning the source. Its whitespace skip after `=` (line ~100) only recognized `SPACE` and `TAB`:

```ts
while (p < limit && (record[p] === SPACE || record[p] === TAB)) p++;
```

`LF`/`CR` are not skipped, even though both constants are declared in the same file and used a few lines below in the type-end scan. For the legal-STEP record `'#1=\nIFCWALL($);'`, the newline right after `=` is left unconsumed, `typeStart` points at the `\n`, and the type-end scan (which *does* stop on `LF`) immediately terminates — so `refs[0].type` comes back `''`. The entity is silently misclassified.

This is ordinary STEP: `packages/parser/test/multiline-entity-records.test.ts` documents a newline directly after `#id=` as legal and present in a real fixture (schependomlaan), and the tokenizer's own `scanEntitiesFast`/`scanEntities` already handle it correctly — only this fast-path helper didn't.

Added two failing tests to `entity-refs-from-index.test.ts` (`'#1=\nIFCWALL($);'` and `'#1=\r\nIFCWALL($);'`), confirmed RED:

```
AssertionError: expected '' to be 'IFCWALL'
```

## Fix (GREEN)

Added `LF`/`CR` to the skip condition, matching the idiom already used a few lines below in the same function's type-end scan:

```ts
while (
  p < limit
  && (record[p] === SPACE || record[p] === TAB || record[p] === LF || record[p] === CR)
) p++;
```

Both new tests pass; no existing test's behavior changed.

## Same-shape sweep

This is the third instance found today of whitespace-around-`=` being mishandled in the parser package: `reference-collector.ts:638` sliced `entityType` without trimming (fixed in #2668), and a suspected sibling in `tokenizer.ts`'s `scanEntitiesFast` (~166–172, the whitespace skip between the express-id digits and `=`) was called out as unexercised (deleting it left all 596 tests green).

- **Tokenizer sibling: verified NOT a live bug.** `scanEntitiesFast('#1 =IFCWALL($);')` and `scanEntitiesFast('#1\n=IFCWALL($);')` both correctly return `{ expressId: 1, type: 'IFCWALL', ... }` — that whitespace skip already includes a separate `NEWLINE` branch (with line counting) alongside the space/tab/CR branch. It was merely untested, not broken. Closed the coverage gap with two new tests in `tokenizer.test.ts`.
- **Package-wide inventory** of byte-comparison whitespace skips (`grep -rn "0x20"` across `packages/parser/src`, excluding generated files) — 4 files:
  - `entity-refs-from-index.ts:100` — **fixed** (this PR).
  - `tokenizer.ts:169,181,234` — already correct (separate LF branch with line counting); now covered by new tests.
  - `scan-worker-inline.ts:93,105,154` — mirrors `tokenizer.ts`'s pattern exactly (separate LF branch); already correct.
  - `columnar-parser-attributes.ts:62,107,122,128` — already includes `0x0A`/`0x0D` in the same condition; already correct.

  No other site needed a fix.

## Downstream-consumer check

Grepped consumers of `buildEntityRefsFromIndex` and `EntityRef.type`. The only caller is `entity-scanner.ts`, which falls through to the worker/wasm/tokenizer scan paths on `entityRefs.length === 0` — not on any `.type` check — and no code in the package special-cases `type === ''` as a sentinel. The bug was a silent misclassification (an empty-string type flowing downstream as a real value), not a code path relying on the broken behavior, so this fix does not surface any latent issue elsewhere that I could find.

## Verify

- `packages/parser` suite: **before** 596 passed / 2 skipped (65 files) — **after** 600 passed / 2 skipped (65 files, +4 new tests: 2 RED→GREEN reproduction tests, 2 tokenizer coverage tests).
- `tsc --noEmit` (package `src`): clean.
- `node ../../scripts/typecheck-tests.mjs` (package tests): `packages/parser OK (65 test files)`.
- `oxlint` on changed files: clean.

## What I did not determine

I did not audit whitespace-skip byte comparisons outside `packages/parser` (e.g. other packages that may tokenize STEP-like text); the task scoped this to the parser package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of entity records when line breaks appear after the `=` delimiter.
  * Correctly identifies entity types across LF and CRLF-formatted source data.
  * Supports whitespace between entity IDs and the `=` delimiter without losing parsed information.

* **Tests**
  * Added coverage for newline and whitespace variations in entity parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->