### PR TITLE
fix(collab): reset room state when startCollab fails to bring up a session

### DIFF
--- a/.changeset/collab-start-failure-resets-room-state.md
+++ b/.changeset/collab-start-failure-resets-room-state.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Reset `collabRoomId`, `collabRole` and `collabSelfToken` when `startCollab` fails to bring up a session, instead of leaving them naming the room that never started. `startCollab` sets those three fields synchronously (so an early `ShareDialog` subscriber sees the join token) before it awaits `createCollabSession`; if that rejects — for example a browser without IndexedDB, or a WebSocket provider that never connects — the failure handler cleared `collabConnecting` and `collabStatus` but left the room id, role and token in place with no live session behind them. Anything reading "is `collabRoomId` set" as "still in a room" (the toolbar indicator, the Share dialog) kept showing a joined room, and `canCollabEdit()` / `canCollabComment()` — the gate `mutationSlice` checks every write against — kept applying the failed room's role instead of falling back to single-user editing rules, silently blocking edits for a viewer/commenter role even though the session that role belonged to never came up.

--- a/apps/viewer/src/store/slices/collabSlice.session-failure.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.session-failure.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `startCollab`'s own `try { ... } catch (err)` around session creation
+ * (collabSlice.ts, roughly :562) resets `collabConnecting` and `collabStatus`
+ * on failure, but not `collabRoomId` / `collabRole` / `collabSelfToken` —
+ * all three set synchronously just before the try block, before any session
+ * exists. If `collab.createCollabSession(...)` rejects (for example
+ * `createIndexedDbProvider` throwing because `indexedDB` is undefined outside
+ * a browser — exactly the Node test/CI environment), the slice is left with
+ * `collabSession: null` but `collabRoomId` / `collabRole` / `collabSelfToken`
+ * still naming the room that failed to start. Any UI keyed off "is
+ * `collabRoomId` set" (the toolbar indicator, ShareDialog) reads this as
+ * "still in the room", and `canCollabEdit()`/`canCollabComment()` — the gate
+ * every write in mutationSlice is checked against — apply the failed room's
+ * role instead of falling back to single-user rules.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCollabSlice, type CollabRole, type CollabSlice } from './collabSlice.js';
+import type { ViewerState } from '../index.js';
+
+function buildSlice(overrides: Record<string, unknown> = {}) {
+  let state: Record<string, unknown> = {
+    models: new Map(),
+    activeModelId: null,
+    ifcDataStore: null,
+    setEditEnabled: () => {},
+    upsertModel: () => {},
+    updateModel: () => {},
+    removeModel: () => {},
+    setIfcDataStore: () => {},
+    setGeometryResult: () => {},
+    ...overrides,
+  };
+  const setState = (partial: unknown) => {
+    const patch =
+      typeof partial === 'function'
+        ? (partial as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+        : (partial as Record<string, unknown>);
+    state = { ...state, ...patch };
+  };
+  const slice = createCollabSlice(setState as never, (() => state) as never, {} as never) as CollabSlice;
+  state = { ...slice, ...state };
+  return { get: () => state as unknown as ViewerState & CollabSlice };
+}
+
+describe('collabSlice.startCollab — session-creation failure leaves stale room state', () => {
+  it('resets collabRoomId/collabRole/collabSelfToken (not just collabStatus) when the session never comes up', async () => {
+    // No global `indexedDB` in this Node test process, so the real
+    // `@ifc-lite/collab#createCollabSession` (provider 'indexeddb', the
+    // default with no configured collab server) rejects inside the awaited
+    // dynamic import — driving startCollab's REAL catch path, not a stand-in.
+    assert.equal(typeof (globalThis as { indexedDB?: unknown }).indexedDB, 'undefined');
+
+    const s = buildSlice();
+    await s.get().startCollab({ roomId: 'room-1', role: 'editor', token: 'tok' });
+
+    const after = s.get();
+    assert.equal(after.collabSession, null, 'no session was created');
+    assert.equal(after.collabStatus, 'disconnected');
+    assert.equal(after.collabConnecting, false);
+
+    // The bug: these three were set (synchronously, before the try) to make
+    // the join token available to early subscribers, and the failure path
+    // never rolls them back.
+    assert.equal(
+      after.collabRoomId,
+      null,
+      'a room the session failed to join must not still be recorded as current',
+    );
+    assert.equal(
+      after.collabRole,
+      null as CollabRole | null,
+      'a stale role gates canCollabEdit/canCollabComment as if a session were live',
+    );
+    assert.equal(after.collabSelfToken, null, 'a stale token must not survive a failed join');
+  });
+});

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -562,7 +562,24 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('[collab] failed to start session:', err);
-      set({ collabConnecting: false, collabStatus: 'disconnected' });
+      // `collabRoomId` / `collabRole` / `collabSelfToken` were set synchronously
+      // above, before any session existed, so a UI reading "collabRoomId is set"
+      // as "still in the room" (the toolbar indicator, ShareDialog) — and
+      // canCollabEdit()/canCollabComment(), which mutationSlice gates every
+      // write on — must not keep applying a room/role that never actually
+      // started. Guarded on collabRoomId still matching this attempt so a
+      // newer start/stop that ran while we awaited isn't clobbered here.
+      if (get().collabRoomId === roomId) {
+        set({
+          collabConnecting: false,
+          collabStatus: 'disconnected',
+          collabRoomId: null,
+          collabRole: null,
+          collabSelfToken: null,
+        });
+      } else {
+        set({ collabConnecting: false, collabStatus: 'disconnected' });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

Part of the #2802 defect sweep of `collabSlice.ts`. `startCollab` sets `collabRoomId`, `collabRole` and `collabSelfToken` synchronously, before awaiting `createCollabSession`, so an early subscriber (e.g. `ShareDialog`) sees the join token. If `createCollabSession` then rejects — e.g. no `IndexedDB` (headless/non-browser), or a WebSocket provider that never connects — the catch block reset `collabConnecting`/`collabStatus` but left `collabRoomId`/`collabRole`/`collabSelfToken` naming the room that never actually started, with no live session behind them.

- Anything reading "`collabRoomId` is set" as "still in a room" (toolbar indicator, Share dialog) kept showing a joined room.
- `canCollabEdit()` / `canCollabComment()` — the gate `mutationSlice` checks every write against — kept applying the failed room's role instead of falling back to single-user editing rules, so a viewer/commenter role from a room that never came up could silently block local edits.

The fix resets the three fields on failure, guarded on `collabRoomId` still matching this attempt so a newer `start`/`stop` call that ran during the await isn't clobbered.

Executable evidence along the way: the failure path reliably reproduces the *presence-timer leak* already described in open PR #2706's `collab-session-dispose-presence-on-setup-failure` changeset (`createPresence` runs before the IndexedDB provider, so a rejection there leaks the awareness eviction + y-protocols timers) — confirmed independently here as a hung `node --test` process. Not fixed in this PR since it's in `packages/collab/src/session.ts`, already touched by #2706.

## Test plan

- [x] RED: `collabSlice.session-failure.test.ts` fails on `main` — `'room-1' !== null` (`collabRoomId` not reset)
- [x] GREEN: same test passes after the fix
- [x] `collabSlice.gates.test.ts` (13 tests) still green — no regression
- [x] `tsc --noEmit` clean on `collabSlice.ts`
- [x] Confirmed clear of open PRs #2706, #2708, #2814 — none touch this line range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed collaboration session starts now reset room, role, and access-token state.
  * Prevented stale connection and permission information from appearing after startup failures.
  * Connection status now correctly returns to disconnected when session creation fails.
  * Preserved newer session state when another connection attempt occurs during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->