### PR TITLE
test(viewer): an op marked written when nothing was written

### DIFF
--- a/apps/viewer/src/lib/layers/collab-publish.test.ts
+++ b/apps/viewer/src/lib/layers/collab-publish.test.ts
@@ -42,6 +42,12 @@ describe('collab session draft publishing (#1717)', () => {
       const manifest = getProvenance(store.loadLayer(result.layerId));
       assert.strictEqual(manifest?.author.kind, 'hybrid');
       assert.strictEqual(manifest?.intent, 'Session fire-rating pass');
+      // No stack behind this publish (`stackFiles: []`): the manifest must
+      // record no base at all, not a fabricated `{kind: 'stack', ...}` —
+      // the later publishes below (`stackFiles: [result.file]`) are the
+      // only ones this suite otherwise checks, and they all take the
+      // non-empty branch.
+      assert.strictEqual(manifest?.base, null);
       // The delta carries ONLY the post-baseline edit, on the GUID path.
       const state = extractStackState([result.file]);
       assert.strictEqual(state.get('wall-guid-1')?.components.get('pset:Pset_FireSafety')?.[FIRE], 'REI90');

--- a/apps/viewer/src/lib/layers/publish.test.ts
+++ b/apps/viewer/src/lib/layers/publish.test.ts
@@ -119,6 +119,41 @@ describe('publishViewerDraft (#1717 V2)', () => {
     assert.deepStrictEqual(result.unresolved, [42]);
   });
 
+  it('a second publish to the same ref appends its layer id after the first, not before', async () => {
+    // `stackFiles`/`layers` are documented "weakest first" (see the
+    // `PublishDraftInit.stackFiles` doc comment and this file's header):
+    // downstream composition reads a ref's `layers` in that order, so a
+    // later publish landing before an earlier one would silently flip
+    // which edit wins on any overlapping attribute. The prior
+    // "deterministic" test republishes the SAME edits, so both an append
+    // and a prepend land on `[layerId, layerId]` — indistinguishable. Two
+    // DIFFERENT edits are required to see the ordering at all.
+    const store = await BrowserLayerStore.open();
+    const base = makeBase();
+    const first = publishViewerDraft({
+      store,
+      stackFiles: [base],
+      mutations: [mutation({ id: 'm1', psetName: 'Pset_FireSafety', propName: 'FireRating', newValue: 'REI30' })],
+      pathOf: () => 'wall-guid-1',
+      intent: 'First edit',
+      authorPrincipal: 'louis',
+      refName: 'local',
+      created: '2026-07-11T12:00:00Z',
+    });
+    const second = publishViewerDraft({
+      store,
+      stackFiles: [base],
+      mutations: [mutation({ id: 'm2', psetName: 'Pset_FireSafety', propName: 'FireRating', newValue: 'REI60' })],
+      pathOf: () => 'wall-guid-1',
+      intent: 'Second edit',
+      authorPrincipal: 'louis',
+      refName: 'local',
+      created: '2026-07-11T13:00:00Z',
+    });
+    assert.notStrictEqual(first.layerId, second.layerId);
+    assert.deepStrictEqual(store.getRef('local')?.layers, [first.layerId, second.layerId]);
+  });
+
   it('is deterministic: same edits, same created stamp, same content address', async () => {
     const store = await BrowserLayerStore.open();
     const init = {
@@ -321,6 +356,29 @@ describe('publishViewerDraft (#1717 V2)', () => {
     // "uri" member (or any other non-code member) is dropped, never
     // wrapped into `{code: <that member's value>}`.
     assert.deepStrictEqual(node?.attributes, { 'bsi::ifc::class': { code: 'IfcColumn' } });
+  });
+
+  it('a set-component op whose values are non-empty but every member fails wire translation is still reported unrepresented, not silently marked written', () => {
+    // Distinct from the `values: {}` empty-pset case (the loop there never
+    // runs at all, so `wrote` trivially stays false): here the loop DOES
+    // run — once, for `uri` — but `wireEntry` returns null for it (nothing
+    // under `attr:class` matches a non-"code" member), so `node.attributes`
+    // is never touched. `wrote` must reflect "did anything actually land
+    // on the wire", not "did we iterate at least one member" — a `wrote =
+    // true` set unconditionally inside the loop (rather than only when
+    // `entry` is truthy) would pass every existing fixture, since every
+    // other test's non-empty `values` has at least one representable
+    // member.
+    const unrepresentedOps: ChangeSetOp[] = [];
+    const op: ChangeSetOp = {
+      op: 'set-component',
+      entity: 'wall-guid-1',
+      componentKey: 'attr:class',
+      values: { uri: 'https://example.invalid/schema' },
+    };
+    const nodes = buildDeltaNodes([op], [], unrepresentedOps);
+    assert.deepStrictEqual(unrepresentedOps, [op]);
+    assert.strictEqual(nodes.find((n) => n.path === 'wall-guid-1'), undefined);
   });
 
   it('an entity deletion publishes an explicit `true` tombstone opinion (not merely a truthy value)', async () => {


### PR DESCRIPTION
Mutation-swept `apps/viewer/src/lib/layers/publish.ts` — the component-op → delta-node wire serialiser. **Test-only, three findings, 11 of 13 mutants already caught.**

## The open question, answered

A sibling sweep noted `publish.test.ts` is **451 lines but had never had mutants run against it**, so nobody knew whether that size was coverage or volume.

**It is mostly real coverage.** Eleven of thirteen targeted mutations were caught by the existing suite: reordering the sort, the tombstone-entity strict-`true` check, the add-entity ifcType guard, the `attr:class` code-only filter, the qset `Number.isFinite` branch, the `attr:core` raw passthrough, the tombstone-component `.some`/base-state guard, `skippedCount` aggregation, the collab `hybrid` flag, and registry-client's status carve-out.

Two genuine gaps survived, plus one equivalent mutant.

## 1. An op silently marked "written" when nothing was written

`buildDeltaNodes` sets `wrote = true` **inside** the `if (entry)` guard, so a `set-component` op whose members all fail wire translation correctly falls through to `unrepresentedOps`. Moving that assignment out by one level makes such an op register as written and **vanish from the unrepresented list**.

Concretely: `componentKey: 'attr:class'` with `values: { uri: '...' }` and no `code` member. Nothing is serialised, and nothing reports that.

The existing `values: {}` empty-pset test cannot distinguish it — with no values the loop never runs at all. That is the sweep's most common shape, now thirteen instances: **a guard whose "do nothing" branch is never exercised.**

I applied the mutant myself:

```
not ok 12 - a set-component op whose values are non-empty but every member fails wire
            translation is still reported unrepresented, not silently marked written
# tests 18   # pass 17
```

Restored; `git status --porcelain` empty.

## 2. Ref append order, invisible to an idempotence fixture

`publishViewerDraft` appends the new layer id to the existing ref. Changing it to **prepend** left all 16 tests passing — because the only multi-publish test republishes *identical* edits, so `[layerId, layerId]` is the same either way.

A fixture written to prove idempotence cannot see ordering. The new test publishes two **different** edits and asserts `[first.layerId, second.layerId]`.

## 3. `publishCollabDraft`'s `base: null` branch was unasserted

Mutating `init.stackFiles.length > 0` to `>= 0` survived: the empty-stackFiles publish should record `manifest.base === null`, but only the *later* non-empty publish asserted `base?.kind === 'stack'`. The first publish's `base` was never checked at all.

## An equivalent mutant, proven

Replacing `value === null ? null : typedPropertyRecord(value)` with an unconditional call in `wireEntry`'s `pset:` branch — `typedPropertyRecord`'s own fallback returns `value` unchanged, so a null input already returns null. Documented, no test written for a tautology.

## Verification

`publish.test.ts` **16 → 18**, `collab-publish.test.ts` +1 assertion, registry-client 8 unchanged — **27 across the territory**, all passing (re-run here).

`check-module-size.mjs` exit 0. `pnpm --filter viewer typecheck` exits 2 against the documented pre-existing unbuilt-closure baseline, and that was checked rather than waved through: grepping the error output for `layers/(publish|registry-client|collab-publish|demo-stack|pending)` returns **zero matches**.

`git status --porcelain` shows only the two test files — no production code touched. No changeset; `apps/viewer` is unpublished.

**Leads not chased, stated rather than implied:** `registry-client.ts`'s `request()` dispatch was swept and found well covered. `demo-stack.ts` and `pending.ts` have **no test files at all** — flagged as untested, not asserted broken. The first needs DOM `fetch`/`File` mocking and is demo-fixture wiring rather than wire-format logic; the second is a thin Zustand store reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
