### PR TITLE
fix(scripts): the CSV escaper gate red on a comment describing the pattern

### DIFF
--- a/scripts/check-csv-escaper-copies.mjs
+++ b/scripts/check-csv-escaper-copies.mjs
@@ -15,10 +15,29 @@
  * delimiter. Correcting nine copies only resets the clock — they drift again.
  * This gate is what stops a tenth appearing.
  *
- * Two patterns are looked for, because they are what every copy had in common:
+ * Three patterns are looked for, because they are what every copy had in common:
  *
- *   1. the formula-trigger character class `[=+\-@\t\r]` / `'=' | '+' | ...`
- *   2. RFC 4180 quote-doubling — replacing `"` with `""`
+ *   1. the formula-trigger character class `[=+\-@\t\r]` (TS/JS)
+ *   2. the same triggers as a Rust match arm, `'=' | '+' | ...`
+ *   3. RFC 4180 quote-doubling — replacing `"` with `""`
+ *
+ * DESIGN: the scan is a raw, per-line, stateless grep. Comments and strings are
+ * scanned exactly like code — nothing is blanked, skipped, or tokenised. Six
+ * attempts at comment-awareness (leading-character skips, block-state tracking,
+ * a string- and regex-aware tokeniser) each shipped a hole, and every hole was
+ * the same shape: a live, working escaper made invisible. A classifier that
+ * decides "this text is a comment" can be wrong in only one useful direction,
+ * and it was wrong in the other one six times. Statelessness is the structural
+ * fix: no line's classification depends on any other line, so no context —
+ * string, template, lifetime, nested comment — can hide a match.
+ *
+ * The cost is that prose NAMING a pattern (a comment quoting the trigger regex)
+ * matches too. That is handled by PROSE_MENTIONS below: an exact-line registry
+ * with the same ratchet semantics as KNOWN_REMAINING. In this repo's whole
+ * history exactly two such lines exist, so the registry is two entries, and a
+ * new doc comment that quotes a pattern costs its author one visible, guided,
+ * one-line registration — a false red someone resolves in a minute, never a
+ * false green nobody sees.
  *
  * Run: `node scripts/check-csv-escaper-copies.mjs`
  * Self-test: `node --test scripts/check-csv-escaper-copies.test.mjs`
@@ -62,8 +81,11 @@ export const NON_IMPLEMENTATION = [
  *
  *  * a NEW copy anywhere fails the gate — this list cannot absorb it, because
  *    entries are matched by exact path;
- *  * an entry that no longer matches any pattern ALSO fails the gate, so the
- *    list shrinks when the debt is paid instead of lingering as dead config.
+ *  * an entry whose CODE no longer matches any pattern ALSO fails the gate, so
+ *    the list shrinks when the debt is paid instead of lingering as dead
+ *    config. Prose mentions inside the file do not keep an entry alive — see
+ *    PROSE_MENTIONS — so deleting the copy while keeping its history comment
+ *    still trips the ratchet.
  *
  * `packages/lists/src/engine.ts` — the library's Lists CSV writer. Left here
  * for two reasons, both structural rather than discretionary:
@@ -81,8 +103,11 @@ export const KNOWN_REMAINING = ['packages/lists/src/engine.ts'];
 export const PATTERNS = [
   {
     name: 'formula-trigger character class',
-    // The TS spelling: a character class holding =, +, -, @ together.
-    re: /\[=\+\\?-@/,
+    // The TS spelling: a character class holding =, +, -, @ together. Any
+    // number of backslashes before the `-`, because the same class written as
+    // a STRING for `new RegExp("^[=+\\-@\\t\\r]")` doubles them — a working
+    // escaper the single-backslash spelling missed.
+    re: /\[=\+\\*-@/,
     hint: 'call escapeCsvCell()/guardSpreadsheetFormula() from @ifc-lite/export, or escape_csv_cell() from ifc_lite_export::csv_cell',
   },
   {
@@ -99,6 +124,84 @@ export const PATTERNS = [
   },
 ];
 
+/**
+ * Individual comment lines that quote a pattern while documenting it. Each
+ * entry excuses a hit only when BOTH match exactly: the file path AND the full
+ * trimmed line text. Ratcheted like KNOWN_REMAINING: an entry that no longer
+ * matches a hit fails the gate and must be deleted.
+ *
+ * Why exact lines instead of comment detection: deciding "is this text a
+ * comment" requires tracking string, template, regex, and comment state across
+ * the whole file in three languages, and six attempts at that each hid a live
+ * escaper. Exact-line registration cannot hide one, by construction:
+ *
+ *  * excusal requires the WHOLE trimmed line to equal a registered sentence,
+ *    so any code sharing the line changes the text and the hit stands;
+ *  * `validateMentions()` (run at import) requires each entry to start with
+ *    `//` and to contain neither `${` nor the star-slash block terminator
+ *    (not spelled here: writing it would close this docblock). Under every
+ *    grammar this repo scans, a line satisfying that is either a comment or
+ *    inert string/JSX data — it cannot EXECUTE. `${` is excluded because
+ *    template interpolation is the one way a `//`-leading line can run code;
+ *    the terminator because it could hand the line's tail back to the
+ *    compiler. Feeding the registered text to `new RegExp` yields a pattern
+ *    prefixed with the English prose, which cannot match a bare trigger cell
+ *    — demonstrated by execution in the self-test.
+ *
+ * The registry does NOT generalise to unregistered prose: a new comment that
+ * quotes a pattern reds the gate until its author registers the line here.
+ * That is the chosen trade. The unwritten tenth copy is code someone writes on
+ * purpose, in whatever shape they find natural (the canonical implementation
+ * itself defines its regex on a standalone line, so no adjacency or context
+ * rule survives contact with real style); prose collisions are accidents, rare
+ * (two lines in 4255 files across the repo's history), and each costs one
+ * visible, self-explanatory line here. A false red is a minute of a
+ * documenter's time; a false green is the tenth copy shipping.
+ */
+export const PROSE_MENTIONS = [
+  {
+    file: 'packages/lists/src/engine.rfc4180.test.ts',
+    text: '// is not a formula to an anchored `/^[=+\\-@\\t\\r]/` but it is one to Excel.',
+  },
+  {
+    file: 'packages/lists/src/engine.ts',
+    text: '// anchored `/^[=+\\-@\\t\\r]/` matching, so `\\uFEFF=HYPERLINK(...)` used to',
+  },
+];
+
+/**
+ * Refuse registry entries that could excuse executable text. Throws on the
+ * first invalid entry; runs against the real registry at import time so the
+ * gate cannot even load with an unsafe entry.
+ */
+export function validateMentions(mentions = PROSE_MENTIONS) {
+  for (const m of mentions) {
+    const id = `PROSE_MENTIONS entry for ${m.file}`;
+    if (typeof m.file !== 'string' || typeof m.text !== 'string') {
+      throw new Error(`${id}: needs string \`file\` and \`text\``);
+    }
+    if (m.text !== m.text.trim()) {
+      throw new Error(`${id}: text must be trimmed (hits are compared trimmed)`);
+    }
+    if (!m.text.startsWith('//')) {
+      throw new Error(`${id}: must be a \`//\` line comment; block-comment bodies carry no marker of their own and cannot be excused safely`);
+    }
+    if (m.text.includes('${')) {
+      throw new Error(`${id}: \`\${\` would execute inside a template literal, so the line would not be inert`);
+    }
+    if (m.text.includes('*/')) {
+      throw new Error(`${id}: \`*/\` could close an open block comment and hand the tail back to the compiler`);
+    }
+    if (!PATTERNS.some((p) => p.re.test(m.text))) {
+      throw new Error(`${id}: matches no PATTERN, so it can never excuse a hit — delete it`);
+    }
+    if (CANONICAL.includes(m.file) || NON_IMPLEMENTATION.includes(m.file)) {
+      throw new Error(`${id}: that file is already exempt wholesale`);
+    }
+  }
+}
+validateMentions();
+
 /** Repository-tracked files worth scanning. */
 function candidateFiles() {
   const out = execFileSync(
@@ -110,138 +213,21 @@ function candidateFiles() {
 }
 
 /**
- * Blank out comment CONTENT, leaving code and line structure intact.
+ * Scan one file's text; returns every pattern hit in it, comments included.
  *
- * Four leading-character heuristics were tried before this and each shipped a
- * hole, every time in the same direction -- a real escaper made invisible:
- *
- *   skip `//`, `*`, `/*`   missed Rust `*out = matches!(..)` and `/* c *""/ code`
- *   skip `//` only         missed `/* \n // *""/ code`, where `*""/` resumes the line
- *   track block state      missed code after `const s = "/* x";`
- *   plus a star-space rule missed `* quote(cells) {}`, a live JS generator method
- *
- * All four passed the same 17 tests. A leading character cannot decide whether
- * a line is a comment, because that depends on what precedes it on the SAME
- * line and on the lines above. So this walks the text once, tracking the only
- * states that change what a character means: line comment, block comment, the
- * three string flavours, and regex literals.
- *
- * Comment characters become spaces rather than being deleted, so line numbers
- * and columns survive and a pattern can still match code sharing a line with a
- * trailing comment.
- *
- * THE SAFETY PROPERTY, stated because the four attempts above each rested on an
- * unstated one that turned out false: **only comment content is blanked.**
- * Strings and regexes are skipped over, never written to. So every way this can
- * be wrong about where a string ends -- a Rust char literal `'='`, a lifetime
- * `&'a str`, an unterminated quote, a backtick inside a single-quoted string --
- * costs at most a MISSED comment, which is a false red. None of them can hide a
- * line of code, because hiding requires writing spaces and that happens only
- * inside a proven block-comment or line-comment run.
- *
- * (Deliberately NOT spelling the block terminator here: writing it inside this
- * docblock closes the docblock, which is how this very edit first broke the
- * file -- the same hazard as the backtick that closed the codegen template.)
- *
- * Verified rather than asserted: `matches!(c, '=' | '+' | '-' | '@')` is still
- * caught after a lifetime declaration and after an unterminated `'`.
- *
- * Rust block comments nest and this does not track depth, so a nested comment
- * closes early and its tail is scanned as code. Same direction: scanning MORE
- * is a false red someone investigates rather than a bypass nobody sees.
+ * Deliberately stateless and raw: each line is tested against each pattern
+ * with no transformation, so nothing that happens on one line — an unclosed
+ * string, a block comment, a template literal — can hide a match on another.
+ * Whether a hit is EXCUSED (canonical file, known copy, registered prose
+ * mention) is policy, and all of it lives in scanRepo.
  */
-const REGEX_KEYWORD = /^(return|typeof|instanceof|in|of|case|yield|await|delete|void|new|do|else)$/;
-
-export function blankComments(text) {
-  const out = text.split('');
-  const n = text.length;
-  let i = 0;
-  // Regex-vs-division turns on the previous significant character: `/` after a
-  // value is division, after an operator or opener it starts a regex.
-  let prevSig = '';
-  let prevWord = '';
-  while (i < n) {
-    const c = text[i];
-    const d = text[i + 1];
-    if (c === '/' && d === '/') {
-      while (i < n && text[i] !== '\n') { out[i] = ' '; i += 1; }
-      continue;
-    }
-    if (c === '/' && d === '*') {
-      out[i] = ' '; out[i + 1] = ' '; i += 2;
-      while (i < n && !(text[i] === '*' && text[i + 1] === '/')) {
-        if (text[i] !== '\n') out[i] = ' ';
-        i += 1;
-      }
-      if (i < n) { out[i] = ' '; out[i + 1] = ' '; i += 2; }
-      prevSig = 'x';
-      continue;
-    }
-    if (c === '"' || c === "'" || c === '`') {
-      // RESYNC AT THE NEWLINE for ' and ". Neither can span a line in JS, TS or
-      // ordinary Rust, and without the bound one unpaired quote in CODE opens a
-      // fake string that runs to the next quote ANYWHERE in the file, losing
-      // phase for everything after it. That is not hypothetical: a Rust
-      // lifetime `&'a str` has an odd number of quotes, and so does a JSX
-      // contraction like `What's New`. 170 .rs files and any .tsx with a
-      // contraction were affected, leaving real comments unblanked (a false
-      // red) and, once phase inverts, letting a `//` inside a real string blank
-      // live code (a bypass).
-      //
-      // Backticks DO span lines, so they are not bounded. An unterminated one
-      // still costs at most a missed comment, never a hidden line of code.
-      const bounded = c !== '`';
-      i += 1;
-      while (i < n) {
-        if (bounded && text[i] === '\n') break;
-        if (text[i] === '\\') { i += 2; continue; }
-        if (text[i] === c) { i += 1; break; }
-        i += 1;
-      }
-      prevSig = 'x';
-      continue;
-    }
-    // A `/` opens a regex after an operator or opener, and also after a keyword
-    // -- `return /["]/.test(s)` is a regex, not division. Without the keyword
-    // arm the quote inside it was read as a string opener and shifted phase.
-    if (c === '/' && (/[=(,:;[{!&|?+\-*%~^<>]/.test(prevSig) || REGEX_KEYWORD.test(prevWord))) {
-      i += 1;
-      while (i < n && text[i] !== '\n') {
-        if (text[i] === '\\') { i += 2; continue; }
-        if (text[i] === '[') { while (i < n && text[i] !== ']' && text[i] !== '\n') i += 1; }
-        if (text[i] === '/') { i += 1; break; }
-        i += 1;
-      }
-      prevSig = 'x';
-      continue;
-    }
-    if (/[A-Za-z_$]/.test(c)) {
-      let k = i;
-      while (k < n && /[A-Za-z0-9_$]/.test(text[k])) k += 1;
-      prevWord = text.slice(i, k);
-      prevSig = text[k - 1];
-      i = k;
-      continue;
-    }
-    if (!/\s/.test(c)) { prevSig = c; prevWord = ''; }
-    i += 1;
-  }
-  return out.join('');
-}
-
-/** Scan one file's text; returns the violations found in it. */
 export function scanText(relPath, text) {
   const normalized = relPath.split(sep).join('/');
-  if (CANONICAL.includes(normalized) || NON_IMPLEMENTATION.includes(normalized)) return [];
   const found = [];
   const rawLines = text.split('\n');
-  // Comment CONTENT is blanked, code is not. A pattern can therefore still
-  // match code that shares a line with a comment, while prose describing the
-  // pattern -- which is what every fix for this defect writes -- cannot red it.
-  const lines = blankComments(text).split('\n');
   for (const p of PATTERNS) {
-    for (let i = 0; i < lines.length; i++) {
-      if (p.re.test(lines[i])) {
+    for (let i = 0; i < rawLines.length; i++) {
+      if (p.re.test(rawLines[i])) {
         found.push({ file: normalized, line: i + 1, pattern: p.name, hint: p.hint, text: rawLines[i].trim() });
       }
     }
@@ -257,8 +243,10 @@ export function scanRepo(files = candidateFiles(), read = (f) => readFileSync(jo
       `refusing to pass on a suspiciously small file list (${files.length}); the scan is broken, not clean`,
     );
   }
+  const exempt = new Set([...CANONICAL, ...NON_IMPLEMENTATION]);
   const hits = [];
   for (const f of files) {
+    if (exempt.has(f.split(sep).join('/'))) continue;
     let text;
     try {
       text = read(f);
@@ -267,15 +255,28 @@ export function scanRepo(files = candidateFiles(), read = (f) => readFileSync(jo
     }
     hits.push(...scanText(f, text));
   }
+
+  // Excuse registered prose mentions: exact file AND exact trimmed line.
+  const usedMentions = new Set();
+  const remaining = hits.filter((h) => {
+    const idx = PROSE_MENTIONS.findIndex((m) => m.file === h.file && m.text === h.text);
+    if (idx === -1) return true;
+    usedMentions.add(idx);
+    return false;
+  });
+  const staleMentions = PROSE_MENTIONS.filter((_, i) => !usedMentions.has(i));
+
   const known = new Set(KNOWN_REMAINING);
-  const violations = hits.filter((h) => !known.has(h.file));
-  const stillHit = new Set(hits.filter((h) => known.has(h.file)).map((h) => h.file));
+  const violations = remaining.filter((h) => !known.has(h.file));
+  // KNOWN_REMAINING liveness counts only non-prose hits, so paying the debt
+  // trips the ratchet even if a history comment naming the pattern stays.
+  const stillHit = new Set(remaining.filter((h) => known.has(h.file)).map((h) => h.file));
   const staleKnown = KNOWN_REMAINING.filter((k) => !stillHit.has(k));
-  return { scanned: files.length, violations, staleKnown, known: [...stillHit] };
+  return { scanned: files.length, violations, staleKnown, staleMentions, known: [...stillHit] };
 }
 
 function main() {
-  const { scanned, violations, staleKnown, known } = scanRepo();
+  const { scanned, violations, staleKnown, staleMentions, known } = scanRepo();
   let failed = false;
 
   if (violations.length > 0) {
@@ -289,6 +290,10 @@ function main() {
     for (const v of violations) {
       process.stderr.write(`  ${v.file}:${v.line}  [${v.pattern}]\n      ${v.text}\n      → ${v.hint}\n`);
     }
+    process.stderr.write(
+      '\nIf a flagged line is a COMMENT that documents the pattern rather than code,\n' +
+        'register its exact text in PROSE_MENTIONS in scripts/check-csv-escaper-copies.mjs.\n',
+    );
   }
 
   if (staleKnown.length > 0) {
@@ -297,6 +302,15 @@ function main() {
       'KNOWN_REMAINING is stale — these no longer hand-roll an escaper, so delete them\n' +
         'from the list (it is a ratchet; it must shrink, never linger):\n' +
         staleKnown.map((k) => `  - ${k}\n`).join(''),
+    );
+  }
+
+  if (staleMentions.length > 0) {
+    failed = true;
+    process.stderr.write(
+      'PROSE_MENTIONS is stale — these registered comment lines no longer exist, so\n' +
+        'delete them (it is a ratchet; it must shrink, never linger):\n' +
+        staleMentions.map((m) => `  - ${m.file}: ${m.text}\n`).join(''),
     );
   }
 

--- a/scripts/check-csv-escaper-copies.mjs
+++ b/scripts/check-csv-escaper-copies.mjs
@@ -160,10 +160,6 @@ export const PATTERNS = [
  */
 export const PROSE_MENTIONS = [
   {
-    file: 'packages/lists/src/engine.rfc4180.test.ts',
-    text: '// is not a formula to an anchored `/^[=+\\-@\\t\\r]/` but it is one to Excel.',
-  },
-  {
     file: 'packages/lists/src/engine.ts',
     text: '// anchored `/^[=+\\-@\\t\\r]/` matching, so `\\uFEFF=HYPERLINK(...)` used to',
   },
@@ -235,7 +231,15 @@ export function scanText(relPath, text) {
   return found;
 }
 
-export function scanRepo(files = candidateFiles(), read = (f) => readFileSync(join(REPO_ROOT, f), 'utf8')) {
+export function scanRepo(
+  files = candidateFiles(),
+  read = (f) => readFileSync(join(REPO_ROOT, f), 'utf8'),
+  // Injectable so the behavioural tests build their own fixtures instead of
+  // binding to whatever the live registry happens to hold. A registry entry is
+  // deleted the moment its line is reworded, so tests keyed to it break for a
+  // reason that has nothing to do with the behaviour they cover.
+  mentions = PROSE_MENTIONS,
+) {
   // A tiny file list means the glob or `git ls-files` silently failed, which
   // would make this gate pass vacuously — the one way a grep gate lies.
   if (files.length < 100) {
@@ -259,12 +263,12 @@ export function scanRepo(files = candidateFiles(), read = (f) => readFileSync(jo
   // Excuse registered prose mentions: exact file AND exact trimmed line.
   const usedMentions = new Set();
   const remaining = hits.filter((h) => {
-    const idx = PROSE_MENTIONS.findIndex((m) => m.file === h.file && m.text === h.text);
+    const idx = mentions.findIndex((m) => m.file === h.file && m.text === h.text);
     if (idx === -1) return true;
     usedMentions.add(idx);
     return false;
   });
-  const staleMentions = PROSE_MENTIONS.filter((_, i) => !usedMentions.has(i));
+  const staleMentions = mentions.filter((_, i) => !usedMentions.has(i));
 
   const known = new Set(KNOWN_REMAINING);
   const violations = remaining.filter((h) => !known.has(h.file));

--- a/scripts/check-csv-escaper-copies.mjs
+++ b/scripts/check-csv-escaper-copies.mjs
@@ -109,16 +109,140 @@ function candidateFiles() {
   return out.split('\0').filter(Boolean);
 }
 
+/**
+ * Blank out comment CONTENT, leaving code and line structure intact.
+ *
+ * Four leading-character heuristics were tried before this and each shipped a
+ * hole, every time in the same direction -- a real escaper made invisible:
+ *
+ *   skip `//`, `*`, `/*`   missed Rust `*out = matches!(..)` and `/* c *""/ code`
+ *   skip `//` only         missed `/* \n // *""/ code`, where `*""/` resumes the line
+ *   track block state      missed code after `const s = "/* x";`
+ *   plus a star-space rule missed `* quote(cells) {}`, a live JS generator method
+ *
+ * All four passed the same 17 tests. A leading character cannot decide whether
+ * a line is a comment, because that depends on what precedes it on the SAME
+ * line and on the lines above. So this walks the text once, tracking the only
+ * states that change what a character means: line comment, block comment, the
+ * three string flavours, and regex literals.
+ *
+ * Comment characters become spaces rather than being deleted, so line numbers
+ * and columns survive and a pattern can still match code sharing a line with a
+ * trailing comment.
+ *
+ * THE SAFETY PROPERTY, stated because the four attempts above each rested on an
+ * unstated one that turned out false: **only comment content is blanked.**
+ * Strings and regexes are skipped over, never written to. So every way this can
+ * be wrong about where a string ends -- a Rust char literal `'='`, a lifetime
+ * `&'a str`, an unterminated quote, a backtick inside a single-quoted string --
+ * costs at most a MISSED comment, which is a false red. None of them can hide a
+ * line of code, because hiding requires writing spaces and that happens only
+ * inside a proven block-comment or line-comment run.
+ *
+ * (Deliberately NOT spelling the block terminator here: writing it inside this
+ * docblock closes the docblock, which is how this very edit first broke the
+ * file -- the same hazard as the backtick that closed the codegen template.)
+ *
+ * Verified rather than asserted: `matches!(c, '=' | '+' | '-' | '@')` is still
+ * caught after a lifetime declaration and after an unterminated `'`.
+ *
+ * Rust block comments nest and this does not track depth, so a nested comment
+ * closes early and its tail is scanned as code. Same direction: scanning MORE
+ * is a false red someone investigates rather than a bypass nobody sees.
+ */
+const REGEX_KEYWORD = /^(return|typeof|instanceof|in|of|case|yield|await|delete|void|new|do|else)$/;
+
+export function blankComments(text) {
+  const out = text.split('');
+  const n = text.length;
+  let i = 0;
+  // Regex-vs-division turns on the previous significant character: `/` after a
+  // value is division, after an operator or opener it starts a regex.
+  let prevSig = '';
+  let prevWord = '';
+  while (i < n) {
+    const c = text[i];
+    const d = text[i + 1];
+    if (c === '/' && d === '/') {
+      while (i < n && text[i] !== '\n') { out[i] = ' '; i += 1; }
+      continue;
+    }
+    if (c === '/' && d === '*') {
+      out[i] = ' '; out[i + 1] = ' '; i += 2;
+      while (i < n && !(text[i] === '*' && text[i + 1] === '/')) {
+        if (text[i] !== '\n') out[i] = ' ';
+        i += 1;
+      }
+      if (i < n) { out[i] = ' '; out[i + 1] = ' '; i += 2; }
+      prevSig = 'x';
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      // RESYNC AT THE NEWLINE for ' and ". Neither can span a line in JS, TS or
+      // ordinary Rust, and without the bound one unpaired quote in CODE opens a
+      // fake string that runs to the next quote ANYWHERE in the file, losing
+      // phase for everything after it. That is not hypothetical: a Rust
+      // lifetime `&'a str` has an odd number of quotes, and so does a JSX
+      // contraction like `What's New`. 170 .rs files and any .tsx with a
+      // contraction were affected, leaving real comments unblanked (a false
+      // red) and, once phase inverts, letting a `//` inside a real string blank
+      // live code (a bypass).
+      //
+      // Backticks DO span lines, so they are not bounded. An unterminated one
+      // still costs at most a missed comment, never a hidden line of code.
+      const bounded = c !== '`';
+      i += 1;
+      while (i < n) {
+        if (bounded && text[i] === '\n') break;
+        if (text[i] === '\\') { i += 2; continue; }
+        if (text[i] === c) { i += 1; break; }
+        i += 1;
+      }
+      prevSig = 'x';
+      continue;
+    }
+    // A `/` opens a regex after an operator or opener, and also after a keyword
+    // -- `return /["]/.test(s)` is a regex, not division. Without the keyword
+    // arm the quote inside it was read as a string opener and shifted phase.
+    if (c === '/' && (/[=(,:;[{!&|?+\-*%~^<>]/.test(prevSig) || REGEX_KEYWORD.test(prevWord))) {
+      i += 1;
+      while (i < n && text[i] !== '\n') {
+        if (text[i] === '\\') { i += 2; continue; }
+        if (text[i] === '[') { while (i < n && text[i] !== ']' && text[i] !== '\n') i += 1; }
+        if (text[i] === '/') { i += 1; break; }
+        i += 1;
+      }
+      prevSig = 'x';
+      continue;
+    }
+    if (/[A-Za-z_$]/.test(c)) {
+      let k = i;
+      while (k < n && /[A-Za-z0-9_$]/.test(text[k])) k += 1;
+      prevWord = text.slice(i, k);
+      prevSig = text[k - 1];
+      i = k;
+      continue;
+    }
+    if (!/\s/.test(c)) { prevSig = c; prevWord = ''; }
+    i += 1;
+  }
+  return out.join('');
+}
+
 /** Scan one file's text; returns the violations found in it. */
 export function scanText(relPath, text) {
   const normalized = relPath.split(sep).join('/');
   if (CANONICAL.includes(normalized) || NON_IMPLEMENTATION.includes(normalized)) return [];
   const found = [];
+  const rawLines = text.split('\n');
+  // Comment CONTENT is blanked, code is not. A pattern can therefore still
+  // match code that shares a line with a comment, while prose describing the
+  // pattern -- which is what every fix for this defect writes -- cannot red it.
+  const lines = blankComments(text).split('\n');
   for (const p of PATTERNS) {
-    const lines = text.split('\n');
     for (let i = 0; i < lines.length; i++) {
       if (p.re.test(lines[i])) {
-        found.push({ file: normalized, line: i + 1, pattern: p.name, hint: p.hint, text: lines[i].trim() });
+        found.push({ file: normalized, line: i + 1, pattern: p.name, hint: p.hint, text: rawLines[i].trim() });
       }
     }
   }

--- a/scripts/check-csv-escaper-copies.test.mjs
+++ b/scripts/check-csv-escaper-copies.test.mjs
@@ -22,10 +22,10 @@ const { scanText, scanRepo, CANONICAL, KNOWN_REMAINING, PROSE_MENTIONS, validate
  * Drive scanRepo with synthetic file contents. Real repo files not named in
  * `overrides` read as empty; padding files satisfy the vacuous-scan guard.
  */
-function repoWith(overrides) {
+function repoWith(overrides, mentions) {
   const pad = Array.from({ length: 120 }, (_, i) => `packages/pad/src/p${i}.ts`);
   const files = [...new Set([...Object.keys(overrides), ...pad])];
-  return scanRepo(files, (f) => overrides[f] ?? '');
+  return scanRepo(files, (f) => overrides[f] ?? '', mentions);
 }
 
 /** The ten real copies this gate exists because of, in their original form. */
@@ -192,7 +192,18 @@ describe('no context hides a live escaper', () => {
 // time via PROSE_MENTIONS, ratcheted like KNOWN_REMAINING.
 // ---------------------------------------------------------------------------
 describe('prose mentions', () => {
-  const [MENTION, ENGINE_MENTION] = PROSE_MENTIONS;
+  // Fixtures, NOT the live registry. Binding these to PROSE_MENTIONS by position
+  // coupled every case below to how many entries the registry happened to hold:
+  // #3107 reworded the line one entry pinned, the entry was deleted, and all
+  // seven cases broke for a reason unrelated to what they test. The real
+  // registry is still exercised, by `validateMentions()` and by the
+  // regex-source case at the end of this block.
+  const MENTION = {
+    file: 'packages/lists/src/fixture-doc.test.ts',
+    text: '// is not a formula to an anchored `/^[=+\\-@\\t\\r]/` but it is one to Excel.',
+  };
+  const [ENGINE_MENTION] = PROSE_MENTIONS;
+  const MENTIONS = [MENTION, ENGINE_MENTION];
   const ENGINE_CODE =
     '      /^[\\p{Cf}\\p{Z}]*[=+\\-@\\t\\r]/u.test(str) &&\n' +
     '      return `"${str.replace(/"/g, \'""\')}"`;\n';
@@ -201,7 +212,7 @@ describe('prose mentions', () => {
     const { violations, staleMentions } = repoWith({
       [MENTION.file]: `const TRIGGERS = ['=', '+'];\n${MENTION.text}\n`,
       [ENGINE_MENTION.file]: `    ${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
-    });
+    }, MENTIONS);
     assert.deepEqual(violations, []);
     assert.deepEqual(staleMentions, []);
   });
@@ -211,7 +222,7 @@ describe('prose mentions', () => {
       'packages/export/src/other.ts': `${MENTION.text}\n`,
       [MENTION.file]: `${MENTION.text}\n`,
       [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
-    });
+    }, MENTIONS);
     assert.equal(violations.length, 1);
     assert.equal(violations[0].file, 'packages/export/src/other.ts');
   });
@@ -222,7 +233,7 @@ describe('prose mentions', () => {
     const { violations } = repoWith({
       [MENTION.file]: `${MENTION.text}\n${copy}\n`,
       [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
-    });
+    }, MENTIONS);
     assert.equal(violations.length, 1, 'the escaper next to the registered comment must still red');
     assert.equal(violations[0].file, MENTION.file);
   });
@@ -233,7 +244,7 @@ describe('prose mentions', () => {
     const { violations } = repoWith({
       [MENTION.file]: `${MENTION.text}\n${line}\n`,
       [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
-    });
+    }, MENTIONS);
     assert.equal(violations.length, 1);
   });
 
@@ -242,7 +253,7 @@ describe('prose mentions', () => {
       'packages/export/src/newdoc.ts': '// never hand-roll the anchored `/^[=+\\-@\\t\\r]/` guard\n',
       [MENTION.file]: `${MENTION.text}\n`,
       [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
-    });
+    }, MENTIONS);
     assert.equal(violations.length, 1, 'a new prose mention must be registered, not silently excused');
   });
 
@@ -250,7 +261,7 @@ describe('prose mentions', () => {
     const { staleMentions } = repoWith({
       [MENTION.file]: 'const nothing = 1;\n',
       [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
-    });
+    }, MENTIONS);
     assert.deepEqual(staleMentions, [MENTION]);
   });
 
@@ -260,7 +271,7 @@ describe('prose mentions', () => {
     const { staleKnown, staleMentions } = repoWith({
       [MENTION.file]: `${MENTION.text}\n`,
       [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\nexport const done = escapeCsvCell;\n`,
-    });
+    }, MENTIONS);
     assert.deepEqual(staleKnown, KNOWN_REMAINING, 'comment-only liveness must not keep the debt entry alive');
     assert.deepEqual(staleMentions, []);
   });

--- a/scripts/check-csv-escaper-copies.test.mjs
+++ b/scripts/check-csv-escaper-copies.test.mjs
@@ -228,6 +228,16 @@ describe('prose mentions', () => {
     // oxlint-disable-next-line no-template-curly-in-string
     '      return `"${str.replace(/"/g, \'""\')}"`;\n';
 
+  // The same paired probe its siblings carry at :252 and :263. Every case below
+  // feeds ENGINE_CODE in as engine.ts's body and then asserts something about
+  // the OTHER file, so an inert ENGINE_CODE would leave all of them green:
+  // neutering it to `return str;` passes 46/46. This makes the fixture prove it
+  // is still an escaper before any of that means anything.
+  assert.ok(
+    scanText(ENGINE_MENTION.file, ENGINE_CODE).length >= 1,
+    'ENGINE_CODE no longer reads as an escaper; every case using it is vacuous',
+  );
+
   it('the registered line, in its registered file, does not red', () => {
     const { violations, staleMentions } = repoWith({
       [MENTION.file]: `const TRIGGERS = ['=', '+'];\n${MENTION.text}\n`,

--- a/scripts/check-csv-escaper-copies.test.mjs
+++ b/scripts/check-csv-escaper-copies.test.mjs
@@ -12,7 +12,7 @@
  *
  * Run: `node --test scripts/check-csv-escaper-copies.test.mjs`
  */
-import { test, describe, it } from 'node:test';
+import { test, describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import * as gate from './check-csv-escaper-copies.mjs';
 
@@ -214,10 +214,6 @@ describe('prose mentions', () => {
   // named assertion instead of six cascading ones, and a bind that survives
   // reordering.
   const ENGINE_MENTION = PROSE_MENTIONS.find((m) => m.file === KNOWN_REMAINING[0]);
-  assert.ok(
-    ENGINE_MENTION,
-    `no PROSE_MENTIONS entry for ${KNOWN_REMAINING[0]}; these cases pin its interaction with the debt ratchet`,
-  );
   const MENTIONS = [MENTION, ENGINE_MENTION];
   // A FIXTURE, not code: this is what `engine.ts` looks like to the scanner, so
   // the `${` has to survive verbatim into the scanned text. oxlint's
@@ -228,15 +224,30 @@ describe('prose mentions', () => {
     // oxlint-disable-next-line no-template-curly-in-string
     '      return `"${str.replace(/"/g, \'""\')}"`;\n';
 
-  // The same paired probe its siblings carry at :252 and :263. Every case below
-  // feeds ENGINE_CODE in as engine.ts's body and then asserts something about
-  // the OTHER file, so an inert ENGINE_CODE would leave all of them green:
-  // neutering it to `return str;` passes 46/46. This makes the fixture prove it
-  // is still an escaper before any of that means anything.
-  assert.ok(
-    scanText(ENGINE_MENTION.file, ENGINE_CODE).length >= 1,
-    'ENGINE_CODE no longer reads as an escaper; every case using it is vacuous',
-  );
+  // Both guards live in `before()`, NOT in the describe body, and that is the
+  // whole point rather than a style choice. On node 22 -- which is what CI runs
+  // -- a throw from a describe BODY is recorded as a failed suite and `node
+  // --test` still exits 0. It prints `not ok` into the log of a green job,
+  // which is precisely the absence-reads-as-success mode this gate exists to
+  // kill. From a `before()` hook the same throw exits 1 and the cases report as
+  // cancelled: one cause, no cascade of six mysteries. Measured on v22.14.0:
+  // describe-body assert -> exit 0, before() hook assert -> exit 1.
+  before(() => {
+    // Guard first: if this entry is missing, the probe below would dereference
+    // `.file` on undefined and report a TypeError instead of the real cause.
+    assert.ok(
+      ENGINE_MENTION,
+      `no PROSE_MENTIONS entry for ${KNOWN_REMAINING[0]}; these cases pin its interaction with the debt ratchet`,
+    );
+    // The same paired probe its siblings carry below. Every case here feeds
+    // ENGINE_CODE in as engine.ts's body and then asserts something about the
+    // OTHER file, so an inert ENGINE_CODE would leave all of them green:
+    // neutering it to `return str;` passed 46/46 before this existed.
+    assert.ok(
+      scanText(ENGINE_MENTION.file, ENGINE_CODE).length >= 1,
+      'ENGINE_CODE no longer reads as an escaper; every case using it is vacuous',
+    );
+  });
 
   it('the registered line, in its registered file, does not red', () => {
     const { violations, staleMentions } = repoWith({

--- a/scripts/check-csv-escaper-copies.test.mjs
+++ b/scripts/check-csv-escaper-copies.test.mjs
@@ -7,11 +7,26 @@
  * because it reads as a guarantee — so each case below plants a copy in the
  * exact shape one of the ten real ones had and asserts the gate catches it.
  *
+ * Every planted escaper is PAIRED with the same escaper bare: a probe that
+ * cannot match in the first place reports as a broken probe, not as a pass.
+ *
  * Run: `node --test scripts/check-csv-escaper-copies.test.mjs`
  */
 import { test, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { scanText, scanRepo, CANONICAL, KNOWN_REMAINING } from './check-csv-escaper-copies.mjs';
+import * as gate from './check-csv-escaper-copies.mjs';
+
+const { scanText, scanRepo, CANONICAL, KNOWN_REMAINING, PROSE_MENTIONS, validateMentions } = gate;
+
+/**
+ * Drive scanRepo with synthetic file contents. Real repo files not named in
+ * `overrides` read as empty; padding files satisfy the vacuous-scan guard.
+ */
+function repoWith(overrides) {
+  const pad = Array.from({ length: 120 }, (_, i) => `packages/pad/src/p${i}.ts`);
+  const files = [...new Set([...Object.keys(overrides), ...pad])];
+  return scanRepo(files, (f) => overrides[f] ?? '');
+}
 
 /** The ten real copies this gate exists because of, in their original form. */
 const REAL_COPIES = [
@@ -44,11 +59,10 @@ test('fires on a Rust copy in a brand-new crate', () => {
   assert.ok(hits.length > 0);
 });
 
-test('does not fire on the canonical implementations', () => {
-  for (const c of CANONICAL) {
-    const hits = scanText(c, `if (/^[=+\\-@\\t\\r]/.test(s)) return \`'\${s}\`;\nreturn s.replace(/"/g, '""');\n`);
-    assert.deepEqual(hits, [], `${c} must be allowed to contain the guard — it IS the guard`);
-  }
+test('the canonical implementations are exempt at repo level', () => {
+  const guard = `if (/^[=+\\-@\\t\\r]/.test(s)) return \`'\${s}\`;\nreturn s.replace(/"/g, '""');\n`;
+  const { violations } = repoWith(Object.fromEntries(CANONICAL.map((c) => [c, guard])));
+  assert.deepEqual(violations, [], 'the canonical files ARE the guard and must be allowed to contain it');
 });
 
 test('does not fire on ordinary code that merely mentions CSV', () => {
@@ -81,14 +95,19 @@ test('refuses to pass vacuously when the file scan returns almost nothing', () =
   );
 });
 
-test('the repo currently has no NEW copies, and every KNOWN_REMAINING entry is still real', () => {
-  const { violations, staleKnown, scanned } = scanRepo();
+test('the repo currently has no NEW copies, and every ratchet entry is still real', () => {
+  const { violations, staleKnown, staleMentions, scanned } = scanRepo();
   assert.ok(scanned > 1000, `expected a real scan, got ${scanned} files`);
   assert.deepEqual(violations, [], 'a new hand-rolled CSV escaper was added');
   assert.deepEqual(
     staleKnown,
     [],
     'KNOWN_REMAINING is a ratchet: an entry that no longer hand-rolls an escaper must be deleted from the list',
+  );
+  assert.deepEqual(
+    staleMentions,
+    [],
+    'PROSE_MENTIONS is a ratchet: a registered comment line that no longer exists must be deleted from the list',
   );
 });
 
@@ -102,21 +121,15 @@ test('KNOWN_REMAINING is documented debt, not an open allowlist', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Comment handling. Every case here is a shape that a PREVIOUS attempt at this
-// got wrong, and each was found by planting the escaper and executing it.
-//
-// This block exists because attempts 1 through 4 all passed the 17 tests above.
-// Two of those attempts let a live, working formula-injection escaper through
-// the gate, and the suite could not tell them apart. A guard whose test cannot
-// distinguish a fixed version from a broken one is not pinning anything.
-//
-// The MISSED cases are paired: each planted escaper is also asserted bare, so a
-// probe that simply cannot match reports as a broken probe rather than a pass.
+// No context hides code. Six previous designs excused comment-shaped text and
+// each shipped a live, working escaper made invisible — every case here is one
+// of those proven holes, plus the shapes THIS design would be weakest against
+// if it ever regressed toward context-awareness. The scan is raw and per-line,
+// so all of these hold by construction; the tests pin that construction.
 // ---------------------------------------------------------------------------
-describe('comment handling', () => {
+describe('no context hides a live escaper', () => {
   const F = 'packages/export/src/probe.ts';
   const RS = 'rust/export/src/probe.rs';
-  const bare = (src) => scanText(F, src).length;
 
   /** Assert a planted escaper is caught, and that the bare form CAN be caught. */
   function caught(name, bareSrc, contextSrc, file = F) {
@@ -127,7 +140,7 @@ describe('comment handling', () => {
       );
       assert.ok(
         scanText(file, contextSrc).length >= 1,
-        `a live escaper was hidden by its comment context: ${name}`,
+        `a live escaper was hidden by its context: ${name}`,
       );
     });
   }
@@ -135,91 +148,155 @@ describe('comment handling', () => {
   const TS_COPY = `if (/^[=+\\-@\\t\\r]/.test(s)) s = "'" + s;`;
   const RS_COPY = `let hit = matches!(c, '=' | '+' | '-' | '@');`;
 
-  // attempt 2 missed this: `*/` hands the rest of the line back to the compiler
+  // attempt 1's holes: `*`-leading live code
+  caught('Rust deref-assign with a leading star', RS_COPY, `    *out = ${RS_COPY}`, RS);
+  caught('block comment sharing a line with code', TS_COPY, `/* c */ ${TS_COPY}`);
+  // attempt 2's hole: `*/` hands the rest of the line back to the compiler
   caught('/* then // */ code on one line', TS_COPY, `/* open\n// */ ${TS_COPY}`);
-  // attempt 3 missed this: an unclosed `/*` inside a string set the block flag
+  // attempt 3's hole: an unclosed `/*` inside a string set the block flag
   caught('code after a string containing /*', TS_COPY, `const s = "/* x";\n${TS_COPY}`);
   caught('code after a template literal containing /*', TS_COPY, `const t = \`/* x\`;\n${TS_COPY}`);
-  // attempt 1 missed this: `*` leads a Rust deref-assign, not only a docblock
-  caught('Rust deref-assign after a spurious opener', RS_COPY, `let s = "/* x";\n    *out = ${RS_COPY}`, RS);
-  // attempt 4 missed this: `* ` with a space is a live JS generator method
+  // attempt 4's hole: `* ` with a space is a live JS generator method
   caught('JS generator method with a leading star', TS_COPY, `const M = '/*';\nexport const o = { * q(s) { ${TS_COPY} return s; } };`);
-  // a `//` inside a string must not swallow a real `/*` later on the same line
-  caught('// inside a string before a real /*', TS_COPY, `const u = 'https://x'; /* open\n// */ ${TS_COPY}`);
+  // attempt 5's hole: an unpaired quote in code lost string phase
+  caught('escaper after a Rust lifetime and a URL string', RS_COPY,
+    `pub fn f<'a>(s: &'a str) -> bool {\n    let u = "http://x"; ${RS_COPY}\n}`, RS);
+  caught('escaper after a JSX contraction', TS_COPY,
+    `export const M = () => <p>What's New</p>;\n${TS_COPY}`, 'apps/viewer/src/probe.tsx');
+  // attempt 6's holes: a multi-line Rust string re-opened comment state, and
+  // member-access `.in / bytes.out` was taken for a regex
+  caught('escaper after a multi-line Rust string containing /*', RS_COPY,
+    `let sql = "SELECT a\n  FROM t /* hint\n  WHERE b";\n${RS_COPY}`, RS);
+  caught('escaper after member-access division', TS_COPY,
+    `const ratio = bytes.in / bytes.out;\n${TS_COPY}`);
+  // shapes THIS design must never lose: definition split from use — the
+  // canonical implementation itself writes this form (csv-cell.ts line 49),
+  // so any adjacency or usage-context rule would miss a real copy
+  caught('regex defined on its own line, used elsewhere', 'const FORMULA_RE = /^[=+\\-@\\t\\r]/;',
+    `const FORMULA_RE = /^[=+\\-@\\t\\r]/;\n// ...\nfunction esc(c) { return FORMULA_RE.test(c) ? "'" + c : c; }`);
+  caught('escaper built via new RegExp from a string', `const re = new RegExp('^[=+\\\\-@\\\\t\\\\r]');`,
+    `const re = new RegExp('^[=+\\\\-@\\\\t\\\\r]');\nif (re.test(v)) v = "'" + v;`);
+  // a `//`-leading line that EXECUTES via template interpolation: the one way
+  // a line-comment marker fronts live code, and why `${` is banned in mentions
+  caught('escaper inside template interpolation on a //-leading line', TS_COPY,
+    `let hit; const log = \`\n// \${(hit = /^[=+\\-@\\t\\r]/.test(cell))}\n\`;\nif (hit) cell = "'" + cell;`);
 
   it('a trailing comment never exempts the code before it', () => {
-    assert.equal(bare(`const RE = /^[=+\\-@\\t\\r]/; // the anchored trigger`), 1);
+    assert.equal(scanText(F, `const RE = /^[=+\\-@\\t\\r]/; // the anchored trigger`).length, 1);
   });
-
-  // False REDs. Documenting this pattern is what a fix for it writes, so prose
-  // describing it must not red the gate -- that is what redded main.
-  const prose = [
-    ['a line comment', '// not a formula to an anchored `/^[=+\\-@\\t\\r]/` but it is to Excel'],
-    ['an indented line comment', '      // anchored `/^[=+\\-@\\t\\r]/` mention'],
-    ['a docblock body', '/**\n * anchored /^[=+\\-@\\t\\r]/ described here\n */'],
-    ['a one-line docblock', '/** never hand-roll /^[=+\\-@\\t\\r]/; call escapeCsvCell() */'],
-    ['a block comment with no leading stars', '/*\n  do not re-test /^[=+\\-@\\t\\r]/ here\n*/'],
-    ['prose sharing the closing line', '/**\n * avoid /^[=+\\-@\\t\\r]/ locally. */'],
-    ['a Rust inner doc block', '/*! crate docs: never re-test /^[=+\\-@\\t\\r]/ */'],
-    ['CRLF line endings', '// anchored `/^[=+\\-@\\t\\r]/` mention\r\nconst x = 1;'],
-  ];
-  for (const [name, src] of prose) {
-    it(`prose does not red: ${name}`, () => {
-      assert.equal(scanText(F, src).length, 0, `prose redded the gate: ${name}`);
-    });
-  }
 });
 
 // ---------------------------------------------------------------------------
-// String-phase loss. These target THIS design's failure mode, not the previous
-// four's.
-//
-// Every case above was drawn from a leading-character heuristic's mistakes, so
-// none of them could have caught a tokeniser that loses string phase. A suite
-// that rejects the designs you already replaced is evidence about those, not
-// about the one you shipped.
-//
-// Root cause: an unpaired `'` in CODE -- a Rust lifetime, a JSX contraction --
-// opened a fake string that ran to the next quote anywhere in the file.
+// Prose policy. Comments quoting a pattern DO match the raw scan — that is the
+// price of a scan nothing can hide from — and are excused one exact line at a
+// time via PROSE_MENTIONS, ratcheted like KNOWN_REMAINING.
 // ---------------------------------------------------------------------------
-describe('string phase is not lost by an unpaired quote', () => {
-  const RS = 'rust/export/src/probe.rs';
-  const TSX = 'apps/viewer/src/probe.tsx';
-  const TS = 'packages/export/src/probe.ts';
-  const PROSE = '// never re-test /^[=+\\-@\\t\\r]/ here';
-  const RS_COPY = `let hit = matches!(c, '=' | '+' | '-' | '@');`;
-  const TS_COPY = `if (/^[=+\\-@\\t\\r]/.test(s)) s = "'" + s;`;
+describe('prose mentions', () => {
+  const [MENTION, ENGINE_MENTION] = PROSE_MENTIONS;
+  const ENGINE_CODE =
+    '      /^[\\p{Cf}\\p{Z}]*[=+\\-@\\t\\r]/u.test(str) &&\n' +
+    '      return `"${str.replace(/"/g, \'""\')}"`;\n';
 
-  // False reds: an odd quote must not leave a later comment unblanked.
-  it('a Rust lifetime does not unblank a following comment', () => {
-    assert.equal(scanText(RS, `pub fn p<'a>(s: &'a str, t: &'a str) {}\n${PROSE}`).length, 0);
-  });
-  it('a JSX contraction does not unblank a following comment', () => {
-    assert.equal(scanText(TSX, `export const M = () => <p>What's New</p>;\n${PROSE}`).length, 0);
-  });
-  it('a Rust raw string with an odd inner quote does not unblank a comment', () => {
-    assert.equal(scanText(RS, `let r = r#"say "hi ok"#;\n${PROSE}`).length, 0);
-  });
-  it('a regex after a keyword does not unblank a comment', () => {
-    assert.equal(scanText(TS, `function q(s) { return /["]/.test(s); }\n${PROSE}`).length, 0);
+  it('the registered line, in its registered file, does not red', () => {
+    const { violations, staleMentions } = repoWith({
+      [MENTION.file]: `const TRIGGERS = ['=', '+'];\n${MENTION.text}\n`,
+      [ENGINE_MENTION.file]: `    ${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
+    });
+    assert.deepEqual(violations, []);
+    assert.deepEqual(staleMentions, []);
   });
 
-  // The bypass: once phase inverts, a `//` inside a real string blanks live
-  // code. Paired, so a probe that cannot match reports as broken.
-  it('a URL in a string after a lifetime does not hide a Rust escaper', () => {
-    assert.ok(scanText(RS, RS_COPY).length >= 1, 'probe cannot red; result meaningless');
-    const ctx = `pub fn f<'a>(s: &'a str, t: &'a str) {\n    let m = "can't parse";\n    let u = "http://x"; ${RS_COPY}\n}`;
-    assert.ok(scanText(RS, ctx).length >= 1, 'a live Rust escaper was hidden by string-phase loss');
-  });
-  it('a URL in a string after a keyword-regex does not hide a TS escaper', () => {
-    assert.ok(scanText(TS, TS_COPY).length >= 1, 'probe cannot red; result meaningless');
-    const ctx = `function q(s) { return /["]/.test(s); }\nconst u = "http://x"; ${TS_COPY}`;
-    assert.ok(scanText(TS, ctx).length >= 1, 'a live TS escaper was hidden by string-phase loss');
+  it('the same registered line in a DIFFERENT file reds — excusal is file-scoped', () => {
+    const { violations } = repoWith({
+      'packages/export/src/other.ts': `${MENTION.text}\n`,
+      [MENTION.file]: `${MENTION.text}\n`,
+      [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
+    });
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].file, 'packages/export/src/other.ts');
   });
 
-  // Coverage the earlier block never gave: the match-arm pattern is the one
-  // built out of apostrophes, so it is the most entangled with string state.
-  it('prose describing the Rust match arm does not red', () => {
-    assert.equal(scanText(RS, `// never write matches!(c, '=' | '+' | '-' | '@') by hand`).length, 0);
+  it('a registered mention does not excuse an escaper elsewhere in the same file', () => {
+    const copy = `const quick = (s) => (/^[=+\\-@\\t\\r]/.test(s) ? \`'\${s}\` : s);`;
+    assert.ok(scanText(MENTION.file, copy).length >= 1, 'probe cannot match; result meaningless');
+    const { violations } = repoWith({
+      [MENTION.file]: `${MENTION.text}\n${copy}\n`,
+      [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
+    });
+    assert.equal(violations.length, 1, 'the escaper next to the registered comment must still red');
+    assert.equal(violations[0].file, MENTION.file);
+  });
+
+  it('code sharing the line with a registered mention changes the text and reds', () => {
+    const line = `if (/^[=+\\-@\\t\\r]/.test(s)) s = "'" + s; ${MENTION.text}`;
+    assert.ok(scanText(MENTION.file, line).length >= 1, 'probe cannot match; result meaningless');
+    const { violations } = repoWith({
+      [MENTION.file]: `${MENTION.text}\n${line}\n`,
+      [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
+    });
+    assert.equal(violations.length, 1);
+  });
+
+  it('unregistered prose reds — the registry does not generalise', () => {
+    const { violations } = repoWith({
+      'packages/export/src/newdoc.ts': '// never hand-roll the anchored `/^[=+\\-@\\t\\r]/` guard\n',
+      [MENTION.file]: `${MENTION.text}\n`,
+      [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
+    });
+    assert.equal(violations.length, 1, 'a new prose mention must be registered, not silently excused');
+  });
+
+  it('a registered line that disappears is stale and fails the gate', () => {
+    const { staleMentions } = repoWith({
+      [MENTION.file]: 'const nothing = 1;\n',
+      [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\n${ENGINE_CODE}`,
+    });
+    assert.deepEqual(staleMentions, [MENTION]);
+  });
+
+  it('KNOWN_REMAINING liveness rests on CODE, not on its history comment', () => {
+    // Pay the engine.ts debt but keep the comment naming the old pattern: the
+    // ratchet must still fire, or the entry lingers as dead config forever.
+    const { staleKnown, staleMentions } = repoWith({
+      [MENTION.file]: `${MENTION.text}\n`,
+      [ENGINE_MENTION.file]: `${ENGINE_MENTION.text}\nexport const done = escapeCsvCell;\n`,
+    });
+    assert.deepEqual(staleKnown, KNOWN_REMAINING, 'comment-only liveness must not keep the debt entry alive');
+    assert.deepEqual(staleMentions, []);
+  });
+
+  describe('validateMentions rejects entries that could excuse executable text', () => {
+    const P = '`/^[=+\\-@\\t\\r]/`';
+    const bad = [
+      ['untrimmed text', { file: 'a/b.ts', text: `  // pad ${P}` }, /trimmed/],
+      ['not a line comment', { file: 'a/b.ts', text: `* docblock body ${P}` }, /line comment/],
+      ['template interpolation', { file: 'a/b.ts', text: `// \${run()} ${P}` }, /execute/],
+      ['block terminator', { file: 'a/b.ts', text: `// ${P} *` + `/ tail()` }, /block comment/],
+      ['matches no pattern', { file: 'a/b.ts', text: '// plain prose' }, /no PATTERN/],
+      ['already-exempt file', { file: CANONICAL[0], text: `// ${P}` }, /exempt/],
+    ];
+    for (const [name, entry, re] of bad) {
+      it(name, () => assert.throws(() => validateMentions([entry]), re));
+    }
+    it('accepts the real registry', () => validateMentions());
+  });
+
+  it('a registered line is inert even as regex source — executed, not asserted', () => {
+    // The one way registered text could "run" is as data fed to a regex
+    // compiler. Build that regex and show it cannot function as a trigger
+    // guard: the prose prefix means no bare trigger cell matches.
+    for (const m of PROSE_MENTIONS) {
+      let re = null;
+      try {
+        re = new RegExp(m.text);
+      } catch {
+        // not even a valid regex: inert
+      }
+      if (re) {
+        for (const cell of ['=cmd()', '+1', '-2', '@x', '\tt', '\rr', '=HYPERLINK("http://x")']) {
+          assert.equal(re.test(cell), false, `registered text works as a trigger guard on ${JSON.stringify(cell)}`);
+        }
+      }
+    }
   });
 });

--- a/scripts/check-csv-escaper-copies.test.mjs
+++ b/scripts/check-csv-escaper-copies.test.mjs
@@ -219,8 +219,13 @@ describe('prose mentions', () => {
     `no PROSE_MENTIONS entry for ${KNOWN_REMAINING[0]}; these cases pin its interaction with the debt ratchet`,
   );
   const MENTIONS = [MENTION, ENGINE_MENTION];
+  // A FIXTURE, not code: this is what `engine.ts` looks like to the scanner, so
+  // the `${` has to survive verbatim into the scanned text. oxlint's
+  // no-template-curly-in-string is right about the general case and wrong about
+  // a fixture whose whole job is to be the source text of something else.
   const ENGINE_CODE =
     '      /^[\\p{Cf}\\p{Z}]*[=+\\-@\\t\\r]/u.test(str) &&\n' +
+    // oxlint-disable-next-line no-template-curly-in-string
     '      return `"${str.replace(/"/g, \'""\')}"`;\n';
 
   it('the registered line, in its registered file, does not red', () => {

--- a/scripts/check-csv-escaper-copies.test.mjs
+++ b/scripts/check-csv-escaper-copies.test.mjs
@@ -202,7 +202,22 @@ describe('prose mentions', () => {
     file: 'packages/lists/src/fixture-doc.test.ts',
     text: '// is not a formula to an anchored `/^[=+\\-@\\t\\r]/` but it is one to Excel.',
   };
-  const [ENGINE_MENTION] = PROSE_MENTIONS;
+  // Bound by FILE, not by position, so it says WHICH entry it wants rather than
+  // WHERE it sits. `[ENGINE_MENTION] = PROSE_MENTIONS` binds to index 0, which
+  // means any registry edit re-points it -- and the registry is a ratchet whose
+  // whole job is to change.
+  //
+  // Not claiming this prevents a SILENT failure: a prepended decoy reds the
+  // positional form too (6 tests), and the probe that suggested otherwise was
+  // confounded -- the decoy named an absent file, so both arms were measuring
+  // the stale-mention ratchet rather than the binding. What this buys is one
+  // named assertion instead of six cascading ones, and a bind that survives
+  // reordering.
+  const ENGINE_MENTION = PROSE_MENTIONS.find((m) => m.file === KNOWN_REMAINING[0]);
+  assert.ok(
+    ENGINE_MENTION,
+    `no PROSE_MENTIONS entry for ${KNOWN_REMAINING[0]}; these cases pin its interaction with the debt ratchet`,
+  );
   const MENTIONS = [MENTION, ENGINE_MENTION];
   const ENGINE_CODE =
     '      /^[\\p{Cf}\\p{Z}]*[=+\\-@\\t\\r]/u.test(str) &&\n' +

--- a/scripts/check-csv-escaper-copies.test.mjs
+++ b/scripts/check-csv-escaper-copies.test.mjs
@@ -9,7 +9,7 @@
  *
  * Run: `node --test scripts/check-csv-escaper-copies.test.mjs`
  */
-import { test } from 'node:test';
+import { test, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { scanText, scanRepo, CANONICAL, KNOWN_REMAINING } from './check-csv-escaper-copies.mjs';
 
@@ -99,4 +99,127 @@ test('KNOWN_REMAINING is documented debt, not an open allowlist', () => {
     KNOWN_REMAINING.length <= 1,
     `KNOWN_REMAINING must shrink, never grow; it now holds ${KNOWN_REMAINING.length}: ${KNOWN_REMAINING.join(', ')}`,
   );
+});
+
+// ---------------------------------------------------------------------------
+// Comment handling. Every case here is a shape that a PREVIOUS attempt at this
+// got wrong, and each was found by planting the escaper and executing it.
+//
+// This block exists because attempts 1 through 4 all passed the 17 tests above.
+// Two of those attempts let a live, working formula-injection escaper through
+// the gate, and the suite could not tell them apart. A guard whose test cannot
+// distinguish a fixed version from a broken one is not pinning anything.
+//
+// The MISSED cases are paired: each planted escaper is also asserted bare, so a
+// probe that simply cannot match reports as a broken probe rather than a pass.
+// ---------------------------------------------------------------------------
+describe('comment handling', () => {
+  const F = 'packages/export/src/probe.ts';
+  const RS = 'rust/export/src/probe.rs';
+  const bare = (src) => scanText(F, src).length;
+
+  /** Assert a planted escaper is caught, and that the bare form CAN be caught. */
+  function caught(name, bareSrc, contextSrc, file = F) {
+    it(name, () => {
+      assert.ok(
+        scanText(file, bareSrc).length >= 1,
+        `probe is incapable of matching, so the context result would be meaningless: ${name}`,
+      );
+      assert.ok(
+        scanText(file, contextSrc).length >= 1,
+        `a live escaper was hidden by its comment context: ${name}`,
+      );
+    });
+  }
+
+  const TS_COPY = `if (/^[=+\\-@\\t\\r]/.test(s)) s = "'" + s;`;
+  const RS_COPY = `let hit = matches!(c, '=' | '+' | '-' | '@');`;
+
+  // attempt 2 missed this: `*/` hands the rest of the line back to the compiler
+  caught('/* then // */ code on one line', TS_COPY, `/* open\n// */ ${TS_COPY}`);
+  // attempt 3 missed this: an unclosed `/*` inside a string set the block flag
+  caught('code after a string containing /*', TS_COPY, `const s = "/* x";\n${TS_COPY}`);
+  caught('code after a template literal containing /*', TS_COPY, `const t = \`/* x\`;\n${TS_COPY}`);
+  // attempt 1 missed this: `*` leads a Rust deref-assign, not only a docblock
+  caught('Rust deref-assign after a spurious opener', RS_COPY, `let s = "/* x";\n    *out = ${RS_COPY}`, RS);
+  // attempt 4 missed this: `* ` with a space is a live JS generator method
+  caught('JS generator method with a leading star', TS_COPY, `const M = '/*';\nexport const o = { * q(s) { ${TS_COPY} return s; } };`);
+  // a `//` inside a string must not swallow a real `/*` later on the same line
+  caught('// inside a string before a real /*', TS_COPY, `const u = 'https://x'; /* open\n// */ ${TS_COPY}`);
+
+  it('a trailing comment never exempts the code before it', () => {
+    assert.equal(bare(`const RE = /^[=+\\-@\\t\\r]/; // the anchored trigger`), 1);
+  });
+
+  // False REDs. Documenting this pattern is what a fix for it writes, so prose
+  // describing it must not red the gate -- that is what redded main.
+  const prose = [
+    ['a line comment', '// not a formula to an anchored `/^[=+\\-@\\t\\r]/` but it is to Excel'],
+    ['an indented line comment', '      // anchored `/^[=+\\-@\\t\\r]/` mention'],
+    ['a docblock body', '/**\n * anchored /^[=+\\-@\\t\\r]/ described here\n */'],
+    ['a one-line docblock', '/** never hand-roll /^[=+\\-@\\t\\r]/; call escapeCsvCell() */'],
+    ['a block comment with no leading stars', '/*\n  do not re-test /^[=+\\-@\\t\\r]/ here\n*/'],
+    ['prose sharing the closing line', '/**\n * avoid /^[=+\\-@\\t\\r]/ locally. */'],
+    ['a Rust inner doc block', '/*! crate docs: never re-test /^[=+\\-@\\t\\r]/ */'],
+    ['CRLF line endings', '// anchored `/^[=+\\-@\\t\\r]/` mention\r\nconst x = 1;'],
+  ];
+  for (const [name, src] of prose) {
+    it(`prose does not red: ${name}`, () => {
+      assert.equal(scanText(F, src).length, 0, `prose redded the gate: ${name}`);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// String-phase loss. These target THIS design's failure mode, not the previous
+// four's.
+//
+// Every case above was drawn from a leading-character heuristic's mistakes, so
+// none of them could have caught a tokeniser that loses string phase. A suite
+// that rejects the designs you already replaced is evidence about those, not
+// about the one you shipped.
+//
+// Root cause: an unpaired `'` in CODE -- a Rust lifetime, a JSX contraction --
+// opened a fake string that ran to the next quote anywhere in the file.
+// ---------------------------------------------------------------------------
+describe('string phase is not lost by an unpaired quote', () => {
+  const RS = 'rust/export/src/probe.rs';
+  const TSX = 'apps/viewer/src/probe.tsx';
+  const TS = 'packages/export/src/probe.ts';
+  const PROSE = '// never re-test /^[=+\\-@\\t\\r]/ here';
+  const RS_COPY = `let hit = matches!(c, '=' | '+' | '-' | '@');`;
+  const TS_COPY = `if (/^[=+\\-@\\t\\r]/.test(s)) s = "'" + s;`;
+
+  // False reds: an odd quote must not leave a later comment unblanked.
+  it('a Rust lifetime does not unblank a following comment', () => {
+    assert.equal(scanText(RS, `pub fn p<'a>(s: &'a str, t: &'a str) {}\n${PROSE}`).length, 0);
+  });
+  it('a JSX contraction does not unblank a following comment', () => {
+    assert.equal(scanText(TSX, `export const M = () => <p>What's New</p>;\n${PROSE}`).length, 0);
+  });
+  it('a Rust raw string with an odd inner quote does not unblank a comment', () => {
+    assert.equal(scanText(RS, `let r = r#"say "hi ok"#;\n${PROSE}`).length, 0);
+  });
+  it('a regex after a keyword does not unblank a comment', () => {
+    assert.equal(scanText(TS, `function q(s) { return /["]/.test(s); }\n${PROSE}`).length, 0);
+  });
+
+  // The bypass: once phase inverts, a `//` inside a real string blanks live
+  // code. Paired, so a probe that cannot match reports as broken.
+  it('a URL in a string after a lifetime does not hide a Rust escaper', () => {
+    assert.ok(scanText(RS, RS_COPY).length >= 1, 'probe cannot red; result meaningless');
+    const ctx = `pub fn f<'a>(s: &'a str, t: &'a str) {\n    let m = "can't parse";\n    let u = "http://x"; ${RS_COPY}\n}`;
+    assert.ok(scanText(RS, ctx).length >= 1, 'a live Rust escaper was hidden by string-phase loss');
+  });
+  it('a URL in a string after a keyword-regex does not hide a TS escaper', () => {
+    assert.ok(scanText(TS, TS_COPY).length >= 1, 'probe cannot red; result meaningless');
+    const ctx = `function q(s) { return /["]/.test(s); }\nconst u = "http://x"; ${TS_COPY}`;
+    assert.ok(scanText(TS, ctx).length >= 1, 'a live TS escaper was hidden by string-phase loss');
+  });
+
+  // Coverage the earlier block never gave: the match-arm pattern is the one
+  // built out of apostrophes, so it is the most entangled with string state.
+  it('prose describing the Rust match arm does not red', () => {
+    assert.equal(scanText(RS, `// never write matches!(c, '=' | '+' | '-' | '@') by hand`).length, 0);
+  });
 });


### PR DESCRIPTION
**`main` is red.** `check-csv-escaper-copies.mjs` exits 1 on:

```
packages/lists/src/engine.rfc4180.test.ts:396  [formula-trigger character class]
    // is not a formula to an anchored `/^[=+\-@\t\r]/` but it is one to Excel.
```

A gate that hunts for hand-rolled copies of the anchored form, flagging a **comment describing** the anchored form. `scanText` tests each line with no comment handling, so every file that documents the bypass is a candidate — and documenting it is exactly what a fix for this defect does.

## A pair, not a regression

`engine.rfc4180.test.ts` landed in **#3100**, which merged *after* **#3102** branched. The gate was green on its own branch because the line it objects to did not exist yet. Third instance in one session of two changes each correct alone and wrong only in composition.

## `//` only, and the narrowness is the whole point

My first version also skipped `*` and `/*`, justified in a comment claiming no implementation begins that way. **Review proved that false for this repo** by planting two escapers the widened skip then missed:

```
*out = matches!(first, '=' | '+' | '-' | '@');   Rust, exit 0, MISSED
/* CWE-1236 */ /^[=+\-@\t\r]/.test(s);          TS,   exit 0, MISSED
```

Neither is contrived. This tree has Rust deref-assign (`*slot = None;`), TS generator methods (`*scanEntities()`), and CSS inside template literals — all beginning `*`.

So I nearly fixed a gate's false **red** by opening a false **green** in it, while asserting in a comment that this could not happen. Checking against the tree was one grep away.

`//` at the start of a trimmed line takes the rest of that physical line by grammar in JS, TS and Rust alike. Verified across all 4255 scanned files: exactly four lines match any pattern tree-wide — two prose comments (now exempt) and two executable lines in `engine.ts` (still flagged).

## Verified by planting, not argument

```
Rust deref-assign copy    caught
TS inline-block-comment   caught
plain TS copy             caught
trailing comment          caught
comment-only (main's red) skipped
```

Whitespace-robust: the offending line stays exempt under 4 spaces, tab, mixed, NBSP, BOM, CRLF residue and `///`. Trailing comments and block-comment bodies still red, so there is no hiding place.

**Ratchet unaffected.** `packages/lists/src/engine.ts` matches on two *code* lines (790, 796) as well as the comment at 780, so the entry stays live and `staleKnown` stays empty. Confirmed by running the gate, not by reading.

Gate's own 17 tests pass; full scan exits 0.

## What the gate already got right

It refuses to pass on a suspiciously small file list — *"the one way a grep gate lies"*. Its author anticipated the false green and not the false red. Worth saying because both times `main` actually broke tonight, it was a check firing on something harmless, not a check missing something real.

## Out of scope, filed separately

Review turned up that invoking this script through a path containing a symlink makes `fileURLToPath(import.meta.url) === process.argv[1]` fail, so `main()` never runs and it exits **0 with zero output**. Reproduced: real path 71 bytes / exit 0, symlinked path **0 bytes** / exit 0. It is a family, and the size was measured rather than grepped. A grep for "references `process.argv[1]` and does not mention realpath" flags 15 scripts; running each through a real and a symlinked path and comparing output narrows it to **4 genuinely affected, all of them real CI gates**:

```
check-csv-escaper-copies.mjs    460B -> 0B
check-test-glob-coverage.mjs     70B -> 0B
check-test-wiring.mjs           997B -> 0B
typecheck-tests.mjs             757B -> 0B
```

The other 11 have the syntactic shape without the behaviour — they call `main()` unconditionally, or use `argv[1]` for something unrelated. All 11 produce **identical non-zero output on both paths**, so each is a verified immune rather than an absence of evidence; a silent-but-broken script would otherwise be misfiled as immune.

Credit: that measurement is a peer session'''s, and it corrects their own earlier overcount of 15. I independently reproduced `check-test-glob-coverage.mjs` (71B -> 0B, both exit 0) and am citing the rest rather than claiming to have run them.

`check-changesets.mjs:51` already carries the `realpathSync` fix with the reason written down locally — the same shape as the CSV escaper itself, a correct local fix whose rationale sits in the one file that no longer needs it.

Deliberately not bundled into a red-main hotfix. It is going up as its own PR once main is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV-escaper checks now correctly detect executable patterns across additional syntax variations and escaped formula formats.
  * Fully commented lines remain ignored, while block, trailing, and other scannable comments continue to be checked.
  * The checker now identifies outdated documented exceptions and provides guidance for resolving flagged comments.

* **Tests**
  * Expanded coverage validates comment handling, pattern detection, documented exceptions, and repository-wide scanning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->