### PR TITLE
test(collab,ifcx): three guards whose do-nothing branch was never exercised

### DIFF
--- a/packages/collab/test/apply-ifcx-overlay.test.ts
+++ b/packages/collab/test/apply-ifcx-overlay.test.ts
@@ -27,7 +27,14 @@ import { describe, expect, it } from 'vitest';
 import * as Y from 'yjs';
 import { IFCLITE_ATTR, type IfcxFile } from '@ifc-lite/ifcx';
 import { createCollabDoc, entitiesMap, ENTITY_KEY } from '../src/doc/schema.js';
-import { createEntity, getAttribute, getEntity, setAttribute } from '../src/doc/entity.js';
+import {
+  addClassification,
+  addMaterial,
+  createEntity,
+  getAttribute,
+  getEntity,
+  setAttribute,
+} from '../src/doc/entity.js';
 import { applyIfcxOverlay, seedFromIfcx } from '../src/snapshot/from-ifcx.js';
 
 function layer(data: IfcxFile['data']): IfcxFile {
@@ -143,6 +150,33 @@ describe('applyIfcxOverlay', () => {
     expect(getAttribute(doc, 'wall', 'ifclite::name')).toBe('back');
     // Base state the resurrecting node never mentions must still be there.
     expect(getAttribute(doc, 'wall', 'ifclite::tag')).toBe('from-base');
+  });
+
+  // Classifications, materials and geometry refs are "single-valued
+  // opinions" per the comment in `overlayEntity`: a node that carries a
+  // list replaces the doc's list wholesale, and a node that carries none
+  // must say nothing, not clear it. Nothing exercised the "says nothing"
+  // half before this.
+  it('leaves classifications and materials untouched when the overlay node carries none', () => {
+    const doc = createCollabDoc();
+    doc.transact(() => {
+      createEntity(doc, 'wall', { ifcClass: 'IfcWall' });
+      addClassification(doc, 'wall', { system: 'Uniclass', code: 'Pr_20_93_88' });
+      addMaterial(doc, 'wall', { materialId: 'concrete' });
+    });
+
+    // A node that only touches an unrelated attribute — no classification
+    // or material opinion at all.
+    applyIfcxOverlay(doc, layer([{ path: 'wall', attributes: { 'ifclite::name': 'Wall B' } }]));
+
+    const classifications = getEntity(doc, 'wall')?.get(ENTITY_KEY.CLASSIFICATIONS) as
+      | Y.Array<unknown>
+      | undefined;
+    const materials = getEntity(doc, 'wall')?.get(ENTITY_KEY.MATERIALS) as
+      | Y.Array<unknown>
+      | undefined;
+    expect(classifications?.toArray()).toEqual([{ system: 'Uniclass', code: 'Pr_20_93_88' }]);
+    expect(materials?.toArray()).toEqual([{ materialId: 'concrete' }]);
   });
 
   // The overlay applier and the seeder share a node decoder, so the

--- a/packages/collab/test/apply-ifcx-overlay.test.ts
+++ b/packages/collab/test/apply-ifcx-overlay.test.ts
@@ -34,6 +34,8 @@ import {
   getAttribute,
   getEntity,
   setAttribute,
+  setChild,
+  setInherit,
 } from '../src/doc/entity.js';
 import { applyIfcxOverlay, seedFromIfcx } from '../src/snapshot/from-ifcx.js';
 
@@ -84,6 +86,34 @@ describe('applyIfcxOverlay', () => {
 
     const attrs = getEntity(doc, 'wall')?.get(ENTITY_KEY.ATTRIBUTES) as Y.Map<unknown> | undefined;
     expect(attrs?.has('ifclite::name')).toBe(false);
+  });
+
+  it('treats a null child/inherit target as a removal opinion', () => {
+    const doc = createCollabDoc();
+    doc.transact(() => {
+      createEntity(doc, 'storey', { ifcClass: 'IfcBuildingStorey' });
+      createEntity(doc, 'wall', { ifcClass: 'IfcWall' });
+      createEntity(doc, 'type-wall', { ifcClass: 'IfcWallType' });
+      setChild(doc, 'storey', 'wall', 'wall');
+      setInherit(doc, 'wall', 'type', 'type-wall');
+    });
+
+    applyIfcxOverlay(
+      doc,
+      layer([
+        { path: 'storey', children: { wall: null } },
+        { path: 'wall', inherits: { type: null } },
+      ]),
+    );
+
+    const children = getEntity(doc, 'storey')?.get(ENTITY_KEY.CHILDREN) as
+      | Y.Map<string>
+      | undefined;
+    const inherits = getEntity(doc, 'wall')?.get(ENTITY_KEY.INHERITS) as
+      | Y.Map<string>
+      | undefined;
+    expect(children?.has('wall')).toBe(false);
+    expect(inherits?.has('type')).toBe(false);
   });
 
   // `extractMinimalLayer` expresses a deletion as this tombstone node.

--- a/packages/ifcx/src/bake.test.ts
+++ b/packages/ifcx/src/bake.test.ts
@@ -5,6 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import type { IfcxFile } from './types.js';
+import { IFCLITE_ATTR } from './types.js';
 import { bakeLayers } from './bake.js';
 
 function makeFile(
@@ -49,5 +50,41 @@ describe('bakeLayers import/schema merge precedence', () => {
     assert.strictEqual(baked.imports.length, 1);
     assert.strictEqual(baked.imports[0].integrity, 'strong-hash');
     assert.strictEqual((baked.schemas['shared-schema'] as any).version, 'strong');
+  });
+});
+
+describe('bakeLayers strips namespaced derived-cache attributes', () => {
+  // BAKE_STRIPPED_PREFIXES matches by prefix (`key.startsWith(...)`), not
+  // exact equality, because derived-cache content is namespaced under
+  // `ifclite::derived::<kind>` (canonical.ts's `canonicalizeLayer` strips
+  // the same namespaced shape, and `computeLayerId` pins a
+  // `${IFCLITE_ATTR.DERIVED}::bvh` fixture as ignored there). Nothing here
+  // pinned bakeLayers against the same shape: an exact-match comparison
+  // that only strips the bare `ifclite::derived` key would leave a
+  // namespaced derived attribute in the baked output undetected.
+  it('drops an `ifclite::derived::<kind>` attribute, not just the bare key', () => {
+    const file: IfcxFile = {
+      header: {
+        id: 'src',
+        ifcxVersion: 'ifcx-alpha',
+        dataVersion: '1',
+        author: 'test',
+        timestamp: '2026-06-09T00:00:00Z',
+      },
+      imports: [],
+      schemas: {},
+      data: [
+        {
+          path: 'wall-1',
+          attributes: { Name: 'W1', [`${IFCLITE_ATTR.DERIVED}::bvh`]: 'cached-hash' },
+        },
+      ],
+    };
+
+    const baked = bakeLayers([file]);
+    const node = baked.data.find((n) => n.path === 'wall-1');
+
+    assert.strictEqual(node?.attributes?.Name, 'W1');
+    assert.strictEqual(node?.attributes?.[`${IFCLITE_ATTR.DERIVED}::bvh`], undefined);
   });
 });


### PR DESCRIPTION
Mutation-swept `packages/collab` and `packages/ifcx`. **Test-only, three findings, all untested-but-correct.**

All three are the same shape: **a guard whose "do nothing" branch was never exercised.** The suites tested that each setter writes what it is given, never that an absent opinion leaves existing state alone.

## 1. `from-ifcx.ts` — the `length > 0` guards before the setters

`overlayEntity`'s guards before `setClassifications` / `setMaterials` / `setGeometryRef` exist so **a node carrying no opinion leaves the doc's existing list untouched**. Removing them — calling the setters unconditionally — left all 258 tests passing.

```
AssertionError: expected [] to deeply equal [ { system: 'Uniclass', code: 'Pr_20_93_88' } ]
```

That is silent data loss on an overlay: any node without classifications would wipe the ones already on the entity.

I re-ran it here, neutralising all five guards: exactly one failure, `leaves classifications and materials untouched when the overlay node carries none`. Restored, green.

## 2. `from-ifcx.ts` — the child/inherit removal loops

`removedChildren` and `removedInherits` are populated when a child or inherit target is `null` — a **removal opinion**. Both loops had **zero coverage anywhere in the suite**; commenting them out left 259 tests green.

```
AssertionError: expected true to be false
```

## 3. `ifcx/bake.ts` — the namespaced-key strip

`materializeNode` uses `BAKE_STRIPPED_PREFIXES.some((prefix) => key.startsWith(prefix))` — a prefix match **by design**, matching how `canonical.ts` strips the same `ifclite::derived::<kind>` shape (pinned there by a `${IFCLITE_ATTR.DERIVED}::bvh` fixture).

But `bake.test.ts` only ever tested import and schema precedence — **the attribute-stripping branch was never exercised at all**, prefixed or bare. Changing `startsWith` to `===` left all 160 tests passing. The bare node-level `ifclite::derived: true` flag is covered elsewhere; the attribute-level namespaced path was not.

## Negative evidence, and one module confirmed genuinely solid

`federated-composition.ts` was mutated five ways — reversed weakest-to-strongest layer iteration, dropped the own-attribute-wins guard, dropped the own-child-wins guard, and skipped null-attribute-removal masking — **all killed** by `inherit-precedence.test.ts` and `tombstones.test.ts`. That module is well covered, not merely green.

`upsertGeometry` was inspected and deliberately **not** mutated: its test file (added in #3090) already exercises every documented branch — create-on-absent, overwrite type and source, params-merge-not-replace, omitted-field-preserved, version-vector-untouched — via direct unit assertions, specifically because the merge path cannot police them. Reading plus the existing test design was enough; a redundant mutation run would have added nothing.

## What was fenced off

PR #3092's `ifclite::meta` provenance carrier and its relationships tripwire, and PR #3090's `applyIfcxOverlay` core create/overwrite/tombstone-ordering — all confirmed still covered rather than re-chased.

## Two practical notes worth recording

**The two packages keep tests in different places.** `packages/collab` uses `test/*.test.ts` under vitest; `packages/ifcx` colocates `src/*.test.ts` and runs them under **`tsx --test`, not vitest**. A single search pattern finds one and misses the other — which is exactly how a coverage claim went wrong earlier today.

**The environment trap fired for real.** Without building `@ifc-lite/data`, `mutations`, `pointcloud` and `ifcx` first, `packages/collab` failed **37 of 50 test files** with "Failed to resolve entry for package @ifc-lite/ifcx". Built via turbo before trusting any run.

## Verification

collab **258 → 260** passing (2 skipped throughout), ifcx **160 → 161**. `typecheck` OK for both (50 and 18 test files). `check-module-size.mjs` exit 0. No changeset — test-only, no published behaviour changed.

**Leads not chased:** `composition.ts`, `provenance.ts`, `layer-stack.ts`, `traversal.ts` and `path-resolver.ts` in `packages/ifcx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
