### PR TITLE
test(clash): pin eight untested geometry-kernel comparison boundaries

### DIFF
--- a/.changeset/pin-clash-geometry-boundaries.md
+++ b/.changeset/pin-clash-geometry-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/clash": patch
+---
+
+Pin eight untested comparison-operator boundaries in the clash geometry kernel with exact-boundary fixtures found by mutation testing (flipping the operator killed zero tests): `contact/aabb.ts`'s `intersects()`, `contains()`, and `longestAxis()`; `contact/bvh.ts`'s and `contact/mesh-bvh.ts`'s inflated-bounds overlap checks; and `engine-ts/obb.ts`'s zero-thickness reject, noise-band skip, and through-penetration far-side check. No production logic changed — this is coverage-only.

--- a/packages/clash/src/contact/aabb.test.ts
+++ b/packages/clash/src/contact/aabb.test.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Boundary-pinning tests for `contact/aabb.ts`. Mutation testing (flipping
+ * each comparison operator below) found these three closed-interval
+ * boundaries had zero test coverage: a fixture merely NEAR a boundary passes
+ * under both the `<=`/`<` (or `>=`/`>`) forms, so it doesn't distinguish
+ * them. Each test here sits exactly ON its boundary.
+ */
+
+import { describe, expect, it } from "vitest";
+import { contains, intersects, longestAxis } from "./aabb.js";
+import type { AABB } from "./types.js";
+
+describe("intersects() — closed-interval face touch (aabb.ts:16)", () => {
+  it("reports overlap when two boxes touch exactly face-to-face on one axis", () => {
+    // a.min[0] === b.max[0] exactly: the boxes share the x=1 plane and are
+    // clearly overlapping on y/z. `<=` (closed interval) says they touch;
+    // a mutated `<` would call this a miss.
+    const a: AABB = { min: [1, 0, 0], max: [2, 1, 1] };
+    const b: AABB = { min: [0, 0, 0], max: [1, 1, 1] };
+    expect(intersects(a, b)).toBe(true);
+  });
+});
+
+describe("contains() — closed-interval point-on-boundary (aabb.ts:46)", () => {
+  it("reports containment for a point exactly on the box's min face", () => {
+    // p[0] === a.min[0] exactly. `>=` (closed interval) includes it; a
+    // mutated `>` would exclude it.
+    const a: AABB = { min: [0, 0, 0], max: [2, 2, 2] };
+    const p: readonly [number, number, number] = [0, 1, 1];
+    expect(contains(a, p)).toBe(true);
+  });
+});
+
+describe("longestAxis() — tie-break order (aabb.ts:91)", () => {
+  it("returns axis 0 (x) when x and y are exactly tied and both exceed z", () => {
+    // dx === dy > dz: a genuine tie, not merely two close values. The
+    // production code's tie-break order (x wins ties with y) is the
+    // behaviour under test, so asserting the specific axis (not "either")
+    // is the point — a mutated `>` on the first clause would fall through
+    // to the y/z comparison and return 1 instead.
+    const a: AABB = { min: [0, 0, 0], max: [4, 4, 1] };
+    expect(longestAxis(a)).toBe(0);
+  });
+});

--- a/packages/clash/src/contact/bvh.test.ts
+++ b/packages/clash/src/contact/bvh.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Boundary-pinning test for the inflated-AABB overlap test in
+ * `contact/bvh.ts`. Mutation testing (flipping `<=` to `<` on
+ * `boundsOverlapInflated`'s first axis clause) found zero test coverage:
+ * nothing sat exactly on the eps-inflated touching boundary.
+ *
+ * `boundsOverlapInflated` short-circuits to `intersects()` when `eps === 0`
+ * (already covered by `aabb.test.ts`), so this test uses eps != 0 to reach
+ * the inflated comparison itself.
+ */
+
+import { describe, expect, it } from "vitest";
+import { Bvh } from "./bvh.js";
+import type { AABB, MeshBounds } from "./types.js";
+
+describe("Bvh.queryPairs — inflated-bounds closed-interval touch (bvh.ts:204)", () => {
+  it("reports a pair whose eps-inflated boxes touch exactly (not merely overlap)", () => {
+    const eps = 0.5;
+    // a.min[0] - eps === b.max[0] + eps exactly (1 - 0.5 === 0 + 0.5): the
+    // inflated boxes touch exactly on x. y/z overlap generously so no other
+    // axis is anywhere near its own boundary.
+    const a: AABB = { min: [1, 0, 0], max: [2, 1, 1] };
+    const b: AABB = { min: [-1, 0, 0], max: [0, 1, 1] };
+    const items: MeshBounds[] = [
+      { id: "A", aabb: a },
+      { id: "B", aabb: b },
+    ];
+    const bvh = Bvh.build(items);
+    expect(bvh.queryPairs(eps)).toEqual([["A", "B"]]);
+  });
+});

--- a/packages/clash/src/contact/mesh-bvh.test.ts
+++ b/packages/clash/src/contact/mesh-bvh.test.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Boundary-pinning test for the inflated-AABB overlap test in
+ * `contact/mesh-bvh.ts`. Mutation testing (flipping `<=` to `<` on
+ * `boundsOverlap`'s first axis clause) found zero test coverage: nothing sat
+ * exactly on the eps-inflated touching boundary. Unlike `bvh.ts`'s
+ * `boundsOverlapInflated`, this `boundsOverlap` has no `eps === 0`
+ * short-circuit, so any eps value reaches the same comparison.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildMeshBvh, queryMeshCross } from "./mesh-bvh.js";
+import type { Mesh } from "./types.js";
+
+function triMesh(id: string, v0: [number, number, number], v1: [number, number, number], v2: [number, number, number]): Mesh {
+  return {
+    id,
+    positions: new Float32Array([...v0, ...v1, ...v2]),
+    indices: new Uint32Array([0, 1, 2]),
+  };
+}
+
+describe("queryMeshCross — inflated-bounds closed-interval touch (mesh-bvh.ts:107)", () => {
+  it("reports a triangle pair whose eps-inflated AABBs touch exactly (not merely overlap)", () => {
+    const eps = 0.5;
+    // Triangle A's AABB is [1,0,0]-[2,1,1]; triangle B's is [-1,0,0]-[0,1,1].
+    // a.min[0] - eps === b.max[0] + eps exactly (1 - 0.5 === 0 + 0.5): the
+    // inflated boxes touch exactly on x, and clearly overlap on y/z.
+    const meshA = triMesh("A", [1, 0, 0], [2, 1, 0], [1, 0, 1]);
+    const meshB = triMesh("B", [-1, 0, 0], [0, 1, 0], [-1, 0, 1]);
+    const bvhA = buildMeshBvh(meshA);
+    const bvhB = buildMeshBvh(meshB);
+    expect(queryMeshCross(bvhA, bvhB, eps)).toEqual([[0, 0]]);
+  });
+});

--- a/packages/clash/src/engine-ts/obb.test.ts
+++ b/packages/clash/src/engine-ts/obb.test.ts
@@ -32,7 +32,7 @@ import { fileURLToPath } from 'node:url';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { testPair } from './narrow.js';
 import { TriMesh } from './tri-mesh.js';
-import { detectObb, obbPenetrationDepth, type Obb } from './obb.js';
+import { detectObb, isThroughPenetration, obbPenetrationDepth, AXIS_NOISE_ULPS, OBB_EPS, type Obb } from './obb.js';
 import { cross, dot } from '../math/vec3.js';
 import { createClashEngine } from '../engine.js';
 import { WasmClashEngine, initClashWasm } from '../engine-wasm/index.js';
@@ -368,6 +368,89 @@ describe('analytic oracle: detectObb / obbPenetrationDepth unit behaviour', () =
     expect(obbA).not.toBeNull();
     expect(obbB).not.toBeNull();
     expect(obbPenetrationDepth(obbA!, obbB!)).toBeNull();
+  });
+});
+
+/**
+ * Boundary-pinning tests found by mutation testing: flipping the operator at
+ * each of these three sites kills zero tests in the suite above. Each test
+ * below sits EXACTLY on its boundary — a fixture merely near it passes under
+ * both operators and pins nothing.
+ */
+describe('boundary pinning: exact thresholds in detectObb / obbPenetrationDepth / isThroughPenetration', () => {
+  it('declines a box whose thickness is inside the OBB_EPS band (obb.ts:148, half[i] > OBB_EPS)', () => {
+    // The existing "open shell" fixture above has EXACTLY zero extent on the
+    // degenerate axis, so it survives a mutated `half[i] > 0` just as well
+    // as the real `half[i] > OBB_EPS` check — it doesn't distinguish them.
+    // This fixture is a genuine closed box (6 faces, so the "2 offset
+    // planes per axis" check passes cleanly) whose z-thickness is exactly
+    // OBB_EPS, i.e. half[2] = OBB_EPS/2 — strictly between 0 and OBB_EPS.
+    // `half[i] > OBB_EPS` correctly still rejects it (a wafer this thin is
+    // not a certifiable box); a mutated `half[i] > 0` would accept it.
+    //
+    // x/y are 1e6 (not 1) so the SIDE faces' triangle normals stay well
+    // clear of `normalize()`'s own `len > OBB_EPS` guard (a face's normal
+    // magnitude before normalisation is ~ the product of its two edge
+    // lengths, here ~1e6 * OBB_EPS = 1, comfortably above OBB_EPS) — with a
+    // 1x1 footprint that cross product is itself ~OBB_EPS, so those faces
+    // get discarded as "degenerate" before this line is ever reached and
+    // the box is rejected for an unrelated reason (only 1 face-normal
+    // family survives), which was verified to happen and pin nothing.
+    expect(OBB_EPS / 2).toBeGreaterThan(0);
+    expect(OBB_EPS / 2).toBeLessThan(OBB_EPS);
+    const el = subdividedBox('A', 'X', [0, 0, 0], [1e6, 1e6, OBB_EPS], 1);
+    const mesh = new TriMesh(el.positions!, el.indices!);
+    expect(detectObb(mesh)).toBeNull();
+  });
+
+  it('skips a candidate axis whose overlap sits exactly at the noise bound (obb.ts:250, Math.abs(overlap) <= noise)', () => {
+    // Construct two axis-aligned boxes so the x-face candidate's overlap is
+    // an EXACT float equality with its own noise bound (not merely close):
+    // solved algebraically from the production formula
+    // `noise = extentSum * AXIS_NOISE_ULPS * EPSILON` with dist = 0, so
+    // `overlap = rA + rB` and `extentSum = rA + rB + 2*hy + 2*hz`, giving
+    // `S := rA + rB = (2*hy + 2*hz) * K / (1 - K)`, `K = AXIS_NOISE_ULPS *
+    // EPSILON` — verified by direct computation to satisfy `overlap ===
+    // noise` bit-for-bit (not just approximately).
+    //
+    // Under the real `<=` check this axis (and its duplicates reached via
+    // the 9 cross-product candidates) is skipped as inconclusive, so the
+    // reported depth comes only from the y/z face axes, each with overlap
+    // 2. A mutated `<` would instead treat the boundary axis as a genuine,
+    // vastly smaller separating-axis candidate (overlap ~= S, ~7e-15),
+    // collapsing the reported depth from 2 to ~7e-15 — an unmistakable,
+    // exactly-assertable difference.
+    const hy = 1;
+    const hz = 1;
+    const K = AXIS_NOISE_ULPS * Number.EPSILON;
+    const S = ((2 * hy + 2 * hz) * K) / (1 - K);
+    const IDENTITY: [Vec3, Vec3, Vec3] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+    const a: Obb = { center: [0, 0, 0], axes: IDENTITY, half: [0, hy, hz] };
+    const b: Obb = { center: [0, 0, 0], axes: IDENTITY, half: [S, hy, hz] };
+    // Sanity check the algebra actually lands exactly on the boundary
+    // before trusting the depth assertion below.
+    const extentSum = 0 + hy + hz + S + hy + hz;
+    const noise = extentSum * K;
+    expect(S).toBe(noise);
+    expect(obbPenetrationDepth(a, b)).toBe(2);
+  });
+
+  it('does not report a through-penetration when the far side lands exactly flush (obb.ts:325, p.half[k] > rQk + |offK| + margin(rQk))', () => {
+    // A thin "duct" (p) whose cross-section fits inside a "wall" (q) and
+    // whose length is constructed to be EXACTLY flush with the wall's far
+    // face — not past it. `half[0]` is built from the identical expression
+    // `piercesAlong` itself evaluates (rQk + |offK| + margin(rQk)), so the
+    // comparison is a bit-exact tie, not an approximation.
+    const rQk = 0.1; // wall half-thickness
+    const offK = 0.05; // duct center offset from wall center, along the pierce axis
+    const margin = OBB_EPS * Math.max(1, rQk);
+    const halfK = rQk + Math.abs(offK) + margin;
+    const IDENTITY: [Vec3, Vec3, Vec3] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+    const duct: Obb = { center: [0, 0, 0], axes: IDENTITY, half: [halfK, 0.05, 0.05] };
+    const wall: Obb = { center: [offK, 0, 0], axes: IDENTITY, half: [rQk, 5, 5] };
+    // `>` (strictly past the far face) correctly reports no through-
+    // penetration at exact flushness; a mutated `>=` would report one.
+    expect(isThroughPenetration(duct, wall)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Mutation testing on the clash narrow-phase geometry kernel found eight comparison-operator boundaries where flipping the operator kills zero tests. All eight were confirmed correct as-is — this PR is coverage-only, no production logic changes.

| file:line | function | current | mutation that kills nothing |
| --- | --- | --- | --- |
| `contact/aabb.ts:16` | `intersects()` | `a.min[0] <= b.max[0]` | `<=` → `<` (face-touching boxes) |
| `contact/aabb.ts:46` | `contains()` | `p[0] >= a.min[0]` | `>=` → `>` (point on the boundary) |
| `contact/aabb.ts:91` | `longestAxis()` | `dx >= dy && dx >= dz` | `>=` → `>` (tied axes) |
| `contact/bvh.ts:204` | `boundsOverlapInflated()` | `a.min[0] - eps <= b.max[0] + eps` | `<=` → `<` |
| `contact/mesh-bvh.ts:107` | `boundsOverlap()` | same pattern | `<=` → `<` |
| `engine-ts/obb.ts:325` | `piercesAlong()` | `p.half[k] > rQk + Math.abs(offK) + margin(rQk)` | `>` → `>=` (far side exactly flush) |
| `engine-ts/obb.ts:250` | noise-band skip | `Math.abs(overlap) <= noise` | `<=` → `<` |
| `engine-ts/obb.ts:148` | zero-thickness reject | `half[i] > OBB_EPS` | → `half[i] > 0` |

Each new fixture sits **exactly** on its boundary — a fixture merely near it passes under both operators and pins nothing, which is the failure mode that left these unguarded:

- `longestAxis()`: a genuine tie (`dx === dy > dz`), asserting the specific tie-broken axis rather than accepting either.
- `obb.ts:148`: a real closed box whose thickness is exactly `OBB_EPS`, so `half = OBB_EPS/2` sits strictly inside the epsilon band (the existing "open shell" fixture has exactly zero extent and survives the mutation, so it doesn't pin this).
- `obb.ts:250`: an exact float-equality construction — `overlap` is solved algebraically from the production noise formula so it equals `noise` bit-for-bit, not approximately. Verified via `expect(S).toBe(noise)` inline before trusting the depth assertion.
- `obb.ts:325`: the pierced member's far-side extent is built from the identical expression `piercesAlong` itself evaluates, so the comparison is a bit-exact tie at "exactly flush."
- The two inflated-bounds boundaries (`bvh.ts`, `mesh-bvh.ts`) are exercised through the public `Bvh`/`queryMeshCross` API with `eps != 0` (both have an `eps === 0` short-circuit to `intersects()`, already covered separately).

## Excluded

`contact/shared-faces.ts:345` has the same gap but is deliberately **not** touched here — PR #2818 is already open against that file and will pin it separately.

## Mutation table (RED, one boundary at a time)

Each mutation was applied individually, the full suite run, and reverted via `cp`+`diff` (never `git checkout --`) before moving to the next. All eight failing sets are disjoint — each mutation kills exactly its own new test and nothing else:

| boundary | failing test |
| --- | --- |
| `aabb.ts:16` `intersects()` | `intersects() — closed-interval face touch (aabb.ts:16) > reports overlap when two boxes touch exactly face-to-face on one axis` |
| `aabb.ts:46` `contains()` | `contains() — closed-interval point-on-boundary (aabb.ts:46) > reports containment for a point exactly on the box's min face` |
| `aabb.ts:91` `longestAxis()` | `longestAxis() — tie-break order (aabb.ts:91) > returns axis 0 (x) when x and y are exactly tied and both exceed z` |
| `bvh.ts:204` `boundsOverlapInflated()` | `Bvh.queryPairs — inflated-bounds closed-interval touch (bvh.ts:204) > reports a pair whose eps-inflated boxes touch exactly (not merely overlap)` |
| `mesh-bvh.ts:107` `boundsOverlap()` | `queryMeshCross — inflated-bounds closed-interval touch (mesh-bvh.ts:107) > reports a triangle pair whose eps-inflated AABBs touch exactly (not merely overlap)` |
| `obb.ts:325` `piercesAlong()` | `boundary pinning: ... > does not report a through-penetration when the far side lands exactly flush (obb.ts:325, ...)` |
| `obb.ts:250` noise-band skip | `boundary pinning: ... > skips a candidate axis whose overlap sits exactly at the noise bound (obb.ts:250, ...)` |
| `obb.ts:148` zero-thickness reject | `boundary pinning: ... > declines a box whose thickness is inside the OBB_EPS band (obb.ts:148, ...)` |

## Calibration

Confirmed the harness is sound by dropping the `sA0 !== 0` guard at `contact/tri-tri.ts:88` (a separate, already-known boundary, reverted immediately after): it failed 12 tests across `world-frame.test.ts` and `contact.test.ts`, matching the established baseline.

## Before/after

`npx vitest run` in `packages/clash`, same command both times:
- Before: 368 passed / 1 skipped (369)
- After: 376 passed / 1 skipped (377) — the 8 new tests

## Test plan

- [x] `npx turbo run build --filter=@ifc-lite/clash^...` and `--filter=@ifc-lite/clash` both succeed
- [x] `npx vitest run` in `packages/clash`: 376 passed / 1 skipped before push
- [x] Each of the eight boundaries independently confirmed RED (mutated) → GREEN (reverted), with disjoint failing-test sets
- [x] Calibration mutation (`tri-tri.ts:88`) reproduces the known 12-test failure
- [x] `git diff` confirms zero production-code changes — test files and changeset only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of geometry clash detection when objects touch exactly at boundaries.
  - Boundary handling is now covered across axis-aligned boxes, bounding-volume hierarchies, mesh intersections, and oriented boxes.
  - Improved consistency for containment checks, axis selection, thin-box rejection, and penetration detection at precision limits.

- **Tests**
  - Added regression coverage for epsilon-based and exact-boundary collision scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->