### PR TITLE
docs(changeset): cover the six #2866 cycle bounds that shipped without one

### DIFF
--- a/.changeset/geometry-bound-boolean-csg-operand-cycle.md
+++ b/.changeset/geometry-bound-boolean-csg-operand-cycle.md
@@ -17,8 +17,10 @@ A path-scoped visited set is now threaded through the whole operand path,
 inserted on the way in and removed on the way out, so an operand legitimately
 reached from two branches of an acyclic tree is still processed both times.
 Its length is the current nesting depth, which also bounds chain length:
-`MAX_OPERAND_PATH_NODES = 64`, well clear of the 42-node chains real exporters
-produce.
+`MAX_OPERAND_PATH_NODES = 64`. That sits well clear of `MAX_BOOLEAN_DEPTH`
+(10), so it cannot make that cap's job harder. The 42-node `DIFFERENCE` chains
+real exporters produce are FirstOperand spine nodes, walked iteratively, and
+never reach this guard.
 
 Unlike the sibling fixes in this series, this one reports: hitting either bound
 returns a catchable geometry error naming the entity — `Cyclic boolean/CSG

--- a/.changeset/geometry-bound-boolean-csg-operand-cycle.md
+++ b/.changeset/geometry-bound-boolean-csg-operand-cycle.md
@@ -1,0 +1,27 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+A Boolean/CSG operand cycle no longer aborts the process.
+`IfcCsgSolid.TreeRootExpression` may be an `IfcBooleanResult` whose operands
+may in turn be `IfcCsgSolid`, so the two recurse into each other over
+file-supplied references. The `IfcCsgSolid` arm built a fresh
+`BooleanClippingProcessor`, resetting both the depth counter and the cycle
+guard, so three entities were enough to recurse forever with depth never
+passing 1. The result was `fatal runtime error: stack overflow, aborting` —
+an abort, not a catchable panic, so nothing downstream could report it. Both
+entity types appear in the Body representations of ordinary files, so an
+exporter bug is enough to trigger it.
+
+A path-scoped visited set is now threaded through the whole operand path,
+inserted on the way in and removed on the way out, so an operand legitimately
+reached from two branches of an acyclic tree is still processed both times.
+Its length is the current nesting depth, which also bounds chain length:
+`MAX_OPERAND_PATH_NODES = 64`, well clear of the 42-node chains real exporters
+produce.
+
+Unlike the sibling fixes in this series, this one reports: hitting either bound
+returns a catchable geometry error naming the entity — `Cyclic boolean/CSG
+operand reference at #N` or `Boolean/CSG operand chain exceeds 64 nested nodes
+at #N`. The offending element is dropped with that error; the rest of the file
+loads.

--- a/.changeset/geometry-bound-layer-slicing-identity-chase.md
+++ b/.changeset/geometry-bound-layer-slicing-identity-chase.md
@@ -20,4 +20,8 @@ Note what happens at the guard, because nothing catchable surfaces. On a
 repeat the probe returns `false`, so `element_is_single_unshifted_item` returns
 `false` and the element renders as a single un-sliced mesh with one material
 instead of per-layer sub-meshes. That is a visible loss of layer materials for
-the offending element, reported nowhere; the rest of the file loads normally.
+the offending element. It is not unreported: the router records a
+`skip:not-single-unshifted-item` diagnostic, which the viewer's batch path
+drains into a `console.warn` naming the element id and that reason. But a
+console warning is not an error a caller can handle, so no downstream code can
+react to it. The rest of the file loads normally.

--- a/.changeset/geometry-bound-layer-slicing-identity-chase.md
+++ b/.changeset/geometry-bound-layer-slicing-identity-chase.md
@@ -1,0 +1,23 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+Layer slicing no longer aborts the process on a self-referential
+`IfcBooleanResult`. `item_has_identity_position` chased
+`IfcBooleanResult.FirstOperand` recursively, and that reference comes from the
+file, so a single entity referring to itself
+(`#10=IFCBOOLEANRESULT(.DIFFERENCE.,#10,#20)`) overflowed the stack. A Rust
+stack overflow aborts the process rather than raising a catchable panic, so no
+caller could turn it into a load error — the whole load died on raw uploaded
+bytes.
+
+The chase is now an iterative walk with a visited set that stops at the first
+repeated node. There is deliberately no length cap: Revit exports chains up to
+42 `DIFFERENCE` nodes deep, and a cap would drop layer slicing on files that
+render correctly today.
+
+Note what happens at the guard, because nothing catchable surfaces. On a
+repeat the probe returns `false`, so `element_is_single_unshifted_item` returns
+`false` and the element renders as a single un-sliced mesh with one material
+instead of per-layer sub-meshes. That is a visible loss of layer materials for
+the offending element, reported nowhere; the rest of the file loads normally.

--- a/.changeset/geometry-bound-trimmed-curve-basis-chase.md
+++ b/.changeset/geometry-bound-trimmed-curve-basis-chase.md
@@ -1,0 +1,21 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+A self-referential `IfcTrimmedCurve` no longer aborts the process.
+`sample_curve_polyline` followed `IfcTrimmedCurve.BasisCurve` recursively, and
+that reference comes from the file, so one entity naming itself as its own
+basis overflowed the stack — an abort rather than a catchable panic, so nothing
+downstream could turn it into a load error. The sampler is reached by any
+`IfcAdvancedBrep` with a composite edge curve and by the surface-of-revolution
+generator profile, so ordinary geometry paths were exposed.
+
+Two guards now, because they bound different things: a visited set stops cycles
+and fan-out, and `MAX_BASIS_CURVE_DEPTH = 32` stops a long acyclic chain, where
+every id is distinct so the set never fires and the recursion aborts on stack
+depth alone. Real trimming nests one or two levels.
+
+At either bound the sampler returns an empty polyline rather than an error, so
+the offending curve contributes no points and the edge or face built from it is
+missing from the mesh. Legitimate trimmed-on-trimmed chains ending at a real
+curve are still sampled in full.

--- a/.changeset/geometry-bound-trimmed-curve-basis-chase.md
+++ b/.changeset/geometry-bound-trimmed-curve-basis-chase.md
@@ -11,9 +11,10 @@ downstream could turn it into a load error. The sampler is reached by any
 generator profile, so ordinary geometry paths were exposed.
 
 Two guards now, because they bound different things: a visited set stops cycles
-and fan-out, and `MAX_BASIS_CURVE_DEPTH = 32` stops a long acyclic chain, where
-every id is distinct so the set never fires and the recursion aborts on stack
-depth alone. Real trimming nests one or two levels.
+(and any fan-out a later change introduces — the single tail call here has none
+today, but nothing enforces that), and `MAX_BASIS_CURVE_DEPTH = 32` stops a
+long acyclic chain, where every id is distinct so the set never fires and the
+recursion aborts on stack depth alone. Real trimming nests one or two levels.
 
 At either bound the sampler returns an empty polyline rather than an error, so
 the offending curve contributes no points and the edge or face built from it is

--- a/.changeset/geometry-composite-curve-profile-points-and-bounds.md
+++ b/.changeset/geometry-composite-curve-profile-points-and-bounds.md
@@ -1,0 +1,34 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+Composite-curve profiles on `IfcSurfaceOfLinearExtrusion` produce geometry
+again, and can no longer abort the process.
+
+The silent half: `extract_composite_curve_points` handed each segment's
+`ParentCurve` id to the profile dispatcher, which reads attribute 2 as "the
+profile's curve". An `IfcPolyline` has no attribute 2, so every segment
+errored, the caller swallowed it, and the function returned an empty point set
+as `Ok` — indistinguishable from a legitimately empty profile. Every
+`IfcSurfaceOfLinearExtrusion` with a composite-curve profile lost its geometry
+this way. Curve dispatch is now separate from profile dispatch, so a
+`ParentCurve` is sampled as the curve it is. Two further defects that only
+became observable once points started flowing are fixed with it:
+`IfcCompositeCurveSegment.SameSense = .F.` now reverses the segment as the
+schema requires, and the joint point between segments is dropped only when it
+actually coincides, so a `.DISCONTINUOUS.` joint or a real gap keeps the point
+it used to lose.
+
+The fatal half: a composite curve whose segment's `ParentCurve` is that same
+composite curve re-entered the sampler and overflowed the stack — an abort, not
+a catchable panic. Three bounds now travel together, each blind to what the
+others catch: a path-scoped visited set for cycles, a nesting cap of 32 for a
+long acyclic chain where every insert succeeds, and a budget of 100,000 curve
+visits for an acyclic DAG that doubles its work per level while nothing is
+cyclic and nothing exceeds the depth cap.
+
+The two kinds of bound behave differently, deliberately. A cycle or the depth
+cap yields no points for that nested curve and reports nothing. Budget
+exhaustion returns a catchable error (`Curve traversal exceeded 100000 nested
+curves`) rather than a truncated point list, because a short profile returned
+as if it were complete is a wrong shape; the element is dropped instead.

--- a/.changeset/wasm-bound-mapped-item-colour-chase.md
+++ b/.changeset/wasm-bound-mapped-item-colour-chase.md
@@ -13,10 +13,11 @@ raising a catchable panic, so the tab's worker died with no error to report.
 
 The chase is bounded in both dimensions, because a depth cap alone only trades
 the abort for a hang — `k` items each leading back into the cycle cost
-`O(k^depth)` decodes. It now stops at 32 hops (matching the sibling
-traversals in `ifc-lite-geometry`'s `router::processing` and
-`ifc-lite-processing`'s `element`) and records the depth each item was
-explored at, so a cycle is broken while an item legitimately reached again from
+`O(k^depth)` decodes. It now stops at 32 hops — the same cap the
+mapped-item traversals in `ifc-lite-geometry`'s `router::processing` and
+`ifc-lite-processing`'s `element` use, which #2873 has since consolidated into
+one `MAX_MAPPED_ITEM_DEPTH` in `ifc-lite-core` that all three now import — and
+records the depth each item was explored at, so a cycle is broken while an item legitimately reached again from
 a shorter branch is still resolved — a plain visited set silently lost that
 item's authored colour.
 

--- a/.changeset/wasm-bound-mapped-item-colour-chase.md
+++ b/.changeset/wasm-bound-mapped-item-colour-chase.md
@@ -6,10 +6,10 @@ The viewer's colour resolver no longer aborts the worker on a cyclic mapped
 item. `find_color_for_geometry` chased `IfcMappedItem ->
 IfcRepresentationMap -> MappedRepresentation.Items` with no depth cap and no
 visited set, and a three-entity file whose mapped representation lists the
-mapped item itself was enough to overflow the stack. Every IFC opened in the
-browser goes through this resolver, and a Rust stack overflow aborts rather
-than raising a catchable panic, so the tab's worker died with no error to
-report.
+mapped item itself was enough to overflow the stack. The resolver runs while
+the browser batches GPU meshes, for every element with a representation in any
+file that carries geometry styles, and a Rust stack overflow aborts rather than
+raising a catchable panic, so the tab's worker died with no error to report.
 
 The chase is bounded in both dimensions, because a depth cap alone only trades
 the abort for a hang — `k` items each leading back into the cycle cost

--- a/.changeset/wasm-bound-mapped-item-colour-chase.md
+++ b/.changeset/wasm-bound-mapped-item-colour-chase.md
@@ -13,8 +13,9 @@ report.
 
 The chase is bounded in both dimensions, because a depth cap alone only trades
 the abort for a hang — `k` items each leading back into the cycle cost
-`O(k^depth)` decodes. It now stops at 32 hops (matching the two sibling
-traversals in `ifc-lite-processing`) and records the depth each item was
+`O(k^depth)` decodes. It now stops at 32 hops (matching the sibling
+traversals in `ifc-lite-geometry`'s `router::processing` and
+`ifc-lite-processing`'s `element`) and records the depth each item was
 explored at, so a cycle is broken while an item legitimately reached again from
 a shorter branch is still resolved — a plain visited set silently lost that
 item's authored colour.

--- a/.changeset/wasm-bound-mapped-item-colour-chase.md
+++ b/.changeset/wasm-bound-mapped-item-colour-chase.md
@@ -1,0 +1,25 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+The viewer's colour resolver no longer aborts the worker on a cyclic mapped
+item. `find_color_for_geometry` chased `IfcMappedItem ->
+IfcRepresentationMap -> MappedRepresentation.Items` with no depth cap and no
+visited set, and a three-entity file whose mapped representation lists the
+mapped item itself was enough to overflow the stack. Every IFC opened in the
+browser goes through this resolver, and a Rust stack overflow aborts rather
+than raising a catchable panic, so the tab's worker died with no error to
+report.
+
+The chase is bounded in both dimensions, because a depth cap alone only trades
+the abort for a hang — `k` items each leading back into the cycle cost
+`O(k^depth)` decodes. It now stops at 32 hops (matching the two sibling
+traversals in `ifc-lite-processing`) and records the depth each item was
+explored at, so a cycle is broken while an item legitimately reached again from
+a shorter branch is still resolved — a plain visited set silently lost that
+item's authored colour.
+
+Nothing catchable surfaces at the bound: the resolver returns `None`, so the
+element renders in its fallback colour instead of its authored one. Geometry is
+unaffected — the router builds the mesh regardless — and the rest of the file
+resolves normally.

--- a/.changeset/wasm-bound-symbolic-item-walk-cycle.md
+++ b/.changeset/wasm-bound-symbolic-item-walk-cycle.md
@@ -1,0 +1,20 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Symbolic (2D) extraction no longer aborts the process on a cyclic or
+explosively branching representation-item graph. `extract_symbolic_item`
+followed file-supplied item references with no depth cap, no cycle guard and no
+work budget, so a self-referential item overflowed the stack — an abort rather
+than a catchable panic, killing the load outright.
+
+Three bounds now travel with the walk: a depth cap of 32, a path-scoped
+re-entry check that breaks cycles, and a budget of 200,000 revisits (first
+visits are free, since their number is bounded by the file; only revisits can
+fan out exponentially).
+
+The walk returns no value, so none of the three bounds reports anything. At
+each one the offending sub-tree is simply dropped: those items produce no
+symbolic geometry, while everything outside the sub-tree extracts normally. A
+malformed file therefore loads with part of its 2D content missing rather than
+taking the process down.

--- a/.changeset/wasm-bound-symbolic-item-walk-cycle.md
+++ b/.changeset/wasm-bound-symbolic-item-walk-cycle.md
@@ -13,8 +13,15 @@ re-entry check that breaks cycles, and a budget of 200,000 revisits (first
 visits are free, since their number is bounded by the file; only revisits can
 fan out exponentially).
 
-The walk returns no value, so none of the three bounds reports anything. At
-each one the offending sub-tree is simply dropped: those items produce no
-symbolic geometry, while everything outside the sub-tree extracts normally. A
+The walk returns no value, so none of the three bounds reports anything. The
+depth cap and the path guard drop the offending sub-tree and nothing else:
+those items produce no symbolic geometry, while the rest of the walk continues
+normally. The revisit budget is wider than a sub-tree — it is held per
+top-level representation item and never restored, so once it is exhausted every
+later revisit in that same walk returns early too, and legitimate geometry
+reached by a revisit after the cycle is lost with it. Cheap termination is
+exactly why the path guard is there, and
+`a_cycle_must_not_starve_the_geometry_that_follows_it` pins it. Each top-level
+item starts with a fresh budget, so the loss stops at that item's walk. A
 malformed file therefore loads with part of its 2D content missing rather than
 taking the process down.


### PR DESCRIPTION
The #2866 family fixed stack-overflow aborts reachable from raw uploaded IFC bytes — a class where a malformed file could kill the tab's worker. **Six of those PRs merged with no changeset**, so none of it would appear in a release note. This adds the six.

| PR | merge | what the bound does |
|---|---|---|
| #2872 | `159c93b0a` | layer-slicing identity chase |
| #2870 | `8c2a484ba` | boolean/CSG operand cycle |
| #2869 | `de35ee126` | symbolic item walk |
| #2868 | `f297186c9` | wasm mapped-item colour chase |
| #2871 | `e543131ff` | trimmed-curve basis chase |
| #2874 | `94a2812a9` | composite-curve profiles |

Verified absent from `.changeset/` on `main` by filename **and** by substance grep — a differently-named file covering the same ground would have made these duplicates.

## Every behaviour claim was checked against the merged code

An earlier draft said each fix "reports a catchable error". That is true of exactly one of them, and the notes now say what each actually does:

- **#2870 genuinely returns an error** — `Err(Error::geometry(...))` naming `MAX_OPERAND_PATH_NODES = 64`.
- **#2872 reports nothing catchable.** The guard sits in a `-> bool`; on a repeat it returns `false` and the element renders as one un-sliced mesh. It also has **no numeric cap at all** — the merged commit rejects one deliberately, because Revit ships 42-node chains — so naming a bound would itself have been an overclaim.
- **#2869 truncates silently.** All three bounded exits are bare `return;` in a `()`-returning fn.
- **#2874 is split** — cycle/depth exit silently, the 100,000-node budget returns an error.

A second pass then caught the *opposite* error in our own corrections: the #2872 note had gone from "catchable error" to "reported nowhere", which is also false — `router/layers.rs:151` pushes a diagnostic that `gpu_meshes/batch.rs:500-523` emits as a `console.warn` naming the element id and skip reason. The note now says both halves: nothing catchable surfaces, but a warning is logged, and a console warning is not something a caller can handle.

Two absolute-quantifier overclaims were also removed: "*every* IFC opened in the browser goes through this resolver" (it is gated on the file carrying geometry styles and the element having a representation), and #2869's "everything outside the sub-tree extracts normally" (true for the depth cap and path guard, **false for the revisit budget**, which is held per top-level representation item and never restored — the repo's own `a_cycle_must_not_starve_the_geometry_that_follows_it` pins exactly that).

## Mechanical

All six start with `---` on line 1, confirmed with `od -c` (no BOM, no leading blank — a stray licence header would break them silently). Package names checked against real workspace `name:` fields. All `patch`: every changed symbol is private, `pub(crate)` or `pub(super)`, and #2870's fn already returned `Result<Mesh>` before the fix.

Attribution follows the split precedent already on `main` — `clash-solid-trust-band-projected-axis.md` attributes a `rust/geometry`-only change to `@ifc-lite/geometry`, `gltf-options-non-exhaustive.md` attributes a bindings-reachable change to `@ifc-lite/wasm`; `config.json` has `fixed: []`/`linked: []`, so these do not co-bump.

`node scripts/check-changesets.mjs` → `changesets: 115 pending, all naming workspace packages.`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or cyclic geometry and representation data.
  * Files now continue loading when invalid elements or deeply nested curves are encountered, instead of terminating.
  * Prevented viewer worker failures during cyclic mapped-item colour resolution.
  * Preserved valid geometry, curve details, profile points, and authored colours where possible.
  * Invalid or excessively complex content is safely omitted or rendered with fallback colours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->