### PR TITLE
fix(scripts): typecheck-tests --audit reported a clean tree it never opened (#3200)

### DIFF
--- a/scripts/typecheck-tests.mjs
+++ b/scripts/typecheck-tests.mjs
@@ -49,7 +49,8 @@
  * different fixes, and neither of them means "this package has no tests".
  *
  * SCAN SCOPE, stated so nobody mistakes the OK for a whole-repo claim: the
- * audit walks `packages/*` and `apps/*`. Test files under `tests/` are NOT in
+ * audit walks every parent `pnpm-workspace.yaml` declares — `packages/*`,
+ * `apps/*` and `examples/*`. Test files under `tests/` are NOT in
  * any typecheck program today (`tests/tsconfig.json` extends the root config,
  * whose `exclude` carries `**\/*.test.ts`, and `tsx --test` transpiles without
  * checking) — the very #2457 gap this file exists to close, one directory
@@ -69,23 +70,54 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
 const SCRIPT_NAME = 'typecheck-tests.mjs';
 const TSC = path.join(REPO_ROOT, 'node_modules', 'typescript', 'bin', 'tsc');
 const TEST_FILE_RE = /\.test\.(ts|tsx|mts|cts)$/;
-const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', '.git', '.turbo']);
+// `target` is Rust's build directory (apps/server is a crate). Nothing under
+// it matches TEST_FILE_RE, so skipping it fixes no false positive — it stops
+// the walk descending through a whole Rust build tree on every local run. CI
+// checkouts are clean, so this is a local-speed change only. Safe to skip
+// unconditionally: `.gitignore` carries a repo-wide `target/`, so no directory
+// of that name can hold a tracked test file.
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', '.git', '.turbo', 'target']);
 const GENERATED_CONFIG = 'tsconfig.tests.json';
 
 /**
  * Package parents the audit walks. Not the whole repo — see SCAN SCOPE above.
+ *
+ * All three of the parents `pnpm-workspace.yaml` declares. `examples` was
+ * missing until the #3201 review, and that gap was the same shape as the
+ * skipped-directory bug fixed below, one level further out and strictly worse:
+ * an unwatched PARENT is never a skipped DIRECTORY, so the "look inside every
+ * skipped directory" check could not reach it either. `examples/*` members are
+ * real TypeScript workspace packages with their own tsconfigs, so a test at
+ * `examples/collab-demo/src/foo.test.ts` escaped in silence. Adding the parent
+ * changed no count on a healthy tree — `find examples -name '*.test.*'` returns
+ * 0 today, so the audit still reports 1,434 files across 46 packages — which is
+ * exactly why only a regression test keeps it closed (typecheck-tests.test.mjs).
  */
-const PACKAGE_PARENTS = ['packages', 'apps'];
+const PACKAGE_PARENTS = ['packages', 'apps', 'examples'];
+
+/** `packages/`; `packages/ and apps/`; `packages/, apps/ and examples/`. */
+function parentList(names) {
+  const parts = names.map((p) => `${p}/`);
+  if (parts.length <= 1) return parts.join('');
+  return `${parts.slice(0, -1).join(', ')} and ${parts.at(-1)}`;
+}
 
 /**
  * Lower bound on how many workspace packages must actually reach the audit.
- * Measured on a healthy tree: 46 packages under `packages/` + `apps/` carry
- * test files. Set to 30 — about a third of headroom, enough that ordinary
+ * Measured on a healthy tree: 46 packages carry test files, all of them under
+ * `packages/` and `apps/` — no `examples/*` member has one today. Set to 30 — about a third of headroom, enough that ordinary
  * churn (a package split, a few merged or retired) never forces an edit here,
- * while the failure this guards against still trips: every way the audit goes
- * blind (a wrong scan root, a `readdirSync` that returns nothing, a
- * package.json read that stops finding files) collapses the count to zero or
- * near it, not to 29.
+ * while the failure this guards against still trips: it is the WHOLESALE
+ * blindings this floor is sized for — a wrong scan root, a `readdirSync` that
+ * returns nothing, a package.json read that stops finding files — and each of
+ * those collapses the count to zero or near it, not to 29.
+ *
+ * It is deliberately not the guard for a PARTIAL drop, and this PR's own change
+ * supplies the counter-example: a package that loses its `tsconfig.json` stops
+ * being audited and the count falls by one. That case is caught earlier and by
+ * name — if the package carries test files the skipped-directory check in
+ * `audit()` fails the run before these counts are consulted, and if it carries
+ * none, no coverage was lost by dropping it.
  */
 const AUDITED_PACKAGES_FLOOR = 30;
 
@@ -285,7 +317,7 @@ export function auditVacuity({
 }) {
   if (seenParents.length === 0) {
     return (
-      `none of ${PACKAGE_PARENTS.map((p) => `${p}/`).join(', ')} exists under ${scanRoot}. ` +
+      `none of ${parentList(PACKAGE_PARENTS)} exists under ${scanRoot}. ` +
       `Refusing a vacuous pass: this audit exists to prove workspace test files reach a typecheck ` +
       `program, and it found nowhere to look for them.`
     );
@@ -293,7 +325,7 @@ export function auditVacuity({
   if (packagesWithTests === null || testFiles === null) return null;
   if (packagesWithTests === 0) {
     return (
-      `${seenParents.map((p) => `${p}/`).join(' and ')} contain no package with a test file. ` +
+      `${parentList(seenParents)} contain no package with a test file. ` +
       `Refusing a vacuous pass: an audit that found zero test files has proved nothing about ` +
       `typecheck coverage.`
     );
@@ -318,7 +350,7 @@ export function auditVacuity({
 }
 
 /**
- * Repo-wide mode: prove every test file under `packages/` and `apps/` is a
+ * Repo-wide mode: prove every test file under the workspace parents is a
  * root file of some typecheck program, and that every package carrying tests
  * actually runs one. This is the part that fails when a test file stops being
  * checked — without it the arrangement rots the next time a package is added.
@@ -356,7 +388,13 @@ async function audit({
     problems.push(
       `${rel}: ${stray.length} test file(s) on disk but no ${missing.join(' and no ')}, ` +
         `so this audit cannot resolve a typecheck program for it and skipped it entirely. ` +
-        `Add the missing file(s), or move the tests into a package that has them.`,
+        `Add the missing file(s), or move the tests into a package that has them. ` +
+        // Both reds are correct and precise, but they arrive one CI run apart:
+        // adding the tsconfig.json this asks for promotes the directory into
+        // the walk below, which then fails it for having no "typecheck"
+        // script. Name both here so the fix is one round trip, not two.
+        `A directory promoted this way also needs a "typecheck" script — under packages/ that must be ` +
+        `"node ../../scripts/${SCRIPT_NAME}" — or the next run fails on that instead.`,
     );
   }
 
@@ -387,7 +425,11 @@ async function audit({
     }
 
     // Which project is supposed to cover this package's tests? Packages use
-    // the generated test program; the two apps typecheck their own tsconfig.
+    // the generated test program; apps and examples typecheck their own
+    // tsconfig. That is right for examples/*: unlike packages/*, their
+    // tsconfigs are standalone (no `extends` of the root config), so they
+    // never inherit the `**/*.test.ts` exclude that makes the generated
+    // program necessary — `"include": ["src"]` already reaches their tests.
     const generated = rel.startsWith('packages/') ? writeTestProgram(dir) : null;
     const project = generated?.config ?? path.join(dir, 'tsconfig.json');
 
@@ -447,7 +489,7 @@ async function audit({
 
   console.log(
     `\ntypecheck-tests: all ${totalOn} test file(s) across ${rows.length} package(s) under ` +
-      `${PACKAGE_PARENTS.map((p) => `${p}/`).join(' and ')} are in a typecheck program.`,
+      `${parentList(PACKAGE_PARENTS)} are in a typecheck program.`,
   );
   return 0;
 }

--- a/scripts/typecheck-tests.mjs
+++ b/scripts/typecheck-tests.mjs
@@ -34,6 +34,27 @@
  * Usage:
  *   node ../../scripts/typecheck-tests.mjs     (cwd = a package; the per-package `typecheck` script)
  *   node scripts/typecheck-tests.mjs --audit   (cwd = repo root; the repo-wide coverage gate)
+ *
+ * ANTI-VACUITY (#3194, #3200). `--audit` used to print
+ * `TOTAL 0 / 0` followed by `every test file on disk is in a typecheck
+ * program.` and exit 0 when it found no packages at all — a scan of nothing
+ * reported as a clean scan. Reproduced by running a copy of this script from
+ * an otherwise-empty tree, and again from a tree where `packages/` and `apps/`
+ * exist but are empty. Four guards now stand between an empty input set and
+ * that success line: neither package parent existing is a failure, no package
+ * carrying tests is a failure, and — against the real repo, where a collapse
+ * would otherwise be invisible — fewer than `AUDITED_PACKAGES_FLOOR` packages
+ * or `TEST_FILES_FLOOR` test files is a failure. A directory the walk cannot
+ * read is loud too, and distinguished from one that is missing: they call for
+ * different fixes, and neither of them means "this package has no tests".
+ *
+ * SCAN SCOPE, stated so nobody mistakes the OK for a whole-repo claim: the
+ * audit walks `packages/*` and `apps/*`. Test files under `tests/` are NOT in
+ * any typecheck program today (`tests/tsconfig.json` extends the root config,
+ * whose `exclude` carries `**\/*.test.ts`, and `tsx --test` transpiles without
+ * checking) — the very #2457 gap this file exists to close, one directory
+ * over, and tracked in #3200. The success line names its scope rather than
+ * claiming every test file on disk.
  */
 
 import { execFile } from 'node:child_process';
@@ -51,13 +72,49 @@ const TEST_FILE_RE = /\.test\.(ts|tsx|mts|cts)$/;
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', '.git', '.turbo']);
 const GENERATED_CONFIG = 'tsconfig.tests.json';
 
+/**
+ * Package parents the audit walks. Not the whole repo — see SCAN SCOPE above.
+ */
+const PACKAGE_PARENTS = ['packages', 'apps'];
+
+/**
+ * Lower bound on how many workspace packages must actually reach the audit.
+ * Measured on a healthy tree: 46 packages under `packages/` + `apps/` carry
+ * test files. Set to 30 — about a third of headroom, enough that ordinary
+ * churn (a package split, a few merged or retired) never forces an edit here,
+ * while the failure this guards against still trips: every way the audit goes
+ * blind (a wrong scan root, a `readdirSync` that returns nothing, a
+ * package.json read that stops finding files) collapses the count to zero or
+ * near it, not to 29.
+ */
+const AUDITED_PACKAGES_FLOOR = 30;
+
+/**
+ * Lower bound on how many test files the walk must find. A second floor,
+ * because the audit has two independent ways to go blind and each leaves the
+ * other's number looking healthy: the package enumeration can collapse, or the
+ * package walk can succeed while `findTestFiles` stops recognising test files
+ * (a change to TEST_FILE_RE, a new extension). Measured on a healthy tree:
+ * 1,434 test files. Set to 900.
+ */
+const TEST_FILES_FLOOR = 900;
+
 /** Test files on disk under `dir`, sorted, repo-relative-free (absolute). */
 function findTestFiles(dir, out = []) {
   let entries;
   try {
     entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return out;
+  } catch (err) {
+    // A directory that is MISSING and one that cannot be READ are different
+    // events, and neither of them is "this package has no test files". The
+    // previous `catch { return out; }` collapsed both into an empty result,
+    // which is how `--audit` could report a clean tree it never opened.
+    throw new Error(
+      err?.code === 'ENOENT'
+        ? `${dir} does not exist — refusing to treat a missing directory as one containing no test files`
+        : `${dir} could not be read (${err?.code ?? err?.message}) — refusing to treat an unreadable directory as one containing no test files`,
+      { cause: err },
+    );
   }
   for (const entry of entries) {
     if (SKIP_DIRS.has(entry.name)) continue;
@@ -167,11 +224,16 @@ async function checkOnePackage(pkgDir) {
   return 0;
 }
 
-function workspaceDirs() {
+/**
+ * @param {string[]} [seenParents] filled with the package parents that exist,
+ *   so a caller can tell "no packages here" from "nowhere to look for them".
+ */
+function workspaceDirs(seenParents = []) {
   const dirs = [];
-  for (const group of ['packages', 'apps']) {
+  for (const group of PACKAGE_PARENTS) {
     const base = path.join(REPO_ROOT, group);
     if (!existsSync(base)) continue;
+    seenParents.push(group);
     for (const name of readdirSync(base).sort()) {
       const dir = path.join(base, name);
       if (!statSync(dir).isDirectory()) continue;
@@ -184,16 +246,78 @@ function workspaceDirs() {
 }
 
 /**
- * Repo-wide mode: prove every test file on disk is a root file of some
- * typecheck program, and that every package carrying tests actually runs one.
- * This is the part that fails when a test file stops being checked — without
- * it the arrangement rots the next time a package is added.
+ * Does this audit run have enough input to mean anything? Returns the refusal
+ * message, or null when the run is worth trusting.
+ *
+ * Pure and exported so `typecheck-tests.test.mjs` can drive every branch: the
+ * audit itself has no `--root` flag (REPO_ROOT comes from this file's own
+ * location), so the only way to exercise these paths end-to-end is to copy the
+ * script into an empty tree, which is how the defect was reproduced but is not
+ * a shape this repo's harnesses use.
+ *
+ * `packagesWithTests` / `testFiles` are null on the structural pass, which
+ * runs before any tsc invocation; the quantitative floors need counts that
+ * only exist after the walk.
+ *
+ * @param {{seenParents: string[], packagesWithTests: number|null, testFiles: number|null}} counts
+ * @returns {string|null}
+ */
+export function auditVacuity({ seenParents, packagesWithTests, testFiles }) {
+  if (seenParents.length === 0) {
+    return (
+      `none of ${PACKAGE_PARENTS.map((p) => `${p}/`).join(', ')} exists under ${REPO_ROOT}. ` +
+      `Refusing a vacuous pass: this audit exists to prove workspace test files reach a typecheck ` +
+      `program, and it found nowhere to look for them.`
+    );
+  }
+  if (packagesWithTests === null || testFiles === null) return null;
+  if (packagesWithTests === 0) {
+    return (
+      `${seenParents.map((p) => `${p}/`).join(' and ')} contain no package with a test file. ` +
+      `Refusing a vacuous pass: an audit that found zero test files has proved nothing about ` +
+      `typecheck coverage.`
+    );
+  }
+  if (packagesWithTests < AUDITED_PACKAGES_FLOOR) {
+    return (
+      `only ${packagesWithTests} package(s) carried test files, floor is ${AUDITED_PACKAGES_FLOOR}. ` +
+      `Refusing a vacuous pass: this repo has about 46, so a count this low means the package walk ` +
+      `stopped working, not that the packages went away. If packages were genuinely removed, lower ` +
+      `AUDITED_PACKAGES_FLOOR in the same commit.`
+    );
+  }
+  if (testFiles < TEST_FILES_FLOOR) {
+    return (
+      `only ${testFiles} test file(s) found, floor is ${TEST_FILES_FLOOR}. ` +
+      `Refusing a vacuous pass: this repo has about 1,434, so a count this low means the test-file ` +
+      `walk or TEST_FILE_RE stopped matching, not that the tests went away. If tests were genuinely ` +
+      `removed, lower TEST_FILES_FLOOR in the same commit.`
+    );
+  }
+  return null;
+}
+
+/**
+ * Repo-wide mode: prove every test file under `packages/` and `apps/` is a
+ * root file of some typecheck program, and that every package carrying tests
+ * actually runs one. This is the part that fails when a test file stops being
+ * checked — without it the arrangement rots the next time a package is added.
  */
 async function audit() {
   const rows = [];
   const problems = [];
+  const seenParents = [];
+  const dirs = workspaceDirs(seenParents);
 
-  for (const dir of workspaceDirs()) {
+  // Anti-vacuity, structural. Checked before any tsc runs, because with an
+  // empty input set everything below it succeeds by having nothing to do.
+  const vacuous = auditVacuity({ seenParents, packagesWithTests: null, testFiles: null });
+  if (vacuous) {
+    console.error(`\ntypecheck-tests: ${vacuous}`);
+    return 1;
+  }
+
+  for (const dir of dirs) {
     const rel = toPosix(path.relative(REPO_ROOT, dir));
     const onDisk = findTestFiles(dir).sort();
     if (onDisk.length === 0) continue;
@@ -239,6 +363,17 @@ async function audit() {
     rows.push({ pkg: rel, inProgram: onDisk.length - missing.length, onDisk: onDisk.length });
   }
 
+  // No rows means nothing was measured, so there is no table to print and
+  // `Math.max()` over an empty list would be -Infinity. Refuse here rather
+  // than fall through to a success line describing a run that looked at
+  // nothing.
+  if (rows.length === 0) {
+    console.error(
+      `\ntypecheck-tests: ${auditVacuity({ seenParents, packagesWithTests: 0, testFiles: 0 })}`,
+    );
+    return 1;
+  }
+
   const width = Math.max(...rows.map((r) => r.pkg.length));
   for (const row of rows) {
     const flag = row.inProgram === row.onDisk ? ' ' : '!';
@@ -253,7 +388,23 @@ async function audit() {
     for (const p of problems) console.error(`  - ${p}`);
     return 1;
   }
-  console.log('\ntypecheck-tests: every test file on disk is in a typecheck program.');
+
+  // Anti-vacuity, quantitative. After the offenders check: a run that found a
+  // real problem should say so rather than argue about how much it measured.
+  const undersized = auditVacuity({
+    seenParents,
+    packagesWithTests: rows.length,
+    testFiles: totalOn,
+  });
+  if (undersized) {
+    console.error(`\ntypecheck-tests: ${undersized}`);
+    return 1;
+  }
+
+  console.log(
+    `\ntypecheck-tests: all ${totalOn} test file(s) across ${rows.length} package(s) under ` +
+      `${PACKAGE_PARENTS.map((p) => `${p}/`).join(' and ')} are in a typecheck program.`,
+  );
   return 0;
 }
 

--- a/scripts/typecheck-tests.mjs
+++ b/scripts/typecheck-tests.mjs
@@ -228,7 +228,7 @@ async function checkOnePackage(pkgDir) {
  * @param {string[]} [seenParents] filled with the package parents that exist,
  *   so a caller can tell "no packages here" from "nowhere to look for them".
  */
-function workspaceDirs(seenParents = [], scanRoot = REPO_ROOT) {
+function workspaceDirs(seenParents = [], scanRoot = REPO_ROOT, skipped = []) {
   const dirs = [];
   for (const group of PACKAGE_PARENTS) {
     const base = path.join(scanRoot, group);
@@ -237,8 +237,17 @@ function workspaceDirs(seenParents = [], scanRoot = REPO_ROOT) {
     for (const name of readdirSync(base).sort()) {
       const dir = path.join(base, name);
       if (!statSync(dir).isDirectory()) continue;
-      if (!existsSync(path.join(dir, 'tsconfig.json'))) continue;
-      if (!existsSync(path.join(dir, 'package.json'))) continue;
+      const missing = [];
+      if (!existsSync(path.join(dir, 'tsconfig.json'))) missing.push('tsconfig.json');
+      if (!existsSync(path.join(dir, 'package.json'))) missing.push('package.json');
+      // A directory without both files cannot be audited — there is no program
+      // to resolve and no `typecheck` script to check. But "cannot be audited"
+      // is not "has no tests": the caller has to look inside before the run
+      // may claim it covered this parent. See auditSkipped() below.
+      if (missing.length > 0) {
+        skipped.push({ dir, missing });
+        continue;
+      }
       dirs.push(dir);
     }
   }
@@ -322,7 +331,8 @@ async function audit({
   const rows = [];
   const problems = [];
   const seenParents = [];
-  const dirs = workspaceDirs(seenParents, scanRoot);
+  const skipped = [];
+  const dirs = workspaceDirs(seenParents, scanRoot, skipped);
   const floors = { scanRoot, packagesFloor, testFilesFloor };
 
   // Anti-vacuity, structural. Checked before any tsc runs, because with an
@@ -331,6 +341,23 @@ async function audit({
   if (vacuous) {
     console.error(`\ntypecheck-tests: ${vacuous}`);
     return 1;
+  }
+
+  // #3201 review: the success line said "all N test file(s) ... under
+  // packages/ and apps/ are in a typecheck program", but workspaceDirs skips
+  // any directory missing tsconfig.json or package.json, and those files were
+  // never counted. A package added without a tsconfig.json therefore had its
+  // tests escape silently — the exact #2457 rot this gate exists to stop, one
+  // level up. Look inside every skipped directory before claiming the parent.
+  for (const { dir, missing } of skipped) {
+    const rel = toPosix(path.relative(scanRoot, dir));
+    const stray = findTestFiles(dir);
+    if (stray.length === 0) continue;
+    problems.push(
+      `${rel}: ${stray.length} test file(s) on disk but no ${missing.join(' and no ')}, ` +
+        `so this audit cannot resolve a typecheck program for it and skipped it entirely. ` +
+        `Add the missing file(s), or move the tests into a package that has them.`,
+    );
   }
 
   for (const dir of dirs) {

--- a/scripts/typecheck-tests.mjs
+++ b/scripts/typecheck-tests.mjs
@@ -228,10 +228,10 @@ async function checkOnePackage(pkgDir) {
  * @param {string[]} [seenParents] filled with the package parents that exist,
  *   so a caller can tell "no packages here" from "nowhere to look for them".
  */
-function workspaceDirs(seenParents = []) {
+function workspaceDirs(seenParents = [], scanRoot = REPO_ROOT) {
   const dirs = [];
   for (const group of PACKAGE_PARENTS) {
-    const base = path.join(REPO_ROOT, group);
+    const base = path.join(scanRoot, group);
     if (!existsSync(base)) continue;
     seenParents.push(group);
     for (const name of readdirSync(base).sort()) {
@@ -249,11 +249,15 @@ function workspaceDirs(seenParents = []) {
  * Does this audit run have enough input to mean anything? Returns the refusal
  * message, or null when the run is worth trusting.
  *
- * Pure and exported so `typecheck-tests.test.mjs` can drive every branch: the
- * audit itself has no `--root` flag (REPO_ROOT comes from this file's own
- * location), so the only way to exercise these paths end-to-end is to copy the
- * script into an empty tree, which is how the defect was reproduced but is not
- * a shape this repo's harnesses use.
+ * Pure and exported so `typecheck-tests.test.mjs` can drive every branch in
+ * isolation. That is NOT sufficient on its own: testing this function only
+ * through direct calls leaves nothing asserting that `audit()` still calls it,
+ * and all four call sites could be deleted with the suite green (#3201
+ * review). `audit()` therefore takes an injectable `scanRoot` and injectable
+ * floors — the `opts.candidateFloor ?? CANDIDATE_FLOOR` seam that
+ * `check-refwalk-guards.mjs` uses — so the same tests drive the refusals END TO
+ * END through `audit()` against a synthetic tree. The CLI exposes no override,
+ * so the gate itself always runs the real root and the real floors.
  *
  * `packagesWithTests` / `testFiles` are null on the structural pass, which
  * runs before any tsc invocation; the quantitative floors need counts that
@@ -262,10 +266,17 @@ function workspaceDirs(seenParents = []) {
  * @param {{seenParents: string[], packagesWithTests: number|null, testFiles: number|null}} counts
  * @returns {string|null}
  */
-export function auditVacuity({ seenParents, packagesWithTests, testFiles }) {
+export function auditVacuity({
+  seenParents,
+  packagesWithTests,
+  testFiles,
+  scanRoot = REPO_ROOT,
+  packagesFloor = AUDITED_PACKAGES_FLOOR,
+  testFilesFloor = TEST_FILES_FLOOR,
+}) {
   if (seenParents.length === 0) {
     return (
-      `none of ${PACKAGE_PARENTS.map((p) => `${p}/`).join(', ')} exists under ${REPO_ROOT}. ` +
+      `none of ${PACKAGE_PARENTS.map((p) => `${p}/`).join(', ')} exists under ${scanRoot}. ` +
       `Refusing a vacuous pass: this audit exists to prove workspace test files reach a typecheck ` +
       `program, and it found nowhere to look for them.`
     );
@@ -278,17 +289,17 @@ export function auditVacuity({ seenParents, packagesWithTests, testFiles }) {
       `typecheck coverage.`
     );
   }
-  if (packagesWithTests < AUDITED_PACKAGES_FLOOR) {
+  if (packagesWithTests < packagesFloor) {
     return (
-      `only ${packagesWithTests} package(s) carried test files, floor is ${AUDITED_PACKAGES_FLOOR}. ` +
+      `only ${packagesWithTests} package(s) carried test files, floor is ${packagesFloor}. ` +
       `Refusing a vacuous pass: this repo has about 46, so a count this low means the package walk ` +
       `stopped working, not that the packages went away. If packages were genuinely removed, lower ` +
       `AUDITED_PACKAGES_FLOOR in the same commit.`
     );
   }
-  if (testFiles < TEST_FILES_FLOOR) {
+  if (testFiles < testFilesFloor) {
     return (
-      `only ${testFiles} test file(s) found, floor is ${TEST_FILES_FLOOR}. ` +
+      `only ${testFiles} test file(s) found, floor is ${testFilesFloor}. ` +
       `Refusing a vacuous pass: this repo has about 1,434, so a count this low means the test-file ` +
       `walk or TEST_FILE_RE stopped matching, not that the tests went away. If tests were genuinely ` +
       `removed, lower TEST_FILES_FLOOR in the same commit.`
@@ -303,22 +314,27 @@ export function auditVacuity({ seenParents, packagesWithTests, testFiles }) {
  * actually runs one. This is the part that fails when a test file stops being
  * checked — without it the arrangement rots the next time a package is added.
  */
-async function audit() {
+async function audit({
+  scanRoot = REPO_ROOT,
+  packagesFloor = AUDITED_PACKAGES_FLOOR,
+  testFilesFloor = TEST_FILES_FLOOR,
+} = {}) {
   const rows = [];
   const problems = [];
   const seenParents = [];
-  const dirs = workspaceDirs(seenParents);
+  const dirs = workspaceDirs(seenParents, scanRoot);
+  const floors = { scanRoot, packagesFloor, testFilesFloor };
 
   // Anti-vacuity, structural. Checked before any tsc runs, because with an
   // empty input set everything below it succeeds by having nothing to do.
-  const vacuous = auditVacuity({ seenParents, packagesWithTests: null, testFiles: null });
+  const vacuous = auditVacuity({ seenParents, packagesWithTests: null, testFiles: null, ...floors });
   if (vacuous) {
     console.error(`\ntypecheck-tests: ${vacuous}`);
     return 1;
   }
 
   for (const dir of dirs) {
-    const rel = toPosix(path.relative(REPO_ROOT, dir));
+    const rel = toPosix(path.relative(scanRoot, dir));
     const onDisk = findTestFiles(dir).sort();
     if (onDisk.length === 0) continue;
 
@@ -353,12 +369,12 @@ async function audit() {
     try {
       rootFiles = (JSON.parse(output).files ?? []).map((f) => path.resolve(dir, f));
     } catch {
-      problems.push(`${rel}: could not read the resolved config for ${toPosix(path.relative(REPO_ROOT, project))}`);
+      problems.push(`${rel}: could not read the resolved config for ${toPosix(path.relative(scanRoot, project))}`);
     }
     const covered = new Set(rootFiles.filter((f) => TEST_FILE_RE.test(f)));
     const missing = onDisk.filter((f) => !covered.has(f));
     for (const f of missing) {
-      problems.push(`${toPosix(path.relative(REPO_ROOT, f))} is in no typecheck program`);
+      problems.push(`${toPosix(path.relative(scanRoot, f))} is in no typecheck program`);
     }
     rows.push({ pkg: rel, inProgram: onDisk.length - missing.length, onDisk: onDisk.length });
   }
@@ -369,7 +385,7 @@ async function audit() {
   // nothing.
   if (rows.length === 0) {
     console.error(
-      `\ntypecheck-tests: ${auditVacuity({ seenParents, packagesWithTests: 0, testFiles: 0 })}`,
+      `\ntypecheck-tests: ${auditVacuity({ seenParents, packagesWithTests: 0, testFiles: 0, ...floors })}`,
     );
     return 1;
   }
@@ -395,6 +411,7 @@ async function audit() {
     seenParents,
     packagesWithTests: rows.length,
     testFiles: totalOn,
+    ...floors,
   });
   if (undersized) {
     console.error(`\ntypecheck-tests: ${undersized}`);
@@ -484,7 +501,7 @@ export function parseCliMode(args) {
   return { error: `expected at most one argument, got ${args.map((a) => JSON.stringify(a)).join(' ')}` };
 }
 
-export { writeTestProgram, GENERATED_CONFIG, relativeExtends };
+export { audit, writeTestProgram, GENERATED_CONFIG, relativeExtends };
 
 // Only run the CLI when invoked as one — importing this must not typecheck the
 // repo and call process.exit.

--- a/scripts/typecheck-tests.test.mjs
+++ b/scripts/typecheck-tests.test.mjs
@@ -23,13 +23,16 @@
  * every package under packages/ happens to get a `../../`-prefixed path that
  * resolves fine — which is exactly why it needs a test rather than a comment.
  *
+ * A second group at the bottom covers anti-vacuity rather than `extends`
+ * semantics: `--audit` used to print a success line after measuring nothing.
+ *
  * Run: node --test scripts/typecheck-tests.test.mjs
  */
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { relativeExtends, parseCliMode } from './typecheck-tests.mjs';
+import { relativeExtends, parseCliMode, auditVacuity } from './typecheck-tests.mjs';
 
 test('a sibling base config is ./-prefixed, not bare', () => {
   // The repo-root case: pkgDir and the base config are the same directory.
@@ -138,4 +141,64 @@ test('every rejection names the offending argument, so the message is actionable
       `error for "${args.join(' ')}" must name ${offender}, got: ${result.error}`,
     );
   }
+});
+
+// --- Anti-vacuity: an audit that measured nothing must not report a clean run ---
+//
+// `--audit` used to print `TOTAL 0 / 0` and `every test file on disk is in a
+// typecheck program.` with exit 0 when it found no packages at all, so CI read
+// "we looked and it was clean" from a run that had looked at nothing. The
+// audit takes no `--root` (REPO_ROOT comes from the script's own location), so
+// the end-to-end reproduction is a copy of the script run from an empty tree;
+// `auditVacuity` is the decision that reproduction exercises, driven directly
+// here so every branch has a case.
+
+test('vacuity: no package parent at all is a refusal, not a clean audit', () => {
+  const msg = auditVacuity({ seenParents: [], packagesWithTests: null, testFiles: null });
+  assert.ok(msg, 'a tree with neither packages/ nor apps/ must be refused');
+  assert.match(msg, /Refusing a vacuous pass/);
+  assert.match(msg, /none of packages\/, apps\/ exists/);
+});
+
+test('vacuity: package parents that hold no tests are a refusal', () => {
+  const msg = auditVacuity({ seenParents: ['packages', 'apps'], packagesWithTests: 0, testFiles: 0 });
+  assert.ok(msg, 'zero packages carrying tests must be refused');
+  assert.match(msg, /Refusing a vacuous pass/);
+  assert.match(msg, /no package with a test file/);
+});
+
+test('vacuity: the structural pass runs before any count exists', () => {
+  // Called once before the walk, when the counts are still unknown: only the
+  // "nowhere to look" branch may fire, and a healthy parent list must not.
+  assert.equal(
+    auditVacuity({ seenParents: ['packages', 'apps'], packagesWithTests: null, testFiles: null }),
+    null,
+  );
+});
+
+test('vacuity: a package count far under the floor is a refusal', () => {
+  const msg = auditVacuity({ seenParents: ['packages', 'apps'], packagesWithTests: 2, testFiles: 40 });
+  assert.ok(msg, 'two packages is a collapsed walk, not a shrunken repo');
+  assert.match(msg, /only 2 package\(s\) carried test files, floor is 30/);
+  // The remedy must name the constant to change, so the fix is not a guess.
+  assert.match(msg, /AUDITED_PACKAGES_FLOOR/);
+});
+
+test('vacuity: a healthy package count with a collapsed test-file count is still a refusal', () => {
+  // The two floors are independent on purpose: the package enumeration can
+  // work while findTestFiles/TEST_FILE_RE stops recognising test files, and
+  // that leaves the package number looking entirely healthy.
+  const msg = auditVacuity({ seenParents: ['packages', 'apps'], packagesWithTests: 46, testFiles: 10 });
+  assert.ok(msg, 'a healthy package count must not excuse an empty test-file count');
+  assert.match(msg, /only 10 test file\(s\) found, floor is 900/);
+  assert.match(msg, /TEST_FILES_FLOOR/);
+});
+
+test('vacuity: the real repo\'s measured counts pass', () => {
+  // 46 packages / 1,434 test files as measured on a healthy tree. If this ever
+  // fails, the floors were raised past what the repo actually has.
+  assert.equal(
+    auditVacuity({ seenParents: ['packages', 'apps'], packagesWithTests: 46, testFiles: 1434 }),
+    null,
+  );
 });

--- a/scripts/typecheck-tests.test.mjs
+++ b/scripts/typecheck-tests.test.mjs
@@ -323,3 +323,54 @@ test('audit(): the same tree passes once both floors are below what it holds', a
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('audit(): a package with tests but no tsconfig.json is a failure, not a silent skip', async () => {
+  // #3201 review finding 3. workspaceDirs skips a directory missing either
+  // tsconfig.json or package.json. Before this check, the tests inside such a
+  // directory were never counted and never mentioned, while the success line
+  // still claimed every test file under packages/ and apps/ was in a program.
+  const root = synthTree({
+    ...appWithOneTest('one'),
+    ...appWithOneTest('two'),
+    'packages/zz-unwired/package.json': JSON.stringify({ name: 'zz-unwired' }),
+    'packages/zz-unwired/src/thing.test.ts': "const x: number = 'not a number';\n",
+  });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1, testFilesFloor: 1 });
+    assert.equal(code, 1, 'a test file in an unauditable directory must fail the gate');
+    assert.match(stderr, /packages\/zz-unwired: 1 test file\(s\) on disk but no tsconfig\.json/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): a directory missing both files is named for both', async () => {
+  const root = synthTree({
+    ...appWithOneTest('one'),
+    'packages/zz-loose/src/thing.test.ts': 'export const x = 1;\n',
+  });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1, testFilesFloor: 1 });
+    assert.equal(code, 1);
+    assert.match(stderr, /no tsconfig\.json and no package\.json/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): an unauditable directory with no tests is not a failure', async () => {
+  // The paired probe: the check must fire on stray TESTS, not on every
+  // directory that lacks a tsconfig. packages/wasm and apps/landing are real
+  // examples in this repo today, and neither carries a test file.
+  const root = synthTree({
+    ...appWithOneTest('one'),
+    'packages/zz-nobuild/package.json': JSON.stringify({ name: 'zz-nobuild' }),
+    'packages/zz-nobuild/src/thing.ts': 'export const x = 1;\n',
+  });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1, testFilesFloor: 1 });
+    assert.equal(code, 0, `expected a clean audit, got: ${stderr}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/typecheck-tests.test.mjs
+++ b/scripts/typecheck-tests.test.mjs
@@ -157,9 +157,9 @@ test('every rejection names the offending argument, so the message is actionable
 
 test('vacuity: no package parent at all is a refusal, not a clean audit', () => {
   const msg = auditVacuity({ seenParents: [], packagesWithTests: null, testFiles: null });
-  assert.ok(msg, 'a tree with neither packages/ nor apps/ must be refused');
+  assert.ok(msg, 'a tree with none of the workspace parents must be refused');
   assert.match(msg, /Refusing a vacuous pass/);
-  assert.match(msg, /none of packages\/, apps\/ exists/);
+  assert.match(msg, /none of packages\/, apps\/ and examples\/ exists/);
 });
 
 test('vacuity: package parents that hold no tests are a refusal', () => {
@@ -249,16 +249,25 @@ function synthTree(spec) {
   return root;
 }
 
-/** One `apps/<name>` package carrying a single test file. */
-function appWithOneTest(name) {
+/**
+ * One `<parent>/<name>` workspace member carrying a single test file, wired so
+ * the audit can resolve a program for it: a package.json with the `scripts` it
+ * is given, and a tsconfig whose `files` already lists the test.
+ */
+function memberWithOneTest(parent, name, scripts = { typecheck: 'tsc' }) {
   return {
-    [`apps/${name}/package.json`]: JSON.stringify({ name, scripts: { typecheck: 'tsc' } }),
-    [`apps/${name}/tsconfig.json`]: JSON.stringify({
+    [`${parent}/${name}/package.json`]: JSON.stringify({ name, scripts }),
+    [`${parent}/${name}/tsconfig.json`]: JSON.stringify({
       compilerOptions: { noEmit: true },
       files: ['./src/a.test.ts'],
     }),
-    [`apps/${name}/src/a.test.ts`]: 'export const a = 1;\n',
+    [`${parent}/${name}/src/a.test.ts`]: 'export const a = 1;\n',
   };
+}
+
+/** One `apps/<name>` package carrying a single test file. */
+function appWithOneTest(name) {
+  return memberWithOneTest('apps', name);
 }
 
 test('audit(): an empty tree is refused, not reported as a clean scan', async () => {
@@ -266,7 +275,7 @@ test('audit(): an empty tree is refused, not reported as a clean scan', async ()
   try {
     const { code, stderr } = await runAudit({ scanRoot: root });
     assert.equal(code, 1);
-    assert.match(stderr, /none of packages\/, apps\/ exists under/);
+    assert.match(stderr, /none of packages\/, apps\/ and examples\/ exists under/);
     assert.match(stderr, /Refusing a vacuous pass/);
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -339,6 +348,12 @@ test('audit(): a package with tests but no tsconfig.json is a failure, not a sil
     const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1, testFilesFloor: 1 });
     assert.equal(code, 1, 'a test file in an unauditable directory must fail the gate');
     assert.match(stderr, /packages\/zz-unwired: 1 test file\(s\) on disk but no tsconfig\.json/);
+    // #3201 review finding 4: adding the tsconfig.json this message asks for
+    // promotes the directory into the walk, which then reds for a missing
+    // "typecheck" script — two CI runs for one fix. The remedy has to name
+    // both, so the message is asserted to mention the second one.
+    assert.match(stderr, /also needs a "typecheck" script/);
+    assert.match(stderr, /typecheck-tests\.mjs/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -360,8 +375,19 @@ test('audit(): a directory missing both files is named for both', async () => {
 
 test('audit(): an unauditable directory with no tests is not a failure', async () => {
   // The paired probe: the check must fire on stray TESTS, not on every
-  // directory that lacks a tsconfig. packages/wasm and apps/landing are real
-  // examples in this repo today, and neither carries a test file.
+  // directory that lacks a tsconfig. `packages/wasm` and `apps/landing` are
+  // real examples in this repo today, and neither carries a file this audit's
+  // TEST_FILE_RE matches.
+  //
+  // The two are not the same case, and the distinction matters. `apps/landing`
+  // has no test file at all. `packages/wasm` carries FIVE — package.test.mjs,
+  // styling-indexed-colour-split.test.mjs, tessellation-quality.test.mjs,
+  // textures.test.mjs, type-only-geometry.test.mjs — run by its own
+  // `"test": "node --test test/*.test.mjs"`. They are outside this gate's
+  // remit rather than absent: TEST_FILE_RE is /\.test\.(ts|tsx|mts|cts)$/, and
+  // .mjs needs no typechecking. That they are genuinely executed is asserted
+  // elsewhere — check-test-glob-coverage.mjs audits 47 packages to this gate's
+  // 46 and reports zero unrun test files.
   const root = synthTree({
     ...appWithOneTest('one'),
     'packages/zz-nobuild/package.json': JSON.stringify({ name: 'zz-nobuild' }),
@@ -370,6 +396,63 @@ test('audit(): an unauditable directory with no tests is not a failure', async (
   try {
     const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1, testFilesFloor: 1 });
     assert.equal(code, 0, `expected a clean audit, got: ${stderr}`);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// --- examples/* is a package parent too (#3201 review finding 3) ---
+//
+// pnpm-workspace.yaml lists THREE parents — `packages/*`, `apps/*` and
+// `examples/*` — and PACKAGE_PARENTS covered the first two. That gap is the
+// same shape as the skipped-directory bug this PR fixes, one level further
+// out and strictly worse: an unwatched PARENT is not a skipped DIRECTORY, so
+// the "look inside every skipped directory" check never reached it either.
+// `examples/babylonjs-viewer` and `examples/collab-demo` are full TypeScript
+// workspace members; a test at `examples/collab-demo/src/foo.test.ts` was
+// invisible to this gate rather than reported by it. (`find examples -name
+// '*.test.*'` returns 0 today, so there was no live offender — which is
+// exactly why only a test can keep it closed.)
+
+test('audit(): a test file under examples/ is audited, not invisible', async () => {
+  const root = synthTree({
+    ...appWithOneTest('one'),
+    // A real examples member as they exist today: no `typecheck` script.
+    ...memberWithOneTest('examples', 'demo', { dev: 'vite' }),
+  });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1, testFilesFloor: 1 });
+    assert.equal(code, 1, 'a test file under examples/ with no typecheck script must fail the gate');
+    assert.match(stderr, /examples\/demo: 1 test file\(s\) on disk but no "typecheck" script/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): a wired examples member passes and is counted', async () => {
+  // The paired probe. Without it the assertion above is satisfied by any
+  // audit() that refuses everything under examples/, and the widened scope
+  // would be a new way to go red rather than a new thing to see.
+  const root = synthTree({ ...appWithOneTest('one'), ...memberWithOneTest('examples', 'demo') });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 2, testFilesFloor: 2 });
+    // packagesFloor 2 / testFilesFloor 2 are the load-bearing part: they pass
+    // only if examples/demo was walked and COUNTED, not merely tolerated.
+    assert.equal(code, 0, `expected a clean audit, got: ${stderr}`);
+    assert.equal(stderr, '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): an empty tree names every parent it looked for', async () => {
+  // The refusal has to be actionable, and it is the only place the scanned
+  // parents are spelled out for a reader. If PACKAGE_PARENTS grows again,
+  // this fails until the message follows.
+  const root = synthTree({ 'README.md': 'no package parents here\n' });
+  try {
+    const { stderr } = await runAudit({ scanRoot: root });
+    assert.match(stderr, /none of packages\/, apps\/ and examples\/ exists under/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/typecheck-tests.test.mjs
+++ b/scripts/typecheck-tests.test.mjs
@@ -32,7 +32,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { relativeExtends, parseCliMode, auditVacuity } from './typecheck-tests.mjs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { relativeExtends, parseCliMode, auditVacuity, audit } from './typecheck-tests.mjs';
 
 test('a sibling base config is ./-prefixed, not bare', () => {
   // The repo-root case: pkgDir and the base config are the same directory.
@@ -201,4 +203,123 @@ test('vacuity: the real repo\'s measured counts pass', () => {
     auditVacuity({ seenParents: ['packages', 'apps'], packagesWithTests: 46, testFiles: 1434 }),
     null,
   );
+});
+
+// ---------------------------------------------------------------------------
+// The guards, driven END TO END through audit().
+//
+// Everything above calls `auditVacuity` directly, which proves the function is
+// right and proves NOTHING about whether the gate still calls it. The #3201
+// review demonstrated the gap by deleting the quantitative block from
+// `audit()`: the whole suite stayed green while the gate went back to calling a
+// collapsed two-package walk clean. These tests fail if any of the four call
+// sites is removed, because they exercise the refusals through `audit()`
+// itself against a synthetic tree.
+
+/**
+ * Run `audit()` and return its exit code together with everything it wrote to
+ * stderr. Asserting the exit code alone is not enough: `audit()` also returns 1
+ * from the offenders check, which fires BEFORE the quantitative floors, so a
+ * test that only checked for 1 would pass on a tree that never reached the
+ * guard it claims to exercise. The refusal text is what identifies the branch.
+ */
+async function runAudit(opts) {
+  const stderr = [];
+  const realError = console.error;
+  const realLog = console.log;
+  console.error = (...args) => stderr.push(args.join(' '));
+  console.log = () => {};
+  try {
+    const code = await audit(opts);
+    return { code, stderr: stderr.join('\n') };
+  } finally {
+    console.error = realError;
+    console.log = realLog;
+  }
+}
+
+/** Build a throwaway workspace and return its root. */
+function synthTree(spec) {
+  const root = mkdtempSync(path.join(tmpdir(), 'typecheck-tests-audit-'));
+  for (const [rel, contents] of Object.entries(spec)) {
+    const full = path.join(root, rel);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return root;
+}
+
+/** One `apps/<name>` package carrying a single test file. */
+function appWithOneTest(name) {
+  return {
+    [`apps/${name}/package.json`]: JSON.stringify({ name, scripts: { typecheck: 'tsc' } }),
+    [`apps/${name}/tsconfig.json`]: JSON.stringify({
+      compilerOptions: { noEmit: true },
+      files: ['./src/a.test.ts'],
+    }),
+    [`apps/${name}/src/a.test.ts`]: 'export const a = 1;\n',
+  };
+}
+
+test('audit(): an empty tree is refused, not reported as a clean scan', async () => {
+  const root = synthTree({ 'README.md': 'no package parents here\n' });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root });
+    assert.equal(code, 1);
+    assert.match(stderr, /none of packages\/, apps\/ exists under/);
+    assert.match(stderr, /Refusing a vacuous pass/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): package parents that exist but hold no tests are refused', async () => {
+  const root = synthTree({ 'apps/.keep': '', 'packages/.keep': '' });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root });
+    assert.equal(code, 1);
+    assert.match(stderr, /contain no package with a test file/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): a partial collapse is refused by the package floor', async () => {
+  // The case the empty-tree guards cannot see, and the one the floors exist
+  // for: the walk works, finds real packages with real tests, and every file
+  // it found IS in a program — but it found two packages instead of 46.
+  const root = synthTree({ ...appWithOneTest('one'), ...appWithOneTest('two') });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root });
+    assert.equal(code, 1);
+    assert.match(stderr, /only 2 package\(s\) carried test files, floor is 30/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): a partial collapse is refused by the test-file floor too', async () => {
+  // Same tree, package floor lowered so it cannot be what fires. The refusal
+  // must still come, from the independent test-file floor.
+  const root = synthTree({ ...appWithOneTest('one'), ...appWithOneTest('two') });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1 });
+    assert.equal(code, 1);
+    assert.match(stderr, /only 2 test file\(s\) found, floor is 900/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('audit(): the same tree passes once both floors are below what it holds', async () => {
+  // The paired probe. Without this, every assertion above could be satisfied
+  // by an audit() that returns 1 unconditionally on a synthetic tree.
+  const root = synthTree({ ...appWithOneTest('one'), ...appWithOneTest('two') });
+  try {
+    const { code, stderr } = await runAudit({ scanRoot: root, packagesFloor: 1, testFilesFloor: 1 });
+    assert.equal(code, 0, `expected a clean audit, got: ${stderr}`);
+    assert.equal(stderr, '');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Finding 1 of #3200, the exhaustive vacuity pass. Fixes the vacuous-pass half; the scope half is left for your ruling and explained below.

`node scripts/typecheck-tests.mjs --audit` is the repo-wide part of the #2457 arrangement — the one gate whose entire job is to notice that something stopped being typechecked. Run against a tree with no packages in it, it printed its success line and exited 0.

## The defect, before

Reproduced by running a copy of the script from an otherwise-empty tree (`REPO_ROOT` is derived from the script's own location, and the audit takes no `--root`), and again from a tree where `packages/` and `apps/` exist but are empty. Same result both times:

```
$ node <empty-tree>/scripts/typecheck-tests.mjs --audit
  TOTAL     0 /    0

typecheck-tests: every test file on disk is in a typecheck program.
EXIT=0
```

Three mechanisms, none of them behind a floor:

```js
  for (const group of ['packages', 'apps']) {
    const base = path.join(REPO_ROOT, group);
    if (!existsSync(base)) continue;
```
```js
  try {
    entries = readdirSync(dir, { withFileTypes: true });
  } catch {
    return out;
  }
```
```js
    const onDisk = findTestFiles(dir).sort();
    if (onDisk.length === 0) continue;
```

A missing package parent is skipped, an unreadable directory becomes an empty file list, a package where nothing was found is skipped — `rows` and `problems` both come back empty, and the success line prints.

## After

```
$ node <empty-tree>/scripts/typecheck-tests.mjs --audit
typecheck-tests: none of packages/, apps/ exists under <empty-tree>. Refusing a vacuous pass: this audit
exists to prove workspace test files reach a typecheck program, and it found nowhere to look for them.
EXIT=1

$ node <empty-dirs-tree>/scripts/typecheck-tests.mjs --audit
typecheck-tests: packages/ and apps/ contain no package with a test file. Refusing a vacuous pass: an audit
that found zero test files has proved nothing about typecheck coverage.
EXIT=1
```

Real repo still passes:

```
$ node scripts/typecheck-tests.mjs --audit
  ...
  apps/viewer                     573 /  573
  apps/viewer-embed                 6 /    6
  TOTAL                          1434 / 1434

typecheck-tests: all 1434 test file(s) across 46 package(s) under packages/ and apps/ are in a typecheck program.
EXIT=0
```

## Floors

Following the idiom in PR #3197 and `check-refwalk-guards.mjs`'s `CANDIDATE_FLOOR`. Measured on a healthy tree, not picked round, with about a third of headroom:

| floor | measured | set to |
| --- | --- | --- |
| `AUDITED_PACKAGES_FLOOR` | 46 packages carrying tests | 30 |
| `TEST_FILES_FLOOR` | 1,434 test files | 900 |

The gap is wide because the failure is not a gradual decline — every way this audit goes blind takes the count to zero, not to one under the floor.

Two floors and not one, because the audit has two independent ways to go blind and **each leaves the other's number looking healthy**: the package enumeration can collapse, or the enumeration can work while `findTestFiles` / `TEST_FILE_RE` stops recognising test files. A single combined floor cannot see either one alone.

Ordering matters and is commented: the structural check runs before any tsc invocation (with an empty input set everything downstream succeeds by having nothing to do), the zero-rows check runs before the table (`Math.max()` over an empty list is `-Infinity`), and the quantitative floors run *after* the offenders report — a run that found a real problem should say so rather than argue about how much it measured.

## The bare `catch`

A MISSING directory and an UNREADABLE one are different events calling for different fixes, and neither of them means "this package has no test files". Both are loud now and reported distinctly, so a permissions error or a typo'd path no longer reads as "nothing here". `findTestFiles` throws rather than calling an audit-local `fail()`, because the per-package mode has exactly the same interest in not mistaking an unreadable directory for an empty one.

## The success line was also false

It said `every test file on disk is in a typecheck program.` It walks `packages/*` and `apps/*`. Three test files live outside that scope and are in **no** typecheck program today:

```
$ git ls-files '*.test.ts' '*.test.tsx' '*.test.mts' '*.test.cts' | awk -F/ '{print $1}' | sort | uniq -c
 579 apps
 855 packages
   3 tests
```

`tests/tsconfig.json` extends the root config, whose `exclude` carries `**/*.test.ts`, and `exclude` filters `include`. From tsc's own resolution:

```
$ node node_modules/typescript/bin/tsc -p tests/tsconfig.json --showConfig
    "files": [
        "./benchmark/viewer-benchmark-page.ts",
        "./benchmark/viewer-benchmark.spec.ts",
        "./e2e/laz-wasm.e2e.spec.ts",
        "./e2e/usd-export.e2e.spec.ts",
        "./e2e/viewer-smoke.e2e.spec.ts"
    ],
    "exclude": [ "../node_modules", "../dist", "../**/*.test.ts" ]
```

Not one `*.test.ts` among the root files, and the only thing that runs them is `tsx --tsconfig tests/tsconfig.json --test`, which — as this script's own header says — transpiles per file without checking types.

**This PR does not close that gap**, deliberately. It makes the line name the scope it actually covered and states the gap in the header, so the OK stops implying it away. Bringing `tests/` into a typecheck program is a repo-shape decision — a fourth generated program, a committed `tests/tsconfig.tests.json`, or folding `tests/` into the audit's enumeration — and I would rather have your ruling than guess, the same way #3195 asked before building. Happy to take it either way.

## Tests

`typecheck-tests.test.mjs` gains six cases. The audit has no `--root` (REPO_ROOT comes from the script's own location), so an end-to-end fixture would mean copying the script into a temp tree — which is how the defect was reproduced but is not a shape this repo's harnesses use. The decision is therefore extracted as a pure exported `auditVacuity()` and driven directly, one case per branch, including one pinning that the real repo's measured counts (46 / 1,434) still pass so a future floor raise past reality fails here rather than in CI.

`node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs`: **603 pass, 0 fail.**

Per-package mode re-run from `packages/clash` to confirm the `findTestFiles` change did not disturb it: still enumerates its 33 test files.

## Scope

One gate. #3200 lists nine others, ranked, and explicitly does not bundle them — a sweeping change across many gates is unreviewable.

No changeset: a CI-only script under `scripts/`, publishing no workspace package.

Refs #3194, #3200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test audits now include example projects and detect stray tests in directories missing required configuration.
  * Rust build output directories are excluded from test discovery.
  * Audit results now report the correct scanned scope and identify missing configuration more clearly.
  * Empty or incomplete scans cannot be reported as successful.

* **Tests**
  * Added comprehensive coverage for example projects, missing configurations, allowed non-test directories, and independent coverage thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Review follow-up (#3201 review, 2026-08-25)

Two findings from that review are fixed on this branch.

**`785e0071d` — the guards are now pinned through `audit()`, not only as a pure function.** The six original tests called the exported `auditVacuity()` directly, so nothing asserted `audit()` still called it. `audit()` takes an injectable `scanRoot` and injectable floors — the `opts.candidateFloor ?? CANDIDATE_FLOOR` seam `check-refwalk-guards.mjs` already uses — and the refusals are driven end to end against a synthetic tree. The CLI exposes no override, so the gate always runs the real root and the real floors.

**`7f4c0309b` — a test file in a directory the audit cannot audit is now a failure.** `workspaceDirs` skips any directory missing `tsconfig.json` or `package.json`, and those files were never counted, so the success line overclaimed. Every skipped directory is now walked for test files first. Three exist today (`packages/wasm`, `apps/landing`, `apps/server`) and none carries a test file, so the real audit is unchanged: `TOTAL 1434 / 1434` across 46 packages, exit 0.

The `git ls-files` count above was `853 packages` and is corrected to `855`, which is what the quoted command returns and what `579 + 855 = 1434` requires.
