### PR TITLE
fix(clash): report a flavor apply honestly when a refused write changed nothing

### DIFF
--- a/apps/viewer/src/lib/clash/persistence.payload.test.ts
+++ b/apps/viewer/src/lib/clash/persistence.payload.test.ts
@@ -1,0 +1,194 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The payload layer: the single functions that build the strings handed to
+ * `localStorage.setItem`, and the comparisons built on top of them.
+ *
+ * `savePresets` used to inline its `JSON.stringify` in the same `try` as the
+ * `setItem`; the serialize half is now `presetsPayload(...) === null`, and
+ * `presetsStoreIdentically` compares two rule sets through that same builder so
+ * a caller asking "would this write change the stored bytes?" compares what
+ * would actually be written. Both halves were unpinned: no test anywhere
+ * asserted `reason: 'serialize'`, and turning `presetsPayload`'s failure return
+ * from `null` into `''` — which makes `savePresets` store an empty string and
+ * report success — left every clash test passing.
+ */
+
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert';
+import {
+  buildInitialPresets,
+  loadSettings,
+  savePresets,
+  saveSettings,
+  presetsStoreIdentically,
+  settingsAlreadyStored,
+  DEFAULT_CLASH_SETTINGS,
+  type ClashPreset,
+} from './persistence.js';
+
+class MemoryStorage {
+  readonly store = new Map<string, string>();
+  getItem(key: string): string | null { return this.store.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.store.set(key, value); }
+  removeItem(key: string): void { this.store.delete(key); }
+}
+
+const g = globalThis as { localStorage?: unknown };
+const PRESETS_KEY = 'ifc-lite-clash-presets';
+const SETTINGS_KEY = 'ifc-lite-clash-settings';
+
+function customPreset(id: string): ClashPreset {
+  return {
+    id,
+    name: `Rule ${id}`,
+    description: '',
+    severity: 'major',
+    selectorA: 'IfcWall',
+    selectorB: 'IfcDoor',
+    enabled: true,
+    builtin: false,
+  };
+}
+
+/**
+ * A preset `JSON.stringify` refuses: a BigInt field throws rather than being
+ * dropped or coerced, so the whole payload cannot be built. Cast because the
+ * type forbids it — the point is what the writer does when the value it is
+ * handed is not the value the type promised.
+ */
+function unserializablePreset(id: string): ClashPreset {
+  return { ...customPreset(id), description: 1n as unknown as string };
+}
+
+describe('clash persistence: the presets payload is the single source of the stored bytes', () => {
+  let ls: MemoryStorage;
+
+  beforeEach(() => {
+    ls = new MemoryStorage();
+    g.localStorage = ls;
+    // Clear persistence.ts's module-level unwritable latches with a clean read
+    // (see the `after` hook in persistence.unreadable.test.ts — every file in
+    // this app shares one process and therefore one copy of that Set).
+    buildInitialPresets();
+    loadSettings();
+  });
+
+  it('refuses a rule set it cannot serialize, and stores nothing', () => {
+    // Premise: an ordinary rule set through the same call does store.
+    assert.deepStrictEqual(savePresets([customPreset('custom-ok')]), { ok: true });
+    const stored = ls.getItem(PRESETS_KEY);
+    assert.ok(stored && stored.includes('custom-ok'), 'the control write must have landed');
+
+    const result = savePresets([unserializablePreset('custom-bad')]);
+
+    assert.strictEqual(result.ok, false, 'an unserializable rule set must not report success');
+    assert.strictEqual(
+      !result.ok && result.reason,
+      'serialize',
+      'the refusal must name serialization, not quota or an unreadable entry',
+    );
+    // ...and it is a clean no-op: the key still holds the previous rule set,
+    // byte for byte. A writer that stored a placeholder for the payload it
+    // could not build would also report a failure, and would still have
+    // destroyed the user's rules.
+    assert.strictEqual(
+      ls.getItem(PRESETS_KEY),
+      stored,
+      'the refused write must leave the stored rule set untouched',
+    );
+
+    // The key must also still be readable: storing an empty string (or any
+    // non-JSON placeholder) would make the next load throw and latch the key
+    // unwritable, turning a refused save into a permanently blocked one.
+    assert.ok(
+      buildInitialPresets().some((p) => p.id === 'custom-ok'),
+      'the stored rule set must still load after the refused write',
+    );
+  });
+
+  it('reports a rule set that cannot be serialized as differing from itself', () => {
+    // Premise: the comparison does answer "identical" for a rule set that can
+    // be serialized, so a blanket `false` cannot pass this test.
+    const fine = [customPreset('custom-ok')];
+    assert.strictEqual(presetsStoreIdentically(fine, [...fine]), true);
+
+    const broken = [unserializablePreset('custom-bad')];
+    assert.strictEqual(
+      presetsStoreIdentically(broken, broken),
+      false,
+      'nothing can be concluded about bytes that cannot be built — not even that they match themselves',
+    );
+    assert.strictEqual(presetsStoreIdentically(broken, fine), false);
+    assert.strictEqual(presetsStoreIdentically(fine, broken), false);
+  });
+
+  it('ignores built-ins that match their default when comparing stored bytes', () => {
+    // The reason this comparison cannot be a structural or reference one:
+    // `presetsToStore` drops unmodified built-ins, so two rule sets that differ
+    // as arrays still write the same bytes.
+    const withBuiltins = buildInitialPresets();
+    const customsOnly = withBuiltins.filter((p) => !p.builtin);
+    assert.notStrictEqual(withBuiltins.length, customsOnly.length, 'the arrays must really differ');
+    assert.strictEqual(presetsStoreIdentically(withBuiltins, customsOnly), true);
+  });
+});
+
+describe('clash persistence: settingsAlreadyStored compares the bytes saveSettings writes', () => {
+  let ls: MemoryStorage;
+
+  beforeEach(() => {
+    ls = new MemoryStorage();
+    g.localStorage = ls;
+    buildInitialPresets();
+    loadSettings();
+  });
+
+  it('is true exactly when the key already holds what the write would produce', () => {
+    // Nothing stored yet: a write would change the key.
+    assert.strictEqual(settingsAlreadyStored(DEFAULT_CLASH_SETTINGS), false);
+
+    assert.deepStrictEqual(saveSettings(DEFAULT_CLASH_SETTINGS), { ok: true });
+    const written = ls.getItem(SETTINGS_KEY);
+
+    // A distinct object with the same field values: the comparison is on the
+    // bytes, not on object identity.
+    assert.strictEqual(settingsAlreadyStored({ ...DEFAULT_CLASH_SETTINGS }), true);
+    // One differing field is enough to make it a real write.
+    assert.strictEqual(
+      settingsAlreadyStored({ ...DEFAULT_CLASH_SETTINGS, tolerance: 0.5 }),
+      false,
+    );
+    assert.strictEqual(
+      settingsAlreadyStored({ ...DEFAULT_CLASH_SETTINGS, reportTouch: !DEFAULT_CLASH_SETTINGS.reportTouch }),
+      false,
+    );
+    assert.strictEqual(ls.getItem(SETTINGS_KEY), written, 'the comparison must not write anything');
+  });
+
+  it('is false for a stored blob that parses to the same settings but different bytes', () => {
+    // A legacy / hand-edited entry can normalize to exactly these settings
+    // while holding other bytes. The write would then really change the key,
+    // so the answer must be "not already stored" — the conservative direction:
+    // a caller uses this to skip a refused write, and skipping one that would
+    // have changed the stored bytes is the failure that matters.
+    ls.setItem(SETTINGS_KEY, JSON.stringify(DEFAULT_CLASH_SETTINGS)); // no wrapper
+    assert.deepStrictEqual(loadSettings(), DEFAULT_CLASH_SETTINGS, 'premise: it loads as these settings');
+    assert.strictEqual(settingsAlreadyStored(DEFAULT_CLASH_SETTINGS), false);
+  });
+
+  it('is false when there is no storage at all', () => {
+    g.localStorage = undefined;
+    assert.strictEqual(settingsAlreadyStored(DEFAULT_CLASH_SETTINGS), false);
+  });
+
+  // The test above leaves `localStorage` absent, and every file in this app
+  // shares one `tsx --test` process: hand the next file a working storage.
+  after(() => {
+    g.localStorage = new MemoryStorage();
+    buildInitialPresets();
+    loadSettings();
+  });
+});

--- a/apps/viewer/src/lib/clash/persistence.payload.test.ts
+++ b/apps/viewer/src/lib/clash/persistence.payload.test.ts
@@ -26,6 +26,7 @@ import {
   presetsStoreIdentically,
   settingsAlreadyStored,
   DEFAULT_CLASH_SETTINGS,
+  type ClashGlobalSettings,
   type ClashPreset,
 } from './persistence.js';
 
@@ -166,6 +167,72 @@ describe('clash persistence: settingsAlreadyStored compares the bytes saveSettin
       false,
     );
     assert.strictEqual(ls.getItem(SETTINGS_KEY), written, 'the comparison must not write anything');
+  });
+
+  /**
+   * The axis "compared through the same builder" does NOT cover.
+   *
+   * `settingsPayload` is shared, but `JSON.stringify` takes its key order from
+   * the object it is handed, and the two production settings objects are built
+   * by two unshared object literals in two files: `snapshotSettings`
+   * (`store/slices/clashSlice.ts`), the only producer of the bytes on disk, and
+   * `normalizeSettings` (this file), the only producer of the object a flavor
+   * carries (via `deserializeClashConfig`). They agree today by convention
+   * alone. Let either literal be reordered — a field moved while editing, a new
+   * field appended on one side and inserted on the other — and a comparison
+   * that rode on key order would answer `false` forever, silently turning every
+   * caller of this into dead code with no test able to see it.
+   *
+   * So the property under test is the values, not the order they were written
+   * in. Both sides here are built field by field, in deliberately different
+   * orders, rather than one spread from the other: a spread inherits the seed's
+   * key order and therefore cannot observe this at all.
+   */
+  it('compares the settings, not the order the producer happened to build them in', () => {
+    const writerOrder: ClashGlobalSettings = {
+      mode: DEFAULT_CLASH_SETTINGS.mode,
+      tolerance: DEFAULT_CLASH_SETTINGS.tolerance,
+      clearance: DEFAULT_CLASH_SETTINGS.clearance,
+      duplicateTolerance: DEFAULT_CLASH_SETTINGS.duplicateTolerance,
+      clusterEpsilon: DEFAULT_CLASH_SETTINGS.clusterEpsilon,
+      reportTouch: DEFAULT_CLASH_SETTINGS.reportTouch,
+      groupBy: DEFAULT_CLASH_SETTINGS.groupBy,
+    };
+    const readerOrder: ClashGlobalSettings = {
+      groupBy: DEFAULT_CLASH_SETTINGS.groupBy,
+      reportTouch: DEFAULT_CLASH_SETTINGS.reportTouch,
+      clusterEpsilon: DEFAULT_CLASH_SETTINGS.clusterEpsilon,
+      duplicateTolerance: DEFAULT_CLASH_SETTINGS.duplicateTolerance,
+      clearance: DEFAULT_CLASH_SETTINGS.clearance,
+      tolerance: DEFAULT_CLASH_SETTINGS.tolerance,
+      mode: DEFAULT_CLASH_SETTINGS.mode,
+    };
+    // Premise: same settings, genuinely different key orders.
+    assert.deepStrictEqual(writerOrder, readerOrder, 'the two objects must carry the same settings');
+    assert.notDeepStrictEqual(
+      Object.keys(writerOrder),
+      Object.keys(readerOrder),
+      'the two objects must really have been built in different orders',
+    );
+
+    // What the writer stores cannot depend on it either: whichever object it is
+    // handed, the key holds the same bytes, so a reordered producer does not
+    // start rewriting a key that already holds the same settings.
+    assert.deepStrictEqual(saveSettings(writerOrder), { ok: true });
+    const fromWriterOrder = ls.getItem(SETTINGS_KEY);
+    assert.deepStrictEqual(saveSettings(readerOrder), { ok: true });
+    assert.strictEqual(ls.getItem(SETTINGS_KEY), fromWriterOrder);
+
+    // ...and the comparison answers on the settings, in both directions.
+    assert.strictEqual(settingsAlreadyStored(writerOrder), true);
+    assert.strictEqual(settingsAlreadyStored(readerOrder), true);
+    assert.deepStrictEqual(saveSettings(writerOrder), { ok: true });
+    assert.strictEqual(settingsAlreadyStored(readerOrder), true);
+
+    // Not weakened into a wrong `true`: this stays a byte comparison against
+    // what the write would produce, so one differing VALUE is still a write.
+    assert.strictEqual(settingsAlreadyStored({ ...readerOrder, tolerance: 0.5 }), false);
+    assert.strictEqual(settingsAlreadyStored({ ...writerOrder, mode: 'clearance' }), false);
   });
 
   it('is false for a stored blob that parses to the same settings but different bytes', () => {

--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -56,9 +56,27 @@ export interface ClashGlobalSettings {
   groupBy: ClashSettingsGroupBy;
 }
 
+/**
+ * Why a save was refused.
+ *
+ * `rollback_failed` is the odd one out: no writer in this module returns it.
+ * It is raised by a caller that writes more than one key and could not undo
+ * the half that landed after a later write was refused (see
+ * `applyClashFlavorConfig` in `clashSlice.ts`). The others all mean "nothing
+ * changed"; this one means storage is now holding a mix the user never chose,
+ * so it is the one value a caller must be able to tell apart without reading
+ * the message.
+ */
+export type ClashSaveFailureReason =
+  | 'quota'
+  | 'serialize'
+  | 'too_many'
+  | 'unreadable'
+  | 'rollback_failed';
+
 export type SaveResult =
   | { ok: true }
-  | { ok: false; reason: 'quota' | 'serialize' | 'too_many' | 'unreadable'; message: string };
+  | { ok: false; reason: ClashSaveFailureReason; message: string };
 
 const PRESETS_KEY = 'ifc-lite-clash-presets';
 const SETTINGS_KEY = 'ifc-lite-clash-settings';

--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -354,9 +354,34 @@ export function loadSettings(): ClashGlobalSettings {
  * The exact string `saveSettings` hands to `localStorage.setItem`. The single
  * source of those bytes, so a caller asking whether a settings write would
  * change anything compares what would actually be written.
+ *
+ * The settings object is rebuilt here, field by field, rather than serialized
+ * as handed in: `JSON.stringify` takes its key order from its input, so
+ * stringifying the caller's object would put that order — not this function —
+ * in charge of the bytes. The two settings objects production compares are
+ * built by two unshared literals in two files (`snapshotSettings` in
+ * `store/slices/clashSlice.ts` builds what is written; `normalizeSettings`
+ * below builds what a flavor carries, via `deserializeClashConfig`), and they
+ * matched only by convention. Reorder either literal and every "is this
+ * already stored?" answer flips to `false` forever, with nothing to catch it.
+ *
+ * Rebuilding here makes the order this function's own, so both sides of any
+ * comparison — and the write itself — serialize the same way regardless of how
+ * their object was assembled. The annotation, not `satisfies`, is deliberate: a
+ * field added to `ClashGlobalSettings` and forgotten here is a compile error
+ * rather than a field silently dropped from storage.
  */
 function settingsPayload(settings: ClashGlobalSettings): string {
-  return JSON.stringify({ schemaVersion: SCHEMA_VERSION, settings });
+  const canonical: ClashGlobalSettings = {
+    mode: settings.mode,
+    tolerance: settings.tolerance,
+    clearance: settings.clearance,
+    duplicateTolerance: settings.duplicateTolerance,
+    clusterEpsilon: settings.clusterEpsilon,
+    reportTouch: settings.reportTouch,
+    groupBy: settings.groupBy,
+  };
+  return JSON.stringify({ schemaVersion: SCHEMA_VERSION, settings: canonical });
 }
 
 /**
@@ -364,14 +389,16 @@ function settingsPayload(settings: ClashGlobalSettings): string {
  * would write for `settings` — i.e. whether that write would change nothing.
  *
  * Built through `settingsPayload`, the same function `saveSettings` writes
- * from, so the compared bytes are the written bytes by construction.
+ * from, so the compared bytes are the written bytes by construction — the key
+ * order included, since that builder fixes it rather than inheriting it from
+ * whichever object literal produced these settings.
  *
  * One-directional on purpose: `false` only means "not provably a no-op". A
  * stored value that normalizes to these settings through some other encoding
- * (a legacy blob without the wrapper, a different key order) answers `false`,
- * because the write really would rewrite the key. A caller uses this to let a
- * refused write pass, and letting one pass that would have changed the stored
- * bytes is the failure that matters.
+ * (a legacy blob without the wrapper, or one an older build wrote in another
+ * key order) answers `false`, because the write really would rewrite the key.
+ * A caller uses this to let a refused write pass, and letting one pass that
+ * would have changed the stored bytes is the failure that matters.
  */
 export function settingsAlreadyStored(settings: ClashGlobalSettings): boolean {
   try {

--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -66,6 +66,11 @@ export interface ClashGlobalSettings {
  * changed"; this one means storage is now holding a mix the user never chose,
  * so it is the one value a caller must be able to tell apart without reading
  * the message.
+ *
+ * A failed undo is necessary but not sufficient: if the write being undone
+ * rewrote the bytes that were already there, nothing was stranded and the
+ * caller reports the refused write's own reason instead. See
+ * `presetsStoreIdentically`.
  */
 export type ClashSaveFailureReason =
   | 'quota'
@@ -259,6 +264,36 @@ export function presetsToStore(presets: ClashPreset[]): ClashPreset[] {
   ];
 }
 
+/**
+ * The exact string `savePresets` hands to `localStorage.setItem`, or null if
+ * the rule set cannot be serialized. The single source of those bytes, so a
+ * caller comparing two rule sets compares what would actually be written.
+ */
+function presetsPayload(presets: ClashPreset[]): string | null {
+  try {
+    return JSON.stringify({ schemaVersion: SCHEMA_VERSION, presets: presetsToStore(presets) });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether storing `a` and storing `b` would write the same bytes under the
+ * presets key — i.e. whether replacing `a` with `b` is a no-op on disk.
+ *
+ * Built through `presetsPayload`, the same function `savePresets` writes from,
+ * so this cannot drift from the real payload the way a structural or reference
+ * comparison could: `presetsToStore` drops built-ins that match their default,
+ * so two rule sets that differ as arrays can still store identically.
+ *
+ * A rule set that fails to serialize is reported as differing from everything,
+ * including itself: nothing can be concluded about bytes that cannot be built.
+ */
+export function presetsStoreIdentically(a: ClashPreset[], b: ClashPreset[]): boolean {
+  const payloadA = presetsPayload(a);
+  return payloadA !== null && payloadA === presetsPayload(b);
+}
+
 /** Persist only custom presets + modified built-ins (quota-safe). */
 export function savePresets(presets: ClashPreset[]): SaveResult {
   if (unwritableKeys.has(PRESETS_KEY)) return refuseOverwrite('clash rules');
@@ -266,11 +301,8 @@ export function savePresets(presets: ClashPreset[]): SaveResult {
   if (custom.length > MAX_PRESETS) {
     return { ok: false, reason: 'too_many', message: `Too many custom rules (max ${MAX_PRESETS}).` };
   }
-  const toStore = presetsToStore(presets);
-  let payload: string;
-  try {
-    payload = JSON.stringify({ schemaVersion: SCHEMA_VERSION, presets: toStore });
-  } catch {
+  const payload = presetsPayload(presets);
+  if (payload === null) {
     return { ok: false, reason: 'serialize', message: 'Could not serialize clash rules.' };
   }
   try {

--- a/apps/viewer/src/lib/clash/persistence.ts
+++ b/apps/viewer/src/lib/clash/persistence.ts
@@ -68,8 +68,8 @@ export interface ClashGlobalSettings {
  * the message.
  *
  * A failed undo is necessary but not sufficient: if the write being undone
- * rewrote the bytes that were already there, nothing was stranded and the
- * caller reports the refused write's own reason instead. See
+ * stored the same rule set that was already stored, nothing was stranded and
+ * the caller reports the refused write's own reason instead. See
  * `presetsStoreIdentically`.
  */
 export type ClashSaveFailureReason =
@@ -279,7 +279,15 @@ function presetsPayload(presets: ClashPreset[]): string | null {
 
 /**
  * Whether storing `a` and storing `b` would write the same bytes under the
- * presets key — i.e. whether replacing `a` with `b` is a no-op on disk.
+ * presets key — i.e. whether replacing `a` with `b` leaves the store's
+ * serialized form unchanged.
+ *
+ * Not the same question as "would the bytes on disk change": `readStoredPresets`
+ * also accepts a legacy bare array, so the key can already be in sync with a
+ * value that is not what `savePresets` writes, and storing either of these rule
+ * sets over it would rewrite it into the current wrapper. What this answers is
+ * that both rule sets persist as the same thing, so whichever one lands, a
+ * reload rebuilds the same state.
  *
  * Built through `presetsPayload`, the same function `savePresets` writes from,
  * so this cannot drift from the real payload the way a structural or reference
@@ -342,10 +350,42 @@ export function loadSettings(): ClashGlobalSettings {
   }
 }
 
+/**
+ * The exact string `saveSettings` hands to `localStorage.setItem`. The single
+ * source of those bytes, so a caller asking whether a settings write would
+ * change anything compares what would actually be written.
+ */
+function settingsPayload(settings: ClashGlobalSettings): string {
+  return JSON.stringify({ schemaVersion: SCHEMA_VERSION, settings });
+}
+
+/**
+ * Whether the settings key already holds exactly the bytes `saveSettings`
+ * would write for `settings` — i.e. whether that write would change nothing.
+ *
+ * Built through `settingsPayload`, the same function `saveSettings` writes
+ * from, so the compared bytes are the written bytes by construction.
+ *
+ * One-directional on purpose: `false` only means "not provably a no-op". A
+ * stored value that normalizes to these settings through some other encoding
+ * (a legacy blob without the wrapper, a different key order) answers `false`,
+ * because the write really would rewrite the key. A caller uses this to let a
+ * refused write pass, and letting one pass that would have changed the stored
+ * bytes is the failure that matters.
+ */
+export function settingsAlreadyStored(settings: ClashGlobalSettings): boolean {
+  try {
+    return localStorage.getItem(SETTINGS_KEY) === settingsPayload(settings);
+  } catch {
+    // No storage, or a blocked one: nothing is provably stored.
+    return false;
+  }
+}
+
 export function saveSettings(settings: ClashGlobalSettings): SaveResult {
   if (unwritableKeys.has(SETTINGS_KEY)) return refuseOverwrite('clash settings');
   try {
-    localStorage.setItem(SETTINGS_KEY, JSON.stringify({ schemaVersion: SCHEMA_VERSION, settings }));
+    localStorage.setItem(SETTINGS_KEY, settingsPayload(settings));
     return { ok: true };
   } catch {
     return { ok: false, reason: 'quota', message: 'Browser storage is full — clash settings were not saved.' };

--- a/apps/viewer/src/services/extensions/host.ts
+++ b/apps/viewer/src/services/extensions/host.ts
@@ -484,7 +484,16 @@ export class ExtensionHostService {
       const config = deserializeClashConfig((target.settings as Record<string, unknown> | undefined)?.clash);
       if (config) {
         const { useViewerStore } = await import('@/store');
-        useViewerStore.getState().applyClashFlavorConfig(config);
+        const applied = useViewerStore.getState().applyClashFlavorConfig(config);
+        // The slice leaves the previous clash config in place when the write is
+        // refused, so there is nothing to undo here — only a reason to report.
+        // This service is deliberately free of UI deps (see the late imports
+        // above), and throwing would abort the sidebar restore below and mark
+        // the whole switch as failed, which it was not; a warning is what is
+        // available at this layer.
+        if (!applied.ok) {
+          console.warn('[ext-host] clash config was not persisted on switch:', applied.message);
+        }
       }
     } catch (err) {
       console.warn('[ext-host] clash restore on switch failed:', err);

--- a/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
@@ -266,6 +266,14 @@ describe('applyClashFlavorConfig - only commit a config that actually persisted'
     assert.strictEqual(recovered.ok, false);
     // Pin the premise: this really is the consistent outcome.
     assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID]);
+    // Pin this half too: "not the stranded reason" would also hold if the
+    // recovered case started reporting some third value, which would be its
+    // own lie. It is an ordinary refused settings write and says so.
+    assert.strictEqual(
+      !recovered.ok && recovered.reason,
+      'quota',
+      'a recovered rollback is just a refused settings write: it carries that write reason',
+    );
 
     // Scenario B: the disk is full, so the settings write AND the rollback both
     // throw and storage is left holding the hybrid. Rebuild from scratch so
@@ -312,6 +320,65 @@ describe('applyClashFlavorConfig - only commit a config that actually persisted'
     // replace the enriched message the console warning relies on.
     assert.ok(
       !stranded.ok && /previous rule set could also not be restored/.test(stranded.message),
+    );
+  });
+
+  /**
+   * ...and the mirror of that: `rollback_failed` must not be raised when
+   * storage is provably intact.
+   *
+   * A flavor can carry a rule set that serializes to exactly what is already
+   * stored while differing only in its tolerances — flavors that share a rule
+   * set and tune the thresholds around it. Then the "presets write" that lands
+   * rewrites the same bytes, so when the settings write and the rollback both
+   * fail there is nothing stranded: both keys still hold what they held before
+   * the apply. Inferring inconsistency from the undo write throwing, without
+   * asking whether the first write changed anything, reports the strongest
+   * "saved data may no longer match" signal over untouched storage.
+   */
+  it('does not claim a failed rollback stranded anything when the rule set never changed', () => {
+    // The rule set the flavor carries is the one already in storage; only the
+    // settings differ. `savePresets` will rewrite byte-for-byte what is there.
+    const sameRuleSet = [customPreset(OLD_CUSTOM_ID, 'Rule from the previous flavor')];
+    const presetsBefore = storage.getItem(PRESETS_KEY);
+    const settingsBefore = storage.getItem(SETTINGS_KEY);
+
+    // Genuine quota exhaustion: the presets write lands, then the settings
+    // write and the rollback's presets write both throw.
+    storage.failAfterWrites = 1;
+
+    const result = state.applyClashFlavorConfig({
+      presets: sameRuleSet,
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.strictEqual(result.ok, false, 'the settings write was still refused');
+    // Pin the premise on BOTH keys: storage is byte-identical to before the
+    // apply, so there is no hybrid to warn about. Comparing raw bytes, not
+    // parsed shapes, because bytes are what a reload rehydrates.
+    assert.strictEqual(
+      storage.getItem(PRESETS_KEY),
+      presetsBefore,
+      'the rule set on disk must be untouched — the write that landed rewrote it identically',
+    );
+    assert.strictEqual(
+      storage.getItem(SETTINGS_KEY),
+      settingsBefore,
+      'the settings write never landed, so that key must be untouched too',
+    );
+    // ...and the store never moved either.
+    assert.ok(state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID));
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+
+    assert.notStrictEqual(
+      !result.ok && result.reason,
+      'rollback_failed',
+      'storage is intact on both keys, so the "storage may be inconsistent" reason is a lie',
+    );
+    assert.strictEqual(
+      !result.ok && result.reason,
+      'quota',
+      'this is an ordinary refused settings write: the reason is the settings write reason',
     );
   });
 

--- a/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
@@ -382,6 +382,163 @@ describe('applyClashFlavorConfig - only commit a config that actually persisted'
     );
   });
 
+  /**
+   * The same no-op rule, applied to the presets key's own legacy shape.
+   *
+   * `readStoredPresets` accepts a bare array as well as the versioned wrapper,
+   * so the store can be in sync with a stored value that is NOT the bytes
+   * `savePresets` writes. Then a presets write that `presetsStoreIdentically`
+   * calls a no-op does change the key's bytes (`[...]` becomes
+   * `{"schemaVersion":1,"presets":[...]}`) — which is why that helper documents
+   * the store's serialized form, not the bytes on disk.
+   *
+   * The verdict is still `'quota'` and not `'rollback_failed'`: what the
+   * upgrade rewrote is the same rule set in the current format, so the pair of
+   * keys left behind rehydrates to exactly the store the user is left looking
+   * at. Nothing was stranded.
+   */
+  it('treats a legacy bare-array upgrade as a no-op presets write when the rollback fails', () => {
+    // Re-seed the presets key in the pre-wrapper format and rebuild the slice
+    // from it, so the store really was loaded through the legacy branch.
+    storage = new MemoryStorage();
+    g.localStorage = storage;
+    storage.setItem(
+      PRESETS_KEY,
+      JSON.stringify([customPreset(OLD_CUSTOM_ID, 'Rule from the previous flavor')]),
+    );
+    storage.setItem(SETTINGS_KEY, JSON.stringify({ schemaVersion: 1, settings: OLD_SETTINGS }));
+    storage.writes.length = 0;
+    const setState = (
+      partial: Partial<ClashSlice> | ((s: ClashSlice) => Partial<ClashSlice>),
+    ) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createClashSlice(setState, () => state, {} as never);
+    assert.ok(
+      state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID),
+      'premise: the legacy bare array really was loaded',
+    );
+
+    const legacyBytes = storage.getItem(PRESETS_KEY);
+    assert.ok(legacyBytes?.startsWith('['), 'premise: the stored value is the bare-array shape');
+
+    // The flavor carries the rule set already in the store; only settings move.
+    const sameRuleSet = [customPreset(OLD_CUSTOM_ID, 'Rule from the previous flavor')];
+    storage.failAfterWrites = 1; // presets land, settings write and rollback throw
+
+    const result = state.applyClashFlavorConfig({
+      presets: sameRuleSet,
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.strictEqual(result.ok, false, 'the settings write was still refused');
+    // The bytes DID change — the wrapper replaced the bare array — so this is
+    // the case the "no-op on disk" wording could not describe.
+    assert.notStrictEqual(
+      storage.getItem(PRESETS_KEY),
+      legacyBytes,
+      'the write that landed rewrote the legacy shape into the wrapper',
+    );
+    // ...and what those new bytes mean is unchanged: reloading gives the same
+    // rule set the store still holds, beside the untouched settings.
+    assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID]);
+    assert.strictEqual(storedTolerance(storage), OLD_SETTINGS.tolerance);
+    assert.ok(state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID));
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+
+    assert.strictEqual(
+      !result.ok && result.reason,
+      'quota',
+      'nothing was stranded: the format upgrade stores the rule set the store still shows',
+    );
+  });
+
+  // ── the settings write is refused but the bytes are already stored ─────────
+
+  /**
+   * The mirror of the presets rule, on the settings key.
+   *
+   * A flavor can carry the settings that are already stored and differ only in
+   * its rule set — flavors that share the detection thresholds and swap the
+   * rules around them. Aborting on `!settingsResult.ok` unconditionally then
+   * rolls back a presets write that was fine and reports "clash settings were
+   * not saved" over storage that holds exactly those settings.
+   */
+  it('applies the flavor when the refused settings write would not have changed the stored bytes', () => {
+    storage.failKey = SETTINGS_KEY;
+    const settingsBefore = storage.getItem(SETTINGS_KEY);
+
+    // A distinct object carrying the settings already on disk: the flavor moves
+    // the rule set only.
+    const result = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: { ...OLD_SETTINGS },
+    });
+
+    assert.deepStrictEqual(
+      result,
+      { ok: true },
+      'the refused write would have rewritten the bytes already stored, so it changed nothing',
+    );
+    // The flavor is live in the store...
+    assert.deepStrictEqual(state.clashPresets.map((p) => p.id), [FLAVOR_CUSTOM_ID]);
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+    // ...and storage matches it on both keys: the new rule set landed and the
+    // settings key still holds the very bytes the flavor asked for.
+    assert.deepStrictEqual(storedCustomIds(storage), [FLAVOR_CUSTOM_ID]);
+    assert.strictEqual(
+      storage.getItem(SETTINGS_KEY),
+      settingsBefore,
+      'the settings key was never written — it did not need to be',
+    );
+    assert.strictEqual(storedTolerance(storage), OLD_SETTINGS.tolerance);
+    assert.deepStrictEqual(
+      storage.writes,
+      [PRESETS_KEY],
+      'the presets write landed and was not rolled back',
+    );
+  });
+
+  it('applies it under genuine quota exhaustion too, without attempting a rollback', () => {
+    // The other side of the same cell: not one blocked key but a full disk, so
+    // the settings write and any rollback would both throw. The presets write
+    // lands first and nothing after it can, which is exactly why the apply must
+    // not depend on a write it does not need.
+    storage.failAfterWrites = 1;
+    const settingsBefore = storage.getItem(SETTINGS_KEY);
+
+    const result = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: { ...OLD_SETTINGS },
+    });
+
+    assert.deepStrictEqual(result, { ok: true });
+    assert.deepStrictEqual(state.clashPresets.map((p) => p.id), [FLAVOR_CUSTOM_ID]);
+    assert.deepStrictEqual(storedCustomIds(storage), [FLAVOR_CUSTOM_ID]);
+    assert.strictEqual(storage.getItem(SETTINGS_KEY), settingsBefore);
+    assert.deepStrictEqual(
+      storage.writes,
+      [PRESETS_KEY],
+      'no rollback was attempted: there was nothing to undo',
+    );
+  });
+
+  it('still fails, and rolls back, when the refused settings differ by a single field', () => {
+    storage.failKey = SETTINGS_KEY;
+
+    const result = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      // Everything the case above has, except one field the user would notice.
+      settings: { ...OLD_SETTINGS, reportTouch: !OLD_SETTINGS.reportTouch },
+    });
+
+    assert.strictEqual(result.ok, false, 'this write really would have changed the stored settings');
+    assert.strictEqual(!result.ok && result.reason, 'quota');
+    assert.ok(!state.clashPresets.some((p) => p.id === FLAVOR_CUSTOM_ID));
+    assert.strictEqual(state.clashReportTouch, OLD_SETTINGS.reportTouch);
+    assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID], 'the presets write was undone');
+  });
+
   // ── partial: presets refused ───────────────────────────────────────────────
 
   it('commits nothing and never touches settings when the presets write is refused', () => {

--- a/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
@@ -245,6 +245,76 @@ describe('applyClashFlavorConfig - only commit a config that actually persisted'
     );
   });
 
+  /**
+   * The two outcomes above differ in a way that matters to a caller: after the
+   * first, storage is consistent (the rollback undid the landed half); after
+   * the second, storage holds the NEW rule set beside the OLD settings. Both
+   * are reported with `ok: false`, so `reason` is the only field a caller can
+   * branch on — a `message` is display text, not a contract. Reusing the
+   * settings write's own `reason` for the double failure makes "recovered" and
+   * "storage is now inconsistent" the same value, and genuine quota exhaustion
+   * (the case that produces the second) reports `'quota'` for both.
+   */
+  it('distinguishes a recovered rollback from a failed one in the machine-readable reason', () => {
+    // Scenario A: only the settings key is blocked, so the rollback's write to
+    // the presets key lands and storage ends up consistent.
+    storage.failKey = SETTINGS_KEY;
+    const recovered = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: FLAVOR_SETTINGS,
+    });
+    assert.strictEqual(recovered.ok, false);
+    // Pin the premise: this really is the consistent outcome.
+    assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID]);
+
+    // Scenario B: the disk is full, so the settings write AND the rollback both
+    // throw and storage is left holding the hybrid. Rebuild from scratch so
+    // this apply starts from the same seeded state scenario A did.
+    storage = new MemoryStorage();
+    g.localStorage = storage;
+    storage.setItem(
+      PRESETS_KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        presets: [customPreset(OLD_CUSTOM_ID, 'Rule from the previous flavor')],
+      }),
+    );
+    storage.setItem(SETTINGS_KEY, JSON.stringify({ schemaVersion: 1, settings: OLD_SETTINGS }));
+    storage.writes.length = 0;
+    const setState = (
+      partial: Partial<ClashSlice> | ((s: ClashSlice) => Partial<ClashSlice>),
+    ) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createClashSlice(setState, () => state, {} as never);
+    storage.failAfterWrites = 1;
+
+    const stranded = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: FLAVOR_SETTINGS,
+    });
+    assert.strictEqual(stranded.ok, false);
+    // Pin the premise: this really is the inconsistent outcome.
+    assert.deepStrictEqual(storedCustomIds(storage), [FLAVOR_CUSTOM_ID]);
+    assert.strictEqual(storedTolerance(storage), OLD_SETTINGS.tolerance);
+
+    assert.notStrictEqual(
+      !stranded.ok && stranded.reason,
+      !recovered.ok && recovered.reason,
+      'a caller must be able to tell a stranded write from a recovered one without parsing the message',
+    );
+    assert.strictEqual(
+      !stranded.ok && stranded.reason,
+      'rollback_failed',
+      'the double failure needs its own reason, not the settings write reason',
+    );
+    // The human-readable half is unchanged: this adds a signal, it does not
+    // replace the enriched message the console warning relies on.
+    assert.ok(
+      !stranded.ok && /previous rule set could also not be restored/.test(stranded.message),
+    );
+  });
+
   // ── partial: presets refused ───────────────────────────────────────────────
 
   it('commits nothing and never touches settings when the presets write is refused', () => {

--- a/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
@@ -1,0 +1,286 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Activating a flavor must only show the flavor's clash config once it is
+ * actually stored.
+ *
+ * `applyClashFlavorConfig` used to `set(...)` first and then discard both
+ * `savePresets` and `saveSettings` results, so with storage refusing a write
+ * (quota, or storage blocked entirely) the panel showed the flavor's rule set
+ * and tolerances as active and the previous flavor's came back on reload.
+ *
+ * It writes TWO independent localStorage keys, so these also pin the partial
+ * case in both directions: presets land / settings refused (the landed half is
+ * rolled back and nothing is committed), and presets refused (settings are
+ * never attempted).
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { createClashSlice, type ClashSlice } from './clashSlice.js';
+import type { ClashPreset, ClashGlobalSettings } from '@/lib/clash/persistence';
+
+const PRESETS_KEY = 'ifc-lite-clash-presets';
+const SETTINGS_KEY = 'ifc-lite-clash-settings';
+
+/**
+ * A real, working storage that can be told to refuse writes to ONE key. Reads
+ * always work and every other key keeps writing, so the module under test still
+ * sees a functioning localStorage: a stub that rejected every `setItem` would
+ * make the whole persistence layer look absent and pass for the wrong reason.
+ */
+class MemoryStorage {
+  private store = new Map<string, string>();
+  /** Key whose `setItem` throws, mimicking a quota / blocked-storage refusal. */
+  failKey: string | null = null;
+  /** Every successful write, in order (lets a test prove nothing was persisted). */
+  writes: string[] = [];
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    if (key === this.failKey) throw new DOMException('quota', 'QuotaExceededError');
+    this.store.set(key, value);
+    this.writes.push(key);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  get length(): number {
+    return this.store.size;
+  }
+  key(i: number): string | null {
+    return [...this.store.keys()][i] ?? null;
+  }
+}
+
+const g = globalThis as { localStorage?: unknown };
+
+const OLD_CUSTOM_ID = 'custom-before-switch';
+const FLAVOR_CUSTOM_ID = 'custom-from-flavor';
+
+/** What the previously active flavor left in storage. */
+const OLD_SETTINGS: ClashGlobalSettings = {
+  mode: 'hard',
+  tolerance: 0.002,
+  clearance: 0.05,
+  duplicateTolerance: 0.01,
+  clusterEpsilon: 1.5,
+  reportTouch: false,
+  groupBy: 'severity',
+};
+
+/** What the flavor being activated carries — every field differs from OLD. */
+const FLAVOR_SETTINGS: ClashGlobalSettings = {
+  mode: 'clearance',
+  tolerance: 0.02,
+  clearance: 0.25,
+  duplicateTolerance: 0.05,
+  clusterEpsilon: 3,
+  reportTouch: true,
+  groupBy: 'rule',
+};
+
+function customPreset(id: string, name: string): ClashPreset {
+  return {
+    id,
+    name,
+    description: '',
+    severity: 'major',
+    selectorA: 'IfcWall',
+    selectorB: 'IfcDoor',
+    enabled: true,
+    builtin: false,
+  };
+}
+
+const FLAVOR_PRESETS: ClashPreset[] = [customPreset(FLAVOR_CUSTOM_ID, 'Flavor rule')];
+
+/** Ids of the custom rules currently written under the presets key. */
+function storedCustomIds(storage: MemoryStorage): string[] {
+  const raw = storage.getItem(PRESETS_KEY);
+  if (!raw) return [];
+  return (JSON.parse(raw) as { presets: ClashPreset[] }).presets.map((p) => p.id);
+}
+
+/** Tolerance currently written under the settings key (null if absent). */
+function storedTolerance(storage: MemoryStorage): number | null {
+  const raw = storage.getItem(SETTINGS_KEY);
+  if (!raw) return null;
+  return (JSON.parse(raw) as { settings: ClashGlobalSettings }).settings.tolerance;
+}
+
+describe('applyClashFlavorConfig - only commit a config that actually persisted', () => {
+  let storage: MemoryStorage;
+  let state: ClashSlice;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    g.localStorage = storage;
+    // Seed the state the previous flavor left behind, through the real writers'
+    // own format, so the slice loads it on construction.
+    storage.setItem(
+      PRESETS_KEY,
+      JSON.stringify({
+        schemaVersion: 1,
+        presets: [customPreset(OLD_CUSTOM_ID, 'Rule from the previous flavor')],
+      }),
+    );
+    storage.setItem(SETTINGS_KEY, JSON.stringify({ schemaVersion: 1, settings: OLD_SETTINGS }));
+    storage.writes.length = 0; // the seed is setup, not a write under test
+
+    const setState = (
+      partial: Partial<ClashSlice> | ((s: ClashSlice) => Partial<ClashSlice>),
+    ) => {
+      state = { ...state, ...(typeof partial === 'function' ? partial(state) : partial) };
+    };
+    state = createClashSlice(setState, () => state, {} as never);
+  });
+
+  it('the stub is selective and the slice really loaded the seeded config', () => {
+    storage.failKey = SETTINGS_KEY;
+    assert.throws(() => storage.setItem(SETTINGS_KEY, 'x'));
+    storage.setItem(PRESETS_KEY, 'y'); // every other key still writes
+    assert.strictEqual(storage.getItem(PRESETS_KEY), 'y'); // ...and reads back
+    // The slice went through the real load path, not a default.
+    assert.ok(state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID));
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+  });
+
+  // ── partial: presets land, settings refused ────────────────────────────────
+
+  it('rolls back and commits nothing when the settings write is refused', () => {
+    storage.failKey = SETTINGS_KEY;
+
+    const result = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.strictEqual(result.ok, false, 'a refused settings write must be reported');
+    assert.ok(!result.ok && result.message.length > 0);
+
+    // Nothing committed: neither half of the flavor's config shows as applied.
+    assert.ok(
+      state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID),
+      'the previous flavor rule set must still be listed',
+    );
+    assert.ok(!state.clashPresets.some((p) => p.id === FLAVOR_CUSTOM_ID));
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+    assert.strictEqual(state.clashDuplicateTolerance, OLD_SETTINGS.duplicateTolerance);
+    assert.strictEqual(state.clashMode, OLD_SETTINGS.mode);
+    assert.strictEqual(state.clashGroupBy, OLD_SETTINGS.groupBy);
+
+    // ...and the half that DID land was undone, so storage agrees with the store.
+    assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID]);
+    assert.strictEqual(storedTolerance(storage), OLD_SETTINGS.tolerance);
+    assert.deepStrictEqual(
+      storage.writes,
+      [PRESETS_KEY, PRESETS_KEY],
+      'the presets write and its rollback, and no settings write',
+    );
+  });
+
+  // ── partial: presets refused ───────────────────────────────────────────────
+
+  it('commits nothing and never touches settings when the presets write is refused', () => {
+    storage.failKey = PRESETS_KEY;
+
+    const result = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.strictEqual(result.ok, false);
+    assert.ok(state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID));
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+    assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID]);
+    assert.strictEqual(
+      storedTolerance(storage),
+      OLD_SETTINGS.tolerance,
+      'settings must not move when the rule set could not be stored',
+    );
+    assert.deepStrictEqual(storage.writes, [], 'nothing was persisted at all');
+  });
+
+  it('rejects an over-cap rule set before writing either key', () => {
+    const tooMany = Array.from({ length: 201 }, (_, i) => customPreset(`custom-${i}`, `Rule ${i}`));
+
+    const result = state.applyClashFlavorConfig({ presets: tooMany, settings: FLAVOR_SETTINGS });
+
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(!result.ok && result.reason, 'too_many');
+    assert.deepStrictEqual(storage.writes, []);
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+    assert.ok(state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID));
+  });
+
+  // ── the happy path still applies ───────────────────────────────────────────
+
+  it('commits both halves and reports ok when storage accepts the writes', () => {
+    const result = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.deepStrictEqual(result, { ok: true });
+    assert.deepStrictEqual(
+      state.clashPresets.map((p) => p.id),
+      [FLAVOR_CUSTOM_ID],
+      'the flavor config replaces the rule set wholesale',
+    );
+    assert.strictEqual(state.clashMode, FLAVOR_SETTINGS.mode);
+    assert.strictEqual(state.clashTolerance, FLAVOR_SETTINGS.tolerance);
+    assert.strictEqual(state.clashClearance, FLAVOR_SETTINGS.clearance);
+    assert.strictEqual(state.clashDuplicateTolerance, FLAVOR_SETTINGS.duplicateTolerance);
+    assert.strictEqual(state.clashClusterEpsilon, FLAVOR_SETTINGS.clusterEpsilon);
+    assert.strictEqual(state.clashReportTouch, FLAVOR_SETTINGS.reportTouch);
+    assert.strictEqual(state.clashGroupBy, FLAVOR_SETTINGS.groupBy);
+
+    assert.deepStrictEqual(storedCustomIds(storage), [FLAVOR_CUSTOM_ID]);
+    assert.strictEqual(storedTolerance(storage), FLAVOR_SETTINGS.tolerance);
+    assert.deepStrictEqual(storage.writes, [PRESETS_KEY, SETTINGS_KEY]);
+  });
+
+  // ── siblings on this branch are untouched ──────────────────────────────────
+
+  it('createClashPreset still gates its own commit on the SaveResult', () => {
+    storage.failKey = PRESETS_KEY;
+    const before = state.clashPresets.length;
+    const refused = state.createClashPreset({
+      name: 'New rule',
+      severity: 'minor',
+      selectorA: 'IfcBeam',
+      selectorB: 'IfcSlab',
+    });
+    assert.strictEqual(refused.ok, false);
+    assert.strictEqual(state.clashPresets.length, before);
+
+    storage.failKey = null;
+    assert.deepStrictEqual(
+      state.createClashPreset({
+        name: 'New rule',
+        severity: 'minor',
+        selectorA: 'IfcBeam',
+        selectorB: 'IfcSlab',
+      }),
+      { ok: true },
+    );
+    assert.strictEqual(state.clashPresets.length, before + 1);
+  });
+
+  it('updateClashPreset still gates its own commit on the SaveResult', () => {
+    storage.failKey = PRESETS_KEY;
+    assert.strictEqual(state.updateClashPreset(OLD_CUSTOM_ID, { name: 'Renamed' }).ok, false);
+    assert.strictEqual(
+      state.clashPresets.find((p) => p.id === OLD_CUSTOM_ID)?.name,
+      'Rule from the previous flavor',
+    );
+
+    storage.failKey = null;
+    assert.deepStrictEqual(state.updateClashPreset(OLD_CUSTOM_ID, { name: 'Renamed' }), { ok: true });
+    assert.strictEqual(state.clashPresets.find((p) => p.id === OLD_CUSTOM_ID)?.name, 'Renamed');
+  });
+});

--- a/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
@@ -20,6 +20,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import { createClashSlice, type ClashSlice } from './clashSlice.js';
+import { deserializeClashConfig } from '@/lib/clash/persistence';
 import type { ClashPreset, ClashGlobalSettings } from '@/lib/clash/persistence';
 
 const PRESETS_KEY = 'ifc-lite-clash-presets';
@@ -537,6 +538,146 @@ describe('applyClashFlavorConfig - only commit a config that actually persisted'
     assert.ok(!state.clashPresets.some((p) => p.id === FLAVOR_CUSTOM_ID));
     assert.strictEqual(state.clashReportTouch, OLD_SETTINGS.reportTouch);
     assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID], 'the presets write was undone');
+  });
+
+  /**
+   * The no-op settings rule with BOTH sides built the way production builds
+   * them, rather than one spread from the other.
+   *
+   * The comparison is between bytes `snapshotSettings` (this file's slice) put
+   * on disk and a settings object `normalizeSettings` built (what
+   * `deserializeClashConfig` hands `applyClashFlavorConfig` from a flavor's
+   * blob — see `ExtensionHostService`). Those are two unshared object literals
+   * in two files, and every other test of this branch feeds the equal case a
+   * spread of the seed, which inherits the seed's key order and so cannot
+   * observe a divergence between the two producers at all.
+   *
+   * So: drive the stored bytes through the slice's own setters (the real
+   * writer), then build the flavor's half through the real deserializer, and
+   * let them meet. Nothing here shares an object with anything there.
+   */
+  it('treats settings the deserializer built as already stored when the slice wrote them', () => {
+    // The real writer: each setter snapshots the slice and persists it.
+    state.setClashMode('clearance');
+    state.setClashTolerance(0.007);
+    state.setClashClearance(0.11);
+    state.setClashDuplicateTolerance(0.023);
+    state.setClashClusterEpsilon(2.5);
+    state.setClashReportTouch(true);
+    state.setClashGroupBy('rule');
+    const settingsBefore = storage.getItem(SETTINGS_KEY);
+    assert.ok(settingsBefore?.includes('0.007'), 'premise: the slice really persisted its snapshot');
+    storage.writes.length = 0;
+
+    // The real reader: a flavor blob through the deserializer, whose settings
+    // object is built by `normalizeSettings` — the other production literal.
+    const config = deserializeClashConfig({
+      presets: [customPreset(FLAVOR_CUSTOM_ID, 'Flavor rule')],
+      settings: {
+        mode: 'clearance',
+        tolerance: 0.007,
+        clearance: 0.11,
+        duplicateTolerance: 0.023,
+        clusterEpsilon: 2.5,
+        reportTouch: true,
+        groupBy: 'rule',
+      },
+    });
+    assert.ok(config, 'premise: the blob deserialized');
+
+    storage.failKey = SETTINGS_KEY;
+    const result = state.applyClashFlavorConfig(config);
+
+    assert.deepStrictEqual(
+      result,
+      { ok: true },
+      'the two producers describe the same settings, so the refused write would have changed nothing',
+    );
+    assert.deepStrictEqual(state.clashPresets.filter((p) => !p.builtin).map((p) => p.id), [FLAVOR_CUSTOM_ID]);
+    assert.deepStrictEqual(storedCustomIds(storage), [FLAVOR_CUSTOM_ID]);
+    assert.strictEqual(storage.getItem(SETTINGS_KEY), settingsBefore, 'the settings key never moved');
+    assert.deepStrictEqual(storage.writes, [PRESETS_KEY]);
+  });
+
+  // ── the presets write is refused but the rule set is already stored ───────
+
+  /**
+   * The same no-op rule as the two cases above, on the write that runs FIRST.
+   *
+   * "Nothing written, nothing to undo" is a statement about the rollback, not a
+   * reason to fail: a flavor can carry the rule set that is already stored and
+   * move only the thresholds — the exact twin of the settings-side case, and
+   * the pairing the rollback branch already names as realistic. With the
+   * presets key blocked, the refused write would have stored what is stored
+   * already, so the settings write below it can still land and the flavor is
+   * fully applied. Aborting instead applies nothing and tells the user the
+   * clash rules were not saved over storage holding exactly those rules.
+   */
+  it('applies the flavor when the refused presets write would not have changed the stored rule set', () => {
+    storage.failKey = PRESETS_KEY;
+    const presetsBefore = storage.getItem(PRESETS_KEY);
+
+    // The flavor carries the rule set already in storage; only settings move.
+    const result = state.applyClashFlavorConfig({
+      presets: [customPreset(OLD_CUSTOM_ID, 'Rule from the previous flavor')],
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.deepStrictEqual(
+      result,
+      { ok: true },
+      'the refused write would have stored the rule set already stored, so it changed nothing',
+    );
+    // The half that had somewhere to go is live in the store...
+    assert.strictEqual(state.clashMode, FLAVOR_SETTINGS.mode);
+    assert.strictEqual(state.clashTolerance, FLAVOR_SETTINGS.tolerance);
+    assert.strictEqual(state.clashGroupBy, FLAVOR_SETTINGS.groupBy);
+    // ...and landed on disk.
+    assert.strictEqual(storedTolerance(storage), FLAVOR_SETTINGS.tolerance);
+    // The rule set the store shows is the flavor's, which is the one the
+    // untouched presets key already holds.
+    assert.deepStrictEqual(state.clashPresets.filter((p) => !p.builtin).map((p) => p.id), [OLD_CUSTOM_ID]);
+    assert.strictEqual(
+      storage.getItem(PRESETS_KEY),
+      presetsBefore,
+      'the presets key was never written — it did not need to be',
+    );
+    assert.deepStrictEqual(storedCustomIds(storage), [OLD_CUSTOM_ID]);
+    assert.deepStrictEqual(
+      storage.writes,
+      [SETTINGS_KEY],
+      'the settings write is the only one that had anything to do',
+    );
+  });
+
+  it('still reports the settings refusal when the no-op presets write is followed by a real one', () => {
+    // The cell where letting the presets write pass must NOT turn into a
+    // success: the rule set is already stored, but the settings write is a
+    // real one and it is refused. Nothing the user asked for was applied, so
+    // this has to stay a failure — the pass-through above only removes a
+    // reason to fail, it does not add a reason to succeed.
+    storage.failKey = PRESETS_KEY;
+    storage.failAfterWrites = 0; // ...and the settings key cannot be written either
+    const presetsBefore = storage.getItem(PRESETS_KEY);
+    const settingsBefore = storage.getItem(SETTINGS_KEY);
+
+    const result = state.applyClashFlavorConfig({
+      presets: [customPreset(OLD_CUSTOM_ID, 'Rule from the previous flavor')],
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.strictEqual(result.ok, false, 'the settings the flavor asked for were not saved');
+    assert.strictEqual(
+      !result.ok && result.reason,
+      'quota',
+      'nothing was stranded: neither key moved, so this is an ordinary refused write',
+    );
+    // Nothing committed, nothing written.
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+    assert.strictEqual(state.clashMode, OLD_SETTINGS.mode);
+    assert.strictEqual(storage.getItem(PRESETS_KEY), presetsBefore);
+    assert.strictEqual(storage.getItem(SETTINGS_KEY), settingsBefore);
+    assert.deepStrictEqual(storage.writes, []);
   });
 
   // ── partial: presets refused ───────────────────────────────────────────────

--- a/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
+++ b/apps/viewer/src/store/slices/clashSlice.flavor.test.ts
@@ -35,6 +35,14 @@ class MemoryStorage {
   private store = new Map<string, string>();
   /** Key whose `setItem` throws, mimicking a quota / blocked-storage refusal. */
   failKey: string | null = null;
+  /**
+   * Once this many writes have landed, EVERY subsequent `setItem` throws,
+   * regardless of key — genuine quota exhaustion (the disk is full), as
+   * opposed to `failKey`'s "this one key is blocked". A rollback write is a
+   * write like any other, so this is what makes a failed rollback reachable:
+   * `failKey` alone can never fail a write to a *different* key.
+   */
+  failAfterWrites: number | null = null;
   /** Every successful write, in order (lets a test prove nothing was persisted). */
   writes: string[] = [];
   getItem(key: string): string | null {
@@ -42,6 +50,9 @@ class MemoryStorage {
   }
   setItem(key: string, value: string): void {
     if (key === this.failKey) throw new DOMException('quota', 'QuotaExceededError');
+    if (this.failAfterWrites !== null && this.writes.length >= this.failAfterWrites) {
+      throw new DOMException('quota', 'QuotaExceededError');
+    }
     this.store.set(key, value);
     this.writes.push(key);
   }
@@ -180,6 +191,57 @@ describe('applyClashFlavorConfig - only commit a config that actually persisted'
       storage.writes,
       [PRESETS_KEY, PRESETS_KEY],
       'the presets write and its rollback, and no settings write',
+    );
+  });
+
+  // ── genuine quota exhaustion: the rollback itself also fails ───────────────
+
+  it('reports the mismatch when the rollback also fails, and never claims the flavor applied', () => {
+    // The presets write is the very first write attempted here (the seed above
+    // resets `writes` to empty), so allowing exactly one write lets it land and
+    // then fails everything after — the settings write AND the rollback's
+    // presets write. A single blocked key (`failKey`) cannot reach this: the
+    // rollback writes to the SAME key that just succeeded, so a per-key stub
+    // would let it through and hide this exact defect.
+    storage.failAfterWrites = 1;
+
+    const result = state.applyClashFlavorConfig({
+      presets: FLAVOR_PRESETS,
+      settings: FLAVOR_SETTINGS,
+    });
+
+    assert.strictEqual(result.ok, false, 'a refused settings write must be reported');
+    assert.ok(
+      !result.ok && /previous rule set could also not be restored/.test(result.message),
+      'the message must name the rollback failure, not read like an ordinary settings refusal',
+    );
+
+    // What the user sees: the store never moved off the previous flavor.
+    assert.ok(
+      state.clashPresets.some((p) => p.id === OLD_CUSTOM_ID),
+      'the previous flavor rule set must still be listed',
+    );
+    assert.ok(!state.clashPresets.some((p) => p.id === FLAVOR_CUSTOM_ID));
+    assert.strictEqual(state.clashTolerance, OLD_SETTINGS.tolerance);
+
+    // What is actually on disk: the hybrid the user never chose. This is the
+    // residual defect — the store is correct, but storage now holds the NEW
+    // presets next to the OLD settings, and that mismatched pair is exactly
+    // what a reload would rehydrate.
+    assert.deepStrictEqual(
+      storedCustomIds(storage),
+      [FLAVOR_CUSTOM_ID],
+      'the presets write landed and the rollback could not undo it',
+    );
+    assert.strictEqual(
+      storedTolerance(storage),
+      OLD_SETTINGS.tolerance,
+      'the settings write never landed at all',
+    );
+    assert.deepStrictEqual(
+      storage.writes,
+      [PRESETS_KEY],
+      'only the original presets write landed; the settings write and the rollback both threw',
     );
   });
 

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -879,13 +879,20 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
           // it, matching every other refused write in this slice; enrich the
           // message so that warning names the real severity instead of
           // reading like an ordinary "settings not saved" refusal.
+          //
+          // `reason` carries the same distinction in machine-readable form.
+          // Passing `settingsResult.reason` through would report `'quota'` for
+          // both halves of this branch — genuine exhaustion is what fails a
+          // rollback in the first place — leaving "recovered, storage is
+          // consistent" and "stranded, storage is not" indistinguishable in
+          // the only field a caller can branch on.
           console.warn(
             '[clash] flavor apply: could not restore the previous rule set after a refused settings write — storage now holds the new rule set with the previous settings:',
             undo.message,
           );
           return {
             ok: false,
-            reason: settingsResult.reason,
+            reason: 'rollback_failed',
             message:
               `${settingsResult.message} The previous rule set could also not be restored ` +
               `(${undo.message}), so saved data may no longer match what is shown.`,

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -54,6 +54,7 @@ import {
   savePresets,
   saveReviews,
   saveSettings,
+  settingsAlreadyStored,
   validatePresetName,
   validateSelector,
   CLASH_BOUNDS,
@@ -857,17 +858,32 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
       if (!presetsResult.ok) return presetsResult; // nothing written, nothing to undo
 
       const settingsResult = saveSettings(settings);
-      if (!settingsResult.ok) {
+      // The same rule the rollback below applies to the presets write, applied
+      // to this one: a refused write that would have stored exactly what is
+      // stored already changed nothing, so it must not fail the apply. A flavor
+      // can carry the settings that are on disk and differ only in its rule set
+      // — flavors that share the thresholds and swap the rules around them —
+      // and then the settings key needs no write at all: the presets write
+      // above landed, and both keys already hold the flavor's config. Aborting
+      // here would roll that write back and report "clash settings were not
+      // saved" over storage holding exactly those settings.
+      //
+      // `settingsAlreadyStored` compares against the bytes `saveSettings`
+      // itself builds, so what is compared is what would have been written; it
+      // answers `false` for anything it cannot prove identical, which only ever
+      // costs a refusal that was already the old behaviour.
+      if (!settingsResult.ok && !settingsAlreadyStored(settings)) {
         // Put the previous rule set back so storage matches the store we are
         // about to leave untouched. This rewrites a payload that fit a moment
         // ago, in place of the one that just replaced it, so it should land.
         const undo = savePresets(previousPresets);
         // A failed undo only strands something if the write it was undoing
-        // actually changed the stored bytes. A flavor can carry the rule set
-        // that is already stored and differ only in its tolerances, and then
-        // the presets write rewrote the same payload: storage still holds the
-        // previous rule set beside the previous settings, which is exactly
-        // what the store holds, so this is an ordinary refused settings write.
+        // stored a different rule set than the one already stored. A flavor can
+        // carry the rule set that is already stored and differ only in its
+        // tolerances, and then the presets write stored the same rule set over
+        // itself: storage still holds the previous rule set beside the previous
+        // settings, which is exactly what the store holds, so this is an
+        // ordinary refused settings write.
         // `presetsStoreIdentically` compares the payloads `savePresets` itself
         // builds, not the arrays, because `presetsToStore` drops unmodified
         // built-ins — two rule sets that differ as arrays can store the same.

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -855,7 +855,26 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
       // before it touches storage, which makes the common failure a clean no-op.
       const previousPresets = get().clashPresets;
       const presetsResult = savePresets(presets);
-      if (!presetsResult.ok) return presetsResult; // nothing written, nothing to undo
+      // The same rule the settings write below and the rollback under it both
+      // apply, applied to the write that runs FIRST: a refused write that would
+      // have stored exactly what is stored already changed nothing, so it must
+      // not fail the apply. "Nothing written, nothing to undo" is a statement
+      // about the rollback, not a reason to abort — a flavor can carry the rule
+      // set that is already stored and differ only in its thresholds (the same
+      // pairing the rollback branch below names), and then the presets key
+      // needs no write at all and the settings write still has somewhere to go.
+      // Aborting here applies neither half and reports "clash rules were not
+      // saved" over storage holding exactly those rules.
+      //
+      // `presetsStoreIdentically` compares the payloads `savePresets` itself
+      // builds, so what is compared is what would have been written; it answers
+      // `false` for anything it cannot prove identical (an unserializable rule
+      // set included), which only ever costs a refusal that was already the old
+      // behaviour. Letting the refusal pass does not make the apply succeed on
+      // its own: everything below still gates on the settings write.
+      if (!presetsResult.ok && !presetsStoreIdentically(previousPresets, presets)) {
+        return presetsResult; // nothing written, nothing to undo
+      }
 
       const settingsResult = saveSettings(settings);
       // The same rule the rollback below applies to the presets write, applied

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -366,8 +366,12 @@ export interface ClashSlice {
   /**
    * Replace the entire clash config (presets + detection settings) and persist.
    * Used when activating a flavor/profile so each one carries its own rule-set.
+   *
+   * All-or-nothing: the two writes go to two independent localStorage keys, so
+   * a refused write (quota, or storage blocked entirely) is undone and nothing
+   * is committed to the store. Callers report `result.message`.
    */
-  applyClashFlavorConfig: (config: { presets: ClashPreset[]; settings: ClashGlobalSettings }) => void;
+  applyClashFlavorConfig: (config: { presets: ClashPreset[]; settings: ClashGlobalSettings }) => SaveResult;
   clearClash: () => void;
 }
 
@@ -837,6 +841,34 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
       }),
 
     applyClashFlavorConfig: ({ presets, settings }) => {
+      // Persist FIRST, commit only if both writes landed: a flavor whose config
+      // is shown as applied but was refused by storage silently reverts to the
+      // previous flavor's rules on the next reload.
+      //
+      // The two halves live under two independent localStorage keys and there is
+      // no transaction across them, so a half-landed apply (new rule set, old
+      // tolerances) is reachable. That state is not one the user can reason
+      // about or even see is wrong, so it is undone rather than committed.
+      // Presets go first because `savePresets` rejects an over-cap rule set
+      // before it touches storage, which makes the common failure a clean no-op.
+      const previousPresets = get().clashPresets;
+      const presetsResult = savePresets(presets);
+      if (!presetsResult.ok) return presetsResult; // nothing written, nothing to undo
+
+      const settingsResult = saveSettings(settings);
+      if (!settingsResult.ok) {
+        // Put the previous rule set back so storage matches the store we are
+        // about to leave untouched. This rewrites a payload that fit a moment
+        // ago, in place of the one that just replaced it, so it should land; if
+        // it does not there is no further recovery, and the caller still reports
+        // the original failure.
+        const undo = savePresets(previousPresets);
+        if (!undo.ok) {
+          console.warn('[clash] flavor apply: could not restore the previous rule set:', undo.message);
+        }
+        return settingsResult;
+      }
+
       const state = get();
       set({
         clashPresets: presets,
@@ -858,9 +890,7 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
           false,
         ),
       });
-      // Persist so the activated flavor's config becomes the working set on reload.
-      savePresets(presets);
-      saveSettings(settings);
+      return { ok: true };
     },
 
     clearClash: () =>

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -859,12 +859,37 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
       if (!settingsResult.ok) {
         // Put the previous rule set back so storage matches the store we are
         // about to leave untouched. This rewrites a payload that fit a moment
-        // ago, in place of the one that just replaced it, so it should land; if
-        // it does not there is no further recovery, and the caller still reports
-        // the original failure.
+        // ago, in place of the one that just replaced it, so it should land.
         const undo = savePresets(previousPresets);
         if (!undo.ok) {
-          console.warn('[clash] flavor apply: could not restore the previous rule set:', undo.message);
+          // The rollback failed too — realistic, since genuine quota exhaustion
+          // (as opposed to one blocked key) leaves the disk full for the next
+          // write as well. The store is still correct: nothing below this
+          // branch runs, so the in-memory flavor never moved. But storage now
+          // holds the NEW presets next to the OLD settings, a hybrid the user
+          // never chose, and that pair rehydrates as-is on the next reload.
+          //
+          // There is no third write to retry and no snapshot beyond the one
+          // that just failed to fall back to, so a bigger recovery mechanism
+          // (re-reading storage back into the store, or a latch that refuses
+          // further applies) would be reacting to a failure mode this rare —
+          // a full quota surviving two consecutive writes — with a permanent
+          // behavior change. What the caller (`ExtensionHostService`, see
+          // `host.ts`) already does with a failed `SaveResult` is console.warn
+          // it, matching every other refused write in this slice; enrich the
+          // message so that warning names the real severity instead of
+          // reading like an ordinary "settings not saved" refusal.
+          console.warn(
+            '[clash] flavor apply: could not restore the previous rule set after a refused settings write — storage now holds the new rule set with the previous settings:',
+            undo.message,
+          );
+          return {
+            ok: false,
+            reason: settingsResult.reason,
+            message:
+              `${settingsResult.message} The previous rule set could also not be restored ` +
+              `(${undo.message}), so saved data may no longer match what is shown.`,
+          };
         }
         return settingsResult;
       }

--- a/apps/viewer/src/store/slices/clashSlice.ts
+++ b/apps/viewer/src/store/slices/clashSlice.ts
@@ -50,6 +50,7 @@ import {
   loadReviews,
   loadSettings,
   saveExclusions,
+  presetsStoreIdentically,
   savePresets,
   saveReviews,
   saveSettings,
@@ -861,7 +862,16 @@ export const createClashSlice: StateCreator<ClashSlice, [], [], ClashSlice> = (s
         // about to leave untouched. This rewrites a payload that fit a moment
         // ago, in place of the one that just replaced it, so it should land.
         const undo = savePresets(previousPresets);
-        if (!undo.ok) {
+        // A failed undo only strands something if the write it was undoing
+        // actually changed the stored bytes. A flavor can carry the rule set
+        // that is already stored and differ only in its tolerances, and then
+        // the presets write rewrote the same payload: storage still holds the
+        // previous rule set beside the previous settings, which is exactly
+        // what the store holds, so this is an ordinary refused settings write.
+        // `presetsStoreIdentically` compares the payloads `savePresets` itself
+        // builds, not the arrays, because `presetsToStore` drops unmodified
+        // built-ins — two rule sets that differ as arrays can store the same.
+        if (!undo.ok && !presetsStoreIdentically(previousPresets, presets)) {
           // The rollback failed too — realistic, since genuine quota exhaustion
           // (as opposed to one blocked key) leaves the disk full for the next
           // write as well. The store is still correct: nothing below this


### PR DESCRIPTION
Applying a clash flavor writes two keys — the rule set, then the settings — and rolls the first back if the second is refused. Three defects in how that reports itself, each found only after fixing the one before it.

## 1. The refusal reason could not distinguish the two outcomes that matter

The double-failure path (settings refused **and** rollback failed, leaving the new rule set with the old settings on disk) reused `settingsResult.reason`. Both writers emit `'quota'`, so "rolled back, disk consistent" and "disk now inconsistent" were identical in the only machine-readable field. Added `'rollback_failed'` (snake_case, matching the union's existing `too_many`).

## 2. Then it lied in the other direction

If the flavor's rule set **serialises to what is already stored** — realistic for flavors sharing a rule set and differing only in tolerances — the rollback rewrites the same bytes, so a failed undo undid nothing. The code still emitted the strongest "storage may be corrupted" signal over byte-identical storage.

Fixed structurally: `presetsPayload()` is extracted so that `savePresets` **and** the comparison build the string from the same function — the compared bytes are the written bytes by construction, not by convention. A structural comparison would have been wrong twice over: `presetsToStore` drops built-ins matching their default, so two rule sets that differ as arrays store identically, which is exactly the live case.

## 3. Then the rule was applied to one write and not the other

The same no-op principle was mirrored onto the settings write — and **not** onto the presets write that runs first. A flavor sharing the rule set and moving only the thresholds, with the presets key blocked, reported *"Browser storage is full — clash rules were not saved"* over storage holding exactly those rules. The same sentence-shaped lie, halves swapped.

Full 16-cell matrix now executed (presets ok/refused × same/diff × settings ok/refused × same/diff). No cell reports success, and none reports a benign reason, over a state the user did not ask for — and a reload rebuilds the reported store in every cell.

## 4. "By construction" was narrower than it claimed

The builder was shared, but `JSON.stringify` key order comes from the **input object**, and the two production inputs are built by two unshared object literals — `snapshotSettings` (`clashSlice.ts:434`) and `normalizeSettings` (`persistence.ts:325`). They agreed only by convention. Swapping two keys in either survived the entire 54-test suite while silently turning the fix into dead code and restoring the original bug, green.

The tests could not see it because every one of them built the flavor settings by spreading the stored seed — inheriting its key order, so divergence was impossible to observe. The fixture was structurally incapable of testing the property it covered.

`settingsPayload` now rebuilds the settings field by field before stringifying, so key order is the builder's regardless of caller. Chosen over a shared constructor because it protects *every* input including a future third producer, whereas a constructor only binds producers that remember to call it — the same convention-not-mechanism failure being fixed. The `ClashGlobalSettings` annotation (not `satisfies`) makes a forgotten field a compile error rather than a field silently dropped from storage.

## On the mutation evidence, stated precisely

The two key-order mutants **now survive, as equivalent mutants** — a fix that makes key order irrelevant necessarily makes a key-order mutation behaviourally inert. That is not a coverage gap, but it is also not a kill, so it is not reported as one.

The stronger statement was verified instead: with the fix reverted, both mutants kill the new production-shaped test, and a control run (fix reverted, no mutation) kills only one — proving the second kill is the mutants' doing rather than the revert's. The fragility is removed, not merely observed.

Other mutants: reverting the presets guard, forcing the guard always-true, dropping a field from the canonical builder (killed by `tsc`, the annotation guard firing), and mis-assigning a field — all killed.

## Verification

54 → **58 passing**, every pre-existing test still green. Wider clash regression across 11 files: **121 passed / 0 failed**. `tsc --noEmit` clean. No changeset — `apps/viewer` is `"private": true`, confirmed against this branch's own three prior commits rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
