### PR TITLE
fix(cli): mutate refused ObjectType on 189 of the 218 types that have it

### DIFF
--- a/.changeset/cli-mutate-objecttype-derived-from-schema.md
+++ b/.changeset/cli-mutate-objecttype-derived-from-schema.md
@@ -1,0 +1,13 @@
+---
+"@ifc-lite/cli": patch
+---
+
+`ifc-lite mutate --set ObjectType=...` refused 189 of the 218 IFC4 entity types that actually have an ObjectType attribute.
+
+The command guarded the write with a hand-written list of 29 type names. Every name in it was correct, but the list had never kept up with the schema, so setting ObjectType on an `IfcFurniture`, `IfcStairFlight`, `IfcPipeSegment`, `IfcSanitaryTerminal` — or any of 185 others — printed `Warning: attribute "ObjectType" not applicable to IFCFURNITURE #7, skipping` and silently wrote nothing. The warning was simply wrong: those entities do define ObjectType.
+
+The set is now read from the bundled buildingSMART schema for the file's own schema version, so it cannot fall behind again, and it distinguishes IFC2X3 from IFC4 rather than being schema-blind as the old list was. A version with no bundled attribute table (`IFC5`, which the exporter accepts) falls back to IFC4 instead of throwing.
+
+The guard still does real work — this is not "write it anywhere". `IfcRelAggregates`, `IfcWallType` and `IfcPropertySet` have no ObjectType slot, so attribute index 4 on those lines is a different attribute entirely and writing to it would corrupt the file; those are still refused, and a test now pins both directions.
+
+Also covered for the first time: that `Name`, `Description` and `ObjectType` land in STEP attribute slots 2, 3 and 4 respectively. This writer edits STEP text by position, so an off-by-one there rewrites a neighbouring attribute rather than failing, and nothing asserted it before.

--- a/packages/cli/src/commands/mutate.test.ts
+++ b/packages/cli/src/commands/mutate.test.ts
@@ -2,13 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import {
   parseWhereFilter,
   parseSetArg,
   coerceValue,
   matchesFilter,
   splitStepArgs,
+  applyAttributeMutations,
+  entitiesWithObjectType,
 } from './mutate.js';
 import { PropertyValueType } from '@ifc-lite/data';
 
@@ -290,5 +292,111 @@ describe('splitStepArgs', () => {
     expect(result[2]).toBe("'Wall-001'");
     expect(result[3]).toBe("'An external wall'");
     expect(result[4]).toBe('$');
+  });
+});
+
+describe('applyAttributeMutations', () => {
+  /** A minimal STEP body with one entity line of the given type. */
+  const stepFile = (expressId: number, type: string, args: string): string =>
+    ['ISO-10303-21;', 'DATA;', `#${expressId}=${type}(${args});`, 'ENDSEC;'].join('\n');
+
+  const mutation = (expressId: number, propName: string, value: string) => ({
+    entity: { ref: { expressId } },
+    propName,
+    value,
+  });
+
+  /** The arguments of the single entity line, after mutation. */
+  const argsOf = (content: string): string[] => {
+    const line = content.split('\n').find((l) => l.startsWith('#'))!;
+    return splitStepArgs(line.slice(line.indexOf('(') + 1, line.lastIndexOf(')')));
+  };
+
+  // IfcRoot fixes GlobalId(0), OwnerHistory(1), Name(2), Description(3), and
+  // IfcObject adds ObjectType(4). Those positions come from the schema, not
+  // from us, and this writer edits STEP text BY INDEX — so an off-by-one
+  // silently rewrites a different attribute instead of failing. Nothing
+  // asserted them before.
+  let objectTypeEntities: ReadonlySet<string>;
+  beforeAll(async () => {
+    objectTypeEntities = await entitiesWithObjectType('IFC4');
+  });
+
+  it('writes Name into slot 2, leaving its neighbours untouched', () => {
+    const before = stepFile(1, 'IFCWALL', "'guid',$,'Old',$,$,$,$,$,$");
+    const args = argsOf(applyAttributeMutations(before, [mutation(1, 'Name', 'New')], objectTypeEntities));
+    expect(args[2]).toBe("'New'");
+    expect(args[0]).toBe("'guid'"); // GlobalId must not move
+    expect(args[3]).toBe('$'); // Description must not be clobbered
+  });
+
+  it('writes Description into slot 3 and ObjectType into slot 4', () => {
+    const before = stepFile(1, 'IFCWALL', "'guid',$,'Name',$,$,$,$,$,$");
+    const withDesc = applyAttributeMutations(before, [mutation(1, 'Description', 'D')], objectTypeEntities);
+    expect(argsOf(withDesc)[3]).toBe("'D'");
+    expect(argsOf(withDesc)[2]).toBe("'Name'");
+
+    const withType = applyAttributeMutations(before, [mutation(1, 'ObjectType', 'T')], objectTypeEntities);
+    expect(argsOf(withType)[4]).toBe("'T'");
+    expect(argsOf(withType)[3]).toBe('$');
+  });
+
+  it('applies ObjectType to entities the old hand-written list omitted', () => {
+    // IfcFurniture declares ObjectType, but was not among the 29 names the
+    // previous allowlist happened to contain, so this was refused outright
+    // with a "not applicable" warning. 189 of IFC4's 218 such entities sat
+    // in that position.
+    const before = stepFile(7, 'IFCFURNITURE', "'guid',$,'Desk',$,$,$,$,$,$");
+    const args = argsOf(
+      applyAttributeMutations(before, [mutation(7, 'ObjectType', 'Workstation')], objectTypeEntities),
+    );
+    expect(args[4]).toBe("'Workstation'");
+  });
+
+  it('still refuses ObjectType on entities that genuinely lack it', () => {
+    // The other direction of the same rule, and the one worth guarding: the
+    // fix must not become "write it anywhere". A relationship and a type
+    // object have no ObjectType slot, so slot 4 there is a different
+    // attribute entirely and writing to it would corrupt the file.
+    for (const type of ['IFCRELAGGREGATES', 'IFCWALLTYPE', 'IFCPROPERTYSET']) {
+      expect(objectTypeEntities.has(type), `${type} must not be treated as having ObjectType`).toBe(false);
+      const before = stepFile(3, type, "'guid',$,'N',$,$,$,$,$,$");
+      const after = applyAttributeMutations(before, [mutation(3, 'ObjectType', 'X')], objectTypeEntities);
+      expect(argsOf(after)[4], `${type} slot 4 must be untouched`).toBe('$');
+    }
+  });
+
+  it('leaves an unrecognised attribute name alone', () => {
+    const before = stepFile(1, 'IFCWALL', "'guid',$,'Name',$,$,$,$,$,$");
+    const after = applyAttributeMutations(before, [mutation(1, 'NotAnAttribute', 'X')], objectTypeEntities);
+    expect(after).toBe(before);
+  });
+
+  it('escapes quotes and backslashes so a value cannot break out of the STEP string', () => {
+    const before = stepFile(1, 'IFCWALL', "'guid',$,'Name',$,$,$,$,$,$");
+    const args = argsOf(
+      applyAttributeMutations(before, [mutation(1, 'Name', "O'Brien\\x")], objectTypeEntities),
+    );
+    expect(args[2]).toBe("'O''Brien\\\\x'");
+  });
+});
+
+describe('entitiesWithObjectType', () => {
+  it('reads the bundled schema rather than a hand-kept list', async () => {
+    // The size is the point: a hand-written list drifts behind the schema,
+    // a derived one cannot.
+    const ifc4 = await entitiesWithObjectType('IFC4');
+    expect(ifc4.size).toBeGreaterThan(100);
+    expect(ifc4.has('IFCFURNITURE')).toBe(true);
+    expect(ifc4.has('IFCWALL')).toBe(true);
+    expect(ifc4.has('IFCRELAGGREGATES')).toBe(false);
+  });
+
+  it('falls back to IFC4 for a schema version it has no table for', async () => {
+    // StepExporter accepts 'IFC5', which has no attribute table here.
+    // Throwing would break `mutate` outright on such a file; falling back
+    // preserves the old hand-written list's behaviour, which was schema-blind.
+    const ifc5 = await entitiesWithObjectType('IFC5');
+    expect(ifc5.has('IFCWALL')).toBe(true);
   });
 });

--- a/packages/cli/src/commands/mutate.ts
+++ b/packages/cli/src/commands/mutate.ts
@@ -15,7 +15,7 @@ import { getFlag, getAllFlags, hasFlag, fatal, printJson } from '../output.js';
 import { MutablePropertyView } from '@ifc-lite/mutations';
 import { StepExporter } from '@ifc-lite/export';
 import { extractPropertiesOnDemand, extractQuantitiesOnDemand } from '@ifc-lite/parser';
-import { PropertyValueType } from '@ifc-lite/data';
+import { PropertyValueType, findAttribute, type IfcSchemaVersion } from '@ifc-lite/data';
 
 /**
  * Parse a --where filter string.
@@ -232,7 +232,11 @@ export async function mutateCommand(args: string[]): Promise<void> {
   // Apply attribute mutations via STEP text post-processing
   if (attributeMutations.length > 0) {
     const textContent = new TextDecoder().decode(result.content);
-    const outputContent = applyAttributeMutations(textContent, attributeMutations);
+    const outputContent = applyAttributeMutations(
+      textContent,
+      attributeMutations,
+      await entitiesWithObjectType(schema),
+    );
     await writeFile(outPath, outputContent, 'utf-8');
   } else {
     await writeFile(outPath, result.content);
@@ -272,26 +276,37 @@ const ATTRIBUTE_INDEX: Record<string, number> = {
 };
 
 /**
- * IFC types that have an ObjectType attribute at index 4.
- * Only IfcObject subtypes (building elements, spatial elements) define ObjectType.
- * Relationship types (IfcRelAggregates, etc.) and type objects do NOT.
+ * IFC types that define an ObjectType attribute, read from the bundled
+ * buildingSMART schema for the file's own version.
+ *
+ * This used to be a hand-written list of 29 type names. Every entry in it was
+ * correct, but IFC4 declares ObjectType on **218** entities, so 189 were
+ * missing — `--set ObjectType=...` on an IfcFurniture, IfcStairFlight,
+ * IfcPipeSegment or IfcSanitaryTerminal was refused with a "not applicable"
+ * warning that was simply wrong. Deriving the set means it cannot fall behind
+ * the schema again, and it is schema-aware: IFC2X3 and IFC4 do not declare
+ * ObjectType on the same entities.
  */
-const OBJECTTYPE_TYPES = new Set([
-  'IFCWALL', 'IFCWALLSTANDARDCASE', 'IFCSLAB', 'IFCCOLUMN', 'IFCBEAM',
-  'IFCDOOR', 'IFCWINDOW', 'IFCROOF', 'IFCSTAIR', 'IFCRAILING', 'IFCMEMBER',
-  'IFCPLATE', 'IFCCOVERING', 'IFCFOOTING', 'IFCPILE', 'IFCCURTAINWALL',
-  'IFCRAMP', 'IFCSPACE', 'IFCBUILDINGELEMENTPROXY', 'IFCFURNISHINGELEMENT',
-  'IFCFLOWSEGMENT', 'IFCFLOWTERMINAL', 'IFCFLOWFITTING', 'IFCDISTRIBUTIONELEMENT',
-  'IFCOPENINGELEMENT', 'IFCSITE', 'IFCBUILDING', 'IFCBUILDINGSTOREY', 'IFCPROJECT',
-]);
+export async function entitiesWithObjectType(schema: string): Promise<ReadonlySet<string>> {
+  // `findAttribute` only knows the versions it has tables for; anything else
+  // (notably IFC5, which StepExporter accepts) falls back to IFC4 rather than
+  // throwing, which is what the hand-written list effectively did.
+  const known = new Set(['IFC2X3', 'IFC4', 'IFC4X3', 'IFC4X3_ADD2']);
+  const version = (known.has(schema) ? schema : 'IFC4') as IfcSchemaVersion;
+  const attr = await findAttribute(version, 'ObjectType');
+  // An attribute can be declared on an entity as a simple value or as part of
+  // a complex type; both mean the slot exists on that entity.
+  return new Set([...(attr?.simpleValueEntities ?? []), ...(attr?.complexEntities ?? [])]);
+}
 
 /**
  * Apply attribute mutations to STEP content via text replacement.
  * For each target entity, finds its STEP line and replaces the attribute at the known index.
  */
-function applyAttributeMutations(
+export function applyAttributeMutations(
   content: string,
   mutations: { entity: any; propName: string; value: string }[],
+  objectTypeEntities: ReadonlySet<string>,
 ): string {
   // Group mutations by expressId for efficient single-pass replacement
   const mutationsByEntity = new Map<number, { propName: string; value: string }[]>();
@@ -325,7 +340,7 @@ function applyAttributeMutations(
       const attrIdx = ATTRIBUTE_INDEX[mut.propName.toLowerCase()];
       if (attrIdx !== undefined && attrIdx < args.length) {
         // Validate ObjectType is only written to entities that define it
-        if (mut.propName.toLowerCase() === 'objecttype' && !OBJECTTYPE_TYPES.has(entityType)) {
+        if (mut.propName.toLowerCase() === 'objecttype' && !objectTypeEntities.has(entityType)) {
           process.stderr.write(`Warning: attribute "ObjectType" not applicable to ${entityType} #${expressId}, skipping\n`);
           continue;
         }


### PR DESCRIPTION
`ifc-lite mutate --set ObjectType=...` guarded the write with a hand-written list of 29 IFC type names:

```ts
const OBJECTTYPE_TYPES = new Set([
  'IFCWALL', 'IFCWALLSTANDARDCASE', 'IFCSLAB', ... // 29 names
]);
```

Every name in it is **correct**. But IFC4 declares `ObjectType` on **218** entities, so **189 were missing**. Setting ObjectType on an `IfcFurniture`, `IfcStairFlight`, `IfcPipeSegment` or `IfcSanitaryTerminal` printed:

```
Warning: attribute "ObjectType" not applicable to IFCFURNITURE #7, skipping
```

…and wrote nothing. The warning was simply wrong — those entities do define it.

Measured against the bundled schema:

| | count |
|---|---|
| IFC4 entities declaring `ObjectType` | 218 |
| names in the hand-written list | 29 |
| list entries **not** in the schema (false positives) | **0** |
| schema entities **missing** from the list | **189** |

## The fix derives the set instead of hand-keeping it

It now reads the bundled buildingSMART schema for the file's own schema version, so it cannot fall behind again — and it distinguishes IFC2X3 from IFC4, where the old list was schema-blind. `mutate.ts:225` already resolved the schema version; it just wasn't used for this.

A version with no bundled attribute table (`IFC5`, which `StepExporter` accepts) falls back to IFC4 rather than throwing, preserving the old list's behaviour there.

## The guard still does real work

This is deliberately **not** "write it anywhere". `IfcRelAggregates`, `IfcWallType` and `IfcPropertySet` have no `ObjectType` slot, so attribute index 4 on those lines is a *different attribute* — writing there would corrupt the file. Those are still refused, and the test pins **both directions**.

That matters: the "still refuses" case **passes against the old list too**, so it isn't just accepting everything. Only the two cases that genuinely depend on the schema flip.

## Also covered for the first time

`applyAttributeMutations` had **no test at all** — `mutate.test.ts` covered only the argument parsers (`parseWhereFilter`, `parseSetArg`, `coerceValue`). So nothing asserted that `Name`, `Description` and `ObjectType` land in STEP slots **2, 3, 4**. This writer edits STEP text *by position*, so an off-by-one rewrites a neighbouring attribute rather than failing — you would get a wall whose Description became its Name, with no error. Those positions are fixed by IfcRoot/IfcObject, and are now pinned along with the quote/backslash escaping that stops a value breaking out of the STEP string.

## RED–GREEN

Restoring the 29-name list fails exactly the two cases that depend on it (`applies ObjectType to entities the old hand-written list omitted`, `reads the bundled schema rather than a hand-kept list`) and leaves the other six passing.

`packages/cli` 464/464, typecheck clean, `check-module-size` exit 0.

## One note on running this locally

Several sibling `dist` builds in my checkout predated `applyStylesInStore` and other recent exports, which made **four unrelated cli test files fail at import** until `create`, `parser`, `data`, `query`, `mutations` and `export` were rebuilt (`npx tsc -b` in each). CI builds fresh so it is unaffected — flagging it only because that red run looks alarming and describes no real bug. AGENTS.md:13 documents the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `ifc-lite mutate --set` to recognize valid `ObjectType` attributes based on the file’s IFC schema.
  * Added support for IFC2X3 and IFC4 schemas, with IFC5 using IFC4 compatibility metadata.
  * Corrected STEP attribute placement for `Name`, `Description`, and `ObjectType`.
  * Preserved validation for unsupported attributes and entities without an `ObjectType` field.
  * Improved handling of escaped quotes and backslashes in attribute values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->