### PR TITLE
Allow whitespace between a typed value's type name and its opening paren

### DIFF
--- a/rust/core/src/parser/tokenizer.rs
+++ b/rust/core/src/parser/tokenizer.rs
@@ -157,18 +157,30 @@ fn derived(input: &[u8]) -> IResult<&[u8], Token<'_>> {
 const MAX_NESTING_DEPTH: u32 = 256;
 
 /// Parse typed value: IFCPARAMETERVALUE(0.), IFCBOOLEAN(.T.)
+///
+/// The type name and its `(` are usually adjacent, but a STEP writer's line
+/// wrap can land exactly between them - measured on a real file where 39 of
+/// 175 `IFCSURFACESTYLERENDERING` entities wrap as `…MEASURE\r\n(1.)`. Without
+/// `ws` here, `char('(')` sees `\r` and the whole entity fails to parse, which
+/// silently dropped it from every full-file walk (`decode_at_uncached` returns
+/// `Err`, and every caller's `let Ok(..) = .. else { continue }` skips it) -
+/// the entity was never malformed, just wrapped where the parser assumed it
+/// never would be.
 fn typed_value_at_depth(input: &[u8], depth: u32) -> IResult<&[u8], Token<'_>> {
     map(
         pair(
             // Type name (all caps with optional numbers/underscores)
             take_while1(|c: u8| c.is_ascii_alphanumeric() || c == b'_'),
             // Arguments
-            delimited(
-                char('('),
-                separated_list0(delimited(ws, char(','), ws), move |i| {
-                    token_at_depth(i, depth)
-                }),
-                char(')'),
+            preceded(
+                ws,
+                delimited(
+                    char('('),
+                    separated_list0(delimited(ws, char(','), ws), move |i| {
+                        token_at_depth(i, depth)
+                    }),
+                    char(')'),
+                ),
             ),
         ),
         |(type_name, args)| Token::TypedValue(type_name, args),

--- a/rust/core/src/parser/tokenizer_tests.rs
+++ b/rust/core/src/parser/tokenizer_tests.rs
@@ -241,3 +241,44 @@ fn comment_free_entity_decodes_unchanged() {
     assert_eq!(ifc_type, IfcType::IfcWall);
     assert_eq!(args.len(), 8);
 }
+
+/// A typed value's `(` may be separated from its type name by whitespace,
+/// including a CRLF line wrap - not just adjacent as in `IFCBOOLEAN(.T.)`.
+#[test]
+fn test_typed_value_tolerates_crlf_before_paren() {
+    let result = typed_value_at_depth(b"IFCPOSITIVELENGTHMEASURE\r\n(1.);", 0);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let (rest, token) = result.unwrap();
+    assert_eq!(rest, b";");
+    match token {
+        Token::TypedValue(type_name, args) => {
+            assert_eq!(type_name, b"IFCPOSITIVELENGTHMEASURE");
+            assert_eq!(args, vec![Token::Float(1.0)]);
+        }
+        _ => panic!("Expected TypedValue token"),
+    }
+}
+
+/// Synthetic reproduction of the Allplan/Allright IFC2X3 export pattern
+/// that motivated this fix: `IFCSURFACESTYLERENDERING` line-wraps with
+/// `\r\n` right between a typed value's type name and its `(`. Before the
+/// fix, `char('(')` saw `\r` and the whole entity failed to parse - which
+/// every full-file walk treats as a silent skip, not a decode error the
+/// caller sees.
+#[test]
+fn test_parse_entity_typed_value_wrapped_with_crlf() {
+    let input = "#42=IFCSURFACESTYLERENDERING($,IFCPOSITIVELENGTHMEASURE\r\n(1.),$,$,$,$,$,$,.NOTDEFINED.);";
+    let result = parse_entity(input);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result);
+    let (id, ifc_type, args) = result.unwrap();
+    assert_eq!(id, 42);
+    assert_eq!(ifc_type, IfcType::IfcSurfaceStyleRendering);
+    assert_eq!(args.len(), 9);
+    match &args[1] {
+        Token::TypedValue(type_name, inner) => {
+            assert_eq!(*type_name, b"IFCPOSITIVELENGTHMEASURE");
+            assert_eq!(*inner, vec![Token::Float(1.0)]);
+        }
+        other => panic!("Expected TypedValue token, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Fix

`typed_value_at_depth` now accepts whitespace between a typed value’s EXPRESS type name and its opening parenthesis, matching the tokenizer’s other token boundaries. This handles line-wrapped IFC values such as `IFCPOSITIVELENGTHMEASURE\r\n(1.)`.

## Regression coverage

Tokenizer and entity-parser regressions cover whitespace and CRLF-wrapped typed values.

## House rule

The tokenizer’s unit tests are split into `tokenizer_tests.rs`; the production module is now below the module-size budget without widening the allowlist.

## Validation

- `cargo test -p ifc-lite-core --lib parser::tokenizer::tests` — 11 passing
- `cargo clippy -p ifc-lite-core --all-targets -- -D warnings` — pass
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — 6 passing
- `git diff --check` — pass
- Fresh current-base CI is required before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typed values now parse correctly when whitespace or line breaks appear between the type name and opening parenthesis.

* **Tests**
  * Expanded tokenizer coverage for basic values, lists, nested structures, entities, nesting limits, and line-wrapped typed values.
  * Reorganized tokenizer tests without changing user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->