### PR TITLE
fix(lists): stop duplicating the trigger class in prose, which reds the CSV gate

### DIFF
--- a/packages/lists/src/engine.rfc4180.test.ts
+++ b/packages/lists/src/engine.rfc4180.test.ts
@@ -393,7 +393,8 @@ describe('every cell survives a third-party parser round trip', () => {
 // round trip is the only place the guard's real contract is observable: after
 // parsing, no cell may still start with a trigger character, INCLUDING when the
 // trigger hides behind leading invisible characters. `\uFEFF=HYPERLINK(...)`
-// is not a formula to an anchored `/^[=+\-@\t\r]/` but it is one to Excel.
+// is not a formula to the pre-hardening guard, which anchored the trigger
+// characters at offset 0, but it is one to Excel.
 // ---------------------------------------------------------------------------
 
 const TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];


### PR DESCRIPTION
`main` has been red since 22:47 on exactly one violation, and it is prose.

```
packages/lists/src/engine.rfc4180.test.ts:396  [formula-trigger character class]
    // is not a formula to an anchored `/^[=+\-@\t\r]/` but it is one to Excel.
```

## What happened

The comment embedded a literal copy of the anchored trigger class. #3102 added `check-csv-escaper-copies.mjs`, whose whole purpose is to stop that class being copied, and it does not distinguish a copy in code from a copy in a comment.

**Each PR was green alone and red only together.** The comment landed via #3100 *after* #3102 branched, so #3102's own CI never saw it. That is the second such pair today, after #3058 + #3039, and neither is visible from either side.

## The fix

Describe the guard instead of restating its pattern. A comment copy goes stale exactly like a code copy, so the gate is right to object even though the line is prose.

```diff
-// is not a formula to an anchored `/^[=+\-@\t\r]/` but it is one to Excel.
+// is not a formula to the pre-hardening guard, which anchored the trigger
+// characters at offset 0, but it is one to Excel.
```

Verified by running, not by reading:

```
before   exit=1, 1 violation
after    exit=0, 4255 files scanned, 1 known outstanding
         (packages/lists/src/engine.ts, so the ratchet is intact and this is a
         real pass rather than the gate going quiet)
```

`check-source-text-assertions` passes. No changeset: that gate validates that existing changesets name workspace members and does not require one to exist, and a comment in a test file changes no behaviour or public API.

## Why it is two lines and not twelve

Four earlier drafts of this comment were rejected in review. The failure mode was identical every time: **a replacement that asserted something extra and unverified.**

| draft | claim | verdict |
|---|---|---|
| 1 | `csv-cell.ts` holds the "single surviving definition" | **false**, `engine.ts:790` has one too, and the gate output quoted in my own commit message named it |
| 2 | a CSV writer should call `guardSpreadsheetFormula` | wrong helper, `csv-cell.ts:99` says CSV writers want `escapeCsvCell` |
| 3 | the XLSX container "quotes for them" | it XML-escapes, it does not quote |
| 4 | restated the #1772 numeric-exemption divergence | **true**, and already documented 55 lines below and, more completely, in the gate's `KNOWN_REMAINING` block |

Draft 4 is the instructive one. It was accurate and still wrong to ship: three homes for one fact is how the next stale comment gets written, which is the same argument this PR makes about the pattern itself.

So this keeps only what the round-trip invariant needs, and adds no pointer, no cross-reference and no second copy of anything. Not one draft was rejected for saying too little.

## Scope

Teaching the gate to skip comments is the better long-term fix and is being worked separately. Six attempts have each been found holed by review, so it wants an unhurried review on a green `main` rather than another round under time pressure. A reframing is also on the table: making the patterns themselves unmatchable by prose, by requiring `.test(` or `matches!(` adjacency, which would remove the need for comment handling entirely.

Nothing in this PR touches the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified formula-injection test coverage for invisible prefixes that Excel recognizes as formulas.
  * Documented that these prefixes bypass the former offset-based trigger check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->