### PR TITLE
feat(collab): let a blob upload be aborted

### DIFF
--- a/.changeset/blob-put-abort-signal.md
+++ b/.changeset/blob-put-abort-signal.md
@@ -1,0 +1,16 @@
+---
+'@ifc-lite/collab': minor
+---
+
+`BlobStore.put` now accepts an optional `AbortSignal`, and `HttpBlobStore`
+forwards it to `fetch`.
+
+A hung upload was worse than a failed one: a rejection is counted, retried and
+can trip a caller's failure ceiling, but a request that never settles produces
+no failure at all, so nothing retries, no ceiling trips, and a geometry seed
+never resolves while the UI reports work in progress. `LayeredBlobStore` also
+forwards the signal, since its `Promise.all` cannot settle while the remote half
+hangs and its `.catch` never runs when nothing rejects.
+
+Additive and optional: existing callers are unaffected, and implementations that
+cannot abort may ignore the option.

--- a/docs/architecture/collab-plan.md
+++ b/docs/architecture/collab-plan.md
@@ -236,6 +236,29 @@ milestone called out in §19.
 > any `BlobStore` implementing the optional `stat()` method. Still
 > pending: parametric → mesh kernel hookup, viewer-side conflict badge,
 > and the determinism CI matrix.
+>
+> `BlobStore.put` takes an optional third argument carrying an
+> `AbortSignal`, so an upload can be given a per-attempt deadline:
+>
+> ```ts
+> const controller = new AbortController();
+> const timer = setTimeout(() => controller.abort(), 30_000);
+> try {
+>   await store.put(bytes, 'application/octet-stream', { signal: controller.signal });
+> } finally {
+>   clearTimeout(timer);
+> }
+> ```
+>
+> This exists because a HUNG upload is worse than a failed one. A
+> rejection is counted, retried and can trip a caller's failure ceiling;
+> a request that never settles produces no failure at all, so nothing
+> retries, no ceiling trips, and a geometry seed never resolves while the
+> UI still reports work in progress. `HttpBlobStore` forwards the signal
+> to `fetch`, and `LayeredBlobStore` forwards it to both halves — its
+> `Promise.all` cannot settle while the remote hangs, and the `.catch`
+> that swallows remote failures never runs when nothing rejects.
+> Implementations that cannot abort may ignore the option.
 
 **Goal:** Geometric edits (parametric and mesh) sync correctly without
 inflating Y.Doc memory or requiring central authority.

--- a/packages/collab/src/geometry/blob-store.ts
+++ b/packages/collab/src/geometry/blob-store.ts
@@ -258,7 +258,9 @@ export class HttpBlobStore implements BlobStore {
       // TS 5.7's tightened `Uint8Array<ArrayBufferLike>` typing doesn't
       // satisfy `BodyInit` directly; the runtime accepts Uint8Array fine.
       body: bytes as unknown as BodyInit,
-      ...(options?.signal ? { signal: options.signal } : {}),
+      // Spread so the key is ABSENT when there is no signal: `signal:
+      // undefined` is not equivalent to omitting it for every fetch impl.
+      ...(options?.signal && { signal: options.signal }),
     });
     if (!res.ok) {
       throw new Error(`@ifc-lite/collab: blob PUT failed: ${res.status} ${res.statusText}`);

--- a/packages/collab/src/geometry/blob-store.ts
+++ b/packages/collab/src/geometry/blob-store.ts
@@ -28,8 +28,26 @@ export interface BlobMeta {
   uploadedAt?: string;
 }
 
+/** Per-call options for {@link BlobStore.put}. */
+export interface BlobPutOptions {
+  /**
+   * Abort the upload.
+   *
+   * A HUNG upload is worse than a failed one (#2798). A rejection is counted,
+   * retried and can trip a caller's failure ceiling; a request that never
+   * settles produces no failure at all, so nothing retries, no ceiling trips,
+   * and a seed simply never resolves while the UI reports work in progress.
+   * That is absence being indistinguishable from success, which is what let
+   * the #2790 outage run for weeks.
+   *
+   * Implementations that cannot honour it must ignore it rather than throw:
+   * an in-memory store completes synchronously and has nothing to abort.
+   */
+  readonly signal?: AbortSignal;
+}
+
 export interface BlobStore {
-  put(bytes: Uint8Array, contentType?: string): Promise<BlobMeta>;
+  put(bytes: Uint8Array, contentType?: string, options?: BlobPutOptions): Promise<BlobMeta>;
   get(hash: BlobHash): Promise<Uint8Array | null>;
   has(hash: BlobHash): Promise<boolean>;
   delete(hash: BlobHash): Promise<boolean>;
@@ -228,7 +246,11 @@ export class HttpBlobStore implements BlobStore {
     return h;
   }
 
-  async put(bytes: Uint8Array, contentType?: string): Promise<BlobMeta> {
+  async put(
+    bytes: Uint8Array,
+    contentType?: string,
+    options?: BlobPutOptions,
+  ): Promise<BlobMeta> {
     const hash = this.hasher(bytes);
     const res = await this.fetchImpl(this.url(hash), {
       method: 'PUT',
@@ -236,6 +258,7 @@ export class HttpBlobStore implements BlobStore {
       // TS 5.7's tightened `Uint8Array<ArrayBufferLike>` typing doesn't
       // satisfy `BodyInit` directly; the runtime accepts Uint8Array fine.
       body: bytes as unknown as BodyInit,
+      ...(options?.signal ? { signal: options.signal } : {}),
     });
     if (!res.ok) {
       throw new Error(`@ifc-lite/collab: blob PUT failed: ${res.status} ${res.statusText}`);
@@ -302,10 +325,17 @@ export class HttpBlobStore implements BlobStore {
 export class LayeredBlobStore implements BlobStore {
   constructor(private readonly local: BlobStore, private readonly remote: BlobStore) {}
 
-  async put(bytes: Uint8Array, contentType?: string): Promise<BlobMeta> {
+  async put(
+    bytes: Uint8Array,
+    contentType?: string,
+    options?: BlobPutOptions,
+  ): Promise<BlobMeta> {
+    // The signal must reach the REMOTE half in particular: `Promise.all` does
+    // not settle until both do, so a remote upload that hangs hangs this call
+    // as well, and the `.catch` below never runs because nothing rejects.
     const [meta] = await Promise.all([
-      this.local.put(bytes, contentType),
-      this.remote.put(bytes, contentType).catch(() => null),
+      this.local.put(bytes, contentType, options),
+      this.remote.put(bytes, contentType, options).catch(() => null),
     ]);
     return meta;
   }

--- a/packages/collab/test/blob-store.test.ts
+++ b/packages/collab/test/blob-store.test.ts
@@ -123,3 +123,62 @@ describe('blob store', () => {
     expect(await http.get(meta.hash)).toBeNull();
   });
 });
+
+// ─── put() abort support (#2798) ───────────────────────────────────────────
+// A HUNG upload is worse than a failed one. A rejection is counted, retried,
+// and can trip a caller's failure ceiling; a request that never settles
+// produces no failure at all, so nothing retries, no ceiling trips, and a
+// geometry seed simply never resolves while the UI reports work in progress.
+
+describe('HttpBlobStore.put honours an AbortSignal', () => {
+  const bytes = new Uint8Array([1, 2, 3]);
+
+  it('passes the signal through to fetch', async () => {
+    let seen: AbortSignal | undefined;
+    const store = new HttpBlobStore({
+      baseUrl: 'https://example.test',
+      fetch: (async (_u: string, init?: RequestInit) => {
+        seen = init?.signal ?? undefined;
+        return new Response(null, { status: 201 });
+      }) as unknown as typeof fetch,
+    });
+
+    const ac = new AbortController();
+    await store.put(bytes, 'application/octet-stream', { signal: ac.signal });
+    expect(seen, 'signal never reached fetch').toBe(ac.signal);
+  });
+
+  it('a put that never settles rejects once aborted', async () => {
+    // The whole point: without this the promise below is still pending after
+    // the timeout and the caller has nothing to count.
+    const store = new HttpBlobStore({
+      baseUrl: 'https://example.test',
+      fetch: ((_u: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () =>
+            reject(new DOMException('Aborted', 'AbortError')),
+          );
+        })) as unknown as typeof fetch,
+    });
+
+    const ac = new AbortController();
+    const pending = store.put(bytes, undefined, { signal: ac.signal });
+    ac.abort();
+    await expect(pending).rejects.toThrow(/abort/i);
+  });
+
+  it('omits the signal entirely when none is given', async () => {
+    // Passing `signal: undefined` is not the same as omitting it for every
+    // fetch implementation, so the option must not appear at all.
+    let had = true;
+    const store = new HttpBlobStore({
+      baseUrl: 'https://example.test',
+      fetch: (async (_u: string, init?: RequestInit) => {
+        had = init !== undefined && 'signal' in init;
+        return new Response(null, { status: 201 });
+      }) as unknown as typeof fetch,
+    });
+    await store.put(bytes);
+    expect(had).toBe(false);
+  });
+});

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -264,6 +264,7 @@
     "BlobHash: type",
     "BlobHasher: type",
     "BlobMeta: interface",
+    "BlobPutOptions: interface",
     "BlobStore: interface",
     "BoundPropertyView: interface",
     "BoxParams: interface",


### PR DESCRIPTION
Closes #2798. Branched from `main`, not stacked on anything.

## The gap

Everything protecting the geometry seed is driven by **failures**: per-blob retry, per-blob isolation, and a circuit breaker that trips after N distinct failures.

A PUT that **hangs** produces none of them:

- no rejection, so nothing retries
- no failure, so the breaker never trips
- no settle, so the seed never resolves while the UI keeps reporting work in progress

That is strictly worse than the HTTP 500s that caused #2790, because a 500 at least *reports*. A hang is the purest form of absence reading as success.

## The change

`BlobStore.put` takes an optional `AbortSignal`; `HttpBlobStore` forwards it to `fetch`. That makes a per-attempt timeout expressible.

**`LayeredBlobStore` forwards it too, and that one matters more than it looks:**

```ts
const [meta] = await Promise.all([
  this.local.put(...),
  this.remote.put(...).catch(() => null),   // never runs if nothing rejects
]);
```

`Promise.all` cannot settle while the remote half hangs, and the `.catch` that swallows remote failures never fires, because nothing rejects. So a hung remote hangs the local put too.

The option is **omitted from the fetch init entirely** when no signal is given, rather than passed as `signal: undefined` — those are not equivalent for every fetch implementation, and there is a test for it.

## Mutation-checked

Dropping the forwarding:

```
× passes the signal through to fetch
× a put that never settles rejects once aborted   5003ms
```

The second one is the interesting failure: it reds by **timing out**, which is the hang itself rather than a proxy for it.

**225 passed across 44 files.** Typecheck, lint, `check-api-surface` (regenerated — `BlobPutOptions` is a new export) and `check-source-text-assertions` all clean.

## Deliberately not here

Wiring a timeout into `seedGeometryToRoom` is **not** in this PR. That file is being rewritten by #2797 (per-blob retry + circuit breaker), and landing both in the same place would conflict for no reason. This is the contract that work will consume; the timeout policy belongs with the retry policy.

Additive and optional, so every existing caller is unchanged.

## Noted, not fixed

`LayeredBlobStore.put` swallows remote failures with `.catch(() => null)` and returns the local meta, so a remote upload that *fails* also reads as success. That is plausibly deliberate for offline-first semantics, but it is the same family as #2790 and worth a decision rather than an assumption. Not changing it here.