### PR TITLE
fix(viewer): clear Auto Spaces preview on storey/model switch

### DIFF
--- a/.changeset/add-element-autospace-preview-stale-storey.md
+++ b/.changeset/add-element-autospace-preview-stale-storey.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the Add Element panel's Auto Spaces preview staying on screen after switching the target storey or federated model.
+
+`AddElementAutoSpacePreview` is a dry-run wall-graph detection keyed to the storey it ran against (`storeyExpressId`), but nothing re-ran or cleared it when the target storey or model changed via the panel's selects — `AddElementOverlay` kept drawing the stale outlines at the old storey's elevation, and the panel kept reporting region/wall counts for a storey the user had since navigated away from. `setAddElementStoreyId` and `setAddElementModelId` now clear `addElementAutoSpacePreview` alongside the id, so a stale preview never outlives the selection it was computed for.

--- a/apps/viewer/src/store/slices/addElementSlice.test.ts
+++ b/apps/viewer/src/store/slices/addElementSlice.test.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Auto Spaces' preview (`addElementAutoSpacePreview`) is a dry-run wall-graph
+ * detection keyed to the storey it ran against — nothing re-runs detection
+ * when the target storey or model changes. Switching either must drop the
+ * stale preview so AddElementOverlay stops drawing outlines for a storey the
+ * user navigated away from, and the panel stops reporting region/wall counts
+ * that no longer describe the current selection.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAddElementSlice, type AddElementSlice } from './addElementSlice.js';
+
+function samplePreview(storeyExpressId: number): AddElementSlice['addElementAutoSpacePreview'] {
+  return {
+    storeyExpressId,
+    outlines: [[[0, 0], [1, 0], [1, 1], [0, 1]]],
+    regions: [{ area: 1 }],
+    wallsConsidered: 4,
+    wallsContributing: 4,
+  };
+}
+
+describe('addElementSlice: Auto Spaces preview invalidation', () => {
+  let state: AddElementSlice;
+  let setState: (partial: Partial<AddElementSlice> | ((state: AddElementSlice) => Partial<AddElementSlice>)) => void;
+
+  beforeEach(() => {
+    setState = (partial) => {
+      const updates = typeof partial === 'function' ? partial(state) : partial;
+      state = { ...state, ...updates };
+    };
+    state = createAddElementSlice(setState, () => state, {} as never);
+  });
+
+  it('setAddElementStoreyId clears a preview computed for the previous storey', () => {
+    state.setAddElementAutoSpacePreview(samplePreview(101));
+    assert.notEqual(state.addElementAutoSpacePreview, null);
+
+    state.setAddElementStoreyId(202);
+    assert.equal(state.addElementAutoSpacePreview, null);
+  });
+
+  it('setAddElementModelId clears a preview computed against the previous model', () => {
+    state.setAddElementAutoSpacePreview(samplePreview(101));
+    assert.notEqual(state.addElementAutoSpacePreview, null);
+
+    state.setAddElementModelId('model-b');
+    assert.equal(state.addElementAutoSpacePreview, null);
+  });
+
+  it('re-setting the SAME storey id also clears — the preview may be stale even without a value change (e.g. re-selecting after an external reset)', () => {
+    state.setAddElementStoreyId(101);
+    state.setAddElementAutoSpacePreview(samplePreview(101));
+    state.setAddElementStoreyId(101);
+    assert.equal(state.addElementAutoSpacePreview, null);
+  });
+
+  it('calibration: setAddElementAutoSpaceParams (unrelated form field) does NOT clear the preview', () => {
+    state.setAddElementAutoSpacePreview(samplePreview(101));
+    state.setAddElementAutoSpaceParams({ MinArea: 2 });
+    assert.notEqual(state.addElementAutoSpacePreview, null);
+  });
+});

--- a/apps/viewer/src/store/slices/addElementSlice.ts
+++ b/apps/viewer/src/store/slices/addElementSlice.ts
@@ -120,7 +120,13 @@ export interface AddElementAutoSpaceParams {
   PredefinedType: string;
 }
 
-/** Live preview from the most recent dry-run detection (cleared on commit). */
+/**
+ * Live preview from the most recent dry-run detection. Cleared on commit,
+ * and on any storey/model switch (`setAddElementStoreyId` /
+ * `setAddElementModelId`) — the outlines and counts are keyed to the storey
+ * they were detected against and do not update themselves when the target
+ * changes.
+ */
 export interface AddElementAutoSpacePreview {
   storeyExpressId: number;
   /** CCW outlines in IFC storey-local 2D (X/Y, m). */
@@ -239,8 +245,18 @@ export const createAddElementSlice: StateCreator<AddElementSlice, [], [], AddEle
     // doesn't make sense as a slab's first corner. Hover is cleared
     // alongside so a stale preview doesn't flash with the new shape.
     set({ addElementType, addElementPendingPoints: [], addElementHoverPoint: null }),
-  setAddElementStoreyId: (addElementStoreyId) => set({ addElementStoreyId }),
-  setAddElementModelId: (addElementModelId) => set({ addElementModelId }),
+  // Auto Spaces' preview is a dry-run detection keyed to the storey it ran
+  // against (`AddElementAutoSpacePreview.storeyExpressId`) — nothing re-runs
+  // detection when the target storey or model changes, so switching either
+  // left the stale outlines drawn in AddElementOverlay and the stale
+  // region/wall counts shown in the panel, describing a storey the user had
+  // since navigated away from. Clear it here, at the single setter both the
+  // panel's Select and its "no longer valid" auto-reset go through, rather
+  // than at each call site.
+  setAddElementStoreyId: (addElementStoreyId) =>
+    set({ addElementStoreyId, addElementAutoSpacePreview: null }),
+  setAddElementModelId: (addElementModelId) =>
+    set({ addElementModelId, addElementAutoSpacePreview: null }),
   setAddElementWallParams: (p) =>
     set((s) => ({ addElementWallParams: { ...s.addElementWallParams, ...p } })),
   setAddElementSlabParams: (p) =>


### PR DESCRIPTION
## Summary
- `AddElementAutoSpacePreview` is a dry-run wall-graph detection keyed to the storey it ran against (`storeyExpressId`), but `setAddElementStoreyId` / `setAddElementModelId` never cleared it.
- `AddElementOverlay` kept drawing the stale outlines at the old storey's elevation, and the Auto Spaces panel kept reporting region/wall counts for a storey the user had since navigated away from — a "computed" result surviving the invalidation of the state it was computed against.
- Both setters (the single point both the panel's Select and its own "no-longer-valid" auto-reset go through) now clear `addElementAutoSpacePreview` alongside the id.

## Test plan
- [x] RED: reverted the fix, `addElementSlice.test.ts` — 3 of 4 tests fail (`setAddElementStoreyId clears a preview computed for the previous storey`, `setAddElementModelId clears a preview computed against the previous model`, `re-setting the SAME storey id also clears…`); calibration test (unrelated field does not clear) passes as expected.
- [x] GREEN: restored the fix, all 4 tests pass.
- [x] `pnpm exec tsc --noEmit` on the viewer package shows no new errors touching this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto Spaces previews are now cleared when the target storey or federated model changes.
  * Prevented stale outlines, selected IDs, and region or wall counts from appearing for previous selections.

* **Tests**
  * Added coverage to verify preview clearing and preservation when updating unrelated Auto Spaces settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->