### PR TITLE
test(collab-server,lens): two conjunctions no fixture could tell from their parts

### DIFF
--- a/packages/collab-server/test/access-control.test.ts
+++ b/packages/collab-server/test/access-control.test.ts
@@ -169,6 +169,26 @@ describe('mint rate limiting (per client IP)', () => {
       ),
     ).toBeNull();
   });
+
+  it('refuses an admin bearer for room A minting a link for already-claimed room B', async () => {
+    const ac = create({ secret: SECRET, dir: freshDir(), mintRateCapacity: 100 });
+    const authorize = authorizeOf(ac);
+    // Claim room A (mints its admin bearer) and room B independently.
+    expect(
+      await authorize({ roomId: 'm/room-a', role: 'editor' }, { bearerClaims: null, clientIp: '1.1.1.10' }),
+    ).toBe('admin');
+    expect(
+      await authorize({ roomId: 'm/room-b', role: 'editor' }, { bearerClaims: null, clientIp: '1.1.1.11' }),
+    ).toBe('admin');
+    // Room A's admin bearer must not be able to mint a link for room B — the
+    // admin bypass is scoped to the bearer's OWN room, not "any admin token".
+    expect(
+      await authorize(
+        { roomId: 'm/room-b', role: 'admin' },
+        { bearerClaims: adminClaims('m/room-a'), clientIp: '1.1.1.12' },
+      ),
+    ).toBeNull();
+  });
 });
 
 describe('claimedRooms cap', () => {

--- a/packages/lens/src/matching.test.ts
+++ b/packages/lens/src/matching.test.ts
@@ -645,7 +645,7 @@ describe('matchesCriteria — classification', () => {
     // system+code filter must reject it even though each half independently
     // has a hit somewhere in the entity's classification list.
     const combinedProvider = createMockProvider([{ id: 3, type: 'IfcWall' }]);
-    (combinedProvider as Record<string, unknown>).getClassifications = (id: number) => {
+    combinedProvider.getClassifications = (id: number) => {
       if (id === 3) {
         return [
           { system: 'Uniclass', identification: 'Ss_25_10', name: 'Wrong code' },

--- a/packages/lens/src/matching.test.ts
+++ b/packages/lens/src/matching.test.ts
@@ -637,6 +637,30 @@ describe('matchesCriteria — classification', () => {
     const basicProvider = createMockProvider([{ id: 1, type: 'IfcWall' }]);
     expect(matchesCriteria({ type: 'classification', classificationSystem: 'x' }, 1, basicProvider)).toBe(false);
   });
+
+  it('requires system AND code together — a system-only or code-only hit on a DIFFERENT reference must not satisfy a combined filter', () => {
+    // id=3 has a classification whose system matches but whose code does not,
+    // and a separate classification whose code matches but whose system does
+    // not. Neither single reference satisfies BOTH constraints, so a combined
+    // system+code filter must reject it even though each half independently
+    // has a hit somewhere in the entity's classification list.
+    const combinedProvider = createMockProvider([{ id: 3, type: 'IfcWall' }]);
+    (combinedProvider as Record<string, unknown>).getClassifications = (id: number) => {
+      if (id === 3) {
+        return [
+          { system: 'Uniclass', identification: 'Ss_25_10', name: 'Wrong code' },
+          { system: 'OtherSystem', identification: 'Pr_60_10_32', name: 'Wrong system' },
+        ];
+      }
+      return [];
+    };
+    const c: LensCriteria = {
+      type: 'classification',
+      classificationSystem: 'Uniclass',
+      classificationCode: 'Pr_60_10_32',
+    };
+    expect(matchesCriteria(c, 3, combinedProvider)).toBe(false);
+  });
 });
 
 describe('matchesCriteria — material', () => {


### PR DESCRIPTION
Mutation-swept `packages/collab-server` and `packages/lens`, neither previously swept. **Test-only — no production code changed**, because both findings are untested-but-correct: the shipped logic is right, the discriminating fixture was missing.

Both gaps are the same shape — **a fixture that cannot tell a conjunction from its parts**, because nothing in it ever makes the two halves disagree.

## 1. `collab-server` — the admin re-mint room binding

`access-control.ts:385`:

```ts
if (bearerClaims?.room === room && bearerClaims.role === 'admin') return request.role;
```

Dropping the room-binding half leaves `if (bearerClaims?.role === 'admin')` — under which **an admin bearer for room A can mint a link for a different, already-claimed room B**, with any role, including admin.

**No existing test ever used `adminClaims(room)` with a room different from the request's `roomId`**, so one principal was only ever observing itself. A permission check that never sees an unauthorised caller cannot fail.

```
AssertionError: expected 'admin' to be null
- Expected: null
+ Received: "admin"
 ❯ test/access-control.test.ts:190:7
```

The new test claims rooms A and B independently, then asserts A's admin bearer cannot mint for B. I re-ran the mutation myself to confirm the pin is real rather than take the report: with the room binding dropped, `refuses an admin bearer for room A minting a link for already-claimed room B` is the **only** failure — 1 failed, 19 passed. Restored, green.

## 2. `lens` — the classification system+code filter's AND semantics

`matching.ts:227` — `if (systemMatch && codeMatch) return true;`. Mutating `&&` → `||` passed every existing test.

The existing fixture's single entity carried **one** classification reference whose system *and* code both matched, so the two operands never disagreed and `&&` was indistinguishable from `||`.

```
AssertionError: expected true to be false
- Expected: false
+ Received: true
 ❯ src/matching.test.ts:385:53
```

The new fixture gives one entity **two** references — one matching system with the wrong code, one matching code with the wrong system — so a combined filter that ORs them wrongly accepts. That is the "identity satisfied by every divergence" trap: any fixture where both halves match on the same reference is blind here.

## Prior-sweep check, since virgin ground cannot be assumed

`git branch -r | grep -iE 'mutation|sweep|audit'` found 35 branches. Only `upstream/collab-client-sweep` touched these paths, and diffing it **against its own merge-base rather than current main** showed zero actual changes to either package — the apparent diff was main's drift since. No test file in either package carries prior-PR sweep comments. Both are genuinely unswept.

## Negative evidence

`path-locks.ts`'s `matches()` — verified the `exemptUserIds` and `exemptRoles` short-circuits are each independently required, covered by the existing registry test. `matchesIfcType`'s exact-vs-subtype ordering, `evaluateLens`'s first-rule-wins `break`, and `engine.ts`'s count-descending sort all have dedicated tests already pinning the correct direction (`should match first rule only (short-circuit)`, `should sort legend by count descending`) — confirmed by reading rather than re-mutated, and reported as such.

## Leads not chased

`lens/src/discovery.ts`'s `count < SAMPLE_SIZE` boundary has no boundary test, but an off-by-one there only over- or under-samples by one entity during property discovery — low consequence.

`path-locks.ts`'s prefix boundary (`/a/bc` against a lock on `/a/b`) was surveyed and **deliberately not reported as a defect**: the raw `startsWith` semantics are documented as intentional, with the trailing separator being the caller's responsibility.

## Verification

`collab-server` access-control 20 passed; `lens` matching 105 passed; `tsc --noEmit` clean for both. `check-module-size.mjs` exits 0 — worth noting the authoring report claimed that script "does not exist in this checkout", which is wrong (it is present and runs); the conclusion that it did not apply happened to be right for a different reason, since the TS ratchet excludes test files and this branch touches only tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
