### PR TITLE
refactor(core): move the LEGACY_ENTITY_NAMES parity check out of an include_str test

### DIFF
--- a/rust/core/src/legacy_entities.rs
+++ b/rust/core/src/legacy_entities.rs
@@ -254,42 +254,21 @@ pub const LEGACY_ENTITY_NAMES: &[&str] = &[
 #[cfg(test)]
 mod legacy_entity_name_tests {
     use super::*;
-    use std::collections::BTreeSet;
 
-    /// The two-lists-that-must-agree guard for [`LEGACY_ENTITY_NAMES`]: the
-    /// arm keys are recovered from this module's own source text, so a newly
-    /// added arm whose key never reaches the const is caught here rather than
-    /// silently shrinking every caller's universe.
+    /// The arm/const parity check that used to live here is now
+    /// `scripts/check-legacy-entity-coverage.mjs`, which already reads this
+    /// file to derive the arm keys and gained a `LEGACY_ENTITY_NAMES`
+    /// comparison to go with it.
     ///
-    /// (Deliberately phrased without an example arm: the key pattern is what
-    /// `scripts/check-legacy-entity-coverage.mjs` scans for, and a made-up
-    /// name in a comment reads to it as a real arm naming no entity.)
-    #[test]
-    fn legacy_entity_names_match_the_lookup_arms() {
-        let src = include_str!("legacy_entities.rs");
-        let mut from_source: BTreeSet<&str> = BTreeSet::new();
-        for line in src.lines() {
-            let trimmed = line.trim();
-            let Some(rest) = trimmed.strip_prefix('"') else {
-                continue;
-            };
-            let Some(end) = rest.find('"') else { continue };
-            if !rest[end + 1..].trim_start().starts_with("=>") {
-                continue;
-            }
-            from_source.insert(&rest[..end]);
-        }
-        assert!(
-            !from_source.is_empty(),
-            "arm-key extraction found nothing -- the parser, not the table, is broken"
-        );
-        let from_const: BTreeSet<&str> = LEGACY_ENTITY_NAMES.iter().copied().collect();
-        assert_eq!(
-            from_source, from_const,
-            "LEGACY_ENTITY_NAMES has drifted from get_legacy_entity_info's match arms"
-        );
-    }
-
+    /// It moved because the only way to state it in-crate was `include_str!`
+    /// of this module's own source, which is a source-text assertion — banned
+    /// by AGENTS.md and flagged by `check-rust-source-text-assertions` (#3195).
+    /// The repo had already made the same call for
+    /// `check-clash-degenerate-reason-parity.mjs`: a claim about two SOURCES
+    /// belongs in a lint. The gate is also strictly stronger here, since it
+    /// fails on drift in BOTH directions and its own harness proves it cannot
+    /// pass by extracting nothing.
+    ///
     /// Every listed name really is legacy -- the cheap direction, but it also
     /// pins that the const holds arm keys and not, say, base-type names.
     #[test]

--- a/scripts/check-legacy-entity-coverage.mjs
+++ b/scripts/check-legacy-entity-coverage.mjs
@@ -88,6 +88,23 @@ export function legacyKeys(rustSource) {
 }
 
 /**
+ * The names in the `LEGACY_ENTITY_NAMES` const — the public mirror of the match
+ * arms, and what `dump_rooted_type_sweep.rs` feeds into the cross-language
+ * rooted-type universe (#3124).
+ *
+ * Bounded to the const's own `&[` … `];` block, so a name appearing only in a
+ * doc comment or in a match arm elsewhere in the file cannot pad it.
+ */
+export function legacyNameConst(rustSource) {
+  const start = rustSource.indexOf('pub const LEGACY_ENTITY_NAMES');
+  if (start === -1) return new Set();
+  const open = rustSource.indexOf('[', start);
+  const close = rustSource.indexOf('];', open);
+  if (open === -1 || close === -1) return new Set();
+  return new Set([...rustSource.slice(open, close).matchAll(/"(IFC[A-Z0-9]+)"/g)].map((m) => m[1]));
+}
+
+/**
  * Uppercase names `IfcType::from_str` resolves to a real variant.
  *
  * Bounded to that ONE function rather than sliced to end of file: the arm shape
@@ -196,6 +213,36 @@ export function checkCoverage({ legacySource, schemaSource, oldTables, tableSize
         `and has no arm in ${LEGACY_REL} — a file containing it loses it from the attribute export` +
         (p.bearsGeometry ? ' and from meshing' : ' (it carries no representation, so meshing loses nothing)'),
     );
+  }
+
+  // THE CONST MUST MIRROR THE ARMS. `LEGACY_ENTITY_NAMES` is public and feeds
+  // the cross-language rooted-type universe, so an arm that never reaches it
+  // shrinks that universe silently — which is how the three stratum leaves
+  // stayed divergent with both halves of that gate green (#3124 review).
+  //
+  // This lives HERE rather than in a Rust test because the only way to state it
+  // in-crate is `include_str!` of the module's own source — a source-text
+  // assertion, which AGENTS.md bans and `check-rust-source-text-assertions`
+  // (#3195) flags. Same call the repo already made for
+  // `check-clash-degenerate-reason-parity.mjs`: a claim about two SOURCES
+  // belongs in a lint, where reading both is the honest thing rather than the
+  // banned thing.
+  const constNames = legacyNameConst(legacySource);
+  if (constNames.size === 0) {
+    failures.push(
+      `no names extracted from LEGACY_ENTITY_NAMES in ${LEGACY_REL} — the extractor has drifted, and two empty sets would otherwise "agree"`,
+    );
+  } else {
+    const missingFromConst = [...keys].filter((k) => !constNames.has(k)).sort();
+    const extraInConst = [...constNames].filter((k) => !keys.has(k)).sort();
+    if (missingFromConst.length > 0)
+      failures.push(
+        `${LEGACY_REL} has match arms absent from LEGACY_ENTITY_NAMES: ${missingFromConst.join(', ')} — every consumer of that const, the rooted-type sweep's universe included, is blind to them`,
+      );
+    if (extraInConst.length > 0)
+      failures.push(
+        `LEGACY_ENTITY_NAMES lists ${extraInConst.join(', ')}, which is not a match arm in ${LEGACY_REL}`,
+      );
   }
 
   for (const key of [...keys].sort()) {

--- a/scripts/check-legacy-entity-coverage.test.mjs
+++ b/scripts/check-legacy-entity-coverage.test.mjs
@@ -102,6 +102,44 @@ test("an arm whose key names no entity is reported — the #3172 misspelling", (
   assert.match(out, /IfcElectricDistributionPoint .*has no arm in/);
 });
 
+test('a match arm absent from LEGACY_ENTITY_NAMES is reported', () => {
+  // The const is public and feeds the cross-language rooted-type universe
+  // (dump_rooted_type_sweep.rs), so an arm that never reaches it makes that
+  // sweep structurally blind to the name -- which is how the three stratum
+  // leaves stayed divergent with both halves of that gate green (#3124 review).
+  const real = readFileSync(join(ROOT, LEGACY_REL), 'utf8');
+  const i = real.indexOf('pub const LEGACY_ENTITY_NAMES');
+  assert.notEqual(i, -1, 'const anchor drifted');
+  const target = '"IFCPRESENTATIONSTYLEASSIGNMENT",';
+  const j = real.indexOf(target, i);
+  assert.notEqual(j, -1, 'mutation anchor drifted');
+  const { status, out } = runOn({ [LEGACY_REL]: real.slice(0, j) + real.slice(j + target.length) });
+  assert.equal(status, 1, out);
+  assert.match(out, /match arms absent from LEGACY_ENTITY_NAMES.*IFCPRESENTATIONSTYLEASSIGNMENT/);
+});
+
+test('a LEGACY_ENTITY_NAMES entry with no match arm is reported', () => {
+  // The other direction. A name in the const that no arm produces would put a
+  // phantom into the sweep's universe and read as a real legacy entity.
+  const real = readFileSync(join(ROOT, LEGACY_REL), 'utf8');
+  const i = real.indexOf('pub const LEGACY_ENTITY_NAMES');
+  const j = real.indexOf('[', i) + 1;
+  const { status, out } = runOn({ [LEGACY_REL]: real.slice(0, j) + '\n    "IFCPHANTOMENTITY",' + real.slice(j) });
+  assert.equal(status, 1, out);
+  assert.match(out, /IFCPHANTOMENTITY, which is not a match arm/);
+});
+
+test('a broken LEGACY_ENTITY_NAMES extractor fails instead of passing vacuously', () => {
+  // Two empty sets agree about everything. If the const is renamed or the
+  // block shape changes, this must fail rather than silently compare nothing.
+  const real = readFileSync(join(ROOT, LEGACY_REL), 'utf8');
+  const { status, out } = runOn({
+    [LEGACY_REL]: real.replace('pub const LEGACY_ENTITY_NAMES', 'pub const RENAMED_CONST'),
+  });
+  assert.equal(status, 1, out);
+  assert.match(out, /no names extracted from LEGACY_ENTITY_NAMES/);
+});
+
 test('a broken legacy-arm extractor fails instead of passing vacuously', () => {
   const { status, out } = runOn({ [LEGACY_REL]: '// every arm gone\n' });
   assert.equal(status, 1, out);


### PR DESCRIPTION
Unblocks #3198. Related to #3195.

## The problem

`legacy_entity_name_tests::legacy_entity_names_match_the_lookup_arms` recovers the match-arm keys by `include_str!`-ing its own module and comparing them to `LEGACY_ENTITY_NAMES`. That is a source-text assertion — banned by `AGENTS.md`, and flagged by the Rust gate #3198 adds.

Running that gate against `main` + #3198 reports **exactly one violation repo-wide**, and this is it:

```
rust/core/src/legacy_entities.rs:269  include_str of legacy_entities.rs
```

The site is an hour old. It arrived with #3124 (`cf840556`), in the follow-up to a review that asked for the const to stop being a second hand-maintained list. So the gate is not surfacing old debt — it caught a good fix reaching for the wrong instrument.

## Moved, not marked

`@source-text-assertion-ok` would have been defensible. That test carries `assert!(!from_source.is_empty(), "arm-key extraction found nothing")`, so the vacuity failure the whole rule exists to catch cannot happen there.

But a marker excuses a violation, and this one is avoidable. `scripts/check-legacy-entity-coverage.mjs` **already parses this file's arm keys** for its own purposes, so it gains a `LEGACY_ENTITY_NAMES` comparison and the Rust test goes away entirely.

This is the call the repo already made for `check-clash-degenerate-reason-parity.mjs`, whose own header says it: *"a cross-language declaration parity claim can only ever be made by reading both SOURCES, which is precisely the shape banned in test files. Naming it a check makes the shape honest."*

## The gate version is stricter than the test it replaces

| drift | verdict |
|---|---|
| a match arm with no const entry | named, exit 1 |
| a const entry with no match arm | named, exit 1 |
| the const renamed or reshaped | `no names extracted`, exit 1 |

All three probed against mutated copies of the real source, and all three are now regression tests in `check-legacy-entity-coverage.test.mjs`. The third is the one the old test could not have: two empty sets agree about everything, and it could only guard its own half of that.

`every_listed_name_resolves_as_legacy` stays — it reads no source text and pins that the const holds arm keys rather than base-type names.

## Verification

- **#3198's gate against this tree:** `OK (593 .rs files, 416 with test code, 110 reads examined, 0 source-text assertions)`. So #3198 lands green with **no marker and no allowlist row**.
- `cargo test --workspace --no-fail-fast`: **2156 passed, 0 failed**
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings`: clean — and it earned its keep, catching the orphaned `use std::collections::BTreeSet` that `cargo test` was perfectly happy to leave behind
- 590 script tests, `check-source-text-assertions`, `check-test-wiring`: green

`pnpm lint`'s unused-locals step fails in my worktree and fails **identically on unmodified main** with the same install state — an `--ignore-scripts` install leaves no `dist/`, so those packages cannot compile standalone. Null-probed, environmental, not this diff.

## Credit

The const and the parity idea are @BIMvoice's, from the #3124 follow-up. Only where the check lives changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to ensure all legacy entity names have matching lookup entries.
  * Added checks for missing, unexpected, or empty legacy entity definitions.
* **Tests**
  * Added regression coverage for inconsistent legacy entity mappings and validation failures.
  * Continued verifying that every declared legacy name resolves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->