### PR TITLE
fix(mcp): wire ids_validate locale, fold overlay into geometry_* GlobalId lookups

### DIFF
--- a/.changeset/mcp-ids-locale-and-geometry-globalid.md
+++ b/.changeset/mcp-ids-locale-and-geometry-globalid.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+Fix two declared-but-ignored MCP tool inputs.
+
+`ids_validate`'s `locale` field (`en`/`de`/`fr`) was read into a variable and immediately discarded (`void input.locale`); no translator was ever built, so every call produced English `failureReason` / requirement-description text regardless of the requested locale. It now builds a `@ifc-lite/ids` translation service from `locale` and passes it into `validateIDS`, so `de`/`fr` actually translate the report.
+
+`geometry_bbox` / `geometry_volume` / `geometry_area`'s `global_id` / `global_ids` selectors resolved by scanning the parsed store directly, never consulting the session's pending-mutation overlay. That put them out of step with every other GlobalId-keyed tool (`get_entity`, `query_entities`, `bsdd_match`, `entity_delete`, ...), which all fold the overlay per the #2014/#2015 one-resolution-rule: an entity created this session (`entity_create`) was invisible to the geometry tools by GlobalId even though `get_entity` found it immediately, and an entity queued for deletion (`entity_delete`) stayed resolvable there after `get_entity` already reported it gone. `resolveExpressIds` now resolves `global_id`/`global_ids` through the same overlay-aware `resolveGlobalIds` helper `get_entity` and `entity_delete` use.

--- a/packages/mcp/src/read-after-write.test.ts
+++ b/packages/mcp/src/read-after-write.test.ts
@@ -32,6 +32,7 @@ import { validationTools } from './tools/validation.js';
 import { findByGlobalId, resolveGlobalIds } from './tools/util.js';
 import { buildDefaultResourceRegistry } from './resources/index.js';
 import { diffTools } from './tools/diff.js';
+import { geometryTools } from './tools/geometry.js';
 
 /** A 22-character IFC GlobalId from a short mnemonic. */
 function guid(mnemonic: string): string {
@@ -124,7 +125,7 @@ interface CountShape {
 let tmp: string;
 let ctx: ToolContext;
 
-const ALL_TOOLS = [...discoveryTools, ...queryTools, ...mutationTools, ...validationTools, ...diffTools];
+const ALL_TOOLS = [...discoveryTools, ...queryTools, ...mutationTools, ...validationTools, ...diffTools, ...geometryTools];
 
 function tool(name: string) {
   const found = ALL_TOOLS.find((t) => t.name === name);
@@ -696,6 +697,42 @@ describe('one GlobalId resolves to one entity, whichever tool asks', () => {
       expect(findByGlobalId(model, gid), gid).toBe(resolveGlobalIds(model, [gid]).get(gid)?.[0] ?? null);
     }
     expect(resolveGlobalIds(model, [guid('WALA')]).get(guid('WALA'))).toEqual([twin, 72]);
+  }, 30_000);
+});
+
+describe('geometry tools resolve GlobalId the same way get_entity does', () => {
+  it('finds a created entity by GlobalId, instead of reporting no selector matched', async () => {
+    await session();
+    await call('entity_create', {
+      type: 'IfcWall',
+      attributes: [`'${guid('WALC')}'`, null, "'Wall C'", null, null, '#40', null, "'tagC'", null],
+    });
+    const entity = await structured<EntityShape & { ref: { expressId: number } }>('get_entity', {
+      global_id: guid('WALC'),
+    });
+
+    // Before the fix, geometry_bbox's GlobalId resolution scanned the parsed
+    // store directly and never consulted the overlay, so a GlobalId
+    // get_entity had just found came back "no entity matched the selector"
+    // here — the two tools disagreed about the same session.
+    const bbox = await structured<{ boxes: Array<{ expressId: number }> }>('geometry_bbox', {
+      global_id: guid('WALC'),
+    });
+    expect(bbox.boxes).toHaveLength(1);
+    expect(bbox.boxes[0].expressId).toBe(entity.ref.expressId);
+  }, 30_000);
+
+  it('stops matching a deleted entity\'s GlobalId, as get_entity does', async () => {
+    await session();
+    await call('entity_delete', { global_id: guid('WALB') });
+
+    await expect(async () => tool('get_entity').handler({ global_id: guid('WALB') }, ctx))
+      .rejects.toThrow(/No entity with GlobalId/);
+
+    // Same GlobalId, same session: geometry_bbox's own selector-resolution
+    // must reach the same "gone" answer, not the raw (undeleted) store entry.
+    await expect(async () => tool('geometry_bbox').handler({ global_id: guid('WALB') }, ctx))
+      .rejects.toThrow(/Provide an entity selector/);
   }, 30_000);
 });
 

--- a/packages/mcp/src/tools/geometry.ts
+++ b/packages/mcp/src/tools/geometry.ts
@@ -16,7 +16,7 @@
 import { EntityNode } from '@ifc-lite/query';
 import { extractProjectUnits, type IfcDataStore } from '@ifc-lite/parser';
 import type { Tool } from './types.js';
-import { okResult, resolveModel } from './util.js';
+import { okResult, resolveModel, resolveGlobalIds } from './util.js';
 import { ToolErrorCode, ToolExecutionError } from '../errors.js';
 
 /**
@@ -47,22 +47,22 @@ function resolveExpressIds(m: ReturnType<typeof resolveModel>, input: Record<str
   const ids: number[] = [];
   if (Array.isArray(input.express_ids)) ids.push(...(input.express_ids as number[]));
   if (typeof input.express_id === 'number') ids.push(input.express_id);
-  if (typeof input.global_id === 'string') {
-    const gid = input.global_id;
-    for (const [, list] of m.store.entityIndex.byType) {
-      for (const id of list) {
-        const node = new EntityNode(m.store, id);
-        if (node.globalId === gid) ids.push(id);
-      }
-    }
-  }
-  if (Array.isArray(input.global_ids)) {
-    const set = new Set(input.global_ids as string[]);
-    for (const [, list] of m.store.entityIndex.byType) {
-      for (const id of list) {
-        const node = new EntityNode(m.store, id);
-        if (set.has(node.globalId)) ids.push(id);
-      }
+  // GlobalId resolution goes through the overlay-aware helper so an
+  // entity this session created (`entity_create`) or removed
+  // (`entity_delete`) resolves identically here to `get_entity` /
+  // `query_entities` / `bsdd_match` — the one-resolution-rule invariant
+  // documented at resolveGlobalIds (#2014/#2015). A raw store scan
+  // (the previous behaviour) neither saw queued creates nor excluded
+  // queued deletes, so a session-created wall's GlobalId came back
+  // "no entity matched" here while every other tool already saw it.
+  const globalIds: string[] = [];
+  if (typeof input.global_id === 'string') globalIds.push(input.global_id);
+  if (Array.isArray(input.global_ids)) globalIds.push(...(input.global_ids as string[]));
+  if (globalIds.length > 0) {
+    const carriers = resolveGlobalIds(m, globalIds);
+    for (const gid of globalIds) {
+      const found = carriers.get(gid);
+      if (found) ids.push(...found);
     }
   }
   return ids;

--- a/packages/mcp/src/tools/validation.test.ts
+++ b/packages/mcp/src/tools/validation.test.ts
@@ -245,6 +245,36 @@ describe('ids_validate summary', () => {
   });
 });
 
+describe('ids_validate locale', () => {
+  it('translates failureReason text into the requested locale, instead of ignoring the field', async () => {
+    // `unnamed.ifc` has one wall with no Name, so this spec fails for it and
+    // produces a failureReason string — the thing a translator rewrites.
+    const en = (await run('unnamed.ifc', 'ids_validate', {
+      ids_xml: IDS_MATCHING_WALLS, locale: 'en',
+    })).structuredContent as unknown as IdsShape & {
+      report: { specificationResults: Array<{ entityResults: Array<{ requirementResults?: Array<{ failureReason?: string }> }> }> };
+    };
+    const de = (await run('unnamed.ifc', 'ids_validate', {
+      ids_xml: IDS_MATCHING_WALLS, locale: 'de',
+    })).structuredContent as unknown as typeof en;
+
+    const enReasons = en.report.specificationResults[0].entityResults
+      .flatMap((e) => e.requirementResults ?? [])
+      .map((r) => r.failureReason)
+      .filter((r): r is string => r !== undefined);
+    const deReasons = de.report.specificationResults[0].entityResults
+      .flatMap((e) => e.requirementResults ?? [])
+      .map((r) => r.failureReason)
+      .filter((r): r is string => r !== undefined);
+
+    expect(enReasons.length).toBeGreaterThan(0);
+    // Before the fix, `locale` was read into a variable and immediately
+    // discarded (`void input.locale`) — no translator was ever built, so
+    // every locale produced byte-identical English text.
+    expect(deReasons).not.toEqual(enReasons);
+  });
+});
+
 describe('ids source resolution', () => {
   it('rejects a call that supplies neither ids_xml nor ids_path', async () => {
     await expect(run('warning-only.ifc', 'ids_validate', {})).rejects.toThrow(/ids_xml or ids_path/);

--- a/packages/mcp/src/tools/validation.ts
+++ b/packages/mcp/src/tools/validation.ts
@@ -12,7 +12,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { parseIDS, validateIDS, type IFCDataAccessor } from '@ifc-lite/ids';
+import { parseIDS, validateIDS, createTranslationService, type IFCDataAccessor, type SupportedLocale } from '@ifc-lite/ids';
 import { IFC_ENTITY_NAMES } from '@ifc-lite/data';
 import { getInheritanceChainAcrossSchemas } from '@ifc-lite/parser';
 import { foldedTypeCounts, pendingMutationsField, pendingOverlay } from '../overlay.js';
@@ -45,17 +45,18 @@ const idsValidate: Tool = {
 
     const idsDoc = parseIDS(xml);
     const accessor = buildIdsAccessor(m.store) as IFCDataAccessor;
+    const locale = (input.locale as SupportedLocale | undefined) ?? 'en';
     const report = await validateIDS(
       idsDoc,
       accessor,
       { modelId: m.id, schemaVersion: m.store.schemaVersion, entityCount: m.store.entityCount },
       {
+        translator: createTranslationService(locale),
         onProgress: (p) => {
           ctx.progress.report(p.percentage / 100, `Validating ${p.phase} (${p.specificationIndex + 1}/${p.totalSpecifications})`, 100);
         },
       },
     );
-    void input.locale;
 
     const summary = summarizeIdsReport(report);
     return okResult(


### PR DESCRIPTION
## Summary

Continuation of the MCP tool schema-field-vs-handler-read sweep, scoped to the previously-unswept families: `viewer.ts`, `export.ts`, `diff.ts`, `layer*.ts`, `clash.ts`, `bcf.ts`, `bsdd.ts`, `validation.ts`, `geometry.ts`. Two confirmed defects found and fixed; details below. Everything else in scope came back clean (per-tool table in the PR discussion / available on request).

- `ids_validate`'s `locale` field (`en`/`de`/`fr`, schema default `en`) was read into a variable and immediately discarded (`void input.locale`) — no translator was ever constructed, so every call produced English `failureReason` text regardless of the requested locale. Fixed by building a `@ifc-lite/ids` translation service from `locale` and passing it as `translator` into `validateIDS`.
- `geometry_bbox` / `geometry_volume` / `geometry_area` resolved `global_id`/`global_ids` by scanning the parsed store directly, never consulting the session's pending-mutation overlay — unlike every other GlobalId-keyed tool (`get_entity`, `query_entities`, `bsdd_match`, `entity_delete`, ...), which fold the overlay per the established one-resolution-rule (#2014/#2015). An entity created this session was invisible to the geometry tools by GlobalId even though `get_entity` found it immediately; an entity queued for deletion stayed resolvable there after `get_entity` already reported it gone. Fixed by routing through the same overlay-aware `resolveGlobalIds` helper `get_entity`/`entity_delete` already use.

Both were demonstrated by direct execution (calling the tools through the registry) before and after the fix, not just by reading the code.

## Test plan

- [x] `pnpm --filter @ifc-lite/mcp build` — clean
- [x] `pnpm --filter @ifc-lite/mcp test` — 270/270 passing (267 pre-existing + 3 new regression tests)
- [x] RED→GREEN verified by hand for both fixes: reverting each change in isolation reproduces exactly the new test(s) failing, with all others still green
- [x] New regression tests: `packages/mcp/src/tools/validation.test.ts` (`ids_validate locale` describe block), `packages/mcp/src/read-after-write.test.ts` (`geometry tools resolve GlobalId the same way get_entity does` describe block)
- [x] Changeset added (`@ifc-lite/mcp` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected locale handling in IDS validation reports for English, German, and French.
  * Geometry tools now correctly resolve GlobalIds for newly created entities.
  * Deleted entities are consistently excluded from geometry lookups.
* **Tests**
  * Added coverage for localized validation messages and read-after-write geometry lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->