### PR TITLE
fix(embed): honour ?autoLoad=false instead of loading anyway (#2934)

### DIFF
--- a/apps/viewer-embed/src/components/EmbedViewer.autoLoad.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.autoLoad.test.ts
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `?autoLoad=false` was parsed and then ignored (#2934).
+ *
+ * `urlParams.test.ts` pins the PARSING of `autoLoad` thoroughly — absent is
+ * `undefined`, `?autoLoad=false` is `false`, anything else is `true`. What
+ * nothing asserted is whether the parsed value is ever *applied*, and it was
+ * not: `EmbedViewer`'s auto-load effect guarded on `modelUrl`, WebGPU support
+ * and `loading`, never on `autoLoad`, so a host that explicitly asked not to
+ * load got the model anyway.
+ *
+ * That is the exact shape #2934 describes, and the reason the bug survived: a
+ * tested parser feeding an untested application.
+ *
+ * TWO tests, and the second is the one that matters. `autoLoad` is
+ * `boolean | undefined`, so the guard has to be `=== false`; the natural
+ * `if (!urlParams.autoLoad) return` would ALSO suppress the default, breaking
+ * every embed that omits the parameter — a far worse bug than the one being
+ * fixed. The default-loads case pins that.
+ *
+ * `useWebGPU` is mocked as supported, and that mock is load-bearing. Under
+ * happy-dom `navigator.gpu` is absent, so the real hook reports
+ * `supported: false` and the auto-load effect returns before reaching the
+ * `autoLoad` check at all. Measured with the mock removed: the two
+ * must-still-load cases FAIL (fetch is never called), and the
+ * `autoLoad=false` case passes for entirely the wrong reason. Without the two
+ * positive cases, this file would look green while proving nothing.
+ */
+
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+
+vi.mock('@/components/viewer/Viewport', () => ({ Viewport: () => null }));
+vi.mock('@/components/viewer/ViewportOverlays', () => ({ ViewportOverlays: () => null }));
+
+// happy-dom has no `navigator.gpu`; without this the effect under test is
+// unreachable and every assertion here would be vacuous.
+vi.mock('@/hooks/useWebGPU', () => ({
+  useWebGPU: () => ({ supported: true, checking: false, reason: null }),
+}));
+
+const loadFile = vi.fn(async () => {});
+vi.mock('@/hooks/useIfc', () => ({
+  useIfc: () => ({
+    geometryResult: null,
+    ifcDataStore: null,
+    loadFile,
+    loading: false,
+    models: new Map(),
+    clearAllModels: vi.fn(),
+    addModel: vi.fn(async () => 'stub-model-id'),
+  }),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const { EmbedViewer } = await import('./EmbedViewer.js');
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+/** `parseUrlParams()` runs once in a `useState` initialiser, so the search
+ *  string has to be in place before the first render. */
+function setSearch(search: string): void {
+  window.history.replaceState({}, '', `/${search}`);
+}
+
+function renderEmbedViewer(): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(EmbedViewer));
+  });
+  mounted.push({ root, container });
+}
+
+/** Let the effect's async IIFE reach its first await. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  fetchSpy = vi.fn(async () => new Response(new ArrayBuffer(8), { status: 200 }));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  loadFile.mockClear();
+  vi.unstubAllGlobals();
+  setSearch('');
+});
+
+describe('EmbedViewer: the autoLoad URL parameter', () => {
+  it('does not fetch the model when autoLoad=false', async () => {
+    setSearch('?modelUrl=https%3A%2F%2Fcdn.example%2Fa.ifc&autoLoad=false');
+    renderEmbedViewer();
+    await settle();
+
+    expect(fetchSpy, 'an explicit autoLoad=false must suppress the fetch').not.toHaveBeenCalled();
+    expect(loadFile).not.toHaveBeenCalled();
+  });
+
+  it('still auto-loads when autoLoad is absent — the default must not regress', async () => {
+    // The case that catches an over-eager guard. `autoLoad` is undefined here,
+    // and `undefined` is falsy: a `!urlParams.autoLoad` check would suppress
+    // loading for every embed that never asked to.
+    setSearch('?modelUrl=https%3A%2F%2Fcdn.example%2Fa.ifc');
+    renderEmbedViewer();
+    await settle();
+
+    expect(fetchSpy, 'omitting autoLoad must keep the existing load behaviour').toHaveBeenCalled();
+  });
+
+  it('still auto-loads for any value other than the literal "false"', async () => {
+    // Mirrors the parser's documented rule, which `urlParams.test.ts` pins:
+    // `?autoLoad=0` is TRUE. A guard written against truthiness of the string
+    // rather than the parsed boolean would get this backwards.
+    setSearch('?modelUrl=https%3A%2F%2Fcdn.example%2Fa.ifc&autoLoad=0');
+    renderEmbedViewer();
+    await settle();
+
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -146,7 +146,7 @@ export function EmbedViewer() {
   // Auto-load model from URL param
   useEffect(() => {
     if (autoLoadAttempted.current) return;
-    if (!urlParams.modelUrl || !webgpu.supported || loading) return;
+    if (!urlParams.modelUrl || urlParams.autoLoad === false || !webgpu.supported || loading) return;
     if (storeModels.size > 0 || geometryResult?.meshes?.length) return;
 
     autoLoadAttempted.current = true;
@@ -169,7 +169,7 @@ export function EmbedViewer() {
         });
       }
     })();
-  }, [urlParams.modelUrl, webgpu.supported, loading, loadFile, storeModels.size, geometryResult?.meshes?.length]);
+  }, [urlParams.modelUrl, urlParams.autoLoad, webgpu.supported, loading, loadFile, storeModels.size, geometryResult?.meshes?.length]);
 
   // Emit progress events to parent
   useEffect(() => {


### PR DESCRIPTION
Refs #2934.

The auto-load effect guarded on `modelUrl`, WebGPU support and `loading` — **never on `autoLoad`**. `grep -n autoLoad EmbedViewer.tsx` matched only the `autoLoadAttempted` ref. A host that explicitly asked not to load got the model regardless.

That is exactly the shape #2934 describes, and the reason it survived: `urlParams.ts`'s **parsing** of `autoLoad` is thoroughly tested, and nothing tested whether the parsed value is ever **applied**. A tested parser feeding an untested application.

## The guard is `=== false`, and that is the whole fix

`autoLoad` is `boolean | undefined`:

| URL | parsed |
|---|---|
| absent | `undefined` |
| `?autoLoad=false` | `false` |
| `?autoLoad=0`, `?autoLoad`, anything else | `true` |

`undefined` is falsy — so the natural `if (!urlParams.autoLoad) return` would **also suppress the default**, breaking every embed that never passed the parameter. That is a far worse bug than the one being fixed, and it is why two of the three new tests assert the *must-still-load* direction rather than the headline case.

## Net zero lines

The condition folds into the existing early return, and `urlParams.autoLoad` joins the existing dependency array. `EmbedViewer.tsx` stays at **484 lines — exactly its module-size budget**, so no ratchet pressure.

## The `useWebGPU` mock is load-bearing, and I checked rather than assumed

Under happy-dom `navigator.gpu` is absent, the real hook reports `supported: false`, and the auto-load effect returns *before* reaching the `autoLoad` check at all.

**Measured with the mock removed:** the two must-still-load cases **fail** (fetch never called) and the `autoLoad=false` case passes for entirely the wrong reason. Without the positive cases this file would look green while proving nothing.

**RED–GREEN:** reverting just the guard fails exactly the `autoLoad=false` case, and leaves both positive cases passing.

## A sharp edge in the parser, surfaced not changed

`?autoLoad=FALSE` (uppercase) parses to **`true`** and loads. The parser is `result.autoLoad = autoLoad !== 'false'` — case-sensitive — and that contract is already deliberate and pinned: `urlParams.test.ts`'s existing case is titled *"treats autoLoad as true unless it is literally `false`"*.

So this is not something this PR introduces or should change; the guard correctly mirrors whatever the parser produces. Flagging it because a host page author writing `?autoLoad=FALSE` would get silent auto-loading, and now that the parameter actually does something, that edge is reachable in a way it was not before. Say the word if you would like it made case-insensitive and I will do it as a separate parser change with its own test.

## Known gap, deliberately not fixed here

With `?modelUrl=...&autoLoad=false` the empty-state hint does **not** render — its condition is `!urlParams.modelUrl`, and `modelUrl` is set. So a direct iframe visitor sees a blank viewport with no explanation.

I left it alone on purpose: that condition is pre-existing and independent of `autoLoad`; the affordance for this case is the SDK's `LOAD_MODEL` command, deferred loading being host-controlled by definition; and fixing it needs line budget in a file already at its cap. Worth your call rather than a half-solution bundled into a bug fix.

`apps/viewer-embed` **152/152** (149 before), `check-module-size` exit 0. No changeset — the embed app is not a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
