### PR TITLE
fix(embed): emit SECTION_CHANGED when the section plane changes

### DIFF
--- a/.changeset/fix-embed-section-changed.md
+++ b/.changeset/fix-embed-section-changed.md
@@ -1,0 +1,19 @@
+---
+'@ifc-lite/viewer-embed': patch
+---
+
+Fix the embed viewer never emitting the `SECTION_CHANGED` event.
+
+`SECTION_CHANGED` is a declared `OutboundEventType` (`@ifc-lite/embed-protocol`)
+that `@ifc-lite/embed-sdk` exposes to host pages as the `'section-changed'`
+event, but nothing in the viewer ever posted it: the `SET_SECTION` bridge
+command handler mutated the section-plane store and replied with `RESPONSE`,
+and stopped there.
+
+`EmbedViewer.tsx` now subscribes to the section-plane store slice and emits
+`SECTION_CHANGED` reactively, the same pattern `CAMERA_CHANGED` and
+`ENTITY_SELECTED` already use for `SET_CAMERA`/`SELECT` (so the event also
+fires for section changes made through the in-viewer section tool, not only
+through `SET_SECTION`). The payload matches `OutboundPayloads.SECTION_CHANGED`
+exactly (`axis`, `position`, `enabled` -- `flipped` is not part of the
+declared shape, so it is not invented here).

--- a/apps/viewer-embed/src/components/EmbedViewer.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.test.ts
@@ -30,6 +30,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EmbedMessageEnvelope } from '@ifc-lite/embed-protocol';
 import React from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { act } from 'react';
@@ -120,5 +121,53 @@ describe('EmbedViewer: postMessage bridge survives React.StrictMode', () => {
     dispatchInbound({ type: 'SET_THEME', data: { theme: 'dark' } });
 
     expect(useViewerStore.getState().theme).toBe('dark');
+  });
+});
+
+/**
+ * SECTION_CHANGED is a declared OutboundEventType (packages/embed-protocol)
+ * that packages/embed-sdk exposes to host pages as 'section-changed'. The
+ * SDK's own test (events-lifecycle.test.ts) only proves the SDK's listener
+ * plumbing works by having the SDK fabricate the event itself -- it cannot
+ * prove the viewer ever sends it. This test drives the REAL bridge handler
+ * (apps/viewer-embed/src/bridge/handler.ts) through the real EmbedViewer
+ * component and observes what actually gets posted to window.parent, the
+ * same instrument the StrictMode test above uses for SET_THEME.
+ */
+describe('EmbedViewer: SET_SECTION emits SECTION_CHANGED to the parent', () => {
+  it('posts SECTION_CHANGED (matching the CAMERA_CHANGED/ENTITY_SELECTED pattern) after SET_SECTION', () => {
+    // handler.ts's SET_SECTION case never calls emitEvent itself -- it only
+    // mutates the store (same as SET_CAMERA/SELECT). The corresponding
+    // outbound event is produced reactively, by a useEffect in EmbedViewer.tsx
+    // subscribed to the relevant store slice -- exactly how CAMERA_CHANGED and
+    // ENTITY_SELECTED are produced from SET_CAMERA/SELECT. Capturing what
+    // reaches window.parent.postMessage is therefore the only way to observe
+    // this, hence overriding window.parent here (the FakeWindow harness in
+    // handler.test.ts does the same, just for a hand-built `window` rather
+    // than happy-dom's).
+    const posted: EmbedMessageEnvelope[] = [];
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: { postMessage: (msg: EmbedMessageEnvelope) => posted.push(msg) },
+    });
+
+    renderEmbedViewer();
+
+    dispatchInbound({ type: 'SET_SECTION', data: { enabled: true }, requestId: 'r1' });
+
+    const types = posted.map((m) => m.type);
+    // RESPONSE for the command must precede the reactive SECTION_CHANGED --
+    // same ordering CAMERA_CHANGED/ENTITY_SELECTED use relative to their
+    // triggering command's RESPONSE (posted synchronously in handler.ts,
+    // versus the event which fires from React's next effect pass).
+    expect(types.indexOf('RESPONSE')).toBeGreaterThanOrEqual(0);
+    expect(types.indexOf('SECTION_CHANGED')).toBeGreaterThan(types.indexOf('RESPONSE'));
+
+    const sectionChanged = posted.find((m) => m.type === 'SECTION_CHANGED');
+    expect(sectionChanged?.data).toEqual({
+      axis: useViewerStore.getState().sectionPlane.axis,
+      position: useViewerStore.getState().sectionPlane.position,
+      enabled: true,
+    });
   });
 });

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -250,6 +250,22 @@ export function EmbedViewer() {
     });
   }, [cameraRotation]);
 
+  // Emit section-plane changes to parent. Mirrors the CAMERA_CHANGED effect
+  // above: the bridge's SET_SECTION handler (apps/viewer-embed/src/bridge/
+  // handler.ts) only mutates `sectionPlane` via the store's setters and never
+  // emits an event itself, so this reactive subscription is what turns those
+  // mutations (from SET_SECTION *or* any in-viewer section-tool interaction)
+  // into the outbound SECTION_CHANGED event -- same source of truth as
+  // ENTITY_SELECTED/CAMERA_CHANGED, not a handler.ts-local special case.
+  const sectionPlane = useViewerStore((s) => s.sectionPlane);
+  useEffect(() => {
+    emitEvent('SECTION_CHANGED', {
+      axis: sectionPlane.axis,
+      position: sectionPlane.position,
+      enabled: sectionPlane.enabled,
+    });
+  }, [sectionPlane]);
+
   // Multi-model: create mapping from modelId to modelIndex
   const modelIdToIndex = useMemo(() => {
     const map = new Map<string, number>();


### PR DESCRIPTION
## Summary

`SECTION_CHANGED` is a declared `OutboundEventType` (`packages/embed-protocol`) that `packages/embed-sdk` exposes to host pages as the `'section-changed'` event, but the viewer never emitted it. `apps/viewer-embed/src/bridge/handler.ts`'s `SET_SECTION` case mutates the section-plane store (`toggleSectionPlane`/`flipSectionPlane`/`setSectionPlaneAxis`/`setSectionPlanePosition`) and posts only the command `RESPONSE` — `grep`ing `SECTION_CHANGED`/`emitEvent(` across `apps/viewer-embed/src` returned zero emit sites before this change.

**Reproduced before fixing**: driving the real bridge through the real `EmbedViewer` component and sending `SET_SECTION {enabled:true}` produced posted message types `["READY","READY","RESPONSE"]` — no `SECTION_CHANGED`.

**Why prior coverage missed it**: `packages/embed-sdk/test/events-lifecycle.test.ts` tests `'section-changed'` dispatch using `harness.emit(...)` — the SDK fabricating the message itself. That proves the SDK's listener plumbing works, not that the viewer ever sends the event. The new test in this PR drives the real handler (via the real `EmbedViewer` component, dispatching a real inbound `postMessage`) and asserts on what actually reaches `window.parent.postMessage`.

**Fix**: `handler.ts`'s `SET_SECTION` case never called `emitEvent` itself (same as `SET_CAMERA`/`SELECT` — those don't emit inline either). The corresponding outbound events (`CAMERA_CHANGED`, `ENTITY_SELECTED`) are produced reactively in `EmbedViewer.tsx` via a `useEffect` subscribed to the relevant store slice, so mutations reach the parent whether they came from the postMessage bridge or in-viewer interaction. I matched that pattern: added a `useEffect` subscribed to `state.sectionPlane`, matching the `CAMERA_CHANGED` effect immediately above it in the file. Ordering: `RESPONSE` is posted synchronously inside `handleCommand`; `SECTION_CHANGED` fires from React's next effect pass, same relative ordering as `CAMERA_CHANGED` after `SET_CAMERA`'s `RESPONSE`.

**Payload**: emits exactly `OutboundPayloads.SECTION_CHANGED` (`axis`, `position`, `enabled`) — `flipped` is not part of the declared shape, so it isn't included.

**No-op resend**: matches the siblings' existing behavior rather than adding new logic — `setSectionPlaneAxis`/`setSectionPlanePosition` are called unconditionally when the field is present in the payload (same as `SET_CAMERA` unconditionally calling `setCameraRotation`), so those always produce a new store object and re-fire the event even if the value is unchanged. `enabled`/`flipped` are only mutated when they actually differ from current state (an existing guard in `SET_SECTION`), so a genuine no-op resend of just those fields does not re-fire the event, because the store object reference doesn't change.

## Not fixed (recorded here for a maintainer decision)

- **`ENTITY_HOVERED`** — declared in `OutboundEventType`, promised by embed-sdk's `EventMap`, never emitted by the viewer. No existing hover state is plumbed into the bridge or store, so wiring it is a larger change than this PR's scope.
- **Seven ignored URL params** — `controls`, `hideAxis`, `hideScale`, `hideTypes`, `select`, `isolate`, `autoLoad` are serialized by the SDK and parsed by `apps/viewer-embed/src/bridge/urlParams.ts`, but `EmbedViewer.tsx` only reads `theme`, `parentOrigin`, `allowOrigins`, `modelUrl`, `view`, `camera`, `bg`. A host using the documented API gets a silent no-op for these. User-visible.
- **No viewer-side protocol version guard** — `isEmbedMessage()` checks `source` but never `version`; a command with an unrecognized or missing `version` field still executes. The SDK side documents this gap in a passing test; the viewer side has no equivalent guard.

## Test plan

- [x] `packages/embed-protocol`: 22/22 (unchanged, no protocol change)
- [x] `packages/embed-sdk`: 69/69 (unchanged)
- [x] `apps/viewer-embed`: 141/141 (140 baseline + 1 new test)
- [x] New test drives the real `EmbedViewer` + bridge handler (not the SDK fabricating the event) and asserts `SECTION_CHANGED` is posted after `RESPONSE`, with the payload matching the store's `sectionPlane` state
- [x] Mutation testing: removing the `emitEvent('SECTION_CHANGED', ...)` call, and swapping in a wrong payload field, both fail the new test; a calibration mutation on `SET_THEME` → `state.setTheme` fails the pre-existing `SET_THEME` tests, confirming the harness detects removed behavior