### PR TITLE
test(renderer): fix three blind fixtures found by mutation sweep

### DIFF
--- a/packages/renderer/src/environment.test.ts
+++ b/packages/renderer/src/environment.test.ts
@@ -137,10 +137,16 @@ describe('packEnvironmentUniforms', () => {
     assert.strictEqual(buf.byteLength, ENVIRONMENT_UNIFORM_SIZE);
     assert.deepStrictEqual(Array.from(buf.slice(0, 4)), [1, 0, 0, Math.fround(0.6)]);
     assertClose(buf[4], 0.9);
+    assertClose(buf[5], 0.8);
+    assertClose(buf[6], 0.7);
     assertClose(buf[7], 0.3);
     assertClose(buf[8], 0.1);
+    assertClose(buf[9], 0.2);
+    assertClose(buf[10], 0.3);
     assertClose(buf[11], 1.0);
     assertClose(buf[12], 0.4);
+    assertClose(buf[13], 0.5);
+    assertClose(buf[14], 0.6);
     assertClose(buf[15], 0.11);
     assertClose(buf[16], 0.12);
     assertClose(buf[17], 0.42);

--- a/packages/renderer/src/scene-local-bounds.test.ts
+++ b/packages/renderer/src/scene-local-bounds.test.ts
@@ -164,14 +164,19 @@ describe('Scene.getEntityTransform', () => {
 
   it('reads a GPU-instanced occurrence transform, column-major -> row-major', () => {
     const scene = new Scene();
-    // Column-major identity + translation (10, 20, 30), packed as the GPU
-    // instance buffer stores it (mat4 at byte offset 0).
+    // Column-major 90°-about-Z rotation (x'=-y, y'=x, z'=z) + translation
+    // (10, 20, 30), packed as the GPU instance buffer stores it (mat4 at
+    // byte offset 0). The rotation 3x3 is deliberately non-symmetric: a
+    // uniform-scale/identity rotation would transpose to itself and could
+    // not catch a transpose bug confined to the rotation sub-block (see
+    // point-cloud-transform.test.ts's 90°-about-Y fixture for the same
+    // pattern).
     const instanceData = new ArrayBuffer(64);
     const dv = new DataView(instanceData);
     // prettier-ignore
     const colMajor = [
-      1, 0, 0, 0,
       0, 1, 0, 0,
+      -1, 0, 0, 0,
       0, 0, 1, 0,
       10, 20, 30, 1,
     ];
@@ -193,8 +198,8 @@ describe('Scene.getEntityTransform', () => {
 
     const transform = scene.getEntityTransform(8);
     assert.deepStrictEqual(Array.from(transform!), [
-      1, 0, 0, 10,
-      0, 1, 0, 20,
+      0, -1, 0, 10,
+      1, 0, 0, 20,
       0, 0, 1, 30,
       0, 0, 0, 1,
     ]);

--- a/packages/renderer/src/symbolic-fill-triangulate.test.ts
+++ b/packages/renderer/src/symbolic-fill-triangulate.test.ts
@@ -64,7 +64,7 @@ function fill(
     points: Float32Array.from(points),
     holesOffsets: Uint32Array.from(holesOffsets),
     worldY,
-    color: [1, 0, 0, 1],
+    color: [0.2, 0.5, 0.8, 1],
   };
 }
 
@@ -126,7 +126,10 @@ describe('SymbolicFillPipeline — IfcAnnotationFillArea holes (#2516)', () => {
     const stream = upload([fill([...SQUARE_4, ...HOLE_2], [4], 2.5)]);
     for (let v = 0; v < stream.length; v += FLOATS_PER_VERTEX) {
       assert.strictEqual(stream[v + 1], 2.5, 'worldY must be constant across the fill');
-      assert.deepStrictEqual(Array.from(stream.slice(v + 3, v + 7)), [1, 0, 0, 1]);
+      assert.deepStrictEqual(
+        Array.from(stream.slice(v + 3, v + 7)),
+        [0.2, 0.5, 0.8, 1].map(Math.fround),
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

A fixture-observability sweep of `packages/renderer` (mutation testing: flip a value in production code, see if any of the 937 tests catch it) found three assertions that pass a mutation they were meant to guard against. This PR fixes the fixtures/assertions only — no production code changes.

### 1. `environment.ts` — `packEnvironmentUniforms` RGB triples

`environment.test.ts`'s "packs the WGSL struct layout exactly" test only asserted the first lane of each RGB triple (`buf[4]`, `buf[8]`, `buf[12]`), leaving `buf[5]`/`[6]`, `buf[9]`/`[10]`, `buf[13]`/`[14]` unchecked.

- **Mutation guarded against:** swap `buf[5]`/`buf[6]` (sunColor G↔B in `packEnvironmentUniforms`).
- **RED:** 18/19 pass under the mutation (1 fail) before the fix.
- **GREEN:** 19/19 pass against real code, both before and after the fix — the point is the *mutation* now fails.
- **Fix:** assert all three lanes of each triple (fixture already used distinct channel values per color, so no fixture value change needed).

### 2. `symbolic-overlay-pipelines.ts:746` — `SymbolicFillPipeline` vertex push

Every fixture in `symbolic-fill-triangulate.test.ts` used `color: [1, 0, 0, 1]` (the `fill()` helper). G and B are both `0`, so a swap of those channels in the vertex push is unobservable.

- **Mutation guarded against:** swap `color[1]`/`color[2]` in the `stream.push(...)` call.
- **RED:** 5/6 pass under the mutation (1 fail).
- **GREEN:** 6/6 pass against real code.
- **Fix:** changed the fixture color to three distinct non-zero channels (`[0.2, 0.5, 0.8, 1]`) and updated the one dependent assertion ("carries the colour through") to match, comparing through `Math.fround` since the uploaded stream is an `f32` buffer.

### 3. `scene.ts:4256-4265` — `getEntityTransform` column-major → row-major

The only test exercising the GPU-instanced path, `scene-local-bounds.test.ts`, used a rotation submatrix that was the 3×3 identity (only the translation `[10,20,30]` was non-trivial). A transpose bug confined to the rotation 3×3 block is invisible when `transpose(I) = I`.

- **Mutation guarded against:** transpose only the `r<3 && c<3` sub-block of the column-major→row-major conversion.
- **RED:** 11/12 pass under the mutation (1 fail).
- **GREEN:** 12/12 pass against real code.
- **Fix:** replaced the identity rotation with a non-symmetric 90°-about-Z rotation (`x'=-y, y'=x, z'=z`), matching the discriminating pattern `point-cloud-transform.test.ts` already uses for its 90°-about-Y fixture. Updated the expected row-major output accordingly.

## Verification

Each finding was reproduced by mutation before fixing (mutation left all 937 tests green), fixed, then re-verified RED (fails under the same mutation) → GREEN (passes against real code, mutation reverted). `git diff` on this branch touches only the three `*.test.ts` files — no production code changed.

This sweep only covers these three findings; `packages/renderer`'s other transform fixtures — `section-plane-basis`'s full-sphere sweep and `camera-controls` — were checked as part of the same pass and are genuinely discriminating (not blind), so left as-is.

## Test plan

- [x] `pnpm exec tsx --test src/*.test.ts` in `packages/renderer`: 937 tests / 188 suites / 0 fail, before and after (test-only strengthening, no new tests added)
- [x] Each of the three fixed tests reproduced RED under its specific mutation, then GREEN with the mutation reverted
- [x] `pnpm exec tsc --noEmit` (build typecheck) and `node ../../scripts/typecheck-tests.mjs` (test typecheck) both clean
- [x] `pnpm dlx oxlint@1.42.0` on the three changed files: 0 warnings/errors (no repo `oxlint` config available in this environment, so this is a weaker check than the project's real lint gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded rendering layout coverage to verify additional color components.
  * Improved transform testing with a rotated GPU-instanced object to validate rotation and translation handling.
  * Updated fill-color coverage to use and verify a broader color value with float precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->