### PR TITLE
fix(geometry): composite-curve profiles yielded no points, and could abort (#2866)

### DIFF
--- a/rust/geometry/src/processors/curve_walk.rs
+++ b/rust/geometry/src/processors/curve_walk.rs
@@ -1,0 +1,64 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Traversal policy for composite-curve sampling: what a walk is allowed to
+//! do, independent of any IFC type. `surface.rs` is the per-type dispatch and
+//! the sampling itself; nothing here knows what an `IfcPolyline` is.
+
+use crate::{Error, Result};
+
+/// Two consecutive composite-curve segment endpoints closer than this are the
+/// same joint, so the repeat is dropped. Wider than float noise and far below
+/// any real modelling distance in either mm or m.
+pub(super) const SEAM_EPS: f64 = 1e-9;
+
+/// Total nested curve visits allowed per profile sample. See [`CurveWalk`].
+pub(super) const MAX_CURVE_NODES: u32 = 100_000;
+
+/// The two bounds on one composite-curve traversal, carried together because
+/// each is blind to what the other catches.
+///
+/// `seen` is PATH-scoped and stops cycles. The depth cap stops a long acyclic
+/// CHAIN, where every insert succeeds so `seen` never fires. And `budget` stops
+/// an acyclic DAG, where two segments per level double the work: nothing is
+/// cyclic, so `seen` is silent, and every level is inside the depth cap, so
+/// that is silent too. Measured before the budget at 2^levels points --
+/// levels=16 gave 131,072 points -- with nothing malformed in the file at all.
+pub(super) struct CurveWalk {
+    pub(super) seen: std::collections::HashSet<u32>,
+    pub(super) budget: u32,
+    /// Set only when a charge is ATTEMPTED with nothing left. Distinct from
+    /// `budget == 0`, which is also true after the last PERMITTED visit -- a
+    /// traversal using exactly `MAX_CURVE_NODES` visits is valid and must not
+    /// be reported as exhausted (CodeRabbit, #2874 review).
+    pub(super) exhausted: bool,
+}
+
+impl CurveWalk {
+    pub(super) fn new() -> Self {
+        Self {
+            seen: std::collections::HashSet::new(),
+            budget: MAX_CURVE_NODES,
+            exhausted: false,
+        }
+    }
+
+    /// Charge one visit. Exhaustion is an ERROR rather than a truncation: a
+    /// short point list returned as if complete is a wrong profile, and the
+    /// caller dropping the element is the honest outcome.
+    pub(super) fn spend(&mut self) -> Result<()> {
+        match self.budget.checked_sub(1) {
+            Some(left) => {
+                self.budget = left;
+                Ok(())
+            }
+            None => {
+                self.exhausted = true;
+                Err(Error::geometry(format!(
+                    "Curve traversal exceeded {MAX_CURVE_NODES} nested curves"
+                )))
+            }
+        }
+    }
+}

--- a/rust/geometry/src/processors/surface.rs
+++ b/rust/geometry/src/processors/surface.rs
@@ -139,6 +139,15 @@ impl SurfaceOfLinearExtrusionProcessor {
         profile_id: u32,
         decoder: &mut EntityDecoder,
     ) -> Result<Vec<Point2<f64>>> {
+        let mut visited = std::collections::HashSet::new();
+        Self::profile_curve_points_guarded(profile_id, decoder, &mut visited)
+    }
+
+    fn profile_curve_points_guarded(
+        profile_id: u32,
+        decoder: &mut EntityDecoder,
+        visited: &mut std::collections::HashSet<u32>,
+    ) -> Result<Vec<Point2<f64>>> {
         let profile = decoder.decode_by_id(profile_id)?;
 
         // IfcArbitraryOpenProfileDef: 0=ProfileType, 1=ProfileName, 2=Curve
@@ -150,6 +159,35 @@ impl SurfaceOfLinearExtrusionProcessor {
         let curve_id = curve_attr
             .as_entity_ref()
             .ok_or_else(|| Error::geometry("Expected entity reference for curve".to_string()))?;
+
+        Self::curve_points_guarded(curve_id, decoder, visited)
+    }
+
+    /// Sample a CURVE (not a profile) into 2D points.
+    ///
+    /// Split out of `get_profile_curve_points` because
+    /// `extract_composite_curve_points` was calling that function with a
+    /// segment's `ParentCurve` id — a curve where a profile was expected. It
+    /// read attribute 2 of the curve as "the profile's curve", and an
+    /// `IfcPolyline` has no attribute 2, so every composite-curve profile
+    /// errored on each segment, had the error swallowed by the caller's
+    /// `if let Ok(..)`, and returned `Ok(vec![])`. Silently: no points, no
+    /// error, indistinguishable from a legitimately empty profile.
+    ///
+    /// `visited` bounds the `profile -> composite curve -> segment ->
+    /// ParentCurve -> profile` cycle, which is file-supplied and aborts the
+    /// process on a stack overflow (#2866). A set rather than a depth cap
+    /// because `extract_composite_curve_points` loops over segments: `k`
+    /// segments each leading back cost `O(k^depth)`, so a cap alone would
+    /// trade the abort for a hang.
+    fn curve_points_guarded(
+        curve_id: u32,
+        decoder: &mut EntityDecoder,
+        visited: &mut std::collections::HashSet<u32>,
+    ) -> Result<Vec<Point2<f64>>> {
+        if !visited.insert(curve_id) {
+            return Ok(Vec::new());
+        }
 
         // Get curve entity to determine type
         let curve = decoder.decode_by_id(curve_id)?;
@@ -171,7 +209,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             }
             IfcType::IfcCompositeCurve => {
                 // Handle composite curves by extracting segments
-                Self::extract_composite_curve_points(curve_id, decoder)
+                Self::extract_composite_curve_points(curve_id, decoder, visited)
             }
             _ => {
                 // Fallback: try to get points directly
@@ -194,6 +232,7 @@ impl SurfaceOfLinearExtrusionProcessor {
     fn extract_composite_curve_points(
         curve_id: u32,
         decoder: &mut EntityDecoder,
+        visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Vec<Point2<f64>>> {
         let curve = decoder.decode_by_id(curve_id)?;
 
@@ -225,7 +264,12 @@ impl SurfaceOfLinearExtrusionProcessor {
             })?;
 
             // Recursively get points from the parent curve
-            if let Ok(segment_points) = Self::get_profile_curve_points(parent_curve_id, decoder) {
+            // The ParentCurve is a CURVE, not a profile. Routing it through the
+            // profile entry point read its attribute 2 as "the curve" and
+            // dropped every segment (#2866).
+            if let Ok(segment_points) =
+                Self::curve_points_guarded(parent_curve_id, decoder, visited)
+            {
                 // Skip first point if we already have points (to avoid duplicates at joints)
                 let start_idx = if all_points.is_empty() { 0 } else { 1 };
                 all_points.extend(segment_points.into_iter().skip(start_idx));
@@ -241,3 +285,7 @@ impl Default for SurfaceOfLinearExtrusionProcessor {
         Self::new()
     }
 }
+
+#[cfg(test)]
+#[path = "surface_cycle_tests.rs"]
+mod surface_cycle_tests;

--- a/rust/geometry/src/processors/surface.rs
+++ b/rust/geometry/src/processors/surface.rs
@@ -15,6 +15,11 @@ use crate::router::GeometryProcessor;
 /// Handles IfcSurfaceOfLinearExtrusion - surface created by sweeping a curve along a direction
 pub struct SurfaceOfLinearExtrusionProcessor;
 
+/// Two consecutive composite-curve segment endpoints closer than this are the
+/// same joint, so the repeat is dropped. Wider than float noise and far below
+/// any real modelling distance in either mm or m.
+const SEAM_EPS: f64 = 1e-9;
+
 impl SurfaceOfLinearExtrusionProcessor {
     pub fn new() -> Self {
         Self
@@ -195,6 +200,22 @@ impl SurfaceOfLinearExtrusionProcessor {
         if depth >= Self::MAX_CURVE_NESTING_DEPTH || !visited.insert(curve_id) {
             return Ok(Vec::new());
         }
+        let out = Self::curve_points_inner(curve_id, decoder, depth, visited);
+        // PATH-scoped: removed on the way out. A global set would be a memo
+        // that returns the WRONG value -- it hands back an empty vec rather
+        // than the points it computed the first time -- and the caller
+        // ACCUMULATES, so a ParentCurve legitimately reused by two segments
+        // would contribute once and silently shorten the profile.
+        visited.remove(&curve_id);
+        out
+    }
+
+    fn curve_points_inner(
+        curve_id: u32,
+        decoder: &mut EntityDecoder,
+        depth: u32,
+        visited: &mut std::collections::HashSet<u32>,
+    ) -> Result<Vec<Point2<f64>>> {
 
         // Get curve entity to determine type
         let curve = decoder.decode_by_id(curve_id)?;
@@ -253,7 +274,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             .as_list()
             .ok_or_else(|| Error::geometry("Expected segment list".to_string()))?;
 
-        let mut all_points = Vec::new();
+        let mut all_points: Vec<Point2<f64>> = Vec::new();
 
         for seg_ref in segment_refs {
             let seg_id = seg_ref.as_entity_ref().ok_or_else(|| {
@@ -271,15 +292,39 @@ impl SurfaceOfLinearExtrusionProcessor {
                 Error::geometry("Expected entity reference for parent curve".to_string())
             })?;
 
-            // Recursively get points from the parent curve
+            // IfcCompositeCurveSegment.SameSense (attribute 1): when false the
+            // segment traverses its ParentCurve BACKWARDS. Nothing applied it
+            // before because no segment ever produced points to orient -- the
+            // dispatch bug above meant every one came back empty, so a
+            // reversed segment and a forward one were indistinguishable.
+            let same_sense = segment
+                .get(1)
+                .map(|v| match v {
+                    ifc_lite_core::AttributeValue::Enum(e) => e != "F" && e != ".F.",
+                    _ => true,
+                })
+                .unwrap_or(true);
+
             // The ParentCurve is a CURVE, not a profile. Routing it through the
             // profile entry point read its attribute 2 as "the curve" and
             // dropped every segment (#2866).
-            if let Ok(segment_points) =
+            if let Ok(mut segment_points) =
                 Self::curve_points_guarded(parent_curve_id, decoder, depth + 1, visited)
             {
-                // Skip first point if we already have points (to avoid duplicates at joints)
-                let start_idx = if all_points.is_empty() { 0 } else { 1 };
+                if !same_sense {
+                    segment_points.reverse();
+                }
+                // Drop the seam point only when it ACTUALLY duplicates the
+                // previous segment's end. A `.DISCONTINUOUS.` transition, or a
+                // gap from a malformed file, leaves a real point that an
+                // unconditional skip would eat.
+                let drop_seam = match (all_points.last(), segment_points.first()) {
+                    (Some(prev), Some(next)) => {
+                        (prev.x - next.x).abs() < SEAM_EPS && (prev.y - next.y).abs() < SEAM_EPS
+                    }
+                    _ => false,
+                };
+                let start_idx = usize::from(drop_seam);
                 all_points.extend(segment_points.into_iter().skip(start_idx));
             }
         }

--- a/rust/geometry/src/processors/surface.rs
+++ b/rust/geometry/src/processors/surface.rs
@@ -135,6 +135,10 @@ impl GeometryProcessor for SurfaceOfLinearExtrusionProcessor {
 
 impl SurfaceOfLinearExtrusionProcessor {
     /// Extract curve points from a profile definition
+    /// Longest nested-curve chain the profile sampler will follow. See
+    /// `curve_points_guarded` for why this sits alongside the visited set.
+    const MAX_CURVE_NESTING_DEPTH: u32 = 32;
+
     fn get_profile_curve_points(
         profile_id: u32,
         decoder: &mut EntityDecoder,
@@ -160,7 +164,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             .as_entity_ref()
             .ok_or_else(|| Error::geometry("Expected entity reference for curve".to_string()))?;
 
-        Self::curve_points_guarded(curve_id, decoder, visited)
+        Self::curve_points_guarded(curve_id, decoder, 0, visited)
     }
 
     /// Sample a CURVE (not a profile) into 2D points.
@@ -174,18 +178,21 @@ impl SurfaceOfLinearExtrusionProcessor {
     /// `if let Ok(..)`, and returned `Ok(vec![])`. Silently: no points, no
     /// error, indistinguishable from a legitimately empty profile.
     ///
-    /// `visited` bounds the `profile -> composite curve -> segment ->
-    /// ParentCurve -> profile` cycle, which is file-supplied and aborts the
-    /// process on a stack overflow (#2866). A set rather than a depth cap
-    /// because `extract_composite_curve_points` loops over segments: `k`
-    /// segments each leading back cost `O(k^depth)`, so a cap alone would
-    /// trade the abort for a hang.
+    /// Guarded by BOTH a visited set and a depth cap, because they bound
+    /// different things. The set stops cycles and fan-out --
+    /// `extract_composite_curve_points` loops over segments, so `k` segments
+    /// each leading back cost `O(k^depth)` and a cap alone would trade the
+    /// abort for a hang. The cap stops a long ACYCLIC chain, where every
+    /// insert succeeds, the set never fires, and the recursion aborts on stack
+    /// depth alone (Codex, #2871/#2872 review). Neither substitutes for the
+    /// other (#2866).
     fn curve_points_guarded(
         curve_id: u32,
         decoder: &mut EntityDecoder,
+        depth: u32,
         visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Vec<Point2<f64>>> {
-        if !visited.insert(curve_id) {
+        if depth >= Self::MAX_CURVE_NESTING_DEPTH || !visited.insert(curve_id) {
             return Ok(Vec::new());
         }
 
@@ -209,7 +216,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             }
             IfcType::IfcCompositeCurve => {
                 // Handle composite curves by extracting segments
-                Self::extract_composite_curve_points(curve_id, decoder, visited)
+                Self::extract_composite_curve_points(curve_id, decoder, depth, visited)
             }
             _ => {
                 // Fallback: try to get points directly
@@ -232,6 +239,7 @@ impl SurfaceOfLinearExtrusionProcessor {
     fn extract_composite_curve_points(
         curve_id: u32,
         decoder: &mut EntityDecoder,
+        depth: u32,
         visited: &mut std::collections::HashSet<u32>,
     ) -> Result<Vec<Point2<f64>>> {
         let curve = decoder.decode_by_id(curve_id)?;
@@ -268,7 +276,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             // profile entry point read its attribute 2 as "the curve" and
             // dropped every segment (#2866).
             if let Ok(segment_points) =
-                Self::curve_points_guarded(parent_curve_id, decoder, visited)
+                Self::curve_points_guarded(parent_curve_id, decoder, depth + 1, visited)
             {
                 // Skip first point if we already have points (to avoid duplicates at joints)
                 let start_idx = if all_points.is_empty() { 0 } else { 1 };

--- a/rust/geometry/src/processors/surface.rs
+++ b/rust/geometry/src/processors/surface.rs
@@ -15,51 +15,9 @@ use crate::router::GeometryProcessor;
 /// Handles IfcSurfaceOfLinearExtrusion - surface created by sweeping a curve along a direction
 pub struct SurfaceOfLinearExtrusionProcessor;
 
-/// Two consecutive composite-curve segment endpoints closer than this are the
-/// same joint, so the repeat is dropped. Wider than float noise and far below
-/// any real modelling distance in either mm or m.
-const SEAM_EPS: f64 = 1e-9;
-
-/// Total nested curve visits allowed per profile sample. See [`CurveWalk`].
-const MAX_CURVE_NODES: u32 = 100_000;
-
-/// The two bounds on one composite-curve traversal, carried together because
-/// each is blind to what the other catches.
-///
-/// `seen` is PATH-scoped and stops cycles. The depth cap stops a long acyclic
-/// CHAIN, where every insert succeeds so `seen` never fires. And `budget` stops
-/// an acyclic DAG, where two segments per level double the work: nothing is
-/// cyclic, so `seen` is silent, and every level is inside the depth cap, so
-/// that is silent too. Measured before the budget at 2^levels points --
-/// levels=16 gave 131,072 points -- with nothing malformed in the file at all.
-struct CurveWalk {
-    seen: std::collections::HashSet<u32>,
-    budget: u32,
-}
-
-impl CurveWalk {
-    fn new() -> Self {
-        Self {
-            seen: std::collections::HashSet::new(),
-            budget: MAX_CURVE_NODES,
-        }
-    }
-
-    /// Charge one visit. Exhaustion is an ERROR rather than a truncation: a
-    /// short point list returned as if complete is a wrong profile, and the
-    /// caller dropping the element is the honest outcome.
-    fn spend(&mut self) -> Result<()> {
-        match self.budget.checked_sub(1) {
-            Some(left) => {
-                self.budget = left;
-                Ok(())
-            }
-            None => Err(Error::geometry(format!(
-                "Curve traversal exceeded {MAX_CURVE_NODES} nested curves"
-            ))),
-        }
-    }
-}
+#[path = "curve_walk.rs"]
+mod curve_walk;
+use curve_walk::{CurveWalk, MAX_CURVE_NODES, SEAM_EPS};
 
 impl SurfaceOfLinearExtrusionProcessor {
     pub fn new() -> Self {
@@ -376,7 +334,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             // truncated profile as if it were complete. That is the silent
             // wrong answer this guard exists to avoid, so exhaustion is
             // re-raised here where the tolerance cannot hide it.
-            if walk.budget == 0 {
+            if walk.exhausted {
                 return Err(Error::geometry(format!(
                     "Curve traversal exceeded {MAX_CURVE_NODES} nested curves"
                 )));

--- a/rust/geometry/src/processors/surface.rs
+++ b/rust/geometry/src/processors/surface.rs
@@ -20,6 +20,47 @@ pub struct SurfaceOfLinearExtrusionProcessor;
 /// any real modelling distance in either mm or m.
 const SEAM_EPS: f64 = 1e-9;
 
+/// Total nested curve visits allowed per profile sample. See [`CurveWalk`].
+const MAX_CURVE_NODES: u32 = 100_000;
+
+/// The two bounds on one composite-curve traversal, carried together because
+/// each is blind to what the other catches.
+///
+/// `seen` is PATH-scoped and stops cycles. The depth cap stops a long acyclic
+/// CHAIN, where every insert succeeds so `seen` never fires. And `budget` stops
+/// an acyclic DAG, where two segments per level double the work: nothing is
+/// cyclic, so `seen` is silent, and every level is inside the depth cap, so
+/// that is silent too. Measured before the budget at 2^levels points --
+/// levels=16 gave 131,072 points -- with nothing malformed in the file at all.
+struct CurveWalk {
+    seen: std::collections::HashSet<u32>,
+    budget: u32,
+}
+
+impl CurveWalk {
+    fn new() -> Self {
+        Self {
+            seen: std::collections::HashSet::new(),
+            budget: MAX_CURVE_NODES,
+        }
+    }
+
+    /// Charge one visit. Exhaustion is an ERROR rather than a truncation: a
+    /// short point list returned as if complete is a wrong profile, and the
+    /// caller dropping the element is the honest outcome.
+    fn spend(&mut self) -> Result<()> {
+        match self.budget.checked_sub(1) {
+            Some(left) => {
+                self.budget = left;
+                Ok(())
+            }
+            None => Err(Error::geometry(format!(
+                "Curve traversal exceeded {MAX_CURVE_NODES} nested curves"
+            ))),
+        }
+    }
+}
+
 impl SurfaceOfLinearExtrusionProcessor {
     pub fn new() -> Self {
         Self
@@ -148,14 +189,14 @@ impl SurfaceOfLinearExtrusionProcessor {
         profile_id: u32,
         decoder: &mut EntityDecoder,
     ) -> Result<Vec<Point2<f64>>> {
-        let mut visited = std::collections::HashSet::new();
-        Self::profile_curve_points_guarded(profile_id, decoder, &mut visited)
+        let mut walk = CurveWalk::new();
+        Self::profile_curve_points_guarded(profile_id, decoder, &mut walk)
     }
 
     fn profile_curve_points_guarded(
         profile_id: u32,
         decoder: &mut EntityDecoder,
-        visited: &mut std::collections::HashSet<u32>,
+        walk: &mut CurveWalk,
     ) -> Result<Vec<Point2<f64>>> {
         let profile = decoder.decode_by_id(profile_id)?;
 
@@ -169,7 +210,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             .as_entity_ref()
             .ok_or_else(|| Error::geometry("Expected entity reference for curve".to_string()))?;
 
-        Self::curve_points_guarded(curve_id, decoder, 0, visited)
+        Self::curve_points_guarded(curve_id, decoder, 0, walk)
     }
 
     /// Sample a CURVE (not a profile) into 2D points.
@@ -195,18 +236,19 @@ impl SurfaceOfLinearExtrusionProcessor {
         curve_id: u32,
         decoder: &mut EntityDecoder,
         depth: u32,
-        visited: &mut std::collections::HashSet<u32>,
+        walk: &mut CurveWalk,
     ) -> Result<Vec<Point2<f64>>> {
-        if depth >= Self::MAX_CURVE_NESTING_DEPTH || !visited.insert(curve_id) {
+        if depth >= Self::MAX_CURVE_NESTING_DEPTH || !walk.seen.insert(curve_id) {
             return Ok(Vec::new());
         }
-        let out = Self::curve_points_inner(curve_id, decoder, depth, visited);
+        walk.spend()?;
+        let out = Self::curve_points_inner(curve_id, decoder, depth, walk);
         // PATH-scoped: removed on the way out. A global set would be a memo
         // that returns the WRONG value -- it hands back an empty vec rather
         // than the points it computed the first time -- and the caller
         // ACCUMULATES, so a ParentCurve legitimately reused by two segments
         // would contribute once and silently shorten the profile.
-        visited.remove(&curve_id);
+        walk.seen.remove(&curve_id);
         out
     }
 
@@ -214,7 +256,7 @@ impl SurfaceOfLinearExtrusionProcessor {
         curve_id: u32,
         decoder: &mut EntityDecoder,
         depth: u32,
-        visited: &mut std::collections::HashSet<u32>,
+        walk: &mut CurveWalk,
     ) -> Result<Vec<Point2<f64>>> {
 
         // Get curve entity to determine type
@@ -237,7 +279,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             }
             IfcType::IfcCompositeCurve => {
                 // Handle composite curves by extracting segments
-                Self::extract_composite_curve_points(curve_id, decoder, depth, visited)
+                Self::extract_composite_curve_points(curve_id, decoder, depth, walk)
             }
             _ => {
                 // Fallback: try to get points directly
@@ -261,7 +303,7 @@ impl SurfaceOfLinearExtrusionProcessor {
         curve_id: u32,
         decoder: &mut EntityDecoder,
         depth: u32,
-        visited: &mut std::collections::HashSet<u32>,
+        walk: &mut CurveWalk,
     ) -> Result<Vec<Point2<f64>>> {
         let curve = decoder.decode_by_id(curve_id)?;
 
@@ -309,7 +351,7 @@ impl SurfaceOfLinearExtrusionProcessor {
             // profile entry point read its attribute 2 as "the curve" and
             // dropped every segment (#2866).
             if let Ok(mut segment_points) =
-                Self::curve_points_guarded(parent_curve_id, decoder, depth + 1, visited)
+                Self::curve_points_guarded(parent_curve_id, decoder, depth + 1, walk)
             {
                 if !same_sense {
                     segment_points.reverse();
@@ -326,6 +368,18 @@ impl SurfaceOfLinearExtrusionProcessor {
                 };
                 let start_idx = usize::from(drop_seam);
                 all_points.extend(segment_points.into_iter().skip(start_idx));
+            }
+
+            // The `if let Ok(..)` above deliberately tolerates ONE malformed
+            // segment rather than losing the whole profile -- but it must not
+            // swallow budget exhaustion, or the loop keeps going and returns a
+            // truncated profile as if it were complete. That is the silent
+            // wrong answer this guard exists to avoid, so exhaustion is
+            // re-raised here where the tolerance cannot hide it.
+            if walk.budget == 0 {
+                return Err(Error::geometry(format!(
+                    "Curve traversal exceeded {MAX_CURVE_NODES} nested curves"
+                )));
             }
         }
 

--- a/rust/geometry/src/processors/surface_cycle_tests.rs
+++ b/rust/geometry/src/processors/surface_cycle_tests.rs
@@ -118,3 +118,30 @@ fn parent_curve_pointing_at_a_profile_terminates() {
 #21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#10);\n";
     assert!(profile_points(data, 10).is_empty());
 }
+
+/// A long ACYCLIC nesting chain: each composite curve's segment parents the
+/// NEXT composite curve, every id distinct, so every `visited.insert` succeeds
+/// and the set never fires. Before the depth cap this aborted the process on
+/// stack depth alone, with no cycle in the file (Codex, #2871/#2872 review).
+#[test]
+fn a_long_acyclic_curve_chain_terminates() {
+    let n: u32 = 3_000;
+    let mut data = String::from("#1=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#100);\n");
+    for i in 0..n {
+        let cc = 100 + i * 2;
+        let seg = 101 + i * 2;
+        let next = if i + 1 == n { 90000 } else { 100 + (i + 1) * 2 };
+        data.push_str(&format!("#{cc}=IFCCOMPOSITECURVE((#{seg}),.F.);\n"));
+        data.push_str(&format!(
+            "#{seg}=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#{next});\n"
+        ));
+    }
+    data.push_str("#90000=IFCPOLYLINE((#90001,#90002));\n");
+    data.push_str("#90001=IFCCARTESIANPOINT((0.,0.));\n");
+    data.push_str("#90002=IFCCARTESIANPOINT((1.,0.));\n");
+    // Asserting the RESULT, not merely that it returned: the polyline sits
+    // 3,000 links down, well past the cap, so nothing survives from beyond it.
+    // "it did not crash" would also be satisfied by a guard that broke the
+    // well-formed case, which the tests above cover in the other direction.
+    assert!(profile_points(&data, 1).is_empty());
+}

--- a/rust/geometry/src/processors/surface_cycle_tests.rs
+++ b/rust/geometry/src/processors/surface_cycle_tests.rs
@@ -145,3 +145,62 @@ fn a_long_acyclic_curve_chain_terminates() {
     // well-formed case, which the tests above cover in the other direction.
     assert!(profile_points(&data, 1).is_empty());
 }
+
+/// A ParentCurve legitimately REUSED by two segments must be sampled both
+/// times. A global visited set makes the second occurrence return empty —
+/// which is not "already computed", it is the wrong value, and the caller
+/// accumulates, so the profile silently comes up short. (Codex + CodeRabbit,
+/// #2874 review.)
+#[test]
+fn a_reused_parent_curve_contributes_to_every_segment() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21,#31),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#22);\n\
+#31=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#22);\n\
+#22=IFCPOLYLINE((#23,#24,#25));\n\
+#23=IFCCARTESIANPOINT((0.,0.));\n\
+#24=IFCCARTESIANPOINT((1.,0.));\n\
+#25=IFCCARTESIANPOINT((1.,1.));\n";
+    // Both occurrences sample; the seam between them does NOT coincide
+    // ((1,1) then (0,0)), so nothing is dropped: 3 + 3 = 6.
+    assert_eq!(profile_points(data, 10).len(), 6);
+}
+
+/// `SameSense = .F.` means the segment traverses its ParentCurve BACKWARDS.
+/// Nothing applied it before, because no segment ever produced points to
+/// orient — every one came back empty, so a reversed segment and a forward one
+/// were indistinguishable. (Codex, #2874 review.)
+#[test]
+fn same_sense_false_reverses_the_segment() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.F.,#22);\n\
+#22=IFCPOLYLINE((#23,#24,#25));\n\
+#23=IFCCARTESIANPOINT((0.,0.));\n\
+#24=IFCCARTESIANPOINT((1.,0.));\n\
+#25=IFCCARTESIANPOINT((1.,1.));\n";
+    let pts = profile_points(data, 10);
+    assert_eq!(pts.len(), 3);
+    assert_eq!(pts[0], Point2::new(1.0, 1.0), "reversed: last authored point first");
+    assert_eq!(pts[2], Point2::new(0.0, 0.0));
+}
+
+/// The seam point is dropped only when it actually duplicates. Two segments
+/// that do NOT meet — a gap, or a `.DISCONTINUOUS.` transition — must keep
+/// every point; an unconditional skip ate one. (Codex, #2874 review.)
+#[test]
+fn a_discontinuous_joint_keeps_both_endpoints() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21,#31),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.DISCONTINUOUS.,.T.,#22);\n\
+#22=IFCPOLYLINE((#23,#24));\n\
+#23=IFCCARTESIANPOINT((0.,0.));\n\
+#24=IFCCARTESIANPOINT((1.,0.));\n\
+#31=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#32);\n\
+#32=IFCPOLYLINE((#33,#34));\n\
+#33=IFCCARTESIANPOINT((5.,5.));\n\
+#34=IFCCARTESIANPOINT((6.,5.));\n";
+    let pts = profile_points(data, 10);
+    assert_eq!(pts.len(), 4, "the joint does not coincide, so no point is dropped");
+    assert_eq!(pts[2], Point2::new(5.0, 5.0));
+}

--- a/rust/geometry/src/processors/surface_cycle_tests.rs
+++ b/rust/geometry/src/processors/surface_cycle_tests.rs
@@ -253,3 +253,60 @@ fn a_wide_acyclic_dag_is_bounded_by_the_node_budget() {
         "the node budget must be what stops it, got: {err}"
     );
 }
+
+/// The budget's boundary, both sides. `budget == 0` is true after the last
+/// PERMITTED visit as well as after a refused one, so re-raising on it would
+/// fail a traversal that used exactly `MAX_CURVE_NODES` visits and exceeded
+/// nothing. `exhausted` is set only by an attempted charge with nothing left.
+/// (CodeRabbit, #2874 review — a valid-but-boundary false positive.)
+#[test]
+fn exactly_max_curve_nodes_visits_is_not_exhaustion() {
+    let mut walk = CurveWalk::new();
+    for i in 0..MAX_CURVE_NODES {
+        walk.spend()
+            .unwrap_or_else(|e| panic!("visit {i} of {MAX_CURVE_NODES} must be permitted: {e}"));
+    }
+    assert_eq!(walk.budget, 0, "the budget is spent to the last unit");
+    assert!(
+        !walk.exhausted,
+        "spending the budget exactly is not exhaustion"
+    );
+
+    // One past is.
+    assert!(walk.spend().is_err(), "the next visit must be refused");
+    assert!(walk.exhausted, "and it must record that it refused one");
+}
+
+/// The same boundary through the CALLER, which is where the off-by-one lived.
+/// One composite curve plus `MAX_CURVE_NODES - 1` segments all parenting the
+/// same polyline is exactly `MAX_CURVE_NODES` visits: the budget lands on zero
+/// having refused nothing, so the profile must come back complete.
+///
+/// The unit test above cannot catch this — it pins `spend`, and the defect was
+/// the caller re-raising on `budget == 0` rather than on a refusal.
+#[test]
+fn a_traversal_of_exactly_the_budget_still_returns_its_profile() {
+    let segs = MAX_CURVE_NODES - 1;
+    let mut d = String::with_capacity(segs as usize * 60);
+    // Segment ids start well above the polyline's, or they collide: at
+    // 1000 + i, segment 8000 would BE #9000.
+    let refs: Vec<String> = (0..segs).map(|i| format!("#{}", 500_000 + i)).collect();
+    d.push_str("#1=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#10);\n");
+    d.push_str(&format!("#10=IFCCOMPOSITECURVE(({}),.F.);\n", refs.join(",")));
+    for i in 0..segs {
+        d.push_str(&format!(
+            "#{}=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#9000);\n",
+            500_000 + i
+        ));
+    }
+    d.push_str("#9000=IFCPOLYLINE((#9001,#9002));\n");
+    d.push_str("#9001=IFCCARTESIANPOINT((0.,0.));\n");
+    d.push_str("#9002=IFCCARTESIANPOINT((1.,0.));\n");
+
+    let content = wrap(&d);
+    let mut decoder = EntityDecoder::new(&content);
+    let item = decoder.decode_by_id(1).expect("decode profile");
+    let pts = SurfaceOfLinearExtrusionProcessor::get_profile_curve_points(item.id, &mut decoder)
+        .expect("a traversal that spends the budget exactly must not be refused");
+    assert!(!pts.is_empty(), "and it must return its points");
+}

--- a/rust/geometry/src/processors/surface_cycle_tests.rs
+++ b/rust/geometry/src/processors/surface_cycle_tests.rs
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::*;
+use ifc_lite_core::EntityDecoder;
+
+fn wrap(data: &str) -> String {
+    format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n\
+FILE_NAME('t.ifc','2024-01-01T00:00:00',(''),(''),'','','');\n\
+FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n{data}ENDSEC;\nEND-ISO-10303-21;\n"
+    )
+}
+
+fn profile_points(data: &str, id: u32) -> Vec<Point2<f64>> {
+    let content = wrap(data);
+    let mut decoder = EntityDecoder::new(&content);
+    SurfaceOfLinearExtrusionProcessor::get_profile_curve_points(id, &mut decoder)
+        .expect("profile points")
+}
+
+/// A well-formed composite-curve profile: one segment whose ParentCurve is a
+/// 3-point IfcPolyline. Before the fix this returned `Ok(vec![])` — the
+/// ParentCurve was routed through the PROFILE entry point, which read
+/// attribute 2 of the polyline as "the profile's curve", found none, errored,
+/// and had the error swallowed by `if let Ok(..)`. No points, no error, and
+/// indistinguishable from a legitimately empty profile.
+const WELLFORMED: &str = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#22);\n\
+#22=IFCPOLYLINE((#23,#24,#25));\n\
+#23=IFCCARTESIANPOINT((0.,0.));\n\
+#24=IFCCARTESIANPOINT((1.,0.));\n\
+#25=IFCCARTESIANPOINT((1.,1.));\n";
+
+#[test]
+fn a_composite_curve_profile_yields_its_segment_points() {
+    let pts = profile_points(WELLFORMED, 10);
+    assert_eq!(
+        pts.len(),
+        3,
+        "a composite profile with one 3-point polyline segment must yield 3 points, got {}",
+        pts.len()
+    );
+    assert_eq!(pts[0], Point2::new(0.0, 0.0));
+    assert_eq!(pts[2], Point2::new(1.0, 1.0));
+}
+
+/// Two segments, so the joint-dedup path is exercised: the second segment's
+/// first point is skipped, giving 3 + 3 - 1 = 5.
+#[test]
+fn two_segments_join_without_duplicating_the_seam() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21,#31),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#22);\n\
+#22=IFCPOLYLINE((#23,#24,#25));\n\
+#23=IFCCARTESIANPOINT((0.,0.));\n\
+#24=IFCCARTESIANPOINT((1.,0.));\n\
+#25=IFCCARTESIANPOINT((1.,1.));\n\
+#31=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#32);\n\
+#32=IFCPOLYLINE((#33,#34,#35));\n\
+#33=IFCCARTESIANPOINT((1.,1.));\n\
+#34=IFCCARTESIANPOINT((2.,1.));\n\
+#35=IFCCARTESIANPOINT((2.,2.));\n";
+    assert_eq!(profile_points(data, 10).len(), 5);
+}
+
+/// The cycle the visited set actually guards: a composite curve whose segment
+/// `ParentCurve` is that same composite curve. `curve_points_guarded` re-enters
+/// itself directly, so nothing structural stops it.
+///
+/// Note the shape here was chosen by mutation, not by guesswork. The obvious
+/// fixture — the ParentCurve pointing back at the PROFILE — is broken by the
+/// curve/profile split alone, so it stayed green with the visited set removed
+/// and would have shipped a guard no test defended.
+#[test]
+fn self_referential_composite_curve_terminates() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#20);\n";
+    assert!(profile_points(data, 10).is_empty());
+}
+
+/// A two-node curve cycle: `#20`'s segment parents `#30`, whose segment
+/// parents `#20`. Not catchable by comparing an id against its immediate
+/// parent.
+#[test]
+fn two_node_composite_curve_cycle_terminates() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#30);\n\
+#30=IFCCOMPOSITECURVE((#31),.F.);\n\
+#31=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#20);\n";
+    assert!(profile_points(data, 10).is_empty());
+}
+
+/// Fan-out: four segments each re-entering the same composite curve. A depth
+/// cap bounds the chain's length and not its breadth, so this costs
+/// `O(4^depth)` without the set — an abort traded for a hang.
+#[test]
+fn cyclic_composite_curve_with_fan_out_terminates() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21,#22,#23,#24),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#20);\n\
+#22=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#20);\n\
+#23=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#20);\n\
+#24=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#20);\n";
+    assert!(profile_points(data, 10).is_empty());
+}
+
+/// And the original shape kept as a regression on the SPLIT: a ParentCurve
+/// pointing at the profile must not re-enter the profile path.
+#[test]
+fn parent_curve_pointing_at_a_profile_terminates() {
+    let data = "#10=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#20);\n\
+#20=IFCCOMPOSITECURVE((#21),.F.);\n\
+#21=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#10);\n";
+    assert!(profile_points(data, 10).is_empty());
+}

--- a/rust/geometry/src/processors/surface_cycle_tests.rs
+++ b/rust/geometry/src/processors/surface_cycle_tests.rs
@@ -204,3 +204,52 @@ fn a_discontinuous_joint_keeps_both_endpoints() {
     assert_eq!(pts.len(), 4, "the joint does not coincide, so no point is dropped");
     assert_eq!(pts[2], Point2::new(5.0, 5.0));
 }
+
+/// Build an ACYCLIC composite-curve DAG: two segments per level, both pointing
+/// at the next level, terminating in a real polyline. Nothing is cyclic and
+/// nothing fails, so neither the path-scoped `seen` set nor the depth cap can
+/// see it — and the work doubles per level.
+fn dag_data(levels: u32) -> String {
+    let mut d = String::from("#1=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#10);\n");
+    for i in 0..levels {
+        let cc = 10 + i;
+        let next = if i + 1 == levels { 9000 } else { 10 + i + 1 };
+        let (s1, s2) = (1000 + i * 2, 1001 + i * 2);
+        d.push_str(&format!("#{cc}=IFCCOMPOSITECURVE((#{s1},#{s2}),.F.);\n"));
+        d.push_str(&format!("#{s1}=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#{next});\n"));
+        d.push_str(&format!("#{s2}=IFCCOMPOSITECURVESEGMENT(.CONTINUOUS.,.T.,#{next});\n"));
+    }
+    d.push_str("#9000=IFCPOLYLINE((#9001,#9002));\n");
+    d.push_str("#9001=IFCCARTESIANPOINT((0.,0.));\n");
+    d.push_str("#9002=IFCCARTESIANPOINT((1.,0.));\n");
+    d
+}
+
+/// Positive control: a modest DAG must still resolve completely, or the budget
+/// is just breaking valid files.
+#[test]
+fn a_modest_acyclic_dag_still_resolves_completely() {
+    let content = wrap(&dag_data(8));
+    let mut decoder = EntityDecoder::new(&content);
+    let item = decoder.decode_by_id(1).expect("decode profile");
+    let pts = SurfaceOfLinearExtrusionProcessor::get_profile_curve_points(item.id, &mut decoder)
+        .expect("8 levels must resolve");
+    assert!(pts.len() > 100, "expected the full expansion, got {}", pts.len());
+}
+
+/// The bound. 30 levels is 2^30 curve visits under a depth cap alone —
+/// measured before the budget at 2^levels points (levels=16 gave 131,072).
+/// Asserted on the ERROR, not on elapsed time: a timing assertion after the
+/// call cannot fire when the call does not return.
+#[test]
+fn a_wide_acyclic_dag_is_bounded_by_the_node_budget() {
+    let content = wrap(&dag_data(30));
+    let mut decoder = EntityDecoder::new(&content);
+    let item = decoder.decode_by_id(1).expect("decode profile");
+    let err = SurfaceOfLinearExtrusionProcessor::get_profile_curve_points(item.id, &mut decoder)
+        .expect_err("a 2^30 traversal must be refused, not attempted");
+    assert!(
+        err.to_string().contains("exceeded"),
+        "the node budget must be what stops it, got: {err}"
+    );
+}


### PR DESCRIPTION
The last unclaimed entry from #2866 — `SurfaceOfLinearExtrusionProcessor::get_profile_curve_points` ↔ `extract_composite_curve_points`. Siblings: #2864, #2868, #2870, #2871, #2872, and @ifc-lite-92's #2869.

Two defects on this path. The one I went looking for was the crash; **the one that matters more is silent.**

## Silent: every composite-curve profile returned zero points

`extract_composite_curve_points` handed a segment's `ParentCurve` id to `get_profile_curve_points`, which expects a **profile** and reads attribute 2 as "the profile's curve". An `IfcPolyline` has no attribute 2, so every segment errored, the caller's `if let Ok(..)` swallowed it, and the function returned `Ok(vec![])`.

Measured on `main` with a well-formed fixture — one segment, a 3-point polyline:

```
PROBE_WELLFORMED Ok(0)
```

No points. No error. `Ok`, so indistinguishable from a legitimately empty profile. Every `IfcSurfaceOfLinearExtrusion` with a composite-curve profile lost its geometry, and nothing anywhere said so.

Fixed by splitting curve dispatch out of profile dispatch, so a `ParentCurve` is sampled as the curve it is.

## Fatal: a self-referential composite curve aborts

A composite curve whose segment's `ParentCurve` is that same composite curve re-enters the sampler directly. In Rust a stack overflow **aborts** rather than raising a catchable panic.

Guarded with a visited set rather than a depth cap, and here that is not a stylistic preference: `extract_composite_curve_points` **loops over segments**, so `k` segments each leading back cost `O(k^depth)` and a cap would trade the abort for a hang.

## The cycle fixtures were wrong, and mutation is the only reason I know

My first cycle fixture had the `ParentCurve` point back at the **profile**. That is the obvious shape, it reproduced the abort on `main`, and it is **broken by the curve/profile split on its own** — so with it as the only cycle test, deleting the visited set left all four tests green.

The guard would have shipped with nothing defending it, in a PR whose stated purpose is that guard.

The fixtures now target a composite curve that re-enters **itself**, which the split does not help with, plus a two-node curve cycle (not catchable by comparing against an immediate parent) and a four-way fan-out. The profile-shaped case is kept as a regression test on the split.

This is the same lesson as #2870, from the other direction: there I had two guards where one was doing the work, here I had one guard where something else was doing the work. Both look identical from a green suite.

## Mutation results

| mutation | result |
|---|---|
| remove the visited set | **SIGABRT** |
| revert the curve/profile split | `a_composite_curve_profile_yields_its_segment_points` and `two_segments_join_without_duplicating_the_seam` FAILED; every cycle test still green |

Two mutations, two disjoint sets of tests, no overlap — so neither fix is resting on the other's coverage.

## Verification

- `cargo test --workspace --no-fail-fast` — **1867 passed, 0 failed**
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` — clean
- `module_size_ratchet` — green, no budget change (`surface.rs` is 291 lines; tests are in a sibling `surface_cycle_tests.rs`)

Checkpointed before mutating, so reverting a mutation could not revert the fix — @ifc-lite-92 hit exactly that on #2869 and it cost a measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved surface profile extraction from composite curves.
  * Correctly handles reversed curve segments and seam points.
  * Preserves discontinuities and gaps between non-coincident segments.
  * Prevents cyclic references and deeply nested curves from causing hangs or unbounded processing.
  * Rejects overly complex curve networks with a clear geometry error instead of returning incomplete results.

* **Tests**
  * Added coverage for curve traversal, seam handling, direction, cyclic references, nested chains, discontinuities, and complex acyclic networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->