### PR TITLE
fix(export): never emit a shared GlobalId twice when merging federated models

### DIFF
--- a/.changeset/merged-export-globalid-collisions.md
+++ b/.changeset/merged-export-globalid-collisions.md
@@ -1,0 +1,26 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix the native (Rust) merged/federated IFC exporter emitting duplicate GlobalIds.
+
+`export_merged_with_stats` (`rust/export/src/merged.rs`) only ID-offsets each
+subsequent model's STEP entity instance names (`#123`) and rewrites the
+`#`-references that point at them. `GlobalId` is a separate 22-character IFC
+GUID attribute on every `IfcRoot` entity, untouched by that offset. Federating
+two models that share an element -- the same file merged twice, a shared
+grid, a linked type -- emitted that element's GlobalId twice into one file, a
+spec violation independent of the exporter's other parity gaps (tracked in
+#2951).
+
+Every model after the first is now checked for a GlobalId already emitted by
+an earlier model; a collision gets a fresh, deterministic GlobalId minted for
+it (seeded from the original id and the source model's index, so output is
+reproducible) rather than being written through unchanged. This mirrors the
+"keep + re-stamp" branch of `MergedExporter`'s GlobalId reconciliation in
+`packages/export/src/merged-exporter.ts` -- the branch that always applies
+here, since the Rust path does not yet do the unit/spatial unification that
+lets the JS path's other branch drop-and-remap a duplicate onto one shared
+instance instead. That unification work remains open under #2951; this change
+only removes the duplicate-GlobalId defect for the offsetting path Rust
+already has.

--- a/.changeset/merged-export-guid-misidentification.md
+++ b/.changeset/merged-export-guid-misidentification.md
@@ -1,0 +1,25 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix the native (Rust) merged/federated IFC exporter's GlobalId-collision fix
+mistaking ordinary model strings for GlobalIds and corrupting them.
+
+`leading_guid` in `rust/export/src/merged.rs` identified an entity's GlobalId
+by scanning for the first quoted token anywhere on its STEP line, then
+excluding a fixed list of non-`IfcRoot` entity types whose first attribute is
+itself a string. Both parts were unsound: a non-rooted entity whose first
+attribute is not a string (e.g. `IFCMATERIALLAYER`, whose 4th attribute is
+`Name`) could still expose a later quoted string to the scan regardless of
+the denylist, and the denylist itself was missing several non-rooted types
+(`IFCMATERIALLAYER`, `IFCMATERIALLAYERSET`, and others). When that
+coincidentally 22-character, GlobalId-charset string collided with a real
+GlobalId already emitted, the exporter silently rewrote it -- corrupting
+ordinary model data such as a material layer's `Name`.
+
+GlobalId identification is now positional and type-checked instead: the
+quoted token must be the entity's true first attribute (only whitespace
+allowed between `(` and the quote), and the entity's type must actually
+derive from `IfcRoot`, checked against `rust/core`'s generated schema
+(`IfcType::is_subtype_of(IfcType::IfcRoot)`) rather than a hand-maintained
+denylist that can drift out of sync with it.

--- a/.changeset/merged-export-guid-schema-coverage.md
+++ b/.changeset/merged-export-guid-schema-coverage.md
@@ -1,0 +1,26 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Fix the native (Rust) merged/federated IFC exporter still missing GlobalIds
+on older-schema (IFC2X3/IFC4) models after the recent GlobalId-misidentification
+fix.
+
+`leading_guid` in `rust/export/src/merged.rs` checks whether an entity's type
+derives from `IfcRoot` via `IfcType::is_subtype_of`, resolved against
+`rust/core`'s generated schema table -- which is generated from IFC4X3 only.
+A rooted entity type that exists in IFC2X3 and/or IFC4 but was dropped or
+renamed in IFC4X3 (`IFCPROXY`, `IFCDOORSTYLE`, `IFCWINDOWSTYLE`, the IFC4
+`*STANDARDCASE`/`*ELEMENTEDCASE` variants, and others -- 54 in total)
+resolves to `IfcType::Unknown`, which is never a subtype of anything, so its
+GlobalId was skipped entirely. Merging two such models sharing one of these
+entities (a shared door/window style, a shared `IFCPROXY`, etc.) emitted that
+GlobalId twice into one file -- the same defect the schema-derived check was
+meant to close, just on older files.
+
+`leading_guid` now also treats an `Unknown`-resolved type as rooted when it
+matches a small supplemental table of IFC2X3/IFC4-only rooted types (derived
+by diffing `@ifc-lite/data`'s per-schema entity tables against the
+IFC4X3-only generated schema). Anything genuinely unrecognised is still
+treated as non-rooted, so the corruption the misidentification fix closed
+stays closed.

--- a/rust/export/src/merged.rs
+++ b/rust/export/src/merged.rs
@@ -10,41 +10,8 @@
 //! spatial unification by name/elevation are the P2 follow-on.
 
 use crate::step_text::{detect_schema, escape};
-use ifc_lite_core::EntityScanner;
+use ifc_lite_core::{EntityScanner, IfcType};
 use std::collections::HashSet;
-
-/// Non-`IfcRoot` entity types whose first attribute is (or can be) a quoted
-/// Name/Identifier string that could coincidentally be 22 charset characters
-/// long. Ported from `NON_ROOTED_STRING_TYPES` in
-/// `packages/export/src/merged-exporter.ts` (kept in sync there) -- without
-/// this denylist, GlobalId reconciliation could mistake a `Name`/`Identifier`
-/// for a GlobalId and corrupt it by "reconciling" a coincidental collision.
-/// A miss in the other direction (treating a real root as non-rooted) only
-/// skips one reconciliation, which is safe.
-const NON_ROOTED_STRING_TYPES: &[&str] = &[
-    // IfcSimpleProperty / IfcComplexProperty (IfcPropertyAbstraction — not rooted)
-    "IFCPROPERTYSINGLEVALUE", "IFCPROPERTYENUMERATEDVALUE", "IFCPROPERTYLISTVALUE",
-    "IFCPROPERTYBOUNDEDVALUE", "IFCPROPERTYTABLEVALUE", "IFCPROPERTYREFERENCEVALUE",
-    "IFCCOMPLEXPROPERTY",
-    // IfcPhysicalQuantity (not rooted)
-    "IFCQUANTITYLENGTH", "IFCQUANTITYAREA", "IFCQUANTITYVOLUME", "IFCQUANTITYCOUNT",
-    "IFCQUANTITYWEIGHT", "IFCQUANTITYTIME", "IFCQUANTITYNUMBER", "IFCPHYSICALCOMPLEXQUANTITY",
-    // Materials & their constituents (IfcMaterialDefinition — not rooted; lead with a Name)
-    "IFCMATERIAL", "IFCMATERIALPROFILE", "IFCMATERIALPROFILESET",
-    "IFCMATERIALCONSTITUENT", "IFCMATERIALCONSTITUENTSET",
-    // Classification, library & document refs (IfcExternalInformation/Reference)
-    "IFCCLASSIFICATION", "IFCCLASSIFICATIONREFERENCE",
-    "IFCLIBRARYINFORMATION", "IFCLIBRARYREFERENCE", "IFCEXTERNALREFERENCE",
-    "IFCDOCUMENTINFORMATION", "IFCDOCUMENTREFERENCE",
-    // Constraints & approvals (lead with a Name/Identifier)
-    "IFCMETRIC", "IFCOBJECTIVE", "IFCAPPROVAL", "IFCTABLE",
-    // Actors (IfcPerson/IfcOrganization lead with an Identification string)
-    "IFCPERSON", "IFCORGANIZATION",
-    // Presentation layers, styles & text literals (lead with a Name/Literal string)
-    "IFCPRESENTATIONLAYERASSIGNMENT", "IFCPRESENTATIONLAYERWITHSTYLE",
-    "IFCSURFACESTYLE", "IFCCURVESTYLE", "IFCTEXTSTYLE", "IFCFILLAREASTYLE",
-    "IFCTEXTLITERAL", "IFCTEXTLITERALWITHEXTENT",
-];
 
 const GLOBAL_ID_CHARS: &[u8; 64] =
     b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$";
@@ -55,22 +22,44 @@ fn is_global_id_shaped(s: &str) -> bool {
     s.len() == 22 && s.bytes().all(|b| GLOBAL_ID_CHARS.contains(&b))
 }
 
-/// Read the first quoted attribute of a STEP entity line (the GlobalId
-/// position for an `IfcRoot` subtype), if it is 22-char GlobalId-shaped and
-/// the entity's type is not in the non-rooted denylist above. Mirrors
-/// `extractGlobalIdFast`/`readLeadingGuid` in `merged-exporter.ts`, working
-/// off raw bytes the same way `rewrite_refs` does (a GlobalId's charset
-/// excludes `'`, so a naive first-quote-pair scan is safe -- it never needs
-/// the doubled-apostrophe in/out-of-string toggle `rewrite_refs` uses for
-/// arbitrary string content).
+/// Read the entity's **first attribute** (the GlobalId position for an
+/// `IfcRoot` subtype), if it is 22-char GlobalId-shaped and the entity's
+/// type actually derives from `IfcRoot`.
+///
+/// Two things distinguish this from a plain "first quoted string on the
+/// line" scan, and both matter: (1) the quote must be the FIRST thing after
+/// `(` (only whitespace allowed in between) -- a non-rooted entity whose
+/// first attribute is a number/enum/reference and whose Name/Identifier
+/// happens to be a 22-char quoted string LATER on the line must not be
+/// mistaken for a rooted entity's GlobalId; (2) `type_name` is checked
+/// against the generated schema's `IfcRoot` subtype table via
+/// [`IfcType::is_subtype_of`] rather than an entity-type denylist -- a
+/// denylist can only ever be as complete as whoever last audited the
+/// schema for non-rooted resource types that lead with a string, while this
+/// positive allowlist is derived from the schema itself and can't drift out
+/// of sync with it. Mirrors `extractGlobalIdFast` in
+/// `packages/export/src/merged-exporter.ts`, which is likewise positional
+/// (skips only whitespace after `(`) though it still uses the denylist —
+/// `rust-core`'s generated schema has no JS-side equivalent to allowlist
+/// from.
+///
+/// Works off raw bytes the same way `rewrite_refs` does (a GlobalId's
+/// charset excludes `'`, so a naive first-quote-pair scan of the attribute
+/// content is safe -- it never needs the doubled-apostrophe in/out-of-string
+/// toggle `rewrite_refs` uses for arbitrary string content).
 fn leading_guid(line: &[u8], type_name: &str) -> Option<String> {
-    if NON_ROOTED_STRING_TYPES.contains(&type_name) {
+    if !IfcType::from_str(type_name).is_subtype_of(IfcType::IfcRoot) {
         return None;
     }
     let open = line.iter().position(|&b| b == b'(')?;
-    let rest = &line[open + 1..];
-    let q1 = rest.iter().position(|&b| b == b'\'')?;
-    let after_q1 = &rest[q1 + 1..];
+    let mut i = open + 1;
+    while i < line.len() && line[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    if line.get(i) != Some(&b'\'') {
+        return None;
+    }
+    let after_q1 = &line[i + 1..];
     let q2 = after_q1.iter().position(|&b| b == b'\'')?;
     let raw = &after_q1[..q2];
     let s = std::str::from_utf8(raw).ok()?;

--- a/rust/export/src/merged.rs
+++ b/rust/export/src/merged.rs
@@ -33,7 +33,9 @@ fn is_global_id_shaped(s: &str) -> bool {
 /// happens to be a 22-char quoted string LATER on the line must not be
 /// mistaken for a rooted entity's GlobalId; (2) `type_name` is checked
 /// against the generated schema's `IfcRoot` subtype table via
-/// [`IfcType::is_subtype_of`] rather than an entity-type denylist -- a
+/// [`IfcType::is_subtype_of`] (plus [`is_legacy_rooted_type`] for the
+/// handful of IFC2X3/IFC4-only rooted types that table doesn't know, since
+/// it's generated from IFC4X3 alone) rather than an entity-type denylist -- a
 /// denylist can only ever be as complete as whoever last audited the
 /// schema for non-rooted resource types that lead with a string, while this
 /// positive allowlist is derived from the schema itself and can't drift out
@@ -48,7 +50,11 @@ fn is_global_id_shaped(s: &str) -> bool {
 /// content is safe -- it never needs the doubled-apostrophe in/out-of-string
 /// toggle `rewrite_refs` uses for arbitrary string content).
 fn leading_guid(line: &[u8], type_name: &str) -> Option<String> {
-    if !IfcType::from_str(type_name).is_subtype_of(IfcType::IfcRoot) {
+    let ifc_type = IfcType::from_str(type_name);
+    let rooted = ifc_type.is_subtype_of(IfcType::IfcRoot)
+        || (matches!(ifc_type, IfcType::Unknown(_))
+            && is_legacy_rooted_type(&type_name.to_ascii_uppercase()));
+    if !rooted {
         return None;
     }
     let open = line.iter().position(|&b| b == b'(')?;
@@ -64,6 +70,45 @@ fn leading_guid(line: &[u8], type_name: &str) -> Option<String> {
     let raw = &after_q1[..q2];
     let s = std::str::from_utf8(raw).ok()?;
     is_global_id_shaped(s).then(|| s.to_string())
+}
+
+/// Rooted entity types that exist in IFC2X3 and/or IFC4 but were dropped or
+/// renamed by IFC4X3 -- the only schema `rust-core`'s generated `IfcType`
+/// table is derived from (`rust/core/src/generated/schema.rs`). For these,
+/// `IfcType::from_str` resolves to `Unknown`, which `is_subtype_of(IfcRoot)`
+/// correctly refuses -- an *unrecognised* type must never be assumed rooted,
+/// that is the exact corruption this file's type check exists to prevent.
+/// This closes the resulting gap for the entities that genuinely ARE rooted
+/// in the older schemas real IFC2X3/IFC4 files still use, so their GlobalIds
+/// keep getting deduplicated across a merge instead of silently duplicating.
+///
+/// Derived by diffing `@ifc-lite/data`'s IFC2X3/IFC4/IFC4X3 entity tables
+/// (`packages/data/src/ifc-schema/generated/entities-*.ts`) against this
+/// crate's IFC4X3-only schema and keeping only the entries whose parent
+/// chain in the older schema reaches `IfcRoot`. Update by re-running that
+/// diff, not by ad hoc inspection.
+fn is_legacy_rooted_type(upper: &str) -> bool {
+    matches!(
+        upper,
+        "IFCBEAMSTANDARDCASE" | "IFCBUILDINGELEMENT" | "IFCBUILDINGELEMENTCOMPONENT"
+        | "IFCBUILDINGELEMENTTYPE" | "IFCCHAMFEREDGEFEATURE" | "IFCCOLUMNSTANDARDCASE"
+        | "IFCCONDITION" | "IFCCONDITIONCRITERION" | "IFCDOORSTANDARDCASE" | "IFCDOORSTYLE"
+        | "IFCEDGEFEATURE" | "IFCELECTRICDISTRIBUTIONPOINT" | "IFCELECTRICHEATERTYPE"
+        | "IFCELECTRICALBASEPROPERTIES" | "IFCELECTRICALCIRCUIT" | "IFCELECTRICALELEMENT"
+        | "IFCENERGYPROPERTIES" | "IFCEQUIPMENTELEMENT" | "IFCEQUIPMENTSTANDARD"
+        | "IFCFLUIDFLOWPROPERTIES" | "IFCFURNITURESTANDARD" | "IFCGASTERMINALTYPE"
+        | "IFCMEMBERSTANDARDCASE" | "IFCMOVE" | "IFCOPENINGSTANDARDCASE" | "IFCORDERACTION"
+        | "IFCPLATESTANDARDCASE" | "IFCPROJECTORDERRECORD" | "IFCPROXY" | "IFCRELASSIGNSTASKS"
+        | "IFCRELASSIGNSTOPROJECTORDER" | "IFCRELASSOCIATESAPPLIEDVALUE"
+        | "IFCRELASSOCIATESPROFILEPROPERTIES" | "IFCRELCONNECTSSTRUCTURALELEMENT"
+        | "IFCRELINTERACTIONREQUIREMENTS" | "IFCRELOCCUPIESSPACES" | "IFCRELOVERRIDESPROPERTIES"
+        | "IFCRELSCHEDULESCOSTITEMS" | "IFCROUNDEDEDGEFEATURE" | "IFCSCHEDULETIMECONTROL"
+        | "IFCSERVICELIFE" | "IFCSERVICELIFEFACTOR" | "IFCSLABELEMENTEDCASE"
+        | "IFCSLABSTANDARDCASE" | "IFCSOUNDPROPERTIES" | "IFCSOUNDVALUE" | "IFCSPACEPROGRAM"
+        | "IFCSPACETHERMALLOADPROPERTIES" | "IFCSTRUCTURALLINEARACTIONVARYING"
+        | "IFCSTRUCTURALPLANARACTIONVARYING" | "IFCTIMESERIESSCHEDULE" | "IFCWALLELEMENTEDCASE"
+        | "IFCWINDOWSTANDARDCASE" | "IFCWINDOWSTYLE"
+    )
 }
 
 /// Replace a line's first quoted attribute (the GlobalId) with `new_guid`.

--- a/rust/export/src/merged.rs
+++ b/rust/export/src/merged.rs
@@ -11,6 +11,161 @@
 
 use crate::step_text::{detect_schema, escape};
 use ifc_lite_core::EntityScanner;
+use std::collections::HashSet;
+
+/// Non-`IfcRoot` entity types whose first attribute is (or can be) a quoted
+/// Name/Identifier string that could coincidentally be 22 charset characters
+/// long. Ported from `NON_ROOTED_STRING_TYPES` in
+/// `packages/export/src/merged-exporter.ts` (kept in sync there) -- without
+/// this denylist, GlobalId reconciliation could mistake a `Name`/`Identifier`
+/// for a GlobalId and corrupt it by "reconciling" a coincidental collision.
+/// A miss in the other direction (treating a real root as non-rooted) only
+/// skips one reconciliation, which is safe.
+const NON_ROOTED_STRING_TYPES: &[&str] = &[
+    // IfcSimpleProperty / IfcComplexProperty (IfcPropertyAbstraction — not rooted)
+    "IFCPROPERTYSINGLEVALUE", "IFCPROPERTYENUMERATEDVALUE", "IFCPROPERTYLISTVALUE",
+    "IFCPROPERTYBOUNDEDVALUE", "IFCPROPERTYTABLEVALUE", "IFCPROPERTYREFERENCEVALUE",
+    "IFCCOMPLEXPROPERTY",
+    // IfcPhysicalQuantity (not rooted)
+    "IFCQUANTITYLENGTH", "IFCQUANTITYAREA", "IFCQUANTITYVOLUME", "IFCQUANTITYCOUNT",
+    "IFCQUANTITYWEIGHT", "IFCQUANTITYTIME", "IFCQUANTITYNUMBER", "IFCPHYSICALCOMPLEXQUANTITY",
+    // Materials & their constituents (IfcMaterialDefinition — not rooted; lead with a Name)
+    "IFCMATERIAL", "IFCMATERIALPROFILE", "IFCMATERIALPROFILESET",
+    "IFCMATERIALCONSTITUENT", "IFCMATERIALCONSTITUENTSET",
+    // Classification, library & document refs (IfcExternalInformation/Reference)
+    "IFCCLASSIFICATION", "IFCCLASSIFICATIONREFERENCE",
+    "IFCLIBRARYINFORMATION", "IFCLIBRARYREFERENCE", "IFCEXTERNALREFERENCE",
+    "IFCDOCUMENTINFORMATION", "IFCDOCUMENTREFERENCE",
+    // Constraints & approvals (lead with a Name/Identifier)
+    "IFCMETRIC", "IFCOBJECTIVE", "IFCAPPROVAL", "IFCTABLE",
+    // Actors (IfcPerson/IfcOrganization lead with an Identification string)
+    "IFCPERSON", "IFCORGANIZATION",
+    // Presentation layers, styles & text literals (lead with a Name/Literal string)
+    "IFCPRESENTATIONLAYERASSIGNMENT", "IFCPRESENTATIONLAYERWITHSTYLE",
+    "IFCSURFACESTYLE", "IFCCURVESTYLE", "IFCTEXTSTYLE", "IFCFILLAREASTYLE",
+    "IFCTEXTLITERAL", "IFCTEXTLITERALWITHEXTENT",
+];
+
+const GLOBAL_ID_CHARS: &[u8; 64] =
+    b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$";
+
+/// True for a 22-character token drawn entirely from the buildingSMART
+/// GlobalId alphabet -- mirrors `GLOBAL_ID_RE` in `merged-exporter.ts`.
+fn is_global_id_shaped(s: &str) -> bool {
+    s.len() == 22 && s.bytes().all(|b| GLOBAL_ID_CHARS.contains(&b))
+}
+
+/// Read the first quoted attribute of a STEP entity line (the GlobalId
+/// position for an `IfcRoot` subtype), if it is 22-char GlobalId-shaped and
+/// the entity's type is not in the non-rooted denylist above. Mirrors
+/// `extractGlobalIdFast`/`readLeadingGuid` in `merged-exporter.ts`, working
+/// off raw bytes the same way `rewrite_refs` does (a GlobalId's charset
+/// excludes `'`, so a naive first-quote-pair scan is safe -- it never needs
+/// the doubled-apostrophe in/out-of-string toggle `rewrite_refs` uses for
+/// arbitrary string content).
+fn leading_guid(line: &[u8], type_name: &str) -> Option<String> {
+    if NON_ROOTED_STRING_TYPES.contains(&type_name) {
+        return None;
+    }
+    let open = line.iter().position(|&b| b == b'(')?;
+    let rest = &line[open + 1..];
+    let q1 = rest.iter().position(|&b| b == b'\'')?;
+    let after_q1 = &rest[q1 + 1..];
+    let q2 = after_q1.iter().position(|&b| b == b'\'')?;
+    let raw = &after_q1[..q2];
+    let s = std::str::from_utf8(raw).ok()?;
+    is_global_id_shaped(s).then(|| s.to_string())
+}
+
+/// Replace a line's first quoted attribute (the GlobalId) with `new_guid`.
+/// `new_guid` is always 22 charset characters (no quote in that charset), so
+/// a straightforward byte replace between the first two apostrophes after
+/// `(` is safe -- same shape as `replaceGlobalId` in `merged-exporter.ts`.
+fn replace_leading_guid(line: &str, new_guid: &str) -> String {
+    let open = match line.find('(') {
+        Some(i) => i,
+        None => return line.to_string(),
+    };
+    let rest = &line[open + 1..];
+    let q1 = match rest.find('\'') {
+        Some(i) => i,
+        None => return line.to_string(),
+    };
+    let after_q1 = &rest[q1 + 1..];
+    let q2 = match after_q1.find('\'') {
+        Some(i) => i,
+        None => return line.to_string(),
+    };
+    let abs_q1 = open + 1 + q1;
+    let abs_q2 = open + 1 + q1 + 1 + q2;
+    format!("{}{}{}", &line[..abs_q1 + 1], new_guid, &line[abs_q2..])
+}
+
+/// Deterministic 22-char GlobalId from an arbitrary seed. Byte-for-byte port
+/// of `deterministicGlobalId` in `packages/parser/src/deterministic-global-id.ts`
+/// (cross-checked against that implementation for identical seeds) -- four
+/// independent 32-bit rolling hashes, cross-mixed, then stamped MSB-first as
+/// a standard IFC GlobalId. Byte-for-byte identity with the JS path's minted
+/// ids is not required (the two exporters mint independently, never for the
+/// same collision), but porting the well-specified, already-hardened
+/// algorithm avoids re-deriving a weaker one from scratch.
+fn deterministic_global_id(seed: &str) -> String {
+    let mut h0: u32 = 0x811c_9dc5;
+    let mut h1: u32 = 0x9e37_79b9;
+    let mut h2: u32 = 0x6c07_8965;
+    let mut h3: u32 = 0xb529_7a4d;
+    for u in seed.encode_utf16() {
+        let c = u as u32;
+        h0 = (h0 ^ c).wrapping_mul(0x0100_0193);
+        h1 = (h1 ^ c ^ (h1 >> 11)).wrapping_mul(0x85eb_ca6b);
+        h2 = h2.wrapping_add(c).wrapping_add(h2 >> 7).wrapping_mul(0xc2b2_ae35);
+        h3 = (h3 ^ ((c << 3) | (c >> 5)) ^ (h3 >> 13)).wrapping_mul(0x27d4_eb2f);
+    }
+    let mix = |x: u32, y: u32| -> u32 {
+        ((x ^ y).wrapping_add((x >> 7) | (y << 25))).wrapping_mul(0x85eb_ca6b)
+    };
+    let m0 = mix(h0, h2);
+    let m1 = mix(h1, h3);
+    let m2 = mix(h2, m1);
+    let m3 = mix(h3, m0);
+
+    let mut bits: Vec<u8> = Vec::with_capacity(128);
+    for word in [m0, m1, m2, m3] {
+        for b in (0..32).rev() {
+            bits.push(((word >> b) & 1) as u8);
+        }
+    }
+    let mut out = String::with_capacity(22);
+    out.push(GLOBAL_ID_CHARS[((bits[0] << 1) | bits[1]) as usize] as char);
+    for i in 0..21usize {
+        let mut v: usize = 0;
+        for b in 0..6usize {
+            v = (v << 1) | bits[2 + i * 6 + b] as usize;
+        }
+        out.push(GLOBAL_ID_CHARS[v] as char);
+    }
+    out
+}
+
+/// Mint a fresh, deterministic, collision-free GlobalId for an entity whose
+/// GlobalId collides with one already emitted. Seeded from the original
+/// GlobalId and the source model's index so the output is reproducible.
+/// Mirrors `mintUniqueGuid` in `merged-exporter.ts`.
+fn mint_unique_guid(
+    original: &str,
+    model_index: usize,
+    emitted: &HashSet<String>,
+    pending: &mut HashSet<String>,
+) -> String {
+    let mut n = 0u32;
+    let mut candidate = deterministic_global_id(&format!("{original}#{model_index}"));
+    while emitted.contains(&candidate) || pending.contains(&candidate) {
+        candidate = deterministic_global_id(&format!("{original}#{model_index}#{n}"));
+        n += 1;
+    }
+    pending.insert(candidate.clone());
+    candidate
+}
 
 /// Options for merged export.
 pub struct MergedOptions {
@@ -118,16 +273,25 @@ pub fn export_merged_with_stats(models: &[&[u8]], opts: &MergedOptions) -> (Stri
     out.push_str(&format!("FILE_SCHEMA(('{}'));\n", escape(&schema)));
     out.push_str("ENDSEC;\nDATA;\n");
 
+    // GlobalId → seen, across every model emitted so far. A `IfcRoot` entity
+    // (by type + GlobalId-shaped first attribute) that repeats a GlobalId
+    // already in this set gets a fresh deterministic id minted for it before
+    // being written (see `leading_guid`/`mint_unique_guid`) -- ID-offsetting
+    // `#`-refs, done above, never touches this attribute, so without this
+    // step two models sharing an element (or the same file merged twice)
+    // would emit the same 22-char GlobalId twice, an IFC spec violation.
+    let mut emitted_guids: HashSet<String> = HashSet::new();
+
     let mut offset: u32 = 0;
     let mut written = 0usize;
     for (i, content) in models.iter().enumerate() {
         let model_project = find_project(content);
         let mut local_max = 0u32;
         let mut scanner = EntityScanner::new(content);
-        let mut lines: Vec<(u32, &[u8])> = Vec::new();
-        while let Some((id, _t, s, e)) = scanner.next_entity() {
+        let mut lines: Vec<(u32, &str, &[u8])> = Vec::new();
+        while let Some((id, t, s, e)) = scanner.next_entity() {
             local_max = local_max.max(id);
-            lines.push((id, &content[s..e]));
+            lines.push((id, t, &content[s..e]));
         }
 
         let is_first = i == 0;
@@ -143,12 +307,29 @@ pub fn export_merged_with_stats(models: &[&[u8]], opts: &MergedOptions) -> (Stri
             None
         };
 
-        for (id, line) in &lines {
+        // GlobalIds minted for THIS model's collisions, so two collisions
+        // within the same model can't mint the same fresh id as each other
+        // (checked in addition to `emitted_guids`).
+        let mut pending_minted: HashSet<String> = HashSet::new();
+
+        for (id, type_name, line) in &lines {
             // Drop later models' IfcProject lines (the project is unified to model 0's).
             if !is_first && Some(*id) == model_project {
                 continue;
             }
-            out.push_str(&rewrite_refs(line, offset, &remap));
+            let mut rewritten = rewrite_refs(line, offset, &remap);
+
+            if let Some(guid) = leading_guid(line, type_name) {
+                if emitted_guids.contains(&guid) {
+                    let fresh = mint_unique_guid(&guid, i, &emitted_guids, &mut pending_minted);
+                    rewritten = replace_leading_guid(&rewritten, &fresh);
+                    emitted_guids.insert(fresh);
+                } else {
+                    emitted_guids.insert(guid);
+                }
+            }
+
+            out.push_str(&rewritten);
             out.push('\n');
             written += 1;
         }

--- a/rust/export/src/merged_tests.rs
+++ b/rust/export/src/merged_tests.rs
@@ -307,13 +307,23 @@ fn detect_schema_un_doubles_backslash_before_escape_re_doubles_it() {
 
 /// Reproduces the issue's headline defect: two federated models that share a
 /// GlobalId (a linked/shared element loaded into both models -- the common
-/// "same file merged twice" and "shared grid" cases) must not emit that
+/// "same file merged twice" and "shared door type" cases) must not emit that
 /// GlobalId twice into the output STEP text. Distinct groups with distinct
 /// counts so nothing passes by coincidence:
-///   - 3 entities whose GlobalId is IDENTICAL across both models (shared
-///     grid axes -- same real-world element, referenced from both models).
+///   - 3 entities whose GlobalId is IDENTICAL across both models (a shared
+///     `IFCDOOR` -- same real-world element, referenced from both models).
 ///   - 2 entities per model (4 total) whose GlobalId is genuinely UNIQUE to
 ///     that model (ordinary walls/spaces -- no collision).
+///
+/// All six entities here are genuine `IfcRoot` subtypes (`IFCDOOR`,
+/// `IFCWALL`, `IFCSPACE`) with their GlobalId as the true first attribute --
+/// unlike the fixture this replaced, which stood `IFCGRIDAXIS` in for a
+/// "GlobalId" using its `AxisTag` attribute. `IfcGridAxis` is NOT an
+/// `IfcRoot` subtype, so that fixture only exercised reconciliation because
+/// of the exact bug this file now fixes: it passed for the wrong reason,
+/// on a type the fixed `leading_guid` correctly stops reconciling (see
+/// `merge_never_corrupts_a_non_rooted_string_that_looks_like_a_globalid`
+/// below for the corruption that fixture was masking).
 ///
 /// Assertion is against the emitted STEP text itself (`.matches(guid).count()`),
 /// not an intermediate map -- this is the shape a reader/writer round-trip
@@ -322,9 +332,9 @@ fn detect_schema_un_doubles_backslash_before_escape_re_doubles_it() {
 #[test]
 fn merge_two_models_never_emit_a_shared_globalid_twice_in_the_output_text() {
     // 22-char buildingSMART-alphabet GlobalIds, distinguishable by name.
-    let shared_grid_a = "00000000000000000000A1";
-    let shared_grid_b = "00000000000000000000B2";
-    let shared_grid_c = "00000000000000000000C3";
+    let shared_door_a = "00000000000000000000A1";
+    let shared_door_b = "00000000000000000000B2";
+    let shared_door_c = "00000000000000000000C3";
     let model1_wall = "11111111111111111111W1";
     let model1_space = "11111111111111111111S1";
     let model2_wall = "22222222222222222222W2";
@@ -333,9 +343,9 @@ fn merge_two_models_never_emit_a_shared_globalid_twice_in_the_output_text() {
     let model_a = format!(
         "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
 #1=IFCPROJECT('proja',$,$,$,$,$,$,$,$);\n\
-#2=IFCGRIDAXIS('{shared_grid_a}',$,$,$,$);\n\
-#3=IFCGRIDAXIS('{shared_grid_b}',$,$,$,$);\n\
-#4=IFCGRIDAXIS('{shared_grid_c}',$,$,$,$);\n\
+#2=IFCDOOR('{shared_door_a}',$,$,$,$,$,$,$,$);\n\
+#3=IFCDOOR('{shared_door_b}',$,$,$,$,$,$,$,$);\n\
+#4=IFCDOOR('{shared_door_c}',$,$,$,$,$,$,$,$);\n\
 #5=IFCWALL('{model1_wall}',$,$,$,$,$,$,$,$);\n\
 #6=IFCSPACE('{model1_space}',$,$,$,$,$,$,$,$,$);\n\
 ENDSEC;\nEND-ISO-10303-21;\n"
@@ -343,9 +353,9 @@ ENDSEC;\nEND-ISO-10303-21;\n"
     let model_b = format!(
         "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
 #1=IFCPROJECT('projb',$,$,$,$,$,$,$,$);\n\
-#2=IFCGRIDAXIS('{shared_grid_a}',$,$,$,$);\n\
-#3=IFCGRIDAXIS('{shared_grid_b}',$,$,$,$);\n\
-#4=IFCGRIDAXIS('{shared_grid_c}',$,$,$,$);\n\
+#2=IFCDOOR('{shared_door_a}',$,$,$,$,$,$,$,$);\n\
+#3=IFCDOOR('{shared_door_b}',$,$,$,$,$,$,$,$);\n\
+#4=IFCDOOR('{shared_door_c}',$,$,$,$,$,$,$,$);\n\
 #5=IFCWALL('{model2_wall}',$,$,$,$,$,$,$,$);\n\
 #6=IFCSPACE('{model2_space}',$,$,$,$,$,$,$,$,$);\n\
 ENDSEC;\nEND-ISO-10303-21;\n"
@@ -354,9 +364,9 @@ ENDSEC;\nEND-ISO-10303-21;\n"
     let (merged, _stats) =
         export_merged_with_stats(&[model_a.as_bytes(), model_b.as_bytes()], &MergedOptions::default());
 
-    // The 3 shared-grid GlobalIds must appear exactly once each in the
+    // The 3 shared-door GlobalIds must appear exactly once each in the
     // output text -- not twice, even though both source models carried them.
-    for guid in [shared_grid_a, shared_grid_b, shared_grid_c] {
+    for guid in [shared_door_a, shared_door_b, shared_door_c] {
         assert_eq!(
             merged.matches(guid).count(),
             1,
@@ -380,11 +390,113 @@ ENDSEC;\nEND-ISO-10303-21;\n"
     // (7, not 10) is what would fail if collisions were silently duplicated
     // instead of reconciled.
     let total_occurrences: usize = [
-        shared_grid_a, shared_grid_b, shared_grid_c,
+        shared_door_a, shared_door_b, shared_door_c,
         model1_wall, model1_space, model2_wall, model2_space,
     ]
     .iter()
     .map(|g| merged.matches(*g).count())
     .sum();
     assert_eq!(total_occurrences, 7, "7 distinct GlobalIds, one occurrence each");
+}
+
+/// The adversarial-review regression: a non-rooted entity carrying a 22-char
+/// quoted string that coincidentally matches the GlobalId charset/length must
+/// survive the merge byte-for-byte, even when it collides with ANOTHER
+/// occurrence of the same string -- because it isn't a GlobalId at all, and
+/// reconciling a coincidence corrupts ordinary model data.
+///
+/// Two independently-pinned layers, distinct group counts (3 vs 2) so
+/// neither passes by coincidence:
+///   - Layer (a), 3 `IFCMATERIALLAYER` entities: `Name` is that type's 4th
+///     attribute, not its first. A scanner that finds the first quoted token
+///     ANYWHERE on the line -- rather than the entity's true first attribute
+///     -- misidentifies it as a GlobalId regardless of how complete a type
+///     denylist is. Two of the three share the exact same 22-char `Name`
+///     (the review's `'AAAAAAAAAAAAAAAAAAAAAA'` repro string) so the second
+///     one hits the reconciliation path if the bug is present.
+///   - Layer (b), 2 `IFCMATERIALLAYERSET` entities: here the coincidental
+///     string genuinely IS the first attribute, so position alone can't
+///     save it -- only recognising that `IfcMaterialLayerSet` is not an
+///     `IfcRoot` subtype does. Both share the same string so the second
+///     hits the reconciliation path if the type is wrongly treated as
+///     rooted.
+#[test]
+fn merge_never_corrupts_a_non_rooted_string_that_looks_like_a_globalid() {
+    let layer_dup = "AAAAAAAAAAAAAAAAAAAAAA"; // the review's exact repro string
+    let layer_unique = "BBBBBBBBBBBBBBBBBBBBBB";
+    let set_dup = "CCCCCCCCCCCCCCCCCCCCCC";
+
+    let content = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('projx',$,$,$,$,$,$,$,$);\n\
+#2=IFCMATERIALLAYER(#10,100.,.F.,'{layer_dup}',$,$,$,$);\n\
+#3=IFCMATERIALLAYER(#10,150.,.F.,'{layer_unique}',$,$,$,$);\n\
+#4=IFCMATERIALLAYER(#10,200.,.F.,'{layer_dup}',$,$,$,$);\n\
+#5=IFCMATERIALLAYERSET('{set_dup}',$,$);\n\
+#6=IFCMATERIALLAYERSET('{set_dup}',$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+
+    let (merged, _stats) =
+        export_merged_with_stats(&[content.as_bytes()], &MergedOptions::default());
+
+    // Layer (a): all three IFCMATERIALLAYER lines, including the two that
+    // coincidentally share the same Name, survive byte-for-byte.
+    for line in [
+        "#2=IFCMATERIALLAYER(#10,100.,.F.,'AAAAAAAAAAAAAAAAAAAAAA',$,$,$,$);",
+        "#3=IFCMATERIALLAYER(#10,150.,.F.,'BBBBBBBBBBBBBBBBBBBBBB',$,$,$,$);",
+        "#4=IFCMATERIALLAYER(#10,200.,.F.,'AAAAAAAAAAAAAAAAAAAAAA',$,$,$,$);",
+    ] {
+        assert!(
+            merged.contains(line),
+            "layer (a): a non-rooted entity's Name (not its first attribute) was corrupted -- missing line {line:?} in:\n{merged}"
+        );
+    }
+
+    // Layer (b): both IFCMATERIALLAYERSET lines, sharing the same coincidental
+    // first-attribute string, survive byte-for-byte too.
+    for line in [
+        "#5=IFCMATERIALLAYERSET('CCCCCCCCCCCCCCCCCCCCCC',$,$);",
+        "#6=IFCMATERIALLAYERSET('CCCCCCCCCCCCCCCCCCCCCC',$,$);",
+    ] {
+        assert!(
+            merged.contains(line),
+            "layer (b): a non-rooted entity's first attribute was corrupted -- missing line {line:?} in:\n{merged}"
+        );
+    }
+}
+
+/// Isolates the positional half of the fix on its own: `IFCMATERIALLAYER`
+/// above is filtered by the `IfcRoot` type check alone (it is never a
+/// rooted type, so `leading_guid` returns early regardless of where the
+/// quote sits) -- that test cannot by itself prove the position check does
+/// anything. This one uses a genuinely rooted type (`IFCWALL`, which DOES
+/// pass the type check) with a malformed/adversarial attribute list whose
+/// first attribute is not a string at all, and whose Name (a later
+/// attribute) happens to be GlobalId-shaped. Only the "quoted token must be
+/// the first attribute" positional rule -- not the type check -- stops this
+/// from being reconciled.
+#[test]
+fn merge_never_corrupts_a_rooted_entitys_non_leading_string_attribute() {
+    let stray = "DDDDDDDDDDDDDDDDDDDDDD";
+    let content = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('projy',$,$,$,$,$,$,$,$);\n\
+#2=IFCWALL(#99,$,'{stray}',$,$,$,$,$,$);\n\
+#3=IFCWALL(#99,$,'{stray}',$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+
+    let (merged, _stats) =
+        export_merged_with_stats(&[content.as_bytes()], &MergedOptions::default());
+
+    for line in [
+        "#2=IFCWALL(#99,$,'DDDDDDDDDDDDDDDDDDDDDD',$,$,$,$,$,$);",
+        "#3=IFCWALL(#99,$,'DDDDDDDDDDDDDDDDDDDDDD',$,$,$,$,$,$);",
+    ] {
+        assert!(
+            merged.contains(line),
+            "a rooted type's non-leading string attribute was mistaken for its GlobalId -- missing line {line:?} in:\n{merged}"
+        );
+    }
 }

--- a/rust/export/src/merged_tests.rs
+++ b/rust/export/src/merged_tests.rs
@@ -304,3 +304,87 @@ fn detect_schema_un_doubles_backslash_before_escape_re_doubles_it() {
     // compounding.
     assert_eq!(schema_line, "FILE_SCHEMA(('IFC\\\\4'));");
 }
+
+/// Reproduces the issue's headline defect: two federated models that share a
+/// GlobalId (a linked/shared element loaded into both models -- the common
+/// "same file merged twice" and "shared grid" cases) must not emit that
+/// GlobalId twice into the output STEP text. Distinct groups with distinct
+/// counts so nothing passes by coincidence:
+///   - 3 entities whose GlobalId is IDENTICAL across both models (shared
+///     grid axes -- same real-world element, referenced from both models).
+///   - 2 entities per model (4 total) whose GlobalId is genuinely UNIQUE to
+///     that model (ordinary walls/spaces -- no collision).
+///
+/// Assertion is against the emitted STEP text itself (`.matches(guid).count()`),
+/// not an intermediate map -- this is the shape a reader/writer round-trip
+/// through our own tooling could not catch (both sides would agree on the
+/// same misreading of an intermediate structure).
+#[test]
+fn merge_two_models_never_emit_a_shared_globalid_twice_in_the_output_text() {
+    // 22-char buildingSMART-alphabet GlobalIds, distinguishable by name.
+    let shared_grid_a = "00000000000000000000A1";
+    let shared_grid_b = "00000000000000000000B2";
+    let shared_grid_c = "00000000000000000000C3";
+    let model1_wall = "11111111111111111111W1";
+    let model1_space = "11111111111111111111S1";
+    let model2_wall = "22222222222222222222W2";
+    let model2_space = "22222222222222222222S2";
+
+    let model_a = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('proja',$,$,$,$,$,$,$,$);\n\
+#2=IFCGRIDAXIS('{shared_grid_a}',$,$,$,$);\n\
+#3=IFCGRIDAXIS('{shared_grid_b}',$,$,$,$);\n\
+#4=IFCGRIDAXIS('{shared_grid_c}',$,$,$,$);\n\
+#5=IFCWALL('{model1_wall}',$,$,$,$,$,$,$,$);\n\
+#6=IFCSPACE('{model1_space}',$,$,$,$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let model_b = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('projb',$,$,$,$,$,$,$,$);\n\
+#2=IFCGRIDAXIS('{shared_grid_a}',$,$,$,$);\n\
+#3=IFCGRIDAXIS('{shared_grid_b}',$,$,$,$);\n\
+#4=IFCGRIDAXIS('{shared_grid_c}',$,$,$,$);\n\
+#5=IFCWALL('{model2_wall}',$,$,$,$,$,$,$,$);\n\
+#6=IFCSPACE('{model2_space}',$,$,$,$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+
+    let (merged, _stats) =
+        export_merged_with_stats(&[model_a.as_bytes(), model_b.as_bytes()], &MergedOptions::default());
+
+    // The 3 shared-grid GlobalIds must appear exactly once each in the
+    // output text -- not twice, even though both source models carried them.
+    for guid in [shared_grid_a, shared_grid_b, shared_grid_c] {
+        assert_eq!(
+            merged.matches(guid).count(),
+            1,
+            "shared GlobalId {guid} must be emitted exactly once, not duplicated across federated models"
+        );
+    }
+
+    // The 4 legitimately-distinct GlobalIds (2 per model) must each survive
+    // unchanged -- exactly one occurrence, no collision to reconcile.
+    for guid in [model1_wall, model1_space, model2_wall, model2_space] {
+        assert_eq!(
+            merged.matches(guid).count(),
+            1,
+            "non-colliding GlobalId {guid} must survive unchanged"
+        );
+    }
+
+    // Overall: 7 distinct GlobalIds (3 shared + 4 unique) must appear in the
+    // output -- one occurrence each, 7 total occurrences of *some* 22-char
+    // GlobalId-shaped token from our fixture set. This distinct count check
+    // (7, not 10) is what would fail if collisions were silently duplicated
+    // instead of reconciled.
+    let total_occurrences: usize = [
+        shared_grid_a, shared_grid_b, shared_grid_c,
+        model1_wall, model1_space, model2_wall, model2_space,
+    ]
+    .iter()
+    .map(|g| merged.matches(*g).count())
+    .sum();
+    assert_eq!(total_occurrences, 7, "7 distinct GlobalIds, one occurrence each");
+}

--- a/rust/export/src/merged_tests.rs
+++ b/rust/export/src/merged_tests.rs
@@ -500,3 +500,40 @@ ENDSEC;\nEND-ISO-10303-21;\n"
         );
     }
 }
+
+/// `IfcDoorStyle` is a genuine `IfcRoot` subtype in IFC2X3 (its first
+/// attribute IS the GlobalId) but the entity was dropped in IFC4X3, whose
+/// entity table is the only one `rust/core`'s generated `IfcType` schema is
+/// derived from. `IfcType::from_str("IFCDOORSTYLE")` therefore resolves to
+/// `Unknown`, which is never a subtype of anything -- so an unpatched
+/// `leading_guid` treats it as non-rooted and never reconciles its GlobalId.
+/// Two IFC2X3 models sharing an `IFCDOORSTYLE` (a shared door-type/style
+/// definition, the common "same catalog type in both files" case) must still
+/// collapse to one occurrence in the merged output, exactly like the
+/// IFC4 `IFCDOOR` case above.
+#[test]
+fn merge_reconciles_a_shared_globalid_on_an_ifc2x3_only_rooted_type() {
+    let shared_style = "00000000000000000000D1";
+
+    let model_a = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('proja',$,$,$,$,$,$,$,$);\n\
+#2=IFCDOORSTYLE('{shared_style}',$,$,$,$,$,$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let model_b = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('projb',$,$,$,$,$,$,$,$);\n\
+#2=IFCDOORSTYLE('{shared_style}',$,$,$,$,$,$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+
+    let (merged, _stats) =
+        export_merged_with_stats(&[model_a.as_bytes(), model_b.as_bytes()], &MergedOptions::default());
+
+    assert_eq!(
+        merged.matches(shared_style).count(),
+        1,
+        "shared IFC2X3-only-rooted GlobalId {shared_style} must be emitted exactly once, not duplicated across federated models -- got:\n{merged}"
+    );
+}


### PR DESCRIPTION
The Rust merged exporter could emit a shared GlobalId twice across federated models. Found on a never-raised branch; merges clean.

## RED had to be surgical

A blunt revert would have taken `#[path = "merged_tests.rs"] mod tests;` with it — the tests would vanish and the run would go vacuously green. So I neutered **only** the dedup block at the call site in `export_merged_with_stats`, leaving every helper and the test module intact:

```
merge_two_models_never_emit_a_shared_globalid_twice_in_the_output_text FAILED
  shared GlobalId 00000000000000000000A1 must be emitted exactly once,
  not duplicated across federated models        left: 2  right: 1
merge_reconciles_a_shared_globalid_on_an_ifc2x3_only_rooted_type FAILED
```

`cargo test -p ifc-lite-export`: **252 lib + 2 integration + 2 doc-tests** pass (250 + 2 fail when neutered). `cargo clippy --workspace --all-targets -- -D warnings` clean, `module_size_ratchet` 5/5, api-surface and changesets pass.

## Prose verified by running, not by reading

- *"byte-for-byte port of `deterministicGlobalId`"* — printed both implementations for three seeds, **identical**: `abc → 3CyRD_hmcIGwa2CMg6S2j2`, `00000000000000000000A1#1 → 2YBkBoek9mhwZCwTqO4E7U`, `x#0#0 → 0b1ZIAGtxrLSoymTQAysB5`.
- *"54 in total"* — the `is_legacy_rooted_type` allowlist holds **exactly 54** entries.
- The claimed-absent types really are absent from `rust/core/src/generated/schema.rs` (`IfcProxy`, `IfcDoorStyle`, `IfcWindowStyle`, `IfcBuildingElement`: 0 hits), so they resolve to `Unknown` as described.
- *"Mirrors `extractGlobalIdFast` … though it still uses the denylist"* — confirmed at `merged-exporter.ts:1245-1265`.

## One caveat worth raising before merge

This knowingly leaves the **Rust exporter on a schema-derived allowlist and the JS exporter on a denylist** (`NON_ROOTED_STRING_TYPES`). The two exporters can now disagree about which entities get GUID-reconciled. The changeset is honest about why — but this is a fresh instance of the divergence shape this repo keeps getting bitten by.

Relatedly: the Rust↔JS `deterministic_global_id` agreement I measured above is **not pinned by any test**, so it can drift silently. A cross-language parity test would close both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
