### PR TITLE
fix(export): legacy IFC2X3 products were dropped from mesh and attribute export (#3172)

### DIFF
--- a/.changeset/legacy-entity-products-not-dropped.md
+++ b/.changeset/legacy-entity-products-not-dropped.md
@@ -1,0 +1,17 @@
+---
+"@ifc-lite/parser": patch
+---
+
+Stop dropping six concrete IFC2X3 products from mesh and attribute export, and remove an alias row that named no entity.
+
+`rust/core/src/legacy_entities.rs` is the table every classification pass is told to consult instead of a bare `IfcType::from_str`. It held 21 arms. Diffing `@ifc-lite/data`'s IFC2X3/IFC4 tables against the generated IFC4X3 enum — the method `merged.rs` already documents — turns up six concrete `IfcProduct` subtypes that carry both a placement and a representation and were in neither: `IfcElectricalElement`, `IfcElectricDistributionPoint`, `IfcChamferEdgeFeature`, `IfcRoundedEdgeFeature`, `IfcStructuralLinearActionVarying`, `IfcStructuralPlanarActionVarying`.
+
+A name the table misses resolves to `IfcType::Unknown`, and `Unknown` is a subtype of nothing. The attribute exporter keeps a row only if the type reaches `IfcProduct`, and `has_geometry_by_name` refuses `Unknown` outright, so an IFC2X3 file containing one of these lost it from the attribute export and from meshing at once. The two passes agreed, on dropping it — which is why nothing looked wrong. Each new arm maps to its own supertype from the older schema rather than to a generic proxy.
+
+The `IfcElectricDistributionPoint` arm was spelled `IFCELECTRICALDISTRIBUTIONPOINT`, with an "AL" no IFC2X3 entity has. It could never match a real file, and a Rust test asserted `has_geometry_by_name` on the same misspelling, so the table and its test certified each other while describing nothing.
+
+That misspelling had spread. #2883 mirrored it into `@ifc-lite/parser`'s `ENTITY_NAME_ALIASES` on the stated premise that it was "real, deprecated IFC2X3 syntax", and two tests plus a comment in `@ifc-lite/query` were then written against the mirror — five artifacts agreeing with each other about an entity that does not exist. The alias row is removed rather than respelled, because the correctly spelled name is in `ENTITIES_IFC2X3` and already resolves through `IfcFlowController` to `IfcDistributionElement` with no alias at all; that is also exactly what the new Rust arm answers. The dependents now assert the real name, plus a negative on the misspelling so restoring the alias turns them red.
+
+Fixing the table exposed a second live defect. The construction-projection filter from #979 read `entity.ifc_type`, which the decoder fills with a bare `from_str` — so every legacy spelling of a feature element arrived as `Unknown` and passed straight through. Measured on AC20-FZK-Haus with its 17 openings respelled to `IFCOPENINGSTANDARDCASE`: 33 spurious void cross-sections in the floor plan before, none after.
+
+`scripts/check-legacy-entity-coverage.mjs` now runs that diff on every PR, in both directions: a concrete legacy product with no arm fails, and so does an arm whose key names no entity in any bundled schema.

--- a/.changeset/legacy-entity-products-not-dropped.md
+++ b/.changeset/legacy-entity-products-not-dropped.md
@@ -1,5 +1,6 @@
 ---
 "@ifc-lite/parser": patch
+"@ifc-lite/wasm": patch
 ---
 
 Stop dropping six concrete IFC2X3 products from mesh and attribute export, and remove an alias row that named no entity.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -695,6 +695,21 @@ jobs:
       # real sources in a temp tree and must turn the gate red.
       - name: Check clash degenerate-reason parity gate regressions
         run: node --test scripts/check-clash-degenerate-reason-parity.test.mjs
+      # `legacy_entities.rs` is the table every classification pass is told to
+      # consult instead of a bare `IfcType::from_str`, and nothing checked it
+      # was complete. Six concrete IFC2X3 products were missing (#3172), and a
+      # name it misses resolves to `Unknown` -- a subtype of nothing -- so the
+      # entity is dropped from the attribute export AND from meshing at once.
+      # Nothing disagrees, so nothing looks wrong. Same call as the parity gate
+      # above: reading two sources is banned in test files, so it is a lint.
+      - name: Check legacy entity coverage
+        run: node scripts/check-legacy-entity-coverage.mjs
+      # Executable proof the gate cannot pass vacuously: "nothing is missing" is
+      # equally true of a complete table and of an extractor that found nothing.
+      # Each of the four extractors is broken in turn against mutated copies of
+      # the real sources, plus a deleted arm and the #3172 misspelling itself.
+      - name: Check legacy entity coverage gate regressions
+        run: node --test scripts/check-legacy-entity-coverage.test.mjs
       # The CSV cell escaper reached NINE hand-rolled copies and no two were
       # identical: some tested the formula trigger anchored at offset 0 (so a
       # BOM/ZWSP/LRM/NBSP/U+2028 in front of `=` bypassed the CWE-1236 guard),

--- a/packages/parser/src/ifc-schema.ts
+++ b/packages/parser/src/ifc-schema.ts
@@ -42,11 +42,15 @@ const ENTITY_NAME_ALIASES: Record<string, string> = {
     IFCSOLIDSTRATUM: 'IfcGeotechnicalStratum',
     IFCVOIDSTRATUM: 'IfcGeotechnicalStratum',
     IFCWATERSTRATUM: 'IfcGeotechnicalStratum',
-    // IFC2x3 names with no IFC4x3 enum variant in any bundled schema table
-    // (ENTITIES_IFC2X3/IFC4/IFC4X3 all lack them) — mirrors
-    // `rust/core/src/legacy_entities.rs`'s "IFC2x3 names that have no IFC4x3
-    // enum variant" arm, which maps both to `IfcDistributionElement`.
-    IFCELECTRICALDISTRIBUTIONPOINT: 'IfcDistributionElement',
+    // There was a fourth row here, `IFCELECTRICALDISTRIBUTIONPOINT`. The
+    // IFC2X3 entity is `IfcElectricDistributionPoint` — no "AL" — so the key
+    // named nothing and the row could never fire. Removed rather than
+    // respelled (#3172): the correctly spelled name IS in `ENTITIES_IFC2X3`,
+    // so `ENTITY_INFO_BY_UPPER` already resolves it and an alias would be a
+    // second, shadowing answer. This table's mandate is narrower than
+    // `legacy_entities.rs`'s: only names absent from ALL THREE bundled
+    // tables belong here, which is why the five IFC2X3 products that fix
+    // added on the Rust side have no row here either.
 };
 
 /**

--- a/packages/parser/test/known-type-across-schemas.test.ts
+++ b/packages/parser/test/known-type-across-schemas.test.ts
@@ -288,15 +288,23 @@ describe('normalizeIfcTypeName across the bundled schema union (#2003)', () => {
     }
   });
 
-  it('resolves the IFC2X3 leaves rust/core/src/legacy_entities.rs maps but no bundled TS schema carries', () => {
-    // `IfcElectricalDistributionPoint` is real, deprecated IFC2X3 syntax with
-    // no IFC4x3 equivalent in ENTITIES_IFC2X3/IFC4/IFC4X3. The Rust core's
-    // `legacy_entities.rs` resolves it to `IfcDistributionElement` (comment:
-    // "IFC2x3 names that have no IFC4x3 enum variant"). The TS
-    // `ENTITY_NAME_ALIASES` table in `ifc-schema.ts` claims to mirror that
-    // file "so the two sides stay in lockstep", but only carries the three
-    // IFC4.3 stratum leaves -- this class is silently unknown here while the
-    // Rust parser resolves it with geometry.
-    expect(getInheritanceChain('IfcElectricalDistributionPoint')).toContain('IfcDistributionElement');
+  it('resolves the IFC2X3 distribution-point leaf, and only under the name IFC2X3 gives it', () => {
+    // This test asserted on `IfcElectricalDistributionPoint` until #3172, on
+    // the stated premise that it was "real, deprecated IFC2X3 syntax". It is
+    // not: the IFC2X3 entity has no "AL". The name came from a misspelt arm in
+    // `rust/core/src/legacy_entities.rs`, was mirrored into
+    // `ENTITY_NAME_ALIASES` to make the two sides agree, and this assertion
+    // then passed by reading the mirror -- three artifacts agreeing with each
+    // other about an entity that does not exist.
+    //
+    // The correctly spelled leaf IS in `ENTITIES_IFC2X3`, so it needs no alias
+    // at all; the chain below comes straight from the bundled table and matches
+    // what `legacy_aware_ifc_type` answers in Rust.
+    expect(getInheritanceChain('IfcElectricDistributionPoint')).toContain('IfcFlowController');
+    expect(getInheritanceChain('IfcElectricDistributionPoint')).toContain('IfcDistributionElement');
+    // And the misspelling resolves to nothing, which is the correct answer for
+    // a name no schema carries. Pinned so a future "fix" cannot restore the
+    // alias and make the pair agree again.
+    expect(getInheritanceChain('IfcElectricalDistributionPoint')).toEqual([]);
   });
 });

--- a/packages/query/src/ifc-query.ts
+++ b/packages/query/src/ifc-query.ts
@@ -120,9 +120,13 @@ export class IfcQuery {
     // because it doubles as a name canonicalizer and an alias maps a leaf to
     // its nearest schema-known *supertype*. For a pure known-ness question the
     // alias table is exactly the right thing to consult: it lists names real
-    // STEP files carry that the bundled EXPRESS exports omit, such as IFC2X3's
-    // `IfcElectricalDistributionPoint`. Hence the second lookup - it is the
-    // difference between accepting and rejecting those names.
+    // STEP files carry that the bundled EXPRESS exports omit, such as IFC4X3's
+    // `IfcSolidStratum`, which the bundled table folds into
+    // `IfcGeotechnicalStratum` with a PredefinedType. Hence the second lookup -
+    // it is the difference between accepting and rejecting those names.
+    // (This cited `IfcElectricalDistributionPoint` until #3172, which is not an
+    // entity in any schema -- the real IFC2X3 name has no "AL", and being in
+    // `ENTITIES_IFC2X3` it never needed the alias table at all.)
     //
     // A genuine query for the Unknown bucket is still made by passing the
     // literal string `'Unknown'`.

--- a/packages/query/test/oftype-unknown-type.test.ts
+++ b/packages/query/test/oftype-unknown-type.test.ts
@@ -94,9 +94,11 @@ const STANDARD_BUT_UNMAPPED = [
   'IfcAudioVisualAppliance',
   'IfcDoorStyle',
   'IfcWindowStyle',
-  // IFC2X3 leaf that no bundled EXPRESS export carries; the parser's
-  // `ENTITY_NAME_ALIASES` is the only table that knows it.
-  'IfcElectricalDistributionPoint',
+  // IFC2X3 flow-controller leaf, carried by `ENTITIES_IFC2X3` and by no enum.
+  // Spelled `IfcElectricalDistributionPoint` here until #3172 -- a name with an
+  // "AL" that IFC2X3 does not have, which reached this list from a misspelt arm
+  // in `rust/core/src/legacy_entities.rs` by way of an alias row mirroring it.
+  'IfcElectricDistributionPoint',
 ] as const;
 
 /**

--- a/rust/core/src/legacy_entities.rs
+++ b/rust/core/src/legacy_entities.rs
@@ -137,13 +137,21 @@ pub fn get_legacy_entity_info(entity_name: &str) -> Option<LegacyEntityInfo> {
             base_type: IfcType::IfcElement,
             has_geometry: true,
         }),
-        // The two concrete `IfcEdgeFeature` leaves, dropped by IFC4. They are
-        // boolean subtraction operands that carry their own placement and
-        // representation, so they map to the surviving abstract base rather
-        // than to `IfcOpeningElement`: that keeps them out of the void/CSG
-        // path (which matches `IfcType::IfcOpeningElement` exactly) while
-        // still excluding them from construction-projection profiles, which
-        // gate on `is_subtype_of(IfcFeatureElement)` (#979).
+        // The two concrete `IfcEdgeFeature` leaves, dropped by IFC4.
+        //
+        // `IfcFeatureElementSubtraction` is not merely AN ancestor that happens
+        // to work. It is the NEAREST SURVIVING one, and that is why these two
+        // need an arm at all: walking outward, their own parent is the first
+        // casualty and the very next link is the first survivor.
+        //
+        //     IfcEdgeFeature                 in ifc2x3, NOT in ifc4x3
+        //     IfcFeatureElementSubtraction   in ifc2x3, in ifc4x3   <- nearest
+        //
+        // Mapping there rather than to `IfcOpeningElement` also keeps them out
+        // of the void/CSG path, which matches `IfcType::IfcOpeningElement`
+        // exactly rather than by inheritance, while still excluding them from
+        // construction-projection profiles, which gate on
+        // `is_subtype_of(IfcFeatureElement)` -- the link directly above (#979).
         "IFCCHAMFEREDGEFEATURE" => Some(LegacyEntityInfo {
             base_type: IfcType::IfcFeatureElementSubtraction,
             has_geometry: true,

--- a/rust/core/src/legacy_entities.rs
+++ b/rust/core/src/legacy_entities.rs
@@ -124,9 +124,17 @@ pub fn get_legacy_entity_info(entity_name: &str) -> Option<LegacyEntityInfo> {
             base_type: IfcType::IfcFlowController,
             has_geometry: true,
         }),
-        // Deprecated by IFC4 in favour of the distribution-element family.
+        // Its own IFC2X3 parent, which survives into IFC4X3. This said
+        // `IfcDistributionElement` on the reasoning that IFC4 deprecated it in
+        // favour of that family -- a claim that was asserted and never
+        // measured, and that contradicted the rule every other arm here
+        // follows. The bundled IFC2X3 table declares the parent as `IfcElement`
+        // (entities-ifc2x3.ts:559) and the entity carries no distribution
+        // attribute, so the wider mapping would also have relabelled it in the
+        // public `ifcType` and moved it to secondary render priority via
+        // `compute_is_simple`. Reported by Codex on #3178.
         "IFCELECTRICALELEMENT" => Some(LegacyEntityInfo {
-            base_type: IfcType::IfcDistributionElement,
+            base_type: IfcType::IfcElement,
             has_geometry: true,
         }),
         // The two concrete `IfcEdgeFeature` leaves, dropped by IFC4. They are

--- a/rust/core/src/legacy_entities.rs
+++ b/rust/core/src/legacy_entities.rs
@@ -100,13 +100,59 @@ pub fn get_legacy_entity_info(entity_name: &str) -> Option<LegacyEntityInfo> {
         }),
 
         // IFC2x3 names that have no IFC4x3 enum variant. They map to the
-        // closest modern equivalent; both carry geometry.
+        // closest modern equivalent; all of them carry geometry.
+        //
+        // This block is the set `scripts/check-legacy-entity-coverage.mjs`
+        // derives: every CONCRETE `IfcProduct` subtype in `@ifc-lite/data`'s
+        // IFC2X3/IFC4 tables that `IfcType::from_str` resolves to `Unknown`.
+        // Anything missing here is dropped from BOTH the attribute export
+        // (`rust/export/src/model.rs` keeps only `is_subtype_of(IfcProduct)`,
+        // and `Unknown` is a subtype of nothing) and from meshing
+        // (`has_geometry_by_name` refuses `Unknown`) -- silent data loss, not
+        // a visible inconsistency (#3172).
         "IFCEQUIPMENTELEMENT" => Some(LegacyEntityInfo {
             base_type: IfcType::IfcDistributionElement,
             has_geometry: true,
         }),
-        "IFCELECTRICALDISTRIBUTIONPOINT" => Some(LegacyEntityInfo {
+        // Spelled IFCELECTRICALDISTRIBUTIONPOINT until #3172. There is no such
+        // IFC2X3 entity -- the real one has no "AL" -- so that arm matched no
+        // file that has ever existed. `IfcFlowController` is this entity's own
+        // IFC2X3 supertype and is still in IFC4X3, so it is the closest
+        // equivalent rather than a guess; it remains a subtype of
+        // `IfcDistributionElement`, which is what the misspelt arm intended.
+        "IFCELECTRICDISTRIBUTIONPOINT" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcFlowController,
+            has_geometry: true,
+        }),
+        // Deprecated by IFC4 in favour of the distribution-element family.
+        "IFCELECTRICALELEMENT" => Some(LegacyEntityInfo {
             base_type: IfcType::IfcDistributionElement,
+            has_geometry: true,
+        }),
+        // The two concrete `IfcEdgeFeature` leaves, dropped by IFC4. They are
+        // boolean subtraction operands that carry their own placement and
+        // representation, so they map to the surviving abstract base rather
+        // than to `IfcOpeningElement`: that keeps them out of the void/CSG
+        // path (which matches `IfcType::IfcOpeningElement` exactly) while
+        // still excluding them from construction-projection profiles, which
+        // gate on `is_subtype_of(IfcFeatureElement)` (#979).
+        "IFCCHAMFEREDGEFEATURE" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcFeatureElementSubtraction,
+            has_geometry: true,
+        }),
+        "IFCROUNDEDEDGEFEATURE" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcFeatureElementSubtraction,
+            has_geometry: true,
+        }),
+        // IFC4 folded the "Varying" structural actions into their base types,
+        // which carry the varying load on an attribute instead. Each maps to
+        // its own IFC2X3 supertype, both of which survive into IFC4X3.
+        "IFCSTRUCTURALLINEARACTIONVARYING" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcStructuralLinearAction,
+            has_geometry: true,
+        }),
+        "IFCSTRUCTURALPLANARACTIONVARYING" => Some(LegacyEntityInfo {
+            base_type: IfcType::IfcStructuralPlanarAction,
             has_geometry: true,
         }),
 

--- a/rust/core/src/schema_helpers.rs
+++ b/rust/core/src/schema_helpers.rs
@@ -73,7 +73,7 @@ where
 ///    [`is_non_geometric_spatial`] for how that exempt set is maintained.
 /// 2. Legacy IFC2x3 / removed-in-IFC4x3 names that aren't in the generated
 ///    enum (e.g. `IFCSLABELEMENTEDCASE`, `IFCBUILDINGELEMENT`, `IFCPROXY`,
-///    `IFCEQUIPMENTELEMENT`, `IFCELECTRICALDISTRIBUTIONPOINT`) resolve through
+///    `IFCEQUIPMENTELEMENT`, `IFCELECTRICDISTRIBUTIONPOINT`) resolve through
 ///    `legacy_entities::get_legacy_entity_info`, which carries a
 ///    `has_geometry` flag.
 /// 3. Reinforcement variants not covered above fall back to a substring

--- a/rust/core/src/schema_helpers_tests.rs
+++ b/rust/core/src/schema_helpers_tests.rs
@@ -115,7 +115,13 @@ fn building_bears_geometry() {
 fn legacy_ifc2x3_distribution_names_have_geometry() {
     // Routed through legacy_entities now (was an inline match arm).
     assert!(has_geometry_by_name("IFCEQUIPMENTELEMENT"));
-    assert!(has_geometry_by_name("IFCELECTRICALDISTRIBUTIONPOINT"));
+    assert!(has_geometry_by_name("IFCELECTRICDISTRIBUTIONPOINT"));
+    // The name this line carried until #3172 was `IFCELECTRICALDISTRIBUTIONPOINT`,
+    // which is not an IFC2X3 entity — the real one has no "AL". The assertion
+    // was green because the table it read carried the same misspelling, so the
+    // pair certified each other and neither described a file. Pinned as a
+    // negative so a respelling cannot quietly come back.
+    assert!(!has_geometry_by_name("IFCELECTRICALDISTRIBUTIONPOINT"));
 }
 
 #[test]
@@ -309,4 +315,126 @@ fn nth_attribute_reversed_boundary_is_false() {
     // `)` appears before `(` — must not panic or index out of bounds.
     assert!(!nth_attribute_is_present(b")(", 0));
     assert!(!nth_attribute_is_present(b"garbage)stuff(more", 0));
+}
+
+/// The five IFC2X3 products #3172 added to `legacy_entities.rs`.
+///
+/// Each one is CONCRETE and carries both `ObjectPlacement` and
+/// `Representation` in `@ifc-lite/data`'s IFC2X3 table, and each one resolved
+/// to `IfcType::Unknown` before the fix. `Unknown` is a subtype of nothing,
+/// so an IFC2X3 file containing them lost them from the attribute export
+/// (`rust/export/src/model.rs` keeps only `is_subtype_of(IfcProduct)`) AND
+/// from meshing (`has_geometry_by_name` refuses `Unknown`) — the two passes
+/// agreed, on dropping the entity from both.
+///
+/// The mapping targets are asserted, not just "is a product": a mapping that
+/// resolved every one of them to `IfcBuildingElementProxy` would satisfy the
+/// product check while throwing the semantics away.
+#[test]
+fn legacy_ifc2x3_products_resolve_to_their_own_supertype() {
+    for (name, expected) in [
+        ("IFCELECTRICALELEMENT", IfcType::IfcDistributionElement),
+        ("IFCELECTRICDISTRIBUTIONPOINT", IfcType::IfcFlowController),
+        ("IFCCHAMFEREDGEFEATURE", IfcType::IfcFeatureElementSubtraction),
+        ("IFCROUNDEDEDGEFEATURE", IfcType::IfcFeatureElementSubtraction),
+        (
+            "IFCSTRUCTURALLINEARACTIONVARYING",
+            IfcType::IfcStructuralLinearAction,
+        ),
+        (
+            "IFCSTRUCTURALPLANARACTIONVARYING",
+            IfcType::IfcStructuralPlanarAction,
+        ),
+    ] {
+        let resolved = legacy_aware_ifc_type(name);
+        assert_eq!(resolved, expected, "{name} resolved to {resolved:?}");
+        assert!(
+            resolved.is_subtype_of(IfcType::IfcProduct),
+            "{name} must reach IfcProduct or the attribute exporter drops it"
+        );
+        assert!(
+            has_geometry_by_name(name),
+            "{name} must reach the geometry pass"
+        );
+    }
+}
+
+/// `IfcFlowController` replaced the misspelt arm's `IfcDistributionElement`,
+/// and the comment in `legacy_entities.rs` claims that is a NARROWING rather
+/// than a change of answer. Claimed is not measured, so it is measured here:
+/// anything keying on the old target still sees the same verdict.
+#[test]
+fn the_electric_distribution_point_remap_only_narrows() {
+    let t = legacy_aware_ifc_type("IFCELECTRICDISTRIBUTIONPOINT");
+    assert_eq!(t, IfcType::IfcFlowController);
+    assert!(
+        t.is_subtype_of(IfcType::IfcDistributionElement),
+        "the arm used to answer IfcDistributionElement; IfcFlowController must still be one"
+    );
+}
+
+/// The two edge features are subtraction operands, and that has to survive the
+/// mapping: `IfcFeatureElementSubtraction` keeps them OUT of the void/CSG path
+/// (which matches `IfcType::IfcOpeningElement` exactly, not by inheritance)
+/// while keeping them out of construction-projection profiles, which gate on
+/// `is_subtype_of(IfcFeatureElement)` (#979). Mapping them to
+/// `IfcOpeningElement` would have satisfied every assertion above and fed two
+/// unrelated entities to the boolean cutter.
+#[test]
+fn edge_features_are_subtraction_operands_not_openings() {
+    for name in ["IFCCHAMFEREDGEFEATURE", "IFCROUNDEDEDGEFEATURE"] {
+        let t = legacy_aware_ifc_type(name);
+        assert!(t.is_subtype_of(IfcType::IfcFeatureElement), "{name}");
+        assert_ne!(t, IfcType::IfcOpeningElement, "{name}");
+        assert!(!t.is_subtype_of(IfcType::IfcOpeningElement), "{name}");
+    }
+}
+
+/// Every arm in `legacy_entities.rs` must map onto a type the generated
+/// IFC4X3 enum actually has, and an arm flagged `has_geometry` must reach
+/// `IfcProduct`. A mapping to `Unknown` would leave the entity exactly as
+/// dropped as having no arm at all, while looking handled in the table.
+#[test]
+fn every_legacy_arm_maps_onto_a_known_product() {
+    for name in [
+        "IFCPRESENTATIONSTYLEASSIGNMENT",
+        "IFCBEAMSTANDARDCASE",
+        "IFCCOLUMNSTANDARDCASE",
+        "IFCMEMBERSTANDARDCASE",
+        "IFCPLATESTANDARDCASE",
+        "IFCSLABSTANDARDCASE",
+        "IFCDOORSTANDARDCASE",
+        "IFCWINDOWSTANDARDCASE",
+        "IFCOPENINGSTANDARDCASE",
+        "IFCSLABELEMENTEDCASE",
+        "IFCWALLELEMENTEDCASE",
+        "IFCDOORSTYLE",
+        "IFCWINDOWSTYLE",
+        "IFCPROXY",
+        "IFCBUILDINGELEMENT",
+        "IFCBUILDINGELEMENTTYPE",
+        "IFCEQUIPMENTELEMENT",
+        "IFCELECTRICDISTRIBUTIONPOINT",
+        "IFCELECTRICALELEMENT",
+        "IFCCHAMFEREDGEFEATURE",
+        "IFCROUNDEDEDGEFEATURE",
+        "IFCSTRUCTURALLINEARACTIONVARYING",
+        "IFCSTRUCTURALPLANARACTIONVARYING",
+        "IFCSOLIDSTRATUM",
+        "IFCVOIDSTRATUM",
+        "IFCWATERSTRATUM",
+    ] {
+        let info = crate::legacy_entities::get_legacy_entity_info(name)
+            .unwrap_or_else(|| panic!("{name} has no arm in legacy_entities.rs"));
+        assert!(
+            !matches!(info.base_type, IfcType::Unknown(_)),
+            "{name} maps to Unknown, which is the same as not being in the table"
+        );
+        if info.has_geometry {
+            assert!(
+                info.base_type.is_subtype_of(IfcType::IfcProduct),
+                "{name} claims geometry but its base type is not an IfcProduct"
+            );
+        }
+    }
 }

--- a/rust/core/src/schema_helpers_tests.rs
+++ b/rust/core/src/schema_helpers_tests.rs
@@ -333,7 +333,7 @@ fn nth_attribute_reversed_boundary_is_false() {
 #[test]
 fn legacy_ifc2x3_products_resolve_to_their_own_supertype() {
     for (name, expected) in [
-        ("IFCELECTRICALELEMENT", IfcType::IfcDistributionElement),
+        ("IFCELECTRICALELEMENT", IfcType::IfcElement),
         ("IFCELECTRICDISTRIBUTIONPOINT", IfcType::IfcFlowController),
         ("IFCCHAMFEREDGEFEATURE", IfcType::IfcFeatureElementSubtraction),
         ("IFCROUNDEDEDGEFEATURE", IfcType::IfcFeatureElementSubtraction),

--- a/rust/geometry/src/profile_extractor.rs
+++ b/rust/geometry/src/profile_extractor.rs
@@ -111,13 +111,14 @@ where
         };
 
         // Issue #979: feature elements (IfcOpeningElement and the rest of the
-        // void/feature family) are boolean subtraction/addition operands, not
-        // building structure — they must never emit a construction-projection
-        // profile. `is_subtype_of` walks the supertype chain, so this single
-        // check covers Opening / Voiding / Earthworks / Projection / Surface
-        // features without touching IfcDoor/IfcWindow (which descend from
-        // IfcBuiltElement, not IfcFeatureElement).
-        if entity.ifc_type.is_subtype_of(IfcType::IfcFeatureElement) {
+        // void/feature family) are boolean operands, not building structure —
+        // they must never emit a construction-projection profile, and walking
+        // the supertype chain covers the whole family in one check. Resolved
+        // from `type_name`, NOT `entity.ifc_type`: the decoder sets that with a
+        // bare `from_str`, so a legacy keyword arrives as `Unknown` (a subtype
+        // of nothing) and `IFCOPENINGSTANDARDCASE` emitted a profile (#3172).
+        let feature_aware = ifc_lite_core::legacy_aware_ifc_type(type_name);
+        if feature_aware.is_subtype_of(IfcType::IfcFeatureElement) {
             continue;
         }
 

--- a/rust/geometry/src/profile_extractor.rs
+++ b/rust/geometry/src/profile_extractor.rs
@@ -117,8 +117,8 @@ where
         // from `type_name`, NOT `entity.ifc_type`: the decoder sets that with a
         // bare `from_str`, so a legacy keyword arrives as `Unknown` (a subtype
         // of nothing) and `IFCOPENINGSTANDARDCASE` emitted a profile (#3172).
-        let feature_aware = ifc_lite_core::legacy_aware_ifc_type(type_name);
-        if feature_aware.is_subtype_of(IfcType::IfcFeatureElement) {
+        let resolved_type = ifc_lite_core::legacy_aware_ifc_type(type_name);
+        if resolved_type.is_subtype_of(IfcType::IfcFeatureElement) {
             continue;
         }
 
@@ -148,7 +148,7 @@ where
             Err(_) => continue,
         };
 
-        let ifc_type_name = entity.ifc_type.name().to_string();
+        let ifc_type_name = resolved_type.name().to_string();
 
         for shape_rep in representations {
             if shape_rep.ifc_type != IfcType::IfcShapeRepresentation {

--- a/rust/geometry/tests/issue_979_feature_element_profiles.rs
+++ b/rust/geometry/tests/issue_979_feature_element_profiles.rs
@@ -123,3 +123,49 @@ fn legacy_opening_spellings_emit_no_profiles_either() {
     // two empty vectors.
     assert!(!baseline.is_empty(), "AC20 must yield structural profiles");
 }
+
+/// #3172 follow-up, reported by Codex on #3178: the profile's `ifc_type` label
+/// was read from `entity.ifc_type` -- the decoder's bare `from_str` -- so every
+/// legacy keyword that DOES emit a profile was labelled `"Unknown"`, while the
+/// mesh and attribute exports labelled the same entity properly.
+///
+/// That is not cosmetic. `rust/export/src/openings.rs`, `rooms.rs` and
+/// `shades.rs` each select profiles by EXACT string equality on this field, so
+/// an IFC2X3 slab authored as `IFCSLABSTANDARDCASE` matched none of them --
+/// the same silent loss this issue is about, one layer further on.
+///
+/// The respelled keyword is `IFCSLAB`, chosen because AC20's slabs actually
+/// PRODUCE profiles (four of them). The first version of this test respelled
+/// `IFCDOOR`, and AC20's doors emit no extruded-area-solid profile at all, so
+/// it compared two door-free lists and passed with the fix reverted.
+#[test]
+fn legacy_spellings_are_labelled_with_their_resolved_type() {
+    let Some(content) = fixture("tests/models/ara3d/AC20-FZK-Haus.ifc") else {
+        eprintln!("AC20-FZK-Haus.ifc fixture missing — skipping");
+        return;
+    };
+    let baseline = extract_profiles(&content, 0);
+    let slab_profiles = baseline.iter().filter(|p| p.ifc_type == "IfcSlab").count();
+    assert!(
+        slab_profiles > 0,
+        "AC20 must yield IfcSlab profiles, or the respelling below moves nothing"
+    );
+
+    let respelled = content.replace("IFCSLAB(", "IFCSLABSTANDARDCASE(");
+    assert_ne!(respelled, content, "the respelling matched nothing");
+    let profiles = extract_profiles(&respelled, 0);
+
+    assert!(
+        !profiles.iter().any(|p| p.ifc_type == "Unknown"),
+        "a legacy keyword was labelled Unknown: {:?}",
+        profiles.iter().map(|p| p.ifc_type.as_str()).collect::<Vec<_>>()
+    );
+
+    // And the label is the RESOLVED type, not merely non-Unknown: the consumers
+    // above ask for exactly "IfcSlab", so the whole multiset must be unchanged.
+    let mut want: Vec<&str> = baseline.iter().map(|p| p.ifc_type.as_str()).collect();
+    let mut got: Vec<&str> = profiles.iter().map(|p| p.ifc_type.as_str()).collect();
+    want.sort_unstable();
+    got.sort_unstable();
+    assert_eq!(got, want, "respelling IFCSLAB changed the profile labels");
+}

--- a/rust/geometry/tests/issue_979_feature_element_profiles.rs
+++ b/rust/geometry/tests/issue_979_feature_element_profiles.rs
@@ -76,3 +76,50 @@ fn ac20_extracts_no_feature_element_profiles() {
         "common structural elements (wall/slab/column/beam) should still produce profiles; got: {types:?}"
     );
 }
+
+/// #3172: the #979 filter read `entity.ifc_type`, which the decoder fills with
+/// a bare `IfcType::from_str`. Every LEGACY keyword therefore arrived as
+/// `Unknown`, and `Unknown` is a subtype of nothing — so the filter that
+/// exists to keep void cross-sections out of the floor plan let every legacy
+/// spelling of a feature element straight through.
+///
+/// `IFCOPENINGSTANDARDCASE` is that spelling for an opening: it is in
+/// `legacy_entities.rs`, so `has_geometry_by_name` admits it to this loop, and
+/// it was then never recognised as a feature element. The fixture is AC20 with
+/// its 17 openings respelled — same geometry, same placements, one keyword
+/// changed — so the only thing that can move the profile count is the filter.
+#[test]
+fn legacy_opening_spellings_emit_no_profiles_either() {
+    let Some(content) = fixture("tests/models/ara3d/AC20-FZK-Haus.ifc") else {
+        eprintln!("AC20-FZK-Haus.ifc fixture missing — skipping");
+        return;
+    };
+    let openings = content.matches("IFCOPENINGELEMENT(").count();
+    assert!(openings > 0, "fixture lost its openings — the respelling below would test nothing");
+
+    let respelled = content.replace("IFCOPENINGELEMENT(", "IFCOPENINGSTANDARDCASE(");
+    assert_eq!(
+        respelled.matches("IFCOPENINGSTANDARDCASE(").count(),
+        openings,
+        "the respelling must move every opening, or the count below is diluted"
+    );
+
+    let baseline = extract_profiles(&content, 0);
+    let legacy = extract_profiles(&respelled, 0);
+
+    // The respelled file must produce the SAME profiles as the original. A
+    // count assertion alone would pass if the filter dropped 17 real walls and
+    // admitted 17 openings, so the types are compared as a multiset.
+    let mut want: Vec<&str> = baseline.iter().map(|p| p.ifc_type.as_str()).collect();
+    let mut got: Vec<&str> = legacy.iter().map(|p| p.ifc_type.as_str()).collect();
+    want.sort_unstable();
+    got.sort_unstable();
+    assert_eq!(
+        got, want,
+        "respelling IFCOPENINGELEMENT as IFCOPENINGSTANDARDCASE changed the extracted profiles"
+    );
+
+    // And the baseline must be non-empty, or "they match" is a statement about
+    // two empty vectors.
+    assert!(!baseline.is_empty(), "AC20 must yield structural profiles");
+}

--- a/scripts/check-legacy-entity-coverage.mjs
+++ b/scripts/check-legacy-entity-coverage.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Lint: `rust/core/src/legacy_entities.rs` must cover every concrete
+ * `IfcProduct` subtype that the generated IFC4X3 enum cannot resolve, and must
+ * not carry an arm whose key names no entity in any bundled schema.
+ *
+ * `rust/core/src/schema_helpers.rs` tells every classification pass to consult
+ * that table "rather than a bare `IfcType::from_str`". Nothing checked that it
+ * was complete. It held 21 arms, and six concrete, geometry-bearing IFC2X3
+ * products were missing (#3172) — `IfcElectricalElement`,
+ * `IfcElectricDistributionPoint`, `IfcChamferEdgeFeature`,
+ * `IfcRoundedEdgeFeature`, `IfcStructuralLinearActionVarying`,
+ * `IfcStructuralPlanarActionVarying`.
+ *
+ * The failure is SILENT, in both passes at once. A name the table misses
+ * resolves to `IfcType::Unknown`, and `Unknown` is a subtype of nothing:
+ * `rust/export/src/model.rs` keeps a row only if the type reaches `IfcProduct`,
+ * and `has_geometry_by_name` refuses `Unknown` outright. So the entity is
+ * dropped from the attribute export AND from meshing — the two passes agree,
+ * on losing it. That is not the geometry/attribute divergence #1496 fixed;
+ * nothing disagrees, so nothing looks wrong.
+ *
+ * `rust/export/src/merged.rs` states the method this gate mechanises: "Derived
+ * by diffing `@ifc-lite/data`'s IFC2X3/IFC4/IFC4X3 entity tables against this
+ * crate's IFC4X3-only schema ... Update by re-running that diff, not by ad hoc
+ * inspection." A comment can only ask; this runs the diff.
+ *
+ * THE DEAD-KEY HALF is the other thing that went unnoticed for as long. The
+ * table carried `"IFCELECTRICALDISTRIBUTIONPOINT"`, and no such IFC2X3 entity
+ * exists — the real one has no "AL". The arm could never match a real file, and
+ * a Rust test asserted `has_geometry_by_name` on the same misspelling, so the
+ * table and its test certified each other while describing nothing.
+ *
+ * WHY A LINT AND NOT A TEST: this is a cross-language claim about two SOURCE
+ * files, which is the shape `check-source-text-assertions.mjs` bans in test
+ * files, for good reasons. Same call as
+ * `check-clash-degenerate-reason-parity.mjs`.
+ *
+ * VACUITY GUARD: both extractors must come back non-empty, and the schema
+ * tables must yield a plausible number of products. Two empty sets agree about
+ * everything, so an extractor broken by a regenerated table would otherwise
+ * turn this green by finding nothing.
+ *
+ * Run via `node scripts/check-legacy-entity-coverage.mjs` (CI node-test job).
+ * `--root <dir>` points it at a mutated copy of the tree; that is how
+ * `check-legacy-entity-coverage.test.mjs` proves it fires.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootFlag = process.argv.indexOf('--root');
+const ROOT =
+  rootFlag !== -1 && process.argv[rootFlag + 1]
+    ? process.argv[rootFlag + 1]
+    : join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const LEGACY_REL = 'rust/core/src/legacy_entities.rs';
+const SCHEMA_REL = 'rust/core/src/generated/schema.rs';
+const DATA_DIR = 'packages/data/src/ifc-schema/generated';
+const OLD_SCHEMAS = ['entities-ifc2x3.ts', 'entities-ifc4.ts'];
+const ALL_SCHEMAS = [...OLD_SCHEMAS, 'entities-ifc4x3.ts'];
+
+/**
+ * Keys the dead-key check exempts, with the reason each one is legitimately
+ * absent from every bundled table.
+ *
+ * The bundled IFC4X3 table models strata as one concrete
+ * `IfcGeotechnicalStratum` with a `PredefinedType` of SOLID / VOID / WATER,
+ * while real infrastructure exporters emit the three leaf keywords (#860).
+ * Those arms fire on real files; it is the TABLE that does not name them.
+ * Every other arm must name something.
+ */
+const KEYS_ABSENT_FROM_EVERY_BUNDLED_TABLE = new Map([
+  ['IFCSOLIDSTRATUM', 'IFC4X3 leaf the bundled table folds into IfcGeotechnicalStratum (#860)'],
+  ['IFCVOIDSTRATUM', 'IFC4X3 leaf the bundled table folds into IfcGeotechnicalStratum (#860)'],
+  ['IFCWATERSTRATUM', 'IFC4X3 leaf the bundled table folds into IfcGeotechnicalStratum (#860)'],
+]);
+
+/** Uppercase keys of every `"IFC…" => Some(LegacyEntityInfo {` arm. */
+export function legacyKeys(rustSource) {
+  return new Set([...rustSource.matchAll(/"(IFC[A-Z0-9]+)"\s*=>\s*Some\(/g)].map((m) => m[1]));
+}
+
+/**
+ * Uppercase names `IfcType::from_str` resolves to a real variant.
+ *
+ * Bounded to that ONE function rather than sliced to end of file: the arm shape
+ * is generated, so a future `pub fn` emitting the same shape would silently
+ * enlarge this set, and a name wrongly believed resolvable is a name this gate
+ * stops demanding an arm for — the quiet direction.
+ */
+export function generatedNames(schemaSource) {
+  const start = schemaSource.indexOf('pub fn from_str');
+  if (start === -1) return new Set();
+  const next = schemaSource.indexOf('pub fn ', start + 'pub fn from_str'.length);
+  const body = schemaSource.slice(start, next === -1 ? undefined : next);
+  return new Set([...body.matchAll(/^\s+"(IFC[A-Z0-9]+)" => Self::/gm)].map((m) => m[1]));
+}
+
+/**
+ * `{ name, parent, abstract, attributes }` per row of a generated
+ * `ENTITIES_*` table. The generator emits one row per line in a fixed shape,
+ * so this is a line match rather than a TS parse.
+ */
+export function parseEntityTable(tsSource) {
+  const out = new Map();
+  const re =
+    /\{ name: "([^"]+)", parent: (?:"([^"]+)"|undefined), abstract: (true|false), predefinedTypes: \[[^\]]*\], attributes: \[([^\]]*)\]/g;
+  for (const m of tsSource.matchAll(re)) {
+    out.set(m[1], {
+      name: m[1],
+      parent: m[2] ?? undefined,
+      isAbstract: m[3] === 'true',
+      attributes: m[4] ? m[4].split(',').map((s) => s.trim().replace(/^"|"$/g, '')) : [],
+    });
+  }
+  return out;
+}
+
+/** Whether `name`'s parent chain within `table` reaches `ancestor`. */
+function reaches(table, name, ancestor) {
+  const seen = new Set();
+  let cur = name;
+  while (cur && table.has(cur) && !seen.has(cur)) {
+    if (cur === ancestor) return true;
+    seen.add(cur);
+    cur = table.get(cur).parent;
+  }
+  return cur === ancestor;
+}
+
+/**
+ * Concrete `IfcProduct` subtypes in an older schema — every entity a real file
+ * can instantiate that both passes decide on by asking whether its type reaches
+ * `IfcProduct`.
+ *
+ * Abstract entities are excluded because no file instantiates one. Nothing else
+ * is: an earlier version of this also required `ObjectPlacement` and
+ * `Representation`, on the reasoning that an entity with neither carries no
+ * geometry to lose. That is true of MESHING and false of the ATTRIBUTE export,
+ * which keeps a row for any product and never looks at attribute 6. Measured on
+ * the pre-fix tree, the two rules select the same six entities, so the narrower
+ * one cost nothing visible while quietly excusing a whole class of loss — the
+ * shape this gate exists to stop.
+ */
+export function droppableProducts(tables) {
+  const found = new Map();
+  for (const { schema, table } of tables) {
+    for (const e of table.values()) {
+      if (e.isAbstract) continue;
+      if (!reaches(table, e.name, 'IfcProduct')) continue;
+      if (!found.has(e.name))
+        found.set(e.name, {
+          name: e.name,
+          schema,
+          parent: e.parent,
+          bearsGeometry:
+            e.attributes.includes('ObjectPlacement') && e.attributes.includes('Representation'),
+        });
+    }
+  }
+  return found;
+}
+
+export function checkCoverage({ legacySource, schemaSource, oldTables, tableSizes, allTableNames }) {
+  const failures = [];
+  const keys = legacyKeys(legacySource);
+  const known = generatedNames(schemaSource);
+  const droppable = droppableProducts(oldTables);
+
+  // Vacuity: every extractor must find something, or "nothing is missing" is
+  // a statement about the extractor rather than about the table.
+  if (keys.size === 0) failures.push(`no arms extracted from ${LEGACY_REL} — the extractor has drifted`);
+  if (known.size < 500)
+    failures.push(`only ${known.size} names extracted from ${SCHEMA_REL}'s from_str — the extractor has drifted`);
+  if (droppable.size === 0) failures.push(`no concrete products extracted from ${DATA_DIR} — the extractor has drifted`);
+  // Sized PER TABLE, not over the union. The union is dominated by IFC2X3 and
+  // IFC4, so a broken IFC4X3 extractor stays far above any union floor while
+  // the dead-key half silently loses the only table that can vouch for an
+  // IFC4X3-only name. Each table answers for itself.
+  for (const [file, size] of tableSizes)
+    if (size < 500) failures.push(`only ${size} entities extracted from ${file} — the extractor has drifted`);
+  if (failures.length > 0) return failures;
+
+  for (const p of [...droppable.values()].sort((a, b) => a.name.localeCompare(b.name))) {
+    const upper = p.name.toUpperCase();
+    if (known.has(upper) || keys.has(upper)) continue;
+    failures.push(
+      `${p.name} (${p.schema}, parent ${p.parent}) is a concrete IfcProduct, is not in the generated IFC4X3 enum, ` +
+        `and has no arm in ${LEGACY_REL} — a file containing it loses it from the attribute export` +
+        (p.bearsGeometry ? ' and from meshing' : ' (it carries no representation, so meshing loses nothing)'),
+    );
+  }
+
+  for (const key of [...keys].sort()) {
+    if (allTableNames.has(key)) continue;
+    if (KEYS_ABSENT_FROM_EVERY_BUNDLED_TABLE.has(key)) continue;
+    failures.push(
+      `${LEGACY_REL} has an arm for "${key}", which names no entity in any bundled schema table — ` +
+        `it can never match a real file. Check the spelling, or declare it in ` +
+        `KEYS_ABSENT_FROM_EVERY_BUNDLED_TABLE with a reason`,
+    );
+  }
+
+  return failures;
+}
+
+function loadTree(root) {
+  const read = (rel) => readFileSync(join(root, rel), 'utf8');
+  const oldTables = OLD_SCHEMAS.map((f) => ({
+    schema: f.replace('entities-', '').replace('.ts', '').toUpperCase(),
+    table: parseEntityTable(read(join(DATA_DIR, f))),
+  }));
+  const allTableNames = new Set();
+  const tableSizes = [];
+  for (const f of ALL_SCHEMAS) {
+    const table = parseEntityTable(read(join(DATA_DIR, f)));
+    tableSizes.push([f, table.size]);
+    for (const name of table.keys()) allTableNames.add(name.toUpperCase());
+  }
+  return {
+    legacySource: read(LEGACY_REL),
+    schemaSource: read(SCHEMA_REL),
+    oldTables,
+    tableSizes,
+    allTableNames,
+  };
+}
+
+// Only run the gate when invoked as a script; the self-test imports the helpers.
+if (process.argv[1] && process.argv[1].endsWith('check-legacy-entity-coverage.mjs')) {
+  // Fail closed: a renamed or moved file must break this rather than silently
+  // reduce it to zero comparisons.
+  const tree = loadTree(ROOT);
+  const failures = checkCoverage(tree);
+
+  if (failures.length > 0) {
+    console.error(`\n${LEGACY_REL} is out of step with the bundled schema tables:\n`);
+    for (const f of failures) console.error(`  ${f}`);
+    console.error(`
+Every pass that classifies an entity goes through this table, and a name it
+misses resolves to IfcType::Unknown -- a subtype of nothing. The entity is then
+dropped from the attribute export and from meshing at once, so nothing
+disagrees and nothing looks wrong.
+
+Add an arm mapping each name to its closest surviving IFC4X3 supertype (its own
+parent chain in the older schema is the place to look, not a guess), and pin it
+in rust/core/src/schema_helpers_tests.rs.
+`);
+    process.exit(1);
+  }
+
+  const exempt = KEYS_ABSENT_FROM_EVERY_BUNDLED_TABLE.size;
+  console.log(
+    `check-legacy-entity-coverage: OK (${legacyKeys(tree.legacySource).size} legacy arms, ` +
+      `${droppableProducts(tree.oldTables).size} concrete legacy products all resolvable, ` +
+      `${exempt} keys exempt by declaration)`,
+  );
+  for (const [key, why] of KEYS_ABSENT_FROM_EVERY_BUNDLED_TABLE) console.log(`  exempt: ${key} — ${why}`);
+}

--- a/scripts/check-legacy-entity-coverage.test.mjs
+++ b/scripts/check-legacy-entity-coverage.test.mjs
@@ -81,7 +81,7 @@ test('the extractors are not vacuous on the real tree', () => {
 });
 
 test('an arm deleted from the table is reported', () => {
-  const anchor = '"IFCELECTRICALELEMENT" => Some(LegacyEntityInfo {\n            base_type: IfcType::IfcDistributionElement,\n            has_geometry: true,\n        }),';
+  const anchor = '"IFCELECTRICALELEMENT" => Some(LegacyEntityInfo {\n            base_type: IfcType::IfcElement,\n            has_geometry: true,\n        }),';
   assert.ok(real.get(LEGACY_REL).includes(anchor), 'mutation anchor drifted');
   const { status, out } = runOn({ [LEGACY_REL]: real.get(LEGACY_REL).replace(anchor, '') });
   assert.equal(status, 1, out);

--- a/scripts/check-legacy-entity-coverage.test.mjs
+++ b/scripts/check-legacy-entity-coverage.test.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for scripts/check-legacy-entity-coverage.mjs.
+ *
+ * The gate reports "nothing is missing". That sentence is true of a table with
+ * nothing missing and equally true of an extractor that found nothing, so every
+ * way it could go false-green is an executable case here: each of its four
+ * extractors broken to return the empty set, an arm deleted, and an arm's key
+ * misspelt the way the real one was (#3172).
+ *
+ * Method matches scripts/check-clash-degenerate-reason-parity.test.mjs: mutate
+ * a copy of the REAL sources in a temp tree outside the repo, run the
+ * UNMODIFIED checker against it via `--root`, and assert exit code plus
+ * message. Every mutation anchor is asserted to exist in the real input first,
+ * so a drifted anchor fails the suite instead of quietly testing nothing.
+ *
+ * Run: node --test scripts/check-legacy-entity-coverage.test.mjs
+ * (wired as a step of the CI node-test job in .github/workflows/test.yml).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { legacyKeys, generatedNames, parseEntityTable, droppableProducts } from './check-legacy-entity-coverage.mjs';
+
+const SCRIPTS = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SCRIPTS, '..');
+const CHECKER = join(SCRIPTS, 'check-legacy-entity-coverage.mjs');
+
+const LEGACY_REL = 'rust/core/src/legacy_entities.rs';
+const SCHEMA_REL = 'rust/core/src/generated/schema.rs';
+const DATA_DIR = 'packages/data/src/ifc-schema/generated';
+const TABLE_RELS = ['entities-ifc2x3.ts', 'entities-ifc4.ts', 'entities-ifc4x3.ts'].map((f) =>
+  join(DATA_DIR, f),
+);
+
+const real = new Map([[LEGACY_REL, null], [SCHEMA_REL, null], ...TABLE_RELS.map((r) => [r, null])]);
+for (const rel of [...real.keys()]) real.set(rel, readFileSync(join(ROOT, rel), 'utf8'));
+
+/** Writes a (possibly mutated) tree to a temp dir and runs the checker on it. */
+function runOn(overrides = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'legacy-entity-coverage-'));
+  try {
+    for (const [rel, content] of real) {
+      const abs = join(dir, rel);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, overrides[rel] ?? content);
+    }
+    const r = spawnSync(process.execPath, [CHECKER, '--root', dir], { encoding: 'utf8' });
+    return { status: r.status, out: `${r.stdout}${r.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('the real tree passes', () => {
+  const { status, out } = runOn();
+  assert.equal(status, 0, out);
+  assert.match(out, /check-legacy-entity-coverage: OK/);
+});
+
+test('the extractors are not vacuous on the real tree', () => {
+  // Each number the gate's verdict depends on, asserted non-trivial here so a
+  // regenerated table that silently changes shape fails loudly rather than
+  // reducing the gate to zero comparisons.
+  assert.ok(legacyKeys(real.get(LEGACY_REL)).size >= 20);
+  assert.ok(generatedNames(real.get(SCHEMA_REL)).size >= 500);
+  const tables = TABLE_RELS.slice(0, 2).map((rel) => ({
+    schema: rel,
+    table: parseEntityTable(real.get(rel)),
+  }));
+  assert.ok(droppableProducts(tables).size >= 100);
+});
+
+test('an arm deleted from the table is reported', () => {
+  const anchor = '"IFCELECTRICALELEMENT" => Some(LegacyEntityInfo {\n            base_type: IfcType::IfcDistributionElement,\n            has_geometry: true,\n        }),';
+  assert.ok(real.get(LEGACY_REL).includes(anchor), 'mutation anchor drifted');
+  const { status, out } = runOn({ [LEGACY_REL]: real.get(LEGACY_REL).replace(anchor, '') });
+  assert.equal(status, 1, out);
+  assert.match(out, /IfcElectricalElement .*has no arm in/);
+});
+
+test("an arm whose key names no entity is reported — the #3172 misspelling", () => {
+  const anchor = '"IFCELECTRICDISTRIBUTIONPOINT"';
+  assert.ok(real.get(LEGACY_REL).includes(anchor), 'mutation anchor drifted');
+  const { status, out } = runOn({
+    [LEGACY_REL]: real.get(LEGACY_REL).replace(anchor, '"IFCELECTRICALDISTRIBUTIONPOINT"'),
+  });
+  assert.equal(status, 1, out);
+  // Both halves must fire: the key names nothing, AND the entity it was meant
+  // to cover is now uncovered. Reporting only one would let a respelling that
+  // moved the arm to another dead name look like a single fixable typo.
+  assert.match(out, /names no entity in any bundled schema table/);
+  assert.match(out, /IfcElectricDistributionPoint .*has no arm in/);
+});
+
+test('a broken legacy-arm extractor fails instead of passing vacuously', () => {
+  const { status, out } = runOn({ [LEGACY_REL]: '// every arm gone\n' });
+  assert.equal(status, 1, out);
+  assert.match(out, /no arms extracted from/);
+});
+
+test('a broken generated-schema extractor fails instead of passing vacuously', () => {
+  const { status, out } = runOn({ [SCHEMA_REL]: 'pub fn from_str() {}\n' });
+  assert.equal(status, 1, out);
+  assert.match(out, /names extracted from .*from_str/);
+});
+
+test('a broken entity-table extractor fails instead of passing vacuously', () => {
+  const overrides = {};
+  for (const rel of TABLE_RELS) overrides[rel] = 'export const ENTITIES = [];\n';
+  const { status, out } = runOn(overrides);
+  assert.equal(status, 1, out);
+  assert.match(out, /no concrete products extracted from/);
+});
+
+test('emptying ONE table is caught, including the one the union would hide', () => {
+  // The dead-key half reads the UNION of the three tables, which IFC2X3 and
+  // IFC4 dominate: a broken IFC4X3 extractor leaves that union at ~1700 names
+  // and clears any union-wide floor while the table that vouches for an
+  // IFC4X3-only name is gone. Each table is therefore sized on its own, and
+  // this asserts that for every one of the three -- the union floor version of
+  // this guard passed the IFC4X3 case, which is why it is sized per table.
+  for (const rel of TABLE_RELS) {
+    const { status, out } = runOn({ [rel]: 'export const ENTITIES = [];\n' });
+    assert.equal(status, 1, `${rel} emptied but the gate stayed green:\n${out}`);
+    assert.match(out, new RegExp(`entities extracted from ${rel.split('/').pop()}`));
+  }
+});


### PR DESCRIPTION
Closes #3172.

`rust/core/src/legacy_entities.rs` is the table `schema_helpers.rs` tells every classification pass to consult "rather than a bare `IfcType::from_str`". Nothing checked that it was complete. It held 21 arms.

## Six missing, not three

Running the diff `rust/export/src/merged.rs` already documents — `@ifc-lite/data`'s IFC2X3/IFC4 tables against this crate's IFC4X3-only schema — turns up **six** concrete `IfcProduct` subtypes in neither table. The issue reported three; the derivation finds six.

| entity | parent in IFC2X3 | mapped to |
|---|---|---|
| `IfcElectricalElement` | `IfcElement` | `IfcDistributionElement` |
| `IfcElectricDistributionPoint` | `IfcFlowController` | `IfcFlowController` |
| `IfcChamferEdgeFeature` | `IfcEdgeFeature` | `IfcFeatureElementSubtraction` |
| `IfcRoundedEdgeFeature` | `IfcEdgeFeature` | `IfcFeatureElementSubtraction` |
| `IfcStructuralLinearActionVarying` | `IfcStructuralLinearAction` | `IfcStructuralLinearAction` |
| `IfcStructuralPlanarActionVarying` | `IfcStructuralPlanarAction` | `IfcStructuralPlanarAction` |

> **Scope correction (Codex, #3179).** The mesh recovery below is real on the **native** path — CLI, server, exporters. On the **browser** path these entities are now meshed but still labelled `ifcType: "Unknown"`, because `gpu_meshes/prepass.rs` drops the resolved type from the jobs wire and `batch.rs` reconstructs it from the decoder's bare `from_str`. That is a pre-existing divergence affecting every entry in the legacy table, which this PR widens by six; it needs a wasm boundary change and is tracked in #3179. Read every "and from meshing" below as native-path.

A name the table misses resolves to `IfcType::Unknown`, and **`Unknown` is a subtype of nothing**. `rust/export/src/model.rs` keeps a row only if the type reaches `IfcProduct`; `has_geometry_by_name` refuses `Unknown` outright. So an IFC2X3 file holding one of these loses it from the attribute export **and** from meshing.

This is not the geometry/attribute divergence #1496 fixed. The two passes agree — on dropping the entity from both — which is exactly why nothing looked wrong.

Each arm maps to its own supertype from the older schema, not to a generic proxy. The edge features go to `IfcFeatureElementSubtraction` deliberately: that keeps them out of the void/CSG path (which matches `IfcType::IfcOpeningElement` exactly, not by inheritance) while keeping them out of construction-projection profiles, which gate on `is_subtype_of(IfcFeatureElement)`. Mapping them to `IfcOpeningElement` would have satisfied every "is it a product" assertion and fed two unrelated entities to the boolean cutter — so that is pinned as its own test.

## The dead arm, and the five artifacts built on it

The table spelled it `IFCELECTRICALDISTRIBUTIONPOINT`, with an "AL" no IFC2X3 entity has. It could never match a real file — and `schema_helpers_tests.rs` asserted `has_geometry_by_name` on the same misspelling, so the table and its test certified each other while describing nothing.

Then it spread. #2883 mirrored the misspelling into `@ifc-lite/parser`'s `ENTITY_NAME_ALIASES` on the stated premise that it was "real, deprecated IFC2X3 syntax", and a parser test, a query test and a comment in `ifc-query.ts` were written against the mirror. Five artifacts agreeing with each other about an entity that does not exist.

The alias row is **removed rather than respelled**: `IfcElectricDistributionPoint` is in `ENTITIES_IFC2X3` and already resolves through `IfcFlowController` to `IfcDistributionElement` with no alias at all — which is exactly what the new Rust arm answers, so the two languages now agree by derivation rather than by mirror. Each dependent asserts the real name and carries a negative on the misspelling; restoring the alias turns them red, verified by restoring it.

## A second live defect, found by fixing the first

#979's construction-projection filter read `entity.ifc_type`, which the decoder fills with a bare `from_str`. Every legacy spelling of a feature element therefore arrived as `Unknown` and passed straight through the filter that exists to keep void cross-sections out of the floor plan.

Measured end to end on AC20-FZK-Haus with its 17 openings respelled to `IFCOPENINGSTANDARDCASE` — same geometry, same placements, one keyword changed:

```
before: 47 profiles (14 structural + 33 spurious "Unknown")
after:  14 profiles (structural only, identical to the unrespelled file)
```

The test compares the two files' extracted types as a multiset, not a count, so dropping 17 real walls and admitting 17 openings could not pass it.

## The gate

`scripts/check-legacy-entity-coverage.mjs` runs that diff on every PR, in both directions: a concrete legacy product with no arm fails, and so does an arm whose key names no entity in any bundled schema. Run against `origin/main` it reports all six entities and the misspelling.

Its own harness breaks each of the four extractors in turn against mutated copies of the real sources, because "nothing is missing" is equally true of a complete table and of an extractor that found nothing. That harness earned its keep during review: the per-table vacuity floor started as a floor on the **union**, which IFC2X3 and IFC4 dominate — an emptied IFC4X3 table cleared it while the dead-key half lost the only table that vouches for an IFC4X3-only name. It is sized per table now.

The rule is also stated as the damage rather than as a proxy: any concrete `IfcProduct` subtype, not only those carrying a representation. Both select the same six today, so the narrower version cost nothing visible while quietly excusing every attribute-export-only loss.

## Verification

`cargo test --workspace --no-fail-fast`, `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings`, `pnpm typecheck`, `pnpm test`, `pnpm lint` — all green. Each new Rust test was run against the unfixed table first and is red there.

Also verified as a **squash onto current `main`** alongside #3176 and #3177, since three PRs each green on their own says nothing about the combination: all three squash cleanly, and on the combined tree `cargo test --workspace` is 2105 passing, clippy is clean, and every script gate agrees — `check-source-text-assertions`, `check-legacy-entity-coverage`, `check-test-wiring` (39 gate scripts, 26 script test files) and `check-changesets` (108 pending, all naming workspace packages).

`profile_extractor.rs` stays at exactly its 758-line allowlist budget; the comment was trimmed to fit rather than the budget raised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored support for six legacy IFC2X3 product classifications during attribute export and geometry meshing.
  * Corrected handling of electric distribution points and related entity inheritance.
  * Fixed legacy opening and slab spellings so feature-element filtering and exported profile types remain accurate.
  * Removed support for an invalid electrical-distribution entity name.
* **Quality Improvements**
  * Added automated coverage and regression checks to help prevent future legacy IFC compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->