### PR TITLE
docs(agents): the contributor check and the session check are different

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,11 @@ report that you bounded it. Mutate the halves separately; they fail differently
 Before touching an issue:
 
 1. `gh issue view <n> --json assignees,title` — **if someone else is assigned, it is theirs.** See "Helping on someone else's issue" below for the two ways that changes.
-2. `gh pr list --search "<n>"` — an open PR referencing the issue is a claim even when nobody is assigned.
+2. Look for an open PR on it. `gh pr list --search "<n>"` is a TEXT search: it
+   matches comment bodies, so it both misses linked PRs that never mention the
+   number and returns unrelated ones that happen to contain it. Treat a hit as a
+   reason to look, not as an answer, and confirm by opening the PR. The linked-PR
+   list on the issue page is authoritative where the two disagree.
 3. If both are clear, `gh issue edit <n> --add-assignee <you>` **before** writing code, not when you open the PR. An assignment made at PR time claims nothing; the window it needed to cover has already closed.
 
 Check again immediately before opening the PR. A claim can appear while you work, and the second check is the cheap one.
@@ -226,9 +230,17 @@ the claim appears.** Both have sunk work, both can reasonably feel they should
 be the one to finish, and the race is usually settled by whoever opens a PR
 first, which rewards speed over ownership.
 
-**The assignee decides. The other stops immediately** rather than racing to open
-first, and hands over what they have as a comment or a patch on the assignee's
-PR. If nobody is assigned yet, the one who claimed first decides.
+**The session named in the earliest claim comment decides. The other stops
+immediately** rather than racing to open first, and hands over what it has as a
+comment or a patch on that session's PR.
+
+"The assignee decides" is not usable here, because the assignee field holds one
+shared account and cannot name a session. The claim comment can, which is the
+other half of why it is required above. If no claim comment exists, ask on the
+issue rather than inferring from the field.
+
+An outside contributor's PR still takes precedence over any internal claim,
+however early. They cannot see our claims and are not bound by them.
 
 Stopping mid-build is cheap. Two finished implementations of the same thing is
 not, and neither is the conversation about which one lands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,60 @@ Before touching an issue:
 
 Check again immediately before opening the PR. A claim can appear while you work, and the second check is the cheap one.
 
+### Every agent is the same GitHub account
+
+`gh issue edit --add-assignee` cannot tell two agents apart, because they all
+push and assign as the **same account**. An issue assigned to that account
+means *somebody has claimed this*. It does **not** mean *you* claimed it, and
+you cannot tell which from the assignee field.
+
+So an assignment to your own account is a claim by someone else until you can
+show otherwise. **Leave a claim comment as well**, naming the session, so the
+next agent can tell:
+
+    gh issue comment <n> --body "Claiming this. Session <id>, branch <name>."
+
+And when you find the account already assigned with no claim comment, ask on
+the issue before starting rather than reading the field as your own.
+
+Note this is about OUR sessions only. An outside contributor has their own
+account, so the field says what it looks like it says for them.
+
+### The contributor check and the session check are different checks
+
+Doing one does not do the other, and the assignee field cannot cover both.
+
+On #3012 the account was self-assigned at 14:12:52 and a PR for the same issue
+appeared 47 minutes later. The natural reading was another session ignoring the
+claim. It was not: **the PR came from an outside contributor**, who has no
+reason to know or care about an internal assignment, and for whom the repo's
+existing rules already apply (look for their PR before starting, external work
+takes precedence, never push to their branch).
+
+The session that self-assigned never ran `gh pr list --search 3012`. No
+assignee field, however precise about sessions, would have helped: **no session
+held it.** Only the PR search would have.
+
+So run both, every time:
+
+    gh issue view <n> --json assignees      # is one of us on it
+    gh pr list --search "<n>"               # is anyone at all on it
+
+### When you collide mid-flight
+
+The checks above cover noticing **before** you start and noticing **after** you
+finish. The expensive case is neither: **both of you are already half-built when
+the claim appears.** Both have sunk work, both can reasonably feel they should
+be the one to finish, and the race is usually settled by whoever opens a PR
+first, which rewards speed over ownership.
+
+**The assignee decides. The other stops immediately** rather than racing to open
+first, and hands over what they have as a comment or a patch on the assignee's
+PR. If nobody is assigned yet, the one who claimed first decides.
+
+Stopping mid-build is cheap. Two finished implementations of the same thing is
+not, and neither is the conversation about which one lands.
+
 ### Helping on someone else's issue
 
 Helping is welcome. **Taking over is not.** Two things make it help:


### PR DESCRIPTION
#3040 landed the claiming rule this morning. This adds three clauses it was missing, and **corrects the incident I first used to justify one of them.**

## What I got wrong, first

I originally wrote this up as a session collision: issue #3012 self-assigned at 14:12:52, a PR for it 47 minutes later, both under the `louistrue` account, therefore the assignee field cannot distinguish sessions.

**It was not a session collision.** #3043 came from an **outside contributor** (`BIMvoice`, a User account, Petru Conduraru). They have their own account, no reason to know about an internal assignment, and the repo's existing rules already cover them: look for their PR before starting, external work takes precedence, never push to their branch.

I checked this only because the session I first accused of it checked my attribution and pushed back. Getting it wrong in a rule *about attribution* would have been a poor place to be sloppy.

## 1. The contributor check and the session check are different checks

This is what #3012 actually demonstrates. The session that self-assigned **never ran `gh pr list --search 3012`**. No assignee field, however precise about sessions, would have helped, because **no session held it**. Only the PR search would have.

```
gh issue view <n> --json assignees      # is one of us on it
gh pr list --search "<n>"               # is anyone at all on it
```

Run both, every time. Doing one does not do the other.

## 2. A shared account cannot express a claim

Still true, just not what happened here. Every one of our agents pushes and assigns as the same account, so `--add-assignee` records "somebody claimed this" and cannot record who. An assignment to your own account is a claim by **someone else** until shown otherwise, and a claim needs a comment naming the session.

Scoped explicitly to our sessions: an outside contributor has their own account and the field means what it appears to mean.

## 3. When you collide mid-flight

#3040 covers noticing **before** you start and **after** you finish. It has nothing for both sides already half-built when the claim appears — settled today by whoever opens a PR first, which rewards speed over ownership.

**The assignee decides, the other stops immediately** and hands over what it has rather than racing.

## Provenance

Clause 3 was proposed by the session that **lost** that race and deliberately did not add it itself. That same session then checked my attribution and found it wrong, which is the only reason this says "contributor" rather than "third session".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated issue-claiming guidance to require confirmation of PR search results against the issue’s linked PRs.
  - Added requirements to record the session identifier and branch in issue comments.
  - Clarified mandatory checks for contributor assignments and open pull requests.
  - Defined ownership rules for competing claims, including priority for the earliest valid claim and outside contributor pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->