### PR TITLE
fix(viewer): wait for the run gate instead of sleeping 50ms past a retired QuickJS module (#3060)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -383,6 +383,19 @@ jobs:
   # Cost of going back to 1, measured: ~70s versus ~19s per shard locally,
   # roughly 8 minutes versus 2 on CI, against a 25 minute cap.
   #
+  # Correction: dropping to 1 MITIGATED #3060, it did not fix it. The defect
+  # was in that file's fixture, which slept a flat 50ms and then asserted that
+  # a run had reached its host gate. The #1922 tests at the bottom of that file
+  # abort a WASM module, the aborted module is retired, and the next run pays a
+  # fresh `newQuickJSWASMModule()` — measured at 46-72ms on a contended
+  # machine, straddling the sleep. Reproduced locally at 11/30 failures with
+  # the exact reported `0 !== 1, then 2 !== 1`, on Node 22.13.1 AND 22.23.2,
+  # by loading the machine rather than by raising concurrency; the fixture now
+  # waits for the gate instead of predicting it, and the same load gives 30/30.
+  # So concurrency was the exposure, not the cause: this setting is still worth
+  # keeping for the other timing-sensitive tests it protects, but it is no
+  # longer what stands between #3060 and a red shard.
+  #
   # Two earlier explanations in this file were WRONG and are corrected here,
   # because a confident wrong comment is worse than none:
   #

--- a/apps/viewer/src/hooks/useSandbox.runSupersession.test.tsx
+++ b/apps/viewer/src/hooks/useSandbox.runSupersession.test.tsx
@@ -175,9 +175,55 @@ after(() => {
   container?.remove();
 });
 
-/** Let the host microtask/timer queues turn so a parked run can make progress. */
-async function tick(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 50));
+/**
+ * How long a run is allowed to take to reach its host gate before the wait
+ * below gives up and lets the call site's assertion report what it found.
+ *
+ * This is a HANG bound, not a timing assumption: it is the same order as the
+ * sandbox's own `timeoutMs`, while the wait it bounds normally ends within a
+ * few milliseconds. Nothing about a passing run depends on its value.
+ */
+const GATE_PARK_TIMEOUT_MS = 10_000;
+
+/**
+ * Turn the host queues until the guest has parked on `count` host gates.
+ *
+ * This used to be a flat 50ms sleep, which is a GUESS about how long
+ * `execute()` needs to import `@ifc-lite/sandbox` and stand up a QuickJS
+ * runtime — and the guess is wrong precisely where this file makes it
+ * hardest. The #1922 tests at the bottom abort a real WASM module, and an
+ * aborted module is RETIRED (`retireQuickJSModule`), so the next `execute()`
+ * pays a full fresh `newQuickJSWASMModule()` instead of reusing the cached
+ * one. Measured on a loaded machine, that one site reaches 46-72ms while
+ * every other site here stays under ~20ms: the sleep straddled the cost it
+ * was supposed to cover.
+ *
+ * When it lost, the damage did not stop at one test. The assertion threw with
+ * the run still un-awaited, that orphaned run parked a moment later into the
+ * NEXT test's freshly emptied `gates`, and that test then counted two — the
+ * `0 !== 1, then 2 !== 1` pair reported as issue #3060, which read as a flake
+ * because the trigger is load, not the diff under test.
+ *
+ * Waiting for the event instead of predicting it removes the guess rather
+ * than enlarging it. Every call site keeps its exact `gates.length` assertion
+ * afterwards, so a run that parks on the wrong number of gates — including
+ * one that leaked in from an earlier test — still fails on the count.
+ *
+ * **The same guess in its other disguise.** Sites that start a second run and
+ * `await` it were relying on the newer run settling to prove the older one had
+ * already REACHED its gate. That is the identical assumption with the sleep
+ * spelled differently, and it loses the same way: under load the older run can
+ * still be standing up its sandbox, and the gate count reads 0. Those sites
+ * call this helper too, and they call it AFTER their settle-order assertion —
+ * that assertion is the load-bearing one, and the wait cannot mask a violation
+ * of it, because a run parked on a gate cannot settle until this file opens
+ * that gate.
+ */
+async function waitForGates(count: number): Promise<void> {
+  const deadline = Date.now() + GATE_PARK_TIMEOUT_MS;
+  while (gates.length < count && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
 }
 
 describe('useSandbox().execute() — cross-instance run supersession', () => {
@@ -203,6 +249,8 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
         ['B'],
         'the older run A must still be in flight when the newer run B settles — without that ordering there is no clobber to guard against and this whole test is vacuous',
       );
+      // Settle order first, gate count second — see `waitForGates`.
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'instance A must be parked on exactly one host gate');
 
       gates[0]!({ marker: 'A-result' });
@@ -263,7 +311,7 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
 
     await act(async () => {
       const p = execute1!(GATED).then((x) => { r = x; });
-      await tick();
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'the lone run must be parked on its gate');
       gates[0]!({ marker: 'lone-result' });
       await p;
@@ -315,6 +363,8 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
       const pB = execute2!(UNGATED).then(() => { settleOrder.push('B'); });
       await pB;
       assert.deepEqual(settleOrder, ['B'], 'A must still be parked when B settles');
+      // Settle order first, gate count second — see `waitForGates`.
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'A must be parked on its host gate');
       gates[0]!({ marker: 'unused' });
       await pA;
@@ -340,7 +390,7 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
     let rA: ScriptResult | null | undefined;
     await act(async () => {
       const pA = execute1!(GATED).then((r) => { rA = r; });
-      await tick();
+      await waitForGates(1);
       assert.equal(gates.length, 1, "instance A's run must be in flight when reset() fires");
       reset1!();
       gates[0]!({ marker: 'stale' });
@@ -372,7 +422,7 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
     await act(async () => {
       const pA = execute1!(GATED).then((r) => { rA = r; });
       reset1!();
-      await tick();
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'the superseded run still runs to its gate — reset() only bumps the epoch here, it has no sandbox to dispose yet');
       gates[0]!({ marker: 'stale' });
       await pA;
@@ -397,6 +447,8 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
       const pSecond = execute1!(UNGATED).then((r) => { settleOrder.push('second'); rSecond = r; });
       await pSecond;
       assert.deepEqual(settleOrder, ['second'], 'the first run must still be parked when the second settles');
+      // Settle order first, gate count second — see `waitForGates`.
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'the first run must be parked on its host gate');
       gates[0]!({ marker: 'superseded' });
       await pFirst;
@@ -427,7 +479,7 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
 
     await act(async () => {
       const pB = execute2!(GATED).then((r) => { rB = r; });
-      await tick();
+      await waitForGates(1);
       assert.equal(gates.length, 1, "instance B's run must be in flight when instance A resets");
       reset1!();
       gates[0]!({ marker: 'B-result' });
@@ -464,7 +516,7 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
     let r: ScriptResult | null | undefined;
     await act(async () => {
       const p = executeOom!(GATED_OOM_AT_TEARDOWN).then((x) => { r = x; });
-      await tick();
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'the reproducer must be parked on its host gate');
       gates[0]!({ marker: 'A-result' });
       await p;
@@ -500,6 +552,8 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
       const pB = execute2!(UNGATED).then(() => { settleOrder.push('B'); });
       await pB;
       assert.deepEqual(settleOrder, ['B'], 'the aborting run must still be parked when the newer run settles');
+      // Settle order first, gate count second — see `waitForGates`.
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'the aborting run must be parked on its host gate');
       gates[0]!({ marker: 'A-result' });
       await pA;
@@ -530,7 +584,7 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
     let r: ScriptResult | null | undefined;
     await act(async () => {
       const p = executeOom!(GATED_OOM_AT_TEARDOWN_AFTER_THROW).then((x) => { r = x; });
-      await tick();
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'the reproducer must be parked on its host gate');
       gates[0]!({ marker: 'unused' });
       await p;
@@ -555,6 +609,8 @@ describe('useSandbox().execute() — cross-instance run supersession', () => {
       const pB = execute2!(UNGATED).then(() => { settleOrder.push('B'); });
       await pB;
       assert.deepEqual(settleOrder, ['B'], 'the aborting run must still be parked when the newer run settles');
+      // Settle order first, gate count second — see `waitForGates`.
+      await waitForGates(1);
       assert.equal(gates.length, 1, 'the aborting run must be parked on its host gate');
       gates[0]!({ marker: 'unused' });
       await pA;


### PR DESCRIPTION
Closes #3060. Reproduced, root-caused, fixed — and both of the framings in the issue turn out to be off, including mine.

## It does not fail alone, and it is not Node-version-dependent

The issue records *"I have not run it in isolation"*. Closing that gap: **30/30 pass unloaded** on Node 22.13.1, and 30/30 on 22.23.2.

I also checked the version hypothesis, since two CI-only hangs this week were `module.registerHooks` (Node 22.15.0) turning an apparent flake into a deterministic failure. Downloaded `node-v22.23.2-darwin-arm64` and ran both. **Both versions fail before and pass after, with the identical signature** — so the loader change is not implicated here.

**It is load-dependent.** With background CPU load: **11/30 failures**, carrying the exact reported `0 !== 1, then 2 !== 1` on `"the reproducer must be parked on its host gate"`.

## The preceding-file framing is off by one boundary

The issue reasons from a `QuickJS aborted while freeing a runtime (#1922)` cascade *in the file before*. Running the repo's own shard command —

```
find src -type f \( -name '*.test.ts' -o -name '*.test.tsx' \) | sort | awk 'NR % 4 == 1'
```

— the file immediately before is **`src/hooks/useIfcLoader.sabStreaming.test.tsx`**, which uses no QuickJS at all. The pair in shard order passes 5/5.

The substance of the reading was right; the boundary is **between tests inside this file**, not between files.

## Cause

The fixture slept a flat **50 ms**, then asserted the run had reached its host gate.

The `#1922` tests at the bottom abort a real WASM module. An aborted module is **retired** (`retireQuickJSModule`), so the next `execute()` pays a fresh `newQuickJSWASMModule()` rather than the cached one. Instrumenting all six wait sites under load: the site running after two aborts takes **46–72 ms**; every other site stays under ~20 ms.

The sleep straddled the cost it was meant to cover.

The `2 !== 1` is the cascade rather than a second bug — the assertion threw with the run un-awaited, that orphan parked into the next test's freshly emptied `gates`, and that test counted two.

## Fix

Every site now waits for the gate to be **registered** instead of predicting when it will be. No assertion weakened, every `gates.length` count unchanged, no skip, no timeout extension.

Five further sites had the same guess in disguise — treating "the newer run settled" as proof the older one had *reached* its gate. Those now wait too, deliberately **after** their settle-order assertion, which is the load-bearing one. The wait cannot mask a violation of it: a run parked on a gate cannot settle until the file opens that gate.

| | before | after |
|---|---|---|
| 22.13.1 unloaded | 30/30 | 30/30 |
| 22.13.1 loaded | 19/30, then 17/20 | **30/30**, and 30/30 at 2× load |
| 22.23.2 loaded | 17/20 | **30/30** |

## Could this mask rather than remove?

The obvious wrong fix here is bumping 50 ms to 500 ms, so this is the check I ran hardest.

**The change removes the sleep that was itself the timing-based mask.** The 10 s bound added is a hang bound, never approached on the passing path — real waits are single-digit milliseconds — and if it were ever hit, the unchanged `gates.length` assertion still reports the count. Passing-path behaviour changes only in that the tests no longer sleep a fixed 50 ms: the file got **faster**, not more lenient.

**One thing deliberately not done.** I did not add drain/teardown machinery to contain the `2 !== 1` cascade. With the root cause removed it cannot arise from this path, and speculative containment risked changing the passing path. A genuine future failure in one test could still perturb the next — flagged as a known, unaddressed residue rather than claimed as fixed.

## A comment corrected, and a follow-up now available

`.github/workflows/test.yml`'s `--test-concurrency=1` comment asserted that concurrency 4 **caused** #3060. It *exposed* it. Comment corrected; **the setting itself left alone**, since reverting to 4 is a CI behaviour change I cannot verify without waiting on CI.

That revert is now a real option — worth roughly 6 min/shard — because the cause is gone rather than merely serialised around. Your call, and it should be its own change.

Typecheck and oxlint clean. No changeset, matching #3061, the sibling test/CI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability under varying system load by replacing timing-based waits with event-based synchronization.
  * Prevented intermittent failures in sandbox execution and run-supersession scenarios, including abort and reset flows.

* **Tests**
  * Expanded coverage and validation across sandbox execution, error handling, supersession, and teardown cases.

* **Documentation**
  * Clarified the cause and mitigation of a previously intermittent viewer test failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->