### PR TITLE
ci(viewer): run each shard serially, so a timing test does not race three others

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -373,6 +373,16 @@ jobs:
   # knows what good looks like rather than only what broken looked like:
   # 2:29, 2:01, 1:50 against a 25 minute cap.
   #
+  # Parallelism comes from the SHARDS, not from concurrency inside a shard.
+  # `--test-concurrency=1` is deliberate: at 4 a timing-sensitive test races
+  # three neighbours, and `useSandbox.runSupersession.test.tsx` failed on three
+  # unrelated PRs in one hour that way (issue #3060) while passing locally 3/3.
+  # The bump to 4 came from an earlier attempt at this lane that was MEASURED
+  # not to help on CI, and it was carried forward as harmless once sharding
+  # worked. It is not harmless, and its speedup is redundant with sharding.
+  # Cost of going back to 1, measured: ~70s versus ~19s per shard locally,
+  # roughly 8 minutes versus 2 on CI, against a 25 minute cap.
+  #
   # Two earlier explanations in this file were WRONG and are corrected here,
   # because a confident wrong comment is worse than none:
   #

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -14,7 +14,7 @@
     "build": "vite build && node ../../scripts/check-tla-chunk-await.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=4 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort | awk -v s=\"${TEST_SHARD:-0}\" -v n=\"${TEST_SHARDS:-1}\" 'NR % n == s')",
+    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort | awk -v s=\"${TEST_SHARD:-0}\" -v n=\"${TEST_SHARDS:-1}\" 'NR % n == s')",
     "check:templates": "tsc -p src/lib/scripts/templates/tsconfig.json --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
Undoing the part of my own CI change that is causing flakes on other people's PRs.

## The evidence

`useSandbox.runSupersession.test.tsx` failed on **three unrelated PRs within an hour** — #3025, #3027, #3044 — always on `Viewer tests (shard 1)`, always on a gate-timing assertion counting 0 or 2 where it wants 1.

None of those diffs can reach that test. Two touch only `packages/extensions` and `packages/create`, which never import it. On the same base, **#3038's shard 1 ran the identical suite green**. Locally shard 1 passes 3 of 3, at both concurrency settings.

So: same base, same suite, some red some green, no path from any of the diffs.

## Why this is mine to undo

`--test-concurrency=4` came from the **first** attempt at this lane — the one I measured and showed **did not help CI at all**. When sharding finally worked I carried it forward on the grounds that a real 2x locally was harmless.

It is not harmless. It makes a timing-sensitive test race three neighbours under CI load, and **its speedup is now redundant**: the parallelism comes from four concurrent shard *jobs*, not from concurrency inside one.

## The cost, measured rather than assumed

```
shard 1, concurrency=4    19s local   (~2:15 on CI)
shard 1, concurrency=1    70s local   (~8:10 on CI)
```

Both against a 25 minute cap. 1386 tests pass either way.

Eight minutes per shard, four shards in parallel, is a budget that absorbs this without argument.

## What I am not claiming

**Not proof.** I have a mechanism and a correlation, not a reproduction: it passes locally either way, and I have no clean pre-sharding CI baseline because the lane was broken all day.

What I do have is a variable I introduced whose benefit is now redundant. Removing it costs six well-affordable minutes and eliminates a candidate. **If the flake survives this, it was never concurrency**, and #3060 is where that investigation continues — including the more interesting possibility there, that a QuickJS runtime aborting during teardown in the preceding file perturbs the next one, in which case the fix is in the teardown and not in the assertion.