### PR TITLE
fix(viewer): tolerate CRLF fences in extractCodeBlocks

### DIFF
--- a/.changeset/code-extractor-crlf-fence.md
+++ b/.changeset/code-extractor-crlf-fence.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix the AI chat's code-block extractor silently dropping every fenced code block in a CRLF-authored assistant message.
+
+`extractCodeBlocks`'s fence regex required a literal `\n` right after the opening fence's language tag. A message with `\r\n` line endings (pasted or Windows-authored content) has `\r` there instead, so the regex never matched the block at all — it rendered as plain text with no "Run" affordance, and a script referencing `bim.` silently lost its executability rather than surfacing an error. The regex now tolerates an optional `\r` before the newline.

--- a/apps/viewer/src/lib/llm/code-extractor.test.ts
+++ b/apps/viewer/src/lib/llm/code-extractor.test.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractCodeBlocks, injectCsvData } from './code-extractor.js';
+
+describe('extractCodeBlocks', () => {
+  it('extracts a plain ```js block (LF line endings)', () => {
+    const md = 'Here:\n```js\nconsole.log(1);\n```\n';
+    const blocks = extractCodeBlocks(md);
+    assert.equal(blocks.length, 1);
+    assert.equal(blocks[0].code, 'console.log(1);');
+    assert.equal(blocks[0].index, 0);
+  });
+
+  it('extracts a ```js block with CRLF line endings (pasted/Windows-authored content)', () => {
+    // Regression: the fence regex required a literal \n right after the
+    // language tag. A CRLF source has \r there instead, so the regex never
+    // matched at all and the block silently rendered as plain text with no
+    // Run affordance - the exact "absence as success" failure mode.
+    const md = 'Here:\r\n```js\r\nconsole.log(1);\r\n```\r\n';
+    const blocks = extractCodeBlocks(md);
+    assert.equal(blocks.length, 1, 'expected the CRLF code block to be recognised');
+    assert.equal(blocks[0].code.trim(), 'console.log(1);');
+  });
+
+  it('extracts a bare (unlabeled) block with CRLF line endings', () => {
+    const md = '```\r\nbim.getSelectedEntities();\r\n```\r\n';
+    const blocks = extractCodeBlocks(md);
+    assert.equal(blocks.length, 1);
+    assert.ok(blocks[0].code.includes('bim.'));
+  });
+
+  it('assigns sequential indices only to extracted (executable) blocks', () => {
+    const md = [
+      '```json\n{"a":1}\n```',
+      '```js\nconsole.log(1);\n```',
+      '```js\nconsole.log(2);\n```',
+    ].join('\n\n');
+    const blocks = extractCodeBlocks(md);
+    assert.deepEqual(blocks.map((b) => b.index), [0, 1]);
+    assert.deepEqual(blocks.map((b) => b.code), ['console.log(1);', 'console.log(2);']);
+  });
+
+  it('skips a non-executable, non-bim block (e.g. json/html)', () => {
+    const md = '```json\n{"a":1}\n```';
+    assert.deepEqual(extractCodeBlocks(md), []);
+  });
+
+  it('includes an unlabeled block that references bim. even if language is not js', () => {
+    const md = '```python\nbim.doSomething()\n```';
+    const blocks = extractCodeBlocks(md);
+    assert.equal(blocks.length, 1);
+  });
+});
+
+describe('injectCsvData', () => {
+  it('prepends a DATA declaration before the script body', () => {
+    const out = injectCsvData('console.log(DATA);', [{ a: '1' }]);
+    assert.ok(out.startsWith('const DATA = [{"a":"1"}];'));
+    assert.ok(out.endsWith('console.log(DATA);'));
+  });
+});

--- a/apps/viewer/src/lib/llm/code-extractor.ts
+++ b/apps/viewer/src/lib/llm/code-extractor.ts
@@ -14,8 +14,11 @@ import type { CodeBlock } from './types.js';
  */
 export function extractCodeBlocks(markdown: string): CodeBlock[] {
   const blocks: CodeBlock[] = [];
-  // Match ```lang\n...code...\n```
-  const regex = /```(\w*)\n([\s\S]*?)```/g;
+  // Match ```lang\n...code...\n```. `\r?` before the newline tolerates CRLF
+  // source text (pasted/Windows-authored messages) - without it, the fence's
+  // opening line never matches, the block is silently treated as plain text,
+  // and its "Run" affordance never appears.
+  const regex = /```(\w*)\r?\n([\s\S]*?)```/g;
   let match: RegExpExecArray | null;
   let index = 0;
 


### PR DESCRIPTION
## Summary
- `extractCodeBlocks` (apps/viewer/src/lib/llm/code-extractor.ts) is the AI chat panel's fenced-code-block extractor, used to find and render executable script blocks in an assistant response.
- Its regex required a literal `\n` immediately after the opening fence's language tag. A message with CRLF line endings (pasted content, a Windows-authored snippet, or any `\r\n`-normalized text) has `\r` there instead, so the regex matched **zero** blocks in that message — every fenced block silently rendered as plain text, with no "Run" affordance, and a `bim.`-referencing script lost its executability with no error surfaced anywhere.
- Confirmed by direct execution before writing the fix (see PR discussion / commit message): a small Node repro against the original regex against a CRLF string returned 0 matches.
- Fix: allow an optional `\r` before the newline (`\r?\n`). Verified the added test goes RED against the original regex and GREEN after the fix.
- Added `code-extractor.test.ts` (file previously had zero test coverage) covering: LF happy path, CRLF happy path (regression), a bare/CRLF `bim.`-referencing block, index assignment skipping non-executable blocks, and the existing `injectCsvData` helper.

## Test plan
- [x] `pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=1 src/lib/llm/code-extractor.test.ts` — 7/7 pass after the fix.
- [x] Confirmed RED: reverting the regex to the original (no `\r?`) fails exactly the 2 CRLF-specific subtests.
- [x] Ran alongside `byok-guard.test.ts`, `recent-searches.test.ts`, `filter-rules.test.ts`, `mapping.test.ts`, `descriptor.test.ts` — no regressions (the one unrelated failure, `context-builder.test.ts`, is a pre-existing missing-package-build issue in this environment, not caused by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)