### PR TITLE
fix(viewer): drop stale slab anchor when Split retargets a different element

### DIFF
--- a/.changeset/split-tool-retarget-stale-anchor.md
+++ b/.changeset/split-tool-retarget-stale-anchor.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the Split tool committing a slab cut against a stale anchor from a different element.
+
+`setSplitTarget` preserved `splitMode: 'first-anchor'` whenever the slice was mid-slab-cut, regardless of whether the new target was the same element the anchor was latched against. Retargeting Split to a different element — e.g. picking a different row in the Hierarchy panel and re-triggering "Split selected entity" from the Command Palette while a slab's first click was still latched — moved `splitTargetModelId`/`splitTargetExpressId` to the new element but left `slabCutAnchor`/`slabCutFootprint`/`slabCutStoreyElevation` pointing at the old one. The next click then committed `splitSlabByLine` against the new target using an anchor point and footprint from an unrelated slab's coordinate space.
+
+`setSplitTarget` now only preserves the latched anchor when the retarget re-enters the *same* element; retargeting to anything else drops back to `'idle'` and clears the anchor/footprint/elevation, matching what `clearSplitHover` already does for every other exit path.

--- a/apps/viewer/src/store/slices/splitToolSlice.retarget.test.ts
+++ b/apps/viewer/src/store/slices/splitToolSlice.retarget.test.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { createSplitToolSlice, type SplitToolSlice } from './splitToolSlice.js';
+
+describe('SplitToolSlice — setSplitTarget while a slab anchor is latched (#2802)', () => {
+  let state: SplitToolSlice;
+  let setState: (partial: Partial<SplitToolSlice> | ((s: SplitToolSlice) => Partial<SplitToolSlice>)) => void;
+
+  beforeEach(() => {
+    setState = (partial) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createSplitToolSlice(setState, () => state, {} as never);
+  });
+
+  it('re-entering the SAME slab preserves the latched anchor', () => {
+    state.setSplitTarget('modelA', 100);
+    state.setSlabCutAnchor([1, 2], [[0, 0], [5, 0], [5, 5], [0, 5]], 0);
+    // Re-targeting the identical element (e.g. re-triggering Split from the
+    // Command Palette on the slab still selected) should not drop the
+    // in-progress two-click flow.
+    state.setSplitTarget('modelA', 100);
+    assert.strictEqual(state.splitMode, 'first-anchor');
+    assert.deepStrictEqual(state.slabCutAnchor, [1, 2]);
+  });
+
+  it('retargeting to a DIFFERENT element clears the previous slab anchor and drops first-anchor mode', () => {
+    // First click on slab A latches a two-click anchor against A's footprint.
+    state.setSplitTarget('modelA', 100);
+    state.setSlabCutAnchor([1, 2], [[0, 0], [5, 0], [5, 5], [0, 5]], 0);
+    assert.strictEqual(state.splitMode, 'first-anchor');
+
+    // Before the second click commits, the user retargets Split to a
+    // different element — e.g. clicking a different row in the Hierarchy
+    // panel (which freely calls setSelectedEntityId regardless of
+    // activeTool) and then re-invoking "Split selected entity" from the
+    // Command Palette, which calls setSplitTarget unconditionally.
+    state.setSplitTarget('modelB', 200);
+
+    assert.strictEqual(
+      state.splitTargetModelId, 'modelB',
+      'target model must follow the retarget',
+    );
+    assert.strictEqual(
+      state.splitTargetExpressId, 200,
+      'target express id must follow the retarget',
+    );
+    // The slab anchor belonged to modelA/100's footprint. Once the target
+    // has moved to an unrelated element, a stale anchor from the OLD
+    // target must not survive — otherwise the second click commits
+    // splitSlabByLine(modelB, 200, <modelA's anchor coordinates>), cutting
+    // the new target along a line anchored in the wrong slab's coordinate
+    // space.
+    assert.strictEqual(
+      state.slabCutAnchor, null,
+      'stale anchor from the previous target must be cleared on retarget',
+    );
+    assert.strictEqual(state.slabCutFootprint, null);
+    assert.strictEqual(state.slabCutStoreyElevation, null);
+    assert.strictEqual(
+      state.splitMode, 'idle',
+      'first-anchor state must not survive a retarget to a different element',
+    );
+  });
+});

--- a/apps/viewer/src/store/slices/splitToolSlice.ts
+++ b/apps/viewer/src/store/slices/splitToolSlice.ts
@@ -111,20 +111,32 @@ export const createSplitToolSlice: StateCreator<SplitToolSlice, [], [], SplitToo
   slabCutStoreyElevation: null,
 
   setSplitTarget: (modelId, expressId) =>
-    set((s) => ({
-      splitTargetModelId: modelId,
-      splitTargetExpressId: expressId,
-      // Entering / leaving a target without a hover yet means we're
-      // back to 'idle' (unless we're mid-slab-cut, in which case
-      // we preserve the latched anchor — the user might re-enter
-      // the slab from outside).
-      splitMode: s.splitMode === 'first-anchor' ? 'first-anchor' : 'idle',
-      splitHoverPoint: null,
-      splitHoverDistance: null,
-      splitHoverLength: null,
-      splitHoverCutPoint: null,
-      splitHoverAxisDirection: null,
-    })),
+    set((s) => {
+      // Mid-slab-cut ('first-anchor'), we preserve the latched anchor only
+      // when the retarget is a no-op re-entry of the SAME element (the user
+      // re-triggering Split on the slab they're already cutting). A retarget
+      // to a genuinely different element — e.g. the Command Palette's
+      // "Split selected entity" firing after the user picked a different
+      // row in the Hierarchy panel while mid-anchor — must drop the stale
+      // anchor/footprint: they belong to the OLD target's coordinate space,
+      // and committing them against the new target would cut it along a
+      // meaningless line (#2802).
+      const sameTarget = s.splitTargetModelId === modelId && s.splitTargetExpressId === expressId;
+      const preserveAnchor = sameTarget && s.splitMode === 'first-anchor';
+      return {
+        splitTargetModelId: modelId,
+        splitTargetExpressId: expressId,
+        splitMode: preserveAnchor ? 'first-anchor' : 'idle',
+        splitHoverPoint: null,
+        splitHoverDistance: null,
+        splitHoverLength: null,
+        splitHoverCutPoint: null,
+        splitHoverAxisDirection: null,
+        ...(preserveAnchor
+          ? {}
+          : { slabCutAnchor: null, slabCutFootprint: null, slabCutStoreyElevation: null }),
+      };
+    }),
   setSplitHover: (hoverPoint, distance, length, cutPoint, axisDirection) =>
     set((s) => ({
       splitHoverPoint: hoverPoint,


### PR DESCRIPTION
## Summary
- Part of the #2802 zero-coverage slice sweep, going deep on `splitToolSlice.ts` (the largest/most stateful of the assigned slices).
- `setSplitTarget` preserved `splitMode: 'first-anchor'` whenever the slice was mid-slab-cut, regardless of whether the new target was the element the anchor was latched against.
- Retargeting Split to a *different* element — e.g. the Command Palette's "Split selected entity" firing after the user picked a different row in the Hierarchy panel while a slab's first click was still latched — moved `splitTargetModelId`/`splitTargetExpressId` to the new element but left `slabCutAnchor`/`slabCutFootprint`/`slabCutStoreyElevation` pointing at the old one. The next click committed `splitSlabByLine` against the new target using an anchor point and footprint from an unrelated slab's coordinate space.
- `setSplitTarget` now only preserves the latched anchor on a same-element retarget; anything else drops back to `'idle'` and clears the anchor state, matching `clearSplitHover`'s existing full reset.

Demonstrated with a store harness before fixing (RED), see the added test.

## Test plan
- [x] `apps/viewer/src/store/slices/splitToolSlice.retarget.test.ts` — new: RED (assertion failure quoted in PR discussion) before the fix, GREEN after.
- [x] Full `src/store/**/*.test.ts` suite (787 tests) passes.
- [x] `tsc --noEmit` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Split tool retargeting to preserve a latched slab-cut anchor only when selecting the same element.
  - Retargeting to a different element now resets split mode and clears stale anchor, footprint, and elevation data.
  - Added coverage for retaining and clearing split-tool state during retargeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->