### PR TITLE
test(ids): split the xsd conformance sweep so one case cannot time out the rest

### DIFF
--- a/packages/ids/src/audit/xsd/ids-xsd-conformance.test.ts
+++ b/packages/ids/src/audit/xsd/ids-xsd-conformance.test.ts
@@ -517,13 +517,14 @@ describe('divergence between auditIDSDocument and ids.xsd', () => {
     expect((await auditIDSDocument(control)).issues).toEqual([]);
   });
 
-  it('every divergent document is genuinely rejected by the schema', async () => {
-    for (const [what, xml] of CASES) {
-      expect(
-        (await schemaErrors(xml)).length,
-        `${what} should violate ids.xsd`
-      ).toBeGreaterThan(0);
-    }
+  // One `it` per case rather than one loop over all of them. Two reasons, and
+  // the second is why this changed: a failure now names the document instead of
+  // reporting only that the sweep ran out of time, and each case gets its own
+  // budget. As a single `it` this did N xmllint-wasm parse-and-validate passes
+  // against vitest's default 5000 ms, which is fine unloaded and timed out
+  // twice on CI (#3110), blocking PRs that touch nothing in this package.
+  it.each(CASES)('%s is genuinely rejected by the schema', async (what, xml) => {
+    expect((await schemaErrors(xml)).length, `${what} should violate ids.xsd`).toBeGreaterThan(0);
   });
 
   it('the set the audit still misses is exactly the known list', async () => {
@@ -535,5 +536,14 @@ describe('divergence between auditIDSDocument and ids.xsd', () => {
     // Shrinking this list is the point. If a fix lands, this goes red and the
     // corresponding entry must be deleted from KNOWN_AUDIT_GAPS.
     expect(missed.sort()).toEqual([...KNOWN_AUDIT_GAPS]);
+    // Left whole, and left on the default budget. It never touches xmllint --
+    // `auditIDSDocument` is the pure-TS reimplementation -- so all six cases
+    // together measure ~3 ms. #3110 described this as a second xmllint loop;
+    // that was wrong, and only the loop above ever flaked.
+    //
+    // It COULD be split (per-case `issues.length === 0` matched against
+    // KNOWN_AUDIT_GAPS, plus a check that every gap entry is a real case name),
+    // but there is nothing to buy: the exact-set assertion is the point, and
+    // a 3 ms test does not need its own budget.
   });
 });


### PR DESCRIPTION
Closes #3110.

`ids-xsd-conformance.test.ts` timed out at 5000 ms on CI **twice today**, blocking #3081 and #2973 — neither of which touches `packages/ids`. `main` was green both times, so it is the budget, not a regression.

## What flaked

Six `xmllint-wasm` parse-and-validate passes inside **one** `it`, against vitest's default 5000 ms. That is a WebAssembly libxml2 pass per case, not a fixed small cost, and the whole workspace runs alongside it.

Now one `it` per case. Each gets its own budget, and a failure names the document instead of reporting only that the sweep ran out of time.

## Measured, not guessed

```
each of the 6 split xmllint cases   ~24 ms
the whole audit sweep (loop 2)        3 ms
control document, both paths         27 ms
334-file corpus batch                48 ms
```

Each split case is the same shape as the 19 pre-existing one-pass-per-`it` tests in the first describe block, which have never flaked. The per-case default carries roughly 200x headroom — an empirical argument rather than a hopeful one.

## What I got wrong first, since it is on the issue too

My first version gave the second loop a 60 s constant, justified by "one xmllint pass per case". **That loop never touches xmllint** — it calls `auditIDSDocument`, the pure-TS reimplementation, and all six cases together measure 3 ms. #3110's own text described it as a second xmllint loop and I built on that without checking.

A comment asserting a cost the code does not have is worse than no comment: the next person lands a genuinely slow test here, reads it, and copies a cost model the code refutes. The constant is gone and both comments now state the measured cost. Issue corrected as well.

## Not done deliberately

Raising the package's global `testTimeout`. It would hide this and every future slow thing in `packages/ids` behind one number nobody revisits.

The suite itself is unchanged and good — validating against buildingSMART's own schemas is an oracle independent of our reader and writer, which is exactly what `parse(write(x)) === x` cannot be.

Verified at the gate scope CI uses: `typecheck-tests: packages/ids OK (19 test files)`, and the `vitest-timeout-audit` gate parses the new `it.each` shape cleanly.