### PR TITLE
test(clash): pin uuidFromSeed against frozen expected UUIDs

### DIFF
--- a/.changeset/pin-clash-deterministic-uuid.md
+++ b/.changeset/pin-clash-deterministic-uuid.md
@@ -1,0 +1,27 @@
+---
+'@ifc-lite/clash': patch
+---
+
+Add frozen-output vectors that pin `uuidFromSeed`'s hard-coded expected UUIDs.
+
+Every existing test touching `uuidFromSeed` (in `bcf-bridge.test.ts`) either
+compared two calls against each other within the same process, or checked
+shape/regex/version-nibble — none asserted a fixed expected value. That is
+the same shape as an encode/decode pair sharing a table: internally
+consistent, free to drift. Confirmed by mutation: replacing all four salt
+constants in `deterministic-uuid.ts` with different arbitrary values still
+produced valid-shaped, self-consistent UUIDs, and the existing suite stayed
+green.
+
+These are BCF topic guids: `bcf-bridge.ts` derives a topic's guid from
+`uuidFromSeed(group.id)` so that re-running the same coordination produces
+byte-identical topic guids and previously exported BCF topics keep
+correlating with the clash they describe. A silent change to the salts, the
+mixing/rotation order, or the version/variant nibble derivation would
+silently detach every previously exported BCF topic from its clash.
+
+No behavior change — this is test-only. The new vectors are frozen output
+captured from the current implementation, not values derived from any
+specification (there is no external reference for this algorithm); the test
+file documents this explicitly so a failing assertion is never "fixed" by
+regenerating the expected value from the new code.

--- a/packages/clash/src/deterministic-uuid.test.ts
+++ b/packages/clash/src/deterministic-uuid.test.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { uuidFromSeed } from './deterministic-uuid.js';
+
+/**
+ * `uuidFromSeed` backs BCF topic guids (see deterministic-uuid.ts docstring):
+ * a topic's guid must be byte-identical across re-runs so a previously
+ * exported BCF topic keeps correlating with the clash it describes. There is
+ * no external reference for these bits — this is our own FNV-1a + xorshift
+ * mix, and no other tool reproduces it — so "correct" here means "matches
+ * what we shipped", not "matches a spec".
+ *
+ * That makes hard-coded expected values the only test that can catch a
+ * silent behavior change: comparing two calls against each other within the
+ * same process (as the tests in bcf-bridge.test.ts do) only proves the
+ * function is internally self-consistent, which survives *any* change to the
+ * salts, the mixing order, or the version/variant nibble derivation as long
+ * as the new code is still self-consistent with itself. Confirmed by
+ * mutation: replacing all four salt constants in deterministic-uuid.ts with
+ * different arbitrary values still produces valid-shaped, internally
+ * self-consistent UUIDs, and the existing suite (368/369) does not notice.
+ *
+ * DO NOT "fix" a failing assertion below by regenerating the expected value
+ * from the new implementation. These strings are frozen-output vectors —
+ * literally today's implementation's output, captured once, not values
+ * derived from any specification or external tool. Regenerating them to make
+ * a red test green defeats the entire point of this file: it would silently
+ * re-anchor to whatever the algorithm now produces, exactly the drift this
+ * test exists to catch. If a change to deterministic-uuid.ts is intentional
+ * and meant to change guids going forward, that is a breaking change for
+ * every previously exported BCF file and must be called out as such (e.g. in
+ * a changeset), not quietly absorbed by updating this file.
+ */
+describe('uuidFromSeed frozen vectors', () => {
+  // Real call shape: bcf-bridge.ts uses `grp-${fnv1a(...)}` group ids
+  // (grouping.ts groupId) and an `overflow:<project>:<maxTopics>:<dropped>`
+  // seed for the overflow marker topic.
+  it('matches the frozen vector for a real group-id seed', () => {
+    expect(uuidFromSeed('grp-1a2b3c4d')).toBe('9cc9c6fe-06d6-495e-ae28-944eb3055511');
+  });
+
+  it('matches the frozen vector for the overflow-marker seed shape', () => {
+    expect(uuidFromSeed('overflow:Clash report:100:5')).toBe(
+      '77e351db-86c0-470e-a154-010f0d5d3529',
+    );
+  });
+
+  it('matches the frozen vector for the empty-string seed', () => {
+    expect(uuidFromSeed('')).toBe('48be8753-e6a6-4fa3-8be7-14cec25887f6');
+  });
+
+  // Two pairs differing in exactly one character, at opposite ends of the
+  // string. stableHash elsewhere in this repo is a confirmed 32-bit,
+  // prefix-coupled hash (a shared prefix can produce a related digest); these
+  // pairs make sure a prefix-coupling or truncation regression in this
+  // module's own hashing would flip one frozen vector without flipping its
+  // sibling, rather than both silently drifting together.
+  it('matches frozen vectors for seeds differing only in the last character', () => {
+    expect(uuidFromSeed('group-critical-a')).toBe('87b7dadf-f988-466a-ab03-2fddc8cbdc87');
+    expect(uuidFromSeed('group-critical-b')).toBe('648a28ea-f9c7-45d1-ad6c-64cbebde3b13');
+  });
+
+  it('matches frozen vectors for seeds differing only in the first character', () => {
+    expect(uuidFromSeed('agroup-critical')).toBe('c6e38cee-4f22-4b6f-b6c2-b6b9fa490991');
+    expect(uuidFromSeed('bgroup-critical')).toBe('bf15ccb9-f12c-4930-982f-b7e73935c99f');
+  });
+
+  // Non-ASCII seed: the fnv1a loop folds each UTF-16 code unit in two
+  // byte-sized steps, so an encoding-level regression (e.g. accidentally
+  // truncating to the low byte only) is a real drift source this vector can
+  // catch.
+  it('matches the frozen vector for a non-ASCII seed', () => {
+    expect(uuidFromSeed('grüppe-übergäng-42')).toBe('cf9157a5-1b67-43f4-bed2-a696546c3dce');
+  });
+});


### PR DESCRIPTION
## The gap

`packages/clash/src/deterministic-uuid.ts` has no dedicated test file. Every test touching `uuidFromSeed` lives in `bcf-bridge.test.ts` and does one of two things: compares two calls against each other **within the same process**, or checks shape/regex/version nibble. None asserts a hard-coded expected UUID.

Reproduced by mutation: replacing all four salt constants at `deterministic-uuid.ts:63-66` (`0x9e3779b1, 0x85ebca77, 0xc2b2ae3d, 0x27d4eb2f`) with different arbitrary values yields a completely different but still valid-shaped, internally self-consistent UUID for every seed — and the existing suite stays at 368/369 passing. Restored via `cp` + `diff` after confirming.

These are BCF topic guids. `bcf-bridge.ts` sets `topic.guid = uuidFromSeed(group.id)` so a re-run of the same coordination produces byte-identical topic guids. A silent change here silently detaches every previously exported BCF topic from the clash it describes.

## Why frozen vectors

There is no external reference for this algorithm — it's our own FNV-1a + xorshift mix, and no other tool reproduces it. So "correct" means "matches what we shipped", not "matches a spec". The added test file and this PR say explicitly: **these are frozen-output vectors captured from the current implementation, not values derived from any specification.** A failing assertion must never be "fixed" by regenerating the expected value from the new code — that would defeat the entire test.

## Chosen seeds

- `'grp-1a2b3c4d'` — the real call shape: `bcf-bridge.ts` calls `uuidFromSeed(group.id)`, and `grouping.ts`'s `groupId` produces `grp-<fnv1a hash>`.
- `'overflow:Clash report:100:5'` — the real seed shape for the overflow-marker topic guid.
- `''` — empty string.
- `'group-critical-a'` / `'group-critical-b'` — differ only in the **last** character.
- `'agroup-critical'` / `'bgroup-critical'` — differ only in the **first** character.
- `'grüppe-übergäng-42'` — non-ASCII seed (encoding-level regressions are a real drift source).

The last-character/first-character pairs exist because this repo has a confirmed 32-bit prefix-coupled hash hazard (`stableHash`) elsewhere; these vectors make sure a prefix-coupling or truncation regression in this module's own hashing would be caught.

## Evidence

Baseline (before, on `upstream/main` at `8332f80d2`): `24 files passed | 1 skipped (25)`, `368 passed | 1 skipped (369)`.

After adding the test file: `25 files passed | 1 skipped (26)`, `374 passed | 1 skipped (375)` (GREEN, with real constants).

RED under the salt mutation (all four salts changed by +1):
```
Tests  6 failed (6)
```
(all 6 of the new tests failed, restored via `cp` + `diff` immediately after).

### Mutation table

| Mutation | Failing tests |
|---|---|
| Salt constants (all four, +1 each) | all 6: real group-id seed, overflow-marker seed, empty-string seed, last-char-pair, first-char-pair, non-ASCII seed |
| Version nibble (`4` → `5` in `timeHiAndVersion`) | all 6 (same list) |
| Variant nibble (`0x8` → `0xc` in the OR mask) | all 6 (same list) |
| Cross-mix/rotation order (word pairing in `a`/`b`/`c`/`d`) | all 6 (same list) |

No gap found for these four mutation shapes — every vector caught every one. Not exhaustive: other possible regressions (e.g. a change to hex-padding width, or to the slice boundaries used to lay out `timeMid`/`clockSeqAndVariant`/`node`) were not separately tried, though any such change would very likely also flip these same frozen strings since they cover the full 128-bit output.

Test-only change; no runtime behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify deterministic UUID generation across standard, empty, overflow-marker, boundary-character, and non-ASCII inputs.
  * Added fixed expected-value checks to detect unintended changes in UUID formatting or generation behavior.

* **Documentation**
  * Documented the new test coverage in the package changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->