### PR TITLE
fix(drawing-2d): make door swing arc agree with the leaf's swingDir

### DIFF
--- a/.changeset/door-swing-arc-matches-leaf.md
+++ b/.changeset/door-swing-arc-matches-leaf.md
@@ -1,0 +1,20 @@
+---
+'@ifc-lite/drawing-2d': patch
+---
+
+Fix door swing arc opening into the opposite room from the drawn leaf.
+
+`DoorSymbolGenerator`'s swing arc was derived purely from `wallDir` plus a
+hardcoded `direction > 0 ? Math.PI : 0` sign, ignoring the `swingDir`
+parameter entirely. The door leaf line, meanwhile, correctly used `swingDir`
+for its open-position tip. Since the arc traces the path of that same tip as
+it swings from closed to open, the two are required to end at the same
+point — instead the arc swept to the wall side opposite the leaf, so a
+door's swing arc and its leaf pointed into different rooms in every
+generated drawing.
+
+`generateArc` and `generateArcSVGPath` now derive both the arc's start and
+end angle from `swingDir` (sweeping back by the swing angle in the
+hinge-side's rotational sense), so the arc always terminates exactly at the
+leaf's open tip, for all four swing types (`SINGLE_SWING_LEFT/RIGHT`,
+`DOUBLE_SWING_LEFT/RIGHT`).

--- a/packages/drawing-2d/src/symbols/door-symbol.test.ts
+++ b/packages/drawing-2d/src/symbols/door-symbol.test.ts
@@ -26,3 +26,79 @@ describe('DoorSymbolGenerator.generateSymbol (single swing)', () => {
     expect(params.hingePoint.x).toBeGreaterThan(center.x);
   });
 });
+
+describe('DoorSymbolGenerator: swing arc must agree with the leaf line', () => {
+  // A door symbol's swing arc traces the path of the leaf's free (non-hinge) tip as it
+  // rotates from closed (flat against the wall) to open. Therefore the arc MUST end exactly
+  // where the leaf line ends — anything else means the drawing shows the leaf swinging into
+  // a different room than the arc.
+  //
+  // wallDir and swingDir are deliberately non-axis-aligned, and each has two non-zero
+  // components, so a swapped x/y basis (or a sign flip on only one axis) cannot hide behind
+  // a coincidental zero component the way an axis-aligned fixture would.
+  const generator = new DoorSymbolGenerator();
+  const center = { x: 10, y: 5 };
+  const width = 2;
+  const halfWidth = width / 2;
+  // wallDir is a unit vector along (3, 4); swingDir is wallDir rotated +90 degrees (CCW),
+  // matching DoorSymbolGenerator.getPerpendicularDirection / generateFromOpening's convention.
+  const wallDir = { x: 0.6, y: 0.8 };
+  const swingDir = { x: -0.8, y: 0.6 };
+
+  function expectPointCloseTo(actual: { x: number; y: number }, expected: { x: number; y: number }) {
+    expect(actual.x).toBeCloseTo(expected.x, 9);
+    expect(actual.y).toBeCloseTo(expected.y, 9);
+  }
+
+  it.each([
+    ['SINGLE_SWING_LEFT', 'left'],
+    ['SINGLE_SWING_RIGHT', 'right'],
+    ['DOUBLE_SWING_LEFT', 'left'],
+    ['DOUBLE_SWING_RIGHT', 'right'],
+  ] as const)('%s: arc end and leaf tip coincide, arc start is the opposite jamb', (operation, hingeSide) => {
+    const result = generator.generateSymbol(center, width, operation, wallDir, swingDir);
+
+    const hingeOffset = hingeSide === 'left' ? -halfWidth : halfWidth;
+    const expectedHinge = {
+      x: center.x + wallDir.x * hingeOffset,
+      y: center.y + wallDir.y * hingeOffset,
+    };
+    const expectedLeafEnd = {
+      x: expectedHinge.x + swingDir.x * width,
+      y: expectedHinge.y + swingDir.y * width,
+    };
+    // Closed position: the leaf lies flat along the wall, reaching the opposite jamb.
+    const expectedArcStart = {
+      x: expectedHinge.x + wallDir.x * (hingeSide === 'left' ? width : -width),
+      y: expectedHinge.y + wallDir.y * (hingeSide === 'left' ? width : -width),
+    };
+
+    const params = result.symbol.parameters as DoorSwingParameters;
+    expectPointCloseTo(params.hingePoint, expectedHinge);
+
+    const leaf = result.lines[0];
+    expectPointCloseTo(leaf.start, expectedHinge);
+    expectPointCloseTo(leaf.end, expectedLeafEnd);
+
+    const arcSegments = generator['config'].arcSegments as number;
+    const arcFirst = result.lines[1];
+    const arcLast = result.lines[arcSegments];
+
+    expectPointCloseTo(arcFirst.start, expectedArcStart);
+    // The critical assertion: the arc's open end must coincide with the leaf's open tip.
+    expectPointCloseTo(arcLast.end, expectedLeafEnd);
+
+    // The SVG arc path must agree too: it also has to end at the leaf tip.
+    expect(result.arcPath).toBeDefined();
+    const match = result.arcPath?.match(
+      /^M\s+([\d.eE+-]+)\s+([\d.eE+-]+)\s+A\s+[\d.eE+-]+\s+[\d.eE+-]+\s+0\s+\d\s+\d\s+([\d.eE+-]+)\s+([\d.eE+-]+)$/
+    );
+    expect(match).not.toBeNull();
+    if (match) {
+      const svgStart = { x: parseFloat(match[1]), y: parseFloat(match[2]) };
+      const svgEnd = { x: parseFloat(match[3]), y: parseFloat(match[4]) };
+      expectPointCloseTo(svgStart, expectedArcStart);
+      expectPointCloseTo(svgEnd, expectedLeafEnd);
+    }
+  });
+});

--- a/packages/drawing-2d/src/symbols/door-symbol.ts
+++ b/packages/drawing-2d/src/symbols/door-symbol.ts
@@ -165,7 +165,6 @@ export class DoorSymbolGenerator {
     const arcLines = this.generateArc(
       hingePoint,
       width,
-      wallDir,
       swingDir,
       hingeSide === 'left' ? 1 : -1,
       swingAngleRad
@@ -181,7 +180,6 @@ export class DoorSymbolGenerator {
       const oppositeArcLines = this.generateArc(
         hingePoint,
         width,
-        wallDir,
         oppositeSwingDir,
         hingeSide === 'left' ? -1 : 1,
         swingAngleRad
@@ -206,7 +204,13 @@ export class DoorSymbolGenerator {
         parameters: params,
       },
       lines,
-      arcPath: this.generateArcSVGPath(hingePoint, width, wallDir, swingDir, swingAngleRad),
+      arcPath: this.generateArcSVGPath(
+        hingePoint,
+        width,
+        swingDir,
+        hingeSide === 'left' ? 1 : -1,
+        swingAngleRad
+      ),
     };
   }
 
@@ -247,7 +251,7 @@ export class DoorSymbolGenerator {
         },
       });
     }
-    lines.push(...this.generateArc(leftHinge, leafWidth, wallDir, swingDir, 1, swingAngleRad));
+    lines.push(...this.generateArc(leftHinge, leafWidth, swingDir, 1, swingAngleRad));
 
     // Right door leaf and arc
     if (this.config.showLeaf) {
@@ -259,7 +263,7 @@ export class DoorSymbolGenerator {
         },
       });
     }
-    lines.push(...this.generateArc(rightHinge, leafWidth, wallDir, swingDir, -1, swingAngleRad));
+    lines.push(...this.generateArc(rightHinge, leafWidth, swingDir, -1, swingAngleRad));
 
     const params: DoorSwingParameters = {
       width,
@@ -494,7 +498,6 @@ export class DoorSymbolGenerator {
   private generateArc(
     center: Point2D,
     radius: number,
-    wallDir: Point2D,
     swingDir: Point2D,
     direction: 1 | -1,
     angleRad: number
@@ -502,8 +505,12 @@ export class DoorSymbolGenerator {
     const lines: Line2D[] = [];
     const segments = this.config.arcSegments;
 
-    // Start angle is along wall direction (door closed)
-    const startAngle = Math.atan2(wallDir.y, wallDir.x) + (direction > 0 ? Math.PI : 0);
+    // The arc must terminate at the leaf's open-position tip (center + swingDir * radius) —
+    // that point is the door's free edge, and the leaf line is drawn from the same swingDir.
+    // Sweep backward from there by angleRad (in the same rotational sense as `direction`) to
+    // find the closed-position start angle, which lands along the wall as expected.
+    const swingAngle = Math.atan2(swingDir.y, swingDir.x);
+    const startAngle = swingAngle - direction * angleRad;
 
     for (let i = 0; i < segments; i++) {
       const t1 = i / segments;
@@ -532,12 +539,14 @@ export class DoorSymbolGenerator {
   private generateArcSVGPath(
     center: Point2D,
     radius: number,
-    wallDir: Point2D,
     swingDir: Point2D,
+    direction: 1 | -1,
     angleRad: number
   ): string {
-    const startAngle = Math.atan2(wallDir.y, wallDir.x);
-    const endAngle = startAngle + angleRad;
+    // Same convention as generateArc: the arc must end at the leaf's open tip
+    // (center + swingDir * radius), swept back by angleRad in `direction`'s sense.
+    const endAngle = Math.atan2(swingDir.y, swingDir.x);
+    const startAngle = endAngle - direction * angleRad;
 
     const startX = center.x + Math.cos(startAngle) * radius;
     const startY = center.y + Math.sin(startAngle) * radius;
@@ -545,7 +554,7 @@ export class DoorSymbolGenerator {
     const endY = center.y + Math.sin(endAngle) * radius;
 
     const largeArc = angleRad > Math.PI ? 1 : 0;
-    const sweep = 1;
+    const sweep = direction > 0 ? 1 : 0;
 
     return `M ${startX} ${startY} A ${radius} ${radius} 0 ${largeArc} ${sweep} ${endX} ${endY}`;
   }


### PR DESCRIPTION
## Summary

`DoorSymbolGenerator.generateArc` (`packages/drawing-2d/src/symbols/door-symbol.ts`) accepted a `swingDir` parameter and never read it — the arc's angles came entirely from `wallDir` plus a hardcoded `direction > 0 ? Math.PI : 0` sign. `generateArcSVGPath` had the same problem, and additionally ignored hinge side (`direction`) entirely, always sweeping the same way. The door leaf line, meanwhile, correctly used `swingDir` for its open-position tip. Since a door's swing arc is the path traced by that same leaf tip as it rotates from closed to open, the two are required to terminate at the same point — instead the arc swept toward the wall side **opposite** the leaf in every drawing.

### Which was wrong, and the evidence

The **arc** was wrong, not the leaf:
- The leaf is the thing depicting the physical door panel; its open-position endpoint is definitionally `hingePoint + swingDir * width`.
- The arc's job (per the file's own doc comment, "swing arc (quarter circle showing door travel)") is to show the sweep of that same physical tip — it has no separate reason to exist except to connect the closed position (along the wall) to that exact leaf tip.
- `swingDir` is always computed by the caller (`generateFromOpening`) as `getPerpendicularDirection(wallDir)` — a fixed 90° rotation of the wall direction — independent of hinge side, and the leaf consistently uses it.
- Only two pre-existing tests exist for this file and both assert `hingePoint.x` only; no snapshot, golden SVG, or downstream consumer encodes the old arc angles as intentional (`arcPath` isn't consumed anywhere in the codebase, `grep -rn "\.arcPath"` outside tests returns nothing).

### Measured coordinates (center=(10,0), width=2, wallDir=(1,0), swingDir=(0,1))

| Type | Leaf tip | Arc start → end (before) | Arc start → end (after) |
|---|---|---|---|
| SINGLE_SWING_LEFT | (9, 2) | (7, 0) → (9, -2) | (11, 0) → (9, 2) |
| SINGLE_SWING_RIGHT | (11, 2) | (13, 0) → (11, -2) | (9, 0) → (11, 2) |
| DOUBLE_SWING_LEFT | (9, 2) | (7, 0) → (9, -2) | (11, 0) → (9, 2) |
| DOUBLE_SWING_RIGHT | (11, 2) | (13, 0) → (11, -2) | (9, 0) → (11, 2) |

After the fix, the arc's end always coincides with the leaf tip, and the arc's start is the opposite door jamb (the closed-leaf position), for all four swing types.

### Fix

`generateArc` and `generateArcSVGPath` now derive the end angle from `atan2(swingDir)` (the leaf's open tip) and sweep backward by the swing angle in the hinge-side's rotational sense to get the start angle (closed, along the wall). `wallDir` is no longer needed for the arc's angle math and was dropped from `generateArc`'s signature; `generateArcSVGPath` gained a `direction` parameter so it also respects hinge side (previously it always swept the same way regardless of hinge side, a related bug in the unused-in-code-today `arcPath` output).

## Test plan

- [x] Reproduced the mismatch with real coordinates for all four swing types (table above) before fixing.
- [x] Added `door-symbol.test.ts` coverage asserting **both** leaf endpoints and arc start/end (line-segment and SVG-path forms) for `SINGLE_SWING_LEFT/RIGHT` and `DOUBLE_SWING_LEFT/RIGHT`, using a non-axis-aligned `wallDir = (0.6, 0.8)` / `swingDir = (-0.8, 0.6)` fixture (both components non-zero on both vectors) so a swapped basis can't hide behind a coincidental zero.
- [x] Confirmed the new tests fail (RED) against the pre-fix code (4/6 fail on the arc/leaf mismatch), then pass (GREEN) after the fix.
- [x] Full `packages/drawing-2d` suite: 361 → 365 passed (32 files, unchanged), before and after.
- [x] `pnpm typecheck` (root, turbo): 1203/1203 test files in program, all packages pass.
- [x] `pnpm lint`: 0 errors (21 pre-existing warnings, unrelated to this change).
- [x] Changeset added (`@ifc-lite/drawing-2d` patch).

### Follow-up (not fixed here, separate change)

`splitSegmentAtOpening` (`packages/drawing-2d/src/openings/opening-filter.ts:132-165`) has zero test coverage — I verified that making it `return []` unconditionally (dropping every wall segment that straddles a door or window opening) still leaves the full `drawing-2d` suite green (365/365). Worth a dedicated PR with coverage before anyone touches that function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)