### PR TITLE
fix(viewer): main is red — the frame test pinned the pre-#3039 side normal

### DIFF
--- a/apps/viewer/src/store/slices/addElementMeshes.frame.test.ts
+++ b/apps/viewer/src/store/slices/addElementMeshes.frame.test.ts
@@ -107,12 +107,23 @@ describe('addElementMeshes: IFC storey-local to renderer frame (#2802)', () => {
 
     // The bottom face is [0, 0, -1] in IFC, so its x and y are BOTH zero and
     // it cannot see the `-face.normal[1]` term at all: flip that sign and the
-    // assertions above still pass. Vertices 8..11 are the first side face,
-    // IFC normal [0, 1, 0], which maps to renderer [0, 0, -1] and is the
-    // component that discriminates.
+    // assertions above still pass. Vertices 8..11 are the first side face, so
+    // that is the component which discriminates.
+    //
+    // That face is corners [0, 4, 5, 1], all four of which sit at y = -Depth/2,
+    // so it is the -Y face of the box and its OUTWARD IFC normal is [0, -1, 0],
+    // mapping to renderer [0, 0, +1].
+    //
+    // This assertion previously read `-1`, pinning [0, +1, 0] — the INWARD
+    // direction. It passed because the side normals were inward at the time,
+    // which is the defect #3039 fixed by orienting each face away from the box
+    // centre. So the expectation was pinned to behaviour that was wrong, and
+    // #3058 and #3039 were each green alone and red together. Computed rather
+    // than re-derived by eye: box centre (0, 0, 1.5), face centre (0, -1, 1.5),
+    // difference (0, -1, 0).
     near(n[24], 0, 'side normal x');
     near(n[25], 0, 'side normal y');
-    near(n[26], -1, 'side normal z (IFC +Y becomes renderer -Z)');
+    near(n[26], 1, 'side normal z (IFC -Y becomes renderer +Z)');
 
     // Every normal is unit length, so none was left un-normalised by the swap.
     // Note this alone cannot see a sign flip, which is why the component


### PR DESCRIPTION
**`main` is red and has been since `deaf4f088`.** Twelve completed Test runs have failed, all on the same single assertion:

```
apps/viewer/src/store/slices/addElementMeshes.frame.test.ts
  not ok 2 - maps normals through the same frame change as positions
    error: 'side normal z (IFC +Y becomes renderer -Z): expected -1, got 1'
  # tests 1772   # pass 1771   # fail 1
```

## A pair: each green alone, red together

- **#3058** added this test, pinning a side-face normal.
- **#3039** then made side normals point **outward**, orienting each face away from the box centre.

Neither is wrong by itself. #3058 was correct *about the code as it then stood*. Only the merged result is wrong, which is why per-PR verification could not catch it.

## #3039 is right; the test pinned the inward normal

Computed against the real corner order rather than re-derived by eye:

```
column Width=1 Depth=2 Height=3, buildAxisBox
box centre       (0,  0, 1.5)
face [0,4,5,1]   all four corners at y = -1, centre (0, -1, 1.5)
outward normal   (0, -1, 0) IFC  ->  renderer (0, 0, +1)
test expected    (0, +1, 0) IFC  ->  renderer (0, 0, -1)
```

That face is the −Y side of the box, so outward points at −Y. The old expectation pinned **inward**, and it passed because the side normals *were* inward — the defect #3039 fixed.

So this is the one case where editing an assertion is correct: the behaviour genuinely changed and the assertion was pinned to the old, wrong behaviour.

## Reverting #3039 is not available, and outward is substantively right

`addElementMeshes.test.ts:148-262`, also from #3039, is a general property test that *every* vertex normal of *every* box shape points away from the centre. Against inward normals it fails 6 assertions. Reverting would mean deleting that file too.

It also matters visually. The renderer draws with `cullMode: 'none'`, so backfaces are unaffected — but the shader takes its shading normal's **sign** from the vertex normal (`main.wgsl.ts:433-435`, `N = N * sign(alignDot)`). The diffuse terms use `abs()` and do not care, but the rim light `max(dot(N, rimLight), 0.0)` and the transparency fresnel do. With `rimLight = normalize(0, 0.2, -1)`, the −Y face's outward `(0,0,1)` gives `dot ≈ -0.98` (no rim); inward gives `+0.98` (full rim). The preview was rim-lighting exactly the faces that should not have it.

## Proof it does not weaken the test

Changing an assertion demands showing it still discriminates, so the mutation was run rather than argued:

```
invert #3039's orientation (normals inward again)   1 of 7 fails
restored                                             7 of 7 pass
addElementMeshes.test.ts (#3039's own suite)       20 of 20 pass
whole apps/viewer/src/store/slices suite          823 of 823 pass
```

Nothing else pins the old direction. A repo-wide sweep of normal consumers — GPU packing, collab wire encode, GLB export, the three.js playground — found none expecting inward, and there are no snapshots or goldens encoding normals.

## The comment now derives the geometry instead of asserting it

The old text stated `IFC normal [0, 1, 0]` as fact, which is what let a wrong sign survive review. It now shows the corner indices, the two centres and the difference, so a reader can check it in place.

## Why this was invisible

Both PRs were verified green before merging and both verifications were correct. Only a completed run on the merged result can see a pair like this, and `main`'s Test queue was 18 commits deep when both landed. Merge cadence below one commit per test-duration does not degrade that signal, it removes it.

No changeset: test-only, as #3058 was.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected side-face orientation so outward-facing normals are rendered properly.
  * Fixed IFC `-Y` normals mapping to the renderer’s expected `+Z` direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->