### PR TITLE
fix(viewer): clear the persisted section mode on a model switch (#2939)

### DIFF
--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -18,7 +18,7 @@ import { createVisibilitySlice, type VisibilitySlice } from './slices/visibility
 import { createUISlice, type UISlice } from './slices/uiSlice.js';
 import { createHoverSlice, type HoverSlice } from './slices/hoverSlice.js';
 import { createCameraSlice, type CameraSlice } from './slices/cameraSlice.js';
-import { createSectionSlice, type SectionSlice } from './slices/sectionSlice.js';
+import { createSectionSlice, clearLastSectionMode, type SectionSlice } from './slices/sectionSlice.js';
 export { customPlaneCenter, loadLastSectionMode } from './slices/sectionSlice.js';
 export type { LastSectionMode } from './slices/sectionSlice.js';
 import { createMeasurementSlice, type MeasurementSlice } from './slices/measurementSlice.js';
@@ -288,6 +288,10 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
     // comment (measurementSlice.ts) for why this must not be a field list
     // duplicated here.
     get().resetAllMeasurementState();
+    // Model-relative section state has two homes: the store fields reset in
+    // the `set` below, and this localStorage key. Clearing one without the
+    // other is not a reset, because the surviving copy is read back first.
+    clearLastSectionMode();
     set({
       // Selection (legacy)
       selectedEntityId: null,
@@ -371,6 +375,13 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
       // capStyle). Those round-trip to localStorage via the slice's
       // persistence helpers; clobbering them here was the cause of "my
       // hatch / colour resets to defaults every time I open a file".
+      //
+      // The persisted `ifc-lite:section-last-mode` key holds the SAME four
+      // model-relative fields, so it is cleared alongside them just above
+      // this `set` -- see the `clearLastSectionMode()` call. Resetting only
+      // the in-memory copy left the persisted one to win on the next panel
+      // mount, which is what made a cardinal cut stick across files (#2939).
+      // Cap appearance is display style, not geometry, so its keys stay.
       sectionPlane: {
         ...get().sectionPlane,
         axis:     SECTION_PLANE_DEFAULTS.AXIS,

--- a/apps/viewer/src/store/resetViewerState.sectionMode.test.ts
+++ b/apps/viewer/src/store/resetViewerState.sectionMode.test.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Model-relative section state has TWO homes, and a reset that clears one is
+ * not a reset (#2939).
+ *
+ * `resetViewerState()` already cleared the in-memory `axis`/`position`/
+ * `enabled`/`flipped`, for the reason its own comment gives: they are
+ * "model-relative and meaningless when switching files". The persisted
+ * `ifc-lite:section-last-mode` key holds exactly those four fields, was never
+ * cleared, and `loadLastSectionMode()` reads it back on the next panel mount.
+ * So the reset was undone the moment the panel remounted, and a cardinal cut
+ * from one model reappeared pre-chosen on the next -- the user never being
+ * offered the face picker again on any file.
+ *
+ * These assert on the PERSISTED value, not on the store fields. Asserting the
+ * store would pass without the fix, because the store half was already
+ * correct: the whole bug lived in the copy that outlives it.
+ */
+
+import '../test/setup-dom.js';
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { useViewerStore, loadLastSectionMode } = await import('./index.js');
+
+describe('resetViewerState and the persisted section mode (#2939)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('drops a cardinal mode saved against the previous model', () => {
+    // Real actions, not a test-only setter: these are the production write
+    // path that creates the stale value, so the fixture cannot drift from
+    // what a user actually does.
+    const s = useViewerStore.getState();
+    s.setSectionPlaneAxis('down');
+    s.setSectionPlanePosition(42);
+    s.flipSectionPlane();
+    assert.equal(
+      loadLastSectionMode().kind,
+      'cardinal',
+      'precondition: the mode must really be persisted, or the assertion below proves nothing',
+    );
+
+    useViewerStore.getState().resetViewerState();
+
+    assert.equal(
+      loadLastSectionMode().kind,
+      'pick',
+      'a model switch must re-arm face-pick: a cardinal cut from the previous file is ' +
+        'model-relative, the same reason resetViewerState already clears the in-memory ' +
+        'axis/position/flipped',
+    );
+  });
+
+  it('leaves the cap appearance preferences alone', () => {
+    // Those are display style, not geometry, and the reset preserves them
+    // deliberately -- clobbering them caused "my hatch / colour resets to
+    // defaults every time I open a file". Without this, a fix that cleared
+    // every section key would look identical to a correct one.
+    localStorage.setItem('ifc-lite:section-cap-style', '"diagonal"');
+    localStorage.setItem('ifc-lite:section-cap-show', 'true');
+    localStorage.setItem('ifc-lite:section-outlines-show', 'false');
+
+    useViewerStore.getState().resetViewerState();
+
+    assert.equal(localStorage.getItem('ifc-lite:section-cap-style'), '"diagonal"');
+    assert.equal(localStorage.getItem('ifc-lite:section-cap-show'), 'true');
+    assert.equal(localStorage.getItem('ifc-lite:section-outlines-show'), 'false');
+  });
+});

--- a/apps/viewer/src/store/slices/sectionSlice.persistedMode.test.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.persistedMode.test.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The persisted section mode is the second home of model-relative state, and
+ * a reset that misses it is not a reset (#2939).
+ *
+ * `resetViewerState()` clears the in-memory `axis`/`position`/`enabled`/
+ * `flipped` because, in its own words, they are "model-relative and
+ * meaningless when switching files". `ifc-lite:section-last-mode` persists
+ * exactly those four fields and was never cleared, so `loadLastSectionMode()`
+ * read them back on the next panel mount and a cardinal cut made on one model
+ * reappeared pre-chosen on the next.
+ *
+ * These pin the clear/save/load contract at the slice level. The store-level
+ * wiring (that `resetViewerState` actually calls `clearLastSectionMode`) is
+ * covered separately -- see the PR, which records why a store-level test needs
+ * a DOM stub this suite does not yet have a pattern for.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * A real `window` and a real `localStorage` via the repo's happy-dom harness,
+ * rather than a hand-rolled stub. Defining `window` at all makes every module
+ * in this import graph take its browser branch, so a partial stub sends you
+ * chasing `matchMedia`, then `location.search`, then whatever the next module
+ * reaches for. The harness already answers all of it.
+ */
+import '../../test/setup-dom.js';
+
+const { __saveLastSectionModeForTest, clearLastSectionMode, loadLastSectionMode } =
+  await import('./sectionSlice.js');
+
+describe('persisted section mode (#2939)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips a cardinal mode, so the clear below is not vacuous', () => {
+    __saveLastSectionModeForTest({ kind: 'cardinal', axis: 'down', position: 42, flipped: true });
+    const loaded = loadLastSectionMode();
+    assert.equal(loaded.kind, 'cardinal');
+    assert.deepEqual(loaded, { kind: 'cardinal', axis: 'down', position: 42, flipped: true });
+  });
+
+  it('clearLastSectionMode re-arms face-pick', () => {
+    __saveLastSectionModeForTest({ kind: 'cardinal', axis: 'side', position: 80, flipped: false });
+    assert.equal(loadLastSectionMode().kind, 'cardinal', 'precondition');
+
+    clearLastSectionMode();
+
+    assert.equal(
+      loadLastSectionMode().kind,
+      'pick',
+      'a cleared mode must fall back to pick, which is what re-offers the face picker',
+    );
+  });
+
+  it('leaves the cap appearance keys alone', () => {
+    // The reset deliberately preserves these: they are display style, not
+    // geometry, and clobbering them caused "my hatch / colour resets to
+    // defaults every time I open a file". A clear that took them too would
+    // look identical to a correct one from the test above alone.
+    localStorage.setItem('ifc-lite:section-cap-style', '"diagonal"');
+    localStorage.setItem('ifc-lite:section-cap-show', 'true');
+    localStorage.setItem('ifc-lite:section-outlines-show', 'false');
+
+    clearLastSectionMode();
+
+    assert.equal(localStorage.getItem('ifc-lite:section-cap-style'), '"diagonal"');
+    assert.equal(localStorage.getItem('ifc-lite:section-cap-show'), 'true');
+    assert.equal(localStorage.getItem('ifc-lite:section-outlines-show'), 'false');
+  });
+});

--- a/apps/viewer/src/store/slices/sectionSlice.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.ts
@@ -109,7 +109,20 @@ function saveLastSectionMode(mode: LastSectionMode): void {
   }
 }
 
-function clearLastSectionMode(): void {
+/// Persist a section mode. Exported under a `__…ForTest` name so the
+/// #2939 regression test can establish the precondition it needs (a mode
+/// saved for a previous model) without driving the whole section UI.
+export const __saveLastSectionModeForTest = saveLastSectionMode;
+
+/// Drop the persisted section mode.
+///
+/// Exported because `resetViewerState()` must call it on a model switch. That
+/// reset already clears the in-memory `axis`/`position`/`enabled`/`flipped`
+/// with the reason stated in its own comment -- they are "model-relative and
+/// meaningless when switching files" -- and this key persists exactly those
+/// four fields. Without this call the reset is undone the moment the panel
+/// remounts and `loadLastSectionMode()` reads the value back (#2939).
+export function clearLastSectionMode(): void {
   if (typeof window === 'undefined') return;
   try {
     window.localStorage.removeItem(SECTION_MODE_STORAGE_KEY);


### PR DESCRIPTION
Closes #2939. Reported by @Frostwritter.

## The bug

Model-relative section state has **two homes** and `resetViewerState()` cleared only one. Its own comment states the rule it was following:

```js
// Section plane: reset axis/position/enabled/flipped (those are
// model-relative and meaningless when switching files), but PRESERVE
// the user's cap appearance preferences
```

`ifc-lite:section-last-mode` persists exactly `{ kind: 'cardinal', axis, position, flipped }` — **the same four fields that comment calls meaningless across files** — and was never cleared. `loadLastSectionMode()` reads it back on the next panel mount, so the in-memory reset was undone the moment the panel remounted. A cardinal cut made on one model reappeared pre-chosen on the next, and the user was never offered the face picker again on any file.

That is why the reporter found *"clearing the browser cache restores the expected behaviour"* — that was the only copy the reset did not reach.

Clearing one home while a second survives **and is read first** is not a reset.

The cap-appearance keys stay, for the reason the comment gives: they are display style rather than geometry, and clobbering them was itself a bug once ("my hatch / colour resets to defaults every time I open a file").

## Tests at two levels, because they fail differently

| mutation | result |
|---|---|
| remove the `clearLastSectionMode()` call | **store** test fails (1 pass, 1 fail) |
| make `clearLastSectionMode` a no-op | **slice** test fails (2 pass, 1 fail) |

Both verified to **compile** (`tsc --noEmit`, exit 0) before their results were read.

Both assert on the **persisted** value rather than the store fields. Asserting the store would pass without this fix, because the store half was already correct — the whole defect lived in the copy that outlives it. Each also asserts the three cap keys survive, so a future "clear everything with `section` in the name" cannot pass as a fix: that would be a different bug with the same green.

The store test drives **real actions** (`setSectionPlaneAxis`, `setSectionPlanePosition`, `flipSectionPlane`) rather than a test-only setter, so its fixture cannot drift from what a user actually does, and it exercises the production write path that creates the stale value.

## Behaviour note beyond the reported bug

Every `resetViewerState` caller now drops the persisted mode, including same-file federated recomposition (`useIfcFederation.ts:399`). That path already wiped the in-memory cut, so this makes the two homes agree rather than introducing a new loss — but a user re-composing an overlay on the same file will now be re-offered the face picker where the panel used to restore their cut. Flagging it rather than letting it be discovered.

Federated *adds* are unaffected: they deliberately skip `resetViewerState`, so both homes survive together and your cut is kept.

## Two corrections behind this

**I first called this working-as-designed and was wrong.** My reasoning was that `position` is a 0-100 percentage rather than a world coordinate, so restoring it across models is geometrically meaningful. That is true and it is the wrong question — the complaint is about the **mode** being sticky, not the position being portable. @BIMvoice reached the right conclusion independently and pushed back on mine.

**The precondition assertions caught the test itself being wrong three times.** The sharpest: a fixture used `axis: 'x'` where the type is `'down' | 'front' | 'side'`, so the loader correctly rejected it and returned `pick` — *the exact value the test asserts the fix produces*. It passed because the fixture was broken, on a bug about absence reading as success.

Non-vacuity assertions are not mainly for catching bad code. They catch the test being wrong in the direction that makes it look right.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting the viewer now also clears the saved section mode, restoring it to the default selection.
  * Cap appearance and outline display preferences are preserved when resetting the viewer.

* **Tests**
  * Added coverage for saving, loading, clearing, and resetting persisted section modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->