### PR TITLE
test(schedule): pin FF and SF link codes in CSV predecessor parsing

### DIFF
--- a/apps/viewer/src/components/viewer/schedule/import/csv.test.ts
+++ b/apps/viewer/src/components/viewer/schedule/import/csv.test.ts
@@ -217,6 +217,19 @@ describe('parseCsvPredecessors', () => {
     assert.deepStrictEqual(deps, [{ predecessorSourceId: '14', type: 'START_START', lagSeconds: -86_400 }]);
   });
 
+  it('parses "12FF+3 days"', () => {
+    const warnings: ScheduleImportWarning[] = [];
+    const deps = parseCsvPredecessors('12FF+3 days', warnings, 1, NO_KNOWN_IDS);
+    assert.strictEqual(warnings.length, 0);
+    assert.deepStrictEqual(deps, [{ predecessorSourceId: '12', type: 'FINISH_FINISH', lagSeconds: 3 * 86_400 }]);
+  });
+
+  it('parses "12SF-1 day" preserving the negative lag', () => {
+    const warnings: ScheduleImportWarning[] = [];
+    const deps = parseCsvPredecessors('12SF-1 day', warnings, 1, NO_KNOWN_IDS);
+    assert.deepStrictEqual(deps, [{ predecessorSourceId: '12', type: 'START_FINISH', lagSeconds: -86_400 }]);
+  });
+
   it('defaults a bare id to FINISH_START with no lag', () => {
     const warnings: ScheduleImportWarning[] = [];
     const deps = parseCsvPredecessors('7', warnings, 1, NO_KNOWN_IDS);


### PR DESCRIPTION
## Summary

Refs #2765.

`parseCsvPredecessors`'s `LINK_CODES` map (`apps/viewer/src/components/viewer/schedule/import/csv-predecessors.ts:51-56`) has all four MS Project link codes:

```ts
const LINK_CODES: Record<string, SequenceTypeEnum> = {
  FS: 'FINISH_START',
  SS: 'START_START',
  FF: 'FINISH_FINISH',
  SF: 'START_FINISH',
};
```

but `csv.test.ts` only individually exercised `FS` (`"12FS+3 days"`) and `SS` (`"14SS-1 day"`). `FF` and `SF` were never asserted.

**Reproduced the gap**: swapping the `FF` and `SF` values (`FF: 'START_FINISH'`, `SF: 'FINISH_FINISH'`) and running `csv.test.ts` left all 97 existing tests green. A real MS Project CSV export using `12FF+3d` or `12SF-1d` would silently produce the wrong dependency type with nothing in the suite to catch it.

**Sibling asymmetry**: `import/mspdi.ts`'s `LINK_TYPE_BY_CODE` — the same four link types, same feature, different import format — already has all four individually round-trip tested in `mspdi.test.ts:97-121` (each code is parsed through actual XML and its resulting `sequenceType` asserted). Re-checked this while here: it's a genuine per-code test, not just a fixture presence check. So the CSV importer's map was half-pinned relative to its own twin.

## Changes

Adds two tests alongside the existing FS/SS ones, matching their shape:
- `parseCsvPredecessors('12FF+3 days', …)` → `{ type: 'FINISH_FINISH', lagSeconds: 3 * 86_400 }`
- `parseCsvPredecessors('12SF-1 day', …)` → `{ type: 'START_FINISH', lagSeconds: -86_400 }`

Both assert lag as well as type, matching the existing FS/SS tests.

**Per-test discrimination verified**: re-applied the FF/SF swap after adding the tests and confirmed both new tests independently go red (not just together as a side effect of some other break) — each failure shows the exact expected-vs-actual type mismatch:
- `parses "12FF+3 days"` → expected `FINISH_FINISH`, got `START_FINISH`
- `parses "12SF-1 day" preserving the negative lag` → expected `START_FINISH`, got `FINISH_FINISH`

Reverted the swap; production code is unchanged (test-only, no changeset needed).

## Test plan
- [x] `csv.test.ts`: 97 → 99 tests, all green with the real (unswapped) map
- [x] Reproduced the gap: swap FF/SF values → still 97/97 green (confirms the pre-existing hole)
- [x] After adding the two new tests: swap again → both new tests independently red, rest green (16 total suite fails: 2 predecessor tests only)
- [x] Restored the map to its correct values
- [x] Full `apps/viewer/src/components/viewer/schedule/**/*.test.{ts,tsx}` run: 286/286 pass (after `pnpm install --frozen-lockfile` + `turbo run build --filter=@ifc-lite/viewer^...` — an uninitialized worktree without that setup shows an unrelated `ERR_MODULE_NOT_FOUND: react`, which is an environment artifact, not a code defect)
- [x] `tsc --noEmit` in `apps/viewer`: clean
- [x] `oxlint` on the touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for parsing `FF` and `SF` predecessor links.
  * Verified support for both positive and negative lag values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->