### PR TITLE
test(ifcx): synthetic hierarchy-builder coverage + new layer-stack suite

### DIFF
--- a/packages/ifcx/src/hierarchy-builder-synthetic.test.ts
+++ b/packages/ifcx/src/hierarchy-builder-synthetic.test.ts
@@ -1,0 +1,278 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Synthetic (non-fixture) coverage for hierarchy-builder.ts.
+ *
+ * hierarchy-builder.test.ts only runs against
+ * tests/models/ifc5/Hello_Wall_hello-wall.ifcx, which is fetched by
+ * `pnpm fixtures` and is absent from a fresh checkout. When absent, that
+ * suite reports 0 tests run wrapped in a `SKIP`-annotated `ok` — a green
+ * result that is not evidence anything executed. These tests build
+ * ComposedNode trees directly so they run everywhere, always, with no
+ * fixture dependency.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { buildHierarchy } from './hierarchy-builder.js';
+import { ATTR } from './types.js';
+import type { ComposedNode } from './types.js';
+
+function node(path: string, classCode?: string, attrs?: Record<string, unknown>): ComposedNode {
+  const attributes = new Map<string, unknown>();
+  if (classCode) {
+    attributes.set(ATTR.CLASS, { code: classCode, uri: `urn:${classCode}` });
+  }
+  for (const [k, v] of Object.entries(attrs ?? {})) {
+    attributes.set(k, v);
+  }
+  return { path, attributes, children: new Map() };
+}
+
+function link(parent: ComposedNode, ...children: ComposedNode[]): void {
+  for (const child of children) {
+    parent.children.set(child.path, child);
+  }
+}
+
+/**
+ * Build a small building: Project -> Site -> Building -> Storey -> Space,
+ * with:
+ *  - wall1: a plain element directly inside the space (normal collectElementIds path)
+ *  - wall2: a plain element directly inside the storey, outside the space
+ *  - rel1: an IfcRelSpaceBoundary2ndLevel child of the space, carrying the
+ *    space-boundary attribute pointing at door1 (the PRIMARY boundary path)
+ *  - fallback1: a child of the space with NO bsi::ifc::class attribute at
+ *    all, but carrying the space-boundary attribute pointing at window1
+ *    (the candidate FALLBACK path under scrutiny)
+ *
+ * door1/window1 are never composed-tree children of anything reachable by
+ * normal traversal — they only exist as pathToId entries, so the only way
+ * either can appear in the output is via collectSpaceBoundaryElementIds.
+ */
+function buildFixture() {
+  const project = node('project', 'IfcProject');
+  const site = node('site', 'IfcSite');
+  const building = node('building', 'IfcBuilding');
+  const storey = node('storey', 'IfcBuildingStorey', { 'bsi::ifc::prop::Elevation': 3 });
+  const space = node('space', 'IfcSpace');
+
+  const wall1 = node('wall1', 'IfcWall');
+  const wall2 = node('wall2', 'IfcWall');
+  const rel1 = node('rel1', 'IfcRelSpaceBoundary2ndLevel', {
+    [ATTR.SPACE_BOUNDARY]: { relatedelement: { ref: 'door1' } },
+  });
+  const fallback1 = node('fallback1', undefined, {
+    [ATTR.SPACE_BOUNDARY]: { relatedelement: { ref: 'window1' } },
+  });
+
+  link(project, site);
+  link(site, building);
+  link(building, storey);
+  link(storey, space, wall2);
+  link(space, wall1, rel1, fallback1);
+
+  const composed = new Map<string, ComposedNode>();
+  for (const n of [project, site, building, storey, space, wall1, wall2, rel1, fallback1]) {
+    composed.set(n.path, n);
+  }
+
+  const pathToId = new Map<string, number>([
+    ['project', 1],
+    ['site', 2],
+    ['building', 3],
+    ['storey', 4],
+    ['space', 5],
+    ['wall1', 10],
+    ['wall2', 11],
+    ['door1', 12],
+    ['window1', 13],
+  ]);
+
+  return { composed, pathToId };
+}
+
+describe('buildHierarchy — synthetic (no fixture required)', () => {
+  it('returns an empty hierarchy when no IfcProject node exists', () => {
+    const composed = new Map<string, ComposedNode>();
+    const pathToId = new Map<string, number>();
+    const hierarchy = buildHierarchy(composed, pathToId);
+
+    assert.strictEqual(hierarchy.project.name, 'Unknown Project');
+    assert.strictEqual(hierarchy.byStorey.size, 0);
+    assert.deepStrictEqual(hierarchy.getPath(1), []);
+    assert.strictEqual(hierarchy.getStoreyByElevation(0), null);
+  });
+
+  it('collects the direct element, the primary space-boundary element, and the fallback space-boundary element into the space', () => {
+    const { composed, pathToId } = buildFixture();
+    const hierarchy = buildHierarchy(composed, pathToId);
+
+    const spaceElements = hierarchy.bySpace.get(5) ?? [];
+    assert.deepStrictEqual(
+      [...spaceElements].sort((a, b) => a - b),
+      [10, 12, 13],
+      'wall1 (direct), door1 (primary boundary rel), window1 (fallback) all present'
+    );
+    assert.strictEqual(hierarchy.getContainingSpace(10), 5);
+    assert.strictEqual(hierarchy.getContainingSpace(12), 5);
+    assert.strictEqual(hierarchy.getContainingSpace(13), 5);
+  });
+
+  it('propagates space elements up through storey/building/site containment', () => {
+    const { composed, pathToId } = buildFixture();
+    const hierarchy = buildHierarchy(composed, pathToId);
+
+    const storeyElements = hierarchy.byStorey.get(4) ?? [];
+    assert.deepStrictEqual(
+      [...storeyElements].sort((a, b) => a - b),
+      [10, 11, 12, 13],
+      'wall2 (direct storey element) plus everything the space contains'
+    );
+    assert.strictEqual(hierarchy.elementToStorey.get(10), 4);
+    assert.strictEqual(hierarchy.elementToStorey.get(13), 4);
+
+    const buildingElements = hierarchy.byBuilding.get(3) ?? [];
+    assert.deepStrictEqual([...buildingElements].sort((a, b) => a - b), [10, 11, 12, 13]);
+
+    const siteElements = hierarchy.bySite.get(2) ?? [];
+    assert.deepStrictEqual([...siteElements].sort((a, b) => a - b), [10, 11, 12, 13]);
+  });
+
+  it('records storey elevation and resolves it by z-coordinate', () => {
+    const { composed, pathToId } = buildFixture();
+    const hierarchy = buildHierarchy(composed, pathToId);
+
+    assert.strictEqual(hierarchy.storeyElevations.get(4), 3);
+    assert.strictEqual(hierarchy.getStoreyByElevation(3), 4);
+  });
+
+  it('getPath returns the root-to-node chain in root-first order for a nested element', () => {
+    const { composed, pathToId } = buildFixture();
+    const hierarchy = buildHierarchy(composed, pathToId);
+
+    const path = hierarchy.getPath(10); // wall1, inside space
+    assert.deepStrictEqual(
+      path.map((n) => n.expressId),
+      [1, 2, 3, 4, 5],
+      'project -> site -> building -> storey -> space, root first'
+    );
+  });
+
+  it('getPath returns the chain up to (and including) the storey for an element that only reaches the storey directly', () => {
+    const { composed, pathToId } = buildFixture();
+    const hierarchy = buildHierarchy(composed, pathToId);
+
+    const path = hierarchy.getPath(11); // wall2, direct storey child
+    assert.deepStrictEqual(path.map((n) => n.expressId), [1, 2, 3, 4]);
+  });
+
+  it('getPath returns an empty array for an element id that is not in the hierarchy', () => {
+    const { composed, pathToId } = buildFixture();
+    const hierarchy = buildHierarchy(composed, pathToId);
+
+    assert.deepStrictEqual(hierarchy.getPath(999), []);
+  });
+
+  it('pushUnique de-duplicates an element two sibling spaces both contribute to the shared storey', () => {
+    // A door shared between two adjoining rooms shows up as a space-boundary
+    // element of BOTH spaces. Each space's own `elements` Set only dedupes
+    // within that one space, so the door legitimately appears once in each
+    // of bySpace(space1) and bySpace(space2). The interesting map is
+    // byStorey: populateMaps folds elements from both spaces into the SAME
+    // storey key, and pushUnique is what stops the door being counted twice
+    // there.
+    const project = node('project', 'IfcProject');
+    const storey = node('storey', 'IfcBuildingStorey');
+    const space1 = node('space1', 'IfcSpace');
+    const space2 = node('space2', 'IfcSpace');
+    const rel1 = node('rel1', 'IfcRelSpaceBoundary', {
+      [ATTR.SPACE_BOUNDARY]: { relatedelement: { ref: 'door' } },
+    });
+    const rel2 = node('rel2', 'IfcRelSpaceBoundary', {
+      [ATTR.SPACE_BOUNDARY]: { relatedelement: { ref: 'door' } },
+    });
+
+    link(project, storey);
+    link(storey, space1, space2);
+    link(space1, rel1);
+    link(space2, rel2);
+
+    const composed = new Map<string, ComposedNode>([
+      ['project', project],
+      ['storey', storey],
+      ['space1', space1],
+      ['space2', space2],
+      ['rel1', rel1],
+      ['rel2', rel2],
+    ]);
+    const pathToId = new Map<string, number>([
+      ['project', 1],
+      ['storey', 2],
+      ['space1', 3],
+      ['space2', 4],
+      ['door', 5],
+    ]);
+
+    const hierarchy = buildHierarchy(composed, pathToId);
+    assert.deepStrictEqual(hierarchy.bySpace.get(3), [5], 'door counted for space1');
+    assert.deepStrictEqual(hierarchy.bySpace.get(4), [5], 'door counted for space2');
+    assert.deepStrictEqual(
+      hierarchy.byStorey.get(2),
+      [5],
+      'door counted exactly once at the storey level despite being contributed by two spaces'
+    );
+  });
+
+  describe('spatial-node construction (name/longName extraction)', () => {
+    it('prefers bsi::ifc::name over Name/TypeName/LongName', () => {
+      const project = node('project', 'IfcProject', {
+        'bsi::ifc::name': 'Direct Name',
+        'bsi::ifc::prop::Name': 'Prop Name',
+        'bsi::ifc::prop::TypeName': 'Type Name',
+        'bsi::ifc::prop::LongName': 'Long Name',
+      });
+      const composed = new Map([['project', project]]);
+      const pathToId = new Map([['project', 1]]);
+      const hierarchy = buildHierarchy(composed, pathToId);
+      assert.strictEqual(hierarchy.project.name, 'Direct Name');
+    });
+
+    it('falls back to prop::Name, then TypeName, then LongName in priority order', () => {
+      const withoutDirect = node('p2', 'IfcProject', {
+        'bsi::ifc::prop::Name': 'Prop Name',
+        'bsi::ifc::prop::TypeName': 'Type Name',
+      });
+      let hierarchy = buildHierarchy(new Map([['p2', withoutDirect]]), new Map([['p2', 1]]));
+      assert.strictEqual(hierarchy.project.name, 'Prop Name');
+
+      const typeOnly = node('p3', 'IfcProject', {
+        'bsi::ifc::prop::TypeName': 'Type Name',
+        'bsi::ifc::prop::LongName': 'Long Name',
+      });
+      hierarchy = buildHierarchy(new Map([['p3', typeOnly]]), new Map([['p3', 1]]));
+      assert.strictEqual(hierarchy.project.name, 'Type Name');
+    });
+
+    it('keeps LongName as a distinct descriptor when it differs from the resolved name', () => {
+      const project = node('project', 'IfcProject', {
+        'bsi::ifc::prop::Name': '01',
+        'bsi::ifc::prop::LongName': 'Main Residence',
+      });
+      const hierarchy = buildHierarchy(new Map([['project', project]]), new Map([['project', 1]]));
+      assert.strictEqual(hierarchy.project.name, '01');
+      assert.strictEqual(hierarchy.project.longName, 'Main Residence');
+    });
+
+    it('drops LongName when it duplicates the resolved name', () => {
+      const project = node('project', 'IfcProject', {
+        'bsi::ifc::prop::Name': 'Main Residence',
+        'bsi::ifc::prop::LongName': 'Main Residence',
+      });
+      const hierarchy = buildHierarchy(new Map([['project', project]]), new Map([['project', 1]]));
+      assert.strictEqual(hierarchy.project.longName, undefined);
+    });
+  });
+});

--- a/packages/ifcx/src/layer-stack.test.ts
+++ b/packages/ifcx/src/layer-stack.test.ts
@@ -1,0 +1,301 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * LayerStack manages an ORDERED array where order is the entire semantics
+ * (strength/precedence in USD-style composition). A fixture with a single
+ * layer, or with layers whose paths never overlap, cannot observe ordering
+ * at all -- every test below uses at least two (usually three) layers that
+ * each carry a node at the SAME path, so ordering, insertion position, and
+ * filtering are all genuinely exercised.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { LayerStack, createLayerStack } from './layer-stack.js';
+import type { IfcxFile, IfcxNode } from './types.js';
+
+function makeFile(nodes: IfcxNode[]): IfcxFile {
+  return {
+    header: {
+      id: 'test',
+      ifcxVersion: '5.0',
+      dataVersion: '1',
+      author: 'test',
+      timestamp: '2026-01-01T00:00:00Z',
+    },
+    imports: [],
+    schemas: {},
+    data: nodes,
+  };
+}
+
+/** A layer whose only node lives at 'wall1', tagged so we can identify which layer's opinion won/appears where. */
+function contestingLayer(tag: string, path = 'wall1'): { file: IfcxFile; buffer: ArrayBuffer } {
+  const file = makeFile([{ path, attributes: { tag } }]);
+  return { file, buffer: new ArrayBuffer(0) };
+}
+
+function addTagged(stack: LayerStack, tag: string, path = 'wall1'): string {
+  const { file, buffer } = contestingLayer(tag, path);
+  return stack.addLayer(file, buffer, tag);
+}
+
+function tags(stack: LayerStack): string[] {
+  return stack.getLayers().map((l) => l.name);
+}
+
+describe('LayerStack — ordering and precedence', () => {
+  it('addLayer inserts new layers at the strongest (index 0) position, not the end', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    addTagged(stack, 'C');
+
+    // C was added last and must be strongest: most-recently-added wins.
+    assert.deepStrictEqual(tags(stack), ['C', 'B', 'A']);
+  });
+
+  it('assigns strength = index after every insert (0 is strongest)', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    addTagged(stack, 'C');
+
+    const strengths = stack.getLayers().map((l) => l.strength);
+    assert.deepStrictEqual(strengths, [0, 1, 2]);
+  });
+
+  it('getNodesForPath returns contesting layers strongest-first for a path every layer defines', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    addTagged(stack, 'C');
+
+    const results = stack.getNodesForPath('wall1');
+    assert.deepStrictEqual(
+      results.map((r) => r.layer.name),
+      ['C', 'B', 'A'],
+      'strongest (most recently added) layer must be listed first'
+    );
+    // Each result actually carries THAT layer's own opinion, not a mixed-up one.
+    assert.deepStrictEqual(
+      results.map((r) => (r.nodes[0].attributes as { tag: string }).tag),
+      ['C', 'B', 'A']
+    );
+  });
+
+  it('addLayerAt splices into the middle of the stack, not onto an end', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A'); // -> [A]
+    addTagged(stack, 'B'); // -> [B, A]
+    const { file, buffer } = contestingLayer('MID');
+    stack.addLayerAt(file, buffer, 'MID', 1); // -> [B, MID, A]
+
+    assert.deepStrictEqual(tags(stack), ['B', 'MID', 'A']);
+    assert.deepStrictEqual(
+      stack.getLayers().map((l) => l.strength),
+      [0, 1, 2]
+    );
+  });
+
+  it('addLayerAt clamps an out-of-range position to the nearest valid slot', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+
+    const { file: f1, buffer: b1 } = contestingLayer('TOO_FAR');
+    stack.addLayerAt(f1, b1, 'TOO_FAR', 999);
+    assert.deepStrictEqual(tags(stack), ['B', 'A', 'TOO_FAR'], 'clamped to the end');
+
+    const { file: f2, buffer: b2 } = contestingLayer('NEGATIVE');
+    stack.addLayerAt(f2, b2, 'NEGATIVE', -5);
+    assert.deepStrictEqual(tags(stack), ['NEGATIVE', 'B', 'A', 'TOO_FAR'], 'clamped to the start');
+  });
+
+  it('moveLayer relocates a layer and renumbers strengths for everyone', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A'); // eventually index 2
+    addTagged(stack, 'B'); // eventually index 1
+    addTagged(stack, 'C'); // eventually index 0
+    // Stack is [C, B, A]. Move A (bottom, weakest) to the top.
+    const aId = stack.getLayers().find((l) => l.name === 'A')!.id;
+    const moved = stack.moveLayer(aId, 0);
+
+    assert.strictEqual(moved, true);
+    assert.deepStrictEqual(tags(stack), ['A', 'C', 'B']);
+    assert.deepStrictEqual(
+      stack.getLayers().map((l) => l.strength),
+      [0, 1, 2]
+    );
+  });
+
+  it('moveLayer clamps the target position within bounds', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    addTagged(stack, 'C'); // [C, B, A]
+    const cId = stack.getLayers().find((l) => l.name === 'C')!.id;
+
+    stack.moveLayer(cId, 999);
+    assert.deepStrictEqual(tags(stack), ['B', 'A', 'C'], 'clamped to the last valid index');
+  });
+
+  it('moveLayer returns false and leaves the stack untouched for an unknown id', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    const before = tags(stack);
+
+    const moved = stack.moveLayer('does-not-exist', 0);
+    assert.strictEqual(moved, false);
+    assert.deepStrictEqual(tags(stack), before);
+  });
+
+  it('removeLayer renumbers the strengths of layers that shift up', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    addTagged(stack, 'C'); // [C, B, A], strengths 0,1,2
+    const bId = stack.getLayers().find((l) => l.name === 'B')!.id;
+
+    const removed = stack.removeLayer(bId);
+    assert.strictEqual(removed, true);
+    assert.deepStrictEqual(tags(stack), ['C', 'A']);
+    assert.deepStrictEqual(
+      stack.getLayers().map((l) => l.strength),
+      [0, 1],
+      'A shifts from strength 2 down to 1 once B is removed'
+    );
+  });
+
+  it('reorderLayers applies exactly the given order, drops omitted ids, and ignores unknown ids', () => {
+    const stack = createLayerStack();
+    const aId = addTagged(stack, 'A');
+    const bId = addTagged(stack, 'B');
+    const cId = addTagged(stack, 'C'); // [C, B, A]
+
+    stack.reorderLayers([aId, cId, 'unknown-id', bId]);
+    // B and C both survive but A must lead per the new order; 'unknown-id' is ignored.
+    assert.deepStrictEqual(tags(stack), ['A', 'C', 'B']);
+    assert.deepStrictEqual(
+      stack.getLayers().map((l) => l.strength),
+      [0, 1, 2]
+    );
+  });
+
+  it('reorderLayers drops any layer id missing from the new order', () => {
+    const stack = createLayerStack();
+    const aId = addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    const cId = addTagged(stack, 'C'); // [C, B, A]
+
+    stack.reorderLayers([cId, aId]); // B omitted
+    assert.deepStrictEqual(tags(stack), ['C', 'A']);
+    assert.strictEqual(stack.count, 2);
+  });
+});
+
+describe('LayerStack — enabled/disabled filtering', () => {
+  it('getEnabledLayers and getNodesForPath skip a disabled middle layer but keep stack order for the rest', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    const bId = addTagged(stack, 'B');
+    addTagged(stack, 'C'); // [C, B, A]
+
+    stack.setLayerEnabled(bId, false);
+
+    assert.deepStrictEqual(
+      stack.getEnabledLayers().map((l) => l.name),
+      ['C', 'A'],
+      'disabled B excluded, C/A order preserved'
+    );
+    assert.deepStrictEqual(
+      stack.getNodesForPath('wall1').map((r) => r.layer.name),
+      ['C', 'A']
+    );
+    // The full (unfiltered) stack still has all three, in original order.
+    assert.deepStrictEqual(tags(stack), ['C', 'B', 'A']);
+  });
+
+  it('toggleLayer flips enabled state each call', () => {
+    const stack = createLayerStack();
+    const aId = addTagged(stack, 'A');
+
+    assert.strictEqual(stack.getLayer(aId)!.enabled, true);
+    stack.toggleLayer(aId);
+    assert.strictEqual(stack.getLayer(aId)!.enabled, false);
+    stack.toggleLayer(aId);
+    assert.strictEqual(stack.getLayer(aId)!.enabled, true);
+  });
+
+  it('hasPath is true only via an enabled layer', () => {
+    const stack = createLayerStack();
+    const aId = addTagged(stack, 'A', 'onlyInA');
+
+    assert.strictEqual(stack.hasPath('onlyInA'), true);
+    stack.setLayerEnabled(aId, false);
+    assert.strictEqual(stack.hasPath('onlyInA'), false);
+  });
+
+  it('getAllPaths unions paths across enabled layers only, deduplicated', () => {
+    const stack = createLayerStack();
+    const aId = addTagged(stack, 'A', 'pathX');
+    addTagged(stack, 'B', 'pathX'); // same path, contests A
+    addTagged(stack, 'C', 'pathY');
+
+    assert.deepStrictEqual([...stack.getAllPaths()].sort(), ['pathX', 'pathY']);
+
+    stack.setLayerEnabled(aId, false);
+    // pathX is still visible via layer B.
+    assert.deepStrictEqual([...stack.getAllPaths()].sort(), ['pathX', 'pathY']);
+  });
+
+  it('getStats counts nodes and unique paths over enabled layers only', () => {
+    const stack = createLayerStack();
+    const aId = addTagged(stack, 'A', 'pathX');
+    addTagged(stack, 'B', 'pathX');
+    addTagged(stack, 'C', 'pathY');
+
+    let stats = stack.getStats();
+    assert.strictEqual(stats.layerCount, 3);
+    assert.strictEqual(stats.enabledCount, 3);
+    assert.strictEqual(stats.totalNodes, 3);
+    assert.strictEqual(stats.uniquePaths, 2);
+
+    stack.setLayerEnabled(aId, false);
+    stats = stack.getStats();
+    assert.strictEqual(stats.layerCount, 3, 'layerCount is unaffected by enabled state');
+    assert.strictEqual(stats.enabledCount, 2);
+    assert.strictEqual(stats.totalNodes, 2);
+    assert.strictEqual(stats.uniquePaths, 2, 'pathX still counted once via layer B');
+  });
+});
+
+describe('LayerStack — basic bookkeeping', () => {
+  it('starts empty', () => {
+    const stack = createLayerStack();
+    assert.strictEqual(stack.isEmpty, true);
+    assert.strictEqual(stack.count, 0);
+  });
+
+  it('clear() empties a populated stack', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    addTagged(stack, 'B');
+    assert.strictEqual(stack.count, 2);
+
+    stack.clear();
+    assert.strictEqual(stack.isEmpty, true);
+    assert.strictEqual(stack.count, 0);
+  });
+
+  it('removeLayer returns false for an unknown id and does not disturb the stack', () => {
+    const stack = createLayerStack();
+    addTagged(stack, 'A');
+    const removed = stack.removeLayer('nope');
+    assert.strictEqual(removed, false);
+    assert.strictEqual(stack.count, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- `hierarchy-builder.test.ts` is the only test for `hierarchy-builder.ts`, and it is entirely gated on `tests/models/ifc5/Hello_Wall_hello-wall.ifcx`, fetched by `pnpm fixtures`. Without that fixture, `node --test` reports the suite as an `ok`-annotated `SKIP` with 0 subtests run. CI's `node-tests` job does fetch fixtures before `pnpm test`, so the gated test runs there, but a fresh/local checkout silently exercises nothing.
- Adds `hierarchy-builder-synthetic.test.ts`: builds `ComposedNode` trees directly (no fixture, no parser) covering `getPath`, `pushUnique` dedup, spatial-node name/longName/elevation extraction, and both space-boundary collection code paths.
- Settles a previously-flagged question about the second `collectSpaceBoundaryElementIds` call in `buildSpatialNode` (the one that fires for a space's non-`IfcRelSpaceBoundary` children): removing it turns two tests red, confirming by execution that it is reachable and load-bearing — it picks up a space-boundary attribute carried on a child node that lacks the `IfcRelSpaceBoundary*` class code.
- `layer-stack.ts` had zero test coverage. Adds `layer-stack.test.ts` with fixtures where every layer genuinely contests the same path, so ordering/precedence/override are actually observable — covering `addLayer`/`addLayerAt` insertion+clamping, `moveLayer`/`removeLayer`/`reorderLayers` renumbering and ordering, and enabled/disabled filtering across `getEnabledLayers`/`getNodesForPath`/`hasPath`/`getAllPaths`/`getStats`.

No production code changed. Every added assertion was verified against a one-line mutation of the corresponding source file (restored afterward, never committed) and confirmed to turn red before being confirmed green again.

## Test plan
- [x] `npx tsx --test src/*.test.ts` in `packages/ifcx` — 150 passed, 0 failed
- [x] `node scripts/typecheck-tests.mjs` (via `packages/ifcx`'s typecheck) — OK
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `npx oxlint` on both new test files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for hierarchy construction, including containment, storey lookup, path resolution, deduplication, and project naming.
  * Added coverage for layer ordering, precedence, insertion, movement, removal, filtering, path queries, statistics, and clearing.
  * Added validation for boundary conditions, unknown identifiers, disabled layers, and duplicate paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->