### PR TITLE
ci: verify fixtures in every workflow that caches them

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -126,6 +126,13 @@ jobs:
       - name: Fetch benchmark fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: node scripts/fixtures/fetch-fixtures.mjs "ara3d/AC20-FZK-Haus.ifc" "various/01_Snowdon_Towers_Sample_Structural(1).ifc"
+      # Unconditional, unlike the fetch above; see the rust-tests job in
+      # test.yml. Scoped to the same two files, because this cache namespace
+      # only ever holds them and a full --check would red the lane for 162
+      # fixtures it never wanted. `ONLY` is applied before `CHECK_ONLY`, so the
+      # file arguments narrow the check as well as the fetch.
+      - name: Verify benchmark fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check "ara3d/AC20-FZK-Haus.ifc" "various/01_Snowdon_Towers_Sample_Structural(1).ifc"
 
       # Production build: `vite preview` (the benchmark's webServer) serves
       # apps/viewer/dist. Turbo builds the workspace deps it needs.

--- a/.github/workflows/determinism.yml
+++ b/.github/workflows/determinism.yml
@@ -86,6 +86,10 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+      # Unconditional, unlike the fetch above; see the note in test.yml's
+      # rust-tests job for why a cache hit needs its own check.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
 
       # exact_predicate_determinism pins exact-predicate signs across
       # platforms; geometry_correctness_harness asserts the committed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -464,6 +464,10 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+      # Unconditional, unlike the fetch above; see the rust-tests job for why
+      # a cache hit still needs its own check.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
       # Run the package script DIRECTLY, not through turbo. Two reasons, both
       # measured rather than assumed:
       #
@@ -540,6 +544,10 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+      # Unconditional, unlike the fetch above; see the rust-tests job for why
+      # a cache hit still needs its own check.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
       - name: Check test wiring
         run: node scripts/check-test-wiring.mjs
       # typecheck-tests.mjs writes the `extends` of every generated test
@@ -825,6 +833,10 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+      # Unconditional, unlike the fetch above; see the rust-tests job for why
+      # a cache hit still needs its own check.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
       # Package dists come from the build artifact; the wasm build
       # soft-skips (no wasm-pack on this runner) and reuses the artifact
       # runtime, so this is just the vite build of the app.
@@ -883,6 +895,25 @@ jobs:
         # The fixtures script is pure Node (no npm deps) so we skip the
         # pnpm install dance Rust-only jobs don't need.
         run: node scripts/fixtures/fetch-fixtures.mjs
+      # Unconditional, unlike the fetch above. The fetch is gated on a cache
+      # MISS, so a cache entry restores tests/models and nothing re-checks it.
+      #
+      # `IFC_LITE_REQUIRE_FIXTURES=1` already turns a MISSING fixture into a
+      # panic, but only for `rust/export`: it is the one crate that reads the
+      # variable, and 32 test files under rust/geometry and rust/processing
+      # carry their own silent-skip helpers that never consult it.
+      #
+      # And the variable catches absence only. `fixture_opt` panics on
+      # `ErrorKind::NotFound` specifically, so a present-but-wrong file --
+      # truncated, or a Git LFS pointer -- returns `Some(bytes)` and the test
+      # asserts against garbage. `--check` compares size and sha256, which is
+      # the class the variable cannot see.
+      #
+      # If this step fires on CI the cache entry is poisoned, and it will keep
+      # firing: actions/cache does not re-save on a primary-key hit. Purge it
+      # with `gh cache delete`; running `pnpm fixtures` locally will not help.
+      - name: Verify fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check
       # Cheap (resolve only, no compile) and it catches a failure mode that
       # otherwise stays invisible for weeks: a release bumps the manifests but
       # leaves Cargo.lock recording the old member versions, so every `--locked`
@@ -980,6 +1011,22 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: node scripts/fixtures/fetch-fixtures.mjs
+      # Unconditional, unlike the fetch above; see the rust-tests job for why
+      # a cache hit still needs its own check.
+      #
+      # triangulation_invariance.rs:136 documents a tolerance on purpose ("so a
+      # single failed fixture fetch does not red the build"). Be precise about
+      # what this actually removes: on the cache-MISS path that tolerance was
+      # already dead, because fetch-fixtures.mjs collects per-entry errors and
+      # exits 1. Only the cache-HIT path is newly covered.
+      #
+      # Wider than that phrasing suggests, and deliberate: --check gates all 164
+      # manifest entries while the census sweeps 111 models, so a fixture the
+      # census never reads can now red a 45-minute lane. Fail-fast at second 5
+      # beats a census whose floors were silently computed over a smaller
+      # population, but it is a real widening, not a no-op.
+      - name: Verify fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check
       - name: Census
         run: cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance -- --nocapture
       # The per-host rows this run measured, uploaded pass or fail. The census


### PR DESCRIPTION
Eight fixture-caching jobs fetched fixtures. Only `build` checked they arrived.

```
test.yml         build              Fetch -> Verify
test.yml         viewer-tests       Fetch -> (none)
test.yml         node-tests         Fetch -> (none)
test.yml         viewer-e2e         Fetch -> (none)
test.yml         rust-tests         Fetch -> (none)
test.yml         geometry-census    Fetch -> (none)
determinism.yml  arm64-determinism  Fetch -> (none)
benchmark.yml    benchmark          Fetch -> (none)
```

The fetch is gated on a cache **miss**, so a cache entry restores `tests/models` and nothing re-checks it. `actions/cache` does not re-save on a primary-key hit, so a poisoned entry stays poisoned until the manifest hash changes.

## My first rationale was wrong, and the real one is narrower

I originally justified this with "a missing fixture makes the test report as PASSED". Review showed that is **false** for the jobs I attached it to: `IFC_LITE_REQUIRE_FIXTURES: "1"` is set at `test.yml:906` and `:921`, and `test_support.rs` turns a missing fixture into a panic under it.

Overstating a gap is the same defect as understating one. Two reasons that do hold:

**It covers one crate.** `rust/export/src/test_support.rs` is the only file that reads the variable — 1 file in `rust/export`, **0** in `rust/geometry`, **0** in `rust/processing` — while 32 test files across those two crates carry their own silent-skip helpers that never consult it.

**It catches absence, never corruption.** `fixture_opt` panics on `ErrorKind::NotFound` *specifically* (`test_support.rs:88-105`), so a present-but-wrong file — truncated, or a Git LFS pointer, which `streaming_rtc_late_site.rs:52` hand-checks for — returns `Some(bytes)` and the test asserts against garbage. `--check` compares size and sha256, which is the class the variable structurally cannot see.

## Verified rather than assumed

```
present   exit 0   "all 164 fixtures present and verified"
absent    exit 1   "fixtures missing or out of date: 164 of 164"
```

Cost measured, not estimated: **0.45–0.46s** over three runs for 164 fixtures / 1.09 GB. `--check` returns before any `fetch()` (`fetch-fixtures.mjs:137`), so it is local hashing with no network.

Unconditional on purpose — gating on `cache-hit == 'true'` would check only the path already known good.

## benchmark.yml gets a scoped check, not an exclusion

My first pass excluded it alongside `moonshot.yml` and `xmatch-fixture.yml`, on the grounds that a full `fixtures:check` would red a lane holding 2 of 164 fixtures. True of a bare `--check`, and the wrong conclusion: `ONLY` is applied to `entries` **before** `CHECK_ONLY`, so passing the same two file arguments narrows the check exactly as it narrows the fetch.

```
all 2 fixtures present and verified          exit 0
fixtures missing or out of date: 2 of 2      exit 1
```

The other two stay excluded and that reason does hold — both already drop the `if:` so the fetcher is simultaneously fetch and integrity check (`moonshot.yml:243` says so). `benchmark.yml` did neither, which made it **the only fixture-caching workflow in the repo with no protection at all**. The paragraph justifying the exclusion was carrying one case it did not describe.

## What geometry-census actually loses

`triangulation_invariance.rs:136` documents a tolerance on purpose ("so a single failed fixture fetch does not red the build"). Being precise about what this removes:

- On the cache-**miss** path that tolerance was already dead — `fetch-fixtures.mjs` collects per-entry errors and exits 1. Only the cache-**hit** path is newly covered.
- `--check` gates all 164 manifest entries while the census sweeps 111 models, so a fixture the census never reads can now red a 45-minute lane.

Deliberate, and wider than "a corpus short a fixture". Recorded in a comment there rather than left as a side effect.

## Context

Found while reviewing #2901, which adds a fixture-free twin of one Rust test and closes the local half of this. That PR stands on its own; this closes the CI half for every caching workflow at once.

Same family as the other absence-reads-as-success faults this repo keeps finding, one layer down in the tooling: nothing distinguished "the fixture corpus is fine" from "there is no corpus".