### PR TITLE
fix(scripts): refuse a vacuous pass in three gates that scanned nothing (#3194)

### DIFF
--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -302,16 +302,41 @@ export function auditPackage(pkgDir, pkgJson) {
   return { testLooking, matched, missed };
 }
 
+/**
+ * Does this path exist? Throws if the answer is UNKNOWABLE.
+ *
+ * `existsSync` answers false for every failure, including EACCES, so an
+ * unreadable directory is indistinguishable from an absent one. That is the
+ * same "absence reads as success" defect this gate was fixed for -- one stage
+ * earlier, in DISCOVERY rather than in the walk. Measured before this change:
+ * a `chmod 000` package carrying a real test script reported
+ * `OK (1 packages audited, 0 unrun test files)` and exit 0, with the locked
+ * package silently missing from the count.
+ */
+function existsOrThrow(path, what) {
+  try {
+    statSync(path);
+    return true;
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    fail(
+      `cannot read ${what} ${path}: ${err.code || err.message}. ` +
+        'Refusing to treat an unreadable path as an absent one -- that is how a ' +
+        'package drops out of the audit without anyone noticing.',
+    );
+  }
+}
+
 export function listPackages(root, seenParents = []) {
   const out = [];
   for (const parent of PACKAGE_PARENTS) {
     const parentDir = join(root, parent);
-    if (!existsSync(parentDir)) continue;
+    if (!existsOrThrow(parentDir, 'package parent')) continue;
     seenParents.push(parent);
     for (const name of readdirSync(parentDir).sort()) {
       const pkgDir = join(parentDir, name);
       const pkgJsonPath = join(pkgDir, 'package.json');
-      if (!existsSync(pkgJsonPath)) continue;
+      if (!existsOrThrow(pkgJsonPath, 'package manifest')) continue;
       let pkgJson;
       try {
         pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -52,6 +52,16 @@
  * which is the CI lane that enforces it. Its own regression harness runs in
  * .github/workflows/test.yml.
  *
+ * ANTI-VACUITY (#3194): this checker used to print
+ * `OK (0 packages audited, 0 unrun test files)` and exit 0 when it found no
+ * packages at all — a scan of nothing reported as a clean scan. Three guards
+ * now stand between an empty input set and that success line: neither
+ * `packages/` nor `apps/` existing is a failure, zero packages found is a
+ * failure, and (against the real repo, where a collapse would otherwise be
+ * invisible) fewer than AUDITED_FLOOR packages actually audited is a failure.
+ * A directory that cannot be read is loud too, and distinguished from one that
+ * is missing — they call for different fixes.
+ *
  * Blind spot, stated so nobody mistakes its OK for a whole-repo claim: it
  * audits `packages/*` and `apps/*` only. Test files under `scripts/` are
  * covered by the glob catch-all step in that workflow, and that the catch-all
@@ -87,6 +97,19 @@ const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|js|mjs)$/;
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', 'generated']);
 const PACKAGE_PARENTS = ['packages', 'apps'];
 
+/**
+ * Lower bound on how many packages must actually get audited when this runs
+ * against the real repo. Measured on a healthy tree: 49 directories under
+ * `packages/` + `apps/`, 47 of which carry a `test` script and so reach the
+ * audit. Set to 30 — roughly a third of headroom, enough that ordinary churn
+ * (a package split, a few merged or retired) never forces an edit here, while
+ * the failure this guards against still trips: every way this checker can go
+ * blind (a wrong scan root, a `readdirSync` that returns nothing, a
+ * package.json read that stops finding files) collapses the count to zero or
+ * near it, not to 29.
+ */
+const AUDITED_FLOOR = 30;
+
 /** All test-looking files under `dir`, as paths relative to `dir`, POSIX-separated. */
 export function findTestLookingFiles(dir) {
   const found = [];
@@ -98,10 +121,17 @@ function walk(root, dir, found) {
   let entries;
   try {
     entries = readdirSync(dir);
-  } catch {
-    // Fail closed elsewhere (a missing package dir is a caller bug); an
-    // unreadable subdirectory here is treated as empty rather than crashing
-    // the whole audit over one package.
+  } catch (err) {
+    // A directory that is MISSING and one that cannot be READ are different
+    // events, and neither of them is "this package has no test files". The
+    // previous `catch { return; }` collapsed both into an empty result, which
+    // is how this checker could audit a tree it never opened and still print
+    // OK (#3194). Both are loud now, with the two cases distinguished.
+    fail(
+      err?.code === 'ENOENT'
+        ? `${dir} does not exist — refusing to treat a missing directory as one containing no test files`
+        : `${dir} could not be read (${err?.code ?? err?.message}) — refusing to treat an unreadable directory as one containing no test files`,
+    );
     return;
   }
   for (const entry of entries) {
@@ -110,8 +140,13 @@ function walk(root, dir, found) {
     let st;
     try {
       st = statSync(full);
-    } catch {
-      continue;
+    } catch (err) {
+      // A dangling symlink is a real and benign thing to meet mid-walk, and
+      // it is genuinely not a test file. Anything else (a permissions error,
+      // a filesystem fault) is not something to walk past in silence.
+      if (err?.code === 'ENOENT') continue;
+      fail(`${full} could not be stat'ed (${err?.code ?? err?.message}) — refusing to skip an entry this checker could not classify`);
+      return;
     }
     if (st.isDirectory()) {
       walk(root, full, found);
@@ -267,11 +302,12 @@ export function auditPackage(pkgDir, pkgJson) {
   return { testLooking, matched, missed };
 }
 
-export function listPackages(root) {
+export function listPackages(root, seenParents = []) {
   const out = [];
   for (const parent of PACKAGE_PARENTS) {
     const parentDir = join(root, parent);
     if (!existsSync(parentDir)) continue;
+    seenParents.push(parent);
     for (const name of readdirSync(parentDir).sort()) {
       const pkgDir = join(parentDir, name);
       const pkgJsonPath = join(pkgDir, 'package.json');
@@ -289,7 +325,28 @@ export function listPackages(root) {
 }
 
 function main() {
-  const packages = listPackages(ROOT);
+  const seenParents = [];
+  const packages = listPackages(ROOT, seenParents);
+
+  // Anti-vacuity, structural: true of the real repo AND of every synthetic
+  // fixture tree the regression harness builds, so it costs the harness
+  // nothing while making "the scan root was wrong" impossible to mistake for
+  // "the audit was clean".
+  if (seenParents.length === 0) {
+    fail(
+      `none of ${PACKAGE_PARENTS.map((p) => `${p}/`).join(', ')} exists under ${ROOT}. ` +
+        `Refusing a vacuous pass: this checker exists to audit workspace packages and found nowhere to look for them.`,
+    );
+    return;
+  }
+  if (packages.length === 0) {
+    fail(
+      `${seenParents.map((p) => `${p}/`).join(' and ')} contain no directory with a package.json under ${ROOT}. ` +
+        `Refusing a vacuous pass: a scan that found zero packages has proved nothing about test-glob coverage.`,
+    );
+    return;
+  }
+
   const offenders = [];
   let audited = 0;
 
@@ -314,6 +371,21 @@ Either widen the test script's glob / vitest "include" to reach these files
 if they are dead and should be deleted, delete them. Do not add a skip.
 `);
     process.exitCode = 1;
+    return;
+  }
+
+  // Anti-vacuity, quantitative. Only meaningful against the real repo: the
+  // regression harness drives synthetic trees of a handful of packages
+  // through `--root`, and one of its cases deliberately audits zero (a
+  // package with no `test` script at all is check-test-wiring's business).
+  // So the floor applies exactly where a silent collapse would be invisible.
+  if (rootFlagIdx === -1 && audited < AUDITED_FLOOR) {
+    fail(
+      `only ${audited} package(s) audited, floor is ${AUDITED_FLOOR}. ` +
+        `Refusing a vacuous pass: this repo has about 47 packages with a \`test\` script, so a count this low means the ` +
+        `package walk or the package.json read stopped working, not that the packages went away. ` +
+        `If packages were genuinely removed, lower AUDITED_FLOOR in the same commit.`,
+    );
     return;
   }
 

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -228,6 +228,41 @@ test('vacuity: a packages/ dir holding no package.json fails instead of reportin
   }
 });
 
+test('an UNREADABLE package is not silently treated as an absent one', () => {
+  // Package DISCOVERY used `existsSync`, which answers false for every
+  // failure, EACCES included -- so a package the gate could not open dropped
+  // out of the audit with no error. Measured before the fix, against a
+  // `chmod 000` package carrying a real test script:
+  //
+  //   check-test-glob-coverage: OK (1 packages audited, 0 unrun test files)
+  //   EXIT=0
+  //
+  // which is this gate's own "absence reads as success" defect, one stage
+  // earlier than the walk it was fixed for.
+  //
+  // The fixture is a FILE where a package directory belongs, so `package.json`
+  // underneath it fails with ENOTDIR. That is deliberate: `chmod 000` does not
+  // stop root, and CI containers routinely run as root, so a permissions-based
+  // fixture would pass here and quietly not test anything on the machine that
+  // matters. ENOTDIR is the same "not ENOENT" branch and is deterministic for
+  // every user.
+  const dir = writeTree({
+    'packages/real-one/package.json': JSON.stringify({ name: 'real-one', scripts: { test: 'vitest run' } }),
+    'packages/real-one/src/a.test.ts': 'x',
+    // Not a directory. Statting `packages/blocked/package.json` gives ENOTDIR.
+    'packages/blocked': 'i am a file, not a package directory\n',
+  });
+  try {
+    const { status, out } = runOn(dir);
+    assert.equal(status, 1, `expected a non-zero exit on an unreadable package, got ${status}: ${out}`);
+    assert.match(out, /cannot read package manifest/);
+    assert.match(out, /Refusing to treat an unreadable path as an absent one/);
+    assert.doesNotMatch(out, /OK \(/, 'must not print a success line at all');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // --- Direct unit tests on the exported glob helpers ---
 
 test('globToRegExp: ** matches zero or more path segments', () => {

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -22,6 +22,10 @@
  *                   include: ['test/**\/*.test.ts']
  *   zero-tests      "vitest run"                   0 test-looking, 0 matched
  *
+ * Two further cases cover anti-vacuity (#3194) rather than glob semantics: a
+ * root with no package parents at all, and a package parent holding no
+ * package.json. Both used to exit 0 with a success line.
+ *
  * Run: node --test scripts/check-test-glob-coverage.test.mjs
  */
 
@@ -180,6 +184,45 @@ test('a find-based recursive command (apps\\/viewer\'s shape) reaches nested tes
     const { status, out } = runOn(dir);
     assert.equal(status, 0, out);
     assert.match(out, /check-test-glob-coverage: OK \(1 packages audited, 0 unrun test files\)/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- Anti-vacuity: a scan that found nothing must not report a clean audit ---
+//
+// Issue #3194: this checker printed `OK (0 packages audited, 0 unrun test
+// files)` and exited 0 when pointed at a tree with no packages in it, so CI
+// read "we looked and it was clean" from a run that had looked at nothing.
+// Both shapes of nothing get a case, because they fail at different points.
+
+test('vacuity: a root with neither packages/ nor apps/ fails instead of reporting a clean audit', () => {
+  // mkdtemp gives a real, readable, EMPTY directory — the exact input that
+  // used to exit 0.
+  const dir = mkdtempSync(join(tmpdir(), 'test-glob-coverage-empty-'));
+  try {
+    const { status, out } = runOn(dir);
+    assert.equal(status, 1, `expected a non-zero exit on an empty tree, got ${status}: ${out}`);
+    assert.match(out, /Refusing a vacuous pass/);
+    assert.match(out, /none of packages\/, apps\/ exists/);
+    assert.doesNotMatch(out, /OK \(/, 'must not print a success line at all');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('vacuity: a packages/ dir holding no package.json fails instead of reporting a clean audit', () => {
+  const dir = writeTree({
+    // A parent that exists but holds nothing this checker recognises as a
+    // package: the walk succeeds, the package list comes back empty.
+    'packages/not-a-package/README.md': '# no package.json here\n',
+  });
+  try {
+    const { status, out } = runOn(dir);
+    assert.equal(status, 1, `expected a non-zero exit on a package-less tree, got ${status}: ${out}`);
+    assert.match(out, /Refusing a vacuous pass/);
+    assert.match(out, /contain no directory with a package\.json/);
+    assert.doesNotMatch(out, /OK \(/, 'must not print a success line at all');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/check-wasm-disposal.mjs
+++ b/scripts/check-wasm-disposal.mjs
@@ -78,12 +78,50 @@ const DISPOSABLE_CLASSES = new Set(['GeometryProcessor']);
  */
 const ALLOWLIST = new Map([]);
 
+/**
+ * Lower bound on how many source files the walk must reach. Measured on a
+ * healthy tree: 2002 non-test `.ts`/`.tsx`/`.mts` files under
+ * `apps/` + `packages/`. Set to 1200 — deep headroom, because
+ * this number only has to separate "the walk works" from "the walk found
+ * nothing", and every way it breaks (a wrong root, an unreadable directory, a
+ * cwd change) takes it to zero, never to a plausible-looking fraction.
+ */
+const SOURCE_FLOOR = 1200;
+
+/**
+ * Lower bound on how many disposable-handle constructions the AST detector
+ * must still find. Measured on a healthy tree: 27. Set to
+ * 18 — a third of headroom, so the ordinary
+ * arrival and removal of call sites does not force an edit here, while the
+ * failure this guards against (a `ts` API change, a rename in
+ * DISPOSABLE_CLASSES, a visitor that stops recursing) still trips: each of
+ * those drops the count to zero, not to 17.
+ */
+const CONSTRUCTION_FLOOR = 18;
+
+/**
+ * Fails closed on a directory it cannot read. The old `catch { return out; }`
+ * turned a missing scan root, a typo'd path and a permissions error alike into
+ * "no source files here", which let the whole gate print its success line
+ * having opened nothing at all (#3194). The two cases are distinguished
+ * because they call for different fixes: a MISSING directory means SCAN_DIRS
+ * or the working directory is wrong; an UNREADABLE one is an environment
+ * fault. Neither is a clean scan.
+ */
 function findSourceFiles(dir, out = []) {
   let entries;
   try {
     entries = readdirSync(dir);
-  } catch {
-    return out;
+  } catch (err) {
+    const why =
+      err?.code === 'ENOENT'
+        ? `does not exist — SCAN_DIRS in this gate, or the tree it was pointed at, is wrong`
+        : `could not be read (${err?.code ?? err?.message})`;
+    console.error(
+      `\n\u274c check-wasm-disposal: ${relative(ROOT, dir) || dir} ${why}.\n` +
+        `Refusing a vacuous pass: a directory this gate cannot open is a broken scan, not a clean one.\n`,
+    );
+    process.exit(1);
   }
   for (const entry of entries) {
     if (SKIP_DIRS.has(entry) || entry.startsWith('.')) continue;
@@ -336,9 +374,12 @@ function isFactoryBody(newExpr) {
 const violations = [];
 const accepted = { using: 0, finally: 0, factory: 0, allowlisted: 0, escapes: 0, disposer: 0 };
 let scanned = 0;
+let walked = 0;
 
 for (const scanDir of SCAN_DIRS) {
-  for (const file of findSourceFiles(join(ROOT, scanDir))) {
+  const sources = findSourceFiles(join(ROOT, scanDir));
+  walked += sources.length;
+  for (const file of sources) {
     const text = readFileSync(file, 'utf8');
     if (![...DISPOSABLE_CLASSES].some((c) => text.includes(`new ${c}`))) continue;
     scanned++;
@@ -381,6 +422,30 @@ for (const scanDir of SCAN_DIRS) {
 const total =
   violations.length + accepted.using + accepted.finally + accepted.factory + accepted.allowlisted + accepted.escapes + accepted.disposer;
 
+// Anti-vacuity, checked BEFORE the violation report so a broken scan can never
+// be reported as either a pass or a (differently wrong) small failure. Two
+// independent floors, because this gate has two ways to go blind and each one
+// leaves the other's number looking healthy: the WALK can stop finding source
+// files, or the walk can succeed while the AST detector stops recognising
+// constructions.
+if (walked < SOURCE_FLOOR) {
+  console.error(
+    `\n\u274c check-wasm-disposal: only ${walked} source file(s) walked under ${SCAN_DIRS.join(', ')}, floor is ${SOURCE_FLOOR}.\n` +
+      `Refusing a vacuous pass: the file walk found almost nothing, so this gate has proved nothing about\n` +
+      `WASM-handle disposal. Check the scan roots and the working directory before touching SOURCE_FLOOR.\n`,
+  );
+  process.exit(1);
+}
+if (total < CONSTRUCTION_FLOOR) {
+  console.error(
+    `\n\u274c check-wasm-disposal: only ${total} \`new ${[...DISPOSABLE_CLASSES].join('`/`new ')}\` construction(s) found, floor is ${CONSTRUCTION_FLOOR}.\n` +
+      `Refusing a vacuous pass: the walk saw ${walked} file(s), so the files are there and it is the detector\n` +
+      `that stopped matching. If the constructions were genuinely removed, lower CONSTRUCTION_FLOOR in the\n` +
+      `same commit — that keeps "this PR reduced the gate's reach" a reviewable line in the diff.\n`,
+  );
+  process.exit(1);
+}
+
 if (violations.length > 0) {
   console.error(
     `❌ ${violations.length} WASM-handle construction(s) with no deterministic release:\n`,
@@ -408,5 +473,5 @@ console.log(
   `✅ All ${total} WASM-handle construction(s) release deterministically ` +
     `(${accepted.using} using, ${accepted.finally} try/finally, ${accepted.factory} factory, ` +
     `${accepted.disposer} disposer-owned, ${accepted.escapes} ownership-transferred, ${accepted.allowlisted} allowlisted) ` +
-    `across ${scanned} file(s).`,
+    `across ${scanned} file(s) with a construction, out of ${walked} source file(s) walked.`,
 );

--- a/scripts/check-wasm-disposal.mjs
+++ b/scripts/check-wasm-disposal.mjs
@@ -126,7 +126,18 @@ function findSourceFiles(dir, out = []) {
   for (const entry of entries) {
     if (SKIP_DIRS.has(entry) || entry.startsWith('.')) continue;
     const full = join(dir, entry);
-    if (statSync(full).isDirectory()) findSourceFiles(full, out);
+    // A dangling symlink is not a source file, but it is also not a reason to
+    // die with a raw stack trace -- a stale build artifact or a bad checkout
+    // leaves them around. Anything OTHER than "the target is gone" is a broken
+    // scan and stays loud, matching how this walk treats an unreadable dir.
+    let st;
+    try {
+      st = statSync(full);
+    } catch (err) {
+      if (err.code === 'ENOENT') continue;
+      throw err;
+    }
+    if (st.isDirectory()) findSourceFiles(full, out);
     else if (SOURCE_RE.test(entry) && !TEST_RE.test(entry)) out.push(full);
   }
   return out;

--- a/scripts/check-whole-state-reset.mjs
+++ b/scripts/check-whole-state-reset.mjs
@@ -75,13 +75,42 @@ const WHOLE_STATE_PATTERNS = [
  *  Generous: a `set()` call can be a few lines below the signature line. */
 const WINDOW = 6;
 
+/**
+ * Lower bound on how many slice files must actually be read. Measured on a
+ * healthy tree: 70 non-test `.ts` files across the three DIRS (106 + 34 + 13
+ * entries, minus their `.test.ts` siblings). Set to 45 — about a third of
+ * headroom, so the steady churn of slices being added, split and retired never
+ * forces an edit here, while the failure mode this exists for still trips.
+ * That failure mode is not a gradual decline: every way this script can go
+ * blind (a renamed `store/` directory, a wrong ROOT, a `readdirSync` that
+ * returns nothing) takes the count to zero or to one directory's worth, not
+ * to 44.
+ */
+const SCANNED_FLOOR = 45;
+
+/**
+ * Fails loudly on both halves of what the old `catch { return []; }` collapsed
+ * into "no files here": a directory that DOES NOT EXIST (a moved or renamed
+ * path, which this script must not silently outlive) and one that exists but
+ * CANNOT BE READ (a permissions error, a filesystem fault). Neither is a
+ * clean scan, and reporting one as a clean scan is the defect in #3194.
+ */
 function listTsFiles(relDir) {
   const abs = join(ROOT, relDir);
   let entries;
   try {
     entries = readdirSync(abs, { withFileTypes: true });
-  } catch {
-    return [];
+  } catch (err) {
+    const why =
+      err?.code === 'ENOENT'
+        ? 'does not exist — it was moved or renamed, and DIRS in this script was not updated'
+        : `could not be read (${err?.code ?? err?.message})`;
+    console.error(
+      `\ncheck-whole-state-reset: scan directory ${relDir} ${why}.\n` +
+        `Refusing a vacuous pass: this script expects to read zustand slice files there, and a\n` +
+        `directory it cannot open is a broken scan, not a clean one.\n`,
+    );
+    process.exit(1);
   }
   return entries
     .filter((e) => e.isFile() && e.name.endsWith('.ts') && !e.name.endsWith('.test.ts'))
@@ -89,6 +118,18 @@ function listTsFiles(relDir) {
 }
 
 const files = DIRS.flatMap(listTsFiles);
+
+if (files.length < SCANNED_FLOOR) {
+  console.error(
+    `\ncheck-whole-state-reset: only ${files.length} slice file(s) found, floor is ${SCANNED_FLOOR}.\n` +
+      `Refusing a vacuous pass: expected the zustand slices under\n` +
+      DIRS.map((d) => `  ${d}\n`).join('') +
+      `A count this low means the scan broke, not that the store shrank. If the slices were\n` +
+      `genuinely consolidated, lower SCANNED_FLOOR in the same commit.\n`,
+  );
+  process.exit(1);
+}
+
 const violations = [];
 const scanned = [];
 


### PR DESCRIPTION
Fixes the three gates in #3194 that printed their success line and exited 0 after walking a directory that was not there.

Each swallowed the failed `readdirSync` with a bare `catch`, returned an empty file list, and had no floor between "found nothing" and "found nothing wrong".

## The defect, before

```
$ node scripts/check-test-glob-coverage.mjs --root <empty dir>
check-test-glob-coverage: OK (0 packages audited, 0 unrun test files)
EXIT=0

$ node <empty-tree>/scripts/check-whole-state-reset.mjs
check-whole-state-reset: OK (0 files scanned, 0 candidates)
EXIT=0

$ node <empty-tree>/scripts/check-wasm-disposal.mjs
✅ All 0 WASM-handle construction(s) release deterministically (0 using, 0 try/finally, 0 factory, 0 disposer-owned, 0 ownership-transferred, 0 allowlisted) across 0 file(s).
EXIT=0
```

Two of the three take no `--root`, so they were exercised by running a copy of the script from an otherwise-empty tree (`ROOT` is derived from the script's own location).

## After

```
$ node scripts/check-test-glob-coverage.mjs --root <empty dir>
check-test-glob-coverage: none of packages/, apps/ exists under <empty dir>. Refusing a vacuous pass: this checker exists to audit workspace packages and found nowhere to look for them.
EXIT=1

$ node <empty-tree>/scripts/check-whole-state-reset.mjs
check-whole-state-reset: scan directory apps/viewer/src/store/slices does not exist — it was moved or renamed, and DIRS in this script was not updated.
Refusing a vacuous pass: this script expects to read zustand slice files there, and a
directory it cannot open is a broken scan, not a clean one.
EXIT=1

$ node <empty-tree>/scripts/check-wasm-disposal.mjs
❌ check-wasm-disposal: apps does not exist — SCAN_DIRS in this gate, or the tree it was pointed at, is wrong.
Refusing a vacuous pass: a directory this gate cannot open is a broken scan, not a clean one.
EXIT=1
```

The quantitative floors were exercised separately, against a tree where the scan directories exist but are nearly empty (so the missing-directory branch does not fire first):

```
check-whole-state-reset: only 2 slice file(s) found, floor is 45. ...
❌ check-wasm-disposal: only 2 source file(s) walked under apps, packages, floor is 1200. ...
check-test-glob-coverage: only 1 package(s) audited, floor is 30. ...
```

## Real repo still passes

```
check-test-glob-coverage: OK (47 packages audited, 0 unrun test files)          EXIT=0
check-whole-state-reset: OK (70 files scanned, 0 candidates)                    EXIT=0
✅ All 27 WASM-handle construction(s) release deterministically (0 using, 17 try/finally,
   5 factory, 1 disposer-owned, 4 ownership-transferred, 0 allowlisted) across 26 file(s)
   with a construction, out of 2002 source file(s) walked.                      EXIT=0
```

## Floors

Follows the idiom already used by most gates here — see `check-refwalk-guards.mjs`'s `CANDIDATE_FLOOR` and `check-csv-escaper-copies.mjs`'s small-file-list check. Each floor is measured on a healthy tree, not picked round, with about a third of headroom:

| gate | measured | floor |
| --- | --- | --- |
| `check-test-glob-coverage` | 47 packages audited (of 49 dirs) | `AUDITED_FLOOR` 30 |
| `check-whole-state-reset` | 70 non-test slice files | `SCANNED_FLOOR` 45 |
| `check-wasm-disposal` | 2002 source files walked | `SOURCE_FLOOR` 1200 |
| `check-wasm-disposal` | 27 constructions found | `CONSTRUCTION_FLOOR` 18 |

The gap is wide in every case because the failure is not a gradual decline — every way these scans break takes the count to zero, not to one under the floor. `check-wasm-disposal` gets two floors because it has two independent ways to go blind and each leaves the other's number looking healthy: the walk can stop finding files, or the walk can succeed while the AST detector stops recognising constructions.

`check-test-glob-coverage`'s quantitative floor applies only when it runs against the real repo. Its regression harness drives synthetic fixture trees of a handful of packages through `--root`, and one case deliberately audits zero (a package with no `test` script is `check-test-wiring`'s business). The structural guards — no package parent exists, or zero packages found — apply everywhere, and are what catch the empty tree.

## The bare `catch`

A MISSING directory and an UNREADABLE one are different events calling for different fixes, so both are now loud and reported distinctly: a permissions error or a typo'd path no longer reads as "nothing here". The one deliberate exception is a dangling symlink met mid-walk in `check-test-glob-coverage`'s `statSync`, which really is not a test file and is skipped with the reason stated in a comment.

## Tests

`check-test-glob-coverage.mjs` has a self-test harness, and two vacuity cases were added to it (a root with no package parents, and a package parent holding no `package.json`) — both used to exit 0 with a success line. The suite goes 9 → 11 tests, all passing. The other two gates have no test file of their own, so none was invented for them.

`node --test scripts/*.test.mjs`: 348 pass, 0 fail. `pnpm lint` exits 0 with no baseline change (`scripts/check-unused-locals.mjs`: "No new unused locals (50 packages, 948 known, none increased)").

## Scope

`check-api-surface.mjs --update` writing an empty snapshot, also named in the issue, is deliberately left alone.

No changeset: all three are CI-only scripts under `scripts/`, publishing no workspace package.

Refs #3194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Automated repository checks now fail clearly when scan locations are missing, unreadable, empty, or incomplete.
  - Validation no longer reports success when no packages, source files, or state-reset files can be discovered.
  - Filesystem errors now produce actionable diagnostics, while dangling links continue to be handled safely.
  - Successful scan reports include useful coverage counts.

- **Tests**
  - Added regression coverage for empty repositories, missing package trees, unreadable paths, and other vacuous scan scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->