### PR TITLE
fix(viewer): bound the Gantt task-tree walk against a cyclic IfcRelNests chain

### DIFF
--- a/apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts
+++ b/apps/viewer/src/components/viewer/schedule/schedule-utils.test.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { ScheduleExtraction, ScheduleTaskInfo } from '@ifc-lite/parser';
+import { flattenTaskTree } from './schedule-utils.js';
+
+function task(
+  globalId: string,
+  parentGlobalId: string | undefined,
+  childGlobalIds: string[],
+  controllingScheduleGlobalIds: string[] = [],
+): ScheduleTaskInfo {
+  return {
+    expressId: Number(globalId.replace(/\D/g, '')) || 0,
+    globalId,
+    name: `Task ${globalId}`,
+    parentGlobalId,
+    childGlobalIds,
+    controllingScheduleGlobalIds,
+  } as unknown as ScheduleTaskInfo;
+}
+
+describe('flattenTaskTree', () => {
+  it('flattens an ordinary parent/child chain in depth-first order', () => {
+    const root = task('R', undefined, ['A']);
+    const a = task('A', 'R', ['B']);
+    const b = task('B', 'A', []);
+    const data: ScheduleExtraction = { tasks: [root, a, b] } as unknown as ScheduleExtraction;
+
+    const rows = flattenTaskTree(data, new Set(['R', 'A', 'B']));
+
+    assert.deepEqual(rows.map(r => r.task.globalId), ['R', 'A', 'B']);
+    assert.deepEqual(rows.map(r => r.depth), [0, 1, 2]);
+  });
+
+  // #2864's fix bounded a mapped-item cycle with a depth cap + visited set;
+  // this is the same defect class in the Gantt task tree: `childGlobalIds` /
+  // `parentGlobalId` are built straight off the file's `IfcRelNests` graph
+  // (schedule-extractor.ts's Pass 2) with no cycle check, so a task that
+  // nests one of its own ancestors used to recurse `visit()` until the stack
+  // overflowed. This is the RED case pre-fix: `A` (root) nests `B`, `B`
+  // nests `A` right back.
+  it('terminates on a cyclic IfcRelNests chain instead of overflowing the stack', () => {
+    const a = task('A', undefined, ['B']);
+    const b = task('B', 'A', ['A']);
+    const data: ScheduleExtraction = { tasks: [a, b] } as unknown as ScheduleExtraction;
+
+    const rows = flattenTaskTree(data, new Set(['A', 'B']));
+
+    // Each task is placed exactly once, at the depth it was first reached.
+    assert.deepEqual(rows.map(r => r.task.globalId).sort(), ['A', 'B']);
+    assert.equal(rows.find(r => r.task.globalId === 'A')?.depth, 0);
+    assert.equal(rows.find(r => r.task.globalId === 'B')?.depth, 1);
+  });
+
+  it('emits a diamond-nested task once, under the first parent reached', () => {
+    // R nests both A and B; A and B both nest C. Not a cycle, but the same
+    // guard that breaks cycles must not drop or duplicate a legitimately
+    // shared descendant.
+    const root = task('R', undefined, ['A', 'B']);
+    const a = task('A', 'R', ['C']);
+    const b = task('B', 'R', ['C']);
+    const c = task('C', 'A', []);
+    const data: ScheduleExtraction = { tasks: [root, a, b, c] } as unknown as ScheduleExtraction;
+
+    const rows = flattenTaskTree(data, new Set(['R', 'A', 'B', 'C']));
+
+    assert.deepEqual(rows.map(r => r.task.globalId), ['R', 'A', 'C', 'B']);
+  });
+
+  it('does not hang when the schedule filter walks a cyclic subtree', () => {
+    // A nests B, B nests A back; neither carries the filter's schedule id.
+    // `descendantsInSchedule` walks this same cyclic graph to decide
+    // visibility, so it needs its own termination guard.
+    const a = task('A', undefined, ['B'], []);
+    const b = task('B', 'A', ['A'], []);
+    const data: ScheduleExtraction = { tasks: [a, b] } as unknown as ScheduleExtraction;
+
+    const rows = flattenTaskTree(data, new Set(['A', 'B']), 'some-other-schedule');
+
+    assert.deepEqual(rows, []);
+  });
+});

--- a/apps/viewer/src/components/viewer/schedule/schedule-utils.ts
+++ b/apps/viewer/src/components/viewer/schedule/schedule-utils.ts
@@ -19,9 +19,26 @@ export interface FlattenedTask {
 }
 
 /**
+ * Longest `IfcTask --[IfcRelNests]--> IfcTask` parent/child chain either walk
+ * below will follow. `childGlobalIds` / `parentGlobalId` are built straight
+ * from the file's `IfcRelNests` graph (`schedule-extractor.ts`'s Pass 2),
+ * which records every RelatingObject/RelatedObjects pair without checking for
+ * a cycle — nothing in the schema forbids a task nesting its own ancestor. A
+ * generous cap: real work breakdown structures are a handful of levels deep.
+ */
+const MAX_TASK_NEST_DEPTH = 64;
+
+/**
  * Flatten a task tree into the display order used by the Gantt list,
  * honoring the current expanded set. Tasks without parents are treated as
  * roots; each root and its expanded descendants appear in depth-first order.
+ *
+ * `visited` is GLOBAL to one flatten, not path-scoped: a cyclic
+ * `IfcRelNests` chain (task A nests B, B nests A) would otherwise recurse
+ * until the stack overflows, and a legitimate diamond (one task nested under
+ * two parents) would otherwise emit the row twice. A task already placed
+ * keeps its first row and is skipped everywhere else, so the walk is always
+ * finite even on malformed input.
  */
 export function flattenTaskTree(
   data: ScheduleExtraction | null,
@@ -47,7 +64,10 @@ export function flattenTaskTree(
   const roots = data.tasks.filter(t => !t.parentGlobalId);
   const filteredRoots = roots.filter(isVisibleForSchedule);
 
+  const visited = new Set<string>();
   const visit = (task: ScheduleTaskInfo, depth: number) => {
+    if (visited.has(task.globalId) || depth > MAX_TASK_NEST_DEPTH) return;
+    visited.add(task.globalId);
     const hasChildren = task.childGlobalIds.length > 0;
     const isExpanded = expanded.has(task.globalId);
     result.push({ task, depth, hasChildren, expanded: isExpanded });
@@ -65,26 +85,37 @@ export function flattenTaskTree(
   // Tasks that are not reachable through IfcRelNests from any root — append
   // at depth 0 so they're not orphaned. Apply the same predicate so the
   // schedule filter is respected.
-  const seen = new Set(result.map(r => r.task.globalId));
   for (const task of data.tasks) {
-    if (seen.has(task.globalId)) continue;
+    if (visited.has(task.globalId)) continue;
     if (!isVisibleForSchedule(task)) continue;
     result.push({ task, depth: 0, hasChildren: false, expanded: false });
+    visited.add(task.globalId);
   }
 
   return result;
 }
 
+/**
+ * Whether `task` or any `IfcRelNests` descendant is controlled by
+ * `scheduleGid`. `visited` guards a single call's own walk against the same
+ * cyclic `childGlobalIds` graph {@link flattenTaskTree} guards against — each
+ * top-level call gets a fresh set, which is enough: once a task's subtree is
+ * fully explored and found not to contain `scheduleGid`, revisiting it via a
+ * different path can only find the same answer again.
+ */
 function descendantsInSchedule(
   task: ScheduleTaskInfo,
   index: Map<string, ScheduleTaskInfo>,
   scheduleGid: string,
+  visited: Set<string> = new Set(),
 ): boolean {
+  if (visited.has(task.globalId)) return false;
+  visited.add(task.globalId);
   for (const childGid of task.childGlobalIds) {
     const child = index.get(childGid);
     if (!child) continue;
     if (child.controllingScheduleGlobalIds.includes(scheduleGid)) return true;
-    if (descendantsInSchedule(child, index, scheduleGid)) return true;
+    if (descendantsInSchedule(child, index, scheduleGid, visited)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

Part of a sweep for the recursion-over-file-references defect class that produced #2863/#2864 (mapped-item colour chase) — a function recursing over an entity reference read out of the parsed file, bounded only by what the file says, with the file not trusted to be acyclic.

`flattenTaskTree`'s `visit()` and the `descendantsInSchedule()` helper it calls (`apps/viewer/src/components/viewer/schedule/schedule-utils.ts`) recurse over `ScheduleTaskInfo.childGlobalIds`, which is built straight from the file's `IfcRelNests` graph (`packages/parser/src/schedule-extractor.ts`'s Pass 2) with no cycle check — nothing in the schema forbids a task nesting one of its own ancestors. A schedule with such a cycle recursed until the stack overflowed, crashing the Gantt view.

- Added `MAX_TASK_NEST_DEPTH` plus a visited set, matching #2864's shape.
- The set is global to one `flattenTaskTree` call rather than path-scoped: a task already placed keeps its first row and is skipped elsewhere, which both breaks the cycle and stops a legitimate diamond (one task nested under two parents) from being emitted twice.
- `descendantsInSchedule` gets its own per-call visited set, since the schedule filter walks the same cyclic graph independently of `visit()`.

## Test plan

- [x] New `schedule-utils.test.ts`: ordinary parent/child ordering, cyclic-chain termination (RED before the fix: `RangeError: Maximum call stack size exceeded`; GREEN after), diamond dedup (RED before: task emitted twice), and the schedule-filter path through `descendantsInSchedule` (RED before: same stack overflow).
- [x] `pnpm --filter @ifc-lite/viewer... typecheck` passes.
- [x] Confirmed RED against the pre-fix file, then GREEN after restoring the fix, per the checked-out diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented schedule views from freezing or overflowing when tasks contain circular relationships.
  - Prevented duplicate task rows when tasks are connected through multiple nesting paths.
  - Improved handling of orphaned and filtered tasks in complex schedule structures.

- **Tests**
  - Added coverage for nested, cyclic, diamond-shaped, and schedule-filtered task hierarchies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
