### PR TITLE
fix(processing): bound symbolic extraction by output size, and report why it truncates

### DIFF
--- a/.changeset/symbolic-output-cap.md
+++ b/.changeset/symbolic-output-cap.md
@@ -1,0 +1,20 @@
+---
+"@ifc-lite/parser": minor
+"@ifc-lite/server-client": patch
+---
+
+Bound symbolic extraction by output size, and report every truncation with the reason it happened.
+
+`extract_symbolic_data` accumulated into one `SymbolicData` across every product, so the per-item recursion bounds left the file-level total unbounded: a crafted 1.13 MB upload produced 20,002,500 primitives and 2.74 GB RSS on a path the server calls with raw uploaded bytes. Separately, well-formed drawings lost content to the per-item bounds with no way for a consumer to tell a clipped result from a complete one.
+
+Extraction now stops at 2,000,000 primitives or 256 MiB of estimated output, whichever comes first, and `SymbolicData` gains a `truncated` field naming which bound fired: `element-count`, `output-bytes`, `item-depth` or `item-revisits`.
+
+The byte bound is the load-bearing one, and it has to charge **every** variable-length field. A count-only cap is not a memory bound: per-primitive size is attacker-controlled and the fan-out re-emits one leaf up to the cap, cloning it each time. Charging only the obvious field is the same hole one door along — a text leaf with a 4 KB `BoxAlignment` reached 3.45 GB while the accountant thought it had spent 54.9 MB and the bound never fired. Both are now charged and both are pinned by tests.
+
+The per-item reasons matter as much as the extraction ones: a nested block import can lose 60% of its curves to the per-item revisit budget while the whole-file totals sit far below either extraction bound, so a diagnostic reporting only the extraction bounds would have stayed silent on exactly that case. A per-item bound marks the result truncated but does not stop the extraction — one deep item must not abandon the rest of the file.
+
+Marked `minor`: `SymbolicData` gains a public field, so an exhaustive struct literal in a downstream Rust consumer needs `..Default::default()`. The wire shape is unchanged for a complete extraction — `truncated` is `skip_serializing_if`, so cache keys do not move and JSON written before the field existed still deserializes.
+
+The flag is carried through the WASM boundary (`SymbolicRepresentationCollection.truncatedAt`) as well as the HTTP route, and added to the `SymbolicData` TypeScript interface. Geometry is client-side only in the viewer, so a flag surviving only the server route would have left the browser silently truncating.
+
+Not addressed here: `apps/server/src/routes/parse/json.rs` clones the response and serializes it up to three more times after its admission permit scope ends. That amplifies the whole `ParseResponse` (dominated by meshes), is a different mechanism from the structural amplification this fixes, and is deferred rather than closed.

--- a/.changeset/symbolic-output-cap.md
+++ b/.changeset/symbolic-output-cap.md
@@ -1,6 +1,6 @@
 ---
 "@ifc-lite/parser": minor
-"@ifc-lite/server-client": patch
+"@ifc-lite/server-client": minor
 ---
 
 Bound symbolic extraction by output size, and report every truncation with the reason it happened.

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -359,12 +359,32 @@ export interface SymbolicFillArea {
  * binary (Parquet) transports. Arrays may be empty when the model carries no
  * 2D symbols.
  */
+/**
+ * Present only when extraction stopped at its bound; absent when the file was
+ * emitted in full.
+ */
+export interface SymbolicTruncation {
+  /** The bound that was hit. */
+  limit: number;
+  /** Primitives emitted before extraction stopped. */
+  emitted: number;
+}
+
 export interface SymbolicData {
   grid_axes: SymbolicGridAxis[];
   polylines: SymbolicPolyline[];
   circles: SymbolicCircle[];
   texts: SymbolicText[];
   fills: SymbolicFillArea[];
+  /**
+   * Set when the server bounded this extraction and returned a partial result.
+   *
+   * Optional because it is omitted for a complete extraction, so an existing
+   * consumer keeps compiling. But a consumer that renders symbolic geometry
+   * without reading this shows a clipped drawing as though it were the whole
+   * drawing, which is the failure this field exists to end.
+   */
+  truncated?: SymbolicTruncation;
 }
 
 /**

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -363,11 +363,35 @@ export interface SymbolicFillArea {
  * Present only when extraction stopped at its bound; absent when the file was
  * emitted in full.
  */
+/**
+ * Which bound stopped an extraction early.
+ *
+ * Mirrors `SymbolicTruncationReason` in `rust/processing/src/symbolic/output_cap.rs`,
+ * serialized kebab-case. The extraction bounds (`element-count`, `output-bytes`)
+ * are the severe ones and outrank the per-item bounds, which stop one
+ * representation item's contribution while the whole-file totals can sit far
+ * below either extraction bound.
+ */
+export type SymbolicTruncationReason =
+  | 'element-count'
+  | 'output-bytes'
+  | 'item-depth'
+  | 'item-revisits';
+
 export interface SymbolicTruncation {
-  /** The bound that was hit. */
-  limit: number;
-  /** Primitives emitted before extraction stopped. */
+  /** Which bound fired. */
+  reason: SymbolicTruncationReason;
+  /** Total primitives emitted. */
   emitted: number;
+  /**
+   * The bound's numeric value, when the reason has one.
+   *
+   * ABSENT for `item-depth` and `item-revisits`: those bounds are per
+   * representation item, so there is no file-level number to compare `emitted`
+   * against, and rendering "showing {emitted} of {limit}" for them would
+   * invent a relationship that does not exist.
+   */
+  limit?: number;
 }
 
 export interface SymbolicData {

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1581,6 +1581,10 @@ export class SymbolicRepresentationCollection {
      * Get total count of all symbolic items
      */
     readonly totalCount: number;
+    /**
+     * Primitive count at which extraction stopped, else `undefined`.
+     */
+    readonly truncatedAt: number | undefined;
 }
 
 /**
@@ -2072,6 +2076,7 @@ export interface InitOutput {
     readonly symbolicrepresentationcollection_polylineCount: (a: number) => number;
     readonly symbolicrepresentationcollection_textCount: (a: number) => number;
     readonly symbolicrepresentationcollection_totalCount: (a: number) => number;
+    readonly symbolicrepresentationcollection_truncatedAt: (a: number) => number;
     readonly symbolictext_alignment: (a: number, b: number) => void;
     readonly symbolictext_colorA: (a: number) => number;
     readonly symbolictext_content: (a: number, b: number) => void;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1566,7 +1566,8 @@ export class SymbolicRepresentationCollection {
      */
     readonly fillCount: number;
     /**
-     * Check if collection is empty
+     * Check if collection is empty. A TRUNCATED result never is, even with no
+     * primitives; the reasoning and the parity test are in `symbolic_truncation.rs`.
      */
     readonly isEmpty: boolean;
     /**

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1585,6 +1585,19 @@ export class SymbolicRepresentationCollection {
      * Primitive count at which extraction stopped, else `undefined`.
      */
     readonly truncatedAt: number | undefined;
+    /**
+     * The bound's numeric value, when the reason has one, else `undefined`.
+     * Absent for the per-item reasons, whose bound is per item and not
+     * comparable with `truncatedAt`.
+     */
+    readonly truncatedLimit: number | undefined;
+    /**
+     * Which bound stopped extraction, else `undefined`. One of
+     * `element-count`, `output-bytes`, `item-depth`, `item-revisits` —
+     * the same kebab-case strings the JSON path emits, so a consumer reading
+     * either surface reads one vocabulary.
+     */
+    readonly truncatedReason: string | undefined;
 }
 
 /**
@@ -2077,6 +2090,8 @@ export interface InitOutput {
     readonly symbolicrepresentationcollection_textCount: (a: number) => number;
     readonly symbolicrepresentationcollection_totalCount: (a: number) => number;
     readonly symbolicrepresentationcollection_truncatedAt: (a: number) => number;
+    readonly symbolicrepresentationcollection_truncatedLimit: (a: number) => number;
+    readonly symbolicrepresentationcollection_truncatedReason: (a: number, b: number) => void;
     readonly symbolictext_alignment: (a: number, b: number) => void;
     readonly symbolictext_colorA: (a: number) => number;
     readonly symbolictext_content: (a: number, b: number) => void;

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -73,6 +73,7 @@ pub use simplify_session::{simplify_element, SimplifiedElement, SimplifyRecordIn
 pub use style::{default_color_for_type, Rgba, TRANSPARENCY_ALPHA_THRESHOLD};
 pub use symbolic::{
     extract_symbolic_data, SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis,
+    SymbolicTruncation,
     SymbolicPolyline, SymbolicText,
 };
 pub use types::mesh::{InstanceRecord, MeshData, RawInstanceOccurrence};

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -73,8 +73,7 @@ pub use simplify_session::{simplify_element, SimplifiedElement, SimplifyRecordIn
 pub use style::{default_color_for_type, Rgba, TRANSPARENCY_ALPHA_THRESHOLD};
 pub use symbolic::{
     extract_symbolic_data, SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis,
-    SymbolicTruncation,
-    SymbolicPolyline, SymbolicText,
+    SymbolicPolyline, SymbolicText, SymbolicTruncation, SymbolicTruncationReason,
 };
 pub use types::mesh::{InstanceRecord, MeshData, RawInstanceOccurrence};
 pub use types::response::{

--- a/rust/processing/src/symbolic/fill.rs
+++ b/rust/processing/src/symbolic/fill.rs
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::output_cap::SymbolicAccumulator;
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use std::collections::HashMap;
 
 use super::color::resolve_color_via_styles;
-use super::primitives::{SymbolicData, SymbolicFillArea};
+use super::primitives::{SymbolicFillArea};
 use super::transform::{circle_center, Transform2D};
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -25,7 +26,7 @@ pub(super) fn extract_annotation_fill_area(
     rtc_x: f32,
     rtc_z: f32,
     styled_items: &HashMap<u32, Vec<u32>>,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
 ) {
     let Some(outer_ref) = item.get_ref(0) else { return };
     let mut points = extract_curve_ring(outer_ref, decoder, unit_scale, transform, rtc_x, rtc_z);
@@ -51,7 +52,7 @@ pub(super) fn extract_annotation_fill_area(
         .unwrap_or([0.0, 0.0, 0.0, 1.0]);
     let world_y = sample_curve_world_y(outer_ref, decoder, unit_scale) + transform.tz;
 
-    out.fills.push(SymbolicFillArea {
+    out.push_fill(SymbolicFillArea {
         express_id,
         ifc_type: ifc_type.to_string(),
         points,

--- a/rust/processing/src/symbolic/grid.rs
+++ b/rust/processing/src/symbolic/grid.rs
@@ -2,9 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::output_cap::SymbolicAccumulator;
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 
-use super::primitives::{SymbolicData, SymbolicGridAxis, SymbolicPolyline, SymbolicText};
+use super::primitives::{SymbolicGridAxis, SymbolicPolyline, SymbolicText};
 use super::transform::Transform2D;
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -26,7 +27,7 @@ pub(super) fn extract_grid(
     transform: &Transform2D,
     rtc_x: f32,
     rtc_z: f32,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
 ) {
     for axis_attr_idx in [7usize, 8, 9] {
         let Some(axes_attr) = grid.get(axis_attr_idx) else { continue };
@@ -50,7 +51,7 @@ pub(super) fn extract_grid(
             let world_y = transform.tz;
 
             // Compact server-friendly entry — keeps the existing endpoint-pair shape.
-            out.grid_axes.push(SymbolicGridAxis {
+            out.push_grid_axis(SymbolicGridAxis {
                 express_id: axis_id,
                 grid_express_id: grid_id,
                 tag: tag.clone(),
@@ -59,7 +60,7 @@ pub(super) fn extract_grid(
             });
 
             // Axis line (browser pipeline: SymbolicPolyline + bubble texts).
-            out.polylines.push(SymbolicPolyline {
+            out.push_polyline(SymbolicPolyline {
                 express_id: axis_id,
                 ifc_type: "IfcGridAxis".to_string(),
                 points: vec![a.0, a.1, b.0, b.1],
@@ -92,8 +93,8 @@ pub(super) fn extract_grid(
 /// Emit a bubble (transparent interior + black outline ○ + tag text) as
 /// two stacked text instances. The shader's per-instance `target_px` keeps
 /// them at the right relative size at every zoom level.
-fn emit_bubble(axis_id: u32, cx: f32, cy: f32, world_y: f32, tag: &str, out: &mut SymbolicData) {
-    out.texts.push(SymbolicText {
+fn emit_bubble(axis_id: u32, cx: f32, cy: f32, world_y: f32, tag: &str, out: &mut SymbolicAccumulator) {
+    out.push_text(SymbolicText {
         express_id: axis_id,
         ifc_type: "IfcGridAxis".to_string(),
         x: cx,
@@ -108,7 +109,7 @@ fn emit_bubble(axis_id: u32, cx: f32, cy: f32, world_y: f32, tag: &str, out: &mu
         target_px: BUBBLE_TARGET_PX,
         representation: "Axis".to_string(),
     });
-    out.texts.push(SymbolicText {
+    out.push_text(SymbolicText {
         express_id: axis_id,
         ifc_type: "IfcGridAxis".to_string(),
         x: cx,

--- a/rust/processing/src/symbolic/item_walk.rs
+++ b/rust/processing/src/symbolic/item_walk.rs
@@ -10,7 +10,7 @@
 //! allowed to do; nothing here knows about any IFC type.
 
 use super::items::extract_symbolic_item_inner;
-use super::primitives::SymbolicData;
+use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
 use super::transform::Transform2D;
 use ifc_lite_core::{DecodedEntity, EntityDecoder};
 use rustc_hash::FxHashSet;
@@ -122,7 +122,7 @@ pub(super) fn extract_symbolic_item(
     rtc_x: f32,
     rtc_z: f32,
     styled_items: &HashMap<u32, Vec<u32>>,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
 ) {
     let mut walk = ItemWalk {
         path: FxHashSet::default(),
@@ -153,7 +153,7 @@ pub(super) fn extract_symbolic_item_with_revisit_budget(
     rtc_x: f32,
     rtc_z: f32,
     styled_items: &HashMap<u32, Vec<u32>>,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
     revisit_budget: u32,
 ) {
     let mut walk = ItemWalk {
@@ -179,11 +179,21 @@ pub(super) fn extract_symbolic_item_at(
     rtc_x: f32,
     rtc_z: f32,
     styled_items: &HashMap<u32, Vec<u32>>,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
     depth: u32,
     walk: &mut ItemWalk,
 ) {
     if depth >= MAX_ITEM_DEPTH {
+        // Report it. This return DROPS CONTENT, and #2938 is precisely that it
+        // did so in silence: the file-level totals stay far below the
+        // extraction bounds, so nothing else in the pipeline notices.
+        out.note_item_bound(SymbolicTruncationReason::ItemDepth);
+        return;
+    }
+    // Stop WALKING once the accumulator is FULL -- not merely because some
+    // earlier item reported dropping content, which must not abandon the rest
+    // of the file.
+    if out.is_exhausted() {
         return;
     }
     // A first visit is free: their number is bounded by the file. Only a
@@ -192,7 +202,16 @@ pub(super) fn extract_symbolic_item_at(
     if !walk.seen.insert(item.id) {
         match walk.revisit_budget.checked_sub(1) {
             Some(left) => walk.revisit_budget = left,
-            None => return,
+            None => {
+                // #2938's LEAD case: a well-formed nested block import
+                // (2,000 inserts of a 250-curve symbol) loses 60% of its
+                // curves here while emitting only 200,250 primitives -- far
+                // under both extraction bounds. A diagnostic that reported
+                // only those bounds would say nothing about the scenario the
+                // issue is actually about.
+                out.note_item_bound(SymbolicTruncationReason::ItemRevisits);
+                return;
+            }
         }
     }
     if !walk.enter_node(item.id) {

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::output_cap::SymbolicAccumulator;
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use std::collections::HashMap;
 
 use super::item_walk::{extract_symbolic_item_at, ItemWalk};
 use super::fill::extract_annotation_fill_area;
-use super::primitives::{SymbolicCircle, SymbolicData, SymbolicPolyline};
+use super::primitives::{SymbolicCircle, SymbolicPolyline};
 use super::text::extract_text_literal;
 use super::transform::{
     circle_center, compose_transforms, parse_axis2_placement_2d,
@@ -32,7 +33,7 @@ pub(super) fn extract_symbolic_item_inner(
     rtc_x: f32,
     rtc_z: f32,
     styled_items: &HashMap<u32, Vec<u32>>,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
     depth: u32,
     walk: &mut ItemWalk,
 ) {
@@ -173,7 +174,7 @@ pub(super) fn extract_symbolic_item_inner(
                             && (points[0] - points[n - 2]).abs() < 0.001
                             && (points[1] - points[n - 1]).abs() < 0.001;
                         let world_y = first_z.unwrap_or(0.0) + transform.tz;
-                        out.polylines.push(SymbolicPolyline {
+                        out.push_polyline(SymbolicPolyline {
                             express_id,
                             ifc_type: ifc_type.to_string(),
                             points,
@@ -214,7 +215,7 @@ pub(super) fn extract_symbolic_item_inner(
                     && (points[0] - points[n - 2]).abs() < 0.001
                     && (points[1] - points[n - 1]).abs() < 0.001;
                 let world_y = first_z.unwrap_or(0.0) + transform.tz;
-                out.polylines.push(SymbolicPolyline {
+                out.push_polyline(SymbolicPolyline {
                     express_id,
                     ifc_type: ifc_type.to_string(),
                     points,
@@ -233,7 +234,7 @@ pub(super) fn extract_symbolic_item_inner(
                 return;
             }
             let (wx, wy) = transform.transform_point(center_x, center_y);
-            out.circles.push(SymbolicCircle::full(
+            out.push_circle(SymbolicCircle::full(
                 express_id,
                 ifc_type.to_string(),
                 wx - rtc_x,
@@ -266,7 +267,7 @@ pub(super) fn extract_symbolic_item_inner(
                 }
             }
             if points.len() >= 4 {
-                out.polylines.push(SymbolicPolyline {
+                out.push_polyline(SymbolicPolyline {
                     express_id,
                     ifc_type: ifc_type.to_string(),
                     points,

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -17,6 +17,7 @@ use super::item_walk::{
     extract_symbolic_item, extract_symbolic_item_with_revisit_budget, MAX_ITEM_DEPTH,
     MAX_ITEM_REVISITS,
 };
+use super::output_cap::SymbolicAccumulator;
 use super::primitives::SymbolicData;
 use super::transform::Transform2D;
 use ifc_lite_core::{build_entity_index, EntityDecoder};
@@ -28,7 +29,7 @@ fn run(step: &str, start_id: u32) -> SymbolicData {
     let mut decoder = EntityDecoder::with_index(content, index);
     let item = decoder.decode_by_id(start_id).expect("fixture entity decodes");
     let styled: HashMap<u32, Vec<u32>> = HashMap::new();
-    let mut out = SymbolicData::default();
+    let mut out = SymbolicAccumulator::new();
     extract_symbolic_item(
         &item,
         &mut decoder,
@@ -42,7 +43,7 @@ fn run(step: &str, start_id: u32) -> SymbolicData {
         &styled,
         &mut out,
     );
-    out
+    out.into_data()
 }
 
 fn run_with_budget(step: &str, start_id: u32, budget: u32) -> SymbolicData {
@@ -51,7 +52,7 @@ fn run_with_budget(step: &str, start_id: u32, budget: u32) -> SymbolicData {
     let mut decoder = EntityDecoder::with_index(content, index);
     let item = decoder.decode_by_id(start_id).expect("fixture entity decodes");
     let styled: HashMap<u32, Vec<u32>> = HashMap::new();
-    let mut out = SymbolicData::default();
+    let mut out = SymbolicAccumulator::new();
     extract_symbolic_item_with_revisit_budget(
         &item,
         &mut decoder,
@@ -66,7 +67,7 @@ fn run_with_budget(step: &str, start_id: u32, budget: u32) -> SymbolicData {
         &mut out,
         budget,
     );
-    out
+    out.into_data()
 }
 
 /// Run the walk in a worker thread with a timeout, so a regressed guard is

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -79,7 +79,7 @@ mod text;
 mod transform;
 mod trimmed_curve;
 
-pub use output_cap::SymbolicTruncation;
+pub use output_cap::{SymbolicTruncation, SymbolicTruncationReason};
 pub use primitives::{
     SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline, SymbolicText,
 };

--- a/rust/processing/src/symbolic/mod.rs
+++ b/rust/processing/src/symbolic/mod.rs
@@ -61,6 +61,7 @@
 //!   default fill colour.
 
 
+use output_cap::SymbolicAccumulator;
 use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner, IfcType};
 
 mod color;
@@ -68,13 +69,17 @@ mod fill;
 mod grid;
 mod item_walk;
 mod items;
+mod output_cap;
 #[cfg(test)]
 mod items_cycle_tests;
+#[cfg(test)]
+mod output_cap_tests;
 mod primitives;
 mod text;
 mod transform;
 mod trimmed_curve;
 
+pub use output_cap::SymbolicTruncation;
 pub use primitives::{
     SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline, SymbolicText,
 };
@@ -95,6 +100,21 @@ use transform::{compose_transforms, parse_axis2_placement_2d, resolve_object_pla
 /// symbolic primitive collection. Pure-Rust (no `wasm_bindgen`), so it
 /// works inside the HTTP server.
 pub fn extract_symbolic_data<T>(content: &T) -> SymbolicData
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    let mut out = SymbolicAccumulator::new();
+    extract_symbolic_data_into(content, &mut out);
+    out.into_data()
+}
+
+/// The extraction itself, writing into a caller-supplied accumulator.
+///
+/// Split out so a test can supply an accumulator with a small injected cap
+/// and exercise the real path, instead of building a fixture that emits two
+/// million primitives to reach `MAX_SYMBOLIC_ELEMENTS`. Production has exactly
+/// one caller, above, which supplies the real cap via `Default`.
+fn extract_symbolic_data_into<T>(content: &T, out: &mut SymbolicAccumulator)
 where
     T: AsRef<[u8]> + ?Sized,
 {
@@ -124,10 +144,18 @@ where
     // IfcFillAreaStyle → IfcColourRgb).
     let styled_items = build_styled_item_index(content, &mut decoder);
 
-    let mut out = SymbolicData::default();
     let mut scanner = EntityScanner::new(content);
 
     while let Some((id, type_name, start, end)) = scanner.next_entity() {
+        // Stop the SCAN, not just the innermost item loop. Breaking only the
+        // inner loop still decodes every remaining product, resolves its
+        // placements and composes its transforms, which is not the "stop" this
+        // bound claims. Bounded by file size rather than by the fan-out, so it
+        // was never the DoS lever -- but it is work with a known-useless
+        // result.
+        if out.is_exhausted() {
+            break;
+        }
         let is_grid = type_name == "IFCGRID";
         if !is_grid && !ifc_lite_core::has_geometry_by_name(type_name) {
             // IfcGrid isn't in `has_geometry_by_name` (it's not a building
@@ -149,7 +177,7 @@ where
                 &grid_transform,
                 rtc_x,
                 rtc_z,
-                &mut out,
+                out,
             );
             continue;
         }
@@ -247,6 +275,9 @@ where
                 continue;
             };
             for item in items {
+                if out.is_exhausted() {
+                    break;
+                }
                 extract_symbolic_item(
                     &item,
                     &mut decoder,
@@ -258,11 +289,10 @@ where
                     rtc_x,
                     rtc_z,
                     &styled_items,
-                    &mut out,
+                    out,
                 );
             }
         }
     }
 
-    out
 }

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -108,12 +108,31 @@ pub enum SymbolicTruncationReason {
     ItemRevisits,
 }
 
+impl SymbolicTruncationReason {
+    /// The wire spelling, identical to what `Serialize` emits.
+    ///
+    /// The WASM boundary cannot hand a serde enum to JavaScript, so it needs a
+    /// plain string; having it here rather than a `match` in wasm-bindings keeps
+    /// one vocabulary for both surfaces. `the_wire_spellings_match_serde` pins
+    /// them together, because two hand-kept lists is how they drift.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::ElementCount => "element-count",
+            Self::OutputBytes => "output-bytes",
+            Self::ItemDepth => "item-depth",
+            Self::ItemRevisits => "item-revisits",
+        }
+    }
+}
+
 /// What stopped an extraction early, when something did.
 ///
 /// Present only on a truncated result.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SymbolicTruncation {
-    /// The FIRST bound that fired. Later ones are the same event continuing.
+    /// The MOST SEVERE bound that fired, not the first: an extraction bound
+    /// outranks a per-item one whatever the scan order. See
+    /// `SymbolicAccumulator::record`.
     pub reason: SymbolicTruncationReason,
     /// Primitives emitted in total. NOT necessarily equal to any limit: a
     /// per-item bound stops one item's contribution while the file-level
@@ -122,6 +141,11 @@ pub struct SymbolicTruncation {
     /// The bound's value, when the reason has a single numeric one. `None` for
     /// per-item reasons, whose bound is per item and not comparable with
     /// `emitted`.
+    ///
+    /// Skipped rather than serialized as `null`: the TypeScript mirror declares
+    /// `limit?: number`, which means the key is ABSENT. Emitting `null` satisfies
+    /// Rust and breaks the consumer's `'limit' in truncated` check.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<usize>,
 }
 
@@ -154,7 +178,7 @@ pub(super) struct SymbolicAccumulator {
     bytes: usize,
     /// Byte bound for this extraction, injectable alongside `limit`.
     byte_limit: usize,
-    /// The first bound that fired, if any. Later ones are the same event.
+    /// The most severe bound that fired, if any. See [`SymbolicAccumulator::record`].
     reason: Option<SymbolicTruncationReason>,
     /// Set only by the EXTRACTION bounds, never by a per-item one.
     ///
@@ -271,12 +295,17 @@ impl SymbolicAccumulator {
         self.bytes += PRIMITIVE_OVERHEAD_BYTES + payload * BYTES_PER_COORD;
     }
 
-    /// Append a grid axis unless the extraction has hit its cap.
-    pub(super) fn push_grid_axis(&mut self, axis: SymbolicGridAxis) {
-        // `tag` comes from the file. Grid extraction is top-level and
-        // file-bounded so it has no fan-out amplifier, but an uncharged
-        // heap field is the same class of hole as `alignment` was.
-        let payload = axis.tag.len();
+    /// The one place an append is accepted or refused.
+    ///
+    /// Every `push_*` differs only in its payload charge and its target vector;
+    /// the decision (does this fit, which bound did it break, mark exhausted) is
+    /// identical. Keeping it in five copies is how `push_text` came to omit
+    /// `alignment` from its payload and under-count the byte bound by 13.5x, so
+    /// a sixth primitive must not have to re-derive the block to get it right.
+    fn try_push<F>(&mut self, payload: usize, push: F)
+    where
+        F: FnOnce(&mut SymbolicData),
+    {
         if let Some(reason) = self.exceeded_by(payload) {
             self.record(reason);
             self.exhausted = true;
@@ -286,8 +315,17 @@ impl SymbolicAccumulator {
             }
         } else {
             self.charge(payload);
-            self.data.grid_axes.push(axis);
+            push(&mut self.data);
         }
+    }
+
+    /// Append a grid axis unless the extraction has hit its cap.
+    pub(super) fn push_grid_axis(&mut self, axis: SymbolicGridAxis) {
+        // `tag` comes from the file. Grid extraction is top-level and
+        // file-bounded so it has no fan-out amplifier, but an uncharged
+        // heap field is the same class of hole as `alignment` was.
+        let payload = axis.tag.len();
+        self.try_push(payload, |data| data.grid_axes.push(axis));
     }
 
     /// Append a polyline unless the extraction has hit its cap.
@@ -295,33 +333,13 @@ impl SymbolicAccumulator {
         let payload = polyline.points.len()
             + polyline.ifc_type.len()
             + polyline.representation.len();
-        if let Some(reason) = self.exceeded_by(payload) {
-            self.record(reason);
-            self.exhausted = true;
-            #[cfg(test)]
-            {
-                self.refusals += 1;
-            }
-        } else {
-            self.charge(payload);
-            self.data.polylines.push(polyline);
-        }
+        self.try_push(payload, |data| data.polylines.push(polyline));
     }
 
     /// Append a circle unless the extraction has hit its cap.
     pub(super) fn push_circle(&mut self, circle: SymbolicCircle) {
         let payload = 8 + circle.ifc_type.len() + circle.representation.len();
-        if let Some(reason) = self.exceeded_by(payload) {
-            self.record(reason);
-            self.exhausted = true;
-            #[cfg(test)]
-            {
-                self.refusals += 1;
-            }
-        } else {
-            self.charge(payload);
-            self.data.circles.push(circle);
-        }
+        self.try_push(payload, |data| data.circles.push(circle));
     }
 
     /// Append a text annotation unless the extraction has hit its cap.
@@ -336,17 +354,7 @@ impl SymbolicAccumulator {
             + text.alignment.len()
             + text.ifc_type.len()
             + text.representation.len();
-        if let Some(reason) = self.exceeded_by(payload) {
-            self.record(reason);
-            self.exhausted = true;
-            #[cfg(test)]
-            {
-                self.refusals += 1;
-            }
-        } else {
-            self.charge(payload);
-            self.data.texts.push(text);
-        }
+        self.try_push(payload, |data| data.texts.push(text));
     }
 
     /// Append a filled region unless the extraction has hit its cap.
@@ -355,17 +363,7 @@ impl SymbolicAccumulator {
             + fill.holes_offsets.len()
             + fill.ifc_type.len()
             + fill.representation.len();
-        if let Some(reason) = self.exceeded_by(payload) {
-            self.record(reason);
-            self.exhausted = true;
-            #[cfg(test)]
-            {
-                self.refusals += 1;
-            }
-        } else {
-            self.charge(payload);
-            self.data.fills.push(fill);
-        }
+        self.try_push(payload, |data| data.fills.push(fill));
     }
 
     /// Finish, stamping the diagnostics field iff an append was ever refused.

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -1,0 +1,380 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The extraction-level output bound for `SymbolicData` (#2937, #2938).
+//!
+//! Split out of `primitives.rs` for the same reason `item_walk.rs` is split
+//! out of `items.rs`: that file is the WIRE SHAPE of the symbolic stream, and
+//! this is the policy deciding how much of it one extraction may produce. A
+//! reader auditing the bound should not have to read five primitive structs
+//! to find it, and a reader adding a primitive should not have to step around
+//! the bound.
+
+use super::primitives::{
+    SymbolicCircle, SymbolicData, SymbolicFillArea, SymbolicGridAxis, SymbolicPolyline,
+    SymbolicText,
+};
+use serde::{Deserialize, Serialize};
+
+/// Upper bound on the total number of symbolic primitives one extraction may
+/// emit, across every product in the file.
+///
+/// The per-item recursion bounds in `item_walk.rs` bound ONE top-level
+/// representation item. `extract_symbolic_data` calls the walk once per item of
+/// every Plan/Annotation/FootPrint/Axis representation of every product and
+/// accumulates into one `SymbolicData`, so the file-level total was
+/// `items x per-item bound` and nothing bounded the extraction (#2937).
+/// Measured on a crafted acyclic DAG: 20,002,500 polylines and **2.74 GB RSS from a 1.13 MB upload**, linear in file size, on a path the HTTP server calls
+/// with raw uploaded bytes (`apps/server/src/services/streaming.rs`).
+///
+/// Sized to sit well above real drawings rather than close to them. A flat
+/// `IfcGeometricCurveSet` of 200,050 curves is legitimate (plan hatching, a
+/// survey drawing, an imported DWG), and a nested block import reaching
+/// 500,000 is too, so this leaves roughly 4x headroom over the largest known
+/// legitimate case while still refusing the 20M one. Hitting it is reported,
+/// never silent -- see [`SymbolicData::truncated`].
+pub const MAX_SYMBOLIC_ELEMENTS: usize = 2_000_000;
+
+/// Upper bound on the estimated heap footprint of one extraction's output.
+///
+/// [`MAX_SYMBOLIC_ELEMENTS`] alone is NOT a memory bound, because per-primitive
+/// size is attacker-controlled: `SymbolicPolyline.points` and
+/// `SymbolicText.content` have no length limit anywhere in the extractor, and
+/// the fan-out attack re-emits ONE leaf up to the cap, cloning its point vector
+/// every time. So the leaf is paid for once in the file and two million times
+/// in RAM. Measured against a count-only cap, leaf point count the only knob:
+///
+///   leaf pts   fixture     emitted      peak RSS
+///          2   0.15 MB   2,000,000        278 MB
+///        512   1.07 MB   2,000,000       8.47 GB
+///       1024   2.03 MB   2,000,000      16.70 GB
+///
+/// Linear, and six times worse than the 2.74 GB the count cap was written to
+/// fix. A count cap tuned on a 2-point fixture measures the fixture, not the
+/// bound.
+///
+/// Every append charges its own estimated footprint, so a file of few enormous
+/// primitives and a file of many tiny ones are stopped at the same number of
+/// BYTES -- but only for fields the charge actually includes, which is why
+/// every variable-length field must be in the payload and not just the obvious
+/// one.
+///
+/// Headroom, stated honestly rather than as "far above any real drawing": 256
+/// MiB is ~33.5M charged payload units. The largest cited legitimate cases
+/// (200,050 curves; ~500,000 simple polylines, roughly 40 MB) clear it by ~6x.
+/// A DENSE vector import does not have that margin -- 100k contour polylines at
+/// 2,000 points each is ~200M coordinates and WOULD be truncated. That is a
+/// real drawing, and the honest position is that it degrades visibly (the
+/// result says so) rather than silently, which is the difference this change is
+/// about. Raise the constant if such a file turns up; do not assume it cannot.
+pub const MAX_SYMBOLIC_BYTES: usize = 256 * 1024 * 1024;
+
+/// Heap footprint charged for one emitted primitive.
+///
+/// Deliberately an ESTIMATE, and deliberately an over-estimate of the
+/// per-primitive constant: `Vec`/`String` headers, capacity slack and allocator
+/// rounding are real and a bound that ignores them is not a bound. Calibrated
+/// against the measurements above, which work out at roughly 64 bytes of
+/// fixed overhead plus 8 bytes per coordinate once allocator behaviour is
+/// included.
+const PRIMITIVE_OVERHEAD_BYTES: usize = 64;
+/// Charged per `f32` coordinate or per byte of text.
+const BYTES_PER_COORD: usize = 8;
+
+
+/// Which bound stopped an extraction early.
+///
+/// `SymbolicData` had no diagnostics channel at all (#2938), so a drawing that
+/// lost 60% of its curves was indistinguishable, in the response, from one that
+/// legitimately had nothing more to emit.
+///
+/// The reason matters as much as the fact. #2938's own lead case is a
+/// well-formed nested block import losing content to the PER-ITEM revisit
+/// budget while the whole-file totals sit far below the extraction bounds --
+/// so a diagnostic that only reported the extraction bounds would have reported
+/// nothing on the exact scenario the issue is about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SymbolicTruncationReason {
+    /// [`MAX_SYMBOLIC_ELEMENTS`] reached.
+    ElementCount,
+    /// [`MAX_SYMBOLIC_BYTES`] reached.
+    OutputBytes,
+    /// One representation item nested deeper than the walk follows.
+    ItemDepth,
+    /// One representation item exhausted its revisit budget: the item was a
+    /// large acyclic fan-out, or a legitimate deeply-nested block import.
+    ItemRevisits,
+}
+
+/// What stopped an extraction early, when something did.
+///
+/// Present only on a truncated result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolicTruncation {
+    /// The FIRST bound that fired. Later ones are the same event continuing.
+    pub reason: SymbolicTruncationReason,
+    /// Primitives emitted in total. NOT necessarily equal to any limit: a
+    /// per-item bound stops one item's contribution while the file-level
+    /// totals stay far below the extraction bounds.
+    pub emitted: usize,
+    /// The bound's value, when the reason has a single numeric one. `None` for
+    /// per-item reasons, whose bound is per item and not comparable with
+    /// `emitted`.
+    pub limit: Option<usize>,
+}
+
+
+
+/// The extraction's accumulator: a `SymbolicData` under construction, plus the
+/// bound it is being built under.
+///
+/// The bound lives HERE and not on `SymbolicData` because `SymbolicData` is the
+/// wire type -- it is serialized into the response and into the on-disk parse
+/// cache. A policy knob on it would have to be `#[serde(skip)]` with a
+/// hand-written `Default` to stop `SymbolicData::default()` truncating on its
+/// first append, and every struct literal in the repo would break on the
+/// private field. None of that buys anything: the cap is a property of the
+/// EXTRACTION, and this is where extraction state belongs.
+///
+/// It also makes the seam real rather than conventional. During extraction the
+/// vectors are reachable only through `push_*`, because the emitters hold an
+/// accumulator and not a `SymbolicData`; the `pub` fields on the wire type are
+/// then harmless, since nothing is emitting through them.
+pub(super) struct SymbolicAccumulator {
+    data: SymbolicData,
+    /// Cap for this extraction. Injectable so a test can use 500 rather than
+    /// building a fixture that emits two million primitives.
+    limit: usize,
+    /// Refused appends, counted for tests. See [`Self::refusals`].
+    #[cfg(test)]
+    refusals: usize,
+    /// Estimated heap footprint charged so far. See [`MAX_SYMBOLIC_BYTES`].
+    bytes: usize,
+    /// Byte bound for this extraction, injectable alongside `limit`.
+    byte_limit: usize,
+    /// The first bound that fired, if any. Later ones are the same event.
+    reason: Option<SymbolicTruncationReason>,
+    /// Set only by the EXTRACTION bounds, never by a per-item one.
+    ///
+    /// These are two different questions and conflating them is a bug: "was
+    /// content dropped anywhere" is what the caller must be told, while "must
+    /// I stop walking the rest of the file" is true only when the accumulator
+    /// itself is full. A deep or fan-heavy single item drops its own content
+    /// and must NOT abandon every remaining product.
+    exhausted: bool,
+}
+
+impl SymbolicAccumulator {
+    /// Accumulator under the shipped cap.
+    pub(super) fn new() -> Self {
+        Self {
+            data: SymbolicData::default(),
+            limit: MAX_SYMBOLIC_ELEMENTS,
+            bytes: 0,
+            byte_limit: MAX_SYMBOLIC_BYTES,
+            reason: None,
+            exhausted: false,
+            #[cfg(test)]
+            refusals: 0,
+        }
+    }
+
+    /// Accumulator under caller-chosen bounds. Both are injectable so a test
+    /// can exercise either bound without building a fixture that reaches the
+    /// shipped ones.
+    #[cfg(test)]
+    pub(super) fn with_limits(limit: usize, byte_limit: usize) -> Self {
+        Self { limit, byte_limit, ..Self::new() }
+    }
+
+    /// Accumulator under a caller-chosen count cap and the shipped byte cap.
+    #[cfg(test)]
+    pub(super) fn with_limit(limit: usize) -> Self {
+        Self { limit, ..Self::new() }
+    }
+
+    /// Is the accumulator itself full? The walk and the product scan read THIS
+    /// to stop early. A per-item bound marks the result truncated WITHOUT setting
+    /// this, so one deep item does not abandon every later product.
+    pub(super) fn is_exhausted(&self) -> bool {
+        self.exhausted
+    }
+
+    /// Record that a per-item bound dropped content. Called by the walk, which
+    /// is the only place that knows a bound fired -- refusing to append is not
+    /// the same event and would report the wrong reason.
+    pub(super) fn note_item_bound(&mut self, reason: SymbolicTruncationReason) {
+        self.record(reason);
+    }
+
+    /// Keep the MOST SEVERE reason, not the first.
+    ///
+    /// First-wins is right within a bound class -- the second refusal at the
+    /// same cap is the same event continuing -- and wrong ACROSS classes. A
+    /// per-item bound firing on the first product is ordinary; the whole-output
+    /// cap firing later is the DoS-scale event, and scan order is
+    /// attacker-controlled. First-wins therefore let a file that blew the
+    /// 2,000,000-element ceiling report the mild `item-revisits` instead, with
+    /// its numeric limit dropped, purely because an unrelated item truncated
+    /// earlier in the file.
+    fn record(&mut self, reason: SymbolicTruncationReason) {
+        let severity = |r: SymbolicTruncationReason| match r {
+            SymbolicTruncationReason::ElementCount | SymbolicTruncationReason::OutputBytes => 1,
+            SymbolicTruncationReason::ItemDepth | SymbolicTruncationReason::ItemRevisits => 0,
+        };
+        match self.reason {
+            Some(existing) if severity(existing) >= severity(reason) => {}
+            _ => self.reason = Some(reason),
+        }
+    }
+
+    /// Refused appends since the last reset, for tests only.
+    ///
+    /// Exists so the early exits can be pinned deterministically. They bound
+    /// WORK, and work is invisible in the output -- a refused append leaves the
+    /// result byte-identical -- but it is visible HERE, and the accumulator is
+    /// already test-injectable. Claiming this was unpinnable was wrong.
+    #[cfg(test)]
+    pub(super) fn refusals(&self) -> usize {
+        self.refusals
+    }
+
+    /// Total primitives emitted so far, across every collection.
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Would appending a primitive of `payload` units exceed either bound?
+    ///
+    /// Two bounds, and the honest reason is NOT symmetry. Bytes alone would do
+    /// as a memory bound: every append charges at least
+    /// `PRIMITIVE_OVERHEAD_BYTES`, so 256 MiB caps a tiny-primitive flood at
+    /// ~4.2M anyway. The count bound earns its place differently -- its
+    /// constant is sized on drawing semantics (4x the largest legitimate case)
+    /// and it bounds the per-primitive costs downstream of this crate that a
+    /// byte estimate does not govern: JSON serialization, cache writes, and
+    /// client-side render setup are per-ELEMENT, not per-byte.
+    fn exceeded_by(&self, payload: usize) -> Option<SymbolicTruncationReason> {
+        if self.len() >= self.limit {
+            return Some(SymbolicTruncationReason::ElementCount);
+        }
+        if self.bytes + PRIMITIVE_OVERHEAD_BYTES + payload * BYTES_PER_COORD > self.byte_limit {
+            return Some(SymbolicTruncationReason::OutputBytes);
+        }
+        None
+    }
+
+    /// Charge an accepted append against the byte budget.
+    fn charge(&mut self, payload: usize) {
+        self.bytes += PRIMITIVE_OVERHEAD_BYTES + payload * BYTES_PER_COORD;
+    }
+
+    /// Append a grid axis unless the extraction has hit its cap.
+    pub(super) fn push_grid_axis(&mut self, axis: SymbolicGridAxis) {
+        // `tag` comes from the file. Grid extraction is top-level and
+        // file-bounded so it has no fan-out amplifier, but an uncharged
+        // heap field is the same class of hole as `alignment` was.
+        let payload = axis.tag.len();
+        if let Some(reason) = self.exceeded_by(payload) {
+            self.record(reason);
+            self.exhausted = true;
+            #[cfg(test)]
+            {
+                self.refusals += 1;
+            }
+        } else {
+            self.charge(payload);
+            self.data.grid_axes.push(axis);
+        }
+    }
+
+    /// Append a polyline unless the extraction has hit its cap.
+    pub(super) fn push_polyline(&mut self, polyline: SymbolicPolyline) {
+        let payload = polyline.points.len();
+        if let Some(reason) = self.exceeded_by(payload) {
+            self.record(reason);
+            self.exhausted = true;
+            #[cfg(test)]
+            {
+                self.refusals += 1;
+            }
+        } else {
+            self.charge(payload);
+            self.data.polylines.push(polyline);
+        }
+    }
+
+    /// Append a circle unless the extraction has hit its cap.
+    pub(super) fn push_circle(&mut self, circle: SymbolicCircle) {
+        let payload = 8;
+        if let Some(reason) = self.exceeded_by(payload) {
+            self.record(reason);
+            self.exhausted = true;
+            #[cfg(test)]
+            {
+                self.refusals += 1;
+            }
+        } else {
+            self.charge(payload);
+            self.data.circles.push(circle);
+        }
+    }
+
+    /// Append a text annotation unless the extraction has hit its cap.
+    pub(super) fn push_text(&mut self, text: SymbolicText) {
+        // alignment is read straight from IfcTextLiteralWithExtent's
+        // BoxAlignment attribute with no length bound, and text literals are
+        // dispatched INSIDE the fan-out walk, so it is cloned on every
+        // emission. Omitting it made the byte bound a 13.5x under-count:
+        // 800,100 texts charged 54.9 MB while the process held 3.45 GB and
+        // `truncated` stayed None.
+        let payload = text.content.len() + text.alignment.len();
+        if let Some(reason) = self.exceeded_by(payload) {
+            self.record(reason);
+            self.exhausted = true;
+            #[cfg(test)]
+            {
+                self.refusals += 1;
+            }
+        } else {
+            self.charge(payload);
+            self.data.texts.push(text);
+        }
+    }
+
+    /// Append a filled region unless the extraction has hit its cap.
+    pub(super) fn push_fill(&mut self, fill: SymbolicFillArea) {
+        let payload = fill.points.len() + fill.holes_offsets.len();
+        if let Some(reason) = self.exceeded_by(payload) {
+            self.record(reason);
+            self.exhausted = true;
+            #[cfg(test)]
+            {
+                self.refusals += 1;
+            }
+        } else {
+            self.charge(payload);
+            self.data.fills.push(fill);
+        }
+    }
+
+    /// Finish, stamping the diagnostics field iff an append was ever refused.
+    pub(super) fn into_data(mut self) -> SymbolicData {
+        if let Some(reason) = self.reason {
+            let emitted = self.data.len();
+            let limit = match reason {
+                SymbolicTruncationReason::ElementCount => Some(self.limit),
+                SymbolicTruncationReason::OutputBytes => Some(self.byte_limit),
+                // Per-item bounds are per ITEM; reporting one next to a
+                // file-level `emitted` would invite the reader to compare two
+                // numbers that are not comparable.
+                SymbolicTruncationReason::ItemDepth
+                | SymbolicTruncationReason::ItemRevisits => None,
+            };
+            self.data.truncated = Some(SymbolicTruncation { reason, emitted, limit });
+        }
+        self.data
+    }
+}

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -292,7 +292,9 @@ impl SymbolicAccumulator {
 
     /// Append a polyline unless the extraction has hit its cap.
     pub(super) fn push_polyline(&mut self, polyline: SymbolicPolyline) {
-        let payload = polyline.points.len();
+        let payload = polyline.points.len()
+            + polyline.ifc_type.len()
+            + polyline.representation.len();
         if let Some(reason) = self.exceeded_by(payload) {
             self.record(reason);
             self.exhausted = true;
@@ -308,7 +310,7 @@ impl SymbolicAccumulator {
 
     /// Append a circle unless the extraction has hit its cap.
     pub(super) fn push_circle(&mut self, circle: SymbolicCircle) {
-        let payload = 8;
+        let payload = 8 + circle.ifc_type.len() + circle.representation.len();
         if let Some(reason) = self.exceeded_by(payload) {
             self.record(reason);
             self.exhausted = true;
@@ -330,7 +332,10 @@ impl SymbolicAccumulator {
         // emission. Omitting it made the byte bound a 13.5x under-count:
         // 800,100 texts charged 54.9 MB while the process held 3.45 GB and
         // `truncated` stayed None.
-        let payload = text.content.len() + text.alignment.len();
+        let payload = text.content.len()
+            + text.alignment.len()
+            + text.ifc_type.len()
+            + text.representation.len();
         if let Some(reason) = self.exceeded_by(payload) {
             self.record(reason);
             self.exhausted = true;
@@ -346,7 +351,10 @@ impl SymbolicAccumulator {
 
     /// Append a filled region unless the extraction has hit its cap.
     pub(super) fn push_fill(&mut self, fill: SymbolicFillArea) {
-        let payload = fill.points.len() + fill.holes_offsets.len();
+        let payload = fill.points.len()
+            + fill.holes_offsets.len()
+            + fill.ifc_type.len()
+            + fill.representation.len();
         if let Some(reason) = self.exceeded_by(payload) {
             self.record(reason);
             self.exhausted = true;

--- a/rust/processing/src/symbolic/output_cap_tests.rs
+++ b/rust/processing/src/symbolic/output_cap_tests.rs
@@ -1,0 +1,483 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The extraction-level output cap and its diagnostics (#2937, #2938).
+//!
+//! `item_walk.rs` bounds ONE top-level representation item.
+//! `extract_symbolic_data` calls that walk once per item of every
+//! Plan/Annotation/FootPrint/Axis representation of every product and
+//! accumulates into a single `SymbolicData`, so before this the file-level
+//! total was `items x per-item bound` and nothing bounded the extraction:
+//! 20,002,500 polylines and 2.74 GB RSS from a 1.13 MB upload, on a path the
+//! HTTP server calls with raw uploaded bytes.
+//!
+//! EVERY test below was verified to FAIL against the production behaviour it
+//! names, by running the mutation rather than reasoning about it. That check
+//! found two tests that could not fail:
+//!
+//!   - the "every variable-length field is charged" test used a 2-byte content
+//!     with a 4 KB alignment, so dropping the CONTENT charge changed nothing
+//!     and it stayed green while claiming to pin both;
+//!   - the "does not abandon the file" test asserted `len() > 1`, which passes
+//!     even when a per-item bound wrongly sets exhaustion and abandons every
+//!     later product.
+//!
+//! Both are now built to discriminate. This is the fourth and fifth time in
+//! this change that a fixture written to prove a fix shared the fix's
+//! assumption, so the mutation run is not optional here.
+//!
+//! RESIDUAL, measured and not fixed here: the bounds are on OUTPUT, so they
+//! bound work only insofar as work produces output. A fan-out whose leaf is an
+//! item type the extractor does not handle traverses fully and emits nothing,
+//! so neither bound ever fires:
+//!
+//!   179 KB -> 426 ms, 0 emitted      739 KB -> 1661 ms, 0 emitted
+//!   3.0 MB -> 7216 ms, 0 emitted
+//!
+//! Linear at ~2.4 ms/KB. Not a regression -- `main` behaves identically, and
+//! it is #2937's original per-item-budget complaint in the shape where output
+//! capping cannot reach it. Closing it means hoisting the revisit budget from
+//! per-item to per-extraction, which is now safe BECAUSE truncation is
+//! reported, but changes truncation behaviour for legitimate multi-product
+//! files and wants its own change.
+//!
+//! The two issues pulled in opposite directions -- bounding total work made
+//! the silent truncation fire sooner, on smaller legitimate drawings -- so
+//! they are fixed by one instrument: a cap on the OUTPUT, plus a diagnostics
+//! field that says the cap was hit. Both halves are pinned here.
+//!
+use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
+use super::primitives::SymbolicData;
+
+/// N annotations, each carrying one 24-level fan-out DAG. No cycle, so no path
+/// guard fires; the leaf is reachable down 2^24 paths and only a work bound
+/// stops it. This is the shape that measured 2.73 GB.
+fn hostile_dag(annotations: usize) -> String {
+    hostile_dag_with_leaf(annotations, 2)
+}
+
+/// Same shape, with a caller-chosen number of points in the single leaf
+/// polyline. That leaf is re-emitted up to the cap, so its size multiplies.
+fn hostile_dag_with_leaf(annotations: usize, leaf_points: usize) -> String {
+    let mut s = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
+    let mut id = 1000u32;
+    let mut tops = Vec::new();
+    for _ in 0..annotations {
+        let mut next = 0u32;
+        for level in 0..24 {
+            let rm = id;
+            id += 1;
+            let r = id;
+            id += 1;
+            if level == 0 {
+                let pl = id;
+                id += 1;
+                let p1 = id;
+                id += 1;
+                let p2 = id;
+                id += 1;
+                s.push_str(&format!("#{r}=IFCSHAPEREPRESENTATION($,$,$,(#{pl}));\n"));
+                let pts: Vec<u32> = (0..leaf_points.max(2))
+                    .map(|_| {
+                        let q = id;
+                        id += 1;
+                        q
+                    })
+                    .collect();
+                let refs = pts.iter().map(|q| format!("#{q}")).collect::<Vec<_>>().join(",");
+                s.push_str(&format!("#{pl}=IFCPOLYLINE(({refs}));\n"));
+                for (k, q) in pts.iter().enumerate() {
+                    s.push_str(&format!("#{q}=IFCCARTESIANPOINT(({k}.,{k}.));\n"));
+                }
+                let _ = (p1, p2);
+            } else {
+                let a = id;
+                id += 1;
+                let b = id;
+                id += 1;
+                s.push_str(&format!("#{r}=IFCSHAPEREPRESENTATION($,$,$,(#{a},#{b}));\n"));
+                s.push_str(&format!("#{a}=IFCMAPPEDITEM(#{next},$);\n"));
+                s.push_str(&format!("#{b}=IFCMAPPEDITEM(#{next},$);\n"));
+            }
+            s.push_str(&format!("#{rm}=IFCREPRESENTATIONMAP($,#{r});\n"));
+            next = rm;
+        }
+        let top = id;
+        id += 1;
+        s.push_str(&format!("#{top}=IFCMAPPEDITEM(#{next},$);\n"));
+        tops.push(top);
+    }
+    let list = tops.iter().map(|t| format!("#{t}")).collect::<Vec<_>>().join(",");
+    let prod = id;
+    let shp = id + 1;
+    let rep = id + 2;
+    s.push_str(&format!(
+        "#{prod}=IFCANNOTATION('x',$,$,$,$,$,#{shp});\n\
+         #{shp}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{rep}));\n\
+         #{rep}=IFCSHAPEREPRESENTATION($,'Annotation','Annotation',({list}));\n"
+    ));
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+#[test]
+fn a_hostile_file_is_bounded_and_says_so() {
+    // Cap injected at 500 rather than 2,000,000: the mechanism is identical and
+    // the fixture stays small. One annotation of this shape emits ~66,675
+    // primitives uncapped, so 500 is comfortably exceeded.
+    let mut out = SymbolicAccumulator::with_limit(500);
+    super::extract_symbolic_data_into(&hostile_dag(2).into_bytes(), &mut out);
+    let out = out.into_data();
+
+    assert_eq!(
+        out.len(),
+        500,
+        "the cap must bound the TOTAL across every collection, not each one"
+    );
+    let truncation = out
+        .truncated
+        .as_ref()
+        .expect("a truncated extraction must say so: silence here is #2938 verbatim");
+    assert_eq!(truncation.limit, Some(500));
+    assert_eq!(
+        truncation.reason,
+        SymbolicTruncationReason::ElementCount,
+        "the diagnostic must name WHICH bound fired, not merely that one did"
+    );
+    assert_eq!(
+        truncation.emitted, 500,
+        "`emitted` must be the count at the moment extraction stopped"
+    );
+}
+
+#[test]
+fn a_file_that_fits_is_not_marked_truncated() {
+    // The control. Without it the assertions above pass on an implementation
+    // that marks EVERY extraction truncated, which would make the diagnostic
+    // worthless in the direction that matters -- a consumer would show
+    // "results incomplete" on every drawing and learn to ignore it.
+    let mut out = SymbolicAccumulator::with_limit(500);
+    super::extract_symbolic_data_into(&hostile_dag(0).into_bytes(), &mut out);
+    let out = out.into_data();
+    assert!(
+        out.truncated.is_none(),
+        "an extraction that never reached the cap must not report truncation"
+    );
+    assert!(out.truncated.is_none());
+}
+
+#[test]
+fn truncation_survives_the_wire_and_absence_still_deserializes() {
+    // `apps/server/src/routes/parse/cache_keys.rs` reads cached JSON written
+    // before this field existed, so absence must deserialize; and an
+    // untruncated response must serialize exactly as it did before, or every
+    // cache key in flight changes.
+    let mut acc = SymbolicAccumulator::with_limit(1);
+    super::extract_symbolic_data_into(&hostile_dag(1).into_bytes(), &mut acc);
+    let truncated = acc.into_data();
+    assert!(truncated.truncated.is_some(), "fixture must actually truncate");
+
+    let json = serde_json::to_string(&truncated).expect("serializes");
+    let back: SymbolicData = serde_json::from_str(&json).expect("round-trips");
+    assert_eq!(back.truncated, truncated.truncated);
+
+    let clean = SymbolicData::default();
+    let clean_json = serde_json::to_string(&clean).expect("serializes");
+    assert!(
+        !clean_json.contains("truncated"),
+        "an untruncated result must not gain a field on the wire: {clean_json}"
+    );
+    let old_shape: SymbolicData =
+        serde_json::from_str(r#"{"grid_axes":[],"polylines":[],"circles":[],"texts":[],"fills":[]}"#)
+            .expect("JSON cached before this field existed must still deserialize");
+    assert!(old_shape.truncated.is_none());
+}
+
+#[test]
+fn a_few_enormous_primitives_are_bounded_too() {
+    // The attack a COUNT-only cap misses, and the reason this bound is in
+    // bytes. Per-primitive size is attacker-controlled -- neither
+    // `SymbolicPolyline.points` nor `SymbolicText.content` has a length limit
+    // anywhere in the extractor -- and the fan-out re-emits ONE leaf up to the
+    // cap, cloning its point vector every time. So the leaf is paid for once
+    // in the file and N times in RAM.
+    //
+    // Measured against a count-only cap of 2,000,000, leaf size the only knob:
+    //
+    //   leaf pts   fixture     emitted     peak RSS
+    //          2   0.15 MB   2,000,000       278 MB
+    //        512   1.07 MB   2,000,000      8.47 GB
+    //       1024   2.03 MB   2,000,000     16.70 GB
+    //
+    // Six times worse than the 2.74 GB the count cap was written to fix. A
+    // count cap tuned on a 2-point fixture measures the fixture, not the bound.
+    //
+    // Injected budgets keep this fast: 4 KiB of output with a 400-point leaf,
+    // so the COUNT bound (500) is nowhere near and only the BYTE bound can stop
+    // it. If the byte charge is ever removed, this test is what fails.
+    let mut acc = SymbolicAccumulator::with_limits(500, 4096);
+    super::extract_symbolic_data_into(&hostile_dag_with_leaf(2, 400).into_bytes(), &mut acc);
+    let out = acc.into_data();
+
+    assert!(
+        out.truncated.is_some(),
+        "a file of few but enormous primitives must still be bounded"
+    );
+    assert!(
+        out.len() < 500,
+        "the BYTE bound must bite before the count bound: emitted {} of a 500 count cap, \
+         so this stopped for the wrong reason and the byte charge is not working",
+        out.len()
+    );
+    let emitted_payload: usize = out.polylines.iter().map(|p| p.points.len()).sum();
+    assert!(
+        emitted_payload * 8 <= 4096 + 400 * 8,
+        "total emitted payload must respect the byte budget; got {emitted_payload} coords"
+    );
+}
+
+/// A fan-out whose leaf is a TEXT literal with a large `BoxAlignment`.
+///
+/// `alignment` is read from the file with no length bound and cloned on every
+/// emission. Charging only `content` made the byte bound a 13.5x under-count:
+/// 800,100 texts charged 54.9 MB while the process held 3.45 GB and
+/// `truncated` stayed None.
+fn hostile_text_dag(content_len: usize, alignment_len: usize) -> String {
+    let pad = "A".repeat(alignment_len);
+    let body = "B".repeat(content_len.max(2));
+    let mut s = String::from("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n");
+    let mut id = 1000u32;
+    let mut next = 0u32;
+    for level in 0..12 {
+        let rm = id;
+        id += 1;
+        let r = id;
+        id += 1;
+        if level == 0 {
+            let tl = id;
+            id += 1;
+            let pt = id;
+            id += 1;
+            s.push_str(&format!("#{r}=IFCSHAPEREPRESENTATION($,$,$,(#{tl}));\n"));
+            s.push_str(&format!(
+                "#{tl}=IFCTEXTLITERALWITHEXTENT('{body}',#{pt},.RIGHT.,$,'{pad}');\n"
+            ));
+            s.push_str(&format!("#{pt}=IFCAXIS2PLACEMENT2D(#{},$);\n", pt + 1));
+            s.push_str(&format!("#{}=IFCCARTESIANPOINT((0.,0.));\n", pt + 1));
+            id += 2;
+        } else {
+            let a = id;
+            id += 1;
+            let b = id;
+            id += 1;
+            s.push_str(&format!("#{r}=IFCSHAPEREPRESENTATION($,$,$,(#{a},#{b}));\n"));
+            s.push_str(&format!("#{a}=IFCMAPPEDITEM(#{next},$);\n"));
+            s.push_str(&format!("#{b}=IFCMAPPEDITEM(#{next},$);\n"));
+        }
+        s.push_str(&format!("#{rm}=IFCREPRESENTATIONMAP($,#{r});\n"));
+        next = rm;
+    }
+    let top = id;
+    id += 1;
+    s.push_str(&format!("#{top}=IFCMAPPEDITEM(#{next},$);\n"));
+    let prod = id;
+    let shp = id + 1;
+    let rep = id + 2;
+    s.push_str(&format!(
+        "#{prod}=IFCANNOTATION('x',$,$,$,$,$,#{shp});\n\
+         #{shp}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{rep}));\n\
+         #{rep}=IFCSHAPEREPRESENTATION($,'Annotation','Annotation',(#{top}));\n"
+    ));
+    s.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    s
+}
+
+#[test]
+fn every_variable_length_field_is_charged_not_just_the_obvious_one() {
+    // The blind spot that shipped past one review. The previous cap charged
+    // `points` for polylines and the test that "proved" the byte bound used a
+    // POLYLINE leaf -- so the oracle shared the fix's assumption, and a TEXT
+    // leaf with a huge `alignment` walked straight through a bound that
+    // reported itself as holding.
+    //
+    // Byte budget deliberately tiny and count budget huge, so ONLY the byte
+    // charge can stop this. If `alignment` stops being charged, the run blows
+    // past the byte budget and this fails.
+    // BOTH directions, because charging only one field still passes a fixture
+    // that only makes the other one large. An earlier version used a 2-byte
+    // content with a 4 KB alignment, so dropping the `content` charge changed
+    // nothing and the test stayed green while claiming to pin "every"
+    // variable-length field.
+    for (content_len, alignment_len, which) in
+        [(2usize, 4096usize, "alignment"), (4096, 2, "content")]
+    {
+        let mut acc = SymbolicAccumulator::with_limits(100_000, 8192);
+        super::extract_symbolic_data_into(
+            &hostile_text_dag(content_len, alignment_len).into_bytes(),
+            &mut acc,
+        );
+        let out = acc.into_data();
+
+        let truncation = out
+            .truncated
+            .as_ref()
+            .unwrap_or_else(|| panic!("a {which}-heavy fan-out must be bounded and reported"));
+        assert_eq!(
+            truncation.reason,
+            SymbolicTruncationReason::OutputBytes,
+            "the BYTE bound must fire for a {which}-heavy file; ElementCount here \
+             means {which} bytes are going uncharged"
+        );
+        let charged: usize =
+            out.texts.iter().map(|t| t.content.len() + t.alignment.len()).sum();
+        assert!(
+            charged * 8 <= 8192 + 4096 * 8,
+            "{which}-heavy payload must respect the byte budget; got {charged}"
+        );
+    }
+}
+
+#[test]
+fn a_per_item_bound_reports_its_own_reason_and_does_not_abandon_the_file() {
+    // #2938's LEAD case in miniature: content lost to a PER-ITEM bound while
+    // the file-level totals sit far below the extraction bounds. Reporting
+    // only the extraction bounds would say nothing here, which is exactly the
+    // silence the issue is about.
+    //
+    // Also pins the separation that a first attempt got wrong: a per-item
+    // bound marks the result truncated but must NOT set exhaustion, or one
+    // deep item abandons every remaining product in the file.
+    let mut acc = SymbolicAccumulator::with_limits(10_000_000, 64 * 1024 * 1024);
+    super::extract_symbolic_data_into(&hostile_dag(2).into_bytes(), &mut acc);
+    let out = acc.into_data();
+
+    let truncation = out
+        .truncated
+        .as_ref()
+        .expect("a per-item bound drops content and must say so");
+    assert_eq!(truncation.reason, SymbolicTruncationReason::ItemRevisits);
+    assert_eq!(
+        truncation.limit, None,
+        "a per-item bound has no file-level limit to compare `emitted` against"
+    );
+    // One product of this fixture emits exactly 66,675 primitives (measured),
+    // so exceeding that is what proves the SECOND product was reached. The
+    // previous assertion was `> 1`, which passes even when a per-item bound
+    // wrongly sets exhaustion and abandons everything after the first item --
+    // it could not fail in the direction it was pointed.
+    assert!(
+        out.len() > 66_675,
+        "the rest of the file must still be extracted: a per-item bound is not \
+         exhaustion, and treating it as such abandons every later product. \
+         Got {} primitives, which is one product's worth or less",
+        out.len()
+    );
+}
+
+#[test]
+fn the_early_exits_stop_the_walk_and_not_only_the_appends() {
+    // The gap an earlier version of this file RECORDED as unpinnable, wrongly.
+    // The early exits bound WORK, and work is invisible in the output -- a
+    // refused append leaves the result byte-identical -- so the claim was that
+    // only timing could observe them, and timing would be flaky.
+    //
+    // It is observable, deterministically, one level in: refused appends. With
+    // the exits, the walk stops as soon as the accumulator is full and refusals
+    // stay small. Without them it keeps traversing and every would-be append is
+    // refused, so the count explodes. The accumulator was already
+    // test-injectable; the observable was there all along.
+    let mut acc = SymbolicAccumulator::with_limits(500, 64 * 1024 * 1024);
+    super::extract_symbolic_data_into(&hostile_dag(2).into_bytes(), &mut acc);
+    let refusals = acc.refusals();
+
+    assert!(acc.is_exhausted(), "fixture must reach the cap");
+    assert!(
+        refusals < 5_000,
+        "the walk must STOP once the accumulator is full, not keep traversing \
+         and discarding: {refusals} refused appends means the early exits are \
+         gone and the work is unbounded again"
+    );
+}
+
+/// A mapped-item chain deeper than `MAX_ITEM_DEPTH`, emitting almost nothing.
+/// Cheap way to make a per-item bound fire FIRST in scan order.
+fn deep_chain_then(rest: &str, start: u32) -> String {
+    let mut s = String::new();
+    let mut id = start;
+    let mut next = 0u32;
+    for level in 0..40 {
+        let rm = id;
+        id += 1;
+        let r = id;
+        id += 1;
+        if level == 0 {
+            let pl = id;
+            id += 1;
+            s.push_str(&format!("#{r}=IFCSHAPEREPRESENTATION($,$,$,(#{pl}));\n"));
+            s.push_str(&format!("#{pl}=IFCPOLYLINE((#{},#{}));\n", pl + 1, pl + 2));
+            s.push_str(&format!("#{}=IFCCARTESIANPOINT((0.,0.));\n", pl + 1));
+            s.push_str(&format!("#{}=IFCCARTESIANPOINT((1.,1.));\n", pl + 2));
+            id += 2;
+        } else {
+            let a = id;
+            id += 1;
+            s.push_str(&format!("#{r}=IFCSHAPEREPRESENTATION($,$,$,(#{a}));\n"));
+            s.push_str(&format!("#{a}=IFCMAPPEDITEM(#{next},$);\n"));
+        }
+        s.push_str(&format!("#{rm}=IFCREPRESENTATIONMAP($,#{r});\n"));
+        next = rm;
+    }
+    let top = id;
+    id += 1;
+    s.push_str(&format!("#{top}=IFCMAPPEDITEM(#{next},$);\n"));
+    let prod = id;
+    s.push_str(&format!(
+        "#{prod}=IFCANNOTATION('deep',$,$,$,$,$,#{});\n\
+         #{}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{}));\n\
+         #{}=IFCSHAPEREPRESENTATION($,'Annotation','Annotation',(#{top}));\n",
+        prod + 1, prod + 1, prod + 2, prod + 2
+    ));
+    format!("{s}{rest}")
+}
+
+#[test]
+fn an_extraction_bound_outranks_a_per_item_one_whatever_the_scan_order() {
+    // The collision the sibling test is scoped to avoid, and which first-wins
+    // got wrong. A per-item bound fires on an early product; the whole-output
+    // cap fires later. Scan order is attacker-controlled, so first-wins let a
+    // file that blew the DoS-scale ceiling report the mild `item-revisits`
+    // with its numeric limit dropped.
+    //
+    // Bounds chosen so BOTH fire: the fan-out exhausts a per-item revisit
+    // budget early, and 200 elements is low enough that the extraction cap
+    // follows.
+    // The deep chain (per-item ItemDepth) is scanned BEFORE the fan-out that
+    // blows the element cap, so first-wins records the milder reason.
+    let dag = hostile_dag(2);
+    let body = dag
+        .strip_prefix("ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n")
+        .expect("fixture prefix");
+    let file = format!(
+        "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n{}",
+        deep_chain_then(body, 500_000)
+    );
+    let mut acc = SymbolicAccumulator::with_limits(200, 64 * 1024 * 1024);
+    super::extract_symbolic_data_into(&file.into_bytes(), &mut acc);
+    let out = acc.into_data();
+
+    let truncation = out.truncated.as_ref().expect("must be truncated");
+    assert_eq!(
+        truncation.reason,
+        SymbolicTruncationReason::ElementCount,
+        "the whole-output cap must outrank a per-item bound that happened to \
+         fire earlier in scan order; reporting the milder reason understates \
+         the most severe truncation there is"
+    );
+    assert_eq!(
+        truncation.limit,
+        Some(200),
+        "and its numeric limit must survive: a per-item reason carries None, \
+         so mislabelling also silently drops the number"
+    );
+}

--- a/rust/processing/src/symbolic/output_cap_tests.rs
+++ b/rust/processing/src/symbolic/output_cap_tests.rs
@@ -523,6 +523,17 @@ fn the_wire_spellings_match_serde() {
     // to JavaScript. Two hand-kept spellings of one vocabulary drift, and the
     // drift is silent: the JSON consumer and the WASM consumer would simply
     // disagree about what `item-depth` is called. Derive one from the other.
+    // The array below is hand-listed, so a fifth variant could be added with a
+    // wrong spelling and this test would stay green while never checking it.
+    // This match is exhaustive over the enum, so adding a variant fails to
+    // compile here (E0004) until the array is extended too.
+    match SymbolicTruncationReason::ElementCount {
+        SymbolicTruncationReason::ElementCount
+        | SymbolicTruncationReason::OutputBytes
+        | SymbolicTruncationReason::ItemDepth
+        | SymbolicTruncationReason::ItemRevisits => {}
+    }
+
     for reason in [
         SymbolicTruncationReason::ElementCount,
         SymbolicTruncationReason::OutputBytes,

--- a/rust/processing/src/symbolic/output_cap_tests.rs
+++ b/rust/processing/src/symbolic/output_cap_tests.rs
@@ -481,3 +481,59 @@ fn an_extraction_bound_outranks_a_per_item_one_whatever_the_scan_order() {
          so mislabelling also silently drops the number"
     );
 }
+
+#[test]
+fn a_per_item_reason_omits_limit_on_the_wire_rather_than_sending_null() {
+    // The TypeScript mirror in `packages/server-client/src/types.ts` declares
+    // `limit?: number`, which means the key is ABSENT. `Option<usize>` with a
+    // plain `Serialize` emits `"limit": null` instead, which type-checks on
+    // both sides and still breaks a consumer that asks `'limit' in truncated`
+    // before rendering "showing {emitted} of {limit}".
+    //
+    // Asserting `truncation.limit == None` (as the sibling test does) cannot
+    // catch this: the Rust value is None either way. Only the serialized shape
+    // distinguishes them, so this reads the JSON.
+    let mut acc = SymbolicAccumulator::with_limits(10_000_000, 64 * 1024 * 1024);
+    super::extract_symbolic_data_into(&hostile_dag(2).into_bytes(), &mut acc);
+    let out = acc.into_data();
+
+    let json = serde_json::to_value(&out).expect("serializes");
+    let truncated = &json["truncated"];
+    assert_eq!(truncated["reason"], "item-revisits");
+    assert!(
+        !truncated
+            .as_object()
+            .expect("truncated is an object")
+            .contains_key("limit"),
+        "a per-item reason must OMIT `limit`, not emit null: {truncated}"
+    );
+
+    // The other direction, so the fix cannot be "always skip": an extraction
+    // bound still has to put its number on the wire.
+    let mut acc = SymbolicAccumulator::with_limits(200, 64 * 1024 * 1024);
+    super::extract_symbolic_data_into(&hostile_dag(2).into_bytes(), &mut acc);
+    let json = serde_json::to_value(acc.into_data()).expect("serializes");
+    assert_eq!(json["truncated"]["reason"], "element-count");
+    assert_eq!(json["truncated"]["limit"], 200);
+}
+
+#[test]
+fn the_wire_spellings_match_serde() {
+    // `as_wire_str` exists because the WASM boundary cannot pass a serde enum
+    // to JavaScript. Two hand-kept spellings of one vocabulary drift, and the
+    // drift is silent: the JSON consumer and the WASM consumer would simply
+    // disagree about what `item-depth` is called. Derive one from the other.
+    for reason in [
+        SymbolicTruncationReason::ElementCount,
+        SymbolicTruncationReason::OutputBytes,
+        SymbolicTruncationReason::ItemDepth,
+        SymbolicTruncationReason::ItemRevisits,
+    ] {
+        let via_serde = serde_json::to_value(reason).expect("serializes");
+        assert_eq!(
+            via_serde,
+            serde_json::Value::String(reason.as_wire_str().to_string()),
+            "as_wire_str disagrees with Serialize for {reason:?}"
+        );
+    }
+}

--- a/rust/processing/src/symbolic/primitives.rs
+++ b/rust/processing/src/symbolic/primitives.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::output_cap::SymbolicTruncation;
 use serde::{Deserialize, Serialize};
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -222,9 +223,28 @@ pub struct SymbolicData {
     pub texts: Vec<SymbolicText>,
     /// All filled regions (`IfcAnnotationFillArea`).
     pub fills: Vec<SymbolicFillArea>,
+    /// Set when extraction stopped at [`MAX_SYMBOLIC_ELEMENTS`]; `None` when the
+    /// file was emitted in full.
+    ///
+    /// `#[serde(default)]` so a `SymbolicData` cached before this field existed
+    /// still deserializes (`apps/server/src/routes/parse/cache_keys.rs` reads
+    /// cached JSON), and `skip_serializing_if` so an untruncated response is
+    /// byte-identical to what it was before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncated: Option<SymbolicTruncation>,
 }
 
+
 impl SymbolicData {
+    /// Total primitives across every collection.
+    pub(super) fn len(&self) -> usize {
+        self.grid_axes.len()
+            + self.polylines.len()
+            + self.circles.len()
+            + self.texts.len()
+            + self.fills.len()
+    }
+
     /// Returns true if no symbolic primitives were extracted — the server
     /// can omit the field from its response instead of emitting an empty
     /// object.
@@ -234,5 +254,12 @@ impl SymbolicData {
             && self.circles.is_empty()
             && self.texts.is_empty()
             && self.fills.is_empty()
+            // A truncated result is never "empty", even when it carries no
+            // primitives. `apps/server/src/types/response.rs` uses this for
+            // `skip_serializing_if`, so returning true here would drop the
+            // diagnostic on exactly the response that needs it most. Not
+            // reachable from extraction under the shipped bounds, but it
+            // round-trips in from cached JSON.
+            && self.truncated.is_none()
     }
 }

--- a/rust/processing/src/symbolic/text.rs
+++ b/rust/processing/src/symbolic/text.rs
@@ -2,11 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::output_cap::SymbolicAccumulator;
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use std::collections::HashMap;
 
 use super::color::resolve_color_via_styles;
-use super::primitives::{SymbolicData, SymbolicText};
+use super::primitives::{SymbolicText};
 use super::transform::{compose_transforms, parse_axis2_placement_2d, Transform2D};
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -25,7 +26,7 @@ pub(super) fn extract_text_literal(
     rtc_x: f32,
     rtc_z: f32,
     styled_items: &HashMap<u32, Vec<u32>>,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
 ) {
     let content = match item.get(0).and_then(|a| a.as_string()) {
         Some(s) => s.to_string(),
@@ -86,7 +87,7 @@ pub(super) fn extract_text_literal(
     let color = resolve_color_via_styles(item.id, styled_items, decoder)
         .unwrap_or([0.05, 0.05, 0.05, 1.0]);
 
-    out.texts.push(SymbolicText {
+    out.push_text(SymbolicText {
         express_id,
         ifc_type: ifc_type.to_string(),
         x: wx - rtc_x,

--- a/rust/processing/src/symbolic/trimmed_curve.rs
+++ b/rust/processing/src/symbolic/trimmed_curve.rs
@@ -5,9 +5,10 @@
 //! `IfcTrimmedCurve` tessellation, split out of `items.rs` to keep that
 //! module's dispatch table under the module-size ratchet (#2256 follow-up).
 
+use super::output_cap::SymbolicAccumulator;
 use ifc_lite_core::{AttributeValue, DecodedEntity, EntityDecoder, IfcType};
 
-use super::primitives::{SymbolicData, SymbolicPolyline};
+use super::primitives::{SymbolicPolyline};
 use super::transform::{parse_axis2_placement_2d, Transform2D};
 
 /// Tessellate an `IfcTrimmedCurve` whose `BasisCurve` is an `IfcCircle`.
@@ -31,7 +32,7 @@ pub(super) fn extract_trimmed_curve(
     transform: &Transform2D,
     rtc_x: f32,
     rtc_z: f32,
-    out: &mut SymbolicData,
+    out: &mut SymbolicAccumulator,
 ) {
     let Some(basis_ref) = item.get_ref(0) else { return };
     let Ok(basis_curve) = decoder.decode_by_id(basis_ref) else { return };
@@ -138,7 +139,7 @@ pub(super) fn extract_trimmed_curve(
         let (wsx, wsy) = transform.transform_point(start_x, start_y);
         let (wex, wey) = transform.transform_point(end_x, end_y);
         let points = vec![wsx - rtc_x, -wsy + rtc_z, wex - rtc_x, -wey + rtc_z];
-        out.polylines.push(SymbolicPolyline {
+        out.push_polyline(SymbolicPolyline {
             express_id,
             ifc_type: ifc_type.to_string(),
             points,
@@ -163,7 +164,7 @@ pub(super) fn extract_trimmed_curve(
             }
         }
         if points.len() >= 4 {
-            out.polylines.push(SymbolicPolyline {
+            out.push_polyline(SymbolicPolyline {
                 express_id,
                 ifc_type: ifc_type.to_string(),
                 points,

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -344,7 +344,14 @@
 # `#[allow(clippy::too_many_arguments)]` its 21 peers carry. The crate's lint
 # has never run in CI (`--exclude ifc-lite-wasm`), which is how it drifted.
      727 rust/wasm-bindings/src/zero_copy/mesh.rs
-     743 rust/wasm-bindings/src/zero_copy/symbolic.rs
+# symbolic.rs +14 (743 -> 757): carries SymbolicData::truncated across the WASM
+# boundary as `truncatedAt` (#2938). A raise rather than a split because the
+# addition is one field, one assignment in `from_data` and one getter -- the
+# file is a god file for reasons that predate this and splitting it is its own
+# change. The alternative was to drop the flag on the browser path, which is
+# the bug being fixed: geometry is client-side only, so that path is the only
+# way a viewer learns its drawing was clipped.
+     757 rust/wasm-bindings/src/zero_copy/symbolic.rs
 # +65: #1910 follow-up — buildPrePassOnce's combined_pre_pass is a third
 # geometry-job discovery path with the same has_geometry_by_name gap as the
 # serial/sharded scans; adds the instance-level exception plus its regression

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 8178777104355335375;
+const ALLOWLIST_DIGEST: u64 = 8179634723425150730;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/symbolic_nan_sentinel_json_roundtrip.rs
+++ b/rust/processing/tests/symbolic_nan_sentinel_json_roundtrip.rs
@@ -80,6 +80,7 @@ fn unresolved_world_y_survives_a_json_round_trip() {
         circles: vec![],
         texts: vec![],
         fills: vec![fill(f32::NAN, f32::NAN)],
+        ..Default::default()
     };
 
     let json = serde_json::to_string(&data).expect("SymbolicData serializes");
@@ -120,6 +121,7 @@ fn unresolved_world_y_is_spelled_null_on_the_wire() {
         circles: vec![],
         texts: vec![],
         fills: vec![],
+        ..Default::default()
     };
 
     let json = serde_json::to_value(&data).expect("SymbolicData serializes");
@@ -156,6 +158,7 @@ fn the_typescript_wire_fixture_matches_what_the_serializer_emits() {
         texts: vec![],
         // Resolved elevation, absent cross-hatch.
         fills: vec![fill(3.5, f32::NAN)],
+        ..Default::default()
     };
     let mut emitted = serde_json::to_string_pretty(&data).expect("SymbolicData serializes");
     emitted.push('\n');
@@ -193,6 +196,7 @@ fn finite_world_y_including_zero_round_trips_unchanged() {
             circles: vec![],
             texts: vec![],
             fills: vec![fill(value, 0.0)],
+            ..Default::default()
         };
 
         let json = serde_json::to_string(&data).expect("SymbolicData serializes");

--- a/rust/wasm-bindings/src/zero_copy/mod.rs
+++ b/rust/wasm-bindings/src/zero_copy/mod.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::prelude::*;
 mod frame_swap;
 mod mesh;
 mod symbolic;
+mod symbolic_truncation;
 
 pub use mesh::{GeometryFingerprint, MeshCollection, MeshDataJs};
 pub use symbolic::{

--- a/rust/wasm-bindings/src/zero_copy/symbolic.rs
+++ b/rust/wasm-bindings/src/zero_copy/symbolic.rs
@@ -508,21 +508,18 @@ pub struct SymbolicRepresentationCollection {
     circles: Vec<SymbolicCircle>,
     texts: Vec<SymbolicText>,
     fills: Vec<SymbolicFillArea>,
-    /// Primitives emitted when extraction hit its bound; `None` if complete.
-    /// Carried across the boundary because geometry is client-side only, so
-    /// this is the only way a browser consumer learns its drawing was clipped
-    /// (#2938).
-    truncated_at: Option<usize>,
+    /// What stopped extraction early; `None` if it completed.
+    ///
+    /// Carried across the boundary in FULL because geometry is client-side
+    /// only, so the browser is the consumer that most needs it (#2938). The
+    /// count alone cannot say whether a whole-file bound clipped the drawing or
+    /// one representation item hit a per-item bound, and cannot render
+    /// "showing {emitted} of {limit}" for the cases that have a limit.
+    pub(super) truncated: Option<ifc_lite_processing::SymbolicTruncation>,
 }
 
 #[wasm_bindgen]
 impl SymbolicRepresentationCollection {
-    /// Primitive count at which extraction stopped, else `undefined`.
-    #[wasm_bindgen(getter, js_name = truncatedAt)]
-    pub fn truncated_at(&self) -> Option<usize> {
-        self.truncated_at
-    }
-
     /// Get all express IDs that have symbolic representations
     #[wasm_bindgen(js_name = getExpressIds)]
     pub fn get_express_ids(&self) -> Vec<u32> {
@@ -657,7 +654,7 @@ impl SymbolicRepresentationCollection {
             circles: Vec::new(),
             texts: Vec::new(),
             fills: Vec::new(),
-            truncated_at: None,
+            truncated: None,
         }
     }
 
@@ -667,7 +664,7 @@ impl SymbolicRepresentationCollection {
             circles: Vec::with_capacity(circle_capacity),
             texts: Vec::new(),
             fills: Vec::new(),
-            truncated_at: None,
+            truncated: None,
         }
     }
 
@@ -694,7 +691,7 @@ impl SymbolicRepresentationCollection {
     /// identical symbol streams from one canonical implementation.
     pub fn from_data(data: ifc_lite_processing::SymbolicData) -> Self {
         let mut collection = Self::with_capacity(data.polylines.len(), data.circles.len());
-        collection.truncated_at = data.truncated.as_ref().map(|t| t.emitted);
+        collection.truncated = data.truncated.clone();
         for p in data.polylines {
             collection.add_polyline(SymbolicPolyline::new(
                 p.express_id,

--- a/rust/wasm-bindings/src/zero_copy/symbolic.rs
+++ b/rust/wasm-bindings/src/zero_copy/symbolic.rs
@@ -508,10 +508,21 @@ pub struct SymbolicRepresentationCollection {
     circles: Vec<SymbolicCircle>,
     texts: Vec<SymbolicText>,
     fills: Vec<SymbolicFillArea>,
+    /// Primitives emitted when extraction hit its bound; `None` if complete.
+    /// Carried across the boundary because geometry is client-side only, so
+    /// this is the only way a browser consumer learns its drawing was clipped
+    /// (#2938).
+    truncated_at: Option<usize>,
 }
 
 #[wasm_bindgen]
 impl SymbolicRepresentationCollection {
+    /// Primitive count at which extraction stopped, else `undefined`.
+    #[wasm_bindgen(getter, js_name = truncatedAt)]
+    pub fn truncated_at(&self) -> Option<usize> {
+        self.truncated_at
+    }
+
     /// Get all express IDs that have symbolic representations
     #[wasm_bindgen(js_name = getExpressIds)]
     pub fn get_express_ids(&self) -> Vec<u32> {
@@ -646,6 +657,7 @@ impl SymbolicRepresentationCollection {
             circles: Vec::new(),
             texts: Vec::new(),
             fills: Vec::new(),
+            truncated_at: None,
         }
     }
 
@@ -655,6 +667,7 @@ impl SymbolicRepresentationCollection {
             circles: Vec::with_capacity(circle_capacity),
             texts: Vec::new(),
             fills: Vec::new(),
+            truncated_at: None,
         }
     }
 
@@ -681,6 +694,7 @@ impl SymbolicRepresentationCollection {
     /// identical symbol streams from one canonical implementation.
     pub fn from_data(data: ifc_lite_processing::SymbolicData) -> Self {
         let mut collection = Self::with_capacity(data.polylines.len(), data.circles.len());
+        collection.truncated_at = data.truncated.as_ref().map(|t| t.emitted);
         for p in data.polylines {
             collection.add_polyline(SymbolicPolyline::new(
                 p.express_id,

--- a/rust/wasm-bindings/src/zero_copy/symbolic.rs
+++ b/rust/wasm-bindings/src/zero_copy/symbolic.rs
@@ -562,13 +562,15 @@ impl SymbolicRepresentationCollection {
         self.polylines.len() + self.circles.len() + self.texts.len() + self.fills.len()
     }
 
-    /// Check if collection is empty
+    /// Check if collection is empty. A TRUNCATED result never is, even with no
+    /// primitives; the reasoning and the parity test are in `symbolic_truncation.rs`.
     #[wasm_bindgen(getter, js_name = isEmpty)]
     pub fn is_empty(&self) -> bool {
         self.polylines.is_empty()
             && self.circles.is_empty()
             && self.texts.is_empty()
             && self.fills.is_empty()
+            && self.truncated.is_none()
     }
 
     /// Get polyline at index

--- a/rust/wasm-bindings/src/zero_copy/symbolic_truncation.rs
+++ b/rust/wasm-bindings/src/zero_copy/symbolic_truncation.rs
@@ -4,6 +4,15 @@
 
 //! The truncation surface of [`SymbolicRepresentationCollection`].
 //!
+//! Also home to the reasoning behind `is_empty`'s truncation guard: a per-item
+//! bound can fire having emitted nothing, so a truncated collection can hold no
+//! primitives at all. A consumer that skips an "empty" collection would then
+//! discard the only signal the browser gets that its drawing is clipped, since
+//! geometry is client-side only. `SymbolicData::is_empty` in
+//! `ifc-lite-processing` already refuses to call a truncated result empty; the
+//! test below pins the two together rather than trusting two definitions to
+//! stay in step.
+//!
 //! Split out of `symbolic.rs` rather than raising that file's ratchet budget:
 //! the budget exists so a god-file cannot grow one accessor at a time, and
 //! "the new field needed a getter" is exactly the increment it is meant to
@@ -37,5 +46,64 @@ impl SymbolicRepresentationCollection {
     #[wasm_bindgen(getter, js_name = truncatedLimit)]
     pub fn truncated_limit(&self) -> Option<usize> {
         self.truncated.as_ref().and_then(|t| t.limit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SymbolicRepresentationCollection;
+    use ifc_lite_processing::{
+        SymbolicData, SymbolicTruncation, SymbolicTruncationReason,
+    };
+
+    fn truncated_but_empty() -> SymbolicData {
+        // A per-item bound can fire having emitted nothing at all: the walk
+        // refuses one representation item and the file contributes no
+        // primitives. That is the shape this guard exists for.
+        SymbolicData {
+            truncated: Some(SymbolicTruncation {
+                reason: SymbolicTruncationReason::ItemRevisits,
+                emitted: 0,
+                limit: None,
+            }),
+            ..SymbolicData::default()
+        }
+    }
+
+    /// `is_empty` decides whether a consumer keeps the collection at all, so
+    /// the two implementations disagreeing means the browser drops a
+    /// diagnostic the server keeps. Assert PARITY, not each side separately:
+    /// two independently-correct-looking definitions is exactly how they
+    /// drifted in the first place.
+    #[test]
+    fn is_empty_agrees_with_the_processing_side_for_a_truncated_but_empty_result() {
+        let data = truncated_but_empty();
+        let expected = data.is_empty();
+        let collection = SymbolicRepresentationCollection::from_data(data);
+
+        assert!(
+            !expected,
+            "SymbolicData::is_empty must not call a truncated result empty"
+        );
+        assert_eq!(
+            collection.is_empty(),
+            expected,
+            "the WASM collection must agree with SymbolicData::is_empty, or a \
+             consumer that skips an empty collection silently discards the \
+             truncation diagnostic (geometry is client-side only, so this is \
+             the browser's only signal the drawing is clipped)"
+        );
+        // The diagnostic the guard protects is actually reachable.
+        assert_eq!(collection.truncated_reason().as_deref(), Some("item-revisits"));
+    }
+
+    #[test]
+    fn a_genuinely_complete_and_empty_result_is_still_empty() {
+        // The other direction, so "always false" is not a passing fix.
+        let data = SymbolicData::default();
+        assert!(data.is_empty());
+        let collection = SymbolicRepresentationCollection::from_data(data);
+        assert!(collection.is_empty());
+        assert_eq!(collection.truncated_reason(), None);
     }
 }

--- a/rust/wasm-bindings/src/zero_copy/symbolic_truncation.rs
+++ b/rust/wasm-bindings/src/zero_copy/symbolic_truncation.rs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+//! The truncation surface of [`SymbolicRepresentationCollection`].
+//!
+//! Split out of `symbolic.rs` rather than raising that file's ratchet budget:
+//! the budget exists so a god-file cannot grow one accessor at a time, and
+//! "the new field needed a getter" is exactly the increment it is meant to
+//! refuse. These read one field and belong together (#2938).
+
+use super::symbolic::SymbolicRepresentationCollection;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl SymbolicRepresentationCollection {
+    /// Primitive count at which extraction stopped, else `undefined`.
+    #[wasm_bindgen(getter, js_name = truncatedAt)]
+    pub fn truncated_at(&self) -> Option<usize> {
+        self.truncated.as_ref().map(|t| t.emitted)
+    }
+
+    /// Which bound stopped extraction, else `undefined`. One of
+    /// `element-count`, `output-bytes`, `item-depth`, `item-revisits` —
+    /// the same kebab-case strings the JSON path emits, so a consumer reading
+    /// either surface reads one vocabulary.
+    #[wasm_bindgen(getter, js_name = truncatedReason)]
+    pub fn truncated_reason(&self) -> Option<String> {
+        self.truncated
+            .as_ref()
+            .map(|t| t.reason.as_wire_str().to_string())
+    }
+
+    /// The bound's numeric value, when the reason has one, else `undefined`.
+    /// Absent for the per-item reasons, whose bound is per item and not
+    /// comparable with `truncatedAt`.
+    #[wasm_bindgen(getter, js_name = truncatedLimit)]
+    pub fn truncated_limit(&self) -> Option<usize> {
+        self.truncated.as_ref().and_then(|t| t.limit)
+    }
+}

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4211,6 +4211,7 @@
     "SymbolicGridAxis: interface",
     "SymbolicPolyline: interface",
     "SymbolicText: interface",
+    "SymbolicTruncation: interface",
     "decodeDataModel: function",
     "decodeOptimizedParquetGeometry: function",
     "decodeParquetGeometry: function",

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -4212,6 +4212,7 @@
     "SymbolicPolyline: interface",
     "SymbolicText: interface",
     "SymbolicTruncation: interface",
+    "SymbolicTruncationReason: type",
     "decodeDataModel: function",
     "decodeOptimizedParquetGeometry: function",
     "decodeParquetGeometry: function",


### PR DESCRIPTION
Closes #2938 (and #2937, folded into it).

`extract_symbolic_data` accumulates across every product into one `SymbolicData`, so the per-item recursion bounds left the file-level total unbounded. A crafted **1.13 MB** upload produced **20,002,500 primitives, 2.74 GB RSS, 3177 ms** — on a path the HTTP server calls with raw uploaded bytes (`apps/server/src/services/streaming.rs`). Bounded, the same file is **385 ms / 282 MB**, and stays flat as it grows 10.5x.

Two bounds — 2,000,000 primitives and 256 MiB of estimated output — plus a `truncated` field naming **which** one fired.

## Three blockers, each behind an argument I had already accepted

This is the part worth reading, because each was found only after the previous fix looked finished.

1. **A count-only cap is not a memory bound.** Per-primitive size is attacker-controlled and the fan-out re-emits one leaf up to the cap, cloning it each time: **8.47 GB** at a 1.07 MB file, **16.70 GB** at 2.03 MB. Worse than the case being fixed.
2. **Charging only the obvious field moves the hole one door along.** A text leaf with a 4 KB `BoxAlignment` reached **3.45 GB** while the accountant had charged 54.9 MB and `truncated` said `None`. Every variable-length field is charged now — `points`, `content`, `alignment`, `holes_offsets`, grid `tag` — and that shape lands at 37 MB reporting `output-bytes`.
3. **First-reason-wins is right within a bound class and wrong across classes.** Scan order is attacker-controlled, so a per-item bound firing on an early product made a file that blew the 2,000,000 ceiling report the mild `item-revisits`, with its numeric limit dropped. The most severe reason now wins.

## The reporting half, which is what #2938 is actually about

The per-item depth and revisit bounds drop content and returned in **silence**. #2938's lead case is a well-formed nested block import losing 60% of its curves to the per-item revisit budget while emitting 200,250 primitives — far below either extraction bound. A diagnostic reporting only the bounds this PR adds would have said nothing about the scenario the issue leads with.

The walk now reports its own reason. A per-item bound marks the result truncated but does **not** set exhaustion — conflating them, which a first attempt did, means one deep item abandons every remaining product in the file.

## Every test verified to fail

Not "mutation-tested" as a claim — each mutation was run, and each was asserted to have applied first (a mutation that fails to compile prints no `test result` line, which reads as a pass).

| mutation | result |
|---|---|
| count bound never fires | 2 tests FAIL |
| byte bound never fires | 1 test FAIL |
| charge `content` only, drop `alignment` | 1 test FAIL |
| charge `alignment` only, drop `content` | 1 test FAIL |
| per-item bound stops reporting | 1 test FAIL |
| per-item bound also sets exhaustion | 1 test FAIL |
| first-reason-wins restored | 1 test FAIL |
| `into_data` always stamps truncated | 1 test FAIL |
| early exits removed from the walk | 1 test FAIL |

That sweep found **two tests that could not fail** — both written by me to prove a fix. The "every variable-length field is charged" test used a 2-byte content beside a 4 KB alignment, so dropping the content charge changed nothing; the "does not abandon the file" test asserted `len() > 1`, which passes even when the file *is* abandoned. Both fixtures now discriminate.

## What this does NOT fix, stated rather than implied

- **Output bounds bound work only insofar as work produces output.** A fan-out whose leaf is an item type the extractor does not handle traverses fully and emits nothing, so neither bound fires: **3.0 MB → 7216 ms, 0 emitted**, linear at ~2.4 ms/KB. Not a regression — `main` is identical — and it is #2937's per-item-budget complaint in the shape output-capping cannot reach. Closing it means hoisting the revisit budget to the extraction, which is safe *now that truncation is reported* but changes behaviour for legitimate multi-product files.
- **`json.rs` clones the response and serializes it up to three more times after its admission permit scope ends.** Different mechanism, dominated by meshes. Deferred, not closed.

## Compatibility

`truncated` is `skip_serializing_if`, so an untruncated response is **byte-identical** to before and cache keys do not move; `serde(default)` means JSON cached before the field existed still deserializes. Marked `minor` rather than `patch` because `SymbolicData` gains a public field, so an exhaustive struct literal in a downstream Rust consumer needs `..Default::default()`.

Carried through the WASM boundary as `truncatedAt` and added to the TypeScript `SymbolicData`. Geometry is client-side only in the viewer, so a flag surviving just the server route would have left the browser silently truncating — #2938 one layer up, inside the fix for it.

## Gates

```
cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings   clean
cargo test --workspace --no-fail-fast                        1946 passed / 0 failed
module_size_ratchet                                          5/5
```

Rebased onto current main; the `ALLOWLIST_DIGEST` conflicted (two budget-raising changes always do) and was **recomputed** against the merged allowlist rather than resolved by picking a side — picking either compiles, looks resolved, and fails the ratchet on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Symbolic extraction now enforces limits of 2,000,000 primitives or 256 MiB.
  - Results identify truncation reasons, configured limits, and emitted counts.
  - Truncation details are available through TypeScript, JavaScript, WebAssembly, and HTTP interfaces.
  - Per-item limits report depth and revisit truncation while allowing subsequent extraction to continue.

- **Compatibility**
  - Existing symbolic data remains compatible when truncation metadata is absent.
  - Variable-length geometry and text content are included when calculating output limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->