### PR TITLE
fix(parser): extract grouped RelatingPropertyDefinition instead of dropping the relationship

### DIFF
--- a/.changeset/columnar-parser-grouped-pset-defs.md
+++ b/.changeset/columnar-parser-grouped-pset-defs.md
@@ -1,0 +1,23 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Fix `extractPropertyRelFast` silently dropping `IfcRelDefinesByProperties` relationships whose `RelatingPropertyDefinition` is a grouped `IfcPropertySetDefinitionSet` instead of a single property/quantity set reference.
+
+`RelatingPropertyDefinition` is typed `IfcPropertySetDefinitionSelect`, whose
+second alternative (`IfcPropertySetDefinitionSet`, a `SET [1:?] OF
+IfcPropertySetDefinition`) is schema-legal in both bundled IFC4 and IFC4X3
+schemas and is written as a parenthesised ref list, e.g. `(#20,#21)`, not a
+bare `#20`. The byte-level scanner read this attribute with `readRefId`,
+which only recognises a bare `#id`; on the list form it saw the opening `(`
+instead of `#`, returned `-1`, and the whole relationship was discarded --
+every related object in the `RelatedObjects` set silently lost all
+properties and quantities from that pset group, with no error surfaced.
+
+`extractPropertyRelFast` now reads the attribute with `readRefList`, which
+already accepts both a bare ref and a parenthesised list, and returns
+`relatingDefs: number[]` instead of a single `relatingDef: number`. The two
+other consumers of this shared scanner (`IfcRelAssociatesMaterial` /
+`...Classification` / `...Document`) are unaffected: none of their
+`Relating*` selects admit a SET alternative, so they always see a
+length-1 list.

--- a/packages/parser/src/columnar-parser-relationships.ts
+++ b/packages/parser/src/columnar-parser-relationships.ts
@@ -93,14 +93,29 @@ export function extractRelFast(
 }
 
 /**
- * Extract property rel data: attr[4]=relatedObjects, attr[5]=relatingDef.
+ * Extract property rel data: attr[4]=relatedObjects, attr[5]=relatingDef(s).
  * Numbers only, no TextDecoder.
+ *
+ * attr[5] is read as a ref LIST, not a single ref: it is reused for both
+ * `IfcRelDefinesByProperties.RelatingPropertyDefinition` (typed
+ * `IfcPropertySetDefinitionSelect`, whose second alternative
+ * `IfcPropertySetDefinitionSet` is a `SET [1:?] OF IfcPropertySetDefinition`
+ * and is written as a parenthesised list, e.g. `(#20,#21)`, not `#20`) and
+ * the single-ref `IfcRelAssociates*` selects (`IfcMaterialSelect` /
+ * `IfcClassificationSelect` / `IfcDocumentSelect`, always one ref).
+ * `readRefList` already accepts both a bare `#id` and a `(...)` list, so one
+ * call handles both callers; the single-ref case is a length-1 list. A prior
+ * version used `readRefId` here, which only recognises a bare `#id` — for a
+ * schema-legal grouped `IfcPropertySetDefinitionSet` (`(#20,#21)`) it saw the
+ * list's opening `(` instead of `#`, returned -1, and this function returned
+ * null, silently dropping the WHOLE `IfcRelDefinesByProperties` relationship:
+ * every related object lost all properties/quantities from that pset group.
  */
 export function extractPropertyRelFast(
     buffer: Uint8Array,
     byteOffset: number,
     byteLength: number,
-): { relatedObjects: number[]; relatingDef: number } | null {
+): { relatedObjects: number[]; relatingDefs: number[] } | null {
     const end = byteOffset + byteLength;
     let pos = byteOffset;
 
@@ -115,7 +130,7 @@ export function extractPropertyRelFast(
     while (pos < end && buffer[pos] !== 0x2C) pos++;
     pos++;
 
-    const [relatingDef, _] = readRefId(buffer, pos, end);
-    if (relatingDef < 0 || relatedObjects.length === 0) return null;
-    return { relatedObjects, relatingDef };
+    const [relatingDefs, _] = readRefList(buffer, pos, end);
+    if (relatingDefs.length === 0 || relatedObjects.length === 0) return null;
+    return { relatedObjects, relatingDefs };
 }

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -354,7 +354,7 @@ export class ColumnarParser {
         const associationTargetIds = new Set<number>();
         for (const ref of associationRelRefs) {
             const result = extractPropertyRelFast(uint8Buffer, ref.byteOffset, ref.byteLength);
-            if (result) associationTargetIds.add(result.relatingDef);
+            if (result) for (const id of result.relatingDefs) associationTargetIds.add(id);
         }
 
         // Collect EntityRefs for association targets that aren't already categorised.
@@ -641,23 +641,29 @@ export class ColumnarParser {
             const ref = propertyRelRefs[pi];
             const result = extractPropertyRelFast(uint8Buffer, ref.byteOffset, ref.byteLength);
             if (result) {
-                const { relatedObjects, relatingDef } = result;
+                const { relatedObjects, relatingDefs } = result;
                 totalPropRelObjects += relatedObjects.length;
 
-                for (const objId of relatedObjects) {
-                    relationshipGraphBuilder.addEdge(relatingDef, objId, RelationshipType.DefinesByProperties, ref.expressId);
-                }
-
-                // Build on-demand property/quantity maps using pre-built Sets (O(1) vs binary search)
-                const isPropSet = propertySetIds.has(relatingDef);
-                const isQtySet = !isPropSet && quantitySetIds.has(relatingDef);
-
-                if (isPropSet || isQtySet) {
-                    const targetMap = isPropSet ? onDemandPropertyMap : onDemandQuantityMap;
+                // RelatingPropertyDefinition is IfcPropertySetDefinitionSelect, whose
+                // second alternative (IfcPropertySetDefinitionSet) is a SET of pset/
+                // qset definitions — `relatingDefs` has more than one entry for that
+                // case. Every entry in the group applies to every related object.
+                for (const relatingDef of relatingDefs) {
                     for (const objId of relatedObjects) {
-                        let list = targetMap.get(objId);
-                        if (!list) { list = []; targetMap.set(objId, list); }
-                        list.push(relatingDef);
+                        relationshipGraphBuilder.addEdge(relatingDef, objId, RelationshipType.DefinesByProperties, ref.expressId);
+                    }
+
+                    // Build on-demand property/quantity maps using pre-built Sets (O(1) vs binary search)
+                    const isPropSet = propertySetIds.has(relatingDef);
+                    const isQtySet = !isPropSet && quantitySetIds.has(relatingDef);
+
+                    if (isPropSet || isQtySet) {
+                        const targetMap = isPropSet ? onDemandPropertyMap : onDemandQuantityMap;
+                        for (const objId of relatedObjects) {
+                            let list = targetMap.get(objId);
+                            if (!list) { list = []; targetMap.set(objId, list); }
+                            list.push(relatingDef);
+                        }
                     }
                 }
             }
@@ -683,7 +689,12 @@ export class ColumnarParser {
             const ref = associationRelRefs[i];
             const result = extractPropertyRelFast(uint8Buffer, ref.byteOffset, ref.byteLength);
             if (result) {
-                const { relatedObjects, relatingDef: relatingRef } = result;
+                // IfcRelAssociates{Material,Classification,Document}'s Relating*
+                // selects are always single refs (unlike RelatingPropertyDefinition
+                // above, none of IfcMaterialSelect/IfcClassificationSelect/
+                // IfcDocumentSelect admit a SET alternative) — take the one entry.
+                const { relatedObjects, relatingDefs } = result;
+                const relatingRef = relatingDefs[0];
                 const typeUpper = getTypeUpper(ref.type);
 
                 if (typeUpper === 'IFCRELASSOCIATESCLASSIFICATION') {

--- a/packages/parser/test/columnar-parser-relationships.test.ts
+++ b/packages/parser/test/columnar-parser-relationships.test.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Direct coverage for {@link extractPropertyRelFast}, the byte-level scanner
+ * behind IfcRelDefinesByProperties / IfcRelAssociates{Material,Classification,
+ * Document} extraction. Previously untested.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { extractPropertyRelFast, extractRelFast } from '../src/columnar-parser-relationships.js';
+
+function toBuf(step: string): Uint8Array {
+  return new TextEncoder().encode(step);
+}
+
+describe('extractPropertyRelFast', () => {
+  it('reads a single-ref RelatingPropertyDefinition (the common case)', () => {
+    const buf = toBuf("#1=IFCRELDEFINESBYPROPERTIES('g',$,$,$,(#10,#11),#20);");
+    const r = extractPropertyRelFast(buf, 0, buf.length);
+    expect(r).toEqual({ relatedObjects: [10, 11], relatingDefs: [20] });
+  });
+
+  // RelatingPropertyDefinition is typed IfcPropertySetDefinitionSelect, whose
+  // second alternative IfcPropertySetDefinitionSet is `SET [1:?] OF
+  // IfcPropertySetDefinition` — schema-legal in both IFC4 and IFC4X3 — and is
+  // written as a parenthesised ref list, e.g. `(#20,#21)`, not a bare `#20`.
+  it('reads a grouped (SET-valued) RelatingPropertyDefinition instead of dropping the relationship', () => {
+    const buf = toBuf("#1=IFCRELDEFINESBYPROPERTIES('g',$,$,$,(#10,#11),(#20,#21));");
+    const r = extractPropertyRelFast(buf, 0, buf.length);
+    expect(r).not.toBeNull();
+    expect(r).toEqual({ relatedObjects: [10, 11], relatingDefs: [20, 21] });
+  });
+
+  it('reads a single-ref RelatingMaterial (IfcRelAssociatesMaterial)', () => {
+    const buf = toBuf('#1=IFCRELASSOCIATESMATERIAL($,$,$,$,(#10),#30);');
+    const r = extractPropertyRelFast(buf, 0, buf.length);
+    expect(r).toEqual({ relatedObjects: [10], relatingDefs: [30] });
+  });
+
+  it('returns null when RelatedObjects is empty', () => {
+    const buf = toBuf('#1=IFCRELDEFINESBYPROPERTIES($,$,$,$,(),#20);');
+    expect(extractPropertyRelFast(buf, 0, buf.length)).toBeNull();
+  });
+
+  it('returns null when RelatingPropertyDefinition is absent ($)', () => {
+    const buf = toBuf('#1=IFCRELDEFINESBYPROPERTIES($,$,$,$,(#10),$);');
+    expect(extractPropertyRelFast(buf, 0, buf.length)).toBeNull();
+  });
+});
+
+describe('extractRelFast: IFCRELCONNECTSPORTTOELEMENT / IFCRELCONNECTSPORTS', () => {
+  it('reads the two single-ref ends for IfcRelConnectsPortToElement', () => {
+    const buf = toBuf("#1=IFCRELCONNECTSPORTTOELEMENT('g',$,$,$,#5,#6);");
+    const r = extractRelFast(buf, 0, buf.length, 'IFCRELCONNECTSPORTTOELEMENT');
+    expect(r).toEqual({ relatingObject: 5, relatedObjects: [6] });
+  });
+
+  it('reads RelatingPort/RelatedPort and ignores the optional trailing RealizingElement', () => {
+    const buf = toBuf("#1=IFCRELCONNECTSPORTS('g',$,$,$,#5,#6,#7);");
+    const r = extractRelFast(buf, 0, buf.length, 'IFCRELCONNECTSPORTS');
+    expect(r).toEqual({ relatingObject: 5, relatedObjects: [6] });
+  });
+});
+
+describe('extractRelFast: IFCRELCONTAINEDINSPATIALSTRUCTURE', () => {
+  it('reads RelatedObjects (list) then RelatingObject (single)', () => {
+    const buf = toBuf("#1=IFCRELCONTAINEDINSPATIALSTRUCTURE('g',$,$,$,(#10,#11),#5);");
+    const r = extractRelFast(buf, 0, buf.length, 'IFCRELCONTAINEDINSPATIALSTRUCTURE');
+    expect(r).toEqual({ relatingObject: 5, relatedObjects: [10, 11] });
+  });
+});


### PR DESCRIPTION
## Summary
- `extractPropertyRelFast` (packages/parser/src/columnar-parser-relationships.ts) read `IfcRelDefinesByProperties.RelatingPropertyDefinition` (attr[5]) with `readRefId`, which only recognises a bare `#id`.
- `RelatingPropertyDefinition` is typed `IfcPropertySetDefinitionSelect`, whose second alternative `IfcPropertySetDefinitionSet` (`SET [1:?] OF IfcPropertySetDefinition`) is schema-legal in both bundled IFC4 and IFC4X3 schemas and is written as a parenthesised list, e.g. `(#20,#21)`, not `#20`.
- On that form the scanner saw the list's opening `(` instead of `#`, returned `-1`, and the function returned `null` — silently dropping the WHOLE relationship. Every object in `RelatedObjects` lost all properties/quantities from that pset group, with no error surfaced (absence-as-success).
- Fix: read attr[5] with `readRefList` (already accepts a bare ref or a list) and return `relatingDefs: number[]`. Updated the three call sites in `columnar-parser.ts`. The two `IfcRelAssociates*` (Material/Classification/Document) call sites are unaffected since none of those `Relating*` selects admit a SET alternative — always a length-1 list.

## Test plan
- [x] New `packages/parser/test/columnar-parser-relationships.test.ts` — direct coverage for `extractPropertyRelFast` (single-ref and grouped-SET `RelatingPropertyDefinition`, empty-`RelatedObjects`, null `RelatingPropertyDefinition`) and `extractRelFast` (port branches, contained-in-spatial-structure).
- [x] Confirmed RED against pre-fix code (`git stash` the fix, rerun): the grouped-SET case returned `null` instead of `{ relatedObjects: [10,11], relatingDefs: [20,21] }`.
- [x] Confirmed GREEN after restoring the fix: `npx vitest run test/columnar-parser-relationships.test.ts` → 8/8 passed.
- [x] Full parser suite: 581 passed, 2 skipped; 2 pre-existing failures unrelated to this change (parser-worker-panic-forward, requires an unbuilt `@ifc-lite/wasm`), 6 suites failed to *load* only because sibling packages (`@ifc-lite/pointcloud`, `@ifc-lite/ifcx`) aren't built in this environment — not caused by this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of grouped property-set definitions, ensuring all associated definitions are recognized.
  * Preserved relationship handling for property, material, classification, document, and spatial associations.
  * Prevented relationships from being silently dropped when multiple property definitions are provided.

* **Tests**
  * Added coverage for grouped definitions, missing references, materials, port connections, optional attributes, and spatial relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->