### PR TITLE
fix(viewer): resolve datum +towgs84 fallback key mismatch for EPSG:2065 / EPSG:27700

### DIFF
--- a/.changeset/reproject-datum-key-mismatch.md
+++ b/.changeset/reproject-datum-key-mismatch.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix EPSG:2065 (S-JTSK Ferro Krovak) and EPSG:27700 (OSGB36 British National Grid, when its precision-grid fetch is unavailable) silently getting zero datum shift on reprojection.
+
+`sanitizeProj4`'s `DATUM_TOWGS84` fallback table is keyed by the datum name reported by the bundled EPSG index (`packages/data`), lowercased. For EPSG:2065 that name is `"S-JTSK (Ferro)"`, and for EPSG:27700 it is `"OSGB36"` — neither matched the table's existing `'s-jtsk'` / `'osgb 1936'` keys, so the lookup missed silently (no warning either, since the OSGB36 case only warns when a `+nadgrids` reference is present to strip, and the 2065 def carries none). EPSG:2065 has no precision-grid coverage at all (see `precision-grids.ts`), so this fallback was its only datum shift — every EPSG:2065 model reprojected with the source CRS's raw coordinates read as if they were already WGS84, landing roughly 100+ m off. EPSG:27700 is normally rescued by the OSTN15 precision grid, so this only bit when that fetch failed (offline, CDN down, or in a Node test environment, which always skips the network fetch).
+
+Added `'osgb36'` and `'s-jtsk (ferro)'` as additional keys carrying the same published Bursa-Wolf parameters already used under the existing aliases. `reproject.test.ts`'s EPSG:2065 fixture previously passed the idealized datum name `'S-JTSK'` rather than the real `'S-JTSK (Ferro)'` the bundled index reports for that code, which is why the mismatch went unnoticed — it now uses the real value, plus a new OSGB36 case.

--- a/apps/viewer/src/lib/geo/reproject.test.ts
+++ b/apps/viewer/src/lib/geo/reproject.test.ts
@@ -55,9 +55,25 @@ describe('sanitizeProj4 datum shift (#1357)', () => {
   it('adds the datum +towgs84 to an offset-datum def that lacks any shift (e.g. Ferro Krovak EPSG:2065)', () => {
     const ferro = '+proj=krovak +axis=swu +lat_0=49.5 +lon_0=42.5 +alpha=30.2881397527778 '
       + '+k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +pm=ferro +units=m +no_defs';
-    const out = sanitizeProj4(ferro, '2065', 'S-JTSK');
+    // The bundled EPSG index (packages/data) reports this code's datum as
+    // "S-JTSK (Ferro)", not "S-JTSK" — verified against
+    // packages/data/src/generated/epsg-index.generated.ts. Using the plain
+    // "S-JTSK" name here made this fixture unable to observe a datum-key
+    // lookup miss: production always passes the "(Ferro)" form for 2065.
+    const out = sanitizeProj4(ferro, '2065', 'S-JTSK (Ferro)');
     assert.ok(out.includes(SJTSK), `expected +towgs84 to be injected, got: ${out}`);
     assert.ok(out.includes('+pm=ferro'), 'must preserve the rest of the definition');
+  });
+
+  it('adds the datum +towgs84 for OSGB36 (EPSG:27700) using the bundled index datum name', () => {
+    // packages/data's bundled entry for 27700 reports datum "OSGB36" (no
+    // space, no "1936"), which must resolve through the same lookup as the
+    // 'osgb 1936' key below.
+    const OSGB = '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489';
+    const withGrid = '+proj=tmerc +ellps=airy +nadgrids=OSTN15_NTv2_OSGBtoETRS.gsb +units=m +no_defs';
+    const out = sanitizeProj4(withGrid, '27700', 'OSGB36');
+    assert.ok(!out.includes('+nadgrids'), 'must drop the unusable grid reference');
+    assert.ok(out.includes(OSGB), `expected OSGB36 +towgs84 to be injected, got: ${out}`);
   });
 
   it('strips an unusable +nadgrids and substitutes the datum +towgs84', () => {

--- a/apps/viewer/src/lib/geo/reproject.ts
+++ b/apps/viewer/src/lib/geo/reproject.ts
@@ -146,8 +146,12 @@ function utmProj4String(zone: string): string | null {
  * DHDN shift). Accuracy is typically ~1-5 m, sufficient for map display.
  */
 const DATUM_TOWGS84: Record<string, string> = {
-  // United Kingdom — OSGB36 (Airy 1830)
+  // United Kingdom — OSGB36 (Airy 1830). The bundled EPSG index (packages/data)
+  // reports this datum as the bare "OSGB36" for EPSG:27700 — keep both forms
+  // keyed since IFC files and EPSG metadata are inconsistent about which one
+  // they emit.
   'osgb 1936': '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489',
+  'osgb36': '+towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489',
   // North America — NAD27 (Clarke 1866)
   'north american datum 1927': '+towgs84=-8,160,176,0,0,0,0',
   'nad27': '+towgs84=-8,160,176,0,0,0,0',
@@ -169,9 +173,16 @@ const DATUM_TOWGS84: Record<string, string> = {
   // Austria — MGI (Bessel 1841)
   'militar-geographische institut': '+towgs84=577.326,90.129,463.919,5.137,1.474,5.297,2.4232',
   'mgi': '+towgs84=577.326,90.129,463.919,5.137,1.474,5.297,2.4232',
-  // Czech Republic — S-JTSK (Bessel 1841)
+  // Czech Republic — S-JTSK (Bessel 1841). EPSG:2065 (Ferro Krovak) — the
+  // exact code #1357 was filed against, and the only S-JTSK code with no
+  // precision-grid coverage (see precision-grids.ts) so this fallback is its
+  // ONLY datum shift — reports its datum as "S-JTSK (Ferro)" in the bundled
+  // EPSG index, not the bare "S-JTSK" below. Without this key the lookup
+  // silently missed (no warning either, since there's no +nadgrids to trigger
+  // one) and EPSG:2065 got zero datum shift.
   'system of the unified trigonometrical cadastral network': '+towgs84=570.8,85.7,462.8,4.998,1.587,5.261,3.56',
   's-jtsk': '+towgs84=570.8,85.7,462.8,4.998,1.587,5.261,3.56',
+  's-jtsk (ferro)': '+towgs84=570.8,85.7,462.8,4.998,1.587,5.261,3.56',
   // New Zealand — NZGD49 (International 1924)
   'new zealand geodetic datum 1949': '+towgs84=59.47,-5.04,187.44,0.47,-0.1,1.024,-4.5993',
   'nzgd49': '+towgs84=59.47,-5.04,187.44,0.47,-0.1,1.024,-4.5993',


### PR DESCRIPTION
## Summary
- `sanitizeProj4`'s `DATUM_TOWGS84` fallback table is keyed by the datum name from the bundled EPSG index (`packages/data`), lowercased and matched exactly.
- For EPSG:2065 (S-JTSK Ferro Krovak) the bundled index reports the datum as `"S-JTSK (Ferro)"`; for EPSG:27700 (OSGB36 British National Grid) it reports `"OSGB36"`. Neither matched the table's existing `'s-jtsk'` / `'osgb 1936'` keys, so the lookup silently missed.
- EPSG:2065 has **no precision-grid coverage** (see `precision-grids.ts`'s explicit comment on this), so this fallback was its only datum shift — every EPSG:2065 model reprojected with zero datum correction, landing roughly 100+ m off, with no warning (the warning is gated on a `+nadgrids` reference being present to strip, and the 2065 def carries none).
- EPSG:27700 is normally rescued by the OSTN15 precision grid fetched from `cdn.proj.org`, so this specific bug only bites when that fetch fails — offline, CDN down, or in a Node test environment (which always skips the network fetch and falls through to this exact path).
- Fixed by adding `'osgb36'` and `'s-jtsk (ferro)'` as additional table keys, carrying the same published Bursa-Wolf parameters already present under the existing aliases.
- `reproject.test.ts`'s EPSG:2065 fixture had been passing the idealized datum name `'S-JTSK'` instead of the real `'S-JTSK (Ferro)'` the bundled index reports for that exact code — a fixture that could not observe this exact key-mismatch class of bug. Corrected it to the real value (confirmed against `packages/data/src/generated/epsg-index.generated.ts`) and added a new EPSG:27700/`'OSGB36'` case.

## Test plan
- [x] `pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=1 src/lib/geo/reproject.test.ts` — RED (2 failing) before the fix, GREEN (32/32) after, from `apps/viewer`.
- [x] Broader geo-directory regression pass (`reproject.test.ts`, `reproject.adversarial.test.ts`, `precision-grids.test.ts`, `double-georeference.test.ts`, `effective-georef.test.ts`, `ecef-camera-frame.test.ts`, `egm96-undulation.test.ts`, `map-absolute.test.ts`, `cesium-bridge.test.ts`) — 158/158 pass.
- [x] `pnpm turbo build --filter=@ifc-lite/viewer...` — clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reprojection reliability for UK OSGB36 and Czech S-JTSK (Ferro) coordinate systems.
  * Corrected datum-shift fallback handling when EPSG metadata uses alternate datum names.
  * Removed unusable grid references and applied the appropriate transformation parameters for affected projections.
* **Tests**
  * Added coverage for UK and Czech reprojection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->