### PR TITLE
fix: ignore node_modules by name, so a symlink is matched too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 package-lock.json
 dist/
 build/


### PR DESCRIPTION
`.gitignore` line 1 was `node_modules/`. **A trailing slash matches directories only**, so a symlink named `node_modules` is not matched and `git add -A` stages it without a word.

Not hypothetical. It happened twice today: symlink `node_modules` into a worktree to run `tsc`, commit with `git add -A`, and every CI job dies at install.

```
ENOTDIR: not a directory, mkdir '/home/runner/work/ifc-lite/ifc-lite/node_modules'
Process completed with exit code 236
```

## The repo already documents this convention, at `.gitignore:87-93`

```
# The fixture directories themselves are ignored too: in a worktree they
# may be machine-local symlinks into the primary checkout.
tests/models/ara3d
tests/models/issues
tests/models/various
```

Those are directories and they carry **no trailing slash, deliberately, for exactly this reason**. `node_modules/` was the odd one out. This brings it into line rather than inventing a rule.

## Verified, in throwaway repos, one per pattern

```
pattern `node_modules/`:  root symlink NOT IGNORED, nested symlink NOT IGNORED
                          git add -A staged BOTH as 120000 blobs
                          real dir still ignored
pattern `node_modules`:   root and nested both matched (.gitignore:1)
                          git add -A staged nothing
                          real dir still ignored
```

Git still prunes rather than descends under both, so there is no walk cost.

## The widening is real, and was checked rather than assumed

The slash-less form also matches a **file** named `node_modules` anywhere. So:

- no tracked path has `node_modules` as its basename, and none contains a `node_modules` segment
- all **5796** tracked paths piped through `git check-ignore --no-index` under both versions of the file produce **identical** result sets (0 ignored in each)
- no nested `.gitignore` and no `info/exclude` carries a conflicting or negating entry
- nothing in `.github/` or `scripts/` depends on the directory-only match: no `git clean`, no `git archive`. The two `--exclude-standard` consumers in `check-git-lfs.mjs` use `--cached`, which lists tracked files regardless of ignore rules

## Alternatives considered and rejected

- **A second `node_modules` line alongside the first**: byte-identical in behaviour, with line 1 then matching nothing. Two lines of dead config.
- **`.git/info/exclude`**: not shareable, so it would not help CI or another clone.
- **A pre-commit hook**: more machinery, not cloned, bypassable with `--no-verify`.
- **Nothing, and blame `git add -A`**: a committed `120000` blob pointing at a machine-local absolute path is broken for every other clone. Making the ignore file correct is the root fix; disciplining every future `git add` is not.

## Why it is worth a commit rather than a habit

Git will not replace an existing directory with a symlink on checkout, so anyone whose `node_modules` is a real directory sees nothing wrong locally, in `git status`, or in a test run. **Only CI and fresh clones are affected** — the most expensive and least expected place.

Split out of the codegen fix that hit this, so a repo-wide ignore change gets looked at for what it is rather than buried in a PR about a schema registry.