### PR TITLE
docs: note where a broad-phase oracle shares the predicate it audits (#2830)

### DIFF
--- a/packages/renderer/src/bvh.test.ts
+++ b/packages/renderer/src/bvh.test.ts
@@ -14,6 +14,20 @@ import type { MeshData } from '@ifc-lite/geometry';
  * (that would make picking/snapping miss real geometry). These tests pin that
  * "no false negatives" invariant against a brute-force reference, plus the
  * degenerate cases (small scene, unbuilt, empty mesh).
+ *
+ * Scope note (#2830): `rayHitsAabb` below is a hand-typed COPY of `BVH`'s
+ * private `rayIntersectsAABB` slab test, not an import, so it genuinely does
+ * catch bugs in the tree itself — construction, node-bounds unions, pruning
+ * (mutation-confirmed: dropping the `t0 > t1` swap in `bvh.ts` fails 4 of the
+ * 8 subtests here). What it cannot catch is a bug in the slab test's own
+ * policy choices, because both copies were written to the same design and
+ * encode them identically — e.g. the `tmax >= 0` front-of-ray tie-break at
+ * `bvh.ts`'s `rayIntersectsAABB` return, duplicated verbatim in `rayHitsAabb`
+ * above. Weakening that one line to `tmax > 0` in `bvh.ts` alone (test file
+ * untouched) leaves all 8 subtests green — mutation-confirmed. Any future
+ * ground truth meant to audit that tie-break needs to derive it independently
+ * (e.g. from an explicit corner/plane check) rather than mirror the slab
+ * algorithm.
  */
 
 interface AABBLike {

--- a/rust/geometry/src/kernel/broadphase.rs
+++ b/rust/geometry/src/kernel/broadphase.rs
@@ -11,6 +11,24 @@
 //! float SAH/centroid sort never decides topology — callers canonicalise the
 //! candidate pairs by exact `(i,j)` keys before processing, so the arrangement
 //! topology (and the pinned determinism manifests) are byte-identical.
+//!
+//! # What the `tests` module's "brute-force" checks can and cannot catch (#2830)
+//!
+//! `bvh_candidate_pairs_match_brute_force` and
+//! `ray_and_point_candidates_are_conservative_supersets` read as independent
+//! oracles, but their reference computations call the SAME predicate functions
+//! the production paths call: `Bvh::query` and the tests' own `brute()` both
+//! call `overlap()` (query at line ~175, brute at line ~262); `Bvh::ray_candidates`
+//! / `Bvh::point_candidates` and the superset test both call `seg_hits_aabb()` /
+//! `aabb_contains()`. These tests therefore validate the TREE — median-split
+//! construction, node-bounds unions, pruning/traversal — never dropping a
+//! candidate the shared predicate would accept; they cannot validate the
+//! predicates (`overlap`, `seg_hits_aabb`, `aabb_contains`) themselves. A sign
+//! or inequality-strictness bug in `overlap()` shifts both the BVH's own
+//! candidate set and the "brute-force" reference identically and both tests
+//! stay green (mutation-confirmed: changing `overlap()`'s `<=` to `<` leaves
+//! both tests passing). Predicate correctness needs its own fixture, derived
+//! independently of these functions.
 
 type Tri = [[f64; 3]; 3];
 type Aabb = ([f64; 3], [f64; 3]);


### PR DESCRIPTION
## Summary

Follows up on #2830 (oracles that share the defect they're meant to catch). Swept the repo outside `packages/clash` (which another agent is covering for #2830's item 2) for the same shape — brute-force oracles, differential/parity suites, round-trip equivalence tests — and mutation-tested every candidate that looked structurally similar.

Most of the repo's existing oracle/differential/parity suites turned out genuinely independent and are already well-documented (literal spec vectors, hand-derived expected values, or textually separate implementations) — no changes needed there. Two spots were confirmed compromised by mutation and now carry a scope note:

- `rust/geometry/src/kernel/broadphase.rs`: `Bvh::query` and the test module's `brute()` reference both call the same `overlap()` predicate; `Bvh::ray_candidates`/`point_candidates` and the "conservative superset" test both call `seg_hits_aabb()`/`aabb_contains()`. Confirmed by mutation: weakening `overlap()`'s `<=` to `<` (changes touching-box behavior) leaves both `bvh_candidate_pairs_match_brute_force` and `ray_and_point_candidates_are_conservative_supersets` green. These tests validate the BVH tree (median-split construction, node-bounds unions, pruning) — never dropping a candidate the shared predicate would accept — but cannot validate the predicates themselves.
- `packages/renderer/src/bvh.test.ts`: `rayHitsAabb` is a hand-typed copy of `BVH`'s private `rayIntersectsAABB` (not shared code), so it does catch real tree/traversal bugs — mutation-confirmed: removing the `t0 > t1` swap in `bvh.ts` fails 4 of 8 subtests. But the two copies encode the same slab-test policy identically, including the `tmax >= 0` front-of-ray tie-break. Weakening that one line in `bvh.ts` alone (test file untouched) leaves all 8 subtests green — mutation-confirmed.

Both mutations were applied, observed failing/passing as claimed, then reverted (`cp`/`diff` restore, verified clean) before committing only the doc changes.

Areas checked and found genuinely independent (no change needed): `rust/geometry/src/triangulation/alt_oracle.rs` + `triangulation_invariance.rs` (separate `earcut` crate vs `earcutr`, feature-gated, already self-documented), `rust/geometry/tests/clash_intersection_oracle.rs` and the `rect_param_*` suites (literal/hand-derived analytic volumes, already self-documented with an explicit "exact kernel is an imperfect oracle" caveat), `packages/merge/src/fast-path-differential.test.ts` (explicitly scoped as an equivalence check on the projection step, not a `planFromStates` correctness oracle — correctness is covered separately in `three-way.test.ts`), the parser/export "widened byte-range reader" equivalence suites (already carry a three-sided raw/accessor/independent-reference design with mutation-checked headers), `packages/encoding/src/ifc-string.parity.test.ts` (hand-authored literal vector fixture, not generated by either decoder), `packages/cache/src/cache.test.ts` xxHash vectors (published spec vectors), `rust/processing` parity suites (snapshot-of-history or independently-maintained-and-documented-as-such loops), `packages/renderer/src/contribution-cull.test.ts` (brute-force 8-corner dot-product oracle is a genuinely different computation from the per-axis-sign shortcut it checks).

## Test plan
- [x] `cargo test --lib kernel::broadphase` (rust/geometry) — 2 passed
- [x] `pnpm exec tsx --test src/bvh.test.ts` (packages/renderer) — 8 passed
- [x] Both suites re-verified green under the mutations described above (RED where claimed, GREEN where claimed), then production/test code restored to a clean diff before committing (comment-only changes)
- [x] `git status --short` clean except the two doc-comment files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory documentation for BVH and geometry validation tests.
  * Clarified which tree construction, traversal, and pruning behaviors are covered.
  * Documented current test limitations, including areas requiring independent fixtures or validation approaches.
  * Recorded guidance for auditing edge-case intersection behavior without relying on duplicated test logic.
  * No user-facing functionality or behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->