### PR TITLE
fix(processing): a cycle-truncated symbolic walk was indistinguishable from a complete one

### DIFF
--- a/.changeset/symbolic-cycle-truncation-reason.md
+++ b/.changeset/symbolic-cycle-truncation-reason.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/server-client": patch
+---
+
+Fix a symbolic-extraction cycle silently truncating with no reported reason.
+
+`extract_symbolic_item`'s path guard (`ItemWalk::enter_node`) returns `false` when the walk revisits a node already on its current path — the representation graph closes a cycle. Both call sites (`item_walk.rs`, for a revisited item id, and `items.rs`, for a revisited representation reached through a different item id) dropped the subtree with a bare `return` and recorded nothing, so a cycle-truncated `SymbolicData` was byte-identical to a complete one: no field, count, or flag distinguished them.
+
+Both sites now call the existing `note_item_bound` reporting mechanism with a new `SymbolicTruncationReason::ItemCycle` variant (wire spelling `item-cycle`), so a cycle-truncated result now carries `truncated: { reason: "item-cycle", emitted, limit: undefined }` like every other bound. `SymbolicTruncationReason` on the TypeScript side gains the same variant.

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -387,10 +387,9 @@ export interface SymbolicTruncation {
   /**
    * The bound's numeric value, when the reason has one.
    *
-   * ABSENT for `item-depth`, `item-revisits` and `item-cycle`: those bounds
-   * are per representation item, so there is no file-level number to compare
-   * `emitted` against, and rendering "showing {emitted} of {limit}" for them
-   * would invent a relationship that does not exist.
+   * ABSENT for `item-depth`, `item-revisits` and `item-cycle`: those bounds are
+   * per representation item, so there is no file-level number to compare
+   * `emitted` against, and "showing {emitted} of {limit}" would invent one.
    */
   limit?: number;
 }

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -376,7 +376,8 @@ export type SymbolicTruncationReason =
   | 'element-count'
   | 'output-bytes'
   | 'item-depth'
-  | 'item-revisits';
+  | 'item-revisits'
+  | 'item-cycle';
 
 export interface SymbolicTruncation {
   /** Which bound fired. */
@@ -386,10 +387,10 @@ export interface SymbolicTruncation {
   /**
    * The bound's numeric value, when the reason has one.
    *
-   * ABSENT for `item-depth` and `item-revisits`: those bounds are per
-   * representation item, so there is no file-level number to compare `emitted`
-   * against, and rendering "showing {emitted} of {limit}" for them would
-   * invent a relationship that does not exist.
+   * ABSENT for `item-depth`, `item-revisits` and `item-cycle`: those bounds
+   * are per representation item, so there is no file-level number to compare
+   * `emitted` against, and rendering "showing {emitted} of {limit}" for them
+   * would invent a relationship that does not exist.
    */
   limit?: number;
 }

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1597,9 +1597,9 @@ export class SymbolicRepresentationCollection {
     readonly truncatedLimit: number | undefined;
     /**
      * Which bound stopped extraction, else `undefined`. One of
-     * `element-count`, `output-bytes`, `item-depth`, `item-revisits` —
-     * the same kebab-case strings the JSON path emits, so a consumer reading
-     * either surface reads one vocabulary.
+     * `element-count`, `output-bytes`, `item-depth`, `item-revisits`,
+     * `item-cycle` — the same kebab-case strings the JSON path emits, so a
+     * consumer reading either surface reads one vocabulary.
      */
     readonly truncatedReason: string | undefined;
 }

--- a/rust/processing/src/symbolic/item_walk.rs
+++ b/rust/processing/src/symbolic/item_walk.rs
@@ -213,6 +213,7 @@ pub(super) fn extract_symbolic_item_at(
         }
     }
     if !walk.enter_node(item.id) {
+        out.note_item_bound(SymbolicTruncationReason::ItemCycle);
         return;
     }
     extract_symbolic_item_inner(

--- a/rust/processing/src/symbolic/items.rs
+++ b/rust/processing/src/symbolic/items.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::output_cap::SymbolicAccumulator;
+use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
 use super::rebase::RenderFrameRebase;
 use ifc_lite_core::{DecodedEntity, EntityDecoder, IfcType};
 use std::collections::HashMap;
@@ -119,6 +119,7 @@ pub(super) fn extract_symbolic_item_inner(
             // re-enters the walk through something that is not an item, so the
             // item ids alone cannot see the cycle it closes.
             if !walk.enter_node(mapped_rep_id) {
+                out.note_item_bound(SymbolicTruncationReason::ItemCycle);
                 return;
             }
             for sub_item in items {

--- a/rust/processing/src/symbolic/items_cycle_tests.rs
+++ b/rust/processing/src/symbolic/items_cycle_tests.rs
@@ -17,7 +17,7 @@ use super::item_walk::{
     extract_symbolic_item, extract_symbolic_item_with_revisit_budget, MAX_ITEM_DEPTH,
     MAX_ITEM_REVISITS,
 };
-use super::output_cap::SymbolicAccumulator;
+use super::output_cap::{SymbolicAccumulator, SymbolicTruncationReason};
 use super::primitives::SymbolicData;
 use super::rebase::RenderFrameRebase;
 use super::transform::Transform2D;
@@ -439,6 +439,99 @@ fn a_large_flat_set_is_not_truncated() {
         out.polylines.len(),
         n,
         "a well-formed flat set must emit every element; charging first visits truncates it"
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// #3108: a cycle-truncated `SymbolicData` must be distinguishable on the wire
+// from a complete one, and by a NAMED reason -- not merely "something was
+// dropped". Each pair below holds the shape fixed and only breaks (cyclic) or
+// keeps (acyclic) the one edge that closes the loop, so the two inputs are
+// otherwise equivalent and any difference in `truncated` is attributable to
+// the cycle guard, not to some other divergence between the fixtures.
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Site 1: `item_walk.rs`'s `enter_node(item.id)` -- the SAME item id revisited
+/// on the current path. #30 is a mapped item whose representation's own Items
+/// list points back at #30 itself.
+#[test]
+fn item_walk_cycle_is_reported_with_the_cycle_reason() {
+    let cyclic = run(
+        &wrap("#30=IFCMAPPEDITEM(#40,$);\n#40=IFCREPRESENTATIONMAP($,#50);\n#50=IFCSHAPEREPRESENTATION($,$,$,(#30));\n"),
+        30,
+    );
+    // Otherwise-equivalent acyclic input: #50's Items list points at a
+    // distinct leaf polyline (#31) instead of back at #30. Same shape --
+    // one mapped item, one representation map, one representation -- with
+    // only the closing edge changed.
+    let acyclic = run(
+        &wrap(
+            "#30=IFCMAPPEDITEM(#40,$);\n#40=IFCREPRESENTATIONMAP($,#50);\n\
+             #50=IFCSHAPEREPRESENTATION($,$,$,(#31));\n\
+             #31=IFCPOLYLINE((#60,#61));\n\
+             #60=IFCCARTESIANPOINT((0.,0.));\n#61=IFCCARTESIANPOINT((1.,1.));\n",
+        ),
+        30,
+    );
+
+    assert!(
+        acyclic.truncated.is_none(),
+        "the acyclic control must be a complete result: {:?}",
+        acyclic.truncated
+    );
+    assert_eq!(
+        cyclic.truncated.as_ref().map(|t| t.reason),
+        Some(SymbolicTruncationReason::ItemCycle),
+        "a cycle closed through item_walk's enter_node(item.id) must be reported \
+         with the cycle reason, not left indistinguishable from the acyclic \
+         control above: {:?}",
+        cyclic.truncated
+    );
+}
+
+/// Site 2: `items.rs`'s `enter_node(mapped_rep_id)` -- the SAME representation
+/// re-entered through a DIFFERENT item id, so the item-id guard above never
+/// fires. Two distinct mapped items (#30, #31) both resolve to representation
+/// #50; #50's own Items list holds #31, so walking #30 enters #50 once
+/// directly and once again while resolving #31.
+#[test]
+fn items_rs_representation_cycle_is_reported_with_the_cycle_reason() {
+    let cyclic = run(
+        &wrap(
+            "#30=IFCMAPPEDITEM(#40,$);\n#31=IFCMAPPEDITEM(#41,$);\n\
+             #40=IFCREPRESENTATIONMAP($,#50);\n#41=IFCREPRESENTATIONMAP($,#50);\n\
+             #50=IFCSHAPEREPRESENTATION($,$,$,(#31));\n",
+        ),
+        30,
+    );
+    // Otherwise-equivalent acyclic input: #41 resolves to a DIFFERENT
+    // representation (#51) that terminates in a real leaf polyline instead of
+    // looping back through #50. Same two-mapped-item shape, only the closing
+    // edge changed.
+    let acyclic = run(
+        &wrap(
+            "#30=IFCMAPPEDITEM(#40,$);\n#31=IFCMAPPEDITEM(#41,$);\n\
+             #40=IFCREPRESENTATIONMAP($,#50);\n#41=IFCREPRESENTATIONMAP($,#51);\n\
+             #50=IFCSHAPEREPRESENTATION($,$,$,(#31));\n\
+             #51=IFCSHAPEREPRESENTATION($,$,$,(#32));\n\
+             #32=IFCPOLYLINE((#60,#61));\n\
+             #60=IFCCARTESIANPOINT((0.,0.));\n#61=IFCCARTESIANPOINT((1.,1.));\n",
+        ),
+        30,
+    );
+
+    assert!(
+        acyclic.truncated.is_none(),
+        "the acyclic control must be a complete result: {:?}",
+        acyclic.truncated
+    );
+    assert_eq!(
+        cyclic.truncated.as_ref().map(|t| t.reason),
+        Some(SymbolicTruncationReason::ItemCycle),
+        "a cycle closed through items.rs's enter_node(mapped_rep_id) must be \
+         reported with the cycle reason, not left indistinguishable from the \
+         acyclic control above: {:?}",
+        cyclic.truncated
     );
 }
 

--- a/rust/processing/src/symbolic/output_cap.rs
+++ b/rust/processing/src/symbolic/output_cap.rs
@@ -106,6 +106,13 @@ pub enum SymbolicTruncationReason {
     /// One representation item exhausted its revisit budget: the item was a
     /// large acyclic fan-out, or a legitimate deeply-nested block import.
     ItemRevisits,
+    /// The walk's path guard (`ItemWalk::enter_node`) refused to re-enter a
+    /// node already on the current path -- a genuine cycle in the
+    /// representation graph, not merely a large fan-out. Distinct from
+    /// [`Self::ItemRevisits`], whose budget can also be exhausted by an
+    /// acyclic file (#2938's lead case); this reason is a cycle and nothing
+    /// else (#3108).
+    ItemCycle,
 }
 
 impl SymbolicTruncationReason {
@@ -121,6 +128,7 @@ impl SymbolicTruncationReason {
             Self::OutputBytes => "output-bytes",
             Self::ItemDepth => "item-depth",
             Self::ItemRevisits => "item-revisits",
+            Self::ItemCycle => "item-cycle",
         }
     }
 }
@@ -246,7 +254,9 @@ impl SymbolicAccumulator {
     fn record(&mut self, reason: SymbolicTruncationReason) {
         let severity = |r: SymbolicTruncationReason| match r {
             SymbolicTruncationReason::ElementCount | SymbolicTruncationReason::OutputBytes => 1,
-            SymbolicTruncationReason::ItemDepth | SymbolicTruncationReason::ItemRevisits => 0,
+            SymbolicTruncationReason::ItemDepth
+            | SymbolicTruncationReason::ItemRevisits
+            | SymbolicTruncationReason::ItemCycle => 0,
         };
         match self.reason {
             Some(existing) if severity(existing) >= severity(reason) => {}
@@ -377,7 +387,8 @@ impl SymbolicAccumulator {
                 // file-level `emitted` would invite the reader to compare two
                 // numbers that are not comparable.
                 SymbolicTruncationReason::ItemDepth
-                | SymbolicTruncationReason::ItemRevisits => None,
+                | SymbolicTruncationReason::ItemRevisits
+                | SymbolicTruncationReason::ItemCycle => None,
             };
             self.data.truncated = Some(SymbolicTruncation { reason, emitted, limit });
         }

--- a/rust/processing/src/symbolic/output_cap_tests.rs
+++ b/rust/processing/src/symbolic/output_cap_tests.rs
@@ -531,7 +531,8 @@ fn the_wire_spellings_match_serde() {
         SymbolicTruncationReason::ElementCount
         | SymbolicTruncationReason::OutputBytes
         | SymbolicTruncationReason::ItemDepth
-        | SymbolicTruncationReason::ItemRevisits => {}
+        | SymbolicTruncationReason::ItemRevisits
+        | SymbolicTruncationReason::ItemCycle => {}
     }
 
     for reason in [
@@ -539,6 +540,7 @@ fn the_wire_spellings_match_serde() {
         SymbolicTruncationReason::OutputBytes,
         SymbolicTruncationReason::ItemDepth,
         SymbolicTruncationReason::ItemRevisits,
+        SymbolicTruncationReason::ItemCycle,
     ] {
         let via_serde = serde_json::to_value(reason).expect("serializes");
         assert_eq!(

--- a/rust/wasm-bindings/src/zero_copy/symbolic_truncation.rs
+++ b/rust/wasm-bindings/src/zero_copy/symbolic_truncation.rs
@@ -30,9 +30,9 @@ impl SymbolicRepresentationCollection {
     }
 
     /// Which bound stopped extraction, else `undefined`. One of
-    /// `element-count`, `output-bytes`, `item-depth`, `item-revisits` —
-    /// the same kebab-case strings the JSON path emits, so a consumer reading
-    /// either surface reads one vocabulary.
+    /// `element-count`, `output-bytes`, `item-depth`, `item-revisits`,
+    /// `item-cycle` — the same kebab-case strings the JSON path emits, so a
+    /// consumer reading either surface reads one vocabulary.
     #[wasm_bindgen(getter, js_name = truncatedReason)]
     pub fn truncated_reason(&self) -> Option<String> {
         self.truncated


### PR DESCRIPTION
Closes #3108.

`walk.enter_node(id)` returning `false` means a cycle was detected and the subtree is dropped. Both call sites dropped it with a bare `return` and recorded nothing, so **a `SymbolicData` whose walk hit a cycle was byte-identical to one that completed.** No field, no count, no flag distinguished them — a consumer could not tell a full result from a partial one.

The reporting mechanism already existed and was in use **four lines above** the first silent return, which is what makes this an oversight rather than a design choice. So the fix uses `note_item_bound` at both sites rather than inventing a new signal.

- `rust/processing/src/symbolic/item_walk.rs:216`
- `rust/processing/src/symbolic/items.rs:121`

## A new reason, wired end to end

`SymbolicTruncationReason` had `ElementCount`, `OutputBytes`, `ItemDepth`, `ItemRevisits` — **none of which fits a cycle.** `ItemRevisits` is a *budget* on how often an item may be re-entered; a cycle is a different fact, and reporting one as the other would be its own kind of silence.

So `ItemCycle` (wire spelling `item-cycle`) was added following the existing pattern everywhere it appears: `as_wire_str`, `record`'s severity match (per-item, severity 0, like `ItemDepth`/`ItemRevisits`), `into_data`'s `limit` match (`None`, because a per-item bound has no file-level number), the exhaustive `the_wire_spellings_match_serde` test, the wasm doc comment listing valid strings, and the TS mirror in `packages/server-client/src/types.ts`.

The doc comment on `limit` was updated too — it enumerated which reasons omit the field, and a new per-item reason has to be listed there or the comment becomes wrong.

## RED, verbatim

```
thread '...items_rs_representation_cycle_is_reported_with_the_cycle_reason' panicked:
assertion `left == right` failed: a cycle closed through items.rs's
enter_node(mapped_rep_id) must be reported with the cycle reason, not left
indistinguishable from the acyclic control above: None
  left: None
 right: Some(ItemCycle)

thread '...item_walk_cycle_is_reported_with_the_cycle_reason' panicked:
assertion `left == right` failed: a cycle closed through item_walk's
enter_node(item.id) must be reported with the cycle reason, not left
indistinguishable from the acyclic control above: None
  left: None
 right: Some(ItemCycle)
```

## Why the obvious test would have proved nothing

A cycle-truncated result is byte-identical to a complete one, so a fixture asserting the cyclic case "produces something" **passes today**. Each test therefore builds a **cyclic input and an otherwise-equivalent acyclic control**, and asserts they differ in a named field:

- **`item_walk.rs`** — cyclic: `#30=IFCMAPPEDITEM(#40,$)` whose representation `#50` has `#30` back in its Items list. Control: identical shape, but `#50` points at a distinct leaf polyline `#31`.
- **`items.rs`** — cyclic: two distinct mapped items `#30`/`#31` resolving through *different* `IfcRepresentationMap`s to the **same** representation `#50`, whose Items list holds `#31`. So `#50` is re-entered under a *different item id* and never trips the `item_walk` guard. Control: `#41` resolves to a separate representation terminating in a real leaf.

That second fixture is the point — the two sites are reached by genuinely different IFC shapes, and a single fixture tripping only one leaves the other unpinned.

## Both sites pinned independently

Reverting each `note_item_bound` call **alone**:

| mutant | result |
|---|---|
| `item_walk.rs` call removed | only `item_walk_cycle_is_reported_with_the_cycle_reason` failed; the `items.rs` test stayed green |
| `items.rs` call removed | only `items_rs_representation_cycle_is_reported_with_the_cycle_reason` failed; the other stayed green |

Each mutant killed by exactly its intended named test.

## Verification

`ifc-lite-processing --lib` **116 → 118** passed, 0 failed. `ifc-lite-wasm --lib` **95 → 97**, 0 failed. `module_size_ratchet` 5/5 with allowlist and digest untouched. `clippy -p ifc-lite-processing -p ifc-lite-wasm --lib -- -D warnings` clean.

The TS half was verified separately, since the authoring worktree had no `node_modules` and said so rather than claiming it: `packages/server-client` typecheck OK, and a repo-wide grep found **no consumer that switches on these reason strings**, so the additive union member cannot break an exhaustive match.

Changeset: `@ifc-lite/server-client` patch — the TS union grew a member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Symbolic extraction now reports item and representation cycles explicitly as `item-cycle` truncation reasons.
  - The new reason is available across API and TypeScript responses.
  - Cycle truncation is distinguished from revisit limits and does not include a numeric limit.

- **Bug Fixes**
  - Prevented cyclic symbolic data from being silently truncated without an explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->