### PR TITLE
fix(cli): honor analyze --out instead of silently discarding it

### DIFF
--- a/.changeset/cli-analyze-out-flag.md
+++ b/.changeset/cli-analyze-out-flag.md
@@ -1,0 +1,16 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix `ifc-lite analyze --out` being a silent no-op.
+
+`analyzeCommand` excluded `--out <file>`'s value from its positional-argument
+scan (so the path wasn't mistaken for the input IFC file) but never actually
+wrote to it: results only ever went to stdout when `--json` was passed, or to
+a stderr summary otherwise. A user running
+`ifc-lite analyze model.ifc --viewer 3456 --type IfcWall --out results.json`
+got no error and no file — the flag looked accepted but did nothing.
+
+`--out` now writes the match results as JSON to the given file, matching the
+convention every other file-producing command in the CLI already follows
+(`writeOutput`). Documented in `docs/guide/cli.md`'s `analyze` flag table.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -143,6 +143,7 @@ Supports property filters (`--where`), missing-property checks (`--missing`), he
 | `--flyto` | Fly camera to results |
 | `--rules <file>` | Batch rules from JSON |
 | `--json` | Machine-readable output |
+| `--out <file>` | Write match results as JSON to a file instead of stdout |
 
 ---
 

--- a/packages/cli/src/commands/analyze.test.ts
+++ b/packages/cli/src/commands/analyze.test.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `analyzeCommand` accepted `--out` in its positional-argument exclusion
+ * list (so the path wasn't mistaken for the input file) but never actually
+ * wrote to it — results only ever went to stdout (`--json`) or a stderr
+ * summary. A user running `ifc-lite analyze model.ifc --viewer 3456
+ * --type IfcWall --out results.json` got no error and no file: a silent
+ * no-op. These tests pin the fix (write match results as JSON to --out)
+ * and the pre-existing stdout/`--json` behaviour it must not disturb.
+ */
+
+import { mkdtemp, readFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { analyzeCommand } from './analyze.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SAMPLE_IFC = join(__dirname, '../../../../apps/viewer/public/samples/hello-wall.ifc');
+
+describe('analyzeCommand --out', () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  afterEach(() => {
+    stdoutSpy?.mockRestore();
+    stderrSpy?.mockRestore();
+  });
+
+  it('writes match results as JSON to --out instead of stdout', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'ifc-analyze-'));
+    const out = join(dir, 'results.json');
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await analyzeCommand([SAMPLE_IFC, '--viewer', '3456', '--type', 'IfcWall', '--color', 'red', '--out', out]);
+
+    // Regression guard for the original bug: the file must actually exist.
+    await expect(access(out)).resolves.toBeUndefined();
+    const written = JSON.parse(await readFile(out, 'utf-8'));
+    expect(Array.isArray(written)).toBe(true);
+    expect(written[0]).toMatchObject({ rule: 'IfcWall' });
+
+    // --out must suppress the stdout JSON payload — it goes to the file, not both places.
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(stdoutCalls.join('')).not.toContain('"rule"');
+  });
+
+  it('still prints JSON to stdout when --out is absent (baseline, unchanged by the fix)', async () => {
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await analyzeCommand([SAMPLE_IFC, '--viewer', '3456', '--type', 'IfcWall', '--color', 'red', '--json']);
+
+    const stdoutCalls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('');
+    expect(stdoutCalls).toContain('"rule"');
+  });
+});

--- a/packages/cli/src/commands/analyze.ts
+++ b/packages/cli/src/commands/analyze.ts
@@ -17,7 +17,7 @@
 
 import { readFile } from 'node:fs/promises';
 import { createStreamingContext } from '../loader.js';
-import { fatal, getFlag, hasFlag, printJson, validateViewerPort } from '../output.js';
+import { fatal, getFlag, hasFlag, printJson, validateViewerPort, writeOutput } from '../output.js';
 import type { BimContext, EntityRef, EntityData } from '@ifc-lite/sdk';
 
 interface AnalyzeRule {
@@ -276,12 +276,13 @@ async function runRule(
 export async function analyzeCommand(args: string[]): Promise<void> {
   const viewerPortStr = getFlag(args, '--viewer');
   if (!viewerPortStr) {
-    fatal('Usage: ifc-lite analyze <file.ifc> --viewer <port> [options]\n\n--viewer is required to push results to the 3D viewer.');
+    fatal('Usage: ifc-lite analyze <file.ifc> --viewer <port> [--out file] [options]\n\n--viewer is required to push results to the 3D viewer.');
   }
   const viewerPort = validateViewerPort(viewerPortStr)!;
 
   const rulesFile = getFlag(args, '--rules');
   const jsonOutput = hasFlag(args, '--json');
+  const outPath = getFlag(args, '--out');
 
   // Find the IFC file
   const positional = args.filter(
@@ -334,7 +335,13 @@ export async function analyzeCommand(args: string[]): Promise<void> {
     }
   }
 
-  if (jsonOutput) {
+  if (outPath) {
+    // --out was previously excluded from positional-arg detection (so its
+    // value was never mistaken for the input file) but never actually
+    // written — a silent no-op. Route the results there, mirroring the
+    // writeOutput convention used by every other file-producing command.
+    await writeOutput(JSON.stringify(results, null, 2) + '\n', outPath);
+  } else if (jsonOutput) {
     printJson(results);
   } else {
     // Summary line


### PR DESCRIPTION
## Summary

CLI flag sweep of `packages/cli`, in the spirit of #2731 / #2738 (declared-vs-parsed-vs-read-vs-tested). `analyzeCommand` (`packages/cli/src/commands/analyze.ts`) special-cased `--out <file>` in its positional-argument exclusion list — `['--viewer', '--rules', '--type', '--missing', '--where', '--color', '--heatmap', '--palette', '--out']` — so the value wasn't mistaken for the input IFC path, but nothing ever read it. Results only ever went to stdout (`--json`) or a stderr summary line. A silent no-op: no error, no file, no warning.

**Confirmed by execution**, before the fix:

```
$ node dist/index.js analyze model.ifc --viewer 3456 --type IfcWall --color red --out /tmp/analyze-out.json --json
[... JSON printed to stdout ...]
$ echo $?
0
$ ls /tmp/analyze-out.json
ls: /tmp/analyze-out.json: No such file or directory
```

`--out` is not currently documented for `analyze` in `docs/guide/cli.md` or the built-in `--help`, but the code's own exclusion array treats it exactly like the command's other real flags (`--viewer`, `--rules`, `--type`, …), which is the strongest signal of intent: it was meant to work.

## Fix

`--out` now writes the match results as JSON to the given file, via the same `writeOutput` helper every other file-producing command (`lod`, `extract-entities`, `export`, …) already uses. Documented the flag in `docs/guide/cli.md`'s `analyze` table and the usage string.

## RED → GREEN

New test: `packages/cli/src/commands/analyze.test.ts` (analyze had zero prior test coverage).

RED (reverted the fix, kept the test):
```
FAIL  src/commands/analyze.test.ts > analyzeCommand --out > writes match results as JSON to --out instead of stdout
AssertionError: promise rejected "Error: ENOENT: no such file or directory, …"
```

GREEN (fix restored): both tests pass.

Calibration: a second test asserts the pre-existing `--json`-to-stdout path is unchanged when `--out` is absent — this pins the baseline behavior the fix must not disturb.

## Verification

- `packages/cli` suite: 394 passed / 8 skipped (402 total) / 38 files — up from the pre-change baseline of 392 passed / 8 skipped (400) / 37 files (2 new tests, 1 new file). All green.
- `packages/cli` typecheck (`scripts/typecheck-tests.mjs`): clean.
- `oxlint` on changed files: clean.
- Re-verified by direct execution after rebuild: `--out` now writes the file; `--json`-only path unchanged.

## Also checked (packages/cli, part of the same sweep)

- `lod --quality`: confirmed by execution that `--quality low` and `--quality high` produce byte-identical LOD1 GLB output — the CLI-facing symptom of the already-tracked #2731 finding #2 (`GeometryProcessorOptions.quality` discarded via `void options.quality` in `packages/geometry/src/index.ts`). Not re-fixed here: it's a cross-package semantics decision (implement real quality tiers vs. reject the flag) that #2731 already flags as the maintainer's call, not a new finding.
- `ids --locale`: already has an open fix, #2755.
- `mcp --allow` under `--transport http`: already fixed by #2738 (merged).
- `view.ts`'s equivalent positional-exclusion pattern (`--port`, `--send`) — both flags are genuinely read; clean.
- `clash.ts` flags (`--tolerance`, `--clearance`, `--group`, `--bcf-status`, `--max-topics`) — all traced to consumption; clean.
- `bsdd.ts` captures `hasFlag(args, '--json')` into an unused `jsonOutput` local, but `--json` isn't documented for `bsdd` and the command always prints JSON regardless — dead local variable, not a user-facing flag defect, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--out <file>` option to the `analyze` command.
  * Analysis match results can now be saved as formatted JSON to a file.

* **Documentation**
  * Updated the CLI guide with details about the new output option.

* **Bug Fixes**
  * Preserved existing behavior for JSON output to the terminal when `--out` is not used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->