### PR TITLE
test(viewer): planar geometry must not read as degenerate, and a BYOK store with no tests

### DIFF
--- a/apps/viewer/src/services/api-keys.test.ts
+++ b/apps/viewer/src/services/api-keys.test.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * BYOK API key storage had no test at all. Real logic worth pinning:
+ *  - `sanitize` trims and type-guards whatever localStorage returns, so a
+ *    corrupted/foreign value degrades to empty strings rather than throwing
+ *    or leaking a non-string into the rest of the app.
+ *  - `hasAnyApiKey` is an OR across the two providers: either key alone
+ *    must be enough.
+ *  - `updateApiKeys` merges onto the existing config (a caller updating
+ *    just one key must not clobber the other).
+ */
+
+import '../test/setup-dom.js';
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  getApiKeys,
+  updateApiKeys,
+  clearApiKeys,
+  hasAnthropicKey,
+  hasOpenaiKey,
+  hasAnyApiKey,
+} from './api-keys.js';
+
+describe('api-keys', () => {
+  beforeEach(() => {
+    clearApiKeys();
+  });
+
+  it('returns an empty config when nothing is stored', () => {
+    assert.deepEqual(getApiKeys(), { anthropicKey: '', openaiKey: '' });
+  });
+
+  it('trims whitespace on save', () => {
+    updateApiKeys({ anthropicKey: '  sk-ant-abc  ' });
+    assert.equal(getApiKeys().anthropicKey, 'sk-ant-abc');
+  });
+
+  it('updating one key preserves the other', () => {
+    updateApiKeys({ anthropicKey: 'sk-ant-abc' });
+    updateApiKeys({ openaiKey: 'sk-oai-xyz' });
+    assert.deepEqual(getApiKeys(), { anthropicKey: 'sk-ant-abc', openaiKey: 'sk-oai-xyz' });
+  });
+
+  it('sanitizes a corrupted stored value back to empty strings instead of throwing', () => {
+    localStorage.setItem('ifc-lite:api-keys:v1', JSON.stringify({ anthropicKey: 42, openaiKey: null }));
+    assert.deepEqual(getApiKeys(), { anthropicKey: '', openaiKey: '' });
+  });
+
+  it('sanitizes non-JSON stored garbage to the empty config', () => {
+    localStorage.setItem('ifc-lite:api-keys:v1', 'not json');
+    assert.deepEqual(getApiKeys(), { anthropicKey: '', openaiKey: '' });
+  });
+
+  it('hasAnthropicKey / hasOpenaiKey reflect only their own provider', () => {
+    updateApiKeys({ anthropicKey: 'sk-ant-abc' });
+    assert.equal(hasAnthropicKey(), true);
+    assert.equal(hasOpenaiKey(), false);
+  });
+
+  it('hasAnyApiKey is true when only the anthropic key is set', () => {
+    updateApiKeys({ anthropicKey: 'sk-ant-abc' });
+    assert.equal(hasAnyApiKey(), true);
+  });
+
+  it('hasAnyApiKey is true when only the openai key is set', () => {
+    updateApiKeys({ openaiKey: 'sk-oai-xyz' });
+    assert.equal(hasAnyApiKey(), true);
+  });
+
+  it('hasAnyApiKey is false when neither key is set', () => {
+    assert.equal(hasAnyApiKey(), false);
+  });
+
+  it('clearApiKeys resets both keys', () => {
+    updateApiKeys({ anthropicKey: 'a', openaiKey: 'b' });
+    clearApiKeys();
+    assert.deepEqual(getApiKeys(), { anthropicKey: '', openaiKey: '' });
+  });
+});

--- a/apps/viewer/src/utils/viewportUtils.geometryBounds.test.ts
+++ b/apps/viewer/src/utils/viewportUtils.geometryBounds.test.ts
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `calculateGeometryBounds` and `accumulateBoundsExcludingTypes` had no
+ * direct tests anywhere in the repo (only reached indirectly through
+ * `Viewport.tsx`), despite carrying real branch logic:
+ *
+ *  - `calculateGeometryBounds`'s degenerate-fallback comment explicitly
+ *    says "Planar/linear geometry (only 1-2 axes equal) is valid and
+ *    should NOT fall back" to the placeholder box — i.e. the AND across
+ *    all three axes in `isFullyDegenerate` is load-bearing, not
+ *    incidental.
+ *  - `accumulateBoundsExcludingTypes` must exclude a mesh by `ifcType`
+ *    membership in `excludeTypes`, not the opposite.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import type { MeshData } from '@ifc-lite/geometry';
+import { calculateGeometryBounds, accumulateBoundsExcludingTypes } from './viewportUtils.js';
+
+/** A one-triangle mesh spanning the given per-axis coordinates. */
+function mesh(
+  x0: number,
+  y0: number,
+  z0: number,
+  opts: { ifcType?: string; origin?: [number, number, number] } = {},
+): MeshData {
+  return {
+    expressId: 1,
+    ifcType: opts.ifcType,
+    origin: opts.origin,
+    positions: new Float32Array([x0, y0, z0, x0 + 1, y0, z0, x0, y0 + 1, z0]),
+    normals: new Float32Array(9),
+    indices: new Uint32Array([0, 1, 2]),
+  } as unknown as MeshData;
+}
+
+describe('calculateGeometryBounds', () => {
+  it('returns the placeholder box for an empty mesh list', () => {
+    const b = calculateGeometryBounds([]);
+    assert.deepEqual(b, { min: { x: -100, y: -100, z: -100 }, max: { x: 100, y: 100, z: 100 } });
+  });
+
+  it('returns real bounds for ordinary 3D geometry', () => {
+    const b = calculateGeometryBounds([mesh(0, 0, 0)]);
+    assert.deepEqual(b.min, { x: 0, y: 0, z: 0 });
+    assert.deepEqual(b.max, { x: 1, y: 1, z: 0 });
+  });
+
+  it('does NOT fall back to the placeholder for planar geometry (one axis degenerate)', () => {
+    // z is constant (planar in the XY plane) but x and y vary: this is
+    // legitimate flat geometry, not a degenerate single point.
+    const b = calculateGeometryBounds([mesh(0, 0, 5)]);
+    assert.deepEqual(b.min, { x: 0, y: 0, z: 5 });
+    assert.deepEqual(b.max, { x: 1, y: 1, z: 5 });
+    assert.notEqual(b.max.x, 100, 'planar geometry must not fall back to the placeholder box');
+  });
+
+  it('falls back to the placeholder only when all three axes are degenerate (single point)', () => {
+    const singlePoint: MeshData = {
+      expressId: 1,
+      positions: new Float32Array([3, 3, 3]),
+      normals: new Float32Array(3),
+      indices: new Uint32Array([0]),
+    } as unknown as MeshData;
+    const b = calculateGeometryBounds([singlePoint]);
+    assert.deepEqual(b, { min: { x: -100, y: -100, z: -100 }, max: { x: 100, y: 100, z: 100 } });
+  });
+
+  it('applies the per-mesh origin so bounds are in world space', () => {
+    const b = calculateGeometryBounds([mesh(0, 0, 0, { origin: [1000, 2000, 3000] })]);
+    assert.deepEqual(b.min, { x: 1000, y: 2000, z: 3000 });
+  });
+});
+
+describe('accumulateBoundsExcludingTypes', () => {
+  it('excludes meshes whose ifcType is in the exclude set', () => {
+    const meshes = [mesh(0, 0, 0, { ifcType: 'IfcSpace' }), mesh(10, 10, 10, { ifcType: 'IfcWall' })];
+    const b = accumulateBoundsExcludingTypes(meshes, new Set(['IfcSpace']));
+    assert.ok(b);
+    assert.deepEqual(b!.min, { x: 10, y: 10, z: 10 });
+  });
+
+  it('includes meshes with no ifcType at all', () => {
+    const meshes = [mesh(0, 0, 0)];
+    const b = accumulateBoundsExcludingTypes(meshes, new Set(['IfcSpace']));
+    assert.ok(b);
+    assert.deepEqual(b!.min, { x: 0, y: 0, z: 0 });
+  });
+
+  it('returns null when every mesh is excluded', () => {
+    const meshes = [mesh(0, 0, 0, { ifcType: 'IfcSpace' })];
+    const b = accumulateBoundsExcludingTypes(meshes, new Set(['IfcSpace']));
+    assert.equal(b, null);
+  });
+});


### PR DESCRIPTION
Mutation-swept `apps/viewer/src/services` and `apps/viewer/src/utils`. **Test-only, two untested surfaces covered, four mutants killed.**

## 1. `viewportUtils.ts` — planar geometry must not read as degenerate

`calculateGeometryBounds` and `accumulateBoundsExcludingTypes` had **zero direct tests anywhere in the repo** — reachable only indirectly through `Viewport.tsx`, and a grep for their names hit no test file.

The interesting mutant is `isFullyDegenerate`'s `&&` → `||`. The function's own comment says planar or linear geometry — one or two axes equal — **must not** fall back to the placeholder box. Under `||`, a flat slab or a wall elevation collapses to a ±100 placeholder.

I re-ran it here rather than take the report:

```
not ok 2 - returns real bounds for ordinary 3D geometry
not ok 3 - does NOT fall back to the placeholder for planar geometry (one axis degenerate)
not ok 5 - applies the per-mesh origin so bounds are in world space
# tests 8   # pass 5
```

Restored, green. The fixture deliberately separates a **planar** case (one axis degenerate) from a **fully degenerate** single point — a suite containing only the latter cannot tell `&&` from `||`.

Second mutant: inverting `mesh.ifcType && excludeTypes.has(mesh.ifcType)` — killed by two tests. The fixture includes both an excluded-type mesh and one with no `ifcType` at all, so the guard's "do nothing" branch is exercised alongside the exclude branch. That shape — **a guard whose no-op branch nothing exercises** — is the single most common finding of this sweep.

## 2. `services/api-keys.ts` — no test at all

Two mutants killed:

- `hasAnyApiKey()`'s `||` → `&&`: with only one provider key set, the app would report having no key at all.
- `sanitize()`'s type guard loosened from `typeof x === 'string'` to a truthy check with `String(x)` coercion: a corrupted stored value of `42` comes back as `"42"` instead of `''`.

The corrupted-value fixture uses a **non-string, non-nullish** value precisely so that a loosened truthy guard behaves differently from the type guard — `null` or `undefined` would have passed under both.

## The 10 km origin/world divergence: verified, and deliberately left alone

Confirmed still present in current code, with the frame traced rather than inferred:

- `viewportUtils.ts:141-152`, `:290-301`, `:348-352` compute `world = origin + position` and apply the 10 km `isValidCoord` bound in **world** space.
- `localParsingUtils.ts:96-104` applies the same bound to the **local** coordinate, before adding the origin — by explicit design, with a comment referencing #1449 so a legitimate georeferenced offset is kept.
- `robustFitBoundsAccumulator.ts:47-51` already documents the divergence without resolving it.

**Not unified.** Unifying tightens a guard for a mesh sitting more than 10 km from its own origin, which is a maintainer decision. Each side's own behaviour is already covered against its own frame by existing tests; no combined divergence-pinning test was added, and that is stated rather than implied.

## Verification

**18 new tests, all passing** (re-run here). Four mutants, four killed, no survivors and no equivalent mutants this pass.

`check-module-size.mjs` exit 0. `pnpm --filter viewer typecheck` exits 2 — **and identically on unmodified `upstream/main`** in the same worktree, with `Cannot find module '@ifc-lite/extensions'` across unrelated files: an unbuilt workspace closure, not a regression. No error in either run touches `viewportUtils.ts` or `api-keys.ts`.

One environment note for the record: the authoring worktree lacked built wasm, so `packages/wasm/pkg`'s build artifacts were copied in to let tests run under Node. **Those are build outputs and are not in this branch** — the diff is exactly two new test files, which I verified.

No changeset — `apps/viewer` is unpublished.

**Leads not chased:** `services/bsdd.ts`, `idb-storage.ts`, `panel-windows.ts` and `file-system-access.ts` all have real logic and no tests. `services/cacheService.ts` was read in full and is a thin lazy-singleton pass-through with no branching worth mutating — reported so nobody re-reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
