### PR TITLE
test(ffi): pin the ty and tz conjuncts of the site-local threshold (#2936)

### DIFF
--- a/rust/ffi/src/tests.rs
+++ b/rust/ffi/src/tests.rs
@@ -120,13 +120,15 @@ fn raw_ifc_with_near_origin_site_translation_is_left_untouched() {
     assert_eq!(result.meshes[1].positions, original_positions_b);
 }
 
-/// Pin the boundary's sharpness on the x-axis, *relative to whatever
-/// `LARGE_COORD_THRESHOLD` currently is*: tx just above the constant must
-/// shift, tx just below must not (ty and tz are held at 0.0 and are not
-/// independently exercised here). The other two fixtures straddle it by
-/// roughly five orders of magnitude (1.0 vs 123456.0), so any threshold
-/// anywhere in between would satisfy them both — this fixture closes that
-/// gap for the *boundary behavior*.
+/// Pin the boundary's sharpness on EACH axis independently, *relative to
+/// whatever `LARGE_COORD_THRESHOLD` currently is*: a translation just above
+/// the constant on any one axis must shift, just below must not. The guard is
+/// a three-way conjunction, so one axis proves nothing about the other two.
+/// With only the x cases present, the `ty` and `tz` conjuncts could each be
+/// deleted outright and all 11 tests still passed (#2936). The other two
+/// fixtures straddle it by roughly five orders of magnitude (1.0 vs
+/// 123456.0), so any threshold anywhere in between would satisfy them both —
+/// this fixture closes that gap for the *boundary behavior*.
 ///
 /// This does **not** pin the constant's *value*: every value used below is
 /// derived from `LARGE_COORD_THRESHOLD` itself, so the fixture is green for
@@ -151,6 +153,14 @@ fn the_large_coordinate_threshold_is_bracketed_on_both_sides() {
         // tell `<` from `<=` apart — both compile and pass identically
         // either way. This closes that gap.
         ([LARGE_COORD_THRESHOLD, 0.0, 0.0], true),
+        // The same three brackets on y and on z: the guard ANDs the three
+        // axes, so each conjunct needs its own boundary.
+        ([0.0, LARGE_COORD_THRESHOLD + 0.5, 0.0], true),
+        ([0.0, LARGE_COORD_THRESHOLD - 0.5, 0.0], false),
+        ([0.0, LARGE_COORD_THRESHOLD, 0.0], true),
+        ([0.0, 0.0, LARGE_COORD_THRESHOLD + 0.5], true),
+        ([0.0, 0.0, LARGE_COORD_THRESHOLD - 0.5], false),
+        ([0.0, 0.0, LARGE_COORD_THRESHOLD], true),
     ] {
         let [tx, ty, tz] = translation;
         let original = processing_result(
@@ -166,7 +176,7 @@ fn the_large_coordinate_threshold_is_bracketed_on_both_sides() {
             assert_eq!(
                 result.mesh_coordinate_space.as_deref(),
                 Some(SITE_LOCAL_MESH_COORDINATE_SPACE),
-                "tx={tx} is past the threshold and must be shifted"
+                "({tx}, {ty}, {tz}) is at or past the threshold and must be shifted"
             );
             let expected_a: Vec<f32> = original_positions_a
                 .chunks_exact(3)
@@ -183,7 +193,7 @@ fn the_large_coordinate_threshold_is_bracketed_on_both_sides() {
             assert_eq!(
                 result.mesh_coordinate_space.as_deref(),
                 Some(RAW_IFC_MESH_COORDINATE_SPACE),
-                "tx={tx} is inside the threshold and must be left alone"
+                "({tx}, {ty}, {tz}) is inside the threshold and must be left alone"
             );
             assert_eq!(result.meshes[0].positions, original_positions_a);
         }


### PR DESCRIPTION
Closes #2936.

## The gap

`normalize_to_site_local` (`rust/ffi/src/lib.rs:145-147`) guards on a three-way conjunction:

```rust
site_tx.abs() < LARGE_COORD_THRESHOLD
    && site_ty.abs() < LARGE_COORD_THRESHOLD
    && site_tz.abs() < LARGE_COORD_THRESHOLD
```

Only the `tx` conjunct was pinned. **Two thirds of the guard could be deleted outright with the whole suite green.**

| mutation | before | after |
|---|---|---|
| `tx`: `<` → `<=` *(control)* | KILLED | FAILED |
| `ty`: `<` → `<=` | SURVIVED 11/11 | FAILED |
| `tz`: `<` → `<=` | SURVIVED 11/11 | FAILED |
| `ty` conjunct → `true` | SURVIVED 11/11 | FAILED |
| `tz` conjunct → `true` | SURVIVED 11/11 | FAILED |

Review reproduced the whole table independently in a detached worktree, both directions, and confirmed the single failing test in every case is `the_large_coordinate_threshold_is_bracketed_on_both_sides`.

## What the missing pins allowed

A site far from the origin on y or z would skip site-local normalisation entirely, leaving the consumer to do its transform and render math on coordinates at georeferenced magnitude. No crash, no error, wrong geometry.

To be precise about the stage: `positions` is already `Vec<f32>` by the time this runs, so this is not where the first quantization happens. What the normalisation prevents is the further collapse downstream. This repo has a documented history of exactly that (`docs/architecture/coordinate-handling.md`), and it is the FFI surface, where the consumer count makes a quiet wrong answer expensive.

## Two axis swaps come free

Not the goal, but the sharper proof that the tuples do real work:

| production mutation | before | after |
|---|---|---|
| read `(st[12], st[14], st[13])` — swap ty/tz | survives | FAILED |
| `chunk[1] -= site_tz`, `chunk[2] -= site_ty` | survives | FAILED |

These die via the per-component expectation on the `should_shift == true` cases. The `false` cases assert only "nothing changed", and a no-op has no axis, so they cannot observe a wrong read on their own.

The fixture is `[0,0,0, 1,2,3]` — deliberately not axis-symmetric, so subtracting on y is distinguishable from subtracting on z. All values (1000.5, 999.5, 1000.0 against 0/1/2/3) are exactly representable in f32, so no rounding slack hides anything.

## Per-tuple independence

Each new tuple was dropped individually and the mutations re-run:

- `[0, T-0.5, 0]` — sole killer of "ty threshold halved"
- `[0, T, 0]` — sole killer of `ty <=`
- `[0, 0, T-0.5]` — sole killer of "tz threshold halved"
- `[0, 0, T]` — sole killer of `tz <=`
- the two `T+0.5` tuples — subsumed

The two subsumed ones are kept deliberately: the pre-existing x block has the identical structure including its one redundant member, and the new tuples mirror it exactly. Symmetry across the three axes is worth more here than dropping two lines.

## Also

The doc comment said *"ty and tz are held at 0.0 and are not independently exercised here"*. True when written; this commit makes it false, so it is updated in the same change rather than becoming the next stale safety comment.

## Deferred

Nothing pins `lib.rs:154`'s "subtract with f64 precision, then store as f32" — rewriting all three lines to `chunk[0] - site_tx as f32` leaves 11/11 green, because every fixture coordinate is exactly representable in f32. A fixture whose f64 and f32 subtractions differ would be needed. Filed separately rather than widening this PR.

Workspace: 1909 passed, 0 failed. Clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded large-coordinate coverage across the x, y, and z axes.
  * Added checks for values above, below, and exactly at the boundary threshold.
  * Improved test failure messages to display the complete translation values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->