### PR TITLE
docs(geometry): the geometryClass call-site count was five, and #3161 converted six (#3173)

### DIFF
--- a/.changeset/geometry-class-six-not-five.md
+++ b/.changeset/geometry-class-six-not-five.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Correct the call-site count in `geometry-class.ts`'s docblock and its test's: six files across three packages compared `geometryClass` against bare integers before the module existed, not five.
+
+The sixth is `apps/viewer/src/components/viewer/ViewportContainer.tsx:819`, which read `(meshes[i].geometryClass ?? 0) !== 0` and now goes through `meshIsNonOccurrence`. It was converted on #3161 and named in that PR's changeset and merge subject, but the two doc comments kept the pre-audit number — and they are what a reader lands on when opening the module. Comment-only; the enumeration now lists all six.

--- a/packages/geometry/src/geometry-class.test.ts
+++ b/packages/geometry/src/geometry-class.test.ts
@@ -20,7 +20,7 @@ import {
  * It CAN pin the TypeScript half of the contract: the four ordinals are
  * distinct, and every class lands on exactly one side of the placed /
  * type-library split. Before this module those numbers were bare literals in
- * five files across three packages, so adding a class meant finding all five
+ * six files across three packages, so adding a class meant finding all six
  * and missing one was silent.
  *
  * It CANNOT verify the numbers against Rust, which is where they are decided

--- a/packages/geometry/src/geometry-class.ts
+++ b/packages/geometry/src/geometry-class.ts
@@ -15,12 +15,13 @@
  * there too.
  *
  * This module exists so the TypeScript half of that contract is stated once.
- * Before it, five files across three packages compared `geometryClass`
+ * Before it, six files across three packages compared `geometryClass`
  * against bare integers -- `apps/viewer/src/lib/type-view-visibility.ts`,
  * `apps/viewer/src/lib/geo/kmz-exporter.ts`,
  * `apps/viewer/src/components/viewer/GLBExportDialog.tsx`,
+ * `apps/viewer/src/components/viewer/ViewportContainer.tsx`,
  * `packages/export/src/demesh-session.ts` and `packages/geometry/src/index.ts`
- * -- so a renumbering meant finding all five, and missing one was invisible.
+ * -- so a renumbering meant finding all six, and missing one was invisible.
  *
  * What this does NOT do is verify the values against Rust. Only an assertion
  * at the real boundary can do that -- see the note in `geometry-class.test.ts`.


### PR DESCRIPTION
Closes #3173.

`geometry-class.ts`'s docblock and its test's both say "five files across three packages compared `geometryClass` against bare integers". The sixth is `apps/viewer/src/components/viewer/ViewportContainer.tsx:819`, which read `(meshes[i].geometryClass ?? 0) !== 0` and now goes through `meshIsNonOccurrence`.

## Why two comments were left saying five

The correction landed three times on #3161 and never on these two:

- `25f6236` converted the sixth site, and said in its own commit message that "five files across three packages" was wrong.
- A later commit fixed the count in the changeset.
- A third fixed the "four files" half of the same changeset sentence.
- A fourth edited the doc comment in `geometry-class.test.ts` — four lines below the stale count — and left it.

So the merge subject, the shipped changeset and the audit that found the site all say six. The only two artifacts still saying five are the ones a reader lands on when they open the module.

## Verified against the tree, not against #3161's account

Grepping every consumer of `@ifc-lite/geometry/geometry-class` finds six production files across three packages — `type-view-visibility.ts`, `kmz-exporter.ts`, `GLBExportDialog.tsx`, `ViewportContainer.tsx`, `demesh-session.ts`, `geometry/src/index.ts` — and `ViewportContainer.tsx` reaches the module through `type-view-visibility.ts` rather than importing it directly, which is why a grep for the ordinals alone misses it.

Comment-only, no behaviour change. The enumeration now lists all six.

## What this does not fix

The count is still a number in prose next to a list, so it can go stale again the same way. A test that counted the call sites would have to read source text, which `check-source-text-assertions` bans in test files for good reasons — so the durable version of this is a `scripts/check-*` lint, not a test, and that is more than this issue asked for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected geometry documentation to accurately identify all six historical geometry-class comparison locations.
  * Updated explanatory comments to reflect the corrected count.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->