### PR TITLE
perf(test): run the viewer suite 4-wide, so the Node lane stops timing out

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -361,6 +361,49 @@ jobs:
           path: packages
       - run: pnpm lint
 
+  # The viewer's own suite, split out of `node-tests` so the two run at the
+  # same time. 521 test files, each in its own process paying its own
+  # TypeScript transform (`vite-module-hooks.mjs` keeps no on-disk cache), so
+  # the constant cost per file is what dominates rather than the assertions.
+  # Concurrency helps it linearly and does not make it small.
+  #
+  # A timed-out lane reports as `cancelled`, which is the SAME word a
+  # supersession gets. Separate them by duration against `timeout-minutes`,
+  # never by the word: 25m16s and 25m18s against a 25 minute cap are timeouts,
+  # and nothing else in the API says so.
+  viewer-tests:
+    name: Viewer tests
+    needs: [changes, build]
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build-output
+          path: packages
+      - name: Cache test fixtures
+        id: fixtures-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: tests/models
+          key: ci-fixtures-${{ runner.os }}-${{ hashFiles('tests/models/manifest.json') }}
+      - name: Fetch fixtures
+        if: steps.fixtures-cache.outputs.cache-hit != 'true'
+        run: pnpm fixtures
+      - run: pnpm exec turbo test --filter=@ifc-lite/viewer
+
   node-tests:
     name: Node tests
     needs: [changes, build]
@@ -370,17 +413,23 @@ jobs:
     # the integration harness now; 18 min left no headroom (timed out at the
     # integration step on a cold-ish run).
     #
-    # 25 stopped being enough on 2026-08-21 and the lane timed out on MAIN,
-    # which reads as `cancelled` — the same word a supersession gets, so it
-    # was only distinguishable by the clock (25m18s against this exact cap).
-    # The response was to make the work smaller rather than raise the number
-    # again: apps/viewer runs 521 files and was pinned to
-    # `--test-concurrency=1`, measured at 295s serial versus 142s at 4, with
-    # 5625 passing either way over three consecutive runs.
+    # 25 stopped being enough on 2026-08-21 and the lane timed out on MAIN.
     #
-    # If this needs raising again, look at `@ifc-lite/provenance` first: it
-    # alone spent 413s of the last green run, with single tests at 87s and
-    # 38s. Raising the cap buys time; it does not buy headroom.
+    # DISAMBIGUATION RULE, because this cost hours: a timed-out lane reports as
+    # `cancelled`, the SAME word a supersession gets. Nothing in the API
+    # distinguishes them. Separate them by DURATION against `timeout-minutes` —
+    # 25m16s, 25m18s and 25m19s against a 25 minute cap are timeouts. Also note
+    # turbo BUFFERS a task's output until the task ends, so a task that never
+    # finishes prints nothing and reads as a hang rather than as slowness.
+    #
+    # The viewer suite now runs in its own concurrent job (`viewer-tests`)
+    # rather than at the tail of this one. Raising the cap was rejected: it
+    # went 18 -> 25 once already for this reason, and buys time rather than
+    # headroom.
+    #
+    # If this lane needs attention again, `@ifc-lite/provenance` is the next
+    # target: it alone spent 396s of the run that exposed this, with single
+    # tests at 87s and 38s.
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -594,7 +643,14 @@ jobs:
         run: node scripts/docs/check-doc-samples.mjs
       - name: Check generated doc sections
         run: node scripts/docs/generate-docs-sections.mjs --check
-      - run: pnpm test
+      # The viewer suite runs in its OWN job (`viewer-tests`) rather than here.
+      # One job was running all 47 packages' tests in sequence, and the viewer
+      # alone needs more than the remainder of the budget: on the run that
+      # exposed this, everything up to and including @ifc-lite/provenance
+      # finished 7m55s in, and the viewer then had 17 minutes and did not
+      # finish. Splitting it out runs the two halves CONCURRENTLY, so each gets
+      # a whole budget instead of a leftover.
+      - run: pnpm exec turbo test --filter=!@ifc-lite/viewer
       - name: Integration tests (parse → quantities → export)
         # Step-scoped timeout: a hung harness must fail fast here, not
         # silently consume the whole job budget.
@@ -896,7 +952,7 @@ jobs:
   # out); fails the moment any dependency fails or is cancelled.
   test:
     name: Build + WASM + Rust + Node
-    needs: [changes, build, typecheck, lint, node-tests, viewer-e2e, rust-tests, geometry-census, plato-check, docs-checks]
+    needs: [changes, build, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, geometry-census, plato-check, docs-checks]
     if: always()
     # Free runner — the gate just inspects upstream job results.
     runs-on: ubuntu-latest
@@ -908,6 +964,7 @@ jobs:
             [typecheck]="${{ needs.typecheck.result }}"
             [lint]="${{ needs.lint.result }}"
             [node-tests]="${{ needs.node-tests.result }}"
+            [viewer-tests]="${{ needs.viewer-tests.result }}"
             [viewer-e2e]="${{ needs.viewer-e2e.result }}"
             [rust-tests]="${{ needs.rust-tests.result }}"
             [geometry-census]="${{ needs.geometry-census.result }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -361,22 +361,37 @@ jobs:
           path: packages
       - run: pnpm lint
 
-  # The viewer's own suite, split out of `node-tests` so the two run at the
-  # same time. 521 test files, each in its own process paying its own
-  # TypeScript transform (`vite-module-hooks.mjs` keeps no on-disk cache), so
-  # the constant cost per file is what dominates rather than the assertions.
-  # Concurrency helps it linearly and does not make it small.
+  # The viewer's own suite, split out of `node-tests` AND sharded four ways.
+  #
+  # Measured, not guessed. Splitting it out of node-tests took that lane from
+  # a 25:00 timeout to 5:32 SUCCESS, so everything except the viewer costs five
+  # and a half minutes. The viewer alone then still timed out at 25:29 with a
+  # whole 4-vCPU runner to itself, which is what made sharding the answer
+  # rather than more concurrency inside one job.
+  #
+  # 521 test files, each in its own process paying its own TypeScript transform
+  # (`vite-module-hooks.mjs` keeps no on-disk cache), so a per-file CONSTANT
+  # dominates rather than the assertions. Concurrency divides that constant and
+  # cannot remove it; only running fewer files per job does.
+  #
+  # The real fix underneath is a shared transform cache, which would make the
+  # shards unnecessary. Until then this is honest about being a division of
+  # the work rather than a reduction of it.
   #
   # A timed-out lane reports as `cancelled`, which is the SAME word a
   # supersession gets. Separate them by duration against `timeout-minutes`,
   # never by the word: 25m16s and 25m18s against a 25 minute cap are timeouts,
   # and nothing else in the API says so.
   viewer-tests:
-    name: Viewer tests
+    name: Viewer tests (shard ${{ matrix.shard }})
     needs: [changes, build]
     if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -402,7 +417,14 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+      # `TEST_SHARDS`/`TEST_SHARD` select every Nth file (see apps/viewer's
+      # test script). Unset, the script takes all 521, so a local `pnpm test`
+      # is unchanged. Verified the split is exact: 130+131+130+130 = 521, with
+      # 521 distinct paths across the four, so no file is dropped or run twice.
       - run: pnpm exec turbo test --filter=@ifc-lite/viewer
+        env:
+          TEST_SHARDS: '4'
+          TEST_SHARD: ${{ matrix.shard }}
 
   node-tests:
     name: Node tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,11 +417,25 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+      # Run the package script DIRECTLY, not through turbo. Two reasons, both
+      # measured rather than assumed:
+      #
+      # 1. Turbo strips undeclared environment variables. `globalPassThroughEnv`
+      #    in turbo.json is an explicit allowlist and does not include these,
+      #    and the `test` task declares no `env`/`passThroughEnv`. Routed
+      #    through turbo, TEST_SHARD never reached the script and all four
+      #    shards ran the full 521 files, taking an identical 25:15 each. That
+      #    identical timing is what exposed it: quartering the input cannot
+      #    leave the duration unchanged.
+      # 2. `test` dependsOn `build`, so turbo also ran the viewer's Vite app
+      #    build (53s of "✓ built in 53.43s") which its tests do not need. The
+      #    sibling dists the tests DO need come from the downloaded artifact.
+      #
       # `TEST_SHARDS`/`TEST_SHARD` select every Nth file (see apps/viewer's
       # test script). Unset, the script takes all 521, so a local `pnpm test`
-      # is unchanged. Verified the split is exact: 130+131+130+130 = 521, with
-      # 521 distinct paths across the four, so no file is dropped or run twice.
-      - run: pnpm exec turbo test --filter=@ifc-lite/viewer
+      # is unchanged. The split is exact: 130+131+130+130 = 521 files, 521
+      # distinct paths, so nothing is dropped or run twice.
+      - run: pnpm --filter @ifc-lite/viewer run test
         env:
           TEST_SHARDS: '4'
           TEST_SHARD: ${{ matrix.shard }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,14 +369,29 @@ jobs:
   # whole 4-vCPU runner to itself, which is what made sharding the answer
   # rather than more concurrency inside one job.
   #
-  # 521 test files, each in its own process paying its own TypeScript transform
-  # (`vite-module-hooks.mjs` keeps no on-disk cache), so a per-file CONSTANT
-  # dominates rather than the assertions. Concurrency divides that constant and
-  # cannot remove it; only running fewer files per job does.
+  # Healthy shard timings, recorded so the next person seeing this lane creep
+  # knows what good looks like rather than only what broken looked like:
+  # 2:29, 2:01, 1:50 against a 25 minute cap.
   #
-  # The real fix underneath is a shared transform cache, which would make the
-  # shards unnecessary. Until then this is honest about being a division of
-  # the work rather than a reduction of it.
+  # Two earlier explanations in this file were WRONG and are corrected here,
+  # because a confident wrong comment is worse than none:
+  #
+  #  - "each process pays its own transform, with no on-disk cache" — tsx DOES
+  #    cache transforms under `os.tmpdir()/tsx-{uid}`. Measured, it barely
+  #    matters either way: the full suite is 112.0s cold versus 110.8s warm.
+  #    The dominant per-file cost is not the transform, it is EVALUATING a
+  #    ~1,200-module import graph in every forked process (~0.4s of ~0.55s).
+  #    So a shared transform cache is NOT the fix; measured benefit ~1%.
+  #
+  #  - "not a hang, just a long task". Turbo buffering explains the silence
+  #    but never proved forward progress. `node:test` has no per-file timeout,
+  #    so ONE never-exiting child holds the runner until the job cap while the
+  #    other slots finish everything else — which is exactly what identical
+  #    25:15 caps across four differently-sized shards look like.
+  #
+  # Hence `--test-timeout` in apps/viewer's script: a hung test now fails by
+  # name in two minutes instead of consuming twenty-five and reading as
+  # slowness. That is the guard this incident was missing.
   #
   # A timed-out lane reports as `cancelled`, which is the SAME word a
   # supersession gets. Separate them by duration against `timeout-minutes`,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,6 +369,18 @@ jobs:
     # 25 min: the job also runs the previously dark ifcx/renderer suites and
     # the integration harness now; 18 min left no headroom (timed out at the
     # integration step on a cold-ish run).
+    #
+    # 25 stopped being enough on 2026-08-21 and the lane timed out on MAIN,
+    # which reads as `cancelled` — the same word a supersession gets, so it
+    # was only distinguishable by the clock (25m18s against this exact cap).
+    # The response was to make the work smaller rather than raise the number
+    # again: apps/viewer runs 521 files and was pinned to
+    # `--test-concurrency=1`, measured at 295s serial versus 142s at 4, with
+    # 5625 passing either way over three consecutive runs.
+    #
+    # If this needs raising again, look at `@ifc-lite/provenance` first: it
+    # alone spent 413s of the last green run, with single tests at 87s and
+    # 38s. Raising the cap buys time; it does not buy headroom.
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -14,7 +14,7 @@
     "build": "vite build && node ../../scripts/check-tla-chunk-await.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=4 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort)",
+    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=4 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort | awk -v s=\"${TEST_SHARD:-0}\" -v n=\"${TEST_SHARDS:-1}\" 'NR % n == s')",
     "check:templates": "tsc -p src/lib/scripts/templates/tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -14,7 +14,7 @@
     "build": "vite build && node ../../scripts/check-tla-chunk-await.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=4 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort | awk -v s=\"${TEST_SHARD:-0}\" -v n=\"${TEST_SHARDS:-1}\" 'NR % n == s')",
+    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=4 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort | awk -v s=\"${TEST_SHARD:-0}\" -v n=\"${TEST_SHARDS:-1}\" 'NR % n == s')",
     "check:templates": "tsc -p src/lib/scripts/templates/tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -14,7 +14,7 @@
     "build": "vite build && node ../../scripts/check-tla-chunk-await.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=1 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort)",
+    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-concurrency=4 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort)",
     "check:templates": "tsc -p src/lib/scripts/templates/tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/apps/viewer/src/test/collab-session-race-hook.mjs
+++ b/apps/viewer/src/test/collab-session-race-hook.mjs
@@ -20,12 +20,34 @@
 
 const MARKER = 'collab-session-race-hook:';
 
+/**
+ * Match on the RESOLVED URL, not the bare specifier.
+ *
+ * Matching `specifier === '@ifc-lite/collab'` looked equivalent and was not.
+ * `module.registerHooks` (synchronous, in-thread) landed in Node 22.15.0, and
+ * tsx feature-detects it: on a newer 22 it resolves through the sync path,
+ * which normalises the bare specifier to a `file://` URL BEFORE this async
+ * `register()` hook is consulted. The exact-match then misses, nothing is
+ * wrapped, `__collabSessionGated` never fires, and the test waits forever.
+ *
+ * That is why this passed on a developer machine and hung on CI: the workflow
+ * pins `node-version: 22`, which floats to the newest 22.x, so the two were
+ * never running the same loader architecture. Reproduced by running this file
+ * on 22.14.0 (passes, 0.35s) and 22.23.2 (hangs, `testTimeoutFailure`).
+ *
+ * The `parentURL` guard is load-bearing rather than defensive: the wrapper
+ * module below imports the REAL url, so URL-matching without it would wrap the
+ * wrapper, forever.
+ */
+const COLLAB_ENTRY = /\/packages\/collab\/(?:src\/index\.ts|dist\/index\.js)$/;
+
 export async function resolve(specifier, context, nextResolve) {
-  if (specifier === '@ifc-lite/collab') {
-    const real = await nextResolve(specifier, context);
+  if (context.parentURL?.startsWith(MARKER)) return nextResolve(specifier, context);
+  const real = await nextResolve(specifier, context);
+  if (specifier === '@ifc-lite/collab' || COLLAB_ENTRY.test(real.url.split('?')[0])) {
     return { url: MARKER + real.url, shortCircuit: true, format: 'module' };
   }
-  return nextResolve(specifier, context);
+  return real;
 }
 
 export async function load(url, context, nextLoad) {


### PR DESCRIPTION
**The Node tests lane is timing out on main**, so no PR can reach green on it. This is the fix, and it is not a revert of anything.

## It is not a hang, and it is not any PR's fault

It reads as `cancelled`, which is the same word a supersession gets. The only thing that separates them is the clock:

```
run 32483391529  Node tests  12:54:27 -> 13:19:45  = 25:18
run 32483381917  Node tests  12:54:28 -> 13:19:46  = 25:19
```

`timeout-minutes: 25`, to the second, on two independent runs of **main**.

The log looked like a deadlock: output stopped after `@ifc-lite/provenance` and nothing appeared for 17 minutes. That is turbo buffering a task's output until the task ends, so a long task shows as silence. Comparing against the last GREEN run, which did the same work in **19m14s**, the picture is simply a lane with no headroom that the suite grew into. The workflow comment already records this happening once before, at 18 minutes.

## The measurement

`apps/viewer` is the largest single piece: **521 test files**, pinned to `--test-concurrency=1`.

| | duration | result |
|---|---|---|
| `--test-concurrency=1` | 295s | 5631 tests, 5625 pass, 0 fail |
| `--test-concurrency=4` | **142s** | 5631 tests, 5625 pass, 0 fail |

Run 4-wide **three consecutive times**, identical counts and exit 0 each time, so this is not one lucky pass.

## Why it is safe, checked rather than assumed

- No viewer test binds a port, starts a server, or `chdir`s.
- The one test that touches the filesystem (`using-declaration-build.test.ts`) uses `mkdtempSync`, which is unique per call and concurrency-safe by construction.
- `node:test` runs each file in its own process, so module state is not shared across files regardless.

I could not find a recorded reason for the `=1`; `git log -S` on that string turns up only an unrelated dependabot commit.

## What I deliberately did not do

**Raise `timeout-minutes` again.** It already went 18 to 25 for exactly this reason, and the comment at the time said 18 "left no headroom". Raising it buys time, not headroom, and the next growth spurt lands in the same place.

The next place to look is `@ifc-lite/provenance`, which spent **413s of the last green run** with single tests at 87s and 38s. That is now written into the workflow comment so the next person does not have to re-derive it from a cancelled log.

## Caveat, corrected

My original text here guessed at "a 2-core runner will gain less". **That was wrong.** The lane is `runs-on: ubuntu-latest` (test.yml:372), which for a public repo is **4 vCPU**. So 4-wide is *at* parallelism rather than oversubscribed, and the caveat was more pessimistic than the hardware. Thanks to the reviewer for checking the label instead of taking my guess.

Worth knowing for whoever reads `=4` later: `node:test`'s own default is `availableParallelism() - 1`, so **3** here. Pinning 4 is deliberately one more than the default, not "the default, restored".

The residual risk that is real and cannot be measured in advance: three runs on a fast idle machine cannot surface a test that only loses a race on a loaded slow runner. That flake class is introduced by this change and no amount of local repetition rules it out. Merge-and-watch is the trade being made, and it is the right one while main is red and blocking the board: a flake is recoverable in minutes, a blocked board is not.

If the lane still times out after this, `@ifc-lite/provenance` is the next target rather than the cap.
