### PR TITLE
fix(extensions,viewer): don't fail a flavor operation on a write that changes nothing

### DIFF
--- a/.changeset/flavor-pointer-write-that-changes-nothing.md
+++ b/.changeset/flavor-pointer-write-that-changes-nothing.md
@@ -21,6 +21,11 @@ already:
 - **`activeFlavorPointer(target)`** is now exported: it builds the id the
   pointer stores for a flavor, so the value compared is the value written by
   construction rather than a second derivation that can drift.
+- **`activeFlavorPointerAlreadyStored(read, pointer)`** is now exported and is
+  the single comparison both hosts ask through, so a change to how the pointer
+  is encoded lands once. It answers `false` for a pointer that is not a string,
+  so an absent id can never match an unset pointer and report a refused write
+  with nothing stored as a successful one.
 - **`ExtensionHostService.switchFlavor`** (viewer) wires that callback through
   `FlavorService.activeId()`, also new. It turned a failed switch into a thrown
   error, which skipped the lens, clash and sidebar restores below it.
@@ -35,6 +40,20 @@ id and version, so a reinstall of the same version overwrote them; a loader
 rejection then deleted the record and the bundle with nothing to restore,
 wiping a working extension. The snapshot is now taken for any previous install.
 The teardown stays gated on a version change.
+
+The rollback also restores the previous record first and in its own step,
+independent of the bundle bytes. The record carries the capability grants, the
+enabled bit, the install time and the source, none of which need bytes: a
+record whose bundle is missing is a state the loader already names
+(`invalid_reference`) and one a reinstall repairs, so a previous install whose
+bytes were already gone no longer has its record deleted by the rollback, and a
+byte write that fails during the restore — `putBundle` is the step with a
+storage-quota path — no longer takes the record down with it.
+
+One cost, in the safe direction: because the snapshot is no longer gated on a
+version change, a transient failure reading the previous bundle bytes now fails
+a same-version reinstall that previously would have proceeded. Nothing is
+written or destroyed in that case; the install has to be retried.
 
 Each comparison is one-directional: `false` means "not provably a no-op", never
 a guess, so anything unreadable costs only a refusal that was already the old

--- a/.changeset/flavor-pointer-write-that-changes-nothing.md
+++ b/.changeset/flavor-pointer-write-that-changes-nothing.md
@@ -41,14 +41,24 @@ rejection then deleted the record and the bundle with nothing to restore,
 wiping a working extension. The snapshot is now taken for any previous install.
 The teardown stays gated on a version change.
 
-The rollback also restores the previous record first and in its own step,
-independent of the bundle bytes. The record carries the capability grants, the
-enabled bit, the install time and the source, none of which need bytes: a
-record whose bundle is missing is a state the loader already names
-(`invalid_reference`) and one a reinstall repairs, so a previous install whose
-bytes were already gone no longer has its record deleted by the rollback, and a
-byte write that fails during the restore — `putBundle` is the step with a
-storage-quota path — no longer takes the record down with it.
+The rollback also restores the previous record under its own guard, independent
+of the bundle bytes. The record carries the capability grants, the enabled bit,
+the install time and the source, none of which need bytes and none of which the
+user can reconstruct, so a previous install whose bytes were already gone no
+longer has its record deleted by the rollback, and a byte write that fails
+during the restore — `putBundle` is the step with a storage-quota path — no
+longer takes the record down with it. A record without its bytes is a state the
+loader names (`invalid_reference`); reinstalling the same version repairs it and
+keeps the grants, but the app offers no route to that today — the Repair queue
+passes an extension whose engine range still matches, so it never reports the
+missing bytes. Keeping the record is still the better outcome: unloaded *and*
+deleted is strictly worse than unloaded.
+
+The rollback now also checks that the record in storage is still the one this
+install wrote before undoing anything. `load` is an await point, so a user can
+uninstall while a slow load is in flight; restoring the previous record after
+that would undo an explicit uninstall. The check is on record identity, never
+on whether bytes exist, so it does not reintroduce the gate above.
 
 One cost, in the safe direction: because the snapshot is no longer gated on a
 version change, a transient failure reading the previous bundle bytes now fails

--- a/.changeset/flavor-pointer-write-that-changes-nothing.md
+++ b/.changeset/flavor-pointer-write-that-changes-nothing.md
@@ -1,0 +1,42 @@
+---
+'@ifc-lite/extensions': minor
+'@ifc-lite/viewer': patch
+---
+
+Don't fail a flavor operation on an active-flavor pointer write that changes
+nothing, and snapshot a same-version reinstall before overwriting its bundle.
+
+Four sites wrote in two steps, and treated a refused second write as fatal
+without first asking whether that write would have stored what was stored
+already:
+
+- **`switchFlavor`** rolled every extension toggle back and reported
+  `'<pointer>'` when `setActiveFlavor` was refused. Re-applying the flavor that
+  is already active writes the id the pointer already holds, so the refusal
+  changed nothing — and the rollback disabled every extension the target
+  declares. `FlavorSwitcherCallbacks` gains an optional `readActiveFlavor()`;
+  when it reports the id `activeFlavorPointer(target)` would have written, the
+  switch stands. Without the callback, or when the read fails, the refusal is
+  still fatal — the behaviour every host had before.
+- **`activeFlavorPointer(target)`** is now exported: it builds the id the
+  pointer stores for a flavor, so the value compared is the value written by
+  construction rather than a second derivation that can drift.
+- **`ExtensionHostService.switchFlavor`** (viewer) wires that callback through
+  `FlavorService.activeId()`, also new. It turned a failed switch into a thrown
+  error, which skipped the lens, clash and sidebar restores below it.
+- **`FlavorService.resetToDefaults`** (viewer) threw when `setActiveId` was
+  refused even though the baseline flavor had landed and the pointer already
+  named it — the common case, since resetting is the way back from anything.
+  It now rethrows only when the pointer is not provably already that id.
+
+Separately, **`installFromBytes`** (viewer) snapshotted the previous install's
+bundle bytes only when the incoming version differed. Bundle bytes are keyed by
+id and version, so a reinstall of the same version overwrote them; a loader
+rejection then deleted the record and the bundle with nothing to restore,
+wiping a working extension. The snapshot is now taken for any previous install.
+The teardown stays gated on a version change.
+
+Each comparison is one-directional: `false` means "not provably a no-op", never
+a guess, so anything unreadable costs only a refusal that was already the old
+behaviour. No path reports success while the stored state differs from what a
+successful operation would have left.

--- a/apps/viewer/src/services/extensions/flavor-service.test.ts
+++ b/apps/viewer/src/services/extensions/flavor-service.test.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  DEFAULT_FLAVOR_ID,
+  InMemoryFlavorStorage,
+  type FlavorStorage,
+} from '@ifc-lite/extensions';
+import { FlavorService } from './flavor-service.js';
+
+/**
+ * An in-memory store whose `setActiveId` is refused — the shape a quota hit
+ * or a blocked IDB transaction presents. Everything else behaves normally,
+ * so the pointer keeps whatever value was seeded before the refusal.
+ */
+function refusingPointerStore(
+  seedActiveId?: string,
+): FlavorStorage & { setActiveCalls: number; setActiveArgs: (string | undefined)[] } {
+  const inner = new InMemoryFlavorStorage();
+  const wrapper = {
+    setActiveCalls: 0,
+    setActiveArgs: [] as (string | undefined)[],
+    putFlavor: inner.putFlavor.bind(inner),
+    getFlavor: inner.getFlavor.bind(inner),
+    listFlavors: inner.listFlavors.bind(inner),
+    deleteFlavor: inner.deleteFlavor.bind(inner),
+    listSnapshots: inner.listSnapshots.bind(inner),
+    restoreSnapshot: inner.restoreSnapshot.bind(inner),
+    clear: inner.clear.bind(inner),
+    getActiveId: () => Promise.resolve(seedActiveId),
+    setActiveId: async (id: string | undefined): Promise<void> => {
+      wrapper.setActiveCalls += 1;
+      wrapper.setActiveArgs.push(id);
+      throw new Error('pointer write refused');
+    },
+  };
+  return wrapper as unknown as FlavorStorage & {
+    setActiveCalls: number;
+    setActiveArgs: (string | undefined)[];
+  };
+}
+
+describe('FlavorService.resetToDefaults', () => {
+  it('succeeds when the refused pointer write would have stored the id already stored', async () => {
+    // The default flavor is already the active one — a second reset writes the
+    // pointer it already holds. That write changes nothing, so a refusal must
+    // not fail the reset: the baseline flavor landed and the pointer names it.
+    const storage = refusingPointerStore(DEFAULT_FLAVOR_ID);
+    const service = new FlavorService({ storage });
+
+    const flavor = await service.resetToDefaults();
+
+    assert.equal(flavor.id, DEFAULT_FLAVOR_ID);
+    assert.equal(storage.setActiveCalls, 1, 'the write is still attempted');
+    // The value compared must be the value written: a write of anything else
+    // would have changed the pointer, so calling it a no-op would be a lie.
+    assert.deepEqual(storage.setActiveArgs, [DEFAULT_FLAVOR_ID]);
+    const stored = await storage.getFlavor(DEFAULT_FLAVOR_ID);
+    assert.ok(stored, 'the baseline flavor is on disk');
+    assert.equal(await storage.getActiveId(), DEFAULT_FLAVOR_ID);
+  });
+
+  it('still fails when the refused pointer write would have moved the pointer', async () => {
+    const storage = refusingPointerStore('flv.other');
+    const service = new FlavorService({ storage });
+
+    await assert.rejects(() => service.resetToDefaults(), /pointer write refused/);
+  });
+
+  it('still fails when the pointer holds nothing', async () => {
+    const storage = refusingPointerStore(undefined);
+    const service = new FlavorService({ storage });
+
+    await assert.rejects(() => service.resetToDefaults(), /pointer write refused/);
+  });
+
+  it('still fails when the pointer is unreadable', async () => {
+    // One-directional: a read that cannot answer is not proof of a no-op.
+    const storage = refusingPointerStore(DEFAULT_FLAVOR_ID);
+    storage.getActiveId = () => Promise.reject(new Error('read io'));
+    const service = new FlavorService({ storage });
+
+    await assert.rejects(() => service.resetToDefaults(), /pointer write refused/);
+  });
+
+  it('rethrows a refused putFlavor — nothing was written to compare against', async () => {
+    const storage = refusingPointerStore(DEFAULT_FLAVOR_ID);
+    storage.putFlavor = () => Promise.reject(new Error('flavor write refused'));
+    const service = new FlavorService({ storage });
+
+    await assert.rejects(() => service.resetToDefaults(), /flavor write refused/);
+    assert.equal(storage.setActiveCalls, 0, 'the pointer write is never reached');
+  });
+});

--- a/apps/viewer/src/services/extensions/flavor-service.ts
+++ b/apps/viewer/src/services/extensions/flavor-service.ts
@@ -15,6 +15,7 @@
 
 import {
   activeFlavorPointer,
+  activeFlavorPointerAlreadyStored,
   DEFAULT_FLAVOR_ID,
   flavorImportedId,
   packFlavor,
@@ -183,35 +184,21 @@ export class FlavorService {
     // storage is exactly what a successful reset leaves behind.
     //
     // `activeFlavorPointer` builds the value handed to `setActiveId`, and
-    // `activeIdAlreadyStored` compares through the same value, so what is
-    // compared is what would have been written.
+    // `activeFlavorPointerAlreadyStored` — the one comparison, shared with the
+    // switcher — compares through that same value, so what is compared is what
+    // would have been written.
     const activeId = activeFlavorPointer(flavor);
     try {
       await this.storage.setActiveId(activeId);
     } catch (err) {
-      if (!(await this.activeIdAlreadyStored(activeId))) throw err;
+      const stored = await activeFlavorPointerAlreadyStored(
+        () => this.storage.getActiveId(),
+        activeId,
+      );
+      if (!stored) throw err;
     }
     this.emit();
     return flavor;
-  }
-
-  /**
-   * Whether the active-flavor pointer already holds exactly `id` — i.e.
-   * whether writing `id` would change nothing.
-   *
-   * One-directional on purpose: `false` only means "not provably a no-op". A
-   * pointer that cannot be read back answers `false`, because the write really
-   * might have changed it. A caller uses this to let a refused write pass, and
-   * letting one pass that would have moved the pointer is the failure that
-   * matters.
-   */
-  private async activeIdAlreadyStored(id: string): Promise<boolean> {
-    try {
-      return (await this.storage.getActiveId()) === id;
-    } catch {
-      // Unreadable pointer: nothing is provably stored.
-      return false;
-    }
   }
 
   /** Subscribe to flavor changes. Returns unsubscribe. */

--- a/apps/viewer/src/services/extensions/flavor-service.ts
+++ b/apps/viewer/src/services/extensions/flavor-service.ts
@@ -14,6 +14,7 @@
  */
 
 import {
+  activeFlavorPointer,
   DEFAULT_FLAVOR_ID,
   flavorImportedId,
   packFlavor,
@@ -57,6 +58,16 @@ export class FlavorService {
   async getActive(): Promise<Flavor | undefined> {
     const id = await this.storage.getActiveId();
     return id ? this.storage.getFlavor(id) : undefined;
+  }
+
+  /**
+   * The persisted active-flavor pointer, without loading the flavor behind it.
+   * `getActive` answers `undefined` both for "no pointer" and for "the pointer
+   * names a flavor that is gone"; a caller comparing against the value a
+   * pointer write would store needs the pointer itself.
+   */
+  async activeId(): Promise<string | undefined> {
+    return this.storage.getActiveId();
   }
 
   async put(flavor: Flavor, reason?: string): Promise<void> {
@@ -164,9 +175,43 @@ export class FlavorService {
       settings: {},
     };
     await this.storage.putFlavor(flavor, 'reset to defaults');
-    await this.storage.setActiveId(id);
+    // A refused pointer write that would have stored exactly what is stored
+    // already changed nothing, so it must not fail the reset. Resetting when
+    // the default flavor is already active — the common case, since the reset
+    // button is the way back from anything — writes the pointer it already
+    // holds: the baseline flavor above landed and the pointer names it, so
+    // storage is exactly what a successful reset leaves behind.
+    //
+    // `activeFlavorPointer` builds the value handed to `setActiveId`, and
+    // `activeIdAlreadyStored` compares through the same value, so what is
+    // compared is what would have been written.
+    const activeId = activeFlavorPointer(flavor);
+    try {
+      await this.storage.setActiveId(activeId);
+    } catch (err) {
+      if (!(await this.activeIdAlreadyStored(activeId))) throw err;
+    }
     this.emit();
     return flavor;
+  }
+
+  /**
+   * Whether the active-flavor pointer already holds exactly `id` — i.e.
+   * whether writing `id` would change nothing.
+   *
+   * One-directional on purpose: `false` only means "not provably a no-op". A
+   * pointer that cannot be read back answers `false`, because the write really
+   * might have changed it. A caller uses this to let a refused write pass, and
+   * letting one pass that would have moved the pointer is the failure that
+   * matters.
+   */
+  private async activeIdAlreadyStored(id: string): Promise<boolean> {
+    try {
+      return (await this.storage.getActiveId()) === id;
+    } catch {
+      // Unreadable pointer: nothing is provably stored.
+      return false;
+    }
   }
 
   /** Subscribe to flavor changes. Returns unsubscribe. */

--- a/apps/viewer/src/services/extensions/host-installer.test.ts
+++ b/apps/viewer/src/services/extensions/host-installer.test.ts
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `installFromBytes` rollback: a loader rejection must leave the previously
+ * installed extension exactly as it was. The bundle bytes are keyed by
+ * `id + version`, so a reinstall of the *same* version overwrites them —
+ * which is precisely the case where the rollback needs a snapshot taken
+ * before the write.
+ */
+
+// fake-indexeddb backs the real IdbExtensionStorage the installer writes to.
+import 'fake-indexeddb/auto';
+
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import {
+  buildBundleFromFiles,
+  packBundle,
+  type Bundle,
+  type BundleFile,
+  type ExtensionLoader,
+  type InstalledExtensionRecord,
+  type LoadedExtensionStatus,
+} from '@ifc-lite/extensions';
+import { IdbExtensionStorage } from './idb-storage.js';
+import { installFromBytes, type InstallerDeps } from './host-installer.js';
+
+const EXT_ID = 'com.example.rollback';
+
+function file(path: string, text: string): BundleFile {
+  return { path, bytes: new TextEncoder().encode(text), text };
+}
+
+/** A minimal but valid bundle whose activate source carries `marker`. */
+function bundleBytes(version: string, marker: string): Uint8Array {
+  const manifest = {
+    manifestVersion: 1,
+    id: EXT_ID,
+    name: 'Rollback Fixture',
+    description: 'Bundle used by the installer rollback tests.',
+    version,
+    engines: { ifcLiteSdk: '>=2.0.0' },
+    capabilities: ['model.read'],
+    activation: ['onStartup'],
+    contributes: {},
+    entry: { activate: 'src/activate.js' },
+  };
+  const manifestFile = file('manifest.json', JSON.stringify(manifest));
+  const activate = file(
+    'src/activate.js',
+    `export function activate() { return ${JSON.stringify(marker)}; }`,
+  );
+  const files = new Map<string, BundleFile>([
+    ['manifest.json', manifestFile],
+    ['src/activate.js', activate],
+  ]);
+  const built = buildBundleFromFiles(files, manifestFile, { kind: 'memory' });
+  if (!built.ok) {
+    throw new Error(`fixture bundle did not build: ${built.errors[0]?.message ?? 'unknown'}`);
+  }
+  return packBundle(built.value as Bundle);
+}
+
+interface Recorder {
+  deps: InstallerDeps;
+  storage: IdbExtensionStorage;
+  loadResults: (LoadedExtensionStatus | undefined)[];
+  /** Teardowns of the running extension, counted at `loader.unload`. */
+  teardowns: { count: number };
+}
+
+/**
+ * Installer deps over the real IDB-backed storage, with the loader's verdict
+ * scripted per call and the runtime / dispatcher reduced to no-ops.
+ */
+function makeDeps(loadResults: (LoadedExtensionStatus | undefined)[]): Recorder {
+  const storage = new IdbExtensionStorage();
+  const teardowns = { count: 0 };
+  const loader = {
+    load: () => Promise.resolve(loadResults.shift()),
+    unload: () => {
+      teardowns.count += 1;
+      return Promise.resolve();
+    },
+    getBundle: () => undefined,
+  } as unknown as ExtensionLoader;
+  const deps = {
+    storage,
+    loader,
+    runtime: {
+      deactivate: () => Promise.resolve(),
+      deactivateWithBundle: () => Promise.resolve(),
+    },
+    dispatcher: { fire: () => Promise.resolve(), resetActivation: () => {} },
+    audit: { append: () => {} },
+    emitAction: () => {},
+    emit: () => {},
+  } as unknown as InstallerDeps;
+  return { deps, storage, loadResults, teardowns };
+}
+
+function okStatus(): LoadedExtensionStatus {
+  return { id: EXT_ID, ok: true, errors: [] } as unknown as LoadedExtensionStatus;
+}
+
+function failStatus(): LoadedExtensionStatus {
+  return { id: EXT_ID, ok: false, errors: [] } as unknown as LoadedExtensionStatus;
+}
+
+async function installedState(
+  storage: IdbExtensionStorage,
+  version: string,
+): Promise<{ record: InstalledExtensionRecord | undefined; bytes: Uint8Array | undefined }> {
+  return {
+    record: await storage.getExtension(EXT_ID),
+    bytes: await storage.getBundle(EXT_ID, version),
+  };
+}
+
+describe('installFromBytes rollback', () => {
+  beforeEach(async () => {
+    await new IdbExtensionStorage().clear();
+  });
+
+  it('restores the working install when a same-version reinstall is rejected', async () => {
+    const good = bundleBytes('1.0.0', 'original');
+    const bad = bundleBytes('1.0.0', 'replacement');
+    assert.notDeepEqual(
+      Array.from(bad),
+      Array.from(good),
+      'the fixture must actually change the stored bytes',
+    );
+
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, good, ['model.read']);
+    const before = await installedState(first.storage, '1.0.0');
+    assert.ok(before.record, 'the first install landed');
+    assert.ok(before.bytes, 'the first install stored its bundle');
+
+    const second = makeDeps([failStatus(), okStatus()]);
+    await assert.rejects(
+      () => installFromBytes(second.deps, bad, ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+
+    // Replacing the bytes under the version that is already loaded is not a
+    // version change: the running extension is left alone.
+    assert.equal(second.teardowns.count, 0, 'no teardown on a same-version reinstall');
+
+    const after = await installedState(second.storage, '1.0.0');
+    assert.deepEqual(after.record, before.record, 'the previous record is back');
+    assert.ok(after.bytes, 'the previous bundle bytes are back');
+    assert.deepEqual(Array.from(after.bytes), Array.from(before.bytes));
+  });
+
+  it('restores the working install when an upgrade is rejected', async () => {
+    const good = bundleBytes('1.0.0', 'original');
+    const bad = bundleBytes('2.0.0', 'upgrade');
+
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, good, ['model.read']);
+    const before = await installedState(first.storage, '1.0.0');
+
+    const second = makeDeps([failStatus(), okStatus()]);
+    await assert.rejects(
+      () => installFromBytes(second.deps, bad, ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+
+    assert.equal(second.teardowns.count, 1, 'the outgoing version is torn down');
+
+    const after = await installedState(second.storage, '1.0.0');
+    assert.deepEqual(after.record, before.record);
+    assert.ok(after.bytes);
+    assert.deepEqual(Array.from(after.bytes), Array.from(before.bytes!));
+    assert.equal(
+      await second.storage.getBundle(EXT_ID, '2.0.0'),
+      undefined,
+      'the rejected bundle is gone',
+    );
+  });
+
+  it('leaves nothing behind when a first install is rejected', async () => {
+    const bad = bundleBytes('1.0.0', 'first');
+    const deps = makeDeps([failStatus()]);
+    await assert.rejects(
+      () => installFromBytes(deps.deps, bad, ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+    const after = await installedState(deps.storage, '1.0.0');
+    assert.equal(after.record, undefined);
+    assert.equal(after.bytes, undefined);
+  });
+});

--- a/apps/viewer/src/services/extensions/host-installer.test.ts
+++ b/apps/viewer/src/services/extensions/host-installer.test.ts
@@ -194,3 +194,82 @@ describe('installFromBytes rollback', () => {
     assert.equal(after.bytes, undefined);
   });
 });
+
+/**
+ * The record and the bundle bytes are two independent pieces of state. A
+ * record can outlive its bytes — the loader has a dedicated
+ * `invalid_reference` error for exactly that — and restoring the bytes can
+ * fail on its own (a storage quota rejection). Neither may take the record
+ * down with it: the record carries the capability grants, the enabled bit,
+ * the install time and the source, none of which need bytes to be worth
+ * keeping, and none of which the user asked to remove.
+ */
+describe('installFromBytes rollback keeps the record independent of the bytes', () => {
+  beforeEach(async () => {
+    await new IdbExtensionStorage().clear();
+  });
+
+  it('keeps the previous record when a same-version reinstall is rejected', async () => {
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, bundleBytes('1.0.0', 'original'), ['model.read']);
+    const before = await installedState(first.storage, '1.0.0');
+    assert.ok(before.record, 'the first install landed');
+
+    // The bytes go missing behind the record's back.
+    await first.storage.deleteBundle(EXT_ID, '1.0.0');
+
+    const second = makeDeps([failStatus(), okStatus()]);
+    await assert.rejects(
+      () => installFromBytes(second.deps, bundleBytes('1.0.0', 'replacement'), ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+
+    const after = await installedState(second.storage, '1.0.0');
+    assert.deepEqual(after.record, before.record, 'the previous record survives');
+  });
+
+  it('keeps the previous record when an upgrade is rejected', async () => {
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, bundleBytes('1.0.0', 'original'), ['model.read']);
+    const before = await installedState(first.storage, '1.0.0');
+    assert.ok(before.record, 'the first install landed');
+    await first.storage.deleteBundle(EXT_ID, '1.0.0');
+
+    const second = makeDeps([failStatus(), okStatus()]);
+    await assert.rejects(
+      () => installFromBytes(second.deps, bundleBytes('2.0.0', 'upgrade'), ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+
+    // The outgoing version is still torn down — that part is a version change.
+    assert.equal(second.teardowns.count, 1, 'the outgoing version is torn down');
+    const after = await installedState(second.storage, '1.0.0');
+    assert.deepEqual(after.record, before.record, 'the previous record survives');
+  });
+
+  it('keeps the previous record when restoring its bytes fails', async () => {
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, bundleBytes('1.0.0', 'original'), ['model.read']);
+    const before = await installedState(first.storage, '1.0.0');
+    assert.ok(before.record, 'the first install landed');
+
+    const second = makeDeps([failStatus(), okStatus()]);
+    // Fail only the restore's `putBundle`, the way a quota rejection would.
+    const realPutBundle = second.storage.putBundle.bind(second.storage);
+    let bundleWrites = 0;
+    second.storage.putBundle = (id: string, version: string, bytes: Uint8Array) => {
+      bundleWrites += 1;
+      if (bundleWrites > 1) return Promise.reject(new Error('QuotaExceeded during restore'));
+      return realPutBundle(id, version, bytes);
+    };
+
+    await assert.rejects(
+      () => installFromBytes(second.deps, bundleBytes('1.0.0', 'replacement'), ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+    assert.ok(bundleWrites > 1, 'the restore actually attempted a bundle write');
+
+    const after = await installedState(second.storage, '1.0.0');
+    assert.deepEqual(after.record, before.record, 'the previous record survives');
+  });
+});

--- a/apps/viewer/src/services/extensions/host-installer.test.ts
+++ b/apps/viewer/src/services/extensions/host-installer.test.ts
@@ -25,7 +25,7 @@ import {
   type LoadedExtensionStatus,
 } from '@ifc-lite/extensions';
 import { IdbExtensionStorage } from './idb-storage.js';
-import { installFromBytes, type InstallerDeps } from './host-installer.js';
+import { installFromBytes, uninstall, type InstallerDeps } from './host-installer.js';
 
 const EXT_ID = 'com.example.rollback';
 
@@ -245,6 +245,106 @@ describe('installFromBytes rollback keeps the record independent of the bytes', 
     assert.equal(second.teardowns.count, 1, 'the outgoing version is torn down');
     const after = await installedState(second.storage, '1.0.0');
     assert.deepEqual(after.record, before.record, 'the previous record survives');
+  });
+
+  it('does not resurrect a record the user uninstalled while the install was loading', async () => {
+    // Install v1, its bytes go missing behind the record's back, then a v2
+    // install hangs in `load` and the user hits Uninstall before it comes
+    // back. The uninstall is explicit and it wins: restoring `previous`
+    // here would undo it and leave a listed-but-unloadable record behind.
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, bundleBytes('1.0.0', 'original'), ['model.read']);
+    assert.ok(await first.storage.getExtension(EXT_ID), 'the first install landed');
+    await first.storage.deleteBundle(EXT_ID, '1.0.0');
+
+    const second = makeDeps([]);
+    let uninstalledDuringLoad = false;
+    (second.deps.loader as { load: (id: string) => Promise<LoadedExtensionStatus | undefined> })
+      .load = async () => {
+        if (uninstalledDuringLoad) return okStatus();
+        uninstalledDuringLoad = true;
+        // The user hits Uninstall while this load is still in flight.
+        await uninstall(second.deps, EXT_ID);
+        return failStatus();
+      };
+
+    await assert.rejects(
+      () => installFromBytes(second.deps, bundleBytes('2.0.0', 'upgrade'), ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+    assert.ok(uninstalledDuringLoad, 'the uninstall actually ran mid-install');
+
+    assert.equal(
+      await second.storage.getExtension(EXT_ID),
+      undefined,
+      'the record the user uninstalled stays uninstalled',
+    );
+  });
+
+  it('still rolls back when the record re-read fails', async () => {
+    // The re-read that guards against an uninstall-mid-load proves nothing
+    // when it fails, so it falls back to rolling back — what happens when
+    // nobody touched storage, which is every case but the racing one.
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, bundleBytes('1.0.0', 'original'), ['model.read']);
+    const before = await first.storage.getExtension(EXT_ID);
+    assert.ok(before, 'the first install landed');
+
+    const second = makeDeps([failStatus(), okStatus()]);
+    const realGet = second.storage.getExtension.bind(second.storage);
+    let reads = 0;
+    second.storage.getExtension = (id: string) => {
+      reads += 1;
+      // The pre-install snapshot read succeeds; the rollback's re-read throws.
+      return reads === 1 ? realGet(id) : Promise.reject(new Error('re-read blew up'));
+    };
+
+    await assert.rejects(
+      () => installFromBytes(second.deps, bundleBytes('1.0.0', 'replacement'), ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+    assert.ok(reads > 1, 'the rollback actually attempted the re-read');
+
+    const after = await new IdbExtensionStorage().getExtension(EXT_ID);
+    assert.deepEqual(after, before, 'the previous record was still restored');
+  });
+
+  it('re-loads the restored record even when there were no bytes to restore', async () => {
+    // The rollback's reload is not gated on the byte snapshot. With the bytes
+    // gone it is the load that makes the loader report the record's real
+    // state (`invalid_reference`) rather than leaving whatever it was running
+    // in place, backed by a bundle no longer in storage. Gating it on
+    // `previousBundleBytes` is otherwise silent — this is the test that
+    // notices.
+    const first = makeDeps([okStatus()]);
+    await installFromBytes(first.deps, bundleBytes('1.0.0', 'original'), ['model.read']);
+    assert.ok(await first.storage.getExtension(EXT_ID), 'the first install landed');
+    await first.storage.deleteBundle(EXT_ID, '1.0.0');
+    assert.equal(
+      await first.storage.getBundle(EXT_ID, '1.0.0'),
+      undefined,
+      'there is no byte snapshot for the rollback to restore',
+    );
+
+    const second = makeDeps([]);
+    const loadedIds: string[] = [];
+    const verdicts = [failStatus(), okStatus()];
+    (second.deps.loader as { load: (id: string) => Promise<LoadedExtensionStatus | undefined> })
+      .load = (id: string) => {
+      loadedIds.push(id);
+      return Promise.resolve(verdicts.shift());
+    };
+
+    await assert.rejects(
+      () => installFromBytes(second.deps, bundleBytes('1.0.0', 'replacement'), ['model.read']),
+      /Loader rejected the new bundle/,
+    );
+
+    assert.deepEqual(
+      loadedIds,
+      [EXT_ID, EXT_ID],
+      'the rollback re-loaded the restored record even with no bytes to restore',
+    );
   });
 
   it('keeps the previous record when restoring its bytes fails', async () => {

--- a/apps/viewer/src/services/extensions/host-installer.ts
+++ b/apps/viewer/src/services/extensions/host-installer.ts
@@ -150,11 +150,20 @@ export async function installFromBytes(
   // Snapshot the previous install so we can restore it if the new
   // bundle fails to load. Without this, a bad update wipes the
   // user's previously-working install entirely.
+  //
+  // The snapshot is taken for every previous install, not only for a version
+  // change. Bundle bytes are keyed by `id + version`, so a reinstall of the
+  // same version overwrites them in `putBundle` below — that is exactly the
+  // case where the rollback has nothing left to read, and it deletes the
+  // record and the bundle of an install the failed write never changed the
+  // identity of. The teardown stays conditional: replacing the bytes under a
+  // version that is already loaded is not a version change, and unloading a
+  // still-working extension is not this function's business.
   const previous = await deps.storage.getExtension(id);
   let previousBundleBytes: Uint8Array | undefined;
-  if (previous && previous.version !== version) {
+  if (previous) {
     previousBundleBytes = await deps.storage.getBundle(id, previous.version);
-    await teardownExtension(deps, id);
+    if (previous.version !== version) await teardownExtension(deps, id);
   }
 
   const record: InstalledExtensionRecord = {

--- a/apps/viewer/src/services/extensions/host-installer.ts
+++ b/apps/viewer/src/services/extensions/host-installer.ts
@@ -184,17 +184,47 @@ export async function installFromBytes(
     await deps.storage.deleteBundle(id, version);
     await deps.storage.deleteExtension(id);
 
-    // Restore the previous install if we had one — re-write its
-    // record and bundle bytes, then re-load. Best effort: log if
-    // restore itself fails, don't mask the original error.
-    if (previous && previousBundleBytes) {
+    // Restore the previous install if we had one — re-write its record and
+    // bundle bytes, then re-load. Best effort: log if a step fails, don't
+    // mask the original error.
+    //
+    // The record goes back FIRST and in its own step. It is the piece the
+    // user cannot reconstruct — the capability grants, the enabled bit, the
+    // install time, the source — and none of it needs bytes: a record whose
+    // bundle is missing is a state the loader already names
+    // (`invalid_reference`, "Bundle for X@Y not found in storage"), and it is
+    // recoverable by reinstalling the same version. So the record is not
+    // gated on a byte snapshot, and a byte write that fails — the plausible
+    // failure here, since `putBundle` is the one with a quota path — cannot
+    // take it down. Each step is independently guarded for the same reason.
+    if (previous) {
       try {
-        await deps.storage.putBundle(id, previous.version, previousBundleBytes);
         await deps.storage.putExtension(previous);
+      } catch (restoreErr) {
+        console.error(
+          `[ext-host] Failed to restore the previous record of ${id}:`,
+          restoreErr,
+        );
+      }
+      if (previousBundleBytes) {
+        try {
+          await deps.storage.putBundle(id, previous.version, previousBundleBytes);
+        } catch (restoreErr) {
+          console.error(
+            `[ext-host] Failed to restore the previous bundle of ${id}:`,
+            restoreErr,
+          );
+        }
+      }
+      try {
+        // Best effort either way: with the bytes back this reloads the
+        // working install; without them the loader reports
+        // `invalid_reference` and nothing is left running, which is the
+        // truthful state and not something a throw here would improve.
         await deps.loader.load(id);
       } catch (restoreErr) {
         console.error(
-          `[ext-host] Failed to restore previous install of ${id}:`,
+          `[ext-host] Failed to reload the previous install of ${id}:`,
           restoreErr,
         );
       }

--- a/apps/viewer/src/services/extensions/host-installer.ts
+++ b/apps/viewer/src/services/extensions/host-installer.ts
@@ -180,53 +180,91 @@ export async function installFromBytes(
 
   const status = await deps.loader.load(id);
   if (!status || !status.ok) {
-    // Roll back. Delete the new bundle + record we just wrote.
-    await deps.storage.deleteBundle(id, version);
-    await deps.storage.deleteExtension(id);
-
-    // Restore the previous install if we had one — re-write its record and
-    // bundle bytes, then re-load. Best effort: log if a step fails, don't
-    // mask the original error.
+    // `load` is an await point, so the record in storage may no longer be the
+    // one written above: the user can hit Uninstall while a slow load is in
+    // flight. An uninstall is explicit and it wins. Rolling back over it would
+    // both delete bytes this install no longer owns and put `previous` back —
+    // undoing the removal the user asked for and leaving a listed record
+    // behind whose bundle is gone.
     //
-    // The record goes back FIRST and in its own step. It is the piece the
-    // user cannot reconstruct — the capability grants, the enabled bit, the
-    // install time, the source — and none of it needs bytes: a record whose
-    // bundle is missing is a state the loader already names
-    // (`invalid_reference`, "Bundle for X@Y not found in storage"), and it is
-    // recoverable by reinstalling the same version. So the record is not
-    // gated on a byte snapshot, and a byte write that fails — the plausible
-    // failure here, since `putBundle` is the one with a quota path — cannot
-    // take it down. Each step is independently guarded for the same reason.
-    if (previous) {
-      try {
-        await deps.storage.putExtension(previous);
-      } catch (restoreErr) {
-        console.error(
-          `[ext-host] Failed to restore the previous record of ${id}:`,
-          restoreErr,
-        );
-      }
-      if (previousBundleBytes) {
+    // This is a record-identity check, not the byte gate the rest of this
+    // rollback deliberately does without: it asks whether the record we wrote
+    // is still the record in storage, never whether any bundle bytes exist. A
+    // previous install whose bytes were already missing still has its record
+    // restored below, which is the case a byte gate here would break.
+    //
+    // A failed read proves nothing either way, so it falls back to rolling
+    // back — what happens when no one touched storage, which is every case
+    // but this one.
+    let ownsStoredRecord = true;
+    try {
+      const current = await deps.storage.getExtension(id);
+      ownsStoredRecord = current?.version === version && current?.bundleHash === bundleHash;
+    } catch (readErr) {
+      console.error(
+        `[ext-host] Could not re-read the record of ${id} before rolling back:`,
+        readErr,
+      );
+    }
+
+    if (ownsStoredRecord) {
+      // Roll back. Delete the new bundle + record we just wrote.
+      await deps.storage.deleteBundle(id, version);
+      await deps.storage.deleteExtension(id);
+
+      // Restore the previous install if we had one — re-write its record and
+      // bundle bytes, then re-load. Best effort: log if a step fails, don't
+      // mask the original error.
+      //
+      // The record and the bytes are restored under independent guards, so
+      // neither takes the other down. That is what is load-bearing here, not
+      // the order of the two writes: the record is not gated on the byte
+      // snapshot, and a failing `putBundle` — the plausible failure, since it
+      // is the step with a quota path — leaves the record standing.
+      //
+      // Keeping a record whose bundle is missing is deliberate. The record
+      // carries the capability grants, the enabled bit, the install time and
+      // the source, none of which need bytes and none of which the user can
+      // reconstruct; unloaded *and* deleted is strictly worse than unloaded.
+      // The loader already names the resulting state (`invalid_reference`,
+      // "Bundle for X@Y not found in storage"). Reinstalling the same version
+      // repairs it and keeps the grants, but the app offers the user no route
+      // to that: the Repair queue passes any extension whose engine range
+      // still matches, so it never reaches the missing bytes, and fork reads
+      // an in-memory cache that is empty after a boot. Treat the reinstall as
+      // something a user who still holds the `.iflx` can do, not as a repair
+      // path the UI provides.
+      if (previous) {
         try {
-          await deps.storage.putBundle(id, previous.version, previousBundleBytes);
+          await deps.storage.putExtension(previous);
         } catch (restoreErr) {
           console.error(
-            `[ext-host] Failed to restore the previous bundle of ${id}:`,
+            `[ext-host] Failed to restore the previous record of ${id}:`,
             restoreErr,
           );
         }
-      }
-      try {
-        // Best effort either way: with the bytes back this reloads the
-        // working install; without them the loader reports
-        // `invalid_reference` and nothing is left running, which is the
-        // truthful state and not something a throw here would improve.
-        await deps.loader.load(id);
-      } catch (restoreErr) {
-        console.error(
-          `[ext-host] Failed to reload the previous install of ${id}:`,
-          restoreErr,
-        );
+        if (previousBundleBytes) {
+          try {
+            await deps.storage.putBundle(id, previous.version, previousBundleBytes);
+          } catch (restoreErr) {
+            console.error(
+              `[ext-host] Failed to restore the previous bundle of ${id}:`,
+              restoreErr,
+            );
+          }
+        }
+        try {
+          // Best effort either way: with the bytes back this reloads the
+          // working install; without them the loader reports
+          // `invalid_reference` and nothing is left running, which is the
+          // truthful state and not something a throw here would improve.
+          await deps.loader.load(id);
+        } catch (restoreErr) {
+          console.error(
+            `[ext-host] Failed to reload the previous install of ${id}:`,
+            restoreErr,
+          );
+        }
       }
     }
     throw new ExtensionInstallError(

--- a/apps/viewer/src/services/extensions/host.flavor-switch.test.ts
+++ b/apps/viewer/src/services/extensions/host.flavor-switch.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The host's end of the flavor-switch pointer write: `switchFlavor` turns a
+ * failed switch into a thrown error and skips the lens / clash / sidebar
+ * restores below it, so a refused pointer write that would have changed
+ * nothing must not reach that branch.
+ */
+
+// fake-indexeddb backs the real IdbFlavorStorage / IdbExtensionStorage the
+// host constructs for itself, so this exercises the production wiring.
+import 'fake-indexeddb/auto';
+
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { createBimContext } from '@ifc-lite/sdk';
+import type { Flavor } from '@ifc-lite/extensions';
+import { ExtensionHostService } from './host.js';
+import { IdbFlavorStorage } from './idb-flavor-storage.js';
+
+class TestHost extends ExtensionHostService {
+  constructor() {
+    super({
+      sdk: createBimContext({
+        transport: {
+          send: () => Promise.reject(new Error('SDK transport is not exercised by this test')),
+          subscribe: () => () => {},
+          close: () => {},
+        },
+      }),
+    });
+  }
+}
+
+function flavor(id: string): Flavor {
+  return {
+    schemaVersion: 1,
+    id,
+    name: id,
+    description: '',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    extensions: [],
+    lenses: [],
+    savedQueries: [],
+    keybindings: [],
+    layout: { state: {} },
+    settings: {},
+  };
+}
+
+/** Run `fn` with the flavor store's pointer write refused. */
+async function withRefusedPointerWrite(fn: () => Promise<void>): Promise<void> {
+  const original = IdbFlavorStorage.prototype.setActiveId;
+  IdbFlavorStorage.prototype.setActiveId = () =>
+    Promise.reject(new Error('pointer write refused'));
+  try {
+    await fn();
+  } finally {
+    IdbFlavorStorage.prototype.setActiveId = original;
+  }
+}
+
+describe('ExtensionHostService.switchFlavor', () => {
+  beforeEach(async () => {
+    await new IdbFlavorStorage().clear();
+  });
+
+  it('does not throw when the refused pointer write already stored the target', async () => {
+    const host = new TestHost();
+    await host.flavors.put(flavor('flv.target'));
+    await host.flavors.activate('flv.target');
+
+    await withRefusedPointerWrite(async () => {
+      // Re-applying the flavor that is already active: the pointer write
+      // rewrites the id it already holds, so its refusal changed nothing.
+      await host.switchFlavor('flv.target');
+    });
+
+    assert.equal(await host.flavors.activeId(), 'flv.target');
+  });
+
+  it('still throws when the refused pointer write would have moved the pointer', async () => {
+    const host = new TestHost();
+    await host.flavors.put(flavor('flv.target'));
+    await host.flavors.put(flavor('flv.other'));
+    await host.flavors.activate('flv.other');
+
+    await withRefusedPointerWrite(async () => {
+      await assert.rejects(
+        () => host.switchFlavor('flv.target'),
+        /Flavor switch failed for: <pointer>/,
+      );
+    });
+
+    assert.equal(await host.flavors.activeId(), 'flv.other');
+  });
+});

--- a/apps/viewer/src/services/extensions/host.ts
+++ b/apps/viewer/src/services/extensions/host.ts
@@ -446,6 +446,12 @@ export class ExtensionHostService {
       setActiveFlavor: async (id) => {
         await this.flavors.activate(id);
       },
+      // Lets the switcher tell a refused pointer write that would have changed
+      // nothing — re-applying the flavor that is already active — from one
+      // that would have moved the pointer. Without it every refusal undoes the
+      // extension toggles that landed and throws below, skipping the lens,
+      // clash and sidebar restores.
+      readActiveFlavor: () => this.flavors.activeId(),
     });
 
     if (!result.ok) {

--- a/packages/extensions/src/flavor/index.ts
+++ b/packages/extensions/src/flavor/index.ts
@@ -51,6 +51,7 @@ export {
   type SyntheticExtension,
 } from './migrate-scripts.js';
 export {
+  activeFlavorPointer,
   switchFlavor,
   type FlavorSwitcherCallbacks,
   type FlavorExtensionState,

--- a/packages/extensions/src/flavor/index.ts
+++ b/packages/extensions/src/flavor/index.ts
@@ -52,6 +52,7 @@ export {
 } from './migrate-scripts.js';
 export {
   activeFlavorPointer,
+  activeFlavorPointerAlreadyStored,
   switchFlavor,
   type FlavorSwitcherCallbacks,
   type FlavorExtensionState,

--- a/packages/extensions/src/flavor/switcher.test.ts
+++ b/packages/extensions/src/flavor/switcher.test.ts
@@ -116,4 +116,96 @@ describe('switchFlavor', () => {
     expect(result.ok).toBe(false);
     expect(result.failures).toContain('<pointer>');
   });
+  it('does not fail the switch when the refused pointer write already stored the target', async () => {
+    // The pointer write is refused, but the pointer on disk already names the
+    // target: that write would have changed nothing, so the extension toggles
+    // that landed must stand and the switch must report success.
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn().mockRejectedValue(new Error('pointer io')),
+      readActiveFlavor: vi.fn().mockResolvedValue('flv.b'),
+    });
+    const result = await switchFlavor({
+      target: flavor('flv.b', ['ext.b']),
+      current: flavor('flv.a', []),
+      installed: [{ id: 'ext.b', enabled: false }],
+      callbacks,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.active.id).toBe('flv.b');
+    expect(result.failures).toEqual([]);
+    expect(result.enabled).toEqual(['ext.b']);
+    // No rollback: ext.b stays enabled.
+    const calls = (callbacks.setEnabled as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toEqual([['ext.b', true]]);
+  });
+
+  it('still fails when the refused pointer write would have stored a different id', async () => {
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn().mockRejectedValue(new Error('pointer io')),
+      readActiveFlavor: vi.fn().mockResolvedValue('flv.a'),
+    });
+    const result = await switchFlavor({
+      target: flavor('flv.b', ['ext.b']),
+      current: flavor('flv.a', []),
+      installed: [{ id: 'ext.b', enabled: false }],
+      callbacks,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('<pointer>');
+    const calls = (callbacks.setEnabled as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toContainEqual(['ext.b', false]);
+  });
+
+  it('still fails when the pointer is unreadable', async () => {
+    // One-directional: anything not provably identical is a refusal, which is
+    // the behaviour a host without the callback already had.
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn().mockRejectedValue(new Error('pointer io')),
+      readActiveFlavor: vi.fn().mockRejectedValue(new Error('read io')),
+    });
+    const result = await switchFlavor({
+      target: flavor('flv.b', ['ext.b']),
+      current: flavor('flv.a', []),
+      installed: [{ id: 'ext.b', enabled: false }],
+      callbacks,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('<pointer>');
+  });
+
+  it('still fails when the host cannot read the pointer back at all', async () => {
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn().mockRejectedValue(new Error('pointer io')),
+    });
+    expect(callbacks.readActiveFlavor).toBeUndefined();
+    const result = await switchFlavor({
+      target: flavor('flv.b', ['ext.b']),
+      current: flavor('flv.a', []),
+      installed: [{ id: 'ext.b', enabled: false }],
+      callbacks,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('<pointer>');
+  });
+
+  it('compares the pointer against the id it hands setActiveFlavor, not the current flavor', async () => {
+    // Guards the compare-the-wrong-pair mutant: reading back `current.id` and
+    // calling that a no-op would pass the stored pointer off as the target.
+    const seen: string[] = [];
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn(async (id: string) => {
+        seen.push(id);
+        throw new Error('pointer io');
+      }),
+      readActiveFlavor: vi.fn().mockResolvedValue('flv.a'),
+    });
+    const result = await switchFlavor({
+      target: flavor('flv.b', []),
+      current: flavor('flv.a', []),
+      installed: [],
+      callbacks,
+    });
+    expect(seen).toEqual(['flv.b']);
+    expect(result.ok).toBe(false);
+  });
 });

--- a/packages/extensions/src/flavor/switcher.test.ts
+++ b/packages/extensions/src/flavor/switcher.test.ts
@@ -192,6 +192,55 @@ describe('switchFlavor', () => {
     expect(result.failures).toContain('<pointer>');
   });
 
+  it('reports a refused pointer write when the host handed a non-function readActiveFlavor', async () => {
+    // `FlavorSwitcherCallbacks` is a published export, so a JS consumer can
+    // hand a non-function here. The no-op check must answer "not provably a
+    // no-op" and take the normal refusal path — it must not throw out of
+    // `switchFlavor`, which would skip the rollback and leave the toggles the
+    // switch had already applied in place.
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn().mockRejectedValue(new Error('pointer io')),
+      readActiveFlavor: true as unknown as () => Promise<string | undefined>,
+    });
+    const result = await switchFlavor({
+      target: flavor('flv.b', ['ext.b']),
+      current: flavor('flv.a', []),
+      installed: [{ id: 'ext.b', enabled: false }],
+      callbacks,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('<pointer>');
+    // The toggle that landed is rolled back, not left applied.
+    const calls = (callbacks.setEnabled as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toContainEqual(['ext.b', false]);
+  });
+
+  it('reports a refused pointer write when building the pointer throws', async () => {
+    // Same contract for a target whose id cannot be read: the no-op check
+    // answers `false` and the switch rejects the write by returning, so the
+    // rollback still runs.
+    const target = flavor('flv.b', ['ext.b']);
+    Object.defineProperty(target, 'id', {
+      get() {
+        throw new Error('id getter blew up');
+      },
+    });
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn().mockRejectedValue(new Error('pointer io')),
+      readActiveFlavor: vi.fn().mockResolvedValue(undefined),
+    });
+    const result = await switchFlavor({
+      target,
+      current: flavor('flv.a', []),
+      installed: [{ id: 'ext.b', enabled: false }],
+      callbacks,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('<pointer>');
+    const calls = (callbacks.setEnabled as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toContainEqual(['ext.b', false]);
+  });
+
   it('compares the pointer against the id it hands setActiveFlavor, not the current flavor', async () => {
     // Guards the compare-the-wrong-pair mutant: reading back `current.id` and
     // calling that a no-op would pass the stored pointer off as the target.

--- a/packages/extensions/src/flavor/switcher.test.ts
+++ b/packages/extensions/src/flavor/switcher.test.ts
@@ -3,7 +3,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it, vi } from 'vitest';
-import { switchFlavor, type FlavorSwitcherCallbacks } from './switcher.js';
+import {
+  activeFlavorPointerAlreadyStored,
+  switchFlavor,
+  type FlavorSwitcherCallbacks,
+} from './switcher.js';
 import type { Flavor, FlavorExtension } from './types.js';
 
 function flavor(id: string, extensionIds: string[]): Flavor {
@@ -207,5 +211,46 @@ describe('switchFlavor', () => {
     });
     expect(seen).toEqual(['flv.b']);
     expect(result.ok).toBe(false);
+  });
+});
+
+describe('activeFlavorPointerAlreadyStored', () => {
+  it('is true only when the stored pointer is exactly the value to be written', async () => {
+    expect(await activeFlavorPointerAlreadyStored(async () => 'flv.a', 'flv.a')).toBe(true);
+    expect(await activeFlavorPointerAlreadyStored(async () => 'flv.b', 'flv.a')).toBe(false);
+    expect(await activeFlavorPointerAlreadyStored(async () => undefined, 'flv.a')).toBe(false);
+  });
+
+  it('is false when the host cannot read the pointer back', async () => {
+    expect(await activeFlavorPointerAlreadyStored(undefined, 'flv.a')).toBe(false);
+    expect(
+      await activeFlavorPointerAlreadyStored(() => Promise.reject(new Error('io')), 'flv.a'),
+    ).toBe(false);
+  });
+
+  it('is false for a non-string pointer, even against an unset pointer', async () => {
+    // The unsafe direction: `undefined === undefined` would report a refused
+    // write with nothing stored as a successful one. The type forbids the
+    // input, so this pins the behaviour if it ever arrives anyway.
+    const missing = undefined as unknown as string;
+    expect(await activeFlavorPointerAlreadyStored(async () => undefined, missing)).toBe(false);
+    expect(await activeFlavorPointerAlreadyStored(async () => 'flv.a', missing)).toBe(false);
+  });
+
+  it('backs the switcher: a target with no id never passes a refused write', async () => {
+    const callbacks = makeCallbacks({
+      setActiveFlavor: vi.fn().mockRejectedValue(new Error('pointer io')),
+      readActiveFlavor: vi.fn().mockResolvedValue(undefined),
+    });
+    const target = flavor('flv.b', []);
+    (target as { id?: string }).id = undefined;
+    const result = await switchFlavor({
+      target,
+      current: flavor('flv.a', []),
+      installed: [],
+      callbacks,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.failures).toContain('<pointer>');
   });
 });

--- a/packages/extensions/src/flavor/switcher.ts
+++ b/packages/extensions/src/flavor/switcher.ts
@@ -198,8 +198,28 @@ export async function switchFlavor(
     // pointer it already holds; failing here would disable every extension the
     // target declares and report the flavor as not applied while the pointer on
     // disk names it.
-    const read = opts.callbacks.readActiveFlavor?.bind(opts.callbacks);
-    if (!(await activeFlavorPointerAlreadyStored(read, activeFlavorPointer(opts.target)))) {
+    //
+    // Everything this check needs is built inside the `try`. We are already
+    // inside a `catch` with toggles applied and the rollback still ahead of
+    // us, so a throw from here would escape `switchFlavor` and skip that
+    // rollback — leaving applied exactly the toggles this branch exists to
+    // preserve or undo. A host that hands a non-function `readActiveFlavor`,
+    // or a target whose id cannot be read, is therefore not provably a no-op:
+    // it takes the refusal path below like any other unreadable pointer.
+    let alreadyStored = false;
+    try {
+      const read =
+        typeof opts.callbacks.readActiveFlavor === 'function'
+          ? opts.callbacks.readActiveFlavor.bind(opts.callbacks)
+          : undefined;
+      alreadyStored = await activeFlavorPointerAlreadyStored(
+        read,
+        activeFlavorPointer(opts.target),
+      );
+    } catch {
+      alreadyStored = false;
+    }
+    if (!alreadyStored) {
       await rollback(opts.callbacks, touched);
       return { ok: false, active: opts.current ?? opts.target, failures: [...failures, '<pointer>'], disabled, enabled };
     }

--- a/packages/extensions/src/flavor/switcher.ts
+++ b/packages/extensions/src/flavor/switcher.ts
@@ -38,6 +38,15 @@ export interface FlavorSwitcherCallbacks {
   reload(id: string): Promise<boolean>;
   /** Persist the active-flavor pointer. */
   setActiveFlavor(id: string): Promise<void>;
+  /**
+   * Read the persisted active-flavor pointer back, if the host can.
+   *
+   * Optional. Supplying it lets the switcher tell a refused pointer write
+   * that would have changed nothing from one that would have: without it,
+   * every refusal fails the switch, which is the behaviour a host that does
+   * not supply it already had.
+   */
+  readActiveFlavor?(): Promise<string | undefined>;
 }
 
 export interface FlavorSwitchResult {
@@ -60,6 +69,44 @@ export interface FlavorSwitchOptions {
   /** Currently-active flavor (for rollback context). */
   current?: Flavor;
   callbacks: FlavorSwitcherCallbacks;
+}
+
+/**
+ * The exact id the active-flavor pointer stores for `target` — the value
+ * `setActiveFlavor` is handed here, and the value a `FlavorStorage.setActiveId`
+ * is handed elsewhere. The single source of it, so a caller asking whether a
+ * pointer write would change anything compares the value that would actually
+ * be written.
+ */
+export function activeFlavorPointer(target: Flavor): string {
+  return target.id;
+}
+
+/**
+ * Whether the persisted active-flavor pointer already holds exactly what
+ * `setActiveFlavor` would write for `target` — i.e. whether that write would
+ * change nothing.
+ *
+ * Built through `activeFlavorPointer`, the same function the write above is
+ * handed, so the compared value is the written value by construction.
+ *
+ * One-directional on purpose: `false` only means "not provably a no-op". A
+ * host that cannot read the pointer back, or whose read fails, answers
+ * `false`, because the write really might have changed it. A caller uses this
+ * to let a refused write pass, and letting one pass that would have moved the
+ * pointer is the failure that matters.
+ */
+async function activeFlavorAlreadyStored(
+  callbacks: FlavorSwitcherCallbacks,
+  target: Flavor,
+): Promise<boolean> {
+  if (!callbacks.readActiveFlavor) return false;
+  try {
+    return (await callbacks.readActiveFlavor()) === activeFlavorPointer(target);
+  } catch {
+    // Unreadable pointer: nothing is provably stored.
+    return false;
+  }
 }
 
 /**
@@ -132,10 +179,19 @@ export async function switchFlavor(
 
   // Step 3: commit the new active-flavor pointer.
   try {
-    await opts.callbacks.setActiveFlavor(opts.target.id);
+    await opts.callbacks.setActiveFlavor(activeFlavorPointer(opts.target));
   } catch (err) {
-    await rollback(opts.callbacks, touched);
-    return { ok: false, active: opts.current ?? opts.target, failures: [...failures, '<pointer>'], disabled, enabled };
+    // A refused write that would have stored exactly what is stored already
+    // changed nothing, so it must not undo the toggles that landed above.
+    // Switching to the flavor that is already the active one — a re-apply
+    // after a partial switch, or a reload that re-runs the switch — writes the
+    // pointer it already holds; failing here would disable every extension the
+    // target declares and report the flavor as not applied while the pointer on
+    // disk names it.
+    if (!(await activeFlavorAlreadyStored(opts.callbacks, opts.target))) {
+      await rollback(opts.callbacks, touched);
+      return { ok: false, active: opts.current ?? opts.target, failures: [...failures, '<pointer>'], disabled, enabled };
+    }
   }
 
   return { ok: true, active: opts.target, failures, disabled, enabled };

--- a/packages/extensions/src/flavor/switcher.ts
+++ b/packages/extensions/src/flavor/switcher.ts
@@ -83,26 +83,36 @@ export function activeFlavorPointer(target: Flavor): string {
 }
 
 /**
- * Whether the persisted active-flavor pointer already holds exactly what
- * `setActiveFlavor` would write for `target` — i.e. whether that write would
- * change nothing.
+ * Whether the persisted active-flavor pointer already holds exactly
+ * `pointer` — i.e. whether writing `pointer` would change nothing.
  *
- * Built through `activeFlavorPointer`, the same function the write above is
- * handed, so the compared value is the written value by construction.
+ * `read` is the host's way of reading the pointer back and `pointer` is the
+ * value that would have been written, which callers build with
+ * `activeFlavorPointer` so the compared value is the written value by
+ * construction. Every host that asks this question asks it in exactly this
+ * shape, so it lives here once: an encoding change to the pointer lands in
+ * `activeFlavorPointer` and this comparison follows it, in every package.
  *
  * One-directional on purpose: `false` only means "not provably a no-op". A
  * host that cannot read the pointer back, or whose read fails, answers
  * `false`, because the write really might have changed it. A caller uses this
  * to let a refused write pass, and letting one pass that would have moved the
  * pointer is the failure that matters.
+ *
+ * The same asymmetry governs a non-string `pointer`: the type forbids it, but
+ * if one arrives, `undefined === undefined` against an unset pointer would
+ * report a refused write with nothing stored as a successful one. That is the
+ * unsafe direction, so it answers `false`.
  */
-async function activeFlavorAlreadyStored(
-  callbacks: FlavorSwitcherCallbacks,
-  target: Flavor,
+export async function activeFlavorPointerAlreadyStored(
+  read: (() => Promise<string | undefined>) | undefined,
+  pointer: string | undefined,
 ): Promise<boolean> {
-  if (!callbacks.readActiveFlavor) return false;
+  if (!read) return false;
+  // Nothing is provably stored for a pointer that is not a value we write.
+  if (typeof pointer !== 'string') return false;
   try {
-    return (await callbacks.readActiveFlavor()) === activeFlavorPointer(target);
+    return (await read()) === pointer;
   } catch {
     // Unreadable pointer: nothing is provably stored.
     return false;
@@ -188,7 +198,8 @@ export async function switchFlavor(
     // pointer it already holds; failing here would disable every extension the
     // target declares and report the flavor as not applied while the pointer on
     // disk names it.
-    if (!(await activeFlavorAlreadyStored(opts.callbacks, opts.target))) {
+    const read = opts.callbacks.readActiveFlavor?.bind(opts.callbacks);
+    if (!(await activeFlavorPointerAlreadyStored(read, activeFlavorPointer(opts.target)))) {
       await rollback(opts.callbacks, touched);
       return { ok: false, active: opts.current ?? opts.target, failures: [...failures, '<pointer>'], disabled, enabled };
     }

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1730,6 +1730,7 @@
     "WhenValue: type",
     "WidgetNode: type",
     "activeFlavorPointer: function",
+    "activeFlavorPointerAlreadyStored: function",
     "assertMethodCall: function",
     "buildAuthoringContract: function",
     "buildBundleFromFiles: function",

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1729,6 +1729,7 @@
     "WhenExpression: type",
     "WhenValue: type",
     "WidgetNode: type",
+    "activeFlavorPointer: function",
     "assertMethodCall: function",
     "buildAuthoringContract: function",
     "buildBundleFromFiles: function",


### PR DESCRIPTION
A two-step write whose second step is refused rolls back step one and fails the whole operation — **without first asking whether step two's write would have changed anything.** When the value being written is already the stored value, the refusal changed nothing, and failing is wrong.

Four sites confirmed and fixed, one rejected. Every claim below was verified by running.

## The fix is structural, not a patch

For each site, the single function that builds the value handed to the storage API is extracted, and **both the writer and the "would this change anything" comparison call it** — so the compared value is the written value by construction rather than by convention. A separately-derived comparison is a second implementation and will drift.

Follows the existing precedent at `apps/viewer/src/lib/layers/browser-store.ts:132-137`, which already does this correctly.

## Sites

**1. `packages/extensions/src/flavor/switcher.ts`** — a refused `setActiveFlavor(target.id)` rolled back *every* extension toggle without asking whether the pointer already named the target. Extracted `activeFlavorPointer(target)`; `FlavorSwitcherCallbacks` gains an optional `readActiveFlavor?()`.

**2. `apps/viewer/src/services/extensions/host.ts`** — consumer of the above; surfaced it as a thrown hard failure that skipped the lens/clash/sidebar restores. One-line wiring, plus a new `FlavorService.activeId()` (`getActive()` cannot serve — it answers `undefined` both for "no pointer" and "pointer names a missing flavor").

**3. `flavor-service.ts` `resetToDefaults`** — failed the whole reset when the pointer write was refused even if the stored id was already `DEFAULT_FLAVOR_ID`.

**4. `host-installer.ts` — this one is data loss, and is a different sub-shape.** A same-version reinstall whose bundle the loader rejects **deleted the working install outright**, record and bytes. The RED shows the previous record coming back as `undefined`. Bundle bytes are keyed `id+version`, so `putBundle` overwrites them in the same-version case while the snapshot was version-gated. Now snapshots `previousBundleBytes` for any previous install; teardown stays version-gated.

**5. `idb-flavor-storage.ts:118-121` — REJECTED, not this shape.** It already reads the stored pointer and writes only when the write would change it. Left untouched.

## Verification

Each site has a RED quoted in the commit, a failure matrix, and mutation testing. Two mutants are reported as **equivalent** rather than claimed killed: an early return whose removal produces a `TypeError` caught by the same handler, and a redundant read.

Two mutants initially survived and were killed only after strengthening the tests — `write activeId + '-x'` (fixed by asserting `setActiveArgs`) and `always tear down` (fixed by adding teardown counters). Both are noted because a mutant that survives a first pass is evidence the test was weaker than it looked.

| suite | before | after |
|---|---|---|
| `packages/extensions` (full) | 776 passed | 781 passed |
| viewer flavor-service (new) | — | 5 passed |
| viewer host.flavor-switch (new) | — | 2 passed |
| viewer host-installer (new) | — | 3 passed |
| neighbours (host-commands, host-exporters, idb-flavor-storage, idb-log-storage, sandbox-factory) | 52 | identical |

The 776 baseline was measured by running the suite with `main`'s `switcher.test.ts` restored over the fixed source — not by arithmetic.

Typecheck clean for both packages (after building deps). `oxlint`: only pre-existing warnings.

Changeset: `@ifc-lite/extensions: minor` (new export + new optional callback member), `@ifc-lite/viewer: patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flavor switching when the selected flavor is already active, avoiding failures from refused no-op writes.
  * Preserved the active flavor and extension state when switching or resetting fails.
  * Improved rollback handling for failed reinstalls and upgrades, including same-version reinstalls and missing bundles.
  * Preserved previous extension records when bundle restoration fails, while retaining clear error reporting for unrecoverable snapshot failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->