### PR TITLE
fix(processing): bound extract_symbolic_item's three file-driven cycles

### DIFF
--- a/rust/processing/src/symbolic/item_walk.rs
+++ b/rust/processing/src/symbolic/item_walk.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 ///
 /// Kept in step with `MAX_MAPPED_ITEM_DEPTH` in `element.rs` and in
 /// `geometry/src/router/processing.rs`, which walk the same mapped-item chain.
-const MAX_ITEM_DEPTH: u32 = 32;
+pub(super) const MAX_ITEM_DEPTH: u32 = 32;
 
 /// Number of times this extraction may re-enter an id it has already visited.
 ///
@@ -51,7 +51,20 @@ const MAX_ITEM_REVISITS: u32 = 200_000;
 /// State threaded through the walk: the ancestors on the current path, and the
 /// remaining emit budget.
 pub(super) struct ItemWalk {
-    /// Ancestors on the CURRENT path -- inserted on entry, removed on exit.
+    /// Every node on the CURRENT path -- inserted on entry, removed on exit.
+    ///
+    /// Holds items AND the non-item nodes the walk re-enters through. Express
+    /// ids are unique per file, so one set needs no separation between them,
+    /// and that matters: the `IfcMappedItem -> IfcRepresentationMap ->
+    /// IfcShapeRepresentation.Items` chain re-enters through the
+    /// REPRESENTATION, which is not an item. A representation whose own items
+    /// map back to it is therefore a cycle an item-only path cannot see -- it
+    /// presents as an innocent k-way fan-out that only the revisit budget
+    /// stops, at `O(k^depth)` charges taken from a budget the rest of the file
+    /// still needs. `a_cycle_must_not_starve_the_geometry_that_follows_it`
+    /// pins that route; `a_set_cycle_must_not_starve_the_geometry_that_follows_it`
+    /// pins the item-only route (`IfcGeometricCurveSet.Elements` back to
+    /// itself), which no other bound covers.
     ///
     /// Deliberately path-scoped rather than global, unlike `element.rs`'s
     /// colour resolver. A colour is a pure function of (item id, style map), so
@@ -66,44 +79,34 @@ pub(super) struct ItemWalk {
     path: FxHashSet<u32>,
     /// Every id this extraction has entered, ever -- never removed.
     ///
-    /// Only used to tell a FIRST visit from a REVISIT. A first visit is
-    /// bounded by the file: an entity has to exist to be reached, so a flat
-    /// `IfcGeometricCurveSet` with 200k children costs 200k first visits and
-    /// nothing can make that exponential. Revisits are the whole danger --
-    /// an acyclic DAG reaches the same node down 2^levels distinct paths.
+    /// Only used to tell a FIRST visit from a REVISIT. See
+    /// [`MAX_ITEM_REVISITS`] for why that distinction is what makes the budget
+    /// safe to have at all.
     seen: FxHashSet<u32>,
     /// Charged on REVISITS only. See [`MAX_ITEM_REVISITS`].
     revisit_budget: u32,
-    /// Representations being expanded on the CURRENT path -- the other way a
-    /// mapped-item chain closes a cycle.
-    ///
-    /// `IfcMappedItem -> IfcRepresentationMap -> IfcShapeRepresentation.Items`
-    /// re-enters the walk through the representation, which is NOT an item and
-    /// so never appears in `path`. A representation whose own items map back to
-    /// it is therefore a cycle the item path guard cannot see: it presents as a
-    /// k-way fan-out that only the revisit budget stops, and stopping it there
-    /// costs `O(k^depth)` charges taken from a budget the rest of the file
-    /// still needs. `a_cycle_must_not_starve_the_geometry_that_follows_it` pins
-    /// the consequence -- an 8-way self-referential map ahead of ordinary
-    /// shared geometry drained the budget and dropped the geometry.
-    ///
-    /// Push/pop like `path`, not global, for the same reason: one
-    /// representation reached through two different mapped items is two real
-    /// pieces of geometry at two different positions.
-    rep_path: FxHashSet<u32>,
 }
 
 impl ItemWalk {
-    /// Begin expanding a mapped representation. `false` means it is already
-    /// being expanded higher up this path -- a cycle -- and must be skipped.
+    /// Put a node on the current path. `false` means it is already being
+    /// expanded higher up this path -- a cycle -- and must not be re-entered.
     ///
-    /// Every caller must pair a `true` with [`ItemWalk::exit_representation`].
-    pub(super) fn enter_representation(&mut self, rep_id: u32) -> bool {
-        self.rep_path.insert(rep_id)
+    /// Node-general on purpose: the walk re-enters through nodes that are not
+    /// representation items, and a seam named for one IFC type would leave the
+    /// next such edge to hand-roll its own guard. Nothing here knows an IFC
+    /// type; `items.rs` decides which ids are nodes.
+    ///
+    /// Every caller must pair a `true` with [`ItemWalk::exit_node`] and must
+    /// not return in between. A leaked id stays on the path for the rest of
+    /// this top-level item's walk, silently skipping every later occurrence of
+    /// that node -- missing geometry with no error, which is the failure this
+    /// module argues is worse than the cycle it guards against.
+    pub(super) fn enter_node(&mut self, id: u32) -> bool {
+        self.path.insert(id)
     }
 
-    pub(super) fn exit_representation(&mut self, rep_id: u32) {
-        self.rep_path.remove(&rep_id);
+    pub(super) fn exit_node(&mut self, id: u32) {
+        self.path.remove(&id);
     }
 }
 
@@ -125,7 +128,6 @@ pub(super) fn extract_symbolic_item(
         path: FxHashSet::default(),
         seen: FxHashSet::default(),
         revisit_budget: MAX_ITEM_REVISITS,
-        rep_path: FxHashSet::default(),
     };
     extract_symbolic_item_at(
         item, decoder, express_id, ifc_type, rep_identifier, unit_scale, transform, rtc_x, rtc_z,
@@ -161,13 +163,13 @@ pub(super) fn extract_symbolic_item_at(
             None => return,
         }
     }
-    if !walk.path.insert(item.id) {
+    if !walk.enter_node(item.id) {
         return;
     }
     extract_symbolic_item_inner(
         item, decoder, express_id, ifc_type, rep_identifier, unit_scale, transform, rtc_x, rtc_z,
         styled_items, out, depth, walk,
     );
-    walk.path.remove(&item.id);
+    walk.exit_node(item.id);
 }
 

--- a/rust/processing/src/symbolic/item_walk.rs
+++ b/rust/processing/src/symbolic/item_walk.rs
@@ -46,7 +46,7 @@ pub(super) const MAX_ITEM_DEPTH: u32 = 32;
 /// legitimately. First visits are bounded by the file itself (an entity must
 /// exist to be reached), so they cannot be the exponential; only revisits can,
 /// and an acyclic DAG reaching one node down 2^levels paths is exactly that.
-const MAX_ITEM_REVISITS: u32 = 200_000;
+pub(super) const MAX_ITEM_REVISITS: u32 = 200_000;
 
 /// State threaded through the walk: the ancestors on the current path, and the
 /// remaining emit budget.
@@ -128,6 +128,38 @@ pub(super) fn extract_symbolic_item(
         path: FxHashSet::default(),
         seen: FxHashSet::default(),
         revisit_budget: MAX_ITEM_REVISITS,
+    };
+    extract_symbolic_item_at(
+        item, decoder, express_id, ifc_type, rep_identifier, unit_scale, transform, rtc_x, rtc_z,
+        styled_items, out, 0, &mut walk,
+    );
+}
+
+/// Same walk with a caller-chosen revisit budget, so a test can pin the
+/// "first visits are never charged" property against a budget of 50 instead of
+/// building a 23.8 MB fixture to exceed the real one. The mechanism under test
+/// is identical; only the scale differs. Measured: the full-size version cost
+/// 4.24s of the crate's 4.79s lib suite.
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(super) fn extract_symbolic_item_with_revisit_budget(
+    item: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+    express_id: u32,
+    ifc_type: &str,
+    rep_identifier: &str,
+    unit_scale: f32,
+    transform: &Transform2D,
+    rtc_x: f32,
+    rtc_z: f32,
+    styled_items: &HashMap<u32, Vec<u32>>,
+    out: &mut SymbolicData,
+    revisit_budget: u32,
+) {
+    let mut walk = ItemWalk {
+        path: FxHashSet::default(),
+        seen: FxHashSet::default(),
+        revisit_budget,
     };
     extract_symbolic_item_at(
         item, decoder, express_id, ifc_type, rep_identifier, unit_scale, transform, rtc_x, rtc_z,

--- a/rust/processing/src/symbolic/item_walk.rs
+++ b/rust/processing/src/symbolic/item_walk.rs
@@ -74,6 +74,37 @@ pub(super) struct ItemWalk {
     seen: FxHashSet<u32>,
     /// Charged on REVISITS only. See [`MAX_ITEM_REVISITS`].
     revisit_budget: u32,
+    /// Representations being expanded on the CURRENT path -- the other way a
+    /// mapped-item chain closes a cycle.
+    ///
+    /// `IfcMappedItem -> IfcRepresentationMap -> IfcShapeRepresentation.Items`
+    /// re-enters the walk through the representation, which is NOT an item and
+    /// so never appears in `path`. A representation whose own items map back to
+    /// it is therefore a cycle the item path guard cannot see: it presents as a
+    /// k-way fan-out that only the revisit budget stops, and stopping it there
+    /// costs `O(k^depth)` charges taken from a budget the rest of the file
+    /// still needs. `a_cycle_must_not_starve_the_geometry_that_follows_it` pins
+    /// the consequence -- an 8-way self-referential map ahead of ordinary
+    /// shared geometry drained the budget and dropped the geometry.
+    ///
+    /// Push/pop like `path`, not global, for the same reason: one
+    /// representation reached through two different mapped items is two real
+    /// pieces of geometry at two different positions.
+    rep_path: FxHashSet<u32>,
+}
+
+impl ItemWalk {
+    /// Begin expanding a mapped representation. `false` means it is already
+    /// being expanded higher up this path -- a cycle -- and must be skipped.
+    ///
+    /// Every caller must pair a `true` with [`ItemWalk::exit_representation`].
+    pub(super) fn enter_representation(&mut self, rep_id: u32) -> bool {
+        self.rep_path.insert(rep_id)
+    }
+
+    pub(super) fn exit_representation(&mut self, rep_id: u32) {
+        self.rep_path.remove(&rep_id);
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -94,6 +125,7 @@ pub(super) fn extract_symbolic_item(
         path: FxHashSet::default(),
         seen: FxHashSet::default(),
         revisit_budget: MAX_ITEM_REVISITS,
+        rep_path: FxHashSet::default(),
     };
     extract_symbolic_item_at(
         item, decoder, express_id, ifc_type, rep_identifier, unit_scale, transform, rtc_x, rtc_z,

--- a/rust/processing/src/symbolic/item_walk.rs
+++ b/rust/processing/src/symbolic/item_walk.rs
@@ -1,0 +1,141 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Bounds for the symbolic representation-item walk (issue #2866).
+//!
+//! Split out of `items.rs` so the guards are readable on their own: `items.rs`
+//! is the per-IFC-type dispatch, and this is the policy that keeps it from
+//! walking a hostile file forever. Everything here is about WHAT the walk is
+//! allowed to do; nothing here knows about any IFC type.
+
+use super::items::extract_symbolic_item_inner;
+use super::primitives::SymbolicData;
+use super::transform::Transform2D;
+use ifc_lite_core::{DecodedEntity, EntityDecoder};
+use rustc_hash::FxHashSet;
+use std::collections::HashMap;
+
+/// Maximum representation-item nesting this walk follows.
+///
+/// Every id below comes from the FILE, and a malformed or hostile IFC can
+/// close a cycle three different ways here: `IfcGeometricSet.Elements` back to
+/// itself, the `IfcMappedItem -> IfcRepresentationMap ->
+/// IfcShapeRepresentation.Items` chain, and `IfcCompositeCurve.Segments ->
+/// IfcCompositeCurveSegment.ParentCurve`. This walk is reachable from
+/// `extract_symbolic_data` on raw uploaded bytes
+/// (`apps/server/src/services/streaming.rs`), so unbounded each one aborts the
+/// process with a stack overflow -- an abort, not a catchable panic (#2866).
+///
+/// Kept in step with `MAX_MAPPED_ITEM_DEPTH` in `element.rs` and in
+/// `geometry/src/router/processing.rs`, which walk the same mapped-item chain.
+const MAX_ITEM_DEPTH: u32 = 32;
+
+/// Number of times this extraction may re-enter an id it has already visited.
+///
+/// A depth cap bounds a path's LENGTH and not its BREADTH: `k` items that each
+/// lead back into a cycle cost `O(k^depth)`, so a cap alone converts an abort
+/// into a hang -- measured at 7.21s for k=3 on the sibling resolver in #2864
+/// before its guard landed. This is the breadth bound.
+///
+/// Charged on REVISITS ONLY, which is what makes it safe to have at all. An
+/// earlier version charged every visit, and that silently truncated a
+/// WELL-FORMED file: `IfcGeometricSet` recurses per element, so one flat set
+/// of 200,050 curves emitted 199,999 and dropped 51 with no error -- plan
+/// hatching, a survey drawing or imported DWG geometry reaches that size
+/// legitimately. First visits are bounded by the file itself (an entity must
+/// exist to be reached), so they cannot be the exponential; only revisits can,
+/// and an acyclic DAG reaching one node down 2^levels paths is exactly that.
+const MAX_ITEM_REVISITS: u32 = 200_000;
+
+/// State threaded through the walk: the ancestors on the current path, and the
+/// remaining emit budget.
+pub(super) struct ItemWalk {
+    /// Ancestors on the CURRENT path -- inserted on entry, removed on exit.
+    ///
+    /// Deliberately path-scoped rather than global, unlike `element.rs`'s
+    /// colour resolver. A colour is a pure function of (item id, style map), so
+    /// an id that resolved once cannot resolve differently elsewhere and a
+    /// global set is safe there. This walk instead ACCUMULATES output and
+    /// composes a `Transform2D` per path, so the same curve reached through two
+    /// different mapped items is two real pieces of geometry at two different
+    /// positions -- a global set would silently drop the second, which is
+    /// missing geometry rather than a cycle guard. Same reasoning as
+    /// `geometry/src/router/processing.rs`, which also accumulates per path.
+    /// `the_same_polyline_under_two_mapped_items_is_emitted_twice` pins it.
+    path: FxHashSet<u32>,
+    /// Every id this extraction has entered, ever -- never removed.
+    ///
+    /// Only used to tell a FIRST visit from a REVISIT. A first visit is
+    /// bounded by the file: an entity has to exist to be reached, so a flat
+    /// `IfcGeometricCurveSet` with 200k children costs 200k first visits and
+    /// nothing can make that exponential. Revisits are the whole danger --
+    /// an acyclic DAG reaches the same node down 2^levels distinct paths.
+    seen: FxHashSet<u32>,
+    /// Charged on REVISITS only. See [`MAX_ITEM_REVISITS`].
+    revisit_budget: u32,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn extract_symbolic_item(
+    item: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+    express_id: u32,
+    ifc_type: &str,
+    rep_identifier: &str,
+    unit_scale: f32,
+    transform: &Transform2D,
+    rtc_x: f32,
+    rtc_z: f32,
+    styled_items: &HashMap<u32, Vec<u32>>,
+    out: &mut SymbolicData,
+) {
+    let mut walk = ItemWalk {
+        path: FxHashSet::default(),
+        seen: FxHashSet::default(),
+        revisit_budget: MAX_ITEM_REVISITS,
+    };
+    extract_symbolic_item_at(
+        item, decoder, express_id, ifc_type, rep_identifier, unit_scale, transform, rtc_x, rtc_z,
+        styled_items, out, 0, &mut walk,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn extract_symbolic_item_at(
+    item: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+    express_id: u32,
+    ifc_type: &str,
+    rep_identifier: &str,
+    unit_scale: f32,
+    transform: &Transform2D,
+    rtc_x: f32,
+    rtc_z: f32,
+    styled_items: &HashMap<u32, Vec<u32>>,
+    out: &mut SymbolicData,
+    depth: u32,
+    walk: &mut ItemWalk,
+) {
+    if depth >= MAX_ITEM_DEPTH {
+        return;
+    }
+    // A first visit is free: their number is bounded by the file. Only a
+    // REVISIT can be part of an exponential fan-out, so only a revisit is
+    // charged.
+    if !walk.seen.insert(item.id) {
+        match walk.revisit_budget.checked_sub(1) {
+            Some(left) => walk.revisit_budget = left,
+            None => return,
+        }
+    }
+    if !walk.path.insert(item.id) {
+        return;
+    }
+    extract_symbolic_item_inner(
+        item, decoder, express_id, ifc_type, rep_identifier, unit_scale, transform, rtc_x, rtc_z,
+        styled_items, out, depth, walk,
+    );
+    walk.path.remove(&item.id);
+}
+

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -106,38 +106,39 @@ pub(super) fn extract_symbolic_item_inner(
                 compose_transforms(&mapping_target_transform, &mapping_origin_transform);
             let composed_transform = compose_transforms(transform, &origin_with_target);
 
-            // The representation goes on the path before its items do: this
-            // chain re-enters the walk through something that is not an item,
-            // so the item path guard cannot see the cycle it closes.
-            if let Some(mapped_rep_id) = rep_map.get_ref(1) {
-                if !walk.enter_representation(mapped_rep_id) {
-                    return;
-                }
-                if let Ok(mapped_rep) = decoder.decode_by_id(mapped_rep_id) {
-                    if let Some(items_attr) = mapped_rep.get(3) {
-                        if let Ok(items) = decoder.resolve_ref_list(items_attr) {
-                            for sub_item in items {
-                                extract_symbolic_item_at(
-                                    &sub_item,
-                                    decoder,
-                                    express_id,
-                                    ifc_type,
-                                    rep_identifier,
-                                    unit_scale,
-                                    &composed_transform,
-                                    rtc_x,
-                                    rtc_z,
-                                    styled_items,
-                                    out,
-                                    depth + 1,
-                                    walk,
-                                );
-                            }
-                        }
-                    }
-                }
-                walk.exit_representation(mapped_rep_id);
+            // Everything that can fail is resolved BEFORE the node goes on
+            // the path, so there is no early return between enter and exit --
+            // a leaked id would silently skip every later occurrence of this
+            // representation for the rest of the walk.
+            let Some(mapped_rep_id) = rep_map.get_ref(1) else { return };
+            let Ok(mapped_rep) = decoder.decode_by_id(mapped_rep_id) else { return };
+            let Some(items_attr) = mapped_rep.get(3) else { return };
+            let Ok(items) = decoder.resolve_ref_list(items_attr) else { return };
+
+            // The representation itself is a node on the path: this chain
+            // re-enters the walk through something that is not an item, so the
+            // item ids alone cannot see the cycle it closes.
+            if !walk.enter_node(mapped_rep_id) {
+                return;
             }
+            for sub_item in items {
+                extract_symbolic_item_at(
+                    &sub_item,
+                    decoder,
+                    express_id,
+                    ifc_type,
+                    rep_identifier,
+                    unit_scale,
+                    &composed_transform,
+                    rtc_x,
+                    rtc_z,
+                    styled_items,
+                    out,
+                    depth + 1,
+                    walk,
+                );
+            }
+            walk.exit_node(mapped_rep_id);
         }
         IfcType::IfcPolyline => {
             if let Some(points_attr) = item.get(0) {

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -106,7 +106,13 @@ pub(super) fn extract_symbolic_item_inner(
                 compose_transforms(&mapping_target_transform, &mapping_origin_transform);
             let composed_transform = compose_transforms(transform, &origin_with_target);
 
+            // The representation goes on the path before its items do: this
+            // chain re-enters the walk through something that is not an item,
+            // so the item path guard cannot see the cycle it closes.
             if let Some(mapped_rep_id) = rep_map.get_ref(1) {
+                if !walk.enter_representation(mapped_rep_id) {
+                    return;
+                }
                 if let Ok(mapped_rep) = decoder.decode_by_id(mapped_rep_id) {
                     if let Some(items_attr) = mapped_rep.get(3) {
                         if let Ok(items) = decoder.resolve_ref_list(items_attr) {
@@ -130,6 +136,7 @@ pub(super) fn extract_symbolic_item_inner(
                         }
                     }
                 }
+                walk.exit_representation(mapped_rep_id);
             }
         }
         IfcType::IfcPolyline => {

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -5,6 +5,7 @@
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use std::collections::HashMap;
 
+use super::item_walk::{extract_symbolic_item_at, ItemWalk};
 use super::fill::extract_annotation_fill_area;
 use super::primitives::{SymbolicCircle, SymbolicData, SymbolicPolyline};
 use super::text::extract_text_literal;
@@ -20,7 +21,7 @@ use super::trimmed_curve::extract_trimmed_curve;
 // ────────────────────────────────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
-pub(super) fn extract_symbolic_item(
+pub(super) fn extract_symbolic_item_inner(
     item: &DecodedEntity,
     decoder: &mut EntityDecoder,
     express_id: u32,
@@ -32,13 +33,15 @@ pub(super) fn extract_symbolic_item(
     rtc_z: f32,
     styled_items: &HashMap<u32, Vec<u32>>,
     out: &mut SymbolicData,
+    depth: u32,
+    walk: &mut ItemWalk,
 ) {
     match item.ifc_type {
         IfcType::IfcGeometricSet | IfcType::IfcGeometricCurveSet => {
             if let Some(elements_attr) = item.get(0) {
                 if let Ok(elements) = decoder.resolve_ref_list(elements_attr) {
                     for element in elements {
-                        extract_symbolic_item(
+                        extract_symbolic_item_at(
                             &element,
                             decoder,
                             express_id,
@@ -50,6 +53,8 @@ pub(super) fn extract_symbolic_item(
                             rtc_z,
                             styled_items,
                             out,
+                            depth + 1,
+                            walk,
                         );
                     }
                 }
@@ -106,7 +111,7 @@ pub(super) fn extract_symbolic_item(
                     if let Some(items_attr) = mapped_rep.get(3) {
                         if let Ok(items) = decoder.resolve_ref_list(items_attr) {
                             for sub_item in items {
-                                extract_symbolic_item(
+                                extract_symbolic_item_at(
                                     &sub_item,
                                     decoder,
                                     express_id,
@@ -118,6 +123,8 @@ pub(super) fn extract_symbolic_item(
                                     rtc_z,
                                     styled_items,
                                     out,
+                                    depth + 1,
+                                    walk,
                                 );
                             }
                         }
@@ -281,7 +288,7 @@ pub(super) fn extract_symbolic_item(
                     for segment in segments {
                         if let Some(curve_ref) = segment.get_ref(2) {
                             if let Ok(parent_curve) = decoder.decode_by_id(curve_ref) {
-                                extract_symbolic_item(
+                                extract_symbolic_item_at(
                                     &parent_curve,
                                     decoder,
                                     express_id,
@@ -293,6 +300,8 @@ pub(super) fn extract_symbolic_item(
                                     rtc_z,
                                     styled_items,
                                     out,
+                                    depth + 1,
+                                    walk,
                                 );
                             }
                         }

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -177,23 +177,36 @@ fn depth_cap_stops_a_chain_longer_than_the_cap() {
 /// second visit instead of spending the budget getting there.
 #[test]
 fn a_cycle_must_not_starve_the_geometry_that_follows_it() {
-    let body = "#10=IFCGEOMETRICCURVESET((#20,#50));\n\
-        #20=IFCMAPPEDITEM(#30,$);\n\
-        #30=IFCREPRESENTATIONMAP($,#40);\n\
-        #40=IFCSHAPEREPRESENTATION($,$,$,(#21,#22,#23,#24,#25,#26,#27,#28));\n\
-        #21=IFCMAPPEDITEM(#30,$);\n#22=IFCMAPPEDITEM(#30,$);\n\
-        #23=IFCMAPPEDITEM(#30,$);\n#24=IFCMAPPEDITEM(#30,$);\n\
-        #25=IFCMAPPEDITEM(#30,$);\n#26=IFCMAPPEDITEM(#30,$);\n\
-        #27=IFCMAPPEDITEM(#30,$);\n#28=IFCMAPPEDITEM(#30,$);\n\
-        #50=IFCPOLYLINE((#60,#61));\n\
-        #60=IFCCARTESIANPOINT((0.,0.));\n\
-        #61=IFCCARTESIANPOINT((1.,1.));\n";
-    let out = run(&wrap(body), 10);
+    // The geometry after the cycle must be reached by a REVISIT, because only
+    // revisits are charged. An earlier version of this test asserted on a
+    // polyline reached by a FIRST visit, which is never charged -- so it
+    // passed even with the budget set to zero and pinned nothing.
+    //
+    // #70 and #71 are two mapped items sharing one representation, so the
+    // polyline inside it is emitted twice: once on the first visit, once on a
+    // revisit. The 8-way self-referential cycle in #20 must not consume the
+    // budget that second emission needs.
+    let shared = "#70=IFCMAPPEDITEM(#72,$);\n        #71=IFCMAPPEDITEM(#72,$);\n        #72=IFCREPRESENTATIONMAP($,#73);\n        #73=IFCSHAPEREPRESENTATION($,$,$,(#50));\n        #50=IFCPOLYLINE((#60,#61));\n        #60=IFCCARTESIANPOINT((0.,0.));\n        #61=IFCCARTESIANPOINT((1.,1.));\n";
+    let cycle = "#20=IFCMAPPEDITEM(#30,$);\n        #30=IFCREPRESENTATIONMAP($,#40);\n        #40=IFCSHAPEREPRESENTATION($,$,$,(#21,#22,#23,#24,#25,#26,#27,#28));\n        #21=IFCMAPPEDITEM(#30,$);\n#22=IFCMAPPEDITEM(#30,$);\n        #23=IFCMAPPEDITEM(#30,$);\n#24=IFCMAPPEDITEM(#30,$);\n        #25=IFCMAPPEDITEM(#30,$);\n#26=IFCMAPPEDITEM(#30,$);\n        #27=IFCMAPPEDITEM(#30,$);\n#28=IFCMAPPEDITEM(#30,$);\n";
+
+    // Control: the same shared geometry with NO cycle ahead of it emits twice.
+    let control = format!("#10=IFCGEOMETRICCURVESET((#70,#71));\n{shared}");
+    let baseline = run(&wrap(&control), 10);
+    assert_eq!(
+        baseline.polylines.len(),
+        2,
+        "control: a representation shared by two mapped items emits twice"
+    );
+
+    // Same file with the cycle in front of it must still emit twice.
+    let with_cycle = format!("#10=IFCGEOMETRICCURVESET((#20,#70,#71));\n{cycle}{shared}");
+    let out = run_with_timeout(wrap(&with_cycle), 10, 60);
     assert_eq!(
         out.polylines.len(),
-        1,
-        "the polyline after the cycle must still be emitted; without the path guard the \
-         cycle consumes MAX_ITEM_BUDGET and starves it"
+        2,
+        "a cycle must not consume the budget that legitimate shared geometry \
+         after it needs; got {} polylines instead of 2",
+        out.polylines.len()
     );
 }
 

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -210,6 +210,30 @@ fn a_cycle_must_not_starve_the_geometry_that_follows_it() {
     );
 }
 
+/// The same starvation, on the route the REPRESENTATION guard does not cover.
+///
+/// `IfcGeometricCurveSet.Elements` closes its cycle through items alone, with
+/// no mapped item and no representation, so only the item path guard can cut
+/// it. Without that guard the 8-way self-reference is merely bounded by the
+/// depth cap and pays a revisit charge at every level, draining the budget the
+/// shared geometry after it needs. This is the test whose absence let the item
+/// path guard be deleted with the whole file still green.
+#[test]
+fn a_set_cycle_must_not_starve_the_geometry_that_follows_it() {
+    let shared = "#70=IFCMAPPEDITEM(#72,$);\n        #71=IFCMAPPEDITEM(#72,$);\n        #72=IFCREPRESENTATIONMAP($,#73);\n        #73=IFCSHAPEREPRESENTATION($,$,$,(#50));\n        #50=IFCPOLYLINE((#60,#61));\n        #60=IFCCARTESIANPOINT((0.,0.));\n        #61=IFCCARTESIANPOINT((1.,1.));\n";
+    let cycle = "#20=IFCGEOMETRICCURVESET((#21,#22,#23,#24,#25,#26,#27,#28));\n        #21=IFCGEOMETRICCURVESET((#20));\n#22=IFCGEOMETRICCURVESET((#20));\n        #23=IFCGEOMETRICCURVESET((#20));\n#24=IFCGEOMETRICCURVESET((#20));\n        #25=IFCGEOMETRICCURVESET((#20));\n#26=IFCGEOMETRICCURVESET((#20));\n        #27=IFCGEOMETRICCURVESET((#20));\n#28=IFCGEOMETRICCURVESET((#20));\n";
+
+    let body = format!("#10=IFCGEOMETRICCURVESET((#20,#70,#71));\n{cycle}{shared}");
+    let out = run_with_timeout(wrap(&body), 10, 60);
+    assert_eq!(
+        out.polylines.len(),
+        2,
+        "a set cycle must not consume the budget the shared geometry after it \
+         needs; got {} polylines instead of 2",
+        out.polylines.len()
+    );
+}
+
 /// A long ACYCLIC chain: every id distinct, so a visited set never fires.
 /// This is the input a set alone cannot stop — one stack frame per
 /// file-supplied entity. Only a chain-length bound catches it.

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -374,11 +374,21 @@ fn an_acyclic_dag_is_bounded_by_total_work_not_by_depth() {
     // first reaches the leaf through a REVISIT, so the budget is the ceiling.
     // A raised budget moves this bound with it instead of leaving a literal
     // that quietly stops binding.
+    // Two assertions, because the derived one alone cannot fail. The ceiling
+    // follows the constant so a raised budget does not silently un-pin it; the
+    // absolute bound pins the CONSEQUENCE, since the walk actually emits
+    // 66,675 here and a tripling would still sit under the 200,000 ceiling
+    // while the derived assertion reported success.
+    let emitted = out.polylines.len();
     assert!(
-        out.polylines.len() <= MAX_ITEM_REVISITS as usize,
-        "an acyclic DAG must be bounded by MAX_ITEM_REVISITS ({}), got {} polylines",
-        MAX_ITEM_REVISITS,
-        out.polylines.len()
+        emitted <= MAX_ITEM_REVISITS as usize,
+        "an acyclic DAG must be bounded by MAX_ITEM_REVISITS ({MAX_ITEM_REVISITS}), \
+         got {emitted} polylines"
+    );
+    assert!(
+        emitted < 100_000,
+        "2^24 paths must collapse to the measured ~66,675, not merely to something \
+         under the budget; got {emitted}"
     );
 }
 
@@ -423,15 +433,26 @@ fn a_large_flat_set_is_not_truncated() {
     );
 }
 
-/// The depth cap is the fourth copy of one policy (`element.rs`,
-/// `router/processing.rs`, `wasm-bindings/.../color.rs`). Those three hold each
-/// other in step with an agreement assertion; this pins the fourth, so moving
-/// the family's value fails here instead of leaving this site silently short.
-/// A shorter cap here renders the geometry but drops its symbolic annotation.
+/// Pins the depth cap to the mapped-item family's VALUE (`element.rs`,
+/// `router/processing.rs`, `wasm-bindings/.../color.rs` all use 32), so moving
+/// the family fails here instead of leaving this site silently behind.
+///
+/// It pins the number and nothing more, deliberately: this cap does NOT count
+/// the same thing the family counts. The others charge one level per
+/// mapped-item hop; this walk also charges `depth + 1` for `IfcGeometricSet`
+/// elements (`items.rs:56`) and `IfcCompositeCurve` segments (`items.rs:311`).
+/// So a mapped chain whose levels each pass through a set or a composite curve
+/// exhausts this cap in roughly half as many hops as the router's, and the
+/// asymmetry is one-directional: this walk is never more permissive, so the
+/// failure is a dropped symbolic annotation on geometry that still renders,
+/// never the reverse. Equalising the numbers does not equalise the semantics,
+/// and no assertion here can catch that -- it is recorded rather than tested.
 #[test]
-fn depth_cap_matches_the_mapped_item_family() {
+fn depth_cap_matches_the_mapped_item_family_value() {
     assert_eq!(
         MAX_ITEM_DEPTH, 32,
-        "must equal MAX_MAPPED_ITEM_DEPTH in element.rs, router/processing.rs and color.rs"
+        "must equal MAX_MAPPED_ITEM_DEPTH in element.rs, router/processing.rs and color.rs; \
+         note this cap charges set elements and curve segments too, so equal values do not \
+         mean equal reach"
     );
 }

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -370,9 +370,14 @@ fn an_acyclic_dag_is_bounded_by_total_work_not_by_depth() {
     let out = run_with_timeout(wrap(&lines), 5, 30);
     // The point is that it TERMINATES within the budget rather than realising
     // 2^24 paths. Emitting some polylines is correct; emitting 2^24 is not.
+    // Derived from the constant rather than restated: every emission past the
+    // first reaches the leaf through a REVISIT, so the budget is the ceiling.
+    // A raised budget moves this bound with it instead of leaving a literal
+    // that quietly stops binding.
     assert!(
-        out.polylines.len() < 300_000,
-        "an acyclic DAG must be bounded by MAX_ITEM_REVISITS, got {} polylines",
+        out.polylines.len() <= MAX_ITEM_REVISITS as usize,
+        "an acyclic DAG must be bounded by MAX_ITEM_REVISITS ({}), got {} polylines",
+        MAX_ITEM_REVISITS,
         out.polylines.len()
     );
 }

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -13,7 +13,10 @@
 //! overflow takes the whole test binary down as SIGABRT, which reads as broken
 //! infrastructure instead of a failed assertion.
 
-use super::item_walk::extract_symbolic_item;
+use super::item_walk::{
+    extract_symbolic_item, extract_symbolic_item_with_revisit_budget, MAX_ITEM_DEPTH,
+    MAX_ITEM_REVISITS,
+};
 use super::primitives::SymbolicData;
 use super::transform::Transform2D;
 use ifc_lite_core::{build_entity_index, EntityDecoder};
@@ -42,6 +45,30 @@ fn run(step: &str, start_id: u32) -> SymbolicData {
     out
 }
 
+fn run_with_budget(step: &str, start_id: u32, budget: u32) -> SymbolicData {
+    let content = step.as_bytes();
+    let index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, index);
+    let item = decoder.decode_by_id(start_id).expect("fixture entity decodes");
+    let styled: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut out = SymbolicData::default();
+    extract_symbolic_item_with_revisit_budget(
+        &item,
+        &mut decoder,
+        1,
+        "IfcAnnotation",
+        "Annotation",
+        1.0,
+        &Transform2D::identity(),
+        0.0,
+        0.0,
+        &styled,
+        &mut out,
+        budget,
+    );
+    out
+}
+
 /// Run the walk in a worker thread with a timeout, so a regressed guard is
 /// observed as a TIMEOUT rather than hanging the suite. Necessary because the
 /// breadth budget's failure mode is a hang, not an abort: a stack overflow
@@ -58,7 +85,7 @@ fn run_with_timeout(step: String, start_id: u32, secs: u64) -> SymbolicData {
     assert!(
         outcome.is_ok(),
         "extract_symbolic_item did not terminate within {secs}s -- the breadth bound \
-         (MAX_ITEM_BUDGET) is gone; a depth cap and a path guard alone allow k! paths"
+         (MAX_ITEM_REVISITS) is gone; a depth cap and a path guard alone allow k! paths"
     );
     let _ = handle.join();
     outcome.unwrap()
@@ -166,11 +193,23 @@ fn depth_cap_stops_a_chain_longer_than_the_cap() {
     );
 }
 
+/// Geometry emitted TWICE: two mapped items sharing one representation, so the
+/// polyline inside it is reached once on a first visit and once on a REVISIT.
+/// Both starvation tests assert on the revisit, because only revisits are
+/// charged -- an assertion on a first visit cannot be starved and pins nothing.
+const SHARED_TWICE: &str = "#70=IFCMAPPEDITEM(#72,$);\n\
+     #71=IFCMAPPEDITEM(#72,$);\n\
+     #72=IFCREPRESENTATIONMAP($,#73);\n\
+     #73=IFCSHAPEREPRESENTATION($,$,$,(#50));\n\
+     #50=IFCPOLYLINE((#60,#61));\n\
+     #60=IFCCARTESIANPOINT((0.,0.));\n\
+     #61=IFCCARTESIANPOINT((1.,1.));\n";
+
 /// The path guard is not redundant with the depth cap, and this is the damage
 /// it prevents rather than the mechanism it uses.
 ///
 /// The cap alone terminates a cycle, so every test above still passes without
-/// the guard. But a cycle re-entered under the cap burns `MAX_ITEM_BUDGET`
+/// the guard. But a cycle re-entered under the cap burns `MAX_ITEM_REVISITS`
 /// before it stops, and the budget is shared by the whole extraction — so the
 /// legitimate geometry that follows the cycle in the same representation is
 /// silently dropped. Cheap termination is the point: the guard returns on the
@@ -186,11 +225,10 @@ fn a_cycle_must_not_starve_the_geometry_that_follows_it() {
     // polyline inside it is emitted twice: once on the first visit, once on a
     // revisit. The 8-way self-referential cycle in #20 must not consume the
     // budget that second emission needs.
-    let shared = "#70=IFCMAPPEDITEM(#72,$);\n        #71=IFCMAPPEDITEM(#72,$);\n        #72=IFCREPRESENTATIONMAP($,#73);\n        #73=IFCSHAPEREPRESENTATION($,$,$,(#50));\n        #50=IFCPOLYLINE((#60,#61));\n        #60=IFCCARTESIANPOINT((0.,0.));\n        #61=IFCCARTESIANPOINT((1.,1.));\n";
     let cycle = "#20=IFCMAPPEDITEM(#30,$);\n        #30=IFCREPRESENTATIONMAP($,#40);\n        #40=IFCSHAPEREPRESENTATION($,$,$,(#21,#22,#23,#24,#25,#26,#27,#28));\n        #21=IFCMAPPEDITEM(#30,$);\n#22=IFCMAPPEDITEM(#30,$);\n        #23=IFCMAPPEDITEM(#30,$);\n#24=IFCMAPPEDITEM(#30,$);\n        #25=IFCMAPPEDITEM(#30,$);\n#26=IFCMAPPEDITEM(#30,$);\n        #27=IFCMAPPEDITEM(#30,$);\n#28=IFCMAPPEDITEM(#30,$);\n";
 
     // Control: the same shared geometry with NO cycle ahead of it emits twice.
-    let control = format!("#10=IFCGEOMETRICCURVESET((#70,#71));\n{shared}");
+    let control = format!("#10=IFCGEOMETRICCURVESET((#70,#71));\n{SHARED_TWICE}");
     let baseline = run(&wrap(&control), 10);
     assert_eq!(
         baseline.polylines.len(),
@@ -199,7 +237,7 @@ fn a_cycle_must_not_starve_the_geometry_that_follows_it() {
     );
 
     // Same file with the cycle in front of it must still emit twice.
-    let with_cycle = format!("#10=IFCGEOMETRICCURVESET((#20,#70,#71));\n{cycle}{shared}");
+    let with_cycle = format!("#10=IFCGEOMETRICCURVESET((#20,#70,#71));\n{cycle}{SHARED_TWICE}");
     let out = run_with_timeout(wrap(&with_cycle), 10, 60);
     assert_eq!(
         out.polylines.len(),
@@ -220,10 +258,9 @@ fn a_cycle_must_not_starve_the_geometry_that_follows_it() {
 /// path guard be deleted with the whole file still green.
 #[test]
 fn a_set_cycle_must_not_starve_the_geometry_that_follows_it() {
-    let shared = "#70=IFCMAPPEDITEM(#72,$);\n        #71=IFCMAPPEDITEM(#72,$);\n        #72=IFCREPRESENTATIONMAP($,#73);\n        #73=IFCSHAPEREPRESENTATION($,$,$,(#50));\n        #50=IFCPOLYLINE((#60,#61));\n        #60=IFCCARTESIANPOINT((0.,0.));\n        #61=IFCCARTESIANPOINT((1.,1.));\n";
     let cycle = "#20=IFCGEOMETRICCURVESET((#21,#22,#23,#24,#25,#26,#27,#28));\n        #21=IFCGEOMETRICCURVESET((#20));\n#22=IFCGEOMETRICCURVESET((#20));\n        #23=IFCGEOMETRICCURVESET((#20));\n#24=IFCGEOMETRICCURVESET((#20));\n        #25=IFCGEOMETRICCURVESET((#20));\n#26=IFCGEOMETRICCURVESET((#20));\n        #27=IFCGEOMETRICCURVESET((#20));\n#28=IFCGEOMETRICCURVESET((#20));\n";
 
-    let body = format!("#10=IFCGEOMETRICCURVESET((#20,#70,#71));\n{cycle}{shared}");
+    let body = format!("#10=IFCGEOMETRICCURVESET((#20,#70,#71));\n{cycle}{SHARED_TWICE}");
     let out = run_with_timeout(wrap(&body), 10, 60);
     assert_eq!(
         out.polylines.len(),
@@ -306,7 +343,7 @@ fn a_shared_item_reached_deep_then_shallow_is_still_emitted() {
 /// doubles per level. Codex found this defeating a cap-plus-set guard on the
 /// curve resolver (#2876) at 2^levels.
 ///
-/// Only a total-work bound stops it. Here that is `MAX_ITEM_BUDGET`.
+/// Only a total-work bound stops it. Here that is `MAX_ITEM_REVISITS`.
 #[test]
 fn an_acyclic_dag_is_bounded_by_total_work_not_by_depth() {
     // Level i's representation holds TWO mapped items, both pointing at level
@@ -335,7 +372,7 @@ fn an_acyclic_dag_is_bounded_by_total_work_not_by_depth() {
     // 2^24 paths. Emitting some polylines is correct; emitting 2^24 is not.
     assert!(
         out.polylines.len() < 300_000,
-        "an acyclic DAG must be bounded by MAX_ITEM_BUDGET, got {} polylines",
+        "an acyclic DAG must be bounded by MAX_ITEM_REVISITS, got {} polylines",
         out.polylines.len()
     );
 }
@@ -347,21 +384,49 @@ fn an_acyclic_dag_is_bounded_by_total_work_not_by_depth() {
 /// size legitimately. First visits are bounded by the file, so they are free.
 #[test]
 fn a_large_flat_set_is_not_truncated() {
-    let n = 200_050usize;
-    let mut lines = String::with_capacity(n * 60);
-    let mut items = String::with_capacity(n * 8);
+    // A flat set LARGER than the revisit budget must still emit every element.
+    // `IfcGeometricSet` recurses per element, so an earlier version that
+    // charged every visit rather than only revisits silently truncated a
+    // well-formed file: 200,050 curves emitted 199,999 and dropped 51, with no
+    // error. Plan hatching, a survey drawing or an imported DWG reaches that
+    // size legitimately.
+    //
+    // Pinned against an injected budget of 50 rather than the real 200,000.
+    // The mechanism is identical -- first visits are not charged, so the set
+    // may exceed the budget -- and the full-size fixture cost 4.24s of the
+    // crate's 4.79s lib suite to build and walk 23.8 MB of STEP.
+    const BUDGET: u32 = 50;
+    let n = BUDGET as usize + 10;
+    let mut lines = String::new();
+    let mut items = String::new();
     for i in 0..n {
         let pl = 1000 + i * 3;
-        if i > 0 { items.push(','); }
+        if i > 0 {
+            items.push(',');
+        }
         items.push_str(&format!("#{pl}"));
         lines.push_str(&format!("#{pl}=IFCPOLYLINE((#{},#{}));\n", pl + 1, pl + 2));
         lines.push_str(&format!("#{}=IFCCARTESIANPOINT((0.,0.));\n", pl + 1));
         lines.push_str(&format!("#{}=IFCCARTESIANPOINT((1.,1.));\n", pl + 2));
     }
     lines.push_str(&format!("#10=IFCGEOMETRICCURVESET(({items}));\n"));
-    let out = run_with_timeout(wrap(&lines), 10, 120);
+    let out = run_with_budget(&wrap(&lines), 10, BUDGET);
     assert_eq!(
-        out.polylines.len(), n,
+        out.polylines.len(),
+        n,
         "a well-formed flat set must emit every element; charging first visits truncates it"
+    );
+}
+
+/// The depth cap is the fourth copy of one policy (`element.rs`,
+/// `router/processing.rs`, `wasm-bindings/.../color.rs`). Those three hold each
+/// other in step with an agreement assertion; this pins the fourth, so moving
+/// the family's value fails here instead of leaving this site silently short.
+/// A shorter cap here renders the geometry but drops its symbolic annotation.
+#[test]
+fn depth_cap_matches_the_mapped_item_family() {
+    assert_eq!(
+        MAX_ITEM_DEPTH, 32,
+        "must equal MAX_MAPPED_ITEM_DEPTH in element.rs, router/processing.rs and color.rs"
     );
 }

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -1,0 +1,330 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Cycle and fan-out guards for `extract_symbolic_item` (issue #2866).
+//!
+//! This walk is reachable from `extract_symbolic_data` on raw uploaded bytes
+//! (`apps/server/src/services/streaming.rs`), and every id it follows comes
+//! from the file. Unbounded, each of the three cycle edges below aborts the
+//! process with a stack overflow — an abort, not a catchable panic.
+//!
+//! Every test asserts the SAFE RESULT rather than "does not crash": a stack
+//! overflow takes the whole test binary down as SIGABRT, which reads as broken
+//! infrastructure instead of a failed assertion.
+
+use super::item_walk::extract_symbolic_item;
+use super::primitives::SymbolicData;
+use super::transform::Transform2D;
+use ifc_lite_core::{build_entity_index, EntityDecoder};
+use std::collections::HashMap;
+
+fn run(step: &str, start_id: u32) -> SymbolicData {
+    let content = step.as_bytes();
+    let index = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, index);
+    let item = decoder.decode_by_id(start_id).expect("fixture entity decodes");
+    let styled: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut out = SymbolicData::default();
+    extract_symbolic_item(
+        &item,
+        &mut decoder,
+        1,
+        "IfcAnnotation",
+        "Annotation",
+        1.0,
+        &Transform2D::identity(),
+        0.0,
+        0.0,
+        &styled,
+        &mut out,
+    );
+    out
+}
+
+/// Run the walk in a worker thread with a timeout, so a regressed guard is
+/// observed as a TIMEOUT rather than hanging the suite. Necessary because the
+/// breadth budget's failure mode is a hang, not an abort: a stack overflow
+/// takes the process down whatever thread it is on, but an unbounded fan-out
+/// just spins, and an elapsed-time assertion inside the call can never fire
+/// because the call never returns. Same harness as
+/// `geometry/src/processors/boolean/chain_cycle_tests.rs`.
+fn run_with_timeout(step: String, start_id: u32, secs: u64) -> SymbolicData {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let _ = tx.send(run(&step, start_id));
+    });
+    let outcome = rx.recv_timeout(std::time::Duration::from_secs(secs));
+    assert!(
+        outcome.is_ok(),
+        "extract_symbolic_item did not terminate within {secs}s -- the breadth bound \
+         (MAX_ITEM_BUDGET) is gone; a depth cap and a path guard alone allow k! paths"
+    );
+    let _ = handle.join();
+    outcome.unwrap()
+}
+
+fn wrap(body: &str) -> String {
+    format!("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n{body}ENDSEC;\nEND-ISO-10303-21;\n")
+}
+
+/// Cycle edge 1: IfcGeometricCurveSet.Elements pointing back at itself.
+#[test]
+fn cyclic_geometric_curve_set_terminates() {
+    let out = run(&wrap("#10=IFCGEOMETRICCURVESET((#10));\n"), 10);
+    assert!(out.polylines.is_empty(), "a self-referential set must emit nothing, not recurse forever");
+}
+
+/// Cycle edge 2: the IfcMappedItem chain (same shape as #2863).
+#[test]
+fn cyclic_mapped_item_terminates() {
+    let out = run(
+        &wrap("#30=IFCMAPPEDITEM(#40,$);\n#40=IFCREPRESENTATIONMAP($,#50);\n#50=IFCSHAPEREPRESENTATION($,$,$,(#30));\n"),
+        30,
+    );
+    assert!(out.polylines.is_empty(), "a cyclic representation map must emit nothing");
+}
+
+/// Cycle edge 3: IfcCompositeCurve.Segments -> ParentCurve back to the curve.
+#[test]
+fn cyclic_composite_curve_terminates() {
+    let out = run(
+        &wrap("#60=IFCCOMPOSITECURVE((#61),.F.);\n#61=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#60);\n"),
+        60,
+    );
+    assert!(out.polylines.is_empty(), "a self-referential composite curve must emit nothing");
+}
+
+/// A depth cap bounds a path's LENGTH, not its BREADTH. `k` items that each
+/// lead back into the cycle cost O(k^depth) with a cap alone — measured at
+/// 7.21s for k=3 on the sibling resolver in #2864 before its guard landed.
+/// This must stay flat in `k`, not exponential.
+#[test]
+fn fanout_cycle_does_not_blow_up() {
+    for k in [1usize, 2, 4, 8, 16] {
+        let mut lines = String::new();
+        let mut items = String::new();
+        for i in 0..k {
+            let id = 100 + i;
+            if i > 0 {
+                items.push(',');
+            }
+            items.push_str(&format!("#{id}"));
+            lines.push_str(&format!("#{id}=IFCMAPPEDITEM(#40,$);\n"));
+        }
+        lines.push_str("#40=IFCREPRESENTATIONMAP($,#50);\n");
+        lines.push_str(&format!("#50=IFCSHAPEREPRESENTATION($,$,$,({items}));\n"));
+
+        let out = run_with_timeout(wrap(&lines), 100, 20);
+        assert!(out.polylines.is_empty(), "k={k}: a fan-out cycle must emit nothing");
+    }
+}
+
+/// The path guard must NOT be global. This walk accumulates output and
+/// composes a transform per path, so the same polyline reached through two
+/// different mapped items is two real pieces of geometry at two positions.
+/// A global visited set would emit only the first — missing geometry.
+#[test]
+fn the_same_polyline_under_two_mapped_items_is_emitted_twice() {
+    let body = "#10=IFCGEOMETRICCURVESET((#20,#21));\n\
+        #20=IFCMAPPEDITEM(#30,$);\n\
+        #21=IFCMAPPEDITEM(#31,$);\n\
+        #30=IFCREPRESENTATIONMAP($,#40);\n\
+        #31=IFCREPRESENTATIONMAP($,#40);\n\
+        #40=IFCSHAPEREPRESENTATION($,$,$,(#50));\n\
+        #50=IFCPOLYLINE((#60,#61));\n\
+        #60=IFCCARTESIANPOINT((0.,0.));\n\
+        #61=IFCCARTESIANPOINT((1.,1.));\n";
+    let out = run(&wrap(body), 10);
+    assert_eq!(
+        out.polylines.len(),
+        2,
+        "a shared polyline reached through two mapped items must be emitted twice; \
+         a GLOBAL visited set would drop the second and silently lose geometry"
+    );
+}
+
+/// The depth cap must actually bound a long non-cyclic chain.
+#[test]
+fn depth_cap_stops_a_chain_longer_than_the_cap() {
+    let hops = 60usize;
+    let mut lines = String::new();
+    for i in 0..hops {
+        let item = 100 + i * 3;
+        let map = item + 1;
+        let repr = item + 2;
+        let next = if i + 1 < hops { 100 + (i + 1) * 3 } else { 9000 };
+        lines.push_str(&format!("#{item}=IFCMAPPEDITEM(#{map},$);\n"));
+        lines.push_str(&format!("#{map}=IFCREPRESENTATIONMAP($,#{repr});\n"));
+        lines.push_str(&format!("#{repr}=IFCSHAPEREPRESENTATION($,$,$,(#{next}));\n"));
+    }
+    lines.push_str("#9000=IFCPOLYLINE((#9001,#9002));\n#9001=IFCCARTESIANPOINT((0.,0.));\n#9002=IFCCARTESIANPOINT((1.,1.));\n");
+    let out = run(&wrap(&lines), 100);
+    assert!(
+        out.polylines.is_empty(),
+        "a 60-hop chain must be cut off by MAX_ITEM_DEPTH=32 before reaching its leaf"
+    );
+}
+
+/// The path guard is not redundant with the depth cap, and this is the damage
+/// it prevents rather than the mechanism it uses.
+///
+/// The cap alone terminates a cycle, so every test above still passes without
+/// the guard. But a cycle re-entered under the cap burns `MAX_ITEM_BUDGET`
+/// before it stops, and the budget is shared by the whole extraction — so the
+/// legitimate geometry that follows the cycle in the same representation is
+/// silently dropped. Cheap termination is the point: the guard returns on the
+/// second visit instead of spending the budget getting there.
+#[test]
+fn a_cycle_must_not_starve_the_geometry_that_follows_it() {
+    let body = "#10=IFCGEOMETRICCURVESET((#20,#50));\n\
+        #20=IFCMAPPEDITEM(#30,$);\n\
+        #30=IFCREPRESENTATIONMAP($,#40);\n\
+        #40=IFCSHAPEREPRESENTATION($,$,$,(#21,#22,#23,#24,#25,#26,#27,#28));\n\
+        #21=IFCMAPPEDITEM(#30,$);\n#22=IFCMAPPEDITEM(#30,$);\n\
+        #23=IFCMAPPEDITEM(#30,$);\n#24=IFCMAPPEDITEM(#30,$);\n\
+        #25=IFCMAPPEDITEM(#30,$);\n#26=IFCMAPPEDITEM(#30,$);\n\
+        #27=IFCMAPPEDITEM(#30,$);\n#28=IFCMAPPEDITEM(#30,$);\n\
+        #50=IFCPOLYLINE((#60,#61));\n\
+        #60=IFCCARTESIANPOINT((0.,0.));\n\
+        #61=IFCCARTESIANPOINT((1.,1.));\n";
+    let out = run(&wrap(body), 10);
+    assert_eq!(
+        out.polylines.len(),
+        1,
+        "the polyline after the cycle must still be emitted; without the path guard the \
+         cycle consumes MAX_ITEM_BUDGET and starves it"
+    );
+}
+
+/// A long ACYCLIC chain: every id distinct, so a visited set never fires.
+/// This is the input a set alone cannot stop — one stack frame per
+/// file-supplied entity. Only a chain-length bound catches it.
+#[test]
+fn a_long_acyclic_chain_does_not_abort() {
+    let hops = 200_000usize;
+    let mut lines = String::with_capacity(hops * 40);
+    for i in 0..hops {
+        let item = 100 + i * 3;
+        let map = item + 1;
+        let repr = item + 2;
+        let next = if i + 1 < hops { 100 + (i + 1) * 3 } else { 90_000_000 };
+        lines.push_str(&format!("#{item}=IFCMAPPEDITEM(#{map},$);\n"));
+        lines.push_str(&format!("#{map}=IFCREPRESENTATIONMAP($,#{repr});\n"));
+        lines.push_str(&format!("#{repr}=IFCSHAPEREPRESENTATION($,$,$,(#{next}));\n"));
+    }
+    lines.push_str("#90000000=IFCPOLYLINE((#90000001,#90000002));\n#90000001=IFCCARTESIANPOINT((0.,0.));\n#90000002=IFCCARTESIANPOINT((1.,1.));\n");
+    let out = run_with_timeout(wrap(&lines), 100, 60);
+    assert!(
+        out.polylines.is_empty(),
+        "a 200k-hop acyclic chain must be cut off by MAX_ITEM_DEPTH, not walked"
+    );
+}
+
+/// The P2 interaction Codex found on the colour resolvers: a GLOBAL visited
+/// set combined with a depth cap can lose a legitimate result. An item first
+/// reached NEAR the cap is marked visited and yields nothing; a later, SHORTER
+/// branch to the same item is then skipped even though it would have resolved.
+///
+/// This walk uses a PATH-scoped set, so the id is released on the way out and
+/// the shallow branch re-explores it freely. Pinned here rather than assumed,
+/// because the failure is a silently missing polyline, not a crash.
+#[test]
+fn a_shared_item_reached_deep_then_shallow_is_still_emitted() {
+    // Branch A: a 30-link chain ending at the shared representation (#7000),
+    // deep enough that anything recorded globally would be at/near the cap.
+    // Branch B: reaches #7000 directly. The polyline under it must be emitted
+    // via B even after A has walked through it.
+    let mut lines = String::new();
+    let hops = 30usize;
+    for i in 0..hops {
+        let item = 100 + i * 3;
+        let map = item + 1;
+        let repr = item + 2;
+        let next = if i + 1 < hops { 100 + (i + 1) * 3 } else { 7000 };
+        lines.push_str(&format!("#{item}=IFCMAPPEDITEM(#{map},$);\n"));
+        lines.push_str(&format!("#{map}=IFCREPRESENTATIONMAP($,#{repr});\n"));
+        lines.push_str(&format!("#{repr}=IFCSHAPEREPRESENTATION($,$,$,(#{next}));\n"));
+    }
+    lines.push_str("#7000=IFCMAPPEDITEM(#7001,$);\n");
+    lines.push_str("#7001=IFCREPRESENTATIONMAP($,#7002);\n");
+    lines.push_str("#7002=IFCSHAPEREPRESENTATION($,$,$,(#7010));\n");
+    lines.push_str("#7010=IFCPOLYLINE((#7011,#7012));\n");
+    lines.push_str("#7011=IFCCARTESIANPOINT((0.,0.));\n#7012=IFCCARTESIANPOINT((1.,1.));\n");
+    // Root holds the deep branch FIRST, then the direct one.
+    lines.push_str("#10=IFCGEOMETRICCURVESET((#100,#7000));\n");
+
+    let out = run(&wrap(&lines), 10);
+    assert!(
+        !out.polylines.is_empty(),
+        "the shared item reached by a SHORT branch must still emit after a deep branch \
+         walked through it; a global visited set would mark it explored and drop this"
+    );
+}
+
+/// The input that defeats a cap AND a path-scoped set: an ACYCLIC DAG where
+/// every branch SUCCEEDS. Nothing errors, so nothing propagates; no id repeats
+/// on any single path, so the path guard never fires; and each level's fan-out
+/// multiplies, so the cap bounds one path's length while the NUMBER of paths
+/// doubles per level. Codex found this defeating a cap-plus-set guard on the
+/// curve resolver (#2876) at 2^levels.
+///
+/// Only a total-work bound stops it. Here that is `MAX_ITEM_BUDGET`.
+#[test]
+fn an_acyclic_dag_is_bounded_by_total_work_not_by_depth() {
+    // Level i's representation holds TWO mapped items, both pointing at level
+    // i+1. 24 levels is 2^24 paths if nothing bounds total work.
+    let levels = 24usize;
+    let mut lines = String::new();
+    for i in 0..levels {
+        let map = 1000 + i * 10;
+        let repr = map + 1;
+        let a = map + 2;
+        let b = map + 3;
+        let next_map = if i + 1 < levels { 1000 + (i + 1) * 10 } else { 90_000 };
+        lines.push_str(&format!("#{map}=IFCREPRESENTATIONMAP($,#{repr});\n"));
+        lines.push_str(&format!("#{repr}=IFCSHAPEREPRESENTATION($,$,$,(#{a},#{b}));\n"));
+        lines.push_str(&format!("#{a}=IFCMAPPEDITEM(#{next_map},$);\n"));
+        lines.push_str(&format!("#{b}=IFCMAPPEDITEM(#{next_map},$);\n"));
+    }
+    lines.push_str("#90000=IFCREPRESENTATIONMAP($,#90001);\n");
+    lines.push_str("#90001=IFCSHAPEREPRESENTATION($,$,$,(#90010));\n");
+    lines.push_str("#90010=IFCPOLYLINE((#90011,#90012));\n");
+    lines.push_str("#90011=IFCCARTESIANPOINT((0.,0.));\n#90012=IFCCARTESIANPOINT((1.,1.));\n");
+    lines.push_str("#5=IFCMAPPEDITEM(#1000,$);\n");
+
+    let out = run_with_timeout(wrap(&lines), 5, 30);
+    // The point is that it TERMINATES within the budget rather than realising
+    // 2^24 paths. Emitting some polylines is correct; emitting 2^24 is not.
+    assert!(
+        out.polylines.len() < 300_000,
+        "an acyclic DAG must be bounded by MAX_ITEM_BUDGET, got {} polylines",
+        out.polylines.len()
+    );
+}
+
+/// A WELL-FORMED flat set larger than the revisit bound must not be truncated.
+/// `IfcGeometricSet` recurses per element, so an earlier version that charged
+/// every visit dropped 51 curves from a valid 200,050-element set with no
+/// error. Plan hatching, survey drawings and imported DWG geometry reach this
+/// size legitimately. First visits are bounded by the file, so they are free.
+#[test]
+fn a_large_flat_set_is_not_truncated() {
+    let n = 200_050usize;
+    let mut lines = String::with_capacity(n * 60);
+    let mut items = String::with_capacity(n * 8);
+    for i in 0..n {
+        let pl = 1000 + i * 3;
+        if i > 0 { items.push(','); }
+        items.push_str(&format!("#{pl}"));
+        lines.push_str(&format!("#{pl}=IFCPOLYLINE((#{},#{}));\n", pl + 1, pl + 2));
+        lines.push_str(&format!("#{}=IFCCARTESIANPOINT((0.,0.));\n", pl + 1));
+        lines.push_str(&format!("#{}=IFCCARTESIANPOINT((1.,1.));\n", pl + 2));
+    }
+    lines.push_str(&format!("#10=IFCGEOMETRICCURVESET(({items}));\n"));
+    let out = run_with_timeout(wrap(&lines), 10, 120);
+    assert_eq!(
+        out.polylines.len(), n,
+        "a well-formed flat set must emit every element; charging first visits truncates it"
+    );
+}

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -66,7 +66,10 @@ use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
 mod color;
 mod fill;
 mod grid;
+mod item_walk;
 mod items;
+#[cfg(test)]
+mod items_cycle_tests;
 mod primitives;
 mod text;
 mod transform;
@@ -78,7 +81,7 @@ pub use primitives::{
 
 use color::build_styled_item_index;
 use grid::extract_grid;
-use items::extract_symbolic_item;
+use item_walk::extract_symbolic_item;
 use transform::{compose_transforms, parse_axis2_placement_2d, resolve_object_placement, Transform2D};
 
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #2866. Second of the seven; @ifc-lite-9a has `find_color_for_geometry` in #2868 and `find_geometry_item_color` in #2864.

## Why this one first

It is the **remote** one. `extract_symbolic_item` is reached from the public `extract_symbolic_data`, which the HTTP server calls on **raw uploaded bytes** (`apps/server/src/services/streaming.rs:179`) for any file whose products carry a Plan/Annotation/FootPrint/Axis representation. And it has **three independent cycle edges**, not one:

```
IfcGeometricSet / IfcGeometricCurveSet .Elements  -> back to the set
IfcMappedItem -> IfcRepresentationMap -> IfcShapeRepresentation.Items
IfcCompositeCurve.Segments -> IfcCompositeCurveSegment.ParentCurve
```

Each aborts the process on `main` — a stack overflow is an **abort, not a catchable panic**, so there is no `catch_unwind`, no error to the caller, no partial result. A self-referential composite curve is a plausible exporter bug rather than an attack.

## Correction to an earlier version of this description

An earlier revision of this PR claimed, in the mutation table, that removing the path guard made the starvation test fail. **That was not true of the code being reviewed.** After a later change the test's fixture reached its geometry on a *first* visit, and only *revisits* are charged, so the test could not be starved and could not fail — it passed with the budget set to zero. Thanks to @ifc-lite-9a for reproducing it rather than reading the table.

The mechanism is worth stating because it is not a typo: changing **what a guard charges for** silently re-scopes every test written against the old charging. The fix was correct and the test was correct, and the pair became meaningless. No diff shows that, and no lane goes red. The corrected table is below and every row was re-run on the committed tree.

## Four bounds, because each covers something the others do not

| bound | bounds what | why the others do not cover it |
|---|---|---|
| `MAX_ITEM_DEPTH = 32` | path **length** | matches `element.rs` and `router/processing.rs`, which walk the same chain |
| path guard, on items | cycles **through items** | `IfcGeometricCurveSet.Elements` back to itself: no mapped item, no representation, so only this sees it |
| path guard, on representations | cycles **through a representation** | the mapped-item chain re-enters through something that is **not an item**, so item ids alone never see it |
| `MAX_ITEM_REVISITS = 200_000` | **breadth** | an *acyclic* DAG reaching one leaf down 2^levels paths has no cycle to catch; only a work budget stops it |

The two path rows are **one set and one seam**, not two mechanisms: express ids are unique per file, so `enter_node`/`exit_node` holds items and non-item nodes together and `items.rs` decides which ids are nodes. That keeps the policy module free of IFC types, and means the next edge that re-enters through a non-item node reuses the seam instead of hand-rolling a third guard.

**Putting the representation on the path is the substantive change in this revision.** `IfcMappedItem -> IfcRepresentationMap -> IfcShapeRepresentation.Items` re-enters the walk through the representation, and a representation is not an item. So a representation whose own items map back to it is a real cycle that presents to the guard as an innocent k-way fan-out, and the only thing that stopped it was the revisit budget — at `O(k^depth)` charges, taken from a budget the rest of the file still needs. Putting the representation on the path cuts it at the edge instead of absorbing it:

```
                                with the guard      without it
8-way self-referential map,
 k=1 top-level item, 698 B           0 ms             10 ms
 k=16,             6698 B            0 ms             43 ms
```
(release, through the public `extract_symbolic_data`)

**Both path guards are push/pop, not global** — the opposite of #2864's choice, for a reason. A colour is a pure function of (item id, style map), so an id that resolved once cannot resolve differently elsewhere and a global set is correct there. This walk **accumulates output and composes a `Transform2D` per path**, so the same curve reached through two different mapped items is two real pieces of geometry at two different positions. A global set would silently drop the second — missing geometry rather than a cycle guard. `the_same_polyline_under_two_mapped_items_is_emitted_twice` pins it.

**The budget is charged on revisits only.** An earlier version charged every visit and silently truncated a well-formed file: one flat `IfcGeometricCurveSet` of 200,050 curves emitted 199,999 and dropped 51 with no error. First visits are bounded by the file itself — an entity must exist to be reached — so they cannot be the exponential. Only revisits can.

## Every bound is pinned by mutation

Each removed independently, on a committed tree, full file re-run:

| bound removed | result |
|---|---|
| `MAX_ITEM_DEPTH` | **SIGABRT** — the #2866 abort itself, from `a_long_acyclic_chain_does_not_abort` |
| `MAX_ITEM_REVISITS` | `an_acyclic_dag_is_bounded_by_total_work_not_by_depth` **FAILS** (30s, budget gone) |
| `enter_node` on the representation | `a_cycle_must_not_starve_the_geometry_that_follows_it` **FAILS** |
| `enter_node` on the item | `a_set_cycle_must_not_starve_the_geometry_that_follows_it` **FAILS** |
| charge first visits, not only revisits | `a_large_flat_set_is_not_truncated` **FAILS** |

Each removed independently, from a file snapshot rather than `git checkout --`, with the mutation asserted to have applied before the run — a mutation that silently fails to apply reports as a surviving guard.

The last row is the one to look at. Deleting the item path guard left **all 11 existing tests green** — so the honest reading was either "it is redundant" or "it is untested", and a mutation table cannot tell those apart. It is untested: it is the only bound covering the `IfcGeometricCurveSet.Elements` route, which closes its cycle through items alone. The twelfth test now pins it and fails without it.

Both starvation tests assert on geometry reached by a **revisit**, since only revisits are charged, and each carries a control asserting the same geometry emits twice with the cycle removed — so a fixture that stops exercising the walk fails loudly instead of passing vacuously.

Tests assert the safe result rather than "does not crash": a stack overflow takes the test binary down as SIGABRT, which reads as broken infrastructure instead of a failed assertion.

## What this does NOT fix, stated plainly

Review of this branch proved two things that survive it. Both are filed; neither is fixed here, and I would rather say so on the PR than have it read as "bounded".

**The walk is bounded; the extraction is not.** `extract_symbolic_item` builds a fresh `ItemWalk` per top-level item, and `mod.rs:250` calls it once per item of every Plan/Annotation/FootPrint/Axis representation of every product, accumulating into one shared `SymbolicData`. Total work is `N x 200_000`, not `200_000`. Measured in release, one crafted acyclic DAG shared by N annotations:

```
  1 annotation   ( 4.0 KB)  ->  24.6 ms,     66,675 polylines
100 annotations  (  22 KB)  ->  1.17 s,   6,667,500 polylines,   912 MB RSS
300 annotations  (  59 KB)  ->  3.50 s,  20,002,500 polylines,  2.73 GB RSS
```

Linear, so ~1 MB of crafted upload reaches tens of GB. On `streaming.rs:179` that is an OOM kill of the server process rather than a bounded walk.

It is still a large improvement on `main`: without a breadth bound the same 24-level fan-out realises 2^24 paths per annotation instead of 66,675, and the depth cap cannot stop it because 24 < 32. But "two orders of magnitude better" is not "bounded", and I am not going to write it up as if it were. Filed as **#2937**. There is exactly one production call site, so the fix is contained -- it is not attempted here because it interacts directly with the next finding.

**`MAX_ITEM_REVISITS` still silently truncates a well-formed acyclic file.** "First visits are free" removes the truncation for the *flat set* shape this PR tests, and not for the nested-block shape: one outer mapped item whose representation holds N inserts of one shared symbol, which is the ordinary DWG block-in-block import the constant's own doc cites as legitimate.

```
outer block ->  500 inserts x 250-curve symbol:  expected 125,000, got 125,000
outer block -> 1000 inserts x 250-curve symbol:  expected 250,000, got 200,250   (20% dropped)
outer block -> 2000 inserts x 250-curve symbol:  expected 500,000, got 200,250   (60% dropped)
```

`200,250 = MAX_ITEM_REVISITS + 250 first visits`. No error, no warning, no flag on `SymbolicData`. And the same drawing with the inserts one level shallower emits all 500,000, because each insert becomes its own walk -- so whether the drawing survives depends on a nesting level the author did not choose deliberately.

These two pull in **opposite directions**: bounding the extraction makes the truncation fire sooner, and on smaller legitimate files. Trading a crafted-input OOM for silent data loss on real drawings is not an improvement, so neither belongs in a change whose job is stopping an abort. The instrument that satisfies both is an output cap plus a diagnostics channel on `SymbolicData`, and that is an API change.

Related: `router/processing.rs:338` raises `Err("MappedItem nesting exceeded maximum depth ...")` for the same traversal, while both bounds here return silently. A truncated drawing is today indistinguishable from one that legitimately had nothing to emit.

## Suite cost

`a_large_flat_set_is_not_truncated` built a **23.8 MB** STEP fixture to exceed the real 200,000 budget, and cost **4.24s of the crate's 4.79s lib suite**. It now injects a budget of 50 and uses 60 elements: same mechanism, same mutation caught (row 5 above), **0.39s** for the whole file.

## Gates

```
cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings   clean
cargo test --workspace --no-fail-fast                          1892 passed / 0 failed
```

## Deliberately not done

`MAX_ITEM_DEPTH = 32` is now the **fourth** copy of this policy (`element.rs`, `router/processing.rs`, `wasm-bindings` via #2868, here). I have named the siblings in the doc comment rather than deduplicating, because a shared home would be a cross-crate move larger than this fix warrants. With five sites left in #2866 that is heading for eight copies of one policy with no way to change it once — I think a shared bounded resolver, or at least a constant in `ifc-lite-core`, is the real fix and I will note it on #2866.
