### PR TITLE
fix(extensions): one AST depth bound, so the two walks over author source cannot diverge

### DIFF
--- a/.changeset/one-ast-depth-bound-for-author-source.md
+++ b/.changeset/one-ast-depth-bound-for-author-source.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/extensions": patch
+---
+
+Give the package's author-source AST walks one depth bound instead of two copies of the same number.
+
+`host/source-wrap.ts`'s `checkBannedConstructs` (#3025) and `ast/bounded-walk.ts` (#3027) landed the same day, each declaring its own private `MAX_AST_DEPTH = 1000`. Both bound traversals over extension-author-supplied source, and both refuse a script that exceeds the bound — so moving one alone would have opened a band where `wrapEntrySource` accepts a script that `validateCode` refuses, or the reverse, with nothing to catch it. `source-wrap.ts` now imports the constant from `ast/bounded-walk.ts`. No behaviour change: the value is the same 1000 it already was.
+
+`bounded-walk.ts`'s module doc claimed to be "the single traversal used by every AST consumer here" and that callers "do not re-implement the traversal", which `checkBannedConstructs` had never been true of — it walks child properties generically, a superset of the positions `acorn-walk`'s `base` descends through. The doc now says which walks go through the module and which does not.

--- a/packages/extensions/src/ast/bounded-walk.ts
+++ b/packages/extensions/src/ast/bounded-walk.ts
@@ -12,10 +12,22 @@
  * `RangeError: Maximum call stack size exceeded` out of the middle of
  * whatever function invoked the walk.
  *
- * This module is the single traversal used by every AST consumer here.
  * It keeps its own stack on the heap and stops at {@link MAX_AST_DEPTH},
  * *reporting* that it stopped rather than throwing. Callers vary the
  * visitor; they do not re-implement the traversal.
+ *
+ * Two of the package's three author-source walks go through here:
+ * `validate/code.ts` and `inference/capability.ts`. The third,
+ * `host/source-wrap.ts`'s `checkBannedConstructs`, keeps its own
+ * heap-stack traversal — it enumerates child properties generically
+ * instead of descending through `acorn-walk`'s `base`, so it visits a
+ * superset of these positions. It does not keep its own limit: it
+ * imports {@link MAX_AST_DEPTH} from here, so raising or lowering the
+ * bound moves both walks rather than opening a band where one gate on
+ * author-supplied source accepts what the next refuses. (The two count
+ * a level slightly differently — generic property nesting versus
+ * `base`'s child dispatch — so they are not guaranteed to cut the same
+ * script at the same node, only to share the same budget.)
  *
  * It descends using `acorn-walk`'s own `base` visitor rather than
  * enumerating object properties generically, so which child positions

--- a/packages/extensions/src/host/source-wrap.ts
+++ b/packages/extensions/src/host/source-wrap.ts
@@ -41,6 +41,7 @@
 
 import * as acorn from 'acorn';
 import type { ValidationError, ValidationResult } from '../types.js';
+import { MAX_AST_DEPTH as SHARED_MAX_AST_DEPTH } from '../ast/bounded-walk.js';
 
 export interface SourceWrapOptions {
   /** Name of the entry function to invoke (e.g. "activate"). */
@@ -142,18 +143,18 @@ if (typeof ${entryFn} === 'function') {
 /**
  * Maximum AST nesting depth the banned-construct walk will inspect.
  *
- * Real entry scripts nest a few tens of levels deep; this bound is
- * two orders of magnitude above that. It exists because the AST comes
- * from extension-author-controlled source: past this depth the walk
- * stops and reports a validation error instead of continuing. acorn's
- * own parser gives up at roughly twice this depth in the same process
- * ("Not enough stack space to parse input"), but that limit moves with
- * however much stack the host happens to have left; this one does not.
+ * Shared with `ast/bounded-walk.ts`, which bounds the package's other
+ * two author-source walks (`validateCode`, `inferCapabilities`). It was a
+ * private `1000` here against that module's `1000`: the same number twice,
+ * with nothing keeping them equal. A script that `wrapEntrySource` accepts
+ * and `validateCode` refuses — or the reverse — is a bundle that passes one
+ * gate on author-supplied source and fails the next, and moving either
+ * constant alone would have produced exactly that band silently.
  *
- * A script nested deeper than this is rejected with an
- * `invalid_value` error naming the limit — never a thrown RangeError.
+ * A script nested deeper than this is rejected with an `invalid_value`
+ * error naming the limit — never a thrown RangeError.
  */
-const MAX_AST_DEPTH = 1000;
+const MAX_AST_DEPTH = SHARED_MAX_AST_DEPTH;
 
 /**
  * Walk the *entire* AST — including nested function bodies, arrow


### PR DESCRIPTION
Two copies of `MAX_AST_DEPTH` bound walks over **extension-author source**, and moving one alone opens a band where one accepts what the other refuses.

`packages/extensions/src/host/source-wrap.ts:156` held a private `1000` (from #3025); `packages/extensions/src/ast/bounded-walk.ts:55` held another (from #3027, merged the same day). Both refuse a script past the bound.

## The divergence band, reproduced directly

A throwaway probe exercising `wrapEntrySource` and `validateCode` on the same 300-level nested script:

| shared constant | `source-wrap.ts` | `wrapEntrySource` | `validateCode` |
|---|---|---|---|
| 1000 | imports it (fixed) | accepts | accepts |
| **100** | imports it (fixed) | **refuses (depth)** | **refuses (depth)** |
| **100** | private `1000` (pre-fix) | **accepts** | **refuses (depth)** |

The third row is the defect: before this change, moving the bound makes `wrapEntrySource` accept exactly what `validateCode` refuses. After it, that row is unreachable.

**The value is unchanged**, so no script changes verdict. `source-wrap.test.ts:163` still passes asserting the literal `'Entry script is nested more than 1000 AST levels deep.'`

## A doc that overclaimed

`bounded-walk.ts` described itself as *"the single traversal used by every AST consumer here"*, with callers who *"do not re-implement the traversal"*. `checkBannedConstructs` always did.

The corrected doc deliberately does **not** claim the two cut the same script at the same node — they count a level differently, and the mutation table above is what that distinction looks like. They share the **budget**, nothing more.

One claim in it is established by reading rather than running: that `checkBannedConstructs`'s generic property enumeration visits a *superset* of the positions `acorn-walk`'s `base` descends. It is sound from the code — generic enumeration reaches computed member properties, object keys and labels that `base` skips — but "superset" is a stronger word than the evidence, so read it as "a different, broader set".

## Checks

`packages/extensions` **60 files / 810 tests passed, 0 failed** at `upstream/main`, and **60 / 810 passed, 0 failed** with the patch — identical, which is the expected shape of a no-behaviour-change consolidation.

No cycle: `ast/bounded-walk.ts` imports only `acorn-walk`, and the new edge is `host/ → ast/`, one-way. No host-only code entered `ast/`; that file's change is doc-only.

**A third copy?** Not in production — `MAX_AST_DEPTH` now has exactly one definition, consumed by `validate/code.ts`, `inference/capability.ts` and `host/source-wrap.ts`, and a repo-wide grep for `AST_DEPTH` / `nested more than` / `AST levels deep` outside `packages/extensions` returns nothing.

The literal `1000` does survive in `source-wrap.test.ts:163`, which asserts the full message string. Left deliberately: pinning the value in a test is a guard rather than a divergence hole, since changing the constant now fails loudly there instead of passing silently. Worth knowing that a future change to the bound touches that assertion — `validate/code.test.ts` uses `/nested more than \d+/` and would not notice.

`tsc --noEmit` exit 0; `typecheck-tests` OK across 60 files; oxlint clean on both changed files; `check-changesets` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
