### PR TITLE
fix(sdk): wire ids.validate({locale}) to the translation service

### DIFF
--- a/.changeset/wire-ids-locale.md
+++ b/.changeset/wire-ids-locale.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/sdk": patch
+---
+
+Fix `bim.ids.validate({ locale })` being silently ignored. The SDK forwarded a `locale` key into `@ifc-lite/ids`'s `validateIDS` options, but `ValidatorOptions` has no such field — only a `translator` object it destructures directly — so every call produced English-only messages regardless of the requested locale (this also made the CLI's `ids --locale` flag inert).
+
+`validate()` now builds a `translator` from the requested locale via `createTranslationService` before calling into the validator, the same pattern the viewer's IDS worker already used. `de` and `fr` locales now actually change the human-readable requirement and failure text in the validation report.

--- a/packages/sdk/src/namespaces/ids.test.ts
+++ b/packages/sdk/src/namespaces/ids.test.ts
@@ -4,8 +4,90 @@
 
 import { describe, it, expect } from 'vitest';
 import { IDSNamespace } from './ids.js';
+import type {
+  IDSDocument,
+  IDSSimpleValue,
+  IDSModelInfo,
+  IFCDataAccessor,
+} from '@ifc-lite/ids';
 
 const ids = new IDSNamespace();
+
+const sv = (value: string): IDSSimpleValue => ({ type: 'simpleValue', value });
+
+/** Minimal IFCDataAccessor over a single entity missing its Name attribute. */
+function makeAccessor(): IFCDataAccessor {
+  return {
+    getEntityType: (id) => (id === 1 ? 'IfcWall' : undefined),
+    getEntityName: () => undefined,
+    getGlobalId: () => undefined,
+    getDescription: () => undefined,
+    getObjectType: () => undefined,
+    getEntitiesByType: (typeName) => (typeName.toUpperCase() === 'IFCWALL' ? [1] : []),
+    getAllEntityIds: () => [1],
+    getPropertyValue: () => undefined,
+    getPropertySets: () => [],
+    getClassifications: () => [],
+    getMaterials: () => [],
+    getParent: () => undefined,
+    getAttribute: () => undefined,
+  };
+}
+
+function makeDoc(): IDSDocument {
+  return {
+    info: { title: 'Locale test' },
+    specifications: [
+      {
+        id: 'spec-0',
+        name: 'Walls must have a name',
+        ifcVersions: ['IFC4'],
+        applicability: { facets: [{ type: 'entity', name: sv('IFCWALL') }] },
+        requirements: [
+          {
+            id: 'req-0',
+            facet: { type: 'attribute', name: sv('Name') },
+            optionality: 'required',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const modelInfo: IDSModelInfo = {
+  modelId: 'test-model',
+  schemaVersion: 'IFC4',
+  entityCount: 1,
+};
+
+describe('IDSNamespace.validate — locale', () => {
+  it('produces a German failure message when locale is "de"', async () => {
+    const reportEn = (await ids.validate(makeDoc(), {
+      accessor: makeAccessor(),
+      modelInfo,
+      locale: 'en',
+    })) as {
+      specificationResults: Array<{
+        entityResults: Array<{ requirementResults: Array<{ failureReason?: string }> }>;
+      }>;
+    };
+    const reportDe = (await ids.validate(makeDoc(), {
+      accessor: makeAccessor(),
+      modelInfo,
+      locale: 'de',
+    })) as typeof reportEn;
+
+    const enReason = reportEn.specificationResults[0].entityResults[0].requirementResults[0]
+      .failureReason;
+    const deReason = reportDe.specificationResults[0].entityResults[0].requirementResults[0]
+      .failureReason;
+
+    expect(enReason).toBeTruthy();
+    expect(deReason).toBeTruthy();
+    expect(deReason).not.toBe(enReason);
+  });
+});
 
 describe('IDSNamespace.summarize', () => {
   it('derives spec pass/fail from entity results when no status is present', () => {

--- a/packages/sdk/src/namespaces/ids.test.ts
+++ b/packages/sdk/src/namespaces/ids.test.ts
@@ -13,6 +13,18 @@ import type {
 
 const ids = new IDSNamespace();
 
+// `IDSNamespace` dynamically imports `@ifc-lite/ids` on first use (see
+// `loadIDS` in ids.ts) so that SDK consumers who never touch `bim.ids`
+// don't pay for it. That's the right tradeoff for real callers, who load
+// the module once and then reuse it — but it means whichever test in this
+// file happens to be the first to call `validate`/`parse`/etc. pays the
+// one-time cold-import cost inside its own timer. Under CI's parallel test
+// load that cost alone can approach the default 5s test timeout. Warm the
+// import here, during module collection (unbounded by any per-test or
+// per-hook timeout), so the locale test below only times the logic it
+// exists to check.
+await import('@ifc-lite/ids');
+
 const sv = (value: string): IDSSimpleValue => ({ type: 'simpleValue', value });
 
 /** Minimal IFCDataAccessor over a single entity missing its Name attribute. */

--- a/packages/sdk/src/namespaces/ids.ts
+++ b/packages/sdk/src/namespaces/ids.ts
@@ -95,9 +95,16 @@ export class IDSNamespace {
    */
   async validate(idsDocument: unknown, options: IDSValidateOptions): Promise<unknown> {
     const mod = await loadIDS();
+    // `ValidatorOptions` has no `locale` field — the validator only
+    // understands a `translator` (see @ifc-lite/ids `ValidatorOptions`).
+    // Build one from the requested locale so `locale` actually reaches
+    // the human-readable messages instead of being silently dropped.
+    const translator = options.locale
+      ? (mod.createTranslationService as AnyFn)(options.locale)
+      : undefined;
     return (mod.validateIDS as AnyFn)(idsDocument, options.accessor, options.modelInfo ?? {}, {
       onProgress: options.onProgress,
-      locale: options.locale,
+      translator,
       includePassingEntities: options.includePassingEntities,
     });
   }

--- a/packages/sdk/src/namespaces/ids.ts
+++ b/packages/sdk/src/namespaces/ids.ts
@@ -38,8 +38,15 @@ export interface IDSValidationProgress {
 export interface IDSValidateOptions {
   /** IFC data accessor — maps IFC model data for validation */
   accessor: unknown;
-  /** Model info (schema version, name, etc.) for spec applicability checks */
-  modelInfo?: { schemaVersion?: string; name?: string; [key: string]: unknown };
+  /**
+   * Model info for spec applicability checks. Mirrors the shape
+   * `@ifc-lite/ids`'s `IDSModelInfo` expects (`modelId`, `schemaVersion`,
+   * `entityCount`) without importing that type, keeping this namespace
+   * decoupled from `@ifc-lite/ids` at compile time (see the summary type
+   * above). All fields are optional here — the validator is called with
+   * `options.modelInfo ?? {}`, so a caller may supply only what it knows.
+   */
+  modelInfo?: { modelId?: string; schemaVersion?: string; entityCount?: number };
   /** Progress callback */
   onProgress?: (progress: IDSValidationProgress) => void;
   /** Locale for human-readable messages */


### PR DESCRIPTION
## Summary

`bim.ids.validate({ locale })` (and therefore the CLI's `ids --locale` flag, issue #2731) was inert. The SDK forwarded `locale: options.locale` straight into `@ifc-lite/ids`'s `validateIDS` options, but `ValidatorOptions` has no `locale` field — only a `translator: TranslationService` it destructures directly (`packages/ids/src/validation/validator.ts:186-188`). The unknown `locale` key was silently dropped, so every call produced English-only messages no matter what locale was requested.

`@ifc-lite/ids` already ships `createTranslationService(locale)` (`packages/ids/src/translation/service.ts`), which returns exactly the `TranslationService` shape the validator's `translator` option expects — no adapter needed. It's already used this way by the viewer's IDS worker (`apps/viewer/src/workers/idsValidation.worker.ts:79-90`), just never wired into the SDK/CLI path.

`IDSNamespace.validate()` now builds the translator from the requested locale before calling into the validator:

```ts
const translator = options.locale
  ? (mod.createTranslationService as AnyFn)(options.locale)
  : undefined;
return (mod.validateIDS as AnyFn)(idsDocument, options.accessor, options.modelInfo ?? {}, {
  onProgress: options.onProgress,
  translator,
  includePassingEntities: options.includePassingEntities,
});
```

This also fixes `gym/channels.ts`'s `locale` pass-through for free, since it goes through the same `IDSNamespace.validate()`.

## Test plan

- [x] Added `packages/sdk/src/namespaces/ids.test.ts` — validates the same missing-attribute failure through `bim.ids.validate` with `locale: 'en'` vs `locale: 'de'` and asserts the failure-reason strings differ.
- [x] `packages/sdk` vitest: new test passes (4/4 in `ids.test.ts`).
- [x] `packages/ids` vitest: `src/validation` suite passes (35/35), unaffected by this change.
- [x] Changeset added (`@ifc-lite/sdk` patch) — this changes user-visible validation-report text.

Note: full-suite `packages/sdk`/`packages/cli`/`packages/ids` vitest runs in my environment show unrelated pre-existing failures (stale `@ifc-lite/data`/`@ifc-lite/parser` dist symlinked from a shared checkout — `isInstantiable is not a function`, `mergeInheritedPropertySets is not a function`, etc.), reproducible with this branch's parent (`upstream/main`) too. None touch translation/locale/IDS-validator code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)