### PR TITLE
test(viewer): a documented cache-key invariant whose only test varied a different field

### DIFF
--- a/apps/viewer/src/lib/drawing/sheet-geometry-key.test.ts
+++ b/apps/viewer/src/lib/drawing/sheet-geometry-key.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `sheetGeometryKeyOf` is what `useViewControls` diffs to decide the pinned
+ * sheet-transform cache went stale, and what `sheetTransformCacheKeyOf`
+ * (tested via `resolveSheetTransform` in sheet-transform.test.ts) is built
+ * from. Its own module doc is explicit about why each field is in the key:
+ * `setPaperSize`, `setFrameStyle`/`updateFrameMargins` and `setDrawingScale`
+ * all mutate the SAME `activeSheet.id` in place (sheetSlice.ts), so the key
+ * has to change even though `id` alone would not (PR #2853 review).
+ *
+ * `sheet-transform.test.ts` exercises the key only through sheets that also
+ * differ by `id` (`buildSheet('some-other-sheet')`), which cannot tell
+ * whether a same-id, scale-only (or paper-only, or viewport-only) change is
+ * actually reflected in the key — a dropped field there would still pass
+ * every test in that file. This file pins each field directly.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PAPER_SIZE_REGISTRY,
+  FRAME_PRESETS,
+  TITLE_BLOCK_PRESETS,
+  DEFAULT_TITLE_BLOCK_FIELDS,
+  DEFAULT_SCALE_BAR,
+  DEFAULT_NORTH_ARROW,
+  type DrawingSheet,
+} from '@ifc-lite/drawing-2d';
+import { sheetGeometryKeyOf, sheetTransformCacheKeyOf } from './sheet-geometry-key.js';
+
+/** A real, fully-populated `DrawingSheet`, mirroring what
+ *  `sheetSlice.createDefaultSheet` produces (see sheet-transform.test.ts). */
+function buildSheet(overrides: Partial<DrawingSheet> = {}): DrawingSheet {
+  const paper = PAPER_SIZE_REGISTRY.A3_LANDSCAPE;
+  const frame = { style: 'professional' as const, ...FRAME_PRESETS.professional };
+  const titleBlock = {
+    ...TITLE_BLOCK_PRESETS.standard,
+    fields: DEFAULT_TITLE_BLOCK_FIELDS.map((f) => ({ ...f })),
+    logo: null,
+  };
+  return {
+    id: 'sheet-under-test',
+    name: 'sheet-under-test',
+    paper,
+    frame,
+    titleBlock,
+    scaleBar: { ...DEFAULT_SCALE_BAR },
+    scale: { name: '1:100', factor: 100, useCase: 'test' },
+    northArrow: { ...DEFAULT_NORTH_ARROW },
+    viewportBounds: { x: 10, y: 10, width: 200, height: 100 },
+    revisions: [],
+    ...overrides,
+  };
+}
+
+describe('sheetGeometryKeyOf', () => {
+  it('returns null for a missing sheet', () => {
+    assert.equal(sheetGeometryKeyOf(null), null);
+    assert.equal(sheetGeometryKeyOf(undefined), null);
+  });
+
+  it('changes when the SCALE changes, even though `id` does not (setDrawingScale, PR #2853)', () => {
+    const at100 = sheetGeometryKeyOf(buildSheet({ scale: { name: '1:100', factor: 100, useCase: 'test' } }));
+    const at50 = sheetGeometryKeyOf(buildSheet({ scale: { name: '1:50', factor: 50, useCase: 'test' } }));
+    assert.notEqual(at100, at50, 'a scale-only change on the same sheet id must change the key');
+  });
+
+  it('changes when the PAPER size changes, even though `id` does not (setPaperSize, PR #2853)', () => {
+    const a3 = sheetGeometryKeyOf(buildSheet({ paper: PAPER_SIZE_REGISTRY.A3_LANDSCAPE }));
+    const a4 = sheetGeometryKeyOf(buildSheet({ paper: PAPER_SIZE_REGISTRY.A4_LANDSCAPE }));
+    assert.notEqual(a3, a4, 'a paper-only change on the same sheet id must change the key');
+  });
+
+  it('changes when the VIEWPORT bounds change, even though `id` does not (frame margin edit, PR #2853)', () => {
+    const narrow = sheetGeometryKeyOf(buildSheet({ viewportBounds: { x: 10, y: 10, width: 200, height: 100 } }));
+    const wide = sheetGeometryKeyOf(buildSheet({ viewportBounds: { x: 10, y: 10, width: 250, height: 100 } }));
+    assert.notEqual(narrow, wide, 'a viewport-only change on the same sheet id must change the key');
+  });
+
+  it('changes when the id changes, all else equal (loadTemplate)', () => {
+    const a = sheetGeometryKeyOf(buildSheet({ id: 'sheet-a' }));
+    const b = sheetGeometryKeyOf(buildSheet({ id: 'sheet-b' }));
+    assert.notEqual(a, b);
+  });
+
+  it('is stable for an unchanged sheet', () => {
+    assert.equal(sheetGeometryKeyOf(buildSheet()), sheetGeometryKeyOf(buildSheet()));
+  });
+});
+
+describe('sheetTransformCacheKeyOf', () => {
+  it('returns null for a missing sheet, independent of axis', () => {
+    assert.equal(sheetTransformCacheKeyOf(null, 'down'), null);
+  });
+
+  it('folds a scale-only change into the cache key too', () => {
+    const at100 = sheetTransformCacheKeyOf(buildSheet({ scale: { name: '1:100', factor: 100, useCase: 'test' } }), 'down');
+    const at50 = sheetTransformCacheKeyOf(buildSheet({ scale: { name: '1:50', factor: 50, useCase: 'test' } }), 'down');
+    assert.notEqual(at100, at50);
+  });
+});

--- a/apps/viewer/src/lib/panels/mobileSheet.test.ts
+++ b/apps/viewer/src/lib/panels/mobileSheet.test.ts
@@ -61,6 +61,22 @@ describe('mobile bottom sheet occupant', () => {
     );
   });
 
+  it('lets Add Element outrank the bottom-strip panels, not just the docked side panel', () => {
+    // The precedence doc claims Add Element beats the bottom strip too, not
+    // only the docked side panel covered by the test above — assert that
+    // directly so reordering the two checks against each other is caught.
+    assert.deepEqual(
+      resolveMobileSheet({
+        ...IDLE,
+        activeTool: 'addElement',
+        ganttVisible: true,
+        scriptVisible: true,
+        listVisible: true,
+      }),
+      { kind: 'addElement' },
+    );
+  });
+
   it('reports the EXTENSION, not the panel behind it', () => {
     assert.deepEqual(
       resolveMobileSheet({ ...IDLE, hasAnalysisExtension: true, sidebarActivePanel: 'clash' }),

--- a/apps/viewer/src/lib/panels/registry.test.ts
+++ b/apps/viewer/src/lib/panels/registry.test.ts
@@ -68,3 +68,20 @@ describe('workspacePanelForShortcutCode (Alt+digit routing #1200/#1208)', () => 
     }
   });
 });
+
+// `isBottomPanel` gates `usePanelControls`' toggle routing (script / gantt /
+// lists go through `toggleBottomPanel`, everything else through the sidebar
+// dock). The test above only exercises 'script' (Digit8) and 'lists'
+// (Digit0) via the shortcut map — 'gantt' (Digit9) was never checked here,
+// so dropping it from `isBottomPanel`'s own condition went unnoticed.
+describe('isBottomPanel', () => {
+  it('is true for exactly script, gantt and lists — the bottom-strip trio', () => {
+    for (const id of WORKSPACE_PANELS.map((p) => p.id)) {
+      assert.strictEqual(
+        isBottomPanel(id),
+        id === 'script' || id === 'gantt' || id === 'lists',
+        `isBottomPanel('${id}')`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Mutation-swept `apps/viewer/src/lib/drawing` and `lib/panels`. **Test-only, three findings, 26 → 36 tests.**

## 1. A documented cache-key invariant with no direct test

`sheet-geometry-key.ts`'s own doc explains that `scale.factor` **must** be in the key because `setDrawingScale` mutates the same sheet `id` in place — the reason PR #2853 exists.

Nothing tested it. The only exerciser, `sheet-transform.test.ts`, varies the key exclusively through a **different `id`** (`buildSheet('some-other-sheet')`), never a same-id scale change. Dropping `|${sheet.scale.factor}` from the template survived all 14 of its tests.

Verified here:

```
not ok 2 - changes when the SCALE changes, even though `id` does not (setDrawingScale, PR #2853)
not ok 2 - folds a scale-only change into the cache key too
```

Restored; `git status --porcelain` empty.

The consequence of that mutant is a **stale cached transform** surviving a scale change — the drawing rendered at the old scale. The new `sheet-geometry-key.test.ts` pins scale, paper and viewport bounds as each independently key-changing on an unchanged id, plus null handling and stability.

This is the shape worth naming: **a documented invariant whose only exerciser varies a different field.** The comment cites the PR that introduced it, which reads as coverage but is not.

## 2. `resolveMobileSheet`'s precedence, one rung untested

The precedence doc claims Add Element outranks the bottom-strip panels, but no test combined `activeTool === 'addElement'` with `ganttVisible` / `scriptVisible` / `listVisible`. Moving the addElement check below the gantt check survived all 5 tests.

```
expected: {kind:'addElement'}   actual: {kind:'panel', id:'gantt'}
```

The existing "extension outranks addElement" test always set `hasAnalysisExtension: true`, so it could never distinguish addElement-versus-bottom-strip ordering — **a middle rung of a precedence chain that the tests always jumped over.**

## 3. `isBottomPanel` reached only two of its three members

Only `script` and `lists` were reachable through the shortcut-based test; `gantt` was never checked. Dropping `id === 'gantt'` from the OR chain passed all 7 tests. Now asserted directly for every registry id, positives and negatives.

## The scouted lead was real, and already covered

`registry.ts:16-17` genuinely carries the *"Alt+N by array index — DO NOT reorder the first seven"* invariant, with `workspacePanelForShortcutCode` at `:154-156`. **It is already well covered** — swapping `properties` and `compare` in `WORKSPACE_PANELS` is killed by `registry.test.ts`'s "Digit1 opens the first panel". Reported as verified-and-covered rather than counted as a finding.

## Verification

drawing **14 → 22**, panels **12 → 14**; 22 re-run here, all passing. Each new test was confirmed RED against its target mutant before being trusted, then GREEN after restore.

Also killed by the existing suites: swapping `flipY, flipX` into `calculateDrawingTransformForAxis` (2 of 14 failed), and reordering the first two `WORKSPACE_PANELS` entries. **No equivalent or unreachable mutants**, and **no coincidental kills** — both kills failed on assertions that directly compare the mutated value rather than colliding with an unrelated literal.

`check-module-size.mjs` exit 0. `pnpm --filter viewer typecheck` **exit 0**, with the touched filenames grepped out of the output for zero matches.

No changeset — `apps/viewer` is unpublished.

**Leads not chased:** `renderPanelBody.tsx` is a pure id→component dispatch already covered exhaustively by `mobile-sheet-coverage.test.ts`; `isAnalysisPanel`/`isLeftPanel` are single-predicate one-liners, untested but too trivial to warrant a RED/GREEN cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
