### PR TITLE
test(renderer): cover multi-piece textured-mesh removal, not just single-piece

### DIFF
--- a/packages/renderer/src/scene-gpu-leaks.test.ts
+++ b/packages/renderer/src/scene-gpu-leaks.test.ts
@@ -318,6 +318,37 @@ describe('Scene shared image textures (#1781)', () => {
     assert.strictEqual(owned.destroyed, 1);
   });
 
+  // The #961 cleanup loop iterates `texturedMeshes` backward while splicing
+  // matches out (`for (let i = length - 1; i >= 0; i--)`), which is required
+  // when one entity owns MORE THAN ONE textured mesh piece — a forward loop
+  // that splices as it goes shifts the array under itself and skips the
+  // element that slides into the just-vacated slot. Every prior test in this
+  // file put at most one texturedMeshes entry per expressId, so that skip was
+  // unobservable: replacing the backward loop with an equivalent-looking
+  // forward one left all of them green.
+  it('destroys every piece of a multi-piece textured entity, not just the first', () => {
+    const scene = new Scene();
+    const texA1 = fakeTexture();
+    const texA2 = fakeTexture();
+    const texB = fakeTexture();
+    const pieceA1 = fakeTexturedMesh(10, texA1);
+    const pieceA2 = fakeTexturedMesh(10, texA2);
+    const pieceB = fakeTexturedMesh(20, texB);
+    scene['texturedMeshes'] = [pieceA1, pieceA2, pieceB] as never;
+    scene['meshDataMap'].set(10, [fakeMeshDataEntry(10)] as never);
+
+    scene.removeMeshesForEntity(10);
+
+    assert.strictEqual(texA1.destroyed, 1, 'first piece of entity 10 must be destroyed');
+    assert.strictEqual(texA2.destroyed, 1, 'second piece of entity 10 must also be destroyed, not skipped');
+    assert.strictEqual(texB.destroyed, 0, 'entity 20\'s piece must survive untouched');
+    assert.strictEqual(
+      scene.getTexturedMeshes().some((tm) => tm.expressId === 10), false,
+      'no piece of entity 10 should remain in texturedMeshes',
+    );
+    assert.strictEqual(scene.getTexturedMeshes().length, 1);
+  });
+
   it('clear() empties the registry and destroys every shared texture once', () => {
     const scene = new Scene();
     const shared = fakeTexture();


### PR DESCRIPTION
## Summary
- `Scene.removeMeshesForEntity`'s #961 textured-mesh cleanup (`packages/renderer/src/scene.ts`, ~line 1385) iterates `texturedMeshes` backward while splicing matching entries out — required so an entity with more than one textured piece has all of them destroyed. A forward loop that splices as it iterates would shift the array under itself and skip the piece sliding into the vacated slot.
- Every existing `texturedMeshes` test put at most one entry per `expressId`, so the direction was unobservable. Confirmed by mutation: rewriting the backward `for` loop as an equivalent-looking forward one left all 15 prior tests in `scene-gpu-leaks.test.ts` green (`tsx --test src/scene-gpu-leaks.test.ts`).

## Test plan
- [x] Added a case with two textured pieces on one entity and a third piece on another; asserts both of the first entity's pieces are destroyed (not just the first) and the second entity's piece is untouched.
- [x] `tsx --test src/scene-gpu-leaks.test.ts` — 16/16 pass with the backward loop intact
- [x] Same command goes RED (1 failing subtest) under the forward-loop mutation, confirming the new test observes the direction
- [x] `pnpm test` in `packages/renderer` — 942/942 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to ensure removing a textured entity cleans up all associated mesh pieces while preserving other entities’ meshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->