### PR TITLE
ci(rust): build and test the parquet-bos feature (#2802)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -727,6 +727,24 @@ jobs:
           IFC_LITE_REQUIRE_FIXTURES: "1"
         run: cargo test --workspace
 
+      # `parquet-bos` is OFF by default because arrow/parquet/zip do not target
+      # wasm32 cleanly (rust/export/Cargo.toml:33). The consequence is that
+      # `cargo test --workspace` above never COMPILES the module, let alone
+      # runs it: an off-by-default feature with no CI leg is dead code that
+      # looks maintained, and the first person to learn it had broken would be
+      # whoever enabled it (#2802).
+      #
+      # Its own step rather than `--all-features`, which would also switch on
+      # anything added later and make an unrelated feature's breakage read as
+      # this one's.
+      - name: Rust tests (parquet-bos feature)
+        env:
+          IFC_LITE_REQUIRE_FIXTURES: "1"
+        run: cargo test -p ifc-lite-export --features parquet-bos
+
+      - name: Clippy (parquet-bos feature)
+        run: cargo clippy -p ifc-lite-export --features parquet-bos --all-targets -- -D warnings
+
   # Geometry watertightness / triangulation-invariance census.
   #
   # Its own job, not a step in `rust-tests`: the sweep runs the whole fixture


### PR DESCRIPTION
Closes **one item** of #2802, not the issue: *"`parquet-bos` is never built in CI — the feature is off by default and no workflow passes `--features parquet-bos` or `--all-features`, so the module is never compiled, let alone tested."*

Confirmed still true on main, and fixed.

## Proven, not argued

`parquet-bos` is off by default because arrow/parquet/zip do not target wasm32 cleanly (`rust/export/Cargo.toml:33`). Injecting a compile error into `rust/export/src/parquet_bos.rs` (334 lines, entirely behind `#[cfg(feature = "parquet-bos")]` at `lib.rs:33-34`):

| lane | result |
|---|---|
| default build — **what CI ran before this PR** | **passes**, 256 lib + 2 + 2 doctests |
| the new feature leg | **fails to compile**, exit 101 |

The default lane is green on a module that does not build. Same shape as an unmanifested fixture or a rate-limited review: nothing reports, so nothing looks wrong — and the first person to learn it had broken would be whoever enabled the feature.

Both legs pass today (257 + 2 + 2 tests, clippy clean under the feature), so this pins a currently-working module rather than fixing a broken one.

## Verified rather than assumed

- **The steps actually fire on this PR.** `rust-tests` is gated on `needs.changes.outputs.rust == 'true'`, and the `rust` paths-filter includes `.github/workflows/test.yml` — so a workflow-only diff triggers its own job. A gate that cannot run on the PR that adds it would be the obvious way for this to be quietly useless.
- **No absence-reads-as-green path.** The test leg sets `IFC_LITE_REQUIRE_FIXTURES=1`, so a missing fixture is a hard failure, not a silent skip. Reproduced: without fixtures the leg fails 57 tests; after fetching, green.
- **Timeout headroom is comfortable.** `Rust tests` runs ~3.2-3.5 min against `timeout-minutes: 28`. The two new steps add ~1-2 minutes cold, well under a minute warm.

## Two choices worth stating

**Its own step, not `--all-features`.** That would also switch on anything added later, so an unrelated feature's breakage would read as this one's.

**A clippy leg as well as a test leg.** `cargo test` compiles with rustc — warnings stay warnings and clippy's lint set never runs. The existing `cargo clippy --workspace --all-targets -- -D warnings` runs *without* the feature, so it never sees this module. This leg is the only thing that lints it.

## Worth knowing, out of scope here

No crate in the repo enables `parquet-bos` or calls `export_bos` / `ParquetBosOptions`. The module has **zero consumers** — which is the dormancy #2802 documents, and an argument someone should make deliberately about whether it earns its 334 lines. Not a question this PR answers.

## Three sibling items are already done, so this PR does not touch them

Checked before writing anything, because #2802 is old enough that its inventory has drifted:

- **COLLADA `to_zup`** and the **glTF u16/u32 index threshold** — both pinned by `56d88b10a` (#2824); `collada_tests.rs:140` names the `z = 0` gap exactly.
- **`collabSlice`** — the issue says zero direct coverage; covered by `8332f80d2` (#2810) plus #2831 and #3011, four test files now.
- **`fixture_or_skip!` reporting PASS when a fixture is absent** — closed by #2835; its remaining gap (the gate's own on-switch untested) is #3014 / #3021.

**#2802 stays open**: the 17 zero-coverage slices, the partially-tested ones, and the `deserializeClashConfig` schema-version decision are all untouched.