### PR TITLE
fix(viewer): remount WidgetErrorBoundary on dock tab switch

### DIFF
--- a/.changeset/widget-error-boundary-remount-on-tab-switch.md
+++ b/.changeset/widget-error-boundary-remount-on-tab-switch.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix a crashed extension widget masking every widget viewed afterward in the same dock slot.
+
+`WidgetErrorBoundary` never cleared its caught error, and `ExtensionDockHost` rendered it (and its `DockBody` parent) without a `key`, so switching the active dock tab reused the same React instance. Once any widget in a dock slot threw during render, every subsequently-viewed widget in that slot showed the first widget's stale crash banner instead of its own content — the panel effectively froze until it fully unmounted.
+
+`DockBody` and `WidgetErrorBoundary` are now keyed on the widget's identity (`extensionId`/`widget` path), so switching tabs discards the crashed instance and mounts a fresh one; re-rendering the *same* widget keeps the same key, so a widget that throws on every render still shows its own crash and does not enter a remount/crash retry loop.

--- a/apps/viewer/src/components/extensions/ExtensionDockHost.tsx
+++ b/apps/viewer/src/components/extensions/ExtensionDockHost.tsx
@@ -96,7 +96,13 @@ export function ExtensionDockHost({ slot, className }: ExtensionDockHostProps) {
         })}
       </div>
       <ScrollArea className="flex-1">
-        <DockBody contribution={active} />
+        {/* Keyed on the tab identity (same composite as the tab button
+            above) so switching tabs remounts `DockBody` — and, inside
+            it, `WidgetErrorBoundary` — instead of reusing the previous
+            tab's component instance and its state. See
+            `WidgetErrorBoundary`'s doc comment for why an unkeyed reuse
+            here masks every later widget behind a stale crash. */}
+        <DockBody key={`${active.extensionId}:${active.payload.id}`} contribution={active} />
       </ScrollArea>
     </div>
   );
@@ -203,6 +209,11 @@ function DockBody({ contribution }: { contribution: SlotContribution<DockContrib
   return (
     <div className="p-3">
       <WidgetErrorBoundary
+        // Keyed on the same identity shown in the fallback label: the
+        // boundary never clears `state.error` itself (see its doc
+        // comment), so a `key` change is what forces React to discard
+        // a crashed instance and mount a fresh one for a new widget.
+        key={`${contribution.extensionId}/${contribution.payload.widget}`}
         label={`${contribution.extensionId}/${contribution.payload.widget}`}
       >
         <WidgetRenderer

--- a/apps/viewer/src/components/extensions/widget/WidgetErrorBoundary.test.tsx
+++ b/apps/viewer/src/components/extensions/widget/WidgetErrorBoundary.test.tsx
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test for the "crashed widget masks every later one" defect
+ * (#2765): `WidgetErrorBoundary` never cleared `state.error`, and its only
+ * caller (`ExtensionDockHost`'s `DockBody`) reused the same React instance
+ * across tab switches (no `key`). Once any widget threw, every
+ * subsequently-viewed widget rendered the SAME stale error instead of its
+ * own content.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { WidgetErrorBoundary } from './WidgetErrorBoundary.js';
+
+function ThrowingWidget(): never {
+  throw new Error('widget A blew up');
+}
+
+function HealthyWidget() {
+  return <div data-testid="healthy">widget B content</div>;
+}
+
+describe('WidgetErrorBoundary', () => {
+  it('characterizes the defect: without a key, the same instance keeps showing a stale crash (#2765)', async () => {
+    // This is the exact bug this suite guards against, reproduced directly
+    // against the boundary: `ExtensionDockHost` used to render
+    // `<WidgetErrorBoundary>` with no `key`, so switching the active dock
+    // tab reused the same React instance. `getDerivedStateFromError` sets
+    // `state.error` and nothing ever clears it, so a healthy widget B
+    // rendered underneath the still-standing fallback for crashed widget
+    // A. This test intentionally omits the `key` the real call site now
+    // applies, to document why that key is load-bearing rather than
+    // decorative — it is expected to keep "passing" (i.e. keep
+    // demonstrating the stale banner) forever, since the component itself
+    // deliberately never self-heals (see its doc comment).
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | undefined;
+
+    try {
+      await act(async () => {
+        root = createRoot(container);
+        root.render(
+          <WidgetErrorBoundary label="ext-a/widget-a">
+            <ThrowingWidget />
+          </WidgetErrorBoundary>,
+        );
+      });
+      assert.match(container.innerHTML, /ext-a\/widget-a crashed while rendering/);
+
+      // Same instance (no key change) now asked to render a different,
+      // healthy widget — mirrors an unkeyed `DockBody`/`WidgetErrorBoundary`
+      // on tab switch.
+      await act(async () => {
+        root!.render(
+          <WidgetErrorBoundary label="ext-b/widget-b">
+            <HealthyWidget />
+          </WidgetErrorBoundary>,
+        );
+      });
+
+      const html = container.innerHTML;
+      assert.doesNotMatch(
+        html,
+        /widget B content/,
+        'documents the defect: B never renders while the stale instance holds an error',
+      );
+      assert.match(
+        html,
+        /widget A blew up/,
+        'documents the defect: A\'s stale error text is still shown for B\'s slot',
+      );
+    } finally {
+      await act(async () => {
+        root?.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it('does not leak a stale error onto the next widget after a key-based remount', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | undefined;
+
+    try {
+      await act(async () => {
+        root = createRoot(container);
+        root.render(
+          <WidgetErrorBoundary key="ext-a/widget-a" label="ext-a/widget-a">
+            <ThrowingWidget />
+          </WidgetErrorBoundary>,
+        );
+      });
+
+      const crashedHtml = container.innerHTML;
+      assert.match(crashedHtml, /ext-a\/widget-a crashed while rendering/);
+      assert.match(crashedHtml, /widget A blew up/);
+
+      // Switch to a different, healthy widget. In the real call site this
+      // is a `key` change (our chosen fix), which forces React to discard
+      // the old boundary instance and mount a fresh one.
+      await act(async () => {
+        root!.render(
+          <WidgetErrorBoundary key="ext-b/widget-b" label="ext-b/widget-b">
+            <HealthyWidget />
+          </WidgetErrorBoundary>,
+        );
+      });
+
+      const healthyHtml = container.innerHTML;
+      assert.match(healthyHtml, /widget B content/, 'healthy widget B must render');
+      assert.doesNotMatch(
+        healthyHtml,
+        /crashed while rendering/,
+        'no stale crash banner should survive the switch',
+      );
+      assert.doesNotMatch(
+        healthyHtml,
+        /widget A blew up/,
+        'widget A\'s error text must not leak onto widget B',
+      );
+    } finally {
+      await act(async () => {
+        root?.unmount();
+      });
+      container.remove();
+    }
+  });
+
+  it('still catches a genuine render crash', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | undefined;
+
+    try {
+      await act(async () => {
+        root = createRoot(container);
+        root.render(
+          <WidgetErrorBoundary key="ext-c/widget-c" label="ext-c/widget-c">
+            <ThrowingWidget />
+          </WidgetErrorBoundary>,
+        );
+      });
+
+      const html = container.innerHTML;
+      assert.match(html, /ext-c\/widget-c crashed while rendering/);
+      assert.match(html, /widget A blew up/);
+    } finally {
+      await act(async () => {
+        root?.unmount();
+      });
+      container.remove();
+    }
+  });
+});

--- a/apps/viewer/src/components/extensions/widget/WidgetErrorBoundary.tsx
+++ b/apps/viewer/src/components/extensions/widget/WidgetErrorBoundary.tsx
@@ -11,6 +11,22 @@
  * Designed as a *narrow* boundary: the host catches everything else
  * via the dispatcher's per-command try/catch. This boundary covers
  * render-time failures (bad bindings, missing fields, etc.).
+ *
+ * Deliberately does NOT self-heal: once `getDerivedStateFromError` sets
+ * `state.error`, nothing inside this component ever clears it — there is
+ * no `componentDidUpdate` reset on prop change. That is intentional, not
+ * an oversight: this boundary cannot tell "the same widget re-rendering
+ * after a transient failure" from "the widget still throws every render"
+ * without re-running the (possibly still-broken) children to find out,
+ * which would turn a caught crash into a crash-retry loop.
+ *
+ * Instead, callers that want a fresh attempt at *different* content are
+ * expected to remount by changing `key` — see `ExtensionDockHost`, which
+ * keys this boundary (and its `DockBody` parent) on the widget's
+ * identity (`extensionId/widget` path) so switching the active dock tab
+ * discards a crashed instance and mounts a new one, while re-rendering
+ * the *same* widget (unchanged key) correctly keeps showing its error
+ * instead of silently retrying forever.
  */
 
 import { Component, type ErrorInfo, type ReactNode } from 'react';


### PR DESCRIPTION
## Summary

A crashed extension widget masked every widget viewed afterward in the same dock slot.

**Root cause.** `WidgetErrorBoundary` (`apps/viewer/src/components/extensions/widget/WidgetErrorBoundary.tsx:35-45`) sets `state.error` in `getDerivedStateFromError` and never clears it — no `key`-based remount, no `componentDidUpdate` reset. Its only caller, `DockBody` in `ExtensionDockHost.tsx`, rendered it (and `DockBody` itself, at `:99`) without a `key`, so switching the active dock tab reused the same React instance.

**Reproduction** (react-dom + happy-dom, `WidgetErrorBoundary.test.tsx`, "characterizes the defect" case): render with `label="ext-a/widget-a"` and a throwing child:

```
ext-a/widget-a crashed while rendering
widget A blew up
```

Re-render the *same instance* with `label="ext-b/widget-b"` and healthy content:

```
ext-b/widget-b crashed while rendering   <-- stale label, wrong widget name
widget A blew up                        <-- widget B never rendered at all
```

Widget B's content never appears; the panel stays stuck on widget A's error until the whole dock unmounts.

**Fix shape chosen: remount via `key` at the call site**, not a `componentDidUpdate` reset inside the boundary. Both `DockBody` (`ExtensionDockHost.tsx:99`) and `WidgetErrorBoundary` (`ExtensionDockHost.tsx:211-217`) are now keyed on the widget's identity (`extensionId`/`widget` path — the same string already shown in the fallback label). Rationale: the boundary itself has no reliable way to distinguish "this is the same widget being asked to try again" from "this is a different widget"; that distinction lives in the caller, which already computes exactly that identity for the fallback label. A `key` change is the idiomatic way to tell React "this is conceptually a different subtree," and it also fixes the `DockBody`-level state reuse (loading/error text) as a side effect of the same key, per its own local state.

**Crash-retry-loop check.** The key is derived from `extensionId`/`widget`, not anything that changes on every render (e.g. a timestamp or the widget JSON itself). So:
- Switching tabs → key changes → remounts → fresh attempt at the new widget. Correct.
- The *same* widget re-rendering (e.g. a host state update) → key unchanged → the crashed instance is reused → the boundary keeps showing its already-caught error and does **not** re-run the still-broken children. No infinite remount/crash-retry loop.

This is documented directly in `WidgetErrorBoundary`'s doc comment, since the "why doesn't this self-heal" question is exactly the thing a future reader will ask.

## Also found, not fixed here (per the review that surfaced this defect)

`FlavorMergeDialog.tsx:108,169` default-selects the "Ours" chip and `handleApply` treats `'ours'` as a no-op — valid only for lens/query/keybinding/setting conflicts. For `extension_version`, `merge.ts:113-119` picks the higher semver (possibly "theirs"), and for `extension_capabilities` the default is `intersectCaps` (neither side). So the chip can misreport the outcome and does not actually control it. That needs a design decision on what the chip should mean per conflict kind — separate from this fix, flagging for maintainer triage.

## Test plan

- [x] `apps/viewer/src/components/extensions/widget/WidgetErrorBoundary.test.tsx` (new): characterizes the pre-fix defect (unkeyed reuse — masking reproduced), confirms the keyed call-site pattern clears a stale error when switching widgets, and confirms a genuine crash is still caught.
- [x] `apps/viewer/src/components/extensions/ExtensionExportSlot.test.tsx` — unaffected, still green (8/8 across both files).
- [x] `tsc --noEmit` in `apps/viewer` — clean.
- [x] `oxlint` on the changed files — clean.
- [ ] Full `apps/viewer` suite — running in CI; the local run did not finish within this session's budget (see PR comment / CI status as authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
