### PR TITLE
refactor(viewer): build the pick-info panel with textContent instead of innerHTML

### DIFF
--- a/.changeset/pick-info-textcontent-not-innerhtml.md
+++ b/.changeset/pick-info-textcontent-not-innerhtml.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer-core": patch
+---
+
+Fix the entity-picking panel building its markup with string-concatenated `innerHTML` instead of `textContent`.
+
+`showPickInfo` in the generated viewer HTML wrote the picked entity's IFC type into `#pick-info` by concatenating it straight into `.innerHTML` — the one interpolation site in the file that did this; every other dynamic value (model stats, the command log, the loading text) is written via `.textContent`. `ifcType` comes from the mesh data the viewer receives at runtime, not a fixed string, so a value containing `<`/`&` would have been parsed as markup rather than displayed as text. `showPickInfo` now builds the panel's rows with `document.createElement` and `.textContent`, matching the pattern used everywhere else in the file.

--- a/.changeset/pick-info-textcontent-not-innerhtml.md
+++ b/.changeset/pick-info-textcontent-not-innerhtml.md
@@ -2,6 +2,8 @@
 "@ifc-lite/viewer-core": patch
 ---
 
-Fix the entity-picking panel building its markup with string-concatenated `innerHTML` instead of `textContent`.
+Build the entity-picking panel with `textContent` instead of string-concatenated `innerHTML`.
 
-`showPickInfo` in the generated viewer HTML wrote the picked entity's IFC type into `#pick-info` by concatenating it straight into `.innerHTML` — the one interpolation site in the file that did this; every other dynamic value (model stats, the command log, the loading text) is written via `.textContent`. `ifcType` comes from the mesh data the viewer receives at runtime, not a fixed string, so a value containing `<`/`&` would have been parsed as markup rather than displayed as text. `showPickInfo` now builds the panel's rows with `document.createElement` and `.textContent`, matching the pattern used everywhere else in the file.
+`showPickInfo` in the generated viewer HTML wrote the picked entity's IFC type into `#pick-info` by concatenating it straight into `.innerHTML` — the one interpolation site in the file that did this; every other dynamic value (model stats, the command log, the loading text) is written via `.textContent`. `showPickInfo` now builds the panel's rows with `document.createElement` and `.textContent`, matching the pattern used everywhere else.
+
+This is hardening, not a fix for a reachable escape. `info.ifcType` is not attacker-controlled today: it reaches the panel only through `addMeshBatch`, which is fed exclusively by `parseMeshesViaPrePass` → the WASM parser, where the value is `IfcType::name()` — a closed set of generated `"Ifc…"` literals, with any unrecognised keyword collapsing to `Unknown(hash)` whose `name()` is the literal `"Unknown"`. No IFC file and no `/api/create` payload can put `<` or `&` into it. What the change buys is that the panel no longer depends on that guarantee holding: the last interpolation site that would break if the type string ever stopped coming from the enum is gone.

--- a/packages/viewer/src/viewer-html.ts
+++ b/packages/viewer/src/viewer-html.ts
@@ -846,9 +846,10 @@ function showPickInfo(eid) {
   if (!info) return;
   const el = document.getElementById('pick-info');
   el.style.display = 'block';
-  // Build with textContent, not innerHTML: info.ifcType comes from streamed
-  // mesh data (a loaded IFC file or /api/create), not a fixed string, so it
-  // must never be parsed as markup.
+  // Build with textContent, not innerHTML. info.ifcType is safe today -- it
+  // comes from the WASM parser's IfcType::name(), a closed set of generated
+  // "Ifc..." literals -- so this is not fixing a reachable escape. It removes
+  // the file's last interpolation site that would depend on that staying true.
   el.textContent = '';
   const row = (cls, text) => {
     const d = document.createElement('div');

--- a/packages/viewer/src/viewer-html.ts
+++ b/packages/viewer/src/viewer-html.ts
@@ -846,11 +846,20 @@ function showPickInfo(eid) {
   if (!info) return;
   const el = document.getElementById('pick-info');
   el.style.display = 'block';
-  el.innerHTML =
-    '<div class="label">Entity #' + eid + '</div>' +
-    '<div class="value">' + info.ifcType + '</div>' +
-    '<div class="label">Triangles</div>' +
-    '<div class="value">' + Math.floor(info.indexCount / 3).toLocaleString() + '</div>';
+  // Build with textContent, not innerHTML: info.ifcType comes from streamed
+  // mesh data (a loaded IFC file or /api/create), not a fixed string, so it
+  // must never be parsed as markup.
+  el.textContent = '';
+  const row = (cls, text) => {
+    const d = document.createElement('div');
+    d.className = cls;
+    d.textContent = text;
+    return d;
+  };
+  el.appendChild(row('label', 'Entity #' + eid));
+  el.appendChild(row('value', info.ifcType));
+  el.appendChild(row('label', 'Triangles'));
+  el.appendChild(row('value', Math.floor(info.indexCount / 3).toLocaleString()));
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/packages/viewer/test/viewer-html-runtime.test.ts
+++ b/packages/viewer/test/viewer-html-runtime.test.ts
@@ -1171,3 +1171,130 @@ describe('viewer blob — handleCommand: lifecycle and unknown actions', () => {
     assert.deepEqual(v.ctx.colorOverrides.get(100001), [0.2, 0.9, 0.4, 1]);
   });
 });
+
+// ── 9. Pick-info panel ──────────────────────────────────────────────────────
+
+/**
+ * `showPickInfo` touches `document`, so it is not browser-free — but the
+ * `makeViewer` harness above already shows a `loadDecls` scope can carry a
+ * `document` seam, so a fake one is all this needs. Asserting on the nodes the
+ * function actually appends — rather than grepping the emitted source for
+ * `.innerHTML` — is what makes the test survive a rewrite: any route that puts
+ * markup in instead of text (`innerHTML`, `insertAdjacentHTML`) fails here,
+ * because a text node is the only thing this fake document produces.
+ */
+function fakeDocument() {
+  /** Every write that would have gone through the HTML parser in a browser. */
+  const markupWrites: string[] = [];
+  const make = () => {
+    const node: any = {
+      className: '',
+      style: {} as Record<string, string>,
+      children: [] as any[],
+      _text: '',
+      get textContent(): string {
+        return node.children.length
+          ? node.children.map((c: any) => c.textContent).join('')
+          : node._text;
+      },
+      set textContent(v: string) {
+        node.children = [];
+        node._text = String(v);
+      },
+      // The two markup routes, recorded rather than parsed. A browser would
+      // turn these into elements; here they are evidence the panel stopped
+      // treating its input as text.
+      set innerHTML(v: string) {
+        markupWrites.push(String(v));
+        node.children = [];
+        node._text = '';
+      },
+      get innerHTML(): string {
+        return markupWrites[markupWrites.length - 1] ?? '';
+      },
+      insertAdjacentHTML(_where: string, v: string) {
+        markupWrites.push(String(v));
+      },
+      appendChild(child: any) {
+        node._text = '';
+        node.children.push(child);
+        return child;
+      },
+    };
+    return node;
+  };
+  const pickInfo = make();
+  return {
+    doc: {
+      getElementById: (id: string) => (id === 'pick-info' ? pickInfo : null),
+      createElement: make,
+    },
+    pickInfo,
+    markupWrites,
+  };
+}
+
+describe('viewer blob — showPickInfo builds the panel as text, not markup', () => {
+  const renderPick = (eid: number, info: Record<string, unknown>) => {
+    const { doc, pickInfo, markupWrites } = fakeDocument();
+    loadDecls(['showPickInfo'], {
+      entityMap: new Map<number, unknown>([[eid, info]]),
+      document: doc,
+    }).showPickInfo(eid);
+    return { el: pickInfo, markupWrites };
+  };
+
+  it('appends one text-only div per row', () => {
+    const { el, markupWrites } = renderPick(7, { ifcType: 'IfcWall', indexCount: 9 });
+    assert.deepEqual(
+      el.children.map((c: any) => [c.className, c.textContent]),
+      [
+        ['label', 'Entity #7'],
+        ['value', 'IfcWall'],
+        ['label', 'Triangles'],
+        ['value', '3'],
+      ],
+    );
+    assert.deepEqual(markupWrites, [], 'no row may be written through the HTML parser');
+  });
+
+  it('keeps an ifcType containing markup characters as literal text', () => {
+    // Not reachable today: ifcType comes from the parser's IfcType::name(), a
+    // closed set of "Ifc..." literals. This pins the property the rewrite
+    // exists to guarantee — the panel renders whatever it is handed as text.
+    const { el, markupWrites } = renderPick(1, {
+      ifcType: '<img src=x onerror=alert(1)>&',
+      indexCount: 3,
+    });
+    assert.deepEqual(
+      markupWrites,
+      [],
+      'the type string must never reach innerHTML or insertAdjacentHTML',
+    );
+    const value = el.children[1];
+    assert.equal(value.textContent, '<img src=x onerror=alert(1)>&');
+    assert.equal(value.children.length, 0, 'the value must be a text node, never parsed markup');
+  });
+
+  it('clears the previous pick rather than appending to it', () => {
+    const { doc, pickInfo } = fakeDocument();
+    const ctx = loadDecls(['showPickInfo'], {
+      entityMap: new Map<number, unknown>([
+        [1, { ifcType: 'IfcWall', indexCount: 3 }],
+        [2, { ifcType: 'IfcSlab', indexCount: 6 }],
+      ]),
+      document: doc,
+    });
+    ctx.showPickInfo(1);
+    ctx.showPickInfo(2);
+    assert.equal(pickInfo.children.length, 4, 'a second pick must replace the first four rows');
+    assert.equal(pickInfo.children[1].textContent, 'IfcSlab');
+  });
+
+  it('leaves the panel untouched for an unknown entity', () => {
+    const { doc, pickInfo } = fakeDocument();
+    loadDecls(['showPickInfo'], { entityMap: new Map(), document: doc }).showPickInfo(99);
+    assert.equal(pickInfo.children.length, 0);
+    assert.equal(pickInfo.style.display, undefined, 'an unknown id must not open the panel');
+  });
+});

--- a/packages/viewer/test/viewer-html.test.ts
+++ b/packages/viewer/test/viewer-html.test.ts
@@ -102,3 +102,24 @@ describe('getViewerHtml — model name escaping', () => {
     assert.doesNotMatch(html, /<link[^>]+href=["']https?:/i);
   });
 });
+
+describe('getViewerHtml — pick-info rendering does not use unescaped innerHTML', () => {
+  // showPickInfo renders `info.ifcType`, a value read from the streamed mesh
+  // data the viewer receives at runtime (from a loaded IFC file or a
+  // /api/create call). Every other dynamic value in this file is written via
+  // `.textContent`; this function alone used to build markup by
+  // string-concatenating into `.innerHTML`, which parses `<`/`&` in the
+  // interpolated value as markup instead of text. Pin the safer sibling
+  // pattern here since showPickInfo touches `document` and so falls outside
+  // the browser-free blob-extraction harness in viewer-html-runtime.test.ts.
+  it('does not assign to innerHTML anywhere in showPickInfo', () => {
+    const html = getViewerHtml('m.ifc');
+    const m = html.match(/function showPickInfo\(eid\) \{[\s\S]*?\n\}/);
+    assert.ok(m, 'showPickInfo not found in the viewer script');
+    assert.doesNotMatch(
+      m[0],
+      /\.innerHTML\s*=/,
+      'showPickInfo must build the pick-info panel without innerHTML string concatenation',
+    );
+  });
+});

--- a/packages/viewer/test/viewer-html.test.ts
+++ b/packages/viewer/test/viewer-html.test.ts
@@ -102,24 +102,3 @@ describe('getViewerHtml — model name escaping', () => {
     assert.doesNotMatch(html, /<link[^>]+href=["']https?:/i);
   });
 });
-
-describe('getViewerHtml — pick-info rendering does not use unescaped innerHTML', () => {
-  // showPickInfo renders `info.ifcType`, a value read from the streamed mesh
-  // data the viewer receives at runtime (from a loaded IFC file or a
-  // /api/create call). Every other dynamic value in this file is written via
-  // `.textContent`; this function alone used to build markup by
-  // string-concatenating into `.innerHTML`, which parses `<`/`&` in the
-  // interpolated value as markup instead of text. Pin the safer sibling
-  // pattern here since showPickInfo touches `document` and so falls outside
-  // the browser-free blob-extraction harness in viewer-html-runtime.test.ts.
-  it('does not assign to innerHTML anywhere in showPickInfo', () => {
-    const html = getViewerHtml('m.ifc');
-    const m = html.match(/function showPickInfo\(eid\) \{[\s\S]*?\n\}/);
-    assert.ok(m, 'showPickInfo not found in the viewer script');
-    assert.doesNotMatch(
-      m[0],
-      /\.innerHTML\s*=/,
-      'showPickInfo must build the pick-info panel without innerHTML string concatenation',
-    );
-  });
-});


### PR DESCRIPTION
`showPickInfo` in `packages/viewer/src/viewer-html.ts` built the pick-info panel by concatenating into `innerHTML`. It now builds it with `createElement` / `textContent`.

Found on a never-raised branch; merges clean. 253 pass / 0 fail.

## This is hardening, not a reachable escape — and the changeset now says so

The branch's original changeset claimed `ifcType` *"comes from the mesh data the viewer receives at runtime, not a fixed string, so a value containing `<`/`&` would have been parsed as markup"*. That implies a reachable condition that does not exist, so it has been rewritten, along with the same overclaim in the in-code comment.

Traced by reading, end to end: `info.ifcType` → `addMeshBatch` (exactly two call sites, `viewer-html.ts:1134` and `:1432`, both inside `parseMeshesViaPrePass`'s `onBatch`) → `MeshDataJs.ifcType` (`rust/wasm-bindings/src/zero_copy/mesh.rs:75`) → `job.ifc_type.name().to_string()` (`rust/processing/src/element.rs:529`, `:760`) → `IfcType::name()` at `rust/core/src/generated/schema.rs:4621`, a match over **870 `"Ifc…"` literals**, every arm grepped: none contains `<` or `&`. Unrecognised keywords collapse to `Unknown(crc32_hash)`, whose `name()` returns the literal `"Unknown"`.

So an attacker would need to control the **Rust enum's variant names**, not the IFC file. No file content and no `/api/create` payload can reach it.

What the change buys is that the panel no longer *depends* on that guarantee holding.

## The test was a grep; it is now behavioural

The original test asserted on generated source text, so it would have stayed green if someone switched to `insertAdjacentHTML`. Its comment claimed it avoided the runtime harness because it "touches `document`" — inaccurate: `viewer-html-runtime.test.ts`'s `makeViewer` already passes a `document` seam into `loadDecls`.

The grep test is deleted and replaced with 4 behavioural tests in that harness, against a fake document whose elements record `innerHTML` / `insertAdjacentHTML` writes into a `markupWrites` array rather than parsing them, so **both** markup routes are observable.

**Mutation-checked both routes:** reverting to `innerHTML` kills 2 assertions; switching to `insertAdjacentHTML` kills the same 2. The old test caught only the first — that gap is closed.

Neighbour check: the `.label` / `.value` CSS classes are preserved by the `row(cls, text)` helper, and nothing else reads `#pick-info`'s children (only `.style.display` at `:840` and `:1479`).

`packages/viewer` 250 → **253** (−1 grep test, +4 DOM tests). `tsc --noEmit` clean, `oxlint` clean, `check-changesets` passes.

## Unrelated, flagged not fixed

`scripts/typecheck-tests.mjs` fails in a fresh worktree with 59 × TS17004 ("Cannot use JSX unless the '--jsx' flag is provided") and 54 × TS2307 across 1278 test files — none of them files this branch touches (grepped its output for `viewer-html`: zero hits). It also drops a generated `tsconfig.tests.json` in the repo root. That looks config-shaped and pre-existing, but **that is inferred from the error shape, not confirmed by a baseline run** — worth someone checking independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
