### PR TITLE
fix(renderer): anchor *-middle box alignments to the correct horizontal point

### DIFF
--- a/.changeset/symbolic-box-alignment-middle-column.md
+++ b/.changeset/symbolic-box-alignment-middle-column.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix `IfcTextLiteralWithExtent` annotation text with a `"top-middle"` or `"bottom-middle"` `BoxAlignment` rendering left-aligned (and `"bottom-middle"` also rendering vertically mid-height) instead of horizontally centered.
+
+The IFC4 `IfcBoxAlignment` WHERE rule pins the enum to `'top-left', 'top-middle', 'top-right', 'middle-left', 'center', 'middle-right', 'bottom-left', 'bottom-middle', 'bottom-right'`. The word `"middle"` is overloaded in that set: it's the vertical qualifier in `"middle-left"`/`"middle-right"` but the *horizontal* qualifier in `"top-middle"`/`"bottom-middle"`. `parseBoxAlignment` in `symbolic-overlay-pipelines.ts` checked `includes('middle')` without regard to position, so it read every `"*-middle"` value as vertical-middle instead of horizontal-center, and never treated `"middle"` as a horizontal signal at all. Compound values are now split on the hyphen so the first token decides vertical and the second decides horizontal, matching the row-then-column order the enum itself uses.

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -603,9 +603,12 @@ export class Section2DOverlayRenderer {
     // 0.3m bias was there to keep the outline lines clear of below-plane
     // geometry, but it made the cap visually drift off the slider plane
     // (users could see a 0.3m gap between the plane preview and the cap).
-    // The fill pipeline uses depthCompare 'always' so z-fighting with
-    // coincident below-plane top faces is not an issue; the stencil gate
-    // keeps the fill restricted to the actual cap polygons.
+    // The fill pipeline uses depthCompare 'greater-equal' (reverse-Z) so the
+    // cap ties cleanly with coincident below-plane top faces and is occluded
+    // by nearer model geometry — see the depthStencil comment on
+    // `fillPipeline` above. There is no stencil test; the fill is restricted
+    // to the actual cap polygons by the triangle-plane intersection geometry
+    // `SectionCutter` produces, not by a stencil gate.
     const offset: [number, number, number] = [0, 0, 0];
 
     // Update uniforms. Field offsets come from SECTION_2D_UNIFORM_SLOTS, which

--- a/packages/renderer/src/symbolic-overlay-pipelines.test.ts
+++ b/packages/renderer/src/symbolic-overlay-pipelines.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { parseBoxAlignment } from './symbolic-overlay-pipelines.js';
+
+/**
+ * `parseBoxAlignment` decodes IFC `BoxAlignment` (`IfcTextLiteralWithExtent`)
+ * into normalized offsets. The type's WHERE rule in the EXPRESS schema
+ * (`IFC4_ADD2_TC1.exp`, `IfcBoxAlignment.WR1`) pins the exact string set:
+ *
+ *   ['top-left', 'top-middle', 'top-right', 'middle-left', 'center',
+ *    'middle-right', 'bottom-left', 'bottom-middle', 'bottom-right']
+ *
+ * Note the asymmetry baked into the spec itself: the row qualifier is
+ * top/middle/bottom, the column qualifier is left/middle/right — 'middle'
+ * means "vertically centered" as a PREFIX ("middle-left") but "horizontally
+ * centered" as a SUFFIX ("top-middle", "bottom-middle"). A parser that
+ * checks `includes('middle')` without regard to position cannot tell those
+ * apart and misreads half the enum.
+ */
+describe('parseBoxAlignment: the full IfcBoxAlignment enum (IFC4 WR1)', () => {
+  const cases: Array<[string, { horizontal: number; vertical: number }]> = [
+    ['top-left',      { horizontal: 0,    vertical: 0 }],
+    ['top-middle',    { horizontal: -0.5, vertical: 0 }],
+    ['top-right',     { horizontal: -1,   vertical: 0 }],
+    ['middle-left',   { horizontal: 0,    vertical: -0.5 }],
+    ['center',        { horizontal: -0.5, vertical: -0.5 }],
+    ['middle-right',  { horizontal: -1,   vertical: -0.5 }],
+    ['bottom-left',   { horizontal: 0,    vertical: -1 }],
+    ['bottom-middle', { horizontal: -0.5, vertical: -1 }],
+    ['bottom-right',  { horizontal: -1,   vertical: -1 }],
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`'${input}' -> horizontal=${expected.horizontal}, vertical=${expected.vertical}`, () => {
+      assert.deepStrictEqual(parseBoxAlignment(input), expected);
+    });
+  }
+
+  it('empty string falls back to bottom-left (IFC4 default)', () => {
+    assert.deepStrictEqual(parseBoxAlignment(''), { horizontal: 0, vertical: -1 });
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    assert.deepStrictEqual(parseBoxAlignment('  TOP-MIDDLE  '), { horizontal: -0.5, vertical: 0 });
+  });
+});

--- a/packages/renderer/src/symbolic-overlay-pipelines.ts
+++ b/packages/renderer/src/symbolic-overlay-pipelines.ts
@@ -676,32 +676,49 @@ export class SymbolicTextPipeline {
  * IFC BoxAlignment → normalized offsets in [-1, 0] for vertical and
  * horizontal axes. Returned offset is multiplied by the relevant span.
  *
- * Vertical:
+ * The EXPRESS WHERE rule (`IfcBoxAlignment.WR1`, `IFC4_ADD2_TC1.exp`) pins
+ * the exact 9-value enum: 'top-left', 'top-middle', 'top-right',
+ * 'middle-left', 'center', 'middle-right', 'bottom-left', 'bottom-middle',
+ * 'bottom-right'. Note the row/column asymmetry the spec itself bakes in:
+ * the ROW qualifier is top/middle/bottom, the COLUMN qualifier is
+ * left/middle/right — so "middle" means vertical-center as the first token
+ * ("middle-left") but horizontal-center as the second token ("top-middle",
+ * "bottom-middle"). A plain `includes('middle')` cannot tell those apart —
+ * it used to read "bottom-middle" as vertical=middle (wrong: it's the
+ * bottom row) and every "*-middle" as horizontal=left (wrong: it's the
+ * middle column). Splitting on the hyphen resolves the ambiguity: the
+ * first token decides vertical, the second decides horizontal, matching
+ * the row-then-column order every compound value in the enum uses.
+ *
+ * Vertical (from the first token, or the whole string for a single-token
+ * value like "center"):
  *   "top"     →  0   (no offset)
  *   "middle"  → -0.5
  *   "bottom"  → -1   (default per IFC)
- * Horizontal:
+ * Horizontal (from the second token, or the whole string for a single-token
+ * value):
  *   "left"    →  0   (default per IFC)
- *   "center"  → -0.5
+ *   "middle" / "center" → -0.5
  *   "right"   → -1
  *
- * Unknown values fall back to ("bottom", "left"). Single-token values like
- * "center" are interpreted as { vertical: "middle", horizontal: "center" }.
+ * Unknown / empty values fall back to ("bottom", "left").
  */
-function parseBoxAlignment(s: string): { horizontal: number; vertical: number } {
+export function parseBoxAlignment(s: string): { horizontal: number; vertical: number } {
   const norm = s.toLowerCase().trim();
-  let horizontal = 0;
-  let vertical = -1;
+  if (norm === '') return { horizontal: 0, vertical: -1 };
 
-  if (norm === '') return { horizontal, vertical };
+  const parts = norm.split('-');
+  const verticalToken = parts.length >= 2 ? parts[0] : norm;
+  const horizontalToken = parts.length >= 2 ? parts[1] : norm;
 
-  if (norm.includes('top')) vertical = 0;
-  else if (norm.includes('middle')) vertical = -0.5;
-  else if (norm.includes('center') && !norm.includes('center-')) vertical = -0.5;
+  let vertical: number;
+  if (verticalToken.includes('top')) vertical = 0;
+  else if (verticalToken.includes('middle') || verticalToken.includes('center')) vertical = -0.5;
   else vertical = -1;
 
-  if (norm.includes('right')) horizontal = -1;
-  else if (norm.includes('center')) horizontal = -0.5;
+  let horizontal: number;
+  if (horizontalToken.includes('right')) horizontal = -1;
+  else if (horizontalToken.includes('middle') || horizontalToken.includes('center')) horizontal = -0.5;
   else horizontal = 0;
 
   return { horizontal, vertical };


### PR DESCRIPTION
`parseBoxAlignment` misreads the horizontal-middle column, so symbolic text is anchored to the wrong point. Found on an unraised branch; merges clean.

RED reproduced by reverting only the `parseBoxAlignment` body in `packages/renderer/src/symbolic-overlay-pipelines.ts`:

```
not ok 2  - 'top-middle'    -> horizontal=-0.5, vertical=0
not ok 8  - 'bottom-middle' -> horizontal=-0.5, vertical=-1
not ok 11 - is case-insensitive and trims whitespace
# tests 11 / pass 8 / fail 3
```

Checked the new logic by hand against all nine `IfcBoxAlignment` WR1 values: `middle-left`, `middle-right`, `center` and the four corners are **unchanged** — only the two `*-middle` values move. So the blast radius is exactly the two alignments that were wrong.

`packages/renderer` 967/967. api-surface, unused-locals, changesets green.

**One thing to decide before merge:** the branch also rewrites a stale comment in `section-2d-overlay.ts` (`depthCompare 'always'` + "stencil gate" → `'greater-equal'`, no stencil). The rewrite is correct against the surrounding code, but it is unrelated to the changeset. Either mention it in the release note or drop it from this branch — it should not ride along silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
