### PR TITLE
test(merge): cover allowUnrelated and the shell-strip modify-vs-delete branch

### DIFF
--- a/packages/merge/src/ref-flow-resolutions.test.ts
+++ b/packages/merge/src/ref-flow-resolutions.test.ts
@@ -186,3 +186,108 @@ describe('candidate already on the ref (published drafts re-merged into their ho
     expect(outcome.status).toBe('unrelated-base');
   });
 });
+
+describe('MergeInit.allowUnrelated (override the unrelated-base refusal)', () => {
+  /**
+   * A ref with an ours-only entity (wall-2, untouched by the candidate)
+   * and an entity the candidate also touches (wall-1, divergent value).
+   * The candidate's declared base matches no prefix of the ref.
+   */
+  function unrelatedSetup() {
+    const store = new MemoryStore();
+    const oursBase = publishable(
+      [{ path: 'wall-1', attributes: { [FIRE]: 'REI60' } }],
+      'OursBase',
+      null,
+    );
+    store.storeLayer(oursBase);
+    const oursOnly = publishable(
+      [{ path: 'wall-2', attributes: { [FIRE]: 'REI30' } }],
+      'OursOnly',
+      [oursBase.header.id],
+    );
+    store.storeLayer(oursOnly);
+    store.setRef('main', { layers: [oursBase.header.id, oursOnly.header.id] });
+
+    const foreignBase = publishable([], 'ForeignBase', null);
+    store.storeLayer(foreignBase);
+    const candidate = publishable(
+      [
+        // Overlaps ours' wall-1 with a divergent value.
+        { path: 'wall-1', attributes: { [FIRE]: 'REI999' } },
+        // An entity that exists only in the candidate's unrelated history.
+        { path: 'wall-3', attributes: { [FIRE]: 'REI45' } },
+      ],
+      'Candidate',
+      [foreignBase.header.id],
+    );
+    store.storeLayer(candidate);
+    return { store, candidate };
+  }
+
+  it('refuses without the flag, and is bypassed with it (same candidate, same ref)', () => {
+    const { store, candidate } = unrelatedSetup();
+
+    const refused = mergeIntoRef(store, { candidateId: candidate.header.id, into: 'main' });
+    expect(refused.status).toBe('unrelated-base');
+
+    // Non-preview execution is where the refusal actually bites (preview
+    // never refuses, flag or not — `!init.preview` already short-circuits
+    // it). Exercise the real bypass on the executing path.
+    const bypassed = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      allowUnrelated: true,
+      resolutions: [{ path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'ours' }],
+    });
+    expect(bypassed.status).not.toBe('unrelated-base');
+    expect(bypassed.status).toBe('merged');
+  });
+
+  it('does not steamroll the ref: ours-only content survives, overlapping paths conflict instead of being overwritten', () => {
+    const { store, candidate } = unrelatedSetup();
+
+    const preview = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      preview: true,
+      allowUnrelated: true,
+    });
+    expect(preview.status).toBe('preview');
+    if (preview.status !== 'preview') return;
+    // The overlapping path surfaces as a conflict for a human to decide —
+    // planning against an empty ancestor must NOT read it as "theirs
+    // wholesale" and silently overwrite ours' value.
+    expect(preview.plan.conflicts).toHaveLength(1);
+    expect(preview.plan.conflicts[0]).toMatchObject({
+      kind: 'concurrent-edit',
+      path: 'wall-1',
+      componentKey: 'pset:Pset_FireSafety',
+    });
+    // wall-2 (ours-only, untouched by the candidate) is not itself a
+    // conflict and is not queued for any destructive op.
+    expect(preview.plan.conflicts.some((c) => c.path === 'wall-2')).toBe(false);
+    expect(
+      preview.plan.autoOps.some((op) => 'path' in op && op.path === 'wall-2' && op.op === 'tombstone-entity')
+    ).toBe(false);
+
+    const outcome = mergeIntoRef(store, {
+      candidateId: candidate.header.id,
+      into: 'main',
+      allowUnrelated: true,
+      resolutions: [{ path: 'wall-1', componentKey: 'pset:Pset_FireSafety', choice: 'ours' }],
+      created: '2026-07-11T02:00:00Z',
+    });
+    expect(outcome.status).toBe('merged');
+    if (outcome.status !== 'merged') return;
+
+    const state = extractStackState(outcome.refLayers.map((id) => store.loadLayer(id)));
+    // Ours' pre-existing, candidate-untouched entity survives verbatim.
+    expect(state.get('wall-2')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI30');
+    // The overlapping conflict resolved to ours, as instructed — not
+    // silently overwritten by treating the candidate's value as "new".
+    expect(state.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI60');
+    // The candidate's genuinely new entity is added.
+    expect(state.get('wall-3')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI45');
+  });
+});

--- a/packages/merge/src/resurrect.test.ts
+++ b/packages/merge/src/resurrect.test.ts
@@ -237,6 +237,42 @@ describe('shell strips and shadowed subtrees (verification-round fixes)', () => 
     expect(merged.get('storey')?.components.size ?? 0).toBe(0);
   });
 
+  it('theirs strips a parent to an empty shell while ours concurrently edits it → modify-vs-delete with a recorded (empty) theirs, resolved without a shadow-killing tombstone', () => {
+    // Unlike the auto-merged case above, ours here touches `storey` ITSELF
+    // (not just the child) — that's what turns the shell-strip into a real
+    // conflict instead of an automatic "theirs" application.
+    const oursEdit = makeLayer([{ path: 'storey', attributes: { [FIRE]: 'REI90' } }], 'ours-edit');
+    const strip = makeLayer(
+      [{ path: 'storey', children: { Wall: null }, attributes: { [CLASS]: null } }],
+      'strip'
+    );
+    const plan = planThreeWayMerge({
+      ancestor: [treeBase],
+      ours: [treeBase, oursEdit],
+      theirs: [treeBase, strip],
+    });
+    expect(plan.conflicts).toHaveLength(1);
+    const conflict = plan.conflicts[0];
+    expect(conflict.kind).toBe('modify-vs-delete');
+    expect(conflict.path).toBe('storey');
+    // The recorded (empty) theirs state is what routes applyResolutions
+    // into the removal-opinions path instead of a plain tombstone.
+    expect(conflict.theirs).toBeDefined();
+    expect(conflict.theirs?.attributes).toEqual({});
+
+    const applied = applyResolutions(plan, [{ path: 'storey', choice: 'theirs' }]);
+    // No tombstone-entity op: that would shadow-kill wall-1, which theirs
+    // never touched directly.
+    expect(applied.ops).not.toContainEqual({ op: 'tombstone-entity', path: 'storey' });
+    const merged = stateAfterMerge([treeBase, oursEdit], [...plan.autoOps, ...applied.ops]);
+    // The whole point of the branch: the child survives instead of dying
+    // under a parent tombstone it was never the target of.
+    expect(merged.get('wall-1')?.deleted).toBe(false);
+    expect(merged.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI60');
+    expect(merged.get('storey')?.deleted ?? false).toBe(false);
+    expect(merged.get('storey')?.components.size ?? 0).toBe(0);
+  });
+
   it('theirs deletes a parent whose child ours edited → ONE subtree conflict on the parent', () => {
     const oursEdit = makeLayer([{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }], 'ours-edit');
     const theirsDel = makeLayer(


### PR DESCRIPTION
## Summary

Two coverage gaps in `packages/merge`, both established by mutation: the specific mutation described for each left the full suite green (91 passed / 4 skipped before this PR).

### Gap 1 — `MergeInit.allowUnrelated: true` was untested in both directions

`ref-flow.ts`'s `mergeIntoRef` refuses a merge when the candidate's declared base matches no prefix of the ref, unless `allowUnrelated` is set:

```ts
if (manifest?.base != null && !ancestor.matched && !init.preview && !init.allowUnrelated) {
  return { status: 'unrelated-base', declaredBase: manifest.base };
}
```

**Reproduce**: removing `&& !init.allowUnrelated` from that condition (so refusal fires unconditionally, flag or not) left the suite green.

Because `!init.preview` is also part of the guard, `preview: true` calls already bypass the refusal unconditionally — the flag only matters on the executing (non-preview) path, so the new test exercises that path directly.

The more important question was whether the override, once exercised, is **destructive**: the surrounding comment warns that three-way planning against an empty ancestor "would read its every op as 'new' and steamroll the ref." I reproduced the actual merge output (not just the non-refusal) with a fixture where:
- an ours-only entity is untouched by the candidate,
- an entity **both sides touch** with divergent values,
- an entity is genuinely new only in the candidate.

**Result: the merge is not destructive.** With an empty ancestor, `mergeEntity`'s change detection treats "ours changed, theirs unchanged" as *theirs never touched it → keep ours* — so the ours-only entity survives verbatim. The entity both sides touch surfaces as a normal `concurrent-edit` conflict (resolved per the caller's `resolutions`/`resolve`, same as any other conflict) rather than being silently overwritten. Only the candidate's genuinely new entity auto-merges. Verified this empirically against real code before writing the test (a throwaway exploration script, not committed).

Tests added in `ref-flow-resolutions.test.ts`:
1. Refuses without the flag; bypassed with it on the executing (non-preview) path.
2. Full merged-state assertions: ours-only entity survives, overlapping entity is a conflict (not silently overwritten), theirs-only entity is added.

RED (mutation: drop `&& !init.allowUnrelated`) → both new tests fail (`expected 'unrelated-base' not to be 'unrelated-base'`, `expected 'unrelated-base' to be 'merged'`).
GREEN → both pass against unmodified code.

### Gap 2 — dead shell-strip branch in `modify-vs-delete` resolution

`merge-layer.ts`'s `applyResolutions`, `modify-vs-delete` case:

```ts
if (conflict.theirs !== undefined) {
  // removal-opinions path (no tombstone, to avoid shadow-killing children)
  return ops;
}
return [{ op: 'tombstone-entity', path: conflict.path }];
```

**Reproduce**: short-circuiting to `if (false && conflict.theirs !== undefined)` left the suite green.

The only existing shell-strip fixture (`resurrect.test.ts`, "an entity theirs stripped to an empty shell...") has `ours` unchanged at the stripped entity, so it auto-merges and never reaches this conflict branch at all — `conflict.theirs !== undefined` was reached by no fixture in the suite.

Added a fixture in the same `describe` block: `ours` edits the parent entity (`storey`) itself while `theirs` strips it to an empty shell (no explicit tombstone) — concurrent changes on the same path is what turns the shell-strip into a real `modify-vs-delete` conflict (as opposed to the existing auto-merge case, where only the *child* is edited and the parent itself is untouched by ours). Resolving with `choice: 'theirs'` and asserting:
- the conflict carries a defined (empty) `theirs` snapshot,
- `applyResolutions` emits removal-opinion ops, not `tombstone-entity`,
- the child (`wall-1`) survives (`deleted: false`) instead of being shadow-killed.

RED (mutation: `if (false && ...)`) → new test fails: `tombstone-entity` emitted, child ends up `deleted: true`.
GREEN → passes against unmodified code; child survives.

## Verify

- `packages/merge` suite: **94 passed | 4 skipped** (was 91 passed | 4 skipped; +3 new tests), 8 files + 1 skipped — unchanged skip count (the 4 skips are `real-model-fuzz.test.ts` cases gated on large `.ifcx` fixtures, expected in a fresh checkout).
- `tsc --noEmit` (package `src` scope): clean.
- `scripts/typecheck-tests.mjs` (test scope): `packages/merge OK (9 test files)`.
- `oxlint` scoped to `packages/merge/src`: 0 errors (1 pre-existing warning in `component-state.ts`, unrelated to this change).
- `git diff` against `main`: production code unchanged (both mutations were reverted after reproducing RED); only the two test files changed.

No changeset — test-only change, no defect found in production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for merging unrelated changes, including explicit opt-in behavior, preserved local entities, conflicts, and newly added entities.
  * Added regression coverage for resolving concurrently edited parent entities that become empty, preserving children while removing obsolete parent data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->