### PR TITLE
test(ids): pin PSET_MISSING and PARTOF_RELATION_MISSING in optional allowlist

### DIFF
--- a/.changeset/ids-optional-absent-pin.md
+++ b/.changeset/ids-optional-absent-pin.md
@@ -1,0 +1,24 @@
+---
+'@ifc-lite/ids': patch
+---
+
+Add regression tests pinning `PSET_MISSING` and `PARTOF_RELATION_MISSING`
+in `checkRequirement`'s `optional` allowlist (`packages/ids/src/validation/validator.ts`).
+
+Per the IDS spec, `optional` means "if present, must satisfy" -- a
+wholly-absent facet passes, a present-but-wrong facet fails. The allowlist
+that implements this already covered eight failure-type codes, but two of
+them -- `PSET_MISSING` (entity has no property sets at all) and
+`PARTOF_RELATION_MISSING` (entity has no parent under the requested
+relation at all) -- had no test forcing that exact shape, so either could
+be silently dropped from the allowlist without failing `vitest run` or the
+vendored buildingSMART corpus runner. Dropping either causes a
+wrong-direction regression: entities that legitimately have nothing would
+start failing an `optional` requirement instead of passing it.
+
+No production logic changed. This also re-verifies the other six codes in
+the same allowlist (`ATTRIBUTE_MISSING`, `PROPERTY_MISSING`,
+`CLASSIFICATION_MISSING`, `MATERIAL_MISSING`, `PREDEFINED_TYPE_MISSING`,
+`PARTOF_PREDEFINED_TYPE_MISSING`) individually against both suites; all
+six were already pinned by at least one of `vitest run` or
+`npm run test:ids-corpus`.

--- a/packages/ids/src/validation/validator.test.ts
+++ b/packages/ids/src/validation/validator.test.ts
@@ -286,6 +286,67 @@ describe('validateIDS — optionality', () => {
     expect(reqResult.status).toBe('pass');
     expect(report.specificationResults[0].status).toBe('pass');
   });
+
+  it('optional property requirement passes when the entity has no pset at all (not merely the property)', async () => {
+    // PSET_MISSING means the entity carries zero property sets — a
+    // stronger "wholly absent" shape than PROPERTY_MISSING (pset
+    // present, named property missing). `optional` must pardon this,
+    // exactly like it pardons ATTRIBUTE_MISSING / PROPERTY_MISSING.
+    const accessor = createMockAccessor([
+      { expressId: 1, type: 'IfcWall' }, // no `properties` at all -> getPropertySets() === []
+    ]);
+
+    const spec = makeSpec({
+      requirements: [
+        {
+          id: 'req-0',
+          facet: {
+            type: 'property',
+            propertySet: sv('Pset_WallCommon'),
+            baseName: sv('FireRating'),
+          },
+          optionality: 'optional',
+        },
+      ],
+    });
+
+    const report = await validateIDS(makeDoc([spec]), accessor, modelInfo);
+    const reqResult = report.specificationResults[0].entityResults[0].requirementResults[0];
+    expect(reqResult.failure?.type).toBe('PSET_MISSING');
+    expect(reqResult.status).toBe('pass');
+    expect(report.specificationResults[0].status).toBe('pass');
+  });
+
+  it('optional partOf requirement passes when the entity has no parent relation at all', async () => {
+    // PARTOF_RELATION_MISSING means the entity has no parent under the
+    // requested relation whatsoever — the relation itself is absent,
+    // not merely pointing at the wrong entity. `optional` must pardon
+    // this "wholly absent" shape the same way it pardons the sibling
+    // *_MISSING failure types.
+    const accessor = createMockAccessor([
+      { expressId: 1, type: 'IfcWall' }, // no `parent` at all -> getParent() === undefined
+    ]);
+
+    const spec = makeSpec({
+      requirements: [
+        {
+          id: 'req-0',
+          facet: {
+            type: 'partOf',
+            relation: 'IfcRelContainedInSpatialStructure',
+            entity: { type: 'entity', name: sv('IFCBUILDINGSTOREY') },
+          },
+          optionality: 'optional',
+        },
+      ],
+    });
+
+    const report = await validateIDS(makeDoc([spec]), accessor, modelInfo);
+    const reqResult = report.specificationResults[0].entityResults[0].requirementResults[0];
+    expect(reqResult.failure?.type).toBe('PARTOF_RELATION_MISSING');
+    expect(reqResult.status).toBe('pass');
+    expect(report.specificationResults[0].status).toBe('pass');
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

`checkRequirement`'s `optional` branch (`packages/ids/src/validation/validator.ts:545-559`) pardons a wholly-absent facet via an eight-code allowlist. Two of those eight -- `PSET_MISSING` (entity has no property sets at all) and `PARTOF_RELATION_MISSING` (entity has no parent under the requested relation at all) -- had no test forcing that exact failure shape. Removing both from the allowlist left `vitest run` at 326/326 and the vendored buildingSMART corpus at 318/318: neither suite caught it.

This PR adds one regression test per code, each asserting `reqResult.failure?.type` to confirm the fixture reaches the intended code (not the neighbouring `PROPERTY_MISSING`), and asserting `status` is `'pass'` -- an `optional` requirement against an entity with no pset/no parent relation at all must pass, not fail. No production logic changed; the existing mapping is correct per the IDS spec's "optional = if present, must satisfy" semantics.

While isolating this, I also individually removed each of the other six codes in the allowlist and reran both suites to check they're pinned somewhere:

| Code | vitest (removed) | corpus (removed) | Pinned by |
|---|---|---|---|
| `ATTRIBUTE_MISSING` | 1 fail: "optional requirements always pass even when facet fails" | 316/318 (2 divergences) | both |
| `PROPERTY_MISSING` | 326/326 (none) | 317/318 (1 divergence) | corpus only |
| `PSET_MISSING` | 326/326 (none) | 318/318 (none) | **neither -- now pinned by this PR** |
| `CLASSIFICATION_MISSING` | 326/326 (none) | 316/318 (2 divergences) | corpus only |
| `MATERIAL_MISSING` | 326/326 (none) | 317/318 (1 divergence) | corpus only |
| `PARTOF_RELATION_MISSING` | 326/326 (none) | 318/318 (none) | **neither -- now pinned by this PR** |
| `PREDEFINED_TYPE_MISSING` | 1 fail: "optional entity requirement passes when predefinedType is wholly absent" | 318/318 (none) | vitest only |
| `PARTOF_PREDEFINED_TYPE_MISSING` | 1 fail: "optional partOf requirement passes when parent predefinedType is wholly absent" | 318/318 (none) | vitest only |

Also reproduced the two isolations given as background for this task, on the unmodified allowlist:
- Removing `PSET_MISSING` + `PARTOF_RELATION_MISSING` together -> vitest 326/326, corpus 318/318 (fully green both ways -- confirms the gap).
- Removing `PROPERTY_MISSING` + `CLASSIFICATION_MISSING` + `MATERIAL_MISSING` + `PARTOF_RELATION_MISSING` together -> corpus drops to 314/318 (4 divergences), confirming the corpus does exercise the other three.

And the calibration: flipping `applicableCount < minExpected` to `<=` at `validator.ts:641` fails exactly one test, `minOccurs=0 maxOccurs=0 passes when no entities match (prohibited spec)` -- confirms the instrument (running vitest against a deliberate mutation) actually works.

Before/after with the real allowlist restored:
- `npx vitest run` (packages/ids): 17 files, 328 tests (was 326; +2 new tests)
- `npm run test:ids-corpus`: 318/318, 100% parity (unchanged)

## Note (not fixed here)

The vendored buildingSMART corpus runner (`scripts/test-ids-corpus.mjs`, `npm run test:ids-corpus`, 318 `.ids`+`.ifc` pairs under `packages/ids/src/__corpus__/buildingsmart-ids/`) is not invoked by any CI workflow (`grep -rn "test-ids-corpus" .github/workflows/*.yml` returns nothing). It passes 318/318 today but isn't run automatically, so it doesn't guard against regressions in CI. Not fixed in this PR to avoid conflicting with other PRs already queued against `test.yml`.

## Test plan
- [x] `npx vitest run` in `packages/ids`: 17 files, 328 tests passed
- [x] `npm run test:ids-corpus` (dist rebuilt): 318/318, 100% parity
- [x] Both new tests reproduced RED (fail) with their respective code removed from the allowlist, and GREEN with the real code
