### PR TITLE
fix(mcp): keep the playground chip list from disagreeing with the upload store on duplicate basenames

### DIFF
--- a/.changeset/mcp-playground-attach-dupes.md
+++ b/.changeset/mcp-playground-attach-dupes.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix the MCP playground chat attaching two files with the same basename in one batch showing two chips for what the upload store treats as one attachment.
+
+`playground-uploads.ts`'s `UploadStore` intentionally de-dupes uploads by basename (last file wins — see its `add()` comment), but `PlaygroundChat`'s `attachFiles` tracked its own `pendingAttachments` list independently, pushing every resolved entry with no such de-dupe. Attaching `spec.ids` (A) and `spec.ids` (B) in one drop produced two chips while the store held only B: the first file's content became unreachable through `ids_validate`/`ids_explain` (which resolve by name through the store) even though its chip was still shown as attached, the duplicate `key={f.name}` in the chip list violated React's key-uniqueness contract, and clicking Remove on either chip — filtering by name — dropped both at once.
+
+The chat panel now tracks only the pending *names* for the current turn and projects them through the store's live contents on every render, so the chip list can no longer disagree with what the store actually holds — there is structurally only one thing to render per name. The store's last-wins behavior is unchanged.
+
+The outbound chat-turn text was never affected: `describeAttachment` reads each in-memory attachment object directly, not through the store.

--- a/apps/viewer/src/components/mcp/PlaygroundChat.tsx
+++ b/apps/viewer/src/components/mcp/PlaygroundChat.tsx
@@ -52,7 +52,13 @@ import {
   type ToolDispatchResult,
 } from './playground-dispatcher';
 import { playgroundFiles, formatBytes as formatFileBytes } from './playground-files';
-import { playgroundUploads, usePlaygroundUploads, type UploadedFile } from './playground-uploads';
+import {
+  playgroundUploads,
+  usePlaygroundUploads,
+  mergeAttachmentNames,
+  resolveAttachments,
+  type UploadedFile,
+} from './playground-uploads';
 import { Paperclip, X } from 'lucide-react';
 
 const MAX_TOOL_CALLS = 25;
@@ -138,10 +144,18 @@ export function PlaygroundChat({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
   // Files attached since the last send. They land in the playgroundUploads
-  // store (so the dispatcher can resolve them by name) AND get listed in
-  // a "to send" array we drain on each submit.
+  // store (so the dispatcher can resolve them by name); we track only the
+  // NAMES pending this turn and project them through the store's current
+  // contents on every render. That projection is what keeps the chip list
+  // structurally unable to disagree with the store: the store already
+  // collapses same-basename uploads to one entry (last-wins), so a name
+  // list can never show two chips — or stale content — for one basename.
   const uploads = usePlaygroundUploads();
-  const [pendingAttachments, setPendingAttachments] = useState<UploadedFile[]>([]);
+  const [pendingNames, setPendingNames] = useState<string[]>([]);
+  const pendingAttachments = useMemo(
+    () => resolveAttachments(uploads, pendingNames),
+    [uploads, pendingNames],
+  );
 
   // Swapping the loaded model invalidates every expressId already in the
   // transcript: they are unique inside ONE STEP file, not across files. The
@@ -251,7 +265,7 @@ export function PlaygroundChat({
     if ((!trimmed && pendingAttachments.length === 0) || isStreaming) return;
     const attachedThisTurn = pendingAttachments;
     setInput('');
-    setPendingAttachments([]);
+    setPendingNames([]);
     void send(trimmed || '(see attached file)', attachedThisTurn);
   };
 
@@ -270,7 +284,9 @@ export function PlaygroundChat({
         setError(`Failed to read ${f.name}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
-    if (list.length > 0) setPendingAttachments((prev) => [...prev, ...list]);
+    if (list.length > 0) {
+      setPendingNames((prev) => mergeAttachmentNames(prev, list.map((e) => e.name)));
+    }
   }, []);
 
   /** Per-kind system note so the agent knows what to do with the file
@@ -370,7 +386,7 @@ export function PlaygroundChat({
                   type="button"
                   onClick={() => {
                     playgroundUploads.remove(f.name);
-                    setPendingAttachments((prev) => prev.filter((x) => x.name !== f.name));
+                    setPendingNames((prev) => prev.filter((n) => n !== f.name));
                   }}
                   className="ml-0.5 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full text-white/50 hover:bg-white/10 hover:text-white"
                   aria-label={`Remove ${f.name}`}

--- a/apps/viewer/src/components/mcp/playground-attach-dupes.test.tsx
+++ b/apps/viewer/src/components/mcp/playground-attach-dupes.test.tsx
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Two different files sharing a basename, attached in one batch, must not
+ * make the UI disagree with `playgroundUploads` about what is attached.
+ *
+ * The store (`playground-uploads.ts`) already de-dupes by basename,
+ * last-wins, on purpose (see the comment at `UploadStore.add`). The bug is
+ * that `PlaygroundChat`'s `attachFiles` pushed every resolved entry into its
+ * own `pendingAttachments` list with no such de-dupe, so the chip list and
+ * the store disagreed: two chips for one store entry, a duplicate React
+ * key, and a Remove click that filtered by name and so dropped both chips
+ * at once — see the PR body for the full write-up.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { PlaygroundChat } from './PlaygroundChat.js';
+import { playgroundUploads } from './playground-uploads.js';
+
+function makeFile(name: string, content: string): File {
+  return new File([content], name, { type: 'text/plain' });
+}
+
+async function attach(input: HTMLInputElement, files: File[]): Promise<void> {
+  Object.defineProperty(input, 'files', { value: files, configurable: true });
+  await act(async () => {
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    // attachFiles awaits file.text() per file — flush those microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+function removeButtons(container: HTMLElement, name: string): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll(`button[aria-label="Remove ${name}"]`));
+}
+
+function allRemoveButtons(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll('button[aria-label^="Remove "]'));
+}
+
+describe('duplicate-basename chat attachments', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    playgroundUploads.clear();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    playgroundUploads.clear();
+  });
+
+  it('renders exactly one chip for a duplicate basename, matching the store', async () => {
+    await act(async () => {
+      root.render(<PlaygroundChat model={null} />);
+    });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    assert.ok(input, 'file input must be present');
+
+    await attach(input, [makeFile('spec.ids', '<A/>'), makeFile('spec.ids', '<B/>')]);
+
+    // The store's own last-wins de-dupe: only <B/> is reachable.
+    const resolved = playgroundUploads.resolve('spec.ids');
+    assert.ok(resolved, 'store must have an entry for spec.ids');
+    assert.equal(resolved!.text, '<B/>', 'store keeps the second file, per its documented last-wins rule');
+
+    // The UI must agree: exactly one chip, not two.
+    assert.equal(
+      removeButtons(container, 'spec.ids').length,
+      1,
+      'exactly one chip should be rendered for a duplicate basename',
+    );
+  });
+
+  it('removing the duplicate chip leaves an unrelated attachment intact', async () => {
+    await act(async () => {
+      root.render(<PlaygroundChat model={null} />);
+    });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await attach(input, [
+      makeFile('dup.ids', '<A/>'),
+      makeFile('dup.ids', '<B/>'),
+      makeFile('keep.ids', '<C/>'),
+    ]);
+
+    assert.equal(allRemoveButtons(container).length, 2, 'one chip per distinct name, not one per file');
+
+    const dupButtons = removeButtons(container, 'dup.ids');
+    assert.equal(dupButtons.length, 1, 'the duplicate name must render as a single chip');
+    await act(async () => {
+      dupButtons[0]!.click();
+    });
+
+    assert.equal(allRemoveButtons(container).length, 1, 'only the dup.ids chip should be removed');
+    assert.equal(removeButtons(container, 'keep.ids').length, 1, 'keep.ids must survive removing dup.ids');
+    assert.ok(playgroundUploads.resolve('keep.ids'), 'keep.ids must still resolve through the store');
+    assert.equal(playgroundUploads.resolve('dup.ids'), null, 'dup.ids must be gone from the store too');
+  });
+
+  it('does not re-show a prior turn\'s attachment chip after send, even though the store keeps it', async () => {
+    // The store deliberately outlives a send (so ids_validate can still
+    // resolve an attachment from an earlier turn — playgroundUploads.clear()
+    // is never called from onSubmit). The chip list must project only the
+    // CURRENT turn's pending names through the store, not "everything the
+    // store has ever seen" — else every past attachment reappears as a
+    // chip forever.
+    await act(async () => {
+      root.render(<PlaygroundChat model={null} />);
+    });
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    const form = container.querySelector('form') as HTMLFormElement;
+    assert.ok(textarea && form);
+
+    await attach(input, [makeFile('first.ids', '<A/>')]);
+    assert.equal(allRemoveButtons(container).length, 1, 'first.ids chip is pending');
+
+    // Submitting clears pendingNames synchronously in onSubmit, even though
+    // send() itself will bail out immediately after (no model loaded) —
+    // that bail-out happens strictly after the clear, so it doesn't affect
+    // what we're testing here.
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    assert.equal(allRemoveButtons(container).length, 0, 'chip list must clear after send');
+    assert.ok(playgroundUploads.resolve('first.ids'), 'the store must still hold it for later ids_path resolution');
+
+    await attach(input, [makeFile('second.ids', '<B/>')]);
+    assert.equal(allRemoveButtons(container).length, 1, 'only the new attachment is pending, not the old one');
+    assert.equal(removeButtons(container, 'first.ids').length, 0, 'the prior turn\'s attachment must not resurface as a chip');
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-uploads.test.ts
+++ b/apps/viewer/src/components/mcp/playground-uploads.test.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `mergeAttachmentNames` / `resolveAttachments` are the two pure functions
+ * PlaygroundChat uses to keep its pending-attachment chip list from ever
+ * disagreeing with the `UploadStore`'s own last-wins de-dupe by basename
+ * (see the integration test in playground-attach-dupes.test.tsx for the
+ * end-to-end repro of the bug this closes).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeAttachmentNames, resolveAttachments, type UploadedFile } from './playground-uploads.js';
+
+function entry(name: string, text: string): UploadedFile {
+  return { name, mimeType: 'text/plain', size: text.length, text, uploadedAt: 0 };
+}
+
+describe('mergeAttachmentNames', () => {
+  it('appends new names in order', () => {
+    assert.deepEqual(mergeAttachmentNames([], ['a.ids', 'b.ids']), ['a.ids', 'b.ids']);
+    assert.deepEqual(mergeAttachmentNames(['a.ids'], ['b.ids']), ['a.ids', 'b.ids']);
+  });
+
+  it('collapses a duplicate name within one added batch to a single entry', () => {
+    assert.deepEqual(mergeAttachmentNames([], ['spec.ids', 'spec.ids']), ['spec.ids']);
+  });
+
+  it('does not re-add a name already pending', () => {
+    assert.deepEqual(mergeAttachmentNames(['spec.ids'], ['spec.ids', 'other.ids']), ['spec.ids', 'other.ids']);
+  });
+});
+
+describe('resolveAttachments', () => {
+  it('projects each pending name to its current store entry', () => {
+    const uploads = [entry('a.ids', 'A'), entry('b.ids', 'B')];
+    assert.deepEqual(
+      resolveAttachments(uploads, ['b.ids', 'a.ids']).map((u) => u.text),
+      ['B', 'A'],
+    );
+  });
+
+  it('drops a name whose upload is no longer in the store', () => {
+    const uploads = [entry('a.ids', 'A')];
+    assert.deepEqual(resolveAttachments(uploads, ['a.ids', 'gone.ids']).map((u) => u.name), ['a.ids']);
+  });
+
+  it('reflects the store last-wins content for a name, not a stale copy', () => {
+    // Two uploads that shared a basename collapse to ONE store entry
+    // (UploadStore.add's job); resolveAttachments must show whatever the
+    // store currently holds for that name — the second file's content.
+    const uploads = [entry('spec.ids', '<B/>')];
+    const resolved = resolveAttachments(uploads, ['spec.ids']);
+    assert.equal(resolved.length, 1);
+    assert.equal(resolved[0]!.text, '<B/>');
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-uploads.ts
+++ b/apps/viewer/src/components/mcp/playground-uploads.ts
@@ -109,6 +109,43 @@ function isTextLike(name: string, mimeType: string): boolean {
   return ext === 'ifc' || ext === 'ids' || ext === 'csv' || ext === 'tsv' || ext === 'xml' || ext === 'json' || ext === 'txt' || ext === 'md';
 }
 
+/** Merge newly-attached names into a pending list, deduping by name. A
+ *  caller (the chat panel) tracks WHICH names are pending as a chat turn's
+ *  attachments; it must never track a second copy of the file contents,
+ *  because `UploadStore.add` above already collapses same-name uploads to
+ *  one entry (last-wins) — keeping only names here makes it structurally
+ *  impossible for the pending list to disagree with the store about how
+ *  many distinct files are attached (#mcp-attach-dupes). */
+export function mergeAttachmentNames(prev: readonly string[], added: readonly string[]): string[] {
+  const seen = new Set(prev);
+  const next = [...prev];
+  for (const name of added) {
+    if (!seen.has(name)) {
+      seen.add(name);
+      next.push(name);
+    }
+  }
+  return next;
+}
+
+/** Project a pending-name list through the store's CURRENT contents, so the
+ *  rendered chip for a name always shows whatever the store actually holds
+ *  for it (i.e. the last file attached under that basename). A name whose
+ *  upload was removed, or never landed, drops out rather than rendering a
+ *  stale or undefined entry. */
+export function resolveAttachments(
+  uploads: readonly UploadedFile[],
+  names: readonly string[],
+): UploadedFile[] {
+  const byName = new Map(uploads.map((u) => [u.name, u] as const));
+  const out: UploadedFile[] = [];
+  for (const name of names) {
+    const u = byName.get(name);
+    if (u) out.push(u);
+  }
+  return out;
+}
+
 function guessMimeType(name: string): string {
   const ext = name.toLowerCase().split('.').pop() ?? '';
   switch (ext) {


### PR DESCRIPTION
## Repro

Attach two different files that share a basename in one batch — e.g. drop `spec.ids` (content A) and `spec.ids` (content B) onto the MCP playground chat together.

`UploadStore.add` (`playground-uploads.ts:56-57`) intentionally de-dupes by basename, last-wins (documented in its own comment): the store ends up holding one entry for `spec.ids`, content B. But `PlaygroundChat.tsx`'s `attachFiles` pushed every resolved entry into its own `pendingAttachments` list with no such de-dupe, so `pendingAttachments.length === 2` while `playgroundUploads.list().length === 1`.

## Three consequences

1. The first file's content (A) is unreachable — anything resolving an attachment by path (`ids_validate` / `ids_explain` via `playgroundUploads.resolve()`) only ever sees B, while A's chip is still displayed as if attached.
2. `key={f.name}` in the chip list produced duplicate React keys (`Encountered two children with the same key, 'spec.ids'` — reproduced live in the new test, see below).
3. The chip's Remove button filtered `pendingAttachments` by `x.name !== f.name`, so clicking Remove on **either** duplicate chip dropped **both**.

**Non-consequence:** the outbound chat-turn text is not corrupted. `describeAttachment` runs on the in-memory `pendingAttachments` objects, each of which carries its own correct `.text` — it is never re-resolved through the store.

## Fix

This is a "two paths that must agree" shape: the store and the UI list independently maintained the same invariant, and only the UI got it wrong. Rather than patch the symptom (de-dupe `pendingAttachments` by name too), the chip list now derives from the store: `PlaygroundChat` tracks only the pending **names** for the current turn (`pendingNames: string[]`) and projects them through the store's live contents on every render via two new pure helpers in `playground-uploads.ts`:

- `mergeAttachmentNames(prev, added)` — dedupes names when merging a new attach batch into the pending list.
- `resolveAttachments(uploads, names)` — projects pending names through the store's *current* contents, so a name always shows whatever the store actually holds for it.

Because the store already collapses same-basename uploads to one entry, there is now structurally only one thing to render per name — the chip list cannot drift from the store the way the old parallel array could. `UploadStore`'s last-wins behavior is untouched.

Once the UI list de-dupes by name, `Remove` (which still filters `pendingNames` by name) is correct on its own — verified by a dedicated test (`removing the duplicate chip leaves an unrelated attachment intact`), not just assumed.

## Evidence: RED → GREEN

New test file `playground-attach-dupes.test.tsx` mounts the real `PlaygroundChat` component (happy-dom + `react-dom/client`) and drives the actual file-input `change` event with two `File`s sharing a basename — this is the real bug, not a simulation of it.

Run against **unmodified** code (`git show HEAD:...` swapped in), scoped test files only:
```
not ok 1 - renders exactly one chip for a duplicate basename, matching the store
    exactly one chip should be rendered for a duplicate basename
    2 !== 1
not ok 2 - removing the duplicate chip leaves an unrelated attachment intact
    one chip per distinct name, not one per file
    3 !== 2
# Encountered two children with the same key, `spec.ids`.
# Encountered two children with the same key, `dup.ids`.
```
(`playground-uploads.test.ts` also fails to even load pre-fix: `mergeAttachmentNames` doesn't exist yet.)

After the fix: all pass, and the duplicate-key warning is gone.

## Mutation table

One call site mutated at a time, scoped run (`playground-attach-dupes.test.tsx` + `playground-uploads.test.ts`, 9 tests total), failing test **names** before/after each mutation, reverted between each:

| Site | Mutation | Tests killed |
|---|---|---|
| `mergeAttachmentNames` dedup guard | drop the `if (!seen.has(name))` check | 4: `renders exactly one chip…`, `removing the duplicate chip…`, `collapses a duplicate name within one added batch…`, `does not re-add a name already pending` |
| `resolveAttachments` lookup key | key the map by `u.name + '!'` | 6: `renders exactly one chip…`, `removing the duplicate chip…`, `does not re-show a prior turn's attachment chip…`, `projects each pending name…`, `drops a name whose upload is no longer in the store`, `reflects the store last-wins content…` |
| `PlaygroundChat`'s `useMemo` call | `resolveAttachments(uploads, pendingNames)` → `uploads` | 1: `does not re-show a prior turn's attachment chip after send, even though the store keeps it` |
| `attachFiles`'s merge call | `mergeAttachmentNames(prev, …)` → raw `[...prev, ...names]` (the original bug) | 2: `renders exactly one chip…`, `removing the duplicate chip…` |
| `onSubmit`'s clear | drop `setPendingNames([])` | 1: `does not re-show a prior turn's attachment chip after send…` |
| Remove button's `setPendingNames` filter | no-op (`(prev) => prev`) | **0 — unpinned.** `resolveAttachments` filters pending names against the store's *live* contents on every render, and the click handler's `playgroundUploads.remove(f.name)` already evicts the entry from the store — so the chip still disappears via that path regardless of whether `pendingNames` itself gets updated. This call remains for hygiene (bounding `pendingNames`' growth across a session) but is not currently exercised by any test that distinguishes it from a no-op. Flagging honestly rather than claiming coverage I don't have. |

## Test counts

- `packages/mcp` suite (untouched by this change): 26 files / 267 tests, pass — before and after.
- `apps/viewer/src/components/mcp/*.test.{ts,tsx}` (11 → 12 files with this PR): **before** (original code, original 10 files) 88/88 pass; **after** (fixed code, 12 files including the 2 new ones) 97/97 pass.
- `tsc --noEmit` in `apps/viewer`: no new errors from this change (10 pre-existing errors, all in unrelated cesium-solar / oauth-pkce code, none touching `mcp/`).

Changeset: `.changeset/mcp-playground-attach-dupes.md`, patch for `@ifc-lite/viewer`.

## Typecheck + lint (foreground)

`npx tsc --noEmit` in `apps/viewer`: 10 pre-existing errors, all in unrelated cesium-solar / `@ifc-lite/oauth-pkce` code (missing `@ifc-lite/solar` module, implicit-`any` params) — none in `mcp/`, none introduced by this change. `pnpm exec oxlint --config .oxlintrc.json --format default` against the 4 touched TS/TSX files: 0 errors, 1 pre-existing warning (`unicorn/no-useless-spread` on a `style={{ ...{ fontFamily: … } }}` spread at `PlaygroundChat.tsx` — present unchanged since `upstream/main`, not part of this diff). The changeset's first line was confirmed byte-for-byte `---` with no license header. Test verification in this PR was scoped to `apps/viewer/src/components/mcp/` (11 → 12 files), not the full `apps/viewer` suite — the `packages/mcp` suite (267 tests) was run in full since this change is entirely in `apps/viewer`.
