### PR TITLE
test(ffi): pin the large-coordinate threshold's exact boundary

### DIFF
--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -144,6 +144,13 @@ fn the_large_coordinate_threshold_is_bracketed_on_both_sides() {
     for (translation, should_shift) in [
         ([LARGE_COORD_THRESHOLD + 0.5, 0.0, 0.0], true),
         ([LARGE_COORD_THRESHOLD - 0.5, 0.0, 0.0], false),
+        // The "untouched" guard is strictly `<`: a translation sitting
+        // exactly on the threshold is NOT `< THRESHOLD`, so it falls through
+        // and shifts, same as anything past it. The two brackets above sit
+        // half a unit off the boundary in either direction, so neither can
+        // tell `<` from `<=` apart — both compile and pass identically
+        // either way. This closes that gap.
+        ([LARGE_COORD_THRESHOLD, 0.0, 0.0], true),
     ] {
         let [tx, ty, tz] = translation;
         let original = processing_result(


### PR DESCRIPTION
## Summary
- `rust/ffi`'s `the_large_coordinate_threshold_is_bracketed_on_both_sides` brackets `LARGE_COORD_THRESHOLD` at ±0.5 (see #2722, which pinned the constant's *value*). That leaves the guard's operator itself — strictly `<` vs `<=` — unpinned: a translation sitting exactly on the threshold is never exercised.
- Mutating `site_tx.abs() < LARGE_COORD_THRESHOLD` (and the `ty`/`tz` copies) to `<=` in `normalize_to_site_local` left the ffi suite green, 11/11 — confirmed by execution.
- Add a third bracket case, `[LARGE_COORD_THRESHOLD, 0.0, 0.0]`, which the strictly-`<` guard must treat as past the threshold (shifted, not left alone). This closes the gap: the same `<=` mutation now fails this test.
- Test-only change; no production code touched. Per 93bab0d21, a Rust-only test change in this crate carries no changeset.

## Test plan
- [x] RED: with `site_tx.abs() < LARGE_COORD_THRESHOLD` mutated to `<=`, `the_large_coordinate_threshold_is_bracketed_on_both_sides` fails (`tx=1000 is past the threshold and must be shifted`).
- [x] GREEN: reverted to `<`, full suite passes — `cargo test -p ifc-lite-ffi` (11/11) and `cargo test -p ifc-lite-ffi --no-default-features` (11/11).
- [x] Calibration mutation (null-check error code 1→9) confirmed the harness kills the expected single test, ruling out a stale/broken build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming translations exactly at the large-coordinate threshold are shifted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->