### PR TITLE
test(export): pin the glTF u16/u32 index threshold and COLLADA to_zup

### DIFF
--- a/rust/export/src/collada_tests.rs
+++ b/rust/export/src/collada_tests.rs
@@ -137,6 +137,49 @@ fn deduplicates_shared_vertices() {
 }
 
 #[test]
+fn to_zup_preserves_negation_and_swap_with_nonzero_z() {
+    // Every OTHER fixture in this file feeds z == 0 into `to_zup`, so `[x, -z,
+    // y]` could drop its negation (or swap y and z) with the whole suite still
+    // green (issue #2802). Every vertex here has z != 0 AND y != z, so both
+    // the negation and the axis swap are independently observable.
+    //
+    // Positions are chosen so the (min+max)/2 midpoint of X, and of -Z (== the
+    // Z-up Y, the OTHER horizontal axis), are each exactly zero across the 3
+    // vertices: the exporter re-centers on the horizontal (X, Y) AABB MIDPOINT
+    // after conversion, and a zero-midpoint choice keeps the expected output
+    // values exact instead of also having to model that
+    // (irrelevant-to-this-gap) centering offset.
+    //
+    // Every vertex ALSO gets its own distinct X, not just distinct Z: with a
+    // repeated X (e.g. two vertices sharing X = -10, one at z = 4 and the
+    // other at z = -4), dropping the negation just swaps which of those two
+    // vertices carries Y = -4 vs Y = 4 -- the *set* of emitted (x, y, z)
+    // triples is unchanged, so a set-membership assertion can't see the bug.
+    let positions = vec![
+        -10.0, 5.0, 4.0, // Y-up (x, y, z)
+        0.0, 5.0, -4.0, //
+        10.0, 5.0, 0.0, //
+    ];
+    let normals: Vec<f32> = std::iter::repeat_n([0.0f32, 1.0, 0.0], 3).flatten().collect();
+    let xml = String::from_utf8(export_collada_from_meshes(
+        &positions, &normals, &[0, 1, 2], &[3], &[3], &[1.0, 0.0, 0.0, 1.0], &[0.0, 0.0, 0.0],
+    ))
+    .unwrap();
+    let verts = parse_positions(&xml);
+    assert_eq!(verts.len(), 3, "no accidental dedup across 3 distinct vertices");
+    // Expected Z-up `[x, -z, y]` for each Y-up input above.
+    let want = [[-10.0f32, -4.0, 5.0], [0.0, 4.0, 5.0], [10.0, 0.0, 5.0]];
+    for w in want {
+        assert!(
+            verts.iter().any(|v| {
+                (v[0] - w[0]).abs() < 1e-3 && (v[1] - w[1]).abs() < 1e-3 && (v[2] - w[2]).abs() < 1e-3
+            }),
+            "expected z-up vertex {w:?} not found in {verts:?}"
+        );
+    }
+}
+
+#[test]
 fn large_model_is_chunked_into_small_text_nodes() {
     // >MAX_VERTS unique vertices must split into multiple <geometry> chunks so no
     // single <float_array> is a huge XML text node. Strict XML parsers (libxml2 and

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -1574,3 +1574,213 @@ fn streaming_bounded_matches_in_memory_on_empty_model() {
     assert_eq!(stats.meshes, 0);
     assert_eq!(in_memory, streamed, "empty-model GLB must be byte-identical");
 }
+
+// ── glTF quantized index componentType: u16 / u32 threshold (issue #2802) ──
+//
+// `push_mesh_quantized` (gltf.rs, in-memory quantized assembler) and the
+// bounded streaming assembler's two independent copies of the same
+// expression (one deciding the accessor's declared `componentType`, one
+// deciding the actual byte width the second pass writes) all switch on
+// `nverts <= u16::MAX as u32 + 1` (i.e. `nverts <= 65536`). No existing
+// fixture straddled that boundary, so an off-by-one there would silently
+// truncate index 65536 into a `u16` (wraps to 0 -- `65536 % 65536 == 0`)
+// while every other assertion in the 228-test suite stayed green.
+//
+// These pin BOTH sides with a REAL round trip: the primitive's index buffer
+// bytes are decoded per the accessor's DECLARED componentType and checked
+// against the untruncated original values, not just the type tag.
+
+/// A single-face `IfcFacetedBrep` with exactly `n` loop points, arranged as a
+/// (very slightly non-planar-safe) convex polygon. `triangulate_face`
+/// (gltf.rs's neighbour in `brep/faceted.rs`) emits EXACTLY one output
+/// vertex per input loop point -- unlike `IfcTriangulatedFaceSet` /
+/// `IfcPolygonalFaceSet`, which flat-shade (duplicate 3 vertices per
+/// triangle, forcing the output vertex count to always be a multiple of 3).
+/// That's the only geometry type in the pipeline that lets a test land on an
+/// EXACT vertex count -- needed here because 65536 and 65537 are not
+/// multiples of any small tessellation quantum.
+fn faceted_brep_fixture(n: u32) -> String {
+    assert!(n >= 3);
+    let mut points = String::with_capacity(n as usize * 40);
+    let mut refs = String::with_capacity(n as usize * 8);
+    for i in 0..n {
+        let id = 1000 + i;
+        // Points on a slowly-growing-radius circle: convex (fast, robust
+        // earcut) and no three points exactly collinear.
+        let angle = std::f64::consts::TAU * (i as f64) / (n as f64);
+        let r = 1000.0 + (i as f64) * 1e-6;
+        let x = r * angle.cos();
+        let y = r * angle.sin();
+        points.push_str(&format!("#{id}=IFCCARTESIANPOINT(({x:.9},{y:.9},0.));\n"));
+        refs.push_str(&format!("#{id},"));
+    }
+    refs.pop(); // trailing comma
+    let loop_id = 1000 + n;
+    let ob_id = loop_id + 1;
+    let face_id = loop_id + 2;
+    let shell_id = loop_id + 3;
+    let brep_id = loop_id + 4;
+    format!(
+        "ISO-10303-21;\n\
+HEADER;\n\
+FILE_DESCRIPTION((''),'2;1');\n\
+FILE_NAME('','',(''),(''),'','','');\n\
+FILE_SCHEMA(('IFC4'));\n\
+ENDSEC;\n\
+DATA;\n\
+#1=IFCPROJECT('0project00000000000001',$,'P',$,$,$,$,(#20),#30);\n\
+#30=IFCUNITASSIGNMENT((#31));\n\
+#31=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\n\
+#20=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);\n\
+#21=IFCAXIS2PLACEMENT3D(#22,$,$);\n\
+#22=IFCCARTESIANPOINT((0.,0.,0.));\n\
+#40=IFCLOCALPLACEMENT($,#21);\n\
+#50=IFCBUILDINGELEMENTPROXY('0elem00000000000000001',$,'E',$,$,#40,#60,$,$);\n\
+#60=IFCPRODUCTDEFINITIONSHAPE($,$,(#61));\n\
+#61=IFCSHAPEREPRESENTATION(#20,'Body','Brep',(#{brep_id}));\n\
+{points}\
+#{loop_id}=IFCPOLYLOOP(({refs}));\n\
+#{ob_id}=IFCFACEOUTERBOUND(#{loop_id},.T.);\n\
+#{face_id}=IFCFACE((#{ob_id}));\n\
+#{shell_id}=IFCCLOSEDSHELL((#{face_id}));\n\
+#{brep_id}=IFCFACETEDBREP(#{shell_id});\n\
+ENDSEC;\n\
+END-ISO-10303-21;\n"
+    )
+}
+
+/// Decode a SCALAR index accessor per its DECLARED `componentType` (5123 =
+/// `UNSIGNED_SHORT`, 5125 = `UNSIGNED_INT`) -- proves the type tag and the
+/// actual byte width written agree, rather than trusting one alone.
+fn decode_indices(json: &Value, bin: &[u8], acc_idx: usize) -> Vec<u64> {
+    let acc = &json["accessors"][acc_idx];
+    let ct = acc["componentType"].as_u64().unwrap();
+    let count = acc["count"].as_u64().unwrap() as usize;
+    let bv_idx = acc["bufferView"].as_u64().unwrap() as usize;
+    let bv = &json["bufferViews"][bv_idx];
+    let base = bv["byteOffset"].as_u64().unwrap_or(0) as usize
+        + acc["byteOffset"].as_u64().unwrap_or(0) as usize;
+    // Cross-check the DECLARED componentType against the bufferView's actual
+    // byteLength: a byte-width mismatch between "what pass 1 declared" and
+    // "what pass 2 actually wrote" (the two-pass streaming path's two
+    // SEPARATE copies of the `small` expression disagreeing) would otherwise
+    // go undetected here -- reading a stream of real u32s as u16s still
+    // happens to surface the expected values at SOME offset (each u32's low
+    // half is its low 16 bits), so a membership check on the decoded values
+    // alone is not sufficient evidence.
+    let width = match ct {
+        5123 => 2u64,
+        5125 => 4u64,
+        other => panic!("unexpected index componentType {other}"),
+    };
+    let declared_len = (count as u64 * width).div_ceil(4) * 4;
+    let actual_len = bv["byteLength"].as_u64().unwrap();
+    assert_eq!(
+        actual_len, declared_len,
+        "index bufferView byteLength ({actual_len}) doesn't match count*declared-width \
+         ({declared_len}) -- the declared componentType disagrees with the bytes actually written"
+    );
+    (0..count)
+        .map(|i| match ct {
+            5123 => {
+                let o = base + i * 2;
+                u16::from_le_bytes(bin[o..o + 2].try_into().unwrap()) as u64
+            }
+            5125 => {
+                let o = base + i * 4;
+                u32::from_le_bytes(bin[o..o + 4].try_into().unwrap()) as u64
+            }
+            other => panic!("unexpected index componentType {other}"),
+        })
+        .collect()
+}
+
+/// The single element's mesh's index accessor id, plus its declared vertex count.
+fn index_acc_and_nverts(json: &Value) -> (usize, u64) {
+    let prim = &json["meshes"][0]["primitives"][0];
+    let idx_acc = prim["indices"].as_u64().expect("indices accessor") as usize;
+    let pos_acc = prim["attributes"]["POSITION"].as_u64().expect("position accessor") as usize;
+    (idx_acc, json["accessors"][pos_acc]["count"].as_u64().unwrap())
+}
+
+/// nverts == u16::MAX + 1 (65536): the LARGEST vertex count that still fits a
+/// `u16` index (max index = nverts - 1 = 65535 = u16::MAX exactly). Through
+/// the IN-MEMORY quantized assembler -- reaches `push_mesh_quantized`'s
+/// threshold (gltf.rs, `let small = nverts <= u16::MAX as u32 + 1`, near
+/// line 805). Runs unconditionally: the fixture is synthetic STEP text, no
+/// downloaded fixture involved.
+#[test]
+fn index_u16_boundary_in_memory() {
+    let content = faceted_brep_fixture(65536);
+    let opts = GltfOptions { quantize: true, ..GltfOptions::default() };
+    let (glb, _) = export_glb_from_result(process_geometry(content.as_bytes()), &opts);
+    let (json, bin) = parse_glb(&glb);
+    let (idx_acc, nverts) = index_acc_and_nverts(&json);
+    assert_eq!(nverts, 65536, "fixture must actually reach the boundary vertex count");
+    assert_eq!(
+        json["accessors"][idx_acc]["componentType"], 5123,
+        "65536 verts must still fit UNSIGNED_SHORT (5123)"
+    );
+    let idx = decode_indices(&json, &bin, idx_acc);
+    assert!(idx.iter().min() == Some(&0), "index 0 must be present: {idx:?}");
+    assert!(idx.contains(&65535), "the max index (65535) must round-trip untruncated: {idx:?}");
+}
+
+/// nverts == u16::MAX + 2 (65537): ONE past the boundary -- max index =
+/// 65536, which does NOT fit a `u16` (65536 % 65536 == 0 is exactly the
+/// silent-wrap failure mode an off-by-one comparison would produce). Same
+/// site as above.
+#[test]
+fn index_u32_promote_in_memory() {
+    let content = faceted_brep_fixture(65537);
+    let opts = GltfOptions { quantize: true, ..GltfOptions::default() };
+    let (glb, _) = export_glb_from_result(process_geometry(content.as_bytes()), &opts);
+    let (json, bin) = parse_glb(&glb);
+    let (idx_acc, nverts) = index_acc_and_nverts(&json);
+    assert_eq!(nverts, 65537, "fixture must actually reach one past the boundary");
+    assert_eq!(
+        json["accessors"][idx_acc]["componentType"], 5125,
+        "65537 verts must promote to UNSIGNED_INT (5125)"
+    );
+    let idx = decode_indices(&json, &bin, idx_acc);
+    assert!(idx.iter().min() == Some(&0), "index 0 must be present: {idx:?}");
+    assert!(
+        idx.contains(&65536),
+        "the max index (65536) must survive as 65536, not wrap to 0: {idx:?}"
+    );
+}
+
+/// Same boundary through the BOUNDED TWO-PASS streaming assembler: pass 1
+/// declares the accessor's `componentType` (gltf.rs, near line 2295), pass 2
+/// writes the actual index bytes using a SEPARATELY re-evaluated copy of the
+/// same expression stashed on `StreamedWrite.quant` (near line 2367,
+/// consumed near line 2618). Both duplicated copies have to agree with pass
+/// 1 AND with the untruncated value for this to pass.
+#[test]
+fn index_u16_boundary_streaming_bounded() {
+    let content = faceted_brep_fixture(65536);
+    let opts = GltfOptions { quantize: true, ..GltfOptions::default() };
+    let (glb, _) = export_glb_streaming_bounded(content.as_bytes(), &opts);
+    let (json, bin) = parse_glb(&glb);
+    let (idx_acc, nverts) = index_acc_and_nverts(&json);
+    assert_eq!(nverts, 65536);
+    assert_eq!(json["accessors"][idx_acc]["componentType"], 5123);
+    let idx = decode_indices(&json, &bin, idx_acc);
+    assert!(idx.iter().min() == Some(&0), "index 0 must be present: {idx:?}");
+    assert!(idx.contains(&65535), "{idx:?}");
+}
+
+/// See [`index_u16_boundary_streaming_bounded`]; the promote side.
+#[test]
+fn index_u32_promote_streaming_bounded() {
+    let content = faceted_brep_fixture(65537);
+    let opts = GltfOptions { quantize: true, ..GltfOptions::default() };
+    let (glb, _) = export_glb_streaming_bounded(content.as_bytes(), &opts);
+    let (json, bin) = parse_glb(&glb);
+    let (idx_acc, nverts) = index_acc_and_nverts(&json);
+    assert_eq!(nverts, 65537);
+    assert_eq!(json["accessors"][idx_acc]["componentType"], 5125);
+    let idx = decode_indices(&json, &bin, idx_acc);
+    assert!(idx.iter().min() == Some(&0), "index 0 must be present: {idx:?}");
+    assert!(idx.contains(&65536), "{idx:?}");
+}


### PR DESCRIPTION
## Summary

Two coverage gaps from #2802, both the "fixture cannot observe the property it asserts" shape. Production code is untouched — verified by RED/GREEN mutation testing at every site below.

### Gap 1 — glTF quantized index componentType (u16 vs u32)

`nverts <= u16::MAX as u32 + 1` decides `UNSIGNED_SHORT` (5123) vs `UNSIGNED_INT` (5125) indices, duplicated at three sites in `rust/export/src/gltf.rs`:

- `push_mesh_quantized` (line 805) — the in-memory quantized assembler.
- The bounded two-pass streaming assembler's accessor-declare copy (line 2295, pass 1).
- The bounded two-pass streaming assembler's byte-write-sizing copy (line 2367, stored on `StreamedWrite.quant`, consumed at the actual write in line 2618, pass 2).

No fixture straddled 65536/65537 vertices, so an off-by-one silently truncates index 65536 into a `u16` (`65536 % 65536 == 0`) while the whole suite stays green.

`IfcTriangulatedFaceSet`/`IfcPolygonalFaceSet` flat-shade (3 duplicated vertices per triangle), so their output vertex count is always a multiple of 3 — neither 65536 nor 65537 is reachable that way. `IfcFacetedBrep`'s per-face fan/earcut triangulation (`triangulate_face` in `brep/faceted.rs`) is the one geometry type whose output preserves exactly one vertex per input loop point, so a single-face fixture with exactly `n` polygon points lands on the exact boundary. Four new tests (one pair per assembler) build that fixture at `n = 65536` and `n = 65537`, decode the index buffer per the DECLARED componentType, and assert both the type tag and a bufferView `byteLength` cross-check — the cross-check matters because reading a real byte-width mismatch (declared u16, actually written u32) as u16 can still coincidentally decode a plausible-looking value at some offset (a u32's low 16 bits survive as a u16), so a plain membership check on decoded values isn't sufficient evidence.

Mutation table (production code restored after each; `cp`+`diff`, no `git checkout`):

| Site | Mutation | Failing test(s) |
|---|---|---|
| gltf.rs:805 | `<=` → `<` | `index_u16_boundary_in_memory` |
| gltf.rs:805 | `+ 1` → `+ 2` | `index_u32_promote_in_memory` |
| gltf.rs:2295 | `<=` → `<` | `index_u16_boundary_streaming_bounded` |
| gltf.rs:2295 | `+ 1` → `+ 2` | `index_u32_promote_streaming_bounded` |
| gltf.rs:2367 | `<=` → `<` | `index_u16_boundary_streaming_bounded` |
| gltf.rs:2367 | `+ 1` → `+ 2` | `index_u32_promote_streaming_bounded` |

All three sites are independently pinned; none is unreachable.

Since the three sites are the same expression copy-pasted three times, extracting a shared `fn u16_index_threshold(nverts: u32) -> bool` helper looks worthwhile — flagging it here per house convention rather than doing that refactor in a test-only PR.

### Gap 2 — COLLADA `to_zup`

`fn to_zup(x, y, z) -> [x, -z, y]` in `rust/export/src/collada.rs`. Every existing fixture fed `z == 0`, so the negation was unobservable. The new test uses `z != 0` and `y != z` per vertex, AND gives every vertex a distinct X — an earlier version of this fixture kept two vertices at the same X (only their Z differed), and dropping the negation just swapped which of those two vertices carried `+4` vs `-4`; the *set* of emitted `(x, y, z)` triples was unchanged, so a set-membership assertion couldn't see the bug. Positions are chosen so the exporter's horizontal-AABB-midpoint re-centering is a no-op, keeping the expected output values exact.

Mutation table:

| Mutation | Failing test(s) |
|---|---|
| `[x, -z, y]` → `[x, z, y]` (drop negation) | `to_zup_preserves_negation_and_swap_with_nonzero_z` only (the pre-existing `converts_yup_to_zup_and_centers` stays green under this mutation — confirms the gap the issue describes) |
| `[x, -z, y]` → `[x, -y, z]` (swap y/z) | `to_zup_preserves_negation_and_swap_with_nonzero_z` AND the pre-existing `converts_yup_to_zup_and_centers` (that swap also breaks the z=0 case) |

### Test hygiene

- All 5 new tests build their own synthetic STEP/flat-array fixtures — none use `fixture_or_skip!`, so none can silently report PASS on a missing download; they run unconditionally.
- Baseline: `cargo test --lib` in `rust/export` — 228 passed (issue cites 226; `main` moved since it was filed). After this PR: 233 passed (+5), 0 failed.
- No production code changed in `gltf.rs` or `collada.rs`.
- No changeset: matches the recent Rust-only ffi threshold test PR (#2722), which also carried none for a test-only `rust/` change.

## Test plan

- [x] `cargo test --lib` in `rust/export`: 228 → 233 passed, 0 failed.
- [x] RED confirmed at all three glTF sites (6 mutations) and both COLLADA mutations; GREEN confirmed after each restore.
- [x] `cargo clippy --lib --tests` in `rust/export`: no new warnings from the added code.

Refs #2802 (not closing — it tracks more items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for COLLADA coordinate conversion, including axis swapping and negation with nonzero depth values.
  * Added glTF export coverage at the 65,536-vertex boundary to verify correct index widths, buffer lengths, and index preservation.
  * Confirmed both standard and streaming exports handle large meshes without index truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->