### PR TITLE
fix(viewer): federated GLB/IFCX/point-cloud add no longer TDZ-crashes into loadState error

### DIFF
--- a/.changeset/federated-glb-instanced-shards-tdz.md
+++ b/.changeset/federated-glb-instanced-shards-tdz.md
@@ -1,0 +1,20 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix a federated GLB/IFCX/point-cloud add being marked `loadState: 'error'` after it had already loaded successfully.
+
+`useIfcLoader`'s shared `finalizeModel` closure read a `const allInstancedShards`
+that is declared ~800 lines further down the same `loadFile` function, inside
+the WASM-streaming section. GLB, IFCX, and point-cloud federated adds call
+`finalizeModel` before that section ever runs, so the read landed in the
+binding's temporal dead zone and threw `ReferenceError: Cannot access
+'allInstancedShards' before initialization` — *after* `addModel` had already
+registered the model with its correctly parsed geometry. The surrounding
+catch then wrote `loadState: 'error'` onto the now-live model, so a user
+federating one of these formats saw a failed model that had, in fact, loaded.
+
+`finalizeModel` now takes the GPU-instancing shard bytes as an explicit
+parameter (default `[]`), forwarded by the WASM streaming path once it has
+populated them. GLB/IFCX/point-cloud loads have no instancing concept, so an
+empty array is the correct value on their path, not a placeholder.

--- a/apps/viewer/src/hooks/useIfcLoader.federatedInstancedShardsTdz.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.federatedInstancedShardsTdz.test.tsx
@@ -1,0 +1,208 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A federated GLB/IFCX/point-cloud add threw a TDZ `ReferenceError` on
+ * `allInstancedShards` (found while writing PR #2768, which pins the
+ * federated id-offset write side but deliberately did not fix this).
+ *
+ * `finalizeModel` (the one finalizer shared by every format/target, added by
+ * the loadFile unification) reads `allInstancedShards` at its federated
+ * branch to forward GPU-instancing shard bytes (#1912). That variable is
+ * declared with `const` ~800 lines further down `loadFile`, inside the
+ * WASM-streaming section — a section GLB, IFCX, and point-cloud loads never
+ * reach. `finalizeModel` is called for those formats BEFORE that `const`
+ * executes, so the read lands in the binding's temporal dead zone and
+ * throws — after `addModel` already registered the model with its real,
+ * correctly-loaded geometry. The catch around the format branch then
+ * marks the (already-live) model `loadState: 'error'`, so a user federating
+ * a GLB sees a failed model that in fact loaded.
+ *
+ * This drives the real `useIfcLoader` hook (not a source-text scan) with a
+ * hand-built, minimal-but-valid GLB — the workable fixture per this repo's
+ * WASM-in-test constraint (`happy-dom` defines `window`, which defeats the
+ * Node `fs`-fallback in `IfcLiteBridge.init()`, so the WASM engine cannot
+ * init under this harness). GLB/IFCX/point-cloud parse WITHOUT the WASM
+ * engine, which is exactly why they are reachable here and exactly why they
+ * are the formats the bug report names.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import { useIfcLoader } from './useIfcLoader.js';
+
+/**
+ * Minimal valid GLB (binary glTF), one triangle, one unlit material.
+ * Adapted from `packages/cache/src/glb.test.ts`'s `buildGLB` (same shape
+ * `GLTFExporter` produces) — kept single-triangle since this test only
+ * needs `detectFormat` to route to the GLB branch and `loadGLBToMeshData`
+ * to hand back at least one mesh.
+ */
+function buildMinimalGLB(): Uint8Array<ArrayBuffer> {
+  const verts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const norms = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const idx = new Uint32Array([0, 1, 2]);
+
+  const posBytes = new Uint8Array(verts.buffer);
+  const normBytes = new Uint8Array(norms.buffer);
+  const idxBytes = new Uint8Array(idx.buffer);
+
+  const json = {
+    asset: { version: '2.0', generator: 'test' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0, extras: { expressId: 100 } }],
+    meshes: [
+      {
+        primitives: [
+          { attributes: { POSITION: 0, NORMAL: 1 }, indices: 2, material: 0 },
+        ],
+      },
+    ],
+    materials: [
+      {
+        pbrMetallicRoughness: { baseColorFactor: [0.8, 0.2, 0.2, 1.0], metallicFactor: 0, roughnessFactor: 1 },
+        extensions: { KHR_materials_unlit: {} },
+      },
+    ],
+    accessors: [
+      { bufferView: 0, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] },
+      { bufferView: 1, byteOffset: 0, componentType: 5126, count: 3, type: 'VEC3' },
+      { bufferView: 2, byteOffset: 0, componentType: 5125, count: 3, type: 'SCALAR' },
+    ],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength, byteLength: normBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength + normBytes.byteLength, byteLength: idxBytes.byteLength, target: 34963 },
+    ],
+    buffers: [{ byteLength: posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength }],
+  };
+
+  const jsonStr = JSON.stringify(json);
+  const jsonBuf = new TextEncoder().encode(jsonStr);
+  const jsonPad = (4 - (jsonBuf.byteLength % 4)) % 4;
+  const jsonChunkLen = jsonBuf.byteLength + jsonPad;
+
+  const binLen = posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength;
+  const binPad = (4 - (binLen % 4)) % 4;
+  const binChunkLen = binLen + binPad;
+
+  const total = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, 0x46546c67, true); // glTF
+  dv.setUint32(4, 2, true);
+  dv.setUint32(8, total, true);
+  dv.setUint32(12, jsonChunkLen, true);
+  dv.setUint32(16, 0x4e4f534a, true); // JSON
+  out.set(jsonBuf, 20);
+  for (let i = 0; i < jsonPad; i++) out[20 + jsonBuf.byteLength + i] = 0x20;
+
+  let off = 20 + jsonChunkLen;
+  dv.setUint32(off, binChunkLen, true);
+  dv.setUint32(off + 4, 0x004e4942, true); // BIN
+  off += 8;
+  out.set(posBytes, off);
+  off += posBytes.byteLength;
+  out.set(normBytes, off);
+  off += normBytes.byteLength;
+  out.set(idxBytes, off);
+
+  return out;
+}
+
+// ─── Harness: the real hook, rendered ────────────────────────────────────
+
+let hookApi: ReturnType<typeof useIfcLoader> | null = null;
+
+function Probe(): null {
+  hookApi = useIfcLoader();
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(async () => {
+  hookApi = null;
+  useViewerStore.getState().resetViewerState();
+  useViewerStore.getState().clearAllModels();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(hookApi, 'the hook must expose loadFile');
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe('useIfcLoader — federated GLB add must not hit the allInstancedShards TDZ', () => {
+  it('finishes with the model live (not loadState "error") and its meshes present', async () => {
+    // A primary model must already be resident: `finalizeModel`'s federated
+    // branch (the one that reads the TDZ'd variable) only runs for
+    // `target.kind === 'federated'`, and a federated add is only meaningful
+    // once model #1 exists.
+    const primaryBytes = buildMinimalGLB();
+    const primaryFile = new File([primaryBytes], 'primary.glb');
+    await act(async () => {
+      await hookApi!.loadFile(primaryFile);
+    });
+    const afterPrimary = useViewerStore.getState();
+    assert.equal(afterPrimary.models.size, 1, 'primary GLB load must register exactly one model');
+    const primaryId = [...afterPrimary.models.keys()][0];
+    assert.notEqual(
+      afterPrimary.models.get(primaryId)?.loadState,
+      'error',
+      'the primary GLB load itself must not error',
+    );
+
+    const federatedBytes = buildMinimalGLB();
+    const federatedFile = new File([federatedBytes], 'federated.glb');
+    const modelId = crypto.randomUUID();
+
+    let caught: unknown = null;
+    await act(async () => {
+      try {
+        await hookApi!.loadFile(federatedFile, { kind: 'federated', modelId, name: 'federated.glb' });
+      } catch (err) {
+        caught = err;
+      }
+    });
+
+    // `loadFile` catches its own errors internally (it never rethrows to the
+    // caller) — the TDZ `ReferenceError` is swallowed by the format branch's
+    // own try/catch and surfaces as a store-level error state instead. This
+    // assertion exists so a future refactor that DOES let it escape fails
+    // loudly here with the real error, rather than only via the loadState
+    // assertion below.
+    assert.equal(caught, null, `loadFile must not throw; got: ${String(caught)}`);
+
+    const after = useViewerStore.getState();
+    const federated = after.models.get(modelId);
+    assert.ok(federated, 'the federated model must be registered in the store (addModel ran before the crash)');
+    assert.notEqual(
+      federated!.loadState,
+      'error',
+      'a federated GLB add that parsed and registered successfully must not be left in loadState "error" '
+      + '(the allInstancedShards TDZ ReferenceError fires AFTER addModel succeeds, in useIfcLoader.ts)',
+    );
+    assert.ok(
+      federated!.geometryResult && federated!.geometryResult.meshes.length > 0,
+      'the federated model must carry its parsed meshes',
+    );
+    assert.equal(after.models.size, 2, 'both the primary and federated models must be present');
+  });
+});

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -493,6 +493,14 @@ export function useIfcLoader() {
         geometryResult: GeometryResult | null,
         schemaVersion: 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5',
         patch?: { loadState?: 'pending' | 'streaming-geometry' | 'hydrating-metadata' | 'complete' | 'error'; cacheState?: 'none' | 'hit' | 'miss' | 'writing'; loadError?: string | null; pointCloudHandleId?: number },
+        // GPU-instancing shard bytes (#1912), forwarded explicitly rather than
+        // closed over: the WASM streaming section's `allInstancedShards` is
+        // declared ~800 lines below this closure, so a plain closure read would
+        // hit its TDZ on every non-WASM format (GLB/IFCX/point-cloud), whose
+        // finalizeModel calls all happen before that declaration executes.
+        // Those formats have no instancing concept, so the correct value on
+        // their path is simply "none" — the default below.
+        instancedShards: ArrayBuffer[] = [],
       ): Promise<void> => {
         // Ordering notice (issue #1804): alignment is baked into a scan at
         // ITS load time (an f64 decode-time offset — it cannot be applied
@@ -629,8 +637,8 @@ export function useIfcLoader() {
           // renderer-side modelId → modelIndex / idOffset lookups
           // (Viewport.tsx's `modelIdToIndex` / `modelIdToOffset`) already see
           // this model when the drain effect runs.
-          if (allInstancedShards.length > 0) {
-            appendInstancedShards(modelId, allInstancedShards);
+          if (instancedShards.length > 0) {
+            appendInstancedShards(modelId, instancedShards);
           }
           return;
         }
@@ -1882,7 +1890,7 @@ export function useIfcLoader() {
                   };
                   await finalizeModel(dataStore, federatedGeometry, getSchemaVersion(dataStore), {
                     loadState: 'complete',
-                  });
+                  }, allInstancedShards);
                   return;
                 }
 
@@ -1891,7 +1899,7 @@ export function useIfcLoader() {
                   // Only show "writing" when this file will actually be cached
                   // under the current plan (respects the size bands + kill switch).
                   cacheState: cachePlan.shouldCache ? 'writing' : 'none',
-                });
+                }, allInstancedShards);
                 // Build spatial index from meshes in time-sliced chunks (non-blocking).
                 // Previously this was synchronous inside requestIdleCallback, blocking
                 // the main thread for seconds on 200K+ mesh models (190M+ float reads


### PR DESCRIPTION
## Summary

Found while writing #2768 (federated id-offset test coverage) — that PR is test-only and deliberately did not fix this.

**Reproduction.** A federated add of a GLB, IFCX, or point-cloud file threw a live `ReferenceError` on every run:

```
ReferenceError: Cannot access 'allInstancedShards' before initialization
    at finalizeModel (useIfcLoader.ts:632)
    at Object.loadFile (useIfcLoader.ts:965)
```

The throw fires *after* `addModel` has already registered the model with its correctly parsed geometry, so the surrounding `catch` then calls `updateModel(modelId, { loadState: 'error', ... })` on a model that had, in fact, loaded successfully. A user federating a GLB saw a failed model that actually loaded.

**Root cause.** `useIfcLoader.ts`'s single `finalizeModel` closure (shared by every format/target) reads `allInstancedShards` in its federated branch to forward GPU-instancing shard bytes (#1912). That variable is `const`-declared ~800 lines further down `loadFile`, inside the WASM-streaming section — a section GLB, IFCX, and point-cloud loads never reach. `finalizeModel` is invoked for those formats (`useIfcLoader.ts:904`, `927`, `965`) *before* that section's declarations run, so the read lands squarely in the binding's temporal dead zone.

**Why this fix and not just hoisting the `const`.** GLB/IFCX/point-cloud have no instancing concept at all — there's nothing to forward on their path, so the correct value there is an empty collection, not a hoisted (and still WASM-only-meaningful) variable. `finalizeModel` now takes the shard bytes as an explicit parameter, defaulting to `[]`; the two WASM-path call sites (post-declaration, `useIfcLoader.ts:1891`/`1899`) pass the real `allInstancedShards` explicitly. This keeps the WASM-only concept out of the shared finalizer's implicit closure entirely, so a future refactor of the streaming section can't reintroduce the same TDZ shape.

**Same-shape sweep.** Grepped every top-of-`loadFile`-scope `const`/`let` against identifiers referenced inside earlier-defined closures in this 2165-line function (`finalizeModel`, `onPartialDataStore`, `onFullDataStore`, `startDataModelParsing`, `markFirstVisibleGeometry`, `getSchemaVersion`, `runMainThreadParser`). `allInstancedShards` was the only real hazard — every other candidate the sweep flagged was either a property access (`target.kind`, false positive on a bare-name regex) or a `let` whose only earlier-defined consumer is a callback that cannot fire before the declaration executes (no `await` sits between the `setTimeout(fn, 0)` that schedules it and the declaration block — all synchronous in the same tick).

**Formats covered.** GLB is covered by a real, hook-driven RED/GREEN test (see below). IFCX and point-cloud reach the exact same `finalizeModel` call path (`useIfcLoader.ts:927`, `904`) with the identical signature change — traced but not independently fixture-tested (the `.ifcx` fixture isn't present in this environment, and per-repo convention fixtures are fetched on demand / tests skip cleanly when absent).

## Test plan

- [x] New test `useIfcLoader.federatedInstancedShardsTdz.test.tsx`: drives the real `useIfcLoader` hook with a hand-built minimal GLB (no WASM needed — GLB/IFCX/point-cloud parse without the engine, which is why they're reachable in this harness and exactly why they're the affected formats). Loads a primary model, then federates a second GLB, and asserts `loadFile` doesn't throw, the federated model is *not* `loadState: 'error'`, and its meshes are present.
- [x] Verified RED against the pre-fix code (reverted the fix in a scratch copy, reran): reproduces the exact `ReferenceError: Cannot access 'allInstancedShards' before initialization` at `useIfcLoader.ts:632`, with the model left in `loadState: 'error'` — then restored the fix and reran GREEN.
- [x] `useIfcLoader.*.test.tsx` + `useIfcFederation.*.test.tsx`: 6 files → 7 tests, all passing (5 pre-existing files/6 tests + 1 new file/1 test).
- [x] `pnpm typecheck` — clean (1204/1204 test files wired, 0 errors).
- [x] `node scripts/check-unused-locals.mjs` — no new unused locals.
- [x] `oxlint` on the touched files — only two pre-existing unrelated warnings (unused `flushSync`/`getViewerStoreApi` imports, untouched by this change).
- [x] Changeset added (`@ifc-lite/viewer` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)