### PR TITLE
test(merge,cache): five blind spots found by mutation, including an ancestor-imposter guard

### DIFF
--- a/packages/cache/src/sections/entity-index.test.ts
+++ b/packages/cache/src/sections/entity-index.test.ts
@@ -38,6 +38,30 @@ describe('EntityIndex section round-trip', () => {
     expect(restored.typeNames[restored.typeIndices[1]]).toBe('IFCSLAB');
   });
 
+  it('normalizes the type name to upper case and prefers a ref-supplied expressId over the map key', () => {
+    // Both halves of `normalizeRef` were unobservable: every existing
+    // fixture in this package already spells its type in upper case and
+    // already sets `expressId` equal to the map key. Mutation testing
+    // confirmed it — deleting `.toUpperCase()`, and replacing
+    // `ref.expressId || id` with a bare `id`, each left the whole
+    // `@ifc-lite/cache` suite green at 83/83.
+    const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>([
+      // Key 99, but the ref names itself 5 — the ref wins.
+      [99, { expressId: 5, type: 'IFCSLAB', byteOffset: 30, byteLength: 15, lineNumber: 0 }],
+      // Mixed case on the wire; and expressId 0 is falsy, so this row is
+      // the one where the map key legitimately supplies the id.
+      [7, { expressId: 0, type: 'IfcWall', byteOffset: 10, byteLength: 20, lineNumber: 0 }],
+    ]);
+    const restored = roundTrip({ byId });
+
+    // Sorted by the NORMALIZED expressId: 5 (from key 99) then 7 (from the
+    // key, the ref having none).
+    expect(Array.from(restored.ids)).toEqual([5, 7]);
+    expect(Array.from(restored.byteOffsets)).toEqual([30, 10]);
+    expect(restored.typeNames[restored.typeIndices[0]]).toBe('IFCSLAB');
+    expect(restored.typeNames[restored.typeIndices[1]]).toBe('IFCWALL');
+  });
+
   it('rejects a typeIndex that points outside the typeNames table (corrupt/truncated cache)', () => {
     // Write a valid, single-type-name section, then corrupt the on-disk
     // typeIndices column so it addresses a type name that doesn't exist —

--- a/packages/cache/src/sections/geometry-chunks.test.ts
+++ b/packages/cache/src/sections/geometry-chunks.test.ts
@@ -88,6 +88,35 @@ describe('groupMeshesIntoChunks', () => {
     const groups = groupMeshesIntoChunks(meshes, 10);
     expect(groups.length).toBe(3);
   });
+
+  // Every case above separates its cells along X alone (`[1000, 0, 0]`),
+  // and every mesh() fixture's FIRST VERTEX is the local origin `[0, 0, 0]`
+  // — two symmetries that made half of `cellKeyOf` unobservable. Mutation
+  // testing confirmed both: computing cy and cz from `x` instead of `y`/`z`,
+  // and dropping the first-vertex term from the anchor entirely, each left
+  // the whole `@ifc-lite/cache` suite green at 83/83.
+
+  it('separates cells along Y and Z, not only along X', () => {
+    // Same X for all three; only the Y and Z components can tell them
+    // apart, at 1000 units against a 32-unit cell.
+    const meshes = [mesh(1, [0, 0, 0]), mesh(2, [0, 1000, 0]), mesh(3, [0, 0, 1000])];
+    const groups = groupMeshesIntoChunks(meshes);
+    expect(groups.length).toBe(3);
+    expect(groups.map((g) => g.map((m) => m.expressId)).sort()).toEqual([[1], [2], [3]]);
+  });
+
+  it('anchors on origin PLUS first vertex, so meshes sharing an origin but sitting far apart still split', () => {
+    // Identical origins: only the local first vertex distinguishes them.
+    // This is the case that matters for absolute (origin-less) meshes,
+    // whose whole world position lives in the vertex data.
+    const near = mesh(1, [0, 0, 0]);
+    const far = mesh(2, [0, 0, 0], {
+      positions: new Float32Array([0, 0, 1000, 1, 0, 1000, 0, 1, 1000]),
+    });
+    expect(near.origin).toEqual(far.origin);
+    const groups = groupMeshesIntoChunks([near, far]);
+    expect(groups.length).toBe(2);
+  });
 });
 
 describe('v13 geometry section round-trip', () => {

--- a/packages/merge/src/resurrect.test.ts
+++ b/packages/merge/src/resurrect.test.ts
@@ -375,3 +375,157 @@ describe('revert invariant: [base, L, revert(L)] == base', () => {
     expect(reverted.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI60');
   });
 });
+
+/**
+ * Every shadowed-subtree fixture above is a ONE-level tree with a SINGLE
+ * child (`storey` → `wall-1`). Three symmetries hide in that shape, and
+ * mutation testing confirmed all three are invisible to the suite as it
+ * stood — each mutant below left the whole `@ifc-lite/merge` suite green:
+ *
+ *  1. depth. `extractStackState`'s tombstone-shadow pass is a work queue,
+ *     but at depth 1 a queue that never re-enqueues is indistinguishable
+ *     from one that does. Truncating it to `if (child) child.deleted = true`
+ *     (no `queue.push`) passed 101/101.
+ *  2. root selection. `escalateShadowedConflicts`'s `rootIn` walks to the
+ *     nearest ancestor whose death is EXPLICIT, deliberately stepping over
+ *     merely shadow-dead ancestors. At depth 1 the first parent is always
+ *     the explicit root, so keying on `entity?.deleted` instead of
+ *     `entity?.explicitDeleted` passed 101/101.
+ *  3. ordering. `subtree` is sorted so the conflict record is stable, but
+ *     a one-element list is its own sort — dropping `.sort()` passed
+ *     101/101.
+ *
+ * This fixture breaks all three: three levels (`building` → `storey` →
+ * two walls), and the walls are declared in REVERSE sorted order so the
+ * natural iteration order is not the sorted order.
+ */
+describe('shadowed subtrees deeper than one level', () => {
+  const CLASS = 'bsi::ifc::class';
+  const deepBase = makeLayer(
+    [
+      {
+        path: 'building',
+        children: { Storey: 'storey' },
+        attributes: { [CLASS]: { code: 'IfcBuilding', uri: 'u' } },
+      },
+      {
+        path: 'storey',
+        // Slot names chosen so neither the slot order nor the path order
+        // matches the sorted path order.
+        children: { WallB: 'wall-2', WallA: 'wall-1' },
+        attributes: { [CLASS]: { code: 'IfcBuildingStorey', uri: 'u' } },
+      },
+      // Declared out of sorted order on purpose: `planFromStates` iterates
+      // the union of path keys in insertion order, so an unsorted `subtree`
+      // would come out as ['wall-2', 'wall-1'].
+      { path: 'wall-2', attributes: { [CLASS]: { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60' } },
+      { path: 'wall-1', attributes: { [CLASS]: { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60' } },
+    ],
+    'deep-base'
+  );
+
+  it('theirs deletes a grandparent whose GRANDCHILDREN ours edited → one conflict on the grandparent, subtree sorted', () => {
+    const oursEdit = makeLayer(
+      [
+        { path: 'wall-2', attributes: { [FIRE]: 'REI90' } },
+        { path: 'wall-1', attributes: { [FIRE]: 'REI120' } },
+      ],
+      'ours-edit'
+    );
+    const theirsDel = makeLayer(
+      [{ path: 'building', attributes: { [IFCLITE_ATTR.DELETED]: true } }],
+      'theirs-del'
+    );
+    const plan = planThreeWayMerge({
+      ancestor: [deepBase],
+      ours: [deepBase, oursEdit],
+      theirs: [deepBase, theirsDel],
+    });
+
+    // The grandchildren are shadow-dead on the theirs side even though the
+    // tombstone sits two levels up — that is the depth the queue provides.
+    const theirsState = extractStackState([deepBase, theirsDel]);
+    expect(theirsState.get('storey')?.deleted).toBe(true);
+    expect(theirsState.get('wall-1')?.deleted).toBe(true);
+    expect(theirsState.get('wall-2')?.deleted).toBe(true);
+    // ...and only `building` owns an explicit tombstone; the descendants
+    // are shadow deaths, which is what `rootIn` must walk past.
+    expect(theirsState.get('building')?.explicitDeleted).toBe(true);
+    expect(theirsState.get('storey')?.explicitDeleted).toBe(false);
+    expect(theirsState.get('wall-1')?.explicitDeleted).toBe(false);
+
+    // One decision, taken at the explicitly-tombstoned ROOT — not at
+    // `storey` (merely shadow-dead) and not once per wall.
+    expect(plan.conflicts).toHaveLength(1);
+    expect(plan.conflicts[0]).toMatchObject({
+      kind: 'modify-vs-delete',
+      path: 'building',
+      subtree: ['wall-1', 'wall-2'],
+    });
+    // No auto tombstone rides along that would pre-empt the decision.
+    expect(plan.autoOps).not.toContainEqual({ op: 'tombstone-entity', path: 'building' });
+
+    // theirs: the whole two-level subtree goes, knowingly.
+    const takeTheirs = applyResolutions(plan, [{ path: 'building', choice: 'theirs' }]);
+    const deleted = stateAfterMerge([deepBase, oursEdit], [...plan.autoOps, ...takeTheirs.ops]);
+    expect(deleted.get('building')?.deleted).toBe(true);
+    expect(deleted.get('storey')?.deleted).toBe(true);
+    expect(deleted.get('wall-1')?.deleted).toBe(true);
+    expect(deleted.get('wall-2')?.deleted).toBe(true);
+
+    // ours: the whole subtree survives, both edits intact and distinct.
+    const takeOurs = applyResolutions(plan, [{ path: 'building', choice: 'ours' }]);
+    const kept = stateAfterMerge([deepBase, oursEdit], [...plan.autoOps, ...takeOurs.ops]);
+    expect(kept.get('building')?.deleted ?? false).toBe(false);
+    expect(kept.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI120');
+    expect(kept.get('wall-2')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI90');
+  });
+
+  it('ours deletes a grandparent whose GRANDCHILDREN theirs edited → resurrectable root conflict plus the per-wall conflicts that carry the edits', () => {
+    const oursDel = makeLayer(
+      [{ path: 'building', attributes: { [IFCLITE_ATTR.DELETED]: true } }],
+      'ours-del'
+    );
+    const theirsEdit = makeLayer(
+      [
+        { path: 'wall-2', attributes: { [FIRE]: 'REI90' } },
+        { path: 'wall-1', attributes: { [FIRE]: 'REI120' } },
+      ],
+      'theirs-edit'
+    );
+    const plan = planThreeWayMerge({
+      ancestor: [deepBase],
+      ours: [deepBase, oursDel],
+      theirs: [deepBase, theirsEdit],
+    });
+
+    // The root gains the resurrectable conflict; `storey`, merely
+    // shadow-dead and untouched by theirs, must not be mistaken for it.
+    expect(plan.conflicts.find((c) => c.path === 'building')).toMatchObject({
+      kind: 'delete-vs-modify',
+      subtree: ['wall-1', 'wall-2'],
+    });
+    expect(plan.conflicts.find((c) => c.path === 'storey')).toBeUndefined();
+    // The descendant conflicts are KEPT on this side: their theirs-side
+    // resolutions carry the actual edits, and become satisfiable only once
+    // the root is resurrected.
+    expect(plan.conflicts.find((c) => c.path === 'wall-1')).toMatchObject({
+      kind: 'delete-vs-modify',
+    });
+    expect(plan.conflicts.find((c) => c.path === 'wall-2')).toMatchObject({
+      kind: 'delete-vs-modify',
+    });
+
+    const applied = applyResolutions(plan, [
+      { path: 'building', choice: 'theirs' },
+      { path: 'wall-1', choice: 'theirs' },
+      { path: 'wall-2', choice: 'theirs' },
+    ]);
+    const merged = stateAfterMerge([deepBase, oursDel], [...plan.autoOps, ...applied.ops]);
+    expect(merged.get('building')?.deleted).toBe(false);
+    expect(merged.get('wall-1')?.deleted).toBe(false);
+    expect(merged.get('wall-2')?.deleted).toBe(false);
+    expect(merged.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI120');
+    expect(merged.get('wall-2')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI90');
+  });
+});

--- a/packages/merge/src/three-way.test.ts
+++ b/packages/merge/src/three-way.test.ts
@@ -396,3 +396,106 @@ describe('partition fuzz: random op partitions never lose ops', () => {
     }
   });
 });
+
+/**
+ * `sharesAncestorPrefix` decides whether the 05 §5.7 projection fast path
+ * may skip re-reading the ancestor layers out of a side's stack. It accepts
+ * a layer either by REFERENCE equality or by content address, and the
+ * content-address arm is deliberately narrowed to ids in the `blake3:` form
+ * — an equal blake3 id is a proof of identical canonical bytes, an equal
+ * arbitrary id is not.
+ *
+ * Every other fixture in this package passes the very same `IfcxFile`
+ * OBJECT as both `ancestor[0]` and `ours[0]`/`theirs[0]`, so the reference
+ * arm alone decides and the id is never consulted. Mutation testing
+ * confirmed the narrowing is unobserved: relaxing the check to
+ * `if (stack[i].header.id === id) continue;` — dropping the `blake3:`
+ * requirement — left the whole `@ifc-lite/merge` suite green at 101/101.
+ * That is a silent-data-loss mutant, not a cosmetic one: the projection
+ * then folds the REAL ancestor while treating an imposter layer's content
+ * as if it were that ancestor, and everything the imposter changed
+ * disappears from the plan with no conflict raised.
+ */
+describe('ancestor-prefix detection is content-addressed, not id-string-matched', () => {
+  const CLASS = 'bsi::ifc::class';
+  const prefixBase = makeLayer(
+    [
+      {
+        path: 'wall-1',
+        attributes: { [CLASS]: { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI60', [EXTERNAL]: true },
+      },
+    ],
+    'not-a-content-address'
+  );
+  // Same id string, different bytes — exactly what a non-content-addressed
+  // id (a branch name, a counter, a test label) cannot rule out.
+  const imposter = makeLayer(
+    [
+      {
+        path: 'wall-1',
+        attributes: { [CLASS]: { code: 'IfcWall', uri: 'u' }, [FIRE]: 'REI30', [EXTERNAL]: true },
+      },
+    ],
+    'not-a-content-address'
+  );
+
+  it('a different document carrying the same NON-blake3 id is not accepted as the ancestor prefix', () => {
+    // Premise, pinned: the ids really are equal and the objects really are
+    // not — otherwise the test would prove nothing.
+    expect(imposter.header.id).toBe(prefixBase.header.id);
+    expect(imposter.header.id.startsWith('blake3:')).toBe(false);
+    expect(imposter).not.toBe(prefixBase);
+
+    const theirsDelta = layer([{ path: 'wall-1', attributes: { [EXTERNAL]: false } }], 'theirs');
+    const plan = planThreeWayMerge({
+      ancestor: [prefixBase],
+      ours: [prefixBase],
+      theirs: [imposter, theirsDelta],
+    });
+
+    expect(plan.conflicts).toEqual([]);
+    // The imposter's own divergence from the ancestor (REI60 → REI30) must
+    // reach the plan. Accepting it as the prefix projects only the suffix
+    // and this op vanishes entirely.
+    expect(plan.autoOps).toContainEqual({
+      op: 'set-component',
+      path: 'wall-1',
+      componentKey: 'pset:Pset_FireSafety',
+      attributes: { [FIRE]: 'REI30' },
+    });
+    // The suffix's own edit still lands, so the assertion above is about
+    // what the fast path DROPS, not about the merge failing wholesale.
+    expect(plan.autoOps).toContainEqual({
+      op: 'set-component',
+      path: 'wall-1',
+      componentKey: 'pset:Pset_WallCommon',
+      attributes: { [EXTERNAL]: false },
+    });
+
+    const merged = stateAfterMerge([prefixBase], plan.autoOps);
+    expect(merged.get('wall-1')?.components.get('pset:Pset_FireSafety')?.[FIRE]).toBe('REI30');
+    expect(merged.get('wall-1')?.components.get('pset:Pset_WallCommon')?.[EXTERNAL]).toBe(false);
+  });
+
+  it('control: the same suffix over the REAL ancestor layer emits only the suffix edit', () => {
+    // Same suffix, same expectations minus the imposter's divergence. This
+    // does not observe which path ran — it fixes the baseline the test
+    // above compares against, so the extra `REI30` op there is provably
+    // caused by the imposter and not by the fixture shape.
+    const theirsDelta = layer([{ path: 'wall-1', attributes: { [EXTERNAL]: false } }], 'theirs');
+    const plan = planThreeWayMerge({
+      ancestor: [prefixBase],
+      ours: [prefixBase],
+      theirs: [prefixBase, theirsDelta],
+    });
+    expect(plan.conflicts).toEqual([]);
+    expect(plan.autoOps).toEqual([
+      {
+        op: 'set-component',
+        path: 'wall-1',
+        componentKey: 'pset:Pset_WallCommon',
+        attributes: { [EXTERNAL]: false },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Mutation-tested `packages/merge` and `packages/cache`: break the code deliberately and see whether anything notices. **Seven mutants survived**, every one of them green on the full suite.

All five findings are **untested-but-correct** — the code was right, the suite was blind. Test-only, no source changes, so no changeset (precedent #2800, #2746).

## 1. Subtree-shadow escalation only ever ran on a one-level, single-child tree

Every fixture is `storey → wall-1`. That one shape independently hides **depth, root-selection and ordering** — three separate rules, none observable.

Three survivors, each green at 101/101:

- `component-state.ts` — the shadow queue truncated to depth 1 (`if (child) child.deleted = true`, no `queue.push`)
- `three-way.ts` — `rootIn` keyed on `entity?.deleted` instead of `entity?.explicitDeleted`
- `three-way.ts` — the `subtree` `.sort()` removed entirely, because **a one-element list is its own sort**

RED, verbatim, once a deep fixture existed:

```
× theirs deletes a grandparent whose GRANDCHILDREN ours edited
    → one conflict on the grandparent, subtree sorted
  [M8]  expected false to be true      (theirsState.get('wall-1')?.deleted)
  [M10] -   "path": "building",  +   "path": "storey",
  [M12] -     "wall-1",  "wall-2",  +     "wall-1",
```

The fixture is `building → storey → wall-1/wall-2` with the walls **declared in reverse sorted order**, run in both directions (theirs-deletes and ours-deletes) plus resolution outcomes. Symmetries avoided: single item, depth 1, already-sorted input.

## 2. `sharesAncestorPrefix`'s content-address guard was never observed — and it prevents silent data loss

Every fixture passes the *same object* as `ancestor[0]` and `theirs[0]`, so the reference arm decides and **the id arm never runs**.

Surviving mutant: drop `id.startsWith('blake3:')`, leaving `if (stack[i].header.id === id) continue;`. Green at 101/101.

What that mutant does is the part worth reading: the projection folds the real ancestor while treating an **imposter layer** as that ancestor. The imposter's entire edit disappears with **no conflict raised**.

```
× a different document carrying the same NON-blake3 id is not accepted as the ancestor prefix
- Expected: { attributes: { …FireRating: "REI30" }, componentKey: "pset:Pset_FireSafety", op: "set-component" }
+ Received: [ { attributes: { …IsExternal: false }, componentKey: "pset:Pset_WallCommon", … } ]
```

The new test pins the premise explicitly — ids equal, objects not, id not blake3 — plus a baseline control, so it cannot decay into passing for the old reason.

## 3. Chunk grouping only ever discriminated on X, and never used the vertex half of its anchor

Two mutants green at 83/83: computing `cy`/`cz` from `x`, and dropping `+ mesh.positions[0..2]` from the anchor. Every fixture separates cells with `[1000, 0, 0]`, and every `mesh()` has first vertex `[0,0,0]` — so both halves of the key were unobservable.

```
× anchors on origin PLUS first vertex … expected 1 to be 2
```

## 4. `normalizeRef`'s two normalizations were both unobservable

Every fixture was already upper-case with `expressId === key`. Removing `.toUpperCase()` and collapsing `ref.expressId || id` → `id` were both green at 83/83. Now pinned with a mixed-case type and a key/ref mismatch (key 99 → ref id 5; key 7 → falsy ref id).

## Mutants the existing suite killed — negative evidence

"I found five gaps" means little without knowing what already works. Killed: swapping `tChanged`/`oChanged` in the entity early-return (27 fail); dropping `!PSET_SET_RE.test(setName)` from the qset fallback (4 fail); inverting `resolveComponentKey`'s `value === null` guard (2 fail); reversing the entity-index `expressId` sort (2 fail); swapping Y/Z in `chunkAabb` (1 fail). **The merge matrix core and the cache round trip are genuinely well covered.**

## Leads not chased, stated rather than buried

- **`applyNode` and `applyNodeCow` are near-duplicates that must agree, with nothing enforcing it.** `applyNodeCow` omits the `IFCLITE_ATTR.DELETED` branch — currently safe *only* because `projectStackStates` bails on any DELETED-bearing layer. That is the two-paths-must-agree shape with a live delta, and it is the strongest follow-up here.
- `groupMeshesIntoChunks`' `chunk.bytes > 0` guard is **unreachable** — `meshRecordByteLength` has a 57-byte fixed floor and a fresh chunk is filled in the same iteration it is created. Defensive dead code, left alone.
- `sharesAncestorPrefix`'s `stack.length < ancestor.length` guard → `true` survives; a stack shorter than its ancestor may be unreachable, not proven either way.
- `Number.isFinite` in the `Qto_` branch survives (needs a non-finite quantity value, likely unserialisable in ifcx).
- `explicitDeleted = value === true` → `= true` survives; only reachable via an explicit `deleted: false` resurrect opinion *inside* a tombstoned subtree.
- `chunkAabb`'s `minX === Infinity` empty-mesh fallback survives — `validateMeshes` may filter such meshes first.
- `BufferWriter.align` / `BufferReader.align` are **dead in this package** (no call sites) and untested.

Same-shape grep: `toUpperCase` normalization also at `cache/src/sections/entities.ts:190`, which has its own coverage. Axis-triple patterns exist only in `cellKeyOf` and `chunkAabb`, and `chunkAabb`'s Y/Z swap is killed.

## Verification

merge **101 → 107**, cache **83 → 86**, both suites fully green. `typecheck` OK for both packages; `oxlint` 7 warnings, all pre-existing, none in new code.

Environment trap closed first, and it mattered: with no `node_modules` the merge suite could not resolve `@ifc-lite/ifcx` at all — **10/10 files errored**. After install and a dependency build, a planted `return []` in `opsForComponentChange` produced **25 failures**, confirming the harness observes this worktree's code rather than the main checkout's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
