### PR TITLE
test(lens): pin matchesClassification's AND with a truth table

### DIFF
--- a/.changeset/lens-classification-and-code-truth-table.md
+++ b/.changeset/lens-classification-and-code-truth-table.md
@@ -1,0 +1,29 @@
+---
+'@ifc-lite/lens': patch
+---
+
+Pin `matchesClassification`'s `systemMatch && codeMatch` (`packages/lens/src/matching.ts:392`) with a truth table.
+
+Test-only; no production code changed. The only existing test supplying both
+`classificationSystem` and `classificationCode` (`'should match classification
+by system AND code'`) gives a case where both match, which passes under `&&`
+and under `||` alike — mutating the `&&` to `||` left all 165 tests green.
+Three cases now cover the remaining rows: system matches but code does not,
+code matches but system does not, and neither matches — each asserting
+`false`, discriminating AND from OR.
+
+Checked the sibling multi-field predicates in the same file
+(`matchesProperty`, `matchesAttribute`, `matchesQuantity`, `matchesMaterial`)
+for the same shape. None share it: each requires only one criteria field to be
+present for its match logic (a `propertySet`/`propertyName` pair, a
+`quantitySet`/`quantityName` pair, etc. are precondition guards, not two
+independently-testable match outcomes ANDed together) — `matchesClassification`
+is the only predicate here where two independently optional fields are both
+matched and ANDed.
+
+Not fixed here, flagged for the maintainer: the `exists` operator's
+empty-string handling is inconsistent across `matchesProperty` (`''` counts as
+present), `matchesQuantity` (`''` counts as present), and `matchesAttribute`
+(`''` counts as absent) — documented in code comments as intentional but not
+exercised by any test. Whether that asymmetry is intended is the maintainer's
+call; a prior sweep judged it low severity and did not pursue it.

--- a/packages/lens/src/matching.test.ts
+++ b/packages/lens/src/matching.test.ts
@@ -602,6 +602,33 @@ describe('matchesCriteria — classification', () => {
     expect(matchesCriteria(c, 1, provider)).toBe(true);
   });
 
+  it('should not match when system matches but code does not', () => {
+    const c: LensCriteria = {
+      type: 'classification',
+      classificationSystem: 'uniclass',
+      classificationCode: 'Pr_99_99_99',
+    };
+    expect(matchesCriteria(c, 1, provider)).toBe(false);
+  });
+
+  it('should not match when code matches but system does not', () => {
+    const c: LensCriteria = {
+      type: 'classification',
+      classificationSystem: 'Omniclass',
+      classificationCode: 'Pr_60_10_32',
+    };
+    expect(matchesCriteria(c, 1, provider)).toBe(false);
+  });
+
+  it('should not match when neither system nor code matches', () => {
+    const c: LensCriteria = {
+      type: 'classification',
+      classificationSystem: 'Omniclass',
+      classificationCode: 'Pr_99_99_99',
+    };
+    expect(matchesCriteria(c, 1, provider)).toBe(false);
+  });
+
   it('should return false when neither system nor code specified', () => {
     expect(matchesCriteria({ type: 'classification' }, 1, provider)).toBe(false);
   });


### PR DESCRIPTION
## Gap

`matchesClassification` (`packages/lens/src/matching.ts:392`) ends with `if (systemMatch && codeMatch) return true;`. That AND was unpinned: mutating it to `||` left all 165 tests in `packages/lens` green.

The only existing test supplying both `classificationSystem` and `classificationCode` — `'should match classification by system AND code'` (`matching.test.ts:596`) — gives a case where *both* fields match. A case where both match passes under AND and under OR alike, so it cannot discriminate the two.

## Truth table added

Alongside the existing "both match" case, three new cases in the same `describe` block:

- system matches, code does not → `false`
- code matches, system does not → `false`
- neither matches → `false`

## Sibling predicates checked

Looked at every other multi-field predicate in `matching.ts` for the same shape (a fixture where every field happens to match, masking a wrong boolean operator):

- `matchesProperty`, `matchesQuantity` — `propertySet`/`propertyName` and `quantitySet`/`quantityName` are presence *guards*, not two independently-matched fields ANDed together. No conjunction to pin.
- `matchesAttribute` — single field (`attributeName`). No conjunction.
- `matchesMaterial` — single field (`materialName`), matched against multiple accessor sources but not ANDed. No conjunction.
- `matchesModel`, `matchesGroup` — single field each. No conjunction.

`matchesClassification` is the only predicate in this file where two independently-optional fields are both matched and ANDed together.

## Mutation table

Each mutation applied, suite run, restored by `cp` + `diff` before the next.

| Site | Mutation | Failing tests |
|---|---|---|
| `matching.ts:392` (the fix) | `systemMatch && codeMatch` → `systemMatch \|\| codeMatch` | `should not match when system matches but code does not`, `should not match when code matches but system does not` |
| `matching.ts:172/174` (calibration) | `members.every` ↔ `members.some` in `matchesCompound` | 8 tests: `colors and counts entities matched by a compound rule like any other rule`, `fails when any member fails`, `an absent property inside an and fails the whole conjunction`, `matches when any member matches (numeric operator leaf)`, `an absent property fails its leaf closed, but the or still matches on another leaf`, `fails a wall that satisfies neither disjunct`, `a nested compound is really evaluated, not treated as an opaque leaf`, `a malformed (non-object) member fails its slot closed instead of throwing` |
| `engine.ts:169` (calibration) | reversed auto-color legend sort (`b[1].length - a[1].length` → `a[1].length - b[1].length`) | 2 tests: `should sort legend by count descending (largest group first)`, `renders a multi-material element in its LARGEST material group colour (#1366)` |

## Before/after

Same command (`pnpm test` in `packages/lens`), same 4 test files:

- Before: 165 passed
- After: 168 passed (3 new)

## Not fixed, flagged for the maintainer

The `exists` operator's empty-string handling is inconsistent across the comparison predicates: `matchesProperty` and `matchesQuantity` treat `''` as present, `matchesAttribute` treats `''` as absent. This is documented in code comments as an intentional asymmetry but is not exercised by any test. Whether the asymmetry is intended is the maintainer's call — a prior sweep judged it low severity and did not pursue it. Left unfixed and unpinned here, only observed.

## Scope

Test-only, no production logic changed (`packages/lens/src/matching.ts` and `engine.ts` are byte-identical to `main`; only `matching.test.ts` and the changeset differ).