### PR TITLE
test(merge): pin the multi-layer suffix fold in the merge fast path

### DIFF
--- a/.changeset/merge-multilayer-suffix-fold-coverage.md
+++ b/.changeset/merge-multilayer-suffix-fold-coverage.md
@@ -1,0 +1,41 @@
+---
+'@ifc-lite/merge': patch
+---
+
+Add test coverage pinning the multi-layer suffix fold in the merge fast path.
+
+`projectSide` (`packages/merge/src/component-state.ts`) folds a side's
+suffix layers weakest-first, per attribute — same contract documented on
+`extractStackState`. That ordering was structurally unpinned: every
+`ours`/`theirs` fixture in the suite was a suffix of length exactly 1, so
+"earlier" never existed and the fold could not be observed. Reversing the
+loop left all 94 existing tests green.
+
+Adds:
+- A hand-written fixture (`component-state.test.ts`) with a two-layer
+  `ours` suffix that writes the same attribute in both layers (different
+  values) plus an attribute written only in the earlier layer, proving
+  shadowing is per-attribute rather than wholesale replacement, and
+  carrying the fold-order-dependent value into an actual
+  `planThreeWayMerge` conflict.
+- A `layersPerSide` parameter on `fast-path-differential.test.ts`'s
+  `scenario()` builder so the differential fuzz's fast-path-equals-
+  reference proof also covers multi-layer suffixes, not only
+  single-layer ones.
+
+No production code changed; `projectSide`'s existing loop order is
+correct (it already applies weakest-first) — only its test coverage was
+missing. Confirmed by reversing the loop locally: the new tests fail
+(RED) and the loop-order mutation at `component-state.ts:179`
+(`extractStackState`'s equivalent fold) still fails the expected 40
+tests across 8 files, confirming both mutation sites are exercised.
+
+Also recorded, not fixed (out of scope for this patch):
+- `merge-layer.ts:41-43` — `applyResolutions`'s `byKey` map uses
+  last-insertion-wins with no test submitting two `ResolutionInput`s for
+  the same `(path, componentKey)`; may be an undefined contract rather
+  than a bug.
+- `ref-flow.ts:109` — `checkRefPolicy`'s `requiredChecks` loop is only
+  ever exercised with a single-entry array; which failing check is
+  reported first with multiple failures is unpinned (message selection
+  only).

--- a/packages/merge/src/component-state.test.ts
+++ b/packages/merge/src/component-state.test.ts
@@ -17,7 +17,8 @@
 
 import { describe, expect, it } from 'vitest';
 import type { IfcxFile } from '@ifc-lite/ifcx';
-import { componentKeyForAttribute, extractStackState } from './component-state.js';
+import { componentKeyForAttribute, extractStackState, projectStackStates } from './component-state.js';
+import { planThreeWayMerge } from './three-way.js';
 
 describe('componentKeyForAttribute', () => {
   it('buckets a custom (non-Pset_) set name as pset:<name> when the value is a typed property record', () => {
@@ -112,5 +113,87 @@ describe('extractStackState + a whole-pset tombstone lookup on a custom-named se
     // one the deletion happened to be classified into.
     const surviving = [...(entity?.components.values() ?? [])].filter((attrs) => key in attrs);
     expect(surviving).toEqual([]);
+  });
+});
+
+/**
+ * `projectSide` (the fast-path 05 §5.7 clone-on-write fold, this file's
+ * `for (const layer of suffix)` loop) folds a side's suffix layers
+ * weakest-first, per attribute — same contract as `extractStackState`'s
+ * comment: "later opinions shadow earlier ones per attribute." That
+ * ordering was structurally unpinned: every `ours`/`theirs` array in the
+ * rest of this suite (three-way.test.ts, merge-layer.test.ts,
+ * resurrect.test.ts, fast-path-differential.test.ts,
+ * real-model-fuzz.test.ts, ref-flow-resolutions.test.ts) is
+ * `[...ancestor, oneLayer]` — a suffix of length exactly 1, so "earlier"
+ * never exists and the fold cannot be observed. This fixture uses a
+ * TWO-layer ours suffix that writes the SAME attribute in both layers
+ * (with different values, so the fold is observable at all) plus an
+ * attribute written only in the earlier layer (so shadowing-per-attribute
+ * is distinguished from wholesale replacement).
+ */
+describe('projectSide folds a multi-layer suffix weakest-first, per attribute', () => {
+  const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+  const SMOKE = 'bsi::ifc::v5a::Pset_FireSafety::SmokeRating';
+
+  function layerAt(id: string, attributes: Record<string, unknown>): IfcxFile {
+    return {
+      header: { id, ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0', author: 't', timestamp: 't' },
+      imports: [],
+      schemas: {},
+      data: [{ path: 'e1', attributes }],
+    } as unknown as IfcxFile;
+  }
+
+  const ancestor = [layerAt('base', { [FIRE]: { type: 'IfcLabel', value: 'REI60' } })];
+  // Ours suffix: two layers, weakest first.
+  //  - o1 (earlier): writes FIRE=REI90 AND SmokeRating=S30.
+  //  - o2 (later):   writes FIRE=REI120 only — SMOKE is untouched here.
+  // Correct (weakest-first) fold: FIRE=REI120 (o2 shadows o1), SMOKE=S30
+  // (only o1 wrote it, so o2 must not erase it). A reversed fold instead
+  // yields FIRE=REI90 (o1 clobbers o2 because it is applied last).
+  const oursSuffix = [
+    layerAt('o1', { [FIRE]: { type: 'IfcLabel', value: 'REI90' }, [SMOKE]: { type: 'IfcLabel', value: 'S30' } }),
+    layerAt('o2', { [FIRE]: { type: 'IfcLabel', value: 'REI120' } }),
+  ];
+  // Theirs: unrelated edit to the same attribute so the merge matrix
+  // records a real `concurrent-edit` conflict whose `ours` snapshot is
+  // the folded component — carrying the fold-order-dependent value into
+  // an actual merge result, not just an internal state map.
+  const theirsSuffix = [layerAt('t1', { [FIRE]: { type: 'IfcLabel', value: 'REI999' } })];
+
+  it('this fixture is fast-path eligible (no tombstones, shared ancestor prefix) — the fold under test actually runs', () => {
+    // Confirms which code path executes: a null return here would mean
+    // the assertions below exercise extractStackState's full fold
+    // instead of projectSide's clone-on-write fold.
+    const projected = projectStackStates(ancestor, oursSuffix, theirsSuffix);
+    expect(projected).not.toBeNull();
+  });
+
+  it('later layer shadows the earlier layer PER ATTRIBUTE: FireRating from o2, SmokeRating survives from o1', () => {
+    const projected = projectStackStates(ancestor, oursSuffix, theirsSuffix);
+    const oursComponent = projected?.o.get('e1')?.components.get('pset:Pset_FireSafety');
+    expect(oursComponent).toEqual({
+      [FIRE]: { type: 'IfcLabel', value: 'REI120' },
+      [SMOKE]: { type: 'IfcLabel', value: 'S30' },
+    });
+  });
+
+  it('matches extractStackState (the reference fold) on the same multi-layer stack', () => {
+    const projected = projectStackStates(ancestor, oursSuffix, theirsSuffix);
+    const reference = extractStackState([...ancestor, ...oursSuffix]);
+    expect(projected?.o.get('e1')?.components.get('pset:Pset_FireSafety')).toEqual(
+      reference.get('e1')?.components.get('pset:Pset_FireSafety')
+    );
+  });
+
+  it('the fold-order-dependent value reaches an actual merge conflict via planThreeWayMerge', () => {
+    const plan = planThreeWayMerge({ ancestor, ours: [...ancestor, ...oursSuffix], theirs: [...ancestor, ...theirsSuffix] });
+    const conflict = plan.conflicts.find((c) => c.path === 'e1' && c.componentKey === 'pset:Pset_FireSafety');
+    expect(conflict?.kind).toBe('concurrent-edit');
+    expect(conflict?.ours?.attributes).toEqual({
+      [FIRE]: { type: 'IfcLabel', value: 'REI120' },
+      [SMOKE]: { type: 'IfcLabel', value: 'S30' },
+    });
   });
 });

--- a/packages/merge/src/fast-path-differential.test.ts
+++ b/packages/merge/src/fast-path-differential.test.ts
@@ -73,7 +73,21 @@ function randomNode(rand: () => number, path: string, tag: string, allowDeletes:
   return { path, attributes: { [FIRE]: `${tag}-fire` } };
 }
 
-function scenario(seed: number, allowDeletes: boolean) {
+/**
+ * `layersPerSide` (default 1, matching the original single-layer sides)
+ * lets a side extend the ancestor with MULTIPLE suffix layers instead of
+ * one. Each layer's node values are tagged with its own layer index
+ * (`${tag}-${l}`), so when two layers happen to touch the same path with
+ * the same attribute (the same 0.35-per-entity roll landing in the same
+ * branch on both layers), they write DIFFERENT values — exactly the
+ * shape that makes `projectSide`'s weakest-first fold
+ * (component-state.ts:321) observable instead of vacuously satisfied.
+ * With `layersPerSide` > 1 this scenario builder is the highest-value
+ * fold coverage in the suite: every generated case, not just one
+ * hand-written fixture, now exercises multi-layer shadowing whenever the
+ * dice land that way.
+ */
+function scenario(seed: number, allowDeletes: boolean, layersPerSide = 1) {
   const rand = lcg(seed);
   const entityCount = 40;
   const baseNodes: IfcxNode[] = [];
@@ -88,17 +102,21 @@ function scenario(seed: number, allowDeletes: boolean) {
   baseNodes.push({ path: 'e-1', attributes: { [FIRE]: 'REI90' } });
   const base = layer(baseNodes, 'base');
 
-  const side = (tag: string): IfcxNode[] => {
-    const nodes: IfcxNode[] = [];
-    for (let i = 0; i < entityCount; i++) {
-      if (rand() < 0.35) nodes.push(randomNode(rand, `e-${i}`, tag, allowDeletes));
+  const side = (tag: string): IfcxNode[][] => {
+    const layers: IfcxNode[][] = [];
+    for (let l = 0; l < layersPerSide; l++) {
+      const nodes: IfcxNode[] = [];
+      for (let i = 0; i < entityCount; i++) {
+        if (rand() < 0.35) nodes.push(randomNode(rand, `e-${i}`, `${tag}-${l}`, allowDeletes));
+      }
+      layers.push(nodes);
     }
-    return nodes;
+    return layers;
   };
 
   const ancestor = [base];
-  const ours = [base, layer(side('ours'), 'ours')];
-  const theirs = [base, layer(side('theirs'), 'theirs')];
+  const ours = [base, ...side('ours').map((nodes, i) => layer(nodes, `ours-${i}`))];
+  const theirs = [base, ...side('theirs').map((nodes, i) => layer(nodes, `theirs-${i}`))];
   return { ancestor, ours, theirs };
 }
 
@@ -115,6 +133,28 @@ describe('fast path ≡ reference (differential fuzz)', () => {
   it('tombstone/resurrect scenarios fall back and still match the reference exactly', () => {
     for (const seed of [4, 9, 16, 25, 36, 49, 64, 81]) {
       const { ancestor, ours, theirs } = scenario(seed, true);
+      const fast = planThreeWayMerge({ ancestor, ours, theirs });
+      const reference = referencePlan(ancestor, ours, theirs);
+      expect(normalize(fast), `seed ${seed}`).toEqual(normalize(reference));
+    }
+  });
+
+  it('multi-layer (3-layer) tombstone-free suffixes take the projection and match the reference exactly', () => {
+    // The whole point of raising layersPerSide: some (path, attribute)
+    // pairs now get written on more than one suffix layer, so the fold
+    // order inside projectSide (component-state.ts:321) is actually
+    // exercised, not vacuously satisfied by a length-1 suffix.
+    for (const seed of [1, 2, 3, 5, 8, 13, 21, 34, 55, 89]) {
+      const { ancestor, ours, theirs } = scenario(seed, false, 3);
+      const fast = planThreeWayMerge({ ancestor, ours, theirs });
+      const reference = referencePlan(ancestor, ours, theirs);
+      expect(normalize(fast), `seed ${seed}`).toEqual(normalize(reference));
+    }
+  });
+
+  it('multi-layer (3-layer) tombstone/resurrect suffixes fall back and still match the reference exactly', () => {
+    for (const seed of [4, 9, 16, 25, 36, 49, 64, 81]) {
+      const { ancestor, ours, theirs } = scenario(seed, true, 3);
       const fast = planThreeWayMerge({ ancestor, ours, theirs });
       const reference = referencePlan(ancestor, ours, theirs);
       expect(normalize(fast), `seed ${seed}`).toEqual(normalize(reference));


### PR DESCRIPTION
## Summary

`projectSide` (`packages/merge/src/component-state.ts:321`, the `for (const layer of suffix)` loop) folds a side's suffix layers weakest-first, per attribute — the same contract `extractStackState`'s docstring states: "later opinions shadow earlier ones per attribute." That ordering was structurally unpinned by the test suite: every `ours`/`theirs` array in `three-way.test.ts`, `merge-layer.test.ts`, `resurrect.test.ts`, `fast-path-differential.test.ts`, `real-model-fuzz.test.ts`, and `ref-flow-resolutions.test.ts` is `[...ancestor, oneLayer]` — a suffix of length exactly 1, so "earlier" never exists and the fold cannot be observed.

**Reproduced locally**: reversing the loop to `[...suffix].reverse()` left all 94 existing tests green (confirmed, then restored via `cp`+`diff`, never `git checkout`).

No production code changed — `projectSide`'s existing loop order is correct. This PR only adds the missing coverage:

- **`packages/merge/src/component-state.test.ts`**: a hand-written fixture with a two-layer `ours` suffix that writes `FireRating` in *both* layers with *different* values (the later layer must win) and `SmokeRating` only in the earlier layer (must survive — proving per-attribute shadowing, not wholesale replacement). Confirms the fixture is fast-path-eligible (`projectStackStates` returns non-null, no tombstones), matches `extractStackState`'s reference fold, and carries the fold-order-dependent value into a real `planThreeWayMerge` `concurrent-edit` conflict.
- **`packages/merge/src/fast-path-differential.test.ts`**: added a `layersPerSide` parameter to the `scenario()` builder (previously hard-coded to one layer per side) and two new differential-fuzz cases (`layersPerSide: 3`, tombstone-free and tombstone-bearing) so the fast-path-equals-reference proof now covers multi-layer suffixes across every generated scenario, not just one hand-written case. Extending `scenario()` was feasible and is the higher-value change per-task guidance — the hand-written fixture is still included because it lets a reviewer verify the specific per-attribute-shadow claim without reading fuzz-generated diffs.

## Evidence (RED → GREEN)

Reversing `component-state.ts:321`'s loop order (`[...suffix].reverse()`) — **RED**, 4 new tests fail:

```
FAIL src/component-state.test.ts > projectSide folds a multi-layer suffix weakest-first, per attribute > later layer shadows the earlier layer PER ATTRIBUTE: FireRating from o2, SmokeRating survives from o1
FAIL src/component-state.test.ts > projectSide folds a multi-layer suffix weakest-first, per attribute > matches extractStackState (the reference fold) on the same multi-layer stack
FAIL src/component-state.test.ts > projectSide folds a multi-layer suffix weakest-first, per attribute > the fold-order-dependent value reaches an actual merge conflict via planThreeWayMerge
FAIL src/fast-path-differential.test.ts > fast path ≡ reference (differential fuzz) > multi-layer (3-layer) tombstone-free suffixes take the projection and match the reference exactly
```
(4 failed, 96 passed, 4 skipped)

Restored (`cp` + `diff` verified identical) — **GREEN**: 100 passed, 4 skipped (up from the 94/4 baseline).

## Mutation table (same command, `vitest run` in `packages/merge`)

| Site | Mutation | Failing tests |
|---|---|---|
| `component-state.ts:321` (`projectSide`, fast path) | reverse suffix loop | the 4 listed above |
| `component-state.ts:179` (`extractStackState`, reference path) | reverse layer loop | 40 failing tests across 8 files (`component-state.test.ts`, `fast-path-differential.test.ts`, `merge-layer.test.ts`, `three-way.test.ts`, `ref-flow-policy-ancestor.test.ts`, `ref-flow-resolutions.test.ts`, `resurrect.test.ts`, `state-diff.test.ts`) — confirms this site's existing 38-test/8-file kill is still calibrated (2 more than the pre-existing 38 because this PR's own new tests also exercise `extractStackState`) |

Before/after suite counts (`vitest run`, `packages/merge`):
- Before: 8 files passed / 1 skipped, 94 tests passed / 4 skipped
- After: 8 files passed / 1 skipped, 100 tests passed / 4 skipped

## Observed but not addressed (recorded per task guidance)

- `merge-layer.ts:41-43` — `applyResolutions`'s `byKey` map is last-insertion-wins with no test submitting two `ResolutionInput`s for the same `(path, componentKey)`. May be an undefined contract rather than a bug — not asserted as a defect here.
- `ref-flow.ts:109` — `checkRefPolicy`'s `requiredChecks` loop is only ever exercised with a single-entry array; which failing check is reported first with multiple failures is unpinned. Message-selection only, not a correctness issue.

## Test plan

- [x] `vitest run` in `packages/merge`: 100 passed / 4 skipped (up from 94/4 baseline)
- [x] `npx turbo run build --filter=@ifc-lite/merge` succeeds
- [x] Reproduced the unpinned fold pre-change (94/94 green under reversed loop)
- [x] RED under `:321` reversal, GREEN restored
- [x] Mutation table for `:321` and `:179`, same command, both before and after