### PR TITLE
test(oauth,sources): lookalike origins and zero-limit pages nothing covered

### DIFF
--- a/packages/oauth-pkce/test/authorization.test.ts
+++ b/packages/oauth-pkce/test/authorization.test.ts
@@ -173,6 +173,23 @@ describe('parseAuthorizationCallback', () => {
     ).toThrow(OAuthRedirectOriginError);
   });
 
+  it('rejects an origin that merely has the expected origin as a string prefix', () => {
+    // A same-origin check implemented as `origin.startsWith(expected)` (or
+    // `.includes(...)`) instead of exact equality would accept this: the
+    // string "https://app.example.com.evil.com" literally starts with
+    // "https://app.example.com", but it is a *different* origin — a
+    // registrable domain the attacker controls. This is the redirect-URI
+    // check matching "too loosely" (prefix rather than exact) that the
+    // origin check exists to rule out; nothing above exercises a callback
+    // whose origin shares that prefix relationship with the expected one.
+    expect(() =>
+      parseAuthorizationCallback(
+        `https://app.example.com.evil.com/callback?code=x&state=${expectedState}`,
+        options,
+      ),
+    ).toThrow(OAuthRedirectOriginError);
+  });
+
   it('surfaces a provider-returned error before checking state', () => {
     expect(() =>
       parseAuthorizationCallback(

--- a/packages/oauth-pkce/test/token-manager.test.ts
+++ b/packages/oauth-pkce/test/token-manager.test.ts
@@ -61,6 +61,36 @@ describe('TokenManager.getValidAccessToken', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('refreshes when the token sits exactly on the skew boundary (expiresAt - skew === now)', async () => {
+    // A fixture well inside or well outside the skew window can't tell `>` from
+    // `>=` apart. This one lands exactly on the boundary: `expiresAt - skew`
+    // equals `now` to the millisecond, so it only distinguishes the two if the
+    // comparison is strict. The freshness check must treat "exactly at the
+    // skew boundary" as needing a refresh, not as still fresh — that's what
+    // the skew buffer is *for*: absorbing the refresh request's own latency,
+    // which a token already sitting exactly `skew` ms from expiry has none of
+    // left.
+    const storage = createMemoryStorage();
+    const fetchMock = vi.fn(async () => jsonResponse({ access_token: 'refreshed', refresh_token: 'r2', expires_in: 3600 }));
+    const now = 1_000_000;
+    const skew = 60_000;
+    const manager = new TokenManager({
+      storageKey: 'acct-1',
+      storage,
+      tokenEndpoint: 'https://auth.example.com/token',
+      clientId: 'client-1',
+      fetch: fetchMock as unknown as typeof fetch,
+      now: () => now,
+      refreshSkewMs: skew,
+    });
+    await manager.setTokens({ accessToken: 'on-the-boundary', refreshToken: 'r1', expiresAt: now + skew });
+
+    const token = await manager.getValidAccessToken();
+
+    expect(token).toBe('refreshed');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('refreshes when the stored token is within the skew window of expiry', async () => {
     const storage = createMemoryStorage();
     const fetchMock = vi.fn(async () => jsonResponse({ access_token: 'refreshed', refresh_token: 'r2', expires_in: 3600 }));

--- a/packages/source-dalux/test/node-url.test.ts
+++ b/packages/source-dalux/test/node-url.test.ts
@@ -102,4 +102,31 @@ describe('node stamping is scoped to the relay', () => {
     await client.getBinary('https://node1.field.dalux.com/service/api/2.0/x/content');
     expect(seen[2]).toContain('daluxNode=node2');
   });
+
+  it('does not stamp a URL whose origin merely has the relay origin as a string prefix', async () => {
+    // Both `stampNode` and `nodeSelectorFor` gate on `url.origin !== <relay
+    // origin>`, which is correct exact-origin equality. A same-origin check
+    // implemented instead as `!origin.startsWith(relayOrigin)` would still
+    // reject a wholly different host (the `cdn.dalux.com` cases above), but
+    // would accept "https://node1.field.dalux.com.evil.com" — a different,
+    // attacker-controlled registrable domain whose origin string literally
+    // starts with the relay's. Nothing above exercises that shape.
+    const seen: string[] = [];
+    const ctx = {
+      fetch: async (url: string) => {
+        seen.push(url);
+        return new Response(new ArrayBuffer(2), { status: 200 });
+      },
+      log: { debug() {}, error() {}, info() {}, warn() {} },
+    } as unknown as ConstructorParameters<typeof BrowserDaluxApiClient>[1];
+
+    const client = new BrowserDaluxApiClient(
+      { baseUrl: 'https://node1.field.dalux.com/service/api', apiKey: 'k', node: 'node2' },
+      ctx,
+    );
+
+    const lookalike = 'https://node1.field.dalux.com.evil.com/service/api/2.0/x/content';
+    await client.getBinary(lookalike);
+    expect(seen[0]).toBe(lookalike);
+  });
 });

--- a/packages/source-dropbox/test/provider.test.ts
+++ b/packages/source-dropbox/test/provider.test.ts
@@ -317,6 +317,23 @@ describe('DropboxProvider', () => {
       expect(clampSearchPageSize(0.5)).toBe(1);
       expect(clampRevisionsPageSize(0.5)).toBe(1);
     });
+
+    // `limit && limit > 0 ? ... : DEFAULT` treats a `0` or negative `limit`
+    // as "not really a limit" and falls back to the default page size,
+    // rather than floor-clamping it up to 1 the way a sub-1 fraction is.
+    // Nothing exercised `0` itself: every existing fixture is either a large
+    // limit, a fraction strictly between 0 and 1, or `undefined` — none of
+    // which distinguish "falls back to the default" from "clamps up to 1",
+    // since `0` is the one input where those two behaviors produce visibly
+    // different page sizes (200/100/10 vs 1).
+    it('falls back to the default page size for a zero or negative limit, not clamped up to 1', () => {
+      expect(clampPageSize(0)).toBe(200);
+      expect(clampPageSize(-5)).toBe(200);
+      expect(clampSearchPageSize(0)).toBe(100);
+      expect(clampSearchPageSize(-5)).toBe(100);
+      expect(clampRevisionsPageSize(0)).toBe(10);
+      expect(clampRevisionsPageSize(-5)).toBe(10);
+    });
   });
 
   describe('download', () => {

--- a/packages/source-fixture/test/provider.test.ts
+++ b/packages/source-fixture/test/provider.test.ts
@@ -159,6 +159,25 @@ describe('interactive auth gate', () => {
   });
 });
 
+describe('paginate() limit clamping', () => {
+  // `paginate`'s `request?.limit && request.limit > 0 ? ... : maxPageSize`
+  // treats a `0` (or negative) limit as "not really a limit" and falls back
+  // to the fixture's own page size, the same as `undefined` — distinct from
+  // a fractional sub-1 limit, which clamps *up* to 1 instead. No existing
+  // fixture across this package's tests passes `limit: 0` itself, so a
+  // `limit >= 0` mutation (clamping zero down to a single-item page instead
+  // of falling back to the default) would pass every one of them unnoticed.
+  it('falls back to the default page size for limit: 0, rather than a single-item page', async () => {
+    const provider = createFixtureSourceProvider({ world: buildTestWorldSpec() }); // default pageSize 25
+    const ctx = createFixtureContext();
+    // `sub1` has exactly 2 files (see world.ts) — well within the default
+    // page size, so a correct fallback returns both in one page.
+    const page = await provider.listFiles(ctx, 'proj-1', 'sub1', undefined, { limit: 0 });
+    expect(page.items.map((f) => f.id)).toEqual(['structural-model', 'structural-notes']);
+    expect(page.cursor).toBeUndefined();
+  });
+});
+
 describe('cursor scoping', () => {
   it('rejects a malformed cursor', async () => {
     const provider = createFixtureSourceProvider({ world: buildTestWorldSpec() });

--- a/packages/source-msgraph/test/provider.test.ts
+++ b/packages/source-msgraph/test/provider.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { PLUGIN_API_VERSION, satisfiesCaretRange } from '@ifc-lite/plugin-api';
 
 import { MsGraphProvider } from '../src/provider.js';
-import { clampPageSize } from '../src/mapping.js';
+import { clampPageSize, searchEndpoint } from '../src/mapping.js';
 import {
   GRAPH_MOCK_DOWNLOAD_HOST,
   GRAPH_MOCK_DOWNLOAD_SECRET,
@@ -173,6 +173,26 @@ describe('MsGraphProvider', () => {
       const page = await provider.searchFiles!(ctx, 'me', 'MODEL');
       expect(page.items.map((f) => f.id)).toEqual(['file-1']);
       expect(page.items[0].containerId).toBe('f-alpha');
+    });
+  });
+
+  describe('searchEndpoint', () => {
+    // The query text sits inside a single-quoted OData string literal
+    // embedded directly in the URL *path* (`search(q='...')`), so a literal
+    // `'` in the user's search text must be doubled (OData's own
+    // string-literal escaping) before `encodeURIComponent` runs — otherwise
+    // it closes the literal early and Graph parses the remainder of the
+    // query as OData syntax rather than search text. No existing fixture's
+    // search text contains a quote, so a mutation that skips the doubling
+    // entirely (`escaped = query`) still passes the whole suite; this pins
+    // the doubling directly against the built path.
+    it('doubles a literal single quote in the query before percent-encoding it', () => {
+      const path = searchEndpoint("O'Brien's model");
+      // OData escaping doubles each `'` to `''` first; `encodeURIComponent`
+      // does not touch `'` itself (it isn't in its escape set), so the
+      // doubled quotes survive verbatim into the URL and only the space
+      // gets percent-encoded.
+      expect(path).toBe("/me/drive/root/search(q='O''Brien''s%20model')");
     });
   });
 
@@ -389,6 +409,18 @@ describe('MsGraphProvider', () => {
     // one item" — the same shape that package's clamp already guards against.
     it('never floors a fractional sub-1 limit to 0', () => {
       expect(clampPageSize(0.5)).toBe('1');
+    });
+
+    // `limit && limit > 0 ? ... : DEFAULT_PAGE_SIZE` treats a `0` (or
+    // negative) limit as "not really a limit" and falls back to the
+    // default, the same as `undefined` — distinct from the sub-1 fractional
+    // case just above, which clamps *up* to 1 instead. No existing fixture
+    // passed exactly `0`, so a `limit >= 0` mutation (accepting zero as a
+    // real request, which then clamps down to `1` instead of falling back
+    // to `200`) would pass unnoticed.
+    it('falls back to the default page size for a zero or negative limit, not clamped up to 1', () => {
+      expect(clampPageSize(0)).toBe('200');
+      expect(clampPageSize(-5)).toBe('200');
     });
   });
 });


### PR DESCRIPTION
Mutation-swept the OAuth helper and the four file-source connectors. **Six findings, all untested-but-correct — every fix is a test, no source changed.**

To be clear up front: **no live vulnerability.** Every check tested here is already correct today. What was missing is the fixture that would catch it *becoming* wrong, and on origin validation and pagination bounds that is worth closing.

Three shapes recur across all five packages.

## 1. Exact-origin checks with no lookalike fixture — twice

`oauth-pkce/src/authorization.ts:89` compares `url.origin !== expectedRedirectOrigin`. Correct. But **the only negative fixture used `evil.example.com`, which shares no prefix with the expected origin** — so weakening the check to `startsWith` accepted `https://app.example.com.evil.com` and the suite stayed green.

Verified here rather than taken on report:

```
× rejects an origin that merely has the expected origin as a string prefix
Tests  1 failed | 15 passed (16)
```

Restored, green.

The same shape appears in `source-dalux`'s `nodeSelectorFor`/`stampNode`, which decides whether a supplied download or pagination link gets the relay's `daluxNode` query parameter attached. Under a `startsWith` mutation, `https://node1.field.dalux.com.evil.com/...` would be treated as relay-bound. A lookalike fixture now covers it.

Worth noting the codebase was **already defended in a neighbouring spot**: dropping the `$` anchor from `source-dalux`'s node-host regex is killed by an existing `node2.field.dalux.com.evil.com` fixture. So the pattern was known — it just had not been applied to these two call sites.

## 2. A zero limit is not an absent limit — three times

`limit && limit > 0 ? … : DEFAULT` appears in `source-dropbox` (three clamps), `source-msgraph`, and `source-fixture`'s own `paginate()`. **None had a fixture passing `limit: 0`** — only large, fractional and `undefined`. So mutating to `limit >= 0` silently turns an explicit `0` into a **one-item page** instead of the default.

The `source-fixture` instance matters most: that is the reference implementation the conformance suite runs against.

## 3. OData quote-escaping with no quoted fixture

`source-msgraph`'s `searchEndpoint` doubles single quotes (`replace(/'/g, "''")`) for OData. **No fixture contained a quote at all**, so deleting the escaping entirely passed the whole suite. Now covered with a genuinely apostrophe-bearing search term.

## Negative evidence

Killed on first try: `token-exchange.ts`'s `expires_in > 0` → `>= 0` (caught by the existing 3600-default assertion) and its `!response.ok` guard disabled (two error-shape tests); `source-dropbox`'s `searchResultParentPath` boundary `<= 0` → `< 0`; `source-dalux`'s node-host regex anchor; and `source-fixture`'s `nextOffset < items.length` → `<=`, which failed **97 tests** across the suite.

**No equivalent or unreachable mutants this round** — every survivor was a genuine gap, stated rather than blurred.

## Judgement calls

`oauth-pkce`'s `callback-channel.ts` and the token-manager queue/session-swap machinery were read in full and are extensively self-documented against past defects, including a fixed NaN-guard PKCE bypass. No live mutant was found there and none was forced.

The `auth.ts` sign-in/sign-out flows were not chased: both connectors already carry a `refresh-race.test.ts` written specifically for the token-manager cache race their comments describe, and reproducing that class a third time is worse value than the origin and pagination sweep.

**Nothing was withheld as sensitive.** Every survivor has an existing regression-class precedent documented in the repo's own comments — the origin-check shape is called out three times as a known risk — so all six were fixed in the open with tests rather than held back.

## Verification

oauth-pkce **85 → 87**, source-dropbox **76 → 77**, source-msgraph **67 → 69**, source-dalux **154 → 155**, source-fixture **192 → 193**; skip counts unchanged throughout. Each finding was confirmed RED with the mutant, reverted, re-run GREEN, then the named test re-verified against the mutant on re-application.

All five packages keep tests in `test/` and run plain `vitest run`, confirmed by reading each `package.json` rather than inferring — a check that produced two wrong coverage claims elsewhere today.

`typecheck` OK per package; `check-module-size.mjs` exit 0. No changeset — test-only, no published behaviour changed. No network calls were made, and no credential material appears in any fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
