### PR TITLE
fix(spatial): lift empty-mesh bounds by mesh.origin instead of world zero

### DIFF
--- a/.changeset/spatial-empty-mesh-origin-lift.md
+++ b/.changeset/spatial-empty-mesh-origin-lift.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/spatial': patch
+---
+
+Fix the spatial index placing an empty mesh with a non-zero origin at world `[0,0,0]` instead of its own origin.
+
+`computeMeshBounds` returned early for `positions.length === 0` before the origin lift ran, so an empty mesh (a mesh with geometry stripped, e.g. a fully-clipped or degenerate element) with `mesh.origin` set was indexed at world `[0,0,0]` regardless of where it actually sits. Every other mesh — including a populated one with the same origin — was correctly lifted by `mesh.origin` before being indexed. Reproduced directly: an empty mesh with `origin: [500, 500, 500]` was found by a query box at `[0,0,0]` and missed by a query box at `[500, 500, 500]`.
+
+The origin extraction is now hoisted above the early return so there is a single place that reads `mesh.origin`, and the empty-mesh path returns a degenerate box at `[ox, oy, oz]` instead of `[0, 0, 0]`. This only changes behaviour for empty meshes that also carry a non-zero `mesh.origin`; the common case (no origin, or a populated mesh) is unaffected.

--- a/packages/spatial/src/spatial-index-builder.test.ts
+++ b/packages/spatial/src/spatial-index-builder.test.ts
@@ -85,6 +85,23 @@ describe('buildSpatialIndex', () => {
     expect(bvh.queryAABB(box(1000, 1000, 1000, 1001, 1001, 1001))).toEqual([]);
   });
 
+  it('gives an empty mesh a degenerate box at the mesh origin when one is set', () => {
+    // Same shape as above, but with a non-zero per-mesh origin. The empty-mesh
+    // early return must apply the same origin lift as the populated-mesh path,
+    // not silently place the mesh at world [0,0,0].
+    const empty: MeshData = {
+      expressId: 9,
+      positions: new Float32Array(0),
+      normals: new Float32Array(0),
+      indices: new Uint32Array(0),
+      color: [1, 1, 1, 1],
+      origin: [500, 500, 500],
+    };
+    const bvh = buildSpatialIndex([empty]);
+    expect(bvh.queryAABB(box(500, 500, 500, 500, 500, 500))).toEqual([9]);
+    expect(bvh.queryAABB(box(0, 0, 0, 0, 0, 0))).toEqual([]);
+  });
+
   it('returns a queryable empty index for no meshes', () => {
     expect(buildSpatialIndex([]).queryAABB(box(-1e9, -1e9, -1e9, 1e9, 1e9, 1e9))).toEqual([]);
   });

--- a/packages/spatial/src/spatial-index-builder.ts
+++ b/packages/spatial/src/spatial-index-builder.ts
@@ -80,11 +80,21 @@ export async function buildSpatialIndexAsync(
  */
 function computeMeshBounds(mesh: MeshData): AABB {
   const positions = mesh.positions;
-  
+
+  // Positions are in the element's local frame (world = origin + position). The
+  // spatial index is queried in world space, so lift the AABB by the per-mesh
+  // origin. Origin is constant per mesh, so a single add to the final extents is
+  // exact and cheapest. No-op when origin is absent/[0,0,0]. Extracted once, above
+  // every return, so the empty-mesh path can't diverge from the general path.
+  const o = mesh.origin;
+  const ox = o ? o[0] : 0;
+  const oy = o ? o[1] : 0;
+  const oz = o ? o[2] : 0;
+
   if (positions.length === 0) {
     return {
-      min: [0, 0, 0],
-      max: [0, 0, 0],
+      min: [ox, oy, oz],
+      max: [ox, oy, oz],
     };
   }
 
@@ -108,15 +118,6 @@ function computeMeshBounds(mesh: MeshData): AABB {
     maxY = Math.max(maxY, y);
     maxZ = Math.max(maxZ, z);
   }
-
-  // Positions are in the element's local frame (world = origin + position). The
-  // spatial index is queried in world space, so lift the AABB by the per-mesh
-  // origin. Origin is constant per mesh, so a single add to the final extents is
-  // exact and cheapest. No-op when origin is absent/[0,0,0].
-  const o = mesh.origin;
-  const ox = o ? o[0] : 0;
-  const oy = o ? o[1] : 0;
-  const oz = o ? o[2] : 0;
 
   return {
     min: [minX + ox, minY + oy, minZ + oz],


### PR DESCRIPTION
## Bug

`computeMeshBounds` in `packages/spatial/src/spatial-index-builder.ts` returned a degenerate `[0,0,0]` box for any mesh with `positions.length === 0`, before the origin lift below ran. Every other path (populated mesh) is lifted by `mesh.origin` before being indexed; the empty-mesh early return skipped that lift entirely.

### Reproduction (real output, against the unpatched code)

```ts
const empty: MeshData = {
  expressId: 9,
  positions: new Float32Array(0),
  normals: new Float32Array(0),
  indices: new Uint32Array(0),
  color: [1, 1, 1, 1],
  origin: [500, 500, 500],
};
const bvh = buildSpatialIndex([empty]);
bvh.queryAABB({ min: [500,500,500], max: [500,500,500] }) // expected [9]
bvh.queryAABB({ min: [0,0,0],       max: [0,0,0] })       // expected []
```

Output:
```
foundAtOrigin [] foundAtWorldZero [ 9 ]
```

The mesh was indexed at world `[0,0,0]` instead of at its own origin `[500,500,500]`.

## Fix

Hoisted the `mesh.origin` extraction above the early return, so there is a single place in the function that reads `mesh.origin` instead of two copies that have to agree. The empty-mesh path now returns a degenerate box at `[ox, oy, oz]` (the natural fix), computed from the same three `const`s the populated-mesh path uses — restructured rather than duplicating the lift in both branches, since two copies of the same lift is exactly the shape that caused this bug.

## Same-shape sweep

Checked the rest of `packages/spatial/src` (`bvh.ts`, `aabb.ts`, `frustum.ts`) for other early returns that skip a transform the main path applies. All other early returns in the package (`BVH.build` on empty meshes, `queryAABB`/`raycast`/`queryFrustum` on a null root) return an empty/no-op result with no default-value computation involved — none apply a per-item transform on one path and skip it on another. No other instance of this shape found.

## Consumer check

`buildSpatialIndex`/`buildSpatialIndexAsync` are consumed by the viewer's loader (`apps/viewer/src/utils/loadingUtils.ts` and its callers) for picking and clash broad-phase, and by `@ifc-lite/clash`'s broad/tri-mesh phases via the `MeshWithBounds`/`BVH` types (which build their own bounds directly, not through `computeMeshBounds`). No consumer treats "empty mesh indexed at world `[0,0,0]`" as a sentinel or relies on it — they all expect world-space-correct bounds, which is what the fix produces. This only changes behaviour for empty meshes that also carry a non-zero `mesh.origin`.

## RED → GREEN

Strengthened the existing test (`spatial-index-builder.test.ts`) — its name already claimed *"at the model origin"*, but it only exercised the empty branch **without** an origin set, so it never crossed the interaction. Added a new case with a non-zero origin.

RED (against unpatched code):
```
 FAIL  src/spatial-index-builder.test.ts > buildSpatialIndex > gives an empty mesh a degenerate box at the mesh origin when one is set
AssertionError: expected [] to deeply equal [ 9 ]
```

GREEN (against the fix): all 11 tests in the file pass.

## Verification

- `packages/spatial` full suite: 50/50 passing before and after (49 before this PR's new test, +1 new test → 50 after).
- `pnpm run build` and `pnpm run typecheck` (both `tsc` and the test-typecheck scope) pass for `packages/spatial`.
- `pnpm dlx oxlint@1.42.0` on the changed files: 0 warnings/errors (no repo `oxlint` config available in this environment, so this is a weaker check than CI's).

## Changeset

Added `.changeset/spatial-empty-mesh-origin-lift.md` (`@ifc-lite/spatial` patch) — this changes indexed positions, which is user-visible in spatial queries (viewer picking, clash broad-phase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spatial indexing for empty meshes with non-zero origins.
  * Empty meshes are now positioned at their defined translated origin instead of defaulting to world coordinates `[0,0,0]`.
  * Preserved correct origin translation for meshes containing geometry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->