### PR TITLE
fix(ifcx): federated composer's inherits precedence matched single-file composer

### DIFF
--- a/.changeset/ifcx-federated-inherit-last-wins.md
+++ b/.changeset/ifcx-federated-inherit-last-wins.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/ifcx": patch
+---
+
+Fix `composeFederated`'s handling of a node with multiple simultaneous `inherits` keys: it resolved conflicting attributes/children with the first-listed inherit winning, while `composeIfcx` (and the buildingSMART IFC5 reference composer) resolve them with the last-listed inherit winning. Given identical input, the two composers previously disagreed on the composed value; `resolveInheritance` in `federated-composition.ts` now matches `composeNode` in `composition.ts`, and own (occurrence-level) attributes still always outrank any inherited value in both.

--- a/packages/ifcx/src/federated-composition.ts
+++ b/packages/ifcx/src/federated-composition.ts
@@ -286,7 +286,22 @@ function resolveInheritance(
   let resolutions = 0;
   let crossLayer = 0;
 
-  // Resolve each inherit reference
+  // Own (occurrence-level) attributes/children always outrank anything
+  // inherited, regardless of inherit order. Snapshot the keys that were
+  // present *before* any inherit is resolved so the loop below can tell
+  // "own opinion" apart from "value left behind by an earlier inherit in
+  // this same loop" -- see the last-listed-wins note below.
+  const ownAttributeKeys = new Set(Object.keys(pre.attributes));
+  const ownChildKeys = new Set(Object.keys(pre.children));
+
+  // Resolve each inherit reference. Composition is USD-style: when a node
+  // has multiple simultaneous `inherits` keys with a conflicting attribute,
+  // the LAST-listed inherit wins (matches composition.ts's composeNode and
+  // the buildingSMART reference composer, AddDataFromPreComposition in
+  // IFC5-development/src/ifcx-core/composition/compose.ts, which applies
+  // `Object.values(input.inherits).forEach(...)` with plain `Map.set`
+  // overwrites). Own attributes/children (captured above) still always
+  // beat any inherited value.
   for (const [, inheritPath] of Object.entries(pre.inherits)) {
     if (!inheritPath) continue;
 
@@ -320,9 +335,11 @@ function resolveInheritance(
     resolutions += subResult.resolutions;
     crossLayer += subResult.crossLayer;
 
-    // Merge inherited data (inherited values are weaker - don't override existing)
+    // Merge inherited data. Own opinions always win; among conflicting
+    // inherits, later-listed overwrites earlier-listed (see comment above
+    // the loop).
     for (const [key, value] of Object.entries(inherited.attributes)) {
-      if (!(key in pre.attributes)) {
+      if (!ownAttributeKeys.has(key)) {
         pre.attributes[key] = value;
         // Track source from inherited node
         const inheritedSource = inherited.attributeSources.get(key);
@@ -333,7 +350,7 @@ function resolveInheritance(
     }
 
     for (const [key, value] of Object.entries(inherited.children)) {
-      if (!(key in pre.children)) {
+      if (!ownChildKeys.has(key)) {
         pre.children[key] = value;
       }
     }

--- a/packages/ifcx/src/inherit-precedence.test.ts
+++ b/packages/ifcx/src/inherit-precedence.test.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pins the precedence rule for multiple simultaneous `inherits` keys on
+ * one node, and asserts composeIfcx (single-file) and composeFederated
+ * (multi-layer) agree on it for the same input.
+ *
+ * Rule: when a node inherits from more than one path and both inherited
+ * paths define the same attribute, the LAST-listed inherit wins. This
+ * matches the buildingSMART reference composer (AddDataFromPreComposition
+ * in IFC5-development/src/ifcx-core/composition/compose.ts), which
+ * resolves `Object.values(input.inherits).forEach(...)` with `Map.set`
+ * overwrites -- later entries win. composition.ts's composeNode already
+ * implemented this; federated-composition.ts's resolveInheritance
+ * previously implemented first-wins instead, so the two composers
+ * disagreed on identical input (composeIfcx -> "B", composeFederated ->
+ * "A"). Own (occurrence-level) attributes must still always beat any
+ * inherited value, from either composer.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { IfcxFile, IfcxNode } from './types.js';
+import { composeIfcx } from './composition.js';
+import { composeFederated } from './federated-composition.js';
+import { createLayerStack } from './layer-stack.js';
+
+function makeFile(data: IfcxNode[], id = 'test'): IfcxFile {
+  return {
+    header: {
+      id,
+      ifcxVersion: 'ifcx-alpha',
+      dataVersion: '1',
+      author: 'test',
+      timestamp: '2026-06-09T00:00:00Z',
+    },
+    imports: [],
+    schemas: {},
+    data,
+  };
+}
+
+// Two base nodes with a conflicting attribute, and a child that inherits
+// from both, in an order where naive first-wins and correct last-wins
+// produce two DIFFERENT, observable results ("A" vs "B").
+const conflictingInheritsNodes: IfcxNode[] = [
+  { path: 'base-a', attributes: { 'test::value': 'A' } },
+  { path: 'base-b', attributes: { 'test::value': 'B' } },
+  {
+    path: 'child',
+    inherits: { first: 'base-a', second: 'base-b' },
+  },
+];
+
+function composeWithFederated(nodes: IfcxNode[]) {
+  const file = makeFile(nodes);
+  const stack = createLayerStack();
+  stack.addLayer(file, new ArrayBuffer(0), 'layer-1');
+  return composeFederated(stack).composed;
+}
+
+describe('inherits precedence agrees across composers', () => {
+  it('composeIfcx resolves multiple inherits with last-listed wins', () => {
+    const composed = composeIfcx(makeFile(conflictingInheritsNodes));
+    assert.strictEqual(composed.get('child')?.attributes.get('test::value'), 'B');
+  });
+
+  it('composeFederated resolves multiple inherits with last-listed wins', () => {
+    const composed = composeWithFederated(conflictingInheritsNodes);
+    assert.strictEqual(composed.get('child')?.attributes.get('test::value'), 'B');
+  });
+
+  it('composeIfcx and composeFederated agree on the same input', () => {
+    const single = composeIfcx(makeFile(conflictingInheritsNodes));
+    const federated = composeWithFederated(conflictingInheritsNodes);
+
+    assert.strictEqual(
+      single.get('child')?.attributes.get('test::value'),
+      federated.get('child')?.attributes.get('test::value')
+    );
+  });
+
+  it("own attributes still beat any inherited value, in both composers", () => {
+    const nodesWithOwnOverride: IfcxNode[] = [
+      ...conflictingInheritsNodes.slice(0, 2),
+      {
+        path: 'child',
+        inherits: { first: 'base-a', second: 'base-b' },
+        attributes: { 'test::value': 'own' },
+      },
+    ];
+
+    const single = composeIfcx(makeFile(nodesWithOwnOverride));
+    const federated = composeWithFederated(nodesWithOwnOverride);
+
+    assert.strictEqual(single.get('child')?.attributes.get('test::value'), 'own');
+    assert.strictEqual(federated.get('child')?.attributes.get('test::value'), 'own');
+  });
+});


### PR DESCRIPTION
## Summary
- `federated-composition.ts`'s `resolveInheritance` resolved a node's multiple simultaneous `inherits` keys with first-listed-wins, while `composition.ts`'s `composeNode` resolves them with last-listed-wins. Given identical input with a conflicting attribute on two inherited paths, `composeIfcx` produced `"B"` and `composeFederated` produced `"A"` for the same node — confirmed with a standalone repro before any fix was written.
- The buildingSMART IFC5 reference composer settles which is correct: `AddDataFromPreComposition` in [`IFC5-development/src/ifcx-core/composition/compose.ts`](https://github.com/buildingSMART/IFC5-development/blob/main/src/ifcx-core/composition/compose.ts) resolves `Object.values(input.inherits).forEach(...)` with plain `Map.set` overwrites in each inherited node's attributes/children — i.e. **later-listed inherits win**. That matches `composition.ts`, not the (buggy) first-wins behavior in `federated-composition.ts`.
- `resolveInheritance` now snapshots the node's own attribute/child keys *before* resolving any inherit, so own (occurrence-level) opinions still always outrank anything inherited, but among multiple inherits the later-listed one now overwrites the earlier-listed one's contribution — matching `composeNode`.
- Adds `inherit-precedence.test.ts`, which pins the agreed last-wins behavior **across both composers on identical input** so this can't silently re-diverge.

## Test plan
- [x] New test file RED against the pre-fix `federated-composition.ts` (verified by temporarily restoring the old file content and rerunning — 2/4 assertions failed with `expected 'A' actual 'B'`), GREEN with the fix.
- [x] Full `packages/ifcx` suite (`npx tsx --test src/*.test.ts`): 123/123 passing, no regressions.
- [x] `npx tsc --noEmit` in `packages/ifcx`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected inheritance precedence when multiple inherited values conflict.
  * Later-listed inherited values now override earlier ones consistently.
  * Node-owned attributes and children continue to take precedence over inherited values.

* **Tests**
  * Added coverage confirming consistent inheritance behavior across composition methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->