### PR TITLE
test(bcf): pin IDS-reporter camera direction, not just its unit length

### DIFF
--- a/.changeset/ids-reporter-camera-direction-test-gap.md
+++ b/.changeset/ids-reporter-camera-direction-test-gap.md
@@ -1,0 +1,20 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Harden the IDS→BCF reporter's camera-direction test so a sign-flipped viewpoint camera can't pass silently.
+
+`computeCameraFromBounds` (`ids-reporter.ts`) places the BCF viewpoint camera
+off-center and points it back at the failing entity. The only test covering
+that direction, `should point camera toward entity center`, checked just
+`Math.sqrt(x²+y²+z²) ≈ 1` — true for *any* unit vector, including one
+pointing the camera at empty space away from the entity. Reversing the
+`dx/dy/dz` sign in `computeCameraFromBounds` (camera looking away from the
+entity instead of at it) left all 48 `ids-reporter.test.ts` tests green.
+
+The test now asserts `cameraDirection` equals the normalized vector from the
+(converted) camera position to the (converted) entity center, so a reversed
+sign fails. No production code changed — `computeCameraFromBounds` already
+computes the correct direction; this closes the fixture gap that couldn't
+have caught a regression there. Confirmed by mutation: reversing the sign in
+`computeCameraFromBounds` now fails the new assertion; reverting restores 48/48.

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -589,6 +589,11 @@ describe('IDS BCF Reporter', () => {
     });
 
     it('should point camera toward entity center', () => {
+      // A unit-length check alone can't tell "toward" from "away" — both are
+      // unit vectors. Assert the direction actually equals the normalized
+      // vector from the (converted) camera position to the (converted)
+      // entity center; a sign-flipped direction would point the camera at
+      // empty space with every prior assertion here still green.
       const report = createMockReport();
       const bounds = new Map<string, EntityBoundsInput>();
       bounds.set('model-1:100', {
@@ -598,14 +603,21 @@ describe('IDS BCF Reporter', () => {
       const project = createBCFFromIDSReport(report, { entityBounds: bounds });
 
       const cam = [...project.topics.values()][0].viewpoints[0].perspectiveCamera!;
-      // Camera direction vector should have non-zero components
-      const dirLen = Math.sqrt(
-        cam.cameraDirection.x ** 2 +
-        cam.cameraDirection.y ** 2 +
-        cam.cameraDirection.z ** 2,
-      );
-      // Should be unit vector (approximately 1)
-      expect(dirLen).toBeCloseTo(1, 3);
+
+      // Entity center in viewer coords is (1,1,1); converted to BCF Z-up
+      // (x, -z, y) per computeCameraFromBounds' documented convention.
+      const bcfCenter = { x: 1, y: -1, z: 1 };
+      const toCenter = {
+        x: bcfCenter.x - cam.cameraViewPoint.x,
+        y: bcfCenter.y - cam.cameraViewPoint.y,
+        z: bcfCenter.z - cam.cameraViewPoint.z,
+      };
+      const toCenterLen = Math.sqrt(toCenter.x ** 2 + toCenter.y ** 2 + toCenter.z ** 2);
+      expect(toCenterLen).toBeGreaterThan(0);
+
+      expect(cam.cameraDirection.x).toBeCloseTo(toCenter.x / toCenterLen, 5);
+      expect(cam.cameraDirection.y).toBeCloseTo(toCenter.y / toCenterLen, 5);
+      expect(cam.cameraDirection.z).toBeCloseTo(toCenter.z / toCenterLen, 5);
     });
 
     it('should position camera away from entity center', () => {


### PR DESCRIPTION
## Summary

- `computeCameraFromBounds` (`packages/bcf/src/ids-reporter.ts`) places the IDS→BCF viewpoint camera off-center and points it back at the failing entity.
- The only test covering that direction, `should point camera toward entity center`, asserted `sqrt(x²+y²+z²) ≈ 1` — true for **any** unit vector, including one pointing the camera away from the entity into empty space.
- Proof: reversing the `dx/dy/dz` sign in `computeCameraFromBounds` (camera facing away from the entity instead of at it) left all 48 `ids-reporter.test.ts` tests green.
- No production code changed — `computeCameraFromBounds` already computes the correct direction (dot product with the true toward-center vector is ~0.99, verified separately against a real third-party BCF file for the shared coordinate-conversion convention). This closes a fixture gap that could not have caught a regression here, the same shape flagged elsewhere in today's BCF audit.

## Test plan

- [x] `cameraDirection` is now asserted equal to `normalize(bcfCenter - cameraViewPoint)`, computed independently in the test from the same bounds.
- [x] RED: reversed the sign in `computeCameraFromBounds`, confirmed the new assertion failed (`expected 0.609... to be close to -0.609...`).
- [x] GREEN: reverted the mutation, confirmed 48/48 `ids-reporter.test.ts` tests pass.
- [x] Full `packages/bcf` suite: 178/178 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of camera direction calculations to detect incorrectly oriented viewpoints.
* **Tests**
  * Strengthened camera-direction coverage by verifying that cameras point toward entity centers.
* **Release**
  * Documented a patch release for the camera-direction test improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->