### PR TITLE
test(solar): pin southern-hemisphere fixtures and an external NOAA reference

### DIFF
--- a/.changeset/solar-southern-and-noaa-pin.md
+++ b/.changeset/solar-southern-and-noaa-pin.md
@@ -1,0 +1,23 @@
+---
+'@ifc-lite/solar': patch
+---
+
+Test coverage only: no production logic changed.
+
+Every non-pole latitude fixture in `packages/solar`'s test suite was
+northern (51.4769, 78, 47); mutating `latitude` to `Math.abs(latitude)` at
+both `solar-position.ts:131` and `sun-times.ts:53` left the full 38-test
+suite green. Added a Sydney (-33.87, 151.21) fixture asserting the season
+flip (December altitude/day-length exceeds June, the opposite of the
+package's northern-hemisphere fixtures) and the azimuth flip (solar noon
+transits near due north, not due south), with a wraparound-safe azimuth
+check.
+
+Also added the package's first comparison against a reference sourced
+outside the repo: every existing assertion was a round-trip, an invariant,
+or a cross-check between `sunPosition` and `sunTimes.solarNoon` -- both
+built on the same `solarGeometry`, so self-consistent but not validated
+against the published NOAA Solar Position Calculator this package claims to
+implement. Pinned `solarGeometry` at the 2024 June solstice and `sunPosition`
+at NOAA's own Boulder, CO worked example against values independently
+re-derived from the published NOAA equations.

--- a/packages/solar/src/noaa-reference.test.ts
+++ b/packages/solar/src/noaa-reference.test.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Cross-check against an EXTERNAL reference, not against another function in
+ * this package. Every other test in packages/solar is a round-trip, an
+ * invariant, or a comparison of sunPosition against sunTimes.solarNoon — both
+ * built from the same solarGeometry(). That is self-consistency: it proves
+ * the two functions agree with each other, not that either matches the
+ * published NOAA Solar Position Calculator this package's docs claim to
+ * implement (see solar-position.ts's module comment).
+ *
+ * The reference numbers below were produced by independently re-implementing
+ * the NOAA Solar Calculation Details equations (the same public formula
+ * description this package's solarGeometry/sunPosition are documented as
+ * following — NOAA Global Monitoring Laboratory "Solar Calculation Details",
+ * equivalent to the low-accuracy solar position algorithm in Meeus,
+ * "Astronomical Algorithms") in a standalone scratch script, WITHOUT reading
+ * solar-position.ts's implementation. The scratch derivation used the
+ * classic acos-form azimuth equation (distinct from the atan2-form this
+ * package uses — a different equation entirely, not a transcription):
+ *
+ *   zenith    = acos(sin(lat)·sin(decl) + cos(lat)·cos(decl)·cos(HA))
+ *   azimuth   = HA > 0
+ *             ? acos(((sin(lat)·cos(zenith)) − sin(decl)) / (cos(lat)·sin(zenith))) + 180
+ *             : 540 − acos(((sin(lat)·cos(zenith)) − sin(decl)) / (cos(lat)·sin(zenith)))
+ *
+ * Running that independent script against this package's `solarGeometry` and
+ * `sunPosition` outputs for the same instants matched to full double-
+ * precision float (~1e-13), which is the evidence that the pinned constants
+ * below are correct — not that they were copied from this package's output.
+ *
+ * Tolerance: declination and equation-of-time are pinned to 1e-6 (precision
+ * 6) — six orders of magnitude looser than the ~1e-13 agreement observed
+ * during re-derivation, so ordinary float/engine noise cannot trip it, but
+ * far tighter than any plausible formula defect. Altitude/azimuth at Boulder
+ * are pinned to 1e-4 (precision 4). A deliberately introduced defect —
+ * flipping the sign between the `y·sin(2·meanLong)` and `2·eccent·sin(meanAnom)`
+ * terms of the equation-of-time formula (solar-position.ts, inside
+ * `solarGeometry`) — moved equationOfTime by ~3.6 minutes, altitude by
+ * ~0.45°, and azimuth by ~1.8° at this same instant: 4-6 orders of magnitude
+ * larger than these tolerances, so the tolerance is chosen to fail loudly on
+ * a real defect while never flagging float noise, not chosen to pass.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { solarGeometry, sunPosition } from './solar-position.js';
+
+describe('NOAA external reference', () => {
+  it('matches the NOAA solar geometry at the 2024 June solstice (UTC midnight)', () => {
+    const { declination, equationOfTime } = solarGeometry(new Date('2024-06-21T00:00:00Z'));
+    expect(declination).toBeCloseTo(23.4385549487431, 6);
+    expect(equationOfTime).toBeCloseTo(-1.8162165525671223, 6);
+  });
+
+  it("matches the NOAA worked example for Boulder, CO (NOAA's own reference site)", () => {
+    // 39.742476 N, 105.1786 W — the site NOAA uses in its own published
+    // worked example for the solar position calculator.
+    const { altitude, azimuth } = sunPosition(
+      new Date('2024-06-21T18:00:00Z'),
+      39.742476,
+      -105.1786,
+    );
+    expect(altitude).toBeCloseTo(68.99371917759282, 4);
+    expect(azimuth).toBeCloseTo(136.2544159308925, 4);
+  });
+});

--- a/packages/solar/src/solar-position.test.ts
+++ b/packages/solar/src/solar-position.test.ts
@@ -78,6 +78,53 @@ describe('sunPosition', () => {
   });
 });
 
+// Sydney — a genuine southern-hemisphere mid-latitude fixture. Every other
+// non-pole latitude in this package's tests is northern (LAT = 51.4769 above,
+// 78 for the Arctic cases, 47 for the longitude-shift cases), and the only
+// negative latitudes are the exact poles, where Math.abs(-90) === 90 leaves
+// the pole assertions unaffected. That gap let `latitude * DEG` silently
+// become `Math.abs(latitude) * DEG` at both solar-position.ts:131 and
+// sun-times.ts:53 without failing a single test. This fixture asserts the two
+// things that actually invert across the equator: which solstice is "summer"
+// (season flip) and which side of the sky the sun transits (azimuth flip).
+describe('sunPosition southern hemisphere', () => {
+  const SYD_LAT = -33.87;
+  const SYD_LON = 151.21;
+
+  it('is higher at the December solstice than the June solstice (season flip)', () => {
+    const juneNoon = sunTimes(new Date('2024-06-20T12:00:00Z'), SYD_LAT, SYD_LON).solarNoon;
+    const decNoon = sunTimes(new Date('2024-12-21T12:00:00Z'), SYD_LAT, SYD_LON).solarNoon;
+    const juneAlt = sunPosition(juneNoon, SYD_LAT, SYD_LON).altitude;
+    const decAlt = sunPosition(decNoon, SYD_LAT, SYD_LON).altitude;
+
+    // Northern-hemisphere London (above) is higher in June than December by
+    // 40°+; a southern site must show the SAME kind of gap in the OPPOSITE
+    // direction. Under `Math.abs(latitude)` both solstices collapse onto the
+    // northern-hemisphere answer (June ≈ 79.6°, December ≈ 32.7°) and this
+    // inequality flips, so this is not just a magnitude check.
+    expect(decAlt).toBeGreaterThan(juneAlt + 30);
+  });
+
+  it('transits due north, not due south, at solar noon (azimuth flip)', () => {
+    const juneNoon = sunTimes(new Date('2024-06-20T12:00:00Z'), SYD_LAT, SYD_LON).solarNoon;
+    const decNoon = sunTimes(new Date('2024-12-21T12:00:00Z'), SYD_LAT, SYD_LON).solarNoon;
+    const juneAz = sunPosition(juneNoon, SYD_LAT, SYD_LON).azimuth;
+    const decAz = sunPosition(decNoon, SYD_LAT, SYD_LON).azimuth;
+
+    // Azimuth is measured clockwise from north (0–360), so "near due north"
+    // wraps around 0°/360° rather than sitting in a single contiguous range —
+    // a naive `azimuth < 10` check would miss a value like 359.97° even
+    // though it is 0.03° from north. Fold into a signed distance from 0/360
+    // instead of testing a raw range.
+    const distanceFromNorth = (az: number) => Math.min(az, 360 - az);
+    expect(distanceFromNorth(juneAz)).toBeLessThan(5);
+    expect(distanceFromNorth(decAz)).toBeLessThan(5);
+
+    // Under `Math.abs(latitude)` both azimuths collapse to ≈180° (due south,
+    // the northern-hemisphere answer), which the check above would catch.
+  });
+});
+
 describe('sunTimes', () => {
   it('gives ~12h of daylight at the equinox', () => {
     const t = sunTimes(new Date('2024-03-20T12:00:00Z'), LAT, LON);
@@ -176,6 +223,28 @@ describe('sunTimes', () => {
     const belowBand = sunTimes(new Date('2024-03-10T12:00:00Z'), 90, 0);
     expect(belowBand.alwaysUp).toBe(false);
     expect(belowBand.alwaysDown).toBe(true);
+  });
+
+  // solarNoon does not depend on latitude at all (it is `720 - 4*longitude -
+  // equationOfTime`), so the southern-hemisphere sunPosition tests above —
+  // which get their instants from `sunTimes(...).solarNoon` — never exercise
+  // sun-times.ts's OWN `latitude * DEG` term. Day length (sunset − sunrise)
+  // is the sun-times-local quantity that depends on latitude's sign via
+  // `tan(latRad) * tan(decRad)` in the hour-angle formula, so it is the one
+  // that actually goes red under `Math.abs(latitude)` at sun-times.ts:53.
+  it('has a longer day in December than June in the southern hemisphere (season flip)', () => {
+    const SYD_LAT = -33.87;
+    const SYD_LON = 151.21;
+    const june = sunTimes(new Date('2024-06-20T12:00:00Z'), SYD_LAT, SYD_LON);
+    const dec = sunTimes(new Date('2024-12-21T12:00:00Z'), SYD_LAT, SYD_LON);
+    const hours = (t: typeof june) =>
+      (t.sunset!.getTime() - t.sunrise!.getTime()) / 3_600_000;
+
+    // Sydney: June ≈ 9.9 h (winter), December ≈ 14.4 h (summer) — the exact
+    // opposite of the northern-hemisphere LAT above. Under `Math.abs(latitude)`
+    // these swap to June ≈ 14.4 h / December ≈ 9.9 h, so a >2 h margin is well
+    // clear of noise but still fails hard under the mutation.
+    expect(hours(dec)).toBeGreaterThan(hours(june) + 2);
   });
 });
 


### PR DESCRIPTION
## Summary

Coverage-only PR for `packages/solar`. Production logic is unchanged; only test files and a changeset are added/modified.

### 1. Southern-hemisphere mid-latitudes were structurally untested

Every non-pole latitude fixture in `packages/solar`'s two test files was northern (`LAT = 51.4769`, `78` for the Arctic cases, `47` for the longitude-shift cases). The only negative latitudes exercised were the exact poles (`-90`), and `Math.abs(-90) === 90`, so a bug that silently forces latitude positive would slip through undetected everywhere except the poles.

**Confirmed by mutation** — changing `const latRad = latitude * DEG;` to `Math.abs(latitude) * DEG` at `solar-position.ts:131` and again at `sun-times.ts:53` left the full 38-test baseline green at either site.

Added a Sydney fixture (`-33.87, 151.21`) in `solar-position.test.ts` that asserts the two things that actually invert across the equator:
- **Season flip** — December solar-noon altitude exceeds June's by 30°+ (`sunPosition southern hemisphere` describe block), and December day length exceeds June's by 2h+ (added to the `sunTimes` describe block, since `solarNoon` itself doesn't depend on latitude — needed to independently exercise `sun-times.ts:53`).
- **Azimuth flip** — solar noon transits near due north (azimuth ≈ 0°/360°), asserted with a wraparound-safe `Math.min(az, 360 - az)` distance rather than a naive range check, since a value like 359.97° would fail a naive `< 10` check despite being 0.03° from north.

**Mutation table** (one site at a time, restored via `cp`+`diff` between each — never `git checkout`/`restore`/`stash`):

| Site | Failing tests |
|---|---|
| `solar-position.ts:131` (`Math.abs(latitude)`) | `sunPosition southern hemisphere > is higher at the December solstice than the June solstice (season flip)`, `sunPosition southern hemisphere > transits due north, not due south, at solar noon (azimuth flip)` |
| `sun-times.ts:53` (`Math.abs(latitude)`) | `sunTimes > has a longer day in December than June in the southern hemisphere (season flip)` |

Both RED runs showed **only** these tests failing; the pre-existing 38 stayed green in both cases (39/40 and 40/41 respectively).

### 2. No test compared against a reference sourced outside the repo

Every existing assertion was a round-trip, an invariant, or a cross-check between `sunPosition` and `sunTimes.solarNoon` — both built on the same `solarGeometry`. That's self-consistency, not external validation, and it's exactly the blindness that hid three live defects in `packages/bcf` (encoder/decoder sharing a table agree with each other and nothing else).

Added `packages/solar/src/noaa-reference.test.ts`, pinning:
- `solarGeometry(2024-06-21T00:00:00Z)` → `decl = 23.4385549487431`, `eot = -1.8162165525671223`
- `sunPosition(2024-06-21T18:00:00Z, 39.742476, -105.1786)` (Boulder, CO — NOAA's own worked-example site) → `alt ≈ 68.9937°`, `az ≈ 136.2544°`

**These were independently re-derived**, not copied from this package's output: a standalone scratch script re-implemented the published NOAA Solar Calculation Details equations from scratch, using the *classic acos-form* azimuth equation (`az = acos(...) + 180` / `540 - acos(...)`), which is a different equation from the atan2-form this package uses — real cross-validation, not a transcription. Running that script against this package's functions for the same instants matched to full double-precision float (~1e-13). The full derivation is documented in a comment at the top of the test file.

**Tolerance**: declination/equation-of-time pinned at precision 6 (`toBeCloseTo(..., 6)`, tolerance 5e-7) — six orders of magnitude looser than the ~1e-13 agreement seen during re-derivation (so ordinary float/engine noise won't trip it) but far tighter than any plausible formula defect. Altitude/azimuth at Boulder pinned at precision 4 (tolerance 5e-5).

**RED evidence**: flipped the sign between the `y·sin(2·meanLong)` and `2·eccent·sin(meanAnom)` terms inside `solarGeometry`'s equation-of-time formula. This shifted `equationOfTime` by ~3.6 minutes, altitude by ~0.45°, and azimuth by ~1.8° — 4-6 orders of magnitude larger than the chosen tolerances. Both `noaa-reference.test.ts` tests failed; all 41 other tests stayed green.

## Before/after

| | Test files | Tests |
|---|---|---|
| Before (upstream/main, `95f35bba1ef080ae732401d8bb436051afe4cc44`) | 2 | 38 |
| After | 3 | 43 |

## Test plan

- [x] `pnpm test` in `packages/solar`: 3 files, 43 tests, all green
- [x] Mutation at `solar-position.ts:131`: only the 2 new southern-hemisphere `sunPosition` tests fail
- [x] Mutation at `sun-times.ts:53`: only the new southern-hemisphere `sunTimes` day-length test fails
- [x] Sign-flip perturbation in `solarGeometry`'s equation-of-time term: both `noaa-reference.test.ts` tests fail
- [x] All exploratory mutations restored via `cp` + `diff` (verified identical to originals); no `git checkout`/`restore`/`stash` used
- [x] `pnpm exec tsc --noEmit` in `packages/solar`: clean (the pre-existing ~10-error `tsc` condition affecting cesium-solar / `@ifc-lite/oauth-pkce` on `main` is unrelated and untouched)
- [x] No existing fixture, assertion, or skip was weakened or edited
- [x] Changeset added (`patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added independent NOAA reference checks for solar geometry and sun-position calculations.
  * Added southern-hemisphere coverage using Sydney data, including seasonal daylight differences and solar-noon direction.
  * Improved validation of latitude handling and solar calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->