### PR TITLE
test(query): three conjunctions no fixture could tell from their halves

### DIFF
--- a/packages/query/test/fluent-api.test.ts
+++ b/packages/query/test/fluent-api.test.ts
@@ -53,6 +53,20 @@ function setupFixtures() {
   return { entityTable, propertyTable };
 }
 
+/**
+ * Same as `setupFixtures`, but the door (id 3) also carries the SAME
+ * pset/property/value as wall 2 (`Pset_WallCommon.IsExternal: false`). Used
+ * only by the conjunction tests below: a filter chain that ANDs on type but
+ * ORs (or drops) the property check would let this door leak into a
+ * `.ofType('IFCWALL')` result, since the property half alone can't tell it
+ * apart from wall 2.
+ */
+function setupOverlapFixture() {
+  const fixtures = setupFixtures();
+  fixtures.propertyTable.associatePropertySet(3, 101);
+  return fixtures;
+}
+
 describe('QueryBuilder', () => {
   it('should return all entities when no filter is applied', () => {
     const { entityTable, propertyTable } = setupFixtures();
@@ -108,6 +122,47 @@ describe('QueryBuilder', () => {
       .execute();
     expect(results).toHaveLength(1);
     expect(results[0].expressId).toBe(2);
+  });
+
+  it('withProperty(value) ANDs with the prior filter instead of replacing it', () => {
+    // Door 3 shares wall 2's exact pset/property/value (see fixture comment).
+    // Without the prior filter also required, `withProperty(..., false)` alone
+    // matches {2, 3} and `.ofType('IFCWALL')` would wrongly include the door.
+    const { entityTable, propertyTable } = setupOverlapFixture();
+    const results = new QueryBuilder(entityTable, propertyTable)
+      .ofType('IFCWALL')
+      .withProperty('Pset_WallCommon', 'IsExternal', false)
+      .execute();
+    expect(results.map(e => e.expressId)).toEqual([2]);
+    // Property side alone (no type filter) legitimately reaches the door too,
+    // confirming the fixture actually creates the overlap this test relies on.
+    const propertyOnly = new QueryBuilder(entityTable, propertyTable)
+      .withProperty('Pset_WallCommon', 'IsExternal', false)
+      .execute();
+    expect(propertyOnly.map(e => e.expressId).sort()).toEqual([2, 3]);
+  });
+
+  it('withProperty(existence) ANDs with the prior filter instead of replacing it', () => {
+    // Same overlap, but the value-less "does this property exist" branch.
+    const { entityTable, propertyTable } = setupOverlapFixture();
+    const results = new QueryBuilder(entityTable, propertyTable)
+      .ofType('IFCWALL')
+      .withProperty('Pset_WallCommon', 'IsExternal')
+      .execute();
+    // Both walls carry Pset_WallCommon.IsExternal; the door must not appear.
+    expect(results.map(e => e.expressId).sort()).toEqual([1, 2]);
+  });
+
+  it('ofType() ANDs with a prior ofType(), so two disagreeing types match nothing', () => {
+    // Every entity has exactly one type, so IFCWALL and IFCDOOR never agree.
+    // A filter that overwrote rather than ANDed with the previous one would
+    // answer this with whichever `ofType()` call ran last (the doors).
+    const { entityTable, propertyTable } = setupOverlapFixture();
+    const results = new QueryBuilder(entityTable, propertyTable)
+      .ofType('IFCWALL')
+      .ofType('IFCDOOR')
+      .execute();
+    expect(results).toEqual([]);
   });
 
 });


### PR DESCRIPTION
Mutation-swept `packages/spatial` and `packages/query`. **Test-only.** One real gap in `query`; `spatial` turned out to be already hardened and is reported as such rather than padded.

## The gap: three conjunctions whose halves never disagreed

`packages/query/src/fluent-api.ts` — `QueryBuilder.ofType()` and both branches of `withProperty()` each rebuild the filter as `previousFilter(entity) && <own predicate>`.

**No existing fixture had an entity satisfying the new predicate while failing the prior one**, so the conjunction was never actually exercised. Three separate mutants, each dropping the `previousFilter(entity) &&` half, **all passed the full 218-test baseline**:

- `ofType`: `this.currentFilter = (entity) => entity.type === type;`
- `withProperty(key, value)`: dropped `if (!previousFilter(entity)) return false;`
- `withProperty(key)` (existence form): same drop

Classification: **untested-but-correct.** The source was never wrong; the suite could not tell.

The fix is a fixture where the two match sets genuinely disagree — door #3 shares wall #2's exact `Pset_WallCommon.IsExternal: false`, so the property-only set `{2,3}` and the type-only set `{1,2}` differ on entity 3. The pre-existing "chain ofType and withProperty" test could never have caught this, because its two sets never diverged. Each mutant is now killed by its own dedicated test.

## `packages/spatial`: already swept, and the near-miss is worth recording

The agent's **initial worktree checkout was stale** and showed *zero* test files for `spatial` — which it nearly reported as a finding. Re-branching from a freshly fetched `upstream/main` showed `aabb.test.ts`, `bvh.test.ts` and `spatial-index-builder.test.ts`, 50 tests, with `git log` attributing them to four prior sweeps (#2147, #2158, #2312, #2764).

That is the same class of error as the branch-drift trap: **a stale checkout makes existing work invisible, and the natural conclusion is "untested" rather than "I am looking at the wrong tree."**

Rather than take the hardening on trust, it spot-checked by hand: mutating `bvh.ts`'s ray-behind-origin boundary `return tmax >= 0` → `> 0` fails exactly 1 test (`bvh.test.ts:175`), 49 passing. Restored, 50/50. **No changes made to `spatial`.**

## Negative evidence

`entity-query.ts`'s `execute()` offset-then-limit ordering — swapping the two `.slice()` calls is caught by `should combine limit and offset`. `resolve-type-name.ts`'s fallback is already pinned by `entity-node-unknown-type.test.ts`. `bvh.ts`'s raycast boundary, above.

`packages/query` was already substantially hardened too — `entity-query.ts`, `entity-node.ts` and `resolve-type-name.ts` all carry sweep-derived comments and fixtures referencing specific prior bugs. The fluent API was the part that had escaped.

## Prior-sweep check

~35 candidate branches, each diffed **against its own merge-base rather than current `main`**. Only `query-diff-create-sweep` touched either package, and it is already merged (`131e3dc84`, #3009).

## Verification

`packages/query` **218 → 221**; `packages/spatial` 50 → 50, untouched. `check-module-size.mjs` exit 0, ratchet not moved. No changeset — test-only, no published behaviour change.

**Leads not chased:** `duckdb-integration.ts` (507 lines) is largely worker/AsyncDuckDB plumbing that is not meaningfully unit-testable without the WASM runtime, and its pure helpers already have dedicated tests. `entity-node.ts`'s traversal is pinned by an explicit diamond-graph regression test whose comment already names the exact mutant a plain visited-set would introduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
