### PR TITLE
fix(server-client): release SSE reader on error, send auth token on getCached

### DIFF
--- a/.changeset/server-client-leak-and-auth.md
+++ b/.changeset/server-client-leak-and-auth.md
@@ -1,0 +1,18 @@
+---
+"@ifc-lite/server-client": patch
+---
+
+Fix two `server-client` request paths that had drifted from their siblings.
+
+`parseParquetStream`'s SSE reader was never released on a throwing path (a
+terminal `error` event, or any exception mid-loop) — `response.body`'s
+`ReadableStreamDefaultReader` stayed locked, leaking the underlying
+connection. `parseStream` already wraps its identical read loop in a
+`try`/`finally` that calls `reader.releaseLock()`; `parseParquetStream` now
+does the same.
+
+`getCached` (`GET /api/v1/cache/{key}`) never sent the configured bearer
+token, even though every other request method does via `authHeaders()` and
+the route is one of the server's `protected_routes` (bearer-gated whenever
+`IFC_SERVER_API_TOKEN` is set). A client configured with `token` would get a
+401 from `getCached` while every other call succeeded.

--- a/packages/server-client/src/client.ts
+++ b/packages/server-client/src/client.ts
@@ -376,79 +376,86 @@ export class IfcServerClient {
     let metadata: ModelMetadata | null = null;
     let symbolic_data: SymbolicData | undefined;
 
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    // A thrown 'error' event (or any other exception mid-loop) must not
+    // leave the reader locked on `response.body` — mirrors the try/finally
+    // `parseStream` already uses for the same SSE-reading shape.
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-      buffer += decoder.decode(value, { stream: true });
+        buffer += decoder.decode(value, { stream: true });
 
-      // Process complete SSE events
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || ''; // Keep incomplete line in buffer
+        // Process complete SSE events
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || ''; // Keep incomplete line in buffer
 
-      for (const line of lines) {
-        if (!line.startsWith('data:')) continue;
+        for (const line of lines) {
+          if (!line.startsWith('data:')) continue;
 
-        const jsonStr = line.slice(5).trim();
-        if (!jsonStr) continue;
+          const jsonStr = line.slice(5).trim();
+          if (!jsonStr) continue;
 
-        try {
-          const event: ParquetStreamEvent = JSON.parse(jsonStr);
+          try {
+            const event: ParquetStreamEvent = JSON.parse(jsonStr);
 
-          switch (event.type) {
-            case 'start':
-              cache_key = event.cache_key;
-              console.log(`[client] Stream started: ${event.total_estimate} entities, cache_key: ${cache_key.substring(0, 16)}...`);
-              break;
+            switch (event.type) {
+              case 'start':
+                cache_key = event.cache_key;
+                console.log(`[client] Stream started: ${event.total_estimate} entities, cache_key: ${cache_key.substring(0, 16)}...`);
+                break;
 
-            case 'progress':
-              // Progress events can be used for UI feedback
-              break;
+              case 'progress':
+                // Progress events can be used for UI feedback
+                break;
 
-            case 'batch': {
-              const decodeStart = performance.now();
-              // Decode base64 Parquet data
-              const binaryStr = atob(event.data);
-              const bytes = new Uint8Array(binaryStr.length);
-              for (let i = 0; i < binaryStr.length; i++) {
-                bytes[i] = binaryStr.charCodeAt(i);
+              case 'batch': {
+                const decodeStart = performance.now();
+                // Decode base64 Parquet data
+                const binaryStr = atob(event.data);
+                const bytes = new Uint8Array(binaryStr.length);
+                for (let i = 0; i < binaryStr.length; i++) {
+                  bytes[i] = binaryStr.charCodeAt(i);
+                }
+
+                // Decode Parquet to meshes
+                const meshes = await decodeParquetGeometry(bytes.buffer);
+                const decodeTime = performance.now() - decodeStart;
+
+                total_meshes += meshes.length;
+                console.log(`[client] Batch #${event.batch_number}: ${meshes.length} meshes, decode: ${decodeTime.toFixed(0)}ms`);
+
+                // Call the batch callback for immediate rendering
+                onBatch({
+                  meshes,
+                  batch_number: event.batch_number,
+                  decode_time_ms: decodeTime,
+                });
+                break;
               }
 
-              // Decode Parquet to meshes
-              const meshes = await decodeParquetGeometry(bytes.buffer);
-              const decodeTime = performance.now() - decodeStart;
+              case 'complete':
+                stats = event.stats;
+                metadata = event.metadata;
+                symbolic_data = event.symbolic_data;
+                const totalTime = performance.now() - uploadStart;
+                console.log(`[client] Stream complete: ${total_meshes} meshes in ${totalTime.toFixed(0)}ms`);
+                break;
 
-              total_meshes += meshes.length;
-              console.log(`[client] Batch #${event.batch_number}: ${meshes.length} meshes, decode: ${decodeTime.toFixed(0)}ms`);
-
-              // Call the batch callback for immediate rendering
-              onBatch({
-                meshes,
-                batch_number: event.batch_number,
-                decode_time_ms: decodeTime,
-              });
-              break;
+              case 'error':
+                throw new Error(`Stream error: ${event.message}`);
             }
-
-            case 'complete':
-              stats = event.stats;
-              metadata = event.metadata;
-              symbolic_data = event.symbolic_data;
-              const totalTime = performance.now() - uploadStart;
-              console.log(`[client] Stream complete: ${total_meshes} meshes in ${totalTime.toFixed(0)}ms`);
-              break;
-
-            case 'error':
-              throw new Error(`Stream error: ${event.message}`);
-          }
-        } catch (e) {
-          if (e instanceof SyntaxError) {
-            console.warn('[client] Failed to parse SSE event:', jsonStr);
-          } else {
-            throw e;
+          } catch (e) {
+            if (e instanceof SyntaxError) {
+              console.warn('[client] Failed to parse SSE event:', jsonStr);
+            } else {
+              throw e;
+            }
           }
         }
       }
+    } finally {
+      reader.releaseLock();
     }
 
     if (!stats || !metadata) {
@@ -1046,6 +1053,7 @@ export class IfcServerClient {
    */
   async getCached(key: string): Promise<ParseResponse | null> {
     const response = await fetch(`${this.baseUrl}/api/v1/cache/${key}`, {
+      headers: this.authHeaders(),
       signal: AbortSignal.timeout(this.timeout),
     });
 

--- a/packages/server-client/src/parse-parquet-stream.test.ts
+++ b/packages/server-client/src/parse-parquet-stream.test.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// `parseParquetStream` decodes real Parquet bytes for 'batch' events, which
+// isn't the point of this test (reader-lock cleanup on the error path). Stub
+// the decoder module so the stream logic runs without a real WASM payload.
+vi.mock('./parquet-decoder.js', () => ({
+  isParquetAvailable: vi.fn(async () => true),
+  decodeParquetGeometry: vi.fn(async () => []),
+  decodeOptimizedParquetGeometry: vi.fn(async () => []),
+}));
+
+import { IfcServerClient } from './client.js';
+
+/** Build a Response whose body streams `chunks` as SSE text. */
+function sseResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function frame(event: unknown): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+function client(): IfcServerClient {
+  return new IfcServerClient({ baseUrl: 'https://example.invalid' });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('parseParquetStream', () => {
+  it('releases the response body reader when the stream reports a terminal error', async () => {
+    // First call: cache-check (miss, so the streaming upload path runs).
+    // Second call: the parquet-stream upload itself, whose SSE body carries
+    // a terminal `error` event — the same shape `parseStream` already
+    // handles by releasing its reader in a `finally`.
+    const streamResponse = sseResponse([
+      frame({ type: 'start', cache_key: 'abc', total_estimate: 2 }),
+      frame({ type: 'error', message: 'boom', code: 'E_BOOM' }),
+    ]);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 })) // cache/check miss
+      .mockResolvedValueOnce(streamResponse); // parquet-stream upload
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      client().parseParquetStream(new ArrayBuffer(4), () => {}),
+    ).rejects.toThrow(/boom/);
+
+    // The reader acquired via `response.body.getReader()` must be released
+    // on this throwing path, exactly as `parseStream`'s `finally` block does.
+    expect(streamResponse.body?.locked).toBe(false);
+  });
+});
+
+describe('getCached', () => {
+  it('sends the configured bearer token, like every other request', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ cache_key: 'k', meshes: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const authedClient = new IfcServerClient({
+      baseUrl: 'https://example.invalid',
+      token: 'secret-token',
+    });
+    await authedClient.getCached('some-key');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string> | undefined;
+    // `/api/v1/cache/{key}` is a protected route on the server (auth
+    // middleware covers all `protected_routes`), so a configured token must
+    // be sent here exactly as it is on `parse`, `parseParquet`, etc.
+    expect(headers?.Authorization).toBe('Bearer secret-token');
+  });
+});


### PR DESCRIPTION
## Summary
- `parseParquetStream`'s SSE `ReadableStreamDefaultReader` was never released when the read loop threw (a terminal `error` event, or any other exception mid-loop), leaking the locked reader / underlying connection. Its sibling `parseStream` already wraps the identical loop in `try`/`finally` + `reader.releaseLock()`; `parseParquetStream` now matches it.
- `getCached` (`GET /api/v1/cache/{key}`) never sent the configured bearer token via `authHeaders()`, even though every other request method does and `/api/v1/cache/{key}` is one of the server's `protected_routes` (bearer-gated when `IFC_SERVER_API_TOKEN` is set). A client configured with `token` would get a 401 from `getCached` alone while every other call succeeded.

Both found via a request/route diff between `packages/server-client`'s `IfcServerClient` and `apps/server`'s Axum router (`apps/server/src/main.rs`) — every client method maps 1:1 to a server route, and the auth middleware wraps `protected_routes` as one layer, but `getCached` skipped the header client-side regardless.

## Test plan
- [x] New `packages/server-client/src/parse-parquet-stream.test.ts`:
  - RED→GREEN: asserts `response.body.locked === false` after `parseParquetStream` throws on a terminal `error` SSE event; failed before the `try`/`finally` fix, passes after.
  - RED→GREEN: asserts a configured `token` is sent as `Authorization: Bearer <token>` on `getCached`; failed before adding `headers: this.authHeaders()`, passes after.
- [x] `pnpm --filter @ifc-lite/server-client vitest run` — 6 files / 45 tests pass.
- [x] `pnpm exec tsc` (package build) — clean.
- [x] Calibration mutation: inverted `if (!terminated)` in `parseStream` → 6 pre-existing tests failed as expected, then reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stream cleanup when parquet data processing encounters errors, helping prevent stalled or unreleased connections.
  - Added bearer authentication to cached-data requests, ensuring protected requests are authorized correctly.

- **Tests**
  - Added coverage for stream cleanup after terminal errors and authentication forwarding for cached requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->