### PR TITLE
test(renderer): isolate each side of selectBoundingBoxesInRect's disjoint test

### DIFF
--- a/packages/renderer/src/scene-rect-select.test.ts
+++ b/packages/renderer/src/scene-rect-select.test.ts
@@ -80,6 +80,47 @@ describe('selectBoundingBoxesInRect (#1904)', () => {
     assert.deepStrictEqual(hits, new Set());
   });
 
+  // The final gate is a 4-way AABB-disjoint test (`maxX < rx0 || minX > rx1 ||
+  // maxY < ry0 || minY > ry1`). The existing "rejects a box whose projection
+  // is outside the rect" test puts the rect in the corner, so it trips BOTH
+  // the minX>rx1 and minY>ry1 clauses at once and cannot tell them apart from
+  // the other two. Each clause is isolated here, with the other axis's rect
+  // bound left wide open so it can't also reject.
+  describe('rejects a box on exactly one side of the rect, isolated per axis', () => {
+    // Box screen AABB is x 50..60, y 40..50 (per the IDENTITY comment above).
+    it('box entirely LEFT of the rect (maxX < rx0)', () => {
+      const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+      const hits = selectBoundingBoxesInRect(
+        boxes, IDENTITY, { x0: 70, y0: 0, x1: 90, y1: 100 }, W, H,
+      );
+      assert.deepStrictEqual(hits, new Set());
+    });
+
+    it('box entirely RIGHT of the rect (minX > rx1)', () => {
+      const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+      const hits = selectBoundingBoxesInRect(
+        boxes, IDENTITY, { x0: 0, y0: 0, x1: 10, y1: 100 }, W, H,
+      );
+      assert.deepStrictEqual(hits, new Set());
+    });
+
+    it('box entirely ABOVE the rect on screen (maxY < ry0)', () => {
+      const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+      const hits = selectBoundingBoxesInRect(
+        boxes, IDENTITY, { x0: 0, y0: 60, x1: 100, y1: 90 }, W, H,
+      );
+      assert.deepStrictEqual(hits, new Set());
+    });
+
+    it('box entirely BELOW the rect on screen (minY > ry1)', () => {
+      const boxes = new Map([[1, box(0, 0, 0, 0.2, 0.2, 0)]]);
+      const hits = selectBoundingBoxesInRect(
+        boxes, IDENTITY, { x0: 0, y0: 0, x1: 100, y1: 10 }, W, H,
+      );
+      assert.deepStrictEqual(hits, new Set());
+    });
+  });
+
   it('selects on partial overlap — the rect need not contain the whole box', () => {
     const boxes = new Map([[1, box(-1, -1, 0, 1, 1, 0)]]); // fills the viewport
     const hits = selectBoundingBoxesInRect(boxes, IDENTITY, { x0: 0, y0: 0, x1: 5, y1: 5 }, W, H);


### PR DESCRIPTION
## Summary
- `selectBoundingBoxesInRect`'s final gate is a 4-clause AABB-disjoint test: `maxX < rx0 || minX > rx1 || maxY < ry0 || minY > ry1`.
- The only existing negative case ("rejects a box whose projection is outside the rect") puts the rect in a screen corner, which trips both `minX > rx1` and `minY > ry1` at once — `maxX < rx0` and `maxY < ry0` were never independently exercised.
- Confirmed by mutation (`packages/renderer/src/scene-rect-select.ts`): dropping `maxX < rx0 ||` from the clause left all 15 prior tests green; separately dropping `maxY < ry0 ||` also left them green (`tsx --test src/scene-rect-select.test.ts`).

## Test plan
- [x] Added a describe block with one isolated test per side (box entirely left / right / above / below the rect on screen), each holding the other axis's rect bound wide open so only the clause under test can fire.
- [x] `tsx --test src/scene-rect-select.test.ts` — 19/19 pass with the guard intact
- [x] Both mutations above now go RED under the new LEFT/ABOVE cases; restoring the guard returns to GREEN
- [x] `pnpm test` in `packages/renderer` — 942/942 pass