### PR TITLE
fix(processing): bound the IfcMappedItem colour chase so a cyclic mapping can't abort the process (#2863)

### DIFF
--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -807,16 +807,22 @@ pub(crate) fn find_geometry_item_color(
     geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
     decoder: &mut EntityDecoder,
 ) -> Option<[f32; 4]> {
-    let mut visited = FxHashSet::default();
+    let mut visited = FxHashMap::default();
     find_geometry_item_color_at(geometry_id, geometry_styles, decoder, 0, &mut visited)
 }
 
-/// The visited set is GLOBAL to one resolution, not path-scoped: the geometry
+/// The visited map is GLOBAL to one resolution, not path-scoped: the geometry
 /// router removes each id on the way out because it accumulates geometry per
-/// path, but a colour is a pure function of the item id and the style map, so
-/// an item that already resolved to `None` cannot resolve differently down a
-/// second branch. Keeping it bounds total decoder calls to the number of
-/// DISTINCT items reachable.
+/// path, whereas a colour is a pure function of the item id and the style map.
+///
+/// It records the DEPTH each item was explored at and permits a revisit from
+/// strictly nearer the root. A plain SET is wrong in combination with the cap:
+/// an item first reached near the limit is cut before its subtree is searched
+/// yet stays marked, so a later shorter branch that WOULD have resolved is
+/// skipped and the colour is silently lost — a wrong value rather than a
+/// crash, so nothing reports it (Codex, #2868 review). Work stays bounded: an
+/// item is re-explored only from closer to the root, at most
+/// `MAX_MAPPED_ITEM_DEPTH` times.
 ///
 /// That matters for more than tidiness. A depth cap alone bounds the chain but
 /// not the fan-out: a malformed representation holding `k` items that each
@@ -828,7 +834,7 @@ fn find_geometry_item_color_at(
     geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
     decoder: &mut EntityDecoder,
     depth: u32,
-    visited: &mut FxHashSet<u32>,
+    visited: &mut FxHashMap<u32, u32>,
 ) -> Option<[f32; 4]> {
     // Direct style on this exact geometry item wins.
     if let Some(style) = geometry_styles.get(&geometry_id) {
@@ -839,9 +845,16 @@ fn find_geometry_item_color_at(
     // geometry and resolve there (recursing handles nested mapped items).
     // Refuse to go deeper than the cap: a cyclic mapping would otherwise
     // recurse until the stack overflows and the process aborts (#2863).
-    if depth >= MAX_MAPPED_ITEM_DEPTH || !visited.insert(geometry_id) {
+    if depth >= MAX_MAPPED_ITEM_DEPTH {
         return None;
     }
+    match visited.get(&geometry_id) {
+        // Explored from here or from CLOSER to the root already: that attempt
+        // had at least as much room under the cap, so it cannot find anything
+        // new. Skipping is safe, and it is what breaks cycles.
+        Some(&seen_at) if seen_at <= depth => return None,
+        _ => visited.insert(geometry_id, depth),
+    };
     let geom = decoder.decode_by_id(geometry_id).ok()?;
     if geom.ifc_type != IfcType::IfcMappedItem {
         return None;

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -790,14 +790,33 @@ fn build_mesh_data(
     mesh_data
 }
 
+/// Longest `IfcMappedItem → IfcRepresentationMap → MappedRepresentation`
+/// chain the colour chase will follow. The chain is built entirely from file
+/// references, so a cyclic one (an item whose mapped representation lists the
+/// item itself) recurses forever without this — and a Rust stack overflow
+/// aborts the process rather than raising a catchable panic, so there is no
+/// caller that could turn it back into a load error (#2863). Real mapped
+/// nesting is a handful of levels deep; 16 matches `MAX_UNIT_RESOLVE_DEPTH`,
+/// the repo's other file-driven recursion bound.
+const MAX_MAPPED_ITEM_DEPTH: u32 = 16;
+
 /// Resolve a geometry item's authored colour: direct style on the item, else
 /// chase `IfcMappedItem → IfcRepresentationMap → MappedRepresentation.Items`
 /// recursively (#913 §2.7 — mapped sub-geometry inherits its underlying
-/// item's style).
+/// item's style), to at most `MAX_MAPPED_ITEM_DEPTH` hops.
 pub(crate) fn find_geometry_item_color(
     geometry_id: u32,
     geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
     decoder: &mut EntityDecoder,
+) -> Option<[f32; 4]> {
+    find_geometry_item_color_at(geometry_id, geometry_styles, decoder, 0)
+}
+
+fn find_geometry_item_color_at(
+    geometry_id: u32,
+    geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
+    decoder: &mut EntityDecoder,
+    depth: u32,
 ) -> Option<[f32; 4]> {
     // Direct style on this exact geometry item wins.
     if let Some(style) = geometry_styles.get(&geometry_id) {
@@ -806,6 +825,11 @@ pub(crate) fn find_geometry_item_color(
 
     // Otherwise, if it's a mapped item, chase the mapping to the underlying
     // geometry and resolve there (recursing handles nested mapped items).
+    // Refuse to go deeper than the cap: a cyclic mapping would otherwise
+    // recurse until the stack overflows and the process aborts (#2863).
+    if depth >= MAX_MAPPED_ITEM_DEPTH {
+        return None;
+    }
     let geom = decoder.decode_by_id(geometry_id).ok()?;
     if geom.ifc_type != IfcType::IfcMappedItem {
         return None;
@@ -819,7 +843,9 @@ pub(crate) fn find_geometry_item_color(
     // IfcShapeRepresentation.Items (attr 3).
     let items = get_refs_from_list(&mapped_representation, 3)?;
     for underlying in items {
-        if let Some(color) = find_geometry_item_color(underlying, geometry_styles, decoder) {
+        if let Some(color) =
+            find_geometry_item_color_at(underlying, geometry_styles, decoder, depth + 1)
+        {
             return Some(color);
         }
     }

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -791,14 +791,12 @@ fn build_mesh_data(
 }
 
 /// Longest `IfcMappedItem → IfcRepresentationMap → MappedRepresentation`
-/// chain the colour chase will follow. The chain is built entirely from file
-/// references, so a cyclic one (an item whose mapped representation lists the
-/// item itself) recurses forever without this — and a Rust stack overflow
-/// aborts the process rather than raising a catchable panic, so there is no
-/// caller that could turn it back into a load error (#2863). Real mapped
-/// nesting is a handful of levels deep; 16 matches `MAX_UNIT_RESOLVE_DEPTH`,
-/// the repo's other file-driven recursion bound.
-const MAX_MAPPED_ITEM_DEPTH: u32 = 16;
+/// chain the colour chase will follow, matching the geometry router's limit
+/// of the same name (`ifc_lite_geometry::router::processing`). The two walk
+/// the SAME chain, so a colour cap below the router's would leave a 17-to-32
+/// link chain rendering its geometry while silently losing the authored style
+/// on its leaf.
+const MAX_MAPPED_ITEM_DEPTH: u32 = 32;
 
 /// Resolve a geometry item's authored colour: direct style on the item, else
 /// chase `IfcMappedItem → IfcRepresentationMap → MappedRepresentation.Items`
@@ -809,14 +807,28 @@ pub(crate) fn find_geometry_item_color(
     geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
     decoder: &mut EntityDecoder,
 ) -> Option<[f32; 4]> {
-    find_geometry_item_color_at(geometry_id, geometry_styles, decoder, 0)
+    let mut visited = FxHashSet::default();
+    find_geometry_item_color_at(geometry_id, geometry_styles, decoder, 0, &mut visited)
 }
 
+/// The visited set is GLOBAL to one resolution, not path-scoped: the geometry
+/// router removes each id on the way out because it accumulates geometry per
+/// path, but a colour is a pure function of the item id and the style map, so
+/// an item that already resolved to `None` cannot resolve differently down a
+/// second branch. Keeping it bounds total decoder calls to the number of
+/// DISTINCT items reachable.
+///
+/// That matters for more than tidiness. A depth cap alone bounds the chain but
+/// not the fan-out: a malformed representation holding `k` items that each
+/// lead back into the cycle costs `O(k^depth)` decodes, so four self-references
+/// at depth 32 is ~2^64 calls — no stack overflow, just a worker pinned
+/// forever. Trading an abort for a hang would not have been a fix (#2863).
 fn find_geometry_item_color_at(
     geometry_id: u32,
     geometry_styles: &FxHashMap<u32, GeometryStyleInfo>,
     decoder: &mut EntityDecoder,
     depth: u32,
+    visited: &mut FxHashSet<u32>,
 ) -> Option<[f32; 4]> {
     // Direct style on this exact geometry item wins.
     if let Some(style) = geometry_styles.get(&geometry_id) {
@@ -827,7 +839,7 @@ fn find_geometry_item_color_at(
     // geometry and resolve there (recursing handles nested mapped items).
     // Refuse to go deeper than the cap: a cyclic mapping would otherwise
     // recurse until the stack overflows and the process aborts (#2863).
-    if depth >= MAX_MAPPED_ITEM_DEPTH {
+    if depth >= MAX_MAPPED_ITEM_DEPTH || !visited.insert(geometry_id) {
         return None;
     }
     let geom = decoder.decode_by_id(geometry_id).ok()?;
@@ -844,7 +856,7 @@ fn find_geometry_item_color_at(
     let items = get_refs_from_list(&mapped_representation, 3)?;
     for underlying in items {
         if let Some(color) =
-            find_geometry_item_color_at(underlying, geometry_styles, decoder, depth + 1)
+            find_geometry_item_color_at(underlying, geometry_styles, decoder, depth + 1, visited)
         {
             return Some(color);
         }

--- a/rust/processing/src/element_tests.rs
+++ b/rust/processing/src/element_tests.rs
@@ -110,3 +110,132 @@ fn infer_opening_material_names_glass_vs_frame() {
     let none = infer_opening_subpart_material_name(&IfcType::IfcWall, [1.0; 4], 1);
     assert!(none.is_none(), "only windows/doors get inferred part names");
 }
+
+#[test]
+fn find_geometry_item_color_terminates_on_cyclic_mapping() {
+    // #100's mapped representation lists #100 itself as an item, so the
+    // chase re-enters where it started. The chain is entirely file-supplied,
+    // so a malformed or hostile file controls the recursion depth.
+    const IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m.ifc','2026-06-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,$,$);
+#100=IFCMAPPEDITEM(#101,$);
+#101=IFCREPRESENTATIONMAP($,#103);
+#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#100));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    let mut decoder = EntityDecoder::new(IFC);
+    assert_eq!(find_geometry_item_color(100, &styles, &mut decoder), None);
+}
+
+/// Build a chain of `hops` nested `IfcMappedItem`s whose innermost mapped
+/// representation lists the styled leaf `#999`. Entry point is `#200`.
+fn nested_mapped_chain(hops: u32) -> String {
+    let mut s = String::from(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n\
+         FILE_NAME('m.ifc','2026-06-04T00:00:00',(''),(''),'','','');\n\
+         FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+         #2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,$,$);\n",
+    );
+    for i in 0..hops {
+        let map_item = 200 + i;
+        let rep_map = 1000 + i;
+        let shape = 2000 + i;
+        // The last hop's representation holds the styled leaf; the others
+        // hold the next mapped item down.
+        let inner = if i + 1 == hops { 999 } else { 200 + i + 1 };
+        s.push_str(&format!("#{map_item}=IFCMAPPEDITEM(#{rep_map},$);\n"));
+        s.push_str(&format!("#{rep_map}=IFCREPRESENTATIONMAP($,#{shape});\n"));
+        s.push_str(&format!(
+            "#{shape}=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#{inner}));\n"
+        ));
+    }
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+#[test]
+fn find_geometry_item_color_resolves_exactly_at_the_depth_cap() {
+    let green = [0.0, 0.8, 0.2, 1.0];
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    styles.insert(999, GeometryStyleInfo::from_color(green));
+
+    let ifc = nested_mapped_chain(MAX_MAPPED_ITEM_DEPTH);
+    let mut decoder = EntityDecoder::new(&ifc);
+    assert_eq!(
+        find_geometry_item_color(200, &styles, &mut decoder),
+        Some(green),
+        "a chain exactly MAX_MAPPED_ITEM_DEPTH hops deep must still resolve"
+    );
+}
+
+#[test]
+fn find_geometry_item_color_stops_one_hop_past_the_depth_cap() {
+    let green = [0.0, 0.8, 0.2, 1.0];
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    styles.insert(999, GeometryStyleInfo::from_color(green));
+
+    let ifc = nested_mapped_chain(MAX_MAPPED_ITEM_DEPTH + 1);
+    let mut decoder = EntityDecoder::new(&ifc);
+    assert_eq!(
+        find_geometry_item_color(200, &styles, &mut decoder),
+        None,
+        "one hop past the cap the chase gives up rather than recursing on"
+    );
+}
+
+/// The two boundary tests above build their chains *from*
+/// `MAX_MAPPED_ITEM_DEPTH`, so they follow the constant wherever it moves and
+/// stay green even if it is tuned down to 1 — they pin the boundary's shape,
+/// not its position. This one uses a literal depth: nesting this shallow is
+/// ordinary in real assemblies (a mapped item inside a mapped type inside an
+/// aggregate), and colour must survive it whatever the cap is set to.
+#[test]
+fn find_geometry_item_color_resolves_ordinary_nesting_depth() {
+    let green = [0.0, 0.8, 0.2, 1.0];
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    styles.insert(999, GeometryStyleInfo::from_color(green));
+
+    let ifc = nested_mapped_chain(8);
+    let mut decoder = EntityDecoder::new(&ifc);
+    assert_eq!(
+        find_geometry_item_color(200, &styles, &mut decoder),
+        Some(green),
+        "8 mapped-item hops is ordinary nesting; the cap must not swallow it"
+    );
+}
+
+/// `resolve_color_for_representation_map` (#957, the type-geometry path) is a
+/// second entry point into the same chase, reaching it from a rep map rather
+/// than from a mapped item. The cap lives inside `find_geometry_item_color`
+/// so it covers both; a guard at either call site would not have.
+#[test]
+fn resolve_color_for_representation_map_terminates_on_cyclic_mapping() {
+    const IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m.ifc','2026-06-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,$,$);
+#100=IFCMAPPEDITEM(#101,$);
+#101=IFCREPRESENTATIONMAP($,#103);
+#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#100));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    let mut decoder = EntityDecoder::new(IFC);
+    assert_eq!(
+        resolve_color_for_representation_map(101, &styles, &mut decoder),
+        None
+    );
+}

--- a/rust/processing/src/element_tests.rs
+++ b/rust/processing/src/element_tests.rs
@@ -239,3 +239,52 @@ END-ISO-10303-21;
         None
     );
 }
+
+/// A depth cap alone bounds the chain LENGTH but not its BREADTH. This
+/// representation holds four items that each lead back into the cycle, so a
+/// depth-only guard explores `4^MAX_MAPPED_ITEM_DEPTH` paths — no stack
+/// overflow, just a worker pinned forever. Trading the abort for a hang would
+/// not have been a fix.
+///
+/// The assertion is on the returned colour, as everywhere else here. Its
+/// failure mode without the visited set is a hang rather than a wrong value,
+/// which CI reports as a lane timeout; that is stated plainly rather than
+/// dressed up as a fast assertion, because there is no way to assert "this
+/// returned before the heat death of the universe" that is not a timing test.
+#[test]
+fn find_geometry_item_color_bounds_cyclic_fan_out_not_just_depth() {
+    const IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m.ifc','2026-06-04T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,$,$);
+#100=IFCMAPPEDITEM(#101,$);
+#101=IFCREPRESENTATIONMAP($,#103);
+#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#110,#111,#112,#113));
+#110=IFCMAPPEDITEM(#101,$);
+#111=IFCMAPPEDITEM(#101,$);
+#112=IFCMAPPEDITEM(#101,$);
+#113=IFCMAPPEDITEM(#101,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    let mut decoder = EntityDecoder::new(IFC);
+    assert_eq!(find_geometry_item_color(100, &styles, &mut decoder), None);
+}
+
+/// The cap is not a free parameter: it must match the geometry router's
+/// `MAX_MAPPED_ITEM_DEPTH`, or a chain longer than this one but shorter than
+/// the router's renders its geometry and silently loses its leaf's style.
+/// The boundary tests above derive their fixtures FROM this constant, so they
+/// follow it anywhere; this pins the value itself.
+#[test]
+fn mapped_item_depth_cap_matches_the_geometry_router() {
+    assert_eq!(
+        MAX_MAPPED_ITEM_DEPTH, 32,
+        "must equal ifc_lite_geometry::router::processing::MAX_MAPPED_ITEM_DEPTH"
+    );
+}

--- a/rust/processing/src/element_tests.rs
+++ b/rust/processing/src/element_tests.rs
@@ -288,3 +288,49 @@ fn mapped_item_depth_cap_matches_the_geometry_router() {
         "must equal ifc_lite_geometry::router::processing::MAX_MAPPED_ITEM_DEPTH"
     );
 }
+
+/// An item shared between a DEEP branch (where the cap cuts its subtree before
+/// the styled leaf) and a SHORT one (where it resolves). A plain visited SET
+/// marks it on the deep visit and skips the short one, silently losing the
+/// colour — a WRONG VALUE rather than a crash, so nothing reports it
+/// (Codex, #2868 review; same shape here).
+#[test]
+fn a_shared_item_resolves_via_the_shallow_branch() {
+    let mut body = String::from(
+        "#200=IFCMAPPEDITEM(#201,$);\n\
+         #201=IFCREPRESENTATIONMAP($,#202);\n\
+         #202=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#300,#900));\n",
+    );
+    for i in 0..30u32 {
+        let (item, rm, sh) = (300 + i, 400 + i, 500 + i);
+        let inner = if i == 29 { 900 } else { 300 + i + 1 };
+        body.push_str(&format!("#{item}=IFCMAPPEDITEM(#{rm},$);\n"));
+        body.push_str(&format!("#{rm}=IFCREPRESENTATIONMAP($,#{sh});\n"));
+        body.push_str(&format!(
+            "#{sh}=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#{inner}));\n"
+        ));
+    }
+    body.push_str(
+        "#900=IFCMAPPEDITEM(#901,$);\n\
+         #901=IFCREPRESENTATIONMAP($,#902);\n\
+         #902=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#950));\n\
+         #950=IFCMAPPEDITEM(#951,$);\n\
+         #951=IFCREPRESENTATIONMAP($,#952);\n\
+         #952=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#999));\n",
+    );
+    let ifc = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n\
+         FILE_NAME('m.ifc','2026-06-04T00:00:00',(''),(''),'','','');\n\
+         FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+         #2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,$,$);\n{body}ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let green = [0.0, 0.8, 0.2, 1.0];
+    let mut styles: FxHashMap<u32, GeometryStyleInfo> = FxHashMap::default();
+    styles.insert(999, GeometryStyleInfo::from_color(green));
+    let mut decoder = EntityDecoder::new(&ifc);
+    assert_eq!(
+        find_geometry_item_color(200, &styles, &mut decoder),
+        Some(green),
+        "the shallow branch reaches the styled leaf well inside the cap"
+    );
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -221,7 +221,14 @@
 # +18: #1891 follow-on — ProducedElementMeshes.geometry_aabb (the world box from the SAME hashing pass) plus the emit-together match that keeps it index-parallel with geometry_hash at the FFI boundary.
 # +35: #1891 closedness — ProducedElementMeshes.geometry_volume + .geometry_closure (the volume and the four-clause verdict that gates it), the widened emit-together match, and threading orient_mesh_outward_verdict's per-mesh verdict from BOTH orient call sites into the hasher. The verdict has to be taken exactly where the orienter already runs and handed to the hasher segment it describes, so it cannot move out of this decision tree; the gate's own 190 lines of rationale live in rust/geometry/src/geom_closure.rs (new, sub-400) rather than here.
 # -22: #1891 review (PR #1993) — the f32-collapse degenerate backstop (env switch, the drop, the per-element tally) moved to the child module element_degenerate.rs (new, 72), which is where the ordering story now belongs: the tally stopped being a diagnostic and became the input to the closure retraction. Budget refreshed downward; the retraction call site itself costs 7 lines here.
-     910 rust/processing/src/element.rs
+# +26: #2863 — bound the IfcMappedItem colour chase. The chain is built
+# from file references, so a cyclic one recursed until the stack overflowed
+# and the process ABORTED (no catchable panic, no error to the caller). The
+# cap has to sit inside find_geometry_item_color, not at a call site: the
+# type-geometry path reaches the same recursion through
+# resolve_color_for_representation_map. 3 lines of guard and a wrapper; the
+# rest is the why, including why 16 and not a visited set.
+     936 rust/processing/src/element.rs
 # +9: #2019 — canonicalise each host's opening order so the world geometry
 # hash stops depending on IFCRELVOIDSELEMENT statement order (sequential void
 # cuts are not associative). Three lines of code plus the why.

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -221,14 +221,17 @@
 # +18: #1891 follow-on — ProducedElementMeshes.geometry_aabb (the world box from the SAME hashing pass) plus the emit-together match that keeps it index-parallel with geometry_hash at the FFI boundary.
 # +35: #1891 closedness — ProducedElementMeshes.geometry_volume + .geometry_closure (the volume and the four-clause verdict that gates it), the widened emit-together match, and threading orient_mesh_outward_verdict's per-mesh verdict from BOTH orient call sites into the hasher. The verdict has to be taken exactly where the orienter already runs and handed to the hasher segment it describes, so it cannot move out of this decision tree; the gate's own 190 lines of rationale live in rust/geometry/src/geom_closure.rs (new, sub-400) rather than here.
 # -22: #1891 review (PR #1993) — the f32-collapse degenerate backstop (env switch, the drop, the per-element tally) moved to the child module element_degenerate.rs (new, 72), which is where the ordering story now belongs: the tally stopped being a diagnostic and became the input to the closure retraction. Budget refreshed downward; the retraction call site itself costs 7 lines here.
-# +26: #2863 — bound the IfcMappedItem colour chase. The chain is built
-# from file references, so a cyclic one recursed until the stack overflowed
-# and the process ABORTED (no catchable panic, no error to the caller). The
-# cap has to sit inside find_geometry_item_color, not at a call site: the
-# type-geometry path reaches the same recursion through
-# resolve_color_for_representation_map. 3 lines of guard and a wrapper; the
-# rest is the why, including why 16 and not a visited set.
-     936 rust/processing/src/element.rs
+# +38: #2863 — bound the IfcMappedItem colour chase. The chain is built from
+# file references, so a cyclic one recursed until the stack overflowed and the
+# process ABORTED (no catchable panic, no error to the caller). The bound has
+# to sit inside find_geometry_item_color, not at a call site: the type-geometry
+# path reaches the same recursion through resolve_color_for_representation_map.
+# Depth cap AND a visited set, matching router/processing.rs which walks the
+# same chain: the cap alone bounds the chain's LENGTH but not its BREADTH, and
+# k items looping back cost O(k^depth) decodes — an abort traded for a hang.
+# 4 lines of guard and a wrapper; the rest is the why, including why the
+# visited set is global here and path-scoped in the router.
+     948 rust/processing/src/element.rs
 # +9: #2019 — canonicalise each host's opening order so the world geometry
 # hash stops depending on IFCRELVOIDSELEMENT statement order (sequential void
 # cuts are not associative). Three lines of code plus the why.

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -230,8 +230,11 @@
 # same chain: the cap alone bounds the chain's LENGTH but not its BREADTH, and
 # k items looping back cost O(k^depth) decodes — an abort traded for a hang.
 # 4 lines of guard and a wrapper; the rest is the why, including why the
-# visited set is global here and path-scoped in the router.
-     948 rust/processing/src/element.rs
+# visited set is global here and path-scoped in the router, and why it records
+# the DEPTH of each visit: a plain set combined with the cap silently LOSES a
+# colour, because an item first reached near the limit is cut before its
+# subtree is searched yet stays marked, so a later shorter branch is skipped.
+     961 rust/processing/src/element.rs
 # +9: #2019 — canonicalise each host's opening order so the world geometry
 # hash stops depending on IFCRELVOIDSELEMENT statement order (sequential void
 # cuts are not associative). Three lines of code plus the why.

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 10102721634454748978;
+const ALLOWLIST_DIGEST: u64 = 3492016058608561705;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 14331080973902923553;
+const ALLOWLIST_DIGEST: u64 = 10102721634454748978;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 13057954648948724589;
+const ALLOWLIST_DIGEST: u64 = 14331080973902923553;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).


### PR DESCRIPTION
Fixes #2863.

## The bug

`element::find_geometry_item_color` chases `IfcMappedItem -> IfcRepresentationMap -> MappedRepresentation.Items` recursively with **no depth cap and no visited set**. The chain is built entirely from file references, so a file that closes the loop recurses forever.

In Rust that is not a recoverable failure. A stack overflow **aborts the process** — no `catch_unwind` reaches it, no error surfaces to the caller. Three entities are enough:

```
#100=IFCMAPPEDITEM(#101,$);
#101=IFCREPRESENTATIONMAP($,#103);
#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#100));
```

Against unmodified `main`:

```
thread 'element::tests::find_geometry_item_color_terminates_on_cyclic_mapping' has overflowed its stack
fatal runtime error: stack overflow, aborting
(signal: 6, SIGABRT: process abort signal)
```

Credit to @BIMvoice's review trail on #2857 for surfacing the family; the canonical half was found by the null comparison (does `main` already do this?) rather than by reading the PR.

## The fix

`MAX_MAPPED_ITEM_DEPTH = 16`, matching `MAX_UNIT_RESOLVE_DEPTH` — the repo's other bound on file-driven recursion. A depth cap rather than a visited set: allocation-free on the prepass path, and real mapped nesting is a handful of levels deep.

**The cap goes inside `find_geometry_item_color`, not at a call site.** There are two entry points into this recursion — `resolve_color_for_representation_map` (the #957 type-geometry path) reaches it from a rep map rather than from a mapped item. A guard at either call site would have left the other one aborting. Both are covered by a test.

## On the tests

Assertions are on the returned colour, never "it does not crash". A stack overflow takes the whole test binary with it and surfaces as SIGABRT, which reads like broken CI infrastructure rather than a failed assertion — the wrong signal to leave for whoever hits it next.

`find_geometry_item_color_resolves_ordinary_nesting_depth` uses a **literal** 8-hop chain, and it is there because of something mutation testing caught. The two boundary tests build their fixtures from `MAX_MAPPED_ITEM_DEPTH` itself, so the fixture follows the constant wherever it moves — when I mutated the cap from 16 to 1, **all four tests stayed green**. They pin the boundary's shape, not its position. The literal-depth test is the one that fails if the cap is ever tuned down far enough to strip colour off real assemblies.

## Verification

| mutation (one occurrence each) | result |
|---|---|
| guard removed (`depth >= MAX` -> `false`) | `stops_one_hop_past_the_depth_cap` FAILED + binary aborts |
| off-by-one (`>=` -> `>`) | `stops_one_hop_past_the_depth_cap` FAILED |
| cap lowered 16 -> 1 | `resolves_ordinary_nesting_depth` FAILED |

Subtest count unchanged across all three.

Gates, run as the exact CI commands:

- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` — clean
- `cargo test --workspace --no-fail-fast` — **1861 passed, 0 failed** (the two `panicked at` lines in the log are the intentional panics inside `wasm-bindings`' poison-recovery tests, which pass)
- `module_size_ratchet` — green, including `allowlist_digest_is_pinned`

`element.rs` grows 26 lines past its recorded budget, so the allowlist row is raised with a reason and `ALLOWLIST_DIGEST` is updated **in this commit**, as that gate demands. Most of the 26 is the why: why a cap and not a visited set, why 16, and why it cannot live at a call site. Splitting the module for this would separate the guard from the recursion it bounds.

No changeset: rust-internal, matching #2838/#2824. Say the word if the wasm-visible behaviour change means one is wanted.

## Sequencing with #2857

#2857 removes the one-hop limit in `color_layer.rs`'s copy of this chase — a limit that turns out to be load-bearing, which is why `main` survives the cyclic file on that path today. With this merged, #2857 should **delegate to the canonical resolver** rather than grow its own visited set: a hardened copy beside an unhardened canonical is the same drift #2857 exists to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mapped-item colour resolution to prevent cyclic traversal from causing unbounded processing.
  * Refined depth-capping so revisits are only skipped when previously explored at the same or shallower depth, improving correctness for shared items and representation-map paths.

* **Tests**
  * Added coverage for cyclic traversal, maximum nesting depth, one-hop-over-cap behavior, branching fan-out bounds, router depth-cap synchronization, and nested mapped-item chains.

* **Chores**
  * Updated module size allowlist and related size-budget metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->