### PR TITLE
fix(core): IFCELECTRICDISTRIBUTIONPOINT was spelled IFCELECTRICAL- in four places

### DIFF
--- a/packages/parser/src/ifc-schema.ts
+++ b/packages/parser/src/ifc-schema.ts
@@ -42,11 +42,20 @@ const ENTITY_NAME_ALIASES: Record<string, string> = {
     IFCSOLIDSTRATUM: 'IfcGeotechnicalStratum',
     IFCVOIDSTRATUM: 'IfcGeotechnicalStratum',
     IFCWATERSTRATUM: 'IfcGeotechnicalStratum',
-    // IFC2x3 names with no IFC4x3 enum variant in any bundled schema table
-    // (ENTITIES_IFC2X3/IFC4/IFC4X3 all lack them) — mirrors
-    // `rust/core/src/legacy_entities.rs`'s "IFC2x3 names that have no IFC4x3
-    // enum variant" arm, which maps both to `IfcDistributionElement`.
-    IFCELECTRICALDISTRIBUTIONPOINT: 'IfcDistributionElement',
+    // Mirrors `rust/core/src/legacy_entities.rs`'s "IFC2x3 names that have no
+    // IFC4x3 enum variant" arm, which maps this to `IfcDistributionElement`.
+    //
+    // Belt and braces on this side: unlike the Rust core, whose generated enum
+    // is IFC4X3-only, the bundled ENTITIES_IFC2X3 table does carry
+    // `IfcElectricDistributionPoint`, so `getInheritanceChain` reaches
+    // `IfcDistributionElement` through its real parents without this alias.
+    // Kept so the two files stay in lockstep, which is what the Rust side
+    // needs.
+    // IFCELECTRIC-, not IFCELECTRICAL-. This key was spelled with an "AL"
+    // the real IFC2X3 entity does not have, mirroring the same typo in
+    // `legacy_entities.rs` -- so both sides agreed, and both missed
+    // `IfcElectricDistributionPoint` entirely.
+    IFCELECTRICDISTRIBUTIONPOINT: 'IfcDistributionElement',
 };
 
 /**

--- a/packages/parser/test/known-type-across-schemas.test.ts
+++ b/packages/parser/test/known-type-across-schemas.test.ts
@@ -289,14 +289,18 @@ describe('normalizeIfcTypeName across the bundled schema union (#2003)', () => {
   });
 
   it('resolves the IFC2X3 leaves rust/core/src/legacy_entities.rs maps but no bundled TS schema carries', () => {
-    // `IfcElectricalDistributionPoint` is real, deprecated IFC2X3 syntax with
-    // no IFC4x3 equivalent in ENTITIES_IFC2X3/IFC4/IFC4X3. The Rust core's
-    // `legacy_entities.rs` resolves it to `IfcDistributionElement` (comment:
-    // "IFC2x3 names that have no IFC4x3 enum variant"). The TS
-    // `ENTITY_NAME_ALIASES` table in `ifc-schema.ts` claims to mirror that
-    // file "so the two sides stay in lockstep", but only carries the three
-    // IFC4.3 stratum leaves -- this class is silently unknown here while the
-    // Rust parser resolves it with geometry.
-    expect(getInheritanceChain('IfcElectricalDistributionPoint')).toContain('IfcDistributionElement');
+    // `IfcElectricDistributionPoint` — IFCELECTRIC-, not IFCELECTRICAL-.
+    //
+    // This assertion used to name the latter and called it "real, deprecated
+    // IFC2X3 syntax". It is not syntax at all: no IFC schema defines it. It
+    // passed because `ENTITY_NAME_ALIASES` carried the same misspelling, so
+    // the test and the table agreed with each other rather than with IFC.
+    //
+    // The real entity reaches `IfcDistributionElement` through the bundled
+    // IFC2X3 table on its own — `IfcFlowController` ->
+    // `IfcDistributionFlowElement` -> `IfcDistributionElement` — so this holds
+    // via the schema rather than via the alias, which is the stronger place
+    // for it to hold.
+    expect(getInheritanceChain('IfcElectricDistributionPoint')).toContain('IfcDistributionElement');
   });
 });

--- a/packages/query/src/ifc-query.ts
+++ b/packages/query/src/ifc-query.ts
@@ -120,9 +120,16 @@ export class IfcQuery {
     // because it doubles as a name canonicalizer and an alias maps a leaf to
     // its nearest schema-known *supertype*. For a pure known-ness question the
     // alias table is exactly the right thing to consult: it lists names real
-    // STEP files carry that the bundled EXPRESS exports omit, such as IFC2X3's
-    // `IfcElectricalDistributionPoint`. Hence the second lookup - it is the
-    // difference between accepting and rejecting those names.
+    // STEP files carry that the bundled EXPRESS exports omit. Hence the second
+    // lookup - it is the difference between accepting and rejecting those
+    // names.
+    //
+    // The example that used to sit here was `IfcElectricalDistributionPoint`,
+    // which is not an IFC entity in any schema -- IFCELECTRIC-, not
+    // IFCELECTRICAL-. It read as a real one because the alias table carried
+    // the same misspelling. The real `IfcElectricDistributionPoint` is in the
+    // bundled IFC2X3 export, so it is not even an example of what this
+    // paragraph describes.
     //
     // A genuine query for the Unknown bucket is still made by passing the
     // literal string `'Unknown'`.

--- a/packages/query/test/oftype-unknown-type.test.ts
+++ b/packages/query/test/oftype-unknown-type.test.ts
@@ -94,9 +94,15 @@ const STANDARD_BUT_UNMAPPED = [
   'IfcAudioVisualAppliance',
   'IfcDoorStyle',
   'IfcWindowStyle',
-  // IFC2X3 leaf that no bundled EXPRESS export carries; the parser's
-  // `ENTITY_NAME_ALIASES` is the only table that knows it.
-  'IfcElectricalDistributionPoint',
+  // IFCELECTRIC-, not IFCELECTRICAL-. This entry named the latter, and said
+  // no bundled EXPRESS export carries it and that `ENTITY_NAME_ALIASES` was
+  // "the only table that knows it". Both halves were wrong for the same
+  // reason: that name is not an IFC entity at all, so the only thing that
+  // "knew" it was an alias key misspelled to match. The real entity is in
+  // ENTITIES_IFC2X3 (`IfcFlowController`), which is why it does not throw —
+  // it is genuinely unmapped by `TYPE_STRING_TO_ENUM`, which is what this
+  // list is for.
+  'IfcElectricDistributionPoint',
 ] as const;
 
 /**

--- a/rust/core/src/legacy_entities.rs
+++ b/rust/core/src/legacy_entities.rs
@@ -105,7 +105,7 @@ pub fn get_legacy_entity_info(entity_name: &str) -> Option<LegacyEntityInfo> {
             base_type: IfcType::IfcDistributionElement,
             has_geometry: true,
         }),
-        "IFCELECTRICALDISTRIBUTIONPOINT" => Some(LegacyEntityInfo {
+        "IFCELECTRICDISTRIBUTIONPOINT" => Some(LegacyEntityInfo {
             base_type: IfcType::IfcDistributionElement,
             has_geometry: true,
         }),
@@ -146,4 +146,52 @@ pub fn is_legacy_entity(entity_name: &str) -> bool {
 /// Get the IFC4x3 base type for a legacy entity, or None if not legacy
 pub fn map_legacy_to_base_type(entity_name: &str) -> Option<IfcType> {
     get_legacy_entity_info(entity_name).map(|info| info.base_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A key here is a STEP keyword, and a keyword no file can contain is an
+    /// arm that never runs.
+    ///
+    /// This one was spelled `IFCELECTRICALDISTRIBUTIONPOINT`, with an "AL" the
+    /// real IFC2X3 entity does not have. `IfcElectricDistributionPoint` — an
+    /// `IfcFlowController`, carrying `ObjectPlacement` and `Representation` —
+    /// therefore missed the table, fell through to `IfcType::from_str` →
+    /// `Unknown`, and lost the `has_geometry: true` this arm exists to give it.
+    /// Nothing failed loudly: the entity was classified as not-geometry and
+    /// dropped from the meshing pass.
+    ///
+    /// The misspelling is asserted ABSENT as well as the real name present, so
+    /// re-adding it as an extra arm cannot quietly satisfy this test.
+    #[test]
+    fn electric_distribution_point_is_spelled_as_the_step_keyword() {
+        let info = get_legacy_entity_info("IFCELECTRICDISTRIBUTIONPOINT")
+            .expect("IFCELECTRICDISTRIBUTIONPOINT is a real IFC2X3 keyword and must resolve");
+        assert!(
+            info.has_geometry,
+            "IfcElectricDistributionPoint carries ObjectPlacement and Representation",
+        );
+
+        assert!(
+            get_legacy_entity_info("IFCELECTRICALDISTRIBUTIONPOINT").is_none(),
+            "IFCELECTRICALDISTRIBUTIONPOINT is not an IFC entity in any schema; \
+             an arm under that key can never match a file",
+        );
+    }
+
+    /// This table exists only for names the generated IFC4X3 schema does not
+    /// know. A key `from_str` already resolves would be dead weight at best and
+    /// a silent disagreement at worst, so pin that this one is still absent.
+    #[test]
+    fn the_repaired_key_is_absent_from_the_generated_schema() {
+        assert!(
+            matches!(
+                IfcType::from_str("IFCELECTRICDISTRIBUTIONPOINT"),
+                IfcType::Unknown(_)
+            ),
+            "if IFC4X3 ever gains this type, this arm should be deleted rather than shadow it",
+        );
+    }
 }

--- a/rust/core/src/schema_helpers.rs
+++ b/rust/core/src/schema_helpers.rs
@@ -73,7 +73,7 @@ where
 ///    [`is_non_geometric_spatial`] for how that exempt set is maintained.
 /// 2. Legacy IFC2x3 / removed-in-IFC4x3 names that aren't in the generated
 ///    enum (e.g. `IFCSLABELEMENTEDCASE`, `IFCBUILDINGELEMENT`, `IFCPROXY`,
-///    `IFCEQUIPMENTELEMENT`, `IFCELECTRICALDISTRIBUTIONPOINT`) resolve through
+///    `IFCEQUIPMENTELEMENT`, `IFCELECTRICDISTRIBUTIONPOINT`) resolve through
 ///    `legacy_entities::get_legacy_entity_info`, which carries a
 ///    `has_geometry` flag.
 /// 3. Reinforcement variants not covered above fall back to a substring

--- a/rust/core/src/schema_helpers_tests.rs
+++ b/rust/core/src/schema_helpers_tests.rs
@@ -115,7 +115,16 @@ fn building_bears_geometry() {
 fn legacy_ifc2x3_distribution_names_have_geometry() {
     // Routed through legacy_entities now (was an inline match arm).
     assert!(has_geometry_by_name("IFCEQUIPMENTELEMENT"));
-    assert!(has_geometry_by_name("IFCELECTRICALDISTRIBUTIONPOINT"));
+    // IFCELECTRIC-, not IFCELECTRICAL-. This assertion previously named the
+    // latter, which is not an entity in any IFC schema — so it passed against a
+    // table key that was misspelled the same way, and proved nothing about the
+    // real `IfcElectricDistributionPoint`, which was meanwhile getting no
+    // geometry at all. A test and a table agreeing on a typo is not coverage.
+    assert!(has_geometry_by_name("IFCELECTRICDISTRIBUTIONPOINT"));
+    assert!(
+        !has_geometry_by_name("IFCELECTRICALDISTRIBUTIONPOINT"),
+        "no IFC schema defines this name; recognising it would mean the typo came back",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Refs #3172 — the typo half of it, which is unambiguous. The larger gap in the same table needs a mapping decision and is untouched here.

`IfcElectricDistributionPoint` is a real, concrete IFC2X3 entity — `IfcFlowController`, carrying `ObjectPlacement` and `Representation`. Every place that claimed to handle it spelled it **`IfcElectricalDistributionPoint`**, with an "AL" that no IFC schema has.

## Four sites, two languages, all agreeing with each other

| site | what it did |
|---|---|
| `rust/core/src/legacy_entities.rs` | the map key — the arm could never match a real file |
| `rust/core/src/schema_helpers_tests.rs` | asserted `has_geometry_by_name` on the misspelling |
| `packages/parser/src/ifc-schema.ts` | `ENTITY_NAME_ALIASES` carried the same misspelled key |
| `packages/parser/test/known-type-across-schemas.test.ts` | asserted it resolves, calling it *"real, deprecated IFC2X3 syntax"* |

The TS alias comment says it mirrors `legacy_entities.rs`. It did — typo included.

**The consequence:** the real entity missed the table, fell through to `IfcType::from_str` → `Unknown`, and lost the `has_geometry: true` that arm exists to give it. The meshing pass then skipped it, silently. Nothing failed, because both languages' tests asserted a name that cannot occur, and both passed against tables misspelled the same way.

That is why "the tests are green" was not evidence here — the oracle shared the defect.

## Verified both directions

```
cargo test -p ifc-lite-core --lib   →  161 passed, 0 failed
```

Restoring the typo fails `electric_distribution_point_is_spelled_as_the_step_keyword` with *"IFCELECTRICDISTRIBUTIONPOINT is a real IFC2X3 keyword and must resolve"*. The new tests assert the misspelling is **absent** as well as the real name present, so re-adding it as an extra arm cannot quietly satisfy them.

## Two things deliberately not done

**The TS alias entry is kept, not deleted** — though on that side it is redundant. `ENTITIES_IFC2X3` does carry `IfcElectricDistributionPoint`, so `getInheritanceChain` reaches `IfcDistributionElement` through its real parents (`IfcFlowController` → `IfcDistributionFlowElement` → `IfcDistributionElement`) with no alias at all. It stays to keep lockstep with the Rust core, whose generated enum is IFC4X3-only and genuinely needs it. The comment there claimed no bundled table carries the entity — false for the corrected name — and is fixed too.

**`base_type` stays `IfcDistributionElement`.** The real parent is `IfcFlowController`, which exists in the Rust schema and would be more precise, but changing it changes classification for a live entity. That is a separate decision from repairing a name, and yours to make.

## Verification gap, stated plainly

The **TS side is not verified locally**: this worktree has no `node_modules`, and the one that had them lost its `.git` to an unrelated prune mid-session. The TS change is a key rename plus its matching test, and the parent chain quoted above was read out of the bundled table rather than assumed. CI runs those tests.

No changeset: `has_geometry` for a previously-unreachable key is a bug fix with no API change, and the packages affected are internal to the parse path — happy to add one if you would rather it appear in the notes.
