### PR TITLE
fix(scripts): stop the clash parity gate telling you to empty the union (#3192)

### DIFF
--- a/scripts/check-clash-degenerate-reason-parity.mjs
+++ b/scripts/check-clash-degenerate-reason-parity.mjs
@@ -26,7 +26,10 @@
  *
  * VACUITY GUARD: both extractors must come back non-empty. Two empty sets are
  * "equal", so an extractor broken by a refactor would otherwise turn this into
- * a check that passes by finding nothing.
+ * a check that passes by finding nothing. It reports under its OWN header and
+ * remedy: a blind extractor is not drift between the two declarations, and the
+ * parity remedy ("match the other side exactly, in both directions") would tell
+ * the reader to empty the union against a set read as empty.
  *
  * COMMENTS ARE STRIPPED FIRST on both sides, symmetrically: a reason named only
  * in prose must not stand in for a real one, in either language.
@@ -131,14 +134,46 @@ if (process.argv[1] && process.argv[1].endsWith('check-clash-degenerate-reason-p
   const failures = checkParity(rustSource, tsSource);
 
   if (failures.length > 0) {
-    console.error('\nClashSolidDegenerateReason has drifted from clash_solid.rs:\n');
+    // A vacuity failure is NOT drift between the two declarations, and the
+    // header must not say it is. `checkParity` returns early on that class
+    // (nothing is compared once a set is empty), so the two are mutually
+    // exclusive and this dispatch is unambiguous.
+    //
+    // Nor can the message name a culprit side: emptying an input produces the
+    // identical "extractor has drifted" text with the regexes untouched, so a
+    // moved source shape and a genuinely shrunken input are indistinguishable
+    // from here. Blame neither.
+    const drifted = failures.some((f) => f.includes('the extractor has drifted'));
+    console.error(
+      drifted
+        ? '\nthis gate could not read one of its inputs:\n'
+        : '\nClashSolidDegenerateReason has drifted from clash_solid.rs:\n',
+    );
     for (const f of failures) console.error(`  ${f}`);
-    console.error(`
+    if (drifted) {
+      // The update-the-union remedy is actively DESTRUCTIVE here. With the
+      // kernel set read as empty, "match exactly, in both directions" means
+      // empty the union -- which silences this gate and breaks the type every
+      // `as ClashSolidDegenerateReason` cast on the wasm boundary depends on.
+      console.error(`
+An extractor above returned NOTHING, so this gate compared nothing and is not
+reporting on parity at all. Do not touch the union on the strength of this run:
+with a set read as empty, "match the other side exactly" means EMPTY IT, which
+silences this gate and breaks the type the wasm boundary casts to.
+
+Two causes produce this identical message and nothing here can tell them apart:
+the source shape moved under this file's regexes, or the input genuinely shrank
+and the regexes are fine. Read the input named above and decide which, then fix
+that -- the extractor in this script, or the source.
+`);
+    } else {
+      console.error(`
 The reason crosses the wasm boundary as an untyped string and is cast on
 arrival, so TypeScript cannot catch this. Update the union in
 ${TS_REL}
 to match ${RUST_REL} exactly, in both directions.
 `);
+    }
     process.exit(1);
   }
 

--- a/scripts/check-clash-degenerate-reason-parity.test.mjs
+++ b/scripts/check-clash-degenerate-reason-parity.test.mjs
@@ -114,6 +114,32 @@ test('RED (vacuity guard) when BOTH extractors find nothing — two empty sets a
   assert.match(out, /no members extracted from ClashSolidDegenerateReason/);
 });
 
+test('the vacuity path does NOT print the update-the-union remedy', () => {
+  // The remedy is destructive for this class: with the kernel set read as
+  // empty, "match exactly, in both directions" means empty the union, which
+  // silences the gate and breaks the type the wasm boundary casts to. The
+  // header must not blame the union either -- nothing drifted between the two
+  // declarations, the gate simply could not read one of them.
+  const { status, out } = runOn({ rust: '// no reasons here at all\n' });
+  assert.equal(status, 1, out);
+  assert.match(out, /this gate could not read one of its inputs/);
+  assert.doesNotMatch(out, /to match .* exactly, in both directions/);
+  assert.doesNotMatch(out, /ClashSolidDegenerateReason has drifted from clash_solid\.rs/);
+  // And it must say plainly that no parity was assessed.
+  assert.match(out, /compared nothing/);
+});
+
+test('a real parity failure still gets the update-the-union remedy', () => {
+  // The other half of the dispatch: narrowing the vacuity path must not have
+  // taken the actual remedy away from the class that needs it.
+  const ts = replaceOnce(realTs, "  | 'malformed-operand'\n", '');
+  const { status, out } = runOn({ ts });
+  assert.equal(status, 1, out);
+  assert.match(out, /ClashSolidDegenerateReason has drifted from clash_solid\.rs/);
+  assert.match(out, /to match .* exactly, in both directions/);
+  assert.doesNotMatch(out, /this gate could not read one of its inputs/);
+});
+
 test('a reason named only in a comment does not count, on either side', () => {
   assert.deepEqual([...kernelReasons('    // - `"invented-reason"` — prose only.\n')], []);
   // Not just FULL-LINE `//`: a trailing comment and a `/* … */` block are prose


### PR DESCRIPTION
Fixes #3192.

`scripts/check-clash-degenerate-reason-parity.mjs` printed one fixed header and one fixed epilogue for every failure class it can raise, including the vacuity class where its own extractor came back empty. For that class both were wrong, and following the printed instruction breaks the type the gate guards.

## Reproduction (before)

Blinding the Rust extractor while leaving the TS union correct and untouched:

```
ClashSolidDegenerateReason has drifted from clash_solid.rs:

  no reason strings extracted from rust/wasm-bindings/src/api/clash_solid.rs — the extractor has drifted from the Rust source

The reason crosses the wasm boundary as an untyped string and is cast on
arrival, so TypeScript cannot catch this. Update the union in
apps/viewer/src/lib/clash/intersection-solid.ts
to match rust/wasm-bindings/src/api/clash_solid.rs exactly, in both directions.
```

Nothing drifted. And with the kernel set read as empty, "match exactly, in both directions" means **empty the union** — which silences the gate and breaks every `as ClashSolidDegenerateReason` cast on the wasm boundary.

## After

```
this gate could not read one of its inputs:

  no reason strings extracted from rust/wasm-bindings/src/api/clash_solid.rs — the extractor has drifted from the Rust source

An extractor above returned NOTHING, so this gate compared nothing and is not
reporting on parity at all. Do not touch the union on the strength of this run:
with a set read as empty, "match the other side exactly" means EMPTY IT, which
silences this gate and breaks the type the wasm boundary casts to.

Two causes produce this identical message and nothing here can tell them apart:
the source shape moved under this file's regexes, or the input genuinely shrank
and the regexes are fine. Read the input named above and decide which, then fix
that -- the extractor in this script, or the source.
```

`checkParity` already returns early on the vacuity class, so vacuity and the missing/phantom classes are mutually exclusive and the two-way dispatch is unambiguous.

Per #3191, the remedy names no culprit side: emptying an input produces the identical "the extractor has drifted" message with the regexes untouched, so a moved source shape and a genuinely shrunken input cannot be told apart from inside the script.

## The guard itself was already fine

Worth stating plainly, since the issue title reads like a blindness bug: the vacuity **guard** is correct and untouched. An empty extractor result has always failed this gate closed (`checkParity`, lines 98-107). This is a reporting defect only — the gate went red for the right reason and then gave destructive advice.

## Proof it still catches a real violation

Renaming one union member in the working tree:

```
ClashSolidDegenerateReason has drifted from clash_solid.rs:

  the kernel can emit 'no-overlap' but ClashSolidDegenerateReason does not declare it
  ClashSolidDegenerateReason declares 'no-overlap-renamed' but the kernel can never emit it
```

Both directions named, correct header, correct remedy. Reverted by the inverse edit and confirmed byte-identical.

## Tests

Two new self-test cases pin both halves of the dispatch: the vacuity path prints the neutral header and does NOT print the update-the-union remedy, and a real parity failure still does. Verified RED against the pre-fix script (`not ok 8 - the vacuity path does NOT print the update-the-union remedy`). Suite: 12/12 green after, and the gate passes on the unmodified tree.

## No changeset

CI-only script change; no published package behaviour moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
