### PR TITLE
test(create): the window PartitioningType normalisation had nothing pinning it

### DIFF
--- a/packages/create/src/in-store/window.test.ts
+++ b/packages/create/src/in-store/window.test.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, expect, it } from 'vitest';
+import {
+  MutablePropertyView,
+  StoreEditor,
+  type MutationEntityRef,
+  type MutationStoreShape,
+} from '@ifc-lite/mutations';
+import { addWindowToStore } from './window.js';
+
+function makeStore(maxId: number): MutationStoreShape {
+  const byId = new Map<number, MutationEntityRef>();
+  for (let id = 1; id <= maxId; id++) {
+    byId.set(id, { expressId: id, type: 'IFCDUMMY', byteOffset: 0, byteLength: 1, lineNumber: id });
+  }
+  return { entityIndex: { byId } };
+}
+
+const ANCHOR = { ownerHistoryId: 5, bodyContextId: 14, axisContextId: 15, storeyId: 43, storeyPlacementId: 54 };
+
+describe('addWindowToStore', () => {
+  it('emits IfcWindow with OverallHeight/OverallWidth + IFC4 PredefinedType + default PartitioningType + null UserDefinedPartitioningType', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+
+    const result = addWindowToStore(editor, ANCHOR, { Position: [1, 2, 0], Width: 0.9, Height: 1.2 });
+
+    const byId = new Map(view.getNewEntities().map((e) => [e.expressId, e]));
+    const win = byId.get(result.windowId);
+    expect(win?.type).toBe('IfcWindow');
+    expect(win?.attributes[8]).toBe(1.2); // OverallHeight
+    expect(win?.attributes[9]).toBe(0.9); // OverallWidth
+    expect(win?.attributes[10]).toBe('.NOTDEFINED.'); // PredefinedType
+    expect(win?.attributes[11]).toBe('.NOTDEFINED.'); // PartitioningType (default)
+    expect(win?.attributes[12]).toBeNull(); // UserDefinedPartitioningType
+  });
+
+  it('drops the IFC4 attribute tail for IFC2X3', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addWindowToStore(
+      editor,
+      { ...ANCHOR, schema: 'IFC2X3' },
+      { Position: [0, 0, 0], Width: 0.9, Height: 1.2 },
+    );
+    const win = view.getNewEntities().find((e) => e.expressId === result.windowId);
+    // 8 IfcRoot/IfcProduct attrs + OverallHeight + OverallWidth = 10.
+    expect(win?.attributes).toHaveLength(10);
+  });
+
+  it('rejects non-positive dimensions', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(10), view);
+    expect(() => addWindowToStore(
+      editor,
+      { ownerHistoryId: 1, bodyContextId: 2, axisContextId: 5, storeyId: 3, storeyPlacementId: 4 },
+      { Position: [0, 0, 0], Width: 0, Height: 1.2 },
+    )).toThrow(/positive/);
+  });
+
+  it('passes through a valid IfcWindowTypePartitioningEnum token unchanged', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addWindowToStore(editor, ANCHOR, {
+      Position: [0, 0, 0], Width: 0.9, Height: 1.2, PartitioningType: 'DOUBLE_PANEL_VERTICAL',
+    });
+    const win = view.getNewEntities().find((e) => e.expressId === result.windowId);
+    expect(win?.attributes[11]).toBe('.DOUBLE_PANEL_VERTICAL.');
+    expect(win?.attributes[12]).toBeNull();
+  });
+
+  it('normalises an out-of-enum PartitioningType to USERDEFINED and records the original value', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addWindowToStore(editor, ANCHOR, {
+      Position: [0, 0, 0], Width: 0.9, Height: 1.2, PartitioningType: 'LOUVERED_SASH',
+    });
+    const win = view.getNewEntities().find((e) => e.expressId === result.windowId);
+    expect(win?.attributes[11]).toBe('.USERDEFINED.');
+    expect(win?.attributes[12]).toBe('LOUVERED_SASH');
+  });
+
+  it('leaves an already-USERDEFINED PartitioningType as USERDEFINED and honours the explicit UserDefinedPartitioningType', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addWindowToStore(editor, ANCHOR, {
+      Position: [0, 0, 0], Width: 0.9, Height: 1.2,
+      PartitioningType: 'USERDEFINED', UserDefinedPartitioningType: 'Bespoke sash',
+    });
+    const win = view.getNewEntities().find((e) => e.expressId === result.windowId);
+    expect(win?.attributes[11]).toBe('.USERDEFINED.');
+    expect(win?.attributes[12]).toBe('Bespoke sash');
+  });
+
+  it('leaves an already-USERDEFINED PartitioningType without a label as null, not the enum token', () => {
+    const view = new MutablePropertyView(null, 'm1');
+    const editor = new StoreEditor(makeStore(40), view);
+    const result = addWindowToStore(editor, ANCHOR, {
+      Position: [0, 0, 0], Width: 0.9, Height: 1.2, PartitioningType: 'USERDEFINED',
+    });
+    const win = view.getNewEntities().find((e) => e.expressId === result.windowId);
+    expect(win?.attributes[11]).toBe('.USERDEFINED.');
+    expect(win?.attributes[12]).toBeNull();
+  });
+});


### PR DESCRIPTION
`window.ts`'s `PartitioningType` normalisation had no test. An out-of-enum value must be remapped to `.USERDEFINED.` **and** carry the original string in `UserDefinedPartitioningType`, so exported STEP never emits an invalid `.<value>.` token — and nothing pinned that.

**Test-only, 7 tests, 4 mutants killed.**

## Two corrections to the brief, and one to the report

I asked for three untested builders. **Only one gap was real, and the report about it was also imprecise.** Both corrections matter more than the finding, so they go first.

**`roof.ts` and `plate.ts` are already covered.** `roof-plate-member.test.ts` has `describe('addRoofToStore')` at line 33 and a matching `addPlateToStore` block, with real assertions on PredefinedType, the IFC2X3 fallback, and default-vs-override. The agent checked this before writing anything and correctly declined to touch them — my "three untested builders" lead was wrong.

**`window.ts` was not untested either.** The report claims a repo-wide grep for `addWindowToStore` in test files "returned nothing"; it does not. `dimension-validation.test.ts:84` drives it through a positive-dimension table, and `native-units.test.ts:119` exercises it for unit conversion.

What **is** genuinely untested is the normalisation specifically — `grep -rn "PartitioningType" packages/create/src --include="*.test.ts"` returns empty. That is the real gap and it is what this PR closes. The file-level "zero references" claim was overstated, and correcting it here rather than letting it ride.

## The four mutants

| mutant | RED |
|---|---|
| drop the enum guard (`partitioningType = 'USERDEFINED'` unconditionally) | `expected '.USERDEFINED.' to be '.NOTDEFINED.'`, plus the valid-token test |
| skip the remap and emit the raw invalid token | `expected '.LOUVERED_SASH.' to be '.USERDEFINED.'` |
| drop the out-of-enum label fallback in `userDefined` | `expected null to be 'LOUVERED_SASH'` |
| remove `assertPositiveFinite(Width, Height)` | `expected [Function] to throw an error` |

The third is the one a shallow fixture misses: it is **equivalent for the enum-token attribute and differs only in the label attribute**, so a test asserting `attributes[11]` alone would not see it. The fixture asserts `[11]` and `[12]` in the same case. I re-ran that mutant here to confirm:

```
× normalises an out-of-enum PartitioningType to USERDEFINED and records the original value
Tests  1 failed | 6 passed (7)
```

Restored; `git status --porcelain` empty.

## The cases

A default with no `PartitioningType` (`.NOTDEFINED.` / null); a valid enum token passing through unchanged; an out-of-enum string remapped with its original value preserved; **already-`USERDEFINED` with an explicit label**, which is the state-already-in-target-condition symmetry; and **already-`USERDEFINED` with no label**, asserting null rather than the raw token.

`door.test.ts` was used as the reference shape — same builder structure, same `makeStore`/`ANCHOR` fixture pattern — with its dimension and IFC2X3 guards mirrored across.

**The vertical-axis failure mode from #3146 and #3148 does not apply here**, and that was checked rather than assumed: `window.ts` is a flat extrusion off a fixed placement with no `Start`/`End` direction computation, so there is no degenerate cross product to guard.

## Verification

`@ifc-lite/create` **367 → 374** tests, 23 → 24 files, all green (re-run here). `check-module-size.mjs` exit 0; `pnpm --filter @ifc-lite/create typecheck` OK across 24 test files. Each mutant was restored from a saved copy with `diff` and `git status --porcelain` confirming exact restoration before continuing.

No changeset — test-only, no published behaviour affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
