### PR TITLE
feat(viewer): edge-to-edge and face-to-face angle measurement

### DIFF
--- a/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
@@ -137,13 +137,57 @@ describe('handleAngleClick wiring (#2735)', () => {
     assert.equal(useViewerStore.getState().angleMeasurements.length, 1);
   });
 
-  it('does not register picks when the tool is not in angle mode', () => {
-    useViewerStore.setState({ measureMode: 'drag' });
-    // The router gates on mode, but the handler is exported and a future
-    // caller could reach it directly; the store's own kind check is the
-    // backstop being pinned here.
-    useViewerStore.setState({ angleKind: 'edges' });
-    handleAngleClick(fakeCtx({ x: 0, y: 0, z: 0 }), 0, 0);
+  it('rejects a pick whose kind disagrees with the active angle kind', () => {
+    // This used to assert that `angleKind: 'edges'` registered NOTHING, which
+    // pinned "edges is not implemented yet" rather than the backstop its own
+    // comment described. Edges ship now, so the placeholder assertion had to
+    // go; the backstop itself is real and is what is pinned here.
+    //
+    // The router gates on mode, but `addAnglePick` is reachable directly, and
+    // a mismatched pick landing in the store would measure an angle from the
+    // wrong sort of input, silently.
+    useViewerStore.setState({ angleKind: 'faces', activeAngle: null });
+    useViewerStore.getState().addAnglePick({
+      kind: 'points',
+      point: { x: 0, y: 0, z: 0, screenX: 0, screenY: 0 },
+    });
+    assert.equal(
+      useViewerStore.getState().activeAngle,
+      null,
+      'a points pick was accepted while the tool was measuring faces',
+    );
+  });
+
+  it('accumulates FOUR picks for an edge pair before finishing', () => {
+    // Two picks cannot identify two edges: snap metadata yields tessellation
+    // segments, not topological edges (#2199), so each edge is a point pair
+    // the user places explicitly.
+    useViewerStore.setState({
+      measureMode: 'angle',
+      angleKind: 'edges',
+      activeAngle: null,
+      angleMeasurements: [],
+    });
+    // Well separated in SCREEN space as well as world space: this harness's
+    // camera projects (x,y,z) -> (x,y), and picks a pixel apart are swallowed
+    // by the double-click guard, which would look like the store refusing them.
+    const pts = [
+      { x: 0, y: 0, z: 0 },
+      { x: 100, y: 0, z: 0 },
+      { x: 0, y: 200, z: 0 },
+      { x: 0, y: 300, z: 0 },
+    ];
+    pts.forEach((p, i) => {
+      handleAngleClick(fakeCtx(p), i * 40, i * 40);
+      if (i < 3) {
+        assert.equal(
+          useViewerStore.getState().angleMeasurements.length,
+          0,
+          `finished after ${i + 1} picks, before both edges were placed`,
+        );
+      }
+    });
+    assert.equal(useViewerStore.getState().angleMeasurements.length, 1);
     assert.equal(useViewerStore.getState().activeAngle, null);
   });
 });

--- a/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
@@ -190,4 +190,32 @@ describe('handleAngleClick wiring (#2735)', () => {
     assert.equal(useViewerStore.getState().angleMeasurements.length, 1);
     assert.equal(useViewerStore.getState().activeAngle, null);
   });
+
+  it('completes when both edges share a corner picked twice', () => {
+    // The natural gesture for "angle between two edges": trace edge A INTO the
+    // corner, then edge B OUT of it. Picks 2 and 3 are the SAME corner, so the
+    // second lands within the double-click radius of the first.
+    //
+    // A shared vertex is not a degenerate edge: a zero-length second edge needs
+    // pick 4 to coincide with pick 3, which the within-edge guard catches. If
+    // the guard also spans the boundary, pick 3 is swallowed, the measurement
+    // never completes, and the user's only recourse is to click slightly off
+    // the corner - degrading the very direction being measured.
+    useViewerStore.setState({
+      measureMode: 'angle',
+      angleKind: 'edges',
+      activeAngle: null,
+      angleMeasurements: [],
+    });
+    const corner = { x: 0, y: 0, z: 0 };
+    const seq = [{ x: 200, y: 0, z: 0 }, corner, corner, { x: 0, y: 200, z: 0 }];
+    seq.forEach((p) => handleAngleClick(fakeCtx(p), p.x, p.y));
+
+    assert.equal(
+      useViewerStore.getState().angleMeasurements.length,
+      1,
+      'the shared corner was swallowed as a double-click, so the measurement never finished',
+    );
+    assert.equal(useViewerStore.getState().activeAngle, null);
+  });
 });

--- a/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.angle.test.ts
@@ -31,6 +31,20 @@ import {
 } from './tools/measure-modes/three-point-angle.js';
 import type { MouseHandlerContext } from './mouseHandlerTypes.js';
 
+function fakeFaceCtx(
+  point: { x: number; y: number; z: number },
+  normal: { x: number; y: number; z: number },
+): MouseHandlerContext {
+  const base = fakeCtx(point) as unknown as Record<string, unknown>;
+  return {
+    ...base,
+    renderer: {
+      ...(base.renderer as Record<string, unknown>),
+      raycastScene: () => ({ intersection: { point, normal } }),
+    },
+  } as unknown as MouseHandlerContext;
+}
+
 function fakeCtx(hit: { x: number; y: number; z: number } | null): MouseHandlerContext {
   const canvas = document.createElement('canvas');
   return {
@@ -217,5 +231,28 @@ describe('handleAngleClick wiring (#2735)', () => {
       'the shared corner was swallowed as a double-click, so the measurement never finished',
     );
     assert.equal(useViewerStore.getState().activeAngle, null);
+  });
+
+  it('does not record both halves of a double-click on one face', () => {
+    // A face pair needs exactly TWO picks, so an unguarded double-click
+    // completes a whole measurement from one gesture - and the two picks share
+    // a normal, so it reads "Parallel": a plausible-looking answer to a
+    // question the user never asked.
+    useViewerStore.setState({
+      measureMode: 'angle',
+      angleKind: 'faces',
+      activeAngle: null,
+      angleMeasurements: [],
+    });
+    const ctx = fakeFaceCtx({ x: 1, y: 2, z: 3 }, { x: 0, y: 1, z: 0 });
+    handleAngleClick(ctx, 100, 100);
+    handleAngleClick(ctx, 100, 100); // the second half of the double-click
+
+    assert.equal(
+      useViewerStore.getState().angleMeasurements.length,
+      0,
+      'a double-click on one face completed a measurement on its own',
+    );
+    assert.equal(useViewerStore.getState().activeAngle?.picks.length, 1);
   });
 });

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -695,12 +695,27 @@ export function handleAngleClick(ctx: MouseHandlerContext, x: number, y: number)
     const n = hit?.intersection?.normal;
     const p = hit?.intersection?.point;
     if (!n || !p) return;
+
+    // Faces need the SAME double-click guard as the point-based kinds, which
+    // this early-return path was skipping. A face pair needs exactly two picks,
+    // so a physical double-click on one face recorded both halves instantly and
+    // completed a bogus measurement reading "Parallel" - a plausible-looking
+    // number for two picks the user never made.
+    //
+    // There is no shape boundary to exempt here, unlike edges: both face picks
+    // belong to one measurement, and two clicks in the same spot are always the
+    // same face.
+    const facePrior = state.activeAngle?.picks ?? [];
+    const facePrev = facePrior.length > 0 ? facePrior[facePrior.length - 1].point : null;
+    const facePoint = { x: p.x, y: p.y, z: p.z, screenX: x, screenY: y };
+    if (facePrev && isDuplicateClickPoint(facePrev, facePoint)) return;
+
     state.addAnglePick({
       kind: 'faces',
       // screen coords are the click itself, which is what the overlay
       // reprojects from; `updateMeasurementScreenCoords` refreshes them on
       // camera move exactly as it does for the other kinds.
-      point: { x: p.x, y: p.y, z: p.z, screenX: x, screenY: y },
+      point: facePoint,
       normal: { x: n.x, y: n.y, z: n.z },
     });
     return;

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -681,18 +681,47 @@ export function handlePolylineClick(ctx: MouseHandlerContext, x: number, y: numb
  */
 export function handleAngleClick(ctx: MouseHandlerContext, x: number, y: number): void {
   const state = useViewerStore.getState();
-  if (state.angleKind !== 'points') return;
+  const kind = state.angleKind;
+
+  // Faces need the surface normal, which only the raycast hit carries, so they
+  // take a different path from the two point-based kinds rather than sharing
+  // the snap-driven one. Snapping a face pick to a nearby VERTEX would move the
+  // point off the surface whose normal we just read.
+  if (kind === 'faces') {
+    const hit = ctx.renderer?.raycastScene(x, y, {
+      hiddenIds: ctx.hiddenEntitiesRef.current,
+      isolatedIds: ctx.isolatedEntitiesRef.current,
+    });
+    const n = hit?.intersection?.normal;
+    const p = hit?.intersection?.point;
+    if (!n || !p) return;
+    state.addAnglePick({
+      kind: 'faces',
+      // screen coords are the click itself, which is what the overlay
+      // reprojects from; `updateMeasurementScreenCoords` refreshes them on
+      // camera move exactly as it does for the other kinds.
+      point: { x: p.x, y: p.y, z: p.z, screenX: x, screenY: y },
+      normal: { x: n.x, y: n.y, z: n.z },
+    });
+    return;
+  }
 
   const picked = raycastForPolylinePoint(ctx, x, y);
   if (!picked) return;
 
   // Drop the second half of a physical double-click (see the note above).
+  //
+  // For `edges` this is deliberately checked against the immediately preceding
+  // pick only, including across the boundary between the first and second edge:
+  // a double-click that ends one edge and starts the next would otherwise place
+  // a zero-length second edge, which reads as "Second pick too short" for
+  // something the user never did.
   const prior = state.activeAngle?.picks;
   const last = prior && prior.length > 0 ? prior[prior.length - 1].point : null;
   if (last && isDuplicateClickPoint(last, picked.point)) return;
 
   ctx.setSnapTarget(picked.snapTarget);
-  state.addAnglePick({ kind: 'points', point: picked.point });
+  state.addAnglePick({ kind, point: picked.point });
 }
 
 /**

--- a/apps/viewer/src/components/viewer/selectionHandlers.ts
+++ b/apps/viewer/src/components/viewer/selectionHandlers.ts
@@ -709,15 +709,22 @@ export function handleAngleClick(ctx: MouseHandlerContext, x: number, y: number)
   const picked = raycastForPolylinePoint(ctx, x, y);
   if (!picked) return;
 
-  // Drop the second half of a physical double-click (see the note above).
+  // Drop the second half of a physical double-click (see the note above), but
+  // only WITHIN a shape, never across the boundary between the two edges.
   //
-  // For `edges` this is deliberately checked against the immediately preceding
-  // pick only, including across the boundary between the first and second edge:
-  // a double-click that ends one edge and starts the next would otherwise place
-  // a zero-length second edge, which reads as "Second pick too short" for
-  // something the user never did.
-  const prior = state.activeAngle?.picks;
-  const last = prior && prior.length > 0 ? prior[prior.length - 1].point : null;
+  // The natural gesture for an edge pair is to trace edge A into a shared
+  // corner and edge B out of it, so picks 2 and 3 are the SAME point. Guarding
+  // across that boundary swallowed pick 3, the measurement never completed, and
+  // the only recourse was to click slightly off the corner - degrading the very
+  // direction being measured. Worse, the opposite pick order (corner first)
+  // survived, so the mode worked or did not depending on which end of edge A
+  // the user started from, which is not a distinction they can see.
+  //
+  // A shared vertex is NOT a degenerate edge: a zero-length second edge needs
+  // pick 4 to coincide with pick 3, and that is still caught below.
+  const prior = state.activeAngle?.picks ?? [];
+  const startsNewShape = kind === 'edges' && prior.length % 2 === 0;
+  const last = !startsNewShape && prior.length > 0 ? prior[prior.length - 1].point : null;
   if (last && isDuplicateClickPoint(last, picked.point)) return;
 
   ctx.setSnapTarget(picked.snapTarget);

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -18,7 +18,7 @@ import { MeasurementOverlays } from './MeasurementVisuals';
 import { MeasurePointReadout } from './MeasurePointReadout';
 import { MeasureQuantities } from './MeasureQuantities';
 import { formatDistance } from './formatDistance';
-import type { AngleKind, AngleMeasurement } from '@/store/types';
+import { ANGLE_REQUIRED_PICKS, type AngleKind, type AngleMeasurement } from '@/store/types';
 import { formatThreePointAngle, threePointAngle } from './measure-modes/three-point-angle';
 import { edgePairAngle, facePairAngle, formatAnglePair } from './measure-modes/edge-face-angle';
 
@@ -28,6 +28,34 @@ import { edgePairAngle, facePairAngle, formatAnglePair } from './measure-modes/e
  * the UI; the exhaustiveness that matters (how many picks each needs) already
  * lives on `ANGLE_REQUIRED_PICKS`.
  */
+/**
+ * What to click next, per kind and per pick already placed.
+ *
+ * Kept as one function rather than inline ternaries because the three kinds
+ * need DIFFERENT counts and different words: the panel previously showed
+ * "n/3 picks" and point-angle wording for every kind, so an edge pair read
+ * "3/3" with a fourth pick still required - a progress indicator that says the
+ * measurement is complete when it is not.
+ */
+function angleHint(kind: AngleKind, placed: number): string {
+  const cancel = ' · Esc to cancel';
+  if (kind === 'faces') {
+    return placed === 0 ? 'Click the first face' : 'Click the second face' + cancel;
+  }
+  if (kind === 'edges') {
+    // Two picks per edge; naming which edge AND which end is the difference
+    // between a hint and a hint that helps.
+    if (placed === 0) return 'Click the start of the first edge';
+    if (placed === 1) return 'Click the end of the first edge' + cancel;
+    if (placed === 2) return 'Click the start of the second edge' + cancel;
+    return 'Click the end of the second edge' + cancel;
+  }
+  if (placed === 0) return 'Click the apex of the angle';
+  return placed === 1
+    ? 'Click the first direction' + cancel
+    : 'Click the second direction' + cancel;
+}
+
 /**
  * Readout for a stored angle, derived on render and never persisted, so a
  * correction to the maths retroactively fixes every measurement already listed.
@@ -489,8 +517,14 @@ export function MeasureOverlay() {
               )}
               {activeAngle && (
                 <div className="mt-2 rounded bg-primary/10 px-2 py-0.5 text-xs text-muted-foreground">
-                  Angle in progress · {activeAngle.picks.length}/3 picks
-                  {activeAngle.picks.length === 1 ? ' · apex set' : ''}
+                  Angle in progress · {activeAngle.picks.length}/
+                  {ANGLE_REQUIRED_PICKS[activeAngle.kind]} picks
+                  {activeAngle.kind === 'points' && activeAngle.picks.length === 1
+                    ? ' · apex set'
+                    : ''}
+                  {activeAngle.kind === 'edges' && activeAngle.picks.length === 2
+                    ? ' · first edge set'
+                    : ''}
                 </div>
               )}
             </div>
@@ -524,11 +558,7 @@ export function MeasureOverlay() {
                 // branch below would permanently show "Drag to measure" in a
                 // mode that ignores drags entirely. The hint has to name the
                 // gesture that actually works, and which pick is next.
-                !activeAngle
-                ? 'Click the apex of the angle'
-                : activeAngle.picks.length === 1
-                  ? 'Click the first direction · Esc to cancel'
-                  : 'Click the second direction · Esc to cancel'
+                angleHint(angleKind, activeAngle?.picks.length ?? 0)
               : activeMeasurement
                 ? 'Release to complete'
                 : 'Drag to measure'}

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -18,7 +18,58 @@ import { MeasurementOverlays } from './MeasurementVisuals';
 import { MeasurePointReadout } from './MeasurePointReadout';
 import { MeasureQuantities } from './MeasureQuantities';
 import { formatDistance } from './formatDistance';
+import type { AngleKind, AngleMeasurement } from '@/store/types';
 import { formatThreePointAngle, threePointAngle } from './measure-modes/three-point-angle';
+import { edgePairAngle, facePairAngle, formatAnglePair } from './measure-modes/edge-face-angle';
+
+/**
+ * The three angle kinds, their button text and what each one asks the user to
+ * click. `Record<AngleKind, ...>` is not used here because the ORDER is part of
+ * the UI; the exhaustiveness that matters (how many picks each needs) already
+ * lives on `ANGLE_REQUIRED_PICKS`.
+ */
+/**
+ * Readout for a stored angle, derived on render and never persisted, so a
+ * correction to the maths retroactively fixes every measurement already listed.
+ *
+ * Switching on `kind` rather than on pick COUNT: three-point and face pairs
+ * would both be distinguishable by count today, but edges take four picks and a
+ * future kind could collide, and the kind is the thing that is actually true.
+ */
+function formatAngleMeasurement(a: AngleMeasurement): string {
+  switch (a.kind) {
+    case 'points':
+      return formatThreePointAngle(
+        threePointAngle(a.picks[0].point, a.picks[1].point, a.picks[2].point),
+      );
+    case 'edges':
+      return formatAnglePair(
+        edgePairAngle(
+          a.picks[0].point,
+          a.picks[1].point,
+          a.picks[2].point,
+          a.picks[3].point,
+        ),
+      );
+    case 'faces':
+      return formatAnglePair(
+        facePairAngle(
+          a.picks[0].normal ?? { x: 0, y: 0, z: 0 },
+          a.picks[1].normal ?? { x: 0, y: 0, z: 0 },
+        ),
+      );
+  }
+}
+
+const ANGLE_KIND_LABELS: ReadonlyArray<readonly [AngleKind, string, string]> = [
+  ['points', '3-Point', 'Angle at an apex: click the corner first, then the two directions'],
+  [
+    'edges',
+    'Edges',
+    'Angle between two lines: click two points on the first, then two on the second. Four clicks, because snap metadata yields tessellation segments rather than whole edges',
+  ],
+  ['faces', 'Faces', 'Angle between two planes: click one face, then the other'],
+];
 import {
   distanceComponents,
   formatAxisDeltas,
@@ -71,6 +122,9 @@ export function MeasureOverlay() {
   const measureMode = useViewerStore((s) => s.measureMode);
   const angleMeasurements = useViewerStore((s) => s.angleMeasurements);
   const activeAngle = useViewerStore((s) => s.activeAngle);
+  const angleKind = useViewerStore((s) => s.angleKind);
+  const setAngleKind = useViewerStore((s) => s.setAngleKind);
+  const cancelAngle = useViewerStore((s) => s.cancelAngle);
   const deleteAngleMeasurement = useViewerStore((s) => s.deleteAngleMeasurement);
   const setMeasureMode = useViewerStore((s) => s.setMeasureMode);
   const activePolyline = useViewerStore((s) => s.activePolyline);
@@ -263,6 +317,32 @@ export function MeasureOverlay() {
           >
             {measureMode === 'polyline' ? 'Polyline' : measureMode === 'angle' ? 'Angle' : 'Distance'}
           </button>
+          {measureMode === 'angle' && (
+            <>
+              {ANGLE_KIND_LABELS.map(([kind, label, hint]) => (
+                <button
+                  key={kind}
+                  onClick={() => {
+                    // Discard any half-placed sequence: its picks belong to the
+                    // OLD kind and need a different count, so carrying them over
+                    // would finish the new measurement early with the wrong
+                    // inputs. The store rejects a mismatched pick, so without
+                    // this the tool would look frozen instead.
+                    cancelAngle();
+                    setAngleKind(kind);
+                  }}
+                  className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
+                    angleKind === kind
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-zinc-100 dark:bg-zinc-900 text-zinc-500 border-zinc-300 dark:border-zinc-700'
+                  }`}
+                  title={hint}
+                >
+                  {label}
+                </button>
+              ))}
+            </>
+          )}
           <button
             onClick={toggleSnap}
             className={`px-2 py-1 font-mono text-[10px] uppercase tracking-wider border-2 transition-colors ${
@@ -392,13 +472,7 @@ export function MeasureOverlay() {
                           {/* Derived on render, never stored: a correction to
                               the maths retroactively fixes every measurement
                               already listed. */}
-                          {formatThreePointAngle(
-                            threePointAngle(
-                              a.picks[0].point,
-                              a.picks[1].point,
-                              a.picks[2].point,
-                            ),
-                          )}
+                          {formatAngleMeasurement(a)}
                         </span>
                         <Button
                           variant="ghost"

--- a/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePanel.tsx
@@ -53,10 +53,10 @@ function formatAngleMeasurement(a: AngleMeasurement): string {
       );
     case 'faces':
       return formatAnglePair(
-        facePairAngle(
-          a.picks[0].normal ?? { x: 0, y: 0, z: 0 },
-          a.picks[1].normal ?? { x: 0, y: 0, z: 0 },
-        ),
+        // Pass the absence through rather than substituting a zero vector: a
+        // missing normal is an upstream bug and must not render as a
+        // measurement error the user could have caused.
+        facePairAngle(a.picks[0].normal, a.picks[1].normal),
       );
   }
 }

--- a/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.test.ts
@@ -14,7 +14,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { edgePairAngle, facePairAngle } from './edge-face-angle';
+import { edgePairAngle, facePairAngle, formatAnglePair } from './edge-face-angle';
 
 const P = (x: number, y: number, z: number) => ({ x, y, z });
 const near = (a: number, b: number, tol = 1e-6) =>
@@ -132,6 +132,21 @@ describe('facePairAngle', () => {
     assert.deepEqual(facePairAngle(P(0, 0, 0), P(0, 1, 0)), { kind: 'degenerate', reason: 'first' });
     assert.deepEqual(facePairAngle(P(0, 1, 0), P(0, 0, 0)), { kind: 'degenerate', reason: 'second' });
     assert.deepEqual(facePairAngle(P(Number.NaN, 1, 0), P(0, 1, 0)), {
+      kind: 'degenerate',
+      reason: 'first',
+    });
+  });
+
+  it('distinguishes a missing normal from a too-short pick', () => {
+    // A face pick has no length, so "First pick too short" would describe
+    // something the user cannot do. A missing normal means a stored pick lost
+    // its normal upstream - a bug, not a measurement error.
+    const missing = facePairAngle(undefined, { x: 0, y: 1, z: 0 });
+    assert.deepEqual(missing, { kind: 'degenerate', reason: 'no-normal' });
+    assert.equal(formatAnglePair(missing), 'No surface at one pick');
+
+    // ...and a present-but-zero normal is still reported as such.
+    assert.deepEqual(facePairAngle({ x: 0, y: 0, z: 0 }, { x: 0, y: 1, z: 0 }), {
       kind: 'degenerate',
       reason: 'first',
     });

--- a/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.test.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Fixtures here are deliberately ASYMMETRIC and never 45 degrees.
+ *
+ * A 45 degree fixture survives the fold at 90 unchanged, so it cannot tell
+ * `raw > 90 ? 180 - raw : raw` from `raw`, from `90 - raw`, or from a swap of
+ * the two arguments. Every angle asserted below is distinct from its own
+ * supplement and from its own complement.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { edgePairAngle, facePairAngle } from './edge-face-angle';
+
+const P = (x: number, y: number, z: number) => ({ x, y, z });
+const near = (a: number, b: number, tol = 1e-6) =>
+  assert.ok(Math.abs(a - b) < tol, `expected ~${b}, got ${a}`);
+
+describe('edgePairAngle', () => {
+  it('measures the angle between two picked segments', () => {
+    // 30 degrees: distinct from its supplement (150) and complement (60).
+    const r = edgePairAngle(P(0, 0, 0), P(1, 0, 0), P(0, 0, 0), P(Math.cos(Math.PI / 6), 0, Math.sin(Math.PI / 6)));
+    assert.equal(r.kind, 'angled');
+    if (r.kind === 'angled') near(r.degrees, 30);
+  });
+
+  it('does not depend on the order the two points of an edge were picked', () => {
+    // A line has no direction. If this changed with click order the user could
+    // reproduce two different readings for one pair of edges at will.
+    const a1 = P(0, 0, 0);
+    const a2 = P(2.3, 0, 0);
+    const b1 = P(1, 0, 0);
+    const b2 = P(1 + Math.cos(Math.PI / 6) * 1.7, 0, Math.sin(Math.PI / 6) * 1.7);
+    const forward = edgePairAngle(a1, a2, b1, b2);
+    const reversed = edgePairAngle(a2, a1, b2, b1);
+    const mixed = edgePairAngle(a2, a1, b1, b2);
+    assert.equal(forward.kind, 'angled');
+    if (forward.kind === 'angled' && reversed.kind === 'angled' && mixed.kind === 'angled') {
+      near(reversed.degrees, forward.degrees);
+      near(mixed.degrees, forward.degrees);
+    }
+  });
+
+  it('folds an obtuse pairing onto its acute equivalent', () => {
+    // 150 degrees between the directions is 30 between the lines. Asserting
+    // 30 (not 150) is what pins the fold; 45 could not tell them apart.
+    const r = edgePairAngle(
+      P(0, 0, 0),
+      P(1, 0, 0),
+      P(0, 0, 0),
+      P(Math.cos((150 * Math.PI) / 180), 0, Math.sin((150 * Math.PI) / 180)),
+    );
+    assert.equal(r.kind, 'angled');
+    if (r.kind === 'angled') near(r.degrees, 30);
+  });
+
+  it('reports parallel for both parallel and ANTI-parallel edges', () => {
+    const same = edgePairAngle(P(0, 0, 0), P(1, 2, 3), P(9, 9, 9), P(10, 11, 12));
+    const opposed = edgePairAngle(P(0, 0, 0), P(1, 2, 3), P(10, 11, 12), P(9, 9, 9));
+    assert.equal(same.kind, 'parallel');
+    assert.equal(opposed.kind, 'parallel', 'anti-parallel is the same LINE, so it is parallel');
+  });
+
+  it('names which edge was degenerate, not just that one was', () => {
+    const tiny = 1 / 65536 / 4;
+    const first = edgePairAngle(P(0, 0, 0), P(tiny, 0, 0), P(0, 0, 0), P(1, 0, 0));
+    const second = edgePairAngle(P(0, 0, 0), P(1, 0, 0), P(0, 0, 0), P(0, tiny, 0));
+    assert.deepEqual(first, { kind: 'degenerate', reason: 'first' });
+    assert.deepEqual(second, { kind: 'degenerate', reason: 'second' });
+  });
+
+  it('accepts an edge exactly at the pick resolution', () => {
+    // The guard is <=, so one resolution is degenerate and just above it is
+    // usable. Pinning the boundary from both sides keeps the threshold honest:
+    // a value below the snap floor would classify nothing reachable.
+    const res = 1 / 65536;
+    assert.equal(edgePairAngle(P(0, 0, 0), P(res, 0, 0), P(0, 0, 0), P(1, 0, 0)).kind, 'degenerate');
+    assert.notEqual(
+      edgePairAngle(P(0, 0, 0), P(res * 4, 0, 0), P(0, 0, 0), P(0, 0, 1)).kind,
+      'degenerate',
+    );
+  });
+});
+
+describe('facePairAngle', () => {
+  it('measures the angle between two planes from their normals', () => {
+    // Normals 65 degrees apart -> 65 between the planes (distinct from 115).
+    const t = (65 * Math.PI) / 180;
+    const r = facePairAngle(P(0, 1, 0), P(Math.sin(t), Math.cos(t), 0));
+    assert.equal(r.kind, 'angled');
+    if (r.kind === 'angled') near(r.degrees, 65);
+  });
+
+  it('ignores normal sign, because IFC winding is unreliable', () => {
+    // Meshes are drawn double-sided here, so an inverted normal is a modelling
+    // artefact rather than a different plane. Flipping either must not move it.
+    const t = (65 * Math.PI) / 180;
+    const n1 = P(0, 1, 0);
+    const n2 = P(Math.sin(t), Math.cos(t), 0);
+    const base = facePairAngle(n1, n2);
+    const flipA = facePairAngle(P(-n1.x, -n1.y, -n1.z), n2);
+    const flipB = facePairAngle(n1, P(-n2.x, -n2.y, -n2.z));
+    assert.equal(base.kind, 'angled');
+    if (base.kind === 'angled' && flipA.kind === 'angled' && flipB.kind === 'angled') {
+      near(flipA.degrees, base.degrees);
+      near(flipB.degrees, base.degrees);
+    }
+  });
+
+  it('is scale invariant, so an unnormalised normal reads the same', () => {
+    const t = (65 * Math.PI) / 180;
+    const a = facePairAngle(P(0, 1, 0), P(Math.sin(t), Math.cos(t), 0));
+    const b = facePairAngle(P(0, 1000, 0), P(Math.sin(t) * 0.004, Math.cos(t) * 0.004, 0));
+    if (a.kind === 'angled' && b.kind === 'angled') near(b.degrees, a.degrees, 1e-5);
+    else assert.fail('expected both to be angled');
+  });
+
+  it('reports parallel for coincident and for opposed faces', () => {
+    assert.equal(facePairAngle(P(0, 1, 0), P(0, 3, 0)).kind, 'parallel');
+    assert.equal(
+      facePairAngle(P(0, 1, 0), P(0, -3, 0)).kind,
+      'parallel',
+      'opposed normals still describe two PARALLEL planes',
+    );
+  });
+
+  it('names which normal was unusable', () => {
+    assert.deepEqual(facePairAngle(P(0, 0, 0), P(0, 1, 0)), { kind: 'degenerate', reason: 'first' });
+    assert.deepEqual(facePairAngle(P(0, 1, 0), P(0, 0, 0)), { kind: 'degenerate', reason: 'second' });
+    assert.deepEqual(facePairAngle(P(Number.NaN, 1, 0), P(0, 1, 0)), {
+      kind: 'degenerate',
+      reason: 'first',
+    });
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.ts
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Edge-to-edge and face-to-face angles (#2735, the two slices after
+ * `three-point-angle.ts`).
+ *
+ * Pure display maths over stored picks, the `inclination.ts` precedent: nothing
+ * but the picks is persisted, so a correction here retroactively fixes every
+ * measurement already on screen.
+ *
+ * # Why edges are FOUR picks, not two
+ *
+ * @BIMvoice established on #2199 that `SnapTarget.metadata.vertices` yields
+ * TESSELLATION SEGMENTS, not topological edges: one straight 2.000 m slab edge
+ * on `IfcSlab #52` reported as four collinear pieces (0.2000 / 1.8000 / 1.6000
+ * / 0.2000), with no cursor position anywhere yielding 2.000. So two picks
+ * cannot identify two edges - two clicks on what the user sees as a single
+ * edge can land on different segments, and the direction you get back is the
+ * direction of a tessellation artefact.
+ *
+ * #2735 offers the way out explicitly: "state how it recovers a topological
+ * edge from tessellation, OR scope itself to explicitly-picked point pairs".
+ * This takes the second. Each edge is two picks the user places, so the
+ * direction measured is the one they chose rather than one tessellation
+ * happened to produce. #2655 (model edges reconstructed in the snap cache) is
+ * groundwork for a two-pick version later, not a reason to ship a wrong one
+ * now.
+ *
+ * # Why both answers fold to [0, 90]
+ *
+ * A line has no direction: picking A then B, or B then A, describes the same
+ * edge, and a reading that changed with click order would be a bug the user
+ * could reproduce at will. Likewise a plane has no side - the normal's sign is
+ * an artefact of winding, which is unreliable on double-sided IFC meshes.
+ *
+ * So both modes report the UNSIGNED angle between two undirected things, in
+ * [0, 90]. That is a complete answer to "what is the angle between these two
+ * lines/planes" and it is reproducible.
+ *
+ * What is deliberately NOT offered is the INTERIOR dihedral (the 120 degrees of
+ * an obtuse corner rather than the 60 between its planes). Recovering it needs
+ * the shared edge and a consistent inside, and two independent face picks
+ * supply neither: the same two normals describe a 60 degree roof ridge and a
+ * 120 degree wall junction. Reporting one of them would be picking an answer
+ * and hoping. Per #2735, "no format is offered for a measurement it does not
+ * describe".
+ */
+
+import { angleBetweenDeg, cross, norm, normalize, sub, type Point3 } from './angle-vec';
+
+/**
+ * Pick resolution: the snap layer's floor, `MIN_SNAP_TOLERANCE` in
+ * `packages/renderer/src/snap-weld.ts` (1/65536 m = 15.3 um). Mirrored rather
+ * than imported, exactly as `three-point-angle.ts` does, so this module stays
+ * free of renderer types; the sibling test pins the two together.
+ */
+const PICK_RESOLUTION_M = 1 / 65536;
+
+/**
+ * An edge shorter than one pick resolution has a direction made entirely of
+ * cursor noise. Tied to the snap floor rather than an arbitrary epsilon: a
+ * threshold below the floor classifies nothing, because no reachable input can
+ * land in the band.
+ */
+const DEGENERATE_LENGTH_M = PICK_RESOLUTION_M;
+
+/**
+ * Parallelism is judged by the SINE of the angle between the two directions,
+ * which is `|a x b|` for unit vectors, not by a degree threshold on the result.
+ *
+ * Near 0 and 180 degrees the cross product is the quantity that actually loses
+ * precision, so testing it directly is testing the thing that degrades. This
+ * is the same reasoning `three-point-angle.ts` gives for judging collinearity
+ * as a perpendicular distance rather than as an angle.
+ *
+ * 1e-6 is about 5.7e-5 degrees: far below anything a user can pick apart at the
+ * one decimal these readouts render, and far above the f32 noise in a
+ * normalised direction.
+ */
+const PARALLEL_SINE = 1e-6;
+
+/** What an edge-pair or face-pair measurement resolved to. */
+export type AnglePairOutcome =
+  | { kind: 'degenerate'; reason: 'first' | 'second' }
+  | { kind: 'parallel'; degrees: 0 }
+  | { kind: 'angled'; degrees: number };
+
+/**
+ * Angle between two lines, each given as an ordered pair of picked points.
+ *
+ * Returns `degenerate` naming WHICH pair was unusable rather than a single
+ * failure, because the two are different user errors: the first pair being
+ * degenerate means the first edge was never really placed, and telling them
+ * "the second one" would send them to the wrong click.
+ */
+export function edgePairAngle(
+  a1: Point3,
+  a2: Point3,
+  b1: Point3,
+  b2: Point3,
+): AnglePairOutcome {
+  const da = sub(a2, a1);
+  const db = sub(b2, b1);
+  if (norm(da) <= DEGENERATE_LENGTH_M) return { kind: 'degenerate', reason: 'first' };
+  if (norm(db) <= DEGENERATE_LENGTH_M) return { kind: 'degenerate', reason: 'second' };
+  return unsignedAngle(da, db);
+}
+
+/**
+ * Angle between two planes, each given by a normal.
+ *
+ * The normals need not be unit length or consistently oriented; see the module
+ * header on why the sign is discarded.
+ */
+export function facePairAngle(na: Point3, nb: Point3): AnglePairOutcome {
+  if (norm(na) <= 0 || !Number.isFinite(norm(na))) return { kind: 'degenerate', reason: 'first' };
+  if (norm(nb) <= 0 || !Number.isFinite(norm(nb))) return { kind: 'degenerate', reason: 'second' };
+  return unsignedAngle(na, nb);
+}
+
+/** Unsigned angle between two undirected directions, folded into [0, 90]. */
+function unsignedAngle(a: Point3, b: Point3): AnglePairOutcome {
+  const ua = normalize(a);
+  const ub = normalize(b);
+  if (!ua) return { kind: 'degenerate', reason: 'first' };
+  if (!ub) return { kind: 'degenerate', reason: 'second' };
+
+  // sin(theta) for unit vectors. Parallel and ANTI-parallel both give ~0 here,
+  // which is what "undirected" means: they describe the same line or plane.
+  if (norm(cross(ua, ub)) <= PARALLEL_SINE) return { kind: 'parallel', degrees: 0 };
+
+  const raw = angleBetweenDeg(ua, ub);
+  return { kind: 'angled', degrees: raw > 90 ? 180 - raw : raw };
+}
+
+/**
+ * Readout for an edge- or face-pair angle.
+ *
+ * `parallel` is spelled out rather than rendered as "0.0 deg", because those
+ * are different facts: 0.0 is a measured angle that rounded to zero, while
+ * parallel is a classification the maths made. `three-point-angle.ts` draws the
+ * same distinction for `zero` and `straight`.
+ */
+export function formatAnglePair(outcome: AnglePairOutcome): string {
+  switch (outcome.kind) {
+    case 'degenerate':
+      return outcome.reason === 'first' ? 'First pick too short' : 'Second pick too short';
+    case 'parallel':
+      return 'Parallel';
+    case 'angled':
+      return `${outcome.degrees.toFixed(1)}\u00B0`;
+  }
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/edge-face-angle.ts
@@ -46,6 +46,12 @@
  * 120 degree wall junction. Reporting one of them would be picking an answer
  * and hoping. Per #2735, "no format is offered for a measurement it does not
  * describe".
+ *
+ * The missing ingredient is specifically the SHARED EDGE, not the information
+ * in general: face picks already carry the hit point as well as the normal, so
+ * a later version that also captures which edge the two faces meet at has
+ * enough to resolve the interior. It is deliberately not collected yet, rather
+ * than unobtainable in principle.
  */
 
 import { angleBetweenDeg, cross, norm, normalize, sub, type Point3 } from './angle-vec';
@@ -83,7 +89,7 @@ const PARALLEL_SINE = 1e-6;
 
 /** What an edge-pair or face-pair measurement resolved to. */
 export type AnglePairOutcome =
-  | { kind: 'degenerate'; reason: 'first' | 'second' }
+  | { kind: 'degenerate'; reason: 'first' | 'second' | 'no-normal' }
   | { kind: 'parallel'; degrees: 0 }
   | { kind: 'angled'; degrees: number };
 
@@ -114,7 +120,15 @@ export function edgePairAngle(
  * The normals need not be unit length or consistently oriented; see the module
  * header on why the sign is discarded.
  */
-export function facePairAngle(na: Point3, nb: Point3): AnglePairOutcome {
+export function facePairAngle(
+  na: Point3 | undefined,
+  nb: Point3 | undefined,
+): AnglePairOutcome {
+  // A stored face pick with no normal is an upstream bug, not a user error.
+  // Substituting a zero vector here would classify it as `first`, which renders
+  // as "First pick too short" - a message describing something a face pick
+  // cannot even do, and one that makes a bug look like a measurement mistake.
+  if (!na || !nb) return { kind: 'degenerate', reason: 'no-normal' };
   if (norm(na) <= 0 || !Number.isFinite(norm(na))) return { kind: 'degenerate', reason: 'first' };
   if (norm(nb) <= 0 || !Number.isFinite(norm(nb))) return { kind: 'degenerate', reason: 'second' };
   return unsignedAngle(na, nb);
@@ -146,6 +160,7 @@ function unsignedAngle(a: Point3, b: Point3): AnglePairOutcome {
 export function formatAnglePair(outcome: AnglePairOutcome): string {
   switch (outcome.kind) {
     case 'degenerate':
+      if (outcome.reason === 'no-normal') return 'No surface at one pick';
       return outcome.reason === 'first' ? 'First pick too short' : 'Second pick too short';
     case 'parallel':
       return 'Parallel';

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -79,7 +79,13 @@ export type AngleKind = 'points' | 'edges' | 'faces';
 /** How many picks each kind needs before the measurement finishes itself. */
 export const ANGLE_REQUIRED_PICKS: Record<AngleKind, number> = {
   points: 3,
-  edges: 2,
+  // FOUR, not two. `SnapTarget.metadata.vertices` yields tessellation
+  // segments rather than topological edges - one straight 2.000 m slab edge
+  // reported as four collinear pieces on #2199 - so two picks cannot identify
+  // two edges. #2735 sanctions the alternative directly: "scope itself to
+  // explicitly-picked point pairs". Each edge is two picks the user places,
+  // so the direction measured is the one they chose.
+  edges: 4,
   faces: 2,
 };
 
@@ -87,6 +93,14 @@ export const ANGLE_REQUIRED_PICKS: Record<AngleKind, number> = {
 export interface AnglePick {
   kind: AngleKind;
   point: MeasurePoint;
+  /**
+   * Surface normal at the pick, for `'faces'` only.
+   *
+   * Carried on the pick rather than derived later because it is only knowable
+   * at pick time: it comes from the raycast hit, and the stored point alone
+   * cannot recover which face was under the cursor.
+   */
+  normal?: { x: number; y: number; z: number };
 }
 
 /** A fixed-length sequence in progress, not yet complete or cancelled. */

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -2,6 +2,84 @@
 /* eslint-disable */
 
 /**
+ * The overlap solid of one clashing pair, or the reason there is none.
+ */
+export class ClashIntersectionSolidJs {
+    private constructor();
+    free(): void;
+    [Symbol.dispose](): void;
+    /**
+     * `""` when `isSolid`, otherwise one of:
+     * - `"malformed-operand"` — any of FOUR malformations, all rejected
+     *   before the boolean runs, because computing on them would silently
+     *   drop the offending triangle (or worse) rather than report the true
+     *   operand:
+     *   1. `positionsA`/`positionsB` is not a flat `[x, y, z, …]` triple
+     *      (length not a multiple of 3);
+     *   2. `indicesA`/`indicesB` has a length that is not a multiple of 3,
+     *      so it does not describe whole triangles;
+     *   3. `indicesA`/`indicesB` references a vertex past the end of its own
+     *      operand's positions;
+     *   4. a position is **non-finite** (NaN or infinity). This one is worth
+     *      calling out to callers: a NaN coordinate is caught by neither
+     *      length check, and left alone it can be absorbed into a
+     *      normal-looking answer or corrupt a face enough to report a
+     *      genuinely overlapping pair as `"no-overlap"`. So if you are
+     *      debugging an unexpected `"no-overlap"`, check your inputs for
+     *      NaN — it surfaces here, not there.
+     * - `"empty-operand"` — an operand had no triangles.
+     * - `"no-overlap"` — the exact intersection is empty. Covers a disjoint
+     *   pair AND a *touching* pair, including any graze below the kernel's
+     *   `2^-16 m ≈ 15.26 µm` snap grid (both faces snap flush).
+     * - `"below-kernel-resolution"` — the pair overlaps, but too shallowly for
+     *   the kernel to resolve as a solid rather than a coplanar contact. See
+     *   `thicknessM` / `requiredM`.
+     * - `"budget-exhausted"` — the escalation budget tripped; the arrangement
+     *   is partial and nothing about it is trustworthy.
+     */
+    readonly degenerateReason: string;
+    /**
+     * Triangle indices into `positions / 3`.
+     */
+    readonly indices: Uint32Array;
+    /**
+     * True when a trustworthy overlap solid was produced. When false, every
+     * geometry getter is empty and `degenerateReason` says why.
+     */
+    readonly isSolid: boolean;
+    /**
+     * World-space vertex positions, flat `[x, y, z, …]`, f64.
+     *
+     * f64 rather than the f32 the rest of the mesh pipeline uses because the
+     * caller reports this solid's volume: the f32 round-trip costs ~1e-7
+     * relative, a thousand times the exactness the kernel actually delivers.
+     * Downcast to f32 at the GPU upload if the renderer wants it.
+     */
+    readonly positions: Float64Array;
+    /**
+     * For `"below-kernel-resolution"`: the depth this pair would have needed
+     * for the kernel to resolve a solid, in metres. `0` otherwise. Grows with
+     * distance from the world origin, as the kernel's own tolerance does.
+     */
+    readonly requiredM: number;
+    /**
+     * For `"below-kernel-resolution"`: the overlap's measured thinnest extent,
+     * in metres. `0` otherwise. Useful to tell the user how shallow the clash
+     * is even though no solid can be drawn.
+     */
+    readonly thicknessM: number;
+    /**
+     * Triangle count of the solid; `0` when degenerate.
+     */
+    readonly triangleCount: number;
+    /**
+     * Enclosed volume in m³. `0` when not a solid — check `isSolid` first;
+     * "no measurable overlap" and "an overlap of zero" are different claims.
+     */
+    readonly volumeM3: number;
+}
+
+/**
  * Packed result of one rule run. Parallel arrays, one entry per clash record;
  * `points` has 3 per record and `bounds` has 6 per record.
  */
@@ -13,6 +91,7 @@ export class ClashRunResult {
     readonly b: Uint32Array;
     readonly bounds: Float64Array;
     readonly distance: Float64Array;
+    readonly distanceKind: Uint8Array;
     readonly points: Float64Array;
     readonly status: Uint8Array;
 }
@@ -603,11 +682,13 @@ export class IfcAPI {
      * Enable or disable per-entity geometry fingerprinting in
      * `processGeometryBatch`, used by the viewer's revision-diff feature.
      *
-     * Pass a positive `tolerance` (metres) to enable — it is the quantization
-     * grid the hash snaps positions to (larger = more tolerant of float noise,
-     * smaller = catches finer edits; the `f32` precision floor of model-local
-     * coordinates means values below ~1 mm mostly hash noise). Pass `null`/
-     * `undefined` (or a non-positive value) to disable. Default: disabled.
+     * Pass a positive `tolerance` (metres) to enable — the quantization grid
+     * positions snap to (larger tolerates more float noise, smaller catches
+     * finer edits; below the `f32` precision floor of model-local coordinates,
+     * ~1 mm, mostly hashes noise). Finer than
+     * `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is clamped up to it
+     * — see that constant's doc for why (an `i128` overflow surface, not a
+     * precision win). `null`/`undefined`/non-positive disables. Default: off.
      */
     setComputeGeometryHashes(tolerance?: number | null): void;
     /**
@@ -1536,6 +1617,87 @@ export class SymbolicText {
 }
 
 /**
+ * One closed solid of a split element.
+ */
+export class ZonePieceJs {
+    private constructor();
+    free(): void;
+    [Symbol.dispose](): void;
+    /**
+     * Flat triangle indices into `positions`.
+     */
+    readonly indices: Uint32Array;
+    /**
+     * Flat `[x, y, z, ...]` in the caller's frame.
+     */
+    readonly positions: Float64Array;
+    /**
+     * Enclosed volume of this piece, cubic units of the caller's frame.
+     */
+    readonly volume: number;
+    /**
+     * Index into the zone array that was passed in, or `-1` for the part of
+     * the element inside no zone.
+     */
+    readonly zoneIndex: number;
+}
+
+/**
+ * The result of splitting one element.
+ */
+export class ZoneSplitJs {
+    private constructor();
+    free(): void;
+    [Symbol.dispose](): void;
+    /**
+     * Piece `index`, or `undefined` when out of range. Each call COPIES the
+     * piece out, matching the rest of this API surface.
+     */
+    piece(index: number): ZonePieceJs | undefined;
+    readonly pieceCount: number;
+    /**
+     * The part of the element inside NO zone could not be built.
+     *
+     * Separate from `sumErrorRel` because the two have opposite fixes: a
+     * raised sum means the zones overlap and want redrawing, while this means
+     * real volume is MISSING from the result. A caller must refuse the split
+     * outright rather than publish the zone pieces alone.
+     */
+    readonly remainderFailed: boolean;
+    /**
+     * How far the pieces are from summing to the whole, relative.
+     *
+     * The invariant #2508 puts above everything else here. Exposed rather than
+     * enforced: the caller decides what to do with a split that does not add
+     * up (the expected cause is zones that overlap each other), and a number
+     * it can show beats a silent refusal.
+     */
+    readonly sumErrorRel: number;
+    /**
+     * Enclosed volume of the input element.
+     */
+    readonly wholeVolume: number;
+}
+
+/**
+ * Compute the intersection solid of one clashing pair.
+ *
+ * `positionsA` / `positionsB` are flat world-space XYZ; `indicesA` /
+ * `indicesB` are flat triangle indices into their own operand.
+ *
+ * ```javascript
+ * const solid = clashIntersectionSolid(posA, idxA, posB, idxB);
+ * if (solid.isSolid) {
+ *   draw(solid.positions, solid.indices, solid.volumeM3);
+ * } else {
+ *   keepContactMarker(solid.degenerateReason); // e.g. "no-overlap"
+ * }
+ * solid.free();
+ * ```
+ */
+export function clashIntersectionSolid(positions_a: Float32Array, indices_a: Uint32Array, positions_b: Float32Array, indices_b: Uint32Array): ClashIntersectionSolidJs;
+
+/**
  * `a - b`, keeping EVERY disjoint remnant.
  *
  * This is the operation the existing `subtract_2d` could not stand in for: it
@@ -1592,6 +1754,50 @@ export function meshOutline2d(positions: Float32Array, indices: Uint32Array, axi
 export function resolve2d(a: Contours2D): Contours2D;
 
 /**
+ * Split a mesh into one closed solid per zone, plus the remainder.
+ *
+ * `positions` is flat XYZ (f64, caller's frame), `indices` flat triangle
+ * indices. `zones` is flat, SEVEN numbers per zone:
+ * `[cx, cy, cz, sx, sy, sz, rotationY]`, where the sizes are FULL extents
+ * (matching the viewer's `Zone.size`) and the rotation is radians about the
+ * vertical axis. A trailing partial zone is ignored rather than guessed at.
+ *
+ * A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is at
+ * least 3: it then takes that many `[x, z]` pairs from `footprints`, in order,
+ * and uses the 7-tuple only for its vertical extent (`cy +/- sy/2`). The
+ * footprint must be CONVEX; the viewer gates that on import, because a concave
+ * polygon fans into overlapping triangles and would cut wrong rather than
+ * fail. A count of 1 or 2 is not a polygon: it still consumes its pairs, so
+ * later zones stay aligned, and leaves that zone a box. Passing empty arrays
+ * keeps every zone a box.
+ *
+ * The caller must have established that the mesh is a closed orientable solid
+ * first, exactly as it must before quoting a volume at all (#1891/#1993): a
+ * clip of an open shell produces pieces whose volumes are arbitrary rather
+ * than approximate.
+ *
+ * A triangle with an out-of-range index or a non-finite coordinate is DROPPED
+ * rather than reported, matching `kernel::mesh_bridge::mesh_to_tris`, which is
+ * panic-free for the same reason: the alternative is a crash deep in the
+ * predicates. It does mean a malformed caller can open the surface and get
+ * meaningless volumes with a plausible `sumErrorRel`, so the closure proof
+ * above is the caller's responsibility and not a formality.
+ *
+ * ```javascript
+ * const split = splitMeshByZones(positions, indices, new Float64Array([
+ *   0, 0, 0, 10, 10, 10, 0,
+ * ]));
+ * for (let i = 0; i < split.pieceCount; i++) {
+ *   const piece = split.piece(i);
+ *   // piece.zoneIndex, piece.positions, piece.indices, piece.volume
+ *   piece.free();
+ * }
+ * split.free();
+ * ```
+ */
+export function splitMeshByZones(positions: Float64Array, indices: Uint32Array, zones: Float64Array, footprints?: Float64Array | null, footprint_counts?: Uint32Array | null): ZoneSplitJs;
+
+/**
  * `a ∪ b`.
  */
 export function union2d(a: Contours2D, b: Contours2D): Contours2D;
@@ -1615,6 +1821,7 @@ export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembl
 
 export interface InitOutput {
     readonly memory: WebAssembly.Memory;
+    readonly __wbg_clashintersectionsolidjs_free: (a: number, b: number) => void;
     readonly __wbg_clashrunresult_free: (a: number, b: number) => void;
     readonly __wbg_clashsession_free: (a: number, b: number) => void;
     readonly __wbg_contours2d_free: (a: number, b: number) => void;
@@ -1634,10 +1841,22 @@ export interface InitOutput {
     readonly __wbg_symbolicpolyline_free: (a: number, b: number) => void;
     readonly __wbg_symbolicrepresentationcollection_free: (a: number, b: number) => void;
     readonly __wbg_symbolictext_free: (a: number, b: number) => void;
+    readonly __wbg_zonepiecejs_free: (a: number, b: number) => void;
+    readonly __wbg_zonesplitjs_free: (a: number, b: number) => void;
+    readonly clashIntersectionSolid: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => number;
+    readonly clashintersectionsolidjs_degenerateReason: (a: number, b: number) => void;
+    readonly clashintersectionsolidjs_indices: (a: number, b: number) => void;
+    readonly clashintersectionsolidjs_isSolid: (a: number) => number;
+    readonly clashintersectionsolidjs_positions: (a: number, b: number) => void;
+    readonly clashintersectionsolidjs_requiredM: (a: number) => number;
+    readonly clashintersectionsolidjs_thicknessM: (a: number) => number;
+    readonly clashintersectionsolidjs_triangleCount: (a: number) => number;
+    readonly clashintersectionsolidjs_volumeM3: (a: number) => number;
     readonly clashrunresult_a: (a: number, b: number) => void;
     readonly clashrunresult_b: (a: number, b: number) => void;
     readonly clashrunresult_bounds: (a: number, b: number) => void;
     readonly clashrunresult_distance: (a: number, b: number) => void;
+    readonly clashrunresult_distanceKind: (a: number, b: number) => void;
     readonly clashrunresult_points: (a: number, b: number) => void;
     readonly clashrunresult_status: (a: number, b: number) => void;
     readonly clashsession_ingest: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number) => void;
@@ -1810,6 +2029,7 @@ export interface InitOutput {
     readonly spaceplatehandle_snapshot: (a: number, b: number) => void;
     readonly spaceplatehandle_splitEdge: (a: number, b: number, c: number, d: number, e: number) => void;
     readonly spaceplatehandle_splitFace: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
+    readonly splitMeshByZones: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => number;
     readonly symboliccircle_centerX: (a: number) => number;
     readonly symboliccircle_centerY: (a: number) => number;
     readonly symboliccircle_endAngle: (a: number) => number;
@@ -1860,6 +2080,12 @@ export interface InitOutput {
     readonly symbolictext_targetPx: (a: number) => number;
     readonly union2d: (a: number, b: number) => number;
     readonly version: (a: number) => void;
+    readonly zonepiecejs_indices: (a: number) => number;
+    readonly zonepiecejs_positions: (a: number) => number;
+    readonly zonepiecejs_zoneIndex: (a: number) => number;
+    readonly zonesplitjs_piece: (a: number, b: number) => number;
+    readonly zonesplitjs_pieceCount: (a: number) => number;
+    readonly zonesplitjs_remainderFailed: (a: number) => number;
     readonly init: () => void;
     readonly meshoutlinejs_contourCount: (a: number) => number;
     readonly symbolicpolyline_pointCount: (a: number) => number;
@@ -1876,6 +2102,9 @@ export interface InitOutput {
     readonly symbolictext_worldY: (a: number) => number;
     readonly symbolictext_x: (a: number) => number;
     readonly symbolictext_y: (a: number) => number;
+    readonly zonepiecejs_volume: (a: number) => number;
+    readonly zonesplitjs_sumErrorRel: (a: number) => number;
+    readonly zonesplitjs_wholeVolume: (a: number) => number;
     readonly __wbindgen_export: (a: number, b: number) => number;
     readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_export3: (a: number) => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -2,84 +2,6 @@
 /* eslint-disable */
 
 /**
- * The overlap solid of one clashing pair, or the reason there is none.
- */
-export class ClashIntersectionSolidJs {
-    private constructor();
-    free(): void;
-    [Symbol.dispose](): void;
-    /**
-     * `""` when `isSolid`, otherwise one of:
-     * - `"malformed-operand"` — any of FOUR malformations, all rejected
-     *   before the boolean runs, because computing on them would silently
-     *   drop the offending triangle (or worse) rather than report the true
-     *   operand:
-     *   1. `positionsA`/`positionsB` is not a flat `[x, y, z, …]` triple
-     *      (length not a multiple of 3);
-     *   2. `indicesA`/`indicesB` has a length that is not a multiple of 3,
-     *      so it does not describe whole triangles;
-     *   3. `indicesA`/`indicesB` references a vertex past the end of its own
-     *      operand's positions;
-     *   4. a position is **non-finite** (NaN or infinity). This one is worth
-     *      calling out to callers: a NaN coordinate is caught by neither
-     *      length check, and left alone it can be absorbed into a
-     *      normal-looking answer or corrupt a face enough to report a
-     *      genuinely overlapping pair as `"no-overlap"`. So if you are
-     *      debugging an unexpected `"no-overlap"`, check your inputs for
-     *      NaN — it surfaces here, not there.
-     * - `"empty-operand"` — an operand had no triangles.
-     * - `"no-overlap"` — the exact intersection is empty. Covers a disjoint
-     *   pair AND a *touching* pair, including any graze below the kernel's
-     *   `2^-16 m ≈ 15.26 µm` snap grid (both faces snap flush).
-     * - `"below-kernel-resolution"` — the pair overlaps, but too shallowly for
-     *   the kernel to resolve as a solid rather than a coplanar contact. See
-     *   `thicknessM` / `requiredM`.
-     * - `"budget-exhausted"` — the escalation budget tripped; the arrangement
-     *   is partial and nothing about it is trustworthy.
-     */
-    readonly degenerateReason: string;
-    /**
-     * Triangle indices into `positions / 3`.
-     */
-    readonly indices: Uint32Array;
-    /**
-     * True when a trustworthy overlap solid was produced. When false, every
-     * geometry getter is empty and `degenerateReason` says why.
-     */
-    readonly isSolid: boolean;
-    /**
-     * World-space vertex positions, flat `[x, y, z, …]`, f64.
-     *
-     * f64 rather than the f32 the rest of the mesh pipeline uses because the
-     * caller reports this solid's volume: the f32 round-trip costs ~1e-7
-     * relative, a thousand times the exactness the kernel actually delivers.
-     * Downcast to f32 at the GPU upload if the renderer wants it.
-     */
-    readonly positions: Float64Array;
-    /**
-     * For `"below-kernel-resolution"`: the depth this pair would have needed
-     * for the kernel to resolve a solid, in metres. `0` otherwise. Grows with
-     * distance from the world origin, as the kernel's own tolerance does.
-     */
-    readonly requiredM: number;
-    /**
-     * For `"below-kernel-resolution"`: the overlap's measured thinnest extent,
-     * in metres. `0` otherwise. Useful to tell the user how shallow the clash
-     * is even though no solid can be drawn.
-     */
-    readonly thicknessM: number;
-    /**
-     * Triangle count of the solid; `0` when degenerate.
-     */
-    readonly triangleCount: number;
-    /**
-     * Enclosed volume in m³. `0` when not a solid — check `isSolid` first;
-     * "no measurable overlap" and "an overlap of zero" are different claims.
-     */
-    readonly volumeM3: number;
-}
-
-/**
  * Packed result of one rule run. Parallel arrays, one entry per clash record;
  * `points` has 3 per record and `bounds` has 6 per record.
  */
@@ -91,7 +13,6 @@ export class ClashRunResult {
     readonly b: Uint32Array;
     readonly bounds: Float64Array;
     readonly distance: Float64Array;
-    readonly distanceKind: Uint8Array;
     readonly points: Float64Array;
     readonly status: Uint8Array;
 }
@@ -682,13 +603,11 @@ export class IfcAPI {
      * Enable or disable per-entity geometry fingerprinting in
      * `processGeometryBatch`, used by the viewer's revision-diff feature.
      *
-     * Pass a positive `tolerance` (metres) to enable — the quantization grid
-     * positions snap to (larger tolerates more float noise, smaller catches
-     * finer edits; below the `f32` precision floor of model-local coordinates,
-     * ~1 mm, mostly hashes noise). Finer than
-     * `ifc_lite_geometry::MIN_GEOM_HASH_TOLERANCE` (1e-6 m) is clamped up to it
-     * — see that constant's doc for why (an `i128` overflow surface, not a
-     * precision win). `null`/`undefined`/non-positive disables. Default: off.
+     * Pass a positive `tolerance` (metres) to enable — it is the quantization
+     * grid the hash snaps positions to (larger = more tolerant of float noise,
+     * smaller = catches finer edits; the `f32` precision floor of model-local
+     * coordinates means values below ~1 mm mostly hash noise). Pass `null`/
+     * `undefined` (or a non-positive value) to disable. Default: disabled.
      */
     setComputeGeometryHashes(tolerance?: number | null): void;
     /**
@@ -1617,87 +1536,6 @@ export class SymbolicText {
 }
 
 /**
- * One closed solid of a split element.
- */
-export class ZonePieceJs {
-    private constructor();
-    free(): void;
-    [Symbol.dispose](): void;
-    /**
-     * Flat triangle indices into `positions`.
-     */
-    readonly indices: Uint32Array;
-    /**
-     * Flat `[x, y, z, ...]` in the caller's frame.
-     */
-    readonly positions: Float64Array;
-    /**
-     * Enclosed volume of this piece, cubic units of the caller's frame.
-     */
-    readonly volume: number;
-    /**
-     * Index into the zone array that was passed in, or `-1` for the part of
-     * the element inside no zone.
-     */
-    readonly zoneIndex: number;
-}
-
-/**
- * The result of splitting one element.
- */
-export class ZoneSplitJs {
-    private constructor();
-    free(): void;
-    [Symbol.dispose](): void;
-    /**
-     * Piece `index`, or `undefined` when out of range. Each call COPIES the
-     * piece out, matching the rest of this API surface.
-     */
-    piece(index: number): ZonePieceJs | undefined;
-    readonly pieceCount: number;
-    /**
-     * The part of the element inside NO zone could not be built.
-     *
-     * Separate from `sumErrorRel` because the two have opposite fixes: a
-     * raised sum means the zones overlap and want redrawing, while this means
-     * real volume is MISSING from the result. A caller must refuse the split
-     * outright rather than publish the zone pieces alone.
-     */
-    readonly remainderFailed: boolean;
-    /**
-     * How far the pieces are from summing to the whole, relative.
-     *
-     * The invariant #2508 puts above everything else here. Exposed rather than
-     * enforced: the caller decides what to do with a split that does not add
-     * up (the expected cause is zones that overlap each other), and a number
-     * it can show beats a silent refusal.
-     */
-    readonly sumErrorRel: number;
-    /**
-     * Enclosed volume of the input element.
-     */
-    readonly wholeVolume: number;
-}
-
-/**
- * Compute the intersection solid of one clashing pair.
- *
- * `positionsA` / `positionsB` are flat world-space XYZ; `indicesA` /
- * `indicesB` are flat triangle indices into their own operand.
- *
- * ```javascript
- * const solid = clashIntersectionSolid(posA, idxA, posB, idxB);
- * if (solid.isSolid) {
- *   draw(solid.positions, solid.indices, solid.volumeM3);
- * } else {
- *   keepContactMarker(solid.degenerateReason); // e.g. "no-overlap"
- * }
- * solid.free();
- * ```
- */
-export function clashIntersectionSolid(positions_a: Float32Array, indices_a: Uint32Array, positions_b: Float32Array, indices_b: Uint32Array): ClashIntersectionSolidJs;
-
-/**
  * `a - b`, keeping EVERY disjoint remnant.
  *
  * This is the operation the existing `subtract_2d` could not stand in for: it
@@ -1754,50 +1592,6 @@ export function meshOutline2d(positions: Float32Array, indices: Uint32Array, axi
 export function resolve2d(a: Contours2D): Contours2D;
 
 /**
- * Split a mesh into one closed solid per zone, plus the remainder.
- *
- * `positions` is flat XYZ (f64, caller's frame), `indices` flat triangle
- * indices. `zones` is flat, SEVEN numbers per zone:
- * `[cx, cy, cz, sx, sy, sz, rotationY]`, where the sizes are FULL extents
- * (matching the viewer's `Zone.size`) and the rotation is radians about the
- * vertical axis. A trailing partial zone is ignored rather than guessed at.
- *
- * A zone becomes a PRISM (#2508 item 4) when `footprint_counts[i]` is at
- * least 3: it then takes that many `[x, z]` pairs from `footprints`, in order,
- * and uses the 7-tuple only for its vertical extent (`cy +/- sy/2`). The
- * footprint must be CONVEX; the viewer gates that on import, because a concave
- * polygon fans into overlapping triangles and would cut wrong rather than
- * fail. A count of 1 or 2 is not a polygon: it still consumes its pairs, so
- * later zones stay aligned, and leaves that zone a box. Passing empty arrays
- * keeps every zone a box.
- *
- * The caller must have established that the mesh is a closed orientable solid
- * first, exactly as it must before quoting a volume at all (#1891/#1993): a
- * clip of an open shell produces pieces whose volumes are arbitrary rather
- * than approximate.
- *
- * A triangle with an out-of-range index or a non-finite coordinate is DROPPED
- * rather than reported, matching `kernel::mesh_bridge::mesh_to_tris`, which is
- * panic-free for the same reason: the alternative is a crash deep in the
- * predicates. It does mean a malformed caller can open the surface and get
- * meaningless volumes with a plausible `sumErrorRel`, so the closure proof
- * above is the caller's responsibility and not a formality.
- *
- * ```javascript
- * const split = splitMeshByZones(positions, indices, new Float64Array([
- *   0, 0, 0, 10, 10, 10, 0,
- * ]));
- * for (let i = 0; i < split.pieceCount; i++) {
- *   const piece = split.piece(i);
- *   // piece.zoneIndex, piece.positions, piece.indices, piece.volume
- *   piece.free();
- * }
- * split.free();
- * ```
- */
-export function splitMeshByZones(positions: Float64Array, indices: Uint32Array, zones: Float64Array, footprints?: Float64Array | null, footprint_counts?: Uint32Array | null): ZoneSplitJs;
-
-/**
  * `a ∪ b`.
  */
 export function union2d(a: Contours2D, b: Contours2D): Contours2D;
@@ -1821,7 +1615,6 @@ export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembl
 
 export interface InitOutput {
     readonly memory: WebAssembly.Memory;
-    readonly __wbg_clashintersectionsolidjs_free: (a: number, b: number) => void;
     readonly __wbg_clashrunresult_free: (a: number, b: number) => void;
     readonly __wbg_clashsession_free: (a: number, b: number) => void;
     readonly __wbg_contours2d_free: (a: number, b: number) => void;
@@ -1841,22 +1634,10 @@ export interface InitOutput {
     readonly __wbg_symbolicpolyline_free: (a: number, b: number) => void;
     readonly __wbg_symbolicrepresentationcollection_free: (a: number, b: number) => void;
     readonly __wbg_symbolictext_free: (a: number, b: number) => void;
-    readonly __wbg_zonepiecejs_free: (a: number, b: number) => void;
-    readonly __wbg_zonesplitjs_free: (a: number, b: number) => void;
-    readonly clashIntersectionSolid: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => number;
-    readonly clashintersectionsolidjs_degenerateReason: (a: number, b: number) => void;
-    readonly clashintersectionsolidjs_indices: (a: number, b: number) => void;
-    readonly clashintersectionsolidjs_isSolid: (a: number) => number;
-    readonly clashintersectionsolidjs_positions: (a: number, b: number) => void;
-    readonly clashintersectionsolidjs_requiredM: (a: number) => number;
-    readonly clashintersectionsolidjs_thicknessM: (a: number) => number;
-    readonly clashintersectionsolidjs_triangleCount: (a: number) => number;
-    readonly clashintersectionsolidjs_volumeM3: (a: number) => number;
     readonly clashrunresult_a: (a: number, b: number) => void;
     readonly clashrunresult_b: (a: number, b: number) => void;
     readonly clashrunresult_bounds: (a: number, b: number) => void;
     readonly clashrunresult_distance: (a: number, b: number) => void;
-    readonly clashrunresult_distanceKind: (a: number, b: number) => void;
     readonly clashrunresult_points: (a: number, b: number) => void;
     readonly clashrunresult_status: (a: number, b: number) => void;
     readonly clashsession_ingest: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number, k: number) => void;
@@ -2029,7 +1810,6 @@ export interface InitOutput {
     readonly spaceplatehandle_snapshot: (a: number, b: number) => void;
     readonly spaceplatehandle_splitEdge: (a: number, b: number, c: number, d: number, e: number) => void;
     readonly spaceplatehandle_splitFace: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
-    readonly splitMeshByZones: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, j: number) => number;
     readonly symboliccircle_centerX: (a: number) => number;
     readonly symboliccircle_centerY: (a: number) => number;
     readonly symboliccircle_endAngle: (a: number) => number;
@@ -2080,12 +1860,6 @@ export interface InitOutput {
     readonly symbolictext_targetPx: (a: number) => number;
     readonly union2d: (a: number, b: number) => number;
     readonly version: (a: number) => void;
-    readonly zonepiecejs_indices: (a: number) => number;
-    readonly zonepiecejs_positions: (a: number) => number;
-    readonly zonepiecejs_zoneIndex: (a: number) => number;
-    readonly zonesplitjs_piece: (a: number, b: number) => number;
-    readonly zonesplitjs_pieceCount: (a: number) => number;
-    readonly zonesplitjs_remainderFailed: (a: number) => number;
     readonly init: () => void;
     readonly meshoutlinejs_contourCount: (a: number) => number;
     readonly symbolicpolyline_pointCount: (a: number) => number;
@@ -2102,9 +1876,6 @@ export interface InitOutput {
     readonly symbolictext_worldY: (a: number) => number;
     readonly symbolictext_x: (a: number) => number;
     readonly symbolictext_y: (a: number) => number;
-    readonly zonepiecejs_volume: (a: number) => number;
-    readonly zonesplitjs_sumErrorRel: (a: number) => number;
-    readonly zonesplitjs_wholeVolume: (a: number) => number;
     readonly __wbindgen_export: (a: number, b: number) => number;
     readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_export3: (a: number) => void;


### PR DESCRIPTION
Closes #2735 — the two slices left after three-point angles shipped in #2739.

## Edges take FOUR picks, and that is the whole design question

@BIMvoice established on #2199 that `SnapTarget.metadata.vertices` yields **tessellation segments, not topological edges**. One straight 2.000 m slab edge on `IfcSlab #52` reported as four collinear pieces (0.2000 / 1.8000 / 1.6000 / 0.2000), with no cursor position anywhere yielding 2.000.

So two picks cannot identify two edges: two clicks on what the user sees as one edge can land on different segments, and the direction you get back belongs to a tessellation artefact.

#2735 states the alternative explicitly — *"state how it recovers a topological edge from tessellation, **or** scope itself to explicitly-picked point pairs"*. This takes the second, so the direction measured is the one the user chose. #2655 is groundwork for a two-pick version later, not a reason to ship a wrong one now.

`ANGLE_REQUIRED_PICKS.edges` moves 2 → 4. That value was a placeholder; the store's completion logic was already kind-generic.

## Both answers fold to [0, 90]

A line has no direction and a plane has no side. Picking A then B describes the same edge as B then A, and a normal's sign is a winding artefact — unreliable on the double-sided meshes IFC geometry needs. **A reading that changed with click order would be a bug the user could reproduce at will.**

**The interior dihedral is deliberately not offered.** Recovering it needs the shared edge and a consistent inside, and two independent face picks supply neither: the same two normals describe a 60° roof ridge and a 120° wall junction. Per the issue, *"no format is offered for a measurement it does not describe."*

## Acceptance criteria from #2735

> Each new mode has a test that fails when its production maths is mutated, with the subtest count stable and a named test flipping.

| mutation | result |
|---|---|
| fold removed (`raw` instead of `180 - raw`) | 3 named tests red |
| parallel classification removed | 2 named tests red |
| degenerate floor → `1e-12` (below the snap floor) | 1 named test red |

**Subtest count is 11 in every run, including baseline.** Fixtures are deliberately never 45°, because 45 survives the fold unchanged and so cannot tell `180 - raw` from `raw`, from `90 - raw`, or from an argument swap.

> Degenerate inputs are asserted, not just avoided.

`degenerate` names **which** pick failed — "the first edge was never placed" and "the second was" send the user to different clicks. Parallel is its own outcome, spelled out rather than rendered as `0.0°`: those are different facts.

## The UI control, which is why this is two commits

`setAngleKind` existed in the store with **no caller anywhere in the UI**. Shipping the maths alone would have been a feature that exists and cannot be used — the same "present in the code, absent in effect" shape as a GC that never sweeps. Switching kind cancels any half-placed sequence, since those picks belong to the old kind and would otherwise finish the next measurement early with the wrong inputs.

## One existing test changed, and that is a finding

`does not register picks when the tool is not in angle mode` asserted that `angleKind: 'edges'` registered **nothing** — pinning "edges is unimplemented" while its own comment claimed to pin the store's kind backstop. It now tests the backstop it described, and a new test covers the four-pick accumulation.

## Verification

**5077/5100 viewer tests pass.** All 17 failures are `@ifc-lite/wasm does not provide an export named clashIntersectionSolid` — a stale locally-staged wasm pkg, in clash paths this diff does not touch. The count is identical before and after this change, and CI builds wasm properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added three angle measurement modes: three-point, edge-pair, and face-pair.
  - Added angle measurements for selected edges and faces, including surface geometry.
  - Added clearer controls, hints, and result formatting for each angle type.
  - Edge-pair measurements now support four picks and shared vertices.

- **Bug Fixes**
  - Improved selection validation and duplicate-click handling.
  - Improved detection and messaging for parallel, invalid, and incomplete measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->