### PR TITLE
test(lists,schedule): pin IfcLogical Unknown case-fold and outline-level clamp boundary

### DIFF
--- a/apps/viewer/src/components/viewer/schedule/import/build.test.ts
+++ b/apps/viewer/src/components/viewer/schedule/import/build.test.ts
@@ -28,7 +28,7 @@ describe('buildScheduleExtraction — hierarchy', () => {
       row({ sourceId: 'c', name: 'C', outlineLevel: 2 }),
       row({ sourceId: 'd', name: 'D', outlineLevel: 1 }),
     ];
-    const { extraction } = buildScheduleExtraction(source(rows), { seed: 'seed-1' });
+    const { extraction, warnings } = buildScheduleExtraction(source(rows), { seed: 'seed-1' });
     const byName = new Map(extraction.tasks.map(t => [t.name, t]));
     const a = byName.get('A')!;
     const b = byName.get('B')!;
@@ -42,6 +42,19 @@ describe('buildScheduleExtraction — hierarchy', () => {
 
     assert.deepStrictEqual(a.childGlobalIds.sort(), [b.globalId, c.globalId].sort());
     assert.deepStrictEqual(d.childGlobalIds, []);
+
+    // Every step here is a normal, non-jumping outline level (1 -> 2 is
+    // exactly one deeper than the open parent, and 2 -> 1 is a dedent, not a
+    // jump). `resolveHierarchy`'s clamp guard (`level > maxAllowed`) must not
+    // fire on the ordinary case: `level > maxAllowed` mutated to
+    // `level >= maxAllowed` still resolves every parent/child link above
+    // correctly (level stays clamped to itself, a no-op) but spuriously warns
+    // on every row whose level equals the max reachable depth -- i.e. on
+    // every normally-nested row in real files. Nothing above catches that.
+    assert.ok(
+      !warnings.some(w => w.code === 'outline-level-jump'),
+      'ordinary 1,2,2,1 nesting must not report an outline-level-jump warning',
+    );
   });
 
   it('clamps an outline-level jump (1 -> 3) and warns', () => {

--- a/packages/lists/src/engine.values.test.ts
+++ b/packages/lists/src/engine.values.test.ts
@@ -229,6 +229,45 @@ describe('sort ordering', () => {
 });
 
 // ============================================================================
+// Boolean-like case-insensitive condition matching (isBooleanLike)
+// ============================================================================
+
+describe('boolean-like condition matching includes IfcLogical "Unknown"', () => {
+  // `isBooleanLike` treats 'true' / 'false' / 'unknown' (any case) as
+  // boolean-like so `equals`/`notEquals` compare them case-insensitively.
+  // engine.test.ts's boolean-case suite only exercises IFCBOOLEAN's
+  // '.T.'/'.F.' -> "True"/"False"; IFCLOGICAL's third state '.U.' ->
+  // "Unknown" was structurally unreachable from that fixture (no property
+  // there resolves to "Unknown"), so the 'unknown' branch of
+  // `isBooleanLike` had no test: deleting it left the full suite green.
+  const withLogical = new Map<number, EntitySpec>([
+    [1, { name: 'A', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'Flag', type: 'logical', value: ['IFCLOGICAL', '.U.'] }] }] }],
+    [2, { name: 'B', type: 'IfcWall', psets: [{ name: 'Pset_X', globalId: 'ps', properties: [{ name: 'Flag', type: 'logical', value: ['IFCLOGICAL', '.T.'] }] }] }],
+  ]);
+  const condDef = (value: string, operator: 'equals' | 'notEquals') => def({
+    conditions: [{ source: 'property', psetName: 'Pset_X', propertyName: 'Flag', operator, value }],
+    columns: [{ id: 'name', source: 'attribute', propertyName: 'Name' }],
+  });
+
+  it('matches "unknown" (lowercase) against a displayed "Unknown" value', () => {
+    const result = executeList(condDef('unknown', 'equals'), providerOver(withLogical));
+    expect(names(result.rows)).toEqual(['A']);
+  });
+
+  it('matches "UNKNOWN" (uppercase) against a displayed "Unknown" value', () => {
+    const result = executeList(condDef('UNKNOWN', 'equals'), providerOver(withLogical));
+    expect(names(result.rows)).toEqual(['A']);
+  });
+
+  // Bounding control: a genuinely different boolean-like value must still
+  // not match, proving this isn't "match everything boolean-like".
+  it('does not match "unknown" against a displayed "True" value', () => {
+    const result = executeList(condDef('unknown', 'notEquals'), providerOver(withLogical));
+    expect(names(result.rows)).toEqual(['B']);
+  });
+});
+
+// ============================================================================
 // Material / classification condition operators
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Sweep of `packages/lists` and the Gantt/schedule import logic (`apps/viewer/src/components/viewer/schedule/**`, since there is no `packages/schedule`) for the sibling-family / degenerate-fixture defect shapes that have paid off elsewhere in this sweep. Two genuine test gaps found, both test-only (production code confirmed correct via RED/GREEN mutation, then restored).

### 1. `isBooleanLike`'s "Unknown" branch was untested (`packages/lists/src/engine.ts:341-346`)

`isBooleanLike` treats a case-insensitive `'true'` / `'false'` / `'unknown'` string as boolean-like, so `equals`/`notEquals` conditions compare them without regard to letter case — this exists specifically for `IfcLogical`, whose third state (`.U.`) displays as `"Unknown"`. The existing boolean-case suite (`engine.test.ts`) only exercises `IFCBOOLEAN`'s `.T.`/`.F.` → `"True"`/`"False"`; no fixture anywhere produces a displayed `"Unknown"`.

**Reproduced the gap**: deleting `|| lower === 'unknown'` from `isBooleanLike` left the full 169-test `packages/lists` suite green.

Added `packages/lists/src/engine.values.test.ts`, a 3-test `describe` block using an `IFCLOGICAL`/`.U.` property, covering `equals` in both cases plus a bounding control (`notEquals` must not match a genuinely different boolean-like value). All three independently go red against the reproduced gap.

### 2. `resolveHierarchy`'s outline-level clamp guard had no boundary test (`apps/viewer/src/components/viewer/schedule/import/build.ts:64`)

`if (level > maxAllowed)` clamps a jumped outline level (e.g. 1 → 3) and emits an `outline-level-jump` warning. The existing hierarchy test only checks the resulting `parentGlobalId`/`childGlobalIds` for an ordinary 1,2,2,1 nesting — never that it produces *no* warning.

**Reproduced the gap**: mutating the guard to `level >= maxAllowed` still resolved every parent/child link in the existing fixture correctly (the clamp becomes a no-op when `level === maxAllowed`), but would spuriously push an `outline-level-jump` warning on every ordinarily-nested row — i.e. on virtually every real MS Project file with subtasks. The full 16-test `build.test.ts` suite stayed green against this mutation.

Added a negative assertion to the existing "resolves parent/child links from outline levels 1,2,2,1" test: `warnings` must not contain `outline-level-jump`.

## Method

Mutation testing throughout: `cp` the original aside, mutate one call site, run the suite, record failing test **names** (not counts), restore via `cp` + `diff` (never `git checkout --`/`restore`/`reset`/`stash`).

**Calibration mutation** (`packages/lists`): flipped `sortBy.direction`'s sign — 7/169 tests failed with clear diffs, confirming the harness/build is sound before trusting "no failure" elsewhere.

## Areas swept clean (no defect, mutation caught it or coverage was already adequate)

`packages/lists`: `summariseListRows` group ordering (count desc, then label tie-break) — pinned; `toScheduleRows`'s `level ?? path.length - 1` fallback — pinned; `csvEscape`'s numeric-vs-formula-trigger exemption — pinned; `resolveSourceSet`'s `expressIdsByModel` per-model validity filter — pinned; `ENTITY_ATTRIBUTES` vs `getAttributeValue`'s switch, and `PropertyCondition`/`ColumnDefinition`'s `source` union vs `getConditionValue`/`extractColumnValues`'s switches — every declared case is handled on both sides, no sibling asymmetry; `discovery.ts`, `presets.ts`, `name-pattern.ts` (including the cached-matcher `g`/`y`-flag strip) — read, no issues found.

`apps/viewer/schedule/import/build.ts`: `scheduleBounds`'s min/max comparison pair — pinned; the sequence-dedup key (`predecessor|successor|type`) — pinned (dropping `type` from the key breaks a distinct test).

## Test plan

- [x] `packages/lists`: `pnpm install --frozen-lockfile` + `turbo run build --filter=@ifc-lite/lists^...` and `--filter=@ifc-lite/lists`, then `vitest run`: baseline 169/169 → 172/172 after the new tests, all green
- [x] `apps/viewer`: `turbo run build --filter=@ifc-lite/viewer^...` and `--filter=@ifc-lite/viewer`, then the project's own `tsx --test` runner (matches `package.json`'s `test` script, not vitest) over `src/components/viewer/schedule/**/*.test.{ts,tsx}`: baseline 284/284 → still 284/284 (new assertions added inside existing `it`s, not new tests) after `build.test.ts`'s change
- [x] Both reproduced gaps confirmed RED with the new assertions in place, then GREEN after restoring production code (`diff` against a pre-mutation `cp` confirmed byte-identical restoration)
- [x] No production code changed — test-only, so no changeset (matches the project's own precedent, see #2778)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed schedule hierarchy handling so standard nesting no longer triggers an incorrect outline-level warning.
  * Corrected filtering for logical values so “Unknown” matches consistently regardless of capitalization.
  * Ensured “not equals” filtering properly excludes unknown values while retaining valid entries.

* **Tests**
  * Added regression coverage for schedule hierarchy warnings and case-insensitive logical-value filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->