### PR TITLE
test(pointcloud): the E57 u16 width branch and LAZ RGB upscale were never executed

### DIFF
--- a/packages/pointcloud/src/formats/e57.test.ts
+++ b/packages/pointcloud/src/formats/e57.test.ts
@@ -16,6 +16,34 @@ import {
 
 const enc = new TextEncoder();
 
+/**
+ * LSB-first bit packer matching e57-decode.ts's `readBitsLE` (E57 §6.3.4
+ * ScaledInteger bit-pack convention): each value's low bit lands at
+ * `bitOffset`, consecutive values pack contiguously, and a value can
+ * straddle a byte boundary.
+ */
+function packBitsLE(values: number[], bitsPerValue: number): Uint8Array {
+  const totalBits = values.length * bitsPerValue;
+  const bytes = new Uint8Array(Math.ceil(totalBits / 8));
+  let bitPos = 0;
+  for (const value of values) {
+    let remaining = bitsPerValue;
+    let v = value;
+    while (remaining > 0) {
+      const byteIdx = bitPos >>> 3;
+      const bitInByte = bitPos & 7;
+      const avail = 8 - bitInByte;
+      const take = Math.min(avail, remaining);
+      const mask = (1 << take) - 1;
+      bytes[byteIdx] |= (v & mask) << bitInByte;
+      v >>>= take;
+      bitPos += take;
+      remaining -= take;
+    }
+  }
+  return bytes;
+}
+
 /** Build a single-packet, cartesianX/Y/Z-only (Float64) Data3DEntry. */
 function buildF64Entry(
   points: Array<{ x: number; y: number; z: number }>,
@@ -998,6 +1026,89 @@ describe('resolveCompressedVectorDataOffset (E57 §6.4.2)', () => {
     expect(chunk.colors![2]).toBeCloseTo(0.125, 5);
   });
 
+  it('decodes u16-wide Integer colour/intensity/classification (maximum > 255)', () => {
+    // writeColorChannel, readIntensityStream, and readClassificationStream
+    // each pick a 1- or 2-byte element width from the declared range
+    // (`widest > 255 ? 2 : 1`) — every existing Integer-kind test in this
+    // file declares maximum <= 255, so the 2-byte (u16) stride was never
+    // observed: hardcoding stride=1 at all three call sites ran green.
+    // Real E57 producers use u16 for >8-bit colour/intensity per spec, so
+    // this is a real format variant, not a hypothetical one.
+    const points = [
+      { x: 1, y: 2, z: 3, r: 300, g: 10, b: 490, intensityRaw: 400, classRaw: 300 },
+      { x: 4, y: 5, z: 6, r: 5, g: 500, b: 0, intensityRaw: 0, classRaw: 65 },
+    ];
+    const n = points.length;
+    const lenF64 = n * 8;
+    const lenU16 = n * 2;
+    // Order matches prototype: x, y, z, colorRed, colorGreen, colorBlue, intensity, classification.
+    const lengths = [lenF64, lenF64, lenF64, lenU16, lenU16, lenU16, lenU16, lenU16];
+    const headerBytes = 4 + 2 + lengths.length * 2;
+    const packetSize = headerBytes + lengths.reduce((a, b) => a + b, 0);
+    const buf = new ArrayBuffer(packetSize);
+    const view = new DataView(buf);
+    view.setUint8(0, 1);
+    view.setUint8(1, 0);
+    view.setUint16(2, packetSize - 1, true);
+    view.setUint16(4, lengths.length, true);
+    for (let i = 0; i < lengths.length; i++) view.setUint16(6 + i * 2, lengths[i], true);
+
+    let cursor = headerBytes;
+    for (const key of ['x', 'y', 'z'] as const) {
+      for (let i = 0; i < n; i++) view.setFloat64(cursor + i * 8, points[i][key], true);
+      cursor += lenF64;
+    }
+    for (const key of ['r', 'g', 'b'] as const) {
+      for (let i = 0; i < n; i++) view.setUint16(cursor + i * 2, points[i][key], true);
+      cursor += lenU16;
+    }
+    for (let i = 0; i < n; i++) view.setUint16(cursor + i * 2, points[i].intensityRaw, true);
+    cursor += lenU16;
+    for (let i = 0; i < n; i++) view.setUint16(cursor + i * 2, points[i].classRaw, true);
+    cursor += lenU16;
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: n,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+        // minimum 0 / maximum 500 -> widest 500 > 255 -> 2-byte (u16) stride.
+        { name: 'colorRed', kind: 'Integer', minimum: 0, maximum: 500 },
+        { name: 'colorGreen', kind: 'Integer', minimum: 0, maximum: 500 },
+        { name: 'colorBlue', kind: 'Integer', minimum: 0, maximum: 500 },
+        { name: 'intensity', kind: 'Integer', minimum: 0, maximum: 500 },
+        { name: 'classification', kind: 'Integer', minimum: 0, maximum: 500 },
+      ],
+    };
+
+    const chunk = decodeE57Scan(new Uint8Array(buf), entry);
+    expect(chunk.pointCount).toBe(2);
+
+    // A stride=1 mutant reads byte 0 of each u16 LE pair instead of the
+    // full 2-byte value, which for these values (all > 255 or with a
+    // nonzero low byte) produces different numbers than the real 2-byte
+    // read — so this is a genuine, non-equivalent survivor probe.
+    expect(chunk.colors).toBeDefined();
+    expect(chunk.colors![0]).toBeCloseTo(300 / 500, 5);
+    expect(chunk.colors![1]).toBeCloseTo(10 / 500, 5);
+    expect(chunk.colors![2]).toBeCloseTo(490 / 500, 5);
+    expect(chunk.colors![3]).toBeCloseTo(5 / 500, 5);
+    expect(chunk.colors![4]).toBeCloseTo(500 / 500, 5);
+    expect(chunk.colors![5]).toBeCloseTo(0 / 500, 5);
+
+    expect(chunk.intensities).toBeDefined();
+    expect(chunk.intensities![0]).toBe(52428); // round((400/500) * 65535)
+    expect(chunk.intensities![1]).toBe(0);
+
+    expect(chunk.classifications).toBeDefined();
+    // Class IDs clamp into u8 (0..255); 300 raw clamps to 255.
+    expect(chunk.classifications![0]).toBe(255);
+    expect(chunk.classifications![1]).toBe(65);
+  });
+
   it('recovers ScaledInteger classification values through their minimum offset', () => {
     // The ScaledInteger classification branch adds `minimum` back to recover
     // the original value, and no test reached it at all — the Integer branch
@@ -1042,6 +1153,99 @@ describe('resolveCompressedVectorDataOffset (E57 §6.4.2)', () => {
     expect(chunk.classifications).toBeDefined();
     // raw + minimum: 1+5 = 6, 10+5 = 15. A `- minimum` swap clamps to 0 and 5.
     expect(Array.from(chunk.classifications!)).toEqual([6, 15]);
+  });
+
+  it('decodes Float-kind intensity (v * 65535, clamped to u16)', () => {
+    // readIntensityStream's Float branch had zero coverage: every existing
+    // intensity test in this file uses the Integer kind. Mutating the
+    // 65535 multiplier to 255 (a LAS-shaped 8-bit scale instead of E57's
+    // normalised-[0,1]-to-u16 scale) ran green.
+    const points = [
+      { x: 1, y: 2, z: 3, intensity: 0.5 },
+      { x: 4, y: 5, z: 6, intensity: 1.0 },
+    ];
+    const n = points.length;
+    const lenF64 = n * 8;
+    const lenF32 = n * 4;
+    const lengths = [lenF64, lenF64, lenF64, lenF32];
+    const headerBytes = 4 + 2 + lengths.length * 2;
+    const packetSize = headerBytes + lengths.reduce((a, b) => a + b, 0);
+    const buf = new ArrayBuffer(packetSize);
+    const view = new DataView(buf);
+    view.setUint8(0, 1);
+    view.setUint8(1, 0);
+    view.setUint16(2, packetSize - 1, true);
+    view.setUint16(4, lengths.length, true);
+    for (let i = 0; i < lengths.length; i++) view.setUint16(6 + i * 2, lengths[i], true);
+
+    let cursor = headerBytes;
+    for (const key of ['x', 'y', 'z'] as const) {
+      for (let i = 0; i < n; i++) view.setFloat64(cursor + i * 8, points[i][key], true);
+      cursor += lenF64;
+    }
+    for (let i = 0; i < n; i++) view.setFloat32(cursor + i * 4, points[i].intensity, true);
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: n,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+        { name: 'intensity', kind: 'Float', precision: 'single' },
+      ],
+    };
+
+    const chunk = decodeE57Scan(new Uint8Array(buf), entry);
+    expect(chunk.intensities).toBeDefined();
+    expect(chunk.intensities![0]).toBe(32768); // round(0.5 * 65535)
+    expect(chunk.intensities![1]).toBe(65535); // round(1.0 * 65535)
+  });
+
+  it('decodes ScaledInteger-kind intensity through the bit-pack walk', () => {
+    // readIntensityStream's ScaledInteger branch had zero coverage anywhere
+    // in this package — only the Integer kind was ever exercised for
+    // intensity. minimum=0/maximum=1000 -> 10 bits per record, so a
+    // byte-aligned-width mutant (8/16/32) cannot hide here.
+    const rawValues = [400, 1000]; // norm 0.4 and 1.0
+    const n = rawValues.length;
+    const lenF64 = n * 8;
+    const bits = packBitsLE(rawValues, 10);
+    const lengths = [lenF64, lenF64, lenF64, bits.length];
+    const headerBytes = 4 + 2 + lengths.length * 2;
+    const packetSize = headerBytes + lengths.reduce((a, b) => a + b, 0);
+    const buf = new ArrayBuffer(packetSize);
+    const view = new DataView(buf);
+    view.setUint8(0, 1);
+    view.setUint8(1, 0);
+    view.setUint16(2, packetSize - 1, true);
+    view.setUint16(4, lengths.length, true);
+    for (let i = 0; i < lengths.length; i++) view.setUint16(6 + i * 2, lengths[i], true);
+
+    let cursor = headerBytes;
+    for (const v of [[1, 4], [2, 5], [3, 6]]) {
+      for (let i = 0; i < n; i++) view.setFloat64(cursor + i * 8, v[i], true);
+      cursor += lenF64;
+    }
+    new Uint8Array(buf, cursor, bits.length).set(bits);
+
+    const entry: Data3DEntry = {
+      guid: 'test',
+      recordCount: n,
+      binaryFileOffset: 0,
+      prototype: [
+        { name: 'cartesianX', kind: 'Float', precision: 'double' },
+        { name: 'cartesianY', kind: 'Float', precision: 'double' },
+        { name: 'cartesianZ', kind: 'Float', precision: 'double' },
+        { name: 'intensity', kind: 'ScaledInteger', minimum: 0, maximum: 1000 },
+      ],
+    };
+
+    const chunk = decodeE57Scan(new Uint8Array(buf), entry);
+    expect(chunk.intensities).toBeDefined();
+    expect(chunk.intensities![0]).toBe(26214); // round(0.4 * 65535)
+    expect(chunk.intensities![1]).toBe(65535); // round(1.0 * 65535)
   });
 
   it('rejects when the section header runs past end of buffer', () => {

--- a/packages/pointcloud/src/streaming/laz-source.test.ts
+++ b/packages/pointcloud/src/streaming/laz-source.test.ts
@@ -129,6 +129,109 @@ function buildLazFileWithBbox(
   return new Blob([buf], { type: 'application/octet-stream' });
 }
 
+const RECORD_LEN_RGB = 26; // LAS point format 2 (has RGB, no GPS time — rgbOffset 20)
+
+/** Same layout as `buildLazFile` but declares point format 2 (RGB) so
+ *  `open()`'s RGB-probe branch (rgbScale detection) actually runs — the
+ *  plain `buildLazFile` header has `hasRgb: false` and skips it entirely. */
+function buildLazFileWithRgbFormat(pointCount: number): Blob {
+  const headerSize = 227;
+  const buf = new ArrayBuffer(headerSize + pointCount * RECORD_LEN_RGB);
+  const view = new DataView(buf);
+  view.setUint32(0, 0x4653414c, true); // "LASF"
+  view.setUint8(24, 1);
+  view.setUint8(25, 2);
+  view.setUint16(94, headerSize, true);
+  view.setUint32(96, headerSize, true);
+  view.setUint32(100, 0, true);
+  view.setUint8(104, 2); // point data format 2 -> hasRgb
+  view.setUint16(105, RECORD_LEN_RGB, true);
+  view.setUint32(107, pointCount, true);
+  view.setFloat64(131, 1, true);
+  view.setFloat64(139, 1, true);
+  view.setFloat64(147, 1, true);
+  return new Blob([buf], { type: 'application/octet-stream' });
+}
+
+/**
+ * Stand-in for the emscripten module whose `getPoint` writes a fixed RGB
+ * triple (all three channels set to `rgbValue`) at the format-2 RGB
+ * offset (byte 20, u16 LE × 3) on every call, so both the probe pass and
+ * the real read see the same channel value.
+ */
+function stubLazPerfModuleWithRgb(rgbValue: number): LazPerfModule {
+  const heap = new Uint8Array(1 << 16);
+  let next = 8;
+  class StubLasZip implements LasZipInstance {
+    open(): void { /* no-op — the stub never decompresses */ }
+    getPoint(dest: number): void {
+      const view = new DataView(heap.buffer, heap.byteOffset, heap.byteLength);
+      view.setUint16(dest + 20, rgbValue, true);
+      view.setUint16(dest + 22, rgbValue, true);
+      view.setUint16(dest + 24, rgbValue, true);
+    }
+    getCount(): number { return 0; }
+    getPointLength(): number { return RECORD_LEN_RGB; }
+    getPointFormat(): number { return 2; }
+    delete(): void { /* no-op */ }
+  }
+  return {
+    LASZip: StubLasZip,
+    HEAPU8: heap,
+    _malloc: (size: number) => {
+      const ptr = next;
+      next += size;
+      return ptr;
+    },
+    _free: () => { /* no-op */ },
+  };
+}
+
+describe('LazStreamingSource RGB rescale (8-bit-stuffed detection)', () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+  });
+
+  it('upscales 8-bit-stuffed RGB (max channel in probe <= 255) by 65535/255', async () => {
+    // Mutation testing found `open()`'s rgbScale computation
+    // (`max > 0 && max <= 255 ? 65535 / 255 : 1`) had zero test coverage:
+    // hard-coding `rgbScale = 1` (i.e. never rescaling) left every test
+    // in this file green. Pin the rescale side of the boundary here, and
+    // the no-rescale side in the sibling test below — a conjunction like
+    // this hides a bug if only one side is ever exercised.
+    restore = setLazPerfLoaderForTesting(async () => stubLazPerfModuleWithRgb(200));
+
+    const src = new LazStreamingSource(buildLazFileWithRgbFormat(8));
+    await src.open();
+    const chunk = await src.next(8);
+    expect(chunk).not.toBeNull();
+    expect(chunk!.colors).toBeDefined();
+    // raw channel = 200 (<=255) -> rescaled to (200 * 65535/255) / 65535 = 200/255.
+    for (let i = 0; i < chunk!.pointCount; i++) {
+      expect(chunk!.colors![i * 3]).toBeCloseTo(200 / 255, 5);
+      expect(chunk!.colors![i * 3 + 1]).toBeCloseTo(200 / 255, 5);
+      expect(chunk!.colors![i * 3 + 2]).toBeCloseTo(200 / 255, 5);
+    }
+  });
+
+  it('leaves true 16-bit RGB (max channel in probe > 255) unscaled', async () => {
+    restore = setLazPerfLoaderForTesting(async () => stubLazPerfModuleWithRgb(60000));
+
+    const src = new LazStreamingSource(buildLazFileWithRgbFormat(8));
+    await src.open();
+    const chunk = await src.next(8);
+    expect(chunk).not.toBeNull();
+    expect(chunk!.colors).toBeDefined();
+    // raw channel = 60000 (>255) -> no rescale: 60000/65535.
+    for (let i = 0; i < chunk!.pointCount; i++) {
+      expect(chunk!.colors![i * 3]).toBeCloseTo(60000 / 65535, 5);
+    }
+  });
+});
+
 describe('LazStreamingSource downsampling', () => {
   let restore: (() => void) | null = null;
 


### PR DESCRIPTION
Mutation-swept the two decoder paths PR #3133 flagged as unexamined: `e57-decode.ts` (678 lines, no dedicated test file) and `streaming/laz-source.ts`. **Test-only, three findings, all untested-but-correct.**

Follows #3133 and deliberately does not repeat it — that PR covered `las.ts` and `ascii-points.ts`; this touches neither. Confirmed by diff-stat against its pushed branch before starting.

## 1. `laz-source.ts:229` — the 8-bit-stuffed RGB auto-upscale had zero coverage

`rgbScale = max > 0 && max <= 255 ? 65535 / 255 : 1` handles LAZ files that stuff 8-bit colour into 16-bit fields. **Hardcoding `rgbScale = 1` left all 168 pre-existing tests green.**

Both sides of the boundary are now pinned — a probe max of 200 rescales, a probe max of 60000 does not — using a format-2 LAS record so `header.hasRgb` is actually true. Pinning only the rescaling side would have left a fixture in the state the mutant produces.

## 2. `e57-decode.ts` — the u16 element-width branch, at three sites

`writeColorChannel` (400), `readIntensityStream` (503) and `readClassificationStream` (625) each choose a 1- or 2-byte element width via `widest > 255 ? 2 : 1`. **Every existing Integer-kind test declares `maximum <= 255`, so the 2-byte branch was never once executed.** Hardcoding the stride to 1 at all three sites left the suite green.

That is the same shape as #3133's LAS finding: **a format variant no fixture produces**, so the decoder and the fixtures agreed with each other rather than with the format.

One packet-level test now covers colour, intensity and classification together at `maximum: 500`, and each of the three sites was re-mutated individually and killed by name.

**A fourth occurrence was found and proven unreachable rather than tested.** `floatOrSiPointCapacity`'s Integer branch (~561) survives the same mutation, but `resolveScanFields` (e57-decode.ts:55-65) throws before returning if any cartesian axis is Integer-kind, and that function is only ever called with `xField`/`yField`/`zField`. Confirmed by grep that both `decodeE57Scan` and `E57StreamingSource` build their fields exclusively through it. Documented as dead code; no test written for a branch that cannot run.

## 3. `readIntensityStream`'s Float and ScaledInteger branches

**Only the Integer kind was ever tested for intensity anywhere in the package.** Mutating `v * 65535` → `v * 255` in the Float branch, and `raw * inv * 65535` → `raw * inv * 255` in ScaledInteger, both left the suite green — individually and together.

The ScaledInteger fixture is built to defeat two symmetries at once: a new `packBitsLE` helper uses a **10-bit field**, not 8/16/32, so the byte-aligned fast path cannot hide a general bit-width bug; and it uses **two records**, so a stride error cannot hide either.

## What is not claimed

**No equivalent mutants this session** — every probed survivor was either a real decision-changing gap or the one unreachable case above, and that distinction is stated rather than blurred.

**No binary fixture was committed.** Every E57 and LAZ buffer is constructed in code, matching #3133's approach for LAS format-7 records. The corpus is fetched, not vendored.

**Leads not chased:** E57 spherical-coordinate prototypes are explicitly out of scope per a code comment at `e57.ts:22-23` referencing #611 — a maintainer decision, not a gap, and left alone on that basis. `laz-source.ts`'s stride and downsampling arithmetic already has a named test exercising a non-trivial stride (3) against 10 source points; not re-probed, but worth a second pass.

## Verification

`packages/pointcloud` **173 → 178** tests (168 → 173 passing, 5 skipped throughout — the skips are environment-dependent native bindings, unchanged). Full suite re-run here: **178 passed**. `typecheck` OK. `check-module-size.mjs` exit 0, "0 new over 400". No changeset — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
