### PR TITLE
test(clash): pin the exact duplicate-set title, cover the mixed-tag branch

### DIFF
--- a/packages/clash/src/duplicates.test.ts
+++ b/packages/clash/src/duplicates.test.ts
@@ -1001,7 +1001,29 @@ describe('groupDuplicateSets', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].members).toHaveLength(3);
     expect(groups[0].title).toContain('3 coincident');
+    // Exact title, not just a `toContain` on the count: a mutation that drops
+    // the tag word entirely (e.g. always uses '' instead of `${tag} `) would
+    // still pass a `toContain('3 coincident')` check, since that substring
+    // survives either way. Pin the full string so the tag word is actually
+    // observed.
+    expect(groups[0].title).toBe('3 coincident IfcWall objects');
     expect(groups[0].id).toMatch(/^grp-[0-9a-f]{8}$/);
+  });
+
+  it('drops the type word when a set mixes IFC types (single-tag branch is not the only branch)', () => {
+    // Two IfcWall boxes plus one IfcColumn box, all coincident: the set spans
+    // more than one IFC type, so the title must read "N objects", not claim a
+    // single type. Every other title test in this suite uses same-tag
+    // fixtures (all IfcWall), so the `comp.tags.size === 1 ? tag : ''` branch
+    // that actually produces '' was previously never exercised.
+    const res = findDuplicates([
+      box('a', [0, 0, 0], 0.5, 12, 'IfcWall'),
+      box('b', [0, 0, 0], 0.5, 12, 'IfcWall'),
+      box('c', [0, 0, 0], 0.5, 12, 'IfcColumn'),
+    ]);
+    const groups = groupDuplicateSets(res);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].title).toBe('3 coincident objects');
   });
 
   it('keeps two duplicate sets that stand close together as TWO findings', () => {


### PR DESCRIPTION
## Summary
- `groupDuplicateSets` (`packages/clash/src/duplicate-sets.ts`) formats each set's title as `${count} coincident ${tag}objects` where `tag` is the single IFC type name when every member shares one type, or `''` when the set spans more than one type.
- Every existing title assertion used `toContain('N coincident')`, which cannot observe the tag word itself, and every fixture in the suite used a single IFC type (`IfcWall`), so the `''` (mixed-type) branch was never exercised by any test.
- Mutation testing: forcing `tag` to always be `''` left every existing test in `duplicates.test.ts` green (59/59).

## Test plan
- [x] `cd packages/clash && npx vitest run src/duplicates.test.ts` — 60/60 pass on clean code (58 existing behaviors + this PR's 2 new/strengthened assertions).
- [x] Reapplied the `tag = ''` mutation → the strengthened tests go RED (`'3 coincident objects'` vs expected `'3 coincident IfcWall objects'`).
- [x] Reverted the mutation → 60/60 pass again.
- [x] `cd packages/clash && npx vitest run` — full package suite: 402 passed, 1 skipped, no regressions.

No production code changed — this is test-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify duplicate-set titles display IFC types correctly.
  * Confirmed the type is shown for uniform sets and omitted for mixed-type sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->