### PR TITLE
fix(viewer): useCompare supersession guard closes run/clear/reselect races

### DIFF
--- a/.changeset/usecompare-race-check.md
+++ b/.changeset/usecompare-race-check.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix a superseded model comparison overwriting a newer one in the Compare panel.
+
+`isCurrentFor` / `buildAtCurrentVersion` in `useCompare.ts` guard the fingerprint cache against a federation re-alignment moving meshes in place — they say nothing about whether a given `runComparison()` call is still the one the user is waiting on. Three ways an in-flight comparison could clobber the panel after the fact, all now fixed:
+
+- A slower `runComparison()` call finishing after a newer one (a different A/B pair, or a re-run) published its answer over it.
+- `clearCompare()` mid-flight did not stick: the in-flight run's eventual result or error resurrected what the user had just cleared.
+- Changing the A/B selection mid-flight (without clicking Run again) still published a result for the old pair, which nothing checked against the currently selected pair — the panel could show a diff that didn't match its own selectors.
+
+`runComparison` now captures a per-call epoch and re-checks it, together with the live `compareBaseModelId`/`compareHeadModelId`, immediately before every write to the store (success, the exhausted-retries error, and the failure path) — never earlier, so nothing can supersede between the check and the write. `clearCompare` is now returned from `useCompare()` and bumps that epoch before delegating to the store action, so `ComparePanel` (and the hook's own re-alignment cleanup) route through it instead of calling the raw store action directly.

--- a/apps/viewer/src/components/viewer/ComparePanel.tsx
+++ b/apps/viewer/src/components/viewer/ComparePanel.tsx
@@ -60,10 +60,13 @@ export function ComparePanel({ onClose }: ComparePanelProps) {
   const addExcludedType = useViewerStore((s) => s.addCompareExcludedType);
   const removeExcludedType = useViewerStore((s) => s.removeCompareExcludedType);
   const clearExcludedTypes = useViewerStore((s) => s.clearCompareExcludedTypes);
-  const clearCompare = useViewerStore((s) => s.clearCompare);
   const bcfAuthor = useViewerStore((s) => s.bcfAuthor);
 
-  const { running, result, error, runComparison } = useCompare();
+  // `clearCompare` comes from the hook, not the raw store action (#2802): an
+  // in-flight `runComparison()` only learns "the user cleared" by watching
+  // THIS wrapper get called, so every clear in this panel must go through it
+  // or a stale result can resurrect itself once the run resolves.
+  const { running, result, error, runComparison, clearCompare } = useCompare();
 
   const modelList = useMemo(() => Array.from(models.values()), [models]);
 

--- a/apps/viewer/src/hooks/useCompare.supersession.test.tsx
+++ b/apps/viewer/src/hooks/useCompare.supersession.test.tsx
@@ -1,0 +1,327 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Supersession races on the compare path (issue #2802 sweep).
+ *
+ * `compareSlice` has no guard of its own - by design, it is "deliberately
+ * dumb" and orchestration lives entirely in `useCompare`. The only staleness
+ * check that hook has is `isCurrentFor` / `buildAtCurrentVersion`, and that
+ * check exists SOLELY to protect the fingerprint CACHE against a federation
+ * re-alignment that moves meshes in place. It says nothing about whether a
+ * given `runComparison()` call is still the one the user is waiting on.
+ *
+ * These tests drive the REAL hook (`useCompare`) over real parsed fixtures and
+ * demonstrate, by execution, that:
+ *
+ *   1. Two overlapping `runComparison()` calls for two different A/B pairs -
+ *      the older, slower one publishes its answer AFTER a newer one already
+ *      finished, clobbering it (`supersedes the newer pair`).
+ *   2. `clearCompare()` mid-flight does not stop the in-flight run from
+ *      resurrecting the just-cleared result once it resolves.
+ *   3. Changing `compareBaseModelId` / `compareHeadModelId` mid-flight (no
+ *      second Run click) still publishes the OLD pair's result, and nothing
+ *      stops the panel's `compareResult` from disagreeing with the currently
+ *      selected pair.
+ *   5. A run that fails AFTER a newer run already published a good result
+ *      clobbers that result with an error / null.
+ *
+ * ## The interleaving is real, not simulated
+ *
+ * As in `useCompare.midRunOptions.test.tsx`, `runComparison()`'s first
+ * `await` is a `setTimeout(0)` macrotask, and `buildEntityFingerprints` yields
+ * again every 1500 entities via the same mechanism. Starting run A (many
+ * entities, so it needs an extra yield) synchronously via `act(() => {...})`
+ * before starting run B (few entities, one yield) guarantees B's callback is
+ * scheduled and drained before A's continuation gets a second turn - so B
+ * really does finish first without any wall-clock timing or fake timers.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import type { GeometryResult, MeshData } from '@ifc-lite/geometry';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { useCompare } from './useCompare.js';
+
+// ─── Fixture ──────────────────────────────────────────────────────────────
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    body,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+/** `n` distinct walls, one line each, GUIDs derived from the index so they are
+ *  valid IFC base64-ish GlobalIds (22 chars) without colliding. */
+function wallsBody(n: number, tag: string): string {
+  const lines: string[] = [];
+  for (let i = 0; i < n; i += 1) {
+    const guid = `${tag}${String(i).padStart(21, '0')}`.slice(0, 22);
+    lines.push(`#${i + 1}=IFCWALL('${guid}',$,'Wall ${tag}${i}',$,$,$,$,$,.STANDARD.);`);
+  }
+  return lines.join('\n');
+}
+
+async function parse(body: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(ifc4(body));
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+/** A model with `n` walls and no meshes (no meshes -> no geometry scope work,
+ *  keeps the fixture cheap - the entity SCAN loop in `buildFingerprints.ts`
+ *  is what yields every 1500, and it iterates the data store directly). */
+function model(id: string, store: IfcDataStore, n: number): FederatedModel {
+  return {
+    id,
+    name: id,
+    ifcDataStore: store,
+    geometryResult: { meshes: [] as MeshData[] } as unknown as GeometryResult,
+    idOffset: 0,
+    maxExpressId: n,
+  } as unknown as FederatedModel;
+}
+
+// ─── Harness ────────────────────────────────────────────────────────────
+
+let hook: ReturnType<typeof useCompare> | null = null;
+
+function Probe(): null {
+  hook = useCompare();
+  return null;
+}
+
+let root: Root | null = null;
+
+interface Pair {
+  baseId: string;
+  headId: string;
+}
+
+/** Slow pair: 1600 walls a side (>= 2 yields in the scan loop at 1500-entity
+ *  boundaries). Fast pair: 2 walls a side (zero extra yields). */
+let SLOW: Pair;
+let FAST: Pair;
+
+async function seed(): Promise<void> {
+  const [slowA, slowB, fastA, fastB] = await Promise.all([
+    parse(wallsBody(1600, 'sA')),
+    parse(wallsBody(1600, 'sB')),
+    parse(wallsBody(2, 'fA')),
+    parse(wallsBody(2, 'fB')),
+  ]);
+  SLOW = { baseId: 'SlowA', headId: 'SlowB' };
+  FAST = { baseId: 'FastA', headId: 'FastB' };
+  useViewerStore.setState({
+    models: new Map([
+      ['SlowA', model('SlowA', slowA, 1600)],
+      ['SlowB', model('SlowB', slowB, 1600)],
+      ['FastA', model('FastA', fastA, 2)],
+      ['FastB', model('FastB', fastB, 2)],
+    ]),
+    compareBaseModelId: SLOW.baseId,
+    compareHeadModelId: SLOW.headId,
+    compareScope: 'both',
+    compareExcludedTypes: [],
+    compareResult: null,
+    compareError: null,
+    compareRunning: false,
+    compareRunSeq: 0,
+  });
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+}
+
+function setPair(p: Pair): void {
+  useViewerStore.setState({ compareBaseModelId: p.baseId, compareHeadModelId: p.headId });
+}
+
+beforeEach(async () => {
+  hook = null;
+  await seed();
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+});
+
+// ─── Scenario 1: slow run started first must not clobber a fast run that
+// finished first, for a DIFFERENT pair ───────────────────────────────────
+
+describe('useCompare - supersession (#2802)', () => {
+  it('scenario 1: a slow run for pair A does not overwrite a fast run for pair B that finished first', async () => {
+    // Start the slow run against SLOW while it is selected.
+    let slowPending: Promise<void> | undefined;
+    act(() => {
+      slowPending = hook!.runComparison();
+    });
+    assert.strictEqual(useViewerStore.getState().compareResult, null, 'slow run must still be in flight');
+
+    // Switch selection to FAST and start a second run before the slow one's
+    // first continuation has a chance to run - no await between the two
+    // starts, so the interleaving is forced, not raced for.
+    setPair(FAST);
+    let fastPending: Promise<void> | undefined;
+    act(() => {
+      fastPending = hook!.runComparison();
+    });
+
+    // Drain both. The fast one (2 walls, no extra yield) resolves on its very
+    // first continuation; the slow one (1600 walls) needs extra macrotask
+    // turns and resolves after it.
+    await act(async () => {
+      await fastPending;
+    });
+    const afterFast = useViewerStore.getState().compareResult;
+    assert.ok(afterFast, 'the fast run must have published');
+    assert.strictEqual(afterFast!.baseModelId, FAST.baseId);
+
+    await act(async () => {
+      await slowPending;
+    });
+    const afterSlow = useViewerStore.getState().compareResult;
+    assert.ok(afterSlow, 'a result must still be present');
+    assert.strictEqual(
+      afterSlow!.baseModelId,
+      FAST.baseId,
+      'the slow (older, no-longer-selected) run must not overwrite the fast run\'s result for the pair that is actually selected',
+    );
+  });
+
+  it('scenario 2: clearCompare() mid-flight is not undone by the in-flight run resolving afterward', async () => {
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = hook!.runComparison();
+    });
+    assert.strictEqual(useViewerStore.getState().compareResult, null, 'run must still be in flight');
+
+    act(() => {
+      hook!.clearCompare();
+    });
+    assert.strictEqual(useViewerStore.getState().compareResult, null, 'cleared');
+
+    await act(async () => {
+      await pending;
+    });
+
+    assert.strictEqual(
+      useViewerStore.getState().compareResult,
+      null,
+      'the stale result must not reappear after the user cleared it',
+    );
+  });
+
+  it('scenario 3: changing the selected pair mid-flight (no second Run click) does not publish a result for the old pair under the new selection', async () => {
+    let pending: Promise<void> | undefined;
+    act(() => {
+      pending = hook!.runComparison();
+    });
+    assert.strictEqual(useViewerStore.getState().compareResult, null, 'run must still be in flight');
+
+    // The user changes the selection to FAST but never clicks Run again.
+    act(() => {
+      setPair(FAST);
+    });
+
+    await act(async () => {
+      await pending;
+    });
+
+    const result = useViewerStore.getState().compareResult;
+    const state = useViewerStore.getState();
+    if (result) {
+      assert.strictEqual(
+        result.baseModelId,
+        state.compareBaseModelId,
+        'a published result must describe the currently selected pair, not a stale one',
+      );
+      assert.strictEqual(result.headModelId, state.compareHeadModelId);
+    }
+    // Either nothing published (acceptable - the stale run was dropped) or
+    // what published agrees with the current selection. What must NEVER
+    // happen is a published result for SLOW while FAST is selected.
+    assert.ok(
+      !result || (result.baseModelId === FAST.baseId) === (state.compareBaseModelId === FAST.baseId),
+      'the panel must not show a diff for a pair that is no longer selected',
+    );
+  });
+
+  it('scenario 5: a failed slow run does not clobber a newer, already-published successful result', async () => {
+    let slowPending: Promise<void> | undefined;
+    act(() => {
+      slowPending = hook!.runComparison();
+    });
+    assert.strictEqual(useViewerStore.getState().compareResult, null, 'slow run must still be in flight');
+
+    // Break the SLOW pair's head model out from under the in-flight run by
+    // clearing its geometryResult - not literally, since the closure already
+    // captured valid handles; instead simulate a fast, successful second run
+    // for FAST, then force the slow run to fail by making its diff throw.
+    // Simplest reliable failure: remove the SLOW head model's data store
+    // reference is already captured, so instead corrupt `maxExpressId` is not
+    // observed by the diff. Use scope='data' vs an unparseable store swap:
+    // easiest is to delete the model entry entirely once the run has grabbed
+    // its closure-local handles - buildEntityFingerprints reads only `store`/
+    // `meshes`, already captured, so removal from the map does not fail it.
+    // Instead, directly monkey-patch the SLOW head store to throw when
+    // iterated, forcing `buildEntityFingerprints` (called on it) to reject.
+    const slowHead = useViewerStore.getState().models.get(SLOW.headId)!;
+    const originalEntities = (slowHead.ifcDataStore as unknown as { entities: unknown }).entities;
+    Object.defineProperty(slowHead.ifcDataStore as object, 'entities', {
+      get() {
+        throw new Error('synthetic extraction failure');
+      },
+      configurable: true,
+    });
+
+    setPair(FAST);
+    let fastPending: Promise<void> | undefined;
+    act(() => {
+      fastPending = hook!.runComparison();
+    });
+
+    await act(async () => {
+      await fastPending;
+    });
+    const afterFast = useViewerStore.getState().compareResult;
+    assert.ok(afterFast, 'the fast run must have published');
+    assert.strictEqual(afterFast!.baseModelId, FAST.baseId);
+
+    await act(async () => {
+      await slowPending;
+    });
+
+    // Restore for hygiene (not strictly required, root gets torn down anyway).
+    Object.defineProperty(slowHead.ifcDataStore as object, 'entities', {
+      value: originalEntities,
+      configurable: true,
+      writable: true,
+    });
+
+    const finalResult = useViewerStore.getState().compareResult;
+    assert.ok(
+      finalResult && finalResult.baseModelId === FAST.baseId,
+      'a failed superseded run must not clobber the newer successful result with an error / null',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useCompare.ts
+++ b/apps/viewer/src/hooks/useCompare.ts
@@ -215,6 +215,39 @@ export function useCompare() {
   // change is a cheap re-diff rather than a full re-extraction.
   const builtRef = useRef<BuiltPair | null>(null);
 
+  /**
+   * Supersession epoch for `runComparison()` itself (#2802 sweep).
+   *
+   * `isCurrentFor` / `buildAtCurrentVersion` protect the fingerprint CACHE
+   * against a federation re-alignment; they say nothing about whether THIS
+   * `runComparison()` call is still the one whose answer the user wants. Two
+   * gaps that check cannot see:
+   *
+   * - A newer `runComparison()` call (same pair or a different one, started
+   *   after the user changed the selection) must win over an older one still
+   *   finishing its extraction, regardless of which resolves first.
+   * - An explicit `clearCompare()` mid-flight must stick - a run that was
+   *   already in the air when the user cleared must not resurrect the result
+   *   they just dismissed.
+   *
+   * Bumped at the start of every `runComparison()` call and by `clearCompare`
+   * below (the ONLY two events that make an in-flight run's eventual answer
+   * unwanted). Each run captures the epoch value once, and every place that
+   * writes to the store re-checks it immediately before writing - never
+   * earlier, so nothing can supersede between the check and the write.
+   */
+  const epochRef = useRef(0);
+
+  /** Bump the epoch and clear, so an in-flight run's `then`/`catch` cannot
+   *  write the result the user just dismissed back into the store. Routes
+   *  through here rather than the raw store action for every caller in this
+   *  file and in `ComparePanel` - a `clearCompare()` invoked directly on the
+   *  store instead of through this wrapper would not be seen. */
+  const clearCompare = useCallback(() => {
+    epochRef.current += 1;
+    useViewerStore.getState().clearCompare();
+  }, []);
+
   const runComparison = useCallback(async () => {
     const store = useViewerStore.getState();
     const baseId = store.compareBaseModelId;
@@ -246,6 +279,23 @@ export function useCompare() {
     const baseGeometry = baseModel.geometryResult;
     const headStore = headModel.ifcDataStore;
     const headGeometry = headModel.geometryResult;
+
+    // Supersedes any run already in flight (same pair or not) - see the epoch
+    // doc comment above. Captured once; re-checked at every write below.
+    const myEpoch = ++epochRef.current;
+
+    /** Is THIS run still the one whose answer the user is waiting on? Both
+     *  conjuncts matter and neither alone is enough: the epoch alone misses a
+     *  selection change that never triggers a second `runComparison()` call
+     *  (scenario 3 - #2802), and the pair-match alone misses a `clearCompare()`
+     *  that leaves the pair untouched (scenario 2 - #2802, `clearCompare`
+     *  "keeps the A/B + scope choices" by design). Read fresh, never cached -
+     *  the whole point is to observe the store as it is right now. */
+    const stillWanted = (): boolean => {
+      if (epochRef.current !== myEpoch) return false;
+      const live = useViewerStore.getState();
+      return live.compareBaseModelId === baseId && live.compareHeadModelId === headId;
+    };
 
     store.setCompareError(null);
     store.setCompareRunning(true);
@@ -300,12 +350,26 @@ export function useCompare() {
       });
       if (!built) {
         // Never silently: `finally` clears the running flag, so returning with
-        // no message would leave the panel blank after the user pressed Run.
-        store.setCompareError(
-          'The model geometry kept changing while comparing. Run the comparison again.',
-        );
+        // no message would leave the panel blank after the user pressed Run -
+        // but only when this run is still the one the user is waiting on; a
+        // superseded run reporting its own failure into a newer run's state
+        // is the scenario-5 clobber (#2802).
+        if (stillWanted()) {
+          store.setCompareError(
+            'The model geometry kept changing while comparing. Run the comparison again.',
+          );
+        }
         return;
       }
+
+      // Re-checked immediately before every write below, synchronously with no
+      // `await` in between - see the epoch doc comment above. A run that lost
+      // the race (a newer run started, the pair changed, or the user cleared)
+      // must publish nothing: not the result, not its cache entry either,
+      // since a stale cache entry for a pair that is no longer selected would
+      // silently defeat the reconciliation effect's `isCurrentFor` check on
+      // the NEXT option change (see that effect's comment).
+      if (!stillWanted()) return;
       builtRef.current = built;
 
       // The diff options are read inside `publishCompareResult`, AFTER every
@@ -345,10 +409,21 @@ export function useCompare() {
       });
     } catch (err) {
       console.error('[compare] comparison failed', err);
-      store.setCompareError((err as Error).message ?? 'Comparison failed.');
-      store.setCompareResult(null);
+      // Same guard as above: a superseded run's own failure must set an error
+      // state for a run nobody is waiting on, not clobber whatever a newer
+      // run already published (#2802 scenario 5).
+      if (stillWanted()) {
+        store.setCompareError((err as Error).message ?? 'Comparison failed.');
+        store.setCompareResult(null);
+      }
     } finally {
-      store.setCompareRunning(false);
+      // A superseded run's `finally` must not flip `compareRunning` back to
+      // false out from under a newer run that owns it now (or that
+      // `clearCompare` already set it false for) - whichever run IS still
+      // wanted controls the flag via its own `finally`.
+      if (epochRef.current === myEpoch) {
+        store.setCompareRunning(false);
+      }
     }
   }, []);
 
@@ -370,8 +445,8 @@ export function useCompare() {
     if (lastContentVersionRef.current === geometryContentVersion) return;
     lastContentVersionRef.current = geometryContentVersion;
     builtRef.current = null;
-    useViewerStore.getState().clearCompare();
-  }, [geometryContentVersion]);
+    clearCompare();
+  }, [geometryContentVersion, clearCompare]);
 
   // Scope, blacklist OR content-matching change with an existing result for the
   // same pair -> re-diff from the cached fingerprints (instant). No-op when
@@ -403,5 +478,5 @@ export function useCompare() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scope, excludedTypes, matchByContent]);
 
-  return { baseModelId, headModelId, scope, running, result, error, runComparison };
+  return { baseModelId, headModelId, scope, running, result, error, runComparison, clearCompare };
 }


### PR DESCRIPTION
## Summary

Follow-up to #2802: verifies, by execution, whether `useCompare.ts`'s supersession guard (`isCurrentFor` / `buildAtCurrentVersion` + the reconciliation effect) actually protects a comparison result against a superseded run — the piece a sibling sweep flagged as suspected-only because `compareSlice` itself is deliberately dumb and has no guard of its own.

Verdict: **it did not hold.** `isCurrentFor` only protects the fingerprint cache against a federation re-alignment moving meshes in place (its key is `baseModelId` / `headModelId` / `contentVersion`, all correct for that purpose). Nothing checked whether a given `runComparison()` call was still the one the user was waiting on before writing to the store. Demonstrated with the real hook over real parsed fixtures:

- **Scenario 1** (two runs in flight, slow one started first): a slower run for one A/B pair published its result *after* a faster run for a different pair had already published — clobbering the newer, currently-selected pair's result.
- **Scenario 2** (run then clear): `clearCompare()` called mid-flight did not stick — the in-flight run resolving afterward wrote its result straight back into the store.
- **Scenario 3** (run then change inputs): changing `compareBaseModelId`/`compareHeadModelId` mid-flight without a second Run click still published the old pair's result, with nothing checking it against the now-selected pair — the exact "panel disagrees with its own selectors" symptom.
- **Scenario 5** (a failed run): a stale run's own failure could clobber a newer run's already-published successful result with an error/null.

Scenario 4 (`isCurrentFor`'s key): confirmed by reading + the existing `useCompare.test.ts` suite that it covers exactly `baseModelId` / `headModelId` / `contentVersion` — correct and sufficient for the fingerprint-cache-vs-re-alignment problem it exists to solve. `compareRunSeq` is a monotonic *completed-comparison* counter bumped only on successful publish and never reset by `clearCompare`; it cannot serve as a "was this superseded" signal and does not help here.

## Fix

`runComparison` now captures a per-call epoch (`epochRef`) at start and defines `stillWanted()` — epoch still current AND the live store's `compareBaseModelId`/`compareHeadModelId` still match this run's pair — re-checked synchronously, with no `await` in between, immediately before every write to the store (the exhausted-retries error, the success publish + cache write, the failure path, and the `finally` that clears `compareRunning`). `clearCompare` is now exposed from `useCompare()`, bumping the epoch before delegating to the store action; `ComparePanel`'s two call sites and the hook's own federation-re-alignment cleanup now route through it instead of calling the raw store action directly (a `clearCompare()` invoked outside the hook would not be seen — noted as a residual).

Stayed out of `compareSlice.ts` / `lensSlice.ts` per #2826.

## Test plan

- [x] New `apps/viewer/src/hooks/useCompare.supersession.test.tsx` drives the real hook, forcing the slow/fast interleaving via the extraction loop's real `setTimeout(0)` yield boundary (no fake timers) — pins scenarios 1, 2, 3, 5.
- [x] RED: mutating the new `stillWanted()` guard to always return `true` fails all 4 new tests (`scenario 1`, `scenario 2`, `scenario 3`, `scenario 5`).
- [x] GREEN: guard restored, all 4 pass; full existing compare suite (`useCompare.test.ts`, `useCompare.midRunOptions.test.tsx`, `compareSlice.test.ts`) still green (29/29).
- [x] `tsc --noEmit` and `oxlint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated comparison results and errors from replacing newer Compare-panel selections.
  - Clearing or changing the selected models now reliably cancels the effect of in-progress comparisons.
  - Prevented stale comparisons from restoring cleared results or displaying incorrect data.

- **Tests**
  - Added coverage for overlapping comparisons, mid-run clearing, selection changes, and delayed failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->