### PR TITLE
test(viewer): three store guards whose no-op branch nothing exercised

### DIFF
--- a/apps/viewer/src/store/slices/dockSlice.test.ts
+++ b/apps/viewer/src/store/slices/dockSlice.test.ts
@@ -69,6 +69,35 @@ describe('dockSlice (#1201)', () => {
     assert.strictEqual(s.getState().floatingPanels.at(-1)?.id, 'compare');
   });
 
+  it('is a no-op (array identity preserved) when the panel is already on top', () => {
+    // Non-default state: two panels floating, target already at the front.
+    // A mutant that always rebuilds+persists on every call passes the
+    // "raises it" test above (order is unaffected either way) but would
+    // still trigger an unconditional localStorage write on every
+    // pointer-down, even when nothing about the order changed.
+    const s = makeStore();
+    s.getState().floatPanel('bcf');
+    s.getState().floatPanel('compare');
+    const before = s.getState().floatingPanels;
+
+    s.getState().bringFloatingPanelToFront('compare');
+
+    assert.strictEqual(s.getState().floatingPanels, before, 'already-on-top must not allocate a new array');
+  });
+
+  it('does nothing when the given id is not currently floating', () => {
+    // Guards against pushing an `undefined` entry onto floatingPanels when
+    // `find` misses — a real crash risk in the renderer, not just a no-op.
+    const s = makeStore();
+    s.getState().floatPanel('bcf');
+    const before = s.getState().floatingPanels;
+
+    s.getState().bringFloatingPanelToFront('compare');
+
+    assert.strictEqual(s.getState().floatingPanels, before);
+    assert.ok(s.getState().floatingPanels.every((p) => p !== undefined && typeof p.id === 'string'));
+  });
+
   it('resetDockLayout drops every floating panel', () => {
     const s = makeStore();
     s.getState().floatPanel('lens');

--- a/apps/viewer/src/store/slices/pinboardSlice.test.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.test.ts
@@ -191,6 +191,47 @@ describe('PinboardSlice', () => {
     });
   });
 
+  describe('removeBasketView', () => {
+    it('removes the view and clears activeBasketViewId when it was the active one', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
+      const id = state.saveCurrentBasketView();
+      assert.strictEqual(state.activeBasketViewId, id);
+
+      state.removeBasketView(id!);
+
+      assert.strictEqual(state.basketViews.length, 0);
+      assert.strictEqual(state.activeBasketViewId, null);
+    });
+
+    it('leaves activeBasketViewId untouched when removing a DIFFERENT (non-active) view', () => {
+      // Non-default state: two saved views, and the active one is NOT the
+      // one being removed. A mutant that unconditionally nulls
+      // activeBasketViewId on every removal passes any test that only
+      // removes the active view — this pins the other direction.
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
+      const firstId = state.saveCurrentBasketView();
+      state.setBasket([{ modelId: 'legacy', expressId: 200 }]);
+      const secondId = state.saveCurrentBasketView();
+      assert.strictEqual(state.activeBasketViewId, secondId);
+
+      state.removeBasketView(firstId!);
+
+      assert.strictEqual(state.basketViews.length, 1);
+      assert.strictEqual(state.basketViews[0].id, secondId);
+      assert.strictEqual(state.activeBasketViewId, secondId, 'removing an inactive view must not clear the active one');
+    });
+
+    it('removing an unknown id is a no-op for activeBasketViewId', () => {
+      state.setBasket([{ modelId: 'legacy', expressId: 100 }]);
+      const id = state.saveCurrentBasketView();
+
+      state.removeBasketView('does-not-exist');
+
+      assert.strictEqual(state.basketViews.length, 1);
+      assert.strictEqual(state.activeBasketViewId, id);
+    });
+  });
+
   describe('clearBasket', () => {
     it('resets activeBasketViewId', () => {
       state.setBasket([{ modelId: 'legacy', expressId: 100 }]);

--- a/apps/viewer/src/store/slices/sourcesSlice.test.ts
+++ b/apps/viewer/src/store/slices/sourcesSlice.test.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createStore } from 'zustand/vanilla';
+import { createSourcesSlice, type SourcesSlice } from './sourcesSlice.js';
+import type { SourceTag } from '@ifc-lite/plugin-api';
+
+const makeStore = () => createStore<SourcesSlice>(createSourcesSlice);
+
+const tag = (label: string): SourceTag => ({
+  provider: 'dropbox',
+  projectId: 'proj',
+  containerId: 'container',
+  fileId: label,
+  revisionId: 'rev-1',
+  loadedAt: 0,
+});
+
+describe('sourcesSlice', () => {
+  describe('setSourceTag', () => {
+    it('stores a tag under its model id without disturbing other models', () => {
+      const s = makeStore();
+      s.getState().setSourceTag('model-1', tag('one'));
+      s.getState().setSourceTag('model-2', tag('two'));
+
+      assert.deepStrictEqual(s.getState().sourceTags.get('model-1'), tag('one'));
+      assert.deepStrictEqual(s.getState().sourceTags.get('model-2'), tag('two'));
+      assert.strictEqual(s.getState().sourceTags.size, 2);
+    });
+  });
+
+  describe('removeSourceTag', () => {
+    it('removes exactly the named model, leaving unrelated tags in place', () => {
+      const s = makeStore();
+      s.getState().setSourceTag('model-1', tag('one'));
+      s.getState().setSourceTag('model-2', tag('two'));
+
+      s.getState().removeSourceTag('model-1');
+
+      assert.ok(!s.getState().sourceTags.has('model-1'));
+      assert.deepStrictEqual(s.getState().sourceTags.get('model-2'), tag('two'));
+    });
+
+    it('leaves the map untouched (same object identity) when the model has no tag', () => {
+      // Non-default state: seed an UNRELATED tag first, so a mutant that wipes
+      // the map on a miss (instead of doing nothing) is caught by content, not
+      // just by the identity check below.
+      const s = makeStore();
+      s.getState().setSourceTag('model-2', tag('two'));
+      const before = s.getState().sourceTags;
+
+      s.getState().removeSourceTag('model-1');
+
+      assert.strictEqual(s.getState().sourceTags, before, 'a miss must not allocate a new Map (guard must short-circuit)');
+      assert.deepStrictEqual(s.getState().sourceTags.get('model-2'), tag('two'));
+    });
+  });
+
+  describe('clearSourceTags', () => {
+    it('empties a non-empty map', () => {
+      const s = makeStore();
+      s.getState().setSourceTag('model-1', tag('one'));
+
+      s.getState().clearSourceTags();
+
+      assert.strictEqual(s.getState().sourceTags.size, 0);
+    });
+
+    it('leaves the map untouched (same object identity) when already empty', () => {
+      const s = makeStore();
+      const before = s.getState().sourceTags;
+
+      s.getState().clearSourceTags();
+
+      assert.strictEqual(s.getState().sourceTags, before, 'clearing an already-empty map must not allocate a new one');
+    });
+  });
+
+  describe('sourcesPanelVisible', () => {
+    it('setSourcesPanelVisible sets the exact value given, in both directions', () => {
+      const s = makeStore();
+      s.getState().setSourcesPanelVisible(true);
+      assert.strictEqual(s.getState().sourcesPanelVisible, true);
+      s.getState().setSourcesPanelVisible(false);
+      assert.strictEqual(s.getState().sourcesPanelVisible, false);
+    });
+
+    it('toggleSourcesPanel flips from either starting value', () => {
+      const s = makeStore();
+      assert.strictEqual(s.getState().sourcesPanelVisible, false);
+      s.getState().toggleSourcesPanel();
+      assert.strictEqual(s.getState().sourcesPanelVisible, true);
+      s.getState().toggleSourcesPanel();
+      assert.strictEqual(s.getState().sourcesPanelVisible, false);
+    });
+  });
+});


### PR DESCRIPTION
Mutation-swept `apps/viewer/src/store`. **Three findings, all untested-but-correct — test-only, no behaviour changed.**

All three are the shape that has dominated today's sweep: **a guard whose "do nothing" branch is never exercised.** A store is dense with these, because the suite naturally tests that an action writes what it is given and never that a no-op leaves state alone.

## 1. `sourcesSlice.ts` — no test file existed at all

`removeSourceTag` and `clearSourceTags` both short-circuit (`if (!state.sourceTags.has(modelId)) return {}`, and `size === 0 ? {} : …`) specifically to **preserve `Map` identity** for identity-based selectors when nothing changes. Mutating either to always rebuild survived, because nothing called them.

```
a miss must not allocate a new Map (guard must short-circuit)   -> produced a new Map(1)
clearing an already-empty map must not allocate a new one       -> produced Map(0) {}
```

The new fixture is **seeded from non-default state** — an unrelated tag already present — so a mutant that wipes on a miss is caught by *content* as well as identity. A test that seeds an empty store, acts, and asserts cannot tell "set correctly" from "reset everything".

## 2. `dockSlice.ts` — the already-on-top guard

The existing test only ever raised a **non-front** panel, so `if (!target || current[current.length - 1]?.id === id) return;` was never exercised.

Dropping it does two things, and the second is a real defect rather than a wasted allocation: **an unknown id pushes `target` — i.e. `undefined` — straight into `floatingPanels`**, which is a crash waiting in the renderer.

I re-ran that mutation here rather than take it on report:

```
not ok 6 - is a no-op (array identity preserved) when the panel is already on top
not ok 7 - does nothing when the given id is not currently floating
# tests 8   # pass 6   # fail 2
```

Restored, green.

## 3. `pinboardSlice.ts` — `removeBasketView` had zero callers in any test

`grep -rl removeBasketView **/*.test.ts*` came back empty. Its ternary clears `activeBasketViewId` **only when the removed view is the active one**; mutating it to an unconditional `null` survived.

Three tests now cover active-view removal clearing it, non-active removal preserving it, and the unknown-id no-op.

## Verification

`sourcesSlice` 0 → 7 (new file), `dockSlice` 6 → 8, `pinboardSlice` 12 → 15 — **30 passing across the three files**, re-run here. Five mutants, all killed by name.

Runner confirmed by reading `apps/viewer/package.json` rather than assumed: this app has **no vitest**, it runs `tsx --import ./src/test/vite-module-hooks.mjs --test`. Getting that wrong has produced two mistaken coverage claims elsewhere today.

`check-module-size.mjs` exit 0. No changeset — `apps/viewer` is unpublished.

## Two pre-existing failures, verified as such rather than assumed

The full `store` + `hooks` sweep shows **100 failures out of 998**, and `pnpm --filter viewer typecheck` fails. **Neither is caused by this branch**, and I checked rather than relying on the report:

- The 100 are `ERR_MODULE_NOT_FOUND` against `apps/viewer/node_modules/@ifc-lite/clash/dist/index.js` and similar — an **unbuilt workspace closure**, identical on the unmodified baseline. None of the three touched files appear in the failure list.
- I ran `pnpm --filter viewer typecheck` on **unmodified `main`** in this worktree and got the same error set (`RepairQueuePanel`, `flavor-service`). Same cause.

A wave of resolution errors is an unbuilt closure, not a finding — worth stating explicitly, since one package failed 37 of 50 files for exactly this reason today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
