### PR TITLE
fix(georef): KMZ export missed the ePset MapUnit correction (1000x)

### DIFF
--- a/.changeset/kmz-export-epset-mapunit-scale.md
+++ b/.changeset/kmz-export-epset-mapunit-scale.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix KMZ export scaling a millimetre IFC2x3 project's `ePset_MapConversion` offsets by 1 instead of 0.001.
+
+`kmzSuggestsAbsoluteAltitude` and `buildKmzForModel` (kmz-export.ts) built their `ProjectedCRS` via `extractGeoreferencingOnDemand` + `mergeProjectedCRS` directly, without the `resolveEpsetMapUnitScale` correction `getEffectiveGeoreference` applies for every other georeference consumer. For a file whose only georeference is an IFC2x3 `ePset_MapConversion` property set with no explicit `MapUnit` — the buildingSMART convention is to read those offsets in the project length unit — `mapUnitScale` stayed `undefined`, so `resolveMapUnitToMetreScale`'s "no MapUnit ⇒ treat offsets as metres" heuristic took over instead: eastings, northings and OrthogonalHeight were all read as metres rather than the project's millimetres, a 1000× error in every exported KMZ placement and the "True elevation (MSL)" altitude-mode hint. Both functions now apply `resolveEpsetMapUnitScale`, matching the correction `GeoreferencingPanel.tsx` already applies (#2859).

--- a/apps/viewer/src/lib/geo/kmz-export.test.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.test.ts
@@ -11,9 +11,92 @@ import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometr
 import type { MapConversion, ProjectedCRS } from '@ifc-lite/parser';
 import type { Renderer } from '@ifc-lite/renderer';
 
+import { StepTokenizer, ColumnarParser, type IfcDataStore } from '@ifc-lite/parser';
+
 import { setGlobalRendererRef } from '../../hooks/useBCF.js';
 import type { KmzProcessor } from './kmz-exporter.js';
-import { buildKmzForResolvedGeoref, computeKmzAltitude, resolveKmzHeading } from './kmz-export.js';
+import {
+  buildKmzForResolvedGeoref,
+  computeKmzAltitude,
+  kmzSuggestsAbsoluteAltitude,
+  resolveKmzHeading,
+} from './kmz-export.js';
+
+/** Builds a real `IfcDataStore` from raw STEP text (mirrors the parser
+ *  package's `on-demand-georef-epset.test.ts` fixture harness) so the ePset
+ *  MapUnit correction is exercised through the actual extractor, not a mock. */
+async function storeFromIfc(ifc: string): Promise<IfcDataStore> {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs: Array<{
+    expressId: number;
+    type: string;
+    byteOffset: number;
+    byteLength: number;
+    lineNumber: number;
+  }> = [];
+  for (const ref of tokenizer.scanEntitiesFast()) {
+    entityRefs.push({
+      expressId: ref.expressId,
+      type: ref.type,
+      byteOffset: ref.offset,
+      byteLength: ref.length,
+      lineNumber: ref.line,
+    });
+  }
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0), entityRefs, {}) as unknown as Promise<IfcDataStore>;
+}
+
+/**
+ * A millimetre-unit IFC2x3 file whose only georeference is an
+ * `ePset_MapConversion` property set — no `IfcMapConversion`/`IfcProjectedCRS`
+ * entities, and (per the buildingSMART ePset convention) no MapUnit property
+ * either. `OrthogonalHeight` is authored `500` — 500 *millimetres*, i.e. 0.5 m
+ * — and the geometry's minimum Z is 500 IFC-world *metres*, well above
+ * `BAKED_MIN_Z_THRESHOLD_METERS` (100 m), so a correctly-scaled 0.5 m
+ * OrthogonalHeight is "no elevation in the georef" and the model should hint
+ * "True elevation (MSL)".
+ */
+const EPSET_MM_IFC = `#1=IFCPROJECT('1mj5Hja8yfJfRTJSXP39EZ',$,'P',$,$,$,$,$,#2);
+#2=IFCUNITASSIGNMENT((#3));
+#3=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#30=IFCSITE('06pHC0eJnCHlVXWW2sVoPO',$,'Site',$,$,$,$,$,.ELEMENT.,$,$,$,$,$);
+#1357=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:7415'),$);
+#1358=IFCPROPERTYSET('27AKTMp8j58fBEhvkJkcNJ',$,'ePset_ProjectedCRS',$,(#1357));
+#1359=IFCRELDEFINESBYPROPERTIES('3eMryiQHj84vNzfI1G88R1',$,$,$,(#30),#1358);
+#1360=IFCPROPERTYSINGLEVALUE('TargetCRS',$,IFCLABEL('EPSG:7415'),$);
+#1361=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCLENGTHMEASURE(160073528.13858587),$);
+#1362=IFCPROPERTYSINGLEVALUE('Northings',$,IFCLENGTHMEASURE(384153306.2191765),$);
+#1363=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCLENGTHMEASURE(500.),$);
+#1364=IFCPROPERTYSINGLEVALUE('XAxisAbscissa',$,IFCREAL(1.),$);
+#1365=IFCPROPERTYSINGLEVALUE('XAxisOrdinate',$,IFCREAL(0.),$);
+#1366=IFCPROPERTYSINGLEVALUE('Scale',$,IFCREAL(1.),$);
+#1367=IFCPROPERTYSET('2If4Y3Lpv6dgTDkC5x_dnr',$,'ePset_MapConversion',$,(#1360,#1361,#1362,#1363,#1364,#1365,#1366));
+#1368=IFCRELDEFINESBYPROPERTIES('0AUnylrXbCLgALz5UN_kQ2',$,$,$,(#30),#1367);`;
+
+describe('kmzSuggestsAbsoluteAltitude — ePset_MapConversion MapUnit scaling (#2859 shape)', () => {
+  it('scales OrthogonalHeight by the project length unit, not 1, for an unset ePset MapUnit', async () => {
+    const dataStore = await storeFromIfc(EPSET_MM_IFC);
+    const geometryResult = {
+      coordinateInfo: {
+        originalBounds: { min: { x: 0, y: 500, z: 0 }, max: { x: 10, y: 510, z: 10 } },
+        shiftedBounds: { min: { x: 0, y: 500, z: 0 }, max: { x: 10, y: 510, z: 10 } },
+        originShift: { x: 0, y: 0, z: 0 },
+      },
+    } as unknown as GeometryResult;
+
+    const suggests = kmzSuggestsAbsoluteAltitude({ geometryResult, dataStore, mutations: undefined });
+
+    // OrthogonalHeight=500 authored in the project length unit (mm, per the
+    // ePset convention) is 0.5 m — "near-zero" — so with geometry sitting at
+    // 500 m Z (baked-in elevation), the dialog must hint absolute altitude.
+    // Pre-fix, the unresolved `mapUnitScale` read 500 as 500 metres (not
+    // near-zero), so this returned false — silently keeping clampToGround,
+    // which floats the model 500 m above the terrain in Google Earth.
+    assert.strictEqual(suggests, true);
+  });
+});
 
 describe('computeKmzAltitude', () => {
   it('scales OrthogonalHeight from map units to metres (mm-CRS file is not 1000x off)', () => {

--- a/apps/viewer/src/lib/geo/kmz-export.ts
+++ b/apps/viewer/src/lib/geo/kmz-export.ts
@@ -12,7 +12,7 @@ import { extractGeoreferencingOnDemand, extractLengthUnitScale, type IfcDataStor
 import type { CoordinateInfo, GeometryResult, MeshData } from '@ifc-lite/geometry';
 import type { GeorefMutationData } from '@/store/slices/mutationSlice';
 import { getMapUnitScale } from './cesium-placement';
-import { mergeMapConversion, mergeProjectedCRS } from './effective-georef';
+import { mergeMapConversion, mergeProjectedCRS, resolveEpsetMapUnitScale } from './effective-georef';
 import { resolveMapUnitToMetreScale } from './geo-scale';
 import { withInstancedMeshes } from '../../utils/instancedExport.js';
 import { effectiveMapConversionForGeometry } from './map-absolute';
@@ -81,6 +81,15 @@ export function kmzSuggestsAbsoluteAltitude(
   const scale = extractLengthUnitScale(input.dataStore.source, input.dataStore.entityIndex) ?? 1;
   const conversion = mergeMapConversion(info?.mapConversion, input.mutations?.mapConversion);
   const crs = mergeProjectedCRS(info?.projectedCRS, input.mutations?.projectedCRS, scale);
+  // `mergeProjectedCRS` alone doesn't know the georeference's `source`, so an
+  // IFC2x3 `ePSet_MapConversion` file with no explicit ePset MapUnit leaves
+  // `mapUnitScale` undefined here -- which `resolveMapUnitToMetreScale`
+  // (inside `suggestAbsoluteAltitudeForKmz`) then reads as "treat offsets as
+  // metres" instead of the buildingSMART convention (project length unit).
+  // `getEffectiveGeoreference` applies this same correction; this function
+  // built its own merge via `extractGeoreferencingOnDemand` and previously
+  // didn't (matches the #2859 fix applied to `GeoreferencingPanel.tsx`).
+  if (crs) crs.mapUnitScale = resolveEpsetMapUnitScale(info?.source, crs.mapUnitScale, scale);
   return suggestAbsoluteAltitudeForKmz(input.geometryResult.coordinateInfo, conversion, crs, scale);
 }
 
@@ -214,6 +223,13 @@ export async function buildKmzForModel(
   const conversion = mergeMapConversion(info?.mapConversion, input.mutations?.mapConversion);
   const crs = mergeProjectedCRS(info?.projectedCRS, input.mutations?.projectedCRS, scale);
   if (!conversion || !crs) return 'not-georeferenced';
+  // Same ePset MapUnit correction `getEffectiveGeoreference` applies (see
+  // `kmzSuggestsAbsoluteAltitude` above) -- without it, a millimetre IFC2x3
+  // project whose only georeference is `ePset_MapConversion` (no explicit
+  // MapUnit) exports every eastings/northings/orthogonalHeight value scaled
+  // by 1 instead of 0.001: the reprojected pin lands ~1000x away from the
+  // model, and `computeKmzAltitude`'s altitude is 1000x too high.
+  crs.mapUnitScale = resolveEpsetMapUnitScale(info?.source, crs.mapUnitScale, scale);
   return buildKmzForResolvedGeoref({
     conversion,
     crs,


### PR DESCRIPTION
## Summary

Continuation of the georef-consumer audit from #2855 / #2859 (same shape: one path applies a correction another path, doing the same job, does not).

`kmz-export.ts`'s `kmzSuggestsAbsoluteAltitude` and `buildKmzForModel` build a `ProjectedCRS` via `extractGeoreferencingOnDemand` + `mergeProjectedCRS` directly, instead of going through `getEffectiveGeoreference`. That skipped `resolveEpsetMapUnitScale` — the correction #2859 added to `GeoreferencingPanel.tsx` for the exact same gap.

For a millimetre-unit IFC2x3 file whose only georeference is an `ePset_MapConversion` property set with no explicit `MapUnit` (the buildingSMART convention — offsets are in the project length unit when MapUnit is absent), `mapUnitScale` stayed `undefined`. `resolveMapUnitToMetreScale`'s "no MapUnit ⇒ treat offsets as metres" heuristic then took over, so every exported KMZ read eastings/northings/OrthogonalHeight as metres instead of millimetres — a 1000x placement error — and the "True elevation (MSL)" altitude-mode hint used the same wrong scale.

- Consumer map for this pass: `dxfExportGeoref.ts` and `pick-to-geo.ts` (both named as candidates) are parameter-driven and route through `getEffectiveGeoreference`/`selectAnchorGeoref` — canonical, no bypass. `terrain-elevation.ts` has no georeference construction (previously cleared switch is unrelated). `CesiumPlacementEditor.tsx`, `useSolarEnvironment.ts`, `PropertiesPanel.tsx`/`ModelMetadataPanel.tsx` (feed `GeoreferencingPanel.tsx`, already fixed by #2859) are all canonical. `kmz-export.ts` was the one bypass found.

## Fix

Both `kmzSuggestsAbsoluteAltitude` and `buildKmzForModel` now apply `resolveEpsetMapUnitScale(info?.source, crs.mapUnitScale, scale)` after `mergeProjectedCRS`, matching `getEffectiveGeoreference`'s composition exactly.

## Test plan

- [x] RED: added `kmzSuggestsAbsoluteAltitude — ePset_MapConversion MapUnit scaling (#2859 shape)` to `kmz-export.test.ts`, built from a real parsed `ePset_MapConversion` fixture (mm project, `OrthogonalHeight=500`); fails `false !== true` on the pre-fix code (geometry sitting 500m up should trigger the absolute-altitude hint, but the un-scaled 500m OrthogonalHeight reads as "not near zero" instead of the correct 0.5m).
- [x] GREEN: same test passes after the fix; full `kmz-export.test.ts` + `kmz-altitude-hint.test.ts` + `effective-georef.test.ts` (67 tests) pass.
- [x] Calibration: reverting `resolveEpsetMapUnitScale`'s fallback from `lengthUnitScale` to `1` fails `defaults an ePSet georef without MapUnit to the project length-unit scale` in `effective-georef.test.ts`, confirming the existing guard still holds.

Scoped test run only (`apps/viewer` doesn't use vitest):
```
pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=1 \
  src/lib/geo/kmz-export.test.ts src/lib/geo/kmz-altitude-hint.test.ts src/lib/geo/effective-georef.test.ts
```

Refs #2855, #2859.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected KMZ export scaling for IFC2x3 models using `ePset_MapConversion` georeferencing.
  - Fixed misplaced model geometry and incorrect altitude values in millimetre-based projects.
  - Improved altitude-mode detection when map conversion data omits an explicit map unit.
  - KMZ exports now consistently interpret offsets using the project’s actual measurement units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->