### PR TITLE
test(encoding,bcf): pin IFC GUID alphabet against an external reference

### DIFF
--- a/packages/bcf/src/guid.test.ts
+++ b/packages/bcf/src/guid.test.ts
@@ -15,9 +15,26 @@ import {
 describe('IFC GUID utilities', () => {
   describe('uuidToIfcGuid', () => {
     it('should convert a known UUID to correct IFC GUID', () => {
-      // Test case from buildingSMART documentation
+      // UUID from buildingSMART documentation. The previous version of this
+      // test only checked length and first-character range, which a wrong
+      // (but internally self-consistent) IFC_GUID_CHARS alphabet also
+      // satisfies - see packages/encoding/src/guid.test.ts for the mutation
+      // evidence. The expected value below is derived independently, via
+      // IfcOpenShell's `legacy_compress` algorithm (identical to its
+      // current `ifcopenshell.guid.compress`), taken verbatim from
+      // https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.9.0/src/ifcopenshell-python/test/test_guid.py
+      // and hand-executed for this UUID (not via this repo's own encoder):
+      //
+      //   chars = string.digits + string.ascii_uppercase + string.ascii_lowercase + "_$"
+      //   def legacy_compress(g):
+      //       bs = [int(g[i:i+2], 16) for i in range(0, len(g), 2)]
+      //       def b64(v, l=4):
+      //           return "".join([chars[(v // (64 ** i)) % 64] for i in range(l)][::-1])
+      //       return "".join([b64(bs[0], 2)] + [b64((bs[i] << 16) + (bs[i+1] << 8) + bs[i+2]) for i in range(1, 16, 3)])
+      //   legacy_compress("3d2b2fa43b2f11e0b7a700163e7a5e00")  # => "0zAo_aEoyHuBUd01O_Ubu0"
       const uuid = '3d2b2fa4-3b2f-11e0-b7a7-00163e7a5e00';
       const ifcGuid = uuidToIfcGuid(uuid);
+      expect(ifcGuid).toBe('0zAo_aEoyHuBUd01O_Ubu0');
       // IFC GUIDs are 22 characters
       expect(ifcGuid.length).toBe(22);
       // First character should be 0-3 (only 2 bits used)

--- a/packages/encoding/src/guid.test.ts
+++ b/packages/encoding/src/guid.test.ts
@@ -21,6 +21,42 @@ describe('guid', () => {
     expect(isValidIfcGuid(ifcGuid)).toBe(true);
   });
 
+  it('encodes a UUID to the exact IFC GUID produced by IfcOpenShell compress/expand (not just self-round-trip)', () => {
+    // Round-trip-only assertions cannot detect a wrong-but-internally-
+    // consistent IFC_GUID_CHARS alphabet: swapping two characters in it
+    // leaves uuidToIfcGuid/ifcGuidToUuid mutually consistent, so this test
+    // pins an externally-verified value instead.
+    //
+    // Expected value derived from IfcOpenShell's `legacy_compress`
+    // algorithm (identical to its current `ifcopenshell.guid.compress`),
+    // taken verbatim from
+    // https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.9.0/src/ifcopenshell-python/test/test_guid.py
+    // and hand-executed here (not via this repo's own encoder). This is
+    // the same UUID buildingSMART's own documentation uses as its worked
+    // example (see packages/bcf/src/guid.test.ts):
+    //
+    //   uuid_orig = "3d2b2fa43b2f11e0b7a700163e7a5e00"
+    //   chars = string.digits + string.ascii_uppercase + string.ascii_lowercase + "_$"
+    //   def legacy_compress(g):
+    //       bs = [int(g[i:i+2], 16) for i in range(0, len(g), 2)]
+    //       def b64(v, l=4):
+    //           return "".join([chars[(v // (64 ** i)) % 64] for i in range(l)][::-1])
+    //       return "".join([b64(bs[0], 2)] + [b64((bs[i] << 16) + (bs[i+1] << 8) + bs[i+2]) for i in range(1, 16, 3)])
+    //   legacy_compress(uuid_orig)  # => "0zAo_aEoyHuBUd01O_Ubu0"
+    //
+    // Chosen (over other candidate vectors, e.g. the "656d1ed0..." UUID
+    // used in that same IfcOpenShell test file) because its expected
+    // output contains both 'A' and 'B': a test vector whose output never
+    // hits the swapped characters would pass even against a mutated
+    // alphabet, silently failing to guard against exactly the bug this
+    // test exists to catch.
+    const uuid = '3d2b2fa4-3b2f-11e0-b7a7-00163e7a5e00';
+    const expectedIfcGuid = '0zAo_aEoyHuBUd01O_Ubu0';
+
+    expect(uuidToIfcGuid(uuid)).toBe(expectedIfcGuid);
+    expect(ifcGuidToUuid(expectedIfcGuid)).toBe(uuid);
+  });
+
   it('rejects a UUID string containing non-hex characters instead of silently zeroing them', () => {
     // hex.length === 32 after stripping dashes, so the length guard passes;
     // parseInt('GG', 16) is NaN, and Uint8Array coerces NaN to 0. Nothing


### PR DESCRIPTION
## Finding

`packages/encoding/src/guid.ts` defines `IFC_GUID_CHARS`, the alphabet used by `uuidToIfcGuid` / `ifcGuidToUuid`. Nothing pinned it to the buildingSMART-standard alphabet: both `packages/encoding/src/guid.test.ts` and `packages/bcf/src/guid.test.ts` tested only via self-round-trip and structural properties (length 22, first char in `0-3`, charset membership).

**Mutation evidence:** swapping two characters in `IFC_GUID_CHARS` (`A`/`B`) left both suites fully green:
- `packages/encoding`: 86/86 passed (5 files)
- `packages/bcf`: 171/171 passed (8 files)

Round-trip and structural checks cannot detect this class of bug — encode and decode stay mutually consistent under a permuted alphabet, so it looks fine to us and would be silently wrong to any spec-correct external tool reading the same GUID.

`packages/bcf/src/guid.test.ts` also had a test citing *"Test case from buildingSMART documentation"* that never asserted the documented value — same gap, worse because it looked like a real check.

## Authoritative source

IfcOpenShell's `guid.compress` (the widely-used, independently-implemented reference for this exact encoding), from:
https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.9.0/src/ifcopenshell-python/test/test_guid.py

```python
chars = string.digits + string.ascii_uppercase + string.ascii_lowercase + "_$"

def legacy_compress(g):
    bs = [int(g[i:i+2], 16) for i in range(0, len(g), 2)]
    def b64(v, l=4):
        return "".join([chars[(v // (64 ** i)) % 64] for i in range(l)][::-1])
    return "".join([b64(bs[0], 2)] + [b64((bs[i] << 16) + (bs[i+1] << 8) + bs[i+2]) for i in range(1, 16, 3)])
```

Hand-executed this algorithm (a separate Python script, not this repo's TypeScript) for the buildingSMART-documented example UUID `3d2b2fa4-3b2f-11e0-b7a7-00163e7a5e00`:

```
legacy_compress("3d2b2fa43b2f11e0b7a700163e7a5e00")  # => "0zAo_aEoyHuBUd01O_Ubu0"
```

This vector was chosen (over other candidates, e.g. the `656d1ed0...` UUID also used in that IfcOpenShell test file) specifically because its output contains both `A` and `B` — a vector whose output never touches the swapped characters would pass even against the mutated alphabet, defeating the point of the test.

## Result: our alphabet matches

`IFC_GUID_CHARS` in this repo is `0-9`, `A-Z`, `a-z`, `_`, `$` in that order — identical to IfcOpenShell's `chars`. Confirmed our current `uuidToIfcGuid` produces exactly `0zAo_aEoyHuBUd01O_Ubu0` for that UUID (checked via `tsx`, not committed as test logic — the committed test asserts the independently-derived string, not our own output). **No behaviour change needed.**

## Changes

- `packages/encoding/src/guid.test.ts`: new test asserting the fixed UUID → exact IFC GUID (and reverse), with the derivation shown in a comment.
- `packages/bcf/src/guid.test.ts`: the existing "known UUID" test now asserts the documented expected value instead of only length/first-char shape.

No changeset — test-only, no runtime behaviour changed.

## Verify

- `packages/encoding`: 86 → 87 passed (5 files, one new test)
- `packages/bcf`: 171 → 171 passed (8 files, existing test tightened in place)
- RED confirmed: with the `A`/`B` swap mutation reintroduced, both new/updated assertions fail with the expected-vs-actual diff shown above; reverting the mutation returns both suites to green.
- `packages/encoding` and `packages/bcf`: `tsc --noEmit` clean; `typecheck` script (`typecheck-tests.mjs`) OK for both.
- `oxlint` not available in this environment; not run.

## What this does not cover

Round-trip tests elsewhere in the repo (any file using `uuidToIfcGuid`/`ifcGuidToUuid` without a fixed external expected value) remain structurally blind to an alphabet-permutation bug for the same reason described above. This PR adds an external anchor for the alphabet itself; it does not audit every other caller.