### PR TITLE
test(renderer): pin governor's MISS_LIMIT boundary

### DIFF
--- a/packages/renderer/src/interaction-effects-governor.test.ts
+++ b/packages/renderer/src/interaction-effects-governor.test.ts
@@ -51,6 +51,19 @@ test('sustained missed frames degrade within the window', () => {
     assert.equal(results[results.length - 1], false, 'sustained misses degrade');
 });
 
+test('degrades at exactly MISS_LIMIT misses, not one frame later', () => {
+    // Every other degrade-timing test drives the miss count well past the
+    // MISS_LIMIT=6 threshold, so an off-by-one (misses > MISS_LIMIT instead
+    // of >=) would still eventually degrade and go unnoticed. Pin the exact
+    // boundary: 5 misses stays enabled, the 6th degrades immediately.
+    const gov = new InteractionEffectsGovernor();
+    const b1 = burst(gov, 0, 10, 10); // calibrate refresh ~10ms
+    const b2 = burst(gov, b1.last + 50, 5, 40); // 5 consecutive missed frames
+    assert.ok(b2.results.every(Boolean), 'fewer than MISS_LIMIT misses stays enabled');
+    const sixth = gov.frame(true, b2.last + 40, false, 0);
+    assert.equal(sixth, false, 'the 6th miss crosses MISS_LIMIT and degrades on this frame');
+});
+
 test('a brief hitch (GC pause) does not degrade', () => {
     const gov = new InteractionEffectsGovernor();
     const { last } = burst(gov, 0, 30, 16.7);


### PR DESCRIPTION
## Summary
- `InteractionEffectsGovernor.frame()` in `packages/renderer/src/interaction-effects-governor.ts` degrades once `misses >= MISS_LIMIT` (6) within the sliding window. Every existing degrade-timing fixture drives well past that count (dozens of missed frames), so a weakening to `misses > MISS_LIMIT` (degrading one frame later than it should) still leaves the whole suite green.
- Confirmed by mutation: `misses >= MISS_LIMIT` -> `misses > MISS_LIMIT` survives all 13 existing tests unchanged.
- Adds one boundary test: calibrate the refresh estimate, drive exactly 5 missed frames (must stay enabled), then one more (the 6th) and assert it degrades on that exact frame.

## Test plan
- [x] `npx tsx --test src/interaction-effects-governor.test.ts` — 14/14 pass on unmodified code.
- [x] Re-ran with the `misses > MISS_LIMIT` mutation reapplied — new test fails, 13/14.
- [x] Restored `interaction-effects-governor.ts` to its original state (test-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage confirming interaction effects remain enabled through five missed frames and degrade on the sixth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->