### PR TITLE
fix(viewer): purge compareResult and the active lens on clearAllModels

### DIFF
--- a/.changeset/clearallmodels-purges-compare-and-lens.md
+++ b/.changeset/clearallmodels-purges-compare-and-lens.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix `clearAllModels` leaving an active model-comparison result and lens still pointed at a federation that no longer exists, and fix `removeModel` leaving a comparison result stale when the removed model was either side of it.
+
+`federationRegistry.clear()` (called by `clearAllModels`) resets the offset counter to 0, so the next model registered can be handed the exact global-id offsets a surviving `compareResult` or lens state describes. `GeoreferencingPanel.tsx`'s `reloadModelsForAlignment` calls `clearAllModels()` directly, without `resetViewerState()` — the only other place either was cleared — then reloads every model. If a comparison or a lens was active, its `excludedHiddenIds`/`diff` or `lensHiddenIds`/`lensColorMap`/`lensAppliedColors` could then silently hide or tint elements of the freshly reloaded, unrelated model. `useLens.ts`'s effect deps (`[activeLensId, activeLens]`) also never re-run on a model add/remove on their own, so a lens stays stale across any such reload regardless.
+
+`clearAllModels` now clears `compareResult` and deactivates the lens (mirroring what `resetViewerState` already does on an ordinary file load). `removeModel` now clears `compareResult` when the removed model was the comparison's base or head — offsets are never reused on a partial removal, so this is precautionary consistency, not a misresolution fix — and leaves it alone otherwise, so removing an unrelated federated sibling does not disturb a comparison between two other still-loaded models.

--- a/apps/viewer/src/store/removeModel-compare-stale.test.ts
+++ b/apps/viewer/src/store/removeModel-compare-stale.test.ts
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { federationRegistry } from '@ifc-lite/renderer';
+import { useViewerStore } from './index.js';
+import type { FederatedModel } from './types.js';
+import type { CompareResult } from './slices/compareSlice.js';
+import { buildCompareOverlay } from '../lib/compare/overlay.js';
+
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+function emptyDiff(): CompareResult['diff'] {
+  return {
+    scope: 'data',
+    excludedTypes: [],
+    entries: [],
+    byKey: new Map(),
+    counts: { added: 0, modified: 0, deleted: 0, unchanged: 0 },
+  } as unknown as CompareResult['diff'];
+}
+
+function makeCompareResult(): CompareResult {
+  return {
+    baseModelId: 'A',
+    headModelId: 'B',
+    baseName: 'A',
+    headName: 'B',
+    scope: 'data',
+    geometryUnavailable: false,
+    excludedHiddenIds: new Set([42, 1005]),
+    diff: emptyDiff(),
+  };
+}
+
+describe('compareResult (incl. excludedHiddenIds) survives model teardown as a dangling — and, after a georef reload, misresolvable — reference', () => {
+  it('clearAllModels now clears compareResult, closing the offset-reuse misresolution window', () => {
+    // Reproduces GeoreferencingPanel.tsx's `reloadModelsForAlignment`:
+    // `clearAllModels()` directly, WITHOUT `resetViewerState()` (the only
+    // other place compareResult was ever cleared), followed by reloading
+    // every model. `federationRegistry.clear()` resets the offset counter to
+    // 0, so the first model registered after the clear can be handed the
+    // exact offsets an un-cleared compareResult's ids describe.
+    federationRegistry.clear();
+    federationRegistry.registerModel('A', 100);
+    federationRegistry.registerModel('B', 100);
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+    });
+    useViewerStore.getState().setCompareResult(makeCompareResult());
+
+    useViewerStore.getState().clearAllModels();
+
+    const afterClear = useViewerStore.getState();
+    console.log('compareResult after clearAllModels:', afterClear.compareResult);
+    assert.strictEqual(
+      afterClear.compareResult,
+      null,
+      'clearAllModels must drop compareResult — every pairing it could describe is gone',
+    );
+
+    // Reload a model — offset space was reset, so it can land on the same
+    // offsets the (now-cleared) old result used to describe. With
+    // compareResult null, there is nothing left to misresolve.
+    const newOffsetC = federationRegistry.registerModel('C', 50);
+    assert.strictEqual(newOffsetC, 0, 'offset space is not burned across a full clear — confirms the hazard is real');
+    useViewerStore.getState().addModel(model('C', newOffsetC, 50));
+    assert.strictEqual(useViewerStore.getState().compareResult, null, 'reload must not resurrect a stale comparison');
+  });
+
+  it('removeModel clears compareResult when the removed model was the base or head of the comparison', () => {
+    federationRegistry.clear();
+    federationRegistry.registerModel('A', 100);
+    federationRegistry.registerModel('B', 100);
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+    });
+    useViewerStore.getState().setCompareResult(makeCompareResult());
+
+    useViewerStore.getState().removeModel('B');
+
+    assert.strictEqual(
+      useViewerStore.getState().compareResult,
+      null,
+      'removing the HEAD model of an active comparison must drop the (now half-describing) result',
+    );
+  });
+
+  it('negative control: removeModel on a model NOT party to the comparison leaves compareResult untouched', () => {
+    // Proves the removeModel fix is not a blanket clear — a third federated
+    // sibling leaving does not invalidate a comparison between two OTHER
+    // still-loaded models.
+    federationRegistry.clear();
+    federationRegistry.registerModel('A', 100);
+    federationRegistry.registerModel('B', 100);
+    federationRegistry.registerModel('C', 100);
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+        ['C', model('C', 2000, 2100)],
+      ]),
+      activeModelId: 'A',
+    });
+    const result = makeCompareResult();
+    useViewerStore.getState().setCompareResult(result);
+
+    useViewerStore.getState().removeModel('C');
+
+    const after = useViewerStore.getState();
+    console.log('compareResult after removing an uninvolved model:', after.compareResult);
+    assert.strictEqual(
+      after.compareResult,
+      result,
+      'a comparison between A and B must survive the removal of an unrelated model C',
+    );
+
+    // And the excludedHiddenIds channel still resolves correctly against the
+    // surviving A/B federation — nothing was disturbed.
+    const { hiddenIds } = buildCompareOverlay(result.diff, false, result.excludedHiddenIds);
+    assert.deepStrictEqual(hiddenIds, new Set([42, 1005]));
+  });
+});

--- a/apps/viewer/src/store/removeModel-lens-stale.test.ts
+++ b/apps/viewer/src/store/removeModel-lens-stale.test.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { federationRegistry } from '@ifc-lite/renderer';
+import { useViewerStore } from './index.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+/** Seeds the store as if `useLens.ts`'s effect had just evaluated an active
+ *  lens against a 2-model federation (A offset 0, B offset 1000) — exactly
+ *  the fields that effect writes on every evaluation. */
+function seedActiveLensState(): void {
+  useViewerStore.setState({
+    activeLensId: 'lens-1',
+    lensColorMap: new Map([[42, '#ff0000'], [1005, '#00ff00']]),
+    lensAppliedColors: new Map([[42, [1, 0, 0, 1]], [1005, [0, 1, 0, 1]]]),
+    lensHiddenIds: new Set([7, 1008]),
+    lensAppliedHiddenIds: [7, 1008],
+    lensRuleCounts: new Map([['rule-1', 2]]),
+    lensRuleEntityIds: new Map([['rule-1', [42, 1005]]]),
+  });
+}
+
+describe('clearAllModels leaves an active lens\'s computed maps stale — offset-reuse can misresolve them', () => {
+  it('clears the lens (deactivates + wipes computed maps) instead of leaving it pointed at a pre-reload federation', () => {
+    // Reproduces the same georef-reload path as removeModel-compare-stale:
+    // `clearAllModels()` directly, without `resetViewerState()` — the only
+    // other place the lens gets deactivated.
+    federationRegistry.clear();
+    federationRegistry.registerModel('A', 100);
+    federationRegistry.registerModel('B', 100);
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+    });
+    seedActiveLensState();
+
+    useViewerStore.getState().clearAllModels();
+
+    const after = useViewerStore.getState();
+    console.log('activeLensId after clearAllModels:', after.activeLensId);
+    console.log('lensHiddenIds after clearAllModels:', [...after.lensHiddenIds]);
+    console.log('lensColorMap after clearAllModels:', [...after.lensColorMap.entries()]);
+
+    assert.strictEqual(after.activeLensId, null, 'clearAllModels must deactivate the lens — no federation is left for it to describe');
+    assert.strictEqual(after.lensHiddenIds.size, 0, 'lensHiddenIds must not survive with stale global ids');
+    assert.strictEqual(after.lensColorMap.size, 0, 'lensColorMap must not survive with stale global ids');
+    assert.strictEqual(after.lensAppliedColors, null);
+    assert.strictEqual(after.lensAppliedHiddenIds.length, 0);
+    assert.strictEqual(after.lensRuleEntityIds.size, 0);
+
+    // Reload: offset space was reset by federationRegistry.clear() inside
+    // clearAllModels, so the first model back gets offset 0 again — global id
+    // 42 (previously A's lens-matched entity) would land on model C's own
+    // live entity 42 if the lens state had survived.
+    const newOffsetC = federationRegistry.registerModel('C', 50);
+    assert.strictEqual(newOffsetC, 0, 'offset space is not burned across a full clear — confirms the hazard is real');
+    useViewerStore.getState().addModel(model('C', newOffsetC, 50));
+
+    const final = useViewerStore.getState();
+    assert.strictEqual(final.activeLensId, null, 'reload must not resurrect a deactivated lens');
+    assert.strictEqual(final.lensHiddenIds.size, 0, 'model C\'s own entity 7 (if it has one) must not be hidden by a stale lens claim');
+  });
+
+  it('negative control: removeModel (partial, no offset reuse) leaves the active lens untouched', () => {
+    // No `federationRegistry.clear()` runs on a partial removal — offsets are
+    // burned, never reused — so there is no collision hazard here, and the
+    // lens state legitimately still describes the surviving model B. Proves
+    // the clearAllModels fix above is not a blanket "any model change clears
+    // the lens".
+    federationRegistry.clear();
+    federationRegistry.registerModel('A', 100);
+    federationRegistry.registerModel('B', 100);
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+    });
+    seedActiveLensState();
+
+    useViewerStore.getState().removeModel('A');
+
+    const after = useViewerStore.getState();
+    console.log('activeLensId after removeModel(A):', after.activeLensId);
+    assert.strictEqual(after.activeLensId, 'lens-1', 'removing one model of a federation must not deactivate an active lens');
+    assert.deepStrictEqual(after.lensHiddenIds, new Set([7, 1008]));
+  });
+});

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -306,6 +306,29 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       cross.clearIdsValidationReport?.();
     }
 
+    // A published compare result (compareSlice) names its base/head models by
+    // id and its `excludedHiddenIds` / `diff` entries carry federation GLOBAL
+    // ids computed against those two models' offsets. If the removed model
+    // was either side of that comparison, the result no longer describes a
+    // pairing that exists — same dangling-reference shape as the IDS report
+    // above, one slice over. Left alone it merely dangles here (removeModel
+    // never resets `federationRegistry`'s offset counter, so no later model
+    // can be re-assigned these same ids) but `clearAllModels` below does not
+    // have that guarantee, so this call site exists for symmetry and so a
+    // partial federation edit (remove one side of a compare, add a
+    // replacement) can't leave a comparison silently describing the old
+    // pairing while a new one of the same shape loads.
+    const compareCross = get() as unknown as {
+      compareResult?: { baseModelId: string; headModelId: string } | null;
+      clearCompare?: () => void;
+    };
+    if (
+      compareCross.compareResult &&
+      (compareCross.compareResult.baseModelId === modelId || compareCross.compareResult.headModelId === modelId)
+    ) {
+      compareCross.clearCompare?.();
+    }
+
     set((state) => {
       const newModels = new Map(state.models);
       newModels.delete(modelId);
@@ -409,6 +432,56 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     endClashScenePresentation(() => get() as unknown as ClashSceneTeardown, 'federation-cleared');
     // Clear the federation registry
     federationRegistry.clear();
+    // `federationRegistry.clear()` above resets the offset counter to 0, so
+    // the very next model registered can be handed the exact offsets any
+    // surviving compare result's `excludedHiddenIds` / `diff` global ids
+    // describe (see `removeModel-compare-stale.test.ts`: a georef-triggered
+    // reload calls `clearAllModels()` then reloads every model, and the
+    // first one back gets offset 0 again). Unconditional, unlike
+    // `removeModel`'s guarded version above — with every model gone there is
+    // no pairing left for a compare result to describe either way, and here
+    // the offset-reuse hazard makes leaving it behind actively dangerous
+    // rather than merely stale.
+    (get() as unknown as { clearCompare?: () => void }).clearCompare?.();
+    // Same offset-reuse hazard, on the lens channel: `useLens.ts`'s effect
+    // deps are `[activeLensId, activeLens]`, NOT `models` — a model
+    // add/remove never re-evaluates the active lens, so `lensColorMap`,
+    // `lensHiddenIds`, `lensAppliedColors`, `lensRuleCounts` and
+    // `lensRuleEntityIds` keep naming whatever global ids they were last
+    // computed against. `resetViewerState` (store/index.ts) already
+    // deactivates the lens and clears these on every ordinary file load; the
+    // gap is the same one `compareResult` had above — the georef-reload path
+    // (`GeoreferencingPanel.tsx`'s `reloadModelsForAlignment`) calls only
+    // `clearAllModels()`, never `resetViewerState()`, and the reload that
+    // follows can hand the first model back offset 0. A lens still "active"
+    // across that reload would then apply its stale hide/colour ids to
+    // whatever entities the new federation assigned those same global ids —
+    // hiding or tinting elements the user never touched. Guarded on
+    // `activeLensId` so a clear with no lens ever active is a no-op, same
+    // shape as `removeModel`'s `compareCross` guard above.
+    const lensCross = get() as unknown as {
+      activeLensId?: string | null;
+      setActiveLens?: (id: string | null) => void;
+      setLensColorMap?: (m: Map<number, string>) => void;
+      setLensAppliedColors?: (m: Map<number, [number, number, number, number]> | null) => void;
+      setLensHiddenIds?: (s: Set<number>) => void;
+      setLensAppliedHiddenIds?: (ids: number[]) => void;
+      setLensRuleIsolation?: (v: { ruleId: string; entityIds: number[] } | null) => void;
+      setLensRuleCounts?: (m: Map<string, number>) => void;
+      setLensRuleEntityIds?: (m: Map<string, number[]>) => void;
+      setLensAutoColorLegend?: (legend: unknown[]) => void;
+    };
+    if (lensCross.activeLensId != null) {
+      lensCross.setActiveLens?.(null);
+      lensCross.setLensColorMap?.(new Map());
+      lensCross.setLensAppliedColors?.(null);
+      lensCross.setLensHiddenIds?.(new Set());
+      lensCross.setLensAppliedHiddenIds?.([]);
+      lensCross.setLensRuleIsolation?.(null);
+      lensCross.setLensRuleCounts?.(new Map());
+      lensCross.setLensRuleEntityIds?.(new Map());
+      lensCross.setLensAutoColorLegend?.([]);
+    }
     return set({
       models: new Map(),
       activeModelId: null,


### PR DESCRIPTION
## Summary

Continues the `modelSlice.removeModel`/`clearAllModels` teardown-audit family (#2832, #2847, #2851) with two more rows from the enumeration:

- **compareSlice.excludedHiddenIds (and compareResult as a whole) — confirmed defect, fixed.** `clearAllModels` never cleared `compareResult`; only `resetViewerState` did. `federationRegistry.clear()` (inside `clearAllModels`) resets the id-offset counter to 0, so the next model registered can be handed the exact global ids a surviving `compareResult`'s `excludedHiddenIds`/`diff` describe. `GeoreferencingPanel.tsx`'s `reloadModelsForAlignment` calls `clearAllModels()` directly, without `resetViewerState()`, then reloads every model — a stale comparison result would then have its hide/colour ids applied to whatever the freshly reloaded, unrelated model was assigned those same offsets. Also fixed `removeModel` to clear `compareResult` when the removed model was the comparison's base or head (precautionary — offsets are never reused on a partial removal, so there is no misresolution risk there, only staleness).
- **lensSlice (`lensColorMap`/`lensHiddenIds`/`lensAppliedColors`/`lensRuleCounts`/`lensRuleEntityIds`) — confirmed defect, fixed.** Same offset-reuse hazard, plus `useLens.ts`'s effect deps (`[activeLensId, activeLens]`) never include `models`, so a model add/remove alone never re-evaluates an active lens. `clearAllModels` now deactivates the lens and clears its computed maps, mirroring what `resetViewerState` already does on an ordinary file load.

Other rows from the enumeration, closed without a code change:
- `clashSlice.clashHighlightColors` — **handled**: already cleared via `endClashScenePresentation` (called from both `removeModel` and `clearAllModels`).
- `clashSlice.clashExclusionCounts` — **benign**: keyed by rule id → count, not by entity/global id, so it cannot misresolve; fully recomputed on `clearAllModels` via `clearClash`, and its removeModel-path staleness mirrors `clashRawResult`'s own deliberately-kept behavior.
- `searchSlice.searchModelFilter` — **benign**: `Set<string>` of model ids, tested only via `.has(r.modelId)` against live search results; a stale entry simply never matches.
- `scheduleSlice.expandedTaskGlobalIds`/`selectedTaskGlobalIds` — **benign**: keyed by IFC `GlobalId` (content UUID), not a federation numeric id/offset, so it can't collide the way a bare `expressId` can.
- `overlaySlice.overlayLayers`/`hiddenIds`/`colorOverrides` — **suspected, not fixed here**: the 'animation' layer (`useConstructionSequence.ts`) is registered from an effect whose deps don't include `models` either, and `scheduleData` (which gates it) is not cleared by `clearAllModels`, only `resetViewerState` — same shape as the two fixed here, via the same `reloadModelsForAlignment` vector. Left as a follow-up: lower-probability trigger (requires animation enabled + paused, not just an active lens/compare) and out of scope for this pass' effort budget.

## Test plan

- [x] `removeModel-compare-stale.test.ts` (new): RED confirmed the defect (compareResult and excludedHiddenIds survive `clearAllModels`, and a subsequent reload assigns the stale ids' offsets to a real, unrelated model — quoted in the test's own comments); GREEN after the fix; negative control proves `removeModel` on an uninvolved third model leaves `compareResult` untouched.
- [x] `removeModel-lens-stale.test.ts` (new): same RED → GREEN → negative-control shape for the lens.
- [x] Mutation-tested both fixes by hand (disabling each guard/call and confirming the corresponding named test fails; a blanket "always clear" mutation is caught by each negative control).
- [x] `pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=1 src/store/removeModel-compare-stale.test.ts src/store/removeModel-lens-stale.test.ts src/store/slices/modelSlice.test.ts src/store/slices/collabSlice.entry-race.test.ts src/store/slices/overlaySlice.test.ts` — 49/49 pass.
- [x] `pnpm turbo run build --filter=@ifc-lite/viewer` — clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearing all models now also clears comparison results and deactivates any active lens.
  * Removing a model involved in a comparison now removes the stale comparison result.
  * Lens visualizations and comparison overlays no longer retain outdated data after models are removed or reset.

* **Tests**
  * Added coverage for model removal, comparison cleanup, lens state reset, and offset reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->