### PR TITLE
test(create): 448 lines of style application with no tests at all

### DIFF
--- a/packages/create/src/in-store/apply-style.test.ts
+++ b/packages/create/src/in-store/apply-style.test.ts
@@ -99,7 +99,11 @@ function byId(editor: StoreEditor) {
 describe('applyStylesInStore', () => {
   it('colours a direct (non-mapped) leaf item and replaces its existing style by default', async () => {
     const store = await parseFixture();
-    const editor = makeEditor(store);
+    // Built inline rather than via makeEditor because the tombstone assertion
+    // below needs the view: `isDeleted` lives on MutablePropertyView, and
+    // StoreEditor does not re-expose it.
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(store, view);
 
     const [result] = applyStylesInStore(editor, store, [
       { products: [100], color: { red: 1, green: 0, blue: 0, alpha: 1 } },
@@ -115,6 +119,11 @@ describe('applyStylesInStore', () => {
     const styledItem = entities.get(result.styledItemIds[0]!);
     expect(styledItem?.type).toBe('IfcStyledItem');
     expect(styledItem?.attributes[0]).toBe('#112');
+    // Styles, on the DEFAULT (IFC4) path, references the IfcSurfaceStyle
+    // directly. IFC2X3 instead wraps it in an IfcPresentationStyleAssignment,
+    // and nothing here asserted which of the two we emitted -- forcing the
+    // wrapper on unconditionally left the suite fully green.
+    expect(styledItem?.attributes[1]).toEqual([`#${result.surfaceStyleId}`]);
 
     const style = entities.get(result.surfaceStyleId!);
     expect(style?.type).toBe('IfcSurfaceStyle');
@@ -128,7 +137,11 @@ describe('applyStylesInStore', () => {
 
     // The old chain (#151/#152/#153) is untouched — only the styled item is
     // tombstoned, per the documented "detached, not deleted" contract.
-    expect(editor.getNewEntity(150)).toBeNull(); // tombstoned
+    // `getNewEntity` reads the newEntities map, and #150 is a SOURCE entity
+    // that was never added to it -- so it returned null whether or not the
+    // removal happened, and the assertion could not fail. `isDeleted` reads
+    // the tombstone itself.
+    expect(view.isDeleted(150)).toBe(true);
   });
 
   it('leaves an already-styled item alone when replaceExisting is false (the do-nothing path)', async () => {

--- a/packages/create/src/in-store/apply-style.test.ts
+++ b/packages/create/src/in-store/apply-style.test.ts
@@ -1,0 +1,266 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `applyStylesInStore` has no coverage at all. It is the sole caller of
+ * `emitSurfaceStyle`, so exercising it also exercises that helper's colour
+ * clamp / transparency rounding / IFC2X3 wrapper branches, which likewise
+ * have no direct tests.
+ *
+ * Fixture is a real parsed store (`IfcParser().parseColumnar`) rather than a
+ * synthetic `MutationStoreShape`: `applyStylesInStore` reads pre-existing
+ * source entities through `EntityExtractor(store.source)`, which a
+ * `MutationStoreShape`-only fixture (the pattern used by `wall.test.ts` etc.)
+ * cannot serve.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
+import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { applyStylesInStore } from './apply-style.js';
+
+const BOILERPLATE = `#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,(#7),#9);
+#5=IFCCARTESIANPOINT((0.,0.,0.));
+#6=IFCAXIS2PLACEMENT3D(#5,$,$);
+#7=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#6,$);
+#8=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#7,$,.MODEL_VIEW.,$);
+#9=IFCUNITASSIGNMENT((#91));
+#91=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#20=IFCLOCALPLACEMENT($,#6);
+#30=IFCBUILDINGSTOREY('0storey000000000000000',$,'Level 0',$,$,#20,$,$,.ELEMENT.,0.);`;
+
+/**
+ * One product (#100) with a direct (non-mapped) representation chain down to
+ * leaf item #112, which already carries a styled item (#150 -> #151..#153).
+ * #101 has no Representation at all; #102 has one whose Items list is empty.
+ * #103/#104 are two occurrences that share one mapped representation's leaf
+ * item (#122) via two distinct IfcMappedItem instances (#123, #127) — the
+ * realistic "type occurrences share one map" shape.
+ */
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+${BOILERPLATE}
+#100=IFCWALL('guidA0000000000000000A',$,'WallA',$,$,#20,#110,$,.STANDARD.);
+#110=IFCPRODUCTDEFINITIONSHAPE($,$,(#111));
+#111=IFCSHAPEREPRESENTATION(#7,'Body','SweptSolid',(#112));
+#112=IFCEXTRUDEDAREASOLID($,$,$,1.);
+
+#150=IFCSTYLEDITEM(#112,(#151),$);
+#151=IFCSURFACESTYLE($,.BOTH.,(#152));
+#152=IFCSURFACESTYLESHADING(#153,0.);
+#153=IFCCOLOURRGB($,0.5,0.5,0.5);
+
+#101=IFCWALL('guidB0000000000000000B',$,'WallB',$,$,#20,$,$,.STANDARD.);
+
+#102=IFCWALL('guidC0000000000000000C',$,'WallC',$,$,#20,#113,$,.STANDARD.);
+#113=IFCPRODUCTDEFINITIONSHAPE($,$,(#114));
+#114=IFCSHAPEREPRESENTATION(#7,'Body','SweptSolid',());
+
+#120=IFCREPRESENTATIONMAP(#6,#121);
+#121=IFCSHAPEREPRESENTATION(#7,'Body','SweptSolid',(#122));
+#122=IFCEXTRUDEDAREASOLID($,$,$,1.);
+
+#123=IFCMAPPEDITEM(#120,#124);
+#124=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#5,1.,$);
+#125=IFCPRODUCTDEFINITIONSHAPE($,$,(#126));
+#126=IFCSHAPEREPRESENTATION(#7,'Body','MappedRepresentation',(#123));
+#103=IFCWALL('guidD0000000000000000D',$,'WallD1',$,$,#20,#125,$,.STANDARD.);
+
+#127=IFCMAPPEDITEM(#120,#128);
+#128=IFCCARTESIANTRANSFORMATIONOPERATOR3D($,$,#5,1.,$);
+#129=IFCPRODUCTDEFINITIONSHAPE($,$,(#130));
+#130=IFCSHAPEREPRESENTATION(#7,'Body','MappedRepresentation',(#127));
+#104=IFCWALL('guidE0000000000000000E',$,'WallD2',$,$,#20,#129,$,.STANDARD.);
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function parseFixture(): Promise<IfcDataStore> {
+  return new IfcParser().parseColumnar(
+    new TextEncoder().encode(MODEL).buffer as ArrayBuffer,
+    { disableWorkerScan: true },
+  );
+}
+
+function makeEditor(store: IfcDataStore): StoreEditor {
+  const view = new MutablePropertyView(null, 'm1');
+  return new StoreEditor(store, view);
+}
+
+function byId(editor: StoreEditor) {
+  return new Map(editor.getNewEntities().map((e) => [e.expressId, e]));
+}
+
+describe('applyStylesInStore', () => {
+  it('colours a direct (non-mapped) leaf item and replaces its existing style by default', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [result] = applyStylesInStore(editor, store, [
+      { products: [100], color: { red: 1, green: 0, blue: 0, alpha: 1 } },
+    ]);
+
+    expect(result.productsWithoutGeometry).toEqual([]);
+    expect(result.styledItemIds).toHaveLength(1);
+    expect(result.replacedStyledItemIds).toEqual([150]);
+    expect(result.keptExistingItemIds).toEqual([]);
+    expect(result.surfaceStyleId).not.toBeNull();
+
+    const entities = byId(editor);
+    const styledItem = entities.get(result.styledItemIds[0]!);
+    expect(styledItem?.type).toBe('IfcStyledItem');
+    expect(styledItem?.attributes[0]).toBe('#112');
+
+    const style = entities.get(result.surfaceStyleId!);
+    expect(style?.type).toBe('IfcSurfaceStyle');
+    const shadingRef = (style?.attributes[2] as string[])[0]!;
+    const shading = entities.get(Number(shadingRef.replace('#', '')));
+    expect(shading?.attributes[1]).toEqual({ real: 0 }); // transparency = 1 - alpha(1)
+
+    const colourRef = shading?.attributes[0] as string;
+    const colour = entities.get(Number(colourRef.replace('#', '')));
+    expect(colour?.attributes).toEqual([null, { real: 1 }, { real: 0 }, { real: 0 }]);
+
+    // The old chain (#151/#152/#153) is untouched — only the styled item is
+    // tombstoned, per the documented "detached, not deleted" contract.
+    expect(editor.getNewEntity(150)).toBeNull(); // tombstoned
+  });
+
+  it('leaves an already-styled item alone when replaceExisting is false (the do-nothing path)', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [result] = applyStylesInStore(editor, store, [
+      { products: [100], color: { red: 0, green: 1, blue: 0 } },
+    ], { replaceExisting: false });
+
+    expect(result.keptExistingItemIds).toEqual([112]);
+    expect(result.styledItemIds).toEqual([]);
+    expect(result.replacedStyledItemIds).toEqual([]);
+    // Nothing needed styling, so no orphan IfcSurfaceStyle/colour chain.
+    expect(result.surfaceStyleId).toBeNull();
+    expect(editor.getNewEntities()).toHaveLength(0);
+  });
+
+  it('creates no entities at all for a batch that reaches no geometry', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [result] = applyStylesInStore(editor, store, [
+      { products: [101, 102], color: { red: 1, green: 1, blue: 1 } },
+    ]);
+
+    expect(result.productsWithoutGeometry).toEqual([101, 102]);
+    expect(result.surfaceStyleId).toBeNull();
+    expect(result.styledItemIds).toEqual([]);
+    expect(editor.getNewEntities()).toHaveLength(0);
+  });
+
+  it('follows IfcMappedItem to style shared geometry once for every occurrence (default)', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [result] = applyStylesInStore(editor, store, [
+      { products: [103, 104], color: { red: 0, green: 0, blue: 1 } },
+    ]);
+
+    expect(result.productsWithoutGeometry).toEqual([]);
+    expect(result.styledItemIds).toHaveLength(1);
+    const styledItem = byId(editor).get(result.styledItemIds[0]!);
+    expect(styledItem?.attributes[0]).toBe('#122'); // the shared leaf, not either mapped item
+  });
+
+  it('styles each IfcMappedItem separately when followMappedItems is false', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [result] = applyStylesInStore(editor, store, [
+      { products: [103, 104], color: { red: 0, green: 0, blue: 1 } },
+    ], { followMappedItems: false });
+
+    expect(result.styledItemIds).toHaveLength(2);
+    const targets = byId(editor)
+      .get(result.styledItemIds[0]!) && result.styledItemIds
+      .map((id) => byId(editor).get(id)?.attributes[0]);
+    expect(new Set(targets)).toEqual(new Set(['#123', '#127']));
+  });
+
+  it('builds the IFC2X3 IfcPresentationStyleAssignment wrapper when the target schema is IFC2X3', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [result] = applyStylesInStore(editor, store, [
+      { products: [100], color: { red: 1, green: 1, blue: 0 } },
+    ], { schema: 'IFC2X3' });
+
+    const entities = byId(editor);
+    const styledItem = entities.get(result.styledItemIds[0]!);
+    const stylesRef = (styledItem?.attributes[1] as string[])[0]!;
+    const assignment = entities.get(Number(stylesRef.replace('#', '')));
+    expect(assignment?.type).toBe('IfcPresentationStyleAssignment');
+    expect(assignment?.attributes[0]).toEqual([`#${result.surfaceStyleId}`]);
+  });
+
+  it('garbage-collects a fully-replaced style chain across two calls', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [first] = applyStylesInStore(editor, store, [
+      { products: [100], color: { red: 1, green: 0, blue: 0 } },
+    ]);
+    const firstStyleId = first.surfaceStyleId!;
+    expect(editor.getNewEntity(firstStyleId)).not.toBeNull();
+
+    // Restyle the same geometry: the first call's IfcStyledItem is
+    // tombstoned, so its whole colour chain should be swept too.
+    applyStylesInStore(editor, store, [
+      { products: [100], color: { red: 0, green: 0, blue: 1 } },
+    ]);
+
+    expect(editor.getNewEntity(first.styledItemIds[0]!)).toBeNull();
+    expect(editor.getNewEntity(firstStyleId)).toBeNull();
+  });
+
+  it('reconciles two batches in one call so the losing batch reports no surviving style', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [batchRed, batchBlue] = applyStylesInStore(editor, store, [
+      { products: [100], color: { red: 1, green: 0, blue: 0 } },
+      { products: [100], color: { red: 0, green: 0, blue: 1 } },
+    ]);
+
+    // Both batches target the same product/leaf item; the later batch wins.
+    expect(batchRed!.styledItemIds).toEqual([]);
+    expect(batchRed!.surfaceStyleId).toBeNull();
+    expect(batchBlue!.styledItemIds).toHaveLength(1);
+    expect(batchBlue!.surfaceStyleId).not.toBeNull();
+
+    const styledItem = byId(editor).get(batchBlue!.styledItemIds[0]!);
+    expect(styledItem?.attributes[0]).toBe('#112');
+  });
+
+  it('clamps out-of-range channels and rounds transparency at the alpha=0 boundary', async () => {
+    const store = await parseFixture();
+    const editor = makeEditor(store);
+
+    const [result] = applyStylesInStore(editor, store, [
+      { products: [100], color: { red: 2, green: -1, blue: 0.5, alpha: 0 } },
+    ]);
+
+    const entities = byId(editor);
+    const style = entities.get(result.surfaceStyleId!);
+    const shadingRef = (style?.attributes[2] as string[])[0]!;
+    const shading = entities.get(Number(shadingRef.replace('#', '')));
+    expect(shading?.attributes[1]).toEqual({ real: 1 }); // transparency = 1 - alpha(0)
+
+    const colourRef = shading?.attributes[0] as string;
+    const colour = entities.get(Number(colourRef.replace('#', '')));
+    expect(colour?.attributes).toEqual([null, { real: 1 }, { real: 0 }, { real: 0.5 }]);
+  });
+});


### PR DESCRIPTION
`packages/create/src/in-store/apply-style.ts` is **448 lines with zero test coverage** — no `apply-style.test.ts` anywhere, and a repo-wide `grep -rl "applyStyle" --include="*.test.ts"` returned nothing. A sibling sweep flagged it as a file-scale gap and deliberately declined to write a narrow pin for it.

**Test-only. 9 tests, 8 mutants, none survived.**

It earned the full pass rather than a single guard test: a representation-tree walk with a depth bound, a mapped-item/shared-geometry branch, a replace-vs-keep merge, an IFC2X3 schema-shape branch, and a cross-call garbage collector for authored style chains.

## The nine branches

1. A direct (non-mapped) leaf styled, with `replaceExisting: true` tombstoning the pre-existing `IfcStyledItem`.
2. **`replaceExisting: false` on an already-styled item** — the do-nothing path: `keptExistingItemIds` populated, zero entities created.
3. **Orphan prevention** — a batch reaching no geometry creates zero entities, so no dangling `IfcSurfaceStyle`.
4. `followMappedItems: true` — two occurrences through distinct `IfcMappedItem`s collapse to **one** styled shared leaf.
5. `followMappedItems: false` — the same two occurrences style **two** separate mapped items.
6. The IFC2X3 branch — the `IfcPresentationStyleAssignment` wrapper, with `IfcStyledItem.Styles` pointing at the assignment rather than the bare `IfcSurfaceStyle`.
7. `sweepAuthoredChains` — restyling the same geometry in a second call GCs the **entire** first chain (colour, shading and style), not just the styled item.
8. Cross-batch reconciliation inside one call — two batches targeting the same item, with the losing batch's result filtered back to empty post-hoc.
9. Boundaries — `alpha: 0` (transparency 1) and out-of-range channels (`red: 2`, `green: -1`) clamped to `[0,1]`.

Tests 2 and 3 are the sweep's most common shape — **a guard whose "do nothing" branch is never exercised**, now eleven instances today.

## Eight mutants, each verified failing before the test was trusted

Dropping the `replaceExisting` keep-guard (`expected [] to equal [112]`); dropping the `toStyle.length === 0` early return (an orphan `surfaceStyleId` appears); removing the `followMapped` check on `IFCMAPPEDITEM` (`expected 1 to have length 2`); disabling the IFC2X3 branch; disabling `sweepAuthoredChains`; neutralising the end-of-call live filter; removing `clamp01`'s clamping; and flipping `1 - alpha` to `alpha` in the transparency calculation.

I re-ran the clamp mutant here rather than take the report:

```
× clamps out-of-range channels and rounds transparency at the alpha=0 boundary
Tests  1 failed | 8 passed (9)
```

Restored, tree clean.

**No survivors, none equivalent, none unreachable** — and the fixtures were checked against the trap that has bitten four agents today: each expects ids derived from independent arithmetic rather than from the source under test, and the mapped-item case uses **two different `IfcMappedItem` ids reaching one shared leaf**, so identical-value and shared-prefix symmetries cannot mask it.

## A neighbour covered without a second file

`_emit-helpers.ts` (299 lines — `emitSurfaceStyle`, `clamp01`, the transparency rounding) is also untested directly, but `apply-style.ts` is its **only caller** of those functions, and all of them are mutation-killed through this suite. A separate test file would duplicate coverage rather than add it, and that judgement is stated rather than left implicit.

## Leads not chased, with reasons

`window.ts`, `roof.ts` and `plate.ts` (~115-121 lines each) have **no test files**, unlike sibling builders `wall.ts`, `slab.ts`, `door.ts`, `space.ts` and `column.ts` which do. `window.ts` is the pick of them: an out-of-enum `PartitioningType` is silently remapped to `USERDEFINED` plus `UserDefinedPartitioningType` so the exported STEP always carries a valid enum token — real normalisation logic, untested.

`resolve-source.ts` (240 lines, used by `duplicateInStore`) also has no direct test, but it is tightly coupled to `duplicate.ts`, which has branches in flight on #3146 and #3148 — left alone rather than risk overlapping diffs.

## Verification

`@ifc-lite/create` **23 files / 367 tests → 24 files / 376 tests**, all green (re-run here). `check-module-size.mjs` exit 0; `pnpm --filter @ifc-lite/create typecheck` OK across 24 test files.

No changeset — test-only, no published behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
