### PR TITLE
test(renderer): observe the architecture typeof guard independently of vendor's

### DIFF
--- a/packages/renderer/src/device-adapter-info.test.ts
+++ b/packages/renderer/src/device-adapter-info.test.ts
@@ -158,4 +158,20 @@ describe('WebGPUDevice adapter-info snapshot (#2624)', () => {
     assert.equal(snapshot.vendor, undefined, 'a non-string vendor is omitted');
     assert.equal(snapshot.architecture, 'testarch', 'while the valid field survives');
   });
+
+  // The vendor and architecture checks are two separate `typeof === 'string'`
+  // guards. The case above only exercises the vendor one (architecture was
+  // always a valid string alongside it) — this flips which field is bad, so
+  // the architecture guard is independently observed rather than assumed
+  // symmetric with vendor's.
+  it('drops a non-string architecture even when vendor is valid', async () => {
+    installNavigator(makeAdapter({ vendor: 'testvendor', architecture: 99 }));
+
+    const device = new WebGPUDevice();
+    await device.init(makeCanvas());
+    const snapshot = device.getAdapterInfo();
+    assert.ok(snapshot);
+    assert.equal(snapshot.vendor, 'testvendor', 'the valid field survives');
+    assert.equal(snapshot.architecture, undefined, 'a non-string architecture is omitted');
+  });
 });


### PR DESCRIPTION
## Summary
- `WebGPUDevice.init()`'s adapter-info snapshot (`packages/renderer/src/device.ts`, ~line 83-84) applies two separate `typeof info.X === 'string'` guards, one for `vendor` and one for `architecture`.
- The existing "drops non-string fields" test only ever made `vendor` the bad field while `architecture` stayed a valid string alongside it, so the `architecture` guard itself was never independently exercised — an all-defaults-but-one-field case.
- Confirmed by mutation: replacing the architecture guard with an unconditional assignment (`snapshot.architecture = info.architecture;`) left all 3 prior tests green (`tsx --test src/device-adapter-info.test.ts`).

## Test plan
- [x] Added a symmetric case with `architecture` as a non-string (number) and `vendor` valid.
- [x] `tsx --test src/device-adapter-info.test.ts` — 4/4 pass with the guard intact
- [x] Same command goes RED (1 failing subtest) under the mutation above, confirming the new test observes the guard
- [x] `pnpm test` in `packages/renderer` — 939/939 pass