### PR TITLE
test(viewer): a parallelogram fixture cannot see a z-slope, and a band pinned from one side

### DIFF
--- a/apps/viewer/src/lib/geo/effective-georef.test.ts
+++ b/apps/viewer/src/lib/geo/effective-georef.test.ts
@@ -280,6 +280,28 @@ describe('effective georeferencing', () => {
     assert.strictEqual(inferMapUnitScale('MILLIMETRE'), 0.001);
   });
 
+  it('infers the SI prefixes between milli and kilo, and keeps them apart', () => {
+    // CENTI, DECI and KILO were the three branches no assertion reached: each
+    // could return any other branch's factor with the suite still green. They
+    // are one `includes` apart from each other and from MILLIMETRE, so a
+    // mis-ordered or mistyped prefix lands on a neighbour rather than failing.
+    assert.strictEqual(inferMapUnitScale('CENTIMETRE'), 0.01);
+    assert.strictEqual(inferMapUnitScale('DECIMETRE'), 0.1);
+    assert.strictEqual(inferMapUnitScale('KILOMETRE'), 1000);
+    // Every prefixed name also contains METRE, so the bare-METRE branch must
+    // stay LAST; if it moved up, all four of these would collapse to 1.
+    assert.notStrictEqual(inferMapUnitScale('KILOMETRE'), 1);
+  });
+
+  it('keeps the US survey foot distinct from the international foot', () => {
+    // The survey-foot branch is tested before FOOT because 'US SURVEY FOOT'
+    // matches both; reversing the two makes it 0.3048 and moves a state-plane
+    // site by ~2 ppm, which is metres over a survey grid.
+    assert.strictEqual(inferMapUnitScale('US SURVEY FOOT'), 0.3048006096);
+    assert.strictEqual(inferMapUnitScale('FTUS'), 0.3048006096);
+    assert.notStrictEqual(inferMapUnitScale('US SURVEY FOOT'), inferMapUnitScale('FOOT'));
+  });
+
   describe('getEffectiveHorizontalScale (issue #595)', () => {
     it('returns 1 when project mm and map m, with Scale=0.001 (Bonsai-style)', () => {
       // mm project (lengthUnitScale=0.001), m map (mapUnitScale=1), Scale=0.001
@@ -389,6 +411,29 @@ describe('effective georeferencing', () => {
       const m = detectScaleUnitMismatch(2, 1, 1);
       assert.ok(m);
       assert.strictEqual(m!.effectiveScale, 2);
+      assert.strictEqual(m!.compensated, false);
+    });
+
+    it('reports a deviation just OUTSIDE the 0.5% band, not just tolerates one inside', () => {
+      // The noise test above pins 1.004 and 0.996 as null, so the band cannot be
+      // TIGHTENED without failing -- but nothing failed when it was widened, and
+      // at 5% it still passed every test in this file. A band is two-sided: pin
+      // the first value that must be reported, or only one direction is guarded.
+      assert.strictEqual(detectScaleUnitMismatch(1.004, 1, 1), null);
+      const over = detectScaleUnitMismatch(1.006, 1, 1);
+      assert.ok(over, '0.6% off unity must be reported, not swallowed by the band');
+      const under = detectScaleUnitMismatch(0.994, 1, 1);
+      assert.ok(under, '-0.6% off unity must be reported too');
+    });
+
+    it('does not call a small genuine mis-scaling compensated', () => {
+      // Every other `compensated` fixture sits at exactly 1 (heuristic fired) or
+      // far away (2, 1e6), so the 0.5% width of that band was never load-bearing:
+      // it could be widened a hundredfold unnoticed. Scale=1.2 is applied for
+      // real and is small enough to fall inside a sloppy band.
+      const m = detectScaleUnitMismatch(1.2, 1, 1);
+      assert.ok(m);
+      assert.strictEqual(m!.effectiveScale, 1.2);
       assert.strictEqual(m!.compensated, false);
     });
   });

--- a/apps/viewer/src/lib/zones/prism.test.ts
+++ b/apps/viewer/src/lib/zones/prism.test.ts
@@ -203,6 +203,55 @@ describe('prism volume on shapes a box cannot express', () => {
     assert.ok(Math.abs(volume - 0.4 * Math.SQRT2) < 1e-9, `diagonal band took ${volume}`);
   });
 
+  it('takes a trapezoid whose edges are NOT parallel, so the chord width varies with z', () => {
+    // Every other slanted fixture here is a PARALLELOGRAM (the diagonal band's
+    // two edges share a slope), which makes `bHi - bLo` zero and the far
+    // region's z-slope term vanish; the tiling case above asserts a + b = whole,
+    // an identity every divergence-1 field satisfies, so it cannot see the
+    // slope either. Between them the integrator's dependence on z was
+    // unobservable: `cz` could be forced to 0, or read off the Y component,
+    // with the whole suite still green.
+    //
+    // The box is deliberately 2 m tall and 1 m deep, rather than `wall()`, which
+    // is 1 x 1 in (y, z): a square end face has a diagonal triangulation
+    // symmetric under swapping y for z, which hides a `cz` that reads the Y
+    // component. Unequal extents make that swap observable too.
+    //
+    // The wedge has lo(z) = 1 and hi(z) = 2 + 2z, so bLo = 0 but bHi = 2 and the
+    // chord widens from 1 m at z = 0 to 3 m at z = 1. Its area is the trapezoid
+    // (1 + 3)/2 * 1 = 2, and it sits inside the box's x and z range, so the
+    // volume taken is 2 * the box's 2 m height = 4.
+    const tall = extrudeLoop([[0, 0], [6, 0], [6, 1], [0, 1]], 0, 2);
+    const wedge: FootprintPoint[] = [[1, 0], [2, 0], [4, 1], [1, 1]];
+    const traps = trapezoidsOfFootprint(wedge);
+    // Pin the asymmetry itself: if a future edit made this fixture a
+    // parallelogram again the assertion below would go quiet rather than fail.
+    assert.ok(
+      traps.some((t) => Math.abs(t.bHi - t.bLo) > 0.5),
+      `fixture must have non-parallel edges, got ${JSON.stringify(traps)}`,
+    );
+    const volume = clippedVolumeForPrism([tall], compilePrism(wedge, -1, 3));
+    assert.ok(Math.abs(volume - 4) < EPS, `wedge took ${volume}, expected 4`);
+  });
+
+  it('counts a face lying exactly on the hi(z) split plane ONCE', () => {
+    // The split at hi(z) hands a polygon to the inside branch or the far
+    // branch; a polygon lying exactly ON the plane satisfies both keep-tests, so
+    // a Sutherland-Hodgman split that kept it on each side would count that face
+    // twice. `accumulateTrapezoid` avoids that by testing `maxD <= 0` and
+    // `minD >= 0` before it ever splits -- and nothing pinned it, because no
+    // fixture put a face on a zone boundary at all, which is the ordinary case
+    // in a tiling plan rather than an edge case.
+    //
+    // This box ends exactly at x = 3 and the footprint's hi edge is x = 3, so
+    // the box's far face is coplanar with the split. The zone takes x in [1, 3]
+    // of a 3 x 2 x 1 m box: volume 4, and 8 if that face is counted twice.
+    const box = extrudeLoop([[0, 0], [3, 0], [3, 1], [0, 1]], 0, 2);
+    const flush: FootprintPoint[] = [[1, 0], [3, 0], [3, 1], [1, 1]];
+    const volume = clippedVolumeForPrism([box], compilePrism(flush, -1, 3));
+    assert.ok(Math.abs(volume - 4) < EPS, `flush face took ${volume}, expected 4`);
+  });
+
   it('sums to the whole across a footprint tiling, which is the invariant that matters', () => {
     // Two triangles that tile the wall's plan exactly, sharing the diagonal.
     const lower: FootprintPoint[] = [[-1, -1], [8, -1], [8, 2]];


### PR DESCRIPTION
Mutation-tested three viewer library modules that have **real logic and no owning test file** — exercised only incidentally by other suites. Tests only; **no source changed**, and no fix was manufactured where the code turned out to be sound.

All three findings are **untested-but-correct**: the code was right, the fixtures were structurally blind.

## 1. The trapezoid z-slope was unobservable

The only slanted fixture in `zones/prism-clip.ts` is a **parallelogram**, so `bHi − bLo` is zero in the far branch. And the tiling fixture asserts `a + b = whole` — **an identity every divergence-1 field satisfies**, so it cannot detect a wrong field at all.

Two survivors at 117/117: `cz = 0`, and `cz` reading the **Y** component.

```
wedge took 2, expected 4
wedge took 6, expected 4
```

The fixture-design detail worth repeating: the first attempt used `wall()`, whose end face is a **unit square — symmetric under y↔z** — and the wrong-component mutant survived it. Caught and replaced with non-parallel edges (`bLo=0, bHi=2`) and a **2×1** end face.

## 2. The split-plane tie-break was unpinned — and its twin was already pinned

No fixture ever put a mesh face **on** a zone boundary, which the code's own comment calls *"the common case in a tiling plan, not an edge case."*

Survivor: making both guards strict (`maxD < 0`, `minD > 0`) double-counts every coplanar face — 117/117 green.

```
flush face took 8, expected 4
```

**The same-shape grep is the strongest evidence here.** `zones/apportionment-clip.ts:236` carries the *identical* guard in the box path, and it **is** pinned — *"an element ending EXACTLY on a shared boundary gets no share of the neighbour."* Two paths that must agree, one with a test and one without. Now both have one.

## 3. `geo/geo-scale.ts` — bands pinned from one side only

- The 0.5% band was pinned only from the **tight** side: `1.004`/`0.996 → null` blocks narrowing, but **widening it tenfold, to 5%, passed everything.** Now pinned at both ends.
- `compensated` is only ever observed at exactly 1 or far away (2, 1e6), so its width was never load-bearing — **widening it 100× went unnoticed.** `Scale=1.2` lands inside a sloppy band and is applied for real.
- `inferMapUnitScale`'s CENTI/DECI/KILO branches had **no assertion at all**, and US-survey-foot precedence over FOOT was untested.

This is the both-ends rule from #2598/#2600: a band pinned from one side permits unbounded drift in the other.

## Negative evidence — 21 mutants killed

**`geo/viewer-enu-rotation.ts`: 4/4 killed** — negate gamma (4 fails), drop `hScale` (1), swap `absc`/`ordi` (6), `northFromVz` sign flip (10). **Genuinely well covered; nothing manufactured here.** Note `eastFromVz` and `northFromVx` are algebraically identical, so swapping them is an *equivalent* mutant rather than a gap.

**`prism-clip.ts`: 9/12 killed** — reject-beyond-maxX, area sign flip, centroid `/3→/2`, `cx` wrong component, `da >= 0 → > 0`, lo-clip using hi coefficients, far-weight operands swapped, minY/maxY swapped, inside perX `1→0`, fan start `i=1→2`.

**`geo-scale.ts`: 8 killed** — `expectedScale` operands swapped, both `specEffective` operand swaps, US-survey-foot ordering *and* value, MILLI value, `compensated:false`, heuristic `!rawScaleProvided` dropped, `resolveMapUnitToMetreScale` returning `lengthUnitScale`, METRE branch moved first.

## Classified as equivalent, deliberately not "fixed"

- `maxD <= 0` and `minD >= 0` mutated **individually** are value-equivalent: on the split plane the two branch weights coincide exactly (`x − lo(z) = hi(z) − lo(z)` when `x = hi(z)`). Only the **pair** double-counts — which is what the new test pins.
- Dropping the unit-mismatch half of the `geo-scale` heuristic: when `mus === lus`, `specEffective` is already 1.
- `!mapUnit` → `mapUnit === undefined`: `''` falls through to the same `return fallback`.
- `accumulate`'s `count < 3 → < 2`: the loop cannot run at count 2.

## Leads not chased — one worth flagging

**`clipPlane`'s `t` clamps and its `1e-12` denominator guard — the #1155 regression fix — can both be deleted with 119/119 green.** No fixture has a near-coincident plane. That is a real gap in a fix that exists specifically to prevent a regression; constructing a numerically meaningful near-degenerate case needs more care than the remaining budget allowed.

Also unexamined: `clash/federation-identity.ts` and `clash/visibility-ownership.ts` (277 lines, **zero test references**), and `geo/terrain-elevation.ts`.

## Verification

zones **117 → 119**, geo **149 → 153**. `tsc --noEmit` clean for both files (remaining errors are pre-existing unbuilt-workspace resolution failures); `oxlint` exit 0 on both.

Environment trap handled before trusting any run — a planted mutation was confirmed to fail 4 tests first. Two suites failed at baseline from missing workspace `dist/`: `@ifc-lite/pointcloud` was built to fix one, and `cesium-model-glb.test.ts` was excluded because `@ifc-lite/clash`'s build needs more of the graph than the disk budget allowed.

**No assertion weakened, no fixture adjusted, no skip added, no ratchet or digest touched.** The existing "tolerates tiny floating-point noise" assertion is untouched — the new test re-asserts `1.004 → null` **additively**, alongside the outside-the-band pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
