### PR TITLE
feat(parser): index the port relationships so plant topology is traversable

### DIFF
--- a/.changeset/port-topology-relationships.md
+++ b/.changeset/port-topology-relationships.md
@@ -1,0 +1,14 @@
+---
+"@ifc-lite/data": minor
+"@ifc-lite/parser": minor
+---
+
+Index `IfcRelConnectsPortToElement` and `IfcRelConnectsPorts`, so plant topology is traversable.
+
+The ports themselves were always parsed — they are `IfcProduct` subtypes and land in the `EntityTable` like any other product — but neither relationship was in the index, so nothing recorded which element a port belonged to or which port it was joined to. A distribution system therefore read as a set of unrelated parts, and there was no way to answer "what is this pump connected to" from the store.
+
+- `RelationshipType` gains `ConnectsPortToElement = 44` and `ConnectsPorts = 45`, keeping the existing 40-range grouping for connection relationships.
+- Both need their own branch in `extractRelFast`: their two ends are single references at attributes 4 and 5, which neither existing branch reads. The default branch takes attribute 5 as a list, and the `IfcRelConnectsElements` branch skips one attribute first because that entity carries an optional `ConnectionGeometry` ahead of its ends.
+- `IfcRelConnectsPorts.RealizingElement` (the optional element that realises a connection, e.g. a length of duct) is deliberately not read. It is a third party to the connection rather than one of its two ends, and treating it as one would invent an edge between a port and that element.
+
+A plant is walked as element → `ConnectsPortToElement` inverse → its ports → `ConnectsPorts` → the opposite ports → `ConnectsPortToElement` forward → their elements.

--- a/packages/cache/src/sections/relationships.ts
+++ b/packages/cache/src/sections/relationships.ts
@@ -171,6 +171,8 @@ function relationshipTypeToString(type: RelationshipType): string {
     [RelationshipType.FillsElement]: 'IfcRelFillsElement',
     [RelationshipType.ConnectsPathElements]: 'IfcRelConnectsPathElements',
     [RelationshipType.ConnectsElements]: 'IfcRelConnectsElements',
+    [RelationshipType.ConnectsPortToElement]: 'IfcRelConnectsPortToElement',
+    [RelationshipType.ConnectsPorts]: 'IfcRelConnectsPorts',
     [RelationshipType.SpaceBoundary]: 'IfcRelSpaceBoundary',
     [RelationshipType.AssignsToGroup]: 'IfcRelAssignsToGroup',
     [RelationshipType.AssignsToProduct]: 'IfcRelAssignsToProduct',

--- a/packages/data/src/relationship-graph.test.ts
+++ b/packages/data/src/relationship-graph.test.ts
@@ -66,6 +66,8 @@ describe('RelationshipGraph', () => {
       [RelationshipType.FillsElement]: 'IfcRelFillsElement',
       [RelationshipType.ConnectsPathElements]: 'IfcRelConnectsPathElements',
       [RelationshipType.ConnectsElements]: 'IfcRelConnectsElements',
+      [RelationshipType.ConnectsPortToElement]: 'IfcRelConnectsPortToElement',
+      [RelationshipType.ConnectsPorts]: 'IfcRelConnectsPorts',
       [RelationshipType.SpaceBoundary]: 'IfcRelSpaceBoundary',
       [RelationshipType.AssignsToGroup]: 'IfcRelAssignsToGroup',
       [RelationshipType.AssignsToProduct]: 'IfcRelAssignsToProduct',

--- a/packages/data/src/relationship-graph.ts
+++ b/packages/data/src/relationship-graph.ts
@@ -280,6 +280,8 @@ function RelationshipTypeToString(type: RelationshipType): string {
     [RelationshipType.FillsElement]: 'IfcRelFillsElement',
     [RelationshipType.ConnectsPathElements]: 'IfcRelConnectsPathElements',
     [RelationshipType.ConnectsElements]: 'IfcRelConnectsElements',
+    [RelationshipType.ConnectsPortToElement]: 'IfcRelConnectsPortToElement',
+    [RelationshipType.ConnectsPorts]: 'IfcRelConnectsPorts',
     [RelationshipType.SpaceBoundary]: 'IfcRelSpaceBoundary',
     [RelationshipType.AssignsToGroup]: 'IfcRelAssignsToGroup',
     [RelationshipType.AssignsToProduct]: 'IfcRelAssignsToProduct',

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -203,6 +203,20 @@ export enum RelationshipType {
   FillsElement = 41,
   VoidsElement = 42,
   ConnectsElements = 43,
+  /**
+   * `IfcRelConnectsPortToElement` — a port belongs to the element it sits on.
+   * Forward runs port → element, matching the EXPRESS attribute order
+   * (RelatingPort, RelatedElement).
+   */
+  ConnectsPortToElement = 44,
+  /**
+   * `IfcRelConnectsPorts` — one port joined to another. Together with
+   * {@link ConnectsPortToElement} this is what makes plant topology
+   * traversable: element → its ports → the ports they connect to → those
+   * ports' elements. Without both, a distribution system in a model is a set
+   * of unrelated parts.
+   */
+  ConnectsPorts = 45,
   SpaceBoundary = 50,
   AssignsToGroup = 60,
   AssignsToProduct = 61,

--- a/packages/export/src/parquet-exporter.ts
+++ b/packages/export/src/parquet-exporter.ts
@@ -629,6 +629,8 @@ function RelationshipTypeToString(type: RelationshipType): string {
         [RelationshipType.FillsElement]: 'IfcRelFillsElement',
         [RelationshipType.ConnectsPathElements]: 'IfcRelConnectsPathElements',
         [RelationshipType.ConnectsElements]: 'IfcRelConnectsElements',
+        [RelationshipType.ConnectsPortToElement]: 'IfcRelConnectsPortToElement',
+        [RelationshipType.ConnectsPorts]: 'IfcRelConnectsPorts',
         [RelationshipType.SpaceBoundary]: 'IfcRelSpaceBoundary',
         [RelationshipType.AssignsToGroup]: 'IfcRelAssignsToGroup',
         [RelationshipType.AssignsToProduct]: 'IfcRelAssignsToProduct',

--- a/packages/parser/src/columnar-parser-indexes.ts
+++ b/packages/parser/src/columnar-parser-indexes.ts
@@ -65,6 +65,7 @@ export const RELATIONSHIP_TYPES = new Set([
     'IFCRELASSOCIATESDOCUMENT',
     'IFCRELVOIDSELEMENT', 'IFCRELFILLSELEMENT',
     'IFCRELCONNECTSPATHELEMENTS', 'IFCRELCONNECTSELEMENTS',
+    'IFCRELCONNECTSPORTTOELEMENT', 'IFCRELCONNECTSPORTS',
     'IFCRELSPACEBOUNDARY',
     'IFCRELASSIGNSTOGROUP', 'IFCRELASSIGNSTOPRODUCT',
     'IFCRELREFERENCEDINSPATIALSTRUCTURE',
@@ -88,6 +89,8 @@ export const REL_TYPE_MAP: Record<string, RelationshipType> = {
     'IFCRELFILLSELEMENT': RelationshipType.FillsElement,
     'IFCRELCONNECTSPATHELEMENTS': RelationshipType.ConnectsPathElements,
     'IFCRELCONNECTSELEMENTS': RelationshipType.ConnectsElements,
+    'IFCRELCONNECTSPORTTOELEMENT': RelationshipType.ConnectsPortToElement,
+    'IFCRELCONNECTSPORTS': RelationshipType.ConnectsPorts,
     'IFCRELSPACEBOUNDARY': RelationshipType.SpaceBoundary,
     'IFCRELASSIGNSTOGROUP': RelationshipType.AssignsToGroup,
     'IFCRELASSIGNSTOPRODUCT': RelationshipType.AssignsToProduct,
@@ -123,6 +126,11 @@ export const HIERARCHY_REL_TYPES = new Set([
     // Structural relationships (voids, fills, connections, groups)
     'IFCRELVOIDSELEMENT', 'IFCRELFILLSELEMENT',
     'IFCRELCONNECTSPATHELEMENTS', 'IFCRELCONNECTSELEMENTS',
+    // Plant topology. This set is the GATE — a relationship type missing here
+    // is never collected and so never reaches `extractRelFast`, which is why
+    // ports were invisible to the relationship graph even though the entities
+    // themselves were parsed.
+    'IFCRELCONNECTSPORTTOELEMENT', 'IFCRELCONNECTSPORTS',
     'IFCRELSPACEBOUNDARY',
     'IFCRELASSIGNSTOGROUP', 'IFCRELASSIGNSTOPRODUCT',
     'IFCRELREFERENCEDINSPATIALSTRUCTURE',

--- a/packages/parser/src/columnar-parser-relationships.ts
+++ b/packages/parser/src/columnar-parser-relationships.ts
@@ -55,6 +55,23 @@ export function extractRelFast(
         const [relating, _] = readRefId(buffer, pos, end);
         if (relating < 0 || related.length === 0) return null;
         return { relatingObject: relating, relatedObjects: related };
+    } else if (typeUpper === 'IFCRELCONNECTSPORTTOELEMENT' || typeUpper === 'IFCRELCONNECTSPORTS') {
+        // attr[4]=RelatingPort, attr[5]=RelatedElement / RelatedPort — both
+        // SINGLE references, and both at the front of the attribute list.
+        //
+        // Neither existing branch fits: the default one reads attr[5] as a
+        // LIST, and the ConnectsElements branch skips one attribute first
+        // because that entity carries an optional ConnectionGeometry at [4].
+        // These two carry the port straight away. (`IfcRelConnectsPorts` also
+        // has an optional RealizingElement at [6] — the element that realises
+        // the connection, e.g. a piece of duct. Not read: it is a third party
+        // to the connection, not one of its two ends, and an edge has two.)
+        const [relating, rp] = readRefId(buffer, pos, end);
+        if (relating < 0) return null;
+        pos = skipCommas(buffer, rp, end, 1);
+        const [related, _] = readRefId(buffer, pos, end);
+        if (related < 0) return null;
+        return { relatingObject: relating, relatedObjects: [related] };
     } else if (typeUpper === 'IFCRELCONNECTSELEMENTS' || typeUpper === 'IFCRELCONNECTSPATHELEMENTS') {
         pos = skipCommas(buffer, pos, end, 1);
         const [relating, rp2] = readRefId(buffer, pos, end);

--- a/packages/parser/test/port-topology.test.ts
+++ b/packages/parser/test/port-topology.test.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { RelationshipType } from '@ifc-lite/data';
+import { StepTokenizer } from '../src/tokenizer.js';
+import { ColumnarParser } from '../src/columnar-parser.js';
+
+// Plant topology: `IfcRelConnectsPortToElement` and `IfcRelConnectsPorts` were
+// not indexed, so a distribution system parsed as a set of unrelated parts —
+// the ports themselves were in the EntityTable (they are IfcProduct subtypes)
+// but nothing said which element a port belonged to or what it was joined to.
+//
+// Neutral synthetic fixture (no real-world identifiers):
+// - a pump and two pipe segments
+// - four ports, one pair joined plainly, one pair joined WITH a
+//   RealizingElement (the optional third attribute, which must not be read as
+//   an end of the connection)
+const IFC = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCPUMP('pump-1',#1,'Pump P-01',$,$,$,$,$,$);
+#11=IFCFLOWSEGMENT('pipe-1',#1,'Pipe R-01',$,$,$,$,$,$);
+#12=IFCFLOWSEGMENT('pipe-2',#1,'Pipe R-02',$,$,$,$,$,$);
+#20=IFCDISTRIBUTIONPORT('port-a',#1,'CP1',$,$,$,$,$,.NOTDEFINED.);
+#21=IFCDISTRIBUTIONPORT('port-b',#1,'CP2',$,$,$,$,$,.NOTDEFINED.);
+#22=IFCDISTRIBUTIONPORT('port-c',#1,'CP3',$,$,$,$,$,.NOTDEFINED.);
+#23=IFCDISTRIBUTIONPORT('port-d',#1,'CP4',$,$,$,$,$,.NOTDEFINED.);
+#30=IFCRELCONNECTSPORTTOELEMENT('r-1',#1,$,$,#20,#10);
+#31=IFCRELCONNECTSPORTTOELEMENT('r-2',#1,$,$,#21,#11);
+#32=IFCRELCONNECTSPORTTOELEMENT('r-3',#1,$,$,#22,#11);
+#33=IFCRELCONNECTSPORTTOELEMENT('r-4',#1,$,$,#23,#12);
+#40=IFCRELCONNECTSPORTS('r-5',#1,$,$,#20,#21,$);
+#41=IFCRELCONNECTSPORTS('r-6',#1,$,$,#22,#23,#11);`;
+
+async function parse() {
+  const source = new TextEncoder().encode(IFC);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs = Array.from(tokenizer.scanEntitiesFast()).map((ref) => ({
+    expressId: ref.expressId,
+    type: ref.type,
+    byteOffset: ref.offset,
+    byteLength: ref.length,
+    lineNumber: ref.line,
+  }));
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0), entityRefs, {});
+}
+
+describe('port topology', () => {
+  it('links a port to the element it sits on, in both directions', async () => {
+    const store = await parse();
+    const rels = store.relationships;
+
+    // Forward follows the EXPRESS order: RelatingPort → RelatedElement.
+    expect(rels.getRelated(20, RelationshipType.ConnectsPortToElement, 'forward')).toEqual([10]);
+    // Inverse is the one a caller actually wants: give me this element's ports.
+    expect(
+      rels.getRelated(11, RelationshipType.ConnectsPortToElement, 'inverse').sort((a, b) => a - b),
+    ).toEqual([21, 22]);
+  });
+
+  it('links port to port', async () => {
+    const store = await parse();
+    const rels = store.relationships;
+
+    expect(rels.getRelated(20, RelationshipType.ConnectsPorts, 'forward')).toEqual([21]);
+    expect(rels.getRelated(21, RelationshipType.ConnectsPorts, 'inverse')).toEqual([20]);
+  });
+
+  it('ignores RealizingElement — a connection has two ends, not three', async () => {
+    const store = await parse();
+    const rels = store.relationships;
+
+    // #41 names #11 as the element realising the connection. The edge is
+    // still port-to-port; reading the optional third attribute as an end
+    // would invent a connection between a port and a pipe.
+    expect(rels.getRelated(22, RelationshipType.ConnectsPorts, 'forward')).toEqual([23]);
+    expect(rels.getRelated(11, RelationshipType.ConnectsPorts, 'forward')).toEqual([]);
+    expect(rels.getRelated(11, RelationshipType.ConnectsPorts, 'inverse')).toEqual([]);
+  });
+
+  it('makes a plant walkable end to end: element → ports → ports → elements', async () => {
+    const store = await parse();
+    const rels = store.relationships;
+
+    // The whole reason both relationships are needed. From the pump, reach
+    // what it is connected to without knowing anything about ports.
+    const reached = new Set<number>();
+    for (const port of rels.getRelated(10, RelationshipType.ConnectsPortToElement, 'inverse')) {
+      const opposite = [
+        ...rels.getRelated(port, RelationshipType.ConnectsPorts, 'forward'),
+        ...rels.getRelated(port, RelationshipType.ConnectsPorts, 'inverse'),
+      ];
+      for (const other of opposite) {
+        for (const element of rels.getRelated(other, RelationshipType.ConnectsPortToElement, 'forward')) {
+          reached.add(element);
+        }
+      }
+    }
+    expect([...reached]).toEqual([11]);
+  });
+
+  it('keeps the ports themselves addressable, so an edge can be drawn', async () => {
+    const store = await parse();
+    // An id the store cannot type is one a consumer has to skip; ports are
+    // IfcProduct subtypes and must survive parsing with their name intact.
+    expect(store.entities.getTypeName(20)).toBe('IfcDistributionPort');
+    expect(store.entities.getName(20)).toBe('CP1');
+  });
+});


### PR DESCRIPTION
## What and why

`IfcRelConnectsPortToElement` and `IfcRelConnectsPorts` were not in the
relationship index. The ports themselves were always parsed — they are
`IfcProduct` subtypes and land in the `EntityTable` like any other product —
but nothing recorded which element a port belonged to or which port it was
joined to. A distribution system therefore read as a set of unrelated parts,
and "what is this pump connected to" could not be answered from the store.

- `RelationshipType` gains `ConnectsPortToElement = 44` and `ConnectsPorts =
  45`, staying inside the existing 40-range for connection relationships.
- Both need their own branch in `extractRelFast`: their two ends are single
  references at attributes 4 and 5. The default branch reads attribute 5 as a
  list, and the `IfcRelConnectsElements` branch skips one attribute first,
  because that entity carries an optional `ConnectionGeometry` ahead of its
  ends.
- `HIERARCHY_REL_TYPES` is the gate — a type missing there is never collected
  and so never reaches `extractRelFast`.
- `IfcRelConnectsPorts.RealizingElement` is deliberately **not** read. It is
  the element that realises a connection (a length of duct, say), a third
  party rather than one of its two ends; treating it as an end would invent an
  edge between a port and that element. Pinned by a test.

With this, a plant is walked as element → `ConnectsPortToElement` inverse →
its ports → `ConnectsPorts` → the opposite ports → `ConnectsPortToElement`
forward → their elements.

## How it was verified

Ran on this change (Windows, node 24, pnpm 10.8.1):

```
pnpm --filter @ifc-lite/parser exec vitest run test/port-topology.test.ts
  1 file, 5 tests passed

pnpm --filter @ifc-lite/parser exec vitest run
  43 files, 340 tests passed

pnpm --filter @ifc-lite/data exec vitest run
  10 files, 98 tests passed
```

`packages/parser/test/port-topology.test.ts` runs against a neutral synthetic
STEP fixture written inline — a pump, two pipe segments, four ports and six
relationships, one port pair joined plainly and one joined *with* a
`RealizingElement`. No fixture download, so it runs anywhere. It covers: the
port-to-element link in both directions, the port-to-port link, that
`RealizingElement` produces no edge, the full walk from element through ports
back to elements, and that the ports stay addressable so an edge can be drawn.

Separately, and by hand rather than in CI, the change was checked against a
real electrical model: 184 ports, 184 port-to-element edges and 92 port-pair
edges read back exactly as the STEP file holds them, with all 92 connections
resolving to both of their elements. That model is not public and is not part
of this PR.

Not run: the full `pnpm test` across all packages, and `cargo test
--workspace`. This change touches no Rust, no geometry and no WASM boundary —
it adds two enum members and one branch in the STEP relationship reader.

- [x] `cargo test --workspace` (Rust) and/or `pnpm test` (TS) pass locally —
      TS tests of the two packages this touches, as listed above
- [ ] Geometry/WASM change: not applicable

## Checklist

- [x] A test asserts the new behavior through a fixture or a stated invariant
- [x] Published `packages/*` touched: added a changeset
      (`.changeset/port-topology-relationships.md`). The export surface is
      unchanged — `scripts/api-surface.json` records `RelationshipType: enum`
      without its members, so added members do not move it.
- [x] Geometry-output change: none
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no module
      pushed past ~400 non-generated lines, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for IFC port-to-element and port-to-port relationships.
  - Enabled topology traversal between plant elements, ports, and connected ports.
  - Preserved port entity types and names during relationship traversal.
  - Excluded optional realizing elements from topology connection endpoints.

- **Tests**
  - Added coverage for bidirectional port relationships and end-to-end topology traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
