### PR TITLE
fix(merge): applyNodeCow silently dropped the DELETED tombstone branch

### DIFF
--- a/.changeset/component-state-cow-deleted-parity.md
+++ b/.changeset/component-state-cow-deleted-parity.md
@@ -1,0 +1,9 @@
+---
+"@ifc-lite/merge": patch
+---
+
+Close a live divergence between `applyNode` and `applyNodeCow` in component-state extraction: `applyNodeCow` silently omitted the `ifclite::deleted` tombstone branch that `applyNode` has, so a `DELETED` opinion reaching it fell through into an ordinary component write instead of setting the entity's `deleted`/`explicitDeleted` flags.
+
+This was safe today only because `projectStackStates` bails to the `extractStackState` fallback (never reaching `applyNodeCow`) whenever any layer in the stack carries a `DELETED` opinion — a behavioural delta held safe by a caller's guard rather than by anything structural, and invisible through the public API.
+
+Both functions now delegate to one shared `applyNodeToEntity` core, parameterised only by whether a touched component is copied before mutation (the one real difference: `applyNodeCow`'s clone-on-write entities may still alias untouched ancestor state). No other branch can drift between the two. No public API change.

--- a/packages/merge/src/component-state.test.ts
+++ b/packages/merge/src/component-state.test.ts
@@ -16,8 +16,15 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { IfcxFile } from '@ifc-lite/ifcx';
-import { componentKeyForAttribute, extractStackState, projectStackStates } from './component-state.js';
+import type { IfcxFile, IfcxNode } from '@ifc-lite/ifcx';
+import {
+  applyNode,
+  applyNodeCow,
+  componentKeyForAttribute,
+  extractStackState,
+  projectStackStates,
+} from './component-state.js';
+import type { EntityState } from './component-state.js';
 import { planThreeWayMerge } from './three-way.js';
 
 describe('componentKeyForAttribute', () => {
@@ -195,5 +202,52 @@ describe('projectSide folds a multi-layer suffix weakest-first, per attribute', 
       [FIRE]: { type: 'IfcLabel', value: 'REI120' },
       [SMOKE]: { type: 'IfcLabel', value: 'S30' },
     });
+  });
+});
+
+/**
+ * RED-first pin for the applyNode / applyNodeCow divergence reported by a
+ * prior sweep (PR #3099): `applyNodeCow` omitted the `IFCLITE_ATTR.DELETED`
+ * branch that `applyNode` has. `projectStackStates` currently bails to
+ * `null` (forcing the `extractStackState` fallback) on ANY layer carrying
+ * a `DELETED` opinion, so `applyNodeCow` is never reached with one through
+ * the public API — the delta is real but currently unobservable from
+ * outside this module. This suite calls `applyNodeCow` directly (exported
+ * for exactly this purpose) to pin the two functions against each other at
+ * the level where the divergence WAS observable, sidestepping the caller's
+ * bail.
+ */
+describe('applyNode / applyNodeCow parity on IFCLITE_ATTR.DELETED', () => {
+  function freshEntity(path: string): EntityState {
+    return {
+      path,
+      components: new Map(),
+      children: new Map(),
+      inherits: new Map(),
+      deleted: false,
+      explicitDeleted: false,
+    };
+  }
+
+  const deleteNode: IfcxNode = {
+    path: 'wall-guid-1',
+    attributes: { 'ifclite::deleted': true },
+  } as unknown as IfcxNode;
+
+  it('applyNode sets deleted/explicitDeleted on a DELETED opinion (reference behaviour)', () => {
+    const entity = freshEntity('wall-guid-1');
+    applyNode(entity, deleteNode);
+    expect(entity.deleted).toBe(true);
+    expect(entity.explicitDeleted).toBe(true);
+    // The tombstone must not leak into components as an ordinary attribute.
+    expect(entity.components.size).toBe(0);
+  });
+
+  it('applyNodeCow must agree with applyNode on a DELETED opinion', () => {
+    const entity = freshEntity('wall-guid-1');
+    applyNodeCow(entity, deleteNode);
+    expect(entity.deleted).toBe(true);
+    expect(entity.explicitDeleted).toBe(true);
+    expect(entity.components.size).toBe(0);
   });
 });

--- a/packages/merge/src/component-state.ts
+++ b/packages/merge/src/component-state.ts
@@ -219,7 +219,22 @@ export function extractStackState(layers: readonly IfcxFile[]): StackState {
   return state;
 }
 
-function applyNode(entity: EntityState, node: IfcxNode): void {
+/**
+ * Shared node-application core for both `applyNode` and `applyNodeCow`.
+ *
+ * A prior sweep (PR #3099) found the two had drifted: `applyNodeCow`
+ * silently omitted the `IFCLITE_ATTR.DELETED` branch that `applyNode` has,
+ * safe only because `projectStackStates` bails to `null` (forcing the
+ * `extractStackState` fallback) whenever any layer carries a `DELETED`
+ * opinion — a live behavioural delta held safe by a caller's guard rather
+ * than by anything structural. Parameterising the ONE difference between
+ * the two call sites (whether a component object is copied before mutation
+ * — required only when the entity may be aliased with another side's
+ * untouched state, as in `projectSide`'s clone-on-write fold) makes every
+ * other branch — including this one — impossible to omit from just one of
+ * them; there is now only one place either could drift from.
+ */
+function applyNodeToEntity(entity: EntityState, node: IfcxNode, options: { cow: boolean }): void {
   if (node.children) {
     for (const [name, child] of Object.entries(node.children)) {
       if (child === null) entity.children.delete(name);
@@ -241,7 +256,8 @@ function applyNode(entity: EntityState, node: IfcxNode): void {
     }
     if (key.startsWith(IFCLITE_ATTR.DERIVED)) continue;
     const componentKey = resolveComponentKey(entity, key, value);
-    const component = entity.components.get(componentKey) ?? {};
+    const existing = entity.components.get(componentKey) ?? {};
+    const component: ComponentAttributes = options.cow ? { ...existing } : existing;
     if (value === null) {
       delete component[key];
       if (Object.keys(component).length === 0) {
@@ -253,6 +269,10 @@ function applyNode(entity: EntityState, node: IfcxNode): void {
     }
     entity.components.set(componentKey, component);
   }
+}
+
+export function applyNode(entity: EntityState, node: IfcxNode): void {
+  applyNodeToEntity(entity, node, { cow: false });
 }
 
 // ---------------------------------------------------------------------------
@@ -383,36 +403,13 @@ function dropEmptyShells(state: StackState): void {
  * `applyNode` for cloned side entities: component objects are copied
  * before mutation so ancestor-shared references are never written through
  * — reference equality stays a valid "unchanged" signal in the matrix.
+ * Delegates to `applyNodeToEntity` (see its docstring) so every other
+ * branch — the DELETED tombstone, the DERIVED skip, child/inherit slot
+ * handling — stays structurally identical to `applyNode`, not merely
+ * copy-pasted and hoped to stay in sync.
  */
-function applyNodeCow(entity: EntityState, node: IfcxNode): void {
-  if (node.children) {
-    for (const [name, child] of Object.entries(node.children)) {
-      if (child === null) entity.children.delete(name);
-      else entity.children.set(name, child);
-    }
-  }
-  if (node.inherits) {
-    for (const [role, target] of Object.entries(node.inherits)) {
-      if (target === null) entity.inherits.delete(role);
-      else entity.inherits.set(role, target);
-    }
-  }
-  if (!node.attributes) return;
-  for (const [key, value] of Object.entries(node.attributes)) {
-    if (key.startsWith(IFCLITE_ATTR.DERIVED)) continue;
-    const componentKey = resolveComponentKey(entity, key, value);
-    const component: ComponentAttributes = { ...(entity.components.get(componentKey) ?? {}) };
-    if (value === null) {
-      delete component[key];
-      if (Object.keys(component).length === 0) {
-        entity.components.delete(componentKey);
-        continue;
-      }
-    } else {
-      component[key] = value;
-    }
-    entity.components.set(componentKey, component);
-  }
+export function applyNodeCow(entity: EntityState, node: IfcxNode): void {
+  applyNodeToEntity(entity, node, { cow: true });
 }
 
 /** Hash + value snapshot for conflict records and fold detection. */


### PR DESCRIPTION
`packages/merge/src/component-state.ts` held two near-duplicate functions that must agree, with nothing enforcing it. **`applyNodeCow` was missing `applyNode`'s `IFCLITE_ATTR.DELETED` branch.**

Under the Cow path a `DELETED` key fell through into the generic component-write path, resolved to `attr:ifclite::deleted`, and was **stored as an ordinary component attribute instead of setting the tombstone flags.**

## Latent, not live — and the reason is the point

This is currently unreachable through the public API, and it is worth being precise about why: `applyNodeCow` is called only from `projectSide`, called only from `projectStackStates`, which returns `null` — forcing the `extractStackState` fallback that uses `applyNode` — whenever **any** layer carries a `DELETED` opinion. Grep confirms no other call site.

So the delta was held safe entirely by a caller's bail. Nothing structural. Change that bail, add a second caller, and it becomes a live tombstone-loss bug.

Because neither function was exported, reaching the divergence at all required calling `applyNodeCow` directly. That framing is the finding: **the public API masks it completely.**

## RED, verbatim

```
FAIL src/component-state.test.ts > applyNode / applyNodeCow parity on IFCLITE_ATTR.DELETED
     > applyNodeCow must agree with applyNode on a DELETED opinion
AssertionError: expected false to be true
```

`applyNode`'s own parity test passed at the same moment, which is what proves the divergence was one-sided rather than a broken fixture.

## What was achieved: one implementation, one entry point

Not a shared helper the two happen to call — a single core. `applyNode` and `applyNodeCow` are now thin wrappers over `applyNodeToEntity(entity, node, { cow })`.

The `cow` flag is the **one genuine constraint** the Cow path has, and it is preserved rather than merged away: its entities may alias untouched ancestor state in `projectSide`'s `o`/`t` maps, so mutating a shared component object in place would corrupt the other side. That is why it shallow-copies (`{ ...existing }`) before mutating, and it still does.

## Verified there was no *other* delta

A line-by-line diff found exactly one substantive difference beyond `DELETED`: the copy-before-mutate above. That is the intentional, documented COW behaviour — not a bug, and kept.

Every branch the survivor now handles, since Cow was the incomplete side: children add/remove, inherits add/remove, the `DELETED` tombstone (**newly executed by the Cow path**), the `DERIVED` skip, `resolveComponentKey` lookup, null-value member deletion, and component set. The newly-reached branch is correct rather than merely convenient — the old `applyNodeCow` docstring already declared its intent to be *"`applyNode` for cloned side entities."*

## The mutation proof that it is structural

Removing the shared `DELETED` branch from `applyNodeToEntity` fails **both** named tests — `applyNode sets deleted/explicitDeleted on a DELETED opinion (reference behaviour)` *and* `applyNodeCow must agree with applyNode on a DELETED opinion`.

One mutation, both entry points. That is the difference between structural parity and two copies that coincidentally agree today.

## Verification

`packages/merge` **107 passed / 4 skipped → 109 passed / 4 skipped** (2 new parity tests). `tsc --noEmit` and `oxlint` clean on the touched files; `pnpm install --frozen-lockfile`, dependency builds, full merge suite before/after/mutant, and the repo's test-typecheck script all run. The mutation was restored from a saved copy and the final `git diff` confirms only the intended three-file change.

Changeset included (`@ifc-lite/merge` patch): a real behavioural fix to published package code, with the currently-latent status stated explicitly in the body rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when applying entity updates, including deletion markers and inherited attributes.
  - Ensured deleted entities are flagged correctly while deletion markers are excluded from component data.
  - Preserved copy-on-write behavior by cloning only components that are modified.

- **Tests**
  - Added coverage confirming consistent behavior across standard and copy-on-write updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->