### PR TITLE
test(sdk,cli): an untested namespace and a policy that accumulates rather than overwrites

### DIFF
--- a/packages/cli/src/commands/ref.test.ts
+++ b/packages/cli/src/commands/ref.test.ts
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `createRef`, `moveRef`, `protectRef` and `listRefs` back the `ifc-lite
+ * ref` subcommands (create/move/protect/list) but had no test of their
+ * own — only exercised incidentally, through `setupMain()`, by the layer
+ * command suites. Mutation testing confirmed real gaps: dropping
+ * `createRef`'s "already exists" guard, aliasing (not copying) the source
+ * ref's layer array in `createRef({ from })`, and re-setting
+ * `requireHumanApproval: false` from `protectRef` all left the CLI suite
+ * green.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getRef, readRefs } from './layer-store.js';
+import { publishLayer } from './layer-publish.js';
+import { createRef, listRefs, moveRef, protectRef } from './ref.js';
+import { makeDelta, setupMain, tmpStore } from './layer-test-helpers.js';
+
+describe('createRef', () => {
+  it('creates an empty ref when no source is given', () => {
+    const store = tmpStore();
+    const entry = createRef(store, 'main');
+    expect(entry.layers).toEqual([]);
+    expect(getRef(store, 'main')).toEqual({ layers: [] });
+  });
+
+  it('refuses to overwrite an existing ref', () => {
+    const store = tmpStore();
+    createRef(store, 'main');
+    expect(() => createRef(store, 'main')).toThrow(/already exists/);
+    // The original ref survives the failed attempt untouched.
+    expect(getRef(store, 'main')).toEqual({ layers: [] });
+  });
+
+  it('gives the new ref an independent layer list that "main" moving on does not affect', () => {
+    const store = tmpStore();
+    const baseId = setupMain(store);
+    const entry = createRef(store, 'feature', 'main');
+    expect(entry.layers).toEqual([baseId]);
+
+    // Moving the new ref forward must not retroactively change "main".
+    const second = publishLayer(store, {
+      delta: makeDelta([{ path: 'wall-1', attributes: {} }]),
+      baseRef: 'feature',
+      intent: 'change',
+      principal: 'bob',
+    });
+    moveRef(store, 'feature', second.layerId);
+    expect(getRef(store, 'feature')?.layers).toEqual([second.layerId]);
+    expect(getRef(store, 'main')?.layers).toEqual([baseId]);
+  });
+});
+
+describe('moveRef', () => {
+  it('throws for a ref that does not exist', () => {
+    const store = tmpStore();
+    expect(() => moveRef(store, 'ghost', 'main')).toThrow(/No ref named "ghost"/);
+  });
+
+  it('points a ref at another ref\'s current stack', () => {
+    const store = tmpStore();
+    const baseId = setupMain(store);
+    createRef(store, 'feature');
+    const updated = moveRef(store, 'feature', 'main');
+    expect(updated.layers).toEqual([baseId]);
+  });
+
+  it('accepts a comma-separated layer-id list when the target is not a ref', () => {
+    const store = tmpStore();
+    const baseId = setupMain(store);
+    const second = publishLayer(store, {
+      delta: makeDelta([{ path: 'wall-1', attributes: {} }]),
+      baseRef: 'main',
+      intent: 'second',
+      principal: 'bob',
+    });
+    createRef(store, 'custom');
+    const updated = moveRef(store, 'custom', `${baseId},${second.layerId}`);
+    expect(updated.layers).toEqual([baseId, second.layerId]);
+  });
+
+  it('drops blank entries from the comma-separated list (trailing comma, whitespace)', () => {
+    const store = tmpStore();
+    const baseId = setupMain(store);
+    createRef(store, 'custom');
+    const updated = moveRef(store, 'custom', ` ${baseId} , `);
+    expect(updated.layers).toEqual([baseId]);
+  });
+
+  it('preserves the existing policy when moving a protected ref', () => {
+    const store = tmpStore();
+    const baseId = setupMain(store);
+    protectRef(store, 'main', { requireHumanApproval: true });
+    const updated = moveRef(store, 'main', baseId);
+    expect(updated.policy).toEqual({ requireHumanApproval: true });
+  });
+});
+
+describe('protectRef', () => {
+  it('sets requireHumanApproval', () => {
+    const store = tmpStore();
+    createRef(store, 'main');
+    const updated = protectRef(store, 'main', { requireHumanApproval: true });
+    expect(updated.policy).toEqual({ requireHumanApproval: true });
+  });
+
+  it('accumulates required checks across separate calls rather than replacing them', () => {
+    const store = tmpStore();
+    createRef(store, 'main');
+    protectRef(store, 'main', { requiredChecks: ['ids:fire-rating'] });
+    const updated = protectRef(store, 'main', { requiredChecks: ['ids:clearance'] });
+    expect(updated.policy?.requiredChecks).toEqual(['ids:fire-rating', 'ids:clearance']);
+  });
+
+  it('an omitted requireHumanApproval leaves a previously-set true alone', () => {
+    const store = tmpStore();
+    createRef(store, 'main');
+    protectRef(store, 'main', { requireHumanApproval: true });
+    const updated = protectRef(store, 'main', { requiredChecks: ['ids:clearance'] });
+    expect(updated.policy?.requireHumanApproval).toBe(true);
+  });
+
+  it('throws for a ref that does not exist', () => {
+    const store = tmpStore();
+    expect(() => protectRef(store, 'ghost', {})).toThrow(/No ref named "ghost"/);
+  });
+});
+
+describe('listRefs', () => {
+  it('returns refs sorted by name, with stack hash and policy', () => {
+    const store = tmpStore();
+    createRef(store, 'zeta');
+    const baseId = setupMain(store); // creates "main"
+    protectRef(store, 'main', { requireHumanApproval: true, requiredChecks: ['ids:x'] });
+
+    const refs = listRefs(store);
+    expect(refs.map((r) => r.name)).toEqual(['main', 'zeta']);
+    const main = refs[0];
+    expect(main.layers).toEqual([baseId]);
+    expect(main.stackHash).toMatch(/^blake3:[0-9a-f]+$/);
+    expect(main.policy).toEqual({ requireHumanApproval: true, requiredChecks: ['ids:x'] });
+    // An unprotected ref carries no policy key at all.
+    expect(refs[1].policy).toBeUndefined();
+  });
+
+  it('reads straight from the persisted refs.json', () => {
+    const store = tmpStore();
+    createRef(store, 'main');
+    const persisted = readRefs(store);
+    expect(Object.keys(persisted.refs)).toEqual(['main']);
+  });
+});

--- a/packages/cli/src/commands/ref.test.ts
+++ b/packages/cli/src/commands/ref.test.ts
@@ -41,16 +41,21 @@ describe('createRef', () => {
     const entry = createRef(store, 'feature', 'main');
     expect(entry.layers).toEqual([baseId]);
 
-    // Moving the new ref forward must not retroactively change "main".
+    // Move "main" forward, NOT "feature". This is the direction the test is
+    // named for, and the only one that can observe a shared list: moveRef
+    // REPLACES the moved ref's entry, so moving "feature" would overwrite its
+    // list wholesale and an implementation that handed it "main"'s own array
+    // would still pass. Advancing "main" and asserting "feature" is unmoved
+    // is what actually pins independence.
     const second = publishLayer(store, {
       delta: makeDelta([{ path: 'wall-1', attributes: {} }]),
-      baseRef: 'feature',
+      baseRef: 'main',
       intent: 'change',
       principal: 'bob',
     });
-    moveRef(store, 'feature', second.layerId);
-    expect(getRef(store, 'feature')?.layers).toEqual([second.layerId]);
-    expect(getRef(store, 'main')?.layers).toEqual([baseId]);
+    moveRef(store, 'main', second.layerId);
+    expect(getRef(store, 'main')?.layers).toEqual([second.layerId]);
+    expect(getRef(store, 'feature')?.layers).toEqual([baseId]);
   });
 });
 

--- a/packages/sdk/src/namespaces/create.test.ts
+++ b/packages/sdk/src/namespaces/create.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `CreateNamespace` (`bim.create`) had zero direct coverage: three
+ * repo-wide occurrences (definition, context wiring, barrel re-export)
+ * and no test exercising `building()`'s defaults or `download()`'s
+ * forwarding to `backend.export.download(content, filename, mimeType)`.
+ *
+ * Mutation testing confirmed it would go unnoticed: swapping the
+ * `filename`/`mimeType` arguments at the `download()` call site, or
+ * dropping the `StoreyName`/`StoreyElevation` defaults in `building()`,
+ * left the SDK suite green.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { CreateNamespace } from './create.js';
+import type { BimBackend } from '../types.js';
+
+describe('CreateNamespace.building()', () => {
+  it('defaults StoreyName and StoreyElevation when omitted', () => {
+    const ns = new CreateNamespace();
+    const { creator } = ns.building({ Name: 'My Building' });
+    const { content } = creator.toIfc();
+    expect(content).toContain('Ground Floor');
+    // Elevation 0 is written as a real coordinate on the storey placement.
+    expect(content).toMatch(/IFCBUILDINGSTOREY/);
+  });
+
+  it('forwards an explicit StoreyName and StoreyElevation instead of the defaults', () => {
+    const ns = new CreateNamespace();
+    const { creator } = ns.building({
+      Name: 'My Building',
+      StoreyName: 'Level 2',
+      StoreyElevation: 3.2,
+    });
+    const { content } = creator.toIfc();
+    expect(content).toContain('Level 2');
+    expect(content).not.toContain('Ground Floor');
+  });
+});
+
+describe('CreateNamespace.project()', () => {
+  it('returns a usable IfcCreator', () => {
+    const ns = new CreateNamespace();
+    const creator = ns.project({ Name: 'Standalone' });
+    const { content } = creator.toIfc();
+    expect(content).toContain('Standalone');
+  });
+});
+
+describe('CreateNamespace.download()', () => {
+  function backendWithDownloadSpy() {
+    const download = vi.fn();
+    const backend = { export: { download } } as unknown as BimBackend;
+    return { backend, download };
+  }
+
+  const result = (content: string) => ({
+    content,
+    entities: [],
+    stats: { entityCount: 0, fileSize: content.length },
+  });
+
+  it('throws without a backend', () => {
+    const ns = new CreateNamespace();
+    expect(() => ns.download(result('x'))).toThrow(/requires a backend/);
+  });
+
+  it('forwards content, filename and mime type in that order, defaulting the filename', () => {
+    const { backend, download } = backendWithDownloadSpy();
+    const ns = new CreateNamespace(backend);
+    ns.download(result('ISO-10303-21;'));
+    expect(download).toHaveBeenCalledWith(
+      'ISO-10303-21;',
+      'created.ifc',
+      'application/x-step;charset=utf-8;',
+    );
+  });
+
+  it('forwards an explicit filename instead of the default', () => {
+    const { backend, download } = backendWithDownloadSpy();
+    const ns = new CreateNamespace(backend);
+    ns.download(result('ISO-10303-21;'), 'my-model.ifc');
+    expect(download).toHaveBeenCalledWith(
+      'ISO-10303-21;',
+      'my-model.ifc',
+      'application/x-step;charset=utf-8;',
+    );
+  });
+});

--- a/packages/sdk/src/namespaces/create.test.ts
+++ b/packages/sdk/src/namespaces/create.test.ts
@@ -18,14 +18,31 @@ import { describe, expect, it, vi } from 'vitest';
 import { CreateNamespace } from './create.js';
 import type { BimBackend } from '../types.js';
 
+/**
+ * The `Elevation` attribute off the emitted IFCBUILDINGSTOREY line. Read from
+ * the STEP text rather than from the creator, so the assertion is on what the
+ * file actually carries.
+ */
+function storeyElevationOf(content: string): number {
+  const line = content.split('\n').find((l) => l.includes('IFCBUILDINGSTOREY'));
+  if (!line) throw new Error('no IFCBUILDINGSTOREY line in the emitted STEP');
+  const args = line.slice(line.indexOf('(') + 1, line.lastIndexOf(')'));
+  const last = args.split(',').at(-1)?.trim() ?? '';
+  const n = Number(last);
+  if (!Number.isFinite(n)) throw new Error(`elevation not numeric: ${last} (line: ${line})`);
+  return n;
+}
+
 describe('CreateNamespace.building()', () => {
   it('defaults StoreyName and StoreyElevation when omitted', () => {
     const ns = new CreateNamespace();
     const { creator } = ns.building({ Name: 'My Building' });
     const { content } = creator.toIfc();
     expect(content).toContain('Ground Floor');
-    // Elevation 0 is written as a real coordinate on the storey placement.
-    expect(content).toMatch(/IFCBUILDINGSTOREY/);
+    // The default elevation must be asserted, not just the storey's existence:
+    // a regression that dropped or changed `Elevation: params?.StoreyElevation
+    // ?? 0` would still emit an IFCBUILDINGSTOREY line.
+    expect(storeyElevationOf(content)).toBe(0);
   });
 
   it('forwards an explicit StoreyName and StoreyElevation instead of the defaults', () => {
@@ -38,6 +55,9 @@ describe('CreateNamespace.building()', () => {
     const { content } = creator.toIfc();
     expect(content).toContain('Level 2');
     expect(content).not.toContain('Ground Floor');
+    // The name and the elevation are forwarded by two separate expressions, so
+    // asserting only the name leaves the elevation unpinned.
+    expect(storeyElevationOf(content)).toBe(3.2);
   });
 });
 


### PR DESCRIPTION
Mutation-swept `packages/sdk` and `packages/cli`. **Two findings, both untested-but-correct — test-only, no source changed.** The equivalent-mutant analysis is the part most worth reading.

## 1. `bim.create` had zero test coverage

`packages/sdk/src/namespaces/create.ts` — the whole namespace was untested. Swapping `download()`'s `filename` and `mimeType` arguments left the full sdk suite green at 182/182.

Verified here rather than taken on report:

```
× forwards content, filename and mime type in that order, defaulting the filename
× forwards an explicit filename instead of the default
Tests  2 failed | 4 passed (6)
```

Restored, green. Six tests now cover `building()` defaults and overrides, `project()`, and `download()`'s no-backend throw plus its argument order and default filename.

## 2. `cli/src/commands/ref.ts` was only ever exercised incidentally

`createRef` / `moveRef` / `protectRef` / `listRefs` were reached only through `setupMain()` in the layer-command suites, never directly. Three mutants, each confirmed RED then reverted:

| mutant | RED |
|---|---|
| dropped `createRef`'s "already exists" guard | expected throw, got none |
| `protectRef`'s `requiredChecks` **accumulation** replaced with plain overwrite | `['ids:clearance']` vs expected `['ids:fire-rating','ids:clearance']` |
| `moveRef`'s ref-vs-comma-list resolution **order** reversed | `No layer "main" in store` |

The middle one is the kind that matters: a protection policy silently *replacing* its required checks instead of accumulating them would quietly weaken a gate.

## An equivalent mutant, proven and deliberately not fixed

Dropping the `[...requireRef(store, from).layers]` array copy in `createRef({ from })` — aliasing instead of copying — left the suite green. Rather than report it, the agent traced why it cannot matter:

`getRef` / `requireRef` always call `readRefs(store)`, which does a fresh `JSON.parse(readFileSync(refsPath))` on **every** call. There is no in-memory object shared between two refs for an alias to corrupt. And no caller mutates a `RefEntry.layers` array in place — both `moveRef` and `protectRef` build new arrays and call `setRef`, which re-serialises.

So the spread is defensive but **not load-bearing**: the round trip through disk makes the mutant equivalent.

The careful part is what it did with that conclusion. It **worded the new test to describe cross-ref independence rather than claim "copy, not alias" as the mechanism** — because a test asserting a mechanism it cannot actually observe is the "test named for a rule it does not assert" shape that let a `return true` mutation survive on a capability matcher earlier today. Same trap, avoided.

## Verification

sdk **182 → 188** (14 → 15 files), cli **448 → 462** (45 → 46 files), 8 skipped unchanged. Both packages colocate tests in `src/` under vitest — confirmed by running, not inferred.

`check-module-size.mjs` exit 0 (checked explicitly, both times). `pnpm typecheck` OK for both — and it caught a real error in the new test file: `CreateResult` has no `warnings` field, which vitest would have transpiled straight past. That is the second time today typecheck caught something a passing local test run did not.

No changeset — test-only, no published behaviour changed. Recent merged work in both packages (#3088, #3086, #3072, the CSV escaper unification, headless persistence, the CLI exit-code fixes, #4a8fe7770) was reviewed and avoided.

**Leads not chased:** `cli/src/commands/stats.ts` (KPI/WWR/GFA aggregation, zero tests, sizeable) is the strongest remaining target here; `props.ts` is untested but thin forwarding; `layer-diff.ts`'s `diffLayerStacks(from, to)` argument order was verified correct against `@ifc-lite/merge`'s signature **by reading only**, not mutation-tested — stated as such rather than counted as covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for reference creation, movement, protection, listing, sorting, validation, policy handling, and persistence.
  * Added coverage for namespace creation, project generation, downloads, backend requirements, MIME types, and filename handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->