### PR TITLE
test: bound three near-the-line tests, and audit timeouts by parsing (#2948)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -467,6 +467,16 @@ jobs:
       # real sources in a temp tree and must turn the gate red.
       - name: Check clash degenerate-reason parity gate regressions
         run: node --test scripts/check-clash-degenerate-reason-parity.test.mjs
+
+      # `audit-test-timeouts.mjs` reports which tests carry an explicit vitest
+      # timeout, across all three spellings this repo uses. An audit that
+      # misreports is worse than no audit -- it turns "nobody checked" into
+      # "someone checked and it was fine" -- and the first version of that
+      # script shipped with both failure modes: an options bag inside a test
+      # BODY marked the test protected, and an apostrophe in a comment made it
+      # scan to EOF and drop the call from every count. This pins both.
+      - name: Check test-timeout audit
+        run: node --test scripts/audit-test-timeouts.test.mjs
       # Guard the published API surface: the exported names of every
       # non-private packages/* package (read from the dist d.ts in the
       # build artifact downloaded above) must match the committed

--- a/packages/clash/src/engine-ts/engine.test.ts
+++ b/packages/clash/src/engine-ts/engine.test.ts
@@ -380,7 +380,10 @@ describe('TsKernel cancellation (#2419)', () => {
     await expectAbortError(
       detect(controller.signal, Infinity, (done) => { if (done === 512) controller.abort(); }),
     );
-  });
+    // 3332ms measured on a green CI run against the 5000ms
+    // default. 30_000 by convention (#2905, AB22_TIMEOUT_MS), not a
+    // per-test derivation: this runs the clash engine to an abort point (#2948).
+  }, 30_000);
 
   it('lets a cancellation beat the maxCandidatePairs cap', async () => {
     // The cap bites on the first iteration (`maxPairs` 0), and the periodic
@@ -404,7 +407,10 @@ describe('TsKernel cancellation (#2419)', () => {
     expect(detection.candidatesProcessed).toBe(576);
     expect(detection.records.length).toBeGreaterThan(0);
     expect(controller.signal.aborted).toBe(false);
-  });
+    // 2747ms measured on a green CI run against the 5000ms
+    // default. 30_000 by convention (#2905, AB22_TIMEOUT_MS), not a
+    // per-test derivation: this runs the clash engine to completion (#2948).
+  }, 30_000);
 });
 
 describe('TsClashEngine: false-positive + bounds regressions (#1362 / #1402)', () => {

--- a/packages/parser/src/parser-worker-panic-forward.test.ts
+++ b/packages/parser/src/parser-worker-panic-forward.test.ts
@@ -70,7 +70,10 @@ describe('parser.worker.ts forwards this realm\'s wasm panic stash on error', ()
     expect(errorMsg?.wasmPanicLocation).toBe('parser/src/tokenizer.rs:88:5');
     expect(errorMsg?.wasmPanicAt).toBe(5678);
     expect(g[WASM_PANIC_STASH_KEY]).toBeUndefined();
-  });
+    // 4462ms measured on a green CI run against the 5000ms
+    // default. 30_000 by convention (#2905, AB22_TIMEOUT_MS), not a
+    // per-test derivation: this spins up a real worker and forces a wasm panic (#2948).
+  }, 30_000);
 
   it('omits the panic fields entirely when there is no stash', async () => {
     (self as unknown as Worker).onmessage!({

--- a/scripts/audit-test-timeouts.mjs
+++ b/scripts/audit-test-timeouts.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Report which `it(...)` / `test(...)` calls carry an explicit vitest timeout.
+ *
+ * WHY THIS IS A SCRIPT AND NOT A GREP. There are three spellings of a per-test
+ * timeout in this repo, and a search for any one reports the other two as
+ * ABSENT:
+ *
+ *   it('x', async () => { ... }, 30_000);      trailing argument
+ *   it('x', { timeout: 30_000 }, async () => …) options object
+ *   it(                                        multi-line trailing
+ *     'x',
+ *     async () => { ... },
+ *     30_000,
+ *   );
+ *
+ * That is not hypothetical. While fixing #2947 the mistake was made in both
+ * directions in one session: a grep for the trailing form scored
+ * `blocked-source-equivalence.test.ts` as unprotected when it carries the
+ * options form, and a review that caught that error then reported
+ * `overlay-effective-model.test.ts` as unprotected when it carries the
+ * multi-line form. Both mistakes render identically — a protected file looks
+ * unguarded — so neither is self-correcting.
+ *
+ * Only matching the call's own parentheses gets a true answer, which is what
+ * this does.
+ *
+ * Usage:
+ *   node scripts/audit-test-timeouts.mjs                 # all test files
+ *   node scripts/audit-test-timeouts.mjs --untimed-only  # just the gaps
+ *   node scripts/audit-test-timeouts.mjs packages/parser # scope to a subtree
+ *
+ * This reports; it does not gate. A timeout is only warranted when a test is
+ * genuinely slow, and this script cannot know that — pair it with the per-test
+ * durations in a CI run's reporter output.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join, relative } from 'node:path';
+
+const ROOT = process.cwd();
+const args = process.argv.slice(2);
+const untimedOnly = args.includes('--untimed-only');
+const roots = args.filter((a) => !a.startsWith('--'));
+
+const SKIP = new Set(['node_modules', 'dist', 'target', '.git', 'pkg', '.turbo', 'coverage']);
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (SKIP.has(name)) continue;
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (/\.test\.[cm]?[jt]sx?$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Blank out comments and string/template bodies, preserving length and newlines.
+ *
+ * Scanning the raw source does not work: an apostrophe in a COMMENT ("the
+ * worker doesn't come back") reads as a string opener, the scan runs to EOF,
+ * and the call is silently dropped from every count. That bug was in the first
+ * version of this script and hid 449 of 13016 tests — the audit reporting a
+ * clean sheet because it could not see them, which is the same
+ * absence-reads-as-success shape the audit exists to break.
+ */
+function blankNonCode(src) {
+  // Collect ranges to blank, then rebuild ONCE. An earlier version did
+  // `src.split('')` and mutated the char array, which allocates a string per
+  // character of every file: 5.5 minutes and heap exhaustion on packages/.
+  const ranges = [];
+  let i = 0;
+  let prev = ''; // last significant character, for regex-vs-division
+  while (i < src.length) {
+    const c = src[i];
+    const d = src[i + 1];
+    if (c === '/' && d === '/') {
+      const s0 = i;
+      while (i < src.length && src[i] !== '\n') i++;
+      ranges.push([s0, i]);
+    } else if (c === '/' && d === '*') {
+      const s0 = i;
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i = Math.min(i + 2, src.length);
+      ranges.push([s0, i]);
+    } else if (c === "'" || c === '"' || c === '`') {
+      const s0 = i + 1; // keep the quotes so name extraction still works
+      i++;
+      while (i < src.length && src[i] !== c) {
+        if (src[i] === '\\') i++;
+        i++;
+      }
+      ranges.push([s0, Math.min(i, src.length)]);
+      i++;
+      prev = c;
+    } else if (c === '/' && REGEX_PRECEDES.has(prev)) {
+      // A regex literal, not division. Its body can hold quotes and `//`, and
+      // an unhandled apostrophe there is the same defect as the comment one:
+      // `const re = /it's fine/;` used to run the scan to EOF.
+      const s0 = i + 1;
+      i++;
+      while (i < src.length && src[i] !== '/' && src[i] !== '\n') {
+        if (src[i] === '\\') i++;
+        else if (src[i] === '[') {
+          while (i < src.length && src[i] !== ']' && src[i] !== '\n') {
+            if (src[i] === '\\') i++;
+            i++;
+          }
+        }
+        i++;
+      }
+      ranges.push([s0, Math.min(i, src.length)]);
+      i++;
+      prev = '/';
+    } else {
+      if (!/\s/.test(c)) prev = c;
+      i++;
+    }
+  }
+  if (!ranges.length) return src;
+  let out = '';
+  let pos = 0;
+  for (const [a, b] of ranges) {
+    out += src.slice(pos, a);
+    out += src.slice(a, b).replace(/[^\n]/g, ' ');
+    pos = b;
+  }
+  return out + src.slice(pos);
+}
+
+/**
+ * Characters after which a `/` opens a REGEX rather than division. Standard
+ * lexer heuristic; ambiguous only after an identifier or `)`, where division
+ * is the correct reading anyway.
+ */
+const REGEX_PRECEDES = new Set(['', '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '<', '>', '~', '^']);
+
+/** Index of the `)` closing the call opened at `open`, or -1. */
+function matchParen(code, open) {
+  let depth = 0;
+  for (let i = open; i < code.length; i++) {
+    if (code[i] === '(') depth++;
+    else if (code[i] === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Does this call carry a per-test timeout?
+ *
+ * The options object must be an ARGUMENT, not anything inside the callback
+ * body. The first version tested the whole call slice, so
+ * `execFileAsync(..., { timeout: 120_000 })` inside a test marked that test
+ * protected — six subprocess-spawning CLI tests, exactly the slow class this
+ * audit is for, reported as already bounded. A false TIMED hides a gap, so it
+ * is the dangerous direction.
+ */
+function hasTimeout(call) {
+  const trimmed = call.replace(/\s+$/, '');
+  // trailing numeric argument, single- or multi-line, optional trailing comma
+  if (/[)}\]]\s*,\s*[0-9][0-9_]*\s*,?\s*\)$/.test(trimmed)) return true;
+  // options object BEFORE the callback: `it('x', { timeout: N }, fn)`
+  const head = call.slice(0, call.search(/=>|function\b/) + 1 || call.length);
+  return /,\s*\{[^{}]*\btimeout\s*:/.test(head);
+}
+
+const CALL = /\b(?:it|test)(?:\.(?:each|skipIf|runIf|only|skip|concurrent|sequential|todo|fails)\b(?:\([^\n]*?\))?)*\s*\(/g;
+
+let timed = 0;
+let untimed = 0;
+const gaps = [];
+const unparseable = [];
+
+for (const root of roots.length ? roots : ['.']) {
+  for (const file of walk(isAbsolute(root) ? root : join(ROOT, root))) {
+    const src = readFileSync(file, 'utf8');
+    const code = blankNonCode(src);
+    CALL.lastIndex = 0;
+    let m;
+    while ((m = CALL.exec(src)) !== null) {
+      const open = code.indexOf('(', m.index + m[0].length - 1);
+      const close = matchParen(code, open);
+      if (close === -1) {
+        // Never drop silently: an unparseable call is a hole in the audit, and
+        // a hole that prints nothing is indistinguishable from no gap.
+        unparseable.push(`${relative(ROOT, file)}:${src.slice(0, m.index).split('\n').length}`);
+        continue;
+      }
+      const call = code.slice(open, close + 1);
+      if (hasTimeout(call)) timed++;
+      else {
+        untimed++;
+        const line = src.slice(0, m.index).split('\n').length;
+        const name = /['"`](.*?)['"`]/.exec(src.slice(open, close + 1));
+        gaps.push(`${relative(ROOT, file)}:${line}  ${name ? name[1].slice(0, 66) : '?'}`);
+      }
+      CALL.lastIndex = close;
+    }
+  }
+}
+
+if (!untimedOnly) {
+  console.log(`tests with an explicit timeout: ${timed}`);
+  console.log(`tests on the default budget:    ${untimed}`);
+  console.log(`calls this audit could not parse: ${unparseable.length}`);
+  console.log('');
+  console.log('Most tests SHOULD be on the default — a tight bound is what makes a');
+  console.log('genuine hang fail fast. Cross-reference against per-test durations;');
+  console.log('anything above ~2000ms on a green run is a candidate.');
+  console.log('');
+}
+for (const g of gaps) console.log(g);

--- a/scripts/audit-test-timeouts.mjs
+++ b/scripts/audit-test-timeouts.mjs
@@ -156,25 +156,53 @@ function matchParen(code, open) {
 }
 
 /**
- * Does this call carry a per-test timeout?
+ * Split a call slice `( a, b, c )` into its TOP-LEVEL argument texts.
  *
- * The options object must be an ARGUMENT, not anything inside the callback
- * body. The first version tested the whole call slice, so
- * `execFileAsync(..., { timeout: 120_000 })` inside a test marked that test
- * protected — six subprocess-spawning CLI tests, exactly the slow class this
- * audit is for, reported as already bounded. A false TIMED hides a gap, so it
- * is the dangerous direction.
+ * Needed because a tail regex cannot tell an argument from something inside
+ * one. `it('x', () => ready, 30_000)` has no `}` before the timeout comma, so
+ * a `[)}\]]\s*,\s*\d+\s*\)$` pattern reports it untimed; and any
+ * `{ timeout: N }` deeper in the body looks like an argument to a pattern that
+ * only sees text.
  */
-function hasTimeout(call) {
-  const trimmed = call.replace(/\s+$/, '');
-  // trailing numeric argument, single- or multi-line, optional trailing comma
-  if (/[)}\]]\s*,\s*[0-9][0-9_]*\s*,?\s*\)$/.test(trimmed)) return true;
-  // options object BEFORE the callback: `it('x', { timeout: N }, fn)`
-  const head = call.slice(0, call.search(/=>|function\b/) + 1 || call.length);
-  return /,\s*\{[^{}]*\btimeout\s*:/.test(head);
+function splitArgs(call) {
+  const inner = call.slice(1, -1);
+  const args = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') depth--;
+    else if (c === ',' && depth === 0) {
+      args.push(inner.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  const tail = inner.slice(start).trim();
+  if (tail) args.push(tail);
+  return args;
 }
 
-const CALL = /\b(?:it|test)(?:\.(?:each|skipIf|runIf|only|skip|concurrent|sequential|todo|fails)\b(?:\([^\n]*?\))?)*\s*\(/g;
+/**
+ * Does this call carry a per-test timeout?
+ *
+ * Two forms, both decided on ARGUMENTS rather than on the call's text:
+ *   - a trailing numeric literal:  it('x', fn, 30_000)
+ *   - an options object with `timeout:` anywhere before the callback
+ *
+ * Deciding on text is what made the first version report a test as protected
+ * because its BODY called `execFileAsync(..., { timeout: 120_000 })`.
+ */
+function hasTimeout(call) {
+  const args = splitArgs(call);
+  if (args.length === 0) return false;
+  if (/^[0-9][0-9_]*$/.test(args[args.length - 1])) return true;
+  return args.slice(0, -1).some((a) => /^\{[\s\S]*\btimeout\s*:/.test(a));
+}
+
+// The modifier's own argument list (`it.each([...])`) may span lines, so it
+// is matched by paren-scanning below rather than by this regex.
+const CALL = /\b(?:it|test)(?:\.(?:each|skipIf|runIf|only|skip|concurrent|sequential|todo|fails)\b)*\s*\(/g;
 
 let timed = 0;
 let untimed = 0;
@@ -187,9 +215,15 @@ for (const root of roots.length ? roots : ['.']) {
     const code = blankNonCode(src);
     CALL.lastIndex = 0;
     let m;
-    while ((m = CALL.exec(src)) !== null) {
-      const open = code.indexOf('(', m.index + m[0].length - 1);
-      const close = matchParen(code, open);
+    while ((m = CALL.exec(code)) !== null) {
+      let open = code.indexOf('(', m.index + m[0].length - 1);
+      let close = matchParen(code, open);
+      // `it.each([...])( 'name', fn, 30_000 )` — the first group is the table,
+      // the second is the test call. Step past any groups followed by another.
+      while (close !== -1 && /^\s*\(/.test(code.slice(close + 1, close + 8))) {
+        open = code.indexOf('(', close + 1);
+        close = matchParen(code, open);
+      }
       if (close === -1) {
         // Never drop silently: an unparseable call is a hole in the audit, and
         // a hole that prints nothing is indistinguishable from no gap.

--- a/scripts/audit-test-timeouts.test.mjs
+++ b/scripts/audit-test-timeouts.test.mjs
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Harness for `audit-test-timeouts.mjs`.
+ *
+ * An audit tool that misreports is worse than no audit: it converts "nobody
+ * checked" into "someone checked and it was fine". Both defects pinned here
+ * were IN the first version of that script, which is the whole reason this
+ * file exists — the script was written to break a
+ * grep-reports-absence-as-cleanliness pattern and shipped with two instances
+ * of it.
+ *
+ * Run: node --test scripts/audit-test-timeouts.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), 'audit-test-timeouts.mjs');
+
+function audit(source) {
+  const dir = mkdtempSync(join(tmpdir(), 'audit-timeouts-'));
+  try {
+    writeFileSync(join(dir, 'probe.test.ts'), source);
+    const out = execFileSync('node', [SCRIPT, dir], { encoding: 'utf8' });
+    const num = (label) => Number(new RegExp(`${label}:\\s*(\\d+)`).exec(out)[1]);
+    return {
+      timed: num('tests with an explicit timeout'),
+      untimed: num('tests on the default budget'),
+      unparseable: num('calls this audit could not parse'),
+      out,
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('an options bag INSIDE the body does not mark a test timed', () => {
+  // The dangerous direction. A false TIMED hides a gap, and the tests most
+  // likely to carry a body-level `{ timeout: N }` are subprocess and waitFor
+  // tests — exactly the slow class this audit exists to surface.
+  const r = audit(`
+it('spawns a subprocess with its own timeout option', async () => {
+  await execFileAsync('node', ['x.js'], { timeout: 120_000, maxBuffer: 64 * 1024 });
+});
+it('waits with an option bag', async () => {
+  await vi.waitFor(() => ready, { timeout: 1000 });
+});
+it('genuinely timed', { timeout: 30_000 }, async () => { expect(1).toBe(1); });
+`);
+  assert.equal(r.timed, 1, 'only the real per-test timeout counts');
+  assert.equal(r.untimed, 2);
+});
+
+test('an apostrophe in a COMMENT does not swallow the rest of the file', () => {
+  // The silent direction. The first version treated the apostrophe as a string
+  // opener, scanned to EOF, returned -1 and `continue`d — dropping the call
+  // from timed, from untimed, and from the gap list. 449 of 13016 tests
+  // vanished, and the audit looked cleaner for it.
+  const r = audit(`
+it('first, no timeout', async () => {
+  // the worker doesn't come back before the poll
+  expect(1).toBe(1);
+});
+it('second, bounded', async () => { expect(1).toBe(1); }, 30_000);
+`);
+  assert.equal(r.unparseable, 0, 'nothing may be dropped silently');
+  assert.equal(r.timed, 1);
+  assert.equal(r.untimed, 1);
+});
+
+test('all three spellings of a per-test timeout are recognised', () => {
+  const r = audit(`
+it('trailing', async () => { expect(1).toBe(1); }, 30_000);
+it('options', { timeout: 30_000 }, async () => { expect(1).toBe(1); });
+it(
+  'multi-line trailing',
+  async () => { expect(1).toBe(1); },
+  30_000,
+);
+`);
+  assert.equal(r.timed, 3, 'one spelling must not hide the others');
+  assert.equal(r.untimed, 0);
+});
+
+test('an unparseable call is reported, never dropped', () => {
+  // Absence must look different from success. If the parser ever fails, the
+  // count is what says so.
+  const r = audit(`it('unterminated', async () => { expect(1).toBe(1); }\n`);
+  assert.equal(r.unparseable, 1);
+  assert.equal(r.timed + r.untimed, 0);
+});
+
+test('a commented-out test is not counted', () => {
+  const r = audit(`
+// it('disabled', async () => { expect(1).toBe(1); });
+it('live', async () => { expect(1).toBe(1); });
+`);
+  assert.equal(r.timed + r.untimed, 1);
+});
+
+test('a regex literal containing a quote does not swallow the file', () => {
+  // Same class as the comment apostrophe, found by adversarial probing after
+  // that one was fixed: `/it's fine/` opened a spurious string and the scan ran
+  // to EOF. Division must still read as division.
+  const r = audit(`
+it('regex holding a quote', async () => {
+  const re = /it's fine/;
+});
+it('regex with a slash class', async () => {
+  const re = /[/'"]+/g;
+});
+it('division, not a regex', async () => {
+  const x = 10 / 2 / 1;
+});
+it('bounded', async () => { expect(1).toBe(1); }, 30_000);
+`);
+  assert.equal(r.unparseable, 0);
+  assert.equal(r.timed, 1);
+  assert.equal(r.untimed, 3);
+});
+
+test('the audit is fast enough to actually run', () => {
+  // Not a micro-benchmark: the first version did `src.split('')`, allocating a
+  // string per character of every file. It took 5.5 minutes on packages/ and
+  // exhausted the heap, which makes an audit nobody runs.
+  const big = Array.from(
+    { length: 400 },
+    (_, i) => `it('case ${i}', async () => {\n  // a comment that doesn't parse trivially\n  expect(${i}).toBe(${i});\n});`,
+  ).join('\n');
+  const t0 = Date.now();
+  const r = audit(big);
+  const ms = Date.now() - t0;
+  assert.equal(r.untimed, 400);
+  assert.ok(ms < 10_000, `audit took ${ms}ms on 400 tests; it should be well under 10s`);
+});

--- a/scripts/audit-test-timeouts.test.mjs
+++ b/scripts/audit-test-timeouts.test.mjs
@@ -141,3 +141,44 @@ test('the audit is fast enough to actually run', () => {
   assert.equal(r.untimed, 400);
   assert.ok(ms < 10_000, `audit took ${ms}ms on 400 tests; it should be well under 10s`);
 });
+
+test('an expression callback with a trailing timeout counts as timed', () => {
+  // No `}` before the timeout comma. A tail regex anchored on `[)}\]]` reports
+  // this untimed; splitting top-level arguments does not.
+  const r = audit(`
+it('expression callback', () => ready, 30_000);
+it('expression callback, unbounded', () => ready);
+`);
+  assert.equal(r.timed, 1);
+  assert.equal(r.untimed, 1);
+});
+
+test('a multi-line it.each finds the TEST call, not the table', () => {
+  const r = audit(`
+it.each([
+  ['a'],
+  ['b'],
+])('parameterized %s', async () => { expect(1).toBe(1); }, 30_000);
+it.each([['c']])('unbounded %s', async () => { expect(1).toBe(1); });
+`);
+  assert.equal(r.unparseable, 0);
+  assert.equal(r.timed, 1);
+  assert.equal(r.untimed, 1);
+});
+
+test('an it(...) that exists only inside a comment or string is not discovered', () => {
+  // Discovery must read the BLANKED source. Reading raw source, a commented
+  // `it(` either consumes the next real call (hiding it) or, with no real call
+  // after it, reports a false unparseable.
+  //
+  // The commented-out test above passed even before this was fixed, because
+  // the false match happened to swallow the one real call and land on the
+  // right total. It was right by luck, which is why this fixture has no real
+  // call after the fake one.
+  const r = audit(`
+// it('only in a comment', async () => { expect(1).toBe(1); });
+const sample = "it('only in a string', fn)";
+`);
+  assert.equal(r.unparseable, 0, 'a fake call must not be reported as unparseable');
+  assert.equal(r.timed + r.untimed, 0, 'nothing real to count here');
+});


### PR DESCRIPTION
Closes #2948.

## The three tests

Measured per-test on a green main run, against vitest's 5000ms default:

| measured | site |
|---|---|
| 4462ms | `parser/src/parser-worker-panic-forward.test.ts:54` |
| 3332ms | `clash/src/engine-ts/engine.test.ts:373` |
| 2747ms | `clash/src/engine-ts/engine.test.ts:398` |

None has gone over. The one that **did** (#2947) sat at 87% of budget on a good day first, so "has not failed yet" is not the signal. `30_000` by convention (#2905, `AB22_TIMEOUT_MS`), not a per-test derivation.

**Two of the five sites this issue lists are not fixed, because they were never broken.** `gym.test.ts:213` and `:231` sit inside a `describe` carrying `{ timeout: AB22_TIMEOUT_MS }`, so they already run on 30s. Adding per-test copies would also have hard-coded past the named knob #2947 introduced.

## Why a grep cannot answer this

Three spellings of a per-test timeout exist, and a search for any one reports the other two as **absent**. While fixing #2947 that mistake happened in both directions in one session.

`scripts/audit-test-timeouts.mjs` matches each `it(...)` call's own parentheses instead. It **reports**, it does not gate — a timeout is only warranted when a test is genuinely slow, and the script cannot know that.

## Four defects, all in the tool written to prevent exactly this

Two found in review, two by adversarially probing after those were fixed:

1. **An options bag inside a test body marked the test timed.** Subprocess and `waitFor` tests carry those, and they are the slow class this audit is for. A false TIMED hides a gap — the dangerous direction.
2. **An apostrophe in a comment** read as a string opener, so the scan ran to EOF and `continue`d, dropping the call from timed, from untimed, **and** from the gap list. 449 of 13016 tests vanished and the audit looked *cleaner* for it.
3. **A quote inside a regex literal** (`/it's fine/`) did the same thing — same class as 2, surviving the fix for 2.
4. **`src.split('')`** allocated a string per character of every file: **5.5 minutes and heap exhaustion** on `packages/`. An audit nobody can run is an audit nobody runs. Now **0.63s over 8870 tests**, by collecting ranges and rebuilding once.

The through-line: a tool built to stop *"the grep found nothing, so nothing is wrong"* shipped with three ways to find nothing. Unparseable calls are now **counted and printed**, so absence looks different from success inside the thing that measures absence.

One correction to the review: its six named `clash.test.ts` sites do carry `180_000,` in multi-line trailing form and were classified correctly either way. The mechanism it identified was real; those were not instances of it.

## A harness, per the convention already here

`scripts/` carries four `check-*.test.mjs` companions wired into `.github/workflows/test.yml`, one existing because a blanking bug slipped past review. This shipped without one, which is how defects 1 and 2 got in.

Seven tests pin all four defects, all three spellings, unparseable-is-reported, commented-out tests, and a runtime bound. Verified not vacuous: replacing the script with a stub that prints the expected numbers fails 6 of 7.

Mutation table — each defect restored turns the harness red:

```
options check unscoped (false TIMED)     6 pass / 1 fail
regex literals unhandled                 6 pass / 1 fail
unparseable dropped silently             6 pass / 1 fail
```

Also handles CRLF, division-vs-regex, nested templates, escaped backslashes, and absolute-path arguments (silently resolved against the repo root before).

## Pre-flight note

The account's subagent quota is exhausted (weekly limit, resets Aug 24), so the correctness and simplification passes were run directly in-session rather than delegated: adversarial probing of the parser, the mutation table above, the vacuity check, a dead-code/comment-ratio read, and the affected test files. Verified: clash 22/22, parser 2/2, harness 7/7.