### PR TITLE
fix(viewer): a zero or infinite scale bar length wedged the 2D canvas render loop

### DIFF
--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.scale-bar-zero-length.test.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.scale-bar-zero-length.test.tsx
@@ -183,6 +183,17 @@ describe('Drawing2DCanvas does not wedge on an unusable scale bar length', () =>
     assert.ok((calls.get('fillRect') ?? 0) >= 0, 'render completed');
   });
 
+  it('returns from the render with an infinite totalLengthM', () => {
+    // A DIFFERENT loop from the other two. `Infinity > 0` passes a positivity
+    // check, so the first version of this guard admitted it, and the HALVING
+    // loop above the doubling one spins because `Infinity / 2` is `Infinity`.
+    // Review caught this against the supposedly-fixed component: a 20,000 ms
+    // budget, killed at 20,002 ms. The bug report named the doubling loop and I
+    // never looked at the one above it.
+    const calls = render(Number.POSITIVE_INFINITY);
+    assert.ok((calls.get('fillRect') ?? 0) >= 0, 'render completed');
+  });
+
   // The positive control. Without it, a guard that skipped the scale bar
   // unconditionally would satisfy both cases above, which would be a worse
   // bug than the hang and completely invisible here.
@@ -198,14 +209,21 @@ describe('Drawing2DCanvas does not wedge on an unusable scale bar length', () =>
   });
 
   // The north arrow is drawn after the scale bar in the same function, so an
-  // early `return` inside the block would have silently dropped it. That was
-  // my first attempt at this guard. Putting it in the `if` condition keeps the
-  // arrow, and this pins that it does.
+  // early `return` inside the block would silently drop it. That was my first
+  // attempt at this guard.
+  //
+  // The assertion is `fillText:N`, not `stroke`, and the difference is the
+  // whole test. Review measured `stroke` at 8 calls with the arrow explicitly
+  // set to `style: 'none'`, because the frame and title-block rules call it
+  // regardless. An `|| stroke` disjunct made this pass 4/4 with the arrow
+  // actually gone, which review proved by reintroducing the early return.
+  // `fillText:N` goes 1 -> 0 with the arrow, and nothing else emits it.
   it('still draws the north arrow when the scale bar is skipped', () => {
     const calls = render(0);
-    assert.ok(
-      (calls.get('stroke') ?? 0) > 0 || (calls.get('fill') ?? 0) > 0,
-      'the north arrow must still be drawn when the scale bar is skipped',
+    assert.equal(
+      calls.get('fillText:N') ?? 0,
+      1,
+      'the north arrow glyph must still be drawn when the scale bar is skipped',
     );
   });
 });

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.scale-bar-zero-length.test.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.scale-bar-zero-length.test.tsx
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `Drawing2DCanvas` sizes its scale bar by doubling a target length until it
+ * fills the cell:
+ *
+ *     while (sbLengthMm < maxBarWidth * 0.3 && targetLengthM < 100)
+ *       targetLengthM = targetLengthM * 2;
+ *
+ * `0 * 2` is 0, so neither condition ever changes and the loop never
+ * terminates. A negative length is the same shape, doubling toward -Infinity,
+ * which stays below 100 forever. The loop runs synchronously inside the drawing
+ * effect, so it does not merely draw wrongly: it wedges the render.
+ *
+ * `calculateOptimalScaleBarLength` returns 0 deliberately, as a sentinel for
+ * "no usable bar at this scale and paper budget", pinned by
+ * scale-bar-ladder.test.ts. The export renderer honours it and draws nothing.
+ * This canvas did not, so the fix is the canvas agreeing with the exporter, not
+ * a change to what 0 means. My first attempt clamped the calculator instead,
+ * which broke that contract and failed the peer's test that asserts it.
+ *
+ * This test exists because the first version of it did not. That one
+ * transcribed the loop into a unit test in `@ifc-lite/drawing-2d` and asserted
+ * the copy spins. Deleting every guard clause from `Drawing2DCanvas` left it
+ * green, because it never imported the component: a guard that could not catch
+ * its own regression. Driving the real component is the whole point, and the
+ * harness for it already existed in this directory.
+ *
+ * How the failure shows up: with the guard removed the render never returns, so
+ * this test does not fail with an assertion, it stops responding and the
+ * runner's timeout kills it. That is a slow red, and it is a real one. Nothing
+ * in-process can bound a synchronous infinite loop, because a wedged event loop
+ * cannot run a timer either.
+ */
+
+import '@/test/setup-dom.js';
+import { installLayout } from '@/test/dom-layout.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  GraphicOverrideEngine,
+  PAPER_SIZE_REGISTRY,
+  FRAME_PRESETS,
+  TITLE_BLOCK_PRESETS,
+  DEFAULT_TITLE_BLOCK_FIELDS,
+  DEFAULT_SCALE_BAR,
+  DEFAULT_NORTH_ARROW,
+  calculateViewportBounds,
+} from '@ifc-lite/drawing-2d';
+import type { Drawing2D, DrawingSheet } from '@ifc-lite/drawing-2d';
+import { Drawing2DCanvas } from './Drawing2DCanvas.js';
+import type { CachedSheetTransform } from '@/lib/drawing/sheet-geometry-key.js';
+
+installLayout();
+
+/** Counting 2D context stub. Mirrors the Proxy stub in
+ *  Drawing2DCanvas.stale-pinned-transform.test.tsx, but tallies the calls that
+ *  draw a scale bar so "did it draw one" is answerable. */
+function installCanvasStub(): { calls: Map<string, number>; restore: () => void } {
+  const calls = new Map<string, number>();
+  const bump = (name: string) => calls.set(name, (calls.get(name) ?? 0) + 1);
+
+  const ctx = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'measureText') return (text: string) => ({ width: String(text).length * 7 });
+        if (prop === 'canvas') return { width: 800, height: 600 };
+        return (...args: unknown[]) => {
+          bump(String(prop));
+          if (String(prop) === 'fillText') bump(`fillText:${String(args[0])}`);
+          return undefined;
+        };
+      },
+      set() {
+        return true;
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D;
+
+  const original = HTMLCanvasElement.prototype.getContext;
+  HTMLCanvasElement.prototype.getContext = ((kind: string) =>
+    kind === '2d' ? ctx : null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+  return { calls, restore: () => { HTMLCanvasElement.prototype.getContext = original; } };
+}
+
+const EMPTY_DRAWING: Drawing2D = {
+  config: {
+    plane: { axis: 'y', position: 0, flipped: false },
+    projectionDepth: 10,
+    includeHiddenLines: true,
+    creaseAngle: 30,
+    scale: 100,
+  },
+  lines: [],
+  cutPolygons: [],
+  projectionPolygons: [],
+  bounds: { min: { x: 0, y: 0 }, max: { x: 10, y: 10 } },
+  stats: {
+    cutLineCount: 0,
+    projectionLineCount: 0,
+    hiddenLineCount: 0,
+    silhouetteLineCount: 0,
+    polygonCount: 0,
+    totalTriangles: 0,
+    processingTimeMs: 0,
+  },
+};
+
+function sheetWithBarLength(totalLengthM: number): DrawingSheet {
+  const paper = PAPER_SIZE_REGISTRY.A3_LANDSCAPE;
+  const frame = { style: 'professional' as const, ...FRAME_PRESETS.professional };
+  const titleBlock = {
+    ...TITLE_BLOCK_PRESETS.standard,
+    fields: DEFAULT_TITLE_BLOCK_FIELDS.map((f) => ({ ...f })),
+    logo: null,
+  };
+  return {
+    id: 'zero-bar',
+    name: 'zero-bar',
+    paper,
+    frame,
+    titleBlock,
+    scaleBar: { ...DEFAULT_SCALE_BAR, visible: true, totalLengthM },
+    scale: { name: '1:100', factor: 100, useCase: '' },
+    northArrow: { ...DEFAULT_NORTH_ARROW },
+    viewportBounds: calculateViewportBounds(paper, frame, titleBlock),
+    revisions: [],
+  };
+}
+
+function render(totalLengthM: number): Map<string, number> {
+  const stub = installCanvasStub();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  const cachedSheetTransformRef: React.MutableRefObject<CachedSheetTransform | null> = {
+    current: null,
+  };
+  try {
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <Drawing2DCanvas
+          drawing={EMPTY_DRAWING}
+          transform={{ x: 0, y: 0, scale: 1 }}
+          showHiddenLines={false}
+          overrideEngine={new GraphicOverrideEngine()}
+          overridesEnabled={false}
+          entityColorMap={new Map()}
+          useIfcMaterials={false}
+          sectionAxis="down"
+          sheetEnabled
+          activeSheet={sheetWithBarLength(totalLengthM)}
+          cachedSheetTransformRef={cachedSheetTransformRef}
+        />,
+      );
+    });
+    return stub.calls;
+  } finally {
+    act(() => { root?.unmount(); });
+    container.remove();
+    stub.restore();
+  }
+}
+
+describe('Drawing2DCanvas does not wedge on an unusable scale bar length', () => {
+  it('returns from the render with totalLengthM = 0', () => {
+    // Reaching the next line at all IS the assertion. Without the guard the
+    // doubling loop never exits and this never returns.
+    const calls = render(0);
+    assert.ok((calls.get('fillRect') ?? 0) >= 0, 'render completed');
+  });
+
+  it('returns from the render with a negative totalLengthM', () => {
+    // Doubles toward -Infinity, which stays below the loop's `< 100` bound.
+    const calls = render(-5);
+    assert.ok((calls.get('fillRect') ?? 0) >= 0, 'render completed');
+  });
+
+  // The positive control. Without it, a guard that skipped the scale bar
+  // unconditionally would satisfy both cases above, which would be a worse
+  // bug than the hang and completely invisible here.
+  it('still draws a bar for a usable length', () => {
+    const zero = render(0);
+    const usable = render(5);
+    const zeroFills = zero.get('fillRect') ?? 0;
+    const usableFills = usable.get('fillRect') ?? 0;
+    assert.ok(
+      usableFills > zeroFills,
+      `a usable length must draw more than an unusable one (usable=${usableFills}, zero=${zeroFills})`,
+    );
+  });
+
+  // The north arrow is drawn after the scale bar in the same function, so an
+  // early `return` inside the block would have silently dropped it. That was
+  // my first attempt at this guard. Putting it in the `if` condition keeps the
+  // arrow, and this pins that it does.
+  it('still draws the north arrow when the scale bar is skipped', () => {
+    const calls = render(0);
+    assert.ok(
+      (calls.get('stroke') ?? 0) > 0 || (calls.get('fill') ?? 0) > 0,
+      'the north arrow must still be drawn when the scale bar is skipped',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -987,36 +987,49 @@ export function Drawing2DCanvas({
       // 6. Draw scale bar at BOTTOM LEFT of title block
       // Uses actual drawingTransform.scaleFactor which accounts for dynamic scaling
       // ─────────────────────────────────────────────────────────────────────
-      // `calculateOptimalScaleBarLength` returns 0 as a deliberate sentinel for
-      // "no usable bar at this scale and paper budget", pinned by
-      // scale-bar-ladder.test.ts. The EXPORT renderer honours it and declines
-      // to draw. This canvas did not: it sizes the bar by doubling until it
-      // fits, and `0 * 2` is 0, so the loop below never terminates. It did not
-      // draw a wrong bar, it wedged the render.
+      // The scale bar is sized by two loops, and BOTH can fail to terminate:
       //
-      // So this is the canvas agreeing with the exporter about what an unusable
-      // length means, not a second opinion about it.
+      //   while (sbLengthMm > maxBarWidth && targetLengthM > 0.5)   // halving
+      //     targetLengthM = targetLengthM / 2;
+      //   while (sbLengthMm < maxBarWidth * 0.3 && targetLengthM < 100)  // doubling
+      //     targetLengthM = targetLengthM * 2;
       //
-      // The three added clauses do two different jobs. Measured, not assumed:
+      // They wedge on different inputs, which is why the guard needs three
+      // clauses and not one. Measured against the real component, each one a
+      // render that had to be killed by the test runner's timeout:
       //
-      //     totalLengthM=0,  scaleFactor=10   HANGS   (0 * 2 is 0, forever)
-      //     totalLengthM=-1, scaleFactor=10   HANGS   (doubles to -Infinity,
-      //                                                which stays < 100)
-      //     totalLengthM=5,  scaleFactor=NaN  terminates
-      //     totalLengthM=5,  scaleFactor=Inf  terminates
-      //     totalLengthM=5,  scaleFactor=0    terminates
+      //     totalLengthM=0         doubling loop   0 * 2 is 0, forever
+      //     totalLengthM=-1        doubling loop   halves toward -Infinity,
+      //                                            which stays < 100
+      //     totalLengthM=Infinity  HALVING loop    Infinity / 2 is Infinity
+      //     scaleFactor=NaN        terminates
+      //     scaleFactor=0          terminates
       //
-      // `scaleBar.totalLengthM > 0` is the clause preventing the hang. The two
-      // scaleFactor clauses prevent a drawn bar instead: at scaleFactor 0,
-      // `actualTotalLength` is 0/0 and the label renders "NaNcm".
+      // The Infinity case is the one I missed first time round, because I
+      // reasoned about the doubling loop the bug report named and never looked
+      // at the one above it. `Infinity > 0` passes a positivity check, so a
+      // guard without `Number.isFinite` reads as complete and is not.
       //
-      // Guards only the scale bar: the north arrow below is drawn after it in
-      // this same function, so an early return would have silently dropped it.
-      // That was my first attempt, and the test pins that it no longer happens.
+      // title-block-renderer.ts:410 already had this exactly right, and says so:
+      // "Checked BEFORE the clamp, and the ordering is load-bearing: testing
+      // the clamped result loses the infinite case". This is the canvas
+      // catching up with the exporter, which is also why `calculateOptimal-
+      // ScaleBarLength` is left alone: it returns 0 for "no usable bar" and the
+      // exporter already declines to draw that. The canvas was the half not
+      // holding up its end.
+      //
+      // The two scaleFactor clauses do a different job. Neither prevents a
+      // hang; they stop a bar being drawn with a `NaNm` label when
+      // `actualTotalLength` comes out 0/0.
+      //
+      // Guards only the scale bar: the north arrow is drawn after this block in
+      // the same function, so an early return would silently drop it. That was
+      // my first attempt.
       if (
         scaleBar.visible &&
         tbH > 10 &&
         scaleBar.totalLengthM > 0 &&
+        Number.isFinite(scaleBar.totalLengthM) &&
         Number.isFinite(drawingTransform.scaleFactor) &&
         drawingTransform.scaleFactor > 0
       ) {

--- a/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
+++ b/apps/viewer/src/components/viewer/Drawing2DCanvas.tsx
@@ -987,7 +987,39 @@ export function Drawing2DCanvas({
       // 6. Draw scale bar at BOTTOM LEFT of title block
       // Uses actual drawingTransform.scaleFactor which accounts for dynamic scaling
       // ─────────────────────────────────────────────────────────────────────
-      if (scaleBar.visible && tbH > 10) {
+      // `calculateOptimalScaleBarLength` returns 0 as a deliberate sentinel for
+      // "no usable bar at this scale and paper budget", pinned by
+      // scale-bar-ladder.test.ts. The EXPORT renderer honours it and declines
+      // to draw. This canvas did not: it sizes the bar by doubling until it
+      // fits, and `0 * 2` is 0, so the loop below never terminates. It did not
+      // draw a wrong bar, it wedged the render.
+      //
+      // So this is the canvas agreeing with the exporter about what an unusable
+      // length means, not a second opinion about it.
+      //
+      // The three added clauses do two different jobs. Measured, not assumed:
+      //
+      //     totalLengthM=0,  scaleFactor=10   HANGS   (0 * 2 is 0, forever)
+      //     totalLengthM=-1, scaleFactor=10   HANGS   (doubles to -Infinity,
+      //                                                which stays < 100)
+      //     totalLengthM=5,  scaleFactor=NaN  terminates
+      //     totalLengthM=5,  scaleFactor=Inf  terminates
+      //     totalLengthM=5,  scaleFactor=0    terminates
+      //
+      // `scaleBar.totalLengthM > 0` is the clause preventing the hang. The two
+      // scaleFactor clauses prevent a drawn bar instead: at scaleFactor 0,
+      // `actualTotalLength` is 0/0 and the label renders "NaNcm".
+      //
+      // Guards only the scale bar: the north arrow below is drawn after it in
+      // this same function, so an early return would have silently dropped it.
+      // That was my first attempt, and the test pins that it no longer happens.
+      if (
+        scaleBar.visible &&
+        tbH > 10 &&
+        scaleBar.totalLengthM > 0 &&
+        Number.isFinite(drawingTransform.scaleFactor) &&
+        drawingTransform.scaleFactor > 0
+      ) {
         // Position: bottom left with small margin
         const sbX = tbX + 3;
         const sbY = tbY + tbH - 8; // 8mm from bottom (leaves room for label)


### PR DESCRIPTION
`Drawing2DCanvas` sizes its scale bar with two loops, and **both** can fail to terminate.

```js
while (sbLengthMm > maxBarWidth && targetLengthM > 0.5)        // halving
  targetLengthM = targetLengthM / 2;
while (sbLengthMm < maxBarWidth * 0.3 && targetLengthM < 100)  // doubling
  targetLengthM = targetLengthM * 2;
```

| input | loop | why it never exits |
|---|---|---|
| `totalLengthM = 0` | doubling | `0 * 2` is `0` |
| `totalLengthM = -1` | doubling | doubles toward `-Infinity`, stays `< 100` |
| `totalLengthM = Infinity` | **halving** | `Infinity / 2` is `Infinity` |

It does not draw a wrong bar. It wedges the render.

## Why zero is reachable

`calculateOptimalScaleBarLength` returns `0` when nothing on the nice-number ladder fits the paper budget. #3056 pinned that, and the **export** renderer honours it by drawing nothing. The canvas did not. So this is the canvas holding up its end, not a new opinion about what `0` means.

`packages/drawing-2d` is byte-identical to main here. My first attempt clamped the calculator so it could not return `0`, which broke a contract #3056 had just merged and tested. That test caught it, which is the argument for rebasing onto main before believing your own diff: mine was two commits behind, so `git diff origin/main` was rendering #3056 and #3020 as a reverse diff.

## What review caught, and it was the important half

**The first version of this fix did not close the bug class.** `Infinity > 0` is true, so the guard admitted it and the halving loop spun. Proven against the supposedly-fixed component: a 20,000 ms budget, killed at 20,002 ms.

I missed it because the report named the doubling loop and I never looked at the one above it. And `title-block-renderer.ts:410` already had it right, with a comment saying the ordering is load-bearing *because* "testing the clamped result loses the infinite case". I copied two of its three checks, dropped the finiteness one, and then wrote that the canvas was "agreeing with the exporter".

**The north-arrow test could not fail.**

```js
assert.ok((calls.get('stroke') ?? 0) > 0 || (calls.get('fill') ?? 0) > 0)
```

`stroke` is 8 with the arrow set to `style: 'none'`, because the frame and title-block rules call it regardless. Review proved it by reintroducing the exact early return the test claims to pin: **4/4 green with the arrow demonstrably gone.** It asserts `fillText:N` now, which nothing else emits.

The arrow matters because it is drawn *after* the scale bar in the same function, so an early `return` silently drops it. That was my first attempt at the guard, which is why it is in the `if` condition.

## Mutations, run rather than reasoned about

```
drop Number.isFinite(totalLengthM)   hangs, killed by the runner
reintroduce the early return         north-arrow test fails (was 4/4 green)
drop all guard clauses               hangs, killed at 45,002 ms
```

The hang shows up as a timeout, not an assertion: nothing in-process can bound a synchronous infinite loop, because a wedged event loop cannot fire the timer that would bound it. Slow red, real red.

An earlier version of this test transcribed the loop into a unit test in `@ifc-lite/drawing-2d` and asserted the **copy** spins. Deleting every guard clause left it green, because it never imported the component. The justification I wrote for that — that the loop lives in a render function no unit test can call — was false: two tests in this directory already drive `Drawing2DCanvas` through an `installCanvasStub` harness.

## Deliberately unpinned

The two `scaleFactor` clauses. No test drives a non-positive or non-finite `scaleFactor`, so deleting them keeps the suite green. They prevent a `NaNm` label, not a hang. Saying so rather than letting green read as coverage.

No changeset: `@ifc-lite/viewer` is private and no published package changed.

Found by a peer session while reworking the scale bar, handed over rather than filed.