### PR TITLE
feat(clash): exact minimum-distance query between two meshes (#2737)

### DIFF
--- a/.changeset/clash-min-distance-query.md
+++ b/.changeset/clash-min-distance-query.md
@@ -1,0 +1,18 @@
+---
+"@ifc-lite/clash": minor
+---
+
+Expose an exact minimum-distance query between two meshes, with witness points.
+
+`triTriDistance` already computed the exact triangle-to-triangle minimum
+distance, but it lived under `math/`, which has no export subpath, so any
+consumer outside the package hit `ERR_PACKAGE_PATH_NOT_EXPORTED`. What did not
+exist anywhere was a traversal that can find the CLOSEST pair: every BVH query
+in the package is an overlap predicate, so two disjoint meshes yield an empty
+candidate set and there is nothing left to measure.
+
+Adds `minDistanceBetweenMeshes` / `minDistanceBetweenBvhs` (branch-and-bound
+over the two BVHs, pruning on the exact AABB lower bound) and re-exports
+`buildMeshBvh` / `queryMeshCross` from `@ifc-lite/clash/contact` so a caller
+measuring one element against several can build each tree once. Additive: no
+existing export changes.

--- a/packages/clash/src/contact/index.ts
+++ b/packages/clash/src/contact/index.ts
@@ -31,6 +31,26 @@ export type { SharedFaceCluster, SharedFaceOptions } from './shared-faces.js';
 export type { TrianglePair, NarrowPhaseOptions } from './narrow-phase.js';
 export { narrowPhase, clusterSharedFaces };
 
+/**
+ * Minimum-distance query, exposed here rather than left package-private
+ * because every consumer that wants it lives outside this package. The
+ * viewer's measure tool needs the exact surface-to-surface distance, and
+ * before this it could not reach any of the machinery: `triTriDistance` sits
+ * under `math/`, which has no export subpath, so a deep import is hard-blocked
+ * by `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+ *
+ * `buildMeshBvh` / `queryMeshCross` come with it: a caller measuring one
+ * element against several should build each tree once rather than pay for it
+ * per query.
+ */
+export {
+  minDistanceBetweenMeshes,
+  minDistanceBetweenBvhs,
+  type MeshDistance,
+  type MinDistanceOptions,
+} from './min-distance.js';
+export { buildMeshBvh, queryMeshCross, type MeshBvh } from './mesh-bvh.js';
+
 export interface ContactOptions extends NarrowPhaseOptions, SharedFaceOptions {}
 
 /**

--- a/packages/clash/src/contact/min-distance.test.ts
+++ b/packages/clash/src/contact/min-distance.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { minDistanceBetweenMeshes } from './min-distance.js';
+import { PairHeap, minDistanceBetweenMeshes } from './min-distance.js';
 import { triangleAt, triangleCount } from './triangle.js';
 import { triTriDistance } from '../math/triangle-distance.js';
 import type { Mesh } from './types.js';
@@ -176,3 +176,51 @@ describe('minDistanceBetweenMeshes', () => {
     expect(r?.distance).toBeLessThanOrEqual(0 + 1e-9);
   });
 });
+
+describe('PairHeap', () => {
+  // The traversal's result is INDEPENDENT of this order — a broken heap still
+  // finds the true minimum, just after visiting more pairs. So the distance
+  // tests above provably cannot catch an inverted sift (verified by mutation),
+  // and the heap needs its own contract test or it has none at all.
+  const entry = (lowerSq: number) => ({ na: null as never, nb: null as never, lowerSq });
+
+  it('pops in ascending order regardless of push order', () => {
+    const heap = new PairHeap();
+    const pushed = [7, 1, 9, 3, 3, 0, 12, 5, 2, 8, 4];
+    for (const v of pushed) heap.push(entry(v));
+    const popped: number[] = [];
+    for (;;) {
+      const e = heap.pop();
+      if (!e) break;
+      popped.push(e.lowerSq);
+    }
+    assert(popped, [...pushed].sort((a, b) => a - b));
+  });
+
+  it('is empty-safe and drains exactly what was pushed', () => {
+    const heap = new PairHeap();
+    expect(heap.pop()).toBeUndefined();
+    heap.push(entry(2));
+    expect(heap.pop()?.lowerSq).toBe(2);
+    expect(heap.pop()).toBeUndefined();
+  });
+
+  it('keeps popping the minimum while pushes are interleaved', () => {
+    // The traversal always pushes children while draining, so an order that
+    // only holds for push-then-drain would not be the property it relies on.
+    const heap = new PairHeap();
+    heap.push(entry(5));
+    heap.push(entry(9));
+    expect(heap.pop()?.lowerSq).toBe(5);
+    heap.push(entry(1));
+    heap.push(entry(7));
+    expect(heap.pop()?.lowerSq).toBe(1);
+    expect(heap.pop()?.lowerSq).toBe(7);
+    expect(heap.pop()?.lowerSq).toBe(9);
+  });
+});
+
+/** Local helper: vitest's deepEqual with a clearer failure for number lists. */
+function assert(actual: number[], expected: number[]): void {
+  expect(actual).toEqual(expected);
+}

--- a/packages/clash/src/contact/min-distance.test.ts
+++ b/packages/clash/src/contact/min-distance.test.ts
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The pruning is the part that can be wrong without looking wrong: a
+ * branch-and-bound traversal that prunes too eagerly still returns a distance,
+ * just a larger one, and on a hand-picked pair of boxes it is usually right
+ * anyway. So the load-bearing test here is the brute-force oracle — every
+ * triangle pair, no pruning — run over meshes deliberately shaped so the
+ * closest pair is NOT the pair a naive descent would reach first.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { minDistanceBetweenMeshes } from './min-distance.js';
+import { triangleAt, triangleCount } from './triangle.js';
+import { triTriDistance } from '../math/triangle-distance.js';
+import type { Mesh } from './types.js';
+
+/** Axis-aligned box as 12 triangles, at `origin` with `size` extents. */
+function box(id: string, origin: [number, number, number], size: [number, number, number]): Mesh {
+  const [x, y, z] = origin;
+  const [w, d, h] = size;
+  const positions = new Float64Array([
+    x, y, z,             x + w, y, z,         x + w, y + d, z,     x, y + d, z,
+    x, y, z + h,         x + w, y, z + h,     x + w, y + d, z + h, x, y + d, z + h,
+  ]);
+  const indices = new Uint32Array([
+    0, 1, 2, 0, 2, 3, // bottom
+    4, 6, 5, 4, 7, 6, // top
+    0, 4, 5, 0, 5, 1, // -Y
+    1, 5, 6, 1, 6, 2, // +X
+    2, 6, 7, 2, 7, 3, // +Y
+    3, 7, 4, 3, 4, 0, // -X
+  ]);
+  return { id, positions, indices };
+}
+
+/** Every triangle pair, no pruning. The oracle the traversal must match. */
+function bruteForceDistance(a: Mesh, b: Mesh): number {
+  let best = Infinity;
+  for (let i = 0; i < triangleCount(a); i++) {
+    const ta = triangleAt(a, i);
+    for (let j = 0; j < triangleCount(b); j++) {
+      const tb = triangleAt(b, j);
+      const r = triTriDistance(
+        [...ta.v0], [...ta.v1], [...ta.v2],
+        [...tb.v0], [...tb.v1], [...tb.v2],
+      );
+      if (r.dist < best) best = r.dist;
+    }
+  }
+  return best;
+}
+
+describe('minDistanceBetweenMeshes', () => {
+  it('measures the gap between two separated boxes', () => {
+    // Faces at x=1 and x=4: the answer is 3, and it is exact rather than
+    // approximate, so this asserts equality rather than a tolerance.
+    const a = box('a', [0, 0, 0], [1, 1, 1]);
+    const b = box('b', [4, 0, 0], [1, 1, 1]);
+    const r = minDistanceBetweenMeshes(a, b);
+    expect(r?.distance).toBeCloseTo(3, 10);
+  });
+
+  it('returns 0 for boxes that touch face to face', () => {
+    const a = box('a', [0, 0, 0], [1, 1, 1]);
+    const b = box('b', [1, 0, 0], [1, 1, 1]);
+    expect(minDistanceBetweenMeshes(a, b)?.distance).toBeCloseTo(0, 10);
+  });
+
+  it('returns 0 for boxes that interpenetrate', () => {
+    const a = box('a', [0, 0, 0], [2, 2, 2]);
+    const b = box('b', [1, 1, 1], [2, 2, 2]);
+    expect(minDistanceBetweenMeshes(a, b)?.distance).toBeCloseTo(0, 10);
+  });
+
+  it('reports witness points that are actually that far apart', () => {
+    // A distance without witness points that agree with it is a number the
+    // caller cannot draw. The measure tool needs the segment, not the scalar.
+    const a = box('a', [0, 0, 0], [1, 1, 1]);
+    const b = box('b', [0, 7.5, 0], [1, 1, 1]);
+    const r = minDistanceBetweenMeshes(a, b);
+    expect(r).not.toBeNull();
+    const [ax, ay, az] = r!.pointA;
+    const [bx, by, bz] = r!.pointB;
+    expect(Math.hypot(ax - bx, ay - by, az - bz)).toBeCloseTo(r!.distance, 9);
+    expect(r!.distance).toBeCloseTo(6.5, 9);
+  });
+
+  it('agrees with brute force where the closest pair is NOT the first one reached', () => {
+    // Diagonal offset, so the nearest triangles are on faces a depth-first
+    // descent visits late. A traversal that prunes wrongly returns a LARGER
+    // distance here and still looks like an answer.
+    const a = box('a', [0, 0, 0], [2, 2, 2]);
+    const b = box('b', [5, 4, 3], [2, 3, 1]);
+    const r = minDistanceBetweenMeshes(a, b);
+    expect(r?.distance).toBeCloseTo(bruteForceDistance(a, b), 9);
+  });
+
+  it('agrees with brute force on irregular meshes big enough to have a real tree', () => {
+    // The box fixtures above cannot exercise the pruning at all: 12 triangles
+    // at leafSize 8 is a 2-leaf tree, and best-first ordering reaches the
+    // optimal leaf pair immediately, so a broken bound changes nothing. This
+    // case was added after mutation testing showed exactly that — inverting
+    // the prune comparison and dropping a child from the descent BOTH left the
+    // suite green. Irregular meshes with a deep tree are what make the oracle
+    // bite.
+    let seed = 0x2737;
+    const rand = () => {
+      // Deterministic LCG: a fixed corpus, so a failure is reproducible.
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed / 0x100000000;
+    };
+    const cloud = (id: string, offset: [number, number, number], n: number): Mesh => {
+      const pos: number[] = [];
+      const idx: number[] = [];
+      for (let t = 0; t < n; t++) {
+        const cx = offset[0] + rand() * 4;
+        const cy = offset[1] + rand() * 4;
+        const cz = offset[2] + rand() * 4;
+        for (let v = 0; v < 3; v++) {
+          pos.push(cx + rand() * 0.8, cy + rand() * 0.8, cz + rand() * 0.8);
+          idx.push(t * 3 + v);
+        }
+      }
+      return { id, positions: new Float64Array(pos), indices: new Uint32Array(idx) };
+    };
+
+    for (const offset of [
+      [9, 0, 0], [0, 9, 0], [0, 0, 9], [7, 7, 7], [2, 1, 0], [-9, 3, 2],
+    ] as Array<[number, number, number]>) {
+      const a = cloud('a', [0, 0, 0], 40);
+      const b = cloud('b', offset, 40);
+      const got = minDistanceBetweenMeshes(a, b, { leafSize: 4 })?.distance ?? NaN;
+      expect(got, `offset ${offset.join(',')}`).toBeCloseTo(bruteForceDistance(a, b), 9);
+    }
+  });
+
+  it('agrees with brute force across many offsets, including overlapping ones', () => {
+    const a = box('a', [0, 0, 0], [2, 2, 2]);
+    for (const [dx, dy, dz] of [
+      [3, 0, 0], [0, 3, 0], [0, 0, 3], [3, 3, 3], [1, 1, 1],
+      [-4, 2, 0], [2.5, -3.5, 1.25], [10, 10, 10], [0.5, 0.5, 9],
+    ] as Array<[number, number, number]>) {
+      const b = box('b', [dx, dy, dz], [2, 2, 2]);
+      const got = minDistanceBetweenMeshes(a, b)?.distance ?? NaN;
+      expect(got, `offset ${dx},${dy},${dz}`).toBeCloseTo(bruteForceDistance(a, b), 9);
+    }
+  });
+
+  it('names the triangles the witness points lie on', () => {
+    const a = box('a', [0, 0, 0], [1, 1, 1]);
+    const b = box('b', [3, 0, 0], [1, 1, 1]);
+    const r = minDistanceBetweenMeshes(a, b);
+    expect(r!.triangleA).toBeGreaterThanOrEqual(0);
+    expect(r!.triangleA).toBeLessThan(triangleCount(a));
+    expect(r!.triangleB).toBeGreaterThanOrEqual(0);
+    expect(r!.triangleB).toBeLessThan(triangleCount(b));
+  });
+
+  it('returns null for a mesh with no triangles, rather than 0', () => {
+    // 0 would read as "they touch". An absent mesh has no distance, and the
+    // caller must be able to tell those apart. The null comes from the empty
+    // BVH root, which is the only way this can happen — an earlier version
+    // also carried a `triangleA < 0` fallback that no input could reach.
+    const empty: Mesh = { id: 'empty', positions: new Float64Array(), indices: new Uint32Array() };
+    expect(minDistanceBetweenMeshes(box('a', [0, 0, 0], [1, 1, 1]), empty)).toBeNull();
+    expect(minDistanceBetweenMeshes(empty, empty)).toBeNull();
+  });
+
+  it('stops early when asked, without claiming a smaller distance than it found', () => {
+    const a = box('a', [0, 0, 0], [1, 1, 1]);
+    const b = box('b', [1, 0, 0], [1, 1, 1]);
+    const r = minDistanceBetweenMeshes(a, b, { earlyExitAtOrBelow: 0 });
+    expect(r?.distance).toBeLessThanOrEqual(0 + 1e-9);
+  });
+});

--- a/packages/clash/src/contact/min-distance.ts
+++ b/packages/clash/src/contact/min-distance.ts
@@ -71,6 +71,67 @@ function mutable(v: Vec3): [number, number, number] {
   return [v[0], v[1], v[2]];
 }
 
+/** A node pair waiting to be explored, with its lower bound on any pair beneath it. */
+export interface PairEntry {
+  na: BvhNode;
+  nb: BvhNode;
+  lowerSq: number;
+}
+
+/**
+ * Binary min-heap over `lowerSq`. Exported for its own tests but deliberately
+ * NOT re-exported from `contact/index.ts`, so it stays out of the package's
+ * public surface: it is an implementation detail of the traversal, and a
+ * hand-rolled sift is precisely the kind of code that needs a direct contract
+ * test rather than being covered incidentally.
+ *
+ * Note that a broken heap order does NOT break the RESULT — the traversal
+ * still visits every unpruned pair and still finds the true minimum, just
+ * slower. That is why the distance tests cannot catch an inverted comparison
+ * here, and why this class is tested on its own terms.
+ *
+ * Small and local on purpose: this is the only
+ * priority queue in the package, and pulling in a dependency (or a generic
+ * implementation) for one traversal would be more surface than the ~25 lines
+ * it replaces.
+ */
+export class PairHeap {
+  private readonly items: PairEntry[] = [];
+
+  push(entry: PairEntry): void {
+    const items = this.items;
+    items.push(entry);
+    let i = items.length - 1;
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (items[parent].lowerSq <= items[i].lowerSq) break;
+      [items[parent], items[i]] = [items[i], items[parent]];
+      i = parent;
+    }
+  }
+
+  pop(): PairEntry | undefined {
+    const items = this.items;
+    if (items.length === 0) return undefined;
+    const top = items[0];
+    const last = items.pop() as PairEntry;
+    if (items.length === 0) return top;
+    items[0] = last;
+    let i = 0;
+    for (;;) {
+      const l = 2 * i + 1;
+      const r = l + 1;
+      let smallest = i;
+      if (l < items.length && items[l].lowerSq < items[smallest].lowerSq) smallest = l;
+      if (r < items.length && items[r].lowerSq < items[smallest].lowerSq) smallest = r;
+      if (smallest === i) break;
+      [items[smallest], items[i]] = [items[i], items[smallest]];
+      i = smallest;
+    }
+    return top;
+  }
+}
+
 interface Best {
   distance: number;
   pointA: Vec3;
@@ -117,19 +178,21 @@ export function minDistanceBetweenBvhs(
     triangleB: -1,
   };
 
-  // Explicit stack of node pairs with their lower bound, processed
-  // best-first: a good bound found early prunes the most.
-  const stack: Array<{ na: BvhNode; nb: BvhNode; lowerSq: number }> = [
-    { na: rootA, nb: rootB, lowerSq: aabbDistSq(rootA.bounds, rootB.bounds) },
-  ];
+  // Frontier of node pairs, popped best-first: the tightest lower bound is
+  // explored first, so a good real distance is found early and prunes the most.
+  //
+  // A min-heap rather than a scan-and-splice over an array. Both are correct,
+  // but the frontier grows with the product of the two trees' widths, and a
+  // linear pick plus a splice is O(n) each, so the traversal degrades toward
+  // quadratic exactly on the large disjoint meshes this query exists for. The
+  // heap keeps it O(log n) per pop with the same visit order.
+  const frontier = new PairHeap();
+  frontier.push({ na: rootA, nb: rootB, lowerSq: aabbDistSq(rootA.bounds, rootB.bounds) });
 
-  while (stack.length > 0) {
-    // Pop the most promising pair rather than the last pushed.
-    let pick = 0;
-    for (let i = 1; i < stack.length; i++) {
-      if (stack[i].lowerSq < stack[pick].lowerSq) pick = i;
-    }
-    const { na, nb, lowerSq } = stack.splice(pick, 1)[0];
+  for (;;) {
+    const next = frontier.pop();
+    if (!next) break;
+    const { na, nb, lowerSq } = next;
 
     // The bound is a lower bound on every pair beneath this node pair, so
     // once it reaches the best distance found, nothing here can improve it.
@@ -175,7 +238,7 @@ export function minDistanceBetweenBvhs(
     }
     for (const c of children) {
       const lower = aabbDistSq(c.na.bounds, c.nb.bounds);
-      if (lower < best.distance * best.distance) stack.push({ ...c, lowerSq: lower });
+      if (lower < best.distance * best.distance) frontier.push({ ...c, lowerSq: lower });
     }
   }
 

--- a/packages/clash/src/contact/min-distance.ts
+++ b/packages/clash/src/contact/min-distance.ts
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Minimum distance between two world-space meshes, with the witness points.
+ *
+ * Why this is a new traversal rather than a new predicate: the exact
+ * triangle-to-triangle minimum distance already exists as `triTriDistance`
+ * (`../math/triangle-distance.ts`), and a second copy of that math would be one
+ * more thing to keep in step. What did NOT exist anywhere in this package is a
+ * traversal that can find the CLOSEST pair.
+ *
+ * Every other query here is an OVERLAP predicate: `Bvh.queryAABB`,
+ * `Bvh.queryPairs` and `queryMeshCross` all prune on AABB intersection, so for
+ * two disjoint meshes they return an empty candidate set and there is nothing
+ * left to measure. Inflating a clash `clearance` does not substitute either:
+ * `testPair` only ever considers triangle pairs already within its margin, so
+ * the answer is capped by the margin you guessed rather than found.
+ *
+ * So this is branch-and-bound over the two BVHs: descend the node pair whose
+ * AABB-to-AABB LOWER bound is smallest, and prune any pair whose lower bound is
+ * already >= the best real distance found so far. The bound is exact for
+ * axis-aligned boxes and never exceeds the true triangle distance, which is
+ * what makes the pruning safe: a pruned subtree cannot contain a closer pair.
+ */
+
+import { buildMeshBvh, type MeshBvh } from './mesh-bvh.js';
+import { triangleAt } from './triangle.js';
+import { triTriDistance } from '../math/triangle-distance.js';
+import type { BvhNode } from './bvh.js';
+import type { AABB, Mesh, Vec3 } from './types.js';
+
+export interface MeshDistance {
+  /** Minimum distance between the two surfaces. 0 when they touch or overlap. */
+  readonly distance: number;
+  /** Witness point on mesh A. */
+  readonly pointA: Vec3;
+  /** Witness point on mesh B. */
+  readonly pointB: Vec3;
+  /** Triangle indices the witness points lie on. */
+  readonly triangleA: number;
+  readonly triangleB: number;
+}
+
+export interface MinDistanceOptions {
+  /** Triangles per BVH leaf. Default 8, matching `buildMeshBvh`. */
+  readonly leafSize?: number;
+  /**
+   * Stop as soon as a distance at or below this is found. Use 0 to stop on
+   * first contact when only "do they touch" matters; leave unset for the exact
+   * distance.
+   */
+  readonly earlyExitAtOrBelow?: number;
+}
+
+/** Squared distance between two AABBs; 0 when they overlap or touch. */
+function aabbDistSq(a: AABB, b: AABB): number {
+  let total = 0;
+  for (let axis = 0; axis < 3; axis++) {
+    // Gap on this axis, in whichever direction they are separated. Negative
+    // overlap contributes nothing, which is what makes this a LOWER bound.
+    const gap = Math.max(0, a.min[axis] - b.max[axis], b.min[axis] - a.max[axis]);
+    total += gap * gap;
+  }
+  return total;
+}
+
+/** The tuple `triTriDistance` expects (its Vec3 is mutable). */
+function mutable(v: Vec3): [number, number, number] {
+  return [v[0], v[1], v[2]];
+}
+
+interface Best {
+  distance: number;
+  pointA: Vec3;
+  pointB: Vec3;
+  triangleA: number;
+  triangleB: number;
+}
+
+/**
+ * Exact minimum distance between two meshes, or `null` when either has no
+ * triangles (there is no distance to a mesh that is not there — deliberately
+ * distinct from returning 0, which would read as "they touch").
+ */
+export function minDistanceBetweenMeshes(
+  a: Mesh,
+  b: Mesh,
+  opts: MinDistanceOptions = {},
+): MeshDistance | null {
+  const bvhA = buildMeshBvh(a, opts.leafSize ?? 8);
+  const bvhB = buildMeshBvh(b, opts.leafSize ?? 8);
+  return minDistanceBetweenBvhs(bvhA, bvhB, opts);
+}
+
+/**
+ * Same, for callers that already hold the BVHs. Worth having separately: the
+ * BVH is the expensive part, and a measure tool asking about one element
+ * against several others should build each mesh's tree once.
+ */
+export function minDistanceBetweenBvhs(
+  a: MeshBvh,
+  b: MeshBvh,
+  opts: MinDistanceOptions = {},
+): MeshDistance | null {
+  const rootA = a.bvh.root;
+  const rootB = b.bvh.root;
+  if (!rootA || !rootB) return null;
+
+  const stopAt = opts.earlyExitAtOrBelow;
+  const best: Best = {
+    distance: Infinity,
+    pointA: [0, 0, 0],
+    pointB: [0, 0, 0],
+    triangleA: -1,
+    triangleB: -1,
+  };
+
+  // Explicit stack of node pairs with their lower bound, processed
+  // best-first: a good bound found early prunes the most.
+  const stack: Array<{ na: BvhNode; nb: BvhNode; lowerSq: number }> = [
+    { na: rootA, nb: rootB, lowerSq: aabbDistSq(rootA.bounds, rootB.bounds) },
+  ];
+
+  while (stack.length > 0) {
+    // Pop the most promising pair rather than the last pushed.
+    let pick = 0;
+    for (let i = 1; i < stack.length; i++) {
+      if (stack[i].lowerSq < stack[pick].lowerSq) pick = i;
+    }
+    const { na, nb, lowerSq } = stack.splice(pick, 1)[0];
+
+    // The bound is a lower bound on every pair beneath this node pair, so
+    // once it reaches the best distance found, nothing here can improve it.
+    if (lowerSq >= best.distance * best.distance) continue;
+
+    const leafA = na.items !== undefined;
+    const leafB = nb.items !== undefined;
+
+    if (leafA && leafB) {
+      for (const ia of na.items ?? []) {
+        const triA = triangleAt(a.mesh, Number(a.bvh.items[ia].id));
+        for (const ib of nb.items ?? []) {
+          const triB = triangleAt(b.mesh, Number(b.bvh.items[ib].id));
+          const r = triTriDistance(
+            mutable(triA.v0), mutable(triA.v1), mutable(triA.v2),
+            mutable(triB.v0), mutable(triB.v1), mutable(triB.v2),
+          );
+          if (r.dist < best.distance) {
+            best.distance = r.dist;
+            best.pointA = r.pA;
+            best.pointB = r.pB;
+            best.triangleA = Number(a.bvh.items[ia].id);
+            best.triangleB = Number(b.bvh.items[ib].id);
+            if (stopAt !== undefined && best.distance <= stopAt) {
+              return { ...best };
+            }
+          }
+        }
+      }
+      continue;
+    }
+
+    // Descend the side that is still internal; when both are, split the one
+    // with the larger box so the bounds tighten fastest.
+    const descendA = leafB || (!leafA && boxExtent(na.bounds) >= boxExtent(nb.bounds));
+    const children: Array<{ na: BvhNode; nb: BvhNode }> = [];
+    if (descendA && !leafA) {
+      if (na.left) children.push({ na: na.left, nb });
+      if (na.right) children.push({ na: na.right, nb });
+    } else if (!leafB) {
+      if (nb.left) children.push({ na, nb: nb.left });
+      if (nb.right) children.push({ na, nb: nb.right });
+    }
+    for (const c of children) {
+      const lower = aabbDistSq(c.na.bounds, c.nb.bounds);
+      if (lower < best.distance * best.distance) stack.push({ ...c, lowerSq: lower });
+    }
+  }
+
+  // Both roots exist, so the mesh has at least one triangle and at least one
+  // leaf pair was evaluated: `best` is always populated here. (An earlier
+  // version returned null on `triangleA < 0`, which no input could reach —
+  // a branch a test cannot exercise is a branch that hides a mistake.)
+  return { ...best };
+}
+
+/** Longest side of a box, used only to choose which side to split. */
+function boxExtent(box: AABB): number {
+  return Math.max(box.max[0] - box.min[0], box.max[1] - box.min[1], box.max[2] - box.min[2]);
+}

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -191,14 +191,21 @@
     "AABB: interface",
     "ContactOptions: interface",
     "Mesh: interface",
+    "MeshBvh: interface",
+    "MeshDistance: interface",
+    "MinDistanceOptions: interface",
     "NarrowPhaseOptions: interface",
     "SharedFaceCluster: interface",
     "SharedFaceOptions: interface",
     "TrianglePair: type",
     "Vec3: type",
+    "buildMeshBvh: function",
     "clusterSharedFaces: function",
     "contactClusters: function",
-    "narrowPhase: function"
+    "minDistanceBetweenBvhs: function",
+    "minDistanceBetweenMeshes: function",
+    "narrowPhase: function",
+    "queryMeshCross: function"
   ],
   "@ifc-lite/clash/ifcx": [
     "IfcxAdapterOptions: interface",


### PR DESCRIPTION
Groundwork for #2737 item 1 (minimum distance between two selected elements). This is the `packages/clash` half: the query itself, exposed and tested. The viewer measure mode follows in a second PR, so this one stays reviewable.

## What was actually missing

The issue reads as "add a distance measure", but the distance **predicate** already exists and is exact: `triTriDistance` in `packages/clash/src/math/triangle-distance.ts` returns the minimum triangle-to-triangle distance and both witness points. Two things blocked reusing it, and only one of them is obvious:

1. **It is unreachable.** `math/` has no export subpath, so `@ifc-lite/clash/math/triangle-distance.js` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. Writing a third distance routine in the viewer would have been the easy path and the wrong one.
2. **No traversal in this repo can answer "closest pair."** Every BVH query here is an *overlap* predicate — `Bvh.queryAABB`, `Bvh.queryPairs`, `queryMeshCross` all prune on AABB intersection, so for two disjoint meshes they return an empty candidate set and there is nothing left to measure. Abusing a clash run with a large `clearance` does not fake it either: `testPair` only ever considers triangle pairs already within the margin, so you get back the margin you guessed rather than the distance.

So this adds the traversal and nothing else: branch-and-bound over the two BVHs, pruning any node pair whose exact AABB lower bound already reaches the best real distance found. The bound never exceeds the true triangle distance, which is what makes the pruning safe.

## The tests were nearly worthless, and mutation testing is what said so

The first version was 9/9 green. Then:

| mutation | result |
| --- | --- |
| invert the prune comparison | **still green** |
| descend only one child | **still green** |
| empty-mesh guard removed | **still green** |
| witness point on A reused for B | caught |

Three of four. The cause was the fixtures: 12-triangle boxes at leafSize 8 make a 2-leaf tree, and best-first ordering reaches the optimal leaf pair immediately, so a broken bound cannot change the answer. The third was unreachable behind an earlier return — a branch no input could exercise, which I deleted rather than left in.

Fixed with a **brute-force oracle** (every triangle pair, no pruning) over irregular seeded meshes deep enough to have a real tree. All four mutations now red a **named** test, with the subtest count unchanged at 10 in every run:

- prune comparison inverted → `agrees with brute force on irregular meshes big enough to have a real tree`
- descend only one child → same test
- early null removed → `returns null for a mesh with no triangles, rather than 0`
- witness point on A reused for B → `reports witness points that are actually that far apart`

An empty mesh returns `null`, not `0`, deliberately: `0` reads as "they touch", and the caller has to be able to tell those apart.

## Verification

- 365 `packages/clash` tests pass (24 files), typecheck clean.
- API surface snapshot updated: **7 additions, no removals** — checked the diff rather than blanket-accepting it.
- Changeset added (minor, additive).

## Not in this PR

The viewer measure mode itself. It touches `measure-modes/`, `MeasurePanel.tsx`, `selectionHandlers.ts` and `measurementSlice.ts`, which are the files #2735 and #2736 also land in, and that lane is strictly serialised — so it goes in its own PR rather than colliding here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added exact minimum-distance queries between meshes, including distance, closest points, and triangle references.
  - Added support for querying prebuilt mesh acceleration structures.
  - Added configurable query options, including leaf sizing and early-exit thresholds.
  - Exposed mesh BVH construction and cross-mesh query utilities through the contact API.
  - Empty meshes are handled safely without producing distance results.
  - Added support for separated, touching, and intersecting mesh comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->