### PR TITLE
feat(mutations,viewer): role-gate bulk mutations below the UI

### DIFF
--- a/.changeset/mutations-canedit-guard.md
+++ b/.changeset/mutations-canedit-guard.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/mutations': minor
+---
+
+Added an opt-in write guard for collaborative/multi-user setups: `BulkQueryEngine` and `CsvConnector` now accept a `canEdit` callback that is checked before any write is applied, throwing a new `MutationGuardError` if it returns false. A `MutationGuard` type is exported for the callback shape. Callers that do not pass `canEdit` see no behaviour change.

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.collab-gate.test.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.collab-gate.test.tsx
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `BulkPropertyEditor` executes mutations via `queryEngine.applyAction()` ->
+ * `MutablePropertyView.setProperty()` directly, bypassing the store's
+ * `setProperty` action entirely — and with it, `canCollabEdit()`. Every
+ * other authoring surface (MainToolbar's Edit pill/undo/redo, AuthorTab's
+ * Edit mode/Add element/Space Sketch, the store's own `setProperty`,
+ * `setAttribute`, geometry move, etc.) gates on
+ * `collabRole === null || collabRole === 'editor' || collabRole === 'admin'`
+ * before mutating. The Bulk Property Editor dialog — reachable from both
+ * MainToolbar's "Edit Properties" menu and the ribbon AuthorTab's "Bulk
+ * property editor" button — has no such check anywhere in its component or
+ * in the direct `applyAction` call path, so a viewer/commenter-role
+ * participant in a shared session can open it and mutate every matching
+ * entity's properties.
+ *
+ * This mounts the real component against a real `MutablePropertyView` (the
+ * same fixture-store pattern `SearchModal.filter.wiring.test.tsx` uses),
+ * drives it through the actual Property Set / Property Name / New Value
+ * inputs and the Execute button — the named user action a viewer-role
+ * participant can take — and asserts no mutation lands when `collabRole`
+ * is 'viewer'.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click, advance } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+import { BulkPropertyEditor } from './BulkPropertyEditor.js';
+
+const MODEL_ID = 'model-a';
+
+function seedStore(collabRole: 'viewer' | 'editor' | null) {
+  const seeded = fixtureModels(
+    fixtureModel(MODEL_ID, {
+      entities: [{ expressId: 42, type: 'IfcWall', name: 'Wall A' }],
+    }),
+  );
+  useViewerStore.setState({
+    ...seeded,
+    mutationViews: new Map(),
+    mutationVersion: 0,
+    collabRole,
+  });
+}
+
+function openDialog(container: HTMLElement): void {
+  const trigger = [...container.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Open'),
+  );
+  assert.ok(trigger, 'dialog trigger button must render');
+  click(trigger!);
+}
+
+async function fillAndExecute(): Promise<void> {
+  // Let the dialog's deferred init (storeys/types) and the mutation-view
+  // registration effects settle.
+  await advance(0);
+
+  const psetInput = [...document.body.querySelectorAll('input')].find(
+    (i) => i.placeholder === 'e.g., Pset_WallCommon',
+  ) as HTMLInputElement | undefined;
+  const propInput = [...document.body.querySelectorAll('input')].find(
+    (i) => i.placeholder === 'e.g., FireRating',
+  ) as HTMLInputElement | undefined;
+  const valueInput = [...document.body.querySelectorAll('input')].find(
+    (i) => i.placeholder === 'Value',
+  ) as HTMLInputElement | undefined;
+  assert.ok(psetInput && propInput && valueInput, 'Property Set / Property Name / New Value inputs must render');
+
+  const setNativeValue = (el: HTMLInputElement, value: string) => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+    setter.call(el, value);
+    el.dispatchEvent(new window.Event('input', { bubbles: true }));
+  };
+  setNativeValue(psetInput!, 'Pset_Test');
+  setNativeValue(propInput!, 'Foo');
+  setNativeValue(valueInput!, 'Bar');
+
+  // Let the match-count debounce (setTimeout(0) then setTimeout(200)) resolve
+  // so `liveMatchCount` becomes non-zero and the Execute button un-disables.
+  await advance(250);
+
+  const executeBtn = [...document.body.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Apply to'),
+  ) as HTMLButtonElement | undefined;
+  assert.ok(executeBtn, 'Execute ("Apply to N entities") button must render');
+  click(executeBtn!);
+  await advance(0);
+}
+
+describe('BulkPropertyEditor — collab role gate on bulk mutation execute', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('a viewer-role participant clicking Execute must not mutate any property', async () => {
+    seedStore('viewer');
+    const container = render(<BulkPropertyEditor trigger={<button>Open</button>} />);
+    openDialog(container);
+    await fillAndExecute();
+
+    const view = useViewerStore.getState().mutationViews.get(MODEL_ID);
+    assert.ok(view, 'a mutation view is registered for the model');
+    const value = view!.getPropertyValue(42, 'Pset_Test', 'Foo');
+    assert.equal(
+      value,
+      null,
+      'Execute must not write Pset_Test.Foo when collabRole is viewer — this is the collab-role bypass',
+    );
+  });
+
+  it('an editor-role participant clicking Execute DOES mutate (sanity: the dialog and query engine work at all)', async () => {
+    seedStore('editor');
+    const container = render(<BulkPropertyEditor trigger={<button>Open</button>} />);
+    openDialog(container);
+    await fillAndExecute();
+
+    const view = useViewerStore.getState().mutationViews.get(MODEL_ID);
+    assert.ok(view, 'a mutation view is registered for the model');
+    const value = view!.getPropertyValue(42, 'Pset_Test', 'Foo');
+    assert.equal(value, 'Bar', 'editor-role execute writes the property (sanity check on the harness)');
+  });
+});

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.collab-gate.test.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.collab-gate.test.tsx
@@ -23,6 +23,18 @@
  * inputs and the Execute button — the named user action a viewer-role
  * participant can take — and asserts no mutation lands when `collabRole`
  * is 'viewer'.
+ *
+ * The UI gate (`canEditInSession`, derived from `collabRole`) sits alongside
+ * an independent engine-level gate: `BulkQueryEngine` is constructed with a
+ * `canCollabEdit` predicate (see `packages/mutations/src/mutation-guard.ts`)
+ * that refuses the write at the chokepoint regardless of what this component
+ * does. That backstop means "no mutation lands" is NOT a fact this file can
+ * use to pin the UI layer on its own — it stays true even with the UI gate
+ * deleted entirely, because the engine still refuses underneath it. The
+ * separate test below asserts the control's own state (`disabled` + the
+ * tooltip) instead, which is the one observable the engine gate cannot
+ * fake: it is true if and only if the UI layer computed `canEditInSession`
+ * correctly for a viewer role.
  */
 
 import '@/test/setup-dom.js';
@@ -112,6 +124,56 @@ describe('BulkPropertyEditor — collab role gate on bulk mutation execute', () 
       value,
       null,
       'Execute must not write Pset_Test.Foo when collabRole is viewer — this is the collab-role bypass',
+    );
+  });
+
+  it('a viewer-role participant sees the Execute button disabled with the collab tooltip', async () => {
+    // Asserts control STATE, not mutation outcome. The engine-level guard
+    // (BulkQueryEngine's canCollabEdit, see mutation-guard.ts) would refuse
+    // the write even if this component's own gate were deleted, so "no
+    // mutation lands" can't distinguish "UI gate present" from "UI gate
+    // removed but engine backstops" — a green run here would mask the loss
+    // of the UI layer. `disabled` + the tooltip text are facts only the UI
+    // layer controls; the engine cannot make them true on its behalf.
+    seedStore('viewer');
+    const container = render(<BulkPropertyEditor trigger={<button>Open</button>} />);
+    openDialog(container);
+    await advance(0);
+
+    const psetInput = [...document.body.querySelectorAll('input')].find(
+      (i) => i.placeholder === 'e.g., Pset_WallCommon',
+    ) as HTMLInputElement | undefined;
+    const propInput = [...document.body.querySelectorAll('input')].find(
+      (i) => i.placeholder === 'e.g., FireRating',
+    ) as HTMLInputElement | undefined;
+    const valueInput = [...document.body.querySelectorAll('input')].find(
+      (i) => i.placeholder === 'Value',
+    ) as HTMLInputElement | undefined;
+    assert.ok(psetInput && propInput && valueInput, 'Property Set / Property Name / New Value inputs must render');
+
+    const setNativeValue = (el: HTMLInputElement, value: string) => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event('input', { bubbles: true }));
+    };
+    setNativeValue(psetInput!, 'Pset_Test');
+    setNativeValue(propInput!, 'Foo');
+    setNativeValue(valueInput!, 'Bar');
+
+    // Let the match-count debounce resolve so liveMatchCount > 0 — otherwise
+    // the button would be disabled for an unrelated reason and the assertion
+    // would be meaningless.
+    await advance(250);
+
+    const executeBtn = [...document.body.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Apply to'),
+    ) as HTMLButtonElement | undefined;
+    assert.ok(executeBtn, 'Execute ("Apply to N entities") button must render');
+    assert.equal(executeBtn!.disabled, true, 'Execute button must be disabled for a viewer-role participant');
+    assert.equal(
+      executeBtn!.title,
+      'Editing requires editor access in this shared session',
+      'the disabled button must explain why via its tooltip',
     );
   });
 

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.collab-gate.test.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.collab-gate.test.tsx
@@ -38,7 +38,7 @@
  */
 
 import '@/test/setup-dom.js';
-import { afterEach, beforeEach, describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { render, cleanup, click, advance } from '@/test/render.js';
 import { useViewerStore } from '@/store';

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
@@ -50,6 +50,7 @@ import {
 import { Progress } from '@/components/ui/progress';
 import { Separator } from '@/components/ui/separator';
 import { useViewerStore } from '@/store';
+import { roleCanEdit } from '@/store/slices/collabSlice';
 import { useIfc } from '@/hooks/useIfc';
 import { configureMutationView } from '@/utils/configureMutationView';
 import { PropertyValueType } from '@ifc-lite/data';
@@ -129,12 +130,13 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
   // the engine itself refuses a write for a viewer/commenter role as containment.
   // (2) canEditInSession mirrors that same role check here in the component, the
   // same way MainToolbar/AuthorTab gate Edit mode, so the Execute button is disabled
-  // and never gets clicked in the first place. null role = single-user, always
+  // and never gets clicked in the first place. Both layers read the one shared
+  // `roleCanEdit` rule that `canCollabEdit()` is itself built from, so a future
+  // role change cannot leave them disagreeing. null role = single-user, always
   // editable.
   const canCollabEdit = useViewerStore((s) => s.canCollabEdit);
   const collabEditRole = useViewerStore((s) => s.collabRole);
-  const canEditInSession =
-    collabEditRole === null || collabEditRole === 'editor' || collabEditRole === 'admin';
+  const canEditInSession = roleCanEdit(collabEditRole);
   // Also get legacy single-model state for backward compatibility
   const legacyIfcDataStore = useViewerStore((s) => s.ifcDataStore);
   const legacyGeometryResult = useViewerStore((s) => s.geometryResult);

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
@@ -122,6 +122,14 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
   const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
   // Subscribe to mutationViews directly to trigger re-render when views are registered
   const mutationViews = useViewerStore((s) => s.mutationViews);
+  // Collab role gate: bulk edits reach the mutation view's setProperty/deleteProperty
+  // directly via BulkQueryEngine.applyAction, bypassing the store's own setProperty
+  // action (and its canCollabEdit() check) entirely — so this component must gate
+  // itself, the same way MainToolbar/AuthorTab gate Edit mode. null role = single-user,
+  // always editable.
+  const collabEditRole = useViewerStore((s) => s.collabRole);
+  const canEditInSession =
+    collabEditRole === null || collabEditRole === 'editor' || collabEditRole === 'admin';
   // Also get legacy single-model state for backward compatibility
   const legacyIfcDataStore = useViewerStore((s) => s.ifcDataStore);
   const legacyGeometryResult = useViewerStore((s) => s.geometryResult);
@@ -557,7 +565,7 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
 
   // Execute bulk update — chunked so the UI stays responsive with a live progress bar
   const handleExecute = useCallback(async () => {
-    if (!queryEngine || liveMatchCount === 0) return;
+    if (!queryEngine || liveMatchCount === 0 || !canEditInSession) return;
 
     setIsExecuting(true);
     setExecuteResult(null);
@@ -622,7 +630,7 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
       setIsExecuting(false);
       setExecuteProgress(null);
     }
-  }, [queryEngine, liveMatchCount, currentCriteria, buildAction, bumpMutationVersion]);
+  }, [queryEngine, liveMatchCount, canEditInSession, currentCriteria, buildAction, bumpMutationVersion]);
 
   // Reset form
   const handleReset = useCallback(() => {
@@ -1030,7 +1038,8 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
               </Button>
               <Button
                 onClick={handleExecute}
-                disabled={liveMatchCount === 0 || !targetProp || (actionType !== 'SET_ATTRIBUTE' && !targetPset) || !executeDirty}
+                disabled={!canEditInSession || liveMatchCount === 0 || !targetProp || (actionType !== 'SET_ATTRIBUTE' && !targetPset) || !executeDirty}
+                title={canEditInSession ? undefined : 'Editing requires editor access in this shared session'}
               >
                 <Play className="h-4 w-4 mr-2" />
                 Apply to {liveMatchCount} entities

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
@@ -122,6 +122,14 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
   const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
   // Subscribe to mutationViews directly to trigger re-render when views are registered
   const mutationViews = useViewerStore((s) => s.mutationViews);
+  // Collab role gate, injected straight into BulkQueryEngine's constructor (see
+  // mutation-guard.ts): bulk edits reach the mutation view's setProperty/
+  // setEntityType directly via applyAction, bypassing the store's own
+  // setProperty action (and its canCollabEdit() check) entirely. Passing the
+  // predicate at construction means the engine itself refuses a write for a
+  // viewer/commenter role, rather than relying on this component remembering
+  // to check first.
+  const canCollabEdit = useViewerStore((s) => s.canCollabEdit);
   // Also get legacy single-model state for backward compatibility
   const legacyIfcDataStore = useViewerStore((s) => s.ifcDataStore);
   const legacyGeometryResult = useViewerStore((s) => s.geometryResult);
@@ -315,9 +323,10 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
       mutationView,
       dataStore.spatialHierarchy || null,
       dataStore.properties || null,
-      dataStore.strings || null
+      dataStore.strings || null,
+      canCollabEdit
     );
-  }, [open, selectedModel, selectedModelId, mutationViews]);
+  }, [open, selectedModel, selectedModelId, mutationViews, canCollabEdit]);
 
   // Build selection criteria using pre-computed typeEnum mapping (no entity scan needed)
   const currentCriteria = useMemo((): SelectionCriteria => {

--- a/apps/viewer/src/components/viewer/DataConnector.collab-gate.test.tsx
+++ b/apps/viewer/src/components/viewer/DataConnector.collab-gate.test.tsx
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The `DataConnector` mirror of `BulkPropertyEditor.collab-gate.test.tsx`.
+ * CSV import reaches `MutablePropertyView.setProperty()` through
+ * `CsvConnector.importAsync()`, bypassing the store's `setProperty` action —
+ * and with it `canCollabEdit()` — exactly as bulk edit does, so the same two
+ * layers apply here: `CsvConnector` is constructed with the store's
+ * `canCollabEdit` predicate (see `packages/mutations/src/mutation-guard.ts`),
+ * and the component disables its own Import button via `canEditInSession`.
+ *
+ * As in the bulk-editor file, "no mutation lands" cannot pin the UI layer —
+ * the engine guard would keep it true with the component's gate deleted. So
+ * this asserts the Import button's `title`, which is the sharpest observable
+ * available here: unlike `disabled` (already true for six unrelated reasons
+ * before a CSV is loaded), the tooltip is set if and only if the component
+ * computed `canEditInSession` false. Making `disabled` meaningful would mean
+ * driving the whole upload/mapping flow through a `FileReader`; the tooltip
+ * needs no fixture file and can fail for exactly one reason.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click, advance } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+import { DataConnector } from './DataConnector.js';
+
+const MODEL_ID = 'model-a';
+
+function seedStore(collabRole: 'viewer' | 'editor' | null) {
+  const seeded = fixtureModels(
+    fixtureModel(MODEL_ID, {
+      entities: [{ expressId: 42, type: 'IfcWall', name: 'Wall A' }],
+    }),
+  );
+  useViewerStore.setState({
+    ...seeded,
+    mutationViews: new Map(),
+    mutationVersion: 0,
+    collabRole,
+  });
+}
+
+async function openAndFindImportButton(): Promise<HTMLButtonElement> {
+  const container = render(<DataConnector trigger={<button>Open</button>} />);
+  const trigger = [...container.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Open'),
+  );
+  assert.ok(trigger, 'dialog trigger button must render');
+  click(trigger!);
+  await advance(0);
+
+  const importBtn = [...document.body.querySelectorAll('button')].find((b) => {
+    const text = b.textContent?.trim() ?? '';
+    return text === 'Import' || /^Import \d+ rows$/.test(text);
+  }) as HTMLButtonElement | undefined;
+  assert.ok(importBtn, 'Import button must render in the dialog footer');
+  return importBtn!;
+}
+
+describe('DataConnector — collab role gate on CSV import', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('a viewer-role participant sees the Import button carry the collab tooltip', async () => {
+    seedStore('viewer');
+    const importBtn = await openAndFindImportButton();
+    assert.equal(
+      importBtn.title,
+      'Editing requires editor access in this shared session',
+      'the Import button must explain why editing is blocked for a viewer role',
+    );
+    assert.equal(importBtn.disabled, true, 'the Import button must be disabled for a viewer role');
+  });
+
+  it('an editor-role participant sees no collab tooltip on the Import button', async () => {
+    seedStore('editor');
+    const importBtn = await openAndFindImportButton();
+    assert.equal(
+      importBtn.title,
+      '',
+      'an editor role must not be told editing is blocked (title is left unset)',
+    );
+  });
+
+  it('a single-user session (null role) sees no collab tooltip on the Import button', async () => {
+    seedStore(null);
+    const importBtn = await openAndFindImportButton();
+    assert.equal(
+      importBtn.title,
+      '',
+      'outside a shared room the local editing rules apply, so no collab tooltip',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/DataConnector.tsx
+++ b/apps/viewer/src/components/viewer/DataConnector.tsx
@@ -61,6 +61,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Progress } from '@/components/ui/progress';
 import { Separator } from '@/components/ui/separator';
 import { useViewerStore } from '@/store';
+import { roleCanEdit } from '@/store/slices/collabSlice';
 import { useIfc } from '@/hooks/useIfc';
 import { configureMutationView } from '@/utils/configureMutationView';
 import { PropertyValueType } from '@ifc-lite/data';
@@ -107,12 +108,13 @@ export function DataConnector({ trigger }: DataConnectorProps) {
   // entirely, so the connector itself refuses a write for a viewer/commenter role
   // as containment. (2) canEditInSession mirrors that same role check here in the
   // component, the same way MainToolbar/AuthorTab gate Edit mode, so the Import
-  // button is disabled and never gets clicked in the first place. null role =
-  // single-user, always editable.
+  // button is disabled and never gets clicked in the first place. Both layers read
+  // the one shared `roleCanEdit` rule that `canCollabEdit()` is itself built from,
+  // so a future role change cannot leave them disagreeing. null role = single-user,
+  // always editable.
   const canCollabEdit = useViewerStore((s) => s.canCollabEdit);
   const collabEditRole = useViewerStore((s) => s.collabRole);
-  const canEditInSession =
-    collabEditRole === null || collabEditRole === 'editor' || collabEditRole === 'admin';
+  const canEditInSession = roleCanEdit(collabEditRole);
   // Also get legacy single-model state for backward compatibility
   const legacyIfcDataStore = useViewerStore((s) => s.ifcDataStore);
   const legacyGeometryResult = useViewerStore((s) => s.geometryResult);

--- a/apps/viewer/src/components/viewer/DataConnector.tsx
+++ b/apps/viewer/src/components/viewer/DataConnector.tsx
@@ -100,6 +100,14 @@ export function DataConnector({ trigger }: DataConnectorProps) {
   const { models } = useIfc();
   const getMutationView = useViewerStore((s) => s.getMutationView);
   const registerMutationView = useViewerStore((s) => s.registerMutationView);
+  // Collab role gate, injected straight into CsvConnector's constructor (see
+  // mutation-guard.ts): CSV import reaches the mutation view's setProperty
+  // directly via generateMutations/importAsync, bypassing the store's own
+  // setProperty action (and its canCollabEdit() check) entirely. Passing the
+  // predicate at construction means the connector itself refuses a write for
+  // a viewer/commenter role, rather than relying on this component
+  // remembering to check first.
+  const canCollabEdit = useViewerStore((s) => s.canCollabEdit);
   // Also get legacy single-model state for backward compatibility
   const legacyIfcDataStore = useViewerStore((s) => s.ifcDataStore);
   const legacyGeometryResult = useViewerStore((s) => s.geometryResult);
@@ -206,9 +214,10 @@ export function DataConnector({ trigger }: DataConnectorProps) {
     return new CsvConnector(
       dataStore.entities,
       mutationView,
-      dataStore.strings || null
+      dataStore.strings || null,
+      canCollabEdit
     );
-  }, [selectedModel, selectedModelId, getMutationView]);
+  }, [selectedModel, selectedModelId, getMutationView, canCollabEdit]);
 
   // Parse CSV file
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/viewer/src/components/viewer/DataConnector.tsx
+++ b/apps/viewer/src/components/viewer/DataConnector.tsx
@@ -100,6 +100,14 @@ export function DataConnector({ trigger }: DataConnectorProps) {
   const { models } = useIfc();
   const getMutationView = useViewerStore((s) => s.getMutationView);
   const registerMutationView = useViewerStore((s) => s.registerMutationView);
+  // Collab role gate: CSV import writes straight to the mutation view (via
+  // csvConnector.importAsync), bypassing the store's own setProperty action
+  // (and its canCollabEdit() check) entirely — same gap as BulkPropertyEditor,
+  // and the same fix: gate this component itself the way MainToolbar/AuthorTab
+  // gate Edit mode. null role = single-user, always editable.
+  const collabEditRole = useViewerStore((s) => s.collabRole);
+  const canEditInSession =
+    collabEditRole === null || collabEditRole === 'editor' || collabEditRole === 'admin';
   // Also get legacy single-model state for backward compatibility
   const legacyIfcDataStore = useViewerStore((s) => s.ifcDataStore);
   const legacyGeometryResult = useViewerStore((s) => s.geometryResult);
@@ -434,7 +442,7 @@ export function DataConnector({ trigger }: DataConnectorProps) {
 
   // Import using CsvConnector.importAsync for non-blocking progress
   const handleImport = useCallback(async () => {
-    if (!csvConnector || !csvContent) return;
+    if (!csvConnector || !csvContent || !canEditInSession) return;
 
     setIsProcessing(true);
     setImportStats(null);
@@ -468,7 +476,7 @@ export function DataConnector({ trigger }: DataConnectorProps) {
     } finally {
       setIsProcessing(false);
     }
-  }, [csvConnector, csvContent, buildDataMapping]);
+  }, [csvConnector, csvContent, canEditInSession, buildDataMapping]);
 
   // Scroll to bottom of the body area — double rAF ensures DOM is painted
   const scrollToBottom = useCallback(() => {
@@ -1014,6 +1022,7 @@ export function DataConnector({ trigger }: DataConnectorProps) {
           <Button
             onClick={handleImport}
             disabled={
+              !canEditInSession ||
               !csvConnector ||
               !csvContent ||
               !matchColumn ||
@@ -1021,6 +1030,7 @@ export function DataConnector({ trigger }: DataConnectorProps) {
               isProcessing ||
               !importDirty
             }
+            title={canEditInSession ? undefined : 'Editing requires editor access in this shared session'}
           >
             {isProcessing && importProgress ? (
               <>

--- a/apps/viewer/src/store/slices/collabSlice.ts
+++ b/apps/viewer/src/store/slices/collabSlice.ts
@@ -109,6 +109,19 @@ import { getEntityCenter } from '@/utils/viewportUtils';
  */
 export type CollabRole = 'viewer' | 'commenter' | 'editor' | 'admin';
 
+/**
+ * The single role -> edit rule. `canCollabEdit()` below is its store-bound
+ * form, and components that mirror the same gate in their own UI
+ * (`BulkPropertyEditor`, `DataConnector`) call this directly off `collabRole`.
+ * Keeping one body means a future role change cannot drift the copies apart.
+ * `null` = not in a shared room, so the local single-user editing rules apply
+ * (handled by the UI's existing `editEnabled` gate) and this returns true.
+ */
+export function roleCanEdit(role: CollabRole | null): boolean {
+  if (role === null) return true;
+  return role === 'editor' || role === 'admin';
+}
+
 export type CollabStatus = 'disconnected' | WebSocketStatus | 'memory' | 'indexeddb';
 
 export interface StartCollabOptions {
@@ -1291,13 +1304,7 @@ export const createCollabSlice: StateCreator<ViewerState, [], [], CollabSlice> =
     }
   },
 
-  canCollabEdit: () => {
-    const role = get().collabRole;
-    // Not in a shared room → fall back to the local single-user editing rules
-    // (handled by the UI's existing `editEnabled` gate), so treat as allowed.
-    if (role === null) return true;
-    return role === 'editor' || role === 'admin';
-  },
+  canCollabEdit: () => roleCanEdit(get().collabRole),
 
   canCollabComment: () => {
     const role = get().collabRole;

--- a/packages/mutations/src/bulk-query-engine.ts
+++ b/packages/mutations/src/bulk-query-engine.ts
@@ -13,6 +13,7 @@ import type { EntityTable, SpatialHierarchy, PropertyTable } from '@ifc-lite/dat
 import { PropertyValueType } from '@ifc-lite/data';
 import type { MutablePropertyView } from './mutable-property-view.js';
 import type { Mutation, PropertyValue } from './types.js';
+import { checkMutationGuard, type MutationGuard } from './mutation-guard.js';
 
 /**
  * Filter operators for property values
@@ -131,19 +132,23 @@ export class BulkQueryEngine {
   private strings: { get(idx: number): string } | null;
   /** expressId → array index lookup, built once to avoid O(n) scans */
   private expressIdIndex: Map<number, number>;
+  /** See mutation-guard.ts: consulted once by `applyAction`, opt-in. */
+  private canEdit: MutationGuard | undefined;
 
   constructor(
     entities: EntityTable,
     mutationView: MutablePropertyView,
     spatialHierarchy?: SpatialHierarchy | null,
     properties?: PropertyTable | null,
-    strings?: { get(idx: number): string } | null
+    strings?: { get(idx: number): string } | null,
+    canEdit?: MutationGuard
   ) {
     this.entities = entities;
     this.mutationView = mutationView;
     this.spatialHierarchy = spatialHierarchy || null;
     this.properties = properties || null;
     this.strings = strings || null;
+    this.canEdit = canEdit;
 
     // Build O(1) lookup map once instead of O(n) linear scan per query
     this.expressIdIndex = new Map<number, number>();
@@ -329,6 +334,7 @@ export class BulkQueryEngine {
    * Apply an action to a single entity (public for chunked execution from UI)
    */
   applyAction(entityId: number, action: BulkAction): Mutation | null {
+    checkMutationGuard(this.canEdit);
     switch (action.type) {
       case 'SET_PROPERTY':
         return this.mutationView.setProperty(

--- a/packages/mutations/src/csv-connector.ts
+++ b/packages/mutations/src/csv-connector.ts
@@ -13,6 +13,7 @@ import type { EntityTable } from '@ifc-lite/data';
 import { PropertyValueType } from '@ifc-lite/data';
 import type { MutablePropertyView } from './mutable-property-view.js';
 import type { Mutation, PropertyValue } from './types.js';
+import { checkMutationGuard, type MutationGuard } from './mutation-guard.js';
 
 /**
  * A parsed CSV row
@@ -114,15 +115,19 @@ export class CsvConnector {
   private entities: EntityTable;
   private mutationView: MutablePropertyView;
   private strings: { get(idx: number): string } | null;
+  /** See mutation-guard.ts: consulted once by `generateMutations`, opt-in. */
+  private canEdit: MutationGuard | undefined;
 
   constructor(
     entities: EntityTable,
     mutationView: MutablePropertyView,
-    strings?: { get(idx: number): string } | null
+    strings?: { get(idx: number): string } | null,
+    canEdit?: MutationGuard
   ) {
     this.entities = entities;
     this.mutationView = mutationView;
     this.strings = strings || null;
+    this.canEdit = canEdit;
   }
 
   /**
@@ -248,6 +253,7 @@ export class CsvConnector {
    * Generate mutations from matched data
    */
   generateMutations(matches: MatchResult[], mapping: DataMapping): Mutation[] {
+    checkMutationGuard(this.canEdit);
     const mutations: Mutation[] = [];
 
     for (const match of matches) {

--- a/packages/mutations/src/index.ts
+++ b/packages/mutations/src/index.ts
@@ -20,6 +20,7 @@ export {
   type EntityTypeNormalizer,
 } from './store-editor.js';
 export { ChangeSetManager } from './change-set.js';
+export { MutationGuardError, type MutationGuard } from './mutation-guard.js';
 export {
   BulkQueryEngine,
   type SelectionCriteria,

--- a/packages/mutations/src/mutation-guard.ts
+++ b/packages/mutations/src/mutation-guard.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Optional local-edit guard for the "always-local" write engines
+ * (`BulkQueryEngine`, `CsvConnector`).
+ *
+ * These two classes are constructed directly by viewer components
+ * (`BulkPropertyEditor.tsx`, `DataConnector.tsx`) and write straight to a
+ * `MutablePropertyView`, bypassing the Zustand store's `setProperty` /
+ * `setEntityType` actions — and, with them, `canCollabEdit()`. Unlike
+ * `MutablePropertyView` and `StoreEditor` themselves (see the module doc on
+ * `MutablePropertyView`), neither engine is ever reached by inbound CRDT
+ * replay, `useZoneWriteBack`, or any `mirror*` helper: both are always
+ * constructed fresh, per dialog-open, from a local user action, and never
+ * shared with — or passed into — the collab plumbing. That makes them safe
+ * to gate at construction: there is no legitimate caller this guard could
+ * wrongly block.
+ *
+ * A caller passes a `canEdit` predicate at construction; the engine consults
+ * it once before mutating and throws `MutationGuardError` (rather than
+ * silently dropping the write) if it returns false. Passing no predicate
+ * preserves today's behaviour exactly — this is opt-in, not a new default,
+ * so it does not change any other consumer of these classes (CLI, SDK,
+ * sandbox bridge, existing tests).
+ */
+
+/** Thrown by a guarded engine when `canEdit()` returns false. */
+export class MutationGuardError extends Error {
+  constructor(message = 'Mutation blocked: editing is disabled for the current role') {
+    super(message);
+    this.name = 'MutationGuardError';
+  }
+}
+
+/** Predicate consulted before a guarded engine applies a write. */
+export type MutationGuard = () => boolean;
+
+/** Throws `MutationGuardError` if `guard` is present and returns false. */
+export function checkMutationGuard(guard: MutationGuard | undefined | null): void {
+  if (guard && !guard()) {
+    throw new MutationGuardError();
+  }
+}

--- a/packages/mutations/test/bulk-query-engine.test.ts
+++ b/packages/mutations/test/bulk-query-engine.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { PropertyValueType } from '@ifc-lite/data';
-import { BulkQueryEngine, MutablePropertyView } from '../src/index.js';
+import { BulkQueryEngine, MutablePropertyView, MutationGuardError } from '../src/index.js';
 
 /**
  * BulkQueryEngine.select() with propertyFilters exercises the private
@@ -303,5 +303,71 @@ describe('BulkQueryEngine property filter operators', () => {
 
       expect(ids).toEqual([2]);
     });
+  });
+});
+
+/**
+ * `BulkQueryEngine.applyAction` writes straight to
+ * `MutablePropertyView.setProperty`/`setEntityType`, bypassing the viewer
+ * store's own actions and `canCollabEdit()` entirely (BulkPropertyEditor.tsx
+ * constructs and drives this class directly — see mutation-guard.ts). These
+ * tests prove the engine refuses a write on its own when constructed with a
+ * `canEdit` predicate that returns false — without any caller having to
+ * remember to check the role first.
+ */
+describe('BulkQueryEngine: local-edit guard (mutation-guard.ts)', () => {
+  it('applyAction throws MutationGuardError and applies nothing when canEdit() is false', () => {
+    const entities = makeEntities(1);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const engine = new BulkQueryEngine(entities, view, null, null, null, () => false);
+
+    expect(() =>
+      engine.applyAction(1, {
+        type: 'SET_PROPERTY',
+        psetName: 'Pset_Test',
+        propName: 'Prop',
+        value: 42,
+        valueType: PropertyValueType.Real,
+      })
+    ).toThrow(MutationGuardError);
+    expect(view.getPropertyValue(1, 'Pset_Test', 'Prop')).toBeNull();
+    expect(view.hasChanges()).toBe(false);
+  });
+
+  it('applyAction still applies when canEdit() is true (guard is opt-in, not a new default)', () => {
+    const entities = makeEntities(1);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const engine = new BulkQueryEngine(entities, view, null, null, null, () => true);
+
+    const mutation = engine.applyAction(1, {
+      type: 'SET_PROPERTY',
+      psetName: 'Pset_Test',
+      propName: 'Prop',
+      value: 42,
+      valueType: PropertyValueType.Real,
+    });
+
+    expect(mutation).not.toBeNull();
+    expect(view.getPropertyValue(1, 'Pset_Test', 'Prop')).toBe(42);
+  });
+
+  it('an engine with no canEdit predicate behaves exactly as before (backward compatible)', () => {
+    const entities = makeEntities(1);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const engine = new BulkQueryEngine(entities, view, null, null, null);
+
+    const mutation = engine.applyAction(1, {
+      type: 'SET_PROPERTY',
+      psetName: 'Pset_Test',
+      propName: 'Prop',
+      value: 42,
+      valueType: PropertyValueType.Real,
+    });
+
+    expect(mutation).not.toBeNull();
+    expect(view.getPropertyValue(1, 'Pset_Test', 'Prop')).toBe(42);
   });
 });

--- a/packages/mutations/test/csv-connector.test.ts
+++ b/packages/mutations/test/csv-connector.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { PropertyValueType } from '@ifc-lite/data';
-import { CsvConnector, MutablePropertyView, type DataMapping } from '../src/index.js';
+import { CsvConnector, MutablePropertyView, MutationGuardError, type DataMapping } from '../src/index.js';
 
 /**
  * Builds a minimal EntityTable-shaped mock, matching the fixture style used
@@ -360,5 +360,95 @@ describe('CsvConnector.importAsync', () => {
       expect(progressUpdates[i]).toBeGreaterThanOrEqual(progressUpdates[i - 1]);
     }
     expect(view.getPropertyValue(3, 'Pset_WallCommon', 'FireRating')).toBe('REI 30');
+  });
+});
+
+/**
+ * `CsvConnector` writes straight to `MutablePropertyView.setProperty`,
+ * bypassing the viewer store's own `setProperty` action and its
+ * `canCollabEdit()` check entirely (DataConnector.tsx constructs and drives
+ * this class directly — see mutation-guard.ts). These tests prove the
+ * engine refuses a write on its own when constructed with a `canEdit`
+ * predicate that returns false — without any caller having to remember to
+ * check the role first.
+ */
+describe('CsvConnector: local-edit guard (mutation-guard.ts)', () => {
+  const rows = [{ expressId: 1, globalId: 'guid-a', name: 'Wall A' }];
+  const mapping: DataMapping = {
+    matchStrategy: { type: 'globalId', column: 'GlobalId' },
+    propertyMappings: [
+      {
+        sourceColumn: 'Rating',
+        targetPset: 'Pset_WallCommon',
+        targetProperty: 'FireRating',
+        valueType: PropertyValueType.Real,
+      },
+    ],
+  };
+  const content = 'GlobalId,Rating\nguid-a,60';
+
+  it('generateMutations throws MutationGuardError and applies nothing when canEdit() is false', () => {
+    const { entities, strings } = makeEntities(rows);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const connector = new CsvConnector(entities, view, strings, () => false);
+
+    const parsed = connector.parse(content);
+    const matches = connector.match(parsed, mapping);
+
+    expect(() => connector.generateMutations(matches, mapping)).toThrow(MutationGuardError);
+    expect(view.getPropertyValue(1, 'Pset_WallCommon', 'FireRating')).toBeNull();
+    expect(view.hasChanges()).toBe(false);
+  });
+
+  it('generateMutations still applies when canEdit() is true (guard is opt-in, not a new default)', () => {
+    const { entities, strings } = makeEntities(rows);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const connector = new CsvConnector(entities, view, strings, () => true);
+
+    const parsed = connector.parse(content);
+    const matches = connector.match(parsed, mapping);
+    const mutations = connector.generateMutations(matches, mapping);
+
+    expect(mutations).toHaveLength(1);
+    expect(view.getPropertyValue(1, 'Pset_WallCommon', 'FireRating')).toBe(60);
+  });
+
+  it("['import'] (sync) surfaces the refusal as a stats error, not a silent no-op", () => {
+    const { entities, strings } = makeEntities(rows);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const connector = new CsvConnector(entities, view, strings, () => false);
+
+    const stats = connector['import'](content, mapping);
+
+    expect(stats.mutationsCreated).toBe(0);
+    expect(stats.errors.length).toBeGreaterThan(0);
+    expect(view.hasChanges()).toBe(false);
+  });
+
+  it('importAsync surfaces the refusal as a stats error, not a silent no-op', async () => {
+    const { entities, strings } = makeEntities(rows);
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor(() => []);
+    const connector = new CsvConnector(entities, view, strings, () => false);
+
+    const stats = await connector.importAsync(content, mapping, () => {});
+
+    expect(stats.mutationsCreated).toBe(0);
+    expect(stats.errors.length).toBeGreaterThan(0);
+    expect(view.hasChanges()).toBe(false);
+  });
+
+  it('a connector with no canEdit predicate behaves exactly as before (backward compatible)', () => {
+    const { connector, view } = makeConnector(rows);
+
+    const parsed = connector.parse(content);
+    const matches = connector.match(parsed, mapping);
+    const mutations = connector.generateMutations(matches, mapping);
+
+    expect(mutations).toHaveLength(1);
+    expect(view.getPropertyValue(1, 'Pset_WallCommon', 'FireRating')).toBe(60);
   });
 });

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -2430,6 +2430,8 @@
     "Mutation: interface",
     "MutationEntityByIdIndex: interface",
     "MutationEntityRef: interface",
+    "MutationGuard: type",
+    "MutationGuardError: class",
     "MutationStoreShape: interface",
     "MutationType: type",
     "NewEntity: interface",


### PR DESCRIPTION
Role-gates bulk mutations at the engine level and in the UI, so a viewer-role participant cannot execute property edits or CSV imports.

Found on a never-raised branch; merges clean.

## Where the gate actually is — stated plainly, because it matters

Three layers, and **the authoritative one is not in this branch**:

- **Server-side, already on `main`:** `packages/collab-server/src/room-manager.ts:368` rejects any `SYNC_UPDATE`/`SYNC_STEP2` write frame when `canWrite(conn.principal)` is false, audited as `reason: 'role'`. The principal's role comes from verified token claims (`access-control.ts:357`, `room-token.ts:236`), not from anything the client asserts. **This is what stops a hostile peer.**
- **Engine-level, this branch:** `checkMutationGuard` in `packages/mutations` — real containment below the UI, but **opt-in**: an unguarded construction behaves as before. Defense-in-depth, not authorization.
- **UI, this branch:** disabled controls and tooltips.

The module doc frames it as containment rather than authorization, which is correct and deliberately unchanged here.

## RED

Six, across both layers: `applyAction throws MutationGuardError`, `generateMutations throws`, `import (sync) surfaces the refusal as a stats error`, `importAsync surfaces the refusal`, plus a viewer-role participant clicking Execute not mutating anything and seeing the button disabled with the collab tooltip.

Neither read path regresses — verified: `BulkQueryEngine.preview()` only calls `select()`, `CsvConnector.preview()` only calls `parse`/`match`; neither touches a guarded method, so a viewer-role user can still preview. `execute()` and `importAsync()` catch the `MutationGuardError` into `errors[]`, so the writes are blocked (each `applyAction` throws before mutating) and the user gets a message rather than a silent no-op.

## Three duplicated predicates became one

`canEditInSession` was hand-spelled in **both** `BulkPropertyEditor.tsx` and `DataConnector.tsx` as `role === null || role === 'editor' || role === 'admin'` — character-for-character copies of `canCollabEdit`'s body in `collabSlice.ts`. Three places that must agree; a role change would have drifted two of them silently.

Now one exported `roleCanEdit(role)`, with `canCollabEdit` delegating to it. **Mutation-tested**: forcing it to `return true` kills 3 of 6 tests — 2 in `BulkPropertyEditor`, 1 in the new `DataConnector` suite — so each consuming component has at least one test that observes the helper.

`DataConnector` previously had **no** UI-gate test; it now has three (viewer / editor / null role). One judgement call: it asserts the Import button's `title` rather than `disabled`, because `disabled` is already true for six unrelated reasons before a CSV is loaded, so it could not fail for the collab reason alone without driving the whole upload+mapping flow. The viewer-role case asserts both.

## Gates

Both failures that blocked this are fixed:
- `check-api-surface` — regenerated with `pnpm api-surface:update` after a full packages build (never hand-edited): **+2 lines, 0 deletions**, both in `@ifc-lite/mutations`. Now `✅ 42 packages, 63 export surfaces, 4193 exports`.
- `check-unused-locals` — dropped an unused `beforeEach` import. Now `✅ 956 known, none increased`. **Baselines untouched.**

`packages/mutations` 202 pass / 10 skipped, unchanged. `apps/viewer` 5409 pass / 0 fail / 6 skipped (+3 from the new file). `tsc --noEmit` clean across `apps/viewer`, `apps/viewer-embed`, `packages/mutations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added collaboration-based editing permissions for bulk property updates and CSV imports.
  - Viewers and commenters can no longer apply changes in shared sessions; editing controls are disabled with an explanatory tooltip.
  - Editors and administrators retain editing access, while single-user sessions remain editable.
  - Added safeguards that prevent unauthorized mutations without applying partial changes.

- **Bug Fixes**
  - Prevented local mutation workflows from bypassing collaboration permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->