### PR TITLE
test(create): the class-based builder's vertical-axis fallback, and an override branch nothing set

### DIFF
--- a/packages/create/src/ifc-creator.test.ts
+++ b/packages/create/src/ifc-creator.test.ts
@@ -993,3 +993,113 @@ describe('IfcCreator dimension validation', () => {
       .toThrow(/zero-length vector/);
   });
 });
+
+/**
+ * computeRefDirection() has a world-X fallback so a near-vertical Axis does
+ * not produce a degenerate (zero-length) cross product:
+ *   up = |axis[2]| < 0.9 ? [0,0,1] : [1,0,0]
+ * Pin both branches — vertical (up flips to world-X) and horizontal (up
+ * stays world-Z) — for two structurally different call sites so the
+ * branches cannot silently collapse into one another.
+ */
+describe('IfcCreator — computeRefDirection vertical-axis branch', () => {
+  // Resolve the raw attribute string of a STEP entity line, e.g.
+  // "#12=IFCDIRECTION((0.,-1.,0.));" -> "(0.,-1.,0.)" is inside — we return
+  // the args between the outer parens as written by stepLine().
+  function entityLine(content: string, id: number): string {
+    const re = new RegExp(`^#${id}=\\w+\\(([\\s\\S]*?)\\);$`, 'm');
+    const m = content.match(re);
+    if (!m) throw new Error(`Entity #${id} not found in content`);
+    return m[1];
+  }
+
+  // Numeric #refs referenced by an entity, in the order they appear —
+  // this mirrors the constructor-argument order used when the line was
+  // built, regardless of exact id numbering.
+  function refIdsOf(content: string, id: number): number[] {
+    return [...entityLine(content, id).matchAll(/#(\d+)/g)].map((m) => Number(m[1]));
+  }
+
+  function directionValueOf(content: string, id: number): number[] {
+    const line = entityLine(content, id); // e.g. "(0.,-1.,0.)" — already the single-paren group
+    const m = line.match(/^\(([^)]+)\)$/);
+    if (!m) throw new Error(`Entity #${id} is not an IFCDIRECTION: ${line}`);
+    return m[1].split(',').map(Number);
+  }
+
+  // addIfcBeam: RefDirection flows through addLocalPlacement's
+  // {Axis, RefDirection} -> IFCLOCALPLACEMENT -> IFCAXIS2PLACEMENT3D chain.
+  function beamRefDirection(content: string, beamId: number): number[] {
+    const [, placementId] = refIdsOf(content, beamId); // [ownerHistory, placement, prodShape]
+    const [, axis2Id] = refIdsOf(content, placementId); // IFCLOCALPLACEMENT(relativeTo, axis2)
+    const [, , refDirId] = refIdsOf(content, axis2Id); // IFCAXIS2PLACEMENT3D(origin, axis, refDir)
+    return directionValueOf(content, refDirId);
+  }
+
+  // addIfcRailing: the outer ObjectPlacement carries no Axis/RefDirection
+  // (identity orientation, so posts extrude along world Z). The
+  // RefDirection instead lands on the rail *solid*'s own
+  // IfcAxis2Placement3D, reached via Representation -> ShapeRepresentation
+  // -> first Item (the rail; posts are items 2 and 3).
+  function railingRefDirection(content: string, railingId: number): number[] {
+    const [, , prodShapeId] = refIdsOf(content, railingId); // [ownerHistory, placement, prodShape]
+    const [shapeId] = refIdsOf(content, prodShapeId); // IFCPRODUCTDEFINITIONSHAPE($,$,(shape))
+    const [, railSolidId] = refIdsOf(content, shapeId); // IFCSHAPEREPRESENTATION(context, item1, ...)
+    const [, railAxis2Id] = refIdsOf(content, railSolidId); // IFCEXTRUDEDAREASOLID(profile, position, dir, depth)
+    const [, , refDirId] = refIdsOf(content, railAxis2Id); // IFCAXIS2PLACEMENT3D(origin, axis, refDir)
+    return directionValueOf(content, refDirId);
+  }
+
+  // Derived directly from computeRefDirection's own formula, not copied
+  // from the sibling in-store tests: up=[1,0,0] when |axis.z|>=0.9,
+  // cross([1,0,0],[0,0,1]) = (0,-1,0), already unit length.
+  const VERTICAL_REF = [0, -1, 0];
+  // up=[0,0,1] when |axis.z|<0.9, cross([0,0,1],[1,0,0]) = (0,1,0).
+  const HORIZONTAL_REF = [0, 1, 0];
+
+  it('addIfcBeam: vertical axis does not throw and yields the world-X-fallback RefDirection', () => {
+    const creator = new IfcCreator();
+    const storey = creator.addIfcBuildingStorey({ Name: 'GF', Elevation: 0 });
+    let beamId!: number;
+    expect(() => {
+      beamId = creator.addIfcBeam(storey, {
+        Start: [0, 0, 0], End: [0, 0, 5], Width: 0.2, Height: 0.4,
+      });
+    }).not.toThrow();
+    const result = creator.toIfc();
+    expect(beamRefDirection(result.content, beamId)).toEqual(VERTICAL_REF);
+  });
+
+  it('addIfcBeam: horizontal axis stays on the world-Z branch', () => {
+    const creator = new IfcCreator();
+    const storey = creator.addIfcBuildingStorey({ Name: 'GF', Elevation: 0 });
+    const beamId = creator.addIfcBeam(storey, {
+      Start: [0, 0, 0], End: [5, 0, 0], Width: 0.2, Height: 0.4,
+    });
+    const result = creator.toIfc();
+    expect(beamRefDirection(result.content, beamId)).toEqual(HORIZONTAL_REF);
+  });
+
+  it('addIfcRailing: vertical axis does not throw and yields the world-X-fallback RefDirection', () => {
+    const creator = new IfcCreator();
+    const storey = creator.addIfcBuildingStorey({ Name: 'GF', Elevation: 0 });
+    let railingId!: number;
+    expect(() => {
+      railingId = creator.addIfcRailing(storey, {
+        Start: [0, 0, 0], End: [0, 0, 5], Height: 1.1,
+      });
+    }).not.toThrow();
+    const result = creator.toIfc();
+    expect(railingRefDirection(result.content, railingId)).toEqual(VERTICAL_REF);
+  });
+
+  it('addIfcRailing: horizontal axis stays on the world-Z branch', () => {
+    const creator = new IfcCreator();
+    const storey = creator.addIfcBuildingStorey({ Name: 'GF', Elevation: 0 });
+    const railingId = creator.addIfcRailing(storey, {
+      Start: [0, 0, 0], End: [5, 0, 0], Height: 1.1,
+    });
+    const result = creator.toIfc();
+    expect(railingRefDirection(result.content, railingId)).toEqual(HORIZONTAL_REF);
+  });
+});

--- a/packages/create/src/in-store/duplicate.test.ts
+++ b/packages/create/src/in-store/duplicate.test.ts
@@ -106,6 +106,18 @@ describe('duplicateInStore', () => {
     expect(point?.attributes[0]).toEqual([10, 20, 3]);
   });
 
+  it('honours an explicit name override instead of auto-suffixing', () => {
+    const store = makeStore(100);
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
+
+    const result = duplicateInStore(editor, baseSource(), { name: 'Wall B' });
+
+    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
+    const wall = byId.get(result.newId);
+    expect(wall?.attributes[2]).toBe('Wall B'); // explicit name wins, no auto-suffix
+  });
+
   it('skips spatial rel when source has no storey', () => {
     const store = makeStore(100);
     const view = new MutablePropertyView(null, 'm1');


### PR DESCRIPTION
Closes the gap #3146 flagged and left unchased: `ifc-creator.ts`'s private `computeRefDirection` has the same world-X fallback for near-vertical members as the `in-store` twins, and **`ifc-creator.test.ts` had no vertical-axis case at all**.

Test-only. The `in-store` twins (`beam.ts`, `member.ts`) are covered by #3146 and untouched here.

## The crash, confirmed on this path too

Removing the fallback (`up = [0,0,1]` unconditionally) and running a vertical member:

```
× addIfcBeam: vertical axis does not throw and yields the world-X-fallback RefDirection
× addIfcRailing: vertical axis does not throw and yields the world-X-fallback RefDirection

AssertionError: expected [Function] to not throw an error but
  'Error: Cannot normalize zero-length vector (check that Start and End are not identical)' was thrown
```

Same error as the `in-store` path. I re-ran this here rather than take the report.

## Two corrections to the brief I gave it

**8 call sites, not 9** — my grep counted the private method's own definition line. All eight (`addIfcBeam`, `addIfcRailing`, `addIfcMember`, `addIfcIShapeBeam`, `addIfcLShapeMember`, `addIfcTShapeMember`, `addIfcUShapeMember`, `addIfcRectangleHollowBeam`) are reachable from a public method with a caller-supplied `Start`/`End`, all computing `dir = vecNorm(End - Start)` identically. **None is unreachable with a vertical axis.**

**The expected values were derived, not copied.** I asked for that specifically, because a constant lifted from the `in-store` tests that happens to match is not evidence. From the formula: vertical `[0,0,1]` → `|axis[2]| = 1 ≥ 0.9` → `up = [1,0,0]` → `cross([1,0,0],[0,0,1]) = [0,-1,0]`. Horizontal `[1,0,0]` → `|axis[2]| = 0 < 0.9` → `up = [0,0,1]` → `cross([0,0,1],[1,0,0]) = [0,1,0]`.

## Why those two call sites

They are **structurally different**, not just two of eight:

- **`addIfcBeam`** — `RefDirection` flows through `addLocalPlacement({Axis, RefDirection})` → `IFCLOCALPLACEMENT` → `IFCAXIS2PLACEMENT3D`.
- **`addIfcRailing`** — the outer `ObjectPlacement` carries **no Axis or RefDirection at all** (identity, so posts extrude along world Z). The computed direction lands instead on the rail *solid*'s own `IfcAxis2Placement3D`, built via `addDirection` + `addAxis2Placement3D` and reached through `Representation → ShapeRepresentation → first Item`.

The remaining six (I/L/T/U-shape, rectangle-hollow) are byte-identical in structure to `addIfcBeam` with different profile builders — a third copy of the same shape, not a third shape.

Each site also pins its **horizontal** case, so the two branches cannot drift into each other.

## A second finding, with the shape inverted

`in-store/duplicate.ts:195-200` — `duplicateName = options.name !== undefined ? options.name : (auto-suffix or pass-through)`. **`duplicate.test.ts` never passes `options.name` anywhere**, so the explicit-override branch was entirely dark.

That is the sweep's most common shape running the other way: usually the *omitted*-input branch goes untested, here it was the **provided**-input branch.

```
AssertionError: expected 'Wall A (copy)' to be 'Wall B'
```

Confirmed a real survivor: under the mutant all 371 pre-existing tests still passed, and only the new test failed.

## Assessed and not pursued, with reasons

`apply-style.ts`'s guard is real, but the whole ~360-line module is untested — a file-scale gap, not a narrow pin, and worth its own pass. `spatial-zone.ts`'s rotation-omitted branch is **already covered**. `generate-spaces.ts`'s `guidRandom` guard is part of a cross-cutting concern threaded through ~15 files, not an isolated guard.

## Verification

`ifc-creator.test.ts` **367 → 371**, `duplicate.test.ts` +1 → **372** package-wide; 109 passing across the two touched files, re-run here. `check-module-size.mjs` exit 0 (nothing extracted, no ratchet action). `pnpm --filter @ifc-lite/create typecheck` OK, 23 test files.

No changeset — test-only, no published behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for beam and railing creation across vertical and horizontal axes.
  - Verified correct reference directions and ensured vertical-axis creation completes without errors.
  - Added coverage confirming explicitly named duplicated walls retain the provided name without an automatic “(copy)” suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->