### PR TITLE
test(encoding): one timing sample decided a linearity assertion

### DIFF
--- a/packages/encoding/src/numeric-literal.test.ts
+++ b/packages/encoding/src/numeric-literal.test.ts
@@ -88,6 +88,11 @@ describe('deciding it is linear, not backtracking', () => {
   const SMALL = 20_000;
   const LARGE = 80_000; // 4x SMALL: linear predicts ~4x, quadratic ~16x.
   const TRIALS = 2; // Best of two batches, so one GC pause cannot inflate a reading.
+  /** Ratio samples to take, keeping the smallest. Three is enough to drop a
+   *  single preempted batch without materially lengthening the test, since
+   *  each batch is calibrated to only a few milliseconds. */
+  const RATIO_SAMPLES = 3;
+
   /** A batch has to be clearly above clock noise to divide by. */
   const MEASURABLE_MS = 2;
 
@@ -149,7 +154,20 @@ describe('deciding it is linear, not backtracking', () => {
     // 200k calls still take under 2ms, which is its own thing worth knowing.
     expect(small).toBeGreaterThanOrEqual(MEASURABLE_MS);
 
-    const growth = batch(LARGE, reps) / small;
+    // Take the SMALLEST of several ratios rather than one sample. Every noise
+    // source here inflates a reading — a scheduler preemption lands in one
+    // batch and not the other — so the minimum is the closest estimate of the
+    // real ratio, and a single unlucky sample can no longer decide the result.
+    // CI produced a lone 9.30 against this bound on 2026-08-24 while `main`
+    // was green, which is the failure mode this removes.
+    //
+    // The bound itself is unchanged. Raising it to absorb the outlier would
+    // have widened the gap the test exists to detect; re-measuring instead
+    // keeps the same discrimination on a steadier number.
+    let growth = Infinity;
+    for (let sample = 0; sample < RATIO_SAMPLES; sample++) {
+      growth = Math.min(growth, batch(LARGE, reps) / batch(SMALL, reps));
+    }
     // Measured over twelve runs at this configuration: the linear scan grows
     // 3.4x to 4.6x, the quadratic regex 15.6x to 17.0x. 8 sits between them.
     expect(growth).toBeLessThan(8);


### PR DESCRIPTION
CI failed **PR #3130** on this test with a growth ratio of **9.30 against a bound of 8** — while `main` was green and #3130's diff never touches `packages/encoding`.

A single timing sample decided the result. One preempted batch turned a correct linear implementation red, and it can do that to **any** PR, since this test runs on every one.

## The fix re-measures rather than relaxes

The ratio is now the **minimum of three samples** instead of one:

```ts
let growth = Infinity;
for (let sample = 0; sample < RATIO_SAMPLES; sample++) {
  growth = Math.min(growth, batch(LARGE, reps) / batch(SMALL, reps));
}
```

Every noise source here **inflates** a reading — a scheduler preemption lands in one batch and not the other — so the minimum is the closest estimate of the true ratio, and no single unlucky sample can decide the outcome.

**The bound stays at 8.** Raising it to absorb the outlier was the obvious move and the wrong one: linear measures 3.4x–4.6x and the quadratic regex 15.6x–17.0x, so widening the ceiling would have eaten into the very gap the test exists to detect. Loosening an assertion to make a red test green is exactly what this repo's rules forbid, and it would have traded a flake for a blind spot.

Three samples is enough to drop one preempted batch without materially lengthening the test, since each batch is already calibrated to a few milliseconds.

## The discrimination still works — verified, not assumed

Swapping the linear scan back for the quadratic regex it replaced:

```
× decides a 20k-character near-number quickly
    AssertionError: expected 393.333583 to be less than 100
× quadrupling the input roughly quadruples the time
    AssertionError: expected 6260.364791999999 to be less than 200
```

The quadratic form is caught by the two **absolute** bounds long before the ratio is even computed — which is the layering this test was designed with. Restored, 7/7 green.

## Why this is worth its own PR

The failing PR's diff is unrelated to this package, so fixing it there would have been the wrong place. This test guards the #3113 fix — a quadratic regex reachable from IFC property values in an uploaded model — and it is worth keeping, so the right response to a flake is to make the measurement steadier rather than to weaken or delete it.

`packages/encoding` 7/7 passing. Test-only; no changeset, since no published behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
