### PR TITLE
test(renderer): pin quantizeInterleaved's exact extent boundary

### DIFF
--- a/packages/renderer/src/quantize.test.ts
+++ b/packages/renderer/src/quantize.test.ts
@@ -102,6 +102,22 @@ describe('quantizeInterleaved (#1682 phase 6)', () => {
     assert.strictEqual(quantizeInterleaved(src, STRIDE), null);
   });
 
+  // The threshold itself: `+1` above overshoots by a whole metre, so a
+  // regression that rejects one lattice step early (`>` mutated to `>=`)
+  // would still pass every other case in this file. Pin both edges of the
+  // exact boundary, on the axis that isn't x so a swapped axis check would
+  // also be caught.
+  it('accepts an extent exactly AT the u16 lattice range, and rejects one step beyond', () => {
+    const atBoundary = interleave([{ p: [0, 0, 0] }, { p: [0, MAX_QUANT_EXTENT, 0] }]);
+    const r = quantizeInterleaved(atBoundary, STRIDE)!;
+    assert.notStrictEqual(r, null, 'exact boundary extent must still quantize');
+    const q = view(r);
+    assert.strictEqual(q.u16[1 * 6 + 1], 65535, 'boundary vertex must land on the top lattice node');
+
+    const oneStepBeyond = interleave([{ p: [0, 0, 0] }, { p: [0, MAX_QUANT_EXTENT + QUANT_STEP, 0] }]);
+    assert.strictEqual(quantizeInterleaved(oneStepBeyond, STRIDE), null);
+  });
+
   it('handles the empty buffer', () => {
     const r = quantizeInterleaved(new Float32Array(0), STRIDE)!;
     assert.strictEqual(r.vertexData.byteLength, 0);


### PR DESCRIPTION
## Summary
- `quantize.test.ts` only tested `MAX_QUANT_EXTENT + 1`, a full metre past the u16 lattice threshold, so a regression that rejected one lattice step too early (`>` mutated to `>=` in the extent guard) left every test green.
- Mutation evidence: applying `>` to `>=` in the three extent comparisons in `quantizeInterleaved` survived all 7 pre-existing tests unmodified.
- Adds a test pinning both edges of the exact threshold: an extent exactly equal to `MAX_QUANT_EXTENT` must still quantize (and its top vertex must land on lattice node 65535), while one `QUANT_STEP` beyond it must return `null`.

## Test plan
- [x] `npx tsx --test src/quantize.test.ts` — 8/8 pass against unmodified `quantize.ts`
- [x] Reapplied the `>` → `>=` mutation to `quantize.ts` — new test fails (RED), confirming it catches the regression
- [x] Reverted the mutation — 8/8 pass again (GREEN), `quantize.ts` unchanged from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for quantization at the maximum supported extent.
  - Verified that exact boundary values map to the highest lattice index.
  - Confirmed values beyond the supported limit are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->