### PR TITLE
fix(ifcx): bakeLayers dedupeImports precedence matches mergeSchemas

### DIFF
--- a/.changeset/ifcx-bake-dedupe-imports-last-wins.md
+++ b/.changeset/ifcx-bake-dedupe-imports-last-wins.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/ifcx": patch
+---
+
+Fix `bakeLayers`' `dedupeImports` keeping the weakest layer's import metadata (e.g. a pinned `integrity` hash) for a URI shared across layers, while `mergeSchemas` in the same file resolves same-key conflicts with the strongest (last) layer winning. `dedupeImports` now agrees with `mergeSchemas` and with `composeIfcx`'s layer semantics generally: the strongest layer's import wins.

--- a/packages/ifcx/src/bake.test.ts
+++ b/packages/ifcx/src/bake.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { IfcxFile } from './types.js';
+import { bakeLayers } from './bake.js';
+
+function makeFile(
+  imports: IfcxFile['imports'],
+  schemas: IfcxFile['schemas'],
+  id: string
+): IfcxFile {
+  return {
+    header: {
+      id,
+      ifcxVersion: 'ifcx-alpha',
+      dataVersion: '1',
+      author: 'test',
+      timestamp: '2026-06-09T00:00:00Z',
+    },
+    imports,
+    schemas,
+    data: [{ path: 'x', attributes: { a: 1 } }],
+  };
+}
+
+describe('bakeLayers import/schema merge precedence', () => {
+  it('dedupes imports on the same URI with the strongest (last) layer winning, matching mergeSchemas', () => {
+    // bakeLayers takes layers weakest-first, strongest-last (its own doc
+    // comment). mergeSchemas resolves same-key conflicts with the last
+    // (strongest) layer's value via Object.assign; dedupeImports must
+    // agree for the same URI, not silently keep the first (weakest)
+    // layer's import metadata.
+    const weak = makeFile(
+      [{ uri: 'shared-uri', integrity: 'weak-hash' }],
+      { 'shared-schema': { version: 'weak' } as any },
+      'weak'
+    );
+    const strong = makeFile(
+      [{ uri: 'shared-uri', integrity: 'strong-hash' }],
+      { 'shared-schema': { version: 'strong' } as any },
+      'strong'
+    );
+
+    const baked = bakeLayers([weak, strong]);
+
+    assert.strictEqual(baked.imports.length, 1);
+    assert.strictEqual(baked.imports[0].integrity, 'strong-hash');
+    assert.strictEqual((baked.schemas['shared-schema'] as any).version, 'strong');
+  });
+});

--- a/packages/ifcx/src/bake.ts
+++ b/packages/ifcx/src/bake.ts
@@ -107,10 +107,15 @@ function materializeNode(node: ComposedNode): IfcxNode {
 }
 
 function dedupeImports(layers: IfcxFile[]): ImportNode[] {
+  // `layers` is weakest-first, strongest-last (see bakeLayers' doc comment).
+  // Later occurrences must win so a stronger layer's import metadata (e.g.
+  // a pinned `integrity` hash) overrides a weaker layer's for the same
+  // URI, matching mergeSchemas' Object.assign (later-wins) below and
+  // composeIfcx's layer semantics generally.
   const byUri = new Map<string, ImportNode>();
   for (const layer of layers) {
     for (const imp of layer.imports) {
-      if (!byUri.has(imp.uri)) byUri.set(imp.uri, imp);
+      byUri.set(imp.uri, imp);
     }
   }
   return [...byUri.values()];


### PR DESCRIPTION
## Summary
- `bake.ts`'s `dedupeImports` kept the **first-seen** `ImportNode` per URI (`if (!byUri.has(imp.uri)) byUri.set(...)`), while `mergeSchemas` in the same file resolves same-key conflicts with the **strongest (last)** layer winning via `Object.assign`. `bakeLayers` takes `layers` weakest-first, strongest-last (its own doc comment), so for imports the *weakest* layer's metadata (e.g. a pinned `integrity` hash) survived a bake even when a stronger layer declared the same URI with a different value — an asymmetry inside one file with no comment justifying the difference, introduced in the same original commit.
- Confirmed with a standalone repro: baking a weak layer then a strong layer, both importing the same URI with different `integrity` values, kept the weak layer's hash while the parallel schema-merge test on the same input correctly picked the strong layer's value.
- Fix: `dedupeImports` now unconditionally overwrites on each occurrence, so the strongest (last) layer wins, matching `mergeSchemas`.
- Adds `bake.test.ts` (did not exist before) covering this precedence for both imports and schemas on the same input.

## Test plan
- [x] New test RED against the pre-fix `dedupeImports` (verified by temporarily restoring the old file content and rerunning), GREEN with the fix.
- [x] Full `packages/ifcx` suite: 120/120 passing, no regressions.
- [x] `npx tsc --noEmit` in `packages/ifcx`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated layer baking to retain metadata from the strongest layer when duplicate imports share the same URI.
  * Aligned baked import behavior with schema merging and composition semantics.

* **Tests**
  * Added coverage confirming that stronger-layer integrity and schema metadata are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->