### PR TITLE
fix(create): guard all in-store builders against NaN/Infinity dimensions

### DIFF
--- a/.changeset/in-store-builders-reject-non-finite-dimensions.md
+++ b/.changeset/in-store-builders-reject-non-finite-dimensions.md
@@ -1,0 +1,41 @@
+---
+'@ifc-lite/create': patch
+---
+
+Fix the eight in-store element builders that emitted invalid IFC when
+given a `NaN` or `Infinity` dimension instead of throwing.
+
+Every in-store builder (`addWallToStore`, `addBeamToStore`,
+`addDoorToStore`, `addWindowToStore`, `addMemberToStore`,
+`addPlateToStore`, `addRoofToStore`, `addSpaceToStore`,
+`addSlabToStore`) validated its `Width`/`Height`/`Depth`/`Thickness`/
+`FrameThickness` params with a bare `value <= 0` check. That check is
+`false` for both `NaN` and `Infinity`, so those values passed
+validation silently and landed as the literal STEP tokens `NaN` /
+`Infinity` in the emitted `IfcExtrudedAreaSolid` and profile
+attributes — e.g. `addWallToStore({ ..., Height: NaN })` threw
+nothing and wrote an `IfcExtrudedAreaSolid` whose Depth attribute was
+the string `"NaN"`.
+
+`addColumnToStore` already guarded against this — the docstring at
+`column.ts:14` records that the `Number.isFinite` check was added
+while closing the merge-roundtrip gap from LTplus-AG/ifc-lite#592 —
+but the fix never propagated to its eight siblings, each of which
+carries its own copy of the same validation shape.
+
+Rather than copy the guard into eight more places (which is how the
+gap opened in the first place — one copy got fixed, eight did not),
+the check is now a single `assertPositiveFinite` helper in
+`_emit-helpers.ts`, and every builder — including `addColumnToStore`
+itself — calls it. A parametrised test
+(`in-store/dimension-validation.test.ts`) runs `NaN`/`Infinity`/
+`-Infinity`/`0`/`-1` against every dimension field of every builder,
+so a future builder added without the guard fails visibly instead of
+shipping silently.
+
+This is a behaviour change: builders that previously accepted a
+`NaN`/`Infinity` dimension and produced invalid IFC now throw
+`Error('add<Type>ToStore: <Fields> must be positive')` instead. No
+caller in this repository relied on the previous permissiveness —
+every call site passes numeric literals or values already validated
+upstream.

--- a/packages/create/src/in-store/_emit-helpers.ts
+++ b/packages/create/src/in-store/_emit-helpers.ts
@@ -22,6 +22,23 @@ import type { StoreEditor } from '@ifc-lite/mutations';
 const POINT_EPSILON = 1e-6;
 
 /**
+ * Guard for element-builder dimension params (Width, Depth, Height,
+ * Thickness, FrameThickness, ...). A bare `value <= 0` check is `false`
+ * for both `NaN` and `Infinity`, so those values sail past validation
+ * and land as the literal strings `"NaN"`/`"Infinity"` in the emitted
+ * `IfcExtrudedAreaSolid`/profile attributes — invalid IFC written with
+ * no error. `column.ts` picked this up while closing the merge-roundtrip
+ * gap from LTplus-AG/ifc-lite#592; every other builder needs the same
+ * `Number.isFinite` guard, so it lives here once instead of as N copies
+ * that can individually go stale.
+ */
+export function assertPositiveFinite(values: readonly number[], message: string): void {
+  if (values.some((v) => !Number.isFinite(v) || v <= 0)) {
+    throw new Error(message);
+  }
+}
+
+/**
  * Emit an IfcLocalPlacement chained to a parent. Wraps the cartesian
  * point + axis-placement bookkeeping. Pass `Axis` and/or `RefDirection`
  * as `[x, y, z]` to override defaults (otherwise IFC fills them with

--- a/packages/create/src/in-store/beam.ts
+++ b/packages/create/src/in-store/beam.ts
@@ -23,7 +23,7 @@ import type { StoreEditor } from '@ifc-lite/mutations';
 import { vecCross, vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
 import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
-import { ownerHistoryRef } from './_emit-helpers.js';
+import { assertPositiveFinite, ownerHistoryRef } from './_emit-helpers.js';
 
 export interface BeamInStoreParams {
   Start: [number, number, number];
@@ -79,9 +79,7 @@ export function addBeamToStore(
   if (beamLen <= 0) {
     throw new Error('addBeamToStore: Start and End must be distinct points');
   }
-  if (params.Width <= 0 || params.Height <= 0) {
-    throw new Error('addBeamToStore: Width and Height must be positive');
-  }
+  assertPositiveFinite([params.Width, params.Height], 'addBeamToStore: Width and Height must be positive');
   const dir: Point3D = vecNorm([dx, dy, dz]);
   const refDir = computeRefDirection(dir);
 

--- a/packages/create/src/in-store/column.ts
+++ b/packages/create/src/in-store/column.ts
@@ -19,7 +19,7 @@
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
-import { ownerHistoryRef } from './_emit-helpers.js';
+import { assertPositiveFinite, ownerHistoryRef } from './_emit-helpers.js';
 
 export interface ColumnInStoreParams {
   /** Base centre of the column, in storey-local coordinates (metres). */
@@ -68,12 +68,10 @@ export function addColumnToStore(
 ): ColumnBuildResult {
   const { ownerHistoryId, bodyContextId, storeyId, storeyPlacementId } = anchor;
 
-  if (
-    !Number.isFinite(params.Width) || !Number.isFinite(params.Depth) || !Number.isFinite(params.Height)
-    || params.Width <= 0 || params.Depth <= 0 || params.Height <= 0
-  ) {
-    throw new Error('addColumnToStore: Width, Depth, and Height must be finite positive numbers');
-  }
+  assertPositiveFinite(
+    [params.Width, params.Depth, params.Height],
+    'addColumnToStore: Width, Depth, and Height must be finite positive numbers',
+  );
 
   // Params are metres; convert dimensioned fields to the file's native
   // length unit before emit (see SpatialAnchor.lengthUnitScale).

--- a/packages/create/src/in-store/dimension-validation.test.ts
+++ b/packages/create/src/in-store/dimension-validation.test.ts
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Cross-builder regression: every in-store element builder must reject
+ * non-finite dimension params (`NaN` / `Infinity`), not just non-positive
+ * ones. A bare `value <= 0` check is `false` for both `NaN` and `Infinity`,
+ * so those values used to sail past validation and land as the literal
+ * STEP tokens `NaN` / `Infinity` in the emitted `IfcExtrudedAreaSolid` /
+ * profile attributes — invalid IFC written with no error.
+ *
+ * `column.ts` picked up the `Number.isFinite` guard while closing the
+ * merge-roundtrip gap from LTplus-AG/ifc-lite#592; this file is the single
+ * place that pins the guard for every builder so a tenth builder landing
+ * without it shows up here instead of shipping silently, the way the
+ * original eight did.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  MutablePropertyView,
+  StoreEditor,
+  type MutationEntityRef,
+  type MutationStoreShape,
+} from '@ifc-lite/mutations';
+import type { SpatialAnchor } from './anchor.js';
+import { addColumnToStore } from './column.js';
+import { addBeamToStore } from './beam.js';
+import { addDoorToStore } from './door.js';
+import { addWindowToStore } from './window.js';
+import { addMemberToStore } from './member.js';
+import { addWallToStore } from './wall.js';
+import { addPlateToStore } from './plate.js';
+import { addRoofToStore } from './roof.js';
+import { addSpaceToStore } from './space.js';
+import { addSlabToStore } from './slab.js';
+
+function makeStore(maxId: number): MutationStoreShape {
+  const byId = new Map<number, MutationEntityRef>();
+  for (let id = 1; id <= maxId; id++) {
+    byId.set(id, { expressId: id, type: 'IFCDUMMY', byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  return { entityIndex: { byId } };
+}
+
+const ANCHOR: SpatialAnchor = {
+  ownerHistoryId: 5,
+  bodyContextId: 14,
+  axisContextId: 15,
+  storeyId: 43,
+  storeyPlacementId: 54,
+};
+
+interface BuilderCase {
+  label: string;
+  build: (editor: StoreEditor, params: Record<string, unknown>) => unknown;
+  base: Record<string, unknown>;
+  /** Dimension fields to fuzz, one at a time. */
+  fields: string[];
+}
+
+const cases: BuilderCase[] = [
+  {
+    label: 'addColumnToStore',
+    build: (editor, params) => addColumnToStore(editor, ANCHOR, params as never),
+    base: { Position: [0, 0, 0], Width: 0.3, Depth: 0.4, Height: 3 },
+    fields: ['Width', 'Depth', 'Height'],
+  },
+  {
+    label: 'addBeamToStore',
+    build: (editor, params) => addBeamToStore(editor, ANCHOR, params as never),
+    base: { Start: [0, 0, 0], End: [5, 0, 0], Width: 0.3, Height: 0.3 },
+    fields: ['Width', 'Height'],
+  },
+  {
+    label: 'addDoorToStore',
+    build: (editor, params) => addDoorToStore(editor, ANCHOR, params as never),
+    base: { Position: [0, 0, 0], Width: 0.9, Height: 2.1, FrameThickness: 0.05 },
+    fields: ['Width', 'Height', 'FrameThickness'],
+  },
+  {
+    label: 'addWindowToStore',
+    build: (editor, params) => addWindowToStore(editor, ANCHOR, params as never),
+    base: { Position: [0, 0, 0], Width: 1.2, Height: 1.5, FrameThickness: 0.05 },
+    fields: ['Width', 'Height', 'FrameThickness'],
+  },
+  {
+    label: 'addMemberToStore',
+    build: (editor, params) => addMemberToStore(editor, ANCHOR, params as never),
+    base: { Start: [0, 0, 0], End: [5, 0, 0], Width: 0.15, Height: 0.15 },
+    fields: ['Width', 'Height'],
+  },
+  {
+    label: 'addWallToStore',
+    build: (editor, params) => addWallToStore(editor, ANCHOR, params as never),
+    base: { Start: [0, 0, 0], End: [5, 0, 0], Thickness: 0.2, Height: 3 },
+    fields: ['Thickness', 'Height'],
+  },
+  {
+    label: 'addPlateToStore',
+    build: (editor, params) => addPlateToStore(editor, ANCHOR, params as never),
+    base: { Position: [0, 0, 0], Width: 1, Depth: 1, Thickness: 0.01 },
+    fields: ['Width', 'Depth', 'Thickness'],
+  },
+  {
+    label: 'addRoofToStore',
+    build: (editor, params) => addRoofToStore(editor, ANCHOR, params as never),
+    base: { Position: [0, 0, 0], Width: 1, Depth: 1, Thickness: 0.01 },
+    fields: ['Width', 'Depth', 'Thickness'],
+  },
+  {
+    label: 'addSpaceToStore',
+    build: (editor, params) => addSpaceToStore(editor, ANCHOR, params as never),
+    base: { Position: [0, 0, 0], Width: 3, Depth: 4, Height: 2.5 },
+    fields: ['Width', 'Depth', 'Height'],
+  },
+  {
+    label: 'addSlabToStore',
+    build: (editor, params) => addSlabToStore(editor, ANCHOR, params as never),
+    base: { Position: [0, 0, 0], Width: 3, Depth: 4, Thickness: 0.2 },
+    fields: ['Width', 'Depth', 'Thickness'],
+  },
+];
+
+describe.each(cases)('$label dimension validation', ({ build, base, fields }) => {
+  it('accepts the valid baseline params (sanity check for the fuzzed fields below)', () => {
+    const editor = new StoreEditor(makeStore(50), new MutablePropertyView(null, 'm1'));
+    expect(() => build(editor, base)).not.toThrow();
+  });
+
+  for (const field of fields) {
+    it(`rejects NaN ${field}`, () => {
+      const editor = new StoreEditor(makeStore(50), new MutablePropertyView(null, 'm1'));
+      expect(() => build(editor, { ...base, [field]: NaN })).toThrow();
+    });
+
+    it(`rejects Infinity ${field}`, () => {
+      const editor = new StoreEditor(makeStore(50), new MutablePropertyView(null, 'm1'));
+      expect(() => build(editor, { ...base, [field]: Infinity })).toThrow();
+    });
+
+    it(`rejects -Infinity ${field}`, () => {
+      const editor = new StoreEditor(makeStore(50), new MutablePropertyView(null, 'm1'));
+      expect(() => build(editor, { ...base, [field]: -Infinity })).toThrow();
+    });
+
+    // Pin the pre-existing behaviour: zero/negative dimensions must keep
+    // throwing exactly as they did before this fix.
+    it(`still rejects zero ${field} (pinned pre-existing behaviour)`, () => {
+      const editor = new StoreEditor(makeStore(50), new MutablePropertyView(null, 'm1'));
+      expect(() => build(editor, { ...base, [field]: 0 })).toThrow(/positive/);
+    });
+
+    it(`still rejects negative ${field} (pinned pre-existing behaviour)`, () => {
+      const editor = new StoreEditor(makeStore(50), new MutablePropertyView(null, 'm1'));
+      expect(() => build(editor, { ...base, [field]: -1 })).toThrow(/positive/);
+    });
+  }
+});

--- a/packages/create/src/in-store/door.ts
+++ b/packages/create/src/in-store/door.ts
@@ -19,6 +19,7 @@
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
+  assertPositiveFinite,
   emitBodyRepresentation,
   emitExtrudedSolid,
   emitLocalPlacement,
@@ -89,12 +90,11 @@ export function addDoorToStore(
   anchor: SpatialAnchor,
   params: DoorInStoreParams,
 ): DoorBuildResult {
-  if (params.Width <= 0 || params.Height <= 0) {
-    throw new Error('addDoorToStore: Width and Height must be positive');
-  }
-  if ((params.FrameThickness ?? 0.05) <= 0) {
-    throw new Error('addDoorToStore: FrameThickness must be positive');
-  }
+  assertPositiveFinite([params.Width, params.Height], 'addDoorToStore: Width and Height must be positive');
+  assertPositiveFinite(
+    [params.FrameThickness ?? 0.05],
+    'addDoorToStore: FrameThickness must be positive',
+  );
   // Params are metres; convert dimensioned fields (incl. the OverallWidth/
   // OverallHeight attributes emitted below) to the file's native length
   // unit before emit (see SpatialAnchor.lengthUnitScale).

--- a/packages/create/src/in-store/member.ts
+++ b/packages/create/src/in-store/member.ts
@@ -16,6 +16,7 @@ import { vecCross, vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
 import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
+  assertPositiveFinite,
   emitBodyRepresentation,
   emitExtrudedSolid,
   emitLocalPlacement,
@@ -75,9 +76,7 @@ export function addMemberToStore(
   if (memberLen <= 0) {
     throw new Error('addMemberToStore: Start and End must be distinct points');
   }
-  if (params.Width <= 0 || params.Height <= 0) {
-    throw new Error('addMemberToStore: Width and Height must be positive');
-  }
+  assertPositiveFinite([params.Width, params.Height], 'addMemberToStore: Width and Height must be positive');
   const dir: Point3D = vecNorm([dx, dy, dz]);
   const refDir = computeRefDirection(dir);
 

--- a/packages/create/src/in-store/plate.ts
+++ b/packages/create/src/in-store/plate.ts
@@ -12,6 +12,7 @@
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, toNativePoint2, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
+  assertPositiveFinite,
   emitBodyRepresentation,
   emitExtrudedSolid,
   emitLocalPlacement,
@@ -67,11 +68,12 @@ export function addPlateToStore(
   anchor: SpatialAnchor,
   params: PlateInStoreParams,
 ): PlateBuildResult {
-  if (params.Thickness <= 0) {
-    throw new Error('addPlateToStore: Thickness must be positive');
-  }
-  if (!isPolygonParams(params) && (params.Width <= 0 || params.Depth <= 0)) {
-    throw new Error('addPlateToStore: Width and Depth must be positive');
+  assertPositiveFinite([params.Thickness], 'addPlateToStore: Thickness must be positive');
+  if (!isPolygonParams(params)) {
+    assertPositiveFinite(
+      [params.Width, params.Depth],
+      'addPlateToStore: Width and Depth must be positive',
+    );
   }
   // Params are metres; convert dimensioned fields to the file's native
   // length unit before emit (see SpatialAnchor.lengthUnitScale). A new

--- a/packages/create/src/in-store/roof.ts
+++ b/packages/create/src/in-store/roof.ts
@@ -14,6 +14,7 @@
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, toNativePoint2, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
+  assertPositiveFinite,
   emitBodyRepresentation,
   emitExtrudedSolid,
   emitLocalPlacement,
@@ -67,11 +68,12 @@ export function addRoofToStore(
   anchor: SpatialAnchor,
   params: RoofInStoreParams,
 ): RoofBuildResult {
-  if (params.Thickness <= 0) {
-    throw new Error('addRoofToStore: Thickness must be positive');
-  }
-  if (!isPolygonParams(params) && (params.Width <= 0 || params.Depth <= 0)) {
-    throw new Error('addRoofToStore: Width and Depth must be positive');
+  assertPositiveFinite([params.Thickness], 'addRoofToStore: Thickness must be positive');
+  if (!isPolygonParams(params)) {
+    assertPositiveFinite(
+      [params.Width, params.Depth],
+      'addRoofToStore: Width and Depth must be positive',
+    );
   }
   // Params are metres; convert dimensioned fields to the file's native
   // length unit before emit (see SpatialAnchor.lengthUnitScale). A new

--- a/packages/create/src/in-store/slab.ts
+++ b/packages/create/src/in-store/slab.ts
@@ -25,7 +25,7 @@
 import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, toNativePoint2, toNativePoint3, type SpatialAnchor } from './anchor.js';
-import { ownerHistoryRef } from './_emit-helpers.js';
+import { assertPositiveFinite, ownerHistoryRef } from './_emit-helpers.js';
 
 export type SlabInStoreParams = SlabRectangleParams | SlabPolygonParams;
 
@@ -122,11 +122,12 @@ export function addSlabToStore(
 ): SlabBuildResult {
   const { ownerHistoryId, bodyContextId, storeyId, storeyPlacementId } = anchor;
 
-  if (params.Thickness <= 0) {
-    throw new Error('addSlabToStore: Thickness must be positive');
-  }
-  if (!isPolygonParams(params) && (params.Width <= 0 || params.Depth <= 0)) {
-    throw new Error('addSlabToStore: Width and Depth must be positive');
+  assertPositiveFinite([params.Thickness], 'addSlabToStore: Thickness must be positive');
+  if (!isPolygonParams(params)) {
+    assertPositiveFinite(
+      [params.Width, params.Depth],
+      'addSlabToStore: Width and Depth must be positive',
+    );
   }
   // Params are metres; convert dimensioned fields to the file's native
   // length unit before emit (see SpatialAnchor.lengthUnitScale). A new

--- a/packages/create/src/in-store/space.ts
+++ b/packages/create/src/in-store/space.ts
@@ -20,6 +20,7 @@ import { generateIfcGuid } from '@ifc-lite/encoding';
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, type SpatialAnchor } from './anchor.js';
 import {
+  assertPositiveFinite,
   emitBodyRepresentation,
   emitExtrudedSolid,
   emitLocalPlacement,
@@ -135,11 +136,12 @@ export function addSpaceToStore(
     ? params.Position ?? [0, 0, 0]
     : params.Position;
 
-  if (params.Height <= 0) {
-    throw new Error('addSpaceToStore: Height must be positive');
-  }
-  if (!polygon && (params.Width <= 0 || params.Depth <= 0)) {
-    throw new Error('addSpaceToStore: Width and Depth must be positive');
+  assertPositiveFinite([params.Height], 'addSpaceToStore: Height must be positive');
+  if (!polygon) {
+    assertPositiveFinite(
+      [params.Width, params.Depth],
+      'addSpaceToStore: Width and Depth must be positive',
+    );
   }
 
   // Geometry coordinates must land in the file's native length unit —

--- a/packages/create/src/in-store/wall.ts
+++ b/packages/create/src/in-store/wall.ts
@@ -22,7 +22,7 @@ import type { StoreEditor } from '@ifc-lite/mutations';
 import { vecNorm } from '../ifc-creator-math.js';
 import type { Point3D } from '../types.js';
 import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
-import { ownerHistoryRef } from './_emit-helpers.js';
+import { assertPositiveFinite, ownerHistoryRef } from './_emit-helpers.js';
 
 export interface WallInStoreParams {
   /** Start of the wall axis, in storey-local coordinates (metres). */
@@ -56,9 +56,10 @@ export function addWallToStore(
 ): WallBuildResult {
   const { ownerHistoryId, bodyContextId, storeyId, storeyPlacementId } = anchor;
 
-  if (params.Thickness <= 0 || params.Height <= 0) {
-    throw new Error('addWallToStore: Thickness and Height must be positive');
-  }
+  assertPositiveFinite(
+    [params.Thickness, params.Height],
+    'addWallToStore: Thickness and Height must be positive',
+  );
   // Params are metres; convert dimensioned fields to the file's native
   // length unit so the emitted STEP coordinates are correctly scaled
   // (see SpatialAnchor.lengthUnitScale). Directions normalise the scale

--- a/packages/create/src/in-store/window.ts
+++ b/packages/create/src/in-store/window.ts
@@ -11,6 +11,7 @@
 import type { StoreEditor } from '@ifc-lite/mutations';
 import { toNativeLength, toNativePoint3, type SpatialAnchor } from './anchor.js';
 import {
+  assertPositiveFinite,
   emitBodyRepresentation,
   emitExtrudedSolid,
   emitLocalPlacement,
@@ -72,12 +73,11 @@ export function addWindowToStore(
   anchor: SpatialAnchor,
   params: WindowInStoreParams,
 ): WindowBuildResult {
-  if (params.Width <= 0 || params.Height <= 0) {
-    throw new Error('addWindowToStore: Width and Height must be positive');
-  }
-  if ((params.FrameThickness ?? 0.05) <= 0) {
-    throw new Error('addWindowToStore: FrameThickness must be positive');
-  }
+  assertPositiveFinite([params.Width, params.Height], 'addWindowToStore: Width and Height must be positive');
+  assertPositiveFinite(
+    [params.FrameThickness ?? 0.05],
+    'addWindowToStore: FrameThickness must be positive',
+  );
   // Params are metres; convert dimensioned fields (incl. the OverallWidth/
   // OverallHeight attributes emitted below) to the file's native length
   // unit before emit (see SpatialAnchor.lengthUnitScale).


### PR DESCRIPTION
## The defect

`packages/create/src/in-store/column.ts:71-74` guards its dimensions with
`!Number.isFinite(...)` before the `<= 0` check. Its docstring records why:
*"closes the merge-roundtrip gap from LTplus-AG/ifc-lite#592"*.

Its eight structural twins used a bare `<= 0`, which is `false` for both
`NaN` and `Infinity`, so those values passed validation silently and were
written into the emitted STEP as the literal strings `"NaN"` / `"Infinity"`
— invalid IFC written with no error.

## Reproduction

Against the pre-fix code, `addWallToStore` with `Height: NaN` threw nothing
and emitted an `IfcExtrudedAreaSolid` whose Depth attribute (`attributes[3]`)
is the literal string `"NaN"`:

```
addWallToStore Height=NaN: NO THROW.
  IfcExtrudedAreaSolid attributes = ["#57","#59","#60","NaN"]
  Profile attributes              = [".AREA.",null,"#56",5,0.2]

addWallToStore Thickness=Infinity: NO THROW.
  IfcExtrudedAreaSolid attributes = ["#57","#59","#60",3]
  Profile attributes              = [".AREA.",null,"#56",5,"Infinity"]

addBeamToStore Height=NaN: NO THROW.
  IfcExtrudedAreaSolid attributes = ["#58","#60","#61",5]
  Profile attributes              = [".AREA.",null,"#57",0.3,"NaN"]

addBeamToStore Width=Infinity: NO THROW.
  IfcExtrudedAreaSolid attributes = ["#58","#60","#61",5]
  Profile attributes              = [".AREA.",null,"#57","Infinity",0.3]
```

After the fix, all four throw `Error('add<Type>ToStore: <fields> must be positive')` instead.

## Builder inventory

| Builder | Guard before | Guard after |
|---|---|---|
| `column.ts:71-75` | `Number.isFinite` (already correct — #592) | unchanged (now via shared helper) |
| `beam.ts:82` | bare `<= 0` | fixed |
| `door.ts:92,95` (incl. `FrameThickness`) | bare `<= 0` | fixed |
| `window.ts:75,78` (incl. `FrameThickness`) | bare `<= 0` | fixed |
| `member.ts:78` | bare `<= 0` | fixed |
| `wall.ts:59` | bare `<= 0` | fixed |
| `plate.ts:70,73` | bare `<= 0` | fixed |
| `roof.ts:70,73` | bare `<= 0` | fixed |
| `space.ts:138,141` | bare `<= 0` | fixed |
| `slab.ts:125,128` | bare `<= 0` | fixed |
| `spatial-zone.ts:130-149` | `Number.isFinite` (already correct) | unchanged |

`door.ts`/`window.ts`'s `FrameThickness` checks weren't in the original
report but have the identical bug shape, so they're fixed too.

Also audited (not fixed, out of scope): `beam.ts`/`member.ts`'s
`beamLen`/`memberLen <= 0` and `wall.ts`'s `wallLen <= 0` "distinct points"
checks have the same `<= 0`-vs-`NaN` gap if `Start`/`End` coordinates are
non-finite — that's a coordinate check, not a dimension-param check per
`column.ts`'s docstring, so it's flagged rather than changed here.
`generate-spaces.ts:120`'s `height <= 0` is a pre-check ahead of a call into
the now-fixed `addSpaceToStore`, so it's already covered transitively.
`packages/create/src/ifc-creator.ts` (the separate from-scratch builder
class, e.g. `addIfcColumn`, `addIfcGableRoof`, `addIfcWallDoor`) has the
same bare-`<= 0` shape and, in `addIfcColumn`'s case, no dimension guard at
all — but it's outside `packages/create/src/in-store/`, the directory this
defect report scoped to, so it's flagged rather than fixed here.

## Why extraction, not copy-paste

Nine copies of the same check is what produced this gap — one got fixed,
eight did not. `assertPositiveFinite(values, message)` now lives once in
`_emit-helpers.ts` and every builder (including `column.ts` itself) calls
it, so a future fix — or a tenth builder — can't land in only one place
again.

## Dependency check

Searched every call site of the nine builders (`packages/cli/src/headless-backend.ts`,
`apps/viewer/src/sdk/adapters/store-adapter.ts`,
`apps/viewer/src/store/slices/mutationSlice.ts`). None catch-and-ignore;
the viewer's `mutationSlice.ts` already wraps every builder call (including
`addColumnToStore`, which has thrown on invalid dimensions since #592) in a
try/catch that surfaces `{ error: message }` to the UI. Nothing relies on
the previous permissiveness — the throw always propagates or turns into a
proper user-facing error instead of silently writing invalid IFC.

## Test plan

- [x] New `packages/create/src/in-store/dimension-validation.test.ts`:
      parametrised across all 10 builders × their dimension fields, asserts
      `NaN`/`Infinity`/`-Infinity` all throw and pins the pre-existing
      `0`/`-1` behaviour.
- [x] Full `packages/create` suite (excluding `guid-determinism.test.ts`,
      which needs `@ifc-lite/wasm` and can't run in this environment):
      **before** 18 test files / 135 tests, all passing; **after** 19 test
      files / 280 tests, all passing.
- [x] `packages/export` suite: 51/54 files pass, 722/752 tests pass (1
      unrelated file fails on the same missing-`@ifc-lite/wasm` environment
      limitation — not a regression from this change).
- [x] `pnpm exec tsc --noEmit` in `packages/create`: clean.
- [x] `pnpm run typecheck` (test-file typecheck scope) in `packages/create`: clean.
- [x] `oxlint` over `packages/create/src/in-store`: only 3 pre-existing
      warnings in files this PR doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In-store element builders now reject `NaN` and infinite dimensions instead of generating invalid IFC output.
  * Zero and negative dimensions continue to be rejected across beams, columns, doors, members, plates, roofs, slabs, spaces, walls, and windows.

* **Tests**
  * Added comprehensive validation coverage for valid, zero, negative, and non-finite dimension values across all supported builders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->