### PR TITLE
fix(dalux): run the real relay in dev, and gate the tests that guard it

### DIFF
--- a/.changeset/dalux-dev-relay-real-handler.md
+++ b/.changeset/dalux-dev-relay-real-handler.md
@@ -1,0 +1,12 @@
+---
+'@ifc-lite/source-dalux': patch
+---
+
+Fix the Dalux node selection in local development, which was inert. The dev
+proxy was given a `router` callback to pick the upstream per request, but Vite
+has no such option: it uses `http-proxy-3`, while `router` belongs to
+`http-proxy-middleware`. The callback was silently ignored, so a developer on a
+non-default node still reached node1.
+
+Dev now serves `/api/dalux` with the same relay handler production uses, rather
+than a second proxy configuration that can drift from it.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -543,6 +543,14 @@ jobs:
         # silently consume the whole job budget.
         timeout-minutes: 5
         run: pnpm test:integration
+      - name: API route tests (relay handlers)
+        # `tests/api/**` was reachable only by running `pnpm test:api` by hand,
+        # so the Dalux relay's path allowlist and node allowlist - the guards
+        # that stop an unauthenticated public endpoint becoming an open proxy -
+        # existed in the repo but never in the pipeline. A guard no lane invokes
+        # is not a gate.
+        timeout-minutes: 5
+        run: pnpm test:api
       - name: WASM contract tests (real processGeometryBatch boundary)
         run: pnpm test:wasm-contract
       # The snap cache reconstructs model edges from the mesher's per-triangle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,14 @@ jobs:
               - 'packages/**'
               - 'tests/e2e/**'
               - 'playwright.config.ts'
+              # The relay handlers and their tests. `pnpm test:api` runs in this
+              # job, so without these a PR touching ONLY the relay skips the one
+              # lane that exercises its allowlists - the guard would exist and
+              # never fire, which is the failure this filter block already warns
+              # about twice above.
+              - 'server/**'
+              - 'api/**'
+              - 'tests/api/**'
               # The lint CONFIG, so a PR that only edits it cannot skip the
               # Lint job that reads it. Absent CI reads as green here, and a
               # guard cannot fire in a job that never runs.

--- a/apps/viewer/vite-plugins/dalux-relay.ts
+++ b/apps/viewer/vite-plugins/dalux-relay.ts
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { Plugin } from 'vite';
+import { createDaluxRelayHandler, loadDaluxRelayConfig } from '../../../server/sources/dalux-relay';
+
+/**
+ * Serve `/api/dalux` in dev with the SAME handler production uses.
+ *
+ * This replaces a `server.proxy` entry, and the reason is worth keeping. The
+ * proxy entry was given a `router` callback to pick the upstream per request
+ * once Dalux nodes became configurable (#2792). **Vite has no `router` option**
+ * — it uses `http-proxy-3`, while `router` belongs to `http-proxy-middleware`,
+ * a different package. The string does not occur anywhere in Vite's shipped
+ * dist, so the callback was silently ignored and a developer on node2 running
+ * `pnpm dev` still reached the default upstream.
+ *
+ * The deeper problem was having a second implementation at all: dev routed
+ * through a hand-written proxy config while production routed through the
+ * handler, so the two could disagree, and the test exercised the shared helper
+ * directly without ever going through Vite — which is exactly why the dead
+ * option was invisible.
+ *
+ * Running the real handler here removes that whole divergence class. The path
+ * allowlist, the node allowlist, the header filtering and the off-host redirect
+ * refusal are now the same code in both environments rather than two things
+ * that have to be kept in step.
+ */
+export function daluxRelayRoute(): Plugin {
+  return {
+    name: 'ifc-lite-dalux-relay',
+    configureServer(server) {
+      const handler = createDaluxRelayHandler(loadDaluxRelayConfig(process.env), {
+        fetchImpl: (...args) => fetch(...args),
+      });
+
+      server.middlewares.use((req, res, next) => {
+        const url = req.url ?? '';
+        if (!url.startsWith('/api/dalux')) return next();
+
+        void (async () => {
+          try {
+            const headers = new Headers();
+            for (const [k, v] of Object.entries(req.headers)) {
+              if (typeof v === 'string') headers.set(k, v);
+              else if (Array.isArray(v)) headers.set(k, v.join(', '));
+            }
+            // GET/HEAD/OPTIONS only reach the relay, so there is no body to
+            // forward; the handler rejects every other method itself.
+            const response = await handler(
+              new Request(`http://localhost${url}`, { method: req.method ?? 'GET', headers }),
+            );
+            res.statusCode = response.status;
+            response.headers.forEach((value, key) => res.setHeader(key, value));
+            const body = response.body ? Buffer.from(await response.arrayBuffer()) : null;
+            res.end(body ?? undefined);
+          } catch (err) {
+            res.statusCode = 502;
+            res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));
+          }
+        })();
+      });
+    },
+  };
+}

--- a/apps/viewer/vite-plugins/dalux-relay.ts
+++ b/apps/viewer/vite-plugins/dalux-relay.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { Readable } from 'node:stream';
+import type { ReadableStream as WebReadableStream } from 'node:stream/web';
 import type { Plugin } from 'vite';
 import { createDaluxRelayHandler, loadDaluxRelayConfig } from '../../../server/sources/dalux-relay';
 
@@ -58,8 +60,15 @@ export function daluxRelayRoute(): Plugin {
             );
             res.statusCode = response.status;
             response.headers.forEach((value, key) => res.setHeader(key, value));
-            const body = response.body ? Buffer.from(await response.arrayBuffer()) : null;
-            res.end(body ?? undefined);
+            // STREAM rather than buffer. The proxy this replaces streamed, and
+            // the relay's biggest response by far is a revision's file content:
+            // buffering would materialise a whole IFC in the Vite process
+            // before sending a byte, while the browser-side client then
+            // materialises its own copy. Replacing a streaming path with a
+            // buffering one is a regression even in dev, where the models are
+            // the same size they are anywhere else.
+            if (response.body) Readable.fromWeb(response.body as WebReadableStream).pipe(res);
+            else res.end();
           } catch (err) {
             res.statusCode = 502;
             res.end(JSON.stringify({ error: err instanceof Error ? err.message : String(err) }));

--- a/apps/viewer/vite-plugins/dalux-relay.ts
+++ b/apps/viewer/vite-plugins/dalux-relay.ts
@@ -37,7 +37,12 @@ export function daluxRelayRoute(): Plugin {
 
       server.middlewares.use((req, res, next) => {
         const url = req.url ?? '';
-        if (!url.startsWith('/api/dalux')) return next();
+        // Match the path BOUNDARY, not the prefix: a bare `startsWith` also
+        // claims `/api/dalux5.1/projects`, and the handler would then strip
+        // `/api/dalux` and relay `5.1/projects` from an unrelated route
+        // instead of passing it on.
+        const path = url.split('?')[0];
+        if (path !== '/api/dalux' && !path.startsWith('/api/dalux/')) return next();
 
         void (async () => {
           try {

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -11,7 +11,7 @@ import { cesiumStaticAssets } from './vite-plugins/cesium-assets';
 import { oauthCallbackRoutes } from './vite-plugins/oauth-callback';
 // Same allowlist the production relay uses, so dev and prod cannot disagree
 // about which Dalux node a request reaches (#2792).
-import { DEFAULT_DALUX_RELAY_CONFIG, resolveDevProxy } from '../../server/sources/dalux-relay';
+import { daluxRelayRoute } from './vite-plugins/dalux-relay';
 
 // --- Build-time changelog parser ---
 
@@ -246,6 +246,10 @@ export default defineConfig({
     topLevelAwait(),
     cesiumStaticAssets(),
     oauthCallbackRoutes(),
+    // Dalux's API sends no CORS headers, so it must go through a same-origin
+    // relay. Dev runs the SAME handler production does (#2792), rather than a
+    // second proxy config that can drift from it.
+    daluxRelayRoute(),
   ],
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),
@@ -301,21 +305,6 @@ export default defineConfig({
         // For local dev, run `pnpm dev:api` from repo root.
         target: 'http://localhost:3001',
         changeOrigin: true,
-      },
-      '/api/dalux': {
-        // Dalux Build's API sends no CORS headers, so browser requests must
-        // go through this same-origin relay (mirrors /api/bsdd below, and
-        // vercel.json's rewrite in production).
-        //
-        // Dalux assigns each customer a node (#2792), so the target cannot be
-        // fixed: a hardcoded node1 here would send a node2 developer's requests
-        // to node1 carrying an unused selector, and dev would silently disagree
-        // with production about which host it reached. `resolveDevProxy` is the
-        // production relay's own allowlist, so the two cannot drift.
-        target: DEFAULT_DALUX_RELAY_CONFIG.upstreamOrigin,
-        changeOrigin: true,
-        router: (req) => resolveDevProxy(req.url).target,
-        rewrite: (p) => resolveDevProxy(p).path,
       },
       '/api/bsdd': {
         target: 'https://api.bsdd.buildingsmart.org',

--- a/packages/source-dalux/test/provider.test.ts
+++ b/packages/source-dalux/test/provider.test.ts
@@ -815,4 +815,45 @@ describe('DaluxBuildProvider', () => {
       expect(result.message).toContain('500');
     });
   });
+
+  // ─── the baseUrl preference actually reaches the wire (#2792) ────────────
+  // The node plumbing is well covered on both sides, but the JOIN between them
+  // is one line in createClient. Reverting just that line left every other test
+  // in this PR green, which is the whole defect family this repo keeps hitting.
+
+  describe('baseUrl preference', () => {
+    it('sends the node selector on requests when a non-default base URL is set', async () => {
+      const seen: string[] = [];
+      const fetchImpl = vi.fn((url: string) => {
+        seen.push(String(url));
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve({ data: [] }) }));
+      }) as unknown as typeof fetch;
+
+      const ctx = createMockCtx(fetchImpl, {
+        apiKey: 'test-key-123',
+        baseUrl: 'https://node2.field.dalux.com/service/api',
+      });
+      await provider.listProjects(ctx);
+
+      expect(seen.length, 'no request was made').toBeGreaterThan(0);
+      expect(
+        seen[0],
+        `the baseUrl preference never reached the request: ${seen[0]}`,
+      ).toContain('daluxNode=node2');
+    });
+
+    it('sends no selector at all when the preference is absent', async () => {
+      // The node1 majority must be byte-for-byte unaffected.
+      const seen: string[] = [];
+      const fetchImpl = vi.fn((url: string) => {
+        seen.push(String(url));
+        return Promise.resolve(mockResponse({ json: () => Promise.resolve({ data: [] }) }));
+      }) as unknown as typeof fetch;
+
+      await provider.listProjects(createMockCtx(fetchImpl, { apiKey: 'test-key-123' }));
+
+      expect(seen.length).toBeGreaterThan(0);
+      expect(seen[0]).not.toContain('daluxNode');
+    });
+  });
 });

--- a/server/sources/dalux-relay.ts
+++ b/server/sources/dalux-relay.ts
@@ -95,35 +95,6 @@ export function resolveUpstreamOrigin(
   return originForNode(requested);
 }
 
-/**
- * Node-aware target and path for the LOCAL DEV proxy.
- *
- * Production routes `/api/dalux` through {@link createDaluxRelayHandler}; dev
- * routes it through Vite's proxy, which resolves a target per request. Both
- * must agree on which node a request reaches and on stripping our routing
- * parameter, so both call this rather than reimplementing the allowlist. It
- * lives here, beside the handler, for the same reason the path allowlist does:
- * dev and prod diverging is the bug.
- *
- * An unknown node falls back to the default target here rather than erroring,
- * because a Vite `router` has no way to answer 400 — the production relay is
- * the one that rejects it, and this keeps dev from silently pointing a bad
- * value somewhere unexpected.
- */
-export function resolveDevProxy(
-  reqUrl: string | undefined,
-  config: DaluxRelayConfig = DEFAULT_DALUX_RELAY_CONFIG,
-): { target: string; path: string } {
-  const url = new URL(reqUrl ?? '/', 'http://localhost');
-  const target =
-    resolveUpstreamOrigin(url.searchParams.get(DALUX_NODE_PARAM), config) ?? config.upstreamOrigin;
-
-  url.searchParams.delete(DALUX_NODE_PARAM);
-  const query = url.searchParams.toString();
-  const path = url.pathname.replace(/^\/api\/dalux/, config.upstreamBasePath);
-  return { target, path: `${path}${query ? `?${query}` : ''}` };
-}
-
 export const DEFAULT_DALUX_RELAY_CONFIG: DaluxRelayConfig = {
   upstreamOrigin: 'https://node1.field.dalux.com',
   upstreamBasePath: '/service/api',

--- a/tests/api/dalux-relay.test.ts
+++ b/tests/api/dalux-relay.test.ts
@@ -4,7 +4,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createDaluxRelayHandler, loadDaluxRelayConfig, resolveUpstreamPath, DEFAULT_DALUX_RELAY_CONFIG, type DaluxRelayConfig, resolveDevProxy } from '../../server/sources/dalux-relay.js';
+import { createDaluxRelayHandler, loadDaluxRelayConfig, resolveUpstreamPath, DEFAULT_DALUX_RELAY_CONFIG, type DaluxRelayConfig } from '../../server/sources/dalux-relay.js';
 
 const APP_ORIGIN = 'https://app.example';
 
@@ -324,32 +324,5 @@ test('accepts the full documented node range', async () => {
     const response = await handler(get(`/api/dalux/5.1/projects?daluxNode=${node}`));
     assert.equal(response.status, 200, `${node} was rejected`);
     assert.equal(captured[0].url, `https://${node}.field.dalux.com/service/api/5.1/projects`);
-  }
-});
-
-// --- dev proxy parity (#2792) ------------------------------------------------
-// Vite's dev proxy resolves a target per request instead of going through the
-// handler, so it must reach the SAME node and strip the SAME routing param.
-// A hardcoded dev target would send a node2 developer to node1 silently.
-
-test('the dev proxy routes to the selected node and strips the selector', () => {
-  const node2 = resolveDevProxy('/api/dalux/5.1/projects?daluxNode=node2&limit=10');
-  assert.equal(node2.target, 'https://node2.field.dalux.com');
-  assert.equal(node2.path, '/service/api/5.1/projects?limit=10');
-  assert.ok(!node2.path.includes('daluxNode'), 'routing param leaked to dev upstream');
-});
-
-test('the dev proxy matches the handler for the default node', () => {
-  const plain = resolveDevProxy('/api/dalux/5.1/projects');
-  assert.equal(plain.target, DEFAULT_DALUX_RELAY_CONFIG.upstreamOrigin);
-  assert.equal(plain.path, '/service/api/5.1/projects');
-});
-
-test('the dev proxy never routes an unknown node somewhere unexpected', () => {
-  // A Vite `router` cannot answer 400, so it falls back to the default target
-  // instead of forwarding a caller-supplied host. The handler is what rejects.
-  for (const bad of ['evil.com', 'node0', 'https://node2.field.dalux.com', '../node2']) {
-    const resolved = resolveDevProxy(`/api/dalux/5.1/projects?daluxNode=${encodeURIComponent(bad)}`);
-    assert.equal(resolved.target, DEFAULT_DALUX_RELAY_CONFIG.upstreamOrigin, `${bad} changed the dev target`);
   }
 });


### PR DESCRIPTION
Three defects in code that #2796 already merged. All found by review; **none of them could have been found by CI**, which is the theme.

## 1. The dev-proxy node routing was inert

#2796 added `router: (req) => resolveDevProxy(req.url).target` to the Vite proxy entry. **Vite has no `router` option.** It uses `http-proxy-3`; `router` belongs to `http-proxy-middleware`, a different package.

Evidence rather than inference:

```
grep -rl "router" <vite@8.2.0>/dist/   ->   0 files
```

The string does not occur anywhere in Vite's shipped package, so the callback could only ever be ignored. A developer on node2 running `pnpm dev` still reached the default upstream — the exact bug #2792 reported, still present in dev.

**The deeper fault was having a second implementation at all.** Dev routed through hand-written proxy config while production routed through the handler, and the test exercised the shared helper *directly* without ever going through Vite. That is why a dead option was invisible.

Dev now serves `/api/dalux` with `createDaluxRelayHandler` itself, so the path allowlist, node allowlist, header filtering and off-host redirect refusal are **the same code in both environments**. `resolveDevProxy` is deleted rather than left as a second source of truth.

## 2. The one line that actually fixes #2792 had no test

`createClient` reading the `baseUrl` preference and handing `node` to the client is the join between two well-tested halves. Reverting just that line left **every test in #2796 green**.

Now covered end to end through `listProjects`, plus the negative case:

```
mutation: const node = undefined
  × sends the node selector on requests when a non-default base URL is set
    the baseUrl preference never reached the request:
    https://node1.field.dalux.com/service/api/5.1/projects
```

## 3. `tests/api/**` was run by no workflow

`pnpm test:api` existed in `package.json` and **nothing invoked it**. So the relay's path and node allowlists — the guards that stop an unauthenticated, publicly reachable endpoint becoming an open proxy — existed in the repo but never in the pipeline.

Wired into the Node tests lane with a step timeout. **A guard no lane invokes is not a gate.** That one is worth a look beyond this PR: it means the open-proxy protections I described in #2796 were, until now, untested in CI.

## Verification

- `@ifc-lite/source-dalux`: **154 passed / 12 skipped**
- `tests/api`: **31/31** (now actually in CI)
- typecheck, `check-test-wiring`, `check-source-text-assertions` clean

## Credit

Raised by a peer session's review of the merged #2793/#2794/#2796. It flagged the Vite one as high-confidence-**unverified** because it could not run the check from a stale checkout — the right way to hand over a finding. I verified it before acting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local Dalux development so requests correctly honor non-default node selection.
  * Improved `/api/dalux` request handling by aligning development behavior with production relay behavior.
  * Relay failures now return a clear HTTP 502 error response.

* **Tests**
  * Added automated API route coverage to the test workflow.
  * Added coverage for custom node selection and default routing behavior.
  * Added validation for request routing across supported Dalux nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->