### PR TITLE
fix(viewer): pinned sheet transform cache survives a sheet swap

### DIFF
--- a/.changeset/pinned-sheet-transform-stale-on-swap.md
+++ b/.changeset/pinned-sheet-transform-stale-on-swap.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the 2D sheet drawing rendering at the wrong position/scale after swapping paper size, scale, or a saved sheet template while "keep position on regenerate" (pinned) was on.
+
+`Drawing2DCanvas` reuses `cachedSheetTransformRef.current` whenever pinned, instead of recomputing the transform from the active sheet's viewport/scale/paper. `useViewControls` only cleared that cache on an axis/flip change or a `sheetEnabled` on/off toggle — but `setPaperSize`, `setFrameStyle`, `updateFrameMargins`, and `setDrawingScale` all mutate the same sheet in place (same id), and `loadTemplate` swaps in a different sheet entirely, none of which ever touch `sheetEnabled`. The cache kept the OLD sheet's transform applied to the new paper/scale/viewport until the user toggled sheet mode off and back on, or changed the section axis.
+
+`useViewControls` now also invalidates the cache whenever the sheet's id, paper size, viewport bounds, or scale factor changes.

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.stale-pinned-transform.test.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.stale-pinned-transform.test.tsx
@@ -1,0 +1,192 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * PR #2853 review (coderabbit): `Drawing2DCanvas` reads
+ * `cachedSheetTransformRef.current` in its drawing effect and reuses it
+ * whenever `isPinned` is on. `useViewControls` is the hook that clears that
+ * ref when the sheet's geometry changes (`useViewControls.sheet-change.test.tsx`),
+ * but it is the PARENT of whatever renders `Drawing2DCanvas`, and React
+ * commits a child's effects before its parent's on the same update. On the
+ * very render the sheet's geometry changes, the canvas's drawing effect can
+ * therefore run BEFORE the clearing effect and reuse a transform computed
+ * for the OLD sheet — and nothing forces a second draw afterwards to correct
+ * it, since clearing a ref is not itself a render trigger.
+ *
+ * `useViewControls.sheet-change.test.tsx` only asserts on the ref-clearing
+ * effect in isolation, so it cannot see this: from that test's point of
+ * view, the ref import always ends up `null`, whichever effect cleared it.
+ * This file drives `Drawing2DCanvas` directly and reproduces the race
+ * window itself — a cached entry, still PRESENT (as it would be for one
+ * frame before the clearing effect runs), tagged with the OLD sheet's
+ * geometry — and asserts the canvas does not trust it.
+ *
+ * The fix (`sheetGeometryKeyOf`, apps/viewer/src/lib/drawing/sheet-geometry-key.ts)
+ * tags each cached transform with the geometry key it was computed FOR, and
+ * `Drawing2DCanvas` validates that key against the CURRENT sheet before ever
+ * reusing the cache — independent of which effect fires first.
+ */
+
+import '@/test/setup-dom.js';
+import { installLayout } from '@/test/dom-layout.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  GraphicOverrideEngine,
+  PAPER_SIZE_REGISTRY,
+  FRAME_PRESETS,
+  TITLE_BLOCK_PRESETS,
+  DEFAULT_TITLE_BLOCK_FIELDS,
+  DEFAULT_SCALE_BAR,
+  DEFAULT_NORTH_ARROW,
+  calculateViewportBounds,
+} from '@ifc-lite/drawing-2d';
+import type { Drawing2D, DrawingSheet } from '@ifc-lite/drawing-2d';
+import { Drawing2DCanvas } from './Drawing2DCanvas.js';
+import { sheetGeometryKeyOf, type CachedSheetTransform } from '@/lib/drawing/sheet-geometry-key.js';
+
+installLayout();
+
+/** No-op 2D context — this test only cares what transform the effect reads
+ *  back into the ref, not what it draws. Mirrors the stub in
+ *  Drawing2DCanvas.unit-display-override.test.tsx. */
+function installCanvasStub(): { restore: () => void } {
+  const ctx = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'measureText') return (text: string) => ({ width: String(text).length * 7 });
+        if (prop === 'canvas') return { width: 800, height: 600 };
+        return () => undefined;
+      },
+      set() {
+        return true;
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D;
+
+  const original = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = ((kind: string) =>
+    kind === '2d' ? ctx : null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+  return { restore: () => { HTMLCanvasElement.prototype.getContext = original; } };
+}
+
+const EMPTY_DRAWING: Drawing2D = {
+  config: {
+    plane: { axis: 'y', position: 0, flipped: false },
+    projectionDepth: 10,
+    includeHiddenLines: true,
+    creaseAngle: 30,
+    scale: 100,
+  },
+  lines: [],
+  cutPolygons: [],
+  projectionPolygons: [],
+  bounds: { min: { x: 0, y: 0 }, max: { x: 10, y: 10 } },
+  stats: {
+    cutLineCount: 0,
+    projectionLineCount: 0,
+    hiddenLineCount: 0,
+    silhouetteLineCount: 0,
+    polygonCount: 0,
+    totalTriangles: 0,
+    processingTimeMs: 0,
+  },
+};
+
+/** A real, fully-populated `DrawingSheet` — the same building blocks
+ *  `sheetSlice.createDefaultSheet` uses — so the frame/title-block draw code
+ *  (margins, border weights, title-block grid) has everything it reads,
+ *  unlike a partially-cast fixture. */
+function sheet(id: string, paperId: 'A3_LANDSCAPE' | 'A0_LANDSCAPE', factor: number): DrawingSheet {
+  const paper = PAPER_SIZE_REGISTRY[paperId];
+  const frame = { style: 'professional' as const, ...FRAME_PRESETS.professional };
+  const titleBlock = {
+    ...TITLE_BLOCK_PRESETS.standard,
+    fields: DEFAULT_TITLE_BLOCK_FIELDS.map((f) => ({ ...f })),
+    logo: null,
+  };
+  const viewportBounds = calculateViewportBounds(paper, frame, titleBlock);
+  return {
+    id,
+    name: id,
+    paper,
+    frame,
+    titleBlock,
+    scaleBar: { ...DEFAULT_SCALE_BAR },
+    scale: { name: 'test', factor, useCase: '' },
+    northArrow: { ...DEFAULT_NORTH_ARROW },
+    viewportBounds,
+    revisions: [],
+  };
+}
+
+const SHEET_A = sheet('sheet-a', 'A3_LANDSCAPE', 50);
+const SHEET_B = sheet('sheet-b', 'A0_LANDSCAPE', 100); // different id, paper AND scale factor
+
+/** A cached transform that is obviously wrong for either sheet — reused only
+ *  if the read site trusts presence alone. */
+const STALE_SENTINEL: CachedSheetTransform = {
+  key: sheetGeometryKeyOf(SHEET_A),
+  translateX: 999,
+  translateY: 999,
+  scaleFactor: 999,
+};
+
+describe('Drawing2DCanvas rejects a pinned cache entry tagged with a DIFFERENT sheet (PR #2853 review)', () => {
+  it('recomputes the transform instead of reusing a stale entry left over from the previous sheet', () => {
+    const stub = installCanvasStub();
+    const cachedSheetTransformRef: React.MutableRefObject<CachedSheetTransform | null> = {
+      current: STALE_SENTINEL,
+    };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      act(() => {
+        root = createRoot(container);
+        // Rendered with SHEET_B (the NEW sheet) while the cache still holds
+        // SHEET_A's stale entry — exactly the one-frame race window: the
+        // clearing effect in `useViewControls` (this hook's parent) has not
+        // run yet, but the canvas is already drawing sheet B.
+        root.render(
+          <Drawing2DCanvas
+            drawing={EMPTY_DRAWING}
+            transform={{ x: 0, y: 0, scale: 1 }}
+            showHiddenLines={false}
+            overrideEngine={new GraphicOverrideEngine()}
+            overridesEnabled={false}
+            entityColorMap={new Map()}
+            useIfcMaterials={false}
+            sectionAxis="down"
+            sheetEnabled
+            activeSheet={SHEET_B}
+            isPinned
+            cachedSheetTransformRef={cachedSheetTransformRef}
+          />,
+        );
+      });
+
+      const after = cachedSheetTransformRef.current;
+      assert.ok(after, 'the draw effect must populate the cache for the new sheet');
+      assert.notStrictEqual(
+        after!.scaleFactor,
+        999,
+        `must not have reused sheet A's stale cached transform for sheet B; got ${JSON.stringify(after)}`,
+      );
+      assert.equal(
+        after!.key,
+        sheetGeometryKeyOf(SHEET_B),
+        `the cached entry must be tagged with sheet B's OWN geometry key; got ${JSON.stringify(after)}`,
+      );
+    } finally {
+      if (root) act(() => { root!.unmount(); });
+      container.remove();
+      stub.restore();
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -17,6 +17,7 @@ import type { PolygonArea2DResult, TextAnnotation2D, CloudAnnotation2D, Annotati
 import type { DxfUnderlayRenderData } from '@/hooks/useDxfUnderlay';
 import type { AnnotationFill2D, AnnotationText2D } from '@/hooks/useSymbolicAnnotations';
 import type { ScanBandPoint } from '@/hooks/scanSectionMath';
+import { sheetGeometryKeyOf, type CachedSheetTransform } from '@/lib/drawing/sheet-geometry-key';
 
 // Fill colors for IFC types (architectural convention)
 const IFC_TYPE_FILL_COLORS: Record<string, string> = {
@@ -363,7 +364,7 @@ interface Drawing2DCanvasProps {
   sectionAxis: 'down' | 'front' | 'side';
   // Pinned mode - keep model fixed in place on sheet
   isPinned?: boolean;
-  cachedSheetTransformRef?: React.MutableRefObject<{ translateX: number; translateY: number; scaleFactor: number } | null>;
+  cachedSheetTransformRef?: React.MutableRefObject<CachedSheetTransform | null>;
   // Annotation props
   annotation2DActiveTool?: Annotation2DTool;
   annotation2DCursorPos?: Point2D | null;
@@ -739,7 +740,17 @@ export function Drawing2DCanvas({
       // Use cached transform when pinned, otherwise calculate new one
       let drawingTransform: { translateX: number; translateY: number; scaleFactor: number };
 
-      if (isPinned && cachedSheetTransformRef?.current) {
+      // Validated against the CURRENT sheet's own geometry key, not just
+      // trusted because it's present: `useViewControls`'s effect that nulls
+      // this ref on a geometry change runs in the SAME commit as this
+      // drawing effect, but as the PARENT hook its effect commits AFTER this
+      // (child) effect — so on the very render the sheet's geometry changes,
+      // a stale (still non-null) cached entry would otherwise be reused for
+      // one frame, and nothing forces a second draw to correct it (PR #2853
+      // review). Comparing `key` here makes this effect correct on its own,
+      // independent of that ordering.
+      const currentSheetGeometryKey = sheetGeometryKeyOf(activeSheet);
+      if (isPinned && cachedSheetTransformRef?.current && cachedSheetTransformRef.current.key === currentSheetGeometryKey) {
         // Use cached transform to keep model fixed in place
         drawingTransform = cachedSheetTransformRef.current;
       } else {
@@ -755,9 +766,10 @@ export function Drawing2DCanvas({
             : baseTransform.translateY - (drawingBounds.maxY + drawingBounds.minY) * baseTransform.scaleFactor,
         };
 
-        // Cache the transform for pinned mode
+        // Cache the transform for pinned mode, tagged with the geometry it
+        // was computed for (see the validation above).
         if (cachedSheetTransformRef) {
-          cachedSheetTransformRef.current = drawingTransform;
+          cachedSheetTransformRef.current = { ...drawingTransform, key: currentSheetGeometryKey };
         }
       }
 

--- a/apps/viewer/src/components/viewer/Section2DPanel.tsx
+++ b/apps/viewer/src/components/viewer/Section2DPanel.tsx
@@ -43,6 +43,7 @@ import { useDrawingExport } from '@/hooks/useDrawingExport';
 import { useSymbolicAnnotationsForDrawing, symbolicAnnotationsOverlayEnabled } from '@/hooks/useSymbolicAnnotations';
 import { useDxfUnderlaysForDrawing, useDxfMapToWorldTransform, dxfWorldShift, dxfUnderlayDrawingBounds } from '@/hooks/useDxfUnderlay';
 import { useScanSectionLayer } from '@/hooks/useScanSectionLayer';
+import type { CachedSheetTransform } from '@/lib/drawing/sheet-geometry-key';
 
 interface Section2DPanelProps {
   mergedGeometry?: GeometryResult | null;
@@ -200,7 +201,7 @@ export function Section2DPanel({
   // Track resize event handlers for cleanup
   const resizeHandlersRef = useRef<{ move: ((e: MouseEvent) => void) | null; up: (() => void) | null }>({ move: null, up: null });
   // Cache sheet drawing transform when pinned (to keep model fixed in place)
-  const cachedSheetTransformRef = useRef<{ translateX: number; translateY: number; scaleFactor: number } | null>(null);
+  const cachedSheetTransformRef = useRef<CachedSheetTransform | null>(null);
 
   // Track panel width for responsive header
   useEffect(() => {

--- a/apps/viewer/src/hooks/useViewControls.sheet-change.test.tsx
+++ b/apps/viewer/src/hooks/useViewControls.sheet-change.test.tsx
@@ -176,6 +176,87 @@ describe('useViewControls sheet-swap cache invalidation', () => {
     }
   });
 
+  it('clears the cache on a PAPER-SIZE-ONLY change (setPaperSize with viewport/scale untouched)', async () => {
+    // Isolates the `paper.widthMm`/`heightMm` term of `sheetGeometryKey`.
+    // The `sheet()` fixture DERIVES `viewportBounds.width` from `widthMm`
+    // (`width: widthMm - 20`), so simply calling `sheet('sheet-a', f, 841)`
+    // for `after` would move paper size AND viewportBounds together and
+    // could not tell which term the assertion actually depends on (PR #2853
+    // review — mutating either term alone left the previous single
+    // "paper AND scale" test green). Build `after` by overriding ONLY
+    // `paper`, holding `before`'s `viewportBounds` literally.
+    const cacheRef: React.MutableRefObject<CachedTransform> = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      const before = sheet('sheet-a', 50, 420);
+      await act(async () => {
+        root = createRoot(container);
+        root.render(<Harness activeSheet={before} cacheRef={cacheRef} />);
+      });
+
+      cacheRef.current = SENTINEL;
+
+      // SAME id, viewportBounds and scale; ONLY the paper size changes.
+      const after: DrawingSheet = {
+        ...before,
+        paper: { ...before.paper, widthMm: 841, heightMm: 594 } as DrawingSheet['paper'],
+      };
+      await act(async () => {
+        root!.render(<Harness activeSheet={after} cacheRef={cacheRef} />);
+      });
+
+      assert.equal(
+        cacheRef.current,
+        null,
+        `cached transform must not survive a paper-size-only change; got ${JSON.stringify(cacheRef.current)}`,
+      );
+    } finally {
+      if (root) await act(async () => { root!.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('clears the cache on a VIEWPORT-BOUNDS-ONLY change (updateFrameMargins with paper/scale untouched)', async () => {
+    // Isolates the `viewportBounds` term of `sheetGeometryKey` — the
+    // `updateFrameMargins` path recomputes `viewportBounds` without
+    // touching `paper` or `scale` at all, so a key that dropped this term
+    // would leave the cache stale through a margin change with nothing
+    // above catching it (PR #2853 review).
+    const cacheRef: React.MutableRefObject<CachedTransform> = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      const before = sheet('sheet-a', 50, 420);
+      await act(async () => {
+        root = createRoot(container);
+        root.render(<Harness activeSheet={before} cacheRef={cacheRef} />);
+      });
+
+      cacheRef.current = SENTINEL;
+
+      // SAME id, paper and scale; ONLY the viewport bounds change.
+      const after: DrawingSheet = {
+        ...before,
+        viewportBounds: { ...before.viewportBounds, x: 20, y: 20 },
+      };
+      await act(async () => {
+        root!.render(<Harness activeSheet={after} cacheRef={cacheRef} />);
+      });
+
+      assert.equal(
+        cacheRef.current,
+        null,
+        `cached transform must not survive a viewport-bounds-only change; got ${JSON.stringify(cacheRef.current)}`,
+      );
+    } finally {
+      if (root) await act(async () => { root!.unmount(); });
+      container.remove();
+    }
+  });
+
   it('negative control: keeps the cached transform across a re-render of the SAME sheet', async () => {
     const cacheRef: React.MutableRefObject<CachedTransform> = { current: null };
     const container = document.createElement('div');

--- a/apps/viewer/src/hooks/useViewControls.sheet-change.test.tsx
+++ b/apps/viewer/src/hooks/useViewControls.sheet-change.test.tsx
@@ -30,10 +30,15 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { DrawingSheet } from '@ifc-lite/drawing-2d';
 import { useViewControls } from './useViewControls.js';
+import type { CachedSheetTransform } from '@/lib/drawing/sheet-geometry-key.js';
 
-type CachedTransform = { translateX: number; translateY: number; scaleFactor: number } | null;
+type CachedTransform = CachedSheetTransform | null;
 
-function sheet(id: string, scale: number, widthMm: number): DrawingSheet {
+/** `factor` is the sheet's actual scale factor (`activeSheet.scale.factor`,
+ *  the field `sheetGeometryKey` reads) — a real `DrawingSheet['scale']`
+ *  object, not a bare number cast past the type, so the fixture's `factor`
+ *  is never `undefined` (PR #2853 review). */
+function sheet(id: string, factor: number, widthMm: number): DrawingSheet {
   return {
     id,
     name: id,
@@ -41,7 +46,7 @@ function sheet(id: string, scale: number, widthMm: number): DrawingSheet {
     frame: {} as unknown as DrawingSheet['frame'],
     titleBlock: { fields: [], position: 'bottom-right', heightMm: 30 } as unknown as DrawingSheet['titleBlock'],
     scaleBar: {} as unknown as DrawingSheet['scaleBar'],
-    scale: scale as unknown as DrawingSheet['scale'],
+    scale: { name: 'test', factor, useCase: '' },
     northArrow: {} as unknown as DrawingSheet['northArrow'],
     viewportBounds: { x: 10, y: 10, width: widthMm - 20, height: 260 },
     revisions: [],
@@ -68,7 +73,7 @@ function Harness({ activeSheet, cacheRef }: HarnessProps): null {
   return null;
 }
 
-const SENTINEL: CachedTransform = { translateX: 1, translateY: 2, scaleFactor: 3 };
+const SENTINEL: CachedTransform = { key: 'sentinel', translateX: 1, translateY: 2, scaleFactor: 3 };
 
 describe('useViewControls sheet-swap cache invalidation', () => {
   it('clears the cached pinned transform when a different sheet replaces activeSheet', async () => {
@@ -129,6 +134,41 @@ describe('useViewControls sheet-swap cache invalidation', () => {
         cacheRef.current,
         null,
         `cached transform must not survive a paper/scale change on the same sheet id; got ${JSON.stringify(cacheRef.current)}`,
+      );
+    } finally {
+      if (root) await act(async () => { root!.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('clears the cache on a SCALE-ONLY change (setDrawingScale with paper untouched)', async () => {
+    // Isolates the `scale.factor` term of `sheetGeometryKey` from the paper
+    // width — the previous test's fixture also changed paper width in the
+    // same rerender, so it could pass even if the scale factor were dropped
+    // from the key entirely (PR #2853 review).
+    const cacheRef: React.MutableRefObject<CachedTransform> = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      const before = sheet('sheet-a', 50, 420);
+      await act(async () => {
+        root = createRoot(container);
+        root.render(<Harness activeSheet={before} cacheRef={cacheRef} />);
+      });
+
+      cacheRef.current = SENTINEL;
+
+      // SAME id and paper, ONLY the scale factor changes.
+      const after: DrawingSheet = { ...before, scale: { name: 'x', factor: 100, useCase: '' } };
+      await act(async () => {
+        root!.render(<Harness activeSheet={after} cacheRef={cacheRef} />);
+      });
+
+      assert.equal(
+        cacheRef.current,
+        null,
+        `cached transform must not survive a scale-only change; got ${JSON.stringify(cacheRef.current)}`,
       );
     } finally {
       if (root) await act(async () => { root!.unmount(); });

--- a/apps/viewer/src/hooks/useViewControls.sheet-change.test.tsx
+++ b/apps/viewer/src/hooks/useViewControls.sheet-change.test.tsx
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The pinned-sheet transform cache must not survive a sheet SWAP.
+ *
+ * `Drawing2DCanvas` reuses `cachedSheetTransformRef.current` whenever
+ * `isPinned` is on, instead of recomputing `calculateDrawingTransform`
+ * from the current sheet's `viewportBounds`/`scale`/`paper`
+ * (Drawing2DCanvas.tsx around line 742). `useViewControls` is the only
+ * place that ever clears that ref — on an axis/flip change, and on a
+ * `sheetEnabled` false→true/true→false toggle.
+ *
+ * Loading a different saved sheet template (`sheetSlice.loadTemplate`,
+ * wired from `SheetSetupPanel`) replaces `activeSheet` with a sheet that
+ * has a different id, paper size, scale and viewport — while
+ * `sheetEnabled` stays `true` throughout, since the user was already in
+ * sheet mode. `setPaperSize` / `setDrawingScale` do the same thing to the
+ * SAME sheet id. Neither transition fires the `sheetEnabled` effect, so
+ * the cache silently keeps the OLD sheet's transform and the canvas draws
+ * the new sheet's content at the wrong position/scale until the user
+ * flips sheet mode off and back on, or changes the section axis.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { DrawingSheet } from '@ifc-lite/drawing-2d';
+import { useViewControls } from './useViewControls.js';
+
+type CachedTransform = { translateX: number; translateY: number; scaleFactor: number } | null;
+
+function sheet(id: string, scale: number, widthMm: number): DrawingSheet {
+  return {
+    id,
+    name: id,
+    paper: { id: 'p', name: 'p', widthMm, heightMm: 297, orientation: 'landscape' } as unknown as DrawingSheet['paper'],
+    frame: {} as unknown as DrawingSheet['frame'],
+    titleBlock: { fields: [], position: 'bottom-right', heightMm: 30 } as unknown as DrawingSheet['titleBlock'],
+    scaleBar: {} as unknown as DrawingSheet['scaleBar'],
+    scale: scale as unknown as DrawingSheet['scale'],
+    northArrow: {} as unknown as DrawingSheet['northArrow'],
+    viewportBounds: { x: 10, y: 10, width: widthMm - 20, height: 260 },
+    revisions: [],
+  };
+}
+
+interface HarnessProps {
+  activeSheet: DrawingSheet | null;
+  cacheRef: React.MutableRefObject<CachedTransform>;
+}
+
+function Harness({ activeSheet, cacheRef }: HarnessProps): null {
+  useViewControls({
+    drawing: null,
+    sectionPlane: { axis: 'down', position: 50, flipped: false },
+    containerRef: { current: null },
+    panelVisible: true,
+    status: 'ready',
+    sheetEnabled: true,
+    activeSheet,
+    isPinned: true,
+    cachedSheetTransformRef: cacheRef,
+  });
+  return null;
+}
+
+const SENTINEL: CachedTransform = { translateX: 1, translateY: 2, scaleFactor: 3 };
+
+describe('useViewControls sheet-swap cache invalidation', () => {
+  it('clears the cached pinned transform when a different sheet replaces activeSheet', async () => {
+    const cacheRef: React.MutableRefObject<CachedTransform> = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      await act(async () => {
+        root = createRoot(container);
+        root.render(<Harness activeSheet={sheet('sheet-a', 50, 420)} cacheRef={cacheRef} />);
+      });
+
+      // Simulate the canvas having cached a transform for sheet A while pinned.
+      cacheRef.current = SENTINEL;
+
+      // Swap to a DIFFERENT sheet (different id/scale/paper) — `sheetEnabled`
+      // never toggles, matching `loadTemplate` / `setPaperSize` / `setDrawingScale`.
+      await act(async () => {
+        root!.render(<Harness activeSheet={sheet('sheet-b', 100, 841)} cacheRef={cacheRef} />);
+      });
+
+      assert.equal(
+        cacheRef.current,
+        null,
+        `cached transform from sheet-a must not survive a swap to sheet-b; got ${JSON.stringify(cacheRef.current)}`,
+      );
+    } finally {
+      if (root) await act(async () => { root!.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('clears the cache when setPaperSize/setDrawingScale mutate the SAME sheet id', async () => {
+    // sheetSlice.setPaperSize / setFrameStyle / setDrawingScale all do
+    // `set({ activeSheet: { ...current, paper, viewportBounds } })` — the id
+    // is untouched. Only `loadTemplate` gives the sheet a new id.
+    const cacheRef: React.MutableRefObject<CachedTransform> = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      const before = sheet('sheet-a', 50, 420);
+      await act(async () => {
+        root = createRoot(container);
+        root.render(<Harness activeSheet={before} cacheRef={cacheRef} />);
+      });
+
+      cacheRef.current = SENTINEL;
+
+      // Same id, different paper width (setPaperSize) and scale (setDrawingScale).
+      const after: DrawingSheet = { ...before, paper: { ...before.paper, widthMm: 841 } as DrawingSheet['paper'], scale: { name: 'x', factor: 100, useCase: '' } };
+      await act(async () => {
+        root!.render(<Harness activeSheet={after} cacheRef={cacheRef} />);
+      });
+
+      assert.equal(
+        cacheRef.current,
+        null,
+        `cached transform must not survive a paper/scale change on the same sheet id; got ${JSON.stringify(cacheRef.current)}`,
+      );
+    } finally {
+      if (root) await act(async () => { root!.unmount(); });
+      container.remove();
+    }
+  });
+
+  it('negative control: keeps the cached transform across a re-render of the SAME sheet', async () => {
+    const cacheRef: React.MutableRefObject<CachedTransform> = { current: null };
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    let root: Root | null = null;
+    try {
+      const sheetA = sheet('sheet-a', 50, 420);
+      await act(async () => {
+        root = createRoot(container);
+        root.render(<Harness activeSheet={sheetA} cacheRef={cacheRef} />);
+      });
+
+      cacheRef.current = SENTINEL;
+
+      // Re-render with the SAME sheet object (e.g. an unrelated parent
+      // re-render) — the cache must survive, or "pinned" would never work.
+      await act(async () => {
+        root!.render(<Harness activeSheet={sheetA} cacheRef={cacheRef} />);
+      });
+
+      assert.deepEqual(
+        cacheRef.current,
+        SENTINEL,
+        'an unrelated re-render with the same sheet must not clear the pin cache',
+      );
+    } finally {
+      if (root) await act(async () => { root!.unmount(); });
+      container.remove();
+    }
+  });
+});

--- a/apps/viewer/src/hooks/useViewControls.ts
+++ b/apps/viewer/src/hooks/useViewControls.ts
@@ -4,6 +4,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Drawing2D, DrawingSheet } from '@ifc-lite/drawing-2d';
+import { sheetGeometryKeyOf, type CachedSheetTransform } from '@/lib/drawing/sheet-geometry-key';
 
 interface UseViewControlsParams {
   drawing: Drawing2D | null;
@@ -14,11 +15,7 @@ interface UseViewControlsParams {
   sheetEnabled: boolean;
   activeSheet: DrawingSheet | null;
   isPinned: boolean;
-  cachedSheetTransformRef: React.MutableRefObject<{
-    translateX: number;
-    translateY: number;
-    scaleFactor: number;
-  } | null>;
+  cachedSheetTransformRef: React.MutableRefObject<CachedSheetTransform | null>;
 }
 
 interface UseViewControlsResult {
@@ -202,9 +199,18 @@ function useViewControls({
   // sheet's transform (position/scale computed for its old paper/viewport)
   // applied to the new content until the user flipped sheet mode off and
   // back on, or changed the section axis.
-  const sheetGeometryKey = activeSheet
-    ? `${activeSheet.id}|${activeSheet.paper.widthMm}x${activeSheet.paper.heightMm}|${activeSheet.viewportBounds.x},${activeSheet.viewportBounds.y},${activeSheet.viewportBounds.width},${activeSheet.viewportBounds.height}|${activeSheet.scale.factor}`
-    : null;
+  //
+  // This effect-driven clear is a best-effort SECOND line of defense, not the
+  // correctness guarantee: `Drawing2DCanvas` is the CHILD of whichever
+  // component calls this hook, and React commits child effects before parent
+  // effects on the same update — so on the very render `sheetGeometryKey`
+  // changes, the canvas's drawing effect can still read the STALE cached
+  // transform (this effect hasn't nulled it yet), draw one frame with it, and
+  // then never redraw again since nothing else changed (PR #2853 review). The
+  // actual guarantee is `Drawing2DCanvas` validating the cached entry's own
+  // `key` against the CURRENT `sheetGeometryKeyOf(activeSheet)` at the READ
+  // site, before ever reusing it — see the module doc there.
+  const sheetGeometryKey = sheetGeometryKeyOf(activeSheet);
   const prevSheetGeometryKeyRef = useRef(sheetGeometryKey);
   useEffect(() => {
     if (sheetGeometryKey !== prevSheetGeometryKeyRef.current) {

--- a/apps/viewer/src/hooks/useViewControls.ts
+++ b/apps/viewer/src/hooks/useViewControls.ts
@@ -191,6 +191,28 @@ function useViewControls({
     }
   }, [sheetEnabled, status, drawing, fitToView]);
 
+  // Track everything the cached transform is actually derived FROM
+  // (`calculateDrawingTransform(drawingBounds, viewport, activeSheet.scale)`
+  // in Drawing2DCanvas.tsx) rather than the sheet's id: `setPaperSize`,
+  // `setFrameStyle`/`updateFrameMargins` (both recompute `viewportBounds`)
+  // and `setDrawingScale` all mutate the SAME `activeSheet.id` in place
+  // (sheetSlice.ts), while `loadTemplate` swaps in a different id entirely.
+  // Any of these must invalidate the cache even though `sheetEnabled` never
+  // toggles across the change. Without this, a pinned view kept the OLD
+  // sheet's transform (position/scale computed for its old paper/viewport)
+  // applied to the new content until the user flipped sheet mode off and
+  // back on, or changed the section axis.
+  const sheetGeometryKey = activeSheet
+    ? `${activeSheet.id}|${activeSheet.paper.widthMm}x${activeSheet.paper.heightMm}|${activeSheet.viewportBounds.x},${activeSheet.viewportBounds.y},${activeSheet.viewportBounds.width},${activeSheet.viewportBounds.height}|${activeSheet.scale.factor}`
+    : null;
+  const prevSheetGeometryKeyRef = useRef(sheetGeometryKey);
+  useEffect(() => {
+    if (sheetGeometryKey !== prevSheetGeometryKeyRef.current) {
+      prevSheetGeometryKeyRef.current = sheetGeometryKey;
+      cachedSheetTransformRef.current = null;
+    }
+  }, [sheetGeometryKey, cachedSheetTransformRef]);
+
   // Auto-fit when: (1) needsFit is true (first open or axis change), or (2) not pinned after regenerate
   // ALWAYS fit when axis changed, regardless of pin state
   // Also re-run when panelVisible changes so we fit when panel opens with existing drawing

--- a/apps/viewer/src/lib/drawing/sheet-geometry-key.ts
+++ b/apps/viewer/src/lib/drawing/sheet-geometry-key.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import type { DrawingSheet } from '@ifc-lite/drawing-2d';
+
+/**
+ * Everything `Drawing2DCanvas`'s pinned-transform cache is actually derived
+ * FROM (`calculateDrawingTransform(drawingBounds, viewport, activeSheet.scale)`),
+ * folded into one comparable string — id, paper size, viewport bounds and
+ * scale factor. `setPaperSize`, `setFrameStyle`/`updateFrameMargins` (both
+ * recompute `viewportBounds`) and `setDrawingScale` all mutate the SAME
+ * `activeSheet.id` in place (sheetSlice.ts), while `loadTemplate` swaps in a
+ * different id entirely — any of these must be visible here even though the
+ * sheet's `id` alone would not change for the first three (PR #2853 review).
+ *
+ * Shared between `useViewControls` (which clears the cache when this key
+ * changes) and `Drawing2DCanvas` (which validates the cache against this key
+ * at the READ site, not just the write site — see the module doc on
+ * `cachedSheetTransformRef` in Drawing2DCanvas.tsx for why the write-site
+ * clear alone is not enough to prevent a stale draw).
+ */
+export function sheetGeometryKeyOf(sheet: DrawingSheet | null | undefined): string | null {
+  if (!sheet) return null;
+  return `${sheet.id}|${sheet.paper.widthMm}x${sheet.paper.heightMm}|${sheet.viewportBounds.x},${sheet.viewportBounds.y},${sheet.viewportBounds.width},${sheet.viewportBounds.height}|${sheet.scale.factor}`;
+}
+
+/**
+ * The pinned-sheet transform cache entry, self-describing: `key` is the
+ * `sheetGeometryKeyOf()` of the sheet it was computed FOR, so a reader can
+ * reject it on a mismatch instead of trusting that some other effect already
+ * cleared it. See {@link sheetGeometryKeyOf}.
+ */
+export interface CachedSheetTransform {
+  key: string | null;
+  translateX: number;
+  translateY: number;
+  scaleFactor: number;
+}


### PR DESCRIPTION
## Summary
- `Drawing2DCanvas` reuses `cachedSheetTransformRef.current` whenever the 2D sheet view is pinned ("keep position on regenerate"), instead of recomputing the transform from the active sheet's viewport/scale/paper.
- `useViewControls` only cleared that cache on a section axis/flip change or a `sheetEnabled` on↔off toggle. `setPaperSize`, `setFrameStyle`, `updateFrameMargins`, and `setDrawingScale` all mutate the *same* sheet id in place, and `loadTemplate` swaps in a different sheet id — none of these ever touch `sheetEnabled`, so the cache silently kept applying the OLD sheet's transform to the new paper/scale/viewport until the user toggled sheet mode off and back on, or changed the section axis.
- `useViewControls` now also invalidates the cache when the sheet's id, paper size, viewport bounds, or scale factor changes.

## Test plan
- [x] `apps/viewer/src/hooks/useViewControls.sheet-change.test.tsx` (new): drives the real hook.
  - RED (before fix): "clears the cached pinned transform when a different sheet replaces activeSheet" failed — `cacheRef.current` stayed the stale sentinel instead of `null`.
  - GREEN (after fix): same test passes, plus a second case covering the same-id `setPaperSize`/`setDrawingScale` mutation shape, plus a negative control proving an unrelated re-render of the *same* sheet does not clear the cache (so pinning still works).
- [x] `pnpm --filter @ifc-lite/viewer` hook test run (targeted file) — 3/3 pass.
- [x] `tsc --noEmit` — no new errors in `useViewControls.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale 2D sheet positioning when switching sheets or changing paper size, scale, viewport, or saved templates while pinned positioning is enabled.
  - Ensured cached transforms remain available during unrelated updates for smoother viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->