### PR TITLE
test(project-units): pin untested scale-multiplier shapes

### DIFF
--- a/rust/core/src/project_units/symbols.rs
+++ b/rust/core/src/project_units/symbols.rs
@@ -222,6 +222,17 @@ mod tests {
     }
 
     #[test]
+    fn prefixed_volume_uses_cubed_power() {
+        // A milli cubic-metre must scale by (1e-3)^3, not (1e-3)^1 or (1e-3)^2:
+        // `prefix_power` for CUBIC_METRE is untested at any non-default value
+        // without this, so a regression collapsing the cube to a square (or to
+        // no power at all) would pass every other test in this file.
+        let (sym, scale) = si_unit_symbol_and_scale("CUBIC_METRE", Some("MILLI")).unwrap();
+        assert_eq!(sym, "mm\u{00B3}");
+        assert!((scale - 1e-9).abs() < 1e-24, "expected 1e-9 (cubed), got {scale}");
+    }
+
+    #[test]
     fn bare_square_metre() {
         let (sym, scale) = si_unit_symbol_and_scale("SQUARE_METRE", None).unwrap();
         assert_eq!(sym, "m\u{00B2}");

--- a/rust/core/src/project_units/tests.rs
+++ b/rust/core/src/project_units/tests.rs
@@ -99,6 +99,36 @@ END-ISO-10303-21;
     assert!((a.si_scale - 0.0174532925199433).abs() < 1e-15);
 }
 
+/// `IFCCONVERSIONBASEDUNIT.ConversionFactor` (`IFCMEASUREWITHUNIT`) can express
+/// its ValueComponent against a *prefixed* SI unit, not just the bare SI base
+/// (e.g. a real-world file defining INCH as `25.4` millimetres rather than
+/// `0.0254` metres). `conversion_factor_scale` must fold that prefix in, or
+/// the resolved si_scale is silently off by the prefix factor (1000x here).
+#[test]
+fn conversion_based_unit_folds_prefixed_component_scale() {
+    let ifc = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('guid',$,'Test',$,$,$,$,(#2),#3);
+#3=IFCUNITASSIGNMENT((#10));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#9=IFCMEASUREWITHUNIT(IFCLENGTHMEASURE(25.4),#8);
+#10=IFCCONVERSIONBASEDUNIT(#11,.LENGTHUNIT.,'INCH',#9);
+#11=IFCDIMENSIONALEXPONENTS(1,0,0,0,0,0,0);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let units = units_of(ifc);
+    let len = units.unit_for_measure("IfcLengthMeasure").unwrap();
+    assert_eq!(len.symbol, "in");
+    // 25.4 stated in millimetres -> 0.0254 m, NOT 25.4 m (dropped prefix).
+    assert!((len.si_scale - 0.0254).abs() < 1e-12, "expected 0.0254, got {}", len.si_scale);
+}
+
 #[test]
 fn kilogram_mass_unit() {
     let ifc = r#"ISO-10303-21;


### PR DESCRIPTION
## Summary

Time-boxed mutation-testing sweep of `rust/core/src/project_units/{measure.rs,symbols.rs}` and `mod.rs` (the third file in that directory is `tests.rs`, not `units.rs` — there is no `project_units/units.rs`; the crate-level `src/units.rs` was checked separately and found adequately covered). This follows on from the columnar_index.rs sweep in #2882.

Found two spots where dropping/doubling a scale factor — the exact silent shape that produced today's ~100m and 1000x georeferencing defects — would pass every existing test:

- `si_unit_name`'s `CUBIC_METRE` entry declares `prefix_power: 3` (cube the SI prefix multiplier for a prefixed cubic metre) but no test ever exercised a prefixed `CUBIC_METRE`. Mutating `3` to `2` left the full 154-test `ifc-lite-core --lib` suite green. Added `prefixed_volume_uses_cubed_power`, a MILLI cubic-metre case asserting `(1e-3)^3 = 1e-9`.
- `conversion_factor_scale` (mod.rs) folds an `IFCCONVERSIONBASEDUNIT.ConversionFactor`'s own SI prefix (a real file can state e.g. INCH as `25.4` *millimetres* rather than `0.0254` metres) but no fixture ever declared a prefixed `UnitComponent`. Dropping the fold (`Some(value)` instead of `Some(value * component_scale)`) also left the suite green. Added `conversion_based_unit_folds_prefixed_component_scale`, pinning `si_scale == 0.0254`, not `25.4`.

Both are test-only additions — the underlying logic was already correct in both cases, only the coverage was missing (confirmed RED against the mutated/buggy code, GREEN against the current implementation).

### Other mutations checked, confirmed clean (no test added)
- `symbols.rs` `si_prefix_symbol` / `crate::units::get_si_prefix_multiplier`: all 16 `IfcSIPrefix` values present and spelled correctly in both tables, verified against each other key-by-key.
- `symbols.rs` `superscript`'s `(4..=9)` boundary: mutating to `(4..=8)` kills nothing, but verified this is because the two code branches compute the identical Unicode codepoint for single-digit exponents — not a coverage gap, the branches are genuinely redundant.
- `mod.rs` `conversion_factor_scale`'s `value > 0.0` guard: mutating to `>= 0.0` kills nothing (unpinned boundary, confirmed). Left unfixed — a zero conversion factor collapses the resolved scale to 0, which fails loudly (visibly wrong, not silently plausible), so it's lower priority than the two silent-corruption fixes above; noted here for visibility.
- `measure.rs`: pure string→enum lookup table, no arithmetic/scale logic to mutate; spot-checked entries against `IfcUnitEnum`/`IfcDerivedUnitEnum`, no mismatches found.

Calibration mutation (`SQUARE_METRE` prefix_power 2→3) was run first and confirmed it kills `prefixed_area_uses_squared_power`, ruling out a broken test harness before concluding anything else was unpinned.

Baseline: `cargo test --lib -p ifc-lite-core` = 154 passing at `upstream/main` (`066ca8df9`) — not the 153/155 mentioned as possible baselines; noting the discrepancy for visibility. After the two new tests: 156 passing, 0 failed.

Rust-only test changes — no changeset per repo convention (see `93bab0d21`).

## Test plan
- [x] `cargo test -p ifc-lite-core --lib` — 156 passed, 0 failed
- [x] Both new tests verified RED against the reverted/buggy logic, GREEN against current logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for correctly applying SI prefixes to powered units, such as cubic millimetres.
  * Added validation that conversion-based units preserve prefixed-unit scaling, including inch-to-metre conversion through millimetres.
  * These checks help ensure unit definitions consistently resolve to accurate SI scales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->