### PR TITLE
test(codegen,world-frame): a cycle guard whose removal hangs the suite

### DIFF
--- a/packages/codegen/test/express-parser.test.ts
+++ b/packages/codegen/test/express-parser.test.ts
@@ -353,7 +353,11 @@ describe('EXPRESS Parser', () => {
       const a = schema.entities.find(e => e.name === 'IfcA')!;
 
       expect(getAllAttributes(a, schema).map(x => x.name).sort()).toEqual(['Bar', 'Foo']);
-      expect(getInheritanceChain(a, schema)).toHaveLength(2);
+      // Length alone would pass on a traversal that returned ['IfcA','IfcA']
+      // or otherwise dropped IfcB, so pin the membership as well as the count.
+      const chain = getInheritanceChain(a, schema);
+      expect(chain).toHaveLength(2);
+      expect([...chain].sort()).toEqual(['IfcA', 'IfcB']);
     });
   });
 

--- a/packages/codegen/test/express-parser.test.ts
+++ b/packages/codegen/test/express-parser.test.ts
@@ -326,6 +326,35 @@ describe('EXPRESS Parser', () => {
 
       expect(chain).toEqual(['IfcRoot', 'IfcObject', 'IfcProduct']);
     });
+
+    it('terminates on a cyclic SUBTYPE OF chain instead of looping forever', () => {
+      // Nothing in the real schemas is cyclic, so removing the `seen` guard
+      // in getAllAttributes/getInheritanceChain never fails an existing test
+      // — it only fails on a malformed schema, which no fixture provides.
+      // Without the guard this hangs (and eventually throws
+      // `RangeError: Invalid array length` once the unbounded levels array
+      // overflows) instead of returning.
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY IfcA
+          SUBTYPE OF (IfcB);
+          Foo : IfcLabel;
+        END_ENTITY;
+
+        ENTITY IfcB
+          SUBTYPE OF (IfcA);
+          Bar : IfcLabel;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const a = schema.entities.find(e => e.name === 'IfcA')!;
+
+      expect(getAllAttributes(a, schema).map(x => x.name).sort()).toEqual(['Bar', 'Foo']);
+      expect(getInheritanceChain(a, schema)).toHaveLength(2);
+    });
   });
 
   describe('Attribute section boundary', () => {

--- a/packages/world-frame-fixtures/src/world-frame.test.ts
+++ b/packages/world-frame-fixtures/src/world-frame.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from 'vitest';
 import {
   WORLD_FRAME_CASES,
   WORLD_FRAME_OFFSET_M,
+  bakedWorldPositions,
   boxTriangles,
   normalProjectedNoiseBound,
   placeWorldFrame,
@@ -112,5 +113,51 @@ describe('world-frame corpus placements', () => {
       expect(quad.positions[i]).toBe(0.4);
     }
     expect(quad.indices).toHaveLength(6);
+  });
+
+  it('normalProjectedNoiseBound is invariant under negating a normal component (the |n_i| in the formula matters)', () => {
+    // Both prior normal cases here (zNormal, xNormal) use only non-negative
+    // components, so a mutant that drops Math.abs() around each n_i term
+    // survives them undetected. The doc comment is explicit that the sum is
+    // over |n_i|, not n_i: a negative-component normal must give the SAME
+    // bound as its positive mirror, never a smaller (or negative) one.
+    const far = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'far-baked' });
+    const posX: [number, number, number] = [1, 0, 0];
+    const negX: [number, number, number] = [-1, 0, 0];
+    const bound = normalProjectedNoiseBound(posX, [far]);
+    expect(normalProjectedNoiseBound(negX, [far])).toBe(bound);
+    expect(bound).toBeGreaterThan(0);
+  });
+
+  it('bakedWorldPositions folds origin into each axis without shifting axes', () => {
+    // Exercises the axis-indexed fold directly: this is the buffer a
+    // consumer with no origin concept (e.g. the clash Mesh, in a sibling
+    // package) actually ingests, and this corpus's own suite never called
+    // it before — an axis-misindexed fold (origin[x] added to position.y,
+    // etc.) passed every other test here undetected.
+    const local = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'at-origin' });
+    const placed = placeWorldFrame(LOCAL_BOX.positions, {
+      frameCase: 'far-local-frame',
+      offsetAxis: 'x',
+    });
+    const baked = bakedWorldPositions(placed);
+    const bakedMin: [number, number, number] = [Infinity, Infinity, Infinity];
+    const bakedMax: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+    for (let i = 0; i < baked.length; i += 3) {
+      for (let a = 0 as 0 | 1 | 2; a < 3; a++) {
+        const c = baked[i + a]!;
+        if (c < bakedMin[a]) bakedMin[a] = c;
+        if (c > bakedMax[a]) bakedMax[a] = c;
+      }
+    }
+    const bakedAabb = { min: bakedMin, max: bakedMax };
+    const reference = worldAabb(local);
+    // X carries both the far offset and rebase noise; Y and Z must fold
+    // exactly (rebase noise only, no offset — the offset axis is X).
+    for (const a of [1, 2] as const) {
+      expect(Math.abs(bakedAabb.min[a]! - reference.min[a]!)).toBeLessThanOrEqual(1e-6);
+      expect(Math.abs(bakedAabb.max[a]! - reference.max[a]!)).toBeLessThanOrEqual(1e-6);
+    }
+    expect(bakedAabb.min[0]!).toBeGreaterThanOrEqual(WORLD_FRAME_OFFSET_M);
   });
 });

--- a/packages/world-frame-fixtures/src/world-frame.test.ts
+++ b/packages/world-frame-fixtures/src/world-frame.test.ts
@@ -122,11 +122,28 @@ describe('world-frame corpus placements', () => {
     // over |n_i|, not n_i: a negative-component normal must give the SAME
     // bound as its positive mirror, never a smaller (or negative) one.
     const far = placeWorldFrame(LOCAL_BOX.positions, { frameCase: 'far-baked' });
-    const posX: [number, number, number] = [1, 0, 0];
-    const negX: [number, number, number] = [-1, 0, 0];
-    const bound = normalProjectedNoiseBound(posX, [far]);
-    expect(normalProjectedNoiseBound(negX, [far])).toBe(bound);
+
+    // A normal with a non-zero component on EVERY axis. Negating only X (the
+    // first version of this test) leaves the Y and Z terms multiplied by
+    // |0| = 0, so dropping Math.abs() from either of those two terms still
+    // passed. Each axis is negated on its own below, so all three terms are
+    // pinned independently rather than only the one that happens to be set.
+    const AXIS: [number, number, number] = [0.5, 0.5, Math.SQRT1_2];
+    const bound = normalProjectedNoiseBound(AXIS, [far]);
     expect(bound).toBeGreaterThan(0);
+
+    for (const axis of [0, 1, 2] as const) {
+      const flipped: [number, number, number] = [...AXIS];
+      flipped[axis] = -flipped[axis];
+      expect(
+        normalProjectedNoiseBound(flipped, [far]),
+        `negating component ${axis} must not change the bound`,
+      ).toBe(bound);
+    }
+
+    // All three at once, so a mutant that drops Math.abs() from every term
+    // (rather than one) cannot hide behind the single-axis cases either.
+    expect(normalProjectedNoiseBound([-AXIS[0], -AXIS[1], -AXIS[2]], [far])).toBe(bound);
   });
 
   it('bakedWorldPositions folds origin into each axis without shifting axes', () => {
@@ -158,6 +175,13 @@ describe('world-frame corpus placements', () => {
       expect(Math.abs(bakedAabb.min[a]! - reference.min[a]!)).toBeLessThanOrEqual(1e-6);
       expect(Math.abs(bakedAabb.max[a]! - reference.max[a]!)).toBeLessThanOrEqual(1e-6);
     }
-    expect(bakedAabb.min[0]!).toBeGreaterThanOrEqual(WORLD_FRAME_OFFSET_M);
+    // X pinned to its exact expected placement, at the same tolerance as Y and
+    // Z above. A `toBeGreaterThanOrEqual(WORLD_FRAME_OFFSET_M)` bound only
+    // proves X is far from the origin, so a doubled or otherwise wrong
+    // positive offset would satisfy it just as well.
+    expect(Math.abs(bakedAabb.min[0]! - (reference.min[0]! + WORLD_FRAME_OFFSET_M)))
+      .toBeLessThanOrEqual(1e-6);
+    expect(Math.abs(bakedAabb.max[0]! - (reference.max[0]! + WORLD_FRAME_OFFSET_M)))
+      .toBeLessThanOrEqual(1e-6);
   });
 });


### PR DESCRIPTION
Mutation-swept `packages/codegen` and `packages/world-frame-fixtures`. **Test-only, three findings, all untested-but-correct.**

## 1. The cyclic `SUBTYPE OF` guard was never verified

`express-parser.ts:409` and `:445` both walk the inheritance chain under `while (current && !seen.has(current.name))`. **No fixture is cyclic**, so dropping that guard survived on both functions.

The proof is unusually direct. On `getAllAttributes`:

```
RangeError: Invalid array length
 ❯ express-parser.ts:413
```

And on `getInheritanceChain` the mutant **hung the run entirely** — unbounded `unshift`, confirmed by a 15 s timeout with zero test output. That is termination proven by observed non-termination rather than argued from reading.

I re-ran it here: dropping the first guard fails exactly `terminates on a cyclic SUBTYPE OF chain instead of looping forever`, 1 failed / 17 passed. Restored, green.

The new test exercises both functions against a two-entity cycle (`IfcA` ↔ `IfcB`). Worth noting a cyclic `SUBTYPE OF` is malformed EXPRESS — but this parser reads schema files from outside the repo, and a hang is a worse failure than an error.

## 2. `normalProjectedNoiseBound` drops `Math.abs()` undetected

`world-frame-fixtures/src/index.ts:215-217` sums `Math.abs(normal[i]) * ulp32(extent[i])`. Both existing tests use **only non-negative-component normals** (`[0,0,1]`, `[1,0,0]`), so removing all three `Math.abs()` calls survived.

```
AssertionError: expected -0.0009765625 to be 0.0009765625
```

A negative bound is meaningless for a noise envelope, and the function's own doc comment explicitly requires `|n_i|`. The new test negates a normal component — the symmetry no prior fixture broke.

## 3. `bakedWorldPositions` had no test in its own package

It is consumed by `packages/clash`'s `world-frame.test.ts`, so it *looked* covered — but this package's own suite never called it. Mutating `o[i % 3]` → `o[(i + 1) % 3]` survived:

```
AssertionError: expected 1.1999999940395356 to be less than or equal to 0.000001
```

## Negative evidence

Killed by existing tests: `crc32.ts` / `type-ids-generator.ts`'s `findCollisions` threshold, `getTypeId`'s `Object.prototype` guard, and the generated type-ids path — the last genuinely covered, because **the generated output is imported and executed by tests rather than self-validated**, which is the failure mode a generator's tests usually have. Also `translateWorld`'s `delta[i % 3]` axis indexing, killed immediately.

## Two survivors deliberately not reported as findings

- **`ulp32`'s subnormal clamp `Math.max(e, -126)`** survives, but the function is only ever called with magnitudes around 1 m to 10 km in this repo — never near `2^-126` — and it has no consumers outside this package. Judged too speculative to pin; noted rather than fixed.
- **`quadTriangles`' u/v axis assignment** — swapping them is **geometrically equivalent for a square quad**, which is the only shape this fixture builds. An equivalent mutant given the current API, not a gap.

## Territory verification

Both packages exist and both hold real runtime logic, which the brief asked to be confirmed rather than assumed: `codegen` is 10 `.ts` files / 2,544 lines with 9 test files; `world-frame-fixtures` is a 414-line `src/index.ts` of geometry and frame arithmetic plus its own test file.

Prior `codegen` mutation work exists (#2150, #2359, #2202) but on **different functions** than those mutated here. `world-frame-fixtures` had only self-consistency tests and had never been mutation-tested.

**Not pursued, with the reason:** the rooted-type duplication and `SI_PREFIX_SCALE` patterns named in the brief live in `packages/parser`, which was off-limits. `rust-generator.ts` and `rust-schema-queries.ts` template emission was read but not deeply mutated — three confirmed findings were preferred over broad shallow coverage.

## Verification

`codegen` **121 → 122**, `world-frame-fixtures` **6 → 8**, all passing (both re-run here). `pnpm typecheck` OK for both — the world-frame check needed `@ifc-lite/geometry`'s dependency chain built first, a pre-existing missing `dist/` unrelated to this change. `check-module-size.mjs` exit 0. No changeset — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for cyclic inheritance schemas, confirming attribute and inheritance traversal completes without infinite loops.
  - Added validation for normal-bound handling when components are negated.
  - Added coverage ensuring baked origins preserve axis alignment and expected far-offset positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->