### PR TITLE
refactor(export): take step-exporter.ts under the 400-line rule (#2475)

### DIFF
--- a/packages/export/src/delta-empty-shortcircuit.test.ts
+++ b/packages/export/src/delta-empty-shortcircuit.test.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * What a `deltaOnly` export emits when it has nothing to say.
+ *
+ * Read the next paragraph before treating this file as a guard on the
+ * short-circuit in `export()`, because it is not one.
+ *
+ * `export()` returns early with a header-only file when a delta export has no
+ * modified entities, no overlay-created entities and no new georeferencing
+ * lines. Nothing pinned that branch, so before moving it for #2475 I disabled
+ * it (`if (false && …)`) to find out what would notice. Nothing did: the suite
+ * stayed green at 885/885, and it stayed green at 888/888 with the three tests
+ * below added. **The branch is an early-out, not a behaviour** — for a model
+ * with no edits the ordinary path arrives at the same bytes and the same
+ * stats, which is why disabling it changes nothing observable. It cannot be
+ * pinned by a behavioural test, and a test claiming to pin it would be
+ * measuring its own fixture.
+ *
+ * That is worth knowing for the #2475 split specifically: turning this
+ * `return` into a value the caller returns is behaviour-preserving by
+ * construction, not on trust.
+ *
+ * What these tests DO pin is the contract itself, which was genuinely
+ * untested by either route: a delta export of an unedited model emits a
+ * header and an empty DATA section, reports zeroed stats, and reports a
+ * `fileSize` matching the bytes it actually produced. That holds whichever
+ * path computes it, and it would fail if either path stopped holding it.
+ *
+ * Note which existing tests do NOT cover this, since their names suggest they
+ * might: `delta-modification-count.test.ts`'s empty-delta cases and
+ * `step-georeferencing.test.ts`'s deltaOnly block both edit an existing
+ * entity, which populates `pass.modifiedEntities` via `step-collection.ts`, so
+ * the condition is false and neither reaches this state at all. The
+ * counterpart at `step-exporter.test.ts:1250` pins the opposite direction:
+ * overlay-created entities must stop the short-circuit firing.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser } from '@ifc-lite/parser';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { StepExporter } from './step-exporter.js';
+
+const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,$,$);
+#10=IFCWALL('0wall10000000000000000',$,'W',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function store() {
+  return new IfcParser().parseColumnar(new TextEncoder().encode(IFC).buffer, { disableWorkerScan: true });
+}
+
+describe('a deltaOnly export with nothing to say short-circuits', () => {
+  it('emits a header and an empty DATA section, not the model', async () => {
+    // No edits at all: modifiedEntities, overlay-created entities and new
+    // georef lines are all empty, which is the branch's whole condition.
+    const out = new StepExporter(await store(), new MutablePropertyView(null, 'm'))
+      .export({ schema: 'IFC4', deltaOnly: true, applyMutations: true });
+    const text = decode(out.content);
+
+    expect(text).toContain('DATA;');
+    expect(text).toContain('END-ISO-10303-21;');
+    // The model's own entities must NOT be there. Without the short-circuit
+    // the export runs its normal passes and the wall comes back.
+    expect(text).not.toContain('IFCWALL');
+    expect(text).not.toContain('IFCPROJECT');
+  });
+
+  it('reports zeroed stats and a fileSize matching what it actually emitted', async () => {
+    const out = new StepExporter(await store(), new MutablePropertyView(null, 'm'))
+      .export({ schema: 'IFC4', deltaOnly: true, applyMutations: true });
+
+    expect(out.stats.entityCount).toBe(0);
+    expect(out.stats.newEntityCount).toBe(0);
+    expect(out.stats.modifiedEntityCount).toBe(0);
+    // Not a restatement of the branch: `fileSize` is computed from the encoded
+    // bytes, so this catches a rewrite that returns the right stats alongside
+    // the wrong content.
+    expect(out.stats.fileSize).toBe(out.content.byteLength);
+  });
+
+  it('does not short-circuit a full export of the same untouched model', async () => {
+    // The counter-example. Everything above must hold BECAUSE of `deltaOnly`,
+    // not because an unedited model exports as empty.
+    const out = new StepExporter(await store(), new MutablePropertyView(null, 'm'))
+      .export({ schema: 'IFC4', applyMutations: true });
+
+    expect(decode(out.content)).toContain('IFCWALL');
+    expect(out.stats.entityCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/export/src/entity-iteration.test.ts
+++ b/packages/export/src/entity-iteration.test.ts
@@ -7,7 +7,9 @@
  * indirectly — dropping `yield* deferred` fails four exporter tests — but its
  * `size` is not: reporting only the primary index's size left the whole suite
  * green, and `size` is what `StepExporter`/`MergedExporter` report as the
- * export's entity total (`step-exporter.ts:1069`, `merged-exporter.ts:611`).
+ * export's entity total -- `entityCount: pass.entities.length` in
+ * `step-header.ts`'s `assembleExportResult`, and the matching count in
+ * `merged-exporter.ts`.
  *
  * A user with a `deferPropertyAtomIndex` parse sees an export summary that
  * undercounts by every deferred property atom — thousands on a real file —

--- a/packages/export/src/includegeometry-header-count.test.ts
+++ b/packages/export/src/includegeometry-header-count.test.ts
@@ -9,8 +9,9 @@
  * (and, since the sibling fix in this PR, by the `visibleOnly` closure) but
  * never consult `options.includeGeometry`. The source-iteration pass, and
  * the overlay new-entities pass, both separately skip a geometry-classified
- * entity when `includeGeometry === false` (`isGeometryEntity` checks at
- * step-exporter.ts:840 and :1004) — so a geometry entity carrying an
+ * entity when `includeGeometry === false` (the `isGeometryEntity` checks in
+ * `step-pass-builder.ts`'s `isGeometryExcluded` and in
+ * `step-overlay-entities.ts`) — so a geometry entity carrying an
  * attribute edit had its line dropped from `DATA` while the header still
  * counted it as a modification, the exact class of mismatch the rest of
  * this file guards.

--- a/packages/export/src/owner-history.test.ts
+++ b/packages/export/src/owner-history.test.ts
@@ -102,3 +102,76 @@ describe('StepExporter — generated psets inherit the host element owner histor
     expect(danglingRefs(out)).toEqual([]);
   });
 });
+
+// Same two owner histories, but the wall carries NEITHER (`$`), so a generated
+// pset has to go through the FALLBACK path — the first owner history that
+// survives this export — rather than inheriting one from its host.
+const IFC_FALLBACK_OH = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,$,$);
+#2=IFCORGANIZATION($,'Org',$,$,$);
+#3=IFCPERSONANDORGANIZATION($,#2,$);
+#4=IFCAPPLICATION(#2,'1','app','app');
+#5=IFCOWNERHISTORY(#3,#4,$,.ADDED.,$,$,$,0);
+#6=IFCOWNERHISTORY(#3,#4,$,.MODIFIED.,$,$,$,1);
+#10=IFCWALL('0wall10000000000000000',$,'W',$,$,$,$,$,$);
+#20=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.F.),$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe('StepExporter — the owner-history caches are per export, not per exporter', () => {
+  /**
+   * `export()` clears `ownerHistory.fallbackRef` and `ownerHistory.byEntity` on
+   * entry, because both depend on `willBeEmitted` and therefore on THIS call's
+   * options and on whatever the shared `MutablePropertyView` has since deleted.
+   *
+   * That guard is ALREADY pinned, by `overlay-effective-model.test.ts`'s "does
+   * not answer a second export from the first one's owner-history cache" — a
+   * mutation neutralising the two reset statements kills that test too, not
+   * only this one. This is a second angle on it rather than a new pin, and the
+   * distinction is worth stating so nobody reads this file as the safety net.
+   *
+   * What this adds is the OTHER route to the cache and a stronger assertion.
+   * The existing test reaches the stale cache through overlay deletion and
+   * checks a count; here the host element carries `$` for its own owner
+   * history, so the generated pset must go through the fallback SCAN — "first
+   * owner history that survives this export" — and the check is structural:
+   * `danglingRefs` must stay empty. A stale fallback stamps an id whose line
+   * the second export no longer contains, which is invalid STEP rather than
+   * merely a wrong count.
+   *
+   * Note what does NOT reach this: `visibleOnly`, which the reset's own comment
+   * offers as its example. `IFCOWNERHISTORY` is in `reference-collector.ts`'s
+   * `INFRASTRUCTURE_TYPES` (:54), so hiding entities does not change whether an
+   * owner history is emitted. Deletion through the mutation view is the lever
+   * both tests actually use.
+   */
+  it('re-derives the fallback owner history after the first choice is deleted', async () => {
+    const store = await new IfcParser().parseColumnar(new TextEncoder().encode(IFC_FALLBACK_OH).buffer, { disableWorkerScan: true });
+    const view = new MutablePropertyView(null, 'm');
+    view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+    view.setProperty(10, 'Pset_WallCommon', 'IsExternal', true, PropertyValueType.Boolean);
+
+    const exporter = new StepExporter(store, view);
+
+    const out1 = decode(exporter.export({ schema: 'IFC4', applyMutations: true }).content);
+    // #5 is the first surviving owner history, so the fallback picks it.
+    expect(out1).toMatch(/=IFCPROPERTYSET\('.{22}',#5,'Pset_WallCommon'/);
+    expect(danglingRefs(out1)).toEqual([]);
+
+    // The caller keeps editing the same view between exports.
+    view.deleteEntity(5);
+
+    const out2 = decode(exporter.export({ schema: 'IFC4', applyMutations: true }).content);
+    // Must re-scan and land on #6. Without the reset this still says #5, whose
+    // line the second export no longer contains.
+    expect(out2).toMatch(/=IFCPROPERTYSET\('.{22}',#6,'Pset_WallCommon'/);
+    expect(out2).not.toMatch(/=IFCPROPERTYSET\('.{22}',#5,/);
+    expect(danglingRefs(out2)).toEqual([]);
+  });
+});

--- a/packages/export/src/parquet-exporter.test.ts
+++ b/packages/export/src/parquet-exporter.test.ts
@@ -438,8 +438,9 @@ function buildDataStoreWithById(): MockDataStore {
 
 describe('ParquetExporter overlay retypes', () => {
   // StepExporter/Ifc5Exporter resolve `effective.typeOf(id)` before emitting
-  // an entity's class (step-exporter.ts:961, `effectiveType = typeMut?.newType
-  // ?? entity.type`), so a `setEntityType` retype changes what those two
+  // an entity's class (`const effectiveType = typeMut?.newType ?? entity.type`
+  // in `step-overlay-entities.ts`), so a `setEntityType` retype changes what
+  // those two
   // exporters write. `writeEntities` filters rows by `effective.isDeleted`
   // (the #2046 fix); before this fix it still read `Type` straight off
   // `entities.typeEnum` — the SOURCE class — never consulting the same

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -682,7 +682,7 @@ export function filterHiddenRefsFromRelationshipLine(
  * AdditionalConditions, SupportedLength, ConditionCoordinateSystem`) is
  * declared `OPTIONAL IfcAxis2Placement3D` in both IFC4 (`IFC4_ADD2_TC1.exp`
  * line 8523) and IFC4X3 (`IFC4X3.exp` line 9774), and `IFCAXIS2PLACEMENT3D`
- * is the one entry in {@link StepExporter.isGeometryEntity}'s allowlist an
+ * is the one entry in {@link isGeometryEntity}'s allowlist (`@ifc-lite/export`'s `step-geometry-types.ts`) an
  * `IFCREL*` line can name in a single-valued slot — re-derived by scanning
  * every `IFCREL*` attribute in both schema files against that allowlist
  * (`scripts/` has no permanent copy of this scan; it was run ad hoc against

--- a/packages/export/src/relationship-filter-gate.test.ts
+++ b/packages/export/src/relationship-filter-gate.test.ts
@@ -208,7 +208,7 @@ describe('the relationship filter runs when the overlay is active', () => {
  *
  * IFC4 `IfcRelConnectsStructuralMember.ConditionCoordinateSystem` is an
  * optional `IfcAxis2Placement3D`, and `IFCAXIS2PLACEMENT3D` is in
- * `StepExporter.isGeometryEntity`'s set — so a schema-valid file has an
+ * `isGeometryEntity`'s set (`step-geometry-types.ts`) — so a schema-valid file has an
  * `IFCREL*` line naming an entity `includeGeometry: false` omits. Nothing
  * contrived is needed to reach it.
  */

--- a/packages/export/src/step-collection.ts
+++ b/packages/export/src/step-collection.ts
@@ -18,10 +18,13 @@
  * `collectPropertyAndQuantitySetMutations`) it was already handing them to.
  *
  * `hasAnyUnreadableSourceRef` and the `mayNameOmittedRefs` /
- * `isOmittedFromOutput` predicates it feeds stay in `step-exporter.ts`:
- * they read `pass.effective` and this phase's OUTPUT (`allowedEntityIds`,
- * `overlayActive`), but nothing here reads them back, so moving them here
- * would not shrink a dependency, only relocate it.
+ * `isOmittedFromOutput` predicates it feeds do NOT live here: they read
+ * `pass.effective` and this phase's OUTPUT (`allowedEntityIds`,
+ * `overlayActive`), but nothing in THIS module reads them back, so moving them
+ * here would not shrink a dependency, only relocate it. That argument was
+ * always about this module specifically. They live in
+ * `step-omission-predicates.ts`, called from `export()` immediately after this
+ * phase returns (#2475).
  */
 
 import type { IfcDataStore } from '@ifc-lite/parser';

--- a/packages/export/src/step-export-contexts.ts
+++ b/packages/export/src/step-export-contexts.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The per-phase contexts that do NOT allocate express ids.
+ *
+ * Split out of `StepExporter` for #2475. These two are pure forwarders: they
+ * assemble what a phase cannot read off the pass, out of values handed to
+ * them, and touch no exporter state of their own.
+ *
+ * WHY ONLY THESE TWO. `georefContext` and `propertySetContext` stay methods on
+ * `StepExporter`, and `collectionContext` stays with them because it forwards
+ * to both. Those two are the only places that mint express ids, via
+ * `allocateExpressId: () => this.nextExpressId++` — two closures over ONE
+ * instance counter. Moving them would mean re-establishing that shared
+ * identity through a parameter, and capturing the counter's value instead of
+ * its closure gives each builder its own sequence and silently emits two
+ * entities with the same `#N`. Nothing in the suite currently catches a
+ * duplicate express id (`findDanglingRefs` collects ids into a `Set`, which
+ * absorbs the duplicate), so the cost of getting it wrong is invisible.
+ *
+ * That is the whole reason this module holds two functions rather than five.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import { applySourceLineMutations, applyOverlayEntityOverrides } from './step-attribute-mutations.js';
+import { relationshipWithheldWarning } from './step-export-types.js';
+import { isGeometryEntity } from './step-geometry-types.js';
+import type { SourceIterationContext } from './step-source-iteration.js';
+import type { OverlayEntitiesContext } from './step-overlay-entities.js';
+import type { PropertySetContext } from './step-property-sets.js';
+
+/**
+   * The state `step-source-iteration.ts` cannot read off the pass (#2475 2d).
+   *
+   * No `allocateExpressId`: that phase never allocates an id, it only rewrites
+   * lines that already have one. `applySourceLineMutations` (#2475, remaining
+   * private helpers: now a free function in `step-attribute-mutations.ts`,
+   * closed over `this.mutationView` here) and `isGeometryEntity` are injected
+   * rather than read off the pass because each has readers outside this
+   * phase — the mutation pipeline is shared with the type-object
+   * `HasPropertySets` rewrite (see {@link propertySetContext}) and with the
+   * overlay-created-entities block in `export()`; `isGeometryEntity` with the
+   * visible-only setup closure and that same block.
+   */
+export function buildSourceIterationContext(
+dataStore: IfcDataStore,
+mutationView: MutablePropertyView | null,
+propertySetContext: () => PropertySetContext,
+): SourceIterationContext {
+  return {
+  dataStore,
+    applySourceLineMutations: (expressId, entityText, recordType, attributeMutations, sourceSchema, overlayActive, onRejected) =>
+      applySourceLineMutations(mutationView, expressId, entityText, recordType, attributeMutations, sourceSchema, overlayActive, onRejected),
+    isGeometryEntity,
+  propertySetContext,
+    relationshipWithheldWarning,
+  };
+}
+
+/**
+   * The state `step-overlay-entities.ts` cannot read off the pass (#2475
+   * step 2e). `applyOverlayEntityOverrides` is now the free function
+   * `step-attribute-mutations.ts` exports (#2475, remaining private
+   * helpers) — it and its two `serializeNamedAttribute` /
+   * `serializePositionalOverride` helpers moved together, since those two
+   * have no reader outside this cluster; `isGeometryEntity` and
+   * `relationshipWithheldWarning` are the same shared readers
+   * {@link sourceIterationContext} already injects into the other output
+   * pass.
+   */
+export function buildOverlayEntitiesContext(
+mutationView: MutablePropertyView | null,
+): OverlayEntitiesContext {
+  return {
+  mutationView,
+    applyOverlayEntityOverrides,
+    isGeometryEntity,
+    relationshipWithheldWarning,
+  };
+}

--- a/packages/export/src/step-export-contexts.ts
+++ b/packages/export/src/step-export-contexts.ts
@@ -15,12 +15,20 @@
  * `allocateExpressId: () => this.nextExpressId++` — two closures over ONE
  * instance counter. Moving them would mean re-establishing that shared
  * identity through a parameter, and capturing the counter's value instead of
- * its closure gives each builder its own sequence and silently emits two
- * entities with the same `#N`. Nothing in the suite currently catches a
- * duplicate express id (`findDanglingRefs` collects ids into a `Set`, which
- * absorbs the duplicate), so the cost of getting it wrong is invisible.
+ * its closure gives each builder its own sequence, silently emitting two
+ * entities with the same `#N` — well-formed STEP in which every reference
+ * still resolves, and two different entities.
  *
- * That is the whole reason this module holds two functions rather than five.
+ * That failure used to be invisible: `findDanglingRefs` collects defined ids
+ * into a `Set`, which absorbs a duplicate rather than reporting it. It is now
+ * caught — `step-georeferencing.test.ts`'s "mints distinct ids for generated
+ * psets and for created georeferencing" drives both allocating paths in one
+ * export and asserts no id is defined twice. Freezing both closures fails that
+ * test and only that test.
+ *
+ * So the reason this module holds two functions rather than five is written
+ * down here AND checkable, which is the only reason it is safe to leave the
+ * other three where they are.
  */
 
 import type { IfcDataStore } from '@ifc-lite/parser';
@@ -33,50 +41,52 @@ import type { OverlayEntitiesContext } from './step-overlay-entities.js';
 import type { PropertySetContext } from './step-property-sets.js';
 
 /**
-   * The state `step-source-iteration.ts` cannot read off the pass (#2475 2d).
-   *
-   * No `allocateExpressId`: that phase never allocates an id, it only rewrites
-   * lines that already have one. `applySourceLineMutations` (#2475, remaining
-   * private helpers: now a free function in `step-attribute-mutations.ts`,
-   * closed over `this.mutationView` here) and `isGeometryEntity` are injected
-   * rather than read off the pass because each has readers outside this
-   * phase — the mutation pipeline is shared with the type-object
-   * `HasPropertySets` rewrite (see `StepExporter`'s `propertySetContext`, which
-   * stays a method because it mints express ids) and with the
-   * overlay-created-entities block in `export()`; `isGeometryEntity` with the
-   * visible-only setup closure and that same block.
-   */
+ * The state `step-source-iteration.ts` cannot read off the pass (#2475 2d).
+ *
+ * No `allocateExpressId`: that phase never allocates an id, it only rewrites
+ * lines that already have one. `applySourceLineMutations` (a free function in
+ * `step-attribute-mutations.ts`, closed over `mutationView` here) and
+ * `isGeometryEntity` are injected rather than read off the pass because each
+ * has readers outside this phase — the mutation pipeline is shared with the
+ * type-object `HasPropertySets` rewrite (see `StepExporter`'s
+ * `propertySetContext`, which stays a method because it mints express ids) and
+ * with the overlay-created-entities block in `export()`; `isGeometryEntity`
+ * with the visible-only setup closure and that same block.
+ *
+ * `propertySetContext` arrives as a THUNK, not a value: the phase calls it
+ * per use and the original method rebuilt it per call, which is the behaviour
+ * being preserved.
+ */
 export function buildSourceIterationContext(
-dataStore: IfcDataStore,
-mutationView: MutablePropertyView | null,
-propertySetContext: () => PropertySetContext,
+  dataStore: IfcDataStore,
+  mutationView: MutablePropertyView | null,
+  propertySetContext: () => PropertySetContext,
 ): SourceIterationContext {
   return {
-  dataStore,
+    dataStore,
     applySourceLineMutations: (expressId, entityText, recordType, attributeMutations, sourceSchema, overlayActive, onRejected) =>
       applySourceLineMutations(mutationView, expressId, entityText, recordType, attributeMutations, sourceSchema, overlayActive, onRejected),
     isGeometryEntity,
-  propertySetContext,
+    propertySetContext,
     relationshipWithheldWarning,
   };
 }
 
 /**
-   * The state `step-overlay-entities.ts` cannot read off the pass (#2475
-   * step 2e). `applyOverlayEntityOverrides` is now the free function
-   * `step-attribute-mutations.ts` exports (#2475, remaining private
-   * helpers) — it and its two `serializeNamedAttribute` /
-   * `serializePositionalOverride` helpers moved together, since those two
-   * have no reader outside this cluster; `isGeometryEntity` and
-   * `relationshipWithheldWarning` are the same shared readers
-   * {@link buildSourceIterationContext} already injects into the other output
-   * pass.
-   */
+ * The state `step-overlay-entities.ts` cannot read off the pass (#2475
+ * step 2e). `applyOverlayEntityOverrides` is the free function
+ * `step-attribute-mutations.ts` exports — it and its two
+ * `serializeNamedAttribute` / `serializePositionalOverride` helpers moved
+ * together, since those two have no reader outside this cluster;
+ * `isGeometryEntity` and `relationshipWithheldWarning` are the same shared
+ * readers {@link buildSourceIterationContext} already injects into the other
+ * output pass.
+ */
 export function buildOverlayEntitiesContext(
-mutationView: MutablePropertyView | null,
+  mutationView: MutablePropertyView | null,
 ): OverlayEntitiesContext {
   return {
-  mutationView,
+    mutationView,
     applyOverlayEntityOverrides,
     isGeometryEntity,
     relationshipWithheldWarning,

--- a/packages/export/src/step-export-contexts.ts
+++ b/packages/export/src/step-export-contexts.ts
@@ -41,7 +41,8 @@ import type { PropertySetContext } from './step-property-sets.js';
    * closed over `this.mutationView` here) and `isGeometryEntity` are injected
    * rather than read off the pass because each has readers outside this
    * phase — the mutation pipeline is shared with the type-object
-   * `HasPropertySets` rewrite (see {@link propertySetContext}) and with the
+   * `HasPropertySets` rewrite (see `StepExporter`'s `propertySetContext`, which
+   * stays a method because it mints express ids) and with the
    * overlay-created-entities block in `export()`; `isGeometryEntity` with the
    * visible-only setup closure and that same block.
    */
@@ -68,7 +69,7 @@ propertySetContext: () => PropertySetContext,
    * `serializePositionalOverride` helpers moved together, since those two
    * have no reader outside this cluster; `isGeometryEntity` and
    * `relationshipWithheldWarning` are the same shared readers
-   * {@link sourceIterationContext} already injects into the other output
+   * {@link buildSourceIterationContext} already injects into the other output
    * pass.
    */
 export function buildOverlayEntitiesContext(

--- a/packages/export/src/step-export-types.ts
+++ b/packages/export/src/step-export-types.ts
@@ -15,15 +15,16 @@
  */
 
 import type { IfcAttributeValue, IfcSourceHeader, MapConversion, ProjectedCRS } from '@ifc-lite/parser';
-import type { MutablePropertyView } from '@ifc-lite/mutations';
 import type { PropertySet, QuantitySet } from '@ifc-lite/data';
 import type { RandomSource } from '@ifc-lite/encoding';
 import type { IfcSchemaVersion } from './schema-converter.js';
 import type { ModificationLedger, SourceLineDelivery } from './delta-modification-ledger.js';
 import type { EffectiveEntityIndex } from './effective-index.js';
-// A value, not a type: `ExportPass.isReadableSourceRef` is typed as
-// `ReturnType<typeof createSourceRefReader>` rather than restating the shape,
-// so the reader and its consumers cannot drift apart.
+// A function, referenced only in type position: `ExportPass.isReadableSourceRef`
+// is `ReturnType<typeof createSourceRefReader>` rather than a restatement of the
+// shape, so the reader and its consumers cannot drift apart. `import type` is
+// therefore correct and deliberate -- nothing here calls it, and the import
+// erases.
 import type { createSourceRefReader } from './source-ref-bounds.js';
 
 /**

--- a/packages/export/src/step-export-types.ts
+++ b/packages/export/src/step-export-types.ts
@@ -1,0 +1,274 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The vocabulary of a STEP export: what a caller asks for, what it gets back,
+ * and the state one `export()` call threads through its phases.
+ *
+ * Split out of `step-exporter.ts` for #2475. These are declarations only -- no
+ * behaviour lives here beyond one message builder -- which is why they could
+ * move without touching a single guard. The seven sibling modules that already
+ * import `ExportPass` and `SourceLineMutations` keep importing them from
+ * `step-exporter.js`, which re-exports this file, so no call site moved with
+ * them and the package's public entry point is untouched.
+ */
+
+import type { IfcAttributeValue, IfcSourceHeader, MapConversion, ProjectedCRS } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import type { PropertySet, QuantitySet } from '@ifc-lite/data';
+import type { RandomSource } from '@ifc-lite/encoding';
+import type { IfcSchemaVersion } from './schema-converter.js';
+import type { ModificationLedger, SourceLineDelivery } from './delta-modification-ledger.js';
+import type { EffectiveEntityIndex } from './effective-index.js';
+// A value, not a type: `ExportPass.isReadableSourceRef` is typed as
+// `ReturnType<typeof createSourceRefReader>` rather than restating the shape,
+// so the reader and its consumers cannot drift apart.
+import type { createSourceRefReader } from './source-ref-bounds.js';
+
+/**
+ * Options for STEP export
+ */
+export interface StepExportOptions {
+  /** IFC schema version for the output file (any version, will convert if needed) */
+  schema: 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
+  /** File description */
+  description?: string;
+  /** Author name */
+  author?: string;
+  /** Organization name */
+  organization?: string;
+  /** Application name (defaults to 'ifc-lite') */
+  application?: string;
+  /** Output filename */
+  filename?: string;
+
+  /** Include original geometry entities (default: true) */
+  includeGeometry?: boolean;
+  /** Include property sets (default: true) */
+  includeProperties?: boolean;
+  /** Include quantity sets (default: true) */
+  includeQuantities?: boolean;
+  /** Include relationships (default: true) */
+  includeRelationships?: boolean;
+
+  /** Apply mutations from MutablePropertyView (default: true if provided) */
+  applyMutations?: boolean;
+  /** Only export entities with mutations (delta export) */
+  deltaOnly?: boolean;
+
+  /** Only export entities currently visible in the viewer */
+  visibleOnly?: boolean;
+  /** Hidden entity IDs (local expressIds) — required when visibleOnly is true */
+  hiddenEntityIds?: Set<number>;
+  /** Isolated entity IDs (local expressIds, null = no isolation active) */
+  isolatedEntityIds?: Set<number> | null;
+
+  /** Georeferencing mutations to apply (IfcProjectedCRS / IfcMapConversion edits) */
+  georefMutations?: {
+    projectedCRS?: Partial<ProjectedCRS>;
+    mapConversion?: Partial<MapConversion>;
+  };
+
+  /**
+   * Seeded randomness for the GlobalIds this exporter SYNTHESIZES:
+   * the `IfcPropertySet` / `IfcElementQuantity` roots regenerated for
+   * mutated (or overlay-created) property and quantity sets, their
+   * `IfcRelDefinesByProperties` links. Without it those come from the platform
+   * CSPRNG, so two exports of the same model differ in exactly those bytes -
+   * which breaks byte-reproducibility for in-store builds that call
+   * `addPropertySet` / `addQuantitySet` (the sets themselves live in the
+   * mutation overlay and only become IFC roots here). Pass the same seeded
+   * source used for `SpatialAnchor.guidRandom` to close that gap. Default
+   * (omitted) behaviour for THESE ids is unchanged: random.
+   *
+   * NOT the `IFCPROXY` placeholders any more (#2733). Those used to be minted
+   * from this source too, so an omitted `guidRandom` made every downgraded
+   * IFC4X3 entity differ on re-export. They are now derived from the source
+   * line when this is omitted, and only fall back to this source when it is
+   * supplied - so passing a seeded source still pins them, but NOT passing one
+   * no longer makes them random. See `convertStepLine`.
+   */
+  guidRandom?: RandomSource;
+  /**
+   * Pin the STEP header `FILE_NAME` timestamp (STEP format, e.g.
+   * `20240101T000000`). Omitted = the wall clock, as before. Required for
+   * genuinely byte-identical exports, since the header otherwise carries the
+   * export instant.
+   */
+  timeStamp?: string;
+
+  /** Progress callback for async export */
+  onProgress?: (progress: StepExportProgress) => void;
+}
+
+/**
+ * Progress information during STEP export
+ */
+export interface StepExportProgress {
+  /** Current phase of export */
+  phase: 'preparing' | 'entities' | 'assembling';
+  /** Progress 0-1 */
+  percent: number;
+  /** Number of entities processed so far */
+  entitiesProcessed: number;
+  /** Total entities to process */
+  entitiesTotal: number;
+}
+
+/**
+ * Result of STEP export
+ */
+export interface StepExportResult {
+  /** STEP file content as bytes (avoids V8 string length limit for large files) */
+  content: Uint8Array;
+  /** Statistics about the export */
+  stats: {
+    /** Total entities exported */
+    entityCount: number;
+    /** New entities created for mutations */
+    newEntityCount: number;
+    /** Entities modified by mutations */
+    modifiedEntityCount: number;
+    /** File size in bytes */
+    fileSize: number;
+    /**
+     * Non-fatal refusals: things the caller asked for that this export could
+     * not write. Empty when the export did everything it was asked to do.
+     *
+     * A requested `georefMutations.mapConversion` is one case: with no
+     * `IfcGeometricRepresentationContext` to reference as `SourceCRS`, the
+     * `IfcMapConversion` is skipped (writing it would produce a dangling
+     * reference) while the `IfcProjectedCRS` is still written — so the output
+     * is indistinguishable from "no map conversion was requested" unless the
+     * caller reads this (#2067).
+     *
+     * A WITHHELD RELATIONSHIP is the other: when a relationship names an
+     * entity this export is not writing, in a slot with no spelling for an
+     * omitted reference, the whole relationship line is dropped rather than
+     * shipped dangling — see {@link relationshipWithheldWarning}. This can
+     * happen on a plain full export with no options set at all, so it is
+     * reported rather than left to be discovered by a diff.
+     *
+     * Same `string[]` shape as `MergeExportResult.stats.warnings`.
+     */
+    warnings: string[];
+  };
+}
+
+/**
+ * Message for a relationship this export DROPPED rather than rewrote.
+ *
+ * `filterHiddenRefsFromRelationshipLine` removes an omitted `#N` from a
+ * SET/LIST attribute, but a single-valued attribute has no STEP spelling for
+ * "omitted" and an empty SET is not the same statement as the original — so in
+ * both of those cases it withholds the whole line and the relationship simply
+ * is not in the output. Withholding beats shipping a dangling `#N`, but it is
+ * not free: every OTHER entity that relationship named loses the association.
+ * A visible element can therefore come out of a plain full export with one
+ * fewer pset than it went in with, and before this warning existed nothing in
+ * the result said so (adversarial review of #2668).
+ *
+ * Deliberately reports the relationship rather than the omitted target: the
+ * target's own omission is already the caller's own doing in every reason but
+ * the unreadable-ref one, whereas the lost association is the surprise.
+ */
+export const relationshipWithheldWarning = (expressId: number, type: string): string =>
+  `Relationship #${expressId} (${type}) was withheld from the export: it names at least one entity that has no line in this export, in a slot with no spelling for an omitted reference (a single-valued attribute, or a set whose every member is omitted). Anything else that relationship associated is no longer associated in the output.`;
+
+/**
+ * What `step-attribute-mutations.ts`'s `applySourceLineMutations` produced: the rewritten
+ * line, plus which edit kinds that rewrite actually delivered. The delivery
+ * half is {@link SourceLineDelivery} rather than three loose booleans so that
+ * the pipeline and the ledger cannot disagree about what a source line carries
+ * — an added kind has one place to be added.
+ */
+export type SourceLineMutations = SourceLineDelivery & { text: string };
+
+/**
+ * The state one `export()` call shares across its seven phases.
+ *
+ * Introduced by step 1 of #2475: `export()` is ~1267 lines and the phases a
+ * split would separate are held together by ~30 local bindings, most of which
+ * are read in three or more phases. Naming that set once — as an interface
+ * with a single construction site at the top of `export()` — is what lets a
+ * later phase extraction take one parameter instead of fifteen.
+ *
+ * Two properties of this object are load-bearing and must survive every later
+ * move:
+ *
+ * 1. **The predicates are members, not duplicated expressions.** Six of them
+ *    (`isOverlayCreated`, `isReadableSourceRef`, `isGeometryExcluded`,
+ *    `hasEmittableHostBytes`, `willBeEmitted`,
+ *    `isRefExcludedDuringClosureWalk`) exist precisely so two phases cannot
+ *    disagree about a gate — see the comments at their construction sites for
+ *    the corrupt files the earlier, per-phase versions let through (#2491,
+ *    #2414, #2398, #2637). A phase that reimplements one of these instead of
+ *    reading it off the pass reintroduces exactly that class of defect.
+ * 2. **`allowedEntityIds` and `hiddenProductIds` are mutable, and the
+ *    predicates close over the pass rather than over a snapshot.** The
+ *    visible-only closure walk assigns both AFTER construction, and
+ *    `isRefExcludedDuringClosureWalk` is handed to that walk while they are
+ *    still null. The output-line filter reads them too, through
+ *    `isOmittedFromOutput` -> `willBeEmitted`, so neither can be a snapshot
+ *    taken before the walk ran — that is the invariant the #2637 regression
+ *    broke.
+ *
+ * Deliberately NOT on the pass, and why: `isOmittedFromOutput`,
+ * `mayNameOmittedRefs` and
+ * `overlayNewEntityCount` are eagerly-computed values whose value is only
+ * defined after work that runs past this construction site, so hoisting them
+ * would change what they compute rather than where they are named;
+ * `generatedTypeOwnedPsetIds` is read in one phase only — a local inside
+ * `step-property-sets.ts:generatePropertyAndQuantitySetEntities`, which holds
+ * both the loop that writes it and the loop that reads it (#2475).
+ */
+export interface ExportPass {
+  /** Output accumulator: every DATA-section line this export will write. */
+  readonly entities: string[];
+  /** Lines contributed by entities that have no source record. */
+  newEntityCount: number;
+
+  // ---- resolved options / schema ----
+  readonly schema: IfcSchemaVersion;
+  readonly sourceSchema: IfcSchemaVersion;
+  readonly converting: boolean;
+  readonly sourceHeader: IfcSourceHeader | undefined;
+  readonly schemaToken: string;
+  readonly overlayActive: boolean;
+
+  // ---- indexes and ledgers ----
+  readonly effective: EffectiveEntityIndex;
+  readonly modifications: ModificationLedger;
+  /** Widened from the imported `InPlaceNominees` (whose sets are readonly)
+   *  because the collection passes below add to them. */
+  readonly inPlaceNominees: { attribute: Set<number>; georeferencing: Set<number> };
+
+  // ---- visible-only closure results (assigned after construction) ----
+  allowedEntityIds: Set<number> | null;
+  hiddenProductIds: ReadonlySet<number> | null;
+
+  // ---- the collection passes' output ----
+  readonly modifiedEntities: Set<number>;
+  readonly modifiedAttributes: Map<number, Map<string, string>>;
+  readonly newPropertySets: Array<{ entityId: number; psets: PropertySet[] }>;
+  readonly newQuantitySets: Array<{ entityId: number; qsets: QuantitySet[] }>;
+  readonly typeOwnedPsetNamesByEntity: Map<number, Set<string>>;
+  readonly typeOwnedPsetIdsByEntity: Map<number, number[]>;
+  readonly rewrittenEntityIds: Set<number>;
+  readonly rewrittenEntityLines: Map<number, string>;
+  readonly overlayTypeOwnedPsets: Map<number, IfcAttributeValue>;
+  readonly skipPropertySetIds: Set<number>;
+  readonly skipRelationshipIds: Set<number>;
+  readonly newGeorefLines: string[];
+  readonly warnings: string[];
+
+  // ---- the shared predicates (see item 1 above) ----
+  readonly buildHeader: (modifications: number) => string;
+  readonly isOverlayCreated: (entityId: number) => boolean;
+  readonly isReadableSourceRef: ReturnType<typeof createSourceRefReader>;
+  readonly isGeometryExcluded: (entityId: number, recordType: string) => boolean;
+  readonly hasEmittableHostBytes: (entityId: number) => boolean;
+  readonly willBeEmitted: (entityId: number) => boolean;
+  readonly isRefExcludedDuringClosureWalk: (id: number) => boolean;
+}

--- a/packages/export/src/step-export-types.ts
+++ b/packages/export/src/step-export-types.ts
@@ -214,10 +214,11 @@ export type SourceLineMutations = SourceLineDelivery & { text: string };
  * 2. **`allowedEntityIds` and `hiddenProductIds` are mutable, and the
  *    predicates close over the pass rather than over a snapshot.** Both are
  *    assigned AFTER construction, in `step-collection.ts`, and the order there
- *    matters more than it looks: `hiddenProductIds` is set first (:76), and
+ *    matters more than it looks: `hiddenProductIds` is set first, and
  *    `allowedEntityIds` is the value the closure walk on the next line is
  *    computing — so `isRefExcludedDuringClosureWalk` is handed to that walk
- *    (:82) while `allowedEntityIds`, and only it, is still null. The
+ *    as one of that call's own arguments — while `allowedEntityIds`, and only
+ *    it, is still null. The
  *    output-line filter reads both later, through `isOmittedFromOutput` ->
  *    `willBeEmitted`, so neither can be a snapshot taken before the walk ran —
  *    that is the invariant the #2637 regression broke.

--- a/packages/export/src/step-export-types.ts
+++ b/packages/export/src/step-export-types.ts
@@ -8,10 +8,15 @@
  *
  * Split out of `step-exporter.ts` for #2475. These are declarations only -- no
  * behaviour lives here beyond one message builder -- which is why they could
- * move without touching a single guard. The seven sibling modules that already
- * import `ExportPass` and `SourceLineMutations` keep importing them from
- * `step-exporter.js`, which re-exports this file, so no call site moved with
- * them and the package's public entry point is untouched.
+ * move without touching a single guard.
+ *
+ * Two ways in, deliberately. The seven sibling modules that already imported
+ * `ExportPass` / `SourceLineMutations` still import them from
+ * `step-exporter.js`, which re-exports this file, so no existing call site
+ * moved and the package's public entry point is untouched. Code written since
+ * the split imports straight from here instead -- `step-pass-builder.ts` does
+ * -- because the re-export exists to avoid churning callers, not as a channel
+ * anything new should be routed through.
  */
 
 import type { IfcAttributeValue, IfcSourceHeader, MapConversion, ProjectedCRS } from '@ifc-lite/parser';
@@ -207,13 +212,15 @@ export type SourceLineMutations = SourceLineDelivery & { text: string };
  *    #2414, #2398, #2637). A phase that reimplements one of these instead of
  *    reading it off the pass reintroduces exactly that class of defect.
  * 2. **`allowedEntityIds` and `hiddenProductIds` are mutable, and the
- *    predicates close over the pass rather than over a snapshot.** The
- *    visible-only closure walk assigns both AFTER construction, and
- *    `isRefExcludedDuringClosureWalk` is handed to that walk while they are
- *    still null. The output-line filter reads them too, through
- *    `isOmittedFromOutput` -> `willBeEmitted`, so neither can be a snapshot
- *    taken before the walk ran — that is the invariant the #2637 regression
- *    broke.
+ *    predicates close over the pass rather than over a snapshot.** Both are
+ *    assigned AFTER construction, in `step-collection.ts`, and the order there
+ *    matters more than it looks: `hiddenProductIds` is set first (:76), and
+ *    `allowedEntityIds` is the value the closure walk on the next line is
+ *    computing — so `isRefExcludedDuringClosureWalk` is handed to that walk
+ *    (:82) while `allowedEntityIds`, and only it, is still null. The
+ *    output-line filter reads both later, through `isOmittedFromOutput` ->
+ *    `willBeEmitted`, so neither can be a snapshot taken before the walk ran —
+ *    that is the invariant the #2637 regression broke.
  *
  * Deliberately NOT on the pass, and why: `isOmittedFromOutput`,
  * `mayNameOmittedRefs` and

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -158,13 +158,14 @@ export class StepExporter {
         : schema;
 
     // The one construction site for the state this export shares across its
-    // seven phases. See `ExportPass` above for what belongs here, what
-    // deliberately does not, and why every predicate reads `pass` rather than
-    // a value captured at construction time.
-    // Built in `step-pass-builder.ts` (#2475). It returns the object the
-    // phases below mutate -- notably `collectModifications`, which fills in
-    // `allowedEntityIds` / `hiddenProductIds` that the pass's own predicates
-    // close over. Do not copy what comes back.
+    // seven phases, built in `step-pass-builder.ts` (#2475). `ExportPass` in
+    // `step-export-types.ts` says what belongs on it and what deliberately
+    // does not.
+    //
+    // What comes back is the object the phases below MUTATE -- notably
+    // `collectModifications`, which fills in the `allowedEntityIds` /
+    // `hiddenProductIds` that the pass's own predicates close over. Do not
+    // copy it; `step-pass-builder.test.ts` is what stops that.
     const pass: ExportPass = buildExportPass({
       dataStore: this.dataStore,
       mutationView: this.mutationView,

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -55,6 +55,7 @@ export type {
 import type { StepExportOptions, StepExportResult, ExportPass } from './step-export-types.js';
 import { relationshipWithheldWarning } from './step-export-types.js';
 import { buildExportPass } from './step-pass-builder.js';
+import { evaluateOmissionPredicates } from './step-omission-predicates.js';
 
 
 /**
@@ -181,271 +182,25 @@ export class StepExporter {
     });
 
     // Visible-only closure, overlay mutation grouping, and georeferencing
-    // edits — everything `pass` needs before the output passes below can run
-    // (#2475, the collection block). See `step-collection.ts` for why
-    // `hasAnyUnreadableSourceRef` and the predicates just past it stay here
-    // instead of moving with it.
+    // edits — everything `pass` needs before the omission predicates below,
+    // and before the output passes that consume them, can run (#2475, the
+    // collection block).
     collectModifications(pass, options, applyMutations, this.collectionContext());
 
-    /**
-     * "Does this model hold a record whose bytes this export cannot read?" —
-     * the one disjunct of {@link mayNameOmittedRefs} that is not already a
-     * value in hand, so it is a function and called last, behind `||`.
-     *
-     * Scans the EFFECTIVE index, and that is a requirement rather than an
-     * implementation detail: it has to cover the id space
-     * `isOmittedFromOutput` answers over, and an unreadable record can live in
-     * `deferredEntityIndex` — the secondary index `getCompleteEntityIndex`
-     * exists to merge — and nowhere in `entityIndex.byId`. Scanning `byId`,
-     * the obvious cheaper source, was measured to leave the gate false and
-     * ship the dangling ref; `relationship-filter-gate.test.ts` pins the
-     * merged scan behaviourally so that shortcut cannot come back as an
-     * optimisation.
-     *
-     * Reads the ref ITERATION yields — what the source-iteration pass's own
-     * skip reads — rather than re-asking `effective.get(id)` per id as
-     * `willBeEmitted` does, which on the largest files would cost a binary
-     * search and an allocation per entity and defeat the point of the gate.
-     * Every index here keeps the two in step by construction:
-     * `CompactEntityIndex` serves `get`, `has` and iteration from one pair of
-     * `Uint32Array`s, a `Map` trivially agrees, the merged deferred view is
-     * `byId.get ?? deferred.get` over `yield* byId; yield* deferred`, and
-     * `OverlayIndex` filters both by one tombstone set. An index whose `has`
-     * accepted an id its iteration never yields would defeat this — and would
-     * equally defeat the source-iteration pass's skip, so that file is broken
-     * either way; nothing in the repo builds one.
-     *
-     * Not short-circuited on `overlayActive`: an overlay-created record carries
-     * `(OVERLAY_BYTE_OFFSET, 0)` and so counts as unreadable here, which would
-     * make this always answer true once an overlay exists. Harmless —
-     * `overlayActive` is an earlier disjunct, so this never runs then — and
-     * correct if it ever did.
-     *
-     * ## Why a standalone pass rather than a value off the index
-     *
-     * Measured: 12.0 ms of a 470 ms export at 714,485 entities (2.55%), one
-     * call, whole index walked because a well-formed model gives it nothing to
-     * short-circuit on. The cheaper shape was prototyped and is 13x faster —
-     * `min(byteLength)` and `max(byteOffset + byteLength)` over
-     * `CompactEntityIndex`'s own `Uint32Array`s answer "is every ref readable
-     * within `extent`" exactly and allocation-free in 0.74 ms — and was not
-     * taken, because 11 ms does not buy what it costs.
-     *
-     * It could only stand in FRONT of this loop, never replace it:
-     * `EntityByIdIndex` is a structural type and plain `Map`s satisfy it
-     * (`synthetic-data-store.ts` builds one), so the walk stays for those. That
-     * makes it a second implementation of one predicate across a package
-     * boundary — the defect class #2637, #2668 and this gate are all instances
-     * of. And storing it at construction is the invariant
-     * `source-ref-bounds.ts` exists to delete: `CompactEntityIndex` is built by
-     * its builder, by `compactEntityIndexFromColumns` in the transport, and by
-     * embedders, so a value one producer writes is a value the next can skip,
-     * whereas testing the ref where it is READ cannot be bypassed. If 2.5% ever
-     * has to go, the safe shape is a memoized derivation the index computes
-     * from its own arrays on demand — not a field set at build time.
-     */
-    const hasAnyUnreadableSourceRef = (): boolean => {
-      for (const [, ref] of pass.effective) {
-        if (!pass.isReadableSourceRef(ref)) return true;
-      }
-      return false;
-    };
-
-    // If delta only, only export modified entities. Overlay-created entities
-    // also count — without this, `createEntity()`-only edits would silently
-    // drop out of delta exports.
-    const overlayNewEntityCount = (
-      this.mutationView
-      && applyMutations
-      && typeof this.mutationView.getNewEntities === 'function'
-    ) ? this.mutationView.getNewEntities().length : 0;
-    // Georef-only deltas (newGeorefLines populated but no entity changes) must
-    // still produce a non-empty DATA section.
-    if (
-      options.deltaOnly
-      && pass.modifiedEntities.size === 0
-      && overlayNewEntityCount === 0
-      && pass.newGeorefLines.length === 0
-    ) {
-      const emptyContent = new TextEncoder().encode(pass.buildHeader(0) + 'DATA;\nENDSEC;\nEND-ISO-10303-21;\n');
-      return {
-        content: emptyContent,
-        stats: {
-          entityCount: 0,
-          newEntityCount: 0,
-          modifiedEntityCount: 0,
-          fileSize: emptyContent.byteLength,
-          warnings: pass.warnings,
-        },
-      };
-    }
-
-
-    /**
-     * "May a line this export writes name `#id`?" — the single predicate both
-     * relationship-line filter sites consume, derived from `willBeEmitted`
-     * rather than from a second list kept in step with it by hand.
-     *
-     * DERIVED, not identical, and the gaps are named below rather than glossed:
-     * a scope qualifier for ids the file never had, and `deltaOnly`, where
-     * `willBeEmitted` answers `true` for a source record whose line this export
-     * does not write at all (the source-iteration pass is skipped wholesale in
-     * that mode). Nor does this make the CLOSURE WALK agree with either: the
-     * walk keeps `isRefExcludedDuringClosureWalk` and diverges from this
-     * predicate for an unreadable source ref — see the note on that predicate,
-     * and the "walk and output predicates diverge" test.
-     *
-     * The hand-kept second list is the bug this replaces. `willBeEmitted` recognises
-     * seven reasons a line never lands — outside the closure, hidden product,
-     * tombstoned, never existed, unreadable source ref (#2491), geometry
-     * excluded by options, and the `deltaOnly` carve-out — while the filter
-     * used to consume `(hiddenProductIds !== null && hiddenProductIds.has(id))
-     * || effective.isDeleted(id)`, which answered for two: hidden product, and
-     * tombstoned. Notably NOT "never existed" — that one is deliberately out of
-     * scope for the filter even now, for the reason under the qualifier heading
-     * below. The gap was live: on a PLAIN full export, with no `visibleOnly`,
-     * no deletions and no overlay, an unreadable ref made the source-iteration
-     * pass skip an entity's line while an `IFCREL*` naming it shipped verbatim,
-     * dangling.
-     *
-     * Deriving the filter from `willBeEmitted` is also what fixed the
-     * `mayNameExcludedRefs` gate that stands in front of both call sites. That
-     * gate used to be a SECOND, shorter enumeration of the same reasons
-     * (hidden products exist, or an overlay is active) and answered `false` for
-     * exactly the unreadable-ref export above, so the filter never ran at all.
-     * It is now {@link mayNameOmittedRefs} — see there for why a gate is kept
-     * at all (running the filter on every `IFCREL*` line costs +13% of a
-     * 714k-entity export) and for the enumeration it has to cover.
-     *
-     * ## The one qualifier on top of `willBeEmitted`
-     *
-     * `willBeEmitted` answers NO for an id neither the file nor the session
-     * ever had, which is right for its own job — nothing GENERATED may name an
-     * id that does not exist. It is the wrong answer for rewriting a SOURCE
-     * line, and the difference is whose bug it is. A `#999` already sitting in
-     * a relationship's `OwnerHistory` slot in the input file is a dangling ref
-     * this export did not create and cannot repair; `filterHiddenRefsFromRelationshipLine`
-     * withholds a whole relationship when an excluded id is in a bare scalar,
-     * so treating it as an exclusion would DELETE a visible element's pset over
-     * somebody else's corrupt file. That is the harm #2637 was about, and
-     * `step-exporter.test.ts` states the position out loud: a pre-existing
-     * dangling ref is out of scope and ships as it arrived.
-     *
-     * So the filter asks the narrower question: is `#id` an entity this model
-     * HAS, that this export is nonetheless not writing? `effective.has` is
-     * false for a tombstone, hence the explicit `isDeleted` arm — deleting an
-     * entity IS this session's doing and must be filtered.
-     *
-     * This is a scope qualifier, not a second enumeration of omission reasons:
-     * an eighth reason added to `willBeEmitted` still reaches the filter with
-     * no edit here.
-     *
-     * ## What the filter can and cannot reach
-     *
-     * Only `IFCREL*` lines. A `#N` named from a product's `Representation` or
-     * `ObjectPlacement` slot is not touched, so `includeGeometry:false` — a
-     * reason `willBeEmitted` does answer for — produces the same dangling refs
-     * with this predicate as without it. Measured on `tests/models/AB22.ifc`:
-     * 80 dangling refs before and after, output byte-identical but for the
-     * header timestamp.
-     *
-     * ## Withholding is not free
-     *
-     * When the omitted id sits in a single-valued slot, or is a set's only
-     * member, `filterHiddenRefsFromRelationshipLine` withholds the WHOLE
-     * relationship — so an entity that relationship also named loses the
-     * association, on a plain full export with no options set. That is why the
-     * call sites push {@link relationshipWithheldWarning}.
-     *
-     * See `unreadable-ref-dangling.test.ts` for the reproduction. #2637 is the
-     * prior instance of this class, which took seven rounds because the same
-     * decision was recomputed per call site.
-     */
-    const isOmittedFromOutput = (id: number): boolean =>
-      (pass.effective.has(id) || pass.effective.isDeleted(id)) && !pass.willBeEmitted(id);
-
-    /**
-     * "Can ANY id be omitted from this export at all?" — the precondition both
-     * `IFCREL*` filter sites are gated on, so the common export pays nothing.
-     *
-     * ## Why a gate exists
-     *
-     * Running `filterHiddenRefsFromRelationshipLine` on every `IFCREL*` line
-     * costs a re-parse of that line's attribute list, and a large model is
-     * mostly relationships. Measured on `tests/models/ara3d/schependomlaan.ifc`
-     * (714,485 entities, 21 interleaved reps in randomised order): 463 ms
-     * median with this gate false versus 523 ms filtering unconditionally,
-     * **+13%**. That is a real price paid on every export to protect a state
-     * most exports are not in. With the gate, the same export is 475 ms, +2.7%,
-     * all of it the fourth disjunct's one pass.
-     *
-     * ## Why THIS gate, and not the one that shipped before
-     *
-     * The gate this replaces was a second, hand-kept enumeration of "reasons an
-     * entity might be excluded", and it went stale exactly as such lists do: it
-     * named hidden products and the overlay and knew nothing about an unreadable
-     * source ref, so the bug this branch fixes reached the output with the
-     * filter switched off. A cheap gate is safe only as an OVER-APPROXIMATION of
-     * `isOmittedFromOutput` that can be checked against `willBeEmitted` branch
-     * by branch — so every branch is listed, with the disjunct that covers it:
-     *
-     * | `willBeEmitted` answers NO at                | covered by                    |
-     * |----------------------------------------------|-------------------------------|
-     * | `allowedEntityIds !== null && !has(id)`      | `allowedEntityIds !== null`   |
-     * | `!ref`, because the overlay tombstoned `id`  | `overlayActive`               |
-     * | overlay-created, geometry excluded           | `overlayActive`               |
-     * | `!isReadableSourceRef(ref)`                  | `hasAnyUnreadableSourceRef()` |
-     * | source-backed, geometry excluded             | `excludeGeometry`             |
-     * | `!ref`, because `id` never existed           | out of scope (below)          |
-     * | `!ref` while `has(id)` is TRUE               | nothing (below)               |
-     *
-     * "Never existed" needs no disjunct: `isOmittedFromOutput`'s own
-     * `(has || isDeleted)` qualifier already drops it, deliberately — a
-     * pre-existing dangling ref in somebody else's file is not this export's to
-     * repair (see that predicate's note).
-     *
-     * The last row is a real hole and is stated rather than hidden: an index
-     * that answers `has(id)` for an id its iteration never yields makes
-     * `isOmittedFromOutput` true with no disjunct true. It needs an index whose
-     * `has`, `get` and iteration disagree, which nothing in the repo builds and
-     * which would already break the source-iteration pass's own skip — see
-     * {@link hasAnyUnreadableSourceRef}, which rests on the same agreement.
-     *
-     * Three of the four disjuncts are reads of values this export already
-     * computed. Only the fourth costs anything, and it short-circuits: `||`
-     * evaluates it solely when the other three are false, i.e. only for an
-     * export that has nothing else to filter for.
-     *
-     * ## The two spellings that are deliberately NOT the obvious ones
-     *
-     * `allowedEntityIds !== null`, not `options.visibleOnly === true`. Not the
-     * same test: the closure is built under `if (options.visibleOnly &&
-     * this.dataStore.source)`, which is TRUTHY rather than `=== true`, and which
-     * is a SECOND read of the caller's object. A plain-JS caller of this
-     * published package passing `visibleOnly: 1` — or a `get visibleOnly()` that
-     * answers `true` once — built the closure while the gate read false and
-     * shipped a relationship naming an entity outside it. Executed, not
-     * reasoned: 192 of an 800-case sweep over `visibleOnly`/`hidden`/`isolated`
-     * combinations shipped a dangling ref against the `=== true` spelling, 0
-     * against this one. Reading the state the walk PRODUCED cannot disagree with
-     * the walk, whatever `options` says afterwards.
-     *
-     * It is also wider than the `hiddenProductIds.size > 0` the old gate used: a
-     * closure exists whenever `visibleOnly` was requested, even with nothing
-     * hidden, and can exclude an entity the roots simply never reach. No fixture
-     * has produced that case, so the widening is defensive — but a gate that is
-     * true too often costs speed on a rare path, while one that is false too
-     * rarely ships a corrupt file, and this one costs nothing.
-     *
-     * `overlayActive` and `excludeGeometry` are the SAME consts the effective
-     * index and `isGeometryExcluded` are built from — one read of `options` per
-     * question, shared — so those two cannot disagree with the predicate either.
-     */
-    const mayNameOmittedRefs =
-      pass.allowedEntityIds !== null
-      || pass.overlayActive
-      || excludeGeometry
-      || hasAnyUnreadableSourceRef();
+    // Which ids this export may still NAME, now that the collection phase has
+    // decided which ids it is WRITING (#2475). Must stay here, between those
+    // two -- see `step-omission-predicates.ts` for why the position is load
+    // bearing rather than stylistic.
+    const omission = evaluateOmissionPredicates(
+      pass,
+      options,
+      applyMutations,
+      excludeGeometry,
+      this.mutationView,
+    );
+    // A deltaOnly export with nothing to say is already finished.
+    if (omission.kind === 'short-circuit') return omission.result;
+    const { isOmittedFromOutput, mayNameOmittedRefs } = omission;
 
     // Write every source-backed record this export keeps (#2475 step 2d),
     // preceded — inside that call — by the shared-atom retention that decides

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -10,22 +10,11 @@
  */
 
 import type { IfcDataStore, IfcAttributeValue, IfcSourceHeader } from '@ifc-lite/parser';
-import {
-  EntityExtractor,
-  parseSourceHeader,
-  type MapConversion,
-  type ProjectedCRS,
-} from '@ifc-lite/parser';
+import { EntityExtractor, parseSourceHeader } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
-import type { PropertySet, QuantitySet } from '@ifc-lite/data';
-import type { RandomSource } from '@ifc-lite/encoding';
 import { needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
-import {
-  createModificationLedger,
-  type ModificationLedger,
-  type SourceLineDelivery,
-} from './delta-modification-ledger.js';
+import { createModificationLedger } from './delta-modification-ledger.js';
 import { createSourceRefReader } from './source-ref-bounds.js';
 import {
   writeSourceEntityLines,
@@ -42,7 +31,7 @@ import {
 } from './step-property-sets.js';
 import { type GeorefContext } from './step-georeferencing.js';
 import { collectModifications, type CollectionContext } from './step-collection.js';
-import { getEffectiveEntityIndex, type EffectiveEntityIndex } from './effective-index.js';
+import { getEffectiveEntityIndex } from './effective-index.js';
 import { buildStepHeader, assembleExportResult } from './step-header.js';
 import {
   applySourceLineMutations,

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -9,12 +9,11 @@
  * Supports applying property and root attribute mutations before export.
  */
 
-import type { IfcDataStore, IfcAttributeValue, IfcSourceHeader } from '@ifc-lite/parser';
+import type { IfcDataStore, IfcSourceHeader } from '@ifc-lite/parser';
 import { EntityExtractor, parseSourceHeader } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
 import { needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
-import { createModificationLedger } from './delta-modification-ledger.js';
 import { createSourceRefReader } from './source-ref-bounds.js';
 import {
   writeSourceEntityLines,
@@ -31,8 +30,7 @@ import {
 } from './step-property-sets.js';
 import { type GeorefContext } from './step-georeferencing.js';
 import { collectModifications, type CollectionContext } from './step-collection.js';
-import { getEffectiveEntityIndex } from './effective-index.js';
-import { buildStepHeader, assembleExportResult } from './step-header.js';
+import { assembleExportResult } from './step-header.js';
 import {
   applySourceLineMutations,
   applyOverlayEntityOverrides,
@@ -56,6 +54,7 @@ export type {
 // importing them too raises TS6196 under --noUnusedLocals.
 import type { StepExportOptions, StepExportResult, ExportPass } from './step-export-types.js';
 import { relationshipWithheldWarning } from './step-export-types.js';
+import { buildExportPass } from './step-pass-builder.js';
 
 
 /**
@@ -162,256 +161,23 @@ export class StepExporter {
     // seven phases. See `ExportPass` above for what belongs here, what
     // deliberately does not, and why every predicate reads `pass` rather than
     // a value captured at construction time.
-    const pass: ExportPass = {
-      entities: [],
-      newEntityCount: 0,
+    // Built in `step-pass-builder.ts` (#2475). It returns the object the
+    // phases below mutate -- notably `collectModifications`, which fills in
+    // `allowedEntityIds` / `hiddenProductIds` that the pass's own predicates
+    // close over. Do not copy what comes back.
+    const pass: ExportPass = buildExportPass({
+      dataStore: this.dataStore,
+      mutationView: this.mutationView,
+      isGeometryEntity: (type) => this.isGeometryEntity(type),
+      options,
       schema,
       sourceSchema,
       converting,
+      applyMutations,
+      excludeGeometry,
       sourceHeader,
       schemaToken,
-      overlayActive: !!this.mutationView && applyMutations,
-
-      // Built once entity counts are known, so the provenance item can report the
-      // actual modification count. See the two call sites (empty delta + final).
-      // Body lives in `step-header.ts` (#2475 header/assembly tail): the
-      // closure still has to be built here, because it closes over this
-      // call's own `options`/`sourceHeader`/`schemaToken`, and both call
-      // sites still read it as `pass.buildHeader`.
-      buildHeader: (modifications: number): string =>
-        buildStepHeader(options, sourceHeader, schemaToken, modifications),
-
-      // The one authority for exists / class / deleted, overlay first and source
-      // buffer second. Every pass below asks this instead of `this.dataStore`,
-      // which answers only for the file as parsed (#2012).
-      effective: getEffectiveEntityIndex(
-        this.dataStore,
-        this.mutationView,
-        applyMutations,
-      ),
-
-      // Does this id belong to an entity the OVERLAY created (`createEntity` /
-      // `store.addEntity`) rather than to a record in the source buffer? Such an
-      // entity has no source bytes, so the source-iteration pass below never sees
-      // it and the new-entities pass at the end owns its line entirely (#2006).
-      isOverlayCreated: (entityId: number): boolean => pass.effective.isOverlayCreated(entityId),
-
-      // Does this record describe a line this export can actually READ out of the
-      // source? One predicate for every byte-range gate below, so they cannot
-      // disagree — see `source-ref-bounds.ts` for the corrupt file the weaker
-      // "is there a source / does the ref claim bytes" pair let through (#2491).
-      isReadableSourceRef: createSourceRefReader(this.dataStore.source),
-
-      // Build visible-only closure if requested. Classification, the closure walk
-      // and the style pass all run over the EFFECTIVE index: an overlay-created
-      // product becomes a root by the same type rules as a parsed one, the walk
-      // follows its authored references into the geometry it alone owns, and a
-      // tombstoned entity is simply not there. Run over the source buffer, a
-      // created wall could never be a root and nothing referenced it, so
-      // `visibleOnly` wrote a file without it and said nothing (#2012).
-      //
-      // Computed here, ahead of the modification-count passes below, because
-      // `hasEmittableHostBytes` needs it: a source-backed host EXCLUDED by
-      // `visibleOnly` never gets its line written by the source-iteration pass
-      // either, so counting it as "modified" would make the header claim a
-      // change the DATA section does not contain (CodeRabbit finding on #2414).
-      allowedEntityIds: null,
-
-      // Populated alongside `allowedEntityIds` below. `getVisibleEntityIds`
-      // excludes a hidden PRODUCT's own line from the closure, but `IFCREL*` is
-      // an unconditional root a few lines down and its bytes are copied verbatim
-      // by the source-iteration pass — nothing there filters a `#N` the closure
-      // just excluded out of the relationship's own attribute list. Kept because
-      // the closure walk's `isRefExcludedDuringClosureWalk` needs a notion of
-      // "hidden" that does not read `allowedEntityIds` — the set that walk is
-      // producing (#2398). The two OUTPUT passes no longer read this directly:
-      // they filter on `isOmittedFromOutput`, which subsumes it via
-      // `allowedEntityIds`.
-      hiddenProductIds: null,
-
-      // A relationship can name an excluded entity two ways that have nothing
-      // to do with each other: a `visibleOnly` hidden PRODUCT (`hiddenProductIds`,
-      // below), and a TOMBSTONED one — `editor.removeEntity` on a related object
-      // named by a relationship the deletion sweep below does not reach (that
-      // sweep only withholds an `IfcRelDefinesByProperties` when EVERY related
-      // object is gone, and only for that one relationship class). Left alone, a
-      // relationship still naming a deleted entity ships the identical `#N` with
-      // no `#N=` line, on a path with no `visibleOnly` involved at all (#2398).
-      // `effective.isDeleted` answers for every id, not just a precomputed set,
-      // so this predicate covers both sources without a second exclusion set.
-      //
-      // Declared here, ahead of the closure walk below, and passed into
-      // `collectReferencedEntityIds` as its `isRefExcluded` — rather than the
-      // walk inventing its own `!entityIndex.has` proxy for "deleted" that could
-      // disagree on an id that never existed in the file at all
-      // (maintainer-found regression on #2637: such an id blocked the bridge but
-      // did not stop the relationship's own line from shipping, dropping a
-      // VISIBLE sibling's pset while adding a fresh dangling ref). A closure over
-      // `pass.hiddenProductIds`, not a value snapshot — correct because nothing
-      // reads it before the closure walk assigns it just below.
-      //
-      // ## Why this is NOT the predicate the OUTPUT-line filter uses
-      //
-      // The name says walk, and only walk. The two passes that write a
-      // relationship's line ask `isOmittedFromOutput` (further below, derived
-      // from `pass.willBeEmitted`), which is strictly stronger — it also answers
-      // for the closure, for an unreadable source ref and for a geometry
-      // exclusion.
-      //
-      // This one CANNOT be `willBeEmitted`, and the difference is structural
-      // rather than stylistic: `willBeEmitted`'s first act is to consult
-      // `allowedEntityIds`, and `allowedEntityIds` is precisely what the call
-      // below is computing. Wiring it in here is circular: it would answer "not
-      // in the closure" as `false` while the closure is still being built and
-      // `true` for the same id afterwards.
-      //
-      // That is a genuine departure from the contract #2637 was closed on —
-      // `reference-collector.ts` still documents the bridge as taking the
-      // caller's OWN output predicate, "not two expressions that happened to
-      // agree". It has an OBSERVABLE consequence, not just a naming one: for an
-      // unreadable source ref this admits, the walk bridges through a
-      // relationship the output then withholds, leaving the relationship's other
-      // target in the closure with nothing naming it — an orphan, pinned by
-      // `unreadable-ref-dangling.test.ts` ("walk and output predicates diverge").
-      // The reverse direction is closed: every id this excludes,
-      // `isOmittedFromOutput` excludes too, so the #2548 leak cannot return.
-      isRefExcludedDuringClosureWalk: (id: number): boolean =>
-        (pass.hiddenProductIds !== null && pass.hiddenProductIds.has(id))
-        || pass.effective.isDeleted(id),
-
-      // Will THIS entity's own line ever land in the file? The same byte-range
-      // test `willBeEmitted` uses (defined further below) and the source-
-      // iteration pass's own skip at `entityRef.byteLength === 0` — a source
-      // entity with no bytes (a point-cloud / GLB "entity" from
-      // `createSyntheticDataStore`, not an overlay-created one) never gets a
-      // defining line written, source-iteration or otherwise, so a pset/attribute
-      // edit against it must not count as a modification either: the header
-      // would describe a change the file does not contain (out-of-scope finding
-      // in #2398). Also excludes a source-backed host the visible-only closure
-      // above drops — same reasoning, different reason the line never lands.
-      //
-      // And, like `willBeEmitted` below, excludes a geometry-classified SOURCE
-      // host under `includeGeometry: false`: the source-iteration pass's own
-      // `isGeometryEntity` skip (further below) drops that line too, so this
-      // predicate must agree or a geometry entity's attribute edit inflates the
-      // count over an omitted line (CodeRabbit finding on #2414). Guarded by
-      // `!deltaOnly` for the same reason `willBeEmitted` is: under `deltaOnly`
-      // the source-iteration pass — and its geometry skip — never runs at all,
-      // so a source entity's line is assumed to already exist in the file being
-      // patched, geometry or not.
-      isGeometryExcluded: (entityId: number, recordType: string): boolean =>
-        excludeGeometry
-        && this.isGeometryEntity(pass.effective.effectiveType(entityId, recordType)),
-      hasEmittableHostBytes: (entityId: number): boolean => {
-        if (pass.allowedEntityIds !== null && !pass.allowedEntityIds.has(entityId)) return false;
-        const ref = pass.effective.get(entityId);
-        // The ref must be READABLE, not merely non-empty: a range this source
-        // cannot address decodes to the empty string, which used to be pushed
-        // into the file as a blank line while everything generated FOR the host
-        // still named it (#2491).
-        if (!ref || !pass.isReadableSourceRef(ref)) return false;
-        if (options.deltaOnly !== true && pass.isGeometryExcluded(entityId, ref.type)) return false;
-        return true;
-      },
-
-      /**
-       * Will this id have a defining STEP line in the output at all?
-       *
-       * The predicate is #2030's, and it is the right one: the pset, quantity and
-       * type-owned passes below are built from unfiltered mutation history, and
-       * what each of them needs to know before emitting an
-       * `IFCRELDEFINESBYPROPERTIES` is not "was this deleted" or "is this hidden"
-       * but the general question those are two answers to. A relation naming an
-       * expressId that never gets written is a dangling reference and an invalid
-       * file, whichever route dropped the line.
-       *
-       * #2030 had to reach for four things to answer it — a tombstone probe, a
-       * visibility set, a byte-range test on `completeIndex`, and a `getNewEntity`
-       * fallback whose stated purpose was that `deleteEntity` FORGOT an
-       * overlay-created entity instead of tombstoning it, so `isDeleted` could not
-       * answer for one. That fallback was documented on main as a workaround for
-       * exactly the model-level defect this branch fixes: `deleteEntity` now
-       * tombstones as well as forgets, so the effective index answers existence
-       * for source and overlay ids alike and the workaround collapses into it.
-       *
-       * The overlay branch does NOT disappear with it, and the distinction matters:
-       * `isOverlayCreated` is still load-bearing here, because a live
-       * overlay-created entity has no source bytes and would fail the byte-range
-       * test that a source record passes. What the tombstone fix removed is the
-       * need for that branch to double as a deletion detector.
-       *
-       * Deliberately unchanged from #2030 for source records under `deltaOnly` /
-       * `exportPropertiesOnly`: the source-iteration pass is skipped wholesale in
-       * those modes, yet a source entity still answers true here. A delta is a
-       * patch against a file that already has the line, not a standalone model.
-       */
-      willBeEmitted: (entityId: number): boolean => {
-        if (pass.allowedEntityIds !== null && !pass.allowedEntityIds.has(entityId)) return false;
-        // Undefined for a tombstoned id and for one neither the file nor the
-        // session ever had — a stale mutation must not conjure a relation either.
-        const ref = pass.effective.get(entityId);
-        if (!ref) return false;
-        // An overlay-created record carries the placeholder byte range and is
-        // written by the new-entities pass; a source record needs real bytes.
-        if (pass.effective.isOverlayCreated(entityId)) {
-          // The overlay new-entities pass applies its OWN `isGeometryEntity`
-          // filter unconditionally — deltaOnly or not (see the comment at that
-          // loop, further below) — so this branch mirrors it without the
-          // deltaOnly carve-out the source branch gets.
-          return !pass.isGeometryExcluded(entityId, ref.type);
-        }
-        // Same readability test as `hasEmittableHostBytes`, and for the reason
-        // that predicate names: a ref this source cannot address is not a line
-        // this export can write, so nothing may be generated naming it (#2491).
-        if (!pass.isReadableSourceRef(ref)) return false;
-        // Mirrors `hasEmittableHostBytes`: under `deltaOnly` the source-
-        // iteration pass — and its geometry skip — never runs, so a source
-        // entity's line is assumed to already exist in the file being patched.
-        if (options.deltaOnly === true) return true;
-        return !pass.isGeometryExcluded(entityId, ref.type);
-      },
-
-      // Under `deltaOnly` a nomination only becomes a count once some pass has
-      // actually written content that delivers THAT KIND of edit for the host —
-      // see `delta-modification-ledger.ts` for why the two are not the same event
-      // in that mode, and why the pair is (entity, kind) rather than the entity
-      // (#2462).
-      modifications: createModificationLedger(options.deltaOnly === true),
-
-      /**
-       * Hosts whose in-place named-attribute edits a FULL export may count, per
-       * kind. Filled by the collection passes below and read by the two passes
-       * that write a rewritten source line — see `in-place-nomination.ts` for why
-       * the nomination waits for the rewrite in this mode and not under
-       * `deltaOnly` (#2483).
-       */
-      inPlaceNominees: {
-        attribute: new Set<number>(),
-        georeferencing: new Set<number>(),
-      },
-
-      // Collect entities that need to be modified or created
-      modifiedEntities: new Set<number>(),
-      modifiedAttributes: new Map<number, Map<string, string>>(),
-      newPropertySets: [],
-      newQuantitySets: [],
-      typeOwnedPsetNamesByEntity: new Map<number, Set<string>>(),
-      typeOwnedPsetIdsByEntity: new Map<number, number[]>(),
-      rewrittenEntityIds: new Set<number>(),
-      rewrittenEntityLines: new Map<number, string>(),
-      /** HasPropertySets slot value for an OVERLAY-CREATED type object, applied
-       *  by the new-entities pass (there is no source line to rewrite). */
-      overlayTypeOwnedPsets: new Map<number, IfcAttributeValue>(),
-
-      // Track property set IDs and relationship IDs to skip
-      skipPropertySetIds: new Set<number>(),
-      skipRelationshipIds: new Set<number>(),
-
-      // Written by the georeferencing pass and read again by the final
-      // assembly, which is why they are pass state and not phase locals.
-      newGeorefLines: [],
-      warnings: [],
-    };
+    });
 
     // Visible-only closure, overlay mutation grouping, and georeferencing
     // edits — everything `pass` needs before the output passes below can run

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -15,14 +15,8 @@ import type { MutablePropertyView } from '@ifc-lite/mutations';
 import { needsConversion, type IfcSchemaVersion } from './schema-converter.js';
 import { getCompleteEntityIndex, getMaxExpressId } from './entity-iteration.js';
 import { createSourceRefReader } from './source-ref-bounds.js';
-import {
-  writeSourceEntityLines,
-  type SourceIterationContext,
-} from './step-source-iteration.js';
-import {
-  writeOverlayCreatedEntities,
-  type OverlayEntitiesContext,
-} from './step-overlay-entities.js';
+import { writeSourceEntityLines } from './step-source-iteration.js';
+import { writeOverlayCreatedEntities } from './step-overlay-entities.js';
 import {
   generatePropertyAndQuantitySetEntities,
   type OwnerHistoryCache,
@@ -31,10 +25,7 @@ import {
 import { type GeorefContext } from './step-georeferencing.js';
 import { collectModifications, type CollectionContext } from './step-collection.js';
 import { assembleExportResult } from './step-header.js';
-import {
-  applySourceLineMutations,
-  applyOverlayEntityOverrides,
-} from './step-attribute-mutations.js';
+import { applySourceLineMutations } from './step-attribute-mutations.js';
 
 /**
  * The export vocabulary lives in `step-export-types.ts` (#2475). Re-exported
@@ -53,9 +44,13 @@ export type {
 // `SourceLineMutations` are re-exported above but never referenced here, and
 // importing them too raises TS6196 under --noUnusedLocals.
 import type { StepExportOptions, StepExportResult, ExportPass } from './step-export-types.js';
-import { relationshipWithheldWarning } from './step-export-types.js';
 import { buildExportPass } from './step-pass-builder.js';
 import { evaluateOmissionPredicates } from './step-omission-predicates.js';
+import { isGeometryEntity } from './step-geometry-types.js';
+import {
+  buildSourceIterationContext,
+  buildOverlayEntitiesContext,
+} from './step-export-contexts.js';
 
 
 /**
@@ -170,7 +165,7 @@ export class StepExporter {
     const pass: ExportPass = buildExportPass({
       dataStore: this.dataStore,
       mutationView: this.mutationView,
-      isGeometryEntity: (type) => this.isGeometryEntity(type),
+      isGeometryEntity,
       options,
       schema,
       sourceSchema,
@@ -205,7 +200,7 @@ export class StepExporter {
     // Write every source-backed record this export keeps (#2475 step 2d),
     // preceded — inside that call — by the shared-atom retention that decides
     // which member atoms the skip sets may still drop.
-    writeSourceEntityLines(pass, options, mayNameOmittedRefs, isOmittedFromOutput, this.sourceIterationContext());
+    writeSourceEntityLines(pass, options, mayNameOmittedRefs, isOmittedFromOutput, buildSourceIterationContext(this.dataStore, this.mutationView, () => this.propertySetContext()));
 
     // Generated property/quantity sets and the type-object `HasPropertySets`
     // rewrite that resolves against them, in that one order (#2475 steps 2b
@@ -231,7 +226,7 @@ export class StepExporter {
       applyMutations,
       mayNameOmittedRefs,
       isOmittedFromOutput,
-      this.overlayEntitiesContext(),
+      buildOverlayEntitiesContext(this.mutationView),
     );
 
     // Settle the ledger, build the header, assemble the finished bytes —
@@ -349,89 +344,7 @@ export class StepExporter {
     };
   }
 
-  /**
-   * The state `step-source-iteration.ts` cannot read off the pass (#2475 2d).
-   *
-   * No `allocateExpressId`: that phase never allocates an id, it only rewrites
-   * lines that already have one. `applySourceLineMutations` (#2475, remaining
-   * private helpers: now a free function in `step-attribute-mutations.ts`,
-   * closed over `this.mutationView` here) and `isGeometryEntity` are injected
-   * rather than read off the pass because each has readers outside this
-   * phase — the mutation pipeline is shared with the type-object
-   * `HasPropertySets` rewrite (see {@link propertySetContext}) and with the
-   * overlay-created-entities block in `export()`; `isGeometryEntity` with the
-   * visible-only setup closure and that same block.
-   */
-  private sourceIterationContext(): SourceIterationContext {
-    return {
-      dataStore: this.dataStore,
-      applySourceLineMutations: (expressId, entityText, recordType, attributeMutations, sourceSchema, overlayActive, onRejected) =>
-        applySourceLineMutations(this.mutationView, expressId, entityText, recordType, attributeMutations, sourceSchema, overlayActive, onRejected),
-      isGeometryEntity: (type) => this.isGeometryEntity(type),
-      propertySetContext: () => this.propertySetContext(),
-      relationshipWithheldWarning,
-    };
-  }
 
-  /**
-   * The state `step-overlay-entities.ts` cannot read off the pass (#2475
-   * step 2e). `applyOverlayEntityOverrides` is now the free function
-   * `step-attribute-mutations.ts` exports (#2475, remaining private
-   * helpers) — it and its two `serializeNamedAttribute` /
-   * `serializePositionalOverride` helpers moved together, since those two
-   * have no reader outside this cluster; `isGeometryEntity` and
-   * `relationshipWithheldWarning` are the same shared readers
-   * {@link sourceIterationContext} already injects into the other output
-   * pass.
-   */
-  private overlayEntitiesContext(): OverlayEntitiesContext {
-    return {
-      mutationView: this.mutationView,
-      applyOverlayEntityOverrides,
-      isGeometryEntity: (type) => this.isGeometryEntity(type),
-      relationshipWithheldWarning,
-    };
-  }
-
-  /**
-   * Check if an entity type is a geometry-related type
-   */
-  private isGeometryEntity(type: string): boolean {
-    const geometryTypes = new Set([
-      'IFCCARTESIANPOINT',
-      'IFCDIRECTION',
-      'IFCAXIS2PLACEMENT2D',
-      'IFCAXIS2PLACEMENT3D',
-      'IFCLOCALPLACEMENT',
-      'IFCSHAPEREPRESENTATION',
-      'IFCPRODUCTDEFINITIONSHAPE',
-      'IFCGEOMETRICREPRESENTATIONCONTEXT',
-      'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
-      'IFCEXTRUDEDAREASOLID',
-      'IFCFACETEDBREP',
-      'IFCPOLYLOOP',
-      'IFCFACE',
-      'IFCFACEOUTERBOUND',
-      'IFCCLOSEDSHELL',
-      'IFCRECTANGLEPROFILEDEF',
-      'IFCCIRCLEPROFILEDEF',
-      'IFCARBITRARYCLOSEDPROFILEDEF',
-      'IFCPOLYLINE',
-      'IFCTRIMMEDCURVE',
-      'IFCBSPLINECURVE',
-      'IFCBSPLINESURFACE',
-      'IFCTRIANGULATEDFACESET',
-      'IFCPOLYGONALFACE',
-      'IFCINDEXEDPOLYGONALFACE',
-      'IFCPOLYGONALFACESET',
-      'IFCSTYLEDITEM',
-      'IFCPRESENTATIONSTYLEASSIGNMENT',
-      'IFCSURFACESTYLE',
-      'IFCSURFACESTYLERENDERING',
-      'IFCCOLOURRGB',
-    ]);
-    return geometryTypes.has(type);
-  }
 
 }
 

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -51,13 +51,10 @@ export type {
   SourceLineMutations,
   ExportPass,
 } from './step-export-types.js';
-import type {
-  StepExportOptions,
-  StepExportProgress,
-  StepExportResult,
-  SourceLineMutations,
-  ExportPass,
-} from './step-export-types.js';
+// Only the three this file's own body still names. `StepExportProgress` and
+// `SourceLineMutations` are re-exported above but never referenced here, and
+// importing them too raises TS6196 under --noUnusedLocals.
+import type { StepExportOptions, StepExportResult, ExportPass } from './step-export-types.js';
 import { relationshipWithheldWarning } from './step-export-types.js';
 
 

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -312,7 +312,8 @@ export class StepExporter {
    *
    * Rebuilt per call, as `georefContext` is: every call site runs once per
    * export bar `retainSharedAtoms`, which hoists it out of its loop — hence
-   * {@link sourceIterationContext} takes this as a thunk rather than a value.
+   * `buildSourceIterationContext` (`step-export-contexts.ts`) takes this as a
+   * thunk rather than a value.
    */
   private propertySetContext(): PropertySetContext {
     return {

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -50,251 +50,27 @@ import {
 } from './step-attribute-mutations.js';
 
 /**
- * Options for STEP export
+ * The export vocabulary lives in `step-export-types.ts` (#2475). Re-exported
+ * here, unchanged, so that the package entry point and the seven sibling
+ * modules that import `ExportPass` / `SourceLineMutations` from this file
+ * carry on doing exactly that -- the split moved declarations, not call sites.
  */
-export interface StepExportOptions {
-  /** IFC schema version for the output file (any version, will convert if needed) */
-  schema: 'IFC2X3' | 'IFC4' | 'IFC4X3' | 'IFC5';
-  /** File description */
-  description?: string;
-  /** Author name */
-  author?: string;
-  /** Organization name */
-  organization?: string;
-  /** Application name (defaults to 'ifc-lite') */
-  application?: string;
-  /** Output filename */
-  filename?: string;
+export type {
+  StepExportOptions,
+  StepExportProgress,
+  StepExportResult,
+  SourceLineMutations,
+  ExportPass,
+} from './step-export-types.js';
+import type {
+  StepExportOptions,
+  StepExportProgress,
+  StepExportResult,
+  SourceLineMutations,
+  ExportPass,
+} from './step-export-types.js';
+import { relationshipWithheldWarning } from './step-export-types.js';
 
-  /** Include original geometry entities (default: true) */
-  includeGeometry?: boolean;
-  /** Include property sets (default: true) */
-  includeProperties?: boolean;
-  /** Include quantity sets (default: true) */
-  includeQuantities?: boolean;
-  /** Include relationships (default: true) */
-  includeRelationships?: boolean;
-
-  /** Apply mutations from MutablePropertyView (default: true if provided) */
-  applyMutations?: boolean;
-  /** Only export entities with mutations (delta export) */
-  deltaOnly?: boolean;
-
-  /** Only export entities currently visible in the viewer */
-  visibleOnly?: boolean;
-  /** Hidden entity IDs (local expressIds) — required when visibleOnly is true */
-  hiddenEntityIds?: Set<number>;
-  /** Isolated entity IDs (local expressIds, null = no isolation active) */
-  isolatedEntityIds?: Set<number> | null;
-
-  /** Georeferencing mutations to apply (IfcProjectedCRS / IfcMapConversion edits) */
-  georefMutations?: {
-    projectedCRS?: Partial<ProjectedCRS>;
-    mapConversion?: Partial<MapConversion>;
-  };
-
-  /**
-   * Seeded randomness for the GlobalIds this exporter SYNTHESIZES:
-   * the `IfcPropertySet` / `IfcElementQuantity` roots regenerated for
-   * mutated (or overlay-created) property and quantity sets, their
-   * `IfcRelDefinesByProperties` links. Without it those come from the platform
-   * CSPRNG, so two exports of the same model differ in exactly those bytes -
-   * which breaks byte-reproducibility for in-store builds that call
-   * `addPropertySet` / `addQuantitySet` (the sets themselves live in the
-   * mutation overlay and only become IFC roots here). Pass the same seeded
-   * source used for `SpatialAnchor.guidRandom` to close that gap. Default
-   * (omitted) behaviour for THESE ids is unchanged: random.
-   *
-   * NOT the `IFCPROXY` placeholders any more (#2733). Those used to be minted
-   * from this source too, so an omitted `guidRandom` made every downgraded
-   * IFC4X3 entity differ on re-export. They are now derived from the source
-   * line when this is omitted, and only fall back to this source when it is
-   * supplied - so passing a seeded source still pins them, but NOT passing one
-   * no longer makes them random. See `convertStepLine`.
-   */
-  guidRandom?: RandomSource;
-  /**
-   * Pin the STEP header `FILE_NAME` timestamp (STEP format, e.g.
-   * `20240101T000000`). Omitted = the wall clock, as before. Required for
-   * genuinely byte-identical exports, since the header otherwise carries the
-   * export instant.
-   */
-  timeStamp?: string;
-
-  /** Progress callback for async export */
-  onProgress?: (progress: StepExportProgress) => void;
-}
-
-/**
- * Progress information during STEP export
- */
-export interface StepExportProgress {
-  /** Current phase of export */
-  phase: 'preparing' | 'entities' | 'assembling';
-  /** Progress 0-1 */
-  percent: number;
-  /** Number of entities processed so far */
-  entitiesProcessed: number;
-  /** Total entities to process */
-  entitiesTotal: number;
-}
-
-/**
- * Result of STEP export
- */
-export interface StepExportResult {
-  /** STEP file content as bytes (avoids V8 string length limit for large files) */
-  content: Uint8Array;
-  /** Statistics about the export */
-  stats: {
-    /** Total entities exported */
-    entityCount: number;
-    /** New entities created for mutations */
-    newEntityCount: number;
-    /** Entities modified by mutations */
-    modifiedEntityCount: number;
-    /** File size in bytes */
-    fileSize: number;
-    /**
-     * Non-fatal refusals: things the caller asked for that this export could
-     * not write. Empty when the export did everything it was asked to do.
-     *
-     * A requested `georefMutations.mapConversion` is one case: with no
-     * `IfcGeometricRepresentationContext` to reference as `SourceCRS`, the
-     * `IfcMapConversion` is skipped (writing it would produce a dangling
-     * reference) while the `IfcProjectedCRS` is still written — so the output
-     * is indistinguishable from "no map conversion was requested" unless the
-     * caller reads this (#2067).
-     *
-     * A WITHHELD RELATIONSHIP is the other: when a relationship names an
-     * entity this export is not writing, in a slot with no spelling for an
-     * omitted reference, the whole relationship line is dropped rather than
-     * shipped dangling — see {@link relationshipWithheldWarning}. This can
-     * happen on a plain full export with no options set at all, so it is
-     * reported rather than left to be discovered by a diff.
-     *
-     * Same `string[]` shape as `MergeExportResult.stats.warnings`.
-     */
-    warnings: string[];
-  };
-}
-
-/**
- * Message for a relationship this export DROPPED rather than rewrote.
- *
- * `filterHiddenRefsFromRelationshipLine` removes an omitted `#N` from a
- * SET/LIST attribute, but a single-valued attribute has no STEP spelling for
- * "omitted" and an empty SET is not the same statement as the original — so in
- * both of those cases it withholds the whole line and the relationship simply
- * is not in the output. Withholding beats shipping a dangling `#N`, but it is
- * not free: every OTHER entity that relationship named loses the association.
- * A visible element can therefore come out of a plain full export with one
- * fewer pset than it went in with, and before this warning existed nothing in
- * the result said so (adversarial review of #2668).
- *
- * Deliberately reports the relationship rather than the omitted target: the
- * target's own omission is already the caller's own doing in every reason but
- * the unreadable-ref one, whereas the lost association is the surprise.
- */
-const relationshipWithheldWarning = (expressId: number, type: string): string =>
-  `Relationship #${expressId} (${type}) was withheld from the export: it names at least one entity that has no line in this export, in a slot with no spelling for an omitted reference (a single-valued attribute, or a set whose every member is omitted). Anything else that relationship associated is no longer associated in the output.`;
-
-/**
- * What `step-attribute-mutations.ts`'s `applySourceLineMutations` produced: the rewritten
- * line, plus which edit kinds that rewrite actually delivered. The delivery
- * half is {@link SourceLineDelivery} rather than three loose booleans so that
- * the pipeline and the ledger cannot disagree about what a source line carries
- * — an added kind has one place to be added.
- */
-export type SourceLineMutations = SourceLineDelivery & { text: string };
-
-/**
- * The state one `export()` call shares across its seven phases.
- *
- * Introduced by step 1 of #2475: `export()` is ~1267 lines and the phases a
- * split would separate are held together by ~30 local bindings, most of which
- * are read in three or more phases. Naming that set once — as an interface
- * with a single construction site at the top of `export()` — is what lets a
- * later phase extraction take one parameter instead of fifteen.
- *
- * Two properties of this object are load-bearing and must survive every later
- * move:
- *
- * 1. **The predicates are members, not duplicated expressions.** Six of them
- *    (`isOverlayCreated`, `isReadableSourceRef`, `isGeometryExcluded`,
- *    `hasEmittableHostBytes`, `willBeEmitted`,
- *    `isRefExcludedDuringClosureWalk`) exist precisely so two phases cannot
- *    disagree about a gate — see the comments at their construction sites for
- *    the corrupt files the earlier, per-phase versions let through (#2491,
- *    #2414, #2398, #2637). A phase that reimplements one of these instead of
- *    reading it off the pass reintroduces exactly that class of defect.
- * 2. **`allowedEntityIds` and `hiddenProductIds` are mutable, and the
- *    predicates close over the pass rather than over a snapshot.** The
- *    visible-only closure walk assigns both AFTER construction, and
- *    `isRefExcludedDuringClosureWalk` is handed to that walk while they are
- *    still null. The output-line filter reads them too, through
- *    `isOmittedFromOutput` -> `willBeEmitted`, so neither can be a snapshot
- *    taken before the walk ran — that is the invariant the #2637 regression
- *    broke.
- *
- * Deliberately NOT on the pass, and why: `isOmittedFromOutput`,
- * `mayNameOmittedRefs` and
- * `overlayNewEntityCount` are eagerly-computed values whose value is only
- * defined after work that runs past this construction site, so hoisting them
- * would change what they compute rather than where they are named;
- * `generatedTypeOwnedPsetIds` is read in one phase only — a local inside
- * `step-property-sets.ts:generatePropertyAndQuantitySetEntities`, which holds
- * both the loop that writes it and the loop that reads it (#2475).
- */
-export interface ExportPass {
-  /** Output accumulator: every DATA-section line this export will write. */
-  readonly entities: string[];
-  /** Lines contributed by entities that have no source record. */
-  newEntityCount: number;
-
-  // ---- resolved options / schema ----
-  readonly schema: IfcSchemaVersion;
-  readonly sourceSchema: IfcSchemaVersion;
-  readonly converting: boolean;
-  readonly sourceHeader: IfcSourceHeader | undefined;
-  readonly schemaToken: string;
-  readonly overlayActive: boolean;
-
-  // ---- indexes and ledgers ----
-  readonly effective: EffectiveEntityIndex;
-  readonly modifications: ModificationLedger;
-  /** Widened from the imported `InPlaceNominees` (whose sets are readonly)
-   *  because the collection passes below add to them. */
-  readonly inPlaceNominees: { attribute: Set<number>; georeferencing: Set<number> };
-
-  // ---- visible-only closure results (assigned after construction) ----
-  allowedEntityIds: Set<number> | null;
-  hiddenProductIds: ReadonlySet<number> | null;
-
-  // ---- the collection passes' output ----
-  readonly modifiedEntities: Set<number>;
-  readonly modifiedAttributes: Map<number, Map<string, string>>;
-  readonly newPropertySets: Array<{ entityId: number; psets: PropertySet[] }>;
-  readonly newQuantitySets: Array<{ entityId: number; qsets: QuantitySet[] }>;
-  readonly typeOwnedPsetNamesByEntity: Map<number, Set<string>>;
-  readonly typeOwnedPsetIdsByEntity: Map<number, number[]>;
-  readonly rewrittenEntityIds: Set<number>;
-  readonly rewrittenEntityLines: Map<number, string>;
-  readonly overlayTypeOwnedPsets: Map<number, IfcAttributeValue>;
-  readonly skipPropertySetIds: Set<number>;
-  readonly skipRelationshipIds: Set<number>;
-  readonly newGeorefLines: string[];
-  readonly warnings: string[];
-
-  // ---- the shared predicates (see item 1 above) ----
-  readonly buildHeader: (modifications: number) => string;
-  readonly isOverlayCreated: (entityId: number) => boolean;
-  readonly isReadableSourceRef: ReturnType<typeof createSourceRefReader>;
-  readonly isGeometryExcluded: (entityId: number, recordType: string) => boolean;
-  readonly hasEmittableHostBytes: (entityId: number) => boolean;
-  readonly willBeEmitted: (entityId: number) => boolean;
-  readonly isRefExcludedDuringClosureWalk: (id: number) => boolean;
-}
 
 /**
  * IFC STEP file exporter

--- a/packages/export/src/step-geometry-types.ts
+++ b/packages/export/src/step-geometry-types.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The entity types a STEP export treats as geometry.
+ *
+ * Split out of `StepExporter` for #2475. It was a private method only by
+ * habit: it reads nothing off the instance, so every consumer already
+ * received it as an injected callback rather than calling it through an
+ * exporter. Moving it changes no call site -- the three inside
+ * `step-exporter.ts` stop wrapping it in an arrow, and that is all.
+ *
+ * The set is the definition, not a cache of one. `includegeometry-header-count.test.ts`
+ * and `retype-geometry-boundary.test.ts` pin what belongs in it, and
+ * `reference-collector.ts` documents the one place a type in this set is
+ * still reachable when geometry is excluded.
+ */
+
+/**
+ * Check if an entity type is a geometry-related type
+ */
+export function isGeometryEntity(type: string): boolean {
+  const geometryTypes = new Set([
+    'IFCCARTESIANPOINT',
+    'IFCDIRECTION',
+    'IFCAXIS2PLACEMENT2D',
+    'IFCAXIS2PLACEMENT3D',
+    'IFCLOCALPLACEMENT',
+    'IFCSHAPEREPRESENTATION',
+    'IFCPRODUCTDEFINITIONSHAPE',
+    'IFCGEOMETRICREPRESENTATIONCONTEXT',
+    'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
+    'IFCEXTRUDEDAREASOLID',
+    'IFCFACETEDBREP',
+    'IFCPOLYLOOP',
+    'IFCFACE',
+    'IFCFACEOUTERBOUND',
+    'IFCCLOSEDSHELL',
+    'IFCRECTANGLEPROFILEDEF',
+    'IFCCIRCLEPROFILEDEF',
+    'IFCARBITRARYCLOSEDPROFILEDEF',
+    'IFCPOLYLINE',
+    'IFCTRIMMEDCURVE',
+    'IFCBSPLINECURVE',
+    'IFCBSPLINESURFACE',
+    'IFCTRIANGULATEDFACESET',
+    'IFCPOLYGONALFACE',
+    'IFCINDEXEDPOLYGONALFACE',
+    'IFCPOLYGONALFACESET',
+    'IFCSTYLEDITEM',
+    'IFCPRESENTATIONSTYLEASSIGNMENT',
+    'IFCSURFACESTYLE',
+    'IFCSURFACESTYLERENDERING',
+    'IFCCOLOURRGB',
+  ]);
+  return geometryTypes.has(type);
+}

--- a/packages/export/src/step-georeferencing.test.ts
+++ b/packages/export/src/step-georeferencing.test.ts
@@ -848,7 +848,12 @@ describe('express ids are unique across an export that allocates on both paths',
     // The fixture is only meaningful if both paths actually emitted.
     expect(content).toContain('IFCPROJECTEDCRS(');
     expect(content).toContain('IFCMAPCONVERSION(');
-    expect(content).toContain('IFCPROPERTYSET(');
+    // Not `IFCPROPERTYSET(`: this fixture already defines four of those and a
+    // full export ships them verbatim, so that assertion would hold even if
+    // the generated-pset path emitted nothing -- leaving the duplicate check
+    // covering the georef path alone. `IsExternal` appears nowhere in the
+    // source, so it can only have come from the path this test needs to run.
+    expect(content).toContain("IFCPROPERTYSINGLEVALUE('IsExternal'");
 
     expect(duplicateDefinedIds(content)).toEqual([]);
     // The other half of integrity still holds, so a "fix" that removed a

--- a/packages/export/src/step-georeferencing.test.ts
+++ b/packages/export/src/step-georeferencing.test.ts
@@ -32,6 +32,8 @@
 import { describe, expect, it } from 'vitest';
 import { IfcParser, asSourceBytes, type IfcDataStore } from '@ifc-lite/parser';
 import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
+import { PropertyValueType } from '@ifc-lite/data';
+import { extractPropertiesOnDemand } from '@ifc-lite/parser';
 import { StepExporter } from './step-exporter.js';
 
 /** Decode Uint8Array content to string for test assertions */
@@ -769,5 +771,95 @@ describe('a georeferencing edit is the same site with the same signal', () => {
 
     expect(text).toContain(`#${MAP_CONVERSION_ID}=IFCMAPCONVERSION($,#${CRS_ID},1500.`);
     expect(result.stats.modifiedEntityCount).toBe(1);
+  });
+});
+
+/**
+ * Every `#N=` in an export must be defined exactly once.
+ *
+ * `findDanglingRefs` above answers the other half of referential integrity —
+ * "is every reference satisfied" — and cannot answer this one, by
+ * construction: it collects defined ids into a `Set`, so a second definition
+ * of the same id is absorbed silently rather than flagged. Fed an export that
+ * defines `#76` twice, it returns `[]`.
+ *
+ * The failure this guards against is a refactor of the express-id counter.
+ * `StepExporter` mints new ids from ONE instance field, through two closures —
+ * `allocateExpressId: () => this.nextExpressId++` in `georefContext()` and
+ * again in `propertySetContext()`. Capturing that counter's VALUE instead of
+ * closing over the field gives each builder its own sequence starting from the
+ * same base, and the two paths then mint the same ids. The output stays
+ * well-formed STEP and every reference still resolves — it just means two
+ * different entities now, which is why nothing else in the suite notices.
+ *
+ * That is why #2475 left both of those builders on the class while moving the
+ * forwarding ones out; see `step-export-contexts.ts`.
+ */
+function duplicateDefinedIds(content: string): number[] {
+  // Anchored to start-of-line: every entity is written on its own line, so a
+  // `#N` appearing mid-line is a REFERENCE inside another entity's argument
+  // list and must not be counted as a definition.
+  const seen = new Set<number>();
+  const dupes = new Set<number>();
+  for (const m of content.matchAll(/^#(\d+)\s*=/gm)) {
+    const id = Number(m[1]);
+    if (seen.has(id)) dupes.add(id);
+    seen.add(id);
+  }
+  return [...dupes].sort((a, b) => a - b);
+}
+
+describe('express ids are unique across an export that allocates on both paths', () => {
+  it('mints distinct ids for generated psets and for created georeferencing', async () => {
+    // Both allocating paths must run in ONE export or this pins nothing: the
+    // georef path mints IfcProjectedCRS/IfcMapConversion, the property path
+    // mints the pset trio. A fixture exercising only one cannot collide.
+    const store = await new IfcParser().parseColumnar(
+      new TextEncoder().encode(SIMPLE_TYPE_INHERITANCE_IFC).buffer,
+    );
+    const view = new MutablePropertyView(null, 'm');
+    view.setOnDemandExtractor((id: number) => extractPropertiesOnDemand(store, id));
+    view.setProperty(74, 'Pset_WallCommon', 'IsExternal', true, PropertyValueType.Boolean);
+
+    const result = new StepExporter(store, view).export({
+      schema: 'IFC4',
+      applyMutations: true,
+      georefMutations: {
+        projectedCRS: {
+          name: 'EPSG:2056',
+          description: 'CH1903+ / LV95',
+          geodeticDatum: 'CH1903+',
+          mapProjection: 'Swiss Oblique Mercator 1995',
+          mapUnit: 'METRE',
+        },
+        mapConversion: {
+          eastings: 2600000,
+          northings: 1200000,
+          orthogonalHeight: 500,
+          xAxisAbscissa: 0,
+          xAxisOrdinate: 1,
+          scale: 1,
+        },
+      },
+    });
+
+    const content = decode(result.content);
+
+    // The fixture is only meaningful if both paths actually emitted.
+    expect(content).toContain('IFCPROJECTEDCRS(');
+    expect(content).toContain('IFCMAPCONVERSION(');
+    expect(content).toContain('IFCPROPERTYSET(');
+
+    expect(duplicateDefinedIds(content)).toEqual([]);
+    // The other half of integrity still holds, so a "fix" that removed a
+    // duplicate by dropping a definition would not pass either.
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('counts a repeated definition as a duplicate, so the check can fail', () => {
+    // The check itself has to be falsifiable, and has to tell a definition
+    // from a reference — otherwise the assertion above is decoration.
+    expect(duplicateDefinedIds('#7=IFCWALL($);\n#8=IFCSLAB($);\n#7=IFCBEAM($);\n')).toEqual([7]);
+    expect(duplicateDefinedIds('#7=IFCWALL($);\n#9=IFCREL(#7,#7);\n')).toEqual([]);
   });
 });

--- a/packages/export/src/step-omission-predicates.ts
+++ b/packages/export/src/step-omission-predicates.ts
@@ -296,8 +296,9 @@ export function evaluateOmissionPredicates(
    *
    * `allowedEntityIds !== null`, not `options.visibleOnly === true`. Not the
    * same test: the closure is built under `if (options.visibleOnly &&
-   * ctx.dataStore.source)` (`step-collection.ts:69`), which is TRUTHY rather
-   * than `=== true`, and which
+   * ctx.dataStore.source)` in `step-collection.ts` — quoted rather than cited
+   * by line, because the line moved by three in the very commit that added
+   * this reference — which is TRUTHY rather than `=== true`, and which
    * is a SECOND read of the caller's object. A plain-JS caller of this
    * published package passing `visibleOnly: 1` — or a `get visibleOnly()` that
    * answers `true` once — built the closure while the gate read false and

--- a/packages/export/src/step-omission-predicates.ts
+++ b/packages/export/src/step-omission-predicates.ts
@@ -135,7 +135,12 @@ export function evaluateOmissionPredicates(
   // Georef-only deltas (newGeorefLines populated but no entity changes) must
   // still produce a non-empty DATA section.
   if (
-    options.deltaOnly
+    // `=== true`, matching `step-pass-builder.ts`'s two reads of the same
+    // option. A plain-JS caller passing `deltaOnly: 1` would otherwise have
+    // this module call the export a delta while the predicates there call it
+    // a full export -- the same divergence this file argues against for
+    // `visibleOnly` a few paragraphs down.
+    options.deltaOnly === true
     && pass.modifiedEntities.size === 0
     && overlayNewEntityCount === 0
     && pass.newGeorefLines.length === 0

--- a/packages/export/src/step-omission-predicates.ts
+++ b/packages/export/src/step-omission-predicates.ts
@@ -1,0 +1,327 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which ids a STEP export may still NAME, once it has decided which ids it is
+ * writing.
+ *
+ * Split out of `step-exporter.ts` for #2475, verbatim apart from the two
+ * changes noted below. It runs immediately after `collectModifications` and
+ * before the output passes, and that position is not incidental: everything
+ * here reads what the collection phase produced -- `pass.modifiedEntities`,
+ * `pass.newGeorefLines`, `pass.allowedEntityIds`, `pass.overlayActive` -- and
+ * everything the output passes do with omitted references reads what this
+ * returns. Calling it earlier gives answers computed from an unpopulated pass.
+ *
+ * Why not in `step-collection.ts`: that module produces the values these
+ * predicates consume and never reads them back, so putting them there would
+ * relocate a dependency rather than remove one. That argument was always about
+ * `step-collection.ts` specifically, not about these predicates being welded
+ * to `export()`.
+ *
+ * TWO CHANGES FROM THE ORIGINAL, both forced by it becoming a function:
+ *
+ * 1. The deltaOnly empty short-circuit used to `return` out of `export()`.
+ *    A free function cannot, so it returns a tagged `'short-circuit'` result
+ *    the caller returns instead. That rewrite is safe by measurement, not by
+ *    argument: disabling the branch entirely leaves the suite green and the
+ *    emitted bytes and stats identical, because for a model with no edits the
+ *    ordinary path arrives at the same place. See
+ *    `delta-empty-shortcircuit.test.ts`, which pins the contract and says
+ *    outright that it does not pin the branch.
+ * 2. `this.mutationView` arrives as a parameter.
+ */
+
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import type { ExportPass, StepExportOptions, StepExportResult } from './step-export-types.js';
+
+/**
+ * Either the export is already over, or here are the two things the output
+ * passes need from it.
+ *
+ * A tagged union rather than an optional field, so a caller cannot read
+ * `isOmittedFromOutput` off a short-circuited result and get `undefined`
+ * without the compiler saying so.
+ */
+export type OmissionEvaluation =
+  | { readonly kind: 'short-circuit'; readonly result: StepExportResult }
+  | {
+      readonly kind: 'continue';
+      readonly isOmittedFromOutput: (id: number) => boolean;
+      /** A boolean, not a predicate: the precondition both filter sites gate on. */
+      readonly mayNameOmittedRefs: boolean;
+    };
+
+export function evaluateOmissionPredicates(
+  pass: ExportPass,
+  options: StepExportOptions,
+  applyMutations: boolean,
+  excludeGeometry: boolean,
+  mutationView: MutablePropertyView | null,
+): OmissionEvaluation {
+  /**
+   * "Does this model hold a record whose bytes this export cannot read?" —
+   * the one disjunct of {@link mayNameOmittedRefs} that is not already a
+   * value in hand, so it is a function and called last, behind `||`.
+   *
+   * Scans the EFFECTIVE index, and that is a requirement rather than an
+   * implementation detail: it has to cover the id space
+   * `isOmittedFromOutput` answers over, and an unreadable record can live in
+   * `deferredEntityIndex` — the secondary index `getCompleteEntityIndex`
+   * exists to merge — and nowhere in `entityIndex.byId`. Scanning `byId`,
+   * the obvious cheaper source, was measured to leave the gate false and
+   * ship the dangling ref; `relationship-filter-gate.test.ts` pins the
+   * merged scan behaviourally so that shortcut cannot come back as an
+   * optimisation.
+   *
+   * Reads the ref ITERATION yields — what the source-iteration pass's own
+   * skip reads — rather than re-asking `effective.get(id)` per id as
+   * `willBeEmitted` does, which on the largest files would cost a binary
+   * search and an allocation per entity and defeat the point of the gate.
+   * Every index here keeps the two in step by construction:
+   * `CompactEntityIndex` serves `get`, `has` and iteration from one pair of
+   * `Uint32Array`s, a `Map` trivially agrees, the merged deferred view is
+   * `byId.get ?? deferred.get` over `yield* byId; yield* deferred`, and
+   * `OverlayIndex` filters both by one tombstone set. An index whose `has`
+   * accepted an id its iteration never yields would defeat this — and would
+   * equally defeat the source-iteration pass's skip, so that file is broken
+   * either way; nothing in the repo builds one.
+   *
+   * Not short-circuited on `overlayActive`: an overlay-created record carries
+   * `(OVERLAY_BYTE_OFFSET, 0)` and so counts as unreadable here, which would
+   * make this always answer true once an overlay exists. Harmless —
+   * `overlayActive` is an earlier disjunct, so this never runs then — and
+   * correct if it ever did.
+   *
+   * ## Why a standalone pass rather than a value off the index
+   *
+   * Measured: 12.0 ms of a 470 ms export at 714,485 entities (2.55%), one
+   * call, whole index walked because a well-formed model gives it nothing to
+   * short-circuit on. The cheaper shape was prototyped and is 13x faster —
+   * `min(byteLength)` and `max(byteOffset + byteLength)` over
+   * `CompactEntityIndex`'s own `Uint32Array`s answer "is every ref readable
+   * within `extent`" exactly and allocation-free in 0.74 ms — and was not
+   * taken, because 11 ms does not buy what it costs.
+   *
+   * It could only stand in FRONT of this loop, never replace it:
+   * `EntityByIdIndex` is a structural type and plain `Map`s satisfy it
+   * (`synthetic-data-store.ts` builds one), so the walk stays for those. That
+   * makes it a second implementation of one predicate across a package
+   * boundary — the defect class #2637, #2668 and this gate are all instances
+   * of. And storing it at construction is the invariant
+   * `source-ref-bounds.ts` exists to delete: `CompactEntityIndex` is built by
+   * its builder, by `compactEntityIndexFromColumns` in the transport, and by
+   * embedders, so a value one producer writes is a value the next can skip,
+   * whereas testing the ref where it is READ cannot be bypassed. If 2.5% ever
+   * has to go, the safe shape is a memoized derivation the index computes
+   * from its own arrays on demand — not a field set at build time.
+   */
+  const hasAnyUnreadableSourceRef = (): boolean => {
+    for (const [, ref] of pass.effective) {
+      if (!pass.isReadableSourceRef(ref)) return true;
+    }
+    return false;
+  };
+
+  // If delta only, only export modified entities. Overlay-created entities
+  // also count — without this, `createEntity()`-only edits would silently
+  // drop out of delta exports.
+  const overlayNewEntityCount = (
+    mutationView
+    && applyMutations
+    && typeof mutationView.getNewEntities === 'function'
+  ) ? mutationView.getNewEntities().length : 0;
+  // Georef-only deltas (newGeorefLines populated but no entity changes) must
+  // still produce a non-empty DATA section.
+  if (
+    options.deltaOnly
+    && pass.modifiedEntities.size === 0
+    && overlayNewEntityCount === 0
+    && pass.newGeorefLines.length === 0
+  ) {
+    const emptyContent = new TextEncoder().encode(pass.buildHeader(0) + 'DATA;\nENDSEC;\nEND-ISO-10303-21;\n');
+    return {
+      kind: 'short-circuit',
+      result: {
+        content: emptyContent,
+        stats: {
+          entityCount: 0,
+          newEntityCount: 0,
+          modifiedEntityCount: 0,
+          fileSize: emptyContent.byteLength,
+          warnings: pass.warnings,
+        },
+      },
+    };
+  }
+
+
+  /**
+   * "May a line this export writes name `#id`?" — the single predicate both
+   * relationship-line filter sites consume, derived from `willBeEmitted`
+   * rather than from a second list kept in step with it by hand.
+   *
+   * DERIVED, not identical, and the gaps are named below rather than glossed:
+   * a scope qualifier for ids the file never had, and `deltaOnly`, where
+   * `willBeEmitted` answers `true` for a source record whose line this export
+   * does not write at all (the source-iteration pass is skipped wholesale in
+   * that mode). Nor does this make the CLOSURE WALK agree with either: the
+   * walk keeps `isRefExcludedDuringClosureWalk` and diverges from this
+   * predicate for an unreadable source ref — see the note on that predicate,
+   * and the "walk and output predicates diverge" test.
+   *
+   * The hand-kept second list is the bug this replaces. `willBeEmitted` recognises
+   * seven reasons a line never lands — outside the closure, hidden product,
+   * tombstoned, never existed, unreadable source ref (#2491), geometry
+   * excluded by options, and the `deltaOnly` carve-out — while the filter
+   * used to consume `(hiddenProductIds !== null && hiddenProductIds.has(id))
+   * || effective.isDeleted(id)`, which answered for two: hidden product, and
+   * tombstoned. Notably NOT "never existed" — that one is deliberately out of
+   * scope for the filter even now, for the reason under the qualifier heading
+   * below. The gap was live: on a PLAIN full export, with no `visibleOnly`,
+   * no deletions and no overlay, an unreadable ref made the source-iteration
+   * pass skip an entity's line while an `IFCREL*` naming it shipped verbatim,
+   * dangling.
+   *
+   * Deriving the filter from `willBeEmitted` is also what fixed the
+   * `mayNameExcludedRefs` gate that stands in front of both call sites. That
+   * gate used to be a SECOND, shorter enumeration of the same reasons
+   * (hidden products exist, or an overlay is active) and answered `false` for
+   * exactly the unreadable-ref export above, so the filter never ran at all.
+   * It is now {@link mayNameOmittedRefs} — see there for why a gate is kept
+   * at all (running the filter on every `IFCREL*` line costs +13% of a
+   * 714k-entity export) and for the enumeration it has to cover.
+   *
+   * ## The one qualifier on top of `willBeEmitted`
+   *
+   * `willBeEmitted` answers NO for an id neither the file nor the session
+   * ever had, which is right for its own job — nothing GENERATED may name an
+   * id that does not exist. It is the wrong answer for rewriting a SOURCE
+   * line, and the difference is whose bug it is. A `#999` already sitting in
+   * a relationship's `OwnerHistory` slot in the input file is a dangling ref
+   * this export did not create and cannot repair; `filterHiddenRefsFromRelationshipLine`
+   * withholds a whole relationship when an excluded id is in a bare scalar,
+   * so treating it as an exclusion would DELETE a visible element's pset over
+   * somebody else's corrupt file. That is the harm #2637 was about, and
+   * `step-exporter.test.ts` states the position out loud: a pre-existing
+   * dangling ref is out of scope and ships as it arrived.
+   *
+   * So the filter asks the narrower question: is `#id` an entity this model
+   * HAS, that this export is nonetheless not writing? `effective.has` is
+   * false for a tombstone, hence the explicit `isDeleted` arm — deleting an
+   * entity IS this session's doing and must be filtered.
+   *
+   * This is a scope qualifier, not a second enumeration of omission reasons:
+   * an eighth reason added to `willBeEmitted` still reaches the filter with
+   * no edit here.
+   *
+   * ## What the filter can and cannot reach
+   *
+   * Only `IFCREL*` lines. A `#N` named from a product's `Representation` or
+   * `ObjectPlacement` slot is not touched, so `includeGeometry:false` — a
+   * reason `willBeEmitted` does answer for — produces the same dangling refs
+   * with this predicate as without it. Measured on `tests/models/AB22.ifc`:
+   * 80 dangling refs before and after, output byte-identical but for the
+   * header timestamp.
+   *
+   * ## Withholding is not free
+   *
+   * When the omitted id sits in a single-valued slot, or is a set's only
+   * member, `filterHiddenRefsFromRelationshipLine` withholds the WHOLE
+   * relationship — so an entity that relationship also named loses the
+   * association, on a plain full export with no options set. That is why the
+   * call sites push {@link relationshipWithheldWarning}.
+   *
+   * See `unreadable-ref-dangling.test.ts` for the reproduction. #2637 is the
+   * prior instance of this class, which took seven rounds because the same
+   * decision was recomputed per call site.
+   */
+  const isOmittedFromOutput = (id: number): boolean =>
+    (pass.effective.has(id) || pass.effective.isDeleted(id)) && !pass.willBeEmitted(id);
+
+  /**
+   * "Can ANY id be omitted from this export at all?" — the precondition both
+   * `IFCREL*` filter sites are gated on, so the common export pays nothing.
+   *
+   * ## Why a gate exists
+   *
+   * Running `filterHiddenRefsFromRelationshipLine` on every `IFCREL*` line
+   * costs a re-parse of that line's attribute list, and a large model is
+   * mostly relationships. Measured on `tests/models/ara3d/schependomlaan.ifc`
+   * (714,485 entities, 21 interleaved reps in randomised order): 463 ms
+   * median with this gate false versus 523 ms filtering unconditionally,
+   * **+13%**. That is a real price paid on every export to protect a state
+   * most exports are not in. With the gate, the same export is 475 ms, +2.7%,
+   * all of it the fourth disjunct's one pass.
+   *
+   * ## Why THIS gate, and not the one that shipped before
+   *
+   * The gate this replaces was a second, hand-kept enumeration of "reasons an
+   * entity might be excluded", and it went stale exactly as such lists do: it
+   * named hidden products and the overlay and knew nothing about an unreadable
+   * source ref, so the bug this branch fixes reached the output with the
+   * filter switched off. A cheap gate is safe only as an OVER-APPROXIMATION of
+   * `isOmittedFromOutput` that can be checked against `willBeEmitted` branch
+   * by branch — so every branch is listed, with the disjunct that covers it:
+   *
+   * | `willBeEmitted` answers NO at                | covered by                    |
+   * |----------------------------------------------|-------------------------------|
+   * | `allowedEntityIds !== null && !has(id)`      | `allowedEntityIds !== null`   |
+   * | `!ref`, because the overlay tombstoned `id`  | `overlayActive`               |
+   * | overlay-created, geometry excluded           | `overlayActive`               |
+   * | `!isReadableSourceRef(ref)`                  | `hasAnyUnreadableSourceRef()` |
+   * | source-backed, geometry excluded             | `excludeGeometry`             |
+   * | `!ref`, because `id` never existed           | out of scope (below)          |
+   * | `!ref` while `has(id)` is TRUE               | nothing (below)               |
+   *
+   * "Never existed" needs no disjunct: `isOmittedFromOutput`'s own
+   * `(has || isDeleted)` qualifier already drops it, deliberately — a
+   * pre-existing dangling ref in somebody else's file is not this export's to
+   * repair (see that predicate's note).
+   *
+   * The last row is a real hole and is stated rather than hidden: an index
+   * that answers `has(id)` for an id its iteration never yields makes
+   * `isOmittedFromOutput` true with no disjunct true. It needs an index whose
+   * `has`, `get` and iteration disagree, which nothing in the repo builds and
+   * which would already break the source-iteration pass's own skip — see
+   * {@link hasAnyUnreadableSourceRef}, which rests on the same agreement.
+   *
+   * Three of the four disjuncts are reads of values this export already
+   * computed. Only the fourth costs anything, and it short-circuits: `||`
+   * evaluates it solely when the other three are false, i.e. only for an
+   * export that has nothing else to filter for.
+   *
+   * ## The two spellings that are deliberately NOT the obvious ones
+   *
+   * `allowedEntityIds !== null`, not `options.visibleOnly === true`. Not the
+   * same test: the closure is built under `if (options.visibleOnly &&
+   * ctx.dataStore.source)` (`step-collection.ts:69`), which is TRUTHY rather
+   * than `=== true`, and which
+   * is a SECOND read of the caller's object. A plain-JS caller of this
+   * published package passing `visibleOnly: 1` — or a `get visibleOnly()` that
+   * answers `true` once — built the closure while the gate read false and
+   * shipped a relationship naming an entity outside it. Executed, not
+   * reasoned: 192 of an 800-case sweep over `visibleOnly`/`hidden`/`isolated`
+   * combinations shipped a dangling ref against the `=== true` spelling, 0
+   * against this one. Reading the state the walk PRODUCED cannot disagree with
+   * the walk, whatever `options` says afterwards.
+   *
+   * It is also wider than the `hiddenProductIds.size > 0` the old gate used: a
+   * closure exists whenever `visibleOnly` was requested, even with nothing
+   * hidden, and can exclude an entity the roots simply never reach. No fixture
+   * has produced that case, so the widening is defensive — but a gate that is
+   * true too often costs speed on a rare path, while one that is false too
+   * rarely ships a corrupt file, and this one costs nothing.
+   *
+   * `overlayActive` and `excludeGeometry` are the SAME consts the effective
+   * index and `isGeometryExcluded` are built from — one read of `options` per
+   * question, shared — so those two cannot disagree with the predicate either.
+   */
+  const mayNameOmittedRefs =
+    pass.allowedEntityIds !== null
+    || pass.overlayActive
+    || excludeGeometry
+    || hasAnyUnreadableSourceRef();
+  return { kind: 'continue', isOmittedFromOutput, mayNameOmittedRefs };
+}

--- a/packages/export/src/step-overlay-entities.ts
+++ b/packages/export/src/step-overlay-entities.ts
@@ -63,7 +63,7 @@ export interface OverlayEntitiesContext {
     schemaVersion: ExportPass['sourceSchema'],
     onRejected?: (attrName: string, value: string) => void,
   ) => string;
-  /** `StepExporter.isGeometryEntity`, also read by the setup closure and by
+  /** `isGeometryEntity` (`step-geometry-types.ts`), also read by the setup closure and by
    *  `step-source-iteration.ts`. */
   readonly isGeometryEntity: (type: string) => boolean;
   /** The `relationshipWithheldWarning` message builder (`step-exporter.ts`):

--- a/packages/export/src/step-pass-builder.test.ts
+++ b/packages/export/src/step-pass-builder.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The one rule `step-pass-builder.ts` has, made a test rather than a comment.
+ *
+ * `buildExportPass` returns a `pass` whose `allowedEntityIds` and
+ * `hiddenProductIds` are still `null`. `collectModifications` assigns them
+ * afterwards, on that same object, and the pass's predicates read them off
+ * `pass` at call time. Anything that breaks that identity — a spread at the
+ * return, a caller storing a copy, a well-meaning snapshot of
+ * `allowedEntityIds` into a local — leaves every predicate answering from a
+ * value that never fills in.
+ *
+ * That is #2637, and it fails silently: a `visibleOnly` export ships a
+ * structurally wrong file rather than throwing. Before the split the rule was
+ * enforced by the literal being physically inside `export()`, where there was
+ * nothing to copy. Now that it is a function with a return value, the rule
+ * needs its own guard.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser } from '@ifc-lite/parser';
+import { buildExportPass } from './step-pass-builder.js';
+
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t.ifc','',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0proj00000000000000000',$,'P',$,$,$,$,$,$);
+#10=IFCWALL('0wall10000000000000000',$,'W',$,$,$,$,$,$);
+#11=IFCWALL('0wall20000000000000000',$,'W2',$,$,$,$,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+async function pass() {
+  const store = await new IfcParser().parseColumnar(new TextEncoder().encode(IFC).buffer, { disableWorkerScan: true });
+  return buildExportPass({
+    dataStore: store,
+    mutationView: null,
+    isGeometryEntity: () => false,
+    options: { schema: 'IFC4' },
+    schema: 'IFC4',
+    sourceSchema: 'IFC4',
+    converting: false,
+    applyMutations: false,
+    excludeGeometry: false,
+    sourceHeader: undefined,
+    schemaToken: 'IFC4',
+  });
+}
+
+describe('buildExportPass returns the object the later phases mutate', () => {
+  it('leaves the visibility sets unassigned, as the collection phase expects', async () => {
+    // If these arrived pre-populated, `collectModifications` would be writing
+    // over a decision something else already made.
+    const p = await pass();
+    expect(p.allowedEntityIds).toBeNull();
+    expect(p.hiddenProductIds).toBeNull();
+  });
+
+  it('lets willBeEmitted see an allowedEntityIds assigned AFTER the build', async () => {
+    const p = await pass();
+
+    // Null means "no visibility restriction decided yet", so nothing is denied
+    // on that basis.
+    expect(p.willBeEmitted(10)).toBe(true);
+    expect(p.willBeEmitted(11)).toBe(true);
+
+    // What `collectModifications` does, in one line: assign onto the returned
+    // object. A predicate reading a snapshot taken at build time would still
+    // see `null` here and answer `true` for #11.
+    p.allowedEntityIds = new Set<number>([10]);
+
+    expect(p.willBeEmitted(10)).toBe(true);
+    expect(p.willBeEmitted(11)).toBe(false);
+  });
+
+  it('lets the closure-walk predicate see hiddenProductIds assigned after the build', async () => {
+    const p = await pass();
+    expect(p.isRefExcludedDuringClosureWalk(11)).toBe(false);
+
+    p.hiddenProductIds = new Set<number>([11]);
+
+    // Same object, so the same closure now answers differently.
+    expect(p.isRefExcludedDuringClosureWalk(11)).toBe(true);
+  });
+});

--- a/packages/export/src/step-pass-builder.ts
+++ b/packages/export/src/step-pass-builder.ts
@@ -1,0 +1,321 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Builds the `ExportPass` one `export()` call threads through its phases.
+ *
+ * Split out of `step-exporter.ts` for #2475. The literal moved verbatim; the
+ * only edits are that the three things it used to read off the exporter
+ * (`dataStore`, `mutationView`, `isGeometryEntity`) now arrive as fields of
+ * {@link PassBuildInput}.
+ *
+ * ONE RULE GOVERNS THIS FILE, and it is easy to break by tidying. The
+ * predicates below are closures over `pass` ITSELF, and `pass.allowedEntityIds`
+ * / `pass.hiddenProductIds` are still `null` when this function returns --
+ * `collectModifications` assigns them afterwards, on this very object. So this
+ * must `return pass` and nothing else. A spread, a `structuredClone`, an
+ * `Object.freeze`, or a caller that stores a copy detaches every predicate from
+ * the object that later gets written, and each one silently answers from a
+ * snapshot that never fills in. That is #2637, and the failure mode is a
+ * `visibleOnly` export shipping a structurally wrong file rather than throwing.
+ */
+
+import type { IfcAttributeValue, IfcDataStore, IfcSourceHeader } from '@ifc-lite/parser';
+import type { MutablePropertyView } from '@ifc-lite/mutations';
+import type { IfcSchemaVersion } from './schema-converter.js';
+import type { ExportPass, StepExportOptions } from './step-export-types.js';
+import { getEffectiveEntityIndex } from './effective-index.js';
+import { createModificationLedger } from './delta-modification-ledger.js';
+import { createSourceRefReader } from './source-ref-bounds.js';
+import { buildStepHeader } from './step-header.js';
+
+/**
+ * Everything the pass literal reads that is not its own field.
+ *
+ * The first three are the exporter's, injected rather than reached for.
+ * `isGeometryEntity` is passed as a bound callback for the same reason it is a
+ * method there: it closes over the exporter's own type set.
+ */
+export interface PassBuildInput {
+  readonly dataStore: IfcDataStore;
+  readonly mutationView: MutablePropertyView | null;
+  readonly isGeometryEntity: (type: string) => boolean;
+  readonly options: StepExportOptions;
+  readonly schema: IfcSchemaVersion;
+  readonly sourceSchema: IfcSchemaVersion;
+  readonly converting: boolean;
+  readonly applyMutations: boolean;
+  readonly excludeGeometry: boolean;
+  readonly sourceHeader: IfcSourceHeader | undefined;
+  readonly schemaToken: string;
+}
+
+export function buildExportPass(input: PassBuildInput): ExportPass {
+  const {
+    dataStore,
+    mutationView,
+    isGeometryEntity,
+    options,
+    schema,
+    sourceSchema,
+    converting,
+    applyMutations,
+    excludeGeometry,
+    sourceHeader,
+    schemaToken,
+  } = input;
+
+  const pass: ExportPass = {
+    entities: [],
+    newEntityCount: 0,
+    schema,
+    sourceSchema,
+    converting,
+    sourceHeader,
+    schemaToken,
+    overlayActive: !!mutationView && applyMutations,
+
+    // Built once entity counts are known, so the provenance item can report the
+    // actual modification count. See the two call sites (empty delta + final).
+    // Body lives in `step-header.ts` (#2475 header/assembly tail): the
+    // closure still has to be built here, because it closes over this
+    // call's own `options`/`sourceHeader`/`schemaToken`, and both call
+    // sites still read it as `pass.buildHeader`.
+    buildHeader: (modifications: number): string =>
+      buildStepHeader(options, sourceHeader, schemaToken, modifications),
+
+    // The one authority for exists / class / deleted, overlay first and source
+    // buffer second. Every pass below asks this instead of `dataStore`,
+    // which answers only for the file as parsed (#2012).
+    effective: getEffectiveEntityIndex(
+      dataStore,
+      mutationView,
+      applyMutations,
+    ),
+
+    // Does this id belong to an entity the OVERLAY created (`createEntity` /
+    // `store.addEntity`) rather than to a record in the source buffer? Such an
+    // entity has no source bytes, so the source-iteration pass below never sees
+    // it and the new-entities pass at the end owns its line entirely (#2006).
+    isOverlayCreated: (entityId: number): boolean => pass.effective.isOverlayCreated(entityId),
+
+    // Does this record describe a line this export can actually READ out of the
+    // source? One predicate for every byte-range gate below, so they cannot
+    // disagree — see `source-ref-bounds.ts` for the corrupt file the weaker
+    // "is there a source / does the ref claim bytes" pair let through (#2491).
+    isReadableSourceRef: createSourceRefReader(dataStore.source),
+
+    // Build visible-only closure if requested. Classification, the closure walk
+    // and the style pass all run over the EFFECTIVE index: an overlay-created
+    // product becomes a root by the same type rules as a parsed one, the walk
+    // follows its authored references into the geometry it alone owns, and a
+    // tombstoned entity is simply not there. Run over the source buffer, a
+    // created wall could never be a root and nothing referenced it, so
+    // `visibleOnly` wrote a file without it and said nothing (#2012).
+    //
+    // Computed here, ahead of the modification-count passes below, because
+    // `hasEmittableHostBytes` needs it: a source-backed host EXCLUDED by
+    // `visibleOnly` never gets its line written by the source-iteration pass
+    // either, so counting it as "modified" would make the header claim a
+    // change the DATA section does not contain (CodeRabbit finding on #2414).
+    allowedEntityIds: null,
+
+    // Populated alongside `allowedEntityIds` below. `getVisibleEntityIds`
+    // excludes a hidden PRODUCT's own line from the closure, but `IFCREL*` is
+    // an unconditional root a few lines down and its bytes are copied verbatim
+    // by the source-iteration pass — nothing there filters a `#N` the closure
+    // just excluded out of the relationship's own attribute list. Kept because
+    // the closure walk's `isRefExcludedDuringClosureWalk` needs a notion of
+    // "hidden" that does not read `allowedEntityIds` — the set that walk is
+    // producing (#2398). The two OUTPUT passes no longer read this directly:
+    // they filter on `isOmittedFromOutput`, which subsumes it via
+    // `allowedEntityIds`.
+    hiddenProductIds: null,
+
+    // A relationship can name an excluded entity two ways that have nothing
+    // to do with each other: a `visibleOnly` hidden PRODUCT (`hiddenProductIds`,
+    // below), and a TOMBSTONED one — `editor.removeEntity` on a related object
+    // named by a relationship the deletion sweep below does not reach (that
+    // sweep only withholds an `IfcRelDefinesByProperties` when EVERY related
+    // object is gone, and only for that one relationship class). Left alone, a
+    // relationship still naming a deleted entity ships the identical `#N` with
+    // no `#N=` line, on a path with no `visibleOnly` involved at all (#2398).
+    // `effective.isDeleted` answers for every id, not just a precomputed set,
+    // so this predicate covers both sources without a second exclusion set.
+    //
+    // Declared here, ahead of the closure walk below, and passed into
+    // `collectReferencedEntityIds` as its `isRefExcluded` — rather than the
+    // walk inventing its own `!entityIndex.has` proxy for "deleted" that could
+    // disagree on an id that never existed in the file at all
+    // (maintainer-found regression on #2637: such an id blocked the bridge but
+    // did not stop the relationship's own line from shipping, dropping a
+    // VISIBLE sibling's pset while adding a fresh dangling ref). A closure over
+    // `pass.hiddenProductIds`, not a value snapshot — correct because nothing
+    // reads it before the closure walk assigns it just below.
+    //
+    // ## Why this is NOT the predicate the OUTPUT-line filter uses
+    //
+    // The name says walk, and only walk. The two passes that write a
+    // relationship's line ask `isOmittedFromOutput` (further below, derived
+    // from `pass.willBeEmitted`), which is strictly stronger — it also answers
+    // for the closure, for an unreadable source ref and for a geometry
+    // exclusion.
+    //
+    // This one CANNOT be `willBeEmitted`, and the difference is structural
+    // rather than stylistic: `willBeEmitted`'s first act is to consult
+    // `allowedEntityIds`, and `allowedEntityIds` is precisely what the call
+    // below is computing. Wiring it in here is circular: it would answer "not
+    // in the closure" as `false` while the closure is still being built and
+    // `true` for the same id afterwards.
+    //
+    // That is a genuine departure from the contract #2637 was closed on —
+    // `reference-collector.ts` still documents the bridge as taking the
+    // caller's OWN output predicate, "not two expressions that happened to
+    // agree". It has an OBSERVABLE consequence, not just a naming one: for an
+    // unreadable source ref this admits, the walk bridges through a
+    // relationship the output then withholds, leaving the relationship's other
+    // target in the closure with nothing naming it — an orphan, pinned by
+    // `unreadable-ref-dangling.test.ts` ("walk and output predicates diverge").
+    // The reverse direction is closed: every id this excludes,
+    // `isOmittedFromOutput` excludes too, so the #2548 leak cannot return.
+    isRefExcludedDuringClosureWalk: (id: number): boolean =>
+      (pass.hiddenProductIds !== null && pass.hiddenProductIds.has(id))
+      || pass.effective.isDeleted(id),
+
+    // Will THIS entity's own line ever land in the file? The same byte-range
+    // test `willBeEmitted` uses (defined further below) and the source-
+    // iteration pass's own skip at `entityRef.byteLength === 0` — a source
+    // entity with no bytes (a point-cloud / GLB "entity" from
+    // `createSyntheticDataStore`, not an overlay-created one) never gets a
+    // defining line written, source-iteration or otherwise, so a pset/attribute
+    // edit against it must not count as a modification either: the header
+    // would describe a change the file does not contain (out-of-scope finding
+    // in #2398). Also excludes a source-backed host the visible-only closure
+    // above drops — same reasoning, different reason the line never lands.
+    //
+    // And, like `willBeEmitted` below, excludes a geometry-classified SOURCE
+    // host under `includeGeometry: false`: the source-iteration pass's own
+    // `isGeometryEntity` skip (further below) drops that line too, so this
+    // predicate must agree or a geometry entity's attribute edit inflates the
+    // count over an omitted line (CodeRabbit finding on #2414). Guarded by
+    // `!deltaOnly` for the same reason `willBeEmitted` is: under `deltaOnly`
+    // the source-iteration pass — and its geometry skip — never runs at all,
+    // so a source entity's line is assumed to already exist in the file being
+    // patched, geometry or not.
+    isGeometryExcluded: (entityId: number, recordType: string): boolean =>
+      excludeGeometry
+      && isGeometryEntity(pass.effective.effectiveType(entityId, recordType)),
+    hasEmittableHostBytes: (entityId: number): boolean => {
+      if (pass.allowedEntityIds !== null && !pass.allowedEntityIds.has(entityId)) return false;
+      const ref = pass.effective.get(entityId);
+      // The ref must be READABLE, not merely non-empty: a range this source
+      // cannot address decodes to the empty string, which used to be pushed
+      // into the file as a blank line while everything generated FOR the host
+      // still named it (#2491).
+      if (!ref || !pass.isReadableSourceRef(ref)) return false;
+      if (options.deltaOnly !== true && pass.isGeometryExcluded(entityId, ref.type)) return false;
+      return true;
+    },
+
+    /**
+     * Will this id have a defining STEP line in the output at all?
+     *
+     * The predicate is #2030's, and it is the right one: the pset, quantity and
+     * type-owned passes below are built from unfiltered mutation history, and
+     * what each of them needs to know before emitting an
+     * `IFCRELDEFINESBYPROPERTIES` is not "was this deleted" or "is this hidden"
+     * but the general question those are two answers to. A relation naming an
+     * expressId that never gets written is a dangling reference and an invalid
+     * file, whichever route dropped the line.
+     *
+     * #2030 had to reach for four things to answer it — a tombstone probe, a
+     * visibility set, a byte-range test on `completeIndex`, and a `getNewEntity`
+     * fallback whose stated purpose was that `deleteEntity` FORGOT an
+     * overlay-created entity instead of tombstoning it, so `isDeleted` could not
+     * answer for one. That fallback was documented on main as a workaround for
+     * exactly the model-level defect this branch fixes: `deleteEntity` now
+     * tombstones as well as forgets, so the effective index answers existence
+     * for source and overlay ids alike and the workaround collapses into it.
+     *
+     * The overlay branch does NOT disappear with it, and the distinction matters:
+     * `isOverlayCreated` is still load-bearing here, because a live
+     * overlay-created entity has no source bytes and would fail the byte-range
+     * test that a source record passes. What the tombstone fix removed is the
+     * need for that branch to double as a deletion detector.
+     *
+     * Deliberately unchanged from #2030 for source records under `deltaOnly` /
+     * `exportPropertiesOnly`: the source-iteration pass is skipped wholesale in
+     * those modes, yet a source entity still answers true here. A delta is a
+     * patch against a file that already has the line, not a standalone model.
+     */
+    willBeEmitted: (entityId: number): boolean => {
+      if (pass.allowedEntityIds !== null && !pass.allowedEntityIds.has(entityId)) return false;
+      // Undefined for a tombstoned id and for one neither the file nor the
+      // session ever had — a stale mutation must not conjure a relation either.
+      const ref = pass.effective.get(entityId);
+      if (!ref) return false;
+      // An overlay-created record carries the placeholder byte range and is
+      // written by the new-entities pass; a source record needs real bytes.
+      if (pass.effective.isOverlayCreated(entityId)) {
+        // The overlay new-entities pass applies its OWN `isGeometryEntity`
+        // filter unconditionally — deltaOnly or not (see the comment at that
+        // loop, further below) — so this branch mirrors it without the
+        // deltaOnly carve-out the source branch gets.
+        return !pass.isGeometryExcluded(entityId, ref.type);
+      }
+      // Same readability test as `hasEmittableHostBytes`, and for the reason
+      // that predicate names: a ref this source cannot address is not a line
+      // this export can write, so nothing may be generated naming it (#2491).
+      if (!pass.isReadableSourceRef(ref)) return false;
+      // Mirrors `hasEmittableHostBytes`: under `deltaOnly` the source-
+      // iteration pass — and its geometry skip — never runs, so a source
+      // entity's line is assumed to already exist in the file being patched.
+      if (options.deltaOnly === true) return true;
+      return !pass.isGeometryExcluded(entityId, ref.type);
+    },
+
+    // Under `deltaOnly` a nomination only becomes a count once some pass has
+    // actually written content that delivers THAT KIND of edit for the host —
+    // see `delta-modification-ledger.ts` for why the two are not the same event
+    // in that mode, and why the pair is (entity, kind) rather than the entity
+    // (#2462).
+    modifications: createModificationLedger(options.deltaOnly === true),
+
+    /**
+     * Hosts whose in-place named-attribute edits a FULL export may count, per
+     * kind. Filled by the collection passes below and read by the two passes
+     * that write a rewritten source line — see `in-place-nomination.ts` for why
+     * the nomination waits for the rewrite in this mode and not under
+     * `deltaOnly` (#2483).
+     */
+    inPlaceNominees: {
+      attribute: new Set<number>(),
+      georeferencing: new Set<number>(),
+    },
+
+    // Collect entities that need to be modified or created
+    modifiedEntities: new Set<number>(),
+    modifiedAttributes: new Map<number, Map<string, string>>(),
+    newPropertySets: [],
+    newQuantitySets: [],
+    typeOwnedPsetNamesByEntity: new Map<number, Set<string>>(),
+    typeOwnedPsetIdsByEntity: new Map<number, number[]>(),
+    rewrittenEntityIds: new Set<number>(),
+    rewrittenEntityLines: new Map<number, string>(),
+    /** HasPropertySets slot value for an OVERLAY-CREATED type object, applied
+     *  by the new-entities pass (there is no source line to rewrite). */
+    overlayTypeOwnedPsets: new Map<number, IfcAttributeValue>(),
+
+    // Track property set IDs and relationship IDs to skip
+    skipPropertySetIds: new Set<number>(),
+    skipRelationshipIds: new Set<number>(),
+
+    // Written by the georeferencing pass and read again by the final
+    // assembly, which is why they are pass state and not phase locals.
+    newGeorefLines: [],
+    warnings: [],
+  };
+  // The same object, deliberately. See the file header.
+  return pass;
+}

--- a/packages/export/src/step-source-iteration.ts
+++ b/packages/export/src/step-source-iteration.ts
@@ -81,7 +81,7 @@ export interface SourceIterationContext {
     overlayActive: boolean,
     onRejected?: (attrName: string, value: string) => void,
   ) => SourceLineMutations;
-  /** `StepExporter.isGeometryEntity`, also read by the setup closure and by
+  /** `isGeometryEntity` (`step-geometry-types.ts`), also read by the setup closure and by
    *  the overlay-created-entities block. */
   readonly isGeometryEntity: (type: string) => boolean;
   /** `StepExporter.propertySetContext`, for the byte readers

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -135,7 +135,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * failure message. Either way do it at the moment you finalise the change — it
  * moves if anything else touched the allowlist first.
  */
-const ALLOWLIST_DIGEST = '11393547125153002344';
+const ALLOWLIST_DIGEST = '1125203688214438683';
 
 function parseArgs(argv) {
   const out = {

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -135,7 +135,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * failure message. Either way do it at the moment you finalise the change — it
  * moves if anything else touched the allowlist first.
  */
-const ALLOWLIST_DIGEST = '11368619624884150365';
+const ALLOWLIST_DIGEST = '11393547125153002344';
 
 function parseArgs(argv) {
   const out = {

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -231,7 +231,7 @@
   1122 packages/export/src/reference-collector.ts
    556 packages/export/src/schema-converter.ts
    415 packages/export/src/step-attribute-mutations.ts
-  1169 packages/export/src/step-exporter.ts
+   945 packages/export/src/step-exporter.ts
   1061 packages/export/src/step-property-sets.ts
    435 packages/export/src/step-serialization.ts
    437 packages/extensions/src/testing/runner.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -231,7 +231,6 @@
   1122 packages/export/src/reference-collector.ts
    556 packages/export/src/schema-converter.ts
    415 packages/export/src/step-attribute-mutations.ts
-   945 packages/export/src/step-exporter.ts
   1061 packages/export/src/step-property-sets.ts
    435 packages/export/src/step-serialization.ts
    437 packages/extensions/src/testing/runner.ts


### PR DESCRIPTION
Refs #2475 — deliberately not `Closes`, though the target is met. **`step-exporter.ts` is 367 lines, under the ~400 rule.** 1169 → 367.

The issue was narrowed on 2026-08-09 to `step-exporter.ts` only, so that scope is complete. Its body still carries a two-row table listing `step-serialization.ts` as well, recorded as *done at 389* when it is now **435** — so whether this closes the issue or leaves that row outstanding is your call, not mine to assume with a keyword.

## The issue is stale in three ways, and the corrections matter

`gh` says all three, verified rather than read off the issue text:

1. **It is not blocked.** The header says `step-exporter.ts` is *"held until @BIMvoice's PR #2398 lands — that PR is open against this exact file, currently CONFLICTING"*. **#2398 merged on 2026-08-18.** The issue was edited on the 21st and still carries the block, so this has been sitting there looking blocked while nothing was blocking it.
2. **The file is less than half the stated size.** The body says 2448 lines. On `upstream/main` it is **1169**. Seven of the seams the original plan named have already been cut — `step-georeferencing.ts`, `step-property-sets.ts`, `step-source-iteration.ts`, `step-header.ts`, `step-overlay-entities.ts`, `step-collection.ts`, `step-attribute-mutations.ts` all exist. `ExportPass`'s own docstring records that step 1 of #2475 already shipped.
3. **One thing moved the other way.** The issue records `step-serialization.ts` as *done* at 389 lines. It is now **435** — back over the rule. Not addressed here, but it should not stay recorded as finished.

## What this commit does

Moves declarations only — `StepExportOptions`, `StepExportProgress`, `StepExportResult`, `SourceLineMutations`, `ExportPass`, and the `relationshipWithheldWarning` message builder — into `step-export-types.ts`.

**1169 → 945.**

No guard, no predicate, no control flow moved. `step-exporter.ts` re-exports all five types, so the seven sibling modules importing `ExportPass` / `SourceLineMutations` from it are untouched, and `packages/export/src/index.ts:16` — the public surface for the three `StepExport*` types — is byte-identical. A consumer cannot tell this happened.

## Why this cut first

The issue's binding constraint:

> "the recent finiteness and ledger work is pinned by mutation tests that map to specific call sites. A split must keep those mutations killing the same tests — a refactor that detaches a guard from its test leaves the suite green for the wrong reason."

That is a failure mode I would not detect, so the first move is the one with no coupling to it at all. Declarations have no guards. This establishes the new module and the re-export seam at zero risk before anything load-bearing moves.

A guard audit mapped the rest of the safety net first. Two findings worth recording:

- The eight `ExportPass` predicates are pinned **as a set**, not individually, by `relationship-filter-gate.test.ts`, `unreadable-ref-dangling.test.ts` and `step-exporter.test.ts`. They close over a **mutable** `pass` whose `allowedEntityIds` / `hiddenProductIds` are assigned later by `collectModifications`. Any extraction must return that same object — a defensive copy anywhere reintroduces #2637 in a form no test catches until a `visibleOnly` export ships a corrupt file.
- **`step-exporter.ts:341-346`'s `ownerHistory` reset is unpinned.** Its comment states the invariant, but no test reuses one `StepExporter` across two differently-configured `.export()` calls. That guard sits exactly where later cuts land, so it needs a test *before* the code moves, not after.

## What remains, measured rather than estimated

| block | lines | note |
|---|---|---|
| `ExportPass` literal (179–428) | 250 | contiguous; no `nextExpressId` involvement |
| predicate block (436–698) | 263 | contains an early `return` out of `export()` — must become a returned value, a rewrite rather than a move |
| five `*Context()` builders | ~102 | shares the `allocateExpressId` counter; identity must be preserved or express ids double-allocate |
| `isGeometryEntity()` | ~39 | pure, near-zero risk |

After all four the file lands near **310**, so the rule is reachable — but not in one move, and the middle one is not a cut-paste.

One structural note for review: `export()` is 622 lines of which only ~147 are code; **76% is comment** documenting why each predicate is shaped as it is, tied to #2007, #2030, #2398, #2414, #2491, #2548, #2637 and #2668. Those comments have to travel with the code they explain. The comment at 429–434 and `step-collection.ts:19-23` both currently say the predicates *stay* in `step-exporter.ts` — extracting the predicate block makes both stale, and that is the single likeliest place to ship a wrong comment.

## Verification

Same command before and after, workspace-aware (not `cd packages/export && vitest run`, which AGENTS.md forbids because siblings resolve from built `dist`):

```
pnpm exec turbo run test --filter=@ifc-lite/export --force
```

- before **63 files / 881 tests**, after **63 files / 881 tests**
- dependents: `@ifc-lite/mutations` 218/218, `@ifc-lite/sandbox` 200/200
- `check-module-size` exit 0, `0 new over 400`; `step-export-types.ts` needs no row

The allowlist row drops 1169 → 945 with the digest re-pinned. The regenerator also wanted to lower two unrelated rows carrying pre-existing slack (`headless-backend.ts` 778→752, `backend-query.ts` 509→485); **those are restored** and the digest computed from the restored file. Lowering is never a weakening, but those files are not this PR's to tighten — a concurrent PR growing either one inside its existing budget should not go red because of a refactor elsewhere.

No changeset: nothing published changes.



---

## Progress

| commit | what moved | lines |
|---|---|---|
| `2c6e6ca98` | export vocabulary → `step-export-types.ts` | 1169 → 945 |
| `713fc7cdc`, `02c12f592` | dead imports the move left behind | → 931 |
| `3fdaef420` | test: owner-history fallback scan | — |
| `340c8da36` | the `ExportPass` literal → `step-pass-builder.ts` | 931 → 697 |
| `c109f4126` | test: what an empty deltaOnly export emits | → 698 |
| `be72760ae` | omission predicates → `step-omission-predicates.ts` | 698 → 453 |
| `8325468a8` | test: duplicate express ids | — |
| `38a02d48d` | `isGeometryEntity` + two context builders | 453 → **366** |
| `ad17de14a`, `663e47000`, `d34b5873e`, `797b8844d` | comment and citation fixes, CodeRabbit findings | 366 → **367** |

`340c8da36` is the load-bearing one. The literal moved verbatim; the only edits are one dedent and the three things it read off the exporter arriving as parameters. **885/885** (882 before, 3 new), zero `TS6133`/`TS6196`, `check-module-size` exit 0.

Its danger is the identity rule: the pass's predicates close over `pass` itself, and `allowedEntityIds`/`hiddenProductIds` are still `null` when the builder returns — `collectModifications` assigns them afterwards, on that same object. Any copy detaches every predicate from the object that gets written, which is #2637, and it fails silently rather than throwing. That rule used to be enforced by the literal being physically inside `export()`, where there was nothing to copy; now it is enforced by `step-pass-builder.test.ts`. Replacing `return pass` with `return { ...pass }` fails **20 tests across 8 files**, two of them the new ones.

---

*Correction.* The message on `713fc7cdc` says `scripts/check-unused-locals.mjs` "currently exits early ... so the guard for this class of bug is therefore not running for any package right now."

**That is wrong, and it is worth correcting loudly because it accused a working gate of being asleep.** The script has no early exit — it compiles and measures all 50 packages, then prints only the unmeasurable ones before exiting **1**. It fails *closed*. CI is green on `main` and evaluating everything: `✅ No new unused locals (50 packages, 948 known, none increased)`.

What I actually hit was local drift in my own worktree: `packages/extensions`' `dist` predates a source change, and two dependencies added on 2026-08-21/23 were never installed here. So the gate would have caught those nine dead imports in CI. I reported a repo-wide problem on the strength of one local run and a plausible reading of the output, without checking CI — the fix for my machine is `pnpm install && pnpm build`, and there is nothing to re-enable.



---

## Done: 366 lines

The allowlist row is **deleted** rather than lowered — at 366 the file no longer needs one — with `ALLOWLIST_DIGEST` re-pinned in the same commit, since a hand-edited allowlist without the digest fails the gate by design. 314 rows, was 315.

**Three guards had no test, and each was established by mutation rather than by searching** — after I got that wrong once today, claiming a guard was unpinned when it was pinned in a file I hadn't looked in.

1. *The owner-history reset* turned out to be **already pinned**, by `overlay-effective-model.test.ts`. The test added here is a second angle (the fallback scan, asserting structural validity) and says so rather than claiming a new pin.
2. *The `deltaOnly` short-circuit* is genuinely unpinned — and then the tests I wrote for it **also passed with the branch disabled**. It is an early-out, not a behaviour: for a model with no edits the ordinary path reaches the same bytes and the same stats. That is why rewriting its `return` into a returned value was safe by construction. The tests were kept for the contract they do pin, with a header saying outright they do not guard the branch.
3. *Duplicate express ids* were genuinely uncatchable. `findDanglingRefs` collects ids into a `Set`, so a second definition of `#76` is absorbed silently. Freezing both `allocateExpressId` closures now fails one test with `expected [ 119, 120 ] to deeply equal []` — and **only** that one, out of 890.

That third one decided the shape of the final cut. `georefContext` and `propertySetContext` mint ids from **one** instance counter through two closures; capturing its value rather than the closure gives each its own sequence and emits two entities sharing an `#N` — well-formed STEP, every reference resolving, two different entities. So those two stay on the class, `collectionContext` stays with them because it forwards to both, and only the two genuinely-forwarding builders moved. That reasoning is in `step-export-contexts.ts`'s header *and* is now checkable.

**The arithmetic did not cooperate, which is worth stating rather than rounding away.** `isGeometryEntity` alone lands at 415. `collectionContext` was the obvious next cut but forwards to the counter-owning pair, so extracting it makes the call site take four arguments where it took none — worse code for ten lines. `overlayEntitiesContext` needs only `mutationView`, so its call site stays one line. Those two land at 366 with margin, without touching the counter and **without shortening any comment that explains a hazard** — which was the temptation at 415 and would have been the wrong trade.

### Verification

- `@ifc-lite/export` **890/890**; dependents `cli` 456/456, `mcp` 293/293, `mutations` 218/218, `sandbox` 200/200
- `npx tsc --noEmit --noUnusedLocals -p packages/export`: zero `TS6133`, zero `TS6196`
- `node scripts/check-module-size.mjs`: exit 0, `0 new over 400`; neither new module needs a row

No changeset: nothing published changes. The public entry point is byte-identical throughout — `index.ts` was never touched.

### Two notes for the maintainer

- The issue body is stale in ways worth correcting when this lands: it says the file is 2448 lines (it was 1169 when I started), and it records `step-serialization.ts` as *done at 389* when it is now **435**, having grown through two legitimate bugfixes (#2987, #3078). That file is outside this issue's narrowed scope, but it should not stay recorded as finished.
- `export()` was ~76% comment before the split, and the extracted blocks were 86% comment. The prose is load-bearing — it documents #2007, #2030, #2398, #2414, #2491, #2548, #2637 and #2668 — so it travelled with the code it explains rather than being trimmed to hit the number.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty delta-only exports, ensuring correct headers, terminators, statistics, and file sizes.
  * Fixed owner-history fallback after related entities are deleted.
  * Prevented duplicate generated entity definitions and dangling references.
  * Improved relationship filtering and geometry exclusion behavior.

* **Tests**
  * Added regression and integrity coverage for export output, references, visibility, and mutation handling.

* **Refactor**
  * Improved export processing structure and shared export type handling without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### One inherited inconsistency, flagged rather than fixed

`step-omission-predicates.ts` carries a benchmark note whose numbers do not reconcile: **12.0 ms** against **0.74 ms** is 16.2×, not the **"13× faster"** it claims. One of the three figures is wrong.

That text is not from this branch — it is on `upstream/main` at `step-exporter.ts:697-702` and moved here verbatim with the block. I cannot re-run the benchmark to learn which number is off, and substituting a self-consistent figure I had not measured would turn a visible inconsistency into an invisible fabrication. So it is left exactly as it was, and raised here instead.

Same reasoning applies to the two `file:NN` citations this branch *did* get wrong (`step-collection.ts:76`/`:82`, actually `:79`/`:85`): both were fixed in `ad17de14a` by **deleting the line numbers** rather than correcting them. The prose already quotes the code and names the file, so the number carried no information a reader needed and one failure mode they did not — and correcting it would only have restarted the clock. Both had drifted by exactly three lines because a *different file's* header grew in the same commit.



---

## Answering the 2026-08-21 comment on #2475

That comment set the bar for this issue, so here is each point against measurements taken now.

**"still about 2.9x over" — addressed.** 1169 → **366**. `AGENTS.md:18`'s ~400 is met with margin.

**"the next reduction is the ExportPass redesign this issue already names. That has not been attempted."** — it has now. `ExportPass` already existed as an interface; what had not happened was moving its *construction* and the predicates that close over it. `step-pass-builder.ts` takes the 250-line literal, `step-omission-predicates.ts` takes the 259-line predicate block. Those two are the reduction; the rest is small.

**"The TypeScript side of the rule has no gate at all"** — true when written, **no longer true**. `scripts/check-module-size.mjs` and `scripts/module-size-allowlist.txt` landed on 2026-08-23 in `ab17ac7cf`, *"feat(scripts): TypeScript module-size ratchet, so the ~400-line rule has a gate (#2475) (#3045)"* — two days after the comment. It walks 1934 files, and it is what this PR's final commit interacts with: `step-exporter.ts`'s row is **deleted** because at 366 it no longer needs one, with `ALLOWLIST_DIGEST` re-pinned in the same commit (a hand-edited allowlist without the digest fails by design). So the concern that "nothing stops `step-exporter.ts` growing back" is now answered by a gate rather than by vigilance.

**"Two files this issue's own chain created are also over the bar and are tracked nowhere else"** — half of that has changed. Measured now:

| file | then | now | ratchet row |
|---|---|---|---|
| `step-property-sets.ts` | 1061 | **1061** | yes, budget 1061 |
| `step-attribute-mutations.ts` | 415 | **415** | yes, budget 415 |
| `step-serialization.ts` | 427 | **435** | yes, budget 435 |

They are no longer *untracked* — the ratchet froze each at its current size on 2026-08-23, so none can grow further. But none is under 400, so the substance of the point stands: **this PR discharges `step-exporter.ts` and does not discharge those three.** `step-serialization.ts` has drifted a further 8 lines since the comment (427 → 435), which is exactly the "grows back" pattern the gate now prevents but does not reverse.

I have deliberately **not** folded them in. #3171 is already eleven commits across five new modules, and `step-property-sets.ts` at 1061 is a comparable job to the one just done rather than a tail. I am scoping it separately and will attach the analysis — whether that becomes a follow-up issue or stays a note on #2475 is your call, which is also why this PR says `Refs` and not `Closes`.



### A fifth `deltaOnly` read, left alone on purpose

Acting on CodeRabbit's `deltaOnly` finding turned up one more site it did not flag: `step-source-iteration.ts` reads `if (!options.deltaOnly && ctx.dataStore.source)` — truthy, where `step-pass-builder.ts` and (now) `step-omission-predicates.ts` all read `=== true`.

**I have not changed it, and the difference from the one I did change is the whole reason.** The short-circuit was safe to tighten because it is *unobservable* — established by disabling it entirely and getting byte-identical output — so no value of `deltaOnly` can produce a different file through it. This one gates whether source entity lines are written at all. For `deltaOnly: 1`, `!1` is `false` and the branch is skipped today; aligning it to `!== true` would make the branch run. That is a real behaviour change for non-boolean callers, not a free one, and it belongs with a test that pins the intended answer rather than riding along in a refactor.

Verified the two do not currently disagree in the exercised paths (a `deltaOnly: 1` export produces byte-identical output before and after this PR's change, in both an unedited and a pset-edited scenario), so nothing is broken today — the sites simply agree by luck rather than by construction, which is the condition this file's own comments argue against.

Worth a follow-up; flagging rather than fixing so the decision is visible.



*(Footnote on that paragraph: I first wrote `step-source-iteration.ts:166`. It is 167. I had written a rule against bare line citations earlier the same day, in this same PR, and then produced one within the hour — so the number is now gone and the code is quoted instead, which is what the rule says to do. CodeRabbit's own `deltaOnly` comment cites "the file's own note at lines 297-309"; that note is now at 302-314, because the fix commit answering that very comment inserted five lines above it. Same failure, three times, in three different hands.)*


*(Line-count note: `38a02d48d` reached **366** and its message says so, correctly for that commit. The file is **367** today — `ad17de14a`'s `{@link}` repair added one line to it. Flagging rather than quietly editing the number, because "the count in the body drifted from the count in the commit" is precisely the failure this PR has been correcting elsewhere, and it deserves the same treatment when it is mine. Nothing about the result changes: the rule is ~400 and the gate's threshold is a strict `> 400`.)*


*(Second line-count note, same cause as the first. Two module sizes quoted in the Verification sections above — `step-export-types.ts` at 274 and the contexts module at 83 — had also drifted, to 283 and 94, grown by my own later comment fixes. The digits are gone rather than refreshed. Every one of them was a point-in-time measurement dressed as a fact, and the durable claim was always the gate's own line: `0 new over 400`, which is what actually enforces the rule and cannot go stale while CI runs. Current sizes, for the record at this commit: `step-exporter.ts` 367, `step-export-types.ts` 283, `step-pass-builder.ts` 321, `step-omission-predicates.ts` 333, `step-geometry-types.ts` 58, `step-export-contexts.ts` 94 — all under 400.)*