### PR TITLE
feat(export): share repeated shapes on the bounded GLB path, and stream STEP export

### DIFF
--- a/.changeset/bounded-glb-rep-instancing.md
+++ b/.changeset/bounded-glb-rep-instancing.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/wasm": minor
+---
+
+Share repeated shapes in the bounded (streaming) GLB assembler, and stream STEP export.
+
+Above the streaming threshold the assembler used to give up on rep-identity instancing, on the grounds that it "needs every occurrence co-resident". The vertex data does; the decision does not. `collate_refs` reads nothing off a mesh's geometry but its length, so what a group needs is an identity, a placement and a size, and those fit in the plan the bounded path already keeps. Measured on a 1 GB building-services model: glTF 1.83 GB to 710 MB, peak RSS 7.83 GB to 6.70 GB.
+
+Shapes are bucketed by `(rep identity, colour, vertex count, index count)` rather than refused wholesale when one occurrence disagrees about size. On that model 532 groups of 87,393 hold an occurrence clipped to a different vertex count, and between them they hold 22,343 of the 151,282 occurrences — refusing the group for the exception would have cost most of the sharing. f32 output only: a quantized shared mesh carries a non-uniform dequant scale that cannot fold into a rotating placement without breaking `Matrix4.decompose`.
+
+Also adds `export_step_to_writer`, which emits each record as it is read instead of returning the whole file as a `String`. On a 1 GB model that removes a gigabyte of output from the peak. It buffers internally, so a caller passing a bare `File` does not pay two syscalls per record.
+
+Output is byte-identical for models with no shareable shapes.

--- a/.changeset/bounded-glb-rep-instancing.md
+++ b/.changeset/bounded-glb-rep-instancing.md
@@ -4,9 +4,21 @@
 
 Share repeated shapes in the bounded (streaming) GLB assembler, and stream STEP export.
 
-Above the streaming threshold the assembler used to give up on rep-identity instancing, on the grounds that it "needs every occurrence co-resident". The vertex data does; the decision does not. `collate_refs` reads nothing off a mesh's geometry but its length, so what a group needs is an identity, a placement and a size, and those fit in the plan the bounded path already keeps. Measured on a 1 GB building-services model: glTF 1.83 GB to 710 MB, peak RSS 7.83 GB to 6.70 GB.
+Above the streaming threshold the assembler used to give up on rep-identity instancing, on the grounds that it "needs every occurrence co-resident". The vertex data does; the decision does not. `collate_refs` reads nothing off a mesh's geometry but its length, so what a group needs is an identity and a placement, and those fit in the plan the bounded path already keeps.
 
-Shapes are bucketed by `(rep identity, colour, vertex count, index count)` rather than refused wholesale when one occurrence disagrees about size. On that model 532 groups of 87,393 hold an occurrence clipped to a different vertex count, and between them they hold 22,343 of the 151,282 occurrences — refusing the group for the exception would have cost most of the sharing. f32 output only: a quantized shared mesh carries a non-uniform dequant scale that cannot fold into a rotating placement without breaking `Matrix4.decompose`.
+Measured on a 1.05 GB building-services model, 320,688 elements, same machine and same binary shape either side:
+
+| | before | after |
+|---|---|---|
+| glTF | 1.82 GB | 1.14 GB |
+| meshes | 226,506 | 109,236 |
+| triangles | 32,273,344 | 19,778,131 |
+| peak RSS | 6.02 GB | 5.36 GB |
+| wall | 16.20 s | 15.95 s |
+
+Grouping follows `collate_refs` exactly: a rep identity whose occurrences disagree about vertex or index count goes out flat, all of it. That refusal is a safety property rather than an oversight, because `rep_identity` is only the RepresentationMap entity id for a mapped item, so two occurrences of one map clipped differently but landing on the same counts are a group whose members are not one shape.
+
+f32 output only. A quantized shared mesh carries a non-uniform dequant scale that cannot fold into a rotating placement without breaking `Matrix4.decompose`, so quantized output still goes out flat.
 
 Also adds `export_step_to_writer`, which emits each record as it is read instead of returning the whole file as a `String`. On a 1 GB model that removes a gigabyte of output from the peak. It buffers internally, so a caller passing a bare `File` does not pay two syscalls per record.
 

--- a/rust/export/examples/step_writer_cost.rs
+++ b/rust/export/examples/step_writer_cost.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MPL-2.0
 //! What does writing an IFC file back out cost, held or streamed?
 //!
 //! `export_step` returns the whole output as a `String`, so a 1 GB model needs
@@ -26,23 +27,19 @@ fn main() -> std::process::ExitCode {
             stats
         }
         "streamed" => {
-            let file = std::fs::File::create(&out).expect("create");
-            let mut w = std::io::BufWriter::with_capacity(1 << 20, file);
-            let stats = match export_step_to_writer(&content, &opts, &mut w) {
+            // A bare `File`. `export_step_to_writer` buffers internally and
+            // flushes before it returns, so the two `write` calls a record
+            // costs are not two syscalls. Without that, this same run took
+            // 15.0 s instead of 4.3 s.
+            let mut file = std::fs::File::create(&out).expect("create");
+            let stats = match export_step_to_writer(&content, &opts, &mut file) {
                 Ok(s) => s,
                 Err(e) => {
                     eprintln!("failed: {e}");
                     return std::process::ExitCode::FAILURE;
                 }
             };
-            // Flushed before the size is read, and the error surfaced: a
-            // `BufWriter` dropped without flushing loses its last buffer and
-            // reports success, which is a truncated file and a zero exit.
-            if let Err(e) = std::io::Write::flush(&mut w) {
-                eprintln!("failed to flush: {e}");
-                return std::process::ExitCode::FAILURE;
-            }
-            drop(w);
+            drop(file);
             println!("output {} bytes", std::fs::metadata(&out).map(|m| m.len()).unwrap_or(0));
             stats
         }

--- a/rust/export/examples/step_writer_cost.rs
+++ b/rust/export/examples/step_writer_cost.rs
@@ -1,0 +1,54 @@
+//! What does writing an IFC file back out cost, held or streamed?
+//!
+//! `export_step` returns the whole output as a `String`, so a 1 GB model needs
+//! the source, the index, and a gigabyte of output live at once — and a `String`
+//! reaching a gigabyte reallocates its way there, so the peak is worse than the
+//! total. `export_step_to_writer` emits each record as it is read. Same file,
+//! same options, one run each, so the two peaks are comparable.
+//!
+//! ```text
+//! step_writer_cost <file.ifc> held|streamed <out.ifc>
+//! ```
+use ifc_lite_export::{export_step_to_writer, export_step_with_stats, StepOptions};
+
+fn main() -> std::process::ExitCode {
+    let input = std::env::args().nth(1).expect("usage: step_writer_cost <file.ifc> held|streamed <out>");
+    let mode = std::env::args().nth(2).unwrap_or_else(|| "streamed".into());
+    let out = std::env::args().nth(3).expect("an output path");
+    let content = std::fs::read(&input).expect("read");
+    println!("input {} bytes", content.len());
+    let opts = StepOptions::default();
+    let stats = match mode.as_str() {
+        "held" => {
+            let (text, stats) = export_step_with_stats(&content, &opts);
+            println!("output {} bytes", text.len());
+            std::fs::write(&out, text.as_bytes()).expect("write");
+            stats
+        }
+        "streamed" => {
+            let file = std::fs::File::create(&out).expect("create");
+            let mut w = std::io::BufWriter::with_capacity(1 << 20, file);
+            let stats = match export_step_to_writer(&content, &opts, &mut w) {
+                Ok(s) => s,
+                Err(e) => {
+                    eprintln!("failed: {e}");
+                    return std::process::ExitCode::FAILURE;
+                }
+            };
+            // Flushed before the size is read, and the error surfaced: a
+            // `BufWriter` dropped without flushing loses its last buffer and
+            // reports success, which is a truncated file and a zero exit.
+            if let Err(e) = std::io::Write::flush(&mut w) {
+                eprintln!("failed to flush: {e}");
+                return std::process::ExitCode::FAILURE;
+            }
+            drop(w);
+            println!("output {} bytes", std::fs::metadata(&out).map(|m| m.len()).unwrap_or(0));
+            stats
+        }
+        other => panic!("mode is held or streamed, not {other}"),
+    };
+    println!("mode {mode}");
+    println!("records {} of {}", stats.written, stats.total);
+    std::process::ExitCode::SUCCESS
+}

--- a/rust/export/examples/world_check.rs
+++ b/rust/export/examples/world_check.rs
@@ -1,0 +1,272 @@
+//! Is the geometry in the same place after a change to how it is packed?
+//!
+//! Walks a GLB's node tree, composes each node's placement, and reduces every
+//! triangle to numbers that do not depend on emission order: how many there are,
+//! where they all are (AABB and the sum of their centroids), and how much
+//! surface they cover. Two files that agree on those describe the same building
+//! however differently they store it.
+//!
+//! Tolerant of the last bits by design. Baked geometry narrows to f32 in world
+//! coordinates; instanced geometry narrows in its own frame and is placed by an
+//! f64 matrix, so the two cannot be compared for equality and should not be.
+use std::collections::HashMap;
+
+fn parse_glb(b: &[u8]) -> (serde_json::Value, Vec<u8>) {
+    assert_eq!(&b[0..4], b"glTF", "not a GLB");
+    let mut off = 12usize;
+    let mut json = None;
+    let mut bin = Vec::new();
+    while off + 8 <= b.len() {
+        let len = u32::from_le_bytes(b[off..off + 4].try_into().unwrap()) as usize;
+        let kind = &b[off + 4..off + 8];
+        let body = &b[off + 8..off + 8 + len];
+        if kind == b"JSON" {
+            json = Some(serde_json::from_slice(body).expect("glb json"));
+        } else {
+            bin = body.to_vec();
+        }
+        off += 8 + len;
+    }
+    (json.expect("json chunk"), bin)
+}
+
+fn mat_mul(a: &[f64; 16], b: &[f64; 16]) -> [f64; 16] {
+    let mut o = [0.0; 16];
+    for r in 0..4 {
+        for c in 0..4 {
+            o[r * 4 + c] = (0..4).map(|k| a[r * 4 + k] * b[k * 4 + c]).sum();
+        }
+    }
+    o
+}
+
+fn apply(m: &[f64; 16], p: [f64; 3]) -> [f64; 3] {
+    [
+        m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
+        m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
+        m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
+    ]
+}
+
+const ID: [f64; 16] = [
+    1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.,
+];
+
+/// glTF stores a node matrix column-major; everything here is row-major.
+fn node_local(n: &serde_json::Value) -> [f64; 16] {
+    if let Some(m) = n.get("matrix").and_then(|v| v.as_array()) {
+        let c: Vec<f64> = m.iter().map(|v| v.as_f64().unwrap()).collect();
+        return [
+            c[0], c[4], c[8], c[12], //
+            c[1], c[5], c[9], c[13], //
+            c[2], c[6], c[10], c[14], //
+            c[3], c[7], c[11], c[15],
+        ];
+    }
+    let mut m = ID;
+    if let Some(s) = n.get("scale").and_then(|v| v.as_array()) {
+        m[0] = s[0].as_f64().unwrap();
+        m[5] = s[1].as_f64().unwrap();
+        m[10] = s[2].as_f64().unwrap();
+    }
+    if let Some(r) = n.get("rotation").and_then(|v| v.as_array()) {
+        let q: Vec<f64> = r.iter().map(|v| v.as_f64().unwrap()).collect();
+        let (x, y, z, w) = (q[0], q[1], q[2], q[3]);
+        let rot = [
+            1. - 2. * (y * y + z * z),
+            2. * (x * y - z * w),
+            2. * (x * z + y * w),
+            0.,
+            2. * (x * y + z * w),
+            1. - 2. * (x * x + z * z),
+            2. * (y * z - x * w),
+            0.,
+            2. * (x * z - y * w),
+            2. * (y * z + x * w),
+            1. - 2. * (x * x + y * y),
+            0.,
+            0.,
+            0.,
+            0.,
+            1.,
+        ];
+        m = mat_mul(&rot, &m);
+    }
+    if let Some(t) = n.get("translation").and_then(|v| v.as_array()) {
+        m[3] += t[0].as_f64().unwrap();
+        m[7] += t[1].as_f64().unwrap();
+        m[11] += t[2].as_f64().unwrap();
+    }
+    m
+}
+
+struct Totals {
+    triangles: u64,
+    min: [f64; 3],
+    max: [f64; 3],
+    centroid_sum: [f64; 3],
+    area: f64,
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: world_check <a.glb> [b.glb]");
+    let t = totals(&path);
+    println!("{path}");
+    report(&t);
+    if let Some(other) = std::env::args().nth(2) {
+        let u = totals(&other);
+        println!("\n{other}");
+        report(&u);
+        println!("\ndelta");
+        println!("  triangles   {}", u.triangles as i64 - t.triangles as i64);
+        for (k, axis) in ["x", "y", "z"].iter().enumerate() {
+            println!(
+                "  {axis} min {:+.6}  max {:+.6}  centroid sum {:+.4}",
+                u.min[k] - t.min[k],
+                u.max[k] - t.max[k],
+                u.centroid_sum[k] - t.centroid_sum[k]
+            );
+        }
+        println!(
+            "  area        {:+.4} m2 ({:+.6} %)",
+            u.area - t.area,
+            (u.area - t.area) / t.area * 100.0
+        );
+    }
+}
+
+fn report(t: &Totals) {
+    println!("  triangles    {}", t.triangles);
+    println!(
+        "  aabb min     [{:.4}, {:.4}, {:.4}]",
+        t.min[0], t.min[1], t.min[2]
+    );
+    println!(
+        "  aabb max     [{:.4}, {:.4}, {:.4}]",
+        t.max[0], t.max[1], t.max[2]
+    );
+    println!(
+        "  centroid sum [{:.4}, {:.4}, {:.4}]",
+        t.centroid_sum[0], t.centroid_sum[1], t.centroid_sum[2]
+    );
+    println!("  area         {:.4} m2", t.area);
+}
+
+fn totals(path: &str) -> Totals {
+    let bytes = std::fs::read(path).expect("read glb");
+    let (j, bin) = parse_glb(&bytes);
+    let nodes = j["nodes"].as_array().cloned().unwrap_or_default();
+    let meshes = j["meshes"].as_array().cloned().unwrap_or_default();
+    let accessors = j["accessors"].as_array().cloned().unwrap_or_default();
+    let views = j["bufferViews"].as_array().cloned().unwrap_or_default();
+
+    // Accessor -> the bytes it names, resolved once and shared, since an
+    // instanced file points many nodes at one mesh.
+    let read_f32x3 = |acc: usize| -> Vec<[f32; 3]> {
+        let a = &accessors[acc];
+        let bv = &views[a["bufferView"].as_u64().unwrap() as usize];
+        let base = bv["byteOffset"].as_u64().unwrap_or(0) as usize
+            + a["byteOffset"].as_u64().unwrap_or(0) as usize;
+        let n = a["count"].as_u64().unwrap() as usize;
+        assert_eq!(
+            a["componentType"].as_u64().unwrap(),
+            5126,
+            "expected f32 positions"
+        );
+        (0..n)
+            .map(|i| {
+                let o = base + i * 12;
+                [
+                    f32::from_le_bytes(bin[o..o + 4].try_into().unwrap()),
+                    f32::from_le_bytes(bin[o + 4..o + 8].try_into().unwrap()),
+                    f32::from_le_bytes(bin[o + 8..o + 12].try_into().unwrap()),
+                ]
+            })
+            .collect()
+    };
+    let read_idx = |acc: usize| -> Vec<u32> {
+        let a = &accessors[acc];
+        let bv = &views[a["bufferView"].as_u64().unwrap() as usize];
+        let base = bv["byteOffset"].as_u64().unwrap_or(0) as usize
+            + a["byteOffset"].as_u64().unwrap_or(0) as usize;
+        let n = a["count"].as_u64().unwrap() as usize;
+        let ct = a["componentType"].as_u64().unwrap();
+        (0..n)
+            .map(|i| match ct {
+                5123 => u16::from_le_bytes(bin[base + i * 2..base + i * 2 + 2].try_into().unwrap())
+                    as u32,
+                5125 => u32::from_le_bytes(bin[base + i * 4..base + i * 4 + 4].try_into().unwrap()),
+                other => panic!("index componentType {other}"),
+            })
+            .collect()
+    };
+
+    let mut cache: HashMap<usize, (Vec<[f32; 3]>, Vec<u32>)> = HashMap::new();
+    let mut t = Totals {
+        triangles: 0,
+        min: [f64::INFINITY; 3],
+        max: [f64::NEG_INFINITY; 3],
+        centroid_sum: [0.0; 3],
+        area: 0.0,
+    };
+
+    // Depth-first from every scene root, composing as we go.
+    let roots: Vec<usize> = j["scenes"][0]["nodes"]
+        .as_array()
+        .map(|a| a.iter().map(|v| v.as_u64().unwrap() as usize).collect())
+        .unwrap_or_default();
+    let mut stack: Vec<(usize, [f64; 16])> = roots.iter().map(|&r| (r, ID)).collect();
+    while let Some((ni, parent)) = stack.pop() {
+        let n = &nodes[ni];
+        let world = mat_mul(&parent, &node_local(n));
+        if let Some(children) = n.get("children").and_then(|v| v.as_array()) {
+            for c in children {
+                stack.push((c.as_u64().unwrap() as usize, world));
+            }
+        }
+        let Some(mi) = n.get("mesh").and_then(|v| v.as_u64()) else {
+            continue;
+        };
+        for prim in meshes[mi as usize]["primitives"].as_array().unwrap() {
+            let pacc = prim["attributes"]["POSITION"].as_u64().unwrap() as usize;
+            let iacc = prim["indices"].as_u64().unwrap() as usize;
+            let entry = cache
+                .entry(pacc)
+                .or_insert_with(|| (read_f32x3(pacc), read_idx(iacc)));
+            let (pos, idx) = (&entry.0, &entry.1);
+            for tri in idx.chunks_exact(3) {
+                let p: Vec<[f64; 3]> = tri
+                    .iter()
+                    .map(|&k| {
+                        let v = pos[k as usize];
+                        apply(&world, [v[0] as f64, v[1] as f64, v[2] as f64])
+                    })
+                    .collect();
+                t.triangles += 1;
+                for k in 0..3 {
+                    let c = (p[0][k] + p[1][k] + p[2][k]) / 3.0;
+                    t.centroid_sum[k] += c;
+                    for v in &p {
+                        if v[k] < t.min[k] {
+                            t.min[k] = v[k];
+                        }
+                        if v[k] > t.max[k] {
+                            t.max[k] = v[k];
+                        }
+                    }
+                }
+                let u = [p[1][0] - p[0][0], p[1][1] - p[0][1], p[1][2] - p[0][2]];
+                let v = [p[2][0] - p[0][0], p[2][1] - p[0][1], p[2][2] - p[0][2]];
+                let c = [
+                    u[1] * v[2] - u[2] * v[1],
+                    u[2] * v[0] - u[0] * v[2],
+                    u[0] * v[1] - u[1] * v[0],
+                ];
+                t.area += 0.5 * (c[0] * c[0] + c[1] * c[1] + c[2] * c[2]).sqrt();
+            }
+        }
+    }
+    t
+}

--- a/rust/export/examples/world_check.rs
+++ b/rust/export/examples/world_check.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MPL-2.0
 //! Is the geometry in the same place after a change to how it is packed?
 //!
 //! Walks a GLB's node tree, composes each node's placement, and reduces every
@@ -203,7 +204,13 @@ fn totals(path: &str) -> Totals {
             .collect()
     };
 
-    let mut cache: HashMap<usize, (Vec<[f32; 3]>, Vec<u32>)> = HashMap::new();
+    // Keyed on both accessors, because the entry holds both. Two primitives
+    // can share a POSITION accessor and index it differently, and keying on the
+    // positions alone would hand the second one the first one's triangles --
+    // silently, in the tool whose job is to prove two paths agree.
+    /// One primitive's positions and triangle indices, read once.
+    type Geom = (Vec<[f32; 3]>, Vec<u32>);
+    let mut cache: HashMap<(usize, usize), Geom> = HashMap::new();
     let mut t = Totals {
         triangles: 0,
         min: [f64::INFINITY; 3],
@@ -233,7 +240,7 @@ fn totals(path: &str) -> Totals {
             let pacc = prim["attributes"]["POSITION"].as_u64().unwrap() as usize;
             let iacc = prim["indices"].as_u64().unwrap() as usize;
             let entry = cache
-                .entry(pacc)
+                .entry((pacc, iacc))
                 .or_insert_with(|| (read_f32x3(pacc), read_idx(iacc)));
             let (pos, idx) = (&entry.0, &entry.1);
             for tri in idx.chunks_exact(3) {

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -2274,10 +2274,15 @@ fn plan_bounded_glb(
     // occurrences of one map clipped differently that land on the same vertex
     // and index counts are a group whose members are not one shape.
     // Sub-bucketing by size hands one of them the other's geometry, silently.
-    // Refusing costs sharing; the other way costs correctness, and the two
-    // paths now answer "which occurrences share a shape" the same way. What it
-    // costs, measured on a 342 MB model: 34.5 MB of glTF instead of 25.0 MB,
-    // against 108 MB with no instancing at all.
+    // Refusing costs sharing; the other way costs correctness. What it costs,
+    // measured on a 342 MB model: 34.5 MB of glTF instead of 25.0 MB, against
+    // 108 MB with no instancing at all.
+    //
+    // This aligns the size rule with the collator, and it does not make the two
+    // paths identical: the in-memory one refuses a whole group where any
+    // occurrence has no instance side-channel, and this one drops that
+    // occurrence and keeps the rest. See
+    // `the_bounded_path_shares_at_least_as_much`, which pins that difference.
     let refused: FxHashSet<u128> = {
         let mut seen: FxHashMap<u128, (u32, u32)> = FxHashMap::default();
         let mut bad: FxHashSet<u128> = FxHashSet::default();

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -1649,10 +1649,12 @@ fn export_gltf_streaming_impl(
     //   pass 1 — the Y-up world AABB for `scene_center` (a precision-centering device, so
     //            any value is correct; the exact one keeps baked f32 magnitudes small);
     //   pass 2 — bake + encode each mesh as a flat node into the chunker, dropping it.
-    // Content-dedup and rep-identity instancing both happen; neither needs every
-    // mesh co-resident, because both decide from the plan rather than from the
-    // vertex data. World geometry is identical either way -- instancing is only
-    // a dedup of repeated placements.
+    // Instancing/content-dedup is skipped: this path pushes every mesh with no
+    // cache. World geometry is identical either way (instancing is only a dedup
+    // of repeated placements), so what it costs is size, not correctness.
+    // `plan_bounded_glb` -- the single-GLB bounded path -- does both; the
+    // decision needs a plan rather than co-resident vertices, and that path
+    // keeps one. This one does not.
     // A shared `index` (when present) is injected into BOTH passes' StreamingOptions so
     // neither re-scans `content` for its entity index (#1516).
     let stream_opts = || StreamingOptions {
@@ -1956,11 +1958,11 @@ pub struct GlbSizeProjection {
 /// or [`project_glb_size`] to decide up front.
 ///
 /// Tradeoffs vs the in-memory assembler (`build_gltf`):
-/// - rep-identity instancing is done here too, on the f32 layout. The vertex
-///   data needs every occurrence co-resident; the grouping decision does not,
-///   so it is made from the plan. Quantized output still skips it: a shared
-///   mesh's non-uniform dequant scale cannot fold into a rotating placement
-///   without breaking `Matrix4.decompose`.
+/// - rep-identity instancing is done here too, on the f32 layout, under the
+///   same policy `collate_refs` applies. The vertex data needs every occurrence
+///   co-resident; the grouping decision does not, so it is made from the plan.
+///   Quantized output still skips it: a shared mesh's non-uniform dequant scale
+///   cannot fold into a rotating placement without breaking `Matrix4.decompose`.
 /// - content-hash dedup is kept (the hash is computed batch-locally on pass 1).
 /// - the model is meshed twice (the price of bounded memory).
 ///
@@ -2198,9 +2200,10 @@ fn plan_bounded_glb(
                 // Beside `metas` rather than in it. An `InstanceMeta` is 424
                 // bytes and this keeps 160, which is what makes rep-identity
                 // instancing affordable on the path that exists to bound
-                // memory. Measured on a 1 GB model: about 30 MB of plan against
-                // 1.1 GB of geometry not written (glTF 1.83 GB -> 710 MB, peak
-                // RSS 7.83 GB -> 6.70 GB). Kept out of the per-mesh struct for
+                // memory. Measured on a 1.05 GB model: about 30 MB of plan
+                // against 680 MB of geometry not written (glTF 1.82 GB ->
+                // 1.14 GB, peak RSS 6.02 GB -> 5.36 GB, same wall time). Kept
+                // out of the per-mesh struct for
                 // two reasons: only instanceable meshes pay, and nothing reads
                 // it after planning, so it drops instead of sitting beside the
                 // whole output buffer while pass 2 writes it.
@@ -2243,10 +2246,6 @@ fn plan_bounded_glb(
     };
 
     // ── Build the glTF JSON (mirrors build_gltf's flat branch exactly) ──────
-    let mut key_counts: FxHashMap<u128, u32> = FxHashMap::default();
-    for meta in &metas {
-        *key_counts.entry(meta.key).or_insert(0) += 1;
-    }
 
     // Rep-identity instancing, which this path used to give up on because it
     // "needs every occurrence co-resident". The vertex data does; the decision
@@ -2259,23 +2258,50 @@ fn plan_bounded_glb(
     // `Matrix4.decompose`, so it needs the nested parent/child node the
     // in-memory path builds.
     let (rtc_zup, site_zup) = site_restore(&meta_result);
-    /// Identity, colour, and shape size.
-    ///
-    /// Colour because a glTF material rides the mesh primitive and not the node.
-    /// Size because two occurrences of one representation can still differ, and
-    /// one of them is then not the shape the other is.
-    ///
-    /// Size belongs in the key rather than in a check that discards the group.
-    /// On a building services model the most repeated shapes are exactly the
-    /// ones with a few clipped occurrences among the thousand plain ones, so
-    /// refusing the group for the exception costs most of the sharing: measured
-    /// on one 1 GB file, 532 groups of 87,393 disagree about size and they hold
-    /// 22,343 of the 151,282 occurrences. Keyed this way the thousand still
-    /// share and the exceptions go out on their own.
-    type RepBucket = (u128, (i32, i32, i32, i32), u32, u32);
+    // Rep identities whose occurrences disagree about shape size. Resolved
+    // before any bucketing, because one disagreeing member refuses the whole
+    // identity and it may be the last one seen.
+    //
+    // This is `collate_refs`' policy, arrived at the hard way. Keying the
+    // bucket on size instead shares more -- on one 1 GB file, 532 rep groups of
+    // 87,393 hold an occurrence clipped to a different vertex count, and
+    // between them 22,343 of the 151,282 occurrences. But the collator's
+    // refusal is a safety property rather than an oversight: `rep_identity` is
+    // only the RepresentationMap entity id for a mapped item, so two
+    // occurrences of one map clipped differently that land on the same vertex
+    // and index counts are a group whose members are not one shape.
+    // Sub-bucketing by size hands one of them the other's geometry, silently.
+    // Refusing costs sharing; the other way costs correctness, and the two
+    // paths now answer "which occurrences share a shape" the same way. What it
+    // costs, measured on a 342 MB model: 34.5 MB of glTF instead of 25.0 MB,
+    // against 108 MB with no instancing at all.
+    let refused: FxHashSet<u128> = {
+        let mut seen: FxHashMap<u128, (u32, u32)> = FxHashMap::default();
+        let mut bad: FxHashSet<u128> = FxHashSet::default();
+        for (i, meta) in metas.iter().enumerate() {
+            let Some(&slot) = rep_of.get(&(i as u32)) else { continue };
+            let rid = reps[slot as usize].0;
+            match seen.get(&rid) {
+                None => {
+                    seen.insert(rid, (meta.nverts, meta.nidx));
+                }
+                Some(&size) if size != (meta.nverts, meta.nidx) => {
+                    bad.insert(rid);
+                }
+                Some(_) => {}
+            }
+        }
+        bad
+    };
+    /// Identity and colour. Colour because a glTF material rides the mesh
+    /// primitive and not the node, so two colours of one shape are two meshes.
+    type RepBucket = (u128, (i32, i32, i32, i32));
     let bucket_of = |mi: usize, m: &StreamedMeshMeta| -> Option<RepBucket> {
-        let (rid, _) = reps[*rep_of.get(&(mi as u32))? as usize];
-        Some((rid, color_key(m.color), m.nverts, m.nidx))
+        let rid = reps[*rep_of.get(&(mi as u32))? as usize].0;
+        if refused.contains(&rid) {
+            return None;
+        }
+        Some((rid, color_key(m.color)))
     };
     /// What one shape does about being shared, decided before the emission loop
     /// so it can read the template's placement while holding the occurrence's
@@ -2315,6 +2341,19 @@ fn plan_bounded_glb(
             })
             .collect()
     };
+    // Content-dedup over the flat remainder only. A rep-grouped mesh never
+    // reads or writes `shared_cache`, so counting it here would make the sole
+    // flat member of its key look shared: it would emit local geometry and a
+    // node translation instead of the baked singleton, and write a cache entry
+    // nothing reads. The in-memory twin counts the remainder, so this matches
+    // rather than diverges from it.
+    let mut key_counts: FxHashMap<u128, u32> = FxHashMap::default();
+    for (i, meta) in metas.iter().enumerate() {
+        if bucket_of(i, meta).is_some_and(|b| rep_groups.contains_key(&b)) {
+            continue;
+        }
+        *key_counts.entry(meta.key).or_insert(0) += 1;
+    }
     let mut rep_cache: FxHashMap<RepBucket, u32> = FxHashMap::default();
     let mut accessors: Vec<Accessor> = Vec::new();
     let mut meshes: Vec<Mesh> = Vec::new();
@@ -2519,15 +2558,21 @@ fn plan_bounded_glb(
         // a translation, so it needs the whole placement and not an offset.
         // `rep` is `Some` only where `bucket_of` was, which is only where
         // `meta.rep` was, so the placement is there by construction.
-        let matrix = rep.and_then(|(_, group)| {
-            let (_, m_k) = reps[*rep_of.get(&(mi as u32))? as usize];
-            Some(occurrence_node_matrix_composed(
+        let matrix = rep.map(|(_, group)| {
+            // Indexed, not `?`. `emit` and `vertex_offset` above have already
+            // committed to this mesh being in a group; falling back to `None`
+            // here would place the template's geometry at this occurrence's
+            // origin with no rotation, which is silent corruption. A miss is a
+            // broken invariant and should say so.
+            let slot = rep_of[&(mi as u32)] as usize;
+            let (_, m_k) = reps[slot];
+            occurrence_node_matrix_composed(
                 m_k,
                 &group.m_ref_inv,
                 rtc_zup,
                 group.template_origin,
                 scene_center,
-            ))
+            )
         });
         let (translation, scale) = if matrix.is_some() {
             (None, None)

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -1649,9 +1649,10 @@ fn export_gltf_streaming_impl(
     //   pass 1 — the Y-up world AABB for `scene_center` (a precision-centering device, so
     //            any value is correct; the exact one keeps baked f32 magnitudes small);
     //   pass 2 — bake + encode each mesh as a flat node into the chunker, dropping it.
-    // Instancing/content-dedup is skipped (it needs every mesh co-resident); the dense
-    // models that actually need bounded memory have little instancing, and world geometry
-    // is identical either way (instancing is only a dedup of repeated placements).
+    // Content-dedup and rep-identity instancing both happen; neither needs every
+    // mesh co-resident, because both decide from the plan rather than from the
+    // vertex data. World geometry is identical either way -- instancing is only
+    // a dedup of repeated placements.
     // A shared `index` (when present) is injected into BOTH passes' StreamingOptions so
     // neither re-scans `content` for its entity index (#1516).
     let stream_opts = || StreamingOptions {
@@ -1867,15 +1868,6 @@ struct StreamedMeshMeta {
     local_max: [f32; 3],
     /// Content-dedup key (local geometry + colour), same as the in-memory flat path.
     key: u128,
-    /// Representation identity and this occurrence's composed world placement,
-    /// for meshes the geometry engine says are provably shareable.
-    ///
-    /// An `InstanceMeta` is 424 bytes; the grouping decision reads one field of
-    /// it and the placement derivation reads one product of three more. So the
-    /// plan keeps 152 bytes a mesh, which is what makes rep-identity instancing
-    /// affordable on the path that exists to bound memory. Measured on a 1 GB
-    /// model: 31 MB of plan against 1.2 GB of geometry not written.
-    rep: Option<(u128, [f64; 16])>,
     /// `Some(write)` when this occurrence emits geometry bytes on pass 2;
     /// `None` when it shares a previously emitted mesh (content-hash dedup).
     write: Option<StreamedWrite>,
@@ -1901,9 +1893,9 @@ struct StreamedWrite {
 /// there — which is the point: the wasm path must never build the whole model
 /// in memory for large inputs.
 fn glb_stream_threshold_bytes() -> usize {
-    // 64 MB: 2x under the smallest input reported to trap the wasm heap (131 MB),
-    // while instancing-heavy mid-size models (which lose rep-identity dedup on
-    // the streaming path) keep the in-memory instanced assembler.
+    // 64 MB: 2x under the smallest input reported to trap the wasm heap (131 MB).
+    // The streaming path used to lose rep-identity dedup, which was a second
+    // reason to keep mid-size models in memory; it no longer does.
     const DEFAULT_MB: usize = 64;
     let mb = std::env::var("IFC_LITE_GLB_STREAM_THRESHOLD_MB")
         .ok()
@@ -1964,10 +1956,12 @@ pub struct GlbSizeProjection {
 /// or [`project_glb_size`] to decide up front.
 ///
 /// Tradeoffs vs the in-memory assembler (`build_gltf`):
-/// - rep-identity instancing is SKIPPED (it needs every occurrence co-resident);
-///   content-hash dedup is kept (the hash is computed batch-locally on pass 1).
-///   Models with no instanceable groups produce BYTE-IDENTICAL output; models
-///   with them produce the same world geometry, larger by the forgone dedup.
+/// - rep-identity instancing is done here too, on the f32 layout. The vertex
+///   data needs every occurrence co-resident; the grouping decision does not,
+///   so it is made from the plan. Quantized output still skips it: a shared
+///   mesh's non-uniform dequant scale cannot fold into a rotating placement
+///   without breaking `Matrix4.decompose`.
+/// - content-hash dedup is kept (the hash is computed batch-locally on pass 1).
 /// - the model is meshed twice (the price of bounded memory).
 ///
 /// Supports both the f32 and the `KHR_mesh_quantization` layouts; the quantized
@@ -2135,6 +2129,12 @@ fn plan_bounded_glb(
     // Intern IFC type names so each distinct type is heap-allocated once, not per mesh.
     let mut type_intern: FxHashMap<String, Arc<str>> = FxHashMap::default();
     let mut metas: Vec<StreamedMeshMeta> = Vec::new();
+    // Quantized output cannot share a shape anyway (see the rep-bucket block
+    // below), so under `--quantize` this is never built rather than built and
+    // then not read.
+    let want_rep = !opts.quantize;
+    let mut reps: Vec<(u128, [f64; 16])> = Vec::new();
+    let mut rep_of: FxHashMap<u32, u32> = FxHashMap::default();
     let mut wmin = [f64::INFINITY; 3];
     let mut wmax = [f64::NEG_INFINITY; 3];
     // Pass 1's result carries `site_transform` and the RTC offset. Dropping it
@@ -2188,6 +2188,32 @@ fn plan_bounded_glb(
                         a
                     }
                 };
+                // Shape identity and this occurrence's composed world
+                // placement, for meshes the geometry engine says are provably
+                // shareable. `canonical_transform` marks the rotation-
+                // normalized tier, where a template is congruent rather than
+                // identical; the in-memory path refuses those groups and so
+                // does this one.
+                //
+                // Beside `metas` rather than in it. An `InstanceMeta` is 424
+                // bytes and this keeps 160, which is what makes rep-identity
+                // instancing affordable on the path that exists to bound
+                // memory. Measured on a 1 GB model: about 30 MB of plan against
+                // 1.1 GB of geometry not written (glTF 1.83 GB -> 710 MB, peak
+                // RSS 7.83 GB -> 6.70 GB). Kept out of the per-mesh struct for
+                // two reasons: only instanceable meshes pay, and nothing reads
+                // it after planning, so it drops instead of sitting beside the
+                // whole output buffer while pass 2 writes it.
+                if want_rep {
+                    let instanceable = m
+                        .instance
+                        .as_ref()
+                        .filter(|i| i.instanceable && i.canonical_transform.is_none());
+                    if let Some(inst) = instanceable {
+                        rep_of.insert(metas.len() as u32, reps.len() as u32);
+                        reps.push((inst.rep_identity, compose_world_meta(inst)));
+                    }
+                }
                 metas.push(StreamedMeshMeta {
                     express_id: m.express_id,
                     ifc_type,
@@ -2199,14 +2225,6 @@ fn plan_bounded_glb(
                     local_min: lmin,
                     local_max: lmax,
                     key: geom_color_key(&y.positions, &y.normals, &y.indices, m.color),
-                    // `canonical_transform` marks the rotation-normalized tier,
-                    // where a template is congruent rather than identical. The
-                    // in-memory path refuses those groups and so does this one.
-                    rep: m
-                        .instance
-                        .as_ref()
-                        .filter(|i| i.instanceable && i.canonical_transform.is_none())
-                        .map(|i| (i.rep_identity, compose_world_meta(i))),
                     write: None,
                 });
             }
@@ -2255,50 +2273,48 @@ fn plan_bounded_glb(
     /// 22,343 of the 151,282 occurrences. Keyed this way the thousand still
     /// share and the exceptions go out on their own.
     type RepBucket = (u128, (i32, i32, i32, i32), u32, u32);
-    let bucket_of = |m: &StreamedMeshMeta| -> Option<RepBucket> {
-        let (rid, _) = m.rep?;
+    let bucket_of = |mi: usize, m: &StreamedMeshMeta| -> Option<RepBucket> {
+        let (rid, _) = reps[*rep_of.get(&(mi as u32))? as usize];
         Some((rid, color_key(m.color), m.nverts, m.nidx))
     };
-    let mut rep_first: FxHashMap<RepBucket, usize> = FxHashMap::default();
-    let mut rep_counts: FxHashMap<RepBucket, u32> = FxHashMap::default();
-    if !opts.quantize {
-        for (i, meta) in metas.iter().enumerate() {
-            let Some(bucket) = bucket_of(meta) else { continue };
-            *rep_counts.entry(bucket).or_insert(0) += 1;
-            rep_first.entry(bucket).or_insert(i);
-        }
-    }
-    /// What one mesh does about sharing its shape, decided before the emission
-    /// loop so it can read the template's placement while holding the
-    /// occurrence's mutably.
-    struct RepPlan {
-        bucket: RepBucket,
-        is_template: bool,
+    /// What one shape does about being shared, decided before the emission loop
+    /// so it can read the template's placement while holding the occurrence's
+    /// mutably.
+    ///
+    /// Per bucket rather than per occurrence. The same plan indexed by mesh is
+    /// 208 bytes on every member of every group: on the 1 GB file's 151,282
+    /// occurrences that is 31 MB, which is what the whole plan costs in the
+    /// first place, on the path that exists to bound memory. It also inverts
+    /// the template's placement once per occurrence instead of once per shape.
+    struct RepGroup {
+        first: usize,
         /// `affine_inverse` of the template's world placement, which maps its
         /// baked geometry back into the shape's own frame.
         m_ref_inv: [f64; 16],
         template_origin: [f64; 3],
     }
-    let rep_plan: Vec<Option<RepPlan>> = metas
-        .iter()
-        .enumerate()
-        .map(|(i, meta)| {
-            let bucket = bucket_of(meta)?;
-            if rep_counts.get(&bucket).copied().unwrap_or(0) < 2 {
-                return None;
-            }
-            let first = *rep_first.get(&bucket)?;
-            // A singular placement has no inverse, so the shape cannot be
-            // recovered from its baked form and the bucket stays flat.
-            let m_ref_inv = affine_inverse(&metas[first].rep?.1)?;
-            Some(RepPlan {
-                bucket,
-                is_template: i == first,
-                m_ref_inv,
-                template_origin: metas[first].origin,
+    let rep_groups: FxHashMap<RepBucket, RepGroup> = {
+        let mut counts: FxHashMap<RepBucket, (usize, u32)> = FxHashMap::default();
+        for (i, meta) in metas.iter().enumerate() {
+            let Some(bucket) = bucket_of(i, meta) else { continue };
+            let e = counts.entry(bucket).or_insert((i, 0));
+            e.1 += 1;
+        }
+        counts
+            .into_iter()
+            .filter(|&(_, (_, n))| n >= 2)
+            .filter_map(|(bucket, (first, _))| {
+                // A singular placement has no inverse, so the shape cannot be
+                // recovered from its baked form and the bucket stays flat.
+                let m_ref = reps[*rep_of.get(&(first as u32))? as usize].1;
+                let m_ref_inv = affine_inverse(&m_ref)?;
+                Some((
+                    bucket,
+                    RepGroup { first, m_ref_inv, template_origin: metas[first].origin },
+                ))
             })
-        })
-        .collect();
+            .collect()
+    };
     let mut rep_cache: FxHashMap<RepBucket, u32> = FxHashMap::default();
     let mut accessors: Vec<Accessor> = Vec::new();
     let mut meshes: Vec<Mesh> = Vec::new();
@@ -2326,7 +2342,9 @@ fn plan_bounded_glb(
     }
     let mut per_meta: Vec<Emitted> = Vec::with_capacity(metas.len());
     for (mi, meta) in metas.iter_mut().enumerate() {
-        let rep = rep_plan[mi].as_ref();
+        // The bucket is the shape's identity, and it is also what the mesh
+        // cache is keyed on, so carry both rather than looking it up twice.
+        let rep = bucket_of(mi, meta).and_then(|b| rep_groups.get(&b).map(|g| (b, g)));
         let placement = [
             meta.origin[0] - scene_center[0],
             meta.origin[1] - scene_center[1],
@@ -2352,7 +2370,7 @@ fn plan_bounded_glb(
         // A shape's geometry goes out once, on its bucket's template. Every
         // other occurrence of it emits a node and no bytes.
         let emit = match rep {
-            Some(plan) => plan.is_template,
+            Some((_, group)) => mi == group.first,
             None => !(shared && shared_cache.contains_key(&meta.key)),
         };
         // f32 path only: singletons bake world-minus-centre into the vertices.
@@ -2486,27 +2504,30 @@ fn plan_bounded_glb(
                 norm_len += meta.nverts as u64 * 12;
                 idx_len += meta.nidx as u64 * 4;
             }
-            if let Some(plan) = rep {
-                rep_cache.insert(plan.bucket, mesh_idx);
+            if let Some((bucket, _)) = rep {
+                rep_cache.insert(bucket, mesh_idx);
             } else if shared {
                 shared_cache.insert(meta.key, (mesh_idx, q_center, q_half));
             }
             (mesh_idx, q_center, q_half)
-        } else if let Some(plan) = rep {
-            (rep_cache[&plan.bucket], q_center, q_half)
+        } else if let Some((bucket, _)) = rep {
+            (rep_cache[&bucket], q_center, q_half)
         } else {
             shared_cache[&meta.key]
         };
         // An occurrence differs from its template by a rotation as often as by
         // a translation, so it needs the whole placement and not an offset.
-        let matrix = rep.map(|plan| {
-            occurrence_node_matrix_composed(
-                meta.rep.expect("a planned occurrence carries its placement").1,
-                &plan.m_ref_inv,
+        // `rep` is `Some` only where `bucket_of` was, which is only where
+        // `meta.rep` was, so the placement is there by construction.
+        let matrix = rep.and_then(|(_, group)| {
+            let (_, m_k) = reps[*rep_of.get(&(mi as u32))? as usize];
+            Some(occurrence_node_matrix_composed(
+                m_k,
+                &group.m_ref_inv,
                 rtc_zup,
-                plan.template_origin,
+                group.template_origin,
                 scene_center,
-            )
+            ))
         });
         let (translation, scale) = if matrix.is_some() {
             (None, None)

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -46,7 +46,9 @@ mod from_meshes;
 mod matrix;
 
 pub use from_meshes::{export_glb_from_meshes, try_export_glb_from_meshes};
-use matrix::{affine_inverse, compose_world_meta, occurrence_node_matrix};
+use matrix::{
+    affine_inverse, compose_world_meta, occurrence_node_matrix, occurrence_node_matrix_composed,
+};
 
 /// Options for glTF/GLB export.
 ///
@@ -1865,6 +1867,15 @@ struct StreamedMeshMeta {
     local_max: [f32; 3],
     /// Content-dedup key (local geometry + colour), same as the in-memory flat path.
     key: u128,
+    /// Representation identity and this occurrence's composed world placement,
+    /// for meshes the geometry engine says are provably shareable.
+    ///
+    /// An `InstanceMeta` is 424 bytes; the grouping decision reads one field of
+    /// it and the placement derivation reads one product of three more. So the
+    /// plan keeps 152 bytes a mesh, which is what makes rep-identity instancing
+    /// affordable on the path that exists to bound memory. Measured on a 1 GB
+    /// model: 31 MB of plan against 1.2 GB of geometry not written.
+    rep: Option<(u128, [f64; 16])>,
     /// `Some(write)` when this occurrence emits geometry bytes on pass 2;
     /// `None` when it shares a previously emitted mesh (content-hash dedup).
     write: Option<StreamedWrite>,
@@ -2188,6 +2199,14 @@ fn plan_bounded_glb(
                     local_min: lmin,
                     local_max: lmax,
                     key: geom_color_key(&y.positions, &y.normals, &y.indices, m.color),
+                    // `canonical_transform` marks the rotation-normalized tier,
+                    // where a template is congruent rather than identical. The
+                    // in-memory path refuses those groups and so does this one.
+                    rep: m
+                        .instance
+                        .as_ref()
+                        .filter(|i| i.instanceable && i.canonical_transform.is_none())
+                        .map(|i| (i.rep_identity, compose_world_meta(i))),
                     write: None,
                 });
             }
@@ -2210,6 +2229,77 @@ fn plan_bounded_glb(
     for meta in &metas {
         *key_counts.entry(meta.key).or_insert(0) += 1;
     }
+
+    // Rep-identity instancing, which this path used to give up on because it
+    // "needs every occurrence co-resident". The vertex data does; the decision
+    // does not. `collate_refs` reads nothing off a mesh's geometry but its
+    // length, so what a group needs is an identity and a placement, and those
+    // fit in the plan this path already keeps.
+    //
+    // f32 output only. Quantized, a shared mesh carries a non-uniform dequant
+    // scale that cannot fold into a rotating placement without breaking
+    // `Matrix4.decompose`, so it needs the nested parent/child node the
+    // in-memory path builds.
+    let (rtc_zup, site_zup) = site_restore(&meta_result);
+    /// Identity, colour, and shape size.
+    ///
+    /// Colour because a glTF material rides the mesh primitive and not the node.
+    /// Size because two occurrences of one representation can still differ, and
+    /// one of them is then not the shape the other is.
+    ///
+    /// Size belongs in the key rather than in a check that discards the group.
+    /// On a building services model the most repeated shapes are exactly the
+    /// ones with a few clipped occurrences among the thousand plain ones, so
+    /// refusing the group for the exception costs most of the sharing: measured
+    /// on one 1 GB file, 532 groups of 87,393 disagree about size and they hold
+    /// 22,343 of the 151,282 occurrences. Keyed this way the thousand still
+    /// share and the exceptions go out on their own.
+    type RepBucket = (u128, (i32, i32, i32, i32), u32, u32);
+    let bucket_of = |m: &StreamedMeshMeta| -> Option<RepBucket> {
+        let (rid, _) = m.rep?;
+        Some((rid, color_key(m.color), m.nverts, m.nidx))
+    };
+    let mut rep_first: FxHashMap<RepBucket, usize> = FxHashMap::default();
+    let mut rep_counts: FxHashMap<RepBucket, u32> = FxHashMap::default();
+    if !opts.quantize {
+        for (i, meta) in metas.iter().enumerate() {
+            let Some(bucket) = bucket_of(meta) else { continue };
+            *rep_counts.entry(bucket).or_insert(0) += 1;
+            rep_first.entry(bucket).or_insert(i);
+        }
+    }
+    /// What one mesh does about sharing its shape, decided before the emission
+    /// loop so it can read the template's placement while holding the
+    /// occurrence's mutably.
+    struct RepPlan {
+        bucket: RepBucket,
+        is_template: bool,
+        /// `affine_inverse` of the template's world placement, which maps its
+        /// baked geometry back into the shape's own frame.
+        m_ref_inv: [f64; 16],
+        template_origin: [f64; 3],
+    }
+    let rep_plan: Vec<Option<RepPlan>> = metas
+        .iter()
+        .enumerate()
+        .map(|(i, meta)| {
+            let bucket = bucket_of(meta)?;
+            if rep_counts.get(&bucket).copied().unwrap_or(0) < 2 {
+                return None;
+            }
+            let first = *rep_first.get(&bucket)?;
+            // A singular placement has no inverse, so the shape cannot be
+            // recovered from its baked form and the bucket stays flat.
+            let m_ref_inv = affine_inverse(&metas[first].rep?.1)?;
+            Some(RepPlan {
+                bucket,
+                is_template: i == first,
+                m_ref_inv,
+                template_origin: metas[first].origin,
+            })
+        })
+        .collect();
+    let mut rep_cache: FxHashMap<RepBucket, u32> = FxHashMap::default();
     let mut accessors: Vec<Accessor> = Vec::new();
     let mut meshes: Vec<Mesh> = Vec::new();
     let mut nodes: Vec<Node> = Vec::new();
@@ -2232,9 +2322,11 @@ fn plan_bounded_glb(
         mesh_idx: u32,
         translation: Option<[f64; 3]>,
         scale: Option<[f64; 3]>,
+        matrix: Option<[f32; 16]>,
     }
     let mut per_meta: Vec<Emitted> = Vec::with_capacity(metas.len());
-    for meta in &mut metas {
+    for (mi, meta) in metas.iter_mut().enumerate() {
+        let rep = rep_plan[mi].as_ref();
         let placement = [
             meta.origin[0] - scene_center[0],
             meta.origin[1] - scene_center[1],
@@ -2257,10 +2349,20 @@ fn plan_bounded_glb(
             }
             (c, h)
         };
-        let emit = !(shared && shared_cache.contains_key(&meta.key));
+        // A shape's geometry goes out once, on its bucket's template. Every
+        // other occurrence of it emits a node and no bytes.
+        let emit = match rep {
+            Some(plan) => plan.is_template,
+            None => !(shared && shared_cache.contains_key(&meta.key)),
+        };
         // f32 path only: singletons bake world-minus-centre into the vertices.
-        let vertex_offset =
-            if shared || quantize { [0.0, 0.0, 0.0] } else { placement };
+        // A shared shape stays in its own frame, because what places it is the
+        // node, and for an instanced occurrence that node is a full matrix.
+        let vertex_offset = if shared || quantize || rep.is_some() {
+            [0.0, 0.0, 0.0]
+        } else {
+            placement
+        };
         let (mesh_idx, center, half) = if emit {
             let (pos_acc, norm_acc, idx_acc) = if quantize {
                 // Quantize is monotone per axis, so the accessor min/max are the
@@ -2384,14 +2486,31 @@ fn plan_bounded_glb(
                 norm_len += meta.nverts as u64 * 12;
                 idx_len += meta.nidx as u64 * 4;
             }
-            if shared {
+            if let Some(plan) = rep {
+                rep_cache.insert(plan.bucket, mesh_idx);
+            } else if shared {
                 shared_cache.insert(meta.key, (mesh_idx, q_center, q_half));
             }
             (mesh_idx, q_center, q_half)
+        } else if let Some(plan) = rep {
+            (rep_cache[&plan.bucket], q_center, q_half)
         } else {
             shared_cache[&meta.key]
         };
-        let (translation, scale) = if quantize {
+        // An occurrence differs from its template by a rotation as often as by
+        // a translation, so it needs the whole placement and not an offset.
+        let matrix = rep.map(|plan| {
+            occurrence_node_matrix_composed(
+                meta.rep.expect("a planned occurrence carries its placement").1,
+                &plan.m_ref_inv,
+                rtc_zup,
+                plan.template_origin,
+                scene_center,
+            )
+        });
+        let (translation, scale) = if matrix.is_some() {
+            (None, None)
+        } else if quantize {
             // Placement is pure translation, so it commutes with the dequant
             // translate: node = T(placement + center) · S(half).
             (
@@ -2410,7 +2529,7 @@ fn plan_bounded_glb(
         } else {
             (None, None)
         };
-        per_meta.push(Emitted { mesh_idx, translation, scale });
+        per_meta.push(Emitted { mesh_idx, translation, scale, matrix });
     }
     for (meta, emitted) in metas.iter().zip(&per_meta) {
         let node_idx = nodes.len() as u32;
@@ -2420,7 +2539,7 @@ fn plan_bounded_glb(
             children: None,
             translation: emitted.translation,
             scale: emitted.scale,
-            matrix: None,
+            matrix: emitted.matrix,
             extras: node_extras(
                 opts.include_metadata,
                 meta.express_id,
@@ -2471,10 +2590,8 @@ fn plan_bounded_glb(
         )
     };
 
-    let (root_translation, site_rotation) = {
-        let (rtc_zup, site_zup) = site_restore(&meta_result);
-        scene_root(scene_center, rtc_zup, site_zup.as_deref())
-    };
+    let (root_translation, site_rotation) =
+        scene_root(scene_center, rtc_zup, site_zup.as_deref());
     let scene_nodes = if element_node_indices.is_empty() {
         Vec::new()
     } else {

--- a/rust/export/src/gltf.rs
+++ b/rust/export/src/gltf.rs
@@ -2198,15 +2198,18 @@ fn plan_bounded_glb(
                 // does this one.
                 //
                 // Beside `metas` rather than in it. An `InstanceMeta` is 424
-                // bytes and this keeps 160, which is what makes rep-identity
-                // instancing affordable on the path that exists to bound
-                // memory. Measured on a 1.05 GB model: about 30 MB of plan
-                // against 680 MB of geometry not written (glTF 1.82 GB ->
-                // 1.14 GB, peak RSS 6.02 GB -> 5.36 GB, same wall time). Kept
-                // out of the per-mesh struct for
-                // two reasons: only instanceable meshes pay, and nothing reads
-                // it after planning, so it drops instead of sitting beside the
-                // whole output buffer while pass 2 writes it.
+                // bytes and one entry here is 160, which is what makes
+                // rep-identity instancing affordable on the path that exists to
+                // bound memory. Measured on a 1.05 GB model: about 30 MB of
+                // plan against 680 MB of geometry not written (glTF 1.82 GB ->
+                // 1.14 GB, peak RSS 6.02 GB -> 5.36 GB, same wall time).
+                //
+                // Out of the per-mesh struct for two reasons: only instanceable
+                // meshes pay, and nothing reads it after planning, so it drops
+                // instead of sitting beside the whole output buffer while pass
+                // 2 writes it. (That 160 is this entry, not the per-mesh struct
+                // -- `the_streamed_mesh_plan_stays_small` pins that separately
+                // at 240, and it is 240 *because* this moved out.)
                 if want_rep {
                     let instanceable = m
                         .instance

--- a/rust/export/src/gltf/matrix.rs
+++ b/rust/export/src/gltf/matrix.rs
@@ -139,7 +139,28 @@ pub(super) fn occurrence_node_matrix(
     template_origin_yup: [f64; 3],
     scene_center: [f64; 3],
 ) -> [f32; 16] {
-    let m_k = compose_world_meta(occ);
+    occurrence_node_matrix_composed(
+        compose_world_meta(occ),
+        m_ref_inv,
+        rtc_zup,
+        template_origin_yup,
+        scene_center,
+    )
+}
+
+/// The same, from a world placement already composed.
+///
+/// `compose_world_meta` is the only thing this derivation reads out of an
+/// `InstanceMeta`, so a caller that has to keep one record per mesh can keep the
+/// 128-byte product instead of the 424-byte struct. That is what lets the
+/// bounded assembler afford instancing at all.
+pub(super) fn occurrence_node_matrix_composed(
+    m_k: [f64; 16],
+    m_ref_inv: &[f64; 16],
+    rtc_zup: [f64; 3],
+    template_origin_yup: [f64; 3],
+    scene_center: [f64; 3],
+) -> [f32; 16] {
     // rel maps the template's PRE-RTC world geometry onto occurrence k's.
     let rel_pre = mat4_mul(&m_k, m_ref_inv);
     // Conjugate into the POST-RTC baked frame the geometry actually lives in.
@@ -157,227 +178,5 @@ pub(super) fn occurrence_node_matrix(
 }
 
 #[cfg(test)]
-mod tests {
-    #[test]
-    fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
-        // A ROTATED occurrence at NATIONAL-GRID coordinates: the node matrix is built
-        // from the same InstanceMeta the baker would carry; reconstructing the
-        // occurrence from the template's baked-local geometry must land on the
-        // occurrence's own baked geometry to sub-millimetre, even though the relative
-        // transform's absolute terms are ~1e5 m. (A pre-RTC `rel` applied to post-RTC
-        // geometry — the bug — misplaces this by ~(R-I)·rtc, i.e. hundreds of metres.)
-        use ifc_lite_geometry::InstanceMeta;
-
-        // Row-major helpers.
-        let translate = |t: [f64; 3]| -> [f64; 16] {
-            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
-        };
-        // Rotation about Z (Z-up): (x,y) rotate, z fixed.
-        let rot_z = |deg: f64| -> [f64; 16] {
-            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
-            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
-        };
-        let apply = |m: &[f64; 16], p: [f64; 3]| -> [f64; 3] {
-            [
-                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
-                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
-                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
-            ]
-        };
-
-        // Placements (Z-up, pre-RTC): template upright, occurrence rotated 37° about Z.
-        let m_ref = super::mat4_mul(&translate([10., 20., 5.]), &rot_z(0.0));
-        let m_k = super::mat4_mul(&translate([60., 35., 5.]), &rot_z(37.0));
-        // National-grid RTC the baker subtracts (e.g. Dutch RD-ish easting/northing).
-        let rtc = [155_000.0_f64, 463_000.0, 0.0];
-
-        // Canonical (rep-local) geometry — a few non-degenerate points.
-        let canonical = [
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 2.0, 0.0],
-            [0.5, 0.5, 1.5],
-            [2.0, 0.3, 0.7],
-        ];
-        // Baked = placement·canonical - rtc, in Z-up.
-        let bake = |m: &[f64; 16]| -> Vec<[f64; 3]> {
-            canonical
-                .iter()
-                .map(|&x| {
-                    let w = apply(m, x);
-                    [w[0] - rtc[0], w[1] - rtc[1], w[2] - rtc[2]]
-                })
-                .collect()
-        };
-        let tmpl_baked = bake(&m_ref);
-        let occ_baked = bake(&m_k);
-
-        // Template origin = centroid of its baked geometry; local = baked - origin.
-        let n = canonical.len() as f64;
-        let origin_z = {
-            let mut o = [0.0; 3];
-            for p in &tmpl_baked {
-                for k in 0..3 {
-                    o[k] += p[k] / n;
-                }
-            }
-            o
-        };
-        // Convert template origin + local, and the occurrence's baked truth, to Y-up.
-        let origin_yup = crate::frame::yup_f64(origin_z);
-        let tmpl_local_yup: Vec<[f64; 3]> = tmpl_baked
-            .iter()
-            .map(|p| crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]]))
-            .collect();
-        let occ_world_yup: Vec<[f64; 3]> = occ_baked.iter().map(|p| crate::frame::yup_f64(*p)).collect();
-
-        // scene_center = centre of the combined baked Y-up AABB.
-        let mut lo = [f64::INFINITY; 3];
-        let mut hi = [f64::NEG_INFINITY; 3];
-        for p in tmpl_baked.iter().chain(occ_baked.iter()) {
-            let y = crate::frame::yup_f64(*p);
-            for k in 0..3 {
-                lo[k] = lo[k].min(y[k]);
-                hi[k] = hi[k].max(y[k]);
-            }
-        }
-        let scene_center = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
-
-        let meta = |transform: [f64; 16]| InstanceMeta {
-            transform,
-            local_transform: None,
-            canonical_transform: None,
-            rep_identity: 42,
-            instanceable: true,
-        };
-        let m_ref_inv = super::affine_inverse(&super::compose_world_meta(&meta(m_ref)))
-            .expect("template placement invertible");
-        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
-
-        // Reconstruct: world = scene_center(root) + node(col-major) · template_local.
-        let mut max_err = 0.0f64;
-        for (lv, truth) in tmpl_local_yup.iter().zip(&occ_world_yup) {
-            let (x, y, z) = (lv[0], lv[1], lv[2]);
-            let world = [
-                scene_center[0] + node[0] as f64 * x + node[4] as f64 * y + node[8] as f64 * z + node[12] as f64,
-                scene_center[1] + node[1] as f64 * x + node[5] as f64 * y + node[9] as f64 * z + node[13] as f64,
-                scene_center[2] + node[2] as f64 * x + node[6] as f64 * y + node[10] as f64 * z + node[14] as f64,
-            ];
-            for k in 0..3 {
-                max_err = max_err.max((world[k] - truth[k]).abs());
-            }
-        }
-        assert!(
-            max_err < 1e-3,
-            "rotated instance under national-grid RTC mis-reconstructed by {max_err} m"
-        );
-    }
-
-    #[test]
-    fn affine_inverse_rejects_singular_placement() {
-        // Zero scale on X collapses the upper 3x3, so there is no affine inverse and the
-        // caller must fall back to the flat (non-instanced) path.
-        let m = [
-            0.0, 0.0, 0.0, 5.0, //
-            0.0, 1.0, 0.0, 0.0, //
-            0.0, 0.0, 1.0, 0.0, //
-            0.0, 0.0, 0.0, 1.0,
-        ];
-        assert!(super::affine_inverse(&m).is_none());
-    }
-
-    #[test]
-    fn compose_world_meta_applies_canonical_then_local_then_transform() {
-        use ifc_lite_geometry::InstanceMeta;
-        // Non-commuting factors so the ORDER is observable: canonical shifts +x, local
-        // rotates 90° about z, transform shifts +x again. A point at the origin must go
-        // origin -(canonical)-> (1,0,0) -(local rot)-> (0,1,0) -(transform)-> (10,1,0).
-        let rot_z90 = [
-            0.0, -1.0, 0.0, 0.0, //
-            1.0, 0.0, 0.0, 0.0, //
-            0.0, 0.0, 1.0, 0.0, //
-            0.0, 0.0, 0.0, 1.0,
-        ];
-        let translate = |t: [f64; 3]| {
-            [
-                1.0, 0.0, 0.0, t[0], //
-                0.0, 1.0, 0.0, t[1], //
-                0.0, 0.0, 1.0, t[2], //
-                0.0, 0.0, 0.0, 1.0,
-            ]
-        };
-        let meta = InstanceMeta {
-            transform: translate([10.0, 0.0, 0.0]),
-            local_transform: Some(rot_z90),
-            canonical_transform: Some(translate([1.0, 0.0, 0.0])),
-            rep_identity: 1,
-            instanceable: true,
-        };
-        let m = super::compose_world_meta(&meta);
-        // Row-major apply to the origin: the translation column is (m[3], m[7], m[11]).
-        let world = [m[3], m[7], m[11]];
-        let want = [10.0, 1.0, 0.0];
-        for k in 0..3 {
-            assert!((world[k] - want[k]).abs() < 1e-9, "axis {k}: {} != {}", world[k], want[k]);
-        }
-    }
-
-    #[test]
-    fn zero_rtc_places_non_identity_occurrence() {
-        use ifc_lite_geometry::InstanceMeta;
-        // With rtc = 0 (the baker subtracted no offset) the conjugation is a no-op, but the
-        // node must STILL place a NON-identity occurrence correctly. Reconstructing the
-        // template's local geometry through the node has to land on the occurrence's own
-        // Y-up world geometry — this catches translation / rotation / matrix-layout errors
-        // an identity-in/identity-out check cannot.
-        let rot_z = |deg: f64| -> [f64; 16] {
-            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
-            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
-        };
-        let translate = |t: [f64; 3]| {
-            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
-        };
-        let apply = |m: &[f64; 16], p: [f64; 3]| {
-            [
-                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
-                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
-                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
-            ]
-        };
-        let meta = |transform: [f64; 16]| InstanceMeta {
-            transform,
-            local_transform: None,
-            canonical_transform: None,
-            rep_identity: 3,
-            instanceable: true,
-        };
-
-        // Template at identity placement (baked geometry = canonical, origin 0); occurrence
-        // rotated 25° about Z and translated. rtc / origin / scene_center all zero.
-        let m_ref = super::compose_world_meta(&meta(super::IDENTITY16));
-        let m_ref_inv = super::affine_inverse(&m_ref).expect("identity invertible");
-        let m_k = super::compose_world_meta(&meta(
-            super::mat4_mul(&translate([7.0, -3.0, 2.0]), &rot_z(25.0)),
-        ));
-        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, [0.0; 3], [0.0; 3], [0.0; 3]);
-
-        let canonical = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.3, 0.4, 0.5]];
-        let mut max_err = 0.0f64;
-        for &p in &canonical {
-            // Template local (Y-up): identity template at origin 0, so just the Y-up point.
-            let lv = crate::frame::yup_f64(p);
-            // Truth: the occurrence's own baked (rtc = 0) geometry, in Y-up.
-            let truth = crate::frame::yup_f64(apply(&m_k, p));
-            let world = [
-                node[0] as f64 * lv[0] + node[4] as f64 * lv[1] + node[8] as f64 * lv[2] + node[12] as f64,
-                node[1] as f64 * lv[0] + node[5] as f64 * lv[1] + node[9] as f64 * lv[2] + node[13] as f64,
-                node[2] as f64 * lv[0] + node[6] as f64 * lv[1] + node[10] as f64 * lv[2] + node[14] as f64,
-            ];
-            for k in 0..3 {
-                max_err = max_err.max((world[k] - truth[k]).abs());
-            }
-        }
-        // The node matrix is downcast to f32, so the bound is f32 precision, not f64.
-        assert!(max_err < 1e-4, "zero-rtc non-identity occurrence mis-placed by {max_err}");
-    }
-}
+#[path = "matrix_tests.rs"]
+mod tests;

--- a/rust/export/src/gltf/matrix_tests.rs
+++ b/rust/export/src/gltf/matrix_tests.rs
@@ -1,0 +1,227 @@
+//! Tests for [`super`], split out to keep the module under the size ratchet.
+//!
+//! Included by `matrix.rs` with `#[path]`, which is the house pattern for a
+//! module whose bulk is `#[cfg(test)]`.
+    #[test]
+    fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
+        // A ROTATED occurrence at NATIONAL-GRID coordinates: the node matrix is built
+        // from the same InstanceMeta the baker would carry; reconstructing the
+        // occurrence from the template's baked-local geometry must land on the
+        // occurrence's own baked geometry to sub-millimetre, even though the relative
+        // transform's absolute terms are ~1e5 m. (A pre-RTC `rel` applied to post-RTC
+        // geometry — the bug — misplaces this by ~(R-I)·rtc, i.e. hundreds of metres.)
+        use ifc_lite_geometry::InstanceMeta;
+
+        // Row-major helpers.
+        let translate = |t: [f64; 3]| -> [f64; 16] {
+            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+        };
+        // Rotation about Z (Z-up): (x,y) rotate, z fixed.
+        let rot_z = |deg: f64| -> [f64; 16] {
+            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
+            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
+        };
+        let apply = |m: &[f64; 16], p: [f64; 3]| -> [f64; 3] {
+            [
+                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
+                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
+                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
+            ]
+        };
+
+        // Placements (Z-up, pre-RTC): template upright, occurrence rotated 37° about Z.
+        let m_ref = super::mat4_mul(&translate([10., 20., 5.]), &rot_z(0.0));
+        let m_k = super::mat4_mul(&translate([60., 35., 5.]), &rot_z(37.0));
+        // National-grid RTC the baker subtracts (e.g. Dutch RD-ish easting/northing).
+        let rtc = [155_000.0_f64, 463_000.0, 0.0];
+
+        // Canonical (rep-local) geometry — a few non-degenerate points.
+        let canonical = [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [0.5, 0.5, 1.5],
+            [2.0, 0.3, 0.7],
+        ];
+        // Baked = placement·canonical - rtc, in Z-up.
+        let bake = |m: &[f64; 16]| -> Vec<[f64; 3]> {
+            canonical
+                .iter()
+                .map(|&x| {
+                    let w = apply(m, x);
+                    [w[0] - rtc[0], w[1] - rtc[1], w[2] - rtc[2]]
+                })
+                .collect()
+        };
+        let tmpl_baked = bake(&m_ref);
+        let occ_baked = bake(&m_k);
+
+        // Template origin = centroid of its baked geometry; local = baked - origin.
+        let n = canonical.len() as f64;
+        let origin_z = {
+            let mut o = [0.0; 3];
+            for p in &tmpl_baked {
+                for k in 0..3 {
+                    o[k] += p[k] / n;
+                }
+            }
+            o
+        };
+        // Convert template origin + local, and the occurrence's baked truth, to Y-up.
+        let origin_yup = crate::frame::yup_f64(origin_z);
+        let tmpl_local_yup: Vec<[f64; 3]> = tmpl_baked
+            .iter()
+            .map(|p| crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]]))
+            .collect();
+        let occ_world_yup: Vec<[f64; 3]> = occ_baked.iter().map(|p| crate::frame::yup_f64(*p)).collect();
+
+        // scene_center = centre of the combined baked Y-up AABB.
+        let mut lo = [f64::INFINITY; 3];
+        let mut hi = [f64::NEG_INFINITY; 3];
+        for p in tmpl_baked.iter().chain(occ_baked.iter()) {
+            let y = crate::frame::yup_f64(*p);
+            for k in 0..3 {
+                lo[k] = lo[k].min(y[k]);
+                hi[k] = hi[k].max(y[k]);
+            }
+        }
+        let scene_center = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
+
+        let meta = |transform: [f64; 16]| InstanceMeta {
+            transform,
+            local_transform: None,
+            canonical_transform: None,
+            rep_identity: 42,
+            instanceable: true,
+        };
+        let m_ref_inv = super::affine_inverse(&super::compose_world_meta(&meta(m_ref)))
+            .expect("template placement invertible");
+        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
+
+        // Reconstruct: world = scene_center(root) + node(col-major) · template_local.
+        let mut max_err = 0.0f64;
+        for (lv, truth) in tmpl_local_yup.iter().zip(&occ_world_yup) {
+            let (x, y, z) = (lv[0], lv[1], lv[2]);
+            let world = [
+                scene_center[0] + node[0] as f64 * x + node[4] as f64 * y + node[8] as f64 * z + node[12] as f64,
+                scene_center[1] + node[1] as f64 * x + node[5] as f64 * y + node[9] as f64 * z + node[13] as f64,
+                scene_center[2] + node[2] as f64 * x + node[6] as f64 * y + node[10] as f64 * z + node[14] as f64,
+            ];
+            for k in 0..3 {
+                max_err = max_err.max((world[k] - truth[k]).abs());
+            }
+        }
+        assert!(
+            max_err < 1e-3,
+            "rotated instance under national-grid RTC mis-reconstructed by {max_err} m"
+        );
+    }
+
+    #[test]
+    fn affine_inverse_rejects_singular_placement() {
+        // Zero scale on X collapses the upper 3x3, so there is no affine inverse and the
+        // caller must fall back to the flat (non-instanced) path.
+        let m = [
+            0.0, 0.0, 0.0, 5.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ];
+        assert!(super::affine_inverse(&m).is_none());
+    }
+
+    #[test]
+    fn compose_world_meta_applies_canonical_then_local_then_transform() {
+        use ifc_lite_geometry::InstanceMeta;
+        // Non-commuting factors so the ORDER is observable: canonical shifts +x, local
+        // rotates 90° about z, transform shifts +x again. A point at the origin must go
+        // origin -(canonical)-> (1,0,0) -(local rot)-> (0,1,0) -(transform)-> (10,1,0).
+        let rot_z90 = [
+            0.0, -1.0, 0.0, 0.0, //
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0,
+        ];
+        let translate = |t: [f64; 3]| {
+            [
+                1.0, 0.0, 0.0, t[0], //
+                0.0, 1.0, 0.0, t[1], //
+                0.0, 0.0, 1.0, t[2], //
+                0.0, 0.0, 0.0, 1.0,
+            ]
+        };
+        let meta = InstanceMeta {
+            transform: translate([10.0, 0.0, 0.0]),
+            local_transform: Some(rot_z90),
+            canonical_transform: Some(translate([1.0, 0.0, 0.0])),
+            rep_identity: 1,
+            instanceable: true,
+        };
+        let m = super::compose_world_meta(&meta);
+        // Row-major apply to the origin: the translation column is (m[3], m[7], m[11]).
+        let world = [m[3], m[7], m[11]];
+        let want = [10.0, 1.0, 0.0];
+        for k in 0..3 {
+            assert!((world[k] - want[k]).abs() < 1e-9, "axis {k}: {} != {}", world[k], want[k]);
+        }
+    }
+
+    #[test]
+    fn zero_rtc_places_non_identity_occurrence() {
+        use ifc_lite_geometry::InstanceMeta;
+        // With rtc = 0 (the baker subtracted no offset) the conjugation is a no-op, but the
+        // node must STILL place a NON-identity occurrence correctly. Reconstructing the
+        // template's local geometry through the node has to land on the occurrence's own
+        // Y-up world geometry — this catches translation / rotation / matrix-layout errors
+        // an identity-in/identity-out check cannot.
+        let rot_z = |deg: f64| -> [f64; 16] {
+            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
+            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
+        };
+        let translate = |t: [f64; 3]| {
+            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+        };
+        let apply = |m: &[f64; 16], p: [f64; 3]| {
+            [
+                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
+                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
+                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
+            ]
+        };
+        let meta = |transform: [f64; 16]| InstanceMeta {
+            transform,
+            local_transform: None,
+            canonical_transform: None,
+            rep_identity: 3,
+            instanceable: true,
+        };
+
+        // Template at identity placement (baked geometry = canonical, origin 0); occurrence
+        // rotated 25° about Z and translated. rtc / origin / scene_center all zero.
+        let m_ref = super::compose_world_meta(&meta(super::IDENTITY16));
+        let m_ref_inv = super::affine_inverse(&m_ref).expect("identity invertible");
+        let m_k = super::compose_world_meta(&meta(
+            super::mat4_mul(&translate([7.0, -3.0, 2.0]), &rot_z(25.0)),
+        ));
+        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, [0.0; 3], [0.0; 3], [0.0; 3]);
+
+        let canonical = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.3, 0.4, 0.5]];
+        let mut max_err = 0.0f64;
+        for &p in &canonical {
+            // Template local (Y-up): identity template at origin 0, so just the Y-up point.
+            let lv = crate::frame::yup_f64(p);
+            // Truth: the occurrence's own baked (rtc = 0) geometry, in Y-up.
+            let truth = crate::frame::yup_f64(apply(&m_k, p));
+            let world = [
+                node[0] as f64 * lv[0] + node[4] as f64 * lv[1] + node[8] as f64 * lv[2] + node[12] as f64,
+                node[1] as f64 * lv[0] + node[5] as f64 * lv[1] + node[9] as f64 * lv[2] + node[13] as f64,
+                node[2] as f64 * lv[0] + node[6] as f64 * lv[1] + node[10] as f64 * lv[2] + node[14] as f64,
+            ];
+            for k in 0..3 {
+                max_err = max_err.max((world[k] - truth[k]).abs());
+            }
+        }
+        // The node matrix is downcast to f32, so the bound is f32 precision, not f64.
+        assert!(max_err < 1e-4, "zero-rtc non-identity occurrence mis-placed by {max_err}");
+    }
+

--- a/rust/export/src/gltf/matrix_tests.rs
+++ b/rust/export/src/gltf/matrix_tests.rs
@@ -1,227 +1,227 @@
+// SPDX-License-Identifier: MPL-2.0
 //! Tests for [`super`], split out to keep the module under the size ratchet.
 //!
 //! Included by `matrix.rs` with `#[path]`, which is the house pattern for a
 //! module whose bulk is `#[cfg(test)]`.
-    #[test]
-    fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
-        // A ROTATED occurrence at NATIONAL-GRID coordinates: the node matrix is built
-        // from the same InstanceMeta the baker would carry; reconstructing the
-        // occurrence from the template's baked-local geometry must land on the
-        // occurrence's own baked geometry to sub-millimetre, even though the relative
-        // transform's absolute terms are ~1e5 m. (A pre-RTC `rel` applied to post-RTC
-        // geometry — the bug — misplaces this by ~(R-I)·rtc, i.e. hundreds of metres.)
-        use ifc_lite_geometry::InstanceMeta;
+#[test]
+fn occurrence_matrix_reconstructs_rotated_instance_under_national_grid_rtc() {
+    // A ROTATED occurrence at NATIONAL-GRID coordinates: the node matrix is built
+    // from the same InstanceMeta the baker would carry; reconstructing the
+    // occurrence from the template's baked-local geometry must land on the
+    // occurrence's own baked geometry to sub-millimetre, even though the relative
+    // transform's absolute terms are ~1e5 m. (A pre-RTC `rel` applied to post-RTC
+    // geometry — the bug — misplaces this by ~(R-I)·rtc, i.e. hundreds of metres.)
+    use ifc_lite_geometry::InstanceMeta;
 
-        // Row-major helpers.
-        let translate = |t: [f64; 3]| -> [f64; 16] {
-            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
-        };
-        // Rotation about Z (Z-up): (x,y) rotate, z fixed.
-        let rot_z = |deg: f64| -> [f64; 16] {
-            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
-            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
-        };
-        let apply = |m: &[f64; 16], p: [f64; 3]| -> [f64; 3] {
-            [
-                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
-                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
-                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
-            ]
-        };
+    // Row-major helpers.
+    let translate = |t: [f64; 3]| -> [f64; 16] {
+        [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+    };
+    // Rotation about Z (Z-up): (x,y) rotate, z fixed.
+    let rot_z = |deg: f64| -> [f64; 16] {
+        let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
+        [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
+    };
+    let apply = |m: &[f64; 16], p: [f64; 3]| -> [f64; 3] {
+        [
+            m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
+            m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
+            m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
+        ]
+    };
 
-        // Placements (Z-up, pre-RTC): template upright, occurrence rotated 37° about Z.
-        let m_ref = super::mat4_mul(&translate([10., 20., 5.]), &rot_z(0.0));
-        let m_k = super::mat4_mul(&translate([60., 35., 5.]), &rot_z(37.0));
-        // National-grid RTC the baker subtracts (e.g. Dutch RD-ish easting/northing).
-        let rtc = [155_000.0_f64, 463_000.0, 0.0];
+    // Placements (Z-up, pre-RTC): template upright, occurrence rotated 37° about Z.
+    let m_ref = super::mat4_mul(&translate([10., 20., 5.]), &rot_z(0.0));
+    let m_k = super::mat4_mul(&translate([60., 35., 5.]), &rot_z(37.0));
+    // National-grid RTC the baker subtracts (e.g. Dutch RD-ish easting/northing).
+    let rtc = [155_000.0_f64, 463_000.0, 0.0];
 
-        // Canonical (rep-local) geometry — a few non-degenerate points.
-        let canonical = [
-            [0.0, 0.0, 0.0],
-            [1.0, 0.0, 0.0],
-            [0.0, 2.0, 0.0],
-            [0.5, 0.5, 1.5],
-            [2.0, 0.3, 0.7],
-        ];
-        // Baked = placement·canonical - rtc, in Z-up.
-        let bake = |m: &[f64; 16]| -> Vec<[f64; 3]> {
-            canonical
-                .iter()
-                .map(|&x| {
-                    let w = apply(m, x);
-                    [w[0] - rtc[0], w[1] - rtc[1], w[2] - rtc[2]]
-                })
-                .collect()
-        };
-        let tmpl_baked = bake(&m_ref);
-        let occ_baked = bake(&m_k);
-
-        // Template origin = centroid of its baked geometry; local = baked - origin.
-        let n = canonical.len() as f64;
-        let origin_z = {
-            let mut o = [0.0; 3];
-            for p in &tmpl_baked {
-                for k in 0..3 {
-                    o[k] += p[k] / n;
-                }
-            }
-            o
-        };
-        // Convert template origin + local, and the occurrence's baked truth, to Y-up.
-        let origin_yup = crate::frame::yup_f64(origin_z);
-        let tmpl_local_yup: Vec<[f64; 3]> = tmpl_baked
+    // Canonical (rep-local) geometry — a few non-degenerate points.
+    let canonical = [
+        [0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [0.0, 2.0, 0.0],
+        [0.5, 0.5, 1.5],
+        [2.0, 0.3, 0.7],
+    ];
+    // Baked = placement·canonical - rtc, in Z-up.
+    let bake = |m: &[f64; 16]| -> Vec<[f64; 3]> {
+        canonical
             .iter()
-            .map(|p| crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]]))
-            .collect();
-        let occ_world_yup: Vec<[f64; 3]> = occ_baked.iter().map(|p| crate::frame::yup_f64(*p)).collect();
+            .map(|&x| {
+                let w = apply(m, x);
+                [w[0] - rtc[0], w[1] - rtc[1], w[2] - rtc[2]]
+            })
+            .collect()
+    };
+    let tmpl_baked = bake(&m_ref);
+    let occ_baked = bake(&m_k);
 
-        // scene_center = centre of the combined baked Y-up AABB.
-        let mut lo = [f64::INFINITY; 3];
-        let mut hi = [f64::NEG_INFINITY; 3];
-        for p in tmpl_baked.iter().chain(occ_baked.iter()) {
-            let y = crate::frame::yup_f64(*p);
+    // Template origin = centroid of its baked geometry; local = baked - origin.
+    let n = canonical.len() as f64;
+    let origin_z = {
+        let mut o = [0.0; 3];
+        for p in &tmpl_baked {
             for k in 0..3 {
-                lo[k] = lo[k].min(y[k]);
-                hi[k] = hi[k].max(y[k]);
+                o[k] += p[k] / n;
             }
         }
-        let scene_center = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
+        o
+    };
+    // Convert template origin + local, and the occurrence's baked truth, to Y-up.
+    let origin_yup = crate::frame::yup_f64(origin_z);
+    let tmpl_local_yup: Vec<[f64; 3]> = tmpl_baked
+        .iter()
+        .map(|p| crate::frame::yup_f64([p[0] - origin_z[0], p[1] - origin_z[1], p[2] - origin_z[2]]))
+        .collect();
+    let occ_world_yup: Vec<[f64; 3]> = occ_baked.iter().map(|p| crate::frame::yup_f64(*p)).collect();
 
-        let meta = |transform: [f64; 16]| InstanceMeta {
-            transform,
-            local_transform: None,
-            canonical_transform: None,
-            rep_identity: 42,
-            instanceable: true,
-        };
-        let m_ref_inv = super::affine_inverse(&super::compose_world_meta(&meta(m_ref)))
-            .expect("template placement invertible");
-        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
-
-        // Reconstruct: world = scene_center(root) + node(col-major) · template_local.
-        let mut max_err = 0.0f64;
-        for (lv, truth) in tmpl_local_yup.iter().zip(&occ_world_yup) {
-            let (x, y, z) = (lv[0], lv[1], lv[2]);
-            let world = [
-                scene_center[0] + node[0] as f64 * x + node[4] as f64 * y + node[8] as f64 * z + node[12] as f64,
-                scene_center[1] + node[1] as f64 * x + node[5] as f64 * y + node[9] as f64 * z + node[13] as f64,
-                scene_center[2] + node[2] as f64 * x + node[6] as f64 * y + node[10] as f64 * z + node[14] as f64,
-            ];
-            for k in 0..3 {
-                max_err = max_err.max((world[k] - truth[k]).abs());
-            }
-        }
-        assert!(
-            max_err < 1e-3,
-            "rotated instance under national-grid RTC mis-reconstructed by {max_err} m"
-        );
-    }
-
-    #[test]
-    fn affine_inverse_rejects_singular_placement() {
-        // Zero scale on X collapses the upper 3x3, so there is no affine inverse and the
-        // caller must fall back to the flat (non-instanced) path.
-        let m = [
-            0.0, 0.0, 0.0, 5.0, //
-            0.0, 1.0, 0.0, 0.0, //
-            0.0, 0.0, 1.0, 0.0, //
-            0.0, 0.0, 0.0, 1.0,
-        ];
-        assert!(super::affine_inverse(&m).is_none());
-    }
-
-    #[test]
-    fn compose_world_meta_applies_canonical_then_local_then_transform() {
-        use ifc_lite_geometry::InstanceMeta;
-        // Non-commuting factors so the ORDER is observable: canonical shifts +x, local
-        // rotates 90° about z, transform shifts +x again. A point at the origin must go
-        // origin -(canonical)-> (1,0,0) -(local rot)-> (0,1,0) -(transform)-> (10,1,0).
-        let rot_z90 = [
-            0.0, -1.0, 0.0, 0.0, //
-            1.0, 0.0, 0.0, 0.0, //
-            0.0, 0.0, 1.0, 0.0, //
-            0.0, 0.0, 0.0, 1.0,
-        ];
-        let translate = |t: [f64; 3]| {
-            [
-                1.0, 0.0, 0.0, t[0], //
-                0.0, 1.0, 0.0, t[1], //
-                0.0, 0.0, 1.0, t[2], //
-                0.0, 0.0, 0.0, 1.0,
-            ]
-        };
-        let meta = InstanceMeta {
-            transform: translate([10.0, 0.0, 0.0]),
-            local_transform: Some(rot_z90),
-            canonical_transform: Some(translate([1.0, 0.0, 0.0])),
-            rep_identity: 1,
-            instanceable: true,
-        };
-        let m = super::compose_world_meta(&meta);
-        // Row-major apply to the origin: the translation column is (m[3], m[7], m[11]).
-        let world = [m[3], m[7], m[11]];
-        let want = [10.0, 1.0, 0.0];
+    // scene_center = centre of the combined baked Y-up AABB.
+    let mut lo = [f64::INFINITY; 3];
+    let mut hi = [f64::NEG_INFINITY; 3];
+    for p in tmpl_baked.iter().chain(occ_baked.iter()) {
+        let y = crate::frame::yup_f64(*p);
         for k in 0..3 {
-            assert!((world[k] - want[k]).abs() < 1e-9, "axis {k}: {} != {}", world[k], want[k]);
+            lo[k] = lo[k].min(y[k]);
+            hi[k] = hi[k].max(y[k]);
         }
     }
+    let scene_center = [(lo[0] + hi[0]) * 0.5, (lo[1] + hi[1]) * 0.5, (lo[2] + hi[2]) * 0.5];
 
-    #[test]
-    fn zero_rtc_places_non_identity_occurrence() {
-        use ifc_lite_geometry::InstanceMeta;
-        // With rtc = 0 (the baker subtracted no offset) the conjugation is a no-op, but the
-        // node must STILL place a NON-identity occurrence correctly. Reconstructing the
-        // template's local geometry through the node has to land on the occurrence's own
-        // Y-up world geometry — this catches translation / rotation / matrix-layout errors
-        // an identity-in/identity-out check cannot.
-        let rot_z = |deg: f64| -> [f64; 16] {
-            let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
-            [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
-        };
-        let translate = |t: [f64; 3]| {
-            [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
-        };
-        let apply = |m: &[f64; 16], p: [f64; 3]| {
-            [
-                m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
-                m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
-                m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
-            ]
-        };
-        let meta = |transform: [f64; 16]| InstanceMeta {
-            transform,
-            local_transform: None,
-            canonical_transform: None,
-            rep_identity: 3,
-            instanceable: true,
-        };
+    let meta = |transform: [f64; 16]| InstanceMeta {
+        transform,
+        local_transform: None,
+        canonical_transform: None,
+        rep_identity: 42,
+        instanceable: true,
+    };
+    let m_ref_inv = super::affine_inverse(&super::compose_world_meta(&meta(m_ref)))
+        .expect("template placement invertible");
+    let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, rtc, origin_yup, scene_center);
 
-        // Template at identity placement (baked geometry = canonical, origin 0); occurrence
-        // rotated 25° about Z and translated. rtc / origin / scene_center all zero.
-        let m_ref = super::compose_world_meta(&meta(super::IDENTITY16));
-        let m_ref_inv = super::affine_inverse(&m_ref).expect("identity invertible");
-        let m_k = super::compose_world_meta(&meta(
-            super::mat4_mul(&translate([7.0, -3.0, 2.0]), &rot_z(25.0)),
-        ));
-        let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, [0.0; 3], [0.0; 3], [0.0; 3]);
-
-        let canonical = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.3, 0.4, 0.5]];
-        let mut max_err = 0.0f64;
-        for &p in &canonical {
-            // Template local (Y-up): identity template at origin 0, so just the Y-up point.
-            let lv = crate::frame::yup_f64(p);
-            // Truth: the occurrence's own baked (rtc = 0) geometry, in Y-up.
-            let truth = crate::frame::yup_f64(apply(&m_k, p));
-            let world = [
-                node[0] as f64 * lv[0] + node[4] as f64 * lv[1] + node[8] as f64 * lv[2] + node[12] as f64,
-                node[1] as f64 * lv[0] + node[5] as f64 * lv[1] + node[9] as f64 * lv[2] + node[13] as f64,
-                node[2] as f64 * lv[0] + node[6] as f64 * lv[1] + node[10] as f64 * lv[2] + node[14] as f64,
-            ];
-            for k in 0..3 {
-                max_err = max_err.max((world[k] - truth[k]).abs());
-            }
+    // Reconstruct: world = scene_center(root) + node(col-major) · template_local.
+    let mut max_err = 0.0f64;
+    for (lv, truth) in tmpl_local_yup.iter().zip(&occ_world_yup) {
+        let (x, y, z) = (lv[0], lv[1], lv[2]);
+        let world = [
+            scene_center[0] + node[0] as f64 * x + node[4] as f64 * y + node[8] as f64 * z + node[12] as f64,
+            scene_center[1] + node[1] as f64 * x + node[5] as f64 * y + node[9] as f64 * z + node[13] as f64,
+            scene_center[2] + node[2] as f64 * x + node[6] as f64 * y + node[10] as f64 * z + node[14] as f64,
+        ];
+        for k in 0..3 {
+            max_err = max_err.max((world[k] - truth[k]).abs());
         }
-        // The node matrix is downcast to f32, so the bound is f32 precision, not f64.
-        assert!(max_err < 1e-4, "zero-rtc non-identity occurrence mis-placed by {max_err}");
     }
+    assert!(
+        max_err < 1e-3,
+        "rotated instance under national-grid RTC mis-reconstructed by {max_err} m"
+    );
+}
 
+#[test]
+fn affine_inverse_rejects_singular_placement() {
+    // Zero scale on X collapses the upper 3x3, so there is no affine inverse and the
+    // caller must fall back to the flat (non-instanced) path.
+    let m = [
+        0.0, 0.0, 0.0, 5.0, //
+        0.0, 1.0, 0.0, 0.0, //
+        0.0, 0.0, 1.0, 0.0, //
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    assert!(super::affine_inverse(&m).is_none());
+}
+
+#[test]
+fn compose_world_meta_applies_canonical_then_local_then_transform() {
+    use ifc_lite_geometry::InstanceMeta;
+    // Non-commuting factors so the ORDER is observable: canonical shifts +x, local
+    // rotates 90° about z, transform shifts +x again. A point at the origin must go
+    // origin -(canonical)-> (1,0,0) -(local rot)-> (0,1,0) -(transform)-> (10,1,0).
+    let rot_z90 = [
+        0.0, -1.0, 0.0, 0.0, //
+        1.0, 0.0, 0.0, 0.0, //
+        0.0, 0.0, 1.0, 0.0, //
+        0.0, 0.0, 0.0, 1.0,
+    ];
+    let translate = |t: [f64; 3]| {
+        [
+            1.0, 0.0, 0.0, t[0], //
+            0.0, 1.0, 0.0, t[1], //
+            0.0, 0.0, 1.0, t[2], //
+            0.0, 0.0, 0.0, 1.0,
+        ]
+    };
+    let meta = InstanceMeta {
+        transform: translate([10.0, 0.0, 0.0]),
+        local_transform: Some(rot_z90),
+        canonical_transform: Some(translate([1.0, 0.0, 0.0])),
+        rep_identity: 1,
+        instanceable: true,
+    };
+    let m = super::compose_world_meta(&meta);
+    // Row-major apply to the origin: the translation column is (m[3], m[7], m[11]).
+    let world = [m[3], m[7], m[11]];
+    let want = [10.0, 1.0, 0.0];
+    for k in 0..3 {
+        assert!((world[k] - want[k]).abs() < 1e-9, "axis {k}: {} != {}", world[k], want[k]);
+    }
+}
+
+#[test]
+fn zero_rtc_places_non_identity_occurrence() {
+    use ifc_lite_geometry::InstanceMeta;
+    // With rtc = 0 (the baker subtracted no offset) the conjugation is a no-op, but the
+    // node must STILL place a NON-identity occurrence correctly. Reconstructing the
+    // template's local geometry through the node has to land on the occurrence's own
+    // Y-up world geometry — this catches translation / rotation / matrix-layout errors
+    // an identity-in/identity-out check cannot.
+    let rot_z = |deg: f64| -> [f64; 16] {
+        let (s, c) = (deg.to_radians().sin(), deg.to_radians().cos());
+        [c, -s, 0., 0., s, c, 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.]
+    };
+    let translate = |t: [f64; 3]| {
+        [1., 0., 0., t[0], 0., 1., 0., t[1], 0., 0., 1., t[2], 0., 0., 0., 1.]
+    };
+    let apply = |m: &[f64; 16], p: [f64; 3]| {
+        [
+            m[0] * p[0] + m[1] * p[1] + m[2] * p[2] + m[3],
+            m[4] * p[0] + m[5] * p[1] + m[6] * p[2] + m[7],
+            m[8] * p[0] + m[9] * p[1] + m[10] * p[2] + m[11],
+        ]
+    };
+    let meta = |transform: [f64; 16]| InstanceMeta {
+        transform,
+        local_transform: None,
+        canonical_transform: None,
+        rep_identity: 3,
+        instanceable: true,
+    };
+
+    // Template at identity placement (baked geometry = canonical, origin 0); occurrence
+    // rotated 25° about Z and translated. rtc / origin / scene_center all zero.
+    let m_ref = super::compose_world_meta(&meta(super::IDENTITY16));
+    let m_ref_inv = super::affine_inverse(&m_ref).expect("identity invertible");
+    let m_k = super::compose_world_meta(&meta(
+        super::mat4_mul(&translate([7.0, -3.0, 2.0]), &rot_z(25.0)),
+    ));
+    let node = super::occurrence_node_matrix(&meta(m_k), &m_ref_inv, [0.0; 3], [0.0; 3], [0.0; 3]);
+
+    let canonical = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.3, 0.4, 0.5]];
+    let mut max_err = 0.0f64;
+    for &p in &canonical {
+        // Template local (Y-up): identity template at origin 0, so just the Y-up point.
+        let lv = crate::frame::yup_f64(p);
+        // Truth: the occurrence's own baked (rtc = 0) geometry, in Y-up.
+        let truth = crate::frame::yup_f64(apply(&m_k, p));
+        let world = [
+            node[0] as f64 * lv[0] + node[4] as f64 * lv[1] + node[8] as f64 * lv[2] + node[12] as f64,
+            node[1] as f64 * lv[0] + node[5] as f64 * lv[1] + node[9] as f64 * lv[2] + node[13] as f64,
+            node[2] as f64 * lv[0] + node[6] as f64 * lv[1] + node[10] as f64 * lv[2] + node[14] as f64,
+        ];
+        for k in 0..3 {
+            max_err = max_err.max((world[k] - truth[k]).abs());
+        }
+    }
+    // The node matrix is downcast to f32, so the bound is f32 precision, not f64.
+    assert!(max_err < 1e-4, "zero-rtc non-identity occurrence mis-placed by {max_err}");
+}

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -1587,12 +1587,10 @@ fn streaming_bounded_shares_a_repeated_shape() {
 
 /// The bounded path shares at least as much as the in-memory one.
 ///
-/// Not the same amount, and the difference is deliberate on both sides. The
-/// in-memory path sends a whole group back to flat when any one occurrence has
-/// no instance side-channel, or when the group disagrees about vertex count;
-/// this one drops the occurrence and keeps the rest, because on a real model the
-/// most repeated shapes are the ones with a few clipped occurrences among the
-/// thousand plain ones. The world geometry either path produces is pinned by
+/// Not necessarily the same amount: both refuse a group that disagrees about
+/// vertex count, but the in-memory path also refuses one where any occurrence
+/// has no instance side-channel, and this one drops that occurrence and keeps
+/// the rest. The world geometry either path produces is pinned by
 /// `streaming_bounded_preserves_world_geometry_on_instanced_model`.
 #[test]
 fn the_bounded_path_shares_at_least_as_much() {
@@ -1874,12 +1872,17 @@ fn index_u32_promote_streaming_bounded() {
 }
 
 /// The bounded path's plan is per mesh, so its size is the thing that decides
-/// whether a very large model fits. 320,688 occurrences at 160 bytes is 51 MB.
+/// whether a very large model fits: 320,688 occurrences at 240 bytes is 77 MB,
+/// and it was 400 (128 MB) before the shape identity moved to a side table.
 ///
 /// Pinned because it is easy to lose by accident: a `u128` field aligns the
 /// whole struct to 16, so adding one costs every other field's padding too, and
 /// nothing else in the type system says so.
+///
+/// 64-bit only. `Arc<str>` and `Option<String>` are narrower on wasm32, so the
+/// number there is a different (also correct) one.
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn the_streamed_mesh_plan_stays_small() {
     assert_eq!(
         std::mem::size_of::<StreamedMeshMeta>(),

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -1514,9 +1514,10 @@ fn streaming_bounded_is_byte_identical_on_flat_models() {
 
 #[test]
 fn streaming_bounded_preserves_world_geometry_on_instanced_model() {
-    // duplex has rep-identity groups the streaming path deliberately skips
-    // (bounded memory cannot hold every occurrence). World geometry must be
-    // identical anyway: same element nodes, same total placed triangles.
+    // duplex has rep-identity groups. Both paths share them now, so both emit
+    // one element node per occurrence and the same total placed triangles; what
+    // differs is how many meshes those nodes point at, which
+    // `streaming_bounded_shares_a_repeated_shape` pins.
     let Some(content) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else { return };
     let opts = GltfOptions::default();
     let (in_memory, _) = export_glb_from_result(process_geometry(&content), &opts);
@@ -1545,6 +1546,72 @@ fn streaming_bounded_preserves_world_geometry_on_instanced_model() {
     // pos/norm are 12-byte and idx 4-byte multiples, so the BIN needs no padding
     // and must be exactly the three declared runs.
     assert_eq!(declared as usize, str_bin.len(), "BIN length matches declared runs");
+}
+
+/// The bounded path shares a repeated shape instead of sending it once per
+/// occurrence.
+///
+/// It used to skip this, on the reasoning that grouping "needs every occurrence
+/// co-resident". The geometry does; the decision does not, and that is the whole
+/// change: grouping reads a representation identity, so what the plan has to
+/// carry is that and a placement.
+///
+/// Pinned as an inequality rather than a count, because the number moves with
+/// the fixture. What must hold is that occurrences outnumber meshes at all,
+/// which is false for every version that baked each one.
+#[test]
+fn streaming_bounded_shares_a_repeated_shape() {
+    let Some(content) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else { return };
+    let opts = GltfOptions::default();
+    let (streamed, stats) = export_glb_streaming_bounded(&content, &opts);
+    let (json, _) = parse_glb(&streamed);
+    let nodes = json["nodes"].as_array().unwrap().len();
+    assert!(stats.meshes > 0, "the fixture has geometry");
+    assert!(
+        stats.meshes < nodes - 1,
+        "{} meshes for {} element nodes: nothing was shared",
+        stats.meshes,
+        nodes - 1,
+    );
+    // A shared shape is placed by a node matrix, because occurrences of one
+    // shape differ by rotation as often as by translation.
+    assert!(
+        json["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|n| n.get("matrix").is_some()),
+        "shared shapes are placed, and not by translation",
+    );
+}
+
+/// The bounded path shares at least as much as the in-memory one.
+///
+/// Not the same amount, and the difference is deliberate on both sides. The
+/// in-memory path sends a whole group back to flat when any one occurrence has
+/// no instance side-channel, or when the group disagrees about vertex count;
+/// this one drops the occurrence and keeps the rest, because on a real model the
+/// most repeated shapes are the ones with a few clipped occurrences among the
+/// thousand plain ones. The world geometry either path produces is pinned by
+/// `streaming_bounded_preserves_world_geometry_on_instanced_model`.
+#[test]
+fn the_bounded_path_shares_at_least_as_much() {
+    let Some(content) = crate::test_support::fixture_opt("ara3d/duplex.ifc") else { return };
+    let opts = GltfOptions::default();
+    let (_, mem) = export_glb_from_result(process_geometry(&content), &opts);
+    let (_, streamed) = export_glb_streaming_bounded(&content, &opts);
+    assert!(
+        streamed.meshes <= mem.meshes,
+        "in-memory emitted {} meshes, bounded {} — bounded found less sharing",
+        mem.meshes,
+        streamed.meshes,
+    );
+    assert!(
+        streamed.vertices <= mem.vertices,
+        "vertices follow meshes: in-memory {}, bounded {}",
+        mem.vertices,
+        streamed.vertices,
+    );
 }
 
 #[test]

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -1546,6 +1546,137 @@ fn streaming_bounded_preserves_world_geometry_on_instanced_model() {
     // pos/norm are 12-byte and idx 4-byte multiples, so the BIN needs no padding
     // and must be exactly the three declared runs.
     assert_eq!(declared as usize, str_bin.len(), "BIN length matches declared runs");
+
+    // And where the triangles actually are. Everything above this line survives
+    // an arbitrary translation of every shared shape: node count, triangle count
+    // and BIN length do not move when a placement is wrong. That is the whole
+    // mechanism this path adds, so it needs an assertion that can see it.
+    let (_, mem_bin) = parse_glb(&in_memory);
+    let mem_w = world_totals(&mem_json, &[&mem_bin]);
+    let str_w = world_totals(&str_json, &[&str_bin]);
+    assert_eq!(mem_w.triangles, str_w.triangles, "placed triangle count");
+    // f32 in world coordinates on one path and f32 in the shape's own frame
+    // placed by an f64 matrix on the other, so the last bits differ by
+    // construction and equality is the wrong test. The tolerance is measured
+    // rather than guessed: on duplex the two agree to ~1e-8 on the centroid
+    // sums and exactly on the bounds, and the smallest displacement this is
+    // meant to catch (one wrongly shared group) moves a centroid sum by
+    // 1.4e-3. 1e-6 sits a thousandfold clear of both.
+    for k in 0..3 {
+        let axis = ["x", "y", "z"][k];
+        assert!(
+            (mem_w.centroid_sum[k] - str_w.centroid_sum[k]).abs() < 1e-6,
+            "centroid sum {axis}: in-memory {} vs bounded {} -- shared shapes are placed differently",
+            mem_w.centroid_sum[k],
+            str_w.centroid_sum[k],
+        );
+        assert!(
+            (mem_w.min[k] - str_w.min[k]).abs() < 1e-6 && (mem_w.max[k] - str_w.max[k]).abs() < 1e-6,
+            "world bounds {axis}: in-memory {:?}..{:?} vs bounded {:?}..{:?}",
+            mem_w.min[k],
+            mem_w.max[k],
+            str_w.min[k],
+            str_w.max[k],
+        );
+    }
+}
+
+/// Where a GLB's triangles are, reduced to numbers that do not depend on
+/// emission order.
+struct WorldTotals {
+    triangles: u64,
+    min: [f64; 3],
+    max: [f64; 3],
+    /// Summed triangle centroids. The discriminating one: an AABB only moves if
+    /// a displaced shape was on the hull, and a triangle count does not move at
+    /// all, but every misplaced triangle shifts this.
+    centroid_sum: [f64; 3],
+}
+
+/// Walk the node tree, compose each placement, and reduce every triangle.
+///
+/// The same reduction `examples/world_check.rs` prints, done where a test can
+/// assert on it. Deliberately a second copy: an example is a separate crate and
+/// reaches only `pub` items, so sharing this would mean putting a test oracle in
+/// the public API. Two copies of a reduction is the cheaper of those.
+fn world_totals(json: &Value, bufs: &[&[u8]]) -> WorldTotals {
+    let empty = vec![];
+    let nodes = json["nodes"].as_array().unwrap_or(&empty);
+    let ident = {
+        let mut m = [0.0; 16];
+        m[0] = 1.0;
+        m[5] = 1.0;
+        m[10] = 1.0;
+        m[15] = 1.0;
+        m
+    };
+    let mut t = WorldTotals {
+        triangles: 0,
+        min: [f64::INFINITY; 3],
+        max: [f64::NEG_INFINITY; 3],
+        centroid_sum: [0.0; 3],
+    };
+    let mut stack: Vec<(usize, [f64; 16])> = json["scenes"][0]["nodes"]
+        .as_array()
+        .unwrap_or(&empty)
+        .iter()
+        .map(|n| (n.as_u64().unwrap() as usize, ident))
+        .collect();
+    while let Some((ni, parent)) = stack.pop() {
+        let node = &nodes[ni];
+        let world = mat_mul(&parent, &node_local(node));
+        if let Some(children) = node.get("children").and_then(Value::as_array) {
+            for c in children {
+                stack.push((c.as_u64().unwrap() as usize, world));
+            }
+        }
+        let Some(mi) = node.get("mesh").and_then(Value::as_u64) else { continue };
+        let prims = json["meshes"][mi as usize]["primitives"].as_array().unwrap();
+        for prim in prims {
+            let pacc = prim["attributes"]["POSITION"].as_u64().unwrap() as usize;
+            let iacc = prim["indices"].as_u64().unwrap() as usize;
+            let pos = decode_positions(json, bufs, pacc);
+            // Read indices here rather than through `decode_indices`, whose
+            // width cross-check assumes one accessor per bufferView. The
+            // bounded path packs every index run into one view at an offset,
+            // which is a different layout and not a defect.
+            let idx = {
+                let acc = &json["accessors"][iacc];
+                let bv = &json["bufferViews"][acc["bufferView"].as_u64().unwrap() as usize];
+                let bin = bufs[bv["buffer"].as_u64().unwrap_or(0) as usize];
+                let base = bv["byteOffset"].as_u64().unwrap_or(0) as usize
+                    + acc["byteOffset"].as_u64().unwrap_or(0) as usize;
+                let count = acc["count"].as_u64().unwrap() as usize;
+                let ct = acc["componentType"].as_u64().unwrap();
+                (0..count)
+                    .map(|i| match ct {
+                        5123 => {
+                            let o = base + i * 2;
+                            u16::from_le_bytes(bin[o..o + 2].try_into().unwrap()) as u64
+                        }
+                        5125 => {
+                            let o = base + i * 4;
+                            u32::from_le_bytes(bin[o..o + 4].try_into().unwrap()) as u64
+                        }
+                        other => panic!("unexpected index componentType {other}"),
+                    })
+                    .collect::<Vec<u64>>()
+            };
+            for tri in idx.chunks_exact(3) {
+                let p: Vec<[f64; 3]> =
+                    tri.iter().map(|&k| transform_point(&world, pos[k as usize])).collect();
+                t.triangles += 1;
+                for k in 0..3 {
+                    t.centroid_sum[k] += (p[0][k] + p[1][k] + p[2][k]) / 3.0;
+                    for v in &p {
+                        t.min[k] = t.min[k].min(v[k]);
+                        t.max[k] = t.max[k].max(v[k]);
+                    }
+                }
+            }
+        }
+    }
+    t
 }
 
 /// The bounded path shares a repeated shape instead of sending it once per

--- a/rust/export/src/gltf_tests.rs
+++ b/rust/export/src/gltf_tests.rs
@@ -1872,3 +1872,18 @@ fn index_u32_promote_streaming_bounded() {
     assert!(idx.iter().min() == Some(&0), "index 0 must be present: {idx:?}");
     assert!(idx.contains(&65536), "{idx:?}");
 }
+
+/// The bounded path's plan is per mesh, so its size is the thing that decides
+/// whether a very large model fits. 320,688 occurrences at 160 bytes is 51 MB.
+///
+/// Pinned because it is easy to lose by accident: a `u128` field aligns the
+/// whole struct to 16, so adding one costs every other field's padding too, and
+/// nothing else in the type system says so.
+#[test]
+fn the_streamed_mesh_plan_stays_small() {
+    assert_eq!(
+        std::mem::size_of::<StreamedMeshMeta>(),
+        240,
+        "the per-mesh plan grew; see the rep side table in plan_bounded_glb"
+    );
+}

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -94,8 +94,8 @@ pub use obj::{export_obj, export_obj_with_stats, ObjOptions, ObjStats};
 #[cfg(feature = "parquet-bos")]
 pub use parquet_bos::{export_bos, ParquetBosOptions};
 pub use step::{
-    export_step, export_step_to_writer, export_step_json, export_step_with_stats, AttrMutation, CopyOnWriteMutation,
-    PropMutation, StepOptions, StepStats,
+    export_step, export_step_json, export_step_to_writer, export_step_with_stats, AttrMutation,
+    CopyOnWriteMutation, PropMutation, StepOptions, StepStats,
 };
 pub use usd::{export_usd, UsdOptions};
 

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -41,6 +41,7 @@ mod schema_convert;
 mod shades;
 mod step;
 mod step_cow;
+mod step_header;
 mod step_text;
 mod usd;
 

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -94,7 +94,7 @@ pub use obj::{export_obj, export_obj_with_stats, ObjOptions, ObjStats};
 #[cfg(feature = "parquet-bos")]
 pub use parquet_bos::{export_bos, ParquetBosOptions};
 pub use step::{
-    export_step, export_step_json, export_step_with_stats, AttrMutation, CopyOnWriteMutation,
+    export_step, export_step_to_writer, export_step_json, export_step_with_stats, AttrMutation, CopyOnWriteMutation,
     PropMutation, StepOptions, StepStats,
 };
 pub use usd::{export_usd, UsdOptions};

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -201,9 +201,16 @@ pub fn export_step(content: &[u8], opts: &StepOptions) -> String {
 
 /// Like [`export_step`] but also returns coverage stats.
 pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, StepStats) {
-    // One allocation instead of the ~30 a doubling `Vec` does on a gigabyte.
-    let mut buf = Vec::with_capacity(content.len());
-    let stats = export_step_to_writer(content, opts, &mut buf).expect("a Vec accepts every write");
+    // Presized for a full re-export, where the output is within a small factor
+    // of the source. Not for a subset: 200 MB filtered to a few records would
+    // reserve 200 MB, and on wasm that linear memory never comes back.
+    let mut buf = match opts.included {
+        None => Vec::with_capacity(content.len()),
+        Some(_) => Vec::new(),
+    };
+    // `emit`, not `export_step_to_writer`: a `Vec` needs no buffering, and
+    // wrapping one memcpys the whole output through a 1 MiB window for nothing.
+    let stats = emit(content, opts, &mut buf).expect("a Vec accepts every write");
     // Every byte came from the source by way of `from_utf8_lossy`, or from a
     // `format!`, so this validates rather than converts.
     let out = String::from_utf8(buf).expect("the writer emits UTF-8");
@@ -214,12 +221,10 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
 /// The two cannot drift: that one is this one writing into a `Vec`.
 ///
 /// The gigabyte of `String` that doubled its way there is gone. What replaces
-/// it is not free, and "proportional to record count" hides how large the
-/// constant is: the entity index measures ~84 bytes a record, so 370 MB on a
-/// 4.4 M-record file and ~1.1 GB on a 16.8 M-record one, before a byte is
-/// written. On a very large model the index outweighs the output it stopped
-/// holding. It is not removable -- source order and the reference closure both
-/// need it.
+/// it is not free: the entity index measures ~84 bytes a record, so 370 MB on
+/// 4.4 M records and ~1.1 GB on 16.8 M, before a byte is written. On a very
+/// large model it outweighs the output it stopped holding, and it is not
+/// removable -- source order and the reference closure both need it.
 ///
 /// `out` is buffered here, so a bare `File` is fine. A record costs two `write`
 /// calls, which unbuffered is two syscalls: measured 15.0 s against 4.3 s on
@@ -315,17 +320,7 @@ fn emit<W: std::io::Write>(
     let repointed = resolved.repointed;
 
     // 3. Emit header + filtered entities (source order) + footer.
-    out.write_all(b"ISO-10303-21;\nHEADER;\n")?;
-    writeln!(out, "FILE_DESCRIPTION(('{}'),'2;1');", escape(&opts.description))?;
-    writeln!(
-        out,
-        "FILE_NAME('','',('{}'),('{}'),'{}','ifc-lite-export','');",
-        escape(&opts.author),
-        escape(&opts.organization),
-        escape(&opts.application),
-    )?;
-    writeln!(out, "FILE_SCHEMA(('{}'));", escape(&schema))?;
-    out.write_all(b"ENDSEC;\nDATA;\n")?;
+    crate::step_header::write_header(out, opts, &schema)?;
 
     let mut written = 0usize;
     for id in &order {

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -199,11 +199,42 @@ pub fn export_step(content: &[u8], opts: &StepOptions) -> String {
     export_step_with_stats(content, opts).0
 }
 
+/// [`export_step_with_stats`], writing as it goes instead of returning the file.
+///
+/// The difference is the output. This never holds it: each record goes to `w` as
+/// it is read, so a 1 GB model costs the entity index and one record rather than
+/// the index plus a gigabyte of `String` that doubled its way there. What stays
+/// resident is proportional to record count, not to file size.
+///
+/// [`export_step_with_stats`] is this function writing into a `Vec`, so the two
+/// cannot drift.
+pub fn export_step_to_writer<W: std::io::Write>(
+    content: &[u8],
+    opts: &StepOptions,
+    w: &mut W,
+) -> std::io::Result<StepStats> {
+    emit(content, opts, w)
+}
+
 /// Like [`export_step`] but also returns coverage stats.
 // The grouped-property-mutation Vec type is explicit by design; aliasing it
 // would hide the (entity, pset) -> [(key, value)] grouping structure.
 #[allow(clippy::type_complexity)]
 pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, StepStats) {
+    let mut buf = Vec::new();
+    let stats = emit(content, opts, &mut buf).expect("a Vec accepts every write");
+    // Every byte came from the source by way of `from_utf8_lossy`, or from a
+    // `format!`, so this validates rather than converts.
+    let out = String::from_utf8(buf).expect("the writer emits UTF-8");
+    (out, stats)
+}
+
+#[allow(clippy::type_complexity)]
+fn emit<W: std::io::Write>(
+    content: &[u8],
+    opts: &StepOptions,
+    out: &mut W,
+) -> std::io::Result<StepStats> {
     // 1. Index every entity line (preserve source order).
     let mut order: Vec<u32> = Vec::new();
     let mut line_of: HashMap<u32, (usize, usize)> = HashMap::new();
@@ -273,17 +304,17 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
     let repointed = resolved.repointed;
 
     // 3. Emit header + filtered entities (source order) + footer.
-    let mut out = String::new();
-    out.push_str("ISO-10303-21;\nHEADER;\n");
-    out.push_str(&format!("FILE_DESCRIPTION(('{}'),'2;1');\n", escape(&opts.description)));
-    out.push_str(&format!(
-        "FILE_NAME('','',('{}'),('{}'),'{}','ifc-lite-export','');\n",
+    out.write_all(b"ISO-10303-21;\nHEADER;\n")?;
+    writeln!(out, "FILE_DESCRIPTION(('{}'),'2;1');", escape(&opts.description))?;
+    writeln!(
+        out,
+        "FILE_NAME('','',('{}'),('{}'),'{}','ifc-lite-export','');",
         escape(&opts.author),
         escape(&opts.organization),
         escape(&opts.application),
-    ));
-    out.push_str(&format!("FILE_SCHEMA(('{}'));\n", escape(&schema)));
-    out.push_str("ENDSEC;\nDATA;\n");
+    )?;
+    writeln!(out, "FILE_SCHEMA(('{}'));", escape(&schema))?;
+    out.write_all(b"ENDSEC;\nDATA;\n")?;
 
     let mut written = 0usize;
     for id in &order {
@@ -296,16 +327,19 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
                     None => raw.into_owned(),
                 };
                 if converting {
-                    out.push_str(&crate::schema_convert::convert_step_line(
-                        &edited,
-                        &source_schema,
-                        &schema,
-                        *id,
-                    ));
+                    out.write_all(
+                        crate::schema_convert::convert_step_line(
+                            &edited,
+                            &source_schema,
+                            &schema,
+                            *id,
+                        )
+                        .as_bytes(),
+                    )?;
                 } else {
-                    out.push_str(&edited);
+                    out.write_all(edited.as_bytes())?;
                 }
-                out.push('\n');
+                out.write_all(b"\n")?;
                 written += 1;
             }
         }
@@ -325,16 +359,19 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             let edited = apply_attr_mutations(&raw, &muts);
             let renumbered = renumber(&edited, *copy_id);
             if converting {
-                out.push_str(&crate::schema_convert::convert_step_line(
-                    &renumbered,
-                    &source_schema,
-                    &schema,
-                    *copy_id,
-                ));
+                out.write_all(
+                    crate::schema_convert::convert_step_line(
+                        &renumbered,
+                        &source_schema,
+                        &schema,
+                        *copy_id,
+                    )
+                    .as_bytes(),
+                )?;
             } else {
-                out.push_str(&renumbered);
+                out.write_all(renumbered.as_bytes())?;
             }
-            out.push('\n');
+            out.write_all(b"\n")?;
             written += 1;
         }
     }
@@ -360,8 +397,8 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
         // Same exhaustion, same answer: inventing ids on a full file would
         // duplicate real records.
         let Some(mut next) = next_id else {
-            out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
-            return (out, StepStats { total: order.len(), written, copies_refused });
+            out.write_all(b"ENDSEC;\nEND-ISO-10303-21;\n")?;
+            return Ok(StepStats { total: order.len(), written, copies_refused });
         };
         for ((express_id, pset_name), props) in &groups {
             // One property set costs one id per property plus one for the set
@@ -377,11 +414,12 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             }
             let mut prop_refs: Vec<u32> = Vec::with_capacity(props.len());
             for (pname, value) in props {
-                out.push_str(&format!(
-                    "#{next}=IFCPROPERTYSINGLEVALUE('{}',$,{},$);\n",
+                writeln!(
+                    out,
+                    "#{next}=IFCPROPERTYSINGLEVALUE('{}',$,{},$);",
                     escape(pname),
                     value
-                ));
+                )?;
                 prop_refs.push(next);
                 next += 1;
                 written += 1;
@@ -389,26 +427,28 @@ pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, St
             let psid = next;
             next += 1;
             let refs_str = prop_refs.iter().map(|r| format!("#{r}")).collect::<Vec<_>>().join(",");
-            out.push_str(&format!(
-                "#{psid}=IFCPROPERTYSET('{}',$,'{}',$,({}));\n",
+            writeln!(
+                out,
+                "#{psid}=IFCPROPERTYSET('{}',$,'{}',$,({}));",
                 crate::schema_convert::placeholder_guid(psid),
                 escape(pset_name),
                 refs_str
-            ));
+            )?;
             written += 1;
             let rid = next;
             next += 1;
-            out.push_str(&format!(
-                "#{rid}=IFCRELDEFINESBYPROPERTIES('{}',$,$,$,(#{express_id}),#{psid});\n",
+            writeln!(
+                out,
+                "#{rid}=IFCRELDEFINESBYPROPERTIES('{}',$,$,$,(#{express_id}),#{psid});",
                 crate::schema_convert::placeholder_guid(rid),
-            ));
+            )?;
             written += 1;
         }
     }
 
-    out.push_str("ENDSEC;\nEND-ISO-10303-21;\n");
+    out.write_all(b"ENDSEC;\nEND-ISO-10303-21;\n")?;
 
-    (out, StepStats { total: order.len(), written, copies_refused })
+    Ok(StepStats { total: order.len(), written, copies_refused })
 }
 
 #[cfg(test)]

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -240,7 +240,8 @@ pub fn export_step_to_writer<W: std::io::Write>(
     use std::io::Write as _;
     let mut buffered = std::io::BufWriter::with_capacity(1 << 20, w);
     let stats = emit(content, opts, &mut buffered)?;
-    // Flushed here: a `BufWriter` dropped unflushed truncates and reports ok.
+    // Flushed here for the error, not for the bytes: `BufWriter::drop` does
+    // flush, it just has nowhere to report a failure and swallows it.
     buffered.flush()?;
     Ok(stats)
 }

--- a/rust/export/src/step.rs
+++ b/rust/export/src/step.rs
@@ -199,34 +199,45 @@ pub fn export_step(content: &[u8], opts: &StepOptions) -> String {
     export_step_with_stats(content, opts).0
 }
 
+/// Like [`export_step`] but also returns coverage stats.
+pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, StepStats) {
+    // One allocation instead of the ~30 a doubling `Vec` does on a gigabyte.
+    let mut buf = Vec::with_capacity(content.len());
+    let stats = export_step_to_writer(content, opts, &mut buf).expect("a Vec accepts every write");
+    // Every byte came from the source by way of `from_utf8_lossy`, or from a
+    // `format!`, so this validates rather than converts.
+    let out = String::from_utf8(buf).expect("the writer emits UTF-8");
+    (out, stats)
+}
+
 /// [`export_step_with_stats`], writing as it goes instead of returning the file.
+/// The two cannot drift: that one is this one writing into a `Vec`.
 ///
-/// The difference is the output. This never holds it: each record goes to `w` as
-/// it is read, so a 1 GB model costs the entity index and one record rather than
-/// the index plus a gigabyte of `String` that doubled its way there. What stays
-/// resident is proportional to record count, not to file size.
+/// The gigabyte of `String` that doubled its way there is gone. What replaces
+/// it is not free, and "proportional to record count" hides how large the
+/// constant is: the entity index measures ~84 bytes a record, so 370 MB on a
+/// 4.4 M-record file and ~1.1 GB on a 16.8 M-record one, before a byte is
+/// written. On a very large model the index outweighs the output it stopped
+/// holding. It is not removable -- source order and the reference closure both
+/// need it.
 ///
-/// [`export_step_with_stats`] is this function writing into a `Vec`, so the two
-/// cannot drift.
+/// `out` is buffered here, so a bare `File` is fine. A record costs two `write`
+/// calls, which unbuffered is two syscalls: measured 15.0 s against 4.3 s on
+/// 4.4 M records. A caller who already buffers pays one memcpy through 1 MiB.
+// The grouped-property-mutation Vec type is explicit by design; aliasing it
+// would hide the (entity, pset) -> [(key, value)] grouping structure.
+#[allow(clippy::type_complexity)]
 pub fn export_step_to_writer<W: std::io::Write>(
     content: &[u8],
     opts: &StepOptions,
     w: &mut W,
 ) -> std::io::Result<StepStats> {
-    emit(content, opts, w)
-}
-
-/// Like [`export_step`] but also returns coverage stats.
-// The grouped-property-mutation Vec type is explicit by design; aliasing it
-// would hide the (entity, pset) -> [(key, value)] grouping structure.
-#[allow(clippy::type_complexity)]
-pub fn export_step_with_stats(content: &[u8], opts: &StepOptions) -> (String, StepStats) {
-    let mut buf = Vec::new();
-    let stats = emit(content, opts, &mut buf).expect("a Vec accepts every write");
-    // Every byte came from the source by way of `from_utf8_lossy`, or from a
-    // `format!`, so this validates rather than converts.
-    let out = String::from_utf8(buf).expect("the writer emits UTF-8");
-    (out, stats)
+    use std::io::Write as _;
+    let mut buffered = std::io::BufWriter::with_capacity(1 << 20, w);
+    let stats = emit(content, opts, &mut buffered)?;
+    // Flushed here: a `BufWriter` dropped unflushed truncates and reports ok.
+    buffered.flush()?;
+    Ok(stats)
 }
 
 #[allow(clippy::type_complexity)]

--- a/rust/export/src/step_header.rs
+++ b/rust/export/src/step_header.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MPL-2.0
+//! The Part 21 header section.
+//!
+//! Its own module because it is its own thing: `HEADER` describes the file --
+//! who wrote it, with what, against which schema -- while `DATA` is the model.
+//! They share only the writer.
+
+use std::io::Write;
+
+use crate::step_text::escape;
+use crate::StepOptions;
+
+/// Write `ISO-10303-21;` through `DATA;`, leaving `out` ready for records.
+///
+/// `schema` is resolved rather than read off `opts`: a `None` there means
+/// "keep the source's", and only the caller has detected what that is.
+pub(crate) fn write_header<W: Write>(
+    out: &mut W,
+    opts: &StepOptions,
+    schema: &str,
+) -> std::io::Result<()> {
+    out.write_all(b"ISO-10303-21;\nHEADER;\n")?;
+    writeln!(out, "FILE_DESCRIPTION(('{}'),'2;1');", escape(&opts.description))?;
+    writeln!(
+        out,
+        "FILE_NAME('','',('{}'),('{}'),'{}','ifc-lite-export','');",
+        escape(&opts.author),
+        escape(&opts.organization),
+        escape(&opts.application),
+    )?;
+    writeln!(out, "FILE_SCHEMA(('{}'));", escape(schema))?;
+    out.write_all(b"ENDSEC;\nDATA;\n")
+}

--- a/rust/export/src/step_tests.rs
+++ b/rust/export/src/step_tests.rs
@@ -882,3 +882,67 @@ fn a_valid_mutations_json_is_still_applied() {
         "propertyMutations from the JSON payload must reach the output too"
     );
 }
+
+/// Streaming and returning produce the same file.
+///
+/// The whole point of `export_step_to_writer` is that a 1 GB model does not have
+/// to exist twice in memory to be written. That is only worth having if the
+/// bytes are the same bytes, so the returned form is defined as the streaming
+/// one writing into a `Vec` and this checks the definition holds through every
+/// branch that writes: header, plain records, copies, and synthesized property
+/// sets.
+#[test]
+fn streaming_and_returning_agree() {
+    let content = br#"ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('g',$,'P',$,$,$,$,$,$);
+#2=IFCWALL('w',$,'W',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+    let opts = StepOptions {
+        description: "d".into(),
+        author: "a".into(),
+        organization: "o".into(),
+        application: "app".into(),
+        property_mutations: vec![PropMutation {
+            express_id: 2,
+            pset_name: "P".into(),
+            prop_name: "k".into(),
+            value: "IFCTEXT('v')".into(),
+        }],
+        ..Default::default()
+    };
+    let (returned, rstats) = export_step_with_stats(content, &opts);
+    let mut streamed = Vec::new();
+    let sstats = export_step_to_writer(content, &opts, &mut streamed).expect("write");
+    assert_eq!(returned.as_bytes(), streamed.as_slice(), "the two forms differ");
+    assert_eq!(rstats.written, sstats.written);
+    assert_eq!(rstats.total, sstats.total);
+    // The property set really was synthesized, so the comparison covered that arm.
+    assert!(returned.contains("IFCPROPERTYSET"), "{returned}");
+}
+
+/// A writer that fails reports the failure instead of losing it.
+#[test]
+fn a_broken_writer_is_an_error() {
+    struct Full;
+    impl std::io::Write for Full {
+        fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(std::io::ErrorKind::StorageFull, "no room"))
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+    let r = export_step_to_writer(
+        b"ISO-10303-21;\nDATA;\nENDSEC;\n",
+        &StepOptions::default(),
+        &mut Full,
+    );
+    let Err(err) = r else { panic!("a full disk is not a successful export") };
+    assert_eq!(err.kind(), std::io::ErrorKind::StorageFull);
+}


### PR DESCRIPTION
## What

Two things the bounded (streaming) GLB assembler and the STEP exporter could not do on a very large model, and now can.

**Repeated shapes are shared on the streaming path.** Above the streaming threshold the assembler gave up on rep-identity instancing, on the grounds that it "needs every occurrence co-resident". The vertex data does. The decision does not: `collate_refs` reads nothing off a mesh's geometry but its length, so what a group needs is an identity and a placement, and those fit in the plan this path already keeps.

**STEP export writes as it goes.** `export_step` builds the whole output in a `String` before returning it, so a 1 GB model holds the source, the index and a gigabyte of output at once, and a `String` reaching a gigabyte reallocates its way there. `export_step_to_writer` emits each record as it is read.

## Measured

A 1.05 GB building-services model, 320,688 elements. Both sides run on the same machine with the same runner, against `origin/main` rather than carried over from an earlier branch state:

| | before | after |
|---|---|---|
| glTF | 1.82 GB | 1.14 GB |
| meshes | 226,506 | 109,236 |
| triangles | 32,273,344 | 19,778,131 |
| peak RSS | 6.02 GB | 5.36 GB |
| wall | 16.20 s | 15.95 s |

Grouping follows `collate_refs` exactly: a rep identity whose occurrences disagree about vertex or index count goes out flat, all of it. Keying the bucket on size instead shares more — on a 342 MB model, 25.0 MB of glTF against 34.5 MB — but the collator's refusal is a safety property rather than an oversight. `rep_identity` is only the RepresentationMap entity id for a mapped item, so two occurrences of one map clipped differently that land on the same counts are a group whose members are not one shape, and sub-bucketing hands one of them the other's geometry. Silently. Both this branch and the review failed to produce a wrong export from it, which is not the same as it being safe.

Worth revisiting with a discriminator that proves two occurrences are one shape. A size match is not that.

f32 output only. A quantized shared mesh carries a non-uniform dequant scale that cannot fold into a rotating placement without breaking `Matrix4.decompose`.

## Proof

Byte-identical bounded GLB output against the pre-review branch tip on three models, and the comparison is not vacuous: on the largest, 39,329 of 42,515 mesh-nodes carry a matrix and 3,425 shapes are shared across 39,521 occurrences, so the instancing path is what was being compared. STEP output byte-identical on the 342 MB / 4.4 M-record file, held against streamed.

An independent per-element comparison of `export_glb_with_stats` against `export_glb_streaming_bounded` — triangle count, world surface area and centroid sum per express id — matched on every element of every file in `tests/models/{ara3d,buildingsmart,issues,local,ifcopenshell}`.

Unbuffered writer cost, measured on the 4.4 M-record file: 15.0 s against 4.3 s end to end. `export_step_to_writer` buffers internally and flushes before returning, so a caller passing a bare `File` does not pay two syscalls a record, and a write that fails on the last buffer is an error rather than a truncated file behind a zero exit.

## Review

Five review passes ran before this was opened, and the last two commits are what they found. The substantive ones:

- The instancing plan was materialised per occurrence rather than per shape: ~87k distinct values stored 151k times, and the template's placement inverted once per occurrence.
- `StreamedMeshMeta.rep` was read only during planning and carried through pass 2 anyway, beside the whole output buffer. It also aligned the struct to 16 for its `u128`, so meshes with no shareable shape paid too. `size_of` 400 to 240, pinned by a test.
- `export_step_to_writer` handed callers the unbuffered footgun above.
- A corrected comment landed on `export_gltf_streaming_impl`, which does neither dedup nor instancing — a new stale doc created while fixing stale docs.
- The node matrix used `?` on a lookup the code above it had already committed to, so a miss would have placed the template's geometry at the occurrence's origin with no rotation.

One suggested fix was rejected with measurements: folding a quantized local bbox into the bucket key. `local_min`/`local_max` are the bbox of geometry already baked to Y-up world-minus-origin, so rotation is in them and every rotated occurrence gets its own bucket. It takes sharing from 3,425 shapes to 17 and the glTF from 25.0 MB to 108.2 MB. It does not harden the feature, it removes it.

## Deferred, named rather than dropped

- `collate_refs` and this path now agree on policy but still hold two copies of the mechanism. Unifying them touches the GPU shard path.
- `included` materialises every id when the caller asked for everything, and `raw.into_owned()` copies a `String` per record on the no-edit path. Measured together at 35% of the STEP emit loop. Both predate this branch.
- `Emitted` carries `matrix` and `(translation, scale)` as separate options where an enum saves 64 bytes a mesh. It mirrors the glTF `Node`, which is genuinely three optionals, so this is a trade rather than a defect.
- `StepStats` has no `#[non_exhaustive]`. Making it so is breaking now, so next semver-major.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added streaming STEP export that writes records incrementally while preserving existing output and reporting statistics.
  - Added bounded GLB instancing for repeated, compatible geometry to reduce file size, mesh and triangle counts, memory usage, and export time.
  - Preserved non-instanced fallbacks for incompatible, quantized, or invalid geometry.
- **Documentation**
  - Added examples and benchmarking utilities for comparing streamed exports and validating GLB output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->