### PR TITLE
test(query): cover escapeSQL and IfcQuery's spatial/hierarchy success paths

### DIFF
--- a/packages/query/src/duckdb-integration.ts
+++ b/packages/query/src/duckdb-integration.ts
@@ -496,9 +496,13 @@ export class DuckDBIntegration {
 }
 
 /**
- * Escape a string for SQL (prevent SQL injection)
+ * Escape a string for SQL (prevent SQL injection).
+ *
+ * Exported for direct unit testing: the surrounding INSERT-building logic
+ * requires a live DuckDB-WASM connection, so exercising this string-escaping
+ * logic through that path is impractical in a unit test.
  */
-function escapeSQL(value: string | null | undefined): string {
+export function escapeSQL(value: string | null | undefined): string {
   if (value === null || value === undefined) {
     return '';
   }

--- a/packages/query/test/escape-sql.test.ts
+++ b/packages/query/test/escape-sql.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { escapeSQL } from '../src/duckdb-integration.js';
+
+// escapeSQL interpolates IFC strings (entity names, GlobalIds, property and
+// quantity values, pset/qset names) directly into DuckDB INSERT statement
+// text. It is exercised here directly rather than through the WASM-backed
+// insert path, which requires a live DuckDB connection.
+describe('escapeSQL', () => {
+  it('leaves a value with no special characters unchanged', () => {
+    expect(escapeSQL('Exterior Wall')).toBe('Exterior Wall');
+  });
+
+  it('doubles a single apostrophe in the middle of a value', () => {
+    // e.g. a French/German description such as "L'entrée principale"
+    expect(escapeSQL("L'entree")).toBe("L''entree");
+  });
+
+  it('doubles several apostrophes in one value', () => {
+    expect(escapeSQL("'a'b'c'")).toBe("''a''b''c''");
+  });
+
+  it('doubles an apostrophe at the start of a value', () => {
+    expect(escapeSQL("'leading")).toBe("''leading");
+  });
+
+  it('doubles an apostrophe at the end of a value', () => {
+    expect(escapeSQL("trailing'")).toBe("trailing''");
+  });
+
+  it('doubles apostrophes in dimension notation like 5\' 6"', () => {
+    expect(escapeSQL('5\' 6"')).toBe('5\'\' 6"');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(escapeSQL('')).toBe('');
+  });
+
+  it('returns an empty string for null', () => {
+    expect(escapeSQL(null)).toBe('');
+  });
+
+  it('returns an empty string for undefined', () => {
+    expect(escapeSQL(undefined)).toBe('');
+  });
+
+  it('leaves a backslash untouched', () => {
+    // DuckDB's default SQL dialect (standard_conforming_strings) does not
+    // treat backslash as an escape character inside a '...' string literal
+    // — unlike MySQL — so a literal backslash needs no special handling here.
+    expect(escapeSQL('C:\\path\\to\\file')).toBe('C:\\path\\to\\file');
+  });
+});

--- a/packages/query/test/ifc-query.test.ts
+++ b/packages/query/test/ifc-query.test.ts
@@ -79,6 +79,83 @@ describe('IfcQuery', () => {
 
   // ── Hierarchy (no spatial hierarchy set up) ───────────────────
 
+  describe('hierarchy / project / storeys with a real spatial hierarchy', () => {
+    // Storeys inserted out of elevation order (id 1 highest, id 2 lowest,
+    // id 3 middle) so an ascending-elevation sort is actually observable —
+    // a comparator that is a no-op, or reversed, would leave [1, 2, 3].
+    function storeyStore() {
+      return createMockStore({
+        entities: [
+          { expressId: 100, type: 'IFCPROJECT', globalId: 'proj-1', name: 'My Project' },
+          { expressId: 1, type: 'IFCBUILDINGSTOREY', globalId: 's1', name: 'Level 2' },
+          { expressId: 2, type: 'IFCBUILDINGSTOREY', globalId: 's2', name: 'Level 0' },
+          { expressId: 3, type: 'IFCBUILDINGSTOREY', globalId: 's3', name: 'Level 1' },
+        ],
+        spatialHierarchy: {
+          projectId: 100,
+          byStorey: [
+            [1, [201, 202]],
+            [2, [203]],
+            [3, [204, 205, 206]],
+          ],
+          storeyElevations: [
+            [1, 6.0],
+            [2, 0.0],
+            [3, 3.0],
+          ],
+        },
+      });
+    }
+
+    it('hierarchy getter returns the real SpatialHierarchy when available', () => {
+      const store = storeyStore();
+      const query = new IfcQuery(store as any);
+      expect(query.hierarchy).not.toBeNull();
+      expect(query.hierarchy!.project.expressId).toBe(100);
+    });
+
+    it('project getter resolves the project entity from spatialHierarchy', () => {
+      const store = storeyStore();
+      const query = new IfcQuery(store as any);
+      expect(query.project).not.toBeNull();
+      expect(query.project!.expressId).toBe(100);
+    });
+
+    it('storeys getter returns storeys sorted ascending by elevation', () => {
+      const store = storeyStore();
+      const query = new IfcQuery(store as any);
+      const ids = query.storeys.map(s => s.expressId);
+      // Elevation order is 2 (0.0) < 3 (3.0) < 1 (6.0) — distinct from the
+      // [1, 2, 3] insertion order used to build byStorey above.
+      expect(ids).toEqual([2, 3, 1]);
+    });
+
+    it('onStorey() returns exactly that storey\'s element ids, in order', () => {
+      const store = storeyStore();
+      const query = new IfcQuery(store as any);
+      expect(query.onStorey(3).execute().map(r => r.expressId)).toEqual([204, 205, 206]);
+      expect(query.onStorey(1).execute().map(r => r.expressId)).toEqual([201, 202]);
+    });
+
+    it('onStorey() distinguishes a wrong key from the requested one', () => {
+      // byStorey keyed so that storeyId + 999999 collides with a *different*,
+      // non-empty entry — a lookup-key bug produces a different populated
+      // result here, not an empty one, which is stronger evidence than a miss.
+      const store = createMockStore({
+        entities: [{ expressId: 100, type: 'IFCPROJECT', globalId: 'proj-1', name: 'Project' }],
+        spatialHierarchy: {
+          projectId: 100,
+          byStorey: [
+            [5, [301, 302]],
+            [1000004, [401]], // 5 + 999999
+          ],
+          storeyElevations: [],
+        },
+      });
+      const query = new IfcQuery(store as any);
+      expect(query.onStorey(5).execute().map(r => r.expressId)).toEqual([301, 302]);
+    });
+  });
 
   // ── Spatial queries (require spatial index) ───────────────────
 
@@ -103,6 +180,33 @@ describe('IfcQuery', () => {
       const store = makeStore();
       const query = new IfcQuery(store as any);
       expect(() => query.onStorey(4)).toThrow(/Spatial hierarchy not available/);
+    });
+  });
+
+  describe('spatial queries with a real spatial index', () => {
+    it('inBounds() returns exactly the ids the index reports', () => {
+      const store = createMockStore({
+        entities: [
+          { expressId: 1, type: 'IFCWALL', globalId: 'w1', name: 'Wall 1' },
+          { expressId: 2, type: 'IFCWALL', globalId: 'w2', name: 'Wall 2' },
+        ],
+        spatialIndex: { queryAABBResult: [1, 2] },
+      });
+      const query = new IfcQuery(store as any);
+      const ids = query.inBounds({ min: [0, 0, 0], max: [1, 1, 1] } as any).execute().map(r => r.expressId);
+      expect(ids).toEqual([1, 2]);
+    });
+
+    it('raycast() returns exactly the ids the index reports, in order', () => {
+      const store = createMockStore({
+        entities: [
+          { expressId: 1, type: 'IFCWALL', globalId: 'w1', name: 'Wall 1' },
+          { expressId: 2, type: 'IFCWALL', globalId: 'w2', name: 'Wall 2' },
+        ],
+        spatialIndex: { raycastResult: [2, 1] },
+      });
+      const query = new IfcQuery(store as any);
+      expect(query.raycast([0, 0, 0], [1, 0, 0])).toEqual([2, 1]);
     });
   });
 

--- a/packages/query/test/mock-store.ts
+++ b/packages/query/test/mock-store.ts
@@ -19,7 +19,10 @@ import {
   QuantityType,
   type IfcStoreBase,
   type IfcEntity,
+  type SpatialHierarchy,
+  type SpatialNode,
 } from '@ifc-lite/data';
+import type { SpatialIndex } from '@ifc-lite/spatial';
 
 export {
   IfcTypeEnum,
@@ -62,11 +65,75 @@ export interface MockRelationship {
   relId: number;
 }
 
+/**
+ * Minimal spatial hierarchy descriptor for mocking `IfcDataStore.spatialHierarchy`.
+ * `byStorey` may contain keys with no corresponding `storeyElevations` entry
+ * (elevation then defaults to 0) — useful for onStorey() fixtures that need
+ * an extra, unrelated map entry to make a wrong-key lookup observable.
+ */
+export interface MockSpatialHierarchyOptions {
+  projectId: number;
+  projectName?: string;
+  /** storeyId -> element expressIds, inserted in the given key order. */
+  byStorey: Array<[number, number[]]>;
+  /** storeyId -> elevation (z), inserted in the given order (need not match `byStorey`'s order). */
+  storeyElevations: Array<[number, number]>;
+}
+
+/** Minimal spatial index descriptor for mocking `IfcDataStore.spatialIndex`. */
+export interface MockSpatialIndexOptions {
+  queryAABBResult?: number[];
+  raycastResult?: number[];
+}
+
 export interface MockStoreOptions {
   entities?: MockEntity[];
   properties?: MockProperty[];
   quantities?: MockQuantity[];
   relationships?: MockRelationship[];
+  /** Omitted by default so existing "not available" throw-branch tests keep passing. */
+  spatialHierarchy?: MockSpatialHierarchyOptions;
+  /** Omitted by default so existing "not available" throw-branch tests keep passing. */
+  spatialIndex?: MockSpatialIndexOptions;
+}
+
+function buildMockSpatialHierarchy(
+  opts: MockSpatialHierarchyOptions,
+  entities: MockEntity[],
+): SpatialHierarchy {
+  const projectEntity = entities.find(e => e.expressId === opts.projectId);
+  const project: SpatialNode = {
+    expressId: opts.projectId,
+    type: IfcTypeEnum.IfcProject,
+    name: opts.projectName ?? projectEntity?.name ?? '',
+    children: [],
+    elements: [],
+  };
+  const byStorey = new Map<number, number[]>(opts.byStorey);
+  const storeyElevations = new Map<number, number>(opts.storeyElevations);
+
+  return {
+    project,
+    byStorey,
+    byBuilding: new Map(),
+    bySite: new Map(),
+    bySpace: new Map(),
+    storeyElevations,
+    storeyHeights: new Map(),
+    elementToStorey: new Map(),
+    getStoreyElements: (storeyId: number) => byStorey.get(storeyId) ?? [],
+    getStoreyByElevation: () => null,
+    getContainingSpace: () => null,
+    getPath: () => [project],
+  };
+}
+
+function buildMockSpatialIndex(opts: MockSpatialIndexOptions): SpatialIndex {
+  return {
+    queryAABB: () => opts.queryAABBResult ?? [],
+    raycast: () => opts.raycastResult ?? [],
+    queryFrustum: () => [],
+  };
 }
 
 /**
@@ -178,9 +245,12 @@ export function createMockStore(opts: MockStoreOptions = {}): IfcStoreBase {
     getProperties: (expressId: number) => properties.getForEntity(expressId),
     getQuantities: (expressId: number) => quantities.getForEntity(expressId),
 
-    // These are optional on IfcDataStore and can be undefined for mock
-    spatialHierarchy: undefined,
-    spatialIndex: undefined,
+    // Optional on IfcDataStore; undefined unless the caller opts in, so the
+    // "not available" throw-branch tests keep exercising the real absent case.
+    spatialHierarchy: opts.spatialHierarchy
+      ? buildMockSpatialHierarchy(opts.spatialHierarchy, opts.entities ?? [])
+      : undefined,
+    spatialIndex: opts.spatialIndex ? buildMockSpatialIndex(opts.spatialIndex) : undefined,
     onDemandPropertyMap: undefined,
     onDemandQuantityMap: undefined,
     onDemandClassificationMap: undefined,


### PR DESCRIPTION
## Summary

Two coverage gaps in `packages/query`, both established by mutation testing before writing any test: each mutation left all 156 existing tests green.

### Gap 1 — `escapeSQL` (packages/query/src/duckdb-integration.ts:501-507)

Reproduce-first: replacing the body with `return value;` (a no-op) left the full 156-test suite green — the function had zero test coverage even though it interpolates IFC strings (entity names, GlobalIds, property/quantity values, pset/qset names) directly into DuckDB `INSERT` SQL text.

`escapeSQL` is module-private and only reachable through a WASM-dependent `init()`/`registerTables` path, so it is now exported (smallest change that makes it directly testable — no other API surface change).

New tests (`test/escape-sql.test.ts`) cover: no special characters, a single apostrophe, several apostrophes, an apostrophe at the start, one at the end, dimension notation (`5' 6"`), empty string, `null`, `undefined`, and a backslash.

**Backslash verdict: not a defect.** DuckDB's default `'...'` string literal follows the SQL standard (like PostgreSQL's `standard_conforming_strings = on`): a backslash inside a plain `'...'` literal is literal, not an escape character — that behavior only changes with an `E'...'`/`e'...'`-prefixed literal, which this code doesn't use. So a bare backslash needs no special handling here, and the test pins that as intended behavior rather than "hardening" the function.

Mutation → test mapping: `return value;` (no-op) fails 7 of the 10 new tests (the apostrophe- and boundary-cases plus null/undefined) while leaving the plain-string and backslash cases passing — restoring the real implementation turns all 10 green.

### Gap 2 — `IfcQuery`'s spatial/hierarchy success paths (packages/query/src/ifc-query.ts:109-154)

Reproduce-first, two independent mutations, each left 156/156 green:
- flipping the `storeys` sort comparator `elevA - elevB` → `elevB - elevA`
- corrupting `onStorey`'s lookup `byStorey.get(storeyId)` → `byStorey.get(storeyId + 999999)`

`test/mock-store.ts` hardcoded `spatialHierarchy`/`spatialIndex` to `undefined`, so `test/ifc-query.test.ts` only ever reached the "not available" throw branches.

`mock-store.ts` now takes **optional** `spatialHierarchy` / `spatialIndex` descriptors (`MockSpatialHierarchyOptions` / `MockSpatialIndexOptions`) and builds real `SpatialHierarchy` / `SpatialIndex` objects from them. Omitted by default, so the existing "not available" throw-branch tests are unaffected — verified they still pass (18/18 in `ifc-query.test.ts`, up from 11, with none of the original assertions changed).

New fixtures in `ifc-query.test.ts`:
- storeys inserted out of elevation order (ids `1, 2, 3` with elevations `6.0, 0.0, 3.0`) so the ascending sort is observable — `storeys` must resolve to `[2, 3, 1]`.
- `onStorey()` asserted against exact id sets/order per storey, plus a dedicated fixture where `storeyId + 999999` collides with a *different populated* `byStorey` entry (`5` vs `1000004`), so a lookup-key bug returns wrong contents rather than an empty result — stronger evidence than a miss.
- `hierarchy`/`project` getters, and `inBounds()`/`raycast()` against a mock `SpatialIndex`, for completeness on the same previously-dead surface.

Mutation → test mapping:
- comparator flip fails `storeys getter returns storeys sorted ascending by elevation` (`[1,3,2]` vs expected `[2,3,1]`)
- lookup corruption fails both `onStorey()` tests, including the collision fixture (`[401]` vs expected `[301,302]`)

Both mutations restored to green after confirming the failures.

## Test plan

- [x] Reproduced both gaps against `main` before writing tests (mutation stays green)
- [x] `packages/query` full suite: baseline 156 passed / 11 files → now 173 passed / 12 files
- [x] Both mutations individually re-applied post-fix and confirmed RED, then reverted to GREEN
- [x] `node ../../scripts/typecheck-tests.mjs` (packages/query scope) — OK, 12 test files
- [x] `npx tsc --noEmit` (packages/query build scope) — clean
- [x] Lint: `oxlint` is not installed anywhere in this environment's dependency store, so the repo's `check-lint-ran.mjs` gate could not be run. Ran `scripts/check-unused-locals.mjs` instead — `packages/query` (the only package touched) does not appear in its failure/violation output; the packages it does flag as failing to compile standalone are pre-existing environment link gaps unrelated to this change (not touched here).

No changeset: test-only change, no defect found (the backslash question resolved as "working as intended for DuckDB's dialect," not a bug).

Out of scope, per the file's own remaining gap: `duckdb-integration.ts`'s `init()`/connection lifecycle is still untested — that needs a stubbed WASM module and wasn't part of this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made SQL escaping functionality available for external use.

* **Tests**
  * Added coverage for SQL escaping, including null, empty, apostrophe, and backslash inputs.
  * Added tests for spatial hierarchy resolution, storey ordering, element lookup, and spatial index results.
  * Enhanced test fixtures to support configurable spatial hierarchy and spatial query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->