### PR TITLE
perf(test): alias built siblings to src in the six configs that pay for it (#2943)

### DIFF
--- a/apps/viewer-embed/vitest.config.ts
+++ b/apps/viewer-embed/vitest.config.ts
@@ -7,6 +7,10 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url)).replaceAll('\\', '/');
+const BUILT_SIBLING = new RegExp(
+  `^${repoRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}packages/[^/]+/(dist|pkg)/`,
+);
 
 export default defineConfig({
   resolve: {
@@ -20,5 +24,6 @@ export default defineConfig({
     // postMessage/targetOrigin assertions exact instead of relying on a DOM impl.
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    server: { deps: { external: [BUILT_SIBLING] } },
   },
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -2,12 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url)).replaceAll('\\', '/');
+const BUILT_SIBLING = new RegExp(
+  `^${repoRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}packages/[^/]+/(dist|pkg)/`,
+);
 
 export default defineConfig({
   test: {
     globals: true,
     include: ['src/**/*.test.ts'],
+    server: { deps: { external: [BUILT_SIBLING] } },
   },
   resolve: {
     alias: {

--- a/packages/data/vitest.config.ts
+++ b/packages/data/vitest.config.ts
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url)).replaceAll('\\', '/');
+const BUILT_SIBLING = new RegExp(
+  `^${repoRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}packages/[^/]+/(dist|pkg)/`,
+);
 
 export default defineConfig({
   test: {
@@ -12,5 +18,6 @@ export default defineConfig({
     // cold cache it routinely exceeds the default 5s test timeout. Bump the
     // window so the cold-path tests don't flake.
     testTimeout: 30_000,
+    server: { deps: { external: [BUILT_SIBLING] } },
   },
 });

--- a/packages/ids/vitest.config.ts
+++ b/packages/ids/vitest.config.ts
@@ -2,11 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url)).replaceAll('\\', '/');
+const BUILT_SIBLING = new RegExp(
+  `^${repoRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}packages/[^/]+/(dist|pkg)/`,
+);
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
+    server: { deps: { external: [BUILT_SIBLING] } },
   },
 });

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -2,12 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url)).replaceAll('\\', '/');
+const BUILT_SIBLING = new RegExp(
+  `^${repoRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}packages/[^/]+/(dist|pkg)/`,
+);
 
 export default defineConfig({
   test: {
     globals: true,
     include: ['src/**/*.test.ts', 'test/**/*.test.ts'],
+    server: { deps: { external: [BUILT_SIBLING] } },
   },
   resolve: {
     alias: {

--- a/packages/parser/vitest.config.ts
+++ b/packages/parser/vitest.config.ts
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url)).replaceAll('\\', '/');
+const BUILT_SIBLING = new RegExp(
+  `^${repoRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}packages/[^/]+/(dist|pkg)/`,
+);
 
 /**
  * `--expose-gc` is required, not optional.
@@ -24,5 +30,6 @@ export default defineConfig({
   test: {
     pool: 'forks',
     env: { NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --expose-gc`.trim() },
+    server: { deps: { external: [BUILT_SIBLING] } },
   },
 });


### PR DESCRIPTION
Closes #2943 for the six packages that actually pay the cost. Every package was measured on a built workspace, three runs each, rather than pattern-matched — and the ones that showed no gain were reverted rather than left as inert edits.

## Measured, before → after

| package | transform | duration | tests |
|---|---|---|---|
| parser | 23.79s → 2.70-2.86s | 4.66s → 1.75-1.86s | 621 passed, 2 skipped |
| mcp | 16.95s → 1.24s | 2.85s → 1.10s | 271 passed |
| cli | 14.18-14.38s → 1.02-1.10s | 4.08s → 2.54-2.56s | 394 passed, 8 skipped |
| ids | 7.58-9.83s → 0.68-0.79s | 1.95-2.30s → 0.93-0.94s | 667 passed |
| data | 8.42s → 3.02-4.83s | 2.34s → 1.15-1.16s | 148 passed |
| viewer-embed | 5.18s → 0.92s | 3.69s → 0.87s | 141 passed |

Identical pass/skip counts before and after in every case. `data`'s residual is its own ~4.4 MB generated EPSG module — unrelated to this, and already covered by its `testTimeout: 30_000`.

## What was deliberately left alone

- **Seven packages have no workspace sibling dependency at all** (`create-ifc-lite`, `embed-protocol`, `extensions`, `oauth-pkce`, `plugin-api`, `pointcloud`, `server-bin`) — nothing to alias.
- **Three already alias siblings to `src/`**, sidestepping the dist-symlink path entirely (`bcf`, `embed-sdk`, `source-fixture`) — 138-473ms baseline.
- `source-dropbox` and `source-msgraph` measure ~200ms. `source-dalux` went 192ms → 157ms, which is noise, and `codegen` showed no change at all (414ms either way) — **both reverted**, since an edit that changes nothing is still a file someone has to review and maintain.

## A separate finding, not fixed here

`export` and `query` alias every sibling straight to that sibling's `src/index.ts`, deliberately, so `vitest run` works on a clean unbuilt checkout. That structurally avoids this issue's mechanism — the `BUILT_SIBLING` regex only matches `.../dist/` or `.../pkg/` — but it does **not** avoid the transform cost; it just points it at source. Measured: export 11.45-11.65s transform, query 8.99s. Closing that would mean giving up the runs-without-a-build property, which is a real trade-off and yours to make.

## On centralisation

Seven packages now carry the identical ~7-line `BUILT_SIBLING` block verbatim — sdk's from #2946 plus these six. That is genuine duplication with a real drift risk, and I would lean toward a shared base config. But there is no root `vitest.workspace.*` or base config in the tree today, so introducing one is a structural change touching all 23 configs at once — larger and riskier than this issue, and #2946 itself shipped an un-centralised copy. Flagging it rather than doing it unasked.

No changeset: `vitest.config.ts` changes only, affecting test transform behaviour, not any published package's runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
