### PR TITLE
test(drawing-2d): pin OpeningFilter's first-match-only multi-void contract

### DIFF
--- a/packages/drawing-2d/src/openings/opening-filter.test.ts
+++ b/packages/drawing-2d/src/openings/opening-filter.test.ts
@@ -64,4 +64,76 @@ describe('OpeningFilter.filterSegment (void removal)', () => {
 
     expect(result).toEqual([segment]);
   });
+
+  it('KNOWN LIMITATION: a segment crossing two disjoint openings is only clipped against the first match', () => {
+    // `filterSegment` (opening-filter.ts) `return`s as soon as the *first*
+    // opening bounds produce a crossing intersection, instead of folding the
+    // result through every opening in the list. A wall crossing two separate
+    // voids (e.g. a door and a window) is therefore only cut against
+    // whichever opening comes first in `voidedBy`, and any further opening
+    // the same segment crosses is left un-clipped.
+    //
+    // This is currently DEAD CODE from the drawing generator's point of
+    // view: `OpeningFilter`/`filterSegmentsForHost` is exported from the
+    // package's public API (src/index.ts) but is not called anywhere in
+    // `drawing-generator.ts` or elsewhere in this repo (verified by
+    // repo-wide grep) — opening voids are cut out of the mesh at the 3D
+    // boolean-geometry stage before 2D projection, not via this class. So
+    // no user-visible bug exists in ifc-lite's own drawings today; this
+    // pins the *current* (buggy) contract of the public function so a
+    // future change to the loop is caught deliberately rather than by
+    // accident, and so any external consumer of this exported API is aware
+    // of the limitation.
+    const doorId = 30;
+    const windowId = 31;
+    const door: OpeningInfo = {
+      type: 'opening',
+      openingId: doorId,
+      hostElementId: HOST_ID,
+      width: 1,
+      height: 200,
+      bounds3D: { min: { x: 1, y: -100, z: 0 }, max: { x: 2, y: 100, z: 1 } },
+      modelIndex: 0,
+    };
+    const window: OpeningInfo = {
+      type: 'opening',
+      openingId: windowId,
+      hostElementId: HOST_ID,
+      width: 1,
+      height: 200,
+      bounds3D: { min: { x: 6, y: -100, z: 0 }, max: { x: 7, y: 100, z: 1 } },
+      modelIndex: 0,
+    };
+    const relationships: OpeningRelationships = {
+      voidedBy: new Map([[HOST_ID, [doorId, windowId]]]),
+      filledBy: new Map(),
+      openingInfo: new Map([[doorId, door], [windowId, window]]),
+    };
+
+    const filter = new OpeningFilter(relationships);
+    filter.projectOpenings({ axis: 'z', position: 0, flipped: false });
+
+    // Non-axis-aligned wall: (0,0) -> (10,5), slope 0.5. It crosses the door
+    // void (x in [1,2]) at t in [0.1, 0.2] -> points (1,0.5)-(2,1), and the
+    // window void (x in [6,7]) at t in [0.6, 0.7] -> points (6,3)-(7,3.5).
+    // Correct filtering (hand-derived, NOT what the function returns) would
+    // produce three pieces:
+    //   (0,0)-(1,0.5), (2,1)-(6,3), (7,3.5)-(10,5)
+    const segment = makeSegment({ x: 0, y: 0 }, { x: 10, y: 5 });
+    const result = filter.filterSegmentsForHost([segment], HOST_ID);
+
+    // Pinned CURRENT (buggy) behavior: only the door (first match) is
+    // clipped; the window is left un-cut, so the second piece runs straight
+    // through the window void from (2,1) all the way to (10,5).
+    expect(result).toEqual([
+      expect.objectContaining({
+        p0_2d: { x: 0, y: 0 },
+        p1_2d: { x: 1, y: 0.5 },
+      }),
+      expect.objectContaining({
+        p0_2d: { x: 2, y: 1 },
+        p1_2d: { x: 10, y: 5 },
+      }),
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

While pinning `splitSegmentAtOpening`, it was suspected that its caller — `filterSegment` in `packages/drawing-2d/src/openings/opening-filter.ts` — splits a wall segment against only the *first* opening whose bounds produce a crossing, instead of folding the split through every opening the segment crosses. This PR settles that with a reproduction and a pinning test.

**Verdict: the defect is real in the function, but it is currently latent — dead code, not a live bug.**

### The loop (opening-filter.ts:122-130)

```ts
// Check if segment crosses any opening
for (const bounds of openingBounds) {
  const intersections = this.segmentBoundsIntersections(p0_2d, p1_2d, bounds);

  if (intersections.length > 0) {
    // Segment crosses opening boundary - split it
    return this.splitSegmentAtOpening(segment, bounds, intersections);
  }
}
```

It `return`s on the first opening with a crossing; later openings in `openingBounds` are never checked, and the split pieces from the first opening are never re-checked against the rest.

### Reproduction (real call, not inferred)

Non-axis-aligned wall `(0,0)->(10,5)` (slope 0.5) crossing two disjoint voids: a "door" at `x∈[1,2]` and a "window" at `x∈[6,7]` (both full-height strips), registered on the same host in that order.

Hand-derived correct filtering (independent of the function): the wall should be cut into three pieces —
`(0,0)-(1,0.5)`, `(2,1)-(6,3)`, `(7,3.5)-(10,5)`.

Actual returned segments from `filterSegmentsForHost`:
```
[ { p0: (0,0),  p1: (1,0.5) },
  { p0: (2,1),  p1: (10,5) } ]
```
The second piece runs straight through the window void at `(6,3)-(7,3.5)` — the window is silently ignored, confirming the defect.

### Blast radius: latent, not live

`OpeningFilter` / `filterSegmentsForHost` is exported from the package's public API (`src/index.ts`) but a repo-wide grep shows it is **not called anywhere** in `drawing-generator.ts` or elsewhere in this repo, only from its own test file. Opening voids are cut out of the wall mesh at the 3D boolean-geometry stage before 2D projection (see the `drawing-generator.ts` STAGE 4 comments on feature-element/opening meshes), not through this 2D-bounds class. So **no user-visible bug exists in ifc-lite's own drawings today** — this code path is currently unreachable from generation.

## What this PR does

Adds a test pinning the *current* (buggy) first-match-only contract with the hand-derived fixture above, so:
- a future change to the loop is caught deliberately, not by accident
- external consumers of the exported `OpeningFilter` API are made aware of the limitation via the test's documentation

No behavior change, so no changeset.

Ref #2771 (overlaps `opening-filter.test.ts`; not incorporating it here, just noting the overlap for the maintainer).

## Test plan
- [x] `packages/drawing-2d` full suite: 361 -> 362 (baseline + 1 new test), all passing
- [x] `pnpm --filter @ifc-lite/drawing-2d typecheck` (test-file scope) — OK
- [x] `pnpm --filter @ifc-lite/drawing-2d exec tsc --noEmit` (src scope) — OK
- [x] `oxlint` on the changed file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)