### PR TITLE
docs(viewer): record that a sheet PDF is a raster, and pin the vector/raster split

### DIFF
--- a/apps/viewer/src/hooks/useDrawingExport.pdfVectorPaths.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingExport.pdfVectorPaths.test.tsx
@@ -1,0 +1,302 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `handleExportPDF` has two writers, and which one runs decides whether the
+ * exported PDF is resolution-independent. That split is a documented
+ * trade-off (see the long note on the `sheetEnabled && activeSheet` branch
+ * in useDrawingExport.ts) and until now nothing pinned it:
+ *
+ *  - SHEET mode rasterizes `generateSheetSVG()` to a PNG and places that one
+ *    image across the paper. This is what fixed #2941 (no frame, title block
+ *    or scale bar) and #2942 (not to scale) — the sheet layout only exists
+ *    inside `generateSheetSVG`, and jsPDF has no SVG import — at the cost of
+ *    a PDF that pixelates under zoom.
+ *  - NON-SHEET mode ("as displayed" / scaled, #2042) writes jsPDF vector
+ *    primitives and rasterizes nothing.
+ *
+ * Both halves matter and each protects the other. Without the first, a
+ * future "make the sheet vector again" change would quietly reintroduce
+ * #2941/#2942 unless it also re-derived the whole sheet layout. Without the
+ * second, routing everything through the raster helper — the obvious
+ * simplification, since it already handles one case — would silently make
+ * the viewer's only true-vector PDF a bitmap, with nothing to catch it: the
+ * export still succeeds, still has the right page size, and still looks
+ * right at 100%.
+ *
+ * The observation is what reaches jsPDF: `addImage` (a raster was embedded)
+ * versus `lines` (vector primitives were written). Both are spied on
+ * `jsPDF.API`, not `jsPDF.prototype` — jsPDF copies its plugin methods onto
+ * each instance as own properties at construction time, so patching the
+ * prototype patches nothing a real instance calls.
+ *
+ * `HTMLCanvasElement`'s 2D context and `Image` decoding do not exist under
+ * happy-dom, so the sheet path's browser rasterization plumbing is stubbed
+ * exactly as useDrawingExport.pdfSheet.test.tsx stubs it. That stub is what
+ * makes `addImage` reachable at all here; it does not decide which branch
+ * runs, which is the only thing these tests assert on.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  GraphicOverrideEngine,
+  PAPER_SIZE_REGISTRY,
+  FRAME_PRESETS,
+  TITLE_BLOCK_PRESETS,
+  DEFAULT_TITLE_BLOCK_FIELDS,
+  DEFAULT_SCALE_BAR,
+  DEFAULT_NORTH_ARROW,
+  calculateViewportBounds,
+  calculateOptimalScaleBarLength,
+  type Drawing2D,
+  type DrawingSheet,
+} from '@ifc-lite/drawing-2d';
+import useDrawingExport from './useDrawingExport.js';
+
+// happy-dom has no `window.alert`; the production failure path calls it from
+// inside a fire-and-forget async IIFE, where a ReferenceError would hang the
+// completion promise below with no visible cause.
+(globalThis as unknown as { alert: (msg?: string) => void }).alert = (msg) => {
+  // eslint-disable-next-line no-console -- test-only diagnostic for a swallowed export error
+  console.error('[handleExportPDF alert]', msg);
+};
+
+/** A valid 1x1 PNG so jsPDF's own decoder accepts the stubbed raster. */
+const TINY_PNG_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
+
+/** A real, renderable sheet, built from the package's own preset tables the
+ *  way `sheetSlice.createDefaultSheet` does. */
+function buildSheet(): DrawingSheet {
+  const paper = PAPER_SIZE_REGISTRY.A3_LANDSCAPE;
+  const framePreset = FRAME_PRESETS.professional;
+  const titleBlockPreset = TITLE_BLOCK_PRESETS.standard;
+  const scale = { name: '1:50', factor: 50, useCase: 'test' };
+  const frame = { style: 'professional' as const, ...framePreset };
+  const titleBlock = {
+    ...titleBlockPreset,
+    fields: DEFAULT_TITLE_BLOCK_FIELDS.map((f) => ({ ...f })),
+    logo: null,
+  };
+  const viewportBounds = calculateViewportBounds(paper, frame, titleBlock);
+  return {
+    id: 'sheet-vector-split',
+    name: 'Sheet',
+    paper,
+    frame,
+    titleBlock,
+    scaleBar: {
+      ...DEFAULT_SCALE_BAR,
+      totalLengthM: calculateOptimalScaleBarLength(scale.factor, viewportBounds.width * 0.3),
+    },
+    scale,
+    northArrow: { ...DEFAULT_NORTH_ARROW },
+    viewportBounds,
+    revisions: [],
+  };
+}
+
+/** One 4-metre horizontal line — enough for the non-sheet path to have real
+ *  geometry to stroke, so "no `lines` call" can never be a vacuous pass. */
+function buildDrawing(): Drawing2D {
+  return {
+    config: {
+      plane: { axis: 'y', position: 0, flipped: false },
+      projectionDepth: 10,
+      includeHiddenLines: true,
+      creaseAngle: 30,
+      scale: 50,
+    },
+    lines: [
+      {
+        line: { start: { x: 0, y: 0 }, end: { x: 4, y: 0 } },
+        category: 'projection',
+        visibility: 'visible',
+        entityId: 1,
+        ifcType: 'IfcWall',
+        modelIndex: 0,
+        depth: 0,
+      },
+    ],
+    cutPolygons: [],
+    projectionPolygons: [],
+    bounds: { min: { x: 0, y: 0 }, max: { x: 4, y: 0 } },
+    stats: {
+      cutLineCount: 0,
+      projectionLineCount: 1,
+      hiddenLineCount: 0,
+      silhouetteLineCount: 0,
+      polygonCount: 0,
+      totalTriangles: 0,
+      processingTimeMs: 0,
+    },
+  };
+}
+
+interface HarnessProps {
+  sheetEnabled: boolean;
+  activeSheet: DrawingSheet;
+  onReady: (fn: (scaleFactor?: number) => void) => void;
+}
+
+function Harness({ sheetEnabled, activeSheet, onReady }: HarnessProps): null {
+  const { handleExportPDF } = useDrawingExport({
+    drawing: buildDrawing(),
+    displayOptions: {
+      showHiddenLines: true,
+      scale: 50,
+      showScanSection: false,
+      scanSectionOpacity: 0,
+      scanSectionIncludeInExport: false,
+    },
+    sectionPlane: { axis: 'down', position: 50, flipped: false },
+    activePresetId: null,
+    entityColorMap: new Map(),
+    overridesEnabled: false,
+    overrideEngine: new GraphicOverrideEngine(),
+    measure2DResults: [],
+    polygonArea2DResults: [],
+    textAnnotations2D: [],
+    cloudAnnotations2D: [],
+    // The sheet object is handed to BOTH cases on purpose: the only
+    // difference between them is the toggle, so a branch that ignored
+    // `sheetEnabled` and keyed off `activeSheet` alone could not pass both.
+    sheetEnabled,
+    activeSheet,
+    dxfUnderlays: [],
+    ifcDataStore: null,
+    coordinateInfo: undefined,
+    scanSection: { points: [] },
+  });
+  onReady(handleExportPDF);
+  return null;
+}
+
+/** Stub the SVG -> canvas -> PNG plumbing happy-dom cannot do. */
+function stubRasterization(): () => void {
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+  // @ts-expect-error -- test stub, narrower signature than the DOM lib's overloaded getContext
+  HTMLCanvasElement.prototype.getContext = function (type: string) {
+    if (type === '2d') return { fillStyle: '', fillRect() {}, drawImage() {} };
+    return originalGetContext.call(this, type as '2d');
+  };
+  const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+  HTMLCanvasElement.prototype.toDataURL = function () {
+    return `data:image/png;base64,${TINY_PNG_B64}`;
+  };
+  const OriginalImage = globalThis.Image;
+  class FakeImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_v: string) {
+      queueMicrotask(() => this.onload?.());
+    }
+  }
+  // @ts-expect-error -- test stub replacing the global Image constructor
+  globalThis.Image = FakeImage;
+  return () => {
+    HTMLCanvasElement.prototype.getContext = originalGetContext;
+    HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+    globalThis.Image = OriginalImage;
+  };
+}
+
+/**
+ * Run the real `handleExportPDF` and return the PDF it actually produced, as
+ * latin1 text (jsPDF writes these objects uncompressed).
+ *
+ * The observation is the FILE, not a spy on jsPDF's internals: `downloadFile`
+ * ends at `URL.createObjectURL(blob)`, so intercepting that yields the exact
+ * bytes the user would have saved. A jsPDF spy is not an option in any case —
+ * `lines` and `output` are per-instance own properties installed by the
+ * constructor, not entries on `jsPDF.API` (verified directly), so there is
+ * nothing shared to patch. The sheet path also creates an object URL for its
+ * intermediate SVG blob, hence the `application/pdf` filter.
+ */
+async function exportPdf(sheetEnabled: boolean): Promise<string> {
+  const restoreRaster = stubRasterization();
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root | null = null;
+  let exportFn: ((scaleFactor?: number) => void) | null = null;
+
+  const originalCreate = URL.createObjectURL;
+  let resolvePdf!: (blob: Blob) => void;
+  const pdfBlob = new Promise<Blob>((resolve) => {
+    resolvePdf = resolve;
+  });
+  URL.createObjectURL = function (obj: Blob | MediaSource): string {
+    if (obj instanceof Blob && obj.type === 'application/pdf') resolvePdf(obj);
+    return originalCreate.call(URL, obj);
+  };
+
+  try {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <Harness
+          sheetEnabled={sheetEnabled}
+          activeSheet={buildSheet()}
+          onReady={(fn) => {
+            exportFn = fn;
+          }}
+        />,
+      );
+    });
+    let blob: Blob | null = null;
+    await act(async () => {
+      exportFn!();
+      blob = await pdfBlob;
+    });
+    const bytes = new Uint8Array(await (blob as unknown as Blob).arrayBuffer());
+    let text = '';
+    for (let i = 0; i < bytes.length; i++) text += String.fromCharCode(bytes[i]);
+    return text;
+  } finally {
+    URL.createObjectURL = originalCreate;
+    restoreRaster();
+    if (root) await act(async () => { (root as Root).unmount(); });
+    container.remove();
+  }
+}
+
+/** jsPDF writes an embedded bitmap as an XObject whose dictionary carries
+ *  `/Subtype /Image`; a purely vector document has no such object. Probed
+ *  against jsPDF 4.2 both ways — `/XObject` alone appears in both and is
+ *  NOT a discriminator. */
+const EMBEDDED_IMAGE = '/Subtype /Image';
+
+/** A stroked path in an uncompressed jsPDF content stream: a moveto, a
+ *  lineto, and the stroke operator, each on its own line. */
+const STROKED_PATH = /\d m\n[-\d. ]+ l\nS\n/;
+
+describe('handleExportPDF — which PDFs are vector and which are raster', () => {
+  it('is a RASTER in sheet mode — the documented cost of fixing #2941/#2942', async () => {
+    const text = await exportPdf(true);
+    assert.ok(
+      text.includes(EMBEDDED_IMAGE),
+      'a sheet PDF carries its page as an embedded bitmap; if that stops being true, the trade-off note on the sheet branch of handleExportPDF is stale',
+    );
+    assert.ok(
+      !STROKED_PATH.test(text),
+      'the sheet path must not ALSO stroke the geometry as vectors — the raster is the whole page, and drawing it twice would double-print it',
+    );
+  });
+
+  it('stays TRUE VECTOR for the non-sheet "as displayed" / scaled PDF (#2042)', async () => {
+    const text = await exportPdf(false);
+    assert.ok(
+      STROKED_PATH.test(text),
+      'the non-sheet PDF must stroke the drawing geometry as vector paths',
+    );
+    assert.ok(
+      !text.includes(EMBEDDED_IMAGE),
+      'the non-sheet PDF must embed no bitmap — it is the only resolution-independent PDF the viewer emits, and routing it through the sheet raster helper would look identical at 100% zoom and only show up under a loupe',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useDrawingExport.pdfVectorPaths.test.tsx
+++ b/apps/viewer/src/hooks/useDrawingExport.pdfVectorPaths.test.tsx
@@ -21,9 +21,11 @@
  * #2941/#2942 unless it also re-derived the whole sheet layout. Without the
  * second, routing everything through the raster helper — the obvious
  * simplification, since it already handles one case — would silently make
- * the viewer's only true-vector PDF a bitmap, with nothing to catch it: the
- * export still succeeds, still has the right page size, and still looks
- * right at 100%.
+ * the viewer's only true-vector PDF OF THE DRAWING a bitmap, with nothing
+ * to catch it: the export still succeeds, still has the right page size,
+ * and still looks right at 100%. (`lib/lists/export/pdf.ts` also emits
+ * pure vector, through `jspdf-autotable`, but that is a tabular report
+ * rather than a drawing; `lib/export/view-pdf/` is a raster.)
  *
  * The observation is what reaches jsPDF: `addImage` (a raster was embedded)
  * versus `lines` (vector primitives were written). Both are spied on
@@ -296,7 +298,7 @@ describe('handleExportPDF — which PDFs are vector and which are raster', () =>
     );
     assert.ok(
       !text.includes(EMBEDDED_IMAGE),
-      'the non-sheet PDF must embed no bitmap — it is the only resolution-independent PDF the viewer emits, and routing it through the sheet raster helper would look identical at 100% zoom and only show up under a loupe',
+      'the non-sheet PDF must embed no bitmap — it is the only resolution-independent PDF of the DRAWING the viewer emits, and routing it through the sheet raster helper would look identical at 100% zoom and only show up under a loupe',
     );
   });
 });

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -1029,10 +1029,18 @@ function useDrawingExport({
   // v1 scope, deliberately smaller than the SVG export: cut-polygon
   // OUTLINES and drawing LINES only (matching what an engineer actually
   // measures off a printed section). Not yet included: area fills /
-  // hatching, DXF underlays, the drawing-sheet title block/frame/scale
-  // bar, text/cloud annotations, and the point-cloud scan overlay. Those
-  // are straightforward follow-ups once this scale plumbing is reviewed;
-  // see the PR description.
+  // hatching, DXF underlays, text/cloud annotations, and the point-cloud
+  // scan overlay. Those are straightforward follow-ups once this scale
+  // plumbing is reviewed; see the PR description.
+  //
+  // The drawing-sheet frame / title block / scale bar are NOT on that list
+  // any more, and this path is not where they will arrive. It is the
+  // NON-SHEET path: since #2941/#2942 the sheet case returns from the
+  // branch at the top of `handleExportPDF` and never reaches here. This
+  // path is still the only PDF export for the "as displayed" / scaled
+  // drawing (#2042) and is not dead — but it is also the only true-vector
+  // PDF the viewer emits, so the branch above is where the raster
+  // trade-off is written down.
   const handleExportPDF = useCallback((scaleFactor?: number) => {
     if (!drawing) return;
 
@@ -1048,6 +1056,41 @@ function useDrawingExport({
     // all branch on `sheetEnabled && activeSheet` (e.g. handleExportSVG
     // above); PDF alone didn't. Reuse the already-correct sheet SVG instead
     // of re-deriving a second sheet layout for jsPDF's vector primitives.
+    //
+    // THE TRADE-OFF THIS BRANCH MAKES, stated so the next reader does not
+    // have to rediscover it by zooming into an exported sheet:
+    //
+    //   A sheet-mode PDF is a RASTER, not vector. It carries one PNG per
+    //   page ({@link SHEET_PDF_DPI}, capped by MAX_SHEET_RASTER_PIXELS),
+    //   so its text and lines are resolution-dependent and will pixelate
+    //   under zoom or on a plotter finer than the effective dpi.
+    //
+    // Before this branch existed, sheet mode fell through to the v1 path
+    // below and produced true-vector output — but of the wrong drawing:
+    // no frame, no title block, no scale bar (#2941) and at
+    // `displayOptions.scale` rather than the sheet's own (#2942). So the
+    // choice was not "vector vs raster", it was "a resolution-independent
+    // PDF that is not the sheet and is not to scale" vs "the correct sheet
+    // at the correct scale, rasterized". Correctness won.
+    //
+    // Vector would require re-deriving the whole sheet — frame, title
+    // block, scale bar, north arrow, and the drawing transform — against
+    // jsPDF's own primitives, because no SVG-import plugin is installed
+    // (apps/viewer depends on `jspdf` and `jspdf-autotable`; there is no
+    // `svg2pdf.js`). That is a second, independent implementation of
+    // `generateSheetSVG` that would then have to be kept in step with it —
+    // exactly the drift the v1 path already demonstrated. It is a real
+    // follow-up, not a hidden cost.
+    //
+    // The route for a user who needs vector today is the SVG export, which
+    // is not an approximation of this: `handleExportSVG` above emits the
+    // SAME `generateSheetSVG()` string, with no raster step at all. The
+    // over-cap toast below already points there; this note records that
+    // the recommendation applies to EVERY sheet PDF, not only capped ones.
+    //
+    // The non-sheet path below is untouched by any of this and stays true
+    // vector — see `useDrawingExport.pdfVectorPaths.test.tsx`, which pins
+    // both halves of that split.
     if (sheetEnabled && activeSheet) {
       const svg = generateSheetSVG();
       if (!svg) return;

--- a/apps/viewer/src/hooks/useDrawingExport.ts
+++ b/apps/viewer/src/hooks/useDrawingExport.ts
@@ -1038,9 +1038,12 @@ function useDrawingExport({
   // NON-SHEET path: since #2941/#2942 the sheet case returns from the
   // branch at the top of `handleExportPDF` and never reaches here. This
   // path is still the only PDF export for the "as displayed" / scaled
-  // drawing (#2042) and is not dead — but it is also the only true-vector
-  // PDF the viewer emits, so the branch above is where the raster
-  // trade-off is written down.
+  // drawing (#2042) and is not dead — it is the only true-vector PDF of
+  // the DRAWING the viewer emits, so the branch above is where the raster
+  // trade-off is written down. (Not the only vector PDF in the app:
+  // `lib/lists/export/pdf.ts` writes a Lists/schedule report through
+  // `jspdf-autotable` with no `addImage` at all. That is a table, not a
+  // drawing. The 3D view export, `lib/export/view-pdf/`, IS a raster.)
   const handleExportPDF = useCallback((scaleFactor?: number) => {
     if (!drawing) return;
 


### PR DESCRIPTION
**The sheet-mode PDF is a raster, and that is deliberate.** #3067 merged carrying a commit that made it so and said it nowhere.

`a0fe557e8` routes sheet-mode PDF through `generateSheetSVG` → PNG rather than jsPDF's vector primitives. That is what fixes #2941 (no frame, title block or scale bar) and #2942 (not to scale): the sheet layout — frame, title block, scale bar, north arrow, and the drawing transform — exists only inside `generateSheetSVG`, and jsPDF ships no SVG import (`apps/viewer` depends on `jspdf` and `jspdf-autotable`; there is no `svg2pdf.js`).

The cost is real and worth stating plainly: **a sheet PDF is no longer resolution-independent.** It carries one PNG per page at `SHEET_PDF_DPI` (300, reduced when the canvas cap binds), so its text and lines pixelate under zoom, or on a plotter finer than the effective dpi. A user who zooms a printed drawing will see it.

The choice was not "vector versus raster". Before that commit, sheet mode fell through to the v1 path and produced true-vector output **of the wrong drawing** — no frame, no title block, no scale bar, laid out at `displayOptions.scale` rather than the sheet's own. So the real choice was "a resolution-independent PDF that is not the sheet and is not to scale" against "the correct sheet at the correct scale, rasterized". Correctness won.

The vector route for a user who needs one is the **SVG export**, and it is not an approximation: `handleExportSVG` emits the *same* `generateSheetSVG()` string with no raster step. The over-cap toast already says so; the code note now records that it applies to every sheet PDF, not only capped ones.

## The vector path is not dead code

Checked rather than assumed. It is unreachable in sheet mode, but it remains the whole of the "as displayed" / scaled PDF export (#2042) and is **the only true-vector PDF of the drawing** the viewer emits.

(An earlier revision said "the only true-vector PDF the viewer emits", full stop. That is false: `apps/viewer/src/lib/lists/export/pdf.ts` builds the Lists/schedule report from `doc.text` plus `jspdf-autotable` with **no `addImage` anywhere**, and it is reachable from the UI via `ListResultsTable.tsx:291` → `exportList` → `toPdf`. Grepped `addImage` across every jsPDF caller in `apps/viewer/src`: drawing-v1 and that report are vector, `lib/export/view-pdf/` is the raster.)

What *was* wrong is its comment, which still listed "the drawing-sheet title block/frame/scale bar" under "not yet included" — implying sheet support would eventually arrive there. It will not; sheet mode returns before reaching it. Corrected.

## The split is now pinned, because it was a claim nothing enforced

New `useDrawingExport.pdfVectorPaths.test.tsx` reads the **produced PDF bytes** — `/Subtype /Image` against a stroked path — rather than spying on jsPDF, because `lines` and `output` are per-instance own properties rather than `jsPDF.API` entries, so a spy would not see them.

Both mutants run:

```
sheet branch disabled          -> raster test red: 'a sheet PDF carries its page as an embedded bitmap...'
condition dropped to activeSheet alone -> vector test red: 'the non-sheet PDF must stroke the drawing geometry as vector paths'
```

Drawing-export PDF suites **10 → 12 pass, 0 fail**. Behaviour untouched — this is comments and a test.

## A true-vector sheet remains a legitimate follow-up

It would mean re-deriving the entire sheet layout against jsPDF primitives — a second implementation that then has to be kept in step with `generateSheetSVG`. That is exactly the drift the v1 path already demonstrated, which is why it is recorded here as a known trade-off rather than attempted.

No changeset: comments and a test only. Viewer `tsc --noEmit` has 2 pre-existing errors in `RepairQueuePanel.{tsx,test.tsx}` (`needsSdkRepair` not exported from `@ifc-lite/extensions`) — unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

