### PR TITLE
test(clash): cover shared runClash orchestration, flag differential's blind spot

### DIFF
--- a/.changeset/clash-shared-orchestration-cover.md
+++ b/.changeset/clash-shared-orchestration-cover.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/clash": patch
+---
+
+Add direct tests for `runClash`'s shared orchestration (severity resolution, exclusions, dedup, sort ordering, summary tallies) and document a blind spot in `differential.test.ts` (#2830).
+
+`engine-wasm/index.ts` calls the same `runClash` (`engine-ts/orchestrator.ts`) as `engine-ts/index.ts`, so the differential suite comparing the two backends can never catch a bug in that shared orchestration — only in the geometry kernel. Verified: constant-folding `inferClashSeverity` to always return `'info'` left all 16 differential tests passing.
+
+The suite's header now says so explicitly. `engine-ts/orchestrator.test.ts` (new) drives `runClash` directly through a fake kernel to cover severity resolution, exclusion gating, identity/dedup, and sort ordering on their own terms; `analysis.test.ts` gained direct coverage of `summarizeClashes`'s tallies. No behavior changes — tests only.

--- a/packages/clash/src/analysis.test.ts
+++ b/packages/clash/src/analysis.test.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
-import { classifyRuleCoverage, isTouching, penetrationDepth, ruleHadNoMatch, sortClashes, TOUCHING_EPSILON } from './analysis.js';
+import { classifyRuleCoverage, isTouching, penetrationDepth, ruleHadNoMatch, sortClashes, summarizeClashes, TOUCHING_EPSILON } from './analysis.js';
 import type { AABB, Clash, ClashElementRef, ClashRuleCoverage, ClashSeverity, ClashStatus, Vec3 } from './types.js';
 
 function ref(key: string, tag: string): ClashElementRef {
@@ -21,6 +21,28 @@ function clash(id: string, distance: number, severity: ClashSeverity, status: Cl
     rule: 'r',
     status,
     distance,
+    point: POINT,
+    bounds: BOUNDS,
+    severity,
+  };
+}
+
+/** Like {@link clash}, but with independently controllable rule and type tags —
+ * for exercising `summarizeClashes`'s `byRule`/`byTypePair` tallies directly. */
+function clashOf(
+  id: string,
+  rule: string,
+  tagA: string,
+  tagB: string,
+  severity: ClashSeverity,
+): Clash {
+  return {
+    id,
+    a: ref(`${id}a`, tagA),
+    b: ref(`${id}b`, tagB),
+    rule,
+    status: 'hard',
+    distance: -0.1,
     point: POINT,
     bounds: BOUNDS,
     severity,
@@ -220,5 +242,56 @@ describe('classifyRuleCoverage', () => {
 
   it('is "partial" when some rules matched and others did not', () => {
     expect(classifyRuleCoverage({ ruleCoverage: [covered(3, 4), covered(0, 4)] })).toBe('partial');
+  });
+});
+
+describe('summarizeClashes', () => {
+  it('totals the clash count', () => {
+    const summary = summarizeClashes([
+      clashOf('1', 'r1', 'IfcPipeSegment', 'IfcBeam', 'critical'),
+      clashOf('2', 'r1', 'IfcDuctSegment', 'IfcWall', 'major'),
+    ]);
+    expect(summary.total).toBe(2);
+  });
+
+  it('tallies byRule per rule id', () => {
+    const summary = summarizeClashes([
+      clashOf('1', 'r1', 'IfcPipeSegment', 'IfcBeam', 'critical'),
+      clashOf('2', 'r1', 'IfcDuctSegment', 'IfcWall', 'major'),
+      clashOf('3', 'r2', 'IfcPipeSegment', 'IfcBeam', 'critical'),
+    ]);
+    expect(summary.byRule).toEqual({ r1: 2, r2: 1 });
+  });
+
+  it('tallies byTypePair keyed by the two element tags, sorted so order does not matter', () => {
+    const summary = summarizeClashes([
+      clashOf('1', 'r1', 'IfcPipeSegment', 'IfcBeam', 'critical'),
+      // Same pair, tags reversed — must land in the SAME bucket as above.
+      clashOf('2', 'r1', 'IfcBeam', 'IfcPipeSegment', 'critical'),
+      clashOf('3', 'r1', 'IfcDuctSegment', 'IfcWall', 'major'),
+    ]);
+    expect(summary.byTypePair).toEqual({
+      'IfcBeam vs IfcPipeSegment': 2,
+      'IfcDuctSegment vs IfcWall': 1,
+    });
+  });
+
+  it('tallies bySeverity across all four severities, including zero counts', () => {
+    const summary = summarizeClashes([
+      clashOf('1', 'r1', 'IfcPipeSegment', 'IfcBeam', 'critical'),
+      clashOf('2', 'r1', 'IfcPipeSegment', 'IfcBeam', 'critical'),
+      clashOf('3', 'r1', 'IfcPipeSegment', 'IfcBeam', 'minor'),
+    ]);
+    expect(summary.bySeverity).toEqual({ critical: 2, major: 0, minor: 1, info: 0 });
+  });
+
+  it('is all-zero for an empty clash list', () => {
+    const summary = summarizeClashes([]);
+    expect(summary).toEqual({
+      total: 0,
+      byRule: {},
+      byTypePair: {},
+      bySeverity: { critical: 0, major: 0, minor: 0, info: 0 },
+    });
   });
 });

--- a/packages/clash/src/differential.test.ts
+++ b/packages/clash/src/differential.test.ts
@@ -8,6 +8,20 @@
  * so any divergence is in the geometry kernel. We assert identical clash sets
  * (by id), status and severity, with distances and points within epsilon
  * (f64 summation order can differ by ~1e-12 across the two implementations).
+ *
+ * SCOPE (#2830): "both run through the identical orchestrator" above is a
+ * limitation, not just an explanation. `engine-wasm/index.ts` calls the same
+ * `runClash` (`engine-ts/orchestrator.ts`) that `engine-ts/index.ts` uses, so
+ * selection (`selectors.ts`), severity (`disciplines.ts`), exclusions
+ * (`exclude.ts`), identity/dedup/sort and the summary (`analysis.ts`) are
+ * SHARED CODE on both sides of this comparison — a bug there produces the
+ * same wrong answer on both backends and this suite stays green. Only the
+ * kernel call (broad + narrow phase geometry) genuinely differs between the
+ * two paths, so that is the only thing this suite actually audits. Verified:
+ * constant-folding `inferClashSeverity` to always return `'info'` leaves
+ * every test below passing. Shared orchestration has its own direct cover in
+ * `engine-ts/orchestrator.test.ts` and `analysis.test.ts` — don't rely on
+ * this file for it.
  */
 
 import { readFileSync } from 'node:fs';

--- a/packages/clash/src/engine-ts/orchestrator.test.ts
+++ b/packages/clash/src/engine-ts/orchestrator.test.ts
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Direct coverage for `runClash`'s own orchestration logic — severity
+ * resolution, exclusions, identity/dedup, ordering and summary — driven
+ * through a fake `ClashKernel` instead of a real geometry backend.
+ *
+ * This is the cover #2830 asks for: the differential suite (`differential.
+ * test.ts`) compares `engine-ts` and `engine-wasm`, but both call this same
+ * `runClash`, so it cannot see a bug here (see that file's header). These
+ * tests target the orchestrator directly so a broken severity rule, a
+ * leaking exclusion, a bad dedup key, a wrong sort comparator, or a bad
+ * summary tally fails on its own, without needing two backends to disagree.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { runClash } from './orchestrator.js';
+import { makeExclusionSet, qualifiedKey } from '../exclude.js';
+import { fromPositions } from '../math/aabb.js';
+import type { ClashKernel, NarrowRecord, RuleDetection } from './kernel.js';
+import type { ClashElement, ClashRule, ClashSettings, Vec3 } from '../types.js';
+
+let nextRef = 1;
+function element(key: string, tag: string, model = 'm'): ClashElement {
+  const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  return {
+    key,
+    ref: nextRef++,
+    model,
+    tag,
+    bounds: fromPositions(positions),
+    positions,
+    indices: new Uint32Array([0, 1, 2]),
+  };
+}
+
+function rec(a: number, b: number, over: Partial<NarrowRecord> = {}): NarrowRecord {
+  return {
+    a,
+    b,
+    status: 'hard',
+    distance: -0.1,
+    distanceKind: 'mesh',
+    point: [0, 0, 0] as Vec3,
+    bounds: fromPositions(new Float32Array([0, 0, 0, 1, 1, 1])),
+    ...over,
+  };
+}
+
+/** A kernel whose broad phase is trivial (every candidate) and whose narrow
+ * phase returns exactly the records the test configured — one entry per rule
+ * id, in call order. Lets a test dictate the raw kernel output directly, so
+ * it exercises only the orchestrator's post-processing. */
+class FakeKernel implements ClashKernel {
+  private calls = 0;
+  constructor(private readonly recordsByCall: NarrowRecord[][]) {}
+
+  prepare(): void {}
+
+  detectRule(): RuleDetection {
+    const records = this.recordsByCall[this.calls] ?? [];
+    this.calls += 1;
+    return { records, candidatesProcessed: records.length, candidatesDropped: 0 };
+  }
+}
+
+function run(
+  elements: ClashElement[],
+  rules: ClashRule[],
+  recordsByCall: NarrowRecord[][],
+  settings: ClashSettings = {},
+) {
+  return runClash(elements, rules, settings, new FakeKernel(recordsByCall));
+}
+
+const hard = (id: string, over: Partial<ClashRule> = {}): ClashRule => ({
+  id,
+  name: id,
+  a: 'IfcWall',
+  b: 'IfcDuct',
+  mode: 'hard',
+  ...over,
+});
+
+describe('runClash: severity resolution', () => {
+  it('uses the rule-supplied severity verbatim, without consulting the discipline matrix', async () => {
+    // IfcWall/IfcDuct matches no CLASH_RULE_PRESETS pair, so an inferred
+    // severity here would be 'info'. An explicit rule.severity must win.
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct')];
+    const result = await run(elements, [hard('r', { severity: 'critical' })], [[rec(0, 1)]]);
+    expect(result.clashes[0].severity).toBe('critical');
+  });
+
+  it('falls back to the discipline matrix when the rule has no severity', async () => {
+    // IfcDuctSegment vs IfcBeam matches the HVACxSTR preset (critical).
+    const elements = [element('A', 'IfcDuctSegment'), element('B', 'IfcBeam')];
+    const rule: ClashRule = { id: 'r', name: 'r', a: 'IfcDuct*', b: 'IfcBeam', mode: 'hard' };
+    const result = await run(elements, [rule], [[rec(0, 1)]]);
+    expect(result.clashes[0].severity).toBe('critical');
+  });
+});
+
+describe('runClash: exclusions', () => {
+  it('drops an excluded pair when excludeVoidsAndHosts is on (the default)', async () => {
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct')];
+    const exclusions = makeExclusionSet([[qualifiedKey('m', 'A'), qualifiedKey('m', 'B')]]);
+    const result = await run(elements, [hard('r')], [[rec(0, 1)]], { exclusions });
+    expect(result.summary.total).toBe(0);
+  });
+
+  it('applies an excluded pair regardless of which element is a/b in the record', async () => {
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct')];
+    const exclusions = makeExclusionSet([[qualifiedKey('m', 'B'), qualifiedKey('m', 'A')]]);
+    const result = await run(elements, [hard('r')], [[rec(0, 1)]], { exclusions });
+    expect(result.summary.total).toBe(0);
+  });
+
+  it('keeps the exclusion set inert when excludeVoidsAndHosts is explicitly off', async () => {
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct')];
+    const exclusions = makeExclusionSet([[qualifiedKey('m', 'A'), qualifiedKey('m', 'B')]]);
+    const result = await run(elements, [hard('r')], [[rec(0, 1)]], {
+      exclusions,
+      excludeVoidsAndHosts: false,
+    });
+    expect(result.summary.total).toBe(1);
+  });
+
+  it('does not drop a pair that is not in the exclusion set', async () => {
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct'), element('C', 'IfcDuct')];
+    const exclusions = makeExclusionSet([[qualifiedKey('m', 'A'), qualifiedKey('m', 'C')]]);
+    const result = await run(elements, [hard('r')], [[rec(0, 1)]], { exclusions });
+    expect(result.summary.total).toBe(1);
+  });
+});
+
+describe('runClash: identity / dedup', () => {
+  it('collapses two kernel records for the same rule and pair into one clash', async () => {
+    // A real kernel should not emit the same pair twice for one rule, but the
+    // orchestrator's `seen` set is the last line of defence against a kernel
+    // that does (e.g. overlapping A/B groups on a two-sided rule) — this
+    // drives that path directly rather than relying on a kernel accident.
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct')];
+    const result = await run(elements, [hard('r')], [[rec(0, 1), rec(1, 0)]]);
+    expect(result.summary.total).toBe(1);
+  });
+
+  it('keeps both clashes when two DIFFERENT rules match the same element pair', async () => {
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct')];
+    const result = await run(
+      elements,
+      [hard('r1'), hard('r2')],
+      [[rec(0, 1)], [rec(0, 1)]],
+    );
+    expect(result.summary.total).toBe(2);
+    expect(new Set(result.clashes.map((c) => c.id)).size).toBe(2);
+  });
+
+  it('skips a same-entity pair (same key + model) even if the kernel emits it', async () => {
+    const elements = [element('K', 'IfcWall'), element('K', 'IfcWall')];
+    const result = await run(elements, [{ id: 'r', name: 'r', a: 'IfcWall', mode: 'hard' }], [[rec(0, 1)]]);
+    expect(result.summary.total).toBe(0);
+  });
+});
+
+describe('runClash: ordering', () => {
+  it('sorts by element A key, then element B key', async () => {
+    const elements = [
+      element('B', 'IfcWall'),
+      element('A', 'IfcWall'),
+      element('D', 'IfcDuct'),
+      element('C', 'IfcDuct'),
+    ];
+    // One rule over a 2x2 selection, records deliberately out of key order.
+    const result = await run(
+      elements,
+      [hard('r')],
+      [[rec(0, 2), rec(1, 3), rec(0, 3), rec(1, 2)]], // B-D, A-C, B-C, A-D
+    );
+    const ordered = result.clashes.map((c) => `${c.a.key}${c.b.key}`);
+    expect(ordered).toEqual(['AC', 'AD', 'BC', 'BD']);
+  });
+
+  it('breaks a tie on the same element pair by rule id', async () => {
+    // Two rules both matching the SAME pair (A, B) — same a.key/b.key on both
+    // clashes, so only the rule-id tiebreak in `byKeyThenRule` can order them.
+    const elements = [element('A', 'IfcWall'), element('B', 'IfcDuct')];
+    const result = await run(
+      elements,
+      [hard('z'), hard('a')], // inserted in rule order z, then a
+      [[rec(0, 1)], [rec(0, 1)]],
+    );
+    expect(result.clashes.map((c) => c.rule)).toEqual(['a', 'z']);
+  });
+});
+
+describe('runClash: summary', () => {
+  it('summary.total and byRule track the deduped, filtered clash list — not the raw records', async () => {
+    const elements = [
+      element('A', 'IfcWall'),
+      element('B', 'IfcDuct'),
+      element('C', 'IfcDuct'),
+    ];
+    const exclusions = makeExclusionSet([[qualifiedKey('m', 'A'), qualifiedKey('m', 'C')]]);
+    const result = await run(
+      elements,
+      [hard('r')],
+      // A-B kept, A-C excluded, A-B duplicated (deduped to one).
+      [[rec(0, 1), rec(0, 2), rec(1, 0)]],
+      { exclusions },
+    );
+    expect(result.summary.total).toBe(1);
+    expect(result.summary.byRule.r).toBe(1);
+    expect(result.clashes).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses items 1 and 2 of #2830 ("An oracle that shares the defect is not an oracle").

`engine-wasm/index.ts` calls the same `runClash` (`engine-ts/orchestrator.ts`) that `engine-ts/index.ts` uses, so `differential.test.ts` compares two paths through **one** implementation: selection, severity, exclusions, identity/dedup/sort and the summary are shared code on both sides. A bug there produces the same wrong answer on both backends and the suite stays green.

Verified before writing anything: constant-folding `inferClashSeverity` (`disciplines.ts:139`) to always return `'info'` leaves **all 16 differential tests green** — only `disciplines.test.ts` (2) and `engine-ts/engine.test.ts` (1) fail.

- **Item 1** — `differential.test.ts`'s header now states this scope limitation explicitly: what the suite audits (the kernel call) and what it cannot (shared orchestration), pointing at the new direct tests.
- **Item 2** — `engine-ts/orchestrator.test.ts` (new) drives `runClash` directly through a fake `ClashKernel`, covering severity resolution (explicit `rule.severity` vs. inferred), exclusion gating (`excludeVoidsAndHosts` on/off, order-independence), identity/dedup (duplicate kernel records for the same rule+pair collapse to one; different rules on the same pair don't), and sort ordering (key order, rule-id tiebreak). `analysis.test.ts` gained direct coverage of `summarizeClashes`'s `byRule`/`byTypePair`/`bySeverity` tallies, which previously had no direct unit test (only hand-built fixture literals in unrelated suites).

No behavior changes — tests and one doc comment only.

## Mutation evidence (failing test names, not counts)

| Mutation | Failing tests BEFORE this PR | Failing tests AFTER |
|---|---|---|
| `inferClashSeverity` constant-folded to `'info'` | `rates MEP vs Structure as critical (either order)`, `rates Electrical vs MEP as minor` (disciplines.test.ts), `infers severity from the discipline matrix when not given` (engine.test.ts) — **0 in differential.test.ts** | same 3, plus `falls back to the discipline matrix when the rule has no severity` (orchestrator.test.ts) |
| Exclusion gate disabled (`isExcluded` short-circuited to `false`) | `honors the exclusion set` (engine.test.ts) + 2 elsewhere | same, plus `drops an excluded pair when excludeVoidsAndHosts is on (the default)`, `applies an excluded pair regardless of which element is a/b in the record`, `summary.total and byRule track the deduped, filtered clash list — not the raw records` (orchestrator.test.ts) |
| Dedup `seen.has(id)` check disabled | **none** | `collapses two kernel records for the same rule and pair into one clash`, `summary.total and byRule track the deduped, filtered clash list — not the raw records` (orchestrator.test.ts) |
| Sort comparator drops the rule-id tiebreak | **none** | `breaks a tie on the same element pair by rule id` (orchestrator.test.ts) |
| `summarizeClashes`'s `byTypePair` un-sorted (order-dependent bucket) | **none** | `tallies byTypePair keyed by the two element tags, sorted so order does not matter` (analysis.test.ts) |

Each mutation was applied, run, confirmed, and reverted (`cp`+`diff` back to the original, no `git checkout`/`stash`).

## Test plan

- [x] `npx vitest run` in `packages/clash`: before 384 passed / 1 skipped (385 total) → after 401 passed / 1 skipped (402 total)
- [x] All 5 mutations shown RED under the new tests, GREEN after revert
- [x] `differential.test.ts`'s 16 tests re-verified green under the `inferClashSeverity` mutation before writing its header comment

Refs #2830. Not closing it — item 3 is a practice, not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for clash summaries, including totals, severity levels, rule counts, type pairs, and empty results.
  * Added orchestration tests covering filtering, deduplication, ordering, severity handling, and summary accuracy.
  * Expanded validation of entity pairing and exclusion behavior.

* **Documentation**
  * Clarified the scope and coverage of differential testing for clash analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->