### PR TITLE
fix(sdk): bim.list.execute() always returned null for every column

### DIFF
--- a/.changeset/list-column-source-mapping.md
+++ b/.changeset/list-column-source-mapping.md
@@ -1,0 +1,34 @@
+---
+'@ifc-lite/sdk': patch
+---
+
+Fix `bim.list.execute()` returning `null` for every column, every row, always.
+
+The SDK's `ListColumn` is documented as `{ header, source }` where `source`
+is a free-form string — `'name'`, `'type'`, `'globalId'`, or a
+`'PsetName.PropName'` path (`packages/sdk/src/namespaces/list.ts`). `@ifc-lite/lists`'
+`executeList` (`packages/lists/src/engine.ts:566`) switches on `col.source`
+against its own structured enum instead — `'attribute' | 'property' |
+'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone'` —
+and falls through to `default: values[i] = null` for anything else
+(`packages/lists/src/engine.ts:608`). `execute()` forwarded SDK columns
+straight through unchanged, so every SDK-shaped column matched none of the
+library's cases: every cell in every `bim.list.execute()` result came back
+`null`, for every caller, on every call.
+
+Separately, the library's `ListDefinition.conditions` is a required array —
+`resolveSourceSet` reads `conditions.length` unconditionally
+(`packages/lists/src/engine.ts:270`) — while the SDK documents its own
+`conditions` as optional. Omitting it (a documented-valid call) threw
+`Cannot read properties of undefined (reading 'length')` instead of running
+unfiltered.
+
+`ListNamespace.execute()` now translates each SDK column into the library's
+`ColumnDefinition` shape (`'name'`/`'type'`/`'globalId'` map to the
+`'attribute'` source; a `'Pset.Prop'` path maps to `'property'`, or
+`'quantity'` when the set name has the `Qto_` prefix `bim.bsdd` already uses
+to distinguish the two) and defaults `conditions` to `[]` when omitted.
+
+Downstream-visible: `bim.list.execute()` now returns the actual property/
+attribute/quantity values it always claimed to, instead of an all-`null`
+table; and a `ListDefinition` without `conditions` no longer throws.

--- a/.changeset/list-column-source-mapping.md
+++ b/.changeset/list-column-source-mapping.md
@@ -21,14 +21,25 @@ Separately, the library's `ListDefinition.conditions` is a required array —
 (`packages/lists/src/engine.ts:270`) — while the SDK documents its own
 `conditions` as optional. Omitting it (a documented-valid call) threw
 `Cannot read properties of undefined (reading 'length')` instead of running
-unfiltered.
+unfiltered. And a *supplied* condition fared no better: the SDK's
+`ListCondition` (`{ psetName, propName, operator: '=' | '!=' | ... }`) has no
+`source` discriminator and spells its operators differently from the
+library's `PropertyCondition` (`'equals' | 'notEquals' | ...`), so it matched
+none of `getConditionValue`'s cases (`engine.ts:382`) and — because a `null`
+actual value makes `matchesCondition` return `false` unconditionally
+(`engine.ts:308`) — every entity failed every condition: a filtered call
+silently came back with an **empty** table rather than an error.
 
 `ListNamespace.execute()` now translates each SDK column into the library's
 `ColumnDefinition` shape (`'name'`/`'type'`/`'globalId'` map to the
 `'attribute'` source; a `'Pset.Prop'` path maps to `'property'`, or
 `'quantity'` when the set name has the `Qto_` prefix `bim.bsdd` already uses
-to distinguish the two) and defaults `conditions` to `[]` when omitted.
+to distinguish the two), translates each supplied condition into the
+library's `PropertyCondition` shape the same way (plus mapping the operator
+spelling), and defaults `conditions` to `[]` when omitted.
 
 Downstream-visible: `bim.list.execute()` now returns the actual property/
 attribute/quantity values it always claimed to, instead of an all-`null`
-table; and a `ListDefinition` without `conditions` no longer throws.
+table; a `ListDefinition` without `conditions` no longer throws; and a
+supplied `conditions` filter now actually filters instead of silently
+returning zero rows.

--- a/packages/sdk/src/namespaces/list.test.ts
+++ b/packages/sdk/src/namespaces/list.test.ts
@@ -86,3 +86,86 @@ describe('ListNamespace.execute (#column-mapping, #conditions-default)', () => {
     expect(result.rows).toHaveLength(2);
   });
 });
+
+/**
+ * PR #2841 review (louistrue): `conditions` gets the `?? []` default this PR
+ * added, but — unlike `columns` — is never translated. The SDK's
+ * `ListCondition` (`{ psetName, propName, operator: '=' | '!=' | ... }`) has
+ * no `source` discriminator at all, so it fails `getConditionValue`'s switch
+ * (`engine.ts:382`) and every entity fails `matchesCondition` (`engine.ts:308`,
+ * a null actual value always returns `false`) — a documented-valid,
+ * SDK-shaped condition silently returns an EMPTY table, not an error and not
+ * a table of nulls. Reviewer-verified this is pre-existing on `main` too, not
+ * introduced by this PR, but explicitly asked for it to be folded in here
+ * rather than shipping a changeset that claims "always returns the actual
+ * values" while a filtered call still gets nothing.
+ */
+describe('ListNamespace.execute (#conditions-translation, PR #2841 review)', () => {
+  function makeProviderWithPsets(): Provider {
+    return {
+      ...makeProvider(),
+      getPropertySets: (id) =>
+        id === 1
+          ? [
+              {
+                name: 'Pset_WallCommon',
+                globalId: 'pset-1',
+                properties: [{ name: 'IsExternal', type: 0, value: true }],
+              },
+            ]
+          : [
+              {
+                name: 'Pset_WallCommon',
+                globalId: 'pset-2',
+                properties: [{ name: 'IsExternal', type: 0, value: false }],
+              },
+            ],
+    };
+  }
+
+  it('translates a "Pset.Prop" condition (psetName/propName/operator) so a filtered list keeps only the matching row', async () => {
+    const definition: ListDefinition = {
+      types: ['IfcWall'],
+      columns: [{ header: 'Name', source: 'name' }],
+      conditions: [{ psetName: 'Pset_WallCommon', propName: 'IsExternal', operator: '=', value: true }],
+    };
+
+    const result = (await new ListNamespace().execute(
+      makeProviderWithPsets(),
+      definition,
+    )) as ExecuteResult;
+
+    // Entity 1 has IsExternal=true, entity 2 has IsExternal=false. Without
+    // translation, every SDK-shaped condition matches nothing and this comes
+    // back empty for BOTH — a wrong row count alone would not distinguish
+    // "translation missing" from "translation inverted", so this also pins
+    // WHICH row survives.
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].values).toEqual(['Wall-1']);
+  });
+
+  it('routes a "Qto_*.Prop" condition to the quantity source, not property', async () => {
+    const provider: Provider = {
+      ...makeProvider(),
+      getQuantitySets: (id) =>
+        id === 1
+          ? [{ name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetVolume', type: 0, value: 12.5 }] }]
+          : [],
+      // A property set of the SAME name under 'property' would also "match"
+      // if the Qto_ prefix routing were dropped — this pset has no
+      // NetVolume, so the test only stays green when the condition is
+      // actually routed to `quantity`.
+      getPropertySets: () => [],
+    };
+    const definition: ListDefinition = {
+      types: ['IfcWall'],
+      columns: [{ header: 'Name', source: 'name' }],
+      conditions: [{ psetName: 'Qto_WallBaseQuantities', propName: 'NetVolume', operator: '=', value: 12.5 }],
+    };
+
+    const result = (await new ListNamespace().execute(provider, definition)) as ExecuteResult;
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].values).toEqual(['Wall-1']);
+  });
+});

--- a/packages/sdk/src/namespaces/list.test.ts
+++ b/packages/sdk/src/namespaces/list.test.ts
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `bim.list.execute()` bridges the SDK's flat `{ header, source }`
+ * `ListColumn` shape to `@ifc-lite/lists`' structured `ColumnDefinition`
+ * (`{ id, source: <enum>, psetName?, propertyName, label? }`). Before this
+ * fix the two never lined up: the library switches on `source` against its
+ * own enum ('attribute' | 'property' | 'quantity' | ...), and SDK columns
+ * carried 'name' / 'type' / 'globalId' / 'Pset.Prop' strings that matched
+ * none of those cases, so every column's value silently came back `null`
+ * for every row, for every caller, always — `executeList`'s default case.
+ *
+ * Separately, the library's `ListDefinition.conditions` is a required
+ * (non-optional) array that `resolveSourceSet` reads unconditionally via
+ * `conditions.length`; the SDK documents its own `conditions` as optional,
+ * so omitting it (a documented-valid call) threw `Cannot read properties
+ * of undefined (reading 'length')` instead of running unfiltered.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ListNamespace, type ListDefinition } from './list.js';
+
+interface Provider {
+  getEntitiesByType: (type: number) => number[];
+  getAllEntityIds?: () => number[];
+  getEntityName: (id: number) => string;
+  getEntityGlobalId: (id: number) => string;
+  getEntityTypeName: (id: number) => string;
+  getEntityDescription?: (id: number) => string;
+  getEntityObjectType?: (id: number) => string;
+  getEntityTag?: (id: number) => string;
+  getPropertySets?: (id: number) => unknown[];
+  getQuantitySets?: (id: number) => unknown[];
+}
+
+function makeProvider(): Provider {
+  return {
+    getEntitiesByType: () => [1, 2],
+    getAllEntityIds: () => [1, 2],
+    getEntityName: (id) => `Wall-${id}`,
+    getEntityGlobalId: (id) => `GUID-${id}`,
+    getEntityTypeName: () => 'IfcWall',
+    getEntityDescription: () => '',
+    getEntityObjectType: () => '',
+    getEntityTag: () => '',
+    getPropertySets: () => [],
+    getQuantitySets: () => [],
+  };
+}
+
+interface ExecuteRow {
+  entityId: number;
+  values: unknown[];
+}
+interface ExecuteResult {
+  rows: ExecuteRow[];
+}
+
+describe('ListNamespace.execute (#column-mapping, #conditions-default)', () => {
+  it('resolves attribute columns (name/type/globalId) to real values instead of null', async () => {
+    const definition: ListDefinition = {
+      types: ['IfcWall'],
+      columns: [
+        { header: 'Name', source: 'name' },
+        { header: 'GlobalId', source: 'globalId' },
+      ],
+    };
+
+    const result = (await new ListNamespace().execute(makeProvider(), definition)) as ExecuteResult;
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0].values).toEqual(['Wall-1', 'GUID-1']);
+    expect(result.rows[1].values).toEqual(['Wall-2', 'GUID-2']);
+  });
+
+  it('does not throw when conditions is omitted (documented as optional)', async () => {
+    const definition: ListDefinition = {
+      types: ['IfcWall'],
+      columns: [{ header: 'Name', source: 'name' }],
+      // conditions intentionally omitted
+    };
+
+    const result = (await new ListNamespace().execute(makeProvider(), definition)) as ExecuteResult;
+    expect(result.rows).toHaveLength(2);
+  });
+});

--- a/packages/sdk/src/namespaces/list.ts
+++ b/packages/sdk/src/namespaces/list.ts
@@ -55,6 +55,38 @@ async function loadLists(): Promise<Record<string, unknown>> {
 
 type AnyFn = (...args: unknown[]) => unknown;
 
+/**
+ * Translate the SDK's flat `{ header, source }` column shape into the
+ * library's structured `ColumnDefinition` (`{ id, source: <enum>, psetName?,
+ * propertyName, label? }`). Without this the two never lined up: the library
+ * switches on `source` against its own enum ('attribute' | 'property' | ...)
+ * and SDK columns carried 'name' / 'type' / 'globalId' / 'Pset.Prop' strings
+ * that matched none of those cases, so `executeList` fell through to its
+ * `default: values[i] = null` branch for every column, every row.
+ */
+function toLibraryColumn(col: ListColumn, index: number): Record<string, unknown> {
+  const id = `col_${index}`;
+  const label = col.header;
+  if (col.source === 'name') return { id, source: 'attribute', propertyName: 'Name', label };
+  if (col.source === 'type') return { id, source: 'attribute', propertyName: 'Class', label };
+  if (col.source === 'globalId') return { id, source: 'attribute', propertyName: 'GlobalId', label };
+
+  const dotIdx = col.source.indexOf('.');
+  if (dotIdx > 0) {
+    const setName = col.source.slice(0, dotIdx);
+    const propertyName = col.source.slice(dotIdx + 1);
+    // Same Qto_ convention bim.bsdd uses to split property sets from
+    // quantity sets: the library has no single "try property, then
+    // quantity" column source, so a definitive choice is required.
+    const source = setName.startsWith('Qto_') ? 'quantity' : 'property';
+    return { id, source, psetName: setName, propertyName, label };
+  }
+
+  // Unrecognized shape (not one of the three special names, no dot path) —
+  // pass through as a raw attribute name rather than silently dropping it.
+  return { id, source: 'attribute', propertyName: col.source, label };
+}
+
 // ============================================================================
 // ListNamespace
 // ============================================================================
@@ -105,6 +137,13 @@ export class ListNamespace {
     const libraryDef = {
       ...definition,
       entityTypes: (definition.types ?? []).map(t => convert(t)),
+      // `conditions` is required (non-optional) on the library's
+      // ListDefinition; the SDK documents it as optional, and
+      // resolveSourceSet() does `conditions.length` unconditionally, so
+      // omitting it threw "Cannot read properties of undefined" instead of
+      // running unfiltered.
+      conditions: definition.conditions ?? [],
+      columns: definition.columns.map(toLibraryColumn),
     };
     return (mod.executeList as AnyFn)(libraryDef, provider, modelId ?? 'default');
   }

--- a/packages/sdk/src/namespaces/list.ts
+++ b/packages/sdk/src/namespaces/list.ts
@@ -9,7 +9,7 @@
  * column discovery, filtering, presets, and CSV export.
  */
 
-import type { ColumnDefinition } from '@ifc-lite/lists';
+import type { ColumnDefinition, PropertyCondition } from '@ifc-lite/lists';
 
 // ============================================================================
 // Types
@@ -89,6 +89,46 @@ function toLibraryColumn(col: ListColumn, index: number): ColumnDefinition {
   return { id, source: 'attribute', propertyName: col.source, label };
 }
 
+/**
+ * Map the SDK's `'=' | '!=' | '>' | '<' | '>=' | '<='` operator spelling to
+ * the library's `'equals' | 'notEquals' | 'gt' | 'lt' | 'gte' | 'lte'`.
+ * `'contains'` and `'exists'` are spelled the same in both and pass through
+ * the fallback unchanged.
+ */
+const CONDITION_OPERATOR_MAP: Record<string, PropertyCondition['operator']> = {
+  '=': 'equals',
+  '!=': 'notEquals',
+  '>': 'gt',
+  '<': 'lt',
+  '>=': 'gte',
+  '<=': 'lte',
+};
+
+/**
+ * Translate the SDK's flat `{ psetName, propName, operator, value }`
+ * `ListCondition` into the library's `PropertyCondition`
+ * (`{ source: <enum>, psetName?, propertyName, operator, value }`).
+ *
+ * Without this, `execute()` passed SDK-shaped conditions straight through
+ * (PR #2841 review): `PropertyCondition.source` is required and SDK
+ * conditions carry none, so `getConditionValue` fell through to
+ * `default: return null` for every condition, and a `null` actual value
+ * makes `matchesCondition` return `false` unconditionally — every entity
+ * fails every condition, so a filtered `bim.list.execute()` call silently
+ * came back with an EMPTY table rather than an error or a table of nulls.
+ * Same `Qto_` convention as `toLibraryColumn` and `bim.bsdd` to choose
+ * between the library's `'property'` and `'quantity'` sources.
+ */
+function toLibraryCondition(condition: ListCondition): PropertyCondition {
+  return {
+    source: condition.psetName.startsWith('Qto_') ? 'quantity' : 'property',
+    psetName: condition.psetName,
+    propertyName: condition.propName,
+    operator: CONDITION_OPERATOR_MAP[condition.operator] ?? (condition.operator as PropertyCondition['operator']),
+    value: condition.value ?? '',
+  };
+}
+
 // ============================================================================
 // ListNamespace
 // ============================================================================
@@ -143,8 +183,11 @@ export class ListNamespace {
       // ListDefinition; the SDK documents it as optional, and
       // resolveSourceSet() does `conditions.length` unconditionally, so
       // omitting it threw "Cannot read properties of undefined" instead of
-      // running unfiltered.
-      conditions: definition.conditions ?? [],
+      // running unfiltered. Each supplied condition is also translated
+      // (toLibraryCondition) — passed through raw, an SDK-shaped condition
+      // matched none of the library's sources and silently emptied the
+      // result instead of filtering it (PR #2841 review).
+      conditions: (definition.conditions ?? []).map(toLibraryCondition),
       columns: definition.columns.map(toLibraryColumn),
     };
     return (mod.executeList as AnyFn)(libraryDef, provider, modelId ?? 'default');

--- a/packages/sdk/src/namespaces/list.ts
+++ b/packages/sdk/src/namespaces/list.ts
@@ -9,6 +9,8 @@
  * column discovery, filtering, presets, and CSV export.
  */
 
+import type { ColumnDefinition } from '@ifc-lite/lists';
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -64,7 +66,7 @@ type AnyFn = (...args: unknown[]) => unknown;
  * that matched none of those cases, so `executeList` fell through to its
  * `default: values[i] = null` branch for every column, every row.
  */
-function toLibraryColumn(col: ListColumn, index: number): Record<string, unknown> {
+function toLibraryColumn(col: ListColumn, index: number): ColumnDefinition {
   const id = `col_${index}`;
   const label = col.header;
   if (col.source === 'name') return { id, source: 'attribute', propertyName: 'Name', label };


### PR DESCRIPTION
## Summary

`bim.list.execute()` — a published `@ifc-lite/sdk` API — silently returned `null` for every cell in every result, for every caller, always.

`ListNamespace`'s `ListColumn` is documented as a flat `{ header, source }` where `source` is a free-form string: `'name'`, `'type'`, `'globalId'`, or a `'PsetName.PropName'` path (`packages/sdk/src/namespaces/list.ts:16-21`). `@ifc-lite/lists`' `executeList` switches on `col.source` against its own structured enum instead (`packages/lists/src/engine.ts:566`, `'attribute' | 'property' | 'quantity' | 'material' | 'classification' | 'spatial' | 'model' | 'zone'`) and falls through to `default: values[i] = null` for anything else (`engine.ts:608`). `execute()` forwarded SDK columns unchanged, so every SDK-shaped column matched none of the library's cases.

Confirmed by execution (not inference) — a standalone script calling the built package against a mock provider returned `values: [null, null]` for `{source: 'name'}` / `{source: 'globalId'}` columns before the fix, and `["Wall-1", "GUID-1"]` after.

Separately, `@ifc-lite/lists`' `ListDefinition.conditions` is a required (non-optional) array — `resolveSourceSet` reads `conditions.length` unconditionally (`engine.ts:270`) — while the SDK documents its own `conditions` as optional (`list.ts:41-42`). Omitting it (a documented-valid call) threw `Cannot read properties of undefined (reading 'length')` instead of running unfiltered.

## Fix

`ListNamespace.execute()` now:
- translates each SDK column into the library's `ColumnDefinition` shape (`'name'`/`'type'`/`'globalId'` → the `'attribute'` source with the matching `propertyName`; a `'Pset.Prop'` path → `'property'`, or `'quantity'` when the set name has the `Qto_` prefix `bim.bsdd` already uses to distinguish the two families)
- defaults `conditions` to `[]` when omitted, matching the SDK's own documented-optional contract

## Downstream-visible behavior change

`bim.list.execute()` now returns the actual property/attribute/quantity values it always claimed to, instead of an all-`null` table. A `ListDefinition` without `conditions` no longer throws. Any caller currently working around the all-null result (e.g. re-deriving values from `bim.query`/`bim.export` instead) will start seeing real data from `bim.list.execute()` itself.

## Test plan

- [x] `packages/sdk/src/namespaces/list.test.ts` (new) — asserts attribute columns resolve to real values, and that omitting `conditions` does not throw.
- [x] RED confirmed: reverting the fix reproduces both failures — `TypeError: Cannot read properties of undefined (reading 'length')` at `engine.ts:270` for both tests.
- [x] GREEN: `packages/sdk` vitest — 170/170 passing (168 baseline + 2 new).
- [x] `node ../../scripts/typecheck-tests.mjs` — OK.
- [x] Changeset added (`@ifc-lite/sdk` patch).
- [x] No export surface changed (`toLibraryColumn` is an internal helper) — `check-api-surface.mjs` not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed list results returning empty values for attribute-based columns such as name and global ID.
  * Added support for property and quantity-based column mappings.
  * Lists can now be executed without specifying conditions; all matching entities are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->