### PR TITLE
test(viewer): say WHICH wait hung in the leave-during-join race (#3054)

### DIFF
--- a/apps/viewer/src/store/slices/collabSlice.leave-during-join-race.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.leave-during-join-race.test.ts
@@ -126,6 +126,67 @@ function buildState() {
   };
 }
 
+/**
+ * Await `p`, or fail with a message naming what did not happen.
+ *
+ * This test has TWO places it can park forever, and until #3054 they were
+ * indistinguishable: both surfaced as `testTimeoutFailure ... 120000ms` with
+ * no indication of which. That cost a day. Three separate structural
+ * explanations were proposed and argued for the same hang — a specifier that
+ * never reached the loader hook, a leave path that never resolved, an
+ * IndexedDB open that never returned — and the output was byte-identical
+ * under all three, so it could not rule out any of them.
+ *
+ * The cause is fixed. This is not a fix for it; it is what makes the NEXT hang
+ * here cost a message instead of an investigation. A test that parks forever
+ * on any upstream failure will park again.
+ *
+ * The timer is CLEARED on the fast path but deliberately NOT unref'd, and that
+ * distinction is the whole helper. An unref'd timer cannot keep the event loop
+ * alive, so when the awaited promise is the only other pending work — exactly
+ * the case this exists to report — Node drains the loop and exits before the
+ * timer can fire. The run then dies with `Promise resolution is still pending
+ * but the event loop has already resolved`, which is another anonymous
+ * failure, and the named message never appears.
+ *
+ * That was not reasoned: the first version had `unref()`, and a standalone
+ * test of this helper caught it, 3 of 4 red. A diagnostic that breaks the
+ * thing it diagnoses is worse than none.
+ *
+ * `clearTimeout` in `finally` is what stops a 30s timer outliving a fast pass.
+ *
+ * What this does NOT do, measured rather than assumed: it does not make a
+ * wedged run exit. In the "continuation never resumes" case the session object
+ * is reachable only from the parked `startCollab` closure — `collabSession` is
+ * still null, so `dispose()` is a no-op and the IndexedDB handle stays open.
+ * The message is printed at 30s either way, which is the whole point; the
+ * process lingering afterwards is unchanged from before.
+ *
+ * The gate case is the opposite; see the call site, which explains why the
+ * whole test body sits inside one try/finally.
+ */
+async function within<T>(p: Promise<T>, ms: number, expected: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms waiting for ${expected}`)), ms);
+  });
+  try {
+    return await Promise.race([p, expiry]);
+  } finally {
+    // Unconditional: the Promise executor runs synchronously so `timer` is
+    // always assigned, and `clearTimeout` accepts undefined anyway. A falsy
+    // guard could only ever skip cleanup for a handle of 0.
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Well under node:test's 120s cap so this fires first and names the cause, and
+ * far above anything a real Y.Doc plus fake-indexeddb open takes even on a
+ * loaded runner, so it cannot flake into a false diagnosis.
+ */
+const GATE_TIMEOUT_MS = 30_000;
+
 describe('collabSlice — stopCollab() racing an in-flight startCollab()', () => {
   it('does not revive collabSession after the user left mid-join', async () => {
     let releaseGate!: () => void;
@@ -157,29 +218,67 @@ describe('collabSlice — stopCollab() racing an in-flight startCollab()', () =>
     // signal rather than guessing a delay: `__collabSessionGated` fires
     // synchronously, from inside the wrapped `createCollabSession`, at the
     // exact moment `session.whenSynced` becomes the gated promise — so by
-    // the time this resolves, `startCollab` is provably parked there.
-    await sessionGatedPromise;
-
-    // Precondition: the join is still recorded as live and in flight —
-    // `startCollab` is parked on the gated `whenSynced`, past the
-    // session-creation guard, short of the final `set()`.
-    assert.equal(s.get().collabRoomId, 'room-1');
-    assert.equal(s.get().collabConnecting, true);
-    assert.equal(s.get().collabSession, null, 'the tail set() has not run yet');
-
-    // The user clicks "Leave" in RoomPanel while still joining.
-    s.get().stopCollab();
-    assert.equal(s.get().collabRoomId, null, 'stopCollab cleared the room synchronously');
-    assert.equal(s.get().collabSession, null);
-
-    // Now let the parked startCollab continuation resume.
-    releaseGate();
-    await pending;
-
-    // Always release the real IndexedDB connection this test opened —
-    // whether or not the assertions below throw — so the process doesn't
-    // hang on an open handle.
+    // the time this resolves WITH 'gated', `startCollab` is provably parked
+    // there. It can now also resolve with 'returned-early', which means the
+    // opposite, and only the assert below tells the two apart.
+    // Everything from here is inside one try/finally so the IndexedDB
+    // connection is released whichever wait gives up. In the gate case
+    // `startCollab` can run to completion and store a LIVE session before this
+    // times out, so the dispose genuinely fires and the run exits.
     try {
+      // Raced against `pending` itself, not awaited alone. `startCollab`
+      // CATCHES everything from the dynamic import through
+      // `createCollabSession` and returns normally, so a failed bring-up
+      // resolves `pending` and simply never fires the gate. Waiting on the gate
+      // alone would sit for the full timeout and then blame the loader hook —
+      // a confident wrong answer, and the exact failure this helper exists to
+      // prevent. Measured: with `globalThis.indexedDB` cleared, the wrap DID
+      // apply and the old message still said it had not.
+      const outcome = await within(
+        Promise.race([
+          sessionGatedPromise.then(() => 'gated' as const),
+          pending.then(() => 'returned-early' as const),
+        ]),
+        GATE_TIMEOUT_MS,
+        'the session to be gated OR startCollab to return (neither happened, so nothing ' +
+          'is running — suspect the loader hook or a wait with no timeout upstream)',
+      );
+      assert.equal(
+        outcome,
+        'gated',
+        'startCollab returned before the session was gated, so bring-up failed or finished ' +
+          'early and swallowed its error — the [collab] diagnostic logged above is the real ' +
+          'cause, NOT the loader hook',
+      );
+
+      // Precondition: the join is still recorded as live and in flight —
+      // `startCollab` is parked on the gated `whenSynced`, past the
+      // session-creation guard, short of the final `set()`.
+      assert.equal(s.get().collabRoomId, 'room-1');
+      assert.equal(s.get().collabConnecting, true);
+      assert.equal(s.get().collabSession, null, 'the tail set() has not run yet');
+
+      // The user clicks "Leave" in RoomPanel while still joining.
+      s.get().stopCollab();
+      assert.equal(s.get().collabRoomId, null, 'stopCollab cleared the room synchronously');
+      assert.equal(s.get().collabSession, null);
+
+      // Now let the parked startCollab continuation resume.
+      releaseGate();
+
+      await within(
+        pending,
+        GATE_TIMEOUT_MS,
+        // Deliberately names BOTH remaining candidates. The gate signal fires
+        // from the `whenSynced` GETTER, so it proves only that the getter was
+        // read — it says nothing about the real `whenSynced` behind it ever
+        // resolving. Claiming "the session path is fine" here would exonerate
+        // a suspect this signal cannot clear.
+        'startCollab to resume after releaseGate() (the gate was read and released, so the ' +
+          'loader hook applied — suspect the real whenSynced never settling, or the tail ' +
+          'after it never returning)',
+      );
+
       // THE BUG: a session the user explicitly left is live again.
       assert.equal(
         s.get().collabSession,


### PR DESCRIPTION
Follow-up recorded on #3054. **Does not close it** — that is the hook fix, already merged in #3035.

## The problem this solves

The test has two awaits that can each park forever, and both surfaced as an identical anonymous `testTimeoutFailure ... 120000ms`. Three separate structural explanations were proposed and argued for the same hang — a specifier that never reached the loader hook, a leave path that never resolved, an IndexedDB open that never returned — and the output was byte-identical under all three, so it could not rule out any of them. That cost a day.

The cause is fixed. This is not a fix for it. It is what makes the **next** hang here cost a message instead of an investigation, and a test that parks forever on any upstream failure will park again.

## My first version committed the exact sin it exists to prevent

`startCollab` catches everything from the dynamic import through `createCollabSession` and **returns normally**, so a failed bring-up resolves `pending` and simply never fires the gate. Waiting on the gate alone therefore sat for the full timeout and then blamed the loader hook.

Review proved it rather than arguing it: with `globalThis.indexedDB` cleared, the stack showed the wrap **had** applied and the diagnostic still said it had not. That is precisely the third explanation the helper claims to rule out.

Racing the gate against `pending` fixes it. If `startCollab` returns first, that is proof bring-up finished or failed early, and the message says so, naming the swallowed `[collab]` log as the real cause. **0s instead of 30s, with the correct attribution instead of a false one.**

The same race fixed a second defect. In the gate case `startCollab` can run to completion and store a **live** session, so the first version — whose wait sat outside the try/finally — printed its message and then wedged the run with an open IndexedDB handle. The guard was on the wait where `dispose()` is a no-op and off the wait where it works, exactly backwards.

## Proven by running each side

```
bring-up fails, wrap applies  -> "startCollab returned before the session was
                                  gated ... the [collab] diagnostic logged
                                  above is the real cause, NOT the loader
                                  hook"                         0s, exits
wrap applies but never gates  -> same message                   0s, exits
releaseGate() withheld        -> "startCollab to resume after releaseGate()
                                  ... suspect the real whenSynced never
                                  settling, or the tail after it"
```

Silent on the happy path: unmodified and this both report 1 pass in 1s.

## Three more corrections, all from review

- The resume message used to say "the signal path is fine". It cannot: the gate fires from the `whenSynced` **getter**, so it proves only that the getter was read, not that the real `whenSynced` behind it ever resolves. It now names both remaining candidates rather than exonerating a suspect it cannot clear.
- An inline comment claimed the `finally` prevents a wedge in the resume case, contradicting the docstring 80 lines above which says the opposite and is right. Two comments in one diff making opposite claims about the same code is the defect this repo keeps paying for, and I wrote both.
- "by the time this resolves, `startCollab` is provably parked there" was true when written and my race made it false, since the await now also resolves with `'returned-early'`.

## And one from a standalone test of the helper

`timer.unref()`. An unref'd timer cannot keep the event loop alive, so when the awaited promise is the only other pending work — the case this exists to report — Node drains the loop and exits before the timer fires, and the named message never appears. 3 of 4 assertions red. A diagnostic whose own failure mode is the thing it diagnoses is worse than none.

## Noted, not done

`within` is the **fifth** inline reinvention of a promise-timeout helper in viewer tests: `settleOrHang` appears verbatim in two files, plus `withDeadline` and two inline races. Extracting a shared one is past the threshold but touches four unrelated test files, which is scope creep here.

It also needs a decision this change has evidence for: **all four existing copies call `.unref()`**, which the measurement above shows fails precisely when the awaited promise is the last pending work. So the extraction would not be a tidy-up — it would fix a latent defect in four places. Worth its own issue if you want it tracked.

## Verification

```
collabSlice.leave-during-join-race.test.ts  1 passed, 0 failed, 1s
tsc --noEmit -p apps/viewer/tsconfig.json  clean
```

Test-only diff. Pre-flight: `/code-review` twice, then `/simplify`; everything raised is applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collaboration join race testing with bounded waits and clearer timeout diagnostics.
  * Added reliable cleanup during interrupted or timed-out join attempts.
  * Added a 30-second safeguard to prevent tests from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->