### PR TITLE
test(fixtures): manifest the 860 solid-stratum fixture so CI can fetch it

### DIFF
--- a/tests/models/manifest.json
+++ b/tests/models/manifest.json
@@ -754,6 +754,11 @@
       "size": 228220
     },
     {
+      "path": "issues/860_solid_stratum.ifc",
+      "sha256": "e2ac9a2382866c5cc3ac021d0143f0fe4e264253d905f1b33340dd36b13813de",
+      "size": 67104
+    },
+    {
       "path": "issues/953_trimmed_curve_cartesian_arc.ifc",
       "sha256": "1740106fe498b12e36b09a4d752d4de538559fbbfadb5aa339e3150ffaf19592",
       "size": 129717


### PR DESCRIPTION
Pairs with #2835. That PR makes a missing fixture loud; this one supplies the fixture it was loud about.

## What was wrong

`glb_nodes_have_export_rows_for_legacy_products` iterates three fixtures. Two are manifested and CI fetches them, so **the test has always run with real coverage** — but the third, `issues/860_solid_stratum.ifc`, was in neither the manifest nor the `fixtures-v1` release. `pnpm fixtures` had nothing to download, so that case has never executed on CI. It passed locally only on machines where the file happened to exist.

The case that never ran is the geoscience `IfcSolidStratum` one the test's own doc comment names. The comment saying *"CI fetches the corpus, so `found` is 3 there"* was an aspiration, not a description.

*(An earlier draft of this PR claimed the whole test had never run on CI. That was wrong and a reviewer caught it — the two ifcopenshell fixtures are manifested and the `checked > 0` assertion did fire.)*

## The blob is anonymised

The header carried a named individual, a company and an internal tracker reference. It was already public on issue #860, but a reporter posting a file is not the named engineer agreeing to have it in this project's release assets.

Replaced with placeholders: `FILE_NAME` author/organisation/originating-system, `IFCPERSON`, `IFCORGANIZATION`, `IFCAPPLICATION`, and the `IFCPROJECT` name.

**What anonymising does not remove, stated plainly:** the geometry is ~2200 real surveyed MGA94 Zone 56 coordinates, and `IFCPROJECTEDCRS('EPSG:28356', ...)` is kept deliberately, so the site inverse-projects to roughly `-26.997, 150.546` (rural Queensland) to about a metre. That is inherent to a georeferenced fixture and cannot be stripped without destroying what the fixture tests. A bare terrain TIN with no person, company or project attached is not personal data, but the location is present and readable, so it is recorded rather than implied away.

Structure untouched: 42 entities before and after, every reference intact, zero dangling refs. The authoring tool name is kept for the same reason `Revit` appears in other fixtures.

Independent review extracted all 52 string literals from the released blob: no person, company or tracker reference survives anywhere in the file, not just the header. No STEP comments, no `\X` escapes, zero non-ASCII bytes.

## Verified end to end, not by inspection

- Replacing the fixture with an empty STEP file makes the test **FAIL** — so its pass is not a skip.
- `fetch-fixtures.mjs` downloads it from the release and hash-verifies: `fetched=1 skipped=0 errors=0`. Tamper-tested: appending one byte makes the script detect the mismatch and re-download, so the hash check is real rather than decorative.
- The test passes against the fetched copy.
- `triangulation_invariance.rs` sweeps every manifest fixture under 50 MB against a pinned golden. This file has no `IFCRELVOIDSELEMENT` and no `IFCOPENINGELEMENT`, so it contributes zero rows and needs no re-bless.

## Ordering

Inserted in `build-manifest.mjs` order (`localeCompare`, between 859 and 953) and verified with that comparator: **0 of 164 positions differ** from what the generator emits, so the next `pnpm fixtures:manifest` is a no-op rather than silent churn on someone else's PR.

## Not the only one

`ara3d/AC-20-Smiley-West-10-Bldg.ifc` is referenced by `issue_584_smiley_west_test.rs` and `voids_production_test.rs` and has never been manifested either — same defect class, still skipping forever on CI. Left for a follow-up rather than widened into here.