### PR TITLE
test(geometry): three survivors from a mutation sweep of layers and mesh_orient

### DIFF
--- a/rust/geometry/src/mesh_orient_tests.rs
+++ b/rust/geometry/src/mesh_orient_tests.rs
@@ -295,3 +295,144 @@ fn reporting_the_verdict_does_not_change_a_single_index() {
         );
     }
 }
+
+/// Flat-shaded triangle soup from a vertex table and a face list — one vertex
+/// per corner, exactly like [`cube`], so welding (not index sharing) is what
+/// builds the edge graph.
+fn soup(verts: &[[f32; 3]], faces: &[[usize; 3]]) -> Mesh {
+    let mut m = Mesh::new();
+    for f in faces {
+        for &vi in f {
+            m.positions.extend_from_slice(&verts[vi]);
+            m.normals.extend_from_slice(&[0.0, 0.0, 0.0]);
+        }
+        let base = m.indices.len() as u32;
+        m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+    }
+    m
+}
+
+/// `all_closed` must reject a NON-MANIFOLD edge, not just a boundary one.
+///
+/// Two tetrahedra glued at a shared face, with that face emitted by BOTH — the
+/// doubled coincident sheet `router::layers` names as the "ghost face", and what
+/// exporters produce whenever two bodies are stacked at a common interface.
+/// Every edge here has TWO or FOUR incident triangles, never one, so a gate
+/// that asks "is any edge under-shared" (`count < 2`) sees a perfectly closed
+/// shell and licenses a divergence-theorem volume over a surface with no
+/// well-defined inside. The pass asks `count != 2`; this pins that.
+///
+/// The existing open-sheet fixtures cannot see the difference: their bad edges
+/// are BOUNDARY edges, degree 1, which both readings reject. Only a
+/// degree-FOUR edge separates the two.
+#[test]
+fn a_doubled_interface_face_is_not_closed_even_though_no_edge_is_under_shared() {
+    // P, Q, R = the shared base; A above it, B below it.
+    let verts = [
+        [0.0f32, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, -1.0],
+    ];
+    let faces = [
+        [0, 1, 2], [3, 1, 0], [3, 2, 1], [3, 0, 2], // tetra A, base included
+        [0, 2, 1], [4, 0, 1], [4, 1, 2], [4, 2, 0], // tetra B, base included again
+    ];
+    let mut m = soup(&verts, &faces);
+
+    // The fixture's defining property: no edge is under-shared, three are
+    // OVER-shared. Asserted, not assumed — it is the whole point of the case.
+    let q = |v: f32| (v as f64 * WELD_SCALE).round() as i64;
+    let mut counts: FxHashMap<((i64, i64, i64), (i64, i64, i64)), u32> = FxHashMap::default();
+    for t in m.indices.chunks_exact(3) {
+        let key = |i: u32| {
+            let b = i as usize * 3;
+            (q(m.positions[b]), q(m.positions[b + 1]), q(m.positions[b + 2]))
+        };
+        let (a, b, c) = (key(t[0]), key(t[1]), key(t[2]));
+        for (x, y) in [(a, b), (b, c), (c, a)] {
+            let e = if x < y { (x, y) } else { (y, x) };
+            *counts.entry(e).or_insert(0) += 1;
+        }
+    }
+    assert!(
+        counts.values().all(|&c| c >= 2),
+        "fixture must have NO boundary edge, else it cannot distinguish the two readings"
+    );
+    assert_eq!(
+        counts.values().filter(|&&c| c > 2).count(),
+        3,
+        "the doubled base contributes exactly three non-manifold edges"
+    );
+
+    let before = m.indices.clone();
+    let v = orient_mesh_outward_verdict(&mut m);
+    assert!(
+        !v.all_closed,
+        "a shell with a degree-4 edge is NOT closed — it has no well-defined inside: {v:?}"
+    );
+    assert!(
+        !v.is_single_closed_solid(),
+        "and therefore must not license a volume: {v:?}"
+    );
+    assert_eq!(
+        m.indices, before,
+        "an unclosed component is left wound exactly as authored"
+    );
+}
+
+/// `all_orientable` must be able to come out FALSE. Nothing else in the suite
+/// ever observes it: every other fixture is orientable, so the contradiction
+/// branch could be deleted outright and the whole package still passed.
+///
+/// The 6-vertex hemi-icosahedron is the minimal triangulation of the real
+/// projective plane: 6 vertices, 15 edges, 10 faces, χ = 1. Every edge is
+/// shared by EXACTLY two triangles — so it is closed and manifold — yet
+/// orientation propagated around it comes back reversed. That combination
+/// (closed AND non-orientable) is the only one that isolates the branch; an
+/// open Möbius band would be rejected by `all_closed` first and prove nothing.
+///
+/// The positions are the octahedron's, which makes the surface self-intersect
+/// in R³. That is unavoidable — no closed non-orientable surface embeds in R³ —
+/// and irrelevant here: the pass reads welded positions for vertex identity and
+/// the edge graph for topology, and never reaches the signed-volume sum on a
+/// component it has already refused.
+#[test]
+fn a_closed_but_non_orientable_shell_is_refused_rather_than_wound_outward() {
+    let verts = [
+        [1.0f32, 0.0, 0.0],
+        [-1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, -1.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, 0.0, -1.0],
+    ];
+    let faces = [
+        [0, 1, 2], [0, 2, 3], [0, 3, 4], [0, 4, 5], [0, 5, 1],
+        [1, 2, 4], [2, 3, 5], [3, 4, 1], [4, 5, 2], [5, 1, 3],
+    ];
+    let mut m = soup(&verts, &faces);
+    let before = m.indices.clone();
+    let v = orient_mesh_outward_verdict(&mut m);
+
+    assert_eq!(v.components, 1, "the hemi-icosahedron is connected: {v:?}");
+    assert!(
+        v.all_closed,
+        "every one of its 15 edges is shared by exactly two triangles: {v:?}"
+    );
+    assert!(
+        !v.all_orientable,
+        "a projective plane has no consistent orientation, so the pass must say so: {v:?}"
+    );
+    assert!(
+        !v.is_single_closed_solid(),
+        "closed is not enough — without an orientation the sign of each \
+         triangle's contribution is arbitrary: {v:?}"
+    );
+    assert!(!v.flipped, "nothing may be re-wound: {v:?}");
+    assert_eq!(
+        m.indices, before,
+        "a non-orientable component keeps the winding it was authored with"
+    );
+}

--- a/rust/geometry/tests/material_layers_test.rs
+++ b/rust/geometry/tests/material_layers_test.rs
@@ -17,7 +17,8 @@ use rustc_hash::FxHashMap;
 
 /// Three-layer wall as a single `IfcExtrudedAreaSolid` (4 m × 0.3 m × 3 m),
 /// material buildup: 50 mm finish + 200 mm core + 50 mm finish = 300 mm total.
-/// Layers stack along AXIS2 (local +Y), POSITIVE, offset = 0.
+/// Layers stack along AXIS2 (local +Y), POSITIVE, offset = −0.15 (the layer set
+/// is centred on the wall's reference line, as the profile is).
 fn three_layer_wall_single_solid_ifc() -> String {
     r#"ISO-10303-21;
 HEADER;
@@ -411,5 +412,216 @@ fn process_element_with_material_layers_returns_none_for_unsliceable() {
     assert!(
         result.is_none(),
         "ConstituentSet must produce None so caller falls back"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// WHERE the cuts land. Everything above counts sub-meshes and reads material
+// ids off them; nothing pins the geometry, and every fixture above shares three
+// symmetries that make the geometry unobservable:
+//
+//   * length unit METRE, so `unit_scale == 1` and dropping the offset's unit
+//     conversion entirely changes no number;
+//   * DirectionSense POSITIVE, so `direction_sense == +1` and moving that
+//     factor onto the wrong term changes no number;
+//   * layer stack 50/200/50 with materials 200/201/200 — a PALINDROME, so
+//     reading the stack back to front changes neither a cut position nor an
+//     emitted material id.
+//
+// The fixture below breaks all three at once: millimetres, NEGATIVE sense, and
+// three distinct thicknesses carrying three distinct materials.
+// ---------------------------------------------------------------------------
+
+/// Same 4 m × 0.30 m × 3 m wall, written in MILLIMETRES, with an asymmetric
+/// 40 / 200 / 60 mm buildup of three distinct materials (#200, #201, #202).
+///
+/// `sense` / `offset_mm` are the layer set's `DirectionSense` and
+/// `OffsetFromReferenceLine`. `.POSITIVE.` with −150 and `.NEGATIVE.` with +150
+/// describe the SAME physical wall from opposite ends of the stack, so the two
+/// must produce mirror-image slabs — which is what makes the sense factor
+/// observable at all.
+fn mm_wall_asymmetric_buildup(sense: &str, offset_mm: f64) -> String {
+    mm_wall_on_axis(".AXIS2.", sense, offset_mm)
+}
+
+fn mm_wall_on_axis(layer_axis: &str, sense: &str, offset_mm: f64) -> String {
+    format!(
+        r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('test.ifc','2024-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1234567890123456789012',#2,'Test',$,$,$,$,(#10),#7);
+#2=IFCOWNERHISTORY(#3,#4,$,.ADDED.,$,$,$,0);
+#3=IFCPERSONANDORGANIZATION(#5,#6,$);
+#4=IFCAPPLICATION(#6,'1.0','Test','Test');
+#5=IFCPERSON($,'Test',$,$,$,$,$,$);
+#6=IFCORGANIZATION($,'Test',$,$,$);
+#7=IFCUNITASSIGNMENT((#8,#9));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#9=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);
+#10=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#11,$);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((0.,0.,0.));
+#13=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#10,$,.MODEL_VIEW.,$);
+#20=IFCLOCALPLACEMENT($,#21);
+#21=IFCAXIS2PLACEMENT3D(#22,#23,#24);
+#22=IFCCARTESIANPOINT((0.,0.,0.));
+#23=IFCDIRECTION((0.,0.,1.));
+#24=IFCDIRECTION((1.,0.,0.));
+#30=IFCRECTANGLEPROFILEDEF(.AREA.,'Wall',#31,4000.,300.);
+#31=IFCAXIS2PLACEMENT2D(#32,#33);
+#32=IFCCARTESIANPOINT((0.,0.));
+#33=IFCDIRECTION((1.,0.));
+#40=IFCEXTRUDEDAREASOLID(#30,#41,#42,3000.);
+#41=IFCAXIS2PLACEMENT3D(#43,$,$);
+#42=IFCDIRECTION((0.,0.,1.));
+#43=IFCCARTESIANPOINT((0.,0.,0.));
+#50=IFCSHAPEREPRESENTATION(#13,'Body','SweptSolid',(#40));
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#50));
+#100=IFCWALL('0001234567890123456789',#2,'TestWall',$,$,#20,#51,'Test',$);
+#200=IFCMATERIAL('Outer',$,$);
+#201=IFCMATERIAL('Core',$,$);
+#202=IFCMATERIAL('Inner',$,$);
+#210=IFCMATERIALLAYER(#200,40.,$,'Outer',$,$,$);
+#211=IFCMATERIALLAYER(#201,200.,$,'Core',$,$,$);
+#212=IFCMATERIALLAYER(#202,60.,$,'Inner',$,$,$);
+#220=IFCMATERIALLAYERSET((#210,#211,#212),'3LayerBuildup',$);
+#221=IFCMATERIALLAYERSETUSAGE(#220,{layer_axis},{sense},{offset_mm:.1},$);
+#300=IFCRELASSOCIATESMATERIAL('0001234567890123456790',#2,$,$,(#100),#221);
+ENDSEC;
+END-ISO-10303-21;
+"#
+    )
+}
+
+/// `(material_id, min, max)` of every emitted slab along local axis `comp`
+/// (0 = X, 1 = Y, 2 = Z), in emission order.
+/// The wall's local frame is the world frame here (identity placement, no RTC,
+/// origin `[0,0,0]`), so `positions` ARE metres along the local axis the layers
+/// stack on.
+fn slab_bands(content: &str) -> Vec<(u32, f64, f64)> {
+    slab_bands_on(content, 1)
+}
+
+fn slab_bands_on(content: &str, comp: usize) -> Vec<(u32, f64, f64)> {
+    let mut decoder = EntityDecoder::new(content);
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    let index = MaterialLayerIndex::from_content(content, &mut decoder);
+    let wall = decoder.decode_by_id(100).expect("decode wall");
+    let buildup = index.get(100).expect("buildup").clone();
+    let void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let collection = router
+        .process_element_with_material_layers(&wall, &mut decoder, &buildup, &void_index)
+        .expect("layered path ok")
+        .expect("Some(SubMeshCollection)");
+    assert_eq!(
+        collection.sub_meshes[0].mesh.origin,
+        [0.0, 0.0, 0.0],
+        "this fixture must stay in the world frame, or the bands below are not metres of world Y"
+    );
+    collection
+        .sub_meshes
+        .iter()
+        .map(|s| {
+            let ys: Vec<f64> = s.mesh.positions.chunks(3).map(|p| p[comp] as f64).collect();
+            let lo = ys.iter().cloned().fold(f64::INFINITY, f64::min);
+            let hi = ys.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            (s.geometry_id, lo, hi)
+        })
+        .collect()
+}
+
+fn assert_bands(got: &[(u32, f64, f64)], want: &[(u32, f64, f64)], what: &str) {
+    assert_eq!(got.len(), want.len(), "{what}: slab count, got {got:?}");
+    for (i, (g, w)) in got.iter().zip(want).enumerate() {
+        assert_eq!(g.0, w.0, "{what}: slab {i} material, got {got:?}");
+        assert!(
+            (g.1 - w.1).abs() < 1e-4 && (g.2 - w.2).abs() < 1e-4,
+            "{what}: slab {i} band [{:.4},{:.4}], want [{:.4},{:.4}]",
+            g.1,
+            g.2,
+            w.1,
+            w.2
+        );
+    }
+}
+
+/// Each layer's slab occupies the exact band the buildup describes: the
+/// thicknesses come out 40/200/60 mm in the file's own unit converted to
+/// metres, in stack order, each carrying its own material.
+///
+/// This is the test the unit conversion is answerable to. A millimetre file
+/// with the offset's `* unit_scale` dropped puts the first interface 150 METRES
+/// off the wall; every earlier fixture is in metres, where that factor is 1.
+#[test]
+fn slabs_land_on_the_exact_bands_the_buildup_describes() {
+    // POSITIVE from MlsBase at local Y = −0.15 m: outer 40 mm first, then the
+    // 200 mm core, then the 60 mm inner leaf, ending at +0.15 m.
+    assert_bands(
+        &slab_bands(&mm_wall_asymmetric_buildup(".POSITIVE.", -150.0)),
+        &[
+            (200, -0.15, -0.11),
+            (201, -0.11, 0.09),
+            (202, 0.09, 0.15),
+        ],
+        "AXIS2 POSITIVE, millimetres",
+    );
+}
+
+/// The mirror. NEGATIVE sense from an MlsBase at +0.15 m describes the same
+/// physical wall walked from the other face, so the same stack must come out
+/// reflected about Y = 0 — first layer at the TOP of the range, last at the
+/// bottom.
+///
+/// This is what makes `direction_sense` observable. It is `+1` in every other
+/// fixture in the repo, and a factor of one hides whatever it multiplies.
+#[test]
+fn negative_direction_sense_stacks_the_layers_the_other_way() {
+    let positive = slab_bands(&mm_wall_asymmetric_buildup(".POSITIVE.", -150.0));
+    let negative = slab_bands(&mm_wall_asymmetric_buildup(".NEGATIVE.", 150.0));
+
+    assert_bands(
+        &negative,
+        &[
+            (200, 0.11, 0.15),
+            (201, -0.09, 0.11),
+            (202, -0.15, -0.09),
+        ],
+        "AXIS2 NEGATIVE, millimetres",
+    );
+
+    // Stated as the reflection too, so the pair cannot both drift the same way.
+    for (i, (p, n)) in positive.iter().zip(&negative).enumerate() {
+        assert_eq!(p.0, n.0, "slab {i}: the same layer keeps its material");
+        assert!(
+            (p.1 + n.2).abs() < 1e-4 && (p.2 + n.1).abs() < 1e-4,
+            "slab {i}: NEGATIVE must mirror POSITIVE about Y=0, got {p:?} vs {n:?}"
+        );
+    }
+}
+
+/// `LayerSetDirection` selects which LOCAL AXIS the stack runs along, and the
+/// AXIS1/AXIS3 arms of `LayerAxis::unit_vector` are reached by no other test in
+/// the repo — every fixture is an AXIS2 wall, so both could return the +Y unit
+/// vector and nothing would notice.
+///
+/// AXIS3 on the same body stacks through the extrusion depth (local +Z), which
+/// is how slabs, roofs and coverings are described. It also pins the
+/// layer-set-shorter-than-the-body rule: this buildup is 300 mm on a 3 m
+/// extrusion, and the LAST slab keeps the whole remainder rather than the
+/// geometry above the final interface being dropped.
+#[test]
+fn axis3_stacks_the_layers_through_the_extrusion_depth() {
+    assert_bands(
+        &slab_bands_on(&mm_wall_on_axis(".AXIS3.", ".POSITIVE.", 0.0), 2),
+        &[
+            (200, 0.0, 0.04),
+            (201, 0.04, 0.24),
+            (202, 0.24, 3.0),
+        ],
+        "AXIS3 POSITIVE, millimetres",
     );
 }


### PR DESCRIPTION
Mutation-tested `rust/geometry/src` and `rust/core/src`: break the code deliberately and see whether anything notices. **Four mutants survived the entire suite**, including two that passed all 718 lib tests.

All three findings are **untested-but-correct**, not broken — verified end-to-end before concluding that, with a probe harness computing actual slab bands across metre/millimetre × POSITIVE/NEGATIVE × AXIS1/AXIS2/AXIS3 × rotated placement, every case matching hand-computed truth. **No production code changed.** Two test files, that is all.

## 1. Material-layer slicing had no fixture that could observe its geometry

Every material-layer fixture in the repo is the same wall: METRE units, POSITIVE sense, and a 50/200/50 stack of materials 200/201/200. Every assertion counts sub-meshes or reads material ids. **None says where a slab sits.**

Three symmetries stacked on top of each other — `unit_scale == 1`, `direction_sense == +1`, and a **palindromic** layer stack with identical outer thicknesses and identical outer materials. That last one is the opposite-edge-swap shape: the wrong answer is preserved by the fixture's own symmetry.

Survivors in `router/layers.rs`, each passing `material_layers_test`, `material_layers_local_frame_test` and `merge_layers_skip_test`:

- `let offset_m = offset * scale;` → `let offset_m = offset;` — **drops the unit conversion entirely**
- `offset_m + direction_sense * cumulative_m` → `offset_m * direction_sense + cumulative_m`
- `SubMesh::new(layer.material_id, …)` → `visual_layers[len - 1 - i].material_id` — **the stack read backwards**

And a fourth in `material_layer_index.rs`: `LayerAxis::Axis3 => [0.0, 0.0, 1.0]` → `[0.0, 1.0, 0.0]`. The Axis1 and Axis3 arms of `unit_vector` are reached by **no test in the repo**.

RED, verbatim, mutant 1:

```
test slabs_land_on_the_exact_bands_the_buildup_describes ... FAILED
test negative_direction_sense_stacks_the_layers_the_other_way ... FAILED
test result: FAILED. 7 passed; 2 failed; 0 ignored
```

**The fix is a fixture that can see:** millimetres (scale ≠ 1), asymmetric **40/200/60 mm**, three **distinct** materials — asserting each slab's material *and* its band `[min, max]` along the stacking axis. The NEGATIVE case is stated both absolutely and as the mirror of the POSITIVE one, so the pair cannot drift together. The AXIS3 case pins the last slab keeping the remainder when the buildup (0.30 m) is thinner than the body (3 m).

Also corrected a doc comment on `three_layer_wall_single_solid_ifc` claiming `offset = 0` where the fixture uses `-0.15`.

## 2. `all_closed` was never asked about a non-manifold edge

Every "open" fixture in the suite fails on **boundary** edges of degree 1. Nothing has a **degree-4** edge — so the guard's `!= 2` was indistinguishable from `< 2`.

Surviving mutant at `mesh_orient.rs:312`: `if inc.count != 2` → `if inc.count < 2`, **passing all 718 lib tests.**

This gates `GeometryClosure::is_trustworthy_solid` → `GeometryHasher::volume`. Under the mutant, a doubled coincident interface sheet — the "ghost face" that `router::layers` documents producing — would license a divergence-theorem volume over a surface with no inside.

```
a shell with a degree-4 edge is NOT closed — it has no well-defined inside:
OrientVerdict { flipped: true, all_closed: true, all_orientable: true, components: 4 }
```

Fixed by two tetrahedra glued at a face emitted by both. The test **asserts the fixture's own defining property first** — no edge under-shared, exactly three over-shared — so it cannot silently degrade into just another open-sheet case.

## 3. `all_orientable` was never observed false anywhere

Every fixture is orientable, so the contradiction branch could be **deleted outright** and all 718 tests still passed.

Reachable or dead? **Reachable** — a closed, manifold, non-orientable triangulation exists as an immersion in R³: the 6-vertex hemi-icosahedron (RP², 6 V / 15 E / 10 F, every edge exactly degree 2).

```
a projective plane has no consistent orientation, so the pass must say so:
OrientVerdict { flipped: true, all_closed: true, all_orientable: true, components: 1 }
```

Closed **and** non-orientable is the only combination that isolates the branch — an open Möbius band is rejected by `all_closed` first and proves nothing.

## Negative evidence — mutants that were killed

Reported because "I found bugs" means little without knowing what the suite already catches:

- moving the `break` before `cumulative_m += …` → first slab empties → killed by `expected one sub-mesh per layer`
- `direction_sense` sign flip → planes land outside the wall → killed by existing count assertions
- `merge_thin_layers`: swapping `p`/`n` in the thicker-neighbour choice → killed by `thin_middle_layer_folded_into_thicker_neighbour`
- `mesh_orient`: `ntri < 2` and the malformed-index guard → killed by `unanalysable_meshes_report_indeterminate`
- **`units.rs` twins** — looked for the classic delta between two implementations of one rule (`extract_length_unit_scale` vs `try_extract_length_unit_scale`); `rust/core/tests/unit_scale_parity.rs` already enforces that the pre-pass sibling never contradicts the full extractor, against shared cross-language vectors. Nothing to add.
- **`projection_outline.rs`'s doc claims it "matches `projectTo2D` in `@ifc-lite/drawing-2d` exactly"** — checked against `packages/drawing-2d/src/math.ts:284-304`. The comment is **accurate** (`x→(z,y)`, `y→(x,z)`, `z→(x,y)`, u mirrored on flip). Worth stating, since comments asserting agreement have been wrong three times today.

## Same-shape sweep and leads not chased

`inc.count != 2` at `mesh_orient.rs:312` is the only edge-incidence degree test in `geometry/src`; `space_dcel/mod.rs:669` (`outs.len() != 2`) is a different subject — **lead, not chased**. The palindromic 50/200/50 fixture is still used by two other suites whose subjects (origin restoration, skip-set membership) do not depend on band positions, so it is left alone now that the asymmetric fixture covers the geometry.

Not chased, stated plainly: `merge_thin_layers`'s `>=` tie-break is unobservable because no fixture has equally thick neighbours (low stakes — it only decides which material dominates a merged slab); `LayerAxis::Axis1`'s `unit_vector` arm is still reached by no test, verified correct by probe; and in `projection_outline.rs`, `axis_min`/`axis_max` accumulate over triangles later skipped as degenerate while the `MAX_OVERLAY_TRIANGLES` bail returns `None` silently — both look deliberate, both unverified.

## Verification

`ifc-lite-geometry` lib **719 → 721** tests (718 → 720 passing, 1 ignored); `material_layers_test` **7 → 10**. Full `cargo test -p ifc-lite-geometry` green across every binary; `cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings` clean; `module_size_ratchet` 5 passed — both changed files are test files and exempt.

No changeset: Rust-only, no published surface change. Every mutation was restored from a saved copy, and the final `git diff` was read to confirm it touches only the two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
