### PR TITLE
fix(viewer): make an unreprojected measurement kind a compile error, not a review catch

### DIFF
--- a/apps/viewer/src/store/measurementReprojectionFields.ts
+++ b/apps/viewer/src/store/measurementReprojectionFields.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The single registry of measurement-slice fields that carry SCREEN
+ * coordinates, and therefore go stale the moment the camera moves.
+ *
+ * Two pieces of code have to agree about this set, and three times they did
+ * not — #2641 (polyline) and #2735 (angle) are both in this repo's history,
+ * and the next kind added repeated it:
+ *
+ *  - `updateMeasurementScreenCoords` (store/slices/measurementSlice.ts)
+ *    reprojects each of these fields once per frame.
+ *  - `hasPendingMeasurementState` (utils/viewportUtils.ts) decides whether
+ *    that pass runs AT ALL — Viewport.tsx consults it first.
+ *
+ * A field reprojected but not gated is dead code: with only that kind of
+ * measurement on screen the gate says "nothing pending", the pass never
+ * runs, and the symptom is identical to having written no reprojection at
+ * all. A comment saying "these two are a pair" was tried, and did not hold.
+ *
+ * So neither side keeps its own list any more. The gate is DERIVED from this
+ * registry (it iterates the keys), and the reprojection pass's `set()`
+ * payload is typed as an exhaustive map over
+ * {@link ReprojectedMeasurementField} — so a field added here without a
+ * reprojection arm, or an arm added there without an entry here, is a
+ * compile error rather than a runtime nothing.
+ *
+ * Keep this module dependency-free: `viewportUtils.ts` imports it and must
+ * stay a pure, store-free unit.
+ *
+ * NOT every field holding a `MeasurePoint` belongs here. `pendingMeasurePoint`
+ * (the legacy click-click flow's first point) and `snapTarget` also carry
+ * screen coordinates and are deliberately absent from BOTH sides; adding one
+ * here without an arm in the reprojection pass would not compile, which is
+ * the intended way to have that conversation.
+ */
+
+/**
+ * How a registered field reports "there is something here":
+ *  - `list`     — an array of finished measurements; pending when non-empty.
+ *  - `nullable` — a single in-progress gesture; pending when not null.
+ */
+export type ReprojectedFieldKind = 'list' | 'nullable';
+
+export const REPROJECTED_MEASUREMENT_FIELDS = {
+  /** Finished drag/click distance measurements. */
+  measurements: 'list',
+  /** The in-progress drag gesture. */
+  activeMeasurement: 'nullable',
+  /** In-progress multi-click polyline sequence (#2199 / #2641). */
+  activePolyline: 'nullable',
+  /** Finished multi-click polylines (#2641). */
+  polylineMeasurements: 'list',
+  /** In-progress angle sequence (#2735). */
+  activeAngle: 'nullable',
+  /** Finished angle measurements (#2735). */
+  angleMeasurements: 'list',
+} as const satisfies Record<string, ReprojectedFieldKind>;
+
+/** Field names of {@link REPROJECTED_MEASUREMENT_FIELDS}. */
+export type ReprojectedMeasurementField = keyof typeof REPROJECTED_MEASUREMENT_FIELDS;
+
+/**
+ * The registry's keys as an iterable. `Object.keys` widens to `string[]`, and
+ * a widened key would silently defeat the gate's exhaustiveness.
+ */
+export const REPROJECTED_MEASUREMENT_FIELD_NAMES = Object.keys(
+  REPROJECTED_MEASUREMENT_FIELDS,
+) as ReprojectedMeasurementField[];

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -26,7 +26,10 @@ import type {
   AnglePick,
 } from '../types.js';
 import { ANGLE_REQUIRED_PICKS } from '../types.js';
-import type { ReprojectedMeasurementField } from '../measurementReprojectionFields.js';
+import type {
+  REPROJECTED_MEASUREMENT_FIELDS,
+  ReprojectedMeasurementField,
+} from '../measurementReprojectionFields.js';
 import { EDGE_LOCK_DEFAULTS } from '../constants.js';
 import { polylineLength } from '@/components/viewer/tools/measure-modes/polyline.js';
 import { isDuplicateClickPoint } from '@/components/viewer/measureHandlers.js';
@@ -221,6 +224,38 @@ const getDefaultEdgeLockState = (): EdgeLockState => ({
   isCorner: false,
   cornerValence: 0,
 });
+
+/**
+ * The registered KIND of each reprojected field must match that field's real
+ * shape on the slice.
+ *
+ * The exhaustive `set()` payload below pins the field NAMES, and
+ * `PendingMeasurementState` turns a `nullable` field registered as `list`
+ * into a compile error (a `T | null` has no `length`). The opposite mistake
+ * is silent without this check: registering a LIST field as `nullable` maps
+ * it to `unknown`, which any array satisfies, so nothing fails to compile —
+ * and `hasPendingMeasurementState` then tests it with `!== null`, which an
+ * array never is. The gate would report "pending" forever and the
+ * per-frame reprojection pass would never stop running.
+ *
+ * VERIFIED BY RUNNING `tsc` before this was added: flipping
+ * `angleMeasurements` to `'nullable'` produced zero errors anywhere.
+ *
+ * Each entry resolves to `true` when the kind matches, and to a descriptive
+ * tuple when it does not — which fails the `Record<..., true>` constraint and
+ * names the offending field in the error.
+ */
+type RegisteredKindMatchesSliceShape = {
+  [K in ReprojectedMeasurementField]: (typeof REPROJECTED_MEASUREMENT_FIELDS)[K] extends 'list'
+    ? MeasurementSlice[K] extends readonly unknown[]
+      ? true
+      : ['registered as `list` but is not an array', K]
+    : null extends MeasurementSlice[K]
+      ? true
+      : ['registered as `nullable` but cannot be null', K];
+};
+type AssertAllTrue<T extends Record<ReprojectedMeasurementField, true>> = T;
+export type _ReprojectedKindsMatch = AssertAllTrue<RegisteredKindMatchesSliceShape>;
 
 export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], MeasurementSlice> = (set, get) => ({
   // Initial state

--- a/apps/viewer/src/store/slices/measurementSlice.ts
+++ b/apps/viewer/src/store/slices/measurementSlice.ts
@@ -26,6 +26,7 @@ import type {
   AnglePick,
 } from '../types.js';
 import { ANGLE_REQUIRED_PICKS } from '../types.js';
+import type { ReprojectedMeasurementField } from '../measurementReprojectionFields.js';
 import { EDGE_LOCK_DEFAULTS } from '../constants.js';
 import { polylineLength } from '@/components/viewer/tools/measure-modes/polyline.js';
 import { isDuplicateClickPoint } from '@/components/viewer/measureHandlers.js';
@@ -442,14 +443,21 @@ export const createMeasurementSlice: StateCreator<MeasurementSlice, [], [], Meas
       return;
     }
 
-    set({
+    // Typed as an EXHAUSTIVE map over the shared field registry, which is the
+    // same registry `hasPendingMeasurementState` (utils/viewportUtils.ts)
+    // derives the gate deciding whether this pass runs at all. A registered
+    // field with no arm above is a missing-property error here; an arm for a
+    // field nobody registered is an excess-property error. Either way the
+    // divergence #2641 and #2735 each shipped stops being expressible.
+    const reprojected: { [K in ReprojectedMeasurementField]: MeasurementSlice[K] } = {
       measurements: updatedMeasurements,
       activeMeasurement: updatedActiveMeasurement,
       activePolyline: updatedActivePolyline,
       polylineMeasurements: updatedPolylineMeasurements,
       activeAngle: updatedActiveAngle,
       angleMeasurements: updatedAngleMeasurements,
-    });
+    };
+    set(reprojected);
   },
 
   // Snap actions

--- a/apps/viewer/src/utils/viewportUtils.pendingMeasurements.test.ts
+++ b/apps/viewer/src/utils/viewportUtils.pendingMeasurements.test.ts
@@ -19,6 +19,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { hasPendingMeasurementState, type PendingMeasurementState } from './viewportUtils.js';
+import {
+  REPROJECTED_MEASUREMENT_FIELDS,
+  REPROJECTED_MEASUREMENT_FIELD_NAMES,
+} from '../store/measurementReprojectionFields.js';
 
 function base(): PendingMeasurementState {
   return {
@@ -72,4 +76,39 @@ describe('hasPendingMeasurementState - angle state (#2735)', () => {
       true,
     );
   });
+});
+
+/**
+ * The cases above name their fields by hand, so they can only ever cover the
+ * kinds someone remembered to write a case for — which is the same failure
+ * mode as the gate itself. These derive from the shared registry instead: a
+ * measurement kind registered in `REPROJECTED_MEASUREMENT_FIELDS` (the only
+ * way to get it reprojected — `updateMeasurementScreenCoords` does not
+ * compile otherwise) is covered here the moment it is added.
+ */
+describe('hasPendingMeasurementState — derived from the field registry', () => {
+  /** All registered fields empty/null, built from the registry itself. */
+  function emptyState(): PendingMeasurementState {
+    const state: Record<string, unknown> = {};
+    for (const field of REPROJECTED_MEASUREMENT_FIELD_NAMES) {
+      state[field] = REPROJECTED_MEASUREMENT_FIELDS[field] === 'list' ? { length: 0 } : null;
+    }
+    return state as PendingMeasurementState;
+  }
+
+  it('the registry is non-empty, so the per-field cases below are not vacuous', () => {
+    assert.ok(REPROJECTED_MEASUREMENT_FIELD_NAMES.length > 0);
+  });
+
+  it('is false when every registered field is empty', () => {
+    assert.equal(hasPendingMeasurementState(emptyState()), false);
+  });
+
+  for (const field of REPROJECTED_MEASUREMENT_FIELD_NAMES) {
+    it(`is true when only \`${field}\` has content`, () => {
+      const state: Record<string, unknown> = { ...emptyState() };
+      state[field] = REPROJECTED_MEASUREMENT_FIELDS[field] === 'list' ? { length: 1 } : {};
+      assert.equal(hasPendingMeasurementState(state as PendingMeasurementState), true);
+    });
+  }
 });

--- a/apps/viewer/src/utils/viewportUtils.ts
+++ b/apps/viewer/src/utils/viewportUtils.ts
@@ -8,6 +8,11 @@
  */
 
 import type { MeshData } from '@ifc-lite/geometry';
+import {
+  REPROJECTED_MEASUREMENT_FIELDS,
+  REPROJECTED_MEASUREMENT_FIELD_NAMES,
+  type ReprojectedMeasurementField,
+} from '../store/measurementReprojectionFields.js';
 
 // ============================================================================
 // Types
@@ -519,44 +524,48 @@ export function unionEntityBounds(
 /**
  * The subset of measurement-slice state that decides whether the animation
  * loop's per-frame reprojection pass (`updateMeasurementScreenCoords`) needs
- * to run at all. Kept as a plain shape (not imported from the store) so this
- * stays a pure function callable from a test with a minimal fixture.
+ * to run at all.
+ *
+ * DERIVED from `REPROJECTED_MEASUREMENT_FIELDS` rather than listed here: that
+ * registry is the one place the reprojected field set is written down, and
+ * the reprojection pass is typed against it too. Structural, not imported
+ * from the store, so this stays a pure function callable from a test with a
+ * minimal fixture — while the live `useViewerStore.getState()` at
+ * Viewport.tsx's call site still has to satisfy it, which is what catches a
+ * field registered under the wrong kind.
  */
-export interface PendingMeasurementState {
-  measurements: { length: number };
-  activeMeasurement: unknown;
-  /** In-progress multi-click polyline sequence (#2199), or null. */
-  activePolyline: unknown;
-  /** Finished multi-click polylines (#2199) — their placed vertices still
-   *  need reprojecting on every camera move, same as drag measurements. */
-  polylineMeasurements: { length: number };
-  /** In-progress angle sequence (#2735), or null. */
-  activeAngle: unknown;
-  /** Finished angle measurements (#2735) - their picks are reprojected too. */
-  angleMeasurements: { length: number };
-}
+export type PendingMeasurementState = {
+  [K in ReprojectedMeasurementField]: (typeof REPROJECTED_MEASUREMENT_FIELDS)[K] extends 'list'
+    ? { length: number }
+    : unknown;
+};
 
 /**
  * True when there is any measurement state whose screen coordinates could
- * be stale after a camera move - drag-mode measurements/gesture,
+ * be stale after a camera move — drag-mode measurements/gesture,
  * polyline-mode sequences/finished polylines (#2641 review defect: this used
  * to check only `measurements`/`activeMeasurement`, so with polyline-only
  * state the reprojection pass never ran and placed points, segments and
  * labels froze at their click-time screen position while orbiting), or angle
  * sequences/measurements (#2735, the same defect a third time).
  *
- * This gate and `updateMeasurementScreenCoords` are a PAIR. Reprojection logic
- * added there without an arm here is dead code for any state this gate does
- * not recognise, and the symptom is identical to having written no
- * reprojection at all.
+ * This gate and `updateMeasurementScreenCoords` are a PAIR: reprojection
+ * logic added there without an arm here is dead code, and the symptom is
+ * identical to having written no reprojection at all. Neither side spells
+ * the pair out by hand any more — both read `REPROJECTED_MEASUREMENT_FIELDS`,
+ * so a new measurement kind reaches this gate as soon as it is registered,
+ * and cannot be reprojected without being registered.
  */
 export function hasPendingMeasurementState(state: PendingMeasurementState): boolean {
-  return (
-    state.measurements.length > 0 ||
-    state.activeMeasurement !== null ||
-    state.activePolyline !== null ||
-    state.polylineMeasurements.length > 0 ||
-    state.activeAngle !== null ||
-    state.angleMeasurements.length > 0
-  );
+  for (const field of REPROJECTED_MEASUREMENT_FIELD_NAMES) {
+    // The mapped type above ties each field's shape to its registered kind,
+    // so these two reads are the only ones the registry can produce.
+    const value: unknown = state[field];
+    if (REPROJECTED_MEASUREMENT_FIELDS[field] === 'list') {
+      if ((value as { length: number }).length > 0) return true;
+    } else if (value !== null) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
Makes a defect that has shipped **three times** a compile error.

`updateMeasurementScreenCoords` reprojects measurement state; `hasPendingMeasurementState` is the gate `Viewport.tsx:814` consults **before running that pass at all**. Add a measurement kind to the first and not the second and the new arm is dead code — the pass never runs for it.

That has happened for polyline (#2641), angle (#2735), and radius (caught in review on #2973). `hasPendingMeasurementState`'s docblock already said the two are a pair and named the earlier omissions. **A comment has now failed three times**, which is the argument for making it unrepresentable rather than documenting it a fourth time.

## They are not keyed on `MeasureMode`

Worth stating, because it was my own first assumption and it is wrong. Neither function mentions `MeasureMode`. Both are keyed on **slice state field names**, and the correspondence to the three modes is not one-to-one:

| field | source |
|---|---|
| `measurements`, `activeMeasurement` | drag + legacy flow — 2 fields, 1 mode |
| `activePolyline`, `polylineMeasurements` | polyline, in-progress + finished |
| `activeAngle`, `angleMeasurements` | angle, in-progress + finished |

So the real invariant is **the set of fields the reprojection pass writes == the set the gate reads**. Keying a check on `MeasureMode` — three variants against six fields, one of which belongs to no single mode — would have been the wrong rule.

## Type-level, not a script

`apps/viewer/src/store/measurementReprojectionFields.ts` holds `REPROJECTED_MEASUREMENT_FIELDS` as the single registry, and the gate **iterates** it, so it cannot lag it. Three teeth, each verified by running `tsc`:

1. **An arm without a registration** → excess-property error on the slice's `set()` payload, typed `{ [K in ReprojectedMeasurementField]: MeasurementSlice[K] }`.
2. **A registration without an arm** → missing-property error at the same site.
3. **Registered under the wrong kind** (`list` vs `nullable`) → `Viewport.tsx:814` fails, because the live store type is the checker.

No script and no wiring: `tsc --noEmit` is already the Typecheck job (`test.yml:304`, `if: frontend == 'true'`, and the filter lists `apps/viewer/**` explicitly — re-read from the YAML rather than assumed).

## RED against the real history

Reconstructed #2735 — registry without the angle fields, slice still reprojecting them, i.e. PR #2739's actual pre-review state:

```
measurementSlice.ts:458:7 - error TS2353: Object literal may only specify known properties,
and 'activeAngle' does not exist in type '{ measurements: Measurement[]; activeMeasurement:
ActiveMeasurement | null; activePolyline: ActivePolyline | null; polylineMeasurements: … }'.
```

Same for #2641 with polyline removed, and the reverse direction errors with `TS2741: Property 'pendingMeasurePoint' is missing`.

**And proof the old design was genuinely silent**, rather than merely unlucky: installing the *historical* `hasPendingMeasurementState` body from `2acf9f8a8^` — diffed byte-for-byte — alongside the angle-reprojecting slice gives `tsc` **0 errors in measurement files** and the gate suite passes **5/5**. That is why review had to catch it three times.

Radius/#2973 is not on `upstream/main` yet, so it could not be used; the two that are in `git log` were, and the comments claim only what history shows.

## A latent fourth instance, registered rather than fixed

`pendingMeasurePoint` holds a `MeasurePoint` and `MeasurementVisuals.tsx:563-578` renders it from `screenX/screenY` — but it is in **neither** function, so it is symmetric and this rule does not flag it. It is arguably the same freeze for the legacy click-click dot between clicks.

Fixing that is a behaviour change rather than a consistency fix, so it is recorded in the docblock as a deliberate exclusion instead of quietly added. `snapTarget` likewise, since it is recomputed per pointer event.

## Adversarial

Removing the core predicate — dropping the mapped-type annotation for a plain `set({...})` — makes the angle RED **disappear**, so the annotation is what does the work rather than the surrounding code. Neutering the gate body takes the registry-derived suite from 15 to **3 pass / 12 fail**.

The new test block asserts the registry is non-empty (a vacuity guard), asserts `false` when all fields are empty, and generates one case per registered field — so a new kind is covered the moment it is registered.

Measurement suites and neighbours: **231 tests across 53 suites, 231 pass**. `tsc --noEmit` has 0 errors in any measurement or viewport file.

**Four suites could not run here** — `resetViewerState.polyline`, `measure-parity`, `polyline-rubber-band`, `measure-quantities-mesh-area` — all `ERR_MODULE_NOT_FOUND` on `@ifc-lite/wasm/pkg/ifc-lite.js`, a Rust artifact not built in this worktree. Environmental and at import time, but stating it rather than implying full coverage.

No changeset: `apps/viewer` is private and the comparable viewer-only commit `55fa1e8db` carries none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
