### PR TITLE
fix(viewer): stop clearSheet wiping saved templates; sync idsSlice isolate-mode resets

### DIFF
--- a/.changeset/slice-defect-sweep-sheet-ids.md
+++ b/.changeset/slice-defect-sweep-sheet-ids.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix two dead-field defects found while adding coverage for #2802's zero-coverage store slices.
+
+`sheetSlice`'s `clearSheet` reused the same `getDefaultState()` helper the store uses to seed its initial state, so clicking "clear sheet" reset `savedSheetTemplates` to `[]` along with the active sheet — silently deleting every saved template. `clearSheet` now preserves `savedSheetTemplates` across the reset.
+
+`idsSlice`'s `clearIdsValidationReport` already reset `idsIsolateMode` when it invalidated the validation report, but its two siblings that also invalidate the report — `setIdsDocument` (loading a new IDS document) and `clearIdsDocument` — did not. The isolate-panel "pressed" state and the 3D isolation built from `idsIsolateMode` in `useIDS.ts` were left pointing at a report that no longer existed after loading or clearing a document. Both now reset `idsIsolateMode` and `idsIsolationScope` the same way `clearIdsValidationReport` does.

--- a/apps/viewer/src/store/slices/idsSlice.test.ts
+++ b/apps/viewer/src/store/slices/idsSlice.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `idsSlice` is one of the 17 slices in #2802 with zero test references.
+ *
+ * The property pinned here: every path that invalidates
+ * `idsValidationReport` must reset `idsIsolateMode` the same way.
+ * `clearIdsValidationReport` already did this. `setIdsDocument` (loading a
+ * new document) and `clearIdsDocument` also null out `idsValidationReport`
+ * and the failed/passed id caches — but, before this fix, left
+ * `idsIsolateMode` untouched. Since the isolate-panel "pressed" state and
+ * the 3D isolation built by `useIDS.ts` both key off `idsIsolateMode`, a
+ * user who isolated failed entities and then loaded a new IDS document (or
+ * cleared it) kept seeing the isolate button as active for a report that no
+ * longer existed — the same "dangling pointer survives a sibling delete"
+ * shape as the `lensSlice.deleteLens` defect from #2765.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createStore } from 'zustand/vanilla';
+import type { IDSValidationReport } from '@ifc-lite/ids';
+import { createIdsSlice, type IDSSlice } from './idsSlice.js';
+
+const make = () => createStore<IDSSlice>(createIdsSlice);
+
+const report = (): IDSValidationReport =>
+  ({
+    specificationResults: [
+      {
+        specification: { id: 'spec1' },
+        entityResults: [
+          { modelId: 'm1', expressId: 1, passed: false },
+          { modelId: 'm1', expressId: 2, passed: true },
+        ],
+      },
+    ],
+  }) as unknown as IDSValidationReport;
+
+describe('idsSlice: clearing the report resets idsIsolateMode consistently', () => {
+  it('clearIdsValidationReport resets idsIsolateMode (the known-good sibling)', () => {
+    const s = make();
+    s.getState().setIdsValidationReport(report());
+    s.getState().setIdsIsolateMode('failed');
+
+    s.getState().clearIdsValidationReport();
+
+    assert.equal(s.getState().idsIsolateMode, null);
+  });
+
+  it('clearIdsDocument resets idsIsolateMode the same way', () => {
+    const s = make();
+    s.getState().setIdsValidationReport(report());
+    s.getState().setIdsIsolateMode('failed');
+
+    s.getState().clearIdsDocument();
+
+    assert.equal(s.getState().idsValidationReport, null);
+    assert.equal(
+      s.getState().idsIsolateMode,
+      null,
+      'stale isolate mode must not survive clearing the document'
+    );
+  });
+
+  it('setIdsDocument (loading a new document) resets idsIsolateMode the same way', () => {
+    const s = make();
+    s.getState().setIdsValidationReport(report());
+    s.getState().setIdsIsolateMode('involved');
+
+    s.getState().setIdsDocument({ specifications: [] } as never);
+
+    assert.equal(s.getState().idsValidationReport, null);
+    assert.equal(
+      s.getState().idsIsolateMode,
+      null,
+      'stale isolate mode must not survive loading a new document'
+    );
+  });
+});

--- a/apps/viewer/src/store/slices/idsSlice.ts
+++ b/apps/viewer/src/store/slices/idsSlice.ts
@@ -219,7 +219,12 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
     set({
       idsDocument,
       // Loading a new document invalidates any previous audit/validation
-      // results — they were tied to a specific document instance.
+      // results — they were tied to a specific document instance. That
+      // includes `idsIsolateMode`: it drives the isolate-button "pressed"
+      // state and the 3D isolation built from the now-discarded report, so
+      // it must be cleared here exactly like `clearIdsValidationReport`
+      // clears it — otherwise the panel keeps showing an isolate mode as
+      // active for a report that no longer exists.
       idsAuditReport: null,
       idsValidationReport: null,
       idsActiveSpecificationId: null,
@@ -227,6 +232,8 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
       idsError: null,
       idsFailedEntityIds: new Set(),
       idsPassedEntityIds: new Set(),
+      idsIsolationScope: 'ids',
+      idsIsolateMode: null,
     }),
 
   clearIdsDocument: () =>
@@ -239,6 +246,8 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
       idsError: null,
       idsFailedEntityIds: new Set(),
       idsPassedEntityIds: new Set(),
+      idsIsolationScope: 'ids',
+      idsIsolateMode: null,
     }),
 
   // Audit actions

--- a/apps/viewer/src/store/slices/sheetSlice.test.ts
+++ b/apps/viewer/src/store/slices/sheetSlice.test.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `sheetSlice` is one of the 17 slices in #2802 with zero test references.
+ *
+ * The property pinned here: `clearSheet` resets the *active* sheet/panel
+ * state, not the user's saved-template library. `getDefaultState()` is
+ * shared between the store's initial state (which correctly starts with an
+ * empty template list) and `clearSheet` (which reused it verbatim), so
+ * clicking "clear sheet" silently deleted every saved template — a
+ * destructive side effect with no relation to what the action name promises.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createStore } from 'zustand/vanilla';
+import { createSheetSlice, type SheetSlice } from './sheetSlice.js';
+
+const make = () => createStore<SheetSlice>(createSheetSlice);
+
+describe('sheetSlice: clearSheet does not destroy saved templates', () => {
+  it('preserves savedSheetTemplates across a clearSheet call', () => {
+    const s = make();
+    s.getState().createSheet();
+    s.getState().saveAsTemplate('My Template');
+
+    assert.equal(s.getState().savedSheetTemplates.length, 1);
+
+    s.getState().clearSheet();
+
+    assert.equal(s.getState().activeSheet, null, 'active sheet is reset');
+    assert.equal(s.getState().sheetEnabled, false, 'sheet-enabled flag is reset');
+    assert.equal(
+      s.getState().savedSheetTemplates.length,
+      1,
+      'saved templates must survive clearing the active sheet'
+    );
+    assert.equal(s.getState().savedSheetTemplates[0]?.name, 'My Template');
+  });
+
+  it('still starts with no templates on a fresh store', () => {
+    const s = make();
+    assert.equal(s.getState().savedSheetTemplates.length, 0);
+  });
+});

--- a/apps/viewer/src/store/slices/sheetSlice.ts
+++ b/apps/viewer/src/store/slices/sheetSlice.ts
@@ -177,7 +177,13 @@ export const createSheetSlice: StateCreator<SheetSlice, [], [], SheetSlice> = (
     set({ activeSheet: { ...current, ...updates } });
   },
 
-  clearSheet: () => set(getDefaultState()),
+  // `clearSheet` resets the *active* sheet/panel state, not the user's
+  // saved template library. `getDefaultState()` also seeds the store's
+  // initial state (which correctly starts with no templates), so it can't
+  // be reused verbatim here without wiping `savedSheetTemplates` on every
+  // "clear" click.
+  clearSheet: () =>
+    set((s) => ({ ...getDefaultState(), savedSheetTemplates: s.savedSheetTemplates })),
 
   setSheetEnabled: (enabled) => {
     if (enabled && !get().activeSheet) {


### PR DESCRIPTION
## Summary

Two dead-field defects found while hunting for bugs in #2802's zero-coverage `apps/viewer/src/store/slices/` files (`sheetSlice`, `idsSlice`).

- **`sheetSlice.clearSheet`** (`apps/viewer/src/store/slices/sheetSlice.ts:180`) called `set(getDefaultState())` — the same helper used to seed the store's initial state — so clicking "clear sheet" reset `savedSheetTemplates` to `[]` along with the active sheet. Any templates the user had saved were silently destroyed. Fixed to preserve `savedSheetTemplates` across the reset.
- **`idsSlice`**'s `clearIdsValidationReport` resets `idsIsolateMode` when it invalidates the validation report. Its two siblings that also invalidate the report — `setIdsDocument` (loading a new IDS document, `apps/viewer/src/store/slices/idsSlice.ts:218`) and `clearIdsDocument` (`:232`) — did not. `idsIsolateMode` drives the isolate-button "pressed" state and the 3D isolation built in `useIDS.ts`, so loading or clearing a document left both pointed at a report that no longer existed. Both now reset `idsIsolateMode` and `idsIsolationScope` the same way `clearIdsValidationReport` does.

Both were confirmed by executing the real reducers against a `zustand/vanilla` store harness (not inferred from reading).

## Test plan

- [x] RED: added `sheetSlice.test.ts` and `idsSlice.test.ts`, reverted the fixes, confirmed the new assertions fail:
  - `sheetSlice: clearSheet does not destroy saved templates > preserves savedSheetTemplates across a clearSheet call`
  - `idsSlice: clearing the report resets idsIsolateMode consistently > clearIdsDocument resets idsIsolateMode the same way`
  - `idsSlice: clearing the report resets idsIsolateMode consistently > setIdsDocument (loading a new document) resets idsIsolateMode the same way`
- [x] GREEN: restored the fixes, all 5 new tests pass (`node --test` via `tsx`)
- [x] `npx tsc --noEmit` clean on the touched files
- [x] Changeset added (`.changeset/slice-defect-sweep-sheet-ids.md`)

Ref #2802 (does not close it — the issue tracks many more zero-coverage slices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing the active sheet now preserves saved sheet templates.
  * Clearing or loading an IDS document now resets isolation mode and scope correctly.
  * Clearing IDS validation data now removes the associated validation report.
* **Tests**
  * Added coverage for sheet-template preservation and IDS state resets to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->