### PR TITLE
fix(mutations): honor sites in BulkQueryEngine.select()

### DIFF
--- a/.changeset/bulk-query-sites-filter.md
+++ b/.changeset/bulk-query-sites-filter.md
@@ -1,0 +1,25 @@
+---
+'@ifc-lite/mutations': patch
+---
+
+Fix `BulkQueryEngine.select()` silently ignoring `SelectionCriteria.sites`.
+
+`sites?: number[]` was declared on `SelectionCriteria` ("Filter by site IDs")
+and `SpatialHierarchy.bySite` was populated to serve it, but `select()` had no
+branch reading `criteria.sites` — unlike its `storeys`, `buildings` and
+`spaces` siblings, which each filter candidates through their matching
+`SpatialHierarchy` map. A caller who scoped a bulk `SET_PROPERTY`,
+`DELETE_PROPERTY`, or `SET_ENTITY_TYPE` to one site got the whole model
+mutated instead, with no error.
+
+The new `sites` branch is structurally identical to `storeys` / `buildings` /
+`spaces`: same guard (`criteria.sites.length > 0 && this.spatialHierarchy`),
+same per-ID lookup through `bySite.get(id)` skipping unknown IDs, same
+intersection semantics when combined with other criteria. An empty `sites`
+array is treated as no filter, matching the existing sibling behavior.
+
+Known, separately-tracked gaps left unfixed (both already self-documented as
+incomplete, so not a silent bug like the one above): `applyAction`'s
+`SET_ATTRIBUTE` case returns `null` unconditionally ("would need to be
+implemented"), and `CsvConnector.matchRow`'s `'property'` strategy warns
+"not yet implemented" and matches nothing.

--- a/packages/mutations/src/bulk-query-engine.ts
+++ b/packages/mutations/src/bulk-query-engine.ts
@@ -202,6 +202,21 @@ export class BulkQueryEngine {
       candidates = candidates.filter((id) => buildingElements.has(id));
     }
 
+    // Filter by sites
+    if (criteria.sites && criteria.sites.length > 0 && this.spatialHierarchy) {
+      const siteSet = new Set(criteria.sites);
+      const siteElements = new Set<number>();
+      for (const siteId of siteSet) {
+        const elements = this.spatialHierarchy.bySite.get(siteId);
+        if (elements) {
+          for (const el of elements) {
+            siteElements.add(el);
+          }
+        }
+      }
+      candidates = candidates.filter((id) => siteElements.has(id));
+    }
+
     // Filter by spaces
     if (criteria.spaces && criteria.spaces.length > 0 && this.spatialHierarchy) {
       const spaceSet = new Set(criteria.spaces);

--- a/packages/mutations/test/bulk-query-engine.test.ts
+++ b/packages/mutations/test/bulk-query-engine.test.ts
@@ -50,6 +50,105 @@ function makeEngineWithProperty(values: Array<string | number | boolean | null>)
   return engine;
 }
 
+/**
+ * Build an engine with 6 entities spread across a small disjoint spatial
+ * hierarchy: sites 100/200, buildings 10/20 (one per site), storeys 1/2
+ * (one per building), and a space 500 nested inside storey 1.
+ *
+ *   site 100 -> building 10 -> storey 1 -> entities 1, 2 (entity 1 also in space 500)
+ *   site 200 -> building 20 -> storey 2 -> entities 3, 4
+ *   entities 5, 6 are not registered under any spatial container.
+ */
+function makeEngineWithSpatialHierarchy() {
+  const entities = makeEntities(6);
+  const view = new MutablePropertyView(null, 'model-1');
+  view.setOnDemandExtractor(() => []);
+
+  const spatialHierarchy = {
+    project: { expressId: 0, type: 0, name: 'Project', children: [], elements: [] },
+    byStorey: new Map([
+      [1, [1, 2]],
+      [2, [3, 4]],
+    ]),
+    byBuilding: new Map([
+      [10, [1, 2]],
+      [20, [3, 4]],
+    ]),
+    bySite: new Map([
+      [100, [1, 2]],
+      [200, [3, 4]],
+    ]),
+    bySpace: new Map([[500, [1]]]),
+    storeyElevations: new Map(),
+    storeyHeights: new Map(),
+    elementToStorey: new Map(),
+  } as any;
+
+  return new BulkQueryEngine(entities, view, spatialHierarchy, null, null);
+}
+
+describe('BulkQueryEngine spatial filters', () => {
+  it('sites filters to entities contained in the given site IDs (disjoint sites)', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ sites: [100] });
+    expect(ids).toEqual([1, 2]);
+  });
+
+  it('sites with a second site ID includes both sites disjoint sets', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ sites: [100, 200] });
+    expect(ids).toEqual([1, 2, 3, 4]);
+  });
+
+  it('sites excludes entities outside the requested site (regression: previously ignored, returned everything)', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ sites: [200] });
+    expect(ids).not.toContain(1);
+    expect(ids).not.toContain(2);
+    expect(ids).toEqual([3, 4]);
+  });
+
+  it('an empty sites array is treated as no filter, matching the storeys/buildings/spaces sibling behavior', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ sites: [] });
+    expect(ids).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('a site ID absent from bySite matches nothing for that ID', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ sites: [999] });
+    expect(ids).toEqual([]);
+  });
+
+  it('sites combined with storeys intersects (not unions) the two criteria', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    // site 100 -> {1,2}; storey 2 -> {3,4}; intersection is empty.
+    const ids = engine.select({ sites: [100], storeys: [2] });
+    expect(ids).toEqual([]);
+    // site 100 -> {1,2}; storey 1 -> {1,2}; intersection is {1,2}.
+    const idsMatching = engine.select({ sites: [100], storeys: [1] });
+    expect(idsMatching).toEqual([1, 2]);
+  });
+
+  it('storeys filters to entities contained in the given storey IDs', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ storeys: [1] });
+    expect(ids).toEqual([1, 2]);
+  });
+
+  it('buildings filters to entities contained in the given building IDs', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ buildings: [20] });
+    expect(ids).toEqual([3, 4]);
+  });
+
+  it('spaces filters to entities contained in the given space IDs', () => {
+    const engine = makeEngineWithSpatialHierarchy();
+    const ids = engine.select({ spaces: [500] });
+    expect(ids).toEqual([1]);
+  });
+});
+
 describe('BulkQueryEngine property filter operators', () => {
   describe('string operators', () => {
     const engine = makeEngineWithProperty(['Alpha', 'Beta', 'Gamma', null]);


### PR DESCRIPTION
## Summary

`BulkQueryEngine.select()` (`packages/mutations/src/bulk-query-engine.ts`) silently ignored `SelectionCriteria.sites`. `sites?: number[]` is declared at line 54 ("Filter by site IDs") and `SpatialHierarchy.bySite: Map<number, number[]>` (`packages/data/src/types.ts:238`) is populated to serve it, but `select()` had no branch reading `criteria.sites` — unlike its `storeys`, `buildings` and `spaces` siblings, each of which filters candidates through the matching `SpatialHierarchy` map.

**Impact:** a bulk `SET_PROPERTY` / `DELETE_PROPERTY` / `SET_ENTITY_TYPE` scoped to a single site applied to the whole model instead. Silent, no error. Zero tests exercised `sites` (or, it turned out, `storeys`/`buildings`/`spaces` either — `grep` over `test/bulk-query-engine.test.ts` before this change found no references to any of the four).

**Reproduction** (standalone script against the built `dist/index.js`, before the fix):
```
select({ sites: [100] }) => [ 1, 2, 3, 4 ]
Expected: [1, 2]
FAIL (bug reproduced: site filter ignored)
```
After the fix, same script: `select({ sites: [100] }) => [ 1, 2 ]` — PASS.

## Fix

Added the `sites` branch structurally identical to `storeys`/`buildings`/`spaces`: same guard (`criteria.sites.length > 0 && this.spatialHierarchy`), same per-ID lookup via `bySite.get(id)` (unknown IDs contribute nothing), same `candidates.filter(...)` intersection when combined with other criteria. The three siblings did not disagree with each other on any edge case (they are structurally identical copies), so there was nothing to reconcile — `sites` now matches all three:

- **empty array** (`sites: []`): guard's `length > 0` check is false, so the filter is skipped entirely — treated as "no filter", same as siblings.
- **site ID absent from `bySite`**: `elements` is `undefined`, contributes nothing to the accumulated element set — that ID matches nothing, same as siblings.
- **combined with `storeys`**: sequential `candidates = candidates.filter(...)` per branch — intersection, not union — same as siblings.
- **missing `spatialHierarchy`**: guarded by `&& this.spatialHierarchy`; if null, the whole branch is skipped (filter not enforced) — same as siblings. This is a pre-existing pattern shared by all four branches, not something introduced here.

## Tests

RED before the fix (5 failing, matching the bug):
```
Tests  5 failed | 20 passed (25)
```
Failures: the four `sites`-specific assertions (basic filter, multi-site union, exclusion, absent-ID) plus the `sites` + `storeys` intersection case.

GREEN after the fix:
```
Tests  25 passed (25)   [bulk-query-engine.test.ts]
Tests  181 passed | 10 skipped (191)   [full suite; before: 172 passed | 10 skipped]
```

Added coverage for `storeys`/`buildings`/`spaces` too since they had none (same latent gap, pinned alongside `sites`).

### Mutation table (each spatial branch disabled one at a time, rebuilt, restored between runs)

| Branch disabled | Failing tests |
|---|---|
| `storeys` | `sites combined with storeys intersects (not unions) the two criteria`, `storeys filters to entities contained in the given storey IDs` |
| `buildings` | `buildings filters to entities contained in the given building IDs` |
| `sites` | `sites filters to entities contained in the given site IDs (disjoint sites)`, `sites with a second site ID includes both sites disjoint sets`, `sites excludes entities outside the requested site (regression: previously ignored, returned everything)`, `a site ID absent from bySite matches nothing for that ID`, `sites combined with storeys intersects (not unions) the two criteria` |
| `spaces` | `spaces filters to entities contained in the given space IDs` |

Every branch's removal killed at least one test — none is unpinned.

**Calibration check** (instrument sanity): reversing the entityId comparison in `compareEffectiveChanges` (`effective-changes.ts:87`) killed 3 tests including `is deterministically ordered by entityId, then kind, then name`, confirming the mutation-testing method itself works.

## Known gaps, unfixed (out of scope, self-documented as incomplete)

- `BulkQueryEngine.applyAction`'s `SET_ATTRIBUTE` case returns `null` unconditionally with a comment that attribute mutations "would need to be implemented" — a bulk action that validates and silently no-ops. Untested.
- `CsvConnector.matchRow`'s `'property'` strategy pushes a "Property matching not yet implemented" warning and matches nothing. Untested.

Both are already self-documented as incomplete (unlike the silent `sites` bug), so left for a maintainer decision on whether a declared-but-unimplemented option should throw instead of no-op.

## Test plan

- [x] RED: new tests fail against unmodified `select()` (5 failures)
- [x] GREEN: same tests pass after the fix (181 passed | 10 skipped, full suite)
- [x] Mutation table: each of the 4 spatial branches independently pinned
- [x] Calibration mutation confirms the instrument works
- [x] Reproduced against built `dist/index.js`, not just source

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk queries can now filter results by one or more site IDs.
  * Site filters work alongside existing building, storey, and space criteria.
  * Empty and unknown site selections are handled consistently.

* **Bug Fixes**
  * Excluded entities unrelated to the selected sites from bulk query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->