### PR TITLE
fix(drawing-2d): add the missing DXF $INSUNITS codes 17-24

### DIFF
--- a/.changeset/dxf-insunits-survey-units.md
+++ b/.changeset/dxf-insunits-survey-units.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/drawing-2d": patch
+---
+
+Fix DXF import treating $INSUNITS codes 17-24 (gigametres, astronomical units, light years, parsecs, and US Survey feet/inch/yard/mile) as unknown and falling back to metres.
+
+The most consequential of these is 21 (US Survey Feet): a civil/survey DXF authored in that unit previously came in at roughly 1/3.28 scale — a large, visible error — even though the fallback correctly warned about the unknown code. US Survey Feet is now converted using its exact legal definition, 1200/3937 m (≈0.3048006096012192 m), not the international foot (0.3048 m exactly); the ~2 parts-per-million difference between the two is the entire reason US Survey Feet is a distinct $INSUNITS code, so Survey inch/yard/mile are derived from the survey foot rather than from international units.

--- a/packages/drawing-2d/src/dxf/convert.ts
+++ b/packages/drawing-2d/src/dxf/convert.ts
@@ -36,6 +36,15 @@ import type {
   DxfUnderlayText,
 } from './types.js';
 
+/**
+ * US Survey Foot, defined exactly as 1200/3937 m (≈ 0.3048006096012192 m).
+ * This is ~2ppm larger than the international foot (0.3048 m exactly) —
+ * the entire reason it is a distinct $INSUNITS code. Survey inch/yard/mile
+ * below are derived from this constant, not from the international foot,
+ * so that distinction isn't silently thrown away.
+ */
+const US_SURVEY_FOOT_METRES = 1200 / 3937;
+
 /** $INSUNITS → metres. Unknown codes fall back to 1 with a warning. */
 const INSUNITS_TO_METRES: Record<number, number> = {
   0: 1, // unitless: assume metres (adjustable via placement scale)
@@ -55,6 +64,14 @@ const INSUNITS_TO_METRES: Record<number, number> = {
   14: 0.1, // decimetres
   15: 10, // decametres
   16: 100, // hectometres
+  17: 1e9, // gigametres
+  18: 1.495978707e11, // astronomical units (IAU 2012 exact definition)
+  19: 9.4607304725808e15, // light years (Julian light year, exact)
+  20: 3.0856775814913673e16, // parsecs (IAU 2015 exact definition)
+  21: US_SURVEY_FOOT_METRES, // US Survey Feet
+  22: US_SURVEY_FOOT_METRES / 12, // US Survey Inch
+  23: US_SURVEY_FOOT_METRES * 3, // US Survey Yard
+  24: US_SURVEY_FOOT_METRES * 5280, // US Survey Mile
 };
 
 /** Recursion guard for nested INSERTs. */

--- a/packages/drawing-2d/src/dxf/convert.ts
+++ b/packages/drawing-2d/src/dxf/convert.ts
@@ -67,7 +67,7 @@ const INSUNITS_TO_METRES: Record<number, number> = {
   17: 1e9, // gigametres
   18: 1.495978707e11, // astronomical units (IAU 2012 exact definition)
   19: 9.4607304725808e15, // light years (Julian light year, exact)
-  20: 3.0856775814913673e16, // parsecs (IAU 2015 exact definition)
+  20: 3.085677581491367e16, // parsecs (IAU 2015; written at the precision f64 carries)
   21: US_SURVEY_FOOT_METRES, // US Survey Feet
   22: US_SURVEY_FOOT_METRES / 12, // US Survey Inch
   23: US_SURVEY_FOOT_METRES * 3, // US Survey Yard

--- a/packages/drawing-2d/src/dxf/dxf.test.ts
+++ b/packages/drawing-2d/src/dxf/dxf.test.ts
@@ -325,6 +325,24 @@ describe('DXF parser', () => {
     expect(layerByName(underlay, '0').paths).toHaveLength(1);
   });
 
+  it('scales $INSUNITS=21 (US Survey Feet) using the exact 1200/3937 m definition, not the international foot', () => {
+    const text =
+      pairsToText(
+        [0, 'SECTION'],
+        [2, 'HEADER'],
+        [9, '$INSUNITS'],
+        [70, 21],
+        [0, 'ENDSEC'],
+      ) +
+      entitiesSection([0, 'LINE'], [8, '0'], [10, 0], [20, 0], [11, 1], [21, 0]);
+    const underlay = importDxf(text);
+    // US Survey Foot = 1200/3937 m exactly (~0.3048006096012192), NOT 0.3048.
+    expect(underlay.unitScale).toBeCloseTo(1200 / 3937, 12);
+    // The 2ppm difference from the international foot must be preserved.
+    expect(underlay.unitScale).not.toBeCloseTo(0.3048, 9);
+    expect(underlay.warnings.some((w) => w.includes('Unknown $INSUNITS'))).toBe(false);
+  });
+
   it('rejects binary DXF and malformed group codes with clear errors', () => {
     expect(() => parseDxf('AutoCAD Binary DXF\r\n rubbish')).toThrow(/Binary DXF/);
     expect(() => parseDxf('0\nSECTION\nnot-a-code\nvalue\n')).toThrow(/group code/);


### PR DESCRIPTION
DXF `$INSUNITS` codes 17–24 were missing from `INSUNITS_TO_METRES`, so a file declaring any of them imported at the wrong scale. Found on an unraised branch; merges clean.

RED reproduced by removing the eight new entries:

```
× scales $INSUNITS=21 (US Survey Feet) using the exact 1200/3937 m definition,
  not the international foot
  AssertionError: expected 1 to be close to 0.3048006096012192,
  received difference is 0.6951993903987808
```

## Constants checked individually

Each verified against the DXF `$INSUNITS` table and its standard value: 17 Gm, 18 AU (1.495978707e11, exact by definition), 19 light-year (Julian, 9.4607304725808e15, exact), 20 parsec (3.0856775814913673e16), 21–24 US Survey feet/inches/yards/miles.

The survey-unit handling is the part worth noting: survey inch, yard and mile are **derived from the survey foot** (1200/3937) rather than from international units, and survey mile is 5280 survey feet. That is the correct call — mixing the two definitions is exactly how a survey-unit file ends up ~2 ppm off, which compounds over site-scale coordinates.

`packages/drawing-2d` 372/372. api-surface, unused-locals, changesets green.

**Coverage limit, stated plainly:** only code 21 has a test. Codes 17–20 and 22–24 were verified **by reading** the constants against their definitions, not by running. If you would rather each had a case, that is a reasonable ask — the table is mechanical enough that one parameterised test would cover all eight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional DXF insertion units, including gigametres, astronomical units, light years, parsecs, and US Survey units.
  - US Survey Feet and related units now use precise conversion factors for improved measurement accuracy.

- **Bug Fixes**
  - Corrected DXF unit handling so US Survey Feet are distinguished from international feet without generating unknown-unit warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->