### PR TITLE
test(geometry): pin gap_boundary to each edge's own half_thickness (#3013)

### DIFF
--- a/rust/geometry/src/space_dcel/tests.rs
+++ b/rust/geometry/src/space_dcel/tests.rs
@@ -905,3 +905,186 @@
                 .unwrap_or_else(|| panic!("no live vertex near {pt:?}"))
         }
     }
+
+    /// A 4x3 room whose four edges carry DISTINCT half-thicknesses, in
+    /// `loop_segments` order: bottom, right, top, left.
+    ///
+    /// `net_outline_uses_each_edges_own_thickness_not_a_neighbours` builds the
+    /// same shape inline and is deliberately left alone here, to keep this diff
+    /// to the function it is about. If either fixture's halves are ever
+    /// retuned, retune both: each test's "only the identity index map survives"
+    /// argument depends on those four values staying pairwise distinct.
+    const ROOM_W: f64 = 4.0;
+    const ROOM_H: f64 = 3.0;
+
+    fn per_edge_thickness_room() -> (SpacePlate, FaceId, [f64; 4]) {
+        let halves = [0.1_f64, 0.2, 0.3, 0.4];
+        let segs: Vec<InputSegment> = loop_segments(&rect(0.0, 0.0, ROOM_W, ROOM_H), 100)
+            .into_iter()
+            .zip(halves)
+            .map(|(s, half)| s.with_half_thickness(half))
+            .collect();
+        let plate = SpacePlate::build(&segs, BuildOptions::default());
+        let room = plate.rooms().next().unwrap();
+        (plate, room, halves)
+    }
+
+    fn bbox(ring: &[[f64; 2]]) -> (f64, f64, f64, f64) {
+        let (mut nx, mut ny) = (f64::INFINITY, f64::INFINITY);
+        let (mut xx, mut xy) = (f64::NEG_INFINITY, f64::NEG_INFINITY);
+        for p in ring {
+            nx = nx.min(p[0]);
+            ny = ny.min(p[1]);
+            xx = xx.max(p[0]);
+            xy = xy.max(p[1]);
+        }
+        (nx, ny, xx, xy)
+    }
+
+    /// `gap_boundary` reads each edge's OWN `half_thickness` (mod.rs, the
+    /// `cycle[i]` lookup). Nothing tested that indexing, because every prior
+    /// fixture gives all four edges of a face the same thickness, and a lookup
+    /// that reads the wrong edge then returns the identical number.
+    ///
+    /// It is uniform TEST PLANS that hid this, not an unreachable path. A gap
+    /// room is bounded by edges from several different rectangles, so an
+    /// exterior wall meeting an interior partition puts distinct halves on one
+    /// cycle, and `build_from_wall_rects` calls `gap_boundary(f, 1.0)` on
+    /// exactly that face to lift each room to its wall axis. Mis-indexing this
+    /// read moves the axis lines and gross faces of any mixed-thickness plan.
+    ///
+    /// The magnitude of the read WAS covered — forcing `half = 0.0` fails two
+    /// tests — which is why this looked tested. Mis-indexing it did not:
+    /// `cycle[i]` to `cycle[0]` left the whole workspace green at 1981 passed.
+    /// So the surviving mutation meant untested, not redundant. #3013
+    ///
+    /// Distinct per-edge thicknesses make only the correct index reproduce the
+    /// result, and each assertion below is that edge's own half by
+    /// construction, so it reads as the property rather than as magic numbers.
+    #[test]
+    fn gap_boundary_pushes_each_edge_out_by_its_own_thickness() {
+        let (plate, room, halves) = per_edge_thickness_room();
+        let [bottom, right, top, left] = halves;
+
+        // 0, 1 and 2 are the three documented values of `factor`: the net gap,
+        // the wall axis, and the gross outer face. Testing 1 and 2 here (0 is
+        // the control below) covers the contract rather than sampling it, and
+        // catches a factor applied nonlinearly, which a single factor cannot.
+        for factor in [1.0_f64, 2.0] {
+            let ring = plate.gap_boundary(room, factor);
+            assert_eq!(ring.len(), 4, "an axis-aligned room stays a quad at factor {factor}");
+
+            // Outward on every side, so the offset rectangle is (4 + left + right)
+            // wide and (3 + bottom + top) tall.
+            // Not redundant with the bounds below: a diamond inscribed in the
+            // same bounding box satisfies all four of them, so area is what
+            // pins the ring to the full rectangle.
+            let expected_area =
+                (ROOM_W + factor * (left + right)) * (ROOM_H + factor * (bottom + top));
+            let area = polygon_area(&ring).abs();
+            assert!(
+                (area - expected_area).abs() < 1e-9,
+                "factor {factor}: expected outward area {expected_area}, got {area}"
+            );
+
+            // Area alone cannot see an OPPOSITE-edge swap: it reads only the sums
+            // (left + right) and (bottom + top), which such a swap leaves
+            // unchanged for any values. Pin each side's POSITION too — that is
+            // what tells an edge apart from the one across the room. Same
+            // reasoning as `net_outline_uses_each_edges_own_thickness_not_a_neighbours`,
+            // where asserting area alone could not have caught the bug.
+            //
+            // These four bounds are exhaustive over mis-indexing, not a sample:
+            // on an axis-aligned quad each bound is set by exactly one edge, so
+            // with four DISTINCT halves the identity map is the only index map
+            // that satisfies all four. That argument covers all 256 maps,
+            // collapses included. Separately confirmed by running the four
+            // uniform shift/collapse mutations of `cycle[i]` — to one edge, to
+            // either neighbour, and to the opposite edge — each of which fails
+            // this test and all of which passed before it.
+            let (min_x, min_y, max_x, max_y) = bbox(&ring);
+            for (got, want, side) in [
+                (min_x, -factor * left, "left"),
+                (max_x, ROOM_W + factor * right, "right"),
+                (min_y, -factor * bottom, "bottom"),
+                (max_y, ROOM_H + factor * top, "top"),
+            ] {
+                assert!(
+                    (got - want).abs() < 1e-9,
+                    "factor {factor}: the {side} edge must sit at {want}, got {got}"
+                );
+            }
+        }
+
+        // Control. `factor = 0` is the net gap itself, so the ring must be the
+        // untouched centreline: if this drifted, every assertion above would be
+        // measuring an offset that was never applied.
+        let (min_x, min_y, max_x, max_y) = bbox(&plate.gap_boundary(room, 0.0));
+        assert!(
+            min_x.abs() < 1e-9 && min_y.abs() < 1e-9
+                && (max_x - ROOM_W).abs() < 1e-9 && (max_y - ROOM_H).abs() < 1e-9,
+            "factor 0 must return the centreline {ROOM_W}x{ROOM_H}, got [{min_x},{min_y}]..[{max_x},{max_y}]"
+        );
+    }
+
+    /// Reachability, run rather than argued. The unit test above pins
+    /// `gap_boundary`'s per-edge read directly; this proves the production
+    /// caller reaches it with edges that actually differ.
+    ///
+    /// `build_from_wall_rects` derives ONE half per RECTANGLE, which is what
+    /// makes the read look unreachable at a glance. But a gap room is bounded
+    /// by edges from SEVERAL rectangles, so four walls of different thickness
+    /// put four distinct halves on one cycle — measured here as
+    /// `[0.25, 0.1, 0.15, 0.2]` — and stage 2 lifts the room to its wall axis
+    /// through `gap_boundary(f, 1.0)`. Mis-indexing that read shuffles the axis
+    /// lines of any mixed-thickness plan, which is ordinary input: an exterior
+    /// wall meeting an interior partition.
+    #[test]
+    fn build_from_wall_rects_lifts_each_wall_by_its_own_half_thickness() {
+        // Interior room (0,0)-(10,6) enclosed by four walls, each a different
+        // thickness, so every edge of the room's cycle carries a distinct half.
+        let rects: Vec<[[f64; 2]; 4]> = vec![
+            [[-0.5, -0.2], [10.3, -0.2], [10.3, 0.0], [-0.5, 0.0]], // bottom, 0.2 thick
+            [[-0.5, 6.0], [10.3, 6.0], [10.3, 6.4], [-0.5, 6.4]],   // top,    0.4
+            [[-0.5, 0.0], [0.0, 0.0], [0.0, 6.0], [-0.5, 6.0]],     // left,   0.5
+            [[10.0, 0.0], [10.3, 0.0], [10.3, 6.0], [10.0, 6.0]],   // right,  0.3
+        ];
+        let plate = SpacePlate::build_from_wall_rects(&rects, BuildOptions::default());
+        let rooms: Vec<FaceId> = plate.rooms().collect();
+        assert_eq!(rooms.len(), 1, "the four walls enclose exactly one room");
+
+        // Control: the cycle really does carry four DIFFERENT halves. Without
+        // this, a build that collapsed them to one value would leave every
+        // assertion below true for the wrong reason — which is precisely how
+        // this read went untested in the first place.
+        let mut halves: Vec<f64> = plate
+            .face_half_edges(rooms[0])
+            .map(|h| plate.half_edges[h.0 as usize].half_thickness)
+            .collect();
+        halves.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // `zip` truncates, so without this a three-edge cycle would satisfy the
+        // loop below while the message still claimed four were checked.
+        assert_eq!(halves.len(), 4, "the room cycle must be four edges, got {halves:?}");
+        for (got, want) in halves.iter().zip([0.1, 0.15, 0.2, 0.25]) {
+            assert!(
+                (got - want).abs() < 1e-9,
+                "expected the four wall halves on one cycle, got {halves:?}"
+            );
+        }
+
+        // Stage 2 already ran `gap_boundary(f, 1.0)`, so the room outline sits on
+        // each wall's own axis: the interior expanded by that wall's half, and
+        // by no other wall's.
+        let (min_x, min_y, max_x, max_y) = bbox(&plate.face_outline(rooms[0]));
+        for (got, want, side) in [
+            (min_x, -0.25, "left (0.5 thick)"),
+            (min_y, -0.1, "bottom (0.2 thick)"),
+            (max_x, 10.15, "right (0.3 thick)"),
+            (max_y, 6.2, "top (0.4 thick)"),
+        ] {
+            assert!(
+                (got - want).abs() < 1e-9,
+                "the {side} wall axis must sit at {want}, got {got}"
+            );
+        }
+    }


### PR DESCRIPTION
Closes #3013.

## The question the issue asked, answered rather than assumed

#3013 said a surviving mutation is a question, not a verdict: the code is either untested or redundant, and those point opposite ways. This is the untested one, and more narrowly than the issue states.

The read's **magnitude** was already covered. Forcing `half = 0.0` fails two existing tests, which is why the line looked exercised. Its per-edge **indexing** was not: changing `cycle[i]` to `cycle[0]` left the whole workspace green at 1981 passed.

## What hid it was uniform test plans, not an unreachable path

My first reading was that `build_from_wall_rects` derives one half per rectangle and stamps it on all four of that rectangle's edges, so reading the wrong edge returns the same number. That is true per rectangle and wrong about the face. A gap room is bounded by edges from **several** rectangles, so four walls of different thickness put four distinct halves on one cycle, and stage 2 lifts every room to its wall axis through `gap_boundary(f, 1.0)`.

So the second test runs that rather than arguing it. Four walls at 0.2, 0.4, 0.5 and 0.3 produce halves `[0.1, 0.15, 0.2, 0.25]` on one cycle, measured, with a control asserting they really are four different values. Mis-indexing the read shuffles the wall-axis lines of any mixed-thickness plan, which is ordinary input: an exterior wall meeting an interior partition.

That matters for how the issue gets read. Had I left the first version's comment in, a future reader could have concluded the guarded path was production-dead.

## Why position and not just area

Area reads only the sums (left + right) and (bottom + top), so an opposite-edge swap leaves it unchanged for any values. That is the trap #2913 recorded in the sibling function, and asserting area alone here would have reproduced it.

Area is not redundant in the other direction either: a diamond inscribed in the same bounding box satisfies all four position bounds, so area is what pins the ring to the full rectangle.

The four bounds are exhaustive over mis-indexing rather than a sample. On an axis-aligned quad each bound is set by exactly one edge, so with four distinct halves the identity map is the only index map satisfying all four, all 256 included.

## Mutation table

Each mutation confirmed to compile first, because one that fails to compile looks identical to one that survives and points the opposite way.

```
cycle[0]             collapse to one edge  -> both tests FAIL  (survived before)
cycle[(i+1) % n]     neighbour             -> both tests FAIL
cycle[(i+n-1) % n]   other neighbour       -> FAILS
cycle[(i+2) % n]     opposite edge         -> both tests FAIL
half = 0.0           magnitude             -> FAILS (2 before, 3 now)
factor * factor      nonlinear factor      -> FAILS at factor 2 only
```

A `factor = 0` control asserts the untouched centreline, so a fixture that stopped producing an offset would fail loudly rather than pass vacuously. Factors 1 and 2 are the wall axis and the gross outer face, the two remaining documented values, so the loop covers the contract instead of sampling it.

## Deliberately not done

`net_outline_uses_each_edges_own_thickness_not_a_neighbours` builds the same fixture inline. Sharing it would be the tidier codebase, but it is a test this change does not otherwise touch. The new helper's doc records the coupling instead: retuning either fixture's halves means retuning both, because each test's identity-only-survivor argument depends on them staying pairwise distinct.

## Note for whoever reads the issue

It cites `rust/processing/src/space_dcel/`. The file is `rust/geometry/src/space_dcel/mod.rs`.

## Verification

```
workspace 1983 passed, 0 failed (1981 before, +2)
clippy --workspace --all-targets -D warnings clean
```

Test-only diff, no production code changed.