### PR TITLE
fix(viewer): stop upsertRemoteAnnotation leaving stale pins in storage

### DIFF
--- a/.changeset/annotations-remote-upsert-stale-storage.md
+++ b/.changeset/annotations-remote-upsert-stale-storage.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix `upsertRemoteAnnotation` leaving a stale pin behind in `localStorage` when a previously-local pin's id later arrives flagged `remote`.
+
+`upsertRemoteAnnotation` only wrote to storage `if (!annotation.remote)`, on the assumption that a `remote`-flagged upsert never needs a write. That held for a fresh peer pin (never persisted, nothing to clean up) but not for an id that was persisted earlier while non-remote: skipping the write left the old local version sitting in storage, ready to resurrect on the next `loadFromStorage()` even though the in-memory map had already moved on. `saveToStorage` already filters its own output to non-remote entries, so the guard was redundant for the write-a-local-pin case and unsafe for the ownership-flip case — both `upsertRemoteAnnotation` and `removeRemoteAnnotation` now always call `saveToStorage`, letting it be the single source of truth for what belongs in storage.

--- a/apps/viewer/src/store/slices/annotationsSlice.test.ts
+++ b/apps/viewer/src/store/slices/annotationsSlice.test.ts
@@ -164,6 +164,111 @@ describe('AnnotationsSlice', () => {
     });
   });
 
+  describe('upsertRemoteAnnotation — persistence symmetry', () => {
+    it('persists an upsert whose incoming annotation is not flagged remote (peer edit of our own pin)', () => {
+      const ann: Annotation = {
+        id: 'ann_ours_edited_by_peer',
+        position: { x: 0, y: 0, z: 0 },
+        note: 'edited remotely but attributed to us',
+        entityExpressId: null,
+        modelId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        // remote intentionally omitted — this is how a peer's edit of OUR pin arrives.
+      };
+      state.upsertRemoteAnnotation(ann);
+      assert.strictEqual(state.annotations.get(ann.id)?.note, ann.note);
+      assert.ok(persistedIds().includes(ann.id), 'non-remote-flagged upsert must be persisted');
+    });
+
+    it('does not persist an upsert whose incoming annotation is flagged remote (a peer-owned pin)', () => {
+      const ann: Annotation = {
+        id: 'ann_peers_pin',
+        position: { x: 0, y: 0, z: 0 },
+        note: "peer's own pin",
+        entityExpressId: null,
+        modelId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        remote: true,
+      };
+      state.upsertRemoteAnnotation(ann);
+      assert.strictEqual(state.annotations.get(ann.id)?.note, ann.note);
+      assert.ok(!persistedIds().includes(ann.id), 'remote-flagged upsert must not be persisted');
+    });
+
+    it('removes the stale storage entry when a previously-local pin flips to remote via upsert', () => {
+      // A pin we authored locally (persisted)...
+      state.beginDraft({ x: 0, y: 0, z: 0 }, null, null);
+      const id = state.commitDraft('local original')!;
+      assert.ok(persistedIds().includes(id), 'sanity: persisted while local');
+      const current = state.annotations.get(id)!;
+
+      // ...then the sync bridge delivers an upsert for the SAME id now flagged
+      // remote (e.g. authorship/ownership resolved differently on replay/reconnect).
+      state.upsertRemoteAnnotation({ ...current, note: 'now owned remotely', remote: true });
+
+      assert.strictEqual(state.annotations.get(id)?.remote, true, 'in-memory reflects the new remote flag');
+      assert.ok(
+        !persistedIds().includes(id),
+        'a pin now flagged remote must not remain in localStorage as a stale local entry',
+      );
+    });
+
+    it('last upsert wins for a shared id regardless of updatedAt (no timestamp-based conflict resolution)', () => {
+      const base = {
+        id: 'ann_shared',
+        position: { x: 0, y: 0, z: 0 },
+        entityExpressId: null,
+        modelId: null,
+        remote: true as const,
+      };
+      // Peer A's update carries a NEWER updatedAt...
+      state.upsertRemoteAnnotation({ ...base, note: 'from peer A (newer timestamp)', createdAt: 100, updatedAt: 9999 });
+      // ...but peer B's arrives second, with an OLDER updatedAt.
+      state.upsertRemoteAnnotation({ ...base, note: 'from peer B (older timestamp)', createdAt: 100, updatedAt: 1 });
+
+      assert.strictEqual(
+        state.annotations.get('ann_shared')?.note,
+        'from peer B (older timestamp)',
+        'the slice applies upserts in call order, not by comparing updatedAt',
+      );
+    });
+  });
+
+  describe('removeRemoteAnnotation — stale selection', () => {
+    it('clears the local selection when a peer removes the pin we currently have selected', () => {
+      state.beginDraft({ x: 0, y: 0, z: 0 }, null, null);
+      const id = state.commitDraft('mine, selected, then removed remotely')!;
+      state.selectAnnotation(id);
+      assert.strictEqual(state.selectedAnnotationId, id);
+
+      state.removeRemoteAnnotation(id);
+
+      assert.strictEqual(state.selectedAnnotationId, null, 'stale selection must be cleared on peer removal');
+    });
+
+    it('clears the local selection when a peer removes a purely-remote pin we have selected', () => {
+      const remoteAnnotation: Annotation = {
+        id: 'ann_remote_selected',
+        position: { x: 1, y: 1, z: 1 },
+        note: "peer's pin, selected locally",
+        entityExpressId: null,
+        modelId: null,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        remote: true,
+      };
+      state.upsertRemoteAnnotation(remoteAnnotation);
+      state.selectAnnotation(remoteAnnotation.id);
+      assert.strictEqual(state.selectedAnnotationId, remoteAnnotation.id);
+
+      state.removeRemoteAnnotation(remoteAnnotation.id);
+
+      assert.strictEqual(state.selectedAnnotationId, null, 'stale selection must be cleared on peer removal');
+    });
+  });
+
   describe('persistence', () => {
     it('survives a fresh slice instantiation by round-tripping localStorage', () => {
       state.beginDraft({ x: 7, y: 8, z: 9 }, 1, 'm1');

--- a/apps/viewer/src/store/slices/annotationsSlice.ts
+++ b/apps/viewer/src/store/slices/annotationsSlice.ts
@@ -295,11 +295,14 @@ export const createAnnotationsSlice: StateCreator<AnnotationsSlice, [], [], Anno
   upsertRemoteAnnotation: (annotation) => {
     set((state) => {
       const next = new Map(state.annotations);
-      // Trust the caller's `remote` flag (set by authorship in the sync bridge):
-      // peers' pins are session-only; a peer's edit to one of OUR pins arrives
-      // as non-remote, so persist it to localStorage like any local edit.
       next.set(annotation.id, annotation);
-      if (!annotation.remote) saveToStorage(next);
+      // Always persist: saveToStorage itself filters to non-remote entries, so
+      // this both (a) writes a non-remote upsert (a peer's edit to one of OUR
+      // pins arrives as non-remote) and (b) cleans up any stale storage entry
+      // left over from a previously-local pin whose id now flips to remote —
+      // skipping the write on `annotation.remote` would leave that old local
+      // version resurrecting on the next `loadFromStorage()`.
+      saveToStorage(next);
       return { annotations: next };
     });
   },
@@ -310,13 +313,15 @@ export const createAnnotationsSlice: StateCreator<AnnotationsSlice, [], [], Anno
       if (!existing) return {};
       const next = new Map(state.annotations);
       next.delete(id);
-      // Mirror upsertRemoteAnnotation's condition: a pin we did NOT mark
-      // `remote` is one of OURS (a peer's edit/delete of our own pin arrives
-      // as non-remote), so it was persisted to localStorage and the deletion
-      // must be too, or it resurrects on the next `loadFromStorage()`. A
-      // purely-remote pin (`existing.remote === true`) was never persisted,
-      // so there's nothing to write here.
-      if (!existing.remote) saveToStorage(next);
+      // Always persist: saveToStorage filters to non-remote entries itself, so
+      // this both (a) removes a non-remote pin's storage entry (a peer's
+      // edit/delete of one of OUR pins arrives as non-remote, and it was
+      // persisted, so the deletion must be too, or it resurrects on the next
+      // `loadFromStorage()`) and (b) cleans up any stale storage entry left
+      // over from before this id's `remote` flag flipped to true — a guard on
+      // `existing.remote` here would skip that cleanup. A pin that was never
+      // persisted (never non-remote) is simply a no-op write.
+      saveToStorage(next);
       return {
         annotations: next,
         selectedAnnotationId: state.selectedAnnotationId === id ? null : state.selectedAnnotationId,


### PR DESCRIPTION
## Summary

Closes out the last named coverage item on #2802: `annotationsSlice`'s `upsertRemoteAnnotation` / `removeRemoteAnnotation` collab-sync pair.

PR #2780 (merged) fixed `removeRemoteAnnotation` never calling `saveToStorage` — a peer's deletion of one of our own pins vanished from memory but survived in `localStorage` and resurrected on reload. That fix is present on `main` (`544dc417e`).

While pinning the rest of the pair I found a related defect in the sibling action:

- `upsertRemoteAnnotation` only called `saveToStorage` `if (!annotation.remote)`. That's correct for a fresh peer pin (never persisted, nothing to write) but wrong for an id that *was* persisted earlier while local, then later arrives flagged `remote` (an ownership flip). Skipping the write in that case left the **old, stale local version sitting in `localStorage`** — ready to resurrect the next `loadFromStorage()` even though the in-memory map had already moved on.
- `saveToStorage` already filters its own output to non-remote entries on every call, so the `if (!annotation.remote)` / `if (!existing.remote)` guards were redundant for the common case and unsafe for the flip case. Both actions now always call `saveToStorage`, letting it be the single source of truth for what's persisted.

Also expanded coverage for the rest of the pair (found already-correct, pinned with mutation-verified tests):
- Stale local selection is cleared when a peer removes the currently-selected pin, both for our own pin and a purely-remote one.
- `upsertRemoteAnnotation` applies upserts in call order — last write wins regardless of `updatedAt` (no timestamp-based conflict resolution in this slice).

## Test plan

- [x] RED: new "removes the stale storage entry when a previously-local pin flips to remote via upsert" test fails before the fix (`node --test`, `not ok 3`).
- [x] GREEN: same suite passes after the fix — 16/16 (`# pass 16 # fail 0`).
- [x] Mutation-verified: reintroducing each removed guard, or reverting the selection-clear / last-write-wins logic, makes the exact expected new test(s) fail and no others.
- [x] `pnpm exec tsc --noEmit` — no errors touching `annotationsSlice.ts`.
- [x] Changeset added (`@ifc-lite/viewer` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of remote annotation changes across sessions.
  * Prevented stale local pins from remaining after remote edits, removals, or ownership changes.
  * Ensured the latest annotation update is retained and removed annotations are cleared from selection.

* **Tests**
  * Added coverage for remote annotation persistence, ownership changes, update ordering, and removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->