### PR TITLE
fix(clash): gate min-distance on triTriIntersect for intersecting pairs

### DIFF
--- a/.changeset/clash-min-distance-intersecting-gate.md
+++ b/.changeset/clash-min-distance-intersecting-gate.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/clash": patch
+---
+
+Fix `minDistanceBetweenMeshes`/`minDistanceBetweenBvhs` reporting a nonzero distance for a genuinely intersecting pair of triangles.
+
+`minDistanceBetweenBvhs` called `triTriDistance` unconditionally on every candidate leaf triangle pair, with no `triTriIntersect` gate. `triTriDistance`'s own contract says it is "only invoked for non-intersecting pairs" — intersecting triangles must be detected separately. For an axis-aligned box-overlap pair the missing gate happened not to matter (overlapping-box vertices/edges land exactly on the boundary features `triTriDistance` samples, so it returned 0 anyway), which is why the existing test suite did not catch it. A tilted, non-axis-aligned triangle pierced through another triangle's face interior has no such coincidence and returned a nonzero gap for two surfaces that actually overlap, contradicting `MeshDistance.distance`'s own documentation ("0 when they touch or overlap").
+
+The traversal now tests `triTriIntersect` before `triTriDistance` on each candidate leaf pair, the same order `engine-ts/narrow.ts` already uses for its per-pair test. Since 0 is the smallest distance this query can ever report, finding an intersecting pair now returns immediately rather than continuing to search the remaining frontier.

--- a/packages/clash/src/contact/min-distance.test.ts
+++ b/packages/clash/src/contact/min-distance.test.ts
@@ -122,13 +122,17 @@ describe('minDistanceBetweenMeshes', () => {
    *  triangle. Barycentric via the standard edge-function / area-ratio
    *  construction (Ericson, Real-Time Collision Detection §3.4). */
   function distanceOffTriangle(
-    p: [number, number, number],
-    a: [number, number, number],
-    b: [number, number, number],
-    c: [number, number, number],
+    p: readonly [number, number, number],
+    a: readonly [number, number, number],
+    b: readonly [number, number, number],
+    c: readonly [number, number, number],
   ): number {
-    const sub = (u: typeof a, v: typeof a): typeof a => [u[0] - v[0], u[1] - v[1], u[2] - v[2]];
-    const cross = (u: typeof a, v: typeof a): typeof a => [
+    const sub = (u: typeof a, v: typeof a): [number, number, number] => [
+      u[0] - v[0],
+      u[1] - v[1],
+      u[2] - v[2],
+    ];
+    const cross = (u: typeof a, v: typeof a): [number, number, number] => [
       u[1] * v[2] - u[2] * v[1],
       u[2] * v[0] - u[0] * v[2],
       u[0] * v[1] - u[1] * v[0],

--- a/packages/clash/src/contact/min-distance.test.ts
+++ b/packages/clash/src/contact/min-distance.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest';
 import { PairHeap, minDistanceBetweenMeshes } from './min-distance.js';
 import { triangleAt, triangleCount } from './triangle.js';
 import { triTriDistance } from '../math/triangle-distance.js';
+import { triTriIntersect } from '../math/triangle-intersect.js';
 import type { Mesh } from './types.js';
 
 /** Axis-aligned box as 12 triangles, at `origin` with `size` extents. */
@@ -36,13 +37,29 @@ function box(id: string, origin: [number, number, number], size: [number, number
   return { id, positions, indices };
 }
 
-/** Every triangle pair, no pruning. The oracle the traversal must match. */
+/**
+ * Every triangle pair, no pruning. The oracle the traversal must match.
+ *
+ * Gated on `triTriIntersect` first, same as the production code: this is
+ * exactly `triTriDistance`'s documented contract (its own file says the
+ * routine "is only invoked for non-intersecting pairs"), and skipping the
+ * gate here would make this "oracle" wrong in the same way production code
+ * was — agreeing with a bug is not the same as being correct.
+ */
 function bruteForceDistance(a: Mesh, b: Mesh): number {
   let best = Infinity;
   for (let i = 0; i < triangleCount(a); i++) {
     const ta = triangleAt(a, i);
     for (let j = 0; j < triangleCount(b); j++) {
       const tb = triangleAt(b, j);
+      if (
+        triTriIntersect(
+          [...ta.v0], [...ta.v1], [...ta.v2],
+          [...tb.v0], [...tb.v1], [...tb.v2],
+        )
+      ) {
+        return 0;
+      }
       const r = triTriDistance(
         [...ta.v0], [...ta.v1], [...ta.v2],
         [...tb.v0], [...tb.v1], [...tb.v2],
@@ -73,6 +90,31 @@ describe('minDistanceBetweenMeshes', () => {
     const a = box('a', [0, 0, 0], [2, 2, 2]);
     const b = box('b', [1, 1, 1], [2, 2, 2]);
     expect(minDistanceBetweenMeshes(a, b)?.distance).toBeCloseTo(0, 10);
+  });
+
+  it('returns 0 for a genuinely intersecting non-axis-aligned pair (not just AABB boxes)', () => {
+    // The box fixture above is insufficient to pin this: axis-aligned box
+    // overlaps happen to land their closest-approach features (vertices,
+    // edges) exactly on the boundary `triTriDistance` samples, so it returns
+    // 0 "by accident" even without an explicit intersection gate. A tilted
+    // triangle pierced through another triangle's face interior — no shared
+    // vertex, no edge-edge touch — has no such boundary coincidence: without
+    // gating on `triTriIntersect` first, `triTriDistance` (whose own contract
+    // says it is only valid for disjoint triangles) reports a nonzero gap
+    // for two surfaces that actually overlap.
+    const a: Mesh = {
+      id: 'a',
+      positions: new Float64Array([0, 0, 0, 10, 0, 2, 0, 10, 3]),
+      indices: new Uint32Array([0, 1, 2]),
+    };
+    const b: Mesh = {
+      id: 'b',
+      positions: new Float64Array([2, 2, -5, 3, 3, 5, 5, 1, 5]),
+      indices: new Uint32Array([0, 1, 2]),
+    };
+    expect(minDistanceBetweenMeshes(a, b)?.distance).toBe(0);
+    // Symmetry must hold in both directions.
+    expect(minDistanceBetweenMeshes(b, a)?.distance).toBe(0);
   });
 
   it('reports witness points that are actually that far apart', () => {

--- a/packages/clash/src/contact/min-distance.test.ts
+++ b/packages/clash/src/contact/min-distance.test.ts
@@ -117,6 +117,72 @@ describe('minDistanceBetweenMeshes', () => {
     expect(minDistanceBetweenMeshes(b, a)?.distance).toBe(0);
   });
 
+  /** How far `p` sits off the plane of triangle (a,b,c) AND outside its
+   *  boundary — 0 exactly when `p` lies on the (possibly degenerate)
+   *  triangle. Barycentric via the standard edge-function / area-ratio
+   *  construction (Ericson, Real-Time Collision Detection §3.4). */
+  function distanceOffTriangle(
+    p: [number, number, number],
+    a: [number, number, number],
+    b: [number, number, number],
+    c: [number, number, number],
+  ): number {
+    const sub = (u: typeof a, v: typeof a): typeof a => [u[0] - v[0], u[1] - v[1], u[2] - v[2]];
+    const cross = (u: typeof a, v: typeof a): typeof a => [
+      u[1] * v[2] - u[2] * v[1],
+      u[2] * v[0] - u[0] * v[2],
+      u[0] * v[1] - u[1] * v[0],
+    ];
+    const dot = (u: typeof a, v: typeof a): number => u[0] * v[0] + u[1] * v[1] + u[2] * v[2];
+    const len = (u: typeof a): number => Math.hypot(u[0], u[1], u[2]);
+
+    const ab = sub(b, a);
+    const ac = sub(c, a);
+    const n = cross(ab, ac);
+    const nLen = len(n) || 1;
+    const ap = sub(p, a);
+    const offPlane = Math.abs(dot(ap, n)) / nLen;
+
+    // Barycentric coordinates via signed sub-triangle areas over the total
+    // triangle normal (works for any orientation, not just axis-aligned).
+    const areaFull = len(n);
+    if (areaFull < 1e-12) return offPlane; // degenerate triangle: plane distance is all that's checkable
+    const u = dot(cross(sub(b, p), sub(c, p)), n) / (areaFull * areaFull);
+    const v = dot(cross(sub(c, p), sub(a, p)), n) / (areaFull * areaFull);
+    const w = 1 - u - v;
+    const outside = Math.max(0, -u, 0, -v, 0, -w);
+    return offPlane + outside * len(ab); // scale the barycentric slack into a length
+  }
+
+  it('the witness points of an intersecting pair actually lie on their reported triangles (PR #2815 review)', () => {
+    // Same fixture as the non-axis-aligned intersection test above: a tilted
+    // triangle pierced through another's face interior, no shared vertex or
+    // edge-edge touch, so there is no boundary coincidence to hide a wrong
+    // witness point. The pre-fix code returned the SAME six-vertex centroid
+    // for both pointA and pointB — a point that lies on neither triangle in
+    // general.
+    const a: Mesh = {
+      id: 'a',
+      positions: new Float64Array([0, 0, 0, 10, 0, 2, 0, 10, 3]),
+      indices: new Uint32Array([0, 1, 2]),
+    };
+    const b: Mesh = {
+      id: 'b',
+      positions: new Float64Array([2, 2, -5, 3, 3, 5, 5, 1, 5]),
+      indices: new Uint32Array([0, 1, 2]),
+    };
+    const r = minDistanceBetweenMeshes(a, b);
+    expect(r).not.toBeNull();
+    expect(r!.distance).toBe(0);
+
+    const triA = triangleAt(a, r!.triangleA);
+    const triB = triangleAt(b, r!.triangleB);
+    const offA = distanceOffTriangle(r!.pointA, [...triA.v0], [...triA.v1], [...triA.v2]);
+    const offB = distanceOffTriangle(r!.pointB, [...triB.v0], [...triB.v1], [...triB.v2]);
+    expect(offA, `pointA ${JSON.stringify(r!.pointA)} must lie on triangle A`).toBeLessThan(1e-9);
+    expect(offB, `pointB ${JSON.stringify(r!.pointB)} must lie on triangle B`).toBeLessThan(1e-9);
+  });
+
   it('reports witness points that are actually that far apart', () => {
     // A distance without witness points that agree with it is a number the
     // caller cannot draw. The measure tool needs the segment, not the scalar.

--- a/packages/clash/src/contact/min-distance.ts
+++ b/packages/clash/src/contact/min-distance.ts
@@ -28,6 +28,7 @@
 import { buildMeshBvh, type MeshBvh } from './mesh-bvh.js';
 import { triangleAt } from './triangle.js';
 import { triTriDistance } from '../math/triangle-distance.js';
+import { triTriIntersect } from '../math/triangle-intersect.js';
 import type { BvhNode } from './bvh.js';
 import type { AABB, Mesh, Vec3 } from './types.js';
 
@@ -204,12 +205,41 @@ export function minDistanceBetweenBvhs(
     if (leafA && leafB) {
       for (const ia of na.items ?? []) {
         const triA = triangleAt(a.mesh, Number(a.bvh.items[ia].id));
+        const va0 = mutable(triA.v0);
+        const va1 = mutable(triA.v1);
+        const va2 = mutable(triA.v2);
         for (const ib of nb.items ?? []) {
           const triB = triangleAt(b.mesh, Number(b.bvh.items[ib].id));
-          const r = triTriDistance(
-            mutable(triA.v0), mutable(triA.v1), mutable(triA.v2),
-            mutable(triB.v0), mutable(triB.v1), mutable(triB.v2),
-          );
+          const vb0 = mutable(triB.v0);
+          const vb1 = mutable(triB.v1);
+          const vb2 = mutable(triB.v2);
+
+          // triTriDistance's own contract (../math/triangle-distance.ts) is
+          // "only invoked for non-intersecting pairs" — intersecting ones
+          // must be gated separately with triTriIntersect, the same order
+          // engine-ts/narrow.ts already uses for its per-pair test. Skipping
+          // this gate is exactly the bug this fix closes: an intersecting
+          // pair fed to triTriDistance reports a nonzero gap for surfaces
+          // that actually overlap.
+          if (triTriIntersect(va0, va1, va2, vb0, vb1, vb2)) {
+            // 0 is the smallest distance this query can ever report, so once
+            // found nothing left in the frontier — pruned or not — can beat
+            // it. Return immediately rather than continuing to search.
+            const p: Vec3 = [
+              (triA.v0[0] + triA.v1[0] + triA.v2[0] + triB.v0[0] + triB.v1[0] + triB.v2[0]) / 6,
+              (triA.v0[1] + triA.v1[1] + triA.v2[1] + triB.v0[1] + triB.v1[1] + triB.v2[1]) / 6,
+              (triA.v0[2] + triA.v1[2] + triA.v2[2] + triB.v0[2] + triB.v1[2] + triB.v2[2]) / 6,
+            ];
+            return {
+              distance: 0,
+              pointA: p,
+              pointB: p,
+              triangleA: Number(a.bvh.items[ia].id),
+              triangleB: Number(b.bvh.items[ib].id),
+            };
+          }
+
+          const r = triTriDistance(va0, va1, va2, vb0, vb1, vb2);
           if (r.dist < best.distance) {
             best.distance = r.dist;
             best.pointA = r.pA;

--- a/packages/clash/src/contact/min-distance.ts
+++ b/packages/clash/src/contact/min-distance.ts
@@ -27,7 +27,7 @@
 
 import { buildMeshBvh, type MeshBvh } from './mesh-bvh.js';
 import { triangleAt } from './triangle.js';
-import { triTriDistance } from '../math/triangle-distance.js';
+import { closestPtPointTriangle, triTriDistance } from '../math/triangle-distance.js';
 import { triTriIntersect } from '../math/triangle-intersect.js';
 import type { BvhNode } from './bvh.js';
 import type { AABB, Mesh, Vec3 } from './types.js';
@@ -225,15 +225,37 @@ export function minDistanceBetweenBvhs(
             // 0 is the smallest distance this query can ever report, so once
             // found nothing left in the frontier — pruned or not — can beat
             // it. Return immediately rather than continuing to search.
-            const p: Vec3 = [
-              (triA.v0[0] + triA.v1[0] + triA.v2[0] + triB.v0[0] + triB.v1[0] + triB.v2[0]) / 6,
-              (triA.v0[1] + triA.v1[1] + triA.v2[1] + triB.v0[1] + triB.v1[1] + triB.v2[1]) / 6,
-              (triA.v0[2] + triA.v1[2] + triA.v2[2] + triB.v0[2] + triB.v1[2] + triB.v2[2]) / 6,
+            //
+            // Each `MeshDistance.pointA`/`pointB` is documented as "witness
+            // point on mesh A"/"on mesh B" — a point that actually lies ON
+            // that triangle. The 6-vertex centroid of BOTH triangles combined
+            // (the pre-fix value here) generally lies on neither: it is the
+            // mean of six points spread across two different planes, not a
+            // point constrained to either surface (PR #2815 review).
+            //
+            // Two rounds of closest-point projection give a pair of points
+            // that DO satisfy that contract exactly, by construction of
+            // `closestPtPointTriangle`: project the midpoint of both
+            // triangles' centroids onto A, then project THAT point onto B, so
+            // `pointB` answers "where does B actually sit relative to A's own
+            // witness" rather than an independent, uncorrelated projection.
+            // For a genuinely overlapping pair this converges into the
+            // overlap region in practice; it is not a claim of the exact
+            // deepest-penetration point (computing the true triangle-triangle
+            // intersection segment/polygon is a separate, larger fix), but it
+            // is always a real point on its own reported triangle, which is
+            // the property callers of this witness point can rely on.
+            const midCentroid: [number, number, number] = [
+              (va0[0] + va1[0] + va2[0] + vb0[0] + vb1[0] + vb2[0]) / 6,
+              (va0[1] + va1[1] + va2[1] + vb0[1] + vb1[1] + vb2[1]) / 6,
+              (va0[2] + va1[2] + va2[2] + vb0[2] + vb1[2] + vb2[2]) / 6,
             ];
+            const pA = closestPtPointTriangle(midCentroid, va0, va1, va2);
+            const pB = closestPtPointTriangle(pA, vb0, vb1, vb2);
             return {
               distance: 0,
-              pointA: p,
-              pointB: p,
+              pointA: pA,
+              pointB: pB,
               triangleA: Number(a.bvh.items[ia].id),
               triangleB: Number(b.bvh.items[ib].id),
             };


### PR DESCRIPTION
## Summary

`minDistanceBetweenBvhs` (`packages/clash/src/contact/min-distance.ts`), added today by #2805 (closing #2737), calls `triTriDistance` unconditionally on every candidate leaf triangle pair with no `triTriIntersect` gate. That violates `triTriDistance`'s own documented contract (`packages/clash/src/math/triangle-distance.ts:116-117`): "Intersecting triangles must be detected separately with `triTriIntersect`; this routine is only invoked for non-intersecting pairs." It also contradicts `MeshDistance.distance`'s own docstring: "0 when they touch or overlap."

The existing `'returns 0 for boxes that interpenetrate'` test in `min-distance.test.ts` did not catch this: it uses axis-aligned boxes, where overlapping-box vertices/edges happen to land exactly on the boundary features `triTriDistance` samples, so it returns 0 by accident. A tilted, non-axis-aligned triangle pierced through another triangle's face interior (no shared vertex, no edge-edge touch) has no such coincidence:

```
triTriIntersect(A,B) = true
minDistanceBetweenMeshes(A,B).distance = 1.4172159745671205   (before fix; should be 0)
```

### Fix

- Gate on `triTriIntersect` before `triTriDistance`, following the order `engine-ts/narrow.ts` already uses for its per-pair test.
- Once an intersecting pair is found, return immediately: 0 is the smallest distance this query can ever report, so nothing left in the frontier — pruned or not — can improve it. Verified this early return does not change the result on non-early-exit paths (only removes unnecessary further search).
- Symmetry (`minDistance(a,b) === minDistance(b,a)`) verified to still hold post-fix on the adversarial pair (both directions return `0`).
- **Cost**: this adds one `triTriIntersect` (SAT, up to 11 axis tests, each with early-exit on separation) call per candidate leaf triangle pair, on a traversal whose purpose is performance. Kept it simple and unconditional rather than inventing a distance-based threshold to skip the check — a hand-picked epsilon here would be a new correctness bug of exactly the kind that bit this package twice already. For the common disjoint-mesh case (this query's main purpose) every leaf pair now pays both the intersection test and the distance computation; for intersecting meshes the traversal now exits earlier than before (as soon as any intersecting leaf pair is found) rather than continuing to search.
- `bruteForceDistance`, the test file's oracle, had the identical contract violation (it also called `triTriDistance` unconditionally), so it could not have caught this bug even with a correct fixture. It now gates on `triTriIntersect` the same way, and returns `0` on an intersecting pair.

### Evidence

RED test added (`'returns 0 for a genuinely intersecting non-axis-aligned pair (not just AABB boxes)'` in `min-distance.test.ts`) using the adversarial triangle pair above, alongside — not replacing — the existing axis-aligned box test, with a comment on why the box fixture alone is insufficient.

Mutation table (one site at a time, failing test **names**):

| Mutation | Failing tests |
|---|---|
| Negate `triTriIntersect(...)` gate at `min-distance.ts:224` | `measures the gap between two separated boxes`, `returns 0 for a genuinely intersecting non-axis-aligned pair (not just AABB boxes)`, `reports witness points that are actually that far apart`, `agrees with brute force where the closest pair is NOT the first one reached`, `agrees with brute force on irregular meshes big enough to have a real tree`, `agrees with brute force across many offsets, including overlapping ones` |
| Replace the early `return` on an intersecting pair with recording into `best` + `continue` (no early exit, same final result) | none — confirms, as expected, that no test observes the early-exit optimization itself, only the final answer |
| Calibration: negate `triTriIntersect(...)` at `engine-ts/narrow.ts:97` | 11 of 16 `differential.test.ts` tests fail: `agrees on a hard clash`, `agrees on clearance (inside and outside the gap)`, `agrees on touch (suppressed and reported)`, `agrees on a self-clash`, `agrees across the full discipline matrix on a mixed model`, `agrees that skewed members sharing only a face are not a hard clash (#1362 Bug A)`, `agrees that members that interpenetrate are a hard clash (#1362 recall)`, `agrees on unequal-length aligned overlap (overlap-centre probe) (#1362)`, `agrees on transformed elements (f32-quantized world coords)`, `agrees on the mesh label for coincident-footprint BOX layers`, `agrees on the AABB-estimate fallback for a non-box contained pair (#1866)` |

Before: `packages/clash` → `npx vitest run` → 24 files passed / 1 skipped, 368 passed / 1 skipped.
After: 24 files passed / 1 skipped, **369** passed / 1 skipped.

## Note — not fixed here, maintainer's call

- The `engine-ts`/`engine-wasm` differential suite cannot catch bugs in shared code: `engine-wasm/index.ts:14` calls the same `runClash` from `engine-ts/orchestrator.ts`, so selection, severity, exclusions, dedup/sort and summary run identically for both backends. Demonstrated separately: constant-folding `inferClashSeverity` (`disciplines.ts:139`) to always return `'info'` left all 16 differential tests green.
- **Suspected, unconfirmed:** `GEO` is a fully declared discipline in `DISCIPLINES` with its own IFC-type selector, but appears in no `CLASH_RULE_PRESETS` pair, so `disciplineMatrixRules()` never generates a rule touching `IfcSite|IfcGeographicElement|IfcEarthworksElement`. `disciplines.test.ts` never references `GEO`. Declared-but-unreachable in the standard matrix; not confirmed as a functional bug, flagging for a maintainer's call.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `npx turbo run build --filter=@ifc-lite/clash^...` and `--filter=@ifc-lite/clash`
- [x] `npx vitest run` in `packages/clash`: 24 files passed / 1 skipped, 369 passed / 1 skipped
- [x] `npx tsc --noEmit` in `packages/clash`: clean
- [x] Reproduced the bug directly against the built `dist/` before the fix, and confirmed `distance === 0` (both directions) after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mesh minimum-distance queries now correctly report zero when surfaces intersect.
  * Improved handling of intersecting, including non-axis-aligned, triangles.
  * Returned contact points now lie on the intersecting surfaces.
  * Queries can finish immediately after detecting an intersection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->