### PR TITLE
test: distinguish a panicked worker from a hung one in the timeout harnesses (#2945)

### DIFF
--- a/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
+++ b/rust/geometry/src/processors/boolean/chain_cycle_tests.rs
@@ -43,10 +43,22 @@ fn collect_with_timeout(content: String, root_id: u32) -> (u32, Vec<u32>) {
             (base.id, cutters.iter().map(|c| c.id).collect::<Vec<_>>())
         }));
     });
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(10));
-    assert!(outcome.is_ok(), "collect_polygonal_chain hung (walk did not terminate)");
+    // Match the variant rather than `is_ok()`: `recv_timeout` returns Err for
+    // Disconnected as well as Timeout, so a PANIC in the worker drops `tx` and
+    // reports as "did not terminate" — a confident wrong diagnosis pointing at
+    // a guard that is fine (#2945).
+    let value = match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("collect_polygonal_chain hung (walk did not terminate)")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("collect_polygonal_chain's worker PANICKED (not a hang); \
+                    its panic is printed above")
+        }
+    };
     let _ = handle.join();
-    outcome.unwrap().expect("collect_polygonal_chain returned Err")
+    value.expect("collect_polygonal_chain returned Err")
 }
 
 #[test]
@@ -63,16 +75,20 @@ fn collect_polygonal_chain_terminates_on_cyclic_first_operand() {
         let _ = tx.send(result.map(|(base, cutters)| (base.id, cutters.len())));
     });
 
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(5));
-    assert!(
-        outcome.is_ok(),
-        "collect_polygonal_chain hung on a cyclic FirstOperand chain"
-    );
+    // Variant-matched, not `is_ok()`: see `collect_with_timeout` (#2945).
+    let value = match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("collect_polygonal_chain hung on a cyclic FirstOperand chain")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("collect_polygonal_chain's worker PANICKED on the cyclic fixture \
+                    (not a hang); its panic is printed above")
+        }
+    };
     let _ = handle.join();
 
-    let (base_id, cutter_count) = outcome
-        .unwrap()
-        .expect("collect_polygonal_chain returned Err");
+    let (base_id, cutter_count) = value.expect("collect_polygonal_chain returned Err");
     // The walk bottoms out on the repeated entity and collects the single
     // PBHS cutter it saw before detecting the cycle.
     assert_eq!(base_id, 10, "cycle should bottom out on the repeated entity");
@@ -628,8 +644,17 @@ fn full_process_terminates_on_cyclic_boolean() {
         );
         let _ = tx.send(result.is_ok());
     });
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(10));
-    assert!(outcome.is_ok(), "full process() hung on a cyclic boolean chain");
+    // Variant-matched, not `is_ok()`: see `collect_with_timeout` (#2945).
+    match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(_) => {}
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("full process() hung on a cyclic boolean chain")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("full process()'s worker PANICKED on the cyclic fixture (not a hang); \
+                    its panic is printed above")
+        }
+    }
     let _ = handle.join();
 }
 
@@ -674,17 +699,23 @@ fn boolean_csg_mutual_recursion_terminates() {
         let _ = tx.send(result.map(|m| m.positions.len()));
     });
 
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(10));
-    assert!(
-        outcome.is_ok(),
-        "Boolean/CSG mutual recursion did not terminate"
-    );
+    // Variant-matched, not `is_ok()`: see `collect_with_timeout` (#2945).
+    let value = match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("Boolean/CSG mutual recursion did not terminate")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("the Boolean/CSG worker PANICKED (not a hang); \
+                    its panic is printed above")
+        }
+    };
     let _ = handle.join();
 
     // The cycle is reported, not silently swallowed: an operand that cannot be
     // resolved must surface as an error so the router drops the element rather
     // than rendering a half-built solid as if it were complete.
-    let err = outcome.unwrap().expect_err("a cyclic operand must be an error");
+    let err = value.expect_err("a cyclic operand must be an error");
     let msg = err.to_string();
     assert!(
         msg.contains("Cyclic boolean/CSG operand reference"),
@@ -708,12 +739,19 @@ fn csg_entry_point_is_guarded_too() {
         let _ = tx.send(result.map(|m| m.positions.len()));
     });
 
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(10));
-    assert!(outcome.is_ok(), "CsgSolid entry point did not terminate");
+    // Variant-matched, not `is_ok()`: see `collect_with_timeout` (#2945).
+    let value = match rx.recv_timeout(std::time::Duration::from_secs(10)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("CsgSolid entry point did not terminate")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("the CsgSolid entry point's worker PANICKED (not a hang); \
+                    its panic is printed above")
+        }
+    };
     let _ = handle.join();
-    outcome
-        .unwrap()
-        .expect_err("a cyclic operand must be an error from this entry point too");
+    value.expect_err("a cyclic operand must be an error from this entry point too");
 }
 
 /// A long ACYCLIC `Boolean -> Csg -> Boolean` chain, every id distinct. The
@@ -750,11 +788,19 @@ fn a_long_acyclic_boolean_csg_chain_terminates() {
         let result = processor.process(&entity, &mut decoder, &schema, Default::default());
         let _ = tx.send(result.map(|m| m.positions.len()).map_err(|e| e.to_string()));
     });
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(20));
-    assert!(outcome.is_ok(), "the operand chain bound did not terminate");
+    // Variant-matched, not `is_ok()`: see `collect_with_timeout` (#2945).
+    let value = match rx.recv_timeout(std::time::Duration::from_secs(20)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("the operand chain bound did not terminate")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("the operand chain worker PANICKED (not a hang, so the chain bound \
+                    is not implicated); its panic is printed above")
+        }
+    };
     let _ = handle.join();
-    let err = outcome
-        .unwrap()
+    let err = value
         .expect_err("an over-long operand chain must be reported, not rendered half-built");
     assert!(
         err.contains("operand chain exceeds"),

--- a/rust/geometry/src/router/layers_cycle_tests.rs
+++ b/rust/geometry/src/router/layers_cycle_tests.rs
@@ -27,13 +27,22 @@ fn identity_of(data: &str, id: u32) -> bool {
         let item = decoder.decode_by_id(id).expect("decode item");
         let _ = tx.send(item_has_identity_position(item, &mut decoder));
     });
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(30));
-    assert!(
-        outcome.is_ok(),
-        "item_has_identity_position did not terminate"
-    );
+    // Match the variant rather than `is_ok()`: `recv_timeout` returns Err for
+    // Disconnected as well as Timeout, so a PANIC in the worker drops `tx` and
+    // reports as "did not terminate" — a confident wrong diagnosis pointing at
+    // a guard that is fine (#2945).
+    let value = match rx.recv_timeout(std::time::Duration::from_secs(30)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("item_has_identity_position did not terminate within 30s")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("item_has_identity_position's worker PANICKED (not a hang); \
+                    its panic is printed above")
+        }
+    };
     let _ = handle.join();
-    outcome.unwrap()
+    value
 }
 
 /// One self-referential entity: `#10`'s FirstOperand is `#10` (#2866).

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -81,14 +81,23 @@ fn run_with_timeout(step: String, start_id: u32, secs: u64) -> SymbolicData {
     let handle = std::thread::spawn(move || {
         let _ = tx.send(run(&step, start_id));
     });
-    let outcome = rx.recv_timeout(std::time::Duration::from_secs(secs));
-    assert!(
-        outcome.is_ok(),
-        "extract_symbolic_item did not terminate within {secs}s -- the breadth bound \
-         (MAX_ITEM_REVISITS) is gone; a depth cap and a path guard alone allow k! paths"
-    );
+    // Match the variant rather than `is_ok()`: `recv_timeout` returns Err for
+    // Disconnected as well as Timeout, so a PANIC in the worker drops `tx` and
+    // reports as "did not terminate" — a confident wrong diagnosis pointing at
+    // a guard that is fine (#2945).
+    let value = match rx.recv_timeout(std::time::Duration::from_secs(secs)) {
+        Ok(v) => v,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => panic!(
+            "extract_symbolic_item did not terminate within {secs}s -- the breadth bound \
+             (MAX_ITEM_REVISITS) is gone; a depth cap and a path guard alone allow k! paths"
+        ),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => panic!(
+            "extract_symbolic_item's worker PANICKED (not a hang, so the breadth bound \
+             is not implicated); its panic is printed above"
+        ),
+    };
     let _ = handle.join();
-    outcome.unwrap()
+    value
 }
 
 fn wrap(body: &str) -> String {

--- a/rust/processing/tests/faceted_brep_deadlock_regression.rs
+++ b/rust/processing/tests/faceted_brep_deadlock_regression.rs
@@ -20,6 +20,7 @@
 //! worker forever, so the timeout fails the test instead of hanging CI.
 
 use std::sync::mpsc;
+use std::sync::mpsc::RecvTimeoutError;
 use std::time::Duration;
 
 const FIXTURE: &str = concat!(
@@ -60,10 +61,18 @@ fn multithreaded_faceted_brep_pipeline_does_not_deadlock() {
         Ok(()) => {
             let _ = worker.join();
         }
-        Err(_) => panic!(
+        // Distinguish the variants: `recv_timeout` returns Err for Disconnected
+        // as well as Timeout, so a PANIC in the worker would otherwise be
+        // reported as a deadlock and send the reader to #1572's `try_lock` fix
+        // for a bug that is not the one they have (#2945).
+        Err(RecvTimeoutError::Timeout) => panic!(
             "process_geometry deadlocked on a faceted-brep-heavy model — the \
              nested-par_iter worker-point-cache re-entrancy regression is back \
              (#1572; fix is `try_lock` in processor/mod.rs)"
+        ),
+        Err(RecvTimeoutError::Disconnected) => panic!(
+            "process_geometry's worker PANICKED rather than deadlocking, so #1572 \
+             is not implicated; its panic is printed above"
         ),
     }
 }


### PR DESCRIPTION
Closes #2945.

## The defect

Nine `rx.recv_timeout` sites across four files asserted on `.is_ok()` (or matched `Err(_)`). **`recv_timeout` returns Err for `Disconnected` as well as `Timeout`**, so a panic in the worker drops `tx`, returns immediately, and was reported as a hang.

The resulting diagnosis wasn't vague — it was confidently wrong, and it named the guard each harness exists to protect:

| file | what a worker panic reported |
|---|---|
| `layers_cycle_tests.rs` | "item_has_identity_position did not terminate" |
| `items_cycle_tests.rs` | "…the breadth bound (MAX_ITEM_REVISITS) is gone" |
| `chain_cycle_tests.rs` | "collect_polygonal_chain hung" |
| `faceted_brep_deadlock_regression.rs` | "the re-entrancy regression is back (#1572; fix is `try_lock` in processor/mod.rs)" |

The last one names an issue **and** a fix. Someone whose decode fixture broke would have gone to read `try_lock` in `processor/mod.rs` about a bug they didn't have.

## After

```
worker panics  -> "worker PANICKED (not a hang)"    returns immediately
genuine hang   -> "did not terminate within Ns"     at the configured cap
```

Both directions verified per file. Previously the two produced the same sentence, and the timing didn't even hint — `Disconnected` returns instantly, so a panic looked like a hang that failed fast.

## Four files, not three

`processing/tests/faceted_brep_deadlock_regression.rs` sits in `tests/` rather than beside a cycle-test module, so a search scoped to `*_cycle_tests.rs` misses it. Fixed together deliberately: the defect spread by copying, and fixing three of four leaves the next person to copy whichever they find first.

A repo-wide sweep for `recv_timeout` / `try_recv` / `recv_deadline` / crossbeam / flume confirms exactly nine sites exist and all nine are covered. The TS side has equivalents (`drainWithDeadline`, the `HUNG` symbol races) and they already keep *rejected* and *timed out* distinct.

## Corrections applied from review

**My panic messages contained a wrong instruction.** They said "run this test directly to see the panic" — but a worker's panic goes to the real stderr, bypassing the harness's per-test capture, so it is *already printed immediately above*. Telling the reader to re-run to see something in front of them is the same species of defect this PR fixes, one level down. Now "its panic is printed above".

The 4-line rationale was repeated at six sites; stated once on `collect_with_timeout` with one-line references elsewhere, matching how this repo already cross-references. `outcome` renamed to `value` where the binding holds the inner result.

## What the workspace run does not cover

`faceted_brep_deadlock_regression.rs` needs `ara3d/schependomlaan.ifc`, which is not in the manifest and absent locally, so it hits `eprintln!("skipping…")` and passes **without executing**. The 1934-passed figure therefore does not cover one of the four files.

Review exercised it directly by repointing FIXTURE at `geometry/tests/fixtures/shared_point_faceted_brep.ifc` with the cap cut to 8s, and confirmed both directions.

That skip is itself the absence-reads-as-success shape (#2835's class) and is pre-existing — flagged, not widened into here.

Workspace 1934 passed, clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved diagnostic reporting for timeout-based regression tests.
  - Worker hangs and worker-thread panics are now reported separately.
  - Added clearer failure messages for disconnected workers across geometry and processing scenarios.
  - Preserved deadlock and non-termination diagnostics when timeouts occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->