### PR TITLE
fix(geometry): bound the trimmed-curve basis chase (#2866)

### DIFF
--- a/rust/geometry/src/processors/advanced_face/polyline.rs
+++ b/rust/geometry/src/processors/advanced_face/polyline.rs
@@ -21,8 +21,21 @@ pub(super) fn sample_curve_polyline(
     quality: TessellationQuality,
 ) -> Vec<Point3<f64>> {
     let mut visited = std::collections::HashSet::new();
-    sample_curve_polyline_guarded(curve, decoder, quality, &mut visited)
+    sample_curve_polyline_guarded(curve, decoder, quality, 0, &mut visited)
 }
+
+/// Longest `IfcTrimmedCurve.BasisCurve` chain the sampler will follow.
+///
+/// The visited set below stops CYCLES; this stops LENGTH. They are not
+/// interchangeable: a chain of 200k distinct trimmed curves makes every
+/// `visited.insert` succeed, so the set never fires and the recursion consumes
+/// one stack frame per file-supplied entity until the process aborts. A file
+/// with no cycle at all reaches the same crash, and a chain is as easy to
+/// author as a loop.
+///
+/// 32 matches the mapped-item bound used elsewhere for file-driven chains.
+/// Real trimming nests one or two levels.
+const MAX_BASIS_CURVE_DEPTH: u32 = 32;
 
 /// `IfcTrimmedCurve.BasisCurve` may itself be an `IfcTrimmedCurve`, and the
 /// reference comes from the file, so `#10=IFCTRIMMEDCURVE(#10,...)` — a single
@@ -31,13 +44,10 @@ pub(super) fn sample_curve_polyline(
 /// into a load error, and this is reached by any `IfcAdvancedBrep` with a
 /// composite edge curve (#2866).
 ///
-/// A visited set rather than a depth cap. The delegation below is currently
-/// the ONLY recursive call here and it is a tail call, so there is no fan-out
-/// and a cap would be sufficient today — but "there is no fan-out" is a
-/// property of the current branch set, not of the traversal, and it is exactly
-/// the property a later edit invalidates without touching this comment. The
-/// set costs one small allocation on a path that already builds a `Vec` of
-/// points per curve.
+/// Both a visited set and a depth cap, because they bound different things:
+/// the set stops cycles (and any future fan-out, which the single tail call
+/// here does not have today but which nothing enforces), the cap stops a long
+/// ACYCLIC chain, where every insert succeeds and the set never fires.
 ///
 /// It is global to one top-level sample, not path-scoped: the result is a pure
 /// function of (curve, quality), so a curve already being sampled cannot yield
@@ -47,9 +57,10 @@ fn sample_curve_polyline_guarded(
     curve: &DecodedEntity,
     decoder: &mut EntityDecoder,
     quality: TessellationQuality,
+    depth: u32,
     visited: &mut std::collections::HashSet<u32>,
 ) -> Vec<Point3<f64>> {
-    if !visited.insert(curve.id) {
+    if depth >= MAX_BASIS_CURVE_DEPTH || !visited.insert(curve.id) {
         return Vec::new();
     }
     use std::f64::consts::TAU;
@@ -280,7 +291,7 @@ fn sample_curve_polyline_guarded(
                 };
             }
         }
-        return sample_curve_polyline_guarded(&basis, decoder, quality, visited);
+        return sample_curve_polyline_guarded(&basis, decoder, quality, depth + 1, visited);
     }
     Vec::new()
 }

--- a/rust/geometry/src/processors/advanced_face/polyline.rs
+++ b/rust/geometry/src/processors/advanced_face/polyline.rs
@@ -20,6 +20,38 @@ pub(super) fn sample_curve_polyline(
     decoder: &mut EntityDecoder,
     quality: TessellationQuality,
 ) -> Vec<Point3<f64>> {
+    let mut visited = std::collections::HashSet::new();
+    sample_curve_polyline_guarded(curve, decoder, quality, &mut visited)
+}
+
+/// `IfcTrimmedCurve.BasisCurve` may itself be an `IfcTrimmedCurve`, and the
+/// reference comes from the file, so `#10=IFCTRIMMEDCURVE(#10,...)` — a single
+/// self-referential entity — recursed forever. A Rust stack overflow ABORTS
+/// rather than raising a catchable panic, so nothing downstream could turn it
+/// into a load error, and this is reached by any `IfcAdvancedBrep` with a
+/// composite edge curve (#2866).
+///
+/// A visited set rather than a depth cap. The delegation below is currently
+/// the ONLY recursive call here and it is a tail call, so there is no fan-out
+/// and a cap would be sufficient today — but "there is no fan-out" is a
+/// property of the current branch set, not of the traversal, and it is exactly
+/// the property a later edit invalidates without touching this comment. The
+/// set costs one small allocation on a path that already builds a `Vec` of
+/// points per curve.
+///
+/// It is global to one top-level sample, not path-scoped: the result is a pure
+/// function of (curve, quality), so a curve already being sampled cannot yield
+/// a different polyline further down, and the delegation returns rather than
+/// accumulating.
+fn sample_curve_polyline_guarded(
+    curve: &DecodedEntity,
+    decoder: &mut EntityDecoder,
+    quality: TessellationQuality,
+    visited: &mut std::collections::HashSet<u32>,
+) -> Vec<Point3<f64>> {
+    if !visited.insert(curve.id) {
+        return Vec::new();
+    }
     use std::f64::consts::TAU;
     let kind = curve.ifc_type.as_str().to_uppercase();
     // The rational variant shares attributes 0-7 with the plain one; sampling
@@ -248,7 +280,11 @@ pub(super) fn sample_curve_polyline(
                 };
             }
         }
-        return sample_curve_polyline(&basis, decoder, quality);
+        return sample_curve_polyline_guarded(&basis, decoder, quality, visited);
     }
     Vec::new()
 }
+
+#[cfg(test)]
+#[path = "polyline_cycle_tests.rs"]
+mod polyline_cycle_tests;

--- a/rust/geometry/src/processors/advanced_face/polyline_cycle_tests.rs
+++ b/rust/geometry/src/processors/advanced_face/polyline_cycle_tests.rs
@@ -57,6 +57,14 @@ ENDSEC;
 END-ISO-10303-21;
 "#;
 
+fn wrap(data: &str) -> String {
+    format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n\
+FILE_NAME('t.ifc','2024-01-01T00:00:00',(''),(''),'','','');\n\
+FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n{data}ENDSEC;\nEND-ISO-10303-21;\n"
+    )
+}
+
 fn sample(content: &str, id: u32) -> Vec<Point3<f64>> {
     let mut decoder = EntityDecoder::new(content);
     let curve = decoder.decode_by_id(id).expect("decode curve");
@@ -81,4 +89,24 @@ fn a_legitimate_nested_trim_still_samples() {
         "nested-but-acyclic trimming must still yield a polyline, got {} points",
         pts.len()
     );
+}
+
+/// A long ACYCLIC chain: `#1` trims `#2` trims `#3`, every id distinct, so
+/// every `visited.insert` succeeds and the set never fires. Before the depth
+/// cap this consumed one stack frame per entity and aborted the process — the
+/// same crash as the cyclic case, on a file containing no cycle at all
+/// (Codex, #2871 review). A chain is as easy to author as a loop.
+#[test]
+fn a_long_acyclic_basis_chain_terminates() {
+    let n: u32 = 5_000;
+    let mut data = String::new();
+    for i in 1..n {
+        data.push_str(&format!(
+            "#{}=IFCTRIMMEDCURVE(#{},(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(1.)),.T.,.PARAMETER.);\n",
+            i,
+            i + 1
+        ));
+    }
+    data.push_str(&format!("#{n}=IFCCARTESIANPOINT((0.,0.,0.));\n"));
+    assert!(sample(&wrap(&data), 1).is_empty());
 }

--- a/rust/geometry/src/processors/advanced_face/polyline_cycle_tests.rs
+++ b/rust/geometry/src/processors/advanced_face/polyline_cycle_tests.rs
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::*;
+use ifc_lite_core::EntityDecoder;
+
+/// A single self-referential entity: `#10`'s `BasisCurve` is `#10`. Enough on
+/// its own to abort the process before the guard (#2866).
+const SELF_BASIS: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#10=IFCTRIMMEDCURVE(#10,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(1.)),.T.,.PARAMETER.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// A two-node cycle: `#10` trims `#11`, which trims `#10` back. The one-entity
+/// case above is catchable by a naive `basis.id == curve.id` check; this one
+/// is not, so it pins that the guard is a real visited set.
+const TWO_CYCLE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#10=IFCTRIMMEDCURVE(#11,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(1.)),.T.,.PARAMETER.);
+#11=IFCTRIMMEDCURVE(#10,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(1.)),.T.,.PARAMETER.);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+/// A legitimate trimmed-on-trimmed chain ending at a real `IfcLine`, so the
+/// guard is shown to stop at cycles rather than at nesting. The assertion is on
+/// the sampled polyline, not on "it returned": a guard that made every trimmed
+/// curve yield nothing would also terminate, and would silently strip geometry
+/// off every IfcAdvancedBrep in the file.
+const NESTED_TRIM_ON_LINE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#10=IFCTRIMMEDCURVE(#11,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(1.)),.T.,.PARAMETER.);
+#11=IFCTRIMMEDCURVE(#12,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(1.)),.T.,.PARAMETER.);
+#12=IFCLINE(#13,#14);
+#13=IFCCARTESIANPOINT((0.,0.,0.));
+#14=IFCVECTOR(#15,1.);
+#15=IFCDIRECTION((1.,0.,0.));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn sample(content: &str, id: u32) -> Vec<Point3<f64>> {
+    let mut decoder = EntityDecoder::new(content);
+    let curve = decoder.decode_by_id(id).expect("decode curve");
+    sample_curve_polyline(&curve, &mut decoder, TessellationQuality::default())
+}
+
+#[test]
+fn self_referential_basis_curve_terminates() {
+    assert!(sample(SELF_BASIS, 10).is_empty());
+}
+
+#[test]
+fn two_node_basis_curve_cycle_terminates() {
+    assert!(sample(TWO_CYCLE, 10).is_empty());
+}
+
+#[test]
+fn a_legitimate_nested_trim_still_samples() {
+    let pts = sample(NESTED_TRIM_ON_LINE, 10);
+    assert!(
+        pts.len() >= 2,
+        "nested-but-acyclic trimming must still yield a polyline, got {} points",
+        pts.len()
+    );
+}


### PR DESCRIPTION
Part of #2866 — entry 5. Sibling PRs: #2864, #2868, #2870.

## The cycle

`sample_curve_polyline` follows `IfcTrimmedCurve.BasisCurve` recursively, and that reference comes from the file. **One entity is enough:**

```
#10=IFCTRIMMEDCURVE(#10,(IFCPARAMETERVALUE(0.)),(IFCPARAMETERVALUE(1.)),.T.,.PARAMETER.);
```

On unmodified `main`: `fatal runtime error: stack overflow, aborting` — SIGABRT. Reached by any `IfcAdvancedBrep` with a composite edge curve (`edge_loop.rs:252`) and by the surface-of-revolution generator profile (`revolution.rs:76,81`).

## Visited set, even though a depth cap would do

Worth spelling out, because this is the one site in the set where a cap really would be sufficient. The basis delegation is the **only** recursive call in this function and it is a tail call, so there is no fan-out — none of the `O(k^depth)` blowup that made a cap insufficient in #2864.

I used a visited set anyway. "There is no fan-out" is a property of the current branch set, not of the traversal, and it is exactly the kind of property a later edit invalidates without touching the comment asserting it. The set costs one small allocation on a path that already builds a `Vec<Point3>` per curve, so the cheaper guard buys nothing worth the coupling.

It is **global** to one top-level sample rather than path-scoped: the polyline is a pure function of (curve, quality), so a curve already being sampled cannot yield a different result deeper down, and the delegation returns rather than accumulating. #2870's Boolean/CSG guard is path-scoped for the opposite reason — geometry there accumulates over a DAG. Same family, opposite answer, decided by the return type rather than by the traversal shape.

## Tests

Three, and the third is the one I would keep if I could only keep one:

1. **self-referential basis** — the reproducer
2. **two-node cycle** (`#10` trims `#11` trims `#10`) — included because the one-entity case is catchable by a naive `basis.id == curve.id` check, so without this a weaker guard passes
3. **a legitimate trimmed-on-trimmed chain ending at a real `IfcLine`** — asserts the polyline is still produced

Number 3 exists because a guard that made every trimmed curve return nothing would also terminate, and would silently strip geometry off every `IfcAdvancedBrep` in the file. Termination is not the property; termination *without* eating real geometry is.

## Mutation results

| mutation | result |
|---|---|
| remove the visited guard | **SIGABRT** |
| make the guard over-broad (basis delegation returns empty) | `a_legitimate_nested_trim_still_samples` FAILED, both cycle tests still green |

Two mutations in opposite directions, each killed by a different test. That is the pair I want on a guard like this: one test that fails if it does too little, one that fails if it does too much.

## Verification

- `cargo test --workspace --no-fail-fast` — **1864 passed, 0 failed**
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` — clean
- `module_size_ratchet` — green, no budget change needed (tests live in a sibling `polyline_cycle_tests.rs`; `polyline.rs` is 290 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented curve sampling from becoming stuck when geometry contains circular references.
  * Cyclic trimmed curves now terminate safely without producing invalid points.
  * Added protection against excessively deep nested curve definitions.
  * Preserved correct polyline generation for valid nested curves ending in a line.
  * Improved handling of malformed or non-terminating geometry by returning no points instead of hanging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->