### PR TITLE
docs(types): mark seven declared-but-never-read option fields deprecated (#2731)

### DIFF
--- a/.changeset/deprecate-unread-optional-fields.md
+++ b/.changeset/deprecate-unread-optional-fields.md
@@ -1,0 +1,41 @@
+---
+'@ifc-lite/drawing-2d': patch
+'@ifc-lite/renderer': patch
+'@ifc-lite/geometry': patch
+---
+
+Seven public option fields that nothing reads are now marked `@deprecated`,
+with JSDoc that says what actually happens instead of what the old comment
+promised. No behaviour changes and no export is removed or renamed — the
+values were already ignored at runtime; only the type-level documentation
+changes, so editors now warn at the point a caller sets one.
+
+- `SVGExportOptions.units` (`drawing-2d`) — `export()` never destructures it;
+  the exporter emits no dimension annotations and always sizes the sheet in
+  millimetres.
+- `OpeningFilterOptions.keepBoundarySegments` (`drawing-2d`) — merged into the
+  filter's options object but never consulted; `tolerance` is the only field
+  that governs how segments near an opening edge are treated.
+- `DoorSymbolConfig.showThreshold` (`drawing-2d`) — no threshold-rendering code
+  exists, so `true` and `false` produce identical geometry.
+- `SnapOptions.snapRadius` (`renderer`) — documented as a world-units snap
+  distance, but every proximity check reads `screenSnapRadius` (pixels).
+  Snapping is screen-space and zoom-dependent; set `screenSnapRadius` instead.
+- `SectionPlaneRenderOptions.flipped` (`renderer`) — the gizmo renderer never
+  reads it. The GPU clip plane flips correctly through separate state, so
+  cutting behaviour is unaffected; only the gizmo option is inert.
+- `RenderOptions.enableDepthTest` (`renderer`) — dead on both ends: nothing
+  sets it and nothing reads it. Depth comparison is fixed per pipeline at
+  construction time and is not configurable through `RenderOptions`.
+- `StreamingOptions.onMetadataBootstrap` (`geometry`) — an unfinished stub. Its
+  siblings `onBatch`, `onColorUpdate`, `onComplete` and `onError` are all
+  dispatched by the bridge; this one never is, so a callback passed here is
+  never called.
+
+Deprecating rather than deleting is deliberate: removing an optional field an
+embedder already passes converts a silent no-op into a TypeScript compile
+error, which is a worse first contact with the problem than a deprecation
+warning that explains it. Removal is left as a separate, explicitly versioned
+decision. See issue #2731 for the full audit; the findings that carry a
+behaviour decision (the streaming batch ramp-up, `GeometryQuality`, and the
+scale-bar / north-arrow renderer divergence) are deliberately untouched here.

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -266,7 +266,7 @@ canvas.addEventListener('mousemove', (e) => {
       snapToVertices: true,
       snapToEdges: true,
       snapToFaces: true,
-      snapRadius: 0.1,           // 10cm world units
+      snapRadius: 0.1,           // deprecated: ignored, screenSnapRadius is what is read
       screenSnapRadius: 20       // 20 pixels
     }
   });
@@ -300,7 +300,7 @@ canvas.addEventListener('mousemove', (e) => {
     snapOptions: {
       snapToVertices: true,
       snapToEdges: true,
-      snapRadius: 0.1,
+      snapRadius: 0.1,          // deprecated: ignored
       screenSnapRadius: 20
     }
   });
@@ -522,7 +522,7 @@ interface RenderOptions {
   clearColor?: [number, number, number, number];
 
   // Performance
-  enableDepthTest?: boolean;
+  enableDepthTest?: boolean;        // deprecated: declared but never read
   enableFrustumCulling?: boolean;
   spatialIndex?: SpatialIndex;
 

--- a/packages/drawing-2d/src/openings/opening-filter.ts
+++ b/packages/drawing-2d/src/openings/opening-filter.ts
@@ -24,7 +24,16 @@ import { projectTo2D, getProjectionAxes } from '../math.js';
 export interface OpeningFilterOptions {
   /** Tolerance for point-in-bounds testing (world units) */
   tolerance: number;
-  /** Whether to keep segments at opening boundaries */
+  /**
+   * Declared but never read. The constructor merges it into `this.options`,
+   * but no method consults it: boundary handling is governed entirely by
+   * {@link tolerance}, which inflates the opening bounds in `pointInBounds`
+   * so a larger tolerance drops slightly more of the segment near the edge.
+   * Setting this to `false` does not make boundary segments disappear.
+   * Slated for removal; see issue #2731.
+   *
+   * @deprecated Ignored by the filter — `tolerance` is what governs boundaries.
+   */
   keepBoundarySegments: boolean;
 }
 

--- a/packages/drawing-2d/src/svg-exporter.ts
+++ b/packages/drawing-2d/src/svg-exporter.ts
@@ -59,7 +59,15 @@ export interface SVGExportOptions {
   projectName?: string;
   /** Background color (default: white) */
   backgroundColor?: string;
-  /** Units for dimension display */
+  /**
+   * Declared but never read. `export()` does not destructure `units` and no
+   * other code path consults it, so setting it has no effect on the emitted
+   * SVG. The exporter emits no dimension annotations at all, and the sheet
+   * itself is always sized in millimetres (`width="…mm"`), so there is no
+   * substitute option to reach for. Slated for removal; see issue #2731.
+   *
+   * @deprecated Ignored by the exporter — see above.
+   */
   units?: 'mm' | 'm';
   /** DXF reference underlays rendered beneath the drawing (issue #1782) */
   underlays?: SVGUnderlayOptions[];

--- a/packages/drawing-2d/src/symbols/door-symbol.ts
+++ b/packages/drawing-2d/src/symbols/door-symbol.ts
@@ -44,7 +44,15 @@ export interface DoorSymbolConfig {
   swingAngle: number;
   /** Show door leaf line */
   showLeaf: boolean;
-  /** Show threshold line */
+  /**
+   * Declared but never read. No threshold-rendering code exists anywhere in
+   * the package, so this field cannot switch anything on: setting it to
+   * `true` produces exactly the same geometry as leaving it at the default
+   * `false`. There is no substitute option — a threshold line would have to
+   * be drawn by the caller. Slated for removal; see issue #2731.
+   *
+   * @deprecated Ignored by the generator — no threshold is ever drawn.
+   */
   showThreshold: boolean;
 }
 

--- a/packages/geometry/src/platform-bridge.ts
+++ b/packages/geometry/src/platform-bridge.ts
@@ -113,7 +113,17 @@ export interface GeometryProcessingResult {
 export interface StreamingOptions {
   /** Callback for each batch of meshes */
   onBatch?: (batch: GeometryBatch) => void;
-  /** Callback for early metadata bootstrap when available */
+  /**
+   * Declared but never read. This is the only occurrence of the name in the
+   * repository — no bridge implementation ever invokes it, so a callback
+   * passed here is never called and no "early metadata bootstrap" is
+   * delivered. Unlike its siblings ({@link onBatch}, {@link onColorUpdate},
+   * {@link onComplete}, {@link onError}), which are all dispatched, this one
+   * is an unfinished stub. There is no substitute callback; metadata must be
+   * read from the completed result. Slated for removal; see issue #2731.
+   *
+   * @deprecated Never invoked — see above.
+   */
   onMetadataBootstrap?: (bootstrap: MetadataBootstrapPayload) => void;
   /** Callback for deferred color updates */
   onColorUpdate?: (updates: Map<number, [number, number, number, number]>) => void;

--- a/packages/renderer/src/section-plane.ts
+++ b/packages/renderer/src/section-plane.ts
@@ -17,7 +17,18 @@ export interface SectionPlaneRenderOptions {
     max: { x: number; y: number; z: number };
   };
   viewProj: Float32Array;
-  flipped?: boolean; // If true, show the opposite side indicator
+  /**
+   * Declared but never read. `SectionPlaneRenderer.render()` never consults
+   * it, so the gizmo quad looks identical either way — this field cannot
+   * "show the opposite side indicator". Note that the actual GPU clip plane
+   * is flipped correctly elsewhere (`scene-raycaster.ts` and `point-picker.ts`
+   * read a `flipped` off their own section-plane state), so cutting behaviour
+   * is unaffected; only this gizmo option is inert. Slated for removal; see
+   * issue #2731.
+   *
+   * @deprecated Ignored by the gizmo renderer — see above.
+   */
+  flipped?: boolean;
   isPreview?: boolean; // If true, render as preview (less opacity)
   min?: number;      // Optional override for min range value
   max?: number;      // Optional override for max range value

--- a/packages/renderer/src/snap-detector.ts
+++ b/packages/renderer/src/snap-detector.ts
@@ -33,6 +33,16 @@ export interface SnapOptions {
   snapToVertices: boolean;
   snapToEdges: boolean;
   snapToFaces: boolean;
+  /**
+   * Declared but never read. Documented as a world-units snap distance, but
+   * every proximity check in `SnapDetector` uses {@link screenSnapRadius}
+   * (pixels) instead — see the two call sites that pass `opts.screenSnapRadius`
+   * into the candidate search. Snapping is therefore purely screen-space and
+   * zoom-dependent; changing this value has no effect. Set
+   * {@link screenSnapRadius} instead. Slated for removal; see issue #2731.
+   *
+   * @deprecated Ignored — `screenSnapRadius` is the value that is read.
+   */
   snapRadius: number; // In world units
   screenSnapRadius: number; // In pixels
   /**

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -204,6 +204,15 @@ export interface RenderOptions {
    * look exactly. See {@link import('./environment.js').LightingEnvironment}.
    */
   environment?: import('./environment.js').LightingEnvironment;
+  /**
+   * Declared but never read. This is the only occurrence of the name in the
+   * package: nothing sets it and nothing consults it, so it is dead on both
+   * ends. Depth testing is decided per pipeline at construction time and is
+   * not configurable through `RenderOptions`; there is no substitute field.
+   * Slated for removal; see issue #2731.
+   *
+   * @deprecated Ignored by the renderer — see above.
+   */
   enableDepthTest?: boolean;
   enableFrustumCulling?: boolean;
   spatialIndex?: import('@ifc-lite/spatial').SpatialIndex;


### PR DESCRIPTION
Ships the self-contained half of #2731 — findings 5a–5g, seven optional fields advertised in a public type and never read.

**Findings 1, 2 and 3 are deliberately not here.** louistrue marked each as needing a decision (the batch ramp-up, `GeometryQuality`, and the scale-bar/north-arrow renderer split), and each changes behaviour. This PR does not imply #2731 is resolved — 10 of its 11 findings remain open.

## Deprecated, not deleted

Following the maintainer's stated lean. Deleting an optional field an embedder passes turns a silent no-op into a TS compile error, which is a breaking change nobody has agreed to. Each JSDoc opens with **"Declared but never read"**, states what actually happens, and either names the substitute (5d → `screenSnapRadius`) or says explicitly there is none. "Slated for removal; see #2731", with no timeline the repo has not agreed.

Three `docs/guide/rendering.md` snippets that advertised `snapRadius: 0.1, // 10cm world units` and listed `enableDepthTest` under "Performance" are annotated too — the docs were selling the same fields.

## All seven re-grepped, none live

Line numbers in the issue had moved, so every location was re-established rather than trusted.

| # | field | current location | evidence |
|---|---|---|---|
| 5a | `SVGExportOptions.units` | `drawing-2d/src/svg-exporter.ts:63` | `export()` at :104 never destructures it |
| 5b | `keepBoundarySegments` | `drawing-2d/src/openings/opening-filter.ts:28` | 2 hits repo-wide: declaration + default |
| 5c | `DoorSymbolConfig.showThreshold` | `drawing-2d/src/symbols/door-symbol.ts:48` | 2 hits: declaration + default |
| 5d | `SnapOptions.snapRadius` | `renderer/src/snap-detector.ts:36` | all checks use `screenSnapRadius` (:146, :209) |
| 5e | `SectionPlaneRenderOptions.flipped` | `renderer/src/section-plane.ts:20` | occurs once in the file — its own declaration |
| 5f | `RenderOptions.enableDepthTest` | `renderer/src/types.ts:207` | 2 hits: declaration + a docs snippet |
| 5g | `onMetadataBootstrap` | `geometry/src/platform-bridge.ts:117` | **1 hit repo-wide**; siblings `onBatch`/`onColorUpdate`/`onComplete`/`onError` all dispatch in `native-bridge.ts` |

## Two corrections to the audit, both verified

- **5g is not in `scripts/api-surface.json`.** That snapshot records exported *names* only — `"StreamingOptions: interface"` at :1904, no members — which is also why a JSDoc change cannot drift it.
- **5b and 5c are required fields, not optional** (their constructors take `Partial<…>`). Deleting them would have broken more than the audit assumed, which strengthens the deprecate-first call rather than weakening it.

## Gates

Full `pnpm turbo run build --filter="./packages/*"` (45/45) before both checks, since a stale `dist` makes either report a confident wrong answer.

- `check-api-surface.mjs` — **green, snapshot untouched**: 42 packages, 63 export surfaces, 4191 exports
- `check-unused-locals.mjs` — green, 956 known, none increased
- `pnpm lint` — 0 errors
- `tsc --noEmit` — clean in all three touched packages
- tests unchanged: `drawing-2d` 371, `renderer` 956, `geometry` 342

**A trap worth recording:** `packages/geometry` shows **6 failed files / 2 failed tests on a completely unmodified tree** until `turbo run build` has run, because it resolves siblings through `dist`. Baseline taken post-build. Anyone measuring that package cold will misread it as a regression.

Changeset written (patch, three packages): `AGENTS.md:68` states the rule unqualified, and JSDoc is emitted into the published `.d.ts`, so consumers see these deprecations in their editors. Patch rather than minor because the surface does not shrink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
