### PR TITLE
fix(clash): pure negation selectors and small coplanar contact classification

### DIFF
--- a/.changeset/clash-selectors-shared-faces-fixes.md
+++ b/.changeset/clash-selectors-shared-faces-fixes.md
@@ -1,0 +1,23 @@
+---
+'@ifc-lite/clash': patch
+---
+
+Fix two clash-detection bugs.
+
+`matchesSelector` mishandled a selector made of only negated alternatives
+(e.g. `!IfcWall|!IfcSlab`): the top-level `!` handling stripped only the
+first leading `!` and negated the recursive match on the remainder, so the
+second exclusion's type still matched. `matchesSelector('IfcSlab',
+'!IfcWall|!IfcSlab')` returned `true` instead of `false`. A pure negation
+list is now treated as an implicit AND of exclusions -- "match everything
+except A and except B" -- rather than the literal (and useless, tautological
+for any single input) OR-of-negations reading. Mixed positive/negative
+selectors (e.g. `IfcWall|!IfcSlab`) are unaffected.
+
+`clusterSharedFaces`'s `classify` step relabeled a small-area coplanar
+contact (area between `pointAreaM2` and `surfaceAreaM2`) as `kind: "line"`,
+but such a cluster comes from `buildSurfaceCluster`, which always sets
+`length_m: 0` -- contradicting the field's own documented invariant
+("line only -- 0 otherwise") and the viewer's contact overlay, which renders
+`"line"` clusters as a 2-point segment rather than the polygon boundary a
+surface cluster actually has. This band is now classified `"surface"`.

--- a/packages/clash/src/contact/contact.test.ts
+++ b/packages/clash/src/contact/contact.test.ts
@@ -41,6 +41,28 @@ describe('contactClusters (contact interface geometry)', () => {
     for (const c of surfaces) expect(c.boundary.length).toBeGreaterThanOrEqual(3);
   });
 
+  it('classifies a small coplanar overlap as surface, not line, and keeps length_m at 0', () => {
+    // A and B share full y,z extent but overlap only a 0.005 x-slice; the
+    // coincident y=0/y=1 side faces produce a coplanar patch of area
+    // 0.005 x 1 = 0.005 m^2 -- between the default pointAreaM2 (0.001) and
+    // surfaceAreaM2 (0.01) thresholds. This is a coplanar/surface contact
+    // (built by buildSurfaceCluster, which always sets length_m: 0), not a
+    // line contact, so it must be classified "surface" -- not relabeled
+    // "line" while keeping a zero length, which would contradict the
+    // documented invariant on `length_m` (line only -- 0 otherwise).
+    const a = box('A', [0, 0, 0], [1, 1, 1]);
+    const b = box('B', [1 - 0.005, 0, 0], [2 - 0.005, 1, 1]);
+    const clusters = contactClusters(a, b);
+    const smallBandClusters = clusters.filter(
+      (c) => c.area_m2 > 0 && c.area_m2 < 0.01 && c.area_m2 >= 0.001,
+    );
+    expect(smallBandClusters.length).toBeGreaterThan(0);
+    for (const c of smallBandClusters) {
+      expect(c.kind).toBe('surface');
+      expect(c.length_m).toBe(0);
+    }
+  });
+
   it('returns no contact for clearly separated boxes', () => {
     const a = box('A', [0, 0, 0], [1, 1, 1]);
     const b = box('B', [5, 5, 5], [6, 6, 6]);

--- a/packages/clash/src/contact/shared-faces.ts
+++ b/packages/clash/src/contact/shared-faces.ts
@@ -344,7 +344,16 @@ function classify(
 ): SharedFaceCluster {
   if (base.area_m2 >= surfaceAreaM2) return { ...base, kind: "surface" };
   if (base.length_m >= lineLengthM) return { ...base, kind: "line" };
-  if (base.area_m2 >= pointAreaM2) return { ...base, kind: "line" };
+  // A cluster below the surface-area threshold but still above the point
+  // floor is a small coplanar/surface contact (buildSurfaceCluster always
+  // sets length_m: 0 -- see the field docs above), not a line: it has no
+  // shared-line length to report, only a small real area and a polygon
+  // boundary. Labeling it "line" here would contradict the length_m
+  // invariant ("line only -- 0 otherwise") and mislead consumers such as
+  // the viewer's contact overlay, which renders "line" clusters as a single
+  // 2-point segment (`boundary[0]`/`boundary[1]`) rather than the polygon
+  // outline a surface cluster actually has.
+  if (base.area_m2 >= pointAreaM2) return { ...base, kind: "surface" };
   return { ...base, kind: "point" };
 }
 

--- a/packages/clash/src/selectors.test.ts
+++ b/packages/clash/src/selectors.test.ts
@@ -41,4 +41,23 @@ describe('matchesSelector', () => {
     expect(matchesSelector('IfcSlab', 'Ifc*|!IfcWall')).toBe(true);
     expect(matchesSelector('IfcWall', '!IfcWall|Ifc*')).toBe(false);
   });
+
+  it('treats a pure negation list as an AND of exclusions', () => {
+    // !A alone: everything except A.
+    expect(matchesSelector('IfcWall', '!IfcWall')).toBe(false);
+    expect(matchesSelector('IfcSlab', '!IfcWall')).toBe(true);
+
+    // !A|!B: everything except A and except B (not the tautologous
+    // literal OR-of-negations reading, which would be true for any
+    // single input since nothing is both A and B).
+    expect(matchesSelector('IfcWall', '!IfcWall|!IfcSlab')).toBe(false);
+    expect(matchesSelector('IfcSlab', '!IfcWall|!IfcSlab')).toBe(false);
+    expect(matchesSelector('IfcBeam', '!IfcWall|!IfcSlab')).toBe(true);
+
+    // Mixed positive + negative must be unaffected by the pure-negation
+    // handling: exclusions still win regardless of order.
+    expect(matchesSelector('IfcWall', 'IfcWall|!IfcSlab')).toBe(true);
+    expect(matchesSelector('IfcSlab', 'IfcWall|!IfcSlab')).toBe(false);
+    expect(matchesSelector('IfcBeam', 'IfcWall|!IfcSlab')).toBe(false);
+  });
 });

--- a/packages/clash/src/selectors.ts
+++ b/packages/clash/src/selectors.ts
@@ -18,13 +18,30 @@ export function matchesSelector(typeName: string, selector: string): boolean {
     return true;
   }
 
-  // Exclusion: !IfcWall means everything except IfcWall
-  if (trimmed.startsWith('!')) {
-    return !matchesSelector(typeName, trimmed.slice(1));
-  }
-
   const alternatives = trimmed.split('|');
   const upper = typeName.toUpperCase();
+
+  // Pure negation list (e.g. "!IfcWall" or "!IfcWall|!IfcSlab"): read
+  // literally as an OR of negations this would be a tautology for any
+  // single input (nothing is both A and B), so a list where every
+  // alternative is an exclusion is instead treated as an implicit AND of
+  // exclusions -- "match everything except A and except B". This also
+  // covers the single-exclusion case ("!IfcWall" means everything but
+  // IfcWall).
+  const nonEmptyAlternatives = alternatives.map((alt) => alt.trim()).filter((alt) => alt.length > 0);
+  const isPureNegationList =
+    nonEmptyAlternatives.length > 0 && nonEmptyAlternatives.every((alt) => alt.startsWith('!'));
+  if (isPureNegationList) {
+    for (const alt of nonEmptyAlternatives) {
+      const pattern = alt.slice(1).toUpperCase();
+      if (!pattern) continue;
+      if (upper === pattern || (pattern.endsWith('*') && upper.startsWith(pattern.slice(0, -1)))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   // Evaluate every alternative so exclusions win regardless of order:
   // any matching negated alternative rejects the type outright, otherwise
   // the type matches when at least one positive alternative matches.


### PR DESCRIPTION
## Summary

Two bugs in `@ifc-lite/clash`, each reproduced with a RED test before fixing.

### 1. `matchesSelector` — pure negation lists (`selectors.ts`)

The top-level `!` handling stripped only the **first** leading `!` and negated the recursive match on the remainder. For a selector made of two negated alternatives with no positive term, the second exclusion's type still matched:

```
matchesSelector('IfcSlab', '!IfcWall|!IfcSlab')  →  true   (wrong)
```

**Semantics chosen:** a selector where every alternative is negated is an implicit AND of exclusions — "match everything except A and except B" — not the literal OR-of-negations reading, which is a tautology for any single input (nothing is both A and B, so "`!A` or `!B`" is true for anything). This generalizes the existing single-negation case (`!IfcWall` = everything but `IfcWall`) to multiple terms, and leaves the existing mixed-alternative semantics (exclusions win regardless of order, e.g. `Ifc*|!IfcWall`) untouched — those are handled by unchanged code and covered by pre-existing tests.

Truth table (all now passing):

| type | selector | result |
|---|---|---|
| IfcWall | `!IfcWall` | false |
| IfcSlab | `!IfcWall` | true |
| IfcWall | `!IfcWall\|!IfcSlab` | false |
| IfcSlab | `!IfcWall\|!IfcSlab` | false |
| IfcBeam | `!IfcWall\|!IfcSlab` | true |
| IfcWall | `IfcWall\|!IfcSlab` (mixed) | true |
| IfcSlab | `IfcWall\|!IfcSlab` (mixed) | false |
| IfcBeam | `IfcWall\|!IfcSlab` (mixed) | false |

### 2. `clusterSharedFaces` — small coplanar contact misclassified as `"line"` (`contact/shared-faces.ts:339-349`)

```ts
if (base.area_m2 >= surfaceAreaM2) return { ...base, kind: "surface" };
if (base.length_m >= lineLengthM)  return { ...base, kind: "line" };
if (base.area_m2 >= pointAreaM2)   return { ...base, kind: "line" };   // bug
return { ...base, kind: "point" };
```

The last-but-one branch relabeled a small-area (between `pointAreaM2` and `surfaceAreaM2`) coplanar cluster as `"line"`, but such a cluster is always built by `buildSurfaceCluster`, which sets `length_m: 0` unconditionally — contradicting the field's own doc: *"`length_m`: Shared-line length in m (line only — 0 otherwise)."*

**Semantics chosen: (a) — that band is `"surface"`.** Checked the real consumer, `apps/viewer/src/hooks/useClash.ts`'s `contactLineList`: it filters `kind === 'surface'` and draws the full `boundary` polygon outline, but filters `kind === 'line'` and draws only `boundary[0]`–`boundary[1]` as a single segment, assuming a 2-point boundary. A misclassified surface cluster has a polygon boundary (from `convexHull2`), so routing it through the `'line'` branch would render a bogus partial edge instead of the actual small patch outline — option (c) (docstring is wrong) is untenable given this consumer, and there's no other reading under which relabeling helps. Fixed by returning `kind: "surface"` for that band instead; the docstring for `length_m` required no change since it's already accurate for surface-kind clusters (always 0).

No existing test exercised this area band with a `kind` assertion, so nothing else needed updating.

## Test plan

- [x] RED: added `treats a pure negation list as an AND of exclusions` to `selectors.test.ts` — 1 failing (`expected true to be false`) against pre-fix code.
- [x] RED: added `classifies a small coplanar overlap as surface, not line, and keeps length_m at 0` to `contact.test.ts` (two boxes overlapping in a 0.005 m² coplanar patch) — failing (`expected 'line' to be 'surface'`) against pre-fix code.
- [x] GREEN: both tests pass after the fixes; full `packages/clash` suite: 368 passed/1 skipped → **370 passed/1 skipped**.
- [x] Mutation testing on each fix line — reverting either produces the exact predicted RED failure (selector: `treats a pure negation list...`; classify: `classifies a small coplanar overlap...`).
- [x] `npx turbo run build --filter=@ifc-lite/clash` passes (tsc clean).
- [x] Changeset added (`@ifc-lite/clash` patch).
- [x] Did not touch `packages/clash/src/adapters/` (in-flight work by another agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved selector matching for lists containing only exclusions, including multiple and wildcard exclusions.
  - Corrected clash detection for small coplanar contacts so they are classified as surface contacts rather than line contacts.
  - Preserved accurate contact measurements, including zero length for surface contacts.

- **Tests**
  - Added coverage for exclusion selector combinations and small-area coplanar contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->