### PR TITLE
test(ids): pin the parser-to-matcher wiring for the string-length facets

### DIFF
--- a/packages/ids/src/parser/xml-parser.test.ts
+++ b/packages/ids/src/parser/xml-parser.test.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { parseIDS, IDSParseError } from './xml-parser.js';
+import { matchConstraint } from '../constraints/index.js';
+import type { IDSBoundsConstraint } from '../types.js';
 
 // ============================================================================
 // Valid IDS XML Parsing
@@ -529,3 +531,92 @@ describe('parseIDS — error handling', () => {
 });
 
 // ============================================================================
+
+// ============================================================================
+// Parser -> matcher wiring for the string-length facets (#2746 follow-up)
+// ============================================================================
+
+/**
+ * `constraints.test.ts` pins `matchBounds` against `IDSBoundsConstraint`
+ * objects built by hand, so it cannot see the parser at all. Measured: making
+ * the parser drop all three length facets
+ *
+ *   bounds.length    = readInt(facetEls.length)    -> undefined
+ *   bounds.minLength = readInt(facetEls.minLength) -> undefined
+ *   bounds.maxLength = readInt(facetEls.maxLength) -> undefined
+ *
+ * left the whole packages/ids suite green at 322/322. In user terms an IDS
+ * author writes `<xs:maxLength value="8"/>`, the restriction is silently
+ * dropped, and every element PASSES: a rule that stops restricting reports
+ * success. These cases assert the extracted facets and then drive the matcher
+ * with them, so the parse-to-match path has to survive as a whole.
+ */
+describe('parseIDS: xs:length / xs:minLength / xs:maxLength reach the matcher', () => {
+  const idsWith = (facets: string): string => `<ids xmlns="http://standards.buildingsmart.org/IDS"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <info><title>T</title></info>
+  <specifications>
+    <specification name="Test" ifcVersion="IFC4">
+      <applicability>
+        <entity><name><simpleValue>IFCWALL</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <attribute>
+          <name><simpleValue>Name</simpleValue></name>
+          <value>
+            <xs:restriction>
+${facets}
+            </xs:restriction>
+          </value>
+        </attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>`;
+
+  /** Asserts the facet type rather than guarding on it: a conditional would
+   *  skip its assertions silently if the shape ever changed. */
+  const boundsOf = (xml: string): IDSBoundsConstraint => {
+    const facet = parseIDS(xml).specifications[0].requirements[0].facet;
+    expect(facet.type).toBe('attribute');
+    const value = (facet as { value?: unknown }).value as IDSBoundsConstraint;
+    expect(value.type).toBe('bounds');
+    return value;
+  };
+
+  it('carries xs:length through the parser and enforces it in the matcher', () => {
+    const bounds = boundsOf(idsWith('              <xs:length value="5"/>'));
+    expect(bounds.length).toBe(5);
+
+    expect(matchConstraint(bounds, 'abcde')).toBe(true);
+    expect(matchConstraint(bounds, 'abcd')).toBe(false);
+    expect(matchConstraint(bounds, 'abcdef')).toBe(false);
+  });
+
+  it('carries xs:minLength through the parser and enforces it in the matcher', () => {
+    const bounds = boundsOf(idsWith('              <xs:minLength value="3"/>'));
+    expect(bounds.minLength).toBe(3);
+
+    expect(matchConstraint(bounds, 'abc')).toBe(true);
+    expect(matchConstraint(bounds, 'ab')).toBe(false);
+  });
+
+  it('carries xs:maxLength through the parser and enforces it in the matcher', () => {
+    const bounds = boundsOf(idsWith('              <xs:maxLength value="8"/>'));
+    expect(bounds.maxLength).toBe(8);
+
+    expect(matchConstraint(bounds, 'abcdefgh')).toBe(true);
+    expect(matchConstraint(bounds, 'abcdefghi')).toBe(false);
+  });
+
+  it('carries a combined minLength/maxLength range', () => {
+    const bounds = boundsOf(idsWith('              <xs:minLength value="2"/>\n              <xs:maxLength value="4"/>'));
+    expect(bounds.minLength).toBe(2);
+    expect(bounds.maxLength).toBe(4);
+
+    expect(matchConstraint(bounds, 'ab')).toBe(true);
+    expect(matchConstraint(bounds, 'abcd')).toBe(true);
+    expect(matchConstraint(bounds, 'a')).toBe(false);
+    expect(matchConstraint(bounds, 'abcde')).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #2746, and the fix for the CodeRabbit finding I confirmed and resolved on that PR before merging it.

#2746 pinned `matchBounds` against `IDSBoundsConstraint` objects **built by hand**. Those cases never touch the parser, so nothing guarded the wiring between the two.

## The gap, measured

On #2746 as merged, making the parser drop all three facets:

```
bounds.length    = readInt(facetEls.length)     ->  undefined
bounds.minLength = readInt(facetEls.minLength)  ->  undefined
bounds.maxLength = readInt(facetEls.maxLength)  ->  undefined

  Test Files  17 passed (17)
       Tests  322 passed (322)
```

Nothing catches it, including #2746's own new tests.

**Why this one matters more than a coverage count.** An IDS author writes `<xs:maxLength value="8"/>`, the parser silently drops it, the restriction never applies, and every element **passes**. A validation rule that quietly stops restricting reports SUCCESS. That is the worst shape a defect in a checker can take, and it is invisible to anyone reading the report.

## What is here

Four cases that parse a real IDS document, assert the extracted facet value, and then drive `matchConstraint` with the parsed constraint, so the whole parse-to-match path has to survive together. Covering `xs:length`, `xs:minLength`, `xs:maxLength`, and a combined `minLength`/`maxLength` range, each asserting both an accepting and a rejecting value.

They assert the facet **type** rather than guarding on it. The neighbouring `parses XSD restriction with bounds` test wraps its assertions in `if (facet.type === 'property') { ... }`, so if that shape ever changed the assertions would be skipped and the test would still pass. Worth a separate sweep, not changed here.

## Mutation check

| | before | after |
|---|---|---|
| parser drops all three length facets | 322 passed, **0 failed** | **4 failed** (the new cases) |

Test-file count is 17 in both runs, so these are tests flipping rather than a file failing to parse.

## A wrong turn worth recording

My first version called `matchConstraint('abcde', bounds)`. The signature is `matchConstraint(constraint, actualValue)`, so the string went in as the constraint, hit `switch (constraint.type)` and fell to `default: return false`. All four tests failed, and the failure looked exactly like a real end-to-end defect: the facet parsed correctly as `5` and the match still returned `false`. I went as far as reading `matchBounds` looking for the bug before checking my own call. Reversed argument order is worth ruling out early when a new integration test fails in a way that implicates well-tested code.

## Verification

- `packages/ids`: 326 passed / 0 failed / 17 files
- root `pnpm run lint`: no errors; root `pnpm run typecheck`: clean

No changeset: test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for XML schema length constraints, including minimum, maximum, and exact-length rules.
  * Verified boundary acceptance and rejection behavior.
  * Added tests for combined minimum and maximum length ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->