### PR TITLE
feat(export): copy a shared record before editing it

### DIFF
--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -36,6 +36,7 @@ mod rooms;
 mod schema_convert;
 mod shades;
 mod step;
+mod step_cow;
 mod step_text;
 mod usd;
 

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -89,8 +89,8 @@ pub use obj::{export_obj, export_obj_with_stats, ObjOptions, ObjStats};
 #[cfg(feature = "parquet-bos")]
 pub use parquet_bos::{export_bos, ParquetBosOptions};
 pub use step::{
-    export_step, export_step_json, export_step_with_stats, AttrMutation, PropMutation, StepOptions,
-    StepStats,
+    export_step, export_step_json, export_step_with_stats, AttrMutation, CopyOnWriteMutation,
+    PropMutation, StepOptions, StepStats,
 };
 pub use usd::{export_usd, UsdOptions};
 

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -34,6 +34,38 @@ pub struct PropMutation {
     pub value: String,
 }
 
+/// Replace one attribute of a record that other records share, by copying the
+/// record and repointing a single referrer at the copy.
+///
+/// The reason this is a writer job rather than a caller one is the id. A copy
+/// needs a number no record holds, and the writer is what knows `max_id`; a
+/// caller that allocates its own has to agree with `PropMutation`'s synthesis
+/// about which numbers are free, and two allocators sharing one space is a
+/// collision waiting for the first export that uses both.
+///
+/// Doing it here also keeps the copy inside the emit path, so it is counted in
+/// [`StepStats::written`] and converted when the export targets another schema.
+/// A record spliced into the output afterwards is neither.
+///
+/// Property sets are the case this exists for. IFC exporters routinely give
+/// each element its own `IfcPropertySet` and point them all at one
+/// `IfcPropertySingleValue` per distinct value, so editing that value in place
+/// changes it for every element sharing it. Copying first changes one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CopyOnWriteMutation {
+    /// The record to copy.
+    pub express_id: u32,
+    /// Which attribute of the copy to replace, zero-based.
+    pub index: usize,
+    /// The replacement, STEP-serialized, e.g. `IFCLABEL('2HR')`.
+    pub value: String,
+    /// The record that should point at the copy instead of the original.
+    pub referrer_id: u32,
+    /// Which attribute of the referrer holds that reference. A list attribute
+    /// is rewritten with the one reference substituted and the rest untouched.
+    pub referrer_index: usize,
+}
+
 /// Options for STEP export.
 pub struct StepOptions {
     /// FILE_SCHEMA label to write (e.g. `IFC4`). `None` ⇒ preserve the source schema.
@@ -46,6 +78,8 @@ pub struct StepOptions {
     pub attribute_mutations: Vec<AttrMutation>,
     /// Property create/update edits — synthesized as new pset entities appended to DATA.
     pub property_mutations: Vec<PropMutation>,
+    /// Copy-then-edit mutations for records other records share.
+    pub copy_on_write: Vec<CopyOnWriteMutation>,
     pub description: String,
     pub author: String,
     pub organization: String,
@@ -59,6 +93,7 @@ impl Default for StepOptions {
             included: None,
             attribute_mutations: Vec::new(),
             property_mutations: Vec::new(),
+            copy_on_write: Vec::new(),
             description: "ViewDefinition [CoordinationView]".to_string(),
             author: "".to_string(),
             organization: "".to_string(),
@@ -75,7 +110,10 @@ pub struct StepStats {
     pub written: usize,
 }
 
-use crate::step_text::{apply_attr_mutations, detect_schema, escape, refs_in_line};
+use crate::step_text::{
+    apply_attr_mutations, attribute_of, detect_schema, escape, refs_in_line, renumber,
+    substitute_ref_in_attr,
+};
 
 // ── Mutation JSON bridge (the wasm-facing contract) ─────────────────────────
 
@@ -204,6 +242,59 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
         muts_by_id.entry(m.express_id).or_default().push((m.index, m.value.clone()));
     }
 
+    // Copy-on-write, resolved before the emit loop so the copies and the
+    // repointed referrers both go through it.
+    //
+    // Allocated from a counter `PropMutation` synthesis continues from, so the
+    // two cannot hand out the same id. `saturating_add` because this now runs
+    // on every export: a file holding `u32::MAX` used to reach it only when
+    // property mutations were present.
+    let mut next_id = max_id.saturating_add(1);
+    let mut copies: Vec<(u32, u32, usize, String)> = Vec::new();
+    // Folded per (referrer, attribute). Two copies repointed through the same
+    // attribute each produced a rewrite of the whole attribute computed from
+    // the untouched original, and the second overwrote the first: one copy was
+    // orphaned and the referrer still pointed at the record it was supposed to
+    // stop sharing. Two properties on one element is the ordinary case, so the
+    // substitutions are applied in sequence to one accumulating value.
+    let mut referrer_edits: HashMap<(u32, usize), String> = HashMap::new();
+    for cow in &opts.copy_on_write {
+        if !line_of.contains_key(&cow.express_id) || !included.contains(&cow.referrer_id) {
+            continue;
+        }
+        let Some(&(rs, re)) = line_of.get(&cow.referrer_id) else {
+            continue;
+        };
+        let copy_id = next_id;
+
+        // Computed against what the attribute holds now, which is the previous
+        // substitution's output when there was one.
+        let current = match referrer_edits.get(&(cow.referrer_id, cow.referrer_index)) {
+            Some(edited) => edited.clone(),
+            None => {
+                let raw = String::from_utf8_lossy(&content[rs..re]);
+                match attribute_of(&raw, cow.referrer_index) {
+                    Some(attr) => attr,
+                    None => continue,
+                }
+            }
+        };
+        let Some(rewritten) = substitute_ref_in_attr(&current, cow.express_id, copy_id) else {
+            // The referrer does not hold that reference, so there is nothing to
+            // repoint. Emitting the copy anyway would leave a record nothing
+            // points at, and one that may reference records the export filtered
+            // out. Skipped rather than half-applied.
+            continue;
+        };
+
+        next_id += 1;
+        copies.push((copy_id, cow.express_id, cow.index, cow.value.clone()));
+        referrer_edits.insert((cow.referrer_id, cow.referrer_index), rewritten);
+    }
+    for ((referrer_id, index), value) in referrer_edits {
+        muts_by_id.entry(referrer_id).or_default().push((index, value));
+    }
+
     // 3. Emit header + filtered entities (source order) + footer.
     let mut out = String::new();
     out.push_str("ISO-10303-21;\nHEADER;\n");
@@ -243,6 +334,28 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
         }
     }
 
+    // The copies, emitted rather than appended: counted in `written` and put
+    // through `convert_step_line` like every other record.
+    for (copy_id, source_id, index, value) in &copies {
+        if let Some(&(s0, e0)) = line_of.get(source_id) {
+            let raw = String::from_utf8_lossy(&content[s0..e0]);
+            let edited = apply_attr_mutations(&raw, &[(*index, value.clone())]);
+            let renumbered = renumber(&edited, *copy_id);
+            if converting {
+                out.push_str(&crate::schema_convert::convert_step_line(
+                    &renumbered,
+                    &source_schema,
+                    &schema,
+                    *copy_id,
+                ));
+            } else {
+                out.push_str(&renumbered);
+            }
+            out.push('\n');
+            written += 1;
+        }
+    }
+
     // 4. Synthesize new property sets from property mutations (fresh ids past max_id).
     if !opts.property_mutations.is_empty() {
         // Group props by (entity, pset) preserving first-seen order.
@@ -261,7 +374,7 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             groups[idx].1.push((m.prop_name.as_str(), m.value.as_str()));
         }
 
-        let mut next = max_id + 1;
+        let mut next = next_id;
         for ((express_id, pset_name), props) in &groups {
             let mut prop_refs: Vec<u32> = Vec::with_capacity(props.len());
             for (pname, value) in props {
@@ -300,167 +413,5 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Count `#id=` entity lines in a STEP DATA section + grab the FILE_SCHEMA label.
-    fn parse_back(step: &str) -> (usize, HashSet<u32>, String) {
-        let bytes = step.as_bytes();
-        let mut ids = HashSet::new();
-        let mut scanner = EntityScanner::new(bytes);
-        while let Some((id, _t, _s, _e)) = scanner.next_entity() {
-            ids.insert(id);
-        }
-        let schema = detect_schema(bytes);
-        (ids.len(), ids, schema)
-    }
-
-    #[test]
-    fn full_roundtrip_preserves_all_entities() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        let (step, stats) = export_step_with_stats(&src, &StepOptions::default());
-
-        // Source entity count == written count == re-parsed count.
-        let (reparsed, _ids, schema) = parse_back(&step);
-        assert_eq!(stats.written, stats.total, "wrote every entity");
-        assert_eq!(reparsed, stats.total, "re-parse recovers every entity");
-        assert!(step.starts_with("ISO-10303-21;"));
-        assert!(step.trim_end().ends_with("END-ISO-10303-21;"));
-        assert_eq!(schema, "IFC2X3", "preserved source schema label");
-    }
-
-    #[test]
-    fn subset_export_is_reference_closed() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        // Pick a real wall id from the model.
-        let mut scanner = EntityScanner::new(&src[..]);
-        let mut wall_id = None;
-        while let Some((id, t, _s, _e)) = scanner.next_entity() {
-            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") || t.eq_ignore_ascii_case("IFCWALL") {
-                wall_id = Some(id);
-                break;
-            }
-        }
-        let wall_id = wall_id.expect("a wall in duplex");
-
-        let (step, stats) = export_step_with_stats(
-            &src,
-            &StepOptions { included: Some(vec![wall_id]), ..StepOptions::default() },
-        );
-        let (_n, ids, _schema) = parse_back(&step);
-
-        assert!(ids.contains(&wall_id), "the requested wall is present");
-        assert!(stats.written < stats.total, "subset is smaller than the whole model");
-
-        // Reference-closed: every #ref emitted must itself be present (no dangling refs).
-        for line in step.lines().filter(|l| l.starts_with('#')) {
-            let mut refs = Vec::new();
-            refs_in_line(line.as_bytes(), &mut refs);
-            for r in refs {
-                assert!(ids.contains(&r), "dangling reference #{r} in subset export");
-            }
-        }
-    }
-
-    #[test]
-    fn attribute_mutation_renames_entity() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        // Find a wall to rename (attribute index 2 = Name on IfcRoot products).
-        let mut scanner = EntityScanner::new(&src[..]);
-        let mut wall_id = None;
-        while let Some((id, t, _s, _e)) = scanner.next_entity() {
-            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
-                wall_id = Some(id);
-                break;
-            }
-        }
-        let wall_id = wall_id.expect("a wall");
-
-        let step = export_step(
-            &src,
-            &StepOptions {
-                attribute_mutations: vec![AttrMutation {
-                    express_id: wall_id,
-                    index: 2,
-                    value: "'RENAMED_BY_TEST'".to_string(),
-                }],
-                ..StepOptions::default()
-            },
-        );
-        // The mutated wall line carries the new name; the model still re-parses fully.
-        let line = step
-            .lines()
-            .find(|l| l.starts_with(&format!("#{wall_id}=")))
-            .expect("wall line present");
-        assert!(line.contains("'RENAMED_BY_TEST'"), "name replaced: {line}");
-        let (reparsed, _ids, _schema) = parse_back(&step);
-        let mut sc = EntityScanner::new(&src[..]);
-        let mut total = 0usize;
-        while sc.next_entity().is_some() {
-            total += 1;
-        }
-        assert_eq!(reparsed, total, "no entities dropped by the edit");
-    }
-
-    #[test]
-    fn property_synthesis_attaches_new_pset() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        let mut scanner = EntityScanner::new(&src[..]);
-        let mut wall = None;
-        while let Some((id, t, _s, _e)) = scanner.next_entity() {
-            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
-                wall = Some(id);
-                break;
-            }
-        }
-        let wall = wall.expect("a wall");
-
-        let (step, stats) = export_step_with_stats(
-            &src,
-            &StepOptions {
-                property_mutations: vec![PropMutation {
-                    express_id: wall,
-                    pset_name: "Pset_Test".to_string(),
-                    prop_name: "MyProp".to_string(),
-                    value: "IFCLABEL('hello')".to_string(),
-                }],
-                ..StepOptions::default()
-            },
-        );
-
-        // The three synthesized entities are present.
-        assert!(
-            step.contains("=IFCPROPERTYSINGLEVALUE('MyProp',$,IFCLABEL('hello'),$);"),
-            "single value synthesized"
-        );
-        assert!(step.contains("'Pset_Test'"), "pset name present");
-        // The synthesized rel ($-owner/name/desc) relates the wall to the new pset —
-        // distinct from duplex's original rels which carry a real OwnerHistory ref.
-        let synth_rel = format!(",$,$,$,(#{wall}),#");
-        assert!(
-            step.lines().any(|l| l.contains("=IFCRELDEFINESBYPROPERTIES(") && l.contains(&synth_rel)),
-            "synthesized rel targeting the wall not found"
-        );
-
-        // Re-parses, and the synthesized entities are counted (written = original + 3).
-        let (reparsed, _ids, _schema) = parse_back(&step);
-        assert_eq!(reparsed, stats.written, "every written entity re-parses");
-        assert_eq!(stats.written, stats.total + 3, "added 1 prop + 1 pset + 1 rel");
-    }
-
-    #[test]
-    fn schema_conversion_to_ifc4_keeps_model_parseable() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        let (step, stats) = export_step_with_stats(
-            &src,
-            &StepOptions { schema: Some("IFC4".to_string()), ..StepOptions::default() },
-        );
-        assert!(step.contains("FILE_SCHEMA(('IFC4'))"));
-        // Conversion preserves every express id (renames type, never drops entities).
-        let (reparsed, _ids, schema) = parse_back(&step);
-        assert_eq!(reparsed, stats.total, "no entities lost in conversion");
-        assert_eq!(schema, "IFC4");
-        // The converted file must still re-parse as a coherent entity set.
-        assert!(step.lines().filter(|l| l.starts_with('#')).count() == stats.written);
-    }
-}
+#[path = "step_tests.rs"]
+mod tests;

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -264,7 +264,18 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
     // substitutions are applied in sequence to one accumulating value.
     let mut referrer_edits: HashMap<(u32, usize), String> = HashMap::new();
     for cow in &opts.copy_on_write {
-        if !line_of.contains_key(&cow.express_id) || !included.contains(&cow.referrer_id) {
+        let Some(&(source_start, source_end)) = line_of.get(&cow.express_id) else {
+            continue;
+        };
+        if !included.contains(&cow.referrer_id) {
+            continue;
+        }
+        // The attribute has to exist before an id is spent on the copy.
+        // `apply_attr_mutations` ignores an index past the end, so without this
+        // the copy comes out identical to the record it copied and the referrer
+        // is repointed at a duplicate that changed nothing.
+        let source_line = String::from_utf8_lossy(&content[source_start..source_end]);
+        if attribute_of(&source_line, cow.index).is_none() {
             continue;
         }
         let Some(&(rs, re)) = line_of.get(&cow.referrer_id) else {
@@ -382,14 +393,24 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             groups[idx].1.push((m.prop_name.as_str(), m.value.as_str()));
         }
 
-        // Same exhaustion, same answer: a synthesized property set needs three
-        // fresh ids, and inventing them on a full file would duplicate real
-        // records.
+        // Same exhaustion, same answer: inventing ids on a full file would
+        // duplicate real records.
         let Some(mut next) = next_id else {
             out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
             return (out, StepStats { total: order.len(), written });
         };
         for ((express_id, pset_name), props) in &groups {
+            // One property set costs one id per property plus one for the set
+            // and one for the relationship. Checking that a single id is left
+            // is not enough: a group that starts near the ceiling used to run
+            // off it part way through and wrap, emitting ids that already
+            // belong to real records. A group that does not fit is skipped
+            // whole, so nothing half-written reaches the file.
+            let needed = u32::try_from(props.len()).ok().and_then(|n| n.checked_add(2));
+            match needed.and_then(|n| u32::MAX.checked_sub(n).map(|limit| next <= limit)) {
+                Some(true) => {}
+                _ => continue,
+            }
             let mut prop_refs: Vec<u32> = Vec::with_capacity(props.len());
             for (pname, value) in props {
                 out.push_str(&format!(

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -246,10 +246,15 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
     // repointed referrers both go through it.
     //
     // Allocated from a counter `PropMutation` synthesis continues from, so the
-    // two cannot hand out the same id. `saturating_add` because this now runs
-    // on every export: a file holding `u32::MAX` used to reach it only when
-    // property mutations were present.
-    let mut next_id = max_id.saturating_add(1);
+    // two cannot hand out the same id.
+    //
+    // `checked_add`, and `None` means no record can be added at all. Saturating
+    // was worse than the overflow it replaced: on a file holding `u32::MAX` it
+    // leaves the counter equal to an id the file already uses, so the first
+    // copy silently collides with a real record. A file that has spent the
+    // whole id space has no room for another record, and emitting one anyway
+    // corrupts it, so none is emitted.
+    let mut next_id = max_id.checked_add(1);
     let mut copies: Vec<(u32, u32, usize, String)> = Vec::new();
     // Folded per (referrer, attribute). Two copies repointed through the same
     // attribute each produced a rewrite of the whole attribute computed from
@@ -265,7 +270,10 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
         let Some(&(rs, re)) = line_of.get(&cow.referrer_id) else {
             continue;
         };
-        let copy_id = next_id;
+        let Some(copy_id) = next_id else {
+            // No id left to give it. Skipped rather than duplicated.
+            continue;
+        };
 
         // Computed against what the attribute holds now, which is the previous
         // substitution's output when there was one.
@@ -287,7 +295,7 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             continue;
         };
 
-        next_id += 1;
+        next_id = copy_id.checked_add(1);
         copies.push((copy_id, cow.express_id, cow.index, cow.value.clone()));
         referrer_edits.insert((cow.referrer_id, cow.referrer_index), rewritten);
     }
@@ -374,7 +382,13 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             groups[idx].1.push((m.prop_name.as_str(), m.value.as_str()));
         }
 
-        let mut next = next_id;
+        // Same exhaustion, same answer: a synthesized property set needs three
+        // fresh ids, and inventing them on a full file would duplicate real
+        // records.
+        let Some(mut next) = next_id else {
+            out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+            return (out, StepStats { total: order.len(), written });
+        };
         for ((express_id, pset_name), props) in &groups {
             let mut prop_refs: Vec<u32> = Vec::with_capacity(props.len());
             for (pname, value) in props {

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -8,7 +8,7 @@
 //! **mutation application** (MutablePropertyView edits bridged from TS) are the P2/P3
 //! follow-ons; the structure here is the seam they plug into.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use ifc_lite_core::EntityScanner;
 use serde::Deserialize;
@@ -108,11 +108,14 @@ pub struct StepStats {
     pub total: usize,
     /// Entities written (after filtering + reference closure).
     pub written: usize,
+    /// Copy-on-write mutations the file could not express, so none was made.
+    /// Non-zero means an edit the caller asked for is not in the output, and
+    /// the caller is the only one who can say what to do about it.
+    pub copies_refused: usize,
 }
 
 use crate::step_text::{
-    apply_attr_mutations, attribute_of, detect_schema, escape, refs_in_line, renumber,
-    substitute_ref_in_attr,
+    apply_attr_mutations, detect_schema, escape, merge_edits, refs_in_line, renumber,
 };
 
 // ── Mutation JSON bridge (the wasm-facing contract) ─────────────────────────
@@ -236,83 +239,30 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
     let converting = opts.schema.is_some()
         && crate::schema_convert::needs_conversion(&source_schema, &schema);
 
-    // Root-attribute edits, grouped by entity id.
-    let mut muts_by_id: HashMap<u32, Vec<(usize, String)>> = HashMap::new();
+    // Root-attribute edits, resolved per (entity, attribute) as they are read.
+    // A list plus a last-wins rule made "the value at this index" a derived
+    // fact that every reader re-derived its own way, and two of them got it
+    // wrong. Keyed by index there is nothing left to derive.
+    let mut muts_by_id: HashMap<u32, BTreeMap<usize, String>> = HashMap::new();
     for m in &opts.attribute_mutations {
-        muts_by_id.entry(m.express_id).or_default().push((m.index, m.value.clone()));
+        muts_by_id.entry(m.express_id).or_default().insert(m.index, m.value.clone());
     }
 
     // Copy-on-write, resolved before the emit loop so the copies and the
-    // repointed referrers both go through it.
-    //
-    // Allocated from a counter `PropMutation` synthesis continues from, so the
-    // two cannot hand out the same id.
-    //
-    // `checked_add`, and `None` means no record can be added at all. Saturating
-    // was worse than the overflow it replaced: on a file holding `u32::MAX` it
-    // leaves the counter equal to an id the file already uses, so the first
-    // copy silently collides with a real record. A file that has spent the
-    // whole id space has no room for another record, and emitting one anyway
-    // corrupts it, so none is emitted.
-    let mut next_id = max_id.checked_add(1);
-    let mut copies: Vec<(u32, u32, usize, String)> = Vec::new();
-    // Folded per (referrer, attribute). Two copies repointed through the same
-    // attribute each produced a rewrite of the whole attribute computed from
-    // the untouched original, and the second overwrote the first: one copy was
-    // orphaned and the referrer still pointed at the record it was supposed to
-    // stop sharing. Two properties on one element is the ordinary case, so the
-    // substitutions are applied in sequence to one accumulating value.
-    let mut referrer_edits: HashMap<(u32, usize), String> = HashMap::new();
-    for cow in &opts.copy_on_write {
-        let Some(&(source_start, source_end)) = line_of.get(&cow.express_id) else {
-            continue;
-        };
-        if !included.contains(&cow.referrer_id) {
-            continue;
-        }
-        // The attribute has to exist before an id is spent on the copy.
-        // `apply_attr_mutations` ignores an index past the end, so without this
-        // the copy comes out identical to the record it copied and the referrer
-        // is repointed at a duplicate that changed nothing.
-        let source_line = String::from_utf8_lossy(&content[source_start..source_end]);
-        if attribute_of(&source_line, cow.index).is_none() {
-            continue;
-        }
-        let Some(&(rs, re)) = line_of.get(&cow.referrer_id) else {
-            continue;
-        };
-        let Some(copy_id) = next_id else {
-            // No id left to give it. Skipped rather than duplicated.
-            continue;
-        };
-
-        // Computed against what the attribute holds now, which is the previous
-        // substitution's output when there was one.
-        let current = match referrer_edits.get(&(cow.referrer_id, cow.referrer_index)) {
-            Some(edited) => edited.clone(),
-            None => {
-                let raw = String::from_utf8_lossy(&content[rs..re]);
-                match attribute_of(&raw, cow.referrer_index) {
-                    Some(attr) => attr,
-                    None => continue,
-                }
-            }
-        };
-        let Some(rewritten) = substitute_ref_in_attr(&current, cow.express_id, copy_id) else {
-            // The referrer does not hold that reference, so there is nothing to
-            // repoint. Emitting the copy anyway would leave a record nothing
-            // points at, and one that may reference records the export filtered
-            // out. Skipped rather than half-applied.
-            continue;
-        };
-
-        next_id = copy_id.checked_add(1);
-        copies.push((copy_id, cow.express_id, cow.index, cow.value.clone()));
-        referrer_edits.insert((cow.referrer_id, cow.referrer_index), rewritten);
-    }
-    for ((referrer_id, index), value) in referrer_edits {
-        muts_by_id.entry(referrer_id).or_default().push((index, value));
-    }
+    // repointed referrers both go through it. Its own module: the pass has four
+    // rules now and every one of them is a file that came out wrong without it.
+    let resolved = crate::step_cow::resolve(
+        &opts.copy_on_write,
+        content,
+        &line_of,
+        &included,
+        &muts_by_id,
+        max_id.checked_add(1),
+    );
+    let next_id = resolved.next_id;
+    let copies_refused = resolved.refused;
+    let copies = resolved.copies;
+    let repointed = resolved.repointed;
 
     // 3. Emit header + filtered entities (source order) + footer.
     let mut out = String::new();
@@ -333,8 +283,8 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             if let Some(&(s, e)) = line_of.get(id) {
                 let raw = String::from_utf8_lossy(&content[s..e]);
                 // Apply root-attribute edits first (original-schema positions), then convert.
-                let edited = match muts_by_id.get(id) {
-                    Some(muts) => apply_attr_mutations(&raw, muts),
+                let edited = match merge_edits(muts_by_id.get(id), repointed.get(id)) {
+                    Some(edits) => apply_attr_mutations(&raw, &edits),
                     None => raw.into_owned(),
                 };
                 if converting {
@@ -355,10 +305,16 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
 
     // The copies, emitted rather than appended: counted in `written` and put
     // through `convert_step_line` like every other record.
-    for (copy_id, source_id, index, value) in &copies {
+    for (copy_id, source_id, edits) in &copies {
         if let Some(&(s0, e0)) = line_of.get(source_id) {
             let raw = String::from_utf8_lossy(&content[s0..e0]);
-            let edited = apply_attr_mutations(&raw, &[(*index, value.clone())]);
+            // The caller's edits to the record belong to the copy too: the
+            // copy is this element's version of that record, not a snapshot
+            // taken before the caller touched it. Repointings do not, which is
+            // why they are resolved into their own map.
+            let mut muts = muts_by_id.get(source_id).cloned().unwrap_or_default();
+            muts.extend(edits.iter().map(|(i, v)| (*i, v.clone())));
+            let edited = apply_attr_mutations(&raw, &muts);
             let renumbered = renumber(&edited, *copy_id);
             if converting {
                 out.push_str(&crate::schema_convert::convert_step_line(
@@ -397,7 +353,7 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
         // duplicate real records.
         let Some(mut next) = next_id else {
             out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
-            return (out, StepStats { total: order.len(), written });
+            return (out, StepStats { total: order.len(), written, copies_refused });
         };
         for ((express_id, pset_name), props) in &groups {
             // One property set costs one id per property plus one for the set
@@ -444,7 +400,7 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
 
     out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
 
-    (out, StepStats { total: order.len(), written })
+    (out, StepStats { total: order.len(), written, copies_refused })
 }
 
 #[cfg(test)]

--- a/rust/export/src/step_cow.rs
+++ b/rust/export/src/step_cow.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Copy-on-write for STEP records, resolved into copies and repointings.
+//!
+//! One `CopyOnWriteMutation` says: this element should stop sharing that
+//! record, so give it a private copy carrying a new value and point it at the
+//! copy instead. Two things come out, and the exporter needs both before it
+//! emits anything: the copies to write after the DATA section it already has,
+//! and the rewritten attribute each referrer now carries.
+//!
+//! Split out of `step.rs` because the pass grew its own rules, and each of them
+//! exists because a file came out wrong without it: an id budget, a chain that
+//! cannot be expressed, two edits landing on one copy, and a referrer index
+//! that has to be checked before an id is spent.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::step_text::{attribute_of, substitute_ref_in_attr};
+use crate::CopyOnWriteMutation;
+
+/// A record to emit: the id it gets, the record it copies, and the attributes
+/// that differ in the copy.
+pub(crate) type Copy = (u32, u32, BTreeMap<usize, String>);
+
+/// What the pass produces. `repointed` is keyed by referrer id and then by
+/// attribute index, which is the shape the emit loop applies.
+pub(crate) struct Resolved {
+    pub(crate) copies: Vec<Copy>,
+    pub(crate) repointed: HashMap<u32, BTreeMap<usize, String>>,
+    /// Mutations that were asked for and not made. Counted so the caller learns
+    /// an edit is missing rather than reading a clean export.
+    pub(crate) refused: usize,
+    /// Where the next synthesized record starts, so property synthesis
+    /// continues from the same counter and the two cannot collide.
+    pub(crate) next_id: Option<u32>,
+}
+
+/// A mutation that survived every check not needing an allocated id, carrying
+/// the referrer attribute as the record spells it.
+struct Candidate<'a> {
+    cow: &'a CopyOnWriteMutation,
+    from_record: String,
+}
+
+/// Everything that can be decided from the file alone.
+///
+/// Separated from the emit loop because the chain rule below needs to know
+/// which copies are real before it can refuse anything on their account, and
+/// "the caller asked for it" is not the same as "it can be made".
+fn candidate<'a>(
+    cow: &'a CopyOnWriteMutation,
+    content: &[u8],
+    line_of: &HashMap<u32, (usize, usize)>,
+    included: &HashSet<u32>,
+) -> Option<Candidate<'a>> {
+    let &(source_start, source_end) = line_of.get(&cow.express_id)?;
+    if !included.contains(&cow.referrer_id) {
+        return None;
+    }
+    // The attribute has to exist before an id is spent on the copy.
+    // `apply_attr_mutations` ignores an index past the end, so without this the
+    // copy comes out identical to the record it copied and the referrer is
+    // repointed at a duplicate that changed nothing.
+    let source_line = String::from_utf8_lossy(&content[source_start..source_end]);
+    attribute_of(&source_line, cow.index)?;
+
+    let &(rs, re) = line_of.get(&cow.referrer_id)?;
+    // Checked against the record, and not against whatever the caller happens
+    // to have staged for that attribute. A caller edit at an index the record
+    // does not have would otherwise satisfy the lookup in the loop below, and
+    // the repointing computed from it is dropped at emit time by the same
+    // out-of-range rule: an id spent and a copy nothing points at.
+    let referrer_line = String::from_utf8_lossy(&content[rs..re]);
+    let from_record = attribute_of(&referrer_line, cow.referrer_index)?;
+    // The referrer has to hold the reference for there to be anything to
+    // repoint. Checked here as well as in the loop, because a mutation that
+    // cannot emit must not make the chain rule refuse another one.
+    substitute_ref_in_attr(&from_record, cow.express_id, 0)?;
+
+    Some(Candidate { cow, from_record })
+}
+
+/// Resolve every mutation the file can express, and count the rest.
+///
+/// `next_id` is `None` when the id space is spent. Saturating was worse than
+/// the overflow it replaced: on a file holding `u32::MAX` it leaves the counter
+/// equal to an id the file already uses, so the first copy silently collides
+/// with a real record. A file that has spent the whole id space has no room for
+/// another record, and emitting one anyway corrupts it.
+pub(crate) fn resolve(
+    mutations: &[CopyOnWriteMutation],
+    content: &[u8],
+    line_of: &HashMap<u32, (usize, usize)>,
+    included: &HashSet<u32>,
+    caller_edits: &HashMap<u32, BTreeMap<usize, String>>,
+    mut next_id: Option<u32>,
+) -> Resolved {
+    let candidates: Vec<Candidate<'_>> = mutations
+        .iter()
+        .filter_map(|cow| candidate(cow, content, line_of, included))
+        .collect();
+    let mut refused = mutations.len() - candidates.len();
+
+    // A record that is itself being copied cannot also be repointed.
+    //
+    // Take one element wanting both its own property set and its own value in
+    // it: the caller issues "copy the property, repoint the set" and "copy the
+    // set, repoint the relationship". The first rewrites the *shared* set, so
+    // every other element reading that set silently picks up this element's new
+    // value, while this element reads its own copy of the set, which still
+    // points at the old record. The edit lands on everyone except the element
+    // that asked for it.
+    //
+    // Saying what was meant needs the mutation to name the copy rather than the
+    // record, and `CopyOnWriteMutation` has no way to. So the inner one is
+    // dropped: the element gets its own set holding the value it already had,
+    // which is incomplete and not wrong. Applying it is wrong.
+    //
+    // Built from the candidates rather than the request, so a copy that cannot
+    // be made does not refuse a repointing that can.
+    let copied: HashSet<u32> = candidates.iter().map(|c| c.cow.express_id).collect();
+
+    let mut copies: Vec<Copy> = Vec::new();
+    let mut repointed: HashMap<u32, BTreeMap<usize, String>> = HashMap::new();
+    // Which copy already serves a (record, referrer, attribute), so a second
+    // edit to the same record folds into it. `CopyOnWriteMutation` carries one
+    // attribute, so editing a property's value and its unit is two mutations
+    // through one referrer; the second used to find its reference already
+    // repointed, conclude the referrer did not hold it, and vanish.
+    let mut serving: HashMap<(u32, u32, usize), usize> = HashMap::new();
+
+    for Candidate { cow, from_record } in candidates {
+        if copied.contains(&cow.referrer_id) {
+            refused += 1;
+            continue;
+        }
+
+        // A second edit to a record this referrer already has a copy of. No new
+        // id, no second substitution: the value joins the copy that is already
+        // being emitted.
+        if let Some(&at) = serving.get(&(cow.express_id, cow.referrer_id, cow.referrer_index)) {
+            copies[at].2.insert(cow.index, cow.value.clone());
+            continue;
+        }
+        let Some(copy_id) = next_id else {
+            // No id left to give it. Skipped rather than duplicated, and
+            // counted: a caller reading a clean export would have no way to
+            // know the edit is not in it.
+            refused += 1;
+            continue;
+        };
+
+        // What the attribute holds now: an earlier substitution's output, then
+        // the caller's edit, then the record. An earlier substitution already
+        // started from the caller's value, so reading it first accumulates.
+        let current = repointed
+            .get(&cow.referrer_id)
+            .and_then(|edits| edits.get(&cow.referrer_index))
+            .or_else(|| {
+                caller_edits
+                    .get(&cow.referrer_id)
+                    .and_then(|edits| edits.get(&cow.referrer_index))
+            })
+            .cloned()
+            .unwrap_or(from_record);
+        let Some(rewritten) = substitute_ref_in_attr(&current, cow.express_id, copy_id) else {
+            // The record holds the reference and the value staged for that
+            // attribute does not, so an earlier edit took it out. Emitting the
+            // copy anyway would leave a record nothing points at.
+            refused += 1;
+            continue;
+        };
+
+        next_id = copy_id.checked_add(1);
+        serving.insert(
+            (cow.express_id, cow.referrer_id, cow.referrer_index),
+            copies.len(),
+        );
+        copies.push((
+            copy_id,
+            cow.express_id,
+            BTreeMap::from([(cow.index, cow.value.clone())]),
+        ));
+        repointed
+            .entry(cow.referrer_id)
+            .or_default()
+            .insert(cow.referrer_index, rewritten);
+    }
+
+    Resolved {
+        copies,
+        repointed,
+        next_id,
+        refused,
+    }
+}

--- a/rust/export/src/step_tests.rs
+++ b/rust/export/src/step_tests.rs
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Tests for `step.rs`, split out under the house pattern (AGENTS.md).
+//!
+//! Moved out so the production module stays under the module-size ratchet
+//! (`rust/processing/tests/module_size_ratchet.rs`); this file is exempt via
+//! the `_tests.rs` suffix convention.
+
+use super::*;
+
+
+    /// Count `#id=` entity lines in a STEP DATA section + grab the FILE_SCHEMA label.
+    fn parse_back(step: &str) -> (usize, HashSet<u32>, String) {
+        let bytes = step.as_bytes();
+        let mut ids = HashSet::new();
+        let mut scanner = EntityScanner::new(bytes);
+        while let Some((id, _t, _s, _e)) = scanner.next_entity() {
+            ids.insert(id);
+        }
+        let schema = detect_schema(bytes);
+        (ids.len(), ids, schema)
+    }
+
+    #[test]
+    fn full_roundtrip_preserves_all_entities() {
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
+        let (step, stats) = export_step_with_stats(&src, &StepOptions::default());
+
+        // Source entity count == written count == re-parsed count.
+        let (reparsed, _ids, schema) = parse_back(&step);
+        assert_eq!(stats.written, stats.total, "wrote every entity");
+        assert_eq!(reparsed, stats.total, "re-parse recovers every entity");
+        assert!(step.starts_with("ISO-10303-21;"));
+        assert!(step.trim_end().ends_with("END-ISO-10303-21;"));
+        assert_eq!(schema, "IFC2X3", "preserved source schema label");
+    }
+
+    #[test]
+    fn subset_export_is_reference_closed() {
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
+        // Pick a real wall id from the model.
+        let mut scanner = EntityScanner::new(&src[..]);
+        let mut wall_id = None;
+        while let Some((id, t, _s, _e)) = scanner.next_entity() {
+            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") || t.eq_ignore_ascii_case("IFCWALL") {
+                wall_id = Some(id);
+                break;
+            }
+        }
+        let wall_id = wall_id.expect("a wall in duplex");
+
+        let (step, stats) = export_step_with_stats(
+            &src,
+            &StepOptions { included: Some(vec![wall_id]), ..StepOptions::default() },
+        );
+        let (_n, ids, _schema) = parse_back(&step);
+
+        assert!(ids.contains(&wall_id), "the requested wall is present");
+        assert!(stats.written < stats.total, "subset is smaller than the whole model");
+
+        // Reference-closed: every #ref emitted must itself be present (no dangling refs).
+        for line in step.lines().filter(|l| l.starts_with('#')) {
+            let mut refs = Vec::new();
+            refs_in_line(line.as_bytes(), &mut refs);
+            for r in refs {
+                assert!(ids.contains(&r), "dangling reference #{r} in subset export");
+            }
+        }
+    }
+
+    #[test]
+    fn attribute_mutation_renames_entity() {
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
+        // Find a wall to rename (attribute index 2 = Name on IfcRoot products).
+        let mut scanner = EntityScanner::new(&src[..]);
+        let mut wall_id = None;
+        while let Some((id, t, _s, _e)) = scanner.next_entity() {
+            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
+                wall_id = Some(id);
+                break;
+            }
+        }
+        let wall_id = wall_id.expect("a wall");
+
+        let step = export_step(
+            &src,
+            &StepOptions {
+                attribute_mutations: vec![AttrMutation {
+                    express_id: wall_id,
+                    index: 2,
+                    value: "'RENAMED_BY_TEST'".to_string(),
+                }],
+                ..StepOptions::default()
+            },
+        );
+        // The mutated wall line carries the new name; the model still re-parses fully.
+        let line = step
+            .lines()
+            .find(|l| l.starts_with(&format!("#{wall_id}=")))
+            .expect("wall line present");
+        assert!(line.contains("'RENAMED_BY_TEST'"), "name replaced: {line}");
+        let (reparsed, _ids, _schema) = parse_back(&step);
+        let mut sc = EntityScanner::new(&src[..]);
+        let mut total = 0usize;
+        while sc.next_entity().is_some() {
+            total += 1;
+        }
+        assert_eq!(reparsed, total, "no entities dropped by the edit");
+    }
+
+    #[test]
+    fn property_synthesis_attaches_new_pset() {
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
+        let mut scanner = EntityScanner::new(&src[..]);
+        let mut wall = None;
+        while let Some((id, t, _s, _e)) = scanner.next_entity() {
+            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
+                wall = Some(id);
+                break;
+            }
+        }
+        let wall = wall.expect("a wall");
+
+        let (step, stats) = export_step_with_stats(
+            &src,
+            &StepOptions {
+                property_mutations: vec![PropMutation {
+                    express_id: wall,
+                    pset_name: "Pset_Test".to_string(),
+                    prop_name: "MyProp".to_string(),
+                    value: "IFCLABEL('hello')".to_string(),
+                }],
+                ..StepOptions::default()
+            },
+        );
+
+        // The three synthesized entities are present.
+        assert!(
+            step.contains("=IFCPROPERTYSINGLEVALUE('MyProp',$,IFCLABEL('hello'),$);"),
+            "single value synthesized"
+        );
+        assert!(step.contains("'Pset_Test'"), "pset name present");
+        // The synthesized rel ($-owner/name/desc) relates the wall to the new pset —
+        // distinct from duplex's original rels which carry a real OwnerHistory ref.
+        let synth_rel = format!(",$,$,$,(#{wall}),#");
+        assert!(
+            step.lines().any(|l| l.contains("=IFCRELDEFINESBYPROPERTIES(") && l.contains(&synth_rel)),
+            "synthesized rel targeting the wall not found"
+        );
+
+        // Re-parses, and the synthesized entities are counted (written = original + 3).
+        let (reparsed, _ids, _schema) = parse_back(&step);
+        assert_eq!(reparsed, stats.written, "every written entity re-parses");
+        assert_eq!(stats.written, stats.total + 3, "added 1 prop + 1 pset + 1 rel");
+    }
+
+    #[test]
+    fn schema_conversion_to_ifc4_keeps_model_parseable() {
+        let src = fixture_or_skip!("ara3d/duplex.ifc");
+        let (step, stats) = export_step_with_stats(
+            &src,
+            &StepOptions { schema: Some("IFC4".to_string()), ..StepOptions::default() },
+        );
+        assert!(step.contains("FILE_SCHEMA(('IFC4'))"));
+        // Conversion preserves every express id (renames type, never drops entities).
+        let (reparsed, _ids, schema) = parse_back(&step);
+        assert_eq!(reparsed, stats.total, "no entities lost in conversion");
+        assert_eq!(schema, "IFC4");
+        // The converted file must still re-parse as a coherent entity set.
+        assert!(step.lines().filter(|l| l.starts_with('#')).count() == stats.written);
+    }
+
+    #[test]
+    fn copy_on_write_moves_one_referrer_and_leaves_the_other() {
+        let src = concat!(
+            "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+            "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+            "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
+            "#42=IFCPROPERTYSINGLEVALUE('Other',$,IFCLABEL('x'),$);\n",
+            "#9=IFCPROPERTYSET('s1',$,'P',$,(#41,#42));\n",
+            "#10=IFCPROPERTYSET('s2',$,'P',$,(#41,#42));\n",
+            "ENDSEC;\nEND-ISO-10303-21;\n"
+        );
+        let (out, stats) = export_step_with_stats(
+            src.as_bytes(),
+            &StepOptions {
+                copy_on_write: vec![CopyOnWriteMutation {
+                    express_id: 41,
+                    index: 2,
+                    value: "IFCLABEL('edited')".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                }],
+                ..StepOptions::default()
+            },
+        );
+
+        // The shared original is untouched, so #10 still reads 'shared'.
+        assert!(out.contains("#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);"));
+        assert!(out.contains("#10=IFCPROPERTYSET('s2',$,'P',$,(#41,#42));"));
+        // #9 points at the copy and keeps its other reference in place.
+        assert!(out.contains("#43=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('edited'),$);"));
+        assert!(out.contains("#9=IFCPROPERTYSET('s1',$,'P',$,(#43,#42));"));
+        // Counted by the writer, which is why this is emitted rather than
+        // appended: the copy is one more record than the source held.
+        assert_eq!(stats.written, stats.total + 1);
+    }
+
+    #[test]
+    fn copy_ids_and_synthesized_ids_do_not_collide() {
+        let src = concat!(
+            "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+            "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+            "#1=IFCWALL('g',$,'W',$,$,$,$,$,$);\n",
+            "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
+            "#9=IFCPROPERTYSET('s1',$,'P',$,(#41));\n",
+            "ENDSEC;\nEND-ISO-10303-21;\n"
+        );
+        let (out, _) = export_step_with_stats(
+            src.as_bytes(),
+            &StepOptions {
+                copy_on_write: vec![CopyOnWriteMutation {
+                    express_id: 41,
+                    index: 2,
+                    value: "IFCLABEL('edited')".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                }],
+                property_mutations: vec![PropMutation {
+                    express_id: 1,
+                    pset_name: "New".to_string(),
+                    prop_name: "P".to_string(),
+                    value: "IFCLABEL('v')".to_string(),
+                }],
+                ..StepOptions::default()
+            },
+        );
+        let mut ids: Vec<&str> = out
+            .lines()
+            .filter_map(|l| l.strip_prefix('#'))
+            .filter_map(|l| l.split('=').next())
+            .collect();
+        let before = ids.len();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), before, "an id was handed out twice");
+    }
+
+
+    fn fixture(rel: &str) -> Vec<u8> {
+        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
+        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
+    }
+
+#[test]
+fn two_copies_through_one_attribute_both_land() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('s1'),$);\n",
+        "#42=IFCPROPERTYSINGLEVALUE('B',$,IFCLABEL('s2'),$);\n",
+        "#9=IFCPROPERTYSET('g',$,'P',$,(#41,#42));\n",
+        "#10=IFCPROPERTYSET('g2',$,'P',$,(#41,#42));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, _) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![
+                CopyOnWriteMutation {
+                    express_id: 41,
+                    index: 2,
+                    value: "IFCLABEL('e1')".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                },
+                CopyOnWriteMutation {
+                    express_id: 42,
+                    index: 2,
+                    value: "IFCLABEL('e2')".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                },
+            ],
+            ..StepOptions::default()
+        },
+    );
+    // Both moved, neither orphaned, and the sharer keeps the originals.
+    assert!(out.contains("#9=IFCPROPERTYSET('g',$,'P',$,(#43,#44));"), "{out}");
+    assert!(out.contains("#10=IFCPROPERTYSET('g2',$,'P',$,(#41,#42));"), "{out}");
+    assert!(out.contains("#43=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('e1'),$);"), "{out}");
+    assert!(out.contains("#44=IFCPROPERTYSINGLEVALUE('B',$,IFCLABEL('e2'),$);"), "{out}");
+}
+
+#[test]
+fn a_copy_whose_referrer_cannot_be_repointed_is_not_emitted() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('s1'),$);\n",
+        "#9=IFCPROPERTYSET('g',$,'P',$,(#42));\n",
+        "#42=IFCPROPERTYSINGLEVALUE('B',$,IFCLABEL('s2'),$);\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL('e1')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            ..StepOptions::default()
+        },
+    );
+    assert_eq!(stats.written, stats.total, "no copy should be emitted");
+    assert!(!out.contains("IFCLABEL('e1')"), "{out}");
+}
+
+#[test]
+fn repointing_leaves_non_ascii_text_in_other_attributes_intact() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('s'),$);\n",
+        "#9=IFCPROPERTYSET('g',$,'Größe',$,(#41));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, _) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL('e')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            ..StepOptions::default()
+        },
+    );
+    assert!(out.contains("'Größe'"), "{out}");
+}
+
+#[test]
+fn a_reference_inside_a_string_is_not_repointed() {
+    assert_eq!(
+        substitute_ref_in_attr("(IFCLABEL('lot #41'),#41)", 41, 43).as_deref(),
+        Some("(IFCLABEL('lot #41'),#43)")
+    );
+}

--- a/rust/export/src/step_tests.rs
+++ b/rust/export/src/step_tests.rs
@@ -408,3 +408,82 @@ fn an_exhausted_id_space_emits_no_copy() {
     ids.dedup();
     assert_eq!(ids.len(), before, "an id was handed out twice");
 }
+
+/// An attribute index past the end of the record. `apply_attr_mutations`
+/// ignores it, so the copy would be a byte-identical twin and the referrer
+/// would be repointed at a record that changed nothing.
+#[test]
+fn a_copy_with_an_out_of_range_attribute_is_not_made() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('s'),$);\n",
+        "#9=IFCPROPERTYSET('g',$,'P',$,(#41));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                // IfcPropertySingleValue has four attributes; this is past them.
+                index: 9,
+                value: "IFCLABEL('e')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            ..StepOptions::default()
+        },
+    );
+    assert_eq!(stats.written, stats.total, "no copy should be emitted");
+    assert!(
+        out.contains("#9=IFCPROPERTYSET('g',$,'P',$,(#41));"),
+        "{out}"
+    );
+}
+
+/// A synthesized property set costs one id per property plus two. Checking that
+/// a single id remained let a group start near the ceiling and wrap part way
+/// through, emitting ids that already belong to real records.
+#[test]
+fn a_property_group_that_does_not_fit_the_id_space_is_skipped_whole() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#1=IFCWALL('g',$,'W',$,$,$,$,$,$);\n",
+        "#4294967293=IFCPROPERTYSINGLEVALUE('Z',$,IFCLABEL('z'),$);\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            property_mutations: vec![
+                PropMutation {
+                    express_id: 1,
+                    pset_name: "New".to_string(),
+                    prop_name: "A".to_string(),
+                    value: "IFCLABEL('a')".to_string(),
+                },
+                PropMutation {
+                    express_id: 1,
+                    pset_name: "New".to_string(),
+                    prop_name: "B".to_string(),
+                    value: "IFCLABEL('b')".to_string(),
+                },
+            ],
+            ..StepOptions::default()
+        },
+    );
+    // Two properties plus a set plus a relationship is four ids, and only two
+    // remain, so the group is not written at all.
+    assert_eq!(stats.written, stats.total, "nothing should be synthesized");
+    let mut ids: Vec<&str> = out
+        .lines()
+        .filter_map(|l| l.strip_prefix('#'))
+        .filter_map(|l| l.split('=').next())
+        .collect();
+    let before = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), before, "an id was handed out twice");
+}

--- a/rust/export/src/step_tests.rs
+++ b/rust/export/src/step_tests.rs
@@ -350,3 +350,42 @@ fn a_reference_inside_a_string_is_not_repointed() {
         Some("(IFCLABEL('lot #41'),#43)")
     );
 }
+
+/// A file that has spent the whole id space has no room for another record.
+/// Saturating the counter left it equal to an id already in use, so the copy
+/// collided with a real record instead of being refused.
+#[test]
+fn an_exhausted_id_space_emits_no_copy() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('s'),$);\n",
+        "#9=IFCPROPERTYSET('g',$,'P',$,(#41));\n",
+        "#4294967295=IFCPROPERTYSINGLEVALUE('Z',$,IFCLABEL('z'),$);\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL('e')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            ..StepOptions::default()
+        },
+    );
+    assert_eq!(stats.written, stats.total, "no record should be added");
+    // And nothing acquired a second definition.
+    let mut ids: Vec<&str> = out
+        .lines()
+        .filter_map(|l| l.strip_prefix('#'))
+        .filter_map(|l| l.split('=').next())
+        .collect();
+    let before = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), before, "an id was handed out twice");
+}

--- a/rust/export/src/step_tests.rs
+++ b/rust/export/src/step_tests.rs
@@ -6,6 +6,8 @@
 //! the `_tests.rs` suffix convention.
 
 use super::*;
+// Exercised directly here; `step.rs` reaches it through `step_cow`.
+use crate::step_text::substitute_ref_in_attr;
 
 /// Count `#id=` entity lines in a STEP DATA section + grab the FILE_SCHEMA label.
 fn parse_back(step: &str) -> (usize, HashSet<u32>, String) {
@@ -486,4 +488,272 @@ fn a_property_group_that_does_not_fit_the_id_space_is_skipped_whole() {
     ids.sort_unstable();
     ids.dedup();
     assert_eq!(ids.len(), before, "an id was handed out twice");
+}
+
+#[test]
+fn copy_on_write_keeps_a_caller_edit_on_the_same_attribute() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
+        "#42=IFCPROPERTYSINGLEVALUE('Other',$,IFCLABEL('x'),$);\n",
+        "#9=IFCPROPERTYSET('s1',$,'P',$,(#41));\n",
+        "#10=IFCPROPERTYSET('s2',$,'P',$,(#41));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, _) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            // The caller adds #42 to the same list the copy has to be
+            // repointed through.
+            attribute_mutations: vec![AttrMutation {
+                express_id: 9,
+                index: 4,
+                value: "(#41,#42)".to_string(),
+            }],
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL('edited')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            ..StepOptions::default()
+        },
+    );
+
+    // Both survive: the caller's #42 and the repointing of #41 onto the copy.
+    // Computing the substitution from the untouched record loses #42, because
+    // the rewrite is applied to the same index after the caller's edit.
+    assert!(out.contains("#9=IFCPROPERTYSET('s1',$,'P',$,(#43,#42));"));
+    assert!(out.contains("#43=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('edited'),$);"));
+    // The other sharer is untouched.
+    assert!(out.contains("#10=IFCPROPERTYSET('s2',$,'P',$,(#41));"));
+}
+
+#[test]
+fn a_copy_carries_a_caller_edit_to_the_record_it_copied() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
+        "#9=IFCPROPERTYSET('s1',$,'P',$,(#41));\n",
+        "#10=IFCPROPERTYSET('s2',$,'P',$,(#41));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, _) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            // A rename of the property, which is a different attribute from the
+            // one the copy edits.
+            attribute_mutations: vec![AttrMutation {
+                express_id: 41,
+                index: 0,
+                value: "'Renamed'".to_string(),
+            }],
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL('edited')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            ..StepOptions::default()
+        },
+    );
+
+    // The copy is built from the record as the caller left it, so it carries
+    // the rename as well as the new value.
+    assert!(out.contains("#42=IFCPROPERTYSINGLEVALUE('Renamed',$,IFCLABEL('edited'),$);"));
+    assert!(out.contains("#9=IFCPROPERTYSET('s1',$,'P',$,(#42));"));
+    // The original keeps the rename and the value the other sharer still reads.
+    assert!(out.contains("#41=IFCPROPERTYSINGLEVALUE('Renamed',$,IFCLABEL('shared'),$);"));
+}
+
+#[test]
+fn a_record_that_is_itself_copied_is_not_also_repointed() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((\'\'),\'2;1\');\n",
+        "FILE_NAME(\'\',\'\',(\'\'),(\'\'),\'\',\'\',\'\');\nFILE_SCHEMA((\'IFC4\'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE(\'Reference\',$,IFCLABEL(\'shared\'),$);\n",
+        "#9=IFCPROPERTYSET(\'s1\',$,\'P\',$,(#41));\n",
+        "#5=IFCRELDEFINESBYPROPERTIES(\'a\',$,$,$,(#1),#9);\n",
+        "#6=IFCRELDEFINESBYPROPERTIES(\'b\',$,$,$,(#2),#9);\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![
+                // A wants its own value, through the set it shares with B.
+                CopyOnWriteMutation {
+                    express_id: 41,
+                    index: 2,
+                    value: "IFCLABEL(\'A-value\')".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                },
+                // ...and its own set, through its own relationship.
+                CopyOnWriteMutation {
+                    express_id: 9,
+                    index: 0,
+                    value: "\'A-pset\'".to_string(),
+                    referrer_id: 5,
+                    referrer_index: 5,
+                },
+            ],
+            ..StepOptions::default()
+        },
+    );
+
+    // Applying both inverts the edit. #9 is what A keeps reading only until the
+    // second mutation moves A onto a copy of it, so the repointing of #9 lands
+    // on B, and A ends up on a copy still holding the old value: the element
+    // that asked for the edit is the one element that does not get it.
+    //
+    // Saying what was meant needs the mutation to name the copy rather than the
+    // record, which `CopyOnWriteMutation` cannot do. So the inner one is
+    // dropped and counted. A gets its own set holding the value it already had,
+    // which is incomplete rather than wrong, and nobody reads a value that is
+    // not theirs.
+    assert_eq!(stats.copies_refused, 1);
+    assert!(out.contains("#42=IFCPROPERTYSET(\'A-pset\',$,\'P\',$,(#41));"));
+    assert!(out.contains("#5=IFCRELDEFINESBYPROPERTIES(\'a\',$,$,$,(#1),#42);"));
+    // B is untouched, and the shared record still says what the source said.
+    assert!(out.contains("#6=IFCRELDEFINESBYPROPERTIES(\'b\',$,$,$,(#2),#9);"));
+    assert!(out.contains("#9=IFCPROPERTYSET(\'s1\',$,\'P\',$,(#41));"));
+    assert!(out.contains("#41=IFCPROPERTYSINGLEVALUE(\'Reference\',$,IFCLABEL(\'shared\'),$);"));
+    // And no orphan: the id the dropped mutation would have spent is not spent.
+    assert!(!out.contains("#43="));
+}
+
+#[test]
+fn two_edits_to_one_shared_record_land_in_one_copy() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((\'\'),\'2;1\');\n",
+        "FILE_NAME(\'\',\'\',(\'\'),(\'\'),\'\',\'\',\'\');\nFILE_SCHEMA((\'IFC4\'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE(\'Reference\',$,IFCLABEL(\'shared\'),$);\n",
+        "#9=IFCPROPERTYSET(\'s1\',$,\'P\',$,(#41));\n",
+        "#10=IFCPROPERTYSET(\'s2\',$,\'P\',$,(#41));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, _) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            // One mutation carries one attribute, so renaming the property and
+            // changing its value is two of them through the same referrer.
+            copy_on_write: vec![
+                CopyOnWriteMutation {
+                    express_id: 41,
+                    index: 2,
+                    value: "IFCLABEL(\'edited\')".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                },
+                CopyOnWriteMutation {
+                    express_id: 41,
+                    index: 0,
+                    value: "\'Renamed\'".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                },
+            ],
+            ..StepOptions::default()
+        },
+    );
+
+    // Both land in the one copy. The second used to find its reference already
+    // repointed, conclude the referrer did not hold it, and vanish with no
+    // signal, so a caller changing a value and a unit lost the unit.
+    assert!(out.contains("#42=IFCPROPERTYSINGLEVALUE(\'Renamed\',$,IFCLABEL(\'edited\'),$);"));
+    assert!(out.contains("#9=IFCPROPERTYSET(\'s1\',$,\'P\',$,(#42));"));
+    // One copy, not two, so no second id was spent and no orphan emitted.
+    assert!(!out.contains("#43="));
+    assert!(out.contains("#10=IFCPROPERTYSET(\'s2\',$,\'P\',$,(#41));"));
+}
+
+#[test]
+fn a_caller_edit_at_a_missing_index_does_not_buy_a_copy() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((\'\'),\'2;1\');\n",
+        "FILE_NAME(\'\',\'\',(\'\'),(\'\'),\'\',\'\',\'\');\nFILE_SCHEMA((\'IFC4\'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE(\'Reference\',$,IFCLABEL(\'shared\'),$);\n",
+        "#9=IFCPROPERTYSET(\'s1\',$,\'P\',$,(#41));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            // Index 9 is past the end of #9, and apply_attr_mutations ignores
+            // it, so the repointing computed from it never reaches the file.
+            attribute_mutations: vec![AttrMutation {
+                express_id: 9,
+                index: 9,
+                value: "(#41)".to_string(),
+            }],
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL(\'v\')".to_string(),
+                referrer_id: 9,
+                referrer_index: 9,
+            }],
+            ..StepOptions::default()
+        },
+    );
+
+    // The referrer index is checked against the record, not against whatever
+    // the caller happens to have staged for it. Without that the copy was
+    // emitted, an id was spent, `written` was inflated, and nothing pointed at
+    // the record that came out.
+    assert!(!out.contains("#42="));
+    assert_eq!(stats.written, stats.total);
+    assert!(out.contains("#9=IFCPROPERTYSET(\'s1\',$,\'P\',$,(#41));"));
+}
+
+#[test]
+fn a_copy_that_cannot_be_made_does_not_refuse_a_repointing() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
+        "#9=IFCPROPERTYSET('s1',$,'P',$,(#41));\n",
+        "#10=IFCPROPERTYSET('s2',$,'P',$,(#41));\n",
+        "#5=IFCRELDEFINESBYPROPERTIES('a',$,$,$,(#1),#10);\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![
+                // #5 points at #10, not #9, so there is nothing here to
+                // repoint and no copy of #9 can be made.
+                CopyOnWriteMutation {
+                    express_id: 9,
+                    index: 0,
+                    value: "'never'".to_string(),
+                    referrer_id: 5,
+                    referrer_index: 5,
+                },
+                // This one is expressible and has nothing to do with the above.
+                CopyOnWriteMutation {
+                    express_id: 41,
+                    index: 2,
+                    value: "IFCLABEL('edited')".to_string(),
+                    referrer_id: 9,
+                    referrer_index: 4,
+                },
+            ],
+            ..StepOptions::default()
+        },
+    );
+
+    // The chain rule refuses a repointing of a record that is being copied.
+    // Built from what was asked for rather than what can be made, it refused
+    // this one on account of a copy that never happens.
+    assert!(out.contains("#42=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('edited'),$);"));
+    assert!(out.contains("#9=IFCPROPERTYSET('s1',$,'P',$,(#42));"));
+    // Only the impossible one is counted.
+    assert_eq!(stats.copies_refused, 1);
+    assert!(out.contains("#10=IFCPROPERTYSET('s2',$,'P',$,(#41));"));
 }

--- a/rust/export/src/step_tests.rs
+++ b/rust/export/src/step_tests.rs
@@ -7,249 +7,256 @@
 
 use super::*;
 
-
-    /// Count `#id=` entity lines in a STEP DATA section + grab the FILE_SCHEMA label.
-    fn parse_back(step: &str) -> (usize, HashSet<u32>, String) {
-        let bytes = step.as_bytes();
-        let mut ids = HashSet::new();
-        let mut scanner = EntityScanner::new(bytes);
-        while let Some((id, _t, _s, _e)) = scanner.next_entity() {
-            ids.insert(id);
-        }
-        let schema = detect_schema(bytes);
-        (ids.len(), ids, schema)
+/// Count `#id=` entity lines in a STEP DATA section + grab the FILE_SCHEMA label.
+fn parse_back(step: &str) -> (usize, HashSet<u32>, String) {
+    let bytes = step.as_bytes();
+    let mut ids = HashSet::new();
+    let mut scanner = EntityScanner::new(bytes);
+    while let Some((id, _t, _s, _e)) = scanner.next_entity() {
+        ids.insert(id);
     }
+    let schema = detect_schema(bytes);
+    (ids.len(), ids, schema)
+}
 
-    #[test]
-    fn full_roundtrip_preserves_all_entities() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        let (step, stats) = export_step_with_stats(&src, &StepOptions::default());
+#[test]
+fn full_roundtrip_preserves_all_entities() {
+    let src = fixture_or_skip!("ara3d/duplex.ifc");
+    let (step, stats) = export_step_with_stats(&src, &StepOptions::default());
 
-        // Source entity count == written count == re-parsed count.
-        let (reparsed, _ids, schema) = parse_back(&step);
-        assert_eq!(stats.written, stats.total, "wrote every entity");
-        assert_eq!(reparsed, stats.total, "re-parse recovers every entity");
-        assert!(step.starts_with("ISO-10303-21;"));
-        assert!(step.trim_end().ends_with("END-ISO-10303-21;"));
-        assert_eq!(schema, "IFC2X3", "preserved source schema label");
-    }
+    // Source entity count == written count == re-parsed count.
+    let (reparsed, _ids, schema) = parse_back(&step);
+    assert_eq!(stats.written, stats.total, "wrote every entity");
+    assert_eq!(reparsed, stats.total, "re-parse recovers every entity");
+    assert!(step.starts_with("ISO-10303-21;"));
+    assert!(step.trim_end().ends_with("END-ISO-10303-21;"));
+    assert_eq!(schema, "IFC2X3", "preserved source schema label");
+}
 
-    #[test]
-    fn subset_export_is_reference_closed() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        // Pick a real wall id from the model.
-        let mut scanner = EntityScanner::new(&src[..]);
-        let mut wall_id = None;
-        while let Some((id, t, _s, _e)) = scanner.next_entity() {
-            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") || t.eq_ignore_ascii_case("IFCWALL") {
-                wall_id = Some(id);
-                break;
-            }
-        }
-        let wall_id = wall_id.expect("a wall in duplex");
-
-        let (step, stats) = export_step_with_stats(
-            &src,
-            &StepOptions { included: Some(vec![wall_id]), ..StepOptions::default() },
-        );
-        let (_n, ids, _schema) = parse_back(&step);
-
-        assert!(ids.contains(&wall_id), "the requested wall is present");
-        assert!(stats.written < stats.total, "subset is smaller than the whole model");
-
-        // Reference-closed: every #ref emitted must itself be present (no dangling refs).
-        for line in step.lines().filter(|l| l.starts_with('#')) {
-            let mut refs = Vec::new();
-            refs_in_line(line.as_bytes(), &mut refs);
-            for r in refs {
-                assert!(ids.contains(&r), "dangling reference #{r} in subset export");
-            }
+#[test]
+fn subset_export_is_reference_closed() {
+    let src = fixture_or_skip!("ara3d/duplex.ifc");
+    // Pick a real wall id from the model.
+    let mut scanner = EntityScanner::new(&src[..]);
+    let mut wall_id = None;
+    while let Some((id, t, _s, _e)) = scanner.next_entity() {
+        if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") || t.eq_ignore_ascii_case("IFCWALL") {
+            wall_id = Some(id);
+            break;
         }
     }
+    let wall_id = wall_id.expect("a wall in duplex");
 
-    #[test]
-    fn attribute_mutation_renames_entity() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        // Find a wall to rename (attribute index 2 = Name on IfcRoot products).
-        let mut scanner = EntityScanner::new(&src[..]);
-        let mut wall_id = None;
-        while let Some((id, t, _s, _e)) = scanner.next_entity() {
-            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
-                wall_id = Some(id);
-                break;
-            }
+    let (step, stats) = export_step_with_stats(
+        &src,
+        &StepOptions {
+            included: Some(vec![wall_id]),
+            ..StepOptions::default()
+        },
+    );
+    let (_n, ids, _schema) = parse_back(&step);
+
+    assert!(ids.contains(&wall_id), "the requested wall is present");
+    assert!(
+        stats.written < stats.total,
+        "subset is smaller than the whole model"
+    );
+
+    // Reference-closed: every #ref emitted must itself be present (no dangling refs).
+    for line in step.lines().filter(|l| l.starts_with('#')) {
+        let mut refs = Vec::new();
+        refs_in_line(line.as_bytes(), &mut refs);
+        for r in refs {
+            assert!(ids.contains(&r), "dangling reference #{r} in subset export");
         }
-        let wall_id = wall_id.expect("a wall");
+    }
+}
 
-        let step = export_step(
-            &src,
-            &StepOptions {
-                attribute_mutations: vec![AttrMutation {
-                    express_id: wall_id,
-                    index: 2,
-                    value: "'RENAMED_BY_TEST'".to_string(),
-                }],
-                ..StepOptions::default()
-            },
-        );
-        // The mutated wall line carries the new name; the model still re-parses fully.
-        let line = step
-            .lines()
-            .find(|l| l.starts_with(&format!("#{wall_id}=")))
-            .expect("wall line present");
-        assert!(line.contains("'RENAMED_BY_TEST'"), "name replaced: {line}");
-        let (reparsed, _ids, _schema) = parse_back(&step);
-        let mut sc = EntityScanner::new(&src[..]);
-        let mut total = 0usize;
-        while sc.next_entity().is_some() {
-            total += 1;
+#[test]
+fn attribute_mutation_renames_entity() {
+    let src = fixture_or_skip!("ara3d/duplex.ifc");
+    // Find a wall to rename (attribute index 2 = Name on IfcRoot products).
+    let mut scanner = EntityScanner::new(&src[..]);
+    let mut wall_id = None;
+    while let Some((id, t, _s, _e)) = scanner.next_entity() {
+        if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
+            wall_id = Some(id);
+            break;
         }
-        assert_eq!(reparsed, total, "no entities dropped by the edit");
     }
+    let wall_id = wall_id.expect("a wall");
 
-    #[test]
-    fn property_synthesis_attaches_new_pset() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        let mut scanner = EntityScanner::new(&src[..]);
-        let mut wall = None;
-        while let Some((id, t, _s, _e)) = scanner.next_entity() {
-            if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
-                wall = Some(id);
-                break;
-            }
+    let step = export_step(
+        &src,
+        &StepOptions {
+            attribute_mutations: vec![AttrMutation {
+                express_id: wall_id,
+                index: 2,
+                value: "'RENAMED_BY_TEST'".to_string(),
+            }],
+            ..StepOptions::default()
+        },
+    );
+    // The mutated wall line carries the new name; the model still re-parses fully.
+    let line = step
+        .lines()
+        .find(|l| l.starts_with(&format!("#{wall_id}=")))
+        .expect("wall line present");
+    assert!(line.contains("'RENAMED_BY_TEST'"), "name replaced: {line}");
+    let (reparsed, _ids, _schema) = parse_back(&step);
+    let mut sc = EntityScanner::new(&src[..]);
+    let mut total = 0usize;
+    while sc.next_entity().is_some() {
+        total += 1;
+    }
+    assert_eq!(reparsed, total, "no entities dropped by the edit");
+}
+
+#[test]
+fn property_synthesis_attaches_new_pset() {
+    let src = fixture_or_skip!("ara3d/duplex.ifc");
+    let mut scanner = EntityScanner::new(&src[..]);
+    let mut wall = None;
+    while let Some((id, t, _s, _e)) = scanner.next_entity() {
+        if t.eq_ignore_ascii_case("IFCWALLSTANDARDCASE") {
+            wall = Some(id);
+            break;
         }
-        let wall = wall.expect("a wall");
-
-        let (step, stats) = export_step_with_stats(
-            &src,
-            &StepOptions {
-                property_mutations: vec![PropMutation {
-                    express_id: wall,
-                    pset_name: "Pset_Test".to_string(),
-                    prop_name: "MyProp".to_string(),
-                    value: "IFCLABEL('hello')".to_string(),
-                }],
-                ..StepOptions::default()
-            },
-        );
-
-        // The three synthesized entities are present.
-        assert!(
-            step.contains("=IFCPROPERTYSINGLEVALUE('MyProp',$,IFCLABEL('hello'),$);"),
-            "single value synthesized"
-        );
-        assert!(step.contains("'Pset_Test'"), "pset name present");
-        // The synthesized rel ($-owner/name/desc) relates the wall to the new pset —
-        // distinct from duplex's original rels which carry a real OwnerHistory ref.
-        let synth_rel = format!(",$,$,$,(#{wall}),#");
-        assert!(
-            step.lines().any(|l| l.contains("=IFCRELDEFINESBYPROPERTIES(") && l.contains(&synth_rel)),
-            "synthesized rel targeting the wall not found"
-        );
-
-        // Re-parses, and the synthesized entities are counted (written = original + 3).
-        let (reparsed, _ids, _schema) = parse_back(&step);
-        assert_eq!(reparsed, stats.written, "every written entity re-parses");
-        assert_eq!(stats.written, stats.total + 3, "added 1 prop + 1 pset + 1 rel");
     }
+    let wall = wall.expect("a wall");
 
-    #[test]
-    fn schema_conversion_to_ifc4_keeps_model_parseable() {
-        let src = fixture_or_skip!("ara3d/duplex.ifc");
-        let (step, stats) = export_step_with_stats(
-            &src,
-            &StepOptions { schema: Some("IFC4".to_string()), ..StepOptions::default() },
-        );
-        assert!(step.contains("FILE_SCHEMA(('IFC4'))"));
-        // Conversion preserves every express id (renames type, never drops entities).
-        let (reparsed, _ids, schema) = parse_back(&step);
-        assert_eq!(reparsed, stats.total, "no entities lost in conversion");
-        assert_eq!(schema, "IFC4");
-        // The converted file must still re-parse as a coherent entity set.
-        assert!(step.lines().filter(|l| l.starts_with('#')).count() == stats.written);
-    }
+    let (step, stats) = export_step_with_stats(
+        &src,
+        &StepOptions {
+            property_mutations: vec![PropMutation {
+                express_id: wall,
+                pset_name: "Pset_Test".to_string(),
+                prop_name: "MyProp".to_string(),
+                value: "IFCLABEL('hello')".to_string(),
+            }],
+            ..StepOptions::default()
+        },
+    );
 
-    #[test]
-    fn copy_on_write_moves_one_referrer_and_leaves_the_other() {
-        let src = concat!(
-            "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
-            "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
-            "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
-            "#42=IFCPROPERTYSINGLEVALUE('Other',$,IFCLABEL('x'),$);\n",
-            "#9=IFCPROPERTYSET('s1',$,'P',$,(#41,#42));\n",
-            "#10=IFCPROPERTYSET('s2',$,'P',$,(#41,#42));\n",
-            "ENDSEC;\nEND-ISO-10303-21;\n"
-        );
-        let (out, stats) = export_step_with_stats(
-            src.as_bytes(),
-            &StepOptions {
-                copy_on_write: vec![CopyOnWriteMutation {
-                    express_id: 41,
-                    index: 2,
-                    value: "IFCLABEL('edited')".to_string(),
-                    referrer_id: 9,
-                    referrer_index: 4,
-                }],
-                ..StepOptions::default()
-            },
-        );
+    // The three synthesized entities are present.
+    assert!(
+        step.contains("=IFCPROPERTYSINGLEVALUE('MyProp',$,IFCLABEL('hello'),$);"),
+        "single value synthesized"
+    );
+    assert!(step.contains("'Pset_Test'"), "pset name present");
+    // The synthesized rel ($-owner/name/desc) relates the wall to the new pset —
+    // distinct from duplex's original rels which carry a real OwnerHistory ref.
+    let synth_rel = format!(",$,$,$,(#{wall}),#");
+    assert!(
+        step.lines()
+            .any(|l| l.contains("=IFCRELDEFINESBYPROPERTIES(") && l.contains(&synth_rel)),
+        "synthesized rel targeting the wall not found"
+    );
 
-        // The shared original is untouched, so #10 still reads 'shared'.
-        assert!(out.contains("#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);"));
-        assert!(out.contains("#10=IFCPROPERTYSET('s2',$,'P',$,(#41,#42));"));
-        // #9 points at the copy and keeps its other reference in place.
-        assert!(out.contains("#43=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('edited'),$);"));
-        assert!(out.contains("#9=IFCPROPERTYSET('s1',$,'P',$,(#43,#42));"));
-        // Counted by the writer, which is why this is emitted rather than
-        // appended: the copy is one more record than the source held.
-        assert_eq!(stats.written, stats.total + 1);
-    }
+    // Re-parses, and the synthesized entities are counted (written = original + 3).
+    let (reparsed, _ids, _schema) = parse_back(&step);
+    assert_eq!(reparsed, stats.written, "every written entity re-parses");
+    assert_eq!(
+        stats.written,
+        stats.total + 3,
+        "added 1 prop + 1 pset + 1 rel"
+    );
+}
 
-    #[test]
-    fn copy_ids_and_synthesized_ids_do_not_collide() {
-        let src = concat!(
-            "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
-            "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
-            "#1=IFCWALL('g',$,'W',$,$,$,$,$,$);\n",
-            "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
-            "#9=IFCPROPERTYSET('s1',$,'P',$,(#41));\n",
-            "ENDSEC;\nEND-ISO-10303-21;\n"
-        );
-        let (out, _) = export_step_with_stats(
-            src.as_bytes(),
-            &StepOptions {
-                copy_on_write: vec![CopyOnWriteMutation {
-                    express_id: 41,
-                    index: 2,
-                    value: "IFCLABEL('edited')".to_string(),
-                    referrer_id: 9,
-                    referrer_index: 4,
-                }],
-                property_mutations: vec![PropMutation {
-                    express_id: 1,
-                    pset_name: "New".to_string(),
-                    prop_name: "P".to_string(),
-                    value: "IFCLABEL('v')".to_string(),
-                }],
-                ..StepOptions::default()
-            },
-        );
-        let mut ids: Vec<&str> = out
-            .lines()
-            .filter_map(|l| l.strip_prefix('#'))
-            .filter_map(|l| l.split('=').next())
-            .collect();
-        let before = ids.len();
-        ids.sort_unstable();
-        ids.dedup();
-        assert_eq!(ids.len(), before, "an id was handed out twice");
-    }
+#[test]
+fn schema_conversion_to_ifc4_keeps_model_parseable() {
+    let src = fixture_or_skip!("ara3d/duplex.ifc");
+    let (step, stats) = export_step_with_stats(
+        &src,
+        &StepOptions {
+            schema: Some("IFC4".to_string()),
+            ..StepOptions::default()
+        },
+    );
+    assert!(step.contains("FILE_SCHEMA(('IFC4'))"));
+    // Conversion preserves every express id (renames type, never drops entities).
+    let (reparsed, _ids, schema) = parse_back(&step);
+    assert_eq!(reparsed, stats.total, "no entities lost in conversion");
+    assert_eq!(schema, "IFC4");
+    // The converted file must still re-parse as a coherent entity set.
+    assert!(step.lines().filter(|l| l.starts_with('#')).count() == stats.written);
+}
 
+#[test]
+fn copy_on_write_moves_one_referrer_and_leaves_the_other() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
+        "#42=IFCPROPERTYSINGLEVALUE('Other',$,IFCLABEL('x'),$);\n",
+        "#9=IFCPROPERTYSET('s1',$,'P',$,(#41,#42));\n",
+        "#10=IFCPROPERTYSET('s2',$,'P',$,(#41,#42));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, stats) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL('edited')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            ..StepOptions::default()
+        },
+    );
 
-    fn fixture(rel: &str) -> Vec<u8> {
-        let path = format!("{}/../../tests/models/{}", env!("CARGO_MANIFEST_DIR"), rel);
-        std::fs::read(&path).unwrap_or_else(|e| panic!("read {path}: {e}"))
-    }
+    // The shared original is untouched, so #10 still reads 'shared'.
+    assert!(out.contains("#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);"));
+    assert!(out.contains("#10=IFCPROPERTYSET('s2',$,'P',$,(#41,#42));"));
+    // #9 points at the copy and keeps its other reference in place.
+    assert!(out.contains("#43=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('edited'),$);"));
+    assert!(out.contains("#9=IFCPROPERTYSET('s1',$,'P',$,(#43,#42));"));
+    // Counted by the writer, which is why this is emitted rather than
+    // appended: the copy is one more record than the source held.
+    assert_eq!(stats.written, stats.total + 1);
+}
+
+#[test]
+fn copy_ids_and_synthesized_ids_do_not_collide() {
+    let src = concat!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n",
+        "FILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n",
+        "#1=IFCWALL('g',$,'W',$,$,$,$,$,$);\n",
+        "#41=IFCPROPERTYSINGLEVALUE('Reference',$,IFCLABEL('shared'),$);\n",
+        "#9=IFCPROPERTYSET('s1',$,'P',$,(#41));\n",
+        "ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let (out, _) = export_step_with_stats(
+        src.as_bytes(),
+        &StepOptions {
+            copy_on_write: vec![CopyOnWriteMutation {
+                express_id: 41,
+                index: 2,
+                value: "IFCLABEL('edited')".to_string(),
+                referrer_id: 9,
+                referrer_index: 4,
+            }],
+            property_mutations: vec![PropMutation {
+                express_id: 1,
+                pset_name: "New".to_string(),
+                prop_name: "P".to_string(),
+                value: "IFCLABEL('v')".to_string(),
+            }],
+            ..StepOptions::default()
+        },
+    );
+    let mut ids: Vec<&str> = out
+        .lines()
+        .filter_map(|l| l.strip_prefix('#'))
+        .filter_map(|l| l.split('=').next())
+        .collect();
+    let before = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), before, "an id was handed out twice");
+}
 
 #[test]
 fn two_copies_through_one_attribute_both_land() {
@@ -285,10 +292,22 @@ fn two_copies_through_one_attribute_both_land() {
         },
     );
     // Both moved, neither orphaned, and the sharer keeps the originals.
-    assert!(out.contains("#9=IFCPROPERTYSET('g',$,'P',$,(#43,#44));"), "{out}");
-    assert!(out.contains("#10=IFCPROPERTYSET('g2',$,'P',$,(#41,#42));"), "{out}");
-    assert!(out.contains("#43=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('e1'),$);"), "{out}");
-    assert!(out.contains("#44=IFCPROPERTYSINGLEVALUE('B',$,IFCLABEL('e2'),$);"), "{out}");
+    assert!(
+        out.contains("#9=IFCPROPERTYSET('g',$,'P',$,(#43,#44));"),
+        "{out}"
+    );
+    assert!(
+        out.contains("#10=IFCPROPERTYSET('g2',$,'P',$,(#41,#42));"),
+        "{out}"
+    );
+    assert!(
+        out.contains("#43=IFCPROPERTYSINGLEVALUE('A',$,IFCLABEL('e1'),$);"),
+        "{out}"
+    );
+    assert!(
+        out.contains("#44=IFCPROPERTYSINGLEVALUE('B',$,IFCLABEL('e2'),$);"),
+        "{out}"
+    );
 }
 
 #[test]

--- a/rust/export/src/step_text.rs
+++ b/rust/export/src/step_text.rs
@@ -138,17 +138,20 @@ fn split_top_level_args(attrs: &str) -> Vec<String> {
     let mut depth = 0i32;
     let mut in_string = false;
     let mut current = String::new();
-    let bytes = attrs.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        let ch = bytes[i] as char;
+    // Over chars, not bytes. `bytes[i] as char` reads a UTF-8 continuation byte
+    // as a Latin-1 character and re-encodes it, so a property name like
+    // `Größe` came back as `GrÃ¶ÃŸe` in any record this rewrote. Every
+    // delimiter STEP cares about is ASCII, so iterating chars costs nothing and
+    // leaves the rest of the text alone.
+    let mut chars = attrs.chars().peekable();
+    while let Some(ch) = chars.next() {
         if ch == '\'' && !in_string {
             in_string = true;
             current.push(ch);
         } else if ch == '\'' && in_string {
-            if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+            if chars.peek() == Some(&'\'') {
                 current.push_str("''");
-                i += 2;
+                chars.next();
                 continue;
             }
             in_string = false;
@@ -166,7 +169,6 @@ fn split_top_level_args(attrs: &str) -> Vec<String> {
         } else {
             current.push(ch);
         }
-        i += 1;
     }
     out.push(current);
     out
@@ -204,3 +206,91 @@ pub(crate) fn apply_attr_mutations(line: &str, muts: &[(usize, String)]) -> Stri
 #[cfg(test)]
 #[path = "step_text_tests.rs"]
 mod tests;
+
+/// Rewrite a record's own id, leaving everything after the `=` untouched.
+///
+/// For a copy-on-write copy: the body is the original's, byte for byte, with
+/// one attribute already replaced, and only the number in front changes.
+pub(crate) fn renumber(line: &str, new_id: u32) -> String {
+    let trimmed = line.trim_end();
+    match trimmed.find('=') {
+        Some(eq) => format!("#{new_id}{}", &trimmed[eq..]),
+        None => line.to_string(),
+    }
+}
+
+/// Replace one reference inside one attribute, leaving its neighbours alone.
+///
+/// Returns the rewritten attribute, or `None` when the attribute does not hold
+/// that reference. The caller is expected to treat `None` as "this edit cannot
+/// be made" rather than proceeding, because a copy nothing points at is an
+/// orphan and a reference to a filtered record is a dangling one.
+///
+/// A list keeps its order and its other entries: repointing one element of a
+/// property set's `HasProperties` must not disturb the rest, or the diff
+/// against the source stops being small.
+///
+/// Text is left alone. A property value reading `'lot #41'` is a sentence, and
+/// rewriting inside it would change what the file says rather than what it
+/// points at.
+/// One attribute of a `#id=TYPE(args);` line, by position.
+///
+/// Split from the substitution below so a caller applying two edits to the
+/// same attribute can feed the first result into the second, rather than
+/// computing both from the original and losing one.
+pub(crate) fn attribute_of(line: &str, index: usize) -> Option<String> {
+    let trimmed = line.trim_end();
+    let body = trimmed.strip_suffix(';').unwrap_or(trimmed);
+    let eq = body.find('=')?;
+    let after = &body[eq + 1..];
+    let popen = after.find('(')?;
+    let aclose = after.rfind(')').filter(|c| *c > popen)?;
+    split_top_level_args(&after[popen + 1..aclose])
+        .into_iter()
+        .nth(index)
+}
+
+
+/// The substitution itself, over one attribute's text.
+pub(crate) fn substitute_ref_in_attr(attr: &str, from: u32, to: u32) -> Option<String> {
+    let old = format!("#{from}");
+    let new = format!("#{to}");
+    let mut out = String::with_capacity(attr.len());
+    let mut replaced = false;
+    let mut in_string = false;
+    let mut rest = attr;
+    while let Some(ch) = rest.chars().next() {
+        if in_string {
+            if ch == '\'' {
+                if rest[ch.len_utf8()..].starts_with('\'') {
+                    out.push_str("''");
+                    rest = &rest[ch.len_utf8() * 2..];
+                    continue;
+                }
+                in_string = false;
+            }
+            out.push(ch);
+            rest = &rest[ch.len_utf8()..];
+            continue;
+        }
+        if ch == '\'' {
+            in_string = true;
+            out.push(ch);
+            rest = &rest[ch.len_utf8()..];
+            continue;
+        }
+        if ch == '#' && rest.starts_with(old.as_str()) {
+            let after = &rest[old.len()..];
+            // `#4` must not match inside `#41`.
+            if !after.starts_with(|c: char| c.is_ascii_digit()) {
+                out.push_str(&new);
+                rest = after;
+                replaced = true;
+                continue;
+            }
+        }
+        out.push(ch);
+        rest = &rest[ch.len_utf8()..];
+    }
+    replaced.then_some(out)
+}

--- a/rust/export/src/step_text.rs
+++ b/rust/export/src/step_text.rs
@@ -8,6 +8,27 @@
 //! line/string utilities with no dependency on the DATA-section emission
 //! orchestration that stays in `step.rs`.
 
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+/// The edits that apply to one record, where a caller's attribute mutation and
+/// a copy-on-write repointing can both land on it. The repointing wins: it was
+/// computed from the caller's value rather than instead of it.
+pub(crate) fn merge_edits<'a>(
+    muts: Option<&'a BTreeMap<usize, String>>,
+    repointed: Option<&'a BTreeMap<usize, String>>,
+) -> Option<Cow<'a, BTreeMap<usize, String>>> {
+    match (muts, repointed) {
+        (None, None) => None,
+        (Some(edits), None) | (None, Some(edits)) => Some(Cow::Borrowed(edits)),
+        (Some(muts), Some(repointed)) => {
+            let mut merged = muts.clone();
+            merged.extend(repointed.iter().map(|(i, v)| (*i, v.clone())));
+            Some(Cow::Owned(merged))
+        }
+    }
+}
+
 /// Escape a STEP string literal body: double the apostrophe and reverse
 /// solidus, and map every ASCII control character (the C0 range plus DEL) to
 /// a space, since ISO 10303-21 restricts a literal's plain-text bytes to the
@@ -176,7 +197,7 @@ fn split_top_level_args(attrs: &str) -> Vec<String> {
 
 /// Apply root-attribute edits to a `#id=TYPE(attrs);` line. Returns the line unchanged
 /// when it cannot be parsed.
-pub(crate) fn apply_attr_mutations(line: &str, muts: &[(usize, String)]) -> String {
+pub(crate) fn apply_attr_mutations(line: &str, muts: &BTreeMap<usize, String>) -> String {
     let trimmed = line.trim_end();
     let body = trimmed.strip_suffix(';').unwrap_or(trimmed);
     let eq = match body.find('=') {
@@ -219,20 +240,6 @@ pub(crate) fn renumber(line: &str, new_id: u32) -> String {
     }
 }
 
-/// Replace one reference inside one attribute, leaving its neighbours alone.
-///
-/// Returns the rewritten attribute, or `None` when the attribute does not hold
-/// that reference. The caller is expected to treat `None` as "this edit cannot
-/// be made" rather than proceeding, because a copy nothing points at is an
-/// orphan and a reference to a filtered record is a dangling one.
-///
-/// A list keeps its order and its other entries: repointing one element of a
-/// property set's `HasProperties` must not disturb the rest, or the diff
-/// against the source stops being small.
-///
-/// Text is left alone. A property value reading `'lot #41'` is a sentence, and
-/// rewriting inside it would change what the file says rather than what it
-/// points at.
 /// One attribute of a `#id=TYPE(args);` line, by position.
 ///
 /// Split from the substitution below so a caller applying two edits to the
@@ -250,8 +257,21 @@ pub(crate) fn attribute_of(line: &str, index: usize) -> Option<String> {
         .nth(index)
 }
 
-
-/// The substitution itself, over one attribute's text.
+/// Replace references inside one attribute, leaving its neighbours alone.
+///
+/// Rewrites every unquoted `#from` in the attribute to `#to`. Returns the
+/// rewritten attribute, or `None` when the attribute does not hold that
+/// reference. The caller is expected to treat `None` as "this edit cannot be
+/// made" rather than proceeding, because a copy nothing points at is an orphan
+/// and a reference to a filtered record is a dangling one.
+///
+/// A list keeps its order and its other entries: repointing one element of a
+/// property set's `HasProperties` must not disturb the rest, or the diff
+/// against the source stops being small.
+///
+/// Text is left alone. A property value reading `'lot #41'` is a sentence, and
+/// rewriting inside it would change what the file says rather than what it
+/// points at.
 pub(crate) fn substitute_ref_in_attr(attr: &str, from: u32, to: u32) -> Option<String> {
     let old = format!("#{from}");
     let new = format!("#{to}");


### PR DESCRIPTION
Editing an attribute in place changes it for every record that references it. IFC exporters routinely give each element its own `IfcPropertySet` and point them all at one `IfcPropertySingleValue` per distinct value, so setting a fire rating on one wall through `AttrMutation` sets it on every wall sharing that value. On a sixteen-thousand-element model, one `Reference` record served eighty property sets and one `Grade` record fifty-seven.

`CopyOnWriteMutation` copies the record, applies the edit to the copy, and repoints one referrer at it. Everything else keeps the original.

## Why this belongs in the writer

Two things it owns.

**Ids.** A copy needs a number no record holds, and `max_id` lives here. A caller allocating its own has to agree with `PropMutation`'s synthesis about which numbers are free; the two counters are threaded so they cannot collide, and there is a test for it.

**The emit path.** A copy that goes through it is counted in `StepStats.written` and converted by `convert_step_line` when the export targets another schema. A record appended to the output afterwards is neither, which makes the written count stop describing the file.

## Correctness

Substitutions fold per referrer attribute. Two copies repointed through one `HasProperties` list each produced a rewrite computed from the untouched original, and the second overwrote the first: one copy orphaned, and the referrer still pointing at the record it was meant to stop sharing. Two properties on one element is the ordinary case here.

A copy is emitted only once its referrer has actually been repointed. Emitting it regardless left a record nothing pointed at, which under a subset export could reference records the closure had filtered out, so the file carried a dangling reference.

## Two fixes to the text helpers

`split_top_level_args` read bytes as chars, which is Latin-1 over UTF-8. Rewriting any record re-encoded non-ASCII text in attributes the caller never touched, so a property set named `'Größe'` came back mangled. This is pre-existing and already reachable through `AttrMutation`; the change here newly triggers it on records only being repointed, so it is fixed rather than worked around.

The substitution skips string literals, so a value reading `'lot #41'` stays a sentence rather than becoming a pointer.

`max_id + 1` is saturating. It used to run only when property mutations were present and now runs on every export, where a file holding `u32::MAX` would panic in debug and wrap in release.

## Tests

Four new: one shared record with two owners (asserting the untouched owner is byte-identical and `written == total + 1`); two copies through one attribute; a copy whose referrer cannot be repointed; and a reference inside a string literal. 231 tests pass.

Tests moved to `step_tests.rs` under the house pattern, which also brings `step.rs` back inside the module-size ratchet it had grown past (644 lines against a 471 budget).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-on-write mutations for STEP exports, allowing selected entities to be duplicated, renumbered, and optionally schema-converted.
  * Export statistics now include generated copies.
* **Bug Fixes**
  * Improved handling of Unicode text, quoted strings, references, and nested lists.
  * Prevented identifier collisions and safely skipped invalid or oversized mutation groups.
* **Tests**
  * Added comprehensive coverage for copy-on-write exports, reference closure, schema conversion, UTF-8 content, validation, and identifier exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->