### PR TITLE
fix(viewer): removeModel/clearAllModels purge pinboard basket state

### DIFF
--- a/.changeset/removemodel-purges-pinboard-basket.md
+++ b/.changeset/removemodel-purges-pinboard-basket.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix `removeModel`/`clearAllModels` leaving the pinboard/basket (`pinboardEntities`, `hierarchyBasketSelection`) pointing at a model that no longer exists.
+
+`pinboardEntities` is pinboardSlice's documented source of truth for the basket: every basket edit (`addToBasket`/`removeFromBasket`/`showPinboard`) re-derives `isolatedEntities` from it via `toGlobalIdForRef` → `toGlobalIdFromModels`, which falls back to the raw, un-offset `expressId` once a ref's `modelId` is no longer in `models`. A basket ref surviving model removal therefore doesn't just dangle: the next basket operation can resolve it to a bare id that collides with a real entity in any surviving model whose own offset range covers that number (any model loaded at `idOffset` 0, notably), silently co-isolating or co-hiding an entity the user never touched — on top of inflating the basket's visible entity count in the toolbar/dock indefinitely. Same shape as the globalId-keyed selection/isolation state `removeModel` already purges (#2832); the basket's own `Set<string>` state was the one sibling that was missed. `clearAllModels` gets the matching unconditional clear for the full-teardown path.

--- a/apps/viewer/src/store/removeModel-pinboard-stale.test.ts
+++ b/apps/viewer/src/store/removeModel-pinboard-stale.test.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { useViewerStore } from './index.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+describe('removeModel purges pinboard basket state pointing at a removed model', () => {
+  it('drops the removed model\'s ref from pinboardEntities, so a later "isolate basket" click cannot leak an unscaled, collision-prone id', () => {
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+    });
+
+    // Basket the removed model's entity 42, plus a surviving entity from B.
+    useViewerStore.getState().setBasket([
+      { modelId: 'A', expressId: 42 },
+      { modelId: 'B', expressId: 5 },
+    ]);
+
+    useViewerStore.getState().removeModel('A');
+
+    const afterRemove = useViewerStore.getState();
+    console.log('pinboardEntities after removeModel:', [...afterRemove.pinboardEntities]);
+    assert.ok(
+      !afterRemove.pinboardEntities.has('A:42'),
+      'pinboardEntities must not contain a ref into the removed model',
+    );
+
+    // Simulate the user re-isolating the basket after removal (the
+    // "Isolate" button in BasketPresentationDock -> showPinboard()). This
+    // ALWAYS fully recomputes isolatedEntities from pinboardEntities via
+    // basketToGlobalIds -> toGlobalIdForRef -> toGlobalIdFromModels, which
+    // falls back to the RAW, un-offset expressId for any ref whose modelId
+    // is no longer in `models`. Before the fix, pinboardEntities still held
+    // "A:42", and showPinboard() would have isolated bare id 42 -- which
+    // sits inside surviving model A-replacement-free ranges (any model with
+    // idOffset 0) and can silently co-isolate an entity the user never
+    // selected. With pinboardEntities purged, this cannot happen.
+    useViewerStore.getState().showPinboard();
+
+    const after = useViewerStore.getState();
+    console.log('isolatedEntities after showPinboard:', after.isolatedEntities && [...after.isolatedEntities]);
+    assert.ok(
+      !after.isolatedEntities?.has(42),
+      'a stale pinboard ref into the removed model must not resurface as an unscaled, collision-prone raw id 42',
+    );
+    assert.deepStrictEqual(
+      after.isolatedEntities,
+      new Set([1005]),
+      'only the surviving basket entry (B:5 -> global id 1005) should be isolated',
+    );
+  });
+});

--- a/apps/viewer/src/store/slices/collabSlice.entry-race.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.entry-race.test.ts
@@ -90,6 +90,8 @@ describe('collabSlice.startCollab — entry race (model removed before the call)
       // (role: 'admin'), but it must exist to type-check the call site.
       setEditEnabled: () => {},
       mutationViews: new Map(),
+      pinboardEntities: new Set(),
+      hierarchyBasketSelection: new Set(),
     } as TestState;
 
     // The precondition: no model was ever loaded, or the last one was removed

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -21,6 +21,14 @@ interface SelectionFields {
   selectedModelId: string | null;
 }
 
+/** The pinboard/basket fields `removeModel` purges (pinboardSlice). Same
+ *  entityRef-string keying as `selectedEntitiesSet` above, reached the same
+ *  way — through a cast, since the fields live on another slice. */
+interface PinboardFields {
+  pinboardEntities: Set<string>;
+  hierarchyBasketSelection: Set<string>;
+}
+
 // Typed setter / getter shim that mirrors zustand's StateCreator
 // signature without the broader middleware machinery the test doesn't
 // need. Using StateCreator's exact types here would pull in the whole
@@ -76,7 +84,13 @@ describe('ModelSlice', () => {
       getState as Parameters<typeof createModelSlice>[1],
       undefined as unknown as Parameters<typeof createModelSlice>[2],
     );
-    state = { ...slice, ifcDataStore: null, geometryResult: null };
+    state = {
+      ...slice,
+      ifcDataStore: null,
+      geometryResult: null,
+      pinboardEntities: new Set<string>(),
+      hierarchyBasketSelection: new Set<string>(),
+    };
   });
 
   describe('initial state', () => {
@@ -389,6 +403,54 @@ describe('ModelSlice', () => {
       state.removeModel('model-2');
       assert.strictEqual(state.activeModelId, 'model-1');
     });
+
+    it('purges the REMOVED model\'s refs from the pinboard basket and keeps every survivor', () => {
+      // pinboardSlice's `pinboardEntities` / `hierarchyBasketSelection` are
+      // Set<string> of entityRef strings ("modelId:expressId"), the exact
+      // same shape `selectedEntitiesSet` already gets purged above. Nothing
+      // purged these: `pinboardEntities` is the documented "source of truth"
+      // basket set (see pinboardSlice.ts's cross-slice-state comment) that
+      // `addToBasket`/`removeFromBasket`/`showPinboard` re-derive
+      // `isolatedEntities` from via `toGlobalIdForRef` on every subsequent
+      // basket edit — and `toGlobalIdFromModels` falls back to the RAW,
+      // un-offset expressId when the ref's modelId is no longer in `models`.
+      // A stale "model-1:42" surviving removal therefore doesn't just dangle:
+      // the next basket operation resolves it to bare global id 42, which can
+      // collide with a real entity in a model whose own offset range covers
+      // 42 (e.g. any model with idOffset 0), silently co-isolating/hiding an
+      // entity the user never selected.
+      state.addModel(createMockModel('model-1', 'First'));
+      state.addModel(createMockModel('model-2', 'Second'));
+      Object.assign(state, {
+        pinboardEntities: new Set(['model-1:42', 'model-2:7']),
+        hierarchyBasketSelection: new Set(['model-1:1', 'model-2:2']),
+      });
+
+      state.removeModel('model-1');
+
+      const after = state as unknown as PinboardFields;
+      assert.deepStrictEqual([...after.pinboardEntities], ['model-2:7'], 'the survivor stays in the basket');
+      assert.deepStrictEqual(
+        [...after.hierarchyBasketSelection],
+        ['model-2:2'],
+        'the survivor stays in the hierarchy-derived basket source',
+      );
+    });
+
+    it('leaves the pinboard basket untouched when it names no ref from the removed model', () => {
+      state.addModel(createMockModel('model-1', 'First'));
+      state.addModel(createMockModel('model-2', 'Second'));
+      Object.assign(state, {
+        pinboardEntities: new Set(['model-2:7']),
+        hierarchyBasketSelection: new Set(['model-2:2']),
+      });
+
+      state.removeModel('model-1');
+
+      const after = state as unknown as PinboardFields;
+      assert.deepStrictEqual([...after.pinboardEntities], ['model-2:7']);
+      assert.deepStrictEqual([...after.hierarchyBasketSelection], ['model-2:2']);
+    });
   });
 
   describe('clearAllModels', () => {
@@ -400,6 +462,20 @@ describe('ModelSlice', () => {
 
       assert.strictEqual(state.models.size, 0);
       assert.strictEqual(state.activeModelId, null);
+    });
+
+    it('clears the pinboard basket along with every model', () => {
+      state.addModel(createMockModel('model-1', 'First'));
+      Object.assign(state, {
+        pinboardEntities: new Set(['model-1:42']),
+        hierarchyBasketSelection: new Set(['model-1:1']),
+      });
+
+      state.clearAllModels();
+
+      const after = state as unknown as PinboardFields;
+      assert.strictEqual(after.pinboardEntities.size, 0);
+      assert.strictEqual(after.hierarchyBasketSelection.size, 0);
     });
   });
 

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -30,6 +30,11 @@ import {
 export interface ModelCrossSliceState {
   ifcDataStore: IfcDataStore | null;
   geometryResult: GeometryResult | null;
+  /** Pinboard/basket state (pinboardSlice) `removeModel`/`clearAllModels`
+   *  purge of refs the removed model(s) owned — same entityRef-string
+   *  keying as `selectedEntitiesSet`. See `removeModel`'s comment for why. */
+  pinboardEntities: Set<string>;
+  hierarchyBasketSelection: Set<string>;
 }
 
 export interface ModelSlice {
@@ -347,6 +352,8 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
         selectedEntities: EntityRef[];
         selectedEntitiesSet: Set<string>;
         selectedModelId: string | null;
+        pinboardEntities: Set<string>;
+        hierarchyBasketSelection: Set<string>;
       }>;
       const priorEntities = sel.selectedEntities ?? [];
       const priorSet = sel.selectedEntitiesSet ?? new Set<string>();
@@ -355,6 +362,30 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
         sel.selectedEntity?.modelId === modelId ||
         sel.activeStorey?.modelId === modelId ||
         keptEntities.length !== priorEntities.length;
+
+      // Pinboard/basket state (pinboardSlice) is keyed the same way as
+      // `selectedEntitiesSet` above -- Set<string> of "modelId:expressId"
+      // entityRef strings -- but was never purged here. `pinboardEntities`
+      // is documented in pinboardSlice.ts as the basket's SOURCE OF TRUTH:
+      // every basket edit (`addToBasket`/`removeFromBasket`/`showPinboard`)
+      // re-derives `isolatedEntities` from it via `toGlobalIdForRef`, and
+      // `toGlobalIdFromModels` falls back to the RAW, un-offset expressId
+      // when a ref's modelId is no longer in `models`. A stale ref surviving
+      // removal therefore doesn't just dangle inertly: the next basket
+      // operation resolves it to a bare, unscaled global id that can collide
+      // with a real entity in any surviving model whose own offset range
+      // covers that raw number (any model with idOffset 0, notably) --
+      // silently co-isolating or co-hiding an entity the user never touched.
+      const priorPinboard = sel.pinboardEntities ?? new Set<string>();
+      const priorHierarchyBasket = sel.hierarchyBasketSelection ?? new Set<string>();
+      const keptPinboard = new Set(
+        [...priorPinboard].filter((k) => stringToEntityRef(k).modelId !== modelId)
+      );
+      const keptHierarchyBasket = new Set(
+        [...priorHierarchyBasket].filter((k) => stringToEntityRef(k).modelId !== modelId)
+      );
+      const pinboardTouchedRemoved =
+        keptPinboard.size !== priorPinboard.size || keptHierarchyBasket.size !== priorHierarchyBasket.size;
 
       return {
         models: newModels,
@@ -380,6 +411,9 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
               ),
               selectedModelId: sel.selectedModelId === modelId ? null : (sel.selectedModelId ?? null),
             }
+          : {}),
+        ...(pinboardTouchedRemoved
+          ? { pinboardEntities: keptPinboard, hierarchyBasketSelection: keptHierarchyBasket }
           : {}),
       };
     });
@@ -414,6 +448,11 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       activeModelId: null,
       ifcDataStore: null,
       geometryResult: null,
+      // Same dangling-ref shape as `removeModel`'s pinboard purge above, for
+      // the full-teardown path: with every model gone, every basket ref is
+      // stale by definition.
+      pinboardEntities: new Set(),
+      hierarchyBasketSelection: new Set(),
     });
   },
 


### PR DESCRIPTION
## Summary

Closing out the `removeModel`/`clearAllModels` teardown family (#2832, #2847) by enumeration: audited every slice under `apps/viewer/src/store/slices/` for model-keyed/derived state and checked whether `removeModel` and `clearAllModels` purge it, and whether the two agree with each other.

Found one more member of the same shape as #2832 (a globalId/entityRef-keyed set that survives model removal): **pinboardSlice's basket state** (`pinboardEntities`, `hierarchyBasketSelection`) was never purged by either function.

`pinboardEntities` is pinboardSlice's documented source of truth for the basket — every basket edit (`addToBasket`/`removeFromBasket`/`showPinboard`) re-derives `isolatedEntities` from it via `toGlobalIdForRef` → `toGlobalIdFromModels`, which falls back to the **raw, un-offset `expressId`** once a ref's `modelId` is no longer in `models`. A stale ref surviving removal therefore doesn't just dangle: the next basket operation can resolve it to a bare id that collides with a real entity in any surviving model whose own offset range covers that number (any model loaded at `idOffset` 0, notably) — silently co-isolating or co-hiding an entity the user never touched, on top of inflating the basket's visible entity count in the toolbar/dock indefinitely.

Demonstrated with a real-store harness (`apps/viewer/src/store/removeModel-pinboard-stale.test.ts`): basket two refs across two federated models, remove one model, call `showPinboard()` — before the fix, `isolatedEntities` picks up the stale ref as bare id `42`; after, only the surviving ref (`1005`) is isolated.

Note: `syncSourceModel.ts`'s `purgeStaleEntityState` — the reference implementation #2832 built on — has the identical gap (doesn't touch pinboard state either) on the same-modelId resync path. Left as a follow-up; flagging here since it's the same root cause.

This PR does not touch the fields #2832 / #2847 already cover (`addElementModelId`, the selection/isolation globalId sets, `pointCloudDeviationComputed`) — no overlap with either open PR's diff.

## Test plan
- [x] RED: `apps/viewer/src/store/slices/modelSlice.test.ts` — 2 new tests fail on unpatched `modelSlice.ts` (`purges the REMOVED model's refs from the pinboard basket and keeps every survivor`, `clears the pinboard basket along with every model`)
- [x] RED: `apps/viewer/src/store/removeModel-pinboard-stale.test.ts` fails on unpatched code, demonstrating the raw-id collision via a real combined-store harness
- [x] GREEN: all of the above pass after the fix
- [x] `pnpm --filter @ifc-lite/viewer` — 152 tests across `selectionSlice`, `visibilitySlice`, `pinboardSlice`, `modelSlice`, `collabSlice.entry-race`, and the new file — all pass
- [x] `tsc --noEmit` clean
- [x] `oxlint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removing a model now clears its related pinboard and hierarchy basket references.
  * Clearing all models now resets all associated basket and pinboard selections.
  * Prevented stale references from causing incorrect isolation, visibility, or entity resolution behavior.

* **Tests**
  * Added coverage for model removal, full model clearing, and preserving unrelated selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->