### PR TITLE
test(merge): strengthen delete-vs-modify golden fixtures to check conflict content

### DIFF
--- a/packages/merge/src/three-way.test.ts
+++ b/packages/merge/src/three-way.test.ts
@@ -136,7 +136,15 @@ describe('three-way decision matrix', () => {
     });
     expect(plan.autoOps).toEqual([]);
     expect(plan.conflicts).toHaveLength(1);
-    expect(plan.conflicts[0].kind).toBe('delete-vs-modify');
+    const conflict = plan.conflicts[0];
+    expect(conflict.kind).toBe('delete-vs-modify');
+    expect(conflict.path).toBe('wall-1');
+    // The conflict must record theirs' actual edit and ours' pre-tombstone
+    // state on the correct sides — swapping them would be unobservable if
+    // only `kind` were asserted.
+    expect(conflict.theirs?.attributes?.['pset:Pset_FireSafety']).toEqual({ [FIRE]: 'REI90' });
+    expect(conflict.ours?.attributes?.['pset:Pset_FireSafety']).toEqual({ [FIRE]: 'REI60' });
+    expect(conflict.base?.attributes?.['pset:Pset_FireSafety']).toEqual({ [FIRE]: 'REI60' });
   });
 
   it('changed vs tombstoned → conflict: modify-vs-delete', () => {
@@ -146,7 +154,14 @@ describe('three-way decision matrix', () => {
       theirs: [base, layer([{ path: 'wall-1', attributes: { [IFCLITE_ATTR.DELETED]: true } }], 'theirs')],
     });
     expect(plan.conflicts).toHaveLength(1);
-    expect(plan.conflicts[0].kind).toBe('modify-vs-delete');
+    const conflict = plan.conflicts[0];
+    expect(conflict.kind).toBe('modify-vs-delete');
+    expect(conflict.path).toBe('wall-1');
+    // Ours carries the actual edit, not the ancestor's stale value —
+    // swapping ours/base here would be unobservable if only `kind` were
+    // asserted.
+    expect(conflict.ours?.attributes?.['pset:Pset_FireSafety']).toEqual({ [FIRE]: 'REI90' });
+    expect(conflict.base?.attributes?.['pset:Pset_FireSafety']).toEqual({ [FIRE]: 'REI60' });
   });
 
   it('tombstoned vs tombstoned → fold (auto)', () => {


### PR DESCRIPTION
## Summary

Two golden fixtures in `packages/merge/src/three-way.test.ts` — "tombstoned vs changed → conflict: delete-vs-modify" and "changed vs tombstoned → conflict: modify-vs-delete" — asserted only `conflict.kind`, never the actual `ours`/`theirs`/`base` content of the emitted conflict.

Mutating `packages/merge/src/three-way.ts` to swap which side's component snapshot lands on `conflict.ours` vs `conflict.theirs` (or to record the ancestor's stale value in place of ours' real edit) survives both tests unnoticed — confirmed by running the mutated code against `three-way.test.ts` alone. The bug is only caught elsewhere in the package, by fixtures in `resurrect.test.ts` that happen to apply the resolution and check the composed state; `three-way.test.ts` itself cannot see it.

This strengthens both fixtures to assert `path` and the actual FireRating value on the correct side, so a swapped-side or stale-ancestor-value bug fails the test that specifically names the decision, not only a distant, unrelated fixture.

## Test plan
- [x] `pnpm --filter @ifc-lite/merge test` — 100 passed, 4 skipped (unrelated pre-existing skips)
- [x] `pnpm --filter @ifc-lite/merge typecheck` — OK
- [x] Mutation testing: swapping `theirs`/`ours` snapshot assignment in the delete-vs-modify branch of `three-way.ts`, and swapping `ours`'s snapshot for the ancestor's in the modify-vs-delete branch, both now fail the strengthened tests (previously silently passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded conflict coverage for three-way merges.
  * Added validation of conflict paths and the corresponding current, incoming, and base values.
  * Improved checks for delete-versus-modify scenarios, including edits compared with ancestor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->