### PR TITLE
fix(embed): make SET_CAMERA, RESET_COLORS and ENTITY_HOVERED actually work (#2934)

### DIFF
--- a/.changeset/embed-set-camera-reset-colors-entity-hovered.md
+++ b/.changeset/embed-set-camera-reset-colors-entity-hovered.md
@@ -1,0 +1,39 @@
+---
+'@ifc-lite/renderer': minor
+'@ifc-lite/embed-protocol': patch
+'@ifc-lite/embed-sdk': patch
+---
+
+Three embed API commands that reported success while doing nothing now work
+(#2934). Each was broken at a different link in the chain.
+
+`SET_CAMERA` had no actuator. The handler called the store's
+`setCameraRotation`, which was `set({ cameraRotation })` and nothing more —
+every orientation entry point on the camera was either relative (`orbit`, the
+90° rotate steppers) or named a direction (`setPresetView`), so an absolute
+azimuth/elevation pair had nothing to reach. The host got a `requestId` ack
+*and* a `CAMERA_CHANGED` echo of its own numbers back, while the view never
+moved. `Camera.setRotation(azimuth, elevation)` is new on `@ifc-lite/renderer`
+— the exact inverse of `Camera.getRotation`, absolute and idempotent, keeping
+the target and orbit distance, with the same pole clamp `orbit` uses — and the
+store action now drives it the way `setProjectionMode` drives its own callback.
+
+`RESET_COLORS` cleared the wrong channel, in both directions at once.
+`SET_COLORS` bakes into the mesh colors, while `clearPendingColorUpdates`
+empties the transient overlay channel the lens, IDS, clash and schedule
+overlays own: the host's own override survived the reset, and another
+subsystem's state was destroyed by it. `SET_COLORS` now marks its writes as an
+override, which captures the colors it displaces, and `RESET_COLORS` restores
+those and leaves the overlay channel alone. The loader's own IFC style pass is
+deliberately not treated as an override, so a reset restores the model's IFC
+colors rather than stripping them.
+
+`ENTITY_HOVERED` was declared, exposed by the SDK, and never emitted — the SDK
+tests passed because they fabricated the event themselves. The viewer's hover
+pipeline was already there but gated behind a toolbar toggle the embed has no
+chrome to offer; the embed now enables it and emits on each hover-target
+change.
+
+`SET_CAMERA`'s `zoom` field remains unapplied and is now documented as
+reserved rather than silently dropped: it has no defined meaning on the viewer
+side, and guessing one is worse than saying so.

--- a/.changeset/embed-set-camera-reset-colors-entity-hovered.md
+++ b/.changeset/embed-set-camera-reset-colors-entity-hovered.md
@@ -28,6 +28,19 @@ those and leaves the overlay channel alone. The loader's own IFC style pass is
 deliberately not treated as an override, so a reset restores the model's IFC
 colors rather than stripping them.
 
+For integrators, that second half is a behaviour change on a published surface
+and not only a fix: `RESET_COLORS` no longer clears `pendingColorUpdates`. A
+host that had been sending it to clear a lens, IDS, clash or schedule overlay
+was relying on a side effect that is now gone, and must clear that overlay
+through the command that owns it. `RESET_COLORS` only undoes `SET_COLORS`.
+
+Also worth knowing before you rely on it: `RESET_COLORS` restores the entities
+the viewer holds in its primary `geometryResult`, which is the FIRST loaded
+model. In a federated embed with more than one model, `SET_COLORS` still
+colours entities in the later models and `RESET_COLORS` does not restore them,
+while both commands ack success. Single-model embeds — the common case — are
+unaffected.
+
 `ENTITY_HOVERED` was declared, exposed by the SDK, and never emitted — the SDK
 tests passed because they fabricated the event themselves. The viewer's hover
 pipeline was already there but gated behind a toolbar toggle the embed has no

--- a/.changeset/embed-set-camera-reset-colors-entity-hovered.md
+++ b/.changeset/embed-set-camera-reset-colors-entity-hovered.md
@@ -50,3 +50,38 @@ change.
 `SET_CAMERA`'s `zoom` field remains unapplied and is now documented as
 reserved rather than silently dropped: it has no defined meaning on the viewer
 side, and guessing one is worse than saying so.
+
+**RESET_COLORS restored the previous model's colours onto the current one.** `meshColorBackup` holds each element's ORIGINAL colour so the reset can put it back, and it was cleared in exactly one place, `resetMeshColors` itself, and in no teardown path. Its keys are global express ids and those are reused across a model swap, so a backup that outlived its model did not go inert: it named live elements of the next one, and `resetMeshColors` queued the departed model's colours into `pendingMeshColorUpdates` for the renderer to upload.
+
+Reproduced against the real store before fixing: load A with entity 12 red, override it, `resetViewerState()`, load B with entity 12 blue, reset. Entity 12 came back A's red.
+
+The map is also first-write-wins, so one leaked entry was permanent. A later override on the new model declined to record that element's real colour, because the id was already present, and every reset from then on restored the wrong one. It corrupted the feature for the rest of the session rather than for one reset.
+
+Cleared now in `resetViewerState`, `removeModel` and `clearAllModels`, and the three are not the same clear.
+
+`resetViewerState` and `clearAllModels` drop the map whole, because both restart the id space: `clearAllModels` calls `federationRegistry.clear()`, offsets go back to 0, and the next model genuinely is handed the ids the last one used.
+
+`removeModel` purges only the removed model's entries, via `resolveGlobalIdInModel`, the owner-scoped resolver this slice already provides for exactly this question. Dropping the map whole there would take the SURVIVING models' undo with it, and it is not needed for them: `unregisterModel` BURNS the removed range rather than reclaiming it, so no later model can be handed those ids. An earlier draft of this fix did drop it whole, and the effect was worse than the bug in one respect: with a live override on a model that was not the one removed, `resetMeshColors` then had nothing to restore from, leaving the store and the GPU out of step with no action left to reconcile them.
+
+**Module-size budgets, recorded deliberately and with the reason.** The gate that landed in #3045 requires either a split or a written justification for a raise, so here is the justification.
+
+Seven files are raised and one row is added. Two of the raises are this fix's own lines, four in `store/index.ts` and thirteen in `store/slices/modelSlice.ts`; the other five and the new row are this PR's feature growth (`camera.ts` +71, `dataSlice.ts` +81, `EmbedViewer.tsx` +39, `types.ts` +12, `Viewport.tsx` +9, `handler.ts` +7).
+
+Splitting was considered and rejected for `dataSlice.ts`, which is the one that matters: it crosses 400 for the first time, at 471. It is a Zustand `StateCreator` returning a single object literal, so dividing it is a restructure of the slice's shape rather than a file move, and doing that inside a bug-fix PR trades a contained change for a broad one. **That is debt, not a resolution**, and it should be split on its own.
+
+One hazard worth naming for whoever resolves the next conflict here: `--update` re-records EVERY row that changed, not only the ones a PR touches. It silently pulled two rows for `packages/cli` and `packages/mcp` into this diff, packages this change never opens. Both are restored and the pin recomputed by hand, so the allowlist diff names only files this PR actually grows.
+
+Worth stating for whoever tunes this gate next: **312 of its 314 rows sit at exactly their measured size on main.** A one-line fix to any of them trips it. This PR's two-line teardown fix did, and every future fix to an allowlisted file will arrive needing a split or a raise.
+
+
+**One thing left standing, deliberately.** `pendingMeshRemovals`, `pendingMeshTranslations` and `pendingMeshRotations` are id-keyed exactly like `meshColorBackup` and are cleared in no teardown path either. `pendingMeshRemovals` is worse than the others, because it ACCUMULATES (`new Set(state.pendingMeshRemovals ?? [])`) rather than being overwritten, so a survivor merges into the next model's removals. `clearAllModels` also clears the backup but not `pendingMeshColorUpdates`, on the one path where offsets really do restart. All of that is pre-existing and none of it is what this PR broke, so it is named here rather than folded in.
+
+**A fourth path leaked the backup, and it is the one an embed host hits.** The three teardown clears above do not cover `setGeometryResult` REPLACING geometry, and `useIfcFederation` calls exactly that on an ACTIVE-MODEL SWITCH: no reset, no removal. So switching models left the backup pointing at the model you came from. Reproduced, then fixed by clearing when the geometry's identity changes; a redundant set of the same object keeps a live undo, which is the mistake the `removeModel` clear made in its first draft.
+
+That one was found by review on 2026-08-22, before this round started, and it is worth saying plainly that the three clears alone would have shipped looking complete.
+
+**`SET_CAMERA` acked before the renderer existed.** `setCameraRotation` calls the actuator optionally and then records the pose, and `setCameraCallbacks` only stored the callbacks. An embed host sending SET_CAMERA before `Viewport`'s effect registers gets a success ack and a camera that never moves: success reported for something that did not happen. A rotation accepted with no actuator is now held and replayed on registration, and an already-applied one is not replayed, so registering a second renderer cannot re-fire it.
+
+**`Camera.setRotation` propagated a non-finite TARGET.** The existing guard rejects non-finite ANGLES, and `isUsableDistance` rescues the radius, but every position component is `target.<axis> + ...` and `setTarget` accepts non-finite coordinates. One NaN there made the whole pose NaN, in a method whose contract is that it RECOVERS a pose. It now refuses, the same way it refuses non-finite angles.
+
+**Two review findings are deferred rather than fixed, with reasons.** `dataSlice.test.ts` carries 19 `as any` casts on its mesh fixtures; typing the fixture properly is the right fix and is test-hygiene work on this PR's own suite rather than anything the fixes above touch. And the `ENTITY_HOVERED` tests cover only model-free ids, so the single-model and N-model federation cases are genuinely uncovered. Both are real; neither is a correctness defect, and folding either in would grow a change that has already grown three times.

--- a/apps/viewer-embed/src/bridge/handler.effects.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.effects.test.ts
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `SET_CAMERA` / `SET_COLORS` / `RESET_COLORS` against the REAL store slices.
+ *
+ * `handler.test.ts` drives a recording double of the store, which is the right
+ * shape for "did the bridge dispatch the right thing" but is structurally
+ * blind to the failure these three commands actually had (#2934): the handler
+ * called a real store action, the action existed, and the action did nothing.
+ * A double records the call and passes.
+ *
+ * So this file wires the handler to `createDataSlice` / `createCameraSlice`
+ * themselves and asserts the EFFECT — the mesh color that comes back, the
+ * orientation that reaches the camera actuator, the overlay channel that is
+ * still intact afterwards.
+ */
+
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+// Same narrow stand-in handler.test.ts uses: the bridge needs exactly one
+// function from the store barrel, and importing the real barrel would drag in
+// zustand + renderer + wasm. The slice creators below are imported directly,
+// so the store logic under test is the real thing.
+vi.mock('@/store/index.js', () => ({
+  toGlobalIdFromModels: (
+    _models: ReadonlyMap<string, { idOffset?: number }>,
+    _modelId: string,
+    expressId: number,
+  ): number => expressId,
+}));
+
+import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
+import { createDataSlice } from '@/store/slices/dataSlice.js';
+import { createCameraSlice } from '@/store/slices/cameraSlice.js';
+import type { CameraRotation } from '@/store/types.js';
+import { initBridge, destroyBridge } from './handler.js';
+
+// ---------------------------------------------------------------------------
+// Window double (postMessage in, postMessage out)
+// ---------------------------------------------------------------------------
+
+function installWindow() {
+  const listeners = new Set<(e: unknown) => void>();
+  const win: any = {
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type === 'message') listeners.add(fn);
+    },
+    removeEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type === 'message') listeners.delete(fn);
+    },
+  };
+  win.parent = { postMessage: () => { /* replies are not the subject here */ } };
+  (globalThis as any).window = win;
+  return {
+    dispatch: (data: unknown) => {
+      for (const fn of [...listeners]) fn({ data, origin: 'https://host.example', source: win.parent });
+    },
+  };
+}
+
+function cmd(type: string, data?: unknown) {
+  return { source: EMBED_SOURCE, version: PROTOCOL_VERSION, type, data, requestId: 'r1' };
+}
+
+// ---------------------------------------------------------------------------
+// Real slices, composed the way the store composes them
+// ---------------------------------------------------------------------------
+
+const mesh = (expressId: number, color: [number, number, number, number]) => ({
+  expressId,
+  positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+  indices: new Uint32Array([0, 1, 2]),
+  normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+  color,
+  ifcType: 'IfcWall',
+});
+
+function makeRealState() {
+  const rotations: CameraRotation[] = [];
+  let state: any;
+  const set = (partial: any) => {
+    const updates = typeof partial === 'function' ? partial(state) : partial;
+    state = { ...state, ...updates };
+  };
+  const get = () => state;
+
+  state = {
+    ...createDataSlice(set, get, undefined as never),
+    ...createCameraSlice(set, get, undefined as never),
+    activeModelId: null,
+    models: new Map(),
+    // Stand-in for the renderer-side actuator the Viewport registers
+    // (Viewport.tsx -> camera.setRotation). What it does with the angles is
+    // `packages/renderer/src/camera-absolute-rotation.test.ts`'s subject; what
+    // matters here is that the command reaches it at all.
+    cameraCallbacks: {
+      setCameraRotation: (rotation: CameraRotation) => { rotations.push(rotation); },
+    },
+  };
+
+  return {
+    rotations,
+    getState: () => state,
+  };
+}
+
+describe('bridge commands against the real store slices', () => {
+  let win: ReturnType<typeof installWindow>;
+  let store: ReturnType<typeof makeRealState>;
+
+  beforeEach(() => {
+    win = installWindow();
+    store = makeRealState();
+    initBridge({
+      getState: store.getState as never,
+      loadModelFromUrl: vi.fn(),
+      loadModelFromBuffer: vi.fn(),
+      addModelFromUrl: vi.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    destroyBridge();
+  });
+
+  describe('SET_CAMERA', () => {
+    it('reaches the camera actuator, not just the store field', () => {
+      // The whole defect: `setCameraRotation` wrote `cameraRotation` and
+      // stopped there, so the host got a success ack and a CAMERA_CHANGED echo
+      // of its own numbers while the view never moved.
+      win.dispatch(cmd('SET_CAMERA', { azimuth: 120, elevation: 30 }));
+
+      expect(store.rotations).toEqual([{ azimuth: 120, elevation: 30 }]);
+    });
+
+    it('records the new orientation in the store as well', () => {
+      win.dispatch(cmd('SET_CAMERA', { azimuth: 120, elevation: 30 }));
+
+      expect(store.getState().cameraRotation).toEqual({ azimuth: 120, elevation: 30 });
+    });
+  });
+
+  describe('RESET_COLORS', () => {
+    it('actually restores the color SET_COLORS baked in', () => {
+      store.getState().appendGeometryBatch([mesh(12, [1, 0, 0, 1])] as never);
+
+      win.dispatch(cmd('SET_COLORS', { colorMap: { '12': [0, 1, 0, 1] } }));
+      expect(store.getState().geometryResult.meshes[0].color).toEqual([0, 1, 0, 1]);
+
+      win.dispatch(cmd('RESET_COLORS'));
+
+      expect(store.getState().geometryResult.meshes[0].color).toEqual([1, 0, 0, 1]);
+      // And the renderer is told to re-upload the restored color, otherwise the
+      // GPU keeps showing the override.
+      expect(store.getState().pendingMeshColorUpdates.get(12)).toEqual([1, 0, 0, 1]);
+    });
+
+    it('leaves another subsystem\'s overlay colors intact', () => {
+      // `pendingColorUpdates` is the lens / IDS / clash / schedule overlay
+      // channel. RESET_COLORS used to clear exactly this and nothing else —
+      // wrong in both directions at once: the host's own override survived,
+      // and an overlay owner's state was destroyed.
+      store.getState().appendGeometryBatch([mesh(12, [1, 0, 0, 1])] as never);
+      store.getState().setPendingColorUpdates(new Map([[12, [1, 1, 0, 1]]]));
+
+      win.dispatch(cmd('SET_COLORS', { colorMap: { '12': [0, 1, 0, 1] } }));
+      win.dispatch(cmd('RESET_COLORS'));
+
+      expect(store.getState().pendingColorUpdates.get(12)).toEqual([1, 1, 0, 1]);
+    });
+  });
+});

--- a/apps/viewer-embed/src/bridge/handler.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.test.ts
@@ -169,6 +169,7 @@ function makeState() {
     showAllInAllModels: rec('showAllInAllModels'),
     updateMeshColors: rec('updateMeshColors'),
     clearPendingColorUpdates: rec('clearPendingColorUpdates'),
+    resetMeshColors: rec('resetMeshColors'),
     setCameraRotation: rec('setCameraRotation'),
     setSectionPlaneAxis: rec('setSectionPlaneAxis'),
     setSectionPlanePosition: rec('setSectionPlanePosition'),
@@ -814,15 +815,24 @@ describe('selection and visibility commands', () => {
   it('SET_COLORS converts string keys to numeric entity ids', async () => {
     initBridge(makeCtx(state));
     await send(fw, cmd('SET_COLORS', { colorMap: { '12': [1, 0, 0, 1] } }, 'r1'));
-    const [updates] = argsOf(state, 'updateMeshColors') as [Map<number, unknown>];
+    const [updates, options] = argsOf(state, 'updateMeshColors') as [Map<number, unknown>, { override?: boolean }];
     expect([...updates.keys()]).toEqual([12]);
     expect(updates.get(12)).toEqual([1, 0, 0, 1]);
+    // Marked as an override so the displaced colors are captured and
+    // RESET_COLORS can put them back.
+    expect(options).toEqual({ override: true });
   });
 
-  it('RESET_COLORS clears pending updates', async () => {
+  it('RESET_COLORS undoes the SET_COLORS bake and leaves the overlay channel alone', async () => {
     initBridge(makeCtx(state));
     await send(fw, cmd('RESET_COLORS', undefined, 'r1'));
-    expect(called(state, 'clearPendingColorUpdates')).toBe(true);
+    // `resetMeshColors` restores what SET_COLORS baked into
+    // geometryResult.meshes[].color. `clearPendingColorUpdates` is the
+    // lens/IDS/clash overlay channel — a different subsystem's state, which
+    // this command must not touch (#2934). See handler.effects.test.ts for the
+    // same pair asserted on the real slices rather than on this double.
+    expect(called(state, 'resetMeshColors')).toBe(true);
+    expect(called(state, 'clearPendingColorUpdates')).toBe(false);
   });
 
   it('SET_TYPE_VISIBILITY toggles only the flags that actually differ', async () => {

--- a/apps/viewer-embed/src/bridge/handler.ts
+++ b/apps/viewer-embed/src/bridge/handler.ts
@@ -375,13 +375,20 @@ async function handleCommand(type: InboundCommandType, data: unknown, requestId?
       for (const [key, color] of Object.entries(payload.colorMap)) {
         updates.set(Number(key), color);
       }
-      state.updateMeshColors(updates);
+      // `override` so the displaced colors are captured and RESET_COLORS can
+      // put them back.
+      state.updateMeshColors(updates, { override: true });
       if (requestId) emitToParent(createResponse(requestId));
       return;
     }
 
     case 'RESET_COLORS': {
-      state.clearPendingColorUpdates();
+      // Undo SET_COLORS: restore the colors it baked into
+      // geometryResult.meshes[].color. Deliberately NOT
+      // clearPendingColorUpdates() — that is the separate lens/IDS/clash/
+      // schedule overlay channel, which SET_COLORS never writes to and this
+      // command has no claim on.
+      state.resetMeshColors();
       if (requestId) emitToParent(createResponse(requestId));
       return;
     }

--- a/apps/viewer-embed/src/components/EmbedViewer.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.test.ts
@@ -171,3 +171,99 @@ describe('EmbedViewer: SET_SECTION emits SECTION_CHANGED to the parent', () => {
     });
   });
 });
+
+/**
+ * ENTITY_HOVERED is a declared OutboundEventType with SDK listener plumbing
+ * and SDK tests — and, before #2934, zero `emitEvent('ENTITY_HOVERED', ...)`
+ * call sites anywhere in this app. The SDK's tests pass because they call
+ * `harness.emit('ENTITY_HOVERED', ...)` themselves, which proves the SDK
+ * dispatches an event the viewer never sent.
+ *
+ * The viewer's hover pipeline is: pointermove -> throttled `renderer.pick()`
+ * -> `setHoverState(...)` (apps/viewer/src/components/viewer/useMouseControls.ts
+ * ~703), with that whole branch gated on `hoverTooltipsEnabled`. These tests
+ * enter at `setHoverState` — the store action the pick path calls — and assert
+ * what reaches `window.parent.postMessage`, covering both remaining links: the
+ * gate the embed has to force on, and the emit. Driving `renderer.pick()`
+ * itself needs a real WebGPU device and is out of reach here.
+ */
+describe('EmbedViewer: emits ENTITY_HOVERED from the viewer hover pipeline', () => {
+  afterEach(() => {
+    useViewerStore.getState().clearHover();
+  });
+
+  it('forces hoverTooltipsEnabled on, without which the pick path never runs', () => {
+    // Defaults to false (UI_DEFAULTS.HOVER_TOOLTIPS_ENABLED) — a main-viewer
+    // toolbar toggle the embed has no chrome to offer.
+    useViewerStore.setState({ hoverTooltipsEnabled: false });
+
+    renderEmbedViewer();
+
+    expect(useViewerStore.getState().hoverTooltipsEnabled).toBe(true);
+  });
+
+  it('posts ENTITY_HOVERED to the parent when the pick path reports a hovered entity', () => {
+    const posted: EmbedMessageEnvelope[] = [];
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: { postMessage: (msg: EmbedMessageEnvelope) => posted.push(msg) },
+    });
+
+    renderEmbedViewer();
+    // emitToParent withholds every non-READY message until a concrete
+    // parentOrigin is captured from a real inbound message — establish that
+    // first, same as the SET_SECTION test above.
+    dispatchInbound({ type: 'SET_THEME', data: { theme: 'light' } });
+
+    act(() => {
+      // Exactly what useMouseControls does with a pick hit.
+      useViewerStore.getState().setHoverState({ entityId: 42, screenX: 10, screenY: 20 });
+    });
+
+    const hovered = posted.find((m) => m.type === 'ENTITY_HOVERED');
+    expect(hovered?.data).toEqual({ id: 42, globalId: undefined, ifcType: undefined });
+  });
+
+  it('does not re-post for the same entity as the pointer drifts across it', () => {
+    const posted: EmbedMessageEnvelope[] = [];
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: { postMessage: (msg: EmbedMessageEnvelope) => posted.push(msg) },
+    });
+
+    renderEmbedViewer();
+    dispatchInbound({ type: 'SET_THEME', data: { theme: 'light' } });
+
+    act(() => {
+      useViewerStore.getState().setHoverState({ entityId: 42, screenX: 10, screenY: 20 });
+    });
+    act(() => {
+      // Same entity, new screen position — every throttled mousemove within
+      // one mesh produces this.
+      useViewerStore.getState().setHoverState({ entityId: 42, screenX: 11, screenY: 21 });
+    });
+
+    expect(posted.filter((m) => m.type === 'ENTITY_HOVERED').length).toBe(1);
+  });
+
+  it('posts again once the pointer moves onto a different entity', () => {
+    const posted: EmbedMessageEnvelope[] = [];
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: { postMessage: (msg: EmbedMessageEnvelope) => posted.push(msg) },
+    });
+
+    renderEmbedViewer();
+    dispatchInbound({ type: 'SET_THEME', data: { theme: 'light' } });
+
+    act(() => {
+      useViewerStore.getState().setHoverState({ entityId: 42, screenX: 10, screenY: 20 });
+    });
+    act(() => {
+      useViewerStore.getState().setHoverState({ entityId: 43, screenX: 30, screenY: 40 });
+    });
+
+    expect(posted.filter((m) => m.type === 'ENTITY_HOVERED').map((m) => (m.data as { id: number }).id))
+      .toEqual([42, 43]);
+  });
+});

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -46,6 +46,19 @@ export function EmbedViewer() {
     setTheme(urlParams.theme === 'dark' ? 'dark' : 'light');
   }, [urlParams.theme, setTheme]);
 
+  // Force hover picking on. `hoverState` (apps/viewer/src/store/slices/
+  // hoverSlice.ts) is populated by useMouseControls.ts's throttled
+  // renderer.pick() on mousemove — the same pipeline the main viewer uses —
+  // but that whole branch is gated behind `hoverTooltipsEnabled`, which
+  // defaults to false (a toolbar toggle). The embed has no toolbar to flip it,
+  // and the ENTITY_HOVERED effect below needs `hoverState` to ever populate.
+  // Safe to force on here: the embed shell never renders <HoverTooltip> (it
+  // lives in ViewerLayout, which the embed doesn't use), so this activates the
+  // picking pipeline only — no tooltip UI appears.
+  useEffect(() => {
+    useViewerStore.setState({ hoverTooltipsEnabled: true });
+  }, []);
+
   // Initialize the postMessage bridge.
   //
   // Guarded via mountBridgeLifecycle/unmountBridgeLifecycle so a React 19
@@ -236,6 +249,32 @@ export function EmbedViewer() {
       emitEvent('ENTITY_DESELECTED', undefined);
     }
   }, [selectedEntityId]);
+
+  // Emit hover events to parent. ENTITY_HOVERED is declared in the protocol
+  // and exposed by the SDK, but nothing in this app ever emitted it — the
+  // SDK's tests pass because they fabricate the event themselves (#2934).
+  //
+  // Subscribes to `hoverState.entityId` specifically, not the whole
+  // `hoverState` object: screenX/screenY/worldXYZ change on every
+  // hover-throttled mousemove even while the pointer stays on the same mesh,
+  // so selecting the object would re-post the event continuously instead of
+  // only on a hover-target change. The protocol declares no ENTITY_UNHOVERED
+  // counterpart to ENTITY_DESELECTED, so null (nothing hovered) is tracked but
+  // never emitted.
+  const hoveredEntityId = useViewerStore((s) => s.hoverState.entityId);
+  useEffect(() => {
+    if (hoveredEntityId === null) return;
+
+    const state = useViewerStore.getState();
+    const lookup = state.resolveGlobalIdFromModels(hoveredEntityId);
+    const model = lookup ? state.models.get(lookup.modelId) : undefined;
+    const entities = model?.ifcDataStore?.entities;
+    emitEvent('ENTITY_HOVERED', {
+      id: hoveredEntityId,
+      globalId: entities?.getGlobalId(lookup?.expressId ?? hoveredEntityId) ?? undefined,
+      ifcType: entities?.getTypeName(lookup?.expressId ?? hoveredEntityId) ?? undefined,
+    });
+  }, [hoveredEntityId]);
 
   // Emit camera rotation changes to parent (throttled)
   const cameraRotation = useViewerStore((s) => s.cameraRotation);

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -1075,6 +1075,15 @@ export function Viewport({
           renderCurrent();
           calculateScale();
         },
+        setCameraRotation: ({ azimuth, elevation }) => {
+          // Absolute counterpart to rotateLeft/rotateRight below (which step by
+          // 90° from wherever the camera already is). Snaps rather than
+          // animates: the caller is a host command that may arrive at slider
+          // rate, and a tween per message would queue up behind itself.
+          camera.setRotation(azimuth, elevation);
+          renderCurrent();
+          calculateScale();
+        },
         rotateLeft: () => {
           animateHorizontalRotation(-Math.PI / 2);
         },

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -334,6 +334,10 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
       error: null,
       pendingColorUpdates: null,
       pendingMeshColorUpdates: null,
+      // The backup those two restore FROM. Ids collide across models, so
+      // surviving a swap made RESET_COLORS paint the old model's colours onto
+      // the new one; first-write-wins made every later reset wrong too.
+      meshColorBackup: null,
       // Drop any undrained GPU-instancing shards from the previous model so they
       // can't be uploaded into the new scene under a rapid model switch.
       pendingInstancedShards: null,

--- a/apps/viewer/src/store/meshColorBackup-stale.test.ts
+++ b/apps/viewer/src/store/meshColorBackup-stale.test.ts
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `dataSlice.meshColorBackup` holds each element's ORIGINAL colour so
+ * `resetMeshColors` can put it back after a SET_COLORS override. It was cleared
+ * in exactly one place, `resetMeshColors` itself, and in no teardown path.
+ *
+ * Its keys are global express ids, and those are REUSED across a model swap, so
+ * a backup that outlives its model does not go inert: it names live elements of
+ * the next one. `resetMeshColors` then queues the departed model's colours into
+ * `pendingMeshColorUpdates`, which the renderer uploads.
+ *
+ * The map is also first-write-wins (`if (!meshColorBackup.has(id))` in
+ * `updateMeshColors`), so a single leaked entry is permanent: a later override
+ * on the NEW model declines to record that element's real colour, and every
+ * reset from then on restores the old one. One stale entry corrupts the feature
+ * for the rest of the session, not just for one reset.
+ *
+ * These run against the REAL combined store, same harness shape as
+ * `clearAllModels-overlay-stale.test.ts` and the `removeModel-*-stale` family.
+ */
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { useViewerStore } from './index.js';
+import type { CameraRotation } from './types.js';
+import type { FederatedModel } from './types.js';
+
+/** Same shape the `removeModel-*-stale` siblings use: the id RANGES are what
+ *  `resolveGlobalIdInModel` reads, so a stub without them makes every scoped
+ *  purge a silent no-op and the test pass for the wrong reason. */
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+type Colour = [number, number, number, number];
+
+const RED: Colour = [1, 0, 0, 1];
+const GREEN: Colour = [0, 1, 0, 1];
+const BLUE: Colour = [0, 0, 1, 1];
+
+const meshOf = (expressId: number, color: Colour) => ({
+  expressId,
+  color,
+  positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+  indices: new Uint32Array([0, 1, 2]),
+  normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+  ifcType: 'IfcWall',
+});
+
+/** Load a model whose entity 12 has `color`, then override it, which is what
+ *  captures the ORIGINAL into the backup. */
+function loadAndOverride(color: Colour): void {
+  const s = useViewerStore.getState();
+  s.setGeometryResult({ meshes: [meshOf(12, color)] } as never);
+  s.updateMeshColors(new Map([[12, GREEN]]), { override: true });
+}
+
+describe('meshColorBackup does not outlive the model it describes', () => {
+  beforeEach(() => {
+    useViewerStore.setState({ meshColorBackup: null, pendingMeshColorUpdates: null } as never);
+  });
+
+  it('resetViewerState drops it, so a swapped-in model keeps its own colours', () => {
+    loadAndOverride(RED);
+    assert.deepStrictEqual(
+      [...(useViewerStore.getState().meshColorBackup ?? [])],
+      [[12, RED]],
+      'the override should have captured the original red',
+    );
+
+    // The primary-load swap path: reset, drop the geometry, load a new model
+    // whose entity 12 is a DIFFERENT colour.
+    useViewerStore.getState().resetViewerState();
+    assert.strictEqual(
+      useViewerStore.getState().meshColorBackup,
+      null,
+      'the previous model’s backup survived the reset',
+    );
+
+    useViewerStore.getState().setGeometryResult({ meshes: [meshOf(12, BLUE)] } as never);
+    useViewerStore.getState().resetMeshColors();
+
+    const queued = useViewerStore.getState().pendingMeshColorUpdates;
+    assert.strictEqual(
+      queued === null || !queued.has(12),
+      true,
+      `RESET_COLORS queued ${JSON.stringify(queued ? [...queued] : null)} for the new model; `
+        + 'a red entry here is the previous model’s colour being uploaded to this one',
+    );
+  });
+
+  it('a geometry REPLACE drops it, and a redundant set of the same object does not', () => {
+    // The path CodeRabbit named and the three teardown clears do not cover:
+    // `useIfcFederation` calls `setGeometryResult` on an ACTIVE-MODEL SWITCH,
+    // with no reset and no removal, so the backup outlived the swap there too.
+    loadAndOverride(RED);
+    assert.deepStrictEqual([...(useViewerStore.getState().meshColorBackup ?? [])], [[12, RED]]);
+
+    useViewerStore.getState().setGeometryResult({ meshes: [meshOf(12, BLUE)] } as never);
+    assert.strictEqual(useViewerStore.getState().meshColorBackup, null, 'the replace should have dropped it');
+
+    // And the new model's own override is now recordable. Before the fix the
+    // stale entry made this a no-op, because the map is first-write-wins.
+    useViewerStore.getState().updateMeshColors(new Map([[12, GREEN]]), { override: true });
+    assert.deepStrictEqual(
+      [...(useViewerStore.getState().meshColorBackup ?? [])],
+      [[12, BLUE]],
+      'the new model’s original colour should be what gets backed up',
+    );
+
+    // A redundant set of the SAME object must not destroy a live undo. This is
+    // the mistake the removeModel clear made in its first draft.
+    const same = useViewerStore.getState().geometryResult;
+    useViewerStore.getState().setGeometryResult(same);
+    assert.deepStrictEqual([...(useViewerStore.getState().meshColorBackup ?? [])], [[12, BLUE]]);
+  });
+
+  it('removeModel purges only the removed model’s entries', () => {
+    // Scoped, not wholesale. `unregisterModel` BURNS the removed range rather
+    // than reclaiming it, so a surviving model can never be handed these ids
+    // and its own undo has to survive. Dropping the map whole left the store
+    // and the GPU permanently out of step, with no action left to reconcile
+    // them: `resetMeshColors` had nothing to restore from.
+    loadAndOverride(RED);
+    const backup = useViewerStore.getState().meshColorBackup;
+    assert.ok(backup, 'the override should have populated the backup');
+    assert.strictEqual(backup.has(12), true);
+
+    // 'gone' owns [0, 1000] so it owns id 12; 'kept' owns [900000, 901000].
+    useViewerStore.setState({
+      meshColorBackup: new Map([...backup, [900_500, BLUE]]),
+      models: new Map([
+        ['gone', model('gone', 0, 1_000)],
+        ['kept', model('kept', 900_000, 1_000)],
+      ]),
+    } as never);
+
+    useViewerStore.getState().removeModel('gone');
+
+    const after = useViewerStore.getState().meshColorBackup;
+    assert.ok(after, 'the surviving model’s entry was dropped with the removed model’s');
+    // Both halves. Without the first, removing the purge entirely still passes;
+    // without the second, purging wholesale still passes.
+    assert.strictEqual(after.has(12), false, 'the removed model’s entry should be gone');
+    assert.strictEqual(after.has(900_500), true, 'the surviving model’s entry should remain');
+  });
+
+  it('clearAllModels drops it', () => {
+    loadAndOverride(RED);
+    useViewerStore.getState().clearAllModels();
+    assert.strictEqual(useViewerStore.getState().meshColorBackup, null);
+  });
+});
+
+describe('a camera rotation accepted before the renderer registers is replayed', () => {
+  it('does not report success for a rotation that never reached the camera', () => {
+    // The embed bridge acks SET_CAMERA and returns regardless of whether
+    // `Viewport`'s effect has registered its callbacks yet. Before this, the
+    // pose was recorded in state and never actuated: success reported for
+    // something that did not happen.
+    useViewerStore.setState({ cameraCallbacks: {}, pendingCameraRotation: null } as never);
+
+    useViewerStore.getState().setCameraRotation({ azimuth: 120, elevation: 30 });
+    assert.deepStrictEqual(
+      useViewerStore.getState().pendingCameraRotation,
+      { azimuth: 120, elevation: 30 },
+      'a rotation with no actuator should be held for replay',
+    );
+
+    const seen: CameraRotation[] = [];
+    useViewerStore.getState().setCameraCallbacks({
+      setCameraRotation: (r: CameraRotation) => { seen.push(r); },
+    } as never);
+
+    assert.deepStrictEqual(seen, [{ azimuth: 120, elevation: 30 }], 'registration should replay it');
+    assert.strictEqual(useViewerStore.getState().pendingCameraRotation, null, 'and clear it');
+  });
+
+  it('does not replay one that already actuated', () => {
+    // The control: with an actuator present the command took effect, so there
+    // is nothing pending and registering a second renderer must not re-fire it.
+    const first: CameraRotation[] = [];
+    useViewerStore.setState({ pendingCameraRotation: null } as never);
+    useViewerStore.getState().setCameraCallbacks({
+      setCameraRotation: (r: CameraRotation) => { first.push(r); },
+    } as never);
+
+    useViewerStore.getState().setCameraRotation({ azimuth: 45, elevation: 10 });
+    assert.strictEqual(first.length, 1);
+    assert.strictEqual(useViewerStore.getState().pendingCameraRotation, null);
+
+    const second: CameraRotation[] = [];
+    useViewerStore.getState().setCameraCallbacks({
+      setCameraRotation: (r: CameraRotation) => { second.push(r); },
+    } as never);
+    assert.deepStrictEqual(second, [], 'an already-applied rotation must not replay');
+  });
+});

--- a/apps/viewer/src/store/slices/cameraSlice.test.ts
+++ b/apps/viewer/src/store/slices/cameraSlice.test.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `setCameraRotation` must ACTUATE, not just record.
+ *
+ * It used to be `set({ cameraRotation })` and nothing else, while its one
+ * caller — the embed bridge's `SET_CAMERA` handler — acked the command as
+ * successful and the outbound `CAMERA_CHANGED` echoed the host's own numbers
+ * straight back. Every success signal, no camera movement (#2934). The
+ * recording proxy over `cameraCallbacks` below is the same probe that showed
+ * zero callbacks being invoked; it now pins the opposite.
+ *
+ * `setProjectionMode` in this same slice is the established shape: drive the
+ * callback, then store the state.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { createCameraSlice, type CameraSlice } from './cameraSlice.js';
+import { CAMERA_DEFAULTS } from '../constants.js';
+
+describe('cameraSlice', () => {
+  let state: CameraSlice;
+  let calls: Array<[string, unknown]>;
+
+  function build(withCallbacks: boolean): void {
+    calls = [];
+    const set = (
+      partial: Partial<CameraSlice> | ((s: CameraSlice) => Partial<CameraSlice>),
+    ) => {
+      const updates = typeof partial === 'function' ? partial(state) : partial;
+      state = { ...state, ...updates };
+    };
+    const get = () => state;
+    state = createCameraSlice(set as never, get as never, undefined as never);
+    if (withCallbacks) {
+      state = {
+        ...state,
+        // Recording proxy over the callback surface the Viewport registers.
+        cameraCallbacks: {
+          setCameraRotation: (rotation) => calls.push(['setCameraRotation', rotation]),
+          setProjectionMode: (mode) => calls.push(['setProjectionMode', mode]),
+        },
+      };
+    }
+  }
+
+  beforeEach(() => build(true));
+
+  describe('setCameraRotation', () => {
+    it('drives the renderer through cameraCallbacks.setCameraRotation', () => {
+      state.setCameraRotation({ azimuth: 120, elevation: 30 });
+
+      assert.deepStrictEqual(calls, [['setCameraRotation', { azimuth: 120, elevation: 30 }]]);
+    });
+
+    it('still records the rotation in the store', () => {
+      state.setCameraRotation({ azimuth: 120, elevation: 30 });
+
+      assert.deepStrictEqual(state.cameraRotation, { azimuth: 120, elevation: 30 });
+    });
+
+    it('records the rotation even when no renderer has registered yet', () => {
+      // cameraCallbacks is `{}` until the Viewport mounts; the store write must
+      // not depend on the actuator existing.
+      build(false);
+
+      state.setCameraRotation({ azimuth: 15, elevation: 5 });
+
+      assert.deepStrictEqual(state.cameraRotation, { azimuth: 15, elevation: 5 });
+      assert.deepStrictEqual(calls, []);
+    });
+
+    it('starts from the shared camera defaults', () => {
+      assert.deepStrictEqual(state.cameraRotation, {
+        azimuth: CAMERA_DEFAULTS.AZIMUTH,
+        elevation: CAMERA_DEFAULTS.ELEVATION,
+      });
+    });
+  });
+
+  describe('updateCameraRotationRealtime', () => {
+    it('stays off the actuator — the per-frame path reports, it does not command', () => {
+      // This is the callback the live navigation loop drives on every frame.
+      // Routing it through the actuator would fight the very gesture that
+      // produced it.
+      state.setOnCameraRotationChange(() => {});
+      state.updateCameraRotationRealtime({ azimuth: 200, elevation: 10 });
+
+      assert.deepStrictEqual(calls, []);
+    });
+  });
+});

--- a/apps/viewer/src/store/slices/cameraSlice.ts
+++ b/apps/viewer/src/store/slices/cameraSlice.ts
@@ -21,6 +21,9 @@ export interface CameraSlice {
   // Actions
   setCameraRotation: (rotation: CameraRotation) => void;
   setCameraCallbacks: (callbacks: CameraCallbacks) => void;
+  /** A rotation accepted before any renderer was registered, replayed by
+   *  {@link setCameraCallbacks}. `null` once applied. */
+  pendingCameraRotation: CameraRotation | null;
   setProjectionMode: (mode: ProjectionMode) => void;
   toggleProjectionMode: () => void;
   setOnCameraRotationChange: (callback: ((rotation: CameraRotation) => void) | null) => void;
@@ -35,6 +38,7 @@ export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> =
     azimuth: CAMERA_DEFAULTS.AZIMUTH,
     elevation: CAMERA_DEFAULTS.ELEVATION,
   },
+  pendingCameraRotation: null,
   cameraCallbacks: {},
   projectionMode: 'perspective',
   onCameraRotationChange: null,
@@ -48,10 +52,20 @@ export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> =
   // This is the absolute-orientation path only; live navigation reports
   // through `updateCameraRotationRealtime`, which must NOT actuate.
   setCameraRotation: (cameraRotation) => {
-    get().cameraCallbacks.setCameraRotation?.(cameraRotation);
-    set({ cameraRotation });
+    const actuator = get().cameraCallbacks.setCameraRotation;
+    actuator?.(cameraRotation);
+    // If no renderer was registered yet the command was ACKED and nothing moved.
+    // An embed host can send SET_CAMERA before `Viewport`'s effect registers its
+    // callbacks, and `setCameraCallbacks` used to only store them, so the pose
+    // was recorded in state and never reached the camera: success reported for
+    // something that did not happen. Remember it and replay on registration.
+    set({ cameraRotation, pendingCameraRotation: actuator ? null : cameraRotation });
   },
-  setCameraCallbacks: (cameraCallbacks) => set({ cameraCallbacks }),
+  setCameraCallbacks: (cameraCallbacks) => {
+    const pending = get().pendingCameraRotation;
+    set({ cameraCallbacks, pendingCameraRotation: null });
+    if (pending) cameraCallbacks.setCameraRotation?.(pending);
+  },
   setProjectionMode: (projectionMode) => {
     get().cameraCallbacks.setProjectionMode?.(projectionMode);
     set({ projectionMode });

--- a/apps/viewer/src/store/slices/cameraSlice.ts
+++ b/apps/viewer/src/store/slices/cameraSlice.ts
@@ -41,7 +41,16 @@ export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> =
   onScaleChange: null,
 
   // Actions
-  setCameraRotation: (cameraRotation) => set({ cameraRotation }),
+  // Drive the renderer FIRST, then record — the same shape as
+  // setProjectionMode below. Recording alone is what made the embed API's
+  // SET_CAMERA inert: the store field was written, `CAMERA_CHANGED` echoed it
+  // back to the host as confirmation, and the camera never moved (#2934).
+  // This is the absolute-orientation path only; live navigation reports
+  // through `updateCameraRotationRealtime`, which must NOT actuate.
+  setCameraRotation: (cameraRotation) => {
+    get().cameraCallbacks.setCameraRotation?.(cameraRotation);
+    set({ cameraRotation });
+  },
   setCameraCallbacks: (cameraCallbacks) => set({ cameraCallbacks }),
   setProjectionMode: (projectionMode) => {
     get().cameraCallbacks.setProjectionMode?.(projectionMode);

--- a/apps/viewer/src/store/slices/dataSlice.test.ts
+++ b/apps/viewer/src/store/slices/dataSlice.test.ts
@@ -197,6 +197,98 @@ describe('DataSlice', () => {
     });
   });
 
+  /**
+   * `resetMeshColors` is what the embed API's `RESET_COLORS` undoes
+   * `SET_COLORS` with (#2934). It used to call `clearPendingColorUpdates`,
+   * which is a DIFFERENT channel: `SET_COLORS` bakes into
+   * `geometryResult.meshes[].color`, while `pendingColorUpdates` belongs to the
+   * lens / IDS / clash / schedule overlays. So the reset both failed to undo
+   * the override and destroyed a claim it did not own — the two directions
+   * asserted separately below.
+   */
+  describe('resetMeshColors', () => {
+    it('restores the pre-override mesh color and re-queues it for the renderer', () => {
+      const mesh = createMockMesh(1, [1, 0, 0, 1]); // original: red
+      state.appendGeometryBatch([mesh] as any);
+
+      const updates = new Map<number, [number, number, number, number]>([[1, [0, 1, 0, 1]]]);
+      state.updateMeshColors(updates, { override: true }); // SET_COLORS: green
+      assert.deepStrictEqual(state.geometryResult?.meshes[0].color, [0, 1, 0, 1]);
+
+      state.resetMeshColors();
+
+      assert.deepStrictEqual(state.geometryResult?.meshes[0].color, [1, 0, 0, 1]);
+      assert.deepStrictEqual(state.pendingMeshColorUpdates?.get(1), [1, 0, 0, 1]);
+      assert.strictEqual(state.meshColorBackup, null);
+    });
+
+    it('restores the ORIGINAL color across repeated overrides, not the last one', () => {
+      const mesh = createMockMesh(1, [1, 0, 0, 1]); // original: red
+      state.appendGeometryBatch([mesh] as any);
+
+      state.updateMeshColors(new Map([[1, [0, 1, 0, 1] as [number, number, number, number]]]), { override: true });
+      state.updateMeshColors(new Map([[1, [0, 0, 1, 1] as [number, number, number, number]]]), { override: true });
+
+      state.resetMeshColors();
+
+      assert.deepStrictEqual(state.geometryResult?.meshes[0].color, [1, 0, 0, 1]);
+    });
+
+    it('leaves the loader\'s IFC style colors alone — they are the model, not an override', () => {
+      // The deferred style/material pass in useIfcLoader goes through
+      // updateMeshColors WITHOUT `override`. If it were backed up, a host's
+      // RESET_COLORS would strip the model's own IFC colors back to the
+      // pre-style default.
+      const mesh = createMockMesh(1, [0.5, 0.5, 0.5, 1]); // pre-style default
+      state.appendGeometryBatch([mesh] as any);
+
+      state.updateMeshColors(new Map([[1, [0.8, 0.6, 0.4, 1] as [number, number, number, number]]]));
+
+      state.resetMeshColors();
+
+      assert.deepStrictEqual(state.geometryResult?.meshes[0].color, [0.8, 0.6, 0.4, 1]);
+      assert.strictEqual(state.meshColorBackup, null);
+    });
+
+    it('restores to the IFC style color, not to the pre-style default', () => {
+      const mesh = createMockMesh(1, [0.5, 0.5, 0.5, 1]);
+      state.appendGeometryBatch([mesh] as any);
+      // Load-time style pass, then a host override on top of it.
+      state.updateMeshColors(new Map([[1, [0.8, 0.6, 0.4, 1] as [number, number, number, number]]]));
+      state.updateMeshColors(new Map([[1, [1, 0, 0, 1] as [number, number, number, number]]]), { override: true });
+
+      state.resetMeshColors();
+
+      assert.deepStrictEqual(state.geometryResult?.meshes[0].color, [0.8, 0.6, 0.4, 1]);
+    });
+
+    it('does not touch pendingColorUpdates — the lens/IDS/clash overlay channel', () => {
+      const mesh = createMockMesh(1, [1, 0, 0, 1]);
+      state.appendGeometryBatch([mesh] as any);
+
+      // Another subsystem's claim on the overlay channel.
+      state.setPendingColorUpdates(new Map([[1, [1, 1, 0, 1] as [number, number, number, number]]]));
+      state.updateMeshColors(new Map([[1, [0, 1, 0, 1] as [number, number, number, number]]]), { override: true });
+
+      state.resetMeshColors();
+
+      assert.deepStrictEqual(state.pendingColorUpdates?.get(1), [1, 1, 0, 1]);
+    });
+
+    it('is a no-op when nothing was ever overridden', () => {
+      const mesh = createMockMesh(1, [1, 0, 0, 1]);
+      state.appendGeometryBatch([mesh] as any);
+      // A load-time style bake still queued for the renderer must survive: a
+      // reset that clears it would drop the model's colors mid-load.
+      state.updateMeshColors(new Map([[1, [0.8, 0.6, 0.4, 1] as [number, number, number, number]]]));
+
+      state.resetMeshColors();
+
+      assert.deepStrictEqual(state.geometryResult?.meshes[0].color, [0.8, 0.6, 0.4, 1]);
+      assert.deepStrictEqual(state.pendingMeshColorUpdates?.get(1), [0.8, 0.6, 0.4, 1]);
+    });
+  });
+
   describe('setPendingColorUpdates', () => {
     it('should clone pending color updates map', () => {
       const updates = new Map<number, [number, number, number, number]>();

--- a/apps/viewer/src/store/slices/dataSlice.ts
+++ b/apps/viewer/src/store/slices/dataSlice.ts
@@ -43,6 +43,18 @@ export interface DataSlice {
   pendingColorUpdates: Map<number, [number, number, number, number]> | null;
   /** Persistent mesh color updates (IFC deferred style/material colors). */
   pendingMeshColorUpdates: Map<number, [number, number, number, number]> | null;
+  /**
+   * Pre-override colors for every entity an *overriding* `updateMeshColors`
+   * call has baked over, keyed by expressId — what `resetMeshColors` restores.
+   * First write per entity wins, so successive overrides never clobber the
+   * ORIGINAL color with an intermediate one. Null when nothing is overridden.
+   *
+   * Only `updateMeshColors(updates, { override: true })` records here. The
+   * loader's own deferred IFC style/material pass goes through the same action
+   * WITHOUT that flag, precisely so a later reset restores the model's IFC
+   * colors rather than stripping them back to the pre-style defaults.
+   */
+  meshColorBackup: Map<number, [number, number, number, number]> | null;
 
   // Actions
   setIfcDataStore: (result: IfcDataStore | null) => void;
@@ -53,8 +65,21 @@ export interface DataSlice {
    *  `geometryContentVersion` for why this is separate from setGeometryResult. */
   bumpGeometryContentVersion: () => void;
   releaseGeometryMemory: () => void;
-  /** Persist mesh color changes in geometryResult (used for IFC style/material updates). */
-  updateMeshColors: (updates: Map<number, [number, number, number, number]>) => void;
+  /**
+   * Persist mesh color changes in geometryResult (used for IFC style/material
+   * updates).
+   *
+   * Pass `{ override: true }` when the colors are a *temporary* override on top
+   * of whatever the mesh already shows (the embed API's `SET_COLORS`): the
+   * displaced colors are captured in `meshColorBackup` so `resetMeshColors`
+   * can put them back. The loader's IFC style pass deliberately omits it — the
+   * colors it writes ARE the model's colors, and backing them up would make a
+   * later reset strip the model's styling.
+   */
+  updateMeshColors: (
+    updates: Map<number, [number, number, number, number]>,
+    options?: { override?: boolean },
+  ) => void;
   /**
    * Pending mesh removals for the renderer. Authoring actions
    * (split, delete) push globalIds here; `useGeometryStreaming`
@@ -115,6 +140,18 @@ export interface DataSlice {
   setPendingColorUpdates: (updates: Map<number, [number, number, number, number]>) => void;
   clearPendingColorUpdates: () => void;
   clearPendingMeshColorUpdates: () => void;
+  /**
+   * Undo every overriding `updateMeshColors` bake since the backup was last
+   * empty: restores `geometryResult.meshes[].color` from `meshColorBackup`,
+   * re-queues those restored colors on `pendingMeshColorUpdates` so the
+   * renderer re-uploads them, and clears the backup.
+   *
+   * Deliberately does NOT touch `pendingColorUpdates`. That is a different
+   * channel with different owners — the lens, IDS, clash and schedule overlays
+   * each install and release their own state there — and clearing it from here
+   * would destroy a claim this subsystem never made.
+   */
+  resetMeshColors: () => void;
   updateCoordinateInfo: (coordinateInfo: CoordinateInfo) => void;
 }
 
@@ -145,6 +182,7 @@ export const createDataSlice: StateCreator<DataSlice & DataCrossSliceState, [], 
   boundedGeometryMode: false,
   pendingColorUpdates: null,
   pendingMeshColorUpdates: null,
+  meshColorBackup: null,
   pendingMeshRemovals: null,
   pendingInstancedShards: null,
   pendingMeshTranslations: null,
@@ -276,7 +314,7 @@ export const createDataSlice: StateCreator<DataSlice & DataCrossSliceState, [], 
     return { geometryResult, models, geometryUpdateTick: state.geometryUpdateTick + 1 };
   }),
 
-  updateMeshColors: (updates) => set((state) => {
+  updateMeshColors: (updates, options) => set((state) => {
     // Clone the Map to prevent external mutation
     const clonedUpdates = new Map(updates);
 
@@ -286,11 +324,22 @@ export const createDataSlice: StateCreator<DataSlice & DataCrossSliceState, [], 
       return { pendingMeshColorUpdates: clonedUpdates };
     }
 
+    // Capture the displaced color for every entity this call overrides that
+    // isn't already backed up — first write wins, so repeated overrides don't
+    // clobber the ORIGINAL color with an intermediate one. Only for override
+    // callers: see `meshColorBackup`.
+    const meshColorBackup = options?.override
+      ? new Map(state.meshColorBackup ?? [])
+      : null;
+
     // New array reference so useGeometryStreaming's useEffect detects the change.
     // Only runs once at 'complete' (not per-batch), so O(n) .map() is fine.
     const updatedMeshes = state.geometryResult.meshes.map(mesh => {
       const newColor = clonedUpdates.get(mesh.expressId);
       if (newColor) {
+        if (meshColorBackup && !meshColorBackup.has(mesh.expressId)) {
+          meshColorBackup.set(mesh.expressId, mesh.color);
+        }
         return { ...mesh, color: newColor };
       }
       return mesh;
@@ -301,6 +350,7 @@ export const createDataSlice: StateCreator<DataSlice & DataCrossSliceState, [], 
         meshes: updatedMeshes,
       },
       pendingMeshColorUpdates: clonedUpdates,
+      ...(meshColorBackup ? { meshColorBackup } : {}),
     };
   }),
 
@@ -309,6 +359,37 @@ export const createDataSlice: StateCreator<DataSlice & DataCrossSliceState, [], 
   clearPendingColorUpdates: () => set({ pendingColorUpdates: null }),
 
   clearPendingMeshColorUpdates: () => set({ pendingMeshColorUpdates: null }),
+
+  resetMeshColors: () => set((state) => {
+    const backup = state.meshColorBackup;
+    if (!backup || backup.size === 0) {
+      // Nothing was overridden — and nothing to clear either. Leaving
+      // `pendingMeshColorUpdates` alone matters: the loader's deferred IFC
+      // style pass queues there, and a reset arriving mid-load must not drop
+      // the model's own colors before the renderer has drained them.
+      return {};
+    }
+
+    if (!state.geometryResult) {
+      // Federation mode: no local geometryResult to restore colors on; still
+      // forward the restore to the renderer's pending queue.
+      return { pendingMeshColorUpdates: new Map(backup), meshColorBackup: null };
+    }
+
+    const restoredMeshes = state.geometryResult.meshes.map(mesh => {
+      const original = backup.get(mesh.expressId);
+      return original ? { ...mesh, color: original } : mesh;
+    });
+
+    return {
+      geometryResult: {
+        ...state.geometryResult,
+        meshes: restoredMeshes,
+      },
+      pendingMeshColorUpdates: new Map(backup),
+      meshColorBackup: null,
+    };
+  }),
 
   setPendingMeshRemovals: (ids) => set((state) => {
     // Accumulate across calls — the streaming loop drains in one

--- a/apps/viewer/src/store/slices/dataSlice.ts
+++ b/apps/viewer/src/store/slices/dataSlice.ts
@@ -206,19 +206,30 @@ export const createDataSlice: StateCreator<DataSlice & DataCrossSliceState, [], 
   }),
 
   setGeometryResult: (geometryResult) => set((state) => {
+    // Replacing the geometry invalidates the colour backup: it maps global
+    // express id -> the element's ORIGINAL colour, and the incoming meshes
+    // reuse those ids for different elements. `useIfcFederation` calls this on
+    // an ACTIVE-MODEL SWITCH, so without this `resetMeshColors` restores the
+    // model you just left onto the one you just opened.
+    //
+    // Keyed on IDENTITY, not on every call: a redundant set of the same object
+    // changes nothing, and dropping the backup there would destroy a live undo
+    // for no gain -- the mistake this fix already made once, in `removeModel`.
+    const backup = geometryResult !== state.geometryResult ? { meshColorBackup: null } : {};
+
     const modelId = state.activeModelId;
     if (!modelId) {
-      return { geometryResult, geometryUpdateTick: state.geometryUpdateTick + 1 };
+      return { geometryResult, geometryUpdateTick: state.geometryUpdateTick + 1, ...backup };
     }
 
     const model = state.models.get(modelId);
     if (!model) {
-      return { geometryResult, geometryUpdateTick: state.geometryUpdateTick + 1 };
+      return { geometryResult, geometryUpdateTick: state.geometryUpdateTick + 1, ...backup };
     }
 
     const models = new Map(state.models);
     models.set(modelId, { ...model, geometryResult });
-    return { geometryResult, models, geometryUpdateTick: state.geometryUpdateTick + 1 };
+    return { geometryResult, models, geometryUpdateTick: state.geometryUpdateTick + 1, ...backup };
   }),
 
   setBoundedGeometryMode: (boundedGeometryMode) => set({ boundedGeometryMode }),

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -88,6 +88,7 @@ describe('ModelSlice', () => {
       ...slice,
       ifcDataStore: null,
       geometryResult: null,
+      meshColorBackup: null,
       addElementModelId: null,
       addElementStoreyId: null,
       selectedEntityId: null,

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -34,6 +34,10 @@ import {
 export interface ModelCrossSliceState {
   ifcDataStore: IfcDataStore | null;
   geometryResult: GeometryResult | null;
+  /** `dataSlice`'s per-element ORIGINAL colours, keyed by global express id.
+   *  Both teardown paths clear it: those ids are REUSED, so a survivor names
+   *  live elements of a model it was never taken from. */
+  meshColorBackup: Map<number, [number, number, number, number]> | null;
   /** AddElement panel's target-model pin (addElementSlice) — cleared here on
    *  full teardown for the same reason `removeModel` clears it when it names
    *  the one model being removed. See that call site's comment. */
@@ -388,9 +392,26 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       compareCross.clearCompare?.();
     }
 
+    // Purge only THIS model's entries from `dataSlice`'s mesh-colour backup.
+    // Dropping the map whole would take the SURVIVING models' undo with it, and
+    // it is not needed for them: `unregisterModel` below burns the removed
+    // range rather than reclaiming it, so no later model is handed these ids.
+    // (`clearAllModels` is the opposite case -- it calls `federationRegistry
+    // .clear()`, offsets restart at 0, and ids genuinely are reused -- which is
+    // why the clear there is unconditional.)
+    //
+    // `resolveGlobalIdInModel` is the owner-scoped resolver this file already
+    // provides for exactly this question; it shares its range and overlay
+    // predicates with the unscoped one, so the two cannot drift.
+    const priorBackup = get().meshColorBackup;
+    const keptBackup = priorBackup
+      ? new Map([...priorBackup].filter(([id]) => get().resolveGlobalIdInModel(modelId, id) === null))
+      : null;
+
     set((state) => {
       const newModels = new Map(state.models);
       newModels.delete(modelId);
+
 
       // Unregister from federation registry
       federationRegistry.unregisterModel(modelId);
@@ -538,6 +559,7 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
         activeModelId: newActiveId,
         ifcDataStore: activeModel?.ifcDataStore ?? null,
         geometryResult: activeModel?.geometryResult ?? null,
+        meshColorBackup: keptBackup && keptBackup.size > 0 ? keptBackup : null,
         ...(selectionTouchedRemoved
           ? {
               selectedEntity:
@@ -750,6 +772,9 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       activeModelId: null,
       ifcDataStore: null,
       geometryResult: null,
+      // Goes with the geometry it describes: first-write-wins, so a survivor
+      // repaints a departed model's colour onto whatever takes that id next.
+      meshColorBackup: null,
       addElementModelId: null,
       addElementStoreyId: null,
       selectedEntityId: null,

--- a/apps/viewer/src/store/types.ts
+++ b/apps/viewer/src/store/types.ts
@@ -422,6 +422,18 @@ export interface CameraCallbacks {
    */
   frameClashRegion?: (min: { x: number; y: number; z: number }, max: { x: number; y: number; z: number }) => void;
   orbit?: (deltaX: number, deltaY: number) => void;
+  /**
+   * Place the camera at an ABSOLUTE orientation (degrees, same convention as
+   * `cameraRotation` and the renderer's `Camera.getRotation`), keeping the
+   * current target and orbit distance.
+   *
+   * Every other orientation callback here is relative (`orbit`, `rotateLeft`,
+   * `rotateRight`) or names a direction (`setPresetView`), so a caller holding
+   * an angle pair — the embed API's `SET_CAMERA` — had nothing to call and the
+   * store write went nowhere (#2934). Driven from `setCameraRotation` in
+   * cameraSlice, mirroring how `setProjectionMode` drives its own callback.
+   */
+  setCameraRotation?: (rotation: CameraRotation) => void;
   projectToScreen?: (worldPos: { x: number; y: number; z: number }) => { x: number; y: number } | null;
   /**
    * Unproject a screen pixel onto the horizontal plane at the

--- a/packages/embed-protocol/src/index.ts
+++ b/packages/embed-protocol/src/index.ts
@@ -93,6 +93,16 @@ export interface InboundPayloads {
   SET_COLORS: { colorMap: Record<string, [number, number, number, number]> };
   RESET_COLORS: void;
   FIT_TO_VIEW: { ids?: number[] };
+  /**
+   * Absolute camera orientation in degrees: `azimuth` horizontal (normalized
+   * into 0-360), `elevation` from the horizon (clamped just inside ±90°, where
+   * the view matrix degenerates). The target and the orbit distance are kept —
+   * this rotates the camera, it does not reframe; use `FIT_TO_VIEW` for that.
+   *
+   * `zoom` is NOT applied. It has no defined meaning on this side (factor?
+   * distance? relative to what?), and the viewer deliberately ignores it rather
+   * than guessing — see #2934. Treat it as reserved.
+   */
   SET_CAMERA: { azimuth: number; elevation: number; zoom?: number };
   SET_VIEW: { preset: ViewPreset };
   SET_SECTION: { axis?: SectionAxis; position?: number; enabled?: boolean; flipped?: boolean };

--- a/packages/embed-sdk/src/index.ts
+++ b/packages/embed-sdk/src/index.ts
@@ -254,7 +254,11 @@ export class IFCLiteEmbed {
     return this.request('FIT_TO_VIEW', { ids }) as Promise<void>;
   }
 
-  /** Set camera orientation */
+  /**
+   * Set the camera's absolute orientation, in degrees, around whatever it is
+   * currently looking at. `zoom` is reserved and ignored by the viewer — see
+   * `InboundPayloads['SET_CAMERA']`.
+   */
   setCamera(azimuth: number, elevation: number, zoom?: number): Promise<void> {
     return this.request('SET_CAMERA', { azimuth, elevation, zoom }) as Promise<void>;
   }

--- a/packages/renderer/src/camera-absolute-rotation.test.ts
+++ b/packages/renderer/src/camera-absolute-rotation.test.ts
@@ -1,0 +1,170 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `Camera.setRotation` — the ABSOLUTE orientation actuator.
+ *
+ * Every other orientation entry point on the camera is either relative
+ * (`orbit`, the viewer's 90° `rotateLeft`/`rotateRight` steppers) or names a
+ * direction rather than an angle (`setPresetView`). A host that says "put the
+ * camera at azimuth 120°, elevation 30°" — the embed API's `SET_CAMERA`, which
+ * had no actuator at all and only wrote a store field (#2934) — needs this one.
+ *
+ * The pinned contract is the round trip against `getRotation`, because that is
+ * what makes the command observable to the caller: the angles the camera
+ * reports back must be the angles that were asked for, and the pose must
+ * actually have moved.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { Camera } from './camera.js';
+import { CAMERA_CONSTANTS as CC } from './constants.js';
+import type { Vec3 } from './types.js';
+
+function len(v: Vec3): number {
+  return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+}
+
+/**
+ * Drive a camera animation on a fake clock. Same helper shape as
+ * `camera-malformed-bounds-fit.test.ts` / `camera-preset-orbit.test.ts`: the
+ * animator's completion promise chains off `requestAnimationFrame`, which does
+ * not exist under `node:test`, so the animation is stepped by hand and the
+ * promise is never awaited.
+ */
+function withStubbedFrameClock(run: (advance: (ms: number) => void) => void): void {
+  const originalNow = Date.now;
+  const hadRaf = Object.prototype.hasOwnProperty.call(globalThis, 'requestAnimationFrame');
+  const originalRaf = Reflect.get(globalThis, 'requestAnimationFrame');
+  let now = 1_000;
+
+  Date.now = () => now;
+  Reflect.set(globalThis, 'requestAnimationFrame', () => 0);
+
+  try {
+    run((ms) => { now += ms; });
+  } finally {
+    Date.now = originalNow;
+    if (hadRaf) {
+      Reflect.set(globalThis, 'requestAnimationFrame', originalRaf);
+    } else {
+      Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
+    }
+  }
+}
+
+function distanceOf(camera: Camera): number {
+  const p = camera.getPosition();
+  const t = camera.getTarget();
+  return len({ x: p.x - t.x, y: p.y - t.y, z: p.z - t.z });
+}
+
+describe('Camera.setRotation (absolute orientation)', () => {
+  it('reports back exactly the angles it was given', () => {
+    const camera = new Camera();
+    for (const [azimuth, elevation] of [[0, 0], [90, 30], [217.5, -42], [359, 12]] as const) {
+      camera.setRotation(azimuth, elevation);
+      const got = camera.getRotation();
+      assert.ok(Math.abs(got.azimuth - azimuth) < 1e-6, `azimuth ${got.azimuth} != ${azimuth}`);
+      assert.ok(Math.abs(got.elevation - elevation) < 1e-6, `elevation ${got.elevation} != ${elevation}`);
+    }
+  });
+
+  it('actually moves the camera position', () => {
+    const camera = new Camera();
+    const before = camera.getPosition();
+    camera.setRotation(180, 45);
+    const after = camera.getPosition();
+    assert.ok(
+      Math.abs(before.x - after.x) + Math.abs(before.y - after.y) + Math.abs(before.z - after.z) > 1e-3,
+      'setRotation left the camera position untouched',
+    );
+  });
+
+  it('is idempotent — repeating the same angles does not walk the camera', () => {
+    // The command is ABSOLUTE, so a host that re-sends its current orientation
+    // (a slider that fires on every frame) must not drift. A relative
+    // implementation would accumulate; only float noise from re-deriving the
+    // radius is allowed here.
+    const camera = new Camera();
+    camera.setRotation(120, 25);
+    const first = camera.getPosition();
+    for (let i = 0; i < 20; i++) camera.setRotation(120, 25);
+    const last = camera.getPosition();
+    const drift = Math.abs(last.x - first.x) + Math.abs(last.y - first.y) + Math.abs(last.z - first.z);
+    assert.ok(drift < 1e-9, `drifted by ${drift} over 20 identical calls`);
+  });
+
+  it('preserves the orbit distance and the target', () => {
+    const camera = new Camera();
+    camera.setTarget(10, 20, 30);
+    camera.setPosition(10, 20, 130); // distance 100 from the target
+    const distanceBefore = distanceOf(camera);
+
+    camera.setRotation(75, -15);
+
+    assert.ok(Math.abs(distanceOf(camera) - distanceBefore) < 1e-6, 'distance changed');
+    assert.deepStrictEqual(camera.getTarget(), { x: 10, y: 20, z: 30 });
+  });
+
+  it('normalizes an out-of-range azimuth into 0-360', () => {
+    const camera = new Camera();
+    camera.setRotation(-90, 0);
+    assert.ok(Math.abs(camera.getRotation().azimuth - 270) < 1e-6);
+  });
+
+  it('clamps elevation just off the poles so the view matrix cannot degenerate', () => {
+    const camera = new Camera();
+    // ±90° is the spherical singularity: `cross(forward, up)` collapses and the
+    // model flips. MIN_PHI is the same margin `orbit` clamps to.
+    const maxElevation = 90 - (CC.MIN_PHI * 180) / Math.PI;
+    camera.setRotation(0, 90);
+    assert.ok(Math.abs(camera.getRotation().elevation - maxElevation) < 1e-6);
+    camera.setRotation(0, -90);
+    assert.ok(Math.abs(camera.getRotation().elevation + maxElevation) < 1e-6);
+  });
+
+  it('supersedes an animation already in flight instead of being erased by it', () => {
+    // A host that sends SET_VIEW (which animates) and then SET_CAMERA must end
+    // up where SET_CAMERA asked. Without cancelling the tween, the very next
+    // `update()` writes the animation's interpolated pose over this one.
+    withStubbedFrameClock((advance) => {
+      const camera = new Camera();
+      // setPresetView starts a tween that `update()` applies frame by frame.
+      camera.setPresetView('top', { min: { x: -10, y: -10, z: -10 }, max: { x: 10, y: 10, z: 10 } });
+
+      camera.setRotation(200, 20);
+      advance(16);
+      camera.update(16);
+
+      const got = camera.getRotation();
+      assert.ok(Math.abs(got.azimuth - 200) < 1e-6, `azimuth drifted to ${got.azimuth}`);
+      assert.ok(Math.abs(got.elevation - 20) < 1e-6, `elevation drifted to ${got.elevation}`);
+    });
+  });
+
+  it('rejects non-finite angles instead of writing a NaN pose', () => {
+    const camera = new Camera();
+    camera.setRotation(30, 10);
+    const pose = camera.getPosition();
+    camera.setRotation(NaN, 10);
+    camera.setRotation(30, Infinity);
+    assert.deepStrictEqual(camera.getPosition(), pose);
+  });
+
+  it('recovers from a degenerate pose rather than propagating it', () => {
+    const camera = new Camera();
+    // position === target: distance 0, so there is no orbit radius to preserve.
+    camera.setTarget(5, 5, 5);
+    camera.setPosition(5, 5, 5);
+    camera.setRotation(45, 20);
+    const got = camera.getRotation();
+    assert.ok(Number.isFinite(got.azimuth) && Number.isFinite(got.elevation));
+    assert.ok(distanceOf(camera) > 0, 'still degenerate after setRotation');
+    assert.ok(Math.abs(got.azimuth - 45) < 1e-6);
+    assert.ok(Math.abs(got.elevation - 20) < 1e-6);
+  });
+});

--- a/packages/renderer/src/camera-absolute-rotation.test.ts
+++ b/packages/renderer/src/camera-absolute-rotation.test.ts
@@ -181,6 +181,27 @@ describe('Camera.setRotation (absolute orientation)', () => {
     assert.deepStrictEqual(camera.getUp(), { x: 0, y: 1, z: 0 });
   });
 
+  it('rejects a non-finite TARGET instead of writing a NaN pose', () => {
+    // The angle guard above is not enough: every position component is
+    // `target.<axis> + ...`, and `setTarget` accepts non-finite coordinates, so
+    // one NaN there makes the whole pose NaN. `isUsableDistance` rescues the
+    // radius and says nothing about the target. This method's contract is that
+    // it RECOVERS a pose, so writing an unrecoverable one is worse than
+    // refusing outright.
+    const camera = new Camera();
+    camera.setRotation(30, 10);
+    const pose = camera.getPosition();
+
+    camera.setTarget(NaN, 0, 0);
+    camera.setRotation(45, 20);
+    assert.deepStrictEqual(camera.getPosition(), pose, 'a NaN target must not move the camera');
+
+    camera.setTarget(0, Infinity, 0);
+    camera.setRotation(60, 15);
+    assert.deepStrictEqual(camera.getPosition(), pose, 'an infinite target must not move it either');
+    assert.ok(Number.isFinite(camera.getPosition().x));
+  });
+
   it('rejects non-finite angles instead of writing a NaN pose', () => {
     const camera = new Camera();
     camera.setRotation(30, 10);

--- a/packages/renderer/src/camera-absolute-rotation.test.ts
+++ b/packages/renderer/src/camera-absolute-rotation.test.ts
@@ -146,6 +146,41 @@ describe('Camera.setRotation (absolute orientation)', () => {
     });
   });
 
+  it('re-seats a non-Y up vector, so the angles are observable from any prior pose', () => {
+    // Every other case here starts from a camera whose `up` is already world
+    // Y, which is the one state where the reset at the end of `setRotation`
+    // cannot be observed -- verified by mutation: deleting
+    // `this.state.camera.up = { x: 0, y: 1, z: 0 }` left the whole file green.
+    //
+    // `getRotation` derives azimuth from the UP vector whenever it has any
+    // horizontal component (`upLen > 0.01`), and only falls back to the
+    // position when up is vertical. A camera restored from a BCF viewpoint
+    // takes its up straight from the file (`Viewport.tsx`'s
+    // `camera.setUp(viewpoint.up...)`), so a top-down viewpoint arrives with
+    // up = (0, 0, -1). Without the reset the new position is written but the
+    // reported azimuth still comes from the stale up vector -- 0 instead of
+    // the 120 that was asked for, i.e. exactly the "the command did nothing"
+    // symptom of #2934, one layer down.
+    const camera = new Camera();
+    camera.setTarget(0, 0, 0);
+    camera.setPosition(0, 100, 0);
+    camera.setUp(0, 0, -1);
+    assert.ok(
+      Math.abs(camera.getRotation().azimuth - 0) < 1e-6,
+      'fixture precondition: the stale up vector reports azimuth 0',
+    );
+
+    camera.setRotation(120, 30);
+
+    const got = camera.getRotation();
+    assert.ok(
+      Math.abs(got.azimuth - 120) < 1e-6,
+      `azimuth ${got.azimuth} != 120 -- the stale up vector still drives the readout`,
+    );
+    assert.ok(Math.abs(got.elevation - 30) < 1e-6, `elevation ${got.elevation} != 30`);
+    assert.deepStrictEqual(camera.getUp(), { x: 0, y: 1, z: 0 });
+  });
+
   it('rejects non-finite angles instead of writing a NaN pose', () => {
     const camera = new Camera();
     camera.setRotation(30, 10);

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -512,6 +512,14 @@ export class Camera {
     // whole point of the command.
     const distance = isUsableDistance(current, 1e-6) ? current : 1;
 
+    // The TARGET is the other unguarded input, and `isUsableDistance` above only
+    // rescues the radius. `setTarget` accepts non-finite coordinates, and every
+    // position component below is `target.<axis> + ...`, so one NaN there makes
+    // the whole pose NaN -- and this method's contract is that it RECOVERS a
+    // pose, so silently writing an unrecoverable one is worse than refusing.
+    // Same rejection shape as the angle guard at the top: change nothing.
+    if (!areFiniteNumbers(target.x, target.y, target.z)) return;
+
     const theta = ((((azimuth % 360) + 360) % 360) * Math.PI) / 180;
     const poleMargin = CAMERA_CONSTANTS.MIN_PHI;
     const phi = Math.max(

--- a/packages/renderer/src/camera.ts
+++ b/packages/renderer/src/camera.ts
@@ -20,11 +20,13 @@ import { FirstPersonNavigator } from './camera-first-person.js';
 import { updateCameraMatrices } from './camera-matrices.js';
 import { pickFitPolicy, type Bounds3, type FitPolicy, type PickFitPolicyOptions } from './camera-fit-policy.js';
 import {
+  areFiniteNumbers,
   DEFAULT_ORTHO_SIZE,
   isUsableBounds,
   isUsableDistance,
   usableOrthoSize,
 } from './camera-guards.js';
+import { CAMERA_CONSTANTS } from './constants.js';
 
 export class Camera {
   private state: CameraInternalState;
@@ -456,6 +458,75 @@ export class Camera {
     }
 
     return { azimuth, elevation };
+  }
+
+  /**
+   * Place the camera at an ABSOLUTE orientation around its current target,
+   * in the same angle convention {@link getRotation} reports — the exact
+   * inverse of it, so `setRotation(a, e)` then `getRotation()` returns
+   * `{ azimuth: a, elevation: e }` (modulo the normalisation and pole clamp
+   * below).
+   *
+   * This is the only absolute-orientation entry point on the camera. Everything
+   * else is relative (`orbit`, and the viewer's 90° rotate steppers built on it)
+   * or names a direction rather than an angle (`setPresetView`), which is why a
+   * host command that says "go to azimuth 120°, elevation 30°" had nothing to
+   * call and silently did nothing (#2934).
+   *
+   * The orbit radius and the target are preserved — this rotates the camera on
+   * its current sphere, it does not reframe. `up` is reset to world Y, matching
+   * `orbit`, so the reported azimuth comes back through `getRotation`'s
+   * position-based branch.
+   *
+   * @param azimuth Horizontal angle in degrees; normalised into [0, 360).
+   * @param elevation Vertical angle in degrees, 0 = horizon. Clamped to just
+   *   inside ±90° (the same `MIN_PHI` margin `orbit` uses) — the exact poles
+   *   collapse `cross(forward, up)` and flip the model.
+   */
+  setRotation(azimuth: number, elevation: number): void {
+    // Angles are an input class of their own, and both of them reach the
+    // trigonometry below unguarded: a non-finite one writes a NaN position and
+    // destroys an otherwise valid pose. Same rejection `orbit` applies to its
+    // deltas — a rejected call changes nothing at all.
+    if (!areFiniteNumbers(azimuth, elevation)) return;
+
+    // An in-flight tween or leftover inertia writes position/target on the next
+    // `update()` and would erase this pose a frame later — a host that sends
+    // SET_VIEW (animated) and then SET_CAMERA would end up at the preset. An
+    // absolute placement supersedes whatever motion is still running, so cancel
+    // it; this also drops the preset-view rotation cycle, which is correct
+    // after the camera has been reoriented out from under it.
+    this.animator.reset();
+
+    const target = this.state.camera.target;
+    const dir = {
+      x: this.state.camera.position.x - target.x,
+      y: this.state.camera.position.y - target.y,
+      z: this.state.camera.position.z - target.z,
+    };
+    const current = Math.sqrt(dir.x * dir.x + dir.y * dir.y + dir.z * dir.z);
+    // A degenerate pose (position === target, or a non-finite one) has no orbit
+    // radius to preserve. Any positive radius yields a well-formed view matrix
+    // at the requested direction, which is strictly better than propagating the
+    // degeneracy — and leaves the caller's angles observable, which is the
+    // whole point of the command.
+    const distance = isUsableDistance(current, 1e-6) ? current : 1;
+
+    const theta = ((((azimuth % 360) + 360) % 360) * Math.PI) / 180;
+    const poleMargin = CAMERA_CONSTANTS.MIN_PHI;
+    const phi = Math.max(
+      poleMargin,
+      Math.min(Math.PI - poleMargin, ((90 - elevation) * Math.PI) / 180),
+    );
+    const sinPhi = Math.sin(phi);
+
+    this.state.camera.position = {
+      x: target.x + distance * sinPhi * Math.sin(theta),
+      y: target.y + distance * Math.cos(phi),
+      z: target.z + distance * sinPhi * Math.cos(theta),
+    };
+    this.state.camera.up = { x: 0, y: 1, z: 0 };
+    this.updateMatrices();
   }
 
   /**

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -135,7 +135,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * failure message. Either way do it at the moment you finalise the change — it
  * moves if anything else touched the allowlist first.
  */
-const ALLOWLIST_DIGEST = '10421879663368917891';
+const ALLOWLIST_DIGEST = '5411512104567186147';
 
 function parseArgs(argv) {
   const out = {

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -14,8 +14,8 @@
 # Any edit here moves ALLOWLIST_DIGEST in scripts/check-module-size.mjs, which
 # must be updated in the same commit — that is the point: loosening the ratchet
 # costs a reviewable line.
-   515 apps/viewer-embed/src/bridge/handler.ts
-   445 apps/viewer-embed/src/components/EmbedViewer.tsx
+   522 apps/viewer-embed/src/bridge/handler.ts
+   484 apps/viewer-embed/src/components/EmbedViewer.tsx
    481 apps/viewer/src/components/extensions/ExtensionsPanel.tsx
    431 apps/viewer/src/components/extensions/FlavorDialog.tsx
    428 apps/viewer/src/components/extensions/widget/WidgetRenderer.tsx
@@ -92,7 +92,7 @@
    970 apps/viewer/src/components/viewer/useGeometryStreaming.ts
    946 apps/viewer/src/components/viewer/useMouseControls.ts
    782 apps/viewer/src/components/viewer/ViewerLayout.tsx
-  1834 apps/viewer/src/components/viewer/Viewport.tsx
+  1843 apps/viewer/src/components/viewer/Viewport.tsx
   1539 apps/viewer/src/components/viewer/ViewportContainer.tsx
    511 apps/viewer/src/components/viewer/ZonesPanel.tsx
    862 apps/viewer/src/hooks/ids/idsExportService.ts
@@ -142,15 +142,16 @@
    561 apps/viewer/src/services/ifc-cache.ts
    581 apps/viewer/src/store/basketVisibleSet.ts
    485 apps/viewer/src/store/constants.ts
-   846 apps/viewer/src/store/index.ts
+   850 apps/viewer/src/store/index.ts
    404 apps/viewer/src/store/slices/addElementMeshes.ts
    452 apps/viewer/src/store/slices/chatSlice.ts
    994 apps/viewer/src/store/slices/clashSlice.ts
   1599 apps/viewer/src/store/slices/collabSlice.ts
+   482 apps/viewer/src/store/slices/dataSlice.ts
    874 apps/viewer/src/store/slices/drawing2DSlice.ts
    482 apps/viewer/src/store/slices/idsSlice.ts
    820 apps/viewer/src/store/slices/measurementSlice.ts
-   889 apps/viewer/src/store/slices/modelSlice.ts
+   914 apps/viewer/src/store/slices/modelSlice.ts
   3283 apps/viewer/src/store/slices/mutationSlice.ts
    478 apps/viewer/src/store/slices/pinboardSlice.ts
   1317 apps/viewer/src/store/slices/scheduleSlice.ts
@@ -159,7 +160,7 @@
    571 apps/viewer/src/store/slices/sheetSlice.ts
    414 apps/viewer/src/store/slices/uiSlice.ts
    485 apps/viewer/src/store/slices/visibilitySlice.ts
-   677 apps/viewer/src/store/types.ts
+   689 apps/viewer/src/store/types.ts
    819 apps/viewer/src/utils/serverDataModel.ts
    441 apps/viewer/src/utils/spatialHierarchy.ts
    573 apps/viewer/src/utils/viewportUtils.ts
@@ -296,7 +297,7 @@
    609 packages/provenance/src/node-hash.ts
    535 packages/query/src/duckdb-integration.ts
    561 packages/renderer/src/camera-controls.ts
-   578 packages/renderer/src/camera.ts
+   657 packages/renderer/src/camera.ts
   3792 packages/renderer/src/index.ts
    780 packages/renderer/src/picker.ts
    952 packages/renderer/src/pipeline.ts


### PR DESCRIPTION
Addresses the three inert commands in #2934. All three were genuinely inert, each broken at a **different** link — "advertised but doesn't work" was one symptom over three causes.

## SET_CAMERA — sender and handler existed; the store action was a dead end

`grep` found exactly one caller of `setCameraRotation` (the bridge), and the action only wrote a field. `CameraCallbacks` had no absolute-orientation member — `orbit`/`rotateLeft`/`rotateRight` are relative, `setPresetView` names a direction — and `Camera` had `getRotation()` with no inverse.

```
not ok 1 - drives the renderer through cameraCallbacks.setCameraRotation
  + actual  []
  - expected [ [ 'setCameraRotation', { azimuth: 120, elevation: 30 } ] ]
```

New `Camera.setRotation(azimuth, elevation)` — the inverse of `getRotation`: keeps target and orbit distance, normalises azimuth, clamps elevation off the poles, rejects non-finite input, and **cancels an in-flight tween** so `update()` cannot erase the pose. Nine tests on the real camera pose, including no drift over 20 repeats and tween supersession; each confirmed load-bearing by reverting the fix.

## RESET_COLORS — wired to the wrong channel, and wrong in both directions

`SET_COLORS` bakes into `geometryResult.meshes[].color`; `RESET_COLORS` was clearing `pendingColorUpdates` — a different channel.

- **Under-clear:** the host's own override survived, because nothing cleared the baked colour.
- **Over-clear:** `pendingColorUpdates` is written by `useClash.ts` (7 sites), `useIDS.ts`, `useOverlayCompositor.ts`, `useCompareOverlay.ts`, `ClashPanel.tsx` and the SDK viewer adapter. A host `RESET_COLORS` destroyed whichever of those held a claim.

Worth noting for the ownership model: the documented records (`lib/clash/visibility-ownership.ts`, `lens-visibility-ownership.ts`) cover the **visibility** channels only. There is no colour-ownership record, so the correct fix is to not touch that channel at all rather than to release it.

`updateMeshColors(updates, { override: true })` now captures displaced colours into a `meshColorBackup` (first write per entity wins) and `resetMeshColors()` restores them, leaving `pendingColorUpdates` untouched.

**This is a correction to an earlier attempt on `upstream/embed-dead-surface-fixes`**, which backed up unconditionally — `useIfcLoader.ts:1803` runs the deferred IFC style pass through the same action, so that version would have stripped the model's own IFC colours back to pre-style defaults. The `override` flag confines the backup to host overrides; both halves are pinned.

## ENTITY_HOVERED — declared and SDK-plumbed, never emitted

`grep -rn "ENTITY_HOVERED" apps/viewer-embed/src` returned **nothing**. The protocol declares it and the SDK tests pass by calling `harness.emit` themselves, so nothing downstream noticed. Two links missing: the hover pipeline is gated on `hoverTooltipsEnabled`, which defaults `false` with no embed chrome to toggle it, and there was no emit effect. Both fixed in `EmbedViewer.tsx`.

Tests enter at `setHoverState` — the store action the pick path calls — and assert what reaches `window.parent.postMessage`, including no re-post on pointer drift within a mesh and a fresh post on a new entity.

## Deliberately not fixed

- `zoom` on `SET_CAMERA` has no defined viewer-side meaning (factor? distance? relative to what?). Now **documented as reserved** in both packages rather than silently dropped.
- Issue items #2 (`CAMERA_CHANGED` never fires for real navigation) and the eight URL params are out of scope and remain open — #2934 stays open after this PR.

## Limits

Driving `renderer.pick()` needs a real WebGPU device, so the pick→`setHoverState` link is stated in the test docblock rather than pinned. Likewise `Viewport.tsx` registering `setCameraRotation` is covered by reading only — as is true of every other camera callback, since registration runs only under a real WebGPU mount.

`packages/renderer` 956 → **965**; `viewer-embed` 141 → **149**; viewer `dataSlice` 15 → **21**, new `cameraSlice` 5; `embed-protocol` 22 and `embed-sdk` 69 unchanged. `turbo run typecheck` 85/85. api-surface **unchanged** — `setRotation` is a member of the already-exported `Camera`, so no regeneration was needed and nothing was hand-edited. Changeset: `renderer` minor (new public method, precedent #2574/#2172), the two embed packages patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Embed integrations can set absolute camera rotation while preserving the current target and distance.
  - Hovering over a different entity emits an `ENTITY_HOVERED` event with entity metadata.
  - Temporary mesh color overrides can be restored without clearing unrelated color updates.
- **Bug Fixes**
  - Improved camera rotation handling, including queued rotations and invalid-input protection.
  - Improved color reset behavior when switching models or replacing geometry.
- **Documentation**
  - Clarified camera rotation units, behavior, and that the reserved `zoom` parameter is ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

