### PR TITLE
test(renderer): cover the 'front' branch of section-plane's axisComponent

### DIFF
--- a/packages/renderer/src/section-plane-range.test.ts
+++ b/packages/renderer/src/section-plane-range.test.ts
@@ -163,6 +163,19 @@ describe('the storey override keeps its axis-aligned units (#2447)', () => {
         assert.strictEqual(mid.sectionPlaneData?.distance, 5);
     });
 
+    // `axisComponent` (render-section-plane.ts) picks which normal component
+    // the override-units check reads: 0 for 'side', 1 for 'down', 2 for
+    // 'front'. Every prior test in this describe block used 'down' — the
+    // 'front' branch of that ternary was never independently exercised, so a
+    // mutation that folds 'front' onto the same component as 'down' left the
+    // whole suite green.
+    it('still honours a valid override on an unrotated front cut', () => {
+        const r = resolve({ axis: 'front', position: 0, min: 3, max: 7 });
+        assert.strictEqual(r.sectionPlaneData?.distance, 3);
+        const mid = resolve({ axis: 'front', position: 50, min: 3, max: 7 });
+        assert.strictEqual(mid.sectionPlaneData?.distance, 5);
+    });
+
     it('honours it for a horizontal cut even when the building is rotated', () => {
         // `axis: 'down'` keeps normal [0,1,0] under a Y rotation, so a
         // storey elevation IS the plane distance and the override is meaningful.


### PR DESCRIPTION
## Summary
- `resolveSectionPlaneFrame`'s storey-override-units check (`packages/renderer/src/render-section-plane.ts`, ~line 348) picks the normal component to validate via a three-way ternary: 0 for `'side'`, 1 for `'down'`, 2 for `'front'`.
- Every existing test in the "the storey override keeps its axis-aligned units" describe block (`section-plane-range.test.ts`) used axis `'down'`; the `'front'` branch was never independently exercised — of the three section-plane axes named in the docs (six-plane logic per the sweep brief, here three axes each usable in both directions), one entire branch had zero coverage.
- Confirmed by mutation: folding the `'front'` branch onto the same component as `'down'` (`: 1` instead of `: 2`) left the entire `pnpm test` suite green (938/938 — `packages/renderer`).

## Test plan
- [x] Added the `'front'`-axis analogue of the existing `'down'` override test: an unrotated front cut with a valid min/max override, checked at 0% and 50% slider position.
- [x] `tsx --test src/section-plane-range.test.ts` — 14/14 pass with the ternary intact
- [x] Same command goes RED (1 failing subtest) under the mutation above, confirming the new test observes the `'front'` branch
- [x] `pnpm test` in `packages/renderer` — 939/939 pass