### PR TITLE
fix(query): DuckDB integration reads NULL string property as empty string

### DIFF
--- a/.changeset/duckdb-property-null-sentinel.md
+++ b/.changeset/duckdb-property-null-sentinel.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/query": patch
+---
+
+Fix `ifc-lite query`'s DuckDB SQL integration reading a NULL string-typed property as an empty string instead of SQL `NULL`.
+
+`createPropertiesTable` (duckdb-integration.ts) resolved `PropertyTable.valueString` with `valueStringIdx >= 0 ? ... : ''`. `valueString` is a `Uint32Array`, so the NULL sentinel written by `StringTable.intern(null)` (-1) wraps to 4294967295 rather than going negative — the `>= 0` check was always true and never caught it, and the row was inserted with `value_string = ''`, indistinguishable from a genuine empty-string property. `WHERE value_string IS NULL` silently matched nothing.
+
+Two siblings on the same column family already guard this correctly: `getPropertyValue`'s String branch in `@ifc-lite/data`'s `property-table.ts` and its cache-restored twin in `@ifc-lite/cache`'s `properties.ts`, both checking `idx < strings.count`. This DuckDB path is named as a sibling in `property-table.ts`'s own doc comment ("the on-demand fallback in `@ifc-lite/query`") but used an independent, unguarded decode. The fix extracts the shared logic into `resolveDuckDBStringLiteral` and applies the same in-range check, emitting the bare `NULL` keyword — matching how this same file already handles the `containedInStorey`/`definedByType` sentinels a few lines above.

--- a/packages/query/src/duckdb-integration.ts
+++ b/packages/query/src/duckdb-integration.ts
@@ -257,14 +257,13 @@ export class DuckDBIntegration {
         const propName = escapeSQL(strings.get(properties.propName[j]));
         const propType = propTypeNames[properties.propType[j]] || 'Unknown';
 
-        const valueStringIdx = properties.valueString[j];
-        const valueString = valueStringIdx >= 0 ? escapeSQL(strings.get(valueStringIdx)) : '';
+        const valueStringLiteral = resolveDuckDBStringLiteral(properties.valueString[j], strings);
         const valueReal = isNaN(properties.valueReal[j]) ? 'NULL' : properties.valueReal[j];
         const valueInt = properties.valueInt[j];
         const valueBoolRaw = properties.valueBool[j];
         const valueBool = valueBoolRaw === 255 ? 'NULL' : valueBoolRaw === 1 ? 'true' : 'false';
 
-        values.push(`(${entityId}, '${psetName}', '${psetGlobalId}', '${propName}', '${propType}', '${valueString}', ${valueReal}, ${valueInt}, ${valueBool})`);
+        values.push(`(${entityId}, '${psetName}', '${psetGlobalId}', '${propName}', '${propType}', ${valueStringLiteral}, ${valueReal}, ${valueInt}, ${valueBool})`);
       }
 
       if (values.length > 0) {
@@ -504,4 +503,29 @@ function escapeSQL(value: string | null | undefined): string {
   }
   // Replace single quotes with two single quotes (SQL escape)
   return value.replace(/'/g, "''");
+}
+
+/**
+ * Resolve a `PropertyTable.valueString` cell to a SQL literal fragment
+ * ready to splice into an INSERT (either `'escaped text'` or the bare
+ * keyword `NULL`).
+ *
+ * `idx` is read from a `Uint32Array`, so the NULL sentinel written by
+ * `StringTable.intern(null)` (-1) wraps to 4294967295 rather than going
+ * negative — an `idx >= 0` guard is therefore always true and never
+ * catches it; only an in-range check (`idx < strings.count`) does. Without
+ * it, a NULL string-typed property value round-tripped through this table
+ * as `''`, indistinguishable from a genuine empty-string property.
+ *
+ * Mirrors the entities table's `containedInStorey`/`definedByType` NULL
+ * handling a few lines above (same file) and `getPropertyValue`'s String
+ * branch in `@ifc-lite/data`'s `property-table.ts` / its cache-restored
+ * twin in `@ifc-lite/cache`'s `properties.ts` — same column family, same
+ * sentinel, now the same guard in all four places.
+ */
+export function resolveDuckDBStringLiteral(
+  idx: number,
+  strings: { get(i: number): string; readonly count: number },
+): string {
+  return idx < strings.count ? `'${escapeSQL(strings.get(idx))}'` : 'NULL';
 }

--- a/packages/query/src/duckdb-string-literal.test.ts
+++ b/packages/query/src/duckdb-string-literal.test.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `resolveDuckDBStringLiteral` (duckdb-integration.ts) is the DuckDB-WASM
+ * sibling of `getPropertyValue`'s String-branch NULL-sentinel guard in
+ * `@ifc-lite/data`'s property-table.ts (and its cache-restored twin in
+ * `@ifc-lite/cache`'s properties.ts): `valueString` is a Uint32Array, so the
+ * -1 NULL sentinel written by `StringTable.intern(null)` wraps to
+ * 4294967295. An `idx >= 0` check is always true for an unsigned array and
+ * never catches it — only an in-range check (`idx < strings.count`) does.
+ * Before this guard, a NULL string-typed property registered into the SQL
+ * `properties` table as the literal `''`, indistinguishable from a real
+ * empty-string property.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { StringTable } from '@ifc-lite/data';
+import { resolveDuckDBStringLiteral } from './duckdb-integration.js';
+
+const NULL_STRING_SENTINEL = 0xffffffff; // -1 written into a Uint32Array
+
+describe('resolveDuckDBStringLiteral: String NULL sentinel', () => {
+  it('emits SQL NULL for the wrapped sentinel index, not the empty-string literal', () => {
+    const strings = StringTable.fromArray(['', 'Pset_Test', 'Name']);
+    expect(resolveDuckDBStringLiteral(NULL_STRING_SENTINEL, strings)).toBe('NULL');
+  });
+
+  it('still emits a quoted literal for an in-range index, including the real empty string', () => {
+    const strings = StringTable.fromArray(['', 'Wall-01']);
+    expect(resolveDuckDBStringLiteral(1, strings)).toBe("'Wall-01'");
+    expect(resolveDuckDBStringLiteral(0, strings)).toBe("''");
+  });
+});


### PR DESCRIPTION
## Summary
- `createPropertiesTable` in `packages/query/src/duckdb-integration.ts` decoded `PropertyTable.valueString` with `valueStringIdx >= 0 ? ... : ''`. `valueString` is a `Uint32Array`, so the NULL sentinel written by `StringTable.intern(null)` (-1) wraps to `4294967295` — the `>= 0` check is always true for an unsigned array and never catches it. A NULL string-typed property was registered into the DuckDB `properties` table as the literal `''`, indistinguishable from a genuine empty-string property; `WHERE value_string IS NULL` silently matched nothing.
- Found by the sibling-outward method: `property-table.ts`'s own doc comment names this DuckDB path as a sibling ("the on-demand fallback in `@ifc-lite/query`") of `getPropertyValue`'s String branch, and its cache-restored twin in `@ifc-lite/cache`'s `properties.ts` — both of which already guard this correctly with `idx < strings.count`. This third, independent decode of the same column family had drifted.
- Fix: extract the shared logic into an exported, unit-testable `resolveDuckDBStringLiteral(idx, strings)` and apply the same in-range guard, emitting the bare `NULL` keyword — matching how this same file already handles the `containedInStorey`/`definedByType` sentinels a few lines above in `createEntitiesTable`.

## Test plan
- [x] Added `packages/query/src/duckdb-string-literal.test.ts` exercising the extracted helper directly (DuckDB-WASM itself is not unit-testable in this environment — dynamically loaded, worker-based).
- [x] RED: reverted the helper to the original `idx >= 0` check — `emits SQL NULL for the wrapped sentinel index, not the empty-string literal` failed (`expected '\'\'' to be 'NULL'`).
- [x] GREEN: restored the `idx < strings.count` guard — both new tests pass.
- [x] `pnpm --filter @ifc-lite/query test` — 158/158 passing (156 pre-existing + 2 new).
- [x] `pnpm --filter @ifc-lite/query build` — clean.

## Sweep scope (packages/data, packages/renderer)
Both packages were audited per the sibling-outward and degenerate-fixture methods described in the sweep brief; both build clean and pass their full suites (data: 148/148, renderer: 937/937) with no regressions. No further confirmed defects were found inside those two packages themselves — the columnar accessors in `packages/data` (`property-table.ts`, `quantity-table.ts`, `entity-table.ts`) were checked against their sentinel conventions (`StringTable.NULL_INDEX`, `valueBool === 255`, `Int32Array` `-1`) and are internally consistent. The one confirmed defect above lives in `packages/query`, the third-party column-family reader named as this feature's own sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DuckDB query results for NULL string properties.
  * Preserved genuine empty-string values instead of treating them as NULL.
  * Ensured valid string values continue to be safely represented in query results.

* **Tests**
  * Added coverage for NULL sentinels, empty strings, and valid string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->