### PR TITLE
fix(mcp): read the validator's own IDS summary instead of recomputing it

### DIFF
--- a/.changeset/ids-mcp-summary-reads-report-summary.md
+++ b/.changeset/ids-mcp-summary-reads-report-summary.md
@@ -1,0 +1,17 @@
+---
+'@ifc-lite/mcp': patch
+---
+
+Fix `ids_validate`'s summary reporting a specification as failed when it legitimately passed while matching zero entities.
+
+`summarizeIdsReport` cast the report to a hand-written minimal shape,
+ignored `spec.status` entirely, and used `entityResults.length > 0` as the
+pass condition for a specification. A specification with an explicit
+`minOccurs="0"` (or a prohibited spec that correctly matches nothing) is a
+legitimate pass with zero matched entities -- the validator's own
+`report.summary` already gets this right, but the tool never read it.
+
+`summarizeIdsReport` now projects `report.summary` directly instead of
+re-deriving the counts, and the report parameter is typed as the real
+`IDSValidationReport` rather than `unknown`, so there is no longer a
+hand-written shape for the two to drift apart on.

--- a/packages/mcp/src/tools/validation.test.ts
+++ b/packages/mcp/src/tools/validation.test.ts
@@ -89,9 +89,11 @@ interface IdsShape {
     totalSpecifications: number;
     passedSpecifications: number;
     failedSpecifications: number;
+    notApplicableSpecifications: number;
     totalEntities: number;
     passedEntities: number;
     failedEntities: number;
+    overallPassRate: number;
   };
 }
 
@@ -206,7 +208,48 @@ const IDS_MATCHING_WALLS = `<?xml version="1.0" encoding="utf-8"?>
   </specifications>
 </ids>`;
 
+/**
+ * `minOccurs="0"` opts a specification out of the IDS 1.0 default
+ * (REQUIRED — at least one match). No IFCFURNITURE exists in
+ * `warning-only.ifc`, so this legitimately matches zero entities and
+ * must be reported as a pass, not a fail — the case the buggy
+ * `entityResults.length > 0` rule got backwards.
+ */
+const IDS_OPTIONAL_MATCHING_NOTHING = `<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns="http://standards.buildingsmart.org/IDS"
+     xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <info><title>Optional furniture</title></info>
+  <specifications>
+    <specification name="Furniture, if present, must be named" ifcVersion="IFC4">
+      <applicability minOccurs="0" maxOccurs="unbounded">
+        <entity><name><simpleValue>IFCFURNITURE</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <attribute><name><simpleValue>Name</simpleValue></name></attribute>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>`;
+
 describe('ids_validate summary', () => {
+  it('counts a minOccurs="0" specification that matched no entity as passed, not failed', async () => {
+    // Counter-example to the vacuous-fail test below: an explicit
+    // `minOccurs="0"` makes zero matches a legitimate pass. The old
+    // `summarizeIdsReport` derived `specPassed = entityResults.length > 0`
+    // and ignored `spec.status` entirely, so it reported this as failed
+    // regardless of cardinality — indistinguishable from the required-spec
+    // case. Reading `report.summary` (which honours `spec.status`) is the
+    // only way to tell the two apart.
+    const out = (await run('warning-only.ifc', 'ids_validate', {
+      ids_xml: IDS_OPTIONAL_MATCHING_NOTHING,
+    })).structuredContent as unknown as IdsShape;
+    expect(out.summary.totalSpecifications).toBe(1);
+    expect(out.summary.totalEntities).toBe(0);
+    expect(out.summary.passedSpecifications).toBe(1);
+    expect(out.summary.failedSpecifications).toBe(0);
+  });
+
+
   it('does not count a specification that matched no entity as passed', async () => {
     // The vacuous-pass rule. A spec whose applicability selects nothing has an
     // empty `entityResults`; counting it as passed is how an IDS typo turns

--- a/packages/mcp/src/tools/validation.ts
+++ b/packages/mcp/src/tools/validation.ts
@@ -12,7 +12,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { parseIDS, validateIDS, createTranslationService, type IFCDataAccessor, type SupportedLocale } from '@ifc-lite/ids';
+import { parseIDS, validateIDS, createTranslationService, type IDSValidationReport, type IFCDataAccessor, type SupportedLocale } from '@ifc-lite/ids';
 import { IFC_ENTITY_NAMES } from '@ifc-lite/data';
 import { getInheritanceChainAcrossSchemas } from '@ifc-lite/parser';
 import { foldedTypeCounts, pendingMutationsField, pendingOverlay } from '../overlay.js';
@@ -88,36 +88,41 @@ async function loadIdsXml(
   });
 }
 
-function summarizeIdsReport(report: unknown): {
+/**
+ * Project the validator's own `report.summary` into the shape this tool
+ * has always returned, instead of re-deriving pass/fail counts from
+ * `specificationResults`.
+ *
+ * A prior version recomputed everything from `entityResults`, treated
+ * `report` as an `unknown` cast to a hand-written minimal interface, and
+ * used `entityResults.length > 0` as the pass condition for a
+ * specification — so a specification that legitimately passes while
+ * matching zero entities (`minOccurs="0"`, or a prohibited spec that
+ * correctly matches nothing) was reported as failed. Because the report
+ * is typed as the real `IDSValidationReport` here, `report.summary` is
+ * the only field this function can read for these numbers — there is no
+ * `entityResults` shape left to drift back onto.
+ */
+function summarizeIdsReport(report: IDSValidationReport): {
   totalSpecifications: number;
   passedSpecifications: number;
   failedSpecifications: number;
+  notApplicableSpecifications: number;
   totalEntities: number;
   passedEntities: number;
   failedEntities: number;
+  overallPassRate: number;
 } {
-  const r = report as { specificationResults?: Array<{ entityResults?: Array<{ passed: boolean }> }> };
-  const specs = r.specificationResults ?? [];
-  let totalEntities = 0;
-  let passedEntities = 0;
-  let passedSpecifications = 0;
-  for (const spec of specs) {
-    const ents = spec.entityResults ?? [];
-    let specPassed = ents.length > 0;
-    for (const e of ents) {
-      totalEntities++;
-      if (e.passed) passedEntities++;
-      else specPassed = false;
-    }
-    if (specPassed) passedSpecifications++;
-  }
+  const s = report.summary;
   return {
-    totalSpecifications: specs.length,
-    passedSpecifications,
-    failedSpecifications: specs.length - passedSpecifications,
-    totalEntities,
-    passedEntities,
-    failedEntities: totalEntities - passedEntities,
+    totalSpecifications: s.totalSpecifications,
+    passedSpecifications: s.passedSpecifications,
+    failedSpecifications: s.failedSpecifications,
+    notApplicableSpecifications: s.totalSpecifications - s.passedSpecifications - s.failedSpecifications,
+    totalEntities: s.totalEntitiesChecked,
+    passedEntities: s.totalEntitiesPassed,
+    failedEntities: s.totalEntitiesFailed,
+    overallPassRate: s.overallPassRate,
   };
 }
 


### PR DESCRIPTION
Two independent fixes to IDS result reporting, on branches that were never raised. Both merge clean, neither conflicts with the other, and both are needed.

## `ids --json` exited 0 on a failing spec

The JSON path did not set a non-zero exit code when the report contained a failed specification, so a failing IDS run looked successful to any caller checking the exit status.

RED:
```
× sets a non-zero exit code when the JSON report contains a failed specification
× agrees with the non-JSON path on the same failing input
  both: expected +0 to be 1
```

CLI suite **395 → 397**.

I checked the "two paths that must agree" risk explicitly, since that is the shape this fix could reintroduce: the JSON path derives its count from `bim.ids.summarize()` while the human path uses `report.summary`. They **do** agree on `failedSpecifications`, because `packages/sdk/src/namespaces/ids.ts:241` already prefers `spec.status === 'fail'`. So the two exit codes cannot diverge. One residual difference that does *not* affect exit status: `summarize` counts `not_applicable` as passed, while `report.summary` counts only `status === 'pass'`.

## MCP `ids_validate` recomputed its own summary

`packages/mcp/src/tools/validation.ts:99-121` held a **third** independent IDS summarizer that ignored `spec.status` entirely, so a `not_applicable` spec (empty `entityResults`) made `specPassed = false` — MCP counted it **failed** while the SDK counted it **passed**.

RED:
```
× counts a minOccurs="0" specification that matched no entity as passed, not failed
  expected +0 to be 1
```

MCP suite **271 → 272**.

**This closes the finding I raised on #2982.** It deletes the `entityResults.length > 0` heuristic and projects `report.summary`, which `packages/ids/src/validation/validator.ts:683-687` computes directly from `result.status` — the authoritative source. It also stops casting the report to a hand-written `unknown` interface and types it as the real `IDSValidationReport`, which structurally prevents the drift from recurring rather than just correcting this instance.

Worth noting the branch names mislead: `cli-mcp-sweep` does **not** touch MCP at all despite its name — it only fixes the CLI exit code. The MCP fix is entirely in `ids-summary-single-source`.

api-surface, unused-locals and changesets pass on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
