### PR TITLE
test(viewer): cover compareSlice's run-result lifecycle and lensSlice's remaining actions

### DIFF
--- a/apps/viewer/src/store/slices/compareSlice.lifecycle.test.ts
+++ b/apps/viewer/src/store/slices/compareSlice.lifecycle.test.ts
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coverage for the compareSlice actions #2802 left untested (roughly 11 of
+ * ~17), with particular attention to the run-result lifecycle the issue
+ * calls out: `compareRunning` / `compareError` / `compareResult` /
+ * `compareRunSeq` / `compareSelectedKey` and `clearCompare`, the state
+ * machine a comparison run moves through (idle -> running -> succeeded /
+ * failed, and back to idle via `clearCompare`).
+ *
+ * The slice itself is documented as "deliberately dumb, mirroring
+ * `clashSlice` + `useClash`" (compareSlice.ts top-of-file comment): every
+ * setter here is an independent reducer with no cross-field invariants of
+ * its own. The orchestration that turns these setters into a race-free
+ * lifecycle (guarding a superseded run's result from landing over a newer
+ * one, clearing stale state on model-content changes) lives in
+ * `useCompare.ts`, which is out of scope for this file. What IS in scope,
+ * and tested below, is that each setter does exactly what it documents and
+ * nothing more — in particular that `clearCompare` resets exactly the four
+ * fields it documents and `compareRunSeq` is genuinely monotonic and
+ * survives a clear.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { createCompareSlice, type CompareSlice } from './compareSlice.js';
+import type { CompareResult } from './compareSlice.js';
+
+function makeSlice(): { get: () => CompareSlice } {
+  let state: CompareSlice;
+  const set = (partial: unknown) => {
+    const next = typeof partial === 'function'
+      ? (partial as (s: CompareSlice) => Partial<CompareSlice>)(state)
+      : partial as Partial<CompareSlice>;
+    state = { ...state, ...next };
+  };
+  state = createCompareSlice(set as never, () => state, {} as never);
+  return { get: () => state };
+}
+
+function fakeResult(overrides: Partial<CompareResult> = {}): CompareResult {
+  return {
+    baseModelId: 'a',
+    headModelId: 'b',
+    baseName: 'A.ifc',
+    headName: 'B.ifc',
+    scope: 'both',
+    geometryUnavailable: false,
+    excludedHiddenIds: new Set(),
+    diff: { entries: [], excludedTypes: [], contentMatches: undefined } as unknown as CompareResult['diff'],
+    ...overrides,
+  };
+}
+
+describe('compareSlice - plain UI setters', () => {
+  it('setComparePanelVisible sets an explicit value', () => {
+    const slice = makeSlice();
+    slice.get().setComparePanelVisible(true);
+    assert.equal(slice.get().comparePanelVisible, true);
+    slice.get().setComparePanelVisible(true);
+    assert.equal(slice.get().comparePanelVisible, true);
+    slice.get().setComparePanelVisible(false);
+    assert.equal(slice.get().comparePanelVisible, false);
+  });
+
+  it('toggleComparePanel flips from either starting state', () => {
+    const slice = makeSlice();
+    assert.equal(slice.get().comparePanelVisible, false);
+    slice.get().toggleComparePanel();
+    assert.equal(slice.get().comparePanelVisible, true);
+    slice.get().toggleComparePanel();
+    assert.equal(slice.get().comparePanelVisible, false);
+  });
+
+  it('setCompareBaseModelId / setCompareHeadModelId set and clear independently', () => {
+    const slice = makeSlice();
+    slice.get().setCompareBaseModelId('model-a');
+    slice.get().setCompareHeadModelId('model-b');
+    assert.equal(slice.get().compareBaseModelId, 'model-a');
+    assert.equal(slice.get().compareHeadModelId, 'model-b');
+    slice.get().setCompareBaseModelId(null);
+    assert.equal(slice.get().compareBaseModelId, null);
+    assert.equal(slice.get().compareHeadModelId, 'model-b', 'setting one must not touch the other');
+  });
+
+  it('setCompareScope replaces the scope', () => {
+    const slice = makeSlice();
+    assert.equal(slice.get().compareScope, 'both');
+    slice.get().setCompareScope('data');
+    assert.equal(slice.get().compareScope, 'data');
+    slice.get().setCompareScope('geometry');
+    assert.equal(slice.get().compareScope, 'geometry');
+  });
+
+  it('setCompareShowUnchanged toggles the ghosting flag', () => {
+    const slice = makeSlice();
+    assert.equal(slice.get().compareShowUnchanged, false);
+    slice.get().setCompareShowUnchanged(true);
+    assert.equal(slice.get().compareShowUnchanged, true);
+  });
+
+  it('setCompareSelectedKey sets and clears the highlighted row', () => {
+    const slice = makeSlice();
+    slice.get().setCompareSelectedKey('GUID-123');
+    assert.equal(slice.get().compareSelectedKey, 'GUID-123');
+    slice.get().setCompareSelectedKey(null);
+    assert.equal(slice.get().compareSelectedKey, null);
+  });
+});
+
+describe('compareSlice - run-result lifecycle', () => {
+  let slice: { get: () => CompareSlice };
+  beforeEach(() => { slice = makeSlice(); });
+
+  it('idle: starts with no result, not running, no error', () => {
+    assert.equal(slice.get().compareResult, null);
+    assert.equal(slice.get().compareRunning, false);
+    assert.equal(slice.get().compareError, null);
+    assert.equal(slice.get().compareRunSeq, 0);
+  });
+
+  it('idle -> running: setCompareRunning(true) does not by itself touch result/error', () => {
+    slice.get().setCompareError('stale error from a previous attempt');
+    slice.get().setCompareRunning(true);
+    assert.equal(slice.get().compareRunning, true);
+    assert.equal(slice.get().compareError, 'stale error from a previous attempt',
+      'clearing the error on a fresh run is the CALLER\'s job (useCompare clears it before setCompareRunning(true))');
+  });
+
+  it('running -> succeeded: setCompareResult publishes the result; compareRunning is a separate flag the caller clears', () => {
+    slice.get().setCompareRunning(true);
+    const result = fakeResult();
+    slice.get().setCompareResult(result);
+    assert.strictEqual(slice.get().compareResult, result);
+    assert.equal(slice.get().compareRunning, true,
+      'setCompareResult does not implicitly clear compareRunning - each setter is independent by design');
+    slice.get().setCompareRunning(false);
+    assert.equal(slice.get().compareRunning, false);
+  });
+
+  it('running -> failed: setCompareError + setCompareResult(null) is how a failure is published, and does not touch compareRunSeq', () => {
+    slice.get().bumpCompareRunSeq();
+    slice.get().setCompareRunning(true);
+    slice.get().setCompareError('Comparison failed.');
+    slice.get().setCompareResult(null);
+    slice.get().setCompareRunning(false);
+    assert.equal(slice.get().compareResult, null);
+    assert.equal(slice.get().compareError, 'Comparison failed.');
+    assert.equal(slice.get().compareRunSeq, 1, 'a failed run must not roll back the completed-run counter');
+  });
+
+  it('a second successful run replaces the first result outright (last-wins, no merge)', () => {
+    const first = fakeResult({ baseModelId: 'a', headModelId: 'b' });
+    const second = fakeResult({ baseModelId: 'a', headModelId: 'c' });
+    slice.get().setCompareResult(first);
+    slice.get().setCompareResult(second);
+    assert.strictEqual(slice.get().compareResult, second);
+  });
+
+  it('bumpCompareRunSeq is monotonic across repeated calls', () => {
+    slice.get().bumpCompareRunSeq();
+    slice.get().bumpCompareRunSeq();
+    slice.get().bumpCompareRunSeq();
+    assert.equal(slice.get().compareRunSeq, 3);
+  });
+
+  it('clearCompare resets exactly result/running/error/selectedKey, leaving A/B/scope/blacklist/matching/runSeq untouched', () => {
+    slice.get().setCompareBaseModelId('model-a');
+    slice.get().setCompareHeadModelId('model-b');
+    slice.get().setCompareScope('geometry');
+    slice.get().addCompareExcludedType('IfcOpeningElement');
+    slice.get().setCompareMatchByContent(false);
+    slice.get().bumpCompareRunSeq();
+    slice.get().setCompareResult(fakeResult());
+    slice.get().setCompareRunning(true);
+    slice.get().setCompareError('boom');
+    slice.get().setCompareSelectedKey('GUID-1');
+
+    slice.get().clearCompare();
+
+    assert.equal(slice.get().compareResult, null, 'result must be cleared');
+    assert.equal(slice.get().compareRunning, false, 'running must be cleared');
+    assert.equal(slice.get().compareError, null, 'error must be cleared');
+    assert.equal(slice.get().compareSelectedKey, null, 'selection must be cleared');
+
+    // Documented as "keeps the A/B + scope choices" - and the run-completed
+    // counter is documented as "never reset" (mirrors clashRunSeq).
+    assert.equal(slice.get().compareBaseModelId, 'model-a');
+    assert.equal(slice.get().compareHeadModelId, 'model-b');
+    assert.equal(slice.get().compareScope, 'geometry');
+    assert.deepStrictEqual(slice.get().compareExcludedTypes, ['IfcOpeningElement']);
+    assert.equal(slice.get().compareMatchByContent, false);
+    assert.equal(slice.get().compareRunSeq, 1, 'clearCompare must not roll back the completed-run counter');
+  });
+
+  it('a superseded run publishing after clearCompare still lands (no guard in the slice itself - documented as the caller\'s responsibility)', () => {
+    // This demonstrates the slice's own behaviour, not a bug in it: the slice
+    // has no notion of "which run this result belongs to" - that identity
+    // check (`isCurrentFor` in useCompare.ts) is what prevents a stale
+    // in-flight run's result from landing over a fresher clear/re-run. A
+    // caller that skips that check would see exactly this.
+    const stale = fakeResult({ headModelId: 'stale-head' });
+    slice.get().setCompareResult(stale);
+    slice.get().clearCompare();
+    assert.equal(slice.get().compareResult, null, 'precondition: clear landed');
+    slice.get().setCompareResult(stale); // the "superseded run" publishing late
+    assert.strictEqual(slice.get().compareResult, stale,
+      'the raw setter has no supersession guard - callers must check before calling it');
+  });
+});

--- a/apps/viewer/src/store/slices/lensSlice.actions.test.ts
+++ b/apps/viewer/src/store/slices/lensSlice.actions.test.ts
@@ -172,7 +172,7 @@ describe('lensSlice - plain UI setters', () => {
 
   it('setLensAutoColorLegend replaces the legend array', () => {
     const slice = makeSlice();
-    const legend = [{ value: 'a', color: '#fff', count: 1 }];
+    const legend = [{ id: 'a', name: 'a', color: '#fff', count: 1 }];
     slice.get().setLensAutoColorLegend(legend);
     assert.strictEqual(slice.get().lensAutoColorLegend, legend);
   });

--- a/apps/viewer/src/store/slices/lensSlice.actions.test.ts
+++ b/apps/viewer/src/store/slices/lensSlice.actions.test.ts
@@ -1,0 +1,266 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coverage for lensSlice actions #2802 left untested: the plain UI setters,
+ * the derived-getters, and — the interesting one — `setSavedLenses`'s
+ * active-pointer bookkeeping, which is the exact sibling of the #2765
+ * `deleteLens` defect (a stale `activeLensId` surviving a set that dropped
+ * the lens it pointed at).
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import type { Lens } from '@ifc-lite/lens';
+import { createLensSlice, type LensSlice } from './lensSlice.js';
+
+function installStubStorage(): Map<string, string> {
+  const data = new Map<string, string>();
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: (k: string) => data.get(k) ?? null,
+    setItem: (k: string, v: string) => { data.set(k, v); },
+    removeItem: (k: string) => { data.delete(k); },
+    clear: () => data.clear(),
+    key: (i: number) => Array.from(data.keys())[i] ?? null,
+    get length() { return data.size; },
+  } as Storage;
+  return data;
+}
+
+const LENS: Lens = {
+  id: 'lens-test-1',
+  name: 'Test lens',
+  rules: [{ id: 'r1', name: 'walls', enabled: true, criteria: { type: 'ifcType', ifcType: 'IfcWall' }, action: 'colorize', color: '#ff0000' }],
+};
+
+function makeSlice(): { get: () => LensSlice } {
+  let state: LensSlice;
+  const set = (partial: unknown) => {
+    const next = typeof partial === 'function'
+      ? (partial as (s: LensSlice) => Partial<LensSlice>)(state)
+      : partial as Partial<LensSlice>;
+    state = { ...state, ...next };
+  };
+  state = createLensSlice(set as never, () => state, {} as never);
+  return { get: () => state };
+}
+
+describe('lensSlice - setSavedLenses active-pointer bookkeeping', () => {
+  beforeEach(() => { installStubStorage(); });
+
+  it('clears activeLensId when the incoming snapshot drops the active lens (sibling of #2765)', () => {
+    const slice = makeSlice();
+    slice.get().createLens(LENS);
+    slice.get().setActiveLens(LENS.id);
+    assert.equal(slice.get().activeLensId, LENS.id, 'precondition');
+
+    // Incoming snapshot (e.g. a flavor switch) no longer contains LENS.
+    const result = slice.get().setSavedLenses([]);
+
+    assert.equal(result.ok, true);
+    assert.equal(slice.get().activeLensId, null,
+      'a snapshot that dropped the active lens must not leave a dangling pointer');
+  });
+
+  it('keeps activeLensId when the incoming snapshot still contains it (bounding control)', () => {
+    // Clearing unconditionally would also satisfy the assertion above while
+    // deselecting the user's lens on every flavor switch.
+    const slice = makeSlice();
+    slice.get().createLens(LENS);
+    slice.get().setActiveLens(LENS.id);
+
+    const result = slice.get().setSavedLenses([LENS]);
+
+    assert.equal(result.ok, true);
+    assert.equal(slice.get().activeLensId, LENS.id);
+  });
+
+  it('restores missing builtins even when the incoming snapshot omits them', () => {
+    const slice = makeSlice();
+    const builtinCountBefore = slice.get().savedLenses.filter((l) => l.builtin).length;
+    assert.ok(builtinCountBefore > 0, 'precondition: builtins are seeded');
+
+    slice.get().setSavedLenses([LENS]);
+
+    const after = slice.get().savedLenses;
+    assert.equal(after.filter((l) => l.builtin).length, builtinCountBefore,
+      'builtins missing from the incoming set must be restored from defaults');
+    assert.ok(after.some((l) => l.id === LENS.id));
+  });
+});
+
+describe('lensSlice - plain UI setters', () => {
+  beforeEach(() => { installStubStorage(); });
+
+  it('setActiveLens sets and clears the pointer', () => {
+    const slice = makeSlice();
+    slice.get().setActiveLens('some-id');
+    assert.equal(slice.get().activeLensId, 'some-id');
+    slice.get().setActiveLens(null);
+    assert.equal(slice.get().activeLensId, null);
+  });
+
+  it('toggleLensPanel flips visibility from either starting state', () => {
+    const slice = makeSlice();
+    assert.equal(slice.get().lensPanelVisible, false);
+    slice.get().toggleLensPanel();
+    assert.equal(slice.get().lensPanelVisible, true);
+    slice.get().toggleLensPanel();
+    assert.equal(slice.get().lensPanelVisible, false);
+  });
+
+  it('setLensPanelVisible sets an explicit value regardless of current state', () => {
+    const slice = makeSlice();
+    slice.get().setLensPanelVisible(true);
+    assert.equal(slice.get().lensPanelVisible, true);
+    slice.get().setLensPanelVisible(true);
+    assert.equal(slice.get().lensPanelVisible, true);
+    slice.get().setLensPanelVisible(false);
+    assert.equal(slice.get().lensPanelVisible, false);
+  });
+
+  it('setLensColorMap replaces the map wholesale', () => {
+    const slice = makeSlice();
+    const map = new Map<number, string>([[1, '#fff']]);
+    slice.get().setLensColorMap(map);
+    assert.strictEqual(slice.get().lensColorMap, map);
+  });
+
+  it('setLensAppliedColors accepts a map or null', () => {
+    const slice = makeSlice();
+    const map = new Map<number, [number, number, number, number]>([[1, [1, 0, 0, 1]]]);
+    slice.get().setLensAppliedColors(map);
+    assert.strictEqual(slice.get().lensAppliedColors, map);
+    slice.get().setLensAppliedColors(null);
+    assert.equal(slice.get().lensAppliedColors, null);
+  });
+
+  it('setLensHiddenIds replaces the set wholesale', () => {
+    const slice = makeSlice();
+    const ids = new Set([1, 2, 3]);
+    slice.get().setLensHiddenIds(ids);
+    assert.strictEqual(slice.get().lensHiddenIds, ids);
+  });
+
+  it('setLensAppliedHiddenIds replaces the array wholesale', () => {
+    const slice = makeSlice();
+    slice.get().setLensAppliedHiddenIds([1, 2]);
+    assert.deepStrictEqual(slice.get().lensAppliedHiddenIds, [1, 2]);
+    slice.get().setLensAppliedHiddenIds([]);
+    assert.deepStrictEqual(slice.get().lensAppliedHiddenIds, []);
+  });
+
+  it('setLensRuleIsolation sets and releases isolation', () => {
+    const slice = makeSlice();
+    const isolation = { ruleId: 'r1', entityIds: [10, 20] };
+    slice.get().setLensRuleIsolation(isolation);
+    assert.deepStrictEqual(slice.get().lensRuleIsolation, isolation);
+    slice.get().setLensRuleIsolation(null);
+    assert.equal(slice.get().lensRuleIsolation, null);
+  });
+
+  it('setLensRuleCounts and setLensRuleEntityIds replace their maps', () => {
+    const slice = makeSlice();
+    const counts = new Map([['r1', 5]]);
+    const ids = new Map([['r1', [1, 2, 3, 4, 5]]]);
+    slice.get().setLensRuleCounts(counts);
+    slice.get().setLensRuleEntityIds(ids);
+    assert.strictEqual(slice.get().lensRuleCounts, counts);
+    assert.strictEqual(slice.get().lensRuleEntityIds, ids);
+  });
+
+  it('setLensAutoColorLegend replaces the legend array', () => {
+    const slice = makeSlice();
+    const legend = [{ value: 'a', color: '#fff', count: 1 }];
+    slice.get().setLensAutoColorLegend(legend);
+    assert.strictEqual(slice.get().lensAutoColorLegend, legend);
+  });
+
+  it('setDiscoveredLensData sets and clears the discovered-data snapshot', () => {
+    const slice = makeSlice();
+    const data = { classes: ['IfcWall'], psets: [], quantities: [], materials: [] } as never;
+    slice.get().setDiscoveredLensData(data);
+    assert.strictEqual(slice.get().discoveredLensData, data);
+    slice.get().setDiscoveredLensData(null);
+    assert.equal(slice.get().discoveredLensData, null);
+  });
+});
+
+describe('lensSlice - mergeDiscoveredData', () => {
+  beforeEach(() => { installStubStorage(); });
+
+  it('is a no-op when nothing has been discovered yet', () => {
+    const slice = makeSlice();
+    assert.equal(slice.get().discoveredLensData, null);
+    slice.get().mergeDiscoveredData({ classes: ['IfcWall'] } as never);
+    assert.equal(slice.get().discoveredLensData, null,
+      'merging into a null snapshot must not fabricate one');
+  });
+
+  it('shallow-merges a patch into the existing snapshot, keeping untouched fields', () => {
+    const slice = makeSlice();
+    slice.get().setDiscoveredLensData({ classes: ['IfcWall'], psets: ['P1'] } as never);
+    slice.get().mergeDiscoveredData({ psets: ['P1', 'P2'] } as never);
+    assert.deepStrictEqual(slice.get().discoveredLensData, { classes: ['IfcWall'], psets: ['P1', 'P2'] });
+  });
+});
+
+describe('lensSlice - getActiveLens / exportLenses', () => {
+  beforeEach(() => { installStubStorage(); });
+
+  it('getActiveLens returns null when nothing is active', () => {
+    const slice = makeSlice();
+    assert.equal(slice.get().getActiveLens(), null);
+  });
+
+  it('getActiveLens returns the lens matching activeLensId', () => {
+    const slice = makeSlice();
+    slice.get().createLens(LENS);
+    slice.get().setActiveLens(LENS.id);
+    assert.equal(slice.get().getActiveLens()?.id, LENS.id);
+  });
+
+  it('getActiveLens returns null for a dangling id pointing at nothing', () => {
+    const slice = makeSlice();
+    slice.get().setActiveLens('no-such-lens');
+    assert.equal(slice.get().getActiveLens(), null);
+  });
+
+  it('exportLenses drops the ephemeral auto-color-from-list lens', () => {
+    const slice = makeSlice();
+    slice.get().activateAutoColorFromColumn({ source: 'attribute', attribute: 'Name' } as never, 'Name');
+    const exported = slice.get().exportLenses();
+    assert.ok(!exported.some((l) => l.id === 'auto-color-from-list'),
+      'the ephemeral lens must not round-trip through export/import');
+  });
+
+  it('exportLenses strips runtime-only fields, keeping id/name/rules/autoColor', () => {
+    const slice = makeSlice();
+    slice.get().createLens(LENS);
+    const exported = slice.get().exportLenses().find((l) => l.id === LENS.id);
+    assert.ok(exported);
+    assert.deepStrictEqual(Object.keys(exported!).sort(), ['id', 'name', 'rules'].sort());
+  });
+});
+
+describe('lensSlice - activateAutoColorFromColumn', () => {
+  beforeEach(() => { installStubStorage(); });
+
+  it('creates and activates an ephemeral auto-color lens, opening the panel', () => {
+    const slice = makeSlice();
+    slice.get().activateAutoColorFromColumn({ source: 'attribute', attribute: 'Level' } as never, 'Level');
+    assert.equal(slice.get().activeLensId, 'auto-color-from-list');
+    assert.equal(slice.get().lensPanelVisible, true);
+    assert.ok(slice.get().savedLenses.some((l) => l.id === 'auto-color-from-list'));
+  });
+
+  it('replaces a previous ephemeral lens rather than accumulating duplicates', () => {
+    const slice = makeSlice();
+    slice.get().activateAutoColorFromColumn({ source: 'attribute', attribute: 'Level' } as never, 'Level');
+    slice.get().activateAutoColorFromColumn({ source: 'attribute', attribute: 'Material' } as never, 'Material');
+    const matches = slice.get().savedLenses.filter((l) => l.id === 'auto-color-from-list');
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].name, 'Color by Material');
+  });
+});


### PR DESCRIPTION
## Summary
- Closes the coverage gap #2802 flags for `compareSlice` (roughly 11 of ~17 actions untested, including the run-result lifecycle called out specifically) and `lensSlice` (12 of 18 actions untested).
- `compareSlice.lifecycle.test.ts` covers every previously-untested setter plus the run-result state machine: idle -> running -> succeeded/failed, `clearCompare`'s exact reset set (`compareResult`/`compareRunning`/`compareError`/`compareSelectedKey`, explicitly leaving A/B/scope/blacklist/matching/`compareRunSeq` alone), and `compareRunSeq` monotonicity surviving a clear.
- `lensSlice.actions.test.ts` covers the remaining plain setters, `getActiveLens`/`exportLenses`, `mergeDiscoveredData`, `activateAutoColorFromColumn`, and specifically mutation-tests `setSavedLenses`'s `activeLensId` bookkeeping — the direct sibling of the #2765 `deleteLens` defect (a stale active pointer surviving a mutation that dropped the lens it pointed at).

No production code changed. Both slices were mutation-tested and found already correct; this PR only adds the missing regression coverage.

## Evidence
- Calibration: reverting `clearCompare` to skip resetting `compareError` was caught by the new suite (`compareSlice - run-result lifecycle` failed; 13/14 passed, 1 failed) — confirms the harness is sound.
- The interesting one: removing the `activeStillThere` guard from `lensSlice`'s `setSavedLenses` (i.e. never clearing `activeLensId` when the incoming snapshot drops the active lens) left the **pre-existing** 28-test suite fully green — the same blind spot #2765 found in `deleteLens`. The new test `clears activeLensId when the incoming snapshot drops the active lens (sibling of #2765)` catches it (RED confirmed, then reverted the mutation to restore GREEN).

## Test plan
- [x] `npx tsx --import ./src/test/vite-module-hooks.mjs --test src/store/slices/compareSlice.test.ts src/store/slices/compareSlice.lifecycle.test.ts src/store/slices/lensSlice.save-failure.test.ts src/store/slices/lensSlice.actions.test.ts` — 65/65 pass
- [x] Calibration + targeted mutations on both files, RED then reverted to GREEN (no net source diff)

Refs #2802. Not closing the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for compare workflows, including result updates, run sequencing, and state clearing.
  * Added coverage for lens management, including saved-lens handling, built-in restoration, active selection, exporting, discovered data, and automatic color lenses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->