### PR TITLE
test(pointcloud): LAS extended-format RGB and an intensity boundary at exactly 1.0

### DIFF
--- a/packages/pointcloud/src/formats/ascii-points.test.ts
+++ b/packages/pointcloud/src/formats/ascii-points.test.ts
@@ -162,4 +162,15 @@ describe('decodeAsciiPoints — PTS', () => {
     expect(chunk.intensities).toBeDefined();
     expect(chunk.intensities![0]).toBeCloseTo(Math.round(0.5 * 65535), 0);
   });
+
+  // The observed max sits exactly ON the 0..1/needs-scaling boundary, not
+  // merely near it: `intensityMax > 1.0` must stay a strict `>`, since at
+  // exactly 1.0 the source is already normalised (scale 65535) — treating
+  // 1.0 as "needs 0..255 rescaling" (`>=`) divides the result by ~255.
+  it('treats an intensity max of exactly 1.0 as already-normalised, not 0..255', () => {
+    const buf = enc.encode('1 2 3 1.0\n4 5 6 0.25\n');
+    const chunk = decodeAsciiPoints(buf, 'pts');
+    expect(chunk.intensities![0]).toBe(65535);
+    expect(chunk.intensities![1]).toBeCloseTo(Math.round(0.25 * 65535), 0);
+  });
 });

--- a/packages/pointcloud/src/formats/las.test.ts
+++ b/packages/pointcloud/src/formats/las.test.ts
@@ -119,6 +119,34 @@ function buildFormat3Records(rows: Array<{
   return new Uint8Array(buf);
 }
 
+/**
+ * Format-7 records (LAS 1.4 extended base record + RGB, 36 bytes): the
+ * format-6 30-byte layout (see `buildFormat6Records`) followed by three
+ * uint16 colour channels at bytes 30-35. `rgbOffsetForFormat` maps formats
+ * 7, 8 and 10 to offset 30 — distinct from formats 3/5's offset 28 — but
+ * nothing built a format >= 6 RGB record, so that offset was unverified.
+ */
+function buildFormat7Records(rows: Array<{
+  x: number; y: number; z: number;
+  intensity?: number; classification?: number;
+  r: number; g: number; b: number;
+}>): Uint8Array {
+  const buf = new ArrayBuffer(rows.length * 36);
+  const view = new DataView(buf);
+  for (let i = 0; i < rows.length; i++) {
+    const off = i * 36;
+    view.setInt32(off, rows[i].x, true);
+    view.setInt32(off + 4, rows[i].y, true);
+    view.setInt32(off + 8, rows[i].z, true);
+    view.setUint16(off + 12, rows[i].intensity ?? 0, true);
+    view.setUint8(off + 16, rows[i].classification ?? 0);
+    view.setUint16(off + 30, rows[i].r, true);
+    view.setUint16(off + 32, rows[i].g, true);
+    view.setUint16(off + 34, rows[i].b, true);
+  }
+  return new Uint8Array(buf);
+}
+
 describe('parseLasHeader', () => {
   it('reads format-0 LAS 1.2 header fields', () => {
     const { header } = buildHeader({
@@ -340,6 +368,25 @@ describe('decodeLasPoints', () => {
     expect(chunk.classifications![0]).toBe(200);
     // 40 & 0x1f === 8, so this too separates "masked" from "not masked".
     expect(chunk.classifications![1]).toBe(40);
+  });
+
+  it('decodes format-7 RGB points from byte 30, not byte 28 (format 3/5\'s offset)', () => {
+    const { header } = buildHeader({
+      pointDataFormatId: 7,
+      pointRecordLength: 36,
+      pointCount: 2,
+      scale: [1, 1, 1],
+    });
+    const h = parseLasHeader(header);
+    expect(h.hasRgb).toBe(true);
+    const records = buildFormat7Records([
+      { x: 0, y: 0, z: 0, r: 65535, g: 0, b: 0 },          // pure red
+      { x: 1, y: 2, z: 3, r: 32768, g: 32768, b: 32768 },  // mid gray
+    ]);
+    const chunk = decodeLasPoints(records, h, 2, 36);
+    expect(chunk.colors).toBeDefined();
+    expect(chunk.colors!.slice(0, 3)).toEqual(new Float32Array([1, 0, 0]));
+    expect(chunk.colors![3]).toBeCloseTo(0.5, 2);
   });
 
   it('decodes format-3 RGB points', () => {


### PR DESCRIPTION
Mutation-swept `packages/sandbox` and `packages/pointcloud`. **Two genuine findings, both in pointcloud; sandbox reported as already well covered.** Test-only.

## 1. LAS formats 7/8/10 put RGB at a different byte offset, and nothing decoded one

`packages/pointcloud/src/formats/las.ts:287-295` — the LAS 1.4 extended formats (7/8/10) place colour at **byte 30**, distinct from formats 3/5's **byte 28**. **No fixture exercised any format ≥ 6 with RGB**, so the whole extended branch was unobserved.

Mutating `case 7: return 30;` to `return 28;`:

```
AssertionError: expected Float32Array[ 0, 1, 0 ] to deeply equal Float32Array[ 1, 0, 0 ]
```

— with **173 of 173 other tests still green**.

Classification: **untested-but-correct** — offset 30 was verified spec-correct for the 36-byte format-7 record. The new fixture builds format-7 records rather than reusing format-3's layout, so a swapped offset produces a **visibly wrong colour** instead of coincidentally matching.

This is the same class as the interop findings earlier today: a format variant our own fixtures never produced, so reader and fixtures agreed with each other rather than with the spec.

## 2. An intensity boundary at exactly 1.0, where its sibling was already pinned

`ascii-points.ts:270` — `intensityMax > 1.0` decides "already 0..1" (scale 65535) versus "needs 0..255 rescaling" (scale 65535/255). **Exactly 1.0 is the boundary itself.**

Mutating `>` to `>=`:

```
AssertionError: expected 257 to be 65535
```

The detail that makes this worth reading: **the identical mutation on the sibling `colorMax > 1.0` check was already caught** by an existing test (`treats 0..1 RGB as already-normalised`). Two parallel checks, one pinned and one not — the colour side had a boundary test and the intensity side never got one.

## An equivalent mutant, correctly not reported as a finding

Probing `intensityMax > 255` → `>=` also survived, and the agent declined to call it a gap: at exactly 255 the two branches are **mathematically identical** (`65535/255 === 65535/intensityMax` when `intensityMax === 255`). A genuine mutation-testing equivalent, not a defect.

That distinction matters — a survivor only means something when the mutated expression actually decides the outcome.

## `packages/sandbox`: already hardened, spot-checked rather than assumed

Bug-numbered comments throughout (#2305, #1922, #1905, #2419). Rather than exhaustively re-mutate:

- `buildSchemaNamespaces`' permission gate already has a dedicated `bridge-permissions.test.ts` whose own description documents killing exactly the deleted-gate and flipped-default mutants.
- Hand-mutating `sandbox.ts:258`'s CPU-timeout comparison (`>` → `<`) was **killed** by `timeout-interrupt.test.ts` (`still returns the main-body value when the jobs complete` failed with `ScriptError: interrupted`). Restored, clean diff verified.
- `bridge-store.ts`'s guards carry a comment describing a prior mutation-derived fix — `addBeam` used to reject only `< 0`, letting `0` through — already fixed and tested.

**No source or test change made to sandbox.** Nothing manufactured.

## Prior-sweep check

`sandbox-sweep` and `pointcloud-parser-sweep` both exist but are **narrow and unmerged**, and neither has an open PR. Diffed against their own merge-bases rather than current `main`: 36 lines in one, 95 in the other. Not package-wide sweeps.

## Same-shape grep

Searched `ply.ts` and `pcd.ts` for the same "adaptive max decides the rescale" shape — **none found**. Their colour unpacking is a fixed `/255` from packed bytes rather than adaptive-max, so this bug class does not recur there.

## Verification

pointcloud **+2 tests** (the count also shows 3 pre-existing environment-dependent skips flipping to passes, from native binding availability — not from these edits). sandbox 200 passed, unchanged. `check-module-size.mjs` exit 0; pointcloud typecheck OK. No changeset — test-only.

**Leads not chased, flagged for a follow-up:** `e57-decode.ts` (678 lines, no dedicated test file separate from `e57.test.ts`) and `streaming/laz-source.ts`'s decompression path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
