### PR TITLE
fix(ifcx): validateProvenance requires the merge field

### DIFF
--- a/.changeset/ifcx-provenance-require-merge-field.md
+++ b/.changeset/ifcx-provenance-require-merge-field.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/ifcx": patch
+---
+
+Fix `validateProvenance` silently accepting an untrusted manifest that omits the required `merge` field entirely. Per `docs/architecture/layer-prs/03-provenance.md` §3.1 and the `ProvenanceManifest` type (`merge: MergeRecord | null`, not optional), every manifest carries `merge`, as `null` for non-merge layers. The check treated `undefined` the same as `null` and skipped validation, so a manifest missing the key passed with zero errors; it now matches the sibling `base` field's pattern and only exempts a literal `null`.

--- a/packages/ifcx/src/provenance.test.ts
+++ b/packages/ifcx/src/provenance.test.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { validateProvenance } from './provenance.js';
+
+/**
+ * Per docs/architecture/layer-prs/03-provenance.md §3.1, `merge` is a
+ * required manifest field (present as `"merge": null` in the schema
+ * example even for non-merge layers, matching the ProvenanceManifest
+ * type's `merge: MergeRecord | null`, not `merge?:`). An untrusted
+ * manifest that omits the key entirely is malformed, the same way one
+ * that omits `base` is caught below.
+ */
+function validManifestMissingMerge(): Record<string, unknown> {
+  const m: Record<string, unknown> = {
+    v: 1,
+    author: { kind: 'human', principal: 'x' },
+    intent: 'test',
+    created: new Date().toISOString(),
+    base: null,
+    parents: [],
+    scope_claim: [],
+    identity_map: [],
+    checks: [],
+    signatures: [],
+  };
+  // `merge` intentionally absent -- not even `merge: undefined`, the key
+  // itself is missing, as a JSON.parse of a hand-written manifest would do.
+  return m;
+}
+
+describe('validateProvenance', () => {
+  it('rejects a manifest that omits the required `merge` key entirely', () => {
+    const errors = validateProvenance(validManifestMissingMerge());
+    assert.ok(
+      errors.some((e) => e.includes('merge')),
+      `expected a merge-related error, got: ${JSON.stringify(errors)}`
+    );
+  });
+
+  it('still accepts a literal `merge: null` (non-merge layer)', () => {
+    const manifest = { ...validManifestMissingMerge(), merge: null };
+    assert.deepStrictEqual(validateProvenance(manifest), []);
+  });
+
+  it('still rejects a malformed non-null merge object', () => {
+    const manifest = { ...validManifestMissingMerge(), merge: { candidate: 'x' } };
+    assert.ok(validateProvenance(manifest).length > 0);
+  });
+});

--- a/packages/ifcx/src/provenance.ts
+++ b/packages/ifcx/src/provenance.ts
@@ -265,7 +265,12 @@ export function validateProvenance(value: unknown): string[] {
     }
   }
 
-  if (m.merge !== null && m.merge !== undefined) {
+  // `merge` is a required field (ProvenanceManifest.merge: MergeRecord | null,
+  // §3.1's example always carries the key, even as `"merge": null`) -- unlike
+  // the optional ProvenanceInit.merge builder input, an untrusted manifest
+  // that omits the key entirely is malformed, not merely "not a merge layer".
+  // Match the `base` field's pattern above: only a literal `null` is exempt.
+  if (m.merge !== null) {
     const merge = m.merge as Record<string, unknown>;
     if (
       typeof merge !== 'object' ||


### PR DESCRIPTION
## Summary
- `validateProvenance`'s check for the `merge` field was `if (m.merge !== null && m.merge !== undefined)`, which silently skips validation when the key is absent entirely — an untrusted manifest missing `merge` passes with zero errors.
- Per `docs/architecture/layer-prs/03-provenance.md` §3.1, the schema example always carries `"merge": null`, and the `ProvenanceManifest` type declares `merge: MergeRecord | null` (not optional) — the field is required, always present, `null` only for non-merge layers.
- The sibling `base` check a few lines above already gets this right (`if (m.base !== null)`, which treats `undefined` as non-null and correctly fails the type check below it); `merge` now follows the same pattern.
- Confirmed empirically with a standalone repro: `validateProvenance({ ...validManifest, /* merge omitted */ })` returned `[]` before the fix.
- `createProvenanceManifest` always sets `merge` (defaulting to `null`), so no legitimate producer is affected. This closes the gap for untrusted input, e.g. `layer-registry.ts`'s registry push path, which calls `validateProvenance` on arbitrary incoming layer headers.
- Adds `provenance.test.ts`, which did not exist before.

## Test plan
- [x] New tests RED against the pre-fix code (verified by temporarily restoring the old file content and rerunning), GREEN with the fix.
- [x] Full `packages/ifcx` suite: 122/122 passing, no regressions.
- [x] `npx tsc --noEmit` in `packages/ifcx`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provenance validation now rejects manifests missing the required merge field.
  * Explicit `merge: null` values remain valid for non-merge layers.
  * Malformed merge records are correctly rejected.

* **Tests**
  * Added coverage for missing, null, and malformed merge values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->