### PR TITLE
fix(ids): stop dropping cardinality-only failures in CLI JSON and BCF export

### DIFF
--- a/.changeset/ids-bcf-truncation-and-cardinality.md
+++ b/.changeset/ids-bcf-truncation-and-cardinality.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/bcf": patch
+---
+
+Fix two ways `createBCFFromIDSReport` could drop IDS validation failures from the exported BCF file with no trace:
+
+- A specification that fails on cardinality alone (its applicability matched zero entities and `minOccurs` required at least one — e.g. a required element type entirely missing from the model) produces an empty `entityResults`. The `per-entity` (default) and `per-requirement` grouping strategies iterate `entityResults` to build topics, so this kind of failure never became a topic at all: the validator correctly counted the specification as failed, but the exported BCF file showed nothing for it. Both strategies now emit a topic for a cardinality-only failure, the same way `per-specification` grouping already did.
+- `maxTopics` (default 1000) cut generation off with a bare early return in all three grouping strategies, silently dropping the remaining entities/specifications/requirements past the cap. `MAX_COMMENTS_PER_TOPIC` already handles its own, narrower truncation (comments within one topic) with an "... and N more" note; `maxTopics` now gets the same treatment via a synthetic `Info` topic recording how many further items were cut off.

--- a/.changeset/ids-summarize-not-applicable.md
+++ b/.changeset/ids-summarize-not-applicable.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/sdk": patch
+---
+
+Fix `bim.ids.summarize()` counting a `not_applicable` specification as passed. A specification whose applicability matches zero entities and whose cardinality does not require a match (no `minOccurs`) is neither a pass nor a fail — `@ifc-lite/ids`'s own `validateIDS` report already treats it that way — but `summarize()` had no `not_applicable` bucket, so its unconditional `else` folded every such specification into `passedSpecifications`. That inflated the spec-level pass rate returned by the CLI's `ids --json` output relative to the CLI's own text-mode output (both should read from the same validation, but text mode reads `report.summary` directly while `--json` goes through `summarize()`).
+
+`IDSValidationSummary` gains a `notApplicableSpecifications` field so `passedSpecifications + failedSpecifications + notApplicableSpecifications === totalSpecifications` always holds, matching the validator's own accounting.

--- a/packages/bcf/src/ids-reporter.test.ts
+++ b/packages/bcf/src/ids-reporter.test.ts
@@ -480,7 +480,78 @@ describe('IDS BCF Reporter', () => {
       const report = createMockReport();
       const project = createBCFFromIDSReport(report, { maxTopics: 1 });
 
-      expect(project.topics.size).toBe(1);
+      // 1 real topic (the cap) + 1 synthetic "...and N more" notice topic,
+      // the same way MAX_COMMENTS_PER_TOPIC's truncation adds an extra
+      // comment rather than dropping the overflow with no trace.
+      const topics = [...project.topics.values()];
+      expect(topics.length).toBe(2);
+      expect(topics.filter((t) => t.topicType !== 'Info').length).toBe(1);
+    });
+
+    it('signals maxTopics truncation instead of silently dropping entities (per-entity grouping)', () => {
+      // createMockReport() has 2 failing entities (express IDs 100, 200) in
+      // its one spec. Capping at 1 topic must not just stop — the comment
+      // cap (MAX_COMMENTS_PER_TOPIC) already adds an "...and N more" note
+      // when it truncates; the topic cap must do the same, or a real export
+      // over 1000+ failures silently drops entities with no trace in the
+      // BCF file.
+      const report = createMockReport();
+      const project = createBCFFromIDSReport(report, { maxTopics: 1 });
+
+      const topics = [...project.topics.values()];
+      const notice = topics.find((t) => /more/i.test(t.title) || /more/i.test(t.description ?? ''));
+      expect(notice, 'expected a truncation-notice topic when maxTopics cuts off remaining entities').toBeDefined();
+      expect(notice!.title + (notice!.description ?? '')).toContain('1');
+    });
+
+    it('does not silently drop a cardinality-only failure (zero applicable entities) in per-entity grouping', () => {
+      // "At least one IfcWindow must exist": a required (minOccurs=1) spec
+      // that matched ZERO entities. The validator correctly marks the
+      // specification 'fail', but there is no entity to attach a topic to
+      // — entityResults is empty. Per-entity grouping (the default) used
+      // to iterate only entityResults, so this failure produced no topic
+      // at all: a real defect (a required element type entirely missing
+      // from the model) was invisible in the exported BCF file while the
+      // CLI/JSON summary correctly counted it as a failed specification.
+      const report: IDSReportInput = {
+        title: 'Cardinality-only failure',
+        specificationResults: [
+          {
+            specification: { name: 'At least one window must exist' },
+            status: 'fail',
+            applicableCount: 0,
+            passedCount: 0,
+            failedCount: 0,
+            entityResults: [],
+            cardinalityResult: {
+              passed: false,
+              actualCount: 0,
+              minExpected: 1,
+              message: 'Expected at least 1, found 0',
+            },
+          },
+        ],
+      };
+
+      const perEntity = createBCFFromIDSReport(report, { topicGrouping: 'per-entity' });
+      expect(perEntity.topics.size, 'per-entity grouping dropped the cardinality-only failure').toBeGreaterThan(0);
+      const perEntityTopic = [...perEntity.topics.values()][0];
+      expect(perEntityTopic.title).toContain('At least one window must exist');
+
+      const perRequirement = createBCFFromIDSReport(report, { topicGrouping: 'per-requirement' });
+      expect(
+        perRequirement.topics.size,
+        'per-requirement grouping dropped the cardinality-only failure',
+      ).toBeGreaterThan(0);
+    });
+
+    it('signals maxTopics truncation for per-requirement grouping too', () => {
+      const report = createMockReport();
+      const project = createBCFFromIDSReport(report, { maxTopics: 1, topicGrouping: 'per-requirement' });
+
+      const topics = [...project.topics.values()];
+      const notice = topics.find((t) => /more/i.test(t.title) || /more/i.test(t.description ?? ''));
+      expect(notice, 'expected a truncation-notice topic when maxTopics cuts off remaining requirement failures').toBeDefined();
     });
 
     it('should handle empty report', () => {

--- a/packages/bcf/src/ids-reporter.ts
+++ b/packages/bcf/src/ids-reporter.ts
@@ -96,6 +96,21 @@ export interface IDSSpecResultInput {
   passedCount: number;
   failedCount: number;
   entityResults: IDSEntityResultInput[];
+  /**
+   * Present when the specification declares minOccurs/maxOccurs. A
+   * cardinality-only failure (e.g. a required entity type entirely
+   * absent from the model) has `applicableCount === 0` and an empty
+   * `entityResults` — there is no entity to attach a per-entity topic
+   * to, so grouping strategies that iterate `entityResults` must fall
+   * back to this to avoid dropping the failure silently.
+   */
+  cardinalityResult?: {
+    passed: boolean;
+    actualCount: number;
+    minExpected?: number;
+    maxExpected?: number | 'unbounded';
+    message: string;
+  };
 }
 
 /** Entity result — structurally matches IDSEntityResult */
@@ -259,6 +274,56 @@ export function createBCFFromIDSReport(
   return project;
 }
 
+/**
+ * Build the topic for a specification that FAILED on cardinality alone
+ * (its applicability matched zero entities and minOccurs required at
+ * least one). There is no entity to attach a per-entity or
+ * per-requirement topic to, so grouping strategies that iterate
+ * `entityResults` need this fallback or the failure never appears in
+ * the exported BCF file at all.
+ */
+function createCardinalityFailureTopic(
+  specResult: IDSSpecResultInput,
+  author: string,
+  failureTopicType: string,
+): BCFTopic {
+  const message = specResult.cardinalityResult?.message ?? 'Cardinality requirement not satisfied';
+  return createTopic({
+    title: `${specResult.specification.name}: cardinality requirement not met`,
+    description: `Specification: ${specResult.specification.name}\n${specResult.specification.description ?? ''}\n\n${message} (0 applicable entities matched).`,
+    author,
+    topicType: failureTopicType,
+    topicStatus: 'Open',
+    priority: 'High',
+    labels: ['IDS', specResult.specification.name, 'cardinality'],
+  });
+}
+
+/**
+ * Add a synthetic "Info" topic recording that `maxTopics` cut off `remaining`
+ * further items. Without this, a large model silently drops entities past
+ * the cap with no trace in the exported BCF file — the same silent-loss
+ * shape `MAX_COMMENTS_PER_TOPIC`'s "... and N more" comment exists to avoid
+ * for comments within one topic.
+ */
+function addTruncationNoticeTopic(
+  project: BCFProject,
+  author: string,
+  remaining: number,
+  itemLabel: string,
+): void {
+  if (remaining <= 0) return;
+  const topic = createTopic({
+    title: `... and ${remaining} more ${itemLabel}${remaining === 1 ? '' : 's'} (truncated at maxTopics)`,
+    description: `The IDS validation report contained more ${itemLabel}s than the configured maxTopics limit. ${remaining} additional ${remaining === 1 ? 'entry was' : 'entries were'} not exported as BCF topics.`,
+    author,
+    topicType: 'Info',
+    topicStatus: 'Open',
+    labels: ['IDS', 'truncated'],
+  });
+  project.topics.set(topic.guid, topic);
+}
+
 // ============================================================================
 // Per-entity grouping (default — recommended)
 // ============================================================================
@@ -280,15 +345,30 @@ function buildTopicsPerEntity(
   opts: BuildOptions,
 ): void {
   let topicCount = 0;
+  let qualifyingCount = 0;
 
   for (const specResult of report.specificationResults) {
     if (specResult.status === 'not_applicable') continue;
 
-    for (const entity of specResult.entityResults) {
-      if (topicCount >= opts.maxTopics) return;
+    // A cardinality-only failure (required entity type matched zero
+    // times) has no entities to iterate below — without this branch the
+    // failure is invisible in per-entity grouping.
+    if (specResult.status === 'fail' && specResult.entityResults.length === 0) {
+      qualifyingCount++;
+      if (topicCount < opts.maxTopics) {
+        const topic = createCardinalityFailureTopic(specResult, opts.author, opts.failureTopicType);
+        project.topics.set(topic.guid, topic);
+        topicCount++;
+      }
+      continue;
+    }
 
+    for (const entity of specResult.entityResults) {
       // Skip passing entities unless requested
       if (entity.passed && !opts.includePassingEntities) continue;
+
+      qualifyingCount++;
+      if (topicCount >= opts.maxTopics) continue;
 
       const failedReqs = entity.requirementResults.filter(r => r.status === 'fail');
       const totalReqs = entity.requirementResults.filter(r => r.status !== 'not_applicable').length;
@@ -343,6 +423,8 @@ function buildTopicsPerEntity(
       topicCount++;
     }
   }
+
+  addTruncationNoticeTopic(project, opts.author, qualifyingCount - topicCount, 'entity');
 }
 
 // ============================================================================
@@ -355,10 +437,12 @@ function buildTopicsPerSpecification(
   opts: Omit<BuildOptions, 'includePassingEntities' | 'passTopicType'>,
 ): void {
   let topicCount = 0;
+  let qualifyingCount = 0;
 
   for (const specResult of report.specificationResults) {
     if (specResult.status !== 'fail') continue;
-    if (topicCount >= opts.maxTopics) return;
+    qualifyingCount++;
+    if (topicCount >= opts.maxTopics) continue;
 
     const failedEntities = specResult.entityResults.filter(e => !e.passed);
 
@@ -414,6 +498,8 @@ function buildTopicsPerSpecification(
     project.topics.set(topic.guid, topic);
     topicCount++;
   }
+
+  addTruncationNoticeTopic(project, opts.author, qualifyingCount - topicCount, 'specification');
 }
 
 // ============================================================================
@@ -426,16 +512,31 @@ function buildTopicsPerRequirement(
   opts: Omit<BuildOptions, 'includePassingEntities' | 'passTopicType'>,
 ): void {
   let topicCount = 0;
+  let qualifyingCount = 0;
 
   for (const specResult of report.specificationResults) {
     if (specResult.status !== 'fail') continue;
+
+    // Cardinality-only failure — no entity/requirement to attach a topic
+    // to below. Same fallback as buildTopicsPerEntity, for the same
+    // reason: otherwise the failure has no BCF topic anywhere.
+    if (specResult.entityResults.length === 0) {
+      qualifyingCount++;
+      if (topicCount < opts.maxTopics) {
+        const topic = createCardinalityFailureTopic(specResult, opts.author, opts.failureTopicType);
+        project.topics.set(topic.guid, topic);
+        topicCount++;
+      }
+      continue;
+    }
 
     for (const entity of specResult.entityResults) {
       if (entity.passed) continue;
 
       for (const req of entity.requirementResults) {
         if (req.status !== 'fail') continue;
-        if (topicCount >= opts.maxTopics) return;
+        qualifyingCount++;
+        if (topicCount >= opts.maxTopics) continue;
 
         const entityLabel = entity.entityName || `#${entity.expressId}`;
 
@@ -472,6 +573,8 @@ function buildTopicsPerRequirement(
       }
     }
   }
+
+  addTruncationNoticeTopic(project, opts.author, qualifyingCount - topicCount, 'requirement failure');
 }
 
 // ============================================================================

--- a/packages/sdk/src/namespaces/ids.test.ts
+++ b/packages/sdk/src/namespaces/ids.test.ts
@@ -133,9 +133,20 @@ describe('IDSNamespace.summarize', () => {
 
     expect(summary.totalSpecifications).toBe(3);
     expect(summary.failedSpecifications).toBe(1);
-    // Legacy shape invariant: passed + failed = total, so a
-    // not-applicable spec counts as non-failed here.
-    expect(summary.passedSpecifications).toBe(2);
+    // A not_applicable spec is neither pass nor fail — it must not be
+    // folded into either bucket. `packages/ids/src/validation/validator.ts`
+    // `calculateSummary` treats it this way already (only 'pass'/'fail'
+    // increment their respective counters); this namespace's summarize()
+    // used to fold it into `passedSpecifications` via an unconditional
+    // `else`, which made a CLI `--json` run disagree with the CLI's own
+    // text-mode output (`report.summary`) and the validator on any model
+    // whose IDS had a spec matching zero entities with no cardinality
+    // requirement forcing a match.
+    expect(summary.passedSpecifications).toBe(1);
+    expect(summary.notApplicableSpecifications).toBe(1);
+    expect(summary.passedSpecifications + summary.failedSpecifications + summary.notApplicableSpecifications).toBe(
+      summary.totalSpecifications,
+    );
   });
 
   it('prohibited spec violated by passing entities counts as failed when status says so', () => {

--- a/packages/sdk/src/namespaces/ids.ts
+++ b/packages/sdk/src/namespaces/ids.ts
@@ -18,6 +18,15 @@ export interface IDSValidationSummary {
   totalSpecifications: number;
   passedSpecifications: number;
   failedSpecifications: number;
+  /**
+   * Specifications whose applicability matched no entities and whose
+   * cardinality does not require a match (e.g. no `minOccurs`). Neither
+   * a pass nor a fail — kept separate so `passed + failed +
+   * notApplicable === total` always holds, matching
+   * `@ifc-lite/ids`'s `IDSValidationSummary.overallPassRate` denominator
+   * semantics (not_applicable specs are never counted as passed there).
+   */
+  notApplicableSpecifications: number;
   totalEntities: number;
   passedEntities: number;
   failedEntities: number;
@@ -223,7 +232,7 @@ export class IDSNamespace {
       status?: 'pass' | 'fail' | 'not_applicable';
     }>;
   }): IDSValidationSummary {
-    let totalSpecs = 0, passedSpecs = 0, failedSpecs = 0;
+    let totalSpecs = 0, passedSpecs = 0, failedSpecs = 0, notApplicableSpecs = 0;
     let totalEntities = 0, passedEntities = 0, failedEntities = 0;
 
     for (const spec of report.specificationResults) {
@@ -239,11 +248,31 @@ export class IDSNamespace {
       // entities), which entity results alone cannot express. Deriving
       // from entities here used to make this summary disagree with the
       // validator's report.summary for exactly those specs.
+      //
+      // A spec explicitly marked not_applicable is neither pass nor
+      // fail. It used to fall through to an unconditional `else` and get
+      // counted as passed — silently inflating the spec-level pass rate
+      // for any IDS containing a spec that matched nothing. There is no
+      // legacy-shape fallback for `status === undefined` here because
+      // `not_applicable` only ever comes from the validator, which always
+      // sets `status`.
+      if (spec.status === 'not_applicable') {
+        notApplicableSpecs++;
+        continue;
+      }
       const specFailed = spec.status !== undefined ? spec.status === 'fail' : anyEntityFailed;
       if (specFailed) failedSpecs++;
       else passedSpecs++;
     }
 
-    return { totalSpecifications: totalSpecs, passedSpecifications: passedSpecs, failedSpecifications: failedSpecs, totalEntities, passedEntities, failedEntities };
+    return {
+      totalSpecifications: totalSpecs,
+      passedSpecifications: passedSpecs,
+      failedSpecifications: failedSpecs,
+      notApplicableSpecifications: notApplicableSpecs,
+      totalEntities,
+      passedEntities,
+      failedEntities,
+    };
   }
 }


### PR DESCRIPTION
IDS results were dropped or miscounted across the CLI JSON output and BCF export. Found on an unraised branch; merges clean onto current `main`.

## Verified on both sides

RED reproduced by reverting each production hunk individually:

**SDK** — reverting the `not_applicable` branch in `packages/sdk/src/namespaces/ids.ts`:
```
× prefers the validator spec status — cardinality-only failures count as failed
  AssertionError: expected 2 to be 1
```

**BCF** — reverting the two cardinality fallbacks in `packages/bcf/src/ids-reporter.ts`:
```
× does not silently drop a cardinality-only failure (zero applicable entities) in per-entity grouping
  AssertionError: per-entity grouping dropped the cardinality-only failure: expected 0 to be greater than 0
```

**BCF truncation** — removing the three `addTruncationNoticeTopic` calls produces 3 failures, including the pre-existing `should respect maxTopics limit`.

`packages/bcf` 183/183, `packages/sdk` 178/178. api-surface, unused-locals and changesets all green — the new `notApplicableSpecifications` field sits on an interface outside the tracked export surface.

## Three review notes

**A — an undocumented semantic change.** `maxTopics` now caps *real* topics and adds one synthetic `Info` notice on top, so `topics.size` can be `maxTopics + 1`. The branch updates the existing test's expectation from 1 to 2 accordingly, which is legitimate — but neither changeset mentions that the cap can be exceeded. Worth one sentence before this lands.

**B — the same bug survives in a third place, out of this branch's scope.** `packages/mcp/src/tools/validation.ts:99-121` holds an independent summarizer that ignores `spec.status` entirely: a `not_applicable` spec (empty `entityResults`) makes `specPassed = false`, so **MCP counts it failed while the SDK counts it passed**. The changeset claims to reconcile the CLI `--json` vs text divergence; that reconciliation does not reach MCP, which stays divergent in the opposite direction. This is a grep-confirmed code read, not an executed divergence — flagged rather than fixed, since widening scope here would obscure what the branch was verified against.

**C — asymmetric coverage.** The per-*requirement* grouping cardinality fallback has no test: removing it alone leaves the suite green. Only the per-entity fallback is pinned.

Three summarizers for one question is the shape that produced this issue in the first place; B is worth its own follow-up rather than a fourth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
