### PR TITLE
fix(viewer): bound the sheet PDF raster to the canvas area limit, and surface the reduction

### DIFF
--- a/.changeset/sheet-pdf-canvas-pixel-ceiling.md
+++ b/.changeset/sheet-pdf-canvas-pixel-ceiling.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Stop the Drawing Sheet PDF export asking the browser for a canvas it will not allocate, and never let a blank one reach the page.
+
+The sheet PDF rasterizes `generateSheetSVG`'s output at a fixed 300 dpi, sized to the sheet's own paper. On the big papers that is far past what WebKit allocates: ARCH E (1219.2 x 914.4 mm) is 14400 x 10800 = 155,520,000 px, A0 is 14043 x 9933 = 139,489,119 px, against `CanvasBase::maxCanvasArea()` — `8192 * 8192` on the iOS family, `16384 * 16384` elsewhere. Nine of the twenty-five registry paper sizes are over the lower cap; ARCH E, not the A0 named in review, is the worst case.
+
+Nothing about that failure announces itself. `CanvasBase::validateArea()` logs a console warning and returns false, the canvas gets no backing store, `getContext('2d')` still hands back a live context, the paint calls no-op, and `toDataURL()` returns the literal string `"data:,"` (`encodeDataURL(RefPtr<ImageBuffer>&&)` returns `"data:,"_s` for a null buffer). The export then died inside jsPDF's PNG decoder, so the user got a complaint about a PNG signature with no remedy in it.
+
+The pixel grid now comes from `fitRasterPixels` — the same helper the 3D-view PDF's shaded underlay already uses, rather than a second cap policy — budgeted at WebKit's lower cap. It scales both sides by one factor, and the image is still placed across the full paper rectangle in millimetres, so a capped sheet is blurrier and never mis-scaled: A0 lands at 208 dpi and ARCH E at 197, both above the 150 dpi this repo already ships as adequate for a printed PDF raster. Papers inside the cap — ARCH C and everything smaller, including the A3 default — are untouched at the full 300 dpi.
+
+Capping is surfaced, not silent: a reduced sheet raises a notice naming the dpi actually delivered and pointing at the SVG export for a vector sheet at any size. And because a pixel budget is necessary but not sufficient — Safari enforces a separate total canvas-memory limit, and any browser can fail a large allocation on a low-memory device — a data URL that is not a PNG is now refused with a message that names the paper size and the way out, instead of being handed to jsPDF.
+
+The cap value and the failure mode are read off WebKit's source, not observed in a browser; no Safari, Chrome or Firefox was run, and Chrome's and Firefox's own limits are not modelled.

--- a/apps/viewer/src/hooks/useDrawingExport.pdfSheet.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingExport.pdfSheet.test.tsx
@@ -1,0 +1,366 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issues #2941/#2942: `handleExportPDF` never checked `sheetEnabled` /
+ * `activeSheet` at all — every PDF export ran the raw-drawing "v1" path
+ * (useDrawingExport.ts, `handleExportPDF`), which lays geometry out with
+ * `computePdfSectionLayout` (a plain fit-to-page) at `displayOptions.scale`
+ * (the on-screen "as displayed" value), never the sheet's own paper size
+ * (`activeSheet.paper`) or scale (`activeSheet.scale.factor`). SVG/DXF/Print
+ * all branch on `sheetEnabled && activeSheet` (see `handleExportSVG` in the
+ * same file); PDF alone didn't, so with a Drawing Sheet active the exported
+ * PDF had no frame/title block/scale bar (#2941) and was laid out at
+ * whatever `displayOptions.scale` happened to be, not the sheet's scale
+ * (#2942) — one root cause for both reports.
+ *
+ * This test mounts the REAL `useDrawingExport` hook (not a reimplementation)
+ * with `sheetEnabled: true` and a real `DrawingSheet` built from the same
+ * `@ifc-lite/drawing-2d` building blocks `sheetSlice.createDefaultSheet`
+ * uses, then calls the real `handleExportPDF()` and inspects what actually
+ * reaches `jsPDF`:
+ *
+ *  - the PDF page (`doc.addImage` width/height) must be the SHEET's own
+ *    paper size, not a fit-to-page size derived from the drawing bounds.
+ *  - the rasterized image must be built from the SAME svg the sheet SVG/
+ *    Print exporters emit (frame + scale-bar markers present).
+ *  - a known-length line (4m) must land on paper at the distance implied by
+ *    the sheet's OWN scale (`1000 / scale.factor` mm per metre) — proving
+ *    the export is actually to scale, and that changing the sheet's scale
+ *    changes the output (not stuck at one hardcoded value).
+ *
+ * `HTMLCanvasElement`'s 2D context and `Image` decoding don't exist under
+ * happy-dom (probed directly: `canvas.getContext('2d')` returns `null`
+ * here), so the rasterization step (SVG -> canvas -> PNG) is stubbed; that
+ * step is pure browser plumbing with nothing sheet-specific in it. Every
+ * sheet-specific number this test asserts on (paper size, svg content, the
+ * to-scale line span) comes out of the REAL production code path.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  GraphicOverrideEngine,
+  PAPER_SIZE_REGISTRY,
+  FRAME_PRESETS,
+  TITLE_BLOCK_PRESETS,
+  DEFAULT_TITLE_BLOCK_FIELDS,
+  DEFAULT_SCALE_BAR,
+  DEFAULT_NORTH_ARROW,
+  calculateViewportBounds,
+  calculateOptimalScaleBarLength,
+  type Drawing2D,
+  type DrawingSheet,
+} from '@ifc-lite/drawing-2d';
+import useDrawingExport from './useDrawingExport.js';
+
+// happy-dom has no `window.alert` — the production error path calls it on
+// failure, which would otherwise throw `ReferenceError: alert is not
+// defined` inside the fire-and-forget async IIFE and hang this test's
+// `addImageCalled` promise forever with no visible cause.
+(globalThis as unknown as { alert: (msg?: string) => void }).alert = (msg) => {
+  // eslint-disable-next-line no-console -- test-only diagnostic for a swallowed export error
+  console.error('[handleExportPDF alert]', msg);
+};
+process.on('unhandledRejection', (reason) => {
+  // eslint-disable-next-line no-console -- test-only diagnostic
+  console.error('[unhandledRejection]', reason);
+});
+
+// A tiny, VALID 1x1 PNG (red pixel) so jsPDF's own PNG decoder accepts it —
+// only its bytes matter to jsPDF, not its pixel size (the page/image
+// dimensions the test asserts on are the explicit `widthMm`/`heightMm`
+// arguments the production code passes to `addImage`, not anything derived
+// from the fake image itself).
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+/** Build a real, renderable `DrawingSheet` the same way
+ *  `sheetSlice.createDefaultSheet` does — reusing the package's own preset
+ *  tables rather than casting a stub object past the interface, so
+ *  `renderFrame`/`renderTitleBlock`/`renderScaleBar` (all called for real by
+ *  `generateSheetSVG`) get everything they read. */
+function buildSheet(paperId: string, scaleFactor: number, scaleName: string): DrawingSheet {
+  const paper = PAPER_SIZE_REGISTRY[paperId];
+  const framePreset = FRAME_PRESETS.professional;
+  const titleBlockPreset = TITLE_BLOCK_PRESETS.standard;
+  const scale = { name: scaleName, factor: scaleFactor, useCase: 'test' };
+
+  const frame = { style: 'professional' as const, ...framePreset };
+  const titleBlock = {
+    ...titleBlockPreset,
+    fields: DEFAULT_TITLE_BLOCK_FIELDS.map((f) => ({ ...f })),
+    logo: null,
+  };
+
+  const viewportBounds = calculateViewportBounds(paper, frame, titleBlock);
+
+  return {
+    id: `sheet-${paperId}-${scaleFactor}`,
+    name: `Sheet ${scaleName}`,
+    paper,
+    frame,
+    titleBlock,
+    scaleBar: {
+      ...DEFAULT_SCALE_BAR,
+      totalLengthM: calculateOptimalScaleBarLength(scale.factor, viewportBounds.width * 0.3),
+    },
+    scale,
+    northArrow: { ...DEFAULT_NORTH_ARROW },
+    viewportBounds,
+    revisions: [],
+  };
+}
+
+/** One 4-metre horizontal line, nothing else — small enough to fit inside
+ *  any of these paper sizes at any of the scales under test without the
+ *  viewport's "shrink to fit" clamp engaging (verified per-fixture below),
+ *  so `calculateDrawingTransform`'s `scaleFactor` output is the sheet's
+ *  exact nominal scale, not a fitted-down one. */
+function buildDrawing(): Drawing2D {
+  return {
+    config: {
+      plane: { axis: 'y', position: 0, flipped: false },
+      projectionDepth: 10,
+      includeHiddenLines: true,
+      creaseAngle: 30,
+      scale: 100,
+    },
+    lines: [
+      {
+        line: { start: { x: 0, y: 0 }, end: { x: 4, y: 0 } },
+        category: 'projection',
+        visibility: 'visible',
+        entityId: 1,
+        ifcType: 'IfcWall',
+        modelIndex: 0,
+        depth: 0,
+      },
+    ],
+    cutPolygons: [],
+    projectionPolygons: [],
+    bounds: { min: { x: 0, y: 0 }, max: { x: 4, y: 0 } },
+    stats: {
+      cutLineCount: 0,
+      projectionLineCount: 1,
+      hiddenLineCount: 0,
+      silhouetteLineCount: 0,
+      polygonCount: 0,
+      totalTriangles: 0,
+      processingTimeMs: 0,
+    },
+  };
+}
+
+interface HarnessProps {
+  activeSheet: DrawingSheet;
+  drawing: Drawing2D;
+  onReady: (fn: (scaleFactor?: number) => void) => void;
+}
+
+function Harness({ activeSheet, drawing, onReady }: HarnessProps): null {
+  const { handleExportPDF } = useDrawingExport({
+    drawing,
+    displayOptions: {
+      showHiddenLines: true,
+      scale: 999999, // deliberately NOT the sheet's scale — if this leaks into the sheet path, the measured span assertion below fails loudly.
+      showScanSection: false,
+      scanSectionOpacity: 0,
+      scanSectionIncludeInExport: false,
+    },
+    sectionPlane: { axis: 'down', position: 50, flipped: false },
+    activePresetId: null,
+    entityColorMap: new Map(),
+    overridesEnabled: false,
+    overrideEngine: new GraphicOverrideEngine(),
+    measure2DResults: [],
+    polygonArea2DResults: [],
+    textAnnotations2D: [],
+    cloudAnnotations2D: [],
+    sheetEnabled: true,
+    activeSheet,
+    dxfUnderlays: [],
+    ifcDataStore: null,
+    coordinateInfo: undefined,
+    scanSection: { points: [] },
+  });
+  onReady(handleExportPDF);
+  return null;
+}
+
+/** Stub the browser rasterization plumbing (SVG -> canvas -> PNG) that
+ *  happy-dom cannot do (`canvas.getContext('2d')` is `null` here), while
+ *  capturing the svg string and the canvas pixel size it was asked to
+ *  rasterize at, for inspection. */
+function stubRasterization(): {
+  capturedSvg: { value: string | null };
+  restore: () => void;
+} {
+  const capturedSvg: { value: string | null } = { value: null };
+
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  // @ts-expect-error -- test stub, narrower signature than the DOM lib's overloaded getContext
+  HTMLCanvasElement.prototype.getContext = function (type: string) {
+    if (type === '2d') {
+      return { fillStyle: '', fillRect() {}, drawImage() {} };
+    }
+    return originalGetContext.call(this, type as '2d');
+  };
+
+  const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+  HTMLCanvasElement.prototype.toDataURL = function () {
+    return `data:image/png;base64,${TINY_PNG_B64}`;
+  };
+
+  const OriginalImage = globalThis.Image;
+  class FakeImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_v: string) {
+      queueMicrotask(() => this.onload?.());
+    }
+  }
+  // @ts-expect-error -- test stub replacing the global Image constructor
+  globalThis.Image = FakeImage;
+
+  const OriginalBlob = globalThis.Blob;
+  class SpyBlob extends OriginalBlob {
+    constructor(parts: BlobPart[], options?: BlobPropertyBag) {
+      super(parts, options);
+      if (options?.type?.includes('svg') && typeof parts[0] === 'string') {
+        capturedSvg.value = parts[0];
+      }
+    }
+  }
+  globalThis.Blob = SpyBlob as unknown as typeof Blob;
+
+  return {
+    capturedSvg,
+    restore: () => {
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+      HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+      globalThis.Image = OriginalImage;
+      globalThis.Blob = OriginalBlob;
+    },
+  };
+}
+
+async function exportPdfForSheet(sheet: DrawingSheet): Promise<{
+  addImageArgs: unknown[];
+  svg: string;
+}> {
+  const rasterStub = stubRasterization();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  let exportFn: ((scaleFactor?: number) => void) | null = null;
+
+  // jsPDF's plugin methods (addImage included) are copied onto each
+  // instance as an OWN property at construction time from `jsPDF.API`
+  // (verified directly: `jsPDF.prototype.addImage` doesn't exist —
+  // `Object.prototype.hasOwnProperty.call(jsPDF.prototype, 'addImage')` is
+  // `false` — but `jsPDF.API.addImage` does, and patching THAT is what a
+  // freshly-constructed instance picks up). Patching `jsPDF.prototype`
+  // silently patches nothing a real instance ever calls.
+  const { jsPDF } = await import('jspdf');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- jsPDF's own `.d.ts` doesn't declare `API` as holding `addImage`, but it does at runtime (verified above); this is a test-only spy, not production code.
+  const jsPDFApi = jsPDF.API as any;
+  const originalAddImage = jsPDFApi.addImage;
+  let resolveAddImage!: (args: unknown[]) => void;
+  const addImageCalled = new Promise<unknown[]>((resolve) => {
+    resolveAddImage = resolve;
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- capturing jsPDF's own variadic addImage overloads
+  jsPDFApi.addImage = function (...args: any[]) {
+    resolveAddImage(args);
+    return originalAddImage.apply(this, args);
+  };
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Harness
+          activeSheet={sheet}
+          drawing={buildDrawing()}
+          onReady={(fn) => {
+            exportFn = fn;
+          }}
+        />,
+      );
+    });
+
+    await act(async () => {
+      exportFn!();
+      await addImageCalled;
+    });
+
+    const addImageArgs = await addImageCalled;
+    if (rasterStub.capturedSvg.value === null) {
+      throw new Error('expected the sheet SVG to have been rasterized (Blob spy never fired)');
+    }
+    return { addImageArgs, svg: rasterStub.capturedSvg.value };
+  } finally {
+    jsPDFApi.addImage = originalAddImage;
+    rasterStub.restore();
+    if (root) await act(async () => { (root as Root).unmount(); });
+    container.remove();
+  }
+}
+
+/** Parse the first `<line x1="..." y1="..." x2="..." y2="...">` inside the
+ *  `drawing-lines` group and return the mm distance between its endpoints —
+ *  the on-paper span of the fixture's 4m line. */
+function measureLineSpanMm(svg: string): number {
+  const match = svg.match(/<line x1="([-\d.]+)" y1="([-\d.]+)" x2="([-\d.]+)" y2="([-\d.]+)"/);
+  assert.ok(match, `expected a <line> element in the exported sheet svg; got:\n${svg.slice(0, 2000)}`);
+  const [, x1, y1, x2, y2] = match.map(Number) as unknown as [never, number, number, number, number];
+  return Math.hypot(x2 - x1, y2 - y1);
+}
+
+describe('handleExportPDF — Drawing Sheet mode (#2941/#2942)', () => {
+  it('sizes the PDF page to the SHEET paper, not a fit-to-page layout', async () => {
+    const sheet = buildSheet('A3_LANDSCAPE', 50, '1:50');
+    const { addImageArgs } = await exportPdfForSheet(sheet);
+    // doc.addImage(pngDataUrl, 'PNG', 0, 0, widthMm, heightMm)
+    const [, , , , widthMm, heightMm] = addImageArgs as [unknown, unknown, unknown, unknown, number, number];
+    assert.equal(widthMm, sheet.paper.widthMm, 'PDF image width must equal the sheet paper width');
+    assert.equal(heightMm, sheet.paper.heightMm, 'PDF image height must equal the sheet paper height');
+  });
+
+  it('rasterizes the sheet SVG — frame and scale-bar markers present (#2941)', async () => {
+    const sheet = buildSheet('A3_LANDSCAPE', 50, '1:50');
+    const { svg } = await exportPdfForSheet(sheet);
+    assert.match(svg, /id="drawing-frame"/, 'exported PDF must be built from the sheet svg (frame missing = #2941)');
+    assert.match(svg, /id="title-block-scale-bar"/, 'exported PDF must be built from the sheet svg (scale bar missing = #2941)');
+  });
+
+  it('is laid out at the SHEET scale, not displayOptions.scale, and changes with it (#2942)', async () => {
+    // 1:50 -> 1000/50 = 20mm per metre -> a 4m line spans 80mm on paper.
+    const sheetA = buildSheet('A3_LANDSCAPE', 50, '1:50');
+    const { svg: svgA } = await exportPdfForSheet(sheetA);
+    const spanA = measureLineSpanMm(svgA);
+    assert.ok(
+      Math.abs(spanA - 80) < 0.01,
+      `at 1:50 a 4m line must span 80mm on paper; measured ${spanA}mm`,
+    );
+
+    // 1:200 -> 1000/200 = 5mm per metre -> the SAME 4m line spans 20mm.
+    const sheetB = buildSheet('A2_LANDSCAPE', 200, '1:200');
+    const { svg: svgB } = await exportPdfForSheet(sheetB);
+    const spanB = measureLineSpanMm(svgB);
+    assert.ok(
+      Math.abs(spanB - 20) < 0.01,
+      `at 1:200 a 4m line must span 20mm on paper; measured ${spanB}mm`,
+    );
+
+    // The reported bug: "scale bar showing 10 cm... not correct in any
+    // scale" — i.e. the export doesn't move at all when the sheet's scale
+    // changes. Assert the two measured spans actually differ.
+    assert.notEqual(spanA, spanB, 'changing the sheet scale must change the on-paper span — it must not be stuck at one value');
+  });
+});

--- a/apps/viewer/src/hooks/useDrawingExport.pdfSheetRasterCap.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingExport.pdfSheetRasterCap.test.tsx
@@ -1,0 +1,487 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Drawing Sheet PDF path rasterizes the sheet SVG at a fixed 300 dpi and
+ * sizes the canvas to the sheet's own paper. On the largest papers that asks
+ * the browser for a canvas far past what WebKit will allocate:
+ *
+ *   ARCH E  1219.2 x 914.4 mm -> 14400 x 10800 px = 155,520,000 px
+ *   A0      1189   x  841   mm -> 14043 x  9933 px = 139,489,119 px
+ *
+ * against `CanvasBase::maxCanvasArea()` (Source/WebCore/html/CanvasBase.cpp),
+ * which is `8192 * 8192` = 67,108,864 on the iOS family and `16384 * 16384`
+ * elsewhere.
+ *
+ * The failure is not an exception. WebKit's `validateArea()` logs a console
+ * warning and returns false; the canvas gets no backing store; `getContext`
+ * still hands back a context, `fillRect`/`drawImage` are no-ops, and
+ * `toDataURL()` returns the literal string `"data:,"` — see
+ * `encodeDataURL(RefPtr<ImageBuffer>&&)` in
+ * Source/WebCore/platform/graphics/ImageUtilities.cpp, which returns
+ * `"data:,"_s` for a null buffer.
+ *
+ * `stubWebKitCanvas` below reproduces exactly that contract, so these tests
+ * drive the real `handleExportPDF` against a faithful over-cap browser rather
+ * than against an assumption.
+ *
+ * What this file CANNOT observe, and does not claim: how any real browser
+ * behaves. No Safari, Chrome or Firefox was run. The over-cap return value is
+ * read off WebKit's source, not measured. What WAS measured is only that
+ * `"data:,"` is rejected by jsPDF rather than quietly embedded — with
+ * jsPDF 4.2 under Node that surfaces as its filesystem-reader error, and with
+ * `jsPDF.API.loadFile` stubbed to return `''` (what a browser XHR on
+ * `data:,` yields) as `wrong PNG signature`. Either way the user gets a
+ * decoder message with no remedy in it. Chrome's and Firefox's own caps, and
+ * Safari's separate *total* canvas-memory limit, are not modelled here.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  GraphicOverrideEngine,
+  PAPER_SIZE_REGISTRY,
+  FRAME_PRESETS,
+  TITLE_BLOCK_PRESETS,
+  DEFAULT_TITLE_BLOCK_FIELDS,
+  DEFAULT_SCALE_BAR,
+  DEFAULT_NORTH_ARROW,
+  calculateViewportBounds,
+  calculateOptimalScaleBarLength,
+  fitRasterPixels,
+  getDefaultPaperSize,
+  type Drawing2D,
+  type DrawingSheet,
+} from '@ifc-lite/drawing-2d';
+import { toast } from '@/components/ui/toast';
+import useDrawingExport, {
+  SHEET_PDF_DPI,
+  MAX_SHEET_RASTER_PIXELS,
+  MAX_SHEET_RASTER_DIMENSION_PX,
+} from './useDrawingExport.js';
+
+/** A tiny, VALID 1x1 PNG so jsPDF's PNG decoder accepts the stubbed raster. */
+const TINY_PNG =
+  'data:image/png;base64,' +
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+/**
+ * WebKit's iOS-family cap, quoted from `CanvasBase.cpp` as an expression
+ * rather than a flattened constant so the provenance stays readable. This is
+ * the lower of WebKit's two caps and therefore the one the exporter has to
+ * hold to; the desktop cap is `16384 * 16384`.
+ */
+const WEBKIT_IOS_MAX_CANVAS_AREA = 8192 * 8192;
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+function buildSheet(paperId: string): DrawingSheet {
+  const paper = PAPER_SIZE_REGISTRY[paperId];
+  assert.ok(paper, `unknown paper id ${paperId}`);
+  const framePreset = FRAME_PRESETS.professional;
+  const titleBlockPreset = TITLE_BLOCK_PRESETS.standard;
+  const scale = { name: '1:100', factor: 100, useCase: 'test' };
+  const frame = { style: 'professional' as const, ...framePreset };
+  const titleBlock = {
+    ...titleBlockPreset,
+    fields: DEFAULT_TITLE_BLOCK_FIELDS.map((f) => ({ ...f })),
+    logo: null,
+  };
+  const viewportBounds = calculateViewportBounds(paper, frame, titleBlock);
+  return {
+    id: `sheet-${paperId}`,
+    name: `Sheet ${paperId}`,
+    paper,
+    frame,
+    titleBlock,
+    scaleBar: {
+      ...DEFAULT_SCALE_BAR,
+      totalLengthM: calculateOptimalScaleBarLength(scale.factor, viewportBounds.width * 0.3),
+    },
+    scale,
+    northArrow: { ...DEFAULT_NORTH_ARROW },
+    viewportBounds,
+    revisions: [],
+  };
+}
+
+function buildDrawing(): Drawing2D {
+  return {
+    config: {
+      plane: { axis: 'y', position: 0, flipped: false },
+      projectionDepth: 10,
+      includeHiddenLines: true,
+      creaseAngle: 30,
+      scale: 100,
+    },
+    lines: [
+      {
+        line: { start: { x: 0, y: 0 }, end: { x: 4, y: 0 } },
+        category: 'projection',
+        visibility: 'visible',
+        entityId: 1,
+        ifcType: 'IfcWall',
+        modelIndex: 0,
+        depth: 0,
+      },
+    ],
+    cutPolygons: [],
+    projectionPolygons: [],
+    bounds: { min: { x: 0, y: 0 }, max: { x: 4, y: 0 } },
+    stats: {
+      cutLineCount: 0,
+      projectionLineCount: 1,
+      hiddenLineCount: 0,
+      silhouetteLineCount: 0,
+      polygonCount: 0,
+      totalTriangles: 0,
+      processingTimeMs: 0,
+    },
+  };
+}
+
+function Harness({
+  activeSheet,
+  onReady,
+}: {
+  activeSheet: DrawingSheet;
+  onReady: (fn: (scaleFactor?: number) => void) => void;
+}): null {
+  const { handleExportPDF } = useDrawingExport({
+    drawing: buildDrawing(),
+    displayOptions: {
+      showHiddenLines: true,
+      scale: 100,
+      showScanSection: false,
+      scanSectionOpacity: 0,
+      scanSectionIncludeInExport: false,
+    },
+    sectionPlane: { axis: 'down', position: 50, flipped: false },
+    activePresetId: null,
+    entityColorMap: new Map(),
+    overridesEnabled: false,
+    overrideEngine: new GraphicOverrideEngine(),
+    measure2DResults: [],
+    polygonArea2DResults: [],
+    textAnnotations2D: [],
+    cloudAnnotations2D: [],
+    sheetEnabled: true,
+    activeSheet,
+    dxfUnderlays: [],
+    ifcDataStore: null,
+    coordinateInfo: undefined,
+    scanSection: { points: [] },
+  });
+  onReady(handleExportPDF);
+  return null;
+}
+
+// ── the browser stub ───────────────────────────────────────────────────────
+
+interface CanvasStub {
+  /** Every canvas size the exporter asked the browser for, in order. */
+  requested: Array<{ width: number; height: number }>;
+  restore: () => void;
+}
+
+/**
+ * @param maxArea over this many pixels the canvas has no backing store and
+ *   `toDataURL` returns `"data:,"`, exactly as WebKit does. `Infinity`
+ *   models a browser that allocates whatever is asked for.
+ */
+function stubWebKitCanvas(maxArea: number): CanvasStub {
+  const requested: Array<{ width: number; height: number }> = [];
+
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  // @ts-expect-error -- test stub, narrower than the DOM lib's overloaded getContext
+  HTMLCanvasElement.prototype.getContext = function (type: string) {
+    // WebKit hands back a live context even when the buffer allocation
+    // failed; the paint calls are simply no-ops. A stub that returned null
+    // here would make the production `if (!ctx) throw` look like a guard it
+    // is not.
+    if (type === '2d') return { fillStyle: '', fillRect() {}, drawImage() {} };
+    return originalGetContext.call(this, type as '2d');
+  };
+
+  const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+  HTMLCanvasElement.prototype.toDataURL = function (this: HTMLCanvasElement) {
+    requested.push({ width: this.width, height: this.height });
+    return this.width * this.height > maxArea ? 'data:,' : TINY_PNG;
+  };
+
+  const OriginalImage = globalThis.Image;
+  class FakeImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_v: string) {
+      queueMicrotask(() => this.onload?.());
+    }
+  }
+  // @ts-expect-error -- test stub replacing the global Image constructor
+  globalThis.Image = FakeImage;
+
+  return {
+    requested,
+    restore: () => {
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+      HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+      globalThis.Image = OriginalImage;
+    },
+  };
+}
+
+interface ExportOutcome {
+  /** `doc.addImage(...)` arguments, or null when the export never got there. */
+  addImageArgs: unknown[] | null;
+  /** The user-facing failure text, or null on success. */
+  alertMessage: string | null;
+  /** Every `toast.info` message raised during the export. */
+  infoToasts: string[];
+  /** Canvas sizes the exporter asked the browser for. */
+  requested: Array<{ width: number; height: number }>;
+}
+
+async function exportSheet(paperId: string, maxArea: number): Promise<ExportOutcome> {
+  const canvas = stubWebKitCanvas(maxArea);
+  const infoToasts: string[] = [];
+  const originalInfo = toast.info;
+  toast.info = (message: string) => {
+    infoToasts.push(message);
+  };
+
+  let alertMessage: string | null = null;
+  let addImageArgs: unknown[] | null = null;
+  let settle!: () => void;
+  const finished = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+
+  const g = globalThis as unknown as { alert?: (msg?: string) => void };
+  const originalAlert = g.alert;
+  g.alert = (msg?: string) => {
+    alertMessage = String(msg);
+    settle();
+  };
+
+  const { jsPDF } = await import('jspdf');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- jsPDF copies plugin methods off `API` onto each instance at construction; patching the prototype patches nothing a real instance calls.
+  const jsPDFApi = jsPDF.API as any;
+  const originalAddImage = jsPDFApi.addImage;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- capturing jsPDF's variadic addImage overloads
+  jsPDFApi.addImage = function (...args: any[]) {
+    addImageArgs = args;
+    const out = originalAddImage.apply(this, args);
+    settle();
+    return out;
+  };
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  let exportFn: ((scaleFactor?: number) => void) | null = null;
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Harness activeSheet={buildSheet(paperId)} onReady={(fn) => { exportFn = fn; }} />,
+      );
+    });
+    await act(async () => {
+      exportFn!();
+      await Promise.race([
+        finished,
+        // A stuck export must fail the assertion below, not hang the runner.
+        new Promise<void>((r) => setTimeout(r, 5000)),
+      ]);
+    });
+    return { addImageArgs, alertMessage, infoToasts, requested: canvas.requested };
+  } finally {
+    jsPDFApi.addImage = originalAddImage;
+    toast.info = originalInfo;
+    if (originalAlert) g.alert = originalAlert; else delete g.alert;
+    canvas.restore();
+    if (root) await act(async () => { (root as Root).unmount(); });
+    container.remove();
+  }
+}
+
+// ── the paper the exporter must not degrade ────────────────────────────────
+
+/**
+ * Largest registry paper whose 300 dpi raster fits inside WEBKIT's cap.
+ *
+ * Derived from `WEBKIT_IOS_MAX_CANVAS_AREA` — the number quoted from
+ * WebKit's source — and deliberately NOT from `MAX_SHEET_RASTER_PIXELS`.
+ * Deriving it from the production constant makes this test move with
+ * whatever the production constant says, so a cap set far too TIGHT would
+ * degrade real exports and still pass here. Measured: with the budget
+ * mutated to `4096 * 4096` the registry-derived version of this test stayed
+ * green, and this version does not.
+ */
+function largestUncappedPaperId(): string {
+  const entries = Object.values(PAPER_SIZE_REGISTRY)
+    .map((p) => ({
+      id: p.id,
+      px: Math.ceil((p.widthMm * SHEET_PDF_DPI) / 25.4) * Math.ceil((p.heightMm * SHEET_PDF_DPI) / 25.4),
+    }))
+    .filter((e) => e.px <= WEBKIT_IOS_MAX_CANVAS_AREA)
+    .sort((a, b) => b.px - a.px);
+  assert.ok(entries.length > 0, 'no registry paper fits WebKit\'s cap — the arithmetic is wrong');
+  return entries[0].id;
+}
+
+let alertGuard: (() => void) | undefined;
+beforeEach(() => {
+  const g = globalThis as unknown as { alert?: (msg?: string) => void };
+  if (!g.alert) {
+    g.alert = () => {};
+    alertGuard = () => { delete g.alert; };
+  }
+});
+afterEach(() => { alertGuard?.(); alertGuard = undefined; });
+
+describe('Drawing Sheet PDF — canvas pixel ceiling', () => {
+  it('the constants are WebKit\'s own caps, not round numbers', () => {
+    assert.equal(
+      MAX_SHEET_RASTER_PIXELS,
+      WEBKIT_IOS_MAX_CANVAS_AREA,
+      'the pixel budget must be CanvasBase::maxCanvasArea() for the iOS family (8192 * 8192), the lower of WebKit\'s two caps',
+    );
+    assert.equal(
+      MAX_SHEET_RASTER_DIMENSION_PX,
+      16_384,
+      'the per-side cap must be the side length WebKit\'s non-iOS area cap is expressed as',
+    );
+    assert.equal(SHEET_PDF_DPI, 300, 'the sheet raster is fixed at 300 dpi — there is no dpi control to point a user at');
+  });
+
+  it('A0 asks for a canvas WebKit refuses, and 300 dpi is what makes it so', () => {
+    // The arithmetic the ceiling comes from, spelled out rather than pinned
+    // to a magic pixel count.
+    const a0 = PAPER_SIZE_REGISTRY.A0_LANDSCAPE;
+    const uncappedPx =
+      Math.ceil((a0.widthMm * SHEET_PDF_DPI) / 25.4) *
+      Math.ceil((a0.heightMm * SHEET_PDF_DPI) / 25.4);
+    assert.ok(
+      uncappedPx > WEBKIT_IOS_MAX_CANVAS_AREA,
+      `A0 at ${SHEET_PDF_DPI} dpi is ${uncappedPx} px, which must exceed WebKit's ${WEBKIT_IOS_MAX_CANVAS_AREA}`,
+    );
+
+    // ARCH E is bigger still — the true worst case, not A0.
+    const archE = PAPER_SIZE_REGISTRY.ARCH_E;
+    const archEPx =
+      Math.ceil((archE.widthMm * SHEET_PDF_DPI) / 25.4) *
+      Math.ceil((archE.heightMm * SHEET_PDF_DPI) / 25.4);
+    assert.ok(archEPx > uncappedPx, 'ARCH E must be the largest supported sheet raster, above A0');
+  });
+
+  it('exports A0 on a WebKit-capped canvas instead of failing on a blank bitmap', async () => {
+    const { addImageArgs, alertMessage, requested } = await exportSheet(
+      'A0_LANDSCAPE',
+      WEBKIT_IOS_MAX_CANVAS_AREA,
+    );
+
+    // RED, before the fix: the exporter asks for 14043 x 9933 px, WebKit
+    // hands back "data:," and jsPDF rejects it — `addImageArgs` stays null
+    // and `alertMessage` is a decoder complaint with no remedy in it.
+    assert.equal(alertMessage, null, `A0 export must succeed; failed with: ${alertMessage}`);
+    assert.ok(addImageArgs, 'jsPDF.addImage must have received a raster');
+
+    assert.equal(requested.length, 1, 'exactly one canvas should be rasterized');
+    const { width, height } = requested[0];
+    assert.ok(
+      width * height <= MAX_SHEET_RASTER_PIXELS,
+      `the exporter asked for ${width}x${height} = ${width * height} px, over the ${MAX_SHEET_RASTER_PIXELS} px budget`,
+    );
+    assert.ok(width <= MAX_SHEET_RASTER_DIMENSION_PX && height <= MAX_SHEET_RASTER_DIMENSION_PX);
+
+    // The grid must be the package's own fit, not a second policy.
+    const a0 = PAPER_SIZE_REGISTRY.A0_LANDSCAPE;
+    const fit = fitRasterPixels(
+      a0.widthMm, a0.heightMm, SHEET_PDF_DPI,
+      MAX_SHEET_RASTER_PIXELS, MAX_SHEET_RASTER_DIMENSION_PX,
+    );
+    assert.deepEqual({ width, height }, { width: fit.widthPx, height: fit.heightPx });
+
+    // Capped means blurrier, NEVER mis-scaled: the page and the image
+    // rectangle stay the sheet's own millimetres.
+    const [, , , , widthMm, heightMm] = addImageArgs as [unknown, unknown, unknown, unknown, number, number];
+    assert.equal(widthMm, a0.widthMm, 'a capped raster must still print at full paper width');
+    assert.equal(heightMm, a0.heightMm, 'a capped raster must still print at full paper height');
+  });
+
+  it('tells the user the resolution dropped — a capped export is never silent', async () => {
+    const { infoToasts } = await exportSheet('A0_LANDSCAPE', WEBKIT_IOS_MAX_CANVAS_AREA);
+    assert.equal(infoToasts.length, 1, `expected one notice about the reduced raster; got ${JSON.stringify(infoToasts)}`);
+
+    const a0 = PAPER_SIZE_REGISTRY.A0_LANDSCAPE;
+    const fit = fitRasterPixels(
+      a0.widthMm, a0.heightMm, SHEET_PDF_DPI,
+      MAX_SHEET_RASTER_PIXELS, MAX_SHEET_RASTER_DIMENSION_PX,
+    );
+    const reported = Math.floor(fit.effectiveDpi);
+    assert.match(
+      infoToasts[0],
+      new RegExp(`\\b${reported}\\b`),
+      'the notice must state the dpi actually delivered',
+    );
+    assert.match(infoToasts[0], new RegExp(`\\b${SHEET_PDF_DPI}\\b`), 'the notice must state what was asked for');
+    // `Math.round` would render 299.53 dpi as "reduced from 300 to 300".
+    assert.notEqual(reported, SHEET_PDF_DPI, 'the reported dpi must never equal the requested one');
+  });
+
+  it('does NOT touch the default sheet paper', async () => {
+    // The paper every sheet starts on (`getDefaultPaperSize()`), named from
+    // outside the cap arithmetic entirely. If a future cap degrades THIS
+    // export, the feature's own default has regressed.
+    const paper = getDefaultPaperSize();
+    const { alertMessage, infoToasts, requested } = await exportSheet(paper.id, Infinity);
+
+    assert.equal(alertMessage, null, `the default paper must export cleanly; failed with: ${alertMessage}`);
+    assert.deepEqual(infoToasts, [], 'the default paper must raise no reduction notice');
+    assert.deepEqual(requested[0], {
+      width: Math.ceil((paper.widthMm * SHEET_PDF_DPI) / 25.4),
+      height: Math.ceil((paper.heightMm * SHEET_PDF_DPI) / 25.4),
+    }, `the default paper must still rasterize at the full ${SHEET_PDF_DPI} dpi`);
+  });
+
+  it('does NOT touch the largest paper that already worked', async () => {
+    const paperId = largestUncappedPaperId();
+    const paper = PAPER_SIZE_REGISTRY[paperId];
+
+    // Not the cap: a browser that allocates anything. If the guard fired here
+    // it would be degrading an export that has no reason to be degraded.
+    const { addImageArgs, alertMessage, infoToasts, requested } = await exportSheet(paperId, Infinity);
+
+    assert.equal(alertMessage, null, `${paperId} must export cleanly; failed with: ${alertMessage}`);
+    assert.ok(addImageArgs, 'jsPDF.addImage must have received a raster');
+    assert.deepEqual(infoToasts, [], `${paperId} is inside the cap and must raise no reduction notice`);
+    assert.deepEqual(requested[0], {
+      width: Math.ceil((paper.widthMm * SHEET_PDF_DPI) / 25.4),
+      height: Math.ceil((paper.heightMm * SHEET_PDF_DPI) / 25.4),
+    }, `${paperId} must still rasterize at the full ${SHEET_PDF_DPI} dpi`);
+  });
+
+  it('names a remedy when the canvas comes back blank anyway', async () => {
+    // Under the pixel budget and STILL blank: Safari enforces a separate
+    // total-canvas-memory limit, and any browser can fail an allocation on a
+    // low-memory device. The cap cannot rule that out, so the blank bitmap
+    // must be recognised rather than handed to jsPDF, whose "wrong PNG
+    // signature" tells a user nothing they can act on.
+    const { addImageArgs, alertMessage } = await exportSheet('A4_LANDSCAPE', 0);
+
+    assert.equal(addImageArgs, null, 'a blank bitmap must never reach jsPDF');
+    assert.ok(alertMessage, 'the user must be told the export failed');
+    assert.doesNotMatch(
+      alertMessage!,
+      /PNG signature/i,
+      'jsPDF\'s decoder message is not an explanation the user can act on',
+    );
+    assert.match(alertMessage!, /SVG/i, 'the message must name the vector export as the way out');
+  });
+});

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -141,6 +141,59 @@ function buildScanSectionSvg(
   return svg;
 }
 
+/**
+ * Rasterize an SVG string to a PNG data URL at `dpi`, sized to exactly
+ * `widthMm` x `heightMm` on paper (issues #2941/#2942). The sheet frame,
+ * title block and scale bar only exist inside `generateSheetSVG` — SVG,
+ * Print and the DXF-underlay path all render that exact string and the
+ * reporter confirmed those are correct. Rather than re-deriving a second,
+ * independent sheet layout for jsPDF's vector primitives (the "v1" PDF path
+ * below did exactly that and dropped the frame/scale bar entirely, and used
+ * `displayOptions.scale` instead of the sheet's own scale), rasterize the
+ * SAME svg the working exporters use so the PDF cannot drift from them.
+ */
+function rasterizeSvgToPngDataUrl(
+  svgString: string,
+  widthMm: number,
+  heightMm: number,
+  dpi = 300,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const pxPerMm = dpi / 25.4;
+    const widthPx = Math.max(1, Math.round(widthMm * pxPerMm));
+    const heightPx = Math.max(1, Math.round(heightMm * pxPerMm));
+
+    const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(svgBlob);
+    const img = new Image();
+    img.onload = () => {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = widthPx;
+        canvas.height = heightPx;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) throw new Error('Canvas 2D context unavailable');
+        // The sheet SVG already paints its own white background rect, but a
+        // canvas starts transparent — belt-and-braces against a transparent
+        // PDF page if that rect is ever clipped away.
+        ctx.fillStyle = '#FFFFFF';
+        ctx.fillRect(0, 0, widthPx, heightPx);
+        ctx.drawImage(img, 0, 0, widthPx, heightPx);
+        resolve(canvas.toDataURL('image/png'));
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error('Failed to rasterize sheet SVG'));
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Failed to load sheet SVG for PDF export'));
+    };
+    img.src = url;
+  });
+}
+
 interface UseDrawingExportParams {
   drawing: Drawing2D | null;
   displayOptions: {
@@ -895,6 +948,50 @@ function useDrawingExport({
   // see the PR description.
   const handleExportPDF = useCallback((scaleFactor?: number) => {
     if (!drawing) return;
+
+    // Drawing Sheet mode (#2941: frame/title block/scale bar missing from
+    // the PDF; #2942: nothing in the PDF is to scale). Root cause for both:
+    // this handler never checked `sheetEnabled`/`activeSheet` at all — it
+    // always ran the raw-drawing "v1" path below, which lays the cut
+    // geometry onto a page sized by `computePdfSectionLayout` (fit-to-page)
+    // at `displayOptions.scale` (the on-screen "as displayed" scale), never
+    // the sheet's own paper size (activeSheet.paper, see
+    // generateSheetSVG at line ~567) or its own scale
+    // (activeSheet.scale.factor, generateSheetSVG line ~576). SVG/DXF/Print
+    // all branch on `sheetEnabled && activeSheet` (e.g. handleExportSVG
+    // above); PDF alone didn't. Reuse the already-correct sheet SVG instead
+    // of re-deriving a second sheet layout for jsPDF's vector primitives.
+    if (sheetEnabled && activeSheet) {
+      const svg = generateSheetSVG();
+      if (!svg) return;
+      const { widthMm, heightMm } = activeSheet.paper;
+      void (async () => {
+        try {
+          const { jsPDF } = await import('jspdf');
+          const pngDataUrl = await rasterizeSvgToPngDataUrl(svg, widthMm, heightMm);
+          const doc = new jsPDF({
+            unit: 'mm',
+            format: [widthMm, heightMm],
+            orientation: widthMm >= heightMm ? 'landscape' : 'portrait',
+          });
+          doc.addImage(pngDataUrl, 'PNG', 0, 0, widthMm, heightMm);
+
+          const stem = `${sanitizeFilename(activeSheet.name, { fallback: 'sheet' })}-${sectionPlane.axis}-${sectionPlane.position}`;
+          downloadFile(doc.output('blob'), `${stem}.pdf`, 'application/pdf');
+          posthog.capture('drawing_exported', {
+            format: 'pdf',
+            axis: sectionPlane.axis,
+            scale_factor: activeSheet.scale.factor,
+            sheet_enabled: true,
+          });
+        } catch (err) {
+          // eslint-disable-next-line no-alert -- matches the raw-drawing PDF path's alert() below; this hook has no toast wiring.
+          alert(err instanceof Error ? `Could not export PDF: ${err.message}` : 'Could not export PDF.');
+        }
+      })();
+      return;
+    }
+
     const effectiveScale = scaleFactor ?? displayOptions.scale ?? 100;
 
     // Axis-specific flipping, matching the SVG "as displayed" export above.
@@ -1004,7 +1101,7 @@ function useDrawingExport({
         alert(err instanceof Error ? `Could not export PDF: ${err.message}` : 'Could not export PDF.');
       }
     })();
-  }, [drawing, displayOptions.scale, displayOptions.showHiddenLines, sectionPlane]);
+  }, [drawing, displayOptions.scale, displayOptions.showHiddenLines, sectionPlane, sheetEnabled, activeSheet, generateSheetSVG]);
 
   // Print handler
   const handlePrint = useCallback(() => {

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -5,6 +5,7 @@
 import { useCallback } from 'react';
 import { posthog } from '@/lib/analytics';
 import { downloadFile, sanitizeFilename } from '@/lib/export/download';
+import { toast } from '@/components/ui/toast';
 import { pdfLineStyleFor } from '@/lib/export/pdf-line-style';
 import {
   GraphicOverrideEngine,
@@ -13,6 +14,8 @@ import {
   calculateDrawingTransform,
   exportToDXF,
   formatScaleFactorLabel,
+  fitRasterPixels,
+  type RasterFit,
   type Drawing2D,
   type DrawingSheet,
   type ElementData,
@@ -142,26 +145,92 @@ function buildScanSectionSvg(
 }
 
 /**
- * Rasterize an SVG string to a PNG data URL at `dpi`, sized to exactly
- * `widthMm` x `heightMm` on paper (issues #2941/#2942). The sheet frame,
- * title block and scale bar only exist inside `generateSheetSVG` — SVG,
- * Print and the DXF-underlay path all render that exact string and the
- * reporter confirmed those are correct. Rather than re-deriving a second,
- * independent sheet layout for jsPDF's vector primitives (the "v1" PDF path
- * below did exactly that and dropped the frame/scale bar entirely, and used
+ * Dots per inch of paper the sheet raster is built at.
+ *
+ * Fixed, with no UI control anywhere: `handleExportPDF` is a single toolbar
+ * action. That is why the ceiling below CAPS rather than REFUSES — a refusal
+ * would have no setting to send the user to, and the sheet's paper size is
+ * the deliverable, not a preference.
+ */
+export const SHEET_PDF_DPI = 300;
+
+/**
+ * Pixel budget for one sheet raster, taken from WebKit's own canvas cap
+ * rather than picked as a round number: `CanvasBase::maxCanvasArea()`
+ * (Source/WebCore/html/CanvasBase.cpp) returns `8192 * 8192` on the iOS
+ * family and `16384 * 16384` elsewhere. The lower of the two is the one that
+ * has to hold, because a canvas over the cap does not report itself:
+ * `CanvasBase::validateArea()` logs a console warning and returns false, the
+ * canvas gets no backing store, `getContext('2d')` still returns a live
+ * context, the paint calls become no-ops, and `toDataURL()` then returns the
+ * literal string `"data:,"` — `encodeDataURL(RefPtr<ImageBuffer>&&)` in
+ * Source/WebCore/platform/graphics/ImageUtilities.cpp returns `"data:,"_s`
+ * for a null buffer. Nothing throws at any point.
+ *
+ * At {@link SHEET_PDF_DPI} that cap binds from ANSI D upwards. The papers
+ * that need it are the big ones — ARCH E is 14400 x 10800 = 155,520,000 px
+ * and A0 is 14043 x 9933 = 139,489,119 px, both far past even the desktop
+ * cap's memory cost (155.5 Mpx x 4 bytes = 622 MB for the bitmap alone).
+ *
+ * NOT verified in any real browser. The value and the failure mode are read
+ * off WebKit's source; Chrome's and Firefox's caps differ and are not
+ * modelled, and Safari's separate TOTAL canvas-memory limit is a second
+ * ceiling this budget cannot rule out — which is why the raster result is
+ * validated below as well as sized.
+ */
+export const MAX_SHEET_RASTER_PIXELS = 8192 * 8192;
+
+/**
+ * Per-side cap: the side length WebKit's non-iOS area cap is expressed as,
+ * and the same number `@ifc-lite/drawing-2d` already uses for the 3D-view
+ * PDF's shaded underlay (`MAX_SHADING_DIMENSION_PX`). No registry paper
+ * reaches it at {@link SHEET_PDF_DPI} (ARCH E's long side is 14400 px); it
+ * exists for a custom paper size, which `DrawingSheet.paper` permits.
+ */
+export const MAX_SHEET_RASTER_DIMENSION_PX = 16_384;
+
+/** A raster, plus what it cost to fit it inside the budget. */
+interface SheetRaster {
+  dataUrl: string;
+  fit: RasterFit;
+}
+
+/**
+ * Rasterize an SVG string to a PNG data URL, sized to exactly `widthMm` x
+ * `heightMm` on paper (issues #2941/#2942). The sheet frame, title block and
+ * scale bar only exist inside `generateSheetSVG` — SVG, Print and the
+ * DXF-underlay path all render that exact string and the reporter confirmed
+ * those are correct. Rather than re-deriving a second, independent sheet
+ * layout for jsPDF's vector primitives (the "v1" PDF path below did exactly
+ * that and dropped the frame/scale bar entirely, and used
  * `displayOptions.scale` instead of the sheet's own scale), rasterize the
  * SAME svg the working exporters use so the PDF cannot drift from them.
+ *
+ * The pixel grid comes from `fitRasterPixels`, the same helper the 3D-view
+ * PDF's shaded underlay uses, so the two raster paths cannot drift into two
+ * different cap policies. It scales BOTH sides by one factor, so a capped
+ * sheet is blurrier and never mis-scaled: the caller still places the image
+ * across the full paper rectangle in millimetres, never at `px / dpi`.
+ *
+ * `fit.capped` is returned rather than swallowed. A user who asked for a
+ * 300 dpi sheet and silently got 104 is the same defect as a blank page, one
+ * step quieter.
  */
 function rasterizeSvgToPngDataUrl(
   svgString: string,
   widthMm: number,
   heightMm: number,
-  dpi = 300,
-): Promise<string> {
+  dpi = SHEET_PDF_DPI,
+): Promise<SheetRaster> {
   return new Promise((resolve, reject) => {
-    const pxPerMm = dpi / 25.4;
-    const widthPx = Math.max(1, Math.round(widthMm * pxPerMm));
-    const heightPx = Math.max(1, Math.round(heightMm * pxPerMm));
+    const fit = fitRasterPixels(
+      widthMm,
+      heightMm,
+      dpi,
+      MAX_SHEET_RASTER_PIXELS,
+      MAX_SHEET_RASTER_DIMENSION_PX,
+    );
+    const { widthPx, heightPx } = fit;
 
     const svgBlob = new Blob([svgString], { type: 'image/svg+xml;charset=utf-8' });
     const url = URL.createObjectURL(svgBlob);
@@ -179,7 +248,25 @@ function rasterizeSvgToPngDataUrl(
         ctx.fillStyle = '#FFFFFF';
         ctx.fillRect(0, 0, widthPx, heightPx);
         ctx.drawImage(img, 0, 0, widthPx, heightPx);
-        resolve(canvas.toDataURL('image/png'));
+
+        const dataUrl = canvas.toDataURL('image/png');
+        // The pixel budget above is necessary, not sufficient. Safari
+        // enforces a separate TOTAL canvas-memory limit, and any browser can
+        // fail a 100+ MB allocation on a low-memory device; in both cases the
+        // buffer is simply absent and this comes back as `"data:,"` with no
+        // exception raised. Handing that to `jsPDF.addImage` produces a
+        // decoder complaint about a PNG signature, which tells the user
+        // nothing they can act on — and if a browser ever returned a valid
+        // all-white PNG instead, the export would "succeed" with a blank
+        // page. Refuse the result here, naming the way out.
+        if (!dataUrl.startsWith('data:image/png')) {
+          throw new Error(
+            `the browser returned an empty ${widthPx}x${heightPx} px canvas for this ` +
+            `${Math.round(widthMm)}x${Math.round(heightMm)} mm sheet. Try a smaller paper ` +
+            `size, or use the SVG export, which is vector and has no pixel limit.`,
+          );
+        }
+        resolve({ dataUrl, fit });
       } catch (err) {
         reject(err instanceof Error ? err : new Error('Failed to rasterize sheet SVG'));
       } finally {
@@ -968,13 +1055,29 @@ function useDrawingExport({
       void (async () => {
         try {
           const { jsPDF } = await import('jspdf');
-          const pngDataUrl = await rasterizeSvgToPngDataUrl(svg, widthMm, heightMm);
+          const { dataUrl, fit } = await rasterizeSvgToPngDataUrl(svg, widthMm, heightMm);
           const doc = new jsPDF({
             unit: 'mm',
             format: [widthMm, heightMm],
             orientation: widthMm >= heightMm ? 'landscape' : 'portrait',
           });
-          doc.addImage(pngDataUrl, 'PNG', 0, 0, widthMm, heightMm);
+          // Full paper rectangle, deliberately NOT `fit.widthPx / dpi`: the
+          // image must span the sheet whatever the raster cost, or a capped
+          // export would print a smaller sheet at the same nominal scale.
+          doc.addImage(dataUrl, 'PNG', 0, 0, widthMm, heightMm);
+
+          if (fit.capped) {
+            // FLOOR, not round: 299.53 dpi renders as "reduced from 300 to
+            // 300" under rounding, which reads as a no-op notice, and
+            // overstating the resolution delivered is the direction that
+            // misleads.
+            toast.info(
+              `Sheet rasterized at ${Math.floor(fit.effectiveDpi)} dpi instead of ` +
+              `${SHEET_PDF_DPI} — a ${Math.round(widthMm)}x${Math.round(heightMm)} mm sheet ` +
+              `exceeds the browser's canvas limit at full resolution. Use the SVG export ` +
+              `for a vector sheet at any size.`,
+            );
+          }
 
           const stem = `${sanitizeFilename(activeSheet.name, { fallback: 'sheet' })}-${sectionPlane.axis}-${sectionPlane.position}`;
           downloadFile(doc.output('blob'), `${stem}.pdf`, 'application/pdf');
@@ -983,9 +1086,13 @@ function useDrawingExport({
             axis: sectionPlane.axis,
             scale_factor: activeSheet.scale.factor,
             sheet_enabled: true,
+            // What the SHEET got, not what was asked for — the same
+            // distinction `PdfViewExportDialog` records as `shading_dpi`.
+            raster_dpi: Math.floor(fit.effectiveDpi),
+            raster_capped: fit.capped,
           });
         } catch (err) {
-          // eslint-disable-next-line no-alert -- matches the raw-drawing PDF path's alert() below; this hook has no toast wiring.
+          // eslint-disable-next-line no-alert -- matches the raw-drawing PDF path's alert() below; a blocking alert is the existing convention for an export that FAILED, and toast.info here is only used for an export that succeeded in a degraded form.
           alert(err instanceof Error ? `Could not export PDF: ${err.message}` : 'Could not export PDF.');
         }
       })();
@@ -1006,7 +1113,7 @@ function useDrawingExport({
     try {
       layout = computePdfSectionLayout(drawing.bounds, currentAxis, effectiveScale, 10);
     } catch (err) {
-      // eslint-disable-next-line no-alert -- matches handlePrint's popup-blocked alert below; this hook has no toast wiring.
+      // eslint-disable-next-line no-alert -- matches handlePrint's popup-blocked alert below; a blocking alert is the existing convention for an export that FAILED, and toast.info here is only used for an export that succeeded in a degraded form.
       alert(err instanceof Error ? err.message : 'Could not export PDF: invalid scale.');
       return;
     }


### PR DESCRIPTION
Bounds the sheet PDF raster so an oversized paper cannot produce an undiagnosable export failure.

> **Read this first — this PR contains a commit that was never raised.** `rasterizeSvgToPngDataUrl` does not exist on `main`. It was introduced by `a0fe557e8` on the branch `fix-drawing-sheet-pdf`, which has **no PR** and is one commit ahead of / 109 behind main. This PR therefore carries **two** commits: that one, and the ceiling fix on top. I did not write `a0fe557e8` and have not independently verified it beyond the suites below — if you would rather it were raised and reviewed separately, say so and I will split them.
>
> It also is **not** part of #2960, contrary to how the finding was originally filed against that PR. #2960 is the section-sheet X-centring work and touches no raster.

## The real ceiling is ARCH E, not A0

Only one DPI exists: `dpi = 300` is a hardcoded default with a single call site that never overrides it, and there is no UI control. So the variable is paper size alone.

All 25 registry sizes at 300 dpi — 9 of 25 exceed the cap:

| paper | px @300 | Mpx | capped | eff. dpi |
|---|---|---|---|---|
| ARCH_E | 14400×10800 | **155.5** | yes | 197 |
| A0 | 14044×9934 | 139.5 | yes | 208 |
| ANSI_E | 13200×10200 | 134.6 | yes | 211 |
| ARCH_E1 | 12600×9000 | 113.4 | yes | 230 |
| ARCH_D | 10800×7200 | 77.8 | yes | 278 |
| A1 | 9934×7016 | 69.7 | yes | 294 |
| ANSI_D | 10200×6600 | 67.3 | yes | 299 |
| **ARCH_C** | 7200×5400 | **38.9** | **no** | 300 |
| A3 (default) | 4961×3508 | 17.4 | no | 300 |

`DrawingSheet.paper` also permits a custom size, so the guard is size-driven rather than enum-driven.

## What actually happens at the cap — and it is not a blank page

Established by reading WebKit source, **not observed in a browser**:

- `CanvasBase::maxCanvasArea()` is `8192*8192` on iOS-family, `16384*16384` elsewhere.
- `CanvasBase::validateArea()` **logs a console warning and returns false** — no exception.
- `getContext('2d')` still returns a live context; `fillRect`/`drawImage` become no-ops.
- `toDataURL` returns the literal **`"data:,"`** for a null buffer.

**Verified by running:** jsPDF 4.2 rejects `"data:,"` rather than embedding it. With `jsPDF.API.loadFile` stubbed to `''` — what a browser XHR on `data:,` yields — the result is `wrong PNG signature`. So today's failure is `alert("Could not export PDF: wrong PNG signature")`: a decoder message with **no remedy in it**.

I could not observe Chrome, Firefox or Safari behaviour directly, or Safari's separate *total* canvas-memory limit, and claim nothing about them.

## Cap-and-surface, not refuse

A refusal has no actionable remedy to name here — there is no DPI control, and the sheet's paper size is the deliverable rather than a preference. "Pick A1 instead of A0" changes the drawing.

So it reuses `fitRasterPixels`, the helper the 3D-view PDF's shaded underlay already uses, giving both raster paths one cap policy. Both sides scale by a single factor and the image still spans the full paper rectangle in mm — **a capped sheet is blurrier, never mis-scaled** — and the reduction is surfaced rather than silent. Worst case is 197 dpi, above the 150 dpi this repo already ships as adequate for a printed PDF raster.

**Threshold:** `MAX_SHEET_RASTER_PIXELS = 8192 * 8192`, WebKit's iOS-family `maxCanvasArea()`, written as the expression rather than a flattened round number; `MAX_SHEET_RASTER_DIMENSION_PX = 16_384`, WebKit's non-iOS side length and the number `@ifc-lite/drawing-2d` already uses.

**A second, independent guard:** a data URL not starting `data:image/png` is refused with a message naming the paper size and pointing at SVG export. That covers what a pixel budget cannot — Safari's total-memory cap, a low-memory allocation failure, and **a browser returning a valid all-white bitmap**, which would otherwise export a genuinely blank page.

The single call site is already inside `try/catch → alert`, so the new throw is handled. `handlePrint`, `handleExportSVG` and DXF do not raster.

## RED → GREEN

RED, with the constants added as inert exports: **6 tests, 3 pass, 3 fail** — A0 never reaches `addImage`, zero reduction notices, and `['data:,', 'PNG', 0, 0, 297, 210]` reaching jsPDF verbatim. GREEN: **7/7**.

Mutated both directions: budget ×64 → 3 red; budget tightened to `4096*4096`, which would degrade currently-working exports → 3 red; blank-bitmap guard disabled → 1 red; notice silenced → 1 red.

**One finding worth recording.** The first version of the "largest paper that already worked" test derived its fixture from the *production* constant — so it stayed green under the over-tight cap, proving nothing. Re-anchored to WebKit's number, with a test pinning `getDefaultPaperSize()` (A3) explicitly. That is noted in the test's own comment.

Largest known-good still works: ARCH_C at 38.9 Mpx and the A3 default both export at full 300 dpi with zero notices, against a stub that allocates anything.

## Gates

Viewer sheet/drawing/export neighbourhood **246 pass / 0 fail**; `@ifc-lite/drawing-2d` **371/371**; `tsc --noEmit` clean; oxlint clean on changed files; `check-changesets` and `check-api-surface` exit 0 (app exports only, no package surface change).

Sources: WebKit `CanvasBase.cpp`, WebKit `ImageUtilities.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Drawing Sheet PDF exports to preserve paper dimensions, sheet layout, title blocks, and scale bars.
  * Automatically adjusts rasterization to browser canvas limits while preserving full-paper placement.
  * Notifies you when export resolution is reduced.

* **Bug Fixes**
  * Added clearer, actionable error messages when PDF rasterization cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->