### PR TITLE
feat(viewer): bridge picked entities to the exact min-distance predicate (#2737)

### DIFF
--- a/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.test.ts
@@ -157,14 +157,20 @@ describe('minDistanceBetweenEntities', () => {
     const meshes = [tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]])];
     const missingB = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 42 });
     assert.equal(missingB.kind, 'refused');
-    if (missingB.kind !== 'refused') return;
+    if (missingB.kind !== 'refused' || missingB.reason !== 'no-usable-geometry') return;
     assert.equal(missingB.missing, 'b');
 
     const missingA = minDistanceBetweenEntities(meshes, { entityId: 42 }, { entityId: 1 });
-    assert.equal(missingA.kind === 'refused' && missingA.missing, 'a');
+    assert.equal(
+      missingA.kind === 'refused' && missingA.reason === 'no-usable-geometry' && missingA.missing,
+      'a',
+    );
 
     const both = minDistanceBetweenEntities(meshes, { entityId: 42 }, { entityId: 43 });
-    assert.equal(both.kind === 'refused' && both.missing, 'both');
+    assert.equal(
+      both.kind === 'refused' && both.reason === 'no-usable-geometry' && both.missing,
+      'both',
+    );
   });
 
   it('gives witness points that lie on their own entity', () => {
@@ -196,5 +202,88 @@ describe('minDistanceBetweenEntities', () => {
     assert.equal(ba.kind, 'ok');
     if (ab.kind !== 'ok' || ba.kind !== 'ok') return;
     assert.ok(Math.abs(ab.distance - ba.distance) < 1e-12);
+  });
+});
+
+describe('corrupt geometry is refused, not measured', () => {
+  /**
+   * The failure these pin is not a wrong number, it is a wrong KIND.
+   *
+   * `minDistanceBetweenBvhs` seeds `best.distance` with `Infinity` and lowers
+   * it only on `r.dist < best.distance`. Every comparison against NaN is
+   * false, so the seed survives and the traversal returns it as though it had
+   * measured something. Tagged `ok`, that renders as "Infinity m" -- the same
+   * class of lie as `distance ?? 0` showing "0.000 m", which is the whole
+   * reason this module returns a union.
+   */
+
+  it('refuses an entity whose only submesh has a NaN vertex', () => {
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[NaN, NaN, NaN], [11, 4, 5], [10, 5, 5]]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    // Before the guard this returned { kind: 'ok', distance: Infinity }.
+    assert.equal(out.kind, 'refused');
+    if (out.kind !== 'refused' || out.reason !== 'no-usable-geometry') return;
+    assert.equal(out.missing, 'b');
+  });
+
+  it('refuses a vertex past the shared 10 km ceiling', () => {
+    // Unshifted survey/UTM coordinates, the case NORMAL_COORD_THRESHOLD_M
+    // exists for. The distance would be arithmetically fine and physically
+    // meaningless.
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[500000, 0, 0], [500001, 0, 0], [500000, 1, 0]]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'refused');
+  });
+
+  it('judges the ceiling in WORLD space, so a big origin alone is not corrupt', () => {
+    // THE COUNTER-EXAMPLE. A guard that tested raw positions would pass
+    // corrupt data; one that tested the origin alone would reject this, which
+    // is ordinary off-origin geometry well inside the ceiling. Both entities
+    // sit near x = 9000 via their origins and must still measure.
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [9000, 0, 0]),
+      tri(2, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [9005, 0, 0]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    assert.ok(Number.isFinite(out.distance), `distance ${out.distance}`);
+    assert.ok(Math.abs(out.distance - 4) < 1e-6, `distance ${out.distance}`);
+  });
+
+  it('drops only the corrupt submesh, keeping an entity that still has good ones', () => {
+    // Rejection is per submesh, matching the degenerate-submesh filter beside
+    // it. Refusing the whole entity would throw away geometry we can measure.
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[NaN, 0, 0], [1, 0, 0], [0, 1, 0]], [50, 0, 0]),
+      tri(2, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [10, 0, 0]),
+    ];
+    const mesh = meshForEntity(meshes, 2);
+    assert.ok(mesh, 'the clean submesh must survive');
+    assert.equal(mesh.positions.length, 9, 'exactly one submesh, not two');
+    assert.equal(mesh.positions[0], 10, 'the surviving submesh is the clean one');
+
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    assert.ok(Number.isFinite(out.distance), `distance ${out.distance}`);
+  });
+
+  it('still refuses when every submesh of an entity is corrupt', () => {
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[NaN, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[0, 0, 0], [Infinity, 0, 0], [0, 1, 0]]),
+    ];
+    assert.equal(meshForEntity(meshes, 2), null);
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'refused');
   });
 });

--- a/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.test.ts
@@ -276,6 +276,38 @@ describe('corrupt geometry is refused, not measured', () => {
     assert.ok(Number.isFinite(out.distance), `distance ${out.distance}`);
   });
 
+  it('reports the dropped count when a discarded submesh was the NEARER one', () => {
+    // The quieter half of the same bug. Entity 2's nearest submesh is corrupt
+    // and gets discarded, so the measurement lands on its far submesh: 99
+    // instead of roughly 5. Unlike "Infinity m" that is a plausible number,
+    // and nothing about the value reveals the problem — so the count must.
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[NaN, 0, 0], [6, 0, 0], [5, 1, 0]]),
+      tri(2, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [100, 0, 0]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    assert.ok(out.distance > 90, `measured against the surviving submesh: ${out.distance}`);
+    assert.equal(out.dropped.b, 1, 'the discarded submesh must be reported');
+    assert.equal(out.dropped.a, 0, 'entity a lost nothing');
+  });
+
+  it('reports zero dropped when nothing was discarded', () => {
+    // The counter-example to the test above: an ordinary measurement must not
+    // look partial, or a readout that flags `dropped` would flag everything.
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [10, 0, 0]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    assert.equal(out.dropped.a, 0);
+    assert.equal(out.dropped.b, 0);
+  });
+
   it('still refuses when every submesh of an entity is corrupt', () => {
     const meshes = [
       tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),

--- a/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.test.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.test.ts
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { MeshData } from '@ifc-lite/geometry';
+import { meshForEntity, minDistanceBetweenEntities } from './min-distance.js';
+
+/**
+ * Fixtures here are deliberately OFF-ORIGIN and, where it matters, off-axis.
+ *
+ * A distance routine that mishandles per-submesh origins, or that rebases
+ * indices wrongly when concatenating, still passes every test whose geometry
+ * sits at the world origin with one submesh per entity — the error cancels.
+ * `measure-modes/radius.ts` records the same lesson from an order-dependent
+ * plane that turned a 2 m arc into a 2.8 km one, so the fixtures below are
+ * built to make that class of mistake visible rather than convenient.
+ */
+
+/** One triangle, as a submesh with its own local frame. */
+function tri(
+  expressId: number,
+  verts: readonly [number, number, number][],
+  origin?: [number, number, number],
+  modelIndex?: number,
+): MeshData {
+  const positions = new Float32Array(verts.flat());
+  return {
+    expressId,
+    positions,
+    normals: new Float32Array(positions.length),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+    ...(origin ? { origin } : {}),
+    ...(modelIndex === undefined ? {} : { modelIndex }),
+  } as MeshData;
+}
+
+describe('meshForEntity', () => {
+  it('applies each submesh its OWN origin, not the first one', () => {
+    // Two submeshes of one entity, sitting 10 apart because their origins
+    // differ. Using submesh 0's origin for both would stack them, and every
+    // distance measured against this entity would be wrong by 10.
+    const meshes = [
+      tri(7, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [100, 0, 0]),
+      tri(7, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [110, 0, 0]),
+    ];
+    const mesh = meshForEntity(meshes, 7);
+    assert.ok(mesh);
+    assert.equal(mesh.positions.length, 18, 'both submeshes must be present');
+    // First vertex of each submesh, in world coordinates.
+    assert.equal(mesh.positions[0], 100);
+    assert.equal(mesh.positions[9], 110);
+  });
+
+  it('rebases indices so the second submesh addresses its own vertices', () => {
+    // Without rebasing, submesh 1's indices [0,1,2] would point back at
+    // submesh 0's vertices: a triangle soup that silently ignores half the
+    // entity while still looking well-formed.
+    const meshes = [
+      tri(7, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [0, 0, 0]),
+      tri(7, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [50, 0, 0]),
+    ];
+    const mesh = meshForEntity(meshes, 7);
+    assert.ok(mesh);
+    assert.deepEqual([...mesh.indices], [0, 1, 2, 3, 4, 5]);
+  });
+
+  it('treats a missing origin as absolute, matching boundsFromMeshes', () => {
+    const mesh = meshForEntity([tri(1, [[3, 4, 5], [4, 4, 5], [3, 5, 5]])], 1);
+    assert.ok(mesh);
+    assert.equal(mesh.positions[0], 3);
+    assert.equal(mesh.positions[1], 4);
+    assert.equal(mesh.positions[2], 5);
+  });
+
+  it('returns null for an entity with no submeshes', () => {
+    assert.equal(meshForEntity([tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]])], 999), null);
+    assert.equal(meshForEntity([], 1), null);
+  });
+
+  it('ignores degenerate submeshes that carry no triangle', () => {
+    const empty = {
+      ...tri(5, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      indices: new Uint32Array([]),
+    } as MeshData;
+    assert.equal(meshForEntity([empty], 5), null);
+  });
+
+  it('separates entities that share an express id across federated models', () => {
+    // Express ids are per-model, so a federated scene reuses them. Matching on
+    // id alone would fuse two different buildings' walls into one soup.
+    const meshes = [
+      tri(3, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], undefined, 0),
+      tri(3, [[80, 0, 0], [81, 0, 0], [80, 1, 0]], undefined, 1),
+    ];
+    const a = meshForEntity(meshes, 3, 0);
+    const b = meshForEntity(meshes, 3, 1);
+    assert.ok(a && b);
+    assert.equal(a.positions.length, 9, 'model 0 must not absorb model 1');
+    assert.equal(b.positions[0], 80);
+    // Without a modelIndex the caller gets both, which is the documented
+    // fallback rather than an accident.
+    assert.equal(meshForEntity(meshes, 3)?.positions.length, 18);
+  });
+});
+
+describe('minDistanceBetweenEntities', () => {
+  it('measures the gap between two separated entities', () => {
+    // Triangles in the z = 5 plane, well away from the origin. Nearest
+    // approach is between (11,4,5) and (15,4,5), so 4.
+    const meshes = [
+      tri(1, [[10, 4, 5], [11, 4, 5], [10, 5, 5]]),
+      tri(2, [[15, 4, 5], [16, 4, 5], [15, 5, 5]]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    assert.ok(Math.abs(out.distance - 4) < 1e-9, `expected 4, got ${out.distance}`);
+  });
+
+  it('accounts for the origin when it decides which submesh is nearest', () => {
+    // Entity 1 has two submeshes: one far, one near. The near one is only near
+    // BECAUSE of its origin. A routine that dropped origins would report the
+    // distance to the far part and be wrong by an order of magnitude.
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [0, 0, 0]),
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]], [18, 0, 0]),
+      tri(2, [[20, 0, 0], [21, 0, 0], [20, 1, 0]]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    // Nearest is submesh 2's far corner at x = 19 against entity 2 at x = 20.
+    assert.ok(Math.abs(out.distance - 1) < 1e-9, `expected 1, got ${out.distance}`);
+  });
+
+  it('reports zero for touching geometry, which is NOT the same as refusing', () => {
+    // The distinction the predicate's own doc insists on: 0 means "they
+    // touch", and it must be reachable and distinguishable from a refusal.
+    const meshes = [
+      tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+      tri(2, [[1, 0, 0], [2, 0, 0], [1, 1, 0]]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    assert.equal(out.distance, 0);
+  });
+
+  it('refuses rather than reporting zero when an entity has no geometry', () => {
+    // The bug this type exists to prevent: `distance ?? 0` would render
+    // "0.000 m" — reading as "these are touching" — for a pick that could not
+    // be measured at all.
+    const meshes = [tri(1, [[0, 0, 0], [1, 0, 0], [0, 1, 0]])];
+    const missingB = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 42 });
+    assert.equal(missingB.kind, 'refused');
+    if (missingB.kind !== 'refused') return;
+    assert.equal(missingB.missing, 'b');
+
+    const missingA = minDistanceBetweenEntities(meshes, { entityId: 42 }, { entityId: 1 });
+    assert.equal(missingA.kind === 'refused' && missingA.missing, 'a');
+
+    const both = minDistanceBetweenEntities(meshes, { entityId: 42 }, { entityId: 43 });
+    assert.equal(both.kind === 'refused' && both.missing, 'both');
+  });
+
+  it('gives witness points that lie on their own entity', () => {
+    // The points come back in the render frame, ready for the readout without
+    // a further transform. If an axis conversion crept in, these would land
+    // somewhere neither entity occupies.
+    const meshes = [
+      tri(1, [[10, 4, 5], [11, 4, 5], [10, 5, 5]]),
+      tri(2, [[15, 4, 5], [16, 4, 5], [15, 5, 5]]),
+    ];
+    const out = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    assert.equal(out.kind, 'ok');
+    if (out.kind !== 'ok') return;
+    assert.ok(out.pointA[0] >= 10 && out.pointA[0] <= 11, `pointA.x ${out.pointA[0]}`);
+    assert.ok(out.pointB[0] >= 15 && out.pointB[0] <= 16, `pointB.x ${out.pointB[0]}`);
+    // Both triangles are flat in z = 5; a frame swap would move this to y.
+    assert.ok(Math.abs(out.pointA[2] - 5) < 1e-9, `pointA.z ${out.pointA[2]}`);
+    assert.ok(Math.abs(out.pointB[2] - 5) < 1e-9, `pointB.z ${out.pointB[2]}`);
+  });
+
+  it('is symmetric in its two arguments', () => {
+    const meshes = [
+      tri(1, [[10, 4, 5], [11, 4, 5], [10, 5, 5]]),
+      tri(2, [[15, 4, 5], [16, 4, 5], [15, 5, 5]]),
+    ];
+    const ab = minDistanceBetweenEntities(meshes, { entityId: 1 }, { entityId: 2 });
+    const ba = minDistanceBetweenEntities(meshes, { entityId: 2 }, { entityId: 1 });
+    assert.equal(ab.kind, 'ok');
+    assert.equal(ba.kind, 'ok');
+    if (ab.kind !== 'ok' || ba.kind !== 'ok') return;
+    assert.ok(Math.abs(ab.distance - ba.distance) < 1e-12);
+  });
+});

--- a/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Minimum distance between two picked entities — the geometry half of #2737's
+ * third item.
+ *
+ * The hard part already exists: `minDistanceBetweenMeshes` in
+ * `@ifc-lite/clash/contact` is an exact branch-and-bound BVH traversal over
+ * the same `triTriDistance` predicate clash detection uses, so this is not a
+ * second copy of a distance routine (which #2737 explicitly asked us not to
+ * write). What was missing is the bridge: the viewer holds `MeshData[]`, and
+ * that predicate wants one `Mesh` per entity.
+ *
+ * Three things make that bridge worth its own tested module rather than a few
+ * lines at a call site.
+ *
+ * 1. AN ENTITY IS USUALLY SEVERAL SUBMESHES, each with its own `origin`. The
+ *    world position of a vertex is `origin + position` (per-element local
+ *    frame, absent meaning absolute) — the same rule `boundsFromMeshes` in
+ *    `utils/viewportUtils.ts` applies. Concatenating submeshes therefore means
+ *    adding EACH submesh's own origin, not one origin for the entity, and
+ *    rebasing each submesh's indices by the running vertex count. Get any of
+ *    those three steps wrong and the answer is silently plausible.
+ *
+ *    That failure mode is not hypothetical here: `measure-modes/radius.ts`
+ *    carries a note about an order-dependent plane that turned a 2 m arc into
+ *    a 2.8 km one. Same family of bug, same file neighbourhood.
+ *
+ * 2. NO AXIS CONVERSION, DELIBERATELY. `Mesh` in `@ifc-lite/clash/contact` is
+ *    documented as "world coordinates (Z-up, matching IFC)", and the viewer's
+ *    frame is Y-up. This module feeds render-frame vertices in ANYWAY, and
+ *    that is correct rather than sloppy: Euclidean distance is invariant under
+ *    the Y-up/Z-up relabeling, which is a rotation — it changes no length. The
+ *    witness points then come back already in the frame the readout displays,
+ *    so there is no conversion hop on the way out either.
+ *
+ *    Converting to IFC axes and back would be two extra transforms whose only
+ *    effect is to cancel, and every transform hop is somewhere the bug in (1)
+ *    can hide. The deviation from the type's stated contract is intentional
+ *    and is why it is written down here.
+ *
+ * 3. `null` IS NOT ZERO. The predicate returns `null` when either mesh has no
+ *    triangles, "deliberately distinct from returning 0, which would read as
+ *    'they touch'". A UI that renders `dist ?? 0` turns "I could not measure
+ *    this" into "these are touching", which is worse than showing nothing.
+ *    The result type below makes that unrepresentable rather than merely
+ *    discouraged.
+ */
+
+import { minDistanceBetweenMeshes } from '@ifc-lite/clash/contact';
+import type { MeshData } from '@ifc-lite/geometry';
+
+/** A point in the viewer's render frame, the same frame `MeshData` uses. */
+export type MeasurePoint3 = readonly [number, number, number];
+
+/**
+ * Why a pair could not be measured. Kept as a reason rather than a bare
+ * `null` so the readout can say which entity was the problem.
+ */
+export interface MinDistanceRefusal {
+  readonly kind: 'refused';
+  /** Which of the two picks had no usable geometry, or 'both'. */
+  readonly missing: 'a' | 'b' | 'both';
+}
+
+export interface MinDistanceOk {
+  readonly kind: 'ok';
+  /** Metres in the render frame. 0 when the two entities touch or overlap. */
+  readonly distance: number;
+  readonly pointA: MeasurePoint3;
+  readonly pointB: MeasurePoint3;
+}
+
+export type MinDistanceResult = MinDistanceOk | MinDistanceRefusal;
+
+/**
+ * Collect one entity's submeshes into a single triangle soup in render-frame
+ * world coordinates.
+ *
+ * Returns `null` when the entity contributes no triangles — either it has no
+ * submeshes at all, or every one of them is degenerate. That is the case the
+ * caller must not confuse with a distance of zero.
+ */
+export function meshForEntity(
+  meshes: readonly MeshData[],
+  entityId: number,
+  modelIndex?: number,
+): { id: string; positions: Float64Array; indices: Uint32Array } | null {
+  const parts = meshes.filter(
+    (m) =>
+      m.expressId === entityId &&
+      // A federated scene reuses express ids across models, so an id alone is
+      // ambiguous. When the caller knows the model, honour it; when it does
+      // not, fall back to id-only rather than silently matching nothing.
+      (modelIndex === undefined || (m.modelIndex ?? 0) === modelIndex) &&
+      m.indices.length >= 3 &&
+      m.positions.length >= 9,
+  );
+  if (parts.length === 0) return null;
+
+  let vertexCount = 0;
+  let indexCount = 0;
+  for (const p of parts) {
+    vertexCount += p.positions.length / 3;
+    indexCount += p.indices.length;
+  }
+
+  const positions = new Float64Array(vertexCount * 3);
+  const indices = new Uint32Array(indexCount);
+
+  let vBase = 0; // vertices written so far, i.e. the rebase offset
+  let pOut = 0;
+  let iOut = 0;
+  for (const part of parts) {
+    // world = origin + position. Each submesh carries its OWN origin; using
+    // the first submesh's origin for all of them displaces every later part.
+    const ox = part.origin ? part.origin[0] : 0;
+    const oy = part.origin ? part.origin[1] : 0;
+    const oz = part.origin ? part.origin[2] : 0;
+
+    for (let i = 0; i < part.positions.length; i += 3) {
+      positions[pOut] = (part.positions[i] as number) + ox;
+      positions[pOut + 1] = (part.positions[i + 1] as number) + oy;
+      positions[pOut + 2] = (part.positions[i + 2] as number) + oz;
+      pOut += 3;
+    }
+    for (let i = 0; i < part.indices.length; i++) {
+      indices[iOut++] = (part.indices[i] as number) + vBase;
+    }
+    vBase += part.positions.length / 3;
+  }
+
+  return { id: `${modelIndex ?? 0}:${entityId}`, positions, indices };
+}
+
+/**
+ * Closest approach between two picked entities.
+ *
+ * Both entities are resolved from the same `MeshData[]` the viewer already
+ * holds, so no re-meshing happens. The witness points come back in the render
+ * frame, ready for `pointCoordinates` without further transformation.
+ */
+export function minDistanceBetweenEntities(
+  meshes: readonly MeshData[],
+  a: { entityId: number; modelIndex?: number },
+  b: { entityId: number; modelIndex?: number },
+): MinDistanceResult {
+  const meshA = meshForEntity(meshes, a.entityId, a.modelIndex);
+  const meshB = meshForEntity(meshes, b.entityId, b.modelIndex);
+
+  if (meshA === null || meshB === null) {
+    const missing = meshA === null && meshB === null ? 'both' : meshA === null ? 'a' : 'b';
+    return { kind: 'refused', missing };
+  }
+
+  const result = minDistanceBetweenMeshes(meshA, meshB);
+  // The predicate's own `null` — reachable only for an empty mesh, which the
+  // guard above already excludes, but propagated rather than assumed away.
+  if (result === null) return { kind: 'refused', missing: 'both' };
+
+  return {
+    kind: 'ok',
+    distance: result.distance,
+    pointA: [result.pointA[0], result.pointA[1], result.pointA[2]],
+    pointB: [result.pointB[0], result.pointB[1], result.pointB[2]],
+  };
+}

--- a/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
@@ -62,6 +62,15 @@
  *    a measurement. The half-metre answer becomes "Infinity m", tagged `ok`.
  *    Both guards below exist for that: reject the geometry going in, and
  *    refuse a non-finite result coming out.
+ *
+ *    Rejection is per submesh, so an entity can lose part of itself and still
+ *    be measurable. That is deliberate — refusing outright would discard
+ *    geometry the user can legitimately measure — but it leaves a quieter
+ *    version of the same problem: the discarded submesh may have been the
+ *    NEARER one, making the reported distance arbitrarily too large while
+ *    looking entirely plausible. So the counts are reported (`dropped`)
+ *    rather than swallowed. This module cannot force a readout to show them,
+ *    but it can refuse to pretend they are zero.
  */
 
 import { minDistanceBetweenMeshes } from '@ifc-lite/clash/contact';
@@ -146,6 +155,21 @@ export interface MinDistanceOk {
   readonly distance: number;
   readonly pointA: MeasurePoint3;
   readonly pointB: MeasurePoint3;
+  /**
+   * Submeshes discarded as corrupt before measuring, per side.
+   *
+   * Either count being non-zero means `distance` is the closest approach of
+   * WHAT SURVIVED, not of the whole entity — and it can be arbitrarily larger
+   * than the truth, because the discarded submesh may have been the nearer
+   * one. Unlike the `Infinity` this module also refuses, that is a plausible
+   * number, so nothing about the value itself reveals the problem.
+   *
+   * Measuring what survives is still the right call — refusing an entity
+   * outright because one submesh is bad would throw away geometry the user
+   * can legitimately measure. Reporting it silently is not. A readout that
+   * ignores this renders a clearance the user may act on.
+   */
+  readonly dropped: { readonly a: number; readonly b: number };
 }
 
 export type MinDistanceResult = MinDistanceOk | MinDistanceRefusal;
@@ -164,8 +188,14 @@ export function meshForEntity(
   meshes: readonly MeshData[],
   entityId: number,
   modelIndex?: number,
-): { id: string; positions: Float64Array; indices: Uint32Array } | null {
-  const parts = meshes.filter(
+): {
+  id: string;
+  positions: Float64Array;
+  indices: Uint32Array;
+  /** Submeshes matched but discarded as corrupt. See `MinDistanceOk.dropped`. */
+  dropped: number;
+} | null {
+  const candidates = meshes.filter(
     (m) =>
       m.expressId === entityId &&
       // A federated scene reuses express ids across models, so an id alone is
@@ -173,9 +203,12 @@ export function meshForEntity(
       // not, fall back to id-only rather than silently matching nothing.
       (modelIndex === undefined || (m.modelIndex ?? 0) === modelIndex) &&
       m.indices.length >= 3 &&
-      m.positions.length >= 9 &&
-      hasUsableCoords(m),
+      m.positions.length >= 9,
   );
+  // Split rather than filter in one pass, because the COUNT is reportable:
+  // measuring against what survives is right, but doing it silently is not.
+  const parts = candidates.filter(hasUsableCoords);
+  const dropped = candidates.length - parts.length;
   if (parts.length === 0) return null;
 
   let vertexCount = 0;
@@ -210,7 +243,7 @@ export function meshForEntity(
     vBase += part.positions.length / 3;
   }
 
-  return { id: `${modelIndex ?? 0}:${entityId}`, positions, indices };
+  return { id: `${modelIndex ?? 0}:${entityId}`, positions, indices, dropped };
 }
 
 /**
@@ -254,5 +287,6 @@ export function minDistanceBetweenEntities(
     distance: result.distance,
     pointA: [result.pointA[0], result.pointA[1], result.pointA[2]],
     pointB: [result.pointB[0], result.pointB[1], result.pointB[2]],
+    dropped: { a: meshA.dropped, b: meshB.dropped },
   };
 }

--- a/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
@@ -47,10 +47,74 @@
  *    this" into "these are touching", which is worse than showing nothing.
  *    The result type below makes that unrepresentable rather than merely
  *    discouraged.
+ *
+ * 4. CORRUPT VERTICES ARE THE VIEWER'S PROBLEM, NOT THE PREDICATE'S. Point (1)
+ *    says this mirrors `boundsFromMeshes`; that rule has a second half, which
+ *    an earlier draft of this module replicated the arithmetic of and dropped.
+ *    `boundsFromMeshes` also discards non-finite and beyond-10 km vertices,
+ *    and the ceiling is shared (`NORMAL_COORD_THRESHOLD_M`) precisely because
+ *    three files had each grown their own copy of it.
+ *
+ *    It matters here more than for a bounding box. `minDistanceBetweenBvhs`
+ *    starts `best.distance` at `Infinity` and lowers it only on
+ *    `r.dist < best.distance`; NaN loses every comparison, so a single NaN
+ *    vertex makes the traversal return its own initialiser as though it were
+ *    a measurement. The half-metre answer becomes "Infinity m", tagged `ok`.
+ *    Both guards below exist for that: reject the geometry going in, and
+ *    refuse a non-finite result coming out.
  */
 
 import { minDistanceBetweenMeshes } from '@ifc-lite/clash/contact';
+import { NORMAL_COORD_THRESHOLD_M } from '@ifc-lite/geometry';
 import type { MeshData } from '@ifc-lite/geometry';
+
+/**
+ * The same vertex test `boundsFromMeshes` applies, against the same shared
+ * ceiling -- `viewportUtils.ts`'s `isValidCoord` is module-private, so this
+ * mirrors it rather than importing it, exactly as `localParsingUtils.ts` and
+ * `useGeometryStreaming.ts` already do.
+ *
+ * Judged in WORLD space, after the origin is added: a real RTC-shifted model
+ * carries a large origin and small positions and stays well inside the
+ * ceiling, so testing raw positions would pass corrupt data and testing the
+ * origin alone would reject good data.
+ */
+function isUsableWorldCoord(x: number, y: number, z: number): boolean {
+  return (
+    Number.isFinite(x) &&
+    Number.isFinite(y) &&
+    Number.isFinite(z) &&
+    Math.abs(x) < NORMAL_COORD_THRESHOLD_M &&
+    Math.abs(y) < NORMAL_COORD_THRESHOLD_M &&
+    Math.abs(z) < NORMAL_COORD_THRESHOLD_M
+  );
+}
+
+/**
+ * Whether every vertex of one submesh survives that test.
+ *
+ * Rejection is per SUBMESH, never per vertex, and that is forced rather than
+ * chosen: `boundsFromMeshes` may skip an individual bad vertex because it only
+ * accumulates a bounding box, whereas dropping one vertex here would shift
+ * every subsequent index and silently corrupt the rebasing below.
+ */
+function hasUsableCoords(part: MeshData): boolean {
+  const ox = part.origin ? part.origin[0] : 0;
+  const oy = part.origin ? part.origin[1] : 0;
+  const oz = part.origin ? part.origin[2] : 0;
+  for (let i = 0; i < part.positions.length; i += 3) {
+    if (
+      !isUsableWorldCoord(
+        (part.positions[i] as number) + ox,
+        (part.positions[i + 1] as number) + oy,
+        (part.positions[i + 2] as number) + oz,
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
 
 /** A point in the viewer's render frame, the same frame `MeshData` uses. */
 export type MeasurePoint3 = readonly [number, number, number];
@@ -59,11 +123,22 @@ export type MeasurePoint3 = readonly [number, number, number];
  * Why a pair could not be measured. Kept as a reason rather than a bare
  * `null` so the readout can say which entity was the problem.
  */
-export interface MinDistanceRefusal {
-  readonly kind: 'refused';
-  /** Which of the two picks had no usable geometry, or 'both'. */
-  readonly missing: 'a' | 'b' | 'both';
-}
+export type MinDistanceRefusal =
+  | {
+      readonly kind: 'refused';
+      readonly reason: 'no-usable-geometry';
+      /** Which of the two picks had no usable geometry, or 'both'. */
+      readonly missing: 'a' | 'b' | 'both';
+    }
+  | {
+      /**
+       * The traversal returned, but not with a real measurement. Carries no
+       * `missing`, because neither pick is the thing at fault -- see the
+       * backstop in `minDistanceBetweenEntities` for what this catches.
+       */
+      readonly kind: 'refused';
+      readonly reason: 'non-finite-distance';
+    };
 
 export interface MinDistanceOk {
   readonly kind: 'ok';
@@ -79,9 +154,11 @@ export type MinDistanceResult = MinDistanceOk | MinDistanceRefusal;
  * Collect one entity's submeshes into a single triangle soup in render-frame
  * world coordinates.
  *
- * Returns `null` when the entity contributes no triangles — either it has no
- * submeshes at all, or every one of them is degenerate. That is the case the
- * caller must not confuse with a distance of zero.
+ * Returns `null` when the entity contributes no USABLE triangles — it has no
+ * submeshes at all, or every one of them is degenerate, or every one of them
+ * carries a vertex the viewer already treats as corrupt (see
+ * `hasUsableCoords`). All three are the case the caller must not confuse with
+ * a distance of zero.
  */
 export function meshForEntity(
   meshes: readonly MeshData[],
@@ -96,7 +173,8 @@ export function meshForEntity(
       // not, fall back to id-only rather than silently matching nothing.
       (modelIndex === undefined || (m.modelIndex ?? 0) === modelIndex) &&
       m.indices.length >= 3 &&
-      m.positions.length >= 9,
+      m.positions.length >= 9 &&
+      hasUsableCoords(m),
   );
   if (parts.length === 0) return null;
 
@@ -152,13 +230,24 @@ export function minDistanceBetweenEntities(
 
   if (meshA === null || meshB === null) {
     const missing = meshA === null && meshB === null ? 'both' : meshA === null ? 'a' : 'b';
-    return { kind: 'refused', missing };
+    return { kind: 'refused', reason: 'no-usable-geometry', missing };
   }
 
   const result = minDistanceBetweenMeshes(meshA, meshB);
   // The predicate's own `null` — reachable only for an empty mesh, which the
   // guard above already excludes, but propagated rather than assumed away.
-  if (result === null) return { kind: 'refused', missing: 'both' };
+  if (result === null) return { kind: 'refused', reason: 'no-usable-geometry', missing: 'both' };
+
+  // A traversal that never completed a comparison still RETURNS, carrying its
+  // `Infinity` initialiser. `minDistanceBetweenBvhs` only overwrites `best` on
+  // `r.dist < best.distance`, and every comparison against NaN is false, so a
+  // non-finite vertex leaves the sentinel in place — and `kind: 'ok'` would
+  // then promise a measurement that was never made. The entry guard above
+  // should make this unreachable; it is asserted rather than assumed because
+  // the cost of being wrong is a readout saying "Infinity m".
+  if (!Number.isFinite(result.distance)) {
+    return { kind: 'refused', reason: 'non-finite-distance' };
+  }
 
   return {
     kind: 'ok',

--- a/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
+++ b/apps/viewer/src/components/viewer/tools/measure-modes/min-distance.ts
@@ -4,7 +4,7 @@
 
 /**
  * Minimum distance between two picked entities — the geometry half of #2737's
- * third item.
+ * second item, "minimum distance between two elements".
  *
  * The hard part already exists: `minDistanceBetweenMeshes` in
  * `@ifc-lite/clash/contact` is an exact branch-and-bound BVH traversal over
@@ -13,8 +13,9 @@
  * write). What was missing is the bridge: the viewer holds `MeshData[]`, and
  * that predicate wants one `Mesh` per entity.
  *
- * Three things make that bridge worth its own tested module rather than a few
- * lines at a call site.
+ * Four things make that bridge worth its own tested module rather than a few
+ * lines at a call site. The fourth arrived from review after the first three
+ * were written, which is why it reads as an afterthought — it is one.
  *
  * 1. AN ENTITY IS USUALLY SEVERAL SUBMESHES, each with its own `origin`. The
  *    world position of a vertex is `origin + position` (per-element local


### PR DESCRIPTION
Refs #2737 — the geometry half of its **second** item, "minimum distance between two elements". The UI wiring follows separately, for a reason at the end.

## What was actually missing

The hard part shipped in #2805: `minDistanceBetweenMeshes` is an exact branch-and-bound BVH traversal over the same `triTriDistance` predicate clash detection uses — so this is **not** a second copy of a distance routine, which #2737 explicitly asked us not to write.

What was missing is the bridge. Nothing in the viewer calls it: `git grep minDistanceBetweenBvhs -- apps` returns nothing, and `MeasureMode` is still `'drag' | 'polyline' | 'angle' | 'radius'`.

## Four things that make this worth a tested module

Each is pinned by a test that fails without it. The fourth was found by review after this PR opened and is written up in its own section below; it is listed here so this list and the module's own header comment agree.

**1. An entity is usually several submeshes, each with its own `origin`.** World position is `origin + position` — the rule `boundsFromMeshes` already applies. Concatenating means adding *each* submesh's own origin and rebasing its indices by the running vertex count. Using the first submesh's origin for all of them, or forgetting to rebase, leaves output that still looks well-formed.

Verified: each mutation fails 2 of the 12 tests. A fixture at the world origin with one submesh per entity would catch **neither** — which is why the fixtures are off-origin and multi-submesh. `measure-modes/radius.ts` records the same lesson from an order-dependent plane that turned a 2 m arc into a 2.8 km one.

**2. No axis conversion, deliberately.** `Mesh` is documented as Z-up; the viewer frame is Y-up. Euclidean distance is **invariant** under that relabeling — it is a rotation, and changes no length. Feeding render-frame vertices straight in means the witness points come back in the frame the readout already uses, with no conversion hop either way. Converting and converting back would be two transforms whose only effect is to cancel, and a transform hop is exactly where (1)'s bug hides. The deviation from the type's stated contract is intentional and documented at the top of the module.

**3. `null` is not zero.** The predicate returns `null` for an empty mesh, *"deliberately distinct from returning 0, which would read as 'they touch'"*. The result is a discriminated union, so `distance ?? 0` — which would render `0.000 m` for something that could not be measured at all — is **not expressible**, rather than merely discouraged.

**4. Corrupt vertices are the viewer's problem, not the predicate's.** Point (1) says this mirrors `boundsFromMeshes`; that rule has a second half, which the first draft of this module dropped. Non-finite and beyond-10 km vertices must be discarded, or a NaN makes the traversal return its own `Infinity` initialiser tagged `ok`. See *Corrupt geometry is refused, not measured* below.

Federated scenes reuse express ids across models, so the lookup takes an optional `modelIndex`; without one it falls back to id-only rather than silently matching nothing. Both are pinned.

## Validated against real geometry, not only the synthetic fixtures

The shipped tests use hand-built single triangles, so I checked the module against a real model — `tests/models/ara3d/duplex.ifc`, parsed through the prebuilt WASM with the same `parseMeshesViaPrePass` the contract script uses. 286 entities, 622 submeshes.

**The per-submesh origin claim is exercised in practice, not just in theory.** 102 of 286 entities have more than one submesh, and **52 of those have submeshes whose origins genuinely differ** — entity 8970, an `IfcStairFlight`, carries 31 submeshes across 31 distinct origins spanning ~4 m of Z. Doors and windows show 2–3 distinct origins for frame/sash/glazing. So the folding this module does is load-bearing on ordinary building geometry; a version that used one origin per entity would be wrong on nearly a fifth of this model.

| check | result |
|---|---|
| two adjacent walls | 3.916 m |
| far-apart walls | 6.756 m |
| model bounding diagonal | ~30.05 m |
| entity against itself | `0`, with `pointA === pointB` |
| symmetry (A,B vs B,A) | identical, witness points swapped |
| repeated identical calls | **bit-identical**, not merely epsilon-close |
| refusals across all 286 entities vs a wall anchor | **zero** |
| timing, one anchor vs all 286 | **0.527 ms/pair average** |

No distance exceeded the bounding diagonal, and no clearly-separated pair returned 0.

Two honest caveats. The `refused` path is unreachable on real entities in this fixture — only a nonexistent express id triggers it — so it stays synthetically tested, which matches the underlying predicate's own note that its `null` is only reachable for an already-excluded empty mesh. And this is one mid-size residential model (39k triangles, entities in the tens-to-hundreds); a dense curved facade or an imported high-poly mesh could behave differently, and the module makes no timing claim.

## Corrupt geometry is refused, not measured (added after review)

An adversarial pass over this module found a real defect, and it is the mirror image of the one the union type was built to prevent.

`meshForEntity` cited `boundsFromMeshes` as the rule it follows and copied only half of it. That function also discards non-finite and beyond-10 km vertices -- the comment *"Skip corrupted vertices (NaN, Inf, or huge coordinates from unshifted data)"* sits at three separate call sites in `viewportUtils.ts`. I replicated the origin arithmetic and dropped the filter.

It matters more here than for a bounding box. `minDistanceBetweenBvhs` seeds `best.distance` with `Infinity` and lowers it only on `r.dist < best.distance`; every comparison against NaN is false, so the seed survives and the traversal returns it **as though it had measured something**. A single NaN vertex produced `{ kind: 'ok', distance: Infinity }` -- which a readout renders as `"Infinity m"`. That is the same class of lie as `distance ?? 0` showing `"0.000 m"` for an unmeasurable pick, which is the entire reason this module returns a union rather than a number.

**Two guards, closing different things.** Entry: reject a submesh whose world-space vertices are non-finite or past `NORMAL_COORD_THRESHOLD_M`. Exit: refuse a non-finite distance -- the entry guard should make it unreachable, so it is asserted rather than assumed.

Rejection is per **submesh**, never per vertex, and that is forced rather than chosen: `boundsFromMeshes` may skip one bad vertex because it only accumulates a box, whereas dropping a vertex here would shift every subsequent index and silently corrupt the rebasing that item (1) above exists to get right.

The test judged in **world** space, after the origin is added. Testing raw positions would pass corrupt data; testing the origin alone would reject an ordinary RTC-shifted model, which carries a large origin and small positions and sits well inside the ceiling. There is a test pinning exactly that case, and it is the one test that must pass with the guard *removed* -- a negative control, not a regression.

**The two halves differ in reachability, and the distinction is worth keeping.** Beyond-10 km is demonstrably reachable: `coordinate-handler.ts` names real UTM/survey models at X: 500,000 m, and the 10 km ceiling had grown into three separate copies before `01ac438c0` unified it. NaN positions have precedent -- `csg/mod.rs` records six `duplex.ifc` wall slices shipping 81 NaN normal components -- but CSG output is now validated, and **I could not find a live producer on the base extraction path**. So that half is an honest defensive guard, not a demonstrated live bug, and this PR should not be read as claiming otherwise.

`MinDistanceRefusal` became a union carrying a `reason`; `missing` is absent on the non-finite variant because neither pick is at fault there. Widening it is free now and expensive later -- `git grep` finds no call site outside this module and its test.

**The guard left a quieter version of the same bug, so `ok` now carries counts.** Rejection is per submesh, which means an entity can lose part of itself and still be measurable -- the right call, since refusing outright would discard geometry the user can legitimately measure. But the discarded submesh may have been the **nearer** one. Constructed case: an entity whose closest submesh carries a NaN and whose far submesh is clean reports `99` when the truth is nearer `5`, tagged `ok`. Unlike `Infinity`, 99 is a plausible number -- nothing about the value reveals that geometry was thrown away, and a clearance check acts on it directly. So `MinDistanceOk` now carries `dropped: { a: number; b: number }`. Behaviour is unchanged; what changes is that the caveat is expressible. This module cannot force a readout to show it, but it can refuse to pretend it is zero.

Counts rather than a boolean, matching the precedent in this same directory: `QuantityRollup.contributing` (`quantities.ts:200`) is a raw count on a successful result, rendered by `MeasureQuantities.tsx:538` as a conditional badge shown only when partial. A boolean would lose the magnitude, which is the first thing a reader wants to know.

*For whoever picks up the wiring PR:* rendering this costs roughly 4 lines per site, and `MeasurePanel.tsx` (760) and `MeasurementVisuals.tsx` (869) are at their caps exactly. It adds nothing to any capped file today, but it is one more thing that PR has to budget for.

**Verification.** 19/19 (12 original, 7 new). Removing both coordinate guards fails 4 of the 5 corruption tests and prints `Infinity` in the assertion diff; hard-coding the `dropped` counts to zero fails the nearer-submesh test. In both mutants the negative-control test still passes, which is the point of it. `check-module-size` exit 0, `0 new over 400`.

One caveat stated plainly: those runs used a copy of the module differing only in where `NORMAL_COORD_THRESHOLD_M` comes from. Local viewer tests cannot import the real module right now for an unrelated reason: Node rejects `geometry/dist/ifc-lite-bridge.js`'s `import init, { IfcAPI } from '@ifc-lite/wasm'` with *"does not provide an export named 'default'"*. **I first wrote that the wasm glue has no default export. That was wrong** -- `packages/wasm/pkg/ifc-lite.js:5397` is `export { initSync, __wbg_init as default };`, and both the workspace symlink and `pkg/package.json` resolve to that file. I had grepped for `export default`, which does not match the `as default` form, and reported the absent match as an absent export. The failure reproduces and is real; its cause is **undiagnosed**, and I am not going to substitute a second guess for the first. `unionEntityBounds.test.ts` fails identically on an unmodified tree, so this is environmental rather than something this branch introduced. CI builds fresh and is the authority.

## Why the UI wiring is not in this PR

Six files the wiring would touch sit at **exactly** their module-size budgets:

`measureHandlers.ts` 715/715 · `MeasurePanel.tsx` 760/760 · `measurementSlice.ts` 820/820 · `MeasurementVisuals.tsx` 869/869 · `measure-modes/radius.ts` 501/501 · `store/types.ts` 689/689

I checked what radius and angle did about this, expecting a precedent. **There isn't one** — the allowlist did not exist when they merged. It was created afterwards (`ab17ac7c`) and snapshotted their growth, so no measure mode has ever faced a live gate. The documented escape hatch (`--allow-raise`, with written justification) exists and has been used, but never for six files at once — that is larger than any raise in the allowlist's history.

That's a call for you, not something to decide inside a feature PR. Options as I see them: a justified multi-file raise; or a pre-refactor first — `MeasurePanel.tsx` has an obvious partial split (the mode-specific formatting helpers `angleHint`/`formatAngleMeasurement`/`formatRadiusPoints`, ~115 lines) that is worth doing regardless but won't by itself free enough room.

**This module stands alone until then**: a tested `entityId × entityId → distance | refusal` function, useful to any caller.

`apps/viewer` 19/19, `check-module-size` exit 0, 292 lines (still under 400, so no allowlist row). No changeset — nothing published changes yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added minimum-distance measurement between selected entities.
  * Measurements support world-space geometry across federated models and multiple submeshes.
  * Results include the closest distance, witness points, and discarded invalid geometry details.
  * Safely handles missing, corrupt, degenerate, or unusable geometry.

* **Tests**
  * Added comprehensive coverage for distance calculations, touching geometry, symmetry, coordinate limits, and invalid geometry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
