### PR TITLE
test(renderer): harden toLocalFrameRay's singular-matrix fallback

### DIFF
--- a/packages/renderer/src/raycast-point-cloud-query.test.ts
+++ b/packages/renderer/src/raycast-point-cloud-query.test.ts
@@ -385,6 +385,36 @@ describe('queryPointClouds with an aligned point cloud', () => {
     assert.deepStrictEqual(identity!.position, bare!.position);
     assert.strictEqual(identity!.distance, bare!.distance);
   });
+
+  it('falls back to the RAW (untransformed) query for a singular matrix, rather than throwing', () => {
+    // A finite, non-identity matrix whose linear part has a collapsed
+    // column (zero z-axis) is singular: MathUtils.invert returns null.
+    // toLocalFrameRay's contract is to treat that exactly like "no
+    // transform needed" (comment above `toLocalFrameRay`: "a safe
+    // fallback for a degenerate matrix") — not to crash on `inv.m`.
+    const singular = new Float32Array([
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 0, 0,
+      5, 0, 0, 1,
+    ]);
+    const index = indexWithPointAt(0, 0, -10);
+    const bare = queryPointClouds(() => sourceWith(index, undefined), rayToward(0, 0), CAMERA, 100);
+    const withSingularModel = queryPointClouds(
+      () => sourceWith(index, singular),
+      rayToward(0, 0),
+      CAMERA,
+      100,
+    );
+    assert.ok(bare, 'sanity: the raw point is reachable at all');
+    assert.ok(withSingularModel, 'a singular alignment matrix must not suppress the raw-index hit');
+    assert.deepStrictEqual(
+      withSingularModel!.position,
+      bare!.position,
+      'singular matrix must fall back to the RAW query, exactly like an absent/identity matrix',
+    );
+    assert.strictEqual(withSingularModel!.distance, bare!.distance);
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary
- `toLocalFrameRay` (packages/renderer/src/pointcloud/point-cloud-ray-transform.ts) guards a singular `node.model` (finite, non-identity, but with a collapsed axis so `MathUtils.invert` returns null) by falling back to the raw/untransformed query — the same path used for an absent or identity matrix.
- No existing fixture ever supplied a singular matrix, so this guard was silently unexercised: deleting `if (!inv) return null;` left the full renderer suite green (851/851).
- Adds a targeted case to `queryPointClouds with an aligned point cloud` in `raycast-point-cloud-query.test.ts` using a matrix with a zero-collapsed z-axis column, asserting the query falls back to the raw hit rather than throwing on `inv.m`.

## Test plan
- [x] `pnpm test` in `packages/renderer` — new test passes against unmodified source (27/27 in the target file, 852/852 overall net of 3 pre-existing unrelated failures in `renderer-device-loss-latch`, `renderer-init-reentry`, `renderer-render-paths`, present on `upstream/main` before this change).
- [x] Mutation proof: removed the `if (!inv) return null;` guard — new test goes RED (throws on `inv.m`); restored the guard — GREEN again.

Test-only hardening; no changeset per repo convention.