### PR TITLE
fix(export): geometry skip must agree with isGeometryExcluded across a retype

### DIFF
--- a/.changeset/step-export-retype-geometry-boundary.md
+++ b/.changeset/step-export-retype-geometry-boundary.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix a STEP export with `includeGeometry: false`: an entity retyped across the geometry boundary (e.g. `IfcWall` to `IfcCartesianPoint`, or the reverse) disagreed with itself about whether its line survived. The source-iteration pass's own geometry skip classified the entity by its RAW authored type, while `isGeometryExcluded` — the predicate `hasEmittableHostBytes`/`willBeEmitted` use to decide whether an edit counts as a delivered modification — classified it by the EFFECTIVE (retyped) type. A wall retyped to a geometry class still shipped its rewritten geometry line into `DATA` despite `includeGeometry: false`, while the header claimed a modification for it; the reverse retype (geometry to non-geometry) silently dropped a legitimate edit with no line and no count. The source-iteration skip now reads `isGeometryExcluded` too, so both agree.

--- a/packages/export/src/retype-geometry-boundary.test.ts
+++ b/packages/export/src/retype-geometry-boundary.test.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression cover for #2861's sibling sweep: the source-iteration pass's
+ * own geometry skip (step-exporter.ts, "Skip geometry if not included")
+ * classified a source entity by its RAW authored type
+ * (`entityRef.type.toUpperCase()`) instead of the EFFECTIVE type
+ * (`pass.effective.effectiveType`, which folds in a retype). That skip must
+ * agree with `isGeometryExcluded` — the predicate `hasEmittableHostBytes`
+ * and `willBeEmitted` both consult to decide whether an edit gets counted
+ * as a delivered modification (see the comment at `isGeometryExcluded`'s
+ * definition, "this predicate must agree or a geometry entity's attribute
+ * edit inflates the count over an omitted line", CodeRabbit finding on
+ * #2414) — or a retype crossing the geometry boundary makes the two passes
+ * disagree about whether a line survives `includeGeometry: false`.
+ *
+ * Every assertion here is against the emitted file TEXT, never against an
+ * internal counter alone.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function headerClaimedModifications(stepText: string): number | null {
+  const m = /Re-exported by ifc-lite, (\d+) modification/.exec(stepText);
+  return m ? Number(m[1]) : null;
+}
+
+const BASE_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition[DesignTransferView]'),'2;1');
+FILE_NAME('base.ifc','2026-08-08T10:00:00+01:00',(''),(''),'ifc-lite','ifc-lite','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0OSuGGYUFyIf0LtE29OSuG',$,'My Project',$,$,$,$,$,$);
+#8=IFCWALL('0OSuGGYUFyIf0LtE29OSuH',$,'Existing Wall',$,$,$,$,$,$);
+#20=IFCCARTESIANPOINT((0.,0.,0.));
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function parseBase(): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(toArrayBuffer(new TextEncoder().encode(BASE_IFC)));
+}
+
+describe('STEP geometry skip vs a retype crossing the geometry boundary', () => {
+  it('retyping a non-geometry entity INTO a geometry class must exclude its line under includeGeometry:false, the same as an entity born geometry', async () => {
+    const store = await parseBase();
+    const view = new MutablePropertyView(null, 'test-model');
+    const editor = new StoreEditor(store, view);
+    // #8 is authored as IFCWALL (not geometry). Retype it to IfcCartesianPoint
+    // (on `isGeometryEntity`'s list) and edit an attribute.
+    editor.setEntityType(8, 'IfcCartesianPoint');
+    editor.setAttribute(8, 'Name', 'renamed');
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      includeGeometry: false,
+    });
+    const text = new TextDecoder().decode(result.content);
+
+    // The retyped-to-geometry line must not land in DATA.
+    expect(text).not.toContain('#8=');
+    expect(text).not.toContain('IFCCARTESIANPOINT($)');
+    // ...and the header must not claim a modification for it either.
+    expect(result.stats.modifiedEntityCount).toBe(0);
+    expect(headerClaimedModifications(text)).toBeNull();
+  });
+
+  it('retyping a geometry entity OUT of a geometry class must emit its line under includeGeometry:false, the same as an entity born non-geometry', async () => {
+    const store = await parseBase();
+    const view = new MutablePropertyView(null, 'test-model');
+    const editor = new StoreEditor(store, view);
+    // #20 is authored as IFCCARTESIANPOINT (geometry). Retype it to IfcWall
+    // (not geometry) and edit an attribute.
+    editor.setEntityType(20, 'IfcWall');
+    editor.setAttribute(20, 'Name', 'renamed');
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      includeGeometry: false,
+    });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).toContain("#20=IFCWALL($,$,'renamed'");
+    expect(result.stats.modifiedEntityCount).toBe(1);
+    expect(headerClaimedModifications(text)).toBe(1);
+  });
+
+  it('bounding control: with geometry included, the retyped-to-geometry line survives and is counted', async () => {
+    const store = await parseBase();
+    const view = new MutablePropertyView(null, 'test-model');
+    const editor = new StoreEditor(store, view);
+    editor.setEntityType(8, 'IfcCartesianPoint');
+    editor.setAttribute(8, 'Name', 'renamed');
+
+    const result = new StepExporter(store, view).export({ schema: 'IFC4' });
+    const text = new TextDecoder().decode(result.content);
+
+    expect(text).toContain('#8=IFCCARTESIANPOINT($)');
+    expect(result.stats.modifiedEntityCount).toBe(1);
+  });
+});

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -1409,11 +1409,16 @@ export class StepExporter {
           continue;
         }
 
-        // Skip if we're only doing geometry or specific types
-        const entityType = entityRef.type.toUpperCase();
-
-        // Skip geometry if not included
-        if (excludeGeometry && this.isGeometryEntity(entityType)) {
+        // Skip geometry if not included. Classified via `isGeometryExcluded`
+        // (which reads the EFFECTIVE type, `effective.effectiveType`) rather
+        // than `entityRef.type` directly: a retype can move a record across
+        // the geometry boundary in either direction, and this check has to
+        // agree with `hasEmittableHostBytes`/`willBeEmitted`'s use of the
+        // same predicate — otherwise a wall retyped to `IfcCartesianPoint`
+        // still ships its (rewritten) geometry line under
+        // `includeGeometry: false`, the exact "predicate must agree" failure
+        // this file already guards for the non-retyped case (#2414).
+        if (pass.isGeometryExcluded(expressId, entityRef.type)) {
           continue;
         }
 
@@ -1455,7 +1460,7 @@ export class StepExporter {
         // withholds must not also be counted as a delivered modification.
         //
         // Classified by the EFFECTIVE type (`effective.effectiveType`), not
-        // the authored `entityType` above: a retype can move a record across
+        // the source's authored type: a retype can move a record across
         // the `IFCREL*` boundary in either direction (`applySourceLineMutations`
         // already rewrote `nextEntityText` to the new class), and this check
         // has to agree with what actually got written, the same way


### PR DESCRIPTION
The source-iteration pass's own geometry skip classified an entity by its **raw authored type** (`entityRef.type.toUpperCase()`), while `isGeometryExcluded` — which `hasEmittableHostBytes` and `willBeEmitted` both consult — reads the **effective** type (`effective.effectiveType`, which folds in a retype).

This file already documents that they must agree. From the comment at `isGeometryExcluded`'s definition:

> this predicate must agree or a geometry entity's attribute edit inflates the count over an omitted line

That contract held for the non-retyped case (#2414) and broke the moment a retype moved a record across the geometry boundary.

### What a user saw

Both directions were wrong, and in opposite ways:

- **Retyping *into* a geometry class** (e.g. a wall retyped to `IfcCartesianPoint`): the rewritten geometry line still shipped into `DATA` under `includeGeometry: false`, **and** the header claimed a modification the file did not contain.
- **The reverse retype**: a legitimate edit was silently dropped — no line, and no count either.

### The fix

Replace the local raw-type check with the shared predicate, so the source-iteration pass and the emission predicates classify identically:

```ts
if (pass.isGeometryExcluded(expressId, entityRef.type)) { continue; }
```

The second hunk only corrects a neighbouring comment that referenced the now-removed local variable.

### Test

`packages/export/src/retype-geometry-boundary.test.ts` asserts against the **emitted file text**, never an internal counter alone — the header's claimed modification count is checked against what actually appears in `DATA`, which is the discrepancy that made this visible.

### How it was found

Sweeping the "must agree" contracts the codebase writes about itself, after #2861 — where `property-table.ts`'s comment named three implementations that had to agree on a NULL sentinel and the third had drifted to a guard that is unconditionally true on an unsigned array. The comments are an accurate map; nobody had been following them.

### Provenance, stated plainly

This work was completed by an agent that then stalled before it could push. I recovered the commit from its worktree, reviewed the production diff and the test, and pushed it. **The RED → GREEN evidence and mutation table were not reported back to me before it died**, so I am not claiming them — the reasoning and the fix are sound on review, but if you want the failing-test-name evidence before merging, say so and I will produce it properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed STEP exports with geometry excluded so retyped entities are filtered correctly.
  - Ensured retyped entities are consistently included or omitted based on their effective type.
  - Corrected modification counts and relationship handling for entities retyped across the geometry boundary.
- **Tests**
  - Added regression coverage for geometry inclusion, exclusion, and entity retyping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->