### PR TITLE
fix(bcf): make Guid-attribute regexes order-independent in reader.ts

### DIFF
--- a/.changeset/bcf-attribute-order-independence.md
+++ b/.changeset/bcf-attribute-order-independence.md
@@ -1,0 +1,22 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Fix `readBCF` silently dropping topics from spec-legal BCF files written by other tools.
+
+`reader.ts`'s regexes for `<Topic>`, `<RelatedTopic>`, `<Comment>`, and the
+comment's `<Viewpoint>` reference required `Guid` to be the attribute
+immediately after the tag name. XML attribute order is not semantically
+significant, so a file written with e.g. `<Topic TopicType="Issue"
+TopicStatus="Open" Guid="topic-1">` failed to match: `readTopic` logged
+"missing Topic element" and the whole topic -- title, comments, viewpoints --
+was silently dropped with no throw and no partial result.
+
+Our own `writer.ts` always emits `Guid` first, so every self round-trip
+passed and no existing test caught this; only a file from another tool
+exposed it.
+
+Each affected site now matches the opening tag generically (`<Tag\b([^>]*)>`)
+and pulls individual attributes out of the captured attribute string with a
+new shared `extractAttr` helper, so attribute order can no longer matter at
+any of these call sites.

--- a/packages/bcf/src/attr-order.test.ts
+++ b/packages/bcf/src/attr-order.test.ts
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * XML attribute order is not semantically significant, but several of
+ * reader.ts's regexes required `Guid="..."` to be the FIRST attribute on an
+ * opening tag. Our own writer.ts always emits Guid first, so a self
+ * round-trip never caught this -- only a file from another tool, where the
+ * attribute order differs, exposes it. These tests build markup with
+ * attributes deliberately reordered before Guid.
+ */
+
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { readBCF } from './reader.js';
+
+async function readMarkup(markup: string) {
+  const zip = new JSZip();
+  zip.file('bcf.version', '<?xml version="1.0"?><Version VersionId="2.1"></Version>');
+  zip.file('topic-1/markup.bcf', markup);
+  const buffer = await zip.generateAsync({ type: 'arraybuffer' });
+  return readBCF(buffer);
+}
+
+describe('interop: attribute order independence', () => {
+  it('reads a Topic whose Guid is not the first attribute', async () => {
+    const markup = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<Markup>',
+      '  <Topic TopicType="Issue" TopicStatus="Open" Guid="topic-1">',
+      '    <Title>Reordered attrs</Title>',
+      '  </Topic>',
+      '</Markup>',
+    ].join('\n');
+
+    const project = await readMarkup(markup);
+
+    expect(project.topics.size).toBe(1);
+    const topic = project.topics.get('topic-1');
+    expect(topic).toBeDefined();
+    expect(topic?.title).toBe('Reordered attrs');
+    expect(topic?.topicType).toBe('Issue');
+    expect(topic?.topicStatus).toBe('Open');
+  });
+
+  it('reads a RelatedTopic whose Guid is not the first attribute', async () => {
+    const markup = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<Markup>',
+      '  <Topic Guid="topic-1">',
+      '    <Title>Has related</Title>',
+      '    <RelatedTopic Foo="bar" Guid="topic-2"/>',
+      '  </Topic>',
+      '</Markup>',
+    ].join('\n');
+
+    const project = await readMarkup(markup);
+    const topic = project.topics.get('topic-1');
+    expect(topic?.relatedTopics).toEqual(['topic-2']);
+  });
+
+  it('reads a Comment whose Guid is not the first attribute', async () => {
+    const markup = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<Markup>',
+      '  <Topic Guid="topic-1">',
+      '    <Title>Has comment</Title>',
+      '  </Topic>',
+      '  <Comment Foo="bar" Guid="comment-1">',
+      '    <Date>2026-01-01T00:00:00Z</Date>',
+      '    <Author>alice@example.com</Author>',
+      '    <Comment>hello</Comment>',
+      '  </Comment>',
+      '</Markup>',
+    ].join('\n');
+
+    const project = await readMarkup(markup);
+    const topic = project.topics.get('topic-1');
+    expect(topic?.comments.length).toBe(1);
+    expect(topic?.comments[0].guid).toBe('comment-1');
+    expect(topic?.comments[0].comment).toBe('hello');
+  });
+
+  it('reads a Comment\'s Viewpoint reference whose Guid is not the first attribute', async () => {
+    const markup = [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<Markup>',
+      '  <Topic Guid="topic-1">',
+      '    <Title>Has comment viewpoint ref</Title>',
+      '  </Topic>',
+      '  <Comment Guid="comment-1">',
+      '    <Date>2026-01-01T00:00:00Z</Date>',
+      '    <Author>alice@example.com</Author>',
+      '    <Comment>hello</Comment>',
+      '    <Viewpoint Foo="bar" Guid="vp-1"/>',
+      '  </Comment>',
+      '</Markup>',
+    ].join('\n');
+
+    const project = await readMarkup(markup);
+    const topic = project.topics.get('topic-1');
+    expect(topic?.comments[0].viewpointGuid).toBe('vp-1');
+  });
+});

--- a/packages/bcf/src/reader.ts
+++ b/packages/bcf/src/reader.ts
@@ -317,14 +317,21 @@ async function readTopic(zip: JSZip, topicFolder: string, budget: ExpansionBudge
 
   const markupContent = await readEntryCapped(markupFile, 'string', budget);
 
-  // Parse Topic element
-  const topicMatch = markupContent.match(/<Topic\s+Guid="([^"]+)"[^>]*>([\s\S]*?)<\/Topic>/);
+  // Parse Topic element. Attributes are captured generically (not anchored to
+  // Guid being first) and pulled out with extractAttr, so a spec-legal file
+  // that orders attributes differently from our own writer still parses.
+  const topicMatch = markupContent.match(/<Topic\b([^>]*)>([\s\S]*?)<\/Topic>/);
   if (!topicMatch) {
     console.warn(`Invalid markup.bcf in ${topicFolder}: missing Topic element`);
     return null;
   }
 
-  const guid = topicMatch[1];
+  const topicAttrs = topicMatch[1];
+  const guid = extractAttr(topicAttrs, 'Guid');
+  if (!guid) {
+    console.warn(`Invalid markup.bcf in ${topicFolder}: Topic element missing Guid`);
+    return null;
+  }
   const topicContent = topicMatch[2];
 
   // Header (source IFC files) sits before Topic in the markup, so parse it from
@@ -332,8 +339,8 @@ async function readTopic(zip: JSZip, topicFolder: string, budget: ExpansionBudge
   const header = parseHeaderFiles(markupContent);
 
   // Extract topic attributes
-  const topicTypeMatch = markupContent.match(/<Topic[^>]*TopicType="([^"]+)"/);
-  const topicStatusMatch = markupContent.match(/<Topic[^>]*TopicStatus="([^"]+)"/);
+  const topicType = extractAttr(topicAttrs, 'TopicType');
+  const topicStatus = extractAttr(topicAttrs, 'TopicStatus');
 
   // Extract topic elements
   const title = extractElement(topicContent, 'Title') || 'Untitled';
@@ -363,9 +370,10 @@ async function readTopic(zip: JSZip, topicFolder: string, budget: ExpansionBudge
 
   // Extract related topics
   const relatedTopics: string[] = [];
-  const relatedMatches = topicContent.matchAll(/<RelatedTopic\s+Guid="([^"]+)"/g);
+  const relatedMatches = topicContent.matchAll(/<RelatedTopic\b([^>]*)\/?>/g);
   for (const match of relatedMatches) {
-    relatedTopics.push(match[1]);
+    const relatedGuid = extractAttr(match[1], 'Guid');
+    if (relatedGuid) relatedTopics.push(relatedGuid);
   }
 
   // Parse comments
@@ -378,8 +386,8 @@ async function readTopic(zip: JSZip, topicFolder: string, budget: ExpansionBudge
     guid,
     title,
     description,
-    topicType: topicTypeMatch?.[1],
-    topicStatus: topicStatusMatch?.[1],
+    topicType,
+    topicStatus,
     priority,
     index: index ? parseInt(index, 10) : undefined,
     creationDate,
@@ -433,6 +441,23 @@ function parseHeaderFiles(markupContent: string): BCFHeaderFile[] {
   }
 
   return files;
+}
+
+/**
+ * Extract an attribute's value from a captured opening-tag attribute string.
+ *
+ * XML attribute order is not semantically significant, so every caller that
+ * needs an attribute off an opening tag must first capture the tag's whole
+ * attribute list generically (e.g. `<Tag\b([^>]*)>`) and then pull individual
+ * attributes out of that captured string with this helper, rather than
+ * anchoring a single regex to one specific attribute position (e.g.
+ * `<Tag\s+Guid="..."`). The latter shape only matches when a foreign tool
+ * happens to write that attribute first, which our own writer.ts always does
+ * -- so a self round-trip can never catch the fragility (see reader.test.ts's
+ * "interop: attribute order independence" suite).
+ */
+function extractAttr(attrsString: string, attrName: string): string | undefined {
+  return attrsString.match(new RegExp(`\\b${attrName}="([^"]*)"`))?.[1];
 }
 
 /**
@@ -544,10 +569,14 @@ function parseComments(markupContent: string): BCFComment[] {
   const comments: BCFComment[] = [];
 
   // Collect every top-level comment-wrapper opening tag and where its body starts.
-  const openRe = /<Comment\s+Guid="([^"]+)"[^>]*>/g;
+  // Attributes are captured generically and pulled out with extractAttr so a
+  // Guid that isn't the tag's first attribute still matches (see extractAttr).
+  const openRe = /<Comment\b([^>]*)>/g;
   const opens: { guid: string; tagStart: number; bodyStart: number }[] = [];
   for (let m = openRe.exec(markupContent); m; m = openRe.exec(markupContent)) {
-    opens.push({ guid: m[1], tagStart: m.index, bodyStart: m.index + m[0].length });
+    const guid = extractAttr(m[1], 'Guid');
+    if (!guid) continue;
+    opens.push({ guid, tagStart: m.index, bodyStart: m.index + m[0].length });
   }
 
   for (let i = 0; i < opens.length; i++) {
@@ -568,14 +597,15 @@ function parseComments(markupContent: string): BCFComment[] {
     const modifiedAuthor = extractElement(content, 'ModifiedAuthor');
 
     // Extract viewpoint reference
-    const viewpointMatch = content.match(/<Viewpoint\s+Guid="([^"]+)"/);
+    const viewpointMatch = content.match(/<Viewpoint\b([^>]*)\/?>/);
+    const viewpointGuid = viewpointMatch ? extractAttr(viewpointMatch[1], 'Guid') : undefined;
 
     comments.push({
       guid: opens[i].guid,
       date,
       author,
       comment,
-      viewpointGuid: viewpointMatch?.[1],
+      viewpointGuid,
       modifiedDate,
       modifiedAuthor,
     });
@@ -599,10 +629,13 @@ async function parseViewpoints(
   // Format: <Viewpoint Guid="xxx"><Viewpoint>filename.bcfv</Viewpoint><Snapshot>snapshot.png</Snapshot></Viewpoint>
   const viewpointInfoMap = new Map<string, { viewpointFile?: string; snapshotFile?: string }>();
 
-  // Match full viewpoint elements with both viewpoint and snapshot references
-  const viewpointElementRegex = /<Viewpoint\s+Guid="([^"]+)"[^>]*>([\s\S]*?)<\/Viewpoint>/g;
+  // Match full viewpoint elements with both viewpoint and snapshot references.
+  // Attributes are captured generically and pulled out with extractAttr so a
+  // Guid that isn't the tag's first attribute still matches (see extractAttr).
+  const viewpointElementRegex = /<Viewpoint\b([^>]*)>([\s\S]*?)<\/Viewpoint>/g;
   for (const match of markupContent.matchAll(viewpointElementRegex)) {
-    const guid = match[1];
+    const guid = extractAttr(match[1], 'Guid');
+    if (!guid) continue;
     const content = match[2];
 
     const viewpointFileMatch = content.match(/<Viewpoint>([^<]+)<\/Viewpoint>/);
@@ -615,10 +648,11 @@ async function parseViewpoints(
   }
 
   // Also match self-closing viewpoint references
-  const simpleViewpointRefs = markupContent.matchAll(/<Viewpoint\s+Guid="([^"]+)"[^>]*\/>/g);
+  const simpleViewpointRefs = markupContent.matchAll(/<Viewpoint\b([^>]*)\/>/g);
   for (const match of simpleViewpointRefs) {
-    if (!viewpointInfoMap.has(match[1])) {
-      viewpointInfoMap.set(match[1], {});
+    const guid = extractAttr(match[1], 'Guid');
+    if (guid && !viewpointInfoMap.has(guid)) {
+      viewpointInfoMap.set(guid, {});
     }
   }
 


### PR DESCRIPTION
## Problem

`packages/bcf/src/reader.ts` had six regexes that required `Guid` to be the
attribute immediately after the tag name (`<Topic\s+Guid="..."`,
`<Comment\s+Guid="..."`, `<Viewpoint\s+Guid="..."`, `<RelatedTopic\s+Guid="..."`).
XML attribute order is not semantically significant, so a spec-legal BCF file
from another tool that orders attributes differently silently loses data.

## Reproduction (RED, current `main`)

```
<Topic TopicType="Issue" TopicStatus="Open" Guid="topic-1">
  <Title>Reordered attrs</Title>
</Topic>
```

Against unpatched `reader.ts`:

```
AssertionError: expected +0 to be 1 // Object.is equality
 ❯ src/attr-order.test.ts:39:33
     39|     expect(project.topics.size).toBe(1);
```

`project.topics.size === 0`. The title, all comments and all viewpoints for
that topic are silently dropped -- no throw, no partial result, just a
`console.warn("Invalid markup.bcf in topic-1: missing Topic element")`.

Our own fixtures never caught this because `writer.ts:220` always emits
`Guid` first, so every self round-trip passes.

## Six-site verdict

| Site | Pattern | Verdict |
|---|---|---|
| `reader.ts:321` `<Topic>` | `<Topic\s+Guid="..."` | **Fragile, reachable.** Confirmed by reproduction above. Fixed. |
| `reader.ts:366` `<RelatedTopic>` | `<RelatedTopic\s+Guid="..."` | **Fragile in principle.** The BCF-XML schema's `RelatedTopic` type has only a `Guid` attribute, so no other attribute can legally precede it today -- but the fix costs nothing and matches the shared pattern, so it's included. Fixed. |
| `reader.ts:547` `<Comment>` wrapper | `<Comment\s+Guid="..."[^>]*>` | **Fragile, reachable.** A foreign tool's `<Comment Foo="x" Guid="...">` drops the comment. Fixed. |
| `reader.ts:571` Comment's `<Viewpoint>` ref | `<Viewpoint\s+Guid="..."` | **Fragile, reachable.** A foreign tool's `<Viewpoint Foo="x" Guid="..."/>` inside a `<Comment>` loses the `viewpointGuid` link. Fixed. |
| `reader.ts:603` markup `<Viewpoints>` wrapper | `<Viewpoint\s+Guid="..."[^>]*>...` | **Separate, pre-existing bug, out of scope.** The real BCF-XML element for this reference is `<Viewpoints Guid="...">` (plural -- confirmed against the buildingSMART `PerspectiveCamera.bcf` official test fixture and our own `writer.ts:301`), but the regex matches literal `<Viewpoint` (singular) followed by whitespace, which never matches "Viewpoints" regardless of attribute order (`\b` boundary fails between `t` and `s`). This code path is dead for any spec-correct file, self-generated or third-party; it happens to be masked by a filename-convention fallback that reconstructs the snapshot path independently. Attribute-order fixed for consistency (uses the shared helper, in case the tag-name bug is fixed later), but the tag-name mismatch itself is a different defect and was left alone to keep this PR scoped to the reported issue. |
| `reader.ts:618` self-closing `<Viewpoint/>` ref | `<Viewpoint\s+Guid="..."[^>]*\/>` | **Fragile, reachable** -- via the same self-closing `<Viewpoint Guid="..."/>` tag written inside `<Comment>` elements (this global regex also picks those up). Fixed. |

## Fix shape

Per the task's preferred option: match the opening tag generically
(`<Tag\b([^>]*)>`) and extract attributes from the captured string in a
second step, via a new shared `extractAttr(attrsString, attrName)` helper.
This can't regress the same way again at any of the fixed call sites, unlike
a regex tweak that special-cases this one instance. `parseHeaderFiles` and
`extractDocumentReferences` already used this idiom elsewhere in the file;
this PR brings the Guid-anchored sites in line with it.

Self-closing tags, escaped-quote attribute values (`[^"]*` is unaffected by
the capture-group restructuring), and the nested-same-tag-name cases
(`<Comment>`'s inner text field, `<Viewpoint>`'s inner filename field) are
all still handled: matches with no `Guid` attribute are explicitly skipped
(`if (!guid) continue`), which is exactly how the old regexes silently
excluded those inner fields by requiring `Guid` to be present at all.

## RED/GREEN per fixed site

All four in `packages/bcf/src/attr-order.test.ts`, each with `Guid` placed
after another attribute:

- `Topic` -- RED: `project.topics.size` 0 vs expected 1. GREEN: parses title, topicType, topicStatus.
- `RelatedTopic` -- RED: `relatedTopics` undefined vs `['topic-2']`. GREEN: parses.
- `Comment` -- RED: `comments.length` 0 vs 1. GREEN: parses guid + text.
- Comment's `Viewpoint` ref -- RED: `viewpointGuid` undefined vs `'vp-1'`. GREEN: parses.

## Writer-side check

`writer.ts` itself never *reads* its own output, so there's no analogous
attribute-order assumption on the write side to check.

## Verify

- `packages/bcf`: 175 passed, 9 files (baseline 171/8 + 4 new tests, 1 new file). No regressions.
- `packages/encoding`: 86 passed, 5 files (matches baseline).
- Typecheck: `packages/bcf`'s `tsc --noEmit` (source) and `typecheck-tests.mjs` (test files) both clean.
- Lint: shared `node_modules` predates `oxlint`, so used `pnpm dlx oxlint@1.42.0` (no repo config) against the changed files -- 0 warnings, 0 errors.

## Test plan

- [x] `pnpm --filter @ifc-lite/bcf test` -- 175 passed
- [x] `pnpm --filter @ifc-lite/encoding test` -- 86 passed
- [x] `tsc --noEmit` in `packages/bcf`
- [x] `node ../../scripts/typecheck-tests.mjs` in `packages/bcf`
- [x] `pnpm dlx oxlint@1.42.0` against changed files
