### PR TITLE
fix(viewer): release workers and devices when the failure happens before the handler

### DIFF
--- a/apps/viewer/src/hooks/ids/idsWorkerClient.test.ts
+++ b/apps/viewer/src/hooks/ids/idsWorkerClient.test.ts
@@ -186,4 +186,24 @@ describe('runValidationInWorker', () => {
     };
     await assert.rejects(runValidationInWorker(baseArgs()), /Failed to spawn IDS worker/);
   });
+
+  it('terminates the worker when postMessage itself throws (DataCloneError)', async () => {
+    // The worker is spawned and its handlers attached BEFORE postMessage runs
+    // (the last statement in the executor). If postMessage throws — a real
+    // failure mode: structured-clone rejects an unsupported value — the
+    // executor's synchronous throw auto-rejects the returned promise, but
+    // nothing on that path calls settle()/terminate(). Same
+    // acquire-then-fallible-step-throws-before-teardown shape as
+    // createCollabSession: the spawned worker thread is never torn down.
+    class ThrowingPostWorker extends FakeWorker {
+      override postMessage(): void {
+        throw new Error('could not be cloned');
+      }
+    }
+    (globalThis as { Worker?: unknown }).Worker = ThrowingPostWorker;
+    const promise = runValidationInWorker(baseArgs());
+    const worker = instances[0];
+    await assert.rejects(promise, /could not be cloned/);
+    assert.equal(worker.terminated, 1, 'a postMessage throw must still terminate the worker');
+  });
 });

--- a/apps/viewer/src/hooks/ids/idsWorkerClient.ts
+++ b/apps/viewer/src/hooks/ids/idsWorkerClient.ts
@@ -124,7 +124,16 @@ export function runValidationInWorker(
       locale: args.locale,
       includePassingEntities: args.includePassingEntities,
     };
-    worker.postMessage(request);
+    try {
+      worker.postMessage(request);
+    } catch (err) {
+      // postMessage can itself throw (e.g. a DataCloneError from structured
+      // clone). A throw here happens after the worker is spawned and its
+      // handlers attached, so without this catch the Promise executor's
+      // synchronous throw auto-rejects the returned promise while nothing
+      // ever calls settle() — the worker thread is left running forever.
+      settle(() => reject(err instanceof Error ? err : new Error(String(err))));
+    }
   });
 }
 

--- a/apps/viewer/src/lib/spacemouse/device.test.ts
+++ b/apps/viewer/src/lib/spacemouse/device.test.ts
@@ -13,7 +13,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { SpaceMouseSession } from './device.js';
+import { SpaceMouseSession, connectSpaceMouse } from './device.js';
 
 const GD = 0x01 << 16;
 const [X, Y, Z] = [GD | 0x30, GD | 0x31, GD | 0x32];
@@ -116,4 +116,56 @@ test('buttons report fires the fit callback on press edges, never motion', () =>
   assert.deepEqual(session.getState().tx, 100);
   assert.equal(session.getLastSampleAt(), sampleAt);
   session.detach();
+});
+
+/**
+ * `openSession` (via `connectSpaceMouse`) opens the physical HID device —
+ * a real OS-level exclusive lock — THEN constructs `SpaceMouseSession`.
+ * If that construction throws (a malformed descriptor, a device that goes
+ * away between `open()` and the constructor's `addEventListener` calls),
+ * the catch block in the candidate loop only records `lastError` and moves
+ * on; the device that `open()` just acquired is never `close()`d. Same
+ * acquire-then-fallible-step-throws-before-teardown shape as
+ * `createCollabSession` (#leak-on-failure-sweep): the HID device leaks,
+ * held open for the rest of the browser tab's lifetime, and a real
+ * 3DxWare-style exclusive-open device becomes unusable by any other
+ * consumer until the page reloads.
+ */
+test('openSession closes a device it opened when SpaceMouseSession construction throws', async () => {
+  const originalNavigator = globalThis.navigator;
+  const closeCalls: number[] = [];
+  function fakeThrowingDevice(productId: number): HIDDevice {
+    const device = new EventTarget() as unknown as Record<string, unknown>;
+    device.vendorId = 0x256f;
+    device.productId = productId;
+    device.productName = 'Fake';
+    device.opened = false;
+    device.collections = [];
+    device.open = async () => { device.opened = true; };
+    device.close = async () => { closeCalls.push(productId); device.opened = false; };
+    // Simulate the constructor failing AFTER open() already succeeded —
+    // e.g. a descriptor-parsing throw or a device that vanished mid-setup.
+    device.addEventListener = () => { throw new Error('boom: cannot subscribe'); };
+    return device as unknown as HIDDevice;
+  }
+
+  const fakeDeviceObj = fakeThrowingDevice(0xc635);
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { hid: { requestDevice: async () => [fakeDeviceObj] } },
+    configurable: true,
+  });
+
+  try {
+    await assert.rejects(connectSpaceMouse({}), /Could not open the SpaceMouse/);
+  } finally {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+    });
+  }
+  assert.deepEqual(
+    closeCalls,
+    [0xc635],
+    'the device openSession() itself opened must be closed when constructing the session fails',
+  );
 });

--- a/apps/viewer/src/lib/spacemouse/device.ts
+++ b/apps/viewer/src/lib/spacemouse/device.ts
@@ -322,11 +322,29 @@ async function openSession(devices: HIDDevice[], options: SpaceMouseSessionOptio
 
   let lastError: unknown = null;
   for (const device of candidates) {
+    // Track whether THIS call did the opening — a device that arrived
+    // already `.opened` (e.g. from `getDevices()`) is owned by whatever
+    // opened it, so a later failure here must not close it out from under
+    // that owner. What we open, we are responsible for releasing.
+    const weOpened = !device.opened;
     try {
-      if (!device.opened) await device.open();
+      if (weOpened) await device.open();
       return new SpaceMouseSession(device, options);
     } catch (err) {
       lastError = err;
+      // `device.open()` can succeed and THEN `new SpaceMouseSession(...)`
+      // throw (a malformed descriptor, a device that vanished mid-setup) —
+      // with nothing else holding a reference to the now-open device, it
+      // would otherwise stay open (an exclusive OS-level lock) for the rest
+      // of the tab's lifetime. Release what this call acquired before
+      // moving on to the next candidate.
+      if (weOpened && device.opened) {
+        try {
+          await device.close();
+        } catch {
+          /* already closed / gone */
+        }
+      }
     }
   }
   throw new Error(

--- a/apps/viewer/src/lib/zones/split-worker-client.test.ts
+++ b/apps/viewer/src/lib/zones/split-worker-client.test.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { splitZonesInWorker } from './split-worker-client.js';
+
+/**
+ * `splitZonesInWorker` spawns one worker per run and arms a 600s watchdog
+ * timer, both released together by `settle()`. The load-bearing case here:
+ * `postMessage` is the LAST statement in the executor, unguarded. If it
+ * throws (structured clone can reject an unsupported value), the Promise
+ * executor's synchronous throw auto-rejects the returned promise, but
+ * nothing on that path calls `settle()` — the spawned worker thread AND the
+ * pending timeout timer both leak. Same acquire-then-fallible-step
+ * shape as `createCollabSession`.
+ */
+
+const instances: FakeWorker[] = [];
+
+class FakeWorker {
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: ((event: { message: string }) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+  terminated = 0;
+
+  constructor(public url: unknown, public options: unknown) {
+    instances.push(this);
+  }
+
+  postMessage(): void {
+    /* no-op by default */
+  }
+
+  terminate(): void {
+    this.terminated++;
+  }
+}
+
+function baseRequest() {
+  return { zones: [], zoneIndex: 0, jobs: [] };
+}
+
+beforeEach(() => {
+  instances.length = 0;
+  (globalThis as { Worker?: unknown }).Worker = FakeWorker;
+});
+
+afterEach(() => {
+  delete (globalThis as { Worker?: unknown }).Worker;
+});
+
+describe('splitZonesInWorker', () => {
+  it('rejects without spawning further work when the Worker constructor throws', async () => {
+    (globalThis as { Worker?: unknown }).Worker = function () {
+      throw new Error('blocked by CSP');
+    };
+    await assert.rejects(splitZonesInWorker(baseRequest()), /Failed to spawn the zone split worker/);
+  });
+
+  it('terminates the worker and clears its timeout timer when postMessage itself throws', async () => {
+    class ThrowingPostWorker extends FakeWorker {
+      override postMessage(): void {
+        throw new Error('could not be cloned');
+      }
+    }
+    (globalThis as { Worker?: unknown }).Worker = ThrowingPostWorker;
+    const promise = splitZonesInWorker(baseRequest());
+    const worker = instances[0];
+    await assert.rejects(promise, /could not be cloned/);
+    assert.equal(worker.terminated, 1, 'a postMessage throw must still terminate the worker');
+  });
+});

--- a/apps/viewer/src/lib/zones/split-worker-client.ts
+++ b/apps/viewer/src/lib/zones/split-worker-client.ts
@@ -102,5 +102,14 @@ export const splitZonesInWorker: ZoneSplitBatchFn = (request, onProgress) =>
     // renderer's live scene, and transferring them would detach the buffers the
     // model is drawn from. The clone's copy IS the price of not blanking the
     // viewport.
-    worker.postMessage(payload);
+    try {
+      worker.postMessage(payload);
+    } catch (error) {
+      // postMessage can itself throw (structured clone rejecting an
+      // unsupported value). Thrown after the worker and its timeout timer
+      // are already live, so without this catch the Promise executor's
+      // synchronous throw auto-rejects the returned promise while nothing
+      // calls settle() — the worker thread AND the 600s timer both leak.
+      settle(() => reject(error instanceof Error ? error : new Error(String(error))));
+    }
   });


### PR DESCRIPTION
Three resources leaked on failure paths in `apps/viewer`: `idsWorkerClient.ts` and `zones/split-worker-client.ts` did not terminate their worker when `postMessage` itself threw, and `spacemouse/device.ts` left a device open when session construction failed after it had opened it.

Found on a never-raised branch; merges clean.

## The RED run is the evidence

All three reproduce:
```
a postMessage throw must still terminate the worker                          (ids)
terminates the worker and clears its timeout timer when postMessage throws   (zones, expected 1 actual 0)
openSession closes a device it opened when SpaceMouseSession construction throws
```

But the striking part is the timing. With production reverted, those three files took **600,887 ms** and the runner had to be killed — the leaked 600-second zone-split timer keeps the Node process alive. Restored, the same three files run in **728 ms**.

So this is not only a resource leak in the app; if it ever regressed it would stall CI for ten minutes per run, in a way that looks like a hang rather than a failure.

## Verification

Full `apps/viewer` suite **5449 tests, 5443 pass, 0 fail, 6 skipped**. `tsc --noEmit` clean. api-surface, unused-locals and changesets all pass — the new `weOpened` local is genuinely read, so it does not move the unused-locals baseline.

Neighbour check on the spacemouse change: `weOpened` correctly avoids closing a device that arrived **already open** from `getDevices()`, and the `!device.opened` test is evaluated at the same instant as before.

No changeset, which is correct — `@ifc-lite/viewer` is `private: true` and viewer-only commits on `main` (e.g. `cc09ad8c1`) ship without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
