### PR TITLE
fix(ids): IFC2X3 occurrence/type mapping table and IfcMaterial's own property sets

### DIFF
--- a/.changeset/ifc2x3-entity-mapping-table.md
+++ b/.changeset/ifc2x3-entity-mapping-table.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/ids": patch
+---
+
+Fix an IDS entity facet naming an IFC4-only class (`IfcAirTerminal`, `IfcFilter`, `IfcValve`, …) never matching anything in an IFC2X3 model.
+
+IFC2X3 predates those classes; the same concept there is a generic occurrence class (`IfcFlowTerminal`, `IfcFlowTreatmentDevice`, `IfcFlowController`, …) related to a specific type object (`IfcAirTerminalType`, `IfcFilterType`, `IfcValveType`, …) via `IfcRelDefinesByType`. buildingSMART's IDS spec defines an occurrence/type mapping table so a facet naming the IFC4-only class still matches the equivalent IFC2X3 pair ("the definition of an IDS applicability facet with entity `IfcFilter`, should result in the identification of all `IfcFlowTreatmentDevice` that are associated with a type `IfcFilterType`") — this package implemented no such mapping, so every entity facet using one of the table's 55 aliases against an IFC2X3 model reported zero applicable entities regardless of content. `packages/ids/src/facets/ifc2x3-type-mapping.ts` now carries the table (scoped to IFC2X3 only — IFC4+ already has a dedicated class for every alias), consulted by `checkEntityFacet`, `entityFacetPasses` and the applicability broadphase filter.
+
+Also fix a property facet applied directly to `IfcMaterial` always reporting the property set missing. `IfcMaterialProperties` (IFC4+) / `IfcExtendedMaterialProperties` (IFC2X3) attach property sets straight to the material, not through `IfcRelDefinesByProperties` like every other pset, and `collectAllPropertySets` never read them.
+
+Found via buildingSMART's official IDS conformance corpus (16 test cases added upstream since this repository's #1685 vendoring, re-synced here): all 6 `pass-` cases covering these two gaps previously failed.

--- a/packages/ids/src/__corpus__/buildingsmart-ids/README.md
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/README.md
@@ -1,6 +1,6 @@
 # buildingSMART/IDS Implementer Test Cases
 
-The 318 IDS+IFC pairs in `attribute/`, `classification/`, `entity/`,
+The 334 IDS+IFC pairs in `attribute/`, `classification/`, `entity/`,
 `ids/`, `material/`, `partof/`, `property/`, `restriction/`, `tolerance/`
 are copied verbatim from
 [buildingSMART/IDS](https://github.com/buildingSMART/IDS) under
@@ -33,10 +33,21 @@ whether the IDS FILE is well-formed at all, which is a question for the audit
 rather than the validator — running an `invalid-` case through `validateIDS`
 returns `fail`, a defensible answer to a different question.
 
-`../corpus.test.ts` runs all 318 pairs on that routing, per specification
+`../corpus.test.ts` runs all 334 pairs on that routing, per specification
 rather than per file. Every `pass-` and `fail-` case currently agrees. Of the
 27 `invalid-` cases the audit detects 6; the other 21 are listed in
 `AUDIT_UNDETECTED` in that file, which may only shrink.
+
+The corpus was re-synced from upstream on 2026-08-19, picking up 16 pairs
+added since the original #1685 vendoring: 8 `entity/*type_mapping_table*`
+cases (the IFC2X3 occurrence/type mapping table — an IDS facet naming an
+IFC4-only class like `IfcAirTerminal` must still match the IFC2X3
+`IfcFlowTerminal` + `IfcAirTerminalType` pair that represents it) and 8
+`property/*material_propert*` / `*project_propert*` cases (property facets
+applied directly to `IfcMaterial`, `IfcObject`/`IfcContext`). Both gaps were
+real: this repository failed all 4 `entity/pass-*type_mapping_table*` cases
+and both `property/pass-material_properties_are_supported_*` cases before
+being fixed.
 
 ## Updating
 

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 a user-defined AirTerminal predefined type resolves via the type mapping table 2/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 a user-defined AirTerminal predefined type resolves via the type mapping table 2/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+          <predefinedType>
+            <simpleValue>USERDEFINED</simpleValue>
+          </predefinedType>
+        </entity>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCFLOWTERMINAL('11C92urGj4PQaK1OBBiGCs',$,$,$,$,$,$,$);
+#2=IFCAIRTERMINALTYPE('2UBRzZtXT2PhMBe36A7LGN',$,$,$,$,$,$,$,$,.DIFFUSER.);
+#3=IFCRELDEFINESBYTYPE('2cocz3LlfB0wld0Eq66x$S',$,$,$,(#1),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_2_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_2_2.ids
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 an AirTerminal can be checked by name via the type mapping table 2/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 an AirTerminal can be checked by name via the type mapping table 2/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <attribute>
+          <name>
+            <simpleValue>Name</simpleValue>
+          </name>
+          <value>
+            <xs:restriction base="xs:string">
+              <xs:pattern value="AIR-.*" />
+            </xs:restriction>
+          </value>
+        </attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_2_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_2_2.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCFLOWTERMINAL('0ou5T2oGnBneTBhyUU15ge',$,'TERM-01',$,$,$,$,$);
+#2=IFCAIRTERMINALTYPE('2mzNicYsf4qQh85_dP6ZUE',$,$,$,$,$,$,$,$,$);
+#3=IFCRELDEFINESBYTYPE('1jPWxWbXz9eeG4TL9DC36M',$,$,$,(#1),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 an AirTerminal predefined type resolves via the type mapping table 2/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 an AirTerminal predefined type resolves via the type mapping table 2/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+          <predefinedType>
+            <simpleValue>DIFFUSER</simpleValue>
+          </predefinedType>
+        </entity>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_2_2.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCFLOWTERMINAL('0RpJAGNMLEZQGDhKiGhGk9',$,$,$,$,$,$,$);
+#2=IFCAIRTERMINALTYPE('2007Eo__HFNOQ9boqcYL19',$,$,$,$,$,$,$,$,.GRILLE.);
+#3=IFCRELDEFINESBYTYPE('3IaY0uquH6XPmXmLftbg4a',$,$,$,(#1),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_2_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_2_2.ids
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 there must be an AirTerminal per the type mapping table 2/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 there must be an AirTerminal per the type mapping table 2/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_2_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/fail-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_2_2.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCWALL('1QkUE_XAzDd8m3lpLgR$dB',$,$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 a user-defined AirTerminal predefined type resolves via the type mapping table 1/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 a user-defined AirTerminal predefined type resolves via the type mapping table 1/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+          <predefinedType>
+            <simpleValue>USERDEFINED</simpleValue>
+          </predefinedType>
+        </entity>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_a_user_defined_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCFLOWTERMINAL('277jdYaJL5X85dRV6V8a65',$,$,$,$,$,$,$);
+#2=IFCAIRTERMINALTYPE('0uAOzxwov2_uqEEukcihfd',$,$,$,$,$,$,$,'CUSTOM-VENT',.USERDEFINED.);
+#3=IFCRELDEFINESBYTYPE('2zRJNm_Lv1CRbxflcpRLA0',$,$,$,(#1),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_1_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_1_2.ids
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 an AirTerminal can be checked by name via the type mapping table 1/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 an AirTerminal can be checked by name via the type mapping table 1/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <attribute>
+          <name>
+            <simpleValue>Name</simpleValue>
+          </name>
+          <value>
+            <xs:restriction base="xs:string">
+              <xs:pattern value="AIR-.*" />
+            </xs:restriction>
+          </value>
+        </attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_1_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_can_be_checked_by_name_via_the_type_mapping_table_1_2.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCFLOWTERMINAL('3R4sKXi15AFOaWD52W39Kl',$,'AIR-01',$,$,$,$,$);
+#2=IFCAIRTERMINALTYPE('02YKwvKtL9hQvZRwgYyxYO',$,$,$,$,$,$,$,$,$);
+#3=IFCRELDEFINESBYTYPE('0qjiMjAkj1BQ_6LVIsbeo6',$,$,$,(#1),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 an AirTerminal predefined type resolves via the type mapping table 1/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 an AirTerminal predefined type resolves via the type mapping table 1/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+          <predefinedType>
+            <simpleValue>DIFFUSER</simpleValue>
+          </predefinedType>
+        </entity>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_an_airterminal_predefined_type_resolves_via_the_type_mapping_table_1_2.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCFLOWTERMINAL('3DfdUozX589eoywUhuqpni',$,$,$,$,$,$,$);
+#2=IFCAIRTERMINALTYPE('0CxV3poQjDqf1V11SKqYWT',$,$,$,$,$,$,$,$,.DIFFUSER.);
+#3=IFCRELDEFINESBYTYPE('1iA4ifE7v18vYAHPT$6r$_',$,$,$,(#1),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_1_2.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_1_2.ids
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>In IFC2X3 there must be an AirTerminal per the type mapping table 1/2</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="In IFC2X3 there must be an AirTerminal per the type mapping table 1/2" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCAIRTERMINAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_1_2.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/entity/pass-in_ifc2x3_there_must_be_an_airterminal_per_the_type_mapping_table_1_2.ifc
@@ -1,0 +1,12 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-06T13:03:02',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCFLOWTERMINAL('2150inZ7vCmB5nlH3oCD_7',$,$,$,$,$,$,$);
+#2=IFCAIRTERMINALTYPE('02pWrE7HH2vQZNKrvqSLzl',$,$,$,$,$,$,$,$,$);
+#3=IFCRELDEFINESBYTYPE('2r4tyDB$zCTRafoSuQeTAL',$,$,$,(#1),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc2x3.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc2x3.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Material properties that are absent fail under IFC2X3</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Material properties that are absent fail under IFC2X3" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCMATERIAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc2x3.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc2x3.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+#2=IFCMATERIAL('Concrete');
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc4.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc4.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Material properties that are absent fail under IFC4</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Material properties that are absent fail under IFC4" ifcVersion="IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCMATERIAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc4.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-material_properties_that_are_absent_fail_under_ifc4.ifc
@@ -1,0 +1,11 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+#2=IFCMATERIAL('Concrete',$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc2x3_via_ifcobject.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc2x3_via_ifcobject.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Project properties that are absent fail under IFC2X3 via IfcObject</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Project properties that are absent fail under IFC2X3 via IfcObject" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCPROJECT</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc2x3_via_ifcobject.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc2x3_via_ifcobject.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc4_via_ifccontext.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc4_via_ifccontext.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Project properties that are absent fail under IFC4 via IfcContext</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Project properties that are absent fail under IFC4 via IfcContext" ifcVersion="IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCPROJECT</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc4_via_ifccontext.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/fail-project_properties_that_are_absent_fail_under_ifc4_via_ifccontext.ifc
@@ -1,0 +1,10 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc2x3_via_extendedmaterialproperties.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc2x3_via_extendedmaterialproperties.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Material properties are supported under IFC2X3 via extended material properties</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Material properties are supported under IFC2X3 via extended material properties" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCMATERIAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc2x3_via_extendedmaterialproperties.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc2x3_via_extendedmaterialproperties.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+#2=IFCMATERIAL('Concrete');
+#3=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL('Bar'),$);
+#4=IFCEXTENDEDMATERIALPROPERTIES(#2,(#3),$,'Custom_Pset');
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc4_via_ifcmaterialproperties.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc4_via_ifcmaterialproperties.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Material properties are supported under IFC4 via IfcMaterialProperties</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Material properties are supported under IFC4 via IfcMaterialProperties" ifcVersion="IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCMATERIAL</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc4_via_ifcmaterialproperties.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-material_properties_are_supported_under_ifc4_via_ifcmaterialproperties.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+#2=IFCMATERIAL('Concrete',$,$);
+#3=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL('Bar'),$);
+#4=IFCMATERIALPROPERTIES('Custom_Pset',$,(#3),#2);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc2x3_via_ifcobject.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc2x3_via_ifcobject.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Project properties are supported under IFC2X3 via IfcObject</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Project properties are supported under IFC2X3 via IfcObject" ifcVersion="IFC2X3">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCPROJECT</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc2x3_via_ifcobject.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc2x3_via_ifcobject.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC2X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+#2=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL('Bar'),$);
+#3=IFCPROPERTYSET('03z7JP9zr2w9rkiQlFGgOv',$,'Custom_Pset',$,(#2));
+#4=IFCRELDEFINESBYPROPERTIES('0N9$lcz4H1lgXGBV5jUras',$,$,$,(#1),#3);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc4_via_ifccontext.ids
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc4_via_ifccontext.ids
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info>
+    <title>Project properties are supported under IFC4 via IfcContext</title>
+    <description>Generated via code automation in the Ids Repository on github.</description>
+  </info>
+  <specifications>
+    <specification name="Project properties are supported under IFC4 via IfcContext" ifcVersion="IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity>
+          <name>
+            <simpleValue>IFCPROJECT</simpleValue>
+          </name>
+        </entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLABEL">
+          <propertySet>
+            <simpleValue>Custom_Pset</simpleValue>
+          </propertySet>
+          <baseName>
+            <simpleValue>Foo</simpleValue>
+          </baseName>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>

--- a/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc4_via_ifccontext.ifc
+++ b/packages/ids/src/__corpus__/buildingsmart-ids/property/pass-project_properties_are_supported_under_ifc4_via_ifccontext.ifc
@@ -1,0 +1,13 @@
+ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2026-08-05T11:36:31',(''),(''),'IfcOpenShell 0.8.5-1c5b825','IfcOpenShell 0.8.5-1c5b825','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,'P',$,$,$,$,$,$);
+#2=IFCPROPERTYSINGLEVALUE('Foo',$,IFCLABEL('Bar'),$);
+#3=IFCPROPERTYSET('2L4MWmten4V8zSRSFndPUu',$,'Custom_Pset',$,(#2));
+#4=IFCRELDEFINESBYPROPERTIES('3MNYCUYuD3UQxvKNqSBUpZ',$,$,$,(#1),#3);
+ENDSEC;
+END-ISO-10303-21;

--- a/packages/ids/src/__corpus__/corpus.test.ts
+++ b/packages/ids/src/__corpus__/corpus.test.ts
@@ -68,7 +68,7 @@ const CORPUS_ROOT = join(dirname(fileURLToPath(import.meta.url)), 'buildingsmart
  * exactly the same green as one that checked all 318. Empty input must not
  * score perfect.
  */
-const EXPECTED = { pass: 179, fail: 112, invalid: 27 } as const;
+const EXPECTED = { pass: 187, fail: 120, invalid: 27 } as const;
 const EXPECTED_SPECS_PER_FILE = 1;
 
 type Expectation = keyof typeof EXPECTED;

--- a/packages/ids/src/bridge/data-accessor.ts
+++ b/packages/ids/src/bridge/data-accessor.ts
@@ -174,6 +174,24 @@ export function createDataAccessor(store: IfcDataStore): IFCDataAccessor {
       );
     },
 
+    getSchemaVersion(): string | undefined {
+      return store.schemaVersion;
+    },
+
+    getTypeEntityType(expressId: number): string | undefined {
+      const typeIds =
+        store.relationships?.getRelated?.(
+          expressId,
+          RelationshipType.DefinesByType,
+          'inverse'
+        ) || [];
+      for (const typeId of typeIds) {
+        const t = accessor.getEntityType(typeId);
+        if (t) return t;
+      }
+      return undefined;
+    },
+
     getEntitiesByType(typeName: string): number[] {
       const ids = store.entityIndex?.byType?.get(typeName.toUpperCase());
       return ids ? Array.from(ids) : [];

--- a/packages/ids/src/bridge/properties.ts
+++ b/packages/ids/src/bridge/properties.ts
@@ -9,6 +9,7 @@ import {
   extractTypePropertiesOnDemand,
   extractTypeEntityOwnProperties,
   extractAllEntityAttributes,
+  extractMaterialPropertiesForMaterialId,
   mergeInheritedPropertySets,
 } from '@ifc-lite/parser';
 import { RelationshipType } from '@ifc-lite/data';
@@ -51,6 +52,7 @@ export function collectAllPropertySets(
   appendInstancePropertySets(store, expressId, scale, own);
   appendQuantitySets(store, expressId, own);
   appendPredefinedPropertySets(store, expressId, own);
+  appendMaterialOwnPropertySets(store, expressId, scale, own);
 
   // Merged per property, not per set — see `mergeInheritedPropertySets`.
   const out = mergeInheritedPropertySets(
@@ -163,6 +165,55 @@ function appendPredefinedPropertySets(
       }));
     if (properties.length > 0) out.push({ name: psetNameAttr, properties });
   }
+}
+
+/**
+ * `IfcMaterialProperties` (IFC4+) / `IfcExtendedMaterialProperties`
+ * (IFC2X3) attach property sets directly to an `IfcMaterial`, not
+ * through `IfcRelDefinesByProperties` like every other pset. When the
+ * IDS applicability targets `IfcMaterial` itself (rather than an
+ * element that merely uses one), those material-owned psets are the
+ * ONLY property source available — without this, a property facet on
+ * `IfcMaterial` always reports the pset missing regardless of content.
+ *
+ * Gated on the entity's own type so this never runs for the much more
+ * common "element that has a material" shape; that path goes through
+ * the material facet, not this one.
+ */
+function appendMaterialOwnPropertySets(
+  store: IfcDataStore,
+  expressId: number,
+  scale: number | undefined,
+  out: PropertySetInfo[]
+): void {
+  if (resolveEntityTypeName(store, expressId)?.toUpperCase() !== 'IFCMATERIAL') return;
+
+  const groups = extractMaterialPropertiesForMaterialId(store, expressId);
+  for (const group of groups) {
+    for (const pset of group.psets) {
+      if (out.some((p) => p.name === pset.name)) continue;
+      out.push({
+        name: pset.name,
+        properties: pset.properties.map((p) => projectProperty(p as RawProp, scale)),
+      });
+    }
+  }
+}
+
+/**
+ * Raw IFC type name for an entity, falling back from the columnar
+ * entity table (which only summarises "interesting" types — resource
+ * -level entities like `IfcMaterial` resolve to `'Unknown'` there) to
+ * `entityIndex.byId`. Mirrors `createDataAccessor`'s `getEntityType`;
+ * duplicated rather than threaded through as a parameter because only
+ * this one caller needs a raw type check ahead of the accessor existing.
+ */
+function resolveEntityTypeName(store: IfcDataStore, expressId: number): string | undefined {
+  const fromTable = store.entities?.getTypeName?.(expressId);
+  if (fromTable && fromTable !== 'Unknown') return fromTable;
+  const entry = store.entityIndex?.byId?.get(expressId);
+  if (!entry) return undefined;
+  return typeof entry === 'object' && 'type' in entry ? String((entry as { type: unknown }).type) : undefined;
 }
 
 function inheritedPropertySets(

--- a/packages/ids/src/facets/entity-facet.ts
+++ b/packages/ids/src/facets/entity-facet.ts
@@ -13,9 +13,45 @@ import type {
 } from '../types.js';
 import type { FacetCheckResult } from './index.js';
 import { matchConstraint, formatConstraint } from '../constraints/index.js';
+import { IFC2X3_MAPPED_ALIASES, rowsForOccurrence } from './ifc2x3-type-mapping.js';
 
 /** IFC entity/predefined type comparisons are case-insensitive per IDS spec */
 const IFC_CASE_INSENSITIVE = { caseInsensitive: true } as const;
+
+/**
+ * Does `facet.name` match this entity through buildingSMART's IFC2X3
+ * occurrence/type mapping table, when a direct type-name comparison
+ * already failed?
+ *
+ * "The following table lists all special cases for checking IFC2X3
+ * models['] identification of model subsets is further restricted by
+ * the type object." — an IDS facet naming an IFC4-only class
+ * (`IfcAirTerminal`) must still match the IFC2X3 (occurrence, type)
+ * pair that represents it (`IfcFlowTerminal` typed by
+ * `IfcAirTerminalType`).
+ * https://github.com/buildingSMART/IDS/blob/master/Documentation/ImplementersDocumentation/ifc2x3-occurrence-type-mapping-table.md
+ *
+ * Scoped to IFC2X3: IFC4+ already has a dedicated class for every alias
+ * in the table, so this must not also fire there.
+ */
+function matchesIfc2x3Mapping(
+  facet: IDSEntityFacet,
+  entityType: string,
+  expressId: number,
+  accessor: IFCDataAccessor
+): boolean {
+  if ((accessor.getSchemaVersion?.() || '').toUpperCase() !== 'IFC2X3') return false;
+  const rows = rowsForOccurrence(entityType.toUpperCase());
+  if (rows.length === 0) return false;
+  const typeEntityType = accessor.getTypeEntityType?.(expressId);
+  if (!typeEntityType) return false;
+  const typeEntityUpper = typeEntityType.toUpperCase();
+  for (const row of rows) {
+    if (row.typeEntity !== typeEntityUpper) continue;
+    if (matchConstraint(facet.name, row.alias, IFC_CASE_INSENSITIVE)) return true;
+  }
+  return false;
+}
 
 /**
  * Check if an entity matches an entity facet
@@ -63,7 +99,10 @@ export function checkEntityFacet(
   }
 
   // Check entity type (case-insensitive per IDS spec — IFC entity names are case-agnostic)
-  if (!matchConstraint(facet.name, entityType, IFC_CASE_INSENSITIVE)) {
+  if (
+    !matchConstraint(facet.name, entityType, IFC_CASE_INSENSITIVE) &&
+    !matchesIfc2x3Mapping(facet, entityType, expressId, accessor)
+  ) {
     return {
       passed: false,
       actualValue: entityType,
@@ -181,7 +220,10 @@ export function entityFacetPasses(
     return false;
   }
 
-  if (!matchConstraint(facet.name, entityType, IFC_CASE_INSENSITIVE)) {
+  if (
+    !matchConstraint(facet.name, entityType, IFC_CASE_INSENSITIVE) &&
+    !matchesIfc2x3Mapping(facet, entityType, expressId, accessor)
+  ) {
     return false;
   }
 
@@ -224,13 +266,32 @@ export function filterByEntityFacet(
 ): number[] | undefined {
   const constraint = facet.name;
 
+  // IFC2X3: a literal naming a mapping-table alias (`IFCAIRTERMINAL`)
+  // never appears as an actual entity type in the model — only its
+  // mapped occurrence class does (`IFCFLOWTERMINAL`). A type-indexed
+  // broadphase filter keyed on the alias itself would come back empty
+  // and wrongly prune every candidate before the per-entity check (and
+  // its type-object lookup) ever runs. Falling back to a full scan
+  // keeps `matchesIfc2x3Mapping` as the single source of truth instead
+  // of duplicating its (occurrence, type) resolution here.
+  const isIfc2x3 = (accessor.getSchemaVersion?.() || '').toUpperCase() === 'IFC2X3';
+
   // For simple values, we can efficiently filter by type
   if (constraint.type === 'simpleValue') {
+    if (isIfc2x3 && IFC2X3_MAPPED_ALIASES.has(constraint.value.toUpperCase())) {
+      return undefined;
+    }
     return accessor.getEntitiesByType(constraint.value);
   }
 
   // For enumerations, collect entities of all specified types
   if (constraint.type === 'enumeration') {
+    if (
+      isIfc2x3 &&
+      constraint.values.some((v) => IFC2X3_MAPPED_ALIASES.has(v.toUpperCase()))
+    ) {
+      return undefined;
+    }
     const ids: number[] = [];
     for (const value of constraint.values) {
       ids.push(...accessor.getEntitiesByType(value));

--- a/packages/ids/src/facets/ifc2x3-type-mapping.ts
+++ b/packages/ids/src/facets/ifc2x3-type-mapping.ts
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * buildingSMART's IFC2X3 occurrence/type mapping table.
+ *
+ * IFC2X3 predates several IFC4 entity classes (`IfcAirTerminal`,
+ * `IfcFilter`, `IfcValve`, …). An IFC2X3 model represents those concepts
+ * with a generic occurrence class (`IfcFlowTerminal`, `IfcFlowController`,
+ * …) related to a specific type object (`IfcAirTerminalType`,
+ * `IfcFilterType`, …) via `IfcRelDefinesByType`. The IDS spec defines this
+ * table so an entity facet can name the IFC4-only class and still match
+ * the equivalent IFC2X3 (occurrence, type) pair:
+ *
+ * "The following table lists all special cases for checking IFC2X3
+ * models[.] ... [F]or example, the definition of an IDS applicability
+ * facet with entity `IfcFilter`, should result in the identification of
+ * all `IfcFlowTreatmentDevice` that are associated with a type
+ * `IfcFilterType`."
+ *
+ * Source (CC BY-ND 4.0, (c) buildingSMART International Ltd):
+ * https://github.com/buildingSMART/IDS/blob/master/Documentation/ImplementersDocumentation/ifc2x3-occurrence-type-mapping-table.md
+ *
+ * Scoped to IFC2X3 only — callers must gate on schema version before
+ * consulting this table. IFC4+ already has real classes for every alias
+ * below, so applying the same fallback there would let a facet match an
+ * entity typed by the *old* IFC2X3-style pairing when the model should
+ * have used the dedicated class instead.
+ */
+
+/** One row of the table: an IDS-facet-visible alias mapped to its IFC2X3 (occurrence, type) pair. */
+export interface Ifc2x3TypeMappingRow {
+  /** The entity name an IDS facet may specify (e.g. `IFCAIRTERMINAL`). Uppercase. */
+  alias: string;
+  /** The actual IFC2X3 occurrence class (e.g. `IFCFLOWTERMINAL`). Uppercase. */
+  occurrence: string;
+  /** The IFC2X3 type class the occurrence must be related to (e.g. `IFCAIRTERMINALTYPE`). Uppercase. */
+  typeEntity: string;
+}
+
+const ROWS: readonly Ifc2x3TypeMappingRow[] = [
+  { alias: 'IFCFURNITURE', occurrence: 'IFCFURNISHINGELEMENT', typeEntity: 'IFCFURNITURETYPE' },
+  { alias: 'IFCSYSTEMFURNITUREELEMENT', occurrence: 'IFCFURNISHINGELEMENT', typeEntity: 'IFCSYSTEMFURNITUREELEMENTTYPE' },
+  { alias: 'IFCACTUATOR', occurrence: 'IFCDISTRIBUTIONCONTROLELEMENT', typeEntity: 'IFCACTUATORTYPE' },
+  { alias: 'IFCALARM', occurrence: 'IFCDISTRIBUTIONCONTROLELEMENT', typeEntity: 'IFCALARMTYPE' },
+  { alias: 'IFCCONTROLLER', occurrence: 'IFCDISTRIBUTIONCONTROLELEMENT', typeEntity: 'IFCCONTROLLERTYPE' },
+  { alias: 'IFCFLOWINSTRUMENT', occurrence: 'IFCDISTRIBUTIONCONTROLELEMENT', typeEntity: 'IFCFLOWINSTRUMENTTYPE' },
+  { alias: 'IFCSENSOR', occurrence: 'IFCDISTRIBUTIONCONTROLELEMENT', typeEntity: 'IFCSENSORTYPE' },
+  { alias: 'IFCAIRTOAIRHEATRECOVERY', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCAIRTOAIRHEATRECOVERYTYPE' },
+  { alias: 'IFCBOILER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCBOILERTYPE' },
+  { alias: 'IFCCHILLER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCCHILLERTYPE' },
+  { alias: 'IFCCOIL', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCCOILTYPE' },
+  { alias: 'IFCCONDENSER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCCONDENSERTYPE' },
+  { alias: 'IFCCOOLEDBEAM', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCCOOLEDBEAMTYPE' },
+  { alias: 'IFCCOOLINGTOWER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCCOOLINGTOWERTYPE' },
+  { alias: 'IFCELECTRICGENERATOR', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCELECTRICGENERATORTYPE' },
+  { alias: 'IFCELECTRICMOTOR', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCELECTRICMOTORTYPE' },
+  { alias: 'IFCEVAPORATIVECOOLER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCEVAPORATIVECOOLERTYPE' },
+  { alias: 'IFCEVAPORATOR', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCEVAPORATORTYPE' },
+  { alias: 'IFCHEATEXCHANGER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCHEATEXCHANGERTYPE' },
+  { alias: 'IFCHUMIDIFIER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCHUMIDIFIERTYPE' },
+  { alias: 'IFCMOTORCONNECTION', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCMOTORCONNECTIONTYPE' },
+  { alias: 'IFCSPACEHEATER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCSPACEHEATERTYPE' },
+  { alias: 'IFCTRANSFORMER', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCTRANSFORMERTYPE' },
+  { alias: 'IFCTUBEBUNDLE', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCTUBEBUNDLETYPE' },
+  { alias: 'IFCUNITARYEQUIPMENT', occurrence: 'IFCENERGYCONVERSIONDEVICE', typeEntity: 'IFCUNITARYEQUIPMENTTYPE' },
+  { alias: 'IFCAIRTERMINALBOX', occurrence: 'IFCFLOWCONTROLLER', typeEntity: 'IFCAIRTERMINALBOXTYPE' },
+  { alias: 'IFCDAMPER', occurrence: 'IFCFLOWCONTROLLER', typeEntity: 'IFCDAMPERTYPE' },
+  { alias: 'IFCELECTRICTIMECONTROL', occurrence: 'IFCFLOWCONTROLLER', typeEntity: 'IFCELECTRICTIMECONTROLTYPE' },
+  { alias: 'IFCFLOWMETER', occurrence: 'IFCFLOWCONTROLLER', typeEntity: 'IFCFLOWMETERTYPE' },
+  { alias: 'IFCPROTECTIVEDEVICE', occurrence: 'IFCFLOWCONTROLLER', typeEntity: 'IFCPROTECTIVEDEVICETYPE' },
+  { alias: 'IFCSWITCHINGDEVICE', occurrence: 'IFCFLOWCONTROLLER', typeEntity: 'IFCSWITCHINGDEVICETYPE' },
+  { alias: 'IFCVALVE', occurrence: 'IFCFLOWCONTROLLER', typeEntity: 'IFCVALVETYPE' },
+  { alias: 'IFCCABLECARRIERFITTING', occurrence: 'IFCFLOWFITTING', typeEntity: 'IFCCABLECARRIERFITTINGTYPE' },
+  { alias: 'IFCDUCTFITTING', occurrence: 'IFCFLOWFITTING', typeEntity: 'IFCDUCTFITTINGTYPE' },
+  { alias: 'IFCJUNCTIONBOX', occurrence: 'IFCFLOWFITTING', typeEntity: 'IFCJUNCTIONBOXTYPE' },
+  { alias: 'IFCPIPEFITTING', occurrence: 'IFCFLOWFITTING', typeEntity: 'IFCPIPEFITTINGTYPE' },
+  { alias: 'IFCCOMPRESSOR', occurrence: 'IFCFLOWMOVINGDEVICE', typeEntity: 'IFCCOMPRESSORTYPE' },
+  { alias: 'IFCFAN', occurrence: 'IFCFLOWMOVINGDEVICE', typeEntity: 'IFCFANTYPE' },
+  { alias: 'IFCPUMP', occurrence: 'IFCFLOWMOVINGDEVICE', typeEntity: 'IFCPUMPTYPE' },
+  { alias: 'IFCCABLECARRIERSEGMENT', occurrence: 'IFCFLOWSEGMENT', typeEntity: 'IFCCABLECARRIERSEGMENTTYPE' },
+  { alias: 'IFCCABLESEGMENT', occurrence: 'IFCFLOWSEGMENT', typeEntity: 'IFCCABLESEGMENTTYPE' },
+  { alias: 'IFCDUCTSEGMENT', occurrence: 'IFCFLOWSEGMENT', typeEntity: 'IFCDUCTSEGMENTTYPE' },
+  { alias: 'IFCPIPESEGMENT', occurrence: 'IFCFLOWSEGMENT', typeEntity: 'IFCPIPESEGMENTTYPE' },
+  { alias: 'IFCELECTRICFLOWSTORAGEDEVICE', occurrence: 'IFCFLOWSTORAGEDEVICE', typeEntity: 'IFCELECTRICFLOWSTORAGEDEVICETYPE' },
+  { alias: 'IFCTANK', occurrence: 'IFCFLOWSTORAGEDEVICE', typeEntity: 'IFCTANKTYPE' },
+  { alias: 'IFCAIRTERMINAL', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCAIRTERMINALTYPE' },
+  { alias: 'IFCELECTRICAPPLIANCE', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCELECTRICAPPLIANCETYPE' },
+  { alias: 'IFCFIRESUPPRESSIONTERMINAL', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCFIRESUPPRESSIONTERMINALTYPE' },
+  { alias: 'IFCLAMP', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCLAMPTYPE' },
+  { alias: 'IFCLIGHTFIXTURE', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCLIGHTFIXTURETYPE' },
+  { alias: 'IFCOUTLET', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCOUTLETTYPE' },
+  { alias: 'IFCSANITARYTERMINAL', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCSANITARYTERMINALTYPE' },
+  { alias: 'IFCSTACKTERMINAL', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCSTACKTERMINALTYPE' },
+  { alias: 'IFCWASTETERMINAL', occurrence: 'IFCFLOWTERMINAL', typeEntity: 'IFCWASTETERMINALTYPE' },
+  { alias: 'IFCDUCTSILENCER', occurrence: 'IFCFLOWTREATMENTDEVICE', typeEntity: 'IFCDUCTSILENCERTYPE' },
+  { alias: 'IFCFILTER', occurrence: 'IFCFLOWTREATMENTDEVICE', typeEntity: 'IFCFILTERTYPE' },
+  { alias: 'IFCVIBRATIONISOLATOR', occurrence: 'IFCEQUIPMENTELEMENT', typeEntity: 'IFCVIBRATIONISOLATORTYPE' },
+];
+
+/** Rows indexed by occurrence class, for the (entityType, typeEntityType) → alias direction. */
+const BY_OCCURRENCE: ReadonlyMap<string, readonly Ifc2x3TypeMappingRow[]> = (() => {
+  const map = new Map<string, Ifc2x3TypeMappingRow[]>();
+  for (const row of ROWS) {
+    const list = map.get(row.occurrence);
+    if (list) list.push(row);
+    else map.set(row.occurrence, [row]);
+  }
+  return map;
+})();
+
+/** Every alias name any row maps to — used for the applicability broadphase. */
+export const IFC2X3_MAPPED_ALIASES: ReadonlySet<string> = new Set(ROWS.map((r) => r.alias));
+
+/**
+ * Rows whose occurrence class is `occurrenceType` (already uppercase),
+ * or an empty array when nothing in the table maps to it.
+ */
+export function rowsForOccurrence(occurrenceType: string): readonly Ifc2x3TypeMappingRow[] {
+  return BY_OCCURRENCE.get(occurrenceType) ?? [];
+}
+
+/** The row whose alias is `alias` (already uppercase), if any. */
+export function rowForAlias(alias: string): Ifc2x3TypeMappingRow | undefined {
+  return ROWS.find((r) => r.alias === alias);
+}

--- a/packages/ids/src/types.ts
+++ b/packages/ids/src/types.ts
@@ -494,6 +494,22 @@ export interface IFCDataAccessor {
    * type is unknown so callers fall back to permissive comparison.
    */
   getAttributeXsdTypes?(expressId: number, attrName: string): readonly string[] | undefined;
+  /**
+   * The model's raw IFC schema version string (e.g. `IFC2X3`, `IFC4`),
+   * when the accessor's backing store carries one. Used only for
+   * schema-scoped facet semantics — currently the IFC2X3
+   * occurrence/type mapping table (`facets/ifc2x3-type-mapping.ts`).
+   */
+  getSchemaVersion?(): string | undefined;
+  /**
+   * The IFC entity class of the type object (`IfcXxxType`) this
+   * instance is related to via `IfcRelDefinesByType`, if any. Distinct
+   * from `getPredefinedTypeRaw`, which reads the type's
+   * `PredefinedType` *value*, not the type object's own entity class
+   * name — needed to resolve the IFC2X3 occurrence/type mapping table,
+   * where the alias is picked out by the TYPE's class, not its value.
+   */
+  getTypeEntityType?(expressId: number): string | undefined;
   /** Get all entity IDs of a specific type */
   getEntitiesByType(typeName: string): number[];
   /** Get all entity IDs */

--- a/packages/ids/src/validation/validator.ts
+++ b/packages/ids/src/validation/validator.ts
@@ -117,6 +117,15 @@ export function createCachedAccessor(accessor: IFCDataAccessor): IFCDataAccessor
       accessor.getAncestors!(id, rel as PartOfRelation)
     ) as IFCDataAccessor['getAncestors'];
   }
+  if (accessor.getSchemaVersion) {
+    // Model-wide, not per-entity — compute once and hand back the
+    // same value forever for this accessor's lifetime.
+    const schemaVersion = accessor.getSchemaVersion();
+    cached.getSchemaVersion = () => schemaVersion;
+  }
+  if (accessor.getTypeEntityType) {
+    cached.getTypeEntityType = memoById((id) => accessor.getTypeEntityType!(id));
+  }
 
   return cached;
 }


### PR DESCRIPTION
## Conformance check against buildingSMART's IDS spec

Per [buildingSMART/IDS](https://github.com/buildingSMART/IDS)'s own vendoring instructions in `packages/ids/src/__corpus__/buildingsmart-ids/README.md`, re-synced the corpus:

```bash
cd /tmp && git clone --depth 1 https://github.com/buildingSMART/IDS.git IDS-bsi
cp -r IDS-bsi/Documentation/ImplementersDocumentation/TestCases/* packages/ids/src/__corpus__/buildingsmart-ids/
```

This picked up **16 pairs added upstream since #1685's original vendoring** (318 → 334). Running the existing `corpus.test.ts` harness against them found **6 of the 8 new `pass-` cases failing** — two real, distinct conformance gaps.

## Defect 1: the IFC2X3 occurrence/type mapping table was not implemented

IFC2X3 predates several IFC4-only classes (`IfcAirTerminal`, `IfcFilter`, `IfcValve`, …). An IFC2X3 model represents those with a generic occurrence class (`IfcFlowTerminal`, `IfcFlowController`, …) related to a specific type object (`IfcAirTerminalType`, `IfcFilterType`, …) via `IfcRelDefinesByType`. buildingSMART's spec ([ifc2x3-occurrence-type-mapping-table.md](https://github.com/buildingSMART/IDS/blob/master/Documentation/ImplementersDocumentation/ifc2x3-occurrence-type-mapping-table.md)) defines a 55-row table so an IDS facet naming the IFC4-only class still matches:

> "the definition of an IDS applicability facet with entity `IfcFilter`, should result in the identification of all `IfcFlowTreatmentDevice` that are associated with a type `IfcFilterType`."

This package implemented no such mapping — `checkEntityFacet` compared the facet name directly against the actual entity type, so every one of the table's 55 aliases matched **zero** entities in an IFC2X3 model regardless of content.

**Fix**: `packages/ids/src/facets/ifc2x3-type-mapping.ts` carries the table (transcribed verbatim from the spec doc, scoped to IFC2X3 only — IFC4+ already has a dedicated class for every alias, so the fallback must not also fire there). Consulted by `checkEntityFacet`, `entityFacetPasses`, and the applicability broadphase filter (`filterByEntityFacet`, which needed its own fix — a type-indexed lookup keyed on the alias itself always comes back empty, since the alias never appears as an actual entity type).

New accessor methods: `getSchemaVersion()` and `getTypeEntityType()` (the type object's own IFC class via `IfcRelDefinesByType`), both optional and both memoized in `createCachedAccessor`.

**RED**: reverted `entity-facet.ts` to `main`, ran the 8 new entity/ cases — 4 of the 4 `pass-*type_mapping_table*` cases failed (`applicableCount: 0`, `status: 'fail'` — cardinality defaults `minOccurs` to 1).
**GREEN**: restored the fix, all 8 pass.

## Defect 2: a property facet on `IfcMaterial` itself always reported the pset missing

`IfcMaterialProperties` (IFC4+) / `IfcExtendedMaterialProperties` (IFC2X3) attach property sets directly to an `IfcMaterial`, not through `IfcRelDefinesByProperties` like every other pset. `collectAllPropertySets` never read them, so a property facet whose applicability targets `IfcMaterial` directly (as opposed to an element that merely uses one — that path goes through the material facet) always failed regardless of content.

**Fix**: `appendMaterialOwnPropertySets` in `packages/ids/src/bridge/properties.ts`, gated on the entity's own type being `IFCMATERIAL`, using the parser's existing `extractMaterialPropertiesForMaterialId`.

**RED**: reverted `properties.ts` to `main`, ran the 8 new property/ cases — both `pass-material_properties_are_supported_*` cases failed; the 2 `project_properties_*` cases (via `IfcObject`/`IfcContext`) already passed, no change needed there.
**GREEN**: restored the fix, all 8 pass.

## Verification

- `pnpm --filter @ifc-lite/ids test`: 667 tests pass (was 651; +16 corpus subtests), 18 files.
- `pnpm --filter @ifc-lite/ids run typecheck`: clean.
- `pnpm --filter @ifc-lite/ids exec tsc`: clean build.
- `turbo run typecheck --filter=@ifc-lite/ids --filter=@ifc-lite/mcp --filter=@ifc-lite/cli`: clean (both packages construct `IFCDataAccessor` only via the bridge's `createDataAccessor`, so the two new optional accessor methods needed no changes there).
- `node scripts/check-source-text-assertions.mjs` / `check-test-wiring.mjs`: clean.
- `corpus.test.ts`'s `EXPECTED` counts move from `{pass: 179, fail: 112}` to `{pass: 187, fail: 120}` for the 334-pair corpus.

## Scope note

Per #2802, this does not touch CI wiring — the corpus already runs as part of `packages/ids`'s normal test suite via #2800; that decision is unchanged here.

No client, partner, or commercial-relationship references.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IFC2X3 entity validation, including occurrence/type aliases and predefined types.
  * Corrected IFC2X3 applicability filtering for mapped entity aliases.
  * Added support for properties directly attached to `IfcMaterial` entities.
  * Improved validation across IFC2X3 and IFC4 material and project property scenarios.

* **Tests**
  * Expanded the conformance corpus from 318 to 334 test pairs.
  * Added coverage for IFC2X3 entity mappings and material/property validation cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->