### PR TITLE
feat(viewer): per-row focus modes for IDS results, reusing the clash approach (#2867)

### DIFF
--- a/apps/viewer/src/components/viewer/IDSPanel.focus-teardown.test.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.focus-teardown.test.tsx
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `IDSPanel`'s unmount cleanup — the one release site of the per-row focus
+ * (#2867) that no test drove. Deleting the cleanup outright left every suite
+ * green (verified by mutation, review of #2867), which is exactly the state
+ * `ClashPanel.focus-teardown.test.tsx` exists to prevent on the clash side:
+ * leaving the panel with an isolate- or ghost-mode row focus would strand the
+ * model isolated on, or faded around, an element whose panel is gone.
+ *
+ * Both channels the row focus writes are checked: the shared VISIBILITY
+ * channel and the PAINT channel (`pendingColorUpdates`), whose focus tint
+ * `ClashPanel` has always handed back on unmount and `IDSPanel` did not.
+ *
+ * The release is ownership-scoped, so the third case here is the one that
+ * makes the other two mean something: a presentation belonging to somebody
+ * else must survive the panel closing.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import { IDSPanel } from './IDSPanel.js';
+import { IDS_FOCUS_COLOR } from '@/hooks/ids/idsColorSystem.js';
+
+Object.defineProperty(HTMLElement.prototype, 'offsetWidth', { get: () => 800, configurable: true });
+Object.defineProperty(HTMLElement.prototype, 'offsetHeight', { get: () => 600, configurable: true });
+
+let root: Root | null = null;
+let container: HTMLElement | null = null;
+
+/** Mount the panel with a row-focus presentation already installed into
+ *  `channel`, and return the unmount. */
+async function mountWithRowFocus(
+  channel: 'isolate' | 'ghost',
+  ids: number[],
+): Promise<() => Promise<void>> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<IDSPanel />);
+  });
+  await act(async () => {
+    useViewerStore.setState({
+      isolatedEntities: channel === 'isolate' ? new Set(ids) : null,
+      ghostExceptEntities: channel === 'ghost' ? new Set(ids) : null,
+      idsFocusVisibilityOwned: { channel, ids: new Set(ids) },
+      pendingColorUpdates: new Map<number, [number, number, number, number]>(
+        ids.map((id) => [id, IDS_FOCUS_COLOR]),
+      ),
+      lensAppliedColors: null,
+    });
+  });
+  const closing = root;
+  root = null;
+  return async () => { await act(async () => closing!.unmount()); };
+}
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  container?.remove();
+  container = null;
+  // One Zustand store is shared across every node:test file — put back what
+  // this suite seeded.
+  useViewerStore.setState({
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    idsFocusVisibilityOwned: null,
+    pendingColorUpdates: null,
+    lensAppliedColors: null,
+  });
+});
+
+describe('IDSPanel unmount ends the IDS row-focus presentation (#2867)', () => {
+  it('releases a row ISOLATION rather than leaving the model isolated on a closed panel', async () => {
+    const unmount = await mountWithRowFocus('isolate', [1]);
+    await unmount();
+
+    const s = useViewerStore.getState();
+    assert.equal(s.isolatedEntities, null,
+      'the panel is gone; an isolation it installed left standing hides the model with nothing on screen to explain it');
+    assert.equal(s.idsFocusVisibilityOwned, null,
+      'and the claim goes with it — a record that outlives its presentation re-matches later');
+  });
+
+  it('releases a row GHOST, and hands the focus tint back with it', async () => {
+    const unmount = await mountWithRowFocus('ghost', [1]);
+    await unmount();
+
+    const s = useViewerStore.getState();
+    assert.equal(s.ghostExceptEntities, null, 'the fade around the focused element ends with the panel');
+    assert.equal(s.idsFocusVisibilityOwned, null);
+    assert.notDeepEqual(s.pendingColorUpdates?.get(1), IDS_FOCUS_COLOR,
+      'the focus marker is painted through the albedo channel — clearing the record alone leaves it on the model');
+  });
+
+  it('leaves a presentation IDS does not own exactly as the user left it', async () => {
+    const unmount = await mountWithRowFocus('ghost', [1]);
+    // Another feature (the spaces X-ray, LayerDiffView, clash) takes the same
+    // channel over with different content, so the IDS record no longer matches.
+    await act(async () => {
+      useViewerStore.setState({ ghostExceptEntities: new Set([1, 9]) });
+    });
+    await unmount();
+
+    const s = useViewerStore.getState();
+    assert.deepEqual(s.ghostExceptEntities && [...s.ghostExceptEntities].sort((a, b) => a - b), [1, 9],
+      "IDS installed {1}, the channel shows {1, 9} — that is somebody else's presentation (#2654)");
+  });
+});

--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -67,6 +67,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useIDS } from '@/hooks/useIDS';
+import type { IDSFocusMode } from '@/store/slices/idsSlice';
 import { openGenericFileDialog } from '@/services/file-dialog';
 import type {
   IDSSpecificationResult,
@@ -76,6 +77,7 @@ import type {
 import { cn } from '@/lib/utils';
 import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
 import { useViewerStore } from '@/store';
+import { releaseOwnedIdsFocusVisibility } from '@/lib/ids/visibility-ownership';
 import { IDSAuditSummary } from './IDSAuditSummary';
 import { IDSExportDialog } from './IDSExportDialog';
 import type { IDSBCFExportSettings, IDSExportProgress } from './IDSExportDialog';
@@ -468,6 +470,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     isolationScope,
     isolateMode,
     isolationActive,
+    focusMode,
 
     // Actions
     loadIDSFile,
@@ -475,9 +478,10 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     runValidation,
     clearValidation,
     setActiveSpecification,
-    selectEntity,
+    focusEntity,
     setFilterMode,
     setIsolationScope,
+    setFocusMode,
     applyColors,
     isolateFailed,
     isolatePassed,
@@ -508,6 +512,16 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
   // updates once a run completes. Hold the user's in-flight choice locally so
   // the dropdown keeps showing the model being validated instead of snapping
   // back to the previous one while `loading` (#1702 C3).
+  // Leaving the panel ends the ROW focus presentation (#2867): an isolate- or
+  // ghost-mode focus would otherwise leave the model isolated on, or faded
+  // around, an element whose panel is gone — the same reason `ClashPanel` has
+  // an unmount cleanup. Ownership-scoped, so a presentation belonging to
+  // clash, the spaces X-ray or IDS's own set-level isolate buttons is left
+  // exactly as the user left it.
+  useEffect(() => () => {
+    releaseOwnedIdsFocusVisibility(useViewerStore.getState());
+  }, []);
+
   const [pendingModelId, setPendingModelId] = useState<string | null>(null);
   useEffect(() => {
     // Once a run settles (report landed or errored), fall back to the report's
@@ -548,10 +562,13 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     fileInputRef.current?.click();
   }, [loadIdsFromDialog]);
 
-  // Handle entity click
+  // Handle entity click. The row's focus MODE (highlight / isolate / ghost) is
+  // the user's persistent choice, applied by `focusEntity` — activating a row
+  // used to select, colour nothing extra and frame, which in a dense model
+  // left the element indistinguishable from the failures around it (#2867).
   const handleEntityClick = useCallback((modelId: string, expressId: number) => {
-    selectEntity(modelId, expressId);
-  }, [selectEntity]);
+    focusEntity(modelId, expressId);
+  }, [focusEntity]);
 
   // Active state for the isolate toggle buttons. A button is "active" only
   // when ITS mode is applied AND isolation is still live, so an externally
@@ -915,6 +932,34 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
             bcfExportProgress={bcfExportProgress}
             report={report}
           />
+        </div>
+
+        {/* On-select focus mode (#2867) — the same control, the same wording
+            and the same three modes as the clash panel's, because it is the
+            same action: how the rest of the model is shown when you activate
+            one result row. */}
+        <div className="flex items-center gap-1 px-2 py-1 border-b text-[11px] text-muted-foreground">
+          <span>On select:</span>
+          <div className="inline-flex rounded-md border border-border overflow-hidden">
+            {([
+              ['highlight', 'Highlight', 'Keep the whole model visible'],
+              ['isolate', 'Isolate', 'Hide everything except the selected element'],
+              ['ghost', 'Ghost', 'Fade the rest to translucent context (X-Ray)'],
+            ] as [IDSFocusMode, string, string][]).map(([m, label, tip]) => (
+              <button
+                key={m}
+                title={tip}
+                aria-pressed={focusMode === m}
+                onClick={() => setFocusMode(m)}
+                className={cn(
+                  'px-1.5 py-0.5 transition-colors',
+                  focusMode === m ? 'bg-primary text-primary-foreground' : 'hover:bg-muted',
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
 
         {/* Specifications List */}

--- a/apps/viewer/src/components/viewer/IDSPanel.tsx
+++ b/apps/viewer/src/components/viewer/IDSPanel.tsx
@@ -77,7 +77,7 @@ import type {
 import { cn } from '@/lib/utils';
 import { tourAnchor, TOUR_ANCHORS } from '@/lib/tours/anchors';
 import { useViewerStore } from '@/store';
-import { releaseOwnedIdsFocusVisibility } from '@/lib/ids/visibility-ownership';
+import { endIdsRowFocusPresentation } from '@/lib/ids/visibility-ownership';
 import { IDSAuditSummary } from './IDSAuditSummary';
 import { IDSExportDialog } from './IDSExportDialog';
 import type { IDSBCFExportSettings, IDSExportProgress } from './IDSExportDialog';
@@ -470,6 +470,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
     isolationScope,
     isolateMode,
     isolationActive,
+    visibilityFilterActive,
     focusMode,
 
     // Actions
@@ -519,7 +520,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
   // clash, the spaces X-ray or IDS's own set-level isolate buttons is left
   // exactly as the user left it.
   useEffect(() => () => {
-    releaseOwnedIdsFocusVisibility(useViewerStore.getState());
+    endIdsRowFocusPresentation(useViewerStore.getState());
   }, []);
 
   const [pendingModelId, setPendingModelId] = useState<string | null>(null);
@@ -906,7 +907,7 @@ export function IDSPanel({ onClose }: IDSPanelProps) {
                 className="h-8 w-8 p-0"
                 aria-label="Clear isolation (show all)"
                 onClick={clearIsolation}
-                disabled={!isolationActive}
+                disabled={!visibilityFilterActive}
               >
                 <Focus className="h-4 w-4" />
               </Button>

--- a/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.isolate.wiring.test.tsx
@@ -262,7 +262,7 @@ describe('LensPanel: isolating a rule resolves geometry-less assemblies to their
   });
 
   it('switches to a DIFFERENT rule matching the same entities without the toggle clearing the channel', () => {
-    // `isolateEntities` is a same-set TOGGLE (visibilitySlice.ts:176-194): fed
+    // `isolateEntities` is a same-set TOGGLE (visibilitySlice.ts, `isolateEntities`): fed
     // the ids the channel already holds it CLEARS. So switching from one rule
     // to another whose criteria differ but whose matches coincide un-isolated
     // the model, while the panel went on to record the new rule as the owner

--- a/apps/viewer/src/components/viewer/LensPanel.tsx
+++ b/apps/viewer/src/components/viewer/LensPanel.tsx
@@ -1369,7 +1369,7 @@ export function LensPanel({ onClose }: LensPanelProps) {
     const resolved = cameraCallbacks.resolveHighlightIds?.(matchingIds) ?? [];
     const isolationIds = [...new Set([...resolved, ...matchingIds])];
 
-    // `isolateEntities` is a same-set TOGGLE (visibilitySlice.ts:176-194): if
+    // `isolateEntities` is a same-set TOGGLE (visibilitySlice.ts, `isolateEntities`): if
     // the channel already holds exactly these ids it CLEARS instead of
     // isolating. Switching from rule A to a rule B that lands on the SAME set
     // would therefore un-isolate the model while the record below claims B

--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -435,7 +435,7 @@ export function SearchModalFilter() {
       isolationIds = [...merged];
     }
 
-    // isolateEntities is a same-set TOGGLE (visibilitySlice.ts:176-194):
+    // isolateEntities is a same-set TOGGLE (visibilitySlice.ts, `isolateEntities`):
     // pressing "Isolate in 3D" again on the identical result un-isolates
     // rather than re-isolating. Detect that up front so the un-isolate press
     // only clears — it must not also select/frame the id set and close the

--- a/apps/viewer/src/components/viewer/tools/space-sketch/ghost-preview-restore.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/ghost-preview-restore.test.tsx
@@ -12,8 +12,8 @@
  * landed AFTER the restore and undid it.
  *
  * That is not a cosmetic race: `setGhostExceptEntities(null)` also nulls
- * `isolatedEntities` (visibilitySlice.ts:227), so the late clear wiped the user's
- * restored ISOLATION as well as their prior X-ray. Opening Space Sketch on a
+ * `isolatedEntities` (visibilitySlice.ts, `setGhostExceptEntities`), so the
+ * late clear wiped the user's restored ISOLATION as well as their prior X-ray. Opening Space Sketch on a
  * clash-focused or isolated view and closing it dropped that view a frame later.
  *
  * Both hooks are rendered together here, in the same order the overlay calls

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceGhostPreview.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceGhostPreview.ts
@@ -151,12 +151,14 @@ export function useSpaceGhostPreview({ enabled, ghosts, contextIds }: GhostPrevi
       // owns that on close, and it runs synchronously on the `enabled` transition
       // while this path is reached from a debounce — so clearing here landed AFTER
       // the restore and undid it. Worse than it sounds: `setGhostExceptEntities(null)`
-      // also nulls `isolatedEntities` (visibilitySlice.ts:227), so a stale clear wiped
-      // the user's restored isolation as well as their prior X-ray.
+      // also nulls `isolatedEntities` (visibilitySlice.ts, `setGhostExceptEntities`),
+      // so a stale clear wiped the user's restored isolation as well as their
+      // prior X-ray.
       //
-      // The tool's own X-ray still gets cleared: `restore` calls
-      // `setIsolatedEntities` first, which sets `ghostExceptEntities: null`
-      // unconditionally (visibilitySlice.ts:221) before replaying any prior X-ray.
+      // The tool's own X-ray still gets cleared: `restore` puts the CAPTURED
+      // view back through `restoreVisibilityState`, which writes both channels
+      // verbatim — so when nothing was ghosted before the tool opened it writes
+      // `ghostExceptEntities: null`, and the tool's X-ray goes with it.
       ghostViewActiveRef.current = false;
       return;
     }

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSceneFraming.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSceneFraming.ts
@@ -60,15 +60,15 @@ export function useSpaceSceneFraming({ enabled, existingSpaceIds }: SceneFraming
     const prior = priorRef.current;
     if (!prior) return;
     const store = useViewerStore.getState();
-    // Isolation and X-ray are mutually exclusive in the slice (each setter
-    // clears the other), so restore isolation first, then any prior X-ray.
-    store.setIsolatedEntities(prior.isolated);
-    // `setIsolatedEntities` also clears `hiddenEntities` (visibilitySlice.ts:220
-    // — isolation supersedes per-entity hiding). This tool never owned that set,
-    // so put it back verbatim: otherwise simply opening and closing Space Sketch
-    // un-hides everything the user had hidden beforehand.
-    if (prior.hidden.size > 0) store.setHiddenEntities(prior.hidden);
-    if (prior.ghostExcept) store.setGhostExceptEntities(prior.ghostExcept);
+    // Isolation, X-ray and per-entity hiding all clear each other through the
+    // individual setters (isolation and ghosting are mutually exclusive;
+    // isolation supersedes hiding). Replaying them one call at a time therefore
+    // walked through states the user never had — and one of those intermediate
+    // states nulls the very channel the next call restores, which strips the
+    // ownership record off a presentation that is coming straight back (#2662
+    // P2, re-found in the review of #2867). One atomic restore instead: the
+    // captured view is a single fact and goes back as one.
+    store.restoreVisibilityState(prior);
     // Restore against the CAPTURED visibility, not a "did we flip it" flag —
     // something else may have toggled spaces mid-session. `keepSpacesVisible`
     // is a floor on that target rather than a skip: after a confirm the user

--- a/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSceneFraming.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/useSpaceSceneFraming.ts
@@ -68,6 +68,12 @@ export function useSpaceSceneFraming({ enabled, existingSpaceIds }: SceneFraming
     // ownership record off a presentation that is coming straight back (#2662
     // P2, re-found in the review of #2867). One atomic restore instead: the
     // captured view is a single fact and goes back as one.
+    //
+    // Two behaviour changes come with it, both wanted: a captured ISOLATION now
+    // survives a non-empty captured hidden set (the replay's `setHiddenEntities`
+    // nulled the isolation it had just restored), and a Class-tab `classFilter`
+    // this tool never touched is no longer cleared on close (that same setter
+    // nulls it).
     store.restoreVisibilityState(prior);
     // Restore against the CAPTURED visibility, not a "did we flip it" flag —
     // something else may have toggled spaces mid-session. `keepSpacesVisible`

--- a/apps/viewer/src/hooks/ids/idsColorSystem.ts
+++ b/apps/viewer/src/hooks/ids/idsColorSystem.ts
@@ -20,6 +20,22 @@ export type ColorTuple = [number, number, number, number];
 export const DEFAULT_FAILED_COLOR: ColorTuple = [0.9, 0.2, 0.2, 1.0];
 export const DEFAULT_PASSED_COLOR: ColorTuple = [0.2, 0.8, 0.2, 1.0];
 
+/**
+ * The colour the ROW the user just activated is painted, on top of the report
+ * overlay (#2867).
+ *
+ * The reported problem is that an activated element cannot be found: it keeps
+ * the report red (failed) or green (passed), so it looks exactly like every
+ * other failing element around it. A third, distinct hue is what separates
+ * "the one I clicked" from "the ones near it", and it has to be far from BOTH
+ * report colours to do that — hence cyan rather than a lighter red.
+ *
+ * Pushed through the colour-override channel (the albedo path the lens and the
+ * clash pair tint use), not the selection outline, so it survives batched and
+ * GPU-instanced geometry and shows in all three focus modes.
+ */
+export const IDS_FOCUS_COLOR: ColorTuple = [0.0, 0.75, 1.0, 1.0];
+
 /** Display options controlling which entities get color overrides */
 export interface ColorDisplayOptions {
   highlightFailed: boolean;

--- a/apps/viewer/src/hooks/useIDS.row-focus-invalidation.test.tsx
+++ b/apps/viewer/src/hooks/useIDS.row-focus-invalidation.test.tsx
@@ -1,0 +1,319 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A visibility-ownership record must not outlive its presentation — from
+ * EITHER side of the shared channel (review of #2867).
+ *
+ * `#2867` closed the stale-record hole only where IDS itself acts
+ * (`installSetIsolation` nulls `idsFocusVisibilityOwned`). Nothing did the
+ * equivalent when ANY OTHER owner replaced the channel, and ownership is
+ * tested by VALUE: a record that survives its presentation goes matching →
+ * cleared → MATCHING AGAIN as soon as the next owner installs a set with equal
+ * content, and the next release then destroys THAT owner's presentation. That
+ * is #2654, reopened, on the IDS side — and symmetrically on the clash side,
+ * where an IDS row focus supersedes a clash ghost.
+ *
+ * The fix is not per-caller: it is the shared invalidation the two slice
+ * setters that REPLACE these channels now perform (`visibilitySlice`), which
+ * drops every record the new channel content no longer matches. This file
+ * drives it through the REAL hooks and the REAL store.
+ *
+ * It also covers the two channels the row focus writes but the release sites
+ * did not both hand back: the PAINT channel (`pendingColorUpdates`), and the
+ * panel's "Clear isolation (show all)" affordance, which read only the
+ * isolate channel while the DEFAULT mode writes the ghost one.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { IDSValidationReport } from '@ifc-lite/ids';
+import type { Clash } from '@ifc-lite/clash';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { useIDS } from './useIDS.js';
+import { useClash } from './useClash.js';
+import { IDS_FOCUS_COLOR } from './ids/idsColorSystem.js';
+
+// ─── Fixture (same shape as `useIDS.row-focus-modes.test.tsx`) ──────────────
+
+function model(id: string): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 0,
+    fileSize: 0,
+    idOffset: 0,
+    maxExpressId: 10,
+  } as unknown as FederatedModel;
+}
+
+function report(): IDSValidationReport {
+  const entity = (expressId: number, passed: boolean) => ({
+    expressId,
+    modelId: 'A',
+    entityType: 'IfcWall',
+    passed,
+    requirementResults: [],
+  });
+  return {
+    document: { specifications: [] },
+    modelInfo: { modelId: 'A', schemaVersion: 'IFC4', entityCount: 3 },
+    timestamp: new Date(0),
+    summary: {
+      totalSpecifications: 1,
+      passedSpecifications: 0,
+      failedSpecifications: 1,
+      totalEntitiesChecked: 3,
+      totalEntitiesPassed: 1,
+      totalEntitiesFailed: 2,
+      overallPassRate: 33,
+    },
+    specificationResults: [
+      {
+        specification: { id: 'spec-1', name: 'Spec 1' },
+        status: 'fail',
+        applicableCount: 3,
+        passedCount: 1,
+        failedCount: 2,
+        passRate: 33,
+        entityResults: [entity(1, false), entity(2, false), entity(3, true)],
+      },
+    ],
+  } as unknown as IDSValidationReport;
+}
+
+const CLASH: Clash = {
+  id: 'clash-1',
+  a: { key: 'A:5', ref: 5, model: 'A', tag: 'IfcWall' },
+  b: { key: 'A:6', ref: 6, model: 'A', tag: 'IfcWall' },
+  rule: 'all-clashes',
+  status: 'hard',
+  distance: -0.5,
+  point: [0.75, 0.5, 0.5],
+  bounds: { min: [0.5, 0, 0], max: [1, 1, 1] },
+  severity: 'major',
+};
+
+type Api = { ids: ReturnType<typeof useIDS>; clash: ReturnType<typeof useClash> };
+
+let api: Api | null = null;
+let root: Root | null = null;
+
+function Probe(): null {
+  api = { ids: useIDS(), clash: useClash() };
+  return null;
+}
+
+async function seed(): Promise<void> {
+  useViewerStore.setState({
+    models: new Map([['A', model('A')], ['B', model('B')]]),
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    hiddenEntities: new Set(),
+    pendingColorUpdates: null,
+    lensAppliedColors: null,
+    idsValidationReport: null,
+    idsActiveEntityId: null,
+    idsIsolateMode: null,
+    idsFocusVisibilityOwned: null,
+    idsFocusMode: 'ghost',
+    clashVisibilityOwned: null,
+    clashSelectedId: null,
+    clashHighlightColors: null,
+  });
+  const container = globalThis.document.createElement('div');
+  globalThis.document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(api, 'the probe must be mounted');
+  await act(async () => {
+    useViewerStore.getState().setIdsValidationReport(report());
+  });
+}
+
+beforeEach(() => {
+  api = null;
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+});
+
+const isolated = () => {
+  const s = useViewerStore.getState().isolatedEntities;
+  return s ? [...s].sort((a, b) => a - b) : null;
+};
+const ghosted = () => {
+  const s = useViewerStore.getState().ghostExceptEntities;
+  return s ? [...s].sort((a, b) => a - b) : null;
+};
+
+// ─── D1 / D2 / D3: a record dropped when another owner takes the channel ────
+
+describe('an ownership record dies with its presentation, whoever replaced it', () => {
+  it('D1: an IDS claim superseded by CLASH does not later destroy the user\'s own isolation', async () => {
+    await seed();
+    // 1. IDS row focus isolates element 1 and records `{isolate, {1}}`.
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    // 2. Clash takes the channel over. The IDS presentation is GONE from the
+    //    screen — `setGhostExceptEntities` nulls `isolatedEntities`.
+    await act(async () => { api!.clash.focusClash(CLASH, 'ghost'); });
+    assert.deepEqual(isolated(), null, 'setup: the IDS isolation is off screen');
+    assert.equal(
+      useViewerStore.getState().idsFocusVisibilityOwned,
+      null,
+      'the IDS claim ended when its presentation did — a record that outlives it re-matches later',
+    );
+
+    // 3. The user isolates element 1 BY HAND (Isolate in 3D / the model tree).
+    //    Equal content to what IDS once installed, and IDS installed none of it.
+    await act(async () => { useViewerStore.getState().setIsolatedEntities(new Set([1])); });
+    assert.deepEqual(isolated(), [1], 'setup: the user owns the isolate channel now');
+
+    // 4. An unrelated model leaves the federation.
+    await act(async () => { useViewerStore.getState().removeModel('B'); });
+
+    assert.deepEqual(
+      isolated(),
+      [1],
+      "the user's own isolation must survive — a stale IDS record matching it by value is #2654 reopened",
+    );
+  });
+
+  it('D2: clash\'s "clear selection, isolation and ghosting" ends the IDS claim too', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'ghost'); });
+    assert.deepEqual(ghosted(), [1], 'setup: IDS owns the ghost channel');
+
+    // The panel button that clears both channels outright, by design.
+    await act(async () => { api!.clash.clearHighlight(); });
+
+    assert.equal(ghosted(), null, 'setup: the ghost is gone (that part is the button working)');
+    assert.equal(
+      useViewerStore.getState().idsFocusVisibilityOwned,
+      null,
+      'and the IDS claim went with the presentation — a stranded record destroys the NEXT owner of the same content',
+    );
+
+    // The consequence, run out: the next owner installs the same content.
+    await act(async () => { useViewerStore.getState().setGhostExceptEntities(new Set([1])); });
+    await act(async () => { useViewerStore.getState().removeModel('B'); });
+    assert.deepEqual(ghosted(), [1], "the next owner's ghost must survive a model removal IDS has no claim on");
+  });
+
+  it('D3 (mirror): an IDS row focus superseding a clash ghost ends the CLASH claim', async () => {
+    await seed();
+    await act(async () => { api!.clash.focusClash(CLASH, 'ghost'); });
+    assert.deepEqual(ghosted(), [5, 6], 'setup: clash owns the ghost channel');
+
+    // IDS takes the channel over: `setIsolatedEntities` nulls the ghosting.
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    assert.equal(ghosted(), null, 'setup: the clash ghost is off screen');
+    assert.equal(
+      useViewerStore.getState().clashVisibilityOwned,
+      null,
+      'the clash claim must end with its presentation — the rule is symmetric or it is not a rule',
+    );
+
+    // The consequence: another owner installs a ghost with the SAME content.
+    await act(async () => { useViewerStore.getState().setGhostExceptEntities(new Set([5, 6])); });
+    await act(async () => { useViewerStore.getState().removeModel('B'); });
+    assert.deepEqual(ghosted(), [5, 6], "the next owner's ghost must survive — clash no longer has a claim on it");
+  });
+
+  it('a record whose content is REPLAYED intact survives — invalidation is by content, not by "somebody wrote"', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+
+    // Space Sketch's open/close view capture and `syncSourceModel` both rebuild
+    // an unchanged channel through the cloning setters (#2662 P2). Equal
+    // members mean the IDS row focus is still exactly what is on screen.
+    await act(async () => { useViewerStore.getState().setIsolatedEntities(new Set([1])); });
+
+    assert.equal(
+      useViewerStore.getState().idsFocusVisibilityOwned?.channel,
+      'isolate',
+      'a content-preserving rewrite must not convert a feature-owned focus into "user" state',
+    );
+    await act(async () => { api!.ids.clearEntitySelection(); });
+    assert.equal(isolated(), null, 'and the release must still work through it');
+  });
+});
+
+// ─── D4: the clear affordance must see BOTH channels ────────────────────────
+
+describe('the "Clear isolation (show all)" affordance follows the presentation, not one channel', () => {
+  it('D4: a row focus in the DEFAULT ghost mode leaves the clear action enabled', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'ghost'); });
+
+    assert.deepEqual(ghosted(), [1], 'setup: the model is faded around element 1');
+    assert.equal(isolated(), null, 'setup: ghosting and isolation are mutually exclusive');
+    assert.equal(
+      api!.ids.visibilityFilterActive,
+      true,
+      'the whole model is faded and the panel greys out its only way back — the default mode makes it dead',
+    );
+  });
+
+  it('and it is disabled when neither channel is showing anything', async () => {
+    await seed();
+    assert.equal(api!.ids.visibilityFilterActive, false, 'nothing is isolated or ghosted — nothing to clear');
+  });
+
+  it('clearing really does clear the ghost the default mode installed', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'ghost'); });
+    await act(async () => { api!.ids.clearIsolation(); });
+    assert.equal(ghosted(), null);
+    assert.equal(api!.ids.visibilityFilterActive, false);
+  });
+});
+
+// ─── D5: the PAINT channel is released where visibility is ──────────────────
+
+describe('the row focus tint is handed back wherever the row focus is released', () => {
+  it('D5: a model removal does not leave a focus marker painted for a row that is gone', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    assert.deepEqual(
+      useViewerStore.getState().pendingColorUpdates?.get(1),
+      IDS_FOCUS_COLOR,
+      'setup: the row wears the focus colour',
+    );
+
+    await act(async () => { useViewerStore.getState().removeModel('B'); });
+
+    assert.notDeepEqual(
+      useViewerStore.getState().pendingColorUpdates?.get(1),
+      IDS_FOCUS_COLOR,
+      'the row focus was released on the visibility channel but left painted — a cyan marker for a focus that ended',
+    );
+  });
+
+  it('D5: clearing the report does not leave a focus marker painted for a row that no longer exists', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+
+    await act(async () => { useViewerStore.getState().clearIdsValidationReport(); });
+
+    assert.notDeepEqual(
+      useViewerStore.getState().pendingColorUpdates?.get(1),
+      IDS_FOCUS_COLOR,
+      'the report is gone; the focus tint for one of its rows must not stay on the model',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useIDS.row-focus-modes.test.tsx
+++ b/apps/viewer/src/hooks/useIDS.row-focus-modes.test.tsx
@@ -1,0 +1,415 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-row focus modes for IDS results (#2867), mirroring the clash panel.
+ *
+ * Activating an IDS result row used to do three things — set the active
+ * entity, set the store selection, and frame it. In a large model that is not
+ * enough to FIND the element: it keeps the same report red/green as every
+ * other failing element around it, and nothing hides or fades the context.
+ *
+ * The clash panel already solved exactly this shape (`focusClash`, #1275): a
+ * persistent `highlight` / `isolate` / `ghost` mode, a distinct colour pushed
+ * through the colour-override channel, and an ownership record so the shared
+ * visibility channels can be released without stepping on another feature.
+ * This file drives the IDS equivalent through the REAL `useIDS()` hook and the
+ * REAL store — including the two-way handoff with clash, which shares those
+ * channels.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { IDSValidationReport } from '@ifc-lite/ids';
+import type { Clash } from '@ifc-lite/clash';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { useIDS } from './useIDS.js';
+import { useClash } from './useClash.js';
+import { IDS_FOCUS_COLOR } from './ids/idsColorSystem.js';
+import { releaseOwnedClashVisibility } from '@/lib/clash/visibility-ownership.js';
+
+// ─── Fixture ────────────────────────────────────────────────────────────────
+
+/** Two models, both with `idOffset: 0`, so a global id equals its express id.
+ *  That keeps the assertions about the visibility channels readable — what is
+ *  under test here is ownership and mode, not id arithmetic (covered by
+ *  `useClash.federated-id-offset.test.tsx`). */
+function model(id: string): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore: null,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 0,
+    fileSize: 0,
+    idOffset: 0,
+    maxExpressId: 10,
+  } as unknown as FederatedModel;
+}
+
+/** One specification, two failing entities (1, 2) and one passing (3). */
+function report(): IDSValidationReport {
+  const entity = (expressId: number, passed: boolean) => ({
+    expressId,
+    modelId: 'A',
+    entityType: 'IfcWall',
+    passed,
+    requirementResults: [],
+  });
+  return {
+    document: { specifications: [] },
+    modelInfo: { modelId: 'A', schemaVersion: 'IFC4', entityCount: 3 },
+    timestamp: new Date(0),
+    summary: {
+      totalSpecifications: 1,
+      passedSpecifications: 0,
+      failedSpecifications: 1,
+      totalEntitiesChecked: 3,
+      totalEntitiesPassed: 1,
+      totalEntitiesFailed: 2,
+      overallPassRate: 33,
+    },
+    specificationResults: [
+      {
+        specification: { id: 'spec-1', name: 'Spec 1' },
+        status: 'fail',
+        applicableCount: 3,
+        passedCount: 1,
+        failedCount: 2,
+        passRate: 33,
+        entityResults: [entity(1, false), entity(2, false), entity(3, true)],
+      },
+    ],
+  } as unknown as IDSValidationReport;
+}
+
+const CLASH: Clash = {
+  id: 'clash-1',
+  a: { key: 'A:5', ref: 5, model: 'A', tag: 'IfcWall' },
+  b: { key: 'A:6', ref: 6, model: 'A', tag: 'IfcWall' },
+  rule: 'all-clashes',
+  status: 'hard',
+  distance: -0.5,
+  point: [0.75, 0.5, 0.5],
+  bounds: { min: [0.5, 0, 0], max: [1, 1, 1] },
+  severity: 'major',
+};
+
+// ─── Harness ────────────────────────────────────────────────────────────────
+
+type Api = { ids: ReturnType<typeof useIDS>; clash: ReturnType<typeof useClash> };
+
+let api: Api | null = null;
+let root: Root | null = null;
+
+function Probe(): null {
+  api = { ids: useIDS(), clash: useClash() };
+  return null;
+}
+
+async function seed(withReport = true): Promise<void> {
+  useViewerStore.setState({
+    models: new Map([['A', model('A')], ['B', model('B')]]),
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    hiddenEntities: new Set(),
+    pendingColorUpdates: null,
+    lensAppliedColors: null,
+    idsValidationReport: null,
+    idsActiveEntityId: null,
+    idsIsolateMode: null,
+    idsFocusVisibilityOwned: null,
+    idsFocusMode: 'ghost',
+    clashVisibilityOwned: null,
+    clashSelectedId: null,
+    clashHighlightColors: null,
+  });
+  const container = globalThis.document.createElement('div');
+  globalThis.document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(api, 'the probe must be mounted');
+  if (withReport) {
+    await act(async () => {
+      useViewerStore.getState().setIdsValidationReport(report());
+    });
+  }
+}
+
+beforeEach(() => {
+  api = null;
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+});
+
+const isolated = () => {
+  const s = useViewerStore.getState().isolatedEntities;
+  return s ? [...s].sort((a, b) => a - b) : null;
+};
+const ghosted = () => {
+  const s = useViewerStore.getState().ghostExceptEntities;
+  return s ? [...s].sort((a, b) => a - b) : null;
+};
+
+// ─── The three modes ────────────────────────────────────────────────────────
+
+describe('IDS per-row focus modes (#2867)', () => {
+  it('isolate: activating a row hides everything except that element, and IDS records the claim', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+
+    assert.deepEqual(isolated(), [1], 'isolate mode must isolate exactly the activated element');
+    assert.equal(ghosted(), null, 'isolation and ghosting are mutually exclusive channels');
+    const owned = useViewerStore.getState().idsFocusVisibilityOwned;
+    assert.ok(owned, 'IDS must record what it installed, so it can release only that');
+    assert.equal(owned.channel, 'isolate');
+    assert.deepEqual([...owned.ids], [1]);
+  });
+
+  it('ghost: the element stays solid and the rest fades to context', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'ghost'); });
+
+    assert.deepEqual(ghosted(), [1], 'ghost mode keeps the activated element solid and fades the rest');
+    assert.equal(isolated(), null);
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned?.channel, 'ghost');
+  });
+
+  it('highlight: neither channel is touched, and IDS claims neither', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'highlight'); });
+
+    assert.equal(isolated(), null, 'highlight shows the element in the whole model');
+    assert.equal(ghosted(), null);
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null,
+      'owning nothing is the fact a later release must read — inferring ownership from "a row is active" over-clears');
+    assert.deepEqual(useViewerStore.getState().idsActiveEntityId, { modelId: 'A', expressId: 1 },
+      'a row IS active — the fact an ownership inference would have mistaken for a claim');
+  });
+
+  it('the activated element is painted a colour its failing neighbours do not share', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'highlight'); });
+
+    const colors = useViewerStore.getState().pendingColorUpdates;
+    assert.ok(colors, 'the focus must reach the colour-override channel');
+    assert.deepEqual(colors.get(1), IDS_FOCUS_COLOR,
+      'the activated row is the one the user is hunting for — it cannot wear the same red as every other failure');
+    assert.notDeepEqual(colors.get(2), IDS_FOCUS_COLOR,
+      'and its equally-failing neighbour must keep the report colour, or the focus colour says nothing');
+    assert.ok(colors.get(2), 'the rest of the report stays coloured — the focus adds to it, it does not replace it');
+  });
+});
+
+// ─── Switching rows and modes ───────────────────────────────────────────────
+
+describe('IDS row focus releases its own previous presentation', () => {
+  it('switching ROWS isolates only the new row, never the union', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    await act(async () => { api!.ids.focusEntity('A', 2, 'isolate'); });
+
+    assert.deepEqual(isolated(), [2], 'the previous row must not accumulate');
+    const colors = useViewerStore.getState().pendingColorUpdates;
+    assert.deepEqual(colors?.get(2), IDS_FOCUS_COLOR, 'the new row wears the focus colour');
+    assert.notDeepEqual(colors?.get(1), IDS_FOCUS_COLOR, 'and the previous row gives it back');
+  });
+
+  it('switching MODES on the same row moves the claim to the other channel', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    await act(async () => { api!.ids.focusEntity('A', 1, 'ghost'); });
+
+    assert.equal(isolated(), null, 'the isolation the previous mode installed must go');
+    assert.deepEqual(ghosted(), [1]);
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned?.channel, 'ghost');
+  });
+
+  it('switching to HIGHLIGHT releases the isolation the row focus itself installed', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    await act(async () => { api!.ids.focusEntity('A', 1, 'highlight'); });
+
+    assert.equal(isolated(), null,
+      'an isolation left standing after the user asked for full context hides the model with no way to tell why');
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null);
+  });
+
+  it('clearing the row selection releases the row focus presentation', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    await act(async () => { api!.ids.clearEntitySelection(); });
+
+    assert.equal(isolated(), null, 'deactivating the row must not leave the model isolated on it');
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null);
+  });
+
+  it('ownership is CONTENT: a later owner of the same channel is not released by IDS', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'ghost'); });
+    assert.deepEqual(ghosted(), [1], 'setup sanity: IDS owns the ghost channel');
+
+    // Another feature (the spaces X-ray, LayerDiffView, Space Sketch) takes the
+    // SAME channel over. Deliberately a SUPERSET of what IDS installed: a
+    // subset test, or "is my record's channel non-empty", both answer "still
+    // mine" here and destroy this owner's ghost. Only equal MEMBERS mean it is
+    // still the IDS row focus on screen.
+    await act(async () => { useViewerStore.getState().setGhostExceptEntities(new Set([1, 9])); });
+
+    await act(async () => { api!.ids.clearEntitySelection(); });
+
+    assert.deepEqual(ghosted(), [1, 9],
+      "IDS installed {1}, the channel shows {1, 9} — that is somebody else's presentation and must survive");
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null,
+      'IDS still drops its own stale claim');
+  });
+
+  it('a NEW report landing ends the row focus built from the old one', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+
+    // A re-run publishes a fresh report. The focused row belonged to the
+    // previous one, and its express ids need not denote the same entities.
+    await act(async () => { useViewerStore.getState().setIdsValidationReport(report()); });
+
+    assert.equal(isolated(), null,
+      'an isolation built from the superseded report must not survive the report that replaced it');
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null);
+  });
+
+  it('clearing the report releases the row focus presentation (no stranded blank viewport)', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    await act(async () => { api!.ids.clearValidation(); });
+
+    assert.equal(isolated(), null,
+      'the report is gone; an isolation built from it left standing makes isEntityVisible false for everything');
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null,
+      'and the claim must not outlive the presentation — a stale record re-matches as soon as another owner installs equal content');
+  });
+});
+
+describe('IDS row focus and IDS set-level isolation are one presentation at a time', () => {
+  it("a row focus that takes the channel clears the isolate buttons' pressed state", async () => {
+    await seed();
+    await act(async () => { api!.ids.isolateFailed(); });
+    assert.deepEqual(isolated(), [1, 2], 'setup sanity: the set-level isolation is showing');
+    assert.equal(useViewerStore.getState().idsIsolateMode, 'failed');
+
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+
+    assert.deepEqual(isolated(), [1], 'the row focus replaced the set isolation on screen');
+    assert.equal(useViewerStore.getState().idsIsolateMode, null,
+      'so the isolate-failed button must stop reading as pressed — it describes an isolation that is no longer there');
+  });
+
+  it('a set-level isolate taking the channel back drops the row focus claim', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    await act(async () => { api!.ids.isolateFailed(); });
+
+    assert.deepEqual(isolated(), [1, 2], 'setup sanity: the set isolation replaced the row focus');
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null,
+      'the row focus no longer owns anything — a record left behind re-matches as soon as another owner installs equal content');
+  });
+
+  it('show-all ends a row GHOST as well, claim included', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'ghost'); });
+    await act(async () => { api!.ids.clearIsolation(); });
+
+    // `setIsolatedEntities(null)` nulls `ghostExceptEntities` too — the two
+    // channels are mutually exclusive (visibilitySlice) — so "show all" really
+    // does show all, and the claim goes with it.
+    assert.equal(ghosted(), null, 'a row ghost must not survive the button that says "show all"');
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null,
+      'and the claim must not outlive it');
+  });
+});
+
+// ─── The two-way handoff with clash ─────────────────────────────────────────
+
+describe('IDS and clash share the visibility channels — neither may strand the other', () => {
+  it('IDS → CLASH: clash taking the channel over survives an IDS row-focus release', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    // Clash takes the channel over with its own content.
+    await act(async () => { api!.clash.focusClash(CLASH, 'ghost'); });
+    assert.deepEqual(ghosted(), [5, 6], 'setup sanity: clash owns the ghost channel now');
+
+    // The IDS row is deactivated. Its record still names `isolate`, but the
+    // channel no longer shows what IDS installed.
+    await act(async () => { api!.ids.clearEntitySelection(); });
+
+    assert.deepEqual(ghosted(), [5, 6],
+      "IDS must release only what IDS installed — clearing by feature rather than by content destroys clash's ghost");
+    assert.equal(useViewerStore.getState().clashVisibilityOwned?.channel, 'ghost',
+      "and clash's own claim must be left intact");
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null,
+      'IDS still drops its own (now stale) claim — a record that outlives its presentation re-matches later');
+  });
+
+  it('CLASH → IDS: an IDS row focus survives clash\'s ownership-scoped release', async () => {
+    await seed();
+    await act(async () => { api!.clash.focusClash(CLASH, 'ghost'); });
+    // IDS takes the channel over with its own content.
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    assert.deepEqual(isolated(), [1], 'setup sanity: IDS owns the isolate channel now');
+    assert.equal(useViewerStore.getState().clashVisibilityOwned?.channel, 'ghost',
+      "setup sanity: clash's record is now stale — its ghost was replaced");
+
+    // `releaseOwnedClashVisibility` is the ONE predicate every ownership-scoped
+    // clash release routes through — the run-start release
+    // (`useClash.discardSolidPresentation`) and every model-lifecycle teardown
+    // (`endClashScenePresentation`). Driven directly because a `run()` needs
+    // real meshed geometry; the predicate is what both paths actually ask.
+    //
+    // NOT `clearHighlight()`: that is the panel's "Clear selection, isolation
+    // and ghosting" button, which clears both channels outright BY DESIGN and
+    // is a user asking for exactly that — see its body in `useClash`.
+    await act(async () => { releaseOwnedClashVisibility(useViewerStore.getState()); });
+
+    assert.deepEqual(isolated(), [1],
+      "clash releases only what clash installed — the IDS row focus is a different owner's presentation");
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned?.channel, 'isolate',
+      "and IDS's claim must be left intact");
+    assert.equal(useViewerStore.getState().clashVisibilityOwned, null,
+      'clash still drops its own stale claim');
+  });
+
+  it('a model removal releases the IDS row focus rather than stranding it', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+
+    await act(async () => { useViewerStore.getState().removeModel('B'); });
+
+    assert.equal(isolated(), null,
+      'an IDS-owned isolation surviving a model removal is a blank viewport with nothing selected');
+    assert.equal(useViewerStore.getState().idsFocusVisibilityOwned, null);
+  });
+
+  it('a model removal does NOT release a channel IDS does not own', async () => {
+    await seed();
+    await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
+    // Another feature (the spaces X-ray, LayerDiffView, Space Sketch) takes over.
+    await act(async () => { useViewerStore.getState().setGhostExceptEntities(new Set([9])); });
+
+    await act(async () => { useViewerStore.getState().removeModel('B'); });
+
+    assert.deepEqual(ghosted(), [9],
+      "IDS never installed this ghost — releasing it would destroy the next owner's presentation (#2654)");
+  });
+});

--- a/apps/viewer/src/hooks/useIDS.row-focus-modes.test.tsx
+++ b/apps/viewer/src/hooks/useIDS.row-focus-modes.test.tsx
@@ -368,8 +368,14 @@ describe('IDS and clash share the visibility channels — neither may strand the
     // IDS takes the channel over with its own content.
     await act(async () => { api!.ids.focusEntity('A', 1, 'isolate'); });
     assert.deepEqual(isolated(), [1], 'setup sanity: IDS owns the isolate channel now');
-    assert.equal(useViewerStore.getState().clashVisibilityOwned?.channel, 'ghost',
-      "setup sanity: clash's record is now stale — its ghost was replaced");
+    // CORRECTED (review of #2867): this used to assert clash's record was left
+    // STALE here — "its ghost was replaced" — as setup sanity. That staleness
+    // was the D3 defect, not a property worth pinning: a record outliving its
+    // presentation re-matches as soon as a third owner installs equal content.
+    // `setIsolatedEntities` now drops every record its write invalidates
+    // (visibilitySlice), symmetrically for both subsystems.
+    assert.equal(useViewerStore.getState().clashVisibilityOwned, null,
+      "setup sanity: clash's claim ended when IDS replaced its ghost");
 
     // `releaseOwnedClashVisibility` is the ONE predicate every ownership-scoped
     // clash release routes through — the run-start release

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -110,8 +110,23 @@ export interface UseIDSResult {
    * (#2867) — the clash panel's three focus modes, applied per IDS row.
    */
   focusMode: IDSFocusMode;
-  /** True when any entity isolation is currently active in the 3D view */
+  /** True when an entity ISOLATION is currently active in the 3D view. Reads
+   *  the isolate channel alone, because the isolate-failed / passed / involved
+   *  buttons derive their pressed state from it and those buttons install
+   *  isolation specifically. */
   isolationActive: boolean;
+  /**
+   * True when EITHER shared visibility channel is showing something — the
+   * state "Clear isolation (show all)" exists to undo.
+   *
+   * Not `isolationActive`: the row focus's DEFAULT mode is `ghost`, and
+   * `setGhostExceptEntities` nulls `isolatedEntities` (the two channels are
+   * mutually exclusive — visibilitySlice). Gating the clear button on the
+   * isolate channel alone therefore greyed out the panel's only way back while
+   * the whole model was faded around one element — the default path, on the
+   * default mode. `ClashPanel`'s equivalent has never had that gate.
+   */
+  visibilityFilterActive: boolean;
   /** Display options */
   displayOptions: {
     highlightFailed: boolean;
@@ -278,6 +293,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const setSelectedEntity = useViewerStore((s) => s.setSelectedEntity);
   const setIsolatedEntities = useViewerStore((s) => s.setIsolatedEntities);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
+  const ghostExceptEntities = useViewerStore((s) => s.ghostExceptEntities);
   const toGlobalId = useViewerStore((s) => s.toGlobalId);
   const cameraCallbacks = useViewerStore((s) => s.cameraCallbacks);
   const geometryResult = useViewerStore((s) => s.geometryResult);
@@ -644,8 +660,15 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
    * exactly what was installed so the release can release only that.
    *
    * Mirrors `useClash.installClashIsolation`, including the read-BACK: the
-   * slice setter clones, and the record must hold what the channel actually
-   * shows, or ownership (tested by value) would never match again.
+   * record holds the SET THE CHANNEL ENDED UP WITH, not the argument.
+   *
+   * Under value equality those two are interchangeable today — the setter
+   * clones the argument, so recording the argument instead is an equivalent
+   * mutant (verified: it survives). The read-back is what stops that from
+   * being a property this code depends on: `null` for "the channel refused the
+   * install" is expressible, and a setter that ever normalised what it stores
+   * (dropping unknown ids, say) would silently make the argument a claim on
+   * something that is not on screen.
    */
   const installFocusIsolation = useCallback((ids: Set<number>): void => {
     const state = useViewerStore.getState();
@@ -1342,6 +1365,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     isolateMode,
     focusMode,
     isolationActive: isolatedEntities != null,
+    visibilityFilterActive: isolatedEntities != null || ghostExceptEntities != null,
     displayOptions,
 
     // Document actions

--- a/apps/viewer/src/hooks/useIDS.ts
+++ b/apps/viewer/src/hooks/useIDS.ts
@@ -45,9 +45,12 @@ import { runValidationInWorker, idsWorkerSupported } from './ids/idsWorkerClient
 import {
   DEFAULT_FAILED_COLOR,
   DEFAULT_PASSED_COLOR,
+  IDS_FOCUS_COLOR,
   buildValidationColorUpdates,
   buildRestoreColorUpdates,
 } from './ids/idsColorSystem';
+import { releaseOwnedIdsFocusVisibility } from '@/lib/ids/visibility-ownership';
+import type { IDSFocusMode } from '@/store/slices/idsSlice';
 import type { ColorTuple } from './ids/idsColorSystem';
 import { downloadReportJSON, downloadReportHTML } from './ids/idsExportService';
 import { posthog } from '../lib/analytics';
@@ -102,6 +105,11 @@ export interface UseIDSResult {
   isolationScope: 'ids' | 'spec';
   /** Which isolate action is currently applied by IDS (null = none) */
   isolateMode: 'failed' | 'passed' | 'involved' | null;
+  /**
+   * How activating a single result row presents the rest of the model
+   * (#2867) — the clash panel's three focus modes, applied per IDS row.
+   */
+  focusMode: IDSFocusMode;
   /** True when any entity isolation is currently active in the 3D view */
   isolationActive: boolean;
   /** Display options */
@@ -129,8 +137,17 @@ export interface UseIDSResult {
   // Selection actions
   /** Set active specification for filtering */
   setActiveSpecification: (specId: string | null) => void;
-  /** Select an entity from results (syncs to 3D view and zooms) */
-  selectEntity: (modelId: string, expressId: number, zoomToEntity?: boolean) => void;
+  /**
+   * Activate an entity from the results: select it, paint it a colour its
+   * peers do not share, frame it, and present the rest of the model according
+   * to `mode` (defaults to the persistent `focusMode`) — #2867.
+   */
+  focusEntity: (
+    modelId: string,
+    expressId: number,
+    mode?: IDSFocusMode,
+    zoomToEntity?: boolean,
+  ) => void;
   /** Clear entity selection */
   clearEntitySelection: () => void;
 
@@ -145,6 +162,8 @@ export interface UseIDSResult {
   setFilterMode: (mode: 'all' | 'failed' | 'passed') => void;
   /** Set the isolation/color scope (whole report vs active spec) */
   setIsolationScope: (scope: 'ids' | 'spec') => void;
+  /** Set the per-row focus mode, and re-apply it to the active row (#2867) */
+  setFocusMode: (mode: IDSFocusMode) => void;
   /** Update display options */
   setDisplayOptions: (options: Partial<UseIDSResult['displayOptions']>) => void;
 
@@ -222,6 +241,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const filterMode = useViewerStore((s) => s.idsFilterMode);
   const isolationScope = useViewerStore((s) => s.idsIsolationScope);
   const isolateMode = useViewerStore((s) => s.idsIsolateMode);
+  const focusMode = useViewerStore((s) => s.idsFocusMode);
   const displayOptions = useViewerStore((s) => s.idsDisplayOptions);
 
   // IDS store actions
@@ -242,6 +262,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   const setIdsFilterMode = useViewerStore((s) => s.setIdsFilterMode);
   const setIdsIsolationScope = useViewerStore((s) => s.setIdsIsolationScope);
   const setIdsIsolateMode = useViewerStore((s) => s.setIdsIsolateMode);
+  const setIdsFocusMode = useViewerStore((s) => s.setIdsFocusMode);
   const setIdsDisplayOptions = useViewerStore((s) => s.setIdsDisplayOptions);
   const idsFailedEntityIds = useViewerStore((s) => s.idsFailedEntityIds);
   const idsPassedEntityIds = useViewerStore((s) => s.idsPassedEntityIds);
@@ -531,41 +552,8 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   // Selection Actions
   // ============================================================================
 
-  const selectEntity = useCallback((modelId: string, expressId: number, zoomToEntity = true) => {
-
-    // Update IDS state
-    setIdsActiveEntity({ modelId, expressId });
-
-    // Sync to viewer selection
-    // Handle legacy mode vs federation mode
-    const isLegacyMode = modelId === '__legacy__' || modelId === 'legacy' || models.size === 0;
-
-    if (isLegacyMode) {
-      // Legacy mode: globalId equals expressId, use 'legacy' for selection
-      setSelectedEntityId(expressId);
-      // Use 'legacy' as the modelId for PropertiesPanel compatibility
-      setSelectedEntity({ modelId: 'legacy', expressId });
-    } else {
-      // Federation mode: use the store helper so ID resolution stays centralized.
-      const globalId = toViewerGlobalId(modelId, expressId);
-      if (globalId == null) return;
-      setSelectedEntityId(globalId);
-      setSelectedEntity({ modelId, expressId });
-    }
-
-    // Zoom to entity after a small delay to ensure selection is processed
-    if (zoomToEntity && cameraCallbacks.frameSelection) {
-      setTimeout(() => {
-        cameraCallbacks.frameSelection?.();
-      }, 50);
-    }
-  }, [setIdsActiveEntity, setSelectedEntityId, setSelectedEntity, models, cameraCallbacks, toViewerGlobalId]);
-
-  const clearEntitySelection = useCallback(() => {
-    setIdsActiveEntity(null);
-    setSelectedEntityId(null);
-    setSelectedEntity(null);
-  }, [setIdsActiveEntity, setSelectedEntityId, setSelectedEntity]);
+  // `focusEntity` / `clearEntitySelection` live further down, after the colour
+  // helpers they build on (`buildColors`) — see "Row Focus (#2867)".
 
   // ============================================================================
   // UI Actions
@@ -646,6 +634,174 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     originalColorsRef.current.clear();
   }, [setPendingColorUpdates]);
 
+
+  // ============================================================================
+  // Row Focus (#2867)
+  // ============================================================================
+
+  /**
+   * Install the row focus's isolation into the SHARED channel, recording
+   * exactly what was installed so the release can release only that.
+   *
+   * Mirrors `useClash.installClashIsolation`, including the read-BACK: the
+   * slice setter clones, and the record must hold what the channel actually
+   * shows, or ownership (tested by value) would never match again.
+   */
+  const installFocusIsolation = useCallback((ids: Set<number>): void => {
+    const state = useViewerStore.getState();
+    state.setIsolatedEntities(ids);
+    const installed = useViewerStore.getState().isolatedEntities;
+    state.setIdsFocusVisibilityOwned(installed ? { channel: 'isolate', ids: installed } : null);
+  }, []);
+
+  /** Install the row focus's ghosting (X-Ray context) into the shared channel,
+   *  with the same install-record contract as `installFocusIsolation`. */
+  const installFocusGhost = useCallback((ids: Set<number>): void => {
+    const state = useViewerStore.getState();
+    state.setGhostExceptEntities(ids);
+    const installed = useViewerStore.getState().ghostExceptEntities;
+    state.setIdsFocusVisibilityOwned(installed ? { channel: 'ghost', ids: installed } : null);
+  }, []);
+
+  /**
+   * Release the isolation/ghost the ROW FOCUS itself installed — and only
+   * that. A clash focus, a spaces X-ray, "Isolate in 3D" or IDS's own
+   * set-level isolate buttons occupying the channel instead do not
+   * content-match the record and survive untouched.
+   */
+  const releaseFocusVisibility = useCallback((): void => {
+    releaseOwnedIdsFocusVisibility(useViewerStore.getState());
+  }, []);
+
+  /**
+   * The colour overlay the report is currently showing, with the focused row
+   * (if any) repainted in {@link IDS_FOCUS_COLOR}.
+   *
+   * The focus colour is ADDED to the report overlay rather than replacing it:
+   * the surrounding red/green is the context that makes "this one is the row I
+   * clicked" mean anything. Scoped exactly as the isolate actions are — the
+   * active spec's own verdict in 'spec' scope, the whole report otherwise — so
+   * activating a row never silently changes which verdict is on screen.
+   *
+   * Does nothing without a report: IDS is not colouring then, and pushing a
+   * map here would take the colour-override channel away from whoever is (a
+   * lens, clash) — the same reason `restoreReportColors` returns early.
+   */
+  const paintFocus = useCallback((focusedGlobalId: number | null): void => {
+    if (!report) return;
+    const colors = isolationScope === 'spec' && activeSpecificationId
+      ? buildColors(activeSpecificationId, true)
+      : buildColors();
+    if (focusedGlobalId != null) colors.set(focusedGlobalId, IDS_FOCUS_COLOR);
+    setPendingColorUpdates(colors);
+  }, [report, isolationScope, activeSpecificationId, buildColors, setPendingColorUpdates]);
+
+  /**
+   * Apply a focus mode to the activated row's element in the shared visibility
+   * channels — the IDS spelling of `useClash.applyFocusMode`:
+   *
+   * - `highlight`: release whatever the row focus itself installed, and take
+   *   no claim. Unlike clash's `highlight`, this does NOT clear both channels
+   *   outright: IDS has set-level isolation of its own (`isolateFailed` and
+   *   friends) that the user may have established deliberately, and clicking a
+   *   row must not silently discard it. Releasing by ownership discards the
+   *   previous ROW presentation and nothing else.
+   * - `isolate`: hide everything except the activated element.
+   * - `ghost`:   keep it solid and fade the rest to translucent context.
+   *
+   * A row focus that installs into a channel supersedes any set-level
+   * isolation that was showing (both slice setters replace the channel
+   * wholesale), so `idsIsolateMode` is cleared with it — otherwise the isolate
+   * buttons keep a pressed state for an isolation no longer on screen.
+   */
+  const applyFocusMode = useCallback((globalId: number, mode: IDSFocusMode): void => {
+    if (mode === 'highlight') {
+      releaseFocusVisibility();
+      return;
+    }
+    if (mode === 'isolate') installFocusIsolation(new Set([globalId]));
+    else installFocusGhost(new Set([globalId]));
+    setIdsIsolateMode(null);
+  }, [releaseFocusVisibility, installFocusIsolation, installFocusGhost, setIdsIsolateMode]);
+
+  const focusEntity = useCallback((
+    modelId: string,
+    expressId: number,
+    mode: IDSFocusMode = focusMode,
+    zoomToEntity = true,
+  ) => {
+    // Update IDS state
+    setIdsActiveEntity({ modelId, expressId });
+
+    // Sync to viewer selection
+    // Handle legacy mode vs federation mode
+    const isLegacyMode = modelId === '__legacy__' || modelId === 'legacy' || models.size === 0;
+
+    if (isLegacyMode) {
+      // Legacy mode: globalId equals expressId, use 'legacy' for selection
+      setSelectedEntityId(expressId);
+      // Use 'legacy' as the modelId for PropertiesPanel compatibility
+      setSelectedEntity({ modelId: 'legacy', expressId });
+    } else {
+      // Federation mode: use the store helper so ID resolution stays centralized.
+      const federatedId = toViewerGlobalId(modelId, expressId);
+      if (federatedId == null) return;
+      setSelectedEntityId(federatedId);
+      setSelectedEntity({ modelId, expressId });
+    }
+
+    // The isolation / ghost / colour-override channels are all keyed by GLOBAL
+    // id — the same id the selection above carries.
+    const globalId = toViewerGlobalId(modelId, expressId);
+    if (globalId != null) {
+      applyFocusMode(globalId, mode);
+      // Selection alone is an outline; in a crowd of equally-red failures that
+      // is exactly what the user reported they cannot find (#2867). The colour
+      // override repaints the albedo, so it also survives batched and
+      // GPU-instanced geometry.
+      paintFocus(globalId);
+    }
+
+    // Zoom to entity after a small delay to ensure selection is processed
+    if (zoomToEntity && cameraCallbacks.frameSelection) {
+      setTimeout(() => {
+        cameraCallbacks.frameSelection?.();
+      }, 50);
+    }
+  }, [
+    focusMode,
+    setIdsActiveEntity,
+    setSelectedEntityId,
+    setSelectedEntity,
+    models,
+    cameraCallbacks,
+    toViewerGlobalId,
+    applyFocusMode,
+    paintFocus,
+  ]);
+
+  /** Switch the focus mode and immediately re-apply it to the active row, so
+   *  the change is visible without re-clicking the row (mirrors
+   *  `ClashPanel.changeFocusMode`, #1275). Re-framing is suppressed: the user
+   *  is changing how they look at the row they are already on, not asking to
+   *  travel to it again. */
+  const setFocusModeAction = useCallback((mode: IDSFocusMode) => {
+    setIdsFocusMode(mode);
+    const active = useViewerStore.getState().idsActiveEntityId;
+    if (active) focusEntity(active.modelId, active.expressId, mode, false);
+  }, [setIdsFocusMode, focusEntity]);
+
+  const clearEntitySelection = useCallback(() => {
+    setIdsActiveEntity(null);
+    setSelectedEntityId(null);
+    setSelectedEntity(null);
+    // The row focus's presentation ends with the row: its isolation/ghost is
+    // released by ownership (so another feature's is left alone), and the
+    // focus tint is repainted back to the plain report overlay.
+    releaseFocusVisibility();
+    paintFocus(null);
+  }, [setIdsActiveEntity, setSelectedEntityId, setSelectedEntity, releaseFocusVisibility, paintFocus]);
+
   // Ref to store applyColors for stable useEffect (prevents infinite loops)
   const applyColorsRef = useRef(applyColors);
   applyColorsRef.current = applyColors;
@@ -693,12 +849,25 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     return ids;
   }, [keyToGlobalId]);
 
+  /**
+   * Install a SET-level isolation (the isolate-failed / passed / involved
+   * buttons). Unowned, exactly as before — but it replaces the channel
+   * wholesale, so any ROW-focus claim on it is now stale and must be dropped:
+   * a record that outlives its presentation starts matching again the moment
+   * another owner installs equal content, and the next release then destroys
+   * THAT owner's presentation (#2654 fourth review).
+   */
+  const installSetIsolation = useCallback((ids: Set<number> | null) => {
+    setIsolatedEntities(ids);
+    useViewerStore.getState().setIdsFocusVisibilityOwned(null);
+  }, [setIsolatedEntities]);
+
   const isolateFailed = useCallback(() => {
     if (isolationScope === 'spec') {
       if (!activeSpecificationId) return;
       const ids = refsToGlobalIds(getFailedEntitiesForSpec(activeSpecificationId));
       if (ids.size > 0) {
-        setIsolatedEntities(ids);
+        installSetIsolation(ids);
         setSpecColors(activeSpecificationId);
         setIdsIsolateMode('failed');
       }
@@ -706,7 +875,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     }
     const failedIds = keySetToGlobalIds(idsFailedEntityIds);
     if (failedIds.size > 0) {
-      setIsolatedEntities(failedIds);
+      installSetIsolation(failedIds);
       setIdsIsolateMode('failed');
     }
   }, [
@@ -716,7 +885,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     refsToGlobalIds,
     keySetToGlobalIds,
     idsFailedEntityIds,
-    setIsolatedEntities,
+    installSetIsolation,
     setSpecColors,
     setIdsIsolateMode,
   ]);
@@ -726,7 +895,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
       if (!activeSpecificationId) return;
       const ids = refsToGlobalIds(getPassedEntitiesForSpec(activeSpecificationId));
       if (ids.size > 0) {
-        setIsolatedEntities(ids);
+        installSetIsolation(ids);
         setSpecColors(activeSpecificationId);
         setIdsIsolateMode('passed');
       }
@@ -734,7 +903,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     }
     const passedIds = keySetToGlobalIds(idsPassedEntityIds);
     if (passedIds.size > 0) {
-      setIsolatedEntities(passedIds);
+      installSetIsolation(passedIds);
       setIdsIsolateMode('passed');
     }
   }, [
@@ -744,7 +913,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     refsToGlobalIds,
     keySetToGlobalIds,
     idsPassedEntityIds,
-    setIsolatedEntities,
+    installSetIsolation,
     setSpecColors,
     setIdsIsolateMode,
   ]);
@@ -757,7 +926,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
         ...getPassedEntitiesForSpec(targetSpec),
       ]);
       if (ids.size > 0) {
-        setIsolatedEntities(ids);
+        installSetIsolation(ids);
         setSpecColors(targetSpec);
         setIdsIsolateMode('involved');
       } else {
@@ -765,7 +934,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
         // nothing to isolate, so drop any stale isolation/overlay left by a
         // previously selected spec rather than leaving it on screen while
         // the panel points at this (empty) spec.
-        setIsolatedEntities(null);
+        installSetIsolation(null);
         restoreReportColors();
         setIdsIsolateMode(null);
       }
@@ -776,7 +945,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     const ids = keySetToGlobalIds(idsFailedEntityIds);
     for (const globalId of keySetToGlobalIds(idsPassedEntityIds)) ids.add(globalId);
     if (ids.size > 0) {
-      setIsolatedEntities(ids);
+      installSetIsolation(ids);
       setPendingColorUpdates(buildColors(undefined, true));
       setIdsIsolateMode('involved');
     }
@@ -789,7 +958,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     keySetToGlobalIds,
     idsFailedEntityIds,
     idsPassedEntityIds,
-    setIsolatedEntities,
+    installSetIsolation,
     setSpecColors,
     restoreReportColors,
     setPendingColorUpdates,
@@ -798,12 +967,18 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
   ]);
 
   const clearIsolation = useCallback(() => {
-    setIsolatedEntities(null);
+    // "Show all" ends the ROW focus's presentation too, both channels of it:
+    // `setIsolatedEntities(null)` nulls `ghostExceptEntities` as well (the two
+    // are mutually exclusive — see visibilitySlice), so a row GHOST goes with
+    // a row isolation, and `installSetIsolation` drops the row focus's claim
+    // with it. No separate ownership-scoped release is needed here, and an
+    // added one would be dead code: verified by mutation.
+    installSetIsolation(null);
     // Returning to "show all" restores the default whole-report coloring,
     // replacing any per-spec green/red applied while isolated.
     restoreReportColors();
     setIdsIsolateMode(null);
-  }, [setIsolatedEntities, restoreReportColors, setIdsIsolateMode]);
+  }, [installSetIsolation, restoreReportColors, setIdsIsolateMode]);
 
   const setActiveSpecification = useCallback((specId: string | null) => {
     setIdsActiveSpecification(specId);
@@ -1165,6 +1340,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     filterMode,
     isolationScope,
     isolateMode,
+    focusMode,
     isolationActive: isolatedEntities != null,
     displayOptions,
 
@@ -1179,7 +1355,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
 
     // Selection actions
     setActiveSpecification,
-    selectEntity,
+    focusEntity,
     clearEntitySelection,
 
     // UI actions
@@ -1188,6 +1364,7 @@ export function useIDS(options: UseIDSOptions = {}): UseIDSResult {
     setLocale,
     setFilterMode: setFilterModeAction,
     setIsolationScope,
+    setFocusMode: setFocusModeAction,
     setDisplayOptions: setDisplayOptionsAction,
 
     // Color actions

--- a/apps/viewer/src/lib/clash/visibility-ownership.ts
+++ b/apps/viewer/src/lib/clash/visibility-ownership.ts
@@ -112,7 +112,15 @@ export interface ClashVisibilityChannels {
  *   the paint channel too (see `endClashScenePresentation`).
  */
 export function releaseOwnedClashVisibility(state: ClashVisibilityChannels): boolean {
-  const stillOurs = releaseOwnedVisibility(state, state.clashVisibilityOwned ?? null);
+  const owned = state.clashVisibilityOwned ?? null;
+  // No record: nothing to release, and nothing to drop. This early return is
+  // load-bearing for the "delegating to `lib/visibility/ownership.ts` kept the
+  // API and the channel effects unchanged" claim: without it, every
+  // ownership-free release path commits a fresh store state (and notifies every
+  // subscriber) writing `null` over `null`, and several of them run on every
+  // model removal. Return values were never the difference (#2867 review).
+  if (!owned) return false;
+  const stillOurs = releaseOwnedVisibility(state, owned);
   state.setClashVisibilityOwned?.(null);
   return stillOurs;
 }

--- a/apps/viewer/src/lib/clash/visibility-ownership.ts
+++ b/apps/viewer/src/lib/clash/visibility-ownership.ts
@@ -41,6 +41,12 @@
  * ownership bookkeeping for the same channels.
  */
 
+import {
+  releaseOwnedVisibility,
+  sameMembers,
+  type VisibilityOwnership,
+} from '../visibility/ownership.js';
+
 /**
  * What clash last installed into a shared visibility channel, and which one.
  * `null` means clash owns neither channel — including after a `highlight`-mode
@@ -49,35 +55,19 @@
  * The installed CONTENT is kept, not just the channel name, because ownership
  * is tested by value: see `releaseOwnedClashVisibility`.
  */
-export type ClashVisibilityOwnership =
-  | { channel: 'ghost' | 'isolate'; ids: ReadonlySet<number> }
-  | null;
+export type ClashVisibilityOwnership = VisibilityOwnership;
 
 /**
- * Content equality for the ownership record. The shared channels are only ever
- * REPLACED wholesale (every slice setter stores a fresh `Set`), never mutated
- * in place, so equal members mean the channel still shows exactly the
- * presentation clash installed.
+ * Content equality for the ownership record — re-exported from
+ * `lib/visibility/ownership.ts`, which now holds the one implementation.
  *
- * Ownership is tested by VALUE, not by `Set` reference: reference identity
- * would be exact, but it is destroyed by every flow that snapshots and later
- * restores the channel with equal content in a fresh `Set` — Space Sketch's
- * open/close view capture (`useSpaceSceneFraming` clones the prior sets and
- * replays them through the cloning slice setters) and a source-model resync
- * (`syncSourceModel` rebuilds the kept sets even when nothing was filtered).
- * Under reference identity those flows silently converted a clash-owned focus
- * into "user" state, so the next run replaced the result set but left the old
- * pair isolated/ghosted (#2662 P2). Value identity survives any content-
- * preserving rewrite, and its one false positive is harmless by construction:
- * it only fires when the channel shows EXACTLY the presentation clash
- * installed, in which case releasing it renders precisely what discarding the
- * clash focus should render.
+ * IDS's per-row focus (#2867) records and releases its own claim on the same
+ * two channels, and two subsystems arbitrating the same channel with two
+ * copies of the same predicate is precisely the shape that drifts. See that
+ * module's doc for WHY ownership is tested by value and not by `Set`
+ * reference (#2662 P2).
  */
-export function sameMembers(a: ReadonlySet<number>, b: ReadonlySet<number>): boolean {
-  if (a.size !== b.size) return false;
-  for (const id of a) if (!b.has(id)) return false;
-  return true;
-}
+export { sameMembers };
 
 /** The store surface `releaseOwnedClashVisibility` reads and writes. Every
  *  member is optional: `modelSlice`'s own tests drive the model actions through
@@ -122,17 +112,7 @@ export interface ClashVisibilityChannels {
  *   the paint channel too (see `endClashScenePresentation`).
  */
 export function releaseOwnedClashVisibility(state: ClashVisibilityChannels): boolean {
-  const owned = state.clashVisibilityOwned ?? null;
-  if (!owned) return false;
-  const current =
-    owned.channel === 'isolate'
-      ? state.isolatedEntities ?? null
-      : state.ghostExceptEntities ?? null;
-  const stillOurs = current !== null && sameMembers(current, owned.ids);
-  if (stillOurs) {
-    if (owned.channel === 'isolate') state.clearIsolation?.();
-    else state.clearGhost?.();
-  }
+  const stillOurs = releaseOwnedVisibility(state, state.clashVisibilityOwned ?? null);
   state.setClashVisibilityOwned?.(null);
   return stillOurs;
 }

--- a/apps/viewer/src/lib/ids/visibility-ownership.test.ts
+++ b/apps/viewer/src/lib/ids/visibility-ownership.test.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `releaseOwnedIdsFocusVisibility`'s own contract, over the surface it is
+ * actually typed for — a plain object with every member optional, not the
+ * combined store.
+ *
+ * The store now invalidates ownership records at its `set`
+ * (`store/visibility-invalidation.ts`), so when this function DOES release a
+ * channel through the live store, the record would be dropped for it anyway.
+ * That is what makes `state.setIdsFocusVisibilityOwned?.(null)` invisible to
+ * every store-driven test, and an untested line is a line that gets deleted.
+ * It is not redundant here: the "still ours?" answer can be NO — in which case
+ * nothing is written, nothing invalidates, and the drop is the only thing
+ * standing between a mismatched record and the next owner of that content
+ * (#2654 fourth review).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  releaseOwnedIdsFocusVisibility,
+  type IDSFocusVisibilityChannels,
+  type IDSFocusVisibilityOwnership,
+} from './visibility-ownership.js';
+
+function channels(over: Partial<IDSFocusVisibilityChannels> = {}): {
+  state: IDSFocusVisibilityChannels;
+  recorded: IDSFocusVisibilityOwnership[];
+  cleared: string[];
+} {
+  const recorded: IDSFocusVisibilityOwnership[] = [];
+  const cleared: string[] = [];
+  const state: IDSFocusVisibilityChannels = {
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    clearIsolation: () => { cleared.push('isolate'); },
+    clearGhost: () => { cleared.push('ghost'); },
+    setIdsFocusVisibilityOwned: (owned) => { recorded.push(owned); },
+    ...over,
+  };
+  return { state, recorded, cleared };
+}
+
+describe('releaseOwnedIdsFocusVisibility', () => {
+  it('releases the channel it still owns, and drops the record', () => {
+    const { state, recorded, cleared } = channels({
+      isolatedEntities: new Set([5]),
+      idsFocusVisibilityOwned: { channel: 'isolate', ids: new Set([5]) },
+    });
+
+    assert.equal(releaseOwnedIdsFocusVisibility(state), true);
+    assert.deepEqual(cleared, ['isolate']);
+    assert.deepEqual(recorded, [null], 'the row focus makes no further claim once released');
+  });
+
+  it('drops the record even when the channel is NOT ours — that is the whole point', () => {
+    // Another owner holds the isolate channel. Nothing is released; if the
+    // record were left behind it would start matching again the moment anyone
+    // installed {5} there, and the next release would destroy THAT owner's
+    // presentation.
+    const { state, recorded, cleared } = channels({
+      isolatedEntities: new Set([9]),
+      idsFocusVisibilityOwned: { channel: 'isolate', ids: new Set([5]) },
+    });
+
+    assert.equal(releaseOwnedIdsFocusVisibility(state), false, "we are not the owner");
+    assert.deepEqual(cleared, [], "and another owner's isolation must not be touched");
+    assert.deepEqual(recorded, [null], 'the stale record must go — no write invalidates it for us here');
+  });
+
+  it('writes nothing at all when there is no record', () => {
+    const { state, recorded, cleared } = channels({ ghostExceptEntities: new Set([1]) });
+
+    assert.equal(releaseOwnedIdsFocusVisibility(state), false);
+    assert.deepEqual(cleared, []);
+    assert.deepEqual(
+      recorded,
+      [],
+      'an unconditional null would commit a fresh store state on every ownership-free release path',
+    );
+  });
+});

--- a/apps/viewer/src/lib/ids/visibility-ownership.ts
+++ b/apps/viewer/src/lib/ids/visibility-ownership.ts
@@ -42,6 +42,7 @@ import {
   type VisibilityChannels,
   type VisibilityOwnership,
 } from '../visibility/ownership.js';
+import { IDS_FOCUS_COLOR } from '../../hooks/ids/idsColorSystem.js';
 
 /**
  * What the IDS row focus last installed into a shared visibility channel, and
@@ -74,7 +75,83 @@ export interface IDSFocusVisibilityChannels extends VisibilityChannels {
  *   focus was still, verifiably, the owner.
  */
 export function releaseOwnedIdsFocusVisibility(state: IDSFocusVisibilityChannels): boolean {
-  const stillOurs = releaseOwnedVisibility(state, state.idsFocusVisibilityOwned ?? null);
+  const owned = state.idsFocusVisibilityOwned ?? null;
+  // No record: nothing to release, and nothing to drop. Returning before the
+  // write keeps this the pure no-op it reads as — an unconditional
+  // `setIdsFocusVisibilityOwned(null)` would commit a fresh store state (and
+  // notify every subscriber) on every ownership-free release path, and several
+  // of them run on every model removal. Same shape as
+  // `releaseOwnedClashVisibility`.
+  if (!owned) return false;
+  const stillOurs = releaseOwnedVisibility(state, owned);
   state.setIdsFocusVisibilityOwned?.(null);
   return stillOurs;
+}
+
+type ColorOverrides = Map<number, [number, number, number, number]>;
+
+/** The store surface `endIdsRowFocusPresentation` reads and writes: the
+ *  visibility channels above plus the PAINT channel (dataSlice). Optional for
+ *  the same reason. */
+export interface IDSRowFocusPresentation extends IDSFocusVisibilityChannels {
+  pendingColorUpdates?: ColorOverrides | null;
+  setPendingColorUpdates?: (updates: ColorOverrides) => void;
+}
+
+/**
+ * End the WHOLE row-focus presentation — both channels it writes.
+ *
+ * The row focus is two channels, not one: the shared visibility channel
+ * (`isolatedEntities` / `ghostExceptEntities`, released by ownership above)
+ * and the PAINT channel — `focusEntity` repaints the activated element
+ * {@link IDS_FOCUS_COLOR} through `pendingColorUpdates`, the albedo path, so
+ * the row can be found among identically-red neighbours. #2867 released the
+ * first at all eleven of its release sites and the second at none of them, so
+ * a model removal or a cleared report left a cyan marker painted on an element
+ * whose row no longer exists. `ClashPanel`'s unmount cleanup has always handed
+ * the paint channel back for exactly this reason (#1277 review), and
+ * `endClashScenePresentation` documents the same three-channel shape.
+ *
+ * What is released is the tint the row focus ITSELF added, not the overlay it
+ * added it to. The focus colour is painted ON TOP of the report's red/green —
+ * that surrounding context is what makes it mean anything — and the report
+ * overlay belongs to the report, which these paths do not all invalidate. So
+ * the entries wearing the focus colour are dropped and every other entry is
+ * left exactly as it was. That is the same value-identity discipline the
+ * visibility channels use, with the same single, bounded false positive: an
+ * entry another owner painted this precise RGBA is indistinguishable from the
+ * marker and goes with it.
+ *
+ * `useIDS`'s own release sites do NOT come through here — `clearEntitySelection`
+ * and `applyFocusMode` follow their release with `paintFocus()`, which rebuilds
+ * the report overlay in full (the display options and geometry that needs are
+ * the hook's, not the store's). This is for the store- and panel-level
+ * teardowns, which have no way to rebuild it and must not leave the marker.
+ *
+ * @returns whether the visibility channel was actually released — i.e. whether
+ *   the row focus was still, verifiably, its owner.
+ */
+export function endIdsRowFocusPresentation(state: IDSRowFocusPresentation): boolean {
+  const released = releaseOwnedIdsFocusVisibility(state);
+
+  const painted = state.pendingColorUpdates;
+  if (painted) {
+    let marked = false;
+    const next: ColorOverrides = new Map();
+    for (const [id, color] of painted) {
+      if (isFocusColor(color)) { marked = true; continue; }
+      next.set(id, color);
+    }
+    // Only write when something changes: an unconditional push would commit a
+    // new map — and re-run the fire-and-forget override effect — on every model
+    // removal in a session that never focused an IDS row.
+    if (marked) state.setPendingColorUpdates?.(next);
+  }
+
+  return released;
+}
+
+function isFocusColor(color: readonly number[]): boolean {
+  return color.length === IDS_FOCUS_COLOR.length
+    && color.every((c, i) => c === IDS_FOCUS_COLOR[i]);
 }

--- a/apps/viewer/src/lib/ids/visibility-ownership.ts
+++ b/apps/viewer/src/lib/ids/visibility-ownership.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Who owns the shared visibility channels while an IDS RESULT ROW is focused
+ * (#2867) — and the one release that reads that ownership.
+ *
+ * The per-row focus modes mirror the clash panel's (`lib/clash/visibility-
+ * ownership.ts`, #1275 / #2654): `isolate` installs the row's element into
+ * `isolatedEntities`, `ghost` installs it into `ghostExceptEntities`, and
+ * `highlight` installs nothing and owns nothing. Both subsystems write the
+ * SAME two channels, so both answer the ownership question with the same
+ * predicate — `lib/visibility/ownership.ts` — rather than each carrying a copy
+ * that can drift.
+ *
+ * ## Scope: the ROW focus, not IDS's set-level isolation
+ *
+ * IDS also has set-level isolation (`isolateFailed` / `isolatePassed` /
+ * `isolateInvolved`), tracked separately by `idsIsolateMode` and driven by its
+ * own buttons. This record covers ONLY what activating a single result row
+ * installed. A row focus in `isolate` or `ghost` mode supersedes a set-level
+ * isolation on screen — one presentation at a time, the same as clash — and
+ * `useIDS.focusEntity` clears `idsIsolateMode` when it does, so the isolate
+ * buttons do not keep showing a pressed state for an isolation the row focus
+ * replaced.
+ *
+ * ## Why a store field and not a hook ref
+ *
+ * The same reason clash's moved (#2654 third review): store-level teardowns —
+ * `removeModel`, `clearAllModels`, `resetViewerState`, and the IDS slice's own
+ * report/document clears — must be able to read it. A `useIDS()`-private ref
+ * is unreachable from all of them, and the alternative, inferring ownership
+ * from `idsActiveEntityId`, is wrong in both directions: a `highlight` focus
+ * sets an active entity while owning nothing (over-clear), and the record
+ * outlives nothing at all if the row is deactivated without the channel being
+ * released (under-clear).
+ */
+
+import {
+  releaseOwnedVisibility,
+  type VisibilityChannels,
+  type VisibilityOwnership,
+} from '../visibility/ownership.js';
+
+/**
+ * What the IDS row focus last installed into a shared visibility channel, and
+ * which one. `null` means the row focus owns neither channel — including after
+ * a `highlight`-mode focus, which deliberately installs nothing.
+ */
+export type IDSFocusVisibilityOwnership = VisibilityOwnership;
+
+/** The store surface `releaseOwnedIdsFocusVisibility` reads and writes. Every
+ *  member is optional, for the same reason clash's is: slice-level tests drive
+ *  store actions through harnesses that stub `get()` with a single slice. */
+export interface IDSFocusVisibilityChannels extends VisibilityChannels {
+  idsFocusVisibilityOwned?: IDSFocusVisibilityOwnership;
+  setIdsFocusVisibilityOwned?: (owned: IDSFocusVisibilityOwnership) => void;
+}
+
+/**
+ * Release the isolation/ghost the IDS row focus itself installed — and ONLY
+ * that. A presentation established by clash, the spaces X-ray, "Isolate in 3D"
+ * or IDS's own set-level isolate buttons does not content-match the record, so
+ * it survives untouched.
+ *
+ * The record is dropped either way: once this has run, the row focus makes no
+ * further claim. That is not optional tidiness — ownership is tested by VALUE,
+ * so a record left behind after its presentation ended starts matching again
+ * the moment another owner installs a set with equal content, and the next
+ * release destroys THAT owner's presentation (#2654 fourth review).
+ *
+ * @returns whether a channel was actually released — i.e. whether the row
+ *   focus was still, verifiably, the owner.
+ */
+export function releaseOwnedIdsFocusVisibility(state: IDSFocusVisibilityChannels): boolean {
+  const stillOurs = releaseOwnedVisibility(state, state.idsFocusVisibilityOwned ?? null);
+  state.setIdsFocusVisibilityOwned?.(null);
+  return stillOurs;
+}

--- a/apps/viewer/src/lib/ids/visibility-ownership.ts
+++ b/apps/viewer/src/lib/ids/visibility-ownership.ts
@@ -71,6 +71,14 @@ export interface IDSFocusVisibilityChannels extends VisibilityChannels {
  * the moment another owner installs a set with equal content, and the next
  * release destroys THAT owner's presentation (#2654 fourth review).
  *
+ * The drop matters most on the branch where nothing is released. When this DID
+ * release through the live store, the store's own channel-write invalidation
+ * (`store/visibility-invalidation.ts`) would have dropped the record for the
+ * same reason — which is exactly why no store-driven test can see this line.
+ * When the answer is "not ours", nothing is written, nothing invalidates, and
+ * this is the only thing that ends the stale claim. `visibility-ownership.test.ts`
+ * covers both branches over the all-optional surface this is typed for.
+ *
  * @returns whether a channel was actually released — i.e. whether the row
  *   focus was still, verifiably, the owner.
  */

--- a/apps/viewer/src/lib/visibility/ownership.test.ts
+++ b/apps/viewer/src/lib/visibility/ownership.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The one ownership predicate over the shared visibility channels — the thing
+ * clash (#2654 / #2662) and the IDS row focus (#2867) both ask before they
+ * clear anything.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ownsCurrentVisibility,
+  releaseOwnedVisibility,
+  sameMembers,
+  type VisibilityChannels,
+} from './ownership.js';
+
+describe('sameMembers', () => {
+  it('is true for equal members in different Set objects', () => {
+    assert.equal(sameMembers(new Set([1, 2]), new Set([2, 1])), true,
+      'value identity is the whole point — a snapshot/restore round-trip rebuilds the Set');
+  });
+
+  it('is false in BOTH directions of containment, not just one', () => {
+    // The size check is what makes the second of these false. Without it, the
+    // member loop alone answers "still ours" for every SUBSET of the record —
+    // and releasing then destroys a presentation somebody else installed.
+    assert.equal(sameMembers(new Set([1, 2]), new Set([1])), false, 'superset is not equal');
+    assert.equal(sameMembers(new Set([1]), new Set([1, 2])), false, 'subset is not equal either');
+  });
+
+  it('is true for two empty sets and false against a non-empty one', () => {
+    assert.equal(sameMembers(new Set(), new Set()), true);
+    assert.equal(sameMembers(new Set(), new Set([1])), false,
+      'an EMPTY channel does not match a non-empty record — the case a size-free member loop gets wrong');
+  });
+});
+
+function channels(over: Partial<VisibilityChannels> = {}): VisibilityChannels & {
+  cleared: string[];
+} {
+  const cleared: string[] = [];
+  return {
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    clearIsolation: () => { cleared.push('isolate'); },
+    clearGhost: () => { cleared.push('ghost'); },
+    cleared,
+    ...over,
+  };
+}
+
+describe('releaseOwnedVisibility', () => {
+  it('clears the channel it owns, and only that channel', () => {
+    const s = channels({ isolatedEntities: new Set([1]), ghostExceptEntities: null });
+    assert.equal(releaseOwnedVisibility(s, { channel: 'isolate', ids: new Set([1]) }), true);
+    assert.deepEqual(s.cleared, ['isolate'], 'the ghost channel is somebody else\'s business');
+  });
+
+  it('leaves a channel whose content no longer matches', () => {
+    const s = channels({ ghostExceptEntities: new Set([1, 9]) });
+    assert.equal(releaseOwnedVisibility(s, { channel: 'ghost', ids: new Set([1]) }), false);
+    assert.deepEqual(s.cleared, [], 'a later owner took the channel over — releasing would destroy their view');
+  });
+
+  it('answers false, and clears nothing, for a record of null', () => {
+    const s = channels({ isolatedEntities: new Set([1]) });
+    assert.equal(releaseOwnedVisibility(s, null), false);
+    assert.deepEqual(s.cleared, [], 'owning nothing means clearing nothing — a full-context highlight owns nothing');
+  });
+
+  it('answers false for a record naming a channel that is now empty', () => {
+    const s = channels({ isolatedEntities: null });
+    assert.equal(ownsCurrentVisibility(s, { channel: 'isolate', ids: new Set([1]) }), false);
+    assert.equal(releaseOwnedVisibility(s, { channel: 'isolate', ids: new Set([1]) }), false);
+    assert.deepEqual(s.cleared, []);
+  });
+});

--- a/apps/viewer/src/lib/visibility/ownership.test.ts
+++ b/apps/viewer/src/lib/visibility/ownership.test.ts
@@ -14,6 +14,7 @@ import {
   ownsCurrentVisibility,
   releaseOwnedVisibility,
   sameMembers,
+  staleOwnershipReset,
   type VisibilityChannels,
 } from './ownership.js';
 
@@ -76,5 +77,81 @@ describe('releaseOwnedVisibility', () => {
     assert.equal(ownsCurrentVisibility(s, { channel: 'isolate', ids: new Set([1]) }), false);
     assert.equal(releaseOwnedVisibility(s, { channel: 'isolate', ids: new Set([1]) }), false);
     assert.deepEqual(s.cleared, []);
+  });
+});
+
+/**
+ * The invalidation side of the same predicate (review of #2867): a channel
+ * write drops every record it just made stale, symmetrically, so no
+ * subsystem's claim can outlive its presentation because a DIFFERENT owner
+ * replaced the channel.
+ */
+describe('staleOwnershipReset', () => {
+  it('drops a record whose channel the write is about to replace', () => {
+    assert.deepEqual(
+      staleOwnershipReset(
+        { idsFocusVisibilityOwned: { channel: 'isolate', ids: new Set([1]) } },
+        { isolatedEntities: new Set([2]), ghostExceptEntities: null },
+      ),
+      { idsFocusVisibilityOwned: null },
+    );
+  });
+
+  it('drops a record whose channel the write NULLS as a side effect', () => {
+    // The two channels are mutually exclusive: writing the ghost one nulls the
+    // isolate one. That is D1 — clash ghosting over an IDS row isolation.
+    assert.deepEqual(
+      staleOwnershipReset(
+        { idsFocusVisibilityOwned: { channel: 'isolate', ids: new Set([1]) } },
+        { isolatedEntities: null, ghostExceptEntities: new Set([5, 6]) },
+      ),
+      { idsFocusVisibilityOwned: null },
+    );
+  });
+
+  it('keeps a record the write leaves content-matching', () => {
+    // Space Sketch's restore and `syncSourceModel`'s rebuild both replay an
+    // unchanged channel through a cloning setter (#2662 P2). Equal members
+    // mean the same presentation is still on screen.
+    assert.deepEqual(
+      staleOwnershipReset(
+        { clashVisibilityOwned: { channel: 'ghost', ids: new Set([1, 2]) } },
+        { isolatedEntities: null, ghostExceptEntities: new Set([2, 1]) },
+      ),
+      {},
+      'a content-preserving rewrite must not launder a feature-owned focus into "user" state',
+    );
+  });
+
+  it('answers for BOTH subsystems, not whichever one was reported', () => {
+    assert.deepEqual(
+      staleOwnershipReset(
+        {
+          idsFocusVisibilityOwned: { channel: 'isolate', ids: new Set([1]) },
+          clashVisibilityOwned: { channel: 'ghost', ids: new Set([5, 6]) },
+        },
+        { isolatedEntities: new Set([9]), ghostExceptEntities: null },
+      ),
+      { idsFocusVisibilityOwned: null, clashVisibilityOwned: null },
+      'one direction of a two-way rule is not a rule',
+    );
+  });
+
+  it('adds no keys when there is nothing to invalidate', () => {
+    // The common case, and the reason this returns a patch rather than a pair
+    // of nulls: slice-level harnesses stub `get()` without these fields, and a
+    // blanket write would introduce them.
+    assert.deepEqual(
+      staleOwnershipReset({}, { isolatedEntities: new Set([1]), ghostExceptEntities: null }),
+      {},
+    );
+    assert.deepEqual(
+      staleOwnershipReset(
+        { idsFocusVisibilityOwned: null, clashVisibilityOwned: null },
+        { isolatedEntities: null, ghostExceptEntities: null },
+      ),
+      {},
+      'a record of `null` is already no claim — nulling it again is a store commit for nothing',
+    );
   });
 });

--- a/apps/viewer/src/lib/visibility/ownership.ts
+++ b/apps/viewer/src/lib/visibility/ownership.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Who owns the SHARED visibility channels, expressed once.
+ *
+ * `isolatedEntities` / `ghostExceptEntities` (visibilitySlice) are shared by
+ * clash, IDS, "Isolate in 3D" (#2532), assembly isolation (#2531),
+ * `LayerDiffView`, Space Sketch's `useSpaceGhostPreview`, BCF and
+ * `syncSourceModel`'s post-removal purge. A feature's teardown may therefore
+ * only release a presentation IT ITSELF installed.
+ *
+ * Clash worked that out first, in painful detail (`lib/clash/visibility-
+ * ownership.ts`, #2654 / #2662) — record what you installed, test ownership by
+ * VALUE rather than by `Set` reference or by "was my feature active", and
+ * release only on a match. IDS's per-row focus (#2867) needs exactly the same
+ * predicate over its own record. This module is that predicate, once: two
+ * subsystems that must agree about a shared channel cannot drift apart if
+ * there is only one implementation for them to drift from.
+ */
+
+/** Which shared channel a presentation was installed into. */
+export type VisibilityChannel = 'ghost' | 'isolate';
+
+/**
+ * What a feature last installed into a shared visibility channel, and which
+ * one. `null` means the feature owns neither channel — including after a
+ * full-context "highlight" focus, which deliberately takes ownership of
+ * nothing.
+ *
+ * The installed CONTENT is kept, not just the channel name, because ownership
+ * is tested by value: see {@link ownsCurrentVisibility}.
+ */
+export type VisibilityOwnership =
+  | { channel: VisibilityChannel; ids: ReadonlySet<number> }
+  | null;
+
+/**
+ * Content equality for an ownership record. The shared channels are only ever
+ * REPLACED wholesale (every slice setter stores a fresh `Set`), never mutated
+ * in place, so equal members mean the channel still shows exactly the
+ * presentation that was installed.
+ *
+ * Ownership is tested by VALUE, not by `Set` reference: reference identity
+ * would be exact, but it is destroyed by every flow that snapshots and later
+ * restores the channel with equal content in a fresh `Set` — Space Sketch's
+ * open/close view capture (`useSpaceSceneFraming` clones the prior sets and
+ * replays them through the cloning slice setters) and a source-model resync
+ * (`syncSourceModel` rebuilds the kept sets even when nothing was filtered).
+ * Under reference identity those flows silently converted a feature-owned
+ * focus into "user" state, so the next run replaced the result set but left
+ * the old presentation isolated/ghosted (#2662 P2). Value identity survives
+ * any content-preserving rewrite, and its one false positive is harmless by
+ * construction: it only fires when the channel shows EXACTLY what was
+ * installed, in which case releasing it renders precisely what discarding that
+ * presentation should render.
+ */
+export function sameMembers(a: ReadonlySet<number>, b: ReadonlySet<number>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) if (!b.has(id)) return false;
+  return true;
+}
+
+/** The channel surface a release reads and writes. Every member is optional:
+ *  slice-level tests drive store actions through harnesses that stub `get()`
+ *  with a single slice, so a slice reaching across must tolerate genuinely
+ *  absent fields rather than assume the combined store. */
+export interface VisibilityChannels {
+  ghostExceptEntities?: Set<number> | null;
+  isolatedEntities?: Set<number> | null;
+  clearGhost?: () => void;
+  clearIsolation?: () => void;
+}
+
+/**
+ * Does the channel named by `owned` still show exactly what was installed?
+ *
+ * A record that no longer matches is NOT inert — ownership is tested by VALUE,
+ * so a stale record goes matching → cleared → MATCHING AGAIN as soon as any
+ * other owner installs a set with equal content (#2654 fourth review). Every
+ * caller therefore drops its record as it releases, whatever this answers.
+ */
+export function ownsCurrentVisibility(
+  state: VisibilityChannels,
+  owned: VisibilityOwnership,
+): boolean {
+  if (!owned) return false;
+  const current =
+    owned.channel === 'isolate'
+      ? state.isolatedEntities ?? null
+      : state.ghostExceptEntities ?? null;
+  return current !== null && sameMembers(current, owned.ids);
+}
+
+/**
+ * Clear the shared channel `owned` names — and ONLY if it still holds exactly
+ * what was installed. Isolation or ghosting established by another feature
+ * does not content-match, so it survives untouched.
+ *
+ * The RECORD is not touched here: every caller nulls its own record
+ * unconditionally afterwards (a stale record is dangerous, see
+ * {@link ownsCurrentVisibility}), and the record lives in the caller's own
+ * slice under the caller's own field name.
+ *
+ * @returns whether a channel was actually released — i.e. whether the caller
+ *   was still, verifiably, the owner.
+ */
+export function releaseOwnedVisibility(
+  state: VisibilityChannels,
+  owned: VisibilityOwnership,
+): boolean {
+  if (!ownsCurrentVisibility(state, owned)) return false;
+  if (owned!.channel === 'isolate') state.clearIsolation?.();
+  else state.clearGhost?.();
+  return true;
+}

--- a/apps/viewer/src/lib/visibility/ownership.ts
+++ b/apps/viewer/src/lib/visibility/ownership.ts
@@ -147,9 +147,11 @@ const OWNERSHIP_RECORD_FIELDS = [
  *
  * Fixing that per caller is one direction of a two-way rule, and the next owner
  * of the channel reintroduces it. So it is answered where the channels are
- * actually written instead — `visibilitySlice`, which every owner goes through
- * — and answered for EVERY record symmetrically, not for the one that happened
- * to be reported.
+ * actually written instead — and for EVERY record symmetrically, not for the
+ * one that happened to be reported. "Where they are written" is the store's own
+ * `set`, wrapped once in `store/visibility-invalidation.ts`: a list of writing
+ * ACTIONS was tried first and was already incomplete on the day it was written
+ * (`showAllInAllModels`, and ten actions in `pinboardSlice`).
  *
  * Invalidation is by CONTENT, not by "somebody wrote": `next` is the state the
  * channels are about to hold, and a record still content-matching it survives.
@@ -162,6 +164,8 @@ const OWNERSHIP_RECORD_FIELDS = [
  * CHANNEL first and its record second (`useClash.installClashIsolation` /
  * `installClashGhost`, `useIDS.installFocusIsolation` / `installFocusGhost`),
  * so a record can never be invalidated by the very write that installed it.
+ * (The middleware also leaves a record the patch itself carries alone, so an
+ * installer that committed both in ONE `set()` would be safe too.)
  *
  * @returns a partial state patch — `{}` when nothing went stale, so the common
  *   case adds no keys to the `set()` and slice-level harnesses that stub `get()`

--- a/apps/viewer/src/lib/visibility/ownership.ts
+++ b/apps/viewer/src/lib/visibility/ownership.ts
@@ -115,3 +115,66 @@ export function releaseOwnedVisibility(
   else state.clearGhost?.();
   return true;
 }
+
+/**
+ * Every store field that holds one of these records, so a THIRD subsystem
+ * recording a claim on the same two channels is invalidated by construction
+ * rather than by remembering to extend a list somewhere else.
+ */
+export interface OwnedVisibilityRecords {
+  idsFocusVisibilityOwned?: VisibilityOwnership;
+  clashVisibilityOwned?: VisibilityOwnership;
+}
+
+const OWNERSHIP_RECORD_FIELDS = [
+  'idsFocusVisibilityOwned',
+  'clashVisibilityOwned',
+] as const satisfies readonly (keyof OwnedVisibilityRecords)[];
+
+/**
+ * The record fields a channel write has just made STALE — the one shared
+ * invalidation point (review of #2867).
+ *
+ * A record that outlives its presentation is not inert. Ownership is tested by
+ * VALUE, so it goes matching → cleared → MATCHING AGAIN the moment any other
+ * owner installs a set with equal content, and the next release then destroys
+ * THAT owner's presentation (#2654 fourth review). Each subsystem already drops
+ * its OWN record as it releases, and IDS's set-level isolate drops the row
+ * focus's — but nothing dropped a record when a DIFFERENT owner replaced the
+ * channel underneath it. Three running reproductions, one per direction:
+ * clash's `focusClash` over an IDS row focus, `useClash.clearHighlight()` over
+ * one, and an IDS row focus over a clash ghost.
+ *
+ * Fixing that per caller is one direction of a two-way rule, and the next owner
+ * of the channel reintroduces it. So it is answered where the channels are
+ * actually written instead — `visibilitySlice`, which every owner goes through
+ * — and answered for EVERY record symmetrically, not for the one that happened
+ * to be reported.
+ *
+ * Invalidation is by CONTENT, not by "somebody wrote": `next` is the state the
+ * channels are about to hold, and a record still content-matching it survives.
+ * That is what keeps the content-preserving rewrites alive — Space Sketch's
+ * open/close view capture and `syncSourceModel`'s rebuild both replay an
+ * unchanged channel through these setters, and under a blanket "any write
+ * invalidates" rule they would silently convert a feature-owned focus into
+ * "user" state, which is #2662 P2 again. It is also why this cannot strand a
+ * presentation the way an unconditional null would: every installer writes the
+ * CHANNEL first and its record second (`useClash.installClashIsolation` /
+ * `installClashGhost`, `useIDS.installFocusIsolation` / `installFocusGhost`),
+ * so a record can never be invalidated by the very write that installed it.
+ *
+ * @returns a partial state patch — `{}` when nothing went stale, so the common
+ *   case adds no keys to the `set()` and slice-level harnesses that stub `get()`
+ *   without these fields are unaffected.
+ */
+export function staleOwnershipReset(
+  records: OwnedVisibilityRecords,
+  next: Pick<VisibilityChannels, 'isolatedEntities' | 'ghostExceptEntities'>,
+): Partial<OwnedVisibilityRecords> {
+  const reset: Partial<OwnedVisibilityRecords> = {};
+  for (const field of OWNERSHIP_RECORD_FIELDS) {
+    const owned = records[field];
+    if (owned && !ownsCurrentVisibility(next, owned)) reset[field] = null;
+  }
+  return reset;
+}

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -59,6 +59,7 @@ import { createSpaceMouseSlice, type SpaceMouseSlice } from './slices/spaceMouse
 import { createLayerStackSlice, type LayerStackSlice } from './slices/layerStackSlice.js';
 import { createZonesSlice, type ZonesSlice } from './slices/zonesSlice.js';
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
+import { withVisibilityOwnershipInvalidation } from './visibility-invalidation.js';
 import {
   endClashScenePresentation,
   type ClashSceneTeardown,
@@ -222,9 +223,16 @@ export type ViewerState = LoadingSlice &
   };
 
 /**
- * Main viewer store combining all slices
+ * Main viewer store combining all slices.
+ *
+ * `withVisibilityOwnershipInvalidation` wraps the store's `set` (and its
+ * `setState`) so that no slice — present or future — can replace
+ * `isolatedEntities` / `ghostExceptEntities` without dropping the
+ * visibility-ownership records that write makes stale. See
+ * `store/visibility-invalidation.ts` for why that is a middleware rather than a
+ * helper each writing action remembers to call.
  */
-const createViewerStore = () => create<ViewerState>()((...args) => ({
+const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInvalidation((...args) => ({
   // Spread all slices
   ...createLoadingSlice(...args),
   ...createSelectionSlice(...args),
@@ -726,7 +734,7 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       get().showWorkspacePanel(panel);
     }
   },
-}));
+})));
 
 const STORE_SINGLETON_KEY = '__ifc_lite_viewer_store__';
 const globalStoreRegistry = globalThis as typeof globalThis & {

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -96,7 +96,7 @@ export type { CollabSlice, CollabRole, CollabStatus, StartCollabOptions } from '
 export type { BCFSlice, BCFSliceState } from './slices/bcfSlice.js';
 
 // Re-export IDS types
-export type { IDSSlice, IDSSliceState, IDSDisplayOptions, IDSFilterMode } from './slices/idsSlice.js';
+export type { IDSSlice, IDSSliceState, IDSDisplayOptions, IDSFilterMode, IDSFocusMode } from './slices/idsSlice.js';
 
 // Re-export List types
 export type { ListSlice } from './slices/listSlice.js';
@@ -469,6 +469,14 @@ const createViewerStore = () => create<ViewerState>()((...args) => ({
       idsError: null,
       idsActiveSpecificationId: null,
       idsActiveEntityId: null,
+      // The per-row focus's claim on the shared isolate/ghost channels
+      // (#2867) goes with the row it belonged to. Both channels are nulled by
+      // this same `set`, so there is nothing left to release — but the RECORD
+      // must not survive: ownership is tested by value, so a record left
+      // behind starts matching again the moment another owner installs equal
+      // content, and the next release destroys that owner's presentation
+      // (#2654 fourth review).
+      idsFocusVisibilityOwned: null,
       // Keep idsDocument, idsValidationReport, idsLocale - user's work
 
       // Lists - reset result but keep definitions (user's saved lists)

--- a/apps/viewer/src/store/slices/idsSlice.ts
+++ b/apps/viewer/src/store/slices/idsSlice.ts
@@ -19,8 +19,8 @@ import type {
   ValidationProgress,
 } from '@ifc-lite/ids';
 import {
-  releaseOwnedIdsFocusVisibility,
-  type IDSFocusVisibilityChannels,
+  endIdsRowFocusPresentation,
+  type IDSRowFocusPresentation,
   type IDSFocusVisibilityOwnership,
 } from '../../lib/ids/visibility-ownership.js';
 
@@ -243,7 +243,7 @@ function buildEntityIdSets(
  * own set-level isolation occupying the channel instead is left alone.
  */
 function endIdsRowFocus(get: () => IDSSlice): void {
-  releaseOwnedIdsFocusVisibility(get() as unknown as IDSFocusVisibilityChannels);
+  endIdsRowFocusPresentation(get() as unknown as IDSRowFocusPresentation);
 }
 
 export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, get) => ({

--- a/apps/viewer/src/store/slices/idsSlice.ts
+++ b/apps/viewer/src/store/slices/idsSlice.ts
@@ -18,6 +18,11 @@ import type {
   SupportedLocale,
   ValidationProgress,
 } from '@ifc-lite/ids';
+import {
+  releaseOwnedIdsFocusVisibility,
+  type IDSFocusVisibilityChannels,
+  type IDSFocusVisibilityOwnership,
+} from '../../lib/ids/visibility-ownership.js';
 
 // ============================================================================
 // Types
@@ -51,6 +56,21 @@ export type IDSIsolationScope = 'ids' | 'spec';
  * IDS is not isolating.
  */
 export type IDSIsolateMode = 'failed' | 'passed' | 'involved' | null;
+
+/**
+ * How the rest of the model is shown when a single IDS result ROW is activated
+ * (#2867) — the same three modes, the same names and the same persistence as
+ * the clash panel's `ClashFocusMode`, because it is the same action:
+ *
+ * - 'highlight': keep the whole model visible;
+ * - 'isolate':   hide everything except the activated element;
+ * - 'ghost':     fade the rest to translucent context (X-Ray).
+ *
+ * A workspace preference: it survives a report clear and a panel switch, like
+ * `clashFocusMode`, so the user picks how they review once rather than per
+ * row.
+ */
+export type IDSFocusMode = 'highlight' | 'isolate' | 'ghost';
 
 export interface IDSSliceState {
   /** Loaded IDS document */
@@ -93,6 +113,18 @@ export interface IDSSliceState {
   idsIsolationScope: IDSIsolationScope;
   /** Which isolate action is currently applied (drives toggle + active state) */
   idsIsolateMode: IDSIsolateMode;
+  /**
+   * How activating a single result row presents the rest of the model
+   * (#2867). Persistent user preference — see {@link IDSFocusMode}.
+   */
+  idsFocusMode: IDSFocusMode;
+  /**
+   * The CLAIM the row focus holds on the shared isolation/ghost channels —
+   * what it installed and where — so a teardown can release exactly that and
+   * nothing else. `null` means the row focus owns neither channel. See
+   * `lib/ids/visibility-ownership.ts`.
+   */
+  idsFocusVisibilityOwned: IDSFocusVisibilityOwnership;
   /** Cached set of failed entity IDs for efficient lookup */
   idsFailedEntityIds: Set<string>; // "modelId:expressId" format
   /** Cached set of passed entity IDs */
@@ -127,6 +159,8 @@ export interface IDSSlice extends IDSSliceState {
   setIdsFilterMode: (mode: IDSFilterMode) => void;
   setIdsIsolationScope: (scope: IDSIsolationScope) => void;
   setIdsIsolateMode: (mode: IDSIsolateMode) => void;
+  setIdsFocusMode: (mode: IDSFocusMode) => void;
+  setIdsFocusVisibilityOwned: (owned: IDSFocusVisibilityOwnership) => void;
 
   // Utility getters
   getActiveSpecificationResult: () => IDSSpecificationResult | null;
@@ -194,6 +228,24 @@ function buildEntityIdSets(
 // Slice Creator
 // ============================================================================
 
+/**
+ * End the per-row focus presentation (#2867) before a state change discards
+ * the report the focused row belonged to.
+ *
+ * ORDER is load-bearing, and it is the same order `endClashScenePresentation`
+ * documents: RELEASE the shared channel first, THEN let the caller's `set()`
+ * null the record. Nulling first leaves the release reading `null`, finding
+ * nothing to release, and leaving a row isolation standing over a report that
+ * no longer exists — `isEntityVisible` false for everything, with nothing on
+ * screen to explain it.
+ *
+ * The release is ownership-scoped, so a clash focus, a spaces X-ray or IDS's
+ * own set-level isolation occupying the channel instead is left alone.
+ */
+function endIdsRowFocus(get: () => IDSSlice): void {
+  releaseOwnedIdsFocusVisibility(get() as unknown as IDSFocusVisibilityChannels);
+}
+
 export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, get) => ({
   // Initial state
   idsDocument: null,
@@ -211,11 +263,21 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
   idsFilterMode: 'all',
   idsIsolationScope: 'ids',
   idsIsolateMode: null,
+  // Ghost by default, exactly as `clashFocusMode` is: the reported problem is
+  // that the activated element cannot be FOUND, and ghosting is the only mode
+  // that both removes the surrounding clutter and keeps enough of the building
+  // on screen to tell where in it you are landed. `isolate` answers the first
+  // half and loses the context; `highlight` answers neither on its own.
+  idsFocusMode: 'ghost',
+  idsFocusVisibilityOwned: null,
   idsFailedEntityIds: new Set(),
   idsPassedEntityIds: new Set(),
 
   // Document actions
-  setIdsDocument: (idsDocument) =>
+  setIdsDocument: (idsDocument) => {
+    // A new document invalidates the report the focused row came from, so the
+    // row focus's claim on the shared channels ends here too.
+    endIdsRowFocus(get);
     set({
       idsDocument,
       // Loading a new document invalidates any previous audit/validation
@@ -234,9 +296,11 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
       idsPassedEntityIds: new Set(),
       idsIsolationScope: 'ids',
       idsIsolateMode: null,
-    }),
+      idsFocusVisibilityOwned: null,
+    });
+  },
 
-  clearIdsDocument: () =>
+  clearIdsDocument: () => {
     // `useIDS.clearIDS` bumps `validationEpochRef` right before calling this,
     // so a `runValidation()` still in flight sees `stillWantedValidation` go
     // false and skips its OWN `finally` reset of `idsLoading`/`idsProgress`
@@ -245,6 +309,9 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
     // ever turns them off, so the clear itself has to (PR #2837 review):
     // without this, a clear that lands mid-run leaves the UI showing a
     // validation spinner that never resolves.
+    // `endIdsRowFocus` runs first for the same reason it does in
+    // `setIdsDocument`: the release must precede the record being nulled.
+    endIdsRowFocus(get);
     set({
       idsDocument: null,
       idsAuditReport: null,
@@ -258,7 +325,9 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
       idsProgress: null,
       idsIsolationScope: 'ids',
       idsIsolateMode: null,
-    }),
+      idsFocusVisibilityOwned: null,
+    });
+  },
 
   // Audit actions
   setIdsAuditReport: (idsAuditReport) => set({ idsAuditReport }),
@@ -267,33 +336,43 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
   // Validation actions
   setIdsValidationReport: (report) => {
     const { failed, passed } = buildEntityIdSets(report);
+    // A landing report replaces the one the focused row belonged to — its
+    // express ids may denote different entities now. Release before the
+    // record is nulled below.
+    endIdsRowFocus(get);
     set({
       idsValidationReport: report,
       idsFailedEntityIds: failed,
       idsPassedEntityIds: passed,
       idsIsolateMode: null,
+      idsFocusVisibilityOwned: null,
       idsError: null,
       idsProgress: null,
     });
   },
 
-  clearIdsValidationReport: () =>
+  clearIdsValidationReport: () => {
     // Same reasoning as `clearIdsDocument` above: `useIDS.clearValidation`
     // bumps the epoch first, which makes a still-in-flight `runValidation()`
     // skip its own `idsLoading`/`idsProgress` reset on purpose — this is the
     // only remaining writer for those fields once that happens (PR #2837
     // review).
+    // And, as in `clearIdsDocument`, the row focus is released BEFORE its
+    // record is nulled — otherwise the isolation outlives the report.
+    endIdsRowFocus(get);
     set({
       idsValidationReport: null,
       idsActiveSpecificationId: null,
       idsActiveEntityId: null,
       idsIsolationScope: 'ids',
       idsIsolateMode: null,
+      idsFocusVisibilityOwned: null,
       idsFailedEntityIds: new Set(),
       idsPassedEntityIds: new Set(),
       idsLoading: false,
       idsProgress: null,
-    }),
+    });
+  },
 
   setIdsProgress: (idsProgress) => set({ idsProgress }),
 
@@ -332,6 +411,10 @@ export const createIdsSlice: StateCreator<IDSSlice, [], [], IDSSlice> = (set, ge
   setIdsIsolationScope: (idsIsolationScope) => set({ idsIsolationScope }),
 
   setIdsIsolateMode: (idsIsolateMode) => set({ idsIsolateMode }),
+
+  setIdsFocusMode: (idsFocusMode) => set({ idsFocusMode }),
+
+  setIdsFocusVisibilityOwned: (idsFocusVisibilityOwned) => set({ idsFocusVisibilityOwned }),
 
   // Utility getters
   getActiveSpecificationResult: () => {

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -18,8 +18,8 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import { federationRegistry, type GlobalIdLookup } from '@ifc-lite/renderer';
 import {
-  releaseOwnedIdsFocusVisibility,
-  type IDSFocusVisibilityChannels,
+  endIdsRowFocusPresentation,
+  type IDSRowFocusPresentation,
 } from '../../lib/ids/visibility-ownership.js';
 import {
   endClashScenePresentation,
@@ -327,9 +327,18 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     // standing over a federation that just changed is the same blank viewport
     // #2654 describes, with nothing on screen to explain it. Released by
     // IDS's OWN record, so a presentation belonging to clash, the spaces
-    // X-ray or IDS's set-level isolate buttons survives untouched. This must
-    // also precede the IDS clears below, which drop the record.
-    releaseOwnedIdsFocusVisibility(get() as unknown as IDSFocusVisibilityChannels);
+    // X-ray or IDS's set-level isolate buttons survives untouched. The row
+    // focus's colour marker goes with it — both channels it wrote.
+    //
+    // CORRECTION (review of #2867): an earlier revision of this comment
+    // claimed this "must also precede the IDS clears below, which drop the
+    // record". It does not. The only clear below is
+    // `clearIdsValidationReport`, which releases through this same helper
+    // BEFORE nulling the record — moving this call after it passes the whole
+    // suite (verified). The order here is not load-bearing and is not
+    // asserted; what IS load-bearing is the release-before-null order INSIDE
+    // `clearIdsValidationReport` (idsSlice), where it is asserted.
+    endIdsRowFocusPresentation(get() as unknown as IDSRowFocusPresentation);
 
     // If the removed model is the one the current IDS report describes, that
     // report is stale by definition — its results reference a model that no
@@ -643,7 +652,7 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     // normally just drops the record — which it must, because a record that
     // outlives its presentation re-matches as soon as any other owner
     // installs equal content (#2654 fourth review).
-    releaseOwnedIdsFocusVisibility(get() as unknown as IDSFocusVisibilityChannels);
+    endIdsRowFocusPresentation(get() as unknown as IDSRowFocusPresentation);
     // Clear the federation registry
     federationRegistry.clear();
     // Same dangling reference as `removeModel`'s `addElementModelId` cleanup

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -18,6 +18,10 @@ import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import { federationRegistry, type GlobalIdLookup } from '@ifc-lite/renderer';
 import {
+  releaseOwnedIdsFocusVisibility,
+  type IDSFocusVisibilityChannels,
+} from '../../lib/ids/visibility-ownership.js';
+import {
   endClashScenePresentation,
   type ClashSceneTeardown,
 } from '@/lib/clash/visibility-ownership';
@@ -316,6 +320,16 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     // — verified against `mutationSlice.clearMutations` — but that is a
     // property of today's implementations, not of this call site.
     endClashScenePresentation(() => get() as unknown as ClashSceneTeardown, 'model-removed');
+
+    // The IDS per-row focus (#2867) owns the same two shared channels clash
+    // does — `focusEntity` installs the activated row's element into
+    // `isolatedEntities` or `ghostExceptEntities` — and a row isolation left
+    // standing over a federation that just changed is the same blank viewport
+    // #2654 describes, with nothing on screen to explain it. Released by
+    // IDS's OWN record, so a presentation belonging to clash, the spaces
+    // X-ray or IDS's set-level isolate buttons survives untouched. This must
+    // also precede the IDS clears below, which drop the record.
+    releaseOwnedIdsFocusVisibility(get() as unknown as IDSFocusVisibilityChannels);
 
     // If the removed model is the one the current IDS report describes, that
     // report is stale by definition — its results reference a model that no
@@ -624,6 +638,12 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     // nothing left for either to refer to, and `resetViewerState`
     // (store/index.ts) has always nulled the visibility fields here.
     endClashScenePresentation(() => get() as unknown as ClashSceneTeardown, 'federation-cleared');
+    // Same claim, released the same way: with every model gone the clash
+    // helper above has already cleared both channels outright, so this
+    // normally just drops the record — which it must, because a record that
+    // outlives its presentation re-matches as soon as any other owner
+    // installs equal content (#2654 fourth review).
+    releaseOwnedIdsFocusVisibility(get() as unknown as IDSFocusVisibilityChannels);
     // Clear the federation registry
     federationRegistry.clear();
     // Same dangling reference as `removeModel`'s `addElementModelId` cleanup

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -19,39 +19,26 @@ import {
   TYPE_VIEW_MODE_STORAGE_KEY,
   type TypeViewMode,
 } from '../constants.js';
-import {
-  staleOwnershipReset,
-  type OwnedVisibilityRecords,
-} from '../../lib/visibility/ownership.js';
-
-/** The two shared channels, as a write about to be committed sets them. */
-interface SharedChannels {
-  isolatedEntities: Set<number> | null;
-  ghostExceptEntities: Set<number> | null;
-}
 
 /**
- * A channel write, plus the invalidation of every visibility-ownership record
- * it just made stale (review of #2867 — see `staleOwnershipReset`).
+ * ## These two channels are shared, and every write of them is invalidating
  *
  * `isolatedEntities` / `ghostExceptEntities` are shared by clash, IDS,
- * "Isolate in 3D", assembly isolation, `LayerDiffView`, Space Sketch, BCF and
- * `syncSourceModel`. Features record what they installed so they can release
- * only that, and a record left behind after ANOTHER owner replaced the channel
- * starts matching again the moment a third owner installs equal content — at
- * which point the stale owner's next release destroys that owner's
- * presentation. Answering it here, where the channels are actually written,
- * covers every owner in both directions at once; answering it per caller
- * covers whichever direction was reported and waits for the next one.
+ * "Isolate in 3D", assembly isolation, `LayerDiffView`, Space Sketch, BCF, the
+ * basket and `syncSourceModel`. Features record what they installed so they
+ * can release only that, and a record left behind after ANOTHER owner replaced
+ * the channel starts matching again the moment a third owner installs equal
+ * content — at which point the stale owner's next release destroys that
+ * owner's presentation (#2654 fourth review).
  *
- * `state` is the slice as Zustand hands it in — the COMBINED store at runtime,
- * a single-slice stub in slice-level test harnesses. The record fields are
- * genuinely absent in the latter, which `staleOwnershipReset` tolerates by
- * returning no keys for them.
+ * The actions below therefore do NOT each carry that invalidation, and must
+ * not start to: it is performed once for the whole store, by the wrapped `set`
+ * every slice and every `useViewerStore.setState` goes through
+ * (`store/visibility-invalidation.ts`). Review of #2867 did answer it here, in
+ * a helper each channel-writing action called — and the list was incomplete on
+ * the day it was written (`showAllInAllModels` below, and ten actions in
+ * `pinboardSlice`). A list of writers is not an invariant.
  */
-function writeChannels(state: unknown, next: SharedChannels): SharedChannels & Partial<OwnedVisibilityRecords> {
-  return { ...next, ...staleOwnershipReset(state as OwnedVisibilityRecords, next) };
-}
 
 export interface VisibilitySlice {
   // State (legacy - single model)
@@ -128,8 +115,23 @@ export interface VisibilitySlice {
    * it.
    *
    * One `set()`, one final state, one invalidation pass against it: a record
-   * that still content-matches what the restore put back survives, exactly as
-   * it did before the restore.
+   * that still content-matches what the restore put back survives.
+   *
+   * It is NOT otherwise equivalent to the replay, and both divergences are
+   * deliberate (measured in `store/visibility-channel-invalidation.test.ts`):
+   *
+   *  - `classFilter` is left alone. The replay reached `setHiddenEntities`
+   *    whenever anything was hidden, and that setter nulls the class filter, so
+   *    closing Space Sketch used to drop a Class-tab filter the tool never
+   *    touched.
+   *  - a captured ISOLATION now survives a non-empty captured hidden set. The
+   *    replay restored the isolation and then `setHiddenEntities` nulled it
+   *    again one call later, so that combination came back without its
+   *    isolation. This is the fix, not a side effect — but it is a behaviour
+   *    change, not a no-op refactor.
+   *
+   * Both channels are written exactly as captured, including a both-non-null
+   * pair — see the body for why that pair is legal.
    */
   restoreVisibilityState: (prior: {
     isolated: Set<number> | null;
@@ -218,13 +220,14 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
       state.isolatedEntities.has(id);
 
     if (isAlreadyIsolated) {
-      return writeChannels(state, { isolatedEntities: null, ghostExceptEntities: state.ghostExceptEntities });
+      return { isolatedEntities: null, ghostExceptEntities: state.ghostExceptEntities };
     } else {
       // Isolate this entity (and unhide it)
       const newHidden = new Set(state.hiddenEntities);
       newHidden.delete(id);
       return {
-        ...writeChannels(state, { isolatedEntities: new Set([id]), ghostExceptEntities: state.ghostExceptEntities }),
+        isolatedEntities: new Set([id]),
+        ghostExceptEntities: state.ghostExceptEntities,
         hiddenEntities: newHidden,
       };
     }
@@ -238,19 +241,20 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
       ids.every(id => state.isolatedEntities!.has(id));
 
     if (isAlreadyIsolated) {
-      return writeChannels(state, { isolatedEntities: null, ghostExceptEntities: state.ghostExceptEntities });
+      return { isolatedEntities: null, ghostExceptEntities: state.ghostExceptEntities };
     } else {
       // Isolate these entities (and unhide them)
       const newHidden = new Set(state.hiddenEntities);
       ids.forEach(id => newHidden.delete(id));
       return {
-        ...writeChannels(state, { isolatedEntities: idsSet, ghostExceptEntities: state.ghostExceptEntities }),
+        isolatedEntities: idsSet,
+        ghostExceptEntities: state.ghostExceptEntities,
         hiddenEntities: newHidden,
       };
     }
   }),
 
-  clearIsolation: () => set((state) => writeChannels(state, {
+  clearIsolation: () => set((state) => ({
     isolatedEntities: null,
     ghostExceptEntities: state.ghostExceptEntities,
   })),
@@ -269,49 +273,57 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
 
   clearClassFilter: () => set({ classFilter: null }),
 
-  clearAllFilters: () => set((state) => ({
-    ...writeChannels(state, { isolatedEntities: null, ghostExceptEntities: null }),
+  clearAllFilters: () => set({
+    isolatedEntities: null,
+    ghostExceptEntities: null,
     classFilter: null,
-  })),
+  }),
 
-  showAll: () => set((state) => ({
-    ...writeChannels(state, { isolatedEntities: null, ghostExceptEntities: null }),
+  showAll: () => set({
+    isolatedEntities: null,
+    ghostExceptEntities: null,
     hiddenEntities: new Set<number>(),
     classFilter: null,
-  })),
+  }),
 
-  setHiddenEntities: (ids) => set((state) => ({
-    ...writeChannels(state, { isolatedEntities: null, ghostExceptEntities: null }),
+  setHiddenEntities: (ids) => set({
+    isolatedEntities: null,
+    ghostExceptEntities: null,
     hiddenEntities: new Set(ids),
     classFilter: null,
-  })),
+  }),
 
-  setIsolatedEntities: (ids) => set((state) => ({
-    ...writeChannels(state, {
-      isolatedEntities: ids ? new Set(ids) : null,
-      ghostExceptEntities: null, // Isolation (hide) and ghosting are mutually exclusive
-    }),
+  setIsolatedEntities: (ids) => set({
+    isolatedEntities: ids ? new Set(ids) : null,
+    ghostExceptEntities: null, // Isolation (hide) and ghosting are mutually exclusive
     hiddenEntities: new Set<number>(), // Clear hidden when setting isolation
-  })),
+  }),
 
-  setGhostExceptEntities: (ids) => set((state) => writeChannels(state, {
+  setGhostExceptEntities: (ids) => set({
     ghostExceptEntities: ids ? new Set(ids) : null,
     // Ghosting shows the rest translucent — clear isolation (which hides it).
     isolatedEntities: null,
-  })),
+  }),
 
-  restoreVisibilityState: ({ isolated, ghostExcept, hidden }) => set((state) => ({
-    // Verbatim, both channels together — the capture can only ever have
-    // observed a legal pair, because every writer of these two enforces their
-    // mutual exclusion.
-    ...writeChannels(state, {
-      isolatedEntities: isolated ? new Set(isolated) : null,
-      ghostExceptEntities: ghostExcept ? new Set(ghostExcept) : null,
-    }),
+  restoreVisibilityState: ({ isolated, ghostExcept, hidden }) => set({
+    // Verbatim, both channels together — including the both-non-null pair,
+    // which IS reachable and is therefore restored rather than normalised. The
+    // individual setters each clear the other channel, but the actions that
+    // deliberately PRESERVE it (`isolateEntity` / `isolateEntities` /
+    // `clearIsolation` / `clearGhost`) do not, so
+    // `setGhostExceptEntities([9]); isolateEntity(5)` leaves isolated={5} and
+    // ghost={9} — and `showPinboard` reaches the same shape from the basket
+    // side. The pair is coherent downstream — isolation filters, ghosting then
+    // fades what survived it (`lib/geo/cesium-model-glb.ts`, which restates the
+    // render pass's order for the world view) — and a capture that observed it
+    // is a view the user actually had; normalising one channel away here would
+    // restore a view they never saw.
+    isolatedEntities: isolated ? new Set(isolated) : null,
+    ghostExceptEntities: ghostExcept ? new Set(ghostExcept) : null,
     hiddenEntities: new Set(hidden),
-  })),
+  }),
 
-  clearGhost: () => set((state) => writeChannels(state, {
+  clearGhost: () => set((state) => ({
     ghostExceptEntities: null,
     isolatedEntities: state.isolatedEntities,
   })),

--- a/apps/viewer/src/store/slices/visibilitySlice.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.ts
@@ -19,6 +19,39 @@ import {
   TYPE_VIEW_MODE_STORAGE_KEY,
   type TypeViewMode,
 } from '../constants.js';
+import {
+  staleOwnershipReset,
+  type OwnedVisibilityRecords,
+} from '../../lib/visibility/ownership.js';
+
+/** The two shared channels, as a write about to be committed sets them. */
+interface SharedChannels {
+  isolatedEntities: Set<number> | null;
+  ghostExceptEntities: Set<number> | null;
+}
+
+/**
+ * A channel write, plus the invalidation of every visibility-ownership record
+ * it just made stale (review of #2867 — see `staleOwnershipReset`).
+ *
+ * `isolatedEntities` / `ghostExceptEntities` are shared by clash, IDS,
+ * "Isolate in 3D", assembly isolation, `LayerDiffView`, Space Sketch, BCF and
+ * `syncSourceModel`. Features record what they installed so they can release
+ * only that, and a record left behind after ANOTHER owner replaced the channel
+ * starts matching again the moment a third owner installs equal content — at
+ * which point the stale owner's next release destroys that owner's
+ * presentation. Answering it here, where the channels are actually written,
+ * covers every owner in both directions at once; answering it per caller
+ * covers whichever direction was reported and waits for the next one.
+ *
+ * `state` is the slice as Zustand hands it in — the COMBINED store at runtime,
+ * a single-slice stub in slice-level test harnesses. The record fields are
+ * genuinely absent in the latter, which `staleOwnershipReset` tolerates by
+ * returning no keys for them.
+ */
+function writeChannels(state: unknown, next: SharedChannels): SharedChannels & Partial<OwnedVisibilityRecords> {
+  return { ...next, ...staleOwnershipReset(state as OwnedVisibilityRecords, next) };
+}
 
 export interface VisibilitySlice {
   // State (legacy - single model)
@@ -79,6 +112,30 @@ export interface VisibilitySlice {
   setIsolatedEntities: (ids: Set<number> | null) => void;
   /** Ghost everything except these entities (X-Ray context). `null` clears it. */
   setGhostExceptEntities: (ids: Set<number> | null) => void;
+  /**
+   * Put a previously CAPTURED view back, all three fields at once.
+   *
+   * Restoring through the individual setters cannot express this: each of them
+   * clears the others (isolation and ghosting are mutually exclusive, and
+   * isolation supersedes per-entity hiding), so a three-call replay passes
+   * through intermediate states the user never had. That used to be invisible;
+   * it stopped being invisible once a channel write started invalidating the
+   * ownership records it makes stale (review of #2867) — restoring a captured
+   * clash GHOST went `setIsolatedEntities(null)` (which nulls the ghost
+   * channel, killing the record) and only then `setGhostExceptEntities(...)`,
+   * so the presentation came back with its claim laundered off. That is #2662
+   * P2 by another route, and `useClash.run-preserves-isolation.test.tsx` catches
+   * it.
+   *
+   * One `set()`, one final state, one invalidation pass against it: a record
+   * that still content-matches what the restore put back survives, exactly as
+   * it did before the restore.
+   */
+  restoreVisibilityState: (prior: {
+    isolated: Set<number> | null;
+    ghostExcept: Set<number> | null;
+    hidden: Set<number>;
+  }) => void;
   /** Clear X-Ray context ghosting. */
   clearGhost: () => void;
 
@@ -161,13 +218,13 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
       state.isolatedEntities.has(id);
 
     if (isAlreadyIsolated) {
-      return { isolatedEntities: null };
+      return writeChannels(state, { isolatedEntities: null, ghostExceptEntities: state.ghostExceptEntities });
     } else {
       // Isolate this entity (and unhide it)
       const newHidden = new Set(state.hiddenEntities);
       newHidden.delete(id);
       return {
-        isolatedEntities: new Set([id]),
+        ...writeChannels(state, { isolatedEntities: new Set([id]), ghostExceptEntities: state.ghostExceptEntities }),
         hiddenEntities: newHidden,
       };
     }
@@ -181,19 +238,22 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
       ids.every(id => state.isolatedEntities!.has(id));
 
     if (isAlreadyIsolated) {
-      return { isolatedEntities: null };
+      return writeChannels(state, { isolatedEntities: null, ghostExceptEntities: state.ghostExceptEntities });
     } else {
       // Isolate these entities (and unhide them)
       const newHidden = new Set(state.hiddenEntities);
       ids.forEach(id => newHidden.delete(id));
       return {
-        isolatedEntities: idsSet,
+        ...writeChannels(state, { isolatedEntities: idsSet, ghostExceptEntities: state.ghostExceptEntities }),
         hiddenEntities: newHidden,
       };
     }
   }),
 
-  clearIsolation: () => set({ isolatedEntities: null }),
+  clearIsolation: () => set((state) => writeChannels(state, {
+    isolatedEntities: null,
+    ghostExceptEntities: state.ghostExceptEntities,
+  })),
 
   setClassFilter: (ids, label) => set((state) => {
     const idsSet = new Set(ids);
@@ -209,25 +269,52 @@ export const createVisibilitySlice: StateCreator<VisibilitySlice, [], [], Visibi
 
   clearClassFilter: () => set({ classFilter: null }),
 
-  clearAllFilters: () => set({ isolatedEntities: null, classFilter: null, ghostExceptEntities: null }),
+  clearAllFilters: () => set((state) => ({
+    ...writeChannels(state, { isolatedEntities: null, ghostExceptEntities: null }),
+    classFilter: null,
+  })),
 
-  showAll: () => set({ hiddenEntities: new Set(), isolatedEntities: null, classFilter: null, ghostExceptEntities: null }),
+  showAll: () => set((state) => ({
+    ...writeChannels(state, { isolatedEntities: null, ghostExceptEntities: null }),
+    hiddenEntities: new Set<number>(),
+    classFilter: null,
+  })),
 
-  setHiddenEntities: (ids) => set({ hiddenEntities: new Set(ids), isolatedEntities: null, classFilter: null, ghostExceptEntities: null }),
+  setHiddenEntities: (ids) => set((state) => ({
+    ...writeChannels(state, { isolatedEntities: null, ghostExceptEntities: null }),
+    hiddenEntities: new Set(ids),
+    classFilter: null,
+  })),
 
-  setIsolatedEntities: (ids) => set({
-    isolatedEntities: ids ? new Set(ids) : null,
-    hiddenEntities: new Set(), // Clear hidden when setting isolation
-    ghostExceptEntities: null, // Isolation (hide) and ghosting are mutually exclusive
-  }),
+  setIsolatedEntities: (ids) => set((state) => ({
+    ...writeChannels(state, {
+      isolatedEntities: ids ? new Set(ids) : null,
+      ghostExceptEntities: null, // Isolation (hide) and ghosting are mutually exclusive
+    }),
+    hiddenEntities: new Set<number>(), // Clear hidden when setting isolation
+  })),
 
-  setGhostExceptEntities: (ids) => set({
+  setGhostExceptEntities: (ids) => set((state) => writeChannels(state, {
     ghostExceptEntities: ids ? new Set(ids) : null,
     // Ghosting shows the rest translucent — clear isolation (which hides it).
     isolatedEntities: null,
-  }),
+  })),
 
-  clearGhost: () => set({ ghostExceptEntities: null }),
+  restoreVisibilityState: ({ isolated, ghostExcept, hidden }) => set((state) => ({
+    // Verbatim, both channels together — the capture can only ever have
+    // observed a legal pair, because every writer of these two enforces their
+    // mutual exclusion.
+    ...writeChannels(state, {
+      isolatedEntities: isolated ? new Set(isolated) : null,
+      ghostExceptEntities: ghostExcept ? new Set(ghostExcept) : null,
+    }),
+    hiddenEntities: new Set(hidden),
+  })),
+
+  clearGhost: () => set((state) => writeChannels(state, {
+    ghostExceptEntities: null,
+    isolatedEntities: state.isolatedEntities,
+  })),
 
   isEntityVisible: (id) => {
     const state = get();

--- a/apps/viewer/src/store/visibility-channel-invalidation.test.ts
+++ b/apps/viewer/src/store/visibility-channel-invalidation.test.ts
@@ -1,0 +1,435 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * EVERY write of `isolatedEntities` / `ghostExceptEntities` invalidates the
+ * ownership records it makes stale — whichever slice performs it.
+ *
+ * Review of #2867 answered the stale-record question in `visibilitySlice`'s
+ * named setters. That is a LIST, and the list was already incomplete when it
+ * was written: `showAllInAllModels` in the same file wrote both channels
+ * through a bare `set()`, and `pinboardSlice` — a different slice entirely —
+ * writes `isolatedEntities` from ten of its actions. Every one of them stranded a
+ * record, and a stranded record is not inert: ownership is tested by VALUE, so
+ * it goes matching → cleared → MATCHING AGAIN the moment another owner
+ * installs a set with equal content, at which point that owner's presentation
+ * is what the stale release destroys (#2654 fourth review).
+ *
+ * The invariant is therefore enforced at the store's `set` itself
+ * (`withVisibilityOwnershipInvalidation`, store/visibility-invalidation.ts) —
+ * there is no way to reach these two fields that does not go through it. This
+ * file pins that for the writers that used to bypass it, and pins the
+ * over-firing side too: a write that leaves a record's content intact must NOT
+ * invalidate it, or the content-preserving replays lose their claim (#2662 P2).
+ */
+
+import { beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { useViewerStore } from './index.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+const store = () => useViewerStore.getState();
+const isolated = () => {
+  const s = store().isolatedEntities;
+  return s ? [...s].sort((a, b) => a - b) : null;
+};
+const ghosted = () => {
+  const s = store().ghostExceptEntities;
+  return s ? [...s].sort((a, b) => a - b) : null;
+};
+
+beforeEach(() => {
+  useViewerStore.setState({
+    // Two models with `idOffset` 0 / 1000 — A's global ids equal its expressIds.
+    models: new Map([['A', model('A', 0, 100)], ['B', model('B', 1000, 1100)]]),
+    activeModelId: 'A',
+    hiddenEntities: new Set(),
+    isolatedEntities: null,
+    ghostExceptEntities: null,
+    classFilter: null,
+    hiddenEntitiesByModel: new Map(),
+    isolatedEntitiesByModel: new Map(),
+    pinboardEntities: new Set(),
+    activeBasketViewId: null,
+    idsFocusVisibilityOwned: null,
+    clashVisibilityOwned: null,
+    idsValidationReport: null,
+  });
+});
+
+/** Put `ids` on the named channel and record IDS as its owner, the way
+ *  `useIDS.installFocusIsolation` / `installFocusGhost` do: channel first,
+ *  record second. */
+function idsOwns(channel: 'isolate' | 'ghost', ids: number[]): void {
+  if (channel === 'isolate') store().setIsolatedEntities(new Set(ids));
+  else store().setGhostExceptEntities(new Set(ids));
+  store().setIdsFocusVisibilityOwned({ channel, ids: new Set(ids) });
+}
+
+function clashOwns(channel: 'isolate' | 'ghost', ids: number[]): void {
+  if (channel === 'isolate') store().setIsolatedEntities(new Set(ids));
+  else store().setGhostExceptEntities(new Set(ids));
+  store().setClashVisibilityOwned({ channel, ids: new Set(ids) });
+}
+
+// ─── D1: `showAllInAllModels` — the eighth writer in the same file ──────────
+
+describe('showAllInAllModels ends every claim on the channels it clears', () => {
+  it('drops an IDS ghost record when it nulls the ghost channel', () => {
+    idsOwns('ghost', [7]);
+    assert.deepEqual(ghosted(), [7], 'setup: IDS owns the ghost channel');
+
+    store().showAllInAllModels();
+
+    assert.equal(ghosted(), null, 'setup: "show all" really does clear the ghost');
+    assert.equal(
+      store().idsFocusVisibilityOwned,
+      null,
+      'the IDS claim ended with its presentation — a record that outlives it re-matches later',
+    );
+  });
+
+  it('drops a clash isolate record when it nulls the isolate channel', () => {
+    clashOwns('isolate', [4, 5]);
+    assert.deepEqual(isolated(), [4, 5], 'setup: clash owns the isolate channel');
+
+    store().showAllInAllModels();
+
+    assert.equal(isolated(), null, 'setup: "show all" really does clear the isolation');
+    assert.equal(store().clashVisibilityOwned, null, 'the rule is symmetric or it is not a rule');
+  });
+
+  it('the destruction chain: a stranded IDS ghost destroys the NEXT owner of the same content', () => {
+    idsOwns('ghost', [7]);
+    // 1. "Show all across all models" wipes the IDS ghost off the screen.
+    store().showAllInAllModels();
+    // 2. Clash installs a ghost that happens to hold the SAME element.
+    clashOwns('ghost', [7]);
+    assert.deepEqual(ghosted(), [7], 'setup: the clash ghost is on screen');
+    // 3. The user clears the IDS report. Its teardown releases "its" ghost —
+    //    which, by value, is now clash's.
+    store().clearIdsValidationReport();
+
+    assert.deepEqual(
+      ghosted(),
+      [7],
+      "clash's ghost must survive a teardown of a presentation that ended two steps ago",
+    );
+  });
+});
+
+// ─── D2: `pinboardSlice` — a different slice, ten bare writers ──────────────
+
+describe('every pinboard write of the isolate channel ends the claims it invalidates', () => {
+  const REFS = [{ modelId: 'A', expressId: 3 }];
+
+  it('clearPinboard', () => {
+    idsOwns('isolate', [9]);
+    store().clearPinboard();
+    assert.equal(isolated(), null, 'setup: the basket clear nulls the isolation');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('clearBasket', () => {
+    idsOwns('isolate', [9]);
+    store().clearBasket();
+    assert.equal(isolated(), null, 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('addToPinboard', () => {
+    idsOwns('isolate', [9]);
+    store().addToPinboard(REFS);
+    assert.deepEqual(isolated(), [3], 'setup: the basket now owns the channel');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('setPinboard', () => {
+    idsOwns('isolate', [9]);
+    store().setPinboard(REFS);
+    assert.deepEqual(isolated(), [3], 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('showPinboard', () => {
+    store().setPinboard(REFS);
+    idsOwns('isolate', [9]);
+    store().showPinboard();
+    assert.deepEqual(isolated(), [3], 'setup: re-isolating the basket replaced the IDS isolation');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('setBasket (non-empty)', () => {
+    idsOwns('isolate', [9]);
+    store().setBasket(REFS);
+    assert.deepEqual(isolated(), [3], 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('setBasket (empty — the early-return branch)', () => {
+    idsOwns('isolate', [9]);
+    store().setBasket([]);
+    assert.equal(isolated(), null, 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('addToBasket', () => {
+    idsOwns('isolate', [9]);
+    store().addToBasket(REFS);
+    assert.deepEqual(isolated(), [3, 9], 'setup: the incremental add keeps the prior set and extends it');
+    assert.equal(
+      store().idsFocusVisibilityOwned,
+      null,
+      'the channel no longer holds exactly {9} — the IDS record no longer describes what is on screen',
+    );
+  });
+
+  it('removeFromBasket (down to empty)', () => {
+    store().setBasket(REFS);
+    idsOwns('isolate', [9]);
+    store().removeFromBasket(REFS);
+    assert.equal(isolated(), null, 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('removeFromBasket (still non-empty)', () => {
+    store().setBasket([{ modelId: 'A', expressId: 3 }, { modelId: 'A', expressId: 4 }]);
+    idsOwns('isolate', [9, 4]);
+    store().removeFromBasket([{ modelId: 'A', expressId: 4 }]);
+    assert.deepEqual(isolated(), [9], 'setup: the incremental remove worked off the current isolation set');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('removeFromPinboard (down to empty)', () => {
+    store().setPinboard(REFS);
+    idsOwns('isolate', [9]);
+    store().removeFromPinboard(REFS);
+    assert.equal(isolated(), null, 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('removeFromPinboard (still non-empty)', () => {
+    store().setPinboard([{ modelId: 'A', expressId: 3 }, { modelId: 'A', expressId: 4 }]);
+    idsOwns('isolate', [9]);
+    store().removeFromPinboard([{ modelId: 'A', expressId: 4 }]);
+    assert.deepEqual(isolated(), [3], 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('restoreBasketEntities', () => {
+    idsOwns('isolate', [9]);
+    store().restoreBasketEntities(['A:3'], 'view-1');
+    assert.deepEqual(isolated(), [3], 'setup');
+    assert.equal(store().idsFocusVisibilityOwned, null);
+  });
+
+  it('a direct `useViewerStore.setState` of the channel is covered too, not just slice actions', () => {
+    // `setState` IS the store's wrapped setter. Real callers reach the channels
+    // this way — the BCF snapshot loops in `useClash` / `useIDS` restore the
+    // saved isolation with it, and so does the collab room.
+    idsOwns('isolate', [9]);
+    useViewerStore.setState({ isolatedEntities: new Set([2]) });
+    assert.deepEqual(isolated(), [2], 'setup');
+    assert.equal(
+      store().idsFocusVisibilityOwned,
+      null,
+      'a setter that skipped `setState` would leave the largest bypass of all open',
+    );
+  });
+
+  it("the destruction chain: a stranded record wipes the user's own hand-made isolation", () => {
+    // 1. An IDS row focus isolates element 3 and records `{isolate, {3}}`.
+    idsOwns('isolate', [3]);
+    // 2. The user clears the basket. `clearPinboard` nulls the isolate channel,
+    //    so the IDS presentation is gone from the screen.
+    store().clearPinboard();
+    assert.equal(isolated(), null, 'setup: the IDS isolation is off screen');
+    // 3. The user isolates element 3 BY HAND ("Isolate in 3D" / the model tree).
+    //    Equal content to what IDS once installed — and IDS installed none of it.
+    store().setIsolatedEntities(new Set([3]));
+    // 4. Anything that tears the IDS report down releases "its" isolation.
+    store().clearIdsValidationReport();
+
+    assert.deepEqual(
+      isolated(),
+      [3],
+      "the user's own isolation must survive — a stale record matching it by value is #2654 reopened",
+    );
+  });
+});
+
+// ─── The other direction: invalidation must not OVER-fire ──────────────────
+
+describe('a write that leaves a record\'s content intact does not invalidate it', () => {
+  it('showPinboard re-installing exactly what is already isolated keeps the basket owner\'s claim', () => {
+    store().setPinboard([{ modelId: 'A', expressId: 3 }]);
+    // Pretend the basket's isolation is a feature-owned presentation with a
+    // record — the same content-preserving replay Space Sketch's view capture
+    // and `syncSourceModel`'s rebuild perform (#2662 P2).
+    store().setClashVisibilityOwned({ channel: 'isolate', ids: new Set([3]) });
+
+    store().showPinboard();
+
+    assert.deepEqual(isolated(), [3], 'setup: the channel content is unchanged');
+    assert.deepEqual(
+      store().clashVisibilityOwned,
+      { channel: 'isolate', ids: new Set([3]) },
+      'a content-preserving rewrite must not convert a feature-owned focus into "user" state',
+    );
+  });
+
+  it('a basket edit that happens to leave the channel content unchanged keeps the record', () => {
+    // `removeFromBasket` works incrementally off whatever is currently
+    // isolated, so removing a ref that is not in it rewrites the channel to an
+    // EQUAL set. Value identity's one false positive, and it is harmless by
+    // construction: the channel still shows exactly what the record describes,
+    // so releasing it renders precisely what discarding that presentation
+    // should render.
+    store().setBasket([{ modelId: 'A', expressId: 3 }]);
+    idsOwns('isolate', [9]);
+    store().removeFromBasket([{ modelId: 'A', expressId: 4 }]);
+    assert.deepEqual(isolated(), [9], 'setup: the content is unchanged');
+    assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'isolate', ids: new Set([9]) });
+  });
+
+  it('a write of ONE channel leaves a record on the OTHER one alone', () => {
+    // `setBasket` writes `isolatedEntities` and never mentions the ghost
+    // channel, which therefore still shows exactly what its owner installed.
+    // Reading the untouched channel as "null" instead of "unchanged" would
+    // invalidate a presentation that is still on screen.
+    store().setGhostExceptEntities(new Set([7]));
+    store().setClashVisibilityOwned({ channel: 'ghost', ids: new Set([7]) });
+
+    store().setBasket([{ modelId: 'A', expressId: 3 }]);
+
+    assert.deepEqual(isolated(), [3], 'setup: the basket took the isolate channel');
+    assert.deepEqual(ghosted(), [7], 'setup: the ghost channel is untouched');
+    assert.deepEqual(
+      store().clashVisibilityOwned,
+      { channel: 'ghost', ids: new Set([7]) },
+      'the clash ghost is still exactly what clash installed — its claim stands',
+    );
+  });
+
+  it('and the mirror: a ghost-only write leaves an ISOLATE record alone', () => {
+    // No slice action writes the ghost channel without also writing isolate,
+    // but `setState` can and does — this pins the other half of "unchanged
+    // means unchanged" rather than leaving it to the writers that exist today.
+    store().setIsolatedEntities(new Set([4]));
+    store().setClashVisibilityOwned({ channel: 'isolate', ids: new Set([4]) });
+
+    useViewerStore.setState({ ghostExceptEntities: new Set([7]) });
+
+    assert.deepEqual(isolated(), [4], 'setup: the isolate channel is untouched');
+    assert.deepEqual(store().clashVisibilityOwned, { channel: 'isolate', ids: new Set([4]) });
+  });
+
+  it('a write that touches NEITHER channel leaves both records alone', () => {
+    idsOwns('ghost', [7]);
+    store().setClashVisibilityOwned({ channel: 'ghost', ids: new Set([7]) });
+
+    store().hideEntities([42]);
+    store().setBasketPresentationVisible(true);
+
+    assert.deepEqual(store().idsFocusVisibilityOwned, { channel: 'ghost', ids: new Set([7]) });
+    assert.deepEqual(store().clashVisibilityOwned, { channel: 'ghost', ids: new Set([7]) });
+  });
+
+  it('an installer that writes the channel and its record in ONE set() keeps the record', () => {
+    // Not how the current installers are written (channel first, record
+    // second), but the choke point must not eat a record that arrives in the
+    // same patch as the channel it describes. The previous claim IS stale here
+    // — {9} is not what the write leaves behind — so without the exception the
+    // invalidation would null the brand-new record along with it.
+    store().setIsolatedEntities(new Set([9]));
+    store().setClashVisibilityOwned({ channel: 'isolate', ids: new Set([9]) });
+
+    useViewerStore.setState({
+      isolatedEntities: new Set([11]),
+      clashVisibilityOwned: { channel: 'isolate', ids: new Set([11]) },
+    });
+
+    assert.deepEqual(isolated(), [11], 'setup');
+    assert.deepEqual(
+      store().clashVisibilityOwned,
+      { channel: 'isolate', ids: new Set([11]) },
+      'a record can never be invalidated by the very write that installed it',
+    );
+  });
+});
+
+// ─── D4: what the atomic restore changed, besides the laundering ───────────
+
+describe('restoreVisibilityState diverges from the three-call replay it replaced', () => {
+  /** The replay `useSpaceSceneFraming.restore` used before this action existed. */
+  function oldReplay(prior: { isolated: Set<number> | null; ghostExcept: Set<number> | null; hidden: Set<number> }): void {
+    store().setIsolatedEntities(prior.isolated);
+    if (prior.hidden.size > 0) store().setHiddenEntities(prior.hidden);
+    if (prior.ghostExcept) store().setGhostExceptEntities(prior.ghostExcept);
+  }
+
+  const PRIOR = { isolated: new Set([3]), ghostExcept: null, hidden: new Set([8]) };
+
+  it('keeps a captured isolation that the replay destroyed on its way past hidden', () => {
+    store().setClassFilter([1, 2], 'IfcWall');
+    oldReplay({ isolated: new Set(PRIOR.isolated), ghostExcept: null, hidden: new Set(PRIOR.hidden) });
+    assert.equal(
+      isolated(),
+      null,
+      'the replay restored the isolation and then `setHiddenEntities` nulled it again',
+    );
+
+    store().setClassFilter([1, 2], 'IfcWall');
+    store().restoreVisibilityState({
+      isolated: new Set(PRIOR.isolated),
+      ghostExcept: null,
+      hidden: new Set(PRIOR.hidden),
+    });
+    assert.deepEqual(isolated(), [3], 'the atomic restore puts back what was captured');
+    assert.deepEqual([...store().hiddenEntities], [8], 'both, together — that is the point');
+  });
+
+  it('leaves classFilter alone, where the replay cleared it', () => {
+    store().setClassFilter([1, 2], 'IfcWall');
+    oldReplay({ isolated: null, ghostExcept: null, hidden: new Set([8]) });
+    assert.equal(
+      store().classFilter,
+      null,
+      '`setHiddenEntities` nulls the class filter, so the replay cleared it whenever anything was hidden',
+    );
+
+    store().setClassFilter([1, 2], 'IfcWall');
+    store().restoreVisibilityState({ isolated: null, ghostExcept: null, hidden: new Set([8]) });
+    assert.equal(
+      store().classFilter?.label,
+      'IfcWall',
+      'the atomic restore writes the three fields it captured and nothing else',
+    );
+  });
+});
+
+// ─── D3: a both-non-null channel pair is reachable, and is restored as-is ──
+
+describe('both channels can legitimately be non-null at once', () => {
+  it('the actions that preserve the other channel reach it', () => {
+    store().setGhostExceptEntities(new Set([9]));
+    store().isolateEntity(5);
+    assert.deepEqual(isolated(), [5]);
+    assert.deepEqual(ghosted(), [9], '`isolateEntity` deliberately preserves the ghost channel');
+  });
+
+  it('and restoreVisibilityState puts that pair back verbatim rather than normalising it', () => {
+    store().restoreVisibilityState({
+      isolated: new Set([5]),
+      ghostExcept: new Set([9]),
+      hidden: new Set(),
+    });
+    assert.deepEqual(isolated(), [5]);
+    assert.deepEqual(ghosted(), [9], 'a captured view the user actually had must come back as that view');
+  });
+});

--- a/apps/viewer/src/store/visibility-invalidation.ts
+++ b/apps/viewer/src/store/visibility-invalidation.ts
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The one place `isolatedEntities` / `ghostExceptEntities` can be written —
+ * the store's own `set`.
+ *
+ * ## Why this is a middleware and not a helper
+ *
+ * These two channels are shared by clash, IDS, "Isolate in 3D", assembly
+ * isolation, `LayerDiffView`, Space Sketch, BCF, the basket and
+ * `syncSourceModel`. Each feature records what it installed so its teardown
+ * can release only that, and ownership is tested by VALUE — so a record left
+ * behind after ANOTHER owner replaced the channel is not inert: it goes
+ * matching → cleared → MATCHING AGAIN the moment a third owner installs a set
+ * with equal content, at which point the stale owner's next release destroys
+ * that owner's presentation (#2654 fourth review).
+ *
+ * Review of #2867 answered that in `visibilitySlice`'s named setters. A list
+ * of writers is not an invariant: the same file's `showAllInAllModels` wrote
+ * both channels through a bare `set()` and was already off the list the day it
+ * was written, and `pinboardSlice` — a different slice — writes
+ * `isolatedEntities` from ten of its actions, every one of them stranding
+ * records.
+ * Wrapping `set` itself removes the choice. A slice cannot reach these fields
+ * except through the store's `set`, and `useViewerStore.setState` is the same
+ * wrapped function, so a writer added in any slice, or a direct `setState`
+ * from a hook or a test, is covered without being told to be.
+ *
+ * ## What it does, and what it deliberately does not do
+ *
+ * Invalidation is by CONTENT, not by "somebody wrote": `staleOwnershipReset`
+ * is given the channel state the write is about to commit, and a record still
+ * content-matching it survives. That is what keeps the content-preserving
+ * replays alive — Space Sketch's open/close view capture and
+ * `syncSourceModel`'s rebuild both push an unchanged channel back through
+ * `set`, and under a blanket "any write invalidates" rule they would silently
+ * convert a feature-owned focus into "user" state, which is #2662 P2 again.
+ *
+ * A record field the patch ITSELF carries is left exactly as the patch has it.
+ * An installer committing the channel and its claim in one `set()` is stating
+ * both at once and must not have the claim eaten by the write that created it.
+ * (Today's installers write the channel first and the record second, two
+ * `set()`s — this makes the atomic form safe too rather than a latent trap.)
+ *
+ * A patch touching NEITHER channel is returned by reference, so the common
+ * case adds no keys, allocates nothing, and preserves the identity-return
+ * optimisation slices use to skip subscriber notifications
+ * (`setHasTypeGeometry`).
+ */
+
+import type { StateCreator, StoreMutatorIdentifier } from 'zustand';
+import {
+  staleOwnershipReset,
+  type OwnedVisibilityRecords,
+  type VisibilityChannels,
+} from '../lib/visibility/ownership.js';
+
+/** The state surface this middleware reads: the two shared channels plus every
+ *  ownership record over them. */
+type ChannelState = Pick<VisibilityChannels, 'isolatedEntities' | 'ghostExceptEntities'> &
+  OwnedVisibilityRecords;
+
+type SetState<T> = (
+  partial: T | Partial<T> | ((state: T) => T | Partial<T>),
+  replace?: boolean | undefined,
+) => void;
+
+/**
+ * Wrap a state creator so every write that replaces a shared visibility
+ * channel also drops the ownership records that write makes stale.
+ */
+export function withVisibilityOwnershipInvalidation<
+  T extends ChannelState,
+  Mps extends [StoreMutatorIdentifier, unknown][] = [],
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
+>(creator: StateCreator<T, Mps, Mcs>): StateCreator<T, Mps, Mcs> {
+  return ((set, get, api) => {
+    const guardedSet: SetState<T> = (partial, replace) => {
+      (set as SetState<T>)((state: T) => {
+        const patch = typeof partial === 'function'
+          ? (partial as (s: T) => T | Partial<T>)(state)
+          : partial;
+        return applyOwnershipInvalidation(state, patch);
+      }, replace);
+    };
+
+    // Replace the store API's own setter too, not just the one handed to the
+    // slices: `useViewerStore.setState(...)` is that function, and it is a
+    // first-class writer of these channels (BCF viewpoint application, the
+    // collab room, test harnesses). Leaving it unwrapped would reintroduce the
+    // bypass this middleware exists to close.
+    api.setState = guardedSet as typeof api.setState;
+
+    return creator(guardedSet as typeof set, get, api);
+  }) as StateCreator<T, Mps, Mcs>;
+}
+
+/**
+ * The invalidation itself, separated from the middleware plumbing so it can be
+ * exercised directly.
+ *
+ * @returns `patch` by reference when nothing went stale.
+ */
+export function applyOwnershipInvalidation<T extends ChannelState>(
+  state: T,
+  patch: T | Partial<T>,
+): T | Partial<T> {
+  if (!patch || typeof patch !== 'object') return patch;
+
+  const writesIsolate = 'isolatedEntities' in patch;
+  const writesGhost = 'ghostExceptEntities' in patch;
+  if (!writesIsolate && !writesGhost) return patch;
+
+  // The channel state the write is about to leave behind: what the patch sets,
+  // and for the channel it does not touch, what is already there.
+  const next = {
+    isolatedEntities: writesIsolate ? patch.isolatedEntities ?? null : state.isolatedEntities ?? null,
+    ghostExceptEntities: writesGhost ? patch.ghostExceptEntities ?? null : state.ghostExceptEntities ?? null,
+  };
+
+  const reset = staleOwnershipReset(state, next);
+  let stale = false;
+  for (const field of Object.keys(reset) as (keyof OwnedVisibilityRecords)[]) {
+    // The patch states this record itself — that is the writer's own claim
+    // about the state it is committing, not a leftover from an earlier one.
+    if (field in patch) delete reset[field];
+    else stale = true;
+  }
+  if (!stale) return patch;
+
+  return { ...patch, ...reset };
+}


### PR DESCRIPTION
Implements #2867 the way you asked — *"lets start by reusing clash approach and we can always add more options like isolate storey etc"*. **Option 1 only; no storey isolation.**

## The problem

Clicking an IDS result row called `selectEntity` (`useIDS.ts:477-504`): set `idsActiveEntity`, set store selection, frame after 50ms. That was the whole action — no isolation, no ghosting, no highlight of its own. The activated entity kept the report's red-if-failed / green-if-passed colour, so **a freshly activated failing element looked identical to every other failing element around it**, and if it sat behind geometry the camera moved to it while nothing made it findable. IDS had set-level isolation but no single-entity equivalent.

## What it mirrors

`idsFocusMode: 'highlight' | 'isolate' | 'ghost'` mirrors `ClashFocusMode` (`clashSlice.ts:45`), same persistence, **same default `'ghost'`**. `installFocusIsolation` / `installFocusGhost` / `applyFocusMode` / `focusEntity` mirror `useClash.ts:314` / `:326` / `:850` / `:871`, including the read-back from the store so the ownership record holds what the channel actually shows. Distinct cyan via the **colour-override channel** rather than a selection outline (`useClash.ts:892-896`), layered on top of the report colours. Same segmented "On select:" control as `ClashPanel.tsx:1034-1054`, and changing mode re-applies to the active row without a re-click.

Two product judgements, both deliberate:
1. **Default `ghost`**, matching clash — isolate alone answers "remove the clutter" but discards the where-am-I context this issue is actually about.
2. **IDS `highlight` releases only what the row focus installed**, unlike clash's, which clears both channels outright. IDS has set-level isolation (`isolateFailed`/`Passed`/`Involved`) that clash lacks, and a row click must not silently discard it.

## Visibility ownership, tested in both directions

The predicate worked out in #2654/#2662 now lives once in `src/lib/visibility/ownership.ts`; `lib/clash/visibility-ownership.ts` delegates to it with its API and docs unchanged, and the new `lib/ids/visibility-ownership.ts` asks the same predicate. One rule, one implementation.

Verified through the real hooks and real store, both ways:
- **IDS → Clash**: IDS isolate → `focusClash(…, 'ghost')` takes the channel → `ids.clearEntitySelection()`; clash's ghost survives, IDS still drops its own stale claim.
- **Clash → IDS**: clash ghost → IDS isolate takes the channel → `releaseOwnedClashVisibility(...)`; the IDS isolation survives, clash drops its stale claim.

Plus `removeModel` releasing an IDS-owned isolation, and *not* releasing a ghost IDS never installed.

Release points: row switch, mode switch, deactivation, new report, cleared report, `clearIdsDocument`, `setIdsDocument`, `removeModel`, `clearAllModels`, `resetViewerState`, panel unmount — release **before** the record is nulled, the order `endClashScenePresentation` documents.

**One behaviour worth your ruling:** `useClash.clearHighlight()` (`useClash.ts:1089-1093`) clears both channels unconditionally by design — it is the panel's "Clear selection, isolation and ghosting" button — so it will also wipe an active IDS row focus. That matches the button's stated contract, so I left it alone rather than quietly scoping it.

## Verification

12 mutants raised, **12 killed**. Four survived a first pass and each exposed a real gap rather than a scoring artefact — including one that caught **a false comment and a dead line I had written**: I claimed `clearIsolation` needed an ownership release because `setIsolatedEntities(null)` "does not touch the ghost channel". It does (`visibilitySlice.ts:224-228` — the channels are mutually exclusive). The redundant call is gone and the comment now states what actually holds.

| | files | tests |
|---|---|---|
| before (34 neighbouring IDS/clash/store suites) | 34 | 279 pass |
| after (same 34 + new suite) | 35 | 297 pass |
| new `lib/visibility/ownership.test.ts` | 1 | 7 pass |

"Before" was measured with `main`'s file content restored in place, not by arithmetic. `tsc --noEmit` clean. No changeset — `apps/viewer` is `"private": true`, confirmed against precedent commit `38ed22be0` rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IDS row-focus modes: Highlight, Isolate, and Ghost.
  * Added focus coloring and automatic cleanup when rows, reports, or models change.
  * Improved visibility restoration to preserve simultaneous hidden, isolated, and ghosted states.
  * Prevented cleanup from overwriting visibility changes made by other features.

* **Bug Fixes**
  * Fixed stale focus and visibility state after replacing reports, clearing filters, or removing models.

* **Tests**
  * Added comprehensive coverage for row-focus modes, visibility ownership, cleanup, and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->