### PR TITLE
feat(ci): enforce "never assert on a source file's text" in rust/ too (#3195)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -590,6 +590,20 @@ jobs:
       # it must not.
       - name: Check the source-text detector's own regressions
         run: node --test scripts/check-source-text-assertions.test.mjs
+      # That gate's SCAN SCOPE is packages/ and apps/ only -- `grep -c rust` over
+      # it returns 0 -- so the same AGENTS.md rule was unenforced across the
+      # whole rust/ tree, demonstrated rather than inferred: a genuine
+      # `fs::read_to_string(".../foo.rs")` plus a `contains` planted in a real
+      # Rust test left CI green (#3129, then #3195). This is the sibling gate,
+      # with its own lexer, because the TypeScript one's precision comes from a
+      # real parse tree that a regex pass sharing the file would erode.
+      # Its own tests run FIRST, for the reason the refwalk pair states: this
+      # check's value is entirely in not passing vacuously, so a broken detector
+      # must fail here rather than report a clean tree.
+      - name: Check Rust source-text gate's own tests
+        run: node --test scripts/check-rust-source-text-assertions.test.mjs
+      - name: Check for source-text assertions in Rust tests
+        run: node scripts/check-rust-source-text-assertions.mjs
       # A walk that follows a file-supplied entity reference with no visited set
       # and no depth cap overflows the Rust stack on a self-referential
       # reference, which is SIGABRT rather than a catchable panic -- in the wasm

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "check:test-wiring": "node scripts/check-test-wiring.mjs",
     "check:test-glob-coverage": "node scripts/check-test-glob-coverage.mjs",
     "check:source-text-assertions": "node scripts/check-source-text-assertions.mjs",
+    "check:rust-source-text-assertions": "node scripts/check-rust-source-text-assertions.mjs",
     "check:refwalk-guards": "node scripts/check-refwalk-guards.mjs",
     "check:module-size": "node scripts/check-module-size.mjs",
     "lint:module-size-baseline": "node scripts/check-module-size.mjs --update",

--- a/scripts/check-rust-source-text-assertions.mjs
+++ b/scripts/check-rust-source-text-assertions.mjs
@@ -1,0 +1,311 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * GATE for issue #3195: AGENTS.md's "never assert on a source file's text" was
+ * unenforced across the whole `rust/` tree.
+ *
+ * `scripts/check-source-text-assertions.mjs` enforces that rule for `packages/`
+ * and `apps/`, and says so in its own header -- "SCAN SCOPE is packages/ and
+ * apps/ test files only". `grep -c rust` over that file returns 0. The
+ * maintainer demonstrated the consequence rather than inferring it: a genuine
+ * source-text assertion (`fs::read_to_string("src/api/space_plate_input.rs")`
+ * plus a `contains`) planted in a real Rust test left the gate exiting 0
+ * without naming the file (#3129).
+ *
+ * Run: `node scripts/check-rust-source-text-assertions.mjs`
+ * (also `pnpm check:rust-source-text-assertions`).
+ *
+ * ## SIBLING GATE, not an extension of the TypeScript one
+ *
+ * The issue offered two shapes and asked the maintainer to choose: fold a Rust
+ * pass into the existing script, or ship a sibling. He had not answered when
+ * this was built, so it is the sibling -- the issue's own stated
+ * recommendation -- and it is REVERSIBLE: the detector is a module with the
+ * same `analyze(text, relPath)` shape the TypeScript one has, so merging the
+ * two later is a call-site change, not a rewrite.
+ *
+ * The reason for the sibling is precision. The TypeScript detector's value is
+ * that it reads filenames out of a real TypeScript parse tree, which is what
+ * stops a comment naming `safe-path.test.ts` from being mistaken for an
+ * assertion. Rust has no parser here, so its detector is a hand-written lexer
+ * with the same PROPERTIES but none of the same code. Putting both in one file
+ * would invite a later "unification" that quietly regresses whichever one loses
+ * -- and the property at risk is the one three false positives were already
+ * paid for.
+ *
+ * ## What it flags
+ *
+ * A read (`include_str!`, `include_bytes!`, `fs::read`, `fs::read_to_string`,
+ * `File::open`) inside test code, whose path is spelled by a string literal
+ * with a SOURCE extension. Fixture reads -- `.ifc`, `.ifcx`, `.json`, a golden
+ * manifest -- are out of scope by construction rather than by exclusion; see
+ * scripts/lib/rust-source-text-detect.mjs, which carries the full design and
+ * the limitations.
+ *
+ * ## Vacuity
+ *
+ * Directly on point, and not hypothetical: three sibling gates were fixed days
+ * ago (#3194 / PR #3197) for passing green while scanning zero files, and
+ * `check-test-glob-coverage` was reproduced printing
+ * `OK (0 packages audited, 0 unrun test files)` with `EXIT=0`. So this one
+ * fails loudly on a missing scan root, a root with no `.rs` files, zero test
+ * files found, and a total read count below READ_FLOOR. The floor is the one
+ * that matters: a detector that silently stops matching (the lexer edited, a
+ * call name renamed) drops to zero reads and would otherwise report a clean
+ * tree, which is exactly the failure this whole family of issues is about.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync, realpathSync } from 'node:fs';
+import { join, dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { analyze, isTestPath } from './lib/rust-source-text-detect.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Scan root. The whole `rust/` tree, deliberately: the TypeScript gate's
+ * mistake was a scope narrower than the rule it enforces, and repeating that
+ * one crate at a time would be the same defect in a smaller box. Every crate
+ * under `rust/` carries tests.
+ */
+const SCAN_ROOTS = ['rust'];
+
+/** Build output and vendored trees hold no first-party tests. */
+const SKIP_DIRS = new Set(['target', 'node_modules', 'pkg', 'dist', 'build']);
+
+/**
+ * Lower bound on how many file reads the detector must still find in Rust test
+ * code. NOT a ceiling on violations (that bound is zero, enforced separately)
+ * -- this exists so the gate cannot pass by having stopped detecting anything.
+ *
+ * Measured at 108 reads across 413 files carrying test code on cd9405b52. Set
+ * to 90, a margin wide enough that ordinary churn does not force an edit, and
+ * narrow enough that a broken lexer -- every break measured while building this
+ * dropped the count to zero or near it -- still fails. If a real refactor
+ * removes reads, lower this in the same commit, which makes "this PR reduced
+ * the gate's reach" a reviewable line in the diff.
+ */
+const READ_FLOOR = 90;
+
+/**
+ * Allowlist for whole files that cannot be converted. EMPTY, and expected to
+ * stay empty: the tree has zero source-text assertions in Rust today, so a row
+ * here is a deliberate statement that a Rust test certifies a string rather
+ * than a behaviour. Prefer the per-site `// @source-text-assertion-ok <reason>`
+ * marker, which stays NAMED in this gate's output. Format, one path per line.
+ */
+const ALLOWLIST_PATH = join(ROOT, 'scripts', 'rust-source-text-assertion-allowlist.txt');
+
+/**
+ * Exact allowlist size, recorded HERE rather than in the allowlist: a ceiling
+ * derived from the file it guards is circular and always passes. Both
+ * directions fail, matching check-source-text-assertions.mjs and
+ * check-refwalk-guards.mjs, so growth must show up as an edit to this line.
+ */
+const ALLOWLIST_CEILING = 0;
+
+/**
+ * Fails closed on an unreadable directory: swallowing it would let the gate
+ * report success without having looked at the file that broke the rule.
+ *
+ * @param {string} dir
+ * @param {string[]} [out]
+ * @returns {string[]}
+ */
+function walk(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith('.') || SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (entry.endsWith('.rs')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * @param {string} path
+ * @returns {Set<string>}
+ */
+function loadAllowlist(path) {
+  if (!existsSync(path)) return new Set();
+  return new Set(
+    readFileSync(path, 'utf8')
+      .split('\n')
+      .map((line) => line.replace(/#.*$/, '').trim())
+      .filter(Boolean)
+  );
+}
+
+/**
+ * The whole check, as a function of a base directory, so its own tests can run
+ * it against a synthetic tree instead of the repo.
+ *
+ * @param {string} base
+ * @param {{ roots?: string[], allowlist?: Set<string>, readFloor?: number, allowlistCeiling?: number }} [opts]
+ * @returns {{ ok: boolean, errors: string[], reads: number, files: number, testFiles: number, offenders: string[], marked: string[], deadMarkers: string[] }}
+ */
+export function runCheck(base, opts = {}) {
+  const roots = opts.roots ?? SCAN_ROOTS;
+  const allowlist = opts.allowlist ?? loadAllowlist(ALLOWLIST_PATH);
+  const readFloor = opts.readFloor ?? READ_FLOOR;
+  const allowlistCeiling = opts.allowlistCeiling ?? ALLOWLIST_CEILING;
+
+  /** @type {string[]} */
+  const errors = [];
+  /** @type {string[]} */
+  const offenders = [];
+  /** @type {string[]} */
+  const marked = [];
+  /** @type {string[]} */
+  const deadMarkers = [];
+  const stale = new Set(allowlist);
+  let reads = 0;
+  let files = 0;
+  let testFiles = 0;
+
+  for (const root of roots) {
+    const abs = join(base, root);
+    if (!existsSync(abs)) {
+      errors.push(
+        `scan root missing: ${root}. The gate has nothing to check, which is a failure, not a pass — fix the path or remove the root.`
+      );
+      continue;
+    }
+    const found = walk(abs);
+    if (found.length === 0) {
+      errors.push(`scan root ${root} contains no .rs files. Refusing to report success on an empty input set.`);
+      continue;
+    }
+    files += found.length;
+    for (const file of found) {
+      const rel = relative(base, file).split('\\').join('/');
+      const text = readFileSync(file, 'utf8');
+      // Cheap pre-filter, so the lexer only runs where a test can live. It has
+      // to agree with the detector's own scope decision, so both consult
+      // `isTestPath` and the same `#[cfg(test)]` spelling.
+      if (!isTestPath(rel) && !/#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/.test(text)) continue;
+      testFiles++;
+      const result = analyze(text, rel);
+      reads += result.reads;
+      for (const line of result.unusedMarkers) deadMarkers.push(`${rel}:${line}`);
+      for (const site of result.marked) marked.push(`${rel}:${site.line}  ${site.path}  ${site.reason}`);
+      if (result.hits.length === 0) continue;
+      if (allowlist.has(rel)) {
+        stale.delete(rel);
+        continue;
+      }
+      for (const hit of result.hits) offenders.push(`${rel}:${hit.line}  ${hit.call} of ${hit.path}`);
+    }
+  }
+
+  if (testFiles === 0 && errors.length === 0) {
+    errors.push(
+      `found ${files} .rs files but not one test file among them. A tree with no tests to check is not a clean tree — refusing a vacuous pass.`
+    );
+  }
+  if (reads < readFloor) {
+    errors.push(
+      `only ${reads} file reads found in Rust test code, floor is ${readFloor}. Either the detector stopped working (check scripts/lib/rust-source-text-detect.mjs) or the reads were genuinely removed — if removed, lower READ_FLOOR in the same commit.`
+    );
+  }
+  if (stale.size > 0) {
+    errors.push(
+      `allowlisted files that no longer contain a source-text assertion (converted or deleted — remove the lines):\n  ${[...stale].join('\n  ')}`
+    );
+  }
+  if (allowlist.size !== allowlistCeiling) {
+    errors.push(
+      `allowlist has ${allowlist.size} entries but ALLOWLIST_CEILING reads ${allowlistCeiling}. Adding a row is a deliberate loosening of this gate and must be visible in review: edit the constant in the same commit. Removing one must lower it, or the ceiling drifts into slack.`
+    );
+  }
+
+  return {
+    ok: errors.length === 0 && offenders.length === 0 && deadMarkers.length === 0,
+    errors,
+    reads,
+    files,
+    testFiles,
+    offenders,
+    marked,
+    deadMarkers,
+  };
+}
+
+/**
+ * Is this module the process entry point?
+ *
+ * Comparing resolved PATHS rather than URLs, for the reason spelled out at
+ * length in scripts/check-refwalk-guards.mjs: `import.meta.url` is
+ * percent-encoded and resolved through symlinks, `process.argv[1]` is neither,
+ * so the obvious spelling fails on a checkout path containing a space and on
+ * macOS's `/var` -> `/private/var` symlink — silently, leaving the gate green
+ * having scanned nothing.
+ *
+ * @returns {boolean}
+ */
+function isMainEntry() {
+  const invoked = process.argv[1];
+  if (!invoked) return false;
+  const self = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(self) === realpathSync(invoked);
+  } catch {
+    return self === resolve(invoked);
+  }
+}
+
+if (isMainEntry()) {
+  const result = runCheck(ROOT);
+
+  if (result.offenders.length > 0) {
+    console.error('\nSource-text assertions found in Rust test code:\n');
+    for (const o of result.offenders) console.error(`  ${o}`);
+    console.error(`
+Each of these reads a SOURCE file from a test. That certifies a string exists,
+not that the code works — it stays green while the behaviour underneath it is
+broken, and goes red on a harmless rename (AGENTS.md, "Never assert on a source
+file's text"; the measured case is #2396, where a wiring test stayed 5/5 green
+with the row handler replaced by a no-op).
+
+Write a behavioural test instead: call the function, feed it the input that
+would exercise the string you were grepping for, and assert on what comes back.
+
+If the read is a MUTATION ANCHOR — asserting the anchor exists before a
+rewrite is built on it, so a rewrite that silently stops applying cannot leave
+the test asserting nothing — mark that site instead:
+
+  // @source-text-assertion-ok mutation anchor guard, not a subject assertion
+  let src = std::fs::read_to_string("../src/lib.rs").unwrap();
+
+Marked sites stay NAMED in this check's output; they are not exemptions in the
+dark. A whole file that cannot be converted at all goes in
+scripts/rust-source-text-assertion-allowlist.txt, which requires raising
+ALLOWLIST_CEILING in the same commit.
+`);
+  }
+
+  if (result.deadMarkers.length > 0) {
+    console.error(`\n${'@source-text-assertion-ok'} markers that excuse nothing:\n`);
+    for (const d of result.deadMarkers) console.error(`  ${d}`);
+    console.error(`
+Either the marker has no reason after it, or the read it excused is gone, moved
+or no longer names a source file. A marker sits inside the read's enclosing
+statement, on the line above where that statement starts, or trailing on the
+read's own line.
+`);
+  }
+
+  for (const e of result.errors) console.error(`\nrust-source-text-assertions: ${e}`);
+
+  if (!result.ok) process.exit(1);
+
+  for (const site of result.marked) {
+    console.log(`  marked @source-text-assertion-ok: ${site}`);
+  }
+  console.log(
+    `check-rust-source-text-assertions: OK (${result.files} .rs files, ${result.testFiles} with test code, ${result.reads} reads examined, 0 source-text assertions)`
+  );
+}

--- a/scripts/check-rust-source-text-assertions.test.mjs
+++ b/scripts/check-rust-source-text-assertions.test.mjs
@@ -1,0 +1,453 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the Rust source-text-assertion gate (issue #3195). Everything runs
+ * against synthetic Rust written into an `mkdtemp` tree, never against `rust/`,
+ * so a change in a real crate can neither break these nor make them vacuously
+ * green -- the construction scripts/check-refwalk-guards.test.mjs and
+ * scripts/check-source-text-assertions.test.mjs both use.
+ *
+ * Three groups, and the second two are not decoration:
+ *
+ *  - FIRING. A gate nobody has watched fail is the thing #3195 is about.
+ *  - NOT FIRING. A gate with false positives gets suppressed and then it
+ *    protects nothing, so every legitimate shape in the real tree -- a fixture
+ *    read, a doc comment naming a `.rs` path, a `.rs` literal that is not a
+ *    read at all -- is pinned as passing.
+ *  - VACUITY. Three sibling gates shipped exiting 0 having examined nothing
+ *    (#3194 / PR #3197). `missingRoot`, `emptyRoot`, `noTestFiles` and
+ *    `readFloor` pin that this one fails loudly instead.
+ *
+ * Run: node --test scripts/check-rust-source-text-assertions.test.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { runCheck } from './check-rust-source-text-assertions.mjs';
+import { analyze, lex } from './lib/rust-source-text-detect.mjs';
+
+const ROOT = 'rust';
+const TESTFILE = `${ROOT}/core/tests/subject_parity.rs`;
+
+/**
+ * Build a temp tree of `{ 'rust/…/x.rs': '…' }` and run the check against it.
+ * Defaults keep the repo's own floor and allowlist out of play.
+ *
+ * @param {Record<string, string>} files
+ * @param {object} [opts]
+ */
+function check(files, opts = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'rust-source-text-'));
+  try {
+    for (const [rel, body] of Object.entries(files)) {
+      const abs = join(dir, rel);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, body);
+    }
+    return runCheck(dir, { roots: [ROOT], allowlist: new Set(), readFloor: 0, allowlistCeiling: 0, ...opts });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/* ─────────────────────────── FIRING ─────────────────────────── */
+
+test('flags the planted violation from #3129 verbatim', () => {
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    let src = std::fs::read_to_string("src/api/space_plate_input.rs").unwrap();
+    assert!(src.contains("fn space_plate_input"));
+}
+`,
+  });
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.offenders, [`${TESTFILE}:4  read_to_string of src/api/space_plate_input.rs`]);
+});
+
+test('flags include_str! of a source file', () => {
+  const r = check({ [TESTFILE]: 'const SRC: &str = include_str!("../src/lib.rs");\n' });
+  assert.deepEqual(r.offenders, [`${TESTFILE}:1  include_str of ../src/lib.rs`]);
+});
+
+test('flags a read whose path is a named const, the tree’s usual spelling', () => {
+  const r = check({
+    [TESTFILE]: `
+const SUBJECT: &str = "../src/lib.rs";
+
+#[test]
+fn t() {
+    let src = std::fs::read_to_string(SUBJECT).unwrap();
+    assert!(src.contains("pub fn"));
+}
+`,
+  });
+  assert.deepEqual(r.offenders, [`${TESTFILE}:6  read_to_string of ../src/lib.rs`]);
+});
+
+test('flags a read inside a #[cfg(test)] mod in a src file', () => {
+  const r = check({
+    [`${ROOT}/core/src/thing.rs`]: `
+pub fn thing() -> u32 { 1 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn t() {
+        let src = std::fs::read_to_string("src/thing.rs").unwrap();
+        assert!(src.contains("pub fn thing"));
+    }
+}
+`,
+  });
+  assert.deepEqual(r.offenders, [`${ROOT}/core/src/thing.rs:8  read_to_string of src/thing.rs`]);
+});
+
+test('flags a TypeScript source read from a Rust test, since the rule is about source, not language', () => {
+  const r = check({ [TESTFILE]: 'const S: &str = include_str!("../../../apps/viewer/src/App.tsx");\n' });
+  assert.deepEqual(r.offenders, [`${TESTFILE}:1  include_str of ../../../apps/viewer/src/App.tsx`]);
+});
+
+/* ───────────────────────── NOT FIRING ───────────────────────── */
+
+test('does not flag a fixture read', () => {
+  const r = check({
+    [TESTFILE]: `
+const FIXTURE: &str = "fixtures/model.ifc";
+
+#[test]
+fn t() {
+    let raw = include_str!("fixtures/vectors.json");
+    let bytes = std::fs::read(FIXTURE).unwrap();
+    assert!(!raw.is_empty() && !bytes.is_empty());
+}
+`,
+  });
+  assert.deepEqual(r.offenders, []);
+  assert.equal(r.reads, 2, 'both reads are examined — they are clean, not invisible');
+});
+
+test('PROSE IS NOT CODE: a doc comment naming a .rs file is not a read', () => {
+  const r = check({
+    [TESTFILE]: `
+//! Mirrors the table in \`src/unit_scale.rs\`, per \`packages/data/src/units.ts\`.
+
+/// See src/thing.rs and safe-path.test.ts for the shape this pins.
+#[test]
+fn t() {
+    /* src/other.rs is named here too, in a block comment */
+    let raw = include_str!("fixtures/vectors.json");
+    assert!(!raw.is_empty());
+}
+`,
+  });
+  assert.deepEqual(r.offenders, []);
+});
+
+test('a .rs literal that is not a read argument is not a read', () => {
+  // The real shape: rust/processing/tests/styling_parity.rs allowlists ITSELF
+  // by name, `rel.ends_with("rust/processing/tests/styling_parity.rs")`.
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    let allow = |rel: &str| rel.ends_with("rust/processing/tests/styling_parity.rs");
+    assert!(allow("rust/processing/tests/styling_parity.rs"));
+}
+`,
+  });
+  assert.deepEqual(r.offenders, []);
+  assert.equal(r.reads, 0);
+});
+
+test('a source read outside test scope is out of scope, because the rule is about tests', () => {
+  const r = check({
+    [`${ROOT}/core/src/tool.rs`]: `
+pub fn count_lines() -> usize {
+    std::fs::read_to_string("src/lib.rs").map(|s| s.lines().count()).unwrap_or(0)
+}
+`,
+  });
+  assert.deepEqual(r.offenders, []);
+  assert.equal(r.testFiles, 0, 'a src file with no #[cfg(test)] is not opened as test code');
+});
+
+test('a string cannot forge a suppression marker', () => {
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    let excuse = "@source-text-assertion-ok totally fine";
+    let src = std::fs::read_to_string("src/lib.rs").unwrap();
+    assert!(src.contains(excuse));
+}
+`,
+  });
+  assert.deepEqual(r.offenders, [`${TESTFILE}:5  read_to_string of src/lib.rs`]);
+  assert.deepEqual(r.deadMarkers, [], 'the string is not a marker in either direction');
+});
+
+/* ─────────────────────────── MARKERS ────────────────────────── */
+
+test('a marker above the statement suppresses the site and NAMES it', () => {
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    // @source-text-assertion-ok mutation anchor guard
+    let src = std::fs::read_to_string("src/lib.rs").unwrap();
+    assert!(src.contains("anchor"));
+}
+`,
+  });
+  assert.deepEqual(r.offenders, []);
+  assert.deepEqual(r.marked, [`${TESTFILE}:5  src/lib.rs  mutation anchor guard`]);
+});
+
+test('a comment INSIDE the read does not break the marker range (#3174)', () => {
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    // @source-text-assertion-ok mutation anchor guard
+    let src = std::fs::read_to_string(
+        // the interior comment that broke the TypeScript gate
+        "src/lib.rs",
+    )
+    .unwrap();
+    assert!(src.contains("anchor"));
+}
+`,
+  });
+  assert.deepEqual(r.offenders, [], 'the remedy the gate prints must be one it accepts');
+  assert.equal(r.deadMarkers.length, 0, 'and it must not then fail a second time for a dead marker');
+});
+
+test('a marker with no reason excuses nothing and is an error', () => {
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    // @source-text-assertion-ok
+    let src = std::fs::read_to_string("src/lib.rs").unwrap();
+    assert!(src.contains("x"));
+}
+`,
+  });
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.offenders, [`${TESTFILE}:5  read_to_string of src/lib.rs`]);
+  assert.deepEqual(r.deadMarkers, [`${TESTFILE}:4`]);
+});
+
+test('a marker left behind after the read is gone is reported dead', () => {
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    // @source-text-assertion-ok mutation anchor guard
+    let raw = include_str!("fixtures/vectors.json");
+    assert!(!raw.is_empty());
+}
+`,
+  });
+  assert.equal(r.ok, false);
+  assert.deepEqual(r.deadMarkers, [`${TESTFILE}:4`]);
+});
+
+/* ─────────────────────────── LEXER ──────────────────────────── */
+
+test('a raw string does not blind the lexer to what follows it', () => {
+  // An unterminated-string bug fails OPEN: it swallows the rest of the file and
+  // the gate goes quiet. Every pre-#3174 bug in the TypeScript detector had
+  // that shape, so each Rust-specific literal form gets a live read after it.
+  const r = check({
+    [TESTFILE]: `
+#[test]
+fn t() {
+    let q = r#"a " quote and a // slash"#;
+    let raw = r"another \\ raw";
+    let b = br##"bytes " here"##;
+    let src = std::fs::read_to_string("src/lib.rs").unwrap();
+    assert!(src.contains(q) && !raw.is_empty() && !b.is_empty());
+}
+`,
+  });
+  assert.deepEqual(r.offenders, [`${TESTFILE}:7  read_to_string of src/lib.rs`]);
+});
+
+test('a NESTED block comment ends where Rust says it ends', () => {
+  const r = check({
+    [TESTFILE]: `
+/* outer /* inner */ still comment, "src/decoy.rs" */
+#[test]
+fn t() {
+    let src = std::fs::read_to_string("src/lib.rs").unwrap();
+    assert!(src.contains("x"));
+}
+`,
+  });
+  assert.deepEqual(r.offenders, [`${TESTFILE}:5  read_to_string of src/lib.rs`]);
+});
+
+test('a lifetime is not an unterminated char literal', () => {
+  const r = check({
+    [TESTFILE]: `
+struct Holder<'a> { s: &'a str }
+
+#[test]
+fn t() {
+    let h = Holder { s: "x" };
+    let src = std::fs::read_to_string("src/lib.rs").unwrap();
+    assert!(src.contains(h.s));
+}
+`,
+  });
+  assert.deepEqual(r.offenders, [`${TESTFILE}:7  read_to_string of src/lib.rs`]);
+});
+
+test('lex masks comments and strings without moving any offset', () => {
+  const text = '// a\nlet s = "bb";\n';
+  const { masked } = lex(text);
+  assert.equal(masked.length, text.length, 'offsets must survive masking');
+  assert.equal(masked.split('\n').length, text.split('\n').length, 'line numbers must survive masking');
+  assert.ok(!masked.includes('bb'), 'string contents are out of the code plane');
+  assert.ok(!masked.includes('a\n') || masked.startsWith('    \n'), 'comment text is out of the code plane');
+});
+
+/* ────────────────────────── ALLOWLIST ───────────────────────── */
+
+const VIOLATION = `
+#[test]
+fn t() {
+    let src = std::fs::read_to_string("src/lib.rs").unwrap();
+    assert!(src.contains("x"));
+}
+`;
+
+test('an allowlist row suppresses exactly its own file', () => {
+  const other = `${ROOT}/core/tests/other_parity.rs`;
+  const r = check(
+    { [TESTFILE]: VIOLATION, [other]: VIOLATION },
+    { allowlist: new Set([TESTFILE]), allowlistCeiling: 1 }
+  );
+  assert.deepEqual(r.offenders, [`${other}:4  read_to_string of src/lib.rs`]);
+});
+
+test('an allowlist row whose file got converted is reported stale', () => {
+  const r = check(
+    { [TESTFILE]: 'const RAW: &str = include_str!("fixtures/vectors.json");\n' },
+    { allowlist: new Set([TESTFILE]), allowlistCeiling: 1 }
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join('\n'), /no longer contain a source-text assertion/);
+});
+
+test('allowlist growth cannot land without editing the ceiling', () => {
+  const r = check({ [TESTFILE]: VIOLATION }, { allowlist: new Set([TESTFILE]), allowlistCeiling: 0 });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join('\n'), /ALLOWLIST_CEILING reads 0/);
+});
+
+test('allowlist shrinkage must lower the ceiling too', () => {
+  const r = check({ [TESTFILE]: VIOLATION }, { allowlist: new Set(), allowlistCeiling: 1 });
+  assert.match(r.errors.join('\n'), /ALLOWLIST_CEILING reads 1/);
+});
+
+/* ─────────────────────────── VACUITY ────────────────────────── */
+
+test('a missing scan root is a failure, not a pass', () => {
+  const r = check({ 'docs/readme.md': 'no rust here\n' });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join('\n'), /scan root missing: rust/);
+});
+
+test('a scan root with no .rs files is a failure, not a pass', () => {
+  const r = check({ [`${ROOT}/core/Cargo.toml`]: '[package]\n' });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join('\n'), /contains no \.rs files/);
+});
+
+test('.rs files but no test code among them refuses a vacuous pass', () => {
+  const r = check({ [`${ROOT}/core/src/lib.rs`]: 'pub fn f() -> u32 { 1 }\n' });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join('\n'), /not one test file among them/);
+});
+
+test('a detector that stopped matching trips the read floor', () => {
+  // The floor's whole job: a lexer edit or a renamed call makes the gate go
+  // QUIET, and quiet reads as clean. Simulated here by holding the floor while
+  // the tree offers fewer reads than it demands.
+  const r = check({ [TESTFILE]: 'const RAW: &str = include_str!("fixtures/vectors.json");\n' }, { readFloor: 90 });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join('\n'), /only 1 file reads found in Rust test code, floor is 90/);
+});
+
+test('the floor is met by the real tree, so it is a floor and not a wish', () => {
+  const run = spawnSync(
+    process.execPath,
+    [fileURLToPath(new URL('./check-rust-source-text-assertions.mjs', import.meta.url))],
+    { encoding: 'utf8' }
+  );
+  const m = /check-rust-source-text-assertions: OK \((\d+) \.rs files, (\d+) with test code, (\d+) reads/.exec(
+    `${run.stdout}${run.stderr}`
+  );
+  assert.ok(m, `no success line:\nstdout: ${run.stdout}\nstderr: ${run.stderr}`);
+  assert.ok(Number(m[1]) > 0, 'scanned 0 .rs files — a green that examined nothing is what this gate is for');
+  assert.ok(Number(m[2]) > 0, 'found 0 files carrying test code');
+  assert.ok(Number(m[3]) > 0, 'examined 0 reads');
+});
+
+/* ────────────────────── ENTRY POINT ─────────────────────────── */
+
+/**
+ * The gate is only worth anything if it RUNS, and a module that falls through
+ * because `isMain` came out false prints nothing and exits 0 -- which CI reads
+ * as a pass. The bug is invisible from inside the test process (an imported
+ * module has `isMain === false` by design), so it has to be spawned, and the
+ * discriminator has to be OUTPUT rather than exit code.
+ */
+test('the gate actually runs from a path containing a space', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'rust source text gate '));
+  try {
+    assert.ok(dir.includes(' '), `temp dir must contain a space, got ${dir}`);
+    const copied = join(dir, 'check-rust-source-text-assertions.mjs');
+    mkdirSync(join(dir, 'lib'), { recursive: true });
+    writeFileSync(copied, readFileSync(new URL('./check-rust-source-text-assertions.mjs', import.meta.url)));
+    writeFileSync(
+      join(dir, 'lib', 'rust-source-text-detect.mjs'),
+      readFileSync(new URL('./lib/rust-source-text-detect.mjs', import.meta.url))
+    );
+
+    const run = spawnSync(process.execPath, [copied], { encoding: 'utf8' });
+    const output = `${run.stdout}${run.stderr}`;
+
+    // The copy has no rust/ tree, so a gate that ran must refuse to report a
+    // pass over zero files. That refusal IS the evidence that it ran.
+    assert.notEqual(output.trim(), '', 'the gate produced no output at all, so `isMain` was false and it never ran');
+    assert.match(
+      output,
+      /rust-source-text-assertions: scan root missing/,
+      `expected the gate to run and refuse an empty scan, got:\n${output}`
+    );
+    assert.equal(run.status, 1, 'a gate that scanned nothing must exit non-zero');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/* ────────────────────── DETECTOR DIRECTLY ───────────────────── */
+
+test('analyze counts reads it does not flag, so the floor measures the detector', () => {
+  const r = analyze('const RAW: &str = include_str!("fixtures/a.json");\n', TESTFILE);
+  assert.equal(r.reads, 1);
+  assert.deepEqual(r.hits, []);
+});

--- a/scripts/lib/rust-source-text-detect.mjs
+++ b/scripts/lib/rust-source-text-detect.mjs
@@ -1,0 +1,494 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Detection half of scripts/check-rust-source-text-assertions.mjs (#3195),
+ * split out so it can be unit-tested against hand-written Rust instead of only
+ * against whatever `rust/` happens to contain today.
+ *
+ * THE RULE is AGENTS.md's, the same one the TypeScript gate enforces: "Never
+ * assert on a source file's text. A test that reads `Thing.tsx` and greps it
+ * certifies a string exists, not that the code works." `rust/` was outside that
+ * gate's scan scope entirely -- `grep -c rust scripts/check-source-text-assertions.mjs`
+ * returned 0 -- so the maintainer demonstrated the hole by planting
+ * `fs::read_to_string("src/api/space_plate_input.rs")` plus a `contains` in a
+ * real Rust test and watching CI stay green (#3129, then #3195).
+ *
+ * ═══ SOURCE READ vs FIXTURE READ ═══
+ *
+ * This is the whole design, so it is stated as a rule rather than a heuristic:
+ *
+ *   A read is flagged when, and only when, the path it reads is spelled by a
+ *   STRING LITERAL whose extension is a SOURCE extension.
+ *
+ * Fixtures are not excluded by a denylist of fixture formats -- `.ifc`,
+ * `.ifcx`, `.json`, `.txt`, `.glb`, a golden manifest -- they are out of scope
+ * by construction, because their extension is not in SOURCE_EXTENSIONS. That
+ * matters because the fixture side is the side with the long tail: this tree
+ * reads at least nine distinct fixture formats, and a denylist would have to
+ * grow with every new one, failing OPEN each time someone forgot. An
+ * extension allowlist fails CLOSED on an unknown format -- a new fixture type
+ * is simply not flagged, and a new source type has to be added here
+ * deliberately.
+ *
+ * The literal may be written at the read site or bound once and named:
+ *
+ *   std::fs::read_to_string("../src/lib.rs")           // direct
+ *   const SUBJECT: &str = "../src/lib.rs";             // named, resolved here
+ *   let text = std::fs::read_to_string(SUBJECT);       //   because this spelling
+ *                                                      //   is the tree's norm
+ *   include_str!("fixtures/vectors.json")              // NOT a source extension
+ *
+ * ═══ PROSE IS NOT CODE ═══
+ *
+ * Inherited, deliberately, from the TypeScript gate's docblock, where it is
+ * load-bearing rather than tidy: three unrelated tests there mention a `.ts`
+ * filename in a COMMENT while reading a wasm binary or a JSON manifest, and
+ * matching those flagged all three falsely. The same trap is live in `rust/`,
+ * where doc comments routinely name `.rs` paths -- `styling_parity.rs` and
+ * `module_size_ratchet.rs` each name several in prose.
+ *
+ * So this module lexes Rust rather than grepping it. Comments and string
+ * literals are MASKED out of the code plane, and:
+ *
+ *   - a path is read only from a STRING LITERAL token, so a comment naming
+ *     `space_plate_input.rs` can never stand in for one;
+ *   - a suppression marker is read only from COMMENT trivia, so a string
+ *     containing `@source-text-assertion-ok` can never forge one;
+ *   - a marker's reach is a CHARACTER range (the enclosing statement, found by
+ *     scanning the masked text back to the previous `;`/`{`/`}`), not a run of
+ *     lines that look unfinished, so a comment INSIDE the statement does not
+ *     break the range logic. That break is #3174, which cost the TypeScript
+ *     gate a double failure -- the assertion AND the marker it said excused
+ *     nothing -- and printed a remedy it would not itself accept.
+ *
+ * The lexer handles the Rust-specific shapes that defeat a naive scan: raw
+ * strings (`r"..."`, `r#"..."#` with any hash count), byte and byte-raw strings
+ * (`b"..."`, `br#"..."#`), NESTED block comments (legal in Rust, unlike C), and
+ * the `'` ambiguity between a char literal and a lifetime. Each of those, left
+ * unhandled, is a fail-OPEN: an unterminated string swallows the rest of the
+ * file and the gate goes quiet, which is how every one of the TypeScript
+ * detector's pre-#3174 bugs presented.
+ *
+ * ═══ WHY NO TAINT PAIRING ═══
+ *
+ * The TypeScript detector pairs the read with the predicate: a `.includes()`
+ * counts only when applied to a value a read produced. It has to, because
+ * reading a fixture is ubiquitous there and the extension carries no signal
+ * (`generate-ifc-schema.test.ts` reads `.ts` fixtures to copy them, and was
+ * falsely flagged until the pairing landed).
+ *
+ * Here the extension IS the signal, and it already separates the two
+ * populations, so the pairing would only be able to make the gate LOOSER.
+ * Reading a source file inside a test and not asserting on it is not a shape
+ * this tree contains -- measured: zero such sites -- and "stricter is the safe
+ * direction for a ratchet" is the same call the TypeScript detector's docblock
+ * makes about its own over-tainting. If a legitimate one appears, the marker is
+ * the answer, and it stays a named line in the gate's output.
+ *
+ * ═══ LIMITATIONS -- read before assuming coverage ═══
+ *
+ *  - NOT CAUGHT: a source read whose path is computed rather than spelled --
+ *    a directory walk that filters on `extension() == Some("rs")` and reads
+ *    what it finds. That is the shape the two legitimate repo-wide ratchets in
+ *    `rust/processing/tests/` use (`styling_parity.rs`,
+ *    `module_size_ratchet.rs`), and it is also a hole a violation could be
+ *    written into. Closing it by flagging every `read_to_string` under such a
+ *    walk was measured and rejected: it flags both ratchets, which are the
+ *    exact tests the repo wants, and a gate whose first act is to demand
+ *    markers on correct code gets suppressed wholesale.
+ *  - NOT CAUGHT: a path assembled by `format!`/`join`/`PathBuf::push` from
+ *    fragments, since no single literal carries the extension.
+ *  - NOT CAUGHT: a read through a helper that takes the literal at ITS call
+ *    site and passes it on -- resolution is one hop, from a file-level `const`
+ *    or `static` or a `let` binding to a literal, not a dataflow.
+ *  - WEAK: test scope is `#[cfg(test)]` blocks, `tests/` directories and
+ *    `*_test.rs` / `*_tests.rs` / `tests.rs` files. A source read from
+ *    NON-test code (a build script, a CLI that legitimately reads Rust) is out
+ *    of scope on purpose -- the rule is about tests.
+ */
+
+/** Extensions that make a read target a SOURCE file rather than a fixture. */
+export const SOURCE_EXTENSIONS = ['.rs', '.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs'];
+
+/** The marker, shared with the TypeScript gate so the repo has one vocabulary. */
+export const MARKER = '@source-text-assertion-ok';
+
+/**
+ * Read calls whose first argument names a file. `read_dir` is absent on
+ * purpose: it names a directory, and the reads it leads to are the computed
+ * paths the limitations note as out of reach.
+ */
+const READ_CALLS = ['read_to_string', 'read', 'open'];
+const READ_MACROS = ['include_str', 'include_bytes'];
+
+/**
+ * @param {string} ch
+ * @returns {boolean}
+ */
+function isIdentChar(ch) {
+  return ch !== undefined && /[A-Za-z0-9_]/.test(ch);
+}
+
+/**
+ * Offset -> 1-based line number, precomputed so the scan stays linear.
+ *
+ * @param {string} text
+ * @returns {(offset: number) => number}
+ */
+function makeLineIndex(text) {
+  const starts = [0];
+  for (let k = 0; k < text.length; k++) if (text[k] === '\n') starts.push(k + 1);
+  return (offset) => {
+    let lo = 0;
+    let hi = starts.length - 1;
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >> 1;
+      if (starts[mid] <= offset) lo = mid;
+      else hi = mid - 1;
+    }
+    return lo + 1;
+  };
+}
+
+/**
+ * Lex Rust into a masked code plane plus the trivia the gate needs.
+ *
+ * `masked` is character-for-character the same length as `text`, with every
+ * comment and every string/char literal replaced by spaces (newlines kept, so
+ * offsets and line numbers survive). Everything structural -- parens, braces,
+ * semicolons, identifiers -- is read from `masked`, which is what makes a brace
+ * inside a string or a `;` inside a comment inert.
+ *
+ * @param {string} text
+ * @returns {{ masked: string, strings: Array<{start:number,end:number,value:string}>, comments: Array<{start:number,line:number,text:string}> }}
+ */
+export function lex(text) {
+  const masked = new Array(text.length);
+  for (let k = 0; k < text.length; k++) masked[k] = text[k];
+  const blank = (from, to) => {
+    for (let k = from; k < to && k < text.length; k++) if (text[k] !== '\n') masked[k] = ' ';
+  };
+  /** @type {Array<{start:number,end:number,value:string}>} */
+  const strings = [];
+  /** @type {Array<{start:number,line:number,text:string}>} */
+  const comments = [];
+
+  const lineOf = makeLineIndex(text);
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    // Line comment.
+    if (c === '/' && text[i + 1] === '/') {
+      let j = i;
+      while (j < text.length && text[j] !== '\n') j++;
+      comments.push({ start: i, line: lineOf(i), text: text.slice(i, j) });
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    // Block comment -- NESTED, which is legal in Rust and not in C.
+    if (c === '/' && text[i + 1] === '*') {
+      let depth = 1;
+      let j = i + 2;
+      while (j < text.length && depth > 0) {
+        if (text[j] === '/' && text[j + 1] === '*') {
+          depth++;
+          j += 2;
+        } else if (text[j] === '*' && text[j + 1] === '/') {
+          depth--;
+          j += 2;
+        } else j++;
+      }
+      comments.push({ start: i, line: lineOf(i), text: text.slice(i, j) });
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    // Raw string, with or without a byte prefix: r"..", r#".."#, br##".."##.
+    if ((c === 'r' || (c === 'b' && text[i + 1] === 'r')) && !isIdentChar(text[i - 1])) {
+      const prefixLen = c === 'r' ? 1 : 2;
+      let j = i + prefixLen;
+      let hashes = 0;
+      while (text[j] === '#') {
+        hashes++;
+        j++;
+      }
+      if (text[j] === '"') {
+        const contentStart = j + 1;
+        const terminator = '"' + '#'.repeat(hashes);
+        const endIdx = text.indexOf(terminator, contentStart);
+        const contentEnd = endIdx === -1 ? text.length : endIdx;
+        const end = Math.min(contentEnd + terminator.length, text.length);
+        strings.push({ start: i, end, value: text.slice(contentStart, contentEnd) });
+        blank(i, end);
+        i = end;
+        continue;
+      }
+    }
+    // Ordinary or byte string.
+    if (c === '"' || (c === 'b' && text[i + 1] === '"' && !isIdentChar(text[i - 1]))) {
+      const start = i;
+      let j = c === '"' ? i + 1 : i + 2;
+      let value = '';
+      while (j < text.length) {
+        if (text[j] === '\\') {
+          value += text[j + 1] ?? '';
+          j += 2;
+          continue;
+        }
+        if (text[j] === '"') break;
+        value += text[j];
+        j++;
+      }
+      strings.push({ start, end: j + 1, value });
+      blank(start, j + 1);
+      i = j + 1;
+      continue;
+    }
+    // `'` is a char literal OR a lifetime. `'a` followed by a non-quote is a
+    // lifetime; treating it as an unterminated char literal would swallow the
+    // file to the next `'` and blind the gate to everything between.
+    if (c === "'") {
+      const isLifetime = /^'[A-Za-z_][A-Za-z0-9_]*(?!')/.test(text.slice(i, i + 24));
+      if (!isLifetime) {
+        let j = i + 1;
+        while (j < text.length) {
+          if (text[j] === '\\') {
+            j += 2;
+            continue;
+          }
+          if (text[j] === "'" || text[j] === '\n') break;
+          j++;
+        }
+        blank(i, j + 1);
+        i = j + 1;
+        continue;
+      }
+    }
+    i++;
+  }
+  return { masked: masked.join(''), strings, comments };
+}
+
+/**
+ * Match the delimiter opened at `open` in the masked plane.
+ *
+ * @param {string} masked
+ * @param {number} open
+ * @returns {number} index of the matching close, or -1
+ */
+function matchDelim(masked, open) {
+  const pairs = { '(': ')', '[': ']', '{': '}' };
+  const close = pairs[masked[open]];
+  if (!close) return -1;
+  let depth = 0;
+  for (let k = open; k < masked.length; k++) {
+    if (masked[k] === masked[open]) depth++;
+    else if (masked[k] === close) {
+      depth--;
+      if (depth === 0) return k;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Ranges of `#[cfg(test)]`-attributed blocks, in masked-plane offsets.
+ *
+ * @param {string} masked
+ * @returns {Array<[number, number]>}
+ */
+function cfgTestRanges(masked) {
+  /** @type {Array<[number, number]>} */
+  const ranges = [];
+  const re = /#\s*\[\s*cfg\s*\(\s*test\s*\)\s*\]/g;
+  let m;
+  while ((m = re.exec(masked)) !== null) {
+    const brace = masked.indexOf('{', m.index);
+    if (brace === -1) continue;
+    // Only treat the attribute as opening a block if nothing but a `mod`
+    // header sits between it and the brace; otherwise `#[cfg(test)] use x;`
+    // would claim the next unrelated block.
+    const between = masked.slice(m.index + m[0].length, brace);
+    if (/[;}]/.test(between)) continue;
+    const end = matchDelim(masked, brace);
+    if (end !== -1) ranges.push([m.index, end]);
+  }
+  return ranges;
+}
+
+/**
+ * Does this path look like a test file by its location or name?
+ *
+ * @param {string} relPath posix-separated, repo-relative
+ * @returns {boolean}
+ */
+export function isTestPath(relPath) {
+  const base = relPath.split('/').pop() ?? relPath;
+  return (
+    relPath.split('/').includes('tests') ||
+    base === 'tests.rs' ||
+    base.endsWith('_tests.rs') ||
+    base.endsWith('_test.rs')
+  );
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isSourcePath(value) {
+  // A path, not a sentence: reject anything with whitespace, which is how a
+  // prose string ending in a filename would otherwise sneak in.
+  if (value.length === 0 || /\s/.test(value)) return false;
+  const lower = value.toLowerCase();
+  return SOURCE_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+/**
+ * Start of the statement enclosing `offset`: scan the MASKED plane back to the
+ * previous `;`, `{` or `}`. Masked, so a `;` inside a comment or a string does
+ * not truncate the range -- that is the #3174 property, stated as code.
+ *
+ * @param {string} masked
+ * @param {number} offset
+ * @returns {number}
+ */
+function statementStart(masked, offset) {
+  for (let k = offset - 1; k >= 0; k--) {
+    if (masked[k] === ';' || masked[k] === '{' || masked[k] === '}') return k + 1;
+  }
+  return 0;
+}
+
+/**
+ * Analyse one Rust file.
+ *
+ * @param {string} text
+ * @param {string} relPath posix-separated, repo-relative
+ * @returns {{ reads: number, hits: Array<{line:number,path:string,call:string}>, marked: Array<{line:number,reason:string,path:string}>, unusedMarkers: number[] }}
+ */
+export function analyze(text, relPath) {
+  const { masked, strings, comments } = lex(text);
+  const lineOf = makeLineIndex(text);
+  const fileIsTest = isTestPath(relPath);
+  /** @type {Array<[number, number]>} */
+  const testRanges = fileIsTest ? [[0, text.length]] : cfgTestRanges(masked);
+  const inTestScope = (offset) => testRanges.some(([a, b]) => offset >= a && offset <= b);
+
+  // One-hop literal bindings: `const NAME: &str = "..."`, `static NAME ... = "..."`,
+  // `let name = "..."`. The value is taken from the STRING TOKEN at that offset,
+  // never from the raw text, so a commented-out binding cannot define a name.
+  /** @type {Map<string, string>} */
+  const bindings = new Map();
+  // The regex stops AT the `=`. It must not run on past it: a string is
+  // blanked to spaces in the masked plane, so a trailing `\s*` would swallow
+  // the very literal being looked for and every named path would resolve to
+  // nothing -- a silent, total loss of this hop, which is the fail-quiet shape
+  // the floor exists to catch and which caught this while writing it.
+  const bindRe =
+    /\b(?:const|static)\s+(?:mut\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:[^=;]*=|\blet\s+(?:mut\s+)?([a-z_][A-Za-z0-9_]*)\s*(?::[^=;]*)?=/g;
+  let bm;
+  while ((bm = bindRe.exec(masked)) !== null) {
+    const name = bm[1] ?? bm[2];
+    if (!name) continue;
+    const valueStart = bm.index + bm[0].length;
+    // The FIRST literal after the `=`, and only if nothing but blank separates
+    // them -- so `let a = helper("x")` binds nothing, which is right: the value
+    // is a call result, not that path.
+    const lit = strings.find((s) => s.start >= valueStart && masked.slice(valueStart, s.start).trim() === '');
+    if (lit && strings.every((s) => s.start >= lit.start || s.end <= valueStart)) bindings.set(name, lit.value);
+  }
+
+  /** @type {Array<{line:number,path:string,call:string,start:number,end:number}>} */
+  const sites = [];
+  let reads = 0;
+
+  // Macro reads: include_str!(..) / include_bytes!(..)
+  const macroRe = new RegExp(`\\b(${READ_MACROS.join('|')})\\s*!\\s*[\\(\\[\\{]`, 'g');
+  // Call reads: fs::read_to_string(..), std::fs::read(..), File::open(..).
+  // A bare `read(`/`open(` is NOT matched -- `reader.read(&mut buf)` is not a
+  // path read, and matching it would put the gate's precision at the mercy of
+  // every I/O helper in the tree.
+  const callRe = new RegExp(`\\b(?:fs|File)\\s*::\\s*(${READ_CALLS.join('|')})\\s*\\(`, 'g');
+
+  for (const re of [macroRe, callRe]) {
+    let m;
+    while ((m = re.exec(masked)) !== null) {
+      const open = m.index + m[0].length - 1;
+      const close = matchDelim(masked, open);
+      if (close === -1) continue;
+      if (!inTestScope(m.index)) continue;
+      reads++;
+      const argStart = open + 1;
+      const argEnd = close;
+      // The path comes from a string literal in the argument -- or from a name
+      // bound to one. A comment inside the argument is masked and cannot
+      // supply either.
+      const lit = strings.find((s) => s.start >= argStart && s.end <= argEnd + 1);
+      let path = lit?.value;
+      if (path === undefined) {
+        const idents = masked.slice(argStart, argEnd).match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? [];
+        for (const id of idents) {
+          if (bindings.has(id)) {
+            path = bindings.get(id);
+            break;
+          }
+        }
+      }
+      if (path === undefined || !isSourcePath(path)) continue;
+      sites.push({
+        line: lineOf(m.index),
+        path,
+        call: m[1],
+        start: statementStart(masked, m.index),
+        end: close,
+      });
+    }
+  }
+
+  sites.sort((a, b) => a.line - b.line);
+
+  // Markers, from COMMENT trivia only. A marker excuses a site when it sits
+  // inside that site's enclosing-statement character range, or on the line
+  // directly above where that statement starts, or trailing on the read's own
+  // line.
+  const markers = comments
+    .filter((c) => c.text.includes(MARKER))
+    .map((c) => ({
+      start: c.start,
+      line: c.line,
+      reason: c.text
+        .slice(c.text.indexOf(MARKER) + MARKER.length)
+        .replace(/\*\/\s*$/, '')
+        .trim(),
+    }));
+
+  /** @type {Array<{line:number,reason:string,path:string}>} */
+  const marked = [];
+  /** @type {Set<number>} */
+  const usedMarkers = new Set();
+  /** @type {Array<{line:number,path:string,call:string}>} */
+  const hits = [];
+
+  for (const site of sites) {
+    const stmtLine = lineOf(site.start);
+    const hit = markers.find(
+      (mk) =>
+        mk.reason.length > 0 &&
+        ((mk.start >= site.start && mk.start <= site.end) || mk.line === stmtLine - 1 || mk.line === site.line)
+    );
+    if (hit) {
+      usedMarkers.add(hit.start);
+      marked.push({ line: site.line, reason: hit.reason, path: site.path });
+    } else {
+      hits.push({ line: site.line, path: site.path, call: site.call });
+    }
+  }
+
+  const unusedMarkers = markers.filter((mk) => !usedMarkers.has(mk.start)).map((mk) => mk.line);
+
+  return { reads, hits, marked, unusedMarkers };
+}

--- a/scripts/rust-source-text-assertion-allowlist.txt
+++ b/scripts/rust-source-text-assertion-allowlist.txt
@@ -1,0 +1,19 @@
+# Rust test files grandfathered past scripts/check-rust-source-text-assertions.mjs
+# (issue #3195). One repo-relative path per line, `#` starts a comment.
+#
+# EMPTY, and expected to stay empty: `rust/` has zero source-text assertions
+# today, so a row here is a deliberate statement that a Rust test certifies a
+# string exists rather than that the code works. Adding one also requires
+# raising ALLOWLIST_CEILING in scripts/check-rust-source-text-assertions.mjs in
+# the SAME commit — a ceiling derived from this file would be circular and
+# always pass — which keeps "this PR loosened a gate" a reviewable line.
+#
+# Prefer the per-site marker to a whole-file row:
+#
+#   // @source-text-assertion-ok mutation anchor guard, not a subject assertion
+#
+# Marked sites stay NAMED in the gate's output; an allowlisted file goes quiet.
+#
+# A row whose file no longer contains a source-text assertion is reported stale
+# and fails, so entries cannot rot: the way one is removed is that the test gets
+# written behaviourally, and the next run tells you to delete the line.


### PR DESCRIPTION
Closes #3195.

`scripts/check-source-text-assertions.mjs` enforces AGENTS.md's *"Never assert on a source file's text"* over `packages/` and `apps/` only — its own header says so, and `grep -c rust` over it returns 0. You demonstrated the consequence rather than inferring it: `fs::read_to_string("src/api/space_plate_input.rs")` plus a `contains`, planted in a real Rust test, left the gate exiting 0 without naming the file.

## Which option this is, and that it is reversible

**Option (2), the sibling gate.** The design question on #3195 had no answer when this was built (no comments on the issue), so it follows the issue's own stated recommendation. **If you prefer (1), folding a Rust pass into the existing script, that is a small change from here** — the detector is a module exposing the same `analyze(text, relPath)` shape the TypeScript one does, so unifying is a call-site edit, not a rewrite.

The reason for the sibling: the TypeScript detector's precision comes from reading filenames out of a real TypeScript parse tree, which is what stops a comment naming `safe-path.test.ts` from being mistaken for an assertion — three false positives were already paid for that. A regex-based Rust pass sharing that file would invite a later "unification" that quietly loses it.

## Source read vs fixture read — the whole design

Stated as a rule rather than a heuristic:

> A read is flagged when, and only when, the path it reads is spelled by a **string literal** whose extension is a **source** extension (`.rs`, `.ts`, `.tsx`, `.mts`, `.cts`, `.js`, `.jsx`, `.mjs`, `.cjs`).

Fixtures are **not** excluded by a denylist of fixture formats. `.ifc`, `.ifcx`, `.json`, `.txt`, a golden manifest are out of scope *by construction*. That matters because the fixture side is the side with the long tail — this tree reads at least nine distinct fixture formats — and a denylist has to grow with every new one, failing **open** each time someone forgets. An extension allowlist fails **closed**: a new fixture type is simply not flagged, and a new source type has to be added deliberately.

The literal may be written at the read site or bound once and named (`const FIXTURE: &str = …` is this tree's usual spelling, so the resolution is one hop from a `const`/`static`/`let` to a literal).

## The properties inherited from the existing gate

The detector lexes Rust rather than grepping it, and keeps the three things the header documents as hard-won:

- **Prose is not code.** A path is read only from a string-literal token, so a doc comment naming `src/unit_scale.rs` can never stand in for one. Live in this tree: `styling_parity.rs` and `module_size_ratchet.rs` each name several `.rs` paths in prose.
- **A marker is read only from comment trivia**, so a string containing `@source-text-assertion-ok` cannot forge one. Pinned as a test.
- **A comment inside the read does not break the range logic (#3174).** The marker's reach is the enclosing statement as a *character* range, found by scanning the masked plane back to the previous `;`/`{`/`}` — not a run of lines that look unfinished. Verified by applying the remedy the gate itself prints, with an interior comment, and watching it clear both the assertion and the dead-marker error.

Rust-specific lexing that a naive scan gets wrong — raw strings (`r#"…"#`, any hash count), byte and byte-raw strings, **nested** block comments (legal in Rust), and the `'` char-literal/lifetime ambiguity — is handled because each of those, left alone, fails **open**: it swallows the rest of the file and the gate goes quiet. That is how every pre-#3174 bug in the TypeScript detector presented.

The marker vocabulary is shared (`// @source-text-assertion-ok <reason>`) so the repo has one word for this, and marked sites stay **named** in the output.

## Proof — three cells

**(a) RED, naming the file.** Planted in `rust/core/tests/unit_scale_parity.rs`, with a doc comment naming the same path on the line above to prove prose does not double-count:

```
  let src = std::fs::read_to_string("src/unit_scale.rs").expect("read subject source");
  assert!(src.contains("fn unit_scale"), "unit_scale is declared");
```

```
$ node scripts/check-rust-source-text-assertions.mjs

Source-text assertions found in Rust test code:

  rust/core/tests/unit_scale_parity.rs:29  read_to_string of src/unit_scale.rs
…
EXIT=1
```

**(b) Reverted by the inverse edit, byte-identical, GREEN.**

```
$ git show upstream/main:rust/core/tests/unit_scale_parity.rs > /tmp/orig_usp.rs
$ diff -q /tmp/orig_usp.rs rust/core/tests/unit_scale_parity.rs; echo "DIFF_EXIT=$?"
DIFF_EXIT=0
$ node scripts/check-rust-source-text-assertions.mjs; echo "EXIT=$?"
check-rust-source-text-assertions: OK (589 .rs files, 413 with test code, 108 reads examined, 0 source-text assertions)
EXIT=0
```

**(c) It does not flag the legitimate cases.** A gate with false positives gets suppressed and then protects nothing, so this was measured on the real files, not asserted:

```
rust/processing/tests/styling_parity.rs: reads=2 hits=[] marked=[]
rust/processing/tests/module_size_ratchet.rs: reads=2 hits=[] marked=[]
rust/core/tests/unit_scale_parity.rs: reads=1 hits=[] marked=[]
rust/processing/tests/mesh_determinism.rs: reads=2 hits=[] marked=[]
rust/processing/tests/issue_1910_bootstrap_regression.rs: reads=1 hits=[] marked=[]
rust/geometry/tests/issue_098_atomic_cut.rs: reads=2 hits=[] marked=[]
```

Those cover all three shapes that could have gone wrong: the two repo-wide ratchets that legitimately read `.rs` files through a directory walk; `styling_parity.rs:243`'s `rel.ends_with("rust/processing/tests/styling_parity.rs")`, a `.rs` string literal that is not a read; and `module_size_ratchet.rs:11`'s doc comment naming `.rs`. Over the whole tree: **0 offenders, 0 dead markers**, so the gate lands green with an empty allowlist and no marker anywhere.

Also planted and reverted separately: a doc comment and a bare `let _prose = "src/unit_scale.rs";` in the same test, which produced `reads=1 hits=[]` — prose and non-read literals stay unflagged.

## Vacuity — the #3194 / PR #3197 idiom

Four hard failures, none of them silent: a **missing scan root**, a root with **no `.rs` files**, **zero test files** among the `.rs` files, and a total read count below **`READ_FLOOR`**. Each message says it is refusing a vacuous pass and names what it expected.

The floor is **measured, not a round number**: 108 reads across 413 files carrying test code on `cd9405b52`, floored at **90**. It earned its keep during development — a `\s*` in the const-resolution regex ran on past the `=` and swallowed the blanked literal, silently losing that entire hop; that is exactly the fail-quiet shape the floor is for, and there is now a comment in the code saying so.

`isMainEntry()` compares resolved paths rather than URLs, for the reason `check-refwalk-guards.mjs` spells out at length, and a spawned test runs the gate from a temp dir **containing a space** and asserts on its *output*, not its exit code — a module that falls through prints nothing and exits 0.

## Tests and wiring

`scripts/check-rust-source-text-assertions.test.mjs` — 29 tests, all against synthetic Rust in `mkdtemp`, never against `rust/`, so a change in a real crate can neither break them nor make them vacuously green. Grouped as firing / not firing / vacuity, plus the lexer cases and the allowlist ratchet in both directions.

```
$ node --test scripts/check-rust-source-text-assertions.test.mjs
# tests 29
# pass 29
# fail 0
```

CI: wired in `.github/workflows/test.yml` immediately after the TypeScript gate's two steps and in the same job, matching how that one and the refwalk pair are wired — the gate's **own tests run first**, because this check's value is entirely in not passing vacuously. `pnpm check:rust-source-text-assertions` added alongside its siblings. `node scripts/check-test-wiring.mjs` passes with the new script counted as a wired CI gate.

**No changeset**: CI-only tooling, no workspace package changes behaviour. `node scripts/check-changesets.mjs` agrees.

## What I could not verify

`pnpm lint` fails locally at `check-unused-locals` with "these packages do not compile standalone" for ~30 packages — the known local artifact of an unbuilt tree, not touched by this diff (which adds four `scripts/` files and edits `package.json` and the workflow). `check-changesets` and `check-test-glob-coverage`, the two `lint` steps that can see this change, both pass.

## Known limitations, stated in the detector's header rather than left implicit

- **Not caught:** a source read whose path is *computed* — a directory walk filtering on `extension() == Some("rs")`. That is the shape both legitimate ratchets use. Flagging every read under such a walk was measured and rejected: it flags both of them, and a gate whose first act is to demand markers on correct code gets suppressed wholesale.
- **Not caught:** a path assembled by `format!`/`join`/`push`, or passed through a helper (resolution is one hop, not a dataflow).
- **Deliberately out of scope:** a source read from non-test code — the rule is about tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
