### PR TITLE
fix(export): fail closed instead of writing a spec-invalid GLB from an empty mesh set

### DIFF
--- a/.changeset/gltf-from-meshes-empty-fail-closed.md
+++ b/.changeset/gltf-from-meshes-empty-fail-closed.md
@@ -1,0 +1,22 @@
+---
+'@ifc-lite/wasm': patch
+'@ifc-lite/geometry': patch
+---
+
+Fix: `exportGlbFromMeshes` (the viewer's from-meshes GLB path, e.g. exporting
+the current selection) now fails closed with `NO_RENDER_GEOMETRY` when the
+visible mesh set is empty, instead of returning a "successful" GLB.
+
+That GLB was structurally invalid per the glTF 2.0 schema: `accessors`,
+`bufferViews`, `meshes` and `nodes` were emitted as empty arrays (the schema
+requires `minItems: 1` on each when present) and the single buffer's
+`byteLength` was `0` (schema `minimum: 1`) — confirmed against the reference
+`gltf-validator`. A consumer that enforces the schema (many glTF tools do)
+rejected the file outright.
+
+`exportGlb` (the from-bytes path) already guarded this case
+(`NO_RENDER_GEOMETRY`, #1438/#1516); `exportGlbFromMeshes` was the one
+sibling entry point that did not, and it is reachable directly from the
+viewer whenever a caller's filtered mesh list — or a filtered list where
+every mesh fails the minimum-geometry check (fewer than 3 vertices, or no
+indices) — comes back empty.

--- a/rust/export/src/gltf/from_meshes.rs
+++ b/rust/export/src/gltf/from_meshes.rs
@@ -78,10 +78,22 @@ pub fn try_export_glb_from_meshes(
     }
     // Every count is backed and every mesh's normals/indices are present, so the
     // infallible assembler's malformed-input `break` is unreachable and no mesh is dropped.
-    Ok(export_glb_from_meshes(
+    let (glb, stats) = export_glb_from_meshes(
         positions, normals, indices, vertex_counts, index_counts, colors, origins,
         express_ids, include_metadata, lit, emissive,
-    ))
+    );
+    // Zero visible meshes (empty input, or every declared mesh failing `view_ok` —
+    // e.g. a single-vertex/zero-index mesh) passes every count check above trivially
+    // and would otherwise return a "successful" GLB that glTF-Validator rejects:
+    // `accessors`/`bufferViews`/`meshes`/`nodes` are EMPTY_ENTITY (glTF schema
+    // `minItems: 1` when present) and `buffers[0].byteLength` is 0 (schema
+    // `minimum: 1`). `try_export_glb` (the from-bytes sibling, #1438/#1516) already
+    // fails closed here with `NoRenderGeometry`; this from-meshes entry point —
+    // reachable from the viewer's `exportGlbFromMeshes` — did not.
+    if stats.meshes == 0 {
+        return Err(ExportError::NoRenderGeometry);
+    }
+    Ok((glb, stats))
 }
 
 /// Assemble a GLB from already-produced meshes (the viewer's MeshData — **no re-meshing**).

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -1012,6 +1012,27 @@ fn try_from_meshes_rejects_index_counts_past_buffer() {
 }
 
 #[test]
+fn try_from_meshes_rejects_empty_input() {
+    // Zero meshes (e.g. a viewer selection whose visible set filtered to
+    // nothing) passes every per-count-consistency check trivially — vsum=0,
+    // isum=0, index_counts.len() 0 >= n 0 — so the checked path fell through
+    // to the infallible assembler and returned Ok with a "successful" GLB.
+    //
+    // glTF-Validator (npm `gltf-validator`, the reference implementation)
+    // rejects that GLB outright: `accessors`/`bufferViews`/`meshes`/`nodes`
+    // are EMPTY_ENTITY (glTF schema requires each `minItems: 1` when
+    // present) and `buffers[0].byteLength` is 0 (schema `minimum: 1`).
+    // `try_export_glb` (the from-bytes sibling, #1438/#1516) already fails
+    // closed on an empty visible-mesh set with `ExportError::NoRenderGeometry`
+    // for exactly this reason; this from-meshes entry point — reachable from
+    // the viewer's `exportGlbFromMeshes` — did not.
+    let err = try_export_glb_from_meshes(&[], &[], &[], &[], &[], &[], &[], &[], false, true, false)
+        .expect_err("zero meshes must be NoRenderGeometry, not a spec-invalid empty GLB");
+    assert!(matches!(err, ExportError::NoRenderGeometry), "got {err:?}");
+    assert_eq!(err.code(), "NO_RENDER_GEOMETRY");
+}
+
+#[test]
 fn export_is_byte_deterministic() {
     // Instancing groups by HashMap keys (rep colour buckets, material dedup);
     // emission order must be fixed so repeated exports are byte-identical.


### PR DESCRIPTION
GLB export from an empty mesh set silently produced a **spec-invalid file** rather than failing. Found on a branch that was never raised; merges clean.

RED reproduced by reverse-applying only the production hunk — `try_from_meshes_rejects_empty_input`. The emitted GLB's JSON chunk decodes to:

```json
{"scenes":[{"nodes":[]}],"nodes":[],"meshes":[],"accessors":[],
 "bufferViews":[],"buffers":[{"byteLength":0}]}
```

That violates the glTF schema's `minItems: 1` on those arrays and `minimum: 1` on `byteLength` — so the file is written, looks like a successful export, and is rejected by conforming readers.

**The failure path already existed and is already handled.** `ExportError::NoRenderGeometry` is a pre-existing code with handlers in `packages/cli/src/commands/export.ts:368` and `packages/mcp/src/tools/export.ts:204`, and it propagates to JS via `js_sys::Error` at `rust/wasm-bindings/src/api/export_glb.rs:127`. The sibling `try_export_glb` already fails closed in exactly this way, so this makes the two consistent rather than introducing a new behaviour.

rust export 248 → 249; `@ifc-lite/geometry` 342 pass. `cargo clippy --workspace --all-targets -- -D warnings`, `module_size_ratchet` and `check-changesets` all pass.

**One doc gap to fix before or after merge:** the comment at `export_glb.rs:92-97` still lists only `MALFORMED_MESH_INPUT` as the fail-closed case, so it now under-describes the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
