### PR TITLE
test(clash): pin the f32-precision-floor boundary exactly, in both kernels

### DIFF
--- a/.changeset/pin-depth-precision-floor-boundary.md
+++ b/.changeset/pin-depth-precision-floor-boundary.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/clash": patch
+---
+
+Pin the `depthClashResult` f32-precision-floor comparison (`<=` at `engine-ts/depth.ts:195`) with a fixture whose box-box MTD lands exactly on the computed floor value, found by mutation testing (flipping the operator killed zero tests — the nearest existing fixtures sit a decade below and well above the boundary). No production logic changed — this is coverage-only, ported 1:1 from the equivalent Rust pin in `rust/clash/src/kernel_tests.rs`.

--- a/packages/clash/src/engine-ts/depth-provenance.test.ts
+++ b/packages/clash/src/engine-ts/depth-provenance.test.ts
@@ -577,6 +577,62 @@ describe('hard-clash distance provenance', () => {
     expect(res.distance).toBe(0);
   });
 
+  it('reports touch, not hard, for a crossing whose MTD lands exactly ON the f32 precision floor (depth.ts:195)', () => {
+    // `depthClashResult` gates on `floorDepth <= precisionFloor(...)`, but no
+    // existing fixture strikes that boundary bit-exactly: the touch/hard
+    // pair above sit a decade below and (via the "genuine crossing" pin in
+    // the paired hard-clash tests) well above it. This one is solved
+    // algebraically to land the z-axis MTD exactly ON `precisionFloor`'s
+    // returned value, so `<=` and a mutated `<` disagree on this fixture and
+    // only this fixture (a "close enough" gap would pass under both). Ported
+    // 1:1 from the Rust pin (`rust/clash/src/kernel_tests.rs`,
+    // `overlap_exactly_at_the_precision_floor_is_touch_not_hard`) so both
+    // kernels carry the same boundary.
+    //
+    // Two boxes crossing at right angles (A long in x, B long in y — a
+    // genuine transversal crossing of their side faces, unlike two boxes
+    // merely STACKED with identical x/y footprints, whose side faces are
+    // parallel and never register as a triangle "crossing" at all, routing
+    // the pair through a branch that never calls `precisionFloor`), thin
+    // (half 0.25) and separated by a tiny gap on z.
+    //
+    // Derivation: `precisionFloor` returns `extent * F32_ULP_SCALE` where
+    // `extent` is the max abs coordinate over both elements' bounds and
+    // `F32_ULP_SCALE = 2^-22`. Pin `extent` to a power of two via A's x-axis
+    // (A spans x = [32, 64], the dominant coordinate over both boxes since B
+    // is thin in x and short in z):
+    //   floor = 64.0 * 2^-22 = 2^-16 = 0.0000152587890625
+    // Both bars are 0.5 thick on z with A centred at z=60.0; B is shifted so
+    // the z overlap (A.max_z - B.min_z — the SAT minimum axis, since the x/y
+    // overlaps are 16.25 each, far larger) equals `floor` exactly:
+    //   B.center_z = A.center_z + 2*halfZ - floor
+    //              = 60.0 + 0.5 - 0.0000152587890625 = 60.4999847412109375
+    // This literal is exactly representable in f32 (60.5 minus an exact
+    // multiple — 4 — of f32's ULP at that magnitude, 2^-18): `boxEl` stores
+    // vertex positions in a `Float32Array`, so it round-trips bit-for-bit,
+    // and `bounds` is passed as the same literal directly (no arithmetic),
+    // matching the Rust fixture's AABB exactly. Verified independently
+    // against JS's own f32 rounding (`Math.fround`) and against the SAT
+    // formula (`rA + rB - dist`) before trusting this fixture.
+    const bZ = 60.499_984_741_210_938; // = Math.fround(60.5 - 2 ** -16), bit-exact
+    expect(Math.fround(bZ)).toBe(bZ);
+    const floor = 64.0 / 4_194_304; // extent(64) * F32_ULP_SCALE
+    expect(floor).toBe(0.0000152587890625);
+    expect(60.25 - (bZ - 0.25)).toBe(floor); // A.max_z - B.min_z === floor, bit-exact
+
+    const a = boxEl('A', 'IfcBeam', [32, -0.25, 59.75], [64, 0.25, 60.25]);
+    const b = boxEl('B', 'IfcBeam', [47.75, -16, bZ - 0.25], [48.25, 16, bZ + 0.25]);
+    const hardOnly: ClashRule = { id: 'r', name: 'r', a: '*', b: '*', mode: 'hard' };
+    const hardRes = testPair(a, new TriMesh(a.positions!, a.indices!), b, new TriMesh(b.positions!, b.indices!), hardOnly, 0.001);
+    expect(hardRes).toBeNull();
+
+    const touchRule: ClashRule = { id: 'r', name: 'r', a: '*', b: '*', mode: 'hard', reportTouch: true };
+    const touchRes = testPair(a, new TriMesh(a.positions!, a.indices!), b, new TriMesh(b.positions!, b.indices!), touchRule, 0.001);
+    if (!touchRes) throw new Error('expected the boundary touch to report');
+    expect(touchRes.status).toBe('touch');
+    expect(touchRes.distance).toBe(0);
+  });
+
   it('reports touch for a CONTAINED non-box pair whose crossing is flush at f32 noise scale, even though its AABB estimate is above the floor', () => {
     // The eight Infra-Bridge pairs (#2536 rebase decision — THE FLOOR WINS):
     // an element authored FLUSH against a surface inside another element's

--- a/rust/clash/src/kernel_tests.rs
+++ b/rust/clash/src/kernel_tests.rs
@@ -342,6 +342,66 @@ fn genuine_small_overlap_above_the_precision_floor_stays_hard() {
 }
 
 #[test]
+fn overlap_exactly_at_the_precision_floor_is_touch_not_hard() {
+    // `depth.rs:207` gates on `floor_depth <= precision_floor(...)`, but no
+    // existing fixture strikes that boundary bit-exactly: the two sibling
+    // tests above sit a decade below and ~7x above it. This one is solved
+    // algebraically to land the z-axis MTD exactly ON `precision_floor`'s
+    // returned value, so `<=` and a mutated `<` disagree on this fixture and
+    // only this fixture (a "close enough" gap would pass under both).
+    //
+    // Same crossing-bars shape as the two sibling fixtures above (needed so
+    // the pair takes the genuine-triangle-crossing path into
+    // `depth_clash_result` — two boxes merely STACKED with identical x/y
+    // footprints have parallel, non-crossing side faces and fall through a
+    // completely different branch of `narrow.rs` that never calls
+    // `precision_floor` at all when the overlap is this far under the
+    // 1 mm tolerance): A is a bar long in x, B a bar long in y, crossing at
+    // right angles over their shared x/y footprint, thin (half 0.25) and
+    // separated by a tiny gap on z.
+    //
+    // Derivation: `precision_floor` returns `extent * F32_ULP_SCALE` where
+    // `extent` is the max abs coordinate over both AABBs and
+    // `F32_ULP_SCALE = 2^-22`. Pin `extent` to a power of two via A's x-axis
+    // (A spans x = [32, 64], the dominant coordinate over both boxes since B
+    // is thin in x and short in z):
+    //   floor = 64.0 * 2^-22 = 2^-16 = 0.0000152587890625
+    // Both bars are 0.5 thick on z with A centred at z=60.0; B is shifted so
+    // the z overlap (A.max_z - B.min_z — the SAT minimum axis, since the x/y
+    // overlaps are 16.25 each, far larger) equals `floor` exactly:
+    //   B.center_z = A.center_z + 2*half_z - floor
+    //              = 60.0 + 0.5 - 0.0000152587890625 = 60.4999847412109375
+    // This literal is exactly representable in f32 (60.5 minus an exact
+    // multiple — 4 — of f32's ULP at that magnitude, 2^-18), so the f32
+    // round-trip through `box_mesh`'s vertex/AABB buffers introduces no
+    // further rounding: computed here in f64 and verified independently
+    // against Rust's own f32 arithmetic (and against the crate's own SAT
+    // formula, `r_a + r_b - dist`) before trusting this fixture.
+    let a = box_mesh([48.0, 0.0, 60.0], [16.0, 0.25, 0.25]);
+    let b = box_mesh([48.0, 0.0, 60.499_984_741_210_938], [0.25, 16.0, 0.25]);
+
+    let floor = 64.0f64 / 4_194_304.0;
+    assert_eq!(floor, 0.0000152587890625, "sanity: the derived floor value");
+
+    let session = session_of(&[a, b]);
+    let hard_only = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);
+    assert!(
+        hard_only.records.is_empty(),
+        "an overlap exactly AT the precision floor must not report as a hard clash, got {:?}",
+        hard_only
+            .records
+            .iter()
+            .map(|r| (r.status, r.distance))
+            .collect::<Vec<_>>()
+    );
+
+    let with_touch = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, true);
+    assert_eq!(with_touch.records.len(), 1, "the boundary touch itself is real information and must still report");
+    assert_eq!(with_touch.records[0].status, ClashStatus::Touch);
+    assert_eq!(with_touch.records[0].distance, 0.0);
+}
+
+#[test]
 fn exact_touch_is_caught_at_tolerance_zero() {
     // The touch band is documented as `<=` precisely so an EXACT face contact at
     // tolerance 0 still reports. Every existing touch test uses a 1 mm tolerance,

--- a/rust/clash/src/kernel_tests.rs
+++ b/rust/clash/src/kernel_tests.rs
@@ -382,6 +382,11 @@ fn overlap_exactly_at_the_precision_floor_is_touch_not_hard() {
 
     let floor = 64.0f64 / 4_194_304.0;
     assert_eq!(floor, 0.0000152587890625, "sanity: the derived floor value");
+    assert_eq!(
+        a.2[5] - b.2[2],
+        floor as f32,
+        "sanity: the generated f32 AABB overlap is exactly the precision floor"
+    );
 
     let session = session_of(&[a, b]);
     let hard_only = session.run_rule(&[0, 1], &[], HARD, 0.001, 0.0, false);


### PR DESCRIPTION
## Summary

`depth.rs:207` and `depth.ts:195` both gate on `floor_depth <= precisionFloor(...)`, but no existing fixture struck that boundary bit-exactly: the nearest siblings sit a decade below and ~7x above it (`sub_precision_floor_crossing_reclassifies_as_touch_not_hard` / `genuine_small_overlap_above_the_precision_floor_stays_hard`). Mutating `<=` to `<` at either site killed 0 tests.

This adds one fixture per kernel — two crossing bars (A long in x, B long in y, genuine transversal triangle crossing) whose z-axis MTD is solved algebraically to land exactly on the computed floor value:

- `extent` pinned to `64.0` via A's x-axis span `[32, 64]`
- `floor = 64.0 * 2^-22 = 2^-16 = 0.0000152587890625`
- B's z-center = `60.0 + 0.5 - 2^-16 = 60.4999847412109375`, exactly representable in f32 (60.5 minus 4 ULPs at that magnitude), so the f32 round-trip through vertex/AABB buffers introduces no further rounding

Verified bit-for-bit equal (`0x3ef0000000000000`) between `floor_depth` and `precisionFloor` in both kernels before trusting the fixture — **both kernels agree on the floor for identical inputs, no divergence found**.

No production logic changed — this is coverage-only, following the precedent of #2820 and #2880.

## Evidence

**Rust** (`cargo test -p ifc-lite-clash`):
- Unmutated: 67 passed, 0 failed (66 baseline on this `upstream/main` SHA — #2880 is not yet merged into it — + 1 new).
- Mutating `<=` -> `<` at `depth.rs:207`: fails exactly `kernel_tests::overlap_exactly_at_the_precision_floor_is_touch_not_hard`, 66 passed / 1 failed.
- Mutation reverted, restored bit-identical to original (`diff` clean).

**TypeScript** (`packages/clash` vitest):
- Unmutated: 402 passed / 1 skipped.
- Mutating `<=` -> `<` at `depth.ts:195`: fails exactly the new test, reporting `distance: -0.0000152587890625` — bit-identical to the Rust floor.
- Mutation reverted.

**Calibration** (known-good mutation to confirm the harness/fixtures are live): dropping the `right` recursion in `Bvh::raycast_node` (`bvh.rs:148`) kills exactly 16 named tests, matching the expected baseline.

## Test plan

- [x] `cargo test -p ifc-lite-clash`: 67 passed, 0 failed
- [x] `cargo clippy -p ifc-lite-clash --all-targets -- -D warnings`: clean
- [x] `pnpm exec vitest run` in `packages/clash`: 402 passed / 1 skipped
- [x] `pnpm run typecheck` in `packages/clash`: OK
- [x] RED/GREEN mutation cycle for both kernels (see above), mutations reverted, diffs clean
- [x] Changeset added for `@ifc-lite/clash` (test-only, patch) — following the #2820 precedent that test-only clash coverage still gets a changeset

Refs #2880, #2820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected precision-boundary classification so overlaps at the f32 precision floor are treated as touches rather than hard clashes.
  * Hard-clash-only evaluations now correctly suppress boundary-touch results.
  * Touch-enabled evaluations report a zero-distance touch at the boundary.

* **Tests**
  * Added regression coverage across TypeScript and Rust implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->