### PR TITLE
test(geometry): pin the per-axis wrong-piece slack in difference_result_looks_degenerate

### DIFF
--- a/rust/geometry/src/csg/csg_tests.rs
+++ b/rust/geometry/src/csg/csg_tests.rs
@@ -346,6 +346,34 @@ fn plane_eps_is_invariant_under_negating_the_normal() {
     }
 }
 
+/// `difference_result_looks_degenerate`'s "wrong piece" bbox check must use
+/// PER-AXIS slack (1 % of each axis's own host span), not a single scalar
+/// derived from the host's longest dimension — see the doc comment on
+/// `ClippingProcessor::difference_result_looks_degenerate` (CodeRabbit review
+/// on PR #861, house.ifc wall #3448).
+///
+/// Fixture: a thin wall, 5 m (X) x 0.4 m (Y) x 7 m (Z). A malformed-cutter
+/// "wrong piece" result pokes 1 cm past the wall's 0.4 m Y face — a real
+/// wrong-piece defect on the wall's thin axis. Per-axis Y slack is 1 % of
+/// 0.4 m = 4 mm, so a 1 cm overshoot must be flagged. A tolerance instead
+/// derived from the LONGEST axis (Z, 7 m -> 7 cm slack) would let that same
+/// 1 cm overshoot through unflagged, because 1 cm < 7 cm.
+#[test]
+fn difference_result_wrong_piece_check_is_per_axis_not_longest_dimension() {
+    let host = aabb_to_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(5.0, 0.4, 7.0));
+    // Same shape as the host, but overshoots the host's Y max by 1 cm —
+    // 1 % of the 5 m X span is 5 cm and 1 % of the 7 m Z span is 7 cm, so
+    // this result sits well within tolerance on BOTH the longest dimension
+    // and X; only the thin Y axis's own 4 mm slack can catch it.
+    let result = aabb_to_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(5.0, 0.41, 7.0));
+
+    assert!(
+        ClippingProcessor::difference_result_looks_degenerate(&host, &result),
+        "a result overshooting the host's thin Y face by 1 cm (4 mm per-axis \
+         slack on that axis) must be flagged as a wrong-piece degenerate result"
+    );
+}
+
 // World-frame corpus tests: a sibling test file, attached here rather than
 // from `mod.rs` because that allowlisted production module is at its
 // module-size-ratchet budget and test files are exempt. The file itself


### PR DESCRIPTION
## Summary
- `ClippingProcessor::difference_result_looks_degenerate`'s bbox "wrong piece" guard already computes its 1% overshoot tolerance PER AXIS (fixed on #861 after a CodeRabbit review caught a single longest-dimension tolerance letting thin-wall overshoots through), but had no direct unit test — only indirect coverage via `processors/boolean` callers.
- Adds a fixture: a 5 m x 0.4 m x 7 m thin wall with a result overshooting the host's 0.4 m Y face by 1 cm. A longest-dimension tolerance (7 cm, from the 7 m Z span) would let this through; the wall's own axis slack (4 mm on Y) must catch it.

## Proof
Mutated the per-axis `Vector3` slack to a single scalar derived from the host's longest dimension (`(host_max - host_min).abs().max() * 0.01` on all three axes) and reran the new test: it failed (RED). Reverted the mutation and reran: it passed (GREEN). Full `ifc-lite-geometry` lib suite: 672 passed, 0 failed, 1 ignored (pre-existing, unrelated).

## Test plan
- [x] `cargo test -p ifc-lite-geometry --lib difference_result_wrong_piece` — new test passes on unmutated code
- [x] Confirmed RED under the longest-dimension-slack mutation, reverted
- [x] `cargo test -p ifc-lite-geometry --lib` — 672 passed, 0 failed, 1 ignored