### PR TITLE
test(viewer): a local pin deleted by the remote-cleanup guard, and three untested files

### DIFF
--- a/apps/viewer/src/lib/collab/annotation-sync.test.ts
+++ b/apps/viewer/src/lib/collab/annotation-sync.test.ts
@@ -1,0 +1,240 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `attachAnnotationInbound` reconciles the room's annotations Y.Map into the
+ * local slice. Two guards carry the real risk here, both matching the sweep's
+ * known failure shape (a guard whose "do nothing" branch is never exercised,
+ * and a delete/absence handled as a value):
+ *
+ *   - `if (isLocalTxn) return` — our own mirror writes must not re-enter the
+ *     slice as if they were a peer's, or every local edit would echo.
+ *   - `if (a.remote && !remote.has(id)) ctx.removeRemote(id)` — only a
+ *     PEER-authored pin missing from the room is treated as deleted. Drop the
+ *     `a.remote &&` half and a locally-authored pin that hasn't round-tripped
+ *     into the room's Y.Doc yet (the documented "brief CRDT lag") gets wiped
+ *     out from under the author while they're still looking at it.
+ *
+ * These tests drive the real `Y.Doc` (`createCollabDoc`) and the real
+ * annotation CRDT helpers (`createAnnotation` / `deleteAnnotation` /
+ * `iterAnnotations`), not a stub — so the guard under test is the one
+ * `collabSlice` actually wires.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import {
+  createCollabDoc,
+  createAnnotation,
+  deleteAnnotation,
+  iterAnnotations,
+  annotationsMap,
+} from '@ifc-lite/collab';
+import type { CollabSession } from '@ifc-lite/collab';
+import type { Annotation } from '@/store/slices/annotationsSlice';
+import {
+  attachAnnotationInbound,
+  annotationToCrdtFields,
+  type AnnotationDocApi,
+  type CrdtAnnotationRecord,
+} from './annotation-sync.js';
+
+/**
+ * `yjs` is a transitive dependency (via `@ifc-lite/collab`), not a direct
+ * dependency of the viewer package — same resolution trick as
+ * `mutation-bridge.test.ts`: load the exact ESM build collab itself uses
+ * (mixing it with the CJS build throws "Unexpected content type" on
+ * `instanceof` checks), so a fork of `doc` and `Y.applyUpdate` can simulate a
+ * genuine peer write (`transaction.local === false`), which a same-doc
+ * `doc.transact()` never produces regardless of what origin is passed.
+ */
+const collabCjsResolve = createRequire(import.meta.resolve('@ifc-lite/collab'));
+const yjsEsmPath = collabCjsResolve.resolve('yjs').replace(/dist[\\/]yjs\.cjs$/, 'dist/yjs.mjs');
+const Y: {
+  applyUpdate(doc: YDoc, update: Uint8Array): void;
+  encodeStateAsUpdate(doc: YDoc, encodedTargetStateVector?: Uint8Array): Uint8Array;
+  encodeStateVector(doc: YDoc): Uint8Array;
+  Doc: new () => YDoc;
+} = await import(pathToFileURL(yjsEsmPath).href);
+type YDoc = ReturnType<typeof createCollabDoc>;
+
+/**
+ * Simulate a peer's edit landing on `doc`: fork a second Y.Doc from `doc`'s
+ * current state, mutate the fork, then apply the diff back onto `doc` — the
+ * fork is a distinct principal with its own writes, not this client echoing
+ * itself.
+ */
+function applyAsRemoteEdit(doc: YDoc, mutate: (remote: YDoc) => void): void {
+  const remote = new Y.Doc();
+  Y.applyUpdate(remote, Y.encodeStateAsUpdate(doc));
+  mutate(remote);
+  const diff = Y.encodeStateAsUpdate(remote, Y.encodeStateVector(doc));
+  Y.applyUpdate(doc, diff);
+}
+
+const api: AnnotationDocApi = {
+  annotationsMap: (doc) => annotationsMap(doc) as unknown as {
+    observeDeep(fn: (events: unknown, txn: { local?: boolean }) => void): void;
+    unobserveDeep(fn: (events: unknown, txn: { local?: boolean }) => void): void;
+  },
+  createAnnotation: (doc, id, fields) => createAnnotation(doc, id, fields),
+  deleteAnnotation: (doc, id) => deleteAnnotation(doc, id),
+  iterAnnotations: (doc) => iterAnnotations(doc) as IterableIterator<CrdtAnnotationRecord>,
+};
+
+function fakeSession(doc: ReturnType<typeof createCollabDoc>): CollabSession {
+  return { doc, transact: (fn: () => void) => doc.transact(fn) } as unknown as CollabSession;
+}
+
+function localAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'pin-1',
+    position: { x: 0, y: 0, z: 0 },
+    note: 'hello',
+    entityExpressId: null,
+    modelId: null,
+    createdAt: 1,
+    updatedAt: 1,
+    authorId: 'me',
+    authorName: 'Me',
+    authorColor: '#111',
+    remote: false,
+    ...overrides,
+  };
+}
+
+/** A recorder standing in for the slice's `upsertRemote` / `removeRemote`. */
+function makeCtx(myId: string, initialLocal: Annotation[] = []) {
+  const local = new Map<string, Annotation>(initialLocal.map((a) => [a.id, a]));
+  const upserts: Annotation[] = [];
+  const removes: string[] = [];
+  return {
+    ctx: {
+      myId: () => myId,
+      getLocal: () => local,
+      upsertRemote: (a: Annotation) => {
+        upserts.push(a);
+        local.set(a.id, a);
+      },
+      removeRemote: (id: string) => {
+        removes.push(id);
+        local.delete(id);
+      },
+    },
+    local,
+    upserts,
+    removes,
+  };
+}
+
+describe('attachAnnotationInbound — local-echo guard', () => {
+  it('does not treat our own mirror write as an inbound change', () => {
+    const doc = createCollabDoc();
+    const session = fakeSession(doc);
+    const { ctx, upserts, removes } = makeCtx('me');
+
+    const teardown = attachAnnotationInbound(session, api, ctx);
+    // Our own mirror write: session.transact(...) -> txn.local === true.
+    session.transact(() =>
+      api.createAnnotation(doc, 'pin-1', annotationToCrdtFields(localAnnotation())),
+    );
+
+    assert.equal(upserts.length, 0, 'a local txn must not re-enter the slice as an inbound change');
+    assert.equal(removes.length, 0);
+    teardown();
+  });
+});
+
+describe('attachAnnotationInbound — delete vs. absence, two principals', () => {
+  it('removes a pin only when its PEER author deleted it from the room', () => {
+    const doc = createCollabDoc();
+    const session = fakeSession(doc);
+    const peerPin = localAnnotation({ id: 'peer-pin', authorId: 'peer', remote: true });
+    const { ctx, removes } = makeCtx('me', [peerPin]);
+
+    // Seed the room with the pin as the peer originally created it, via a
+    // genuine cross-doc write, so its deletion below is a real peer write too.
+    applyAsRemoteEdit(doc, (remote) => createAnnotation(remote, 'peer-pin', annotationToCrdtFields(peerPin)));
+
+    const teardown = attachAnnotationInbound(session, api, ctx);
+    applyAsRemoteEdit(doc, (remote) => deleteAnnotation(remote, 'peer-pin'));
+
+    assert.deepEqual(removes, ['peer-pin'], 'a peer-authored pin missing from the room is removed');
+    teardown();
+  });
+
+  it('does NOT delete a pin I authored that has not round-tripped into the room yet', () => {
+    // This is the guard's whole reason to exist: a pin I just created is in my
+    // local map (optimistic) but the room's Y.Doc genuinely has nothing else
+    // yet (a brief CRDT lag before my own mirror write lands). An unrelated
+    // inbound change must not wipe it out from under me.
+    const doc = createCollabDoc();
+    const session = fakeSession(doc);
+    const myPin = localAnnotation({ id: 'my-pin', authorId: 'me', remote: false });
+    const { ctx, removes } = makeCtx('me', [myPin]);
+
+    const teardown = attachAnnotationInbound(session, api, ctx);
+    // Some unrelated remote activity ticks the map (e.g. a peer's own pin
+    // arriving) without ever containing 'my-pin'.
+    applyAsRemoteEdit(doc, (remote) =>
+      createAnnotation(remote, 'peer-pin', annotationToCrdtFields(localAnnotation({ id: 'peer-pin', authorId: 'peer' }))),
+    );
+
+    assert.deepEqual(removes, [], 'a not-yet-synced, locally-authored pin must survive the lag');
+    teardown();
+  });
+
+  it('overwrites MY pin when a peer (not the owner) edits it — ownership stays mine, content is theirs', () => {
+    const doc = createCollabDoc();
+    const session = fakeSession(doc);
+    const original = localAnnotation({ id: 'my-pin', authorId: 'me', note: 'original', updatedAt: 1, remote: false });
+    const { ctx, upserts, local } = makeCtx('me', [original]);
+
+    const teardown = attachAnnotationInbound(session, api, ctx);
+    // Seed the room with the pin as it already is, then have a PEER principal
+    // edit it (actor is not the owner: authorId stays 'me', the edit is
+    // someone else's write, via a genuine cross-doc update).
+    applyAsRemoteEdit(doc, (remote) => createAnnotation(remote, 'my-pin', annotationToCrdtFields(original)));
+    applyAsRemoteEdit(doc, (remote) => {
+      const fields = annotationToCrdtFields({ ...original, note: 'edited by peer', updatedAt: 2 });
+      createAnnotation(remote, 'my-pin', fields);
+    });
+
+    assert.ok(upserts.some((a) => a.note === 'edited by peer'), 'the room version wins once it differs');
+    assert.equal(local.get('my-pin')?.remote, false, 'ownership is by author, not by who wrote the change');
+    teardown();
+  });
+
+  it('does not churn the slice on a true no-op (same note, same updatedAt)', () => {
+    const doc = createCollabDoc();
+    const session = fakeSession(doc);
+    const pin = localAnnotation({ id: 'my-pin', authorId: 'peer', remote: true, note: 'x', updatedAt: 5 });
+    // The room already has this exact pin (a prior sync), and the local slice
+    // already mirrors it — so attach's initial pull is itself a no-op too.
+    createAnnotation(doc, 'my-pin', annotationToCrdtFields(pin));
+    const { ctx, upserts } = makeCtx('me', [pin]);
+
+    const teardown = attachAnnotationInbound(session, api, ctx);
+    assert.equal(upserts.length, 0, 'initial pull of an already-mirrored pin is a no-op');
+    // A peer re-sets the identical fields again — same note/updatedAt.
+    applyAsRemoteEdit(doc, (remote) => createAnnotation(remote, 'my-pin', annotationToCrdtFields(pin)));
+
+    assert.equal(upserts.length, 0, 'identical note+updatedAt is a no-op, not an upsert');
+    teardown();
+  });
+
+  it('initial pull reflects pins already in the room for a late joiner', () => {
+    const doc = createCollabDoc();
+    const session = fakeSession(doc);
+    createAnnotation(doc, 'existing', annotationToCrdtFields(localAnnotation({ id: 'existing', authorId: 'peer' })));
+    const { ctx, upserts } = makeCtx('me');
+
+    const teardown = attachAnnotationInbound(session, api, ctx);
+    assert.equal(upserts.length, 1, 'attach does an initial pull, not just future changes');
+    assert.equal(upserts[0].id, 'existing');
+    teardown();
+  });
+});

--- a/apps/viewer/src/lib/collab/blob-store.test.ts
+++ b/apps/viewer/src/lib/collab/blob-store.test.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * blob-store.ts had zero test coverage. `createSharedBlobStore` is a small
+ * factory, but its branch (server vs. local-only) picks between two entirely
+ * different storage backends, and its `ws → http` base-URL rewrite has to
+ * survive the exact URL shapes the collab-server config accepts (a bare
+ * `ws://` origin, a `wss://` origin, and one with a trailing slash — the
+ * comment in `blob-upload.ts`'s sibling module notes a trailing slash used to
+ * produce a double-slashed URL once a path is appended).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createSharedBlobStore } from './blob-store.js';
+
+/** A stand-in for `typeof import('@ifc-lite/collab')`, recording constructor calls. */
+function fakeCollabModule() {
+  const httpCalls: unknown[] = [];
+  let indexedDbCalls = 0;
+  const module = {
+    HttpBlobStore: class {
+      opts: unknown;
+      constructor(opts: unknown) {
+        this.opts = opts;
+        httpCalls.push(opts);
+      }
+    },
+    createIndexedDbBlobStore: async () => {
+      indexedDbCalls++;
+      return { kind: 'indexeddb' } as never;
+    },
+  };
+  return { module, httpCalls, callCount: () => indexedDbCalls };
+}
+
+describe('createSharedBlobStore', () => {
+  it('uses IndexedDB in local-only mode (no server URL)', async () => {
+    const { module, httpCalls, callCount } = fakeCollabModule();
+    const store = await createSharedBlobStore(module as never, null);
+    assert.equal(httpCalls.length, 0, 'must not construct an HTTP store with no server');
+    assert.equal(callCount(), 1);
+    assert.deepEqual(store, { kind: 'indexeddb' });
+  });
+
+  it('uses HttpBlobStore against the server, converting ws(s):// to http(s)://', async () => {
+    const { module, httpCalls } = fakeCollabModule();
+    await createSharedBlobStore(module as never, 'wss://collab.example.test', 'tok-123');
+    assert.equal(httpCalls.length, 1);
+    assert.deepEqual(httpCalls[0], { baseUrl: 'https://collab.example.test', token: 'tok-123' });
+  });
+
+  it('converts plain ws:// (not just wss://) to http://', async () => {
+    const { module, httpCalls } = fakeCollabModule();
+    await createSharedBlobStore(module as never, 'ws://localhost:1234');
+    assert.equal((httpCalls[0] as { baseUrl: string }).baseUrl, 'http://localhost:1234');
+  });
+
+  it('strips a trailing slash so the /blobs route does not get a double slash', async () => {
+    const { module, httpCalls } = fakeCollabModule();
+    await createSharedBlobStore(module as never, 'wss://collab.example.test/');
+    assert.equal((httpCalls[0] as { baseUrl: string }).baseUrl, 'https://collab.example.test');
+  });
+
+  it('passes an undefined token through when none is given', async () => {
+    const { module, httpCalls } = fakeCollabModule();
+    await createSharedBlobStore(module as never, 'wss://collab.example.test');
+    assert.equal((httpCalls[0] as { token?: string }).token, undefined);
+  });
+});

--- a/apps/viewer/src/lib/collab/blob-upload.test.ts
+++ b/apps/viewer/src/lib/collab/blob-upload.test.ts
@@ -55,7 +55,7 @@ class CountingBlobStore implements BlobStore {
   async put(_bytes: Uint8Array, _contentType?: string): Promise<BlobMeta> {
     this.attempts++;
     if (this.attempts <= this.failFirst) throw new Error(`synthetic failure #${this.attempts}`);
-    return { hash: `hash-${this.attempts}`, size: 0, contentType: 'application/octet-stream' };
+    return { hash: `hash-${this.attempts}`, byteLength: 0, contentType: 'application/octet-stream' };
   }
   get(): Promise<Uint8Array | null> {
     return Promise.resolve(null);
@@ -63,8 +63,8 @@ class CountingBlobStore implements BlobStore {
   has(): Promise<boolean> {
     return Promise.resolve(false);
   }
-  delete(): Promise<void> {
-    return Promise.resolve();
+  delete(): Promise<boolean> {
+    return Promise.resolve(false);
   }
   list(): Promise<string[]> {
     return Promise.resolve([]);

--- a/apps/viewer/src/lib/collab/blob-upload.test.ts
+++ b/apps/viewer/src/lib/collab/blob-upload.test.ts
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `uploadCountOption` and `putBlobWithRetry` were, until now, only exercised
+ * indirectly through `geometry-sync.test.ts`'s `seedGeometryToRoom` cases
+ * (which pin `concurrency`/`maxFailures` against a NaN override). `retries`
+ * itself, the floor/negative/fractional edges of the guard, and
+ * `putBlobWithRetry`'s own attempt-count and error-identity contract were
+ * never pinned directly. `boundedRetryDelayMs` already has its own direct
+ * coverage in `geometry-sync.test.ts`'s "retry backoff bounds" — not
+ * duplicated here.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import type { BlobStore, BlobMeta } from '@ifc-lite/collab';
+import { putBlobWithRetry, uploadCountOption } from './blob-upload.js';
+
+describe('uploadCountOption', () => {
+  it('passes a valid non-negative integer through untouched', () => {
+    assert.equal(uploadCountOption(5, 99), 5);
+    assert.equal(uploadCountOption(0, 99), 0, 'zero is a legitimate override (e.g. retries: 0)');
+  });
+
+  it('floors a fractional value rather than rejecting it', () => {
+    assert.equal(uploadCountOption(2.9, 99), 2);
+  });
+
+  it('falls back on NaN — the guard this function exists for', () => {
+    // `failures >= NaN` is false forever: a NaN override must fall back to the
+    // default rather than silently disabling the ceiling it configures.
+    assert.equal(uploadCountOption(Number.NaN, 10), 10);
+  });
+
+  it('falls back on a negative value', () => {
+    assert.equal(uploadCountOption(-5, 10), 10);
+  });
+
+  it('falls back on +/- Infinity', () => {
+    assert.equal(uploadCountOption(Number.POSITIVE_INFINITY, 10), 10);
+    assert.equal(uploadCountOption(Number.NEGATIVE_INFINITY, 10), 10);
+  });
+
+  it('falls back on undefined', () => {
+    assert.equal(uploadCountOption(undefined, 10), 10);
+  });
+});
+
+/** A `BlobStore` whose `put()` fails a fixed number of times, then succeeds. */
+class CountingBlobStore implements BlobStore {
+  attempts = 0;
+  constructor(private readonly failFirst: number) {}
+  async put(_bytes: Uint8Array, _contentType?: string): Promise<BlobMeta> {
+    this.attempts++;
+    if (this.attempts <= this.failFirst) throw new Error(`synthetic failure #${this.attempts}`);
+    return { hash: `hash-${this.attempts}`, size: 0, contentType: 'application/octet-stream' };
+  }
+  get(): Promise<Uint8Array | null> {
+    return Promise.resolve(null);
+  }
+  has(): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+  delete(): Promise<void> {
+    return Promise.resolve();
+  }
+  list(): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+}
+
+describe('putBlobWithRetry', () => {
+  it('returns on the first successful attempt without retrying', async () => {
+    const store = new CountingBlobStore(0);
+    const result = await putBlobWithRetry(store, new Uint8Array([1]), 2, [0, 0]);
+    assert.equal(store.attempts, 1);
+    assert.equal(result.hash, 'hash-1');
+  });
+
+  it('retries exactly up to `retries` and returns once it succeeds', async () => {
+    const store = new CountingBlobStore(2); // fails attempts 1 and 2, succeeds on 3
+    const result = await putBlobWithRetry(store, new Uint8Array([1]), 2, [0, 0]);
+    assert.equal(store.attempts, 3, 'the initial attempt plus exactly 2 retries');
+    assert.equal(result.hash, 'hash-3');
+  });
+
+  it('makes exactly retries+1 attempts total, never one more, when every attempt fails', async () => {
+    const store = new CountingBlobStore(Number.POSITIVE_INFINITY);
+    await assert.rejects(() => putBlobWithRetry(store, new Uint8Array([1]), 2, [0, 0]));
+    assert.equal(store.attempts, 3, 'retries: 2 means 3 total attempts, not 2');
+  });
+
+  it('throws the actual last error, not a synthesized one', async () => {
+    const store = new CountingBlobStore(Number.POSITIVE_INFINITY);
+    await assert.rejects(
+      () => putBlobWithRetry(store, new Uint8Array([1]), 1, [0]),
+      (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.equal(err.message, 'synthetic failure #2', 'the LAST attempt error, not the first');
+        return true;
+      },
+    );
+  });
+
+  it('with zero retries, makes exactly one attempt and surfaces its error', async () => {
+    const store = new CountingBlobStore(Number.POSITIVE_INFINITY);
+    await assert.rejects(() => putBlobWithRetry(store, new Uint8Array([1]), 0, []));
+    assert.equal(store.attempts, 1, 'retries: 0 must not silently retry anyway');
+  });
+});

--- a/apps/viewer/src/lib/collab/geometry-sync.test.ts
+++ b/apps/viewer/src/lib/collab/geometry-sync.test.ts
@@ -437,6 +437,27 @@ describe('geometry-sync seed resilience', () => {
     assert.equal(seeded.seeded, 0);
     assert.equal(seeded.skipped.empty, 2);
   });
+
+  it('also skips a mesh with positions but no triangles (indices released independently)', async () => {
+    // The pre-flight guard is `positions.length === 0 || indices.length === 0`
+    // — an OR of two independently-checked arrays. A mesh can plausibly carry
+    // vertex data with no index buffer (e.g. only the position side of
+    // bounded-geometry release ran, or an upstream tessellation produced a
+    // degenerate/empty index list for a non-empty point set). Every existing
+    // "empty mesh" fixture zeroed BOTH arrays together, so a mutant that
+    // checked only `positions.length === 0` passed the whole suite.
+    const { session, pathFor } = docWithEntities(1);
+    const blobStore = new MemoryBlobStore();
+    const indexlessMesh: MeshData = { ...sampleMesh(0), indices: new Uint32Array(0) };
+
+    const seeded = await seedGeometryToRoom(api, session, blobStore, [indexlessMesh], pathFor, {
+      concurrency: 1,
+    });
+
+    assert.equal(seeded.attempted, 0, 'a mesh with no triangles must not be uploaded');
+    assert.equal(seeded.seeded, 0);
+    assert.equal(seeded.skipped.empty, 1);
+  });
 });
 
 describe('retry backoff bounds', () => {

--- a/apps/viewer/src/lib/collab/share-link.test.ts
+++ b/apps/viewer/src/lib/collab/share-link.test.ts
@@ -1,0 +1,218 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * share-link.ts had zero test coverage. It has two shapes worth pinning:
+ *
+ *   - server vs. local-only mode branch on `collabServerUrl()` — a live
+ *     collab server that rejects, times out, or answers with a malformed body
+ *     must not be treated as success, and local-only mode must not silently
+ *     pretend a privileged op (revoke/kick) succeeded.
+ *   - `parseRoleFromToken` decodes untrusted, possibly-malformed input
+ *     (an opaque server-signed token, or garbage) and must fail closed (null),
+ *     never throw and never accept a role the type doesn't allow.
+ *
+ * `collabServerUrl()` reads `import.meta.env.VITE_COLLAB_SERVER_URL`, which
+ * `vite-module-hooks-impl.mjs` shims to `globalThis.__VITE_ENV__` under
+ * `tsx --test` — so toggling that object between tests exercises both the
+ * server and local-only branches of the SAME module without a build step.
+ * No real network calls are made: `fetch` is stubbed per test.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import {
+  mintRoomId,
+  mintRoomToken,
+  revokeRoomToken,
+  kickRoomPeer,
+  parseRoleFromToken,
+  buildShareUrl,
+} from './share-link.js';
+
+type Env = { VITE_COLLAB_SERVER_URL?: string };
+/**
+ * `vite-module-hooks-impl.mjs` binds `import.meta.env` to
+ * `(globalThis.__VITE_ENV__ ??= {...})` — a `??=`, evaluated once, at the
+ * FIRST module that reads it. Every module sharing that binding therefore
+ * sees the SAME object thereafter; replacing `globalThis.__VITE_ENV__`
+ * wholesale (`g.__VITE_ENV__ = {...}`) leaves already-loaded modules pointing
+ * at the stale object. Mutate the existing object's property instead.
+ */
+function setServerUrl(url: string | undefined): void {
+  const g = globalThis as unknown as { __VITE_ENV__?: Env };
+  g.__VITE_ENV__ ??= {};
+  if (url === undefined) delete g.__VITE_ENV__.VITE_COLLAB_SERVER_URL;
+  else g.__VITE_ENV__.VITE_COLLAB_SERVER_URL = url;
+}
+
+const originalFetch = globalThis.fetch;
+function stubFetch(fn: typeof fetch): void {
+  globalThis.fetch = fn as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  setServerUrl(undefined);
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  setServerUrl(undefined);
+});
+
+describe('mintRoomId', () => {
+  it('mints a short, URL-friendly, non-empty id', () => {
+    const id = mintRoomId();
+    assert.ok(id.length > 0);
+    assert.match(id, /^[A-Za-z0-9_-]+$/);
+  });
+
+  it('does not repeat across calls (collision-safe at test scale)', () => {
+    const ids = new Set(Array.from({ length: 50 }, () => mintRoomId()));
+    assert.equal(ids.size, 50);
+  });
+});
+
+describe('mintRoomToken — local-only mode (no server configured)', () => {
+  it('returns a decodable dev placeholder round-tripping room/role', async () => {
+    const token = await mintRoomToken({ roomId: 'room-1', role: 'editor' });
+    assert.equal(parseRoleFromToken(token), 'editor');
+  });
+
+  it('never calls fetch when no server is configured', async () => {
+    let called = false;
+    stubFetch(async () => {
+      called = true;
+      throw new Error('must not be called in local-only mode');
+    });
+    await mintRoomToken({ roomId: 'room-1', role: 'viewer' });
+    assert.equal(called, false);
+  });
+});
+
+describe('mintRoomToken — server mode', () => {
+  it('returns the server-minted token on success', async () => {
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async (input) => {
+      assert.equal(String(input), 'https://collab.example.test/collab/token');
+      return new Response(JSON.stringify({ token: 'signed.jwt.token' }), { status: 200 });
+    });
+    const token = await mintRoomToken({ roomId: 'room-1', role: 'admin' });
+    assert.equal(token, 'signed.jwt.token');
+  });
+
+  it('rejects on a non-ok HTTP status rather than returning an empty/placeholder token', async () => {
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async () => new Response('nope', { status: 403 }));
+    await assert.rejects(
+      () => mintRoomToken({ roomId: 'room-1', role: 'viewer' }),
+      /token mint failed \(403\)/,
+    );
+  });
+
+  it('rejects on a 200 with a malformed body (no token field)', async () => {
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    await assert.rejects(() => mintRoomToken({ roomId: 'room-1', role: 'viewer' }), /returned no token/);
+  });
+});
+
+describe('revokeRoomToken', () => {
+  it('is a no-op (false) in local-only mode — it must not claim success it cannot deliver', async () => {
+    let called = false;
+    stubFetch(async () => {
+      called = true;
+      return new Response(null, { status: 200 });
+    });
+    const revoked = await revokeRoomToken('some-token', 'bearer');
+    assert.equal(revoked, false);
+    assert.equal(called, false, 'no network call in local-only mode');
+  });
+
+  it('reflects the server response in server mode', async () => {
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async () => new Response(null, { status: 200 }));
+    assert.equal(await revokeRoomToken('tok', 'bearer'), true);
+  });
+
+  it('returns false when the server rejects the revoke', async () => {
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async () => new Response(null, { status: 401 }));
+    assert.equal(await revokeRoomToken('tok', 'bearer'), false);
+  });
+});
+
+describe('kickRoomPeer', () => {
+  it('is a no-op (false) in local-only mode', async () => {
+    let called = false;
+    stubFetch(async () => {
+      called = true;
+      return new Response(JSON.stringify({ kicked: true }), { status: 200 });
+    });
+    assert.equal(await kickRoomPeer('room-1', 42, 'bearer'), false);
+    assert.equal(called, false);
+  });
+
+  it('returns true only when the server body says kicked === true', async () => {
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async () => new Response(JSON.stringify({ kicked: true }), { status: 200 }));
+    assert.equal(await kickRoomPeer('room-1', 42, 'bearer'), true);
+  });
+
+  it('returns false on an ok response whose body does not confirm the kick', async () => {
+    // A malformed/absent confirmation must not be treated as success — the
+    // admin UI would tell the caller "peer removed" when nothing happened.
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async () => new Response(JSON.stringify({}), { status: 200 }));
+    assert.equal(await kickRoomPeer('room-1', 42, 'bearer'), false);
+  });
+
+  it('returns false on a non-ok status without inspecting the body', async () => {
+    setServerUrl('wss://collab.example.test');
+    stubFetch(async () => new Response(JSON.stringify({ kicked: true }), { status: 500 }));
+    assert.equal(await kickRoomPeer('room-1', 42, 'bearer'), false);
+  });
+});
+
+describe('parseRoleFromToken', () => {
+  it('round-trips a role through the dev placeholder for every valid role', async () => {
+    for (const role of ['viewer', 'commenter', 'editor', 'admin'] as const) {
+      const token = await mintRoomToken({ roomId: 'r', role });
+      assert.equal(parseRoleFromToken(token), role);
+    }
+  });
+
+  it('decodes the middle segment of a real 3-part JWT shape', () => {
+    const payload = { role: 'editor' };
+    const b64url = (s: string) =>
+      Buffer.from(s, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const jwt = `${b64url('{"alg":"none"}')}.${b64url(JSON.stringify(payload))}.sig`;
+    assert.equal(parseRoleFromToken(jwt), 'editor');
+  });
+
+  it('returns null for a role the type does not allow, rather than passing it through', () => {
+    const b64url = (s: string) =>
+      Buffer.from(s, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const token = b64url(JSON.stringify({ role: 'superadmin' }));
+    assert.equal(parseRoleFromToken(token), null);
+  });
+
+  it('fails closed (null) on garbage input rather than throwing', () => {
+    assert.equal(parseRoleFromToken('not-base64-!!!'), null);
+    assert.equal(parseRoleFromToken(''), null);
+  });
+
+  it('fails closed on valid base64 that is not JSON', () => {
+    const b64url = Buffer.from('just some bytes', 'utf8').toString('base64');
+    assert.equal(parseRoleFromToken(b64url), null);
+  });
+});
+
+describe('buildShareUrl', () => {
+  it('encodes room and token as query params', () => {
+    const url = buildShareUrl('room-1', 'tok en/with+special');
+    const parsed = new URL(url.startsWith('?') ? `http://x${url}` : url);
+    assert.equal(parsed.searchParams.get('room'), 'room-1');
+    assert.equal(parsed.searchParams.get('t'), 'tok en/with+special');
+  });
+});


### PR DESCRIPTION
Mutation-swept the collab sync and blob paths. **Test-only, 145 → 165 tests, five findings.** Three of these files had **zero tests**.

## 1. A locally-authored pin deleted out from under its author

`annotation-sync.ts`'s inbound cleanup is `if (a.remote && !remote.has(id)) ctx.removeRemote(id)`. Dropping the `a.remote &&` half means **any locally-authored pin not yet present in the room gets deleted** — precisely during the "brief CRDT lag" the code's own comment documents, before your own create round-trips.

The guard was correct; nothing pinned it.

**The fixture required getting a subtlety right**, and the agent got it wrong first: it used a same-doc `origin` string, which **Yjs does not treat as remote** — verified by reading Yjs's `Transaction.js`. The test passed for the wrong reason. It now syncs two real `Y.Doc`s via `Y.applyUpdate` so `txn.local` is genuinely `false`, matching the established `mutation-bridge.test.ts` pattern.

## 2. An OR-guard with one half never exercised

`geometry-sync.ts`'s pre-flight skip is `positions.length === 0 || indices.length === 0`. Checking only `positions` left **the entire existing 19-test suite green**, because every "empty mesh" fixture zeroed **both arrays together** — the conjunction-whose-halves-never-disagree symmetry.

Verified here:

```
not ok 7 - also skips a mesh with positions but no triangles (indices released independently)
# tests 20   # pass 19
```

Same shape as the `mutation-bridge.ts` finding on #3156, smaller blast radius: a wasted upload attempt on a degenerate mesh rather than data corruption.

## 3–5. Three files with no tests at all

**`share-link.ts`** — a privileged multi-branch I/O surface with zero coverage. `kickRoomPeer`'s `json.kicked === true` weakened to `!== false` means **a malformed or absent confirmation body reports success to an admin UI**; `revokeRoomToken` dropping `res.ok` always returns true. Driven with a stubbed `fetch`, no real network.

**`blob-upload.ts`** — `retries` had no direct coverage. Two mutants: dropping `value >= 0` lets a negative retry count through, and `attempt <= retries` → `<` is an off-by-one that four assertions now catch, pinning both the exact `retries + 1` attempt count and last-error identity.

**`blob-store.ts`** — dropping the trailing-slash strip in `toHttpBase` makes a `wss://host/` config produce a double-slashed `/blobs` route.

## Two fixture failures caught before commit, both environment-level

Worth recording because neither is obvious and both would have produced silent false passes:

- **`globalThis.__VITE_ENV__` must be mutated in place, not replaced.** `vite-module-hooks-impl.mjs` binds `import.meta.env` to it once via `??=`, so a wholesale replacement **silently no-ops** — every "server mode" test ran in local-only mode. Caught because assertions failed for the *wrong reason*, not because it was anticipated.
- The Yjs same-doc `origin` issue above.

## Judged already covered, with the mutants tried

`placement-sweep.ts` and `step-seed.ts` — mutating `collectPlacementDrift`'s baseline and `pathToId` guards, and `buildStepSeedSource`'s table-versus-reparse path, all died immediately against the existing multi-cycle interleaving regression tests. No findings, nothing manufactured.

## Verification

**145 → 165** tests across 13 collab files, all passing; 42 re-run here. Every mutant restored from a `/tmp` copy and confirmed by reading the file back plus `git status --porcelain`.

`check-module-size.mjs` exit 0. `pnpm --filter viewer typecheck` **exit 0** — and it caught a real fixture-type mismatch in `blob-upload.test.ts` (`BlobMeta.byteLength`, not `size`; `delete()` returns `Promise<boolean>`), fixed in a follow-up commit. That is the fifth time today typecheck caught something a green test run did not.

No changeset — `apps/viewer` is unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
