### PR TITLE
test(drawing-2d): independently observe door, window, and bare-opening classification

### DIFF
--- a/packages/drawing-2d/src/openings/opening-relationship-builder.test.ts
+++ b/packages/drawing-2d/src/openings/opening-relationship-builder.test.ts
@@ -60,4 +60,38 @@ describe('OpeningRelationshipBuilder', () => {
     expect(info?.type).toBe('door');
     expect(info?.doorOperation).toBe('DOUBLE_DOOR_SINGLE_SWING');
   });
+
+  // determineOpeningType has three arms (door / window / bare opening with no
+  // symbol type). The test above only exercises the door arm, so a bug that
+  // misclassifies a window (e.g. as a door) would pass every existing
+  // fixture. Each opening here has a distinct filling type so the three
+  // arms are independently observable in one assertion pass.
+  it('classifies door, window, and bare openings independently', () => {
+    const entityMetadata = new Map<number, EntityMetadata>([
+      [10, { ifcType: 'IfcOpeningElement', bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 2 } } }],
+      [20, { ifcType: 'IfcDoor' }],
+      [30, { ifcType: 'IfcOpeningElement', bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 2 } } }],
+      [40, { ifcType: 'IfcWindow' }],
+      [50, { ifcType: 'IfcOpeningElement', bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 2 } } }],
+    ]);
+
+    const relationships = new OpeningRelationshipBuilder(entityMetadata)
+      .addVoidRelationships([
+        { hostId: 1, openingId: 10 },
+        { hostId: 1, openingId: 30 },
+        { hostId: 1, openingId: 50 }, // no fill -> bare opening
+      ])
+      .addFillRelationships([
+        { openingId: 10, elementId: 20 }, // door
+        { openingId: 30, elementId: 40 }, // window
+      ])
+      .build(0);
+
+    expect(relationships.openingInfo.get(10)?.type).toBe('door');
+    expect(relationships.openingInfo.get(30)?.type).toBe('window');
+    expect(relationships.openingInfo.get(50)?.type).toBe('opening');
+
+    // doorOperation must not leak onto a window-filled opening.
+    expect(relationships.openingInfo.get(30)?.doorOperation).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

`OpeningRelationshipBuilder.determineOpeningType()` has three arms (door / window / bare opening with no recognized filling type), but `opening-relationship-builder.test.ts` only exercised the door arm ("assigns doorOperation only for door-type openings"). A misclassified window would pass every existing fixture, including a spurious `doorOperation` extraction downstream (gated on `type === 'door'`).

## Evidence

Mutation:
```diff
-    if (upper.includes('WINDOW')) return 'window';
+    if (upper.includes('WINDOW')) return 'door';
```
Result: the existing 2-test suite stayed green (survived).

Added a fixture with three openings sharing the same host — a door-filled opening, a window-filled opening, and an unfilled (bare) opening — asserting all three classifications independently in one pass, plus that `doorOperation` stays `undefined` on the window.

Re-ran the same mutation against the new test: **RED** (`expected 'door' to be 'window'`). Reverted the mutation, confirmed green: 3/3, and the full package suite (32 files / 371 tests) still passes.

## Test plan
- [x] `pnpm exec vitest run src/openings/opening-relationship-builder.test.ts` in `packages/drawing-2d` — 3/3 passing
- [x] `pnpm exec vitest run` (full package) — 371/371 passing
- [x] Confirmed the new assertion goes RED under the described mutation, then reverts to GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)