### PR TITLE
fix(merge): verify content after a stableHash match instead of trusting it alone

### DIFF
--- a/.changeset/merge-hash-collision-fold.md
+++ b/.changeset/merge-hash-collision-fold.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/merge": patch
+---
+
+Fix the three-way merge, layer diff, and revert-op paths trusting a `stableHash` component match with no fallback content check.
+
+`snapshotOf` (`component-state.ts`) hashes each component's canonical JSON with `stableHash`, and every consumer — the three-way merge's fold/keep-ours decisions, the layer diff's changed-component detection, and revert-op generation — decided "same content" from hash equality alone. `stableHash` is a 64-bit FNV-1a hash: strong, but not cryptographic, and unlike `packages/diff`'s content-match pass (which requires an independent component sub-hash or geometry-hash agreement before trusting a `dataHash` match) nothing here had a fallback. A collision would have silently folded two genuinely different concurrent edits into one — the losing edit vanishes with no conflict raised — or silently skipped reverting a component that had actually changed.
+
+`attributesContentEqual` now verifies with an exact canonical-JSON comparison whenever two hashes already agree, at negligible cost since it only runs on the (common) case of an actual match. No behavior changes for any non-colliding pair.

--- a/packages/clash/src/deterministic-uuid.test.ts
+++ b/packages/clash/src/deterministic-uuid.test.ts
@@ -53,11 +53,14 @@ describe('uuidFromSeed frozen vectors', () => {
   });
 
   // Two pairs differing in exactly one character, at opposite ends of the
-  // string. stableHash elsewhere in this repo is a confirmed 32-bit,
-  // prefix-coupled hash (a shared prefix can produce a related digest); these
-  // pairs make sure a prefix-coupling or truncation regression in this
-  // module's own hashing would flip one frozen vector without flipping its
-  // sibling, rather than both silently drifting together.
+  // string. This module's own `fnv1a` (above) is a 32-bit FNV-1a mix,
+  // independent of `@ifc-lite/diff`'s `stableHash` — the two share no code
+  // and this file never imports the other. Prefix-coupling is exactly the
+  // failure mode a per-character FNV-1a-style update is prone to (a shared
+  // prefix can produce a related digest); these pairs make sure a
+  // prefix-coupling or truncation regression in THIS module's hashing would
+  // flip one frozen vector without flipping its sibling, rather than both
+  // silently drifting together.
   it('matches frozen vectors for seeds differing only in the last character', () => {
     expect(uuidFromSeed('group-critical-a')).toBe('87b7dadf-f988-466a-ab03-2fddc8cbdc87');
     expect(uuidFromSeed('group-critical-b')).toBe('648a28ea-f9c7-45d1-ad6c-64cbebde3b13');

--- a/packages/merge/src/component-state.ts
+++ b/packages/merge/src/component-state.ts
@@ -421,6 +421,36 @@ export function snapshotOf(attributes: ComponentAttributes): ComponentSnapshot {
 }
 
 /**
+ * Exact content equality between two attribute maps — not merely hash
+ * equality.
+ *
+ * Every caller in this package (`three-way.ts`, `state-diff.ts`,
+ * `inverse.ts`) uses `snapshotOf`'s hash to decide a merge outcome: fold two
+ * edits together, treat a side as "didn't touch it", or skip emitting a
+ * revert op. `stableHash` is a 64-bit FNV-1a hash — strong, but explicitly
+ * not cryptographic (see its docstring in `@ifc-lite/diff`) — and unlike
+ * `packages/diff`'s content-match pass, which requires an independent
+ * signal (component sub-hash agreement, often a geometry hash too) before
+ * trusting a `dataHash` match, none of the hash comparisons in this package
+ * had any fallback. A collision would silently fold two genuinely different
+ * edits — one vanishes with no conflict raised — or silently skip reverting
+ * a component that actually changed.
+ *
+ * Call this only after the hash already compared equal: it's the expensive
+ * half of a cheap-then-exact check, not a replacement for hashing. Callers
+ * keep the fast hash comparison as the common-case rejection and add this
+ * as the verifying fallback exactly where the two lines currently agree.
+ */
+export function attributesContentEqual(
+  x: ComponentAttributes | undefined,
+  y: ComponentAttributes | undefined,
+): boolean {
+  if (x === y) return true;
+  if (x === undefined || y === undefined) return false;
+  return canonicalStringify(x) === canonicalStringify(y);
+}
+
+/**
  * Unified view used by the matrix: real components plus `child:<name>` /
  * `inherit:<role>` pseudo-components whose single attribute is the
  * referenced path. Both are relation edges, so divergent edits surface

--- a/packages/merge/src/inverse.ts
+++ b/packages/merge/src/inverse.ts
@@ -13,7 +13,12 @@ import type { IfcxFile, ProvenanceAuthor } from '@ifc-lite/ifcx';
 import { computeLayerId, createProvenanceManifest, setProvenance } from '@ifc-lite/ifcx';
 import type { ComponentAttributes, MergeOp } from './types.js';
 import type { StackState } from './component-state.js';
-import { componentEntries, extractStackState, snapshotOf } from './component-state.js';
+import {
+  attributesContentEqual,
+  componentEntries,
+  extractStackState,
+  snapshotOf,
+} from './component-state.js';
 import { opsForComponentChange } from './three-way.js';
 import { opsToNodes } from './merge-layer.js';
 
@@ -60,7 +65,10 @@ export function buildInverseOps(before: StackState, after: StackState): MergeOp[
       const afterAttrs = afterComponents.get(key);
       const beforeHash = beforeAttrs ? snapshotOf(beforeAttrs).hash : undefined;
       const afterHash = afterAttrs ? snapshotOf(afterAttrs).hash : undefined;
-      if (beforeHash === afterHash) continue;
+      // A `stableHash` collision here would skip reverting a component that
+      // actually changed; verify with an exact content check once the
+      // hashes already agree (see `attributesContentEqual`).
+      if (beforeHash === afterHash && attributesContentEqual(beforeAttrs, afterAttrs)) continue;
       ops.push(...opsForComponentChange(path, key, afterAttrs, beforeAttrs));
     }
   }

--- a/packages/merge/src/state-diff.ts
+++ b/packages/merge/src/state-diff.ts
@@ -11,7 +11,12 @@
  */
 
 import type { IfcxFile } from '@ifc-lite/ifcx';
-import { componentEntries, extractStackState, snapshotOf } from './component-state.js';
+import {
+  attributesContentEqual,
+  componentEntries,
+  extractStackState,
+  snapshotOf,
+} from './component-state.js';
 import type { StackState } from './component-state.js';
 
 export interface ModifiedEntity {
@@ -65,7 +70,10 @@ export function diffStackStates(from: StackState, to: StackState): StackDiff {
       if (a === b) continue;
       const aHash = a === undefined ? undefined : snapshotOf(a).hash;
       const bHash = b === undefined ? undefined : snapshotOf(b).hash;
-      if (aHash !== bHash) changed.push(key);
+      // Hash equality alone would trust a `stableHash` collision as "no
+      // change"; `a === b` was already ruled out above, so a match here
+      // needs an exact-content check too (see `attributesContentEqual`).
+      if (aHash !== bHash || !attributesContentEqual(a, b)) changed.push(key);
     }
     if (changed.length > 0) modified.push({ path, components: changed });
   }

--- a/packages/merge/src/three-way-hash-collision.test.ts
+++ b/packages/merge/src/three-way-hash-collision.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `snapshotOf` (component-state.ts) hashes a component's canonical JSON with
+ * `stableHash` and the three-way merge trusts equality of that hash alone to
+ * decide "same edit, fold" (see the decision matrix in three-way.ts: "both
+ * changed, equal sub-hash -> fold (auto)"). A real 64-bit FNV-1a collision is
+ * not something this test can find by brute force (the birthday bound needs
+ * on the order of 2^32 hash computations), so `stableHash` is mocked here to
+ * force one deterministically between two component payloads that are
+ * genuinely different content ('REI90' vs 'REI120'). This isolates the
+ * question the audit cares about: IF stableHash ever collides, does the
+ * merge engine notice? Everything else about the merge (the actual
+ * three-way decision matrix, the entity/component walk) runs unmocked.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { IfcxFile, IfcxNode } from '@ifc-lite/ifcx';
+
+vi.mock('@ifc-lite/diff', () => ({
+  stableHash: (value: string): string => {
+    // Force exactly the two payloads this test cares about to collide;
+    // everything else still hashes distinctly so the rest of the merge
+    // matrix behaves normally.
+    if (value.includes('REI90') || value.includes('REI120')) return 'deadbeefdeadbeef';
+    let h = 0;
+    for (let i = 0; i < value.length; i += 1) h = (h * 31 + value.charCodeAt(i)) >>> 0;
+    return h.toString(16).padStart(16, '0');
+  },
+}));
+
+const { planThreeWayMerge } = await import('./three-way.js');
+
+function makeLayer(data: IfcxNode[], id = 'layer'): IfcxFile {
+  return {
+    header: {
+      id,
+      ifcxVersion: 'ifcx_alpha',
+      dataVersion: '1.0.0',
+      author: 'test',
+      timestamp: '2026-06-09T00:00:00Z',
+    },
+    imports: [],
+    schemas: {},
+    data,
+  };
+}
+
+const FIRE = 'bsi::ifc::v5a::Pset_FireSafety::FireRating';
+
+const base = makeLayer(
+  [{ path: 'wall-1', attributes: { 'bsi::ifc::class': { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60' } }],
+  'base',
+);
+
+describe('three-way merge under a forced stableHash collision', () => {
+  it('does not silently fold two genuinely different concurrent edits into one', () => {
+    const plan = planThreeWayMerge({
+      ancestor: [base],
+      ours: [base, makeLayer([{ path: 'wall-1', attributes: { [FIRE]: 'REI90' } }], 'ours')],
+      theirs: [base, makeLayer([{ path: 'wall-1', attributes: { [FIRE]: 'REI120' } }], 'theirs')],
+    });
+
+    // Ours set FireRating to REI90, theirs set it to REI120: a genuine
+    // concurrent edit that must surface as a conflict. The mocked
+    // stableHash makes their component sub-hashes collide — exactly the
+    // "equal sub-hash" condition the fold branch trusts with no fallback.
+    // Before the fix: the fold branch fires on the collision, plan.conflicts
+    // is empty AND plan.autoOps is empty, so the merge silently keeps
+    // "ours" (REI90) and theirs' edit (REI120) vanishes with no trace, no
+    // warning, no conflict for a human to resolve.
+    expect(plan.conflicts).toHaveLength(1);
+    expect(plan.conflicts[0]?.kind).toBe('concurrent-edit');
+    expect(plan.conflicts[0]?.ours?.attributes).toEqual({ [FIRE]: 'REI90' });
+    expect(plan.conflicts[0]?.theirs?.attributes).toEqual({ [FIRE]: 'REI120' });
+    expect(plan.autoOps).toEqual([]);
+  });
+});

--- a/packages/merge/src/three-way.ts
+++ b/packages/merge/src/three-way.ts
@@ -34,6 +34,7 @@ import type {
 } from './types.js';
 import type { EntityState, StackState } from './component-state.js';
 import {
+  attributesContentEqual,
   componentEntries,
   extractStackState,
   projectStackStates,
@@ -264,6 +265,22 @@ function escalateShadowedConflicts(
 
 type HashOf = (attrs: ComponentAttributes | undefined) => string | undefined;
 
+/**
+ * Attribute-map equality: hash first (cheap, and correct for every real
+ * match), `attributesContentEqual` only when the hashes already agree. See
+ * that function's docstring for why this indirection exists — the fold and
+ * "didn't touch it" decisions below trusted the hash alone before this.
+ */
+function attrsEqual(
+  x: ComponentAttributes | undefined,
+  y: ComponentAttributes | undefined,
+  hashOf: HashOf
+): boolean {
+  if (x === y) return true;
+  if (hashOf(x) !== hashOf(y)) return false;
+  return attributesContentEqual(x, y);
+}
+
 interface EntityMergeResult {
   ops: MergeOp[];
   conflicts: MergeConflict[];
@@ -288,7 +305,7 @@ function componentsEqual(
     const other = y.get(key);
     if (!other) return false;
     if (other === attrs) continue;
-    if (hashOf(other) !== hashOf(attrs)) return false;
+    if (!attrsEqual(other, attrs, hashOf)) return false;
   }
   return true;
 }
@@ -417,13 +434,13 @@ function mergeEntity(
     // Reference equality first (shared objects from the projection fast
     // path); only genuinely diverging references pay for hashing.
     if (aAttrs === oAttrs && aAttrs === tAttrs) continue;
-    const oChanged = aAttrs === oAttrs ? false : hashOf(aAttrs) !== hashOf(oAttrs);
-    const tChanged = aAttrs === tAttrs ? false : hashOf(aAttrs) !== hashOf(tAttrs);
+    const oChanged = aAttrs === oAttrs ? false : !attrsEqual(aAttrs, oAttrs, hashOf);
+    const tChanged = aAttrs === tAttrs ? false : !attrsEqual(aAttrs, tAttrs, hashOf);
     if (!oChanged && !tChanged) continue;
     touched += 1;
 
     if (oChanged && !tChanged) continue; // keep ours
-    if (oChanged && tChanged && (oAttrs === tAttrs || hashOf(oAttrs) === hashOf(tAttrs))) continue; // fold
+    if (oChanged && tChanged && (oAttrs === tAttrs || attrsEqual(oAttrs, tAttrs, hashOf))) continue; // fold
 
     if (!oChanged && tChanged) {
       ops.push(...opsForComponentChange(path, key, aAttrs, tAttrs, oAttrs));
@@ -462,7 +479,7 @@ function opsForComponentDelta(
     const aAttrs = ancestor.get(key);
     const tAttrs = theirs.get(key);
     if (aAttrs === tAttrs) continue;
-    if (aAttrs !== undefined && tAttrs !== undefined && hashOf(aAttrs) === hashOf(tAttrs)) continue;
+    if (aAttrs !== undefined && tAttrs !== undefined && attrsEqual(aAttrs, tAttrs, hashOf)) continue;
     ops.push(...opsForComponentChange(path, key, aAttrs, tAttrs, ours.get(key)));
   }
   return ops;


### PR DESCRIPTION
## Summary

Audit of `stableHash` (`packages/diff/src/fingerprint.ts`) and its call sites, per the request to determine what a hash collision actually does at each consumer and whether it's verified.

**The premise had already moved**: `stableHash` was widened from 32 to 64 bits in #1987 (closing #1962), and `packages/diff`'s content-match pass already guards its one hash-only retiring path with `componentsAgree` (component sub-hash agreement) — that part of the audit came back clean, with the documented (and accepted) residual that a collision confined to `attr:core` can't be caught, because FNV-1a's per-character update is a bijection.

**`packages/merge` had no such guard.** `snapshotOf` (`component-state.ts`) hashes each component's canonical JSON with `stableHash`, and every consumer trusted equality of that hash alone as content equality:
- `three-way.ts`'s decision matrix ("both changed, equal sub-hash → fold (auto)") — a collision would silently fold two genuinely different concurrent edits into one, discarding the losing edit with **no conflict raised**.
- `state-diff.ts`'s layer diff — a collision would report a changed component as unchanged.
- `inverse.ts`'s revert-op generation — a collision would skip reverting a component that had actually changed.

None of these had `packages/diff`'s independent verification signal.

## Fix

`attributesContentEqual` (component-state.ts) does an exact canonical-JSON comparison, used as a fallback only when two hashes already agree — negligible extra cost, since it only runs on real matches. Wired into all four hash-trusting comparisons in `three-way.ts`, plus the ones in `state-diff.ts` and `inverse.ts`.

Reproduced with a forced (mocked) `stableHash` collision between two different `FireRating` edits (`three-way-hash-collision.test.ts`): RED before this change — the fold branch fired on the collision, `plan.conflicts` and `plan.autoOps` were both empty, so the merge silently kept "ours" and theirs' edit vanished with no trace. GREEN after.

Also fixes a stale comment in `packages/clash`'s `deterministic-uuid.test.ts` claiming `stableHash` is "a confirmed 32-bit, prefix-coupled hash" (written the same day, after the 64-bit widening had already been live for over two weeks) — corrected to note that module's own `fnv1a` mix is unrelated to `stableHash` entirely.

## Not fixed / left to a maintainer decision

- Widening `stableHash` itself — out of scope, a data-format change with migration consequences.
- The `attr:core`-confined collision gap in `packages/diff`'s `componentsAgree` guard — already documented and accepted as a real, permanent residual; not something a fallback can close without hashing finer-grained slices, which is a bigger design change.

## Test plan

- [x] `pnpm exec vitest run` in `packages/merge` — 101 passed, 4 skipped, no regressions
- [x] `pnpm exec tsc --noEmit` in `packages/merge` — clean
- [x] `pnpm exec vitest run` in `packages/diff` — 298 passed, unaffected
- [x] `pnpm exec vitest run src/deterministic-uuid.test.ts` in `packages/clash` — 6 passed
- [x] New test `three-way-hash-collision.test.ts`: RED before the fix, GREEN after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge accuracy when different component data produces the same hash.
  * Prevented legitimate changes from being skipped during three-way merges, layer comparisons, and revert operations.
  * Ensured concurrent edits correctly surface conflicts instead of being silently combined.
* **Tests**
  * Added regression coverage for hash-collision scenarios.
* **Documentation**
  * Added release notes describing the collision-safety improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->