### PR TITLE
test(renderer): exercise all six faces of foldOccurrenceWorldBox's union

### DIFF
--- a/packages/renderer/src/instanced-render.test.ts
+++ b/packages/renderer/src/instanced-render.test.ts
@@ -314,6 +314,36 @@ describe('foldOccurrenceWorldBox — template cull metadata', () => {
     assert.deepStrictEqual(meta.bounds, { min: [-5, 0, 0], max: [2, 2, 2] });
   });
 
+  it('grows the union bounds independently on each of the six min/max faces', () => {
+    // The prior "grows the union after" test only ever moves the min-X face
+    // (the second box's minY/minZ/maxY/maxZ all equal the seed box's), so a
+    // copy-paste bug in any of the OTHER five branches — e.g. `maxY` writing
+    // into `tb.max[0]` instead of `tb.max[1]` — is invisible to it. Exercise
+    // each of the six comparisons with a box that extends the union on
+    // exactly one face and leaves the other five untouched, so a
+    // wrong-axis write is caught on the specific face it corrupts.
+    const meta = freshMeta();
+    foldOccurrenceWorldBox(meta, box(0, 0, 0, 10, 10, 10)); // seed union
+
+    foldOccurrenceWorldBox(meta, box(-1, 4, 4, 5, 5, 5)); // extends min-X only
+    assert.deepStrictEqual(meta.bounds, { min: [-1, 0, 0], max: [10, 10, 10] }, 'min-X');
+
+    foldOccurrenceWorldBox(meta, box(4, -2, 4, 5, 5, 5)); // extends min-Y only
+    assert.deepStrictEqual(meta.bounds, { min: [-1, -2, 0], max: [10, 10, 10] }, 'min-Y');
+
+    foldOccurrenceWorldBox(meta, box(4, 4, -3, 5, 5, 5)); // extends min-Z only
+    assert.deepStrictEqual(meta.bounds, { min: [-1, -2, -3], max: [10, 10, 10] }, 'min-Z');
+
+    foldOccurrenceWorldBox(meta, box(4, 4, 4, 11, 5, 5)); // extends max-X only
+    assert.deepStrictEqual(meta.bounds, { min: [-1, -2, -3], max: [11, 10, 10] }, 'max-X');
+
+    foldOccurrenceWorldBox(meta, box(4, 4, 4, 5, 12, 5)); // extends max-Y only
+    assert.deepStrictEqual(meta.bounds, { min: [-1, -2, -3], max: [11, 12, 10] }, 'max-Y');
+
+    foldOccurrenceWorldBox(meta, box(4, 4, 4, 5, 5, 13)); // extends max-Z only
+    assert.deepStrictEqual(meta.bounds, { min: [-1, -2, -3], max: [11, 12, 13] }, 'max-Z');
+  });
+
   it('maxOccRadius tracks the LARGEST single occurrence, not the union diagonal', () => {
     const meta = freshMeta();
     foldOccurrenceWorldBox(meta, box(0, 0, 0, 1, 1, 1));       // r = sqrt(3)/2


### PR DESCRIPTION
## Summary
- The existing "grows the union after" test in `instanced-render.test.ts` only ever moves the min-X face — the second box's minY/minZ/maxY/maxZ all equal the seed box's — so a copy-paste bug in any of the other five union comparisons (e.g. the maxY branch writing into `tb.max[0]` instead of `tb.max[1]`) is invisible to it.
- Mutation evidence: changing `if (w.maxY > tb.max[1]) tb.max[1] = w.maxY;` to write into `tb.max[0]` survived all 15 pre-existing tests; same for the minY branch writing into `tb.min[0]`.
- Adds a test that extends the union on exactly one face at a time across all six comparisons (min-X/Y/Z, max-X/Y/Z), so a wrong-axis write is caught on the specific face it corrupts.

## Test plan
- [x] `npx tsx --test src/instanced-render.test.ts` — 16/16 pass against unmodified `instanced-render.ts`
- [x] Reapplied the `maxY -> tb.max[0]` mutation — new test fails (RED)
- [x] Reapplied the `minY -> tb.min[0]` mutation — new test fails (RED)
- [x] Reverted both mutations — 16/16 pass again (GREEN), `instanced-render.ts` unchanged from main