### PR TITLE
test(parser,export): give two real-fixture tests the timeout their siblings have

### DIFF
--- a/packages/export/src/reference-collector.equivalence.test.ts
+++ b/packages/export/src/reference-collector.equivalence.test.ts
@@ -312,6 +312,8 @@ describe('reference-collector: source-shape equivalence', () => {
     });
   });
 
+  // 60s: parses a 2.4 MB IFC; ~2.3s under CI fork contention against vitest's
+  // 5000ms default. Same shape as the parser twin, which went over.
   it('agrees across source shapes on a real IFC file', async (ctx) => {
     if (!existsSync(FIXTURE_PATH)) {
       // ctx.skip(), never a bare `return`: a return records a PASS, so the
@@ -405,5 +407,5 @@ describe('reference-collector: source-shape equivalence', () => {
     expect(styledRaw.size).toBeGreaterThan(closureRaw.size);
     expect(sorted(styledAccessor)).toEqual(sorted(styledRaw));
     expect(sorted(styledReference)).toEqual(sorted(styledRaw));
-  });
+  }, 60_000);
 });


### PR DESCRIPTION
Fixes the flake blocking #2905, #2930 and #2869.

## The failure

`packages/parser/src/widened-readers.equivalence.test.ts > agrees across source shapes on a real IFC file`, `Test timed out in 5000ms`. Three PRs, none of which touched parser code.

## It is not a slow test, it is a missing guard rail

The test parses a 2.4 MB IFC (`ara3d/AC20-FZK-Haus.ifc`) four ways. Per-file reporter line, which excludes import and transform:

| | |
|---|---|
| local, uncontended | ~125 ms |
| CI, on a **green** main run | **4356 ms** (87% of the 5000ms default) |
| CI, on the failing run | 5257 ms |

87% of budget on a good day. It was one busy runner away from red at all times, and today's ~70 open PRs supplied the busy runner.

Every sibling real-fixture test in that package already carries an explicit timeout:

```
entity-extractor.equivalence.test.ts:185    }, 60_000);
data-store-transport.test.ts:74,148,161,223 }, 120_000);
data-store-transport.test.ts:183            }, 180_000);
blocked-source-equivalence.test.ts:93       { timeout: 60_000 }
```

This file never got one. An omission, not a policy choice.

## Why 60_000, and why not a package-level `testTimeout`

`60_000` matches `entity-extractor.equivalence.test.ts` — same directory, same fixture, same equivalence-over-a-real-file shape. Deliberately not a fresh estimate; matching the nearest sibling is what stops sites drifting into different numbers.

A package-level `testTimeout` would invent a second mechanism beside a working one and loosen the bound for the ~60 fast files a tight 5s still serves. #2935 established the rule (do not blanket-raise), and a targeted per-test timeout is what this package already does six times, so this follows that rule rather than bending it.

It is also **not** the fix for the transform tax in #2943. That cost lands at collection time, outside the callback vitest times, so externalising sibling `dist/` and `pkg/` bundles cuts this package's wall clock without moving this budget at all. Separate and additive; noted because the two are easy to conflate.

## Second file

`packages/export/src/reference-collector.equivalence.test.ts` has the same test name, the same fixture and the same shape, measured 2281ms in the same green run, and had no timeout. Fixed alongside because it is the same test, not because a sweep was in scope.

## A wrong claim I had to retract

An earlier draft said these were "the only two" real-fixture tests without a timeout. That was false, and the way it was false is worth recording.

**There are three spellings of a vitest timeout in this repo**, and a grep for any one reports the other two as absent:

```
}, 60_000);                    trailing        ~7 sites in these packages
it(name, { timeout: N }, fn)   options object  blocked-source-equivalence.test.ts:93
},\n    60_000,\n  );          multi-line      12 sites incl. overlay-effective-model.test.ts:987
```

My single-idiom grep scored already-protected files as unprotected, and a review that flagged the error then made the mirror mistake in the other direction, listing `overlay-effective-model.test.ts:961` as untimed when it carries `60_000` in the third spelling.

A brace-matching audit across all three finds **5 further untimed tests in the 2000-5000ms band**, all in other families (gym episodes, wasm panic forwarding, clash engine). Filed separately rather than swept in here.

## Verification

- **The timeout argument is wired, not decorative.** Under `--testTimeout=50` both tests pass (125ms, 84ms) while an identical test with no third argument fails at 50ms.
- **Both tests really run.** Confirmed against the real fixture, not skipped — `ctx.skip()` reports as a pass, and a genuinely absent fixture renders as a distinct `↓` line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated equivalence tests to allow up to 60 seconds for completion.
  * Added runtime expectation documentation to clarify that these tests may take longer than standard test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->