### PR TITLE
fix(scripts): six ways the source-text gate reported a clean file

### DIFF
--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -42,15 +42,16 @@
  *
  * IF YOU ARE HERE BECAUSE A CORRECT TEST IS FLAGGED: the escape hatch is an
  * `// @source-text-assertion-ok <reason>` comment on the assertion's own line or
- * above it, in the style of `@unwired-by-design`. An assertion wrapped over
- * several lines counts as one, so the marker may sit above the line the
- * assertion STARTS on; `markerLineFor` in the detector owns the exact rule. It exists for the
- * anchor guard -- `assert.ok(source.includes(from))` before a
+ * above it, in the style of `@unwired-by-design`. It exists for the anchor
+ * guard -- `assert.ok(source.includes(from))` before a
  * `source.replace(from, to)`, which asserts on file text precisely so a mutation
  * that silently fails to apply cannot test nothing. Marked sites are counted and
  * NAMED in this check's output, and a marker that excuses nothing is an error,
  * so an exemption stays a reviewable line rather than a silent hole. Prefer it
  * to the allowlist, which is for whole files that cannot be converted at all.
+ * An assertion wrapped over several lines counts as one, so the marker may sit
+ * above the line the assertion STARTS on; `markerLineFor` in the detector owns
+ * the exact rule.
  *
  * COMMENTS ARE STRIPPED FIRST, and that is load-bearing rather than tidy: three
  * unrelated tests mention a `.ts` filename in prose ("as per `safe-path.test.ts`",

--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -196,8 +196,9 @@ if (deadMarkers.length > 0) {
   for (const site of deadMarkers) console.error(`  ${site}`);
   console.error(`
 Either the marker has no reason after it, or the assertion it excused is gone
-or moved. A marker must sit on the assertion's own line or the line directly
-above it -- an unattached one is an exemption nobody can see the scope of.
+or moved. A marker sits on the assertion's own line or above it, and an
+assertion wrapped over several lines counts as one: the marker may sit above
+the line the assertion STARTS on, which is where this message shows it.
 `);
 }
 

--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -42,7 +42,9 @@
  *
  * IF YOU ARE HERE BECAUSE A CORRECT TEST IS FLAGGED: the escape hatch is an
  * `// @source-text-assertion-ok <reason>` comment on the assertion's own line or
- * the line above it, in the style of `@unwired-by-design`. It exists for the
+ * above it, in the style of `@unwired-by-design`. An assertion wrapped over
+ * several lines counts as one, so the marker may sit above the line the
+ * assertion STARTS on; `markerLineFor` in the detector owns the exact rule. It exists for the
  * anchor guard -- `assert.ok(source.includes(from))` before a
  * `source.replace(from, to)`, which asserts on file text precisely so a mutation
  * that silently fails to apply cannot test nothing. Marked sites are counted and

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -357,10 +357,16 @@ test('a regex literal holding a quote is still blanked, not read as code', () =>
   // flagged if the regex body were scanned as code -- the earlier version of
   // this test had no read, so `analyze` returned at the `READS_A_FILE` guard
   // before `blankStrings` ran, and it passed for three unrelated reasons.
+  //
+  // And then a FOURTH: the body was spelled `source\.includes\(`, which does not
+  // contain the `.includes(` that `PREDICATE_METHOD` looks for, so scanning it as
+  // code found nothing either way. Disabling regex blanking outright left the
+  // whole 64-test suite green. The token below is unescaped on purpose, so the
+  // body really is a predicate on a tainted receiver if it is ever read as code.
   assert.equal(flagged(`
 import { readFileSync } from 'node:fs';
 const source = readFileSync('a/b.ts', 'utf8');
-const RE = /source\\.includes\\(['"]/;
+const RE = /source.includes()["']/;
 it('x', () => { expect(RE.source).toBe('literal'); });
 `), false);
 });

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -731,3 +731,42 @@ assert.ok(v${links}.includes('x'));
     true,
   );
 });
+
+test('a $-named helper propagates taint into its PARAMETER', () => {
+  // Distinct from the `$read` test above, which reaches the verdict through the
+  // helper's RETURN value. This one goes through `callRe`, where `$` broke the
+  // pattern twice: as a regex anchor (needs escaping) and as a non-word
+  // character (so a leading `\b` can never match). Fixing only the anchor left
+  // this silent, and nothing pinned it.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+function $check(text) { assert.ok(text.includes('x')); }
+$check(source);
+`),
+    true,
+  );
+});
+
+test('the pass bound covers names no binding declares', () => {
+  // A `for..of` element is not a binding and not a function, so a cap derived
+  // from `bindings.length + fns.length` was SMALLER than the chain it had to
+  // resolve -- four reverse-ordered links gave a cap of 3 and reported a clean
+  // file, which the fixed 8 it replaced had caught. The bound now counts the
+  // distinct identifiers, which is what the loop can actually add.
+  const links = 6;
+  const chain = Array.from(
+    { length: links },
+    (_, i) => `for (const v${links - i} of v${links - i - 1}.split('x')) { use(v${links - i}); }`,
+  );
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+${chain.join('\n')}
+const v0 = readFileSync('a.ts', 'utf8');
+assert.ok(v${links}.includes('y'));
+`),
+    true,
+  );
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -836,3 +836,35 @@ assert.ok(source.split('x').some($line => $line.includes('y')));
     true,
   );
 });
+
+test('every path that names a value survives a leading $', () => {
+  // `$` is legal in a JS identifier and is NOT a word character, so `\b` can
+  // never match in front of a leading one. That single language fact produced
+  // three separate silent bugs in this module, each found independently rather
+  // than by looking for siblings after the first: `valueIdentifiers`, `callRe`,
+  // and both arrow-parameter patterns.
+  //
+  // This pins the FAMILY. Reintroduce `\b` in front of an identifier class
+  // anywhere in the taint analysis and one of these reds, instead of the gate
+  // going quiet until someone happens to name a variable `$source`.
+  const cases = {
+    'binding': "const $src = readFileSync('a.ts', 'utf8');\nassert.ok($src.includes('x'));",
+    'let then assign': "let $s;\n$s = readFileSync('a.ts', 'utf8');\nassert.ok($s.includes('x'));",
+    'helper return': "function $load(p) { return readFileSync(p, 'utf8'); }\nconst s = $load('a.ts');\nassert.ok(s.includes('x'));",
+    'helper parameter': "function $check(t) { assert.ok(t.includes('x')); }\nconst s = readFileSync('a.ts', 'utf8');\n$check(s);",
+    'bare arrow helper': "const $chk = $t => $t.includes('x');\nconst s = readFileSync('a.ts', 'utf8');\nassert.ok($chk(s));",
+    'for-of element': "const s = readFileSync('a.ts', 'utf8');\nfor (const $line of s.split('n')) { assert.ok($line.includes('x')); }",
+    'arrow callback param': "const s = readFileSync('a.ts', 'utf8');\nassert.ok(s.split('n').some($l => $l.includes('x')));",
+    'function callback param': "const s = readFileSync('a.ts', 'utf8');\nassert.ok(s.split('n').some(function ($l) { return $l.includes('x'); }));",
+  };
+  for (const [name, body] of Object.entries(cases)) {
+    assert.equal(
+      flagged(`
+import { readFileSync } from 'node:fs';
+${body}
+`),
+      true,
+      `a $-leading name went undetected via: ${name}`,
+    );
+  }
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -290,7 +290,17 @@ const x = 1;`);
 // 4. End to end against the real repo.
 
 test('the gate passes on the repo and states its counts', () => {
-  const r = spawnSync(process.execPath, [GATE], { encoding: 'utf8', cwd: ROOT });
+  // A spawn that never starts, or one that hangs, must not be readable as a
+  // gate failure with nothing to say. Without `error`, a failed spawn gives
+  // `status: null` and empty stdout/stderr, so the assertion below prints an
+  // empty message and the real cause is invisible; without `timeout` a hung
+  // gate holds the job until CI kills it.
+  const r = spawnSync(process.execPath, [GATE], {
+    encoding: 'utf8',
+    cwd: ROOT,
+    timeout: 120_000,
+  });
+  assert.equal(r.error, undefined, `the gate failed to run: ${r.error?.message}`);
   const output = `${r.stdout}${r.stderr}`;
   assert.equal(r.status, 0, output);
   assert.match(

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -770,3 +770,41 @@ assert.ok(v${links}.includes('y'));
     true,
   );
 });
+
+test('a control keyword and its ( may sit on different lines', () => {
+  // `closesAControlHeader` skipped only spaces and tabs, so a newline between
+  // `if` and `(` made the header read as an ordinary parenthesised expression.
+  // The regex after it became division and its quote desynced the lexer.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+if
+(ok) /["']/.test(value);
+assert.ok(source.includes('tok'));
+`),
+    true,
+  );
+});
+
+test('an optional call is still a call', () => {
+  // `?.(` bypassed all three call patterns, including the FAIL-CLOSED rule for
+  // flow this analysis cannot follow -- a guard that exists to catch the
+  // unfollowable was itself sidestepped by two characters. `?.` can also sit on
+  // either side of a method name.
+  for (const body of [
+    "function check(text) { assert.ok(text.includes('x')); }\ncheck?.(source);",
+    "assert.ok(source.split('x')?.some((line) => line.includes('y')));",
+    "mutators[key]?.(source);\nconst cb = (t) => assert.ok(t.includes('x'));",
+  ]) {
+    assert.equal(
+      flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+${body}
+`),
+      true,
+      `optional call escaped: ${body}`,
+    );
+  }
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -421,6 +421,18 @@ test('a marker that excuses nothing is still an unused marker', () => {
   // ending in `/`, and truncating at the `//` of a URL leaves it ending in `:`.
   // Both are accepted by `CONTINUES`, so both let the marker reach further --
   // a per-line stripper made the gate WORSE on them, not merely no better.
+  // Those two are also the only entries that DISCRIMINATE: restore the old
+  // per-line stripper and only they go red. The other four stay green under
+  // that mutation and are here as coverage, not as a pin.
+  //
+  // A bare ` */` used to be in this list and was REMOVED, which is a loosening
+  // and so belongs on the record rather than in a commit message. An orphan
+  // `*/` has no opener, so `stripComments` leaves it whole, it ends in `/`,
+  // and the marker now reaches ACROSS it -- excusing a predicate and marking
+  // itself used, both halves silent. It is dropped because no valid JS puts a
+  // bare `*/` on the walk path (a real one always has an opener above, and the
+  // balanced case below is handled), not because the gate holds there. If
+  // `stripComments` ever learns to handle unbalanced blocks, this is open.
   for (const separator of [
     '// Arrange:',
     '// ------------------',

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -32,7 +32,7 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { analyze } from './source-text-assertion-detect.mjs';
+import { analyze, blankStrings, stripComments } from './source-text-assertion-detect.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const GATE = join(ROOT, 'scripts', 'check-source-text-assertions.mjs');
@@ -319,4 +319,135 @@ test('the narrowing kept every file the flat detector flagged', () => {
       `${rel} was detected by the flat check and must still be detected`,
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// Two silent UNDER-detections, both found by review of the narrowing above.
+// A gate that stops seeing is worse than one that never looked: it reports
+// "no source-text assertion here" for a file that still has one, and the next
+// person deletes its allowlist row.
+// ---------------------------------------------------------------------------
+
+test('a quote inside a REGEX LITERAL does not blank the rest of the file', () => {
+  // `blankStrings` knew about strings and template interpolation but not about
+  // regex literals, so the `"` in `/["']/` opened a string that never closed
+  // and every assertion after it became invisible. Both halves are asserted:
+  // the assertion BEFORE the regex, which always worked, and the one AFTER it.
+  assert.equal(flagged(`
+    import { readFileSync } from 'node:fs';
+    const src = readFileSync('a/b.ts', 'utf8');
+    const QUOTED = /["']/;
+    it('x', () => { expect(src).toContain('token'); });
+  `), true);
+});
+
+test('a regex literal holding a quote is still blanked, not read as code', () => {
+  // The other direction of the regex fix. This file DOES read a source file and
+  // DOES contain a predicate spelling, so it reaches `blankStrings` and would be
+  // flagged if the regex body were scanned as code -- the earlier version of
+  // this test had no read, so `analyze` returned at the `READS_A_FILE` guard
+  // before `blankStrings` ran, and it passed for three unrelated reasons.
+  assert.equal(flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+const RE = /source\\.includes\\(['"]/;
+it('x', () => { expect(RE.source).toBe('literal'); });
+`), false);
+});
+
+test('a DOTTED read starts taint, like a bare one', () => {
+  // `valueIdentifiers` drops any name preceded by `.`, so `fs.readFileSync(p)`
+  // yielded `{fs, p}` and taint never started. `READS_A_FILE` still matched, so
+  // the file was ANALYSED rather than skipped and the answer was a confident
+  // `flagged: false`. Namespaced reads are the ordinary spelling in this repo.
+  assert.equal(flagged(`
+    import fs from 'node:fs';
+    const src = fs.readFileSync('a/b.ts', 'utf8');
+    it('x', () => { expect(src).toContain('token'); });
+  `), true);
+});
+
+test('an awaited namespaced read starts taint too', () => {
+  assert.equal(flagged(`
+    import fsp from 'node:fs/promises';
+    const src = await fsp.readFile('a/b.ts', 'utf8');
+    it('x', () => { expect(src).toContain('token'); });
+  `), true);
+});
+
+test('a file with no read at all is still not flagged', () => {
+  // The control for both fixes above. Neither may be satisfiable by flagging
+  // everything: a predicate applied to a literal is not a source-text
+  // assertion, and that is the whole point of the narrowing.
+  assert.equal(flagged(`
+    const src = 'a literal, not a file';
+    it('x', () => { expect(src).toContain('token'); });
+  `), false);
+});
+
+test('a marker excuses a WRAPPED assertion, written as the gate prints it', () => {
+  // The remedy `check-source-text-assertions.mjs` prints puts the marker above
+  // `assert.ok(...)`. On a wrapped call the predicate is two lines below it, so
+  // the marker excused nothing AND was reported unused: CI failed twice and the
+  // printed fix did not work. A remedy an instrument prints must be one the
+  // instrument accepts.
+  const r = analyze(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+// @source-text-assertion-ok anchor guard, not a subject assertion
+assert.ok(
+  source.includes(anchor),
+  \`anchor drifted\`,
+);
+`);
+  assert.equal(r.flagged, false);
+  assert.equal(r.marked.length, 1);
+  assert.deepEqual(r.unusedMarkers, []);
+});
+
+test('a marker that excuses nothing is still an unused marker', () => {
+  // The control for the widening above. Reaching further up must not turn the
+  // marker into a blanket exemption: one attached to unrelated code still has
+  // to be reported, or "marked sites stay named" stops being true.
+  // The separator matters. `const unrelated = 1;` ends in `;`, which the walk
+  // already rejects, so it certified nothing. A COMMENT is the case that broke
+  // it: `CONTINUES` contains `*`, `/`, `:` and `-`, so an ordinary `// Arrange:`
+  // or this repo's own `// -----` separator read as a continuation and let a
+  // stale marker reach an unrelated predicate -- while ALSO marking it used, so
+  // the dead-marker check went quiet.
+  for (const separator of ['// Arrange:', '// ------------------', '// see https://x/', ' */']) {
+    const r = analyze(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+// @source-text-assertion-ok nothing here to excuse
+${separator}
+it('x', () => { expect(source).toContain('token'); });
+`);
+    assert.equal(r.flagged, true, `separator ${separator} let a stale marker through`);
+    assert.equal(r.unusedMarkers.length, 1, `separator ${separator} hid the unused marker`);
+  }
+});
+
+test('a JSX closing tag does not open a regex', () => {
+  // `</Foo>` puts `<` directly before the slash. Accepting `<` as a regex
+  // preceder made every closing tag open one, and on a line with a second `/`
+  // the span swallowed an opening quote and blanked the rest of the FILE --
+  // the exact whole-file desync the regex handling was added to remove.
+  assert.equal(flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+render(<Foo trigger={<button>Open</button>} src="img/x.png" />);
+assert.ok(source.includes('handleRowClick'));
+`), true);
+});
+
+test('division after ++ is not read as a regex', () => {
+  // Asserted on the BLANKING, not on `flagged`. The first version of this test
+  // checked `flagged` with the assertion on a different line, so the corruption
+  // never reached the verdict and it passed with the bug live: `a++ / b) / c`
+  // blanked to `(a++        c;`, eating the `)` and unbalancing every
+  // paren-matching read downstream. Two slashes on one line, so the
+  // unterminated-literal fallback does not save it.
+  const line = 'const r = (a++ / b) / c;';
+  assert.equal(blankStrings(stripComments(line)), line);
 });

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -486,3 +486,97 @@ test('division after ++ is not read as a regex', () => {
   const line = 'const r = (a++ / b) / c;';
   assert.equal(blankStrings(stripComments(line)), line);
 });
+
+// ---------------------------------------------------------------------------
+// 6. Fail-open holes CodeRabbit found on the PR head, and their siblings.
+//    All five are the dangerous direction: the gate going SILENT on a real
+//    source-text assertion, which is indistinguishable from a clean file.
+
+test('a `//` inside a STRING does not blank the rest of the file', () => {
+  // Comments were stripped by a regex that could not see strings, so
+  // `'see // the docs'` truncated to an unterminated quote and the string
+  // lexer blanked everything after it. No marker involved: the assertion two
+  // lines down simply became invisible and the file reported clean.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+const doc = 'see // the docs';
+assert.ok(source.includes('token'));
+`),
+    true,
+  );
+});
+
+test('a marker inside a STRING LITERAL excuses nothing', () => {
+  // Markers were matched against RAW lines, so any string containing the
+  // marker text suppressed a real finding. A string is not a comment.
+  const r = analyze(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+const doc = 'write @source-text-assertion-ok fake to suppress';
+assert.ok(source.includes('token'));
+`);
+  assert.equal(r.flagged, true, 'a string suppressed a real finding');
+  assert.deepEqual(r.marked, [], 'a string was accepted as a marker');
+});
+
+test('a REAL comment marker still excuses, so the fix is not a blanket refusal', () => {
+  // The control for the two above. Without it, deleting marker support
+  // entirely would pass them both.
+  const r = analyze(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+// @source-text-assertion-ok anchor guard
+assert.ok(source.includes('token'));
+`);
+  assert.equal(r.flagged, false);
+  assert.equal(r.marked.length, 1);
+});
+
+test('an iteration callback carries the bytes one element at a time', () => {
+  // `source.split('\n').some((line) => line.includes(x))` reads a file and
+  // asserts on its text, but no tainted NAME appears inside the callback, so
+  // the predicate looked like it applied to a clean parameter.
+  for (const body of [
+    "assert.ok(source.split('\\n').some((line) => line.includes('x')));",
+    "const hit = (line) => line.includes('x');\nassert.ok(source.split('\\n').some(hit));",
+    "for (const line of source.split('\\n')) { assert.ok(line.includes('x')); }",
+  ]) {
+    assert.equal(
+      flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+${body}
+`),
+      true,
+      `this shape escaped the detector: ${body}`,
+    );
+  }
+});
+
+test('a path loop is not tainted just because the path list is', () => {
+  // The bound on the rule above. `files` IS tainted here -- it is derived from
+  // a tainted value, and this analysis has no way to know the derivation
+  // produced PATHS rather than contents. Tainting every `for..of` whose
+  // iterable carries file bytes therefore also taints `file`, and
+  // `file.endsWith('.ts')` becomes a false hit: measured as 4 of them in
+  // apps/viewer/src/components/viewer/toolbar-parity.test.ts, whose line 323
+  // is exactly `for (const file of files)`.
+  //
+  // Nothing lexical separates a tainted array of lines from a tainted array of
+  // filenames, so the rule takes only the `.split(` it can prove. Widen it and
+  // this reds.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const root = readFileSync('cfg.json', 'utf8');
+const files = walk(root);
+for (const file of files) {
+  assert.ok(file.endsWith('.test.ts'));
+}
+`),
+    false,
+    'a loop over PATHS derived from file bytes was read as a source-text assertion',
+  );
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -662,3 +662,72 @@ for (const line of other.split(sep) || src) { assert.ok(line.includes('y')); }
     true,
   );
 });
+
+// ---------------------------------------------------------------------------
+// 7. Review-bot findings on #3116. All four were silent under-detection, and
+//    each has a control that behaved correctly before the fix, so the fixture
+//    distinguishes the bug from the shape.
+
+test('a single arrow parameter needs no parentheses', () => {
+  // `fnRe` required a `(`, so `const check = src => …` registered no function
+  // and the call site never tainted `src`, while `(src) => …` was caught.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+const check = src => src.includes('x');
+assert.ok(check(source));
+`),
+    true,
+  );
+});
+
+test('a regex as an unbraced control body is not division', () => {
+  // `)` is not a regex-preceder, because `(a + b) / c` IS division. But an
+  // unbraced `if` body can be a regex expression statement, and reading that as
+  // division let the `"` open a string that never closed.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+if (ok) /["']/.test(value);
+assert.ok(source.includes('tok'));
+`),
+    true,
+  );
+  // The control: a genuine division after `)` must stay division.
+  assert.equal(blankStrings('const q = (1 + 2) / 3;'), 'const q = (1 + 2) / 3;');
+});
+
+test('a helper whose name contains $ is still followed', () => {
+  // `$` is legal in a JS identifier and is NOT a word character, so `\b` never
+  // matched in front of a leading `$`: `$read(x)` yielded `read`, which is not
+  // in the tainted set. `a.$b` lost its dot marker the same way, turning a
+  // property into a value.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+function $read(p) { return readFileSync(p, 'utf8'); }
+const s2 = $read('a.ts');
+assert.ok(s2.includes('x'));
+`),
+    true,
+  );
+});
+
+test('taint propagation is not cut short by a fixed pass cap', () => {
+  // Bindings declared in REVERSE order resolve one link per pass, so a fixed
+  // cap of 8 stopped an eight-link chain and reported a clean file. The bound
+  // is now derived from the input, which it cannot need to exceed.
+  const links = 12;
+  const chain = Array.from({ length: links }, (_, i) => `const v${links - i} = v${links - i - 1};`);
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+${chain.join('\n')}
+const v0 = readFileSync('a.ts', 'utf8');
+assert.ok(v${links}.includes('x'));
+`),
+    true,
+  );
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -808,3 +808,31 @@ ${body}
     );
   }
 });
+
+test('a quoted string cannot cross a line', () => {
+  // The string state ended only on the matching quote, so ONE unpaired `'` or
+  // `"` kept the lexer inside a string until the next quote anywhere later in
+  // the file. Both views were blanked across that whole span, and every read,
+  // filename literal and predicate inside it disappeared.
+  assert.equal(
+    blankStrings("const bad = ';\nconst keep = 1;\nconst z = ';"),
+    "const bad = ' \nconst keep = 1;\nconst z = ' ",
+    'an unpaired quote swallowed the following lines',
+  );
+  // A template literal MAY span lines, so it must still be blanked across them.
+  assert.equal(blankStrings('const t = `a\nb`;'), 'const t = ` \n `;');
+});
+
+test('a $-leading callback parameter is tainted', () => {
+  // `\b` cannot match in front of a leading `$`, so the arrow-parameter pattern
+  // captured `line` out of `$line` and the real name stayed clean. Same failure
+  // as `valueIdentifiers` and `callRe`, in the third place it appears.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+assert.ok(source.split('x').some($line => $line.includes('y')));
+`),
+    true,
+  );
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -624,3 +624,41 @@ assert.ok(source.split('\\n').some(function (line) { return line.includes('x'); 
     true,
   );
 });
+
+test('division BY a regex literal does not desync the lexer', () => {
+  // The blanked view keeps a regex's opening `/`. Blanking the literal whole
+  // made the following division look back PAST it to the `=`, call itself a
+  // regex, run forward into the next string for its "closing" slash, and blank
+  // the rest of the file. Nonsense code, but the failure is silence, and the
+  // guard costs one character.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+const n = /a/ / b; const s = 'q/w';
+assert.ok(source.includes('tok'));
+`),
+    true,
+  );
+});
+
+test('the for-of iterable keeps its last character', () => {
+  // `matchParen` returns the index OF the `)`, not just past it -- its
+  // docstring said the opposite and this code trusted the docstring, so an
+  // extra `- 1` chopped the iterable's final character.
+  //
+  // The tainted name is LAST here on purpose. The first version of this test
+  // used `(src).split('\\n')`, where chopping the trailing `)` still left
+  // `src` in the slice, so it passed with the bug live -- a fixture that could
+  // not fail. Chopping `|| src` to `|| sr` loses the only tainted name.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const src = readFileSync('a/b.ts', 'utf8');
+const sep = 'x';
+const other = '';
+for (const line of other.split(sep) || src) { assert.ok(line.includes('y')); }
+`),
+    true,
+  );
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -415,7 +415,20 @@ test('a marker that excuses nothing is still an unused marker', () => {
   // or this repo's own `// -----` separator read as a continuation and let a
   // stale marker reach an unrelated predicate -- while ALSO marking it used, so
   // the dead-marker check went quiet.
-  for (const separator of ['// Arrange:', '// ------------------', '// see https://x/', ' */']) {
+  //
+  // The last two are why the walk reads `stripComments` output rather than a
+  // per-line stripper of its own: a TRAILING block comment leaves the line
+  // ending in `/`, and truncating at the `//` of a URL leaves it ending in `:`.
+  // Both are accepted by `CONTINUES`, so both let the marker reach further --
+  // a per-line stripper made the gate WORSE on them, not merely no better.
+  for (const separator of [
+    '// Arrange:',
+    '// ------------------',
+    '// see https://x/',
+    '/** a balanced block */',
+    'const unrelated = 1; /* trailing block */',
+    'const url = "http://x";',
+  ]) {
     const r = analyze(`
 import { readFileSync } from 'node:fs';
 const source = readFileSync('a/b.ts', 'utf8');

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -580,3 +580,47 @@ for (const file of files) {
     'a loop over PATHS derived from file bytes was read as a source-text assertion',
   );
 });
+
+test('a regex directly after a block comment does not blank the file', () => {
+  // `regexLiteralEnd` decides regex-vs-division from the previous significant
+  // character. Reading that from RAW text puts the `/` of a preceding `*/` in
+  // front of the literal, so `/["']/` read as division, the `"` opened a
+  // string that never closed, and everything below went invisible. The
+  // backward scan therefore reads the output-so-far, where comments are
+  // already spaces. Route the lookback back through raw text and this reds.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+const a = 1; /* c */ /["']/.test(z);
+assert.ok(source.includes('tok'));
+`),
+    true,
+  );
+});
+
+test('a call chained before .split does not hide the loop', () => {
+  // The iterable is read to the `)` MATCHING the for-header's `(`. Capturing
+  // it with `[^)]*` stopped inside `source.trim().split('\n')` at the `)` of
+  // `trim(`, so the `.split(` was never seen.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+for (const line of source.trim().split('\\n')) { assert.ok(line.includes('x')); }
+`),
+    true,
+  );
+});
+
+test('an anonymous function callback carries taint like an arrow', () => {
+  // Same flow, different spelling. Matching only `=>` left it undetected.
+  assert.equal(
+    flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('a/b.ts', 'utf8');
+assert.ok(source.split('\\n').some(function (line) { return line.includes('x'); }));
+`),
+    true,
+  );
+});

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -108,20 +108,21 @@ const REGEX_PRECEDING_WORDS = /(?:^|[^A-Za-z0-9_$])(return|typeof|instanceof|cas
  * The division-vs-regex question is decided by the previous significant
  * character. That is the standard heuristic and it is APPROXIMATE, not sound;
  * measured against the TypeScript parser over the scanned corpus it disagrees
- * on a handful of lines, none of which currently changes a verdict. The
- * lookback reads `back` rather than raw source precisely so that comments,
- * already blanked by the single pass, cannot supply that previous character.
+ * on a handful of lines, none of which currently changes a verdict.
  * A `[...]` class is tracked, since `/` inside one is literal, and an
  * unterminated literal (no closing `/` before the line ends) is treated as
  * division rather than swallowing the rest of the file.
  */
-function regexLiteralEnd(src, start, back = src) {
+function regexLiteralEnd(src, start, back) {
   // The BACKWARD scan reads `back`, which is the output-so-far with comments
   // already blanked, while the forward scan reads raw `src`. They must differ:
   // looking back over raw text puts the `/` of a preceding `*/` in front of
   // the literal, so `const a = 1; /* c */ /["']/.test(z)` reads as DIVISION,
   // the `"` opens a string that never closes, and the rest of the file is
   // blanked -- a silent fail-open. Comments blank to spaces, which this skips.
+  // `back` is REQUIRED rather than defaulting to `src`: a default would let a
+  // future two-argument call silently restore that bug, and absence should not
+  // read as success.
   let k = start - 1;
   while (k >= 0 && (back[k] === ' ' || back[k] === '\t')) k--;
   const prev = k >= 0 ? back[k] : '';
@@ -135,9 +136,7 @@ function regexLiteralEnd(src, start, back = src) {
   // `a++ / b` and `a-- / b` are division, so a doubled `+`/`-` is excluded even
   // though a single one is a legitimate preceder (`a + /re/.test(b)`).
   const doubled = (prev === '+' || prev === '-') && back[k - 1] === prev;
-  const wordSpan = Array.from({ length: k + 1 - Math.max(0, k - 12) }, (_, n) =>
-    back[Math.max(0, k - 12) + n],
-  ).join('');
+  const wordSpan = back.slice(Math.max(0, k - 12), k + 1).join('');
   const isRegex =
     !doubled
     && (prev === ''
@@ -518,8 +517,11 @@ function computeTainted(blanked) {
       // at the `)` of `trim(`, so the `.split(` below was never seen and the
       // loop body read as clean -- the silent direction.
       const header = blanked.indexOf('(', m.index);
+      // No emptiness guard here on purpose: an empty or inverted range slices
+      // to '', which fails the `.split(` test below and adds no taint -- the
+      // same outcome, without a line that reads as a guard while guarding
+      // nothing. Verified on `for (const x of ) {}` and an unclosed header.
       const iterEnd = matchParen(blanked, header);
-      if (iterEnd <= m.index + m[0].length) continue;
       // Deliberately narrow to a SPLIT of tainted text. Tainting on
       // `carriesFileBytes` alone also catches `for (const file of files)`
       // where the elements are PATHS, not contents -- measured as 4 false hits
@@ -592,11 +594,13 @@ const CONTINUES = /(?:[([,]|=>|&&|\|\||[-+*/%?:]|=)\s*$/;
  * both halves of the gate wrong at once.
  *
  * `stripComments` is now string-aware (it is one view of the single lexing
- * pass), so a `//` inside a string no longer truncates the line: measured
- * across the scanned corpus, NO file's stripped view differs in length from
- * the original. `name: '///'`, `'https://x/y'` and `'see // docs'` all keep
- * their trailing `;` and correctly stop the walk. The earlier per-line
- * stripper got each of those wrong in the fail-open direction.
+ * pass), so a `//` inside a string no longer truncates the line: `name: '///'`,
+ * `'https://x/y'` and `'see // docs'` all keep their trailing `;` and correctly
+ * stop the walk, where the earlier per-line stripper got each of them wrong in
+ * the fail-open direction. (Do not restate that as "no file's stripped view
+ * differs in LENGTH from the original". That holds for ANY input, because this
+ * pass blanks to spaces and never deletes, so it stays true with the
+ * string-awareness removed. It measures the blanking, not the fix.)
  *
  * The 24-line bound is a POLICY cap on how far a marker may reach, not a
  * runaway guard -- the walk terminates on its own, because `codeLines[top - 2]`
@@ -644,11 +648,12 @@ export function analyze(original) {
     return { ...empty, unusedMarkers: [...markerLines.keys()] };
   }
 
-  // The SAME pass that produced `stripped`, not a second lex of it. Re-lexing
-  // comment-blanked text is not equivalent: blanking a comment changes the
-  // character `regexLiteralEnd` looks back at, so `x = (/* c */ /re/.test(y))`
-  // loses the whole regex on the two-pass route. Keeping one pass is the point
-  // of `lexViews`.
+  // The SAME pass that produced `stripped`, not a second lex of it. The two
+  // routes now agree (they did NOT before the `back` lookback landed, which is
+  // what an earlier version of this comment recorded), so this is duplicated
+  // work rather than a correctness trap -- but one pass is the point of
+  // `lexViews`, and re-lexing its own output invites the ordering hazards it
+  // exists to remove.
   const blanked = views.blanked;
   const tainted = computeTainted(blanked);
 

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -102,6 +102,38 @@ const REGEX_PRECEDERS = new Set([
 const REGEX_PRECEDING_WORDS = /(?:^|[^A-Za-z0-9_$])(return|typeof|instanceof|case|in|of|delete|void|new|do|else|yield|await)$/;
 
 /**
+ * TRUE when the `)` at `end` closes an `if (…)` / `for (…)` / `while (…)` style
+ * HEADER rather than a parenthesised expression.
+ *
+ * `)` is not a regex-preceder, because `(a + b) / c` is division. But an
+ * unbraced control body can be a regex expression statement:
+ *
+ *     if (ok) /["']/.test(value);
+ *
+ * There the `/` starts a literal, and reading it as division let the `"` open a
+ * string that never closed, blanking the rest of the file -- the gate then
+ * reported a clean file. Distinguishing the two needs the token before the
+ * MATCHING `(`, so this walks back to it.
+ */
+function closesAControlHeader(back, end) {
+  if (back[end] !== ')') return false;
+  let depth = 0;
+  let j = end;
+  for (; j >= 0; j--) {
+    if (back[j] === ')') depth++;
+    else if (back[j] === '(') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  if (j < 0) return false;
+  let w = j - 1;
+  while (w >= 0 && (back[w] === ' ' || back[w] === '\t')) w--;
+  const span = back.slice(Math.max(0, w - 8), w + 1).join('');
+  return /(?:^|[^A-Za-z0-9_$])(if|for|while|switch|catch|with)$/.test(span);
+}
+
+/**
  * If `src[start]` opens a regex literal, the index just PAST it (flags
  * included); otherwise `start`, meaning "this `/` is division".
  *
@@ -141,7 +173,8 @@ function regexLiteralEnd(src, start, back) {
     !doubled
     && (prev === ''
       || REGEX_PRECEDERS.has(prev)
-      || REGEX_PRECEDING_WORDS.test(wordSpan));
+      || REGEX_PRECEDING_WORDS.test(wordSpan)
+      || closesAControlHeader(back, k));
   if (!isRegex) return start;
 
   let i = start + 1;
@@ -306,7 +339,14 @@ export function stripComments(source) {
 /** Identifiers in `expr` at value position: property names after `.` excluded. */
 function valueIdentifiers(expr) {
   const names = new Set();
-  const re = /(\.?)\s*\b([A-Za-z_$][\w$]*)\b/g;
+  // NOT `\b` before the name. `$` is legal in a JS identifier and is not a word
+  // character, so `\b` never matches in front of a LEADING `$`: `$read(x)`
+  // yielded `read`, which matches nothing in the tainted set, and `a.$b` yielded
+  // `b` with the dot marker lost, so a property was read as a value. Both are
+  // silent. An explicit "not preceded by an identifier character" assertion
+  // handles `$`, and the trailing `\b` is unnecessary because the class is
+  // greedy.
+  const re = /(\.?)\s*(?<![\w$])([A-Za-z_$][\w$]*)/g;
   let m;
   while ((m = re.exec(expr)) !== null) {
     if (m[1] === '.') continue;
@@ -425,6 +465,12 @@ function computeTainted(blanked) {
   const fns = [];
   const fnRe =
     /\bfunction\s*\*?\s*([A-Za-z_$][\w$]*)?\s*\(|\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:function\s*\*?\s*[A-Za-z_$\w$]*\s*)?\(/g;
+  // A single arrow parameter needs no parentheses, and requiring the `(` above
+  // meant `const check = src => src.includes(x)` registered no function at all:
+  // the call site never tainted `src`, and the equivalent `(src) =>` spelling
+  // was caught while this one went silent.
+  const bareArrowRe =
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?([A-Za-z_$][\w$]*)\s*=>/g;
   while ((m = fnRe.exec(blanked)) !== null) {
     const open = blanked.lastIndexOf('(', fnRe.lastIndex);
     const close = matchParen(blanked, open);
@@ -457,8 +503,27 @@ function computeTainted(blanked) {
     }
     fns.push({ name: m[1] || m[2], params, body, concise });
   }
+  while ((m = bareArrowRe.exec(blanked)) !== null) {
+    const arrow = blanked.indexOf('=>', m.index) + 2;
+    const braced = /^\s*\{/.test(blanked.slice(arrow));
+    const bodyStart = braced ? blanked.indexOf('{', arrow) : arrow;
+    fns.push({
+      name: m[1],
+      params: [m[2]],
+      body: braced
+        ? blanked.slice(bodyStart, matchParen(blanked, bodyStart) + 1)
+        : blanked.slice(arrow, statementEnd(blanked, arrow)),
+      concise: !braced,
+    });
+  }
 
-  for (let pass = 0; pass < 8; pass++) {
+  // Each pass that changes anything adds at least one name, and names come from
+  // the file, so `bindings.length + fns.length + 2` is an upper bound the loop
+  // cannot need to exceed -- it is a runaway guard, not a policy. The old fixed
+  // 8 WAS reachable: a chain declared in reverse order resolves one link per
+  // pass, so eight links exhausted it and `analyze` reported a clean file.
+  const maxPasses = bindings.length + fns.length + 2;
+  for (let pass = 0; pass < maxPasses; pass++) {
     const before = tainted.size;
     for (const b of bindings) {
       if (carriesFileBytes(b.rhs)) for (const n of b.names) tainted.add(n);
@@ -472,7 +537,10 @@ function computeTainted(blanked) {
       }
       // A tainted argument taints the parameter it lands in.
       if (!fn.name || fn.params.length === 0) continue;
-      const callRe = new RegExp(`\\b${fn.name}\\s*\\(`, 'g');
+      // `$` is legal in a JS identifier AND is a regex anchor, so `$read` built
+      // a pattern that could never match and the helper's parameter taint was
+      // lost with no signal. Escape before interpolating.
+      const callRe = new RegExp(`\\b${fn.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\(`, 'g');
       let call;
       while ((call = callRe.exec(blanked)) !== null) {
         const open = callRe.lastIndex - 1;

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -57,8 +57,10 @@
  *     // @source-text-assertion-ok mutation anchor guard, not a subject assertion
  *     assert.ok(source.includes(from), `anchor not found: ${from}`);
  *
- * The marker suppresses the predicate on its own line or the line immediately
- * below, must carry a reason, and a marker that suppresses nothing is an error
+ * The marker suppresses the predicate on its own line, or anywhere from the
+ * first line of the enclosing assertion upward by one -- a wrapped
+ * `assert.ok(\n  source.includes(x),\n)` puts the predicate below the line the
+ * marker sits above, and the remedy this gate prints assumes that works
  * — same ratchet discipline as the allowlist. The decision stays a grep-able
  * line in the diff, which a structural carve-out never would be.
  */
@@ -96,6 +98,67 @@ const CLOSERS = ')]}';
  * and `${…}` interpolations. Length preservation is load-bearing: every index
  * computed on the blanked text is used against the original.
  */
+/** Characters after which a `/` begins a REGEX rather than a division. */
+const REGEX_PRECEDERS = new Set([
+  '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '~', '^', '>', '\n',
+]);
+
+/** Keywords after which a `/` begins a regex (`return /re/.test(x)`). */
+const REGEX_PRECEDING_WORDS = /(?:^|[^A-Za-z0-9_$])(return|typeof|instanceof|case|in|of|delete|void|new|do|else|yield|await)$/;
+
+/**
+ * If `src[start]` opens a regex literal, the index just PAST it (flags
+ * included); otherwise `start`, meaning "this `/` is division".
+ *
+ * The division-vs-regex question is decided by the previous significant
+ * character. That is the standard heuristic and it is APPROXIMATE, not sound:
+ * `stripComments` runs first but is string-unaware, so a `//` inside a string
+ * literal (`'file:///x'`) truncates the line and can leave this looking at the
+ * wrong character. Measured against the TypeScript parser over the scanned
+ * corpus, it disagrees on a handful of lines, none of which currently changes a
+ * verdict. A `[...]` class is tracked, since `/` inside one is literal, and an
+ * unterminated literal (no closing `/` before the line ends) is treated as
+ * division rather than swallowing the rest of the file.
+ */
+function regexLiteralEnd(src, start) {
+  let k = start - 1;
+  while (k >= 0 && (src[k] === ' ' || src[k] === '\t')) k--;
+  const prev = k >= 0 ? src[k] : '';
+  // `<` is deliberately NOT a preceder. `</Foo>` puts one directly before the
+  // slash, and these files are `.tsx`: accepting it made every JSX closing tag
+  // open a "regex", which on a line with a second `/` swallowed the opening
+  // quote and desynced the scanner for the rest of the FILE. That is the exact
+  // whole-file blanking this function exists to prevent, reintroduced by the
+  // fix for it. `>` has to stay, because it carries `=>`.
+  //
+  // `a++ / b` and `a-- / b` are division, so a doubled `+`/`-` is excluded even
+  // though a single one is a legitimate preceder (`a + /re/.test(b)`).
+  const doubled = (prev === '+' || prev === '-') && src[k - 1] === prev;
+  const isRegex =
+    !doubled
+    && (prev === ''
+      || REGEX_PRECEDERS.has(prev)
+      || REGEX_PRECEDING_WORDS.test(src.slice(Math.max(0, k - 12), k + 1)));
+  if (!isRegex) return start;
+
+  let i = start + 1;
+  let inClass = false;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '\n') return start; // unterminated: it was division after all
+    if (c === '\\') { i += 2; continue; }
+    if (c === '[') inClass = true;
+    else if (c === ']') inClass = false;
+    else if (c === '/' && !inClass) {
+      i++;
+      while (i < src.length && /[a-z]/.test(src[i])) i++; // flags
+      return i;
+    }
+    i++;
+  }
+  return start;
+}
+
 export function blankStrings(src) {
   const out = src.split('');
   const stack = [];
@@ -128,6 +191,20 @@ export function blankStrings(src) {
       stack.push({ kind: 'str', quote: c });
       i++;
       continue;
+    }
+    // A REGEX LITERAL is the third thing that can hold a quote. Without this,
+    // `/["']/` opened a string that never closed and blanked the rest of the
+    // FILE, so every assertion after it became invisible and the gate reported
+    // "no source-text assertion" for a file that still had several. That is
+    // silent UNDER-detection, the opposite of the direction this detector's
+    // docblock says it errs in.
+    if (c === '/') {
+      const end = regexLiteralEnd(src, i);
+      if (end > i) {
+        for (let k = i; k < end; k++) if (src[k] !== '\n') out[k] = ' ';
+        i = end;
+        continue;
+      }
     }
     if (top && top.kind === 'interp') {
       if (OPENERS.includes(c)) top.depth++;
@@ -244,6 +321,15 @@ function receiverStart(blanked, dot) {
 function computeTainted(blanked) {
   const tainted = new Set(['readFileSync', 'readFile']);
   const refersToTainted = (expr) => {
+    // A READ is a read however it is spelled. `valueIdentifiers` drops any name
+    // preceded by `.`, so `fs.readFileSync(p)` yielded `{fs, p}` and taint never
+    // started -- `READS_A_FILE` still matched, so the file was ANALYSED rather
+    // than skipped, the taint set stayed empty, and the answer was
+    // `flagged: false`. Namespaced reads are the ordinary spelling in this repo
+    // and `await fsp.readFile(...)` failed the same way, so the gate was blind
+    // to both. Seeding from the same pattern that decides whether to analyse at
+    // all stops the two from disagreeing.
+    if (READS_A_FILE.test(expr)) return true;
     for (const name of valueIdentifiers(expr)) if (tainted.has(name)) return true;
     return false;
   };
@@ -369,6 +455,62 @@ function splitArgs(text) {
  *             marked: Array<{line: number, reason: string}>,
  *             unusedMarkers: number[] }}
  */
+/** A line is a continuation of the one below it when it ends mid-expression. */
+const CONTINUES = /(?:[([,]|=>|&&|\|\||[-+*/%?:]|=)\s*$/;
+
+/**
+ * `line` with any trailing `//` comment removed, so {@link CONTINUES} is asked
+ * about CODE rather than prose.
+ *
+ * Without this the walk was defeated by an ordinary comment: `CONTINUES`
+ * contains `*`, `/`, `:` and `-`, so `// Arrange:`, `// see https://x/`, a
+ * JSDoc ` *` line and this repo's own `// ------` separators all read as
+ * continuations. A stale marker then reached across them to excuse an unrelated
+ * predicate AND was recorded as used, so the dead-marker check went quiet too:
+ * both halves of the gate wrong at once.
+ *
+ * A `//` inside a string (`'file:///x'`) is truncated here as well, which makes
+ * the line look like a NON-continuation. That direction is safe: the marker is
+ * not accepted, so the predicate is reported rather than silently excused.
+ */
+function codeOf(line) {
+  const at = line.indexOf('//');
+  const code = (at === -1 ? line : line.slice(0, at)).trim();
+  // A BLOCK-comment fragment carries no code either, and ` */` is the one that
+  // bites: it ends in `/`, which `CONTINUES` accepts, so a JSDoc block above a
+  // stale marker read as one long continuation.
+  if (code.startsWith('*') || code.startsWith('/*')) return '';
+  return code;
+}
+
+/**
+ * The line carrying the marker that excuses a predicate on `line`, or `null`.
+ *
+ * A marker sits immediately above the ASSERTION, and the assertion may be
+ * wrapped over several lines, so the predicate is not always on the line the
+ * marker is above. This walks up over continuation lines to the statement's
+ * first line and allows the marker anywhere from just above that down to the
+ * predicate itself.
+ *
+ * The 24-line bound is a runaway guard, not a policy: a statement longer than
+ * that is already unreadable, and the previous bound of 8 was small enough that
+ * a legitimately long wrapped assertion fell out the other side and hit the
+ * double failure this exists to remove.
+ */
+function markerLineFor(markerLines, rawLines, line) {
+  if (markerLines.has(line)) return line;
+  let top = line;
+  for (let n = 0; n < 24; n++) {
+    const above = codeOf(rawLines[top - 2] ?? '');
+    if (!CONTINUES.test(above)) break;
+    top -= 1;
+  }
+  for (let candidate = line - 1; candidate >= top - 1; candidate--) {
+    if (markerLines.has(candidate)) return candidate;
+  }
+  return null;
+}
+
 export function analyze(original) {
   const stripped = stripComments(original);
   const empty = { flagged: false, hits: [], marked: [], unusedMarkers: [] };
@@ -408,8 +550,23 @@ export function analyze(original) {
     }
     if (!hit) continue;
     const line = lineOf(dot);
-    // A marker excuses the predicate on its own line or the line below it.
-    const markerLine = markerLines.has(line) ? line : markerLines.has(line - 1) ? line - 1 : null;
+    // A marker excuses the predicate on its own line, or on any line from the
+    // start of the enclosing statement to just above it.
+    //
+    // "The line above" alone was wrong for a WRAPPED assertion, which is the
+    // prevailing style in the files this gate actually reports. Written exactly
+    // as `check-source-text-assertions.mjs` prints the remedy:
+    //
+    //     // @source-text-assertion-ok anchor guard
+    //     assert.ok(
+    //       source.includes(anchor),
+    //     );
+    //
+    // the predicate is on the THIRD line and the marker on the first, so the
+    // marker excused nothing AND was then reported as unused: CI failed twice
+    // and the printed fix did not work. A remedy an instrument prints has to be
+    // one the instrument accepts.
+    const markerLine = markerLineFor(markerLines, rawLines, line);
     if (markerLine !== null && markerLines.get(markerLine)) {
       usedMarkers.add(markerLine);
       marked.push({ line, reason: markerLines.get(markerLine) });

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -255,7 +255,13 @@ function lexViews(src) {
     if (c === '/') {
       const end = regexLiteralEnd(src, i, blanked);
       if (end > i) {
-        for (let k = i; k < end; k++) if (src[k] !== '\n') blanked[k] = ' ';
+        // Keep the OPENING `/` in the blanked view. Blanking a literal whole
+        // makes the next `/` look back past it to whatever preceded the
+        // literal: in `const n = /a/ / b; const s = 'q/w';` the division saw
+        // `=`, called itself a regex, ran forward into the `'q/w'` string for
+        // its "closing" slash, and blanked the rest of the file. A surviving
+        // `/` is not a regex-preceder, so the division is read as division.
+        for (let k = i + 1; k < end; k++) if (src[k] !== '\n') blanked[k] = ' ';
         i = end;
         continue;
       }
@@ -333,7 +339,7 @@ function statementEnd(blanked, start) {
   return blanked.length;
 }
 
-/** Index just past the `)` matching the `(` at `open`. */
+/** Index OF the `)` matching the `(` at `open`; `blanked.length` if unclosed. */
 function matchParen(blanked, open) {
   let depth = 0;
   for (let i = open; i < blanked.length; i++) {
@@ -512,7 +518,7 @@ function computeTainted(blanked) {
       // at the `)` of `trim(`, so the `.split(` below was never seen and the
       // loop body read as clean -- the silent direction.
       const header = blanked.indexOf('(', m.index);
-      const iterEnd = matchParen(blanked, header) - 1;
+      const iterEnd = matchParen(blanked, header);
       if (iterEnd <= m.index + m[0].length) continue;
       // Deliberately narrow to a SPLIT of tainted text. Tainting on
       // `carriesFileBytes` alone also catches `for (const file of files)`

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -106,19 +106,25 @@ const REGEX_PRECEDING_WORDS = /(?:^|[^A-Za-z0-9_$])(return|typeof|instanceof|cas
  * included); otherwise `start`, meaning "this `/` is division".
  *
  * The division-vs-regex question is decided by the previous significant
- * character. That is the standard heuristic and it is APPROXIMATE, not sound:
- * `stripComments` runs first but is string-unaware, so a `//` inside a string
- * literal (`'file:///x'`) truncates the line and can leave this looking at the
- * wrong character. Measured against the TypeScript parser over the scanned
- * corpus, it disagrees on a handful of lines, none of which currently changes a
- * verdict. A `[...]` class is tracked, since `/` inside one is literal, and an
+ * character. That is the standard heuristic and it is APPROXIMATE, not sound;
+ * measured against the TypeScript parser over the scanned corpus it disagrees
+ * on a handful of lines, none of which currently changes a verdict. The
+ * lookback reads `back` rather than raw source precisely so that comments,
+ * already blanked by the single pass, cannot supply that previous character.
+ * A `[...]` class is tracked, since `/` inside one is literal, and an
  * unterminated literal (no closing `/` before the line ends) is treated as
  * division rather than swallowing the rest of the file.
  */
-function regexLiteralEnd(src, start) {
+function regexLiteralEnd(src, start, back = src) {
+  // The BACKWARD scan reads `back`, which is the output-so-far with comments
+  // already blanked, while the forward scan reads raw `src`. They must differ:
+  // looking back over raw text puts the `/` of a preceding `*/` in front of
+  // the literal, so `const a = 1; /* c */ /["']/.test(z)` reads as DIVISION,
+  // the `"` opens a string that never closes, and the rest of the file is
+  // blanked -- a silent fail-open. Comments blank to spaces, which this skips.
   let k = start - 1;
-  while (k >= 0 && (src[k] === ' ' || src[k] === '\t')) k--;
-  const prev = k >= 0 ? src[k] : '';
+  while (k >= 0 && (back[k] === ' ' || back[k] === '\t')) k--;
+  const prev = k >= 0 ? back[k] : '';
   // `<` is deliberately NOT a preceder. `</Foo>` puts one directly before the
   // slash, and these files are `.tsx`: accepting it made every JSX closing tag
   // open a "regex", which on a line with a second `/` swallowed the opening
@@ -128,12 +134,15 @@ function regexLiteralEnd(src, start) {
   //
   // `a++ / b` and `a-- / b` are division, so a doubled `+`/`-` is excluded even
   // though a single one is a legitimate preceder (`a + /re/.test(b)`).
-  const doubled = (prev === '+' || prev === '-') && src[k - 1] === prev;
+  const doubled = (prev === '+' || prev === '-') && back[k - 1] === prev;
+  const wordSpan = Array.from({ length: k + 1 - Math.max(0, k - 12) }, (_, n) =>
+    back[Math.max(0, k - 12) + n],
+  ).join('');
   const isRegex =
     !doubled
     && (prev === ''
       || REGEX_PRECEDERS.has(prev)
-      || REGEX_PRECEDING_WORDS.test(src.slice(Math.max(0, k - 12), k + 1)));
+      || REGEX_PRECEDING_WORDS.test(wordSpan));
   if (!isRegex) return start;
 
   let i = start + 1;
@@ -244,7 +253,7 @@ function lexViews(src) {
     }
 
     if (c === '/') {
-      const end = regexLiteralEnd(src, i);
+      const end = regexLiteralEnd(src, i, blanked);
       if (end > i) {
         for (let k = i; k < end; k++) if (src[k] !== '\n') blanked[k] = ' ';
         i = end;
@@ -481,6 +490,10 @@ function computeTainted(blanked) {
       const args = blanked.slice(open + 1, matchParen(blanked, open));
       for (const cb of args.matchAll(/(\([^()]*\)|\b[A-Za-z_$][\w$]*)\s*=>/g))
         for (const q of valueIdentifiers(cb[1])) tainted.add(q);
+      // An anonymous `function (line) { … }` callback is the same flow with a
+      // different spelling, and matching only arrows left it undetected.
+      for (const cb of args.matchAll(/\bfunction\s*[A-Za-z_$][\w$]*?\s*\(([^()]*)\)|\bfunction\s*\(([^()]*)\)/g))
+        for (const q of valueIdentifiers(cb[1] ?? cb[2] ?? '')) tainted.add(q);
       // A HOISTED callback is passed by name, so its parameters are declared
       // somewhere else entirely: `.some(hit)` with `const hit = (line) => …`.
       for (const arg of splitArgs(args)) {
@@ -492,8 +505,15 @@ function computeTainted(blanked) {
     // requires an `=`, so this shape bound nothing and the loop body read as
     // clean.
     for (const m of blanked.matchAll(
-      /\bfor\s*\(\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s+of\s+([^)]*)\)/g,
+      /\bfor\s*\(\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s+of\s+/g,
     )) {
+      // The iterable runs to the `)` MATCHING the for-header's `(`, not to the
+      // first one. A `[^)]*` capture stopped inside `source.trim().split('\n')`
+      // at the `)` of `trim(`, so the `.split(` below was never seen and the
+      // loop body read as clean -- the silent direction.
+      const header = blanked.indexOf('(', m.index);
+      const iterEnd = matchParen(blanked, header) - 1;
+      if (iterEnd <= m.index + m[0].length) continue;
       // Deliberately narrow to a SPLIT of tainted text. Tainting on
       // `carriesFileBytes` alone also catches `for (const file of files)`
       // where the elements are PATHS, not contents -- measured as 4 false hits
@@ -502,7 +522,7 @@ function computeTainted(blanked) {
       // array of filenames, so this takes the shape it can prove and leaves
       // `for (const line of lines)` (split bound to a name first) uncovered
       // rather than paying for it in false flags on every path loop.
-      const iter = m[2].trim();
+      const iter = blanked.slice(m.index + m[0].length, iterEnd).trim();
       if (/\.\s*split\s*\(/.test(iter) && carriesFileBytes(iter)) tainted.add(m[1]);
     }
     // FAIL CLOSED on flow this analysis cannot follow. When file bytes are
@@ -565,19 +585,12 @@ const CONTINUES = /(?:[([,]|=>|&&|\|\||[-+*/%?:]|=)\s*$/;
  * predicate AND is recorded as used, so the dead-marker check goes quiet too:
  * both halves of the gate wrong at once.
  *
- * Stripping NARROWS that class, it does not close it, and the walk inherits
- * `stripComments`'s string-unawareness (see its own note above). Its guard
- * covers only the FIRST slash pair, so a third slash is preceded by `/` and
- * still truncates: `name: '///'` becomes a line ending in `/`, which
- * `CONTINUES` accepts, and the walk continues where it should stop. Measured
- * over the scanned corpus the trade is heavily favourable -- 300 lines where
- * stripping SHORTENS marker reach (mostly `'https://…'` in strings, which the
- * old per-line stripper left ending in `:`) against 8 where it lengthens it,
- * and 7 of those 8 genuinely end in `,` and so SHOULD continue. The one that
- * should not is the `'///'` line. No verdict on a real file changes either
- * way, because such a line also leaves an unterminated quote and `blankStrings`
- * desyncs first, which hides the predicate entirely. Both are the same root cause:
- * comments cannot be stripped without lexing strings.
+ * `stripComments` is now string-aware (it is one view of the single lexing
+ * pass), so a `//` inside a string no longer truncates the line: measured
+ * across the scanned corpus, NO file's stripped view differs in length from
+ * the original. `name: '///'`, `'https://x/y'` and `'see // docs'` all keep
+ * their trailing `;` and correctly stop the walk. The earlier per-line
+ * stripper got each of those wrong in the fail-open direction.
  *
  * The 24-line bound is a POLICY cap on how far a marker may reach, not a
  * runaway guard -- the walk terminates on its own, because `codeLines[top - 2]`
@@ -625,7 +638,12 @@ export function analyze(original) {
     return { ...empty, unusedMarkers: [...markerLines.keys()] };
   }
 
-  const blanked = blankStrings(stripped);
+  // The SAME pass that produced `stripped`, not a second lex of it. Re-lexing
+  // comment-blanked text is not equivalent: blanking a comment changes the
+  // character `regexLiteralEnd` looks back at, so `x = (/* c */ /re/.test(y))`
+  // loses the whole regex on the two-pass route. Keeping one pass is the point
+  // of `lexViews`.
+  const blanked = views.blanked;
   const tainted = computeTainted(blanked);
 
   const lineOf = (index) => blanked.slice(0, index).split('\n').length;

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -128,7 +128,11 @@ function closesAControlHeader(back, end) {
   }
   if (j < 0) return false;
   let w = j - 1;
-  while (w >= 0 && (back[w] === ' ' || back[w] === '\t')) w--;
+  // ALL whitespace, not just space and tab. A control keyword and its `(` can
+  // sit on different lines (`if\n(ok) /re/.test(v)`), and stopping at the
+  // newline read the header as an ordinary parenthesised expression, so the
+  // regex became division and its quote desynced the lexer.
+  while (w >= 0 && /\s/.test(back[w])) w--;
   const span = back.slice(Math.max(0, w - 8), w + 1).join('');
   return /(?:^|[^A-Za-z0-9_$])(if|for|while|switch|catch|with)$/.test(span);
 }
@@ -550,7 +554,7 @@ function computeTainted(blanked) {
       // character, so a leading `\b` can never match in front of it. Fixing
       // only the anchor still lost the helper's parameter taint silently.
       const literalName = fn.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const callRe = new RegExp(`(?<![\\w$])${literalName}\\s*\\(`, 'g');
+      const callRe = new RegExp(`(?<![\\w$])${literalName}\\s*(?:\\?\\.)?\\s*\\(`, 'g');
       let call;
       while ((call = callRe.exec(blanked)) !== null) {
         const open = callRe.lastIndex - 1;
@@ -566,10 +570,16 @@ function computeTainted(blanked) {
     // detector saw a predicate applied to `line`, a parameter it believed was
     // clean. Same for `.filter`, `.map`, `.every`, `.forEach`, `.find`. Taint
     // flows from the RECEIVER to the callback's parameters.
-    for (const m of blanked.matchAll(/\.\s*[A-Za-z_$][\w$]*\s*\(/g)) {
-      const dot = m.index;
+    // `?.` can sit on EITHER side of the method name: `xs?.some(cb)` and
+    // `xs.at(0)?.(cb)`. Matching only the trailing form left
+    // `source.split(sep)?.some((line) => …)` undetected.
+    for (const m of blanked.matchAll(/\??\.\s*[A-Za-z_$][\w$]*\s*(?:\?\.)?\s*\(/g)) {
+      // Walk back from the START of the match, which is the `.` in the plain
+      // form and the `?` in the optional one. Handing `receiverStart` the dot
+      // itself makes it stop on that `?` immediately and return an EMPTY
+      // receiver, so every optional call looked untainted.
       const open = m.index + m[0].length - 1;
-      if (!carriesFileBytes(blanked.slice(receiverStart(blanked, dot), dot))) continue;
+      if (!carriesFileBytes(blanked.slice(receiverStart(blanked, m.index), m.index))) continue;
       const args = blanked.slice(open + 1, matchParen(blanked, open));
       for (const cb of args.matchAll(/(\([^()]*\)|\b[A-Za-z_$][\w$]*)\s*=>/g))
         for (const q of valueIdentifiers(cb[1])) tainted.add(q);
@@ -611,6 +621,12 @@ function computeTainted(blanked) {
       const iter = blanked.slice(m.index + m[0].length, iterEnd).trim();
       if (/\.\s*split\s*\(/.test(iter) && carriesFileBytes(iter)) tainted.add(m[1]);
     }
+    // `?.(` is accepted everywhere `(` is. An optional call is still a call,
+    // and omitting it let `check?.(source)` skip the named-call path and
+    // `mutators[key]?.(source)` skip the fail-closed path below -- a rule that
+    // exists to catch what cannot be followed was itself bypassable by two
+    // characters.
+    //
     // FAIL CLOSED on flow this analysis cannot follow. When file bytes are
     // handed to a callee it cannot name — `mutators[key](real[key])`, or
     // anything returned by a call — the value lands in a parameter no lexical
@@ -620,7 +636,7 @@ function computeTainted(blanked) {
     // Named callees (`mutate(real.platform, …)`) and plain dotted ones
     // (`fs.writeFileSync(path, text)`) are followed or ignored precisely and do
     // not trigger this.
-    for (const call of blanked.matchAll(/[)\]]\s*\(/g)) {
+    for (const call of blanked.matchAll(/[)\]]\s*(?:\?\.)?\s*\(/g)) {
       const open = call.index + call[0].length - 1;
       if (!splitArgs(blanked.slice(open + 1, matchParen(blanked, open))).some(carriesFileBytes))
         continue;

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -155,21 +155,52 @@ function regexLiteralEnd(src, start) {
 }
 
 /**
- * Blank out string and template-literal CONTENT, preserving length, newlines,
- * and `${…}` interpolations. Length preservation is load-bearing: every index
- * computed on the blanked text is used against the original.
+ * ONE pass over `src` producing three length- and line-preserving views.
+ *
+ * Comments and strings cannot be lexed separately, because each can contain
+ * the other. Doing comments first (the old `stripComments`) truncated
+ * `const doc = 'see // the docs';` to an unterminated quote, and the string
+ * lexer then blanked the REST OF THE FILE, so every assertion after it went
+ * invisible and the gate reported nothing to see. Doing strings first fails
+ * the mirror case, a quote inside a comment. So both happen here, together.
+ *
+ *   text      comments blanked, string CONTENT intact -- for the pattern tests
+ *             that must still see a filename literal
+ *   blanked   comments AND string content blanked -- the code skeleton every
+ *             index-based read walks
+ *   comments  ONLY comment interiors kept -- markers are read from this, so a
+ *             `@source-text-assertion-ok` sitting inside a STRING can no
+ *             longer excuse a real finding
+ *
+ * Blanking to spaces rather than deleting keeps every index and line number
+ * equal to the original, which every caller here relies on.
  */
-export function blankStrings(src) {
-  const out = src.split('');
+function lexViews(src) {
+  const text = src.split('');
+  const blanked = src.split('');
+  const comments = src.split('');
+  for (let k = 0; k < src.length; k++) if (src[k] !== '\n') comments[k] = ' ';
+
+  const blankBoth = (k) => {
+    if (src[k] === '\n') return;
+    text[k] = ' ';
+    blanked[k] = ' ';
+  };
+  const keepComment = (k) => {
+    blankBoth(k);
+    comments[k] = src[k];
+  };
+
   const stack = [];
   let i = 0;
   while (i < src.length) {
     const c = src[i];
     const top = stack[stack.length - 1];
+
     if (top && top.kind === 'str') {
       if (c === '\\') {
-        if (src[i] !== '\n') out[i] = ' ';
-        if (src[i + 1] !== undefined && src[i + 1] !== '\n') out[i + 1] = ' ';
+        if (src[i] !== '\n') blanked[i] = ' ';
+        if (src[i + 1] !== undefined && src[i + 1] !== '\n') blanked[i + 1] = ' ';
         i += 2;
         continue;
       }
@@ -183,29 +214,44 @@ export function blankStrings(src) {
         i += 2;
         continue;
       }
-      if (c !== '\n') out[i] = ' ';
+      if (c !== '\n') blanked[i] = ' ';
       i++;
       continue;
     }
+
+    // COMMENTS ARE TESTED BEFORE REGEX. `//` would otherwise be offered to
+    // `regexLiteralEnd` as an empty literal and could swallow code up to the
+    // next slash on the line.
+    if (c === '/' && src[i + 1] === '/') {
+      while (i < src.length && src[i] !== '\n') keepComment(i++);
+      continue;
+    }
+    if (c === '/' && src[i + 1] === '*') {
+      keepComment(i++);
+      keepComment(i++);
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) keepComment(i++);
+      if (i < src.length) {
+        keepComment(i++);
+        keepComment(i++);
+      }
+      continue;
+    }
+
     if (c === "'" || c === '"' || c === '`') {
       stack.push({ kind: 'str', quote: c });
       i++;
       continue;
     }
-    // A REGEX LITERAL is the third thing that can hold a quote. Without this,
-    // `/["']/` opened a string that never closed and blanked the rest of the
-    // FILE, so every assertion after it became invisible and the gate reported
-    // "no source-text assertion" for a file that still had several. That is
-    // silent UNDER-detection, the opposite of the direction this detector's
-    // docblock says it errs in.
+
     if (c === '/') {
       const end = regexLiteralEnd(src, i);
       if (end > i) {
-        for (let k = i; k < end; k++) if (src[k] !== '\n') out[k] = ' ';
+        for (let k = i; k < end; k++) if (src[k] !== '\n') blanked[k] = ' ';
         i = end;
         continue;
       }
     }
+
     if (top && top.kind === 'interp') {
       if (OPENERS.includes(c)) top.depth++;
       else if (c === '}' && top.depth === 0) {
@@ -216,21 +262,31 @@ export function blankStrings(src) {
     }
     i++;
   }
-  return out.join('');
+  return { text: text.join(''), blanked: blanked.join(''), comments: comments.join('') };
 }
 
 /**
- * Drop `//` and block comments, PRESERVING LINE NUMBERS so a marker can be
- * matched against the line of the predicate it excuses. Stripping is
- * load-bearing rather than tidy: three unrelated tests mention a `.ts` filename
+ * Blank string and template-literal CONTENT, preserving length, newlines and
+ * `${…}` interpolations. Length preservation is load-bearing: every index
+ * computed on the blanked text is used against the original. One view of
+ * {@link lexViews} rather than a second scanner.
+ */
+export function blankStrings(src) {
+  return lexViews(src).blanked;
+}
+
+/**
+ * Comments blanked, string content INTACT, line numbers and length preserved,
+ * so a marker can be matched against the line of the predicate it excuses.
+ * Load-bearing rather than tidy: three unrelated tests mention a `.ts` filename
  * in prose while reading a wasm binary or a JSON manifest.
+ *
+ * One view of {@link lexViews}. It used to be a pair of regexes that truncated
+ * a line at `//` with no idea whether that `//` was inside a STRING, which is
+ * what made the gate go silent from `const doc = 'see // the docs';` onward.
  */
 export function stripComments(source) {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-    .split('\n')
-    .map((line) => line.replace(/(^|[^:'"`\\])\/\/.*$/, '$1'))
-    .join('\n');
+  return lexViews(source).text;
 }
 
 /** Identifiers in `expr` at value position: property names after `.` excluded. */
@@ -412,6 +468,43 @@ function computeTainted(blanked) {
         });
       }
     }
+    // An ITERATION CALLBACK receives the bytes one ELEMENT at a time, so no
+    // tainted NAME ever appears inside it. `source.split('\n').some((line) =>
+    // line.includes(needle))` reads the file and asserts on its text, and the
+    // detector saw a predicate applied to `line`, a parameter it believed was
+    // clean. Same for `.filter`, `.map`, `.every`, `.forEach`, `.find`. Taint
+    // flows from the RECEIVER to the callback's parameters.
+    for (const m of blanked.matchAll(/\.\s*[A-Za-z_$][\w$]*\s*\(/g)) {
+      const dot = m.index;
+      const open = m.index + m[0].length - 1;
+      if (!carriesFileBytes(blanked.slice(receiverStart(blanked, dot), dot))) continue;
+      const args = blanked.slice(open + 1, matchParen(blanked, open));
+      for (const cb of args.matchAll(/(\([^()]*\)|\b[A-Za-z_$][\w$]*)\s*=>/g))
+        for (const q of valueIdentifiers(cb[1])) tainted.add(q);
+      // A HOISTED callback is passed by name, so its parameters are declared
+      // somewhere else entirely: `.some(hit)` with `const hit = (line) => …`.
+      for (const arg of splitArgs(args)) {
+        const named = fns.find((f) => f.name && f.name === arg.trim());
+        if (named) for (const q of named.params) tainted.add(q);
+      }
+    }
+    // `for (const line of source.split('\n'))` binds the ELEMENT. `bindRe`
+    // requires an `=`, so this shape bound nothing and the loop body read as
+    // clean.
+    for (const m of blanked.matchAll(
+      /\bfor\s*\(\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s+of\s+([^)]*)\)/g,
+    )) {
+      // Deliberately narrow to a SPLIT of tainted text. Tainting on
+      // `carriesFileBytes` alone also catches `for (const file of files)`
+      // where the elements are PATHS, not contents -- measured as 4 false hits
+      // in toolbar-parity.test.ts, because a list of paths is tainted too.
+      // Nothing lexical separates a tainted array of lines from a tainted
+      // array of filenames, so this takes the shape it can prove and leaves
+      // `for (const line of lines)` (split bound to a name first) uncovered
+      // rather than paying for it in false flags on every path loop.
+      const iter = m[2].trim();
+      if (/\.\s*split\s*\(/.test(iter) && carriesFileBytes(iter)) tainted.add(m[1]);
+    }
     // FAIL CLOSED on flow this analysis cannot follow. When file bytes are
     // handed to a callee it cannot name — `mutators[key](real[key])`, or
     // anything returned by a call — the value lands in a parameter no lexical
@@ -513,12 +606,17 @@ function markerLineFor(markerLines, codeLines, line) {
  *             unusedMarkers: number[] }}
  */
 export function analyze(original) {
-  const stripped = stripComments(original);
+  const views = lexViews(original);
+  const stripped = views.text;
   const strippedLines = stripped.split('\n');
   const empty = { flagged: false, hits: [], marked: [], unusedMarkers: [] };
   const rawLines = original.split('\n');
   const markerLines = new Map();
-  rawLines.forEach((line, idx) => {
+  // Markers are read from the COMMENT view, never the raw line. A raw-line
+  // scan accepted `const doc = 'write @source-text-assertion-ok fake';` as a
+  // genuine marker, so a STRING could excuse a real finding -- a silent
+  // fail-open in the direction this gate exists to prevent.
+  views.comments.split('\n').forEach((line, idx) => {
     const m = MARKER.exec(line);
     if (m) markerLines.set(idx + 1, (m[1] || '').trim());
   });

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -517,12 +517,20 @@ function computeTainted(blanked) {
     });
   }
 
-  // Each pass that changes anything adds at least one name, and names come from
-  // the file, so `bindings.length + fns.length + 2` is an upper bound the loop
-  // cannot need to exceed -- it is a runaway guard, not a policy. The old fixed
-  // 8 WAS reachable: a chain declared in reverse order resolves one link per
-  // pass, so eight links exhausted it and `analyze` reported a clean file.
-  const maxPasses = bindings.length + fns.length + 2;
+  // Every name this loop adds is an identifier that appears LEXICALLY in the
+  // file -- a binding name, a parameter, a for-of element, a callback
+  // parameter -- and every pass that changes anything adds at least one. So the
+  // count of distinct identifiers bounds the productive passes, and the loop
+  // cannot need more.
+  //
+  // Two earlier versions were both wrong in the SILENT direction. A fixed 8 was
+  // reachable: bindings declared in reverse order resolve one link per pass, so
+  // eight links exhausted it. Replacing it with `bindings.length + fns.length`
+  // was worse, and its comment claimed a proof it did not have -- neither term
+  // counts for-of names or callback parameters, so four reverse-ordered
+  // `for (const vN of vN-1.split(…))` links gave a cap of 3 and returned a
+  // clean file, which even the fixed 8 had caught.
+  const maxPasses = valueIdentifiers(blanked).size + 2;
   for (let pass = 0; pass < maxPasses; pass++) {
     const before = tainted.size;
     for (const b of bindings) {
@@ -537,10 +545,12 @@ function computeTainted(blanked) {
       }
       // A tainted argument taints the parameter it lands in.
       if (!fn.name || fn.params.length === 0) continue;
-      // `$` is legal in a JS identifier AND is a regex anchor, so `$read` built
-      // a pattern that could never match and the helper's parameter taint was
-      // lost with no signal. Escape before interpolating.
-      const callRe = new RegExp(`\\b${fn.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\(`, 'g');
+      // `$` is legal in a JS identifier and breaks this pattern TWICE: it is a
+      // regex anchor, so the name must be escaped, and it is not a word
+      // character, so a leading `\b` can never match in front of it. Fixing
+      // only the anchor still lost the helper's parameter taint silently.
+      const literalName = fn.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const callRe = new RegExp(`(?<![\\w$])${literalName}\\s*\\(`, 'g');
       let call;
       while ((call = callRe.exec(blanked)) !== null) {
         const open = callRe.lastIndex - 1;

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -259,6 +259,17 @@ function lexViews(src) {
         i += 2;
         continue;
       }
+      // A `'` or `"` literal CANNOT cross a line. Without this an unpaired
+      // quote kept the lexer in string state until the next quote anywhere
+      // later in the file, blanking both views across that whole span, so every
+      // read, filename literal and predicate inside it disappeared and the file
+      // reported clean. Only a template literal may span lines; a legal line
+      // continuation is a `\` escape and was already consumed above.
+      if (c === '\n' && top.quote !== '`') {
+        stack.pop();
+        i++;
+        continue;
+      }
       if (c !== '\n') blanked[i] = ' ';
       i++;
       continue;
@@ -581,7 +592,7 @@ function computeTainted(blanked) {
       const open = m.index + m[0].length - 1;
       if (!carriesFileBytes(blanked.slice(receiverStart(blanked, m.index), m.index))) continue;
       const args = blanked.slice(open + 1, matchParen(blanked, open));
-      for (const cb of args.matchAll(/(\([^()]*\)|\b[A-Za-z_$][\w$]*)\s*=>/g))
+      for (const cb of args.matchAll(/(\([^()]*\)|(?<![\w$])[A-Za-z_$][\w$]*)\s*=>/g))
         for (const q of valueIdentifiers(cb[1])) tainted.add(q);
       // An anonymous `function (line) { … }` callback is the same flow with a
       // different spelling, and matching only arrows left it undetected.
@@ -640,7 +651,7 @@ function computeTainted(blanked) {
       const open = call.index + call[0].length - 1;
       if (!splitArgs(blanked.slice(open + 1, matchParen(blanked, open))).some(carriesFileBytes))
         continue;
-      for (const m2 of blanked.matchAll(/(\([^()]*\)|\b[A-Za-z_$][\w$]*)\s*=>/g))
+      for (const m2 of blanked.matchAll(/(\([^()]*\)|(?<![\w$])[A-Za-z_$][\w$]*)\s*=>/g))
         for (const p of valueIdentifiers(m2[1])) tainted.add(p);
       for (const fn of fns) for (const p of fn.params) tainted.add(p);
       break;

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -93,11 +93,6 @@ const MARKER = /@source-text-assertion-ok\b[ \t]*(\S[^\n]*)?/;
 const OPENERS = '([{';
 const CLOSERS = ')]}';
 
-/**
- * Blank out string and template-literal CONTENT, preserving length, newlines,
- * and `${…}` interpolations. Length preservation is load-bearing: every index
- * computed on the blanked text is used against the original.
- */
 /** Characters after which a `/` begins a REGEX rather than a division. */
 const REGEX_PRECEDERS = new Set([
   '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '~', '^', '>', '\n',
@@ -159,6 +154,11 @@ function regexLiteralEnd(src, start) {
   return start;
 }
 
+/**
+ * Blank out string and template-literal CONTENT, preserving length, newlines,
+ * and `${…}` interpolations. Length preservation is load-bearing: every index
+ * computed on the blanked text is used against the original.
+ */
 export function blankStrings(src) {
   const out = src.split('');
   const stack = [];
@@ -320,7 +320,11 @@ function receiverStart(blanked, dot) {
 /** Every name that can hold, or return, bytes that came off the disk. */
 function computeTainted(blanked) {
   const tainted = new Set(['readFileSync', 'readFile']);
-  const refersToTainted = (expr) => {
+  // TRUE when `expr` yields bytes off the disk -- either because it PERFORMS a
+  // read, or because it refers to a name already known to hold one. The two
+  // arms are why this is not called `refersToTainted`: the first answers a
+  // question about the expression itself, not about the `tainted` set.
+  const carriesFileBytes = (expr) => {
     // A READ is a read however it is spelled. `valueIdentifiers` drops any name
     // preceded by `.`, so `fs.readFileSync(p)` yielded `{fs, p}` and taint never
     // started -- `READS_A_FILE` still matched, so the file was ANALYSED rather
@@ -387,14 +391,14 @@ function computeTainted(blanked) {
   for (let pass = 0; pass < 8; pass++) {
     const before = tainted.size;
     for (const b of bindings) {
-      if (refersToTainted(b.rhs)) for (const n of b.names) tainted.add(n);
+      if (carriesFileBytes(b.rhs)) for (const n of b.names) tainted.add(n);
     }
     for (const fn of fns) {
       // A helper that returns file bytes taints its own name, so both
       // `readSource(f).includes(x)` and `const s = readSource(f)` are seen.
       if (fn.name && !tainted.has(fn.name)) {
         const returned = fn.concise ? [fn.body] : fn.body.match(/\breturn\b[^;\n]*/g) || [];
-        if (returned.some(refersToTainted)) tainted.add(fn.name);
+        if (returned.some(carriesFileBytes)) tainted.add(fn.name);
       }
       // A tainted argument taints the parameter it lands in.
       if (!fn.name || fn.params.length === 0) continue;
@@ -404,7 +408,7 @@ function computeTainted(blanked) {
         const open = callRe.lastIndex - 1;
         const args = splitArgs(blanked.slice(open + 1, matchParen(blanked, open)));
         args.forEach((arg, idx) => {
-          if (idx < fn.params.length && refersToTainted(arg)) tainted.add(fn.params[idx]);
+          if (idx < fn.params.length && carriesFileBytes(arg)) tainted.add(fn.params[idx]);
         });
       }
     }
@@ -419,7 +423,7 @@ function computeTainted(blanked) {
     // not trigger this.
     for (const call of blanked.matchAll(/[)\]]\s*\(/g)) {
       const open = call.index + call[0].length - 1;
-      if (!splitArgs(blanked.slice(open + 1, matchParen(blanked, open))).some(refersToTainted))
+      if (!splitArgs(blanked.slice(open + 1, matchParen(blanked, open))).some(carriesFileBytes))
         continue;
       for (const m2 of blanked.matchAll(/(\([^()]*\)|\b[A-Za-z_$][\w$]*)\s*=>/g))
         for (const p of valueIdentifiers(m2[1])) tainted.add(p);
@@ -449,39 +453,8 @@ function splitArgs(text) {
   return args;
 }
 
-/**
- * @param {string} original Raw file text (comments intact — markers live there).
- * @returns {{ flagged: boolean, hits: Array<{line: number, text: string}>,
- *             marked: Array<{line: number, reason: string}>,
- *             unusedMarkers: number[] }}
- */
 /** A line is a continuation of the one below it when it ends mid-expression. */
 const CONTINUES = /(?:[([,]|=>|&&|\|\||[-+*/%?:]|=)\s*$/;
-
-/**
- * `line` with any trailing `//` comment removed, so {@link CONTINUES} is asked
- * about CODE rather than prose.
- *
- * Without this the walk was defeated by an ordinary comment: `CONTINUES`
- * contains `*`, `/`, `:` and `-`, so `// Arrange:`, `// see https://x/`, a
- * JSDoc ` *` line and this repo's own `// ------` separators all read as
- * continuations. A stale marker then reached across them to excuse an unrelated
- * predicate AND was recorded as used, so the dead-marker check went quiet too:
- * both halves of the gate wrong at once.
- *
- * A `//` inside a string (`'file:///x'`) is truncated here as well, which makes
- * the line look like a NON-continuation. That direction is safe: the marker is
- * not accepted, so the predicate is reported rather than silently excused.
- */
-function codeOf(line) {
-  const at = line.indexOf('//');
-  const code = (at === -1 ? line : line.slice(0, at)).trim();
-  // A BLOCK-comment fragment carries no code either, and ` */` is the one that
-  // bites: it ends in `/`, which `CONTINUES` accepts, so a JSDoc block above a
-  // stale marker read as one long continuation.
-  if (code.startsWith('*') || code.startsWith('/*')) return '';
-  return code;
-}
 
 /**
  * The line carrying the marker that excuses a predicate on `line`, or `null`.
@@ -492,16 +465,24 @@ function codeOf(line) {
  * first line and allows the marker anywhere from just above that down to the
  * predicate itself.
  *
- * The 24-line bound is a runaway guard, not a policy: a statement longer than
- * that is already unreadable, and the previous bound of 8 was small enough that
- * a legitimately long wrapped assertion fell out the other side and hit the
- * double failure this exists to remove.
+ * `codeLines` must be COMMENT-STRIPPED (`stripComments`), because `CONTINUES`
+ * contains `*`, `/`, `:` and `-`, so `// Arrange:`, `// see https://x/`, a JSDoc
+ * ` *` line and this repo's own `// ------` separators all read as continuations
+ * of prose. A stale marker then reaches across them to excuse an unrelated
+ * predicate AND is recorded as used, so the dead-marker check goes quiet too:
+ * both halves of the gate wrong at once.
+ *
+ * The 24-line bound is a POLICY cap on how far a marker may reach, not a
+ * runaway guard -- the walk terminates on its own, because `codeLines[top - 2]`
+ * yields `''` at the top of the file and `''` is not a continuation. The
+ * previous bound of 8 was small enough that a legitimately long wrapped
+ * assertion fell out the other side and hit the double failure above.
  */
-function markerLineFor(markerLines, rawLines, line) {
+function markerLineFor(markerLines, codeLines, line) {
   if (markerLines.has(line)) return line;
   let top = line;
   for (let n = 0; n < 24; n++) {
-    const above = codeOf(rawLines[top - 2] ?? '');
+    const above = (codeLines[top - 2] ?? '').trim();
     if (!CONTINUES.test(above)) break;
     top -= 1;
   }
@@ -511,8 +492,15 @@ function markerLineFor(markerLines, rawLines, line) {
   return null;
 }
 
+/**
+ * @param {string} original Raw file text (comments intact — markers live there).
+ * @returns {{ flagged: boolean, hits: Array<{line: number, text: string}>,
+ *             marked: Array<{line: number, reason: string}>,
+ *             unusedMarkers: number[] }}
+ */
 export function analyze(original) {
   const stripped = stripComments(original);
+  const strippedLines = stripped.split('\n');
   const empty = { flagged: false, hits: [], marked: [], unusedMarkers: [] };
   const rawLines = original.split('\n');
   const markerLines = new Map();
@@ -566,7 +554,7 @@ export function analyze(original) {
     // marker excused nothing AND was then reported as unused: CI failed twice
     // and the printed fix did not work. A remedy an instrument prints has to be
     // one the instrument accepts.
-    const markerLine = markerLineFor(markerLines, rawLines, line);
+    const markerLine = markerLineFor(markerLines, strippedLines, line);
     if (markerLine !== null && markerLines.get(markerLine)) {
       usedMarkers.add(markerLine);
       marked.push({ line, reason: markerLines.get(markerLine) });

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -472,6 +472,20 @@ const CONTINUES = /(?:[([,]|=>|&&|\|\||[-+*/%?:]|=)\s*$/;
  * predicate AND is recorded as used, so the dead-marker check goes quiet too:
  * both halves of the gate wrong at once.
  *
+ * Stripping NARROWS that class, it does not close it, and the walk inherits
+ * `stripComments`'s string-unawareness (see its own note above). Its guard
+ * covers only the FIRST slash pair, so a third slash is preceded by `/` and
+ * still truncates: `name: '///'` becomes a line ending in `/`, which
+ * `CONTINUES` accepts, and the walk continues where it should stop. Measured
+ * over the scanned corpus the trade is heavily favourable -- 300 lines where
+ * stripping SHORTENS marker reach (mostly `'https://…'` in strings, which the
+ * old per-line stripper left ending in `:`) against 8 where it lengthens it,
+ * and 7 of those 8 genuinely end in `,` and so SHOULD continue. The one that
+ * should not is the `'///'` line. No verdict on a real file changes either
+ * way, because such a line also leaves an unterminated quote and `blankStrings`
+ * desyncs first, which hides the predicate entirely. Both are the same root cause:
+ * comments cannot be stripped without lexing strings.
+ *
  * The 24-line bound is a POLICY cap on how far a marker may reach, not a
  * runaway guard -- the walk terminates on its own, because `codeLines[top - 2]`
  * yields `''` at the top of the file and `''` is not a continuation. The


### PR DESCRIPTION
## Relationship to #3085, read this first

This branch **contains #3085's commit**, rebased onto current main with Petru Conduraru's authorship preserved (`b20672ed4`, originally `a82545a86`). So the diff below includes their work as well as mine, and merging this would make #3085 redundant rather than complementary.

That was not my call to make, so I did not force-push over their branch and I am not proposing a merge order. Two options, both fine:

1. **Merge this, close #3085 as superseded.** Everything lands at once and the gate is sound the moment it does.
2. **Merge #3085 first, then I rebase this onto the new main and drop the duplicated commit.** Costs a rebase and leaves main with a fail-open gate in between.

I would take 1 only with the author's agreement, since it retires their PR. I have asked them and had no answer yet.

Follow-up to #3085. That PR extracts a source-text detector and narrows the gate to predicates applied to text a file read produced. This hardens it. It is a separate PR because #3085 belongs to its author and I did not want to rewrite their branch.

**It should land with or before #3085.** CodeRabbit's review on #3085's head lists five actionable findings, and merging that PR alone would replace main's currently over-detecting gate with one that under-detects on ordinary code. Every one of those five is fixed here.

## What was silently missed

Each of these made the gate report a clean file. That is the direction it exists to prevent, and it looks exactly like success.

| shape | why it went silent |
|---|---|
| `const doc = 'see // the docs';` | comments were stripped by a regex that could not see strings, so the line truncated to an unterminated quote and the string lexer blanked the REST OF THE FILE |
| `const doc = 'write @source-text-assertion-ok x';` | markers were matched against raw lines, so a string could excuse a real finding |
| `/["']/` | the lexer had no notion of regex literals, so the quote opened a string that never closed |
| `fs.readFileSync(p)` | a dotted read never seeded taint, so the file was analysed and then found nothing |
| `source.split('\n').some((line) => line.includes(x))` | an iteration callback gets bytes one element at a time, so no tainted name appears inside it |
| a marker above a wrapped `assert.ok(` | the marker was accepted only on the predicate's line or one above, so the remedy the gate PRINTS did not work |

## How

Strings and comments cannot be lexed separately, because each can contain the other. They are now one pass, `lexViews`, returning three length- and line-preserving views: `text` (comments blanked, strings intact), `blanked` (both blanked), `comments` (only comment interiors). Markers read from `comments`, so only a real comment excuses anything. `stripComments` and `blankStrings` became views of that pass rather than two more scanners.

Taint now flows from a tainted receiver into iteration-callback parameters, including callbacks passed by name and anonymous `function` expressions.

## Two holes this work opened and closed

Worth stating, because both were introduced by earlier commits in this same branch and neither showed up in a corpus differential.

Applying a `/simplify` finding (use `views.blanked` instead of re-lexing) introduced a fail-open: `regexLiteralEnd` looked back over raw text, so `const a = 1; /* c */ /["']/.test(z)` read as division and blanked the file. The two reviewers disagreed about that exact line and only running it settled it. The double lex was a workaround; the fix was to make the backward scan read the blanked prefix.

Doing that then opened another: blanking a regex literal whole let a following division look back past it. `const n = /a/ / b; const s = 'q/w';` blanked the file. The blanked view now keeps the literal's opening `/`.

Also: `matchParen`'s docstring said "index just past the `)`" and it returns the index OF the `)`. Trusting it cost a character off the `for..of` iterable. Docstring corrected.

## Deliberate limits

- `for (const line of lines)`, where the split is bound to a name first, is NOT covered. Tainting every `for..of` whose iterable carries file bytes also taints `for (const file of files)` where the elements are paths: 4 false hits in `toolbar-parity.test.ts`, whose line 323 is exactly that. Nothing lexical separates a tainted array of lines from a tainted array of filenames, so the rule takes the `.split(` it can prove. Pinned by its own test.
- A default parameter containing a call, `function (line = f(1))`, is not covered. Pre-existing for arrows too.
- A full-line comment INSIDE a wrapped assertion still breaks marker reach. Verified identical before #3085's widening, so it is a gap neither PR closes.

## Verification

- 53 tests, up from 34. Every new one was mutation-checked and reds under the specific revert it exists to catch, and each mutation asserts it changed the file first, after two silently did not apply.
- Verdicts identical across all 1402 scanned test files, for every commit here.
- The whole-file desync is measurably gone: 129 code characters recovered in `packages/viewer/test/server.test.ts`, 1677 in `packages/extensions/src/host/source-wrap.test.ts`.
- Gate reports `OK (7 allowlisted, 0 marked, 0 new)`. No allowlist row added or annexed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved source-text assertion detection across file reads, helper calls, callbacks, loops, and complex control flows.
  - Added support for valid `@source-text-assertion-ok` markers, including detection of unused markers.
  - Enhanced reports with flagged assertion details and marked-site counts.

- **Bug Fixes**
  - Improved handling of strings, comments, templates, regular expressions, optional calls, and complex control flows.

- **Tests**
  - Added extensive regression coverage, including marker handling, execution failures, timeouts, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->