### PR TITLE
test(ids): cover optional's value-mismatch fail and partOf's multi-ancestor tie-break

### DIFF
--- a/packages/ids/src/facets/facets.test.ts
+++ b/packages/ids/src/facets/facets.test.ts
@@ -1013,5 +1013,47 @@ describe('checkPartOfFacet', () => {
     const result = checkPartOfFacet(facet, 5, accessor);
     expect(result.passed).toBe(true);
   });
+
+  it('prefers a specific failure over a generic entity mismatch across multiple ancestors', () => {
+    // Two ancestors, neither passing, so the loop never returns early —
+    // it must run the full tie-break. The nearer ancestor (100) is the
+    // wrong entity type entirely (generic PARTOF_ENTITY_MISMATCH); the
+    // further one (200) is the right entity type but the wrong
+    // predefinedType (more specific PARTOF_PREDEFINED_TYPE_MISMATCH).
+    // The reported failure must be the specific one, not whichever
+    // ancestor happened to be checked first.
+    const multiAncestorAccessor = {
+      ...accessor,
+      getAncestors(
+        expressId: number,
+        relationType: string
+      ) {
+        if (expressId !== 6 || relationType !== 'IfcRelContainedInSpatialStructure') {
+          return [];
+        }
+        return [
+          { expressId: 100, entityType: 'IfcSpace' }, // generic entity mismatch
+          {
+            expressId: 200,
+            entityType: 'IfcBuildingStorey',
+            predefinedType: 'GROUND_FLOOR',
+          }, // right entity, wrong predefinedType
+        ];
+      },
+    } as typeof accessor;
+
+    const facet: IDSPartOfFacet = {
+      type: 'partOf',
+      relation: 'IfcRelContainedInSpatialStructure',
+      entity: {
+        type: 'entity',
+        name: sv('IfcBuildingStorey'),
+        predefinedType: sv('BASEMENT'),
+      },
+    };
+    const result = checkPartOfFacet(facet, 6, multiAncestorAccessor);
+    expect(result.passed).toBe(false);
+    expect(result.failure?.type).toBe('PARTOF_PREDEFINED_TYPE_MISMATCH');
+  });
 });
 

--- a/packages/ids/src/validation/validator.test.ts
+++ b/packages/ids/src/validation/validator.test.ts
@@ -150,6 +150,36 @@ describe('validateIDS — optionality', () => {
     expect(reqResult.status).toBe('pass');
   });
 
+  it('optional requirement fails when facet is present but wrong (not merely absent)', async () => {
+    // `optional` pardons a wholly-absent facet, but must NOT pardon bad
+    // data: a present Description with the wrong value is an
+    // ATTRIBUTE_VALUE_MISMATCH, not an ATTRIBUTE_MISSING, so it must
+    // fail rather than be waved through by the missingFailures allowlist.
+    const accessor = createMockAccessor([
+      { expressId: 1, type: 'IfcWall', description: 'Wrong value' },
+    ]);
+
+    const spec = makeSpec({
+      requirements: [
+        {
+          id: 'req-0',
+          facet: {
+            type: 'attribute',
+            name: sv('Description'),
+            value: sv('Expected value'),
+          },
+          optionality: 'optional',
+        },
+      ],
+    });
+
+    const report = await validateIDS(makeDoc([spec]), accessor, modelInfo);
+    const reqResult = report.specificationResults[0].entityResults[0].requirementResults[0];
+    expect(reqResult.failure?.type).toBe('ATTRIBUTE_VALUE_MISMATCH');
+    expect(reqResult.status).toBe('fail');
+    expect(report.specificationResults[0].status).toBe('fail');
+  });
+
   it('prohibited requirements fail when facet passes', async () => {
     const accessor = createMockAccessor([
       { expressId: 1, type: 'IfcWall', description: 'Should not exist' },


### PR DESCRIPTION
Refs #2747.

## Gap 1 — `optional` cardinality is only tested against wholly-missing failures

`packages/ids/src/validation/validator.ts` (`checkRequirement`, the `optional` branch): the `missingFailures` allowlist is the entire discriminator between "optional pardons an absent thing" and "optional does not pardon a present-but-wrong thing." The comment states that intent, but the only existing test (`'optional requirements always pass even when facet fails'`) used a **missing** `Description` attribute.

**Reproduce.** Added `ATTRIBUTE_VALUE_MISMATCH` to `missingFailures` (i.e. made `optional` pardon bad data too) and ran the suite: **all 305 tests stayed green**. That confirms nothing distinguished "wholly absent" from "present but wrong" for `optional`.

**Fix (test-only).** Added `'optional requirement fails when facet is present but wrong (not merely absent)'` in `validator.test.ts`: an optional `Description` attribute with the wrong value now must report `ATTRIBUTE_VALUE_MISMATCH` and `status: 'fail'`.

**Mutation check.** Re-applied the same allowlist mutation with the new test present: it failed with `expected 'pass' to be 'fail'`, correctly killed. Reverted the mutation before committing.

**`prohibited` cardinality finding.** Already exercised in both directions in `validator.test.ts` (`'prohibited requirements fail when facet passes'` and `'prohibited requirements pass when facet fails (attribute missing)'`) — no gap found here, no new test needed.

## Gap 2 — `partOf`'s multi-ancestor tie-break is unreached

`packages/ids/src/facets/partof-facet.ts` (`checkPartOfFacet`): when an entity has multiple ancestors and none pass, the loop is supposed to prefer a specific failure (e.g. `PARTOF_PREDEFINED_TYPE_MISMATCH`) over a generic `PARTOF_ENTITY_MISMATCH`. Every existing fixture supplied exactly one ancestor, so this tie-break never ran with two genuinely different failures.

**Reproduce.** Replaced the tie-break condition with `bestFailure = bestFailure ?? result` (first failure wins, no preference) and ran the suite: **all 307 tests stayed green** (including the not-yet-added test, run separately at that point — 305 baseline + the gap-1 test = 306, all green under this mutation too). Confirms the tie-break logic was unreached by any fixture.

**Fix (test-only).** Added `'prefers a specific failure over a generic entity mismatch across multiple ancestors'` in `facets.test.ts`, using a hand-built accessor (`{ ...accessor, getAncestors: ... }`) returning two non-passing ancestors: a nearer one with a generic `PARTOF_ENTITY_MISMATCH` and a further one with a more specific `PARTOF_PREDEFINED_TYPE_MISMATCH`. Neither ancestor passes, so the loop runs the full tie-break instead of returning early. Asserts the reported failure type is the specific one.

**Mutation check.** Re-applied the tie-break mutation with the new test present: it failed with `expected 'PARTOF_ENTITY_MISMATCH' to be 'PARTOF_PREDEFINED_TYPE_MISMATCH'`, correctly killed, while all other 306 tests stayed green (confirming the mutation was otherwise unreached). Reverted the mutation before committing.

## Verify

- `packages/ids` suite: 305 → 307 passed, 16 files (re-baselined at HEAD `fb51e87bd`; the #2746 baseline of ~316 didn't match at this HEAD, so re-baselined per instructions).
- `pnpm exec tsc --noEmit` in `packages/ids`: clean.
- `node scripts/typecheck-tests.mjs` (packages/ids scope): `packages/ids OK (16 test files)`.
- `pnpm lint` (repo root): 0 errors (pre-existing unrelated warnings only, verified against `upstream/main` before my changes).

## Test plan

- [x] `pnpm --filter @ifc-lite/ids test` — 307 passed
- [x] Both new tests independently verified to fail under their respective mutation and pass against current code
- [x] `pnpm exec tsc --noEmit` (packages/ids)
- [x] `node scripts/typecheck-tests.mjs`
- [x] `pnpm lint`

No changeset — test-only change, no production code modified.