### PR TITLE
test(renderer): pin FederationRegistry's MAX_SAFE_OFFSET exact boundary

### DIFF
--- a/packages/renderer/src/federation-registry.test.ts
+++ b/packages/renderer/src/federation-registry.test.ts
@@ -47,6 +47,19 @@ describe('FederationRegistry - offset assignment', () => {
     reg.registerModel('modelA', 1_999_999_990);
     assert.throws(() => reg.registerModel('modelB', 100), /exceed safe ID limit/);
   });
+
+  it('allows registration landing EXACTLY on the MAX_SAFE_OFFSET boundary, rejects one past it', () => {
+    // The guard is `nextOffset + maxExpressId > MAX_SAFE_OFFSET`: landing
+    // exactly ON the limit must be allowed (the boundary itself is safe),
+    // only crossing it must throw. Testing only far past the limit (as the
+    // test above does) cannot tell `>` apart from `>=` at the boundary.
+    const reg = new FederationRegistry();
+    reg.registerModel('modelA', 0); // offset 0, nextOffset -> 1
+    // sum = nextOffset(1) + maxExpressId(1_999_999_999) = 2_000_000_000 exactly.
+    assert.doesNotThrow(() => reg.registerModel('modelB', 1_999_999_999));
+    // nextOffset is now 2_000_000_001; any further model overflows by exactly 1.
+    assert.throws(() => reg.registerModel('modelC', 0), /exceed safe ID limit/);
+  });
 });
 
 describe('FederationRegistry - toGlobalId / fromGlobalId round-trip', () => {


### PR DESCRIPTION
## Summary
- The existing overflow test only exercises `registerModel()` far past `MAX_SAFE_OFFSET` (by 91), so a `>` -> `>=` mutation in the overflow guard (`this.nextOffset + maxExpressId > MAX_SAFE_OFFSET`) survives it unmodified: a registration landing exactly ON the safe limit would wrongly throw, and every existing test stayed green.
- Mutation evidence: changing `>` to `>=` in the overflow guard survived all 12 pre-existing tests.
- Adds a test that lands `nextOffset + maxExpressId` on exactly `2_000_000_000` (must succeed) and then exactly one past it (must throw), pinning both sides of the boundary the guard is meant to enforce.

## Test plan
- [x] `npx tsx --test src/federation-registry.test.ts` — 13/13 pass against unmodified `federation-registry.ts`
- [x] Reapplied the `>` -> `>=` mutation — new test fails (RED)
- [x] Reverted the mutation — 13/13 pass again (GREEN), `federation-registry.ts` unchanged from main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming registration succeeds at the maximum supported offset.
  * Verified that registrations exceeding the supported limit produce the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->