### PR TITLE
fix(export): reject a non-numeric REAL attribute instead of quoting it

### DIFF
--- a/.changeset/real-slot-non-numeric.md
+++ b/.changeset/real-slot-non-numeric.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/export': patch
+---
+
+A non-numeric value in a REAL-typed named attribute is no longer written as a
+quoted string. `#2725` fixed the numeric case; a non-numeric one still fell
+through and was quoted, producing the same ISO 10303-21 violation that fix
+exists to prevent. `StoreEditor.setAttribute` takes a string, so any UI text
+field bound to a georeferencing REAL could deliver one.
+
+The slot now keeps the value the file had AND the export reports the dropped
+edit through `stats.warnings`, so a discarded edit is visible rather than
+inferred from its absence.

--- a/packages/export/src/real-slot-non-numeric.test.ts
+++ b/packages/export/src/real-slot-non-numeric.test.ts
@@ -89,12 +89,41 @@ describe('a non-numeric REAL-typed attribute edit', () => {
     const { line, warnings } = await exportWithScale('2.5');
     expect(line).toMatch(/,2\.5[,)]/);
     expect(line).not.toContain("'2.5'");
-    expect(warnings).not.toContain('Scale');
+    // Empty, not merely free of 'Scale': a filtered assertion still passes if
+    // the export starts emitting some unrelated warning.
+    expect(warnings).toBe('');
   });
 
   it('still clears the slot for an empty value, and warns about nothing', async () => {
     const { line, warnings } = await exportWithScale('');
     expect(line).toContain('#41=IFCMAPCONVERSION($,#40,1000.,2000.,0.,$,$,$);');
-    expect(warnings).not.toContain('Scale');
+    expect(warnings).toBe('');
+  });
+
+  it('reports a rejected REAL edit on an OVERLAY-CREATED entity too', async () => {
+    // This path had no test, which is exactly why the rejection callback was
+    // wired into the helper and never passed at the call site: the slot was
+    // kept and nothing was said - the silent discard this change exists to
+    // prevent, surviving inside the change preventing it.
+    const store = await parseBase();
+    const view = new MutablePropertyView(null, 'test-model');
+    const created = view.createEntity('IfcMapConversion', [
+      null, null, null, null, null, null, null, null,
+    ]);
+    new StoreEditor(store, view).setAttribute(created.expressId, 'Scale', 'abc');
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      applyMutations: true,
+    });
+    const text = new TextDecoder().decode(result.content);
+    const line = text.split('\n').find((l) => l.startsWith(`#${created.expressId}=`)) ?? '';
+    const warnings = result.stats.warnings.join('\n');
+
+    expect(line, 'a non-numeric value was written into a REAL slot').not.toContain("'abc'");
+    expect(warnings, 'the rejection was silent on the overlay path').toContain(
+      `#${created.expressId}`,
+    );
+    expect(warnings).toContain('Scale');
   });
 });

--- a/packages/export/src/real-slot-non-numeric.test.ts
+++ b/packages/export/src/real-slot-non-numeric.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A non-numeric value in a REAL-typed named attribute (#2741).
+ *
+ * #2725 keyed REAL formatting off schema type, which fixed the common case: a
+ * numeric string now writes an unquoted REAL. A NON-numeric value still fell
+ * through and was QUOTED, producing the same ISO 10303-21 violation that fix
+ * exists to prevent.
+ *
+ * Every test here asserts BOTH halves: the bad output is absent AND the drop is
+ * reported. Asserting only the absence would pass just as well if the edit
+ * vanished without trace, which is the failure #2723/#2724/#2726 were written
+ * to pin - an exporter claiming a modification it did not carry.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+
+const MAP_ID = 41;
+
+const BASE_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'');
+FILE_NAME('t','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0OSuGGYUFyIf0LtE29OSuG',$,'My Project',$,$,$,$,$,$);
+#40=IFCPROJECTEDCRS('EPSG:1000',$,$,$,$,$,$);
+#41=IFCMAPCONVERSION($,#40,1000.,2000.,0.,$,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+function toArrayBuffer(u8: Uint8Array): ArrayBuffer {
+  return u8.buffer.slice(u8.byteOffset, u8.byteOffset + u8.byteLength) as ArrayBuffer;
+}
+
+async function parseBase(): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(toArrayBuffer(new TextEncoder().encode(BASE_IFC)));
+}
+
+async function exportWithScale(value: string) {
+  const store = await parseBase();
+  const view = new MutablePropertyView(null, 'test-model');
+  new StoreEditor(store, view).setAttribute(MAP_ID, 'Scale', value);
+  const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+  const text = new TextDecoder().decode(result.content);
+  const line = text.split('\n').find((l) => l.startsWith(`#${MAP_ID}=`)) ?? '';
+  return { line, warnings: result.stats.warnings.join('\n') };
+}
+
+describe('a non-numeric REAL-typed attribute edit', () => {
+  it('is not written as a quoted string, and says so', async () => {
+    const { line, warnings } = await exportWithScale('abc');
+    // The violation: a quoted string where the schema declares a REAL.
+    expect(line, 'a non-numeric value was written into a REAL slot').not.toContain("'abc'");
+    // The slot keeps what the file had.
+    expect(line).toContain('#41=IFCMAPCONVERSION($,#40,1000.,2000.,0.,$,$,$);');
+    // ...and the drop is visible, not inferred from absence.
+    expect(warnings).toContain('#41');
+    expect(warnings).toContain('Scale');
+    expect(warnings).toMatch(/not a number/);
+  });
+
+  it('rejects a stringified NaN, which Number() would otherwise accept as a value', async () => {
+    // `Number('NaN')` is NaN, not a parse failure, so a naive isNaN-free guard
+    // would emit the token `NaN` - lexically invalid STEP that re-parses as a
+    // different argument count and shifts every slot after it.
+    const { line, warnings } = await exportWithScale(String(Number.NaN));
+    expect(line).not.toContain("'NaN'");
+    expect(line).not.toMatch(/,NaN[,)]/);
+    expect(warnings).toContain('#41');
+  });
+
+  it('rejects Infinity for the same reason', async () => {
+    const { line, warnings } = await exportWithScale('Infinity');
+    expect(line).not.toContain("'Infinity'");
+    expect(line).not.toMatch(/,Infinity[,)]/);
+    expect(warnings).toContain('#41');
+  });
+
+  it('still writes a numeric value, and warns about nothing', async () => {
+    // The #2725 behaviour must be untouched: this is the case that works.
+    const { line, warnings } = await exportWithScale('2.5');
+    expect(line).toMatch(/,2\.5[,)]/);
+    expect(line).not.toContain("'2.5'");
+    expect(warnings).not.toContain('Scale');
+  });
+
+  it('still clears the slot for an empty value, and warns about nothing', async () => {
+    const { line, warnings } = await exportWithScale('');
+    expect(line).toContain('#41=IFCMAPCONVERSION($,#40,1000.,2000.,0.,$,$,$);');
+    expect(warnings).not.toContain('Scale');
+  });
+});

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -1465,6 +1465,15 @@ export class StepExporter {
             attributeOverrides,
             positionalOverrides,
             pass.sourceSchema,
+            // Overlay-created entities report a rejected REAL edit exactly as
+            // source-backed ones do. Without this the slot was kept and NOTHING
+            // was said - the silent discard this whole change exists to
+            // prevent, surviving in the one path that had no test.
+            (attr, value) =>
+              pass.warnings.push(
+                `entity #${entity.expressId}: attribute ${attr} not written - ` +
+                  `${JSON.stringify(value)} is not a number and the slot is REAL-typed`,
+              ),
           );
         }
         let line: string | null = `#${entity.expressId}=${upperType}(${argsText});`;

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -1135,6 +1135,11 @@ export class StepExporter {
           pass.modifiedAttributes.get(expressId),
           pass.sourceSchema,
           pass.overlayActive,
+          (attr, value) =>
+            pass.warnings.push(
+              `entity #${expressId}: attribute ${attr} not written - ` +
+                `${JSON.stringify(value)} is not a number and the slot is REAL-typed`,
+            ),
         );
         let nextEntityText = mutated.text;
 
@@ -1272,6 +1277,11 @@ export class StepExporter {
           pass.modifiedAttributes.get(entityId),
           pass.sourceSchema,
           pass.overlayActive,
+          (attr, value) =>
+            pass.warnings.push(
+              `entity #${entityId}: attribute ${attr} not written - ` +
+                `${JSON.stringify(value)} is not a number and the slot is REAL-typed`,
+            ),
         );
       }
       if (mutated === null) {
@@ -1808,6 +1818,7 @@ export class StepExporter {
     attributeMutations: Map<string, string> | undefined,
     sourceSchema: IfcSchemaVersion,
     overlayActive: boolean,
+    onRejected?: (attrName: string, value: string) => void,
   ): SourceLineMutations {
     let text = entityText;
     let workingType = recordType.toUpperCase();
@@ -1838,7 +1849,13 @@ export class StepExporter {
     let attributed = false;
     if (attributeMutations && attributeMutations.size > 0) {
       const beforeAttributes = text;
-      text = this.applyAttributeMutations(text, workingType, attributeMutations, sourceSchema);
+      text = this.applyAttributeMutations(
+        text,
+        workingType,
+        attributeMutations,
+        sourceSchema,
+        onRejected,
+      );
       attributed = text !== beforeAttributes;
     }
 
@@ -1863,6 +1880,7 @@ export class StepExporter {
     entityType: string,
     attributeMutations: Map<string, string>,
     schemaVersion: IfcSchemaVersion,
+    onRejected?: (attrName: string, value: string) => void,
   ): string {
     const openParen = entityText.indexOf('(');
     const closeParen = entityText.lastIndexOf(');');
@@ -1893,7 +1911,20 @@ export class StepExporter {
       // The source path shares every `$`-slot hole with the overlay-created
       // path, because a source record has plenty of `$` slots of its own. Both
       // go through the one helper below.
-      args[index] = this.serializeNamedAttribute(entityType, index, value, args[index], realSlots);
+      const serialized = this.serializeNamedAttribute(
+        entityType,
+        index,
+        value,
+        args[index],
+        realSlots,
+      );
+      if (serialized === null) {
+        // Slot untouched AND reported. Not counted as a change: claiming a
+        // modification we did not make is the failure this avoids.
+        onRejected?.(attrName, value);
+        continue;
+      }
+      args[index] = serialized;
       changed = true;
     }
 
@@ -1931,7 +1962,7 @@ export class StepExporter {
     value: string,
     currentToken: string,
     realSlots: ReadonlySet<number>,
-  ): string {
+  ): string | null {
     if (getEnumTypedSlots(entityType).has(index)) return serializeEnumToken(value);
     if (getStringTypedSlots(entityType).has(index)) return serializeStringSlot(value);
     if (realSlots.has(index)) {
@@ -1939,6 +1970,19 @@ export class StepExporter {
       if (trimmed === '') return '$';
       const numberValue = Number(trimmed);
       if (Number.isFinite(numberValue)) return toStepReal(numberValue);
+      // A non-numeric value in a REAL slot used to fall through and be QUOTED,
+      // producing the same ISO 10303-21 violation #2725 exists to prevent
+      // (#2741). `StoreEditor.setAttribute` takes a string, so any UI text
+      // field bound to a georeferencing REAL can deliver one; it does not need
+      // a corrupt file.
+      //
+      // `null` means "leave the slot as the file had it". Simply returning
+      // `currentToken` here would stop the invalid output but SILENTLY DISCARD
+      // the edit - the exporter would then claim a modification it did not
+      // carry, which is the exact misreport #2723/#2724/#2726 were written to
+      // pin. The caller turns this into a warning, so a dropped edit is visible
+      // rather than inferred from absence.
+      return null;
     }
     return serializeAttributeValue(value, currentToken);
   }
@@ -1970,6 +2014,7 @@ export class StepExporter {
     attributeOverrides: Map<string, string> | null,
     positionalOverrides: Map<number, IfcAttributeValue> | null,
     schemaVersion: IfcSchemaVersion,
+    onRejected?: (attrName: string, value: string) => void,
   ): string {
     const args = argsText.length > 0 ? splitTopLevelArgs(argsText) : [];
     const attrNames = getAttributeNamesAcrossSchemas(entityType);
@@ -2006,7 +2051,21 @@ export class StepExporter {
     // has taken args.length to at least that, so each one lands.
     const realSlots = getRealTypedSlots(entityType, schemaVersion);
     for (const [index, value] of named) {
-      args[index] = this.serializeNamedAttribute(entityType, index, value, args[index], realSlots);
+      const serialized = this.serializeNamedAttribute(
+        entityType,
+        index,
+        value,
+        args[index],
+        realSlots,
+      );
+      // Overlay-created entities take the same rejection: a non-numeric REAL is
+      // invalid STEP whoever authored the record. The slot keeps the `$` this
+      // path padded it with, rather than gaining a quoted string.
+      if (serialized === null) {
+        onRejected?.(attrNames[index] ?? `#${index}`, value);
+        continue;
+      }
+      args[index] = serialized;
     }
 
     if (positionalOverrides && positionalOverrides.size > 0) {


### PR DESCRIPTION
Closes #2741.

## The bug

`#2725` keyed named-attribute REAL formatting off schema type, which fixed the common case. A **non-numeric** value still fell through to `serializeAttributeValue`, which quotes it — producing exactly the ISO 10303-21 violation that fix exists to prevent.

Not a regression (it behaved this way before #2725 too), but reachable **without a corrupt file**: `StoreEditor.setAttribute` takes a string, so any UI text field bound to a georeferencing REAL can deliver one.

## Why `return currentToken` is the wrong fix

That was the tempting one-liner: leave the slot as the file had it. It stops the invalid output but **silently discards the edit**, so the exporter claims a modification it did not carry — the exact misreport #2723/#2724/#2726 were written to pin.

So the REAL branch returns `null` meaning *"leave the slot alone"*, and the caller turns that into a warning naming the entity, the attribute and the rejected value. The rejection also does not count as a change, for the same reason.

## Mutation-checked in both directions, and the second one is the point

| mutation | result |
|---|---|
| restore the fall-through (the bug) | 3 named tests red — the value is quoted again |
| keep the token but **drop the warning** | the same 3 red |

The issue asked for exactly this:

> Worth a test that a non-numeric REAL edit produces **both** an unchanged slot and a warning — absence of the bad output alone would pass even if the edit vanished without trace.

## `NaN` and `Infinity` are covered explicitly

`Number('NaN')` returns `NaN` rather than failing, so a guard without the finite check would emit the bare token `NaN`. That is not a corrupted attribute — it is **lexically invalid STEP that re-parses as a different argument count**, shifting every slot after it.

## Scope

Both call sites, including overlay-created entities: a non-numeric REAL is invalid STEP whoever authored the record.

**738 passed / 30 skipped across 56 files.** Typecheck, lint and `check-source-text-assertions` clean. (The two `no-unused-vars` warnings in `step-exporter.ts` are pre-existing — I verified the count is 2 on `origin/main`'s version and 2 on mine.)

## Not blocked by the export stack

The plan sequenced #2741 behind #2751 because both touch `step-exporter.ts`. I checked rather than assumed: `git diff origin/main...origin/refactor/export-property-set-phase` shows **zero** occurrences of `serializeNamedAttribute`, so #2751 does not touch this function and the two do not conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid non-numeric values from being exported in REAL-typed attributes.
  * Preserved the original attribute value when an invalid edit is rejected.
  * Added export warnings when values such as text, `NaN`, or `Infinity` are discarded.
  * Continued supporting numeric and empty values without warnings.

* **Tests**
  * Added coverage for source-backed and newly created entities, including valid and invalid REAL values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->