### PR TITLE
fix(viewer): cache a failed symbolic parse so a doomed source is not re-parsed every tick

### DIFF
--- a/apps/viewer/src/hooks/useSymbolicAnnotations.retryStorm.test.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.retryStorm.test.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test for the retry-storm defect found in the error-path sweep
+ * (see the sibling fix already applied in useGridLines3D.ts / useAlignmentLines3D.ts
+ * — "Cache empty on failure so we don't retry a doomed parse every tick").
+ *
+ * `ensureParseFor` memoizes a successful parse in `PARSE_CACHE` keyed by the
+ * source's content hash, and a `PARSE_INFLIGHT` map de-dupes concurrent calls
+ * for the same key. But on a genuine parse FAILURE, the original code cleared
+ * `PARSE_INFLIGHT` and returned without ever touching `PARSE_CACHE` — so the
+ * next `ensureParseFor` call for the same (still-broken) source treats it as
+ * never-attempted and reruns the full-source WASM walk from scratch. Every
+ * `stores` dependency change (any federated model visibility toggle, any
+ * `models`/`ifcDataStore` update) re-triggers the same doomed, expensive parse.
+ *
+ * Fault: `store.source.toTransferable()` throws — a real, synchronously
+ * reachable failure `getWholeSourceForWorker` can hit (e.g. a source whose
+ * transferable has already been consumed/detached), not a mocked module.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import {
+  ensureParseFor,
+  __resetSymbolicAnnotationsCacheForTests,
+  __symbolicAnnotationsCacheHasForTests,
+} from './useSymbolicAnnotations.js';
+
+function makeFailingStore(callCounter: { count: number }): IfcDataStore {
+  return {
+    source: {
+      contentKey: 'retry-storm-fault-key',
+      byteLength: 10,
+      toTransferable() {
+        callCounter.count += 1;
+        throw new Error('injected fault: source already consumed');
+      },
+    },
+    // entityIndex intentionally absent — hasEntityType() treats a
+    // missing/empty index as "don't skip", so parseAnnotations reaches
+    // getWholeSourceForWorker() and hits the injected fault.
+  } as unknown as IfcDataStore;
+}
+
+describe('ensureParseFor retry storm on repeated parse failure', () => {
+  beforeEach(() => {
+    __resetSymbolicAnnotationsCacheForTests();
+  });
+
+  it('does not re-run a doomed parse on the second tick for the same source', async () => {
+    const callCounter = { count: 0 };
+    const store = makeFailingStore(callCounter);
+
+    // First failure: this is the "handles the first failure correctly" leg —
+    // the parse runs once, fails, and is reported.
+    await Promise.all(ensureParseFor([store]));
+    assert.equal(callCounter.count, 1, 'first tick should attempt the parse exactly once');
+
+    // Second tick, same still-broken source (e.g. a re-render triggered by
+    // an unrelated `models`/`ifcDataStore` update). A correctly-memoized
+    // failure must NOT re-attempt the expensive WASM walk.
+    await Promise.all(ensureParseFor([store]));
+    assert.equal(
+      callCounter.count,
+      1,
+      'second tick must not re-run the parse for a source that already failed once',
+    );
+
+    // The failure must be visible in the cache (as an empty result) so
+    // downstream consumers don't stay in an indefinite "loading" limbo.
+    assert.equal(
+      __symbolicAnnotationsCacheHasForTests('retry-storm-fault-key'),
+      true,
+      'a failed parse must still populate PARSE_CACHE so retries are skipped',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -146,12 +146,22 @@ function notifyCacheChange(): void {
   for (const fn of CACHE_LISTENERS) fn();
 }
 
-function ensureParseFor(stores: IfcDataStore[]): void {
+/**
+ * Exported for unit testing (retry-storm regression, see
+ * `useSymbolicAnnotations.retryStorm.test.ts`). Returns the in-flight
+ * promises so a test can await completion without polling module state.
+ */
+export function ensureParseFor(stores: IfcDataStore[]): Promise<void>[] {
+  const started: Promise<void>[] = [];
   for (const store of stores) {
     const key = sourceKey(store);
     if (!key) continue;
     if (PARSE_CACHE.has(key)) continue;
-    if (PARSE_INFLIGHT.has(key)) continue;
+    const existing = PARSE_INFLIGHT.get(key);
+    if (existing) {
+      started.push(existing);
+      continue;
+    }
 
     const promise = (async () => {
       try {
@@ -159,14 +169,33 @@ function ensureParseFor(stores: IfcDataStore[]): void {
         PARSE_CACHE.set(key, result);
         notifyCacheChange();
       } catch (error) {
+        // Cache empty on failure so we don't retry a doomed parse every tick
+        // (matches useGridLines3D / useAlignmentLines3D — a model whose
+        // annotation section is malformed would otherwise re-run the
+        // full-source WASM walk on every `stores` dependency change).
         // eslint-disable-next-line no-console
         console.warn('[useSymbolicAnnotations] parse failed:', error);
+        PARSE_CACHE.set(key, createEmptyParseResult());
+        notifyCacheChange();
       } finally {
         PARSE_INFLIGHT.delete(key);
       }
     })();
     PARSE_INFLIGHT.set(key, promise);
+    started.push(promise);
   }
+  return started;
+}
+
+/** @internal test-only reset of the module-level parse cache. */
+export function __resetSymbolicAnnotationsCacheForTests(): void {
+  PARSE_CACHE.clear();
+  PARSE_INFLIGHT.clear();
+}
+
+/** @internal test-only peek at how many entries are cached for a source key. */
+export function __symbolicAnnotationsCacheHasForTests(key: string): boolean {
+  return PARSE_CACHE.has(key);
 }
 
 /** One active model's data store plus the identity needed to map a parsed


### PR DESCRIPTION
A symbolic-annotation parse that fails was not cached, so a doomed source was re-parsed on **every tick** — the cost repeating indefinitely for a file that can never succeed. `apps/viewer/src/hooks/useSymbolicAnnotations.ts` now caches the empty result and notifies, matching `useGridLines3D` and `useAlignmentLines3D`.

Found on a never-raised branch; merges clean.

## The naive RED was vacuous, and that is worth recording

Reverting the whole production hunk removes the test-only exports, so the test file dies at module load:

```
SyntaxError: does not provide an export named '__resetSymbolicAnnotationsCacheForTests'
```

That is a **module-load failure, not proof the assertion pins anything** — a red run that proves nothing. Re-running with a surgical revert of only the two headline lines (`PARSE_CACHE.set(key, createEmptyParseResult()); notifyCacheChange();`) gives the real RED:

```
does not re-run a doomed parse on the second tick for the same source
  expected: 1   actual: 2
```

So the claim is genuinely pinned. Flagging the method because "I reverted it and the tests went red" is exactly the evidence that would have been wrong here.

## Checked rather than assumed

The comment claims the pattern matches `useGridLines3D` / `useAlignmentLines3D`. Verified — `useGridLines3D.ts:76-81` is the same pattern with the same comment, verbatim. Not an overclaim.

The `__…ForTests` export style has established precedent in this app (10+ files, e.g. `lib/webgl-capability.ts`, `utils/loadTelemetry.ts`), so it is not a new convention.

Full `apps/viewer` suite **5446 tests, 5440 pass, 0 fail**. `tsc --noEmit` clean. Gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
