### PR TITLE
fix(viewer): stray blank line in synthetic-key compare BCF description

### DIFF
--- a/.changeset/bcf-description-stray-blank-line.md
+++ b/.changeset/bcf-description-stray-blank-line.md
@@ -1,0 +1,26 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix a stray blank line in the exported BCF description for compare rows with a synthetic key.
+
+`bcfTextFromChange` builds its description as an array of lines, dropping the
+GlobalId line for synthetic `missing:` keys by pushing `''` in its place, then
+filtering with `lines.filter((l, i) => l !== '' || i > 0)`. That filter is a
+no-op: `lines[0]` is always the `"Detected in model comparison: …"` line and is
+never blank, so `i > 0` is true for every other index and nothing was ever
+removed. A `missing:` row therefore kept an empty line where the GlobalId line
+should have been omitted.
+
+The direct fix (`lines.filter(l => l !== '')`) would have broken a second,
+unrelated use of `''`: the function also pushes an intentional blank separator
+before the `"Data changes:"` block, and dropping every `''` removes that
+separator too. `''` was overloaded between "omit this line" and "this line is
+a deliberate blank" - two meanings needed two values.
+
+`lines` is now typed `(string | null)[]`; a synthetic-key row pushes `null`
+(omitted) instead of `''`, and the filter drops only `null`, leaving the real
+`''` separator before "Data changes:" untouched.
+
+Cosmetic only - an extra blank line in an exported BCF topic description for
+rows with no GlobalId (deleted or added-without-GlobalId compare rows).

--- a/apps/viewer/src/components/viewer/compare/changeRow.test.ts
+++ b/apps/viewer/src/components/viewer/compare/changeRow.test.ts
@@ -4,8 +4,15 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import type { ContentMatch, ContentMatchKind, DiffCounts } from '@ifc-lite/diff';
-import { contentMatchRows, hasReportableChanges } from './changeRow.js';
+import type { ContentMatch, ContentMatchKind, DiffCounts, DiffEntry } from '@ifc-lite/diff';
+import {
+  bcfTextFromChange,
+  changeLabel,
+  changedTypeCounts,
+  contentMatchRows,
+  hasReportableChanges,
+  type CompareRow,
+} from './changeRow.js';
 import type { CompareRef } from '@/lib/compare/buildFingerprints';
 
 const fp = (modelId: string, globalId: number, ifcType = 'IfcWall') => ({
@@ -112,5 +119,111 @@ describe('hasReportableChanges (#1891 review)', () => {
     assert.strictEqual(hasReportableChanges(counts(1, 0, 0), []), true);
     assert.strictEqual(hasReportableChanges(counts(0, 1, 0), []), true);
     assert.strictEqual(hasReportableChanges(counts(0, 0, 1), []), true);
+  });
+});
+
+const row = (over: Partial<CompareRow> = {}): CompareRow => ({
+  key: '2O2Fr$t4X7Zf8NOew3FLOH',
+  ifcType: 'IfcWall',
+  name: 'W1',
+  state: 'modified',
+  changeKinds: ['geometry'],
+  ref: { modelId: 'a', localId: 1, globalId: 1 },
+  ...over,
+});
+
+describe('bcfTextFromChange (#1199)', () => {
+  it('omits the GlobalId line for a synthetic `missing:` key without leaving a blank line behind', () => {
+    // `missing:` keys are synthesized for a compare row that has no real
+    // GlobalId (see CompareRow.key doc) - the line must be dropped, not
+    // blanked, so no stray empty line sits where it would have been.
+    const { description } = bcfTextFromChange(
+      row({ key: 'missing:foo', state: 'deleted', changeKinds: [] }),
+      { data: [], geometry: { movedDistance: 1.234, reshaped: false, delta: { x: 0, y: 0, z: 1.234 }, sizeDelta: { x: 0, y: 0, z: 0 } }, dataOnlyGeometric: false },
+    );
+    assert.strictEqual(description, 'Detected in model comparison: deleted.\nMoved 1.234 m.');
+  });
+
+  it('keeps the GlobalId line for a normal key', () => {
+    const { description } = bcfTextFromChange(
+      row(),
+      { data: [], geometry: { movedDistance: 1.234, reshaped: false, delta: { x: 0, y: 0, z: 1.234 }, sizeDelta: { x: 0, y: 0, z: 0 } }, dataOnlyGeometric: false },
+    );
+    assert.strictEqual(
+      description,
+      'Detected in model comparison: geometry.\nGlobalId: 2O2Fr$t4X7Zf8NOew3FLOH\nMoved 1.234 m.',
+    );
+  });
+
+  it('keeps the intentional blank separator before "Data changes:" for a normal key', () => {
+    const { description } = bcfTextFromChange(
+      row({ changeKinds: ['data'] }),
+      {
+        data: [{ category: 'property', group: 'Pset_WallCommon', name: 'FireRating', before: 'A', after: 'B', kind: 'changed' }],
+        geometry: null,
+        dataOnlyGeometric: false,
+      },
+    );
+    assert.strictEqual(
+      description,
+      'Detected in model comparison: data.\nGlobalId: 2O2Fr$t4X7Zf8NOew3FLOH\n\nData changes:\n- Pset_WallCommon / FireRating: A -> B',
+    );
+  });
+
+  it('keeps the intentional blank separator AND omits the GlobalId line together for a missing: key', () => {
+    // The case a careless single-sentinel fix breaks: the omitted GlobalId
+    // line must vanish while the deliberate blank before "Data changes:"
+    // survives - exactly one blank line, not zero and not two.
+    const { description } = bcfTextFromChange(
+      row({ key: 'missing:foo', state: 'deleted', changeKinds: [] }),
+      {
+        data: [{ category: 'property', group: 'Pset_WallCommon', name: 'FireRating', before: undefined, after: undefined, kind: 'removed' }],
+        geometry: null,
+        dataOnlyGeometric: false,
+      },
+    );
+    assert.strictEqual(
+      description,
+      'Detected in model comparison: deleted.\n\nData changes:\n- Pset_WallCommon / FireRating: removed',
+    );
+  });
+});
+
+describe('changedTypeCounts (#1470)', () => {
+  const entry = (over: Partial<DiffEntry<CompareRef>>): DiffEntry<CompareRef> => ({
+    key: 'k',
+    state: 'modified',
+    changeKinds: [],
+    head: { key: 'k', ifcType: 'IfcWall', dataHash: 'd', ref: { modelId: 'b', localId: 1, globalId: 1 } },
+    base: { key: 'k', ifcType: 'IfcWall', dataHash: 'd', ref: { modelId: 'a', localId: 1, globalId: 1 } },
+    ...over,
+  });
+
+  it('tallies changed entries by type, most-changed first, excluding unchanged', () => {
+    const entries = [
+      entry({ key: 'w1', head: { key: 'w1', ifcType: 'IfcWall', dataHash: 'd', ref: { modelId: 'b', localId: 1, globalId: 1 } } }),
+      entry({ key: 'w2', head: { key: 'w2', ifcType: 'IfcWall', dataHash: 'd', ref: { modelId: 'b', localId: 2, globalId: 2 } } }),
+      entry({
+        key: 'd1',
+        head: { key: 'd1', ifcType: 'IfcDoor', dataHash: 'd', ref: { modelId: 'b', localId: 3, globalId: 3 } },
+      }),
+      entry({ key: 'u1', state: 'unchanged' }),
+    ];
+    assert.deepStrictEqual(changedTypeCounts(entries), [
+      { type: 'IfcWall', count: 2 },
+      { type: 'IfcDoor', count: 1 },
+    ]);
+  });
+});
+
+describe('changeLabel', () => {
+  it('reads added/deleted straight off the state', () => {
+    assert.strictEqual(changeLabel(row({ state: 'added', changeKinds: [] })), 'added');
+    assert.strictEqual(changeLabel(row({ state: 'deleted', changeKinds: [] })), 'deleted');
+  });
+
+  it('joins change kinds for a modified row, falling back to "changed" when empty', () => {
+    assert.strictEqual(changeLabel(row({ state: 'modified', changeKinds: ['geometry', 'data'] })), 'geometry + data');
+    assert.strictEqual(changeLabel(row({ state: 'modified', changeKinds: [] })), 'changed');
   });
 });

--- a/apps/viewer/src/components/viewer/compare/changeRow.ts
+++ b/apps/viewer/src/components/viewer/compare/changeRow.ts
@@ -173,9 +173,12 @@ export function bcfTextFromChange(
   const typeLabel = row.ifcType.replace(/^Ifc/, '');
   const name = row.name || typeLabel;
   const title = `${typeLabel} "${name}" - ${changeLabel(row)}`;
-  const lines: string[] = [
+  // `null` marks a line to be OMITTED entirely (filtered out below); `''`
+  // is reserved for an intentional blank separator (e.g. before "Data
+  // changes:"). The two must not share a value - see the filter comment.
+  const lines: (string | null)[] = [
     `Detected in model comparison: ${changeLabel(row)}.`,
-    row.key.startsWith('missing:') ? '' : `GlobalId: ${row.key}`,
+    row.key.startsWith('missing:') ? null : `GlobalId: ${row.key}`,
   ];
   if (detail?.geometry) {
     if (detail.geometry.movedDistance > 0) lines.push(`Moved ${detail.geometry.movedDistance.toFixed(3)} m.`);
@@ -191,5 +194,8 @@ export function bcfTextFromChange(
     }
     if (detail.data.length > 20) lines.push(`- ... and ${detail.data.length - 20} more`);
   }
-  return { title, description: lines.filter((l, i) => l !== '' || i > 0).join('\n') };
+  // Only `null` lines (omitted rows, e.g. the missing-key GlobalId) are
+  // dropped here; a real `''` separator (see the "Data changes:" push
+  // above) survives so its blank line stays in the output.
+  return { title, description: lines.filter((l): l is string => l !== null).join('\n') };
 }


### PR DESCRIPTION
## Summary

`bcfTextFromChange` (`apps/viewer/src/components/viewer/compare/changeRow.ts`) builds the exported BCF description as an array of lines, and drops the `GlobalId:` line for a synthetic `missing:`-keyed compare row by pushing `''` in its place. It then filters with:

```ts
lines.filter((l, i) => l !== '' || i > 0)
```

That filter is a no-op given its own invariant: `lines[0]` is always `"Detected in model comparison: …"` and is never blank, so `i > 0` is true for every other index and nothing is ever removed.

### Reproduced

```
bcfTextFromChange({key:'missing:foo', ifcType:'IfcWall', name:'W1', state:'deleted', changeKinds:[]},
                  {geometry:{movedDistance:1.234, reshaped:false}})
→ "Detected in model comparison: deleted.\n\nMoved 1.234 m."   // BEFORE (stray blank line)
→ "Detected in model comparison: deleted.\nMoved 1.234 m."     // AFTER (fixed)
```

A normal (real GlobalId) key was already correct both before and after:

```
"Detected in model comparison: geometry.\nGlobalId: 2O2Fr$t4X7Zf8NOew3FLOH\nMoved 1.234 m."
```

## Why `''` was overloaded, and the sentinel chosen

`''` is pushed in two places in this function:
1. `row.key.startsWith('missing:') ? '' : \`GlobalId: ...\`` - meant "omit this line".
2. `lines.push('', 'Data changes:')` - an intentional blank separator before the "Data changes:" block.

The obvious fix, `lines.filter(l => l !== '')`, would remove both - fixing the stray line but also destroying the deliberate separator whenever a `missing:`-keyed row also has data changes:

```
BEFORE (bug):  "Detected in model comparison: deleted.\n\n\nData changes:\n- ..."   // double blank
NAIVE FIX:     "Detected in model comparison: deleted.\nData changes:\n- ..."       // separator gone
CORRECT FIX:   "Detected in model comparison: deleted.\n\nData changes:\n- ..."     // one blank, kept
```

`lines` is now typed `(string | null)[]`. The omitted-line case pushes `null` instead of `''`, and the filter becomes `lines.filter((l): l is string => l !== null)`. `''` keeps its one remaining meaning: a real blank separator.

## Tests (RED before the fix, GREEN after)

Added to `changeRow.test.ts`:
- synthetic-key row -> no stray blank line (asserts the exact string)
- normal-key row -> GlobalId line kept (asserts the exact string)
- normal-key row with data changes -> the separator before "Data changes:" survives (asserts the exact string)
- synthetic-key row with data changes -> the separator survives **and** the GlobalId line is gone, in the same output (the case a careless single-sentinel fix breaks)

Also added opportunistic coverage for `changedTypeCounts` and `changeLabel`, which had no direct tests.

## Impact

Cosmetic only - an extra blank line in an exported BCF topic description for compare rows with no GlobalId (deleted/added synthetic rows). Not data-corrupting.

## Test plan

- [x] `apps/viewer` compare-directory test file (`changeRow.test.ts`): 17/17 pass
- [x] Full `apps/viewer` suite (`npm run test`, `node:test`): ran to completion; pre-existing failures unrelated to this change (traced to test files importing `@ifc-lite/extensions`/other workspace packages missing from this fresh worktree's install - confirmed by grepping failing files for a shared `ERR_MODULE_NOT_FOUND`/unrelated-package signature, none touching `compare/`)
- [x] `npx tsc --noEmit`: no errors in `changeRow.ts` or `changeRow.test.ts`; pre-existing unrelated errors elsewhere in the repo, unaffected by this change
- [x] `oxlint` on the two changed files: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exported BCF descriptions to remove omitted GlobalId lines without removing intentional blank separators.
  * Improved formatting for comparison rows using synthetic keys.

* **Tests**
  * Added coverage for BCF text formatting, row change labels, type-count ordering, and exclusion of unchanged entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->