### PR TITLE
fix(parser): resolve IfcElectricalDistributionPoint's inheritance chain

### DIFF
--- a/.changeset/parser-electrical-distribution-point-alias.md
+++ b/.changeset/parser-electrical-distribution-point-alias.md
@@ -1,0 +1,24 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Resolve `IfcElectricalDistributionPoint`'s inheritance chain in the TS parser.
+
+`IfcElectricalDistributionPoint` is deprecated IFC2x3 syntax that no bundled
+schema table (`ENTITIES_IFC2X3`/`IFC4`/`IFC4X3`) carries as a class — none has
+an entry for it at all. `rust/core/src/legacy_entities.rs` handles this by
+name ("IFC2x3 names that have no IFC4x3 enum variant") and resolves it to
+`IfcDistributionElement`. `ifc-schema.ts`'s `ENTITY_NAME_ALIASES` table
+carries a comment claiming it "mirrors `rust/core/src/legacy_entities.rs` so
+the two sides stay in lockstep", but only ported the three IFC4.3 stratum
+leaves — this entity, and 16 other Rust-side legacy names, were never added.
+Of those, only this one is a real gap: the other 16 (`IfcBeamStandardCase`,
+`IfcWindowStyle`, `IfcProxy`, ...) already resolve directly, since they exist
+in `ENTITIES_IFC4`.
+
+Before this change, `getInheritanceChain('IfcElectricalDistributionPoint')`
+returned `[]` in the TS parser while the Rust core resolved the same entity
+name to `IfcDistributionElement` with geometry — a real cross-language
+divergence on a legal (if deprecated) STEP entity. `ENTITY_NAME_ALIASES` now
+carries the same mapping, so `getInheritanceChain` includes
+`IfcDistributionElement` for this class, matching the Rust core.

--- a/packages/parser/src/ifc-schema.ts
+++ b/packages/parser/src/ifc-schema.ts
@@ -42,6 +42,11 @@ const ENTITY_NAME_ALIASES: Record<string, string> = {
     IFCSOLIDSTRATUM: 'IfcGeotechnicalStratum',
     IFCVOIDSTRATUM: 'IfcGeotechnicalStratum',
     IFCWATERSTRATUM: 'IfcGeotechnicalStratum',
+    // IFC2x3 names with no IFC4x3 enum variant in any bundled schema table
+    // (ENTITIES_IFC2X3/IFC4/IFC4X3 all lack them) — mirrors
+    // `rust/core/src/legacy_entities.rs`'s "IFC2x3 names that have no IFC4x3
+    // enum variant" arm, which maps both to `IfcDistributionElement`.
+    IFCELECTRICALDISTRIBUTIONPOINT: 'IfcDistributionElement',
 };
 
 /**

--- a/packages/parser/test/known-type-across-schemas.test.ts
+++ b/packages/parser/test/known-type-across-schemas.test.ts
@@ -21,7 +21,7 @@
 import { describe, it, expect } from 'vitest';
 import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3, IFC_DATA_TYPES } from '@ifc-lite/data';
 import { SCHEMA_REGISTRY, getEntityMetadata } from '../src/generated/schema-registry.js';
-import { isKnownType, normalizeIfcTypeName } from '../src/ifc-schema.js';
+import { isKnownType, normalizeIfcTypeName, getInheritanceChain } from '../src/ifc-schema.js';
 
 /**
  * The six EXPRESS TYPEs the IDS-derived `IFC_DATA_TYPES` table omits but the
@@ -249,5 +249,17 @@ describe('normalizeIfcTypeName across the bundled schema union (#2003)', () => {
     for (const type of ['IfcSolidStratum', 'IfcVoidStratum', 'IfcWaterStratum']) {
       expect(normalizeIfcTypeName(type), type).toBe(type);
     }
+  });
+
+  it('resolves the IFC2X3 leaves rust/core/src/legacy_entities.rs maps but no bundled TS schema carries', () => {
+    // `IfcElectricalDistributionPoint` is real, deprecated IFC2X3 syntax with
+    // no IFC4x3 equivalent in ENTITIES_IFC2X3/IFC4/IFC4X3. The Rust core's
+    // `legacy_entities.rs` resolves it to `IfcDistributionElement` (comment:
+    // "IFC2x3 names that have no IFC4x3 enum variant"). The TS
+    // `ENTITY_NAME_ALIASES` table in `ifc-schema.ts` claims to mirror that
+    // file "so the two sides stay in lockstep", but only carries the three
+    // IFC4.3 stratum leaves -- this class is silently unknown here while the
+    // Rust parser resolves it with geometry.
+    expect(getInheritanceChain('IfcElectricalDistributionPoint')).toContain('IfcDistributionElement');
   });
 });


### PR DESCRIPTION
## Summary

- `packages/parser/src/ifc-schema.ts`'s `ENTITY_NAME_ALIASES` table carries a comment claiming it "mirrors `rust/core/src/legacy_entities.rs` so the two sides stay in lockstep", but only ported 3 of the 20 legacy-name mappings the Rust file declares (the IFC4.3 stratum leaves). Verified by diffing the two tables against the bundled TS schema union: of the remaining 17, 16 already resolve on their own (they exist directly in `ENTITIES_IFC4`), but `IfcElectricalDistributionPoint` does not exist in any bundled TS schema table (`ENTITIES_IFC2X3`/`IFC4`/`IFC4X3`) and had no alias either.
- Before this change: `getInheritanceChain('IfcElectricalDistributionPoint')` returned `[]` in the TS parser, while the Rust core (`legacy_entities.rs`, comment: "IFC2x3 names that have no IFC4x3 enum variant") resolves the same entity name to `IfcDistributionElement` with geometry. A real STEP file using this deprecated-but-legal IFC2x3 entity type would silently get different, worse answers out of the TS parser than out of the Rust core for the same bytes.
- Added the missing alias so the TS side matches the Rust mapping.

## Test plan

- [x] Added a RED test in `packages/parser/test/known-type-across-schemas.test.ts` asserting `getInheritanceChain('IfcElectricalDistributionPoint')` contains `IfcDistributionElement`; failed before the fix (`expected [] to include 'IfcDistributionElement'`), passes after.
- [x] Calibration: reverted the alias locally and re-ran the test — it failed with the same assertion, confirming the test actually pins the new behavior.
- [x] `pnpm exec vitest run test/known-type-across-schemas.test.ts` — 16/16 passed.
- [x] Full `packages/parser` suite run; pre-existing unrelated failures only (missing `@ifc-lite/wasm`/`@ifc-lite/ifcx` build artifacts in this sandboxed environment, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inheritance resolution for the legacy `IfcElectricalDistributionPoint` entity.
  * The entity now correctly resolves to `IfcDistributionElement` instead of returning an empty inheritance chain.

* **Tests**
  * Added coverage to verify correct behavior across supported schema versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->