### PR TITLE
fix(collab): keep a snapshot round-trip idempotent for a null attribute

### DIFF
--- a/.changeset/collab-snapshot-null-attribute-round-trip.md
+++ b/.changeset/collab-snapshot-null-attribute-round-trip.md
@@ -1,0 +1,18 @@
+---
+'@ifc-lite/collab': patch
+---
+
+Fix `snapshotToIfcx` writing a literal `null` for a flat attribute value that its own counterpart, `seedFromIfcx`, treats as an IFCX removal opinion and silently drops.
+
+A doc attribute can legitimately hold `null` (e.g. a user clearing a root
+attribute like `Description` through the viewer's mutation bridge). Before
+this fix, `snapshotToIfcx` serialized that value verbatim, so a
+snapshot -> seed -> snapshot cycle was not idempotent: the first snapshot
+carried `"Description": null`, the intervening seed dropped the key per
+`from-ifcx.ts`'s documented contract, and the second snapshot of the
+re-seeded doc omitted the key entirely - two snapshots of "the same" doc
+state disagreeing with each other.
+
+`snapshotToIfcx` now drops null-valued attributes on the way out, matching
+the reader's contract instead of handing it a value it is guaranteed to
+discard on the next round-trip.

--- a/packages/collab/src/snapshot/to-ifcx.ts
+++ b/packages/collab/src/snapshot/to-ifcx.ts
@@ -72,7 +72,19 @@ export function snapshotToIfcx(doc: Y.Doc, options: SnapshotOptions = {}): IfcxF
       for (const k of inheritsKeys) node.inherits[k] = json.inherits[k];
     }
 
-    const attributes = flattenStructuredBranches(json, { geometryRecordFor });
+    // `seedFromIfcx` treats a literal `null` attribute value as an IFCX
+    // removal opinion and never stores it (see from-ifcx.ts) — so a
+    // doc attribute holding `null` (e.g. a root attribute the user
+    // cleared, mirrored via mutation-bridge.ts's `toScalar`) must not
+    // be emitted as-is: the very next seed would silently drop it,
+    // disagreeing with what this writer just produced. Match the
+    // reader's contract on the way out instead of losing the key on
+    // the next round-trip.
+    const flattened = flattenStructuredBranches(json, { geometryRecordFor });
+    const attributes: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(flattened)) {
+      if (value !== null) attributes[key] = value;
+    }
     if (Object.keys(attributes).length > 0) {
       node.attributes = attributes;
     }

--- a/packages/collab/test/layers.test.ts
+++ b/packages/collab/test/layers.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
 import { createCollabDoc } from '../src/doc/schema.js';
 import { createEntity, setAttribute } from '../src/doc/entity.js';
 import { captureBaseline, extractUserLayer } from '../src/snapshot/layers.js';
@@ -28,5 +29,28 @@ describe('extractUserLayer', () => {
     const wallNode = layer.data.find((n) => n.path === 'wall')!;
     expect(wallNode.attributes?.Name).toBe('after');
     expect(wallNode.attributes?.Description).toBe('extra');
+  });
+
+  it('excludes a second peer\'s edits — the single-client fixture above cannot observe this', () => {
+    // With only one clientID ever touching `doc`, the test above passes
+    // whether or not `filterUpdateByClient` actually filters anything —
+    // "everything belongs to the only client" is true either way. This
+    // fixture needs two distinct clientIDs to discriminate "filtered
+    // correctly" from "filtering is a no-op".
+    const doc = createCollabDoc();
+    createEntity(doc, 'wall');
+    setAttribute(doc, 'wall', 'Name', 'from-peer-A');
+    const clientA = doc.clientID;
+
+    const peerDoc = createCollabDoc();
+    Y.applyUpdate(peerDoc, Y.encodeStateAsUpdate(doc));
+    peerDoc.clientID = clientA + 1; // distinct from doc's clientID
+    setAttribute(peerDoc, 'wall', 'Description', 'from-peer-B');
+    Y.applyUpdate(doc, Y.encodeStateAsUpdate(peerDoc, Y.encodeStateVector(doc)));
+
+    const layer = extractUserLayer(doc, undefined, { clientId: clientA });
+    const wallNode = layer.data.find((n) => n.path === 'wall');
+    expect(wallNode?.attributes?.Name).toBe('from-peer-A');
+    expect(wallNode?.attributes?.Description).toBeUndefined();
   });
 });

--- a/packages/collab/test/to-ifcx-null-attribute.test.ts
+++ b/packages/collab/test/to-ifcx-null-attribute.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `to-ifcx` and `from-ifcx` must agree on what a literal `null` flat
+ * attribute value means.
+ *
+ * `from-ifcx.ts` documents (and enforces) that a `null` attribute value
+ * is an IFCX "removal opinion": with no underlying layer to remove from,
+ * it means "absent", so `seedFromIfcx` never stores it.
+ *
+ * A doc attribute can legitimately hold a literal `null` today —
+ * `apps/viewer`'s `mutation-bridge.ts` writes exactly that when a user
+ * clears a root attribute (`toScalar(null) === null`, fed straight into
+ * `setAttribute`). Before this fix, `snapshotToIfcx` serialized that
+ * `null` verbatim, so a snapshot → seed → snapshot cycle was NOT
+ * idempotent: the first snapshot carries `"Description": null`, the
+ * seed drops the key (per from-ifcx's own contract), and the second
+ * snapshot of the re-seeded doc omits the key entirely — two snapshots
+ * of "the same" doc state that disagree with each other.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createEntity, setAttribute } from '../src/doc/entity.js';
+import { createCollabDoc } from '../src/doc/schema.js';
+import { seedFromIfcx } from '../src/snapshot/from-ifcx.js';
+import { snapshotToIfcx } from '../src/snapshot/to-ifcx.js';
+
+describe('to-ifcx / from-ifcx agreement on null attribute values', () => {
+  it('keeps a snapshot -> seed -> snapshot cycle idempotent for a null attribute', () => {
+    const doc = createCollabDoc();
+    createEntity(doc, '/e1', { ifcClass: 'IfcWall' });
+    // Mirrors mutation-bridge.ts clearing a root attribute to null.
+    setAttribute(doc, '/e1', 'Description', null);
+
+    const snapshot1 = snapshotToIfcx(doc, { timestamp: 'T' });
+    const node1 = snapshot1.data.find((n) => n.path === '/e1');
+
+    const doc2 = createCollabDoc();
+    seedFromIfcx(doc2, snapshot1);
+    const snapshot2 = snapshotToIfcx(doc2, { timestamp: 'T' });
+    const node2 = snapshot2.data.find((n) => n.path === '/e1');
+
+    // The writer must not hand out a value its own reader treats as
+    // "absent" (a literal `null`) — that produced a first snapshot that
+    // disagreed with every snapshot taken after the first re-seed.
+    expect(node1?.attributes?.Description).not.toBe(null);
+    expect(node1).toEqual(node2);
+  });
+});


### PR DESCRIPTION
A snapshot → seed → snapshot cycle was not idempotent for a null attribute. Found on a never-raised branch; merges clean.

RED, reverse-applying only `packages/collab/src/snapshot/to-ifcx.ts`:
```
FAIL keeps a snapshot -> seed -> snapshot cycle idempotent for a null attribute
AssertionError: expected null not to be null
```

`packages/collab` 227 pass / 2 skip (226 + 1 fail reverted); `packages/collab-server` 182 pass. api-surface, unused-locals and changesets all pass.

The second commit is test-only, so I mutation-checked it rather than taking it on trust: neutering `filterUpdateByClient` in `layers.ts` fails the **new** test while the old one still passes. Non-vacuous.

Every prose claim checked against the code — `from-ifcx.ts:77` really drops nulls, `mutation-bridge.ts:135 toScalar` really returns `null`. No overclaim.

**One comment that is now a hair less true**, not blocking: `minimal-layer.ts:92-95` says the two writers "stay in lockstep by construction (#1031)". It builds `liveAttrs` from `flattenStructuredBranches` directly, so it still emits `key: null` where the full writer now drops the key. I traced the reader — both land at "key absent", so there is no behavioural divergence, but the lockstep claim no longer holds literally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
