### PR TITLE
fix(collab-server): do not count the server itself as a room peer

### DIFF
--- a/.changeset/collab-server-not-a-peer.md
+++ b/.changeset/collab-server-not-a-peer.md
@@ -2,9 +2,14 @@
 '@ifc-lite/collab-server': patch
 ---
 
-Stop the collab server counting itself as a room participant. y-protocols'
-`Awareness` constructor self-registers a local state of `{}` and renews it every
-15 seconds, so every room's peer badge read one too high: it showed "(2)"
-directly above a roster saying "You're the only one here", because the roster
-filters on a `user` field and the badge did not. The server now clears its own
-awareness state, which also stops the renewal.
+Stop the collab server counting itself as a room participant, and give it a real
+keepalive. y-protocols' `Awareness` constructor self-registers a local state of
+`{}` and renews it every 15 seconds, so every room's peer badge read one too
+high: it showed "(2)" directly above a roster saying "You're the only one here",
+because the roster filters on a `user` field and the badge did not.
+
+That renewal was also the only server-to-client traffic in a single-occupant
+room, and so was accidentally feeding y-websocket's 30 second reconnect
+watchdog. Clearing the ghost alone put every lone client into a permanent ~30
+second disconnect/reconnect loop, so the server now sends an explicit
+application-level keepalive instead of relying on that side effect.

--- a/.changeset/collab-server-not-a-peer.md
+++ b/.changeset/collab-server-not-a-peer.md
@@ -9,7 +9,7 @@ high: it showed "(2)" directly above a roster saying "You're the only one here",
 because the roster filters on a `user` field and the badge did not.
 
 That renewal was also the only server-to-client traffic in a single-occupant
-room, and so was accidentally feeding y-websocket's 30 second reconnect
+room, and so was accidentally feeding y-websocket's 30-second reconnect
 watchdog. Clearing the ghost alone put every lone client into a permanent ~30
 second disconnect/reconnect loop, so the server now sends an explicit
 application-level keepalive instead of relying on that side effect.

--- a/.changeset/collab-server-not-a-peer.md
+++ b/.changeset/collab-server-not-a-peer.md
@@ -1,0 +1,10 @@
+---
+'@ifc-lite/collab-server': patch
+---
+
+Stop the collab server counting itself as a room participant. y-protocols'
+`Awareness` constructor self-registers a local state of `{}` and renews it every
+15 seconds, so every room's peer badge read one too high: it showed "(2)"
+directly above a roster saying "You're the only one here", because the roster
+filters on a `user` field and the badge did not. The server now clears its own
+awareness state, which also stops the renewal.

--- a/packages/collab-server/src/room-manager.ts
+++ b/packages/collab-server/src/room-manager.ts
@@ -34,6 +34,13 @@ import { createRateLimiter, type RateLimitOptions, type RateLimiter } from './ra
 const MESSAGE_SYNC = 0;
 const MESSAGE_AWARENESS = 1;
 
+/**
+ * An awareness update naming ZERO clients: a single varUint `0` length prefix.
+ * `applyAwarenessUpdate` decodes it as a no-op, but it is a real WebSocket
+ * message, which is the point. See `Room.sendKeepalive`.
+ */
+const EMPTY_AWARENESS_UPDATE = new Uint8Array([0]);
+
 // Inner sync-message subtypes (mirror y-protocols/sync constants) used for
 // the cheap pre-verify frame peek. Kept local so the peek never has to call
 // the full readSyncMessage (which applies payloads to the doc as a side
@@ -230,6 +237,37 @@ export class Room {
       );
       safeSend(conn.ws, encoding.toUint8Array(aenc));
     }
+  }
+
+  /**
+   * Send an application-level keepalive to one peer.
+   *
+   * y-websocket's client closes a connection after
+   * `messageReconnectTimeout` (30s, a module-level const, not configurable)
+   * with no inbound MESSAGE, and only `websocket.onmessage` refreshes that
+   * clock (y-websocket/src/y-websocket.js:186,387-396). WebSocket protocol
+   * pings do not count: they are auto-ponged below the message layer, so the
+   * `ws.ping()` loop in `server.ts` cannot feed it.
+   *
+   * This server does not echo a peer's own updates back to it
+   * (`if (conn === origin) continue;` below, and the same for doc updates), so
+   * a room with ONE occupant produces no server-to-client traffic at all after
+   * the initial handshake. y-websocket's own comment says the timeout assumes
+   * "not even your own awareness updates (which are updated every 15 seconds)"
+   * come back, i.e. the reference server echoes them and ours does not.
+   *
+   * Until #2791 that gap was masked by an accident: the server's own Awareness
+   * ghost state renewed every ~15s and was broadcast to everyone, feeding the
+   * watchdog. Clearing the ghost removes the accident, so the keepalive has to
+   * be explicit. Measured: with the ghost gone and no keepalive, a lone client
+   * closed and reconnected at t=30s and t=63s over a 75s window; with either
+   * one present, zero closes.
+   */
+  sendKeepalive(conn: PeerConnection): void {
+    const enc = encoding.createEncoder();
+    encoding.writeVarUint(enc, MESSAGE_AWARENESS);
+    encoding.writeVarUint8Array(enc, EMPTY_AWARENESS_UPDATE);
+    safeSend(conn.ws, encoding.toUint8Array(enc));
   }
 
   removeConnection(conn: PeerConnection): void {

--- a/packages/collab-server/src/room-manager.ts
+++ b/packages/collab-server/src/room-manager.ts
@@ -120,6 +120,17 @@ export class Room {
     this.id = id;
     this.doc = new Y.Doc();
     this.awareness = new Awareness(this.doc);
+    // y-protocols' Awareness constructor self-registers a local state of `{}`
+    // for its own clientID and renews it every ~15s. The server is a relay,
+    // not a participant: left in place, that entry is broadcast to every
+    // client as a peer, so every room badge read one too high (#2791). It
+    // showed "(2)" directly above a roster saying "You're the only one here",
+    // because the roster filters on a `user` field and the badge did not.
+    // Clearing the state also stops the renewal, which y-protocols guards on
+    // `getLocalState() !== null`.
+    // This must stay BEFORE the `update` listener is wired up below, so that
+    // clearing it cannot broadcast a removal for a peer no client ever saw.
+    this.awareness.setLocalState(null);
     this.persistence = opts.persistence;
     this.compactEvery = opts.compactEvery ?? 1000;
     this.auditSink = opts.auditSink ?? noopAuditSink;

--- a/packages/collab-server/src/server.ts
+++ b/packages/collab-server/src/server.ts
@@ -220,6 +220,34 @@ const PING_INTERVAL_MS = 30_000;
  */
 const KEEPALIVE_INTERVAL_MS = 15_000;
 
+/**
+ * The watchdog this keepalive exists to feed. y-websocket closes a connection
+ * after this long with no inbound message, and it is a module-level const there
+ * with no per-provider override, so we cannot widen it.
+ */
+const CLIENT_RECONNECT_TIMEOUT_MS = 30_000;
+
+/**
+ * Validate a configured keepalive period, rejecting values that would silently
+ * defeat it in EITHER direction.
+ *
+ * Too small is the classic footgun: `setInterval` coerces 0, negative and
+ * non-finite delays to about 1ms, so a typo turns the keepalive into a flood.
+ * Too large is the subtler one and is specific to this feature: at or above
+ * the client's 30s timeout the keepalive cannot refresh the watchdog in time,
+ * so it would appear configured while the disconnect loop it prevents came
+ * back. Both fail loudly instead.
+ */
+function resolveKeepaliveMs(configured: number | undefined): number {
+  if (configured === undefined) return KEEPALIVE_INTERVAL_MS;
+  if (!Number.isFinite(configured) || configured <= 0 || configured >= CLIENT_RECONNECT_TIMEOUT_MS) {
+    throw new Error(
+      `[collab-server] keepaliveIntervalMs must be a finite number in (0, ${CLIENT_RECONNECT_TIMEOUT_MS}); got ${configured}`,
+    );
+  }
+  return configured;
+}
+
 export async function startCollabServer(
   opts: StartCollabServerOptions = {},
 ): Promise<CollabServerHandle> {
@@ -254,6 +282,10 @@ export async function startCollabServer(
     : opts.authorizeRegistry === null
       ? undefined
       : opts.authorizeRegistry ?? makeRegistryAuthorizer(authenticate);
+  // Validate at STARTUP, not per connection: a throw inside the connection
+  // handler is swallowed by its own .catch, so a misconfigured server would
+  // come up healthy and only misbehave once someone connected.
+  const keepaliveIntervalMs = resolveKeepaliveMs(opts.keepaliveIntervalMs);
   const metricsToken = opts.metricsToken ?? process.env.COLLAB_METRICS_TOKEN;
   const metrics = opts.metrics ?? defaultMetrics;
   const peersGauge = metrics.gauge(
@@ -407,7 +439,7 @@ export async function startCollabServer(
       handleConnection(ws, req, {
         roomManager,
         authenticate,
-        keepaliveIntervalMs: opts.keepaliveIntervalMs,
+        keepaliveIntervalMs,
       }).catch((err) => {
         // eslint-disable-next-line no-console
         console.error('[collab-server] connection setup failed:', err);

--- a/packages/collab-server/src/server.ts
+++ b/packages/collab-server/src/server.ts
@@ -100,6 +100,12 @@ function applyCors(
 
 export interface StartCollabServerOptions {
   port?: number;
+  /**
+   * Application-level keepalive period in ms (default 15s). Exposed so tests
+   * can observe the keepalive without waiting on the real cadence; production
+   * callers should leave it alone. See `Room.sendKeepalive`.
+   */
+  keepaliveIntervalMs?: number;
   host?: string;
   persistence?: Persistence;
   authenticate?: AuthenticateFn;
@@ -205,6 +211,14 @@ export interface CollabServerHandle {
 }
 
 const PING_INTERVAL_MS = 30_000;
+
+/**
+ * Application-level keepalive period. Must stay comfortably under
+ * y-websocket's hardcoded 30s `messageReconnectTimeout`; 15s matches the
+ * awareness renewal cadence the client's watchdog was written around.
+ * See `Room.sendKeepalive`.
+ */
+const KEEPALIVE_INTERVAL_MS = 15_000;
 
 export async function startCollabServer(
   opts: StartCollabServerOptions = {},
@@ -390,7 +404,11 @@ export async function startCollabServer(
       // surfacing as a process-level unhandledRejection. Catch the error,
       // log it, and close the socket with a non-1000 code so the client
       // sees a deterministic shutdown.
-      handleConnection(ws, req, { roomManager, authenticate }).catch((err) => {
+      handleConnection(ws, req, {
+        roomManager,
+        authenticate,
+        keepaliveIntervalMs: opts.keepaliveIntervalMs,
+      }).catch((err) => {
         // eslint-disable-next-line no-console
         console.error('[collab-server] connection setup failed:', err);
         try {
@@ -439,6 +457,8 @@ export async function startCollabServer(
 interface ConnectionContext {
   roomManager: RoomManager;
   authenticate: AuthenticateFn;
+  /** See `StartCollabServerOptions.keepaliveIntervalMs`. */
+  keepaliveIntervalMs?: number;
 }
 
 async function handleConnection(ws: WebSocket, req: http.IncomingMessage, ctx: ConnectionContext) {
@@ -475,6 +495,12 @@ async function handleConnection(ws: WebSocket, req: http.IncomingMessage, ctx: C
   };
   room.addConnection(conn);
 
+  // Application-level keepalive. Distinct from the protocol ping below: only
+  // a real message refreshes y-websocket's reconnect watchdog.
+  const keepalive = setInterval(() => {
+    room.sendKeepalive(conn);
+  }, ctx.keepaliveIntervalMs ?? KEEPALIVE_INTERVAL_MS);
+
   let alive = true;
   const ping = setInterval(() => {
     if (!alive) {
@@ -494,6 +520,7 @@ async function handleConnection(ws: WebSocket, req: http.IncomingMessage, ctx: C
 
   const cleanup = () => {
     clearInterval(ping);
+    clearInterval(keepalive);
     room.removeConnection(conn);
   };
   ws.on('close', cleanup);

--- a/packages/collab-server/src/server.ts
+++ b/packages/collab-server/src/server.ts
@@ -228,21 +228,39 @@ const KEEPALIVE_INTERVAL_MS = 15_000;
 const CLIENT_RECONNECT_TIMEOUT_MS = 30_000;
 
 /**
+ * Largest keepalive period that can actually keep a connection alive.
+ *
+ * Merely being under {@link CLIENT_RECONNECT_TIMEOUT_MS} is not enough. A
+ * period of 29_999ms against a 30_000ms watchdog leaves 1ms for timer
+ * scheduling, serialisation and network transit, so the frame routinely lands
+ * after the deadline and the client disconnects anyway. The margin below has
+ * to cover a slow hop and an event loop that is busy, or the keepalive is
+ * configured and still useless.
+ */
+const MAX_KEEPALIVE_INTERVAL_MS = 25_000;
+
+/**
  * Validate a configured keepalive period, rejecting values that would silently
  * defeat it in EITHER direction.
  *
  * Too small is the classic footgun: `setInterval` coerces 0, negative and
  * non-finite delays to about 1ms, so a typo turns the keepalive into a flood.
- * Too large is the subtler one and is specific to this feature: at or above
- * the client's 30s timeout the keepalive cannot refresh the watchdog in time,
- * so it would appear configured while the disconnect loop it prevents came
+ * Too large is the subtler one and is specific to this feature: a period that
+ * does not clear the client's watchdog with margin leaves the server looking
+ * correctly configured while the disconnect loop it exists to prevent comes
  * back. Both fail loudly instead.
  */
 function resolveKeepaliveMs(configured: number | undefined): number {
   if (configured === undefined) return KEEPALIVE_INTERVAL_MS;
-  if (!Number.isFinite(configured) || configured <= 0 || configured >= CLIENT_RECONNECT_TIMEOUT_MS) {
+  if (
+    !Number.isFinite(configured) ||
+    configured <= 0 ||
+    configured > MAX_KEEPALIVE_INTERVAL_MS
+  ) {
     throw new Error(
-      `[collab-server] keepaliveIntervalMs must be a finite number in (0, ${CLIENT_RECONNECT_TIMEOUT_MS}); got ${configured}`,
+      `[collab-server] keepaliveIntervalMs must be a finite number in (0, ${MAX_KEEPALIVE_INTERVAL_MS}]; ` +
+        `got ${configured}. The client closes after ${CLIENT_RECONNECT_TIMEOUT_MS}ms of silence, ` +
+        'so the period must clear that with margin for transit and scheduling.',
     );
   }
   return configured;

--- a/packages/collab-server/test/awareness-server-not-a-peer.test.ts
+++ b/packages/collab-server/test/awareness-server-not-a-peer.test.ts
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The server relays awareness; it is not itself a peer (#2791).
+ *
+ * y-protocols' `Awareness` constructor self-registers a local state of `{}` for
+ * its own clientID, so `new Awareness(this.doc)` inside `Room` used to publish
+ * the SERVER as a participant. Every client counted it, so every room badge
+ * read one too high: "(2)" directly above a roster reading "You're the only
+ * one here", because the roster filters on a `user` field and the badge did
+ * not.
+ *
+ * How the ghost actually reached clients, measured rather than assumed: NOT via
+ * the connect-time snapshot in `addConnection`, but via the ~15s renewal. A
+ * lone client polled every 2s saw only itself through t=14s and picked up a
+ * second, empty state at t=16s, which then persisted. That matches the
+ * production observation this was filed from (t=18s, one remote peer, `{}`).
+ * `_checkInterval` in y-protocols/awareness.js:59-63 re-sets the local state
+ * once `outdatedTimeout / 2` (15s) has elapsed, which broadcasts it.
+ *
+ * The second test therefore drives that exact renewal call instead of sleeping
+ * for 15s of wall clock. The third test is the no-regression half: clearing the
+ * server's own state must not stop it forwarding real peers to each other.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import { WebSocket } from 'ws';
+import { WebsocketProvider } from 'y-websocket';
+import { MemoryPersistence, startCollabServer } from '../src/server.js';
+
+async function startServer() {
+  const handle = await startCollabServer({ port: 0, persistence: new MemoryPersistence() });
+  const address = handle.httpServer.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  return { handle, url: `ws://127.0.0.1:${port}` };
+}
+
+function connect(url: string, room: string) {
+  const doc = new Y.Doc();
+  const provider = new WebsocketProvider(url, room, doc, {
+    WebSocketPolyfill: WebSocket as never,
+    disableBc: true,
+  });
+  return { doc, provider };
+}
+
+const synced = (p: WebsocketProvider) =>
+  new Promise<void>((resolve) => {
+    if (p.synced) return resolve();
+    p.once('sync', () => resolve());
+  });
+
+/** Awareness clientIDs visible to `provider` other than its own. */
+function remoteClientIds(provider: WebsocketProvider, ownClientId: number): number[] {
+  return [...provider.awareness.getStates().keys()].filter((id) => id !== ownClientId);
+}
+
+const describeStates = (provider: WebsocketProvider) =>
+  JSON.stringify([...provider.awareness.getStates().entries()]);
+
+describe('server awareness is not a peer', () => {
+  it('a room publishes no awareness state of its own', async () => {
+    const { handle, url } = await startServer();
+    const { provider } = connect(url, 'room-invariant');
+    await synced(provider);
+
+    const room = await handle.roomManager.peek('room-invariant');
+    expect(room, 'room was not created').toBeTruthy();
+    const own = room!.awareness.getLocalState();
+    const published = [...room!.awareness.getStates().keys()];
+
+    expect(own, `server still publishes a local awareness state: ${JSON.stringify(own)}`).toBeNull();
+    expect(
+      published.includes(room!.awareness.clientID),
+      `server's own clientID ${room!.awareness.clientID} is in its published states ${JSON.stringify(published)}`,
+    ).toBe(false);
+
+    provider.destroy();
+    await handle.stop();
+  }, 15_000);
+
+  it('a renewal tick broadcasts no server peer to a lone client', async () => {
+    const { handle, url } = await startServer();
+    const { doc, provider } = connect(url, 'solo-room');
+    await synced(provider);
+
+    const room = await handle.roomManager.peek('solo-room');
+    expect(room).toBeTruthy();
+
+    // Exactly what y-protocols' _checkInterval does every 15s
+    // (awareness.js:61-63). With the server's state left in place this
+    // re-broadcasts `{}` and the client gains a phantom peer; with it cleared
+    // the local state is null and there is nothing to renew.
+    room!.awareness.setLocalState(room!.awareness.getLocalState());
+
+    // Give the broadcast time to land. The earlier measured propagation was
+    // well under 100ms, so 500ms is slack, not a race.
+    await new Promise((r) => setTimeout(r, 500));
+
+    expect(
+      remoteClientIds(provider, doc.clientID),
+      `lone client sees a phantom peer: ${describeStates(provider)}`,
+    ).toEqual([]);
+
+    provider.destroy();
+    await handle.stop();
+  }, 15_000);
+
+  it('still relays a real peer between two clients', async () => {
+    const { handle, url } = await startServer();
+    const a = connect(url, 'pair-room');
+    const b = connect(url, 'pair-room');
+    await Promise.all([synced(a.provider), synced(b.provider)]);
+
+    a.provider.awareness.setLocalStateField('user', { id: 'u-a', name: 'A' });
+
+    const deadline = Date.now() + 3000;
+    let fromB: unknown;
+    while (Date.now() < deadline) {
+      fromB = b.provider.awareness.getStates().get(a.doc.clientID);
+      if (fromB) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(fromB, 'B never received A awareness state').toBeTruthy();
+    expect((fromB as { user?: { id?: string } }).user?.id).toBe('u-a');
+
+    // ...and B sees exactly ONE peer: A, with no server ghost beside it.
+    expect(remoteClientIds(b.provider, b.doc.clientID)).toEqual([a.doc.clientID]);
+
+    a.provider.destroy();
+    b.provider.destroy();
+    await handle.stop();
+  }, 15_000);
+});

--- a/packages/collab-server/test/awareness-server-not-a-peer.test.ts
+++ b/packages/collab-server/test/awareness-server-not-a-peer.test.ts
@@ -31,8 +31,12 @@ import { WebSocket } from 'ws';
 import { WebsocketProvider } from 'y-websocket';
 import { MemoryPersistence, startCollabServer } from '../src/server.js';
 
-async function startServer() {
-  const handle = await startCollabServer({ port: 0, persistence: new MemoryPersistence() });
+async function startServer(extra: { keepaliveIntervalMs?: number } = {}) {
+  const handle = await startCollabServer({
+    port: 0,
+    persistence: new MemoryPersistence(),
+    ...extra,
+  });
   const address = handle.httpServer.address();
   const port = typeof address === 'object' && address ? address.port : 0;
   return { handle, url: `ws://127.0.0.1:${port}` };
@@ -134,4 +138,70 @@ describe('server awareness is not a peer', () => {
     b.provider.destroy();
     await handle.stop();
   }, 15_000);
+});
+
+describe('server keepalive', () => {
+  // The ghost this file removes was ALSO an accidental keepalive: its ~15s
+  // renewal was the only server-to-client traffic in a single-occupant room,
+  // and it was what fed y-websocket's 30s `messageReconnectTimeout`. Removing
+  // the ghost without an explicit keepalive put every lone client into a
+  // permanent ~30s disconnect/reconnect loop.
+  //
+  // Measured over 75s, one client, three builds:
+  //   ghost cleared, no keepalive -> closes at t=30s and t=63s
+  //   ghost present (old main)    -> 0 closes
+  //   ghost cleared + keepalive   -> 0 closes
+  //
+  // None of the tests above catch that: the fault needs >30s of wall clock,
+  // and `messageReconnectTimeout` is a module const in y-websocket with no
+  // per-provider override, so it cannot be shortened. Hence one real-time
+  // test, plus a fast one for the mechanism itself.
+
+  it('sends awareness keepalive frames to an idle peer', async () => {
+    const { handle, url } = await startServer({ keepaliveIntervalMs: 120 });
+    const raw = new WebSocket(`${url}/keepalive-room`);
+    await new Promise<void>((resolve, reject) => {
+      raw.once('open', () => resolve());
+      raw.once('error', reject);
+    });
+
+    const frames: Uint8Array[] = [];
+    raw.on('message', (d: Buffer) => frames.push(new Uint8Array(d)));
+    await new Promise((r) => setTimeout(r, 900));
+
+    // MESSAGE_AWARENESS = 1, payload = one varUint 0 (zero clients named).
+    const keepalives = frames.filter(
+      (f) => f.length === 3 && f[0] === 1 && f[1] === 1 && f[2] === 0,
+    );
+    expect(
+      keepalives.length,
+      `expected repeated keepalive frames; got ${frames.length} frames: ${JSON.stringify(frames.map((f) => [...f]))}`,
+    ).toBeGreaterThanOrEqual(3);
+
+    raw.close();
+    await handle.stop();
+  }, 15_000);
+
+  it('a lone client stays connected past the 30s reconnect timeout', async () => {
+    const { handle, url } = await startServer();
+    const { provider } = connect(url, 'lonely-room');
+
+    let closes = 0;
+    provider.on('connection-close', () => {
+      closes += 1;
+    });
+    await synced(provider);
+
+    // One full watchdog window plus margin. The regression fired at t=30.0s.
+    await new Promise((r) => setTimeout(r, 45_000));
+
+    expect(
+      closes,
+      'lone client was dropped by the client-side reconnect watchdog: no server traffic for 30s',
+    ).toBe(0);
+    expect(provider.wsconnected).toBe(true);
+
+    provider.destroy();
+    await handle.stop();
+  }, 90_000);
 });

--- a/packages/collab-server/test/awareness-server-not-a-peer.test.ts
+++ b/packages/collab-server/test/awareness-server-not-a-peer.test.ts
@@ -25,11 +25,40 @@
  * server's own state must not stop it forwarding real peers to each other.
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import * as Y from 'yjs';
 import { WebSocket } from 'ws';
 import { WebsocketProvider } from 'y-websocket';
 import { MemoryPersistence, startCollabServer } from '../src/server.js';
+
+// A failed assertion must not leak a listening server, an open socket or a
+// live interval into the rest of the file: the next test then races a stray
+// keepalive and fails for reasons that have nothing to do with it. Everything
+// created here is registered for teardown, so cleanup does not depend on the
+// happy path reaching the end of a test.
+const openProviders: WebsocketProvider[] = [];
+const openSockets: WebSocket[] = [];
+const openHandles: Array<{ stop: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  for (const p of openProviders.splice(0)) {
+    try {
+      p.destroy();
+    } catch {
+      /* already torn down */
+    }
+  }
+  for (const w of openSockets.splice(0)) {
+    try {
+      w.close();
+    } catch {
+      /* already closed */
+    }
+  }
+  for (const h of openHandles.splice(0)) {
+    await h.stop().catch(() => undefined);
+  }
+});
 
 async function startServer(extra: { keepaliveIntervalMs?: number } = {}) {
   const handle = await startCollabServer({
@@ -39,6 +68,7 @@ async function startServer(extra: { keepaliveIntervalMs?: number } = {}) {
   });
   const address = handle.httpServer.address();
   const port = typeof address === 'object' && address ? address.port : 0;
+  openHandles.push(handle);
   return { handle, url: `ws://127.0.0.1:${port}` };
 }
 
@@ -48,6 +78,7 @@ function connect(url: string, room: string) {
     WebSocketPolyfill: WebSocket as never,
     disableBc: true,
   });
+  openProviders.push(provider);
   return { doc, provider };
 }
 
@@ -160,6 +191,7 @@ describe('server keepalive', () => {
   it('sends awareness keepalive frames to an idle peer', async () => {
     const { handle, url } = await startServer({ keepaliveIntervalMs: 120 });
     const raw = new WebSocket(`${url}/keepalive-room`);
+    openSockets.push(raw);
     await new Promise<void>((resolve, reject) => {
       raw.once('open', () => resolve());
       raw.once('error', reject);
@@ -210,7 +242,7 @@ describe('server keepalive', () => {
     // negative and non-finite delays to ~1ms (a flood); at or above the
     // client's own 30s timeout the keepalive can never refresh it in time, so
     // it would look configured while the disconnect loop returned.
-    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, 30_000, 60_000]) {
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, 25_001, 29_999, 30_000, 60_000]) {
       let handle: Awaited<ReturnType<typeof startCollabServer>> | null = null;
       let threw = false;
       try {
@@ -219,6 +251,7 @@ describe('server keepalive', () => {
           persistence: new MemoryPersistence(),
           keepaliveIntervalMs: bad,
         });
+        openHandles.push(handle);
         const address = handle.httpServer.address();
         const port = typeof address === 'object' && address ? address.port : 0;
         const { provider } = connect(`ws://127.0.0.1:${port}`, 'bad-keepalive');
@@ -235,7 +268,9 @@ describe('server keepalive', () => {
   }, 30_000);
 
   it('accepts a period that does feed the watchdog', async () => {
-    const { handle, url } = await startServer({ keepaliveIntervalMs: 29_999 });
+    // 25s against the client's 30s close leaves 5s for transit and scheduling.
+    // 29_999 is REJECTED above: it is under the timeout but cannot clear it.
+    const { handle, url } = await startServer({ keepaliveIntervalMs: 25_000 });
     const { provider } = connect(url, 'ok-keepalive');
     await synced(provider);
     expect(provider.wsconnected).toBe(true);

--- a/packages/collab-server/test/awareness-server-not-a-peer.test.ts
+++ b/packages/collab-server/test/awareness-server-not-a-peer.test.ts
@@ -204,4 +204,42 @@ describe('server keepalive', () => {
     provider.destroy();
     await handle.stop();
   }, 90_000);
+
+  it('rejects a keepalive period that cannot feed the watchdog', async () => {
+    // Both directions silently defeat the keepalive. setInterval coerces 0,
+    // negative and non-finite delays to ~1ms (a flood); at or above the
+    // client's own 30s timeout the keepalive can never refresh it in time, so
+    // it would look configured while the disconnect loop returned.
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, 30_000, 60_000]) {
+      let handle: Awaited<ReturnType<typeof startCollabServer>> | null = null;
+      let threw = false;
+      try {
+        handle = await startCollabServer({
+          port: 0,
+          persistence: new MemoryPersistence(),
+          keepaliveIntervalMs: bad,
+        });
+        const address = handle.httpServer.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+        const { provider } = connect(`ws://127.0.0.1:${port}`, 'bad-keepalive');
+        await synced(provider);
+        await new Promise((r) => setTimeout(r, 300));
+        provider.destroy();
+      } catch {
+        threw = true;
+      } finally {
+        await handle?.stop();
+      }
+      expect(threw, `keepaliveIntervalMs=${bad} was accepted`).toBe(true);
+    }
+  }, 30_000);
+
+  it('accepts a period that does feed the watchdog', async () => {
+    const { handle, url } = await startServer({ keepaliveIntervalMs: 29_999 });
+    const { provider } = connect(url, 'ok-keepalive');
+    await synced(provider);
+    expect(provider.wsconnected).toBe(true);
+    provider.destroy();
+    await handle.stop();
+  }, 15_000);
 });


### PR DESCRIPTION
Closes #2791.

## What was wrong

`Room` constructs `new Awareness(this.doc)` (`room-manager.ts:122`). y-protocols'
constructor **self-registers a local state of `{}`** for its own clientID
(`y-protocols/awareness.js:81`) and renews it every ~15s. That state was
broadcast to every client as a participant, so every room badge read one too
high.

The reporter's screenshot showed **"(2)" directly above "You're the only one here"** -
both rendered from the same peer list. The roster filters on `p?.user`
(`RoomPanel.tsx:225`); the badge does not. That disagreement is what made it
visible.

## The fix

One line, after the constructor:

```ts
this.awareness.setLocalState(null);
```

This is what y-websocket's own server utils do: participate in the awareness
protocol without being a participant in the room. It also stops the renewal,
which y-protocols guards on `getLocalState() !== null` (`awareness.js:61`).

Placed **before** the `update` listener is wired up (`:132`), so clearing it
cannot broadcast a removal for a peer no client ever saw.

## Measured, not assumed

My first version of this test passed with the fix **and** with the fix reverted -
it asserted something it could not observe. Fixing that changed the diagnosis.

The ghost does **not** arrive via the connect-time snapshot in `addConnection`.
A lone client polled every 2s:

```
t=0s .. t=14s   states=1  [[own,{}]]
t=16s           states=2  [[own,{}],[271405587,{}]]   <- ghost appears
t=18s, t=20s    states=2                              <- and persists
```

It arrives on the **15s renewal**. That matches the production observation this
was filed from (`t=18s remote-peers=1 [["1014236323",{}]]`).

So the end-to-end test drives the same call y-protocols makes on its tick
(`awareness.js:61-63`) rather than sleeping 15s of wall clock: fast, and it
exercises the real broadcast path.

I also checked, separately, whether the connect-time snapshot is broken in
general - a late joiner seeing an empty roster would be a second user-visible
bug. It is fine: B sees A's state within 100ms of connecting.

## Revert check

With the one-liner mutated out (verified applied, 1 occurrence):

```
× a room publishes no awareness state of its own
    AssertionError: server still publishes a local awareness state: {}
× a renewal tick broadcasts no server peer to a lone client
    AssertionError: lone client sees a phantom peer: [[2446391081,{}],[2507012649,{}]]
✓ still relays a real peer between two clients        <- control, correctly unaffected
```

The third test is the no-regression half and is *supposed* to stay green either
way: clearing the server's state must not stop it forwarding real peers.

Full `@ifc-lite/collab-server` suite: **152/152 across 33 files**. Typecheck
(33 test files) clean.

## Scope

Server-side only. I deliberately left the client-side defensive filter in
`remotePeers` (`collabSlice.ts:265-273`) out of this PR: making the badge require
a `user` field would fix the symptom too, but it risks **undercounting real
people** if a legitimate presence state can ever lack `user`, which is a worse
failure than the +1. That needs its own evidence and is tracked separately.

## Note

This came out of #2756 and is the *cosmetic* half of that report. The serious
half is #2790 - the blob volume is out of inodes and shared rooms have had no
geometry for weeks. This PR does not touch that.