### PR TITLE
fix(viewer): report hidden objects, in the viewport's own style

### DIFF
--- a/.changeset/hidden-object-count-ui.md
+++ b/.changeset/hidden-object-count-ui.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Report hidden objects as a count, in the viewport's own style.
+
+The overlay added in #2980 read "1442 of 1446 objects visible" inside a rounded pill with an amber accent. Two things wrong with that.
+
+**It reported the wrong number.** The figure a user acts on is what the viewer is withholding. A ratio makes them subtract to find the four objects that matter. It now reads "4 hidden".
+
+**It did not follow the viewport's design.** The 3D overlays along the bottom edge are deliberately plain: the scale bar and axis helper are bare text at `text-xs text-foreground/80` with no container. The badge instead used `rounded-full` with a border, a backdrop blur, a shadow and `text-amber-500`, which is neither the bottom-row treatment nor a palette colour. It is now styled as its neighbours are.
+
+Counting logic is unchanged; only the reported figure and the presentation.

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -197,32 +197,30 @@ export function ViewportOverlays({ hideViewCube = false }: { hideViewCube?: bool
         </div>
       )}
 
-      {/* Visible-object count. Passive: it only renders once something is
-          actually hidden, so an unfiltered model carries no chrome — the same
-          "speak up only when the numbers disagree" rule the point-cloud class
-          list uses (`PointCloudClasses.tsx`). `total === 0` (no model loaded,
-          or a model with no physical objects) therefore renders nothing at
-          all rather than a meaningless "0 of 0".
-          Bottom-right: bottom-left is the scale/axis cluster and bottom-centre
-          is the storey badge. It tracks `basketPresentationVisible` the same
-          way the storey badge does, and keeps `bottom-4` on mobile like the
-          bottom-left cluster. */}
+      {/* Hidden-object count. Reports what is WITHHELD, not a ratio: the
+          number a user acts on is "what am I not seeing", and "1442 of 1446
+          visible" makes them do the subtraction to find the 4 that matter.
+          Passive, so an unfiltered model carries no chrome at all.
+
+          Styled as the bottom-left scale/axis cluster is: bare text at
+          `text-xs text-foreground/80`, no pill, no border, no backdrop, no
+          off-palette accent. The 3D overlays along the bottom edge are
+          deliberately plain, and this sits in that row. */}
       {(objectCounts.hidden > 0 || objectCounts.ghosted > 0) && (
         <div
           className={cn(
-            'absolute right-6 px-3 py-1.5 bg-background/80 backdrop-blur-sm rounded-full border shadow-sm',
+            'absolute right-4 flex flex-col items-end gap-1',
             basketPresentationVisible ? 'bottom-28' : 'bottom-4',
           )}
           role="status"
         >
-          <span className="text-[11px] text-muted-foreground tabular-nums">
-            {/* Amber only when something is genuinely hidden. Ghosted objects
-                are translucent, i.e. still drawn, so X-Ray on its own is
-                reported without the warning colour. */}
-            <span className={cn(objectCounts.hidden > 0 && 'text-amber-500')}>
-              {objectCounts.visible} of {objectCounts.total} objects visible
-            </span>
-            {objectCounts.ghosted > 0 && ` · ${objectCounts.ghosted} ghosted`}
+          <span className="text-xs text-foreground/80 tabular-nums">
+            {[
+              objectCounts.hidden > 0 && `${objectCounts.hidden} hidden`,
+              objectCounts.ghosted > 0 && `${objectCounts.ghosted} ghosted`,
+            ]
+              .filter(Boolean)
+              .join(' · ')}
           </span>
         </div>
       )}

--- a/apps/viewer/src/lib/physical-objects.ts
+++ b/apps/viewer/src/lib/physical-objects.ts
@@ -3,14 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * "How many physical objects are visible?" — the denominator, and the count.
+ * "How many physical objects is the viewer withholding?" — the count, and the
+ * denominator it has to be derived against.
  *
- * The obvious denominator is `geometryResult.meshes.length`, but that counts
- * things that PRODUCED a mesh. An object that is in the file and never
- * generated geometry is then absent from the denominator too, so the ratio is
- * definitionally 1: the badge would read "1203 of 1203 visible" while a wall
- * silently failed to slice. Counting from the entity index instead makes the
- * gap between "in the model" and "on screen" observable.
+ * The UI reports HIDDEN, not a ratio, because that is the number a user acts
+ * on. But the hidden count still has to be derived from a total, and the
+ * obvious total, `geometryResult.meshes.length`, counts things that PRODUCED a
+ * mesh. An object in the file that never generated geometry is then absent
+ * from the total as well, so hidden comes out as zero while a wall silently
+ * failed to slice. Counting from the entity index instead makes the gap
+ * between "in the model" and "on screen" observable.
  *
  * The mesh array is the wrong denominator in three separate ways, not one:
  * an element can produce MANY `MeshData` entries (one per material or CSG
@@ -26,8 +28,8 @@
  *
  * `IfcElement` is the schema's own word for "an element of a construction
  * work" — a thing with physical presence. Everything excluded is excluded
- * because counting it would cry wolf, i.e. report objects as "not visible"
- * that were never meant to be drawn:
+ * because counting it would cry wolf, i.e. report objects as hidden that
+ * were never meant to be drawn:
  *
  * - Spatial containers (`IfcSite`, `IfcBuilding`, `IfcBuildingStorey`,
  *   `IfcSpace`) descend from `IfcSpatialElement`, NOT `IfcElement`, so they
@@ -36,7 +38,7 @@
  * - `IfcSpace` in particular is a real object a user cares about, but the
  *   viewer ships with spaces hidden (`TYPE_VISIBILITY_SEMANTIC_DEFAULTS.spaces
  *   === false`). In the denominator, every default-loaded model with rooms
- *   would permanently read "N not visible" — an alarm that is never actionable
+ *   would permanently report N hidden — an alarm that is never actionable
  *   and never wrong to ignore, which is the worst kind. It is a spatial
  *   element by schema and hidden by product decision, so both readings agree:
  *   out.


### PR DESCRIPTION
Fixes the overlay shipped in #2980, which I merged. Both complaints are correct.

## It reported the wrong number

It read **"1442 of 1446 objects visible"**. The figure a user acts on is what the viewer is *withholding*, so a ratio makes them do the subtraction to find the four objects that actually matter. It now reads **"4 hidden"**, with ghosted appended when present.

## It did not follow the viewport's design

The 3D overlays along the bottom edge are deliberately plain. The scale bar and axis helper are bare text at `text-xs text-foreground/80` with **no container at all** (`ViewportOverlays.tsx:270`).

The badge instead used `rounded-full` with a border, a backdrop blur, a shadow and `text-amber-500`. That is neither the bottom-row treatment nor a palette colour. It had copied the storey badge, which is centre-screen chrome, rather than the row it actually sits in.

```diff
-'absolute right-6 px-3 py-1.5 bg-background/80 backdrop-blur-sm rounded-full border shadow-sm'
+'absolute right-4 flex flex-col items-end gap-1'

-<span className="text-[11px] text-muted-foreground tabular-nums">
-  <span className={cn(objectCounts.hidden > 0 && 'text-amber-500')}>
-    {objectCounts.visible} of {objectCounts.total} objects visible
+<span className="text-xs text-foreground/80 tabular-nums">
+  {[
+    objectCounts.hidden > 0 && `${objectCounts.hidden} hidden`,
+    objectCounts.ghosted > 0 && `${objectCounts.ghosted} ghosted`,
+  ].filter(Boolean).join(' · ')}
```

## Also

`physical-objects.ts`'s module doc explained the ratio wording throughout, including a worked example of a badge reading "1203 of 1203 visible". Left alone it would have been a careful explanation of a UI that no longer exists, so it is updated to describe what the code now does. The counting logic itself is untouched.

## Verification

```
tsc --noEmit -p apps/viewer/tsconfig.json      clean
physical-objects.test.ts                        26 passed / 0 failed
oxlint ViewportOverlays.tsx                     no new warnings
```

The one `no-unused-vars` warning on that file (`handleFitAll`, line 134) is pre-existing on main; I checked rather than assumed.

Note the `Node tests` lane is currently timing out repo-wide at its 25 minute cap, on main as well, so it is inherited rather than caused here.
