### PR TITLE
fix(scripts): make the prebuilt-WASM fetch work on Windows again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -478,6 +478,14 @@ jobs:
       # through a pipe and asserts the bytes that arrive.
       - name: Check lint gate survives a piped stdout
         run: node --test scripts/check-lint-ran.test.mjs
+      # fetch-prebuilt-wasm.mjs read `npm pack`'s trimmed stdout as the tarball
+      # path. npm 11 prints its "npm notice" block on STDOUT, so the trim
+      # returned twenty lines of prose and the tar two lines down exited 2,
+      # surfacing as a bare `status: 2` that reads like a corrupt download.
+      # That script is the only route to a WASM bundle on a machine without a
+      # Rust toolchain, so the failure blocked the whole viewer build.
+      - name: Check npm pack output is read machine-readably
+        run: node --test scripts/lib/npm-pack-output.test.mjs
       # The Release workflow runs ONLY on main, and only on an actual publish,
       # so nothing on a PR ever read release-crates.mjs's publish ORDER. #2574
       # added a versioned dev-dependency (ifc-lite-clash) to rust/geometry and

--- a/scripts/fetch-prebuilt-wasm.mjs
+++ b/scripts/fetch-prebuilt-wasm.mjs
@@ -11,6 +11,7 @@ import { execSync } from 'node:child_process';
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { tarballNameFromPackOutput } from './lib/npm-pack-output.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, '..');
@@ -30,16 +31,22 @@ if (existsSync(wasmFile)) {
 }
 
 console.log(`Fetching ${tarball} from npm…`);
-const tgzName = execSync(`npm pack ${tarball}`, {
-  cwd: rootDir,
-  encoding: 'utf8',
-}).trim();
+const tgzName = tarballNameFromPackOutput(
+  execSync(`npm pack ${tarball} --json`, { cwd: rootDir, encoding: 'utf8' }),
+);
 
-const extractDir = join(rootDir, '.wasm-fetch-tmp');
+const EXTRACT_DIR_NAME = '.wasm-fetch-tmp';
+const extractDir = join(rootDir, EXTRACT_DIR_NAME);
 rmSync(extractDir, { recursive: true, force: true });
 mkdirSync(extractDir, { recursive: true });
 
-execSync(`tar -xzf ${JSON.stringify(join(rootDir, tgzName))} -C ${JSON.stringify(extractDir)}`, {
+// Relative paths, not absolute ones. GNU tar — what Git for Windows ships and
+// what is first on PATH there — reads a leading `C:` as a REMOTE HOST and
+// fails with "Cannot connect to C: resolve failed" before it opens anything.
+// `--force-local` would fix that for GNU tar and break Windows' own bsdtar,
+// which does not know the flag; running from `rootDir` with relative paths
+// works for both and needs no branch on which tar is installed.
+execSync(`tar -xzf ${JSON.stringify(tgzName)} -C ${JSON.stringify(EXTRACT_DIR_NAME)}`, {
   cwd: rootDir,
   stdio: 'inherit',
 });

--- a/scripts/lib/npm-pack-output.mjs
+++ b/scripts/lib/npm-pack-output.mjs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Read the tarball name out of `npm pack`'s output.
+ *
+ * `npm pack` without `--json` prints an "npm notice" block — the tarball
+ * contents, sizes, shasum, integrity — and npm 11 writes that block to
+ * STDOUT, not stderr. A caller that trims the captured stdout therefore ends
+ * up with twenty lines of prose instead of a filename, and whatever it hands
+ * that to fails somewhere else entirely: `fetch-prebuilt-wasm.mjs` passed it
+ * to `tar -xzf` and got a bare `status: 2`, which reads like a corrupt
+ * download rather than a parse bug. The fix is to ask npm for its
+ * machine-readable form and read the documented field.
+ */
+export function tarballNameFromPackOutput(stdout) {
+  let entries;
+  try {
+    entries = JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      'npm pack --json did not return JSON. Output began: ' +
+        JSON.stringify(String(stdout).slice(0, 120)),
+    );
+  }
+  const filename = Array.isArray(entries) ? entries[0]?.filename : undefined;
+  if (typeof filename !== 'string' || filename === '') {
+    throw new Error(
+      'npm pack --json returned no filename. Output began: ' +
+        JSON.stringify(String(stdout).slice(0, 120)),
+    );
+  }
+  return filename;
+}

--- a/scripts/lib/npm-pack-output.test.mjs
+++ b/scripts/lib/npm-pack-output.test.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test for fetch-prebuilt-wasm.mjs reading `npm pack`'s human
+ * output as a filename.
+ *
+ * The defect: the script ran `npm pack <spec>` and used the trimmed stdout as
+ * the tarball path. That held while npm printed its "npm notice" block on
+ * stderr. npm 11 prints it on STDOUT, so the trim returned the whole block —
+ * about twenty lines listing tarball contents, sizes and the shasum — and the
+ * `tar -xzf` two lines down was handed that as a path. tar exited 2 and the
+ * script rethrew a bare `status: 2` with no stdout and no stderr, which reads
+ * like a corrupt download. On a Windows box without a Rust toolchain this is
+ * the ONLY way to get the WASM bundle, so the failure blocks the whole
+ * viewer build with a message pointing nowhere near the cause.
+ *
+ * The first case is the actual npm 11.16.0 output, pasted verbatim. The second
+ * is what a notice-on-stdout npm gives WITHOUT `--json`: the parser must
+ * refuse it loudly rather than return a plausible-looking line, because the
+ * silent version of this bug is what cost the afternoon.
+ *
+ * Run: node --test scripts/lib/npm-pack-output.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tarballNameFromPackOutput } from './npm-pack-output.mjs';
+
+const NPM_11_JSON = `[
+  {
+    "id": "@ifc-lite/wasm@4.7.0",
+    "name": "@ifc-lite/wasm",
+    "version": "4.7.0",
+    "size": 1540116,
+    "unpackedSize": 4617738,
+    "shasum": "efe7ad75c4ce966daa0507f4c7e33d4b4f2083a3",
+    "filename": "ifc-lite-wasm-4.7.0.tgz",
+    "entryCount": 6,
+    "bundled": []
+  }
+]`;
+
+const NPM_11_NOTICE_ON_STDOUT = `npm notice
+npm notice package: @ifc-lite/wasm@4.7.0
+npm notice Tarball Contents
+npm notice 16.7kB LICENSE
+npm notice 4.3MB pkg/ifc-lite_bg.wasm
+npm notice Tarball Details
+npm notice name: @ifc-lite/wasm
+npm notice version: 4.7.0
+npm notice filename: ifc-lite-wasm-4.7.0.tgz
+npm notice total files: 6
+npm notice
+ifc-lite-wasm-4.7.0.tgz`;
+
+test('reads the filename from npm 11 --json output', () => {
+  assert.equal(tarballNameFromPackOutput(NPM_11_JSON), 'ifc-lite-wasm-4.7.0.tgz');
+});
+
+test('refuses the human notice block instead of guessing a path from it', () => {
+  // The point of the whole change: this input must not silently produce
+  // something tar will choke on later.
+  assert.throws(
+    () => tarballNameFromPackOutput(NPM_11_NOTICE_ON_STDOUT),
+    /did not return JSON/,
+  );
+});
+
+test('refuses a well-formed response that carries no filename', () => {
+  assert.throws(() => tarballNameFromPackOutput('[{"name":"@ifc-lite/wasm"}]'), /no filename/);
+  assert.throws(() => tarballNameFromPackOutput('[]'), /no filename/);
+});
+
+test('names the offending output in the error, truncated', () => {
+  // A parse failure here surfaces on a dev machine that cannot build WASM at
+  // all, so the message has to say what npm actually said.
+  assert.throws(() => tarballNameFromPackOutput('not json at all'), (err) => {
+    assert.match(err.message, /not json at all/);
+    return true;
+  });
+});


### PR DESCRIPTION
## What and why

`pnpm build:wasm:fetch` is the only way to get a WASM bundle on a machine
without a Rust toolchain — the path CONTRIBUTING points Windows contributors
at. It fails there with npm 11. Two independent defects in the same eight
lines, each masking the other:

**1. The tarball name came from `npm pack`'s human output.** The script used
the trimmed stdout as a path. That worked while npm printed its `npm notice`
block on stderr. npm 11 prints it on **stdout**, so the trim returns about
twenty lines — tarball contents, sizes, shasum — instead of a filename. Now
`npm pack --json` and the documented `filename` field.

**2. `tar -xzf "C:\…"` is a remote host to GNU tar.** Git for Windows ships
GNU tar and puts it first on PATH; it reads the leading `C:` as a host and
fails with `Cannot connect to C: resolve failed` before opening anything.
`--force-local` fixes GNU tar and breaks Windows' own bsdtar, which does not
know the flag — so the call now runs from the repo root with relative paths,
which both accept without branching on which tar is installed.

Together they surface as a bare `status: 2` with `stdout: null, stderr: null`.
That reads like a corrupt download rather than a parse bug plus a path bug.
The viewer build then fails downstream on `"clashIntersectionSolid" is not
exported by "../../packages/wasm/pkg/ifc-lite.js"`, which points nowhere near
the cause.

The parse moved to `scripts/lib/npm-pack-output.mjs` so it can be tested
without the script's fetch running on import — the same split as
`lib/server-bin-targets-parse.mjs` and `lib/unused-locals-classify.mjs`.

## How it was verified

End to end on Windows 11, npm 11.16.0, Node 24, with no Rust toolchain
installed — the setup the script exists for:

```
$ rm packages/wasm/pkg/ifc-lite.js packages/wasm/pkg/ifc-lite_bg.wasm
$ node scripts/fetch-prebuilt-wasm.mjs
Fetching @ifc-lite/wasm@4.7.0 from npm…
Installed prebuilt WASM to …\packages\wasm\pkg
$ node --test scripts/lib/npm-pack-output.test.mjs
ℹ pass 4
ℹ fail 0
```

Before the change the same sequence ended in `tar: Child returned status 128`
after being handed the notice block, and with that fixed, in
`Cannot connect to C: resolve failed`. Afterwards `pnpm --filter
@ifc-lite/viewer exec vite build` completes (6477 modules) instead of failing
on the missing `clashIntersectionSolid` export.

The test pins the real npm 11.16.0 `--json` output and asserts that the
notice block is **refused** rather than turned into a plausible-looking path:
the silent version of this bug is the expensive one.

- [x] `cargo test --workspace` (Rust) and/or `pnpm test` (TS) pass locally —
      `node --test scripts/lib/npm-pack-output.test.mjs`, 4 passed. This
      change touches no Rust, no TS package and no geometry; the full `pnpm
      test` on this Windows box fails for unrelated environment reasons
      (locale thousands separators, `ERR_UNSUPPORTED_ESM_URL_SCHEME` on
      absolute `c:\` paths), which is a large part of why this script matters.
- [ ] Geometry/WASM change: not applicable — this fetches a published bundle,
      it does not build one.

## Checklist

- [x] A test asserts the new behavior through a fixture or a stated invariant
- [x] Published `packages/*` touched: none — tooling only, so no changeset
      (`check-changesets.mjs` says as much: "a tooling-only change has no
      publishable package"). Registered in `.github/workflows/test.yml`
      alongside the other `scripts/` tests.
- [x] Geometry-output change: none
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}` (the one
      `catch` rethrows with the offending output), no module past ~400 lines,
      no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prebuilt WASM package retrieval across npm versions, including npm 11 output.
  * Prevented invalid package paths from causing extraction failures on Windows and other supported environments.
  * Added clearer errors when package metadata is invalid or incomplete.

* **Tests**
  * Added regression coverage for valid, malformed, and incomplete npm package output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->