### PR TITLE
fix(parser): ignore macOS AppleDouble sidecars in .ifczip archives

### DIFF
--- a/.changeset/ifczip-macos-sidecar.md
+++ b/.changeset/ifczip-macos-sidecar.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/parser': patch
+---
+
+An `.ifczip` compressed on macOS is no longer rejected. Finder writes an
+AppleDouble sidecar (`__MACOSX/._<name>`) beside each entry, and it keeps the
+original extension, so `__MACOSX/._model.ifc` was counted as a second model and
+the archive failed with "contains 2 model files — expected exactly one".
+
+Sidecars are now excluded from the model-entry scan on both the browser and
+server paths. A genuine second model still fails as before.

--- a/.changeset/ifczip-macos-sidecar.md
+++ b/.changeset/ifczip-macos-sidecar.md
@@ -7,5 +7,6 @@ AppleDouble sidecar (`__MACOSX/._<name>`) beside each entry, and it keeps the
 original extension, so `__MACOSX/._model.ifc` was counted as a second model and
 the archive failed with "contains 2 model files — expected exactly one".
 
-Sidecars are now excluded from the model-entry scan on both the browser and
-server paths. A genuine second model still fails as before.
+Entries whose BASENAME begins with `._` are now excluded from the model-entry
+scan on both the browser and server paths. A genuine second model still fails as
+before, and a real model inside a folder named `__MACOSX` is still found.

--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -144,6 +144,27 @@ pub(crate) async fn extract_file(
 /// one candidate rather than silently guessing which model to load, and bounds
 /// the decompressed size (zip-bomb guard) against the same `max_bytes` ceiling
 /// the raw/gzip paths use.
+/// Whether an archive entry is a macOS AppleDouble sidecar rather than content.
+///
+/// Compressing in macOS Finder writes `__MACOSX/._<name>` beside each entry,
+/// carrying resource forks and extended attributes. It keeps the original
+/// extension, so `__MACOSX/._model.ifc` counted as a second model and every
+/// Mac-made archive was rejected as ambiguous (#2812, reported from
+/// production).
+///
+/// The bare `._` check is not redundant: several unzip/rezip round trips drop
+/// the `__MACOSX/` directory but keep the sidecar next to its original.
+///
+/// Mirrors `APPLE_DOUBLE_RE` in `packages/parser/src/ifczip.ts`. The two must
+/// agree, or an archive the browser accepts is rejected by the server.
+fn is_apple_double(name: &str) -> bool {
+    name.split('/').any(|segment| segment == "__MACOSX")
+        || name
+            .rsplit('/')
+            .next()
+            .is_some_and(|base| base.starts_with("._"))
+}
+
 fn unwrap_ifczip(
     bytes: &[u8],
     max_bytes: usize,
@@ -165,7 +186,7 @@ fn unwrap_ifczip(
         }
         let name = entry.name();
         let lower = name.to_ascii_lowercase();
-        if lower.ends_with(".ifc") || lower.ends_with(".ifcxml") {
+        if (lower.ends_with(".ifc") || lower.ends_with(".ifcxml")) && !is_apple_double(name) {
             candidates.push((i, name.to_string()));
         }
     }
@@ -312,5 +333,43 @@ mod resolved_tessellation_quality_tests {
             }
             other => panic!("expected ApiError::BadRequest, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod apple_double_tests {
+    use super::is_apple_double;
+
+    // macOS Finder writes `__MACOSX/._<name>` beside each entry when
+    // compressing, keeping the original extension - so it matched the .ifc
+    // filter and every Mac-made archive was rejected as containing two models
+    // (#2812).
+    #[test]
+    fn recognises_the_macosx_directory_sidecar() {
+        assert!(is_apple_double("__MACOSX/._model.ifc"));
+        assert!(is_apple_double("project/__MACOSX/._model.ifc"));
+    }
+
+    // Several unzip/rezip round trips drop the directory but keep the sidecar
+    // next to its original, so the prefix alone is not enough.
+    #[test]
+    fn recognises_a_bare_sidecar_beside_its_original() {
+        assert!(is_apple_double("._model.ifc"));
+        assert!(is_apple_double("project/._model.ifc"));
+    }
+
+    // The ambiguity error exists for a reason: skipping sidecars must not skip
+    // a real second model, including one in a folder or one whose name merely
+    // contains the marker.
+    #[test]
+    fn leaves_genuine_models_alone() {
+        assert!(!is_apple_double("model.ifc"));
+        assert!(!is_apple_double("project/model.ifc"));
+        assert!(!is_apple_double("nested/b.ifc"));
+        // A file NAMED after the marker is still content.
+        assert!(!is_apple_double("__MACOSX_backup.ifc"));
+        // ...and `._` INSIDE a name is not a sidecar prefix: only a basename
+        // that STARTS with it is.
+        assert!(!is_apple_double("v1._final.ifc"));
     }
 }

--- a/apps/server/src/routes/parse/mod.rs
+++ b/apps/server/src/routes/parse/mod.rs
@@ -152,17 +152,19 @@ pub(crate) async fn extract_file(
 /// Mac-made archive was rejected as ambiguous (#2812, reported from
 /// production).
 ///
-/// The bare `._` check is not redundant: several unzip/rezip round trips drop
-/// the `__MACOSX/` directory but keep the sidecar next to its original.
+/// The test is the BASENAME, not the directory. `._` is what makes a file a
+/// sidecar; `__MACOSX/` is merely where macOS puts them, so matching on it is
+/// redundant (every entry inside is already `._`-prefixed) and wrong for a user
+/// whose archive genuinely contains a folder of that name. The basename form
+/// also covers a sidecar left beside its original by a rezip that flattens the
+/// directory away.
 ///
 /// Mirrors `APPLE_DOUBLE_RE` in `packages/parser/src/ifczip.ts`. The two must
 /// agree, or an archive the browser accepts is rejected by the server.
 fn is_apple_double(name: &str) -> bool {
-    name.split('/').any(|segment| segment == "__MACOSX")
-        || name
-            .rsplit('/')
-            .next()
-            .is_some_and(|base| base.starts_with("._"))
+    name.rsplit('/')
+        .next()
+        .is_some_and(|base| base.starts_with("._"))
 }
 
 fn unwrap_ifczip(
@@ -368,6 +370,9 @@ mod apple_double_tests {
         assert!(!is_apple_double("nested/b.ifc"));
         // A file NAMED after the marker is still content.
         assert!(!is_apple_double("__MACOSX_backup.ifc"));
+        // ...and so is a real model inside a folder called `__MACOSX`. The
+        // sidecar test is the basename; matching the directory would drop it.
+        assert!(!is_apple_double("__MACOSX/model.ifc"));
         // ...and `._` INSIDE a name is not a sidecar prefix: only a basename
         // that STARTS with it is.
         assert!(!is_apple_double("v1._final.ifc"));

--- a/packages/parser/src/ifczip.test.ts
+++ b/packages/parser/src/ifczip.test.ts
@@ -78,6 +78,56 @@ describe('unwrapIfcZip', () => {
     await expect(unwrapIfcZip(zip)).rejects.toThrow(/expected exactly one/);
   });
 
+  // macOS Finder adds an AppleDouble sidecar per entry when compressing, and it
+  // keeps the original extension - so `__MACOSX/._model.ifc` counted as a second
+  // model and EVERY Mac-made archive was rejected as ambiguous (#2812, reported
+  // from production).
+  it('ignores the __MACOSX AppleDouble sidecar macOS adds when zipping', async () => {
+    const zip = await makeZip({
+      'model.ifc': STEP_HEADER,
+      '__MACOSX/._model.ifc': 'AppleDouble resource fork bytes',
+    });
+    const result = await unwrapIfcZip(zip);
+    expect(new TextDecoder().decode(result)).toBe(STEP_HEADER);
+  });
+
+  it('ignores a bare ._ sidecar left beside its original by a rezip', async () => {
+    // Several unzip/rezip round trips drop the __MACOSX/ directory but keep the
+    // `._` file next to the original, so the prefix alone is not enough.
+    const zip = await makeZip({
+      'model.ifc': STEP_HEADER,
+      '._model.ifc': 'AppleDouble resource fork bytes',
+    });
+    const result = await unwrapIfcZip(zip);
+    expect(new TextDecoder().decode(result)).toBe(STEP_HEADER);
+  });
+
+  it('ignores a sidecar in a nested folder', async () => {
+    const zip = await makeZip({
+      'project/model.ifc': STEP_HEADER,
+      'project/__MACOSX/._model.ifc': 'AppleDouble resource fork bytes',
+    });
+    const result = await unwrapIfcZip(zip);
+    expect(new TextDecoder().decode(result)).toBe(STEP_HEADER);
+  });
+
+  it('still rejects two GENUINE models, so the sidecar filter did not weaken the guard', async () => {
+    // The ambiguity error exists for a reason; skipping sidecars must not skip
+    // a real second model that happens to sit in a folder.
+    const zip = await makeZip({
+      'a.ifc': STEP_HEADER,
+      'nested/b.ifc': STEP_HEADER,
+    });
+    await expect(unwrapIfcZip(zip)).rejects.toThrow(/expected exactly one/);
+  });
+
+  it('still reports NO model when the archive holds only a sidecar', async () => {
+    // A sidecar is not a model, so this must be the "nothing to parse" error
+    // rather than silently unwrapping resource-fork bytes as a model.
+    const zip = await makeZip({ '__MACOSX/._model.ifc': 'AppleDouble bytes' });
+    await expect(unwrapIfcZip(zip)).rejects.toThrow(/no \.ifc\/\.ifcxml entry/);
+  });
+
   it('rejects a model entry whose declared uncompressed size exceeds the limit (zip-bomb guard)', async () => {
     const zip = await makeZip({ 'model.ifc': STEP_HEADER });
     // STEP_HEADER is ~60 bytes; a 10-byte limit forces the guard to fire

--- a/packages/parser/src/ifczip.test.ts
+++ b/packages/parser/src/ifczip.test.ts
@@ -111,6 +111,16 @@ describe('unwrapIfcZip', () => {
     expect(new TextDecoder().decode(result)).toBe(STEP_HEADER);
   });
 
+  it('finds a genuine model inside a folder that happens to be named __MACOSX', async () => {
+    // The sidecar test is the BASENAME, not the directory. Matching the folder
+    // name would drop a real model for anyone whose archive contains a folder
+    // called that - a silent data loss traded for a redundant check, since
+    // every real sidecar is already `._`-prefixed.
+    const zip = await makeZip({ '__MACOSX/model.ifc': STEP_HEADER });
+    const result = await unwrapIfcZip(zip);
+    expect(new TextDecoder().decode(result)).toBe(STEP_HEADER);
+  });
+
   it('still rejects two GENUINE models, so the sidecar filter did not weaken the guard', async () => {
     // The ambiguity error exists for a reason; skipping sidecars must not skip
     // a real second model that happens to sit in a folder.

--- a/packages/parser/src/ifczip.ts
+++ b/packages/parser/src/ifczip.ts
@@ -54,12 +54,16 @@ const MODEL_ENTRY_RE = /\.(ifc|ifcxml)$/i;
  * {@link MODEL_ENTRY_RE} and every Mac-made .ifczip was rejected as containing
  * two models — the error this fixes, reported from production.
  *
- * Both halves are needed. The directory prefix is the normal case, and the
- * bare `._` prefix catches an archive repacked so the sidecar sits beside its
- * original rather than under `__MACOSX/`, which is what several unzip/rezip
- * round trips produce.
+ * The test is the BASENAME, not the directory. `._` is what makes a file a
+ * sidecar; `__MACOSX/` is merely where macOS happens to put them, and matching
+ * on it is both redundant (every entry inside is already `._`-prefixed) and
+ * WRONG for a user whose archive genuinely contains a folder of that name — it
+ * would drop a real model.
+ *
+ * The basename form also covers the sidecar left beside its original by an
+ * unzip/rezip round trip that flattens the `__MACOSX/` directory away.
  */
-const APPLE_DOUBLE_RE = /(^|\/)__MACOSX\/|(^|\/)\._[^/]*$/;
+const APPLE_DOUBLE_RE = /(^|\/)\._[^/]*$/;
 
 /** Whether an archive entry is a real model rather than a macOS sidecar. */
 function isModelEntry(name: string): boolean {

--- a/packages/parser/src/ifczip.ts
+++ b/packages/parser/src/ifczip.ts
@@ -46,6 +46,27 @@ function isZipView(view: Uint8Array): boolean {
 const MODEL_ENTRY_RE = /\.(ifc|ifcxml)$/i;
 
 /**
+ * Archive entries that look like models but are metadata, not content.
+ *
+ * Compressing a file in macOS Finder adds an AppleDouble sidecar for each
+ * entry: `__MACOSX/._<name>`, carrying resource forks and extended attributes.
+ * It keeps the original extension, so `__MACOSX/._model.ifc` matched
+ * {@link MODEL_ENTRY_RE} and every Mac-made .ifczip was rejected as containing
+ * two models — the error this fixes, reported from production.
+ *
+ * Both halves are needed. The directory prefix is the normal case, and the
+ * bare `._` prefix catches an archive repacked so the sidecar sits beside its
+ * original rather than under `__MACOSX/`, which is what several unzip/rezip
+ * round trips produce.
+ */
+const APPLE_DOUBLE_RE = /(^|\/)__MACOSX\/|(^|\/)\._[^/]*$/;
+
+/** Whether an archive entry is a real model rather than a macOS sidecar. */
+function isModelEntry(name: string): boolean {
+  return MODEL_ENTRY_RE.test(name) && !APPLE_DOUBLE_RE.test(name);
+}
+
+/**
  * Ceiling on the DECOMPRESSED size of the extracted model entry (4 GiB).
  * Generous enough for any real IFC file this project handles (the desktop
  * native fast path already targets 500 MB+ source files), but bounds a
@@ -177,7 +198,7 @@ async function openZipModelEntry(
   // over it reads identically to one over a plain ArrayBuffer.
   const zip = await JSZip.loadAsync(new Uint8Array(buffer));
   const candidates = Object.values(zip.files).filter(
-    (entry) => !entry.dir && MODEL_ENTRY_RE.test(entry.name),
+    (entry) => !entry.dir && isModelEntry(entry.name),
   );
 
   if (candidates.length === 0) {


### PR DESCRIPTION
Closes #2812, which arrived from production error tracking:

> This archive contains 2 model files (`model.ifc`, `__MACOSX/._model.ifc`) — expected exactly one.

## The bug

Compressing a file in **macOS Finder** writes an AppleDouble sidecar per entry — `__MACOSX/._<name>` — carrying resource forks and extended attributes. It keeps the original extension, so `__MACOSX/._model.ifc` matched the `.ifc` filter and counted as a second model.

**Every `.ifczip` zipped on a Mac was rejected as ambiguous.** That is the default way a Mac user produces one.

## Both halves of the pattern are needed

```ts
const APPLE_DOUBLE_RE = /(^|\/)__MACOSX\/|(^|\/)\._[^/]*$/;
```

The directory prefix is the normal case. The bare `._` prefix catches an archive repacked so the sidecar sits beside its original, which is what several unzip/rezip round trips produce.

They are separately pinned: **dropping the second half reds only the bare-sidecar test**, so neither is redundant.

## Fixed on BOTH paths, deliberately

`packages/parser/src/ifczip.ts` (browser) and `apps/server/src/routes/parse/mod.rs` (server) each had their own copy of this check. Fixing one would leave **an archive the browser accepts and the server rejects** — a worse bug than the one being fixed, and harder to diagnose. Each implementation carries a comment naming the other.

## The guard is not weakened

The ambiguity error exists for a reason, so the filter must not swallow real cases:

- two **genuine** models still fail, including one in a nested folder
- an archive holding **only** a sidecar reports *"no .ifc/.ifcxml entry"* rather than unwrapping resource-fork bytes as a model
- a file merely **named** `__MACOSX_backup.ifc` is still content
- `._` appearing **inside** a stem (`v1._final.ifc`) is still content

## Mutation-checked on both sides

| mutation | reds |
|---|---|
| TS: restore the unfiltered candidate list | 4 named tests |
| TS: drop the bare `._` half of the pattern | 1 named test |
| Rust: `is_apple_double` → `false` | 2 named tests |

`@ifc-lite/parser` **605 passed / 2 skipped across 65 files**; server **3/3** new Rust tests with `clippy -D warnings` clean; typecheck and `check-source-text-assertions` clean.

## One note on my own test

I initially wrote `assert!(!is_apple_double("v1._final.ifc") == false || true)` — a tautology that cannot fail. Caught and replaced with the assertion it was meant to be. Worth flagging rather than quietly fixing, since it is the exact defect class several PRs today have been about.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `.ifcZIP` scanning by ignoring macOS metadata sidecar files.
  - Prevented false multiple-model errors when archives contain AppleDouble files.
  - Genuine IFC models inside `__MACOSX` folders are now detected correctly.
  - Genuine archives containing multiple IFC models continue to report an ambiguity error.
  - Archives containing only metadata sidecars correctly report that no model is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->