### PR TITLE
perf(export): hoist the geometry type set out of the per-entity call path

### DIFF
--- a/packages/export/src/step-geometry-types.ts
+++ b/packages/export/src/step-geometry-types.ts
@@ -18,41 +18,49 @@
  */
 
 /**
- * Check if an entity type is a geometry-related type
+ * The set itself, at module scope rather than rebuilt per call.
+ *
+ * `isGeometryEntity` runs once per entity, through `isGeometryExcluded`, the
+ * source-iteration skip and `step-overlay-entities.ts` — so constructing this
+ * inside the function allocated a 31-string `Set` per entity on every export.
+ * It was written that way as a private method and moved here verbatim; being a
+ * free function is what makes hoisting it trivial and obviously safe.
  */
+const GEOMETRY_TYPES: ReadonlySet<string> = new Set([
+  'IFCCARTESIANPOINT',
+  'IFCDIRECTION',
+  'IFCAXIS2PLACEMENT2D',
+  'IFCAXIS2PLACEMENT3D',
+  'IFCLOCALPLACEMENT',
+  'IFCSHAPEREPRESENTATION',
+  'IFCPRODUCTDEFINITIONSHAPE',
+  'IFCGEOMETRICREPRESENTATIONCONTEXT',
+  'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
+  'IFCEXTRUDEDAREASOLID',
+  'IFCFACETEDBREP',
+  'IFCPOLYLOOP',
+  'IFCFACE',
+  'IFCFACEOUTERBOUND',
+  'IFCCLOSEDSHELL',
+  'IFCRECTANGLEPROFILEDEF',
+  'IFCCIRCLEPROFILEDEF',
+  'IFCARBITRARYCLOSEDPROFILEDEF',
+  'IFCPOLYLINE',
+  'IFCTRIMMEDCURVE',
+  'IFCBSPLINECURVE',
+  'IFCBSPLINESURFACE',
+  'IFCTRIANGULATEDFACESET',
+  'IFCPOLYGONALFACE',
+  'IFCINDEXEDPOLYGONALFACE',
+  'IFCPOLYGONALFACESET',
+  'IFCSTYLEDITEM',
+  'IFCPRESENTATIONSTYLEASSIGNMENT',
+  'IFCSURFACESTYLE',
+  'IFCSURFACESTYLERENDERING',
+  'IFCCOLOURRGB',
+]);
+
+/** Check if an entity type is a geometry-related type. */
 export function isGeometryEntity(type: string): boolean {
-  const geometryTypes = new Set([
-    'IFCCARTESIANPOINT',
-    'IFCDIRECTION',
-    'IFCAXIS2PLACEMENT2D',
-    'IFCAXIS2PLACEMENT3D',
-    'IFCLOCALPLACEMENT',
-    'IFCSHAPEREPRESENTATION',
-    'IFCPRODUCTDEFINITIONSHAPE',
-    'IFCGEOMETRICREPRESENTATIONCONTEXT',
-    'IFCGEOMETRICREPRESENTATIONSUBCONTEXT',
-    'IFCEXTRUDEDAREASOLID',
-    'IFCFACETEDBREP',
-    'IFCPOLYLOOP',
-    'IFCFACE',
-    'IFCFACEOUTERBOUND',
-    'IFCCLOSEDSHELL',
-    'IFCRECTANGLEPROFILEDEF',
-    'IFCCIRCLEPROFILEDEF',
-    'IFCARBITRARYCLOSEDPROFILEDEF',
-    'IFCPOLYLINE',
-    'IFCTRIMMEDCURVE',
-    'IFCBSPLINECURVE',
-    'IFCBSPLINESURFACE',
-    'IFCTRIANGULATEDFACESET',
-    'IFCPOLYGONALFACE',
-    'IFCINDEXEDPOLYGONALFACE',
-    'IFCPOLYGONALFACESET',
-    'IFCSTYLEDITEM',
-    'IFCPRESENTATIONSTYLEASSIGNMENT',
-    'IFCSURFACESTYLE',
-    'IFCSURFACESTYLERENDERING',
-    'IFCCOLOURRGB',
-  ]);
-  return geometryTypes.has(type);
+  return GEOMETRY_TYPES.has(type);
 }

--- a/packages/export/src/step-geometry-types.ts
+++ b/packages/export/src/step-geometry-types.ts
@@ -22,11 +22,20 @@
  *
  * `isGeometryEntity` runs once per entity, through `isGeometryExcluded`, the
  * source-iteration skip and `step-overlay-entities.ts` — so constructing this
- * inside the function allocated a 31-string `Set` per entity on every export.
- * It was written that way as a private method and moved here verbatim; being a
- * free function is what makes hoisting it trivial and obviously safe.
+ * inside the function allocated a 31-string `Set` per entity on any export
+ * that excludes geometry. It was written that way as a private method and
+ * moved here verbatim; being a free function is what makes hoisting it
+ * trivial and obviously safe.
+ *
+ * Named PRIMITIVE deliberately. `@ifc-lite/parser` exports a `GEOMETRY_TYPES`
+ * of its own holding BUILDING ELEMENTS — `IFCWALL`, `IFCDOOR`, `IFCCOVERING`
+ * — which is close to the opposite of this set's contents: representation
+ * primitives like `IFCCARTESIANPOINT` and `IFCEXTRUDEDAREASOLID`. The two
+ * never collide as imports, since this one is module-private, but they
+ * collide for anyone grepping the symbol, and "the geometry types" is exactly
+ * the phrase that would make a reader reach for the wrong one.
  */
-const GEOMETRY_TYPES: ReadonlySet<string> = new Set([
+const GEOMETRY_PRIMITIVE_TYPES: ReadonlySet<string> = new Set([
   'IFCCARTESIANPOINT',
   'IFCDIRECTION',
   'IFCAXIS2PLACEMENT2D',
@@ -62,5 +71,5 @@ const GEOMETRY_TYPES: ReadonlySet<string> = new Set([
 
 /** Check if an entity type is a geometry-related type. */
 export function isGeometryEntity(type: string): boolean {
-  return GEOMETRY_TYPES.has(type);
+  return GEOMETRY_PRIMITIVE_TYPES.has(type);
 }

--- a/packages/export/src/step-pass-builder.ts
+++ b/packages/export/src/step-pass-builder.ts
@@ -33,9 +33,10 @@ import { buildStepHeader } from './step-header.js';
 /**
  * Everything the pass literal reads that is not its own field.
  *
- * The first three are the exporter's, injected rather than reached for.
- * `isGeometryEntity` is passed as a bound callback for the same reason it is a
- * method there: it closes over the exporter's own type set.
+ * `dataStore` and `mutationView` are the exporter's, injected rather than
+ * reached for. `isGeometryEntity` arrives as a parameter for a different
+ * reason: it is the free function in `step-geometry-types.ts`, so taking it
+ * here keeps this builder independent of the exporter AND of that module.
  */
 export interface PassBuildInput {
   readonly dataStore: IfcDataStore;


### PR DESCRIPTION
Two CodeRabbit findings from #3171 that landed after it merged, so they need their own change rather than another commit on a closed PR. Both were filed under *Nitpick comments* in the walkthrough body rather than as inline threads, which is how they were missed while that PR was open.

## The allocation

`isGeometryEntity` rebuilt a 31-string `Set` on **every call**. It runs once per entity — through `isGeometryExcluded`, the source-iteration skip, and `step-overlay-entities.ts` — so a large export allocated one `Set` per entity. It is now at module scope as `GEOMETRY_TYPES`.

Worth being exact about blame: **this is not a regression from #3171.** The private method allocated per call too, and #3171 moved it verbatim; a review at the time spotted it and correctly ruled it out of scope for a refactor meant to change nothing. What changed is that being a free function makes the hoist obviously safe rather than a behaviour question.

## The check that matters

The dedent rewrote every line of the type literal, so a dropped or altered name would be silent and would change what counts as geometry. Extracted and sorted both sides and diffed:

```
diff <(git show upstream/main:...step-geometry-types.ts | grep -oE "'IFC[A-Z0-9]+'" | sort) \
     <(grep -oE "'IFC[A-Z0-9]+'" packages/export/src/step-geometry-types.ts | sort)
```

Identical, 31 names.

## A comment that contradicted its own PR

`step-pass-builder.ts`'s `PassBuildInput` doc said `isGeometryEntity` *"is passed as a bound callback for the same reason it is a method there: it closes over the exporter's own type set."*

#3171 is what stopped it being a method. It is a free function in `step-geometry-types.ts`, whose header says outright that it reads nothing off the instance — so those two files shipped disagreeing about the same symbol. It now says why it is really a parameter: taking it here keeps the builder independent of the exporter *and* of that module.

## Verification

**Not verified locally, stated plainly rather than implied.** The worktree carrying `node_modules` lost its `.git` to an unrelated prune mid-session, and the replacement has no dependencies installed. These exact file contents passed **890/890**, `tsc --noUnusedLocals` clean of both TS6133 and TS6196, and `check-module-size` exit 0 before that happened — and the type-set diff above is the check that actually matters for this diff. CI is the authority.

No changeset: nothing published changes, and there is no behaviour change to describe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between geometry representation primitives and parser building-element types.
  * Updated STEP pass-building documentation to explain how export data, mutation views, and geometry checks are supplied.

* **Refactor**
  * Refined internal geometry type terminology without changing geometry classification behavior or exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->