### PR TITLE
fix(viewer): reset deviation heatmap flag on model removal

### DIFF
--- a/.changeset/deviation-heatmap-survives-model-removal.md
+++ b/.changeset/deviation-heatmap-survives-model-removal.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the BIM ↔ scan deviation heatmap (`DeviationPanel`) staying "computed" — slider, legend and colours all left showing — after removing a federated model whose geometry the heatmap was built against.
+
+`DeviationComputer.compute` builds its BVH from every triangle currently in the scene, not just one model's, so removing any federated model invalidates a prior compute. `pointCloudDeviationComputed` is the flag that gates both the panel's "Recompute" vs. "Compute deviation" label and its auto-recompute effect (`!computed && ...`), so leaving it `true` meant nothing ever re-triggered a rebuild — the panel kept presenting a heatmap computed against a triangle set that no longer existed until the user happened to click Recompute themselves.
+
+`removeModel` already tears down this same "references geometry that just changed" class of staleness for the clash focus, the IDS validation report and the compare result; the deviation flag was the one sibling it left out. `clearAllModels` gets the same fix for the full-teardown path.

--- a/apps/viewer/src/store/removeModel-deviation-stale.test.ts
+++ b/apps/viewer/src/store/removeModel-deviation-stale.test.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `removeModel` must drop a computed BIM<->scan deviation result: the
+ * heatmap in `DeviationPanel` is built from a BVH over every triangle
+ * currently in the scene (`DeviationComputer.compute`, packages/renderer),
+ * so removing a federated model changes the very geometry the buffer
+ * describes. `pointCloudDeviationComputed` gates BOTH the "Recompute" vs.
+ * "Compute deviation" label and the auto-recompute effect
+ * (`!computed && ...`) in `DeviationPanel.tsx`, so once it is left `true`
+ * nothing re-triggers a rebuild and the slider/legend keep presenting a
+ * heatmap computed against a mesh set that no longer exists.
+ *
+ * `removeModel` already tears down the same "references geometry that just
+ * changed" class of staleness for the clash focus, the IDS validation
+ * report and the compare result (see its own comments) -- this is the one
+ * sibling it left out.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { useViewerStore } from './index.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset } as unknown as FederatedModel;
+}
+
+function seedTwoModelsWithComputedDeviation(): void {
+  useViewerStore.setState({
+    models: new Map([
+      ['A', model('A', 0)],
+      ['B', model('B', 100000)],
+    ]),
+    activeModelId: 'A',
+  });
+  useViewerStore.getState().setPointCloudDeviationComputed(true);
+}
+
+describe('removeModel drops a stale computed deviation result', () => {
+  it('clears pointCloudDeviationComputed when a model is removed', () => {
+    seedTwoModelsWithComputedDeviation();
+    useViewerStore.getState().removeModel('A');
+    const s = useViewerStore.getState();
+
+    assert.strictEqual(
+      s.pointCloudDeviationComputed,
+      false,
+      'a removed model changed the scene\'s triangle set, so the prior deviation compute no longer describes it',
+    );
+  });
+});

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -237,6 +237,8 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       idsValidationReport?: { modelInfo: { modelId: string } } | null;
       clearIdsValidationReport?: () => void;
       removeSourceTag?: (id: string) => void;
+      pointCloudDeviationComputed?: boolean;
+      setPointCloudDeviationComputed?: (computed: boolean) => void;
     };
     cross.clearMutations?.(modelId);
     cross.clearMutationView?.(modelId);
@@ -244,6 +246,17 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     // sources UI stops offering "Sync from source" for a model that no
     // longer exists and the tag map cannot grow without bound.
     cross.removeSourceTag?.(modelId);
+    // A computed BIM<->scan deviation heatmap (`DeviationPanel`) is built from
+    // a BVH over EVERY triangle in the scene (`DeviationComputer.compute`,
+    // packages/renderer) -- not scoped to this model -- so removing any
+    // federated model invalidates it exactly like the clash focus and IDS
+    // report above. `pointCloudDeviationComputed` gates the panel's own
+    // auto-recompute effect, so leaving it `true` here would leave the
+    // slider/legend presenting a heatmap computed against a triangle set that
+    // no longer exists, with nothing left to trigger a rebuild.
+    if (cross.pointCloudDeviationComputed) {
+      cross.setPointCloudDeviationComputed?.(false);
+    }
 
     // Drop the focused-clash PRESENTATION — the A/B pair tint, the contact
     // marker (lines + AABB box) and the on-demand intersection solid, all of
@@ -392,9 +405,15 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     const crossClear = get() as unknown as {
       clearIdsValidationReport?: () => void;
       clearSourceTags?: () => void;
+      pointCloudDeviationComputed?: boolean;
+      setPointCloudDeviationComputed?: (computed: boolean) => void;
     };
     crossClear.clearIdsValidationReport?.();
     crossClear.clearSourceTags?.();
+    // Same staleness as `removeModel` above, for the full-teardown path.
+    if (crossClear.pointCloudDeviationComputed) {
+      crossClear.setPointCloudDeviationComputed?.(false);
+    }
     // A clash run describes pairs of elements in models that are all about to
     // be gone, and the on-demand intersection SOLID is a mesh drawn into the
     // live scene — `Viewport`'s draw gate reads `clashSelectedId` +


### PR DESCRIPTION
## Summary

- `removeModel` tears down clash focus, the IDS validation report and the compare result whenever a federated model leaves, because each references geometry that just changed. `pointCloudDeviationComputed` — the flag that gates `DeviationPanel`'s "Recompute" label and its own auto-recompute effect — was the one sibling that got skipped.
- The BIM ↔ scan deviation BVH (`DeviationComputer.compute`, `packages/renderer`) is built from every triangle currently in the scene, not scoped to one model, so removing any federated model invalidates a previously-computed heatmap. Left `true`, nothing ever re-triggers a rebuild: the slider, legend and colour ramp keep presenting a result computed against a triangle set that no longer exists.
- Fixed in both `removeModel` and `clearAllModels` (the full-teardown path), mirroring the existing clash/IDS handling exactly.

## Test plan

- [x] `apps/viewer/src/store/removeModel-deviation-stale.test.ts` (new): RED before the fix (`pointCloudDeviationComputed` stayed `true` after `removeModel`), GREEN after.
- [x] Full `apps/viewer/src/store/**/*.test.ts` suite: 790 pass, 0 fail.
- [x] `removeModel-selection-purge.test.ts` and `modelSlice.test.ts` re-run individually to confirm no regression in the cross-slice teardown this touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deviation heatmaps remaining marked as computed after removing a model.
  * Clearing all models now correctly invalidates existing deviation results.
  * Deviation calculations can now automatically refresh against the remaining scene data.

* **Tests**
  * Added coverage for resetting deviation state when federated models are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->