### PR TITLE
feat(viewer): derive mass from volume x material density, labelled by provenance (#2736)

### DIFF
--- a/.changeset/measure-derived-weight-provenance.md
+++ b/.changeset/measure-derived-weight-provenance.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/viewer": minor
+---
+
+Measure: derive a mass from geometry volume × material density, labelled as derived.
+
+The Quantities panel reported a weight only when the file declared an `IfcQuantityWeight`. A model with geometry and materials but no declared weight reported nothing, even though everything needed to compute one was present.
+
+It now derives a mass from the meshed geometry volume (the same value the "Volume mesh" row reports, after opening cuts) times the material density the file declares in `Pset_MaterialCommon.MassDensity`, and shows it as its own **"Mass derived"** row.
+
+**It is a separate row, never the same number.** A declared `Qto` weight, a mass computed from a density the file declared, and a mass estimated from a density the file did not are three different confidence levels. They are totalled separately and labelled separately, the same way the panel already refuses to read a bare `Volume` as a `NetVolume`. The row's tooltip and a footnote both say the figure is calculated and not an IFC-declared quantity.
+
+**A declared weight is never derived over.** When the file states a weight, that is the answer and no derivation runs for that element — including when a volume and a density are both available.
+
+**An untrusted volume produces no mass at all.** For a model federation alignment re-baked (`'same-crs'` / `'reprojected'`), the proved volume describes a size that is no longer on screen (#1993), so no mass is derived from it and the existing note explains why. Likewise, an element whose materials declare *different* densities gets no mass: without each material's share of the volume there is no answer, and the panel says so rather than picking one.
+
+Units route through `project_units` as the single source: densities convert from the file's `MASSDENSITYUNIT` and the result renders in `MASSUNIT`, honouring the per-unit-type display override. The row says "Mass" rather than "Weight" because kg/m³ × m³ is a mass; where a file's `MASSUNIT` resolves to a force symbol instead, no mass is derived and the panel reports that rather than guessing between kilograms and kilonewtons.
+
+Scope: only the file's own density is wired. There is no project density library in the viewer today, so the "estimated from a library density" basis is modelled and tested but has no configured source yet. IFC2X3's `IfcGeneralMaterialProperties.MassDensity` — a scalar attribute rather than a property set — is still not read by the parser, so IFC2X3 files carrying their density that way are unaffected.
+
+Closes #2736.

--- a/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
@@ -411,6 +411,10 @@ export function MeasureQuantities() {
       const declaredWeight = picked.find(
         (q) => q.quantityType === MEASURABLE_QUANTITY_TYPES.Weight,
       );
+      // Exactly the complement of `resolveElementWeight`'s `no-volume` and
+      // `volume-untrusted` guards — `Number.isFinite(undefined)` is `false`,
+      // so this is one expression for both.
+      const densityCouldMatter = volumeTrusted && Number.isFinite(volume);
       weightOutcomes.push(
         resolveElementWeight(
           declaredWeight
@@ -434,7 +438,18 @@ export function MeasureQuantities() {
                 // prebuilt tables carry properties and quantities, not
                 // material psets — so there is genuinely no density to read,
                 // and asking anyway walks an index that is not there.
-                density: store.source?.length && store.entityIndex
+                //
+                // Gated a SECOND time on the volume, because
+                // `extractMaterialPropertiesOnDemand` re-parses the source
+                // buffer per element and `resolveElementWeight` returns
+                // `no-volume` / `volume-untrusted` BEFORE it ever reads a
+                // density. Without this the panel paid that per-element parse
+                // for every element it was already going to withhold — the one
+                // place the per-model caching above was not applied. It is a
+                // cost guard only: it mirrors the resolver's two volume
+                // refusals, so every element it skips is one whose outcome the
+                // density could not have changed.
+                density: densityCouldMatter && store.source?.length && store.entityIndex
                   ? pickIfcDensity(
                       extractMaterialPropertiesOnDemand(store, ref.expressId),
                       densityToSi,

--- a/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasureQuantities.tsx
@@ -57,6 +57,17 @@
  *   component cannot end up gating it, structurally rather than by
  *   convention.
  *
+ * - **Mass derived** — geometry volume x the material density the file declares
+ *   in `Pset_MaterialCommon.MassDensity` (#2736). This is the ONLY number on
+ *   the panel this tool calculates from two unrelated facts, so it is the one
+ *   that most needs its provenance attached, and `measure-modes/weight.ts`
+ *   attaches it: a declared `Qto` weight is never derived over, an untrusted
+ *   volume never becomes a mass at all, and a density the file did not declare
+ *   would land in a separate "estimated" row rather than this one. The whole
+ *   arithmetic is `kg/m³ x m³`, which is why the row says "Mass" and not
+ *   "Weight" — #2736 §4's mass-vs-force distinction, answered by routing
+ *   through `project_units`' `MASSUNIT` rather than a second convention.
+ *
  * Values are normalised to SI at read time, while each value is still next to
  * the `ProjectUnits` that explain it, because a federation can mix a
  * millimetre model with a metre one. Display then converts once, honouring the
@@ -72,6 +83,7 @@ import { toGlobalIdFromModels } from '@/store/globalId';
 import {
   extractQuantitiesOnDemand,
   extractTypeQuantitiesOnDemand,
+  extractMaterialPropertiesOnDemand,
   extractProjectUnits,
   ProjectUnits,
   type IfcDataStore,
@@ -89,10 +101,19 @@ import {
   rollupQuantities,
   rollupGeometryVolumes,
   rollupMeshArea,
+  MEASURABLE_QUANTITY_TYPES,
   type PickedQuantity,
   type QuantityBasis,
 } from './measure-modes/quantities';
 import { collectMeshAreas } from './measure-modes/mesh-area';
+import {
+  pickIfcDensity,
+  resolveElementWeight,
+  rollupWeights,
+  classifyWeightUnitKind,
+  type WeightBasis,
+  type WeightOutcome,
+} from './measure-modes/weight';
 
 const QUANTITY_TYPE_LABEL: Record<number, string> = {
   0: 'Length',
@@ -105,6 +126,32 @@ const BASIS_LABEL: Record<QuantityBasis, string> = {
   net: 'net',
   gross: 'gross',
   unqualified: '',
+};
+
+/**
+ * Row labels for the two DERIVED weight bases (#2736).
+ *
+ * `declared` has no entry because it is not rendered from this rollup: a
+ * declared `Qto` weight is already a row of the `declared` quantity table
+ * above, complete with its own net/gross basis, and rendering it twice would
+ * be the second number this panel exists to avoid. The rollup still models it
+ * — that is what lets a declared weight suppress its own derivation — it is
+ * just not drawn from here.
+ *
+ * "Mass" rather than "Weight" is deliberate and is #2736 §4: kg/m³ x m³ is a
+ * mass, and a row that said "Weight" beside a `MASSUNIT` total would leave the
+ * reader to guess whether it meant a force.
+ */
+const DERIVED_WEIGHT_LABEL: Record<Exclude<WeightBasis, 'declared'>, string> = {
+  'derived-ifc-density': 'Mass derived',
+  'derived-library-density': 'Mass estimated',
+};
+
+const DERIVED_WEIGHT_TITLE: Record<Exclude<WeightBasis, 'declared'>, string> = {
+  'derived-ifc-density':
+    'Mass CALCULATED as the meshed geometry volume (after opening cuts) x the material density the file declares in Pset_MaterialCommon.MassDensity. Not an IFC-declared weight quantity. A mass, not a force.',
+  'derived-library-density':
+    'Mass ESTIMATED as the meshed geometry volume (after opening cuts) x a density from the project density library. The file does not declare this density. A mass, not a force.',
 };
 
 /**
@@ -123,6 +170,25 @@ function siConverterFor(units: ProjectUnits) {
       ?? { symbol: entry.defaultSymbol, siScale: 1.0 };
     return convertValue(value, resolveFromUnit(entry.unitType, fileUnit), { scale: 1 });
   };
+}
+
+/**
+ * Build the file-unit -> kg/m³ converter for a material's declared density.
+ *
+ * Routed through `unitForMeasure('IFCMASSDENSITYMEASURE')` — the same
+ * `project_units` resolver the property cards already use for this measure —
+ * rather than assuming kg/m³. A project declaring grams and millimetres writes
+ * its `MassDensity` in g/mm³, and taking that number as kilograms per cubic
+ * metre is wrong by a factor of a million.
+ *
+ * `unitForMeasure` already falls back to the measure's SI default, so the
+ * common file that declares no `MASSDENSITYUNIT` converts by 1.
+ */
+function densitySiConverterFor(units: ProjectUnits) {
+  const fileUnit = units.unitForMeasure('IFCMASSDENSITYMEASURE')
+    ?? { symbol: 'kg/m³', siScale: 1.0 };
+  const from = resolveFromUnit('MASSDENSITYUNIT', fileUnit);
+  return (value: number): number => convertValue(value, from, { scale: 1 });
 }
 
 /**
@@ -239,14 +305,18 @@ export function MeasureQuantities() {
       }
     };
     // Models whose vertices federation alignment re-baked. Their volumes are
-    // not merely suspect, they describe a different size — so they are never
-    // read, rather than read and quietly compared.
+    // not merely suspect, they describe a different size — so no total ever
+    // includes them, and the gate is at every READ site below rather than at
+    // collection: the derived-mass path (#2736) has to be able to tell "this
+    // element's volume was invalidated" from "the kernel proved no volume for
+    // this element", and it can only do that if the invalidated volume is
+    // still visible to say so about. Nothing downstream may read this map
+    // without first consulting `rescaledModelIds`.
     const rescaledModelIds = new Set<string>();
     if (models.size > 0) {
       for (const [id, m] of models) {
         if (!geometryVolumesSurviveAlignment(m.federationAlignmentStatus)) {
           rescaledModelIds.add(id);
-          continue;
         }
         collectVolumes(m.geometryResult?.meshes, m.geometryResult?.instancedGeometryVolumes);
       }
@@ -266,9 +336,14 @@ export function MeasureQuantities() {
     });
 
     const unitsCache = new Map<string, ProjectUnits>();
+    // Per model, not per element: resolving MASSDENSITYUNIT walks the unit
+    // assignment, and a 5000-element selection would otherwise redo it 5000
+    // times for the one answer its model can give.
+    const densityConverters = new Map<string, (value: number) => number>();
     const typeCaches = new Map<string, Map<number, ReturnType<typeof extractQuantitiesOnDemand>>>();
     const perElement: PickedQuantity[][] = [];
     const geometryVolumes: Array<number | undefined> = [];
+    const weightOutcomes: WeightOutcome[] = [];
     let withoutStore = 0;
     let rescaled = 0;
 
@@ -295,34 +370,86 @@ export function MeasureQuantities() {
           : ProjectUnits.empty();
         unitsCache.set(ref.modelId, units);
       }
+      let densityToSi = densityConverters.get(ref.modelId);
+      if (!densityToSi) {
+        densityToSi = densitySiConverterFor(units);
+        densityConverters.set(ref.modelId, densityToSi);
+      }
       let typeCache = typeCaches.get(ref.modelId);
       if (!typeCache) {
         typeCache = new Map();
         typeCaches.set(ref.modelId, typeCache);
       }
 
-      perElement.push(
-        pickElementQuantities(
-          quantitySetsFor(store, ref.expressId, typeCache),
-          siConverterFor(units),
-        ),
+      const picked = pickElementQuantities(
+        quantitySetsFor(store, ref.expressId, typeCache),
+        siConverterFor(units),
       );
+      perElement.push(picked);
+
+      const volumeTrusted = !rescaledModelIds.has(ref.modelId);
+      const volume = volumeByGlobalId.get(
+        toGlobalIdFromModels(models, ref.modelId, ref.expressId),
+      );
+
       // A re-baked model contributes no volume AND is not counted as unproved:
       // the kernel proved one, alignment invalidated it, and the note below
       // says exactly that.
-      if (rescaledModelIds.has(ref.modelId)) {
-        rescaled += 1;
+      if (volumeTrusted) {
+        geometryVolumes.push(volume);
       } else {
-        geometryVolumes.push(
-          volumeByGlobalId.get(toGlobalIdFromModels(models, ref.modelId, ref.expressId)),
-        );
+        rescaled += 1;
       }
+
+      // Weight, with its provenance (#2736). The file's own `Qto` weight is
+      // taken FIRST and, when present, is the whole answer — `pickElementQuantities`
+      // already returns it net-before-gross-before-unqualified, so `find` takes
+      // the most representative one. Only when there is none does the density
+      // lookup run at all, which is both the correct precedence (never derive
+      // over what the file declared) and the reason a large selection of
+      // properly-quantified elements pays nothing for this feature.
+      const declaredWeight = picked.find(
+        (q) => q.quantityType === MEASURABLE_QUANTITY_TYPES.Weight,
+      );
+      weightOutcomes.push(
+        resolveElementWeight(
+          declaredWeight
+            ? {
+                declared: { value: declaredWeight.value, provenance: declaredWeight.provenance },
+                volumeTrusted,
+              }
+            : {
+                volume,
+                volumeTrusted,
+                unitKind: classifyWeightUnitKind(units.resolvedForUnitType('MASSUNIT')?.symbol),
+                // Only the file's own density is wired today; there is no
+                // project density library to fall back to (see the module's
+                // `derived-library-density`, which no call site can reach yet).
+                //
+                // Gated on the SAME condition as `extractProjectUnits` above,
+                // and for the same reason: material properties live in
+                // `IfcMaterialProperties` entities that are only reachable by
+                // reading attributes out of the STEP source through
+                // `entityIndex`. A server-parsed store has neither — its
+                // prebuilt tables carry properties and quantities, not
+                // material psets — so there is genuinely no density to read,
+                // and asking anyway walks an index that is not there.
+                density: store.source?.length && store.entityIndex
+                  ? pickIfcDensity(
+                      extractMaterialPropertiesOnDemand(store, ref.expressId),
+                      densityToSi,
+                    )
+                  : undefined,
+              },
+        ),
+      );
     }
 
     return {
       declared: rollupQuantities(perElement),
       geometry: rollupGeometryVolumes(geometryVolumes),
       meshArea: rollupMeshArea(meshAreas),
+      weights: rollupWeights(weightOutcomes),
       meshAreaIncomplete,
       elements: refs.length,
       withoutStore,
@@ -348,8 +475,17 @@ export function MeasureQuantities() {
     );
   }
 
-  const { declared, geometry, meshArea, meshAreaIncomplete, elements, withoutStore, rescaled } = summary;
-  const nothing = declared.length === 0 && geometry.proved === 0 && meshArea.withMesh === 0;
+  const { declared, geometry, meshArea, weights, meshAreaIncomplete, elements, withoutStore, rescaled } = summary;
+  // Derived-mass rows only. The `declared` basis is already a row of the
+  // `declared` table above; see DERIVED_WEIGHT_LABEL.
+  const derivedWeights = weights.rows.filter((r) => r.basis !== 'declared');
+  // A derived mass needs a trusted proved volume, so `geometry.proved === 0`
+  // already implies `derivedWeights` is empty — stated as a condition rather
+  // than left as an invariant a future edit could break silently.
+  const nothing = declared.length === 0
+    && geometry.proved === 0
+    && meshArea.withMesh === 0
+    && derivedWeights.length === 0;
 
   return (
     <div className="border-t px-2 py-2 space-y-1.5">
@@ -425,6 +561,32 @@ export function MeasureQuantities() {
               )}
             </div>
           )}
+
+          {/* Derived mass (#2736). Each basis is its own row: a mass computed
+              from a density the FILE declared and one estimated from a library
+              default are different claims, and one total labelled "Weight"
+              covering both would be exactly the false precision the gross/net
+              split above exists to avoid. The label is never rendered apart
+              from the number — they are the same element. */}
+          {derivedWeights.map((r) => (
+            <div
+              key={r.basis}
+              className="flex items-baseline gap-2 whitespace-nowrap"
+              title={[DERIVED_WEIGHT_TITLE[r.basis as Exclude<WeightBasis, 'declared'>], ...r.provenance].join('\n')}
+            >
+              <span className="w-[5.5rem] shrink-0 font-mono text-[9px] uppercase tracking-wider text-muted-foreground/70">
+                {DERIVED_WEIGHT_LABEL[r.basis as Exclude<WeightBasis, 'declared'>]}
+              </span>
+              <span className="font-mono text-[11px] tabular-nums">
+                {render(r.total, MEASURABLE_QUANTITY_TYPES.Weight)}
+              </span>
+              {r.contributing < elements && (
+                <span className="font-mono text-[9px] text-amber-600 dark:text-amber-500">
+                  {r.contributing}/{elements}
+                </span>
+              )}
+            </div>
+          ))}
         </div>
       )}
 
@@ -438,6 +600,41 @@ export function MeasureQuantities() {
         <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
           net = openings excluded · gross = openings included · mesh = as built,
           after opening cuts (volume) or total triangulated surface (area)
+        </div>
+      )}
+
+      {/* #2736's provenance requirement, stated rather than implied by a row
+          label: a derived mass is a calculation of ours, not a quantity the
+          file authored, and the reader is told which density it used. */}
+      {derivedWeights.length > 0 && (
+        <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
+          mass derived = mesh volume × the file&apos;s Pset_MaterialCommon.MassDensity
+          {derivedWeights.some((r) => r.basis === 'derived-library-density')
+            ? '; mass estimated = mesh volume × a project library density the file does not declare'
+            : ''}
+          . Not an IFC-declared weight quantity.
+        </div>
+      )}
+      {weights.withheld['density-ambiguous'] > 0 && (
+        <div className="font-mono text-[9px] leading-tight text-muted-foreground/70">
+          {weights.withheld['density-ambiguous']} element
+          {weights.withheld['density-ambiguous'] === 1 ? '' : 's'} declare
+          materials with different densities and no share of the volume to
+          apportion between them, so no mass was derived for
+          {weights.withheld['density-ambiguous'] === 1 ? ' it' : ' them'}.
+        </div>
+      )}
+      {weights.withheld['weight-unit-is-force'] > 0 && (
+        <div className="flex items-start gap-1.5 font-mono text-[9px] leading-tight text-amber-600 dark:text-amber-500">
+          <TriangleAlert className="mt-0.5 h-2.5 w-2.5 shrink-0" />
+          <span>
+            {weights.withheld['weight-unit-is-force']} element
+            {weights.withheld['weight-unit-is-force'] === 1 ? '' : 's'} sit
+            {weights.withheld['weight-unit-is-force'] === 1 ? 's' : ''} in a model
+            whose MASSUNIT declares a force, not a mass. No mass was derived
+            rather than guessing whether the result should read as kilograms or
+            kilonewtons.
+          </span>
         </div>
       )}
 

--- a/apps/viewer/src/components/viewer/tools/measure-modes/weight.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/weight.test.ts
@@ -1,0 +1,390 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #2736's acceptance, stated as assertions.
+ *
+ * The three bullets the issue names are covered by, in order:
+ * - "derives a mass ..."           — geometry + density with nothing declared
+ * - "an untrusted volume ..."      — the #1993 refusal, asserted directly
+ * - the mutation bullet            — `multiplies the volume by the density`
+ *   pins the arithmetic and `reads the density off Pset_MaterialCommon`
+ *   pins the lookup, so mutating either reds a named test.
+ *
+ * The fourth group exists because the derivation tests alone would pass for an
+ * implementation that ALWAYS derives: a declared weight must still come back
+ * labelled `declared`, and must not be recomputed from geometry.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  resolveElementWeight,
+  rollupWeights,
+  pickIfcDensity,
+  classifyWeightUnitKind,
+  type MaterialPsetGroupLike,
+  type WeightOutcome,
+} from './weight.js';
+
+const CONCRETE = 2400;
+
+/** A density pick as `pickIfcDensity` would have produced it. */
+const ifcDensity = (density = CONCRETE) =>
+  ({
+    kind: 'density',
+    pick: { density, basis: 'derived-ifc-density', provenance: 'Concrete · Pset_MaterialCommon.MassDensity' },
+  }) as const;
+
+const libraryDensity = (density = CONCRETE) =>
+  ({
+    kind: 'density',
+    pick: { density, basis: 'derived-library-density', provenance: 'project library · Concrete' },
+  }) as const;
+
+const materialGroup = (
+  materialName: string,
+  psetName: string,
+  properties: Array<{ name: string; value: unknown }>,
+): MaterialPsetGroupLike => ({ materialName, psets: [{ name: psetName, properties }] });
+
+describe('resolveElementWeight — derivation (#2736 acceptance 1)', () => {
+  it('derives a mass from geometry volume and material density when nothing is declared', () => {
+    const out = resolveElementWeight({
+      volume: 2,
+      volumeTrusted: true,
+      density: ifcDensity(),
+    });
+    assert.equal(out.kind, 'weight');
+    assert.ok(out.kind === 'weight');
+    assert.equal(out.weight.value, 4800);
+  });
+
+  it('multiplies the volume by the density', () => {
+    // Pins the arithmetic itself, so swapping the operator or dropping either
+    // operand cannot stay green. Deliberately uses two values whose sum,
+    // difference and quotient all differ from their product.
+    const out = resolveElementWeight({ volume: 3, volumeTrusted: true, density: ifcDensity(7) });
+    assert.ok(out.kind === 'weight');
+    assert.equal(out.weight.value, 21);
+    assert.notEqual(out.weight.value, 3 + 7);
+    assert.notEqual(out.weight.value, 3 / 7);
+  });
+
+  it('labels the result derived, never plain "declared"', () => {
+    const fromFile = resolveElementWeight({ volume: 1, volumeTrusted: true, density: ifcDensity() });
+    assert.ok(fromFile.kind === 'weight');
+    assert.equal(fromFile.weight.basis, 'derived-ifc-density');
+
+    const fromLibrary = resolveElementWeight({
+      volume: 1,
+      volumeTrusted: true,
+      density: libraryDensity(),
+    });
+    assert.ok(fromLibrary.kind === 'weight');
+    assert.equal(fromLibrary.weight.basis, 'derived-library-density');
+  });
+
+  it('carries the density source through as the result provenance', () => {
+    const out = resolveElementWeight({ volume: 1, volumeTrusted: true, density: ifcDensity() });
+    assert.ok(out.kind === 'weight');
+    assert.equal(out.weight.provenance, 'Concrete · Pset_MaterialCommon.MassDensity');
+  });
+});
+
+describe('resolveElementWeight — refusals (#2736 acceptance 2)', () => {
+  it('produces NO mass from an untrusted volume, rather than a wrong one', () => {
+    // The #1993 case: federation alignment re-baked the vertices, so the
+    // proved volume describes a size that is no longer on screen. There IS a
+    // volume and there IS a density; the answer is still nothing.
+    const out = resolveElementWeight({
+      volume: 2,
+      volumeTrusted: false,
+      density: ifcDensity(),
+    });
+    assert.equal(out.kind, 'none');
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'volume-untrusted');
+  });
+
+  it('distinguishes an untrusted volume from an absent one', () => {
+    const absent = resolveElementWeight({ volumeTrusted: true, density: ifcDensity() });
+    assert.ok(absent.kind === 'none');
+    assert.equal(absent.reason, 'no-volume');
+  });
+
+  it('gives no mass when no density could be found', () => {
+    const out = resolveElementWeight({ volume: 2, volumeTrusted: true });
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'no-density');
+  });
+
+  it('treats a zero or negative density as no density, never as a zero-kilogram answer', () => {
+    for (const bad of [0, -5]) {
+      const out = resolveElementWeight({ volume: 2, volumeTrusted: true, density: ifcDensity(bad) });
+      assert.ok(out.kind === 'none', `density ${bad} must not produce a weight`);
+      assert.equal(out.reason, 'no-density');
+    }
+  });
+
+  it('gives no mass when a non-finite volume masquerades as a proved one', () => {
+    const out = resolveElementWeight({
+      volume: Number.NaN,
+      volumeTrusted: true,
+      density: ifcDensity(),
+    });
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'no-volume');
+  });
+
+  it('declines to derive when the file\'s MASSUNIT resolved to a force', () => {
+    const out = resolveElementWeight({
+      volume: 2,
+      volumeTrusted: true,
+      density: ifcDensity(),
+      unitKind: 'force',
+    });
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'weight-unit-is-force');
+  });
+
+  it('passes a density conflict through as its own reason, not as "no density"', () => {
+    const out = resolveElementWeight({
+      volume: 2,
+      volumeTrusted: true,
+      density: { kind: 'none', reason: 'density-ambiguous' },
+    });
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'density-ambiguous');
+  });
+});
+
+describe('resolveElementWeight — a declared weight is never derived over', () => {
+  it('reports a declared weight as declared', () => {
+    const out = resolveElementWeight({
+      declared: { value: 1234, provenance: 'Qto_WallBaseQuantities.NetWeight' },
+      volumeTrusted: true,
+    });
+    assert.ok(out.kind === 'weight');
+    assert.equal(out.weight.basis, 'declared');
+    assert.equal(out.weight.value, 1234);
+    assert.equal(out.weight.provenance, 'Qto_WallBaseQuantities.NetWeight');
+  });
+
+  it('does NOT overwrite a declared weight with a derivation, even when both are available', () => {
+    // An implementation that always derives would pass every test above and
+    // silently replace the file's own number with ours. 2 m³ x 2400 kg/m³ is
+    // 4800, and the declared 1234 must survive it.
+    const out = resolveElementWeight({
+      declared: { value: 1234, provenance: 'Qto_WallBaseQuantities.NetWeight' },
+      volume: 2,
+      volumeTrusted: true,
+      density: ifcDensity(),
+    });
+    assert.ok(out.kind === 'weight');
+    assert.equal(out.weight.value, 1234);
+    assert.equal(out.weight.basis, 'declared');
+  });
+
+  it('still reports a declared weight when the volume is untrusted', () => {
+    // The untrusted-volume refusal is about DERIVING. It must not suppress a
+    // number the file itself authored, which no alignment touched.
+    const out = resolveElementWeight({
+      declared: { value: 50, provenance: 'Qto_BeamBaseQuantities.GrossWeight' },
+      volume: 2,
+      volumeTrusted: false,
+      density: ifcDensity(),
+    });
+    assert.ok(out.kind === 'weight');
+    assert.equal(out.weight.basis, 'declared');
+    assert.equal(out.weight.value, 50);
+  });
+
+  it('drops a non-finite declared weight rather than reporting it', () => {
+    const out = resolveElementWeight({
+      declared: { value: Number.NaN, provenance: 'Qto_Bad.Weight' },
+      volumeTrusted: true,
+    });
+    assert.ok(out.kind === 'none');
+  });
+});
+
+describe('pickIfcDensity — the density lookup (#2736 acceptance 3)', () => {
+  it('reads the density off Pset_MaterialCommon.MassDensity', () => {
+    // Pins BOTH names. Mutating either the pset name or the property name the
+    // lookup matches on reds this test.
+    const out = pickIfcDensity([
+      materialGroup('Concrete C30/37', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: 2400 }]),
+    ]);
+    assert.equal(out.kind, 'density');
+    assert.ok(out.kind === 'density');
+    assert.equal(out.pick.density, 2400);
+    assert.equal(out.pick.basis, 'derived-ifc-density');
+    assert.equal(out.pick.provenance, 'Concrete C30/37 · Pset_MaterialCommon.MassDensity');
+  });
+
+  it('ignores a density-looking property in a DIFFERENT pset', () => {
+    const out = pickIfcDensity([
+      materialGroup('Steel', 'Pset_MaterialSteel', [{ name: 'MassDensity', value: 7850 }]),
+    ]);
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'no-density');
+  });
+
+  it('ignores a different property in the right pset', () => {
+    const out = pickIfcDensity([
+      materialGroup('Timber', 'Pset_MaterialCommon', [{ name: 'Porosity', value: 0.3 }]),
+    ]);
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'no-density');
+  });
+
+  it('matches the pset and property names case-insensitively', () => {
+    const out = pickIfcDensity([
+      materialGroup('Brick', 'PSET_MATERIALCOMMON', [{ name: 'massdensity', value: 1800 }]),
+    ]);
+    assert.ok(out.kind === 'density');
+    assert.equal(out.pick.density, 1800);
+  });
+
+  it('refuses a stringly-typed density instead of coercing it', () => {
+    const out = pickIfcDensity([
+      materialGroup('Concrete', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: '2400' }]),
+    ]);
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'no-density');
+  });
+
+  it('applies the SI converter, so a file declaring g/cm³ does not out-weigh one in kg/m³', () => {
+    const out = pickIfcDensity(
+      [materialGroup('Concrete', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: 2.4 }])],
+      (v) => v * 1000,
+    );
+    assert.ok(out.kind === 'density');
+    assert.equal(out.pick.density, 2400);
+  });
+
+  it('drops a value the converter turned non-finite', () => {
+    const out = pickIfcDensity(
+      [materialGroup('Concrete', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: 2400 }])],
+      () => Number.NaN,
+    );
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'no-density');
+  });
+
+  it('reports a conflict when two materials declare different densities, rather than picking one', () => {
+    // A layered wall is not its heaviest layer, and it is not the mean of its
+    // layers either. Without each layer's volume there is no answer.
+    const out = pickIfcDensity([
+      materialGroup('Concrete', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: 2400 }]),
+      materialGroup('Insulation', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: 30 }]),
+    ]);
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'density-ambiguous');
+  });
+
+  it('accepts two materials that agree on the density', () => {
+    const out = pickIfcDensity([
+      materialGroup('Concrete A', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: 2400 }]),
+      materialGroup('Concrete B', 'Pset_MaterialCommon', [{ name: 'MassDensity', value: 2400 }]),
+    ]);
+    assert.ok(out.kind === 'density');
+    assert.equal(out.pick.density, 2400);
+  });
+
+  it('finds no density in an element with no materials at all', () => {
+    const out = pickIfcDensity([]);
+    assert.ok(out.kind === 'none');
+    assert.equal(out.reason, 'no-density');
+  });
+});
+
+describe('classifyWeightUnitKind', () => {
+  it('reads a mass unit as a mass', () => {
+    for (const symbol of ['kg', 'g', 't', 'lb']) {
+      assert.equal(classifyWeightUnitKind(symbol), 'mass', symbol);
+    }
+  });
+
+  it('reads a force symbol declared under MASSUNIT as a force', () => {
+    for (const symbol of ['N', 'kN', 'lbf', 'kip']) {
+      assert.equal(classifyWeightUnitKind(symbol), 'force', symbol);
+    }
+  });
+
+  it('treats a file that declares no MASSUNIT as a mass, matching the kg default', () => {
+    // Not a third "unknown" state: `QUANTITY_TYPE_UNIT` already defaults
+    // QuantityType.Weight to kilograms, and suppressing the derivation for
+    // every unit-less file would be a refusal with nothing behind it.
+    assert.equal(classifyWeightUnitKind(undefined), 'mass');
+  });
+});
+
+describe('rollupWeights', () => {
+  const derived = (value: number): WeightOutcome => ({
+    kind: 'weight',
+    weight: { basis: 'derived-ifc-density', value, provenance: 'Concrete · Pset_MaterialCommon.MassDensity' },
+  });
+  const declared = (value: number): WeightOutcome => ({
+    kind: 'weight',
+    weight: { basis: 'declared', value, provenance: 'Qto_WallBaseQuantities.NetWeight' },
+  });
+
+  it('never sums a declared weight into a derived one', () => {
+    // The defect this whole module exists to avoid: one number labelled
+    // "Weight" that is part measurement and part estimate.
+    const { rows } = rollupWeights([declared(100), derived(50)]);
+    assert.equal(rows.length, 2);
+    assert.deepEqual(
+      rows.map((r) => [r.basis, r.total]),
+      [['declared', 100], ['derived-ifc-density', 50]],
+    );
+  });
+
+  it('keeps the two derived bases apart from each other too', () => {
+    const { rows } = rollupWeights([
+      derived(50),
+      { kind: 'weight', weight: { basis: 'derived-library-density', value: 7, provenance: 'library · Steel' } },
+    ]);
+    assert.deepEqual(
+      rows.map((r) => [r.basis, r.total]),
+      [['derived-ifc-density', 50], ['derived-library-density', 7]],
+    );
+  });
+
+  it('totals within a basis and counts its contributors', () => {
+    const { rows } = rollupWeights([derived(50), derived(25), { kind: 'none', reason: 'no-volume' }]);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].total, 75);
+    assert.equal(rows[0].contributing, 2);
+  });
+
+  it('counts every withheld element by its reason', () => {
+    const { withheld } = rollupWeights([
+      { kind: 'none', reason: 'volume-untrusted' },
+      { kind: 'none', reason: 'volume-untrusted' },
+      { kind: 'none', reason: 'no-density' },
+      { kind: 'none', reason: 'density-ambiguous' },
+      { kind: 'none', reason: 'weight-unit-is-force' },
+      derived(1),
+    ]);
+    assert.equal(withheld['volume-untrusted'], 2);
+    assert.equal(withheld['no-density'], 1);
+    assert.equal(withheld['density-ambiguous'], 1);
+    assert.equal(withheld['weight-unit-is-force'], 1);
+    assert.equal(withheld['no-volume'], 0);
+  });
+
+  it('deduplicates the provenance list and sorts it', () => {
+    const { rows } = rollupWeights([derived(1), derived(2)]);
+    assert.deepEqual(rows[0].provenance, ['Concrete · Pset_MaterialCommon.MassDensity']);
+  });
+
+  it('is empty for an empty selection, with every reason at zero', () => {
+    const { rows, withheld } = rollupWeights([]);
+    assert.deepEqual(rows, []);
+    assert.deepEqual(Object.values(withheld), [0, 0, 0, 0, 0]);
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/weight.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/weight.ts
@@ -1,0 +1,354 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Weight with its provenance attached — issue #2736 (split from #2199 §6).
+ *
+ * `quantities.ts` already reports a weight the file DECLARES. This module adds
+ * the other two ways a weight can be known, and — the whole point — keeps them
+ * apart:
+ *
+ * - `declared` — an `IfcQuantityWeight` the file authored. Measured.
+ * - `derived-ifc-density` — geometry volume x a density the FILE declared
+ *   (`Pset_MaterialCommon.MassDensity`). Calculated from two things the file
+ *   said, but the multiplication is ours.
+ * - `derived-library-density` — geometry volume x a density the file never
+ *   said, supplied by a user or project density library. An estimate.
+ *
+ * These are three different confidence levels and this module refuses to
+ * collapse them, for the same reason `QuantityBasis` refuses to read a bare
+ * `Volume` as "net": labelling an estimate "Weight" asserts a measurement the
+ * file never made. {@link rollupWeights} therefore totals each basis into its
+ * own row rather than summing them, so a selection where half the elements
+ * declare a weight and half are estimated can never render as one number.
+ *
+ * Three refusals are load-bearing and are why this is a module rather than
+ * three lines at the call site:
+ *
+ * **A declared weight is never derived over.** {@link resolveElementWeight}
+ * returns the declared value the moment there is one, before it even looks at
+ * volume or density. A derivation that "improved on" a declared quantity would
+ * replace what the file says with what we computed, which is the opposite of
+ * what this panel is for.
+ *
+ * **An untrusted volume never becomes a confident mass.** The geometry volume
+ * is only usable when the caller vouches for it (`volumeTrusted`) — federation
+ * alignment can re-bake a model's vertices, leaving a proved volume that
+ * describes a size no longer on screen (#1993,
+ * `geometryVolumesSurviveAlignment`). Multiplying that by a density would turn
+ * "we scaled it away" into a mass with four significant figures. No result at
+ * all is the better answer, and the reason is returned rather than swallowed so
+ * the readout can say it.
+ *
+ * **Two materials disagreeing about density is not an average.** A layered
+ * wall's mass is the sum of each layer's volume times its own density, and
+ * nothing here knows the layer volumes. Picking one of the densities, or the
+ * mean of them, would answer a question we cannot answer — so
+ * {@link pickIfcDensity} reports the conflict instead (`density-ambiguous`).
+ */
+
+/** Where a weight came from, in descending order of what the file vouches for. */
+export type WeightBasis = 'declared' | 'derived-ifc-density' | 'derived-library-density';
+
+/**
+ * Whether the file's weight convention is a mass or a force — issue #2736 §4.
+ *
+ * `QuantityType.Weight` resolves through `project_units`' `MASSUNIT`
+ * (`QUANTITY_TYPE_UNIT` in `lib/units/display.ts`), which is the canonical
+ * source and the only one this feature uses. A file whose `MASSUNIT` resolves
+ * to a force symbol (an exporter writing `.NEWTON.` under `MASSUNIT`) has said
+ * something self-contradictory, and `'force'` records that rather than papering
+ * over it — see {@link resolveElementWeight}, which then declines to derive
+ * rather than guessing whether the reader wanted kilograms or kilonewtons.
+ */
+export type WeightUnitKind = 'mass' | 'force';
+
+/** A density already normalised to SI kg/m³, and what supplied it. */
+export interface DensityPick {
+  /** kg/m³. */
+  density: number;
+  /** Which of the two derived bases this density earns. */
+  basis: Exclude<WeightBasis, 'declared'>;
+  /** `Concrete C30/37 · Pset_MaterialCommon.MassDensity` — readable, not parsed. */
+  provenance: string;
+}
+
+/** Why a density could not be settled on. Both are things the readout can say. */
+export type NoDensityReason =
+  /** Nothing offered a density for this element at all. */
+  | 'no-density'
+  /** Its materials declared densities that disagree, with no way to apportion. */
+  | 'density-ambiguous';
+
+export type DensityResult =
+  | { kind: 'density'; pick: DensityPick }
+  | { kind: 'none'; reason: NoDensityReason };
+
+/** Everything known about one element's weight, before deciding. */
+export interface ElementWeightInput {
+  /**
+   * The file's own weight quantity, already SI (kg), if it declared one.
+   * Present means DONE: nothing below is consulted.
+   */
+  declared?: { value: number; provenance: string };
+  /** Geometry volume in SI m³; `undefined` when the kernel proved none. */
+  volume?: number;
+  /**
+   * Whether that volume still describes the geometry on screen. `false` for a
+   * model federation alignment re-baked — the volume exists and is wrong.
+   */
+  volumeTrusted: boolean;
+  /** The density to multiply by, or the reason there is none. */
+  density?: DensityResult;
+  /** The file's weight convention. Defaults to `'mass'`, the IFC meaning. */
+  unitKind?: WeightUnitKind;
+}
+
+/** One element's answer, with the confidence level it was reached at. */
+export interface ElementWeight {
+  basis: WeightBasis;
+  /**
+   * Kilograms. Declared weights arrive already converted from the file's
+   * `MASSUNIT`; derived ones are kg/m³ x m³, which is kg by construction.
+   */
+  value: number;
+  provenance: string;
+}
+
+/** Why no weight could be given. Each one is something the readout can say. */
+export type NoWeightReason =
+  /** The kernel proved no enclosed volume for this element. */
+  | 'no-volume'
+  /** A volume exists but federation alignment invalidated it (#1993). */
+  | 'volume-untrusted'
+  /** The file's MASSUNIT resolves to a force; mass vs force is unanswerable. */
+  | 'weight-unit-is-force'
+  | NoDensityReason;
+
+export type WeightOutcome =
+  | { kind: 'weight'; weight: ElementWeight }
+  | { kind: 'none'; reason: NoWeightReason };
+
+/**
+ * Decide one element's weight and how much to trust it.
+ *
+ * The order of the guards IS the specification, so read it as one: declared
+ * wins outright; a force convention stops the derivation before it starts; an
+ * untrusted volume is refused SEPARATELY from a missing one (they are
+ * different facts and the readout distinguishes them); and a non-positive or
+ * non-finite density counts as no density at all, because a zero-kilogram mass
+ * presented as an answer is worse than no answer.
+ */
+export function resolveElementWeight(input: ElementWeightInput): WeightOutcome {
+  const { declared, volume, volumeTrusted, density } = input;
+
+  // Declared first, and unconditionally. Everything after this line is a
+  // calculation; the file's own number is not something to improve on.
+  if (declared && Number.isFinite(declared.value)) {
+    return {
+      kind: 'weight',
+      weight: { basis: 'declared', value: declared.value, provenance: declared.provenance },
+    };
+  }
+
+  // A derivation produces kilograms — kg/m³ x m³ — and cannot be relabelled
+  // into the newtons this file's own convention implies without inventing a
+  // gravity constant the unit system does not have. So it declines.
+  if ((input.unitKind ?? 'mass') === 'force') {
+    return { kind: 'none', reason: 'weight-unit-is-force' };
+  }
+
+  if (volume === undefined || !Number.isFinite(volume)) {
+    return { kind: 'none', reason: 'no-volume' };
+  }
+  if (!volumeTrusted) {
+    return { kind: 'none', reason: 'volume-untrusted' };
+  }
+  if (!density) return { kind: 'none', reason: 'no-density' };
+  if (density.kind === 'none') return { kind: 'none', reason: density.reason };
+
+  const { pick } = density;
+  if (!Number.isFinite(pick.density) || pick.density <= 0) {
+    return { kind: 'none', reason: 'no-density' };
+  }
+
+  const value = volume * pick.density;
+  // Both inputs were finite and the density positive, so this is finite unless
+  // the multiplication overflowed to Infinity — which is not a mass.
+  if (!Number.isFinite(value)) return { kind: 'none', reason: 'no-density' };
+
+  return {
+    kind: 'weight',
+    weight: { basis: pick.basis, value, provenance: pick.provenance },
+  };
+}
+
+/** A per-basis weight total across a selection. */
+export interface WeightRollup {
+  basis: WeightBasis;
+  /** Kilograms, summed only within this basis. */
+  total: number;
+  /** How many elements contributed. Never more than the selection. */
+  contributing: number;
+  /** Distinct source strings summed into this total, sorted. */
+  provenance: string[];
+}
+
+/** Rows are ordered by descending confidence, so the readout never reorders. */
+const BASIS_ORDER: Readonly<Record<WeightBasis, number>> = {
+  declared: 0,
+  'derived-ifc-density': 1,
+  'derived-library-density': 2,
+};
+
+/** The counts a readout needs in order to explain what it is NOT showing. */
+export type NoWeightCounts = Readonly<Record<NoWeightReason, number>>;
+
+export interface WeightSummary {
+  rows: WeightRollup[];
+  /** Elements that produced no weight, by reason. Every element is accounted for. */
+  withheld: NoWeightCounts;
+}
+
+/**
+ * Total each basis across a selection, keeping the bases apart.
+ *
+ * Summing a declared weight into a library-density estimate would produce a
+ * number that is neither, and there is no honest label for it — so each basis
+ * gets its own row and the reader adds them up only if they decide to.
+ */
+export function rollupWeights(perElement: ReadonlyArray<WeightOutcome>): WeightSummary {
+  const buckets = new Map<WeightBasis, WeightRollup & { names: Set<string> }>();
+  const withheld: Record<NoWeightReason, number> = {
+    'no-volume': 0,
+    'volume-untrusted': 0,
+    'no-density': 0,
+    'density-ambiguous': 0,
+    'weight-unit-is-force': 0,
+  };
+
+  for (const outcome of perElement) {
+    if (outcome.kind === 'none') {
+      withheld[outcome.reason] += 1;
+      continue;
+    }
+    const { basis, value, provenance } = outcome.weight;
+    let bucket = buckets.get(basis);
+    if (!bucket) {
+      bucket = { basis, total: 0, contributing: 0, provenance: [], names: new Set<string>() };
+      buckets.set(basis, bucket);
+    }
+    bucket.total += value;
+    bucket.contributing += 1;
+    bucket.names.add(provenance);
+  }
+
+  const rows = [...buckets.values()]
+    .map(({ names, ...rest }) => ({ ...rest, provenance: [...names].sort() }))
+    .sort((a, b) => BASIS_ORDER[a.basis] - BASIS_ORDER[b.basis]);
+
+  return { rows, withheld };
+}
+
+/**
+ * Symbols that mean a force, for a `MASSUNIT` that resolved to one of them.
+ *
+ * Deliberately about the SYMBOL rather than the IFC unit enum: the enum
+ * already says `MASSUNIT`, and the reason we look twice is that some exporters
+ * write a force unit under it. The first three come from `alternatives.ts`'s
+ * `FORCEUNIT` family; `kip` comes from `conversionUnitSymbol` in the parser's
+ * unit resolver.
+ */
+const FORCE_SYMBOLS: ReadonlySet<string> = new Set(['N', 'kN', 'MN', 'lbf', 'kip']);
+
+/**
+ * Classify the file's weight convention from the symbol `MASSUNIT` resolved to.
+ *
+ * `undefined` — the file declared no `MASSUNIT` — is `'mass'`, not a third
+ * "unknown" state: `QUANTITY_TYPE_UNIT` already defaults `QuantityType.Weight`
+ * to kilograms and that default is what the panel renders today. Answering
+ * "unknown" here would suppress the derivation for the overwhelmingly common
+ * file that declares no units at all, which is not an ambiguity — IFC's own
+ * meaning for `IfcQuantityWeight` is a mass.
+ */
+export function classifyWeightUnitKind(massUnitSymbol: string | undefined): WeightUnitKind {
+  if (massUnitSymbol && FORCE_SYMBOLS.has(massUnitSymbol.trim())) return 'force';
+  return 'mass';
+}
+
+/** The minimal shape this module needs from `extractMaterialPropertiesOnDemand`. */
+export interface MaterialPsetGroupLike {
+  materialName: string;
+  psets: ReadonlyArray<{
+    name: string;
+    properties: ReadonlyArray<{ name: string; value: unknown }>;
+  }>;
+}
+
+/** The pset and property IFC standardises a material's density under. */
+const DENSITY_PSET = 'pset_materialcommon';
+const DENSITY_PROPERTY = 'massdensity';
+
+/**
+ * Relative tolerance for calling two materials' densities "the same number".
+ *
+ * Two materials CAN legitimately carry the same density written slightly
+ * differently (2400 vs 2400.0000001 after a unit round trip). Anything wider
+ * than a float-noise band would start averaging genuinely different materials,
+ * which is the thing {@link pickIfcDensity} exists to refuse.
+ */
+const DENSITY_AGREEMENT_TOLERANCE = 1e-9;
+
+/**
+ * Read one SI density off an element's material property sets.
+ *
+ * `toSi` converts the file's declared `MASSDENSITYUNIT` into kg/m³ and is the
+ * caller's job for the same reason it is in `pickElementQuantities`: the file
+ * unit is only knowable next to the `ProjectUnits` that declared it.
+ *
+ * Returns `density-ambiguous` — NOT a density — when the element's materials
+ * declare more than one distinct value. Deriving a mass then would need each
+ * material's share of the volume, which this panel does not have; a layered
+ * wall is not its heaviest layer and is not the average of its layers either.
+ */
+export function pickIfcDensity(
+  groups: ReadonlyArray<MaterialPsetGroupLike>,
+  toSi: (value: number) => number = (v) => v,
+): DensityResult {
+  let chosen: { density: number; provenance: string } | undefined;
+
+  for (const group of groups) {
+    for (const pset of group.psets) {
+      if (pset.name.trim().toLowerCase() !== DENSITY_PSET) continue;
+      for (const property of pset.properties) {
+        if (property.name.trim().toLowerCase() !== DENSITY_PROPERTY) continue;
+        // Only an actual number counts. A string "2400" is a value some
+        // exporter did not type, and coercing it would make the tool's
+        // confidence depend on a `Number()` call rather than on the schema.
+        if (typeof property.value !== 'number' || !Number.isFinite(property.value)) continue;
+
+        const density = toSi(property.value);
+        // A converter that returned garbage must not become a mass either —
+        // the check above was on the RAW value, which says nothing about this.
+        if (!Number.isFinite(density) || density <= 0) continue;
+
+        const provenance = `${group.materialName} · ${pset.name}.${property.name}`;
+        if (!chosen) {
+          chosen = { density, provenance };
+          continue;
+        }
+        const spread = Math.abs(density - chosen.density);
+        if (spread > DENSITY_AGREEMENT_TOLERANCE * Math.max(density, chosen.density)) {
+          return { kind: 'none', reason: 'density-ambiguous' };
+        }
+      }
+    }
+  }
+
+  if (!chosen) return { kind: 'none', reason: 'no-density' };
+  return {
+    kind: 'density',
+    pick: { density: chosen.density, basis: 'derived-ifc-density', provenance: chosen.provenance },
+  };
+}

--- a/apps/viewer/src/components/viewer/tools/measure-quantities-derived-weight.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-quantities-derived-weight.test.tsx
@@ -1,0 +1,313 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #2736's acceptance at the READOUT, not at the pure function.
+ *
+ * `measure-modes/weight.test.ts` pins the arithmetic and the refusals.
+ * This file pins the two things only the rendered panel can answer:
+ *
+ * 1. a model with no declared weight but with geometry and a material density
+ *    actually PUTS a mass on screen, and
+ * 2. the number never appears without the label that says it was derived —
+ *    the failure mode the issue is really about is a confident-looking figure
+ *    with no provenance, and a pure function cannot fail that way.
+ *
+ * The store is assembled from STEP lines the way
+ * `packages/parser/test/on-demand-material-properties.test.ts` does, so the
+ * material-density read goes through the real `extractMaterialPropertiesOnDemand`
+ * rather than a stub of it. If that extractor stops resolving
+ * `Pset_MaterialCommon`, these tests fail — which is the point.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useViewerStore } from '@/store/index.js';
+import { ToolOverlays } from '../ToolOverlays.js';
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+function renderNode(node: ReactNode): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<TooltipProvider>{node}</TooltipProvider>);
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+const render = (): HTMLElement => renderNode(<ToolOverlays />);
+
+function openSection(container: HTMLElement, label: string): void {
+  const button = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent?.trim() === label,
+  );
+  assert.ok(button, `no section button labelled "${label}" on the measure panel`);
+  act(() => {
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+function unmountAll(): void {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+}
+
+/**
+ * A store with one element carrying one material whose `Pset_MaterialCommon`
+ * declares a `MassDensity`, built the way the parser's own tests build one.
+ */
+function densityStore(
+  density: number | null,
+  declaredWeight?: number,
+) {
+  const lines = [`#1=IFCWALL('g1',$,'Wall',$,$,$,$,$,$);`];
+  if (density !== null) {
+    lines.push(
+      `#10=IFCMATERIAL('Concrete C30/37',$,'concrete');`,
+      `#20=IFCPROPERTYSINGLEVALUE('MassDensity',$,${density.toFixed(1)},$);`,
+      `#30=IFCMATERIALPROPERTIES('Pset_MaterialCommon',$,(#20),#10);`,
+    );
+  }
+  if (declaredWeight !== undefined) {
+    lines.push(
+      `#51=IFCQUANTITYWEIGHT('NetWeight',$,$,${declaredWeight.toFixed(1)},$);`,
+      `#50=IFCELEMENTQUANTITY('q1',$,'Qto_WallBaseQuantities',$,$,(#51));`,
+    );
+  }
+  const text = lines.join('\n');
+  const source = new TextEncoder().encode(text);
+
+  const byId = new Map<number, unknown>();
+  const byType = new Map<string, number[]>();
+  let cursor = 0;
+  for (const line of lines) {
+    const start = text.indexOf(line, cursor);
+    const match = line.match(/^#(\d+)\s*=\s*(\w+)\(/);
+    if (match) {
+      const expressId = parseInt(match[1], 10);
+      const type = match[2];
+      byId.set(expressId, { expressId, type, byteOffset: start, byteLength: line.length, lineNumber: 1 });
+      const key = type.toUpperCase();
+      const list = byType.get(key) ?? [];
+      list.push(expressId);
+      byType.set(key, list);
+    }
+    cursor = start + line.length;
+  }
+
+  return {
+    source,
+    entityIndex: { byId, byType },
+    onDemandMaterialMap: density === null
+      ? new Map<number, number[]>()
+      : new Map<number, number[]>([[1, [10]]]),
+    // Present but possibly empty: `extractQuantitiesOnDemand` falls back to the
+    // prebuilt quantity TABLE when this map is absent, and these stores have
+    // no such table.
+    onDemandQuantityMap: declaredWeight === undefined
+      ? new Map<number, number[]>()
+      : new Map<number, number[]>([[1, [50]]]),
+  } as never;
+}
+
+/** 0.25 m³ x 2400 kg/m³ = 600 kg — chosen so the rendered figure has no
+ *  thousands separator to make the assertion locale-dependent. */
+const VOLUME = 0.25;
+const DENSITY = 2400;
+const EXPECTED_MASS = '600';
+
+function federatedModel(over: Record<string, unknown>) {
+  return {
+    id: 'm1',
+    name: 'model',
+    ifcDataStore: densityStore(DENSITY),
+    geometryResult: { meshes: [{ expressId: 1, geometryVolume: VOLUME }] },
+    visible: true,
+    idOffset: 0,
+    maxExpressId: 100000,
+    loadedAt: 1,
+    ...over,
+  } as never;
+}
+
+beforeEach(() => {
+  unmountAll();
+  useViewerStore.setState({
+    activeTool: 'measure',
+    measurements: [],
+    activeMeasurement: null,
+    pendingMeasurePoint: null,
+    measureReferencePoint: null,
+    selectedEntity: null,
+    selectedEntitiesSet: new Set<string>(),
+    models: new Map(),
+    ifcDataStore: null,
+    geometryResult: null,
+    unitDisplayOverrides: {},
+  });
+});
+
+after(() => {
+  unmountAll();
+});
+
+describe('#2736 acceptance 1: geometry + density with no declared weight produces a labelled mass', () => {
+  it('renders the derived mass', () => {
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({})]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(
+      text,
+      new RegExp(`Mass derived\\s*${EXPECTED_MASS} kg`),
+      `no derived mass on the panel despite geometry volume and a declared density: ${text}`,
+    );
+  });
+
+  it('never shows the derived number without the word that says it was derived', () => {
+    // The defect #2736 exists to prevent: a confident figure with no
+    // provenance. Asserted as "if the number is on screen at all, the label
+    // is too", so it holds however the row is later restyled.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({})]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, new RegExp(`${EXPECTED_MASS} kg`), text);
+    assert.match(text, /Mass derived/, `the mass rendered without its basis label: ${text}`);
+    assert.match(
+      text,
+      /Not an IFC-declared weight quantity/,
+      `the panel showed a calculated mass without saying the file never declared it: ${text}`,
+    );
+  });
+
+  it('does not label it a declared weight', () => {
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({})]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.doesNotMatch(
+      text,
+      /Weight\s*600/,
+      `a derived mass was presented as a declared Weight quantity: ${text}`,
+    );
+  });
+});
+
+describe('#2736 acceptance 2: an untrusted volume produces NO mass', () => {
+  it('withholds the mass entirely for a federation-rescaled model', () => {
+    // Same element, same density, same proved volume — the ONLY difference is
+    // that alignment re-baked this model's vertices (#1993), so the volume no
+    // longer describes what is on screen. A wrong mass is worse than none.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({ federationAlignmentStatus: 'same-crs' })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.doesNotMatch(
+      text,
+      /Mass derived/,
+      `a rescaled model's invalidated volume became a confident mass: ${text}`,
+    );
+    assert.doesNotMatch(text, new RegExp(`${EXPECTED_MASS} kg`), text);
+  });
+
+  it('says why, rather than looking like a model with no materials', () => {
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({ federationAlignmentStatus: 'same-crs' })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    assert.match(
+      container.textContent ?? '',
+      /federation alignment rescaled/,
+      container.textContent ?? '',
+    );
+  });
+});
+
+describe('#2736: an element with geometry but no material density gets no mass', () => {
+  it('shows the volume and no mass at all', () => {
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({ ifcDataStore: densityStore(null) })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /Volume mesh/, `the proved volume itself went missing: ${text}`);
+    assert.doesNotMatch(text, /Mass derived/, `a mass appeared with no density to derive it from: ${text}`);
+  });
+});
+
+describe('#2736: a server-parsed store has no material psets to read', () => {
+  it('reports the proved volume and no mass, without walking an index it does not have', () => {
+    // A server-parsed store carries prebuilt property and quantity TABLES and
+    // no STEP source — material psets live in `IfcMaterialProperties` entities
+    // that only the source can answer for. Asking anyway reads
+    // `entityIndex.byId` off a store that has no `entityIndex` and takes the
+    // whole panel down with it, which is how this guard was found.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({
+        ifcDataStore: {
+          source: new Uint8Array(0),
+          quantities: { getForEntity: () => [] },
+        } as never,
+      })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /Volume mesh/, `the panel failed to render at all: ${text}`);
+    assert.doesNotMatch(text, /Mass derived/, text);
+  });
+});
+
+describe('#2736 both directions: a declared weight is still reported, and not derived over', () => {
+  it('reports the file\'s own Qto weight and does NOT add a derived mass beside it', () => {
+    // Everything a derivation needs is present — proved volume AND a declared
+    // density — so an implementation that always derives would show 600 kg
+    // here. The file said 1234, and that is the answer.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({ ifcDataStore: densityStore(DENSITY, 1234) })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(text, /Weight net/, `the declared Qto weight stopped being reported: ${text}`);
+    assert.doesNotMatch(
+      text,
+      /Mass derived/,
+      `a derivation was shown for an element whose file declares its weight: ${text}`,
+    );
+    assert.doesNotMatch(
+      text,
+      new RegExp(`${EXPECTED_MASS} kg`),
+      `the declared weight was overwritten by the derived mass: ${text}`,
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-quantities-derived-weight.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-quantities-derived-weight.test.tsx
@@ -69,8 +69,9 @@ function unmountAll(): void {
 function densityStore(
   density: number | null,
   declaredWeight?: number,
+  unitLines: string[] = [],
 ) {
-  const lines = [`#1=IFCWALL('g1',$,'Wall',$,$,$,$,$,$);`];
+  const lines = [`#1=IFCWALL('g1',$,'Wall',$,$,$,$,$,$);`, ...unitLines];
   if (density !== null) {
     lines.push(
       `#10=IFCMATERIAL('Concrete C30/37',$,'concrete');`,
@@ -283,6 +284,94 @@ describe('#2736: a server-parsed store has no material psets to read', () => {
     const text = container.textContent ?? '';
     assert.match(text, /Volume mesh/, `the panel failed to render at all: ${text}`);
     assert.doesNotMatch(text, /Mass derived/, text);
+  });
+});
+
+/**
+ * `MASSDENSITYUNIT` declared as g/m³ rather than kg/m³ (an `IfcDerivedUnit` of
+ * gram^1 · metre^-3, so `siScale` is 1e-3). The assignment lists ONLY the
+ * derived unit, so `MASSUNIT` stays at its kg default and the rendered symbol
+ * is unchanged — the sole difference from the kg/m³ fixtures above is the
+ * factor the density has to be converted by.
+ *
+ * Without this, every component fixture declares its density in the SI unit
+ * where the converter's scale is 1, so `densitySiConverterFor` could be the
+ * identity function without any test noticing.
+ */
+const G_PER_M3_UNITS = [
+  `#200=IFCSIUNIT(*,.MASSUNIT.,$,.GRAM.);`,
+  `#201=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);`,
+  `#202=IFCDERIVEDUNITELEMENT(#200,1);`,
+  `#203=IFCDERIVEDUNITELEMENT(#201,-3);`,
+  `#204=IFCDERIVEDUNIT((#202,#203),.MASSDENSITYUNIT.,$);`,
+  `#210=IFCUNITASSIGNMENT((#204));`,
+  `#220=IFCPROJECT('p1',$,'P',$,$,$,$,$,#210);`,
+];
+
+/** A file writing a FORCE unit under `MASSUNIT` — the self-contradiction
+ *  #2736 §4 refuses to guess about. Same wall, same density, same volume. */
+const FORCE_MASSUNIT_UNITS = [
+  `#200=IFCSIUNIT(*,.MASSUNIT.,$,.NEWTON.);`,
+  `#210=IFCUNITASSIGNMENT((#200));`,
+  `#220=IFCPROJECT('p1',$,'P',$,$,$,$,$,#210);`,
+];
+
+describe('#2736: the density is converted from the unit the FILE declared it in', () => {
+  it('converts a g/m\u00b3 density before multiplying, rather than reading it as kg/m\u00b3', () => {
+    // 2 400 000 g/m³ IS 2400 kg/m³, so the honest answer is the same 600 kg
+    // the kg/m³ fixtures report. Taking the number at face value would print
+    // 600 000 kg — a thousand-fold error that looks entirely plausible.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({
+        ifcDataStore: densityStore(DENSITY * 1000, undefined, G_PER_M3_UNITS),
+      })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.match(
+      text,
+      new RegExp(`Mass derived\\s*${EXPECTED_MASS} kg`),
+      `the file's MASSDENSITYUNIT was not honoured when converting its density: ${text}`,
+    );
+    assert.doesNotMatch(
+      text,
+      /600[\s,'\u00a0\u202f]?000/,
+      `the g/m\u00b3 density was multiplied in as if it were kg/m\u00b3: ${text}`,
+    );
+  });
+});
+
+describe('#2736 \u00a74: a MASSUNIT that resolves to a force derives nothing', () => {
+  it('withholds the mass and says why, instead of guessing kilograms', () => {
+    // Everything a derivation needs is present; the only thing wrong is that
+    // the file declared newtons under MASSUNIT. kg/m³ x m³ is a mass and this
+    // file's own convention says the column is a force, so there is no answer
+    // that is not a guess.
+    useViewerStore.setState({
+      selectedEntitiesSet: new Set(['m1:1']),
+      models: new Map([['m1', federatedModel({
+        ifcDataStore: densityStore(DENSITY, undefined, FORCE_MASSUNIT_UNITS),
+      })]]),
+    });
+    const container = render();
+    openSection(container, 'Qty');
+    const text = container.textContent ?? '';
+    assert.doesNotMatch(
+      text,
+      /Mass derived/,
+      `a mass was derived for a file whose MASSUNIT declares a force: ${text}`,
+    );
+    assert.doesNotMatch(text, new RegExp(`${EXPECTED_MASS} `), text);
+    assert.match(
+      text,
+      /MASSUNIT declares a force/,
+      `the panel withheld the mass without saying why: ${text}`,
+    );
+    // The volume itself is untouched by the unit confusion — this is a
+    // refusal to derive, not a refusal to report what the kernel proved.
+    assert.match(text, /Volume mesh/, text);
   });
 });
 


### PR DESCRIPTION
Closes #2736. Weight derived from volume × material density, with provenance — and with the provenance treated as the point rather than a label added afterwards.

## Three bases, never summed together

`WeightBasis = 'declared' | 'derived-ifc-density' | 'derived-library-density'`, in a new pure module `weight.ts`. `rollupWeights` totals each basis separately and **never sums across them**, because a declared `Qto` weight, a weight from an IFC-declared density, and a weight from a project default are three different confidence levels. Derived rows render as "Mass derived" / "Mass estimated" with a tooltip and a footnote stating the figure is calculated rather than IFC-declared.

That follows the precedent the issue points at: the same module already refuses to treat `unqualified` volume as a synonym for `net` or `gross`, because a plain `Volume` makes no claim about openings.

## Acceptance, each pinned

**A model with no declared weight but with geometry + density produces a labelled mass.** RED against a shape-only stub:

```
not ok 1 - derives a mass from geometry volume and material density when nothing is declared
not ok 2 - multiplies the volume by the density
not ok 3 - labels the result derived, never plain "declared"
```

**An untrusted volume produces no mass rather than a wrong one.**

```
not ok 1 - produces NO mass from an untrusted volume, rather than a wrong one
```

**Both directions**, since a change that always derives would pass every derivation test while regressing the shipped feature:

```
not ok 1 - reports a declared weight as declared
not ok 2 - does NOT overwrite a declared weight with a derivation, even when both are available
```

**Honest caveat on the RED.** 11 of the 34 tests passed against the stub — all of them negative assertions ("returns no density", "treats undeclared MASSUNIT as mass"), which a `return none` stub satisfies by construction. They are not worthless (one was killed by a mutant below), but they are not evidence of the implementation on their own.

## Four mutants, each killed by a named test

| mutant | caught by |
|---|---|
| `DENSITY_PSET` → `'pset_materialsteel'` | `reads the density off Pset_MaterialCommon.MassDensity` + 7 more |
| `volume * density` → `volume + density` | `multiplies the volume by the density` + 2 more |
| deleted the `if (!volumeTrusted)` guard | `produces NO mass from an untrusted volume…`, `withholds the mass entirely for a federation-rescaled model` |
| declared-precedence branch forced false | `does NOT overwrite a declared weight with a derivation…` + 2 more |

**A gap I did not close**, stated rather than left to be found: mutating `densityToSi` to the identity in the *component* is not caught, because the component tests use kg/m³ where the scale is 1. The converter is asserted at unit level; its wiring is not.

## Mass vs force — resolved through `project_units`, not guessed

`QUANTITY_TYPE_UNIT` already maps `QuantityType.Weight → MASSUNIT / kg`, so `project_units` stays the canonical source and no second convention was invented. ρ[kg/m³] × V[m³] is unambiguously a mass, which is why the readout says **Mass**, not Weight.

The genuinely ambiguous case — a file whose `MASSUNIT` resolves to a force symbol (`N`, `kN`, `MN`, `lbf`, `kip`, which some exporters do write there) — **emits nothing** and shows an amber note explaining why. An *undeclared* `MASSUNIT` is treated as mass, IFC's own default, rather than as a third unknown state: refusing there would suppress the feature for nearly every file.

## Scoped out, deliberately

**The density library.** There is no project density library or settings surface in the viewer today. `derived-library-density` is a first-class, tested basis with a real render path, but **no source is wired to it**, so no library row can appear. Adding one needs a settings surface, persistence and a starter table — a product decision rather than part of this issue. To do it I would need: where the library lives (per-project or per-user), whether it keys on material name or IFC material category, and who seeds the defaults.

**IFC2X3 `IfcGeneralMaterialProperties.MassDensity`** is a scalar attribute the parser explicitly drops (`on-demand-extractors.ts:1050`). Reading it is a `packages/parser` change; noted in the changeset.

## A defect introduced and caught in flight

`extractMaterialPropertiesOnDemand` walks `entityIndex.byId`, and the server-parsed path has neither `source` nor `entityIndex` — so the first wiring **crashed the whole panel**. Caught by the pre-existing `measure-parity` test `reads type-declared quantities on the server-parsed path`. Now gated on `store.source?.length && store.entityIndex`, the same condition `extractProjectUnits` already uses, with a new named test pinning it.

## Counts

`weight.test.ts` 34/0 · `measure-quantities-derived-weight.test.tsx` 8/0 · all `components/viewer/tools/**` **302 pass / 0 fail** · `lib/units` 36/0 · `@ifc-lite/parser` 622 pass, 2 skipped. `tsc --noEmit` 0 errors after a build, also verified 171 == 171 against the pristine baseline beforehand. oxlint clean in the touched files. `check-changesets`, `check-unused-locals`, `check-test-wiring`, `check-source-text-assertions` all pass.

Not run: CI, e2e, the full sharded viewer suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
