### PR TITLE
test(export,processing): close four more fixtures that cannot fail for their own reason

### DIFF
--- a/rust/export/src/merged_tests.rs
+++ b/rust/export/src/merged_tests.rs
@@ -537,3 +537,159 @@ ENDSEC;\nEND-ISO-10303-21;\n"
         "shared IFC2X3-only-rooted GlobalId {shared_style} must be emitted exactly once, not duplicated across federated models -- got:\n{merged}"
     );
 }
+
+/// Every fixture above that merges two models gives both of them an
+/// `IfcProject` at the SAME express id (`#1`, or literally the same file
+/// twice) -- so `canonical_project` and the current model's own
+/// `model_project` are always equal, and the redirect in `remap` cannot be
+/// observed to pick the right one of the two. Confirmed by mutation:
+/// rewriting `return Some(cp)` to `return Some(mp)` in
+/// `export_merged_with_stats` left all of the above green.
+///
+/// Here the two models' projects sit at DIFFERENT express ids (`#1` in model
+/// A, `#7` in model B) and each model has a rooted entity that references its
+/// own project, so the redirect has a distinguishable right and wrong answer:
+/// model B's reference must land on model A's `#1`, not on the dropped `#7`
+/// (which no longer exists at all after the merge) and not on the offset
+/// `#7 + offset` either.
+#[test]
+fn merge_redirects_a_later_models_project_ref_to_the_first_models_project_id() {
+    // Model A: project at #1, max id 5. Model B: project at #7, max id 9 --
+    // deliberately different ids, and #7 is past model A's maximum so a
+    // remap that returns the model's OWN project id produces a reference to
+    // an express id that exists nowhere in the merged output.
+    let model_a = "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('11111111111111111111P1',$,'ProjectA',$,$,$,$,$,$);\n\
+#5=IFCRELAGGREGATES('11111111111111111111R1',$,$,$,#1,(#1));\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+    let model_b = "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#7=IFCPROJECT('22222222222222222222P2',$,'ProjectB',$,$,$,$,$,$);\n\
+#9=IFCRELAGGREGATES('22222222222222222222R2',$,$,$,#7,(#7));\n\
+ENDSEC;\nEND-ISO-10303-21;\n";
+
+    let (merged, stats) = export_merged_with_stats(
+        &[model_a.as_bytes(), model_b.as_bytes()],
+        &MergedOptions::default(),
+    );
+
+    // Model B's project line is dropped; 4 source entities minus 1 = 3.
+    assert_eq!(stats.written, 3, "later model's IfcProject line is dropped");
+
+    // The surviving project is model A's, at its original express id.
+    let project_lines: Vec<&str> =
+        merged.lines().filter(|l| l.contains("=IFCPROJECT(")).collect();
+    assert_eq!(project_lines.len(), 1, "single unified project, got {project_lines:?}");
+    assert!(
+        project_lines[0].starts_with("#1=IFCPROJECT("),
+        "the first model's project keeps its own id: {:?}",
+        project_lines[0]
+    );
+    assert!(
+        project_lines[0].contains("'ProjectA'"),
+        "the surviving project is model A's, not model B's: {:?}",
+        project_lines[0]
+    );
+
+    // Model B's offset is model A's max (5) + 1 = 6, so its #9 becomes #15.
+    // Both of its project references must have been redirected to #1 --
+    // NOT left at #7 (the model's own project id, which is gone) and NOT
+    // offset to #13.
+    let b_rel = merged
+        .lines()
+        .find(|l| l.contains("'22222222222222222222R2'"))
+        .expect("model B's IfcRelAggregates line");
+    assert_eq!(
+        b_rel, "#15=IFCRELAGGREGATES('22222222222222222222R2',$,$,$,#1,(#1));",
+        "model B's references to its own project must be redirected to model A's project id"
+    );
+
+    // Model A's own reference is untouched (offset 0, no redirect needed).
+    assert!(
+        merged.contains("#5=IFCRELAGGREGATES('11111111111111111111R1',$,$,$,#1,(#1));"),
+        "model A's project references are unchanged:\n{merged}"
+    );
+
+    // And nothing dangles: neither the model's own project id nor its
+    // offset image may appear anywhere in the merged text.
+    assert!(!merged.contains("#7"), "the dropped project id must not survive:\n{merged}");
+    assert!(!merged.contains("#13"), "the dropped project id must not be offset:\n{merged}");
+}
+
+/// Collect the leading 22-char GlobalId-shaped token of every DATA-section
+/// entity line, i.e. exactly what `leading_guid` reads.
+fn leading_guid_tokens(step: &str) -> Vec<String> {
+    step.lines()
+        .filter(|l| l.starts_with('#'))
+        .filter_map(|l| {
+            let open = l.find('(')?;
+            let rest = &l[open + 1..];
+            let body = rest.strip_prefix('\'')?;
+            let q2 = body.find('\'')?;
+            let tok = &body[..q2];
+            is_global_id_shaped(tok).then(|| tok.to_string())
+        })
+        .collect()
+}
+
+/// `mint_unique_guid` seeds from `{original}#{model_index}`, so two entities
+/// in the SAME model that both carry the SAME already-emitted GlobalId mint
+/// from an IDENTICAL seed. Two guards keep their fresh ids apart, and they
+/// are redundant with each other: `pending.insert(candidate.clone())` inside
+/// `mint_unique_guid`, and `emitted_guids.insert(fresh)` at the call site.
+/// Every fixture above collides at most ONE entity per model, so neither
+/// guard is exercised at all -- confirmed by mutation: deleting either one
+/// individually, and deleting BOTH, all left the pre-existing tests green,
+/// and the both-deleted case emits the same minted GlobalId three times.
+/// (Because the guards are redundant, this test dies only when both are
+/// gone; it is pinning the observable invariant, not either line.)
+///
+/// Duplicated GlobalIds inside a single file are a real-world authoring
+/// defect, and a merge that "fixes" them by minting the same replacement
+/// twice has simply moved the spec violation rather than removed it. The
+/// assertion is on the emitted STEP text (every leading GlobalId distinct),
+/// not on an intermediate map.
+#[test]
+fn merge_mints_distinct_ids_for_two_collisions_within_the_same_model() {
+    let shared = "00000000000000000000E1";
+    let model_a = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('11111111111111111111PA',$,$,$,$,$,$,$,$);\n\
+#2=IFCDOOR('{shared}',$,$,$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    // Model B carries the SAME GlobalId on THREE entities: all three collide
+    // with model A's already-emitted one, and all three seed identically.
+    let model_b = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('','',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n\
+#1=IFCPROJECT('22222222222222222222PB',$,$,$,$,$,$,$,$);\n\
+#2=IFCDOOR('{shared}',$,$,$,$,$,$,$,$);\n\
+#3=IFCDOOR('{shared}',$,$,$,$,$,$,$,$);\n\
+#4=IFCDOOR('{shared}',$,$,$,$,$,$,$,$);\n\
+ENDSEC;\nEND-ISO-10303-21;\n"
+    );
+
+    let (merged, _stats) = export_merged_with_stats(
+        &[model_a.as_bytes(), model_b.as_bytes()],
+        &MergedOptions::default(),
+    );
+
+    // 5 rooted entities survive (model B's project is dropped): 1 project,
+    // 1 original door, 3 doors that each needed a fresh id.
+    let tokens = leading_guid_tokens(&merged);
+    assert_eq!(tokens.len(), 5, "five rooted entities in the merged output: {tokens:?}");
+
+    let unique: HashSet<&String> = tokens.iter().collect();
+    assert_eq!(
+        unique.len(),
+        tokens.len(),
+        "every emitted GlobalId must be distinct -- same-model collisions minting the same replacement just relocates the duplicate: {tokens:?}"
+    );
+
+    // The original is kept exactly once (model A's), and the three
+    // replacements are all fresh.
+    assert_eq!(
+        tokens.iter().filter(|t| *t == shared).count(),
+        1,
+        "the colliding GlobalId survives on exactly one entity: {tokens:?}"
+    );
+}

--- a/rust/export/src/schema_convert.rs
+++ b/rust/export/src/schema_convert.rs
@@ -250,6 +250,53 @@ mod tests {
         assert_eq!(convert_entity_type("IFCFACILITY", "IFC4X3", "IFC2X3"), "IFCBUILDING");
     }
 
+    /// The UPGRADE table (`map_2x3_to_4`) had no test in this crate: the only
+    /// 2X3 → 4 case above is `IFCWALL`, a type that is unchanged in every
+    /// schema, so replacing the whole arm with a pass-through left the entire
+    /// `ifc-lite-export` suite green (confirmed by mutation). The TS twin
+    /// `packages/export/src/schema-converter.test.ts` covers this direction;
+    /// the Rust port is what the CLI, server and wasm actually run.
+    ///
+    /// Concretely, un-renamed output is an INVALID file: none of these three
+    /// type names exists in IFC4.
+    #[test]
+    fn ifc2x3_only_types_are_renamed_on_upgrade() {
+        for (from, want) in [
+            ("IFCELECTRICDISTRIBUTIONPOINT", "IFCELECTRICDISTRIBUTIONBOARD"),
+            ("IFCGASTERMINALTYPE", "IFCBURNERTYPE"),
+            ("IFCEQUIPMENTELEMENT", "IFCBUILDINGELEMENTPROXY"),
+        ] {
+            assert_eq!(convert_entity_type(from, "IFC2X3", "IFC4"), want, "2X3 → 4");
+            // 2X3 → 4X3 and 2X3 → 5 route through the same table.
+            assert_eq!(convert_entity_type(from, "IFC2X3", "IFC4X3"), want, "2X3 → 4X3");
+            assert_eq!(convert_entity_type(from, "IFC2X3", "IFC5"), want, "2X3 → 5");
+        }
+    }
+
+    /// The direct `4X3 → 4` arm was only ever reached by types it does NOT
+    /// rename: `entity_type_renames` chains through it on the way to 2X3, and
+    /// `alignment_becomes_proxy_on_downgrade` hits the proxy branch instead.
+    /// Replacing the arm with a pass-through likewise left the suite green.
+    /// `IFC5 → IFC4` shares the arm, so it is pinned here too — nothing else
+    /// in this crate exercises `canon`'s IFC5 branch at all.
+    #[test]
+    fn ifc4x3_and_ifc5_types_are_renamed_down_to_ifc4() {
+        for (from, want) in [
+            ("IFCBRIDGE", "IFCBUILDING"),
+            ("IFCBRIDGEPART", "IFCBUILDINGSTOREY"),
+            ("IFCPAVEMENT", "IFCSLAB"),
+            ("IFCCAISSONFOUNDATION", "IFCFOOTING"),
+            ("IFCDISTRIBUTIONBOARD", "IFCELECTRICDISTRIBUTIONBOARD"),
+        ] {
+            assert_eq!(convert_entity_type(from, "IFC4X3", "IFC4"), want, "4X3 → 4");
+            assert_eq!(convert_entity_type(from, "IFC5", "IFC4"), want, "5 → 4");
+        }
+        // 4 ↔ 4X3 ↔ 5 carry no renames, and IFCX* canonicalizes to IFC5.
+        assert_eq!(convert_entity_type("IFCWALL", "IFC4", "IFC5"), "IFCWALL");
+        assert_eq!(convert_entity_type("IFCBRIDGE", "IFCX", "IFC4"), "IFCBUILDING");
+        assert!(!needs_conversion("IFC5", "IFCX"));
+    }
+
     #[test]
     fn downgrade_trims_attributes() {
         // IfcWall in IFC4 has 9 attrs (trailing PredefinedType); IFC2X3 keeps 8.

--- a/rust/processing/tests/site_local_frame_rotation.rs
+++ b/rust/processing/tests/site_local_frame_rotation.rs
@@ -1,0 +1,254 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Direct unit coverage for `convert_mesh_to_site_local` — the public
+//! site-local frame conversion the streaming server calls on meshes it
+//! produces outside this crate's parallel loop.
+//!
+//! `site_rotation.rs` drives the same conversion through `process_geometry`,
+//! but its fixture shares two symmetries with the code under test, and each
+//! one hides a whole arm of it. Both were confirmed by mutation against the
+//! full `ifc-lite-processing` suite:
+//!
+//! 1. **The per-mesh `origin` is `[0, 0, 0]`.** The fixture's coordinates are
+//!    small, so no RTC rebase ever moves a mesh off its origin, and
+//!    `apply_inverse_rotation_point_f64` early-returns on the all-zero point
+//!    every single time. Replacing that function's body with an immediate
+//!    `return` — deleting the origin rotation the module's own comment calls
+//!    load-bearing ("otherwise the element would be rotated about the wrong
+//!    centre") — left the entire suite green.
+//! 2. **The only site rotation exercised is a yaw about Z.** A yaw leaves
+//!    `r02 = r12 = r20 = r21 = 0` and `r22 = 1`, so the four z-coupled matrix
+//!    entries are all zero and the transpose that distinguishes `R` from `Rᵀ`
+//!    is unobservable on them. Swapping `column_major_matrix[2]` with
+//!    `column_major_matrix[8]` — reading the z-coupled terms off the wrong
+//!    side of the diagonal — also left the entire suite green.
+//!
+//! Each test here builds its expectation from the OTHER direction: a chosen
+//! site-local point is rotated FORWARD by a hand-composed `R` to make the
+//! input, and the conversion must give the chosen point back. Nothing here
+//! reuses the production indexing, so a mutation to it cannot be mirrored
+//! into the expectation.
+
+use ifc_lite_processing::{convert_mesh_to_site_local, MeshData};
+
+/// Column-major 4x4 from a 3x3 given row-wise, plus a translation.
+/// `r[i][j]` is row `i`, column `j`; column-major storage puts (row r, col c)
+/// at index `c * 4 + r`.
+fn column_major(r: [[f64; 3]; 3], t: [f64; 3]) -> Vec<f64> {
+    let mut m = vec![0.0f64; 16];
+    for (c, col) in m.chunks_exact_mut(4).enumerate().take(3) {
+        for (row, cell) in col.iter_mut().enumerate().take(3) {
+            *cell = r[row][c];
+        }
+    }
+    m[12] = t[0];
+    m[13] = t[1];
+    m[14] = t[2];
+    m[15] = 1.0;
+    m
+}
+
+/// Multiply two row-major 3x3s.
+fn mul3(a: [[f64; 3]; 3], b: [[f64; 3]; 3]) -> [[f64; 3]; 3] {
+    let mut out = [[0.0f64; 3]; 3];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, cell) in row.iter_mut().enumerate() {
+            *cell = (0..3).map(|k| a[i][k] * b[k][j]).sum();
+        }
+    }
+    out
+}
+
+fn rot_z(deg: f64) -> [[f64; 3]; 3] {
+    let (s, c) = deg.to_radians().sin_cos();
+    [[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]]
+}
+
+fn rot_x(deg: f64) -> [[f64; 3]; 3] {
+    let (s, c) = deg.to_radians().sin_cos();
+    [[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]]
+}
+
+/// Apply a row-major 3x3 to a point.
+fn apply(r: [[f64; 3]; 3], p: [f64; 3]) -> [f64; 3] {
+    [
+        r[0][0] * p[0] + r[0][1] * p[1] + r[0][2] * p[2],
+        r[1][0] * p[0] + r[1][1] * p[1] + r[1][2] * p[2],
+        r[2][0] * p[0] + r[2][1] * p[1] + r[2][2] * p[2],
+    ]
+}
+
+/// The site-local points this file wants back out of the conversion.
+/// Deliberately asymmetric: no two components equal, none zero, and the set
+/// is not closed under any axis swap or sign flip.
+const WANT: [[f64; 3]; 3] = [[1.5, -2.25, 3.75], [-4.5, 6.25, -0.5], [8.0, 0.75, -5.5]];
+
+/// A per-mesh origin far from zero and from the site translation, so the
+/// "world point = origin + position" split is genuinely loaded on both halves.
+const ORIGIN: [f64; 3] = [123.5, -47.25, 61.75];
+
+/// Build the mesh whose world points (`origin + position`) are `WANT`
+/// forward-rotated by `r`, with `origin` itself carrying `ORIGIN` rotated the
+/// same way. Positions are then whatever is left over — that is exactly the
+/// invariant the conversion has to preserve.
+fn mesh_in_world(r: [[f64; 3]; 3]) -> MeshData {
+    let rotated_origin = apply(r, ORIGIN);
+    let mut positions = Vec::new();
+    let mut normals = Vec::new();
+    for want in WANT {
+        let world = apply(r, want);
+        positions.push((world[0] - rotated_origin[0]) as f32);
+        positions.push((world[1] - rotated_origin[1]) as f32);
+        positions.push((world[2] - rotated_origin[2]) as f32);
+        // A distinct unit normal per vertex, likewise forward-rotated.
+        let n = apply(r, unit(want));
+        normals.push(n[0] as f32);
+        normals.push(n[1] as f32);
+        normals.push(n[2] as f32);
+    }
+    MeshData::new(
+        1,
+        "IfcWall".to_string(),
+        positions,
+        normals,
+        vec![0, 1, 2],
+        [1.0, 1.0, 1.0, 1.0],
+    )
+    .with_origin(rotated_origin)
+}
+
+fn unit(p: [f64; 3]) -> [f64; 3] {
+    let l = (p[0] * p[0] + p[1] * p[1] + p[2] * p[2]).sqrt();
+    [p[0] / l, p[1] / l, p[2] / l]
+}
+
+fn assert_close(got: [f64; 3], want: [f64; 3], eps: f64, what: &str) {
+    for i in 0..3 {
+        assert!(
+            (got[i] - want[i]).abs() < eps,
+            "{what}: axis {i} got {} want {} (full got {got:?}, want {want:?})",
+            got[i],
+            want[i]
+        );
+    }
+}
+
+/// Check that every world point (`origin + position`) of the converted mesh is
+/// back at its chosen site-local value, and every normal back at its own.
+fn assert_recovers_want(mesh: &MeshData, what: &str) {
+    assert_eq!(mesh.positions.len(), WANT.len() * 3, "{what}: vertex count");
+    for (i, want) in WANT.iter().enumerate() {
+        let p = &mesh.positions[i * 3..i * 3 + 3];
+        let world = [
+            p[0] as f64 + mesh.origin[0],
+            p[1] as f64 + mesh.origin[1],
+            p[2] as f64 + mesh.origin[2],
+        ];
+        // f32 storage at coordinate magnitude ~130 (the origin) costs ~1e-5.
+        assert_close(world, *want, 2e-4, &format!("{what}: vertex {i}"));
+
+        let n = &mesh.normals[i * 3..i * 3 + 3];
+        assert_close(
+            [n[0] as f64, n[1] as f64, n[2] as f64],
+            unit(*want),
+            1e-5,
+            &format!("{what}: normal {i}"),
+        );
+    }
+}
+
+/// A yaw about Z with a NON-ZERO per-mesh origin. `site_rotation.rs` covers
+/// the yaw, but only ever with `origin == [0, 0, 0]`; this is the case that
+/// separates "rotate the vertices" from "rotate the element about the site
+/// origin".
+#[test]
+fn a_non_zero_mesh_origin_is_inverse_rotated_with_the_positions() {
+    let r = rot_z(30.0);
+    let site = column_major(r, [10.0, 20.0, 4.5]);
+    let mut mesh = mesh_in_world(r);
+
+    // The fixture must not be vacuous: the mesh really is off-origin, and its
+    // origin really is rotated away from ORIGIN.
+    assert_ne!(mesh.origin, [0.0, 0.0, 0.0], "origin must be non-zero");
+    assert_ne!(mesh.origin, ORIGIN, "origin must start rotated");
+
+    convert_mesh_to_site_local(&mut mesh, Some(&site));
+
+    assert_close(mesh.origin, ORIGIN, 1e-9, "origin returns to the site-local frame");
+    assert_recovers_want(&mesh, "yaw with non-zero origin");
+}
+
+/// An out-of-plane site rotation, so all nine 3x3 entries are non-zero and
+/// pairwise distinct. A yaw-only fixture zeroes `r02`, `r12`, `r20`, `r21`
+/// and pins `r22 = 1`, which makes the transpose in the inverse rotation
+/// unobservable on the z-coupled half of the matrix.
+#[test]
+fn an_out_of_plane_site_rotation_exercises_the_z_coupled_matrix_entries() {
+    // ZXZ Euler angles: a single Rz·Rx leaves r[2][0] exactly zero, which is
+    // one of the very entries this test exists to load. Three factors put
+    // every entry genuinely off zero and pairwise apart (asserted below).
+    let r = mul3(mul3(rot_z(25.0), rot_x(45.0)), rot_z(50.0));
+
+    // Guard the premise. A yaw-only matrix has four zero entries and a 1 on
+    // the diagonal, which is exactly why reading a z-coupled term off the
+    // wrong side of the diagonal is invisible there. Here every entry must be
+    // off zero AND no two may share a magnitude, so ANY index swap between
+    // them changes the result by far more than the tolerances below.
+    let flat: Vec<f64> = r.iter().flatten().copied().collect();
+    for (k, v) in flat.iter().enumerate() {
+        assert!(
+            v.abs() > 0.05,
+            "r[{}][{}] = {v} is too close to zero to distinguish a transpose",
+            k / 3,
+            k % 3
+        );
+    }
+    for a in 0..flat.len() {
+        for b in (a + 1)..flat.len() {
+            assert!(
+                (flat[a].abs() - flat[b].abs()).abs() > 0.05,
+                "entries {a} and {b} share a magnitude ({}, {}) -- swapping them would be invisible",
+                flat[a],
+                flat[b]
+            );
+        }
+    }
+
+    let site = column_major(r, [-500.0, 250.0, 12.5]);
+    let mut mesh = mesh_in_world(r);
+    convert_mesh_to_site_local(&mut mesh, Some(&site));
+
+    assert_close(mesh.origin, ORIGIN, 1e-9, "origin returns to the site-local frame");
+    assert_recovers_want(&mesh, "yaw + pitch");
+}
+
+/// No site transform at all: the mesh must come through untouched, including
+/// its origin. Guards the `None` arm against a mutation that rotates anyway.
+#[test]
+fn no_site_transform_leaves_the_mesh_alone() {
+    let r = rot_z(30.0);
+    let before = mesh_in_world(r);
+    let mut mesh = mesh_in_world(r);
+    convert_mesh_to_site_local(&mut mesh, None);
+    assert_eq!(mesh.positions, before.positions);
+    assert_eq!(mesh.normals, before.normals);
+    assert_eq!(mesh.origin, before.origin);
+}
+
+/// An identity rotation with a non-zero translation: the rotation arm
+/// fast-outs, and the origin must NOT be shifted by the translation — that
+/// is the RTC subtraction's job, upstream. A mutation that folded the
+/// translation column in here would move every mesh twice.
+#[test]
+fn an_identity_rotation_with_a_translation_does_not_move_the_origin() {
+    let identity = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+    let site = column_major(identity, [10.0, 20.0, 4.5]);
+    let before = mesh_in_world(identity);
+    let mut mesh = mesh_in_world(identity);
+    convert_mesh_to_site_local(&mut mesh, Some(&site));
+    assert_eq!(mesh.origin, before.origin, "translation is handled upstream, not here");
+    assert_eq!(mesh.positions, before.positions);
+    assert_eq!(mesh.normals, before.normals);
+}


### PR DESCRIPTION
Round two of the blind-fixture sweep, into `rust/export` and `rust/processing` — where a wrong answer writes a bad file rather than a bad render. **Nine mutations run across 22 fixtures; four sites were blind.**

**No production bug found**, same as round one. In all four the code is correct and only the fixture could not see it.

## 1. Schema conversion — the Rust port was untested where the TS twin was covered

`rust/export/src/schema_convert.rs`. The only `2X3 → 4` case was `IFCWALL`, a type **unchanged in every schema**; the direct `4X3 → 4` arm was only ever reached by types it does not rename.

Replacing each rename arm with a pass-through left the whole `ifc-lite-export` suite green — and **un-renamed output is an invalid file**: `IFCELECTRICDISTRIBUTIONPOINT`, `IFCGASTERMINALTYPE` and `IFCEQUIPMENTELEMENT` do not exist in IFC4.

Both directions *are* covered by the TS twin `packages/export/src/schema-converter.test.ts`. The Rust port — the one the CLI, the server and wasm actually run — was not. Two tests now cover the full 2X3→4 table, the 4X3→4 and IFC5→4 arms, and `canon`'s IFC5/IFCX branch, which nothing in the crate had exercised.

## 2. Site-local frame conversion — the widest one

`rust/processing/src/processor/site_local.rs`, two independent symmetries:

**(a)** The fixture's coordinates are small, so every mesh has `origin == [0,0,0]` and `apply_inverse_rotation_point_f64` early-returns every time. Replacing that function's body with an immediate `return` — deleting the correction its own comment calls load-bearing, *"otherwise the element would be rotated about the wrong centre"* — left **the entire `ifc-lite-processing` suite** green.

**(b)** The only site rotation exercised anywhere is a yaw about Z, which zeroes `r02/r12/r20/r21` and pins `r22 = 1`. Swapping `column_major_matrix[2]` with `[8]` — reading the z-coupled terms off the wrong side of the diagonal — also left the entire suite green.

New `rust/processing/tests/site_local_frame_rotation.rs` drives the public `convert_mesh_to_site_local` directly, with expectations built from the **other direction** — a chosen site-local point forward-rotated to make the input — so no production indexing is reused as its own oracle.

## 3. Federated export — the canonical project redirect

`rust/export/src/merged.rs`. Every two-model fixture gives both models an `IfcProject` at the **same** express id (`#1`, or literally the same file merged twice), so `canonical_project` and the model's own `model_project` are always equal.

`return Some(cp)` → `return Some(mp)` left all 12 tests green. The new fixture puts the projects at `#1` and `#7`, each referenced by its own model.

## 4. Minted-GlobalId distinctness

Same file. Every fixture collides at most **one** entity per model, so neither guard keeping two identically-seeded minted ids apart is exercised. Deleting `pending.insert(candidate)`, deleting `emitted_guids.insert(fresh)`, and deleting **both** — which really does emit the same GlobalId three times — all left the suite green.

A model carrying the same GlobalId on three entities now asserts every emitted leading GlobalId is distinct. **Honest caveat, written into the test doc:** the two guards are redundant with each other, so this pins the observable invariant rather than either line.

## Cleared, with the mutation that died

`rust/clash`'s `contains_point`: flipping the parity test `crossings & 1 == 1` → `crossings > 0` is killed by `contains_point_agrees_with_a_brute_force_scan_over_every_triangle`, which compares against an independent exhaustive scan over 20,000 probes plus every vertex nudged ±1e-9. Genuinely discriminating; nothing added.

## Read but not mutation-tested, reported as such

`step_cow.rs` (15 dedicated fixtures, no obvious symmetry); `model_inherit_tests.rs`, `frame_tests.rs`, `clash/kernel_tests.rs` (already carry explicit "Kills:" annotations from an earlier sweep).

One thing noticed by reading only: **`yup_matrix4`'s translation column is asserted by no test** — the bottom-row test sets a translation but checks only row 3. Not a live defect, since `scene_root`, its only caller, reads the rotation part and ignores the translation. Flagged rather than acted on.

## Not reached, and why

`packages/create`, `packages/clash` and `packages/parser`. This worktree has no `node_modules`, and an un-installed cross-package `@ifc-lite/*` import silently resolves to the **main checkout's** source — so a run could not be trusted. Rather than install and risk contaminated results, the budget went into depth on the Rust side. Those three remain unswept.

`cargo test -p ifc-lite-export`, `-p ifc-lite-processing`, `-p ifc-lite-clash` all green; clippy `-D warnings` clean; `module_size_ratchet` green with `schema_convert.rs` at 336 lines, no allowlist or digest touched. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for merged STEP exports, including project reference redirection and duplicate GlobalId handling.
  * Added schema conversion tests for type renaming across IFC versions and canonical identity behavior.
  * Added coverage for site-local mesh transformations, including rotations, translations, normals, and no-transform scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->