### PR TITLE
refactor(core): one MAX_MAPPED_ITEM_DEPTH, plus the guard-choice rule (#2873)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,48 @@ Browser-first IFC toolkit: a WebGPU web viewer plus a headless CLI/MCP/server. N
 ## Test fixtures
 - Not committed (no LFS): catalogued in `tests/models/manifest.json`, fetched via `pnpm fixtures`. Tests must **skip** (never throw/panic) when a fixture is absent; point to `pnpm fixtures` in the skip message. Add one: drop under `tests/models/<group>/`, run `pnpm fixtures:manifest`, then `pnpm fixtures:upload`; commit only the manifest. CI runs `pnpm fixtures` before tests.
 
+## Bounding walks over file-supplied references
+
+Entity references come from the file, so their shape is exporter- and
+attacker-controlled. An unbounded recursive walk over one self-referential
+entity dies by `SIGABRT`, which is not a catchable panic: nothing upstream turns
+it into a load error, and in the wasm geometry worker it takes down the
+instance. #2866 found seven such sites.
+
+The three mechanisms are not interchangeable, and each alone leaves a hole:
+
+- a **depth cap** bounds one path's LENGTH, not its breadth. `k` items each
+  leading back into a cycle cost `O(k^depth)`, turning an abort into a hang
+  (measured 7.21s at k=3). A hang is worse: nothing reports it.
+- a **visited set** bounds cycles and revisits. While the walk still recurses it
+  does NOT bound a long *acyclic* chain: every insert succeeds, the set never
+  fires, and the stack still overflows.
+- a **work budget** bounds acyclic DAG fan-out, which neither of the others
+  sees. A DAG where every branch succeeds never errors and never repeats an id;
+  it just emits `2^levels` outputs.
+
+Choose the visited set's SCOPE by what the walk returns:
+
+- **global / memoising** when the result is a pure function of the id (a colour
+  is determined by item id plus style map). Safe and strictly stronger: it kills
+  fan-out outright.
+- **path-scoped** (insert on the way in, remove on the way out) when output
+  ACCUMULATES. A boolean operand tree is a DAG and geometry accumulates, so the
+  same node down two branches is two real pieces of geometry. A global set
+  silently drops the second: **missing geometry, not a cycle guard**, and no
+  termination test notices.
+
+Prefer making the walk **iterative** over adding a cap: with no stack to consume
+there is nothing left for a cap to protect, and the visited set becomes
+sufficient alone. A cap tight enough to stop a cycle usually rejects legitimate
+input — #960 records Revit `FirstOperand` chains 42 nodes deep.
+
+Reuse the shared bound where the chain is shared: `ifc_lite_core::limits`.
+
+A guard that both ACTS and REPORTS has a two-part contract — bound the work, and
+report that you bounded it. Mutate the halves separately; they fail differently
+(a missing bound hangs, a missing report returns a truncated success).
+
 ## Writing tests
 - A new test must assert behavior through a real fixture or a stated invariant. Don't write: set-state-then-read-it-back store tests, tests that assert a mock's return value (they test the mock), constructor/setter tautologies, or byte-for-byte output pinning unless the byte layout IS the compatibility contract (e.g. signed bundles). Regression tests cite the issue/PR number in the test name or a comment.
 - Every package with test files needs a `test` script in its package.json or `turbo test` silently skips it; `scripts/check-test-wiring.mjs` (CI) enforces this. Packages use vitest OR node:test via `tsx --test`; match the package's existing convention, never mix within a package.

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -69,6 +69,7 @@ pub mod fast_parse;
 pub mod generated;
 pub mod georef;
 pub mod legacy_entities;
+pub mod limits;
 pub mod model_bounds;
 pub mod parser;
 pub mod project_units;
@@ -88,6 +89,7 @@ pub use fast_parse::{
 };
 pub use generated::{IfcType, IFC_TYPES};
 pub use georef::{GeoRefExtractor, GeoRefSource, GeoReference, RtcOffset};
+pub use limits::MAX_MAPPED_ITEM_DEPTH;
 pub use legacy_entities::{
     get_legacy_entity_info, is_legacy_entity, map_legacy_to_base_type, LegacyEntityInfo,
 };

--- a/rust/core/src/limits.rs
+++ b/rust/core/src/limits.rs
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Bounds on walks over file-supplied entity references, and the rule for
+//! choosing between them.
+//!
+//! # Why a walk over file references needs a bound at all
+//!
+//! Entity references come from the file, so their shape is attacker- and
+//! exporter-controlled. `#10=IFCBOOLEANRESULT(.DIFFERENCE.,#10,#20)` is one
+//! self-referential entity, and an unbounded recursive walk over it consumes a
+//! stack frame per hop until the process dies. In Rust that death is a
+//! `SIGABRT`, not a catchable panic: nothing upstream can turn it into a load
+//! error, and in the wasm geometry worker it takes down the whole instance.
+//! #2866 found seven such sites, two of them reachable from uploaded bytes or
+//! from any file opened in the browser.
+//!
+//! # Choosing the bound: by what the walk RETURNS, not by how it traverses
+//!
+//! The three mechanisms are not interchangeable, and each one alone leaves a
+//! real hole:
+//!
+//! - a **depth cap** bounds one path's LENGTH. It does not bound breadth: `k`
+//!   items each leading back into a cycle costs `O(k^depth)`, which converts an
+//!   abort into a hang. Measured at 7.21s for k=3 in #2864, and a hang is worse
+//!   than a crash because nothing reports it.
+//! - a **visited set** bounds cycles and revisits. While the walk still
+//!   recurses it does NOT bound a long *acyclic* chain: every insert succeeds,
+//!   the set never fires, and the stack still overflows (verified at 200k links).
+//! - a **work budget** bounds acyclic DAG fan-out, which neither of the others
+//!   sees. An acyclic graph where every branch succeeds never errors and never
+//!   repeats an id; it just emits 2^levels outputs.
+//!
+//! Pick the visited set's SCOPE by what the walk produces:
+//!
+//! - **global / memoising** when the result is a pure function of the id. A
+//!   colour is determined by (item id, style map), so an id that resolved once
+//!   cannot resolve differently down another branch. Global is safe here and
+//!   strictly stronger: it kills fan-out outright.
+//! - **path-scoped** (insert on the way in, remove on the way out) when output
+//!   ACCUMULATES. A boolean operand tree is a DAG and geometry accumulates, so
+//!   the same node reached down two branches is two real pieces of geometry. A
+//!   global set silently drops the second: **missing geometry, not a cycle
+//!   guard**, and no test that only checks termination will notice.
+//!
+//! Getting this backwards fails silently in both directions, which is why the
+//! rule is written down rather than left to be re-derived per site.
+//!
+//! # Prefer iterating over capping
+//!
+//! If the walk can be made iterative, do that instead of adding a length cap:
+//! with no stack to consume there is nothing left for a cap to protect, and the
+//! visited set becomes sufficient on its own. A cap chosen to stop a cycle is
+//! usually tight enough to reject legitimate input — #960 records Revit
+//! exports with `FirstOperand` chains 42 `DIFFERENCE` nodes deep, and a walk
+//! capped below that returns "no" for a file that renders correctly today.
+//!
+//! # Pin the guard, not just the behaviour
+//!
+//! A guard that both ACTS and REPORTS has a two-part contract: bound the work,
+//! AND report that you bounded it. Mutate the halves separately — they fail
+//! differently, a missing bound hangs and a missing report returns a truncated
+//! success. Several guards added under #2866 were initially unpinned: deleting
+//! a visited set left 693 tests green because a depth cap was covering for it,
+//! and a long-chain test asserted `false`, a value both "bailed early" and
+//! "walked correctly" produce.
+
+/// Maximum `IfcMappedItem` → `IfcRepresentationMap` → `MappedRepresentation.Items`
+/// nesting any walk in this workspace will follow.
+///
+/// Shared because three crates walk the SAME chain and their bounds must agree:
+/// `ifc_lite_processing::element`, `ifc_lite_geometry::router::processing` and
+/// `ifc-lite-wasm`'s styling colour resolver. When they disagreed the failure
+/// was silent — #2864 shipped 16 against the router's 32, so any element whose
+/// chain was 17 to 32 links long still rendered its geometry and quietly lost
+/// its authored colour.
+///
+/// A walk over this chain also needs a cycle guard; the cap alone is not
+/// sufficient (see the module docs above for which kind).
+pub const MAX_MAPPED_ITEM_DEPTH: u32 = 32;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The documented contract. This pins the VALUE; the constant being shared
+    /// is what pins agreement between the three walks, and that is now
+    /// structural rather than asserted.
+    #[test]
+    fn mapped_item_depth_is_the_documented_32() {
+        assert_eq!(MAX_MAPPED_ITEM_DEPTH, 32);
+    }
+}

--- a/rust/core/src/limits.rs
+++ b/rust/core/src/limits.rs
@@ -2,79 +2,35 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Bounds on walks over file-supplied entity references, and the rule for
-//! choosing between them.
+//! Bounds on walks over file-supplied entity references.
 //!
-//! # Why a walk over file references needs a bound at all
-//!
-//! Entity references come from the file, so their shape is attacker- and
-//! exporter-controlled. `#10=IFCBOOLEANRESULT(.DIFFERENCE.,#10,#20)` is one
-//! self-referential entity, and an unbounded recursive walk over it consumes a
-//! stack frame per hop until the process dies. In Rust that death is a
-//! `SIGABRT`, not a catchable panic: nothing upstream can turn it into a load
-//! error, and in the wasm geometry worker it takes down the whole instance.
-//! #2866 found seven such sites, two of them reachable from uploaded bytes or
-//! from any file opened in the browser.
-//!
-//! # Choosing the bound: by what the walk RETURNS, not by how it traverses
-//!
-//! The three mechanisms are not interchangeable, and each one alone leaves a
-//! real hole:
-//!
-//! - a **depth cap** bounds one path's LENGTH. It does not bound breadth: `k`
-//!   items each leading back into a cycle costs `O(k^depth)`, which converts an
-//!   abort into a hang. Measured at 7.21s for k=3 in #2864, and a hang is worse
-//!   than a crash because nothing reports it.
-//! - a **visited set** bounds cycles and revisits. While the walk still
-//!   recurses it does NOT bound a long *acyclic* chain: every insert succeeds,
-//!   the set never fires, and the stack still overflows (verified at 200k links).
-//! - a **work budget** bounds acyclic DAG fan-out, which neither of the others
-//!   sees. An acyclic graph where every branch succeeds never errors and never
-//!   repeats an id; it just emits 2^levels outputs.
-//!
-//! Pick the visited set's SCOPE by what the walk produces:
-//!
-//! - **global / memoising** when the result is a pure function of the id. A
-//!   colour is determined by (item id, style map), so an id that resolved once
-//!   cannot resolve differently down another branch. Global is safe here and
-//!   strictly stronger: it kills fan-out outright.
-//! - **path-scoped** (insert on the way in, remove on the way out) when output
-//!   ACCUMULATES. A boolean operand tree is a DAG and geometry accumulates, so
-//!   the same node reached down two branches is two real pieces of geometry. A
-//!   global set silently drops the second: **missing geometry, not a cycle
-//!   guard**, and no test that only checks termination will notice.
-//!
-//! Getting this backwards fails silently in both directions, which is why the
-//! rule is written down rather than left to be re-derived per site.
-//!
-//! # Prefer iterating over capping
-//!
-//! If the walk can be made iterative, do that instead of adding a length cap:
-//! with no stack to consume there is nothing left for a cap to protect, and the
-//! visited set becomes sufficient on its own. A cap chosen to stop a cycle is
-//! usually tight enough to reject legitimate input — #960 records Revit
-//! exports with `FirstOperand` chains 42 `DIFFERENCE` nodes deep, and a walk
-//! capped below that returns "no" for a file that renders correctly today.
-//!
-//! # Pin the guard, not just the behaviour
-//!
-//! A guard that both ACTS and REPORTS has a two-part contract: bound the work,
-//! AND report that you bounded it. Mutate the halves separately — they fail
-//! differently, a missing bound hangs and a missing report returns a truncated
-//! success. Several guards added under #2866 were initially unpinned: deleting
-//! a visited set left 693 tests green because a depth cap was covering for it,
-//! and a long-chain test asserted `false`, a value both "bailed early" and
-//! "walked correctly" produce.
+//! A cap bounds one path's LENGTH only. A walk that can revisit also needs a
+//! cycle guard, and one that fans out over a DAG also needs a work budget; the
+//! three are not interchangeable and choosing wrongly fails silently in both
+//! directions. The rule for picking, and the scope rule for the visited set,
+//! are in AGENTS.md under "Bounding walks over file-supplied references" —
+//! there rather than here, because whoever needs it is adding a NEW walk
+//! somewhere else and will not open this file.
 
 /// Maximum `IfcMappedItem` → `IfcRepresentationMap` → `MappedRepresentation.Items`
 /// nesting any walk in this workspace will follow.
 ///
 /// Shared because three crates walk the SAME chain and their bounds must agree:
 /// `ifc_lite_processing::element`, `ifc_lite_geometry::router::processing` and
-/// `ifc-lite-wasm`'s styling colour resolver. When they disagreed the failure
-/// was silent — #2864 shipped 16 against the router's 32, so any element whose
-/// chain was 17 to 32 links long still rendered its geometry and quietly lost
-/// its authored colour.
+/// `ifc-lite-wasm`'s styling colour resolver.
+///
+/// Disagreement fails SILENTLY, which is why it is worth making structural. A
+/// mid-review revision of #2864 held 16 against the router's 32: an element
+/// whose chain was 17 to 32 links long would have rendered its geometry and
+/// quietly lost its authored colour. That was caught before merge and never
+/// shipped — the point is that nothing except a reviewer's attention was
+/// stopping it.
+///
+/// `ifc_lite_processing::symbolic::item_walk::MAX_ITEM_DEPTH` also walks this
+/// chain and asserts equality with this constant, but deliberately keeps its
+/// own name: it charges `depth + 1` for `IfcGeometricSet` elements and
+/// `IfcCompositeCurve` segments as well, so an equal number does not mean equal
+/// reach. It is never more permissive than this one.
 ///
 /// A walk over this chain also needs a cycle guard; the cap alone is not
 /// sufficient (see the module docs above for which kind).

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -27,8 +27,10 @@ use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
-/// Maximum nested IfcMappedItem depth we will traverse for a single geometry item.
-const MAX_MAPPED_ITEM_DEPTH: usize = 32;
+// Maximum nested IfcMappedItem depth for a single geometry item. Shared with
+// `ifc_lite_processing::element` and the wasm styling colour resolver, which
+// walk the same chain; the constant's own docs say why they must agree.
+use ifc_lite_core::MAX_MAPPED_ITEM_DEPTH;
 
 impl GeometryRouter {
     /// Process building element (IfcWall, IfcBeam, etc.) into mesh
@@ -335,7 +337,7 @@ impl GeometryRouter {
             &rustc_hash::FxHashMap<u32, crate::processors::texture::ResolvedTextureMap>,
         >,
     ) -> Result<()> {
-        if depth >= MAX_MAPPED_ITEM_DEPTH {
+        if depth >= MAX_MAPPED_ITEM_DEPTH as usize {
             return Err(Error::geometry(format!(
                 "MappedItem nesting exceeded maximum depth of {} at #{}",
                 MAX_MAPPED_ITEM_DEPTH, item.id
@@ -894,7 +896,7 @@ impl GeometryRouter {
         visited: &mut FxHashSet<u32>,
         truncated: &mut bool,
     ) -> Result<Mesh> {
-        if depth >= MAX_MAPPED_ITEM_DEPTH {
+        if depth >= MAX_MAPPED_ITEM_DEPTH as usize {
             return Err(Error::geometry(format!(
                 "MappedItem nesting exceeded maximum depth of {} at #{}",
                 MAX_MAPPED_ITEM_DEPTH, item.id
@@ -1138,5 +1140,27 @@ impl GeometryRouter {
         self.scale_mesh(&mut mesh);
         self.apply_placement(element, decoder, &mut mesh)?;
         Ok(Some(mesh))
+    }
+}
+
+#[cfg(test)]
+mod shared_cap_tests {
+    /// `MAX_MAPPED_ITEM_DEPTH` must be the one in `ifc_lite_core::limits`, not
+    /// a private copy that happens to hold the same number today.
+    ///
+    /// This is not redundant with the constant being shared. Sharing removes
+    /// the drift that EXISTS; it does not stop anyone reintroducing a local
+    /// `const MAX_MAPPED_ITEM_DEPTH` that shadows the import. Verified by
+    /// mutation: with the import replaced by a private `= 16` — the exact
+    /// #2864 regression, where elements with 17-to-32-link chains rendered
+    /// their geometry and silently lost their authored colour — 800 tests
+    /// stayed green until this test existed.
+    #[test]
+    fn mapped_item_depth_is_the_shared_constant() {
+        assert_eq!(
+            super::MAX_MAPPED_ITEM_DEPTH,
+            ifc_lite_core::MAX_MAPPED_ITEM_DEPTH,
+            "use the shared cap from ifc_lite_core::limits, not a private copy"
+        );
     }
 }

--- a/rust/geometry/src/router/processing.rs
+++ b/rust/geometry/src/router/processing.rs
@@ -1151,10 +1151,15 @@ mod shared_cap_tests {
     /// This is not redundant with the constant being shared. Sharing removes
     /// the drift that EXISTS; it does not stop anyone reintroducing a local
     /// `const MAX_MAPPED_ITEM_DEPTH` that shadows the import. Verified by
-    /// mutation: with the import replaced by a private `= 16` — the exact
-    /// #2864 regression, where elements with 17-to-32-link chains rendered
-    /// their geometry and silently lost their authored colour — 800 tests
-    /// stayed green until this test existed.
+    /// mutation: with the import replaced by a private `= 16`, 800 tests stayed
+    /// green until this test existed. A mid-review revision of #2864 held
+    /// exactly that value against the router's 32, so the shadow is not a
+    /// hypothetical shape.
+    ///
+    /// The assertion is on the VALUE, not on identity, so a private copy
+    /// holding the same 32 still passes. That is the honest ceiling: Rust has
+    /// no cheap const-identity check, and a same-value shadow is harmless until
+    /// the shared value is next tuned, at which point this fires.
     #[test]
     fn mapped_item_depth_is_the_shared_constant() {
         assert_eq!(

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -790,13 +790,7 @@ fn build_mesh_data(
     mesh_data
 }
 
-/// Longest `IfcMappedItem → IfcRepresentationMap → MappedRepresentation`
-/// chain the colour chase will follow, matching the geometry router's limit
-/// of the same name (`ifc_lite_geometry::router::processing`) — a cap below
-/// the router's would leave a 17-to-32 link chain rendering its geometry
-/// while silently losing the authored style on its leaf. `pub(crate)`:
-/// `processor::color_layer` delegates here rather than keeping its own copy.
-pub(crate) const MAX_MAPPED_ITEM_DEPTH: u32 = 32;
+pub(crate) use ifc_lite_core::MAX_MAPPED_ITEM_DEPTH;
 
 /// Resolve a geometry item's authored colour: direct style on the item, else
 /// chase `IfcMappedItem → IfcRepresentationMap → MappedRepresentation.Items`

--- a/rust/processing/src/element_tests.rs
+++ b/rust/processing/src/element_tests.rs
@@ -276,16 +276,27 @@ END-ISO-10303-21;
     assert_eq!(find_geometry_item_color(100, &styles, &mut decoder), None);
 }
 
-/// The cap is not a free parameter: it must match the geometry router's
-/// `MAX_MAPPED_ITEM_DEPTH`, or a chain longer than this one but shorter than
-/// the router's renders its geometry and silently loses its leaf's style.
-/// The boundary tests above derive their fixtures FROM this constant, so they
-/// follow it anywhere; this pins the value itself.
+/// The cap is not a free parameter: it must match the geometry router's, or a
+/// chain longer than this one but shorter than the router's renders its
+/// geometry and silently loses its leaf's style.
+///
+/// Agreement is now STRUCTURAL: all three walks import one constant from
+/// `ifc_lite_core::limits`, so they cannot disagree. This test used to assert
+/// `MAX_MAPPED_ITEM_DEPTH == 32` against a literal, with a message claiming it
+/// "must equal ifc_lite_geometry::router::processing::MAX_MAPPED_ITEM_DEPTH" —
+/// but it never read the router's value, so it would have stayed green while
+/// the router moved to any other number. It pinned agreement in its message and
+/// a literal in its assertion, which is the illusion of enforcement rather than
+/// enforcement. The value itself is pinned once, in core, next to the constant.
+///
+/// What is worth keeping here is the identity of the import, so that swapping
+/// back to a private copy is a visible change rather than a silent one.
 #[test]
-fn mapped_item_depth_cap_matches_the_geometry_router() {
+fn mapped_item_depth_cap_is_the_shared_constant() {
     assert_eq!(
-        MAX_MAPPED_ITEM_DEPTH, 32,
-        "must equal ifc_lite_geometry::router::processing::MAX_MAPPED_ITEM_DEPTH"
+        MAX_MAPPED_ITEM_DEPTH,
+        ifc_lite_core::MAX_MAPPED_ITEM_DEPTH,
+        "element.rs must use the shared cap, not a private copy"
     );
 }
 

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -450,7 +450,8 @@ fn a_large_flat_set_is_not_truncated() {
 #[test]
 fn depth_cap_matches_the_mapped_item_family_value() {
     assert_eq!(
-        MAX_ITEM_DEPTH, 32,
+        MAX_ITEM_DEPTH,
+        ifc_lite_core::MAX_MAPPED_ITEM_DEPTH,
         "must equal MAX_MAPPED_ITEM_DEPTH in element.rs, router/processing.rs and color.rs; \
          note this cap charges set elements and curve segments too, so equal values do not \
          mean equal reach"

--- a/rust/wasm-bindings/src/api/styling/color.rs
+++ b/rust/wasm-bindings/src/api/styling/color.rs
@@ -312,10 +312,15 @@ mod shared_cap_tests {
     /// This is not redundant with the constant being shared. Sharing removes
     /// the drift that EXISTS; it does not stop anyone reintroducing a local
     /// `const MAX_MAPPED_ITEM_DEPTH` that shadows the import. Verified by
-    /// mutation: with the import replaced by a private `= 16` — the exact
-    /// #2864 regression, where elements with 17-to-32-link chains rendered
-    /// their geometry and silently lost their authored colour — 800 tests
-    /// stayed green until this test existed.
+    /// mutation: with the import replaced by a private `= 16`, 800 tests stayed
+    /// green until this test existed. A mid-review revision of #2864 held
+    /// exactly that value against the router's 32, so the shadow is not a
+    /// hypothetical shape.
+    ///
+    /// The assertion is on the VALUE, not on identity, so a private copy
+    /// holding the same 32 still passes. That is the honest ceiling: Rust has
+    /// no cheap const-identity check, and a same-value shadow is harmless until
+    /// the shared value is next tuned, at which point this fires.
     #[test]
     fn mapped_item_depth_is_the_shared_constant() {
         assert_eq!(

--- a/rust/wasm-bindings/src/api/styling/color.rs
+++ b/rust/wasm-bindings/src/api/styling/color.rs
@@ -2,18 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-/// Longest `IfcMappedItem -> IfcRepresentationMap -> MappedRepresentation`
-/// chain the colour chase will follow.
-///
-/// This is the THIRD copy of this constant. `ifc_lite_geometry`'s
-/// `router::processing` and `ifc_lite_processing`'s `element` both define
-/// `MAX_MAPPED_ITEM_DEPTH = 32` for the same traversal; all three must agree,
-/// or a chain longer than the smallest cap renders its geometry through the
-/// router while silently losing the authored style on its leaf. They are not
-/// deduplicated because the router's is private and the three crates do not
-/// share a home for it — collapsing them is worth doing and is a bigger change
-/// than this fix (#2866).
-const MAX_MAPPED_ITEM_DEPTH: u32 = 32;
+use ifc_lite_core::MAX_MAPPED_ITEM_DEPTH;
 
 /// Find color for a geometry item, following MappedItem references if needed.
 /// This handles the case where IfcStyledItem points to geometry inside a MappedRepresentation,
@@ -314,3 +303,25 @@ END-ISO-10303-21;
 #[cfg(test)]
 #[path = "color_cycle_tests.rs"]
 mod find_color_for_geometry_cycle_tests;
+
+#[cfg(test)]
+mod shared_cap_tests {
+    /// `MAX_MAPPED_ITEM_DEPTH` must be the one in `ifc_lite_core::limits`, not
+    /// a private copy that happens to hold the same number today.
+    ///
+    /// This is not redundant with the constant being shared. Sharing removes
+    /// the drift that EXISTS; it does not stop anyone reintroducing a local
+    /// `const MAX_MAPPED_ITEM_DEPTH` that shadows the import. Verified by
+    /// mutation: with the import replaced by a private `= 16` — the exact
+    /// #2864 regression, where elements with 17-to-32-link chains rendered
+    /// their geometry and silently lost their authored colour — 800 tests
+    /// stayed green until this test existed.
+    #[test]
+    fn mapped_item_depth_is_the_shared_constant() {
+        assert_eq!(
+            super::MAX_MAPPED_ITEM_DEPTH,
+            ifc_lite_core::MAX_MAPPED_ITEM_DEPTH,
+            "use the shared cap from ifc_lite_core::limits, not a private copy"
+        );
+    }
+}

--- a/rust/wasm-bindings/src/api/styling/color_cycle_tests.rs
+++ b/rust/wasm-bindings/src/api/styling/color_cycle_tests.rs
@@ -127,15 +127,20 @@ fn stops_one_hop_past_the_depth_cap() {
     assert_eq!(find_color_for_geometry(200, &styles, &mut decoder), None);
 }
 
-/// The cap is not a free parameter: all three copies of this traversal
-/// must agree, or the shortest one silently strips colour off chains the
-/// others still render.
+/// The cap is not a free parameter: every walk over this chain must agree, or
+/// the shortest one silently strips colour off chains the others still render.
+///
+/// There are no longer three copies to compare — all three sites import one
+/// constant — so this asserts the import rather than a literal. It used to read
+/// `assert_eq!(MAX_MAPPED_ITEM_DEPTH, 32)` with a message naming the other two
+/// crates, which is the shape it was written to prevent: the message claimed
+/// agreement while the assertion checked a constant against itself.
 #[test]
-fn depth_cap_agrees_with_the_other_two_copies() {
+fn depth_cap_is_the_shared_constant() {
     assert_eq!(
-        MAX_MAPPED_ITEM_DEPTH, 32,
-        "must equal ifc_lite_geometry::router::processing and \
-         ifc_lite_processing::element MAX_MAPPED_ITEM_DEPTH"
+        MAX_MAPPED_ITEM_DEPTH,
+        ifc_lite_core::MAX_MAPPED_ITEM_DEPTH,
+        "use the shared cap from ifc_lite_core::limits, not a private copy"
     );
 }
 


### PR DESCRIPTION
Closes #2873. Unblocked by #2866 closing, which that issue was explicitly waiting on.

## The problem

Three crates walked the same `IfcMappedItem → IfcRepresentationMap → Items` chain with three private copies of `MAX_MAPPED_ITEM_DEPTH = 32`, and nothing kept them equal. The router's was `usize`, the other two `u32`.

Now one `pub const` in `ifc_lite_core::limits`, imported at all three sites.

## The existing test was the illusion of enforcement

```rust
assert_eq!(MAX_MAPPED_ITEM_DEPTH, 32,
    "must equal ifc_lite_geometry::router::processing::MAX_MAPPED_ITEM_DEPTH");
```

It pinned its own copy to a **literal** and never read the router's. The message claimed agreement; the assertion compared a constant to itself. It would have stayed green while the router moved to any other value.

## Sharing alone did not close it, and only mutation showed that

My first version stopped at "the constant is shared, so agreement is structural." It is not:

| mutation | result |
|---|---|
| shared const → 16 | core value test **FAILS** |
| private `const MAX_MAPPED_ITEM_DEPTH = 16` in the router | **800 tests GREEN** |

A local `const` shadows the import and nothing noticed — the same illusion I had just deleted. Each site now asserts its constant **is** `ifc_lite_core::MAX_MAPPED_ITEM_DEPTH`, and the router mutation fails.

The assertion is on **value**, not identity, so a private copy holding the same `32` still passes. That is the honest ceiling — Rust has no cheap const-identity check, and a same-value shadow is inert until the shared value is next tuned, at which point it fires. The docs say that rather than overclaiming.

## A false justification, corrected

An earlier draft of this PR said "#2864 shipped 16 against the router's 32, so elements with 17-to-32-link chains rendered geometry and silently lost their colour" — in the commit message **and three source doc comments**. Review challenged it; the history refutes it:

```
7bf76d10f (introduced 16)     on main: NO
be80666e2 (corrected to 32)   on main: NO
5d54de032 (merged #2864)      on main: YES  -> ships `= 32`
```

Both 16-valued commits were branch-only and fixed in review. **No user ever saw a 16 cap.** Still the right motivation — nothing but a reviewer's attention stopped it — but it now reads as the near-miss it was.

## A second walk that claimed to be in step and was not

`symbolic/item_walk.rs`'s `MAX_ITEM_DEPTH` documents itself as *"kept in step with `MAX_MAPPED_ITEM_DEPTH`"* and asserted against the literal 32. Proven inert: with the shared constant at 16, all 98 processing tests stayed green. Now asserts against the shared constant, and that mutation fails it.

Its **value** is deliberately not folded in — it charges `depth + 1` for `IfcGeometricSet` elements and `IfcCompositeCurve` segments too, so equal numbers do not mean equal reach. It is never more permissive, so the asymmetry costs a dropped annotation on geometry that still renders, never the reverse.

## The written rule

The guard-choice procedure the seven #2866 fixes actually used now lives in **AGENTS.md**, not in `limits.rs`. Whoever needs it is adding a *new* walk elsewhere and will never open a file holding one constant; whoever opens that file is reusing an existing bound. `limits.rs` keeps a pointer, and went from ~100 lines to 50.

It records why the three mechanisms are not interchangeable (a depth cap bounds length not breadth, `O(k^depth)` turns an abort into a hang; a visited set does not bound a long acyclic chain while the walk recurses; a work budget bounds fan-out neither sees) and the scope rule: global when the result is a pure function of the id, path-scoped when output accumulates — global where output accumulates drops the second copy of a shared node, which is **missing geometry, not a caught cycle**.

## Behaviour

Unchanged. `32u32 as usize == 32usize`, the operator is unchanged, and the constant is only compared and printed. `rust/geometry/tests/nested_mapped_item.rs` is untouched by this diff, hard-codes the boundary (`32 * 36`, "32 links reached, depth 0..=31") and still passes.

Workspace 1937 passed, clippy clean.

## Separate finding, not fixed here

There are **two** `MAX_PLACEMENT_DEPTH` constants on the `IfcLocalPlacement.PlacementRelTo` chain with different values: `router/transforms/mod.rs:271` = 32 and `profile_extractor.rs:522` = 100, both falling back to identity on exceed. A placement chain 33–100 deep gets identity from one and a real transform from the other. Same defect class as this issue; recorded on #2873's thread rather than widening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared limit for mapped-item traversal, improving consistency across processing, geometry, styling, and WebAssembly features.
  * Added guidance for safely handling deeply nested or cyclic entity references.

* **Bug Fixes**
  * Standardized traversal depth protection to prevent excessive or unbounded processing.

* **Tests**
  * Added and updated checks confirming all relevant components use the shared traversal limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->