### PR TITLE
fix(viewer): open a collapsed group when its row survives the IDS report search

### DIFF
--- a/apps/viewer/src/hooks/ids/idsExportService.test.ts
+++ b/apps/viewer/src/hooks/ids/idsExportService.test.ts
@@ -555,3 +555,92 @@ describe('buildReportHTML — search matches content, not chrome', () => {
     }
   });
 });
+
+describe('buildReportHTML — a search hit inside the collapsed per-entity table is actually shown', () => {
+  // Grouping by requirement demoted the per-entity table into a
+  // `<details class="entity-table-details">` that ships CLOSED. `filterAll`
+  // only ever toggled a `hidden` class on rows, so a term that exists only in
+  // that table produced "1 of 3 rows shown" over a page showing nothing, with
+  // no cue that the match was behind a disclosure.
+  //
+  // The fixture name below appears ONLY on a PASSING entity, which is
+  // deliberate: a failing entity is rendered twice (once in the requirement
+  // group, which is not inside any `<details>`, and once in the per-entity
+  // table), so a failing-entity fixture would have a visible match either way
+  // and could not tell the two behaviours apart.
+  const PASS_ONLY = 'UNIQUEPASSNAME';
+
+  function buildReport(): string {
+    const req = makeRequirement('req-details');
+    const failing = makeEntity(1, [makeReqResult(req, 'fail', { failureReason: 'bad wall' })], {
+      entityName: 'Failing Wall',
+      globalId: 'GID-FAIL',
+    });
+    const passing = makeEntity(2, [makeReqResult(req, 'pass')], {
+      entityName: PASS_ONLY,
+      globalId: 'GID-PASS',
+    });
+    return buildReportHTML(
+      makeReport([makeSpecResult(makeSpecification('spec-d', 'Spec D', [req]), [failing, passing])]),
+      'en',
+    );
+  }
+
+  function groups(page: ReportPage): HTMLDetailsElement[] {
+    return Array.from(
+      page.document.querySelectorAll('details.entity-table-details'),
+    ) as HTMLDetailsElement[];
+  }
+
+  it('opens the group holding the only surviving row', () => {
+    const page = renderReport(buildReport());
+    try {
+      assert.deepEqual(
+        groups(page).map(d => d.open),
+        [false],
+        'fixture check: the per-entity table must ship collapsed, or this proves nothing',
+      );
+
+      const hit = searchRows(page, PASS_ONLY.toLowerCase());
+      assert.ok(hit.visible.length > 0, 'the search must match the passing entity');
+      assert.deepEqual(
+        groups(page).map(d => d.open),
+        [true],
+        'a counted match the reader cannot see is not a match',
+      );
+    } finally {
+      page.close();
+    }
+  });
+
+  it('leaves a group with no surviving row closed', () => {
+    const page = renderReport(buildReport());
+    try {
+      searchRows(page, 'nothingmatchesthis');
+      assert.deepEqual(
+        groups(page).map(d => d.open),
+        [false],
+        'an empty group must not be forced open — that would be noise, not a result',
+      );
+    } finally {
+      page.close();
+    }
+  });
+
+  it('restores the reader\'s own open/closed state when the search is cleared', () => {
+    const page = renderReport(buildReport());
+    try {
+      searchRows(page, PASS_ONLY.toLowerCase());
+      assert.deepEqual(groups(page).map(d => d.open), [true]);
+
+      searchRows(page, '');
+      assert.deepEqual(
+        groups(page).map(d => d.open),
+        [false],
+        'clearing the search must hand the disclosure back, not leave every group forced open',
+      );
+    } finally {
+      page.close();
+    }
+  });
+});

--- a/apps/viewer/src/hooks/ids/idsExportService.test.ts
+++ b/apps/viewer/src/hooks/ids/idsExportService.test.ts
@@ -644,3 +644,94 @@ describe('buildReportHTML — a search hit inside the collapsed per-entity table
     }
   });
 });
+
+describe('buildReportHTML — the search also opens the collapsed specification around the hit', () => {
+  // The per-entity <details> is nested inside a `.spec` accordion, and
+  // `.spec-body { display: none }` until that accordion carries the "open"
+  // class — which only a FAILING specification ships with. The suite above
+  // cannot see this: its fixture has a failing entity, so its spec is open
+  // from the start and opening the <details> is enough there.
+  //
+  // The asymmetric case is a spec where EVERY entity passes. Then the spec
+  // ships collapsed, and un-hiding a row plus opening its <details> still
+  // leaves the reader looking at nothing while the counter claims a match.
+  const HIT = 'AAAUNIQUEPASSSPEC';
+
+  function buildAllPassingSpecReport(): string {
+    const req = makeRequirement('req-pass-spec');
+    const hit = makeEntity(1, [makeReqResult(req, 'pass')], { entityName: HIT, globalId: 'GID-1' });
+    const other = makeEntity(2, [makeReqResult(req, 'pass')], { entityName: 'Other Wall', globalId: 'GID-2' });
+    const specResult = makeSpecResult(makeSpecification('spec-p', 'All Passing Spec', [req]), [hit, other]);
+    assert.equal(specResult.status, 'pass', 'fixture check: the spec must PASS, or it ships open and proves nothing');
+    return buildReportHTML(makeReport([specResult]), 'en');
+  }
+
+  function specOpen(page: ReportPage): boolean[] {
+    return Array.from(page.document.querySelectorAll('.spec')).map(s => s.classList.contains('open'));
+  }
+
+  function detailsOpen(page: ReportPage): boolean[] {
+    return Array.from(
+      page.document.querySelectorAll('details.entity-table-details'),
+    ).map(d => (d as HTMLDetailsElement).open);
+  }
+
+  it('opens the passing specification holding the surviving row, and restores it on clear', () => {
+    const page = renderReport(buildAllPassingSpecReport());
+    try {
+      assert.deepEqual(specOpen(page), [false], 'fixture check: a passing spec must ship collapsed');
+
+      const hit = searchRows(page, HIT.toLowerCase());
+      assert.equal(hit.visible.length, 1, 'the search must match exactly the one entity');
+      assert.deepEqual(
+        specOpen(page),
+        [true],
+        'a match inside a collapsed specification is counted but not shown — opening only the <details> is not enough',
+      );
+
+      searchRows(page, '');
+      assert.deepEqual(
+        specOpen(page),
+        [false],
+        'clearing the search must hand the specification accordion back too',
+      );
+    } finally {
+      page.close();
+    }
+  });
+
+  it('leaves a specification with no surviving row collapsed', () => {
+    const page = renderReport(buildAllPassingSpecReport());
+    try {
+      searchRows(page, 'nothingmatchesthis');
+      assert.deepEqual(specOpen(page), [false], 'an empty specification must not be forced open');
+    } finally {
+      page.close();
+    }
+  });
+
+  it('a second search before the first is cleared must not snapshot what the first one forced open', () => {
+    // The restore snapshot is taken once, on the transition into the filtered
+    // state. Re-taking it on every keystroke would record what the PREVIOUS
+    // keystroke forced open, and clearing would then leave the page
+    // reorganised — the exact side effect the restore exists to prevent.
+    const page = renderReport(buildAllPassingSpecReport());
+    try {
+      searchRows(page, HIT.toLowerCase());
+      assert.deepEqual(specOpen(page), [true]);
+      assert.deepEqual(detailsOpen(page), [true]);
+
+      searchRows(page, 'wall'); // second search, first never cleared
+      searchRows(page, '');
+
+      assert.deepEqual(
+        specOpen(page),
+        [false],
+        'refining a search must not bake the forced-open state into what gets restored',
+      );
+      assert.deepEqual(detailsOpen(page), [false]);
+    } finally {
+      page.close();
+    }
+  });
+});

--- a/apps/viewer/src/hooks/ids/idsExportService.ts
+++ b/apps/viewer/src/hooks/ids/idsExportService.ts
@@ -727,6 +727,10 @@ export function buildReportHTML(report: IDSValidationReport, locale: SupportedLo
 
   <script>
     let currentFilter = 'all';
+    // Snapshot of the per-entity <details> open/closed state taken the moment
+    // a search/filter starts, so clearing it restores what the reader had
+    // rather than leaving every group forced open. Null while unfiltered.
+    let detailsRestore = null;
 
     function toggleSpec(i) {
       document.getElementById('spec-' + i).classList.toggle('open');
@@ -763,6 +767,25 @@ export function buildReportHTML(report: IDSValidationReport, locale: SupportedLo
         row.classList.toggle('hidden', !show);
         if (show) visible++;
       });
+
+      // The per-entity table lives inside a collapsed <details>, so un-hiding
+      // a row there is not enough to SHOW it: the counter would read
+      // "1 of 3 rows shown" while the reader sees an empty page and no cue
+      // that the match is behind a disclosure. Open any group that holds a
+      // surviving row while a search/filter is active, and put the reader's
+      // own open/closed state back when the search is cleared.
+      const groups = document.querySelectorAll('details.entity-table-details');
+      if (search || currentFilter !== 'all') {
+        if (detailsRestore === null) {
+          detailsRestore = Array.prototype.map.call(groups, function (d) { return d.open; });
+        }
+        groups.forEach(d => {
+          if (d.querySelector('.entity-row:not(.hidden)')) d.open = true;
+        });
+      } else if (detailsRestore !== null) {
+        groups.forEach((d, i) => { d.open = detailsRestore[i]; });
+        detailsRestore = null;
+      }
 
       document.getElementById('result-count').textContent =
         search || currentFilter !== 'all'

--- a/apps/viewer/src/hooks/ids/idsExportService.ts
+++ b/apps/viewer/src/hooks/ids/idsExportService.ts
@@ -731,6 +731,11 @@ export function buildReportHTML(report: IDSValidationReport, locale: SupportedLo
     // a search/filter starts, so clearing it restores what the reader had
     // rather than leaving every group forced open. Null while unfiltered.
     let detailsRestore = null;
+    // Same snapshot for the outer .spec accordions, which ship collapsed
+    // unless the specification failed. Taken and released together with
+    // detailsRestore, so the two can never disagree about what "unfiltered"
+    // looked like.
+    let specRestore = null;
 
     function toggleSpec(i) {
       document.getElementById('spec-' + i).classList.toggle('open');
@@ -774,17 +779,30 @@ export function buildReportHTML(report: IDSValidationReport, locale: SupportedLo
       // that the match is behind a disclosure. Open any group that holds a
       // surviving row while a search/filter is active, and put the reader's
       // own open/closed state back when the search is cleared.
+      //
+      // The <details> is itself inside a .spec accordion whose .spec-body is
+      // display:none unless the spec carries the "open" class — and only a
+      // FAILING spec ships with it. So for an all-passing specification,
+      // opening the disclosure alone still leaves the match invisible; the
+      // spec has to be opened too, on the same rule and with the same restore.
       const groups = document.querySelectorAll('details.entity-table-details');
+      const specs = document.querySelectorAll('.spec');
       if (search || currentFilter !== 'all') {
         if (detailsRestore === null) {
           detailsRestore = Array.prototype.map.call(groups, function (d) { return d.open; });
+          specRestore = Array.prototype.map.call(specs, function (s) { return s.classList.contains('open'); });
         }
         groups.forEach(d => {
           if (d.querySelector('.entity-row:not(.hidden)')) d.open = true;
         });
+        specs.forEach(s => {
+          if (s.querySelector('.entity-row:not(.hidden)')) s.classList.add('open');
+        });
       } else if (detailsRestore !== null) {
         groups.forEach((d, i) => { d.open = detailsRestore[i]; });
+        specs.forEach((s, i) => { s.classList.toggle('open', specRestore[i]); });
         detailsRestore = null;
+        specRestore = null;
       }
 
       document.getElementById('result-count').textContent =


### PR DESCRIPTION
The IDS report's search counts matches the reader cannot see.

Found reviewing #2979 after it merged. Its two changes do not compose: grouping demoted the per-entity table into a `<details class="entity-table-details">` that ships **closed**, while `filterAll` only toggles a `hidden` class on rows.

**VERIFIED BY RUNNING the shipped script**, searching a name carried only by a *passing* entity:

```
result-count text:                        1 of 3 rows shown
rows un-hidden:                           1
each un-hidden row inside a CLOSED <details>?   [ 'CLOSED' ]
```

The counter reports a match over a page showing nothing, with no cue that the match is behind a collapsed disclosure. A user searching for an element they know is in the model sees "1 of 3 rows shown" above an apparently empty table.

## The fix

`filterAll` opens any group holding a surviving row while filtering, and **restores the reader's own disclosure state on clear** — so it does not quietly reorganise the page as a side effect of typing and deleting a query.

Three tests through the report's existing harness, RED-verified: 2 fail of 14 before, **16/16** after. `tsc --noEmit` clean.

## The fixture is a passing-only entity, deliberately

A **failing** entity renders twice — once inside the per-entity `<details>`, once in the per-requirement failing-elements table, which is not inside any disclosure. So a failing fixture would find the second copy un-hidden and visible, and pass with the defect present.

That is the fixture-symmetry trap: the fixture must be a name carried only by a passing entity, which appears exactly once and only inside the closed group.

## Verified still live on `main`

Checked against `c02b58510` by reading main's blob rather than trusting the branch: `grep` for `detailsRestore` / `d.open` in `idsExportService.ts` returns only the four CSS selector lines and the `<details class="entity-table-details">` markup. No open-on-match logic exists.

## A related defect handed back rather than fixed

`idsExportService.ts`'s print CSS contains `details { open; }`. **`open` is an HTML attribute, not a CSS declaration**, so the rule is malformed and dropped — meaning a *printed* report has every disclosure collapsed.

Pre-existing (`git log -S` traces it to `5db4010a7`, #193), but #2979 widened its blast radius from the per-requirement detail cells to the whole per-entity table. The cross-browser-correct replacement needs a real browser to verify, which is exactly why #2979's own "no browser was available" caveat was the right call to state — this is the class of thing it could not catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
