### PR TITLE
fix(viewer): stop maskKey revealing secret characters when the key body contains a dash

### DIFF
--- a/apps/viewer/src/lib/llm/clipboard-detect.test.ts
+++ b/apps/viewer/src/lib/llm/clipboard-detect.test.ts
@@ -76,6 +76,25 @@ test('maskKey falls back to bullets for absurdly short input', () => {
   assert.equal(maskKey(''), '••••');
 });
 
+test('maskKey does not leak secret characters when the secret body contains a dash', () => {
+  // The key alphabet is [A-Za-z0-9_-] (see PROVIDER_PATTERNS), so a real
+  // secret can legitimately contain a `-` anywhere after the provider
+  // prefix. `maskKey` must mask everything past the KNOWN prefix regardless
+  // of where any later dash falls — a secret-body dash is not the prefix
+  // boundary.
+  const legacyKey = 'sk-ab-cdEFGH12IJKLMNOP34QRST5678';
+  const legacyMasked = maskKey(legacyKey);
+  assert.equal(legacyMasked.startsWith('sk-••••'), true, `expected only "sk-" unmasked, got: ${legacyMasked}`);
+  assert.equal(legacyMasked.endsWith('5678'), true);
+  assert.equal(legacyMasked.includes('ab-cd'), false, `secret body leaked into: ${legacyMasked}`);
+
+  const projKey = 'sk-proj-ab-cdEFGH12IJKLMNOP34QRST';
+  const projMasked = maskKey(projKey);
+  assert.equal(projMasked.startsWith('sk-proj-••••'), true, `expected only "sk-proj-" unmasked, got: ${projMasked}`);
+  assert.equal(projMasked.endsWith('QRST'), true);
+  assert.equal(projMasked.includes('ab-cd'), false, `secret body leaked into: ${projMasked}`);
+});
+
 // ── readClipboardKey ──────────────────────────────────────────────────────
 // We can't easily simulate a real browser Clipboard API in node:test, but we
 // can verify the helper degrades gracefully when navigator/clipboard is absent

--- a/apps/viewer/src/lib/llm/clipboard-detect.ts
+++ b/apps/viewer/src/lib/llm/clipboard-detect.ts
@@ -66,6 +66,26 @@ export async function readClipboardKey(provider: BYOKProvider): Promise<string |
 }
 
 /**
+ * Recognised provider prefixes, longest-first so `sk-proj-` etc. win over the
+ * bare `sk-` they all start with. Anchored at the start of the string.
+ *
+ * Deliberately NOT `lastIndexOf('-')` on the whole key: the secret alphabet
+ * ([A-Za-z0-9_-], see `PROVIDER_PATTERNS`) permits a dash anywhere in the
+ * body, and `lastIndexOf` would find the RIGHTMOST dash in the string —
+ * which, the moment a secret's random tail contains one, is a dash inside
+ * the secret, not the provider prefix. That mis-measured "prefix" then gets
+ * displayed in plaintext, leaking part of the key. This must match a KNOWN
+ * prefix and nothing else.
+ */
+const KEY_PREFIX_PATTERNS: readonly RegExp[] = [
+  /^sk-ant-api03-/,
+  /^sk-proj-/,
+  /^sk-svcacct-/,
+  /^sk-admin-/,
+  /^sk-/,
+];
+
+/**
  * Render-safe key mask. Preserves the provider prefix so the user can confirm
  * the right key is detected, hides the secret middle, shows the last 4 chars
  * for disambiguation.
@@ -76,8 +96,10 @@ export async function readClipboardKey(provider: BYOKProvider): Promise<string |
  */
 export function maskKey(key: string): string {
   if (key.length < 12) return '••••';
-  const dashIdx = key.lastIndexOf('-');
-  const prefixEnd = dashIdx > 0 && dashIdx < 14 ? dashIdx + 1 : Math.min(14, key.length - 4);
+  const prefixMatch = KEY_PREFIX_PATTERNS.map((pattern) => pattern.exec(key)?.[0]).find(
+    (match) => match !== undefined,
+  );
+  const prefixEnd = prefixMatch !== undefined ? prefixMatch.length : 0;
   return `${key.slice(0, prefixEnd)}••••${key.slice(-4)}`;
 }
 


### PR DESCRIPTION
`maskKey` can render more of an API key in plaintext than intended. Found on a branch that was never raised; merges clean.

## The defect, confirmed

On `upstream/main`, `maskKey` uses `key.lastIndexOf('-')` — the **rightmost** dash in the whole string. The key alphabet (`[A-Za-z0-9_-]`) permits dashes inside the secret body, so a dash landing in the first 14 characters is treated as the end of the provider prefix.

Demonstrated with synthetic values only: for an `sk-` key whose body contains a dash at index 11, the old mask renders **12 leading characters in plaintext** — 9 of them secret body past the `sk-` prefix. Where no dash falls below index 14, the fallback `Math.min(14, key.length - 4)` shows 14 leading characters unconditionally.

```
not ok 13 - maskKey does not leak secret characters when the secret body contains a dash
```
17 → 18 passing.

## Please read the scope before treating this as an incident

`maskKey` has exactly two call sites, both rendering into an on-screen `<code>` element in `ByokKeyModal.tsx` (lines 266, 282). The output is **not logged, not persisted, and not transmitted anywhere**. The exposure is shoulder-surfing or a screenshot of the user's own key on their own screen, bounded at 14 leading characters plus the 4 trailing characters both versions show by design.

So: genuine hardening, **not** a credential-exfiltration defect. Worth fixing, not worth an incident.

## One behaviour change to note

Keys with no recognised prefix now show `••••` plus the last 4, instead of 14 leading characters. Safer — but it narrows the documented purpose ("preserves the provider prefix so the user can confirm the right key is detected") for any future non-`sk-` provider. Worth a decision if more providers are coming.

No changeset, correctly — `apps/viewer` is not a published package, and `check-changesets.mjs` passes.

**The branch name is wrong and should be changed before merge:** it is called `compare-llm-geo-sweep` but contains no compare and no geometry changes — only this masking fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
