### PR TITLE
ci: verify the fixture cache instead of trusting a cache hit

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -127,6 +127,12 @@ jobs:
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: node scripts/fixtures/fetch-fixtures.mjs "ara3d/AC20-FZK-Haus.ifc" "various/01_Snowdon_Towers_Sample_Structural(1).ifc"
 
+      # Unconditional — the fetch above is gated on a cache miss, so on a cache
+      # hit nothing had ever confirmed the restored tree still matches the
+      # manifest. Scoped to the same two paths: this cache holds only those.
+      - name: Verify benchmark fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check "ara3d/AC20-FZK-Haus.ifc" "various/01_Snowdon_Towers_Sample_Structural(1).ifc"
+
       # Production build: `vite preview` (the benchmark's webServer) serves
       # apps/viewer/dist. Turbo builds the workspace deps it needs.
       - name: Build viewer app

--- a/.github/workflows/determinism.yml
+++ b/.github/workflows/determinism.yml
@@ -87,6 +87,12 @@ jobs:
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
 
+      # Unconditional — the fetch above is gated on a cache miss, so on a cache
+      # hit nothing had ever confirmed the restored tree still matches the
+      # manifest. A partial cache made fixture-gated tests skip and report ok.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
+
       # exact_predicate_determinism pins exact-predicate signs across
       # platforms; geometry_correctness_harness asserts the committed
       # x86_64-generated .snap files byte-for-byte against the pure-Rust

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -464,6 +464,13 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+
+      # Unconditional — this is the point of the step. The fetch above is
+      # gated on a cache miss, so on a cache hit nothing had ever confirmed the
+      # restored tree still matches the manifest. A partial or corrupted cache
+      # then made every fixture-gated test skip silently and report ok.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
       # Run the package script DIRECTLY, not through turbo. Two reasons, both
       # measured rather than assumed:
       #
@@ -540,6 +547,13 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+
+      # Unconditional — this is the point of the step. The fetch above is
+      # gated on a cache miss, so on a cache hit nothing had ever confirmed the
+      # restored tree still matches the manifest. A partial or corrupted cache
+      # then made every fixture-gated test skip silently and report ok.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
       - name: Check test wiring
         run: node scripts/check-test-wiring.mjs
       # typecheck-tests.mjs writes the `extends` of every generated test
@@ -825,6 +839,13 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: pnpm fixtures
+
+      # Unconditional — this is the point of the step. The fetch above is
+      # gated on a cache miss, so on a cache hit nothing had ever confirmed the
+      # restored tree still matches the manifest. A partial or corrupted cache
+      # then made every fixture-gated test skip silently and report ok.
+      - name: Verify fixtures
+        run: pnpm fixtures:check
       # Package dists come from the build artifact; the wasm build
       # soft-skips (no wasm-pack on this runner) and reuses the artifact
       # runtime, so this is just the vite build of the app.
@@ -883,6 +904,13 @@ jobs:
         # The fixtures script is pure Node (no npm deps) so we skip the
         # pnpm install dance Rust-only jobs don't need.
         run: node scripts/fixtures/fetch-fixtures.mjs
+
+      # Unconditional — this is the point of the step. The fetch above is
+      # gated on a cache miss, so on a cache hit nothing had ever confirmed the
+      # restored tree still matches the manifest. A partial or corrupted cache
+      # then made every fixture-gated test skip silently and report ok.
+      - name: Verify fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check
       # Cheap (resolve only, no compile) and it catches a failure mode that
       # otherwise stays invisible for weeks: a release bumps the manifests but
       # leaves Cargo.lock recording the old member versions, so every `--locked`
@@ -980,6 +1008,13 @@ jobs:
       - name: Fetch fixtures
         if: steps.fixtures-cache.outputs.cache-hit != 'true'
         run: node scripts/fixtures/fetch-fixtures.mjs
+
+      # Unconditional — this is the point of the step. The fetch above is
+      # gated on a cache miss, so on a cache hit nothing had ever confirmed the
+      # restored tree still matches the manifest. A partial or corrupted cache
+      # then made every fixture-gated test skip silently and report ok.
+      - name: Verify fixtures
+        run: node scripts/fixtures/fetch-fixtures.mjs --check
       - name: Census
         run: cargo test -p ifc-lite-geometry --features triangulation-alt --test triangulation_invariance -- --nocapture
       # The per-host rows this run measured, uploaded pass or fail. The census

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -715,6 +715,18 @@ jobs:
       # file — the three ways it could otherwise wave a package through.
       - name: Check test-glob-coverage gate regressions
         run: node --test scripts/check-test-glob-coverage.test.mjs
+      # `fetch-fixtures.mjs --check` is the step every fixture-consuming job now
+      # runs unconditionally after its cache-gated fetch, so it is a gate about
+      # a gate: if IT can pass over nothing, it is worse than absent, because it
+      # also buys silence. These cases drive the unmodified script against
+      # synthetic corpora and assert it reds — naming the offending path — for a
+      # fixture that is absent, byte-flipped at the same size, or truncated, and
+      # for each way of verifying nothing: no manifest, an unparseable one, one
+      # listing zero files, and a scoped `--check a.ifc b.ifc` naming a path the
+      # manifest no longer lists. Positive controls keep it from being switched
+      # off for redding a healthy tree.
+      - name: Check the fixture-cache verification cannot pass vacuously
+        run: node --test scripts/fixtures/fetch-fixtures.test.mjs
       # The steps above name each scripts/ test file one by one, which is
       # itself the trap check-test-glob-coverage.mjs exists to catch: the file
       # that shipped that gate was the one entry nobody added, so a gate for
@@ -723,8 +735,10 @@ jobs:
       # closes it by GLOB, so the next script's tests run on the commit that
       # adds them. The named steps above stay for their comments and for
       # per-gate attribution; re-running them here costs a few seconds.
+      # scripts/fixtures/ is in the glob because it was NOT: the first test file
+      # under it would have been added, run locally, and then never run again.
       - name: Run every scripts/ test file (glob catch-all)
-        run: node --test scripts/*.test.mjs scripts/lib/*.test.mjs
+        run: node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/scripts/fixtures/fetch-fixtures.mjs
+++ b/scripts/fixtures/fetch-fixtures.mjs
@@ -113,12 +113,24 @@ function resolveFixturePath(relPath) {
 
 let entries = manifest.files;
 if (ONLY.length) {
-  const wanted = new Set(ONLY.map((p) => p.replace(/^tests\/models\//, '')));
-  entries = entries.filter((f) => wanted.has(f.path));
-  if (!entries.length) {
-    console.error(`error: none of the requested paths are in the manifest`);
+  const wanted = ONLY.map((p) => p.replace(/^tests\/models\//, ''));
+  const known = new Set(manifest.files.map((f) => f.path));
+  // A requested path the manifest does not list is a hard error, not a silent
+  // narrowing. Filtering it away made `--check a.ifc b.ifc` report "all 1
+  // fixtures present and verified" after a rename dropped `b.ifc` from the
+  // manifest — a green gate over a corpus the caller never actually got. The
+  // fetch form was worse: it downloaded nothing for the renamed path and still
+  // exited 0, so the job ran against whatever the cache happened to hold.
+  const unknown = wanted.filter((p) => !known.has(p));
+  if (unknown.length) {
+    for (const p of unknown) {
+      console.error(`error: ${p} is not listed in ${MANIFEST_PATH}`);
+    }
+    console.error(`requested paths not in the manifest: ${unknown.length} of ${wanted.length}`);
     process.exit(2);
   }
+  const wantedSet = new Set(wanted);
+  entries = entries.filter((f) => wantedSet.has(f.path));
 }
 
 async function sha256OfFile(path) {

--- a/scripts/fixtures/fetch-fixtures.mjs
+++ b/scripts/fixtures/fetch-fixtures.mjs
@@ -58,7 +58,16 @@ if (!existsSync(MANIFEST_PATH)) {
   process.exit(2);
 }
 
-const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+// Read and parse defensively: an unreadable or truncated manifest must fail
+// with a message that names the file, not with a raw JSON.parse stack trace
+// that a CI reader has to decode.
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+} catch (err) {
+  console.error(`error: ${MANIFEST_PATH} could not be read as JSON: ${err.message}`);
+  process.exit(2);
+}
 if (!manifest || typeof manifest !== 'object') {
   console.error(`error: ${MANIFEST_PATH} is not a JSON object`);
   process.exit(2);
@@ -69,6 +78,14 @@ if (manifest.version !== 1) {
 }
 if (!Array.isArray(manifest.files)) {
   console.error(`error: ${MANIFEST_PATH} is missing a "files" array`);
+  process.exit(2);
+}
+// An empty corpus would make --check succeed vacuously ("all 0 fixtures
+// present"), which is exactly the silence this script exists to break: every
+// fixture_or_skip! test would then no-op and still report ok. A manifest that
+// lists nothing is a broken manifest, not an empty-but-valid one.
+if (manifest.files.length === 0) {
+  console.error(`error: ${MANIFEST_PATH} lists no files — the manifest is empty or truncated`);
   process.exit(2);
 }
 
@@ -112,18 +129,27 @@ async function sha256OfFile(path) {
 
 function classify(entry) {
   const abs = resolveFixturePath(entry.path);
-  if (!existsSync(abs)) return { state: 'missing', abs };
+  if (!existsSync(abs)) {
+    return { state: 'missing', abs, reason: 'missing from tests/models/' };
+  }
   const st = statSync(abs);
   // LFS pointer files are always small; skip the hash if size mismatches.
-  if (st.size !== entry.size) return { state: 'mismatch', abs };
+  if (st.size !== entry.size) {
+    return {
+      state: 'mismatch',
+      abs,
+      reason: `size mismatch: manifest says ${entry.size} bytes, on disk ${st.size}`,
+    };
+  }
   return { state: 'unchecked', abs };
 }
 
 async function fetchOne(entry) {
   let abs;
   let state;
+  let reason;
   try {
-    ({ abs, state } = classify(entry));
+    ({ abs, state, reason } = classify(entry));
   } catch (err) {
     return { entry, action: 'error', error: err };
   }
@@ -132,10 +158,11 @@ async function fetchOne(entry) {
     if (got === entry.sha256) {
       return { entry, action: 'skip' };
     }
+    reason = `sha256 mismatch: manifest says ${entry.sha256}, on disk ${got}`;
   }
 
   if (CHECK_ONLY || LIST_ONLY) {
-    return { entry, action: 'needed' };
+    return { entry, action: 'needed', reason };
   }
 
   mkdirSync(dirname(abs), { recursive: true });
@@ -235,6 +262,14 @@ if (LIST_ONLY) {
 
 if (CHECK_ONLY) {
   if (needed || errors.length) {
+    // Name every offender. "verification failed: 3 of 164" sends the reader
+    // back to the manifest to work out which three; a CI log that names the
+    // path and says missing / wrong size / wrong hash does not.
+    for (const r of results) {
+      if (r.action === 'needed') {
+        console.error(`error: tests/models/${r.entry.path}: ${r.reason}`);
+      }
+    }
     if (needed) {
       console.error(`fixtures missing or out of date: ${needed} of ${entries.length}`);
       console.error('run: pnpm fixtures');

--- a/scripts/fixtures/fetch-fixtures.test.mjs
+++ b/scripts/fixtures/fetch-fixtures.test.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for `fetch-fixtures.mjs --check`, the step every fixture-consuming CI
+ * job runs unconditionally after its cache-gated fetch.
+ *
+ * Why this file exists. The fetch is gated on a cache MISS, so on a cache HIT
+ * nothing confirmed the restored `tests/models/` still matched the manifest.
+ * A partial or corrupted cache then turned every `fixture_or_skip!` test into
+ * a no-op that printed a skip line and reported ok. `--check` closes that —
+ * which makes it a gate about a gate, and a gate that can itself pass over
+ * nothing is worth less than no gate at all, because it also buys silence.
+ *
+ * So two directions are under test:
+ *
+ *   1. It must go RED for each way a cache hit can be wrong, and NAME the
+ *      offender: absent from disk, right size but wrong bytes, wrong size.
+ *      "3 of 164" sends the reader back to the manifest to work out which
+ *      three; the path plus the reason does not.
+ *   2. It must not report success having verified nothing. A manifest that is
+ *      absent, unparseable, or lists zero files makes the per-entry loop
+ *      iterate over an empty set, so `needed` is 0 because nothing was
+ *      examined. Each must exit non-zero. So must a scoped invocation
+ *      (`--check a.ifc b.ifc`, as benchmark.yml uses) naming a path the
+ *      manifest does not list: filtering it away silently reported "all 1
+ *      fixtures present and verified" over a corpus one file short.
+ *
+ * The passing cases exist to hold (2) honest: a check that reds a healthy tree
+ * gets switched off, which is worse than the vacuity it closes.
+ *
+ * Each case builds a synthetic repo root under a temp dir — a copy of the real
+ * script (it resolves `tests/models/` relative to its own location, so a copy
+ * is how you point it at a synthetic corpus) plus a hand-written manifest and
+ * a few small files. `--check` never fetches, so nothing here touches the
+ * network.
+ *
+ * Run: node --test scripts/fixtures/fetch-fixtures.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, 'fetch-fixtures.mjs');
+
+const sha256 = (buf) => createHash('sha256').update(buf).digest('hex');
+
+/**
+ * Build a synthetic repo root: a copy of the real fetcher at
+ * `<root>/scripts/fixtures/`, a manifest at `<root>/tests/models/`, and
+ * whatever files `onDisk` names. Returns the root; the caller removes it.
+ *
+ * @param {object} opts
+ * @param {string[]} opts.fixtures      manifest-relative paths to manifest
+ * @param {Record<string,string>} [opts.onDisk]  path -> exact bytes to write
+ * @param {unknown} [opts.manifest]     raw manifest override (object)
+ * @param {string} [opts.manifestText]  raw manifest bytes (wins over both)
+ * @param {boolean} [opts.noManifest]   write no manifest at all
+ */
+function makeRoot(opts) {
+  const root = mkdtempSync(join(tmpdir(), 'fixcheck-'));
+  const scriptDir = join(root, 'scripts', 'fixtures');
+  const modelsDir = join(root, 'tests', 'models');
+  mkdirSync(scriptDir, { recursive: true });
+  mkdirSync(modelsDir, { recursive: true });
+  copyFileSync(SCRIPT, join(scriptDir, 'fetch-fixtures.mjs'));
+
+  // Canonical contents for every manifested fixture. The manifest records the
+  // hash and size of THESE, so a test that writes something else on disk is
+  // writing a corrupted cache entry.
+  const canonical = new Map(
+    (opts.fixtures ?? []).map((p) => [p, Buffer.from(`ISO-10303-21;\n/* ${p} */\nEND-ISO-10303-21;\n`)]),
+  );
+
+  const files = [...canonical].map(([path, buf]) => ({
+    path,
+    sha256: sha256(buf),
+    size: buf.length,
+  }));
+
+  // `onDisk` defaults to the canonical bytes for every manifested fixture —
+  // i.e. a healthy cache. Tests override entries to corrupt or drop them.
+  const onDisk = opts.onDisk ?? Object.fromEntries([...canonical].map(([p, b]) => [p, b]));
+  for (const [path, contents] of Object.entries(onDisk)) {
+    const abs = join(modelsDir, path);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, contents);
+  }
+
+  if (!opts.noManifest) {
+    const text =
+      opts.manifestText ??
+      JSON.stringify(
+        opts.manifest ?? { version: 1, base_url: 'https://example.invalid/fixtures', files },
+        null,
+        2,
+      );
+    writeFileSync(join(modelsDir, 'manifest.json'), text);
+  }
+  return root;
+}
+
+/** Run `--check` (plus any scoped paths) inside a synthetic root. */
+function check(root, ...paths) {
+  const res = spawnSync(
+    process.execPath,
+    [join(root, 'scripts', 'fixtures', 'fetch-fixtures.mjs'), '--check', ...paths],
+    { encoding: 'utf8' },
+  );
+  return { status: res.status, out: `${res.stdout}${res.stderr}` };
+}
+
+/** Assert non-zero exit and that every fragment appears in the output. */
+function assertRed({ status, out }, ...fragments) {
+  assert.notEqual(status, 0, `expected a non-zero exit, got ${status}. Output:\n${out}`);
+  for (const f of fragments) {
+    assert.ok(out.includes(f), `expected output to mention ${JSON.stringify(f)}. Output:\n${out}`);
+  }
+}
+
+// --- direction 1: every way a cache hit can be wrong, named ----------------
+
+test('a fixture absent from the restored tree is named', () => {
+  const root = makeRoot({
+    fixtures: ['ara3d/a.ifc', 'various/b.ifc'],
+    onDisk: { 'ara3d/a.ifc': 'ISO-10303-21;\n/* ara3d/a.ifc */\nEND-ISO-10303-21;\n' },
+  });
+  try {
+    const r = check(root);
+    assertRed(r, 'tests/models/various/b.ifc', 'missing from tests/models/', '1 of 2');
+    // The healthy one must not be reported as an offender.
+    assert.ok(!r.out.includes('tests/models/ara3d/a.ifc'), r.out);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a right-sized but byte-flipped fixture is named as a hash mismatch', () => {
+  // The case presence-only checking cannot see, and the one a truncated or
+  // half-written cache entry most resembles once the size happens to match.
+  const good = 'ISO-10303-21;\n/* ara3d/a.ifc */\nEND-ISO-10303-21;\n';
+  const flipped = good.replace('/* ara3d/a.ifc */', '/* ara3d/X.ifc */');
+  assert.equal(flipped.length, good.length, 'the fixture for this test must keep the size equal');
+  const root = makeRoot({ fixtures: ['ara3d/a.ifc'], onDisk: { 'ara3d/a.ifc': flipped } });
+  try {
+    assertRed(check(root), 'tests/models/ara3d/a.ifc', 'sha256 mismatch', sha256(Buffer.from(good)));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a truncated fixture is named as a size mismatch', () => {
+  const good = 'ISO-10303-21;\n/* ara3d/a.ifc */\nEND-ISO-10303-21;\n';
+  const root = makeRoot({ fixtures: ['ara3d/a.ifc'], onDisk: { 'ara3d/a.ifc': good.slice(0, 10) } });
+  try {
+    assertRed(check(root), 'tests/models/ara3d/a.ifc', 'size mismatch', '10');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// --- direction 2: no way to tick having verified nothing -------------------
+
+test('an empty tests/models under a cache hit reds, naming every entry', () => {
+  const root = makeRoot({ fixtures: ['ara3d/a.ifc', 'various/b.ifc'], onDisk: {} });
+  try {
+    assertRed(check(root), 'tests/models/ara3d/a.ifc', 'tests/models/various/b.ifc', '2 of 2');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a manifest listing zero files reds instead of "all 0 fixtures verified"', () => {
+  const root = makeRoot({
+    fixtures: [],
+    manifest: { version: 1, base_url: 'https://example.invalid/fixtures', files: [] },
+  });
+  try {
+    assertRed(check(root), 'lists no files');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an unparseable manifest reds with the path, not a JSON.parse stack', () => {
+  const root = makeRoot({ fixtures: [], manifestText: '{"version":1,"files":[' });
+  try {
+    const r = check(root);
+    assertRed(r, 'manifest.json', 'could not be read as JSON');
+    assert.ok(!r.out.includes('at JSON.parse'), `expected no raw stack trace. Output:\n${r.out}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a missing manifest reds', () => {
+  const root = makeRoot({ fixtures: [], noManifest: true });
+  try {
+    assertRed(check(root), 'manifest.json', 'not found');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a scoped check naming a path the manifest does not list reds', () => {
+  // benchmark.yml checks two literal paths. Filtering an unknown path away
+  // let a manifest rename shrink the checked set in silence — the check ticked
+  // over a corpus the job never received.
+  const root = makeRoot({ fixtures: ['ara3d/a.ifc'] });
+  try {
+    assertRed(check(root, 'ara3d/a.ifc', 'various/renamed.ifc'), 'various/renamed.ifc', 'not listed in');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// --- positive controls: a healthy tree must stay green ---------------------
+
+test('a complete corpus passes and says how many it verified', () => {
+  const root = makeRoot({ fixtures: ['ara3d/a.ifc', 'various/b.ifc'] });
+  try {
+    const r = check(root);
+    assert.equal(r.status, 0, r.out);
+    assert.ok(r.out.includes('all 2 fixtures present and verified'), r.out);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a scoped check over known paths passes', () => {
+  const root = makeRoot({ fixtures: ['ara3d/a.ifc', 'various/b.ifc'] });
+  try {
+    const r = check(root, 'ara3d/a.ifc', 'tests/models/various/b.ifc');
+    assert.equal(r.status, 0, r.out);
+    assert.ok(r.out.includes('all 2 fixtures present and verified'), r.out);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
`test.yml` fetches fixtures **gated on a cache miss**. On a cache hit nothing verifies the cached directory contains what the manifest lists — so every `fixture_or_skip!` test, and the fifteen hand-rolled equivalents, no-op silently while reporting `ok`.

The step that sets `IFC_LITE_REQUIRE_FIXTURES=1` says in its own comment that a missing fixture there is *"fixture drift, not a legitimate local skip"*. The cache-hit path is how that guarantee is lost.

## It hashes, and that is what catches a bad cache hit

Full sha256 with a size pre-filter. Three REDs, verbatim:

```
error: …hello-wall-add-fire-rating-30.ifcx: missing from tests/models/
fixtures missing or out of date: 1 of 164

error: …hello-wall-add-fire-rating-60.ifcx: size mismatch: manifest says 631 bytes, on disk 400

error: …hello-wall-add-specific-fire-rating.ifcx: sha256 mismatch:
  manifest says cc18df60…, on disk b0820be2…
```

The third is one byte flipped with the size unchanged — the shape presence-checking would miss, and exactly what a truncated or corrupted cache looks like.

**Cost, measured rather than estimated:** 164 files, **1.016 GiB**, **0.81 s** wall clock (~1.8 GB/s, hardware SHA-256, six workers, warm cache). Colder on a runner and disk-bound there, still single-digit seconds against jobs that run for minutes.

## The branch's own failure mode, found inside the fix

The scoped form — the one `benchmark.yml` uses — **silently dropped a requested path the manifest does not list**:

```
$ node scripts/fixtures/fetch-fixtures.mjs --check "ara3d/AC20-FZK-Haus.ifc" "various/DOES-NOT-EXIST.ifc"
all 1 fixtures present and verified
exit=0
```

The plain fetch form was worse: it downloaded nothing for that path and exited 0. So a manifest rename would have shrunk the benchmark's corpus to one file with a green check over it — a gate against silent no-ops, silently no-opping.

Now a hard error naming each offender, exit 2. Every call site's paths were verified against the manifest first — `benchmark.yml` ×2, `moonshot.yml` ×2, `xmatch-fixture.yml` ×3, and four doc invocations including the `tests/models/`-prefixed form — so nothing existing reds.

## It cannot pass vacuously

| case | result |
|---|---|
| `tests/models/` gone entirely | `manifest.json not found`, exit 2 |
| manifest present, tree empty — the realistic bad cache hit | 164 named offenders, exit 1 |
| `files: []` | `lists no files — the manifest is empty or truncated`, exit 2 |
| truncated JSON | `could not be read as JSON: Unexpected end of JSON input`, exit 2 |
| `chmod 000` | `could not be read as JSON: EACCES`, exit 2 |

## Nothing tested any of this

Added `scripts/fixtures/fetch-fixtures.test.mjs` — 10 hermetic cases, synthetic corpora, no network. Every assertion mutation-checked: reverting to presence-only, deleting the per-offender naming loop, the empty-manifest guard, the JSON `try`/`catch`, and the unlisted-path guard each kill exactly the tests written for them, with the positive controls surviving.

And the CI glob was `scripts/*.test.mjs scripts/lib/*.test.mjs` — **`scripts/fixtures/` was not in it**, so the new file would have run once and never again. Glob extended, named step added. `node --test` over all three → **146 pass, 0 fail**.

## Placement, re-parsed from YAML rather than eyeballed

All 13 workflow files parsed with the `yaml` package. Every `Verify` step sits immediately after that job's cache-gated `Fetch`, is unconditional, and every one of those jobs already had a `fixtures-cache` step — **no step was added to a job that does not need fixtures.**

| file | job | `if:` |
|---|---|---|
| test.yml | build *(pre-existing)* | `rust \|\| frontend` |
| test.yml | viewer-tests · node-tests | `frontend \|\| rust` |
| test.yml | viewer-e2e | `(frontend \|\| rust) && pull_request` |
| test.yml | rust-tests | `rust` |
| test.yml | geometry-census | `geometry && pull_request` |
| determinism.yml | arm64-determinism | none (cron/dispatch) |
| benchmark.yml | benchmark | none, scoped to its 2 paths |

The other fixture-consuming jobs — `ifcopenshell-parity/full`, `moonshot/standing-evidence`, `xmatch-fixture` — run their fetch **unconditionally**, which is fetch-and-verify in one, so they have no cache-hit hole and are correctly left alone.

Cache keys: no `restore-keys` anywhere, and every key embeds `hashFiles('tests/models/manifest.json')` — so a hit implies an identical manifest, and the check can only red on a genuinely partial or corrupt cache rather than on drift.

## Would anything red on `main` today?

**No red expected — but concluded, not observed**, since CI was not run. The basis: `build` and `release` already run the identical `--check` on `main` and are green; the key structure means a hit cannot be manifest-stale; the manifest verifies 164/164 against a real corpus locally; and the one behaviour change was checked against every existing call site.

No `fixture_or_skip!` call site touched — that is #2802's scope. No skip weakened, no cache bypassed, no fixture binary committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fixture validation to detect missing, corrupted, truncated, empty, malformed, or unlisted files.
  * Verification now runs reliably even when fixtures are restored from cache.
  * Error messages identify the affected fixture and the reason validation failed.

* **Tests**
  * Added comprehensive coverage for valid and invalid fixture repositories, including manifest parsing and scoped checks.
  * Expanded automated test coverage across benchmark, determinism, viewer, Node, Rust, and end-to-end test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->