### PR TITLE
fix(wasm): the browser labelled every legacy IFC keyword "Unknown" (#3179)

### DIFF
--- a/.changeset/wasm-legacy-keyword-labels.md
+++ b/.changeset/wasm-legacy-keyword-labels.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Label legacy IFC keywords with their resolved type in the browser, not `"Unknown"`.
+
+The native pipeline resolves a legacy keyword through `legacy_entities.rs` and labels the node with its real base type. The browser path did not: the jobs wire carries only `(id, start, end)`, so `batch.rs` rebuilt the type from `entity.ifc_type` — the decoder's bare `IfcType::from_str` — and every keyword IFC4X3 dropped arrived as `Unknown` with the Unknown default colour. `IfcProxy`, the eight `*StandardCase` variants, both `*ElementedCase`, `IfcDoorStyle`, `IfcWindowStyle`, `IfcEquipmentElement` and the three IFC4X3 strata leaves were all affected. Type-exact visibility rules and styling consumers skipped them, and nothing threw.
+
+It cannot be recovered from the decoded value: `IfcType::Unknown` stores a CRC32 hash, not the name. It is recomputed from the record instead, which the batch already holds — a short scan to the first `(`, paid only by entities the decoder could not name.
+
+Fixing it surfaced a second defect. `extract_entity_type_name` did not trim, so `#71= IFCCOLUMN(` — legal STEP, and what buildingSMART's own `column-straight-rectangle-tessellation.ifc` writes on all 26 of its entity lines — yielded `" IFCCOLUMN"` with a leading space, matching no lookup. The function had no production caller, so its broken contract had never been exercised.

--- a/rust/core/src/fast_parse.rs
+++ b/rust/core/src/fast_parse.rs
@@ -252,6 +252,15 @@ pub fn should_use_fast_path(type_name: &str) -> bool {
 /// Extract entity type name from raw bytes
 ///
 /// From `#77=IFCTRIANGULATEDFACESET(...)` extracts `IFCTRIANGULATEDFACESET`
+///
+/// TRIMMED, because STEP permits whitespace around `=` and real exporters use
+/// it: buildingSMART's own `column-straight-rectangle-tessellation.ifc` writes
+/// `#71= IFCCOLUMN(` on all 26 of its entity lines. Until #3179 this returned
+/// `" IFCCOLUMN"` with the leading space for those files, which no lookup
+/// keyed on a type name can match — the function's own doc comment above
+/// promised otherwise. It had no production caller at the time, so nothing
+/// noticed; `legacy_aware_ifc_type_from_record` is the first, and it silently
+/// resolved every entity in such a file to `Unknown` until this was fixed.
 #[inline]
 pub fn extract_entity_type_name(bytes: &[u8]) -> Option<&str> {
     // Find '=' position
@@ -265,7 +274,8 @@ pub fn extract_entity_type_name(bytes: &[u8]) -> Option<&str> {
         return None;
     }
 
-    std::str::from_utf8(&bytes[type_start..type_end]).ok()
+    let name = std::str::from_utf8(&bytes[type_start..type_end]).ok()?.trim();
+    (!name.is_empty()).then_some(name)
 }
 
 /// Extract the first entity reference from an entity's first attribute

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -102,7 +102,7 @@ pub use project_units::{
 pub use schema_gen::{AttributeValue, DecodedEntity, GeometryCategory, IfcSchema, ProfileCategory};
 pub use schema_helpers::{
     has_geometry_by_name, is_representationless_spatial_container_by_name, is_simple_geometry_type,
-    legacy_aware_ifc_type, nth_attribute_is_present,
+    legacy_aware_ifc_type, legacy_aware_ifc_type_from_record, nth_attribute_is_present,
 };
 pub use step_encoding::{decode_ifc_string, encode_ifc_string};
 pub use streaming::{parse_stream, ParseEvent, StreamConfig};

--- a/rust/core/src/schema_helpers.rs
+++ b/rust/core/src/schema_helpers.rs
@@ -286,6 +286,32 @@ pub fn legacy_aware_ifc_type(type_name: &str) -> IfcType {
     }
 }
 
+/// The legacy-aware type for an entity, recovered from its RAW STEP RECORD.
+///
+/// For callers that hold a `DecodedEntity` and its source bytes but no keyword.
+/// `DecodedEntity.ifc_type` comes from a bare [`IfcType::from_str`], and for a
+/// name IFC4X3 dropped that is `IfcType::Unknown` — which stores a **CRC32
+/// hash, not the name**, so the keyword cannot be recovered from it. The record
+/// is the only place it still exists.
+///
+/// `decoded` is returned unchanged when it is already a known type, so the
+/// scan is paid only by entities that need it, and when the record is
+/// malformed enough that no keyword can be read.
+///
+/// Exists because the wasm mesh batch had exactly this shape and got it wrong:
+/// every legacy keyword reached the browser labelled `"Unknown"` while the
+/// native pipeline, which still has the keyword in hand, labelled it correctly
+/// (#3179).
+pub fn legacy_aware_ifc_type_from_record(decoded: IfcType, record: &[u8]) -> IfcType {
+    if !matches!(decoded, IfcType::Unknown(_)) {
+        return decoded;
+    }
+    match crate::fast_parse::extract_entity_type_name(record) {
+        Some(name) => legacy_aware_ifc_type(name),
+        None => decoded,
+    }
+}
+
 fn compute_is_simple(upper: &str) -> bool {
     let t = legacy_aware_ifc_type(upper);
 

--- a/rust/core/src/schema_helpers_tests.rs
+++ b/rust/core/src/schema_helpers_tests.rs
@@ -438,3 +438,73 @@ fn every_legacy_arm_maps_onto_a_known_product() {
         }
     }
 }
+
+/// `legacy_aware_ifc_type_from_record` — the resolution the wasm mesh batch
+/// needs and did not have (#3179).
+///
+/// The browser path holds a `DecodedEntity` whose `ifc_type` came from a bare
+/// `from_str`, plus the raw record. For a legacy keyword that field is
+/// `Unknown`, and `Unknown` stores a CRC32 hash rather than the name, so the
+/// keyword survives only in the record.
+///
+/// The keywords here are ones `legacy_entities.rs` carries on `main`. The six
+/// #3172 adds are deliberately absent: this branch is cut from `main` and must
+/// not depend on a table that is still in review, or it goes green here and red
+/// on merge in whichever order the two land. The first draft used
+/// `IFCELECTRICALELEMENT` and failed for exactly that reason.
+#[test]
+fn a_legacy_record_resolves_where_the_decoded_type_cannot() {
+    // What the decoder produces for these, and what the browser was emitting.
+    //
+    // The SPACED forms are not padding. STEP permits whitespace around `=` and
+    // buildingSMART's own `column-straight-rectangle-tessellation.ifc` writes
+    // `#71= IFCCOLUMN(` on all 26 of its entity lines. The first draft of this
+    // test used only the tight form, passed, and the end-to-end wasm check then
+    // failed on the real fixture -- `extract_entity_type_name` was returning
+    // `" IFCCOLUMN"` untrimmed and every entity in such a file resolved to
+    // `Unknown`. A hand-written record is a weaker fixture than a real one.
+    for (record, expected) in [
+        (&b"#12=IFCPROXY('guid',$,$,$,$,$,$,$,$);"[..], IfcType::IfcBuildingElementProxy),
+        (&b"#13=IFCSLABSTANDARDCASE('guid',$,$,$,$,$,$,$,$);"[..], IfcType::IfcSlab),
+        (&b"#14=IFCDOORSTANDARDCASE('guid',$,$,$,$,$,$,$,$);"[..], IfcType::IfcDoor),
+        (&b"#15=IFCSOLIDSTRATUM('guid',$,$,$,$,$,$,$,$);"[..], IfcType::IfcGeotechnicalStratum),
+        // Whitespace around `=`, both sides, as real exporters emit it.
+        (&b"#16= IFCPROXY('guid',$,$,$,$,$,$,$,$);"[..], IfcType::IfcBuildingElementProxy),
+        (&b"#17 = IFCSLABSTANDARDCASE('guid',$,$);"[..], IfcType::IfcSlab),
+        (&b"#18=\tIFCDOORSTANDARDCASE('guid',$,$);"[..], IfcType::IfcDoor),
+    ] {
+        let name = crate::fast_parse::extract_entity_type_name(record).unwrap();
+        let decoded = IfcType::from_str(name);
+        assert!(
+            matches!(decoded, IfcType::Unknown(_)),
+            "{name} must be Unknown to the bare decoder, or this test proves nothing"
+        );
+        assert_eq!(legacy_aware_ifc_type_from_record(decoded, record), expected, "{name}");
+    }
+}
+
+/// A type the decoder already knows is returned UNCHANGED and without a scan,
+/// so the cost falls only on the entities that need it -- and, more to the
+/// point, so a malformed record cannot relabel a known entity.
+#[test]
+fn a_known_type_is_returned_untouched_whatever_the_record_says() {
+    let wall = IfcType::from_str("IFCWALL");
+    assert!(!matches!(wall, IfcType::Unknown(_)));
+    // Record deliberately disagrees with the decoded type; the decoded type wins.
+    assert_eq!(
+        legacy_aware_ifc_type_from_record(wall, b"#1=IFCSLABSTANDARDCASE('g');"),
+        IfcType::IfcWall
+    );
+}
+
+/// An unreadable record leaves the answer exactly as the decoder had it, rather
+/// than inventing one. `Unknown` in, `Unknown` out -- the entity is no worse off
+/// than before this function existed.
+#[test]
+fn an_unreadable_record_changes_nothing() {
+    let unknown = IfcType::from_str("IFCNOTAREALENTITY");
+    assert!(matches!(unknown, IfcType::Unknown(_)));
+    for record in [&b""[..], &b"garbage with no equals or paren"[..], &b"#1="[..], &b"#1=("[..]] {
+        assert_eq!(legacy_aware_ifc_type_from_record(unknown, record), unknown);
+    }
+}

--- a/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/batch.rs
@@ -399,7 +399,28 @@ impl IfcAPI {
             let Ok(entity) = decoder.decode_and_cache(id, start, end) else {
                 continue;
             };
-            let ifc_type = entity.ifc_type;
+            // LEGACY-AWARE, like the native pre-pass at
+            // `processing/src/processor/mod.rs:711`. `entity.ifc_type` comes
+            // from the decoder's bare `IfcType::from_str`, so every keyword
+            // IFC4X3 dropped -- IfcProxy, the *StandardCase family, the strata
+            // leaves, the six #3172 added -- arrived here as `Unknown` and was
+            // emitted to the browser with `ifcType: "Unknown"` and the Unknown
+            // default colour, while the CLI and exporters labelled the same
+            // entity correctly (#3179).
+            //
+            // Recomputed from the SOURCE KEYWORD rather than recovered from
+            // `entity.ifc_type`, because it cannot be: `IfcType::Unknown(u32)`
+            // stores a CRC32 hash and `DecodedEntity` keeps no raw name, so
+            // there is nothing to map back from. The bytes are already in hand
+            // -- `content[start..end]` is the record `decode_and_cache` just
+            // parsed -- so this is a ~20-byte scan to the first `(`, not a
+            // re-read. Cheaper than widening the jobs wire, which is 3 u32 per
+            // job across Rust and TS and would have paid marshalling cost on
+            // every job to fix the few that are legacy.
+            let ifc_type = ifc_lite_core::legacy_aware_ifc_type_from_record(
+                entity.ifc_type,
+                content.get(start..end).unwrap_or_default(),
+            );
 
             // Resolve the element-level colour inline (folded from the deleted
             // pre-pass) so the entity is decoded exactly once.

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -65,6 +65,7 @@ const LAYERED_AVAILABLE = existsSync(LAYERED_IFC);
 if (!LAYERED_AVAILABLE) {
   console.log('⚠️  layered-wall fixture missing — run `pnpm fixtures`. geometryClass pin will be skipped.');
 }
+const COLUMN_AVAILABLE_FOR_LEGACY = existsSync(COLUMN_IFC);
 const SPACES_AVAILABLE = existsSync(SPACES_IFC);
 if (!SPACES_AVAILABLE) {
   console.log('⚠️  spaces fixture missing — run `pnpm fixtures`. Energy-model tests will be skipped.');
@@ -830,6 +831,64 @@ test('exportGlbFromMeshes output is spec-conformant glTF 2.0 (0 errors, 0 warnin
   assertClean(fromMeshesReport, 'exportGlbFromMeshes');
   assert.equal(fromMeshesReport.info.totalTriangleCount, 1, 'the one triangle handed in');
 });
+
+// ===== legacy keywords keep their type across the wasm boundary (#3179) =====
+//
+// The native pipeline resolves a legacy keyword through `legacy_entities.rs`
+// and labels the node with its real base type. The BROWSER path did not: the
+// jobs wire carries only (id, start, end), so `batch.rs` rebuilt the type from
+// `entity.ifc_type` -- the decoder's bare `IfcType::from_str` -- and every
+// keyword IFC4X3 dropped arrived as `Unknown` with the Unknown default colour.
+//
+// It is silent in the same way a wrong geometryClass is: the mesh renders, it
+// is simply mislabelled, and type-exact visibility rules and styling quietly
+// skip it. Nothing throws.
+//
+// This has to be checked HERE rather than in a Rust unit test, because the
+// defect lived in the wasm binding specifically -- the native path was correct
+// the whole time, so any test that did not cross the boundary agreed with the
+// half that already worked.
+if (COLUMN_AVAILABLE_FOR_LEGACY) {
+  console.log('\n📋 legacy keyword labelling (Rust → JS, #3179)');
+
+  test('a legacy keyword crosses as its resolved type, not "Unknown"', () => {
+    // IFCCOLUMN is modern; IFCBEAMSTANDARDCASE is IFC4-removed and sits in
+    // `legacy_entities.rs` mapping to IfcBeam. Respelling the fixture's columns
+    // changes ONE keyword and nothing else, so the label is the only variable.
+    const modern = readFileSync(COLUMN_IFC, 'utf-8');
+    assert.ok(modern.includes('IFCCOLUMN('), 'fixture lost its columns — the respelling would test nothing');
+    const legacy = modern.replace(/IFCCOLUMN\(/g, 'IFCBEAMSTANDARDCASE(');
+
+    const collect = (content) => {
+      const collection = parseMeshesViaPrePass(api, content);
+      const types = [];
+      for (let i = 0; i < collection.length; i++) {
+        const m = collection.get(i);
+        if (!m) continue;
+        types.push(m.ifcType);
+        m.free();
+      }
+      collection.free();
+      return types;
+    };
+
+    const before = collect(modern);
+    const after = collect(legacy);
+
+    assert.ok(before.length > 0, 'the fixture must produce meshes, or this pins nothing');
+    assert.equal(after.length, before.length, 'the respelling changed how many meshes are produced');
+    assert.ok(
+      !after.includes('Unknown'),
+      `a legacy keyword crossed as "Unknown": ${JSON.stringify(after)}`,
+    );
+    // And the RESOLVED type specifically — "not Unknown" would also be
+    // satisfied by any other wrong label.
+    assert.ok(
+      after.every((t) => t === 'IfcBeam'),
+      `expected every mesh to label as IfcBeam, saw ${JSON.stringify([...new Set(after)])}`,
+    );
+  });
+}
 
 // ===== geometryClass ordinals, pinned at the real boundary =====
 //


### PR DESCRIPTION
Closes #3179.

The native pipeline resolves a legacy keyword through `legacy_entities.rs` and labels the node with its real base type — `processor/mod.rs:711` says so in its own comment. **The browser path did not.**

| site | what it does |
|---|---|
| `gpu_meshes/prepass.rs:87` | serialises jobs as `[id, start, end]`, discards the resolved type |
| `gpu_meshes/batch.rs:402` | rebuilds it from `entity.ifc_type` — the decoder's bare `IfcType::from_str` |
| `processing/src/element.rs:758` | labels `MeshData` from `job.ifc_type.name()` |

So `IfcProxy`, the eight `*StandardCase` variants, both `*ElementedCase`, `IfcDoorStyle`, `IfcWindowStyle`, `IfcEquipmentElement` and the three IFC4X3 strata leaves all reached the browser as `ifcType: "Unknown"` with the Unknown default colour. Silent in the usual way: the mesh renders, it is merely mislabelled, so type-exact visibility rules and styling consumers skip it and nothing throws.

## Not a wire change

The issue proposed widening `jobs_flat` from 3 u32 to 4, and I estimated the same. Both wrong — the batch already has what it needs. `content` is in scope, each job carries `start`/`end`, and `ifc_lite_core::extract_entity_type_name` already existed and was already exported. **The fix is one call site.**

It genuinely cannot be recovered from the decoded value: `IfcType::Unknown(u32)` stores a CRC32 hash and `DecodedEntity` keeps no raw name. So the resolution lives in a new `legacy_aware_ifc_type_from_record` in core rather than inline in the binding, which makes it testable natively instead of only through wasm. A known type is returned untouched, so the scan is paid only by entities that need it — and a malformed record cannot relabel a real entity.

## Scope checked, not assumed

`prepass.rs` and `styling/prepass.rs` hold three more bare `from_str` sites. They do not matter: the 4th tuple field they fill is destructured as `_` by every consumer, `emit_jobs_chunk` included. `batch.rs` was the whole defect.

## A second defect, found only end-to-end

`extract_entity_type_name` did not trim. `#71= IFCCOLUMN(` — legal STEP, and what buildingSMART's own `column-straight-rectangle-tessellation.ifc` writes on **all 26** of its entity lines — returned `" IFCCOLUMN"` with a leading space, matching no lookup keyed on a type name. Its doc comment promised otherwise.

It had **no production caller**, so the broken contract had never been exercised. This change is the first, and without the fix it would have resolved every entity in such a file to `Unknown`. Corrected at the source, with spaced forms (`= `, ` = `, `=\t`) added to the tests.

That one is the lesson worth recording: my three native tests used hand-written records in the tight `#1=IFCBEAM(` form, all passed, and all missed it. A fixture I author shares my blind spot about what real files look like.

## Verification

First establishing that the toolchain is present — `wasm-pack`, `nightly-2025-11-15`, `wasm32-unknown-unknown` — rather than asserting it is not, which is the mistake that got this deferred in the first place.

- **`scripts/test-wasm-contract.mjs`: 64 passed, 0 failed**, against a real wasm build. The new case respells the fixture's `IFCCOLUMN` to `IFCBEAMSTANDARDCASE` — one keyword, nothing else — and requires every mesh back as `IfcBeam`.
- **Paired probe**: reverting the call site and rebuilding turns that case red with `["Unknown"]`, so it measures the fix and not the fixture.
- `cargo test --workspace --no-fail-fast`: **2102 passed**.
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings`: clean.

## Relationship to the other open PRs

Cut from `main`, independent of #3178. The tests deliberately use only keywords `legacy_entities.rs` carries on `main` — my first draft used `IFCELECTRICALELEMENT`, which #3178 adds, and it failed here for exactly that reason. Whichever order the two land, neither breaks the other; once both are in, the six entities #3178 adds get correct browser labels for free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy IFC entities are now correctly labeled with their resolved types instead of `Unknown`.
  * Improved recognition of entity types when STEP records contain extra whitespace.
  * Mesh classification and generation now preserve accurate types for legacy and IFC4X3 entities.
  * Malformed records and already-known types continue to behave as expected.

* **Tests**
  * Added coverage for legacy keywords, whitespace handling, conflicting type data, and browser-side mesh type resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->