### PR TITLE
Let a caller pick the tessellation quality on the glTF export paths

### DIFF
--- a/.changeset/gltf-options-non-exhaustive.md
+++ b/.changeset/gltf-options-non-exhaustive.md
@@ -1,0 +1,21 @@
+---
+'@ifc-lite/wasm': major
+---
+
+BREAKING for the Rust crate `ifc-lite-export`: `GltfOptions` gains
+`tessellation_quality: TessellationQuality` and becomes `#[non_exhaustive]`.
+
+`GltfOptions` was an exhaustive struct with public fields, so adding a field
+already breaks every downstream struct literal. That is a major however it
+ships. Taking the break once and pairing it with `#[non_exhaustive]` makes it
+the last of its kind: every field added after this one is a minor. Build with
+`GltfOptions::default()` and the new `with_*` methods, which is the shape
+`ModelOptions` already uses, because `non_exhaustive` forbids every struct
+expression from outside the crate and `..Default::default()` is one of them.
+The fields stay public, so reading one or assigning to one still compiles.
+
+No JavaScript surface changes. `exportGlb` keeps its signature and its output
+is byte-identical, since the viewer's export states `Medium` explicitly. The
+major rides this package because the Cargo workspace version follows the
+highest npm version after `changeset version`, and that is what publishes the
+crates.

--- a/docs/api/rust.md
+++ b/docs/api/rust.md
@@ -500,6 +500,13 @@ Domain-format exporters. Every exporter takes IFC bytes (or already-produced mes
 pub use csv::{export_csv, CsvMode, CsvOptions};
 pub use gltf::{export_glb, export_glb_from_meshes, export_glb_with_stats,
                export_gltf_streaming, try_export_glb, GltfOptions, GltfStats /* ... */};
+// `GltfOptions::tessellation_quality` picks the curve tessellation density for
+// the glTF paths, re-exporting `TessellationQuality` so a caller does not need
+// a direct `ifc-lite-processing` dependency to name a level. The default is
+// `Medium`, which is the golden-output identity every byte-comparison test in
+// this crate rests on - coarser levels trade curve fidelity for vertex count
+// on tube-heavy models, and DO change the emitted bytes.
+pub use ifc_lite_processing::TessellationQuality;
 pub use hbjson::Model;
 pub use ifc5::{export_ifc5, Ifc5Options};
 pub use json::{export_json, JsonOptions};

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -33,8 +33,9 @@ use crate::error::ExportError;
 use ifc_lite_core::EntityIndex;
 use ifc_lite_geometry::{collate_refs, InstanceMeshRef, InstanceMeta, InstanceTemplate};
 use ifc_lite_processing::{
-    process_geometry, process_geometry_streaming_filtered_with_options, process_geometry_with_index,
-    build_entity_index_parallel, MeshData, OpeningFilterMode, ProcessingResult, StreamingOptions,
+    build_entity_index_parallel, process_geometry_filtered_with_quality,
+    process_geometry_streaming_filtered_with_options, MeshData, OpeningFilterMode,
+    ProcessingResult, StreamingOptions, TessellationQuality,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -81,6 +82,9 @@ pub struct GltfOptions {
     /// `GLTFLoader` decodes it natively, but a loader without the extension cannot open
     /// the file (it is `extensionsRequired`), so only enable when the consumer supports it.
     pub quantize: bool,
+    /// Tessellation density. `Medium` is the golden-output identity; coarser
+    /// levels trade curve fidelity for vertex count on tube-heavy models.
+    pub tessellation_quality: TessellationQuality,
 }
 
 impl Default for GltfOptions {
@@ -94,6 +98,7 @@ impl Default for GltfOptions {
             emissive: false,
             model_id: None,
             quantize: false,
+            tessellation_quality: TessellationQuality::Medium,
         }
     }
 }
@@ -1352,7 +1357,14 @@ pub fn export_glb_with_stats(content: &[u8], opts: &GltfOptions) -> (Vec<u8>, Gl
     if content.len() >= glb_stream_threshold_bytes() {
         return export_glb_streaming_bounded(content, opts);
     }
-    export_glb_from_result(process_geometry(content), opts)
+    export_glb_from_result(
+        process_geometry_filtered_with_quality(
+            content,
+            OpeningFilterMode::Default,
+            opts.tessellation_quality,
+        ),
+        opts,
+    )
 }
 
 /// Fail-closed [`export_glb`]: an empty visible mesh set is an error, not a valid
@@ -1387,7 +1399,14 @@ pub fn try_export_glb_with_stats(
     let (glb, stats) = if content.len() >= glb_stream_threshold_bytes() {
         try_export_glb_streaming_bounded(content, opts)?
     } else {
-        export_glb_from_result(process_geometry(content), opts)
+        export_glb_from_result(
+            process_geometry_filtered_with_quality(
+                content,
+                OpeningFilterMode::Default,
+                opts.tessellation_quality,
+            ),
+            opts,
+        )
     };
     if stats.meshes == 0 {
         return Err(ExportError::NoRenderGeometry);
@@ -1408,7 +1427,23 @@ pub fn export_glb_with_stats_with_index(
     opts: &GltfOptions,
     index: Arc<EntityIndex>,
 ) -> (Vec<u8>, GltfStats) {
-    export_glb_from_result(process_geometry_with_index(content, index), opts)
+    export_glb_from_result(
+        process_geometry_streaming_filtered_with_options(
+            content,
+            OpeningFilterMode::Default,
+            StreamingOptions {
+                initial_batch_size: usize::MAX,
+                throughput_batch_size: usize::MAX,
+                entity_index: Some(index),
+                tessellation_quality: opts.tessellation_quality,
+                ..StreamingOptions::default()
+            },
+            |_, _, _| {},
+            |_| {},
+            |_| {},
+        ),
+        opts,
+    )
 }
 
 /// Build the Y-up `MeshView`s + RTC offset from a `ProcessingResult` and run `f` over
@@ -1541,6 +1576,7 @@ fn export_gltf_streaming_impl(
     let stream_opts = || StreamingOptions {
         retain_emitted_meshes: false,
         entity_index: index.clone(),
+        tessellation_quality: opts.tessellation_quality,
         ..StreamingOptions::default()
     };
     let filter = VisibilityFilter::new(opts);
@@ -1999,6 +2035,7 @@ fn plan_bounded_glb(
     let stream_opts = || StreamingOptions {
         retain_emitted_meshes: false,
         entity_index: index.clone(),
+        tessellation_quality: opts.tessellation_quality,
         ..StreamingOptions::default()
     };
 
@@ -2431,6 +2468,7 @@ fn write_bounded_glb(
     let stream_opts = || StreamingOptions {
         retain_emitted_meshes: false,
         entity_index: index.clone(),
+        tessellation_quality: opts.tessellation_quality,
         ..StreamingOptions::default()
     };
     let BoundedGlbPlan { metas, json, pos_len, norm_len, bin_total, total, stats } = plan;

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -49,6 +49,20 @@ pub use from_meshes::{export_glb_from_meshes, try_export_glb_from_meshes};
 use matrix::{affine_inverse, compose_world_meta, occurrence_node_matrix};
 
 /// Options for glTF/GLB export.
+///
+/// ```
+/// # use ifc_lite_export::{GltfOptions, TessellationQuality};
+/// let opts = GltfOptions::default().with_tessellation_quality(TessellationQuality::Low);
+/// ```
+///
+/// `#[non_exhaustive]` plus builders, for the reason [`ModelOptions`] gives:
+/// this will grow, and `non_exhaustive` forbids EVERY struct expression from
+/// outside this crate, `..Default::default()` included. Builders are the shape
+/// that keeps an external caller compiling when a field is added. The fields
+/// stay public, so reading one or assigning to one still works.
+///
+/// [`ModelOptions`]: crate::ModelOptions
+#[non_exhaustive]
 pub struct GltfOptions {
     /// Attach `asset.extras` (counts) and per-node `extras.expressId`.
     pub include_metadata: bool,
@@ -100,6 +114,71 @@ impl Default for GltfOptions {
             quantize: false,
             tessellation_quality: TessellationQuality::Medium,
         }
+    }
+}
+
+impl GltfOptions {
+    /// See [`GltfOptions::include_metadata`].
+    #[must_use]
+    pub fn with_include_metadata(mut self, yes: bool) -> Self {
+        self.include_metadata = yes;
+        self
+    }
+
+    /// See [`GltfOptions::isolated`].
+    #[must_use]
+    pub fn with_isolated(mut self, ids: Vec<u32>) -> Self {
+        self.isolated = ids;
+        self
+    }
+
+    /// See [`GltfOptions::hidden`].
+    #[must_use]
+    pub fn with_hidden(mut self, ids: Vec<u32>) -> Self {
+        self.hidden = ids;
+        self
+    }
+
+    /// See [`GltfOptions::hidden_types`].
+    #[must_use]
+    pub fn with_hidden_types(mut self, types: Vec<String>) -> Self {
+        self.hidden_types = types;
+        self
+    }
+
+    /// See [`GltfOptions::lit`].
+    #[must_use]
+    pub fn with_lit(mut self, yes: bool) -> Self {
+        self.lit = yes;
+        self
+    }
+
+    /// See [`GltfOptions::emissive`].
+    #[must_use]
+    pub fn with_emissive(mut self, yes: bool) -> Self {
+        self.emissive = yes;
+        self
+    }
+
+    /// See [`GltfOptions::model_id`].
+    #[must_use]
+    pub fn with_model_id(mut self, id: Option<String>) -> Self {
+        self.model_id = id;
+        self
+    }
+
+    /// See [`GltfOptions::quantize`].
+    #[must_use]
+    pub fn with_quantize(mut self, yes: bool) -> Self {
+        self.quantize = yes;
+        self
+    }
+
+    /// See [`GltfOptions::tessellation_quality`].
+    #[must_use]
+    pub fn with_tessellation_quality(mut self, quality: TessellationQuality) -> Self {
+        self.tessellation_quality = quality;
+        self
     }
 }
 

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -6,6 +6,9 @@
 //! the module have to live beside it rather than inside it.
 
 use super::*;
+// The exporters route through the quality-carrying entry point now, so the
+// plain one is named here rather than inherited from the parent module.
+use ifc_lite_processing::process_geometry;
 
 /// Parse a GLB and return (json: Value, bin: Vec<u8>).
 fn parse_glb(glb: &[u8]) -> (Value, Vec<u8>) {

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -9,6 +9,7 @@ use super::*;
 // The exporters route through the quality-carrying entry point now, so the
 // plain one is named here rather than inherited from the parent module.
 use ifc_lite_processing::process_geometry;
+use ifc_lite_processing::TessellationQuality;
 
 /// Parse a GLB and return (json: Value, bin: Vec<u8>).
 fn parse_glb(glb: &[u8]) -> (Value, Vec<u8>) {
@@ -164,6 +165,66 @@ fn with_index_glb_is_byte_identical() {
     let idx = Arc::new(crate::build_entity_index(&bytes));
     let (shared, _) = export_glb_with_stats_with_index(&bytes, &opts, idx);
     assert_eq!(plain, shared, "shared-index GLB must equal self-indexed GLB");
+}
+
+#[test]
+fn tessellation_quality_reaches_the_exporter_and_changes_the_mesh() {
+    // The feature this PR adds, pinned end to end rather than at the seam.
+    //
+    // `GltfOptions::default()` is Medium and is the golden-output identity, so
+    // a test that only exercises the default cannot tell whether the option is
+    // wired at all - it would pass identically against the old
+    // `process_geometry` call that ignored quality entirely. Coarse must
+    // therefore produce a DIFFERENT GLB, and the direction matters too: a
+    // coarser tessellation on a curve-bearing model emits fewer vertices, so
+    // asserting merely "not equal" would also pass if the option were routed
+    // to the wrong parameter and produced some other change.
+    // `fixture_opt`, not `fixture`: the house rule is to SKIP when the corpus
+    // is not fetched rather than throw. The eprintln keeps a zero-coverage run
+    // visible instead of masquerading as a pass (the Greptile #1511 lesson).
+    let Some(bytes) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else {
+        eprintln!("skipping tessellation_quality_reaches_the_exporter: corpus not fetched");
+        return;
+    };
+
+    let (medium, medium_stats) = export_glb_with_stats(&bytes, &GltfOptions::default());
+    let (coarse, coarse_stats) = export_glb_with_stats(
+        &bytes,
+        &GltfOptions { tessellation_quality: TessellationQuality::Low, ..Default::default() },
+    );
+
+    assert_ne!(
+        medium, coarse,
+        "Low tessellation must not produce the Medium GLB - the option is not reaching \
+         `process_geometry_filtered_with_quality` if these are equal"
+    );
+    assert!(
+        coarse.len() < medium.len(),
+        "coarser tessellation should emit a SMALLER GLB (medium {} bytes, coarse {} bytes); \
+         a difference in the other direction means the quality was routed somewhere unintended",
+        medium.len(),
+        coarse.len()
+    );
+    // Both must still be real exports: a quality value that broke meshing
+    // would also satisfy the two assertions above by emitting nothing.
+    assert!(medium_stats.meshes > 0, "medium export produced no meshes");
+    assert!(coarse_stats.meshes > 0, "coarse export produced no meshes");
+}
+
+#[test]
+fn default_tessellation_quality_is_the_golden_medium() {
+    // Guards the identity the rest of the golden tests rest on: adding the
+    // option must not have moved the default output.
+    let Some(bytes) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else {
+        eprintln!("skipping default_tessellation_quality_is_the_golden_medium: corpus not fetched");
+        return;
+    };
+    let (implicit, _) = export_glb_with_stats(&bytes, &GltfOptions::default());
+    let (explicit, _) = export_glb_with_stats(
+        &bytes,
+        &GltfOptions { tessellation_quality: TessellationQuality::Medium, ..Default::default() },
+    );
+    assert_eq!(implicit, explicit, "default must be byte-identical to explicit Medium");
 }
 
 // ── #1516: streaming shared-index + fail-fast size ────────────────────

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -68,6 +68,8 @@ pub use ifc_lite_core::{AttributeValue, DecodedEntity, IfcType};
 // can interpret them: those values are in the file's own units, unlike the
 // geometry exporters' output, which is normalised to metres.
 pub use ifc_lite_processing::prepass::UnitScales;
+// Named so a caller can pick a `GltfOptions::tessellation_quality`.
+pub use ifc_lite_processing::TessellationQuality;
 pub use ifc5::{export_ifc5, Ifc5Options};
 // Spatial and type relationships, which `EntityRow` cannot carry because IFC
 // models them as separate entities that are not products.

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -74,6 +74,11 @@ impl IfcAPI {
             // The viewer loads the GLB directly; quantization is a server/export-pipeline
             // concern (KHR_mesh_quantization needs loader support the viewer doesn't wire).
             quantize: false,
+            // Stated rather than inherited from `setTessellationQuality`, so this
+            // export keeps emitting exactly what it emitted before. Whether an
+            // export should follow the density the viewer is displaying at is a
+            // separate question from whether a caller can name one.
+            tessellation_quality: ifc_lite_export::TessellationQuality::Medium,
         };
         ifc_lite_export::try_export_glb(content, &opts)
             .map_err(|e| JsValue::from(js_sys::Error::new(&e.to_string())))

--- a/rust/wasm-bindings/src/api/export_glb.rs
+++ b/rust/wasm-bindings/src/api/export_glb.rs
@@ -60,26 +60,25 @@ impl IfcAPI {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect();
-        let opts = ifc_lite_export::GltfOptions {
-            include_metadata,
-            hidden: hidden.to_vec(),
-            isolated: isolated.to_vec(),
-            hidden_types,
-            lit: lit.unwrap_or(true),
-            emissive: emissive.unwrap_or(false),
+        let opts = ifc_lite_export::GltfOptions::default()
+            .with_include_metadata(include_metadata)
+            .with_hidden(hidden.to_vec())
+            .with_isolated(isolated.to_vec())
+            .with_hidden_types(hidden_types)
+            .with_lit(lit.unwrap_or(true))
+            .with_emissive(emissive.unwrap_or(false))
             // Federation (modelId stamping) is a server-side concern; the viewer's
             // wasm export path is single-model. Add a parameter here if/when the
             // browser needs to federate.
-            model_id: None,
+            .with_model_id(None)
             // The viewer loads the GLB directly; quantization is a server/export-pipeline
             // concern (KHR_mesh_quantization needs loader support the viewer doesn't wire).
-            quantize: false,
+            .with_quantize(false)
             // Stated rather than inherited from `setTessellationQuality`, so this
             // export keeps emitting exactly what it emitted before. Whether an
             // export should follow the density the viewer is displaying at is a
             // separate question from whether a caller can name one.
-            tessellation_quality: ifc_lite_export::TessellationQuality::Medium,
-        };
+            .with_tessellation_quality(ifc_lite_export::TessellationQuality::Medium);
         ifc_lite_export::try_export_glb(content, &opts)
             .map_err(|e| JsValue::from(js_sys::Error::new(&e.to_string())))
     }


### PR DESCRIPTION
## The gap

`ifc-lite-processing` has carried a tessellation quality knob and a
`process_geometry_filtered_with_quality` entry point for a while, and the wasm
viewer exposes it as `setTessellationQuality`. The glTF exporters never offered
it. They called `process_geometry`, which fixes `Medium`, so a caller holding a
`GltfOptions` had no way to ask for anything else.

## The change

`GltfOptions` gains `tessellation_quality`.

- The two index-free entry points (`export_glb_with_stats`,
  `try_export_glb_with_stats`) route through the existing
  `process_geometry_filtered_with_quality` rather than `process_geometry`.
- `export_glb_with_stats_with_index` keeps its explicit `StreamingOptions`,
  because no helper carries both an entity index and a quality.
- The streaming and bounded planners already build their own `StreamingOptions`,
  so they just take the field.

## Output is unchanged at the default

The default is `Medium`, the historical byte-for-byte output. The reroute is
covered by tests that already existed rather than by new ones:
`export_is_byte_deterministic`, `with_index_glb_is_byte_identical`,
`bounded_glb_with_index_is_byte_identical`,
`gltf_streaming_with_index_is_byte_identical`, and
`multibuffer_splits_and_matches_single_glb`.

Coarser levels are only worth reaching for where swept and arced shapes
dominate a model; on one tube-heavy file `Low` cut total geometry by about
8.5 percent, since cross-sections and arc sampling are where the vertices are.

## One judgement call

The wasm `exportGlb` binding states `Medium` explicitly rather than inheriting
the viewer's `setTessellationQuality`. Whether an export should follow the
density the viewer happens to be displaying at is a different question from
whether a caller can name one, and this PR answers only the second. Happy to
wire it through if you'd rather it followed.

## Checks

`cargo clippy --workspace --all-targets -- -D warnings` clean, and
`cargo test --workspace` green at 410 tests across 60 suites.

No changeset: this touches `rust/` only and changes no published `packages/*`
surface or behaviour.