### PR TITLE
fix(release): a failed v-tag push was swallowed, and the release then invented the tag (#3202)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,13 +312,29 @@ jobs:
         if: steps.release-gate.outputs.run_root == 'true'
         run: |
           # Create the v* tag (changesets creates @scope/package@version tags, not v* tags)
+          #
+          # `|| true` on `git tag` is deliberate: a backfill or a re-run hits an
+          # existing tag and idempotency is the point. It is NOT on the push.
+          # A swallowed push is not "no release" -- `gh release create` CREATES a
+          # missing tag itself, and with no `--target` it does so from the latest
+          # state of the default branch (its own `--help` says so). So the failure
+          # mode was a green release pointing at a DIFFERENT commit than the
+          # packages published from it, which `packages/server-bin/src/binary.ts`
+          # then resolves its download URL against (#3202).
+          #
+          # The backfill path added after 2026-08-12 is the one most exposed to
+          # this: a backfill by definition runs after `main` has moved on.
           git tag "v${VERSION}" || true
-          git push origin "v${VERSION}" || true
+          git push origin "v${VERSION}"
           # Create release, skipping if it already exists
           if gh release view "v${VERSION}" > /dev/null 2>&1; then
             echo "Release v${VERSION} already exists, skipping"
           else
+            # --verify-tag: refuse to invent the tag. The push above is the only
+            # thing allowed to create it, and it is now unguarded, so a failure is
+            # loud where it happens instead of being reasoned about downstream.
             gh release create "v${VERSION}" \
+              --verify-tag \
               --title "v${VERSION}" \
               --notes "See CHANGELOG.md for details"
           fi
@@ -345,9 +361,15 @@ jobs:
           if gh release view "$TAG" > /dev/null 2>&1; then
             echo "Release $TAG already exists, skipping (server binaries already published)"
           else
+            # Same shape as the root release above: idempotent tag, UNGUARDED
+            # push, and `--verify-tag` so `gh` cannot invent the ref at
+            # default-branch head if the push failed (#3202). Getting this wrong
+            # here is worse than above -- server-binaries.yml uploads the
+            # per-platform archives to whatever commit this tag names.
             git tag "$TAG" || true
-            git push origin "$TAG" || true
+            git push origin "$TAG"
             gh release create "$TAG" \
+              --verify-tag \
               --title "$TAG" \
               --notes "Native server binary for @ifc-lite/server-bin v${SB_VERSION}. See CHANGELOG.md."
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -710,6 +710,20 @@ jobs:
       # the real sources, plus a deleted arm and the #3172 misspelling itself.
       - name: Check legacy entity coverage gate regressions
         run: node --test scripts/check-legacy-entity-coverage.test.mjs
+      # `|| true` on `git tag` is right (a re-run hits an existing tag);
+      # on the PUSH it made a failed push silent, and `gh release create` then
+      # creates the missing tag ITSELF at default-branch head -- so the run
+      # stayed green with the tag on a different commit than the packages
+      # published from it (#3202). Baseline is zero: this gate landed in the
+      # same change that removed the only two instances.
+      - name: Check for swallowed git push failures
+        run: node scripts/check-swallowed-push.mjs
+      # Executable proof it cannot pass vacuously: a missing or empty workflow
+      # directory must fail rather than report clean, and `|| true` on `git tag`
+      # must NOT be flagged -- a rule that caught both would be suppressed on
+      # its first run.
+      - name: Check swallowed-push gate regressions
+        run: node --test scripts/check-swallowed-push.test.mjs
       # The CSV cell escaper reached NINE hand-rolled copies and no two were
       # identical: some tested the formula trigger anchored at offset 0 (so a
       # BOM/ZWSP/LRM/NBSP/U+2028 in front of `=` bypassed the CWE-1236 guard),

--- a/scripts/check-swallowed-push.mjs
+++ b/scripts/check-swallowed-push.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ratchet: a workflow may not discard the exit status of a `git push`.
+ *
+ * `|| true` on `git tag` is correct — a backfill or a re-run hits an existing
+ * tag and idempotency is the point. On the PUSH it is a different thing
+ * entirely, and `release.yml` had it on both `v*` tag pushes (#3202).
+ *
+ * WHY THE FAILURE IS SILENT-AND-WRONG RATHER THAN LOUD-AND-ABSENT, which is
+ * what makes this worth a gate rather than a code review note: a swallowed push
+ * does not yield "no release". `gh release create` CREATES a missing tag itself,
+ * and with no `--target` it does so "from the latest state of the default
+ * branch" — its own `--help` says so. So the run continues, the release exists,
+ * every check is green, and the tag points at a DIFFERENT commit than the
+ * packages published from it. `packages/server-bin/src/binary.ts` then resolves
+ * its download URL from that tag, and its fallback chain can find a STALE
+ * archive, which is worse than a 404.
+ *
+ * The interaction that makes it likely rather than theoretical: the fix added
+ * after the 2026-08-12 incident introduced a BACKFILL path so a later run can
+ * tag a version whose tag went missing. A backfill by definition runs after
+ * `main` has moved on — so the code path added to recover from the previous
+ * incident is the one most exposed to this one.
+ *
+ * SCOPE is `.github/workflows/**`, and the baseline is ZERO: this gate is added
+ * in the same change that removes the only two instances, so it never has to
+ * grandfather anything. If a legitimate swallowed push ever appears, the
+ * escape hatch is an `# allow-swallowed-push <reason>` comment on the line
+ * above, which this check NAMES in its output rather than hiding.
+ *
+ * Run via `node scripts/check-swallowed-push.mjs` (CI node-test job).
+ * `--root <dir>` points it at a mutated copy of the tree; that is how
+ * `check-swallowed-push.test.mjs` proves it fires.
+ */
+
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join, dirname, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootFlag = process.argv.indexOf('--root');
+const ROOT =
+  rootFlag !== -1 && process.argv[rootFlag + 1]
+    ? process.argv[rootFlag + 1]
+    : join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const WORKFLOW_DIR = '.github/workflows';
+export const MARKER = 'allow-swallowed-push';
+
+/**
+ * A `git push` whose failure is discarded.
+ *
+ * `|| true` and `|| :` are the two spellings that mean "ignore this"; `: ` is a
+ * shell no-op and reads as decorative, which is exactly why it is worth naming.
+ * A push inside a larger `||` chain that ends in one of those counts too.
+ */
+export const SWALLOWED_PUSH = /\bgit\s+push\b[^\n]*?\|\|\s*(?:true|:)\s*(?:$|#)/;
+
+/** Every `.yml`/`.yaml` under the workflow directory. */
+export function workflowFiles(root) {
+  const dir = join(root, WORKFLOW_DIR);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => /\.ya?ml$/.test(f))
+    .map((f) => join(dir, f))
+    .filter((f) => statSync(f).isFile());
+}
+
+/** `{ line, text }` for every swallowed push, minus marked ones. */
+export function findSwallowedPushes(source) {
+  const lines = source.split('\n');
+  const hits = [];
+  const marked = [];
+  lines.forEach((line, i) => {
+    if (!SWALLOWED_PUSH.test(line)) return;
+    const above = lines[i - 1] ?? '';
+    if (above.includes(MARKER) || line.includes(MARKER)) {
+      marked.push({ line: i + 1, text: line.trim() });
+      return;
+    }
+    hits.push({ line: i + 1, text: line.trim() });
+  });
+  return { hits, marked };
+}
+
+// Only run the gate when invoked as a script; the self-test imports the helpers.
+if (process.argv[1] && process.argv[1].endsWith('check-swallowed-push.mjs')) {
+  const files = workflowFiles(ROOT);
+  // Fail closed: an empty workflow directory means the scan root moved, not
+  // that every workflow is clean. Absence must not read as success.
+  if (files.length === 0) {
+    console.error(
+      `\nNo workflow files found under ${WORKFLOW_DIR}. The scan root has moved, ` +
+        `so this check examined nothing — which is not the same as finding nothing.\n`,
+    );
+    process.exit(1);
+  }
+
+  const offenders = [];
+  const markedSites = [];
+  for (const file of files) {
+    const rel = relative(ROOT, file).split('\\').join('/');
+    const { hits, marked } = findSwallowedPushes(readFileSync(file, 'utf8'));
+    for (const h of hits) offenders.push(`${rel}:${h.line}  ${h.text}`);
+    for (const m of marked) markedSites.push(`${rel}:${m.line}  ${m.text}`);
+  }
+
+  if (offenders.length > 0) {
+    console.error('\nA `git push` whose failure is discarded:\n');
+    for (const o of offenders) console.error(`  ${o}`);
+    console.error(`
+\`|| true\` on \`git tag\` is fine — a re-run hits an existing tag and idempotency
+is the point. On the PUSH it means a network, auth or ref-lock failure becomes a
+silent no-op and the job continues as though the ref reached the remote.
+
+That does not produce "no release". \`gh release create\` creates a missing tag
+itself, from the latest state of the DEFAULT BRANCH when no \`--target\` is given,
+so the run stays green and the tag points at a different commit than the packages
+published from it (#3202).
+
+Drop the \`|| true\` so the failure is loud where it happens, and pass
+\`--verify-tag\` to \`gh release create\` so it cannot invent the ref instead.
+
+If a swallowed push is genuinely right somewhere, say why on the line above:
+
+  # ${MARKER}: <reason>
+  git push origin "$TAG" || true
+
+Marked sites stay NAMED in this check's output; they are not exemptions in the dark.
+`);
+    process.exit(1);
+  }
+
+  console.log(
+    `check-swallowed-push: OK (${files.length} workflow files, ${markedSites.length} marked)`,
+  );
+  for (const m of markedSites) console.log(`  marked: ${m}`);
+}

--- a/scripts/check-swallowed-push.mjs
+++ b/scripts/check-swallowed-push.mjs
@@ -53,11 +53,16 @@ export const MARKER = 'allow-swallowed-push';
 /**
  * A `git push` whose failure is discarded.
  *
- * `|| true` and `|| :` are the two spellings that mean "ignore this"; `: ` is a
+ * `|| true` and `|| :` are the two spellings that mean "ignore this"; `:` is a
  * shell no-op and reads as decorative, which is exactly why it is worth naming.
- * A push inside a larger `||` chain that ends in one of those counts too.
+ *
+ * The no-op may be followed by a COMMAND-LIST DELIMITER rather than end of line.
+ * A push chained with `; echo continuing` discards its status just as
+ * thoroughly, and an end-of-line-only rule walks straight past it. `;`, `&`,
+ * `|` and `)` all continue the line while leaving the status discarded.
+ * Reported by CodeRabbit on #3208.
  */
-export const SWALLOWED_PUSH = /\bgit\s+push\b[^\n]*?\|\|\s*(?:true|:)\s*(?:$|#)/;
+export const SWALLOWED_PUSH = /\bgit\s+push\b[^\n]*?\|\|\s*(?:true|:)\s*(?:$|[#;&|)])/;
 
 /** Every `.yml`/`.yaml` under the workflow directory. */
 export function workflowFiles(root) {

--- a/scripts/check-swallowed-push.test.mjs
+++ b/scripts/check-swallowed-push.test.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for scripts/check-swallowed-push.mjs.
+ *
+ * The gate reports "no swallowed pushes". That sentence is equally true of a
+ * clean tree and of a scan that examined nothing, so every way it could go
+ * false-green is an executable case here: the workflow directory missing, the
+ * directory present but empty, and each spelling of a discarded exit status.
+ *
+ * Method matches scripts/check-clash-degenerate-reason-parity.test.mjs: write a
+ * mutated tree to a temp dir, run the UNMODIFIED checker against it via
+ * `--root`, and assert exit code plus message.
+ *
+ * Run: node --test scripts/check-swallowed-push.test.mjs
+ * (wired as a step of the CI node-test job in .github/workflows/test.yml).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { findSwallowedPushes, SWALLOWED_PUSH, MARKER } from './check-swallowed-push.mjs';
+
+const SCRIPTS = dirname(fileURLToPath(import.meta.url));
+const CHECKER = join(SCRIPTS, 'check-swallowed-push.mjs');
+
+/** Writes `files` (relative path -> content) into a temp tree and runs the gate. */
+function runOn(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'swallowed-push-'));
+  try {
+    for (const [rel, content] of Object.entries(files)) {
+      const abs = join(dir, rel);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, content);
+    }
+    const r = spawnSync(process.execPath, [CHECKER, '--root', dir], { encoding: 'utf8' });
+    return { status: r.status, out: `${r.stdout}${r.stderr}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const CLEAN = `name: x
+jobs:
+  release:
+    steps:
+      - run: |
+          git tag "v1" || true
+          git push origin "v1"
+`;
+
+test('a clean workflow passes, and says how much it looked at', () => {
+  const { status, out } = runOn({ '.github/workflows/release.yml': CLEAN });
+  assert.equal(status, 0, out);
+  assert.match(out, /check-swallowed-push: OK \(1 workflow files/);
+});
+
+test('`|| true` on a push is caught', () => {
+  const { status, out } = runOn({
+    '.github/workflows/release.yml': CLEAN.replace('git push origin "v1"', 'git push origin "v1" || true'),
+  });
+  assert.equal(status, 1, out);
+  assert.match(out, /release\.yml:\d+.*git push origin "v1" \|\| true/);
+});
+
+test('`|| :` is caught too — a shell no-op reads as decorative', () => {
+  const { status, out } = runOn({
+    '.github/workflows/release.yml': CLEAN.replace('git push origin "v1"', 'git push origin "v1" || :'),
+  });
+  assert.equal(status, 1, out);
+});
+
+test('`|| true` on `git tag` is NOT caught — idempotency there is the point', () => {
+  // The whole value of this gate is that it separates the two. A rule that
+  // flagged both would be suppressed wholesale on its first run.
+  const { status } = runOn({ '.github/workflows/release.yml': CLEAN });
+  assert.equal(status, 0);
+  assert.ok(SWALLOWED_PUSH.test('git push origin "v1" || true'));
+  assert.ok(!SWALLOWED_PUSH.test('git tag "v1" || true'));
+});
+
+test('a marked site is excused AND named, not hidden', () => {
+  const marked = CLEAN.replace(
+    '          git push origin "v1"',
+    `          # ${MARKER}: mirror remote is best-effort\n          git push origin "v1" || true`,
+  );
+  const { status, out } = runOn({ '.github/workflows/release.yml': marked });
+  assert.equal(status, 0, out);
+  assert.match(out, /1 marked/);
+  assert.match(out, /marked: .*release\.yml/);
+});
+
+test('a MISSING workflow directory fails instead of reporting clean', () => {
+  // The failure this gate exists to prevent, one level up: a scan that examined
+  // nothing must not be indistinguishable from a scan that found nothing.
+  const { status, out } = runOn({ 'README.md': 'no workflows here\n' });
+  assert.equal(status, 1, out);
+  assert.match(out, /scan root has moved|examined nothing/);
+});
+
+test('an EMPTY workflow directory fails instead of reporting clean', () => {
+  const { status, out } = runOn({ '.github/workflows/.keep': '' });
+  assert.equal(status, 1, out);
+  assert.match(out, /No workflow files found/);
+});
+
+test('the detector reports the right line number', () => {
+  // An offender named at the wrong line sends the reader to innocent code.
+  const src = ['a', 'b', 'git push origin "x" || true', 'c'].join('\n');
+  const { hits } = findSwallowedPushes(src);
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].line, 3);
+});

--- a/scripts/check-swallowed-push.test.mjs
+++ b/scripts/check-swallowed-push.test.mjs
@@ -86,6 +86,25 @@ test('`|| true` on `git tag` is NOT caught — idempotency there is the point', 
   assert.ok(!SWALLOWED_PUSH.test('git tag "v1" || true'));
 });
 
+test('a no-op followed by a command-list delimiter is still swallowed', () => {
+  // End-of-line was not the only spelling. Chaining after the no-op discards the
+  // push status just as thoroughly, and an `(?:$|#)` anchor walks past it.
+  // Reported by CodeRabbit on #3208; each of these was verified to flip the
+  // regex from false to true.
+  const forms = {
+    'semicolon': 'git push origin "v1" || true; echo continuing',
+    'background': 'git push origin "v1" || true & ',
+    'subshell close': '(git push origin "v1" || true)',
+    'pipe': 'git push origin "v1" || true | tee log',
+  };
+  for (const [label, line] of Object.entries(forms)) {
+    const { status, out } = runOn({
+      '.github/workflows/release.yml': CLEAN.replace('          git push origin "v1"', `          ${line}`),
+    });
+    assert.equal(status, 1, `${label} was not caught:\n${out}`);
+  }
+});
+
 test('a marked site is excused AND named, not hidden', () => {
   const marked = CLEAN.replace(
     '          git push origin "v1"',


### PR DESCRIPTION
Closes #3202.

`release.yml` discarded the exit status of both `v*` tag pushes:

```
:316   git push origin "v${VERSION}" || true
:349   git push origin "$TAG"        || true
```

`|| true` on the adjacent `git tag` is correct and **stays** — a backfill or re-run hits an existing tag and idempotency is the point. On the **push** it means a network, auth or ref-lock failure becomes a silent no-op and the job continues as though the ref reached the remote.

## Why this is worth more than deleting two characters

A swallowed push does not produce "no release". **`gh release create` creates the missing tag itself**, and with no `--target` it does so *"from the latest state of the default branch"* — verbatim from `gh release create --help`, confirmed against gh 2.97.0. Neither call site passed `--target` or `--verify-tag` (measured on `origin/main`).

So the run stays green and the tag points at a **different commit than the packages published from it**. `packages/server-bin/src/binary.ts:199` resolves its download URL from that tag, and the fallback chain at `:220` can find a **stale** archive — worse than a 404.

**The interaction makes it likely rather than theoretical.** The fix added after 2026-08-12 introduced a *backfill* path so a later run can tag a version whose tag went missing. A backfill by definition runs after `main` has moved on — so the code path added to recover from the previous incident is the one most exposed to this one.

**Not the same defect as 2026-08-12**, and worth stating since the adjacent code carries a comment about a tag failure. That was a *wrong gate*: the v-tag steps skipped because `published == 'true'` was false after `changesets/action` itself failed. Nothing was swallowed. This is an *unguarded push*.

> **Scope correction (CodeRabbit, #3209).** This closes the route where `gh release create` **invents** a tag at default-branch head. It does **not** close the other route to the same harm: `git tag` with no object tags the checkout HEAD, and the job checks out the triggering commit — so a **backfill** creates `v<old-version>` at a newer commit, and the now-unguarded push publishes it. Tracked in #3209. Read the claims below as being about tag *invention*, not about every way a tag can end up on the wrong commit.

## Both halves, because they answer different questions

- The push is **unguarded**, so a failure is loud where it happens.
- `gh release create` gains **`--verify-tag`**, so it cannot invent the ref at all.

`--target` would make an auto-created tag *correct*; `--verify-tag` makes auto-creation *impossible*. The second is the better property for a release workflow — a tag conjured by tooling is a fact about the world that no later run can distinguish from one the workflow pushed deliberately.

## The ratchet

`scripts/check-swallowed-push.mjs`, wired into the node-test job. **Baseline is zero** — it lands in the same change that removes the only two instances, so it never grandfathers anything.

It separates the two spellings deliberately: `git tag … || true` is **not** flagged. A rule that caught both would be suppressed wholesale on its first run.

Run against an unfixed copy of `origin/main` it reports exactly the two sites:

```
.github/workflows/release.yml:316  git push origin "v${VERSION}" || true
.github/workflows/release.yml:349  git push origin "$TAG" || true
```

Its harness covers every way it could go false-green — including the failure the gate is itself about: a **missing or empty** workflow directory exits 1 rather than reporting clean, so a scan that examined nothing cannot read as a scan that found nothing.

## Verification

598 script tests green, `check-test-wiring` OK (40 gate scripts, 27 script test files), both workflow files still parse as YAML. No changeset — workflow and `scripts/` only, no publishable package.

## Credit

Issue by @BIMvoice. bimvoice-02 confirmed the `gh release create` auto-tag behaviour against the CLI's own contract — the issue flagged it as its one unmeasured premise — and argued `--verify-tag` over `--target`, which is the stronger property and the one I took.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release jobs now fail when tag pushes fail instead of continuing silently.
  - Releases verify that the expected tag exists before creation, preventing releases from using unintended default-branch tags.

- **New Features**
  - Added automated checks to detect workflow commands that suppress push failures.
  - Added support for explicitly marked exceptions and actionable error reporting.

- **Tests**
  - Added regression coverage for failed pushes, valid tag operations, exceptions, missing workflows, and diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
