### PR TITLE
fix(wasm): bound the mapped-item colour chase in the viewer resolver (#2866)

### DIFF
--- a/rust/wasm-bindings/src/api/styling/color.rs
+++ b/rust/wasm-bindings/src/api/styling/color.rs
@@ -23,7 +23,7 @@ pub(crate) fn find_color_for_geometry(
     geometry_styles: &rustc_hash::FxHashMap<u32, [f32; 4]>,
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> Option<[f32; 4]> {
-    let mut visited = rustc_hash::FxHashSet::default();
+    let mut visited = rustc_hash::FxHashMap::default();
     find_color_for_geometry_at(geom_id, geometry_styles, decoder, 0, &mut visited)
 }
 
@@ -40,18 +40,27 @@ pub(crate) fn find_color_for_geometry(
 ///   7.21s. That is an abort traded for a hang, which in a browser worker is
 ///   the worse of the two because it reads as a slow file (#2864).
 ///
-/// The visited set is GLOBAL to one resolution, not path-scoped. The geometry
+/// The visited map is GLOBAL to one resolution, not path-scoped: the geometry
 /// router removes each id on the way out because it accumulates geometry per
-/// path; a colour is a pure function of the item id and the style map, so an
-/// item that already resolved to `None` cannot resolve differently down a
-/// second branch. Keeping it bounds total decodes to the number of DISTINCT
-/// reachable items, which eliminates the fan-out rather than bounding it.
+/// path, whereas a colour is a pure function of the item id and the style map.
+///
+/// It records the DEPTH each item was explored at, and permits a revisit from
+/// a shallower one. A plain set is wrong in combination with the cap: an item
+/// first reached near the limit is cut before its subtree is searched, yet
+/// stays marked, so a later shorter branch that WOULD have resolved is skipped
+/// and the colour is silently lost. Measured on a 30-link branch sharing an
+/// item with a direct one: `Some(green)` became `None` (Codex, #2868 review).
+/// Two individually correct guards whose naive combination produces a wrong
+/// value rather than a crash, so nothing reports it.
+///
+/// Work stays bounded: an item is re-explored only from strictly nearer the
+/// root, so at most `MAX_MAPPED_ITEM_DEPTH` times.
 fn find_color_for_geometry_at(
     geom_id: u32,
     geometry_styles: &rustc_hash::FxHashMap<u32, [f32; 4]>,
     decoder: &mut ifc_lite_core::EntityDecoder,
     depth: u32,
-    visited: &mut rustc_hash::FxHashSet<u32>,
+    visited: &mut rustc_hash::FxHashMap<u32, u32>,
 ) -> Option<[f32; 4]> {
     use ifc_lite_core::IfcType;
 
@@ -60,11 +69,18 @@ fn find_color_for_geometry_at(
         return Some(color);
     }
 
-    // Refuse to go deeper, and refuse to revisit: see this function's doc for
-    // why both are needed and why the set is global.
-    if depth >= MAX_MAPPED_ITEM_DEPTH || !visited.insert(geom_id) {
+    // Refuse to go deeper, and refuse to REDO work that cannot produce a new
+    // answer. See this function's doc for why both are needed.
+    if depth >= MAX_MAPPED_ITEM_DEPTH {
         return None;
     }
+    match visited.get(&geom_id) {
+        // Already explored from here or from CLOSER to the root: the cap left
+        // that attempt at least as much room as this one has, so it cannot
+        // find anything new. Skipping is safe and breaks cycles.
+        Some(&seen_at) if seen_at <= depth => return None,
+        _ => visited.insert(geom_id, depth),
+    };
 
     // If not, check if it's an IfcMappedItem and follow the reference
     let geom = decoder.decode_by_id(geom_id).ok()?;

--- a/rust/wasm-bindings/src/api/styling/color.rs
+++ b/rust/wasm-bindings/src/api/styling/color.rs
@@ -2,6 +2,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+/// Longest `IfcMappedItem -> IfcRepresentationMap -> MappedRepresentation`
+/// chain the colour chase will follow.
+///
+/// This is the THIRD copy of this constant. `ifc_lite_geometry`'s
+/// `router::processing` and `ifc_lite_processing`'s `element` both define
+/// `MAX_MAPPED_ITEM_DEPTH = 32` for the same traversal; all three must agree,
+/// or a chain longer than the smallest cap renders its geometry through the
+/// router while silently losing the authored style on its leaf. They are not
+/// deduplicated because the router's is private and the three crates do not
+/// share a home for it — collapsing them is worth doing and is a bigger change
+/// than this fix (#2866).
+const MAX_MAPPED_ITEM_DEPTH: u32 = 32;
+
 /// Find color for a geometry item, following MappedItem references if needed.
 /// This handles the case where IfcStyledItem points to geometry inside a MappedRepresentation,
 /// not to the MappedItem itself.
@@ -10,11 +23,47 @@ pub(crate) fn find_color_for_geometry(
     geometry_styles: &rustc_hash::FxHashMap<u32, [f32; 4]>,
     decoder: &mut ifc_lite_core::EntityDecoder,
 ) -> Option<[f32; 4]> {
+    let mut visited = rustc_hash::FxHashSet::default();
+    find_color_for_geometry_at(geom_id, geometry_styles, decoder, 0, &mut visited)
+}
+
+/// The chain is built entirely from file references, so a malformed file
+/// controls both its depth and its branching factor. Both have to be bounded:
+///
+/// * **Depth** — a cyclic chain (an item whose mapped representation lists that
+///   item) recursed until the stack overflowed, and a Rust stack overflow
+///   ABORTS the process rather than raising a catchable panic, so no caller
+///   could turn it back into a load error. Three entities were enough (#2866).
+/// * **Breadth** — a cap alone bounds the chain's length, not its fan-out: `k`
+///   items each leading back into the cycle cost `O(k^depth)` decodes. Measured
+///   on the sibling resolver at cap 16: 1 item 211us, 2 items 21.4ms, 3 items
+///   7.21s. That is an abort traded for a hang, which in a browser worker is
+///   the worse of the two because it reads as a slow file (#2864).
+///
+/// The visited set is GLOBAL to one resolution, not path-scoped. The geometry
+/// router removes each id on the way out because it accumulates geometry per
+/// path; a colour is a pure function of the item id and the style map, so an
+/// item that already resolved to `None` cannot resolve differently down a
+/// second branch. Keeping it bounds total decodes to the number of DISTINCT
+/// reachable items, which eliminates the fan-out rather than bounding it.
+fn find_color_for_geometry_at(
+    geom_id: u32,
+    geometry_styles: &rustc_hash::FxHashMap<u32, [f32; 4]>,
+    decoder: &mut ifc_lite_core::EntityDecoder,
+    depth: u32,
+    visited: &mut rustc_hash::FxHashSet<u32>,
+) -> Option<[f32; 4]> {
     use ifc_lite_core::IfcType;
 
     // First check if this geometry ID directly has a color
     if let Some(&color) = geometry_styles.get(&geom_id) {
         return Some(color);
+    }
+
+    // Refuse to go deeper, and refuse to revisit: see this function's doc for
+    // why both are needed and why the set is global.
+    if depth >= MAX_MAPPED_ITEM_DEPTH || !visited.insert(geom_id) {
+        return None;
     }
 
     // If not, check if it's an IfcMappedItem and follow the reference
@@ -42,9 +91,13 @@ pub(crate) fn find_color_for_geometry(
         for item in items_list {
             if let Some(underlying_geom_id) = item.as_entity_ref() {
                 // Recursively find color (handles nested MappedItems)
-                if let Some(color) =
-                    find_color_for_geometry(underlying_geom_id, geometry_styles, decoder)
-                {
+                if let Some(color) = find_color_for_geometry_at(
+                    underlying_geom_id,
+                    geometry_styles,
+                    decoder,
+                    depth + 1,
+                    visited,
+                ) {
                     return Some(color);
                 }
             }
@@ -241,3 +294,7 @@ END-ISO-10303-21;
         assert_eq!(resolve_element_color(&wall, &styles, &mut decoder), None);
     }
 }
+
+#[cfg(test)]
+#[path = "color_cycle_tests.rs"]
+mod find_color_for_geometry_cycle_tests;

--- a/rust/wasm-bindings/src/api/styling/color_cycle_tests.rs
+++ b/rust/wasm-bindings/src/api/styling/color_cycle_tests.rs
@@ -138,3 +138,56 @@ fn depth_cap_agrees_with_the_other_two_copies() {
          ifc_lite_processing::element MAX_MAPPED_ITEM_DEPTH"
     );
 }
+
+/// An item shared between a DEEP branch (where the cap cuts its subtree before
+/// the styled leaf) and a SHORT one (where it resolves). A plain visited SET
+/// marks it on the deep visit and skips the short one, silently losing the
+/// colour: measured `Some(green)` -> `None` before the map recorded depths
+/// (Codex, #2868 review).
+///
+/// This is the failure mode that produces a WRONG VALUE rather than a crash,
+/// so nothing reports it — which is why it is asserted on the colour and not
+/// on termination.
+#[test]
+fn a_shared_item_resolves_via_the_shallow_branch() {
+    let mut s = String::from(
+        "#200=IFCMAPPEDITEM(#201,$);\n\
+         #201=IFCREPRESENTATIONMAP($,#202);\n\
+         #202=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#300,#900));\n",
+    );
+    for i in 0..30u32 {
+        let (item, rm, sh) = (300 + i, 400 + i, 500 + i);
+        let inner = if i == 29 { 900 } else { 300 + i + 1 };
+        s.push_str(&format!("#{item}=IFCMAPPEDITEM(#{rm},$);\n"));
+        s.push_str(&format!("#{rm}=IFCREPRESENTATIONMAP($,#{sh});\n"));
+        s.push_str(&format!(
+            "#{sh}=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#{inner}));\n"
+        ));
+    }
+    // X (#900) needs TWO more hops to reach the styled leaf, so arriving at
+    // depth 31 leaves #950 cut by the cap at 32 while #900 is already marked
+    // visited.
+    s.push_str(
+        "#900=IFCMAPPEDITEM(#901,$);\n\
+         #901=IFCREPRESENTATIONMAP($,#902);\n\
+         #902=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#950));\n\
+         #950=IFCMAPPEDITEM(#951,$);\n\
+         #951=IFCREPRESENTATIONMAP($,#952);\n\
+         #952=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#999));\n",
+    );
+    let ifc = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION(('Test'),'2;1');\n\
+         FILE_NAME('test','2026-05-27',(''),(''),'','','');\n\
+         FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+         #2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,$,$);\n{s}ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let mut decoder = decoder_for(&ifc);
+    let mut styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+    styles.insert(999, [0.0, 0.8, 0.2, 1.0]);
+    assert_eq!(
+        find_color_for_geometry(200, &styles, &mut decoder),
+        Some([0.0, 0.8, 0.2, 1.0]),
+        "the shallow branch reaches the styled leaf well inside the cap; \
+         marking the item on the deep branch must not hide it"
+    );
+}

--- a/rust/wasm-bindings/src/api/styling/color_cycle_tests.rs
+++ b/rust/wasm-bindings/src/api/styling/color_cycle_tests.rs
@@ -1,0 +1,140 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `find_color_for_geometry` chases `IfcMappedItem -> IfcRepresentationMap
+//! -> MappedRepresentation.Items`. The chain is built entirely from file
+//! references, so a malformed file controls both its depth and its
+//! branching factor (#2866).
+use super::{find_color_for_geometry, MAX_MAPPED_ITEM_DEPTH};
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+use rustc_hash::FxHashMap;
+
+fn decoder_for(content: &str) -> EntityDecoder<'static> {
+    let content: &'static str = Box::leak(content.to_string().into_boxed_str());
+    let idx = build_entity_index(content);
+    EntityDecoder::with_index(content, idx)
+}
+
+/// `#100`'s mapped representation lists `#100` itself.
+const CYCLIC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test','2026-05-27',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,$,$);
+#100=IFCMAPPEDITEM(#101,$);
+#101=IFCREPRESENTATIONMAP($,#103);
+#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#100));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn terminates_on_cyclic_mapping() {
+    let mut decoder = decoder_for(CYCLIC);
+    let styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+    assert_eq!(find_color_for_geometry(100, &styles, &mut decoder), None);
+}
+
+/// Four items looping back through one representation map. A depth cap
+/// alone bounds the chain's LENGTH but not its BREADTH, so this costs
+/// `O(4^depth)` decodes without the visited set -- no stack overflow, just
+/// a worker pinned on the file. The assertion is on the returned colour,
+/// as everywhere here; its failure mode without the set is a HANG rather
+/// than a wrong value, which surfaces as a lane timeout. That is stated
+/// plainly because there is no way to assert "returned in finite time"
+/// that is not a timing test.
+const CYCLIC_FAN_OUT: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test','2026-05-27',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,$,$);
+#100=IFCMAPPEDITEM(#101,$);
+#101=IFCREPRESENTATIONMAP($,#103);
+#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#110,#111,#112,#113));
+#110=IFCMAPPEDITEM(#101,$);
+#111=IFCMAPPEDITEM(#101,$);
+#112=IFCMAPPEDITEM(#101,$);
+#113=IFCMAPPEDITEM(#101,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn bounds_cyclic_fan_out_not_just_depth() {
+    let mut decoder = decoder_for(CYCLIC_FAN_OUT);
+    let styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+    assert_eq!(find_color_for_geometry(100, &styles, &mut decoder), None);
+}
+
+/// Build an acyclic chain of `hops` nested mapped items whose innermost
+/// representation holds the styled leaf `#999`. Entry point is `#200`.
+fn nested_chain(hops: u32) -> String {
+    let mut s = String::from(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION(('Test'),'2;1');\n\
+         FILE_NAME('test','2026-05-27',(''),(''),'','','');\n\
+         FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+         #2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,$,$);\n",
+    );
+    for i in 0..hops {
+        let item = 200 + i;
+        let map = 1000 + i;
+        let shape = 2000 + i;
+        let inner = if i + 1 == hops { 999 } else { 200 + i + 1 };
+        s.push_str(&format!("#{item}=IFCMAPPEDITEM(#{map},$);\n"));
+        s.push_str(&format!("#{map}=IFCREPRESENTATIONMAP($,#{shape});\n"));
+        s.push_str(&format!(
+            "#{shape}=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#{inner}));\n"
+        ));
+    }
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+/// A literal depth, not one derived from `MAX_MAPPED_ITEM_DEPTH`: fixtures
+/// built from the constant follow it wherever it moves and stay green even
+/// if it is tuned to 1, so they pin the boundary's shape and never its
+/// position. 20 hops is past the sibling resolver's former cap of 16 and
+/// within the router's 32 -- the case a mismatched cap breaks, and it
+/// breaks it by returning a WRONG COLOUR rather than by crashing: the
+/// geometry still renders and just loses its authored style, with nothing
+/// reporting it.
+#[test]
+fn resolves_a_legitimate_twenty_hop_chain() {
+    let ifc = nested_chain(20);
+    let mut decoder = decoder_for(&ifc);
+    let mut styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+    styles.insert(999, [0.0, 0.8, 0.2, 1.0]);
+    assert_eq!(
+        find_color_for_geometry(200, &styles, &mut decoder),
+        Some([0.0, 0.8, 0.2, 1.0]),
+        "a 20-hop chain is within every sibling's cap and must keep its style"
+    );
+}
+
+#[test]
+fn stops_one_hop_past_the_depth_cap() {
+    let ifc = nested_chain(MAX_MAPPED_ITEM_DEPTH + 1);
+    let mut decoder = decoder_for(&ifc);
+    let mut styles: FxHashMap<u32, [f32; 4]> = FxHashMap::default();
+    styles.insert(999, [0.0, 0.8, 0.2, 1.0]);
+    assert_eq!(find_color_for_geometry(200, &styles, &mut decoder), None);
+}
+
+/// The cap is not a free parameter: all three copies of this traversal
+/// must agree, or the shortest one silently strips colour off chains the
+/// others still render.
+#[test]
+fn depth_cap_agrees_with_the_other_two_copies() {
+    assert_eq!(
+        MAX_MAPPED_ITEM_DEPTH, 32,
+        "must equal ifc_lite_geometry::router::processing and \
+         ifc_lite_processing::element MAX_MAPPED_ITEM_DEPTH"
+    );
+}


### PR DESCRIPTION
Part of #2866 — the `find_color_for_geometry` entry. @ifc-lite-92 is taking `extract_symbolic_item`.

## The bug

`find_color_for_geometry` (`rust/wasm-bindings/src/api/styling/color.rs`) chases `IfcMappedItem -> IfcRepresentationMap -> MappedRepresentation.Items` with **no depth cap and no visited set**. This is the colour resolver that every IFC opened in the browser viewer goes through.

Reproduced on unmodified `main`, three entities:

```
#100=IFCMAPPEDITEM(#101,$);
#101=IFCREPRESENTATIONMAP($,#103);
#103=IFCSHAPEREPRESENTATION(#2,'Body','MappedRepresentation',(#100));
```

```
fatal runtime error: stack overflow, aborting
(signal: 6, SIGABRT: process abort signal)
```

A Rust stack overflow **aborts** — no `catch_unwind` reaches it, so nothing can turn it back into a load error. The tab's worker dies.

## Both dimensions, because a cap alone is not a fix

That lesson is from #2864, where my first attempt capped depth only. A cap bounds the chain's **length**; `k` items each leading back into the cycle cost `O(k^depth)` decodes. Measured on the sibling resolver at cap 16:

| items looping back | elapsed |
|---|---:|
| 1 | 211 µs |
| 2 | 21.4 ms |
| 3 | **7.21 s** |

An abort traded for a hang — and in a browser worker the hang is the worse one, because it reads as a slow file rather than a failure.

So this uses the shape `router/processing.rs` has had since it was written: **depth cap and a visited set**. The set is **global** to one resolution, not path-scoped — the router removes ids on the way out because it accumulates geometry per path, but a colour is a pure function of (item id, style map), so an item that resolved to `None` cannot resolve differently down another branch. Keeping it bounds total decodes to the number of *distinct* reachable items.

## The constant is now the third copy, deliberately

`processing::element` and `geometry::router::processing` both define `MAX_MAPPED_ITEM_DEPTH = 32` for this same traversal. All three must agree, or the shortest one silently strips colour off chains the others still render. The constant here carries a comment naming the other two and a test pins the value.

**Not deduplicated in this PR**: the router's is private and the three crates have no shared home for it, so collapsing them is a cross-crate move considerably larger than this fix. Flagging it as a deliberate deferral rather than an oversight — it is the right follow-up.

## Mutation results

| mutation | result |
|---|---|
| remove the visited set (keep the cap) | **hangs** — mutant ran at 99% CPU until killed |
| remove the depth cap (keep the set) | `stops_one_hop_past_the_depth_cap` FAILED |
| cap 32 -> 16 | `depth_cap_agrees_with_the_other_two_copies` FAILED **and** `resolves_a_legitimate_twenty_hop_chain` FAILED |

The third row is the one worth reading. A mismatched cap is a **wrong colour, not a crash** — the geometry still renders through the router and just silently loses its authored style — so it needs a behavioural test, not only a constant assertion. The 20-hop fixture uses a literal depth on purpose: the boundary fixtures are built *from* `MAX_MAPPED_ITEM_DEPTH` and therefore follow it anywhere, including down to 1.

On the first row: without the visited set the failure is a hang rather than a wrong value, so it surfaces as a lane timeout. That is written into the test as-is, because there is no way to assert "returned in finite time" that is not a timing test.

## Verification

- `cargo test --workspace --no-fail-fast` — **1866 passed, 0 failed**
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` — clean (this crate is the one CI excludes, so its tests are the gate)
- `module_size_ratchet` — green

The ratchet caught the tests pushing `color.rs` to 436 lines. Rather than take an allowlist row, they moved to a sibling `color_cycle_tests.rs` (the house pattern for test-heavy modules); the production file is back to 300 lines and test files are exempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mapped geometry color resolution to safely handle cyclic and deeply nested mappings.
  * Prevented excessive processing and potential stack overflows when resolving complex geometry relationships.

* **Tests**
  * Added coverage for cyclic mappings, branching cycles, valid nested chains, shared traversal paths, and depth-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->