### PR TITLE
test(clash): pin unionBounds/meanPoint per-axis, not just on X

### DIFF
--- a/packages/clash/src/grouping.test.ts
+++ b/packages/clash/src/grouping.test.ts
@@ -221,6 +221,29 @@ describe('groupClashes — aggregates', () => {
     expect(group.bounds.max[0]).toBeCloseTo(1.1, 6);
   });
 
+  /**
+   * Every other bounds/mean fixture in this file offsets members only along
+   * X, leaving Y and Z at 0 with an identical half-extent on every axis — a
+   * per-axis component swap (e.g. `unionBounds`/`meanPoint` reading `a.min[2]`
+   * where it means `a.min[1]`) is invisible there because both axes carry the
+   * same value in every fixture. Giving each member a distinct, non-zero
+   * value on X, Y, *and* Z makes every axis independently checkable.
+   */
+  it('bounds union and mean point are correct per-axis, not just on X', () => {
+    const clashes = [
+      clash({ id: 'c1', a: PIPE, b: BEAM, rule: 'R', point: [0, 2, 10] }),
+      clash({ id: 'c2', a: PIPE, b: BEAM, rule: 'R', point: [4, 6, 30] }),
+    ];
+    const [group] = groupClashes(makeResult(clashes), { by: 'cluster', epsilon: 100 });
+    expect(group.members).toHaveLength(2);
+    expect(group.representativePoint[0]).toBeCloseTo(2, 6);
+    expect(group.representativePoint[1]).toBeCloseTo(4, 6);
+    expect(group.representativePoint[2]).toBeCloseTo(20, 6);
+    // bounds half-size 0.1 around each point.
+    expect(group.bounds.min).toEqual([-0.1, 1.9, 9.9]);
+    expect(group.bounds.max).toEqual([4.1, 6.1, 30.1]);
+  });
+
   it('sorts groups by severity then member count desc', () => {
     const clashes = [
       // major group with 1 member


### PR DESCRIPTION
## Summary

`grouping.test.ts`'s bounds/mean-point fixtures all offset members only along X, leaving Y and Z at 0 with an identical half-extent (0.1) on every axis. A per-axis component swap in `unionBounds` or `meanPoint` (e.g. reading `a.min[2]` where it means `a.min[1]`) is invisible to the existing suite because every fixture carries the same value on Y and Z.

Confirmed by mutation: swapping the Y/Z components in `unionBounds`'s min/max arrays left the entire existing `grouping.test.ts` suite green (23/23 passing).

## Fix

Adds one fixture with a distinct, non-zero value on X, Y, *and* Z per member, so each axis of `unionBounds`/`meanPoint` is independently checkable.

## Test plan
- [x] `pnpm exec vitest run src/grouping.test.ts` — GREEN (24/24) against the real implementation.
- [x] Same suite against the Y/Z-swap mutation in `unionBounds` — RED (new test fails, all others still pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for cluster grouping with distinct three-dimensional coordinates.
  * Verifies accurate representative-point averages and combined bounds across all axes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->