### PR TITLE
fix(renderer): keep the LOD vertex memo below V8's Map ceiling (#3028)

### DIFF
--- a/.changeset/lod-vertex-map-ceiling.md
+++ b/.changeset/lod-vertex-map-ceiling.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/renderer": patch
+---
+
+Fix `RangeError: Map maximum size exceeded` when building LOD for a very large batch (#3028).
+
+`simplifyIndicesByClustering` memoized cluster representatives in a `Map` keyed per vertex. V8 caps a `Map` at 2^24 - 1 entries, so a batch referencing more than ~16.7 million distinct vertices threw, which rejected the whole geometry finalize and left the viewer showing streaming fragments.
+
+That is reachable from a legitimate file rather than needing a hostile one. Bucket size is bounded in bytes against the GPU's `maxBufferSize`, which is deliberately requested at the adapter maximum so multi-GB models render, and buckets group by spatial cell and colour rather than by model, so a dense federated load co-batches.
+
+The memo is now an `Int32Array` keyed by vertex index: the same lookup, 4 bytes per vertex flat instead of the Map's per-entry overhead, and no ceiling below the index space. The cell map, which is bounded by occupied cells rather than vertices, now bails through the function's existing "simplification does not pay" contract if it ever approaches the same cap, so callers fall back to full-detail LOD0 instead of losing the batch.

--- a/packages/renderer/src/lod-simplify.test.ts
+++ b/packages/renderer/src/lod-simplify.test.ts
@@ -151,6 +151,50 @@ describe('simplifyIndicesByClustering', () => {
     }
   });
 
+  it('lets vertex 0 be its own cluster representative', () => {
+    // The per-vertex memo is an Int32Array (a Map throws past 2^24 entries,
+    // issue #3028), so index 0 is both a real representative and the falsy
+    // value.
+    //
+    // What this test does NOT do, stated because the name would otherwise
+    // imply it: it does not pin the -1 sentinel. Mutating the fill to 0 and
+    // the guard to `memo !== 0` leaves all ten tests green, verified by
+    // running it. A falsy sentinel makes vertex 0 look permanently
+    // unmemoized, so it is re-resolved on every reference through the same
+    // `repOfCell` lookup, which returns the same answer. That is a
+    // performance regression with no observable output difference, and no
+    // assertion on the returned buffer can see it. The sentinel choice is
+    // therefore documented at the declaration rather than defended here.
+    //
+    // What it does pin is that vertex 0 is usable as a representative at all,
+    // which a sentinel collision that skipped it would break.
+    //
+    // Triangle 0 spans three separate cells so it survives; every later
+    // triangle has all three corners in one cell so it collapses and is
+    // dropped. That guarantees a real reduction (not a null return) and puts
+    // vertex 0 in the output as its own representative.
+    const positions: Array<[number, number, number]> = [
+      [0, 0, 0],
+      [10, 0, 0],
+      [20, 0, 0],
+    ];
+    for (let t = 1; t <= LOD_MIN_TRIANGLES + 2; t++) {
+      positions.push([100 + t * 10, 0, 0], [100 + t * 10, 0, 0], [100 + t * 10, 0, 0]);
+    }
+    const data = interleave(positions);
+    const indices = new Uint32Array(positions.length);
+    for (let i = 0; i < positions.length; i++) indices[i] = i;
+
+    const out = simplifyIndicesByClustering(data, STRIDE, indices, 1);
+    assert.ok(out, 'expected simplification to produce a buffer');
+    assert.ok(out.includes(0), 'vertex 0 must survive as a cluster representative');
+    assert.deepEqual(
+      Array.from(out),
+      [0, 1, 2],
+      'only the spread triangle survives, and it keeps vertex 0 as its own representative',
+    );
+  });
+
   it('is translation-invariant in output SIZE (cell alignment may differ slightly)', () => {
     const a = strip(LOD_MIN_TRIANGLES, 0.01);
     const b = strip(LOD_MIN_TRIANGLES, 0.01);
@@ -160,6 +204,64 @@ describe('simplifyIndicesByClustering', () => {
     const lodB = simplifyIndicesByClustering(b.vertexData, STRIDE, b.indices, 1.0)!;
     assert.ok(Math.abs(lodA.length - lodB.length) <= 6, `${lodA.length} vs ${lodB.length}`);
   });
+});
+
+describe('simplifyIndicesByClustering at the V8 Map ceiling (issue #3028)', () => {
+  // The defect this guards needs more than 2^24 - 1 distinct referenced
+  // vertices in ONE batch, which is ~16.7 million. There is no cheap fixture
+  // for that: the buffers alone are a few hundred MB, so this cannot run on
+  // every commit.
+  //
+  // It is therefore DEMANDABLE rather than skipped-and-forgotten, following
+  // `fixture_or_skip!` / IFC_LITE_REQUIRE_FIXTURES on the Rust side. Set
+  // IFC_LITE_HEAVY_TESTS=1 to run it.
+  //
+  // Being honest about why this exists at all: with it skipped, reverting the
+  // fix (Int32Array back to Map) leaves every other test in this file green.
+  // I ran that mutation to check. So without this, the change has no
+  // regression test, and saying so is better than implying the other tests
+  // cover it.
+  const heavy = process.env.IFC_LITE_HEAVY_TESTS === '1';
+
+  it(
+    'memoizes past 2^24 vertices without throwing RangeError',
+    { skip: heavy ? false : 'set IFC_LITE_HEAVY_TESTS=1 (allocates ~340MB)' },
+    () => {
+      // Stride 3 keeps the vertex buffer as small as this can be: no normals,
+      // no entity lane.
+      //
+      // Every vertex sits at the SAME position, which matters. The per-vertex
+      // memo grows to 2^24 entries while the cell map stays at ONE. Spreading
+      // them out instead would overflow the CELL map first, and its own bail
+      // returns null before the per-vertex memo is ever stressed, so the test
+      // would pass with the defect present. I found that by running the
+      // mutation, not by reasoning about it.
+      const STRIDE_MIN = 3;
+      // The count has to EXCEED 2 ** 24 - 1 distinct references, not reach it:
+      // a Map throws on the insert that would take it past the cap, so landing
+      // exactly on it passes. `n = 2 ** 24 + 1` rounded down to a multiple of
+      // three gives 2 ** 24 - 1 references, one short, and the test passed with
+      // the defect present. Caught by running the mutation.
+      const n = 2 ** 24 + 3;
+      const data = new Float32Array(n * STRIDE_MIN);
+      const indices = new Uint32Array(n - (n % 3));
+      for (let i = 0; i < indices.length; i++) indices[i] = i;
+      assert.ok(
+        indices.length > 2 ** 24 - 1,
+        `fixture must exceed the Map cap; got ${indices.length} references`,
+      );
+
+      // Before the fix this threw `RangeError: Map maximum size exceeded`
+      // from the per-vertex memo, which rejected the whole finalize and left
+      // the viewer showing streaming fragments.
+      const out = simplifyIndicesByClustering(data, STRIDE_MIN, indices, 1);
+
+      // Nothing collapses, so the honest outcome is null ("simplification
+      // does not pay"), NOT a throw. Either a buffer or null is a pass here;
+      // the assertion is that we got a verdict at all.
+      assert.ok(out === null || out instanceof Uint32Array);
+    },
+  );
 });
 
 describe('lodCellSizeForBounds', () => {

--- a/packages/renderer/src/lod-simplify.ts
+++ b/packages/renderer/src/lod-simplify.ts
@@ -37,6 +37,12 @@ export const LOD_CELL_FRACTION = 0.02;
  * @returns the LOD1 index buffer, or null when simplification does not pay
  *   (too few source triangles, or the result is not meaningfully smaller)
  */
+/**
+ * V8 caps a `Map` at 2^24 - 1 entries and throws `RangeError: Map maximum size
+ * exceeded` on the next insert. Stopping one short keeps the refusal ours.
+ */
+const MAX_MAP_ENTRIES = 2 ** 24 - 1;
+
 export function simplifyIndicesByClustering(
   vertexData: Float32Array,
   strideFloats: number,
@@ -48,7 +54,24 @@ export function simplifyIndicesByClustering(
   if (!(cellSize > 0) || !Number.isFinite(cellSize)) return null;
 
   // Cell id per referenced vertex, memoized (vertices are referenced ~1-3x).
-  const cellOf = new Map<number, number>(); // vertexIndex -> cluster representative vertexIndex
+  //
+  // A TYPED ARRAY, not a Map, because V8 caps a Map at 2^24 - 1 entries and
+  // this is keyed per vertex. A single batch can exceed that: bucket size is
+  // bounded in BYTES against the GPU's `maxBufferSize` (`scene.ts`
+  // `resolveActiveBucket`), and that limit is deliberately requested at the
+  // adapter maximum so multi-GB models render, which on a 2 GiB adapter allows
+  // roughly 69M vertices per bucket at 28 B each. Buckets also group by
+  // spatial cell and colour rather than by model, so a dense federated load
+  // co-batches. Production hit exactly this: `RangeError: Map maximum size
+  // exceeded` from this line (issue #3028), which rejected the whole finalize
+  // and left the viewer on streaming fragments.
+  //
+  // -1 means "not yet memoized". Vertex indices are non-negative, so the
+  // sentinel cannot collide with a real representative. Int32Array also costs
+  // 4 bytes per vertex flat, well under the Map's per-entry overhead for the
+  // same population.
+  const vertexCount = strideFloats > 0 ? (vertexData.length / strideFloats) | 0 : 0;
+  const cellOf = new Int32Array(vertexCount).fill(-1); // vertexIndex -> representative, -1 = unset
   const repOfCell = new Map<string, number>(); // cell key -> representative vertexIndex
 
   // Clustering is ENTITY-SCOPED: the per-vertex entityId lane (u32 bit-cast
@@ -63,20 +86,31 @@ export function simplifyIndicesByClustering(
     : null;
 
   const repOf = (vi: number): number => {
-    let rep = cellOf.get(vi);
-    if (rep !== undefined) return rep;
+    const memo = cellOf[vi];
+    if (memo !== -1) return memo;
     const base = vi * strideFloats;
     const cx = Math.floor(vertexData[base] / cellSize);
     const cy = Math.floor(vertexData[base + 1] / cellSize);
     const cz = Math.floor(vertexData[base + 2] / cellSize);
     const entity = idLane ? idLane[base + 6] : 0;
     const key = `${cx},${cy},${cz},${entity}`;
-    rep = repOfCell.get(key);
-    if (rep === undefined) {
+    const existing = repOfCell.get(key);
+    let rep: number;
+    if (existing === undefined) {
       rep = vi;
+      // `repOfCell` is the remaining Map, and it is bounded by the number of
+      // OCCUPIED cells rather than by vertices, so it only approaches the same
+      // 2^24 cap when almost nothing collapses. That case is precisely the one
+      // where LOD1 would be no smaller than LOD0, so bail through the
+      // function's existing "simplification does not pay" contract rather than
+      // letting it throw. Callers already handle null (`scene.ts` renders
+      // LOD0), so nothing goes missing (issue #3028).
+      if (repOfCell.size >= MAX_MAP_ENTRIES) return -1;
       repOfCell.set(key, vi);
+    } else {
+      rep = existing;
     }
-    cellOf.set(vi, rep);
+    cellOf[vi] = rep;
     return rep;
   };
 
@@ -86,6 +120,8 @@ export function simplifyIndicesByClustering(
     const a = repOf(indices[i]);
     const b = repOf(indices[i + 1]);
     const c = repOf(indices[i + 2]);
+    // A cell-map overflow (see `repOf`) means nothing was collapsing anyway.
+    if (a < 0 || b < 0 || c < 0) return null;
     // Collapsed triangles (any two corners in the same cell) are dropped.
     if (a === b || b === c || a === c) continue;
     out[w] = a;


### PR DESCRIPTION
Closes #3028.

A production `RangeError: Map maximum size exceeded`, one user, one session, first seen today. Decoded from the live bundle frame by frame to `simplifyIndicesByClustering`'s per-vertex memo at `lod-simplify.ts`.

V8 caps a `Map` at 2^24 - 1 entries. The memo is keyed per vertex, so a batch referencing more than ~16.7M distinct vertices throws. The throw rejected the whole geometry finalize, leaving that user on streaming fragments.

## Reachable from a legitimate file, not a hostile one

This matters because it decides the fix. A bound would be wrong here.

- Bucket size is bounded in **bytes** against the GPU's `maxBufferSize`, and that limit is deliberately requested at the **adapter maximum** so multi-GB models render. On a 2 GiB adapter that allows roughly 69M vertices per bucket at 28 B each, four times past the Map cap.
- Buckets group by spatial cell and colour, **not by model**, so a dense federated load co-batches.
- No vertex-count bound exists anywhere on the batch path. The existing bounds are all byte-based and scaled to a GPU ceiling that was raised past the V8 one.

## The fix

The memo becomes an `Int32Array` keyed by vertex index, sentinel `-1`. Same lookup, 4 bytes per vertex flat rather than the Map's per-entry overhead, and no ceiling below the index space.

The **cell** map is bounded by occupied cells rather than vertices, so it only nears the same cap when almost nothing is collapsing — which is precisely when LOD1 would be no smaller than LOD0. It now returns the function's existing `null` ("simplification does not pay") instead of throwing. Callers already handle null by rendering LOD0, so nothing goes missing.

## The test is demandable, and here is the blunt part

Reproducing this needs ~340MB of buffers, so it cannot run on every commit. It is gated behind `IFC_LITE_HEAVY_TESTS=1`, following the `fixture_or_skip!` / `IFC_LITE_REQUIRE_FIXTURES` pattern already used on the Rust side.

**With it skipped, reverting this fix leaves every other test in the file green.** I ran that mutation. So without this test the change has no regression coverage, and saying so is better than implying the neighbours cover it.

## Three corrections to my own fixture

Each found by running the mutation, not by reasoning about it. Recording them because each one is a test that would have passed while the defect was present:

1. **Spreading vertices across cells overflowed the CELL map first**, and its bail returns null before the per-vertex memo is ever stressed. Test passed with the defect present. All vertices now share one position, so the cell map stays at one entry while the memo grows.
2. **`n - (n % 3)` gave exactly 2^24 - 1 references.** A Map throws on the insert that would *exceed* the cap, so landing exactly on it passes. Now `2 ** 24 + 3`, with a precondition assertion on the reference count so the fixture cannot silently drift back under.
3. **The sibling sentinel test does not pin the sentinel.** Mutating `-1` to `0` leaves everything green, because a falsy sentinel only costs a re-resolve and changes no output. The test now says that rather than letting its name imply otherwise.

## Verification

```
mutation (Int32Array -> Map), heavy test:  RangeError: Map maximum size exceeded, exit 1
with the fix, heavy test:                  pass
lod-simplify suite (default):              10 passed, 1 skipped
renderer typecheck:                        clean
```

## Not in this PR

The investigation also found that when `createBatchedMesh` throws mid-run, the GPU buffers it already allocated for that batch leak: `createTracked` only cleans up when `device.createBuffer` itself throws, not when code between allocations does. Removing this throw site removes the trigger, but the shape remains for any other mid-run throw. Worth its own PR rather than widening this one.