### PR TITLE
fix(cli): set a non-zero exit code when ids --json reports a failed spec

### DIFF
--- a/.changeset/ids-json-exit-code.md
+++ b/.changeset/ids-json-exit-code.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/cli": patch
+---
+
+Fix `ifc-lite ids --json` always exiting 0, even when the IDS report contains a failed specification.
+
+The human-readable path has always set `process.exitCode` from `summary.failedSpecifications`, so a CI step piping `ifc-lite ids` output failed the build on a genuine validation failure. The `--json` path returned right after printing the report without ever touching `process.exitCode` — a script driving this command with `--json` (the shape any script would actually parse) saw a clean exit 0 even when every specification failed. Proven by direct invocation: the same fixture exited 1 without `--json` and 0 with it. The `--json` path now sets the same exit code from the same summary.

--- a/packages/cli/src/commands/ids.test.ts
+++ b/packages/cli/src/commands/ids.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite ids --json` exit-code contract.
+ *
+ * The human-readable path has always set `process.exitCode` from
+ * `summary.failedSpecifications` so a CI step piping through this command
+ * fails when the model fails IDS validation. The `--json` path returned
+ * right after `printJson(...)` without ever touching `process.exitCode` --
+ * a script driving this command with `--json` (the shape any script would
+ * actually parse) saw a clean exit 0 even when every specification failed.
+ * Proven by direct invocation: `ifc-lite ids <fail-fixture> --json` exited 0
+ * while the same fixture without `--json` exited 1.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { idsCommand } from './ids.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const corpus = resolve(here, '../../../ids/src/__corpus__/buildingsmart-ids/classification');
+const FAIL_IFC = resolve(corpus, 'fail-systems_should_match_exactly_2_5.ifc');
+const FAIL_IDS = resolve(corpus, 'fail-systems_should_match_exactly_2_5.ids');
+const PASS_IFC = resolve(corpus, 'pass-systems_should_match_exactly_1_5.ifc');
+const PASS_IDS = resolve(corpus, 'pass-systems_should_match_exactly_1_5.ids');
+
+function silenceOutput() {
+  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('idsCommand --json exit code', () => {
+  it('sets a non-zero exit code when the JSON report contains a failed specification', async () => {
+    silenceOutput();
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+      await idsCommand([FAIL_IFC, FAIL_IDS, '--json']);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it('leaves the exit code at 0 for a fully passing --json run', async () => {
+    silenceOutput();
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+      await idsCommand([PASS_IFC, PASS_IDS, '--json']);
+      expect(process.exitCode).toBe(0);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it('agrees with the non-JSON path on the same failing input', async () => {
+    silenceOutput();
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+      await idsCommand([FAIL_IFC, FAIL_IDS]);
+      const humanExit = process.exitCode;
+
+      process.exitCode = 0;
+      await idsCommand([FAIL_IFC, FAIL_IDS, '--json']);
+      const jsonExit = process.exitCode;
+
+      expect(jsonExit).toBe(humanExit);
+      expect(jsonExit).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+});

--- a/packages/cli/src/commands/ids.ts
+++ b/packages/cli/src/commands/ids.ts
@@ -67,6 +67,12 @@ export async function idsCommand(args: string[]): Promise<void> {
     // Keep the established machine-readable summary shape.
     const summary = bim.ids.summarize(report);
     printJson({ summary, report });
+    // Mirror the human-readable path's exit-code contract: a CI pipeline
+    // driving this command with --json (the shape any script would pick)
+    // must see a non-zero exit on a genuine IDS failure. Without this the
+    // JSON path always exited 0 -- a validation failure printed to stdout
+    // but reported as success to the shell.
+    process.exitCode = summary.failedSpecifications > 0 ? 1 : 0;
     return;
   }
 


### PR DESCRIPTION
Two independent fixes to IDS result reporting, on branches that were never raised. Both merge clean, neither conflicts with the other, and both are needed.

## `ids --json` exited 0 on a failing spec

The JSON path did not set a non-zero exit code when the report contained a failed specification, so a failing IDS run looked successful to any caller checking the exit status.

RED:
```
× sets a non-zero exit code when the JSON report contains a failed specification
× agrees with the non-JSON path on the same failing input
  both: expected +0 to be 1
```

CLI suite **395 → 397**.

I checked the "two paths that must agree" risk explicitly, since that is the shape this fix could reintroduce: the JSON path derives its count from `bim.ids.summarize()` while the human path uses `report.summary`. They **do** agree on `failedSpecifications`, because `packages/sdk/src/namespaces/ids.ts:241` already prefers `spec.status === 'fail'`. So the two exit codes cannot diverge. One residual difference that does *not* affect exit status: `summarize` counts `not_applicable` as passed, while `report.summary` counts only `status === 'pass'`.

## MCP `ids_validate` recomputed its own summary

`packages/mcp/src/tools/validation.ts:99-121` held a **third** independent IDS summarizer that ignored `spec.status` entirely, so a `not_applicable` spec (empty `entityResults`) made `specPassed = false` — MCP counted it **failed** while the SDK counted it **passed**.

RED:
```
× counts a minOccurs="0" specification that matched no entity as passed, not failed
  expected +0 to be 1
```

MCP suite **271 → 272**.

**This closes the finding I raised on #2982.** It deletes the `entityResults.length > 0` heuristic and projects `report.summary`, which `packages/ids/src/validation/validator.ts:683-687` computes directly from `result.status` — the authoritative source. It also stops casting the report to a hand-written `unknown` interface and types it as the real `IDSValidationReport`, which structurally prevents the drift from recurring rather than just correcting this instance.

Worth noting the branch names mislead: `cli-mcp-sweep` does **not** touch MCP at all despite its name — it only fixes the CLI exit code. The MCP fix is entirely in `ids-summary-single-source`.

api-surface, unused-locals and changesets pass on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
