### PR TITLE
test(drawing-2d): cover the straddling-void split in OpeningFilter

### DIFF
--- a/packages/drawing-2d/src/openings/opening-filter.test.ts
+++ b/packages/drawing-2d/src/openings/opening-filter.test.ts
@@ -65,3 +65,72 @@ describe('OpeningFilter.filterSegment (void removal)', () => {
     expect(result).toEqual([segment]);
   });
 });
+
+describe('OpeningFilter.filterSegment (straddling void — splitSegmentAtOpening)', () => {
+  // Void bounds are the axis-aligned [0,0]-[4,4] box from makeRelationships().
+  // Every wall segment below is diagonal (dx !== dy, neither dx nor dy is 0)
+  // so that a swapped x/y axis inside the split logic would show up as a
+  // wrong coordinate, not just a wrong count.
+
+  it('starts outside, ends inside the void: keeps only the outside part, cut exactly at the boundary', () => {
+    const filter = new OpeningFilter(makeRelationships());
+    filter.projectOpenings({ axis: 'z', position: 0, flipped: false });
+
+    // p0=(-2,1) outside (x<0); p1=(2,2) inside the void.
+    // Line: x = -2 + 4t, y = 1 + t. Crosses the left edge x=0 at t=0.5 -> (0, 1.5).
+    const segment = makeSegment({ x: -2, y: 1 }, { x: 2, y: 2 });
+    const result = filter.filterSegmentsForHost([segment], HOST_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].p0_2d).toEqual({ x: -2, y: 1 });
+    expect(result[0].p1_2d).toEqual({ x: 0, y: 1.5 });
+  });
+
+  it('starts inside, ends outside the void (mirror case): keeps only the outside part, cut at the opposite edge', () => {
+    const filter = new OpeningFilter(makeRelationships());
+    filter.projectOpenings({ axis: 'z', position: 0, flipped: false });
+
+    // p0=(2,2) inside the void; p1=(6,3) outside (x>4).
+    // Line: x = 2 + 4t, y = 2 + t. Crosses the right edge x=4 at t=0.5 -> (4, 2.5).
+    const segment = makeSegment({ x: 2, y: 2 }, { x: 6, y: 3 });
+    const result = filter.filterSegmentsForHost([segment], HOST_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].p0_2d).toEqual({ x: 4, y: 2.5 });
+    expect(result[0].p1_2d).toEqual({ x: 6, y: 3 });
+  });
+
+  it('spans the whole void (starts and ends outside): keeps both outside parts with correct endpoints', () => {
+    const filter = new OpeningFilter(makeRelationships());
+    filter.projectOpenings({ axis: 'z', position: 0, flipped: false });
+
+    // p0=(-2,1) outside (x<0); p1=(6,3) outside (x>4).
+    // Line: x = -2 + 8t, y = 1 + 2t.
+    // Crosses left edge x=0 at t=0.25 -> (0, 1.5); crosses right edge x=4 at t=0.75 -> (4, 2.5).
+    const segment = makeSegment({ x: -2, y: 1 }, { x: 6, y: 3 });
+    const result = filter.filterSegmentsForHost([segment], HOST_ID);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].p0_2d).toEqual({ x: -2, y: 1 });
+    expect(result[0].p1_2d).toEqual({ x: 0, y: 1.5 });
+    expect(result[1].p0_2d).toEqual({ x: 4, y: 2.5 });
+    expect(result[1].p1_2d).toEqual({ x: 6, y: 3 });
+  });
+
+  it('starts exactly flush with a void edge: the boundary point counts as inside, so only the exterior tail survives', () => {
+    const filter = new OpeningFilter(makeRelationships());
+    filter.projectOpenings({ axis: 'z', position: 0, flipped: false });
+
+    // p0=(0,1) sits exactly on the void's left edge (x=0); p1=(8,5) is well outside (x>4).
+    // Line: x = 8t, y = 1 + 4t. Crosses the right edge x=4 at t=0.5 -> (4, 3).
+    // pointInBounds treats x=0 as inside (inclusive boundary), so the piece from
+    // p0 to the right-edge crossing lies inside the void and must be dropped;
+    // only the tail from (4,3) to p1 survives.
+    const segment = makeSegment({ x: 0, y: 1 }, { x: 8, y: 5 });
+    const result = filter.filterSegmentsForHost([segment], HOST_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].p0_2d).toEqual({ x: 4, y: 3 });
+    expect(result[0].p1_2d).toEqual({ x: 8, y: 5 });
+  });
+});


### PR DESCRIPTION
## Summary

`packages/drawing-2d/src/openings/opening-filter.ts`, `splitSegmentAtOpening` splits a wall cut segment that **partially overlaps** a door/window void — the ordinary case for any real wall crossing a doorway. It had no test: `opening-filter.test.ts` only covered "segment fully inside void" and "segment fully outside void".

**Mutation that used to pass:** replacing the body of `splitSegmentAtOpening` with `return [];` (silently dropping every straddling segment) left the full `packages/drawing-2d` suite at 361/361 passing.

## What each new case pins

Void bounds are the axis-aligned `[0,0]-[4,4]` box already used by the existing fixture. All new wall segments are **diagonal** (`dx !== dy`, neither `dx` nor `dy` is 0) so a swapped x/y axis inside the split logic would surface as a wrong coordinate, not just a wrong count. Expected coordinates were derived by hand from the line/box geometry, not by running the function first.

- **Starts outside, ends inside** — one surviving part, cut exactly at the void's left edge.
- **Starts inside, ends outside (mirror)** — one surviving part, cut at the opposite (right) edge — catches a sign/index error the first case alone would miss.
- **Spans the whole void** (starts and ends outside) — two surviving parts; both endpoints of each part are asserted, not just the count.
- **Starts exactly flush with a void edge** — the boundary point is inclusive (`pointInBounds` treats an edge-touching point as inside), so the initial piece from the flush start into the void is correctly dropped and only the exterior tail survives. This pins the inclusive/exclusive boundary behavior.

## RED / GREEN

- **GREEN:** all 4 new tests pass against the unmodified implementation. `packages/drawing-2d` suite: 365 passed (361 baseline + 4 new), 32 files.
- **RED (mutation 1 — `return []`):** all 4 new tests fail; the original 361 stay green.
- **RED (mutation 2 — subtler):** swapped which side of the split is kept (inverted the `!pointInBounds(...)` check in both branches of `splitSegmentAtOpening`, so the inside piece is kept instead of the outside piece). All 4 new tests fail again; the original 361 stay green.
- Both mutations were reverted before pushing; the diff is test-only.

## Test plan

- [x] `pnpm test` in `packages/drawing-2d`: 365/365 passing
- [x] `pnpm typecheck` (root, turbo): all packages OK
- [x] `pnpm lint` (root): 0 errors (21 pre-existing warnings, unrelated files)
- [x] Confirmed RED under both mutations described above, then reverted

No changeset — test-only change.