### PR TITLE
test(renderer): cover PickingManager's already-hydrated-piece dedup

### DIFF
--- a/packages/renderer/src/picking-manager.test.ts
+++ b/packages/renderer/src/picking-manager.test.ts
@@ -260,6 +260,27 @@ describe('PickingManager', () => {
       assert.equal(h.selectRectCalls, 0, 'small model should use the GPU path, not the CPU fallback');
     });
 
+    // The `existingMeshes` harness knob above was declared but never exercised
+    // by any test in this file, so the "assume existing pieces correspond to
+    // the first N pieces in stable order" dedup (picking-manager.ts, the
+    // `ordinal < baselineExisting` skip) had no coverage: a multi-piece entity
+    // that was already partially hydrated (e.g. from an earlier pick()) would
+    // silently re-create pieces it already had, duplicating GPU mesh buffers.
+    it('does not re-hydrate a piece that already exists for a multi-piece entity', async () => {
+      const wallPieces = [{ expressId: WALL }, { expressId: WALL }];
+      const h = harness({
+        existingMeshes: [{ expressId: WALL }],
+        pieces: (id) => (id === WALL ? wallPieces : undefined),
+      });
+
+      await h.manager.pickRect(0, 0, 100, 100);
+
+      assert.equal(
+        h.createdMeshes.length, 2,
+        'the already-existing piece must not be re-created; only the missing second piece should be hydrated',
+      );
+    });
+
     it('falls back to Scene.selectRect once geometry data is released', async () => {
       const h = harness({ released: true });
 


### PR DESCRIPTION
## Summary
- `PickingManager.prepareBatchedPick`'s hydration loop skips creating a mesh piece whose ordinal falls under the pre-existing count for its key (`ordinal < baselineExisting`) — it assumes already-hydrated pieces correspond to the first N pieces in stable order, avoiding duplicate GPU mesh creation for a multi-piece entity that was partially hydrated by an earlier pick.
- `picking-manager.test.ts`'s harness already declared an `existingMeshes` override for exercising this, but no test ever passed it, so the skip had zero coverage.
- Confirmed by mutation: `sed -i 's/if (ordinal < baselineExisting) continue;/if (false \&\& ordinal < baselineExisting) continue;/'` left all 13 pre-existing tests green (`tsx --test src/picking-manager.test.ts`).
- Added a case with a 2-piece WALL entity that already has one piece hydrated (`existingMeshes: [{ expressId: WALL }]`); asserts only the missing second piece is created (`createdMeshes.length === 2`, not 3). Verified RED under the mutation above, GREEN with the guard restored.

## Test plan
- [x] `tsx --test src/picking-manager.test.ts` — 14/14 pass with the fix in place
- [x] Same command goes RED (1 failing subtest) under the `ordinal < baselineExisting` mutation, confirming the new test observes the guard
- [x] `pnpm test` in `packages/renderer` — 938/938 pass