### PR TITLE
fix(viewer): guard loader awaits that resume after their load was superseded

### DIFF
--- a/.changeset/useifcserver-stale-stream-write-guard.md
+++ b/.changeset/useifcserver-stale-stream-write-guard.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix `loadFromServer`'s streaming path writing a superseded load's geometry into the model the user just opened.
+
+`useIfcCache.ts`'s `isStale` doc claims the same re-check contract as `loadFromServer`'s, but the streaming batch callback passed to `client.parseParquetStream` (and the post-stream/post-parse writes on all three server paths) never re-checked `isStale` after their awaits. A user opening file B while file A was still streaming from the server kept getting A's later batches painted into B's slot, including the trailing progress line reaching `Complete` for a load nobody owned any more. `loadFromServer` now re-checks `isStale` inside the batch callback and after each of the streaming/Parquet/JSON awaits, matching `loadFromCache`'s per-chunk guard, and returns `false` for a superseded load instead of reporting success.

--- a/.changeset/useifcserver-stale-stream-write-guard.md
+++ b/.changeset/useifcserver-stale-stream-write-guard.md
@@ -5,3 +5,5 @@
 Fix `loadFromServer`'s streaming path writing a superseded load's geometry into the model the user just opened.
 
 `useIfcCache.ts`'s `isStale` doc claims the same re-check contract as `loadFromServer`'s, but the streaming batch callback passed to `client.parseParquetStream` (and the post-stream/post-parse writes on all three server paths) never re-checked `isStale` after their awaits. A user opening file B while file A was still streaming from the server kept getting A's later batches painted into B's slot, including the trailing progress line reaching `Complete` for a load nobody owned any more. `loadFromServer` now re-checks `isStale` inside the batch callback and after each of the streaming/Parquet/JSON awaits, matching `loadFromCache`'s per-chunk guard, and returns `false` for a superseded load instead of reporting success.
+
+Also closes one more post-await window in the same function: a re-check right after `await client.isParquetSupported()` resolves, so a load already superseded during that capability check no longer goes on to issue the (now-pointless) parse request at all.

--- a/apps/viewer/src/hooks/useIfcLoader.federatedAlignStaleGuard.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.federatedAlignStaleGuard.test.tsx
@@ -1,0 +1,294 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Stale-guard-after-await sweep: `useIfcLoader.ts`'s `finalizeModel`
+ * FEDERATED branch, specifically its alignment await:
+ *
+ *   const status = await alignGeometryToReference(geometryResult, parsedGeoref, referenceGeoref);
+ *   federationAlignmentStatus = status;
+ *   ... (idOffset, addModel, buildSpatialIndexForModel, appendInstancedShards)
+ *
+ * `alignGeometryToReference` is real reprojection work — genuine wall-clock
+ * duration — and it is the ONLY `await` anywhere in the federated branch
+ * (verified: every write below it — `registerModelOffset`, `addModel`,
+ * `buildSpatialIndexForModel`, `appendInstancedShards`,
+ * `renderer.relabelPointCloudAsset` — is synchronous). Before this fix,
+ * nothing re-checked `loadSessionRef` after that await, so a federated add
+ * superseded by a newer primary load while its alignment was in flight would
+ * still register itself, still offset every mesh id, still add itself to
+ * `useViewerStore`'s `models` map, and still build a spatial index — all for
+ * a load the user had already abandoned.
+ *
+ * **Concrete interleaving this drives.** A federation anchor model
+ * ("ref-model", `EPSG:9999902`) is already in the store. Load A is a
+ * federated GLB add ("model-a", `EPSG:9999901` — a different CRS from the
+ * anchor, so `finalizeModel` takes the cross-CRS reprojection path, the one
+ * with a real `await`). While A's alignment is in flight, the user starts an
+ * entirely new PRIMARY load, load B (a plain GLB, no georef, completes
+ * synchronously — no engine needed, see
+ * `useIfcLoader.federatedIdOffset.test.tsx`'s header for why GLB is the
+ * engine-free fixture of choice for the federated branch). B's `loadFile`
+ * bumps `loadSessionRef` as its very first statement, before any `await` —
+ * so by the time A resumes from its held alignment call, its captured
+ * session is stale by construction, not by timing luck.
+ *
+ * **How the alignment await is held open deterministically.** Both CRS names
+ * (`EPSG:9999901` / `EPSG:9999902`) are fabricated codes that do not exist in
+ * the bundled 7000+-entry EPSG index, so `resolveProjection`
+ * (`lib/geo/reproject.ts`) falls through every offline resolution step (grid
+ * cache — short-circuited under `NODE_TEST_CONTEXT` — bundled index,
+ * well-known-name table, UTM heuristic) to its LAST resort: a real
+ * `fetch('https://epsg.io/<code>.proj4')`. `fetch` is a true global (not an
+ * ESM named export this repo can't monkeypatch — see
+ * `ExtensionHostProvider.tsx`'s header on why `mock.module` is rejected
+ * here), so the test overrides `globalThis.fetch` with a promise it controls
+ * and waits on a signal that fetch was actually called, never a tick count.
+ * Releasing the held fetch with a rejection sends `alignGeometryToReference`
+ * down its ordinary `status: 'failed'` return path — the exact shape a
+ * genuine reprojection failure takes in production — so the guard is
+ * exercised on a real, only-slightly-contrived control-flow outcome, not a
+ * fake one.
+ *
+ * **Why `georefMutations`, not a hand-built STEP/IFCX georeference.** GLB's
+ * own `dataStore` carries no IFC entities (`createMinimalGlbDataStore`
+ * builds an entity-less store), so it cannot carry a
+ * `IfcMapConversion`/`IfcProjectedCRS` pair on its own. `finalizeModel`
+ * merges the dataStore's (here: absent) georeference with
+ * `useViewerStore`'s per-model `georefMutations` map
+ * (`extractModelGeoref(dataStore, coordinateInfo, georefMutations.get(modelId))`),
+ * and `mergeProjectedCRS`/`mergeMapConversion`
+ * (`lib/geo/effective-georef.ts`) build a complete `ProjectedCRS`/
+ * `MapConversion` from the mutation alone when the dataStore has none. This
+ * is the same store action a user's manual georef edit (`GeoreferencingPanel`)
+ * drives — not a test-only backdoor — seeded directly here only because
+ * constructing a real STEP/IFCX `IfcMapConversion` fixture would need either
+ * the STEP-text route (`kmz-export.test.ts`'s `storeFromIfc`, IFC2X3/IFC4
+ * entities the IFCX ECS model does not speak) or an unreachable WASM engine,
+ * neither of which is what this guard's placement depends on: only that
+ * `finalizeModel` sees a non-null `parsedGeoref` AND `referenceGeoref` and
+ * therefore takes the cross-CRS `await` branch.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { createMinimalGlbDataStore } from './ingest/viewerModelIngest.js';
+import { createCoordinateInfo } from '../utils/localParsingUtils.js';
+import { useIfcLoader } from './useIfcLoader.js';
+
+// ─── A real, minimal GLB fixture (mirrors useIfcLoader.federatedIdOffset.test.tsx) ──
+function buildGLB(expressId: number): Uint8Array {
+  const verts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const norms = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const idx = new Uint32Array([0, 1, 2]);
+
+  const posBytes = new Uint8Array(verts.buffer);
+  const normBytes = new Uint8Array(norms.buffer);
+  const idxBytes = new Uint8Array(idx.buffer);
+
+  const json = {
+    asset: { version: '2.0', generator: 'test' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0, extras: { expressId } }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2, material: 0 }] }],
+    materials: [
+      {
+        pbrMetallicRoughness: { baseColorFactor: [0.7, 0.7, 0.7, 1.0], metallicFactor: 0, roughnessFactor: 1 },
+        extensions: { KHR_materials_unlit: {} },
+      },
+    ],
+    accessors: [
+      { bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] },
+      { bufferView: 1, componentType: 5126, count: 3, type: 'VEC3' },
+      { bufferView: 2, componentType: 5125, count: 3, type: 'SCALAR' },
+    ],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength, byteLength: normBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength + normBytes.byteLength, byteLength: idxBytes.byteLength, target: 34963 },
+    ],
+    buffers: [{ byteLength: posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength }],
+  };
+
+  const jsonStr = JSON.stringify(json);
+  const jsonBuf = new TextEncoder().encode(jsonStr);
+  const jsonPad = (4 - (jsonBuf.byteLength % 4)) % 4;
+  const jsonChunkLen = jsonBuf.byteLength + jsonPad;
+
+  const binLen = posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength;
+  const binPad = (4 - (binLen % 4)) % 4;
+  const binChunkLen = binLen + binPad;
+
+  const total = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, 0x46546c67, true); // glTF
+  dv.setUint32(4, 2, true);
+  dv.setUint32(8, total, true);
+  dv.setUint32(12, jsonChunkLen, true);
+  dv.setUint32(16, 0x4e4f534a, true); // JSON
+  out.set(jsonBuf, 20);
+  for (let i = 0; i < jsonPad; i++) out[20 + jsonBuf.byteLength + i] = 0x20;
+
+  let off = 20 + jsonChunkLen;
+  dv.setUint32(off, binChunkLen, true);
+  dv.setUint32(off + 4, 0x004e4942, true); // BIN
+  off += 8;
+  out.set(posBytes, off);
+  off += posBytes.byteLength;
+  out.set(normBytes, off);
+  off += normBytes.byteLength;
+  out.set(idxBytes, off);
+
+  return out;
+}
+
+function glbFile(name: string, expressId: number): File {
+  return new File([buildGLB(expressId) as BlobPart], name, { type: 'model/gltf-binary' });
+}
+
+// ─── Harness ────────────────────────────────────────────────────────────
+
+let hookApi: ReturnType<typeof useIfcLoader> | null = null;
+
+function Probe(): null {
+  hookApi = useIfcLoader();
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+let origFetch: typeof globalThis.fetch;
+
+beforeEach(async () => {
+  hookApi = null;
+  origFetch = globalThis.fetch;
+  useViewerStore.getState().resetViewerState();
+  useViewerStore.getState().clearAllModels();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(hookApi, 'the hook must expose loadFile');
+});
+
+afterEach(async () => {
+  globalThis.fetch = origFetch;
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe('useIfcLoader — a superseded federated add must not overwrite the store after its alignment await (#stale-guard-after-await sweep)', () => {
+  it('load A (federated, cross-CRS alignment held open) resolving after load B (primary GLB) has published must not register A', async () => {
+    // Seed the federation anchor: an already-loaded model with a real,
+    // resolvable georef under a distinct CRS. `findReferenceGeorefModel`
+    // reads this straight off the store.
+    const refModel: FederatedModel = {
+      id: 'ref-model',
+      name: 'anchor.glb',
+      ifcDataStore: createMinimalGlbDataStore(new ArrayBuffer(0), 0),
+      geometryResult: {
+        meshes: [],
+        totalVertices: 0,
+        totalTriangles: 0,
+        coordinateInfo: createCoordinateInfo({ min: { x: 0, y: 0, z: 0 }, max: { x: 0, y: 0, z: 0 } }),
+      },
+      visible: true,
+      collapsed: false,
+      schemaVersion: 'IFC4',
+      loadedAt: 1,
+      fileSize: 0,
+      idOffset: 0,
+      maxExpressId: 0,
+    };
+    useViewerStore.getState().addModel(refModel);
+    useViewerStore.setState({
+      georefMutations: new Map([
+        ['ref-model', {
+          projectedCRS: { name: 'EPSG:9999902', mapUnit: 'METRE', mapUnitScale: 1 },
+          mapConversion: { eastings: 1000, northings: 2000, orthogonalHeight: 0, xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1 },
+        }],
+        ['model-a', {
+          projectedCRS: { name: 'EPSG:9999901', mapUnit: 'METRE', mapUnitScale: 1 },
+          mapConversion: { eastings: 500, northings: 800, orthogonalHeight: 0, xAxisAbscissa: 1, xAxisOrdinate: 0, scale: 1 },
+        }],
+      ]),
+    } as Partial<ReturnType<typeof useViewerStore.getState>>);
+
+    // Hold `fetch` open — the real, only-remaining async boundary
+    // `alignGeometryToReference`'s cross-CRS path reaches for these two
+    // fabricated, not-in-the-bundled-index EPSG codes.
+    let resolveHold!: () => void;
+    const held = new Promise<Response>((_resolve, reject) => {
+      resolveHold = () => reject(new Error('network unavailable (test)'));
+    });
+    let resolveFetchCalled!: () => void;
+    const fetchCalled = new Promise<void>((resolve) => {
+      resolveFetchCalled = resolve;
+    });
+    globalThis.fetch = ((..._args: Parameters<typeof fetch>) => {
+      resolveFetchCalled();
+      return held;
+    }) as typeof fetch;
+
+    const fileA = glbFile('federated-race.glb', 7);
+
+    let pendingA!: Promise<void>;
+    await act(async () => {
+      pendingA = hookApi!.loadFile(fileA, { kind: 'federated', modelId: 'model-a' });
+      // Deterministically wait until load A's alignment has actually reached
+      // (and started awaiting) the network fallback, rather than guessing a
+      // microtask-tick count.
+      await fetchCalled;
+    });
+
+    // Load B: a real, complete PRIMARY load — bumps `loadSessionRef` as its
+    // very first statement, before any await, and publishes its own
+    // geometry. This is the exact moment load A becomes superseded.
+    const fileB = glbFile('winner.glb', 111);
+    await act(async () => {
+      await hookApi!.loadFile(fileB);
+    });
+
+    const geometryAfterB = useViewerStore.getState().geometryResult;
+    assert.ok(geometryAfterB, 'load B must have published its own geometry');
+    assert.equal(geometryAfterB!.meshes[0]?.expressId, 111, 'the published primary geometry is load B\'s');
+    assert.equal(
+      useViewerStore.getState().models.has('model-a'),
+      false,
+      'sanity: load A must not have registered before B completed — otherwise this test is not driving the race it claims to',
+    );
+
+    // Load A's alignment fetch finally rejects — its (now-stale) finalize
+    // resumes and, on the buggy code, unconditionally offsets its mesh ids,
+    // registers itself in the federation registry, and adds itself to the
+    // store.
+    await act(async () => {
+      resolveHold();
+      await pendingA;
+    });
+
+    assert.equal(
+      useViewerStore.getState().models.has('model-a'),
+      false,
+      'load A was superseded before its alignment resolved — it must not register itself in the store',
+    );
+    // The primary slot (load B) must survive load A's discarded finalize
+    // exactly as it was. (The anchor model itself is legitimately cleared by
+    // B's own primary-load reset — `loadFile`'s `if (target.kind ===
+    // 'primary') { ...; clearAllModels(); }` — which is unrelated to the
+    // guard under test here.)
+    assert.equal(useViewerStore.getState().geometryResult, geometryAfterB, "load B's geometry must be untouched by A's discarded finalize");
+  });
+});

--- a/apps/viewer/src/hooks/useIfcLoader.ifcxStaleGuard.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.ifcxStaleGuard.test.tsx
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Stale-guard-after-await sweep: `useIfcLoader.ts`'s IFCX branch.
+ *
+ *   const result = await parseIfcxViewerModel(buffer, setProgress);
+ *   if (target.kind === 'primary') {
+ *     setGeometryResult(result.geometryResult);
+ *     setIfcDataStore(result.dataStore);
+ *   }
+ *   await finalizeModel(result.dataStore, result.geometryResult, result.schemaVersion);
+ *
+ * `parseIfcxViewerModel` is the only await in this branch, and — unlike
+ * every sibling branch in this same function (the cache branch's
+ * `if (cacheOutcome === 'stale') return;`, the point-cloud branch's
+ * `if (loadSessionRef.current !== currentSession) { ...unwind...; return; }`,
+ * and the server branch, which delegates its own internal re-checks to
+ * `loadFromServer`'s `isStale` predicate) — this branch had NO re-check that
+ * a newer load (or model removal) hadn't superseded this one while the parse
+ * was in flight. `finalizeModel` itself provides no protection either: none
+ * of its internal writes (`addModel`, `buildSpatialIndexForModel`,
+ * `appendInstancedShards`, `updateModel`) re-check the session — tracing
+ * confirmed zero `loadSessionRef` references inside its body. So a
+ * superseded IFCX parse landing late used to overwrite whatever a newer,
+ * already-displayed load had published, unconditionally.
+ *
+ * Concrete interleaving this drives: load A (an IFCX file whose buffer read
+ * this test holds open) is in progress when the user picks a different file,
+ * load B (a GLB, parsed and finalized synchronously — no engine needed, see
+ * `useIfcLoader.federatedIdOffset.test.tsx`'s header for why GLB is the
+ * engine-free fixture of choice here). B completes and its geometry is the
+ * current store state. A's (real, successful) IFCX parse then resolves late;
+ * on the buggy code A's stale, empty-geometry result overwrites B's
+ * already-published geometry in the store even though B is what the user
+ * asked for and is looking at.
+ *
+ * **Deterministic interleaving, not a tick count.** `loadFile`'s session bump
+ * (`++loadSessionRef.current`) is its very first statement, before any
+ * `await` (see `useIfcLoader.cacheStaleness.test.tsx`'s header for the same
+ * reasoning) — so firing `loadFile(fileB)` to completion while `loadFile(fileA)`
+ * is deliberately parked on a held promise leaves `fileA`'s captured session
+ * stale by construction, not by timing luck. The hold point is `fileA`'s own
+ * `File#arrayBuffer()` (the read `acquireFileBuffer` performs for a
+ * sub-threshold file) rather than `parseIfcxViewerModel` itself:
+ * `parseIfcxViewerModel` → `parseIfcx` is real, synchronous JSON/ECS work
+ * wrapped in an `async` function with no internal `await` at all, so there is
+ * no way to suspend it mid-flight the way `useIfcServer.stale-guard.test.tsx`
+ * suspends `parseParquet` (a real network round trip). Holding the file read
+ * instead achieves the identical race shape: the session flips strictly
+ * between `fileA`'s last await and the write the fix guards, which is the
+ * property that matters, not which specific await carries it.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store';
+import { useIfcLoader } from './useIfcLoader.js';
+
+// ─── A real, minimal GLB fixture (load B — the winning load) ──────────────
+// Mirrors useIfcLoader.federatedIdOffset.test.tsx's fixture builder exactly:
+// one triangle, one node, carrying `extras.expressId`, routed via
+// `detectFormat`'s `0x46546C67` magic-byte check and parsed for real by
+// `parseGlbViewerModel` — no WASM engine required.
+function buildGLB(expressId: number): Uint8Array {
+  const verts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const norms = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const idx = new Uint32Array([0, 1, 2]);
+
+  const posBytes = new Uint8Array(verts.buffer);
+  const normBytes = new Uint8Array(norms.buffer);
+  const idxBytes = new Uint8Array(idx.buffer);
+
+  const json = {
+    asset: { version: '2.0', generator: 'test' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0, extras: { expressId } }],
+    meshes: [{ primitives: [{ attributes: { POSITION: 0, NORMAL: 1 }, indices: 2, material: 0 }] }],
+    materials: [
+      {
+        pbrMetallicRoughness: { baseColorFactor: [0.7, 0.7, 0.7, 1.0], metallicFactor: 0, roughnessFactor: 1 },
+        extensions: { KHR_materials_unlit: {} },
+      },
+    ],
+    accessors: [
+      { bufferView: 0, componentType: 5126, count: 3, type: 'VEC3', min: [0, 0, 0], max: [1, 1, 0] },
+      { bufferView: 1, componentType: 5126, count: 3, type: 'VEC3' },
+      { bufferView: 2, componentType: 5125, count: 3, type: 'SCALAR' },
+    ],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength, byteLength: normBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength + normBytes.byteLength, byteLength: idxBytes.byteLength, target: 34963 },
+    ],
+    buffers: [{ byteLength: posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength }],
+  };
+
+  const jsonStr = JSON.stringify(json);
+  const jsonBuf = new TextEncoder().encode(jsonStr);
+  const jsonPad = (4 - (jsonBuf.byteLength % 4)) % 4;
+  const jsonChunkLen = jsonBuf.byteLength + jsonPad;
+
+  const binLen = posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength;
+  const binPad = (4 - (binLen % 4)) % 4;
+  const binChunkLen = binLen + binPad;
+
+  const total = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, 0x46546c67, true); // glTF
+  dv.setUint32(4, 2, true);
+  dv.setUint32(8, total, true);
+  dv.setUint32(12, jsonChunkLen, true);
+  dv.setUint32(16, 0x4e4f534a, true); // JSON
+  out.set(jsonBuf, 20);
+  for (let i = 0; i < jsonPad; i++) out[20 + jsonBuf.byteLength + i] = 0x20;
+
+  let off = 20 + jsonChunkLen;
+  dv.setUint32(off, binChunkLen, true);
+  dv.setUint32(off + 4, 0x004e4942, true); // BIN
+  off += 8;
+  out.set(posBytes, off);
+  off += posBytes.byteLength;
+  out.set(normBytes, off);
+  off += normBytes.byteLength;
+  out.set(idxBytes, off);
+
+  return out;
+}
+
+function glbFile(name: string, expressId: number): File {
+  return new File([buildGLB(expressId) as BlobPart], name, { type: 'model/gltf-binary' });
+}
+
+// ─── A real, minimal IFCX fixture (load A — the superseded load) ──────────
+// Valid enough for `parseIfcx` to succeed (a recognized `header.ifcxVersion`,
+// zero entities so the "overlay-only-ifcx" empty-geometry guard doesn't
+// fire) while carrying no geometry of its own — its content is irrelevant to
+// the race, only that it parses successfully and would (on the buggy code)
+// land a real, distinct write.
+function ifcxFile(name: string): File {
+  const json = {
+    header: { id: 'h', ifcxVersion: 'ifcx-alpha', dataVersion: '1', author: 't', timestamp: '' },
+    imports: [],
+    schemas: {},
+    data: [],
+  };
+  const bytes = new TextEncoder().encode(JSON.stringify(json));
+  return new File([bytes as BlobPart], name, { type: 'application/json' });
+}
+
+// ─── Harness: the real hook, rendered ──────────────────────────────────────
+
+let hookApi: ReturnType<typeof useIfcLoader> | null = null;
+
+function Probe(): null {
+  hookApi = useIfcLoader();
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(async () => {
+  hookApi = null;
+  useViewerStore.getState().resetViewerState();
+  useViewerStore.getState().clearAllModels();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(hookApi, 'the hook must expose loadFile');
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe('useIfcLoader — a superseded IFCX load must not overwrite the newer geometry (#stale-guard-after-await sweep)', () => {
+  it('load A (IFCX, held open) resolving after load B (GLB) has published must not clobber B\'s geometry', async () => {
+    const fileA = ifcxFile('race.ifcx');
+    const realBuffer = await fileA.arrayBuffer(); // capture real bytes before shadowing the method
+
+    let resolveHold!: (buf: ArrayBuffer) => void;
+    const held = new Promise<ArrayBuffer>((resolve) => {
+      resolveHold = resolve;
+    });
+    let resolveCalled!: () => void;
+    const arrayBufferCalled = new Promise<void>((resolve) => {
+      resolveCalled = resolve;
+    });
+    // Shadow ONLY this instance's `arrayBuffer()` — the method
+    // `acquireFileBuffer` awaits for a sub-threshold file. `file.slice(...)`
+    // (the earlier point-cloud-detection head read) returns a fresh `Blob`
+    // unaffected by this instance-level override, so format sniffing still
+    // sees the real header bytes.
+    fileA.arrayBuffer = () => {
+      resolveCalled();
+      return held;
+    };
+
+    const fileB = glbFile('winner.glb', 777);
+
+    let pendingA!: Promise<void>;
+    await act(async () => {
+      pendingA = hookApi!.loadFile(fileA);
+      // Deterministically wait until load A has actually reached (and
+      // started awaiting) the file read, rather than guessing a
+      // microtask-tick count.
+      await arrayBufferCalled;
+    });
+
+    // Load B: a real, complete primary load that bumps `loadSessionRef`
+    // (its very first statement, before any await) and publishes its own
+    // geometry — the exact moment load A becomes superseded.
+    await act(async () => {
+      await hookApi!.loadFile(fileB);
+    });
+
+    const geometryAfterB = useViewerStore.getState().geometryResult;
+    assert.ok(geometryAfterB, 'load B must have published geometry');
+    assert.equal(geometryAfterB!.meshes.length, 1, 'load B (GLB) published its one triangle');
+    assert.equal(geometryAfterB!.meshes[0].expressId, 777, 'the published mesh is load B\'s, not a stale placeholder');
+
+    // Load A's file read finally resolves — its IFCX parse now runs and
+    // (on the buggy code) unconditionally overwrites the store.
+    await act(async () => {
+      resolveHold(realBuffer);
+      await pendingA;
+    });
+
+    const geometryFinal = useViewerStore.getState().geometryResult;
+    assert.equal(
+      geometryFinal,
+      geometryAfterB,
+      'load A was superseded before its IFCX parse resolved — its result must not replace ' +
+        "load B's already-published geometry",
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -547,6 +547,19 @@ export function useIfcLoader() {
             setProgress({ phase: 'Aligning georeferenced model', percent: 90 });
             preAlignment = capturePreAlignment(geometryResult);
             const status = await alignGeometryToReference(geometryResult, parsedGeoref, referenceGeoref);
+            // Stale-guard-after-await sweep: `alignGeometryToReference` is real
+            // reprojection work — the only await in the federated branch (every
+            // write below it, registerModelOffset/addModel/buildSpatialIndex-
+            // ForModel/appendInstancedShards/relabelPointCloudAsset, is
+            // synchronous, so one check here covers the whole branch). Nothing
+            // has been acquired yet at this point — no offset registered, no
+            // model added, no spatial index built, no renderer asset relabeled
+            // — so, exactly like the IFCX branch above, there is nothing to
+            // unwind: write nothing and return.
+            if (loadSessionRef.current !== currentSession) {
+              console.warn(`[useIfc] federated finalize ABORTED after alignment: stale session (mine=${currentSession}, current=${loadSessionRef.current}) — alignment result discarded`);
+              return;
+            }
             federationAlignmentStatus = status;
             if (status === 'reprojected') {
               toast.info(
@@ -928,6 +941,19 @@ export function useIfcLoader() {
 
         try {
           const result = await parseIfcxViewerModel(buffer, setProgress);
+          // Stale-guard-after-await sweep: `parseIfcxViewerModel` is a real
+          // (client-side) parse — the only await in this branch — and a
+          // newer load (or model removal) may have superseded this one while
+          // it ran. The point-cloud branch immediately above unwinds
+          // cleanly on the same check (renderer asset removed, counts
+          // cleared); IFCX acquires no renderer/registry resource before
+          // this point, so there is nothing to unwind — write nothing,
+          // exactly like the cache branch's `if (cacheOutcome === 'stale')
+          // return;`.
+          if (loadSessionRef.current !== currentSession) {
+            console.warn(`[useIfc] IFCX finalize ABORTED: stale session (mine=${currentSession}, current=${loadSessionRef.current}) — result discarded`);
+            return;
+          }
           if (target.kind === 'primary') {
             setGeometryResult(result.geometryResult);
             setIfcDataStore(result.dataStore);
@@ -939,6 +965,13 @@ export function useIfcLoader() {
           setLoading(false);
           return;
         } catch (err: unknown) {
+          // Same guard on the error path (#stale-guard sweep): a superseded
+          // load's OWN parse failure must not clobber the newer load's model
+          // record with an `error` state it never had.
+          if (loadSessionRef.current !== currentSession) {
+            console.warn(`[useIfc] IFCX parse failed on an already-stale session (mine=${currentSession}, current=${loadSessionRef.current}) — error discarded:`, err);
+            return;
+          }
           if (err instanceof Error && err.message === 'overlay-only-ifcx') {
             console.warn(`[useIfc] IFCX file "${file.name}" has no geometry - this appears to be an overlay file that adds properties to a base model.`);
             console.warn('[useIfc] To use this file, load it together with a base IFCX file (select both files at once).');

--- a/apps/viewer/src/hooks/useIfcServer.parquetSupportedStaleGuard.test.tsx
+++ b/apps/viewer/src/hooks/useIfcServer.parquetSupportedStaleGuard.test.tsx
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `loadFromServer` re-checks `isStale` after every awaited network round
+ * trip EXCEPT one: `await client.isParquetSupported()` — the capability
+ * check that decides which of the three parse paths (streaming Parquet,
+ * non-streaming Parquet, JSON) to take. Without a re-check immediately
+ * after it, a load superseded while that single await was in flight still
+ * goes on to issue the (now-pointless) `parseParquet`/`parse`/
+ * `parseParquetStream` request — the downstream guards on THOSE awaits
+ * only stop the write into the store, they don't stop the wasted request
+ * from ever being made.
+ *
+ * This fixture blocks `isParquetSupported` on a manually-controlled gate,
+ * waits on a signal that it was actually called (not a tick count), flips
+ * `isStale` while it's still pending, then releases it — and asserts the
+ * downstream parse call never happens at all.
+ */
+
+(globalThis as unknown as { __VITE_ENV__?: Record<string, unknown> }).__VITE_ENV__ = {
+  MODE: 'test',
+  DEV: false,
+  PROD: false,
+  VITE_IFC_SERVER_URL: 'http://localhost:9999',
+  VITE_USE_SERVER: 'true',
+};
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  IfcServerClient,
+  type ParquetParseResponse,
+  type HealthResponse,
+} from '@ifc-lite/server-client';
+import { useViewerStore } from '@/store';
+
+// Deferred until AFTER __VITE_ENV__ is seeded above.
+const { useIfcServer } = await import('./useIfcServer.js');
+
+// ─── Fixture ────────────────────────────────────────────────────────────
+
+/** Small buffer — stays on the non-streaming Parquet path regardless of
+ * `parquetSupported`, so this test isolates the `isParquetSupported`
+ * guard from the (already-guarded) streaming-batch path. */
+const SMALL_BUFFER = { byteLength: 1024 } as ArrayBuffer;
+
+const PARQUET_RESULT: ParquetParseResponse = {
+  meshes: [
+    {
+      express_id: 1,
+      ifc_type: 'IFCWALL',
+      positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+      normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+      indices: new Uint32Array([0, 1, 2]),
+      color: [0.5, 0.25, 0.125, 1],
+    },
+  ],
+  cache_key: 'test-cache-key',
+  metadata: {
+    schema_version: 'IFC4',
+    entity_count: 1,
+    geometry_entity_count: 1,
+    coordinate_info: { origin_shift: [0, 0, 0], is_geo_referenced: false },
+  },
+  stats: {
+    total_meshes: 1,
+    total_vertices: 3,
+    total_triangles: 1,
+    parse_time_ms: 1,
+    geometry_time_ms: 1,
+    total_time_ms: 2,
+    from_cache: false,
+  },
+  parquet_stats: {
+    payload_size: 0,
+    decode_time_ms: 0,
+  },
+};
+
+/** Gate controlling when `isParquetSupported` resolves, so the test can
+ * flip `isStale` while it's pending, deterministically. */
+let releaseIsParquetSupported: (value: boolean) => void;
+let isParquetSupportedGate: Promise<boolean>;
+/** Resolves once `isParquetSupported` has actually been CALLED — a signal,
+ * not a tick count, per the interleaving requirement above. */
+let isParquetSupportedCalled: Promise<void>;
+let signalIsParquetSupportedCalled: () => void;
+let parseParquetCallCount: number;
+
+function resetGates() {
+  isParquetSupportedGate = new Promise<boolean>((resolve) => {
+    releaseIsParquetSupported = resolve;
+  });
+  isParquetSupportedCalled = new Promise<void>((resolve) => {
+    signalIsParquetSupportedCalled = resolve;
+  });
+  parseParquetCallCount = 0;
+}
+
+const originalHealth = IfcServerClient.prototype.health;
+const originalIsParquetSupported = IfcServerClient.prototype.isParquetSupported;
+const originalParseParquet = IfcServerClient.prototype.parseParquet;
+const originalFetchDataModel = IfcServerClient.prototype.fetchDataModel;
+
+beforeEach(() => {
+  resetGates();
+  IfcServerClient.prototype.health = async (): Promise<HealthResponse> =>
+    ({ status: 'ok' }) as HealthResponse;
+  IfcServerClient.prototype.isParquetSupported = async () => {
+    signalIsParquetSupportedCalled();
+    return isParquetSupportedGate;
+  };
+  IfcServerClient.prototype.parseParquet = async (): Promise<ParquetParseResponse> => {
+    parseParquetCallCount++;
+    return PARQUET_RESULT;
+  };
+  // Fire-and-forget background fetch — not observed by this test.
+  IfcServerClient.prototype.fetchDataModel = async () => null;
+  useViewerStore.setState({ progress: null, geometryResult: null, ifcDataStore: null });
+});
+
+afterEach(() => {
+  IfcServerClient.prototype.health = originalHealth;
+  IfcServerClient.prototype.isParquetSupported = originalIsParquetSupported;
+  IfcServerClient.prototype.parseParquet = originalParseParquet;
+  IfcServerClient.prototype.fetchDataModel = originalFetchDataModel;
+  useViewerStore.setState({ progress: null, geometryResult: null, ifcDataStore: null });
+});
+
+// ─── Harness: the real hook, rendered ─────────────────────────────────────
+
+type LoadFromServer = ReturnType<typeof useIfcServer>['loadFromServer'];
+
+let root: Root | null = null;
+let loadFromServer: LoadFromServer | null = null;
+
+function Probe() {
+  loadFromServer = useIfcServer().loadFromServer;
+  return null;
+}
+
+describe('loadFromServer — supersession during the isParquetSupported await', () => {
+  beforeEach(async () => {
+    loadFromServer = null;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(<Probe />);
+    });
+    assert.ok(loadFromServer, 'the hook must expose loadFromServer');
+  });
+
+  afterEach(async () => {
+    const current = root;
+    root = null;
+    if (current) await act(async () => current.unmount());
+  });
+
+  it('a load superseded while isParquetSupported is in flight must not go on to call parseParquet', async () => {
+    let stale = false;
+    const resultPromise = loadFromServer!(
+      new File(['x'], 'model.ifc'),
+      SMALL_BUFFER,
+      () => stale,
+    );
+
+    // Wait on the SIGNAL that isParquetSupported was called, not a tick
+    // count — the intervening isServerAvailable/health await means a fixed
+    // number of microtask ticks is not a reliable proxy for "we're now
+    // inside the isParquetSupported call".
+    await isParquetSupportedCalled;
+
+    // Supersede this load while isParquetSupported is still pending, then
+    // let it resolve.
+    stale = true;
+    releaseIsParquetSupported(true);
+
+    const result = await resultPromise;
+
+    assert.equal(result, false, 'a superseded load must not report success');
+    assert.equal(
+      parseParquetCallCount,
+      0,
+      'a load already known to be stale right after isParquetSupported resolves must not ' +
+        'go on to issue the parseParquet request at all',
+    );
+  });
+
+  it('control: a NON-stale load still proceeds to parseParquet and paints geometry', async () => {
+    const resultPromise = loadFromServer!(new File(['x'], 'model.ifc'), SMALL_BUFFER, () => false);
+    await isParquetSupportedCalled;
+    releaseIsParquetSupported(true);
+
+    const result = await resultPromise;
+
+    assert.equal(result, true, 'a non-stale load must report success');
+    assert.equal(parseParquetCallCount, 1, 'a non-stale load must still reach parseParquet');
+    const meshIds = (useViewerStore.getState().geometryResult?.meshes ?? []).map((m) => m.expressId);
+    assert.deepEqual(meshIds, [1], 'a non-stale load must still paint its geometry');
+  });
+});

--- a/apps/viewer/src/hooks/useIfcServer.staleness.test.tsx
+++ b/apps/viewer/src/hooks/useIfcServer.staleness.test.tsx
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `loadFromServer`'s streaming path must never write into the ACTIVE model
+ * slot once a newer load owns it — the same contract `loadFromCache` upholds
+ * (see `useIfcCache.staleness.test.tsx`, PR #2301). `useIfcCache.ts`'s own
+ * `isStale` doc claims this IS the same contract ("Same contract as
+ * `loadFromServer`'s (useIfcServer.ts:120)"), but until this fix that claim
+ * was aspirational: `loadFromServer`'s streaming batch callback (the
+ * `onBatch` argument to `client.parseParquetStream`) wrote `setProgress` and
+ * `setGeometryResult` on EVERY batch without ever re-checking `isStale`,
+ * unlike `useIfcCache`'s per-chunk guard in its streaming loop.
+ *
+ * The window is real: `client.parseParquetStream` is one long-running await
+ * that invokes `onBatch` once per batch as data arrives. A user who opens
+ * file B while file A is still streaming has A's later batches land in B's
+ * slot — the new model blanks and then repopulates with the previous file's
+ * geometry.
+ *
+ * A single-batch fixture cannot observe this: the whole defect is about what
+ * happens AFTER supersession, so this fixture delivers two batches with a
+ * controllable gap between them and flips `isStale` in that gap.
+ */
+
+import '@/test/setup-dom.js';
+
+// Must run BEFORE the static import graph below evaluates: `ifcConfig.ts`
+// reads `import.meta.env` at module top level (via the test harness's
+// `??=` prelude, see `vite-module-hooks-impl.mjs`), so `SERVER_URL` is
+// already captured as `''` by the time any later statement in THIS file
+// runs. A dynamic `import()` after this assignment is what defers module
+// evaluation past it.
+(globalThis as unknown as { __VITE_ENV__?: Record<string, unknown> }).__VITE_ENV__ = {
+  MODE: 'test',
+  DEV: false,
+  PROD: false,
+  // Localhost so `isServerReachable` (useIfcServer.ts) treats it as
+  // same-origin-safe under happy-dom's default `http://localhost/` location.
+  VITE_IFC_SERVER_URL: 'http://localhost:9999',
+  VITE_USE_SERVER: 'true',
+};
+
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  IfcServerClient,
+  type ParquetBatch,
+  type ParquetStreamResult,
+  type MeshData as ServerMeshData,
+  type HealthResponse,
+} from '@ifc-lite/server-client';
+import { useViewerStore } from '@/store';
+
+// Deferred until AFTER __VITE_ENV__ is seeded above — see comment there.
+const { useIfcServer } = await import('./useIfcServer.js');
+
+// ─── Fixture: two streamed batches ────────────────────────────────────────
+
+function rawMesh(expressId: number): ServerMeshData {
+  return {
+    express_id: expressId,
+    ifc_type: 'IFCWALL',
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [0.5, 0.25, 0.125, 1],
+  };
+}
+
+const BATCH_1: ParquetBatch = { meshes: [rawMesh(1)], batch_number: 1, decode_time_ms: 0 };
+const BATCH_2: ParquetBatch = { meshes: [rawMesh(2)], batch_number: 2, decode_time_ms: 0 };
+
+const STREAM_RESULT: ParquetStreamResult = {
+  cache_key: 'test-cache-key',
+  total_meshes: 2,
+  stats: {
+    total_meshes: 2,
+    total_vertices: 6,
+    total_triangles: 2,
+    parse_time_ms: 1,
+    geometry_time_ms: 1,
+    total_time_ms: 2,
+    from_cache: false,
+  },
+  metadata: {
+    schema_version: 'IFC4',
+    entity_count: 2,
+    geometry_entity_count: 2,
+    coordinate_info: { origin_shift: [0, 0, 0], is_geo_referenced: false },
+  },
+};
+
+/** A fake ArrayBuffer that reports a size over the streaming threshold
+ * (150MB) without allocating real memory — `loadFromServer` only ever
+ * reads `buffer.byteLength`. */
+const HUGE_BUFFER = { byteLength: 200 * 1024 * 1024 } as ArrayBuffer;
+
+/** Gate controlling when batch 2 is delivered, so the test can flip
+ * `isStale` in the window between the two batches deterministically. */
+let releaseBatch2: () => void;
+let batch2Gate: Promise<void>;
+let batchesDelivered: number;
+
+function resetGate() {
+  batchesDelivered = 0;
+  batch2Gate = new Promise<void>((resolve) => {
+    releaseBatch2 = resolve;
+  });
+}
+
+const originalHealth = IfcServerClient.prototype.health;
+const originalIsParquetSupported = IfcServerClient.prototype.isParquetSupported;
+const originalParseParquetStream = IfcServerClient.prototype.parseParquetStream;
+const originalFetchDataModel = IfcServerClient.prototype.fetchDataModel;
+
+beforeEach(() => {
+  resetGate();
+  IfcServerClient.prototype.health = async (): Promise<HealthResponse> =>
+    ({ status: 'ok' }) as HealthResponse;
+  IfcServerClient.prototype.isParquetSupported = async () => true;
+  IfcServerClient.prototype.parseParquetStream = async function (
+    _file: File | ArrayBuffer,
+    onBatch: (batch: ParquetBatch) => void,
+  ): Promise<ParquetStreamResult> {
+    onBatch(BATCH_1);
+    batchesDelivered = 1;
+    await batch2Gate;
+    onBatch(BATCH_2);
+    batchesDelivered = 2;
+    return STREAM_RESULT;
+  };
+  // The background data-model fetch (fire-and-forget after geometry is set)
+  // is not what this test observes — without a mock it hits a real network
+  // socket that retries for tens of seconds against nothing listening on
+  // :9999. `null` takes the same short-circuit `loadFromServer` already
+  // handles for "no data model available".
+  IfcServerClient.prototype.fetchDataModel = async () => null;
+  useViewerStore.setState({ progress: null, geometryResult: null, ifcDataStore: null });
+});
+
+afterEach(() => {
+  IfcServerClient.prototype.health = originalHealth;
+  IfcServerClient.prototype.isParquetSupported = originalIsParquetSupported;
+  IfcServerClient.prototype.parseParquetStream = originalParseParquetStream;
+  IfcServerClient.prototype.fetchDataModel = originalFetchDataModel;
+  useViewerStore.setState({ progress: null, geometryResult: null, ifcDataStore: null });
+});
+
+// ─── Harness: the real hook, rendered ─────────────────────────────────────
+
+type LoadFromServer = ReturnType<typeof useIfcServer>['loadFromServer'];
+
+let root: Root | null = null;
+let loadFromServer: LoadFromServer | null = null;
+
+function Probe() {
+  loadFromServer = useIfcServer().loadFromServer;
+  return null;
+}
+
+function snapshot() {
+  const s = useViewerStore.getState();
+  return {
+    geometryMeshIds: (s.geometryResult?.meshes ?? []).map((m) => m.expressId),
+    progressPhase: s.progress?.phase,
+  };
+}
+
+describe('loadFromServer — a superseded stream must not paint into the active slot', () => {
+  beforeEach(async () => {
+    loadFromServer = null;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(<Probe />);
+    });
+    assert.ok(loadFromServer, 'the hook must expose loadFromServer');
+  });
+
+  afterEach(async () => {
+    const current = root;
+    root = null;
+    if (current) await act(async () => current.unmount());
+  });
+
+  it('supersession BETWEEN streaming batches leaves the second batch unpainted', async () => {
+    let stale = false;
+    const resultPromise = loadFromServer!(
+      new File(['x'], 'model.ifc'),
+      HUGE_BUFFER,
+      () => stale,
+    );
+
+    // Let batch 1 land. `loadFromServer` awaits `isServerAvailable` (which
+    // awaits `client.health()`) and `client.isParquetSupported()` before it
+    // ever reaches `parseParquetStream`, so this needs to drain more than a
+    // couple of microtask ticks — poll with a generous bound instead of
+    // guessing a tick count.
+    for (let i = 0; i < 50 && batchesDelivered < 1; i++) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    assert.equal(batchesDelivered, 1, 'batch 1 must have been delivered before we flip staleness');
+    const afterBatch1 = snapshot();
+    assert.deepEqual(
+      afterBatch1.geometryMeshIds,
+      [1],
+      'pre-supersession: batch 1 must have painted normally',
+    );
+
+    // Now supersede this load and release batch 2.
+    stale = true;
+    releaseBatch2();
+    const result = await resultPromise;
+
+    assert.equal(result, false, 'a superseded streaming load must not report success');
+    const after = snapshot();
+    assert.deepEqual(
+      after.geometryMeshIds,
+      [1],
+      'batch 2 must NOT be painted after supersession — only the pre-supersession mesh may land',
+    );
+    assert.notEqual(
+      after.progressPhase,
+      'Streaming batch 2',
+      'no progress line for the post-supersession batch may be posted',
+    );
+    assert.notEqual(
+      after.progressPhase,
+      'Complete',
+      'the trailing Complete write must not fire for a superseded load',
+    );
+  });
+
+  it('control: a NON-stale load still paints both batches', async () => {
+    // No staleness to wait on here — release batch 2 immediately so the
+    // mocked stream completes like an ordinary uninterrupted load.
+    releaseBatch2();
+    const result = await loadFromServer!(new File(['x'], 'model.ifc'), HUGE_BUFFER, () => false);
+    assert.equal(result, true, 'a non-stale load must report success');
+    const after = snapshot();
+    assert.deepEqual(
+      after.geometryMeshIds.sort((a, b) => a - b),
+      [1, 2],
+      'a non-stale load must still paint every batch — the fix must not disable streaming',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useIfcServer.ts
+++ b/apps/viewer/src/hooks/useIfcServer.ts
@@ -116,7 +116,13 @@ export function useIfcServer() {
   const loadFromServer = useCallback(async (
     file: File,
     buffer: ArrayBuffer,
-    /** Optional staleness check — returns true if this load has been superseded. */
+    /**
+     * Optional staleness check — returns true if this load has been
+     * superseded. Same contract as `loadFromCache`'s (useIfcCache.ts:194):
+     * re-checked before every write into the active model slot, including
+     * inside the streaming batch callback below — a stale batch (or a stale
+     * post-stream/post-parse result) writes nothing.
+     */
     isStale?: () => boolean,
   ): Promise<boolean> => {
     const { setProgress, setIfcDataStore, setGeometryResult } = useViewerStore.getState();
@@ -167,6 +173,14 @@ export function useIfcServer() {
 
         // Use streaming endpoint with batch callback
         const streamResult = await client.parseParquetStream(file, (batch: ParquetBatch) => {
+          // Re-check on every batch: `onBatch` fires once per batch of ONE
+          // long-running awaited stream, so a newer load can own the active
+          // slot by the time any batch after the first arrives. Same
+          // contract, same reason, as useIfcCache.ts's per-chunk guard in its
+          // streaming loop — without it a superseded load's later batches
+          // keep painting into the model the user just opened.
+          if (isStale?.()) return;
+
           batchCount++;
 
           // Convert batch meshes to viewer format (snake_case to camelCase, number[] to TypedArray)
@@ -222,6 +236,13 @@ export function useIfcServer() {
           }
         });
 
+        // Re-check after the stream's single big await resolves: supersession
+        // can land at any point during it, including after the LAST batch's
+        // onBatch call returns. Without this the "final geometry set with
+        // complete bounds" write below still lands in the active slot for a
+        // load nobody owns any more.
+        if (isStale?.()) return false;
+
         cacheKey = streamResult.cache_key;
         streamMetadata = streamResult.metadata;
         streamStats = streamResult.stats;
@@ -272,6 +293,10 @@ export function useIfcServer() {
         // NON-STREAMING PATH - for smaller files, use batch request (with cache check)
         // Use Parquet endpoint - much smaller payload (~15x compression)
         const parquetResult = await client.parseParquet(file);
+        // Re-check right after this await, before the first write below —
+        // same reason as the streaming re-check above: a non-streaming parse
+        // is still one awaited network round trip a newer load can outrun.
+        if (isStale?.()) return false;
         result = parquetResult;
 
         setProgress({ phase: 'Converting meshes', percent: 70 });
@@ -281,6 +306,7 @@ export function useIfcServer() {
       } else {
         // Fallback to JSON endpoint
         result = await client.parse(file);
+        if (isStale?.()) return false;
 
         setProgress({ phase: 'Converting meshes', percent: 70 });
 

--- a/apps/viewer/src/hooks/useIfcServer.ts
+++ b/apps/viewer/src/hooks/useIfcServer.ts
@@ -143,6 +143,12 @@ export function useIfcServer() {
       // Check if Parquet is supported (requires parquet-wasm)
       const parquetSupported = await client.isParquetSupported();
 
+      // A newer load (or model removal) may have superseded this one while
+      // the capability check above was in flight — same reasoning as every
+      // other post-await re-check in this function: an `await` is a window
+      // for `isStale` to flip, not just the streaming/parse calls below.
+      if (isStale?.()) return false;
+
       let allMeshes: MeshData[];
       let result: ServerParseResultType;
 


### PR DESCRIPTION
Stale-guard coverage for the loader: several `await` points could resume after the load they belong to had been superseded, and write their results anyway.

Found on a never-raised branch; merges clean.

## This is the chain tip — ship only this one

Three sibling branches exist. Verified by **content, not by commit**, since the tip is an independent 3-commit rebuild rather than a branch containing the others:

- `useIfcLoader.ts` is **byte-identical** to `stale-guard-federated-align` (empty `git diff` between the two for that path), as are both loader test files.
- For `useIfcServer.ts` the tip carries all of `federated-align`'s guards **plus one more**, and moves the post-stream guard **earlier** — from just before `setGeometryResult` (~:275) to immediately after the stream `await` (~:242). Reading `upstream/main`:218-268, the region between the two placements is pure local computation with no store writes, so the earlier placement is strictly wider and observably equivalent.

So `stale-guard-after-await` ⊂ `stale-guard-loader-trace` ⊂ `stale-guard-federated-align` ⊂ this.

**One thing to know before merging:** the tip **replaces** the chain's `useIfcServer.stale-guard.test.tsx` + `useIfcServer.stale-guard.viteEnvSeed.ts` with `useIfcServer.staleness.test.tsx` + `useIfcServer.parquetSupportedStaleGuard.test.tsx` (459 lines vs 215), dropping the `viteEnvSeed` helper. No coverage is lost, but it is a rewrite rather than an addition — worth a look if you preferred the seed harness.

## Verification

RED with production reverted: all four test files fail — federated add after an alignment `await`, IFCX load, `isParquetSupported` await, and a superseded stream. **6 tests, 2 pass, 4 fail**; the two that pass are the non-stale control cases, which is the right shape.

Full `apps/viewer` suite **5451 tests, 5445 pass, 0 fail**. `tsc --noEmit` clean. unused-locals, api-surface and changesets all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
