### PR TITLE
fix(create): compose the wall placement chain in the storey frame

### DIFF
--- a/.changeset/wall-placement-chain-storey-frame.md
+++ b/.changeset/wall-placement-chain-storey-frame.md
@@ -17,3 +17,5 @@ root, because storey-local is the frame the write side uses: the generated
 `IfcSpace` is authored with the storey placement as its `PlacementRelTo`.
 `existingSpaceFootprintsByStorey` shares that frame and now uses the same
 composition.
+
+A storey with no `ObjectPlacement` — optional on `IfcProduct` — has no chain to stop the composition, so nothing is composed at all for it rather than composing every hop up to the world root and returning world coordinates where storey-local ones are the contract.

--- a/.changeset/wall-placement-chain-storey-frame.md
+++ b/.changeset/wall-placement-chain-storey-frame.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/create": patch
+---
+
+Compose intermediate `IfcLocalPlacement.PlacementRelTo` hops in wall extraction
+
+`extractWallSegmentsForStorey` read only a wall's own `RelativePlacement` and
+ignored `PlacementRelTo`. That is right for a wall placed directly under its
+storey, but the standard `IfcElementAssembly` grouping (curtain walls, precast
+panel runs, railing systems) inserts an intermediate placement between the
+member and the storey — and its translation and rotation were silently
+dropped, so the member was extracted at the wrong position relative to its
+siblings and the enclosed room was never detected.
+
+Composition stops at the storey's own placement rather than continuing to the
+root, because storey-local is the frame the write side uses: the generated
+`IfcSpace` is authored with the storey placement as its `PlacementRelTo`.
+`existingSpaceFootprintsByStorey` shares that frame and now uses the same
+composition.

--- a/packages/create/src/in-store/extract-walls-placement-chain.test.ts
+++ b/packages/create/src/in-store/extract-walls-placement-chain.test.ts
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `extractWallSegmentsForStorey` must express every segment in the STOREY
+ * frame — the same frame `generateSpacesFromWalls` authors into, since
+ * `addSpaceToStore` emits the new `IfcSpace` with `anchor.storeyPlacementId`
+ * as its `PlacementRelTo` (`space.ts`, `resolve-anchor.ts`).
+ *
+ * Two properties, both observable only because this fixture's storey sits at
+ * a NON-ORIGIN placement (100., 200., 0.):
+ *
+ *  1. Intermediate `IfcLocalPlacement.PlacementRelTo` hops between a wall and
+ *     its storey (the standard `IfcElementAssembly` grouping for curtain
+ *     walls / precast panels / railing systems) must be composed in. Reading
+ *     only the wall's own `RelativePlacement` drops that hop's translation
+ *     and rotation, so the member lands at the wrong place relative to
+ *     siblings placed directly under the storey.
+ *
+ *  2. A wall placed directly under the storey must NOT move. Composing on
+ *     past the storey to the root would add the storey's own (100, 200)
+ *     offset to every segment, and the space generated from those segments
+ *     would then be authored 100 m east / 200 m north of the actual room.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser } from '@ifc-lite/parser';
+import { extractWallSegmentsForStorey } from './extract-walls.js';
+
+// Storey #4's own placement #10 is at (100., 200., 0.) relative to the
+// building — the offset that makes "storey frame" distinguishable from
+// "root frame". Under it:
+//   #50 wall  — single hop: PlacementRelTo = #10 (the storey) directly.
+//   #52 wall  — two hops: PlacementRelTo = #30 (IfcElementAssembly #40's
+//               placement, at (3., 4., 0.) in the storey frame).
+//   #54 wall  — two hops through a ROTATED assembly #42 at (3., 4., 0.)
+//               with RefDirection (0., 1., 0.), own origin (1., 0.).
+const ifc = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0PROJECT000000000000',$,'Proj',$,$,$,$,(#7),#8);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#9,$);
+#9=IFCAXIS2PLACEMENT3D(#90,$,$);
+#90=IFCCARTESIANPOINT((0.,0.,0.));
+#8=IFCUNITASSIGNMENT((#81));
+#81=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#2=IFCSITE('0SITE0000000000000000',$,'Site',$,$,#11,$,$,.ELEMENT.,$,$,$,$,$);
+#11=IFCLOCALPLACEMENT($,#12);
+#12=IFCAXIS2PLACEMENT3D(#91,$,$);
+#91=IFCCARTESIANPOINT((0.,0.,0.));
+#3=IFCBUILDING('0BUILDING000000000000',$,'Bldg',$,$,#13,$,$,.ELEMENT.,$,$,$);
+#13=IFCLOCALPLACEMENT(#11,#14);
+#14=IFCAXIS2PLACEMENT3D(#92,$,$);
+#92=IFCCARTESIANPOINT((0.,0.,0.));
+#4=IFCBUILDINGSTOREY('0STOREY00000000000000',$,'Storey',$,$,#10,$,$,.ELEMENT.,0.);
+#10=IFCLOCALPLACEMENT(#13,#15);
+#15=IFCAXIS2PLACEMENT3D(#93,$,$);
+#93=IFCCARTESIANPOINT((100.,200.,0.));
+#50=IFCWALL('0WALL0000000000000000',$,'Direct',$,$,#20,#60,$,$);
+#20=IFCLOCALPLACEMENT(#10,#21);
+#21=IFCAXIS2PLACEMENT3D(#94,$,#95);
+#94=IFCCARTESIANPOINT((0.,0.,0.));
+#95=IFCDIRECTION((1.,0.,0.));
+#40=IFCELEMENTASSEMBLY('0ASSEMBLY000000000000',$,'Asm',$,$,#30,$,$,$,.NOTDEFINED.);
+#30=IFCLOCALPLACEMENT(#10,#31);
+#31=IFCAXIS2PLACEMENT3D(#96,$,#97);
+#96=IFCCARTESIANPOINT((3.,4.,0.));
+#97=IFCDIRECTION((1.,0.,0.));
+#52=IFCWALL('0WALL0000000000000001',$,'Nested',$,$,#22,#60,$,$);
+#22=IFCLOCALPLACEMENT(#30,#23);
+#23=IFCAXIS2PLACEMENT3D(#98,$,#99);
+#98=IFCCARTESIANPOINT((0.,0.,0.));
+#99=IFCDIRECTION((1.,0.,0.));
+#42=IFCELEMENTASSEMBLY('0ASSEMBLY000000000001',$,'AsmRot',$,$,#32,$,$,$,.NOTDEFINED.);
+#32=IFCLOCALPLACEMENT(#10,#33);
+#33=IFCAXIS2PLACEMENT3D(#100,$,#101);
+#100=IFCCARTESIANPOINT((3.,4.,0.));
+#101=IFCDIRECTION((0.,1.,0.));
+#54=IFCWALL('0WALL0000000000000002',$,'NestedRot',$,$,#24,#60,$,$);
+#24=IFCLOCALPLACEMENT(#32,#25);
+#25=IFCAXIS2PLACEMENT3D(#102,$,#103);
+#102=IFCCARTESIANPOINT((1.,0.,0.));
+#103=IFCDIRECTION((1.,0.,0.));
+#60=IFCPRODUCTDEFINITIONSHAPE($,$,(#61));
+#61=IFCSHAPEREPRESENTATION(#7,'Axis','Curve2D',(#62));
+#62=IFCPOLYLINE((#63,#64));
+#63=IFCCARTESIANPOINT((0.,0.));
+#64=IFCCARTESIANPOINT((5.,0.));
+#70=IFCRELAGGREGATES('0RELAGG0000000000000',$,$,$,#2,(#3));
+#71=IFCRELAGGREGATES('0RELAGG0000000000001',$,$,$,#3,(#4));
+#72=IFCRELCONTAINEDINSPATIALSTRUCTURE('0RELCONT000000000000',$,$,$,(#50,#40,#42),#4);
+#73=IFCRELAGGREGATES('0RELAGG0000000000002',$,$,$,#40,(#52));
+#74=IFCRELAGGREGATES('0RELAGG0000000000003',$,$,$,#42,(#54));
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function segmentsByWall(): Promise<Map<number, { a: number[]; b: number[] }>> {
+  const parser = new IfcParser();
+  const buf = new TextEncoder().encode(ifc).buffer;
+  const store = await parser.parseColumnar(buf);
+  const result = extractWallSegmentsForStorey(store, 4);
+  const byWall = new Map<number, { a: number[]; b: number[] }>();
+  result.contributingWallIds.forEach((id, i) => {
+    const s = result.segments[i];
+    byWall.set(id, { a: [s.a[0], s.a[1]], b: [s.b[0], s.b[1]] });
+  });
+  return byWall;
+}
+
+describe('extractWallSegmentsForStorey: PlacementRelTo chain, storey frame', () => {
+  it('does not move a wall placed directly under a non-origin storey', async () => {
+    const byWall = await segmentsByWall();
+    // The storey's own (100, 200) offset must NOT leak in: the authoring
+    // side re-anchors the generated space to the storey placement, which
+    // would apply that offset a second time.
+    expect(byWall.get(50)).toEqual({ a: [0, 0], b: [5, 0] });
+  });
+
+  it("composes an assembly's intermediate hop into a nested wall's axis", async () => {
+    const byWall = await segmentsByWall();
+    // assembly origin (3, 4) + wall-local (0, 0) => (3, 4); axis (1, 0).
+    expect(byWall.get(52)).toEqual({ a: [3, 4], b: [8, 4] });
+  });
+
+  it("composes a rotated assembly's hop (rotation, not just translation)", async () => {
+    const byWall = await segmentsByWall();
+    // assembly frame: origin (3, 4), axisX (0, 1). The wall's own origin
+    // (1, 0) maps to (3, 5); its axis (1, 0) maps to (0, 1), so b = (3, 10).
+    expect(byWall.get(54)).toEqual({ a: [3, 5], b: [3, 10] });
+  });
+});

--- a/packages/create/src/in-store/extract-walls-unplaceable-storey.test.ts
+++ b/packages/create/src/in-store/extract-walls-unplaceable-storey.test.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `IfcProduct.ObjectPlacement` is OPTIONAL, so a storey may legitimately
+ * carry `$` there. The storey-frame chain walk stops composing when it
+ * reaches the storey's OWN placement chain — and a storey with no placement
+ * has no such chain, so there is nothing to stop on and composition runs on
+ * to the world root, handing back WORLD coordinates where the contract (and
+ * every caller) says storey-local.
+ *
+ * Both readers below are reachable with such a storey:
+ *  - `extractWallSegmentsForStorey` — the preview path.
+ *  - `existingSpaceFootprintsByStorey`, which iterates every
+ *    `IfcBuildingStorey` in the store with no anchor resolution at all.
+ * Only the non-dry-run authoring path is protected, by `resolveSpatialAnchor`
+ * refusing a storey with no resolvable `IfcLocalPlacement`.
+ *
+ * The site (1000, 2000) and building (100, 200) offsets exist so "composed to
+ * the world root" is a different number from "composed nothing" — the wall
+ * and the space are placed relative to the BUILDING placement, the nearest
+ * one that survives when the storey has none.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser } from '@ifc-lite/parser';
+import { extractWallSegmentsForStorey, existingSpaceFootprintsByStorey } from './extract-walls.js';
+
+const ifc = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0PROJECT000000000000',$,'Proj',$,$,$,$,(#7),#8);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#9,$);
+#9=IFCAXIS2PLACEMENT3D(#90,$,$);
+#90=IFCCARTESIANPOINT((0.,0.,0.));
+#8=IFCUNITASSIGNMENT((#81));
+#81=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#2=IFCSITE('0SITE0000000000000000',$,'Site',$,$,#11,$,$,.ELEMENT.,$,$,$,$,$);
+#11=IFCLOCALPLACEMENT($,#12);
+#12=IFCAXIS2PLACEMENT3D(#91,$,$);
+#91=IFCCARTESIANPOINT((1000.,2000.,0.));
+#3=IFCBUILDING('0BUILDING000000000000',$,'Bldg',$,$,#13,$,$,.ELEMENT.,$,$,$);
+#13=IFCLOCALPLACEMENT(#11,#14);
+#14=IFCAXIS2PLACEMENT3D(#92,$,$);
+#92=IFCCARTESIANPOINT((100.,200.,0.));
+#4=IFCBUILDINGSTOREY('0STOREY00000000000000',$,'Storey',$,$,$,$,$,.ELEMENT.,0.);
+#50=IFCWALL('0WALL0000000000000000',$,'Direct',$,$,#20,#60,$,$);
+#20=IFCLOCALPLACEMENT(#13,#21);
+#21=IFCAXIS2PLACEMENT3D(#94,$,#95);
+#94=IFCCARTESIANPOINT((0.,0.,0.));
+#95=IFCDIRECTION((1.,0.,0.));
+#60=IFCPRODUCTDEFINITIONSHAPE($,$,(#61));
+#61=IFCSHAPEREPRESENTATION(#7,'Axis','Curve2D',(#62));
+#62=IFCPOLYLINE((#63,#64));
+#63=IFCCARTESIANPOINT((0.,0.));
+#64=IFCCARTESIANPOINT((5.,0.));
+#6=IFCSPACE('0SPACE000000000000000',$,'Room',$,$,#26,#66,$,.ELEMENT.,.INTERNAL.,$);
+#26=IFCLOCALPLACEMENT(#13,#27);
+#27=IFCAXIS2PLACEMENT3D(#96,$,#97);
+#96=IFCCARTESIANPOINT((0.,0.,0.));
+#97=IFCDIRECTION((1.,0.,0.));
+#66=IFCPRODUCTDEFINITIONSHAPE($,$,(#67));
+#67=IFCSHAPEREPRESENTATION(#7,'Body','SweptSolid',(#68));
+#68=IFCEXTRUDEDAREASOLID(#69,#75,#76,3.);
+#69=IFCARBITRARYCLOSEDPROFILEDEF(.AREA.,$,#70);
+#70=IFCPOLYLINE((#71,#72,#73,#74));
+#71=IFCCARTESIANPOINT((1.,0.));
+#72=IFCCARTESIANPOINT((3.,0.));
+#73=IFCCARTESIANPOINT((3.,2.));
+#74=IFCCARTESIANPOINT((1.,2.));
+#75=IFCAXIS2PLACEMENT3D(#98,$,$);
+#98=IFCCARTESIANPOINT((0.,0.,0.));
+#76=IFCDIRECTION((0.,0.,1.));
+#77=IFCRELAGGREGATES('0RELAGG0000000000000',$,$,$,#2,(#3));
+#78=IFCRELAGGREGATES('0RELAGG0000000000001',$,$,$,#3,(#4));
+#79=IFCRELCONTAINEDINSPATIALSTRUCTURE('0RELCONT000000000000',$,$,$,(#50),#4);
+#80=IFCRELAGGREGATES('0RELAGG0000000000002',$,$,$,#4,(#6));
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function parse() {
+  return await new IfcParser().parseColumnar(new TextEncoder().encode(ifc).buffer);
+}
+
+describe('storey with no ObjectPlacement', () => {
+  it('does not compose the site/building offsets into a wall segment', async () => {
+    const store = await parse();
+    const result = extractWallSegmentsForStorey(store, 4);
+    const byWall = new Map(
+      result.contributingWallIds.map((id, i) => [
+        id,
+        [
+          [result.segments[i].a[0], result.segments[i].a[1]],
+          [result.segments[i].b[0], result.segments[i].b[1]],
+        ],
+      ]),
+    );
+    // Composing nothing — the wall's own frame — is what this returned before
+    // the storey-frame walk existed. Composing on to the root would give
+    // [[1100, 2200], [1105, 2200]]: world coordinates labelled storey-local,
+    // which the authoring side would then offset by the storey a second time.
+    expect(byWall.get(50)).toEqual([
+      [0, 0],
+      [5, 0],
+    ]);
+  });
+
+  it('does not compose them into an existing space footprint either', async () => {
+    const store = await parse();
+    const byStorey = existingSpaceFootprintsByStorey(store);
+    expect(byStorey.get(4)).toEqual([
+      [
+        [1, 0],
+        [3, 0],
+        [3, 2],
+        [1, 2],
+      ],
+    ]);
+  });
+});

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -184,8 +184,13 @@ export function extractWallSegmentsForStorey(
   const dividerIds = collectDividerIdsOnStorey(store, extractor, storeyExpressId, dividerTypes, log);
   log(`storey #${storeyExpressId}: ${dividerIds.length} contained divider element(s)`);
 
+  // Segments are emitted in the STOREY frame, so composition of each
+  // element's PlacementRelTo chain stops as soon as it reaches the storey's
+  // own placement chain. See `frameInStoreyFrame`.
+  const storeyChain = storeyPlacementChain(store, extractor, overlay, storeyExpressId);
+
   for (const id of dividerIds) {
-    const result = extractWallAxisFromSource(store, extractor, id, log);
+    const result = extractWallAxisFromSource(store, extractor, id, storeyChain, log);
     if (result.segment) {
       segments.push(scaleSegment(result.segment, lengthUnitScale));
       contributing.push(id);
@@ -200,7 +205,7 @@ export function extractWallSegmentsForStorey(
     for (const ent of overlay.getNewEntities()) {
       if (!dividerTypes.has(ent.type.toLowerCase())) continue;
       overlayCount++;
-      const result = extractWallAxisFromOverlay(store, extractor, overlay, ent, log);
+      const result = extractWallAxisFromOverlay(store, extractor, overlay, ent, storeyChain, log);
       if (result.segment) {
         // Overlay walls are authored via addWallToStore which emits
         // metre coords — don't double-scale.
@@ -346,6 +351,9 @@ export function existingSpaceFootprintsByStorey(store: IfcDataStore): Map<number
   const contained = buildRelatingChildrenIndex(store, extractor, 'IFCRELCONTAINEDINSPATIALSTRUCTURE', 5, 4);
   for (const st of store.getEntitiesByType('IfcBuildingStorey')) {
     const kids = [...(aggregated.get(st.expressId) ?? []), ...(contained.get(st.expressId) ?? [])];
+    // Same frame as the extracted wall segments — storey-local — so the
+    // overlap test in generate-spaces compares like with like.
+    const storeyChain = storeyPlacementChain(store, extractor, undefined, st.expressId);
     const footprints: Vec2[][] = [];
     for (const id of kids) {
       if ((store.entities.getTypeName(id) ?? '').toUpperCase() !== 'IFCSPACE') continue;
@@ -356,7 +364,7 @@ export function existingSpaceFootprintsByStorey(store: IfcDataStore): Map<number
       const placementId = numericAttr(ent.attributes[5]);   // ObjectPlacement
       const representationId = numericAttr(ent.attributes[6]); // Representation
       if (placementId === null || representationId === null) continue;
-      const frame = readPlacementFrame(store, extractor, undefined, placementId);
+      const frame = frameInStoreyFrame(store, extractor, undefined, placementId, storeyChain);
       const localPts = gatherBodyFootprintPoints(store, extractor, undefined, representationId);
       if (!frame || !localPts || localPts.length < 3) continue;
       footprints.push(localPts.map((p) => {
@@ -414,6 +422,7 @@ function extractWallAxisFromSource(
   store: IfcDataStore,
   extractor: EntityExtractor,
   wallId: number,
+  storeyChain: ReadonlySet<number>,
   log: Logger,
 ): ExtractAttempt {
   const ref = store.entityIndex.byId.get(wallId);
@@ -430,7 +439,7 @@ function extractWallAxisFromSource(
   const representationId = numericAttr(wall.attributes[6]);
   if (placementId === null) return { segment: null, reason: 'no-placement' };
   if (representationId === null) return { segment: null, reason: 'no-representation' };
-  return computeWallSegment(store, extractor, placementId, representationId, undefined, wallId, log);
+  return computeWallSegment(store, extractor, placementId, representationId, undefined, wallId, storeyChain, log);
 }
 
 function extractWallAxisFromOverlay(
@@ -438,13 +447,14 @@ function extractWallAxisFromOverlay(
   extractor: EntityExtractor,
   overlay: OverlayWallReader,
   wall: { expressId: number; attributes: IfcAttributeValue[] },
+  storeyChain: ReadonlySet<number>,
   log: Logger,
 ): ExtractAttempt {
   const placementId = numericAttr(wall.attributes[5]);
   const representationId = numericAttr(wall.attributes[6]);
   if (placementId === null) return { segment: null, reason: 'no-placement' };
   if (representationId === null) return { segment: null, reason: 'no-representation' };
-  return computeWallSegment(store, extractor, placementId, representationId, overlay, wall.expressId, log);
+  return computeWallSegment(store, extractor, placementId, representationId, overlay, wall.expressId, storeyChain, log);
 }
 
 interface PlacementFrame {
@@ -461,9 +471,10 @@ function computeWallSegment(
   representationId: number,
   overlay: OverlayWallReader | undefined,
   wallId: number,
+  storeyChain: ReadonlySet<number>,
   log: Logger,
 ): ExtractAttempt {
-  const frame = readPlacementFrame(store, extractor, overlay, placementId);
+  const frame = frameInStoreyFrame(store, extractor, overlay, placementId, storeyChain);
   if (!frame) {
     log(`wall #${wallId}: placement chain not resolvable (placement=#${placementId})`);
     return { segment: null, reason: 'placement-not-resolvable' };
@@ -747,11 +758,12 @@ function finaliseSegment(start: Vec2, end: Vec2, wallId: number, log: Logger, so
 }
 
 /**
- * Walk IfcLocalPlacement → IfcAxis2Placement3D → CartesianPoint and
- * read the ground-plane origin + RefDirection. Returns null when any
- * link is missing.
+ * Walk IfcLocalPlacement → IfcAxis2Placement3D → CartesianPoint and read the
+ * ground-plane origin + RefDirection *of this one placement*, i.e. expressed
+ * in its own `PlacementRelTo` parent's frame. Returns null when any link is
+ * missing.
  */
-function readPlacementFrame(
+function readOwnPlacementFrame(
   store: IfcDataStore,
   extractor: EntityExtractor,
   overlay: OverlayWallReader | undefined,
@@ -783,6 +795,104 @@ function readPlacementFrame(
     }
   }
   return { origin: [origin[0], origin[1]], axisX };
+}
+
+/**
+ * The set of placement ids that make up the storey's OWN placement chain:
+ * the storey's `ObjectPlacement` and every ancestor reachable from it via
+ * `IfcLocalPlacement.PlacementRelTo`. Composition stops when it reaches one
+ * of these — see `frameInStoreyFrame`.
+ *
+ * Returns an empty set when the storey has no resolvable placement; the
+ * chain walk then behaves as before this existed and composes only what it
+ * can reach before running out of parents.
+ */
+function storeyPlacementChain(
+  store: IfcDataStore,
+  extractor: EntityExtractor,
+  overlay: OverlayWallReader | undefined,
+  storeyId: number,
+): Set<number> {
+  const chain = new Set<number>();
+  const storey = readEntity(store, extractor, overlay, storeyId);
+  if (!storey) return chain;
+  let id = numericAttr(storey.attributes[5]); // ObjectPlacement
+  while (id !== null && !chain.has(id)) {
+    chain.add(id);
+    const placement = readEntity(store, extractor, overlay, id);
+    if (!placement) break;
+    id = numericAttr(placement.attributes[0]); // PlacementRelTo
+  }
+  return chain;
+}
+
+/**
+ * Compose `inner` (expressed in `outer`'s frame) with `outer`, giving the
+ * frame of `inner` expressed in whatever frame `outer` is expressed in.
+ */
+function composeFrames(outer: PlacementFrame, inner: PlacementFrame): PlacementFrame {
+  const ax = outer.axisX[0];
+  const ay = outer.axisX[1];
+  // Perpendicular = rotate axisX 90° CCW around +Z — same convention as
+  // `applyFrame`, which this must agree with exactly.
+  const px = -ay;
+  const py = ax;
+  return {
+    origin: applyFrame(outer, inner.origin),
+    // Directions rotate but do not translate.
+    axisX: [ax * inner.axisX[0] + px * inner.axisX[1], ay * inner.axisX[0] + py * inner.axisX[1]],
+  };
+}
+
+/**
+ * Frame of `placementId` expressed in the STOREY's frame: this placement's
+ * own frame composed with every intermediate `IfcLocalPlacement.
+ * PlacementRelTo` hop, stopping *before* the storey's own placement.
+ *
+ * An element's `ObjectPlacement` is not always one hop from its storey. The
+ * IFC-standard grouping pattern — an `IfcElementAssembly` for a curtain
+ * wall, precast panel run or railing system, all of them in
+ * `DEFAULT_DIVIDER_TYPES` — inserts an intermediate `IfcLocalPlacement`
+ * between the member and the storey. Reading only the member's own
+ * `RelativePlacement` silently drops that hop's translation and rotation, so
+ * the member is extracted at the wrong position relative to walls placed
+ * directly under the storey: corners that should meet come out disconnected
+ * and the enclosed room is never detected.
+ *
+ * Composition deliberately STOPS at the storey rather than continuing to the
+ * root. Storey-local is the frame the write side uses: `generateSpacesFromWalls`
+ * hands these segments to `addSpaceToStore`, which authors the new `IfcSpace`
+ * with `anchor.storeyPlacementId` as its `PlacementRelTo` (see `space.ts` and
+ * `resolve-anchor.ts`). Composing to the root would bake the storey's own
+ * offset into the coordinates and the storey placement would then apply it a
+ * second time, putting the space a whole site-offset away from its room.
+ */
+function frameInStoreyFrame(
+  store: IfcDataStore,
+  extractor: EntityExtractor,
+  overlay: OverlayWallReader | undefined,
+  placementId: number,
+  storeyChain: ReadonlySet<number>,
+): PlacementFrame | null {
+  let frame = readOwnPlacementFrame(store, extractor, overlay, placementId);
+  if (!frame) return null;
+  // Visited-set termination: exact for cyclic/self-referential
+  // `PlacementRelTo` in malformed IFC, and needs no arbitrary depth bound.
+  const visited = new Set<number>([placementId]);
+  let currentId = placementId;
+  for (;;) {
+    const placement = readEntity(store, extractor, overlay, currentId);
+    const relToId = placement ? numericAttr(placement.attributes[0]) : null;
+    // Stop at the storey's own placement (or any of its ancestors): the
+    // frame is already storey-local. Also stops at the root, at a cycle,
+    // and at an unresolvable parent (best effort with what we have).
+    if (relToId === null || storeyChain.has(relToId) || visited.has(relToId)) return frame;
+    const parent = readOwnPlacementFrame(store, extractor, overlay, relToId);
+    if (!parent) return frame;
+    frame = composeFrames(parent, frame);
+    visited.add(relToId);
+    currentId = relToId;
+  }
 }
 
 /**

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -422,7 +422,7 @@ function extractWallAxisFromSource(
   store: IfcDataStore,
   extractor: EntityExtractor,
   wallId: number,
-  storeyChain: ReadonlySet<number>,
+  storeyChain: ReadonlySet<number> | null,
   log: Logger,
 ): ExtractAttempt {
   const ref = store.entityIndex.byId.get(wallId);
@@ -447,7 +447,7 @@ function extractWallAxisFromOverlay(
   extractor: EntityExtractor,
   overlay: OverlayWallReader,
   wall: { expressId: number; attributes: IfcAttributeValue[] },
-  storeyChain: ReadonlySet<number>,
+  storeyChain: ReadonlySet<number> | null,
   log: Logger,
 ): ExtractAttempt {
   const placementId = numericAttr(wall.attributes[5]);
@@ -471,7 +471,7 @@ function computeWallSegment(
   representationId: number,
   overlay: OverlayWallReader | undefined,
   wallId: number,
-  storeyChain: ReadonlySet<number>,
+  storeyChain: ReadonlySet<number> | null,
   log: Logger,
 ): ExtractAttempt {
   const frame = frameInStoreyFrame(store, extractor, overlay, placementId, storeyChain);
@@ -803,20 +803,25 @@ function readOwnPlacementFrame(
  * `IfcLocalPlacement.PlacementRelTo`. Composition stops when it reaches one
  * of these — see `frameInStoreyFrame`.
  *
- * Returns an empty set when the storey has no resolvable placement; the
- * chain walk then behaves as before this existed and composes only what it
- * can reach before running out of parents.
+ * Returns `null` — NOT an empty set — when the storey has no resolvable
+ * placement, which `IfcProduct.ObjectPlacement` being OPTIONAL makes a
+ * well-formed possibility. An empty set is not "no storey frame", it is
+ * "a storey frame the walk can never reach": the walk would find nothing to
+ * stop on and compose every hop up to the world root, labelling world
+ * coordinates storey-local. `frameInStoreyFrame` treats `null` as "compose
+ * nothing" instead — see there.
  */
 function storeyPlacementChain(
   store: IfcDataStore,
   extractor: EntityExtractor,
   overlay: OverlayWallReader | undefined,
   storeyId: number,
-): Set<number> {
+): Set<number> | null {
   const chain = new Set<number>();
   const storey = readEntity(store, extractor, overlay, storeyId);
-  if (!storey) return chain;
+  if (!storey) return null;
   let id = numericAttr(storey.attributes[5]); // ObjectPlacement
+  if (id === null) return null;
   while (id !== null && !chain.has(id)) {
     chain.add(id);
     const placement = readEntity(store, extractor, overlay, id);
@@ -866,16 +871,27 @@ function composeFrames(outer: PlacementFrame, inner: PlacementFrame): PlacementF
  * `resolve-anchor.ts`). Composing to the root would bake the storey's own
  * offset into the coordinates and the storey placement would then apply it a
  * second time, putting the space a whole site-offset away from its room.
+ *
+ * A `null` `storeyChain` (storey with no `ObjectPlacement`) means there is no
+ * storey frame to compose towards, so no hop is composed at all.
  */
 function frameInStoreyFrame(
   store: IfcDataStore,
   extractor: EntityExtractor,
   overlay: OverlayWallReader | undefined,
   placementId: number,
-  storeyChain: ReadonlySet<number>,
+  storeyChain: ReadonlySet<number> | null,
 ): PlacementFrame | null {
   let frame = readOwnPlacementFrame(store, extractor, overlay, placementId);
   if (!frame) return null;
+  // No storey placement at all (`ObjectPlacement` is OPTIONAL): there is no
+  // storey frame to compose towards and nothing for the walk to stop on, so
+  // walking parents would run to the world root and return world coordinates
+  // where every caller expects storey-local ones. Compose nothing — the
+  // element's own frame, which is what this returned before the chain walk
+  // existed — and leave the element where its own placement puts it rather
+  // than silently moving it by the site and building offsets.
+  if (!storeyChain) return frame;
   // Visited-set termination: exact for cyclic/self-referential
   // `PlacementRelTo` in malformed IFC, and needs no arbitrary depth bound.
   const visited = new Set<number>([placementId]);


### PR DESCRIPTION
Wall extraction dropped intermediate `IfcLocalPlacement.PlacementRelTo` hops, so a wall nested under an assembly was placed wrongly.

## Both properties pinned, because fixing one direction breaks the other

There is an earlier unraised attempt at this (`create-inference-depth`) that composes the chain all the way to the **root**. That fixes the assembly hop and **regresses the ordinary single-hop case**, because `generateSpacesFromWalls` → `addSpaceToStore` authors the resulting `IfcSpace` with `anchor.storeyPlacementId` as its `PlacementRelTo` (`space.ts:152`, `resolve-anchor.ts:33`). Coordinates are storey-local by contract, so root coordinates get re-offset by the storey placement a second time.

Both REDs, verified by running against a fixture whose storey sits at `(100., 200., 0.)` — the non-origin placement is the whole point, since an origin storey makes the bug unobservable:

```
1) composes an assembly's intermediate hop into a nested wall's axis
   expected { a: [0,0], b: [5,0] } to deeply equal { a: [3,4], b: [8,4] }

2) does not move a wall placed directly under a non-origin storey
   expected { a: [100,200], b: [105,200] } to deeply equal { a: [0,0], b: [5,0] }
```

The second RED is produced against the root-composing approach — i.e. it is the regression that attempt ships.

## The frame

`frameInStoreyFrame` composes each element's chain and stops on reaching the storey's own placement **or any ancestor of it** (`storeyPlacementChain`, collected once per extraction). Using the whole ancestor set rather than just the storey id means a malformed file whose wall hangs directly off the building placement stops there instead of composing to the root — same coordinates as today for that case.

`existingSpaceFootprintsByStorey` shares this frame and was calling the same one-hop helper, so it carried the same latent gap. It now goes through `frameInStoreyFrame`. For the direct storey children it enumerates today the output is **byte-identical** — the value of the change is that both frames come from one code path and cannot drift.

## No new constant

Termination is a `Set<number>` of visited placement ids. That is exact for cyclic and self-referential `PlacementRelTo` in malformed IFC and terminates on any finite file, so no arbitrary numeric bound is needed.

This matters for **#2969**, which unifies the two Rust constants into a single `ifc_lite_core::limits::MAX_PLACEMENT_DEPTH`. The earlier attempt adds a *third* value — `MAX_PLACEMENT_CHAIN_DEPTH = 64` in TypeScript — which would undo that unification the moment both landed. There is nothing here to keep in sync.

## Verification

Mutation-tested in both directions, both die:
- **one hop too late** (drop the storey stop, compose to root) → the single-hop test fails with `[100,200]`
- **one hop too early** (return before composing any parent) → both assembly tests fail

`packages/create` **358 → 361** (+3, one new file, no existing test changed). `packages/cli` 394 passed / 8 skipped. `apps/viewer` `useSpaceBake` + `useZoneSpatialZones` 25 passed. `tsc --noEmit` clean.

Re-ran the original reproduction after the fix: four single-hop walls under the non-origin storey give outline `[[0,0],[10,0],[10,10],[0,10]]`, unchanged from `main`.

Changeset `@ifc-lite/create` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected wall and space positioning when elements are nested within translated or rotated assemblies.
  * Ensured extracted geometry is consistently calculated relative to the storey coordinate frame.
  * Improved placement handling for source walls, overlay walls, and existing space footprints.

* **Tests**
  * Added regression coverage for direct, translated, and rotated nested walls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->