### PR TITLE
test(embed): two swapped fields and a guard order only a throwing destroy reveals

### DIFF
--- a/apps/viewer-embed/src/bridge/lifecycle.test.ts
+++ b/apps/viewer-embed/src/bridge/lifecycle.test.ts
@@ -250,4 +250,22 @@ describe('displacement checks', () => {
 
     expect(fw.listenerCount()).toBe(0);
   });
+
+  it('resets the guard BEFORE calling destroy, so a throwing destroy still leaves the guard unlatched', () => {
+    // Pins the ordering documented in lifecycle.ts's comment: if `destroy`
+    // itself throws, the guard must already be false so a later mount can
+    // still recover instead of being permanently stuck "already mounted".
+    // Swapping the two statements (destroy() then ref.current = false)
+    // is equivalent for every OTHER test in this file -- they all call
+    // unmount() to completion before the next mount() -- so only a
+    // throwing destroy distinguishes the order.
+    installWindow(); // satisfies afterEach's unconditional destroyBridge()
+    const ref: MountGuardRef = { current: true };
+
+    expect(() => unmountBridgeLifecycle(ref, () => {
+      throw new Error('destroy failed');
+    })).toThrow('destroy failed');
+
+    expect(ref.current).toBe(false);
+  });
 });

--- a/packages/embed-sdk/test/iframe-url.test.ts
+++ b/packages/embed-sdk/test/iframe-url.test.ts
@@ -60,6 +60,22 @@ describe('iframe URL construction', () => {
     expect(p.has('hideScale')).toBe(false);
   });
 
+  it('maps hideAxis and hideScale to their own distinct params, not each other', () => {
+    // Setting only one flag distinguishes a key swap: both prior tests set
+    // hideAxis and hideScale to the SAME value together, so `params.set(
+    // 'hideScale', ...)` under `if (opts.hideAxis)` (and vice versa) would
+    // still satisfy them. Verified by reverting the swap in isolation: with
+    // only hideAxis:true, that mutant sets `hideScale` and leaves `hideAxis`
+    // unset.
+    const axisOnly = urlOf({ hideAxis: true }).searchParams;
+    expect(axisOnly.get('hideAxis')).toBe('true');
+    expect(axisOnly.has('hideScale')).toBe(false);
+
+    const scaleOnly = urlOf({ hideScale: true }).searchParams;
+    expect(scaleOnly.get('hideScale')).toBe('true');
+    expect(scaleOnly.has('hideAxis')).toBe(false);
+  });
+
   it('joins hideTypes with commas', () => {
     const p = urlOf({ hideTypes: ['IFCSPACE', 'IFCOPENINGELEMENT'] }).searchParams;
     expect(p.get('hideTypes')).toBe('IFCSPACE,IFCOPENINGELEMENT');


### PR DESCRIPTION
Mutation-swept `apps/viewer-embed`, `packages/embed-protocol` and `packages/embed-sdk`. **Test-only, two findings, both untested-but-correct.**

## 1. `hideAxis` and `hideScale` could be swapped undetectably

`packages/embed-sdk/src/index.ts:133-134` maps two independent options to two URL params. **Swapping them — `hideAxis` → `hideScale`, `hideScale` → `hideAxis` — left all 15 `iframe-url.test.ts` tests passing.**

Every existing test set both flags to the **same value together**, which is the "two fields defaulting to the same value" symmetry: when both are `true`, a swap is invisible by construction. The new test sets each in isolation.

## 2. The mount guard unlatches before teardown, and only a throwing `destroy` can show it

`apps/viewer-embed/src/bridge/lifecycle.ts:41-48` resets `ref.current = false` **before** calling `destroy()`. Swapping the two statements left all 7 existing tests green.

The agent verified this is a **genuine survivor rather than an equivalent mutant**, which is the part worth reading: with a throwing `destroy`, the original order leaves `ref.current === false`, while the swapped order leaves it **permanently `true` — a guard stuck shut, so the component never re-initialises.** Every existing test lets `destroy()` return normally, so the difference could not appear.

I re-ran that mutation here rather than take it on trust. Swapping the order fails exactly one test:

```
× resets the guard BEFORE calling destroy, so a throwing destroy still leaves the guard unlatched
Tests  1 failed | 7 passed (8)
```

Restored, green. Worth noting the code's own comment justifies the ordering by a *different* mechanism — StrictMode's synchronous cleanup-and-remount — so this test pins the same line for a second, independent reason.

## A correction to the brief this agent was given

I told it #2978 was "awaiting the maintainer's ruling." **It is merged** (2026-08-24T00:40Z), and the agent checked rather than accepting my framing.

What #2978 actually fixed: `SET_CAMERA`, `RESET_COLORS` and `ENTITY_HOVERED` across `handler.ts`, `EmbedViewer.tsx` and the viewer camera/data/model slices. What it explicitly left out of scope: the **eight URL params** (`controls`, the `autoLoad` gate, `hideAxis`, `hideScale`, `select`, `isolate`, `hideTypes`, `camera`) and `CAMERA_CHANGED` on real navigation — confirmed still parsed-but-never-applied on current `main`.

Those remain open under #2934, and were deliberately **not** attempted here: applying them is feature work, not a mutation-sweep finding.

## Negative evidence

Confirmed genuinely covered, with non-symmetric fixtures that would catch a key swap: `SET_TYPE_VISIBILITY`'s per-field toggle (distinct true/false per field), `GET_MODEL_INFO`'s per-model aggregation (distinct entity and triangle counts per model), `FIT_TO_VIEW`'s empty-array boundary, and `urlParams.ts`'s `select`/`isolate`/`hideAxis`/`hideScale` parsing — each `it.each` case sets only its own query key, so a parser-side swap is caught there even though the SDK-side swap was not.

## Verification

`viewer-embed` **149 → 150**, `embed-sdk` **69 → 70**, `embed-protocol` 22 unchanged. The 149/22/69 baseline matches #2978's own reported counts exactly.

`check-module-size.mjs` exit 0. `tsc --noEmit` clean on `embed-sdk` and `embed-protocol`; `turbo run typecheck` across all three, 35/35 tasks successful — run explicitly because a sibling PR today passed vitest locally and still failed CI's typecheck on an unnecessary cast.

No changeset — test-only, no runtime behaviour changed.

**Leads not chased:** `EmbedViewer.tsx`'s `ENTITY_SELECTED` / `CAMERA_CHANGED` / `SECTION_CHANGED` emit effects, untestable without a real React/WebGPU mount — the same documented limitation #2978 hit on its pick-path tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
