### PR TITLE
fix(export): encode non-ASCII with X2/X4 directives in written STEP files

### DIFF
--- a/.changeset/step-export-non-ascii-x2-directive.md
+++ b/.changeset/step-export-non-ascii-x2-directive.md
@@ -1,0 +1,8 @@
+---
+"@ifc-lite/export": patch
+"@ifc-lite/data": patch
+---
+
+Fix the STEP/IFC exporter writing non-ASCII characters (accented Latin, Cyrillic, CJK, emoji, etc.) as raw UTF-8 bytes instead of ISO 10303-21 `\X2\`/`\X4\` control directives.
+
+ISO 10303-21 6.3.3.4 restricts a string literal's plain-text bytes to the basic graphic range 32-126; every other character must be a control directive, never a raw byte. A consumer that treats the file's bytes as ISO-8859-1 — the byte encoding the base standard and most real-world IFC tooling assumes for IFC2X3/IFC4/IFC4X3 — turned any name, label, or description carrying a non-ASCII character into mojibake or a broken parse. `escapeStepString` (in both `@ifc-lite/export` and `@ifc-lite/data`, the two copies that back the STEP writer and the shared header/entity serializer) now encodes such characters as `\X2\HHHH\X0\` (BMP) or `\X4\HHHHHHHH\X0\` (non-BMP), matching what our own reader already decodes and what real IFC tools expect.

--- a/.changeset/wasm-step-export-non-ascii-x2-directive.md
+++ b/.changeset/wasm-step-export-non-ascii-x2-directive.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix the Rust STEP writer (`ifc-lite-export`'s `step_text::escape`, used by `export_step`/`merged.rs`) writing non-ASCII characters as raw UTF-8 bytes instead of ISO 10303-21 `\X2\`/`\X4\` control directives — the same defect and fix as the TS-side `@ifc-lite/export`/`@ifc-lite/data` change. `ifc_lite_core::encode_ifc_string` already implemented the correct directive encoding but was never wired into this writer; it now is.

--- a/packages/data/src/step-serializers.test.ts
+++ b/packages/data/src/step-serializers.test.ts
@@ -89,3 +89,16 @@ describe('generateHeader control-char handling', () => {
     expect(fileNameLine).not.toContain('Line2\n');
   });
 });
+
+describe('generateHeader non-ASCII encoding (ISO 10303-21 6.3.3.4)', () => {
+  // Same spec clause / buildingSMART guidance as the export package's
+  // `escapeStepString` test: a string literal's plain-text bytes are
+  // restricted to decimal 32-126; a byte outside that range must be a
+  // `\X2\`/`\X4\` control directive, never emitted raw.
+  it('encodes a BMP character in FILE_NAME as \\X2\\HHHH\\X0\\, not raw UTF-8', () => {
+    const header = generateHeader({ schema: 'IFC4', author: ['Trümpler'] });
+    const fileNameLine = header.split('\n').find((l) => l.startsWith('FILE_NAME'));
+    expect(fileNameLine).toContain('Tr\\X2\\00FC\\X0\\mpler');
+    expect(fileNameLine).not.toContain('Trümpler');
+  });
+});

--- a/packages/data/src/step-serializers.ts
+++ b/packages/data/src/step-serializers.ts
@@ -180,13 +180,38 @@ export function serializeValue(value: StepValue): string {
  * value can never inject a physical line break into the line-oriented STEP
  * output (matching the export package's escaper) — a raw newline in a header
  * or attribute value would otherwise split one record across two lines.
+ *
+ * ISO 10303-21 6.3.3.4 restricts a string literal's plain-text bytes to the
+ * "basic graphic" range 32-126; every other character is a control directive
+ * (`\X\HH`, `\X2\HHHH\X0\`, `\X4\HHHHHHHH\X0\`), never a raw byte —
+ * buildingSMART's IFC string-encoding guidance states the same for
+ * IFC2X3/IFC4/IFC4X3. A reader that treats the file's bytes as ISO-8859-1 —
+ * the byte encoding the base standard and most real consumers assume — turns
+ * a raw UTF-8 multi-byte sequence into mojibake or a broken parse (reported,
+ * reproduced in real IFC tooling: IfcOpenShell#699/#1016, files rejected by
+ * Solibri). Matches `@ifc-lite/export`'s `escapeStepString`.
  */
 function escapeStepString(str: string): string {
-  return str
+  const escaped = str
     .replace(/\\/g, '\\\\')  // Backslash
     .replace(/'/g, "''")     // Single quote
     // eslint-disable-next-line no-control-regex
     .replace(/[\x00-\x1F\x7F]+/g, ' '); // Collapse control chars
+  // Non-ASCII directive encoding, one character at a time. Must run AFTER
+  // backslash-doubling above: the directive's own backslashes are literal
+  // syntax the reader expects undoubled.
+  let out = '';
+  for (const ch of escaped) {
+    const cp = ch.codePointAt(0)!;
+    if (cp >= 32 && cp <= 126) {
+      out += ch;
+    } else if (cp <= 0xFFFF) {
+      out += `\\X2\\${cp.toString(16).toUpperCase().padStart(4, '0')}\\X0\\`;
+    } else {
+      out += `\\X4\\${cp.toString(16).toUpperCase().padStart(8, '0')}\\X0\\`;
+    }
+  }
+  return out;
 }
 
 /**

--- a/packages/data/src/step-value-strings.test.ts
+++ b/packages/data/src/step-value-strings.test.ts
@@ -14,11 +14,12 @@
  *
  *   - a literal from a REAL FILE now decodes its directives (the first block);
  *   - a value written by this module's own `escapeStepString` still comes back
- *     byte-identical (the second block). That writer emits non-ASCII RAW and
- *     never emits a directive, so every `\\` it produces really is a doubled
- *     reverse solidus — and giving directives precedence in the scan is exactly
- *     what keeps `\\X2\\…` reading as the LITERAL text `\X2\…` rather than
- *     decoding to the character it would have meant unescaped.
+ *     byte-identical (the second block), including a value that merely LOOKS
+ *     like a directive: `escapeStepString` doubles every reverse solidus in
+ *     the caller's text, so `\X2\00FC\X0\` typed by a user becomes
+ *     `\\X2\\00FC\\X0\\` on disk, and giving directives precedence in the
+ *     scan is exactly what keeps that doubled form reading back as the
+ *     LITERAL text `\X2\00FC\X0\` rather than decoding to `ü`.
  *
  * Note how the fixtures are built. A source literal is spelled with explicit
  * `\\` in the TS string so the file says what bytes are on disk; the expected
@@ -91,9 +92,11 @@ describe('the escapeStepString / parseStepValue pair stays closed', () => {
     expect(roundTrip("it's")).toBe("it's");
   });
 
-  it('a non-ASCII value survives - the writer emits it RAW', () => {
-    // No directive is written, so nothing for the reader to decode; the point
-    // is that the reader must not invent one.
+  it('a non-ASCII value survives - the writer emits an \\X2\\ directive, not raw UTF-8', () => {
+    // ISO 10303-21 6.3.3.4 / buildingSMART's IFC string-encoding guidance:
+    // bytes outside decimal 32-126 must be a control directive, never a raw
+    // byte. `escapeStepString` now emits one; this checks the writer and
+    // reader still agree once it does.
     expect(roundTrip('Trümpler')).toBe('Trümpler');
   });
 

--- a/packages/export/src/step-serialization.test.ts
+++ b/packages/export/src/step-serialization.test.ts
@@ -12,6 +12,7 @@ import {
   resolveExpressBase,
   tokenIsRealLiteral,
   toStepReal,
+  escapeStepString,
 } from './step-serialization.js';
 import { toStepRealScaled } from './unit-normalize.js';
 
@@ -192,5 +193,30 @@ describe('toStepRealScaled', () => {
     for (const v of [Number.MAX_VALUE, Number.MIN_VALUE, -1.5e-300, 1e-7, 123.456]) {
       expect(toStepRealScaled(v)).toMatch(STEP_REAL_RE);
     }
+  });
+});
+
+describe('escapeStepString non-ASCII encoding (ISO 10303-21 6.3.3.4)', () => {
+  // ISO 10303-21 restricts a string literal's plain-text bytes to the "basic
+  // graphic" range 32-126; anything outside it is a control directive
+  // (\X\HH, \X2\HHHH\X0\, \X4\HHHHHHHH\X0\), never a raw byte. buildingSMART's
+  // own IFC string-encoding guidance states the same for IFC2X3/IFC4/IFC4X3:
+  // "characters ... represented by decimal value 32 to 126 ... any other
+  // character ... has to be encoded" (e.g. German 'Ä' as '\X2\00C4\X0\').
+  // A reader that treats the file bytes as ISO-8859-1 (the byte encoding real
+  // consumers - and the base standard - assume) turns a raw UTF-8 multi-byte
+  // sequence into mojibake or an outright parse break; this is a reported,
+  // reproduced defect in real IFC tooling (IfcOpenShell#699, files rejected
+  // by Solibri) for exactly this shape of writer bug.
+  it('encodes a BMP character as \\X2\\HHHH\\X0\\, not raw UTF-8', () => {
+    expect(escapeStepString('Trümpler')).toBe('Tr\\X2\\00FC\\X0\\mpler');
+  });
+
+  it('encodes a non-BMP character (emoji) as \\X4\\HHHHHHHH\\X0\\', () => {
+    expect(escapeStepString('😀')).toBe('\\X4\\0001F600\\X0\\');
+  });
+
+  it('leaves printable ASCII untouched', () => {
+    expect(escapeStepString('plain text 123')).toBe('plain text 123');
   });
 });

--- a/packages/export/src/step-serialization.ts
+++ b/packages/export/src/step-serialization.ts
@@ -104,18 +104,56 @@ export function serializeTypedMarker(type: string, value: string | number | bool
 }
 
 /**
- * Escape a string for STEP format (backslash and single-quote escaping).
+ * Escape a string for STEP format: backslash and single-quote doubling, plus
+ * non-ASCII directive encoding.
  *
  * Control characters (CR/LF and other C0 codes) are collapsed to a single
  * space so every generated STEP entity stays on one physical line and
  * round-trips through the line-oriented merge/convert paths.
+ *
+ * ISO 10303-21 6.3.3.4 restricts a string literal's plain-text bytes to the
+ * "basic graphic" range 32-126; every other character is a control directive
+ * (`\X\HH`, `\X2\HHHH\X0\`, `\X4\HHHHHHHH\X0\`), never a raw byte — and
+ * buildingSMART's IFC string-encoding guidance states the same for the
+ * IFC2X3/IFC4/IFC4X3 schemas this exporter targets: characters outside
+ * decimal 32-126 "have to be encoded" (e.g. 'Ä' as `\X2\00C4\X0\`). A reader
+ * that treats the file's bytes as ISO-8859-1 — the byte encoding the base
+ * standard and most real consumers assume for these schemas — turns a raw
+ * UTF-8 multi-byte sequence into mojibake or a broken parse; this exact
+ * writer shape is a reported, reproduced defect in real IFC tooling
+ * (IfcOpenShell#699/#1016; files rejected by Solibri). Encoded one character
+ * at a time (never batching a run into one `\X2\...\X0\` block) to keep the
+ * encoder trivially correct; ISO 10303-21 allows either.
  */
 export function escapeStepString(str: string): string {
-  return str
+  const escaped = str
     .replace(/\\/g, '\\\\')
     .replace(/'/g, "''")
     // eslint-disable-next-line no-control-regex
     .replace(/[\x00-\x1F\x7F]+/g, ' ');
+  return encodeNonAsciiStepDirectives(escaped);
+}
+
+/**
+ * Replace every character outside the STEP "basic graphic" range (32-126)
+ * with its `\X2\`/`\X4\` directive. Must run AFTER backslash-doubling: the
+ * directive's own backslashes are literal syntax the reader expects
+ * undoubled, so escaping non-ASCII first would corrupt them when the
+ * backslash-doubling pass ran afterward.
+ */
+function encodeNonAsciiStepDirectives(str: string): string {
+  let out = '';
+  for (const ch of str) {
+    const cp = ch.codePointAt(0)!;
+    if (cp >= 32 && cp <= 126) {
+      out += ch;
+    } else if (cp <= 0xFFFF) {
+      out += `\\X2\\${cp.toString(16).toUpperCase().padStart(4, '0')}\\X0\\`;
+    } else {
+      out += `\\X4\\${cp.toString(16).toUpperCase().padStart(8, '0')}\\X0\\`;
+    }
+  }
+  return out;
 }
 
 /**

--- a/rust/export/src/step_text.rs
+++ b/rust/export/src/step_text.rs
@@ -9,9 +9,17 @@
 //! orchestration that stays in `step.rs`.
 
 /// Escape a STEP string literal body: double the apostrophe and reverse
-/// solidus, and map every ASCII control character (the C0 range plus DEL) to
-/// a space, since ISO 10303-21 restricts a literal's plain-text bytes to the
-/// basic graphic range 32-126.
+/// solidus, map every ASCII control character (the C0 range plus DEL) to a
+/// space, and encode any character outside the basic graphic range as its
+/// `\X2\`/`\X4\` control directive — never a raw byte — since ISO 10303-21
+/// 6.3.3.4 restricts a literal's plain-text bytes to 32-126. buildingSMART's
+/// IFC string-encoding guidance states the same for IFC2X3/IFC4/IFC4X3: a
+/// character outside decimal 32-126 "has to be encoded" (e.g. 'Ä' as
+/// `\X2\00C4\X0\`). A reader that treats the file's bytes as ISO-8859-1 — the
+/// byte encoding the base standard and most real consumers assume — turns a
+/// raw UTF-8 multi-byte sequence into mojibake or a broken parse; this exact
+/// writer shape is a reported, reproduced defect in real IFC tooling
+/// (IfcOpenShell#699/#1016; files rejected by Solibri).
 pub(crate) fn escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -22,7 +30,15 @@ pub(crate) fn escape(s: &str) -> String {
             '\'' => out.push_str("''"),
             '\\' => out.push_str("\\\\"),
             '\0'..='\u{1F}' | '\u{7F}' => out.push(' '),
-            _ => out.push(c),
+            '\u{20}'..='\u{7E}' => out.push(c),
+            _ => {
+                let cp = c as u32;
+                if cp <= 0xFFFF {
+                    out.push_str(&format!("\\X2\\{cp:04X}\\X0\\"));
+                } else {
+                    out.push_str(&format!("\\X4\\{cp:08X}\\X0\\"));
+                }
+            }
         }
     }
     out

--- a/rust/export/src/step_text_tests.rs
+++ b/rust/export/src/step_text_tests.rs
@@ -160,6 +160,23 @@ fn escape_no_special_chars_is_byte_identical() {
         assert_eq!(escape(s), s);
     }
 }
+
+#[test]
+fn escape_encodes_non_ascii_as_x2_directive_not_raw_utf8() {
+    // ISO 10303-21 6.3.3.4 restricts a string literal's plain-text bytes to
+    // the basic graphic range 32-126 — the same clause the doc comment above
+    // `escape()` already cites for control chars. A byte outside that range
+    // must be a control directive (`\X\HH`, `\X2\HHHH\X0\`, `\X4\HHHHHHHH\X0\`),
+    // never a raw byte; buildingSMART's IFC string-encoding guidance says the
+    // same for IFC2X3/IFC4/IFC4X3. `ifc_lite_core::encode_ifc_string` already
+    // implements this correctly but was never wired into this writer, so a
+    // BMP or non-BMP character in a name/label went out as raw UTF-8 — bytes
+    // a reader that (correctly, per spec) treats the file as ISO-8859-1 turns
+    // into mojibake or a broken parse. Matches the TS-side fix in
+    // `@ifc-lite/export`'s `escapeStepString`.
+    assert_eq!(escape("Trümpler"), r"Tr\X2\00FC\X0\mpler");
+    assert_eq!(escape("😀"), r"\X4\0001F600\X0\");
+}
 /// End-to-end write-side round-trip for the ISO 10303-21 doubling escapes.
 ///
 /// ifc-lite's own reader (`ifc_lite_core::step_encoding::decode_ifc_string`


### PR DESCRIPTION
The Rust STEP writer emits raw UTF-8 where the spec requires `\X2\` / `\X4\` directives, so a written file carries encoding other tools will not read as intended. Found on a branch that was never raised; merges clean.

RED reproduced by reverse-applying only the production hunks:

```
rust:   escape_encodes_non_ascii_as_x2_directive_not_raw_utf8
        left: "Trümpler"   right: "Tr\X2\00FC\X0\mpler"
export: expected '😀' to be '\X4\0001F600\X0\'
data:   expect(fileNameLine).toContain('Tr\X2\00FC\X0\mpler')
```

Round-trip verified rather than assumed: every `escapeStepString` call site sits inside a `'…'` STEP literal, and the readers (`rust/core/src/step_encoding.rs`, `packages/parser/src/source-header.ts`) already decode both directives.

`@ifc-lite/export` 768→770, `@ifc-lite/data` 148→149, rust export 248→249. Neighbours green: parser 621, cli 394, sdk 178, create 358, plus `cargo test -p ifc-lite-wasm -p ifc-lite-core`. api-surface, unused-locals, changesets (2), `cargo clippy --workspace --all-targets -- -D warnings` and `module_size_ratchet` all pass.

**One thing to weigh before merging.** `rust/core/src/step_encoding.rs:146` already has a canonical `encode_ifc_string`; this branch adds a **second** encoder in `rust/export/src/step_text.rs` rather than reusing it. They are behaviourally equivalent except for `\X\HH` vs `\X2\00HH` on U+0080–U+00FF and backslash handling — but that makes three copies of a subtle encoder, which is the shape that produced the divergence being fixed here. Worth deciding now rather than after a fourth appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
