### PR TITLE
fix(viewer): keep the actionable advice when a provider explains a dead model (#2886)

### DIFF
--- a/apps/viewer/src/lib/llm/stream-client.test.ts
+++ b/apps/viewer/src/lib/llm/stream-client.test.ts
@@ -95,3 +95,41 @@ test('streamChat surfaces request timeout errors', async () => {
     globalThis.clearTimeout = originalClearTimeout;
   }
 });
+
+test('a retired model still tells the user what they can actually do (#2886)', async () => {
+  // The free Devstral window closed and the provider answered with migration
+  // advice aimed at whoever configures routing: "migrate to the paid slug".
+  // Nobody can do that from the viewer. The branch that adds "switch model"
+  // used to run only when the provider said nothing, so the users handed the
+  // most confusing message were told the least about their options.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(
+    JSON.stringify({
+      code: 'provider_model_not_found',
+      model: 'mistralai/devstral-2512',
+      providerMessage:
+        'The free Devstral 2 2512 period has ended. To continue using this model, please migrate to the paid slug: mistralai/devstral-2512',
+    }),
+    { status: 502, headers: { 'Content-Type': 'application/json' } },
+  );
+
+  try {
+    let captured: string | null = null;
+    await streamChat({
+      proxyUrl: '/api/chat',
+      model: 'mistralai/devstral-2512',
+      messages: [{ role: 'user', content: 'hi' }],
+      onChunk: () => undefined,
+      onComplete: () => undefined,
+      onError: (error) => { captured = error.message; },
+    });
+
+    const message = captured as string | null;
+    assert.ok(message, 'expected an error to surface');
+    assert.match(message, /mistralai\/devstral-2512/, 'the dead model should be named');
+    assert.match(message, /free Devstral 2 2512 period has ended/, "the provider's explanation is worth keeping");
+    assert.match(message, /[Ss]witch model/, 'the one action available in this app must be stated');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/viewer/src/lib/llm/stream-client.ts
+++ b/apps/viewer/src/lib/llm/stream-client.ts
@@ -333,11 +333,16 @@ export async function streamChat(options: StreamOptions): Promise<void> {
       if (response.status === 502 && errorBody.code === 'provider_model_not_found') {
         const providerMessage = errorBody.providerMessage?.trim();
         const modelLabel = errorBody.model ? ` ${errorBody.model}` : '';
-        if (providerMessage) {
-          errorDetail = `Provider routing unavailable for${modelLabel}. ${providerMessage}`;
-        } else {
-          errorDetail = `Provider routing unavailable for${modelLabel}. Try again shortly or switch model.`;
-        }
+        // The provider's own text is usually addressed to whoever configures the
+        // routing, not to the person sitting in front of the viewer: when a free
+        // tier ends it says to migrate to a paid slug (#2886), which nobody can
+        // do from here. Switching model is the one thing that always works in
+        // this app, so say it in both branches -- it used to appear only when
+        // the provider stayed silent, i.e. it was withheld from exactly the
+        // users who had been handed an instruction they could not act on.
+        errorDetail = providerMessage
+          ? `Provider routing unavailable for${modelLabel}. ${providerMessage} Switch model to continue.`
+          : `Provider routing unavailable for${modelLabel}. Try again shortly or switch model.`;
       }
 
       if (errorBody.code === 'provider_error' && errorBody.providerMessage) {


### PR DESCRIPTION
Closes the code half of #2886. The model-list swap itself is a deploy concern (`VITE_LLM_FREE_MODELS`); this is the part that isn't.

## The defect

`apps/viewer/src/lib/llm/stream-client.ts` handled a dead model like this:

```ts
if (providerMessage) {
  errorDetail = `Provider routing unavailable for${modelLabel}. ${providerMessage}`;
} else {
  errorDetail = `Provider routing unavailable for${modelLabel}. Try again shortly or switch model.`;
}
```

"Switch model" — the one action that works from inside the viewer — was added **only when the provider said nothing**. When the provider did explain itself, its explanation replaced the advice entirely.

So the reporter in #2886 saw:

> Provider routing unavailable for mistralai/devstral-2512. The free Devstral 2 2512 period has ended. To continue using this model, please migrate to the paid slug: mistralai/devstral-2512

That text is addressed to whoever configures routing, not to someone sitting in front of the viewer, and migrating to a paid slug is not something they can do from here. The users handed the most confusing message were told the least about their options.

## The fix

Keep the provider's explanation, and always append the action:

> Provider routing unavailable for mistralai/devstral-2512. The free Devstral 2 2512 period has ended. To continue using this model, please migrate to the paid slug: mistralai/devstral-2512 **Switch model to continue.**

The silent-provider branch is unchanged.

## Test

`apps/viewer/src/lib/llm/stream-client.test.ts` gains a regression test built from this issue's **exact payload** — the real `provider_model_not_found` body and the provider's real message, not a paraphrase. It asserts the provider's explanation survives *and* that the actionable sentence is present, so neither half can be dropped later.

Verified by running, on this branch:

```
$ pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=1 \
    src/lib/llm/stream-client.test.ts
ok 4 - a retired model still tells the user what they can actually do (#2886)
# tests 4  # pass 4  # fail 0
```

It fails against `main` on the assertion that the one available action must be stated.

## Scope

No changeset: `apps/viewer` is private and this changes user-facing copy on an error path, not a published package's surface. Nothing about the model list or `VITE_LLM_FREE_MODELS` is touched here — that remains a deployment decision, and this PR does not attempt to make it otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when a selected model is unavailable.
  - Provider explanations are now preserved while clearly identifying the unavailable model.
  - Added guidance to switch models to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->