### PR TITLE
test(ids): pin the xs:length/minLength/maxLength bounds facets

### DIFF
--- a/packages/ids/src/constraints/constraints.test.ts
+++ b/packages/ids/src/constraints/constraints.test.ts
@@ -341,6 +341,83 @@ describe('matchConstraint — bounds', () => {
 });
 
 // ============================================================================
+// matchConstraint — bounds (string-length facets: xs:length / xs:minLength /
+// xs:maxLength)
+// ============================================================================
+
+describe('matchConstraint — bounds (length facets)', () => {
+  const bounds = (
+    opts: Partial<IDSBoundsConstraint>
+  ): IDSBoundsConstraint => ({
+    type: 'bounds',
+    ...opts,
+  });
+
+  describe('length (exact)', () => {
+    const c = bounds({ length: 4 });
+
+    it('passes when the string length exactly matches', () => {
+      expect(matchConstraint(c, 'abcd')).toBe(true);
+    });
+
+    it('fails when the string is one character shorter', () => {
+      expect(matchConstraint(c, 'abc')).toBe(false);
+    });
+
+    it('fails when the string is one character longer', () => {
+      expect(matchConstraint(c, 'abcde')).toBe(false);
+    });
+  });
+
+  describe('minLength', () => {
+    const c = bounds({ minLength: 3 });
+
+    it('passes exactly at the boundary', () => {
+      expect(matchConstraint(c, 'abc')).toBe(true);
+    });
+
+    it('fails one character below the boundary', () => {
+      expect(matchConstraint(c, 'ab')).toBe(false);
+    });
+
+    it('passes above the boundary', () => {
+      expect(matchConstraint(c, 'abcd')).toBe(true);
+    });
+  });
+
+  describe('maxLength', () => {
+    const c = bounds({ maxLength: 5 });
+
+    it('passes exactly at the boundary', () => {
+      expect(matchConstraint(c, 'abcde')).toBe(true);
+    });
+
+    it('fails one character above the boundary', () => {
+      expect(matchConstraint(c, 'abcdef')).toBe(false);
+    });
+
+    it('passes below the boundary', () => {
+      expect(matchConstraint(c, 'abcd')).toBe(true);
+    });
+  });
+
+  it('minLength and maxLength combined form a range', () => {
+    const c = bounds({ minLength: 2, maxLength: 3 });
+    expect(matchConstraint(c, 'a')).toBe(false);
+    expect(matchConstraint(c, 'ab')).toBe(true);
+    expect(matchConstraint(c, 'abc')).toBe(true);
+    expect(matchConstraint(c, 'abcd')).toBe(false);
+  });
+
+  it('length is evaluated against the string form of a numeric value', () => {
+    // actualValue may arrive as a number (e.g. a numeric IFC attribute);
+    // the length facets still operate on its textual representation.
+    expect(matchConstraint(bounds({ length: 3 }), 123)).toBe(true);
+    expect(matchConstraint(bounds({ length: 3 }), 12)).toBe(false);
+  });
+});
+
+// ============================================================================
 // matchConstraint — unknown type
 // ============================================================================
 


### PR DESCRIPTION
## Finding

`packages/ids/src/constraints/index.ts`, `matchBounds` (~295-303) implements the IDS `xs:length` / `xs:minLength` / `xs:maxLength` restriction facets:

```ts
if (constraint.length !== undefined && str.length !== constraint.length) { return false; }
if (constraint.minLength !== undefined && str.length < constraint.minLength) { return false; }
if (constraint.maxLength !== undefined && str.length > constraint.maxLength) { return false; }
```

No existing fixture constructed a bounds constraint with `length`, `minLength`, or `maxLength` set.

## Reproduce-first

Inverted all three inequalities (`!==`→`===`, `<`→`>=`, `>`→`<=`) and ran the full `packages/ids` suite before writing any test: it stayed green at **305 passed (16 files)**, confirming the gap. Reverted before writing tests.

## Parser-side check

The XML parser **does** populate these fields from `<xs:restriction>`: `xml-parser.ts:653-665` collects `length`/`minLength`/`maxLength` child facet elements, and `xml-parser.ts:683-685` reads them into the `IDSBoundsConstraint`. So the constraint is reachable from a real `.ids` file — this is a test gap, not a dead-code gap. (Note: `src/__corpus__/buildingsmart-ids/restriction/*max_and_min_length*` fixtures encode this facet pair in XML but nothing in the test suite currently loads the `__corpus__` directory, so they weren't exercising this path either.)

## Tests added

`packages/ids/src/constraints/constraints.test.ts`, new `describe('matchConstraint — bounds (length facets)')` block. Each field pinned independently at its boundary (not comfortably inside it):

| Field | Tests | Boundary check |
|---|---|---|
| `length` | exact match passes; one shorter fails; one longer fails; numeric actualValue coerced to string | `length: 4` vs `'abcd'`/`'abc'`/`'abcde'` |
| `minLength` | at boundary passes; one below fails; above passes | `minLength: 3` vs `'abc'`/`'ab'`/`'abcd'` |
| `maxLength` | at boundary passes; one above fails; below passes | `maxLength: 5` vs `'abcde'`/`'abcdef'`/`'abcd'` |

Plus a combined `minLength`+`maxLength` range test.

## RED→GREEN verification

Re-inverted each inequality individually (production code reverted after each check — final diff is test-only):

- `length` (`!==`→`===`): kills 4 tests — the 3 `length (exact)` tests + the numeric-coercion test.
- `minLength` (`<`→`>=`): kills 4 tests — the 3 `minLength` tests + the combined-range test.
- `maxLength` (`>`→`<=`): kills 4 tests — the 3 `maxLength` tests + the combined-range test.

## Verification

- `packages/ids` suite: 305 → **316 passed (16 files)**.
- Package typecheck (`tsc --noEmit`, `src` scope): clean.
- Test typecheck (`scripts/typecheck-tests.mjs`): `packages/ids OK (16 test files)`.
- Root `pnpm lint`: 0 errors (21 pre-existing warnings elsewhere, unrelated).

## Scope

This covers only the `length`/`minLength`/`maxLength` bounds facets. `enumeration` and `pattern` constraint types were not assessed in this pass.

No changeset — test-only change, no production code modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for string-length constraints, including exact, minimum, maximum, and combined length ranges.
  * Added boundary-failure cases and validation of numeric values based on their string representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->