### PR TITLE
fix(extensions): one AST walker, and fail closed when a node type cannot be walked

### DIFF
--- a/.changeset/bounded-ast-walk-for-author-source.md
+++ b/.changeset/bounded-ast-walk-for-author-source.md
@@ -16,8 +16,10 @@ stack the caller happened to have left.
 
 Both now traverse through a new internal `walkBounded`
 (`src/ast/bounded-walk.ts`), which keeps its own stack on the heap and stops at
-`MAX_AST_DEPTH = 1000` (~500 source levels of `if (1) { … }`, below acorn's own
-parse floor of roughly 1200). It descends using `acorn-walk`'s `base` visitor
+`MAX_AST_DEPTH = 1000` (~500 source levels of `if (1) { … }`; acorn's own parser
+gives up somewhere above that, but where depends on the host's remaining stack —
+measured on Node 22 between 1100 and 4000 source levels, so it is not a fixed
+floor to sit under). It descends using `acorn-walk`'s `base` visitor
 and reports nodes in `walk.simple`'s post-order, so which child positions count
 as nodes — non-computed member properties and object keys stay unvisited — and
 the order they arrive in are unchanged. Behaviour below the bound is identical.

--- a/.changeset/one-ast-walker-that-fails-closed.md
+++ b/.changeset/one-ast-walker-that-fails-closed.md
@@ -1,0 +1,60 @@
+---
+'@ifc-lite/extensions': patch
+---
+
+Put the entry-script scan on the package's one AST walker, and fail closed on a
+subtree the walker cannot descend.
+
+Three follow-ups to the bounded-walk work, all latent rather than live — no
+input reaching this package today takes any of the paths below.
+
+**One walker, one bound.** `src/ast/bounded-walk.ts` opened with "this module is
+the single traversal used by every AST consumer here… Callers vary the visitor;
+they do not re-implement the traversal", while `host/source-wrap.ts` ran its own
+hand-written traversal with its own private `MAX_AST_DEPTH = 1000` and its own
+generic child enumeration. Two walkers and two constants with a comment telling
+the next reader the second one did not exist. `checkBannedConstructs` now calls
+`walkBounded`; the duplicate constant and the generic `childNodes` helper are
+gone.
+
+The migration narrows which child positions get *reported* — `acorn-walk`'s
+`base` skips non-computed member properties, plain object keys, labels,
+`ExportSpecifier`s and pattern `Property` wrappers, which the generic
+property-crawl reported as nodes. It does not narrow what the scan *catches*: a
+differential run over 59 sources placing each banned construct in an exotic
+position found no banned node reached by the generic crawl and missed by
+`base`, including the pattern-default case where the `Property` wrapper is
+skipped but the `ImportExpression` under it is still visited via `ObjectPattern`.
+The accept/reject depths are unchanged for both shapes measured (`if`-nesting
+and arrow chains), and a test now pins `wrapEntrySource` and `validateCode`
+against each other across the boundary so a future divergence fails.
+
+**A missing `base` is now a failure, not a silent stop.** `walkBounded` reported
+a node it had no `base` for and skipped its entire subtree. Every caller is a
+scanner looking for things it must not find, so a skipped subtree was a scan
+that failed open: `validateCode` returned `ok`, `inferCapabilities` published an
+under-counted capability set, and `wrapEntrySource` wrapped the script — none of
+them could tell "found nothing" from "never looked". `acorn-walk` throws on a
+missing `base` for exactly this reason; we report instead of throwing because
+these callers are declared to return a result. The result now carries
+`unwalkableTypes`, and all three callers treat a non-empty list the way they
+already treat `depthExceeded`. This becomes reachable the first time acorn is
+upgraded ahead of `acorn-walk` — the skew that landed class static blocks,
+import attributes and `await using`. Verified against acorn 8.18.0 /
+acorn-walk 8.3.5: no node type acorn emits today is missing a base, and the
+tests reproduce the skew by removing one `base` entry rather than waiting for an
+upgrade.
+
+**Two comments that named a number acorn does not have.** The walker's docstring
+claimed acorn "gives up at roughly 1200 source levels" and `source-wrap.ts`
+claimed "roughly twice this depth". Both understate — so they erred safe — but
+as written they were the numbers a future reader would cite to justify raising
+the bound. Measured on Node 22, the same script parses at 1100 source levels and
+aborts the process at 1200 in a default-stack run (a fatal V8 abort, exit 134,
+not a catchable error), is rejected at 1200 under this repo's vitest workers,
+and parses at 4000 under `node --stack-size=4000`. The parser's give-up point is
+a property of the host's remaining stack, not of acorn, and the docstring now
+says so — which is the argument for a fixed heap-based bound, not against it.
+
+`MAX_AST_DEPTH` is unchanged at 1000. No public API change; `walkBounded` is
+still not exported from the package entry point.

--- a/.changeset/one-ast-walker-that-fails-closed.md
+++ b/.changeset/one-ast-walker-that-fails-closed.md
@@ -41,9 +41,11 @@ these callers are declared to return a result. The result now carries
 already treat `depthExceeded`. This becomes reachable the first time acorn is
 upgraded ahead of `acorn-walk` — the skew that landed class static blocks,
 import attributes and `await using`. Verified against acorn 8.18.0 /
-acorn-walk 8.3.5: no node type acorn emits today is missing a base, and the
-tests reproduce the skew by removing one `base` entry rather than waiting for an
-upgrade.
+acorn-walk 8.3.5: no node type the walk actually reaches is missing a base.
+(`ExportSpecifier` has no `base` entry, but `base.ExportNamedDeclaration` never
+descends into `specifiers`, so the walk never dispatches on it — it is unreached,
+not unwalkable.) The tests reproduce the skew by removing one `base` entry rather
+than waiting for an upgrade.
 
 **Two comments that named a number acorn does not have.** The walker's docstring
 claimed acorn "gives up at roughly 1200 source levels" and `source-wrap.ts`

--- a/packages/extensions/src/ast/bounded-walk.test.ts
+++ b/packages/extensions/src/ast/bounded-walk.test.ts
@@ -105,4 +105,71 @@ describe('walkBounded', () => {
     expect(res.depthExceeded).toBe(false);
     expect(seen).toBe(MAX_AST_DEPTH * 3);
   });
+
+  it('leaves unwalkableTypes empty for ordinary source', () => {
+    const res = walkBounded(
+      parse('async function activate(ctx) { const w = await ctx.bim.query.byType("IfcWall"); return w.length; }'),
+      () => {},
+    );
+    expect(res.unwalkableTypes).toEqual([]);
+  });
+});
+
+/**
+ * The node types acorn can emit are not the node types `acorn-walk`
+ * knows how to descend — the two packages version independently, and
+ * every new syntax (class static blocks, import attributes, `await
+ * using`) lands in the parser first. `withoutBase` reproduces that
+ * skew deliberately instead of waiting for an upgrade to produce it:
+ * it removes one `base` entry for the duration of the callback, so a
+ * node type acorn still emits becomes one the walker cannot descend.
+ */
+function withoutBase<T>(type: string, run: () => T): T {
+  const base = walk.base as unknown as Record<string, unknown>;
+  const saved = base[type];
+  expect(saved).toBeTypeOf('function');
+  delete base[type];
+  try {
+    return run();
+  } finally {
+    base[type] = saved;
+  }
+}
+
+describe('walkBounded — a subtree it cannot descend', () => {
+  it('reports the type instead of silently skipping the subtree', () => {
+    const ast = parse('try { eval("payload"); } catch (e) {}');
+    const seen: string[] = [];
+    const res = withoutBase('TryStatement', () =>
+      walkBounded(ast, (_n, type) => {
+        seen.push(type);
+      }),
+    );
+
+    // The subtree really was skipped — this is the fail-open shape.
+    expect(seen).not.toContain('CallExpression');
+    // …and the result says so, so the caller cannot read the silence
+    // as "nothing found".
+    expect(res.unwalkableTypes).toEqual(['TryStatement']);
+    // Not a depth problem: the two causes stay distinguishable.
+    expect(res.depthExceeded).toBe(false);
+  });
+
+  it('keeps walking the siblings of the subtree it could not descend', () => {
+    const ast = parse('try {} catch (e) {} eval("after");');
+    const seen: string[] = [];
+    const res = withoutBase('TryStatement', () =>
+      walkBounded(ast, (_n, type) => {
+        seen.push(type);
+      }),
+    );
+    expect(seen).toContain('CallExpression');
+    expect(res.unwalkableTypes).toEqual(['TryStatement']);
+  });
+
+  it('deduplicates repeated unwalkable types', () => {
+    const ast = parse('try {} catch (e) {} try {} catch (e) {}');
+    const res = withoutBase('TryStatement', () => walkBounded(ast, () => {}));
+    expect(res.unwalkableTypes).toEqual(['TryStatement']);
+  });
 });

--- a/packages/extensions/src/ast/bounded-walk.ts
+++ b/packages/extensions/src/ast/bounded-walk.ts
@@ -46,6 +46,16 @@ import * as walk from 'acorn-walk';
  * (`IfStatement` -> `BlockStatement`), so the bound bites at 500 such
  * source levels.
  *
+ * The bound is in AST levels, so its effective *source*-level threshold
+ * varies by construct, and for cheap constructs it is unreachable. An
+ * arrow link (`() => () => …`) costs one level, not two, so this bound
+ * would need ~1000 of them — and acorn runs out of stack parsing that
+ * shape at a few hundred links, well before the walk is ever asked. The
+ * asymmetry is intended: the bound guards the walk's own stack, and a
+ * construct that the parser rejects first never reaches the walk.
+ * `host/source-wrap.test.ts` pins both the 1:2 cost ratio and the fact
+ * that every parseable arrow depth is accepted.
+ *
  * Do NOT think of this as "well under acorn's own parser limit": acorn
  * has no fixed limit to be under. The same script, on Node 22, parses
  * at 1100 source levels and aborts the process at 1200 in a

--- a/packages/extensions/src/ast/bounded-walk.ts
+++ b/packages/extensions/src/ast/bounded-walk.ts
@@ -12,10 +12,13 @@
  * `RangeError: Maximum call stack size exceeded` out of the middle of
  * whatever function invoked the walk.
  *
- * This module is the single traversal used by every AST consumer here.
- * It keeps its own stack on the heap and stops at {@link MAX_AST_DEPTH},
- * *reporting* that it stopped rather than throwing. Callers vary the
- * visitor; they do not re-implement the traversal.
+ * This module is the single traversal used by every AST consumer here
+ * — `validateCode`, `inferCapabilities` and the entry-script
+ * banned-construct scan in `host/source-wrap.ts`. It keeps its own
+ * stack on the heap and stops at {@link MAX_AST_DEPTH}, *reporting*
+ * that it stopped rather than throwing. Callers vary the visitor; they
+ * do not re-implement the traversal, and there is exactly one depth
+ * bound for them to disagree about.
  *
  * It descends using `acorn-walk`'s own `base` visitor rather than
  * enumerating object properties generically, so which child positions
@@ -40,11 +43,19 @@ import * as walk from 'acorn-walk';
  * caller reports a validation failure instead of continuing.
  *
  * One `if (1) { … }` source level costs two levels here
- * (`IfStatement` -> `BlockStatement`), and acorn's own parser gives up
- * at roughly 1200 *source* levels ("Not enough stack space to parse
- * input"). That parser limit moves with however much stack the host
- * happens to have left; this one does not, which is the entire point —
- * the accept/reject boundary must not depend on the caller's remaining
+ * (`IfStatement` -> `BlockStatement`), so the bound bites at 500 such
+ * source levels.
+ *
+ * Do NOT think of this as "well under acorn's own parser limit": acorn
+ * has no fixed limit to be under. The same script, on Node 22, parses
+ * at 1100 source levels and aborts the process at 1200 in a
+ * default-stack run, is rejected at 1200 under this repo's vitest
+ * workers ("Not enough stack space to parse input"), and parses at
+ * 4000 under `node --stack-size=4000`. The parser's give-up point is a
+ * property of the host's remaining stack, not of acorn — and one of
+ * those three failures is a fatal V8 abort (exit 134), not a catchable
+ * error. This bound does not move, which is the entire point: the
+ * accept/reject boundary must not depend on the caller's remaining
  * stack.
  *
  * Catching the `RangeError` instead would reintroduce exactly that
@@ -68,6 +79,21 @@ export interface BoundedWalkResult {
    * never as "nothing found".
    */
   depthExceeded: boolean;
+  /**
+   * Node types `acorn-walk` had no `base` entry for, deduplicated. The
+   * subtree under such a node was NOT descended, so — exactly like
+   * {@link depthExceeded} — the visit is incomplete and the caller MUST
+   * treat a non-empty list as a failure. Every call site here is a
+   * scanner looking for things it must not find, so an unwalkable
+   * subtree is a scan that found nothing because it never looked.
+   *
+   * This is how a walk sees an acorn upgrade that lands a new node type
+   * ahead of `acorn-walk` (class static blocks, import attributes and
+   * `await using` all arrived that way). `acorn-walk` throws on a
+   * missing base for the same reason; we report instead of throwing
+   * because the callers are declared to return a result, not to throw.
+   */
+  unwalkableTypes: readonly string[];
 }
 
 function isAstNode(value: unknown): value is AstNode {
@@ -100,14 +126,17 @@ interface Frame {
  * key. One traversal is therefore shared across sites that care about
  * entirely different node types.
  *
- * Returns `{ depthExceeded: true }` if the bound stopped the walk. The
- * traversal never throws for depth reasons.
+ * Returns `depthExceeded: true` if the bound stopped the walk, and
+ * lists in `unwalkableTypes` any node type it could not descend. The
+ * traversal never throws for either reason — but a caller that ignores
+ * either field is reporting "clean" on a tree it did not finish
+ * reading.
  */
 export function walkBounded(
   root: unknown,
   visit: (node: AstNode, type: string) => void,
 ): BoundedWalkResult {
-  if (!isAstNode(root)) return { depthExceeded: false };
+  if (!isAstNode(root)) return { depthExceeded: false, unwalkableTypes: [] };
 
   const baseVisitor = walk.base as unknown as Record<
     string,
@@ -115,6 +144,7 @@ export function walkBounded(
   >;
 
   const stack: Frame[] = [{ node: root, depth: 0, expanded: false }];
+  const unwalkable = new Set<string>();
 
   while (stack.length > 0) {
     const frame = stack.pop()!;
@@ -125,12 +155,18 @@ export function walkBounded(
       continue;
     }
 
-    if (frame.depth > MAX_AST_DEPTH) return { depthExceeded: true };
+    if (frame.depth > MAX_AST_DEPTH) {
+      return { depthExceeded: true, unwalkableTypes: [...unwalkable] };
+    }
 
     const baseFn = baseVisitor[type];
     if (!baseFn) {
-      // Unknown node type: report it and stop descending, matching
-      // acorn-walk's own behaviour of throwing only on a missing base.
+      // No base for this type: we cannot enumerate its children, so its
+      // whole subtree goes uninspected. Report the node itself and keep
+      // walking its siblings — the rest of the tree is still worth
+      // scanning — but record the type so the caller fails instead of
+      // reading the visitor's silence as "nothing found".
+      unwalkable.add(type);
       visit(frame.node, type);
       continue;
     }
@@ -158,5 +194,5 @@ export function walkBounded(
     }
   }
 
-  return { depthExceeded: false };
+  return { depthExceeded: false, unwalkableTypes: [...unwalkable] };
 }

--- a/packages/extensions/src/host/source-wrap.test.ts
+++ b/packages/extensions/src/host/source-wrap.test.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
+import * as walk from 'acorn-walk';
+import { validateCode } from '../validate/code.js';
 import { wrapEntrySource } from './source-wrap.js';
 
 describe('wrapEntrySource — happy', () => {
@@ -180,5 +182,180 @@ describe('wrapEntrySource — deeply nested entry scripts', () => {
     if (!r.ok) {
       expect(r.errors.some((e) => e.message.includes('Dynamic `import(...)`'))).toBe(true);
     }
+  });
+});
+
+describe('wrapEntrySource — one depth bound, shared with validateCode', () => {
+  // `wrapEntrySource` and `validateCode` used to run two hand-written
+  // traversals with two private copies of the depth constant. They now
+  // share `walkBounded`; this pins the agreement so a re-divergence is
+  // a failing test rather than a latent one.
+  const ifs = (n: number) => `${'if (1) {'.repeat(n)}function activate(ctx) {}${'}'.repeat(n)}`;
+  const arrows = (n: number) => `function activate(ctx) { const f = ${'() => '.repeat(n)}1; }`;
+
+  // Deliberately spans the accept/reject boundary of both shapes: the
+  // test would be vacuous if every depth landed on the same side.
+  const DEPTHS = [10, 200, 400, 450, 475, 490, 499, 500, 501, 600, 900];
+
+  for (const [shape, make] of [['if-block', ifs], ['arrow chain', arrows]] as const) {
+    it(`accepts and rejects the same ${shape} depths as validateCode`, () => {
+      const verdicts = DEPTHS.map((n) => {
+        const source = make(n);
+        return {
+          n,
+          wrap: wrapEntrySource(source, { entryFnName: 'activate' }).ok,
+          validate: validateCode(source).ok,
+        };
+      });
+
+      for (const v of verdicts) {
+        expect(`${v.n}:${v.wrap}`).toBe(`${v.n}:${v.validate}`);
+      }
+      // The range really does straddle the bound.
+      expect(verdicts.some((v) => v.wrap)).toBe(true);
+      expect(verdicts.some((v) => !v.wrap)).toBe(true);
+    });
+  }
+});
+
+describe('wrapEntrySource — every banned construct, in a nested position', () => {
+  // Migrating this scan onto `acorn-walk`'s `base` narrowed which child
+  // positions are descended (non-computed member properties, plain
+  // object keys, labels and pattern `Property` wrappers are no longer
+  // reported as nodes). One case per banned construct, each buried
+  // where the old generic property-crawl was the only obvious way to
+  // reach it, so a coverage loss shows up here.
+  const cases: Array<[string, string]> = [
+    ['ImportDeclaration', 'import fs from "node:fs";\nfunction activate(ctx) {}'],
+    ['ExportNamedDeclaration', 'export const a = 1;\nfunction activate(ctx) {}'],
+    ['ExportDefaultDeclaration', 'export default 1;\nfunction activate(ctx) {}'],
+    ['ExportAllDeclaration', 'export * from "node:fs";\nfunction activate(ctx) {}'],
+    ['ImportExpression in a class static block', 'class C { static { import("node:fs"); } }\nfunction activate(ctx) {}'],
+    ['ImportExpression in a computed key', 'const o = { [import("node:fs")]: 1 };\nfunction activate(ctx) {}'],
+    ['ImportExpression in an object value', 'const o = { k: import("node:fs") };\nfunction activate(ctx) {}'],
+    ['ImportExpression in a default parameter', 'function activate(ctx, a = import("node:fs")) {}'],
+    ['ImportExpression in a destructuring default', 'function activate(ctx) { const { a = import("node:fs") } = ctx; }'],
+    [
+      'ImportExpression in a template literal',
+      `function activate(ctx) { return \`\${import("node:fs")}\`; }`,
+    ],
+    ['ImportExpression behind optional chaining', 'function activate(ctx) { return ctx?.a?.[import("node:fs")]; }'],
+    ['ImportExpression in a class field initialiser', 'class C { p = import("node:fs"); }\nfunction activate(ctx) {}'],
+    ['ImportExpression in a getter body', 'const o = { get a() { return import("node:fs"); } };\nfunction activate(ctx) {}'],
+    ['ImportExpression under a label', 'function activate(ctx) { outer: { import("node:fs"); } }'],
+    ['ImportExpression in a catch clause', 'function activate(ctx) { try {} catch (e) { import("node:fs"); } }'],
+    ['ImportExpression with import attributes', 'function activate(ctx) { import("node:fs", { with: { type: "json" } }); }'],
+  ];
+
+  for (const [name, source] of cases) {
+    it(`rejects ${name}`, () => {
+      const r = wrapEntrySource(source, { entryFnName: 'activate' });
+      expect(r.ok).toBe(false);
+    });
+  }
+
+  it('reports each banned construct exactly once', () => {
+    // `walkBounded` reports statements and expressions twice — once
+    // under acorn-walk's synthetic key, once under the real type. The
+    // visitor switches on the supplied key for that reason; switching
+    // on `node.type` would double every diagnostic.
+    const r = wrapEntrySource('function activate(ctx) { import("node:fs"); }', {
+      entryFnName: 'activate',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors).toHaveLength(1);
+  });
+});
+
+describe('wrapEntrySource — a subtree the walker cannot descend', () => {
+  /** See `validate/code.test.ts`: simulates an acorn/acorn-walk skew. */
+  function withoutBase<T>(type: string, run: () => T): T {
+    const base = walk.base as unknown as Record<string, unknown>;
+    const saved = base[type];
+    expect(saved).toBeTypeOf('function');
+    delete base[type];
+    try {
+      return run();
+    } finally {
+      base[type] = saved;
+    }
+  }
+
+  it('refuses to wrap a script it could not fully check', () => {
+    const source = 'function activate(ctx) { try { import("node:fs"); } catch (e) {} }';
+    // Unmodified, the buried `import()` is found — so the rejection
+    // below is about the missing base, not about this source.
+    expect(wrapEntrySource(source, { entryFnName: 'activate' }).ok).toBe(false);
+
+    const r = withoutBase('TryStatement', () =>
+      wrapEntrySource(source, { entryFnName: 'activate' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors.some((e) => e.message.includes('cannot traverse'))).toBe(true);
+      expect(r.errors.some((e) => e.message.includes('TryStatement'))).toBe(true);
+    }
+  });
+
+  it('does not wrap a clean-looking script whose subtree went unscanned', () => {
+    const source = 'function activate(ctx) { try { ctx.bim.query.byType("IfcWall"); } catch (e) {} }';
+    expect(wrapEntrySource(source, { entryFnName: 'activate' }).ok).toBe(true);
+
+    const r = withoutBase('TryStatement', () =>
+      wrapEntrySource(source, { entryFnName: 'activate' }),
+    );
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('wrapEntrySource — realistic extension sources still wrap', () => {
+  // The other direction of the fail-closed change: tightening the
+  // walker must not start rejecting ordinary extension code.
+  const REALISTIC = `
+const STOREY_TYPE = 'IfcBuildingStorey';
+
+async function collectWalls(ctx) {
+  const walls = await ctx.bim.query.byType('IfcWall');
+  return walls.filter((w) => w?.properties?.LoadBearing === true);
+}
+
+class WallReport {
+  #rows = [];
+  static HEADER = ['GlobalId', 'Name'];
+  static { WallReport.created = 0; }
+  add(wall) {
+    this.#rows.push([wall.globalId, wall.name ?? '(unnamed)']);
+  }
+  get rows() { return this.#rows; }
+}
+
+async function activate(ctx) {
+  const report = new WallReport();
+  try {
+    for (const wall of await collectWalls(ctx)) report.add(wall);
+    const { rows = [] } = report;
+    label: for (const row of rows) {
+      if (row.length === 0) continue label;
+      ctx.bim.log?.info?.(\`row \${row.join(', ')}\`);
+    }
+    const byStorey = { [STOREY_TYPE]: rows.length, total: rows.length };
+    return byStorey;
+  } catch (err) {
+    ctx.bim.log?.error?.(String(err));
+    return null;
+  }
+}
+`;
+
+  it('wraps a realistic extension entry script with no errors', () => {
+    const r = wrapEntrySource(REALISTIC, { entryFnName: 'activate' });
+    if (!r.ok) throw new Error(`unexpected errors: ${JSON.stringify(r.errors)}`);
+    expect(r.ok).toBe(true);
+  });
+
+  it('validateCode also passes that same source', () => {
+    const r = validateCode(REALISTIC);
+    expect(r.errors).toEqual([]);
+    expect(r.ok).toBe(true);
   });
 });

--- a/packages/extensions/src/host/source-wrap.test.ts
+++ b/packages/extensions/src/host/source-wrap.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
+import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
 import { validateCode } from '../validate/code.js';
 import { wrapEntrySource } from './source-wrap.js';
@@ -193,29 +194,94 @@ describe('wrapEntrySource — one depth bound, shared with validateCode', () => 
   const ifs = (n: number) => `${'if (1) {'.repeat(n)}function activate(ctx) {}${'}'.repeat(n)}`;
   const arrows = (n: number) => `function activate(ctx) { const f = ${'() => '.repeat(n)}1; }`;
 
-  // Deliberately spans the accept/reject boundary of both shapes: the
-  // test would be vacuous if every depth landed on the same side.
-  const DEPTHS = [10, 200, 400, 450, 475, 490, 499, 500, 501, 600, 900];
-
-  for (const [shape, make] of [['if-block', ifs], ['arrow chain', arrows]] as const) {
-    it(`accepts and rejects the same ${shape} depths as validateCode`, () => {
-      const verdicts = DEPTHS.map((n) => {
-        const source = make(n);
-        return {
-          n,
-          wrap: wrapEntrySource(source, { entryFnName: 'activate' }).ok,
-          validate: validateCode(source).ok,
-        };
-      });
-
-      for (const v of verdicts) {
-        expect(`${v.n}:${v.wrap}`).toBe(`${v.n}:${v.validate}`);
-      }
-      // The range really does straddle the bound.
-      expect(verdicts.some((v) => v.wrap)).toBe(true);
-      expect(verdicts.some((v) => !v.wrap)).toBe(true);
+  const verdictsFor = (make: (n: number) => string, depths: readonly number[]) =>
+    depths.map((n) => {
+      const source = make(n);
+      return {
+        n,
+        wrap: wrapEntrySource(source, { entryFnName: 'activate' }).ok,
+        validate: validateCode(source).ok,
+      };
     });
-  }
+
+  // Deliberately spans the accept/reject boundary: the test would be
+  // vacuous if every depth landed on the same side, so the straddle is
+  // asserted below rather than assumed.
+  const IF_DEPTHS = [10, 200, 400, 450, 475, 490, 499, 500, 501, 600, 900];
+
+  it('accepts and rejects the same if-block depths as validateCode', () => {
+    const verdicts = verdictsFor(ifs, IF_DEPTHS);
+
+    for (const v of verdicts) {
+      expect(`${v.n}:${v.wrap}`).toBe(`${v.n}:${v.validate}`);
+    }
+    // The range really does straddle the bound.
+    expect(verdicts.some((v) => v.wrap)).toBe(true);
+    expect(verdicts.some((v) => !v.wrap)).toBe(true);
+  });
+
+  // An arrow chain CANNOT straddle the bound, and the same depth list
+  // must not be reused for it. `MAX_AST_DEPTH` counts AST levels, and
+  // one arrow link costs one where one `if (1) {}` costs two (pinned by
+  // the ratio test below), so the bound needs ~1000 links — while acorn
+  // runs out of stack parsing this shape far earlier. Measured here: 400
+  // links parse, 425 fail with "Not enough stack space to parse input",
+  // and the exact crossover moves with the host's remaining stack (the
+  // very dependency `MAX_AST_DEPTH` exists to keep out of the verdict),
+  // so it is not pinned. Reusing IF_DEPTHS made the arrow half assert a
+  // straddle it reached only by PARSE failure at 450+, not by the bound
+  // — the same verdict for an unrelated reason, and flaky with it.
+  //
+  // So the honest claim, and the one asserted: within what acorn parses,
+  // every arrow depth is accepted, and both entry points agree on that.
+  const ARROW_DEPTHS = [10, 100, 200, 300];
+
+  it('accepts every parseable arrow-chain depth, and agrees with validateCode', () => {
+    const verdicts = verdictsFor(arrows, ARROW_DEPTHS);
+
+    for (const v of verdicts) {
+      expect(`${v.n}:${v.wrap}`).toBe(`${v.n}:${v.validate}`);
+    }
+    // Not a straddle — the bound is unreachable for this shape. Pin the
+    // uniformity so a future run that starts rejecting these is a
+    // failure to look at rather than a silently narrower test.
+    expect(verdicts.map((v) => `${v.n}:${v.wrap}`)).toEqual(
+      ARROW_DEPTHS.map((n) => `${n}:true`),
+    );
+  });
+
+  it('an arrow link costs one AST level where an `if (1) {}` block costs two', () => {
+    // The reason the two shapes need different depth lists, pinned
+    // directly instead of left as prose. Measured with an independent
+    // iterative crawl over acorn's tree — deliberately not `walkBounded`,
+    // which is the thing under test, and iterative so this helper cannot
+    // overflow the stack it is reasoning about.
+    const astDepth = (source: string): number => {
+      const root = acorn.parse(source, { ecmaVersion: 'latest', sourceType: 'module' });
+      let max = 0;
+      const stack: Array<{ value: unknown; depth: number }> = [{ value: root, depth: 0 }];
+      while (stack.length > 0) {
+        const { value, depth } = stack.pop()!;
+        if (Array.isArray(value)) {
+          for (const item of value) stack.push({ value: item, depth });
+          continue;
+        }
+        if (typeof value !== 'object' || value === null) continue;
+        const isNode = typeof (value as { type?: unknown }).type === 'string';
+        const childDepth = isNode ? depth + 1 : depth;
+        if (isNode && childDepth > max) max = childDepth;
+        for (const [key, child] of Object.entries(value)) {
+          if (key === 'type' || key === 'start' || key === 'end') continue;
+          stack.push({ value: child, depth: childDepth });
+        }
+      }
+      return max;
+    };
+
+    // Differences, so the constant prologue of each shape cancels.
+    expect(astDepth(ifs(200)) - astDepth(ifs(100))).toBe(200);
+    expect(astDepth(arrows(200)) - astDepth(arrows(100))).toBe(100);
+  });
 });
 
 describe('wrapEntrySource — every banned construct, in a nested position', () => {

--- a/packages/extensions/src/host/source-wrap.ts
+++ b/packages/extensions/src/host/source-wrap.ts
@@ -40,6 +40,7 @@
  */
 
 import * as acorn from 'acorn';
+import { MAX_AST_DEPTH, walkBounded } from '../ast/bounded-walk.js';
 import type { ValidationError, ValidationResult } from '../types.js';
 
 export interface SourceWrapOptions {
@@ -140,22 +141,6 @@ if (typeof ${entryFn} === 'function') {
 }
 
 /**
- * Maximum AST nesting depth the banned-construct walk will inspect.
- *
- * Real entry scripts nest a few tens of levels deep; this bound is
- * two orders of magnitude above that. It exists because the AST comes
- * from extension-author-controlled source: past this depth the walk
- * stops and reports a validation error instead of continuing. acorn's
- * own parser gives up at roughly twice this depth in the same process
- * ("Not enough stack space to parse input"), but that limit moves with
- * however much stack the host happens to have left; this one does not.
- *
- * A script nested deeper than this is rejected with an
- * `invalid_value` error naming the limit — never a thrown RangeError.
- */
-const MAX_AST_DEPTH = 1000;
-
-/**
  * Walk the *entire* AST — including nested function bodies, arrow
  * bodies, class methods, and blocks — looking for constructs we do
  * not support in v1. Returns one ValidationError per offending node.
@@ -169,33 +154,27 @@ const MAX_AST_DEPTH = 1000;
  * arrow, a class method, etc. — which is exactly the gap this walk
  * closes: the previous top-level-only scan missed it entirely.
  *
- * The traversal keeps its own stack on the heap instead of recursing
- * the way `acorn-walk` does. `wrapEntrySource` is declared to return a
+ * The traversal is `walkBounded` — the package's one AST walker. It
+ * keeps its own stack on the heap instead of recursing the way
+ * `acorn-walk` does: `wrapEntrySource` is declared to return a
  * ValidationResult, and a recursive walk over a deeply nested script
  * escapes that contract by throwing a RangeError out of the middle of
  * it. Deeply nested input has to come back as a *reported* error, the
- * same way acorn's own depth failure already does.
+ * same way acorn's own depth failure already does. Sharing the walker
+ * is what keeps this scan and `validateCode` from drifting apart on
+ * where "too deep" starts.
+ *
+ * The visitor switches on the type key `walkBounded` supplies, not on
+ * `node.type`: `acorn-walk` re-dispatches statements and expressions
+ * under synthetic keys, so a node reached that way is reported twice,
+ * once under each key, and switching on `node.type` would report every
+ * banned construct twice.
  */
 function checkBannedConstructs(ast: acorn.Node): ValidationError[] {
   const errors: ValidationError[] = [];
-  const stack: Array<{ node: AstNode; depth: number }> = [
-    { node: ast as unknown as AstNode, depth: 0 },
-  ];
 
-  while (stack.length > 0) {
-    const { node, depth } = stack.pop()!;
-
-    if (depth > MAX_AST_DEPTH) {
-      errors.push({
-        path: '',
-        code: 'invalid_value',
-        message: `Entry script is nested more than ${MAX_AST_DEPTH} AST levels deep.`,
-        hint: 'Flatten the script — extract deeply nested blocks into separate helper functions.',
-      });
-      return errors;
-    }
-
-    switch (node.type) {
+  const { depthExceeded, unwalkableTypes } = walkBounded(ast, (_node, type) => {
+    switch (type) {
       case 'ImportDeclaration':
         errors.push({
           path: '',
@@ -218,50 +197,31 @@ function checkBannedConstructs(ast: acorn.Node): ValidationError[] {
         });
         break;
     }
+  });
 
-    // Push children in reverse so the LIFO stack visits them in source
-    // order, matching the order acorn-walk would have reported in.
-    const children = childNodes(node);
-    for (let i = children.length - 1; i >= 0; i--) {
-      stack.push({ node: children[i]!, depth: depth + 1 });
-    }
+  if (depthExceeded) {
+    errors.push({
+      path: '',
+      code: 'invalid_value',
+      message: `Entry script is nested more than ${MAX_AST_DEPTH} AST levels deep.`,
+      hint: 'Flatten the script — extract deeply nested blocks into separate helper functions.',
+    });
+    return errors;
+  }
+
+  // A subtree the walker could not descend was never scanned, so a
+  // clean result would mean "found no `import`" when it means "did not
+  // look". Refuse the script instead of wrapping it.
+  if (unwalkableTypes.length > 0) {
+    errors.push({
+      path: '',
+      code: 'invalid_value',
+      message: `Entry script contains AST node types the validator cannot traverse (${unwalkableTypes.join(', ')}); it was not fully checked.`,
+      hint: 'This usually means the parser is newer than the walker it is paired with — report it rather than working around it.',
+    });
   }
 
   return errors;
-}
-
-interface AstNode {
-  type: string;
-  [key: string]: unknown;
-}
-
-function isAstNode(value: unknown): value is AstNode {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { type?: unknown }).type === 'string'
-  );
-}
-
-/**
- * Every child node of `node`, in property order. Generic over the AST
- * shape on purpose: an unknown property is either a primitive, a node,
- * or an array of nodes, and anything else (`loc`, `regex`, …) carries
- * no `type` string and is skipped.
- */
-function childNodes(node: AstNode): AstNode[] {
-  const out: AstNode[] = [];
-  for (const key of Object.keys(node)) {
-    const value = node[key];
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (isAstNode(item)) out.push(item);
-      }
-    } else if (isAstNode(value)) {
-      out.push(value);
-    }
-  }
-  return out;
 }
 
 function exportError(): ValidationError {

--- a/packages/extensions/src/inference/capability.test.ts
+++ b/packages/extensions/src/inference/capability.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
+import * as walk from 'acorn-walk';
 import { inferCapabilities, type InferenceResult } from './capability.js';
 
 describe('inferCapabilities — read-only patterns', () => {
@@ -217,5 +218,33 @@ describe('inferCapabilities — deeply nested scripts fail closed', () => {
     expect(deep.parseErrors.map((e) => e.message)).toEqual(
       shallow.parseErrors.map((e) => e.message),
     );
+  });
+});
+
+describe('inferCapabilities — a subtree the walker cannot descend', () => {
+  /** See `validate/code.test.ts`: simulates an acorn/acorn-walk skew. */
+  function withoutBase<T>(type: string, run: () => T): T {
+    const base = walk.base as unknown as Record<string, unknown>;
+    const saved = base[type];
+    expect(saved).toBeTypeOf('function');
+    delete base[type];
+    try {
+      return run();
+    } finally {
+      base[type] = saved;
+    }
+  }
+
+  it('reports a parse error rather than an under-counted capability set', () => {
+    const source = 'bim.viewer.colorize({});\ntry { bim.model.write(); } catch (e) {}';
+    // Unmodified, both calls are seen.
+    expect(inferCapabilities(source).capabilities.length).toBeGreaterThan(1);
+
+    const r = withoutBase('TryStatement', () => inferCapabilities(source));
+    expect(r.parseErrors.some((e) => /cannot traverse/.test(e.message))).toBe(true);
+    expect(r.parseErrors.some((e) => /TryStatement/.test(e.message))).toBe(true);
+    // Fail closed: the floor it did see is discarded, not published.
+    expect(r.capabilities).toEqual([]);
+    expect(r.observations).toEqual([]);
   });
 });

--- a/packages/extensions/src/inference/capability.ts
+++ b/packages/extensions/src/inference/capability.ts
@@ -94,7 +94,7 @@ export function inferCapabilities(source: string): InferenceResult {
   }
 
   const observations: InferenceObservation[] = [];
-  const { depthExceeded } = walkBounded(ast, (node, type) => {
+  const { depthExceeded, unwalkableTypes } = walkBounded(ast, (node, type) => {
     if (type !== 'MemberExpression') return;
     const chain = readMemberChain(node);
     if (!chain || chain[0] !== 'bim') return;
@@ -127,6 +127,19 @@ export function inferCapabilities(source: string): InferenceResult {
   if (depthExceeded) {
     parseErrors.push({
       message: `source is nested more than ${MAX_AST_DEPTH} AST levels deep; capabilities could not be inferred`,
+      line: 0,
+      column: 0,
+    });
+    return { capabilities: [], observations: [], parseErrors };
+  }
+
+  // A subtree the walker could not descend hides `bim.*` calls just as
+  // effectively as the depth bound does, so it goes down the same
+  // channel and the inferred set is discarded rather than published as
+  // if it were complete.
+  if (unwalkableTypes.length > 0) {
+    parseErrors.push({
+      message: `source contains AST node types the walker cannot traverse (${unwalkableTypes.join(', ')}); capabilities could not be inferred`,
       line: 0,
       column: 0,
     });

--- a/packages/extensions/src/validate/code.test.ts
+++ b/packages/extensions/src/validate/code.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, expect, it } from 'vitest';
+import * as walk from 'acorn-walk';
 import { validateCode, type CodeValidationResult } from './code.js';
 
 describe('validateCode — clean sources pass', () => {
@@ -180,5 +181,52 @@ describe('validateCode — deeply nested sources are bounded, not fatal', () => 
     const deep = recurse(2000);
     expect(deep.ok).toBe(shallow.ok);
     expect(deep.errors.map((e) => e.message)).toEqual(shallow.errors.map((e) => e.message));
+  });
+});
+
+describe('validateCode — a subtree the walker cannot descend', () => {
+  /**
+   * acorn and acorn-walk version independently, and every new syntax
+   * (class static blocks, import attributes, `await using`) reaches
+   * the parser before the walker. Rather than wait for an upgrade to
+   * produce that skew, remove one `base` entry for the duration of the
+   * call: a node type acorn still emits becomes one the walker has no
+   * way to descend.
+   */
+  function withoutBase<T>(type: string, run: () => T): T {
+    const base = walk.base as unknown as Record<string, unknown>;
+    const saved = base[type];
+    expect(saved).toBeTypeOf('function');
+    delete base[type];
+    try {
+      return run();
+    } finally {
+      base[type] = saved;
+    }
+  }
+
+  it('refuses the source instead of passing it as clean', () => {
+    // `eval(...)` is banned and sits inside the subtree the walker
+    // cannot enter. A scan that never looked must not report "clean".
+    const r = withoutBase('TryStatement', () =>
+      validateCode('try { eval("payload"); } catch (e) {}'),
+    );
+    expect(r.ok).toBe(false);
+    expect(r.errors.some((e) => /cannot traverse/.test(e.message))).toBe(true);
+    expect(r.errors.some((e) => /TryStatement/.test(e.message))).toBe(true);
+  });
+
+  it('names the failure even when nothing banned is visible', () => {
+    // The subtler half: no banned construct anywhere, so the only
+    // signal that the scan was incomplete is the walker's own report.
+    const r = withoutBase('TryStatement', () => validateCode('try { const x = 1; } catch (e) {}'));
+    expect(r.ok).toBe(false);
+    expect(r.errors.map((e) => e.code)).toEqual(['invalid_value']);
+  });
+
+  it('still passes the same source once the walker can descend it', () => {
+    // Pins that the rejection comes from the missing base, not from
+    // the source: unmodified, this is a clean script.
+    expect(validateCode('try { const x = 1; } catch (e) {}').ok).toBe(true);
   });
 });

--- a/packages/extensions/src/validate/code.ts
+++ b/packages/extensions/src/validate/code.ts
@@ -72,7 +72,7 @@ export function validateCode(source: string, opts: CodeValidationOptions = {}): 
     return { ok: false, errors };
   }
 
-  const { depthExceeded } = walkBounded(ast, (node, type) => {
+  const { depthExceeded, unwalkableTypes } = walkBounded(ast, (node, type) => {
     switch (type) {
       case 'Identifier': {
         const n = node as unknown as acorn.Identifier;
@@ -147,6 +147,18 @@ export function validateCode(source: string, opts: CodeValidationOptions = {}): 
       code: 'invalid_value',
       message: `Source is nested more than ${MAX_AST_DEPTH} AST levels deep; it was not fully validated.`,
       hint: 'Flatten the source — extract deeply nested blocks into separate helper functions.',
+    });
+  }
+
+  // Same rule, different cause: a subtree the walker could not descend
+  // is unexamined source. A banned global or an `eval` under it would
+  // have gone unseen, so this cannot come back `ok`.
+  if (unwalkableTypes.length > 0) {
+    errors.push({
+      path: prefix,
+      code: 'invalid_value',
+      message: `Source contains AST node types this validator cannot traverse (${unwalkableTypes.join(', ')}); it was not fully validated.`,
+      hint: 'This usually means the parser is newer than the walker it is paired with — report it rather than working around it.',
     });
   }
 


### PR DESCRIPTION
Three findings in already-merged code from #3025/#3027, found by an adversarial pass over our own PRs.

## 1. "The single traversal" was not single

`bounded-walk.ts:16-19` claimed *"This module is the single traversal used by every AST consumer here… Callers vary the visitor; they do not re-implement the traversal."*

`source-wrap.ts:179` re-implemented it, with its own private `MAX_AST_DEPTH = 1000` and its own generic `childNodes` enumeration instead of `acorn-walk`'s `base`. #3025 landed the private copy; #3027 landed the "single traversal" module one commit later and did not migrate it. Two constants, two walkers, and a comment telling the next reader the second does not exist.

**Migrated rather than documented.** `checkBannedConstructs` now calls `walkBounded`; the private constant, the local `AstNode`/`isAstNode` and the generic `childNodes` are deleted. `grep -rn MAX_AST_DEPTH` over `packages` + `apps` now shows exactly one definition.

**What the two enumerations differ on**, established by a differential over 59 sources placing each banned construct in an exotic position (acorn 8.18.0 / acorn-walk 8.3.5): `base` omits `Identifier` (non-computed member properties, plain object keys, labels, import/export local bindings), `PrivateIdentifier`, `ExportSpecifier`, and the `Property` wrapper inside object *patterns*.

That last looked like a real loss — `const { a = import("m") } = o` reports a missed `Property` whose subtree holds an `ImportExpression`. Tracing the visit showed `base.ObjectPattern` descends `prop.value` directly, so the `ImportExpression` is still reached. **Refined to "is any banned node itself missed", the answer across the corpus is no**: none of the omitted types can be a banned node, and none is the sole path to one.

Behaviour unchanged where it matters, measured before and after: `wrapEntrySource` and `validateCode` both accept if-nesting at 499 and reject at 500, and both reject arrow chains at 480 while accepting 400 — identical either side of the migration.

One hazard handled: `walkBounded` reports skip-through nodes twice (once under acorn-walk's synthetic key, once under the real type), so the visitor switches on the supplied `type` key rather than `node.type`. A test pins "reports each banned construct exactly once".

## 2. A fail-open branch in a security validator

`bounded-walk.ts:126-131` reported an unknown node type and **silently skipped its entire subtree**, without setting `depthExceeded`. `acorn-walk` throws on a missing base precisely so this cannot pass unnoticed. `validateCode` is a banned-construct scanner, so a skipped subtree is a scan that fails open and a caller that sees a clean pass.

**RED, constructed by injecting the skew rather than waiting for it:** a helper deletes one `acorn-walk` `base` entry (`TryStatement`) for the duration of the call and restores it in `finally`. With the fix disabled, **7 tests fail** — including

```js
validateCode('try { eval("payload"); } catch (e) {}')  // -> ok: true
```

a banned `eval` passing a security scan clean.

`BoundedWalkResult` now carries `unwalkableTypes` (deduped; the walk continues through siblings so the rest of the tree is still scanned). **All three callers surface it**, each mirroring its existing `depthExceeded` handling: `validateCode` pushes an `invalid_value` error naming the types → `ok: false`; `inferCapabilities` pushes a `parseErrors` entry and returns an **empty** capability set, the channel `migrateSavedScripts` and the promote dialog already use to refuse; `wrapEntrySource` returns errors instead of a wrap. Each has its own test, so no flag goes unread.

Not reachable against acorn 8.18 / acorn-walk 8.3.5 today — it becomes live the first time acorn is upgraded ahead of acorn-walk.

## 3. Two numbers that would have justified raising the bound

Both were framed as properties of acorn. Measured on Node 22.13.1, one process per data point:

- **1100 source levels parse; 1200 aborts the process fatally** — `FATAL ERROR: RegExpCompiler Allocation failed`, exit 134, **not catchable**.
- Under this repo's vitest workers, **1200 already throws** "Not enough stack space to parse input".
- Under `node --stack-size=4000`, **4000 parses fine**.

So the docstring no longer quotes a floor. It says the give-up point is the host's remaining stack, and notes that one of the three failure modes is an uncatchable abort — which strengthens the case for the fixed heap bound rather than weakening it. The same claim is corrected in the still-pending changeset `bounded-ast-walk-for-author-source.md`, which would otherwise ship into the changelog.

**`MAX_AST_DEPTH` is unchanged.** A prior pass established it fires at 500 source levels while acorn parses far deeper in-process, so the limit sits below the ceiling it protects. The earlier non-monotonic evidence — "400 ok, 600 threw, 700 ok, 800 threw" — was a stack-budget boundary, not a property of the input.

## Adversarial checks

**Passes with the change reverted?** No — 7 tests go red. The parity test is the one exception and it is labelled as such: it is a **drift guard**, not a RED, because the two paths already agreed. To show it is not vacuous, a simulated divergence (making `validateCode` reject at a different threshold) fails it, and it asserts its depth range straddles the boundary in both directions.

**Does it now reject valid source?** No. A realistic 30-line extension entry — class with a private field, `static {}` block, getter, labelled loop with `continue label`, optional chaining, template literal, destructuring default, computed key, try/catch — wraps clean and validates clean, asserted in two tests.

**Per-banned-construct verification, 16 cases:** `ImportDeclaration`, `ExportNamedDeclaration`, `ExportDefaultDeclaration`, `ExportAllDeclaration` and `ImportExpression`, each in a class static block, computed key, object value, default parameter, destructuring default, template literal, behind optional chaining, class field initialiser, getter body, under a label, in a catch clause, and with import attributes. A silent coverage loss in a security scanner is the worst outcome here, so it is enumerated rather than assumed.

`packages/extensions` **810 → 841 tests**, 60 files, all passing. `tsc --noEmit` clean, `typecheck-tests` OK, oxlint clean, `check-changesets` clean.

The changeset states these are **latent, not live**, names the exact acorn/acorn-walk versions the "not reachable today" claim rests on, and says the differential was run rather than reasoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source validation to reject scripts that cannot be fully inspected.
  * Prevented incomplete capability detection from reporting partial results.
  * Added consistent handling for deeply nested or unsupported syntax.
  * Ensured sibling code remains checked when unsupported syntax is encountered.
* **Tests**
  * Added coverage for depth limits, unsupported syntax, validation, source wrapping, and capability inference.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->