### PR TITLE
test(drawing-2d): the gap tolerance had no fixture sitting exactly on it

### DIFF
--- a/packages/drawing-2d/src/line-merger.test.ts
+++ b/packages/drawing-2d/src/line-merger.test.ts
@@ -118,6 +118,41 @@ describe('mergeCollinearLines', () => {
       expect(merged).toHaveLength(2);
     });
 
+    it('bridges a gap sitting EXACTLY on the tolerance', () => {
+      // The two cases above straddle the boundary without landing on it, so
+      // `next.t0 <= current.t1 + gapTolerance` could become `<` and both would
+      // still pass -- measured: the whole package stays at 425/425.
+      //
+      // The exact-equality case is not exotic here. Extracted 2D lines come
+      // from geometry that shares vertices, so a wall edge split by an opening
+      // boundary produces segments meeting at a gap of precisely zero or
+      // precisely the snapping step. Getting this wrong emits two abutting
+      // segments where the drawing should show one continuous line -- a
+      // hairline break in the exported DXF or SVG, not an error.
+      //
+      // 0.25 and 1.25 are used rather than 0.01/1.01 so the comparison is
+      // exact in binary floating point: `1 + 0.25` IS `1.25`, whereas
+      // `1 + 0.01` and the literal `1.01` differ by an ulp and the test would
+      // be asserting something subtler than it appears to.
+      const merged = mergeCollinearLines(
+        [seg(0, 0, 1, 0), seg(1.25, 0, 2, 0)],
+        { gapTolerance: 0.25 },
+      );
+      expect(merged).toHaveLength(1);
+      expect(lengthOf(merged[0])).toBeCloseTo(2, 9);
+    });
+
+    it('does NOT bridge a gap one step beyond the tolerance', () => {
+      // The other side of the same boundary, at the smallest separation that
+      // should still fail. Without this, a change from `<=` to `<` would be
+      // caught but a change to `<= tolerance * 2` would not.
+      const merged = mergeCollinearLines(
+        [seg(0, 0, 1, 0), seg(1.25 + 1e-9, 0, 2, 0)],
+        { gapTolerance: 0.25 },
+      );
+      expect(merged).toHaveLength(2);
+    });
+
     it('applies the DEFAULT gapTolerance when options are omitted entirely', () => {
       // The default (0.01) is what production passes: `drawing-generator`
       // calls `mergeDrawingLines(allLines)` with no options object, so the

--- a/packages/drawing-2d/src/line-merger.test.ts
+++ b/packages/drawing-2d/src/line-merger.test.ts
@@ -147,12 +147,24 @@ describe('mergeCollinearLines', () => {
       expect(lengthOf(merged[0])).toBeCloseTo(2, 9);
     });
 
-    it('does NOT bridge a gap one step beyond the tolerance', () => {
-      // The other side of the same boundary, at the smallest separation that
-      // should still fail. Without this, a change from `<=` to `<` would be
-      // caught but a change to `<= tolerance * 2` would not.
+    it('does NOT bridge a gap one representable step beyond the tolerance', () => {
+      // The other side of the same boundary, at the smallest separation a
+      // double can express. Without this, a change from `<=` to `<` would be
+      // caught but a widening of the tolerance itself would not.
+      //
+      // `Number.EPSILON` is exactly one ULP here, not an approximation: 1.25
+      // lies in the binade [1, 2), where the spacing between representable
+      // doubles is exactly 2^-52 — which is what `Number.EPSILON` is. So
+      // `1.25 + Number.EPSILON` is the very next double after the boundary,
+      // and this case fails the moment the comparison admits anything above it.
+      //
+      // It survives the parametric projection, which was the real question —
+      // `t0` is a projection onto the reference direction, not the literal, so
+      // an epsilon could have been rounded away in transit. Measured: it is
+      // not. An earlier draft used `1e-9`, roughly 4.5 million ULPs out, which
+      // pinned the boundary far more loosely than the wording implied.
       const merged = mergeCollinearLines(
-        [seg(0, 0, 1, 0), seg(1.25 + 1e-9, 0, 2, 0)],
+        [seg(0, 0, 1, 0), seg(1.25 + Number.EPSILON, 0, 2, 0)],
         { gapTolerance: 0.25 },
       );
       expect(merged).toHaveLength(2);

--- a/packages/drawing-2d/src/line-merger.test.ts
+++ b/packages/drawing-2d/src/line-merger.test.ts
@@ -130,10 +130,15 @@ describe('mergeCollinearLines', () => {
       // segments where the drawing should show one continuous line -- a
       // hairline break in the exported DXF or SVG, not an error.
       //
-      // 0.25 and 1.25 are used rather than 0.01/1.01 so the comparison is
-      // exact in binary floating point: `1 + 0.25` IS `1.25`, whereas
-      // `1 + 0.01` and the literal `1.01` differ by an ulp and the test would
-      // be asserting something subtler than it appears to.
+      // 0.25 and 1.25 are used because both are exactly representable in
+      // binary, so `1 + 0.25 === 1.25` holds structurally and this case really
+      // does sit ON the boundary rather than near it.
+      //
+      // 0.01/1.01 would in fact also work here -- `1 + 0.01 === 1.01` is true,
+      // the rounding happens to land on the same double -- but only by
+      // coincidence of this particular pair, and a test whose exactness rests
+      // on a rounding coincidence is one nobody can safely edit. Powers of two
+      // make the property independent of the arithmetic.
       const merged = mergeCollinearLines(
         [seg(0, 0, 1, 0), seg(1.25, 0, 2, 0)],
         { gapTolerance: 0.25 },


### PR DESCRIPTION
`mergeCollinearSegments` bridges a collinear gap with `next.t0 <= current.t1 + gapTolerance`.

The existing cases **straddle that boundary without landing on it** — one gap strictly inside the tolerance, one outside. So changing `<=` to `<` leaves `packages/drawing-2d` at **425/425 passing**. With this case, exactly one test fails and the other 32 still pass.

## Why the exact case matters here

Extracted 2D lines come from geometry that shares vertices, so a wall edge split by an opening boundary produces segments meeting at *precisely* zero or *precisely* the snapping step — landing on the boundary is the ordinary outcome, not a contrived one.

Getting it wrong emits two abutting segments where the drawing should show one continuous line: a hairline break in the exported DXF or SVG, with no error raised. `drawing-generator.ts:385` calls this on every batch of extracted lines.

## On the fixture values

It uses `0.25` and `1.25` because both are **exactly representable in binary**, so `1 + 0.25 === 1.25` holds structurally and the case really does sit *on* the boundary rather than near it.

`0.01`/`1.01` would in fact also work — `1 + 0.01 === 1.01` is true, the rounding happens to land on the same double — but only by coincidence of that particular pair. A test whose exactness rests on a rounding coincidence is one nobody can safely edit; powers of two make the property independent of the arithmetic.

A second case pins the other side at the smallest separation that must still fail, so a change to `<= tolerance * 2` is caught as well as `<=` → `<`.

## Scope note

A second candidate was investigated and **dropped**, in a different package: `packages/renderer`'s `fill-triangulate.ts` and its `orient(a, b, c) <= 0` ear guard also survives mutation, but I verified the output is byte-identical with and without the change — same triangles, same area, no degenerate triangle produced. The mutation is behaviourally inert there, so it survives for a reason that has nothing to do with coverage, and a test claiming to close that gap would have been false. Worth stating because a surviving mutation is not by itself evidence of missing coverage.

`drawing-2d` **427/427** (425 before), `check-module-size` exit 0. Test-only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

*Correction (post-review audit): this body originally claimed `1 + 0.01` and the literal `1.01` "differ by an ulp". That is false — they are bit-identical (`295c8fc2f528f03f`), verified with `node -e "console.log(1 + 0.01 === 1.01)"` → `true`. The fixture choice stands, but for the honest reason now stated: 0.25 is exactly representable, so the boundary equality does not depend on a rounding coincidence. The test code and its comment are corrected in `cffac4eb9`.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added boundary-case coverage for merging collinear lines.
  * Verified that gaps at the tolerance limit are merged, while slightly larger gaps remain separate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->