### PR TITLE
fix(export): derive IFCPROXY GlobalIds deterministically

### DIFF
--- a/.changeset/step-proxy-deterministic-globalid.md
+++ b/.changeset/step-proxy-deterministic-globalid.md
@@ -1,0 +1,14 @@
+---
+'@ifc-lite/export': patch
+---
+
+STEP export is deterministic again for IFC4X3 models targeting IFC4. Every
+IFC4X3-only class is downgraded to an `IFCPROXY` placeholder, and each one was
+minted a fresh GlobalId on every export, so exporting an unchanged model twice
+never produced the same bytes and anything keyed on GlobalId across exports lost
+its association.
+
+The placeholder id is now derived from the source line. Re-exporting an
+unchanged model reproduces it, while two federated occurrences of the same
+entity still get distinct ids, because the merged exporter offsets each model's
+express ids. A caller-supplied seeded `RandomSource` still takes precedence.

--- a/.changeset/step-proxy-deterministic-globalid.md
+++ b/.changeset/step-proxy-deterministic-globalid.md
@@ -2,13 +2,18 @@
 '@ifc-lite/export': patch
 ---
 
-STEP export is deterministic again for IFC4X3 models targeting IFC4. Every
-IFC4X3-only class is downgraded to an `IFCPROXY` placeholder, and each one was
-minted a fresh GlobalId on every export, so exporting an unchanged model twice
-never produced the same bytes and anything keyed on GlobalId across exports lost
-its association.
+STEP export is deterministic again for IFC4X3 models targeting IFC4. Alignment
+classes with no IFC4 equivalent (`IfcAlignmentCant`, `IfcAlignmentHorizontal`,
+`IfcAlignmentVertical`, `IfcAlignmentSegment`) are replaced by an `IFCPROXY`
+placeholder, and each one was minted a fresh GlobalId on every export, so
+exporting an unchanged model twice never produced the same bytes and anything
+keyed on GlobalId across exports lost its association. Other IFC4X3-only classes
+are mapped to IFC4 equivalents and were never affected.
 
 The placeholder id is now derived from the source line. Re-exporting an
 unchanged model reproduces it, while two federated occurrences of the same
 entity still get distinct ids, because the merged exporter offsets each model's
 express ids. A caller-supplied seeded `RandomSource` still takes precedence.
+
+Note that fully byte-identical output also needs `pinnedTimestamp`: the STEP
+header otherwise carries the export instant.

--- a/packages/export/src/schema-converter.test.ts
+++ b/packages/export/src/schema-converter.test.ts
@@ -271,4 +271,61 @@ describe('schema-converter', () => {
       }
     });
   });
+
+  // ─── IFCPROXY GlobalId determinism (#2733) ──────────────────────────────
+
+  describe('IFCPROXY placeholders get a deterministic GlobalId', () => {
+    // IFC4X3-only alignment classes have no IFC4 representation, so they are
+    // replaced wholesale by a placeholder. Each one used to be minted a FRESH
+    // GlobalId on every export, so exporting an unchanged model twice never
+    // produced the same bytes.
+    const seg = "#42=IFCALIGNMENTSEGMENT('2K5H1$Zs9CQuKQFQKQFQKQ',#1,'A',$,$,#7,#9,$);";
+
+    it('is byte-identical across repeated conversions of the same input', () => {
+      const a = convertStepLine(seg, 'IFC4X3', 'IFC4');
+      const b = convertStepLine(seg, 'IFC4X3', 'IFC4');
+      expect(a).toBe(b);
+      expect(a).toContain('IFCPROXY');
+      expect(a).toContain("'IFCALIGNMENTSEGMENT'");
+    });
+
+    it('mints a well-formed IFC GlobalId', () => {
+      const guid = /IFCPROXY\('([^']*)'/.exec(convertStepLine(seg, 'IFC4X3', 'IFC4'))?.[1] ?? '';
+      expect(isValidIfcGuid(guid), `malformed GlobalId: ${guid}`).toBe(true);
+    });
+
+    it('gives DIFFERENT ids to two federated occurrences of the same entity', () => {
+      // The reason the obvious fix (copy the source GlobalId onto the proxy) is
+      // wrong: two models can legitimately carry the same alignment GlobalId,
+      // and a shared proxy id would unify them into one. The merged exporter
+      // offsets each model's express ids, so the lines differ by prefix.
+      const m1 = "#42=IFCALIGNMENTSEGMENT('2K5H1$Zs9CQuKQFQKQFQKQ',#1,'A',$,$,#7,#9,$);";
+      const m2 = "#99=IFCALIGNMENTSEGMENT('2K5H1$Zs9CQuKQFQKQFQKQ',#1,'A',$,$,#7,#9,$);";
+      const g1 = /IFCPROXY\('([^']*)'/.exec(convertStepLine(m1, 'IFC4X3', 'IFC4'))?.[1];
+      const g2 = /IFCPROXY\('([^']*)'/.exec(convertStepLine(m2, 'IFC4X3', 'IFC4'))?.[1];
+      expect(g1).toBeTruthy();
+      expect(g2, 'two federated occurrences collapsed onto one GlobalId').not.toBe(g1);
+    });
+
+    it('distinguishes entities that differ only in their attributes', () => {
+      const other = "#42=IFCALIGNMENTSEGMENT('3xJ2mQ8vT1AuVwXyZ0BcDe',#1,'B',$,$,#7,#9,$);";
+      const g1 = /IFCPROXY\('([^']*)'/.exec(convertStepLine(seg, 'IFC4X3', 'IFC4'))?.[1];
+      const g2 = /IFCPROXY\('([^']*)'/.exec(convertStepLine(other, 'IFC4X3', 'IFC4'))?.[1];
+      expect(g2).not.toBe(g1);
+    });
+
+    it('still honours a caller-supplied seeded RandomSource', () => {
+      // An export that already pins its randomness keeps its behaviour, so this
+      // change cannot alter output for callers that opted into determinism.
+      const seeded = () => {
+        let n = 0;
+        return () => ((n = (n * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff);
+      };
+      const a = convertStepLine(seg, 'IFC4X3', 'IFC4', seeded());
+      const b = convertStepLine(seg, 'IFC4X3', 'IFC4', seeded());
+      expect(a).toBe(b);
+      const bare = convertStepLine(seg, 'IFC4X3', 'IFC4');
+      expect(a, 'seeded source was ignored').not.toBe(bare);
+    });
+  });
 });

--- a/packages/export/src/schema-converter.ts
+++ b/packages/export/src/schema-converter.ts
@@ -21,6 +21,7 @@
  */
 
 import { generateIfcGuid, type RandomSource } from '@ifc-lite/encoding';
+import { deterministicGlobalId } from '@ifc-lite/parser';
 import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, type IfcEntityInfo } from '@ifc-lite/data';
 
 export type IfcSchemaVersion = 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
@@ -365,7 +366,32 @@ export function convertStepLine(
   // Replace entities that have no valid representation in the target schema
   // with IFCPROXY placeholders to preserve EXPRESS IDs and prevent dangling references
   if (shouldSkipEntity(newType, toSchema)) {
-    return `${prefix}IFCPROXY('${generateIfcGuid(random)}',$,'${entityType}',$,$,$,$,.NOTDEFINED.,$);`;
+    // Derive the placeholder's GlobalId from the source line rather than
+    // minting a random one (#2733). Every downgraded entity used to get a
+    // FRESH id on every export, so exporting an unchanged IFC4X3 model twice
+    // never produced the same bytes: 116 differing lines, 58 of them IFCPROXY,
+    // at identical byte size, which is the signature of
+    // same-shape-different-identifier.
+    //
+    // Reusing the SOURCE entity's own GlobalId looks like the obvious fix and
+    // is wrong. `merged-exporter.test.ts` pins the case: two federated models
+    // legitimately carry the same alignment GlobalId, and a fresh id per
+    // occurrence is what stops them being unified into one. Copying the source
+    // id would silently collapse two alignments into one.
+    //
+    // Seeding from the whole line satisfies both. Re-exporting an unchanged
+    // model reproduces the line and so the id; two federated occurrences differ
+    // because the merged exporter offsets each model's express ids, so their
+    // `prefix` differs. Same primitive and same reasoning as `mintUniqueGuid`
+    // in merged-exporter.ts, which seeds from the original id plus the model's
+    // stable id.
+    //
+    // A caller-supplied seeded source still wins, so an export that already
+    // pins its randomness keeps its existing behaviour.
+    const guid = random
+      ? generateIfcGuid(random)
+      : deterministicGlobalId(`ifcproxy:${prefix}${entityType}(${attrsRaw})`);
+    return `${prefix}IFCPROXY('${guid}',$,'${entityType}',$,$,$,$,.NOTDEFINED.,$);`;
   }
 
   // Adjust attribute count if downgrading to IFC2X3

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -154,14 +154,20 @@ export interface StepExportOptions {
    * Seeded randomness for the GlobalIds this exporter SYNTHESIZES:
    * the `IfcPropertySet` / `IfcElementQuantity` roots regenerated for
    * mutated (or overlay-created) property and quantity sets, their
-   * `IfcRelDefinesByProperties` links, and any `IFCPROXY` placeholder minted
-   * by schema conversion. Without it those come from the platform CSPRNG, so
-   * two exports of the same model differ in exactly those bytes - which
-   * breaks byte-reproducibility for in-store builds that call
+   * `IfcRelDefinesByProperties` links. Without it those come from the platform
+   * CSPRNG, so two exports of the same model differ in exactly those bytes -
+   * which breaks byte-reproducibility for in-store builds that call
    * `addPropertySet` / `addQuantitySet` (the sets themselves live in the
    * mutation overlay and only become IFC roots here). Pass the same seeded
    * source used for `SpatialAnchor.guidRandom` to close that gap. Default
-   * (omitted) behaviour is unchanged: random.
+   * (omitted) behaviour for THESE ids is unchanged: random.
+   *
+   * NOT the `IFCPROXY` placeholders any more (#2733). Those used to be minted
+   * from this source too, so an omitted `guidRandom` made every downgraded
+   * IFC4X3 entity differ on re-export. They are now derived from the source
+   * line when this is omitted, and only fall back to this source when it is
+   * supplied - so passing a seeded source still pins them, but NOT passing one
+   * no longer makes them random. See `convertStepLine`.
    */
   guidRandom?: RandomSource;
   /**


### PR DESCRIPTION
Closes #2733. Branched from `main`.

## The bug

Every IFC4X3-only class downgraded to IFC4 becomes an `IFCPROXY`, and each one was minted a **fresh GlobalId on every export**. So exporting an unchanged model twice never produced the same bytes:

```
control: the SAME build exported twice
  116 differing lines, 58 of them IFCPROXY
  byte sizes identical
```

Identical sizes with differing content is the signature of same-shape-different-identifier. A GlobalId is a durability contract, so anything keyed on it across exports silently lost its association, and re-export was not idempotent.

## I tried the obvious fix first, and it is wrong

Reuse the source entity's GlobalId on the placeholder. One line, obviously correct — and it **reds `merged-exporter.test.ts:925`**, which is deliberate:

```ts
const sharedGuid = guid('sharedAlign');
const m1 = buildModel('m1', 'A', [... IFCALIGNMENTHORIZONTAL('${sharedGuid}', ...)]);
const m2 = buildModel('m2', 'B', [... IFCALIGNMENTHORIZONTAL('${sharedGuid}', ...)]);
// expects 2 proxies, and NOT to contain sharedGuid
```

Two **federated** models legitimately carry the same alignment GlobalId, and the fresh id per occurrence is the only thing keeping them distinct through a merge. Copying the source id collapses two alignments into one — trading nondeterministic ids for **lost geometry in federation**, which is a much worse bug than the one being fixed.

I would not have caught that from the diff. The suite caught it.

## What actually works

Seed the placeholder id from the whole source line:

```ts
const guid = random
  ? generateIfcGuid(random)
  : deterministicGlobalId(`ifcproxy:${prefix}${entityType}(${attrsRaw})`);
```

- **Deterministic**: re-exporting an unchanged model reproduces the line, so it reproduces the id.
- **Unique across federation**: the merged exporter offsets each model's express ids, so the two occurrences differ by `prefix`.
- **Backward compatible**: a caller-supplied seeded `RandomSource` still wins, so any export that already pinned its randomness is unchanged.

This is not a new invention — it is the same primitive and the same reasoning as `mintUniqueGuid` in `merged-exporter.ts`, which already seeds from *"the original GlobalId and the model's stable id so the output is reproducible"*.

## Mutation-checked in both directions

That matters more than usual here, because the wrong fix passes a naive determinism test:

| mutation | reds |
|---|---|
| back to random minting (the bug) | `is byte-identical across repeated conversions of the same input` |
| copy the source id (the naive fix) | `gives DIFFERENT ids to two federated occurrences` **and** the pre-existing `no false unify` guard |

The naive fix reds a test I added *and* one that already existed, independently of each other.

**730 passed / 30 skipped across 54 files.** Typecheck, lint and `check-source-text-assertions` clean.

## Scope

`pinnedTimestamp` already exists for the header's export instant; genuinely byte-identical output needs both, and that is unchanged by this PR. The `IfcSchemaVersion` unused-import lint warning in the test file is pre-existing on `main` (one occurrence, the import line itself) and untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - IFC4X3 models exported to IFC4 now receive repeatable identifiers for converted proxy entities.
  - Federated occurrences and entities with different source attributes retain distinct identifiers.
  - Existing caller-provided seeded randomness remains supported.

- **Documentation**
  - Clarified how seeded randomness affects generated entities, relationships, and proxy identifiers.

- **Tests**
  - Added coverage for repeatability, valid IFC identifiers, uniqueness, and seeded behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->