### PR TITLE
fix(mcp): mutation_batch dispatches sub-ops with raw args, not validated

### DIFF
--- a/.changeset/mutation-batch-forwards-defaults.md
+++ b/.changeset/mutation-batch-forwards-defaults.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/mcp": patch
+---
+
+Fix `mutation_batch` dispatching each sub-op with its raw, pre-validation `args` instead of `validateInput`'s validated result.
+
+Same shape as the collab-server bug in #2846: `mutation_batch`'s per-op loop already calls `validateInput(tool.inputSchema, subArgs)` and checks `validation.valid`, but then handed `subArgs` — the original, unvalidated object — to `tool.handler`, discarding `validation.value`. A single, non-batched call to the same tool goes through `MCPServer.handleToolCall`, which correctly dispatches with `validation.value` (the schema-default-filled result).
+
+No sub-tool on the batch whitelist (`entity_set_property`, `entity_delete_property`, `entity_set_attribute`, `entity_create`, `entity_delete`) currently declares a schema `default`, so this had no observable effect today — but the moment one does, a batched call and a single call would silently disagree about what an omitted field means, exactly like the `handleMessage`/`verifyWithReplayProtector` divergence, and the mismatch would be invisible to any test that only exercises `validateInput` in isolation or only exercises the reject path through `mutation_batch`.
+
+`mutation_batch` now dispatches with `validation.value`, matching the single-call path.

--- a/packages/mcp/src/read-after-write.test.ts
+++ b/packages/mcp/src/read-after-write.test.ts
@@ -1126,3 +1126,45 @@ describe('pendingMutations rides on every payload that folds', () => {
     }
   }, 30_000);
 });
+
+/**
+ * `mutation_batch` re-validates each op's `args` with `validateInput` (the
+ * same call `MCPServer` makes before a direct, non-batched dispatch) but must
+ * then hand the *validated* value — the one with schema defaults filled in —
+ * to the sub-tool's handler, not the raw `args` it was given. A single-call
+ * `entity_set_property` already gets `validation.value`, via `server.ts`; a
+ * batched one must see the same value or the two dispatch paths silently
+ * disagree about what an omitted, defaulted field means.
+ *
+ * `entity_set_property`'s schema declares no default today, so this test
+ * grafts one on temporarily (restored in `finally`) to observe the
+ * dispatch path itself, independent of which tool happens to ship a
+ * `default` on a given day.
+ */
+describe('mutation_batch forwards validated (default-filled) args to its sub-tool', () => {
+  it('a defaulted field omitted from the op reaches the handler with its default, not undefined', async () => {
+    await session();
+    const setProperty = mutationTools.find((t) => t.name === 'entity_set_property');
+    if (!setProperty) throw new Error('entity_set_property not registered');
+    const valueSchema = (setProperty.inputSchema.properties as Record<string, { default?: unknown }>).value;
+    const hadDefault = 'default' in valueSchema;
+    const previousDefault = valueSchema.default;
+    valueSchema.default = 'grafted-default';
+    try {
+      const batch = await structured<{ results: Array<{ ok: boolean; result?: { mutation?: { value?: unknown } } }> }>(
+        'mutation_batch',
+        {
+          operations: [
+            // `value` is intentionally omitted so only the schema default can supply it.
+            { tool: 'entity_set_property', args: { global_id: guid('WALA'), pset: 'Pset_WallCommon', name: 'GraftedProp' } },
+          ],
+        },
+      );
+      expect(batch.results[0].ok).toBe(true);
+      expect(batch.results[0].result?.mutation?.value).toBe('grafted-default');
+    } finally {
+      if (hadDefault) valueSchema.default = previousDefault;
+      else delete valueSchema.default;
+    }
+  }, 30_000);
+});

--- a/packages/mcp/src/tools/mutate.ts
+++ b/packages/mcp/src/tools/mutate.ts
@@ -276,7 +276,7 @@ const mutationBatch: Tool = {
           });
           continue;
         }
-        const out = await tool.handler(subArgs, ctx);
+        const out = await tool.handler(validation.value as Record<string, unknown>, ctx);
         if (out.isError) results.push({ tool: op.tool, ok: false, error: (out.structuredContent?.message as string) ?? 'failed' });
         else results.push({ tool: op.tool, ok: true, result: out.structuredContent });
       } catch (err) {


### PR DESCRIPTION
## Summary
- `mutation_batch`'s per-op loop calls `validateInput(tool.inputSchema, subArgs)` and checks `validation.valid`, but then dispatches `tool.handler(subArgs, ctx)` — the original, unvalidated object — instead of `validation.value`, the schema-default-filled result `validateInput` actually returns.
- The single-call path (`MCPServer.handleToolCall`) already dispatches with `validation.value`. This is the same shape as the collab-server bug fixed in #2846: a guard computes a transformed value, the caller ignores it and uses the raw input instead.
- No sub-tool on the batch whitelist (`entity_set_property`, `entity_delete_property`, `entity_set_attribute`, `entity_create`, `entity_delete`) declares a schema `default` today, so this had no observable effect in production — confirmed by grepping every tool schema in `packages/mcp/src/tools/*.ts`. The moment one does, a batched call and a single call would silently disagree about what an omitted field means, and the divergence would be invisible to any test that only unit-tests `validateInput` or only exercises `mutation_batch`'s reject path.
- Fixed by dispatching with `validation.value` instead of `subArgs`, mirroring `server.ts`.

## Test plan
- [x] Added a regression test (`packages/mcp/src/read-after-write.test.ts`, describe block `mutation_batch forwards validated (default-filled) args to its sub-tool`) that temporarily grafts a `default` onto `entity_set_property`'s schema (restored in `finally`), omits that field from a batch op, and asserts the handler received the default — not `undefined`.
- [x] RED confirmed against the pre-fix code (`tool.handler(subArgs, ctx)`): `AssertionError: expected undefined to be 'grafted-default'`.
- [x] GREEN confirmed against the fix: test passes.
- [x] Full `packages/mcp` suite: 268 tests passed, 26 files.
- [x] `tsc --noEmit` clean in `packages/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed batched mutations to apply validated inputs consistently with individual mutations.
  - Schema defaults are now correctly applied when processing operations in a mutation batch.
  - Improved reliability for batched property updates and other sub-operations.

- **Tests**
  - Added regression coverage confirming default values are forwarded during batch execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->