### PR TITLE
fix(cache): derive typeRanges on hydration, so pre-#3101 caches stop serving the old semantics

### DIFF
--- a/.changeset/cache-derive-typeranges-on-hydration.md
+++ b/.changeset/cache-derive-typeranges-on-hydration.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/cache": patch
+---
+
+Derive `EntityTable.typeRanges` from the type column when hydrating a cache, instead of trusting the serialized triples.
+
+`typeRanges` changed meaning from `start + count` to a `[firstRow, lastRow + 1]` span. `FORMAT_VERSION` was not bumped, and correctly so — `readHeader` throws only on `version > FORMAT_VERSION`, so caches at the current version are accepted by design and a bump would change nothing for them. The consequence is that the stored triples carry either meaning with nothing to tell them apart, and `readEntities` passed them straight to the public `EntityTable.typeRanges`. For a type whose rows are interleaved with another's — the ordinary case in IFC — the old form named a range that stopped short of the type's own later rows; the two forms coincide only when a type happens to be contiguous, which is what kept the divergence out of sight.
+
+`readEntities` already built per-type index arrays for `getByType()`, which is why that path was never affected. The spans are now derived from those same arrays, so one structure feeds both. The serialized field is still written, and still read to keep the byte layout unchanged, but its value no longer reaches the table.
+
+This closes the window for caches already on disk rather than fixing a regression: the mixed meaning existed before the semantics changed and is not damage that change caused.

--- a/packages/cache/src/sections/entities.test.ts
+++ b/packages/cache/src/sections/entities.test.ts
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `EntityTable.typeRanges` changed in #3101 from `start + count` to a
+ * `[firstRow, lastRow + 1]` span. `FORMAT_VERSION` was deliberately not
+ * bumped (`header.ts` throws only on `version > FORMAT_VERSION`, so older
+ * caches are accepted by design), so a cache written before #3101 still
+ * deserializes `start + count` triples. `readEntities` used to hand those
+ * straight to the public `EntityTable.typeRanges`.
+ *
+ * The two forms COINCIDE whenever a type happens to occupy contiguous rows,
+ * which is exactly what kept the divergence invisible — every fixture here
+ * therefore interleaves its types.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { StringTable, IfcTypeEnum, entityTableFromColumns } from '@ifc-lite/data';
+import type { EntityTable } from '@ifc-lite/data';
+import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import { writeEntities, readEntities } from './entities.js';
+
+/**
+ * Rows 0/2/4 are IfcWall, rows 1/3 are IfcSpace — neither type is contiguous.
+ *   span semantics:        Wall [0, 5), Space [1, 4)
+ *   pre-#3101 start+count: Wall  0 + 3,  Space  1 + 2
+ * Both fields differ for both types, so no assertion below can be satisfied
+ * by the wrong form.
+ */
+const INTERLEAVED_TYPES: readonly IfcTypeEnum[] = [
+  IfcTypeEnum.IfcWall,
+  IfcTypeEnum.IfcSpace,
+  IfcTypeEnum.IfcWall,
+  IfcTypeEnum.IfcSpace,
+  IfcTypeEnum.IfcWall,
+];
+
+function columnsFor(types: readonly IfcTypeEnum[], strings: StringTable) {
+  const count = types.length;
+  const globalId = new Uint32Array(count);
+  for (let i = 0; i < count; i++) {
+    globalId[i] = strings.intern(`gid-${i}`);
+  }
+  return {
+    count,
+    expressId: Uint32Array.from(types.map((_t, i) => (i + 1) * 10)),
+    typeEnum: Uint16Array.from(types),
+    globalId,
+    name: new Uint32Array(count),
+    description: new Uint32Array(count),
+    objectType: new Uint32Array(count),
+    flags: new Uint8Array(count),
+    containedInStorey: new Int32Array(count).fill(-1),
+    definedByType: new Int32Array(count).fill(-1),
+    geometryIndex: new Int32Array(count).fill(-1),
+  };
+}
+
+/**
+ * Serialize a section whose type-range triples carry the SUPPLIED values, then
+ * hydrate it. `entityTableFromColumns` prefers supplied `typeRanges` over the
+ * ones it would derive, so passing pre-#3101 `start + count` pairs produces
+ * byte-for-byte the payload an old writer produced — the layout never changed,
+ * only the meaning of the third field.
+ */
+function hydrate(
+  types: readonly IfcTypeEnum[],
+  stored: Map<IfcTypeEnum, { start: number; end: number }>,
+): { table: EntityTable; strings: StringTable } {
+  const strings = new StringTable();
+  const columns = columnsFor(types, strings);
+  const source = entityTableFromColumns({ ...columns, typeRanges: stored }, strings);
+  const writer = new BufferWriter();
+  writeEntities(writer, source);
+  return { table: readEntities(new BufferReader(writer.build()), strings), strings };
+}
+
+function hydrateTable(
+  types: readonly IfcTypeEnum[],
+  stored: Map<IfcTypeEnum, { start: number; end: number }>,
+): EntityTable {
+  return hydrate(types, stored).table;
+}
+
+/** The pre-#3101 `start + count` triples for the interleaved fixture. */
+function oldStartPlusCount(): Map<IfcTypeEnum, { start: number; end: number }> {
+  return new Map([
+    [IfcTypeEnum.IfcWall, { start: 0, end: 3 }],
+    [IfcTypeEnum.IfcSpace, { start: 1, end: 2 }],
+  ]);
+}
+
+/** The post-#3101 spans for the same fixture. */
+function newSpans(): Map<IfcTypeEnum, { start: number; end: number }> {
+  return new Map([
+    [IfcTypeEnum.IfcWall, { start: 0, end: 5 }],
+    [IfcTypeEnum.IfcSpace, { start: 1, end: 4 }],
+  ]);
+}
+
+describe('readEntities derives typeRanges instead of trusting the stored triples', () => {
+  it('gives span semantics for a pre-#3101 cache with interleaved types', () => {
+    const table = hydrateTable(INTERLEAVED_TYPES, oldStartPlusCount());
+
+    // Positions, not a count and not a sum: `a + b = whole` has many wrong
+    // solutions. IfcWall's last row is 4, so its span must end at 5 — the
+    // stored triple said 3.
+    expect(table.typeRanges.get(IfcTypeEnum.IfcWall)).toEqual({ start: 0, end: 5 });
+    expect(table.typeRanges.get(IfcTypeEnum.IfcSpace)).toEqual({ start: 1, end: 4 });
+  });
+
+  it('gives the same answer for a post-#3101 cache whose triples are already spans', () => {
+    const table = hydrateTable(INTERLEAVED_TYPES, newSpans());
+
+    expect(table.typeRanges.get(IfcTypeEnum.IfcWall)).toEqual({ start: 0, end: 5 });
+    expect(table.typeRanges.get(IfcTypeEnum.IfcSpace)).toEqual({ start: 1, end: 4 });
+  });
+
+  it('lands on one answer whichever vintage wrote the cache', () => {
+    const fromOld = hydrateTable(INTERLEAVED_TYPES, oldStartPlusCount());
+    const fromNew = hydrateTable(INTERLEAVED_TYPES, newSpans());
+
+    expect([...fromOld.typeRanges]).toEqual([...fromNew.typeRanges]);
+  });
+
+  it('covers every row of its type, and its endpoints are rows of that type', () => {
+    const table = hydrateTable(INTERLEAVED_TYPES, oldStartPlusCount());
+
+    for (const [type, range] of table.typeRanges) {
+      for (let row = 0; row < table.count; row++) {
+        if (table.typeEnum[row] !== type) continue;
+        expect(row).toBeGreaterThanOrEqual(range.start);
+        expect(row).toBeLessThan(range.end);
+      }
+      // The span is [first, last + 1], so both endpoints name rows of the type.
+      expect(table.typeEnum[range.start]).toBe(type);
+      expect(table.typeEnum[range.end - 1]).toBe(type);
+    }
+  });
+
+  it('keeps getByType consistent with the derived spans', () => {
+    const table = hydrateTable(INTERLEAVED_TYPES, oldStartPlusCount());
+
+    expect(table.getByType(IfcTypeEnum.IfcWall)).toEqual([10, 30, 50]);
+    expect(table.getByType(IfcTypeEnum.IfcSpace)).toEqual([20, 40]);
+  });
+
+  // --- what the displaced straight-through assignment used to do -----------
+
+  it('gives a single-row type a one-wide span', () => {
+    const types = [IfcTypeEnum.IfcWall, IfcTypeEnum.IfcDoor, IfcTypeEnum.IfcWall];
+    const table = hydrateTable(
+      types,
+      new Map([
+        [IfcTypeEnum.IfcWall, { start: 0, end: 2 }], // old: start 0, count 2
+        [IfcTypeEnum.IfcDoor, { start: 1, end: 1 }], // old: start 1, count 1
+      ]),
+    );
+
+    expect(table.typeRanges.get(IfcTypeEnum.IfcDoor)).toEqual({ start: 1, end: 2 });
+    expect(table.typeRanges.get(IfcTypeEnum.IfcWall)).toEqual({ start: 0, end: 3 });
+  });
+
+  it('has no entry for a type absent from the table', () => {
+    const table = hydrateTable(INTERLEAVED_TYPES, oldStartPlusCount());
+
+    expect(table.typeRanges.has(IfcTypeEnum.IfcDoor)).toBe(false);
+    expect(table.typeRanges.size).toBe(2);
+  });
+
+  it('drops a stored triple for a type that no row carries', () => {
+    // Only a corrupt or hand-written cache can hold one: the builder records a
+    // range from a row it saw. An empty range names no rows, so nothing is lost.
+    const stored = oldStartPlusCount();
+    stored.set(IfcTypeEnum.IfcBeam, { start: 2, end: 0 });
+    const table = hydrateTable(INTERLEAVED_TYPES, stored);
+
+    expect(table.typeRanges.has(IfcTypeEnum.IfcBeam)).toBe(false);
+    expect([...table.typeRanges.keys()]).toEqual([IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSpace]);
+  });
+
+  it('returns an empty map for an empty table', () => {
+    const table = hydrateTable([], new Map());
+
+    expect(table.count).toBe(0);
+    expect(table.typeRanges.size).toBe(0);
+  });
+
+  it('orders the map by first appearance in the type column', () => {
+    // The straight-through assignment kept the serialized order; the derivation
+    // keeps first-appearance order. They agree for anything the builder wrote,
+    // and this pins the order the derivation guarantees even when the stored
+    // triples arrive in the other order.
+    const stored = new Map([
+      [IfcTypeEnum.IfcSpace, { start: 1, end: 2 }],
+      [IfcTypeEnum.IfcWall, { start: 0, end: 3 }],
+    ]);
+    const table = hydrateTable(INTERLEAVED_TYPES, stored);
+
+    expect([...table.typeRanges.keys()]).toEqual([IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSpace]);
+  });
+
+  it('round-trips the derived spans through a second write', () => {
+    const { table: first, strings } = hydrate(INTERLEAVED_TYPES, oldStartPlusCount());
+    const writer = new BufferWriter();
+    writeEntities(writer, first);
+    const second = readEntities(new BufferReader(writer.build()), strings);
+
+    expect([...second.typeRanges]).toEqual([...first.typeRanges]);
+  });
+});

--- a/packages/cache/src/sections/entities.ts
+++ b/packages/cache/src/sections/entities.ts
@@ -26,6 +26,11 @@ import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
  *   - geometryIndex: Int32Array[count]
  *   - typeRangeCount: uint16
  *   - typeRanges: [type:uint16, start:uint32, end:uint32][]
+ *
+ * The typeRanges triples are vestigial on read: `readEntities` derives the
+ * spans from the typeEnum column instead, because pre-#3101 caches stored
+ * `start + count` here and the format version does not distinguish them.
+ * They are still written so the section layout is unchanged.
  */
 export function writeEntities(writer: BufferWriter, entities: EntityTable): void {
   const count = entities.count;
@@ -74,22 +79,27 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
   const definedByType = reader.readInt32Array(count);
   const geometryIndex = reader.readInt32Array(count);
 
-  // Read type ranges
+  // Read (and discard) the stored type-range triples. The bytes must still be
+  // consumed to keep the reader aligned, but their meaning is not trustworthy:
+  // caches written before #3101 hold `start + count`, later ones hold a
+  // `[firstRow, lastRow + 1]` span, and FORMAT_VERSION was deliberately not
+  // bumped (header.ts accepts any version <= FORMAT_VERSION by design), so
+  // both vintages arrive here indistinguishable. The spans are derived from
+  // the live typeEnum column below instead.
   const typeRangeCount = reader.readUint16();
-  const typeRanges = new Map<IfcTypeEnum, { start: number; end: number }>();
 
   for (let i = 0; i < typeRangeCount; i++) {
-    const type = reader.readUint16() as IfcTypeEnum;
-    const start = reader.readUint32();
-    const end = reader.readUint32();
-    typeRanges.set(type, { start, end });
+    reader.readUint16(); // type
+    reader.readUint32(); // start
+    reader.readUint32(); // end (or count, for a pre-#3101 cache)
   }
 
   // Build EntityTable with methods
   const HAS_GEOMETRY = 0b00000001;
 
-  // Build correct per-type index arrays for getByType()
-  // typeRanges assumes contiguous entities per type, which fails with interleaved IFC files
+  // Build correct per-type index arrays. Every row of a type is listed, so
+  // this survives IFC files that interleave types — unlike the serialized
+  // typeRanges, which cannot express more than one contiguous run per type.
   const typeIndices = new Map<IfcTypeEnum, number[]>();
   for (let i = 0; i < count; i++) {
     const t = typeEnum[i] as IfcTypeEnum;
@@ -99,6 +109,13 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
       typeIndices.set(t, arr);
     }
     arr.push(i);
+  }
+
+  // Derive the spans from the same index arrays, so the one structure that
+  // survives interleaving feeds both getByType() and the public typeRanges.
+  const typeRanges = new Map<IfcTypeEnum, { start: number; end: number }>();
+  for (const [type, indices] of typeIndices) {
+    typeRanges.set(type, { start: indices[0], end: indices[indices.length - 1] + 1 });
   }
 
   // PRE-BUILD INDEX MAP: O(n) once, then O(1) lookups


### PR DESCRIPTION
Closes #3109. Follow-up to #3101, which fixed the builder — this closes the window for caches **already on disk**.

To be precise about what this is: the mixed-meaning window is the **status quo**, not damage #3101 caused. It existed before that PR and would exist had it not merged, which is why it correctly did not block the merge.

## Why a version bump would not have helped

`FORMAT_VERSION` is 13 and was deliberately left alone. `header.ts:82` throws only on `version > FORMAT_VERSION`, so older caches are accepted **by design**, and the codebase relies on that with per-section migrations. Bumping changes nothing for an existing v13 cache and would assert a format change that did not happen — only the third field's *meaning* changed, not the layout.

So a pre-#3101 cache deserializes `start + count` triples and `entities.ts` set them straight onto the public `EntityTable.typeRanges`.

## The fix reuses the derivation that already existed

`readEntities` was already building per-type index arrays for `getByType()`. The triples are now consumed and discarded — the bytes must still be read to keep the reader aligned — and the map is derived from those same arrays:

```ts
for (const [type, indices] of typeIndices) {
  typeRanges.set(type, { start: indices[0], end: indices[indices.length - 1] + 1 });
}
```

**One producer, one structure.** Adding a second derivation would have recreated the exact shape #3101 was about.

Two stale comments were corrected rather than left to mislead: the note above `typeIndices` claimed `typeRanges` assumes contiguity, which is no longer true of the value this function returns, and the write-format doc block now records that the triples are vestigial on read.

## RED, verbatim

```
 ❯ src/sections/entities.test.ts (11 tests | 6 failed)
     × gives span semantics for a pre-#3101 cache with interleaved types
AssertionError: expected { start: +0, end: 3 } to deeply equal { start: +0, end: 5 }
-   "end": 5,
+   "end": 3,
```

The fixture is rows 0/2/4 `IfcWall`, 1/3 `IfcSpace` — **neither type contiguous**, and both `start` and `end` differ between the two forms, so no assertion can be satisfied by the wrong one. A contiguous fixture cannot tell `start + count` from a span, which is what kept the original bug invisible.

The payload comes from `writeEntities` on a table whose `typeRanges` hold pre-#3101 `start + count`, so it is **byte-identical to what an old writer emitted**. It is read back through the public `EntityTable.typeRanges`, never through `typeIndices` — the existing test deletes `columns.typeRanges` before rebuilding, which is precisely why the builder half went unnoticed.

## Both directions pinned

Old triples (`Wall 0+3`, `Space 1+2`) and new spans (`Wall [0,5)`, `Space [1,4)`) both hydrate to `{0,5}` / `{1,4}`, and a third test asserts the two hydrations are equal element-for-element. A fix that only handled the old form would silently break caches written since #3101.

## What the displaced straight-through assignment did, now pinned

- single-row type → one-wide span (`IfcDoor {1,2}`)
- type absent from the column → no entry, `size` exact
- empty table → empty map
- map ordering → first appearance in the type column (was serialized order; identical for anything the builder wrote)
- second write round-trips the derived spans

**One deliberate behaviour change, asserted rather than left implicit:** a stored triple for a type that no row carries is now **dropped**. Only reachable from a corrupt or hand-written cache, and an empty range names no rows.

## Mutants — each verified by running, source restored from a saved copy

| mutant | killed by |
|---|---|
| `end = lastIndex` (off-by-one) | `gives span semantics for a pre-#3101 cache with interleaved types`, +3 more |
| `start = indices[last]` (last-seen, not first-seen) | same, plus `covers every row of its type, and its endpoints are rows of that type` |
| `end = indices[0] + indices.length` (contiguity assumed) | same, plus `gives a single-row type a one-wide span` |
| trust the stored triples (the bug itself) | the 6-failure RED run above |

## Left alone, and worth someone's attention

`readEntities` is a near-duplicate of `entityTableFromColumns` in `packages/data` across the whole closure block — **a second, separate two-producers shape.** Out of scope here, but it is the same class of divergence.

## Verification

`packages/cache` **86 → 97** tests (10 → 11 files, 0 failures); `packages/data` 164 passed, checked for fallout. `typecheck` OK; `pnpm turbo run build --filter="./packages/*"` 45/45 then `check:api-surface` unchanged at 4242 exports; `check-changesets`, `check-test-wiring`, `check-test-glob-coverage` (0 unrun), `check-source-text-assertions`, `check:vitest-timeout-audit` all clean. `add-license-headers --check` reports 96 pre-existing misses, all `rust/**`, none from this branch.

Environment trap closed by inspection **and** by consequence: `packages/cache/node_modules/@ifc-lite/data` symlinks inside the worktree, and the mutation runs are themselves the proof the suite reads local source — edits to `entities.ts` moved the results.

Nothing weakened, no skip, no fixture adjusted, no ratchet or digest touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache hydration to correctly derive entity type ranges, including caches with interleaved entity types.
  - Preserved compatibility with existing cache data formats.
  - Improved type-based lookups and handling of empty, missing, or single-row entity types.
- **Tests**
  - Added comprehensive coverage for cache hydration, type lookups, and round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->