### PR TITLE
test: close the two coverage gaps left by #2730 and #2734

### DIFF
--- a/packages/export/src/header-override.test.ts
+++ b/packages/export/src/header-override.test.ts
@@ -17,6 +17,9 @@
  *  - `options.application` override of `preprocessorVersion` (~:352)
  *  - `authorization: sourceHeader?.authorization` (~:354)
  *  - `options.filename ?? 'export.ifc'` — the `options.filename` half (~:355-356)
+ *  - `timeStamp: options.timeStamp` (~:454) — the eighth override, added
+ *    after the original sweep: mutating it to `undefined` still killed
+ *    nothing once the seven above were covered.
  *
  * Every fixture below gives the source header a value DIFFERENT from both
  * the caller override (where one applies) and the hardcoded default, so a
@@ -136,5 +139,31 @@ describe('StepExporter header overrides (options.* wins over source/default)', (
     expect(out.name).toBe('caller-override.ifc');
     expect(out.name).not.toBe('source-file.ifc');
     expect(out.name).not.toBe('export.ifc');
+  });
+
+  // The eighth override. Unlike the seven above, its default is not a constant
+  // but the wall clock, so "differs from the default" cannot be asserted by
+  // comparing against a fixed string. A timestamp in the past is distinct from
+  // both the source header's and any clock-derived default by construction.
+  it('options.timeStamp replaces the FILE_NAME timestamp slot (not the source or the wall clock)', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({
+      schema: store.schemaVersion,
+      timeStamp: '2011-11-11T11:11:11',
+    });
+    const out = exportedHeader(result.content);
+    expect(out.timeStamp).toBe('2011-11-11T11:11:11');
+    expect(out.timeStamp).not.toBe('2026-01-01T00:00:00');
+  });
+
+  // Control for the test above: with no override the slot must still be filled
+  // from the clock, so a mutation that drops the override entirely cannot be
+  // mistaken for "the field is simply never written".
+  it('without options.timeStamp the slot is still populated', async () => {
+    const store = await parse(SOURCE_MODEL);
+    const result = new StepExporter(store).export({ schema: store.schemaVersion });
+    const out = exportedHeader(result.content);
+    expect(out.timeStamp).toBeTruthy();
+    expect(out.timeStamp).not.toBe('2011-11-11T11:11:11');
   });
 });

--- a/packages/export/src/header-override.test.ts
+++ b/packages/export/src/header-override.test.ts
@@ -17,7 +17,7 @@
  *  - `options.application` override of `preprocessorVersion` (~:352)
  *  - `authorization: sourceHeader?.authorization` (~:354)
  *  - `options.filename ?? 'export.ifc'` — the `options.filename` half (~:355-356)
- *  - `timeStamp: options.timeStamp` (~:454) — the eighth override, added
+ *  - `timeStamp: options.timeStamp` (~:454): the eighth override, added
  *    after the original sweep: mutating it to `undefined` still killed
  *    nothing once the seven above were covered.
  *

--- a/packages/mcp/test/viewer-config.test.ts
+++ b/packages/mcp/test/viewer-config.test.ts
@@ -62,7 +62,7 @@ async function bootServer(config?: { autoOpenViewer?: boolean; viewerPort?: numb
   return server;
 }
 
-/** A port that is free right now — so the assertions below pin a port the
+/** A port that is free right now, so the assertions below pin a port the
  *  caller chose, not the `0` default that every other case in this file uses
  *  and that therefore cannot distinguish "config honoured" from "default". */
 async function freePort(): Promise<number> {
@@ -110,7 +110,7 @@ describe('ServerConfig.autoOpenViewer / .viewerPort — public API is honoured',
   });
 
   // The cases above all pass `viewerPort: 0` / `port: 0`, which is ALSO the
-  // built-in default — so none of them can tell a honoured config port from
+  // built-in default, so none of them can tell a honoured config port from
   // the default. Confirmed by mutation: dropping `this.config.viewerPort` from
   // the resolution chain killed nothing. These two pin the port half.
   it('config.viewerPort is honoured (a non-default port reaches the viewer)', async () => {

--- a/packages/mcp/test/viewer-config.test.ts
+++ b/packages/mcp/test/viewer-config.test.ts
@@ -17,6 +17,7 @@
  * These three tests pin all three levels.
  */
 
+import { createServer } from 'node:net';
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -61,6 +62,22 @@ async function bootServer(config?: { autoOpenViewer?: boolean; viewerPort?: numb
   return server;
 }
 
+/** A port that is free right now — so the assertions below pin a port the
+ *  caller chose, not the `0` default that every other case in this file uses
+ *  and that therefore cannot distinguish "config honoured" from "default". */
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const addr = probe.address();
+      if (addr === null || typeof addr === 'string') { probe.close(); reject(new Error('no port')); return; }
+      const port = addr.port;
+      probe.close(() => resolve(port));
+    });
+  });
+}
+
 describe('ServerConfig.autoOpenViewer / .viewerPort — public API is honoured', () => {
   it('level 3 — neither flag nor config set: no auto-open, defaults win', async () => {
     const server = await bootServer();
@@ -90,5 +107,27 @@ describe('ServerConfig.autoOpenViewer / .viewerPort — public API is honoured',
     const state = await server.maybeAutoOpenViewer({ autoOpen: false });
     expect(state).toBeNull();
     expect(server.viewer.isOpen()).toBe(false);
+  });
+
+  // The cases above all pass `viewerPort: 0` / `port: 0`, which is ALSO the
+  // built-in default — so none of them can tell a honoured config port from
+  // the default. Confirmed by mutation: dropping `this.config.viewerPort` from
+  // the resolution chain killed nothing. These two pin the port half.
+  it('config.viewerPort is honoured (a non-default port reaches the viewer)', async () => {
+    const port = await freePort();
+    const server = await bootServer({ autoOpenViewer: true, viewerPort: port });
+    const state = await server.maybeAutoOpenViewer();
+    expect(state).not.toBeNull();
+    expect(state!.url).toBe(`http://localhost:${port}/`);
+  });
+
+  it('an explicit override port wins over a contradicting config port', async () => {
+    const configPort = await freePort();
+    const overridePort = await freePort();
+    expect(overridePort).not.toBe(configPort);
+    const server = await bootServer({ autoOpenViewer: true, viewerPort: configPort });
+    const state = await server.maybeAutoOpenViewer({ port: overridePort });
+    expect(state).not.toBeNull();
+    expect(state!.url).toBe(`http://localhost:${overridePort}/`);
   });
 });


### PR DESCRIPTION
Follow-up to #2730 and #2734, both merged. Each left one field of its own claim unpinned.

**Neither is a code defect.** I probed both behaviours directly and they are correct. The problem is that in both cases a mutation reverting the feature killed nothing, so a future regression would ship silently.

## `packages/export`, `options.timeStamp`

Found by running the CodeRabbit CLI locally (the hosted bot was rate-limited on #2730 and never reviewed it).

#2730 pinned seven header-override sites and its header comment lists exactly those seven, so its claims were accurate, `timeStamp` is an **eighth** it did not cover. Measured on merged main:

```
timeStamp: options.timeStamp  ->  timeStamp: undefined
  723 passed, 0 failed
```

The wrinkle is that this override's default is the **wall clock**, not a constant, so the discipline the rest of that file follows, "give the source header a value different from both the override and the hardcoded default", cannot be applied by comparing against a fixed string. A timestamp in the past is distinct from both the source value and any clock-derived default by construction.

A second test pins that the slot is still populated when no override is passed, so a mutation that drops the override cannot be mistaken for "this field is simply never written", the absence-shaped reading of the same evidence.

## `packages/mcp`, `ServerConfig.viewerPort`

#2734's four tests all pass `viewerPort: 0` / `port: 0`. That value **is the built-in default**, and the URL assertion is `expect(state!.url).toMatch(/^http:\/\/localhost:\d+\/$/)`, which any port satisfies. So no assertion depended on the config port:

```
overrides?.port ?? this.config.viewerPort ?? 0   ->   overrides?.port ?? 0
  265 passed, 0 failed
```

I confirmed the feature itself works before merging #2734, a probe with `viewerPort: 45671` produced exactly `http://localhost:45671/`, and an explicit override port beat a contradicting config port. So this closes a test gap, not a bug.

The new tests allocate a genuinely free port at runtime rather than hardcoding one, so they pin a caller-chosen port without introducing a fixed-port flake.

## Mutation results

Each mutation is the one that reverts the feature the test claims to cover:

| mutation | before | after |
|---|---|---|
| `timeStamp: options.timeStamp` -> `undefined` | 0 tests fail | **1** (the new test) |
| `?? this.config.viewerPort` dropped | 0 tests fail | **1** (the new test) |

Test-file counts are unchanged in every run (53 for export, 6 in the mcp file), so these are tests flipping, not a file failing to parse and reporting `no tests`.

## Verification

- `packages/export`: 725 passed / 0 failed / 30 skipped
- `packages/mcp`: 267 passed / 0 failed
- root `pnpm run lint`: 0 errors; root `pnpm run typecheck`: clean, 1193/1193

No changeset: test-only, no published behaviour change.

