### PR TITLE
fix(viewer): make a relative coordinate unmistakable for a position, and show its datum (#2737)

### DIFF
--- a/.changeset/relative-coordinate-datum-readout.md
+++ b/.changeset/relative-coordinate-datum-readout.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Make the Measure tool's relative-coordinate readout distinguishable from an absolute one, and show the datum it is measured from (#2737 §3).
+
+The temporary reference point itself already shipped: a store field and a subtraction feeding one "Rel. ref" row. Two things about how that row read are fixed here.
+
+The offset printed as `X 3.000  Y 4.000  Z 4.000` — character for character the shape every absolute coordinate the viewer shows uses (model-local, project/anchor, render-frame world, georeferenced). Only the small label cell beside it said otherwise, and a label cell is what a narrow panel or a screenshot crop loses. It now prints as signed per-axis deltas, `ΔX +3.000  ΔY +4.000  ΔZ +4.000`, so the distinction is carried in the value and survives being read out of context. A zero axis stays unsigned: an offset of nothing has no direction.
+
+The datum was also never displayed, only implied by the delta row's existence — an offset whose origin is off-screen or forgotten is a number nobody can act on. A **Datum** row now shows the reference point's own position, in the same frame and the same format as the Model row above it, because that is what it is: a point somebody picked. Both rows are derived from the store on every render, so moving the reference recomputes the offset in place and clearing it removes both rows rather than leaving their last numbers on screen.
+
+No change to when the datum is kept or dropped, to the absolute rows when no datum is set, or to the georeferenced projection.

--- a/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
+++ b/apps/viewer/src/components/viewer/tools/MeasurePointReadout.tsx
@@ -23,9 +23,20 @@
  * - **Render** — the shifted frame the renderer works in. Shown only when the
  *   pipeline actually shifted the model, since otherwise it is the same row
  *   twice under two labels.
- * - **Reference** — offset from a user-set datum. Shown once one is set.
+ * - **Datum** — the temporary reference point itself (#2737 §3), as a position
+ *   in the SAME frame and format as the Model row above, because that is what
+ *   it is: a point somebody picked. Shown once one is set.
+ * - **Relative** — the live point's offset FROM that datum. Also shown only
+ *   once one is set, and printed as signed per-axis deltas (`ΔX +2.500`) so it
+ *   cannot be read as a position. The two rows ship together on purpose: an
+ *   offset whose origin is off-screen or forgotten is a number nobody can act
+ *   on, so the datum is never left implied by the delta row's existence.
  * - **Map** — projected E/N/H and WGS84 lat/lon. Unchanged from #1674/#1679,
  *   and still gated on the Geo XYZ toggle and a usable IfcMapConversion.
+ *
+ * Only the Relative row is a delta; every other row is a position, and no
+ * datum is ever subtracted from one. A relative reading and a georeferenced
+ * one are therefore never the same number wearing different labels.
  */
 
 import { Crosshair, Globe, MapPin, XCircle } from 'lucide-react';
@@ -90,6 +101,13 @@ export function MeasurePointReadout() {
   const offset = referencePoint
     ? relativeOffset(coords.local, viewerToIfcAxes(referencePoint))
     : null;
+  // The datum's own position, resolved through the SAME frame reconstruction
+  // as the live point so the two rows are comparable by eye. Derived on every
+  // render from the store rather than captured when the datum was set: moving
+  // or clearing the reference re-renders this component, so a displayed offset
+  // and the datum printed beside it can never disagree with each other or
+  // outlive the datum they were taken from.
+  const datum = referencePoint ? pointCoordinates(referencePoint, frame) : null;
   const enh = showGeo && anchor ? projectedEnh(livePoint, anchor) : null;
 
   return (
@@ -132,9 +150,19 @@ export function MeasurePointReadout() {
         {coords.shifted && (
           <CoordRow label="Render" value={formatCoordinateTriple(coords.local)} hint="m" />
         )}
+        {datum && (
+          <CoordRow
+            label="Datum"
+            // A position, not a delta — same frame, same formatter, same
+            // unlabelled metres as the Model row, because reading the two
+            // against each other is the point of showing it at all.
+            value={formatCoordinateTriple(datum.world)}
+            hint="m"
+          />
+        )}
         {offset && (
           <CoordRow
-            label="Rel. ref"
+            label="Relative"
             // dx/dy/dz are a LENGTH DELTA, not a raw model coordinate — unlike
             // the Model/Render/Map rows above, this triple must honour the
             // same LENGTHUNIT override as the trailing distance hint, or the

--- a/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
@@ -57,32 +57,61 @@ describe('formatDistance', () => {
   });
 });
 
-// #2538 deep review: MeasurePointReadout's "Rel. ref" row converted only its
+// #2538 deep review: MeasurePointReadout's relative row converted only its
 // trailing distance hint, leaving the X/Y/Z triple beside it in unlabelled
 // metres — a `ft` override made the row read a metre triple next to a feet
 // distance. `formatSignedTriple` is the fix: the same LENGTHUNIT conversion
 // `formatDistance` applies to the hint, applied per axis to the triple.
 describe('formatSignedTriple', () => {
-  it('keeps the pre-#2199 unlabelled-metres triple when overrides is omitted', () => {
-    assert.strictEqual(formatSignedTriple({ x: 1, y: 2, z: 3 }), 'X 1.000  Y 2.000  Z 3.000');
+  it('keeps unlabelled metres when overrides is omitted', () => {
+    assert.strictEqual(
+      formatSignedTriple({ x: 1, y: 2, z: 3 }),
+      'ΔX +1.000  ΔY +2.000  ΔZ +3.000',
+    );
   });
 
-  it('keeps the unlabelled-metres triple for an empty override map', () => {
-    assert.strictEqual(formatSignedTriple({ x: 1, y: 2, z: 3 }, {}), 'X 1.000  Y 2.000  Z 3.000');
+  it('keeps unlabelled metres for an empty override map', () => {
+    assert.strictEqual(
+      formatSignedTriple({ x: 1, y: 2, z: 3 }, {}),
+      'ΔX +1.000  ΔY +2.000  ΔZ +3.000',
+    );
   });
 
   it('converts every axis into the LENGTHUNIT override, matching formatDistance per axis', () => {
     // 1 m -> 3.2808 ft, 2 m -> 6.5617 ft, 3 m -> 9.8425 ft (3.28084 ft/m).
     assert.strictEqual(
       formatSignedTriple({ x: 1, y: 2, z: 3 }, { LENGTHUNIT: 'ft' }),
-      'X 3.2808  Y 6.5617  Z 9.8425',
+      'ΔX +3.2808  ΔY +6.5617  ΔZ +9.8425',
     );
   });
 
-  it('keeps negative axes signed after conversion', () => {
+  it('keeps negative axes signed after conversion, and leaves a zero axis unsigned', () => {
     assert.strictEqual(
       formatSignedTriple({ x: -1, y: 0, z: 3.048 }, { LENGTHUNIT: 'ft' }),
-      'X -3.2808  Y 0  Z 10',
+      'ΔX -3.2808  ΔY 0  ΔZ +10',
     );
+  });
+
+  it('marks every axis as a delta, so the triple cannot be read as a position (#2737 §3)', () => {
+    // The acceptance criterion — *a relative coordinate is visually distinct
+    // from an absolute one* — held in the value itself, not in the row label
+    // beside it. The four absolute kinds the viewer prints (model-local,
+    // project/anchor, render-frame world, georeferenced) all render as
+    // `X … Y … Z …`; this must never collide with that shape, whatever the
+    // unit or the sign.
+    for (const [p, overrides] of [
+      [{ x: 1, y: 2, z: 3 }, {}],
+      [{ x: -1, y: 0, z: 3.048 }, { LENGTHUNIT: 'ft' }],
+      [{ x: 0, y: 0, z: 0 }, { LENGTHUNIT: 'mm' }],
+    ] as const) {
+      const out = formatSignedTriple(p, overrides);
+      assert.doesNotMatch(out, /(^|\s)X /, `a delta triple printed like a position: "${out}"`);
+      assert.match(out, /^ΔX .*ΔY .*ΔZ /, `axis markers missing: "${out}"`);
+    }
+  });
+
+  it('gives a zero offset no direction', () => {
+    // `+0.000` claims a direction an offset of nothing does not have.
+    assert.strictEqual(formatSignedTriple({ x: 0, y: 0, z: 0 }), 'ΔX 0.000  ΔY 0.000  ΔZ 0.000');
   });
 });

--- a/apps/viewer/src/components/viewer/tools/formatDistance.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.ts
@@ -68,7 +68,7 @@ function formatDistanceMagnitude(meters: number, overrides: Record<string, strin
 
 /**
  * Format a signed X/Y/Z LENGTH-DELTA triple honoring the LENGTHUNIT display
- * override, e.g. `X 3.2808  Y 6.5617  Z 9.8425`.
+ * override, e.g. `ΔX +3.2808  ΔY +6.5617  ΔZ -9.8425`.
  *
  * This is for a triple that IS a distance — the Measure tool's
  * relative-reference offset (dx/dy/dz from a user-set datum), the same kind
@@ -78,7 +78,20 @@ function formatDistanceMagnitude(meters: number, overrides: Record<string, strin
  * point positions in a file's own coordinate system or a projected CRS, and
  * are deliberately out of #2199's scope.
  *
- * Deep review on #2538: before this, the "Rel. ref" row converted only its
+ * The `Δ` prefix and the explicit `+` are the #2737 §3 acceptance criterion —
+ * *a relative coordinate is visually distinct from an absolute one* — carried
+ * in the VALUE rather than only in the row label beside it. The viewer names
+ * four kinds of coordinate (model-local, project/anchor, render-frame world
+ * and georeferenced), every one of which prints as `X … Y … Z …`; a fifth kind
+ * that printed the same way would be told apart only by the label cell, and a
+ * label cell is exactly what a narrow panel, a copied line or a screenshot
+ * crop loses. `ΔX +2.500` cannot be misread as a position no matter where it
+ * is quoted.
+ *
+ * A zero axis gets no sign: an offset of nothing has no direction, and `+0.000`
+ * claims one.
+ *
+ * Deep review on #2538: before this, the relative row converted only its
  * trailing distance hint, leaving the triple beside it in unlabelled metres —
  * a `ft` override made the row read e.g. `X 1.000 Y 2.000 Z 3.000  12.2758
  * ft`, mixing units in one line. All three axes share one override, so the
@@ -89,6 +102,11 @@ export function formatSignedTriple(
   p: { x: number; y: number; z: number },
   overrides: Record<string, string> = {},
 ): string {
-  const axis = (n: number) => formatDistanceMagnitude(n, overrides);
-  return `X ${axis(p.x)}  Y ${axis(p.y)}  Z ${axis(p.z)}`;
+  const axis = (n: number) => {
+    const magnitude = formatDistanceMagnitude(n, overrides);
+    // A negative value already carries its own '-' from the formatter, so only
+    // the positive direction needs one added.
+    return n > 0 ? `+${magnitude}` : magnitude;
+  };
+  return `ΔX ${axis(p.x)}  ΔY ${axis(p.y)}  ΔZ ${axis(p.z)}`;
 }

--- a/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
@@ -213,6 +213,23 @@ function coordRowLabel(container: HTMLElement, value: RegExp): string {
   return row.querySelector(':scope > span')?.textContent?.trim() ?? '';
 }
 
+/**
+ * The VALUE cell of the coordinate row whose label cell reads exactly `label`.
+ *
+ * The inverse of {@link coordRowLabel}, and needed for the same reason: the
+ * relative rows print a triple that a whole-panel text scan cannot tell from
+ * the absolute row above them (that indistinguishability is the very thing
+ * #2737 §3 is about), so a row has to be reached by its label, then read.
+ */
+function coordRow(container: HTMLElement, label: string): { value: string; hint: string } | null {
+  const row = [...container.querySelectorAll('div')].find(
+    (d) => d.querySelector(':scope > span')?.textContent?.trim() === label,
+  );
+  if (!row) return null;
+  const spans = row.querySelectorAll(':scope > span');
+  return { value: spans[1]?.textContent ?? '', hint: spans[2]?.textContent ?? '' };
+}
+
 /** Click the panel's section button whose label is `label`. */
 function openSection(container: HTMLElement, label: string): void {
   const button = [...container.querySelectorAll('button')].find(
@@ -386,8 +403,8 @@ describe('the shipped panel hosts each #2199 section', () => {
     // Renderer (3, 3, -4) -> IFC (3, 4, 3). The northing is +4, not -4: the
     // sign is what a dropped negation would flip.
     assert.match(text, /X 3\.000\s+Y 4\.000\s+Z 3\.000/, `wrong model coordinates: ${text}`);
-    // Offset from IFC (0, 0, -1) is (3, 4, 4).
-    assert.match(text, /X 3\.000\s+Y 4\.000\s+Z 4\.000/, `wrong relative offset: ${text}`);
+    // Offset from IFC (0, 0, -1) is (3, 4, 4), printed as signed deltas.
+    assert.match(text, /ΔX \+3\.000\s+ΔY \+4\.000\s+ΔZ \+4\.000/, `wrong relative offset: ${text}`);
   });
 
   it('Qty answers for an empty selection instead of rendering nothing', () => {
@@ -484,7 +501,7 @@ describe('the LENGTHUNIT override reaches every rendered readout (#2538 wiring g
     assert.match(text, /H 10 ft\s+V 0 ft/, `horizontal\/vertical line did not convert to ft: ${text}`);
   });
 
-  it('Point: the Rel. ref triple and its distance hint agree in the override unit', () => {
+  it('Point: the Relative triple and its distance hint agree in the override unit', () => {
     useViewerStore.setState({
       measurements: [{ id: 'm1', start: FT_START, end: FT_END, distance: 3.048 }],
       // Reference point at the origin (renderer space) so the offset to the
@@ -495,24 +512,20 @@ describe('the LENGTHUNIT override reaches every rendered readout (#2538 wiring g
     const container = render();
     openSection(container, 'Point');
 
-    // Isolate the "Rel. ref" row specifically — the Model row above it stays
+    // Isolate the "Relative" row specifically — the Model row above it stays
     // in unlabelled metres by design (#2199 scope), and DOES print "X 3.048"
     // for this same fixture, so a whole-panel text search cannot tell the two
     // apart.
-    const relRefRow = [...container.querySelectorAll('div')].find(
-      (d) => d.querySelector(':scope > span')?.textContent?.trim() === 'Rel. ref',
-    );
-    assert.ok(relRefRow, `no "Rel. ref" row rendered: ${container.textContent}`);
-    const spans = relRefRow!.querySelectorAll(':scope > span');
-    const value = spans[1]?.textContent ?? '';
-    const hint = spans[2]?.textContent ?? '';
+    const relRefRow = coordRow(container, 'Relative');
+    assert.ok(relRefRow, `no "Relative" row rendered: ${container.textContent}`);
+    const { value, hint } = relRefRow;
 
     // Renderer (3.048, 0, 0) -> IFC (3.048, 0, 0): dx=3.048 -> 10 ft.
-    assert.match(value, /X 10\s+Y 0\s+Z 0/, `Rel. ref triple did not convert to ft: "${value}"`);
-    assert.equal(hint, '10 ft', `Rel. ref distance hint did not convert to ft: "${hint}"`);
+    assert.match(value, /ΔX \+10\s+ΔY 0\s+ΔZ 0/, `Relative triple did not convert to ft: "${value}"`);
+    assert.equal(hint, '10 ft', `Relative distance hint did not convert to ft: "${hint}"`);
     // The failure mode this guards: hint converts but the triple stays in
-    // unlabelled metres, e.g. "X 3.048  Y 0.000  Z 0.000" next to "10 ft".
-    assert.doesNotMatch(value, /X 3\.048/, `Rel. ref triple fell back to unconverted metres: "${value}"`);
+    // unlabelled metres, e.g. "ΔX +3.048  ΔY 0.000  ΔZ 0.000" next to "10 ft".
+    assert.doesNotMatch(value, /3\.048/, `Relative triple fell back to unconverted metres: "${value}"`);
   });
 
   it('does not convert when unitDisplayOverrides is empty, as the control for the tests above', () => {
@@ -693,6 +706,45 @@ describe('the relative-coordinate datum belongs to the scene it was picked in', 
     );
   });
 
+  it('survives a measure-mode switch, like the session settings and unlike the in-progress gesture', () => {
+    // Which comparable state does the datum follow? `setMeasureMode` discards
+    // GESTURE state (the in-progress drag/polyline/angle and the snap target)
+    // because picks taken under one mode mean something else under the next.
+    // It leaves the session SETTINGS (`snapEnabled`, `geoReadoutEnabled`)
+    // alone. A setting-out datum is a session choice, not a half-finished
+    // pick — the same origin is still the origin whether the next reading is
+    // taken by drag, polyline or angle — so it follows the settings.
+    useViewerStore.setState({
+      measureMode: 'drag',
+      measureReferencePoint: { x: 1, y: 2, z: 3 },
+      activeMeasurement: { start: START, current: END, distance: Math.hypot(3, 3, 4) },
+    });
+    useViewerStore.getState().setMeasureMode('polyline');
+    const after = useViewerStore.getState();
+    assert.equal(after.activeMeasurement, null, 'the gesture should have been discarded');
+    assert.deepEqual(
+      after.measureReferencePoint,
+      { x: 1, y: 2, z: 3 },
+      'switching how the next point is picked must not move the origin it is measured from',
+    );
+  });
+
+  it('survives leaving the measure tool entirely', () => {
+    // `setActiveTool` away from 'measure' calls `resetMeasureGesture`, which
+    // is the one boundary that clears every in-progress pick. The datum is not
+    // one: re-entering the tool to take one more offset from the same origin
+    // is the whole point of a temporary reference point.
+    useViewerStore.setState({
+      activeTool: 'measure',
+      measureReferencePoint: { x: 1, y: 2, z: 3 },
+      activeMeasurement: { start: START, current: END, distance: Math.hypot(3, 3, 4) },
+    });
+    useViewerStore.getState().setActiveTool('select');
+    const after = useViewerStore.getState();
+    assert.equal(after.activeMeasurement, null, 'the gesture should have been discarded');
+    assert.deepEqual(after.measureReferencePoint, { x: 1, y: 2, z: 3 });
+  });
+
   it('is dropped when a new primary file replaces the scene', () => {
     // The datum is stored in RENDERER space. Carried into the next model it
     // would subtract a point from the outgoing scene and print a plausible,
@@ -700,6 +752,110 @@ describe('the relative-coordinate datum belongs to the scene it was picked in', 
     useViewerStore.setState({ measureReferencePoint: { x: 1, y: 2, z: 3 } });
     useViewerStore.getState().resetViewerState();
     assert.equal(useViewerStore.getState().measureReferencePoint, null);
+  });
+});
+
+describe('a relative coordinate is visually distinct from an absolute one (#2737 §3)', () => {
+  /** Live point renderer (3, 3, -4) = IFC (3, 4, 3); datum renderer (0, -1, 0)
+   *  = IFC (0, 0, -1), so the offset is IFC (3, 4, 4) — distinct on every
+   *  axis from both the absolute point and the datum. */
+  const seedPickAndDatum = (datum: Vec3 | null = { x: 0, y: -1, z: 0 }) => {
+    useViewerStore.setState({
+      measurements: [{ id: 'm1', start: START, end: END, distance: Math.hypot(3, 3, 4) }],
+      measureReferencePoint: datum,
+    });
+  };
+
+  it('prints the relative triple in a form no absolute row uses', () => {
+    seedPickAndDatum();
+    const container = render();
+    openSection(container, 'Point');
+    const model = coordRow(container, 'Model');
+    const relative = coordRow(container, 'Relative');
+    assert.ok(model, `no Model row: ${container.textContent}`);
+    assert.ok(relative, `no Relative row: ${container.textContent}`);
+    // The absolute row is a bare X/Y/Z position.
+    assert.match(model.value, /^X 3\.000\s+Y 4\.000\s+Z 3\.000$/, `Model row: "${model.value}"`);
+    // The relative row is per-axis deltas with explicit signs. The
+    // distinction lives in the VALUE, not only in the label beside it, so it
+    // survives being read out of context.
+    assert.match(
+      relative.value,
+      /^ΔX \+3\.000\s+ΔY \+4\.000\s+ΔZ \+4\.000$/,
+      `Relative row: "${relative.value}"`,
+    );
+    assert.doesNotMatch(
+      relative.value,
+      /^X /,
+      `a relative triple formatted like an absolute coordinate: "${relative.value}"`,
+    );
+  });
+
+  it('shows the datum the offset is measured from, in the same frame as the absolute row', () => {
+    // The failure mode #2737 names: a number whose reference point is
+    // off-screen or forgotten. The origin has to be READABLE, not implied by
+    // the existence of a delta row.
+    seedPickAndDatum();
+    const container = render();
+    openSection(container, 'Point');
+    const datum = coordRow(container, 'Datum');
+    assert.ok(datum, `the reference point itself is not shown: ${container.textContent}`);
+    // Renderer (0, -1, 0) -> IFC (0, 0, -1). Printed exactly like the Model
+    // row, because it IS a model coordinate — a position, not a delta.
+    assert.match(datum.value, /^X 0\.000\s+Y 0\.000\s+Z -1\.000$/, `Datum row: "${datum.value}"`);
+  });
+
+  it('shows neither relative row, and an unchanged absolute one, when no datum is set', () => {
+    // The other direction: a change that always subtracts would satisfy every
+    // test above while breaking the coordinate readout that already shipped.
+    seedPickAndDatum(null);
+    const container = render();
+    openSection(container, 'Point');
+    assert.equal(coordRow(container, 'Relative'), null, 'a relative row with no datum set');
+    assert.equal(coordRow(container, 'Datum'), null, 'a datum row with no datum set');
+    const model = coordRow(container, 'Model');
+    assert.ok(model, `no Model row: ${container.textContent}`);
+    assert.match(model.value, /^X 3\.000\s+Y 4\.000\s+Z 3\.000$/, `Model row: "${model.value}"`);
+  });
+
+  it('recomputes the offset in place when the datum is moved under a reading on screen', () => {
+    seedPickAndDatum();
+    const container = render();
+    openSection(container, 'Point');
+    assert.match(coordRow(container, 'Relative')?.value ?? '', /ΔZ \+4\.000/);
+
+    // Move the datum a metre up in renderer Y (IFC Z -1 -> +1): the offset's
+    // Z must fall from +4 to +2, not keep the number taken from the old
+    // origin.
+    act(() => {
+      useViewerStore.getState().setMeasureReferencePoint({ x: 0, y: 1, z: 0 });
+    });
+    const moved = coordRow(container, 'Relative');
+    assert.match(
+      moved?.value ?? '',
+      /^ΔX \+3\.000\s+ΔY \+4\.000\s+ΔZ \+2\.000$/,
+      `stale offset after the datum moved: "${moved?.value}"`,
+    );
+    assert.match(
+      coordRow(container, 'Datum')?.value ?? '',
+      /^X 0\.000\s+Y 0\.000\s+Z 1\.000$/,
+      'the displayed datum did not follow the store',
+    );
+  });
+
+  it('removes the relative rows when the datum is cleared, rather than leaving their last numbers', () => {
+    seedPickAndDatum();
+    const container = render();
+    openSection(container, 'Point');
+    assert.ok(coordRow(container, 'Relative'));
+
+    act(() => {
+      useViewerStore.getState().setMeasureReferencePoint(null);
+    });
+    assert.equal(coordRow(container, 'Relative'), null, 'a relative offset outlived its origin');
+    assert.equal(coordRow(container, 'Datum'), null, 'a datum row outlived the datum');
+    // And the absolute readout is still there and still absolute.
+    assert.match(coordRow(container, 'Model')?.value ?? '', /^X 3\.000\s+Y 4\.000\s+Z 3\.000$/);
   });
 });
 


### PR DESCRIPTION
#2737 §3, but **narrower than the issue implies** — and the correction is the first thing worth saying.

## §3 was already substantially shipped

Not by #2737 work: `measureReferencePoint` (store field), `relativeOffset()`, a set/clear button pair and a `Rel. ref` row all landed inside #2514/#2538 as part of #2199. I claimed this issue expecting to build the feature; most of it existed.

What did **not** hold is precisely what the issue warns about:

> "The care needed is in the **labelling**: a relative coordinate must never be mistakable for a project or georeferenced one."

and the acceptance bullet that the origin must be visible rather than implied. That is what this changes.

## The fifth kind is two rows, not one

`MeasurePointReadout.tsx` is the vocabulary's one home, stacking rows most-local outwards, each a **position**: **Model** (IFC Z-up, relabelled **Anchor** when a federation alignment re-based models into another file's frame, so the label never claims a file the numbers may not belong to), **Render** (shown only when `coords.shifted`), and **Map** / **Lat / Lon** via `projectedEnh`.

A relative reading is two facts, so it slots in as two rows:

- **Datum** — the reference point's own position, printed by the *same* `formatCoordinateTriple` in the *same* frame. It is a position, so it joins the existing vocabulary unchanged.
- **Relative** — the delta, which is **not** a position and must not print like one. `formatSignedTriple` emits `ΔX +3.000  ΔY +4.000  ΔZ +4.000`.

**The distinction lives in the value, not the label cell.** That is deliberate: a lost or mistranslated label still leaves `ΔX` unmistakable, whereas a bare `X 3.000` labelled "Relative" is one CSS change away from reading as a coordinate.

## RED

`36 tests / 32 pass / 4 fail`, all four in the new block:

```
'no Relative row: …Last pointModelX 3.000 Y 4.000 Z 3.000mRel. refX 3.000 Y 4.000 Z 4.000…'
'the reference point itself is not shown: …Rel. refX 3.000 Y 4.000 Z 4.000…'
'null == true'            (removes the relative rows when the datum is cleared)
(empty vs '')             (recomputes the offset in place when the datum is moved)
```

## Six mutants, six killed by name

| mutant | caught by |
|---|---|
| `relativeOffset` subtraction → addition | `prints the relative triple in a form no absolute row uses` + 2 |
| relative row's label → `"Model"` | same + `…the Relative triple and its distance hint agree in the override unit` |
| drop the `Δ` markers | all 6 `formatSignedTriple` cases + 4 panel tests |
| always subtract (unset datum as origin) | `shows neither relative row, and an unchanged absolute one, when no datum is set` |
| Datum row removed | `shows the datum the offset is measured from…` |
| datum snapshotted instead of re-derived | `recomputes the offset in place when the datum is moved under a reading on screen` |

## Datum lifetime — the rule, and what is characterization rather than new

**It survives a mode switch, and that was already the shipped behaviour.** The tests pinning it are characterization and **would pass with this change reverted** — stating that rather than counting them as evidence.

The rule they pin: `setMeasureMode` discards **gesture** state (`activeMeasurement`, `activePolyline`, `activeAngle`, `snapTarget`), and `resetMeasureGesture` does the same on leaving the tool; **session settings** (`snapEnabled`, `geoReadoutEnabled`) survive both. A setting-out datum is a session choice, not a half-finished pick — the same origin is still the origin whether the next reading is a drag, polyline or angle — so it follows the settings. It is dropped only by `resetAllMeasurementState`, which is correct: it is stored in renderer space.

Both tests also assert the gesture *was* discarded, so they cannot pass by nothing happening.

## Stale relative values: recompute, and remove on clear — never mark stale

Both rows derive from the store on every render, so there is no snapshot to go stale. Pinned by `recomputes the offset in place when the datum is moved under a reading on screen` (the offset's Z falls +4 → +2 **and** the Datum row follows) and `removes the relative rows when the datum is cleared, rather than leaving their last numbers` (both rows vanish **and** the absolute row survives). The snapshot mutant exists to prove the alternative would be caught.

## Can a relative value render unlabelled?

No path found, checked rather than assumed. `formatSignedTriple` has exactly one production call site, and its output self-identifies. On loading or no-pick the component early-returns a prompt, so there is no value at all. **There is no clipboard or export path for measurements** — `grep -rl clipboard apps/viewer/src` returns 16 files, none under `components/viewer/tools/`; `PropertiesPanel`'s copy path uses `renderToWorldViewer` and never sees the datum.

The georeferenced readout is untouched: `projectedEnh(livePoint, anchor)` takes the live point, never the offset, and the datum is subtracted in exactly one place. The `each printed number comes from the source it claims` suite still passes.

## Counts

Measure-mode suites and neighbours: **274 tests, 274 pass, 0 fail** across 56 suites. Targeted `measure-parity` + `formatDistance` 48/48. `tsc --noEmit` clean. `pnpm lint` — which runs `check-changesets`, `check-test-glob-coverage`, `check-unused-locals`, `check-lint-ran` — no errors.

Not run: the full viewer suite or a viewer build (disk).

The changeset says plainly that the reference point already shipped, names only what changed, and disclaims changes to datum lifetime, the absolute rows and the projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
