### PR TITLE
test(viewer): cover collabSlice's role gate and teardown (#2802)

### DIFF
--- a/apps/viewer/src/store/slices/bcfSlice.delete-contracts.test.ts
+++ b/apps/viewer/src/store/slices/bcfSlice.delete-contracts.test.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `bcfSlice` is one of the 17 slices in #2802 with zero test references.
+ *
+ * The property pinned here is specifically "a delete clears the pointers that
+ * referenced what was deleted", and it is chosen because this codebase has
+ * ALREADY shipped that defect: #2765 found `lensSlice.deleteLens` leaving
+ * `activeLensId` pointing at a lens that no longer existed, and nothing failed.
+ * `bcfSlice` is the largest untested surface with the same shape — six delete
+ * paths and two active pointers — so a regression here would be silent in
+ * exactly the same way.
+ *
+ * The slice is CORRECT today. That is worth stating plainly: this is regression
+ * cover for behaviour that already works, not a bug fix. It earns its place
+ * because the failure mode is invisible — a dangling `activeTopicId` renders as
+ * an empty panel, not as an error — and because the identical defect has
+ * occurred here before.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createStore } from 'zustand/vanilla';
+import type { BCFProject, BCFTopic, BCFViewpoint } from '@ifc-lite/bcf';
+import { createBcfSlice, type BCFSlice } from './bcfSlice.js';
+
+const viewpoint = (guid: string): BCFViewpoint => ({ guid }) as BCFViewpoint;
+
+const topic = (guid: string, viewpoints: BCFViewpoint[] = []): BCFTopic =>
+  ({
+    guid,
+    title: `Topic ${guid}`,
+    creationDate: '2026-08-18T00:00:00Z',
+    creationAuthor: 'test@example.com',
+    comments: [],
+    viewpoints,
+  }) as BCFTopic;
+
+const project = (...topics: BCFTopic[]): BCFProject => ({
+  version: '2.1',
+  topics: new Map(topics.map((t) => [t.guid, t])),
+});
+
+const make = () => createStore<BCFSlice>(createBcfSlice);
+
+describe('bcfSlice: a delete clears the pointers into what it deleted', () => {
+  it('deleting the ACTIVE topic clears both the topic and viewpoint pointers', () => {
+    // Both, because the viewpoint pointer refers to a viewpoint that lived on
+    // the deleted topic: clearing only the topic leaves the second pointer
+    // dangling, which is the harder half to notice.
+    const s = make();
+    s.getState().setBcfProject(project(topic('T1', [viewpoint('V1')]), topic('T2')));
+    s.getState().setActiveTopic('T1');
+    s.getState().setActiveViewpoint('V1');
+
+    s.getState().deleteTopic('T1');
+
+    assert.equal(s.getState().activeTopicId, null);
+    assert.equal(s.getState().activeViewpointId, null, 'the viewpoint belonged to the deleted topic');
+    assert.equal(s.getState().bcfProject?.topics.has('T1'), false);
+    assert.equal(s.getState().bcfProject?.topics.has('T2'), true, 'the survivor stays');
+  });
+
+  it('deleting a DIFFERENT topic leaves the active pointers alone', () => {
+    // The bounding control. Clearing unconditionally would satisfy the
+    // assertion above while throwing the user out of the topic they are
+    // reading every time any other topic is deleted.
+    const s = make();
+    s.getState().setBcfProject(project(topic('T1', [viewpoint('V1')]), topic('T2')));
+    s.getState().setActiveTopic('T1');
+    s.getState().setActiveViewpoint('V1');
+
+    s.getState().deleteTopic('T2');
+
+    assert.equal(s.getState().activeTopicId, 'T1');
+    assert.equal(s.getState().activeViewpointId, 'V1');
+  });
+
+  it('deleting the ACTIVE viewpoint clears the viewpoint pointer only', () => {
+    const s = make();
+    s.getState().setBcfProject(project(topic('T1', [viewpoint('V1'), viewpoint('V2')])));
+    s.getState().setActiveTopic('T1');
+    s.getState().setActiveViewpoint('V1');
+
+    s.getState().deleteViewpoint('T1', 'V1');
+
+    assert.equal(s.getState().activeViewpointId, null);
+    assert.equal(s.getState().activeTopicId, 'T1', 'the topic is still open');
+    assert.deepEqual(
+      s.getState().bcfProject?.topics.get('T1')?.viewpoints.map((v) => v.guid),
+      ['V2'],
+    );
+  });
+
+  it('deleting a DIFFERENT viewpoint leaves the active one selected', () => {
+    const s = make();
+    s.getState().setBcfProject(project(topic('T1', [viewpoint('V1'), viewpoint('V2')])));
+    s.getState().setActiveViewpoint('V1');
+
+    s.getState().deleteViewpoint('T1', 'V2');
+
+    assert.equal(s.getState().activeViewpointId, 'V1');
+  });
+
+  it('loading a new project drops pointers into the old one', () => {
+    // Ids are GUIDs, so a collision is unlikely rather than impossible — and
+    // the failure would be a pointer into the PREVIOUS project resolving
+    // against the new one, which is worse than a dangling pointer.
+    const s = make();
+    s.getState().setBcfProject(project(topic('T1', [viewpoint('V1')])));
+    s.getState().setActiveTopic('T1');
+    s.getState().setActiveViewpoint('V1');
+
+    s.getState().setBcfProject(project(topic('T9')));
+
+    assert.equal(s.getState().activeTopicId, null);
+    assert.equal(s.getState().activeViewpointId, null);
+  });
+
+  it('clearing the project clears the pointers with it', () => {
+    const s = make();
+    s.getState().setBcfProject(project(topic('T1', [viewpoint('V1')])));
+    s.getState().setActiveTopic('T1');
+    s.getState().setActiveViewpoint('V1');
+
+    s.getState().clearBcfProject();
+
+    assert.equal(s.getState().bcfProject, null);
+    assert.equal(s.getState().activeTopicId, null);
+    assert.equal(s.getState().activeViewpointId, null);
+  });
+
+  it('a delete against a project that is not loaded is a no-op, not a crash', () => {
+    // Reachable through an undo/redo or a panel action racing a project close.
+    const s = make();
+    s.getState().deleteTopic('T1');
+    s.getState().deleteViewpoint('T1', 'V1');
+    assert.equal(s.getState().bcfProject, null);
+  });
+
+  it('a delete naming a topic that is not there leaves the project untouched', () => {
+    const s = make();
+    s.getState().setBcfProject(project(topic('T1')));
+    s.getState().setActiveTopic('T1');
+
+    s.getState().deleteViewpoint('T-missing', 'V1');
+
+    assert.equal(s.getState().activeTopicId, 'T1');
+    assert.equal(s.getState().bcfProject?.topics.size, 1);
+  });
+});

--- a/apps/viewer/src/store/slices/collabSlice.gates.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.gates.test.ts
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * First slice of github.com/LTplus-AG/ifc-lite/issues/2802: `collabSlice` is
+ * 1300 lines wired into the store and, until this file, **no test called
+ * `createCollabSlice` at all**. Replacing `get().activeModelId` with a garbage
+ * literal left 60/60 green and `tsc` clean.
+ *
+ * That matters more here than the line count suggests. This is the slice the
+ * #2790 outage lived in — a failed share reported success for weeks — and the
+ * two things covered here are the ones other code TRUSTS:
+ *
+ *   - `canCollabEdit` / `canCollabComment` are the authorisation answer
+ *     `mutationSlice` gates every write on. Wrong in the permissive direction
+ *     and a viewer-role user accumulates local edits that never reach the room;
+ *     wrong in the restrictive direction and single-user editing breaks
+ *     entirely.
+ *   - every `mirror*` is documented "no-ops without an active session". Nothing
+ *     tested that, and it is what makes them safe to call unconditionally from
+ *     the mutation path in single-user mode.
+ *
+ * The async half (`startCollab`'s session lifecycle, the recipient reconstruct)
+ * still has no coverage and is not attempted here: it needs a live
+ * `CollabSession`. This file deliberately takes the synchronous surface that
+ * needs no session, rather than claiming the whole slice.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCollabSlice, type CollabRole, type CollabSlice } from './collabSlice.js';
+import type { ViewerState } from '../index.js';
+
+/**
+ * Build the slice over a mock store. The slice reaches across to other slices
+ * (`models`, `ifcDataStore`, `setEditEnabled`), so those are stubbed to the
+ * minimum the synchronous paths touch.
+ */
+function buildSlice(overrides: Record<string, unknown> = {}) {
+  const calls: string[] = [];
+  let state: Record<string, unknown> = {
+    models: new Map(),
+    activeModelId: null,
+    ifcDataStore: null,
+    setEditEnabled: (on: boolean) => calls.push(`setEditEnabled(${on})`),
+    upsertModel: () => calls.push('upsertModel'),
+    updateModel: () => calls.push('updateModel'),
+    removeModel: () => calls.push('removeModel'),
+    setIfcDataStore: () => calls.push('setIfcDataStore'),
+    setGeometryResult: () => calls.push('setGeometryResult'),
+    ...overrides,
+  };
+  const setState = (partial: unknown) => {
+    const patch =
+      typeof partial === 'function'
+        ? (partial as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+        : (partial as Record<string, unknown>);
+    state = { ...state, ...patch };
+  };
+  const slice = createCollabSlice(
+    setState as never,
+    (() => state) as never,
+    {} as never,
+  ) as CollabSlice;
+  state = { ...slice, ...state };
+  return {
+    calls,
+    get: () => state as unknown as ViewerState & CollabSlice,
+    setRole: (collabRole: CollabRole | null) => {
+      state = { ...state, collabRole };
+    },
+  };
+}
+
+describe('collabSlice: the role gate every write is checked against', () => {
+  /** The whole matrix, in one place. A role missing here is a role nothing pins. */
+  const CASES: ReadonlyArray<readonly [CollabRole | null, boolean, boolean]> = [
+    // role, canEdit, canComment
+    [null, true, true], // single-user: no room, so no collab restriction applies
+    ['viewer', false, false],
+    ['commenter', false, true],
+    ['editor', true, true],
+    ['admin', true, true],
+  ];
+
+  for (const [role, canEdit, canComment] of CASES) {
+    it(`${role ?? 'no room'}: edit=${canEdit} comment=${canComment}`, () => {
+      const s = buildSlice();
+      s.setRole(role);
+      assert.equal(s.get().canCollabEdit(), canEdit);
+      assert.equal(s.get().canCollabComment(), canComment);
+    });
+  }
+
+  it('treats "no room" as allowed rather than as a missing permission', () => {
+    // The distinction the null case encodes: outside a shared room the local
+    // single-user editing rules apply, so a collab gate returning false here
+    // would silently disable editing for every user who never shares anything.
+    const s = buildSlice();
+    s.setRole(null);
+    assert.equal(s.get().canCollabEdit(), true, 'single-user editing must not be gated by collab');
+  });
+
+  it('does not let a commenter write the model', () => {
+    // The pair that is easiest to get wrong, asserted against each other: a
+    // commenter may write comments and must not write the model.
+    const s = buildSlice();
+    s.setRole('commenter');
+    assert.equal(s.get().canCollabComment(), true);
+    assert.equal(s.get().canCollabEdit(), false);
+  });
+});
+
+describe('collabSlice: mirrors are inert in a single-user store', () => {
+  // Every mirror is called unconditionally by the mutation path, so in
+  // single-user mode they must be silent and harmless. That is the contract
+  // `mutationSlice` relies on, and nothing tested it.
+  //
+  // WHAT THIS CANNOT DISTINGUISH, stated because the obvious reading is wrong:
+  // each mirror guards on `!session || !store || !docApi`, and `docApi` is a
+  // MODULE-scoped binding that only `startCollab` ever sets. Outside a session
+  // it is null, so it is the binding guard here — verified by mutation:
+  // forcing `session` truthy leaves these tests green, because `docApi` still
+  // stops the call.
+  //
+  // So this pins "the mirrors are inert outside a session", NOT "the session
+  // check specifically is what stops them". Isolating the three conditions
+  // needs a live `CollabSession` to bind `docApi`, which is the untested async
+  // surface #2802 leaves open. Naming the limit rather than letting the test
+  // title imply cover it does not have.
+  let s: ReturnType<typeof buildSlice>;
+
+  beforeEach(() => {
+    s = buildSlice();
+  });
+
+  it('property, attribute and annotation mirrors are silent no-ops', () => {
+    const st = s.get();
+    assert.equal(st.collabSession, null, 'precondition: no session');
+    // The assertion that carries weight is `calls` staying empty below: it
+    // proves nothing reached another slice, whichever guard did the stopping.
+    st.mirrorPropertyEdit(1, 'Pset_Test', 'P', 'v', 0 as never);
+    st.mirrorPropertyDelete(1, 'Pset_Test', 'P');
+    st.mirrorAttributeEdit(1, 'Name', 'x');
+    st.mirrorAnnotationUpsert({ id: 'a1' } as never);
+    st.mirrorAnnotationDelete('a1');
+    // Nothing reached the other slices, and nothing threw.
+    assert.deepEqual(s.calls, []);
+  });
+
+  it('geometry and placement mirrors are silent no-ops', () => {
+    const st = s.get();
+    st.mirrorEntityRemove('m1', 1);
+    st.mirrorPlacementEdit('m1', 1, [1, 0, 0]);
+    st.mirrorEntityGeometry('m1', 1, { expressId: 1 } as never);
+    assert.deepEqual(s.calls, []);
+  });
+
+  it('leaves the geometry notice channel empty when nothing happened', () => {
+    // The notice is a one-shot for the toast surface; a mirror no-op must not
+    // post one, or a single-user session would show collab errors.
+    assert.equal(s.get().collabGeometryNotice, null);
+    assert.equal(s.get().consumeCollabGeometryNotice(), null);
+  });
+});
+
+describe('collabSlice: the one-shot geometry notice', () => {
+  it('is delivered once and then cleared', () => {
+    // Written for #2795: the joiner posts here when a room hydrates with
+    // entities but no meshes, and the layout consumes it. Delivering twice
+    // would double-toast; never clearing would re-toast on every re-render.
+    const s = buildSlice({ collabGeometryNotice: 'geometry missing' });
+    assert.equal(s.get().consumeCollabGeometryNotice(), 'geometry missing');
+    assert.equal(s.get().collabGeometryNotice, null, 'consumed notices are cleared');
+    assert.equal(s.get().consumeCollabGeometryNotice(), null, 'a second read gets nothing');
+  });
+});
+
+describe('collabSlice: stopCollab returns the room state to rest', () => {
+  it('clears every room-scoped field, including the seed failure', () => {
+    // A field left behind here leaks into the NEXT room: a stale
+    // `collabSeedFailure` would make a healthy share report the previous
+    // room's failure, and a stale role would gate writes by an old permission.
+    const s = buildSlice({
+      collabRoomId: 'room-1',
+      collabRole: 'viewer' as CollabRole,
+      collabSelfToken: 'tok',
+      collabLastShareToken: 'share-tok',
+      collabSeedFailure: 'geometry upload failed',
+      collabGeometryNotice: 'stale notice',
+      collabPanelVisible: true,
+      collabPeersSinceBaseline: true,
+    });
+
+    s.get().stopCollab();
+
+    const after = s.get();
+    assert.equal(after.collabRoomId, null);
+    assert.equal(after.collabRole, null);
+    assert.equal(after.collabSelfToken, null);
+    assert.equal(after.collabLastShareToken, null);
+    assert.equal(after.collabSeedFailure, null, 'a seed failure must not survive into the next room');
+    assert.equal(after.collabGeometryNotice, null);
+    assert.equal(after.collabStatus, 'disconnected');
+    assert.deepEqual(after.collabPeers, []);
+    assert.equal(after.collabPeersSinceBaseline, false);
+  });
+
+  it('is safe to call when no session was ever started', () => {
+    // startCollab calls it first thing, so this is the ordinary path, not an
+    // edge case.
+    const s = buildSlice();
+    s.get().stopCollab();
+    assert.equal(s.get().collabRoomId, null);
+  });
+});


### PR DESCRIPTION
First slice of #2802 (the coverage-gap half of #2765). Refs #2802 — does not close it.

Until this PR, **no test called `createCollabSlice` at all**. 1300 lines wired into the store, and replacing `get().activeModelId` with a garbage literal left 60/60 green and `tsc` clean. This is also the slice the #2790 outage lived in, where a failed share reported success for weeks.

## What it covers, and why these parts first

Not "some tests for a big file" — the three things other code *trusts*:

| covered | why it matters |
|---|---|
| `canCollabEdit` / `canCollabComment` | the authorisation answer `mutationSlice` gates **every write** on |
| `stopCollab`'s teardown | a field left behind leaks into the **next room** |
| the one-shot geometry notice | delivered once and cleared, or the toast surface double-fires |

The role matrix is a single table, so a role missing from it is a role nothing pins. Two cases are asserted against each other because they fail in opposite directions:

- a **commenter** must be able to comment and must **not** be able to write the model;
- the **null** role (not in a room) must read as **allowed** — gating it would silently disable editing for every user who never shares anything, which is the restrictive-direction failure nobody would attribute to collab.

The `stopCollab` test names each field rather than snapshotting, including `collabSeedFailure`: a stale one would make a healthy share report the *previous* room's failure.

## Verification, and the one that got away

Five of six mutations are caught by a **named** test, subtest count stable at 17:

| mutation | test that reds |
| --- | --- |
| let a viewer write the model | `viewer: edit=false comment=false` |
| deny the single-user (no room) case | `treats "no room" as allowed rather than as a missing permission` |
| let a viewer comment | `viewer: edit=false comment=false` |
| `stopCollab` forgets `collabSeedFailure` | `clears every room-scoped field, including the seed failure` |
| notice returned without clearing | `is delivered once and then cleared` |
| **force `session` truthy in `mirrorPropertyEdit`** | **nothing — see below** |

The sixth is the finding, and it is on-theme for this issue. Each mirror guards on `!session || !store || !docApi`, and **`docApi` is a module-scoped binding only `startCollab` ever sets** — so outside a session it is the guard actually doing the stopping, and the session check cannot be isolated. My test title said "inert without a session"; what it verifies is "inert outside a session", which is weaker.

Retitled, and the limit documented in the file rather than left implied. Isolating those three conditions needs a live `CollabSession`, which is the async surface #2802 explicitly leaves open.

## Not covered

`startCollab`'s session lifecycle and the recipient reconstruct — they need a real `CollabSession`. This PR takes the synchronous surface only and says so, rather than claiming the slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for collaboration permissions based on user roles.
  * Verified mirror operations remain inactive without a collaboration session.
  * Added checks for one-time geometry notices.
  * Verified collaboration shutdown clears room-specific state.
  * Added regression coverage for safely deleting topics and viewpoints, including active selection cleanup.
  * Verified active selections are preserved when unrelated items are deleted and reset when projects are loaded or cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->