### PR TITLE
fix(viewer): apply the else-by-type quantity fallback to area and weight, not just volume

### DIFF
--- a/.changeset/material-totals-quantity-fallback.md
+++ b/.changeset/material-totals-quantity-fallback.md
@@ -19,3 +19,16 @@ rather than depending on the qset scan order the previous volume-only
 fallback relied on. The per-element map-building + pick logic that all
 three totals shared is now a single extracted function instead of three
 call sites that could (and did) drift apart.
+
+Follow-up fix: the alphabetical fallback could select `CrossSectionArea` —
+a beam/column/member's section (profile) property, not a surface extent —
+as the element's Area, because no candidate name matched it and it sorts
+before every real surface-area name those elements carry
+(`GrossSurfaceArea`, `NetSurfaceArea`, `OuterSurfaceArea`). Proven on the
+app's own shipped `infra-bridge.ifc` sample, this reported a bridge beam's
+0.12 m² cross-section as its material area instead of leaving the total
+unset. `AREA_CANDIDATES` now recognises the standard surface-area names by
+name (so standard beams/columns resolve without reaching the fallback at
+all), and the fallback itself excludes `crosssectionarea` so it can never
+be picked even as a last resort — degrading to "no value" rather than a
+wrong one when it's the only area quantity present.

--- a/.changeset/material-totals-quantity-fallback.md
+++ b/.changeset/material-totals-quantity-fallback.md
@@ -1,0 +1,21 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix the material totals panel dropping area/weight for vendor-named quantities.
+
+`MaterialTotalsPanel`'s `pickQuantity` docstring promised "pick a quantity
+value by candidate names (case-insensitive), else by type," but only the
+volume total implemented the else-by-type fallback. An element whose only
+area (or weight) quantity used a name outside the IFC-standard candidate
+list — a vendor-specific `PerimeterArea` or `TopArea`, say — contributed
+zero to that material's area/weight total and its row stayed hidden, while
+the identical situation for volume was counted correctly.
+
+`pickQuantity` now applies the else-by-type fallback uniformly to volume,
+area and weight, picking the alphabetically-first named quantity of that
+type when nothing matches a candidate name — a deterministic tiebreak,
+rather than depending on the qset scan order the previous volume-only
+fallback relied on. The per-element map-building + pick logic that all
+three totals shared is now a single extracted function instead of three
+call sites that could (and did) drift apart.

--- a/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.aggregation.test.ts
+++ b/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.aggregation.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `pickQuantity`'s docstring on `MaterialTotalsPanel` promises: "Pick a
+ * quantity value by candidate names (case-insensitive), else by type." The
+ * volume call site implemented that fallback; the area and weight call
+ * sites — built from the same `*ByName` maps in the same `qset.quantities`
+ * loop — did not. An element whose only area (or weight) quantity carries a
+ * vendor-specific name outside the IFC-standard candidate list (e.g.
+ * "PerimeterArea", "TopArea") contributed zero to that material's total and
+ * its row was hidden, while the identical situation for volume was counted.
+ * This has been present since the file's first commit (#978).
+ *
+ * These tests drive `aggregateQuantitiesFromQsets` — the function extracted
+ * from the three call sites so the "match a candidate name, else by type"
+ * rule is applied identically to volume, area and weight instead of three
+ * copies that can silently drift apart.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { QuantityType } from '@ifc-lite/data';
+import { aggregateQuantitiesFromQsets } from './MaterialTotalsPanel.js';
+
+type Qty = { name: string; type: number; value: number };
+type Qset = { quantities: readonly Qty[] };
+
+function qsets(quantities: Qty[]): Qset[] {
+  return [{ quantities }];
+}
+
+describe('aggregateQuantitiesFromQsets', () => {
+  describe('volume', () => {
+    it('picks a candidate-named quantity (existing behaviour)', () => {
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'NetVolume', type: QuantityType.Volume, value: 12 }]),
+      );
+      assert.equal(r.volume, 12);
+    });
+
+    it('falls back to a non-candidate-named quantity of the same type (the fix)', () => {
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'CustomVendorVolume', type: QuantityType.Volume, value: 7 }]),
+      );
+      assert.equal(r.volume, 7);
+    });
+
+    it('is undefined when no volume quantity exists', () => {
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'NetArea', type: QuantityType.Area, value: 5 }]),
+      );
+      assert.equal(r.volume, undefined);
+    });
+  });
+
+  describe('area', () => {
+    it('picks a candidate-named quantity (existing behaviour)', () => {
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'NetArea', type: QuantityType.Area, value: 30 }]),
+      );
+      assert.equal(r.area, 30);
+    });
+
+    it('falls back to a non-candidate-named quantity of the same type (the fix)', () => {
+      // RED against pre-fix code: the area call site had no else-by-type
+      // fallback, so this returned undefined and the total stayed 0.
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'PerimeterArea', type: QuantityType.Area, value: 18 }]),
+      );
+      assert.equal(r.area, 18);
+    });
+
+    it('is undefined when no area quantity exists', () => {
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'NetVolume', type: QuantityType.Volume, value: 9 }]),
+      );
+      assert.equal(r.area, undefined);
+    });
+  });
+
+  describe('weight', () => {
+    it('picks a candidate-named quantity (existing behaviour)', () => {
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'NetWeight', type: QuantityType.Weight, value: 500 }]),
+      );
+      assert.equal(r.weight, 500);
+    });
+
+    it('falls back to a non-candidate-named quantity of the same type (the fix)', () => {
+      // RED against pre-fix code: the weight call site had no else-by-type
+      // fallback, so this returned undefined and the total stayed 0.
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'ShippingWeight', type: QuantityType.Weight, value: 250 }]),
+      );
+      assert.equal(r.weight, 250);
+    });
+
+    it('is undefined when no weight quantity exists', () => {
+      const r = aggregateQuantitiesFromQsets(
+        qsets([{ name: 'NetArea', type: QuantityType.Area, value: 4 }]),
+      );
+      assert.equal(r.weight, undefined);
+    });
+  });
+
+  it('breaks ties among several non-candidate names deterministically (alphabetical)', () => {
+    const r = aggregateQuantitiesFromQsets(
+      qsets([
+        { name: 'ZTopArea', type: QuantityType.Area, value: 99 },
+        { name: 'APerimeterArea', type: QuantityType.Area, value: 11 },
+      ]),
+    );
+    assert.equal(r.area, 11);
+  });
+});

--- a/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.aggregation.test.ts
+++ b/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.aggregation.test.ts
@@ -17,6 +17,27 @@
  * from the three call sites so the "match a candidate name, else by type"
  * rule is applied identically to volume, area and weight instead of three
  * copies that can silently drift apart.
+ *
+ * PR #2777 review 1 (louistrue): proved on the app's own shipped sample
+ * (`apps/viewer/public/samples/infra-bridge.ifc`) that the alphabetical
+ * by-type fallback picks a beam's `CrossSectionArea` — a section property,
+ * not a surface extent — as its Area, because no candidate name matched and
+ * `crosssectionarea` sorts before the beam's other (non-candidate) area
+ * names. Review 2: the fix is `AREA_CANDIDATES` recognising the standard
+ * surface-area names by NAME (so beams/columns/members resolve without ever
+ * reaching the fallback) plus `AREA_TYPE_FALLBACK_DENY` excluding
+ * `crosssectionarea` from the fallback itself, so it can never be selected
+ * even as a last resort.
+ *
+ * Review 1's MAJOR finding: every fixture in the original suite held exactly
+ * one quantity of the kind under test, so the candidate-match path and the
+ * type-fallback path returned the same value — deleting the candidate
+ * matching entirely (`for (const c of candidates) ...` -> `void candidates;`)
+ * left all 10 tests green. The "candidate wins over fallback" and
+ * "case-insensitive match" tests below use TWO quantities per fixture, one
+ * that only the candidate-priority / case-insensitive path picks correctly
+ * and one that the (deny-filtered) alphabetical fallback would pick instead
+ * if matching were skipped — see the mutation notes on each test.
  */
 
 import { describe, it } from 'node:test';
@@ -113,5 +134,89 @@ describe('aggregateQuantitiesFromQsets', () => {
       ]),
     );
     assert.equal(r.area, 11);
+  });
+
+  describe('CrossSectionArea must never be reported as a surface Area (PR #2777 review 1)', () => {
+    it('is undefined when the only area quantity is CrossSectionArea (infra-bridge.ifc beam shape)', () => {
+      // Real shape of apps/viewer/public/samples/infra-bridge.ifc's
+      // Qto_BeamBaseQuantities (#385/#442/#493): NetVolume, Length,
+      // CrossSectionArea — no surface-area quantity at all. Before this
+      // fix, the alphabetical fallback had exactly one Area-typed name to
+      // choose from and picked it, reporting 0.12 m2 (the beam's profile
+      // area) as the material's surface area. Absence is the honest result.
+      const r = aggregateQuantitiesFromQsets(
+        qsets([
+          { name: 'NetVolume', type: QuantityType.Volume, value: 0.48 },
+          { name: 'Length', type: QuantityType.Length, value: 4000 },
+          { name: 'CrossSectionArea', type: QuantityType.Area, value: 0.12 },
+        ]),
+      );
+      assert.equal(r.area, undefined);
+    });
+
+    it('picks a real surface-area quantity over CrossSectionArea by name (the requested beam fixture)', () => {
+      // The exact fixture louistrue's second review asked for: "a beam
+      // carrying CrossSectionArea AND OuterSurfaceArea, asserting the
+      // surface area is chosen." outersurfacearea is now in
+      // AREA_CANDIDATES, so this resolves by name and never reaches the
+      // fallback at all.
+      const r = aggregateQuantitiesFromQsets(
+        qsets([
+          { name: 'CrossSectionArea', type: QuantityType.Area, value: 0.06 },
+          { name: 'OuterSurfaceArea', type: QuantityType.Area, value: 11.9 },
+        ]),
+      );
+      assert.equal(r.area, 11.9);
+    });
+
+    it('excludes CrossSectionArea from the by-type fallback even when a non-candidate name is also present', () => {
+      // Neither name matches AREA_CANDIDATES, so this exercises the
+      // fallback path (not name matching). MUTATION: delete
+      // AREA_TYPE_FALLBACK_DENY (or stop passing it to pickQuantity) and
+      // this goes RED — alphabetical sort puts 'crosssectionarea' before
+      // 'vendorsurfacearea', returning 0.06 instead of 11.9.
+      const r = aggregateQuantitiesFromQsets(
+        qsets([
+          { name: 'CrossSectionArea', type: QuantityType.Area, value: 0.06 },
+          { name: 'VendorSurfaceArea', type: QuantityType.Area, value: 11.9 },
+        ]),
+      );
+      assert.equal(r.area, 11.9);
+    });
+  });
+
+  describe('candidate priority is load-bearing, not incidental (PR #2777 review 1 MAJOR finding)', () => {
+    it('prefers Net over Gross even though Gross sorts first alphabetically', () => {
+      // MUTATION: delete the candidate-matching loop in pickQuantity
+      // (`for (const c of candidates) ...` -> `void candidates;`) and this
+      // goes RED — with matching skipped, both fixtures fall straight to
+      // the alphabetical fallback, which prefers 'grossarea' (13) over
+      // 'netarea' (7) purely by spelling. Every fixture in the original
+      // suite held one quantity per kind, so this priority was unguarded:
+      // the candidate path and the fallback path always agreed.
+      const r = aggregateQuantitiesFromQsets(
+        qsets([
+          { name: 'GrossArea', type: QuantityType.Area, value: 13 },
+          { name: 'NetArea', type: QuantityType.Area, value: 7 },
+        ]),
+      );
+      assert.equal(r.area, 7);
+    });
+
+    it('matches candidate names case-insensitively even when a differently-cased fallback name would sort first', () => {
+      // MUTATION: change `q.name.toLowerCase()` to `q.name` in
+      // aggregateQuantitiesFromQsets and this goes RED — the map key stays
+      // 'NETAREA' (uppercase), which no longer matches the lowercase
+      // candidate 'netarea', so it falls to the alphabetical fallback.
+      // Case-sensitive sort puts 'AVendorArea' (5000) before 'NETAREA'
+      // (10), returning the wrong value.
+      const r = aggregateQuantitiesFromQsets(
+        qsets([
+          { name: 'NETAREA', type: QuantityType.Area, value: 10 },
+          { name: 'AVendorArea', type: QuantityType.Area, value: 5000 },
+        ]),
+      );
+      assert.equal(r.area, 10);
+    });
   });
 });

--- a/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
@@ -50,7 +50,22 @@ interface MaterialTotals {
   byClass: Array<{ ifcClass: string; count: number }>;
 }
 
-/** Pick a quantity value by candidate names (case-insensitive), else by type. */
+/**
+ * Pick a quantity value by candidate names (case-insensitive), else by type:
+ * when nothing matches a candidate but the map is non-empty, fall back to the
+ * alphabetically-first name. That fallback exists for vendor-specific
+ * quantity names (e.g. "PerimeterArea", "TopArea") that carry a real value of
+ * the right type but never match the IFC-standard candidate list — without
+ * it, such an element contributes nothing to the total and its row is
+ * dropped from the panel even though the quantity was there all along.
+ *
+ * The tiebreak is alphabetical rather than "whichever the map saw first":
+ * map insertion order mirrors the order qsets/quantities were encountered
+ * while scanning the element (itself downstream of on-demand-parse vs.
+ * type-fallback ordering, see the qsets selection above) — a happenstance of
+ * traversal, not a meaningful choice. Sorting by name at least makes the
+ * fallback reproducible independent of that traversal order.
+ */
 function pickQuantity(
   byName: Map<string, number>,
   candidates: string[],
@@ -59,7 +74,50 @@ function pickQuantity(
     const v = byName.get(c);
     if (v !== undefined) return v;
   }
-  return undefined;
+  if (byName.size === 0) return undefined;
+  const firstName = [...byName.keys()].sort()[0];
+  return byName.get(firstName);
+}
+
+const VOLUME_CANDIDATES = ['netvolume', 'grossvolume', 'volume'];
+const AREA_CANDIDATES = [
+  'netarea',
+  'grossarea',
+  'netsidearea',
+  'grosssidearea',
+  'netfloorarea',
+  'grossfloorarea',
+  'area',
+];
+const WEIGHT_CANDIDATES = ['netweight', 'grossweight', 'weight'];
+
+/**
+ * Build per-name quantity maps from an element's (or its type's) qsets and
+ * pick one value of each quantity kind — the single place all three call
+ * sites (volume/area/weight) share, so the "match a candidate name, else by
+ * type" rule from `pickQuantity`'s docstring is applied identically to all
+ * three instead of three copies that can silently drift apart (as they did:
+ * only the volume call site implemented the fallback).
+ */
+export function aggregateQuantitiesFromQsets(
+  qsets: ReadonlyArray<{ quantities: ReadonlyArray<{ name: string; type: number; value: number }> }>,
+): { volume?: number; area?: number; weight?: number } {
+  const volByName = new Map<string, number>();
+  const areaByName = new Map<string, number>();
+  const weightByName = new Map<string, number>();
+  for (const qset of qsets) {
+    for (const q of qset.quantities) {
+      const key = q.name.toLowerCase();
+      if (q.type === QuantityType.Volume) volByName.set(key, q.value);
+      else if (q.type === QuantityType.Area) areaByName.set(key, q.value);
+      else if (q.type === QuantityType.Weight) weightByName.set(key, q.value);
+    }
+  }
+  return {
+    volume: pickQuantity(volByName, VOLUME_CANDIDATES),
+    area: pickQuantity(areaByName, AREA_CANDIDATES),
+    weight: pickQuantity(weightByName, WEIGHT_CANDIDATES),
+  };
 }
 
 /** Format an aggregated quantity with magnitude-appropriate precision. */
@@ -191,33 +249,19 @@ export function MaterialTotalsPanel({ materialId, modelId }: { materialId: numbe
                 return own.some((qset) => qset.quantities.length > 0) ? own : typeQsetsFor(entityId);
               })();
           if (qsets.length === 0) continue;
-          const volByName = new Map<string, number>();
-          const areaByName = new Map<string, number>();
-          const weightByName = new Map<string, number>();
-          for (const qset of qsets) {
-            for (const q of qset.quantities) {
-              const key = q.name.toLowerCase();
-              if (q.type === QuantityType.Volume) volByName.set(key, q.value);
-              else if (q.type === QuantityType.Area) areaByName.set(key, q.value);
-              else if (q.type === QuantityType.Weight) weightByName.set(key, q.value);
-            }
-          }
+          const { volume: vol, area, weight: wt } = aggregateQuantitiesFromQsets(qsets);
 
-          const vol = pickQuantity(volByName, ['netvolume', 'grossvolume', 'volume'])
-            ?? (volByName.size > 0 ? [...volByName.values()][0] : undefined);
           if (vol !== undefined) {
             result.volume += vol * weight;
             result.hasVolume = true;
             result.elementsWithVolume += 1;
           }
 
-          const area = pickQuantity(areaByName, ['netarea', 'grossarea', 'netsidearea', 'grosssidearea', 'netfloorarea', 'grossfloorarea', 'area']);
           if (area !== undefined) {
             result.area += area * weight;
             result.hasArea = true;
           }
 
-          const wt = pickQuantity(weightByName, ['netweight', 'grossweight', 'weight']);
           if (wt !== undefined) {
             result.weight += wt * weight;
             result.hasWeight = true;

--- a/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.tsx
@@ -52,12 +52,13 @@ interface MaterialTotals {
 
 /**
  * Pick a quantity value by candidate names (case-insensitive), else by type:
- * when nothing matches a candidate but the map is non-empty, fall back to the
- * alphabetically-first name. That fallback exists for vendor-specific
- * quantity names (e.g. "PerimeterArea", "TopArea") that carry a real value of
- * the right type but never match the IFC-standard candidate list — without
- * it, such an element contributes nothing to the total and its row is
- * dropped from the panel even though the quantity was there all along.
+ * when nothing matches a candidate but the map (minus `deny`) is non-empty,
+ * fall back to the alphabetically-first remaining name. That fallback exists
+ * for vendor-specific quantity names (e.g. "PerimeterArea", "TopArea") that
+ * carry a real value of the right type but never match the IFC-standard
+ * candidate list — without it, such an element contributes nothing to the
+ * total and its row is dropped from the panel even though the quantity was
+ * there all along.
  *
  * The tiebreak is alphabetical rather than "whichever the map saw first":
  * map insertion order mirrors the order qsets/quantities were encountered
@@ -65,21 +66,38 @@ interface MaterialTotals {
  * type-fallback ordering, see the qsets selection above) — a happenstance of
  * traversal, not a meaningful choice. Sorting by name at least makes the
  * fallback reproducible independent of that traversal order.
+ *
+ * `deny` excludes names that are the right IFC *type* (e.g. `IfcQuantityArea`)
+ * but not the right *kind* of value — `CrossSectionArea` is a section
+ * property (profile area), not a surface extent, yet it type-checks as an
+ * area and sorts alphabetically before every real surface-area name a beam
+ * or column carries (`GrossSurfaceArea`, `NetSurfaceArea`, `OuterSurfaceArea`).
+ * A name-blind alphabetical fallback would silently select it and report a
+ * value up to two orders of magnitude too small. Skipping a denied name
+ * still degrades to "no value" rather than a wrong one when it is the only
+ * candidate present — the honest outcome PR #2777 traded away.
  */
 function pickQuantity(
   byName: Map<string, number>,
   candidates: string[],
+  deny: ReadonlySet<string> = EMPTY_DENY,
 ): number | undefined {
   for (const c of candidates) {
     const v = byName.get(c);
     if (v !== undefined) return v;
   }
-  if (byName.size === 0) return undefined;
-  const firstName = [...byName.keys()].sort()[0];
-  return byName.get(firstName);
+  const fallbackNames = [...byName.keys()].filter((n) => !deny.has(n)).sort();
+  if (fallbackNames.length === 0) return undefined;
+  return byName.get(fallbackNames[0]);
 }
 
+const EMPTY_DENY: ReadonlySet<string> = new Set();
+
 const VOLUME_CANDIDATES = ['netvolume', 'grossvolume', 'volume'];
+// Most-specific first: the true extents (net/gross *surface* area) are tried
+// before the generic "area" name, so a beam/column/member carrying a
+// standard `NetSurfaceArea`/`OuterSurfaceArea` quantity resolves BY NAME and
+// never reaches the by-type fallback at all (louistrue, PR #2777 review 2).
 const AREA_CANDIDATES = [
   'netarea',
   'grossarea',
@@ -87,8 +105,16 @@ const AREA_CANDIDATES = [
   'grosssidearea',
   'netfloorarea',
   'grossfloorarea',
+  'netsurfacearea',
+  'grosssurfacearea',
+  'outersurfacearea',
   'area',
 ];
+// `CrossSectionArea` (IfcBeam/IfcColumn/IfcMember/IfcFooting/IfcPile/duct
+// and pipe segments' Qto_*BaseQuantities) is an `IfcQuantityArea` but a
+// section/profile property, not an extent — the by-type fallback must never
+// select it. See `pickQuantity`'s docstring.
+const AREA_TYPE_FALLBACK_DENY: ReadonlySet<string> = new Set(['crosssectionarea']);
 const WEIGHT_CANDIDATES = ['netweight', 'grossweight', 'weight'];
 
 /**
@@ -115,7 +141,7 @@ export function aggregateQuantitiesFromQsets(
   }
   return {
     volume: pickQuantity(volByName, VOLUME_CANDIDATES),
-    area: pickQuantity(areaByName, AREA_CANDIDATES),
+    area: pickQuantity(areaByName, AREA_CANDIDATES, AREA_TYPE_FALLBACK_DENY),
     weight: pickQuantity(weightByName, WEIGHT_CANDIDATES),
   };
 }


### PR DESCRIPTION
## Summary

`MaterialTotalsPanel`'s `pickQuantity` docstring (`~:53`) promises: *"Pick a quantity value by candidate names (case-insensitive), else by type."* Only the volume call site implemented that fallback; area and weight did not, despite building from the same `*ByName` maps in the same `qset.quantities` loop:

```ts
const vol  = pickQuantity(volByName, ['netvolume','grossvolume','volume'])
  ?? (volByName.size > 0 ? [...volByName.values()][0] : undefined);   // fallback
const area = pickQuantity(areaByName, [...]);                          // no fallback
const wt   = pickQuantity(weightByName, [...]);                        // no fallback
```

An element whose only area (or weight) quantity carries a vendor-specific name outside the candidate list (e.g. `PerimeterArea`, `TopArea`) contributed **zero** to that material's total and its row was hidden, while the identical situation for volume was counted. Present since the file's first commit (#978); nothing tested this aggregation loop.

## Verdict on the volume line's own fallback

The pre-existing volume fallback (`[...volByName.values()][0]`) picks whichever quantity the `Map` saw first — i.e. insertion order from the `qset.quantities` scan, itself downstream of on-demand-parse vs. type-fallback qset selection. That is deterministic for a fixed input file (parsing isn't random), but it is not a *meaningful* choice — just happenstance of traversal order. Making area/weight copy that rule verbatim would still leave the ordering coupled to internal scan order.

I judged this worth fixing for all three rather than replicating a dubious rule: `pickQuantity`'s fallback now sorts the candidate map's keys and returns the alphabetically-first one. This is deterministic independent of qset scan order, testable, and applied identically to volume/area/weight through one function (`aggregateQuantitiesFromQsets`) instead of three call sites that could — and did — drift apart.

## Rule applied

- Extracted `aggregateQuantitiesFromQsets(qsets)` from the three separate call sites; it builds the `volByName`/`areaByName`/`weightByName` maps once and calls `pickQuantity` for all three.
- `pickQuantity`: match a candidate name (case-insensitive) first; else, if the map is non-empty, return the value for the alphabetically-first name.

## RED/GREEN (all three quantity kinds)

Added `apps/viewer/src/components/viewer/properties/MaterialTotalsPanel.aggregation.test.ts`, driving `aggregateQuantitiesFromQsets` directly (candidate-named / non-candidate-named / absent, per kind), plus a tiebreak test.

- **Volume**: passed both before and after (existing behaviour retained).
- **Area — non-candidate name (`PerimeterArea`)**: RED against pre-fix code (`area` came back `undefined`, so the total stayed 0) → GREEN after the fix (`area === 18`).
- **Weight — non-candidate name (`ShippingWeight`)**: RED against pre-fix code (`weight` came back `undefined`) → GREEN after the fix (`weight === 250`).
- **Tiebreak** (two non-candidate area names): RED against pre-fix code (`undefined`, since the fallback didn't exist for area at all) → GREEN, picks the alphabetically-first (`APerimeterArea` over `ZTopArea`).

Confirmed RED by temporarily reverting `pickQuantity`/`aggregateQuantitiesFromQsets` to the pre-fix shape (candidate-only pick for area/weight, map-insertion-order fallback for volume only) and re-running the suite: 3 failures (area fallback, weight fallback, tiebreak), 7 passes (volume cases + the "no quantity" cases). Restored the fix and re-ran: 10/10 pass.

Also ran the full `properties/` directory suite (8 files, 40 tests) — all pass.

**The full `apps/viewer` suite did not finish locally in the time available; CI on this PR's head is the authority for that count.**

## Verification run locally

- `pnpm exec tsc --noEmit` (via `turbo run typecheck --filter=@ifc-lite/viewer`) — clean.
- `oxlint` over the changed files and the `properties/` directory — no new warnings (three pre-existing unrelated warnings in `BsddCard.tsx`/`LocationMap.tsx`).
- Changeset added (`@ifc-lite/viewer` patch) — this changes displayed totals.

## Test plan

- [x] `apps/viewer` `properties/` test suite (40 tests, includes the new file) — all pass
- [x] Typecheck clean
- [x] Lint clean on changed files
- [ ] Full `apps/viewer` suite — not completed locally; defer to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved material totals so volume, area, and weight values are selected consistently.
  * Added deterministic fallback handling for vendor-specific quantity names.
  * Prevented cross-sectional area values from being incorrectly used as surface-area totals.
  * Ensured totals remain predictable when multiple quantities of the same type are available, with unavailable values shown when no valid quantity exists.

* **Tests**
  * Added coverage for matching quantities, fallback selection, missing values, exclusions, and alphabetical tie-breaking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->