### PR TITLE
fix(viewer): scope clearDrawing2D to drawing-generation fields only

### DIFF
--- a/.changeset/drawing2d-cleardrawing-scope.md
+++ b/.changeset/drawing2d-cleardrawing-scope.md
@@ -1,0 +1,18 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix `clearDrawing2D` wiping graphic overrides, DXF underlays, and all 2D
+annotations instead of just the generated drawing.
+
+`clearDrawing2D` called `set(getDefaultState())`, resetting the entire
+`Drawing2DSlice` to its initial values. The "View 2D" button
+(`SectionPanel.tsx`) calls it solely to force drawing regeneration with the
+current settings -- but the whole-state reset also discarded the user's
+custom graphic-override rules, the enabled/disabled state of the built-in
+overrides, every DXF underlay they had imported, and every measurement,
+polygon-area, text, and cloud annotation on the 2D sheet.
+
+`clearDrawing2D` now resets only the drawing-generation fields
+(`drawing2D`, `drawing2DStatus`, `drawing2DProgress`, `drawing2DPhase`,
+`drawing2DError`, `drawing2DSvgContent`).

--- a/apps/viewer/src/store/slices/drawing2DSlice.test.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.test.ts
@@ -67,6 +67,39 @@ describe('drawing2DSlice.addDxfUnderlay (PR #1965 review: tri-state georeference
   });
 });
 
+// SectionPanel.tsx's "View 2D" button calls clearDrawing2D() purely to force
+// regeneration with current settings (see the comment at its call site).
+// clearDrawing2D used to `set(getDefaultState())`, wiping the ENTIRE slice --
+// graphic overrides, DXF underlays, and all annotations -- exactly like the
+// `clearSheet` whole-state-default defect (sheetSlice.ts:180). It must only
+// reset the drawing-generation fields.
+describe('drawing2DSlice.clearDrawing2D (regression: must not wipe unrelated slice state)', () => {
+  it('resets drawing-generation fields but leaves overrides, DXF underlays, and annotations untouched', () => {
+    const s = makeStore();
+    s.getState().addCustomRule({
+      id: 'r1', name: 'rule 1', priority: 1, enabled: true,
+      criteria: { logic: 'and', conditions: [] }, style: {},
+    });
+    s.getState().setOverridesEnabled(false);
+    s.getState().addTextAnnotation2D({
+      id: 't1', position: { x: 0, y: 0 }, text: 'hello',
+      fontSize: 14, color: '#000', backgroundColor: '#fff', borderColor: '#000',
+    });
+    s.getState().addDxfUnderlay(makeUnderlay());
+    s.getState().setDrawing2D({} as never);
+
+    s.getState().clearDrawing2D();
+
+    const state = s.getState();
+    assert.strictEqual(state.drawing2D, null);
+    assert.strictEqual(state.drawing2DStatus, 'idle');
+    assert.strictEqual(state.customOverrideRules.length, 1, 'clearDrawing2D must not wipe custom override rules');
+    assert.strictEqual(state.overridesEnabled, false, 'clearDrawing2D must not reset overridesEnabled');
+    assert.strictEqual(state.textAnnotations2D.length, 1, 'clearDrawing2D must not wipe text annotations');
+    assert.strictEqual(state.dxfUnderlays.length, 1, 'clearDrawing2D must not wipe DXF underlays');
+  });
+});
+
 // Issue #2043: `visible` (2D) and `visible3D` (3D) are independent toggles,
 // both defaulting to on -- the issue's explicit "default to visible in both
 // 2D and 3D" requirement, and a load-time-only 2D-vs-3D choice was rejected.

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -438,7 +438,19 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
     drawing2DDisplayOptions: { ...state.drawing2DDisplayOptions, ...options },
   })),
 
-  clearDrawing2D: () => set(getDefaultState()),
+  // Only the drawing-generation fields, NOT the whole slice: this is called
+  // by "View 2D" (SectionPanel.tsx) purely to force regeneration with
+  // current settings, so it must leave graphic overrides, DXF underlays,
+  // and all annotation/measurement state (which `getDefaultState()` would
+  // wipe) untouched.
+  clearDrawing2D: () => set({
+    drawing2D: null,
+    drawing2DStatus: 'idle',
+    drawing2DProgress: 0,
+    drawing2DPhase: '',
+    drawing2DError: null,
+    drawing2DSvgContent: null,
+  }),
 
   // Graphic Override Actions
   setActivePreset: (presetId) => set({ activePresetId: presetId }),


### PR DESCRIPTION
## Summary

Part of the issue #2802 test-coverage sweep on `drawing2DSlice` (862 lines, ~55/62 actions untested) and `pinboardSlice` (478 lines, ~19/25 untested).

- `clearDrawing2D` (`apps/viewer/src/store/slices/drawing2DSlice.ts:441`, was `set(getDefaultState())`) reset the **entire** `Drawing2DSlice`, not just the generated drawing. The only call site, `SectionPanel.tsx`'s "View 2D" button, invokes it purely to force regeneration with current settings — but the whole-state reset also silently discarded the user's custom graphic-override rules, the enabled/disabled state of built-in overrides, every imported DXF underlay, and every measure/polygon-area/text/cloud annotation on the 2D sheet.
- Same shape as the `clearSheet` defect noted in the issue (`sheetSlice.ts:180`): an action named after one concern resets to whole-state defaults instead of scoping to its own fields.
- Fixed to reset only `drawing2D`, `drawing2DStatus`, `drawing2DProgress`, `drawing2DPhase`, `drawing2DError`, `drawing2DSvgContent`.
- Added a regression test (`drawing2DSlice.test.ts`) demonstrating overrides/DXF underlays/annotations survive `clearDrawing2D`.

## Test plan

- [x] `npx tsx --test drawing2DSlice.test.ts pinboardSlice.test.ts` — 20/20 pass
- [x] RED: reverted the fix locally, new test failed (`not ok 2 - drawing2DSlice.clearDrawing2D (regression...)`)
- [x] GREEN: restored the fix, all 20 pass
- [x] `tsc --noEmit` clean for both touched files
- [x] Full `store/slices/*.test.ts` run: 527/536 pass; the 9 pre-existing failures are in unrelated slices (chat/clash/layerStack/mutation/schedule/script) untouched by this change

Refs #2802. Not closing the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing a 2D drawing now removes only generated drawing content.
  * Graphic overrides, annotations, measurements, and DXF underlays are preserved when the drawing is cleared.
  * Improved reliability of drawing reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->