### PR TITLE
fix(export,lists,viewer): numeric CSV cells export as numbers

### DIFF
--- a/.changeset/csv-numeric-cells-export-as-numbers.md
+++ b/.changeset/csv-numeric-cells-export-as-numbers.md
@@ -1,0 +1,66 @@
+---
+"@ifc-lite/encoding": minor
+"@ifc-lite/export": minor
+"@ifc-lite/lists": patch
+"@ifc-lite/viewer": patch
+"@ifc-lite/sdk": patch
+"@ifc-lite/cli": patch
+"@ifc-lite/mcp": patch
+---
+
+CSV: numeric cells export as numbers. **The formula guard's default changed.**
+Pass `exemptNumbers: false` to `escapeCsvCell` / `guardSpreadsheetFormula` to
+keep the old behaviour.
+
+**Read this first if you consume `@ifc-lite/export`.** The CWE-1236 guard
+prefixes a leading `=`, `+`, `-`, `@`, TAB or CR with `'` so a spreadsheet reads
+the cell as text. It now makes one exception by default: a cell that is *wholly*
+a signed number is left alone. Nothing in your code has to change for the
+behaviour to change, which is why this is called out here rather than in a
+footnote.
+
+The exception cannot weaken the guard. The exempted language contains only
+`+ - . e E` and the digits `0-9`, which cannot spell a function name, a cell
+reference or a `(`. `=`, `@`, TAB and CR are never exempted, `-0.35=cmd` is not
+wholly a number and stays guarded, and a leading invisible character defeats the
+exemption rather than the guard, so `<ZWSP>-1` is still prefixed.
+
+**What it costs.** The exemption looks at the value, not the column, so a
+numeric-looking *identifier* held as text is now written as a number: a
+`+`-prefixed phone number becomes `4.1791E+10` in Excel with the `+` gone, and
+`-007` becomes `-7`. Those were previously preserved exactly, as `'`-prefixed
+text. If a writer needs that, pass `exemptNumbers: false`.
+
+**Why the exception exists.** `@ifc-lite/lists` had exempted numbers since #1772
+("`-0.35` exported as `'-0.35` and broke Excel SUM()") while every other writer
+guarded them, so the same list exported two ways did not match. The policy is
+now one default rather than eleven call-site decisions that drift.
+
+**The viewer's Lists CSV stopped formatting numbers before writing them.** It
+ran every value through the display formatter, which calls `toLocaleString()` on
+integers. Under en-US that wrote `"-1,000"`, quoted because of the comma, so the
+column stopped summing. Under a locale that groups with `.` it wrote a bare
+`-3.000`, which a spreadsheet in a `,`-grouping locale reads back as **-3**, a
+silent 1000x error in a quantity column. Exempting numbers fixes neither, since
+neither string is wholly numeric in the locale that produced it. CSV is
+machine-readable output, so it now writes the number, matching what the XLSX
+writer always did. PDF, which a human reads, is unchanged.
+
+Two consequences of that, both deliberate. Unit-converted values now show their
+full double precision (3 ft in metres is `0.9144000000000001`, not `0.9144`),
+which is the same value the XLSX export already carried, so the two agree. And grouping a
+list by a numeric column used to hard-code that column as non-numeric in the
+schedule/pivot export, where the grouping value is the *only* place the value
+appears; it wrote `"'-3,000"` and nothing else for -3000. Schedule grouping
+columns now inherit `numeric` and carry the raw value, falling back to the group
+label where a bucket holds values that merely format alike.
+
+**The numeric test no longer backtracks.** It was
+`/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/`, quadratic on a failing match and
+reached only after a trigger matched, so `-` plus 60k digits took ~1.8s. IFC
+property text is attacker-controllable, which made that a denial of service on
+an export. It is a linear scan now, and lives in `@ifc-lite/encoding` (no
+dependencies, already depended on by both callers) as the new `isWhollyNumeric`
+export, so there is one copy per language rather than one per package. The
+accepted language is unchanged, checked by sweeping every string up to four
+characters over the alphabet it is built from against the old regex.

--- a/.changeset/csv-numeric-cells-export-as-numbers.md
+++ b/.changeset/csv-numeric-cells-export-as-numbers.md
@@ -25,11 +25,19 @@ reference or a `(`. `=`, `@`, TAB and CR are never exempted, `-0.35=cmd` is not
 wholly a number and stays guarded, and a leading invisible character defeats the
 exemption rather than the guard, so `<ZWSP>-1` is still prefixed.
 
-**What it costs.** The exemption looks at the value, not the column, so a
-numeric-looking *identifier* held as text is now written as a number: a
-`+`-prefixed phone number becomes `4.1791E+10` in Excel with the `+` gone, and
-`-007` becomes `-7`. Those were previously preserved exactly, as `'`-prefixed
-text. If a writer needs that, pass `exemptNumbers: false`.
+**What it costs.** The default has to guess from the text, because most callers
+hand it a bare string, and guessing gets identifiers wrong: a `+`-prefixed phone
+number is wholly numeric as text, so it is written bare and Excel renders
+`4.1791E+10` with the `+` gone. `-007` becomes `-7`. Both were previously kept
+exactly, as `'`-prefixed text.
+
+The viewer's Lists CSV does not guess, because it has the value itself: it
+exempts a cell when the value really is a number and guards it otherwise, so a
+phone number stays text there and a measure stays summable even in a column that
+also holds text. So this cost applies to the writers that only ever see strings,
+which is the CLI, the SDK, MCP, the compare report, search results, zone tables
+and `@ifc-lite/lists`' own CSV. Pass `exemptNumbers: false` to opt any of them
+out.
 
 **Why the exception exists.** `@ifc-lite/lists` had exempted numbers since #1772
 ("`-0.35` exported as `'-0.35` and broke Excel SUM()") while every other writer

--- a/apps/viewer/src/lib/lists/export/csv.test.ts
+++ b/apps/viewer/src/lib/lists/export/csv.test.ts
@@ -147,18 +147,45 @@ describe('toCsv numeric columns round-trip as numbers', () => {
     }
   });
 
-  it('a numeric-looking STRING cell is exempt, one that only looks numeric is not', () => {
-    // Same policy, applied to a text column: the exemption is about the value,
-    // not about which column it sits in.
+  it('a real number in a MIXED column is still summable', () => {
+    // `detectNumericColumns` marks a whole column as text if one sampled value
+    // is a string, which mixed IFC properties routinely are. Keying the
+    // exemption off the COLUMN re-created #1772 here: every genuine number in
+    // the column, and the grand total with them, shipped as `'-3.35` text.
+    const rows: ListRow[] = [
+      { entityId: 1, modelId: 'm', values: ['P01', 'W1', -3] },
+      { entityId: 2, modelId: 'm', values: ['P01', 'W2', 'n/a'] },
+      { entityId: 3, modelId: 'm', values: ['P01', 'W3', -0.35] },
+      { entityId: 4, modelId: 'm', values: ['P01', 'W4', '+41791234567'] },
+    ];
+    const csv = toCsv(buildExportModel({
+      ...numBase, rows,
+      numericCols: [false, false, false], // the mixed column reads as text
+      grouping: { columnId: '', sumColumnIds: ['area'] },
+    }));
+    const lines = csv.split('\r\n');
+    assert.strictEqual(lines[1], 'P01,W1,-3');
+    assert.strictEqual(lines[3], 'P01,W3,-0.35');
+    // A string that merely looks numeric is still text.
+    assert.strictEqual(lines[4], "P01,W4,'+41791234567");
+    // The grand total is the assertion that matters: text here breaks SUM().
+    assert.strictEqual(lines[5], 'TOTAL (4),,-3.35');
+  });
+
+  it('a numeric-looking STRING cell stays text', () => {
+    // The exemption is type-aware here: this writer knows the column is not
+    // numeric, so `-1` is an identifier, not a measure. A phone number
+    // (`+41791234567`) is the case that matters -- exempting it would let a
+    // spreadsheet render 4.1791E+10 and drop the `+`.
     const rows: ListRow[] = [
       { entityId: 1, modelId: 'm', values: ['P01', '-1', 1] },
-      { entityId: 2, modelId: 'm', values: ['P01', '-1,000', 2] },
+      { entityId: 2, modelId: 'm', values: ['P01', '+41791234567', 2] },
       { entityId: 3, modelId: 'm', values: ['P01', '=cmd()', 3] },
     ];
     const csv = toCsv(buildExportModel({ ...numBase, rows, grouping: { columnId: '', sumColumnIds: [] } }));
     const lines = csv.split('\r\n');
-    assert.strictEqual(lines[1], 'P01,-1,1');
-    assert.strictEqual(lines[2], 'P01,"\'-1,000",2');
+    assert.strictEqual(lines[1], "P01,'-1,1");
+    assert.strictEqual(lines[2], "P01,'+41791234567,2");
     assert.strictEqual(lines[3], "P01,'=cmd(),3");
   });
 });

--- a/apps/viewer/src/lib/lists/export/csv.test.ts
+++ b/apps/viewer/src/lib/lists/export/csv.test.ts
@@ -89,3 +89,161 @@ describe('toCsv schedule (pivot) arrangement (#1790 round 2)', () => {
     assert.strictEqual(csv.split('\r\n').length, 1 + 3);
   });
 });
+
+// CSV is machine-readable output. Every assertion here is on the CSV TEXT
+// produced by the real `buildExportModel` -> `toCsv` path, because the defects
+// it pins were both invisible to a unit test of the escaper: the escaper was
+// correct and `displayCell` was correct, and routing one through the other is
+// what produced a number a spreadsheet could not read back.
+describe('toCsv numeric columns round-trip as numbers', () => {
+  const numCols: ColumnDefinition[] = [
+    { id: 'building', source: 'spatial', propertyName: 'Building' },
+    { id: 'type', source: 'attribute', propertyName: 'Class' },
+    { id: 'area', source: 'quantity', propertyName: 'Area' },
+  ];
+  // Every value is chosen to EXCEED the thing being tested, not to sit on it:
+  // |x| >= 1000 so a display formatter inserts a grouping separator, and the
+  // sign so the formula guard has a trigger to fire on.
+  const numRows: ListRow[] = ([
+    ['P01', 'IfcWall', -3000],
+    ['P01', 'IfcWall', -0.35],
+    ['P02', 'IfcDoor', 1234567],
+    ['P02', 'IfcDoor', 0.35],
+  ] as [string, string, number][]).map(([b, t, a], i) => ({
+    entityId: i + 1, modelId: 'm', values: [b, t, a],
+  }));
+  const numBase = {
+    title: 'Numbers',
+    columns: numCols,
+    rows: numRows,
+    numericCols: [false, false, true],
+    columnWidths: [120, 120, 120],
+    generatedAt: 'now',
+  };
+
+  it('emits the raw number, never the display-formatted one', () => {
+    const csv = toCsv(buildExportModel({ ...numBase, grouping: { columnId: '', sumColumnIds: ['area'] } }));
+    assert.deepStrictEqual(csv.split('\r\n'), [
+      'Building,Class,Area',
+      'P01,IfcWall,-3000',
+      'P01,IfcWall,-0.35',
+      'P02,IfcDoor,1234567',
+      'P02,IfcDoor,0.35',
+      'TOTAL (4),,1231567',
+    ]);
+  });
+
+  it('no numeric cell is quoted or apostrophe-prefixed', () => {
+    // The two failure modes, stated as the damage rather than the mechanism: a
+    // quoted cell stops the column summing, an apostrophe makes it text. Under
+    // a `.`-grouping locale the old path emitted neither -- it emitted a BARE
+    // `-3.000`, which a `,`-grouping spreadsheet reads back as -3.
+    const csv = toCsv(buildExportModel({ ...numBase, grouping: { columnId: '', sumColumnIds: ['area'] } }));
+    for (const line of csv.split('\r\n').slice(1)) {
+      const areaCell = line.split(',').at(-1) ?? '';
+      assert.ok(!areaCell.includes('"'), `area cell was quoted: ${areaCell}`);
+      assert.ok(!areaCell.startsWith("'"), `area cell was prefixed: ${areaCell}`);
+      assert.strictEqual(areaCell, String(Number(areaCell)), `area cell is not a bare number: ${areaCell}`);
+    }
+  });
+
+  it('a numeric-looking STRING cell is exempt, one that only looks numeric is not', () => {
+    // Same policy, applied to a text column: the exemption is about the value,
+    // not about which column it sits in.
+    const rows: ListRow[] = [
+      { entityId: 1, modelId: 'm', values: ['P01', '-1', 1] },
+      { entityId: 2, modelId: 'm', values: ['P01', '-1,000', 2] },
+      { entityId: 3, modelId: 'm', values: ['P01', '=cmd()', 3] },
+    ];
+    const csv = toCsv(buildExportModel({ ...numBase, rows, grouping: { columnId: '', sumColumnIds: [] } }));
+    const lines = csv.split('\r\n');
+    assert.strictEqual(lines[1], 'P01,-1,1');
+    assert.strictEqual(lines[2], 'P01,"\'-1,000",2');
+    assert.strictEqual(lines[3], "P01,'=cmd(),3");
+  });
+});
+
+// GROUPED exports, which every test above was blind to: they all built an
+// ungrouped model, so `c.numeric` reached the writer intact. Grouping routes
+// the value through `buildNestedGroupBuckets`, which formats labels with
+// `displayCell` on the way in, and the schedule presentation used to hard-code
+// `numeric: false` on its grouping columns on the way out.
+describe('toCsv keeps a numeric GROUPING column numeric', () => {
+  const cols: ColumnDefinition[] = [
+    { id: 'lvl', source: 'spatial', propertyName: 'Level' },
+    { id: 'area', source: 'quantity', propertyName: 'Area' },
+  ];
+  // -3000 exceeds the grouping-separator threshold in both directions: en-US
+  // renders it "-3,000" (quoted, so the column stops summing) and de-DE renders
+  // it "-3.000" (bare, so an en-US reader gets -3). Neither is the number.
+  const rows: ListRow[] = [
+    { entityId: 1, modelId: 'm', values: [-3000, 1] },
+    { entityId: 2, modelId: 'm', values: [-3000, 2] },
+  ];
+  const base = {
+    title: 'T', columns: cols, rows, numericCols: [true, true],
+    columnWidths: [90, 90], generatedAt: 'now',
+  };
+
+  it('the schedule pivot writes the group value as a number', () => {
+    // This is the ONLY place the grouping value appears in this presentation,
+    // so getting it wrong loses the value rather than merely duplicating it.
+    const csv = toCsv(buildExportModel({
+      ...base,
+      grouping: { columnId: 'lvl', columnIds: ['lvl'], sumColumnIds: ['area'], view: 'schedule' },
+    }));
+    assert.deepStrictEqual(csv.split('\r\n'), ['Level,Count,Area', '-3000,2,3', 'TOTAL (2),2,3']);
+  });
+
+  it('a TEXT grouping column carrying a formula is still guarded', () => {
+    // The control: inheriting `numeric` from the source column must not hand a
+    // payload through as if it were data.
+    const csv = toCsv(buildExportModel({
+      title: 'T', columns: cols,
+      rows: [{ entityId: 1, modelId: 'm', values: ['=cmd()', 1] }],
+      numericCols: [false, true], columnWidths: [90, 90], generatedAt: 'now',
+      grouping: { columnId: 'lvl', columnIds: ['lvl'], sumColumnIds: ['area'], view: 'schedule' },
+    }));
+    assert.strictEqual(csv.split('\r\n')[1], "'=cmd(),1,1");
+  });
+
+  it('falls back to the label when one bucket holds DIFFERENT raw values', () => {
+    // Buckets are keyed by the formatted label, so 12.345671 and 12.345679 --
+    // distinct numbers that both render "12.3457" -- are one group. Emitting
+    // either raw value would put a number in the file that only half the
+    // members have.
+    const csv = toCsv(buildExportModel({
+      ...base,
+      rows: [
+        { entityId: 1, modelId: 'm', values: [12.345671, 1] },
+        { entityId: 2, modelId: 'm', values: [12.345679, 2] },
+      ],
+      grouping: { columnId: 'lvl', columnIds: ['lvl'], sumColumnIds: ['area'], view: 'schedule' },
+    }));
+    assert.strictEqual(csv.split('\r\n')[1], '12.3457,2,3');
+  });
+
+  it('an EMPTY grouping cell still exports as the "(none)" bucket, not a blank', () => {
+    // Carrying raw values must not lose the bucketing vocabulary: a blank cell
+    // is indistinguishable from a missing one, and `(none)` is what the table
+    // view and every earlier export called it.
+    const csv = toCsv(buildExportModel({
+      ...base,
+      rows: [{ entityId: 1, modelId: 'm', values: [null, 5] }],
+      grouping: { columnId: 'lvl', columnIds: ['lvl'], sumColumnIds: ['area'], view: 'schedule' },
+    }));
+    assert.strictEqual(csv.split('\r\n')[1], '(none),1,5');
+  });
+
+  it('the section form carries the value in its own column, unformatted', () => {
+    // The leading "Group" cell is a human path label (values joined with " / ")
+    // and stays display-formatted on purpose. That loses nothing: the grouping
+    // column is ALSO emitted as itself, and that copy must be the number.
+    const csv = toCsv(buildExportModel({
+      ...base,
+      grouping: { columnId: 'lvl', columnIds: ['lvl'], sumColumnIds: ['area'] },
+    }));
+    const first = csv.split('\r\n')[1];
+    assert.ok(first.endsWith(',-3000,1'), `Level column was not the raw number: ${first}`);
+  });
+});

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -6,11 +6,24 @@ import { escapeCsvCell } from '@ifc-lite/export';
 import type { CellValue } from '@ifc-lite/lists';
 import { displayCell, type ExportColumn, type ExportModel } from './model';
 
-/** CWE-1236 formula guard + RFC 4180 quoting, delegated to `@ifc-lite/export`'s
- *  single escaper. No options: the numeric exemption is the shared default, so
- *  this writer cannot drift away from the other ten. */
-function esc(s: string, delim: string): string {
-  return escapeCsvCell(s, { delimiter: delim });
+/**
+ * CWE-1236 formula guard + RFC 4180 quoting, delegated to `@ifc-lite/export`'s
+ * single escaper.
+ *
+ * `exemptNumbers` is passed EXPLICITLY here, against the shared default, and
+ * this is the one writer entitled to do that: it knows each column's type, so
+ * it does not have to guess from the text. The shared default has to guess,
+ * because most callers hand it a bare string.
+ *
+ * Guessing gets identifiers wrong. `+41791234567` is an `IfcTelecomAddress`
+ * phone number and `-007` is a zero-padded code; both are wholly numeric as
+ * TEXT, so a value-shape test exempts them and a spreadsheet then reads the
+ * first as 4.1791E+10 with the `+` gone. Passing `false` for text keeps them
+ * exactly as written. The numeric path opts back in below, where the value
+ * really is a number.
+ */
+function esc(s: string, delim: string, exemptNumbers = false): string {
+  return escapeCsvCell(s, { delimiter: delim, exemptNumbers });
 }
 
 /**
@@ -30,8 +43,23 @@ function esc(s: string, delim: string): string {
  * test (`1e+21` included), so this path is never prefixed either.
  */
 function cell(v: CellValue, c: ExportColumn, delim: string): string {
-  if (c.numeric && typeof v === 'number' && Number.isFinite(v)) return esc(String(v), delim);
-  return esc(displayCell(v), delim);
+  // TWO decisions, and they are not the same one.
+  //
+  // Whether to FORMAT is a property of the column: only a numeric column skips
+  // the display formatter, because only there is every value a measure.
+  //
+  // Whether to EXEMPT is a property of the value. A real number is a number
+  // wherever it sits, and `detectNumericColumns` marks a whole column as text
+  // if even one sampled value is a string -- which mixed IFC properties are,
+  // routinely. Gating the exemption on the column re-created #1772 in exactly
+  // that case: a summed mixed column exported its grand total as `'-3.35`.
+  const isNumber = typeof v === 'number' && Number.isFinite(v);
+  // `String(v)` on a finite number is always wholly numeric, `1e+21` included.
+  if (c.numeric && isNumber) return esc(String(v), delim, true);
+  // A number in a text column still goes through the formatter, so `-3000`
+  // becomes `-3,000`, which is not wholly numeric and stays guarded either way.
+  // Small values survive it intact and are exempt, as they were before.
+  return esc(displayCell(v), delim, isNumber);
 }
 
 /**

--- a/apps/viewer/src/lib/lists/export/csv.ts
+++ b/apps/viewer/src/lib/lists/export/csv.ts
@@ -4,14 +4,34 @@
 
 import { escapeCsvCell } from '@ifc-lite/export';
 import type { CellValue } from '@ifc-lite/lists';
-import { displayCell, type ExportModel } from './model';
+import { displayCell, type ExportColumn, type ExportModel } from './model';
 
 /** CWE-1236 formula guard + RFC 4180 quoting, delegated to `@ifc-lite/export`'s
- *  single escaper. `exemptNumbers` is left at its default `false`, which is
- *  what `neutralizeSpreadsheetFormula` did here before and what
- *  `injection.test.ts` pins (see the policy note in `model.ts`). */
+ *  single escaper. No options: the numeric exemption is the shared default, so
+ *  this writer cannot drift away from the other ten. */
 function esc(s: string, delim: string): string {
   return escapeCsvCell(s, { delimiter: delim });
+}
+
+/**
+ * CSV is machine-readable output, so a numeric column emits the NUMBER, the
+ * same contract `xlsx.ts` already keeps (`cellValue`) and the opposite of
+ * `pdf.ts`, which is for a human to read.
+ *
+ * `displayCell` is a DISPLAY formatter: it runs `toLocaleString()` on integers.
+ * Routing numbers through it wrote `-1,000` into a CSV under en-US (a quoted
+ * string, so the column stops summing) and `-3.000` under de-DE (bare, so a
+ * spreadsheet in a `,`-grouping locale reads it back as -3 — a silent 1000x
+ * error in a quantity column). Exempting numbers from the formula guard does
+ * not fix either one, because neither string is wholly numeric to the guard in
+ * the locale that produced it. Not formatting is what fixes it.
+ *
+ * `String(v)` on a finite number is always accepted by the guard's numeric
+ * test (`1e+21` included), so this path is never prefixed either.
+ */
+function cell(v: CellValue, c: ExportColumn, delim: string): string {
+  if (c.numeric && typeof v === 'number' && Number.isFinite(v)) return esc(String(v), delim);
+  return esc(displayCell(v), delim);
 }
 
 /**
@@ -32,14 +52,14 @@ export function toCsv(model: ExportModel, delimiter = ','): string {
     const cols = model.schedule.columns;
     const lines = [cols.map((c) => esc(c.label, delimiter)).join(delimiter)];
     for (const row of model.schedule.rows) {
-      lines.push(cols.map((_, i) => esc(displayCell(row[i]), delimiter)).join(delimiter));
+      lines.push(cols.map((c, i) => cell(row[i], c, delimiter)).join(delimiter));
     }
     if (model.sumColumnIds.length > 0) {
       const totalLabel = `TOTAL (${model.totals.count})`;
       lines.push(cols.map((c, i) => {
         if (i === 0) return esc(totalLabel, delimiter);
-        if (c.id === '__count') return esc(displayCell(model.totals.count), delimiter);
-        if (c.summed) return esc(displayCell(model.totals.sums[c.id]), delimiter);
+        if (c.id === '__count') return cell(model.totals.count, c, delimiter);
+        if (c.summed) return cell(model.totals.sums[c.id], c, delimiter);
         return '';
       }).join(delimiter));
     }
@@ -52,7 +72,7 @@ export function toCsv(model: ExportModel, delimiter = ','): string {
 
   const line = (groupLabel: string | null, values: CellValue[]) => {
     const cells = grouped ? [esc(groupLabel ?? '', delimiter)] : [];
-    for (let i = 0; i < model.columns.length; i++) cells.push(esc(displayCell(values[i]), delimiter));
+    for (let i = 0; i < model.columns.length; i++) cells.push(cell(values[i], model.columns[i], delimiter));
     return cells.join(delimiter);
   };
 
@@ -68,7 +88,7 @@ export function toCsv(model: ExportModel, delimiter = ','): string {
     const cells = grouped ? [esc(totalLabel, delimiter)] : [];
     for (let i = 0; i < model.columns.length; i++) {
       const c = model.columns[i];
-      if (c.summed) cells.push(esc(displayCell(model.totals.sums[c.id]), delimiter));
+      if (c.summed) cells.push(cell(model.totals.sums[c.id], c, delimiter));
       else if (!grouped && i === 0) cells.push(esc(totalLabel, delimiter));
       else cells.push('');
     }

--- a/apps/viewer/src/lib/lists/export/injection.test.ts
+++ b/apps/viewer/src/lib/lists/export/injection.test.ts
@@ -87,7 +87,9 @@ describe('neutralizeSpreadsheetFormula — parity with the sibling guards', () =
 
 describe('neutralizeSpreadsheetFormula (#1790 review, CWE-1236)', () => {
   it('prefixes an apostrophe to every formula-trigger lead char', () => {
-    for (const s of ['=1+1', '+1', '-1', '@SUM(A1)', '\tx', '\rx']) {
+    // `+1` / `-1` are NOT here: they are wholly numeric and exempt since the
+    // #1772 policy was applied to this call site too. See the split below.
+    for (const s of ['=1+1', '@SUM(A1)', '\tx', '\rx', '=1', '@1']) {
       assert.strictEqual(neutralizeSpreadsheetFormula(s), `'${s}`);
     }
   });
@@ -95,6 +97,24 @@ describe('neutralizeSpreadsheetFormula (#1790 review, CWE-1236)', () => {
     for (const s of ['Building A', 'A Level 0', 'IfcWall', '3.14', '']) {
       assert.strictEqual(neutralizeSpreadsheetFormula(s), s);
     }
+  });
+
+  // What is unique to THIS call site is that it passes NO options, so it takes
+  // the shared guard's default. The accepted language itself is pinned once, in
+  // `packages/encoding/src/numeric-literal.test.ts`; restating it here would be
+  // a third copy of a table that is already exhaustively swept.
+  it('takes the shared default: a wholly-numeric cell is not guarded', () => {
+    assert.strictEqual(neutralizeSpreadsheetFormula('-0.35'), '-0.35');
+    assert.strictEqual(neutralizeSpreadsheetFormula('+1'), '+1');
+  });
+  it('and a number with a payload glued on still is', () => {
+    assert.strictEqual(neutralizeSpreadsheetFormula('-0.35=cmd'), "'-0.35=cmd");
+  });
+  it('an invisible in front of a number defeats the exemption, not the guard', () => {
+    // The trigger scan looks PAST a leading invisible run; the numeric test does
+    // not, so `\u200b-1` is triggered and not exempt. Failing closed is right.
+    assert.strictEqual(neutralizeSpreadsheetFormula('\u200b-1'), "'\u200b-1");
+    assert.strictEqual(neutralizeSpreadsheetFormula('   -1'), "'   -1");
   });
   it('guards a BOM-hidden marker without consuming the BOM', () => {
     // Was `'=evil` — i.e. the BOM deleted. The guard now looks past it instead,

--- a/apps/viewer/src/lib/lists/export/model.ts
+++ b/apps/viewer/src/lib/lists/export/model.ts
@@ -125,7 +125,9 @@ export function displayCell(value: CellValue): string {
  * marker hidden behind one still executes, while an anchored regex stops
  * matching. They are looked past, not removed — see `guardSpreadsheetFormula`.
  *
- * Shared by the CSV and XLSX writers so both honour the guideline identically.
+ * Used by the XLSX writer for its string cells. The CSV writer calls
+ * `escapeCsvCell` directly instead, because it also needs RFC 4180 quoting;
+ * both reach the same guard in `@ifc-lite/export`.
  */
 export function neutralizeSpreadsheetFormula(s: string): string {
   // Delegates to `@ifc-lite/export`'s single guard. The copy that used to live
@@ -135,20 +137,13 @@ export function neutralizeSpreadsheetFormula(s: string): string {
   // part of a field and should not be ignored"). The shared guard looks *past*
   // the run instead of removing it — same payloads guarded, data intact.
   //
-  // NOTE a deliberate, unresolved divergence from `packages/lists/src/engine.ts`:
-  // that copy EXEMPTS a genuine number from the `-`/`+` trigger (#1772, comment:
-  // "`-0.35` exported as `'-0.35` and broke Excel SUM()"), whereas this call
-  // site guards it -- and `injection.test.ts` pins `'+1'` as guarded on purpose.
-  // So the viewer's Lists CSV ships every negative measure as text while the
-  // library's does not. Both behaviours are deliberately tested, so they cannot
-  // both be right; picking one is a product decision (broken SUM() vs a cell
-  // that a spreadsheet could re-read as a formula) and is a maintainer call.
-  //
-  // What changed is only the MECHANISM: the policy is now an argument to one
-  // shared guard (`exemptNumbers`) rather than a reason to keep two
-  // implementations of it. Passing `false` here preserves this call site's
-  // behaviour exactly.
-  return guardSpreadsheetFormula(s, { exemptNumbers: false });
+  // No options: the numeric exemption is the shared guard's DEFAULT, which is
+  // how the repo stopped disagreeing with itself. `packages/lists/src/engine.ts`
+  // has exempted genuine numbers since #1772 ("`-0.35` exported as `'-0.35` and
+  // broke Excel SUM()"); this call site guarded them, so the same list exported
+  // from the viewer and from the library did not match.
+
+  return guardSpreadsheetFormula(s);
 }
 
 export function buildExportModel(input: BuildModelInput): ExportModel {
@@ -238,14 +233,50 @@ export function buildExportModel(input: BuildModelInput): ExportModel {
       const scheduleCols: ExportColumn[] = [
         ...groupColumnIds.map((id) => {
           const i = columns.findIndex((c) => c.id === id);
-          return { id, label: exportCols[i]?.label ?? id, numeric: false, summed: false, width: exportCols[i]?.width ?? 120 };
+          // `numeric` is INHERITED from the source column, not hard-coded false.
+          // In this presentation the grouping value is a data cell -- it is the
+          // only place the value appears -- so a numeric grouping column has to
+          // reach the writers as numeric or they format it for a human.
+          return {
+            id,
+            label: exportCols[i]?.label ?? id,
+            numeric: exportCols[i]?.numeric ?? false,
+            summed: false,
+            width: exportCols[i]?.width ?? 120,
+          };
         }),
         { id: '__count', label: 'Count', numeric: true, summed: false, width: 80 },
         ...sumIdx.map((s) => exportCols[s.idx]),
       ];
+      // RAW group values, not `g.path`. `path` is built by the shared bucketing
+      // helper from `displayCell`, so it is already locale-formatted text by the
+      // time it gets here: grouping by a quantity wrote `"'-3,000"` as the sole
+      // rendering of -3000, and under a `.`-grouping locale a bare `-3.000` that
+      // a `,`-grouping spreadsheet reads back as -3. Every row in a leaf group
+      // shares the grouping cell by construction, so the first row carries it.
+      const rawGroupValues = (g: (typeof nested)[number]): CellValue[] =>
+        levelIndices.map((idx, level) => {
+          // The bucket's LABEL is true of every member by construction; a raw
+          // value is only true of the members that share it. Prefer the raw
+          // value, fall back to the label whenever it would not be.
+          const label = g.path[level] ?? null;
+          if (idx < 0) return label;
+          const first = g.rows[0]?.values[idx] ?? null;
+          // An empty grouping cell is bucketed under the literal label
+          // `(none)`, and `-1` above means "no column at this level" -- the
+          // same bucket. Writing a blank instead would be indistinguishable
+          // from a missing value.
+          if (first === null || first === undefined || first === '') return label;
+          // `buildGroupBuckets` keys buckets by the FORMATTED label, so two
+          // distinct raw values that format alike land in ONE bucket (12.345671
+          // and 12.345679 both render "12.3457"). Emitting row 0's value would
+          // assert a number only one member actually has.
+          if (g.rows.some((r) => r.values[idx] !== first)) return label;
+          return first;
+        });
       const scheduleRows: CellValue[][] = nested
         .filter((g) => g.level === leafLevel)
-        .map((g) => [...g.path, g.count, ...sumIdx.map((s) => g.sums[s.id])]);
+        .map((g) => [...rawGroupValues(g), g.count, ...sumIdx.map((s) => g.sums[s.id])]);
       schedule = { columns: scheduleCols, rows: scheduleRows };
     }
   }

--- a/apps/viewer/src/lib/search/result-export.test.ts
+++ b/apps/viewer/src/lib/search/result-export.test.ts
@@ -151,6 +151,20 @@ describe('__internal helpers', () => {
     assert.strictEqual(__internal.escapeCsvCell('Wall A'), 'Wall A');
   });
 
+  it('exports a signed number as a number, not as text', () => {
+    // This writer sets no options, so it takes the shared guard's DEFAULT.
+    // Until that default flipped, every negative value here shipped as
+    // `'-0.35` and the column stopped summing in a spreadsheet (#1772).
+    // Pinned at a CALL SITE, not only in the library: six writers take this
+    // default and not one of them could see it change.
+    assert.strictEqual(__internal.escapeCsvCell('-0.35'), '-0.35');
+    assert.strictEqual(__internal.escapeCsvCell('+1'), '+1');
+    // The exemption is for numbers, not for the sign: anything glued on is
+    // still a formula as far as the guard is concerned.
+    assert.strictEqual(__internal.escapeCsvCell('-0.35=cmd'), "'-0.35=cmd");
+    assert.strictEqual(__internal.escapeCsvCell('@1'), "'@1");
+  });
+
   // Filename sanitisation now lives in lib/export/download.ts (sanitizeFilename),
   // which preserves case and dots — see download.test.ts. downloadResult() routes
   // its stem through it, so there is no module-local helper to test here anymore.

--- a/docs/guide/extension-authoring.md
+++ b/docs/guide/extension-authoring.md
@@ -124,6 +124,11 @@ Excel, Sheets and LibreOffice otherwise treat as a live formula (CWE-1236). A
 model can carry those characters in any text property, so a hand-built CSV
 exports them straight into a spreadsheet as executable content.
 
+A cell that is wholly a number (`-0.35`, `+1`) is deliberately left unescaped,
+so exported measures still sum. It cannot carry a formula: the only characters
+it may contain are `+ - . e E` and the digits, which spell no function name and
+no cell reference. `-0.35=cmd` is not wholly a number and is still escaped.
+
 The host cannot add that guard for you. What an exporter returns is an opaque
 blob, and escaping it would mean parsing arbitrary third-party CSV and would
 corrupt any exporter producing something other than a table. The escaping has

--- a/docs/guide/lists.md
+++ b/docs/guide/lists.md
@@ -140,7 +140,11 @@ const csv = listResultToCSV(result);
 
 ### CSV Safety
 
-`listResultToCSV` guards against spreadsheet formula injection (CWE-1236): any cell that starts with `=`, `+`, `-`, `@`, tab, or carriage return is prefixed with a single quote so Excel and Google Sheets treat it as text rather than a formula. Standard CSV quoting (double quotes, `""` escaping) is applied on top.
+`listResultToCSV` guards against spreadsheet formula injection (CWE-1236): a cell that starts with `=`, `+`, `-`, `@`, tab, or carriage return is prefixed with a single quote so Excel and Google Sheets treat it as text rather than a formula. The trigger is looked for past any leading invisible characters, so a zero-width space in front of `=` does not slip through.
+
+One exception, deliberate: a cell that is **wholly** a number (`-0.35`, `+1`, `-1.5e-3`) is left alone, so a column of negative measures still sums in a spreadsheet. Such a cell cannot carry a formula, since the accepted characters are only `+ - . e E` and the digits. Anything with a trigger and a non-numeric tail (`-0.35=cmd`) is still prefixed. The consequence to know about is that a numeric-looking *identifier* held as text — a `+`-prefixed phone number, a zero-padded code like `-007` — is now written as a number rather than preserved as text.
+
+Standard CSV quoting (double quotes, `""` escaping) is applied on top.
 
 ## Grouping, Aggregation & Schedules
 

--- a/packages/encoding/src/index.ts
+++ b/packages/encoding/src/index.ts
@@ -13,5 +13,6 @@ export {
   isValidUuid,
 } from './guid.js';
 export type { RandomSource } from './guid.js';
+export { isWhollyNumeric } from './numeric-literal.js';
 export { parsePropertyValue } from './property-value.js';
 export type { ParsedPropertyValue } from './property-value.js';

--- a/packages/encoding/src/numeric-literal.test.ts
+++ b/packages/encoding/src/numeric-literal.test.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The language `isWhollyNumeric` accepts, and the reason it is a hand-written
+ * scan rather than the obvious regex.
+ *
+ * The oracle here is deliberately NOT a hand-listed table: a table is written
+ * by whoever changed the scan, so it shares their blind spot. It is the regex
+ * the scan replaced -- a separate mechanism deciding the same language -- run
+ * over an exhaustively generated corpus rather than a list anyone chose.
+ */
+import { describe, it, expect } from 'vitest';
+import { isWhollyNumeric } from './numeric-literal.js';
+
+/**
+ * The spec. Deliberately still here after the implementation stopped using it:
+ * it states the accepted language in one line, and a deliberate change to that
+ * language has to be made here too. It is not used in production because it
+ * backtracks (see the timing test below).
+ */
+const SPEC_RE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+/** Every string up to 4 characters over the alphabet the language is built
+ *  from, plus the characters most likely to be wrongly accepted. */
+function corpus(): string[] {
+  const alpha = ['', '+', '-', '.', '0', '1', '9', 'e', 'E', ',', ' ', '\t', '\n', 'x', '１', '١'];
+  const out = new Set<string>();
+  for (const a of alpha) for (const b of alpha) for (const c of alpha) for (const d of alpha) {
+    out.add(a + b + c + d);
+  }
+  return [...out];
+}
+
+describe('isWhollyNumeric accepts exactly the documented language', () => {
+  const all = corpus();
+
+  it('the corpus is actually populated (an empty sweep proves nothing)', () => {
+    expect(all.length).toBeGreaterThan(50_000);
+  });
+
+  it('agrees with the spec regex on every string in it', () => {
+    const disagree = all.filter((v) => SPEC_RE.test(v) !== isWhollyNumeric(v)).map((v) => JSON.stringify(v));
+    expect(disagree).toEqual([]);
+  });
+
+  it('the sweep can fail: a deliberately narrower language is caught', () => {
+    // Without this, an empty corpus or an always-agreeing oracle would also
+    // report zero disagreements and the test above would pin nothing.
+    const narrower = (v: string) => /^[+-]?\d+$/.test(v);
+    expect(all.filter((v) => SPEC_RE.test(v) !== narrower(v)).length).toBeGreaterThan(50);
+  });
+
+  it('rejects digits that are not ASCII', () => {
+    // `\d` is ASCII-only in JS and this scan matches that on purpose: a
+    // full-width or Arabic-Indic digit is not a number here.
+    expect(isWhollyNumeric('１')).toBe(false);
+    expect(isWhollyNumeric('١')).toBe(false);
+  });
+});
+
+describe('deciding it is linear, not backtracking', () => {
+  /**
+   * `SPEC_RE` is quadratic on a failing match: `\d+\.?\d*` retries at every
+   * split point before the engine gives up. Its caller is the CSV formula
+   * guard, which reaches it only after a trigger character matched -- so `-`
+   * followed by tens of thousands of digits, an ordinary attacker-controllable
+   * IFC property value, froze an export.
+   *
+   * Asserted as a RATIO between the two on the same input on the same machine,
+   * so a fast or slow runner moves both ends together and there is no absolute
+   * millisecond bound to re-tune. A ratio alone would be satisfied by 0 vs 0,
+   * so it is paired with a floor proving the slow half took measurable time.
+   */
+  const hostile = `-${'1'.repeat(30_000)}x`;
+  const elapsed = (f: () => void): number => {
+    const t0 = performance.now();
+    f();
+    return performance.now() - t0;
+  };
+
+  it('rejects the hostile input, so the timings below measure a real decision', () => {
+    expect(isWhollyNumeric(hostile)).toBe(false);
+  });
+
+  it('runs orders of magnitude faster than the regex it replaced', () => {
+    const regexMs = elapsed(() => void SPEC_RE.test(hostile));
+    const scanMs = elapsed(() => void isWhollyNumeric(hostile));
+    // Floor: if the backtracking half finished instantly, the ratio below would
+    // compare two zeroes and pass against any implementation at all.
+    expect(regexMs).toBeGreaterThan(50);
+    // Measured gap is ~10,000x, so 50x is far out of reach of timing noise and
+    // still unreachable for anything that backtracks.
+    expect(scanMs * 50).toBeLessThan(regexMs);
+  });
+});

--- a/packages/encoding/src/numeric-literal.test.ts
+++ b/packages/encoding/src/numeric-literal.test.ts
@@ -62,36 +62,100 @@ describe('isWhollyNumeric accepts exactly the documented language', () => {
 
 describe('deciding it is linear, not backtracking', () => {
   /**
-   * `SPEC_RE` is quadratic on a failing match: `\d+\.?\d*` retries at every
-   * split point before the engine gives up. Its caller is the CSV formula
-   * guard, which reaches it only after a trigger character matched -- so `-`
-   * followed by tens of thousands of digits, an ordinary attacker-controllable
-   * IFC property value, froze an export.
+   * The property is LINEARITY, so measure linearity: quadruple the input and
+   * the time should roughly quadruple, not go up sixteenfold.
    *
-   * Asserted as a RATIO between the two on the same input on the same machine,
-   * so a fast or slow runner moves both ends together and there is no absolute
-   * millisecond bound to re-tune. A ratio alone would be satisfied by 0 vs 0,
-   * so it is paired with a floor proving the slow half took measurable time.
+   * This never runs the regex it replaced. Comparing against it proved only
+   * "faster than that regex", which drags the regex's pathological cost and the
+   * runner's speed into the assertion: it needed an absolute `regexMs > 50`
+   * floor to stay meaningful, and that floor had under 4x of margin, so a
+   * machine a few times faster than this one would have gone red with a message
+   * that made no sense.
+   *
+   * Be clear about the division of labour, because it is not what it looks
+   * like. A quadratic regression is caught by the two ABSOLUTE bounds, which
+   * fire long before any ratio is computed -- they are the fast, blunt half.
+   * The growth ratio is the half that states the actual claim (the cost is
+   * linear in the length) and the half no runner speed can move, but on a
+   * quadratic implementation it is never reached.
+   *
+   * The input sizes are bounded on purpose. A quadratic implementation at
+   * n=200_000 needs about half an hour for ONE call, so a ratio measured there
+   * would HANG rather than fail, and a hang burns the job instead of reporting.
+   * At n=20_000 one such call is ~0.2s, which is why the guard below probes a
+   * single call before it batches anything.
    */
-  const hostile = `-${'1'.repeat(30_000)}x`;
-  const elapsed = (f: () => void): number => {
+  const SMALL = 20_000;
+  const LARGE = 80_000; // 4x SMALL: linear predicts ~4x, quadratic ~16x.
+  const TRIALS = 2; // Best of two batches, so one GC pause cannot inflate a reading.
+  /** A batch has to be clearly above clock noise to divide by. */
+  const MEASURABLE_MS = 2;
+
+  const hostile = (n: number): string => `-${'1'.repeat(n)}x`;
+
+  const once = (n: number): number => {
+    const v = hostile(n);
     const t0 = performance.now();
-    f();
+    isWhollyNumeric(v);
     return performance.now() - t0;
   };
 
-  it('rejects the hostile input, so the timings below measure a real decision', () => {
-    expect(isWhollyNumeric(hostile)).toBe(false);
+  /** Fastest of `TRIALS` batches of `reps` calls, in ms. */
+  const batch = (n: number, reps: number): number => {
+    const v = hostile(n);
+    let best = Infinity;
+    for (let trial = 0; trial < TRIALS; trial++) {
+      const t0 = performance.now();
+      for (let i = 0; i < reps; i++) isWhollyNumeric(v);
+      best = Math.min(best, performance.now() - t0);
+    }
+    return best;
+  };
+
+  it('rejects the hostile input, so the timings measure a real decision', () => {
+    // If this returned early the numbers below would be timing nothing.
+    expect(isWhollyNumeric(hostile(SMALL))).toBe(false);
   });
 
-  it('runs orders of magnitude faster than the regex it replaced', () => {
-    const regexMs = elapsed(() => void SPEC_RE.test(hostile));
-    const scanMs = elapsed(() => void isWhollyNumeric(hostile));
-    // Floor: if the backtracking half finished instantly, the ratio below would
-    // compare two zeroes and pass against any implementation at all.
-    expect(regexMs).toBeGreaterThan(50);
-    // Measured gap is ~10,000x, so 50x is far out of reach of timing noise and
-    // still unreachable for anything that backtracks.
-    expect(scanMs * 50).toBeLessThan(regexMs);
+  it('decides a 20k-character near-number quickly', () => {
+    // The fast, blunt check. 0.32-0.39ms measured here; CI has come in around
+    // 30x slower on this workload, so ~10ms against a 100ms bound. The regex
+    // this replaced took ~180ms at this length.
+    expect(once(SMALL)).toBeLessThan(100);
   });
+
+  it('quadrupling the input roughly quadruples the time', { timeout: 30_000 }, () => {
+    // Guard before batching. A cold call at the larger size is 0.5-0.9ms here
+    // and ~25ms on a runner 30x slower, against a 200ms bound. Without it the
+    // batches below run 400 calls: a quadratic implementation would take about
+    // twenty minutes and a merely slow one several seconds, and a test that
+    // grinds is worse than one that fails, because it burns the job instead of
+    // reporting.
+    expect(once(LARGE)).toBeLessThan(200);
+
+    // CALIBRATE the batch size rather than fixing it. A fixed count is a
+    // hardware-dependent assertion in the fast direction: a quick enough runner
+    // cannot produce a measurable baseline, and the test then fails while the
+    // implementation is perfectly correct. Doubling until the measurement is
+    // comfortably above clock noise makes a faster machine do more work instead
+    // of going red, and a slower one stop at the first batch.
+    let reps = 50;
+    let small = batch(SMALL, reps);
+    while (small < MEASURABLE_MS && reps < 200_000) {
+      reps *= 2;
+      small = batch(SMALL, reps);
+    }
+    // Not a speed bound: this asserts CALIBRATION succeeded. Failing here means
+    // 200k calls still take under 2ms, which is its own thing worth knowing.
+    expect(small).toBeGreaterThanOrEqual(MEASURABLE_MS);
+
+    const growth = batch(LARGE, reps) / small;
+    // Measured over twelve runs at this configuration: the linear scan grows
+    // 3.4x to 4.6x, the quadratic regex 15.6x to 17.0x. 8 sits between them.
+    expect(growth).toBeLessThan(8);
+  });
+
+  // The explicit timeout is a backstop, not a crutch: this test does real work
+  // whose wall time is set by the runner, and CI has twice come in far slower
+  // than this machine. The assertions above are what bound the behaviour.
 });

--- a/packages/encoding/src/numeric-literal.ts
+++ b/packages/encoding/src/numeric-literal.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Whether `v` is WHOLLY a signed decimal number, optionally in exponent form:
+ * `-0.35`, `+1`, `-1.5e-3`, `-.5`, `-1.`. Anchored at BOTH ends, so `-0.35=cmd`
+ * is not one and `1,000` is not one either.
+ *
+ * Lives here, in a package with no dependencies, because three different
+ * callers need it and only two of them can afford `@ifc-lite/export`: the CSV
+ * formula guard (`packages/export/src/csv-cell.ts`) exempts a genuine number
+ * from the `+`/`-` trigger so a spreadsheet column still sums (#1772), and
+ * `@ifc-lite/lists` needs the same decision in its own CSV writer.
+ * `rust/export/src/csv_cell.rs::is_wholly_numeric` decides the same language on
+ * the other side of the language boundary; what holds those two together is the
+ * shared vector fixture, not a promise that they look alike.
+ *
+ * The regex this replaces — `/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/` —
+ * is QUADRATIC on a failing match: `\d+\.?\d*` retries at every split point
+ * before the engine gives up. This scan is linear, which is the whole reason it
+ * is spelled out by hand. (For scale, on `-` + 60k digits + one letter the
+ * regex took ~1.8s and the scan ~1ms; the ratio is the point, not the numbers.)
+ *
+ * Cell text comes from IFC properties, so the input is attacker-controllable and
+ * a leading `-` is exactly what reaches this check. `\d` is ASCII-only in JS, and
+ * this scan matches that deliberately: a full-width or Arabic-Indic digit is NOT
+ * a number here and stays guarded.
+ */
+export function isWhollyNumeric(v: string): boolean {
+  const n = v.length;
+  let i = 0;
+  if (i < n && (v[i] === '+' || v[i] === '-')) i++;
+
+  // Mantissa: `\d+\.?\d*` or `\.\d+` — at least one digit either way.
+  let digits = 0;
+  while (i < n && v[i] >= '0' && v[i] <= '9') { i++; digits++; }
+  if (i < n && v[i] === '.') {
+    i++;
+    while (i < n && v[i] >= '0' && v[i] <= '9') { i++; digits++; }
+  }
+  if (digits === 0) return false;
+
+  // Optional exponent, which must carry at least one digit if present.
+  if (i < n && (v[i] === 'e' || v[i] === 'E')) {
+    i++;
+    if (i < n && (v[i] === '+' || v[i] === '-')) i++;
+    let expDigits = 0;
+    while (i < n && v[i] >= '0' && v[i] <= '9') { i++; expDigits++; }
+    if (expDigits === 0) return false;
+  }
+
+  // Anchored at the end: trailing anything, including a newline, disqualifies.
+  return i === n;
+}

--- a/packages/export/src/csv-cell.parity.test.ts
+++ b/packages/export/src/csv-cell.parity.test.ts
@@ -14,7 +14,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { escapeCsvCell, INVISIBLE_PREFIX_RE, PADDING_RE } from './csv-cell.js';
+import { escapeCsvCell, INVISIBLE_PREFIX_RE, PADDING_RE, type CsvCellOptions } from './csv-cell.js';
 
 interface Vector {
   name: string;
@@ -50,11 +50,17 @@ describe('escapeCsvCell matches the shared cross-language vectors', () => {
 
   for (const v of fixture.cases) {
     it(`vector: ${v.name}`, () => {
-      const got = escapeCsvCell(v.input, {
-        delimiter: v.delimiter ?? ',',
-        exemptNumbers: v.exemptNumbers ?? false,
-        quoteWhitespacePadded: v.quoteWhitespacePadded ?? false,
-      });
+      // An ABSENT field means "whatever the library defaults to", not a
+      // hard-coded value. Spelling the defaults out here made the harness blind
+      // to the one thing it exists to catch: the two languages' defaults
+      // drifting apart. Vectors that name no options at all therefore pin the
+      // TS and Rust defaults against each other.
+      const opts: CsvCellOptions = { delimiter: v.delimiter ?? ',' };
+      if (v.exemptNumbers !== undefined) opts.exemptNumbers = v.exemptNumbers;
+      if (v.quoteWhitespacePadded !== undefined) {
+        opts.quoteWhitespacePadded = v.quoteWhitespacePadded;
+      }
+      const got = escapeCsvCell(v.input, opts);
       expect(got).toBe(v.expected);
     });
   }

--- a/packages/export/src/csv-cell.parity.test.ts
+++ b/packages/export/src/csv-cell.parity.test.ts
@@ -55,7 +55,11 @@ describe('escapeCsvCell matches the shared cross-language vectors', () => {
       // to the one thing it exists to catch: the two languages' defaults
       // drifting apart. Vectors that name no options at all therefore pin the
       // TS and Rust defaults against each other.
-      const opts: CsvCellOptions = { delimiter: v.delimiter ?? ',' };
+      // Start EMPTY, not `{ delimiter: ',' }`: spelling the delimiter out meant
+      // no vector ever exercised the TypeScript delimiter default, so it could
+      // drift from Rust's unnoticed. Same reasoning as the options below.
+      const opts: CsvCellOptions = {};
+      if (v.delimiter !== undefined) opts.delimiter = v.delimiter;
       if (v.exemptNumbers !== undefined) opts.exemptNumbers = v.exemptNumbers;
       if (v.quoteWhitespacePadded !== undefined) {
         opts.quoteWhitespacePadded = v.quoteWhitespacePadded;

--- a/packages/export/src/csv-cell.ts
+++ b/packages/export/src/csv-cell.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { isWhollyNumeric } from '@ifc-lite/encoding';
+
 /**
  * THE CSV cell escaper for this repository's TypeScript.
  *
@@ -48,29 +50,30 @@ export const INVISIBLE_PREFIX_RE = /[\p{Cf}\p{Z}]/u;
  */
 const TRIGGER_RE = /^[\p{Cf}\p{Z}]*[=+\-@\t\r]/u;
 
-/**
- * A cell that is WHOLLY a signed decimal number, optionally in exponent form.
- * Anchored at both ends on purpose: `-0.35=cmd` is not a number and must stay
- * guarded. Applied only when the caller opts in (see `exemptNumbers`).
- */
-const WHOLLY_NUMERIC_RE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
-
 export interface CsvCellOptions {
   /** Column delimiter the cell will be joined with. Default `,`. */
   delimiter?: string;
   /**
    * Exempt a cell that is wholly a signed number (`-0.35`, `+1`, `-1.5e-3`)
    * from the `+`/`-` formula trigger, so spreadsheet `SUM()` still works on
-   * exported measures (#1772).
+   * exported measures (#1772). **Default `true`.**
    *
-   * This is a PRODUCT policy, not a security one, and the repo currently
-   * disagrees with itself about it: `@ifc-lite/lists` exempts numbers while
-   * the viewer's Lists export guards them, and both behaviours are
-   * deliberately tested (see the note at
-   * `apps/viewer/src/lib/lists/export/model.ts`). Resolving that split is a
-   * maintainer call; carrying it as an option means the disagreement no longer
-   * requires two implementations of the guard. Default `false`, matching every
-   * current caller of this module.
+   * A PRODUCT policy, not a security one. The exemption cannot weaken the
+   * guard: the accepted language is built from `+ - . e E 0-9` and nothing
+   * else, which cannot spell a function name, a cell reference or a `(`, so
+   * every string it exempts is inert in a spreadsheet. `=`, `@`, TAB and CR are
+   * never exempted, and a number with anything glued to it (`-0.35=cmd`) is not
+   * wholly numeric and stays guarded.
+   *
+   * The default used to be `false`, which made the repo disagree with itself:
+   * `@ifc-lite/lists` exempted numbers, every other writer guarded them, and
+   * both behaviours were deliberately tested. Exempting is now the default so
+   * the policy lives in ONE place instead of at eleven call sites, where it
+   * would drift. Pass `false` to opt a writer out.
+   *
+   * This flag does NOT make a numeric column sum on its own; a cell that
+   * arrives already display-formatted is not wholly numeric and no setting here
+   * changes that. `apps/viewer/src/lib/lists/export/csv.ts` explains why.
    */
   exemptNumbers?: boolean;
   /**
@@ -108,8 +111,9 @@ export function guardSpreadsheetFormula(
   value: string,
   options: Pick<CsvCellOptions, 'exemptNumbers'> = {},
 ): string {
+  const { exemptNumbers = true } = options;
   if (!TRIGGER_RE.test(value)) return value;
-  if (options.exemptNumbers === true && WHOLLY_NUMERIC_RE.test(value)) return value;
+  if (exemptNumbers && isWhollyNumeric(value)) return value;
   return `'${value}`;
 }
 

--- a/packages/lists/src/engine.csv-numeric-cells.test.ts
+++ b/packages/lists/src/engine.csv-numeric-cells.test.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `listResultToCSV`'s numeric exemption, asserted on the BYTES the real writer
+ * emits rather than on the helper it calls.
+ *
+ * This writer is the one remaining hand-rolled escaper in the repo (the sole
+ * entry on `scripts/check-csv-escaper-copies.mjs`'s `KNOWN_REMAINING` list),
+ * so what it does with a number is not implied by any test of the shared guard.
+ * The LANGUAGE itself is pinned once, next to its implementation, in
+ * `packages/encoding/src/numeric-literal.test.ts` -- the cases here are only
+ * the ones that reach a spreadsheet differently.
+ */
+import { describe, it, expect } from 'vitest';
+import { listResultToCSV } from './engine.js';
+import type { ListResult, ColumnDefinition, CellValue } from './types.js';
+
+const ONE_COL: ColumnDefinition[] = [{ id: 'v', source: 'attribute', propertyName: 'V' }];
+
+/** The single data cell of a one-column, one-row export. */
+function cell(value: CellValue): string {
+  const res: ListResult = {
+    columns: ONE_COL,
+    rows: [{ entityId: 1, modelId: 'default', values: [value] }],
+    totalCount: 1,
+    executionTime: 0,
+  };
+  const lines = listResultToCSV(res).split('\r\n');
+  expect(lines).toHaveLength(2); // header + the one row, or the fixture is wrong
+  return lines[1];
+}
+
+describe('listResultToCSV and the #1772 numeric exemption', () => {
+  it('writes a signed number as a number, so the column still sums', () => {
+    for (const v of ['-0.35', '+1', '-1.5e-3']) expect(cell(v)).toBe(v);
+  });
+
+  it('still guards a trigger, and anything merely glued to a number', () => {
+    for (const v of ['=1+1', '@SUM(A1)', '-0.35=cmd', '+1-2']) expect(cell(v)).toBe(`'${v}`);
+  });
+
+  it('still guards what a display formatter produced rather than a number', () => {
+    // `-1,000` is `toLocaleString()` output for -1000, not one number. It is
+    // guarded, then quoted because it carries the delimiter.
+    expect(cell('-1,000')).toBe('"\'-1,000"');
+    expect(cell('-1 000')).toBe("'-1 000");
+  });
+});

--- a/packages/lists/src/engine.ts
+++ b/packages/lists/src/engine.ts
@@ -10,7 +10,7 @@
  */
 
 import type { PropertySet, Property, QuantitySet, Quantity } from '@ifc-lite/data';
-import { parsePropertyValue } from '@ifc-lite/encoding';
+import { isWhollyNumeric, parsePropertyValue } from '@ifc-lite/encoding';
 import { compileNameMatcher } from './name-pattern.js';
 import type {
   ListDataProvider,
@@ -786,10 +786,7 @@ export function listResultToCSV(result: ListResult, delimiter = ','): string {
     // is itself a trigger, so "\t=cmd" would stop being guarded. `\p{Z}` rather
     // than `\p{Zs}` because the separator category also covers `Zl`/`Zp`, so
     // U+2028/U+2029 would otherwise remain viable hiding prefixes.
-    if (
-      /^[\p{Cf}\p{Z}]*[=+\-@\t\r]/u.test(str) &&
-      !/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(str)
-    ) {
+    if (/^[\p{Cf}\p{Z}]*[=+\-@\t\r]/u.test(str) && !isWhollyNumeric(str)) {
       str = `'${str}`;
     }
     if (str.includes(delimiter) || str.includes('"') || str.includes('\n') || str.includes('\r')) {

--- a/rust/export/src/csv.rs
+++ b/rust/export/src/csv.rs
@@ -237,6 +237,32 @@ fn quantities_csv(model: &ExportModel, opts: &CsvOptions) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// `escape` spells its options out rather than using
+    /// `..CsvCellOptions::default()`, so a NEW option on a security-relevant
+    /// guard cannot be inherited without someone deciding. The cost is that
+    /// this writer does NOT follow the shared default automatically: the
+    /// "DEFAULT OPTIONS" vectors in the shared fixture pin every TypeScript
+    /// writer against `escape_csv_cell`'s default and would not notice this one
+    /// drifting away from it.
+    ///
+    /// So pin the WRITER, not the default. Asserting
+    /// `CsvCellOptions::default().exempt_numbers` would still pass if this
+    /// function stopped honouring it.
+    #[test]
+    fn escape_exempts_a_wholly_numeric_cell_and_guards_everything_else() {
+        // #1772: a negative measure must reach a spreadsheet as a number, or
+        // the column stops summing.
+        assert_eq!(escape("-0.35", ","), "-0.35");
+        assert_eq!(escape("+1", ","), "+1");
+        // The exemption is for numbers, not for the sign.
+        assert_eq!(escape("-0.35=cmd", ","), "'-0.35=cmd");
+        assert_eq!(escape("=1+1", ","), "'=1+1");
+        assert_eq!(escape("@SUM(A1)", ","), "'@SUM(A1)");
+        // Still RFC 4180 on top of the guard.
+        assert_eq!(escape("a,b", ","), "\"a,b\"");
+    }
+
     use super::*;
 
     #[test]

--- a/rust/export/src/csv.rs
+++ b/rust/export/src/csv.rs
@@ -49,7 +49,11 @@ fn escape(value: &str, delimiter: &str) -> String {
     // not silently inherit one.
     escape_csv_cell(
         value,
-        &CsvCellOptions { delimiter, exempt_numbers: false, quote_whitespace_padded: false },
+        &CsvCellOptions {
+            delimiter,
+            exempt_numbers: true,
+            quote_whitespace_padded: false,
+        },
     )
 }
 

--- a/rust/export/src/csv_cell.rs
+++ b/rust/export/src/csv_cell.rs
@@ -101,11 +101,16 @@ pub struct CsvCellOptions<'a> {
     /// from the `+`/`-` trigger, so spreadsheet `SUM()` still works on exported
     /// measures (#1772).
     ///
-    /// A PRODUCT policy, not a security one, and the repo currently disagrees
-    /// with itself about it (`@ifc-lite/lists` exempts, the viewer's Lists
-    /// export guards, both deliberately tested). Carrying it as an option means
-    /// the disagreement no longer requires two implementations of the guard.
-    /// Defaults to `false`, matching every current caller.
+    /// A PRODUCT policy, not a security one. The exemption cannot weaken the
+    /// guard: the accepted language is built from `+ - . e E 0-9` and nothing
+    /// else, which cannot spell a function name, a cell reference or a `(`, so
+    /// every string it exempts is inert in a spreadsheet. `=`, `@`, TAB and CR
+    /// are never exempted.
+    ///
+    /// **Defaults to `true`**, in lockstep with the TypeScript half. The two
+    /// defaults are pinned together by a shared vector that passes NO options
+    /// (see `csv_cell_parity.rs`), because a harness that always sets every
+    /// field explicitly cannot see the defaults drift apart.
     pub exempt_numbers: bool,
     /// Also quote a cell whose first or last character is whitespace, so an
     /// importer that would otherwise trim the padding cannot (RFC 4180 §2.4
@@ -119,7 +124,7 @@ pub struct CsvCellOptions<'a> {
 
 impl Default for CsvCellOptions<'_> {
     fn default() -> Self {
-        Self { delimiter: ",", exempt_numbers: false, quote_whitespace_padded: false }
+        Self { delimiter: ",", exempt_numbers: true, quote_whitespace_padded: false }
     }
 }
 

--- a/rust/export/tests/csv_cell_parity.rs
+++ b/rust/export/tests/csv_cell_parity.rs
@@ -71,10 +71,19 @@ fn rust_csv_cell_matches_shared_vectors() {
         let name = case["name"].as_str().unwrap_or("<unnamed>");
         let input = case["input"].as_str().expect("input is a string");
         let expected = case["expected"].as_str().expect("expected is a string");
+        // An ABSENT field means "whatever the library defaults to", not a
+        // hard-coded value. Restating the defaults here made the harness blind
+        // to the one thing it exists to catch: the two languages' defaults
+        // drifting apart. Vectors that name no options pin both defaults.
+        let defaults = CsvCellOptions::default();
         let opts = CsvCellOptions {
-            delimiter: case["delimiter"].as_str().unwrap_or(","),
-            exempt_numbers: case["exemptNumbers"].as_bool().unwrap_or(false),
-            quote_whitespace_padded: case["quoteWhitespacePadded"].as_bool().unwrap_or(false),
+            delimiter: case["delimiter"].as_str().unwrap_or(defaults.delimiter),
+            exempt_numbers: case["exemptNumbers"]
+                .as_bool()
+                .unwrap_or(defaults.exempt_numbers),
+            quote_whitespace_padded: case["quoteWhitespacePadded"]
+                .as_bool()
+                .unwrap_or(defaults.quote_whitespace_padded),
         };
 
         let got = escape_csv_cell(input, &opts);
@@ -141,4 +150,25 @@ fn named_bypasses_are_all_covered() {
     // TAB is NOT in the class: it is itself a trigger, so skipping past it
     // would un-guard "\t=cmd" — the exact trap `\s` would have walked into.
     assert!(!is_invisible_prefix('\t'), "TAB must stay a trigger, not a skip");
+}
+
+/// `csv.rs::escape` spells its options out rather than using
+/// `..CsvCellOptions::default()`, so that a NEW option on a security-relevant
+/// guard cannot be inherited without someone deciding. The cost of that
+/// guardrail is that the one real Rust CSV caller does NOT follow the shared
+/// default automatically — the "DEFAULT OPTIONS" vectors pin every TypeScript
+/// writer against `escape_csv_cell`'s default, and would not have noticed this
+/// one drifting away from it.
+///
+/// So pin the two together directly. If the shared default moves, this fails
+/// and whoever moved it decides what `export_csv` should do, instead of the two
+/// silently disagreeing.
+#[test]
+fn the_csv_exporter_still_agrees_with_the_shared_default() {
+    assert!(
+        CsvCellOptions::default().exempt_numbers,
+        "rust/export/src/csv.rs hard-codes `exempt_numbers: true`; the shared \
+         default has moved away from it, so the CSV exporter and every \
+         TypeScript writer no longer agree"
+    );
 }

--- a/rust/export/tests/csv_cell_parity.rs
+++ b/rust/export/tests/csv_cell_parity.rs
@@ -152,23 +152,22 @@ fn named_bypasses_are_all_covered() {
     assert!(!is_invisible_prefix('\t'), "TAB must stay a trigger, not a skip");
 }
 
-/// `csv.rs::escape` spells its options out rather than using
-/// `..CsvCellOptions::default()`, so that a NEW option on a security-relevant
-/// guard cannot be inherited without someone deciding. The cost of that
-/// guardrail is that the one real Rust CSV caller does NOT follow the shared
-/// default automatically — the "DEFAULT OPTIONS" vectors pin every TypeScript
-/// writer against `escape_csv_cell`'s default, and would not have noticed this
-/// one drifting away from it.
+/// The shared fixture's "DEFAULT OPTIONS" vectors pin the TypeScript default
+/// against `escape_csv_cell`'s default. They cannot see `csv.rs::escape`, which
+/// spells its options out so a NEW option cannot be inherited silently, and so
+/// does NOT follow the shared default automatically.
 ///
-/// So pin the two together directly. If the shared default moves, this fails
-/// and whoever moved it decides what `export_csv` should do, instead of the two
-/// silently disagreeing.
+/// `csv::tests::escape_exempts_a_wholly_numeric_cell_and_guards_everything_else`
+/// pins what that writer does. This pins the value it is hard-coded to, so a
+/// coordinated flip of the product policy -- both language defaults to `false`,
+/// fixture updated -- fails here instead of leaving the Rust exporter exempting
+/// while every TypeScript writer guards.
 #[test]
-fn the_csv_exporter_still_agrees_with_the_shared_default() {
+fn the_csv_exporters_hard_coded_option_still_matches_the_shared_default() {
     assert!(
         CsvCellOptions::default().exempt_numbers,
         "rust/export/src/csv.rs hard-codes `exempt_numbers: true`; the shared \
-         default has moved away from it, so the CSV exporter and every \
-         TypeScript writer no longer agree"
+         default has moved away from it, so that exporter and every TypeScript \
+         writer no longer agree"
     );
 }

--- a/rust/export/tests/fixtures/csv_cell_vectors.json
+++ b/rust/export/tests/fixtures/csv_cell_vectors.json
@@ -1,5 +1,5 @@
 {
-  "//": "Shared cross-language CSV-cell vectors. The TypeScript escaper (packages/export/src/csv-cell.ts, via csv-cell.parity.test.ts) and the Rust escaper (rust/export/src/csv_cell.rs, via tests/csv_cell_parity.rs) are BOTH pinned to this file, so the two cannot drift unnoticed. Regenerate the ranges with scripts/gen-csv-cell-vectors.mjs; author cases by hand. Case defaults when omitted: delimiter \",\", exemptNumbers false, quoteWhitespacePadded false.",
+  "//": "Shared cross-language CSV-cell vectors. The TypeScript escaper (packages/export/src/csv-cell.ts, via csv-cell.parity.test.ts) and the Rust escaper (rust/export/src/csv_cell.rs, via tests/csv_cell_parity.rs) are BOTH pinned to this file, so the two cannot drift unnoticed. Regenerate the ranges with scripts/gen-csv-cell-vectors.mjs; author cases by hand. A case that omits an option gets the LIBRARY default for it, not a value spelled out by the harness -- that is what the DEFAULT OPTIONS cases pin.",
   "invisiblePrefixNote": "Code points a spreadsheet importer swallows or renders as spacing, yet which do NOT stop a following =/+/-/@ from being evaluated as a formula. Exactly Unicode general categories Cf + Z (Zs, Zl, Zp). TypeScript spells this /[\\p{Cf}\\p{Z}]/u; Rust spells it as a const range table. Both suites sweep every code point 0..=0x10FFFF against the ranges below, so an engine/table mismatch fails loudly instead of silently re-opening the bypass.",
   "invisiblePrefixRanges": [
     [
@@ -195,14 +195,16 @@
       "expected": "'=1+1"
     },
     {
-      "name": "plus is a formula trigger",
+      "name": "plus is a formula trigger when the exemption is opted out of",
       "input": "+1",
-      "expected": "'+1"
+      "expected": "'+1",
+      "exemptNumbers": false
     },
     {
-      "name": "minus is a formula trigger",
+      "name": "minus is a formula trigger when the exemption is opted out of",
       "input": "-0.35",
-      "expected": "'-0.35"
+      "expected": "'-0.35",
+      "exemptNumbers": false
     },
     {
       "name": "at is a formula trigger",
@@ -285,9 +287,10 @@
       "expected": "﻿ "
     },
     {
-      "name": "numeric exemption off (default): a negative measure is guarded",
+      "name": "numeric exemption opted out: a negative measure is guarded",
       "input": "-0.35",
-      "expected": "'-0.35"
+      "expected": "'-0.35",
+      "exemptNumbers": false
     },
     {
       "name": "numeric exemption on: a negative measure stays summable",
@@ -383,6 +386,98 @@
       "input": " =cmd ",
       "expected": "\"' =cmd \"",
       "quoteWhitespacePadded": true
+    },
+    {
+      "name": "numeric exemption on: a bare decimal point with no integer part",
+      "input": "-.5",
+      "expected": "-.5",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: a trailing decimal point with no fraction",
+      "input": "-1.",
+      "expected": "-1.",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: an uppercase exponent",
+      "input": "-1E5",
+      "expected": "-1E5",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: a dot-grouped integer, which de-DE displayCell emits for -3000",
+      "input": "-3.000",
+      "expected": "-3.000",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: a sign and a lone decimal point carry no digit",
+      "input": "-.",
+      "expected": "'-.",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: an exponent marker with no exponent digits",
+      "input": "-1e",
+      "expected": "'-1e",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: an exponent sign with no exponent digits",
+      "input": "-1e+",
+      "expected": "'-1e+",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: a comma-grouped integer, which en-US displayCell emits for -1000",
+      "input": "-1,000",
+      "expected": "\"'-1,000\"",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: a trailing newline is past the end of the number",
+      "input": "-1\n",
+      "expected": "\"'-1\n\"",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: full-width digits are not ASCII digits",
+      "input": "-１",
+      "expected": "'-１",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: Arabic-Indic digits are not ASCII digits",
+      "input": "-١",
+      "expected": "'-١",
+      "exemptNumbers": true
+    },
+    {
+      "name": "numeric exemption on: a space-grouped integer is not one number",
+      "input": "-1 000",
+      "expected": "'-1 000",
+      "exemptNumbers": true
+    },
+    {
+      "name": "DEFAULT OPTIONS: a negative measure is exempt",
+      "input": "-0.35",
+      "expected": "-0.35"
+    },
+    {
+      "name": "DEFAULT OPTIONS: a signed integer is exempt",
+      "input": "+1",
+      "expected": "+1"
+    },
+    {
+      "name": "DEFAULT OPTIONS: a real formula trigger is still guarded",
+      "input": "=1+1",
+      "expected": "'=1+1"
+    },
+    {
+      "name": "DEFAULT OPTIONS: a number with a payload glued on is still guarded",
+      "input": "-0.35=cmd",
+      "expected": "'-0.35=cmd"
     }
   ]
 }

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1461,6 +1461,7 @@
     "ifcGuidToUuid: function",
     "isValidIfcGuid: function",
     "isValidUuid: function",
+    "isWhollyNumeric: function",
     "parsePropertyValue: function",
     "uuidToIfcGuid: function"
   ],

--- a/scripts/check-csv-escaper-copies.mjs
+++ b/scripts/check-csv-escaper-copies.mjs
@@ -89,14 +89,18 @@ export const NON_IMPLEMENTATION = [
  *
  * `packages/lists/src/engine.ts` — the library's Lists CSV writer. Left here
  * for two reasons, both structural rather than discretionary:
- *   1. `@ifc-lite/lists` does not depend on `@ifc-lite/export`, so it cannot
- *      call the shared escaper without a new package dependency — a maintainer
- *      call, not a mechanical rewire.
- *   2. It carries the #1772 numeric exemption (`-0.35` stays summable), which
- *      the viewer's Lists export deliberately does NOT. That policy split is
- *      unresolved and is a product decision. The shared escaper can express
- *      both (`exemptNumbers`), so adopting it needs no behaviour change — only
- *      the dependency and someone's say-so.
+ *   1. `@ifc-lite/lists` does not depend on `@ifc-lite/export`. There is no
+ *      CYCLE stopping it — `export` never reaches `lists` — but `export` drags
+ *      in parquet-wasm, apache-arrow and jszip, which is a lot to add to a
+ *      package whose only deps are `data` and `encoding`. The way out is to
+ *      move the escaper DOWN into `@ifc-lite/encoding` (zero deps, already a
+ *      dependency of both) and re-export it, the way `isWhollyNumeric` already
+ *      went. That is a maintainer call, not a mechanical rewire.
+ *   2. It carries the #1772 numeric exemption (`-0.35` stays summable). That
+ *      used to be a policy split, because every other writer guarded numbers;
+ *      it is no longer one — the shared escaper exempts them BY DEFAULT, so
+ *      adopting it here is now behaviour-preserving and the only thing left in
+ *      the way is the package dependency.
  */
 export const KNOWN_REMAINING = ['packages/lists/src/engine.ts'];
 

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -135,7 +135,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * failure message. Either way do it at the moment you finalise the change — it
  * moves if anything else touched the allowlist first.
  */
-const ALLOWLIST_DIGEST = '10786644548108296391';
+const ALLOWLIST_DIGEST = '12372517592902696348';
 
 function parseArgs(argv) {
   const out = {

--- a/scripts/gen-csv-cell-vectors.mjs
+++ b/scripts/gen-csv-cell-vectors.mjs
@@ -60,8 +60,14 @@ const cases = [
   { name: 'semicolon delimiter forces quoting', input: 'a;b', expected: '"a;b"', delimiter: ';' },
 
   { name: 'equals is a formula trigger', input: '=1+1', expected: "'=1+1" },
-  { name: 'plus is a formula trigger', input: '+1', expected: "'+1" },
-  { name: 'minus is a formula trigger', input: '-0.35', expected: "'-0.35" },
+  {
+      name: 'plus is a formula trigger when the exemption is opted out of',
+      input: '+1', expected: "'+1", exemptNumbers: false,
+    },
+  {
+      name: 'minus is a formula trigger when the exemption is opted out of',
+      input: '-0.35', expected: "'-0.35", exemptNumbers: false,
+    },
   { name: 'at is a formula trigger', input: '@SUM(A1)', expected: "'@SUM(A1)" },
   { name: 'leading TAB is a formula trigger', input: '\tcmd', expected: "'\tcmd" },
   {
@@ -110,9 +116,9 @@ const cases = [
   { name: 'a cell of nothing but invisibles is left alone', input: `${BOM}${NBSP}`, expected: `${BOM}${NBSP}` },
 
   {
-    name: 'numeric exemption off (default): a negative measure is guarded',
-    input: '-0.35', expected: "'-0.35",
-  },
+      name: 'numeric exemption opted out: a negative measure is guarded',
+      input: '-0.35', expected: "'-0.35", exemptNumbers: false,
+    },
   {
     name: 'numeric exemption on: a negative measure stays summable',
     input: '-0.35', expected: '-0.35', exemptNumbers: true,
@@ -181,8 +187,67 @@ const cases = [
     name: 'padded quoting on: a guarded cell with trailing padding is still wrapped',
     input: ' =cmd ', expected: '"\' =cmd "', quoteWhitespacePadded: true,
   },
-];
+    // The numeric language's boundaries. Each accepted case is a shape a naive
+    // rewrite of the scan drops; each rejected case is a way it could wrongly
+    // accept. `-1,000` and `-3.000` are what a DISPLAY formatter emits for
+    // -1000 and -3000 under en-US and de-DE, which is why they are here.
+    {
+      name: 'numeric exemption on: a bare decimal point with no integer part',
+      input: '-.5', expected: '-.5', exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: a trailing decimal point with no fraction',
+      input: '-1.', expected: '-1.', exemptNumbers: true,
+    },
+    { name: 'numeric exemption on: an uppercase exponent', input: '-1E5', expected: '-1E5', exemptNumbers: true },
+    {
+      name: 'numeric exemption on: a dot-grouped integer, which de-DE displayCell emits for -3000',
+      input: '-3.000', expected: '-3.000', exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: a sign and a lone decimal point carry no digit',
+      input: '-.', expected: "'-.", exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: an exponent marker with no exponent digits',
+      input: '-1e', expected: "'-1e", exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: an exponent sign with no exponent digits',
+      input: '-1e+', expected: "'-1e+", exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: a comma-grouped integer, which en-US displayCell emits for -1000',
+      input: '-1,000', expected: `"'-1,000"`, exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: a trailing newline is past the end of the number',
+      input: '-1\n', expected: `"'-1\n"`, exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: full-width digits are not ASCII digits',
+      input: '-\uFF11', expected: "'-\uFF11", exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: Arabic-Indic digits are not ASCII digits',
+      input: '-\u0661', expected: "'-\u0661", exemptNumbers: true,
+    },
+    {
+      name: 'numeric exemption on: a space-grouped integer is not one number',
+      input: '-1 000', expected: "'-1 000", exemptNumbers: true,
+    },
 
+    // Vectors that set NO options at all, so they pin the two languages'
+    // DEFAULTS against each other. Without these, both harnesses spell every
+    // option out and a default drifting on one side is invisible.
+    { name: 'DEFAULT OPTIONS: a negative measure is exempt', input: '-0.35', expected: '-0.35' },
+    { name: 'DEFAULT OPTIONS: a signed integer is exempt', input: '+1', expected: '+1' },
+    { name: 'DEFAULT OPTIONS: a real formula trigger is still guarded', input: '=1+1', expected: "'=1+1" },
+    {
+      name: 'DEFAULT OPTIONS: a number with a payload glued on is still guarded',
+      input: '-0.35=cmd', expected: "'-0.35=cmd",
+    },
+];
 const doc = {
   '//': [
     'Shared cross-language CSV-cell vectors. The TypeScript escaper',
@@ -190,7 +255,7 @@ const doc = {
     'escaper (rust/export/src/csv_cell.rs, via tests/csv_cell_parity.rs) are BOTH',
     'pinned to this file, so the two cannot drift unnoticed.',
     'Regenerate the ranges with scripts/gen-csv-cell-vectors.mjs; author cases by hand.',
-    'Case defaults when omitted: delimiter ",", exemptNumbers false, quoteWhitespacePadded false.',
+    'A case that omits an option gets the LIBRARY default for it, not a value spelled out by the harness -- that is what the DEFAULT OPTIONS cases pin.',
   ].join(' '),
   invisiblePrefixNote: [
     'Code points a spreadsheet importer swallows or renders as spacing, yet which do',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -257,7 +257,7 @@
    464 packages/lens/src/engine.ts
    426 packages/lens/src/matching.ts
    417 packages/lens/src/types.ts
-   815 packages/lists/src/engine.ts
+   812 packages/lists/src/engine.ts
    423 packages/lists/src/types.ts
    509 packages/mcp/src/backend-query.ts
    420 packages/mcp/src/overlay.ts


### PR DESCRIPTION
## The default of a security guard changed

`escapeCsvCell` / `guardSpreadsheetFormula` now leave a cell that is **wholly a
number** unprefixed. Pass `exemptNumbers: false` to keep the old behaviour.
Nothing in a consumer's code has to change for the output to change, so it is
stated here first rather than in a footnote.

## Four defects, one path

A number in a list, on its way to a number in a CSV.

**1. The viewer's Lists CSV formatted before escaping.** `displayCell` calls
`toLocaleString()` on integers, so en-US wrote `"-1,000"`, quoted because of the
comma, and the column stopped summing. A locale that groups with `.` wrote a
bare `-3.000`, which a spreadsheet in a `,`-grouping locale reads back as **-3**:
a silent 1000x error in a quantity column. Numeric columns now emit the number,
which is the contract `xlsx.ts` already kept. `pdf.ts`, read by a human, is
unchanged.

**2. The same defect, past the flat table.** Grouping by a numeric column
hard-coded `numeric: false` on the schedule/pivot export's grouping columns, and
their values came from the bucketing helper, which formats labels on the way in.
In that presentation the grouping value is the *only* place the value appears,
so `-3000` exported as `"'-3,000"` and nothing else.

Buckets are keyed by the formatted **label**, so the label is true of every
member while a raw value is only true of the members sharing it: `12.345671` and
`12.345679` both render `12.3457` and land in one bucket. The raw value is used
only where every member agrees; the label carries it otherwise, which is also
what keeps the `(none)` bucket named rather than blank.

**3. The repo disagreed with itself.** `@ifc-lite/lists` had exempted numbers
since #1772 while every other writer guarded them, so the same list exported two
ways did not match. The exemption is now the shared default in both languages,
one decision instead of eleven that drift.

**4. The numeric test backtracked.** It was
`/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/`, quadratic on a failing match and
reached only *after* a trigger matched, so `-` plus 60k digits took ~1.8s. IFC
property text is attacker-controllable, which made that a denial of service on
an export. Now a linear scan, living in `@ifc-lite/encoding` (no dependencies,
already depended on by both callers) as `isWhollyNumeric`.

## What it costs

The shared default has to guess from the text, because most callers hand it a
bare string, and guessing gets identifiers wrong: a `+`-prefixed phone number is
wholly numeric as text, so Excel renders `4.1791E+10` with the `+` gone, and
`-007` becomes `-7`.

The viewer's Lists CSV does not guess, because it has the value. It keeps two
decisions apart: whether to **format** is a property of the column, whether to
**exempt** is a property of the value. Conflating them re-created #1772 in a
column holding both numbers and text (`detectNumericColumns` marks the whole
column as text if one sampled value is a string), which shipped the grand total
as `'-3.35`. Caught in review, reproduced, fixed, and pinned on the TOTAL row.

So the cost lands on the writers that only ever see strings: the CLI, the SDK,
MCP, the compare report, search results, zone tables and `@ifc-lite/lists`' own
CSV. Both guide pages and the changeset say so plainly.

Unit-converted values now carry full double precision (3 ft in metres is
`0.9144000000000001`, not `0.9144`). That is the same value the XLSX export
already wrote, so the two now agree.

## The exemption cannot weaken the guard

The accepted language contains only `+ - . e E` and the digits, which cannot
spell a function name, a cell reference or a `(`. `=`, `@`, TAB and CR are never
exempted. `-0.35=cmd` is not wholly a number and stays guarded. A leading
invisible defeats the *exemption*, not the guard, so `<ZWSP>-1` is still
prefixed. No CSV reader in this repo strips a leading apostrophe, so the change
only ever reduces them on a round-trip.

## Verified by running, not by reading

- **TS/Rust differential**, 39,082 cases plus 20k random longer strings, TS
  defaults against `CsvCellOptions::default()`: **0 mismatches**.
- **New scan vs the regex it replaced**, exhaustive to length 3 over a 27-char
  pool including lone surrogates, plus 400k random and 5k-20k-char inputs:
  **0 disagreements**. A control with a deliberately narrower language reports
  102, so the sweep can fail.
- **`String(v)`** on 2.2M random doubles plus boundary values (`1e21`, `5e-324`,
  `-0`, `MAX_VALUE`): every one passes the guard unmodified.
- **Mutation**, by exit code: reverting the regex, narrowing the language,
  dropping the end anchor, un-flipping the default, restoring `numeric: false`,
  restoring the display path, and dropping the `(none)` fallback each go red.
- Suites: encoding 93, export 851, lists 235, viewer CSV surfaces 226,
  `cargo test` 303. `clippy -D warnings`, both typecheck scopes, and all eight
  repo gates clean, including the module-size ratchet that landed mid-review.

## Instruments repaired

Three checks could not have caught what they exist to catch.

- The **parity harness** spelled every option out on both sides, so it was blind
  to the two languages' defaults drifting apart. An absent field now means
  "library default", and four vectors set no options at all.
- The **shared fixture is generated**. Vectors added to the JSON by hand were
  reverted by the documented regeneration command (reproduced: 60 cases back to
  44). They live in the generator now, and regenerating twice is a no-op.
- The **Rust CSV writer** spells its options out on purpose, so it does not
  follow the shared default automatically. A test pins the two together.

Every fixture in the original version of this change built an *ungrouped* model,
which is why defect 2 survived my own review.

---

Touches `packages/` and `rust/`, so this is yours to merge rather than mine. A
`major` on `@ifc-lite/export` is defensible instead of the `minor` I used, given
it is a relaxed default on a security guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CSV exports preserve wholly numeric values, including signed decimals and scientific notation, as unquoted numeric text.
  - Grouped and schedule exports retain raw numeric values when consistent.
  - Added a utility for recognizing valid numeric values.
  - Numeric exemptions can be disabled when prior guarding behavior is required.

- **Bug Fixes**
  - Spreadsheet safeguards continue protecting numeric-looking strings with extra characters, invisible prefixes, or formula triggers.
  - Improved detection rejects malformed and non-ASCII numeric formats.

- **Documentation**
  - Clarified CSV safety and numeric-value handling in export guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
