### PR TITLE
test(viewer): pin environmentSlice's clamps and preset re-seed, which nothing caught

### DIFF
--- a/apps/viewer/src/store/slices/environmentSlice.test.ts
+++ b/apps/viewer/src/store/slices/environmentSlice.test.ts
@@ -180,6 +180,40 @@ describe('environmentSlice', () => {
     assert.strictEqual(s.getState().envSunAngle, 1.7);
   });
 
+  // The three tests above pin the SETTER direction of each clamp. The slice
+  // clamps in two places, though: every setter, and once at construction over
+  // whatever `loadPersisted()` returns. localStorage is not a trusted input —
+  // it survives downgrades, is hand-editable, and is shared across tabs — so
+  // the constructor direction is the one that actually faces a hostile value.
+  //
+  // Verified by mutation: dropping `clampShadowResolution`, `clampSunTime` or
+  // `clampSunAngle` from the `initial` object and passing the stored value
+  // straight through left the suite 15/15 green before these were added.
+  it('clamps a stored shadowResolution that is not a supported size', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ shadowResolution: 8192 }));
+    // 8192 reaches the renderer as a shadow-map texture side; only the
+    // allow-list stands between a corrupt entry and an allocation failure.
+    assert.strictEqual(makeStore().getState().envShadowResolution, 0);
+  });
+
+  it('clamps a stored sunTime outside the sun-arc day window', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ sunTime: 23 }));
+    assert.strictEqual(makeStore().getState().envSunTime, 18);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ sunTime: Number.NaN }));
+    // JSON.stringify turns NaN into null, which is exactly the shape a
+    // corrupt entry takes on disk — and `null ?? 13` keeps the default.
+    assert.strictEqual(makeStore().getState().envSunTime, 13);
+  });
+
+  it('clamps a stored sunAngle outside [0.1, 5]', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ preset: 'overcast', sunAngle: 50 }));
+    const angle = makeStore().getState().envSunAngle;
+    assert.strictEqual(angle, 5);
+    // Not the preset's own angle either: the stored override is clamped, not
+    // discarded, so this cannot pass by falling back to the preset seed.
+    assert.notStrictEqual(angle, LIGHTING_PRESETS.overcast.shadowSunAngleDeg);
+  });
+
   it('envPanelOpen is session-only: toggling it does not touch persisted storage', () => {
     const s = makeStore();
     s.getState().toggleEnvPanel();

--- a/apps/viewer/src/store/slices/environmentSlice.test.ts
+++ b/apps/viewer/src/store/slices/environmentSlice.test.ts
@@ -7,6 +7,7 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { createStore } from 'zustand/vanilla';
 import { createEnvironmentSlice, type EnvironmentSlice } from './environmentSlice.js';
+import { LIGHTING_PRESETS } from '@/lib/lighting-presets';
 
 const STORAGE_KEY = 'ifc-lite:environment';
 
@@ -94,6 +95,89 @@ describe('environmentSlice', () => {
     assert.doesNotThrow(() => makeStore());
     const s = makeStore();
     assert.strictEqual(s.getState().envExposure, 1);
+  });
+
+  // The three dials below were the ones this file did NOT reach. Verified by
+  // mutation: deleting `clampSunAngle`'s range clamp, `clampSunTime`'s range
+  // clamp or `clampShadowResolution`'s allow-list snap outright — and each of
+  // their `Number.isFinite` fallbacks — left the suite fully green, while the
+  // same treatment of `clampExposure`/`clampHardness`/`clampSoftness` turned
+  // it red. Exposure was pinned; the rest were not.
+  it('setEnvSunAngle clamps to [0.1, 5] and rejects NaN', () => {
+    const s = makeStore();
+    s.getState().setEnvSunAngle(50);
+    assert.strictEqual(s.getState().envSunAngle, 5);
+    s.getState().setEnvSunAngle(-1);
+    assert.strictEqual(s.getState().envSunAngle, 0.1);
+    s.getState().setEnvSunAngle(2.5);
+    assert.strictEqual(s.getState().envSunAngle, 2.5);
+    s.getState().setEnvSunAngle(Number.NaN);
+    // The renderer divides by / compares against this angle when sizing the
+    // penumbra; NaN here poisons the shadow term rather than widening it.
+    assert.strictEqual(s.getState().envSunAngle, 0.53);
+  });
+
+  it('setEnvSunTime clamps to the 6..18 sun-arc day window and rejects NaN', () => {
+    const s = makeStore();
+    s.getState().setEnvSunTime(23);
+    assert.strictEqual(s.getState().envSunTime, 18);
+    s.getState().setEnvSunTime(0);
+    assert.strictEqual(s.getState().envSunTime, 6);
+    s.getState().setEnvSunTime(9.5);
+    assert.strictEqual(s.getState().envSunTime, 9.5);
+    s.getState().setEnvSunTime(Number.NaN);
+    assert.strictEqual(s.getState().envSunTime, 13);
+  });
+
+  it('setEnvShadowResolution snaps to a supported size, falling back to 0 (Auto)', () => {
+    const s = makeStore();
+    s.getState().setEnvShadowResolution(2048);
+    assert.strictEqual(s.getState().envShadowResolution, 2048);
+    // 8192 is a plausible-looking value that is NOT on the allow-list; it must
+    // become Auto rather than be handed to the renderer as a texture size.
+    s.getState().setEnvShadowResolution(8192);
+    assert.strictEqual(s.getState().envShadowResolution, 0);
+    // NaN lands on Auto too — though note that `clampShadowResolution`'s own
+    // `Number.isFinite` early return is redundant for this input: `includes`
+    // uses SameValueZero, so `[0, 1024, 2048, 4096].includes(NaN)` is already
+    // false and the allow-list branch returns 0 by itself. Deleting that early
+    // return leaves this assertion green.
+    s.getState().setEnvShadowResolution(Number.NaN);
+    assert.strictEqual(s.getState().envShadowResolution, 0);
+  });
+
+  it('setEnvPreset re-seeds envSunAngle from the preset, overriding a manual angle', () => {
+    // louistrue's #2670 review: cast-shadow softness is a property of the sky,
+    // so switching preset must move the angle with it. Nothing pinned this.
+    const s = makeStore();
+    s.getState().setEnvSunAngle(2.5);
+    s.getState().setEnvPreset('overcast');
+    assert.strictEqual(
+      s.getState().envSunAngle,
+      LIGHTING_PRESETS.overcast.shadowSunAngleDeg,
+      'a preset switch must carry its own sun angle, not keep the manual override',
+    );
+    // And a preset with a *different* angle, so the assertion cannot pass on a
+    // shared default: overcast is 4.0, golden is 0.8.
+    s.getState().setEnvPreset('golden');
+    assert.strictEqual(s.getState().envSunAngle, LIGHTING_PRESETS.golden.shadowSunAngleDeg);
+  });
+
+  it('with no stored angle, seeds envSunAngle from the RESTORED preset, not a fixed 0.53', () => {
+    // CodeRabbit #3053: a persisted Overcast used to reopen crisp (0.53) until
+    // the first preset switch. `sunAngle` is deliberately absent here.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ preset: 'overcast' }));
+    const s = makeStore();
+    assert.strictEqual(s.getState().envSunAngle, LIGHTING_PRESETS.overcast.shadowSunAngleDeg);
+    assert.notStrictEqual(s.getState().envSunAngle, LIGHTING_PRESETS.default.shadowSunAngleDeg);
+  });
+
+  it('a stored sunAngle override survives rehydration and is not overwritten by the preset', () => {
+    // The other direction of the same rule — the #3053 fix must not turn into
+    // "the preset always wins".
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ preset: 'overcast', sunAngle: 1.7 }));
+    const s = makeStore();
+    assert.strictEqual(s.getState().envSunAngle, 1.7);
   });
 
   it('envPanelOpen is session-only: toggling it does not touch persisted storage', () => {


### PR DESCRIPTION
`environmentSlice`'s tests pin one half of their own subject.

Found reviewing #3024 after it merged. That PR covered six slices; I mutated all six plus `persistence.ts`. **Five are genuinely load-bearing** — 15 mutations across `playbackSlice`, `listSlice`, `spaceMouseSlice`, `solarSlice`, `geometryLoadSettings` and the `Array.isArray` guard, every one caught.

`environmentSlice` is the exception. **Seven mutations left the existing 9-test suite fully green**, re-verified against current `main` at `c02b58510`:

```
# tests 9 # pass 9 # fail 0   clampSunAngle range clamp → return value
# tests 9 # pass 9 # fail 0   clampSunTime range clamp → return value
# tests 9 # pass 9 # fail 0   shadow-resolution allow-list → return value
# tests 9 # pass 9 # fail 0   sun-angle Number.isFinite fallback deleted
# tests 9 # pass 9 # fail 0   sun-time Number.isFinite fallback deleted
# tests 9 # pass 9 # fail 0   setEnvPreset no longer re-seeds envSunAngle
# tests 9 # pass 9 # fail 0   stored-preset seed replaced by a fixed 0.53
```

**Two of those are findings the maintainer and CodeRabbit already raised** — `setEnvPreset` re-seeding the sun angle is @louistrue's own #2670 review finding, and the stored-preset seed is CodeRabbit's on #3053. Both were fixed, and nothing pins either, so both could silently regress.

Exposure, hardness and softness *are* pinned, which is what makes this the one-direction-of-a-two-way-rule shape rather than an untested slice: the file looks covered, and is, for half its surface.

## Six replacement tests

Each RED-verified against its own mutation, with **both directions of the #3053 rule** pinned — the restored preset seeds the angle, and a fixed value does not. 9 → **15/15**.

## One thing recorded rather than fixed

`clampShadowResolution`'s `Number.isFinite` early return is dead for `NaN`: `[0,1024,2048,4096].includes(NaN)` is already `false`, so the allow-list snap handles it before the guard can. Harmless, and removing it would be a behaviour-neutral tidy rather than a fix, so it is noted in the test file rather than changed.

## Verified still live on `main`

`environmentSlice.test.ts` on `c02b58510` is still 9 tests, and `grep` for `SunTime|SunAngle|ShadowResolution` matches nothing. The single `setEnvPreset` hit is inside the persistence test, which asserts the persisted preset id — not the sun angle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
