### PR TITLE
fix(data): handle doubled single quotes when parsing STEP string literals

### DIFF
--- a/.changeset/step-list-quote-blind-comma-split.md
+++ b/.changeset/step-list-quote-blind-comma-split.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/data": patch
+---
+
+Fix `parseStepValue`/`parseStepList` corrupting a STEP list whose string member contains a literal comma.
+
+`parseStepList` split at every top-level comma while tracking paren/bracket nesting but not quote state, so a string list member with a comma inside it — legal STEP content, and exactly what an `IfcLabel`/`IfcText` value (a description, an address line, ...) is free to contain — split mid-string: `('a,b','c')` came back as `["'a", "b'", "c"]` instead of `['a,b', 'c']`. `@ifc-lite/parser`'s `source-header.ts` had already solved this exact problem for STEP header fields with a quote-aware `splitTopLevel` and documented why a quote-blind splitter mis-splits; this generic list parser — re-exported as the public `parseStepValue` from both `@ifc-lite/data` and `@ifc-lite/parser` — had the same gap. `parseStepList` now tracks single-quoted string state (with `''` escapes) the same way, so parens/brackets and commas inside a quoted member no longer perturb the split.

--- a/packages/data/src/step-serializers.ts
+++ b/packages/data/src/step-serializers.ts
@@ -337,7 +337,22 @@ export function parseStepValue(str: string): StepValue {
 }
 
 /**
- * Parse a STEP list
+ * Parse a STEP list.
+ *
+ * Splits at top-level commas, tracking both paren/bracket nesting AND
+ * single-quoted string state (with `''` escapes). Without quote-tracking, a
+ * string member containing a literal comma — e.g. `('a,b','c')`, which any
+ * IfcLabel/IfcText value is free to contain — split mid-string: `'a,b'`
+ * became the two malformed tokens `'a` and `b'` instead of the one string
+ * `a,b`. Parens/brackets *inside* a quoted string (also legal STEP content)
+ * must likewise not perturb `depth`, hence checking `inString` first.
+ *
+ * Mirrors `splitTopLevel` in `@ifc-lite/parser`'s `source-header.ts`, which
+ * already had to solve this same problem for header fields and documented
+ * why: "FILE_DESCRIPTION items ... routinely contain commas ... inside
+ * quoted strings ... which a splitter that ignores quote state would
+ * mis-split." That reasoning applies equally to any STEP list, not just
+ * header fields — this generic parser had the same gap.
  */
 function parseStepList(str: string): StepValue[] {
   // Remove outer parentheses
@@ -348,12 +363,29 @@ function parseStepList(str: string): StepValue[] {
 
   const values: StepValue[] = [];
   let depth = 0;
+  let inString = false;
   let current = '';
 
   for (let i = 0; i < inner.length; i++) {
     const char = inner[i];
 
-    if (char === '(' || char === '[') {
+    if (inString) {
+      current += char;
+      if (char === "'") {
+        if (inner[i + 1] === "'") {
+          current += "'";
+          i++;
+        } else {
+          inString = false;
+        }
+      }
+      continue;
+    }
+
+    if (char === "'") {
+      inString = true;
+      current += char;
+    } else if (char === '(' || char === '[') {
       depth++;
       current += char;
     } else if (char === ')' || char === ']') {

--- a/packages/data/src/step-value-strings.test.ts
+++ b/packages/data/src/step-value-strings.test.ts
@@ -27,7 +27,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { parseStepValue } from './step-serializers.js';
+import { parseStepValue, serializeValue } from './step-serializers.js';
 import { generateHeader } from './step-serializers.js';
 
 /** Strip the outer quotes the way `parseStepValue` is handed a literal. */
@@ -64,6 +64,36 @@ describe('parseStepValue decodes STEP directives, not just the doublings', () =>
     // `parseStepList` recurses into `parseStepValue`, so the list path had the
     // same gap and is the only in-repo caller.
     expect(parseStepValue("('\\X2\\00FC\\X0\\','plain')")).toEqual(['ü', 'plain']);
+  });
+});
+
+describe('parseStepList respects quote state, not just paren/bracket depth', () => {
+  // `parseStepList` split on every top-level comma without tracking whether
+  // it was inside a single-quoted string. A list member that is itself a
+  // string containing a literal comma — legal STEP content, and exactly what
+  // an IfcLabel/IfcText value like a description or address routinely is —
+  // split mid-string: `('a,b','c')` came back as `["'a", "b'", "c"]` instead
+  // of `['a,b', 'c']`. `@ifc-lite/parser`'s `source-header.ts` already solved
+  // this same problem for header fields with a quote-aware `splitTopLevel`
+  // and documented exactly why a quote-blind splitter mis-splits; this
+  // generic list parser — the one two other packages re-export as their
+  // public `parseStepValue` — had the same gap.
+  it('keeps a comma inside a quoted list member intact', () => {
+    expect(parseStepValue("('a,b','c')")).toEqual(['a,b', 'c']);
+  });
+
+  it('round-trips a value produced by serializeValue through this module', () => {
+    const serialized = serializeValue(['a,b', 'c']);
+    expect(serialized).toBe("('a,b','c')");
+    expect(parseStepValue(serialized)).toEqual(['a,b', 'c']);
+  });
+
+  it('does not let a paren/bracket inside a quoted string perturb nesting depth', () => {
+    expect(parseStepValue("('(a,b)','c')")).toEqual(['(a,b)', 'c']);
+  });
+
+  it('still tracks the doubled-quote escape while inside a string', () => {
+    expect(parseStepValue("('it''s, ok','c')")).toEqual(["it's, ok", 'c']);
   });
 });
 


### PR DESCRIPTION
STEP string literals containing a doubled single quote (`''`, the spec's escape for a literal apostrophe) were split at the wrong point. Found on a never-raised branch; merges clean.

RED, reverse-applying only `packages/data/src/step-serializers.ts` — 3 failures, e.g.:
```
- "it's, ok"
+ "'it''s"
+ "ok'"
```

`packages/data` 152 pass (149 + 3 fail reverted). Downstream consumer `packages/parser` also run on-branch: **621 pass / 2 skip**. api-surface, unused-locals and changesets all pass.

Hand-checked the `''` escape state machine — append, lookahead, skip, stay in-string — and the `inString`-before-`depth` ordering. Correct. Changeset claims match the code, including the `source-header.ts` precedent it cites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
