### PR TITLE
test(sdk): warm list.test.ts's dynamic imports outside the test budget

### DIFF
--- a/packages/sdk/src/namespaces/list.test.ts
+++ b/packages/sdk/src/namespaces/list.test.ts
@@ -19,8 +19,46 @@
  * of undefined (reading 'length')` instead of running unfiltered.
  */
 
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { ListNamespace, type ListDefinition } from './list.js';
+
+/**
+ * `ListNamespace.execute()` dynamically imports `@ifc-lite/lists` and
+ * `@ifc-lite/data` on first use (`loadLists` in `list.ts`) so SDK consumers
+ * who never touch `bim.list` don't pay for them. Right tradeoff for real
+ * callers -- but it means whichever test here runs first pays the one-time
+ * cold-import cost inside its own timer: measured at 2002ms cold and 481ms on
+ * a warm repo, against 2-3ms once the modules are resolved.
+ *
+ * Under CI's parallel load that alone crosses the 5000ms default. This file
+ * failed on FIVE unrelated PRs at once -- #2822, #2905, #2907, #2923, #2930 --
+ * every one between 5005ms and 5056ms, while passing locally on the same
+ * commit. Warming here moves the cost outside every `it()`'s budget, so each
+ * test times only its own logic and keeps the tight default: a genuine hang
+ * still fails in 5s rather than 30s.
+ *
+ * Same root cause and directory as `ids.test.ts` (3a00b5e64, which reported
+ * 5021-5038ms), and the same shape as `packages/export/src/parquet-geometry.test.ts`
+ * (#2248). `bcf.ts`, `drawing.ts` and `sandbox.ts` share the lazy-import idiom
+ * and have not fired yet.
+ *
+ * Warmed rather than mocked: these tests exist to prove the real bridge to the
+ * real library produces real values, and a mocked `executeList` would pass
+ * with the very column-mapping bug they were written to catch (#2841).
+ *
+ * Known limitation, and the alternative was tried rather than assumed: this
+ * names `execute()`'s imports instead of driving `execute()` itself, so a
+ * third dependency added there would silently stop being covered. Driving the
+ * real method would stay correct by construction, but every module-scope
+ * `await` form breaks function hoisting in this file under vite's transform
+ * (`makeProviderWithPsets` hits `ReferenceError: makeProvider is not
+ * defined`), which is why the warm-up sits in `beforeAll`. If `execute()`
+ * gains an import, add it here.
+ */
+beforeAll(async () => {
+  await import('@ifc-lite/lists');
+  await import('@ifc-lite/data');
+}, 30_000);
 
 interface Provider {
   getEntitiesByType: (type: number) => number[];


### PR DESCRIPTION
## Why

`packages/sdk/src/namespaces/list.test.ts` failed on **five unrelated PRs at once** — #2822, #2905, #2907, #2923, #2930 — every one just past vitest's 5000 ms default:

```
× resolves attribute columns (name/type/globalId) to real values instead of null   5056ms
× resolves attribute columns ...                                                   5044ms
× resolves attribute columns ...                                                   5039ms
× resolves attribute columns ...                                                   5038ms
× does not throw when conditions is omitted (documented as optional)               5005ms
```

The same file passes locally on the same commit. So one flaky test was gating roughly a fifth of the open board, and five authors were being told their change had broken something it never touched.

## Cause

Not the assertions. `ListNamespace.execute()` dynamically imports `@ifc-lite/lists` and `@ifc-lite/data` on first use (`loadLists`, `list.ts:53`) so consumers who never touch `bim.list` don't pay for them — right for real callers, but **whichever `it()` runs first pays the one-time cold-import cost inside its own timer.**

Measured: **2002 ms cold / 481 ms warm** for that test, against **2–3 ms** for the other three.

Third instance of one class. `ids.test.ts`, same directory, was fixed two days ago (`3a00b5e64`) for the identical cause at **5021–5038 ms**. `packages/export/src/parquet-geometry.test.ts` (#2248) is the same shape again.

## Why warmed rather than a raised timeout

My first version raised the timeout to 30 s. Warming is better on three counts: every `it()` keeps the tight 5000 ms default so a **genuine hang still fails in 5 s rather than 30**; a test added later is covered without anyone remembering; and it matches the two existing answers in this repo rather than inventing a third.

**Warmed rather than mocked, deliberately.** These tests exist to prove the *real* bridge to the *real* library produces real values — a mocked `executeList` would pass with the exact column-mapping bug they were written to catch (#2841).

## Verification

| | first test | others |
|---|---|---|
| with the warm-up | **2 ms** | 1–2 ms |
| warm-up removed | 481 ms warm / 2002 ms cold | 1–2 ms |

## Two review findings, recorded rather than dropped

**The warm list duplicates knowledge from `execute()`** — if a third dependency is added there this silently stops covering it, and a stale warm-up is indistinguishable from a working one. Driving `execute()` itself would stay correct by construction, and **I tried it**: every module-scope `await` form breaks function hoisting in this file under vite's transform, so `makeProviderWithPsets` hits `ReferenceError: makeProvider is not defined`. Hence `beforeAll`, with the limitation written at the warm-up.

**`bcf.ts`, `drawing.ts`, `sandbox.ts` share the same lazy-import idiom** and have not fired yet. Noted, not fixed here.

## Scope

This treats a symptom of CI contention, not the contention itself. But a test that cannot survive a busy runner is its own defect, and this one was mislabelling five innocent PRs as broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an asynchronous test-suite warm-up to ensure required list and data components are ready before testing.
  * Increased setup timeout to support reliable initialization.
  * Existing test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->