### PR TITLE
fix(codegen): correct IFC4X3 schema filename in generateAll()

### DIFF
--- a/.changeset/codegen-generate-all-ifc4x3-filename.md
+++ b/.changeset/codegen-generate-all-ifc4x3-filename.md
@@ -1,0 +1,19 @@
+---
+'@ifc-lite/codegen': patch
+---
+
+`generateAll()` named the IFC4X3 schema file as `IFC4X3_ADD2.exp`, but the
+schema actually shipped in `schemas/` is `IFC4X3.exp`. The function does not
+throw or exit non-zero when a named schema file is missing — it logs a
+warning and moves on — so calling `generateAll()` silently produced only the
+`ifc4/` output directory and skipped `ifc4x3/` entirely, with no error to
+signal that a whole schema had gone missing.
+
+`generateAll()` is not exercised by any script in this repo (the package.json
+`generate:ifc4x3` script calls the CLI directly with an explicit path), so the
+mismatch was invisible here, but it is exported from the package's public API
+for anyone using `@ifc-lite/codegen` as a library.
+
+Fixed the filename and added a regression test that runs `generateAll()`
+against the real `schemas/` directory and asserts both output directories are
+produced.

--- a/packages/codegen/src/generator.ts
+++ b/packages/codegen/src/generator.ts
@@ -249,7 +249,7 @@ export function generateAll(
 ): void {
   const schemas = [
     { name: 'IFC4', file: 'IFC4_ADD2_TC1.exp', dir: 'ifc4' },
-    { name: 'IFC4X3', file: 'IFC4X3_ADD2.exp', dir: 'ifc4x3' },
+    { name: 'IFC4X3', file: 'IFC4X3.exp', dir: 'ifc4x3' },
   ];
 
   for (const schema of schemas) {

--- a/packages/codegen/test/generate-all.test.ts
+++ b/packages/codegen/test/generate-all.test.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test: generateAll() must find both schema files it names.
+ *
+ * generateAll() hardcodes the schema filenames it looks for in the given
+ * schemas directory. If a filename drifts out of sync with what actually
+ * ships in schemas/, generateAll() does not throw or exit non-zero — it
+ * just logs a warning and silently skips that schema's output directory.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { generateAll } from '../src/generator.js';
+
+describe('generateAll', () => {
+  let outDir: string | undefined;
+
+  afterEach(() => {
+    if (outDir) {
+      rmSync(outDir, { recursive: true, force: true });
+      outDir = undefined;
+    }
+  });
+
+  it('generates output for every schema it names, not just the first', () => {
+    outDir = mkdtempSync(join(tmpdir(), 'codegen-generate-all-'));
+    const schemasDir = join(process.cwd(), 'schemas');
+
+    generateAll(schemasDir, outDir);
+
+    const produced = readdirSync(outDir);
+    expect(produced).toContain('ifc4');
+    expect(produced).toContain('ifc4x3');
+    expect(existsSync(join(outDir, 'ifc4x3', 'entities.ts'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `generateAll()` in `packages/codegen/src/generator.ts` named the IFC4X3 schema file `IFC4X3_ADD2.exp`, but the file actually shipped in `schemas/` is `IFC4X3.exp`.
- A missing schema file only logs a warning (`⚠️ Schema file not found: ...`) rather than throwing or exiting non-zero, so `generateAll()` silently produced only the `ifc4/` output directory and skipped `ifc4x3/` entirely — confirmed by running it against the real `schemas/` directory.
- `generateAll()` is not called by any script in this repo (`generate:ifc4x3` goes through the CLI with an explicit schema path, which is why the mismatch was invisible here), but it is exported from `@ifc-lite/codegen`'s public API for library consumers.

## Test plan
- [x] Added `packages/codegen/test/generate-all.test.ts`, which runs `generateAll()` against the real `schemas/` directory and asserts both `ifc4/` and `ifc4x3/entities.ts` are produced.
- [x] RED: reverting the filename fix reproduces the failure (`expected [ 'ifc4' ] to include 'ifc4x3'`).
- [x] GREEN: `pnpm test` in `packages/codegen` — 9 files / 117 tests passing (was 8/116).
- [x] `pnpm run build` (tsc) passes; regenerating `generated/ifc4` and `generated/ifc4x3` via the CLI is still byte-identical to the committed output (unaffected by this fix, since the CLI scripts pass explicit paths).
- [x] Also swept `packages/create-ifc-lite`: scaffolded and built all six templates (basic, threejs, babylonjs, react, server, server-native) in a scratch directory — all build cleanly with no other defects found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IFC4X3 schema selection during code generation.
  * Ensured generation produces output for both IFC4 and IFC4X3 schemas.

* **Tests**
  * Added regression coverage verifying IFC4X3 output and generated entity files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->