### PR TITLE
test(viewer): a bare apostrophe is its own opening and closing quote

### DIFF
--- a/apps/viewer/src/components/viewer/properties/raw-step-format.test.ts
+++ b/apps/viewer/src/components/viewer/properties/raw-step-format.test.ts
@@ -1,0 +1,204 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  extractRawStepTokens,
+  serializeStepToken,
+  isInlineEditableToken,
+  parseRawStepInput,
+} from './raw-step-format.js';
+
+function bytesOf(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+describe('extractRawStepTokens', () => {
+  it('returns null for a non-positive byteLength', () => {
+    const buf = bytesOf('#42=IFCWALL();');
+    assert.strictEqual(extractRawStepTokens(buf, 0, 0), null);
+    assert.strictEqual(extractRawStepTokens(buf, 0, -1), null);
+  });
+
+  it('tokenizes a simple entity body', () => {
+    const text = "#42=IFCWALL('abc',#1,.T.,(1,2,3));";
+    const buf = bytesOf(text);
+    const tokens = extractRawStepTokens(buf, 0, text.length);
+    assert.deepStrictEqual(tokens, ["'abc'", '#1', '.T.', '(1,2,3)']);
+  });
+
+  it('works without the trailing semicolon', () => {
+    const text = "#42=IFCWALL('abc',#1)";
+    const buf = bytesOf(text);
+    const tokens = extractRawStepTokens(buf, 0, text.length);
+    assert.deepStrictEqual(tokens, ["'abc'", '#1']);
+  });
+
+  it('returns null when the entity body cannot be parsed (mismatched parens)', () => {
+    const text = "#42=IFCWALL('abc',#1;";
+    const buf = bytesOf(text);
+    assert.strictEqual(extractRawStepTokens(buf, 0, text.length), null);
+  });
+
+  it('does not split on a comma embedded inside a quoted string', () => {
+    const text = "#1=IFCLABEL('a,b');";
+    const buf = bytesOf(text);
+    const tokens = extractRawStepTokens(buf, 0, text.length);
+    assert.deepStrictEqual(tokens, ["'a,b'"]);
+  });
+
+  it('honours a doubled single-quote as an escaped quote inside a string', () => {
+    const text = "#1=IFCLABEL('it''s a test');";
+    const buf = bytesOf(text);
+    const tokens = extractRawStepTokens(buf, 0, text.length);
+    assert.deepStrictEqual(tokens, ["'it''s a test'"]);
+  });
+
+  it('reads only the requested byte slice, honouring byteOffset', () => {
+    const prefix = 'XXXX';
+    const entity = "#7=IFCWALL('x');";
+    const text = prefix + entity;
+    const buf = bytesOf(text);
+    const tokens = extractRawStepTokens(buf, prefix.length, entity.length);
+    assert.deepStrictEqual(tokens, ["'x'"]);
+  });
+});
+
+describe('serializeStepToken', () => {
+  it('serializes null and undefined as $', () => {
+    assert.strictEqual(serializeStepToken(null), '$');
+    // `undefined` is outside the static `IfcAttributeValue` type but the
+    // function guards it explicitly (`value === undefined`) for callers that
+    // reach it dynamically (e.g. an unset positional attribute lookup).
+    assert.strictEqual(serializeStepToken(undefined as unknown as import('@ifc-lite/mutations').IfcAttributeValue), '$');
+  });
+
+  it('serializes booleans distinctly', () => {
+    assert.strictEqual(serializeStepToken(true), '.T.');
+    assert.strictEqual(serializeStepToken(false), '.F.');
+  });
+
+  it('serializes finite numbers verbatim and non-finite numbers as $', () => {
+    assert.strictEqual(serializeStepToken(42), '42');
+    assert.strictEqual(serializeStepToken(1.5), '1.5');
+    assert.strictEqual(serializeStepToken(0), '0');
+    assert.strictEqual(serializeStepToken(Number.NaN), '$');
+    assert.strictEqual(serializeStepToken(Number.POSITIVE_INFINITY), '$');
+  });
+
+  it('passes through $ and * strings unchanged', () => {
+    assert.strictEqual(serializeStepToken('$'), '$');
+    assert.strictEqual(serializeStepToken('*'), '*');
+  });
+
+  it('passes through a reference string unchanged', () => {
+    assert.strictEqual(serializeStepToken('#123'), '#123');
+  });
+
+  it('upper-cases an enum-shaped string', () => {
+    assert.strictEqual(serializeStepToken('.area.'), '.AREA.');
+    assert.strictEqual(serializeStepToken('.AREA.'), '.AREA.');
+  });
+
+  it('quotes a plain string and doubles embedded single quotes', () => {
+    assert.strictEqual(serializeStepToken('My Column'), "'My Column'");
+    assert.strictEqual(serializeStepToken("it's"), "'it''s'");
+  });
+
+  it('serializes arrays recursively, comma-joined and wrapped in parens', () => {
+    assert.strictEqual(serializeStepToken([1, 'a', null, true]), "(1,'a',$,.T.)");
+  });
+
+  it('serializes an empty array as ()', () => {
+    assert.strictEqual(serializeStepToken([]), '()');
+  });
+});
+
+describe('isInlineEditableToken', () => {
+  it('treats an empty/whitespace token as editable', () => {
+    assert.strictEqual(isInlineEditableToken(''), true);
+    assert.strictEqual(isInlineEditableToken('   '), true);
+  });
+
+  it('treats a list token as not editable', () => {
+    assert.strictEqual(isInlineEditableToken('(1,2,3)'), false);
+  });
+
+  it('treats a typed-value token as not editable, case-insensitively', () => {
+    assert.strictEqual(isInlineEditableToken("IFCLABEL('x')"), false);
+    assert.strictEqual(isInlineEditableToken("ifclabel('x')"), false);
+  });
+
+  it('treats a plain scalar token as editable', () => {
+    assert.strictEqual(isInlineEditableToken('#42'), true);
+    assert.strictEqual(isInlineEditableToken('.T.'), true);
+    assert.strictEqual(isInlineEditableToken("'hello'"), true);
+  });
+});
+
+describe('parseRawStepInput', () => {
+  it('maps empty, $, and null (any case) to null value', () => {
+    assert.deepStrictEqual(parseRawStepInput(''), { value: null });
+    assert.deepStrictEqual(parseRawStepInput('$'), { value: null });
+    assert.deepStrictEqual(parseRawStepInput('null'), { value: null });
+    assert.deepStrictEqual(parseRawStepInput('NULL'), { value: null });
+  });
+
+  it('maps .T./.t. to true and .F./.f. to false', () => {
+    assert.deepStrictEqual(parseRawStepInput('.T.'), { value: true });
+    assert.deepStrictEqual(parseRawStepInput('.t.'), { value: true });
+    assert.deepStrictEqual(parseRawStepInput('.F.'), { value: false });
+    assert.deepStrictEqual(parseRawStepInput('.f.'), { value: false });
+  });
+
+  it('keeps a reference as-is', () => {
+    assert.deepStrictEqual(parseRawStepInput('#77'), { value: '#77' });
+  });
+
+  it('upper-cases an enum value', () => {
+    assert.deepStrictEqual(parseRawStepInput('.area.'), { value: '.AREA.' });
+  });
+
+  it('parses an integer', () => {
+    assert.deepStrictEqual(parseRawStepInput('42'), { value: 42 });
+    assert.deepStrictEqual(parseRawStepInput('-7'), { value: -7 });
+  });
+
+  it('parses real numbers in several notations, including scientific', () => {
+    assert.deepStrictEqual(parseRawStepInput('1.5'), { value: 1.5 });
+    assert.deepStrictEqual(parseRawStepInput('.5'), { value: 0.5 });
+    assert.deepStrictEqual(parseRawStepInput('5.'), { value: 5 });
+    assert.deepStrictEqual(parseRawStepInput('1e3'), { value: 1000 });
+    assert.deepStrictEqual(parseRawStepInput('-1.5e-3'), { value: -0.0015 });
+  });
+
+  it('strips wrapping quotes and un-escapes doubled quotes', () => {
+    assert.deepStrictEqual(parseRawStepInput("'foo'"), { value: 'foo' });
+    assert.deepStrictEqual(parseRawStepInput("'it''s'"), { value: "it's" });
+  });
+
+  it('rejects list literals with an actionable error, without corrupting the value', () => {
+    const result = parseRawStepInput('(1,2,3)');
+    assert.deepStrictEqual(result, { error: 'Lists and typed values must be edited from the script panel' });
+  });
+
+  it('rejects typed-value literals the same way', () => {
+    const result = parseRawStepInput("IFCLABEL('x')");
+    assert.deepStrictEqual(result, { error: 'Lists and typed values must be edited from the script panel' });
+  });
+
+  it('falls back to treating an unrecognised token as a plain string', () => {
+    assert.deepStrictEqual(parseRawStepInput('hello'), { value: 'hello' });
+  });
+
+  it('treats a bare single quote as a literal apostrophe, not an empty quoted string', () => {
+    // A single "'" both starts and ends with a quote character (it's the same
+    // character satisfying both checks), so without the `length >= 2` guard
+    // this would be misread as an empty quoted string ({ value: '' }) instead
+    // of the literal apostrophe the user typed.
+    assert.deepStrictEqual(parseRawStepInput("'"), { value: "'" });
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/space-sketch/storey-footprint.test.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/storey-footprint.test.ts
@@ -46,6 +46,38 @@ describe('exteriorPerimeter', () => {
     }
   });
 
+  it('DROPS corners that fall inside the hull, and returns the loop in order', () => {
+    // The test above asserts only that the result CONTAINS each extreme
+    // corner, which the raw unhulled corner list also does -- deleting the
+    // `convexHull` call and returning `rects.flatMap(r => r.corners)` left the
+    // whole file at 9 passed, 0 failed. Containment cannot fail; exclusion
+    // can, so that is what this pins.
+    //
+    // An inner rect wholly inside an outer one: all four of its corners are
+    // interior and none may survive. Asserting the exact array also pins the
+    // winding and the starting vertex, which `perimeterWalls` depends on --
+    // it walks the result as a closed loop, so a correct SET in a wrong ORDER
+    // would emit walls across the diagonal.
+    const outer = rect([
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]);
+    const inner = rect([
+      [4, 4],
+      [6, 4],
+      [6, 6],
+      [4, 6],
+    ]);
+    assert.deepStrictEqual(exteriorPerimeter([outer, inner]), [
+      [0, 0],
+      [10, 0],
+      [10, 10],
+      [0, 10],
+    ]);
+  });
+
   it('returns fewer than 3 points when there are not enough distinct corners', () => {
     assert.deepStrictEqual(exteriorPerimeter([]), []);
   });

--- a/apps/viewer/src/components/viewer/tools/space-sketch/storey-footprint.test.ts
+++ b/apps/viewer/src/components/viewer/tools/space-sketch/storey-footprint.test.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { exteriorPerimeter, perimeterWalls } from './storey-footprint.js';
+import type { WallRect } from '@/lib/wall-rects-from-meshes';
+
+type Pt = [number, number];
+
+/** A `size`×`size` square, CCW from the origin. */
+const SQUARE: Pt[] = [
+  [0, 0],
+  [10, 0],
+  [10, 10],
+  [0, 10],
+];
+
+/** A rectangle described by its 4 corners, for `exteriorPerimeter`'s input. */
+function rect(corners: Pt[]): WallRect {
+  return { corners, centreline: [corners[0], corners[1]], thickness: 0.2 };
+}
+
+describe('exteriorPerimeter', () => {
+  it('returns the convex hull of every corner across all rects', () => {
+    const rects = [
+      rect([
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 1],
+      ]),
+      rect([
+        [9, 9],
+        [10, 9],
+        [10, 10],
+        [9, 10],
+      ]),
+    ];
+    const hull = exteriorPerimeter(rects);
+    // The hull must reach every extreme corner across both rects.
+    for (const p of [[0, 0], [10, 9], [10, 10], [0, 1]] as Pt[]) {
+      assert.ok(hull.some(([x, y]) => x === p[0] && y === p[1]), `hull missing ${p}`);
+    }
+  });
+
+  it('returns fewer than 3 points when there are not enough distinct corners', () => {
+    assert.deepStrictEqual(exteriorPerimeter([]), []);
+  });
+});
+
+describe('perimeterWalls', () => {
+  it('returns null when the hull is degenerate (fewer than 3 points)', () => {
+    assert.strictEqual(perimeterWalls([]), null);
+    assert.strictEqual(perimeterWalls([[0, 0]]), null);
+    assert.strictEqual(perimeterWalls([[0, 0], [1, 1]]), null);
+  });
+
+  it('emits one thin wall per hull edge, defaulting to 0.2 thickness', () => {
+    const walls = perimeterWalls(SQUARE);
+    assert.ok(walls);
+    assert.strictEqual(walls!.length, 4);
+    for (const w of walls!) assert.strictEqual(w.thickness, 0.2);
+  });
+
+  it('centres each synthetic wall on its hull edge, wrapping the last edge back to the first vertex', () => {
+    const walls = perimeterWalls(SQUARE)!;
+    assert.deepStrictEqual(
+      walls.map((w) => w.centreline),
+      [
+        [[0, 0], [10, 0]],
+        [[10, 0], [10, 10]],
+        [[10, 10], [0, 10]],
+        [[0, 10], [0, 0]],
+      ],
+    );
+  });
+
+  it('offsets the 4 corners of each wall symmetrically across the centreline by half the thickness', () => {
+    const thickness = 2;
+    const walls = perimeterWalls(SQUARE, thickness)!;
+    const bottom = walls[0]; // centreline (0,0) -> (10,0)
+    // Perpendicular to a horizontal edge is vertical: corners should sit at
+    // y = +1 and y = -1 (half of thickness 2), x unchanged from the endpoints.
+    const ys = bottom.corners.map(([, y]) => y).sort((a, b) => a - b);
+    assert.deepStrictEqual(ys, [-1, -1, 1, 1]);
+    const xs = bottom.corners.map(([x]) => x).sort((a, b) => a - b);
+    assert.deepStrictEqual(xs, [0, 0, 10, 10]);
+  });
+
+  it('respects a custom thickness parameter', () => {
+    const walls = perimeterWalls(SQUARE, 1)!;
+    for (const w of walls) assert.strictEqual(w.thickness, 1);
+  });
+
+  it('skips a degenerate (near-zero-length) edge and still returns the remaining walls when at least 3 survive', () => {
+    // A repeated vertex creates a zero-length edge between it and its
+    // duplicate. With 5 hull points but one degenerate edge, 4 real walls
+    // should remain (a pentagon minus the one collapsed edge).
+    const hull: Pt[] = [
+      [0, 0],
+      [10, 0],
+      [10, 0], // duplicate of the previous point -> zero-length edge, skipped
+      [10, 10],
+      [0, 10],
+    ];
+    const walls = perimeterWalls(hull)!;
+    assert.strictEqual(walls.length, 4);
+  });
+
+  it('returns null when skipping degenerate edges leaves fewer than 3 walls', () => {
+    // A "triangle" whose first two vertices coincide only has one genuine
+    // edge once the degenerate one is dropped, and one > 0 length edge is
+    // not a wall loop — perimeterWalls should refuse rather than emit a
+    // 2-wall non-loop.
+    const hull: Pt[] = [
+      [0, 0],
+      [0, 0],
+      [10, 0],
+    ];
+    assert.strictEqual(perimeterWalls(hull), null);
+  });
+});


### PR DESCRIPTION
Mutation-swept the pure logic in `apps/viewer/src/components`. **Test-only, two untested modules covered, 40 tests, 8 mutants killed.**

Most files there with real logic already had tests (measure-modes, schedule import, hierarchy, the lens modules). `encodingUtils.ts` turned out to be pure re-exports and types with no logic, and was skipped rather than padded. Two genuinely untested, logic-bearing files remained.

## The finding: a bare `'` starts and ends with `'`

`raw-step-format.ts`'s `parseRawStepInput` guards its quoted-string branch with `trimmed.length >= 2`:

```ts
if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
```

That third clause exists because **a single apostrophe satisfies both of the first two** — the same character is simultaneously the opening and the closing quote. Without it, a user typing `'` into the Raw STEP tab gets an **empty string** instead of a literal apostrophe.

Dropping the guard, verified here:

```
not ok 11 - treats a bare single quote as a literal apostrophe, not an empty quoted string
AssertionError: { value: '' } vs { value: "'" }
```

Restored, green. This is a new entry in the symmetry catalogue: **one character satisfying two opposite-end checks** — a degenerate palindrome, and not something any two-or-more-character fixture can reach.

Also killed there: the `.T.`/`.F.` boolean swap, a dropped `Number.isFinite` guard, dropped quote-escaping in string serialisation, an inverted `isInlineEditableToken` list check, and the `depth === 0` guard in `splitTopLevelArgs`' comma split.

## `storey-footprint.ts` — convex-hull wall synthesis, previously untested

Three mutants killed: the hull wraparound (`(i+1) % hull.length` becoming `i+1`, breaking the closing edge back to the first vertex), `thickness/2` becoming `thickness` (doubling wall width), and the `out.length >= 3` loop-completion guard.

## Two survivors, classified rather than reported as findings

**Unreachable in practice:** widening the entity-type regex from `[A-Z0-9_]+` to `[A-Z0-9_]*`, allowing an empty type keyword. Every real STEP entity line the caller extracts carries a type keyword; an untyped entity is invalid STEP this function was never meant to accept. No test written for input that cannot arrive.

**Equivalent, and proven:** weakening the early `hull.length < 3` guard to `< 2`. Hull lengths 0, 1 and 2 were each checked independently and all still return `null`, because they trip the later `out.length >= 3` check regardless. The early guard is a redundant fast path, not load-bearing — a test for it would assert a tautology.

## Verification

**40 new tests across 2 files**, all passing (re-run here). Own-fixture check done per finding: after each test the motivating mutant was re-applied and the **specific named test** confirmed as the failure, not just the suite in aggregate.

`check-module-size.mjs` exit 0. `pnpm --filter viewer typecheck` exit 0 — and it caught a real problem during development: `serializeStepToken(undefined)` does not satisfy `IfcAttributeValue`, even though the function guards it at runtime for dynamic callers. Fixed with an explicit cast and a comment explaining why, rather than left to fail in CI. That is the third time today typecheck caught something a green test run did not.

Diff confirmed to contain only the two new test files — 329 insertions, no source or build-artifact changes.

No changeset — `apps/viewer` is unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for raw STEP token extraction, serialization, editing rules, and input parsing.
  * Added coverage for storey footprint perimeter calculations, including convex hulls, wall generation, custom thickness, degenerate geometry, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->