### PR TITLE
test(export): pin the fixture gate's ON switch, in both directions (#3014)

### DIFF
--- a/rust/export/src/test_support.rs
+++ b/rust/export/src/test_support.rs
@@ -145,4 +145,52 @@ mod tests {
     fn not_present_is_off() {
         assert!(!require_fixtures_from(Err(VarError::NotPresent)));
     }
+
+    /// The gate's ON switch, which nothing pinned until #3014.
+    ///
+    /// Mutating the `Ok(v) if v == "1" => true` arm to `false` used to leave
+    /// the whole crate green: the one arm that turns drift detection on could
+    /// regress and CI would stay green forever. That is the failure
+    /// `fixture_or_skip!` exists to close, one level up -- the gate's own
+    /// on-switch had no gate.
+    ///
+    /// Deliberately no test-count here. A number would be true on the day it
+    /// was written and drift with every test added, which is the same
+    /// stale-comment trap this file's other docs avoid.
+    ///
+    /// Asserted in BOTH directions deliberately. `assert!(on)` alone is
+    /// satisfied by a mutation that hard-codes the arm to `true`, which is a
+    /// different bug with the same green: fixtures would then be demanded on
+    /// every developer machine, and the loud failure would be indistinguishable
+    /// from a real drift. Pinning "1" on AND "0"/"" off is what makes the pair
+    /// unfakeable by a constant.
+    #[test]
+    fn the_on_switch_is_on_and_the_off_values_are_off() {
+        assert!(
+            require_fixtures_from(Ok("1".to_string())),
+            "\"1\" must turn the gate ON; this is the arm whose regression \
+             silently disables drift detection"
+        );
+        assert!(
+            !require_fixtures_from(Ok("0".to_string())),
+            "\"0\" must turn the gate OFF, or the arm above could be a constant"
+        );
+        assert!(
+            !require_fixtures_from(Ok(String::new())),
+            "an empty value must be OFF, or the arm above could be a constant"
+        );
+    }
+
+    /// An unrecognised value must panic rather than be guessed either way.
+    /// Guessing "off" silently disables the gate; guessing "on" turns a typo
+    /// into a red build on every machine without the fixtures.
+    #[test]
+    fn an_unrecognised_value_is_rejected() {
+        let result =
+            std::panic::catch_unwind(|| require_fixtures_from(Ok("yes".to_string())));
+        assert!(
+            result.is_err(),
+            "an unrecognised value must panic, not be guessed"
+        );
+    }
 }


### PR DESCRIPTION
Closes #3014.

## The gap

`require_fixtures_from` decides whether a missing fixture is a loud failure or a silent skip. Every way it turns **off** had a test — `NotPresent`, `NotUnicode`, unrecognised values. The one arm that turns it **on** had none.

Mutating `Ok(v) if v == "1" => true` to `false` leaves the crate green on current main. Verified: **256/256 lib, 260/260 across all targets.**

So a regression of the single arm that enables drift detection would disable it silently while CI stayed green forever — the failure #2835 exists to close, one level up. The gate's own on-switch had no gate.

## Both directions, deliberately

`assert!(on)` alone is satisfied by a mutation that hard-codes the arm to `true`. That is a *different* bug with the same green: fixtures would then be demanded on every developer machine, and the loud failure would be indistinguishable from real drift.

Pinning `"1"` ON **and** `"0"`/`""` OFF is what makes the pair unfakeable by a constant.

## Mutation table

Each verified to **compile** before its result was read — a mutation that fails to build and one that survives look identical from test output and point at opposite conclusions.

| mutation | result |
|---|---|
| `Ok("1") => true` → `false` | on-switch test **FAILS** |
| `"0"/"" => false` → `true` | on-switch test **FAILS** |
| whole body → constant `true` | **FAILS** via the `"0"`/`""` assertions |
| whole body → constant `false` | **FAILS** via the `"1"` assertion |
| the first mutation, on `origin/main` | **SURVIVES**, 256/256 |

The last row is the issue's central claim, confirmed independently rather than taken from the filing.

Also pins that an unrecognised value panics rather than being guessed. Guessing "off" silently disables the gate; guessing "on" turns a typo into a red build on every machine without fixtures. Neither is a safe default, which is why the production code panics and why that now has a test.

## One thing I got wrong first

An earlier draft quoted **"235/235 green"** from #3014's filing — in the commit message *and* in the source comment. That figure was measured at #2835-review time and is already stale; today it is 256.

A test count baked into a doc comment is true on the day it is written and drifts with every test added. That is the stale-comment trap this file's other docs carefully avoid, and I would have planted a fresh one. The comment now states the property without a number.

Thread safety checked: both new tests pass constructed `Result` values and never read or set the real environment, so they cannot race the other tests in this multi-threaded crate — which is the reason `require_fixtures_from` takes its input as a parameter in the first place.

Workspace 1981 passed, clippy clean.