### PR TITLE
test(cache): pin decodeGeometryChunk's consumed-bytes guard

### DIFF
--- a/.changeset/cache-chunk-consumed-guard.md
+++ b/.changeset/cache-chunk-consumed-guard.md
@@ -1,0 +1,34 @@
+---
+'@ifc-lite/cache': patch
+---
+
+Pin the reject path of `decodeGeometryChunk`'s consumed-bytes guard.
+
+`decodeGeometryChunk` (v13 chunked geometry) ends with
+`if (reader.position !== raw.byteLength) throw ...` — it requires a chunk's
+mesh records to consume exactly the decoded buffer. Mutation testing showed
+this guard was unpinned: deleting it left the full suite green, even though
+the sibling `uncompressedLength` mismatch guard immediately above it already
+had a dedicated test.
+
+The gap is structural, not incidental: `meshCount` and `uncompressedLength`
+are directory-level fields and can both be truthful while a mesh record's
+*own* `vertexCount` field disagrees with how many vertices were actually
+written for it (truncation or corruption mid record). That desync doesn't
+move the chunk's overall decoded length or its declared mesh count, so
+neither of the two checks that run before this guard can catch it —
+`readMeshRecord` simply under-reads, and only the consumed-bytes check
+notices the reader stopped short of the chunk's end.
+
+The new test builds one real chunk, then corrupts only the lone mesh
+record's `vertexCount` field (leaving the directory's `meshCount` and
+`uncompressedLength` untouched and correct) so the record under-consumes by
+exactly the bytes two shortened arrays account for. It fails when the guard
+is removed and passes with it restored; a control decode with the field
+restored round-trips fine, confirming the corruption — not an unrelated
+fixture bug — is what triggers the throw.
+
+As a calibration check, the analogous mutation on the neighbouring
+`validateGeometryDirectory` `headLength` guard (`geometry-directory.ts:32-36`)
+was confirmed to fail exactly one existing test, showing the harness and
+build are sound and the new test's win is real.

--- a/packages/cache/src/sections/geometry-chunks.test.ts
+++ b/packages/cache/src/sections/geometry-chunks.test.ts
@@ -340,4 +340,47 @@ describe('decodeGeometryChunk length verification', () => {
     const decoded = await decodeGeometryChunk(stored, realInfo, 13);
     expectMeshesEqual(decoded, meshes);
   });
+
+  // Mutation testing showed the sibling `reader.position !== raw.byteLength`
+  // guard's reject path was also unasserted: deleting it left the full suite
+  // green. Unlike the case above, meshCount and uncompressedLength are BOTH
+  // truthful here — the corruption lives one level deeper, inside the mesh
+  // record itself. A record's own vertexCount field can disagree with the
+  // number of vertices actually written for it (truncation/corruption mid
+  // record) without moving the chunk's overall decoded length or its
+  // declared mesh count, so readMeshRecord under-reads and leaves the reader
+  // short of the chunk's end. Only this guard — not the uncompressedLength
+  // check above — can catch that.
+  it('throws when a mesh record under-consumes the declared chunk length (meshCount and uncompressedLength are both truthful)', async () => {
+    const meshes = [mesh(1, [0, 0, 0])];
+    const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
+    const open = openGeometryChunksV13(section, 0, 13);
+    const realInfo = open.chunks[0];
+    expect(realInfo.flags & GeometryChunkFlags.DeflateRaw).toBe(0); // uncompressed: raw === stored
+    expect(realInfo.meshCount).toBe(1);
+
+    const bytes = new Uint8Array(section);
+    const stored = bytes.subarray(realInfo.byteOffset, realInfo.byteOffset + realInfo.byteLength);
+
+    // Corrupt the lone mesh record's own vertexCount field (record offset 4,
+    // right after the 4-byte expressId) so it under-reports 2 vertices
+    // instead of the real 3. `realInfo` (meshCount, uncompressedLength) is
+    // passed through unmodified: the directory-level checks earlier in
+    // decodeGeometryChunk see a fully consistent chunk and pass, so this
+    // fixture reaches the consumed-bytes guard rather than one of them.
+    const dv = new DataView(stored.buffer, stored.byteOffset, stored.byteLength);
+    const realVertexCount = dv.getUint32(4, true);
+    expect(realVertexCount).toBe(3);
+    dv.setUint32(4, realVertexCount - 1, true);
+
+    await expect(decodeGeometryChunk(stored, realInfo, 13)).rejects.toThrow(
+      /Invalid cache: chunk claims \d+ mesh record\(s\) but consumed \d+ of \d+ bytes/,
+    );
+
+    // Control: restoring the true vertexCount round-trips fine — the throw
+    // above is caused by the corruption, not some unrelated fixture bug.
+    dv.setUint32(4, realVertexCount, true);
+    const decoded = await decodeGeometryChunk(stored, realInfo, 13);
+    expectMeshesEqual(decoded, meshes);
+  });
 });


### PR DESCRIPTION
## Summary

`decodeGeometryChunk` (`packages/cache/src/sections/geometry-chunks.ts:298-302`) ends with a consumed-bytes guard: `if (reader.position !== raw.byteLength) throw ...`. It catches a chunk whose directory-declared `meshCount` and `uncompressedLength` are internally consistent, but whose mesh records don't consume exactly the decoded buffer (a truncated/corrupted record mid-stream).

**Evidence it was unpinned**: deleting the guard left the full suite green (82/82). With the new test added and the guard deleted, exactly the new test fails — everything else stays green.

**New test** (`geometry-chunks.test.ts`, alongside the existing `uncompressedLength` guard test): builds one real chunk, then corrupts only the lone mesh record's own `vertexCount` field, leaving the directory's `meshCount` and `uncompressedLength` untouched and correct. That desync doesn't move the chunk's overall decoded length or declared mesh count, so `readMeshRecord` simply under-reads and only the consumed-bytes guard notices the reader stopped short of the chunk's end. A control decode with the field restored round-trips fine.

**Calibration**: the analogous mutation on the sibling `validateGeometryDirectory` `headLength` guard (`geometry-directory.ts:32-36`) was confirmed to fail exactly one existing test — `rejects a headLength that disagrees with the actual parsed head size, even when chunk 0 is forged to match it` — confirming the harness and build are sound and the new test's win is real.

## Mutation table

| Guard mutated | Failing test names |
|---|---|
| `geometry-chunks.ts:298-302` (consumed-bytes) | `throws when a mesh record under-consumes the declared chunk length (meshCount and uncompressedLength are both truthful)` |
| `geometry-directory.ts:32-36` (headLength, calibration) | `rejects a headLength that disagrees with the actual parsed head size, even when chunk 0 is forged to match it` |

## Test plan

- [x] Baseline: `npx vitest run` in `packages/cache` → 10 files, 82 tests passed
- [x] RED: guard at `geometry-chunks.ts:298-302` deleted → new test fails (82 passed, 1 failed), all others green
- [x] GREEN: guard restored → 10 files, 83 tests passed
- [x] Calibration mutation on `geometry-directory.ts:32-36` reproduced exactly as expected, then restored (`cp` + `diff` clean)