### PR TITLE
ci(viewer): shard by a hash of the path, so membership is stable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -373,6 +373,15 @@ jobs:
   # knows what good looks like rather than only what broken looked like:
   # 2:29, 2:01, 1:50 against a 25 minute cap.
   #
+  # Shard membership is a hash of the file PATH, not its index in the sorted
+  # list. With `NR % n` every file after an added or removed test moves to a
+  # different shard: measured, adding ONE file reassigned 534 of 534. Two
+  # things that breaks. A flaky file wanders between shards, and "shard 1
+  # passed on PR X" stops being evidence about shard 1 on PR Y, because they
+  # are not the same set of files. I used exactly that cross-PR comparison as
+  # proof while chasing a flake, and it did not hold. With the hash, adding a
+  # file reassigns 0 of 534.
+  #
   # Parallelism comes from the SHARDS, not from concurrency inside a shard.
   # `--test-concurrency=1` is deliberate: at 4 a timing-sensitive test races
   # three neighbours, and `useSandbox.runSupersession.test.tsx` failed on three

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -14,7 +14,7 @@
     "build": "vite build && node ../../scripts/check-tla-chunk-await.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
-    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort | awk -v s=\"${TEST_SHARD:-0}\" -v n=\"${TEST_SHARDS:-1}\" 'NR % n == s')",
+    "test": "tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 $(find src -type f \\( -name '*.test.ts' -o -name '*.test.tsx' \\) | sort | awk -v s=\"${TEST_SHARD:-0}\" -v n=\"${TEST_SHARDS:-1}\" '{h=0; for(i=1;i<=length($0);i++) h=(h*31+index(\" !\\\"#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{|}~\", substr($0,i,1)))%1000003} h%n==s')",
     "check:templates": "tsc -p src/lib/scripts/templates/tsconfig.json --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
A reviewer pointed out that my sharding was unstable. They were right, and it invalidates a piece of evidence I used elsewhere.

## The problem

I sharded with `awk 'NR % n == s'` over the sorted file list, so a file's shard depends on its **index**. Adding or removing any test file shifts every file after it.

Measured on the real tree, not assumed:

```
adding ONE test file, index-based:   534 of 534 files reassigned
adding ONE test file, hash-based:      0 of 534 files reassigned
```

## Two things that breaks

**A flaky file wanders.** "Shard 2 is the slow one" or "the flake lives in shard 1" decays with every test added.

**Cross-PR comparison is invalid**, and this is the one that caught me. While chasing the `useSandbox.runSupersession` flake I argued that **#3038's shard 1 passing on the same base** showed #3027's shard-1 failure was unrelated. Different PRs have different file counts, therefore different shard composition — so those were not the same set of files, and the argument does not carry.

The conclusion still stands on the rest of the evidence: neither diff can reach that test, it passes locally 3 of 3, and five PRs hit it under `--test-concurrency=4` while none has since. But I put an invalid argument in the pile and presented it as proof, and it should not have been there.

## The fix

Shard membership becomes a hash of the file path, so it is a property of the file and nothing else.

Partition verified exact rather than assumed:

```
124 + 147 + 127 + 136 = 534 files
534 distinct paths across the four shards
no env set -> still selects all 534, so a local `pnpm test` is unchanged
```

The workflow comment records why, including the 534-of-534 measurement, so the next person does not reintroduce `NR % n` as the obvious way to shard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test sharding now uses deterministic file-based assignment, keeping test files consistently in the same shard between runs.
  * Added documentation explaining shard membership and how it differs from index-based distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->