### PR TITLE
test(viewer): a quantity table checked only against itself

### DIFF
--- a/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
+import { QuantityType } from '@ifc-lite/data';
 import {
   classifyBasis,
   pickElementQuantities,
@@ -24,6 +25,47 @@ const qset = (
   name: string,
   quantities: Array<{ name: string; type: number; value: number }>,
 ): QuantitySetLike => ({ name, quantities });
+
+describe('MEASURABLE_QUANTITY_TYPES', () => {
+  // This table is the whole reason `pickElementQuantities` can trust a
+  // quantity's TYPE rather than its name (see the module doc). Every other
+  // test in this file destructures its members symbolically, which proves
+  // the code is internally consistent but never that the numbers it uses
+  // are the ones the parser actually emits — a fixture built from the
+  // source it checks proves nothing. These pin the raw literals against
+  // `@ifc-lite/data`'s `QuantityType`, the parser's own enum, independently.
+
+  it('matches the parser QuantityType enum value for each measurable type', () => {
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Length, QuantityType.Length);
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Area, QuantityType.Area);
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Volume, QuantityType.Volume);
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Weight, QuantityType.Weight);
+  });
+
+  it('pins the literal values directly, independent of the enum import', () => {
+    // Belt-and-braces: even if `@ifc-lite/data`'s enum itself drifted, these
+    // literals are IFC's own `IfcQuantityWeight`/`IfcQuantityVolume`/etc.
+    // STEP-encoded meaning and do not move.
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Length, 0);
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Area, 1);
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Volume, 2);
+    assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Weight, 4);
+  });
+
+  it('excludes Count and Time, and has no duplicate values', () => {
+    const values: readonly number[] = Object.values(MEASURABLE_QUANTITY_TYPES);
+    assert.strictEqual(new Set(values).size, values.length, 'duplicate quantity-type value');
+    assert.ok(!values.includes(QuantityType.Count), 'Count must stay excluded');
+    assert.ok(!values.includes(QuantityType.Time), 'Time must stay excluded');
+  });
+
+  it('is complete: exactly the four measurement kinds, nothing added or dropped', () => {
+    assert.deepStrictEqual(
+      Object.keys(MEASURABLE_QUANTITY_TYPES).sort(),
+      ['Area', 'Length', 'Volume', 'Weight'],
+    );
+  });
+});
 
 describe('classifyBasis', () => {
   it('reads the openings-included/excluded distinction off the name prefix', () => {

--- a/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/quantities.test.ts
@@ -43,9 +43,16 @@ describe('MEASURABLE_QUANTITY_TYPES', () => {
   });
 
   it('pins the literal values directly, independent of the enum import', () => {
-    // Belt-and-braces: even if `@ifc-lite/data`'s enum itself drifted, these
-    // literals are IFC's own `IfcQuantityWeight`/`IfcQuantityVolume`/etc.
-    // STEP-encoded meaning and do not move.
+    // Belt-and-braces against the enum import drifting: assert the literals
+    // rather than re-deriving them from the thing under test.
+    //
+    // What this does NOT rest on, because an earlier version of this comment
+    // claimed it: these are not IFC's encoding. `QuantityType` is ifc-lite's
+    // own enum (`packages/data/src/types.ts`), and IFC names its quantities
+    // rather than numbering them — `columnar-parser-indexes.ts` maps the STEP
+    // keyword `IFCQUANTITYWEIGHT` onto `QuantityType.Weight`, so the ordinal
+    // is ours to keep stable, not something the format pins for us. That is
+    // the reason to pin it here, not a reason it cannot move.
     assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Length, 0);
     assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Area, 1);
     assert.strictEqual(MEASURABLE_QUANTITY_TYPES.Volume, 2);


### PR DESCRIPTION
Hunted one specific shape across the viewer: **lookup tables whose control flow is tested but whose values are not.** A sibling sweep (#3154) found `lib/units`' conversion table could be wrong by a **factor of ten** with the whole suite green, so this pass asked where else that holds.

**Test-only, one finding.** Most candidate tables turned out not to qualify, and saying which and why is much of the value here.

## The finding: a fixture built from the source it checks

`components/viewer/tools/measure-modes/quantities.ts:81-86` — `MEASURABLE_QUANTITY_TYPES` maps four measurable kinds onto the parser's `QuantityType` ordinals.

**Every existing test destructures the table and uses its own symbols in the fixtures:**

```ts
const { Length, Area, Volume, Weight } = MEASURABLE_QUANTITY_TYPES;
```

So nothing ever compared the raw literals against `QuantityType` in `packages/data/src/types.ts` (`Length=0, Area=1, Volume=2, Count=3, Weight=4, Time=5`). Changing `Weight: 4` to `Weight: 6` left all 35 tests passing.

Verified here:

```
not ok 1 - matches the parser QuantityType enum value for each measurable type
not ok 2 - pins the literal values directly, independent of the enum import
```

Restored; `git status --porcelain` empty.

## The sharpest thing in this report: mutants killed by coincidence

Two other mutants **were** caught — and the agent correctly refused to count them as coverage.

`Weight: 5` collided with a test's own hardcoded `TIME = 3600` literal, and `Weight: 2` collided with `Volume`. Both tripped the existing "ignores Count and Time" test. But that is **a coincidence of the fixture's chosen numbers, not a check on the table's correctness** — the mutant that avoids every hardcoded literal, `Weight: 6`, sails through.

That distinction matters generally: a mutant dying does not always mean the behaviour is pinned. Sometimes it means the fixture happened to collide.

## Expected values derived independently

Read from `packages/data/src/types.ts` — the parser's own enum — **not** from the table under test, which is the whole point given how the gap arose. The four new tests pin:

1. each entry against the imported `QuantityType`,
2. each entry against its raw literal as well, so enum drift and table drift are separately visible,
3. no duplicate values, with `Count` and `Time` explicitly excluded,
4. **completeness** — `Object.keys(...)` is exactly `['Area','Length','Volume','Weight']`.

That last one is the highest-value assertion: a **dropped** entry is the failure mode that has actually shipped in this repo (an SI-prefix table holding 4 of 16 entries, silently 1,000,000× wrong).

## Tables surveyed and judged not applicable

Stated so nobody re-derives them: `measure-modes/weight.ts` has density and force-symbol logic but no static physical table; `lib/spacemouse/constants.ts` holds UX tuning constants that are **not independently derivable**, so a test would just restate them; `tools/sectionConstants.ts` is trivial UI labels.

**Not chased, with reasons:** `lib/panels/registry.ts` carries a real "don't reorder the first seven panels" invariant tied to Alt+N shortcuts — a structural invariant on an array rather than a value table, and a plausible follow-up. `NAME_PREFERENCE` and `BASIS_ORDER` in the same file are ordering tables whose correctness is UX preference rather than physical or schema fact, so an independent derivation does not exist.

## Verification

`quantities.test.ts` **35 → 39**, all passing (re-run here). All three mutants re-applied after the fix and confirmed killed by **named** tests, not just a suite count.

Its own first draft had a typecheck error — `Object.values(...)` inferring a narrow `(0|1|2|4)[]` union, so `includes(QuantityType.Count)` would not compile. Caught and fixed before pushing. That is the fourth time today typecheck caught something a green test run did not.

`check-module-size.mjs` exit 0. `pnpm --filter viewer typecheck` exits 2 against the documented unbuilt-closure baseline; grepping its output for `quantities` returns **zero matches**, and the remaining errors are the usual `Cannot find module '@ifc-lite/clash'` noise.

The wider `measure-modes` sweep shows 147/150, with the 3 failures being pre-existing `ERR_MODULE_NOT_FOUND` crashes in unrelated files — `quantities.test.ts` is not among them.

No changeset — `apps/viewer` is unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
