### PR TITLE
fix(bcf): resolve markup snapshot filenames via the plural <Viewpoints> tag

### DIFF
--- a/.changeset/bcf-viewpoints-markup-tag-fix.md
+++ b/.changeset/bcf-viewpoints-markup-tag-fix.md
@@ -1,0 +1,31 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Fix `readBCF` failing to resolve a viewpoint's snapshot when `markup.bcf` names
+it with a non-buildingSMART-convention filename.
+
+`parseViewpoints` looked up each viewpoint's declared `<Viewpoint>`/`<Snapshot>`
+filenames in `markup.bcf` with a regex matching the singular tag
+`<Viewpoint Guid="...">`. The markup element that actually carries those
+filenames is plural — `<Viewpoints Guid="...">`, per the BCF 2.1/3.0 schema and
+this package's own writer (`writer.ts` `writeMarkupFile` emits exactly that tag)
+— so the regex could never match a spec-correct file, and the lookup map was
+always empty. Every snapshot resolution silently fell through to a
+filename-guessing fallback (`Viewpoint_<guid>.bcfv` → `Snapshot_<guid>.png` and
+similar patterns). That fallback happens to cover buildingSMART's own reference
+fixtures, which follow the convention, but a third-party file is free to name
+its entries however it likes; when the filenames don't match a guessed
+pattern, the snapshot markup.bcf explicitly names was silently dropped even
+though it exists in the archive.
+
+The viewpoint's own GUID was never at risk — it comes from the `.bcfv` file's
+`<VisualizationInfo Guid="...">` element directly, independent of this lookup
+— so this was a snapshot-association defect, not a GUID/identity defect.
+
+Fixed the regex to match the plural `<Viewpoints>` tag, so the markup-declared
+filename is used when present and the naming-convention fallback now only
+runs when markup.bcf genuinely doesn't declare a snapshot. Added a test using
+a synthetic third-party-shaped archive (custom filenames, spec-legal) that
+previously lost its snapshot and now resolves it, plus a regression test
+against the buildingSMART `PerspectiveCamera.bcf` fixture.

--- a/packages/bcf/src/reader.test.ts
+++ b/packages/bcf/src/reader.test.ts
@@ -463,4 +463,73 @@ describe('BCF Reader - buildingSMART Test Files', () => {
       expect(project.version).toBe('2.1');
     });
   });
+
+  describe('markup.bcf <Viewpoints> element (plural, per BCF 2.1/3.0 schema)', () => {
+    it('resolves the markup-declared Snapshot filename even when it does not follow the buildingSMART naming convention', async () => {
+      // The <Viewpoints Guid="..."> markup element is the top-level element linking a
+      // viewpoint's GUID to its .bcfv file and snapshot image (see writer.ts
+      // writeMarkupFile, which emits exactly this plural tag). A prior regex here
+      // looked for singular <Viewpoint Guid="..."> -- the tag Comment elements use to
+      // *reference* a viewpoint -- which can never match this markup element. That left
+      // the reader silently falling back to guessing the snapshot filename from
+      // naming-convention patterns (Viewpoint_<guid>.bcfv -> Snapshot_<guid>.png etc.).
+      // Third-party BCF files are free to name their entries however they like per
+      // spec; when the snapshot filename doesn't match any guessed pattern, the
+      // snapshot the markup explicitly names must still be found.
+      const zip = new JSZip();
+      const topicGuid = '11111111-1111-1111-1111-111111111111';
+      const vpGuid = '22222222-2222-2222-2222-222222222222';
+      zip.file('bcf.version', '<?xml version="1.0"?><Version VersionId="2.1"><DetailedVersion>2.1</DetailedVersion></Version>');
+      zip.file(
+        `${topicGuid}/markup.bcf`,
+        `<?xml version="1.0" encoding="utf-8"?>
+<Markup>
+  <Topic Guid="${topicGuid}">
+    <Title>Custom filenames</Title>
+  </Topic>
+  <Viewpoints Guid="${vpGuid}">
+    <Viewpoint>custom_camera_view.bcfv</Viewpoint>
+    <Snapshot>custom_image_export.png</Snapshot>
+  </Viewpoints>
+</Markup>`
+      );
+      zip.file(
+        `${topicGuid}/custom_camera_view.bcfv`,
+        `<?xml version="1.0" encoding="utf-8"?>
+<VisualizationInfo Guid="${vpGuid}">
+  <PerspectiveCamera>
+    <CameraViewPoint><X>0</X><Y>0</Y><Z>0</Z></CameraViewPoint>
+    <CameraDirection><X>1</X><Y>0</Y><Z>0</Z></CameraDirection>
+    <CameraUpVector><X>0</X><Y>0</Y><Z>1</Z></CameraUpVector>
+    <FieldOfView>60</FieldOfView>
+  </PerspectiveCamera>
+</VisualizationInfo>`
+      );
+      zip.file(`${topicGuid}/custom_image_export.png`, new Uint8Array([0x89, 0x50, 0x4e, 0x47, 1, 2, 3, 4]));
+
+      const buffer = await zip.generateAsync({ type: 'nodebuffer' });
+      const project = await readBCF(buffer);
+      const topic = project.topics.get(topicGuid);
+
+      expect(topic?.viewpoints).toHaveLength(1);
+      const vp = topic!.viewpoints[0];
+      // The viewpoint's own GUID comes from the .bcfv file's VisualizationInfo element,
+      // independent of this markup lookup, so it was never at risk -- but the snapshot
+      // association was.
+      expect(vp.guid).toBe(vpGuid);
+      expect(vp.snapshot).toBeDefined();
+      expect(vp.snapshotData).toBeDefined();
+    });
+
+    it('still finds the buildingSMART-fixture snapshot via the plural tag (regression against PerspectiveCamera.bcf)', async () => {
+      const filePath = join(TEST_DATA_DIR, 'PerspectiveCamera.bcf');
+      const buffer = await readFile(filePath);
+      const project = await readBCF(buffer);
+      const topic = [...project.topics.values()][0];
+
+      expect(topic.viewpoints).toHaveLength(1);
+      expect(topic.viewpoints[0].guid).toBe('caddfaad-73b0-4751-8d3f-ba2a4a954b7a');
+      expect(topic.viewpoints[0].snapshot).toBeDefined();
+    });
+  });
 });

--- a/packages/bcf/src/reader.ts
+++ b/packages/bcf/src/reader.ts
@@ -595,12 +595,21 @@ async function parseViewpoints(
 ): Promise<BCFViewpoint[]> {
   const viewpoints: BCFViewpoint[] = [];
 
-  // Parse viewpoint references from markup.bcf to get snapshot filenames
-  // Format: <Viewpoint Guid="xxx"><Viewpoint>filename.bcfv</Viewpoint><Snapshot>snapshot.png</Snapshot></Viewpoint>
+  // Parse viewpoint references from markup.bcf to get snapshot filenames.
+  // The markup element is plural -- <Viewpoints Guid="xxx"><Viewpoint>file.bcfv</Viewpoint>
+  // <Snapshot>file.png</Snapshot></Viewpoints> -- per the BCF 2.1/3.0 schema (see
+  // writer.ts writeMarkupFile) and buildingSMART's own reference fixtures. A prior
+  // version of this regex looked for singular <Viewpoint Guid="..."> instead, which is
+  // the tag Comment elements use to reference a viewpoint (see parseComments below) --
+  // it can never match the top-level markup element, so this map was always empty and
+  // every snapshot resolution silently fell through to the filename-guessing fallback.
+  // On a real-world file whose viewpoint/snapshot filenames don't follow the
+  // buildingSMART naming convention, that fallback fails to find the snapshot at all
+  // even though markup.bcf names it explicitly.
   const viewpointInfoMap = new Map<string, { viewpointFile?: string; snapshotFile?: string }>();
 
   // Match full viewpoint elements with both viewpoint and snapshot references
-  const viewpointElementRegex = /<Viewpoint\s+Guid="([^"]+)"[^>]*>([\s\S]*?)<\/Viewpoint>/g;
+  const viewpointElementRegex = /<Viewpoints\s+Guid="([^"]+)"[^>]*>([\s\S]*?)<\/Viewpoints>/g;
   for (const match of markupContent.matchAll(viewpointElementRegex)) {
     const guid = match[1];
     const content = match[2];
@@ -615,7 +624,7 @@ async function parseViewpoints(
   }
 
   // Also match self-closing viewpoint references
-  const simpleViewpointRefs = markupContent.matchAll(/<Viewpoint\s+Guid="([^"]+)"[^>]*\/>/g);
+  const simpleViewpointRefs = markupContent.matchAll(/<Viewpoints\s+Guid="([^"]+)"[^>]*\/>/g);
   for (const match of simpleViewpointRefs) {
     if (!viewpointInfoMap.has(match[1])) {
       viewpointInfoMap.set(match[1], {});


### PR DESCRIPTION
## Summary

`parseViewpoints` in `packages/bcf/src/reader.ts` looked up each viewpoint's declared `<Viewpoint>`/`<Snapshot>` filenames in `markup.bcf` using a regex for the **singular** `<Viewpoint Guid="...">` tag. The actual top-level markup element is **plural**: `<Viewpoints Guid="...">`, per the BCF 2.1/3.0 schema, confirmed against buildingSMART's own `PerspectiveCamera.bcf` fixture and against this package's own `writer.ts:301` (`writeMarkupFile`), which emits exactly that plural tag.

That regex can never match a spec-correct file, so the lookup map (`viewpointInfoMap`) was always empty. Every snapshot resolution silently fell through to a filename-guessing fallback (`Viewpoint_<guid>.bcfv` → `Snapshot_<guid>.png` and similar patterns). That fallback happens to cover buildingSMART's own reference fixtures because they follow the convention — but a third-party BCF file is free to name its viewpoint/snapshot files however it likes per spec. When the actual filenames don't match a guessed pattern, the snapshot markup.bcf explicitly names is silently dropped even though it's present in the archive.

**The viewpoint's GUID was never at risk.** It's read from the `.bcfv` file's own `<VisualizationInfo Guid="...">` element directly (`parseViewpointContent`), independent of this markup lookup — confirmed by round-tripping `PerspectiveCamera.bcf` through `readBCF`/`writeBCF`/`readBCF` and comparing viewpoint GUIDs (unchanged). So this is a **snapshot-association data-loss defect**, not a GUID/identity defect. Comment→viewpoint GUID references are also unaffected: `parseComments` uses a separate regex for the singular `<Viewpoint Guid="..."/>` tag, which really is singular in that context (a comment's viewpoint reference, per `writer.ts:316`).

Fixed the regex to match `<Viewpoints>`. The filename-guessing fallback is left in place as a genuine safety net for files that don't declare a snapshot in markup at all — there's no conflict between the two paths: the markup-declared filename is tried first, and the fallback only runs when it's absent (`if (!snapshotFile) { ... }`).

## Test plan

- [x] `packages/bcf` suite: 171 → 173 passed (8 files), all green
- [x] New test: synthetic third-party-shaped archive (spec-legal custom filenames, not following the buildingSMART naming convention) that previously lost its snapshot now resolves it correctly
- [x] Regression test against the buildingSMART `PerspectiveCamera.bcf` fixture (still resolves via the plural tag)
- [x] Round-trip check: `readBCF` → `writeBCF` → `readBCF` preserves the viewpoint GUID
- [x] `pnpm --filter @ifc-lite/bcf build` and `typecheck` (both scopes) pass
- [x] `oxlint` clean on changed files (no repo `.oxlintrc.json` in this environment — a weaker check than CI's gate)
- [x] Changeset added (`@ifc-lite/bcf` patch)

## Note

This branch is expected to conflict with #2758 (open against `packages/bcf/src/reader.ts`, adding a shared `extractAttr` helper for an unrelated attribute-order fix). This PR does not attempt to incorporate or resolve that conflict — flagging for the maintainer to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)