### PR TITLE
test(ifcx): pin quantity classification against the real IFC5 corpus

### DIFF
--- a/.changeset/ifcx-pin-quantity-classification.md
+++ b/.changeset/ifcx-pin-quantity-classification.md
@@ -1,0 +1,25 @@
+---
+'@ifc-lite/ifcx': patch
+---
+
+Pin `isQuantityProperty` / `routesToQuantityTable` quantity-vs-property
+classification against real third-party IFC5 fixtures (buildingSMART sample
+scenes under `tests/models/ifc5/`), not our own writer's output.
+
+`exactQuantityNames` and `suffixPatterns` in `property-extractor.ts` are two
+hand-maintained, asymmetric name lists (e.g. `Height`/`Width`/`Depth`/
+`Thickness` are exact-match only, absent from the suffix list) with no prior
+test coverage in the package. A corpus-wide census of every
+`bsi::ifc::prop::*` short name across the whole downloaded fixture set found
+no real misclassification: every name present (`Height`, `Width`, `Depth`,
+`Volume`, `Length`, `NetArea`, `NetSideArea`, `NetVolume`,
+`CrossSectionArea`, plus non-quantity names like `ElevationOfRefHeight`,
+`ElevationOfTerrain`, `NumberOfStoreys`) already classifies correctly — this
+is a coverage gap, not a bug fix.
+
+New tests pin the exact quantity/property split for `Hello_Wall_hello-wall.ifcx`
+and the PCERT `Building-Architecture`/`Building-Structural` sample scenes by
+value, so a future edit to either list can no longer silently regress the
+split (deleting `Height` from `exactQuantityNames` previously left the
+package's whole suite green while dropping Hello Wall's extracted quantities
+from 10 to 5).

--- a/packages/ifcx/src/quantity-classification.test.ts
+++ b/packages/ifcx/src/quantity-classification.test.ts
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pins `isQuantityProperty` / `routesToQuantityTable` classification against
+ * real third-party IFC5 fixtures (buildingSMART sample scenes), not against
+ * our own writer's output. `exactQuantityNames` and `suffixPatterns` in
+ * property-extractor.ts are hand-maintained name lists with no prior test
+ * coverage — a corpus-wide census of every `bsi::ifc::prop::*` short name
+ * across tests/models/ifc5/ found no real misclassification (every name in
+ * the corpus already classifies correctly), so this is a coverage gap, not
+ * a bug fix. These tests pin the specific quantity/property split so a
+ * future edit to either list cannot silently regress it.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve, dirname } from 'node:path';
+import { parseIfcx } from './index.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const FIXTURES_DIR = resolve(REPO_ROOT, 'tests/models/ifc5');
+const HELLO_WALL_PATH = resolve(FIXTURES_DIR, 'Hello_Wall_hello-wall.ifcx');
+const PCERT_ARCH_PATH = resolve(FIXTURES_DIR, 'PCERT-Sample-Scene_Building-Architecture.ifcx');
+const PCERT_STRUCT_PATH = resolve(FIXTURES_DIR, 'PCERT-Sample-Scene_Building-Structural.ifcx');
+
+// Per AGENTS.md §9 fixtures are fetched on demand; skip the suite cleanly
+// when the bytes aren't on disk so a fresh checkout doesn't crash here.
+const FIXTURES_AVAILABLE =
+  existsSync(HELLO_WALL_PATH) && existsSync(PCERT_ARCH_PATH) && existsSync(PCERT_STRUCT_PATH);
+
+function toArrayBuffer(buffer: Buffer): ArrayBuffer {
+  const copy = new ArrayBuffer(buffer.byteLength);
+  new Uint8Array(copy).set(buffer);
+  return copy;
+}
+
+async function parseFixture(path: string) {
+  const buffer = readFileSync(path);
+  return parseIfcx(toArrayBuffer(buffer));
+}
+
+function quantitiesFor(
+  result: Awaited<ReturnType<typeof parseFixture>>,
+  path: string
+): Array<{ qset: string; name: string; value: unknown }> {
+  const id = result.pathToId.get(path);
+  assert.ok(id !== undefined, `path ${path} present in parsed entity table`);
+  return result.quantities
+    .getForEntity(id!)
+    .flatMap((qset) => qset.quantities.map((q) => ({ qset: qset.name, name: q.name, value: q.value })));
+}
+
+function propertiesFor(
+  result: Awaited<ReturnType<typeof parseFixture>>,
+  path: string
+): Array<{ name: string; value: unknown }> {
+  const id = result.pathToId.get(path);
+  assert.ok(id !== undefined, `path ${path} present in parsed entity table`);
+  return result.properties.getForEntity(id!).flatMap((pset) => pset.properties.map((p) => ({ name: p.name, value: p.value })));
+}
+
+describe(
+  'quantity classification — pinned against real IFC5 fixtures',
+  { skip: !FIXTURES_AVAILABLE && 'tests/models/ifc5/*.ifcx missing — run `pnpm fixtures`' },
+  () => {
+    it('Hello_Wall: legacy flat bsi::ifc::prop keys extract exactly Volume+Height per element (10 quantities)', async () => {
+      const result = await parseFixture(HELLO_WALL_PATH);
+
+      const wall = quantitiesFor(result, '93791d5d-5beb-437b-b8ec-2f1f0ba4bf3b');
+      assert.deepStrictEqual(
+        wall.map((q) => q.name).sort(),
+        ['Height', 'Volume']
+      );
+      assert.strictEqual(wall.find((q) => q.name === 'Height')?.value, 3);
+      assert.strictEqual(wall.find((q) => q.name === 'Volume')?.value, 2.783999976);
+
+      const space = quantitiesFor(result, 'e3035b71-bd9f-4cdc-86fd-b56e2f4605b6');
+      assert.deepStrictEqual(
+        space.map((q) => q.name).sort(),
+        ['Height', 'Volume']
+      );
+      assert.strictEqual(space.find((q) => q.name === 'Height')?.value, 3);
+      assert.strictEqual(space.find((q) => q.name === 'Volume')?.value, 120);
+
+      const window = quantitiesFor(result, '25503984-6605-43a1-8597-eae657ff5bea');
+      assert.deepStrictEqual(
+        window.map((q) => q.name).sort(),
+        ['Height', 'Volume']
+      );
+      assert.strictEqual(window.find((q) => q.name === 'Height')?.value, 1.2);
+      assert.strictEqual(window.find((q) => q.name === 'Volume')?.value, 0.025999999592);
+
+      // Whole-file total: wall + space + 3 windows (A, B, and the 3rd
+      // window authored directly in this file), each contributing exactly
+      // Volume + Height => 10 quantity rows total.
+      const allIds = new Set(result.pathToId.values());
+      let total = 0;
+      for (const id of allIds) {
+        for (const qset of result.quantities.getForEntity(id)) {
+          total += qset.quantities.length;
+        }
+      }
+      assert.strictEqual(total, 10, 'exactly 10 quantities extracted across the whole file');
+    });
+
+    it('PCERT Building-Architecture: Depth/Width/Length/NetArea/NetSideArea/NetVolume classify as quantities', async () => {
+      const result = await parseFixture(PCERT_ARCH_PATH);
+
+      // Slab (Qto_SlabBaseQuantities): NetVolume, Depth, NetArea.
+      const slab = quantitiesFor(result, 'fd6c02d8-3a65-4a35-b52f-c44462cf2d51');
+      assert.deepStrictEqual(
+        slab.map((q) => q.name).sort(),
+        ['Depth', 'NetArea', 'NetVolume']
+      );
+      assert.strictEqual(slab.find((q) => q.name === 'NetVolume')?.value, 6.4375);
+      assert.strictEqual(slab.find((q) => q.name === 'Depth')?.value, 0.25);
+      assert.strictEqual(slab.find((q) => q.name === 'NetArea')?.value, 25.75);
+
+      // Wall (Qto_WallBaseQuantities): NetVolume, Width, Length, NetSideArea.
+      const wall = quantitiesFor(result, '4a68ae33-91b6-41df-be94-04a42c5c605f');
+      assert.deepStrictEqual(
+        wall.map((q) => q.name).sort(),
+        ['Length', 'NetSideArea', 'NetVolume', 'Width']
+      );
+      assert.strictEqual(wall.find((q) => q.name === 'NetVolume')?.value, 1.269265);
+      assert.strictEqual(wall.find((q) => q.name === 'Width')?.value, 0.2);
+      assert.strictEqual(wall.find((q) => q.name === 'Length')?.value, 1.8);
+      assert.strictEqual(wall.find((q) => q.name === 'NetSideArea')?.value, 6.346325);
+    });
+
+    it('PCERT Building-Architecture: ElevationOfRefHeight/ElevationOfTerrain/NumberOfStoreys stay properties, not quantities', async () => {
+      const result = await parseFixture(PCERT_ARCH_PATH);
+      const buildingPath = '26fd704c-772c-422c-b09c-cc8243205408';
+
+      // These names all end in a token ("Height") that also appears in
+      // exactQuantityNames — but they are IfcSite/IfcBuilding attributes,
+      // not Qto_ quantities, and must never route to the quantity table.
+      const quantities = quantitiesFor(result, buildingPath);
+      assert.deepStrictEqual(quantities, [], 'building entity carries zero quantities');
+
+      const props = propertiesFor(result, buildingPath);
+      assert.strictEqual(props.find((p) => p.name === 'ElevationOfRefHeight')?.value, 0);
+      assert.strictEqual(props.find((p) => p.name === 'ElevationOfTerrain')?.value, 0);
+      assert.strictEqual(props.find((p) => p.name === 'NumberOfStoreys')?.value, 1);
+    });
+
+    it('PCERT Building-Structural: CrossSectionArea classifies as a quantity alongside Length and NetVolume', async () => {
+      const result = await parseFixture(PCERT_STRUCT_PATH);
+      const beam = quantitiesFor(result, '3d8e9f86-e116-4190-91ed-5a3a2f821730');
+      assert.deepStrictEqual(
+        beam.map((q) => q.name).sort(),
+        ['CrossSectionArea', 'Length', 'NetVolume']
+      );
+      assert.strictEqual(beam.find((q) => q.name === 'CrossSectionArea')?.value, 0.02);
+      assert.strictEqual(beam.find((q) => q.name === 'Length')?.value, 2.7);
+      assert.strictEqual(beam.find((q) => q.name === 'NetVolume')?.value, 0.054);
+    });
+  }
+);


### PR DESCRIPTION
## Outcome

Coverage gap, not a live defect.

`isQuantityProperty` (`packages/ifcx/src/property-extractor.ts:241-262`) uses two hand-maintained name lists — `exactQuantityNames` and `suffixPatterns` — with no prior test coverage in the package. The lists are asymmetric (`Height`/`Width`/`Depth`/`Thickness` are exact-match only, not in the suffix list), which raised the question of whether real third-party files hit a misclassification.

## Corpus-wide census

Walked every `bsi::ifc::prop::*` key across the full downloaded `tests/models/ifc5/` corpus (47 `.ifcx` files). Distinct short names found, with file counts:

| name | isQuantityProperty | files | note |
|---|---|---|---|
| Volume | true | 12 | exact + suffix |
| Height | true | 2 | exact only |
| Width | true | 2 | exact only |
| Depth | true | 2 | exact only |
| Length | true | 3 | exact + suffix |
| NetArea | true | 2 | suffix |
| NetSideArea | true | 2 | suffix |
| NetVolume | true | 3 | suffix |
| CrossSectionArea | true | 2 | exact + suffix (redundant) |
| ElevationOfRefHeight | **false** | 3 | ends in "Height" but correctly excluded — it's an `IfcSite`/`IfcBuilding` attribute, not a `Qto_` quantity |
| ElevationOfTerrain | false | 3 | property |
| FireRating | false | 3 | property |
| NumberOfStoreys | false | 3 | property |
| RefElevation | false | 10 | property |
| Description, Name, IsExternal, TypeName, Station, UsageType | false | — | properties |

Every name in the corpus classifies correctly. `ElevationOfRefHeight` is the interesting case: it ends in "Height", so if `Height` were ever added to `suffixPatterns` (to "fix" the asymmetry), this real IfcSite property would flip to a quantity — the current asymmetry is accidentally protective here, not a bug. No misclassification found anywhere in the corpus, so this PR ships tests only, no table edit.

## RED → per-entry mutation table

Test file: `packages/ifcx/src/quantity-classification.test.ts`, 4 new tests pinning exact values from `Hello_Wall_hello-wall.ifcx` and the PCERT `Building-Architecture`/`Building-Structural` sample scenes. All 4 pass against unmodified code (124/124 total, up from the 120/120 baseline).

Mutated each list entry individually (delete one line, rebuild, run just the new test file), then restored via `cp` from a backup and `diff`-verified clean before moving to the next entry — never `git checkout --`/`restore`/`stash`.

**`exactQuantityNames`:**

| entry | removing it fails | pinned? |
|---|---|---|
| Volume | `Hello_Wall: ... (10 quantities)` | yes |
| Area | *(none)* | **no** — no bare `"Area"` name in corpus |
| Length | `PCERT Building-Architecture: ...`, `PCERT Building-Structural: ...` | yes |
| Width | `PCERT Building-Architecture: ...` | yes |
| Height | `Hello_Wall: ...` | yes |
| Depth | `PCERT Building-Architecture: ...` | yes |
| Thickness | *(none)* | **no** — absent from corpus |
| Weight | *(none)* | **no** — absent from corpus |
| Mass | *(none)* | **no** — absent from corpus |
| Count | *(none)* | **no** — absent from corpus |
| Perimeter | *(none)* | **no** — absent from corpus |
| CrossSectionArea | *(none)* | **no** — redundant with the `Area` suffix pattern, which still catches it |

**`suffixPatterns`:**

| entry | removing it fails | pinned? |
|---|---|---|
| Volume | `PCERT Building-Architecture: ...`, `PCERT Building-Structural: ...` | yes |
| Area | `PCERT Building-Architecture: ...` | yes |
| Length | *(none)* | **no** — corpus has no compound `*Length` name (plain `Length` is exact-list pinned) |
| Weight | *(none)* | **no** — absent from corpus |
| Mass | *(none)* | **no** — absent from corpus |
| Count | *(none)* | **no** — absent from corpus |
| Perimeter | *(none)* | **no** — absent from corpus |

Per rule, the unpinned entries above are stated plainly rather than papered over — the downloaded corpus simply doesn't exercise `Area` (bare), `Thickness`, `Weight`, `Mass`, `Count`, `Perimeter`, or any compound `*Length` name, so those remain coverage gaps this PR does not close. No speculative names were added to either list.

## Fixture handling

`tests/models/ifc5/` is gitignored and fetched via `pnpm fixtures`. The new suite follows the existing skip pattern from `hierarchy-builder.test.ts` (`describe(..., { skip: !FIXTURES_AVAILABLE && '...' })`) — this reports as a genuine Node test-runner skip, not a silent pass, and CI (`test.yml`, `release.yml`, `determinism.yml`) runs `pnpm fixtures` / `pnpm fixtures:check` before the test step, so the suite genuinely executes in CI rather than skipping.

## Test plan

- [x] `npx tsx --test src/*.test.ts` in `packages/ifcx`: 124 tests, 34 suites, 0 failures (up from 120/33/0 baseline)
- [x] New suite passes standalone against unmodified code
- [x] Per-entry mutation of both lists individually, failing test names captured, reverted via `cp`+`diff` (never `git checkout --`/`restore`/`stash`)
- [x] Changeset added (`@ifc-lite/ifcx` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
