### PR TITLE
test(mutations): assert BulkQueryEngine.select() AND-composes propertyFilters

### DIFF
--- a/packages/mutations/test/bulk-query-engine.test.ts
+++ b/packages/mutations/test/bulk-query-engine.test.ts
@@ -267,4 +267,41 @@ describe('BulkQueryEngine property filter operators', () => {
       ).toEqual([2]);
     });
   });
+
+  describe('multiple propertyFilters compose as AND', () => {
+    // Two independent properties per entity so a fixture with only one
+    // filter can't observe whether later filters actually narrow the
+    // candidate set or silently replace it (`select()` applies each
+    // filter in `criteria.propertyFilters` in sequence over the same
+    // `candidates` array — a bug that used only the LAST filter would
+    // pass every single-filter test above unnoticed).
+    function makeEngineWithTwoProperties(rows: Array<[string, number]>) {
+      const entities = makeEntities(rows.length);
+      const view = new MutablePropertyView(null, 'model-1');
+      view.setOnDemandExtractor(() => []);
+      rows.forEach(([category, qty], i) => {
+        const entityId = i + 1;
+        view.setProperty(entityId, 'Pset_Test', 'Category', category, PropertyValueType.Label);
+        view.setProperty(entityId, 'Pset_Test', 'Qty', qty, PropertyValueType.Real);
+      });
+      return new BulkQueryEngine(entities, view, null, null, null);
+    }
+
+    it('narrows on both conditions, not just the last one in the array', () => {
+      const engine = makeEngineWithTwoProperties([
+        ['A', 5], // entity 1: matches Category, fails Qty
+        ['A', 15], // entity 2: matches both
+        ['B', 15], // entity 3: fails Category, matches Qty
+      ]);
+
+      const ids = engine.select({
+        propertyFilters: [
+          { psetName: 'Pset_Test', propName: 'Category', operator: '=', value: 'A' },
+          { psetName: 'Pset_Test', propName: 'Qty', operator: '>', value: 10 },
+        ],
+      });
+
+      expect(ids).toEqual([2]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`BulkQueryEngine.select()` applies each `criteria.propertyFilters` entry in a loop, narrowing `candidates` on every iteration (AND composition). Every existing fixture in `bulk-query-engine.test.ts` passed exactly one filter, so this loop's actual composition behavior was never independently observed — a regression that applied only the last filter (or replaced instead of narrowed) would have passed all 25 existing tests.

## Evidence

Mutation:
```diff
- if (criteria.propertyFilters && criteria.propertyFilters.length > 0) {
-   for (const filter of criteria.propertyFilters) {
-     candidates = this.filterByProperty(candidates, filter);
-   }
- }
+ if (criteria.propertyFilters && criteria.propertyFilters.length > 0) {
+   const filter = criteria.propertyFilters[criteria.propertyFilters.length - 1];
+   candidates = this.filterByProperty(candidates, filter);
+ }
```
Result: all 25 existing tests stayed green (survived).

Added a fixture with two independent property conditions (`Category = 'A'` AND `Qty > 10`) across three entities, where each condition alone matches a different, wrong subset ([1,2] vs [2,3]) and only the AND-composition matches the correct singleton ([2]).

Re-ran the same mutation against the new test: **RED** (`expected [2, 3] to equal [2]`). Reverted the mutation, confirmed green: 26/26.

## Test plan
- [x] `pnpm exec vitest run test/bulk-query-engine.test.ts` in `packages/mutations` — 26/26 passing
- [x] Confirmed the new assertion goes RED under the described mutation, then reverts to GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)