### PR TITLE
refactor(scripts): parse the source-text gate's input instead of scanning it (#3174)

### DIFF
--- a/scripts/check-source-text-assertions.mjs
+++ b/scripts/check-source-text-assertions.mjs
@@ -50,15 +50,22 @@
  * so an exemption stays a reviewable line rather than a silent hole. Prefer it
  * to the allowlist, which is for whole files that cannot be converted at all.
  * An assertion wrapped over several lines counts as one, so the marker may sit
- * above the line the assertion STARTS on; `markerLineFor` in the detector owns
- * the exact rule.
+ * anywhere from one line above the ENCLOSING STATEMENT down to the predicate,
+ * and may also be written after the assertion on the same line. That range is
+ * the statement's own range in the parse tree, so a comment INSIDE the
+ * assertion does not break it -- which it did until #3174, and the run then
+ * failed twice over: once for the assertion, once for the marker it said
+ * excused nothing. A remedy an instrument prints has to be one it accepts.
  *
- * COMMENTS ARE STRIPPED FIRST, and that is load-bearing rather than tidy: three
- * unrelated tests mention a `.ts` filename in prose ("as per `safe-path.test.ts`",
- * "apache-arrow hides the `.d.ts`") while reading a wasm binary or a JSON
- * manifest, and matching those flagged all three. It is the same trap the test
- * this guard was born from fell into -- an assertion that matched its own
- * explanatory comment instead of the code.
+ * PROSE IS NOT CODE, and that separation is load-bearing rather than tidy:
+ * three unrelated tests mention a `.ts` filename in a comment ("as per
+ * `safe-path.test.ts`", "apache-arrow hides the `.d.ts`") while reading a wasm
+ * binary or a JSON manifest, and matching those flagged all three. It is the
+ * same trap the test this guard was born from fell into -- an assertion that
+ * matched its own explanatory comment instead of the code. The detector reads
+ * filenames from string and template literals in the tree, so a comment can no
+ * longer stand in for one, and a marker is read from comment trivia, so a
+ * string can no longer forge one.
  *
  * SCAN SCOPE is packages/ and apps/ test files only; scripts/*.test.mjs are not
  * scanned. That is a deliberate limit, not an oversight: those files run gates
@@ -164,7 +171,11 @@ const staleAllowlistEntries = new Set(allowlist);
 for (const dir of SEARCH_DIRS) {
   for (const file of walk(join(ROOT, dir))) {
     const rel = relative(ROOT, file).split('\\').join('/');
-    const result = analyze(readFileSync(file, 'utf8'));
+    // The PATH, not just the text: `analyze` parses with TypeScript, and TS
+    // and TSX are different grammars -- `<T>(x)` is a type assertion in one and
+    // an unclosed JSX tag in the other. Handing it the real name is what makes
+    // the parse match the file.
+    const result = analyze(readFileSync(file, 'utf8'), rel);
     for (const line of result.unusedMarkers) deadMarkers.push(`${rel}:${line}`);
     for (const site of result.marked) markedSites.push(`${rel}:${site.line}  ${site.reason}`);
     if (!result.flagged) continue;

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -32,7 +32,7 @@ import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { analyze, blankStrings, stripComments } from './source-text-assertion-detect.mjs';
+import { analyze } from './source-text-assertion-detect.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const GATE = join(ROOT, 'scripts', 'check-source-text-assertions.mjs');
@@ -483,14 +483,30 @@ assert.ok(source.includes('handleRowClick'));
 });
 
 test('division after ++ is not read as a regex', () => {
-  // Asserted on the BLANKING, not on `flagged`. The first version of this test
-  // checked `flagged` with the assertion on a different line, so the corruption
-  // never reached the verdict and it passed with the bug live: `a++ / b) / c`
-  // blanked to `(a++        c;`, eating the `)` and unbalancing every
-  // paren-matching read downstream. Two slashes on one line, so the
-  // unterminated-literal fallback does not save it.
-  const line = 'const r = (a++ / b) / c;';
-  assert.equal(blankStrings(stripComments(line)), line);
+  // This used to assert on the BLANKING, because the hand-rolled lexer read
+  // `a++ / b) / c` as a regex, blanked it to `(a++        c;`, and ate the `)`
+  // -- and an earlier version that checked `flagged` with the assertion on a
+  // different line passed with that bug live, because the corruption never
+  // reached the verdict.
+  //
+  // There is no blanking to assert on now (#3174): TypeScript decides regex
+  // versus division in the parser. So the property is stated where it is
+  // observable, in BOTH directions on the same input, which is what the
+  // earlier one-sided version lacked -- a rewrite that only checked the
+  // flagged case would pass on a detector that flags everything.
+  const hazard = 'const r = (a++ / b) / c;';
+  assert.equal(flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+${hazard}
+assert.ok(source.includes('tok'));
+`), true, 'a division after ++ swallowed the assertion below it');
+  assert.equal(flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+${hazard}
+assert.ok(other.includes('tok'));
+`), false, 'the same file with an UNTAINTED subject must stay clean');
 });
 
 // ---------------------------------------------------------------------------
@@ -701,8 +717,16 @@ assert.ok(source.includes('tok'));
 `),
     true,
   );
-  // The control: a genuine division after `)` must stay division.
-  assert.equal(blankStrings('const q = (1 + 2) / 3;'), 'const q = (1 + 2) / 3;');
+  // The control: a genuine division after `)` must stay division. Stated on
+  // the verdict now rather than on a blanked view (#3174) -- if that `/ 3;`
+  // opened a regex, everything to the next `/` would be one token and the
+  // assertion below would vanish with it.
+  assert.equal(flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+const q = (1 + 2) / 3;
+assert.ok(source.includes('tok'));
+`), true, 'a genuine division was read as a regex and ate the assertion');
 });
 
 test('a helper whose name contains $ is still followed', () => {
@@ -816,17 +840,28 @@ ${body}
 });
 
 test('a quoted string cannot cross a line', () => {
-  // The string state ended only on the matching quote, so ONE unpaired `'` or
-  // `"` kept the lexer inside a string until the next quote anywhere later in
-  // the file. Both views were blanked across that whole span, and every read,
-  // filename literal and predicate inside it disappeared.
-  assert.equal(
-    blankStrings("const bad = ';\nconst keep = 1;\nconst z = ';"),
-    "const bad = ' \nconst keep = 1;\nconst z = ' ",
-    'an unpaired quote swallowed the following lines',
-  );
-  // A template literal MAY span lines, so it must still be blanked across them.
-  assert.equal(blankStrings('const t = `a\nb`;'), 'const t = ` \n `;');
+  // The hand-rolled string state ended only on the matching quote, so ONE
+  // unpaired `'` or `"` kept the lexer inside a string until the next quote
+  // anywhere later in the file, and every read, filename literal and predicate
+  // in that span disappeared -- a whole file silently unscanned.
+  //
+  // Stated on the verdict now rather than on a blanked view (#3174). A quoted
+  // string cannot cross a newline, so the assertion two lines down must still
+  // be seen; a TEMPLATE literal may, so a predicate written INSIDE one is
+  // string content and must not be.
+  assert.equal(flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+const bad = ';
+assert.ok(source.includes('tok'));
+`), true, 'an unpaired quote swallowed the following lines');
+  assert.equal(flagged(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+const t = \`a
+assert.ok(source.includes('tok'));
+b\`;
+`), false, 'a predicate inside a multi-line template is string content, not code');
 });
 
 test('a $-leading callback parameter is tainted', () => {
@@ -873,4 +908,208 @@ ${body}
       `a $-leading name went undetected via: ${name}`,
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// 8. What parsing bought, and what it must not have cost (#3174).
+//
+// The three gaps below were found and measured while working on #3116 and left
+// in place because each needed more than that PR's scope. They were recorded
+// only in a commit message and a PR body, which is the failure shape this repo
+// keeps paying for. Here they are, executable.
+
+test('gap 1: a comment inside a wrapped assertion no longer kills the marker', () => {
+  // `markerLineFor` walked up over lines a regex called continuations. An
+  // interior comment strips to blank, which is not a continuation, so the walk
+  // stopped there and the marker above the assertion never reached the
+  // predicate. The gate then failed TWICE in the same run -- "source-text
+  // assertion found" and "marker that excuses nothing" -- and the remedy it
+  // prints in its own error text did not clear it.
+  const result = analyze(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+// @source-text-assertion-ok anchor guard
+assert.ok(
+  // the anchor must exist before we replace it
+  source.includes(anchor),
+);
+`);
+  assert.equal(result.flagged, false, 'the marker still does not reach past an interior comment');
+  assert.equal(result.marked.length, 1);
+  assert.deepEqual(result.unusedMarkers, [], 'the marker must not also be reported as dead');
+});
+
+test('gap 1: the fix must NOT be the fail-open one that was measured and rejected', () => {
+  // Making blank lines transparent to the walk closes gap 1 and opens a hole:
+  // a marker whose guard was deleted then reaches DOWN across blank lines to an
+  // unrelated predicate, turning a dead marker (loud) into a silent exemption.
+  // The marker's reach is the ENCLOSING STATEMENT, and a different statement is
+  // a different range, so no amount of blank line brings this one into scope.
+  const result = analyze(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+// @source-text-assertion-ok anchor guard
+
+
+
+assert.ok(source.includes('handleRowClick'));
+`);
+  assert.equal(result.flagged, true, 'a marker reached across blank lines and excused a real finding');
+  assert.equal(result.marked.length, 0);
+  assert.equal(result.unusedMarkers.length, 1, 'the orphaned marker must still be reported');
+});
+
+test('gap 3: a default parameter containing a call no longer hides the callback parameter', () => {
+  // Callback parameter lists were captured with `[^()]*`, which cannot cross
+  // the nested parens of `(line = pad(1))`. The parameter was never tainted, so
+  // the entire callback body read as clean -- in BOTH spellings. The plain
+  // forms are here as the control: they passed before, and a rewrite that
+  // flagged everything would satisfy the defaulted cases alone.
+  const head = `
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+`;
+  const bodies = {
+    'function (line)': `assert.ok(source.split('\\n').some(function (line) { return line.includes('TODO'); }));`,
+    'function (line = pad(1))': `assert.ok(source.split('\\n').some(function (line = pad(1)) { return line.includes('TODO'); }));`,
+    '(line) =>': `assert.ok(source.split('\\n').some((line) => line.includes('TODO')));`,
+    '(line = pad(1)) =>': `assert.ok(source.split('\\n').some((line = pad(1)) => line.includes('TODO')));`,
+    '({ text: line = pad(1) }) =>': `assert.ok(source.split('\\n').some(({ text: line = pad(1) }) => line.includes('TODO')));`,
+  };
+  for (const [label, body] of Object.entries(bodies))
+    assert.equal(flagged(head + body), true, `callback parameter went untainted via: ${label}`);
+});
+
+test('gap 2 stays open, and says so out loud', () => {
+  // Not a defect being tolerated silently. Widening the for-of rule to "any
+  // iterable carrying file bytes" also taints `for (const file of files)` where
+  // the elements are PATHS -- measured as 4 new hits in toolbar-parity.test.ts.
+  // Nothing in the SYNTAX separates a tainted array of lines from a tainted
+  // array of filenames, so parsing does not close this one either. If a future
+  // change makes the bound form flag, this test is the place that says the
+  // question was reopened rather than a rule quietly widening.
+  const head = `
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+`;
+  assert.equal(
+    flagged(head + `for (const line of source.split('\\n')) { assert.ok(!line.includes('TODO')); }`),
+    true,
+    'the inline split must still be caught, or this test is measuring nothing',
+  );
+  assert.equal(
+    flagged(head + `const lines = source.split('\\n');\nfor (const line of lines) { assert.ok(!line.includes('TODO')); }`),
+    false,
+    'gap 2 closed -- if that was deliberate, update this test and the docblock',
+  );
+});
+
+test('a TYPE ANNOTATION is not a parameter name', () => {
+  // The scanning version read parameter names out of the raw text between the
+  // parens, so `function rename(file: string, from: RegExp, to: string)`
+  // registered `string` and `RegExp` as parameters. Both really were in the
+  // taint set of packages/data/scripts/generate-ifc-schema.test.ts on main, and
+  // the index misalignment they caused is what tainted a subprocess-output
+  // assertion there -- the one false positive the pairing rule exists to
+  // prevent.
+  //
+  // The fixture asserts on a bare `string` on purpose, which no real test would
+  // write. That is what makes it DISCRIMINATING: `string` is a name only if the
+  // annotation was read as one. An earlier version of this test put the
+  // annotation in a slot no tainted argument reached, so it passed on the old
+  // detector too and measured nothing.
+  const src = `
+import { readFileSync } from 'node:fs';
+function load(p: string, kind: string) { return kind; }
+const s = readFileSync('a.ts', 'utf8');
+load('literal', s);
+`;
+  assert.equal(
+    flagged(src + `assert.ok(string.includes('nope'));`),
+    false,
+    'the annotation `string` was read as a parameter name and got tainted',
+  );
+  // The control: the parameter that argument REALLY lands in is tainted, so the
+  // assertion above is not passing because the call propagated nothing.
+  assert.equal(flagged(src + `assert.ok(kind.includes('yes'));`), true);
+});
+
+test('an argument taints the parameter it actually lands in', () => {
+  // Same root cause as the annotation case: a flat name list has no positions,
+  // so argument 1 could taint whatever name happened to sit at index 1 of a
+  // list that included annotations. Positional alignment means the SECOND
+  // parameter is tainted by the SECOND argument and by nothing else.
+  const src = (call) => `
+import { readFileSync } from 'node:fs';
+function check(clean: string, dirty: string) { assert.ok(dirty.includes('x')); }
+const s = readFileSync('a.ts', 'utf8');
+${call}
+`;
+  assert.equal(flagged(src(`check('literal', s);`)), true, 'the tainted argument reached its parameter');
+  assert.equal(flagged(src(`check(s, 'literal');`)), false, 'taint landed in the wrong parameter');
+});
+
+test('a marker written after the assertion on the same line still excuses it', () => {
+  // TypeScript attaches a same-line trailing comment to the PRECEDING token, so
+  // it is trailing trivia and not leading trivia of anything. A comment walk
+  // that reads only leading ranges loses every marker written this way -- and
+  // this is a documented spelling of the escape hatch, so losing it turns a
+  // marked site into a hard failure with no way to clear it.
+  const result = analyze(`
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+assert.ok(source.includes(anchor), 'drifted'); // @source-text-assertion-ok anchor guard
+`);
+  assert.equal(result.flagged, false);
+  assert.equal(result.marked.length, 1);
+  assert.deepEqual(result.unusedMarkers, []);
+});
+
+test('TypeScript-only syntax between the read and the predicate does not hide it', () => {
+  // The scanner had no notion of TS syntax at all -- it saw characters, and a
+  // type annotation was only ever "text that happens to sit between parens".
+  // These are the spellings a real test file reaches for around a file read,
+  // and each one has to leave the taint intact.
+  const head = `
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+`;
+  const shapes = {
+    'as cast': `const s = source as string;\nassert.ok(s.includes('x'));`,
+    'satisfies': `const s = source satisfies string;\nassert.ok(s.includes('x'));`,
+    'non-null': `const s = source!;\nassert.ok(s.includes('x'));`,
+    'generic helper': `function id<T>(v: T): T { return v; }\nassert.ok(id(source).includes('x'));`,
+    'jsx in the file': `render(<div>{source}</div>);\nassert.ok(source.includes('x'));`,
+  };
+  for (const [label, body] of Object.entries(shapes))
+    assert.equal(flagged(head + body), true, `taint was lost across: ${label}`);
+});
+
+test('two fail-opens the rewrite closed on the way past, named so they stay closed', () => {
+  // Neither is in #3174's list. Both were live on main, both are silent, and
+  // both are gone because the tree answers the question the regexes were
+  // approximating -- which is the argument for parsing, stated as two facts
+  // instead of as a preference.
+  const head = `
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+`;
+
+  // A CLASS METHOD as the helper. The function-shape regex matched
+  // `function name(` and `const name = (` and nothing else, so a method's
+  // parameter was never registered and the call site tainted nothing.
+  assert.equal(
+    flagged(head + `class C { check(t: string) { return t.includes('x'); } }\nassert.ok(new C().check(source));`),
+    true,
+    'a class method helper hid the assertion',
+  );
+
+  // An OPTIONAL-CHAIN predicate. `\.` matches the dot of `?.`, so the walk back
+  // for the receiver started on the `?`, stopped immediately and returned an
+  // empty receiver -- `source` was never part of the subject. The detector's
+  // own comments describe this exact trap being fixed for the iteration-callback
+  // rule; the predicate scan had the same bug and was never revisited. Two
+  // characters bought a clean file.
+  assert.equal(flagged(head + `assert.ok(source?.includes('x'));`), true, 'an optional-chain predicate escaped');
+  assert.equal(flagged(head + `assert.ok(source?.split('n')?.some((l) => l.includes('x')));`), true);
 });

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -1196,3 +1196,53 @@ const source = readFileSync('Thing.tsx', 'utf8');
     'an undecidable callee stopped failing closed',
   );
 });
+
+test('an angle-bracket type assertion is a wrapper too, where unwrap is load-bearing', () => {
+  // `unwrap` handles `TypeAssertionExpression` and nothing exercised it, because
+  // every other fixture parses as TSX and TSX cannot express `<T>value` — it
+  // reads as an unclosed JSX tag (2 parse errors, no assertion node). So the
+  // branch was dead in the suite while looking covered. Reported by CodeRabbit
+  // on #3177 alongside the `?.` guards, which is the other half of the same
+  // mistake: a guard would have swallowed a missing predicate and no test
+  // reached the path to notice.
+  //
+  // THE FIRST VERSION OF THIS TEST DID NOT MEASURE THE ARM. It asserted on
+  // `const s = <string>source` and on a callback nested inside an assertion,
+  // and both stay flagged with the arm deleted — the binding rule and the
+  // callback rule each walk the whole subtree, so they descend through the
+  // wrapper without needing it removed. Deleting the arm scored the same.
+  //
+  // The arm is load-bearing exactly where a node is inspected STRUCTURALLY
+  // rather than walked: resolving a callback passed BY NAME, and walking from
+  // a function up to the name it is bound to. Both of these flip to `false`
+  // with the arm removed, which is what makes them the test.
+  const head = `
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.ts', 'utf8');
+`;
+  const needsUnwrap = {
+    'named callback inside an assertion': `const hit = (line) => line.includes('x');\nassert.ok(source.split('n').some(<(l: string) => boolean>hit));`,
+    'helper declaration wrapped in one': `const chk = <(t: string) => boolean>((t) => t.includes('x'));\nassert.ok(chk(source));`,
+  };
+  for (const [label, body] of Object.entries(needsUnwrap))
+    assert.equal(analyze(head + body, 'a.ts').flagged, true, `unwrap missed: ${label}`);
+
+  // Kept as controls, and labelled as such: these two are covered by the
+  // subtree walks whether or not the arm exists, so they prove the fixtures
+  // parse — not that the arm works.
+  const coveredByWalks = {
+    'binding through an assertion': `const s = <string>source;\nassert.ok(s.includes('x'));`,
+    'callback nested inside one': `assert.ok(source.split('n').some(<(l: string) => boolean>((line) => line.includes('x'))));`,
+  };
+  for (const [label, body] of Object.entries(coveredByWalks))
+    assert.equal(analyze(head + body, 'a.ts').flagged, true, `control failed: ${label}`);
+
+  // And the reason the default fileName is TSX: the SAME source parsed as TSX
+  // is not this program at all, so a fixture that forgot the filename would be
+  // asserting about something else entirely.
+  assert.equal(
+    analyze(head + coveredByWalks['binding through an assertion'], 'a.tsx').flagged,
+    false,
+    'TSX now parses `<string>value` — if TypeScript changed, this test measures the wrong thing',
+  );
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -1113,3 +1113,49 @@ const source = readFileSync('Thing.tsx', 'utf8');
   assert.equal(flagged(head + `assert.ok(source?.includes('x'));`), true, 'an optional-chain predicate escaped');
   assert.equal(flagged(head + `assert.ok(source?.split('n')?.some((l) => l.includes('x')));`), true);
 });
+
+test('a callback wrapped in parentheses or a type wrapper is still a callback', () => {
+  // Reported by Codex on #3177, and it was a REGRESSION rather than a
+  // pre-existing gap: `some(((line) => …))` hands the argument loop a
+  // ParenthesizedExpression, so a bare `isFunctionLike` answered no and `line`
+  // stayed clean. The scanning version caught every one of these, because its
+  // callback pattern matched the arrow wherever it sat in the argument text.
+  //
+  // Shipping without this would have moved the gate in the one direction it
+  // must never move -- quieter -- while the PR claimed the opposite. Each row
+  // below was checked against main's detector, and all but the last were green
+  // there.
+  const head = `
+import { readFileSync } from 'node:fs';
+const source = readFileSync('Thing.tsx', 'utf8');
+`;
+  const wrapped = {
+    'parenthesized arrow': `assert.ok(source.split('n').some(((line) => line.includes('TODO'))));`,
+    'as-cast callback': `assert.ok(source.split('n').some(((line) => line.includes('TODO')) as any));`,
+    'satisfies callback': `assert.ok(source.split('n').some(((line) => line.includes('TODO')) satisfies unknown));`,
+    'parenthesized function expression': `assert.ok(source.split('n').some((function (line) { return line.includes('TODO'); })));`,
+    // Not a regression -- main missed this one too -- but the same root cause,
+    // so it is closed and pinned with the rest rather than left as a sibling
+    // waiting to be found separately.
+    'parenthesized hoisted callback': `const hit = (line) => line.includes('TODO');\nassert.ok(source.split('n').some((hit)));`,
+    // The declaration side of the same blindness: the arrow's parent is the
+    // parenthesis, not the declaration, so the helper had no name at all.
+    'wrapped helper declaration': `const chk = ((t) => t.includes('x'));\nassert.ok(chk(source));`,
+  };
+  for (const [label, body] of Object.entries(wrapped))
+    assert.equal(flagged(head + body), true, `a wrapped callback went untainted via: ${label}`);
+
+  // A wrapped RECEIVER is a different path -- it is read by subtree walk, which
+  // descends through the wrapper -- and must keep working.
+  assert.equal(flagged(head + `assert.ok((source).includes('x'));`), true);
+  assert.equal(flagged(head + `assert.ok((source as string).includes('x'));`), true);
+
+  // And the callee is deliberately NOT unwrapped: `(fn)(source)` is a callee
+  // this analysis cannot name, so it must stay in the fail-closed branch that
+  // taints every parameter, exactly as the scanning version had it.
+  assert.equal(
+    flagged(head + `function opaque(t) { assert.ok(t.includes('x')); }\n(opaque)(source);`),
+    true,
+    'an undecidable callee stopped failing closed',
+  );
+});

--- a/scripts/check-source-text-assertions.test.mjs
+++ b/scripts/check-source-text-assertions.test.mjs
@@ -1145,6 +1145,43 @@ const source = readFileSync('Thing.tsx', 'utf8');
   for (const [label, body] of Object.entries(wrapped))
     assert.equal(flagged(head + body), true, `a wrapped callback went untainted via: ${label}`);
 
+  // The SECOND round of the same finding, also from Codex on #3177: unwrapping
+  // a fixed list of wrappers is not enough, because an expression can SELECT a
+  // callback without being one. The scanning version found arrows anywhere in
+  // the argument text, so each of these was green on main and red here until
+  // the argument is walked rather than root-tested.
+  const selected = {
+    'ternary': `assert.ok(source.split('n').some(flag ? (line) => line.includes('TODO') : other));`,
+    'logical ||': `assert.ok(source.split('n').some(cb || ((line) => line.includes('TODO'))));`,
+    'comma operator': `assert.ok(source.split('n').some((noop(), (line) => line.includes('TODO'))));`,
+    'spread of a literal': `assert.ok(source.split('n').some(...[(line) => line.includes('TODO')]));`,
+    'nested inside a call': `assert.ok(source.split('n').some(wrapCb((line) => line.includes('TODO'))));`,
+  };
+  for (const [label, body] of Object.entries(selected))
+    assert.equal(flagged(head + body), true, `a selected callback went untainted via: ${label}`);
+
+  // A callback passed BY NAME through a selector. Main did NOT catch this one,
+  // so it is not a regression -- it is closed here because resolving the
+  // selector's branches costs nothing once they are already being walked.
+  assert.equal(
+    flagged(head + `const hit = (line) => line.includes('TODO');\nassert.ok(source.split('n').some(flag ? hit : other));`),
+    true,
+    'a named callback behind a ternary went untainted',
+  );
+
+  // DEFERRED, and recorded so it is a known hole rather than an assumed one: a
+  // callback FACTORY, `some(makeCheck())`, where no function expression appears
+  // in the argument at all. Main misses it too, so this PR regresses nothing.
+  // Closing it means treating any unresolvable argument as fail-closed, and
+  // nothing lexically marks "callback position" -- `source.includes(getAnchor())`
+  // has the same shape and is an ordinary assertion, so that rule would taint
+  // every parameter in a large share of real test files.
+  assert.equal(
+    flagged(head + `function makeCheck() { return (line) => line.includes('TODO'); }\nassert.ok(source.split('n').some(makeCheck()));`),
+    false,
+    'the callback-factory hole closed -- update this test and the docblock if that was deliberate',
+  );
+
   // A wrapped RECEIVER is a different path -- it is read by subtree walk, which
   // descends through the wrapper -- and must keep working.
   assert.equal(flagged(head + `assert.ok((source).includes('x'));`), true);

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -199,6 +199,14 @@ function walk(node, visit) {
  * Deliberately NOT applied to a call's CALLEE. `(fn)(source)` must stay in the
  * fail-closed branch, which is where the scanning version put it and where an
  * undecidable callee belongs.
+ *
+ * Every predicate is called DIRECTLY, with no `?.` guard. The first version
+ * wrote `ts.isSatisfiesExpression?.(n) ?? false` out of caution about the API
+ * surface, which is a fail-open dressed as defensiveness: a renamed or missing
+ * predicate would answer "not a wrapper" and silently stop unwrapping, instead
+ * of throwing where someone would see it. `typescript@^6.0.3` exports all five
+ * (checked), and if a future version does not, this should break loudly.
+ * Reported by CodeRabbit on #3177.
  */
 function unwrap(node) {
   let n = node;
@@ -206,9 +214,9 @@ function unwrap(node) {
     n &&
     (ts.isParenthesizedExpression(n) ||
       ts.isAsExpression(n) ||
-      (ts.isSatisfiesExpression?.(n) ?? false) ||
+      ts.isSatisfiesExpression(n) ||
       ts.isNonNullExpression(n) ||
-      (ts.isTypeAssertionExpression?.(n) ?? false))
+      ts.isTypeAssertionExpression(n))
   )
     n = n.expression;
   return n;
@@ -320,15 +328,7 @@ function functionName(fn) {
   // the parenthesis, not the declaration, so the helper had no name and its
   // call sites tainted nothing.
   let parent = fn.parent;
-  while (
-    parent &&
-    (ts.isParenthesizedExpression(parent) ||
-      ts.isAsExpression(parent) ||
-      (ts.isSatisfiesExpression?.(parent) ?? false) ||
-      ts.isNonNullExpression(parent) ||
-      (ts.isTypeAssertionExpression?.(parent) ?? false))
-  )
-    parent = parent.parent;
+  while (parent && unwrap(parent) !== parent) parent = parent.parent;
   if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
   if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
   if (

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -188,6 +188,33 @@ function walk(node, visit) {
 }
 
 /**
+ * Strip the wrappers that change how an expression is SPELLED and not what it
+ * IS: parentheses, `as`, `satisfies`, `!`, and the angle-bracket assertion.
+ *
+ * Needed wherever a node is inspected STRUCTURALLY — "is this argument a
+ * function?", "is it an identifier naming one?". A subtree walk does not care,
+ * because it descends through the wrapper anyway; a `ts.isFunctionLike` check
+ * on the wrapper answers no and taints nothing.
+ *
+ * Deliberately NOT applied to a call's CALLEE. `(fn)(source)` must stay in the
+ * fail-closed branch, which is where the scanning version put it and where an
+ * undecidable callee belongs.
+ */
+function unwrap(node) {
+  let n = node;
+  while (
+    n &&
+    (ts.isParenthesizedExpression(n) ||
+      ts.isAsExpression(n) ||
+      (ts.isSatisfiesExpression?.(n) ?? false) ||
+      ts.isNonNullExpression(n) ||
+      (ts.isTypeAssertionExpression?.(n) ?? false))
+  )
+    n = n.expression;
+  return n;
+}
+
+/**
  * The name a callee resolves to, for `f(…)`, `fs.readFileSync(…)` and
  * `a.b.c(…)` alike — the rightmost identifier, which is the one that says what
  * is being called. `null` when the callee is anything else, which is the
@@ -257,7 +284,19 @@ function parameterNames(fn) {
  */
 function functionName(fn) {
   if (fn.name && ts.isIdentifier(fn.name)) return fn.name.text;
-  const parent = fn.parent;
+  // Up THROUGH the wrappers: in `const f = ((x) => …)` the arrow's parent is
+  // the parenthesis, not the declaration, so the helper had no name and its
+  // call sites tainted nothing.
+  let parent = fn.parent;
+  while (
+    parent &&
+    (ts.isParenthesizedExpression(parent) ||
+      ts.isAsExpression(parent) ||
+      (ts.isSatisfiesExpression?.(parent) ?? false) ||
+      ts.isNonNullExpression(parent) ||
+      (ts.isTypeAssertionExpression?.(parent) ?? false))
+  )
+    parent = parent.parent;
   if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
   if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
   if (
@@ -420,7 +459,16 @@ function computeTainted(sourceFile) {
       // body read as clean in both the arrow and the `function` spelling.
       if (!ts.isPropertyAccessExpression(call.expression)) continue;
       if (!carriesFileBytes(call.expression.expression)) continue;
-      for (const arg of args) {
+      for (const rawArg of args) {
+        // UNWRAPPED first. `some(((line) => …))` and
+        // `some(((line) => …) as Predicate)` hand this loop a
+        // ParenthesizedExpression / AsExpression, so a bare `isFunctionLike`
+        // answered no, `line` stayed clean and the whole callback body read as
+        // clean with it. The scanning version caught these -- its callback
+        // pattern matched the arrow wherever it sat in the argument text --
+        // so shipping without this would have been a REGRESSION into the one
+        // direction this gate must never move. Reported by Codex on #3177.
+        const arg = unwrap(rawArg);
         if (ts.isFunctionLike(arg) && arg.parameters) taintAll(parameterNames(arg));
         // A HOISTED callback is passed by name, so its parameters are declared
         // somewhere else entirely: `.some(hit)` with `const hit = (line) => …`.

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -20,9 +20,7 @@
  * The obvious repair, excluding `.stdout`/`.stderr` receivers, was considered
  * and REJECTED: a file may legitimately assert on file text in one place and
  * wrap a subprocess result in another, and an exclusion keyed on the second
- * would blind the gate to the first with nothing recording the decision. That
- * is the same class of mistake — a proxy that correlates with the property you
- * want, until it does not.
+ * would blind the gate to the first with nothing recording the decision.
  *
  * So this module pairs them. A predicate counts only when it is applied to a
  * value that a file read produced. Taint starts at `readFileSync`/`readFile`
@@ -40,11 +38,91 @@
  * under-tainting would silently drop coverage, which is the direction that
  * turns a gate into decoration.
  *
+ * ═══ WHY THIS PARSES INSTEAD OF SCANNING (#3174) ═══
+ *
+ * Until #3174 this module hand-rolled a lexer for JS, TS and TSX, and its own
+ * docblock said the central heuristic was "APPROXIMATE, not sound". Its history
+ * was a string of fail-opens that each looked like a small fix: a quote inside
+ * a regex literal blanking the rest of the file, a `//` inside a string doing
+ * the same, `)` before `/` read as division when it closed an `if` header, a
+ * `$` defeating a `\b`. Each was found by someone reading the file, not by the
+ * gate, because every one of them made the gate go QUIET.
+ *
+ * Two more were open when the rewrite landed, and neither could be closed by
+ * another pattern:
+ *
+ *   - A COMMENT INSIDE A WRAPPED ASSERTION killed the marker. `markerLineFor`
+ *     walked up over lines a `CONTINUES` regex accepted; an interior comment
+ *     strips to blank, which is not a continuation, so the walk stopped and the
+ *     marker above the assertion never reached the predicate. The gate then
+ *     failed twice — "source-text assertion found" AND "marker that excuses
+ *     nothing" — and the remedy it prints in its own error text did not clear
+ *     it. Making blank lines transparent was measured and REJECTED: it lets a
+ *     marker reach across blank lines to an unrelated predicate, turning a loud
+ *     dead marker into a silent exemption. The marker's reach is "the enclosing
+ *     statement", which is a range in the tree, not a run of lines that look
+ *     unfinished.
+ *
+ *   - A DEFAULT PARAMETER CONTAINING A CALL hid the callback's parameter.
+ *     Callback parameter lists were captured with `[^()]*`, which cannot cross
+ *     the nested parens of `(line = pad(1)) =>`, so the parameter was never
+ *     tainted and the whole callback body read as clean.
+ *
+ * Both are the same sentence: the regex cannot see structure the parser has for
+ * free. So the scanning layer is gone — `blankStrings`, `stripComments`,
+ * `regexLiteralEnd`, `closesAControlHeader`, `CONTINUES`, `markerLineFor`,
+ * `statementEnd`, `matchParen`, `receiverStart`, `splitArgs` — and with it every
+ * fail-open those functions were patched for. `ts.createSourceFile` decides
+ * regex-versus-division, string and template boundaries, comment extents and
+ * statement ranges, and it is `createSourceFile` specifically: `ts.createScanner`
+ * alone never calls `reScanSlashToken`, so it gets the same class of question
+ * wrong that the hand-rolled `regexLiteralEnd` did.
+ *
+ * Cost, measured on this machine over the 1430 test files the gate walks, three
+ * runs each: 0.82s end to end while scanning, 1.51s parsing. Both under two
+ * seconds, on a CI job that runs the entire node test suite.
+ *
+ * VERDICTS CHANGED on the corpus, and only these two — the diff was run file by
+ * file, old detector against new, comparing hit, marked and dead-marker lines:
+ *
+ *   - `packages/data/scripts/generate-ifc-schema.test.ts:164` was flagged and is
+ *     not. `expect(r.stderr).toContain(message)` asserts on SUBPROCESS OUTPUT,
+ *     which is the exact false positive the pairing rule was built to stop, and
+ *     this file is the one named in the paragraph above for it. The scanner read
+ *     parameter names out of the raw text between the parens, so
+ *     `rename(file: string, from: RegExp, to: string)` registered `string` and
+ *     `RegExp` as parameters — both were really in that file's taint set on
+ *     `main` — and the index shift they caused walked taint into `message`, a
+ *     table field holding a literal error string. `fn.parameters` has no such
+ *     slots. The file's two real hits, on a callback parameter that does receive
+ *     file contents, are unchanged.
+ *
+ *   - `apps/viewer/src/components/viewer/toolbar/export-ui-parity.test.tsx`
+ *     gained four hits (575, 581, 585, 590). They are genuine: `hookSource`
+ *     comes from `readSource('…/useExportCommands.ts')`, `successToasts` from
+ *     its `matchAll`, and the four predicates run on elements found in it. The
+ *     file is already allowlisted, so the gate's verdict is unchanged.
+ *
+ * Both directions are pinned in `check-source-text-assertions.test.mjs`, so
+ * neither is held together by this paragraph alone.
+ *
+ * WHAT DID NOT CHANGE is the taint analysis: still one flat name set, no
+ * scoping, deliberately over-eager. It is the same rules against a tree instead
+ * of against string slices, and `analyze`'s return shape is identical.
+ *
+ * STILL OPEN, deliberately: `for (const line of lines)` where the split was
+ * bound to a name first. Widening the for-of rule to "any iterable carrying
+ * file bytes" also taints `for (const file of files)` where the elements are
+ * PATHS — measured as 4 new hits in `toolbar-parity.test.ts`. That is a
+ * question about what an array HOLDS, which a parser cannot answer either, so
+ * parsing does not close it and the rule still takes only the `.split(` it can
+ * prove.
+ *
  * WHAT COUNTS AS THE PREDICATE'S SUBJECT is both the receiver chain and the
  * arguments, because both spellings occur: `source.includes(x)` and
  * `assert.match(source, /x/)` and `new RegExp(x).exec(source)` are the same
  * assertion. `expect(source).toContain(x)` needs no special case — `expect(…)`
- * is part of the receiver chain, so `source` is found by reading it.
+ * is the receiver, so `source` is found by reading it.
  *
  * THE ANCHOR-GUARD ESCAPE HATCH. `assert.ok(source.includes(from), 'mutation
  * anchor not found')` before a `source.replace(from, to)` is, by this rule, a
@@ -57,762 +135,468 @@
  *     // @source-text-assertion-ok mutation anchor guard, not a subject assertion
  *     assert.ok(source.includes(from), `anchor not found: ${from}`);
  *
- * The marker suppresses the predicate on its own line, or anywhere from the
- * first line of the enclosing assertion upward by one -- a wrapped
- * `assert.ok(\n  source.includes(x),\n)` puts the predicate below the line the
- * marker sits above, and the remedy this gate prints assumes that works
- * — same ratchet discipline as the allowlist. The decision stays a grep-able
- * line in the diff, which a structural carve-out never would be.
+ * The marker suppresses the predicate on its own line, or anywhere from one
+ * line above the ENCLOSING STATEMENT down to the predicate. That range comes
+ * from the tree, so a wrapped assertion — with or without comments inside it —
+ * is one statement and the marker the gate tells you to write is the marker it
+ * accepts. The decision stays a grep-able line in the diff, which a structural
+ * carve-out never would be.
  */
 
-/** Reads a file from disk at all — the taint source. */
-export const READS_A_FILE = /\b(readFileSync|readFile)\s*\(/;
+import ts from 'typescript';
+
+/**
+ * The taint source: a disk read, however the call is qualified. This used to be
+ * a regex matched against a blanked view of the text, which is why it had to
+ * also decide `fs.readFileSync` and `await fsp.readFile` for itself. The tree
+ * answers that, so the two NAMES are the whole rule.
+ */
+const READ_NAMES = new Set(['readFileSync', 'readFile']);
 
 /**
  * Names a SOURCE file as a literal. Fixture formats (.ifc, .json, .csv, …) are
  * deliberately absent: reading a fixture and asserting on it is a normal test.
+ *
+ * Applied to string and template-literal CONTENT from the tree, so a `.ts`
+ * filename that appears only in prose cannot satisfy it. That used to need a
+ * comment-stripping pass, and it was load-bearing rather than tidy: three
+ * unrelated tests mention a `.ts` filename in a comment while reading a wasm
+ * binary or a JSON manifest, and matching those flagged all three.
  */
-export const SOURCE_LITERAL = /['"`][^'"`\n]*\.(ts|tsx|mts|rs|css|scss)['"`]/;
+const SOURCE_LITERAL = /^[^'"`\n]*\.(ts|tsx|mts|rs|css|scss)$/;
 
 /**
  * Text predicates. `test` and `exec` are here because this repo already writes
  * them that way — `/re/.test(source)` in export-ui-parity.test.tsx and
  * `new RegExp(…).exec(src)` in prepass-class-spans.test.ts, the latter a form
- * the guard was blind to until #2434. Under the pairing rule they no longer
- * need the receiver-name allowlist the flat version used (`.test(source|src|
- * text|…)`): the receiver of `/re/.test(x)` is a regex and never tainted, so
- * what decides the case is whether `x` came from a file — which is the actual
- * question.
+ * the guard was blind to until #2434. Under the pairing rule they need no
+ * receiver-name allowlist: the receiver of `/re/.test(x)` is a regex and never
+ * tainted, so what decides the case is whether `x` came from a file.
  */
-const PREDICATE_METHOD =
-  /\.\s*(includes|indexOf|match|search|startsWith|endsWith|exec|test|toContain|toMatch)\s*\(/g;
+const PREDICATE_METHODS = new Set([
+  'includes', 'indexOf', 'match', 'search', 'startsWith', 'endsWith',
+  'exec', 'test', 'toContain', 'toMatch',
+]);
 
 /** `@source-text-assertion-ok <reason>` — see the docblock. */
 const MARKER = /@source-text-assertion-ok\b[ \t]*(\S[^\n]*)?/;
 
-const OPENERS = '([{';
-const CLOSERS = ')]}';
-
-/** Characters after which a `/` begins a REGEX rather than a division. */
-const REGEX_PRECEDERS = new Set([
-  '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '~', '^', '>', '\n',
-]);
-
-/** Keywords after which a `/` begins a regex (`return /re/.test(x)`). */
-const REGEX_PRECEDING_WORDS = /(?:^|[^A-Za-z0-9_$])(return|typeof|instanceof|case|in|of|delete|void|new|do|else|yield|await)$/;
-
-/**
- * TRUE when the `)` at `end` closes an `if (…)` / `for (…)` / `while (…)` style
- * HEADER rather than a parenthesised expression.
- *
- * `)` is not a regex-preceder, because `(a + b) / c` is division. But an
- * unbraced control body can be a regex expression statement:
- *
- *     if (ok) /["']/.test(value);
- *
- * There the `/` starts a literal, and reading it as division let the `"` open a
- * string that never closed, blanking the rest of the file -- the gate then
- * reported a clean file. Distinguishing the two needs the token before the
- * MATCHING `(`, so this walks back to it.
- */
-function closesAControlHeader(back, end) {
-  if (back[end] !== ')') return false;
-  let depth = 0;
-  let j = end;
-  for (; j >= 0; j--) {
-    if (back[j] === ')') depth++;
-    else if (back[j] === '(') {
-      depth--;
-      if (depth === 0) break;
-    }
-  }
-  if (j < 0) return false;
-  let w = j - 1;
-  // ALL whitespace, not just space and tab. A control keyword and its `(` can
-  // sit on different lines (`if\n(ok) /re/.test(v)`), and stopping at the
-  // newline read the header as an ordinary parenthesised expression, so the
-  // regex became division and its quote desynced the lexer.
-  while (w >= 0 && /\s/.test(back[w])) w--;
-  const span = back.slice(Math.max(0, w - 8), w + 1).join('');
-  return /(?:^|[^A-Za-z0-9_$])(if|for|while|switch|catch|with)$/.test(span);
+/** Depth-first over every node in the tree. */
+function walk(node, visit) {
+  visit(node);
+  ts.forEachChild(node, (child) => walk(child, visit));
 }
 
 /**
- * If `src[start]` opens a regex literal, the index just PAST it (flags
- * included); otherwise `start`, meaning "this `/` is division".
- *
- * The division-vs-regex question is decided by the previous significant
- * character. That is the standard heuristic and it is APPROXIMATE, not sound;
- * measured against the TypeScript parser over the scanned corpus it disagrees
- * on a handful of lines, none of which currently changes a verdict.
- * A `[...]` class is tracked, since `/` inside one is literal, and an
- * unterminated literal (no closing `/` before the line ends) is treated as
- * division rather than swallowing the rest of the file.
+ * The name a callee resolves to, for `f(…)`, `fs.readFileSync(…)` and
+ * `a.b.c(…)` alike — the rightmost identifier, which is the one that says what
+ * is being called. `null` when the callee is anything else, which is the
+ * fail-closed case below.
  */
-function regexLiteralEnd(src, start, back) {
-  // The BACKWARD scan reads `back`, which is the output-so-far with comments
-  // already blanked, while the forward scan reads raw `src`. They must differ:
-  // looking back over raw text puts the `/` of a preceding `*/` in front of
-  // the literal, so `const a = 1; /* c */ /["']/.test(z)` reads as DIVISION,
-  // the `"` opens a string that never closes, and the rest of the file is
-  // blanked -- a silent fail-open. Comments blank to spaces, which this skips.
-  // `back` is REQUIRED rather than defaulting to `src`: a default would let a
-  // future two-argument call silently restore that bug, and absence should not
-  // read as success.
-  let k = start - 1;
-  while (k >= 0 && (back[k] === ' ' || back[k] === '\t')) k--;
-  const prev = k >= 0 ? back[k] : '';
-  // `<` is deliberately NOT a preceder. `</Foo>` puts one directly before the
-  // slash, and these files are `.tsx`: accepting it made every JSX closing tag
-  // open a "regex", which on a line with a second `/` swallowed the opening
-  // quote and desynced the scanner for the rest of the FILE. That is the exact
-  // whole-file blanking this function exists to prevent, reintroduced by the
-  // fix for it. `>` has to stay, because it carries `=>`.
-  //
-  // `a++ / b` and `a-- / b` are division, so a doubled `+`/`-` is excluded even
-  // though a single one is a legitimate preceder (`a + /re/.test(b)`).
-  const doubled = (prev === '+' || prev === '-') && back[k - 1] === prev;
-  const wordSpan = back.slice(Math.max(0, k - 12), k + 1).join('');
-  const isRegex =
-    !doubled
-    && (prev === ''
-      || REGEX_PRECEDERS.has(prev)
-      || REGEX_PRECEDING_WORDS.test(wordSpan)
-      || closesAControlHeader(back, k));
-  if (!isRegex) return start;
+function calleeName(expr) {
+  if (ts.isIdentifier(expr)) return expr.text;
+  if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.name)) return expr.name.text;
+  return null;
+}
 
-  let i = start + 1;
-  let inClass = false;
-  while (i < src.length) {
-    const c = src[i];
-    if (c === '\n') return start; // unterminated: it was division after all
-    if (c === '\\') { i += 2; continue; }
-    if (c === '[') inClass = true;
-    else if (c === ']') inClass = false;
-    else if (c === '/' && !inClass) {
-      i++;
-      while (i < src.length && /[a-z]/.test(src[i])) i++; // flags
-      return i;
-    }
-    i++;
-  }
-  return start;
+/** TRUE when the subtree PERFORMS a read, however the call is qualified. */
+function performsRead(node) {
+  let found = false;
+  walk(node, (n) => {
+    if (found || !ts.isCallExpression(n)) return;
+    const name = calleeName(n.expression);
+    if (name && READ_NAMES.has(name)) found = true;
+  });
+  return found;
 }
 
 /**
- * ONE pass over `src` producing three length- and line-preserving views.
+ * Identifiers in `node` at VALUE position — property names after `.` excluded,
+ * so `fs.readFileSync` contributes `fs` and not `readFileSync`, and `a.source`
+ * does not contribute `source`.
  *
- * Comments and strings cannot be lexed separately, because each can contain
- * the other. Doing comments first (the old `stripComments`) truncated
- * `const doc = 'see // the docs';` to an unterminated quote, and the string
- * lexer then blanked the REST OF THE FILE, so every assertion after it went
- * invisible and the gate reported nothing to see. Doing strings first fails
- * the mirror case, a quote inside a comment. So both happen here, together.
- *
- *   text      comments blanked, string CONTENT intact -- for the pattern tests
- *             that must still see a filename literal
- *   blanked   comments AND string content blanked -- the code skeleton every
- *             index-based read walks
- *   comments  ONLY comment interiors kept -- markers are read from this, so a
- *             `@source-text-assertion-ok` sitting inside a STRING can no
- *             longer excuse a real finding
- *
- * Blanking to spaces rather than deleting keeps every index and line number
- * equal to the original, which every caller here relies on.
+ * The scanning version did this with a regex that dropped any name preceded by
+ * a dot, which cost it two silent bugs around `$` (not a word character, so a
+ * leading `\b` never matched). The tree says which identifiers are property
+ * names, so neither case can come back.
  */
-function lexViews(src) {
-  const text = src.split('');
-  const blanked = src.split('');
-  const comments = src.split('');
-  for (let k = 0; k < src.length; k++) if (src[k] !== '\n') comments[k] = ' ';
-
-  const blankBoth = (k) => {
-    if (src[k] === '\n') return;
-    text[k] = ' ';
-    blanked[k] = ' ';
-  };
-  const keepComment = (k) => {
-    blankBoth(k);
-    comments[k] = src[k];
-  };
-
-  const stack = [];
-  let i = 0;
-  while (i < src.length) {
-    const c = src[i];
-    const top = stack[stack.length - 1];
-
-    if (top && top.kind === 'str') {
-      if (c === '\\') {
-        if (src[i] !== '\n') blanked[i] = ' ';
-        if (src[i + 1] !== undefined && src[i + 1] !== '\n') blanked[i + 1] = ' ';
-        i += 2;
-        continue;
-      }
-      if (c === top.quote) {
-        stack.pop();
-        i++;
-        continue;
-      }
-      if (top.quote === '`' && c === '$' && src[i + 1] === '{') {
-        stack.push({ kind: 'interp', depth: 0 });
-        i += 2;
-        continue;
-      }
-      // A `'` or `"` literal CANNOT cross a line. Without this an unpaired
-      // quote kept the lexer in string state until the next quote anywhere
-      // later in the file, blanking both views across that whole span, so every
-      // read, filename literal and predicate inside it disappeared and the file
-      // reported clean. Only a template literal may span lines; a legal line
-      // continuation is a `\` escape and was already consumed above.
-      if (c === '\n' && top.quote !== '`') {
-        stack.pop();
-        i++;
-        continue;
-      }
-      if (c !== '\n') blanked[i] = ' ';
-      i++;
-      continue;
-    }
-
-    // COMMENTS ARE TESTED BEFORE REGEX. `//` would otherwise be offered to
-    // `regexLiteralEnd` as an empty literal and could swallow code up to the
-    // next slash on the line.
-    if (c === '/' && src[i + 1] === '/') {
-      while (i < src.length && src[i] !== '\n') keepComment(i++);
-      continue;
-    }
-    if (c === '/' && src[i + 1] === '*') {
-      keepComment(i++);
-      keepComment(i++);
-      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) keepComment(i++);
-      if (i < src.length) {
-        keepComment(i++);
-        keepComment(i++);
-      }
-      continue;
-    }
-
-    if (c === "'" || c === '"' || c === '`') {
-      stack.push({ kind: 'str', quote: c });
-      i++;
-      continue;
-    }
-
-    if (c === '/') {
-      const end = regexLiteralEnd(src, i, blanked);
-      if (end > i) {
-        // Keep the OPENING `/` in the blanked view. Blanking a literal whole
-        // makes the next `/` look back past it to whatever preceded the
-        // literal: in `const n = /a/ / b; const s = 'q/w';` the division saw
-        // `=`, called itself a regex, ran forward into the `'q/w'` string for
-        // its "closing" slash, and blanked the rest of the file. A surviving
-        // `/` is not a regex-preceder, so the division is read as division.
-        for (let k = i + 1; k < end; k++) if (src[k] !== '\n') blanked[k] = ' ';
-        i = end;
-        continue;
-      }
-    }
-
-    if (top && top.kind === 'interp') {
-      if (OPENERS.includes(c)) top.depth++;
-      else if (c === '}' && top.depth === 0) {
-        stack.pop();
-        i++;
-        continue;
-      } else if (CLOSERS.includes(c)) top.depth--;
-    }
-    i++;
-  }
-  return { text: text.join(''), blanked: blanked.join(''), comments: comments.join('') };
-}
-
-/**
- * Blank string and template-literal CONTENT, preserving length, newlines and
- * `${…}` interpolations. Length preservation is load-bearing: every index
- * computed on the blanked text is used against the original. One view of
- * {@link lexViews} rather than a second scanner.
- */
-export function blankStrings(src) {
-  return lexViews(src).blanked;
-}
-
-/**
- * Comments blanked, string content INTACT, line numbers and length preserved,
- * so a marker can be matched against the line of the predicate it excuses.
- * Load-bearing rather than tidy: three unrelated tests mention a `.ts` filename
- * in prose while reading a wasm binary or a JSON manifest.
- *
- * One view of {@link lexViews}. It used to be a pair of regexes that truncated
- * a line at `//` with no idea whether that `//` was inside a STRING, which is
- * what made the gate go silent from `const doc = 'see // the docs';` onward.
- */
-export function stripComments(source) {
-  return lexViews(source).text;
-}
-
-/** Identifiers in `expr` at value position: property names after `.` excluded. */
-function valueIdentifiers(expr) {
+function valueIdentifiers(node) {
   const names = new Set();
-  // NOT `\b` before the name. `$` is legal in a JS identifier and is not a word
-  // character, so `\b` never matches in front of a LEADING `$`: `$read(x)`
-  // yielded `read`, which matches nothing in the tainted set, and `a.$b` yielded
-  // `b` with the dot marker lost, so a property was read as a value. Both are
-  // silent. An explicit "not preceded by an identifier character" assertion
-  // handles `$`, and the trailing `\b` is unnecessary because the class is
-  // greedy.
-  const re = /(\.?)\s*(?<![\w$])([A-Za-z_$][\w$]*)/g;
-  let m;
-  while ((m = re.exec(expr)) !== null) {
-    if (m[1] === '.') continue;
-    names.add(m[2]);
-  }
+  walk(node, (n) => {
+    if (!ts.isIdentifier(n)) return;
+    const parent = n.parent;
+    if (parent && ts.isPropertyAccessExpression(parent) && parent.name === n) return;
+    if (parent && ts.isQualifiedName(parent) && parent.right === n) return;
+    if (parent && ts.isPropertyAssignment(parent) && parent.name === n) return;
+    if (parent && ts.isBindingElement(parent) && parent.propertyName === n) return;
+    names.add(n.text);
+  });
   return names;
 }
 
-/** End index (exclusive) of the statement whose right-hand side starts at `start`. */
-function statementEnd(blanked, start) {
-  let depth = 0;
-  for (let i = start; i < blanked.length; i++) {
-    const c = blanked[i];
-    if (OPENERS.includes(c)) depth++;
-    else if (CLOSERS.includes(c)) {
-      if (depth === 0) return i;
-      depth--;
-    } else if (c === ';' && depth === 0) return i;
-    else if (c === '\n' && depth === 0) {
-      // Approximate ASI: a line that ends mid-expression, or whose successor
-      // continues one, is not a statement boundary.
-      const before = blanked.slice(start, i).trimEnd().slice(-1);
-      if (before && '=+-*/%,.?:&|<>({[!~^'.includes(before)) continue;
-      const next = /\S/.exec(blanked.slice(i));
-      if (next && '.?:+-*/%&|,)]}'.includes(next[0])) continue;
-      return i;
-    }
-  }
-  return blanked.length;
+/** Every identifier a binding name binds, destructuring patterns included. */
+function boundNames(name) {
+  const out = [];
+  if (ts.isIdentifier(name)) return [name.text];
+  walk(name, (n) => {
+    if (!ts.isBindingElement(n)) return;
+    if (ts.isIdentifier(n.name)) out.push(n.name.text);
+  });
+  return out;
 }
 
-/** Index OF the `)` matching the `(` at `open`; `blanked.length` if unclosed. */
-function matchParen(blanked, open) {
-  let depth = 0;
-  for (let i = open; i < blanked.length; i++) {
-    if (OPENERS.includes(blanked[i])) depth++;
-    else if (CLOSERS.includes(blanked[i])) {
-      depth--;
-      if (depth === 0) return i;
-    }
-  }
-  return blanked.length;
+/** Every name a function's parameter list binds, as one array per parameter. */
+function parameterNames(fn) {
+  return fn.parameters.map((p) => boundNames(p.name));
 }
 
 /**
- * Start index of the receiver chain ending at `dot` — walking back over
- * balanced `(…)`/`[…]` groups and dotted identifiers, so the receiver of
- * `expect(readFileSync(p)).toContain(x)` is the whole `expect(readFileSync(p))`.
+ * The name a function-like is KNOWN BY at its declaration: its own name, or the
+ * variable it is assigned to. Anonymous callbacks have none, and taint reaches
+ * their parameters through the receiver rule instead.
  */
-function receiverStart(blanked, dot) {
-  let i = dot - 1;
-  for (;;) {
-    while (i >= 0 && /\s/.test(blanked[i])) i--;
-    if (i < 0) return 0;
-    const c = blanked[i];
-    if (c === ')' || c === ']') {
-      let depth = 0;
-      for (; i >= 0; i--) {
-        if (CLOSERS.includes(blanked[i])) depth++;
-        else if (OPENERS.includes(blanked[i])) {
-          depth--;
-          if (depth === 0) break;
-        }
-      }
-      i--;
-      continue;
-    }
-    if (/[\w$]/.test(c)) {
-      while (i >= 0 && /[\w$]/.test(blanked[i])) i--;
-      while (i >= 0 && /\s/.test(blanked[i])) i--;
-      if (i >= 0 && blanked[i] === '.') {
-        i--;
-        continue;
-      }
-      return i + 1;
-    }
-    return i + 1;
-  }
+function functionName(fn) {
+  if (fn.name && ts.isIdentifier(fn.name)) return fn.name.text;
+  const parent = fn.parent;
+  if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (
+    parent &&
+    ts.isBinaryExpression(parent) &&
+    parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    ts.isIdentifier(parent.left)
+  )
+    return parent.left.text;
+  return null;
 }
 
-/** Every name that can hold, or return, bytes that came off the disk. */
-function computeTainted(blanked) {
-  const tainted = new Set(['readFileSync', 'readFile']);
-  // TRUE when `expr` yields bytes off the disk -- either because it PERFORMS a
-  // read, or because it refers to a name already known to hold one. The two
-  // arms are why this is not called `refersToTainted`: the first answers a
-  // question about the expression itself, not about the `tainted` set.
-  const carriesFileBytes = (expr) => {
-    // A READ is a read however it is spelled. `valueIdentifiers` drops any name
-    // preceded by `.`, so `fs.readFileSync(p)` yielded `{fs, p}` and taint never
-    // started -- `READS_A_FILE` still matched, so the file was ANALYSED rather
-    // than skipped, the taint set stayed empty, and the answer was
-    // `flagged: false`. Namespaced reads are the ordinary spelling in this repo
-    // and `await fsp.readFile(...)` failed the same way, so the gate was blind
-    // to both. Seeding from the same pattern that decides whether to analyse at
-    // all stops the two from disagreeing.
-    if (READS_A_FILE.test(expr)) return true;
-    for (const name of valueIdentifiers(expr)) if (tainted.has(name)) return true;
+/** The expressions a function-like can return, concise arrow bodies included. */
+function returnedExpressions(fn) {
+  if (fn.body && !ts.isBlock(fn.body)) return [fn.body];
+  const out = [];
+  if (!fn.body) return out;
+  walk(fn.body, (n) => {
+    // A nested function's `return` belongs to that function, not this one.
+    if (ts.isReturnStatement(n) && n.expression && enclosingFunction(n) === fn) out.push(n.expression);
+  });
+  return out;
+}
+
+/** The nearest function-like ancestor of `node`, or `null` at top level. */
+function enclosingFunction(node) {
+  for (let n = node.parent; n; n = n.parent) if (ts.isFunctionLike(n)) return n;
+  return null;
+}
+
+/** The nearest Statement ancestor of `node` — the marker's reach (#3174). */
+function enclosingStatement(node) {
+  for (let n = node; n; n = n.parent) if (ts.isStatement(n)) return n;
+  return node;
+}
+
+/**
+ * Every name that can hold, or return, bytes that came off the disk.
+ *
+ * One flat set, no scoping, deliberately over-eager — unchanged in shape from
+ * the scanning version, because none of its rules were about syntax the regexes
+ * got wrong. What changed is where each rule reads its input: a parameter list
+ * comes from `fn.parameters` rather than from `[^()]*`, an argument list from
+ * `call.arguments` rather than from a comma splitter, a receiver from
+ * `callee.expression` rather than from a backwards walk over balanced brackets.
+ */
+function computeTainted(sourceFile) {
+  const tainted = new Set(READ_NAMES);
+
+  const bindings = [];      // { names: string[], init: Node }
+  const functions = [];     // { node, name, params: string[][] }
+  const calls = [];         // CallExpression
+  const forOfs = [];        // ForOfStatement
+  const identifierCount = new Set();
+
+  walk(sourceFile, (n) => {
+    if (ts.isIdentifier(n)) identifierCount.add(n.text);
+    if (ts.isVariableDeclaration(n) && n.initializer)
+      bindings.push({ names: boundNames(n.name), init: n.initializer });
+    if (
+      ts.isBinaryExpression(n) &&
+      n.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      (ts.isIdentifier(n.left) || ts.isObjectLiteralExpression(n.left) || ts.isArrayLiteralExpression(n.left))
+    )
+      bindings.push({ names: [...valueIdentifiers(n.left)], init: n.right });
+    // `isFunctionLike` also matches TYPE-level nodes — the `(text: string) =>
+    // string` inside a parameter annotation. Their names bind nothing at
+    // runtime, so registering them can only ADD names to the set, and this
+    // analysis is deliberately over-eager: over-tainting makes the gate
+    // stricter, and narrowing it is the direction that goes quiet.
+    if (ts.isFunctionLike(n) && n.parameters)
+      functions.push({ node: n, name: functionName(n), params: parameterNames(n) });
+    if (ts.isCallExpression(n)) calls.push(n);
+    if (ts.isForOfStatement(n)) forOfs.push(n);
+  });
+
+  // Keyed by name, and a LIST per name: two helpers can share one (a shadowed
+  // inner `read`, a method and a free function). Keeping only the last would
+  // drop the other's parameters from taint, which is the silent direction.
+  const byName = new Map();
+  for (const fn of functions) {
+    if (!fn.name) continue;
+    if (!byName.has(fn.name)) byName.set(fn.name, []);
+    byName.get(fn.name).push(fn);
+  }
+
+  /**
+   * TRUE when `node` yields bytes off the disk — either because it PERFORMS a
+   * read, or because it refers to a name already known to hold one. The two
+   * arms are why this is not called `refersToTainted`: the first answers a
+   * question about the expression itself, not about the `tainted` set.
+   */
+  const carriesFileBytes = (node) => {
+    if (!node) return false;
+    if (performsRead(node)) return true;
+    for (const name of valueIdentifiers(node)) if (tainted.has(name)) return true;
     return false;
   };
 
-  // Declarations and assignments: `const|let|var x = RHS`, `{a, b} = RHS`, `x = RHS`.
-  const bindings = [];
-  const bindRe = /(?:\b(?:const|let|var)\s+)?([A-Za-z_$][\w$]*|\{[^{}\n]*\}|\[[^[\]\n]*\])\s*=(?!=|>)/g;
-  let m;
-  while ((m = bindRe.exec(blanked)) !== null) {
-    const rhsStart = m.index + m[0].length;
-    bindings.push({
-      names: [...valueIdentifiers(m[1])],
-      rhs: blanked.slice(rhsStart, statementEnd(blanked, rhsStart)),
-    });
-  }
+  const taintAll = (namesPerParam) => {
+    for (const names of namesPerParam) for (const n of names) tainted.add(n);
+  };
 
-  // Functions, so a read behind a helper and a read passed as an argument both
-  // propagate: `function f(p) { … }`, `const f = (p) => …`, `const f = function (p) {…}`.
-  const fns = [];
-  const fnRe =
-    /\bfunction\s*\*?\s*([A-Za-z_$][\w$]*)?\s*\(|\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:function\s*\*?\s*[A-Za-z_$\w$]*\s*)?\(/g;
-  // A single arrow parameter needs no parentheses, and requiring the `(` above
-  // meant `const check = src => src.includes(x)` registered no function at all:
-  // the call site never tainted `src`, and the equivalent `(src) =>` spelling
-  // was caught while this one went silent.
-  const bareArrowRe =
-    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?([A-Za-z_$][\w$]*)\s*=>/g;
-  while ((m = fnRe.exec(blanked)) !== null) {
-    const open = blanked.lastIndexOf('(', fnRe.lastIndex);
-    const close = matchParen(blanked, open);
-    const params = [...valueIdentifiers(blanked.slice(open + 1, close))];
-    // Body: the block or concise arrow body that follows the parameter list.
-    // The gap may hold a TS return-type annotation (`): string {`), so it is
-    // matched as "anything that is not a statement" rather than whitespace —
-    // requiring whitespace is what made `function readSource(p): string` opaque.
-    const after = blanked.slice(close + 1);
-    const braceOffset = after.indexOf('{');
-    const arrowOffset = after.indexOf('=>');
-    let body = '';
-    let concise = false;
-    if (
-      arrowOffset !== -1 &&
-      (braceOffset === -1 || arrowOffset < braceOffset) &&
-      /^[^;{}]*$/.test(after.slice(0, arrowOffset))
-    ) {
-      const rest = after.slice(arrowOffset + 2);
-      const lead = rest.match(/^\s*/)[0].length;
-      const bodyStart = close + 1 + arrowOffset + 2 + (rest[lead] === '{' ? lead : 0);
-      body =
-        rest[lead] === '{'
-          ? blanked.slice(bodyStart, matchParen(blanked, bodyStart) + 1)
-          : blanked.slice(bodyStart, statementEnd(blanked, bodyStart));
-      concise = rest[lead] !== '{';
-    } else if (braceOffset !== -1 && /^[^;{}]*$/.test(after.slice(0, braceOffset))) {
-      const bodyStart = close + 1 + braceOffset;
-      body = blanked.slice(bodyStart, matchParen(blanked, bodyStart) + 1);
-    }
-    fns.push({ name: m[1] || m[2], params, body, concise });
-  }
-  while ((m = bareArrowRe.exec(blanked)) !== null) {
-    const arrow = blanked.indexOf('=>', m.index) + 2;
-    const braced = /^\s*\{/.test(blanked.slice(arrow));
-    const bodyStart = braced ? blanked.indexOf('{', arrow) : arrow;
-    fns.push({
-      name: m[1],
-      params: [m[2]],
-      body: braced
-        ? blanked.slice(bodyStart, matchParen(blanked, bodyStart) + 1)
-        : blanked.slice(arrow, statementEnd(blanked, arrow)),
-      concise: !braced,
-    });
-  }
-
-  // Every name this loop adds is an identifier that appears LEXICALLY in the
-  // file -- a binding name, a parameter, a for-of element, a callback
-  // parameter -- and every pass that changes anything adds at least one. So the
-  // count of distinct identifiers bounds the productive passes, and the loop
-  // cannot need more.
-  //
-  // Two earlier versions were both wrong in the SILENT direction. A fixed 8 was
-  // reachable: bindings declared in reverse order resolve one link per pass, so
-  // eight links exhausted it. Replacing it with `bindings.length + fns.length`
-  // was worse, and its comment claimed a proof it did not have -- neither term
-  // counts for-of names or callback parameters, so four reverse-ordered
-  // `for (const vN of vN-1.split(…))` links gave a cap of 3 and returned a
-  // clean file, which even the fixed 8 had caught.
-  const maxPasses = valueIdentifiers(blanked).size + 2;
+  // Every name this loop can add is an identifier that appears in the file, and
+  // every productive pass adds at least one, so the count of distinct
+  // identifiers bounds the passes. A fixed cap was reachable — bindings
+  // declared in reverse order resolve one link per pass — and a
+  // `bindings.length + functions.length` cap was worse, because neither term
+  // counts for-of names or callback parameters.
+  const maxPasses = identifierCount.size + 2;
   for (let pass = 0; pass < maxPasses; pass++) {
     const before = tainted.size;
-    for (const b of bindings) {
-      if (carriesFileBytes(b.rhs)) for (const n of b.names) tainted.add(n);
+
+    for (const b of bindings) if (carriesFileBytes(b.init)) for (const n of b.names) tainted.add(n);
+
+    // A helper that RETURNS file bytes taints its own name, so both
+    // `readSource(f).includes(x)` and `const s = readSource(f)` are seen.
+    for (const fn of functions) {
+      if (!fn.name || tainted.has(fn.name)) continue;
+      if (returnedExpressions(fn.node).some(carriesFileBytes)) tainted.add(fn.name);
     }
-    for (const fn of fns) {
-      // A helper that returns file bytes taints its own name, so both
-      // `readSource(f).includes(x)` and `const s = readSource(f)` are seen.
-      if (fn.name && !tainted.has(fn.name)) {
-        const returned = fn.concise ? [fn.body] : fn.body.match(/\breturn\b[^;\n]*/g) || [];
-        if (returned.some(carriesFileBytes)) tainted.add(fn.name);
-      }
-      // A tainted argument taints the parameter it lands in.
-      if (!fn.name || fn.params.length === 0) continue;
-      // `$` is legal in a JS identifier and breaks this pattern TWICE: it is a
-      // regex anchor, so the name must be escaped, and it is not a word
-      // character, so a leading `\b` can never match in front of it. Fixing
-      // only the anchor still lost the helper's parameter taint silently.
-      const literalName = fn.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const callRe = new RegExp(`(?<![\\w$])${literalName}\\s*(?:\\?\\.)?\\s*\\(`, 'g');
-      let call;
-      while ((call = callRe.exec(blanked)) !== null) {
-        const open = callRe.lastIndex - 1;
-        const args = splitArgs(blanked.slice(open + 1, matchParen(blanked, open)));
-        args.forEach((arg, idx) => {
-          if (idx < fn.params.length && carriesFileBytes(arg)) tainted.add(fn.params[idx]);
-        });
-      }
-    }
-    // An ITERATION CALLBACK receives the bytes one ELEMENT at a time, so no
-    // tainted NAME ever appears inside it. `source.split('\n').some((line) =>
-    // line.includes(needle))` reads the file and asserts on its text, and the
-    // detector saw a predicate applied to `line`, a parameter it believed was
-    // clean. Same for `.filter`, `.map`, `.every`, `.forEach`, `.find`. Taint
-    // flows from the RECEIVER to the callback's parameters.
-    // `?.` can sit on EITHER side of the method name: `xs?.some(cb)` and
-    // `xs.at(0)?.(cb)`. Matching only the trailing form left
-    // `source.split(sep)?.some((line) => …)` undetected.
-    for (const m of blanked.matchAll(/\??\.\s*[A-Za-z_$][\w$]*\s*(?:\?\.)?\s*\(/g)) {
-      // Walk back from the START of the match, which is the `.` in the plain
-      // form and the `?` in the optional one. Handing `receiverStart` the dot
-      // itself makes it stop on that `?` immediately and return an EMPTY
-      // receiver, so every optional call looked untainted.
-      const open = m.index + m[0].length - 1;
-      if (!carriesFileBytes(blanked.slice(receiverStart(blanked, m.index), m.index))) continue;
-      const args = blanked.slice(open + 1, matchParen(blanked, open));
-      for (const cb of args.matchAll(/(\([^()]*\)|(?<![\w$])[A-Za-z_$][\w$]*)\s*=>/g))
-        for (const q of valueIdentifiers(cb[1])) tainted.add(q);
-      // An anonymous `function (line) { … }` callback is the same flow with a
-      // different spelling, and matching only arrows left it undetected.
-      for (const cb of args.matchAll(/\bfunction\s*[A-Za-z_$][\w$]*?\s*\(([^()]*)\)|\bfunction\s*\(([^()]*)\)/g))
-        for (const q of valueIdentifiers(cb[1] ?? cb[2] ?? '')) tainted.add(q);
-      // A HOISTED callback is passed by name, so its parameters are declared
-      // somewhere else entirely: `.some(hit)` with `const hit = (line) => …`.
-      for (const arg of splitArgs(args)) {
-        const named = fns.find((f) => f.name && f.name === arg.trim());
-        if (named) for (const q of named.params) tainted.add(q);
-      }
-    }
-    // `for (const line of source.split('\n'))` binds the ELEMENT. `bindRe`
-    // requires an `=`, so this shape bound nothing and the loop body read as
-    // clean.
-    for (const m of blanked.matchAll(
-      /\bfor\s*\(\s*(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s+of\s+/g,
-    )) {
-      // The iterable runs to the `)` MATCHING the for-header's `(`, not to the
-      // first one. A `[^)]*` capture stopped inside `source.trim().split('\n')`
-      // at the `)` of `trim(`, so the `.split(` below was never seen and the
-      // loop body read as clean -- the silent direction.
-      const header = blanked.indexOf('(', m.index);
-      // No emptiness guard here on purpose: an empty or inverted range slices
-      // to '', which fails the `.split(` test below and adds no taint -- the
-      // same outcome, without a line that reads as a guard while guarding
-      // nothing. Verified on `for (const x of ) {}` and an unclosed header.
-      const iterEnd = matchParen(blanked, header);
-      // Deliberately narrow to a SPLIT of tainted text. Tainting on
-      // `carriesFileBytes` alone also catches `for (const file of files)`
-      // where the elements are PATHS, not contents -- measured as 4 false hits
-      // in toolbar-parity.test.ts, because a list of paths is tainted too.
-      // Nothing lexical separates a tainted array of lines from a tainted
-      // array of filenames, so this takes the shape it can prove and leaves
-      // `for (const line of lines)` (split bound to a name first) uncovered
-      // rather than paying for it in false flags on every path loop.
-      const iter = blanked.slice(m.index + m[0].length, iterEnd).trim();
-      if (/\.\s*split\s*\(/.test(iter) && carriesFileBytes(iter)) tainted.add(m[1]);
-    }
-    // `?.(` is accepted everywhere `(` is. An optional call is still a call,
-    // and omitting it let `check?.(source)` skip the named-call path and
-    // `mutators[key]?.(source)` skip the fail-closed path below -- a rule that
-    // exists to catch what cannot be followed was itself bypassable by two
-    // characters.
-    //
-    // FAIL CLOSED on flow this analysis cannot follow. When file bytes are
-    // handed to a callee it cannot name — `mutators[key](real[key])`, or
-    // anything returned by a call — the value lands in a parameter no lexical
-    // rule can identify, and the honest answer is "undecidable", not "clean".
-    // Undecidable resolves to tainting every function-expression parameter in
-    // the file, so coverage degrades toward MORE flagging rather than less.
-    // Named callees (`mutate(real.platform, …)`) and plain dotted ones
-    // (`fs.writeFileSync(path, text)`) are followed or ignored precisely and do
-    // not trigger this.
-    for (const call of blanked.matchAll(/[)\]]\s*(?:\?\.)?\s*\(/g)) {
-      const open = call.index + call[0].length - 1;
-      if (!splitArgs(blanked.slice(open + 1, matchParen(blanked, open))).some(carriesFileBytes))
+
+    for (const call of calls) {
+      const args = call.arguments;
+
+      // FAIL CLOSED on flow this analysis cannot follow. When file bytes are
+      // handed to a callee it cannot name — `mutators[key](real[key])`, or
+      // anything returned by a call — the value lands in a parameter no lexical
+      // rule can identify, and the honest answer is "undecidable", not "clean".
+      // Undecidable resolves to tainting every parameter in the file, so
+      // coverage degrades toward MORE flagging rather than less. Named callees
+      // and plain dotted ones are followed or ignored precisely and never reach
+      // here. An optional call is still a call: `check?.(source)` is the same
+      // shape and used to slip past on two characters.
+      if (calleeName(call.expression) === null && args.some(carriesFileBytes)) {
+        for (const fn of functions) taintAll(fn.params);
         continue;
-      for (const m2 of blanked.matchAll(/(\([^()]*\)|(?<![\w$])[A-Za-z_$][\w$]*)\s*=>/g))
-        for (const p of valueIdentifiers(m2[1])) tainted.add(p);
-      for (const fn of fns) for (const p of fn.params) tainted.add(p);
-      break;
+      }
+
+      // A tainted argument taints the parameter it lands in.
+      const named = byName.get(calleeName(call.expression));
+      if (named)
+        for (const fn of named)
+          args.forEach((arg, idx) => {
+            if (idx < fn.params.length && carriesFileBytes(arg))
+              for (const n of fn.params[idx]) tainted.add(n);
+          });
+
+      // An ITERATION CALLBACK receives the bytes one ELEMENT at a time, so no
+      // tainted NAME ever appears inside it. `source.split('\n').some((line) =>
+      // line.includes(needle))` reads the file and asserts on its text, and the
+      // detector saw a predicate applied to `line`, a parameter it believed was
+      // clean. Taint flows from the RECEIVER to the callback's parameters — for
+      // `.filter`, `.map`, `.every`, `.forEach`, `.find` and every other method,
+      // since nothing here needs to know which one it is.
+      //
+      // The parameters come from `fn.parameters`, which is what closes gap 3 of
+      // #3174: the regex captured a parameter list with `[^()]*` and could not
+      // cross the nested parens of `(line = pad(1)) =>`, so that callback's
+      // body read as clean in both the arrow and the `function` spelling.
+      if (!ts.isPropertyAccessExpression(call.expression)) continue;
+      if (!carriesFileBytes(call.expression.expression)) continue;
+      for (const arg of args) {
+        if (ts.isFunctionLike(arg) && arg.parameters) taintAll(parameterNames(arg));
+        // A HOISTED callback is passed by name, so its parameters are declared
+        // somewhere else entirely: `.some(hit)` with `const hit = (line) => …`.
+        if (ts.isIdentifier(arg)) for (const fn of byName.get(arg.text) ?? []) taintAll(fn.params);
+      }
     }
+
+    // `for (const line of source.split('\n'))` binds the ELEMENT, and no
+    // assignment appears, so a binding rule cannot see it.
+    //
+    // Deliberately narrow to a SPLIT of tainted text. Tainting on
+    // `carriesFileBytes` alone also catches `for (const file of files)` where
+    // the elements are PATHS, not contents — measured as 4 false hits in
+    // toolbar-parity.test.ts, because a list of paths is tainted too. Nothing
+    // in the SYNTAX separates a tainted array of lines from a tainted array of
+    // filenames, which is why parsing does not close this and the rule still
+    // takes only the `.split(` it can prove. `for (const line of lines)` with
+    // the split bound to a name first stays uncovered, on purpose (#3174).
+    for (const loop of forOfs) {
+      const iterable = loop.expression;
+      let splits = false;
+      walk(iterable, (n) => {
+        if (ts.isCallExpression(n) && calleeName(n.expression) === 'split') splits = true;
+      });
+      if (!splits || !carriesFileBytes(iterable)) continue;
+      if (ts.isVariableDeclarationList(loop.initializer))
+        for (const d of loop.initializer.declarations) for (const n of boundNames(d.name)) tainted.add(n);
+    }
+
     if (tainted.size === before) break;
   }
   return tainted;
 }
 
-/** Split an argument list on top-level commas. */
-function splitArgs(text) {
-  const args = [];
-  let depth = 0;
-  let start = 0;
-  for (let i = 0; i < text.length; i++) {
-    const c = text[i];
-    if (OPENERS.includes(c)) depth++;
-    else if (CLOSERS.includes(c)) depth--;
-    else if (c === ',' && depth === 0) {
-      args.push(text.slice(start, i));
-      start = i + 1;
+/**
+ * `@source-text-assertion-ok` markers, by the line the marker text sits on.
+ *
+ * Read from COMMENTS only, never from raw lines: a raw-line scan accepted
+ * `const doc = 'write @source-text-assertion-ok fake';` as a genuine marker, so
+ * a STRING could excuse a real finding — a silent fail-open in the direction
+ * this gate exists to prevent.
+ *
+ * Every comment is trivia of some token, so walking the token tree reaches all
+ * of them, `}` and the end-of-file token included. BOTH sides are needed, not
+ * just leading: TypeScript attaches a comment that follows code on the SAME
+ * line to the preceding token as TRAILING trivia, so a marker written
+ * `assert.ok(…); // @source-text-assertion-ok why` is not leading trivia of
+ * anything — reading only leading ranges lost every same-line marker, which is
+ * a documented spelling of the escape hatch.
+ *
+ * This is the whole reason `stripComments` is gone: the parser already knows
+ * which `//` is a comment and which is inside a string or a regex literal, and
+ * getting that wrong is what once blanked a whole file and left the gate quiet.
+ */
+function markersByLine(sourceFile, text) {
+  const markers = new Map();
+  const seen = new Set();
+  const record = (range) => {
+    if (seen.has(range.pos)) return;
+    seen.add(range.pos);
+    const body = text.slice(range.pos, range.end);
+    const m = MARKER.exec(body);
+    if (!m) return;
+    const line = sourceFile.getLineAndCharacterOfPosition(range.pos + m.index).line + 1;
+    markers.set(line, (m[1] || '').trim());
+  };
+  const visitToken = (node) => {
+    const children = node.getChildren(sourceFile);
+    if (children.length === 0) {
+      for (const r of ts.getLeadingCommentRanges(text, node.getFullStart()) ?? []) record(r);
+      for (const r of ts.getTrailingCommentRanges(text, node.getEnd()) ?? []) record(r);
+      return;
     }
-  }
-  args.push(text.slice(start));
-  return args;
+    for (const child of children) visitToken(child);
+  };
+  visitToken(sourceFile);
+  return markers;
 }
 
-/** A line is a continuation of the one below it when it ends mid-expression. */
-const CONTINUES = /(?:[([,]|=>|&&|\|\||[-+*/%?:]|=)\s*$/;
-
-/**
- * The line carrying the marker that excuses a predicate on `line`, or `null`.
- *
- * A marker sits immediately above the ASSERTION, and the assertion may be
- * wrapped over several lines, so the predicate is not always on the line the
- * marker is above. This walks up over continuation lines to the statement's
- * first line and allows the marker anywhere from just above that down to the
- * predicate itself.
- *
- * `codeLines` must be COMMENT-STRIPPED (`stripComments`), because `CONTINUES`
- * contains `*`, `/`, `:` and `-`, so `// Arrange:`, `// see https://x/`, a JSDoc
- * ` *` line and this repo's own `// ------` separators all read as continuations
- * of prose. A stale marker then reaches across them to excuse an unrelated
- * predicate AND is recorded as used, so the dead-marker check goes quiet too:
- * both halves of the gate wrong at once.
- *
- * `stripComments` is now string-aware (it is one view of the single lexing
- * pass), so a `//` inside a string no longer truncates the line: `name: '///'`,
- * `'https://x/y'` and `'see // docs'` all keep their trailing `;` and correctly
- * stop the walk, where the earlier per-line stripper got each of them wrong in
- * the fail-open direction. (Do not restate that as "no file's stripped view
- * differs in LENGTH from the original". That holds for ANY input, because this
- * pass blanks to spaces and never deletes, so it stays true with the
- * string-awareness removed. It measures the blanking, not the fix.)
- *
- * The 24-line bound is a POLICY cap on how far a marker may reach, not a
- * runaway guard -- the walk terminates on its own, because `codeLines[top - 2]`
- * yields `''` at the top of the file and `''` is not a continuation. The
- * previous bound of 8 was small enough that a legitimately long wrapped
- * assertion fell out the other side and hit the double failure above.
- */
-function markerLineFor(markerLines, codeLines, line) {
-  if (markerLines.has(line)) return line;
-  let top = line;
-  for (let n = 0; n < 24; n++) {
-    const above = (codeLines[top - 2] ?? '').trim();
-    if (!CONTINUES.test(above)) break;
-    top -= 1;
-  }
-  for (let candidate = line - 1; candidate >= top - 1; candidate--) {
-    if (markerLines.has(candidate)) return candidate;
-  }
-  return null;
+/** TRUE when any string or template literal in the tree names a source file. */
+function namesASourceFile(sourceFile) {
+  let found = false;
+  walk(sourceFile, (n) => {
+    if (found) return;
+    if (ts.isStringLiteralLike(n)) {
+      if (SOURCE_LITERAL.test(n.text)) found = true;
+      return;
+    }
+    // A template with substitutions has no single `.text`; each literal span is
+    // its own chance to end in an extension (`` `${dir}/Thing.tsx` ``).
+    if (ts.isTemplateExpression(n)) {
+      if (SOURCE_LITERAL.test(n.head.text)) found = true;
+      for (const span of n.templateSpans) if (SOURCE_LITERAL.test(span.literal.text)) found = true;
+    }
+  });
+  return found;
 }
 
 /**
  * @param {string} original Raw file text (comments intact — markers live there).
+ * @param {string} [fileName] Used only to pick the TS-vs-TSX grammar.
  * @returns {{ flagged: boolean, hits: Array<{line: number, text: string}>,
  *             marked: Array<{line: number, reason: string}>,
  *             unusedMarkers: number[] }}
  */
-export function analyze(original) {
-  const views = lexViews(original);
-  const stripped = views.text;
-  const strippedLines = stripped.split('\n');
-  const empty = { flagged: false, hits: [], marked: [], unusedMarkers: [] };
-  const rawLines = original.split('\n');
-  const markerLines = new Map();
-  // Markers are read from the COMMENT view, never the raw line. A raw-line
-  // scan accepted `const doc = 'write @source-text-assertion-ok fake';` as a
-  // genuine marker, so a STRING could excuse a real finding -- a silent
-  // fail-open in the direction this gate exists to prevent.
-  views.comments.split('\n').forEach((line, idx) => {
-    const m = MARKER.exec(line);
-    if (m) markerLines.set(idx + 1, (m[1] || '').trim());
-  });
+export function analyze(original, fileName = 'source.tsx') {
+  // `createSourceFile`, NOT `createScanner`. TypeScript resolves regex versus
+  // division in the PARSER, by calling `reScanSlashToken` when the grammar says
+  // a regex is allowed; the scanner on its own never makes that call and gets
+  // the same class of question wrong that the hand-rolled lexer did.
+  const sourceFile = ts.createSourceFile(
+    fileName,
+    original,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    fileName.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
 
-  if (!READS_A_FILE.test(stripped) || !SOURCE_LITERAL.test(stripped)) {
-    return { ...empty, unusedMarkers: [...markerLines.keys()] };
+  const markers = markersByLine(sourceFile, original);
+  const rawLines = original.split('\n');
+  const lineOf = (pos) => sourceFile.getLineAndCharacterOfPosition(pos).line + 1;
+
+  // `performsRead` over the whole file is the same question as "does this
+  // file read anything at all", so it is the same function.
+  if (!performsRead(sourceFile) || !namesASourceFile(sourceFile)) {
+    return { flagged: false, hits: [], marked: [], unusedMarkers: [...markers.keys()] };
   }
 
-  // The SAME pass that produced `stripped`, not a second lex of it. The two
-  // routes now agree (they did NOT before the `back` lookback landed, which is
-  // what an earlier version of this comment recorded), so this is duplicated
-  // work rather than a correctness trap -- but one pass is the point of
-  // `lexViews`, and re-lexing its own output invites the ordering hazards it
-  // exists to remove.
-  const blanked = views.blanked;
-  const tainted = computeTainted(blanked);
-
-  const lineOf = (index) => blanked.slice(0, index).split('\n').length;
+  const tainted = computeTainted(sourceFile);
   const hits = [];
   const marked = [];
   const usedMarkers = new Set();
 
-  PREDICATE_METHOD.lastIndex = 0;
-  let m;
-  while ((m = PREDICATE_METHOD.exec(blanked)) !== null) {
-    const dot = m.index;
-    const open = m.index + m[0].length - 1;
-    const receiver = blanked.slice(receiverStart(blanked, dot), dot);
-    const args = blanked.slice(open + 1, matchParen(blanked, open));
-    const subject = `${receiver} ${args}`;
-    let hit = false;
-    for (const name of valueIdentifiers(subject)) {
-      if (tainted.has(name)) {
-        hit = true;
-        break;
-      }
-    }
-    if (!hit) continue;
-    const line = lineOf(dot);
-    // A marker excuses the predicate on its own line, or on any line from the
-    // start of the enclosing statement to just above it.
+  walk(sourceFile, (node) => {
+    if (!ts.isCallExpression(node)) return;
+    const callee = node.expression;
+    if (!ts.isPropertyAccessExpression(callee) || !ts.isIdentifier(callee.name)) return;
+    if (!PREDICATE_METHODS.has(callee.name.text)) return;
+
+    // The subject is the receiver AND the arguments, because both spellings
+    // occur: `source.includes(x)` and `assert.match(source, /x/)`.
+    const subject = [callee.expression, ...node.arguments];
+    if (!subject.some((s) => [...valueIdentifiers(s)].some((n) => tainted.has(n)))) return;
+
+    const line = lineOf(callee.name.getStart(sourceFile));
+
+    // A marker excuses the predicate on its own line, or on any line from one
+    // above the ENCLOSING STATEMENT down to the predicate.
     //
-    // "The line above" alone was wrong for a WRAPPED assertion, which is the
-    // prevailing style in the files this gate actually reports. Written exactly
-    // as `check-source-text-assertions.mjs` prints the remedy:
-    //
-    //     // @source-text-assertion-ok anchor guard
-    //     assert.ok(
-    //       source.includes(anchor),
-    //     );
-    //
-    // the predicate is on the THIRD line and the marker on the first, so the
-    // marker excused nothing AND was then reported as unused: CI failed twice
-    // and the printed fix did not work. A remedy an instrument prints has to be
-    // one the instrument accepts.
-    const markerLine = markerLineFor(markerLines, strippedLines, line);
-    if (markerLine !== null && markerLines.get(markerLine)) {
+    // The scanning version walked up over lines a regex called continuations,
+    // and a COMMENT INSIDE the assertion stopped the walk dead — so the marker
+    // the gate prints as the remedy did not reach the predicate, and was then
+    // reported as excusing nothing. CI failed twice and the printed fix did not
+    // work. The statement's own range has no such hole, and unlike "treat blank
+    // lines as continuations" it cannot reach across a gap to an unrelated
+    // predicate: a different statement is a different range.
+    const first = lineOf(enclosingStatement(node).getStart(sourceFile));
+    let markerLine = null;
+    for (let candidate = line; candidate >= first - 1; candidate--)
+      if (markers.has(candidate)) { markerLine = candidate; break; }
+
+    if (markerLine !== null && markers.get(markerLine)) {
       usedMarkers.add(markerLine);
-      marked.push({ line, reason: markerLines.get(markerLine) });
-      continue;
+      marked.push({ line, reason: markers.get(markerLine) });
+      return;
     }
     hits.push({ line, text: rawLines[line - 1]?.trim() ?? '' });
-  }
+  });
+
+  hits.sort((a, b) => a.line - b.line);
+  marked.sort((a, b) => a.line - b.line);
 
   return {
     flagged: hits.length > 0,
     hits,
     marked,
-    unusedMarkers: [...markerLines.keys()].filter((l) => !usedMarkers.has(l)),
+    unusedMarkers: [...markers.keys()].filter((l) => !usedMarkers.has(l)).sort((a, b) => a - b),
   };
 }

--- a/scripts/source-text-assertion-detect.mjs
+++ b/scripts/source-text-assertion-detect.mjs
@@ -215,6 +215,38 @@ function unwrap(node) {
 }
 
 /**
+ * The expressions a callback slot can actually evaluate to, looking through the
+ * operators that SELECT between callbacks without being one: `?:`, `&&`, `||`,
+ * `??`, the comma operator, and a spread.
+ *
+ * Only used to resolve a callback passed BY NAME. Function expressions are
+ * found by walking the argument instead, which needs no enumeration.
+ */
+function callbackCandidates(node, out = []) {
+  const n = unwrap(node);
+  if (!n) return out;
+  if (ts.isConditionalExpression(n)) {
+    callbackCandidates(n.whenTrue, out);
+    callbackCandidates(n.whenFalse, out);
+    return out;
+  }
+  const SELECTORS = new Set([
+    ts.SyntaxKind.AmpersandAmpersandToken,
+    ts.SyntaxKind.BarBarToken,
+    ts.SyntaxKind.QuestionQuestionToken,
+    ts.SyntaxKind.CommaToken,
+  ]);
+  if (ts.isBinaryExpression(n) && SELECTORS.has(n.operatorToken.kind)) {
+    callbackCandidates(n.left, out);
+    callbackCandidates(n.right, out);
+    return out;
+  }
+  if (ts.isSpreadElement(n)) return callbackCandidates(n.expression, out);
+  out.push(n);
+  return out;
+}
+
+/**
  * The name a callee resolves to, for `f(…)`, `fs.readFileSync(…)` and
  * `a.b.c(…)` alike — the rightmost identifier, which is the one that says what
  * is being called. `null` when the callee is anything else, which is the
@@ -460,19 +492,25 @@ function computeTainted(sourceFile) {
       if (!ts.isPropertyAccessExpression(call.expression)) continue;
       if (!carriesFileBytes(call.expression.expression)) continue;
       for (const rawArg of args) {
-        // UNWRAPPED first. `some(((line) => …))` and
-        // `some(((line) => …) as Predicate)` hand this loop a
-        // ParenthesizedExpression / AsExpression, so a bare `isFunctionLike`
-        // answered no, `line` stayed clean and the whole callback body read as
-        // clean with it. The scanning version caught these -- its callback
-        // pattern matched the arrow wherever it sat in the argument text --
-        // so shipping without this would have been a REGRESSION into the one
-        // direction this gate must never move. Reported by Codex on #3177.
-        const arg = unwrap(rawArg);
-        if (ts.isFunctionLike(arg) && arg.parameters) taintAll(parameterNames(arg));
+        // ANYWHERE inside the argument, not just at its root. The scanning
+        // version matched arrows and `function` expressions wherever they sat
+        // in the argument TEXT, so testing only the root node was a REGRESSION
+        // into the one direction this gate must never move -- measured against
+        // main on `((line) => …)`, `… as any`, `… satisfies unknown`,
+        // `(function (line) {…})`, `flag ? (line) => … : other`,
+        // `cb || ((line) => …)`, `(noop(), (line) => …)`,
+        // `...[(line) => …]` and `wrapCb((line) => …)`, all of which main
+        // flagged and the root-only test did not. Reported by Codex on #3177.
+        walk(rawArg, (n) => {
+          if (ts.isFunctionLike(n) && n.parameters) taintAll(parameterNames(n));
+        });
         // A HOISTED callback is passed by name, so its parameters are declared
         // somewhere else entirely: `.some(hit)` with `const hit = (line) => …`.
-        if (ts.isIdentifier(arg)) for (const fn of byName.get(arg.text) ?? []) taintAll(fn.params);
+        // Resolved through the operators that SELECT a callback, so
+        // `.some(flag ? hit : other)` reaches `hit` -- a hole main had too.
+        for (const candidate of callbackCandidates(rawArg))
+          if (ts.isIdentifier(candidate))
+            for (const fn of byName.get(candidate.text) ?? []) taintAll(fn.params);
       }
     }
 


### PR DESCRIPTION
Closes #3174.

`source-text-assertion-detect.mjs` hand-rolled a lexer for JS, TS and TSX, and its own docblock said the central heuristic was "APPROXIMATE, not sound". Its history is a string of fail-opens that each looked like a small fix — a quote inside a regex literal blanking the rest of the file, a `//` inside a string doing the same, `)` before `/` read as division when it closed an `if` header, a `$` defeating a `\b`. Every one made the gate go **quiet**, and every one was found by someone reading the file rather than by the gate.

## The two gaps the issue reported

**Gap 1 — a comment inside a wrapped assertion killed the marker.** `markerLineFor` walked up over lines a `CONTINUES` regex accepted; an interior comment strips to blank, which is not a continuation, so the walk stopped and the marker never reached the predicate. CI then failed twice in one run — "source-text assertion found" **and** "marker that excuses nothing" — and the remedy the gate prints in its own error text did not clear it.

The obvious repair, making blank lines transparent, is a fail-open and is not taken: a marker whose guard was deleted then reaches down across blank lines to an unrelated predicate, turning a loud dead marker into a silent exemption. Both directions are tests now.

**Gap 3 — a default parameter containing a call hid the callback's parameter.** `[^()]*` cannot cross the nested parens of `(line = pad(1)) =>`, so the parameter was never tainted and the whole callback body read as clean, in both the arrow and the `function` spelling.

Both are one sentence: the regex cannot see structure the parser has for free.

## What changed

The scanning layer is gone — `blankStrings`, `stripComments`, `regexLiteralEnd`, `closesAControlHeader`, `CONTINUES`, `markerLineFor`, `statementEnd`, `matchParen`, `receiverStart`, `splitArgs` — and with it every fail-open those functions were patched for. Marker reach is now the enclosing statement's range; callback parameters come from `node.parameters`.

It is `ts.createSourceFile` and **not** `ts.createScanner`: the scanner never calls `reScanSlashToken`, so it gets the same class of question wrong that the old `regexLiteralEnd` did.

The taint analysis did not change shape — one flat name set, no scoping, deliberately over-eager. `analyze`'s return type is identical; it gained an optional filename so a `.ts` file gets the TS grammar rather than TSX (measured: no file in the corpus is sensitive to that choice).

818 lines → 604, of which more is prose than before.

## Two more fail-opens, found while probing

Neither is in the issue. Both were live on `main`, both silent, both closed here and named in tests so they stay closed:

- **A class method used as a helper.** The function-shape regex matched `function name(` and `const name = (` and nothing else, so a method's parameter was never registered and the call site tainted nothing.
- **An optional-chain predicate**, `assert.ok(source?.includes('x'))`. `\.` matches the dot of `?.`, so the receiver walk started on the `?`, stopped at once and returned an empty receiver — `source` was never part of the subject. The detector's own comments describe this exact trap being fixed for the iteration-callback rule; the predicate scan had the same bug and was never revisited.

## Step 4 of the issue: verdicts on the corpus

Diffed file by file, old detector against new, over all **1430** scanned test files, comparing hit lines, marked lines and dead-marker lines. **Two differ, both accounted for:**

| file | change | why |
|---|---|---|
| `packages/data/scripts/generate-ifc-schema.test.ts:164` | flagged → not flagged | It asserts on **subprocess output**, the exact false positive the pairing rule was built to stop, and is the file this module's docblock names for it. The scanner read parameter names out of the raw text between the parens, so `rename(file: string, from: RegExp, to: string)` registered `string` and `RegExp` as parameters — both really were in that file's taint set on `main` — and the index shift walked taint into `message`, a table field holding a literal error string. That file's two real hits are unchanged. |
| `apps/viewer/.../export-ui-parity.test.tsx` | +4 hits (575, 581, 585, 590) | All genuine: `hookSource` comes from `readSource('.../useExportCommands.ts')` and the predicates run on elements found in it. The file is already allowlisted, so the gate's verdict does not move. |

The gate's own output is byte-identical before and after: `check-source-text-assertions: OK (8 allowlisted, 0 marked, 0 new)`.

## Gap 2 stays open, and says so in a test

Widening the for-of rule to any iterable carrying file bytes also taints `for (const file of files)` where the elements are **paths** — measured as 4 new hits in `toolbar-parity.test.ts`. That is a question about what an array *holds*, which parsing does not answer either. The test asserts the bound form still does **not** flag, so if a future change closes it, that test is where the reopening gets recorded rather than a rule quietly widening.

## Cost

Three runs each, this machine: **0.82s** end to end scanning, **1.51s** parsing. No pathological file — the slowest single file is 20ms.

## Tests

53 → 73, and every pre-existing one still passes. Run against `main`'s detector, **five** of the new ones are red: the two gaps, the annotation misreading, argument-to-parameter alignment, and the class-method/optional-chain pair.

The four assertions that read `blankStrings`/`stripComments` directly are rewritten against `analyze` rather than dropped. Each states its property in **both** directions, because a one-sided rewrite would pass on a detector that flags everything — and the comment on one of them records that an earlier one-sided version of exactly that test passed with the bug live.

No changeset: `scripts/` is not a publishable package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-text assertion detection across JavaScript, TypeScript, and TSX syntax.
  * Better handles comments, regular expressions, strings, optional chaining, callbacks, loops, class methods, and complex syntax.
  * Recognizes exemption markers throughout multiline statements.
  * Added safer handling for unresolved calls and unsupported syntax.

* **Tests**
  * Expanded regression and end-to-end coverage for assertion detection, marker placement, and known edge cases.

* **Documentation**
  * Clarified parser behavior and exemption marker interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->