### PR TITLE
test(clash,renderer): two predicates nothing exercised at exactly zero

### DIFF
--- a/packages/clash/src/contact/tri-tri.test.ts
+++ b/packages/clash/src/contact/tri-tri.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Boundary-pinning test for `triTriIntersect`'s chord reconstruction
+ * (`triChord` in `contact/tri-tri.ts`).
+ *
+ * Mutation testing found this file has zero dedicated tests (only exercised
+ * indirectly through `contact.test.ts` / `world-frame.test.ts`, which never
+ * happen to hit an EXACT on-plane vertex): widening any one of the three
+ * `triChord` edge-crossing clauses from a strict `d0 < 0` to `d0 <= 0` (or the
+ * symmetric `>` -> `>=`) passed the full suite unchanged. That widened clause
+ * double-counts a vertex that sits exactly on the other triangle's plane —
+ * once via the edge-crossing clause (now falsely true), once via the
+ * dedicated `d0 === 0` on-plane-vertex push a few lines below — corrupting
+ * `pts` with a duplicate `first`/`last` and collapsing the reported chord to
+ * a zero-length segment at that vertex instead of the true intersection
+ * segment.
+ *
+ * This pins the currently-CORRECT behaviour so a future edit with that same
+ * shape (loosening a strict inequality) is caught immediately rather than
+ * silently reintroducing the corruption.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { triTriIntersect } from './tri-tri.js';
+import type { Triangle } from './triangle.js';
+
+describe('triTriIntersect — chord through a vertex exactly on the other plane', () => {
+  it('reports the true crossing segment, not a degenerate point, when one vertex sits exactly on the opposite plane', () => {
+    // B lies exactly in the z=0 plane.
+    const b: Triangle = { v0: [0, 0, 0], v1: [1, 0, 0], v2: [0, 1, 0] };
+    // A shares a vertex (0.2, 0.2, 0) exactly on B's plane, with its other
+    // two vertices straddling z=0 (one above, one below) so A genuinely
+    // crosses B's plane rather than merely touching it.
+    const a: Triangle = { v0: [0.2, 0.2, 0], v1: [0.5, 0.5, 1], v2: [0.5, 0.5, -1] };
+
+    const r = triTriIntersect(a, b, 1e-9);
+    expect(r.kind).toBe('cross');
+    if (r.kind !== 'cross') return;
+
+    // The true chord runs from A's on-plane vertex to where edge A.v1-A.v2
+    // crosses z=0 (the midpoint, by symmetry) — length ~0.424 m, not 0.
+    const dx = r.p1[0] - r.p0[0];
+    const dy = r.p1[1] - r.p0[1];
+    const dz = r.p1[2] - r.p0[2];
+    const len = Math.hypot(dx, dy, dz);
+    expect(len).toBeGreaterThan(0.1);
+
+    // Both reported endpoints must lie in B's plane (z=0) and be genuinely
+    // distinct points, not the same vertex reported twice.
+    expect(Math.abs(r.p0[2])).toBeLessThan(1e-9);
+    expect(Math.abs(r.p1[2])).toBeLessThan(1e-9);
+    const endpoints = [r.p0, r.p1].map((p) => p.map((c) => Math.round(c * 1e6)).join(','));
+    expect(endpoints[0]).not.toBe(endpoints[1]);
+  });
+});

--- a/packages/renderer/src/fill-predicates.test.ts
+++ b/packages/renderer/src/fill-predicates.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Boundary-pinning tests for `fill-predicates.ts`. This module has no
+ * dedicated test file — it is only exercised indirectly through
+ * `fill-triangulate.test.ts` / `fill-bridge-anchor.test.ts` /
+ * `symbolic-fill-triangulate.test.ts`, whose fixtures never happen to put a
+ * segment endpoint exactly ON another segment's line.
+ *
+ * Mutation testing found `properlyCross`'s first clause survives being
+ * widened from strict `< 0` to `<= 0`: the full suite of 42 fill-pipeline
+ * tests stays green. That widening makes `properlyCross(a, b, c, d)` report
+ * TRUE when `a` or `b` lies exactly on the infinite line through `c, d` —
+ * contradicting this file's own doc comment ("Shared endpoints and touching
+ * do not count") and `fill-bridge-anchor.ts`'s reliance on that contract to
+ * decide whether a candidate hole-bridge is clear.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { orient, pointOnSegment, properlyCross, samePoint } from './fill-predicates.js';
+
+describe('orient', () => {
+  it('is 0 for exactly collinear points', () => {
+    assert.strictEqual(orient({ x: 0, z: 0 }, { x: 2, z: 0 }, { x: 1, z: 0 }), 0);
+  });
+  it('sign flips with the two candidate points swapped', () => {
+    const p = { x: 0, z: 0 };
+    const q = { x: 2, z: 0 };
+    assert.strictEqual(orient(p, q, { x: 1, z: 1 }), 1);
+    assert.strictEqual(orient(p, q, { x: 1, z: -1 }), -1);
+  });
+});
+
+describe('properlyCross', () => {
+  it('is true for a genuine X crossing', () => {
+    const a = { x: 0, z: 0 };
+    const b = { x: 2, z: 2 };
+    const c = { x: 0, z: 2 };
+    const d = { x: 2, z: 0 };
+    assert.strictEqual(properlyCross(a, b, c, d), true);
+  });
+
+  it('is false when the tested edge only touches the bridge endpoint (T-junction), not a genuine crossing', () => {
+    // Bridge a->b runs along z=0 from x=0 to x=2. Edge c->d is the vertical
+    // line x=2, straddling z=0 — but it meets a->b exactly AT b (2,0), the
+    // bridge's own endpoint, not through its interior. This is the
+    // "shared endpoint" case the doc says must not count as a crossing:
+    // widening the first clause from `< 0` to `<= 0` (because b lies exactly
+    // on line c-d, product is 0) flips this to a false positive.
+    const a = { x: 0, z: 0 };
+    const b = { x: 2, z: 0 };
+    const c = { x: 2, z: 1 };
+    const d = { x: 2, z: -1 };
+    assert.strictEqual(properlyCross(a, b, c, d), false);
+  });
+
+  it('is false for two segments that merely touch at a shared endpoint', () => {
+    const a = { x: 0, z: 0 };
+    const b = { x: 2, z: 0 };
+    const c = { x: 2, z: 0 };
+    const d = { x: 2, z: 2 };
+    assert.strictEqual(properlyCross(a, b, c, d), false);
+  });
+
+  it('is false for two parallel, non-intersecting segments', () => {
+    const a = { x: 0, z: 0 };
+    const b = { x: 2, z: 0 };
+    const c = { x: 0, z: 1 };
+    const d = { x: 2, z: 1 };
+    assert.strictEqual(properlyCross(a, b, c, d), false);
+  });
+});
+
+describe('pointOnSegment', () => {
+  it('excludes endpoints when includeEnds is false', () => {
+    const a = { x: 0, z: 0 };
+    const b = { x: 2, z: 0 };
+    assert.strictEqual(pointOnSegment(a, a, b, false), false);
+    assert.strictEqual(pointOnSegment(b, a, b, false), false);
+    assert.strictEqual(pointOnSegment({ x: 1, z: 0 }, a, b, false), true);
+  });
+  it('includes endpoints when includeEnds is true', () => {
+    const a = { x: 0, z: 0 };
+    const b = { x: 2, z: 0 };
+    assert.strictEqual(pointOnSegment(a, a, b, true), true);
+    assert.strictEqual(pointOnSegment(b, a, b, true), true);
+  });
+  it('is false for a point off the line entirely', () => {
+    const a = { x: 0, z: 0 };
+    const b = { x: 2, z: 0 };
+    assert.strictEqual(pointOnSegment({ x: 1, z: 1 }, a, b, true), false);
+  });
+});
+
+describe('samePoint', () => {
+  it('is true only within tolerance scaled to the given extent', () => {
+    const a = { x: 0, z: 0 };
+    assert.strictEqual(samePoint(a, { x: 1e-13, z: 0 }, 1), true);
+    assert.strictEqual(samePoint(a, { x: 0.5, z: 0 }, 1), false);
+  });
+});


### PR DESCRIPTION
Mutation-swept `packages/clash` and `packages/renderer`, neither previously swept. **Test-only — no production code changed**, because both findings turned out to be untested-but-correct rather than broken.

Both gaps share a shape worth naming: a predicate whose **exactly-zero** case is unreachable from any existing fixture, because ordinary geometry fixtures land *near* a boundary but never *on* it.

## 1. `clash/src/contact/tri-tri.ts` — the chord when a vertex lies exactly on the other plane

`triChord`'s Möller chord reconstruction has no dedicated test; it is reached only through `contact.test.ts` and `world-frame.test.ts`, whose fixtures never place a triangle vertex exactly on the opposite triangle's plane.

Surviving mutant: widening one edge-crossing clause from `d0 < 0` to `d0 <= 0`. **The full 425-test clash suite stayed green.**

```
AssertionError: expected 0 to be greater than 0.1
 ❯ src/contact/tri-tri.test.ts:49:17
   expect(len).toBeGreaterThan(0.1);
```

Why that mutant is wrong: with a vertex exactly on the plane, the widened clause pushes that vertex into `pts` **twice** — once via the now-true edge clause, once via the dedicated `d0 === 0` on-plane check a few lines later. `first` and `last` become the same duplicated point, so the reported crossing segment **collapses to zero length** instead of returning the true chord.

The shipped code is correct: a direct probe confirms it returns `p0=(0.2,0.2,0)`, `p1=(0.5,0.5,0)` for the constructed case. Now pinned.

## 2. `renderer/src/fill-predicates.ts` — a T-junction bridge endpoint

No dedicated test; reached only through the fill-triangulate / bridge-anchor pipeline (42 tests), whose fixtures never place a bridge endpoint exactly on another edge's line.

Surviving mutant: `properlyCross`'s first clause widened from `< 0` to `<= 0`. **All 42 fill-pipeline tests stayed green.**

That mutant contradicts the function's **own doc comment** — *"Shared endpoints and touching do not count"* — which `fill-bridge-anchor.ts` relies on to decide whether a candidate hole-bridge is clear. Under it, a bridge merely *touching* a boundary vertex is misclassified as blocked.

New tests cover `orient`, `properlyCross` (genuine cross / T-junction / shared endpoint / parallel), `pointOnSegment` and `samePoint`; 1 of 10 assertions goes RED under the mutant.

**The symmetry avoided in both:** the fixture puts the value *exactly* at zero — a vertex on the plane, an endpoint on the line — which is precisely what a "nearby but not exact" fixture cannot see.

## Negative evidence — what the suites already catch

This matters more than usual here, because both packages turned out to be **unusually well hardened**. A `git branch -vv` found roughly **70 prior `mutation`/`audit`/`sweep` branches** in this repo, and several comments inside `aabb.test.ts`, `bvh.test.ts` and the disciplines-adjacent files are themselves artifacts of earlier sweeps. That is why most comparison operators, tolerance directions and index arithmetic tried here were already pinned.

Killed: `inferClashSeverity`'s severity precedence `<`→`>` (2 failures); `isLeftOrOn`'s `cross >= 0`→`<= 0` (13 failures across two suites); `sameShape`'s `area <= 0` guard and `relClose`'s `<=` boundary; `classify`'s point-fallback forced to `"surface"`, killed by the explicit #2600-era RED test at 5 km from origin.

**One survivor investigated and deliberately not reported as a finding:** `convexHull2`'s collinear-pop `<= 0` → `< 0`. Area, perimeter, centroid and span are all mathematically invariant to keeping or dropping collinear boundary points, and no test asserts an exact hull vertex count — cosmetic, not a defect.

**One survivor reasoned about but not executed**, flagged as such rather than claimed: `broad.ts`'s self-clash `j <= i` → `j < i` appears protected by `isSameEntity`'s reference-identity check downstream. Not chased.

## Leads not chased

`engine-ts/obb.ts`, `depth.ts`, `narrow.ts`, `min-distance.ts` carry dense documentation referencing #2536, #2600, #1866, #1362/#1402 — strong evidence of prior sweeps, so they were skipped rather than re-litigated. `scene-raycaster.ts`, `post-processor.ts`, `instanced-render.ts`, `point-picker.ts`, `federation-registry.ts` and `edl-pass.ts` were surveyed by listing only, not read in depth.

## Verification

clash **425 → 426**, renderer **1116 → 1126**, all passing. `pnpm build` clean for both packages; repo-wide `typecheck` green at 1403 test files, with every test file on disk in a typecheck program.

Each finding was verified GREEN → mutate → RED → revert → GREEN, with the exact assertion recorded above.

The sweep stopped early at 5.1 GiB free disk rather than pressing on, so the unchased leads above are budget, not judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
