### PR TITLE
test(extensions): a capability test named for a rule it never checked

### DIFF
--- a/packages/extensions/src/capability/match.test.ts
+++ b/packages/extensions/src/capability/match.test.ts
@@ -115,9 +115,19 @@ describe('matchCapability — wildcards', () => {
 });
 
 describe('matchCapability — target requirements', () => {
-  it('no-target grant does not cover targeted request', () => {
+  it('no-target grant matches a no-target request of the same scope+action', () => {
     expect(matchCapability(parse('model.create'), parse('model.create'))).toBe(true);
-    // a fictional "with target" against "without target" — make sure asymmetry holds
+  });
+
+  it('no-target grant does NOT cover a targeted request of the same scope+action', () => {
+    // Regression: a grant of "model.create" (no target) must not be
+    // treated as "covers everything" once the scope/action matches. The
+    // grammar allows any scope.action to carry a target
+    // (`model.create:foo` parses fine even though the doc calls
+    // model.create untargeted by convention), so this is reachable, not
+    // hypothetical. Mutating the no-target branch to `return true`
+    // survived the full suite before this test existed.
+    expect(matchCapability(parse('model.create'), parse('model.create:foo'))).toBe(false);
   });
 
   it('with-target grant does not cover no-target request', () => {

--- a/packages/extensions/src/capability/risk.test.ts
+++ b/packages/extensions/src/capability/risk.test.ts
@@ -66,6 +66,22 @@ describe('computeRisk', () => {
     const r = computeRisk(p('network.fetch:example.com'));
     expect(r.description).toContain('example.com');
   });
+
+  it('red: a requiresTarget capability with no target is treated as universal', () => {
+    // Regression: command.invoke's catalogue entry sets requiresTarget:
+    // true precisely so an untargeted grant (equivalent to "invoke any
+    // command") escalates past its yellow baseRisk. Disabling the
+    // requiresTarget branch entirely left the full suite green — nothing
+    // else exercises a grammatically-valid but target-missing grant on a
+    // requiresTarget scope/action.
+    const r = computeRisk(p('command.invoke'));
+    expect(r.tier).toBe('red');
+    expect(r.description).toContain('Missing required target');
+  });
+
+  it('red: model.mutate with no target is treated as universal (same rule)', () => {
+    expect(computeRisk(p('model.mutate')).tier).toBe('red');
+  });
 });
 
 describe('computeRisks / overallTier', () => {

--- a/packages/extensions/src/host/sdk-version.test.ts
+++ b/packages/extensions/src/host/sdk-version.test.ts
@@ -69,6 +69,17 @@ describe('sdk-version', () => {
     expect(evaluateCompatibility('x', '>=2.1.0-rc.1', '2.5.0').status).toBe('compatible');
   });
 
+  it('a bare version pin (no comparator prefix) defaults to exact match', () => {
+    // Regression: `parseRange` defaults a missing comparator symbol to
+    // '=' (see COMPARATOR_RE / the `m[1] ?? '='` fallback), but nothing
+    // exercised a pin without an explicit operator — every other test
+    // uses '>=', '^', or '~'. Mutating the default to '>=' left the
+    // full suite green.
+    expect(evaluateCompatibility('x', '2.0.0', '2.0.0').status).toBe('compatible');
+    expect(evaluateCompatibility('x', '2.0.0', '2.5.0').status).toBe('outdated');
+    expect(evaluateCompatibility('x', '2.0.0', '1.9.0').status).toBe('outdated');
+  });
+
   it('findAffected returns one result per installed entry', () => {
     const results = findAffected(
       [


### PR DESCRIPTION
Mutation-swept `packages/extensions`. **Test-only, three findings, all untested-but-correct** — the code was right, the coverage was missing.

## 1. A test named for a rule it did not check

`capability/match.ts`'s `!grant.target` branch correctly returns `!requested.target`. The suite had a test called **`'no-target grant does not cover targeted request'`** — which actually asserted **no-target vs. no-target**, i.e. the opposite case. It tested nothing the neighbouring test did not.

So mutating that branch to `return true` — *a grant covers everything once scope and action match* — **survived all 842 tests.** On a capability matcher, that is the mutation that matters.

The test name is now honest and a real assertion added: `matchCapability(parse('model.create'), parse('model.create:foo'))` → `false`.

Reachability was established rather than assumed: **the grammar lets any `scope.action` carry a target**, so `model.create:foo` parses even though the catalogue treats `model.create` as untargeted by convention. Not hypothetical.

## 2. The default `=` comparator for a bare version pin

`host/sdk-version.ts`'s `parseRange` falls back to `const op = (m[1] ?? '=')`. **Every existing fixture used an explicit `>=`, `^` or `~` prefix**, so the bare-pin path never ran — mutating the default to `'>='` survived the full suite. Now pinned at, above and below the target version.

## 3. `requiresTarget` escalation with no target

`capability/risk.ts` escalates a `requiresTarget: true` capability with **no** target to `red`, because an untargeted grant of `command.invoke` or `model.mutate` is equivalent to a universal wildcard. **No fixture used a requiresTarget scope/action without a target**, so disabling the whole branch survived 844 tests. Tests added for `command.invoke` and `model.mutate`, asserting `red` and the "Missing required target" description.

## Negative evidence

`host/permissions.ts`, `host/check.ts` and `signing/verify.ts` were hand-mutated across their fail-closed guards, tamper and format-error paths, and wrong-length-key checks — **all killed by existing tests.** Genuinely well covered.

**One branch proven unreachable rather than tested:** `host/check.ts`'s "any one of multiple required capabilities suffices" loop. Every catalogue entry in `inference/catalogue.ts` currently declares 0 or 1 required capability, so the multi-capability OR branch cannot execute with the present catalogue. Reported as proven-unreachable, not as a defect — and no test written for a branch that cannot run.

## Flagged for you, deliberately not fixed

`host/sdk-version.ts`'s JSDoc claims a `permissive` status for ranges that "technically pass but cross a major version." **The implementation never does this** — `permissive` is reached only for unparseable or wildcard ranges. That is a doc/implementation mismatch, but the fix is ambiguous (which comparators should trigger it? is it policy-only?), so it was left rather than a feature manufactured under cover of a sweep.

## Prior-sweep check

No sweep branch touched `packages/extensions`. `fix/extensions-single-ast-walker` is a targeted unmerged fix, not a sweep — diffed against its own merge-base, its footprint is `ast/bounded-walk.ts`, `host/source-wrap.ts`, `inference/capability.ts`, `validate/code.ts`, and those files were avoided to keep the branches independent. Two other candidates diffed to **zero** lines in this package.

## Verification

`packages/extensions` **842 → 846**, all passing (re-run here to confirm). `pnpm typecheck` OK; `check-module-size.mjs` exit 0. No changeset — test-only.

## `packages/plugin-api`: checked, already hardened

The brief also named `packages/plugin-api`. There was some confusion about it that is worth recording accurately rather than leaving in the history.

The agent first reported it absent; it exists. I then claimed it had **zero test files**, which was **my error** — I searched `packages/plugin-api/src`, and this package keeps its tests in `test/`. `find .../src -name "*.test.ts"` returns nothing here regardless of coverage.

The real state: `test/version.test.ts` (34 tests) and `test/types.test.ts` (12 `expectTypeOf` checks), **both already on `main`**. `test/version.test.ts` came from `480f5da74` — *"test(plugin-api): cover the version gate that decides plugin registration (#2340)"* — and its docstring records that it exists because of a prior mutation sweep: *"a broken major-version check (e.g. always returning true) passed the full test suite unchanged"* before it was written.

Spot-checked rather than taken on trust — three hand-mutations of `src/version.ts`, all killed: the exact-patch boundary `>=` → `>` (3 failures, including `satisfiesCaretRange('2.0.0', '^2.0.0')`); dropping the major-version guard entirely (3 failures); and `matchesGlob`'s `?` widened from one character to any run (1 failure). File restored byte-identical after each.

`src/types.ts` (513 lines) and `src/index.ts` (38 lines) hold **no runtime logic** — a grep for exported consts, functions and classes in `types.ts` returns nothing, and `index.ts` is pure re-exports. No test was manufactured for either; `expectTypeOf` checks are the right coverage form for a pure type surface and are already present.

**A near-duplicate reported rather than unified:** `plugin-api/version.ts`'s `satisfiesCaretRange` and `extensions/host/sdk-version.ts`'s `evaluateCompatibility` are two independent range matchers. They gate unrelated subsystems against independently-versioned constants — a viewer file-source plugin's `manifest.api` versus an AI-authored extension's `engines.ifcLiteSdk` — with deliberately different grammars and result shapes. No caller reads both against the same value, so there is no shared invariant to violate, and neither file was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

