### PR TITLE
fix(cli): make ask --json exit non-zero where the human path signals failure

### DIFF
--- a/.changeset/ask-json-exit-code-on-recipe-failure.md
+++ b/.changeset/ask-json-exit-code-on-recipe-failure.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/cli": patch
+---
+
+Fix `ifc-lite ask <file> "<question>" --json` always exiting 0, even when the matched recipe throws.
+
+The recipe-execution catch branched on `--json`: the non-JSON path called `fatal()`, which hard-exits 1, but the JSON path only printed `{ error }` and fell through without setting `process.exitCode` — a caller reading just the exit code (a build pipeline, a script) saw success on a question that could not be answered. The `--json` path now sets `process.exitCode = 1` in that catch, matching the non-JSON verdict.

--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite ask <file> "<question>" --json` must not exit 0 when the matched
+ * recipe throws.
+ *
+ * `askCommand`'s recipe-execution catch (ask.ts) branches on `--json`: the
+ * non-JSON path calls `fatal()`, which hard-exits 1; the JSON path prints
+ * `{ error }` and falls through with no exit code set at all, so the process
+ * exits 0 — a build pipeline reading only the exit code sees success on a
+ * question that could not be answered. Same shape as the `ids --json`
+ * always-exit-0 defect.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createHeadlessContext = vi.hoisted(() => vi.fn());
+vi.mock('../loader.js', () => ({ createHeadlessContext }));
+
+const { askCommand } = await import('./ask.js');
+
+describe('askCommand when the matched recipe throws', () => {
+  let stdout: string;
+  let stderr: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let previousExitCode: number | string | null | undefined;
+
+  beforeEach(() => {
+    stdout = '';
+    stderr = '';
+    previousExitCode = process.exitCode;
+    process.exitCode = 0;
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+      stderr += String(chunk);
+      return true;
+    });
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((): never => {
+      throw new Error('process.exit called');
+    });
+    // A recipe throwing mid-execution (e.g. a backend/geometry failure) is
+    // exactly what the shared try/catch in askCommand is there for; a `bim`
+    // whose `query()` throws reaches it the same way a real failure would.
+    createHeadlessContext.mockResolvedValue({
+      bim: {
+        query: () => {
+          throw new Error('backend query failed');
+        },
+      },
+      store: { schemaVersion: 'IFC4' },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = previousExitCode;
+  });
+
+  it('the human path hard-exits non-zero', async () => {
+    await expect(askCommand(['model.ifc', 'how many walls'])).rejects.toThrow('process.exit called');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('the --json path must also report failure via the exit code', async () => {
+    await askCommand(['model.ifc', 'how many walls', '--json']);
+
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toBeTruthy();
+    // This is the assertion the current code fails: nothing sets
+    // process.exitCode (and process.exit is never called) on the --json path.
+    expect(process.exitCode).not.toBe(0);
+  });
+});

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -477,6 +477,10 @@ export async function askCommand(args: string[]): Promise<void> {
   } catch (err: any) {
     if (jsonOutput) {
       printJson({ error: err.message, recipe: recipe.name, question });
+      // Match the non-JSON path's verdict: a build pipeline reading only the
+      // exit code must not see success on a question that could not be
+      // answered (same shape as the `ids --json` always-exit-0 defect).
+      process.exitCode = 1;
     } else {
       fatal(`Recipe "${recipe.name}" failed: ${err.message}`);
     }


### PR DESCRIPTION
`ask --json` returned exit code 0 on a path where the human output signals failure. Found on a never-raised branch; merges clean.

RED:
```
expect(process.exitCode).not.toBe(0)
AssertionError: expected +0 not to be +0   (ask.test.ts:76)
```
`packages/cli` 396 pass / 8 skip (395 + 1 fail reverted). api-surface, unused-locals and changesets all pass.

## This removes a two-paths divergence and introduces none

Checked deliberately, because "the machine path and the human path disagree" has already produced several defects here (CLI vs MCP vs SDK IDS summaries):

- Audited **every** `--json` branch in `ask.ts`. The only other JSON/human split (`!found`, line 432) already falls through to a shared `process.exit(1)`, so this closes the last gap in the file.
- Traced `packages/cli/src/index.ts` for a competing `process.exit(0)` that would swallow the code — there is none, so `process.exitCode = 1` survives to exit.
- `fatal()` is `process.exit(1)` (`output.ts:99`).
- Grepped `packages/cli/src/commands/` for the same shape elsewhere: no other instance.

The test restores `process.exitCode` in `afterEach` and pairs the JSON assertion with a human-path control, so it cannot pass by leaking state between cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
