### PR TITLE
fix(drawing-2d): the title block's scale bar was wrong at every scale

### DIFF
--- a/.changeset/scale-bar-reciprocal-units.md
+++ b/.changeset/scale-bar-reciprocal-units.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/drawing-2d": patch
+---
+
+The title block's scale bar was labelled wrong on every export, at every scale.
+
+`effectiveScaleFactor` is millimetres per metre and `scale.factor` is the N of 1:N. They are reciprocal, the renderer divided by whichever it was handed, and `useDrawingExport` hands it the former on every export. A 5 m bar read 0.5 m at 1:100, and 0.1 m at 1:500 where 25 m is right.
+
+A bar too big for its title block now shrinks to a round distance it can honestly span, rather than being clamped to the cell and having its label rounded afterwards — a 120mm preset capped a 5m bar at 3.6m and printed "4m".
+
+One behaviour worth knowing about: on a sheet whose drawing is shrunk to fit by roughly 1000x or more (a ~500 m model at 1:1), no round distance both fits the title-block cell and draws segments wide enough to survive rounding, so the scale bar is omitted. Previously that case drew a cell-filling bar labelled with a nonsense distance, so omitting it is the better outcome — but it is a bar disappearing where one used to be.
+
+Also: a degenerate division count no longer overflows the bar or emits an 11MB group; a NaN or negative `heightMm` no longer reaches the emitted `height=` attribute; and a non-positive, NaN or infinite length or scale draws nothing instead of `<rect width="-10.00">`.

--- a/packages/drawing-2d/src/sheet/scale-bar-ladder.test.ts
+++ b/packages/drawing-2d/src/sheet/scale-bar-ladder.test.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The shared nice-length ladder and the label-exactness predicate.
+ *
+ * These moved here so the sheet's "what length should this bar default to"
+ * (`calculateOptimalScaleBarLength`, used by `sheetSlice`) and the title
+ * block's "largest one that fits this cell" cannot disagree about what "nice"
+ * means. `calculateOptimalScaleBarLength` had NO test before that move, and
+ * the move changes its output — so it gets one here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  NICE_BAR_LENGTHS_M,
+  barLabelIsExact,
+  calculateOptimalScaleBarLength,
+  formatBarLabel,
+} from './scale-bar-types.js';
+
+// The renderer's own formatter, imported rather than reimplemented. A private
+// copy here would agree with itself no matter how the renderer changed, which
+// is an oracle that cannot disagree with what it checks.
+const format = formatBarLabel;
+
+describe('the shared bar-length ladder', () => {
+  it('every entry survives its own label formatting', () => {
+    // This is the property the snap depends on to promise an exact label, so a
+    // new entry has to keep it. 0.15 would print "15cm" correctly; 0.125 would
+    // print "13cm" and lie.
+    for (const m of NICE_BAR_LENGTHS_M) {
+      expect(barLabelIsExact(m), `barLabelIsExact(${m})`).toBe(true);
+      const printed = format(m);
+      const parsed = printed.endsWith('cm')
+        ? Number(printed.slice(0, -2)) / 100
+        : Number(printed.slice(0, -1));
+      expect(parsed, `${m} prints as ${printed}`).toBeCloseTo(m, 9);
+    }
+  });
+
+  it('is ascending and reaches low enough for 1:1', () => {
+    for (let i = 1; i < NICE_BAR_LENGTHS_M.length; i++) {
+      expect(NICE_BAR_LENGTHS_M[i]).toBeGreaterThan(NICE_BAR_LENGTHS_M[i - 1]);
+    }
+    // The binding number is 36, not 50: `maxBarWidth` is
+    // `min(width * 0.3, 50)` and the shipped `compact` preset is 120 mm wide.
+    // Asserting against 50 passes with a 0.05 floor while 1:1 on that preset
+    // draws no bar at all, which is the regression this is here to stop.
+    expect(NICE_BAR_LENGTHS_M[0] * 1000).toBeLessThanOrEqual(36);
+  });
+});
+
+describe('formatBarLabel', () => {
+  it('prints the literal strings the renderer is expected to emit', () => {
+    // Literals, not a round trip. The round-trip check above parses whatever
+    // unit was emitted, so it reads "500cm" for a 5 m bar as perfectly honest —
+    // it cannot see the cm/m threshold moving. These can.
+    expect(formatBarLabel(0.02)).toBe('2cm');
+    expect(formatBarLabel(0.5)).toBe('50cm');
+    expect(formatBarLabel(1)).toBe('1m');
+    expect(formatBarLabel(5)).toBe('5m');
+    expect(formatBarLabel(1000)).toBe('1000m');
+  });
+});
+
+describe('barLabelIsExact', () => {
+  it('rejects lengths that would print a rounded lie', () => {
+    // Tolerant enough for the ladder's own float artefacts, strict enough to
+    // reject a value half a millimetre off. The old form used
+    // `Math.round(m * 1000) / 10`, which tolerated ±0.5 mm and let 0.0201
+    // through to print "2cm" over a bar 0.1 mm too long.
+    expect(barLabelIsExact(0.02)).toBe(true);
+    expect(barLabelIsExact(0.0201)).toBe(false);
+    expect(barLabelIsExact(2.5)).toBe(false);
+    expect(barLabelIsExact(3.6)).toBe(false);
+  });
+
+  it('rejects a length too small to print as a whole centimetre', () => {
+    // Anything under 0.005 m rounds to zero centimetres, which IS an integer,
+    // so the old predicate called it exact and the renderer drew a 0.4 mm bar
+    // labelled "0cm".
+    for (const m of [0.0004, 0.001, 0.004, 0.00499]) {
+      expect(barLabelIsExact(m), `${m}`).toBe(false);
+    }
+    expect(barLabelIsExact(0.01)).toBe(true);
+
+    // The `>= 1` centimetre floor exists for THIS, and only this: a length so
+    // small that it IS within the epsilon of zero centimetres. Everything
+    // between here and 1 cm is already rejected by the epsilon itself, since
+    // 0.4 cm is nowhere near an integer. Without the floor this draws a
+    // zero-length bar labelled "0cm".
+    // Only 1e-12 actually reaches the floor: 1e-10 m is 1e-8 cm and 1e-9 m is
+    // 1e-7 cm, both of which exceed the 1e-9 epsilon and are rejected before
+    // the floor is consulted. Keeping all three, with this note, so a later
+    // trim to "one representative" does not keep 1e-9 and silently drop the
+    // only floor coverage in the suite.
+    for (const m of [1e-12, 1e-10, 1e-9]) {
+      expect(barLabelIsExact(m), `${m}`).toBe(false);
+    }
+  });
+
+  it('rejects non-positive and non-finite', () => {
+    // -5 formats to "-500cm" perfectly happily, which is why the predicate has
+    // to say so rather than leaving it to a caller's sign check.
+    for (const m of [0, -5, -0.02, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(barLabelIsExact(m), `${m}`).toBe(false);
+    }
+  });
+});
+
+describe('calculateOptimalScaleBarLength', () => {
+  it('returns a usable length across the shipped scales', () => {
+    // It had no test, and sharing the ladder changed its output: adding 0.02
+    // and 0.05 turned three previously-0 results into real lengths, because
+    // the old list bottomed out at 0.1 and fell through to
+    // `Math.round(modelLength)`. A 0 default means the sheet asks for a bar of
+    // no length, which the renderer then declines to draw.
+    for (const scaleFactor of [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000]) {
+      for (const maxLengthMm of [36, 50, 80, 200]) {
+        const m = calculateOptimalScaleBarLength(scaleFactor, maxLengthMm);
+        expect(m, `1:${scaleFactor} in ${maxLengthMm}mm`).toBeGreaterThan(0);
+        expect(barLabelIsExact(m), `1:${scaleFactor} in ${maxLengthMm}mm -> ${m}`).toBe(true);
+      }
+    }
+  });
+
+  it('can still return a non-ladder value from its rounding fallback', () => {
+    // The 40 cells above all match a ladder entry, so the `Math.round` fallback
+    // never runs there — asserting "never 0" over them would have been a claim
+    // about a branch the test does not reach. It IS reachable with a small
+    // enough paper budget, and it returns 0 there.
+    expect(calculateOptimalScaleBarLength(1, 16)).toBe(0);
+    expect(barLabelIsExact(calculateOptimalScaleBarLength(1, 16))).toBe(false);
+    // Which the renderer then declines to draw rather than emitting a bar of
+    // no length — the two halves agree about what an unusable length is.
+  });
+});

--- a/packages/drawing-2d/src/sheet/scale-bar-types.ts
+++ b/packages/drawing-2d/src/sheet/scale-bar-types.ts
@@ -42,6 +42,87 @@ export const DEFAULT_SCALE_BAR: ScaleBarConfig = {
 };
 
 /**
+ * Round distances a scale bar is allowed to span, ascending.
+ *
+ * Shared by the two things that pick a bar length — the sheet's default
+ * ("what should this bar be?") and the title-block renderer's snap ("largest
+ * one that fits this cell") — so they cannot disagree about what "nice" means.
+ * They were separate literals with identical contents, which is one edit away
+ * from divergence.
+ *
+ * Every entry survives the printed label's formatting exactly: whole
+ * centimetres below 1 m, whole metres above. That is the property that makes
+ * the snap able to promise an exact label, so a new entry has to keep it —
+ * 0.15 would print "15cm" correctly but 0.125 would print "13cm" and lie.
+ *
+ * Reaches 0.02 because `maxBarWidth` is `min(width * 0.3, 50)`. On the shipped
+ * compact preset (120 mm) that is 36 mm, and stopping the ladder at 0.1 left
+ * both 1:1 and 1:2 with no bar at all. At the full 50 mm only 1:1 fails, since
+ * 0.1 m at 1:2 is exactly 50 mm — so 36 is the binding number, which is what
+ * `scale-bar-ladder.test.ts` asserts against.
+ */
+export const NICE_BAR_LENGTHS_M: readonly number[] = [
+  0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000,
+];
+
+/**
+ * Whether `m` survives the scale bar's label formatting without lying:
+ * whole centimetres below 1 m, whole metres above.
+ */
+export function barLabelIsExact(m: number): boolean {
+  // States the contract explicitly. The arithmetic below happens to reject all
+  // of these too — -5 fails the `>= 1` floor, NaN and Infinity fail because
+  // `Math.abs(NaN - NaN)` is not `< 1e-9` — so removing this line changes no
+  // test. It is kept as documentation a reader does not have to derive, not as
+  // a load-bearing check.
+  if (!(m > 0) || !Number.isFinite(m)) return false;
+  // Symmetric epsilon on both branches. `Number.isInteger` alone is too strict
+  // for the float artefacts the ladder itself carries (`0.02 * 100` is
+  // 2.0000000000000004), and `Math.round(m * 1000) / 10` was too loose in the
+  // other direction: it tolerates ±0.5 mm, so 0.0201 m passed and printed
+  // "2cm" over a bar 0.1 mm longer than that.
+  //
+  // The `>= 1` is what stops a sub-centimetre length passing. Without it,
+  // anything under 0.005 m rounds to zero centimetres, which is an integer, so
+  // it was "exact" — and drew a 0.4 mm bar labelled "0cm". A bar claiming to
+  // span no distance is less honest than no bar.
+  if (m < 1) {
+    const cm = m * 100;
+    return Math.abs(cm - Math.round(cm)) < 1e-9 && Math.round(cm) >= 1;
+  }
+  return Math.abs(m - Math.round(m)) < 1e-9;
+}
+
+/**
+ * Smallest SEGMENT worth drawing, in millimetres of paper.
+ *
+ * Segment widths are emitted through `toFixed(2)`, so anything under 0.005 mm
+ * prints `width="0.00"` — a label with no bar under it. That is reachable: at
+ * 1:1 on a 760 m model the transform gives 0.42 mm per metre, so a 5 cm bar is
+ * 0.02 mm wide and all five of its segments print zero. The old clamp-to-cell
+ * hid this by always stretching the bar to fill the cell; choosing the distance
+ * first removed that accident, so the floor has to be explicit.
+ *
+ * Deliberately a per-SEGMENT bound rather than a whole-bar one. A blanket bar
+ * minimum of 5 mm rejects a perfectly legible 4 mm bar at 1:500, which is a
+ * real configuration; what actually fails is a segment rounding to zero, and
+ * that is what this measures. 0.01 mm is twice the rounding threshold.
+ *
+ * A correction to an earlier version of this note, because it misattributed
+ * the mechanism: the old `Math.min(barLengthMm, maxBarWidth)` clamp could not
+ * ENLARGE anything. What filled the cell was the reciprocal-units bug — at
+ * 0.42 mm per metre the old formula computed `0.05 * 1000 / 0.42` = 119 mm and
+ * the clamp capped that at 50. So one bug was hiding another, which is why
+ * fixing the arithmetic is what exposed this.
+ */
+export const MIN_BAR_SEGMENT_MM = 0.01;
+
+/** The end label the scale bar prints for a given distance. */
+export function formatBarLabel(m: number): string {
+  return m < 1 ? `${(m * 100).toFixed(0)}cm` : `${m.toFixed(0)}m`;
+}
+
+/**
  * Calculate optimal scale bar length based on drawing scale
  * Returns length in model units (meters)
  *
@@ -58,12 +139,7 @@ export function calculateOptimalScaleBarLength(
   // Convert paper length to model units (meters)
   const modelLength = (targetPaperLengthMm * scaleFactor) / 1000;
 
-  // Round to nice numbers for readability
-  const niceNumbers = [
-    0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000,
-  ];
-
-  for (const n of niceNumbers) {
+  for (const n of NICE_BAR_LENGTHS_M) {
     if (n >= modelLength * 0.5 && n <= modelLength * 1.5) {
       return n;
     }

--- a/packages/drawing-2d/src/sheet/title-block-renderer.ts
+++ b/packages/drawing-2d/src/sheet/title-block-renderer.ts
@@ -13,6 +13,7 @@
  */
 
 import type { TitleBlockConfig, RevisionEntry, TitleBlockPosition } from './title-block-types.js';
+import { NICE_BAR_LENGTHS_M, barLabelIsExact, formatBarLabel, MIN_BAR_SEGMENT_MM } from './scale-bar-types.js';
 import type { ScaleBarConfig, NorthArrowConfig } from './scale-bar-types.js';
 import type { DrawingScale } from '../styles.js';
 
@@ -387,20 +388,129 @@ function renderScaleBarInTitleBlock(
 ): string {
   let svg = '    <g id="title-block-scale-bar">\n';
 
-  // Use effective scale factor if provided (for dynamic scaling), otherwise use configured scale
-  const scaleFactor = effectiveScaleFactor ?? scale.factor;
+  // These two arguments are in RECIPROCAL units, and this function used to
+  // substitute one for the other in a single formula:
+  //
+  //   effectiveScaleFactor  millimetres per metre  (10 at 1:100)
+  //   scale.factor          the N of 1:N           (100 at 1:100)
+  //
+  // `calculateDrawingTransform` returns the former — `sheet-types.ts` uses it
+  // as `drawingWidth * scaleFactor` to get millimetres — its own doc says "mm
+  // per meter", and `useDrawingExport` passes it on EVERY export. So the branch
+  // the exporter always takes was the wrong one, and every exported bar was
+  // labelled wrong at every scale: a 5 m bar read 0.5 m at 1:100, and 0.1 m at
+  // 1:500 where 25 m is right. Normalise to one unit so there is one formula.
+  const mmPerMetre = effectiveScaleFactor ?? 1000 / scale.factor;
 
   // Position: bottom left with small margin
   const barX = x + 3;
   const barY = y + h - 8; // 8mm from bottom (leaves room for label)
   const maxBarWidth = Math.min(w * 0.3, 50);
-  const barLengthMm = (scaleBar.totalLengthM * 1000) / scaleFactor;
-  const actualBarLength = Math.min(barLengthMm, maxBarWidth);
-  const barHeight = Math.min(scaleBar.heightMm, 3);
-  const actualTotalLength = (actualBarLength * scaleFactor) / 1000;
+  const barLengthMm = scaleBar.totalLengthM * mmPerMetre;
 
-  // Draw alternating bar segments
-  const divisions = scaleBar.primaryDivisions;
+  // Checked BEFORE the clamp, and the ordering is load-bearing: testing the
+  // clamped result loses the infinite case, because `Math.min(Infinity, 50)`
+  // is a perfectly finite 50.
+  //
+  // `mmPerMetre > 0` is checked SEPARATELY and is not redundant with
+  // `barLengthMm > 0`. An earlier version claimed one check on the product
+  // covered "any combination" of the two operands. It does not: two negatives
+  // cancel, so `totalLengthM: -5` with `effectiveScaleFactor: -10` gives
+  // `barLengthMm` 50 and passes every clause, after which the labels print
+  // NEGATIVE distances on a bar that draws normally. That is worse than the
+  // malformed rect this guard was written to stop, because nothing about the
+  // output looks wrong. Credit to CodeRabbit for the case and to
+  // @bimvoice-01 for relaying it.
+  //
+  // Deliberately not recording which of the sign checks in this file is
+  // load-bearing. Three versions of this paragraph did — "the snap masks
+  // this", then "this is load-bearing", then "three things reject it" — and
+  // each was a correct measurement made false by the next commit, twice by my
+  // own hand within one session and once by a revert. A mutation result is a
+  // fact about the whole program, so anything anywhere invalidates it, while
+  // it reads like a durable property. The commit message is where such a
+  // measurement belongs, pinned to a tree.
+  //
+  // Without this the bar emitted `<rect width="-10.00">`, invalid SVG dressed
+  // as a drawing. Drawing nothing is the honest degradation: a missing scale
+  // bar is visibly missing.
+  if (
+    !(mmPerMetre > 0) ||
+    !(barLengthMm > 0) ||
+    !Number.isFinite(barLengthMm) ||
+    !(maxBarWidth > 0)
+  ) {
+    return '';
+  }
+
+  // Snap to a ROUND distance that fits, rather than clamping to the cell width
+  // and rounding the label afterwards. Folding the clamp into the label is not
+  // enough on its own: the label prints to 0 dp, so a 120 mm title block (a
+  // shipped preset) caps a 5 m bar at 36 mm = 3.6 m and prints "4m" — 11% off
+  // on a printed sheet, and up to ~33% for a bar landing near 1.5 m.
+  //
+  // Choosing the distance first makes the label exact by construction.
+  //
+  // It does NOT yet make the export agree with the on-screen preview, and an
+  // earlier version of this comment claimed it did. Measured over nine common
+  // (block width x scale) pairs with the default 5 m bar, six disagree:
+  // `Drawing2DCanvas` halves/doubles from the configured length, clamps to the
+  // cell, and rounds the label from the clamped value — the same clamp-then-
+  // round shape this function just stopped doing, so at a 120 mm block and
+  // 1:100 the preview still prints "3m" over a 2.5 m bar while the export
+  // prints an exact "2m". Unifying them means moving the preview onto
+  // `NICE_BAR_LENGTHS_M` too, which is a viewer change and not this diff.
+
+  // `divisions`, bounded at BOTH ends. The low end stops 0 dividing and 2.5 drawing three
+  // segments of width L/2.5 (the loop runs while `i < 2.5`), overflowing the
+  // bar by 20%. The high end matters too: 100000 divisions emits an 11.5 MB
+  // group of 0.0005 mm rects, and 1e7 is about a gigabyte — it hangs the export
+  // rather than drawing a bad bar. Nothing legible needs more than 20.
+  const divisions = Number.isFinite(scaleBar.primaryDivisions)
+    ? Math.min(20, Math.max(1, Math.floor(scaleBar.primaryDivisions)))
+    : 1;
+
+  const requestedM = scaleBar.totalLengthM;
+  // Fits the cell AND draws segments that survive `toFixed(2)`. Without the
+  // lower bound a bar can be chosen whose segments all print `width="0.00"`
+  // under a confident label — a label with no bar, which is the dishonesty
+  // this function refuses everywhere else. Reachable at 1:1 on a large model,
+  // where the transform gives well under 1 mm per metre.
+  const fits = (m: number) =>
+    m * mmPerMetre <= maxBarWidth + 1e-9 &&
+    (m * mmPerMetre) / divisions >= MIN_BAR_SEGMENT_MM - 1e-12;
+
+  // Keep the requested length when it already fits AND already labels exactly.
+  // Snapping unconditionally shrank bars that were fine: a 4 m bar at 1:100 is
+  // 40 mm in a 50 mm cell and prints "4m" exactly, and snapping it to the
+  // nearest ladder value below halved it to 2 m for no reason.
+  let actualTotalLength: number | undefined = fits(requestedM) && barLabelIsExact(requestedM)
+    ? requestedM
+    : undefined;
+
+  if (actualTotalLength === undefined) {
+    // Otherwise take the largest round distance that fits and does not claim
+    // more than was asked for.
+    const candidates = NICE_BAR_LENGTHS_M.filter((m) => m <= requestedM + 1e-9 && fits(m));
+    actualTotalLength = candidates[candidates.length - 1];
+  }
+
+  if (actualTotalLength === undefined) {
+    // Not even the smallest round distance fits the cell. A missing bar is
+    // visibly missing; a bar labelled with a distance it does not span is not.
+    return '';
+  }
+  const actualBarLength = actualTotalLength * mmPerMetre;
+
+  // `heightMm` reaches the emitted `height=` attribute, so it needs the same
+  // treatment as the length: NaN printed `height="NaN"` on every rect and
+  // `y="NaN"` on both labels, and a negative printed `height="-5.00"`. Guarding
+  // one of two attributes that reach the SVG is not guarding.
+  const barHeight = Number.isFinite(scaleBar.heightMm)
+    ? Math.min(Math.max(scaleBar.heightMm, 0.1), 3)
+    : 3;
+
+  // Draw alternating bar segments; `divisions` was normalised above.
   const divWidth = actualBarLength / divisions;
 
   for (let i = 0; i < divisions; i++) {
@@ -419,9 +529,10 @@ function renderScaleBarInTitleBlock(
   svg += `font-family="Arial, sans-serif" font-size="${fontSize}" `;
   svg += `text-anchor="start" fill="#000000">0</text>\n`;
 
-  const endLabel = actualTotalLength < 1
-    ? `${(actualTotalLength * 100).toFixed(0)}cm`
-    : `${actualTotalLength.toFixed(0)}m`;
+  // Shared with `barLabelIsExact`, which decides whether a length CAN be
+  // printed without lying. Those two have to agree, and an inline copy here is
+  // exactly how they would stop agreeing.
+  const endLabel = formatBarLabel(actualTotalLength);
   svg += `      <text x="${(barX + actualBarLength).toFixed(2)}" y="${labelY.toFixed(2)}" `;
   svg += `font-family="Arial, sans-serif" font-size="${fontSize}" `;
   svg += `text-anchor="end" fill="#000000">${endLabel}</text>\n`;

--- a/packages/drawing-2d/src/sheet/title-block-scale-bar.test.ts
+++ b/packages/drawing-2d/src/sheet/title-block-scale-bar.test.ts
@@ -1,0 +1,258 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The title block's scale bar must mean what it says (#2731).
+ *
+ * `renderTitleBlock` takes the sheet's scale two ways and they are RECIPROCAL:
+ * `effectiveScaleFactor` is millimetres per metre (10 at 1:100), `scale.factor`
+ * is the N of 1:N (100 at 1:100). The renderer divided by whichever it was
+ * handed, and `useDrawingExport` hands it the former on every export — so every
+ * exported bar was labelled wrong at every scale.
+ *
+ * Every assertion drives `renderTitleBlock`, the entry the exporter calls, and
+ * passes `effectiveScaleFactor`, because omitting it exercises a fallback
+ * branch the real exporter never takes. Driving the right entry point is not
+ * enough; it has to be driven with the arguments the caller actually supplies.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderTitleBlock, type FrameInnerBounds } from './title-block-renderer.js';
+import { DEFAULT_SCALE_BAR, type ScaleBarConfig } from './scale-bar-types.js';
+import type { TitleBlockConfig } from './title-block-types.js';
+import type { DrawingScale } from '../styles.js';
+
+const FRAME: FrameInnerBounds = { x: 0, y: 0, width: 420, height: 297 };
+const SCALE: DrawingScale = { name: '1:100', factor: 100, useCase: 'test' };
+const TITLE_BLOCK: TitleBlockConfig = {
+  layout: 'standard', position: 'bottom-right', widthMm: 180, heightMm: 60,
+  borderWeight: 0.5, gridWeight: 0.25, fields: [], logo: null,
+  showRevisionHistory: false, maxRevisionEntries: 0,
+};
+
+function barSvg(
+  overrides: Partial<ScaleBarConfig> = {},
+  block: TitleBlockConfig = TITLE_BLOCK,
+  mmPerMetre: number | undefined = 1000 / SCALE.factor,
+): string {
+  const svg = renderTitleBlock(block, FRAME, [], {
+    scaleBar: { ...DEFAULT_SCALE_BAR, ...overrides },
+    scale: SCALE,
+    effectiveScaleFactor: mmPerMetre,
+  }).svgElements;
+  const start = svg.indexOf('<g id="title-block-scale-bar">');
+  return start < 0 ? '' : svg.slice(start, svg.indexOf('</g>', start));
+}
+
+/** Segment widths, excluding `stroke-width` which contains "width=" as a substring. */
+const widths = (svg: string) =>
+  [...svg.matchAll(/(?<!stroke-)width="([0-9.]+)"/g)].map((m) => Number(m[1]));
+
+/** The end label's distance in metres, parsed from what was actually emitted. */
+function labelledMetres(svg: string): number {
+  const all = [...svg.matchAll(/>([0-9.]+)(cm|m)<\/text>/g)];
+  const m = all[all.length - 1];
+  if (!m) throw new Error(`no end label in: ${svg.slice(0, 200)}`);
+  return m[2] === 'cm' ? Number(m[1]) / 100 : Number(m[1]);
+}
+
+/**
+ * THE property: what the bar draws on paper equals what it says it spans.
+ * Asserting the label alone would let the bar be any size; asserting the width
+ * alone would let the label say anything.
+ */
+function expectBarHonest(svg: string, mmPerMetre: number, what: string) {
+  const drawn = widths(svg).reduce((a, b) => a + b, 0);
+  // Tolerance scales with the segment count, because each `width=` is
+  // `toFixed(2)` and N of them carry up to N * 0.005 of rounding. A flat 5e-5
+  // passed only because every fixture happened to divide evenly: three
+  // segments of a 50 mm bar emit 16.67 each and sum to 50.01, which is 200x
+  // that tolerance and would have redded for a reason unrelated to the claim.
+  const segments = widths(svg).length;
+  expect(drawn, `${what}: drawn mm`).toBeCloseTo(labelledMetres(svg) * mmPerMetre, 0);
+  expect(Math.abs(drawn - labelledMetres(svg) * mmPerMetre), `${what}: within rounding`)
+    .toBeLessThanOrEqual(segments * 0.005 + 1e-9);
+}
+describe('title block scale bar means what it says (#2731)', () => {
+  it('the drawn length matches the labelled distance at every scale', () => {
+    // THE measurement property. `effectiveScaleFactor` and `scale.factor` are
+    // reciprocal and the renderer used to divide by whichever it got, so a 5 m
+    // bar read 0.5 m at 1:100 and 0.1 m at 1:500 where 25 m is right.
+    for (const [factorN, mmPerMetre] of [[50, 20], [100, 10], [200, 5], [500, 2]] as const) {
+      const wide: TitleBlockConfig = { ...TITLE_BLOCK, widthMm: 600 };
+      const svg = barSvg({ totalLengthM: 2, primaryDivisions: 4 }, wide, mmPerMetre);
+
+      expectBarHonest(svg, mmPerMetre, `1:${factorN}`);
+      // And it really is the 2 m asked for, not some other honest pairing.
+      expect(labelledMetres(svg), `labelled m at 1:${factorN}`).toBe(2);
+      // The literal string, because `labelledMetres` parses whichever unit was
+      // emitted and so reads "200cm" as honest. Only this sees the renderer
+      // drifting from the shared formatter.
+      expect(svg, `label text at 1:${factorN}`).toContain('>2m</text>');
+    }
+  });
+
+  it('the scale.factor fallback labels correctly too', () => {
+    // `effectiveScaleFactor` is optional and `renderTitleBlock` is published
+    // API, so a caller omitting it takes the OTHER half of the reciprocal fix.
+    const wide: TitleBlockConfig = { ...TITLE_BLOCK, widthMm: 600 };
+    const svg = barSvg({ totalLengthM: 2, primaryDivisions: 4 }, wide, undefined);
+    expectBarHonest(svg, 1000 / SCALE.factor, 'scale.factor fallback');
+    expect(labelledMetres(svg)).toBe(2);
+  });
+
+  it('a bar too big for its block shrinks to a ROUND distance it can honestly span', () => {
+    // The earlier version of this fix clamped to the cell width and folded the
+    // clamp into the label — but the label prints to 0 dp, so a 60 mm block
+    // capping a 5 m bar at 18 mm (1.8 m) still printed "2m". Rounding undid the
+    // fold. Choosing a round distance FIRST makes the label exact instead.
+    const mmPerMetre = 1000 / SCALE.factor;
+    // 180 and 600 would be the same case: min(w * 0.3, 50) caps both at 50.
+    for (const widthMm of [60, 120, 180]) {
+      const svg = barSvg({ totalLengthM: 5, primaryDivisions: 5 }, { ...TITLE_BLOCK, widthMm });
+      expectBarHonest(svg, mmPerMetre, `${widthMm}mm block`);
+      // It fits the cell, and never claims more than was asked for.
+      const drawn = widths(svg).reduce((a, b) => a + b, 0);
+      expect(drawn, `${widthMm}mm block: fits`).toBeLessThanOrEqual(Math.min(widthMm * 0.3, 50) + 1e-6);
+      expect(labelledMetres(svg), `${widthMm}mm block: not inflated`).toBeLessThanOrEqual(5);
+    }
+    // Control: a roomy block still shows the full 5 m, so the above is not
+    // passing by shrinking everything to nothing.
+    expect(labelledMetres(barSvg({ totalLengthM: 5, primaryDivisions: 5 }))).toBe(5);
+  });
+
+  it('a degenerate division count degrades rather than printing NaN', () => {
+    for (const primaryDivisions of [0, -3, 2.5, 100000, Number.NaN]) {
+      const svg = barSvg({ primaryDivisions });
+      // The segments must fit the bar they divide. `2.5` drew THREE segments of
+      // width L/2.5 — the loop runs while `i < 2.5` — overflowing by 20% and
+      // spilling past the cell. `100000` emitted an 11.5 MB group.
+      //
+      // Deliberately NOT asserting the absence of "NaN" or a negative label
+      // position here: an earlier version did, with comments claiming the
+      // unguarded code produced those. Run against the parent commit it does
+      // not — 0 and -3 simply emit no rects and label normally. Those
+      // assertions could not fail, and the comments justifying them were
+      // false. Width is the only thing that discriminates.
+      expectBarHonest(svg, 1000 / SCALE.factor, `divisions=${primaryDivisions}`);
+      const drawn = widths(svg).reduce((a, b) => a + b, 0);
+      expect(drawn, `total segment width for divisions=${primaryDivisions}`)
+        .toBeLessThanOrEqual(Math.min(TITLE_BLOCK.widthMm * 0.3, 50) + 1e-6);
+      expect(svg.match(/<rect/g)?.length ?? 0, `rect count for ${primaryDivisions}`)
+        .toBeLessThanOrEqual(20);
+    }
+  });
+
+  it('a degenerate length or an unusable block draws nothing, not negative-width rects', () => {
+    for (const totalLengthM of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(barSvg({ totalLengthM }), `totalLengthM=${totalLengthM}`).toBe('');
+    }
+    for (const bad of [0, -10, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(barSvg({}, TITLE_BLOCK, bad), `scale=${bad}`).toBe('');
+    }
+
+    // BOTH operands negative. This is the case a single-negative fixture
+    // cannot reach: -5 metres at -10 mm/m multiplies to a perfectly positive
+    // 50 mm, so it passes a guard that only checks the product, and the labels
+    // then print NEGATIVE distances on a bar that draws normally. Worse than
+    // the malformed rect the guard exists to stop, because nothing about the
+    // output looks wrong.
+    //
+    // What this pins is the BEHAVIOUR — no bar, rather than one that draws
+    // normally and labels "-500cm". Several checks in the source can each
+    // produce that outcome, and which of them is load-bearing has changed
+    // three times in this file's short history, so naming one here would be a
+    // claim with a shorter shelf life than the test.
+    for (const [totalLengthM, mmPerMetre] of [[-5, -10], [-0.5, -20], [-1, -1000]] as const) {
+      expect(
+        barSvg({ totalLengthM }, TITLE_BLOCK, mmPerMetre),
+        `both negative: ${totalLengthM}m at ${mmPerMetre}mm/m`,
+      ).toBe('');
+    }
+    expect(barSvg({}, { ...TITLE_BLOCK, widthMm: 0 })).toBe('');
+    // Control: a sane config DOES draw one, so the above is not passing
+    // because the fixture never produces a bar.
+    expect(barSvg()).toContain('<rect');
+  });
+
+  it('a degenerate heightMm does not reach the emitted attributes', () => {
+    // The guard covered the two operands of the LENGTH and stopped there, so
+    // `heightMm` still went out raw: NaN printed `height="NaN"` on every rect
+    // and `y="NaN"` on both labels, and -5 printed `height="-5.00"`. The same
+    // "invalid SVG dressed as a drawing" the length guard exists to prevent,
+    // one line below it.
+    for (const heightMm of [Number.NaN, -5, 0, Number.POSITIVE_INFINITY, 999]) {
+      const svg = barSvg({ heightMm });
+      expect(svg, `heightMm=${heightMm}`).not.toContain('NaN');
+      expect(svg, `heightMm=${heightMm}`).not.toContain('Infinity');
+      expect(svg, `heightMm=${heightMm}`).not.toMatch(/height="-/);
+      for (const h of [...svg.matchAll(/height="([0-9.]+)"/g)].map((m) => Number(m[1]))) {
+        expect(h, `heightMm=${heightMm}: bar height`).toBeGreaterThan(0);
+        expect(h, `heightMm=${heightMm}: capped to the cell`).toBeLessThanOrEqual(3);
+      }
+    }
+  });
+
+  it('still draws a bar at the scales where the ladder nearly runs out', () => {
+    // The snap's "nothing fits" branch had no test, which is how a regression
+    // shipped in the first version of this fix: `maxBarWidth` caps at 50 mm, so
+    // at 1:1 (1000 mm per metre) a 0.1 m bar needs 100 mm. With the ladder
+    // stopping at 0.1, BOTH 1:1 and 1:2 on the shipped compact preset produced
+    // no scale bar at all — a silent regression on two listed scales.
+    const compact: TitleBlockConfig = { ...TITLE_BLOCK, widthMm: 120 };
+    for (const [label, mmPerMetre, block] of [
+      ['1:1 compact', 1000, compact],
+      ['1:1 standard', 1000, TITLE_BLOCK],
+      ['1:2 compact', 500, compact],
+      ['1:5 compact', 200, compact],
+    ] as const) {
+      const svg = barSvg({ totalLengthM: 0.1 }, block, mmPerMetre);
+      expect(svg, `${label}: must still draw a bar`).not.toBe('');
+      expectBarHonest(svg, mmPerMetre, label);
+    }
+  });
+
+  it('does not shrink a bar that already fits and already labels exactly', () => {
+    // Snapping unconditionally halved bars that were fine: 4 m at 1:100 is
+    // 40 mm in a 50 mm cell and prints "4m" exactly, and the ladder's nearest
+    // value below is 2 m. `totalLengthM` is a public config field, so an
+    // off-ladder-but-exact request is a caller's legitimate choice.
+    // Each pair is a length that FITS its scale's 50 mm cell: 4 m at 10 mm/m is
+    // 40 mm, 40 m at 1 mm/m is 40 mm. A length that does not fit is supposed to
+    // snap, so using one here would test the opposite of the claim.
+    for (const [requested, mmPerMetre] of [[3, 10], [4, 10], [30, 1], [40, 1]] as const) {
+      const svg = barSvg({ totalLengthM: requested }, { ...TITLE_BLOCK, widthMm: 600 }, mmPerMetre);
+      expect(labelledMetres(svg), `${requested}m at ${mmPerMetre}mm/m kept`).toBe(requested);
+      expectBarHonest(svg, mmPerMetre, `${requested}m`);
+    }
+    const mmPerMetre = 1000 / SCALE.factor;
+    // Control: one that does NOT label exactly still snaps down rather than
+    // rounding its label, which is the defect this whole change is about.
+    const svg = barSvg({ totalLengthM: 3.6 }, { ...TITLE_BLOCK, widthMm: 600 }, mmPerMetre);
+    expect(labelledMetres(svg), '3.6m snaps rather than printing "4m"').toBe(2);
+  });
+
+  it('never draws a bar whose segments round away to nothing', () => {
+    // Removing the clamp-to-cell removed the only thing that kept the drawn bar
+    // visible. Segment widths go out through `toFixed(2)`, so anything under
+    // 0.005 mm prints `width="0.00"` — a confident label with no bar under it,
+    // which is the same dishonesty the length guard exists to stop.
+    //
+    // Reachable at 1:1 on a large model: the transform gives well under 1 mm
+    // per metre there, so a 5 cm bar is 0.02 mm wide and all five of its
+    // segments print zero. Measured on the parent of this fix.
+    for (const mmPerMetre of [0.42, 0.1, 0.02, 0.001]) {
+      const svg = barSvg({ totalLengthM: 0.05 }, TITLE_BLOCK, mmPerMetre);
+      if (svg === '') continue; // declining to draw is the honest outcome
+      expect(svg, `${mmPerMetre}mm/m: no zero-width segments`).not.toMatch(/(?<!stroke-)width="0\.00"/);
+      for (const w of widths(svg)) {
+        expect(w, `${mmPerMetre}mm/m: segment width`).toBeGreaterThan(0);
+      }
+      expectBarHonest(svg, mmPerMetre, `${mmPerMetre}mm/m`);
+    }
+    // Control: at a sane scale the same config DOES draw, so the loop above is
+    // not passing by skipping every case.
+    expect(barSvg({ totalLengthM: 0.05 }, TITLE_BLOCK, 200)).toContain('<rect');
+  });
+});


### PR DESCRIPTION
**Every exported scale bar has been labelled wrong, at every scale.**

`renderTitleBlock` takes the sheet's scale two ways and they are reciprocal:

```
effectiveScaleFactor   millimetres per metre  (10 at 1:100)
scale.factor           the N of 1:N           (100 at 1:100)
```

The renderer divided by whichever it was handed, and `useDrawingExport` hands it the former on **every** export:

```
scale    bar drawn   labelled   correct
1:50      50 mm       1.0 m      2.5 m
1:100     50 mm       0.5 m      5 m
1:200     50 mm       0.3 m      10 m
1:500     50 mm       0.1 m      25 m
```

## Scope changed under this PR, and the history matters

This began as the shared-renderer half of #2731 item 3. **#3055 resolved that item the other way**, deleting the uncalled `renderScaleBar`/`renderNorthArrow` pair, so the branch was reset to main and reworked. That decision stands and the sharing work is dropped.

What survives is the part a byte-compare cannot catch. #3055's before/after compare correctly proves that deleting dead code changes no bytes; it cannot show whether the surviving bytes are right, and they were not.

## Also fixed, all in the one function

- **A bar too big for its cell now shrinks to a round distance it can honestly span.** Folding the clamp into the label was not enough: labels print to whole metres, so the shipped 120 mm preset capped a 5 m bar at 3.6 m and printed **"4m"**. Rounding undid the fold. Choosing the distance first makes the label exact by construction.
- **Segments can no longer round away to nothing.** Removing the clamp removed the only thing keeping the bar *visible* — at 1:1 on a 760 m model the transform gives 0.42 mm/m, so a 5 cm bar is 0.02 mm wide and every segment printed `width="0.00"` under a confident `>5cm</text>`. The bound is per-segment, not per-bar, because a blanket 5 mm minimum rejects a legible 4 mm bar at 1:500.
- **`primaryDivisions` bounded at both ends.** `2.5` drew three segments of width `L/2.5` (the loop runs while `i < 2.5`), overflowing by 20%; `100000` emitted 11.5 MB.
- **`heightMm` guarded** — it reached the emitted `height=` attribute and printed `height="NaN"` on every rect.
- **Two negatives cancel**, so `-5` m at `-10` mm/m passed a guard that only checked the product and printed negative distances on a normal-looking bar.
- **`barLabelIsExact` no longer calls sub-centimetre lengths exact** — anything under 0.005 m rounds to zero centimetres, which is an integer, so it drew a 0.4 mm bar labelled `"0cm"`.

## Deduplication

`NICE_BAR_LENGTHS_M`, `barLabelIsExact` and `formatBarLabel` now live in `scale-bar-types.ts`, shared with `calculateOptimalScaleBarLength` — which had **no test at all** and whose output this change alters.

## Verification

```
@ifc-lite/drawing-2d   389 passed, 0 failed
tsc --noEmit           clean
```

Eight mutations, each caught by its own test. Review also ran a 40,000-case fuzz (block width × requested length × mm-per-metre × divisions × heightMm × scale) finding zero defects, and a sweep over every paper size × three presets × eleven scales confirming a bar is drawn in every shipped configuration.

**One behaviour change worth knowing:** on a sheet shrunk to fit by ~1000x or more, no round distance both fits the cell and survives rounding, so the bar is omitted. Previously that case drew a cell-filling bar labelled with a nonsense distance.

**Known gap, stated rather than hidden:** the on-screen preview still clamps-then-rounds, so at a 120 mm block and 1:100 it prints "3m" over a 2.5 m bar while the export prints an exact "2m". Unifying them is a viewer change.

Does not close #2731 — item 3 was closed by #3055; this is a defect in what survived it.

Pre-flight: `/simplify` and `/code-review` across five rounds. Four of them found real defects, three of which were regressions I introduced during the rework, including the invisible bar above.