### PR TITLE
test(diff): the mutuality half of mutualNearestPairs was never observed

### DIFF
--- a/packages/diff/src/mutual-nearest.test.ts
+++ b/packages/diff/src/mutual-nearest.test.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { mutualNearestPairs } from './mutual-nearest.js';
+
+describe('mutualNearestPairs', () => {
+  it('never produces a pairing with a repeated base or head index (mutation-sweep finding)', () => {
+    // A is closer to X than to anything else, but X's OWN nearest neighbour is
+    // B, not A (B sits even closer to X than A does). Meanwhile B's nearest is
+    // Y (farther than X, but still B's best option) and Y's nearest is B too —
+    // so B-Y is mutual and A-X is NOT (A's chosen head, X, prefers B instead).
+    //
+    // A greedy "does `from` have SOME nearest counterpart" check (dropping the
+    // `nearestBase[h] === b` half of the mutuality test) accepts A-X purely
+    // because A's own scan found X — without ever checking whether X agrees.
+    // Confirmed by removing that check and running this exact fixture: the
+    // function then returns TWO pairs, both claiming head index 0 (X) —
+    // corrupting the 1:1 pairing this function's own doc promises ("Mutual
+    // pairs ... are necessarily disjoint").
+    const base: [number, number, number][] = [
+      [0, 0, 0], // A
+      [1.5, 0, 0], // B
+    ];
+    const head: [number, number, number][] = [
+      [1, 0, 0], // X — B's true nearest (dist 0.5), not A's (dist 1)
+      [3, 0, 0], // Y — B's fallback once X is taken
+    ];
+
+    const pairs = mutualNearestPairs(base, head, 10, () => true);
+
+    // Every base index and every head index appears in at most one pair.
+    const baseIndices = pairs.map((p) => p.base);
+    const headIndices = pairs.map((p) => p.head);
+    expect(new Set(baseIndices).size).toBe(baseIndices.length);
+    expect(new Set(headIndices).size).toBe(headIndices.length);
+
+    // The concrete, correct answer: B claims its true nearest X first (it is
+    // closer to X than A is), leaving A to pair with the only head left, Y —
+    // even though A's naive first-choice was X.
+    expect(pairs).toEqual([
+      { base: 0, head: 1, distance: 3 },
+      { base: 1, head: 0, distance: 0.5 },
+    ]);
+  });
+
+  it('abstains (empty pairing) when every point is equidistant from every other — a symmetric layout has no unique nearest neighbour', () => {
+    const base: [number, number, number][] = [
+      [0, 0, 0],
+      [10, 0, 0],
+    ];
+    const head: [number, number, number][] = [
+      [5, 0, 0],
+      [5, 0, 0],
+    ];
+
+    const pairs = mutualNearestPairs(base, head, 100, () => true);
+    expect(pairs).toEqual([]);
+  });
+
+  it('rejects a pair whose distance exceeds maxDistance even though it would otherwise be mutual', () => {
+    const base: [number, number, number][] = [[0, 0, 0]];
+    const head: [number, number, number][] = [[100, 0, 0]];
+
+    const pairs = mutualNearestPairs(base, head, 10, () => true);
+    expect(pairs).toEqual([]);
+  });
+
+  it('vetoes a pair via `accept` without disturbing the pool for later rounds', () => {
+    const base: [number, number, number][] = [
+      [0, 0, 0], // A
+      [5, 0, 0], // B
+    ];
+    const head: [number, number, number][] = [
+      [1, 0, 0], // X — A's nearest
+      [4, 0, 0], // Y — B's nearest
+    ];
+
+    // Veto A-X specifically; B-Y should still be accepted independently.
+    const pairs = mutualNearestPairs(base, head, 100, (b, h) => !(b === 0 && h === 0));
+
+    expect(pairs).toEqual([{ base: 1, head: 1, distance: 1 }]);
+  });
+});

--- a/packages/diff/src/mutual-nearest.test.ts
+++ b/packages/diff/src/mutual-nearest.test.ts
@@ -7,10 +7,10 @@ import { mutualNearestPairs } from './mutual-nearest.js';
 
 describe('mutualNearestPairs', () => {
   it('never produces a pairing with a repeated base or head index (mutation-sweep finding)', () => {
-    // A is closer to X than to anything else, but X's OWN nearest neighbour is
-    // B, not A (B sits even closer to X than A does). Meanwhile B's nearest is
-    // Y (farther than X, but still B's best option) and Y's nearest is B too —
-    // so B-Y is mutual and A-X is NOT (A's chosen head, X, prefers B instead).
+    // A's nearest head is X (dist 1), but X's OWN nearest base is B (dist 0.5),
+    // so A-X is NOT mutual. B's nearest head is also X — and X agrees — so
+    // B-X is the mutual pair, and it retires in the first round. Only then
+    // does A pair with the head left over, Y (dist 3).
     //
     // A greedy "does `from` have SOME nearest counterpart" check (dropping the
     // `nearestBase[h] === b` half of the mutuality test) accepts A-X purely
@@ -25,7 +25,7 @@ describe('mutualNearestPairs', () => {
     ];
     const head: [number, number, number][] = [
       [1, 0, 0], // X — B's true nearest (dist 0.5), not A's (dist 1)
-      [3, 0, 0], // Y — B's fallback once X is taken
+      [3, 0, 0], // Y — what A is left with once B-X retires
     ];
 
     const pairs = mutualNearestPairs(base, head, 10, () => true);


### PR DESCRIPTION
Mutation-swept `packages/diff` and `packages/mutations`. **Test-only — one real gap found in `diff`, and `mutations` reported honestly as already well covered.**

## The gap: `mutualNearestPairs`' mutuality check was never observed

`mutual-nearest.ts:130` accepts a candidate pair only when `h = nearestHead[b]` **and** `nearestBase[h] === b`. That second half is the "mutual" in the function's name, and its own doc calls it load-bearing: *"Mutual pairs within one round are necessarily disjoint."*

Dropping it — `if (h < 0) continue;` — degrades the algorithm to one-directional greedy nearest, and **the full 298-test suite still passed.**

What that mutant actually produces, from a direct repro: base points A=(0,0,0), B=(1.5,0,0) and heads X=(1,0,0), Y=(3,0,0). A's naive nearest is X, but X's own true nearest is B (0.5 < 1). The mutated code returns `[{base:0,head:0},{base:1,head:0}]` — **two pairs both claiming head index 0**, breaking exactly the 1:1 disjointness the doc promises.

Classification: **untested-but-correct.** The code was right; nothing could tell.

I re-ran the mutation here rather than take the report. With the mutuality half dropped, the new `never produces a pairing with a repeated base or head index` test is the only failure:

```
AssertionError: expected 1 to be 2
Tests  1 failed | 3 passed (4)
```

Restored, green. The other three new tests pin the tie-abstention path, the `maxDistance` cutoff, and the `accept` veto.

**Same-shape grep:** this is the only mutual-nearest-neighbour implementation in either package; nothing else follows the pattern.

## `packages/mutations`: no gap found, and that is the report

Chased four candidates and found each already pinned by name, mostly by maintainer-hardened regression work: `getEffectiveChanges` (the #1967 chain — sort tiebreak, no-op filtering, forgotten-vs-tombstoned handling), `change-set-to-ops` (LWW fold order, tombstone/recreate interaction, whole-pset empty-array edges, pinned against #2048/#2263), `bulk-query-engine`'s numeric filter operators — **whose boundary fixture already sits exactly on the comparison value** (20 among [10,20,30]), with all six operators individually asserted — and `store-editor`'s id-collision watermark.

No fix was manufactured for it. 208 passing / 10 skipped, unchanged.

## Negative evidence

Killed by existing tests: `mutual-nearest.ts`'s tie-break `best < second` → `<=` (caught by `content-match-position.test.ts`); `key-aliases.ts`'s collision guard `=== 1` → `>= 1` (2 failures); `store-editor.ts`'s `removeEntity` null check inverted (2 failures).

## Prior-sweep check, done properly

~35 candidate branches, each diffed **against its own merge-base rather than current `main`** — the drift trap that made an untouched branch look like a sweep earlier today. Every branch whose file list included `packages/mutations`' larger files turned out to be pure drift, with an empty real diff.

Two genuine touches surfaced, neither a package-wide sweep and neither merged: `untouched-packages-sweep` edited `mutable-property-view.ts` (superseded — main's #3032 already covers that null-vs-absent area), and `fix/schema-pin-sweep` added one 35-line geometryHash-vs-aabb block to `diff.test.ts`.

## Verification

`packages/diff` **298 → 302** passing (14 → 15 files). `check-module-size.mjs` exit 0, ratchet not moved. No changeset — test-only, no published behaviour change.

**Leads not chased**, stated rather than implied: `csv-connector.ts` and `mutable-property-view.ts` (2,121 lines, the largest file in either package), plus `diff`'s `split-merge*.ts` and `identity-sidecar.ts` — surveyed by listing only, not mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for mutual nearest-pair matching, including unique pair selection and prevention of duplicate matches.
  * Added validation for ambiguous equidistant layouts, maximum-distance limits, and rejected pair candidates.
  * Confirmed that declined matches do not prevent valid matches from being found later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->