### PR TITLE
fix(collab): unfreeze a joined room's maxExpressId so peer edits keep resolving (#2719)

### DIFF
--- a/apps/viewer/src/lib/collab/express-id-bounds.test.ts
+++ b/apps/viewer/src/lib/collab/express-id-bounds.test.ts
@@ -22,7 +22,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { highestExpressId, raisedMaxExpressId } from './collabSlice.js';
+import { highestExpressId, raisedMaxExpressId } from '@/lib/collab/express-id-bounds';
 
 const idMap = (...ids: number[]): Map<number, string> =>
   new Map(ids.map((id) => [id, `/GUID${id}`]));

--- a/apps/viewer/src/lib/collab/express-id-bounds.ts
+++ b/apps/viewer/src/lib/collab/express-id-bounds.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The expressId high-water mark a reconstructed room model is gated on.
+ *
+ * Lives here rather than in `collabSlice` for two reasons. It is pure, so it is
+ * testable without driving an async reconstruct nothing can start; and #2706
+ * moves the reconstruct itself into `lib/collab/room-model-apply.ts`, so the
+ * rule is already where that refactor will want it instead of having to be
+ * carried across in the same change.
+ */
+
+/**
+ * Highest expressId in a reconstructed id map, or 0 when there is none.
+ *
+ * One definition for both reconstruct branches: the first build and every
+ * re-derive have to agree on what the bound means, and computing it twice by
+ * hand is how they came to disagree (#2719).
+ */
+export function highestExpressId(idToPath: Map<number, string> | undefined): number {
+  let max = 0;
+  if (idToPath) {
+    for (const id of idToPath.keys()) if (id > max) max = id;
+  }
+  return max;
+}
+
+/**
+ * The new `maxExpressId` bound for a re-derived room model, or `null` when it
+ * must not move.
+ *
+ * RAISED, NEVER LOWERED. A peer deleting an entity shrinks the id space, but
+ * ids already handed out elsewhere (selection, annotations, a pending mesh)
+ * have to keep resolving through `globalId.ts`'s
+ * `localExpressId <= model.maxExpressId` gate, so the bound is a high-water
+ * mark rather than a current count. Lowering it would turn a delete into a
+ * silent unresolvable-selection bug, which is the same defect as the freeze,
+ * just triggered from the other direction.
+ */
+export function raisedMaxExpressId(
+  current: number,
+  idToPath: Map<number, string> | undefined,
+): number | null {
+  const seen = highestExpressId(idToPath);
+  return seen > current ? seen : null;
+}

--- a/apps/viewer/src/store/slices/collabSlice.maxExpressId.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.maxExpressId.test.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * github.com/LTplus-AG/ifc-lite/issues/2719: a recipient's `maxExpressId` was
+ * captured on the FIRST reconstruct and never moved again.
+ *
+ * The chain, each link verified against the code: `collabSlice` computed the
+ * bound only inside `if (!modelCreated)`; the re-derive branch called only
+ * `setIfcDataStore`, which writes `{...model, ifcDataStore}` and leaves the
+ * bound alone; the IFCX re-derive re-allocates dense ids from 1
+ * (`entity-extractor.ts`), so a peer's newly created entity lands above the
+ * frozen bound; and `globalId.ts` gates resolution on
+ * `localExpressId <= model.maxExpressId`. Net effect: everything a peer added
+ * after the joiner's first reconstruct silently stopped resolving.
+ *
+ * The bound's movement rule is the part worth pinning, because it is wrong in
+ * BOTH directions: frozen loses new entities, and tracking the count exactly
+ * would break ids already handed out when a peer deletes something.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { highestExpressId, raisedMaxExpressId } from './collabSlice.js';
+
+const idMap = (...ids: number[]): Map<number, string> =>
+  new Map(ids.map((id) => [id, `/GUID${id}`]));
+
+describe('highestExpressId', () => {
+  it('is the largest id present, not the count', () => {
+    // Sparse ids are the realistic case after edits, and a count would report 3.
+    assert.equal(highestExpressId(idMap(4, 91, 17)), 91);
+  });
+
+  it('is 0 for an absent or empty map', () => {
+    assert.equal(highestExpressId(undefined), 0);
+    assert.equal(highestExpressId(new Map()), 0);
+  });
+});
+
+describe('raisedMaxExpressId: the bound only ever goes up', () => {
+  it('raises when a peer added an entity above the frozen bound', () => {
+    // The defect in one line: without this the joiner keeps 12 and entity 13
+    // resolves to nothing.
+    assert.equal(raisedMaxExpressId(12, idMap(1, 7, 13)), 13);
+  });
+
+  it('does not move when the re-derive stayed within the bound', () => {
+    // null means "no write", which matters: an unconditional updateModel would
+    // churn the model record on every peer edit.
+    assert.equal(raisedMaxExpressId(20, idMap(1, 7, 13)), null);
+  });
+
+  it('does not move when the highest id is exactly the bound', () => {
+    // The boundary the gate uses is `<=`, so an id equal to the bound already
+    // resolves and needs no raise.
+    assert.equal(raisedMaxExpressId(13, idMap(13)), null);
+  });
+
+  it('does NOT lower the bound when a peer deleted the highest entity', () => {
+    // Tracking the current maximum exactly would be the mirror-image defect:
+    // ids already handed out to selection or annotations must keep resolving.
+    assert.equal(raisedMaxExpressId(99, idMap(1, 2, 3)), null);
+  });
+
+  it('raises from a fresh model that has seen nothing yet', () => {
+    assert.equal(raisedMaxExpressId(0, idMap(5)), 5);
+  });
+
+  it('stays put for an empty re-derive rather than collapsing to 0', () => {
+    assert.equal(raisedMaxExpressId(42, undefined), null);
+    assert.equal(raisedMaxExpressId(42, new Map()), null);
+  });
+});

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -82,6 +82,41 @@ import { getEntityCenter } from '@/utils/viewportUtils';
  */
 export type CollabRole = 'viewer' | 'commenter' | 'editor' | 'admin';
 
+/**
+ * Highest expressId in a reconstructed id map, or 0 when there is none.
+ *
+ * One definition for both reconstruct branches: the first build and every
+ * re-derive have to agree on what the bound means, and computing it twice by
+ * hand is how they came to disagree (#2719).
+ */
+export function highestExpressId(idToPath: Map<number, string> | undefined): number {
+  let max = 0;
+  if (idToPath) {
+    for (const id of idToPath.keys()) if (id > max) max = id;
+  }
+  return max;
+}
+
+/**
+ * The new `maxExpressId` bound for a re-derived room model, or `null` when it
+ * must not move.
+ *
+ * RAISED, NEVER LOWERED. A peer deleting an entity shrinks the id space, but
+ * ids already handed out elsewhere (selection, annotations, a pending mesh)
+ * have to keep resolving through `globalId.ts`'s
+ * `localExpressId <= model.maxExpressId` gate, so the bound is a high-water
+ * mark rather than a current count. Lowering it would turn a delete into a
+ * silent unresolvable-selection bug, which is the same defect as the freeze,
+ * just triggered from the other direction.
+ */
+export function raisedMaxExpressId(
+  current: number,
+  idToPath: Map<number, string> | undefined,
+): number | null {
+  const seen = highestExpressId(idToPath);
+  return seen > current ? seen : null;
+}
+
 export type CollabStatus = 'disconnected' | WebSocketStatus | 'memory' | 'indexeddb';
 
 export interface StartCollabOptions {
@@ -704,10 +739,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
               // editable MutablePropertyView. idOffset 0 — mesh expressIds are
               // already in the reconstructed store's id space.
               modelCreated = true;
-              let maxExpressId = 0;
-              if (payload.idToPath) {
-                for (const id of payload.idToPath.keys()) if (id > maxExpressId) maxExpressId = id;
-              }
+              const maxExpressId = highestExpressId(payload.idToPath);
               get().upsertModel({
                 id: roomModelId,
                 name: 'Shared model',
@@ -727,6 +759,22 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
               // place (keeps the model id + activeModelId stable). setIfcDataStore
               // also updates the global store the outbound mirror reads.
               get().setIfcDataStore(payload.dataStore);
+              // ...but `setIfcDataStore` writes `{...model, ifcDataStore}` and
+              // leaves `maxExpressId` at whatever the FIRST reconstruct captured
+              // (#2719). The re-derive re-allocates dense ids from 1
+              // (`entity-extractor.ts`), so a peer's newly created entity lands
+              // ABOVE that frozen bound, and `globalId.ts` gates resolution on
+              // `localExpressId <= model.maxExpressId`. Everything a peer adds
+              // after the first reconstruct then stops resolving: no error, the
+              // entity is simply not found.
+              //
+              // Raised, never lowered. A delete shrinks the id space, but ids
+              // already handed out elsewhere (selection, annotations) must keep
+              // resolving, so the bound is a high-water mark rather than a
+              // current count.
+              const model = get().models.get(roomModelId);
+              const raised = model ? raisedMaxExpressId(model.maxExpressId, payload.idToPath) : null;
+              if (raised !== null) get().updateModel(roomModelId, { maxExpressId: raised });
             }
             const geomCount = session.doc.getMap('geometry').size;
             if (geomCount !== lastGeomCount) {

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -73,6 +73,7 @@ import {
   seedFailureMessage,
   writeGeometrySeedMarker,
 } from '@/lib/collab/geometry-seed-signal';
+import { highestExpressId, raisedMaxExpressId } from '@/lib/collab/express-id-bounds';
 import { createSharedBlobStore } from '@/lib/collab/blob-store';
 import {
   attachAnnotationInbound,
@@ -90,41 +91,6 @@ import { getEntityCenter } from '@/utils/viewportUtils';
  * UI affordances.
  */
 export type CollabRole = 'viewer' | 'commenter' | 'editor' | 'admin';
-
-/**
- * Highest expressId in a reconstructed id map, or 0 when there is none.
- *
- * One definition for both reconstruct branches: the first build and every
- * re-derive have to agree on what the bound means, and computing it twice by
- * hand is how they came to disagree (#2719).
- */
-export function highestExpressId(idToPath: Map<number, string> | undefined): number {
-  let max = 0;
-  if (idToPath) {
-    for (const id of idToPath.keys()) if (id > max) max = id;
-  }
-  return max;
-}
-
-/**
- * The new `maxExpressId` bound for a re-derived room model, or `null` when it
- * must not move.
- *
- * RAISED, NEVER LOWERED. A peer deleting an entity shrinks the id space, but
- * ids already handed out elsewhere (selection, annotations, a pending mesh)
- * have to keep resolving through `globalId.ts`'s
- * `localExpressId <= model.maxExpressId` gate, so the bound is a high-water
- * mark rather than a current count. Lowering it would turn a delete into a
- * silent unresolvable-selection bug, which is the same defect as the freeze,
- * just triggered from the other direction.
- */
-export function raisedMaxExpressId(
-  current: number,
-  idToPath: Map<number, string> | undefined,
-): number | null {
-  const seen = highestExpressId(idToPath);
-  return seen > current ? seen : null;
-}
 
 export type CollabStatus = 'disconnected' | WebSocketStatus | 'memory' | 'indexeddb';
 


### PR DESCRIPTION
Fixes #2719.

A recipient captured `maxExpressId` on the **first** reconstruct and never moved it again, so every entity a peer created afterwards silently stopped resolving. No error, no warning — the entity is simply not found.

## The chain, each link read rather than assumed

| step | code |
| --- | --- |
| the bound is computed only on the first build | `collabSlice.ts`, inside `if (!modelCreated)` |
| the re-derive branch calls only `setIfcDataStore` | which writes `{...model, ifcDataStore}` and leaves `maxExpressId` alone (`dataSlice.ts`) |
| the re-derive re-allocates dense ids from 1 | `packages/ifcx/src/entity-extractor.ts` — `let nextExpressId = 1` |
| resolution is gated on the bound | `globalId.ts` — `localExpressId <= model.maxExpressId`, and `resolveGlobalIdFromModels` carries the same test |

So the id space grows on every re-derive while the bound stays where the joiner first found it.

## The movement rule is wrong in both directions, which is why it is a named function

Frozen loses new entities. But tracking the current maximum *exactly* would **lower** the bound when a peer deletes the highest entity, and ids already handed out to selection or annotations would stop resolving — the same defect, triggered from the other side.

So the bound is a **high-water mark: raised, never lowered.** That rule now lives in `raisedMaxExpressId`, a pure function, instead of a condition buried in an async reconstruct that nothing can drive. `null` means "no write", which also stops an unconditional `updateModel` churning the model record on every peer edit.

## Verification

Four mutations, each applied to exactly one occurrence, each caught by a **named** test, subtest count unchanged at 10 in every run:

| mutation | test that reds |
| --- | --- |
| never raise the bound (the original defect) | `raises when a peer added an entity above the frozen bound` |
| track the maximum exactly, so a delete lowers it | `does NOT lower the bound when a peer deleted the highest entity` |
| raise on `>=` instead of `>` | `does not move when the highest id is exactly the bound` |
| `highestExpressId` returns the count instead of the max | `is the largest id present, not the count` |

Sparse ids are used deliberately in the fixtures: a count and a maximum agree on `[1,2,3]` and disagree on `[4,91,17]`, and only the second can tell the two implementations apart.

`pnpm --filter @ifc-lite/viewer run typecheck` clean, and the collab suites pass together (42 tests) on a tree with current main merged in.

## Note on sequencing

#2706 rewrites this same else-branch into `apps/viewer/src/lib/collab/room-model-apply.ts`. I checked before deciding: it is an external PR at `REVIEW_REQUIRED` with **`Node tests` failing**, so it is not landing imminently, and the freeze survives that refactor either way (its patch type carries no `maxExpressId`). The fix is written as a pure function precisely so it folds into that helper when it lands, rather than needing to be rewritten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collaborative model reconstruction to preserve the highest observed IFC express ID.
  * Prevented express ID bounds from decreasing after deletions or empty updates.
  * Ensured newly introduced higher IDs are correctly recognized.

* **Tests**
  * Added coverage for sparse, empty, missing, increasing, and decreasing ID scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->