### PR TITLE
test(clash): strengthen BCF viewpoint camera and coloring assertions

### DIFF
--- a/packages/clash/src/bcf-bridge.test.ts
+++ b/packages/clash/src/bcf-bridge.test.ts
@@ -252,6 +252,44 @@ describe('createBCFFromClashResult', () => {
     expect(vp?.components?.selection?.length).toBeGreaterThan(0);
     expect(vp?.components?.coloring?.length).toBe(2);
     expect(vp?.perspectiveCamera).toBeDefined();
+
+    // Camera must actually frame this group's bounds ([0,0,0]-[4,3,2], center
+    // [2, 1.5, 1]), not some other point (e.g. the origin). Expected numbers
+    // are computed independently here from the documented formula (radius =
+    // 0.5*diagonal, standoff = radius*distanceFactor, direction =
+    // normalize([1, 0.7, 1])) and the viewer(Y-up)->BCF(Z-up) axis mapping
+    // (bcf.x=viewer.x, bcf.y=-viewer.z, bcf.z=viewer.y) documented in
+    // packages/bcf/src/viewpoint.ts, rather than by calling the production
+    // helper, so a bug in that helper can't hide from this assertion.
+    const cam = vp?.perspectiveCamera;
+    expect(cam?.cameraViewPoint.x).toBeCloseTo(6.265886914190135, 6);
+    expect(cam?.cameraViewPoint.y).toBeCloseTo(-5.265886914190135, 6);
+    expect(cam?.cameraViewPoint.z).toBeCloseTo(4.486120839933094, 6);
+    // Direction must point from the camera towards the group's center
+    // ([2, -1, 1.5] in BCF coords), not e.g. towards the origin.
+    const towardCenter = {
+      x: 2 - cam!.cameraViewPoint.x,
+      y: -1 - cam!.cameraViewPoint.y,
+      z: 1.5 - cam!.cameraViewPoint.z,
+    };
+    const towardCenterLen = Math.sqrt(
+      towardCenter.x ** 2 + towardCenter.y ** 2 + towardCenter.z ** 2,
+    );
+    expect(cam?.cameraDirection.x).toBeCloseTo(towardCenter.x / towardCenterLen, 6);
+    expect(cam?.cameraDirection.y).toBeCloseTo(towardCenter.y / towardCenterLen, 6);
+    expect(cam?.cameraDirection.z).toBeCloseTo(towardCenter.z / towardCenterLen, 6);
+
+    // Coloring must map each color to the correct side: red (FFFF3333) to the
+    // 'a' members, orange (FFFFA500) to the 'b' members. group-critical has
+    // c1 = (GUID_A1, GUID_B1) and c2 = (GUID_A1, GUID_B2), so 'a' is the
+    // single guid GUID_A1 and 'b' is {GUID_B1, GUID_B2}. A test that only
+    // checks `coloring.length === 2` cannot see the two colors' guid lists
+    // swapped.
+    const coloring = vp?.components?.coloring ?? [];
+    const red = coloring.find((c) => c.color === 'FFFF3333');
+    const orange = coloring.find((c) => c.color === 'FFFFA500');
+    expect(red?.components.map((c) => c.ifcGuid)).toEqual(['GUID_A1']);
+    expect(orange?.components.map((c) => c.ifcGuid).sort()).toEqual(['GUID_B1', 'GUID_B2']);
   });
 
   it('invokes the snapshot provider per group', async () => {

--- a/packages/clash/src/duplicates.test.ts
+++ b/packages/clash/src/duplicates.test.ts
@@ -1001,7 +1001,29 @@ describe('groupDuplicateSets', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].members).toHaveLength(3);
     expect(groups[0].title).toContain('3 coincident');
+    // Exact title, not just a `toContain` on the count: a mutation that drops
+    // the tag word entirely (e.g. always uses '' instead of `${tag} `) would
+    // still pass a `toContain('3 coincident')` check, since that substring
+    // survives either way. Pin the full string so the tag word is actually
+    // observed.
+    expect(groups[0].title).toBe('3 coincident IfcWall objects');
     expect(groups[0].id).toMatch(/^grp-[0-9a-f]{8}$/);
+  });
+
+  it('drops the type word when a set mixes IFC types (single-tag branch is not the only branch)', () => {
+    // Two IfcWall boxes plus one IfcColumn box, all coincident: the set spans
+    // more than one IFC type, so the title must read "N objects", not claim a
+    // single type. Every other title test in this suite uses same-tag
+    // fixtures (all IfcWall), so the `comp.tags.size === 1 ? tag : ''` branch
+    // that actually produces '' was previously never exercised.
+    const res = findDuplicates([
+      box('a', [0, 0, 0], 0.5, 12, 'IfcWall'),
+      box('b', [0, 0, 0], 0.5, 12, 'IfcWall'),
+      box('c', [0, 0, 0], 0.5, 12, 'IfcColumn'),
+    ]);
+    const groups = groupDuplicateSets(res);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].title).toBe('3 coincident objects');
   });
 
   it('keeps two duplicate sets that stand close together as TWO findings', () => {

--- a/packages/clash/src/duplicates.test.ts
+++ b/packages/clash/src/duplicates.test.ts
@@ -1001,29 +1001,7 @@ describe('groupDuplicateSets', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].members).toHaveLength(3);
     expect(groups[0].title).toContain('3 coincident');
-    // Exact title, not just a `toContain` on the count: a mutation that drops
-    // the tag word entirely (e.g. always uses '' instead of `${tag} `) would
-    // still pass a `toContain('3 coincident')` check, since that substring
-    // survives either way. Pin the full string so the tag word is actually
-    // observed.
-    expect(groups[0].title).toBe('3 coincident IfcWall objects');
     expect(groups[0].id).toMatch(/^grp-[0-9a-f]{8}$/);
-  });
-
-  it('drops the type word when a set mixes IFC types (single-tag branch is not the only branch)', () => {
-    // Two IfcWall boxes plus one IfcColumn box, all coincident: the set spans
-    // more than one IFC type, so the title must read "N objects", not claim a
-    // single type. Every other title test in this suite uses same-tag
-    // fixtures (all IfcWall), so the `comp.tags.size === 1 ? tag : ''` branch
-    // that actually produces '' was previously never exercised.
-    const res = findDuplicates([
-      box('a', [0, 0, 0], 0.5, 12, 'IfcWall'),
-      box('b', [0, 0, 0], 0.5, 12, 'IfcWall'),
-      box('c', [0, 0, 0], 0.5, 12, 'IfcColumn'),
-    ]);
-    const groups = groupDuplicateSets(res);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].title).toBe('3 coincident objects');
   });
 
   it('keeps two duplicate sets that stand close together as TWO findings', () => {


### PR DESCRIPTION
## Summary
- `packages/clash/src/bcf-bridge.test.ts`'s "attaches a framing viewpoint with selection and coloring" test only asserted `coloring.length === 2` and that `perspectiveCamera` was defined/present.
- Mutation testing showed this test could not observe: (1) the two clash-side color/guid assignments being swapped (red mapped to the `b` side, orange to the `a` side), or (2) the camera target being pinned to the world origin instead of the actual group bounds midpoint.
- Both mutations left all 19 tests in the file green. This PR adds assertions computed independently from the documented camera formula and the Y-up/Z-up axis mapping in `packages/bcf/src/viewpoint.ts` (not by calling the production helper), plus explicit per-color guid checks.

## Test plan
- [x] `cd packages/clash && npx vitest run src/bcf-bridge.test.ts` — 19/19 pass on clean code.
- [x] Reapplied the a/b color swap mutation → strengthened test goes RED (`GUID_B1,GUID_B2` vs expected `GUID_A1`).
- [x] Reapplied the camera-target-zeroed mutation → strengthened test goes RED (`4.27` vs expected `6.27`).
- [x] Reverted both mutations → 19/19 pass again.
- [x] `cd packages/clash && npx vitest run` — full package suite: 401 passed, 1 skipped, no regressions.

No production code changed — this is test-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded clash viewpoint validation to confirm camera positioning and direction relative to group bounds and center.
  * Added coverage ensuring red and orange clash colors are assigned to the correct IFC elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->