### PR TITLE
test(collab-server): pin the path-lock accept path end to end

### DIFF
--- a/.changeset/pathlock-accept-path-e2e.md
+++ b/.changeset/pathlock-accept-path-e2e.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/collab-server': patch
+---
+
+Pin the path-lock accept path end to end: a write to an *unlocked* prefix, verified by `verifyAgainstPathLocks`, actually reaches a second peer through a real `startCollabServer` instance.
+
+`path-locks.test.ts` already had a real reject-path test (`rejects writes to locked prefixes via verifyAgainstPathLocks`) but no accept-path equivalent — the remaining coverage was pure-function tests of `harvestUpdatePaths` / `registry.matches`. That asymmetry is exactly the shape that let the anti-replay protector's accept path go silently broken (fixed in #2846): `handleMessage` ignored the transformed `payload` the verifier returned, so every accepted edit vanished while the reject-path test stayed green.
+
+`verifyAgainstPathLocks` doesn't transform its input (pure allow/deny), so it isn't exposed to that exact bug shape, but the accept path through `Room.dispatchMessage` was still unverified end to end. Confirmed the new test pins something: mutating `dispatchMessage`'s `MESSAGE_SYNC` branch to swallow accepted `messageYjsUpdate` frames without applying them fails only the new test (the reject-path test and the pure-function tests stay green); reverting restores 5/5.
+
+No production code changed; this is coverage only.

--- a/packages/collab-server/test/path-locks.test.ts
+++ b/packages/collab-server/test/path-locks.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 import { startCollabServer } from '../src/server.js';
 import { MemoryPersistence } from '../src/persistence.js';
@@ -105,6 +105,65 @@ describe('path-locks', () => {
     expect(rejects.some((e) => String((e.detail as { reason?: string } | undefined)?.reason).startsWith('locked:'))).toBe(true);
 
     prov.destroy();
+    await handle.stop();
+  }, 10_000);
+
+  // The reject-path test above only proves the verifier can say no. It
+  // does not prove an allowed write actually reaches other peers — that
+  // is a separate, unverified claim about how `handleMessage` dispatches
+  // an `{ ok: true }` decision. In the sibling replay-protector verifier,
+  // the accept path was silently broken (the transformed `payload` it
+  // returned was never dispatched, so every accepted edit vanished)
+  // while its own reject-path test stayed green (fixed in #2846). This
+  // test drives two real peers through a real `startCollabServer` with
+  // `verifyAgainstPathLocks` installed and asserts the downstream
+  // effect — peer 2 observing peer 1's write to an *unlocked* path —
+  // not just the verifier's return value.
+  it('accepts writes to unlocked prefixes and propagates them to other peers via verifyAgainstPathLocks', async () => {
+    const reg = createPathLockRegistry();
+    reg.add({ prefix: 'entities/locked', label: 'frozen' });
+    const audit = new MemoryAuditSink();
+
+    const handle = await startCollabServer({
+      port: 0,
+      persistence: new MemoryPersistence(),
+      auditSink: audit,
+      verifyMessage: verifyAgainstPathLocks(reg),
+    });
+    const port = (handle.httpServer.address() as { port: number }).port;
+    const url = `ws://127.0.0.1:${port}`;
+
+    const doc1 = new Y.Doc();
+    const prov1 = new WebsocketProvider(url, 'project/main', doc1, {
+      WebSocketPolyfill: WebSocket as never,
+      disableBc: true,
+    });
+    const doc2 = new Y.Doc();
+    const prov2 = new WebsocketProvider(url, 'project/main', doc2, {
+      WebSocketPolyfill: WebSocket as never,
+      disableBc: true,
+    });
+    await Promise.all([
+      new Promise<void>((res) => (prov1.synced ? res() : prov1.once('sync', () => res()))),
+      new Promise<void>((res) => (prov2.synced ? res() : prov2.once('sync', () => res()))),
+    ]);
+
+    // Write to an UNLOCKED path from peer 1.
+    const ents1 = doc1.getMap('entities');
+    doc1.transact(() => {
+      const wall = new Y.Map<unknown>();
+      wall.set('kind', 'wall');
+      ents1.set('open-wall', wall);
+    });
+
+    // Assert the downstream effect on peer 2, not the verifier's decision.
+    await vi.waitFor(() => {
+      const ents2 = doc2.getMap('entities');
+      expect(ents2.has('open-wall')).toBe(true);
+    }, { timeout: 5_000, interval: 25 });
+
+    prov1.destroy();
+    prov2.destroy();
     await handle.stop();
   }, 10_000);
 });


### PR DESCRIPTION
## Summary

- `packages/collab-server/test/path-locks.test.ts` had a real reject-path end-to-end test (`rejects writes to locked prefixes via verifyAgainstPathLocks`) driving a real `startCollabServer` + websocket client, but the accept path was only exercised by pure-function tests of `harvestUpdatePaths` / `registry.matches`.
- That asymmetry is the same shape that let the anti-replay protector's accept path go silently broken while its own reject-path test stayed green (`handleMessage` ignored the transformed `payload` the verifier returned) — fixed in #2846.
- Added a test that connects two real websocket peers through a real `startCollabServer` with `verifyMessage: verifyAgainstPathLocks(reg)`, writes to an *unlocked* prefix from peer 1, and asserts peer 2 observes the write — the downstream effect, not the verifier's return value.

## Mutation proof

Mutated `Room.dispatchMessage`'s `MESSAGE_SYNC` branch in `room-manager.ts` to swallow accepted `messageYjsUpdate` frames without applying them:

```
if (decoding.peekVarUint(decoder) === SYNC_UPDATE) break; // MUTATION
```

Result: only the new test fails (`accepts writes to unlocked prefixes and propagates them to other peers via verifyAgainstPathLocks`); the reject-path test and the three pure-function tests stay green (4/5). Reverting restores 5/5.

## Part 2 (guard sweep)

Investigated the two candidates called out as strongest under "returns a transformed value that the caller might discard": `packages/ids`'s `createCachedAccessor` wrapping (`validator.ts:67`, threaded consistently through `validateIDS`/`validateSpecification`) and `packages/parser`'s `normalizeWasmEntityRefs`/`asSourceBytes` widening helpers (`entity-scanner.ts:167`, `source-bytes.ts:490`) — both consume their own transformed output correctly at every call site checked; no defect found. Did not have scope to sweep `packages/sandbox`, `packages/mcp`, `packages/extensions` (outside the capability gate under private disclosure), `apps/server` middleware, or `apps/viewer` services beyond a quick look at `apps/server/src/middleware/auth.rs` (a boolean pass/fail gate, not a transform — deprioritized per the sweep's own criterion). No fix shipped for Part 2; this PR is test-only.

## Test plan

- [x] `pnpm exec vitest run test/path-locks.test.ts` in `packages/collab-server` — 5/5 passed
- [x] `pnpm exec vitest run` (full collab-server suite) — 178/178 passed
- [x] Mutation proof recorded above (both runs)
- [x] Changeset added (`patch`, test-only, following existing precedent)

References #2846 for context on the bug shape this guards against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage confirming that changes made to permitted, unlocked paths are successfully synchronized between connected peers.
  - Improved validation of collaborative editing workflows, including server communication, cross-peer updates, and cleanup after testing.

- **Release**
  - Prepared a patch release for the collaboration server package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->