### PR TITLE
Allow whitespace between a typed value's type name and its opening paren

### DIFF
--- a/rust/core/src/parser/tokenizer.rs
+++ b/rust/core/src/parser/tokenizer.rs
@@ -157,18 +157,30 @@ fn derived(input: &[u8]) -> IResult<&[u8], Token<'_>> {
 const MAX_NESTING_DEPTH: u32 = 256;
 
 /// Parse typed value: IFCPARAMETERVALUE(0.), IFCBOOLEAN(.T.)
+///
+/// The type name and its `(` are usually adjacent, but a STEP writer's line
+/// wrap can land exactly between them - measured on a real file where 39 of
+/// 175 `IFCSURFACESTYLERENDERING` entities wrap as `…MEASURE\r\n(1.)`. Without
+/// `ws` here, `char('(')` sees `\r` and the whole entity fails to parse, which
+/// silently dropped it from every full-file walk (`decode_at_uncached` returns
+/// `Err`, and every caller's `let Ok(..) = .. else { continue }` skips it) -
+/// the entity was never malformed, just wrapped where the parser assumed it
+/// never would be.
 fn typed_value_at_depth(input: &[u8], depth: u32) -> IResult<&[u8], Token<'_>> {
     map(
         pair(
             // Type name (all caps with optional numbers/underscores)
             take_while1(|c: u8| c.is_ascii_alphanumeric() || c == b'_'),
             // Arguments
-            delimited(
-                char('('),
-                separated_list0(delimited(ws, char(','), ws), move |i| {
-                    token_at_depth(i, depth)
-                }),
-                char(')'),
+            preceded(
+                ws,
+                delimited(
+                    char('('),
+                    separated_list0(delimited(ws, char(','), ws), move |i| {
+                        token_at_depth(i, depth)
+                    }),
+                    char(')'),
+                ),
             ),
         ),
         |(type_name, args)| Token::TypedValue(type_name, args),
@@ -459,5 +471,46 @@ mod tests {
     #[test]
     fn test_parse_entity_rejects_one_over_max_nesting() {
         assert!(parse_entity(&nested(MAX_NESTING_DEPTH as usize + 1)).is_err());
+    }
+
+    /// A typed value's `(` may be separated from its type name by whitespace,
+    /// including a CRLF line wrap - not just adjacent as in `IFCBOOLEAN(.T.)`.
+    #[test]
+    fn test_typed_value_tolerates_crlf_before_paren() {
+        let result = typed_value_at_depth(b"IFCPOSITIVELENGTHMEASURE\r\n(1.);", 0);
+        assert!(result.is_ok(), "Failed to parse: {:?}", result);
+        let (rest, token) = result.unwrap();
+        assert_eq!(rest, b";");
+        match token {
+            Token::TypedValue(type_name, args) => {
+                assert_eq!(type_name, b"IFCPOSITIVELENGTHMEASURE");
+                assert_eq!(args, vec![Token::Float(1.0)]);
+            }
+            _ => panic!("Expected TypedValue token"),
+        }
+    }
+
+    /// Synthetic reproduction of the Allplan/Allright IFC2X3 export pattern
+    /// that motivated this fix: `IFCSURFACESTYLERENDERING` line-wraps with
+    /// `\r\n` right between a typed value's type name and its `(`. Before the
+    /// fix, `char('(')` saw `\r` and the whole entity failed to parse - which
+    /// every full-file walk treats as a silent skip, not a decode error the
+    /// caller sees.
+    #[test]
+    fn test_parse_entity_typed_value_wrapped_with_crlf() {
+        let input = "#42=IFCSURFACESTYLERENDERING($,IFCPOSITIVELENGTHMEASURE\r\n(1.),$,$,$,$,$,$,.NOTDEFINED.);";
+        let result = parse_entity(input);
+        assert!(result.is_ok(), "Failed to parse: {:?}", result);
+        let (id, ifc_type, args) = result.unwrap();
+        assert_eq!(id, 42);
+        assert_eq!(ifc_type, IfcType::IfcSurfaceStyleRendering);
+        assert_eq!(args.len(), 9);
+        match &args[1] {
+            Token::TypedValue(type_name, inner) => {
+                assert_eq!(*type_name, b"IFCPOSITIVELENGTHMEASURE");
+                assert_eq!(*inner, vec![Token::Float(1.0)]);
+            }
+            other => panic!("Expected TypedValue token, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## What and why

`typed_value_at_depth` required a typed value's `(` to immediately follow its type
name (`IFCBOOLEAN(.T.)`), unlike every other token boundary in the tokenizer, which
already tolerates whitespace there. A real-world Allplan/Allright IFC2X3 export
line-wraps with `\r\n` at exactly that point for some `IFCSURFACESTYLERENDERING`
entities (`…MEASURE\r\n(1.)`), which made `char('(')` see `\r` and fail the whole
entity parse — silently dropping 39 of 175 such entities from a full-file walk
(every caller's decode error is a silent skip) and taking their referencing
`IfcSurfaceStyle` colours down with them, measured as a roof rendering its generic
type-fallback colour instead of its actual grey.

Fix: skip `ws` between the type name and `(`, matching every other token boundary
in this tokenizer.

## How it was verified

- `cargo test -p ifc-lite-core --lib parser::tokenizer::tests` — all 11 pass,
  including the two new regression tests
- `cargo clippy -p ifc-lite-core --all-targets -- -D warnings` — clean

- [x] `cargo test --workspace` (Rust) and/or `pnpm test` (TS) pass locally

## Checklist

- [x] A test asserts the new behavior through a fixture or a stated invariant —
      `test_typed_value_tolerates_crlf_before_paren` (tokenizer-level) and
      `test_parse_entity_typed_value_wrapped_with_crlf` (synthetic
      `IFCSURFACESTYLERENDERING` entity reproducing the real export's `\r\n` wrap)
- [x] House rules: no `as any` / `@ts-ignore`, no silent `catch {}`, no module
      pushed past ~400 non-generated lines, no repo-wide `cargo fmt`
- [x] No client or project identifiers in code, tests, commit messages, or this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Typed values can now be parsed when whitespace or line breaks appear between the type name and opening parenthesis.
  - Improved support for CRLF-formatted input.
  - Added coverage for standalone and entity-wrapped typed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->