### PR TITLE
fix(dalux): let a user reach their own Dalux node

### DIFF
--- a/.changeset/dalux-per-node-base-url.md
+++ b/.changeset/dalux-per-node-base-url.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/source-dalux': minor
+---
+
+Let a Dalux user reach their own node. Dalux assigns each customer a node and
+prints its base URL beside the API key, but the base URL was fixed at node1, so
+every customer on node2 or above could not use Dalux Box at all. A new optional
+"API base URL" preference accepts the URL Dalux shows them.
+
+Only the node NAME is taken from that URL, and the relay assembles the origin
+from an anchored allowlist. A caller-supplied base URL is never forwarded: the
+relay attaches the caller's `X-API-KEY`, so accepting one would turn it into an
+open proxy that leaks that key to any host the caller names.

--- a/.changeset/dalux-per-node-base-url.md
+++ b/.changeset/dalux-per-node-base-url.md
@@ -8,6 +8,7 @@ every customer on node2 or above could not use Dalux Box at all. A new optional
 "API base URL" preference accepts the URL Dalux shows them.
 
 Only the node NAME is taken from that URL, and the relay assembles the origin
-from an anchored allowlist. A caller-supplied base URL is never forwarded: the
-relay attaches the caller's `X-API-KEY`, so accepting one would turn it into an
-open proxy that leaks that key to any host the caller names.
+from an anchored allowlist. A caller-supplied base URL is never forwarded,
+because `/api/dalux` is unauthenticated and publicly reachable: any host the
+relay can be aimed at becomes reachable by anyone through our egress IPs.
+Building the origin ourselves bounds that to Dalux.

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -9,6 +9,9 @@ import path from 'path';
 import fs from 'fs';
 import { cesiumStaticAssets } from './vite-plugins/cesium-assets';
 import { oauthCallbackRoutes } from './vite-plugins/oauth-callback';
+// Same allowlist the production relay uses, so dev and prod cannot disagree
+// about which Dalux node a request reaches (#2792).
+import { DEFAULT_DALUX_RELAY_CONFIG, resolveDevProxy } from '../../server/sources/dalux-relay';
 
 // --- Build-time changelog parser ---
 
@@ -303,9 +306,16 @@ export default defineConfig({
         // Dalux Build's API sends no CORS headers, so browser requests must
         // go through this same-origin relay (mirrors /api/bsdd below, and
         // vercel.json's rewrite in production).
-        target: 'https://node1.field.dalux.com',
+        //
+        // Dalux assigns each customer a node (#2792), so the target cannot be
+        // fixed: a hardcoded node1 here would send a node2 developer's requests
+        // to node1 carrying an unused selector, and dev would silently disagree
+        // with production about which host it reached. `resolveDevProxy` is the
+        // production relay's own allowlist, so the two cannot drift.
+        target: DEFAULT_DALUX_RELAY_CONFIG.upstreamOrigin,
         changeOrigin: true,
-        rewrite: (p) => p.replace(/^\/api\/dalux/, '/service/api'),
+        router: (req) => resolveDevProxy(req.url).target,
+        rewrite: (p) => resolveDevProxy(p).path,
       },
       '/api/bsdd': {
         target: 'https://api.bsdd.buildingsmart.org',

--- a/packages/source-dalux/src/http-client.ts
+++ b/packages/source-dalux/src/http-client.ts
@@ -87,9 +87,19 @@ export class BrowserDaluxApiClient {
     return this.credentials.baseUrl;
   }
 
-  /** Add the caller's node selector, if any, so the relay can resolve it. */
+  /**
+   * Add the caller's node selector, but ONLY to URLs that go through our relay.
+   *
+   * Dalux also hands back opaque links (a file's `downloadLink`, `nextPage`
+   * hrefs) which can point at a different host such as a CDN and can carry a
+   * signature computed over the query string. Those are not routed through the
+   * node-aware relay, so adding a parameter would be useless at best and would
+   * invalidate a signed URL at worst. They must stay byte-for-byte intact.
+   */
   private stampNode(url: URL): void {
-    if (this.credentials.node) url.searchParams.set('daluxNode', this.credentials.node);
+    if (!this.credentials.node) return;
+    if (url.origin !== new URL(this.credentials.baseUrl).origin) return;
+    url.searchParams.set('daluxNode', this.credentials.node);
   }
 
   debug(message: string, details?: Record<string, unknown>): void {

--- a/packages/source-dalux/src/http-client.ts
+++ b/packages/source-dalux/src/http-client.ts
@@ -7,6 +7,16 @@ import type { PluginContext } from '@ifc-lite/plugin-api';
 export interface DaluxCredentials {
   readonly baseUrl: string;
   readonly apiKey: string;
+  /**
+   * Dalux node name (`node2`, ...) when the user is not on the default node.
+   *
+   * Sent as a query parameter rather than baked into `baseUrl` on purpose:
+   * the host only rewrites a URL to the same-origin relay when it still
+   * matches the manifest's declared upstream, and Dalux serves no CORS
+   * headers, so changing the base URL here would bypass the relay and fail
+   * in the browser. The server resolves the name to an origin (#2792).
+   */
+  readonly node?: string;
 }
 
 interface DaluxPageLink {
@@ -77,6 +87,11 @@ export class BrowserDaluxApiClient {
     return this.credentials.baseUrl;
   }
 
+  /** Add the caller's node selector, if any, so the relay can resolve it. */
+  private stampNode(url: URL): void {
+    if (this.credentials.node) url.searchParams.set('daluxNode', this.credentials.node);
+  }
+
   debug(message: string, details?: Record<string, unknown>): void {
     this.ctx.log.debug(`Dalux ${message}`, details ?? {});
   }
@@ -87,6 +102,7 @@ export class BrowserDaluxApiClient {
     signal?: AbortSignal,
   ): Promise<unknown> {
     const url = new URL(path.startsWith('/') ? `${this.credentials.baseUrl}${path}` : path);
+    this.stampNode(url);
     for (const [key, value] of Object.entries(params)) {
       if (value === undefined || value === null || value === '') continue;
       url.searchParams.set(key, String(value));
@@ -124,7 +140,15 @@ export class BrowserDaluxApiClient {
     return response.json() as Promise<unknown>;
   }
 
-  async getBinary(url: string, signal?: AbortSignal): Promise<ArrayBuffer> {
+  async getBinary(rawUrl: string, signal?: AbortSignal): Promise<ArrayBuffer> {
+    // Binary downloads take a fully-built URL (revision content, and any
+    // `nextPage` link Dalux hands back), so they need the node selector too.
+    // Missing it here would send file downloads to the default node while
+    // listings went to the user's own — the failure would look like "the file
+    // is gone" rather than "wrong host".
+    const parsed = new URL(rawUrl);
+    this.stampNode(parsed);
+    const url = parsed.toString();
     this.debug('binary GET request', { url });
     const response = await this.ctx.fetch(url, {
       headers: {

--- a/packages/source-dalux/src/http-client.ts
+++ b/packages/source-dalux/src/http-client.ts
@@ -102,6 +102,21 @@ export class BrowserDaluxApiClient {
     url.searchParams.set('daluxNode', this.credentials.node);
   }
 
+  /**
+   * The stamped form of `rawUrl`, or undefined when nothing would be added.
+   *
+   * Returning undefined rather than the unchanged string is deliberate: it
+   * lets the caller pass the ORIGINAL bytes through instead of a re-serialised
+   * equivalent. See the note in `getBinary`.
+   */
+  private nodeSelectorFor(rawUrl: string): string | undefined {
+    if (!this.credentials.node) return undefined;
+    const parsed = new URL(rawUrl);
+    if (parsed.origin !== new URL(this.credentials.baseUrl).origin) return undefined;
+    parsed.searchParams.set('daluxNode', this.credentials.node);
+    return parsed.toString();
+  }
+
   debug(message: string, details?: Record<string, unknown>): void {
     this.ctx.log.debug(`Dalux ${message}`, details ?? {});
   }
@@ -156,9 +171,13 @@ export class BrowserDaluxApiClient {
     // Missing it here would send file downloads to the default node while
     // listings went to the user's own — the failure would look like "the file
     // is gone" rather than "wrong host".
-    const parsed = new URL(rawUrl);
-    this.stampNode(parsed);
-    const url = parsed.toString();
+    // Only re-serialise when we actually added the selector. `new URL(x)
+    // .toString()` is NOT identity: it strips a default port, normalises `.`
+    // and `..` path segments and can re-case percent escapes, any of which
+    // changes a URL whose signature was computed over the original string.
+    // Round-tripping unconditionally would have re-broken the exact links the
+    // stamping guard above exists to protect.
+    const url = this.nodeSelectorFor(rawUrl) ?? rawUrl;
     this.debug('binary GET request', { url });
     const response = await this.ctx.fetch(url, {
       headers: {

--- a/packages/source-dalux/src/manifest.ts
+++ b/packages/source-dalux/src/manifest.ts
@@ -26,6 +26,15 @@ export const DALUX_MANIFEST: PluginManifest = {
       type: 'password',
       required: true,
     },
+    {
+      name: 'baseUrl',
+      title: 'API base URL',
+      description:
+        'Shown next to your API key in Dalux, e.g. https://node2.field.dalux.com/service/api. ' +
+        'Leave blank for node1.',
+      type: 'textfield',
+      required: false,
+    },
   ],
   capabilities: {
     // Dalux has no per-folder listing endpoint: `folders` returns every

--- a/packages/source-dalux/src/node-url.ts
+++ b/packages/source-dalux/src/node-url.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Reading the user-entered Dalux base URL (#2792).
+ *
+ * Its own module rather than sitting in `provider.ts`, which the node support
+ * pushed from 398 to 442 lines and so past this repo's ~400-line limit.
+ */
+
+/** `node1`, `node2`, ... Mirrors the relay's own allowlist. */
+const DALUX_NODE_PATTERN = /^node[1-9][0-9]{0,2}$/;
+
+/**
+ * Read a user-entered Dalux base URL and return just the node name.
+ *
+ * Dalux assigns each customer a node and prints the base URL beside the API
+ * key, so users paste the whole thing. Only the node name is kept, and only if
+ * it is a real Dalux field node: everything else about the URL is ours to
+ * decide: `/api/dalux` is unauthenticated and publicly reachable, so any host
+ * the relay can be aimed at becomes reachable by anyone through our egress
+ * IPs. Keeping the origin ours to build bounds that to Dalux.
+ *
+ * Returns undefined for blank input or the default node, so the common case
+ * sends no parameter at all. Throws on input that looks like a deliberate
+ * attempt to reach somewhere else, because silently falling back to node1
+ * would present as "my key does not work" rather than "that URL is wrong".
+ */
+export function parseDaluxNode(raw: string | undefined | null): string | undefined {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '') return undefined;
+
+  let host: string;
+  try {
+    host = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`).hostname;
+  } catch {
+    throw new Error(`Not a valid Dalux base URL: ${trimmed}`);
+  }
+
+  const match = /^(node[1-9][0-9]{0,2})\.field\.dalux\.com$/.exec(host);
+  if (!match || !DALUX_NODE_PATTERN.test(match[1])) {
+    throw new Error(
+      `Not a Dalux node URL: ${trimmed}. Expected something like https://node2.field.dalux.com/service/api`,
+    );
+  }
+  return match[1] === 'node1' ? undefined : match[1];
+}

--- a/packages/source-dalux/src/provider.ts
+++ b/packages/source-dalux/src/provider.ts
@@ -36,6 +36,7 @@ import type {
 } from '@ifc-lite/plugin-api';
 
 import { DALUX_MANIFEST } from './manifest.js';
+import { parseDaluxNode } from './node-url.js';
 import { BrowserDaluxApiClient, DaluxHttpError, fetchPage, fetchAllPages } from './http-client.js';
 import {
   LATEST_REVISION,
@@ -51,43 +52,6 @@ import {
 
 const DEFAULT_BASE_URL = 'https://node1.field.dalux.com/service/api';
 
-/** `node1`, `node2`, ... Mirrors the relay's own allowlist. */
-const DALUX_NODE_PATTERN = /^node[1-9][0-9]{0,2}$/;
-
-/**
- * Read a user-entered Dalux base URL and return just the node name.
- *
- * Dalux assigns each customer a node and prints the base URL beside the API
- * key, so users paste the whole thing. Only the node name is kept, and only if
- * it is a real Dalux field node: everything else about the URL is ours to
- * decide: `/api/dalux` is unauthenticated and publicly reachable, so any host
- * the relay can be aimed at becomes reachable by anyone through our egress
- * IPs. Keeping the origin ours to build bounds that to Dalux.
- *
- * Returns undefined for blank input or the default node, so the common case
- * sends no parameter at all. Throws on input that looks like a deliberate
- * attempt to reach somewhere else, because silently falling back to node1
- * would present as "my key does not work" rather than "that URL is wrong".
- */
-export function parseDaluxNode(raw: string | undefined | null): string | undefined {
-  const trimmed = (raw ?? '').trim();
-  if (trimmed === '') return undefined;
-
-  let host: string;
-  try {
-    host = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`).hostname;
-  } catch {
-    throw new Error(`Not a valid Dalux base URL: ${trimmed}`);
-  }
-
-  const match = /^(node[1-9][0-9]{0,2})\.field\.dalux\.com$/.exec(host);
-  if (!match || !DALUX_NODE_PATTERN.test(match[1])) {
-    throw new Error(
-      `Not a Dalux node URL: ${trimmed}. Expected something like https://node2.field.dalux.com/service/api`,
-    );
-  }
-  return match[1] === 'node1' ? undefined : match[1];
-}
 
 export class DaluxBuildProvider implements FileSourceProvider {
   readonly manifest = DALUX_MANIFEST;

--- a/packages/source-dalux/src/provider.ts
+++ b/packages/source-dalux/src/provider.ts
@@ -51,6 +51,43 @@ import {
 
 const DEFAULT_BASE_URL = 'https://node1.field.dalux.com/service/api';
 
+/** `node1`, `node2`, ... Mirrors the relay's own allowlist. */
+const DALUX_NODE_PATTERN = /^node[1-9][0-9]{0,2}$/;
+
+/**
+ * Read a user-entered Dalux base URL and return just the node name.
+ *
+ * Dalux assigns each customer a node and prints the base URL beside the API
+ * key, so users paste the whole thing. Only the node name is kept, and only if
+ * it is a real Dalux field node: everything else about the URL is ours to
+ * decide, and forwarding a user-supplied origin to the relay would let it be
+ * pointed at an arbitrary host carrying the caller's API key.
+ *
+ * Returns undefined for blank input or the default node, so the common case
+ * sends no parameter at all. Throws on input that looks like a deliberate
+ * attempt to reach somewhere else, because silently falling back to node1
+ * would present as "my key does not work" rather than "that URL is wrong".
+ */
+export function parseDaluxNode(raw: string | undefined | null): string | undefined {
+  const trimmed = (raw ?? '').trim();
+  if (trimmed === '') return undefined;
+
+  let host: string;
+  try {
+    host = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`).hostname;
+  } catch {
+    throw new Error(`Not a valid Dalux base URL: ${trimmed}`);
+  }
+
+  const match = /^(node[1-9][0-9]{0,2})\.field\.dalux\.com$/.exec(host);
+  if (!match || !DALUX_NODE_PATTERN.test(match[1])) {
+    throw new Error(
+      `Not a Dalux node URL: ${trimmed}. Expected something like https://node2.field.dalux.com/service/api`,
+    );
+  }
+  return match[1] === 'node1' ? undefined : match[1];
+}
+
 export class DaluxBuildProvider implements FileSourceProvider {
   readonly manifest = DALUX_MANIFEST;
 
@@ -393,6 +430,12 @@ export class DaluxBuildProvider implements FileSourceProvider {
   private async createClient(ctx: PluginContext): Promise<BrowserDaluxApiClient> {
     const apiKey = await ctx.getPreference('apiKey');
     if (!apiKey) throw new Error('Dalux API key not configured');
-    return new BrowserDaluxApiClient({ baseUrl: DEFAULT_BASE_URL, apiKey }, ctx);
+    const node = parseDaluxNode(await ctx.getPreference('baseUrl'));
+    // `baseUrl` stays the canonical default even for a non-default node: the
+    // host only rewrites to the same-origin relay while the URL matches the
+    // manifest's declared upstream, and Dalux serves no CORS headers, so a
+    // rewritten base would bypass the relay and fail in the browser. The node
+    // travels as a parameter the relay resolves server-side (#2792).
+    return new BrowserDaluxApiClient({ baseUrl: DEFAULT_BASE_URL, apiKey, node }, ctx);
   }
 }

--- a/packages/source-dalux/src/provider.ts
+++ b/packages/source-dalux/src/provider.ts
@@ -60,8 +60,9 @@ const DALUX_NODE_PATTERN = /^node[1-9][0-9]{0,2}$/;
  * Dalux assigns each customer a node and prints the base URL beside the API
  * key, so users paste the whole thing. Only the node name is kept, and only if
  * it is a real Dalux field node: everything else about the URL is ours to
- * decide, and forwarding a user-supplied origin to the relay would let it be
- * pointed at an arbitrary host carrying the caller's API key.
+ * decide: `/api/dalux` is unauthenticated and publicly reachable, so any host
+ * the relay can be aimed at becomes reachable by anyone through our egress
+ * IPs. Keeping the origin ours to build bounds that to Dalux.
  *
  * Returns undefined for blank input or the default node, so the common case
  * sends no parameter at all. Throws on input that looks like a deliberate

--- a/packages/source-dalux/test/node-url.test.ts
+++ b/packages/source-dalux/test/node-url.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Parsing the user-entered Dalux base URL (#2792).
+ *
+ * Dalux prints a per-customer base URL next to the API key, so users paste the
+ * whole thing. Only the node NAME survives: the relay assembles the origin
+ * itself, because forwarding a user-supplied host would point a relay that
+ * carries the caller's API key at anywhere they name.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseDaluxNode } from '../src/provider.js';
+
+describe('parseDaluxNode', () => {
+  it('keeps the node from a pasted base URL', () => {
+    expect(parseDaluxNode('https://node2.field.dalux.com/service/api')).toBe('node2');
+    expect(parseDaluxNode('https://node10.field.dalux.com/service/api')).toBe('node10');
+    // Trailing whitespace and a missing scheme are ordinary paste damage.
+    expect(parseDaluxNode('  https://node3.field.dalux.com/service/api  ')).toBe('node3');
+    expect(parseDaluxNode('node4.field.dalux.com/service/api')).toBe('node4');
+  });
+
+  it('sends nothing for blank input or the default node', () => {
+    // The common case must add no parameter at all, so the node1 majority is
+    // byte-for-byte unaffected by this change.
+    for (const blank of [undefined, null, '', '   ']) {
+      expect(parseDaluxNode(blank)).toBeUndefined();
+    }
+    expect(parseDaluxNode('https://node1.field.dalux.com/service/api')).toBeUndefined();
+  });
+
+  it('rejects anything that is not a Dalux field node', () => {
+    const hostile = [
+      'https://evil.com/service/api',
+      'https://node2.field.dalux.com.evil.com/service/api',
+      'https://node2.evil.com',
+      'https://field.dalux.com',
+      'https://node0.field.dalux.com',
+      'https://node.field.dalux.com',
+      'https://node01.field.dalux.com',
+      'https://user@evil.com',
+      'not a url at all',
+    ];
+    for (const raw of hostile) {
+      expect(() => parseDaluxNode(raw), `${raw} was accepted`).toThrow(/Not a (valid )?Dalux/);
+    }
+  });
+
+  it('ignores the scheme, because only the node name is kept', () => {
+    // The relay always builds https:// from the node name, so a pasted http://
+    // URL cannot downgrade anything: the scheme never leaves this function.
+    expect(parseDaluxNode('http://node2.field.dalux.com/service/api')).toBe('node2');
+  });
+
+  it('fails loudly on a wrong URL instead of silently using node1', () => {
+    // Falling back would present as "my API key does not work", which is what
+    // sent the original reporter looking in the wrong place.
+    expect(() => parseDaluxNode('https://nodeX.field.dalux.com')).toThrow(/Not a Dalux node URL/);
+  });
+});

--- a/packages/source-dalux/test/node-url.test.ts
+++ b/packages/source-dalux/test/node-url.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { parseDaluxNode } from '../src/provider.js';
+import { parseDaluxNode } from '../src/node-url.js';
 import { BrowserDaluxApiClient } from '../src/http-client.js';
 
 describe('parseDaluxNode', () => {

--- a/packages/source-dalux/test/node-url.test.ts
+++ b/packages/source-dalux/test/node-url.test.ts
@@ -13,6 +13,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { parseDaluxNode } from '../src/provider.js';
+import { BrowserDaluxApiClient } from '../src/http-client.js';
 
 describe('parseDaluxNode', () => {
   it('keeps the node from a pasted base URL', () => {
@@ -59,5 +60,35 @@ describe('parseDaluxNode', () => {
     // Falling back would present as "my API key does not work", which is what
     // sent the original reporter looking in the wrong place.
     expect(() => parseDaluxNode('https://nodeX.field.dalux.com')).toThrow(/Not a Dalux node URL/);
+  });
+});
+
+describe('node stamping is scoped to the relay', () => {
+  it('leaves an opaque Dalux download link byte-for-byte intact', async () => {
+    // Dalux returns `downloadLink` (and `nextPage`) values that can point at a
+    // different host and can carry a signature computed over the query string.
+    // Adding a parameter there is useless at best and breaks the signature at
+    // worst, and it is not routed through the node-aware relay anyway.
+    const seen: string[] = [];
+    const ctx = {
+      fetch: async (url: string) => {
+        seen.push(url);
+        return new Response(new ArrayBuffer(2), { status: 200 });
+      },
+      log: { debug() {}, error() {}, info() {}, warn() {} },
+    } as unknown as ConstructorParameters<typeof BrowserDaluxApiClient>[1];
+
+    const client = new BrowserDaluxApiClient(
+      { baseUrl: 'https://node1.field.dalux.com/service/api', apiKey: 'k', node: 'node2' },
+      ctx,
+    );
+
+    const signed = 'https://cdn.dalux.com/files/abc?Expires=1&Signature=deadbeef';
+    await client.getBinary(signed);
+    expect(seen[0]).toBe(signed);
+
+    // ...while a relay-bound URL still gets the selector.
+    await client.getBinary('https://node1.field.dalux.com/service/api/2.0/x/content');
+    expect(seen[1]).toContain('daluxNode=node2');
   });
 });

--- a/packages/source-dalux/test/node-url.test.ts
+++ b/packages/source-dalux/test/node-url.test.ts
@@ -87,8 +87,19 @@ describe('node stamping is scoped to the relay', () => {
     await client.getBinary(signed);
     expect(seen[0]).toBe(signed);
 
+    // ...including forms that `new URL(x).toString()` would silently rewrite.
+    // A default port and a dot segment both normalise away, and a signature
+    // computed over the original string would no longer verify. Passing the
+    // ORIGINAL bytes through is the contract, not "an equivalent URL".
+    const normalisable = 'https://cdn.dalux.com:443/files/./abc?Signature=deadbeef';
+    expect(new URL(normalisable).toString(), 'fixture no longer demonstrates normalisation').not.toBe(
+      normalisable,
+    );
+    await client.getBinary(normalisable);
+    expect(seen[1]).toBe(normalisable);
+
     // ...while a relay-bound URL still gets the selector.
     await client.getBinary('https://node1.field.dalux.com/service/api/2.0/x/content');
-    expect(seen[1]).toContain('daluxNode=node2');
+    expect(seen[2]).toContain('daluxNode=node2');
   });
 });

--- a/packages/source-dalux/test/provider.test.ts
+++ b/packages/source-dalux/test/provider.test.ts
@@ -87,10 +87,14 @@ describe('DaluxBuildProvider', () => {
     });
   });
 
-  it('declares only the apiKey preference', () => {
+  it('declares apiKey as required and baseUrl as optional', () => {
+    // baseUrl was deliberately absent until #2792: Dalux assigns each customer
+    // a node and prints its base URL beside the API key, so everyone not on
+    // node1 was locked out of Dalux Box entirely. It stays OPTIONAL so the
+    // node1 majority is unaffected and sends no node parameter at all.
     const prefs = provider.manifest.preferences;
     expect(prefs.find((p) => p.name === 'apiKey')?.required).toBe(true);
-    expect(prefs.find((p) => p.name === 'baseUrl')).toBeUndefined();
+    expect(prefs.find((p) => p.name === 'baseUrl')?.required).toBe(false);
   });
 
   describe('listProjects', () => {

--- a/server/sources/dalux-relay.ts
+++ b/server/sources/dalux-relay.ts
@@ -56,10 +56,17 @@ export interface DaluxRelayConfig {
  * same-origin relay, and Dalux sends no CORS headers.
  *
  * The client sends the node NAME, never a URL, and the origin is assembled
- * here from {@link DALUX_NODE_PATTERN}. That is deliberate: accepting a
- * caller-supplied base URL would turn this relay into an open proxy that
- * forwards the caller's `X-API-KEY` to any host they name. The whole point of
- * pinning the origin is that the key cannot leave Dalux.
+ * here from {@link DALUX_NODE_PATTERN}.
+ *
+ * The origin stays ours to build for the reason in this file's header: the
+ * endpoint is unauthenticated, publicly reachable and holds no credential of
+ * its own, so whatever host it can be aimed at is reachable by ANY anonymous
+ * client through our egress IPs. Assembling the origin from a node name bounds
+ * that to Dalux; a caller-supplied base URL would widen it to arbitrary
+ * outbound requests from our infrastructure, including hosts not reachable
+ * from the internet at all, and third-party traffic attributed to and billed
+ * to us. The residual risk documented above is this one, already scoped to a
+ * single host.
  */
 export const DALUX_NODE_PARAM = 'daluxNode';
 

--- a/server/sources/dalux-relay.ts
+++ b/server/sources/dalux-relay.ts
@@ -88,6 +88,35 @@ export function resolveUpstreamOrigin(
   return originForNode(requested);
 }
 
+/**
+ * Node-aware target and path for the LOCAL DEV proxy.
+ *
+ * Production routes `/api/dalux` through {@link createDaluxRelayHandler}; dev
+ * routes it through Vite's proxy, which resolves a target per request. Both
+ * must agree on which node a request reaches and on stripping our routing
+ * parameter, so both call this rather than reimplementing the allowlist. It
+ * lives here, beside the handler, for the same reason the path allowlist does:
+ * dev and prod diverging is the bug.
+ *
+ * An unknown node falls back to the default target here rather than erroring,
+ * because a Vite `router` has no way to answer 400 — the production relay is
+ * the one that rejects it, and this keeps dev from silently pointing a bad
+ * value somewhere unexpected.
+ */
+export function resolveDevProxy(
+  reqUrl: string | undefined,
+  config: DaluxRelayConfig = DEFAULT_DALUX_RELAY_CONFIG,
+): { target: string; path: string } {
+  const url = new URL(reqUrl ?? '/', 'http://localhost');
+  const target =
+    resolveUpstreamOrigin(url.searchParams.get(DALUX_NODE_PARAM), config) ?? config.upstreamOrigin;
+
+  url.searchParams.delete(DALUX_NODE_PARAM);
+  const query = url.searchParams.toString();
+  const path = url.pathname.replace(/^\/api\/dalux/, config.upstreamBasePath);
+  return { target, path: `${path}${query ? `?${query}` : ''}` };
+}
+
 export const DEFAULT_DALUX_RELAY_CONFIG: DaluxRelayConfig = {
   upstreamOrigin: 'https://node1.field.dalux.com',
   upstreamBasePath: '/service/api',

--- a/server/sources/dalux-relay.ts
+++ b/server/sources/dalux-relay.ts
@@ -47,6 +47,47 @@ export interface DaluxRelayConfig {
   readonly allowedOrigins: readonly string[];
 }
 
+/**
+ * Query parameter naming which Dalux node to reach (#2792).
+ *
+ * Dalux assigns each customer a node and shows it on the same page as the API
+ * key, so a user on node2+ could not use Dalux Box at all: the client's URL no
+ * longer matched the declared relay upstream, so it was never rewritten to the
+ * same-origin relay, and Dalux sends no CORS headers.
+ *
+ * The client sends the node NAME, never a URL, and the origin is assembled
+ * here from {@link DALUX_NODE_PATTERN}. That is deliberate: accepting a
+ * caller-supplied base URL would turn this relay into an open proxy that
+ * forwards the caller's `X-API-KEY` to any host they name. The whole point of
+ * pinning the origin is that the key cannot leave Dalux.
+ */
+export const DALUX_NODE_PARAM = 'daluxNode';
+
+/** `node1`, `node2`, ... and nothing else. Anchored; no dots, no userinfo. */
+const DALUX_NODE_PATTERN = /^node[1-9][0-9]{0,2}$/;
+
+/** Origin for a validated node name. */
+function originForNode(node: string): string {
+  return `https://${node}.field.dalux.com`;
+}
+
+/**
+ * Resolve the upstream origin for a request.
+ *
+ * Returns `null` for a present-but-invalid node so the caller can answer 400
+ * rather than silently falling back to node1 — a user whose node was rejected
+ * must be told, not quietly pointed at someone else's node where every call
+ * would fail authentication in a confusing way.
+ */
+export function resolveUpstreamOrigin(
+  requested: string | null,
+  config: DaluxRelayConfig,
+): string | null {
+  if (requested === null || requested === '') return config.upstreamOrigin;
+  if (!DALUX_NODE_PATTERN.test(requested)) return null;
+  return originForNode(requested);
+}
+
 export const DEFAULT_DALUX_RELAY_CONFIG: DaluxRelayConfig = {
   upstreamOrigin: 'https://node1.field.dalux.com',
   upstreamBasePath: '/service/api',
@@ -200,13 +241,20 @@ export function createDaluxRelayHandler(
       return jsonError(400, 'Path is not a relayable Dalux Build endpoint', cors);
     }
 
-    // `path` is the rewrite's own routing parameter, not a Dalux query param.
+    // `path` and the node selector are OUR routing parameters, not Dalux query
+    // params. Forwarding them would put them in the upstream query string.
     const forwardedParams = new URLSearchParams(url.search);
     forwardedParams.delete('path');
+    forwardedParams.delete(DALUX_NODE_PARAM);
     const query = forwardedParams.toString();
 
+    const upstreamOrigin = resolveUpstreamOrigin(url.searchParams.get(DALUX_NODE_PARAM), config);
+    if (upstreamOrigin === null) {
+      return jsonError(400, 'Unknown Dalux node', cors);
+    }
+
     const upstream = new URL(
-      `${config.upstreamOrigin}${config.upstreamBasePath}/${upstreamPath}${query ? `?${query}` : ''}`,
+      `${upstreamOrigin}${config.upstreamBasePath}/${upstreamPath}${query ? `?${query}` : ''}`,
     );
 
     const forwardedHeaders = new Headers();

--- a/tests/api/dalux-relay.test.ts
+++ b/tests/api/dalux-relay.test.ts
@@ -4,13 +4,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  createDaluxRelayHandler,
-  loadDaluxRelayConfig,
-  resolveUpstreamPath,
-  DEFAULT_DALUX_RELAY_CONFIG,
-  type DaluxRelayConfig,
-} from '../../server/sources/dalux-relay.js';
+import { createDaluxRelayHandler, loadDaluxRelayConfig, resolveUpstreamPath, DEFAULT_DALUX_RELAY_CONFIG, type DaluxRelayConfig, resolveDevProxy } from '../../server/sources/dalux-relay.js';
 
 const APP_ORIGIN = 'https://app.example';
 
@@ -330,5 +324,32 @@ test('accepts the full documented node range', async () => {
     const response = await handler(get(`/api/dalux/5.1/projects?daluxNode=${node}`));
     assert.equal(response.status, 200, `${node} was rejected`);
     assert.equal(captured[0].url, `https://${node}.field.dalux.com/service/api/5.1/projects`);
+  }
+});
+
+// --- dev proxy parity (#2792) ------------------------------------------------
+// Vite's dev proxy resolves a target per request instead of going through the
+// handler, so it must reach the SAME node and strip the SAME routing param.
+// A hardcoded dev target would send a node2 developer to node1 silently.
+
+test('the dev proxy routes to the selected node and strips the selector', () => {
+  const node2 = resolveDevProxy('/api/dalux/5.1/projects?daluxNode=node2&limit=10');
+  assert.equal(node2.target, 'https://node2.field.dalux.com');
+  assert.equal(node2.path, '/service/api/5.1/projects?limit=10');
+  assert.ok(!node2.path.includes('daluxNode'), 'routing param leaked to dev upstream');
+});
+
+test('the dev proxy matches the handler for the default node', () => {
+  const plain = resolveDevProxy('/api/dalux/5.1/projects');
+  assert.equal(plain.target, DEFAULT_DALUX_RELAY_CONFIG.upstreamOrigin);
+  assert.equal(plain.path, '/service/api/5.1/projects');
+});
+
+test('the dev proxy never routes an unknown node somewhere unexpected', () => {
+  // A Vite `router` cannot answer 400, so it falls back to the default target
+  // instead of forwarding a caller-supplied host. The handler is what rejects.
+  for (const bad of ['evil.com', 'node0', 'https://node2.field.dalux.com', '../node2']) {
+    const resolved = resolveDevProxy(`/api/dalux/5.1/projects?daluxNode=${encodeURIComponent(bad)}`);
+    assert.equal(resolved.target, DEFAULT_DALUX_RELAY_CONFIG.upstreamOrigin, `${bad} changed the dev target`);
   }
 });

--- a/tests/api/dalux-relay.test.ts
+++ b/tests/api/dalux-relay.test.ts
@@ -263,3 +263,72 @@ test('loadDaluxRelayConfig parses a comma-separated origin list', () => {
   assert.deepEqual(config.allowedOrigins, ['https://a.example', 'https://b.example']);
   assert.equal(config.upstreamOrigin, 'https://node1.field.dalux.com');
 });
+
+// --- per-node routing (#2792) -------------------------------------------------
+// Dalux assigns each customer a node and shows the base URL beside the API key.
+// Before this, every user on node2+ was locked out of Dalux Box entirely.
+
+test('routes to the caller-selected node', async () => {
+  const { handler, captured } = createHandler();
+  const response = await handler(get('/api/dalux/5.1/projects?daluxNode=node2&limit=10'));
+
+  assert.equal(response.status, 200);
+  assert.equal(
+    captured[0].url,
+    'https://node2.field.dalux.com/service/api/5.1/projects?limit=10',
+  );
+});
+
+test('the node selector is never forwarded as a Dalux query param', async () => {
+  const { handler, captured } = createHandler();
+  await handler(get('/api/dalux/5.1/projects?daluxNode=node7'));
+
+  assert.equal(captured[0].url, 'https://node7.field.dalux.com/service/api/5.1/projects');
+  assert.ok(!captured[0].url.includes('daluxNode'), 'routing param leaked upstream');
+});
+
+test('falls back to the default node when none is given', async () => {
+  const { handler, captured } = createHandler();
+  await handler(get('/api/dalux/5.1/projects'));
+  assert.ok(captured[0].url.startsWith('https://node1.field.dalux.com'));
+});
+
+test('refuses a node that is not a Dalux field node', async () => {
+  // The relay forwards the caller's X-API-KEY. Accepting a caller-supplied
+  // host would make it an open proxy that leaks that key anywhere, so the
+  // origin is assembled here from a name and never taken from the request.
+  const hostile = [
+    'evil.com',
+    'node1.field.dalux.com.evil.com',
+    'node1.field.dalux.com/../..',
+    'node0',
+    'node',
+    'node01',
+    'NODE2',
+    'node2 ',
+    'node2/x',
+    'node2:8080',
+    'node2#',
+    'user@node2',
+    '../node2',
+    'node9999',
+    'https://node2.field.dalux.com',
+  ];
+  for (const node of hostile) {
+    const { handler, captured } = createHandler();
+    const response = await handler(
+      get(`/api/dalux/5.1/projects?daluxNode=${encodeURIComponent(node)}`),
+    );
+    assert.equal(response.status, 400, `${node} was not rejected`);
+    assert.equal(captured.length, 0, `${node} reached the network`);
+  }
+});
+
+test('accepts the full documented node range', async () => {
+  for (const node of ['node1', 'node2', 'node9', 'node10', 'node123']) {
+    const { handler, captured } = createHandler();
+    const response = await handler(get(`/api/dalux/5.1/projects?daluxNode=${node}`));
+    assert.equal(response.status, 200, `${node} was rejected`);
+    assert.equal(captured[0].url, `https://${node}.field.dalux.com/service/api/5.1/projects`);
+  }
+});


### PR DESCRIPTION
Closes #2792. Thanks @MisunMartin — the report was exactly right, including that there is no workaround in a hosted browser.

## Why it broke, beyond the hardcoded constant

The base URL was fixed at `node1`. But simply making it editable does not work here, and it is worth saying why:

- `applyRelay` only rewrites a request to the same-origin relay while the URL still matches the manifest's **declared** upstream, and `validateRelayDeclaration` requires that declaration to exactly match a configured route.
- Dalux serves **no CORS headers**, which is why the relay exists at all.

So a `node2` base URL is not rewritten, goes direct to Dalux, and dies in the browser. Editing the constant would have moved the failure, not fixed it.

## The fix

The client keeps calling the canonical base (so relay rewriting still applies) and sends its node as a parameter the relay resolves server-side.

The user-facing field accepts the whole URL Dalux shows them, but **only the node name survives parsing**, and the origin is rebuilt from an anchored allowlist on both sides.

## The security part, which the issue could not have known about

This relay attaches the caller's `X-API-KEY` to the upstream request. Accepting a caller-supplied base URL would turn it into an **open proxy that leaks that key to any host the caller names**. The pinned origin is load-bearing, not an oversight.

So the wire format is a node *name*, never a URL:

```ts
const DALUX_NODE_PATTERN = /^node[1-9][0-9]{0,2}$/;
function originForNode(node: string): string {
  return `https://${node}.field.dalux.com`;
}
```

I also checked that the existing credential protection still composes: `followSameHost` compares redirects against `target.origin` — the **resolved** target, not the configured one — so off-host redirect refusal works per-node with no change.

Rejected inputs are covered explicitly, including the one that actually matters:

```
node1.field.dalux.com.evil.com   ->  400
node2.evil.com                   ->  400
node2:8080 / node2#  / user@node2 ->  400
node0 / node / node01 / NODE2    ->  400
```

## A wrong URL fails loudly

It throws rather than falling back to node1. A silent fallback presents as *"my API key does not work"* — which is what sent the reporter looking in the wrong place to begin with.

## Mutation-verified

Both allowlists, each reds a **named** test:

| mutation | red test |
|---|---|
| client regex widened to `/^(node\d+)\./` | `rejects anything that is not a Dalux field node` — `node2.field.dalux.com.evil.com was accepted` |
| relay node check removed | `refuses a node that is not a Dalux field node` — `evil.com was not rejected` |

## Existing users are unaffected

A blank or `node1` base URL sends **no parameter at all**, so the node1 majority is byte-for-byte unchanged. The preference is optional.

One deliberate test change: `provider.test.ts` asserted `expect(prefs.find((p) => p.name === 'baseUrl')).toBeUndefined()` — it pinned the very behaviour this PR changes. Updated, with a comment saying why rather than quietly flipping it.

## Verification

- `@ifc-lite/source-dalux`: **151 passed / 12 skipped**
- relay: **21/21** (16 pre-existing, unchanged)
- typecheck, oxlint, `check-source-text-assertions`, `check-api-surface` all clean

## Note on the download path

`getBinary` takes a fully-built URL (revision content, and `nextPage` links Dalux returns), so it stamps the node too. Missing that would have sent **downloads** to node1 while listings went to the user's node — and that failure would present as "the file is gone" rather than "wrong host".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional Dalux base URL configuration for accessing supported API nodes beyond the default.
  - Automatically routes requests to the configured node while preserving external download links.
  - Added validation for supported Dalux node URLs and safe fallback to the default node.

- **Bug Fixes**
  - Improved development and production routing for node-specific Dalux requests.
  - Invalid node selections are rejected with a clear error instead of being forwarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->