### PR TITLE
fix(viewer): georeferencing panel ePSet mapUnitScale parity

### DIFF
--- a/.changeset/georeferencing-panel-epset-scale-parity.md
+++ b/.changeset/georeferencing-panel-epset-scale-parity.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the Georeferencing panel's double-georeference banner reading the wrong scale for IFC2x3 `ePSet_MapConversion` files with no explicit ePset `MapUnit` — a 1000x scale error for millimetre projects.
+
+`getEffectiveGeoreference` (`effective-georef.ts`) resolves this case via `resolveEpsetMapUnitScale`: when an ePSet-sourced georeference has no explicit `MapUnit`, its offsets are in the project length unit per the buildingSMART convention, not metres. Every other consumer of the georeference — `ViewportContainer`, `BasepointOverlay`, `FederationAlignmentControls`, `federationAlign.ts`, `useAnchorGeoreference.ts` — reaches that fix by calling `getEffectiveGeoreference`.
+
+`GeoreferencingPanel.tsx` built its `mergedCRS` from `mergeProjectedCRS` alone, fed by `ModelMetadataPanel.tsx`'s own direct `extractGeoreferencingOnDemand` call rather than `getEffectiveGeoreference`. For an ePSet-sourced file with no explicit MapUnit this left `mapUnitScale` `undefined`, which `resolveMapUnitToMetreScale` reads as "treat offsets as metres" — the panel's `detectDoubleGeoreference` check then scaled a millimetre project's eastings/northings by 1 instead of 0.001, a 1000x error in the reported residual/displacement.
+
+`mergedCRS` now applies `resolveEpsetMapUnitScale` after `mergeProjectedCRS`, matching `getEffectiveGeoreference`'s composition exactly.

--- a/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
+++ b/apps/viewer/src/components/viewer/properties/GeoreferencingPanel.tsx
@@ -24,6 +24,7 @@ import {
   detectScaleUnitMismatch,
   mergeMapConversion,
   mergeProjectedCRS,
+  resolveEpsetMapUnitScale,
   supportsStandardGeoreferencing,
 } from '@/lib/geo/effective-georef';
 import { detectDoubleGeoreference, formatApproxDistance, trimFloat } from '@/lib/geo/double-georeference';
@@ -368,8 +369,22 @@ export function GeoreferencingPanel({ georef, modelId, enableEditing, schemaVers
   const canUseStandardGeoreferencing = supportsStandardGeoreferencing(schemaVersion, georef);
 
   const mergedCRS = useMemo((): ProjectedCRS | undefined => {
-    return mergeProjectedCRS(georef?.projectedCRS, mutations?.projectedCRS, lengthUnitScale ?? 1);
-  }, [georef?.projectedCRS, mutations?.projectedCRS, lengthUnitScale]);
+    const merged = mergeProjectedCRS(georef?.projectedCRS, mutations?.projectedCRS, lengthUnitScale ?? 1);
+    if (!merged) return merged;
+    // `mergeProjectedCRS` alone doesn't know the georeference's `source`, so an
+    // IFC2x3 `ePSet_MapConversion` file with no explicit ePset MapUnit leaves
+    // `mapUnitScale` undefined here -- which `resolveMapUnitToMetreScale` then
+    // reads as "treat offsets as metres" instead of the buildingSMART
+    // convention (project length unit). Every other consumer routes through
+    // `getEffectiveGeoreference`, which applies this same correction; this
+    // panel built its own `georef` via `extractGeoreferencingOnDemand` and
+    // never did, so `detectDoubleGeoreference` below was scaling a millimetre
+    // project's eastings/northings by 1 instead of 0.001 -- 1000x off.
+    return {
+      ...merged,
+      mapUnitScale: resolveEpsetMapUnitScale(georef?.source, merged.mapUnitScale, lengthUnitScale ?? 1),
+    };
+  }, [georef?.projectedCRS, georef?.source, mutations?.projectedCRS, lengthUnitScale]);
 
   const mergedConversion = useMemo((): MapConversion | undefined => {
     return mergeMapConversion(georef?.mapConversion, mutations?.mapConversion);

--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -234,6 +234,44 @@ describe('effective georeferencing', () => {
     it('leaves siteLocation georef untouched', () => {
       assert.strictEqual(resolveEpsetMapUnitScale('siteLocation', undefined, 0.001), undefined);
     });
+
+    /**
+     * `getEffectiveGeoreference` calls `mergeProjectedCRS` then
+     * `resolveEpsetMapUnitScale` in sequence (this file's `getEffectiveGeoreference`,
+     * around the `resolveEpsetMapUnitScale(original?.source, ...)` call). Every
+     * consumer that builds its CRS this way -- ViewportContainer, BasepointOverlay,
+     * FederationAlignmentControls, federationAlign.ts, useAnchorGeoreference.ts --
+     * gets the corrected scale.
+     *
+     * `GeoreferencingPanel.tsx` used to call `mergeProjectedCRS` ALONE (its
+     * `georef` prop comes from `ModelMetadataPanel.tsx`'s own
+     * `extractGeoreferencingOnDemand` call, not `getEffectiveGeoreference`), so
+     * for an ePSet_MapConversion IFC2x3 file with no explicit ePset MapUnit its
+     * `mergedCRS.mapUnitScale` stayed `undefined` -- which
+     * `resolveMapUnitToMetreScale` reads as "treat offsets as metres" (scale 1)
+     * instead of the project length-unit scale. For a millimetre project that
+     * fed `detectDoubleGeoreference` an easting/northing 1000x too large.
+     * Pinning the two-step composition here so a regression in either function
+     * -- or a caller that goes back to calling `mergeProjectedCRS` alone --
+     * shows up.
+     */
+    it('mergeProjectedCRS + resolveEpsetMapUnitScale composition matches getEffectiveGeoreference (GeoreferencingPanel parity)', () => {
+      const original: ProjectedCRS = {
+        id: 1,
+        name: 'RD_New',
+        mapUnit: undefined,
+        mapUnitScale: undefined,
+      };
+      const lengthUnitScale = 0.001; // millimetre project
+
+      const merged = mergeProjectedCRS(original, undefined, lengthUnitScale);
+      const scaleWithoutFix = resolveMapUnitToMetreScale(merged?.mapUnitScale, lengthUnitScale);
+      assert.strictEqual(scaleWithoutFix, 1, 'sanity: mergeProjectedCRS alone leaves the ePSet gap open');
+
+      const correctedMapUnitScale = resolveEpsetMapUnitScale('ePSetMapConversion', merged?.mapUnitScale, lengthUnitScale);
+      const scaleWithFix = resolveMapUnitToMetreScale(correctedMapUnitScale, lengthUnitScale);
+      assert.strictEqual(scaleWithFix, lengthUnitScale, 'the composed scale must match every other consumer');
+    });
   });
 
   it('infers common IFC map unit names', () => {


### PR DESCRIPTION
## Summary

Following #2855's `reproject.ts` datum-key fix, this PR was scoped to a sibling sweep of the geo/undulation code around `cesium-bridge.ts`, `useCesiumBridge.ts`, `double-georeference.ts`, `effective-georef.ts`, `ecef-camera-frame.ts`, and `terrain-elevation.ts`.

- **EGM96 undulation double-application (the priority row): confirmed clean, no bug.** All three call sites read/write distinct quantities:
  - `apps/viewer/src/lib/geo/cesium-bridge.ts:159-161` — converts the MODEL origin height orthometric → ellipsoidal exactly once per `computeCesiumModelOrigin` call; the result is stored in `modelOrigin.height` and never touched again.
  - `apps/viewer/src/components/viewer/cesium/useCesiumBridge.ts:170` — converts a separate TERRAIN sample (not the model height) orthometric → ellipsoidal, purely to compare against the already-ellipsoidal model frame for the below-terrain clip plane.
  - `apps/viewer/src/components/viewer/cesium/useCesiumBridge.ts:204` — recomputes the same N to convert that terrain value back to orthometric for the "snap to terrain" save target (`orthometricTargetForTerrain`), a net no-op on the terrain value, and still never touches the model height.
  
  No path re-enters `computeCesiumModelOrigin`/`createCesiumBridge` for the same conversion object, so N cannot be applied twice to the model. Existing fixtures (`egm96-undulation.test.ts`, `cesium-placement.test.ts`) already exercise materially non-zero undulation locations (Czechia ~+45m, Switzerland ~+49m, Netherlands ~+43m), not just sea level.

- **`double-georeference.ts` vs `effective-georef.ts` sibling comparison — found and fixed a real asymmetry**, described below.

- `ecef-camera-frame.ts` has no height/undulation logic at all (not applicable). `terrain-elevation.ts`'s `switch` over `TerrainElevationSource` is a closed local union, not an externally-sourced key table, so it doesn't match the #2855 "exact-match lookup table keyed on a string whose real value differs" shape.

## The fix

`getEffectiveGeoreference` (`effective-georef.ts`) resolves a documented gap: an IFC2x3 `ePSet_MapConversion` georeference with no explicit ePset `MapUnit` must scale its offsets by the *project length unit*, not treat them as metres (`resolveEpsetMapUnitScale`). Every consumer that goes through `getEffectiveGeoreference` — `ViewportContainer`, `BasepointOverlay`, `FederationAlignmentControls`, `federationAlign.ts`, `useAnchorGeoreference.ts` — gets this correction.

`GeoreferencingPanel.tsx` didn't: its `georef` prop (from `ModelMetadataPanel.tsx`) comes from a direct `extractGeoreferencingOnDemand` call, and its `mergedCRS` was built with `mergeProjectedCRS` alone, never applying `resolveEpsetMapUnitScale`. For an ePSet-sourced millimetre-unit project with no explicit MapUnit, this left `mapUnitScale` `undefined`, which `resolveMapUnitToMetreScale` reads as "treat as metres" — so the panel's `detectDoubleGeoreference` double-georeference banner scaled eastings/northings by 1 instead of 0.001, a demonstrated 1000x error (see the added test).

`mergedCRS` now applies `resolveEpsetMapUnitScale` after `mergeProjectedCRS`, matching `getEffectiveGeoreference`'s own composition.

## Test plan

- [x] `pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=1 src/lib/geo/effective-georef.test.ts src/lib/geo/double-georeference.test.ts src/lib/geo/cesium-bridge.test.ts src/lib/geo/cesium-placement.test.ts src/lib/geo/egm96-undulation.test.ts` — 111/111 pass
- [x] Mutation calibration: reverting `resolveEpsetMapUnitScale`'s fallback to `1` fails both the pre-existing `defaults an ePSet georef without MapUnit to the project length-unit scale` test and the new `mergeProjectedCRS + resolveEpsetMapUnitScale composition ... (GeoreferencingPanel parity)` test; reverting the fix restores green
- [x] `turbo run build --filter=@ifc-lite/viewer` — clean
- [x] `tsc --noEmit` on the touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)