### PR TITLE
fix(processing): re-point parallel_scan's stale AC-20-Smiley-West fixture ref

### DIFF
--- a/rust/processing/src/parallel_scan.rs
+++ b/rust/processing/src/parallel_scan.rs
@@ -364,11 +364,19 @@ mod native {
         /// Fixture leg: byte-identical over real models when present. Sweeps chunk
         /// counts AND checks the public `build_entity_index_parallel` (thread-count
         /// driven) path. Skips (never fails) when fixtures are absent.
+        ///
+        /// `ara3d/AC-20-Smiley-West-10-Bldg.ifc` was the original third leg but is
+        /// not, and never was, in `tests/models/manifest.json` — `pnpm fixtures`
+        /// cannot fetch it, so this leg silently never ran. Swapped for
+        /// `ara3d/advanced_model.ifc` (35MB, in the manifest), which serves the
+        /// same role: a third large, structurally distinct real model. The test
+        /// is model-agnostic (byte-identical parallel-vs-serial STEP scan), so any
+        /// large real fixture exercises the same property.
         #[test]
         fn fixtures_byte_identical() {
             for rel in [
                 "ara3d/schependomlaan.ifc",
-                "ara3d/AC-20-Smiley-West-10-Bldg.ifc",
+                "ara3d/advanced_model.ifc",
                 "various/01_BIMcollab_Example_ARC.ifc",
             ] {
                 let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);


### PR DESCRIPTION
## Summary

Follow-up to #2802 / #2835, which measured `rust/export`'s `fixture_or_skip!` silent-skip problem and added `IFC_LITE_REQUIRE_FIXTURES=1` (not yet merged/wired) to turn a missing fixture into a hard failure in CI. #2835 itself found one stale reference surviving `pnpm fixtures` in `rust/export` (`issues/860_solid_stratum.ifc`) and noted the same silent-skip shape recurs, uninventoried, across `rust/geometry` and `rust/processing`.

I cross-checked every `.ifc` path referenced anywhere under `rust/*/src` and `rust/*/tests` against `tests/models/manifest.json` to find the complete set of stale references (paths a test names that `pnpm fixtures` can never fetch because they're not catalogued).

**Fixed here:**
- `rust/processing/src/parallel_scan.rs`: `fixtures_byte_identical` referenced `ara3d/AC-20-Smiley-West-10-Bldg.ifc`, which is not, and never was, in the manifest (checked full manifest history — no commit ever added it). The test is model-agnostic (byte-identical parallel-vs-serial STEP scan over any large real file), so I swapped it for `ara3d/advanced_model.ifc` (35MB, already in the manifest) — same role, third large/structurally-distinct model. Verified: with fixtures fetched, the swapped-in fixture exercises the real assertions (not a skip); without fixtures, it still skips cleanly as before.

**Found but NOT fixed — needs your call:**
- `rust/export/src/gltf_tests.rs`: `glb_nodes_have_export_rows_for_legacy_products` references `issues/860_solid_stratum.ifc` (from issue #860, `UT_Tin_in_MGA_56.zip`). Never in the manifest (checked full history). No equivalent fixture exists anywhere in the fetched 163-file corpus — grepped every fixture for `IFCSOLIDSTRATUM`/geotechnical-stratum entities, found none, so there's no drop-in re-point target for this specific leg (the other two legs in the same loop, `1030-sphere.ifc`/`1032-curve.ifc`, cover the `IfcProxy` case fine and both *are* in the manifest). Restoring the manifest entry needs the actual fixture file plus a `fixtures-v1` release-asset upload (`pnpm fixtures:upload`) — neither of which I can do without fabricating a hash/URL. Left the test as-is; with `IFC_LITE_REQUIRE_FIXTURES=1` (from #2835) it will still fail this one case (verified locally: 227 passed, 1 failed, naming this fixture) until someone with the original file uploads it, or the test is deliberately narrowed to drop the stratum leg.

**Also noted, out of scope for this PR:** `rust/geometry/tests/voids_production_test.rs::production_fixture_walls_have_holes` has the same shape (one of its two cases references `ara3d/AC-20-Smiley-West-10-Bldg.ifc`, not in the manifest) but is not `#[ignore]`, unlike its sibling `production_smiley_all_host_walls_have_holes`. Its module doc already documents the Smiley-West case as "manual-only," so this may be intentional; flagging for awareness only, not touched.

Everything else referenced across `rust/*/src` and `rust/*/tests` (~260 unique `.ifc` paths checked) resolves to either a manifest-catalogued fixture, a checked-in `tests/fixtures/`-style local file, or an already-`#[ignore]`d and self-documented non-manifest fixture (e.g. `ar_wall_test.rs`, `issue_584_smiley_west_test.rs`).

## Verify

```
IFC_LITE_REQUIRE_FIXTURES=1 cargo test -p ifc-lite-processing --lib parallel_scan   # 6 passed; 0 failed
cargo test -p ifc-lite-processing --lib                                             # 73 passed; 0 failed (fixtures present)
cargo test -p ifc-lite-export --lib                                                 # 228 passed; 0 failed (default, fixtures present)
# default (no fixtures, flag unset) — unchanged:
cargo test -p ifc-lite-processing --lib parallel_scan   # 6 passed; 0 failed
cargo test -p ifc-lite-export --lib                     # 228 passed; 0 failed
```

`IFC_LITE_REQUIRE_FIXTURES` doesn't exist on `main` yet (that's #2835, unmerged); I temporarily overlaid its `test_support.rs` diff locally (not committed) to confirm `rust/export` with fixtures + the flag now reproduces exactly #2835's own "227 passed; 1 failed" (the `860_solid_stratum.ifc` case above), then restored the file — this PR does not touch `test_support.rs` or any workflow file.

No changeset: Rust-only test-infrastructure change, matching #2722, #2720, #2718 precedent (none carried one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated byte-identity test coverage to use an available IFC model fixture.
  * Added documentation clarifying the fixture substitution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->