### PR TITLE
fix(geometry): break the Boolean <-> CSG operand cycle (#2866)

### DIFF
--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -715,3 +715,36 @@ fn csg_entry_point_is_guarded_too() {
         .unwrap()
         .expect_err("a cyclic operand must be an error from this entry point too");
 }
+
+/// A long ACYCLIC `Boolean -> Csg -> Boolean` chain, every id distinct. The
+/// CSG hop passes `depth` unchanged (a CsgSolid is not a boolean nesting
+/// level), so `MAX_BOOLEAN_DEPTH` never advances and every `visited.insert`
+/// succeeds — the set never fires either. Before `MAX_OPERAND_PATH_NODES` this
+/// aborted the process on stack depth alone, with no cycle in the file
+/// (Codex, #2871/#2872 review; the same gap here).
+#[test]
+fn a_long_acyclic_boolean_csg_chain_terminates() {
+    let n: u32 = 4_000;
+    let mut data = String::new();
+    for i in 0..n {
+        let b = 1 + i * 2;
+        let c = 2 + i * 2;
+        let next_b = if i + 1 == n { 90000 } else { 1 + (i + 1) * 2 };
+        data.push_str(&format!("#{b}=IFCBOOLEANRESULT(.DIFFERENCE.,#{c},#90001);\n"));
+        data.push_str(&format!("#{c}=IFCCSGSOLID(#{next_b});\n"));
+    }
+    data.push_str("#90000=IFCBLOCK($,1.,1.,1.);\n#90001=IFCBLOCK($,1.,1.,1.);\n");
+
+    let content = wrap_ifc(&data);
+    let mut decoder = EntityDecoder::new(&content);
+    let entity = decoder.decode_by_id(1).expect("decode #1");
+    let processor = BooleanClippingProcessor::new();
+    let schema = IfcSchema::new();
+    let err = processor
+        .process(&entity, &mut decoder, &schema, Default::default())
+        .expect_err("an over-long operand chain must be reported, not rendered half-built");
+    assert!(
+        err.to_string().contains("operand chain exceeds"),
+        "expected the chain bound to be named, got: {err}"
+    );
+}

--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -735,16 +735,29 @@ fn a_long_acyclic_boolean_csg_chain_terminates() {
     }
     data.push_str("#90000=IFCBLOCK($,1.,1.,1.);\n#90001=IFCBLOCK($,1.,1.,1.);\n");
 
+    // On a worker thread like its siblings: if the bound regresses, this
+    // overflows the stack, and a stack overflow ABORTS the whole test binary --
+    // taking ~690 unrelated tests with it and burying whichever test reported
+    // the regression cleanly. Cargo still exits non-zero, so it is not a false
+    // green, but the diagnostic is unreadable.
     let content = wrap_ifc(&data);
-    let mut decoder = EntityDecoder::new(&content);
-    let entity = decoder.decode_by_id(1).expect("decode #1");
-    let processor = BooleanClippingProcessor::new();
-    let schema = IfcSchema::new();
-    let err = processor
-        .process(&entity, &mut decoder, &schema, Default::default())
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let mut decoder = EntityDecoder::new(&content);
+        let entity = decoder.decode_by_id(1).expect("decode #1");
+        let processor = BooleanClippingProcessor::new();
+        let schema = IfcSchema::new();
+        let result = processor.process(&entity, &mut decoder, &schema, Default::default());
+        let _ = tx.send(result.map(|m| m.positions.len()).map_err(|e| e.to_string()));
+    });
+    let outcome = rx.recv_timeout(std::time::Duration::from_secs(20));
+    assert!(outcome.is_ok(), "the operand chain bound did not terminate");
+    let _ = handle.join();
+    let err = outcome
+        .unwrap()
         .expect_err("an over-long operand chain must be reported, not rendered half-built");
     assert!(
-        err.to_string().contains("operand chain exceeds"),
+        err.contains("operand chain exceeds"),
         "expected the chain bound to be named, got: {err}"
     );
 }
@@ -812,4 +825,45 @@ fn the_path_bound_counts_csg_frames_too_not_only_booleans() {
         err.to_string().contains("operand chain exceeds"),
         "the path bound must be what stops it, got: {err}"
     );
+}
+
+/// Pins the path-scoped `remove` on BOTH sides. Deleting either one leaves the
+/// set accumulate-only, which turns a legitimately SHARED operand into a
+/// reported cycle: `#10` below is reached from two different branches of an
+/// acyclic tree, not twice down one path.
+///
+/// Without the removes this returns `Err("Cyclic boolean/CSG operand
+/// reference at #10")` and the router drops the whole element. Every other
+/// test in this file stayed green with them deleted -- the same
+/// unpinned-not-redundant trap this file already records for the CSG insert,
+/// one step over.
+#[test]
+fn an_operand_shared_between_two_branches_is_not_a_cycle() {
+    for (label, shared) in [
+        ("boolean", "#10=IFCBOOLEANRESULT(.UNION.,#900,#901);\n"),
+        ("csg", "#10=IFCCSGSOLID(#11);\n#11=IFCBOOLEANRESULT(.UNION.,#900,#901);\n"),
+    ] {
+        let data = format!(
+            "#1=IFCBOOLEANRESULT(.UNION.,#2,#3);\n\
+             #2=IFCBOOLEANRESULT(.UNION.,#900,#10);\n\
+             #3=IFCBOOLEANRESULT(.UNION.,#900,#10);\n\
+             {shared}\
+             #900=IFCBLOCK($,1.,1.,1.);\n\
+             #901=IFCBLOCK($,1.,1.,1.);\n"
+        );
+        let content = wrap_ifc(&data);
+        let mut decoder = EntityDecoder::new(&content);
+        let entity = decoder.decode_by_id(1).expect("decode #1");
+        let processor = BooleanClippingProcessor::new();
+        let schema = IfcSchema::new();
+        let mesh = processor
+            .process(&entity, &mut decoder, &schema, Default::default())
+            .unwrap_or_else(|e| {
+                panic!("{label}: an operand shared across two BRANCHES is not a cycle: {e}")
+            });
+        assert!(
+            !mesh.positions.is_empty(),
+            "{label}: the shared operand must contribute geometry"
+        );
+    }
 }

--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -748,3 +748,68 @@ fn a_long_acyclic_boolean_csg_chain_terminates() {
         "expected the chain bound to be named, got: {err}"
     );
 }
+
+/// `IfcCsgSolid.TreeRootExpression` may not be another `IfcCsgSolid` (IFC 4.3
+/// `IfcCsgSelect`), and `CsgSolidProcessor` rejects it. Nothing asserted that
+/// anywhere, which mattered while the path bound counted boolean ids only and
+/// leaned on this rejection to keep the frame count bounded. The bound now
+/// counts CSG ids too, so this is a plain spec check again — but a "be lenient
+/// about nested CsgSolid" change is a plausible bad-exporter fix, and it should
+/// fail here rather than in whatever it silently un-bounds.
+#[test]
+fn a_csg_solid_rooted_in_another_csg_solid_is_rejected() {
+    let content = wrap_ifc(
+        "#10=IFCCSGSOLID(#20);\n\
+         #20=IFCCSGSOLID(#30);\n\
+         #30=IFCBLOCK($,1.,1.,1.);\n",
+    );
+    let mut decoder = EntityDecoder::new(&content);
+    let entity = decoder.decode_by_id(10).expect("decode #10");
+    let processor = crate::processors::CsgSolidProcessor::new();
+    let schema = IfcSchema::new();
+    let err = processor
+        .process(&entity, &mut decoder, &schema, Default::default())
+        .expect_err("IfcCsgSolid -> IfcCsgSolid is a spec violation and must be refused");
+    assert!(
+        err.to_string().contains("not another IfcCsgSolid"),
+        "the rejection must name what it rejected, got: {err}"
+    );
+}
+
+/// Pins that the path bound counts EVERY frame, not just the boolean ones.
+///
+/// An alternating `Boolean -> Csg -> Boolean` chain puts two entities on the
+/// stack per level. Counting booleans only, 50 levels reads as 50 against a
+/// bound of 64 and is accepted while actually standing 100 frames deep — the
+/// bound silently means twice its own number. Counting both, the same chain
+/// crosses 64 and is refused.
+///
+/// This is the assertion that was missing when an earlier revision dropped the
+/// CSG-side insert: at the time, removing it changed no test, which read as
+/// "redundant" and was really "unpinned".
+#[test]
+fn the_path_bound_counts_csg_frames_too_not_only_booleans() {
+    let n: u32 = 50;
+    let mut data = String::new();
+    for i in 0..n {
+        let b = 1 + i * 2;
+        let c = 2 + i * 2;
+        let next_b = if i + 1 == n { 90000 } else { 1 + (i + 1) * 2 };
+        data.push_str(&format!("#{b}=IFCBOOLEANRESULT(.DIFFERENCE.,#{c},#90001);\n"));
+        data.push_str(&format!("#{c}=IFCCSGSOLID(#{next_b});\n"));
+    }
+    data.push_str("#90000=IFCBLOCK($,1.,1.,1.);\n#90001=IFCBLOCK($,1.,1.,1.);\n");
+
+    let content = wrap_ifc(&data);
+    let mut decoder = EntityDecoder::new(&content);
+    let entity = decoder.decode_by_id(1).expect("decode #1");
+    let processor = BooleanClippingProcessor::new();
+    let schema = IfcSchema::new();
+    let err = processor
+        .process(&entity, &mut decoder, &schema, Default::default())
+        .expect_err("100 stack frames must cross a 64-frame bound");
+    assert!(
+        err.to_string().contains("operand chain exceeds"),
+        "the path bound must be what stops it, got: {err}"
+    );
+}

--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -632,3 +632,86 @@ fn full_process_terminates_on_cyclic_boolean() {
     assert!(outcome.is_ok(), "full process() hung on a cyclic boolean chain");
     let _ = handle.join();
 }
+
+/// `IfcCsgSolid.TreeRootExpression` may be an `IfcBooleanResult`, whose
+/// operands may in turn be `IfcCsgSolid` — so the two are mutually recursive
+/// over file-supplied references. `CsgSolidProcessor::process` built a FRESH
+/// `BooleanClippingProcessor`, resetting both `depth` and the cycle guard, so
+/// three entities recursed forever with depth never passing 1 (#2866).
+///
+/// `csg_primitive.rs` already rejected `IfcCsgSolid -> IfcCsgSolid` explicitly,
+/// "so a malformed (or adversarial) file with a self-reference can't blow the
+/// stack". That guard is one hop wide. This is the two-hop cycle it cannot see.
+const CSG_BOOLEAN_CYCLE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#10=IFCBOOLEANRESULT(.DIFFERENCE.,#20,#30);
+#20=IFCCSGSOLID(#10);
+#30=IFCBLOCK($,1.,1.,1.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+#[test]
+fn boolean_csg_mutual_recursion_terminates() {
+    // Worker thread + timeout, matching the test above: a regression that
+    // loops without growing the stack shows up as a timeout rather than
+    // hanging the suite. (A regression that DOES grow the stack aborts the
+    // whole binary — no harness can catch that one, so it is named here
+    // rather than implied.)
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let content = CSG_BOOLEAN_CYCLE.to_string();
+        let mut decoder = EntityDecoder::new(&content);
+        let entity = decoder.decode_by_id(10).expect("decode #10");
+        let processor = BooleanClippingProcessor::new();
+        let schema = IfcSchema::new();
+        let result = processor.process(&entity, &mut decoder, &schema, Default::default());
+        let _ = tx.send(result.map(|m| m.positions.len()));
+    });
+
+    let outcome = rx.recv_timeout(std::time::Duration::from_secs(10));
+    assert!(
+        outcome.is_ok(),
+        "Boolean/CSG mutual recursion did not terminate"
+    );
+    let _ = handle.join();
+
+    // The cycle is reported, not silently swallowed: an operand that cannot be
+    // resolved must surface as an error so the router drops the element rather
+    // than rendering a half-built solid as if it were complete.
+    let err = outcome.unwrap().expect_err("a cyclic operand must be an error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Cyclic boolean/CSG operand reference"),
+        "expected the cycle to be named, got: {msg}"
+    );
+}
+
+/// Entering through `CsgSolidProcessor` rather than the boolean side must be
+/// guarded too — the router registers it directly, so that is the path a real
+/// file takes when the element's Body item IS the `IfcCsgSolid`.
+#[test]
+fn csg_entry_point_is_guarded_too() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = std::thread::spawn(move || {
+        let content = CSG_BOOLEAN_CYCLE.to_string();
+        let mut decoder = EntityDecoder::new(&content);
+        let entity = decoder.decode_by_id(20).expect("decode #20");
+        let processor = crate::processors::CsgSolidProcessor::new();
+        let schema = IfcSchema::new();
+        let result = processor.process(&entity, &mut decoder, &schema, Default::default());
+        let _ = tx.send(result.map(|m| m.positions.len()));
+    });
+
+    let outcome = rx.recv_timeout(std::time::Duration::from_secs(10));
+    assert!(outcome.is_ok(), "CsgSolid entry point did not terminate");
+    let _ = handle.join();
+    outcome
+        .unwrap()
+        .expect_err("a cyclic operand must be an error from this entry point too");
+}

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -41,17 +41,19 @@ const MAX_BOOLEAN_DEPTH: u32 = 10;
 /// Longest chain of nested boolean/CSG operand nodes on one path. Bounds the
 /// stack where `MAX_BOOLEAN_DEPTH` cannot: see `process_with_depth`.
 ///
-/// Counted from the visited set, which holds BOOLEAN ids only -- CSG nodes are
-/// not inserted. That still bounds the true frame count, but only because
-/// `CsgSolidProcessor` rejects `IfcCsgSolid -> IfcCsgSolid` outright as a spec
-/// violation: no path can chain CSG nodes, so every one is followed by a
-/// boolean or terminates at a primitive, and `#CSG <= #Boolean + 1`. The real
-/// cap is therefore ~2x this number of frames.
-///
-/// That is a load-bearing dependency on a guard in another file, written down
-/// here because nothing else links them. If that rejection is ever relaxed,
-/// this bound has to start counting CSG ids too (CodeRabbit, #2870 review).
+/// Both boolean AND CSG nodes go into the set, so `len()` is an honest count of
+/// recursion frames on the current path and this number means what it says. An
+/// earlier revision counted booleans only and leaned on `IfcCsgSolid ->
+/// IfcCsgSolid` being rejected elsewhere to keep the ratio bounded; see
+/// `CsgSolidProcessor::process_with_boolean_cycle_guard` for why that was the
+/// wrong trade.
 const MAX_OPERAND_PATH_NODES: usize = 64;
+
+/// Entity ids on the CURRENT operand path — inserted on the way in, removed on
+/// the way out, so `len()` is live recursion depth. The two accumulate-only
+/// sets in this file (`collect_polygonal_chain`'s, and the spine walk's
+/// `spine_seen`) are NOT frame counts and must not be compared to the bound.
+pub(crate) type OperandPath = rustc_hash::FxHashSet<u32>;
 
 /// BooleanResult processor
 /// Handles IfcBooleanResult and IfcBooleanClippingResult - CSG operations
@@ -155,7 +157,7 @@ impl BooleanClippingProcessor {
         decoder: &mut EntityDecoder,
         depth: u32,
         quality: TessellationQuality,
-        visited: &mut std::collections::HashSet<u32>,
+        visited: &mut OperandPath,
     ) -> Result<Mesh> {
         match operand.ifc_type {
             IfcType::IfcExtrudedAreaSolid => {
@@ -410,7 +412,7 @@ impl BooleanClippingProcessor {
         decoder: &mut EntityDecoder,
         depth: u32,
         quality: TessellationQuality,
-        visited: &mut std::collections::HashSet<u32>,
+        visited: &mut OperandPath,
     ) -> Result<Option<Mesh>> {
         let (base_entity, cutters) = self.collect_polygonal_chain(entity.clone(), decoder)?;
         if cutters.len() < 2 {
@@ -620,7 +622,7 @@ impl BooleanClippingProcessor {
         schema: &IfcSchema,
         depth: u32,
         quality: TessellationQuality,
-        visited: &mut std::collections::HashSet<u32>,
+        visited: &mut OperandPath,
     ) -> Result<Mesh> {
         // PATH-scoped, not global: a boolean tree is a DAG and geometry
         // ACCUMULATES, so one operand legitimately referenced down two
@@ -666,7 +668,7 @@ impl BooleanClippingProcessor {
         _schema: &IfcSchema,
         depth: u32,
         quality: TessellationQuality,
-        visited: &mut std::collections::HashSet<u32>,
+        visited: &mut OperandPath,
     ) -> Result<Mesh> {
         // Depth limit to prevent stack overflow from nested boolean operands
         if depth > MAX_BOOLEAN_DEPTH {
@@ -776,7 +778,7 @@ impl BooleanClippingProcessor {
         decoder: &mut EntityDecoder,
         depth: u32,
         quality: TessellationQuality,
-        visited: &mut std::collections::HashSet<u32>,
+        visited: &mut OperandPath,
     ) -> Result<Mesh> {
         let operator = Self::boolean_operator(entity);
 
@@ -974,7 +976,7 @@ impl GeometryProcessor for BooleanClippingProcessor {
         schema: &IfcSchema,
         quality: TessellationQuality,
     ) -> Result<Mesh> {
-        let mut visited = std::collections::HashSet::new();
+        let mut visited = OperandPath::default();
         self.process_with_depth(entity, decoder, schema, 0, quality, &mut visited)
     }
 

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -40,6 +40,17 @@ const MAX_BOOLEAN_DEPTH: u32 = 10;
 
 /// Longest chain of nested boolean/CSG operand nodes on one path. Bounds the
 /// stack where `MAX_BOOLEAN_DEPTH` cannot: see `process_with_depth`.
+///
+/// Counted from the visited set, which holds BOOLEAN ids only -- CSG nodes are
+/// not inserted. That still bounds the true frame count, but only because
+/// `CsgSolidProcessor` rejects `IfcCsgSolid -> IfcCsgSolid` outright as a spec
+/// violation: no path can chain CSG nodes, so every one is followed by a
+/// boolean or terminates at a primitive, and `#CSG <= #Boolean + 1`. The real
+/// cap is therefore ~2x this number of frames.
+///
+/// That is a load-bearing dependency on a guard in another file, written down
+/// here because nothing else links them. If that rejection is ever relaxed,
+/// this bound has to start counting CSG ids too (CodeRabbit, #2870 review).
 const MAX_OPERAND_PATH_NODES: usize = 64;
 
 /// BooleanResult processor

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -38,6 +38,10 @@ use halfspace_cap::force_cdt_fail_on_ring_for_test;
 /// significant stack space for CSG operations.
 const MAX_BOOLEAN_DEPTH: u32 = 10;
 
+/// Longest chain of nested boolean/CSG operand nodes on one path. Bounds the
+/// stack where `MAX_BOOLEAN_DEPTH` cannot: see `process_with_depth`.
+const MAX_OPERAND_PATH_NODES: usize = 64;
+
 /// BooleanResult processor
 /// Handles IfcBooleanResult and IfcBooleanClippingResult - CSG operations
 ///
@@ -614,6 +618,25 @@ impl BooleanClippingProcessor {
         // choice `router/processing.rs` makes, and the opposite of the colour
         // resolvers, where the result is a pure function of the id so a global
         // set is both safe and stronger (#2864).
+        // The set is path-scoped, so its LENGTH is the current operand-nesting
+        // depth -- a chain bound for free, and one that covers the CSG hop.
+        // It is needed because that hop passes `depth` UNCHANGED (a CsgSolid
+        // is not itself a boolean nesting level), so a long ACYCLIC
+        // `Boolean -> Csg -> Boolean` chain never advances MAX_BOOLEAN_DEPTH,
+        // every `visited.insert` succeeds, and the recursion aborts on stack
+        // depth alone. Measured: 4,000 links, SIGABRT (Codex, #2871/#2872
+        // review; the same gap in this file).
+        //
+        // 64 sits well clear of MAX_BOOLEAN_DEPTH (10) so it cannot make that
+        // cap's job harder, and clear of the 42-node Revit chains from #960,
+        // which are FirstOperand SPINE nodes walked iteratively and never
+        // reach here.
+        if visited.len() >= MAX_OPERAND_PATH_NODES {
+            return Err(Error::geometry(format!(
+                "Boolean/CSG operand chain exceeds {MAX_OPERAND_PATH_NODES} nested nodes at #{}",
+                entity.id
+            )));
+        }
         if !visited.insert(entity.id) {
             return Err(Error::geometry(format!(
                 "Cyclic boolean/CSG operand reference at #{}",

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -188,6 +188,13 @@ impl BooleanClippingProcessor {
             // both `depth` and the cycle guard. `#10 IfcBooleanResult -> FirstOperand
             // #20 IfcCsgSolid -> TreeRootExpression #10` then recursed forever with
             // depth never passing 1, and a Rust stack overflow ABORTS (#2866).
+            // `depth` restarts at 0 here, as it did before this guard existed
+            // (the hop built a fresh processor). Carrying it would tighten
+            // MAX_BOOLEAN_DEPTH, which #960 calibrated against a per-processor
+            // reset: 8 booleans + a CsgSolid + 8 more is valid, resolves on
+            // main, and would error as "depth 11 exceeds limit 10", dropping
+            // the element. MAX_OPERAND_PATH_NODES bounds the stack across the
+            // hop instead, counting frames of both kinds.
             IfcType::IfcCsgSolid => CsgSolidProcessor::with_skip_small_cuts(
                 self.skip_small_cuts,
             )
@@ -195,7 +202,7 @@ impl BooleanClippingProcessor {
                 operand,
                 decoder,
                 &self.schema,
-                depth,
+                0,
                 quality,
                 visited,
             ),

--- a/rust/geometry/src/processors/boolean/mod.rs
+++ b/rust/geometry/src/processors/boolean/mod.rs
@@ -140,6 +140,7 @@ impl BooleanClippingProcessor {
         decoder: &mut EntityDecoder,
         depth: u32,
         quality: TessellationQuality,
+        visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Mesh> {
         match operand.ifc_type {
             IfcType::IfcExtrudedAreaSolid => {
@@ -165,11 +166,25 @@ impl BooleanClippingProcessor {
             IfcType::IfcBlock => {
                 BlockProcessor::new().process(operand, decoder, &self.schema, quality)
             }
-            IfcType::IfcCsgSolid => CsgSolidProcessor::with_skip_small_cuts(self.skip_small_cuts)
-                .process(operand, decoder, &self.schema, quality),
+            // `CsgSolidProcessor::process` builds a FRESH BooleanClippingProcessor
+            // for a boolean TreeRootExpression, so routing through it used to reset
+            // both `depth` and the cycle guard. `#10 IfcBooleanResult -> FirstOperand
+            // #20 IfcCsgSolid -> TreeRootExpression #10` then recursed forever with
+            // depth never passing 1, and a Rust stack overflow ABORTS (#2866).
+            IfcType::IfcCsgSolid => CsgSolidProcessor::with_skip_small_cuts(
+                self.skip_small_cuts,
+            )
+            .process_with_boolean_cycle_guard(
+                operand,
+                decoder,
+                &self.schema,
+                depth,
+                quality,
+                visited,
+            ),
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
                 // Recursive case with depth tracking
-                self.process_with_depth(operand, decoder, &self.schema, depth + 1, quality)
+                self.process_with_depth(operand, decoder, &self.schema, depth + 1, quality, visited)
             }
             _ => Ok(Mesh::new()),
         }
@@ -380,6 +395,7 @@ impl BooleanClippingProcessor {
         decoder: &mut EntityDecoder,
         depth: u32,
         quality: TessellationQuality,
+        visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Option<Mesh>> {
         let (base_entity, cutters) = self.collect_polygonal_chain(entity.clone(), decoder)?;
         if cutters.len() < 2 {
@@ -390,7 +406,8 @@ impl BooleanClippingProcessor {
         // walked iteratively above, so a 12-cutter chain reaches here at the
         // SAME `depth` as a 2-cutter one — the recursion-depth limit can't drop
         // it.
-        let base_mesh = self.process_operand_with_depth(&base_entity, decoder, depth, quality)?;
+        let base_mesh =
+            self.process_operand_with_depth(&base_entity, decoder, depth, quality, visited)?;
         if base_mesh.is_empty() {
             return Ok(Some(base_mesh));
         }
@@ -581,13 +598,41 @@ impl BooleanClippingProcessor {
     /// Revit exports building-element-part chains up to 42 DIFFERENCE nodes
     /// deep; the recursive walk hit the cap at 10, errored, and the router
     /// dropped the whole element's geometry.
-    fn process_with_depth(
+    pub(crate) fn process_with_depth(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        schema: &IfcSchema,
+        depth: u32,
+        quality: TessellationQuality,
+        visited: &mut std::collections::HashSet<u32>,
+    ) -> Result<Mesh> {
+        // PATH-scoped, not global: a boolean tree is a DAG and geometry
+        // ACCUMULATES, so one operand legitimately referenced down two
+        // different branches must be processed both times. Removing the id on
+        // the way out breaks cycles without dropping real geometry — the same
+        // choice `router/processing.rs` makes, and the opposite of the colour
+        // resolvers, where the result is a pure function of the id so a global
+        // set is both safe and stronger (#2864).
+        if !visited.insert(entity.id) {
+            return Err(Error::geometry(format!(
+                "Cyclic boolean/CSG operand reference at #{}",
+                entity.id
+            )));
+        }
+        let out = self.process_with_depth_inner(entity, decoder, schema, depth, quality, visited);
+        visited.remove(&entity.id);
+        out
+    }
+
+    fn process_with_depth_inner(
         &self,
         entity: &DecodedEntity,
         decoder: &mut EntityDecoder,
         _schema: &IfcSchema,
         depth: u32,
         quality: TessellationQuality,
+        visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Mesh> {
         // Depth limit to prevent stack overflow from nested boolean operands
         if depth > MAX_BOOLEAN_DEPTH {
@@ -605,10 +650,10 @@ impl BooleanClippingProcessor {
         // Walk down the left spine, collecting nodes whose second operands
         // are applied innermost-first once the base mesh exists.
         let mut spine: Vec<DecodedEntity> = Vec::new();
-        let mut visited: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        let mut spine_seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
         let mut current = entity.clone();
         let mut mesh = loop {
-            if !visited.insert(current.id) {
+            if !spine_seen.insert(current.id) {
                 // Cyclic FirstOperand chain (malformed input). The recursive
                 // walk bottomed out on the depth cap; fail the same way with
                 // a reason that names the actual problem.
@@ -622,12 +667,12 @@ impl BooleanClippingProcessor {
                 IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult
             ) {
                 // Bottom of the spine: the base solid.
-                break self.process_operand_with_depth(&current, decoder, depth, quality)?;
+                break self.process_operand_with_depth(&current, decoder, depth, quality, visited)?;
             }
             let operator = Self::boolean_operator(&current);
             if operator == ".DIFFERENCE." || operator == "DIFFERENCE" {
                 if let Some(result) =
-                    self.try_union_polygonal_chain(&current, decoder, depth, quality)?
+                    self.try_union_polygonal_chain(&current, decoder, depth, quality, visited)?
                 {
                     // Batched PBHS resolution handled this node and everything
                     // below it (see the comment on the sequential step).
@@ -652,7 +697,7 @@ impl BooleanClippingProcessor {
                 // per-level early-out (for every operator, UNION included).
                 return Ok(mesh);
             }
-            mesh = self.apply_boolean_step(node, mesh, decoder, depth, quality)?;
+            mesh = self.apply_boolean_step(node, mesh, decoder, depth, quality, visited)?;
         }
         Ok(mesh)
     }
@@ -697,6 +742,7 @@ impl BooleanClippingProcessor {
         decoder: &mut EntityDecoder,
         depth: u32,
         quality: TessellationQuality,
+        visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Mesh> {
         let operator = Self::boolean_operator(entity);
 
@@ -821,7 +867,7 @@ impl BooleanClippingProcessor {
             // bath, any `IfcCsgSolid` with a solid cutter) silently rendered
             // as the uncut host even when the operands were trivially small.
             let second_mesh =
-                self.process_operand_with_depth(&second_operand, decoder, depth, quality)?;
+                self.process_operand_with_depth(&second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
                 self.record_failure(BoolOp::Difference, BoolFailureReason::EmptyOperand);
                 return Ok(mesh);
@@ -852,7 +898,7 @@ impl BooleanClippingProcessor {
         // Handle UNION operation — a real CSG union (overlap removed) on the
         // pure-Rust exact kernel.
         if operator == ".UNION." || operator == "UNION" {
-            let second_mesh = self.process_operand_with_depth(&second_operand, decoder, depth, quality)?;
+            let second_mesh = self.process_operand_with_depth(&second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
                 self.record_failure(BoolOp::Union, BoolFailureReason::EmptyOperand);
                 return Ok(mesh);
@@ -867,7 +913,7 @@ impl BooleanClippingProcessor {
         // pure-Rust exact kernel.
         if operator == ".INTERSECTION." || operator == "INTERSECTION" {
             let second_mesh =
-                self.process_operand_with_depth(&second_operand, decoder, depth, quality)?;
+                self.process_operand_with_depth(&second_operand, decoder, depth, quality, visited)?;
             if second_mesh.is_empty() {
                 self.record_failure(BoolOp::Intersection, BoolFailureReason::EmptyOperand);
                 return Ok(Mesh::new());
@@ -894,7 +940,8 @@ impl GeometryProcessor for BooleanClippingProcessor {
         schema: &IfcSchema,
         quality: TessellationQuality,
     ) -> Result<Mesh> {
-        self.process_with_depth(entity, decoder, schema, 0, quality)
+        let mut visited = std::collections::HashSet::new();
+        self.process_with_depth(entity, decoder, schema, 0, quality, &mut visited)
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/csg_primitive.rs
+++ b/rust/geometry/src/processors/csg_primitive.rs
@@ -10,6 +10,7 @@
 //! (`IfcRectangularPyramid`, `IfcRightCircularCone`, `IfcRightCircularCylinder`)
 //! are not yet implemented.
 
+use super::boolean::OperandPath;
 use crate::extrusion::apply_transform;
 use crate::{scale_segments, Error, Mesh, Result, TessellationQuality, Vector3};
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcSchema, IfcType};
@@ -132,11 +133,13 @@ impl CsgSolidProcessor {
     /// forever with depth never passing 1 — and a stack overflow ABORTS in
     /// Rust, so nothing could turn it into a load error (#2866).
     ///
-    /// This does not insert `entity.id` itself: every cycle must pass through
-    /// an `IfcBooleanResult` (`IfcCsgSolid -> IfcCsgSolid` is rejected below),
-    /// so the insert in `process_with_depth` breaks all of them. A second one
-    /// here was written first and removed once mutation testing showed that
-    /// with both present, deleting EITHER left every test green.
+    /// The CSG id is inserted too, path-scoped like the boolean side, so
+    /// `visited.len()` is an honest frame count. An earlier revision omitted
+    /// it because deleting either insert left every test green — which meant
+    /// neither was PINNED, not that one was redundant
+    /// (`the_path_bound_counts_csg_frames_too_not_only_booleans` now pins it).
+    /// Omitting it also made the `IfcCsgSolid -> IfcCsgSolid` rejection below
+    /// load-bearing for stack safety instead of a spec check.
     pub(crate) fn process_with_boolean_cycle_guard(
         &self,
         entity: &DecodedEntity,
@@ -144,9 +147,17 @@ impl CsgSolidProcessor {
         schema: &IfcSchema,
         depth: u32,
         quality: TessellationQuality,
-        visited: &mut std::collections::HashSet<u32>,
+        visited: &mut OperandPath,
     ) -> Result<Mesh> {
-        self.resolve_tree_root(entity, decoder, schema, depth, quality, visited)
+        if !visited.insert(entity.id) {
+            return Err(Error::geometry(format!(
+                "Cyclic boolean/CSG operand reference at #{}",
+                entity.id
+            )));
+        }
+        let out = self.resolve_tree_root(entity, decoder, schema, depth, quality, visited);
+        visited.remove(&entity.id);
+        out
     }
 
     /// Shared body of `process` and `process_with_boolean_cycle_guard`.
@@ -157,7 +168,7 @@ impl CsgSolidProcessor {
         schema: &IfcSchema,
         depth: u32,
         quality: TessellationQuality,
-        visited: &mut std::collections::HashSet<u32>,
+        visited: &mut OperandPath,
     ) -> Result<Mesh> {
         let root_attr = entity.get(0).ok_or_else(|| {
             Error::geometry("IfcCsgSolid missing TreeRootExpression".to_string())
@@ -203,7 +214,7 @@ impl GeometryProcessor for CsgSolidProcessor {
     ) -> Result<Mesh> {
         // Top-level entry (the router registers this processor directly, so
         // this is the path a file whose Body item IS the IfcCsgSolid takes).
-        let mut visited = std::collections::HashSet::new();
+        let mut visited = OperandPath::default();
         self.resolve_tree_root(entity, decoder, schema, 0, quality, &mut visited)
     }
 
@@ -407,43 +418,5 @@ fn build_axis_aligned_box(x: f64, y: f64, z: f64) -> Mesh {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn axis_aligned_box_is_closed_and_has_outward_normals() {
-        let mesh = build_axis_aligned_box(2.0, 3.0, 4.0);
-        assert_eq!(mesh.positions.len() / 3, 24);
-        assert_eq!(mesh.indices.len() / 3, 12);
-
-        let mut min = [f32::INFINITY; 3];
-        let mut max = [f32::NEG_INFINITY; 3];
-        for chunk in mesh.positions.chunks_exact(3) {
-            for i in 0..3 {
-                min[i] = min[i].min(chunk[i]);
-                max[i] = max[i].max(chunk[i]);
-            }
-        }
-        assert_eq!(min, [0.0, 0.0, 0.0]);
-        assert_eq!(max, [2.0, 3.0, 4.0]);
-
-        // Each face's normal should match its outward axis.
-        let mut faces_seen = [false; 6];
-        for chunk in mesh.normals.chunks_exact(12) {
-            let nx = chunk[0];
-            let ny = chunk[1];
-            let nz = chunk[2];
-            let label = match (nx, ny, nz) {
-                (x, _, _) if x > 0.5 => 0,
-                (x, _, _) if x < -0.5 => 1,
-                (_, y, _) if y > 0.5 => 2,
-                (_, y, _) if y < -0.5 => 3,
-                (_, _, z) if z > 0.5 => 4,
-                (_, _, z) if z < -0.5 => 5,
-                _ => panic!("non-axial normal"),
-            };
-            faces_seen[label] = true;
-        }
-        assert!(faces_seen.iter().all(|&seen| seen), "missing a face");
-    }
-}
+#[path = "csg_primitive_tests.rs"]
+mod tests;

--- a/rust/geometry/src/processors/csg_primitive.rs
+++ b/rust/geometry/src/processors/csg_primitive.rs
@@ -121,13 +121,43 @@ impl Default for CsgSolidProcessor {
     }
 }
 
-impl GeometryProcessor for CsgSolidProcessor {
-    fn process(
+impl CsgSolidProcessor {
+    /// Like [`GeometryProcessor::process`], but carrying the caller's boolean
+    /// recursion depth and path-scoped visited set across the hop.
+    ///
+    /// `IfcCsgSolid.TreeRootExpression` may be an `IfcBooleanResult` whose
+    /// operands may be `IfcCsgSolid`, so the two are mutually recursive over
+    /// file-supplied references. Entering through `process()` built a FRESH
+    /// `BooleanClippingProcessor`, resetting both, so three entities recursed
+    /// forever with depth never passing 1 — and a stack overflow ABORTS in
+    /// Rust, so nothing could turn it into a load error (#2866).
+    ///
+    /// This does not insert `entity.id` itself: every cycle must pass through
+    /// an `IfcBooleanResult` (`IfcCsgSolid -> IfcCsgSolid` is rejected below),
+    /// so the insert in `process_with_depth` breaks all of them. A second one
+    /// here was written first and removed once mutation testing showed that
+    /// with both present, deleting EITHER left every test green.
+    pub(crate) fn process_with_boolean_cycle_guard(
         &self,
         entity: &DecodedEntity,
         decoder: &mut EntityDecoder,
         schema: &IfcSchema,
+        depth: u32,
         quality: TessellationQuality,
+        visited: &mut std::collections::HashSet<u32>,
+    ) -> Result<Mesh> {
+        self.resolve_tree_root(entity, decoder, schema, depth, quality, visited)
+    }
+
+    /// Shared body of `process` and `process_with_boolean_cycle_guard`.
+    fn resolve_tree_root(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        schema: &IfcSchema,
+        depth: u32,
+        quality: TessellationQuality,
+        visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Mesh> {
         let root_attr = entity.get(0).ok_or_else(|| {
             Error::geometry("IfcCsgSolid missing TreeRootExpression".to_string())
@@ -140,11 +170,13 @@ impl GeometryProcessor for CsgSolidProcessor {
         // an `IfcBooleanResult` or an `IfcCsgPrimitive3D`, NEVER another
         // `IfcCsgSolid`. Reject that case explicitly so a malformed (or
         // adversarial) file with a self-reference can't blow the stack on
-        // unbounded recursion.
+        // unbounded recursion. That guard is one hop wide; the visited set
+        // threaded through the boolean side closes the two-hop
+        // CSG -> Boolean -> CSG cycle it cannot see (#2866).
         match root.ifc_type {
             IfcType::IfcBooleanResult | IfcType::IfcBooleanClippingResult => {
                 BooleanClippingProcessor::with_skip_small_cuts(self.skip_small_cuts)
-                    .process(&root, decoder, schema, quality)
+                    .process_with_depth(&root, decoder, schema, depth, quality, visited)
             }
             IfcType::IfcBlock => BlockProcessor::new().process(&root, decoder, schema, quality),
             IfcType::IfcSphere => SphereProcessor::new().process(&root, decoder, schema, quality),
@@ -158,6 +190,21 @@ impl GeometryProcessor for CsgSolidProcessor {
                 other
             ))),
         }
+    }
+}
+
+impl GeometryProcessor for CsgSolidProcessor {
+    fn process(
+        &self,
+        entity: &DecodedEntity,
+        decoder: &mut EntityDecoder,
+        schema: &IfcSchema,
+        quality: TessellationQuality,
+    ) -> Result<Mesh> {
+        // Top-level entry (the router registers this processor directly, so
+        // this is the path a file whose Body item IS the IfcCsgSolid takes).
+        let mut visited = std::collections::HashSet::new();
+        self.resolve_tree_root(entity, decoder, schema, 0, quality, &mut visited)
     }
 
     fn supported_types(&self) -> Vec<IfcType> {

--- a/rust/geometry/src/processors/csg_primitive_tests.rs
+++ b/rust/geometry/src/processors/csg_primitive_tests.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::*;
+
+#[test]
+fn axis_aligned_box_is_closed_and_has_outward_normals() {
+    let mesh = build_axis_aligned_box(2.0, 3.0, 4.0);
+    assert_eq!(mesh.positions.len() / 3, 24);
+    assert_eq!(mesh.indices.len() / 3, 12);
+
+    let mut min = [f32::INFINITY; 3];
+    let mut max = [f32::NEG_INFINITY; 3];
+    for chunk in mesh.positions.chunks_exact(3) {
+        for i in 0..3 {
+            min[i] = min[i].min(chunk[i]);
+            max[i] = max[i].max(chunk[i]);
+        }
+    }
+    assert_eq!(min, [0.0, 0.0, 0.0]);
+    assert_eq!(max, [2.0, 3.0, 4.0]);
+
+    // Each face's normal should match its outward axis.
+    let mut faces_seen = [false; 6];
+    for chunk in mesh.normals.chunks_exact(12) {
+        let nx = chunk[0];
+        let ny = chunk[1];
+        let nz = chunk[2];
+        let label = match (nx, ny, nz) {
+            (x, _, _) if x > 0.5 => 0,
+            (x, _, _) if x < -0.5 => 1,
+            (_, y, _) if y > 0.5 => 2,
+            (_, y, _) if y < -0.5 => 3,
+            (_, _, z) if z > 0.5 => 4,
+            (_, _, z) if z < -0.5 => 5,
+            _ => panic!("non-axial normal"),
+        };
+        faces_seen[label] = true;
+    }
+    assert!(faces_seen.iter().all(|&seen| seen), "missing a face");
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -109,8 +109,13 @@
 # branches must be processed twice. A lower depth cap was rejected -- #960 made
 # the FirstOperand spine iterative precisely so Revit's 42-node DIFFERENCE
 # chains clear MAX_BOOLEAN_DEPTH=10, and a cap tight enough to stop this cycle
-# would drop those elements' geometry.
-     962 rust/geometry/src/processors/boolean/mod.rs
+# would drop those elements' geometry. A SECOND bound, MAX_OPERAND_PATH_NODES,
+# caps the path length: the CSG hop passes `depth` unchanged, so a long ACYCLIC
+# Boolean -> Csg -> Boolean chain never advances MAX_BOOLEAN_DEPTH and every
+# visited.insert succeeds -- 4,000 links aborted the process. The set is
+# path-scoped, so its LENGTH is the current depth and the bound costs no extra
+# parameter.
+     985 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
 # +47: #2866 — the CSG half of the same fix. `process` splits into a shared
 # `resolve_tree_root` plus `process_with_boolean_cycle_guard`, the entry that

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -98,7 +98,7 @@
 # new row: adds from_spans (build the index from pre-collected IfcRelAssociatesMaterial spans, no re-walk) + the MaterialLayerFlat wire codec (to_flat/from_flat) + round-trip tests, so the streaming pre-pass ships the index to workers once instead of each worker re-scanning the file (perf/single-scan #563).
      563 rust/geometry/src/material_layer_index.rs
     1529 rust/geometry/src/mesh.rs
-# +43: #2866 — Boolean and CSG are mutually recursive over file references
+# +86: #2866 — Boolean and CSG are mutually recursive over file references
 # (IfcBooleanResult operand -> IfcCsgSolid -> TreeRootExpression -> that same
 # IfcBooleanResult). CsgSolidProcessor built a FRESH BooleanClippingProcessor,
 # resetting depth and the cycle guard, so three entities aborted the process.
@@ -126,9 +126,9 @@
 # so the note is the record of a regression avoided rather than commentary.
     1005 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
-# -27: #2866 — the Boolean<->CSG cycle guard, with the module's tests moved to a
-# sibling csg_primitive_tests.rs. Budget refreshed DOWNWARD: the split more than
-# paid for the guard.
+# +20: #2866 — the Boolean<->CSG cycle guard, with the module's tests moved to a
+# sibling csg_primitive_tests.rs (402 -> 422). The guard costs more than the
+# test split paid back, so this is a LOOSENING and is recorded as one.
      422 rust/geometry/src/processors/csg_primitive.rs
      608 rust/geometry/src/processors/sectioned.rs
      758 rust/geometry/src/profile_extractor.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -118,15 +118,15 @@
 # because csg_primitive.rs rejects IfcCsgSolid -> IfcCsgSolid, so #CSG <=
 # #Boolean + 1 -- a load-bearing dependency on a guard in another file, written
 # down at the constant because nothing else links them.
-     996 rust/geometry/src/processors/boolean/mod.rs
+# +2: #2866 review — the CSG id now goes into the path set too, so
+# MAX_OPERAND_PATH_NODES counts every frame instead of half of them and no
+# longer leans on a rejection in another file.
+     998 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
-# +47: #2866 — the CSG half of the same fix. `process` splits into a shared
-# `resolve_tree_root` plus `process_with_boolean_cycle_guard`, the entry that
-# carries the caller's depth and visited set across the hop instead of starting
-# a fresh processor. The existing IfcCsgSolid -> IfcCsgSolid rejection here was
-# written against exactly this attack and is one hop wide; the comment now says
-# so, next to the guard it does not cover.
-     449 rust/geometry/src/processors/csg_primitive.rs
+# -27: #2866 — the Boolean<->CSG cycle guard, with the module's tests moved to a
+# sibling csg_primitive_tests.rs. Budget refreshed DOWNWARD: the split more than
+# paid for the guard.
+     422 rust/geometry/src/processors/csg_primitive.rs
      608 rust/geometry/src/processors/sectioned.rs
      758 rust/geometry/src/profile_extractor.rs
      598 rust/geometry/src/profiles/curves_2d.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -114,14 +114,17 @@
 # Boolean -> Csg -> Boolean chain never advances MAX_BOOLEAN_DEPTH and every
 # visited.insert succeeds -- 4,000 links aborted the process. The set is
 # path-scoped, so its LENGTH is the current depth and the bound costs no extra
-# parameter. The set holds BOOLEAN ids only, which still bounds the frame count
-# because csg_primitive.rs rejects IfcCsgSolid -> IfcCsgSolid, so #CSG <=
-# #Boolean + 1 -- a load-bearing dependency on a guard in another file, written
-# down at the constant because nothing else links them.
-# +2: #2866 review — the CSG id now goes into the path set too, so
+# parameter. BOTH boolean and CSG ids go in, so len() is an honest frame count
+# (see the +2 note below).
+# +9: #2866 review — the CSG id now goes into the path set too, so
 # MAX_OPERAND_PATH_NODES counts every frame instead of half of them and no
-# longer leans on a rejection in another file.
-     998 rust/geometry/src/processors/boolean/mod.rs
+# longer leans on a rejection in another file. Seven of the nine are the note
+# at the CSG hop recording why `depth` RESTARTS there: carrying it across
+# silently tightened MAX_BOOLEAN_DEPTH, which #960 calibrated against a
+# per-processor reset, and a valid 8-CsgSolid-8 chain that resolves on main
+# would have been dropped with "depth 11 exceeds limit 10". Caught in review,
+# so the note is the record of a regression avoided rather than commentary.
+    1005 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
 # -27: #2866 — the Boolean<->CSG cycle guard, with the module's tests moved to a
 # sibling csg_primitive_tests.rs. Budget refreshed DOWNWARD: the split more than

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -98,9 +98,27 @@
 # new row: adds from_spans (build the index from pre-collected IfcRelAssociatesMaterial spans, no re-walk) + the MaterialLayerFlat wire codec (to_flat/from_flat) + round-trip tests, so the streaming pre-pass ships the index to workers once instead of each worker re-scanning the file (perf/single-scan #563).
      563 rust/geometry/src/material_layer_index.rs
     1529 rust/geometry/src/mesh.rs
-     919 rust/geometry/src/processors/boolean/mod.rs
+# +43: #2866 — Boolean and CSG are mutually recursive over file references
+# (IfcBooleanResult operand -> IfcCsgSolid -> TreeRootExpression -> that same
+# IfcBooleanResult). CsgSolidProcessor built a FRESH BooleanClippingProcessor,
+# resetting depth and the cycle guard, so three entities aborted the process.
+# The guard must sit INSIDE the recursion, so this is a visited set threaded
+# through the five functions on the operand path plus a path-scoped
+# insert/remove around process_with_depth. Path-scoped, not global: a boolean
+# tree is a DAG and geometry ACCUMULATES, so an operand referenced down two
+# branches must be processed twice. A lower depth cap was rejected -- #960 made
+# the FirstOperand spine iterative precisely so Revit's 42-node DIFFERENCE
+# chains clear MAX_BOOLEAN_DEPTH=10, and a cap tight enough to stop this cycle
+# would drop those elements' geometry.
+     962 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
-     402 rust/geometry/src/processors/csg_primitive.rs
+# +47: #2866 — the CSG half of the same fix. `process` splits into a shared
+# `resolve_tree_root` plus `process_with_boolean_cycle_guard`, the entry that
+# carries the caller's depth and visited set across the hop instead of starting
+# a fresh processor. The existing IfcCsgSolid -> IfcCsgSolid rejection here was
+# written against exactly this attack and is one hop wide; the comment now says
+# so, next to the guard it does not cover.
+     449 rust/geometry/src/processors/csg_primitive.rs
      608 rust/geometry/src/processors/sectioned.rs
      758 rust/geometry/src/profile_extractor.rs
      598 rust/geometry/src/profiles/curves_2d.rs

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -114,8 +114,11 @@
 # Boolean -> Csg -> Boolean chain never advances MAX_BOOLEAN_DEPTH and every
 # visited.insert succeeds -- 4,000 links aborted the process. The set is
 # path-scoped, so its LENGTH is the current depth and the bound costs no extra
-# parameter.
-     985 rust/geometry/src/processors/boolean/mod.rs
+# parameter. The set holds BOOLEAN ids only, which still bounds the frame count
+# because csg_primitive.rs rejects IfcCsgSolid -> IfcCsgSolid, so #CSG <=
+# #Boolean + 1 -- a load-bearing dependency on a guard in another file, written
+# down at the constant because nothing else links them.
+     996 rust/geometry/src/processors/boolean/mod.rs
      486 rust/geometry/src/processors/brep/faceted.rs
 # +47: #2866 — the CSG half of the same fix. `process` splits into a shared
 # `resolve_tree_root` plus `process_with_boolean_cycle_guard`, the entry that

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 8784770703442983011;
+const ALLOWLIST_DIGEST: u64 = 15487705653382690904;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 14083366379525509263;
+const ALLOWLIST_DIGEST: u64 = 8784770703442983011;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 15487705653382690904;
+const ALLOWLIST_DIGEST: u64 = 4869304399876600136;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 18355130832265857600;
+const ALLOWLIST_DIGEST: u64 = 14083366379525509263;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 15910523188906584285;
+const ALLOWLIST_DIGEST: u64 = 18355130832265857600;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).


### PR DESCRIPTION
Part of #2866 — entry 6. @ifc-lite-92 has `extract_symbolic_item`; my #2868 covers `find_color_for_geometry`.

## The cycle

`IfcCsgSolid.TreeRootExpression` may be an `IfcBooleanResult`, whose operands may in turn be `IfcCsgSolid` — the two are mutually recursive over file-supplied references. `BooleanClippingProcessor`'s operand switch routed the `IfcCsgSolid` arm through `CsgSolidProcessor::process`, which builds a **fresh** `BooleanClippingProcessor`, resetting both `depth` and the cycle guard.

```
#10=IFCBOOLEANRESULT(.DIFFERENCE.,#20,#30);
#20=IFCCSGSOLID(#10);
#30=IFCBLOCK($,1.,1.,1.);
```

On unmodified `main`: `fatal runtime error: stack overflow, aborting` — SIGABRT. Depth never passes 1. `IfcBooleanResult`/`IfcCsgSolid` are ordinary Body-representation entities, so this is reachable by an exporter bug, not only by an attack.

## The guard that was one hop too narrow

`csg_primitive.rs` already had this, and it is worth quoting because the author was thinking about precisely this problem:

> Per IFC 4.3, the root must be an `IfcBooleanResult` or an `IfcCsgPrimitive3D`, NEVER another `IfcCsgSolid`. **Reject that case explicitly so a malformed (or adversarial) file with a self-reference can't blow the stack on unbounded recursion.**

Correct, deliberate, documented — and it closes the *one-hop* `CSG -> CSG` cycle while leaving the *two-hop* `CSG -> Boolean -> CSG` cycle open. The comment now says so, sitting next to the case it does not cover.

## Why a visited set and not a lower cap

`MAX_BOOLEAN_DEPTH` is 10, and #960 made the FirstOperand spine iterative *specifically* so legitimate deep chains clear it — Revit emits 42-node DIFFERENCE chains, and capping them dropped whole elements' geometry. A cap tight enough to stop this cycle would regress exactly those files.

The set is **path-scoped** (insert on the way in, remove on the way out), matching `router/processing.rs`. A boolean tree is a DAG and geometry **accumulates**, so an operand legitimately referenced down two branches must be processed both times. This is the opposite of the colour resolvers in #2864/#2868, where the result is a pure function of the id and a global set is both safe and strictly stronger.

## Mutation results — and why the diff shrank

| mutation | result |
|---|---|
| revert the CSG hop to the depth-resetting `process()` | **SIGABRT** |
| remove the visited-set guard | **SIGABRT** |

The first version of this fix **also** inserted on the CSG side. Mutation testing showed that with both guards present, deleting **either one** left all 14 tests green — two guards, and nothing pinned either of them. Since every cycle here must pass through an `IfcBooleanResult` (`CSG -> CSG` is rejected outright), the boolean-side insert breaks all of them and the CSG-side one was redundant. It is gone, and the remaining guard now dies under mutation.

That is the part I would not have found by reading. A redundant guard looks like defence in depth and is indistinguishable from a guard that works, right up until someone deletes the one that was doing the work.

## Tests

Reuse this module's existing worker-thread-plus-`recv_timeout` harness, so a non-growing infinite loop surfaces as a timeout instead of hanging the suite. (A regression that grows the stack aborts the whole binary — no harness catches that, so the test says so rather than implying it.)

They assert the error **names the cycle**, not merely that a call returned: a half-built solid rendered as complete is the outcome being guarded against, and "returned something" is satisfied by it. Both entry points are covered — via the boolean operand, and via the router calling `CsgSolidProcessor` directly when a Body item *is* the `IfcCsgSolid`.

## Verification

- `cargo test --workspace --no-fail-fast` — **1863 passed, 0 failed**
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` — clean
- `module_size_ratchet` — green

Both touched modules were already allowlisted and grew past budget (+43 and +47). Raised with written justifications and the digest updated in the same commit. I did not split them: the guard has to sit inside the recursion it bounds, and the growth is one threaded parameter across five signatures plus the rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented infinite recursion and stack overflows when Boolean and CSG geometry references form cycles.
  * Cyclic references now terminate safely with a clear geometry error.
  * Added bounded handling for deeply nested Boolean–CSG geometry, preventing partial rendering or stack overflow.
  * Improved cycle handling across Boolean and CSG processing paths, including shared geometry operands.

* **Tests**
  * Added regression coverage for recursive references, direct CSG entry points, long acyclic chains, and primitive box geometry validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->