### PR TITLE
test(viewer): four I/O services with no tests, and an error body parsed as data

### DIFF
--- a/apps/viewer/src/services/bsdd.test.ts
+++ b/apps/viewer/src/services/bsdd.test.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchClassInfo, searchRelatedClasses, bsddDataTypeLabel } from './bsdd.js';
+
+/** Minimal Response-like stub covering only what fetchJson touches. */
+function jsonResponse(ok: boolean, status: number, body: unknown): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    json: async () => body,
+  } as unknown as Response;
+}
+
+type FetchCall = { url: string };
+
+describe('bsdd', () => {
+  let calls: FetchCall[];
+  let responder: (url: string) => Response;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    calls = [];
+    globalThis.fetch = (async (url: string | URL) => {
+      const u = String(url);
+      calls.push({ url: u });
+      return responder(u);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('fetchClassInfo', () => {
+    it('returns null when the API responds with an error status, instead of parsing the error body as success', async () => {
+      responder = () => jsonResponse(false, 404, { uri: 'should-not-be-used', code: 'IfcBogus' });
+      const result = await fetchClassInfo('IfcBogusType1');
+      assert.equal(result, null);
+    });
+
+    it('maps a well-formed class response, including nested class properties', async () => {
+      responder = (url) => {
+        if (url.includes('/api/Class/v1')) {
+          return jsonResponse(true, 200, {
+            uri: 'https://identifier.buildingsmart.org/uri/buildingsmart/ifc/4.3/class/IfcWall',
+            code: 'IfcWall',
+            name: 'Wall',
+            definition: 'A vertical construction',
+            classProperties: [
+              {
+                name: 'IsExternal',
+                propertyUri: 'https://x/IsExternal',
+                dataType: 'Boolean',
+                propertySet: 'Pset_WallCommon',
+              },
+            ],
+          });
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      };
+      const result = await fetchClassInfo('IfcWall2');
+      assert.ok(result);
+      assert.equal(result.code, 'IfcWall');
+      assert.equal(result.classProperties.length, 1);
+      assert.equal(result.classProperties[0].name, 'IsExternal');
+      assert.equal(result.classProperties[0].isIfcStandard, true);
+    });
+
+    it('returns null (not a thrown parse error) for a malformed payload missing all expected fields', async () => {
+      responder = () => jsonResponse(true, 200, null as unknown as Record<string, unknown>);
+      // A malformed payload of `null` makes `raw.classProperties` throw inside
+      // mapClassResponse (reading a property of null); fetchClassInfo's outer
+      // try/catch must convert that into a null return, not an unhandled throw.
+      const result = await fetchClassInfo('IfcBogusType2');
+      assert.equal(result, null);
+    });
+
+    it('URL-encodes an IFC type name containing special characters', async () => {
+      responder = () => jsonResponse(true, 200, { uri: 'u', code: 'X', name: 'X', classProperties: [] });
+      await fetchClassInfo('Ifc Weird&Type/Name');
+      assert.ok(calls.length > 0);
+      const url = calls[0].url;
+      assert.ok(!url.includes('Ifc Weird&Type/Name'), `raw type name leaked unencoded into ${url}`);
+      assert.ok(url.includes(encodeURIComponent('Ifc Weird&Type/Name')));
+    });
+
+    it('caches a successful lookup and does not re-fetch within the TTL', async () => {
+      let fetchCount = 0;
+      responder = () => {
+        fetchCount += 1;
+        return jsonResponse(true, 200, { uri: 'u', code: 'IfcSlab', name: 'Slab', classProperties: [{ name: 'P', propertyUri: 'u/p' }] });
+      };
+      const first = await fetchClassInfo('IfcSlabCached');
+      const second = await fetchClassInfo('IfcSlabCached');
+      assert.ok(first);
+      assert.ok(second);
+      assert.equal(fetchCount, 1, 'second call should be served from cache, not re-fetched');
+    });
+  });
+
+  describe('searchRelatedClasses', () => {
+    it('returns an empty array (not a throw) when the API errors', async () => {
+      responder = () => jsonResponse(false, 500, {});
+      const result = await searchRelatedClasses('IfcDoor');
+      assert.deepStrictEqual(result, []);
+    });
+
+    it('URL-encodes the search text and related-entities filter', async () => {
+      responder = () => jsonResponse(true, 200, { classes: [] });
+      await searchRelatedClasses('Ifc Weird&Type/Name');
+      assert.ok(calls.length > 0);
+      const url = calls[0].url;
+      assert.ok(!url.includes('Ifc Weird&Type/Name'), `raw type name leaked unencoded into ${url}`);
+      const encoded = encodeURIComponent('Ifc Weird&Type/Name');
+      assert.ok(url.includes(`SearchText=${encoded}`), `SearchText not encoded in ${url}`);
+      assert.ok(url.includes(`RelatedIfcEntities=${encoded}`), `RelatedIfcEntities not encoded in ${url}`);
+    });
+
+    it('maps search results defensively even when fields are missing', async () => {
+      responder = () => jsonResponse(true, 200, { classes: [{ name: 'Door' }] });
+      const result = await searchRelatedClasses('IfcDoor');
+      assert.equal(result.length, 1);
+      assert.equal(result[0].name, 'Door');
+      assert.equal(result[0].code, 'Door');
+      assert.equal(result[0].uri, '');
+    });
+  });
+
+  describe('bsddDataTypeLabel', () => {
+    it('normalizes known bSDD data types case-insensitively', () => {
+      assert.equal(bsddDataTypeLabel('boolean'), 'Boolean');
+      assert.equal(bsddDataTypeLabel('REAL'), 'Real');
+      assert.equal(bsddDataTypeLabel('Number'), 'Real');
+      assert.equal(bsddDataTypeLabel('integer'), 'Integer');
+      assert.equal(bsddDataTypeLabel('character'), 'String');
+    });
+
+    it('passes through an unrecognized data type unchanged', () => {
+      assert.equal(bsddDataTypeLabel('Enumeration'), 'Enumeration');
+    });
+
+    it('defaults a null/absent data type to "String"', () => {
+      assert.equal(bsddDataTypeLabel(null), 'String');
+    });
+  });
+});

--- a/apps/viewer/src/services/extensions/idb-storage.recovery.test.ts
+++ b/apps/viewer/src/services/extensions/idb-storage.recovery.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Isolated in its own file (own child process under the node test runner)
+ * so the module-level `dbPromise` singleton in idb-storage.ts starts
+ * genuinely unset — the recovery path only runs on the *first* open of a
+ * corrupted database, and other test files opening the (real, healthy)
+ * database first would mask it.
+ */
+
+// fake-indexeddb installs a Node-compatible IDB implementation on
+// `globalThis.indexedDB` when imported via the `/auto` entry point.
+import 'fake-indexeddb/auto';
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { IdbExtensionStorage } from './idb-storage.js';
+
+// Mirrors the private DB_NAME/DB_VERSION constants in idb-storage.ts.
+const DB_NAME = 'ifc-lite-extensions';
+const DB_VERSION = 1;
+
+describe('IdbExtensionStorage recovery', () => {
+  it('recreates the database when an object store is unexpectedly missing', async () => {
+    // Simulate corruption: pre-create the database at the module's own
+    // name+version, but with only one of the two stores it expects. This
+    // is the state the recovery branch in openDatabase() exists to detect.
+    await new Promise<void>((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onupgradeneeded = () => {
+        req.result.createObjectStore('extensions', { keyPath: 'id' });
+        // 'extension-bundles' intentionally omitted.
+      };
+      req.onsuccess = () => {
+        req.result.close();
+        resolve();
+      };
+      req.onerror = () => reject(req.error);
+    });
+
+    const storage = new IdbExtensionStorage();
+
+    // Any operation opens the db and must trigger recovery rather than
+    // silently operating against a database that's missing a store.
+    const list = await storage.listExtensions();
+    assert.deepStrictEqual(list, []);
+
+    // The recreated database must actually have both stores usable —
+    // not just "extensions" (the one that happened to already exist).
+    await storage.putBundle('x', '1.0.0', new Uint8Array([1, 2, 3]));
+    const bundle = await storage.getBundle('x', '1.0.0');
+    assert.deepStrictEqual(bundle, new Uint8Array([1, 2, 3]));
+  });
+});

--- a/apps/viewer/src/services/extensions/idb-storage.test.ts
+++ b/apps/viewer/src/services/extensions/idb-storage.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// fake-indexeddb installs a Node-compatible IDB implementation on
+// `globalThis.indexedDB` when imported via the `/auto` entry point.
+import 'fake-indexeddb/auto';
+
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import type { InstalledExtensionRecord } from '@ifc-lite/extensions';
+import { ExtensionStorageQuotaError, IdbExtensionStorage } from './idb-storage.js';
+
+function record(id: string): InstalledExtensionRecord {
+  return {
+    id,
+    name: id,
+    version: '1.0.0',
+    manifestVersion: 1,
+    installedAt: '2026-01-01T00:00:00Z',
+  } as unknown as InstalledExtensionRecord;
+}
+
+describe('IdbExtensionStorage', () => {
+  let storage: IdbExtensionStorage;
+
+  beforeEach(async () => {
+    storage = new IdbExtensionStorage();
+    await storage.clear();
+  });
+
+  describe('deleteExtension cascade', () => {
+    it('deletes only bundles belonging to the deleted extension, by prefix key, not by substring', async () => {
+      // "a" and "ab" share a common prefix; a naive substring match on the
+      // bundle key ("ab@1.0.0".includes("a")) would wrongly delete "ab"'s
+      // bundle when deleting "a". The real key format is `<id>@<version>`,
+      // so the correct boundary is the "@" separator.
+      await storage.putExtension(record('a'));
+      await storage.putExtension(record('ab'));
+      await storage.putBundle('a', '1.0.0', new Uint8Array([1]));
+      await storage.putBundle('ab', '1.0.0', new Uint8Array([2]));
+
+      await storage.deleteExtension('a');
+
+      const deleted = await storage.getBundle('a', '1.0.0');
+      const survivor = await storage.getBundle('ab', '1.0.0');
+      assert.equal(deleted, undefined, 'bundle for the deleted extension must be gone');
+      assert.deepStrictEqual(
+        survivor,
+        new Uint8Array([2]),
+        'an unrelated extension sharing a name prefix must survive',
+      );
+    });
+
+    it('deletes the extension record itself', async () => {
+      await storage.putExtension(record('solo'));
+      await storage.deleteExtension('solo');
+      const got = await storage.getExtension('solo');
+      assert.equal(got, undefined);
+    });
+  });
+
+  describe('quota handling', () => {
+    it('wraps a QuotaExceededError from putExtension in ExtensionStorageQuotaError', async () => {
+      const originalPut = IDBObjectStore.prototype.put;
+      IDBObjectStore.prototype.put = function quotaPut(): never {
+        throw Object.assign(new Error('quota'), { name: 'QuotaExceededError' });
+      };
+      try {
+        await assert.rejects(
+          () => storage.putExtension(record('q')),
+          (err: unknown) => err instanceof ExtensionStorageQuotaError,
+        );
+      } finally {
+        IDBObjectStore.prototype.put = originalPut;
+      }
+    });
+
+    it('wraps a QuotaExceededError from putBundle in ExtensionStorageQuotaError', async () => {
+      const originalPut = IDBObjectStore.prototype.put;
+      IDBObjectStore.prototype.put = function quotaPut(): never {
+        throw Object.assign(new Error('quota'), { name: 'QuotaExceededError' });
+      };
+      try {
+        await assert.rejects(
+          () => storage.putBundle('q', '1.0.0', new Uint8Array([9])),
+          (err: unknown) => err instanceof ExtensionStorageQuotaError,
+        );
+      } finally {
+        IDBObjectStore.prototype.put = originalPut;
+      }
+    });
+
+    it('does not wrap a non-quota error — it must propagate as-is', async () => {
+      const originalPut = IDBObjectStore.prototype.put;
+      IDBObjectStore.prototype.put = function boomPut(): never {
+        throw new Error('disk read-only');
+      };
+      try {
+        await assert.rejects(
+          () => storage.putExtension(record('e')),
+          (err: unknown) => !(err instanceof ExtensionStorageQuotaError) && (err as Error).message === 'disk read-only',
+        );
+      } finally {
+        IDBObjectStore.prototype.put = originalPut;
+      }
+    });
+  });
+
+  describe('clear', () => {
+    it('empties both stores', async () => {
+      await storage.putExtension(record('x'));
+      await storage.putBundle('x', '1.0.0', new Uint8Array([1]));
+      await storage.clear();
+      assert.deepStrictEqual(await storage.listExtensions(), []);
+      assert.equal(await storage.getBundle('x', '1.0.0'), undefined);
+    });
+  });
+});

--- a/apps/viewer/src/services/file-system-access.test.ts
+++ b/apps/viewer/src/services/file-system-access.test.ts
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// happy-dom registers `window`/`DOMException` globally.
+import '../test/setup-dom.js';
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  handlesFromDataTransfer,
+  openIfcFilesWithHandles,
+  readFreshFile,
+  supportsFileSystemAccess,
+} from './file-system-access.js';
+
+type FSFileHandleLike = {
+  name: string;
+  kind: 'file';
+  getFile: () => Promise<File>;
+  queryPermission?: (opts: { mode: string }) => Promise<'granted' | 'denied' | 'prompt'>;
+  requestPermission?: (opts: { mode: string }) => Promise<'granted' | 'denied' | 'prompt'>;
+};
+
+function fakeFile(name: string): File {
+  return new File(['content'], name, { type: 'application/octet-stream' });
+}
+
+function fakeHandle(name: string, overrides: Partial<FSFileHandleLike> = {}): FSFileHandleLike {
+  return {
+    name,
+    kind: 'file',
+    getFile: async () => fakeFile(name),
+    ...overrides,
+  };
+}
+
+describe('file-system-access', () => {
+  let originalShowOpenFilePicker: unknown;
+
+  beforeEach(() => {
+    originalShowOpenFilePicker = (window as unknown as Record<string, unknown>).showOpenFilePicker;
+  });
+
+  afterEach(() => {
+    (window as unknown as Record<string, unknown>).showOpenFilePicker = originalShowOpenFilePicker;
+  });
+
+  describe('supportsFileSystemAccess', () => {
+    it('is false when showOpenFilePicker is absent', () => {
+      delete (window as unknown as Record<string, unknown>).showOpenFilePicker;
+      assert.equal(supportsFileSystemAccess(), false);
+    });
+
+    it('is true when showOpenFilePicker is a function', () => {
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => [];
+      assert.equal(supportsFileSystemAccess(), true);
+    });
+  });
+
+  describe('openIfcFilesWithHandles', () => {
+    it('returns null when the API is unavailable', async () => {
+      delete (window as unknown as Record<string, unknown>).showOpenFilePicker;
+      const result = await openIfcFilesWithHandles();
+      assert.equal(result, null);
+    });
+
+    it('returns null (not an error) when the user cancels the picker (AbortError), without a console warning', async () => {
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => {
+        throw new DOMException('The user aborted a request.', 'AbortError');
+      };
+      const originalWarn = console.warn;
+      let warned = false;
+      console.warn = () => {
+        warned = true;
+      };
+      try {
+        const result = await openIfcFilesWithHandles();
+        assert.equal(result, null);
+        assert.equal(warned, false, 'a routine user cancellation must not be logged as a warning');
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    it('returns null AND logs a warning when the picker fails for a non-abort reason', async () => {
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => {
+        throw new Error('some other picker failure');
+      };
+      const originalWarn = console.warn;
+      let warned = false;
+      console.warn = () => {
+        warned = true;
+      };
+      try {
+        const result = await openIfcFilesWithHandles();
+        assert.equal(result, null);
+        assert.equal(warned, true, 'a genuine picker failure should be surfaced');
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    it('returns files+handles for a successful pick', async () => {
+      const handles = [fakeHandle('a.ifc'), fakeHandle('b.ifc')];
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => handles;
+      const result = await openIfcFilesWithHandles();
+      assert.ok(result);
+      assert.equal(result.length, 2);
+      assert.equal(result[0].file.name, 'a.ifc');
+      assert.equal(result[0].handle, handles[0]);
+    });
+
+    it('skips a handle whose getFile() fails, but still returns the others', async () => {
+      const badHandle = fakeHandle('broken.ifc', {
+        getFile: async () => {
+          throw new Error('file moved');
+        },
+      });
+      const goodHandle = fakeHandle('ok.ifc');
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => [badHandle, goodHandle];
+      const result = await openIfcFilesWithHandles();
+      assert.ok(result);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].file.name, 'ok.ifc');
+    });
+
+    it('returns null (not an empty array) when every picked handle fails to read', async () => {
+      const badHandle = fakeHandle('broken.ifc', {
+        getFile: async () => {
+          throw new Error('file moved');
+        },
+      });
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => [badHandle];
+      const result = await openIfcFilesWithHandles();
+      assert.equal(result, null);
+    });
+  });
+
+  describe('readFreshFile', () => {
+    it('re-reads the file when the engine has no permission API (optimistic true)', async () => {
+      const handle = fakeHandle('x.ifc');
+      const file = await readFreshFile(handle as unknown as FileSystemFileHandle);
+      assert.ok(file);
+      assert.equal(file.name, 'x.ifc');
+    });
+
+    it('re-reads the file when permission is already granted', async () => {
+      const handle = fakeHandle('x.ifc', {
+        queryPermission: async () => 'granted',
+      });
+      const file = await readFreshFile(handle as unknown as FileSystemFileHandle);
+      assert.ok(file);
+    });
+
+    it('returns null WITHOUT reading the file when permission is denied and cannot be re-requested', async () => {
+      let getFileCalls = 0;
+      const handle = fakeHandle('x.ifc', {
+        queryPermission: async () => 'prompt',
+        getFile: async () => {
+          getFileCalls += 1;
+          return fakeFile('x.ifc');
+        },
+      });
+      const file = await readFreshFile(handle as unknown as FileSystemFileHandle);
+      assert.equal(file, null);
+      assert.equal(getFileCalls, 0, 'must not read the file when permission was not confirmed granted');
+    });
+
+    it('re-prompts via requestPermission and reads on grant', async () => {
+      const handle = fakeHandle('x.ifc', {
+        queryPermission: async () => 'prompt',
+        requestPermission: async () => 'granted',
+      });
+      const file = await readFreshFile(handle as unknown as FileSystemFileHandle);
+      assert.ok(file);
+    });
+
+    it('returns null when requestPermission is re-prompted and denied', async () => {
+      let getFileCalls = 0;
+      const handle = fakeHandle('x.ifc', {
+        queryPermission: async () => 'prompt',
+        requestPermission: async () => 'denied',
+        getFile: async () => {
+          getFileCalls += 1;
+          return fakeFile('x.ifc');
+        },
+      });
+      const file = await readFreshFile(handle as unknown as FileSystemFileHandle);
+      assert.equal(file, null);
+      assert.equal(getFileCalls, 0);
+    });
+
+    it('returns null when getFile() itself throws after permission was granted', async () => {
+      const handle = fakeHandle('x.ifc', {
+        queryPermission: async () => 'granted',
+        getFile: async () => {
+          throw new Error('moved/deleted');
+        },
+      });
+      const file = await readFreshFile(handle as unknown as FileSystemFileHandle);
+      assert.equal(file, null);
+    });
+  });
+
+  describe('handlesFromDataTransfer', () => {
+    function fakeDataTransfer(items: Array<{ kind: string; getAsFileSystemHandle?: () => Promise<unknown> }>) {
+      return { items } as unknown as DataTransfer;
+    }
+
+    it('resolves null when the API is unavailable', async () => {
+      delete (window as unknown as Record<string, unknown>).showOpenFilePicker;
+      const dt = fakeDataTransfer([{ kind: 'file', getAsFileSystemHandle: async () => fakeHandle('a.ifc') }]);
+      const result = await handlesFromDataTransfer(dt);
+      assert.equal(result, null);
+    });
+
+    it('resolves null when there are no file-kind items (e.g. only text/plain)', async () => {
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => [];
+      const dt = fakeDataTransfer([{ kind: 'string' }]);
+      const result = await handlesFromDataTransfer(dt);
+      assert.equal(result, null);
+    });
+
+    it('resolves null when the browser does not expose getAsFileSystemHandle', async () => {
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => [];
+      const dt = fakeDataTransfer([{ kind: 'file' }]);
+      const result = await handlesFromDataTransfer(dt);
+      assert.equal(result, null);
+    });
+
+    it('returns handles for dropped files, skipping non-file kinds', async () => {
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => [];
+      const dt = fakeDataTransfer([
+        { kind: 'file', getAsFileSystemHandle: async () => fakeHandle('dropped.ifc') },
+        { kind: 'string' },
+      ]);
+      const result = await handlesFromDataTransfer(dt);
+      assert.ok(result);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].file.name, 'dropped.ifc');
+    });
+
+    it('skips a dropped item whose handle is a directory, not a file', async () => {
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async () => [];
+      const dirHandle = { name: 'folder', kind: 'directory' };
+      const dt = fakeDataTransfer([{ kind: 'file', getAsFileSystemHandle: async () => dirHandle }]);
+      const result = await handlesFromDataTransfer(dt);
+      assert.equal(result, null);
+    });
+  });
+});

--- a/apps/viewer/src/services/panel-windows.test.ts
+++ b/apps/viewer/src/services/panel-windows.test.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// happy-dom must be registered before anything (including `@/store`, which
+// this module and its store subscription touch) evaluates its module body.
+import '../test/setup-dom.js';
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { getViewerStoreApi } from '@/store';
+import {
+  closeAllPanelWindows,
+  closePanelWindow,
+  getPanelWindowsSnapshot,
+  openPanelWindow,
+  subscribePanelWindows,
+  syncPanelWindowsTheme,
+} from './panel-windows.js';
+
+/** Minimal fake `Window` covering only what panel-windows.ts touches. */
+function fakeWindow() {
+  const listeners = new Map<string, Array<() => void>>();
+  let closed = false;
+  const win = {
+    get closed() {
+      return closed;
+    },
+    close: () => {
+      closed = true;
+    },
+    focus: () => {},
+    addEventListener: (type: string, cb: () => void) => {
+      const arr = listeners.get(type) ?? [];
+      arr.push(cb);
+      listeners.set(type, arr);
+    },
+    removeEventListener: (type: string, cb: () => void) => {
+      const arr = listeners.get(type);
+      if (!arr) return;
+      const i = arr.indexOf(cb);
+      if (i >= 0) arr.splice(i, 1);
+    },
+    document: {
+      title: '',
+      documentElement: { className: '', style: {} as Record<string, string> },
+      head: { appendChild: () => {} },
+      body: { style: {} as Record<string, string> },
+      createElement: () => ({}),
+    },
+  };
+  return win as unknown as Window & { close: () => void; readonly closed: boolean };
+}
+
+describe('panel-windows', () => {
+  let originalOpen: typeof window.open;
+  let openedWindows: ReturnType<typeof fakeWindow>[];
+
+  beforeEach(() => {
+    // Fresh store slate: poppedOutIds must not leak between tests.
+    const api = getViewerStoreApi();
+    for (const id of [...api.getState().poppedOutIds]) {
+      api.getState().setPanelPoppedOut(id, false);
+    }
+    closeAllPanelWindows();
+
+    originalOpen = window.open;
+    openedWindows = [];
+    window.open = (() => {
+      const w = fakeWindow();
+      openedWindows.push(w);
+      return w;
+    }) as typeof window.open;
+  });
+
+  afterEach(() => {
+    closeAllPanelWindows();
+    window.open = originalOpen;
+  });
+
+  it('opens a popup window and records it in the snapshot', async () => {
+    const kind = await openPanelWindow('clash');
+    assert.equal(kind, 'popup');
+    const snap = getPanelWindowsSnapshot();
+    assert.equal(snap.length, 1);
+    assert.equal(snap[0].id, 'clash');
+  });
+
+  it('returns null when window.open is blocked by a popup blocker', async () => {
+    window.open = (() => null) as unknown as typeof window.open;
+    const kind = await openPanelWindow('clash');
+    assert.equal(kind, null);
+    assert.equal(getPanelWindowsSnapshot().length, 0);
+  });
+
+  it('focuses (and does not re-open) an already-popped-out panel', async () => {
+    await openPanelWindow('clash');
+    assert.equal(openedWindows.length, 1);
+    const kind = await openPanelWindow('clash');
+    assert.equal(kind, 'popup');
+    assert.equal(openedWindows.length, 1, 'must reuse the existing window, not open a second one');
+  });
+
+  it('closePanelWindow removes only the closed entry — an unrelated open panel survives', async () => {
+    await openPanelWindow('clash');
+    await openPanelWindow('bcf');
+    assert.equal(getPanelWindowsSnapshot().length, 2);
+
+    closePanelWindow('clash');
+
+    const snap = getPanelWindowsSnapshot();
+    assert.equal(snap.length, 1, 'exactly one entry should remain');
+    assert.equal(snap[0].id, 'bcf', 'the unrelated panel must survive the close');
+    assert.equal(openedWindows[0].closed, true, 'the closed panel\'s OS window must actually be closed');
+    assert.equal(openedWindows[1].closed, false, 'the surviving panel\'s OS window must NOT be closed');
+  });
+
+  it('closePanelWindow re-docks the panel in the store', async () => {
+    await openPanelWindow('clash');
+    assert.ok(getViewerStoreApi().getState().poppedOutIds.includes('clash'));
+    closePanelWindow('clash');
+    assert.ok(!getViewerStoreApi().getState().poppedOutIds.includes('clash'));
+  });
+
+  it('closeAllPanelWindows closes every open window and clears the map', async () => {
+    await openPanelWindow('clash');
+    await openPanelWindow('bcf');
+    closeAllPanelWindows();
+    assert.equal(getPanelWindowsSnapshot().length, 0);
+    assert.ok(openedWindows.every((w) => w.closed));
+  });
+
+  it('subscribePanelWindows stops notifying after unsubscribe, while an unrelated listener keeps firing', async () => {
+    let countA = 0;
+    let countB = 0;
+    const unsubA = subscribePanelWindows(() => {
+      countA += 1;
+    });
+    const unsubB = subscribePanelWindows(() => {
+      countB += 1;
+    });
+
+    await openPanelWindow('clash');
+    assert.equal(countA, 1);
+    assert.equal(countB, 1);
+
+    unsubA();
+    await openPanelWindow('bcf');
+    assert.equal(countA, 1, 'unsubscribed listener must not fire again');
+    assert.equal(countB, 2, 'the still-subscribed listener must keep firing');
+
+    unsubB();
+  });
+
+  it('syncPanelWindowsTheme updates only windows that are still open', async () => {
+    await openPanelWindow('clash');
+    await openPanelWindow('bcf');
+    openedWindows[0].close(); // simulate the child window having been closed out-of-band
+
+    syncPanelWindowsTheme('dark');
+
+    assert.equal(
+      (openedWindows[1].document as unknown as { documentElement: { className: string } }).documentElement
+        .className,
+      'dark',
+    );
+    // The closed window's class must be left alone (guarded by `!win.closed`).
+    assert.notEqual(
+      (openedWindows[0].document as unknown as { documentElement: { className: string } }).documentElement
+        .className,
+      'dark',
+    );
+  });
+
+  it('re-docking a panel via the store (poppedOutIds no longer includes it) closes its window', async () => {
+    await openPanelWindow('clash');
+    assert.equal(getPanelWindowsSnapshot().length, 1);
+
+    getViewerStoreApi().getState().setPanelPoppedOut('clash', false);
+
+    assert.equal(getPanelWindowsSnapshot().length, 0, 'store-driven re-dock must detach the window');
+    assert.equal(openedWindows[0].closed, true);
+  });
+});


### PR DESCRIPTION
Four viewer I/O services with **no dedicated tests** now have 46, covering **10 mutants**. Test-only.

These are platform and network boundaries, so the failures that matter are the ones that should be *refused* or *cleaned up* and are not.

## The ten

**`bsdd.ts`** — `fetchJson`'s `if (!res.ok) throw` guard removed, and an HTTP **error body parses as valid class data**. And dropping `encodeURIComponent` on the search parameters, which I re-ran here:

```
not ok 2 - URL-encodes the search text and related-entities filter
# tests 11   # pass 10
```

**`services/extensions/idb-storage.ts`** — the corrupt-database recovery branch (`if (!db.objectStoreNames.contains(...))`) never ran; disabling it gives `No objectStore named extension-bundles in this database`. Cascade delete by `key.includes(id)` instead of `startsWith(`${id}@`)`, caught by a fixture with extensions `"a"` and `"ab"` — a shared name prefix is the only shape that pins the `@` boundary. And `isQuotaError` forced to `false`.

**`panel-windows.ts`** — `open.delete(id)` removed from `detach()`, leaving a **handle in the map after close** (8 of 9 tests red), and the unsubscribe function turned into a no-op. Both tests assert an **unrelated** listener or panel survives, so a mutant that clears everything is caught too.

**`file-system-access.ts`** — `ensureReadPermission`'s final `return false` flipped to `true`, i.e. **a permission denial treated as success**; and `return opened.length > 0 ? opened : null` reduced to `return opened`, so an all-failed read returns `[]` rather than `null`.

## Two fixtures that let a mutant survive — caught by the author, not by review

This is the part worth reading.

**The search-encoding test initially covered the wrong URL.** It exercised the primary `Class/v1` URI, not the `Class/Search/v1` URL that `searchRelatedClasses` and `resolveFallbackClassUri` actually build — so dropping `encodeURIComponent` there survived. Caught, dedicated test added, mutant re-applied, RED confirmed.

**The cancelled-picker mutant is behaviourally equivalent for the return value.** Removing the `AbortError` special case still returns `null` either way — what changes is whether `console.warn` fires. The first test could not observe that, so the mutant survived silently. The test now spies on `console.warn` and asserts it is **not** called for a routine cancellation but **is** for a genuine picker failure.

That second one is a good illustration of why "the mutant survived" is not automatically a finding: the observable difference was one level away from the return value, and finding it required asking *what else* the branch does.

## Two corrections to the brief

`services/idb-storage.ts` **does not exist** — the real file is `services/extensions/idb-storage.ts`. It is imported by `host-installer.test.ts` via `fake-indexeddb`, but only as plumbing; its own quota, recovery and cascade-delete logic was never directly tested.

The recovery test needed its **own file**: the module's `dbPromise` singleton persists across tests in one process, and only the *first* open of a corrupted database triggers recovery.

## An environment trap worth recording

Copying stale `dist` from the sibling main checkout produced a **real type mismatch** (`summarizeClashes` missing) because that checkout sits on a diverged branch. Building from source in-worktree fixed it. That is the stale-`dist` trap with a twist — the artifacts were not merely old, they were from different code.

Only `packages/wasm/pkg` was copied (prebuilt, 4.1 MB). **`git status --short` shows exactly the five new test files, all added, no stray artifacts** — verified.

## Verification

**0 → 46 tests** across 5 files, all passing (re-run here). `check-module-size.mjs` exit 0; `pnpm --filter viewer typecheck` **clean outright** — no baseline comparison needed, unlike the unbuilt-closure failures other branches hit today.

No changeset — `apps/viewer` is unpublished.

**Not chased:** the `documentPictureInPicture` path in `panel-windows.ts` and `bridgeStyles`' stylesheet cloning are exercised only incidentally through the popup fallback, which is what all 9 panel tests drive. A dedicated PiP test is the follow-up here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
