### PR TITLE
feat(geometry,wasm,cache): representation-item identity crosses the boundary, disjoint from material ids (#3199)

### DIFF
--- a/.changeset/rep-item-identity-across-boundary.md
+++ b/.changeset/rep-item-identity-across-boundary.md
@@ -2,14 +2,19 @@
 "@ifc-lite/geometry": minor
 "@ifc-lite/wasm": minor
 "@ifc-lite/cache": minor
+"@ifc-lite/server-client": minor
 ---
 
 Carry representation-item identity across the wasm boundary, and stop delivering material ids in the same field.
 
-`MeshData` gains two DISJOINT fields. `geometryItemId` is always the `IfcRepresentationItem` a mesh was tessellated from, so a host can drill from a rendered piece into an `IfcWindow`'s pane or frame and navigate to that entity in source. `materialLayerId` is always the `IfcMaterial` whose layer a mesh slices. Never both — a consumer that ignores the distinction still cannot read one as the other.
+`MeshData` gains two DISJOINT fields. `geometryItemId` is always the `IfcRepresentationItem` a mesh was tessellated from, so a host can drill from a rendered piece into an `IfcWindow`'s pane or frame and navigate to that entity in source. `materialId` is always the `IfcMaterial` whose layer a mesh slices. Never both — a consumer that ignores the distinction still cannot read one as the other.
 
 The router already kept each item's STEP id and it already reached the server REST payload; `MeshDataJs::from_mesh_data` did not copy it, so the browser never saw it. And for material-layered walls and slabs the same field carried the layer's `IfcMaterial` id, so following it to source landed on the wrong entity with nothing to warn the caller.
 
 `geometryClass === 3` cannot discriminate the two: it is stamped from a static material-index check made before the geometry runs, while the layered path can bail at runtime and emit representation-item submeshes under that class. The discriminator therefore lives on `SubMeshCollection`, set where the layered slabs are built.
 
-Both fields cross the boundary, both converters carry them, and the cache format gains them at v14 — without that, a cache-restored session silently lost the identity.
+Neither field is ever `0`. `IfcMaterialLayer.Material` is optional, so an air gap reaches the mesher as `material_id 0` — that is the decoder's "no reference" sentinel, not an entity, and STEP instance names start at `#1`. Twelve slabs of `duplex.ifc` reported `IfcMaterial #0` before this was filtered at the setter. An air-gap slab is still meshed; it simply reports no material.
+
+Both fields cross the boundary, both wasm converters carry them, the REST wire shape and `convertServerMesh` carry them, and the cache format gains them at v14 — without that, a cache-restored session silently lost the identity.
+
+BREAKING FOR THE RUST CRATE, and this changeset cannot express it. `ifc-lite-processing` is published to crates.io (`scripts/release-crates.mjs`), `MeshData` gains a public field, and `with_style_metadata` goes from two arguments to three — both break a struct literal or a call downstream, which `rust/export/src/usd/tests.rs` demonstrates in-repo. `scripts/sync-versions.js` derives the Cargo workspace version from the highest npm package version, so a `minor` here ships 6.0.0 → 6.1.0 and a consumer pinned to `ifc-lite-processing = "6"` breaks on `cargo update`. Nothing gates this: there is no `cargo-semver-checks` anywhere in the repo.

--- a/.changeset/rep-item-identity-across-boundary.md
+++ b/.changeset/rep-item-identity-across-boundary.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/geometry": minor
+"@ifc-lite/wasm": minor
+"@ifc-lite/cache": minor
+---
+
+Carry representation-item identity across the wasm boundary, and stop delivering material ids in the same field.
+
+`MeshData` gains two DISJOINT fields. `geometryItemId` is always the `IfcRepresentationItem` a mesh was tessellated from, so a host can drill from a rendered piece into an `IfcWindow`'s pane or frame and navigate to that entity in source. `materialLayerId` is always the `IfcMaterial` whose layer a mesh slices. Never both — a consumer that ignores the distinction still cannot read one as the other.
+
+The router already kept each item's STEP id and it already reached the server REST payload; `MeshDataJs::from_mesh_data` did not copy it, so the browser never saw it. And for material-layered walls and slabs the same field carried the layer's `IfcMaterial` id, so following it to source landed on the wrong entity with nothing to warn the caller.
+
+`geometryClass === 3` cannot discriminate the two: it is stamped from a static material-index check made before the geometry runs, while the layered path can bail at runtime and emit representation-item submeshes under that class. The discriminator therefore lives on `SubMeshCollection`, set where the layered slabs are built.
+
+Both fields cross the boundary, both converters carry them, and the cache format gains them at v14 — without that, a cache-restored session silently lost the identity.

--- a/apps/viewer/src/utils/coldGeometryProvider.test.ts
+++ b/apps/viewer/src/utils/coldGeometryProvider.test.ts
@@ -5,7 +5,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import type { CoordinateInfo, MeshData } from '@ifc-lite/geometry';
-import { buildGeometrySectionV13, openGeometryChunksV13 } from '@ifc-lite/cache';
+import { buildGeometrySectionV13, openGeometryChunksV13, FORMAT_VERSION } from '@ifc-lite/cache';
 import { makeColdGeometryProvider } from './coldGeometryProvider.js';
 
 const coordInfo: CoordinateInfo = {
@@ -32,7 +32,15 @@ async function makeFixture() {
   // Two far-apart cells → at least two chunks with disjoint AABBs.
   const meshes = [mesh(1, [1, 1, 1]), mesh(2, [2, 2, 2]), mesh(3, [1000, 0, 0])];
   const section = await buildGeometrySectionV13(meshes, coordInfo);
-  const open = openGeometryChunksV13(section, 0, 13);
+  // The reader version is "whatever the writer just emitted", not a literal.
+  // It was pinned to 13 and went stale at the #3199 bump: the writer gained 8
+  // bytes per mesh record, a v13 reader skipped them, and every record after
+  // the first was misaligned -- which `decodeGeometryChunk`'s exact-consumption
+  // check caught, but only here, because the cache package's own suite does not
+  // run this file. `buildGeometrySectionV13` takes NO version argument: it
+  // always writes current, so any literal paired with it is a bet on the
+  // format never moving.
+  const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
   return { section, chunks: open.chunks };
 }
 
@@ -43,7 +51,7 @@ describe('makeColdGeometryProvider', () => {
       source: section,
       geometrySectionOffset: 0,
       chunks,
-      version: 13,
+      version: FORMAT_VERSION,
     });
     const near = await provider.loadMeshesInBounds([0, 0, 0], [10, 10, 10]);
     assert.deepStrictEqual(near.map((m) => m.expressId).sort(), [1, 2]);
@@ -62,7 +70,7 @@ describe('makeColdGeometryProvider', () => {
       source: blob,
       geometrySectionOffset: 128,
       chunks,
-      version: 13,
+      version: FORMAT_VERSION,
     });
     const near = await provider.loadMeshesInBounds([0, 0, 0], [10, 10, 10]);
     assert.deepStrictEqual(near.map((m) => m.expressId).sort(), [1, 2]);

--- a/apps/viewer/src/utils/serverMesh.test.ts
+++ b/apps/viewer/src/utils/serverMesh.test.ts
@@ -50,3 +50,33 @@ test('keeps an origin that is zero on only some axes', () => {
   const out = convertServerMesh({ ...base, origin: [0, 0, -20] });
   assert.deepEqual(out.origin, [0, 0, -20]);
 });
+
+test('forwards the representation-item id, so a REST-loaded pick can reach source (#3199)', () => {
+  const out = convertServerMesh({ ...base, geometry_item_id: 1234 });
+  assert.equal(out.geometryItemId, 1234);
+  assert.equal('materialId' in out, false);
+});
+
+test('forwards the material id, disjoint from the representation-item id (#3199)', () => {
+  const out = convertServerMesh({ ...base, material_id: 3876 });
+  assert.equal(out.materialId, 3876);
+  assert.equal('geometryItemId' in out, false);
+});
+
+test('omits both source ids when the server sent neither', () => {
+  const out = convertServerMesh(base);
+  assert.equal('geometryItemId' in out, false);
+  assert.equal('materialId' in out, false);
+});
+
+// The other two optionals in this converter are truthiness-gated on purpose: a
+// zero origin and class 0 are both the default, so carrying them would make the
+// same mesh decode differently per transport. A source id is not like that --
+// it is an express instance name, and this converter must not invent a rule
+// about which values are "real". The server already drops 0 (`#0` is not an
+// entity), so if one ever arrives the honest thing is to pass it through and
+// let the id-provenance tests catch it, not to silently swallow it here.
+test('does not truthiness-gate the source ids the way it gates origin and class', () => {
+  const out = convertServerMesh({ ...base, geometry_item_id: 0 });
+  assert.equal(out.geometryItemId, 0, 'a 0 id was dropped by a truthiness check');
+});

--- a/apps/viewer/src/utils/serverMesh.ts
+++ b/apps/viewer/src/utils/serverMesh.ts
@@ -34,5 +34,18 @@ export function convertServerMesh(m: ServerMeshData): MeshData {
     // make the same mesh decode to a different shape depending on transport.
     ...(m.origin?.some((v) => v !== 0) ? { origin: m.origin } : {}),
     ...(m.geometry_class ? { geometryClass: m.geometry_class } : {}),
+    // The two DISJOINT source ids (#3199). Tested against `undefined`, never for
+    // truthiness -- unlike the two optionals above, which are correctly
+    // truthiness-gated because a zero origin and class 0 are both the default.
+    //
+    // The server never sends `0` for either id (`#0` is not a STEP instance
+    // name; an air-gap layer is sent as absent), so this converter would be
+    // gating on a value it can never see. That is exactly why it must NOT gate:
+    // a converter enforcing a producer's invariant turns a future producer bug
+    // into silent data loss here instead of a visible wrong id upstream, and
+    // dropping an id is how the REST path keeps rendering identically while a
+    // host loses the ability to drill from a picked piece to its source.
+    ...(m.geometry_item_id !== undefined ? { geometryItemId: m.geometry_item_id } : {}),
+    ...(m.material_id !== undefined ? { materialId: m.material_id } : {}),
   };
 }

--- a/packages/cache/src/sections/geometry-chunks.test.ts
+++ b/packages/cache/src/sections/geometry-chunks.test.ts
@@ -13,7 +13,14 @@ import {
   inflateRaw,
   decodeGeometryChunk,
 } from './geometry-chunks.js';
-import { GeometryChunkFlags, type GeometryChunkInfo } from '../types.js';
+import { FORMAT_VERSION, GeometryChunkFlags, type GeometryChunkInfo } from '../types.js';
+
+// These suites all read back what `buildGeometrySectionV13` just wrote, so the
+// reader version is "whatever the writer emits", not a literal. It was pinned
+// to 13 and went stale at the #3199 bump: the writer added 8 bytes per mesh
+// record, a v13 reader skipped them, and every record after the first was
+// misaligned. The on-disk version literal is pinned in header.test.ts, which
+// is where a silent bump should be caught.
 
 const coordInfo = (overrides: Partial<CoordinateInfo> = {}): CoordinateInfo => ({
   originShift: { x: 1.5, y: -2.5, z: 1e6 },
@@ -131,7 +138,7 @@ describe('v13 geometry section round-trip', () => {
   it('round-trips meshes, counts and coordinateInfo (compressed)', async () => {
     const info = coordInfo({ wasmRtcOffset: { x: 1, y: 2, z: 3 }, buildingRotation: 0.25 });
     const section = await buildGeometrySectionV13(meshes, info);
-    const result = await readGeometryV13(section, 0, 13);
+    const result = await readGeometryV13(section, 0, FORMAT_VERSION);
     expectMeshesEqual(result.meshes, meshes);
     expect(result.totalVertices).toBe(12);
     expect(result.totalTriangles).toBe(4);
@@ -140,13 +147,13 @@ describe('v13 geometry section round-trip', () => {
 
   it('round-trips with compression disabled', async () => {
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
-    const result = await readGeometryV13(section, 0, 13);
+    const result = await readGeometryV13(section, 0, FORMAT_VERSION);
     expectMeshesEqual(result.meshes, meshes);
   });
 
   it('exposes a directory with valid AABBs and per-chunk decode', async () => {
     const section = await buildGeometrySectionV13(meshes, coordInfo());
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     expect(open.chunks.length).toBeGreaterThanOrEqual(2);
     let total = 0;
     for (let i = 0; i < open.chunks.length; i++) {
@@ -171,7 +178,7 @@ describe('v13 geometry section round-trip', () => {
   it('small chunks skip compression; a large repetitive chunk compresses', async () => {
     // Small: below the 64KiB floor → raw.
     const small = await buildGeometrySectionV13([mesh(1, [0, 0, 0])], coordInfo());
-    const openSmall = openGeometryChunksV13(small, 0, 13);
+    const openSmall = openGeometryChunksV13(small, 0, FORMAT_VERSION);
     expect(openSmall.chunks[0].flags & GeometryChunkFlags.DeflateRaw).toBe(0);
 
     // Large + repetitive: one 100k-vertex mesh of zeros → compresses well.
@@ -181,7 +188,7 @@ describe('v13 geometry section round-trip', () => {
       indices: new Uint32Array(300_000),
     });
     const section = await buildGeometrySectionV13([big], coordInfo());
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     expect(open.chunks[0].flags & GeometryChunkFlags.DeflateRaw).toBe(GeometryChunkFlags.DeflateRaw);
     expect(open.chunks[0].byteLength).toBeLessThan(open.chunks[0].uncompressedLength / 4);
     const decoded = await open.readChunk(0);
@@ -190,7 +197,7 @@ describe('v13 geometry section round-trip', () => {
 
   it('handles empty mesh lists', async () => {
     const section = await buildGeometrySectionV13([], coordInfo());
-    const result = await readGeometryV13(section, 0, 13);
+    const result = await readGeometryV13(section, 0, FORMAT_VERSION);
     expect(result.meshes).toEqual([]);
     expect(result.totalVertices).toBe(0);
   });
@@ -223,19 +230,19 @@ describe('corrupt geometry chunk directory', () => {
     const meshes = [mesh(1, [0, 0, 0]), mesh(2, [5000, 5000, 5000])]; // forced into separate chunks
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
     const bytes = new Uint8Array(section);
-    const info0 = openGeometryChunksV13(section, 0, 13).chunks[0];
+    const info0 = openGeometryChunksV13(section, 0, FORMAT_VERSION).chunks[0];
     const entry = findDirectoryEntry(bytes, info0.byteOffset, info0.byteLength);
     const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     dv.setUint32(entry + 28, info0.byteLength + 10_000, true); // byteLength: reach past the buffer end
 
-    expect(() => openGeometryChunksV13(section, 0, 13)).toThrow(/not contiguous/);
+    expect(() => openGeometryChunksV13(section, 0, FORMAT_VERSION)).toThrow(/not contiguous/);
   });
 
   it('rejects a chunk whose inflated byteLength/meshCount/uncompressedLength consistently absorb the next chunk', async () => {
     const meshes = [mesh(1, [0, 0, 0]), mesh(2, [5000, 5000, 5000])];
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
     const bytes = new Uint8Array(section);
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     expect(open.chunks.length).toBe(2); // control: the fixture really did split into 2 chunks
     const info0 = open.chunks[0];
     const info1 = open.chunks[1];
@@ -250,13 +257,13 @@ describe('corrupt geometry chunk directory', () => {
     dv.setUint32(entry + 32, absorbedLength, true); // uncompressedLength
     dv.setUint32(entry + 36, info0.meshCount + info1.meshCount, true); // meshCount
 
-    expect(() => openGeometryChunksV13(section, 0, 13)).toThrow(/not contiguous/);
+    expect(() => openGeometryChunksV13(section, 0, FORMAT_VERSION)).toThrow(/not contiguous/);
   });
 
   it('bounding control: a valid multi-chunk directory (ranges reaching exactly to the next chunk) still decodes', async () => {
     const meshes = [mesh(1, [0, 0, 0]), mesh(2, [5000, 5000, 5000])];
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     expect(open.chunks.length).toBe(2);
     const decoded0 = await open.readChunk(0);
     const decoded1 = await open.readChunk(1);
@@ -271,7 +278,7 @@ describe('corrupt geometry chunk directory', () => {
     const meshes = [mesh(1, [0, 0, 0]), mesh(2, [5000, 5000, 5000])];
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
     const bytes = new Uint8Array(section);
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 
     // Shift EVERY chunk's byteOffset by the same delta. Relative spacing —
@@ -282,7 +289,7 @@ describe('corrupt geometry chunk directory', () => {
       dv.setUint32(entry + 24, info.byteOffset + SHIFT, true);
     }
 
-    expect(() => openGeometryChunksV13(section, 0, 13)).toThrow(
+    expect(() => openGeometryChunksV13(section, 0, FORMAT_VERSION)).toThrow(
       /chunk 0 byteOffset .* does not start at the end of the head/,
     );
   });
@@ -299,7 +306,7 @@ describe('corrupt geometry chunk directory', () => {
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
     const bytes = new Uint8Array(section);
     const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     const info0 = open.chunks[0];
     const trueHeadLength = dv.getUint32(0, true);
     const entry = findDirectoryEntry(bytes, info0.byteOffset, info0.byteLength);
@@ -310,7 +317,7 @@ describe('corrupt geometry chunk directory', () => {
     dv.setUint32(0, forgedHeadLength, true);
     dv.setUint32(entry + 24, 4 + forgedHeadLength, true);
 
-    expect(() => openGeometryChunksV13(section, 0, 13)).toThrow(/headLength/);
+    expect(() => openGeometryChunksV13(section, 0, FORMAT_VERSION)).toThrow(/headLength/);
   });
 
   // `readChunk`'s own end-of-buffer check was unreachable from the tests
@@ -322,7 +329,7 @@ describe('corrupt geometry chunk directory', () => {
     const meshes = [mesh(1, [0, 0, 0]), mesh(2, [5000, 5000, 5000])];
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
     const bytes = new Uint8Array(section);
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     const last = open.chunks[open.chunks.length - 1];
     const entry = findDirectoryEntry(bytes, last.byteOffset, last.byteLength);
     const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
@@ -330,7 +337,7 @@ describe('corrupt geometry chunk directory', () => {
 
     // The directory still validates: chunk 0 is anchored, and the last chunk
     // has no successor for the contiguity loop to compare against.
-    const reopened = openGeometryChunksV13(section, 0, 13);
+    const reopened = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     await expect(reopened.readChunk(open.chunks.length - 1)).rejects.toThrow(
       /exceeds buffer length/,
     );
@@ -348,7 +355,7 @@ describe('decodeGeometryChunk length verification', () => {
   it('throws when the stored bytes decode to a length that disagrees with the directory', async () => {
     const meshes = [mesh(1, [0, 0, 0])];
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     const realInfo = open.chunks[0];
     expect(realInfo.flags & GeometryChunkFlags.DeflateRaw).toBe(0); // uncompressed: raw === stored
 
@@ -357,7 +364,7 @@ describe('decodeGeometryChunk length verification', () => {
 
     // Directory claims one more byte than the record actually decodes to.
     const lyingInfo: GeometryChunkInfo = { ...realInfo, uncompressedLength: realInfo.uncompressedLength + 1 };
-    await expect(decodeGeometryChunk(stored, lyingInfo, 13)).rejects.toThrow(
+    await expect(decodeGeometryChunk(stored, lyingInfo, FORMAT_VERSION)).rejects.toThrow(
       /Invalid cache: chunk decoded to \d+ bytes, directory says \d+/,
     );
 
@@ -366,7 +373,7 @@ describe('decodeGeometryChunk length verification', () => {
     // the decoded content itself (mesh count + expressId), not mere
     // truthiness: an empty array is also truthy and would satisfy a
     // `resolves.toBeTruthy()` check whether or not any mesh actually decoded.
-    const decoded = await decodeGeometryChunk(stored, realInfo, 13);
+    const decoded = await decodeGeometryChunk(stored, realInfo, FORMAT_VERSION);
     expectMeshesEqual(decoded, meshes);
   });
 
@@ -383,7 +390,7 @@ describe('decodeGeometryChunk length verification', () => {
   it('throws when a mesh record under-consumes the declared chunk length (meshCount and uncompressedLength are both truthful)', async () => {
     const meshes = [mesh(1, [0, 0, 0])];
     const section = await buildGeometrySectionV13(meshes, coordInfo(), { compress: false });
-    const open = openGeometryChunksV13(section, 0, 13);
+    const open = openGeometryChunksV13(section, 0, FORMAT_VERSION);
     const realInfo = open.chunks[0];
     expect(realInfo.flags & GeometryChunkFlags.DeflateRaw).toBe(0); // uncompressed: raw === stored
     expect(realInfo.meshCount).toBe(1);
@@ -402,14 +409,14 @@ describe('decodeGeometryChunk length verification', () => {
     expect(realVertexCount).toBe(3);
     dv.setUint32(4, realVertexCount - 1, true);
 
-    await expect(decodeGeometryChunk(stored, realInfo, 13)).rejects.toThrow(
+    await expect(decodeGeometryChunk(stored, realInfo, FORMAT_VERSION)).rejects.toThrow(
       /Invalid cache: chunk claims \d+ mesh record\(s\) but consumed \d+ of \d+ bytes/,
     );
 
     // Control: restoring the true vertexCount round-trips fine — the throw
     // above is caused by the corruption, not some unrelated fixture bug.
     dv.setUint32(4, realVertexCount, true);
-    const decoded = await decodeGeometryChunk(stored, realInfo, 13);
+    const decoded = await decodeGeometryChunk(stored, realInfo, FORMAT_VERSION);
     expectMeshesEqual(decoded, meshes);
   });
 });

--- a/packages/cache/src/sections/geometry.test.ts
+++ b/packages/cache/src/sections/geometry.test.ts
@@ -1,0 +1,170 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Per-mesh record round-trip, at the level `writeMeshRecord` /
+ * `readMeshRecord` actually operate on.
+ *
+ * geometry-chunks.test.ts covers the same writer through the v13 chunk
+ * section, but it compares meshes with a helper that only looks at
+ * expressId/ifcType/geometryClass/color/origin/arrays — a field the writer
+ * drops is invisible to it. These tests read the record back field by field,
+ * and check the byte accounting the chunk budgeter depends on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { MeshData } from '@ifc-lite/geometry';
+import { writeMeshRecord, readMeshRecord, meshRecordByteLength } from './geometry.js';
+import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import { FORMAT_VERSION } from '../types.js';
+
+function mesh(overrides: Partial<MeshData> = {}): MeshData {
+  return {
+    expressId: 8970,
+    positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [0.5, 0.25, 0.125, 1],
+    // 7 bytes keeps every following field 4-byte aligned, which
+    // `readFloat32Array` needs (it views the buffer rather than copying).
+    ifcType: 'IFCWALL',
+    geometryClass: 0,
+    origin: [10, 20, 30],
+    ...overrides,
+  };
+}
+
+/** Write one record and read it straight back. */
+function roundTrip(m: MeshData, version: number = FORMAT_VERSION): MeshData {
+  const writer = new BufferWriter();
+  writeMeshRecord(writer, m);
+  return readMeshRecord(new BufferReader(writer.build()), version, 0);
+}
+
+describe('mesh record source ids (#3199)', () => {
+  it('carries geometryItemId back, and leaves materialLayerId absent', () => {
+    // 4638 is a real IfcRepresentationItem id from tests/models/ara3d/duplex.ifc.
+    const out = roundTrip(mesh({ geometryItemId: 4638 }));
+    expect(out.geometryItemId).toBe(4638);
+    expect(out.materialLayerId).toBeUndefined();
+  });
+
+  it('carries materialLayerId back, and leaves geometryItemId absent', () => {
+    // 3941 is a real IfcMaterial id from the same fixture's layered walls.
+    const out = roundTrip(mesh({ geometryClass: 3, materialLayerId: 3941 }));
+    expect(out.materialLayerId).toBe(3941);
+    expect(out.geometryItemId).toBeUndefined();
+    expect(out.geometryClass).toBe(3);
+  });
+
+  it('leaves both absent when the mesh carried neither', () => {
+    const out = roundTrip(mesh());
+    expect(out.geometryItemId).toBeUndefined();
+    expect(out.materialLayerId).toBeUndefined();
+  });
+
+  it('never invents the other id: a restored mesh carries at most one', () => {
+    for (const m of [
+      mesh({ geometryItemId: 4638 }),
+      mesh({ geometryClass: 3, materialLayerId: 3941 }),
+      mesh(),
+    ]) {
+      const out = roundTrip(m);
+      expect(out.geometryItemId === undefined || out.materialLayerId === undefined).toBe(true);
+    }
+  });
+
+  it('keeps a 0 materialLayerId, which means an air-gap layer and not "absent"', () => {
+    // IfcMaterialLayer.Material is OPTIONAL. material_layer_index.rs decodes an
+    // absent one as `material_id = 0` ("Zero means no material"), layers.rs
+    // slices a slab for it like any other layer, and the wasm boundary hands
+    // that slice out as materialLayerId === 0 — checked against the built
+    // runtime on a duplex.ifc whose #3876 layer had its material dropped: 12
+    // meshes came back with materialLayerId 0.
+    //
+    // So 0 is a value, not a hole, and it is also falsy. A cache that encodes
+    // "absent" as 0 cannot tell the two apart and drops the air gap.
+    const out = roundTrip(mesh({ geometryClass: 3, materialLayerId: 0 }));
+    expect(out.materialLayerId).toBe(0);
+    expect(out.geometryItemId).toBeUndefined();
+  });
+});
+
+describe('mesh record byte accounting', () => {
+  // geometry-chunks.ts budgets chunk sizes with meshRecordByteLength and then
+  // rejects a chunk whose records do not consume it exactly, so a wrong count
+  // is a hard read failure later, not a rounding error.
+  it('meshRecordByteLength matches the bytes written, for every id combination', () => {
+    for (const m of [
+      mesh(),
+      mesh({ geometryItemId: 4638 }),
+      mesh({ materialLayerId: 3941 }),
+      mesh({ materialLayerId: 0 }),
+      mesh({ ifcType: undefined }),
+    ]) {
+      const writer = new BufferWriter();
+      writeMeshRecord(writer, m);
+      expect(writer.position).toBe(meshRecordByteLength(m));
+    }
+  });
+
+  it('the record is longer than a v13 one, which is what the version bump was for', () => {
+    // Not pinned to an exact delta: how the ids are encoded is still open (two
+    // bare u32 cannot represent a 0 materialLayerId — see the air-gap test).
+    // What must hold is that the record grew at all, because that is what makes
+    // a v13 reader misparse a v14 record and what FORMAT_VERSION has to signal.
+    const m = mesh({ geometryItemId: 4638 });
+    const v13Length =
+      4 + 4 + 4 + 16 + 4 + 7 + 1 + 24 +
+      m.positions.byteLength + m.normals.byteLength + m.indices.byteLength;
+    expect(meshRecordByteLength(m)).toBeGreaterThanOrEqual(v13Length + 8);
+  });
+});
+
+describe('mesh record version gating', () => {
+  /** The v13 record layout: identical, minus the two id words. */
+  function writeV13Record(writer: BufferWriter, m: MeshData): void {
+    writer.writeUint32(m.expressId);
+    writer.writeUint32(m.positions.length / 3);
+    writer.writeUint32(m.indices.length);
+    for (const c of m.color) writer.writeFloat32(c);
+    writer.writeString(m.ifcType || '');
+    writer.writeUint8(m.geometryClass ?? 0);
+    writer.writeFloat64(m.origin ? m.origin[0] : 0);
+    writer.writeFloat64(m.origin ? m.origin[1] : 0);
+    writer.writeFloat64(m.origin ? m.origin[2] : 0);
+    writer.writeTypedArray(m.positions);
+    writer.writeTypedArray(m.normals);
+    writer.writeTypedArray(m.indices);
+  }
+
+  it('reads a v13 record at version 13: no ids, and every later field intact', () => {
+    // The version gate has to be aligned as well as present. If it read the
+    // ids unconditionally it would take them out of the origin, and the
+    // failure would surface as displaced geometry rather than a missing id.
+    const source = mesh({ expressId: 4242, origin: [10, 20, 30] });
+    const writer = new BufferWriter();
+    writeV13Record(writer, source);
+    const out = readMeshRecord(new BufferReader(writer.build()), 13, 0);
+
+    expect(out.geometryItemId).toBeUndefined();
+    expect(out.materialLayerId).toBeUndefined();
+    expect(out.expressId).toBe(4242);
+    expect(out.ifcType).toBe('IFCWALL');
+    expect(out.origin).toEqual([10, 20, 30]);
+    expect(Array.from(out.positions)).toEqual(Array.from(source.positions));
+    expect(Array.from(out.indices)).toEqual(Array.from(source.indices));
+  });
+
+  it('an old cache degrades the ids to unknown, never to a wrong id', () => {
+    // A v13 entry has no id bytes at all, so "absent" is the only honest
+    // answer — and it is the same state the runtime uses where the identity
+    // was genuinely merged away. Nothing downstream has to special-case it.
+    const writer = new BufferWriter();
+    writeV13Record(writer, mesh({ geometryClass: 3 }));
+    const out = readMeshRecord(new BufferReader(writer.build()), 13, 0);
+    expect('geometryItemId' in out).toBe(false);
+    expect('materialLayerId' in out).toBe(false);
+  });
+});

--- a/packages/cache/src/sections/geometry.test.ts
+++ b/packages/cache/src/sections/geometry.test.ts
@@ -43,17 +43,17 @@ function roundTrip(m: MeshData, version: number = FORMAT_VERSION): MeshData {
 }
 
 describe('mesh record source ids (#3199)', () => {
-  it('carries geometryItemId back, and leaves materialLayerId absent', () => {
+  it('carries geometryItemId back, and leaves materialId absent', () => {
     // 4638 is a real IfcRepresentationItem id from tests/models/ara3d/duplex.ifc.
     const out = roundTrip(mesh({ geometryItemId: 4638 }));
     expect(out.geometryItemId).toBe(4638);
-    expect(out.materialLayerId).toBeUndefined();
+    expect(out.materialId).toBeUndefined();
   });
 
-  it('carries materialLayerId back, and leaves geometryItemId absent', () => {
+  it('carries materialId back, and leaves geometryItemId absent', () => {
     // 3941 is a real IfcMaterial id from the same fixture's layered walls.
-    const out = roundTrip(mesh({ geometryClass: 3, materialLayerId: 3941 }));
-    expect(out.materialLayerId).toBe(3941);
+    const out = roundTrip(mesh({ geometryClass: 3, materialId: 3941 }));
+    expect(out.materialId).toBe(3941);
     expect(out.geometryItemId).toBeUndefined();
     expect(out.geometryClass).toBe(3);
   });
@@ -61,32 +61,38 @@ describe('mesh record source ids (#3199)', () => {
   it('leaves both absent when the mesh carried neither', () => {
     const out = roundTrip(mesh());
     expect(out.geometryItemId).toBeUndefined();
-    expect(out.materialLayerId).toBeUndefined();
+    expect(out.materialId).toBeUndefined();
   });
 
   it('never invents the other id: a restored mesh carries at most one', () => {
     for (const m of [
       mesh({ geometryItemId: 4638 }),
-      mesh({ geometryClass: 3, materialLayerId: 3941 }),
+      mesh({ geometryClass: 3, materialId: 3941 }),
       mesh(),
     ]) {
       const out = roundTrip(m);
-      expect(out.geometryItemId === undefined || out.materialLayerId === undefined).toBe(true);
+      expect(out.geometryItemId === undefined || out.materialId === undefined).toBe(true);
     }
   });
 
-  it('keeps a 0 materialLayerId, which means an air-gap layer and not "absent"', () => {
-    // IfcMaterialLayer.Material is OPTIONAL. material_layer_index.rs decodes an
-    // absent one as `material_id = 0` ("Zero means no material"), layers.rs
-    // slices a slab for it like any other layer, and the wasm boundary hands
-    // that slice out as materialLayerId === 0 — checked against the built
-    // runtime on a duplex.ifc whose #3876 layer had its material dropped: 12
-    // meshes came back with materialLayerId 0.
+  it('round-trips a 0 materialId rather than reading it as "absent"', () => {
+    // This pins the ENCODING, not a claim about what the producer emits.
     //
-    // So 0 is a value, not a hole, and it is also falsy. A cache that encodes
-    // "absent" as 0 cannot tell the two apart and drops the air gap.
-    const out = roundTrip(mesh({ geometryClass: 3, materialLayerId: 0 }));
-    expect(out.materialLayerId).toBe(0);
+    // History, because the stated reason changed mid-PR and a stale one here
+    // would mislead: `IfcMaterialLayer.Material` is OPTIONAL,
+    // `material_layer_index.rs` decoded an absent one as `material_id = 0`
+    // ("Zero means no material"), and a duplex.ifc with #3876's material
+    // dropped produced 12 meshes carrying `materialId: 0` at the wasm boundary.
+    // #3199 then filtered 0 to `None` at the producer, since `#0` is not a STEP
+    // instance name — so that measurement no longer describes the runtime, and
+    // the air-gap behaviour is pinned where it belongs, in
+    // `scripts/test-wasm-contract.mjs` and `mesh_id_provenance.rs`.
+    //
+    // What survives is the encoding rule: 0 is falsy, and a format that spells
+    // "absent" as 0 cannot distinguish the two. That must hold whatever the
+    // producer decides to send, which is why this test still passes a 0.
+    const out = roundTrip(mesh({ geometryClass: 3, materialId: 0 }));
+    expect(out.materialId).toBe(0);
     expect(out.geometryItemId).toBeUndefined();
   });
 });
@@ -99,8 +105,8 @@ describe('mesh record byte accounting', () => {
     for (const m of [
       mesh(),
       mesh({ geometryItemId: 4638 }),
-      mesh({ materialLayerId: 3941 }),
-      mesh({ materialLayerId: 0 }),
+      mesh({ materialId: 3941 }),
+      mesh({ materialId: 0 }),
       mesh({ ifcType: undefined }),
     ]) {
       const writer = new BufferWriter();
@@ -111,7 +117,7 @@ describe('mesh record byte accounting', () => {
 
   it('the record is longer than a v13 one, which is what the version bump was for', () => {
     // Not pinned to an exact delta: how the ids are encoded is still open (two
-    // bare u32 cannot represent a 0 materialLayerId — see the air-gap test).
+    // bare u32 cannot represent a 0 materialId — see the air-gap test).
     // What must hold is that the record grew at all, because that is what makes
     // a v13 reader misparse a v14 record and what FORMAT_VERSION has to signal.
     const m = mesh({ geometryItemId: 4638 });
@@ -149,7 +155,7 @@ describe('mesh record version gating', () => {
     const out = readMeshRecord(new BufferReader(writer.build()), 13, 0);
 
     expect(out.geometryItemId).toBeUndefined();
-    expect(out.materialLayerId).toBeUndefined();
+    expect(out.materialId).toBeUndefined();
     expect(out.expressId).toBe(4242);
     expect(out.ifcType).toBe('IFCWALL');
     expect(out.origin).toEqual([10, 20, 30]);
@@ -165,6 +171,6 @@ describe('mesh record version gating', () => {
     writeV13Record(writer, mesh({ geometryClass: 3 }));
     const out = readMeshRecord(new BufferReader(writer.build()), 13, 0);
     expect('geometryItemId' in out).toBe(false);
-    expect('materialLayerId' in out).toBe(false);
+    expect('materialId' in out).toBe(false);
   });
 });

--- a/packages/cache/src/sections/geometry.ts
+++ b/packages/cache/src/sections/geometry.ts
@@ -80,12 +80,19 @@ export function writeMeshRecord(writer: BufferWriter, mesh: MeshData): void {
   // this piece was tessellated from, or the material layer it slices. Written
   // unconditionally as two u32 so the record stays fixed-shape.
   //
-  // The absent sentinel is 0xFFFFFFFF, NOT 0. `layers.rs` uses `0` for a layer
-  // with no material — an air gap — so a 0 here is a real value that must round
-  // trip. Treating it as absent is the valid-but-falsy trap, and it would have
-  // silently dropped exactly the layers that are hardest to notice missing.
+  // The absent sentinel is 0xFFFFFFFF, NOT 0, and the reason is worth keeping
+  // straight because it CHANGED during #3199. `layers.rs` decodes a layer with
+  // no material — an air gap — as `material_id = 0`, so 0 reached this writer
+  // and the first draft encoded "absent" as 0, which silently dropped exactly
+  // those layers: the valid-but-falsy trap.
+  //
+  // The producer now filters it instead (`with_style_metadata` maps a source id
+  // of 0 to `None`, because `#0` is not a STEP instance name), so nothing
+  // upstream emits 0 today. This layer does NOT rely on that: an encoding whose
+  // absence marker is a value the domain can produce is one upstream change
+  // away from being wrong again, and 0xFFFFFFFF costs nothing.
   writer.writeUint32(mesh.geometryItemId ?? ABSENT_SOURCE_ID);
-  writer.writeUint32(mesh.materialLayerId ?? ABSENT_SOURCE_ID);
+  writer.writeUint32(mesh.materialId ?? ABSENT_SOURCE_ID);
 
   // Write per-element local-frame origin (v6+, 3×f64): world = origin +
   // position. [0,0,0] for absolute meshes. Without it a cache from a
@@ -109,7 +116,7 @@ export function meshRecordByteLength(mesh: MeshData): number {
     16 +                   // color f32x4
     4 + ifcTypeBytes +     // ifcType string
     1 +                    // geometryClass
-    8 +                    // geometryItemId + materialLayerId u32x2 (v14+)
+    8 +                    // geometryItemId + materialId u32x2 (v14+)
     24 +                   // origin f64x3
     mesh.positions.byteLength + mesh.normals.byteLength + mesh.indices.byteLength
   );
@@ -195,19 +202,20 @@ export function readMeshRecord(reader: BufferReader, version: number, meshIndex:
   // viewer's bumped cache key, so they re-mesh fresh rather than load here.
   const geometryClass = version >= 5 ? reader.readUint8() : 0;
 
-  // Read the two disjoint source ids (version 14+, #3199). 0 means absent.
+  // Read the two disjoint source ids (version 14+, #3199). See
+  // ABSENT_SOURCE_ID for what "absent" is encoded as, and why it is not 0.
   // Older caches predate the fields entirely and leave both undefined, which is
   // the same state the runtime uses where the identity is genuinely merged away
   // -- so a v13 cache degrades to "unknown", never to a WRONG id.
   let geometryItemId: number | undefined;
-  let materialLayerId: number | undefined;
+  let materialId: number | undefined;
   if (version >= 14) {
     const gid = reader.readUint32();
     const mid = reader.readUint32();
     // Compared against the sentinel, never for truthiness: 0 is a real
     // material-layer id (an air gap) and must survive the round trip.
     if (gid !== ABSENT_SOURCE_ID) geometryItemId = gid;
-    if (mid !== ABSENT_SOURCE_ID) materialLayerId = mid;
+    if (mid !== ABSENT_SOURCE_ID) materialId = mid;
   }
 
   // Read per-element local-frame origin (version 6+); world = origin + position.
@@ -234,7 +242,7 @@ export function readMeshRecord(reader: BufferReader, version: number, meshIndex:
     // Spread only the one that is set, so the disjointness the format preserves
     // survives into the object a consumer reads (#3199).
     ...(geometryItemId !== undefined ? { geometryItemId } : {}),
-    ...(materialLayerId !== undefined ? { materialLayerId } : {}),
+    ...(materialId !== undefined ? { materialId } : {}),
     ...(origin ? { origin } : {}),
   };
 }

--- a/packages/cache/src/sections/geometry.ts
+++ b/packages/cache/src/sections/geometry.ts
@@ -76,6 +76,17 @@ export function writeMeshRecord(writer: BufferWriter, mesh: MeshData): void {
   // type-library geometry reappears in Model mode and the switch disappears.
   writer.writeUint8(mesh.geometryClass ?? 0);
 
+  // Write the two DISJOINT source ids (v14+, #3199): the representation item
+  // this piece was tessellated from, or the material layer it slices. Written
+  // unconditionally as two u32 so the record stays fixed-shape.
+  //
+  // The absent sentinel is 0xFFFFFFFF, NOT 0. `layers.rs` uses `0` for a layer
+  // with no material — an air gap — so a 0 here is a real value that must round
+  // trip. Treating it as absent is the valid-but-falsy trap, and it would have
+  // silently dropped exactly the layers that are hardest to notice missing.
+  writer.writeUint32(mesh.geometryItemId ?? ABSENT_SOURCE_ID);
+  writer.writeUint32(mesh.materialLayerId ?? ABSENT_SOURCE_ID);
+
   // Write per-element local-frame origin (v6+, 3×f64): world = origin +
   // position. [0,0,0] for absolute meshes. Without it a cache from a
   // local-frame load restores small local positions with no origin → every
@@ -98,6 +109,7 @@ export function meshRecordByteLength(mesh: MeshData): number {
     16 +                   // color f32x4
     4 + ifcTypeBytes +     // ifcType string
     1 +                    // geometryClass
+    8 +                    // geometryItemId + materialLayerId u32x2 (v14+)
     24 +                   // origin f64x3
     mesh.positions.byteLength + mesh.normals.byteLength + mesh.indices.byteLength
   );
@@ -142,6 +154,11 @@ function writeAABB(writer: BufferWriter, aabb: AABB): void {
   writeVec3(writer, aabb.max);
 }
 
+/** Absent marker for the v14 source ids. Not 0 — `layers.rs` uses 0 for a
+ *  material-free layer, so 0 is a real value (#3199). No STEP express id can
+ *  reach 0xFFFFFFFF. */
+const ABSENT_SOURCE_ID = 0xffffffff;
+
 // Maximum reasonable values for sanity checking
 const MAX_VERTEX_COUNT = 100_000_000; // 100M vertices max per mesh
 const MAX_INDEX_COUNT = 300_000_000; // 300M indices max per mesh
@@ -178,6 +195,21 @@ export function readMeshRecord(reader: BufferReader, version: number, meshIndex:
   // viewer's bumped cache key, so they re-mesh fresh rather than load here.
   const geometryClass = version >= 5 ? reader.readUint8() : 0;
 
+  // Read the two disjoint source ids (version 14+, #3199). 0 means absent.
+  // Older caches predate the fields entirely and leave both undefined, which is
+  // the same state the runtime uses where the identity is genuinely merged away
+  // -- so a v13 cache degrades to "unknown", never to a WRONG id.
+  let geometryItemId: number | undefined;
+  let materialLayerId: number | undefined;
+  if (version >= 14) {
+    const gid = reader.readUint32();
+    const mid = reader.readUint32();
+    // Compared against the sentinel, never for truthiness: 0 is a real
+    // material-layer id (an air gap) and must survive the round trip.
+    if (gid !== ABSENT_SOURCE_ID) geometryItemId = gid;
+    if (mid !== ABSENT_SOURCE_ID) materialLayerId = mid;
+  }
+
   // Read per-element local-frame origin (version 6+); world = origin + position.
   let origin: [number, number, number] | undefined;
   if (version >= 6) {
@@ -199,6 +231,10 @@ export function readMeshRecord(reader: BufferReader, version: number, meshIndex:
     color,
     ifcType,
     geometryClass,
+    // Spread only the one that is set, so the disjointness the format preserves
+    // survives into the object a consumer reads (#3199).
+    ...(geometryItemId !== undefined ? { geometryItemId } : {}),
+    ...(materialLayerId !== undefined ? { materialLayerId } : {}),
     ...(origin ? { origin } : {}),
   };
 }

--- a/packages/cache/src/sections/header.test.ts
+++ b/packages/cache/src/sections/header.test.ts
@@ -69,8 +69,9 @@ describe('writeHeader', () => {
     expect(view.getUint32(0, true)).toBe(0x4c434649);
     expect(Array.from(buf.subarray(0, 4))).toEqual([0x49, 0x46, 0x43, 0x4c]);
 
-    // version: uint16 LE at byte 4.
-    expect(view.getUint16(4, true)).toBe(13);
+    // version: uint16 LE at byte 4. Moved 13 -> 14 with the #3199 mesh-record
+    // change; update this literal only alongside a types.ts ledger entry.
+    expect(view.getUint16(4, true)).toBe(14);
   });
 
   it('writes each section-table entry field at its documented byte offset within the 16-byte entry', () => {

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -84,8 +84,19 @@ export const MAGIC = 0x4C434649; // "IFCL" in little-endian
  *   cache-hit load (first paint after the FIRST chunk instead of a full
  *   deserialize) and is the on-disk foundation for evict-to-disk residency.
  *   Per-mesh record layout inside a chunk is UNCHANGED from v12.
+ *
+ * v14: the per-mesh record gains the two DISJOINT source ids (#3199) —
+ *   `geometryItemId` (an `IfcRepresentationItem`) and `materialLayerId` (an
+ *   `IfcMaterial`), two u32 written unconditionally with 0 meaning absent.
+ *   Bumped rather than read leniently because the record is positional: a v13
+ *   reader handed a v14 record would take the origin's first f64 out of the two
+ *   new u32 and every field after it would be garbage. A v14 reader still reads
+ *   v13 records correctly — the fields are version-gated and degrade to
+ *   `undefined`, which is the same state the runtime uses where the identity is
+ *   genuinely merged away, so an old cache degrades to "unknown" and never to a
+ *   WRONG id.
  */
-export const FORMAT_VERSION = 13;
+export const FORMAT_VERSION = 14;
 
 /** Geometry chunking parameters (v13+). Grouping is a WRITE-side layout
  *  policy: readers only trust the directory, so these can change without a

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -86,8 +86,14 @@ export const MAGIC = 0x4C434649; // "IFCL" in little-endian
  *   Per-mesh record layout inside a chunk is UNCHANGED from v12.
  *
  * v14: the per-mesh record gains the two DISJOINT source ids (#3199) —
- *   `geometryItemId` (an `IfcRepresentationItem`) and `materialLayerId` (an
- *   `IfcMaterial`), two u32 written unconditionally with 0 meaning absent.
+ *   `geometryItemId` (an `IfcRepresentationItem`) and `materialId` (an
+ *   `IfcMaterial`), two u32 written unconditionally with **0xFFFFFFFF** meaning
+ *   absent. NOT 0, deliberately: `#0` is not a STEP instance name, but
+ *   `router/layers.rs` DOES decode an unreferenced layer (an air gap) as
+ *   `material_id = 0`. The producer filters that to absent as of #3199, so 0
+ *   should never reach this record — the sentinel keeps the encoding correct
+ *   without depending on that, since an absence marker the domain can produce
+ *   is one upstream change from being wrong again.
  *   Bumped rather than read leniently because the record is positional: a v13
  *   reader handed a v14 record would take the origin's first f64 out of the two
  *   new u32 and every field after it would be garbage. A v14 reader still reads

--- a/packages/geometry/src/geometry-coordinate.test.ts
+++ b/packages/geometry/src/geometry-coordinate.test.ts
@@ -295,6 +295,51 @@ describe('convertMeshCollectionToBatch', () => {
     expect(batch[1].geometryClass).toBe(1);
   });
 
+  // #3199. These exist because deleting BOTH new spreads from
+  // `convertMeshCollectionToBatch` left this suite at 353/353 green: the
+  // converter is the only path by which the viewer's main thread sees the ids,
+  // and every other test added for #3199 reads the raw `MeshCollection`, which
+  // is upstream of it.
+  it('carries the representation-item id through to the batch', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(
+        fakeCollection([
+          fakeMesh({ expressId: 1, geometryItemId: 4242 } as never),
+          fakeMesh({ expressId: 2 }),
+        ])
+      )
+    );
+
+    expect(batch[0].geometryItemId).toBe(4242);
+    expect(batch[0].materialId).toBeUndefined();
+    // Absent stays ABSENT rather than becoming a key with `undefined`: the
+    // cache writer and the REST mirror both distinguish "no key" from a value,
+    // and a stamped `undefined` reads as present to `'x' in obj`.
+    expect('geometryItemId' in batch[1]).toBe(false);
+    expect('materialId' in batch[1]).toBe(false);
+  });
+
+  it('carries the material id through to the batch, disjoint from the item id', () => {
+    const batch = convertMeshCollectionToBatch(
+      asCollection(fakeCollection([fakeMesh({ expressId: 1, materialId: 3876 } as never)]))
+    );
+
+    expect(batch[0].materialId).toBe(3876);
+    expect('geometryItemId' in batch[0]).toBe(false);
+  });
+
+  it('does not truthiness-gate the ids: a 0 survives the converter', () => {
+    // The producer filters 0 (`#0` is not a STEP instance name), but this
+    // converter must not be the thing enforcing that -- a `? :` on the value
+    // instead of on `!== undefined` would drop a 0 silently, and the two
+    // failures look identical from the viewer.
+    const batch = convertMeshCollectionToBatch(
+      asCollection(fakeCollection([fakeMesh({ expressId: 1, geometryItemId: 0 } as never)]))
+    );
+
+    expect(batch[0].geometryItemId).toBe(0);
+  });
+
   it('carries a four-component shading colour, and drops a mis-sized one', () => {
     const batch = convertMeshCollectionToBatch(
       asCollection(

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -89,6 +89,10 @@ export function convertMeshCollectionToBatch(
           originArr && originArr.length === 3 && (originArr[0] || originArr[1] || originArr[2])
             ? [originArr[0], originArr[1], originArr[2]]
             : undefined;
+        // #3199: the two DISJOINT source ids. Read ONCE each, like `origin`
+        // above -- every access crosses the wasm boundary and copies.
+        const sourceGeometryItemId = (mesh as { geometryItemId?: number }).geometryItemId;
+        const sourceMaterialId = (mesh as { materialId?: number }).materialId;
         // Local (pre-placement) AABB + placement transform (issue #1474);
         // absent on older bundles (no getter) or when not captured (e.g. an
         // instancing template).
@@ -122,12 +126,8 @@ export function convertMeshCollectionToBatch(
           // `undefined` for whichever does not apply, and spreading only the
           // defined one keeps them from both landing on the object. Older wasm
           // bundles lack both getters, so both spread to nothing.
-          ...((mesh as { geometryItemId?: number }).geometryItemId !== undefined
-            ? { geometryItemId: (mesh as { geometryItemId?: number }).geometryItemId }
-            : {}),
-          ...((mesh as { materialLayerId?: number }).materialLayerId !== undefined
-            ? { materialLayerId: (mesh as { materialLayerId?: number }).materialLayerId }
-            : {}),
+          ...(sourceGeometryItemId !== undefined ? { geometryItemId: sourceGeometryItemId } : {}),
+          ...(sourceMaterialId !== undefined ? { materialId: sourceMaterialId } : {}),
         };
 
         // #961: copy the Rust-decoded surface texture + per-vertex UVs (the

--- a/packages/geometry/src/geometry-coordinate.ts
+++ b/packages/geometry/src/geometry-coordinate.ts
@@ -117,6 +117,17 @@ export function convertMeshCollectionToBatch(
           // #957 follow-up: carry the Model/Types geometry class so the viewer's
           // view-mode filter can show/hide type-library geometry.
           geometryClass: (mesh as { geometryClass?: number }).geometryClass ?? 0,
+          // #3199: the representation item this piece came from, or the
+          // material layer it slices. DISJOINT -- the wasm getters return
+          // `undefined` for whichever does not apply, and spreading only the
+          // defined one keeps them from both landing on the object. Older wasm
+          // bundles lack both getters, so both spread to nothing.
+          ...((mesh as { geometryItemId?: number }).geometryItemId !== undefined
+            ? { geometryItemId: (mesh as { geometryItemId?: number }).geometryItemId }
+            : {}),
+          ...((mesh as { materialLayerId?: number }).materialLayerId !== undefined
+            ? { materialLayerId: (mesh as { materialLayerId?: number }).materialLayerId }
+            : {}),
         };
 
         // #961: copy the Rust-decoded surface texture + per-vertex UVs (the

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -1003,9 +1003,9 @@ function collectMeshes(
           ...(origin ? { origin } : {}),
           ...(localBounds ? { localBounds } : {}),
           ...(localToWorld ? { localToWorld } : {}),
-          // Provenance for the Model/Types switch (0=occurrence, 1=orphan type,
-          // 2=instanced type). Older wasm bundles lack the getter → default 0.
+          // Model/Types provenance + the two DISJOINT source ids (#3199); older wasm lacks all three getters.
           geometryClass: mesh.geometryClass ?? 0,
+          ...(mesh.geometryItemId !== undefined ? { geometryItemId: mesh.geometryItemId } : mesh.materialLayerId !== undefined ? { materialLayerId: mesh.materialLayerId } : {}),
         };
         session.pendingTransfers.push(positions.buffer, normals.buffer, indices.buffer);
         session.cumulativeMeshBytes += positions.byteLength + normals.byteLength + indices.byteLength;

--- a/packages/geometry/src/geometry.worker.ts
+++ b/packages/geometry/src/geometry.worker.ts
@@ -1003,9 +1003,9 @@ function collectMeshes(
           ...(origin ? { origin } : {}),
           ...(localBounds ? { localBounds } : {}),
           ...(localToWorld ? { localToWorld } : {}),
-          // Model/Types provenance + the two DISJOINT source ids (#3199); older wasm lacks all three getters.
-          geometryClass: mesh.geometryClass ?? 0,
-          ...(mesh.geometryItemId !== undefined ? { geometryItemId: mesh.geometryItemId } : mesh.materialLayerId !== undefined ? { materialLayerId: mesh.materialLayerId } : {}),
+          geometryClass: mesh.geometryClass ?? 0, // 0=occurrence 1=orphan type 2=instanced type; older wasm lacks all three getters here
+          ...(mesh.geometryItemId !== undefined ? { geometryItemId: mesh.geometryItemId } : {}), // #3199: two DISJOINT ids, TWO
+          ...(mesh.materialId !== undefined ? { materialId: mesh.materialId } : {}), // spreads as in convertMeshCollectionToBatch
         };
         session.pendingTransfers.push(positions.buffer, normals.buffer, indices.buffer);
         session.cumulativeMeshBytes += positions.byteLength + normals.byteLength + indices.byteLength;

--- a/packages/geometry/src/symbolic-types.ts
+++ b/packages/geometry/src/symbolic-types.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The symbolic-representation type family, split out of `types.ts` (#3199).
+ *
+ * Moved rather than trimmed: `types.ts` sat EXACTLY at its module-size budget,
+ * and the TS allowlist is explicit that budgets ratchet DOWN only and are never
+ * raised to make a red gate green. This family is self-contained -- nothing
+ * imports it from `types.ts`, and the names the package root exposes come from
+ * `ifc-lite-bridge.ts` -- so it is the natural seam. `types.ts` re-exports it,
+ * so the public surface is unchanged.
+ */
+
+/**
+ * Representation identifier types for symbolic representations
+ */
+export type SymbolicRepIdentifier = 'Plan' | 'Annotation' | 'FootPrint' | 'Axis';
+
+/**
+ * A 2D polyline from symbolic representations
+ * Used for door swings, window cuts, equipment symbols, etc.
+ */
+export interface SymbolicPolyline {
+  /** Express ID of the parent IFC element */
+  expressId: number;
+  /** IFC type name (e.g., "IfcDoor", "IfcWindow") */
+  ifcType: string;
+  /** 2D points as Float32Array [x1, y1, x2, y2, ...] */
+  points: Float32Array;
+  /** Number of points in the polyline */
+  pointCount: number;
+  /** Whether this is a closed loop */
+  isClosed: boolean;
+  /** Representation identifier ("Plan", "Annotation", etc.) */
+  repIdentifier: string;
+}
+
+/**
+ * A 2D circle or arc from symbolic representations
+ */
+export interface SymbolicCircle {
+  /** Express ID of the parent IFC element */
+  expressId: number;
+  /** IFC type name */
+  ifcType: string;
+  /** Center X coordinate */
+  centerX: number;
+  /** Center Y coordinate */
+  centerY: number;
+  /** Radius */
+  radius: number;
+  /** Start angle in radians (0 for full circle) */
+  startAngle: number;
+  /** End angle in radians (2π for full circle) */
+  endAngle: number;
+  /** Whether this is a full circle */
+  isFullCircle: boolean;
+  /** Representation identifier */
+  repIdentifier: string;
+}
+
+/**
+ * Collection of symbolic representations from an IFC model
+ * These are pre-authored 2D representations for architectural drawings
+ */
+export interface SymbolicRepresentationCollection {
+  /** Number of polylines */
+  polylineCount: number;
+  /** Number of circles/arcs */
+  circleCount: number;
+  /** Total count of all symbolic items */
+  totalCount: number;
+  /** Check if collection is empty */
+  isEmpty: boolean;
+  /** Get polyline at index */
+  getPolyline(index: number): SymbolicPolyline | undefined;
+  /** Get circle at index */
+  getCircle(index: number): SymbolicCircle | undefined;
+  /** Get all express IDs that have symbolic representations */
+  getExpressIds(): Uint32Array;
+}
+
+/**
+ * Converted symbolic data for use in drawing generation
+ * Organized by express ID for easy lookup
+ */
+export interface SymbolicDataByEntity {
+  /** Map from expressId to polylines for that entity */
+  polylines: Map<number, SymbolicPolyline[]>;
+  /** Map from expressId to circles for that entity */
+  circles: Map<number, SymbolicCircle[]>;
+  /** Set of express IDs that have symbolic representations */
+  expressIds: Set<number>;
+}

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -54,6 +54,16 @@ export interface MeshData {
    *  for every vertex, so picking/selection resolves to the correct individual
    *  entity even though many entities share a single GPU batch. */
   entityIds?: Uint32Array;
+  /** The `IfcRepresentationItem` this mesh came from, so a host can drill from
+   *  a rendered piece to its entity (#2985). ALWAYS a representation item;
+   *  `materialLayerId` carries the other case and the two are NEVER both set.
+   *  Absent where identity is merged away (single-mesh fallback, cached
+   *  `IfcMappedItem`, GPU instancing) (#3199). */
+  geometryItemId?: number;
+  /** The `IfcMaterial` layer this mesh slices. DISJOINT from `geometryItemId`,
+   *  which used to carry it — so following that field for a layered wall landed
+   *  on the wrong entity. `geometryClass === 3` cannot substitute (#3199). */
+  materialLayerId?: number;
   /** Per-vertex texture coordinates (u, v pairs, 1:1 with positions), present
    *  only for textured meshes (issue #961). */
   uvs?: Float32Array;
@@ -366,84 +376,6 @@ export interface GeometryResult {
 // For Plan, Annotation, FootPrint representations (2D curves for drawings)
 // ═══════════════════════════════════════════════════════════════════════════
 
-/**
- * Representation identifier types for symbolic representations
- */
-export type SymbolicRepIdentifier = 'Plan' | 'Annotation' | 'FootPrint' | 'Axis';
-
-/**
- * A 2D polyline from symbolic representations
- * Used for door swings, window cuts, equipment symbols, etc.
- */
-export interface SymbolicPolyline {
-  /** Express ID of the parent IFC element */
-  expressId: number;
-  /** IFC type name (e.g., "IfcDoor", "IfcWindow") */
-  ifcType: string;
-  /** 2D points as Float32Array [x1, y1, x2, y2, ...] */
-  points: Float32Array;
-  /** Number of points in the polyline */
-  pointCount: number;
-  /** Whether this is a closed loop */
-  isClosed: boolean;
-  /** Representation identifier ("Plan", "Annotation", etc.) */
-  repIdentifier: string;
-}
-
-/**
- * A 2D circle or arc from symbolic representations
- */
-export interface SymbolicCircle {
-  /** Express ID of the parent IFC element */
-  expressId: number;
-  /** IFC type name */
-  ifcType: string;
-  /** Center X coordinate */
-  centerX: number;
-  /** Center Y coordinate */
-  centerY: number;
-  /** Radius */
-  radius: number;
-  /** Start angle in radians (0 for full circle) */
-  startAngle: number;
-  /** End angle in radians (2π for full circle) */
-  endAngle: number;
-  /** Whether this is a full circle */
-  isFullCircle: boolean;
-  /** Representation identifier */
-  repIdentifier: string;
-}
-
-/**
- * Collection of symbolic representations from an IFC model
- * These are pre-authored 2D representations for architectural drawings
- */
-export interface SymbolicRepresentationCollection {
-  /** Number of polylines */
-  polylineCount: number;
-  /** Number of circles/arcs */
-  circleCount: number;
-  /** Total count of all symbolic items */
-  totalCount: number;
-  /** Check if collection is empty */
-  isEmpty: boolean;
-  /** Get polyline at index */
-  getPolyline(index: number): SymbolicPolyline | undefined;
-  /** Get circle at index */
-  getCircle(index: number): SymbolicCircle | undefined;
-  /** Get all express IDs that have symbolic representations */
-  getExpressIds(): Uint32Array;
-}
-
-/**
- * Converted symbolic data for use in drawing generation
- * Organized by express ID for easy lookup
- */
-export interface SymbolicDataByEntity {
-  /** Map from expressId to polylines for that entity */
-  polylines: Map<number, SymbolicPolyline[]>;
-  /** Map from expressId to circles for that entity */
-  circles: Map<number, SymbolicCircle[]>;
-  /** Set of express IDs that have symbolic representations */
-  expressIds: Set<number>;
-}
+// The symbolic-representation family lives in its own module (#3199); re-exported
+// here so every existing `from './types.js'` import keeps working unchanged.
+export * from './symbolic-types.js';

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -56,14 +56,14 @@ export interface MeshData {
   entityIds?: Uint32Array;
   /** The `IfcRepresentationItem` this mesh came from, so a host can drill from
    *  a rendered piece to its entity (#2985). ALWAYS a representation item;
-   *  `materialLayerId` carries the other case and the two are NEVER both set.
+   *  `materialId` carries the other case and the two are NEVER both set.
    *  Absent where identity is merged away (single-mesh fallback, cached
    *  `IfcMappedItem`, GPU instancing) (#3199). */
   geometryItemId?: number;
   /** The `IfcMaterial` layer this mesh slices. DISJOINT from `geometryItemId`,
    *  which used to carry it — so following that field for a layered wall landed
    *  on the wrong entity. `geometryClass === 3` cannot substitute (#3199). */
-  materialLayerId?: number;
+  materialId?: number;
   /** Per-vertex texture coordinates (u, v pairs, 1:1 with positions), present
    *  only for textured meshes (issue #961). */
   uvs?: Float32Array;

--- a/packages/server-client/src/symbolic-types.ts
+++ b/packages/server-client/src/symbolic-types.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The symbolic (2D drawing) wire shapes of the parse response.
+ *
+ * Split out of `types.ts` under the module-size ratchet (#3199): the family is
+ * self-contained -- nothing here references a mesh, a spatial node or a
+ * property -- and `types.ts` re-exports it, so the package's public surface is
+ * unchanged and every existing `from '@ifc-lite/server-client'` import keeps
+ * resolving. Mirrors the same split made in `@ifc-lite/geometry`.
+ */
+
+/**
+ * A single `IfcGridAxis` tag + axis curve (compact endpoint-pair shape).
+ */
+export interface SymbolicGridAxis {
+  express_id: number;
+  grid_express_id: number;
+  tag: string;
+  /** Endpoint pair `[x0, y0, x1, y1]` in metres (plan view). */
+  endpoints: [number, number, number, number];
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
+}
+
+/**
+ * A 2D polyline (`IfcPolyline`, `IfcIndexedPolyCurve`, tessellated ellipses,
+ * trimmed-curve arcs, grid axis lines).
+ */
+export interface SymbolicPolyline {
+  express_id: number;
+  ifc_type: string;
+  /** Flat `[x0, y0, x1, y1, …]` plan-view coordinates. */
+  points: number[];
+  closed: boolean;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
+  representation: string;
+}
+
+/**
+ * A 2D circle / arc (`IfcCircle`).
+ */
+export interface SymbolicCircle {
+  express_id: number;
+  ifc_type: string;
+  center_x: number;
+  center_y: number;
+  radius: number;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
+  /** Start angle in radians (0 for a full circle). */
+  start_angle: number;
+  /** End angle in radians (`2π` for a full circle). */
+  end_angle: number;
+  representation: string;
+}
+
+/**
+ * A 2D text annotation (`IfcTextLiteral` / grid bubble glyphs + tags).
+ */
+export interface SymbolicText {
+  express_id: number;
+  ifc_type: string;
+  x: number;
+  y: number;
+  /** Baseline orientation as a `(cos, sin)` pair. */
+  dir_x: number;
+  dir_y: number;
+  /** Font cap height in model units (already unit-scaled). */
+  height: number;
+  content: string;
+  /** IFC `BoxAlignment` (`top-left`, `center`, …). Empty when absent. */
+  alignment: string;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
+  /** sRGB straight-alpha colour `[r, g, b, a]`. */
+  color: [number, number, number, number];
+  /** Per-instance target screen-pixel cap height (`0` = renderer default). */
+  target_px: number;
+  representation: string;
+}
+
+/**
+ * A 2D filled region (`IfcAnnotationFillArea`). Outer ring + optional holes
+ * packed into a single `points` buffer; `holes_offsets[i]` is the vertex index
+ * where hole `i` begins.
+ */
+export interface SymbolicFillArea {
+  express_id: number;
+  ifc_type: string;
+  points: number[];
+  holes_offsets: number[];
+  fill_color: [number, number, number, number];
+  has_hatching: boolean;
+  hatch_spacing: number;
+  hatch_angle: number;
+  /**
+   * Secondary cross-hatch angle. `null` when absent — the Rust model uses
+   * `f32::NAN`, which `serde_json` serializes as JSON `null` (not `NaN`).
+   */
+  hatch_angle_secondary: number | null;
+  hatch_line_width: number;
+  /**
+   * World-Y elevation in metres, or `null` when unresolved. See the
+   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
+   */
+  world_y: number | null;
+  representation: string;
+}
+
+/**
+ * 2D symbol data extracted from `IfcAnnotation` and `IfcGrid` entities.
+ *
+ * Returned inline by `POST /api/v1/parse` and the streaming `complete` events,
+ * and fetched by cache key from `GET /api/v1/parse/symbolic/{cache_key}` for the
+ * binary (Parquet) transports. Arrays may be empty when the model carries no
+ * 2D symbols.
+ */
+/**
+ * Present only when extraction stopped at its bound; absent when the file was
+ * emitted in full.
+ */
+/**
+ * Which bound stopped an extraction early.
+ *
+ * Mirrors `SymbolicTruncationReason` in `rust/processing/src/symbolic/output_cap.rs`,
+ * serialized kebab-case. The extraction bounds (`element-count`, `output-bytes`)
+ * are the severe ones and outrank the per-item bounds, which stop one
+ * representation item's contribution while the whole-file totals can sit far
+ * below either extraction bound.
+ */
+export type SymbolicTruncationReason =
+  | 'element-count'
+  | 'output-bytes'
+  | 'item-depth'
+  | 'item-revisits'
+  | 'item-cycle';
+
+export interface SymbolicTruncation {
+  /** Which bound fired. */
+  reason: SymbolicTruncationReason;
+  /** Total primitives emitted. */
+  emitted: number;
+  /**
+   * The bound's numeric value, when the reason has one.
+   *
+   * ABSENT for `item-depth`, `item-revisits` and `item-cycle`: those bounds
+   * count traversal revisits and nesting depth, not emitted primitives, so
+   * there is no number to compare `emitted` against without inventing one.
+   */
+  limit?: number;
+}
+
+export interface SymbolicData {
+  grid_axes: SymbolicGridAxis[];
+  polylines: SymbolicPolyline[];
+  circles: SymbolicCircle[];
+  texts: SymbolicText[];
+  fills: SymbolicFillArea[];
+  /**
+   * Set when the server bounded this extraction and returned a partial result.
+   *
+   * Optional because it is omitted for a complete extraction, so an existing
+   * consumer keeps compiling. But a consumer that renders symbolic geometry
+   * without reading this shows a clipped drawing as though it were the whole
+   * drawing, which is the failure this field exists to end.
+   */
+  truncated?: SymbolicTruncation;
+}

--- a/packages/server-client/src/types.ts
+++ b/packages/server-client/src/types.ts
@@ -48,8 +48,26 @@ export interface MeshData {
   presentation_layer?: string;
   /** Resolved material name for this (sub-)mesh, when known. */
   material_name?: string;
-  /** Source geometry item id for per-item styled sub-meshes. */
+  /**
+   * The `IfcRepresentationItem` this (sub-)mesh was tessellated from — ALWAYS a
+   * representation item, never a material. Before #3199 the server sent an
+   * `IfcMaterial` id here for material-layered walls, so a consumer following it
+   * to source landed on the wrong entity. Absent where the identity is genuinely
+   * merged away (single-mesh fallback, cached `IfcMappedItem`, instanced).
+   *
+   * Never `0`: `#0` is not a STEP instance name. The same filter applies to
+   * `material_id` below.
+   */
   geometry_item_id?: number;
+  /**
+   * The `IfcMaterial` whose layer this (sub-)mesh slices — ALWAYS a material,
+   * never a representation item. DISJOINT from `geometry_item_id`: the server
+   * never sends both. Never `0` either, and here that is load-bearing rather
+   * than trivially true: an unreferenced layer (an air gap) decodes to
+   * `material_id 0` in the mesher, and is sent as ABSENT rather than as
+   * `IfcMaterial #0`, which is not an entity anyone can navigate to (#3199).
+   */
+  material_id?: number;
   /** Space/zone properties attached to the element, when extracted. */
   properties?: Record<string, string>;
   /**
@@ -240,176 +258,13 @@ export interface GeometryDiagnostics {
 // and would silently invent a datum-level elevation. Anything that buckets or
 // sorts by elevation must exclude the `null`s rather than treat them as zero.
 
-/**
- * A single `IfcGridAxis` tag + axis curve (compact endpoint-pair shape).
- */
-export interface SymbolicGridAxis {
-  express_id: number;
-  grid_express_id: number;
-  tag: string;
-  /** Endpoint pair `[x0, y0, x1, y1]` in metres (plan view). */
-  endpoints: [number, number, number, number];
-  /**
-   * World-Y elevation in metres, or `null` when unresolved. See the
-   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
-   */
-  world_y: number | null;
-}
+// The symbolic (2D drawing) wire shapes live in `symbolic-types.ts` and are
+// re-exported here, so this module's public surface is unchanged (#3199).
+// `export *` re-exports without binding locally, so the names this file still
+// REFERENCES are imported too.
+import type { SymbolicData } from './symbolic-types.js';
+export * from './symbolic-types.js';
 
-/**
- * A 2D polyline (`IfcPolyline`, `IfcIndexedPolyCurve`, tessellated ellipses,
- * trimmed-curve arcs, grid axis lines).
- */
-export interface SymbolicPolyline {
-  express_id: number;
-  ifc_type: string;
-  /** Flat `[x0, y0, x1, y1, …]` plan-view coordinates. */
-  points: number[];
-  closed: boolean;
-  /**
-   * World-Y elevation in metres, or `null` when unresolved. See the
-   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
-   */
-  world_y: number | null;
-  representation: string;
-}
-
-/**
- * A 2D circle / arc (`IfcCircle`).
- */
-export interface SymbolicCircle {
-  express_id: number;
-  ifc_type: string;
-  center_x: number;
-  center_y: number;
-  radius: number;
-  /**
-   * World-Y elevation in metres, or `null` when unresolved. See the
-   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
-   */
-  world_y: number | null;
-  /** Start angle in radians (0 for a full circle). */
-  start_angle: number;
-  /** End angle in radians (`2π` for a full circle). */
-  end_angle: number;
-  representation: string;
-}
-
-/**
- * A 2D text annotation (`IfcTextLiteral` / grid bubble glyphs + tags).
- */
-export interface SymbolicText {
-  express_id: number;
-  ifc_type: string;
-  x: number;
-  y: number;
-  /** Baseline orientation as a `(cos, sin)` pair. */
-  dir_x: number;
-  dir_y: number;
-  /** Font cap height in model units (already unit-scaled). */
-  height: number;
-  content: string;
-  /** IFC `BoxAlignment` (`top-left`, `center`, …). Empty when absent. */
-  alignment: string;
-  /**
-   * World-Y elevation in metres, or `null` when unresolved. See the
-   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
-   */
-  world_y: number | null;
-  /** sRGB straight-alpha colour `[r, g, b, a]`. */
-  color: [number, number, number, number];
-  /** Per-instance target screen-pixel cap height (`0` = renderer default). */
-  target_px: number;
-  representation: string;
-}
-
-/**
- * A 2D filled region (`IfcAnnotationFillArea`). Outer ring + optional holes
- * packed into a single `points` buffer; `holes_offsets[i]` is the vertex index
- * where hole `i` begins.
- */
-export interface SymbolicFillArea {
-  express_id: number;
-  ifc_type: string;
-  points: number[];
-  holes_offsets: number[];
-  fill_color: [number, number, number, number];
-  has_hatching: boolean;
-  hatch_spacing: number;
-  hatch_angle: number;
-  /**
-   * Secondary cross-hatch angle. `null` when absent — the Rust model uses
-   * `f32::NAN`, which `serde_json` serializes as JSON `null` (not `NaN`).
-   */
-  hatch_angle_secondary: number | null;
-  hatch_line_width: number;
-  /**
-   * World-Y elevation in metres, or `null` when unresolved. See the
-   * "UNRESOLVED SCALARS" note at the top of this section — `null` is not `0`.
-   */
-  world_y: number | null;
-  representation: string;
-}
-
-/**
- * 2D symbol data extracted from `IfcAnnotation` and `IfcGrid` entities.
- *
- * Returned inline by `POST /api/v1/parse` and the streaming `complete` events,
- * and fetched by cache key from `GET /api/v1/parse/symbolic/{cache_key}` for the
- * binary (Parquet) transports. Arrays may be empty when the model carries no
- * 2D symbols.
- */
-/**
- * Present only when extraction stopped at its bound; absent when the file was
- * emitted in full.
- */
-/**
- * Which bound stopped an extraction early.
- *
- * Mirrors `SymbolicTruncationReason` in `rust/processing/src/symbolic/output_cap.rs`,
- * serialized kebab-case. The extraction bounds (`element-count`, `output-bytes`)
- * are the severe ones and outrank the per-item bounds, which stop one
- * representation item's contribution while the whole-file totals can sit far
- * below either extraction bound.
- */
-export type SymbolicTruncationReason =
-  | 'element-count'
-  | 'output-bytes'
-  | 'item-depth'
-  | 'item-revisits'
-  | 'item-cycle';
-
-export interface SymbolicTruncation {
-  /** Which bound fired. */
-  reason: SymbolicTruncationReason;
-  /** Total primitives emitted. */
-  emitted: number;
-  /**
-   * The bound's numeric value, when the reason has one.
-   *
-   * ABSENT for `item-depth`, `item-revisits` and `item-cycle`: those bounds
-   * count traversal revisits and nesting depth, not emitted primitives, so
-   * there is no number to compare `emitted` against without inventing one.
-   */
-  limit?: number;
-}
-
-export interface SymbolicData {
-  grid_axes: SymbolicGridAxis[];
-  polylines: SymbolicPolyline[];
-  circles: SymbolicCircle[];
-  texts: SymbolicText[];
-  fills: SymbolicFillArea[];
-  /**
-   * Set when the server bounded this extraction and returned a partial result.
-   *
-   * Optional because it is omitted for a complete extraction, so an existing
-   * consumer keeps compiling. But a consumer that renders symbolic geometry
-   * without reading this shows a clipped drawing as though it were the whole
-   * drawing, which is the failure this field exists to end.
-   */
-  truncated?: SymbolicTruncation;
-}
 
 /**
  * Full parse response with all meshes.

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1035,6 +1035,11 @@ export class MeshDataJs {
      */
     readonly geometryClass: number;
     /**
+     * Source `IfcRepresentationItem`, or `undefined` where identity is merged
+     * away. Never set alongside `materialLayerId` (#3199).
+     */
+    readonly geometryItemId: number | undefined;
+    /**
      * True when this mesh carries a surface texture (#961).
      */
     readonly hasTexture: boolean;
@@ -1058,6 +1063,10 @@ export class MeshDataJs {
      * `local_bounds` above).
      */
     readonly localToWorld: Float64Array | undefined;
+    /**
+     * `IfcMaterial` layer sliced, or `undefined` (#3199).
+     */
+    readonly materialLayerId: number | undefined;
     /**
      * Get normals as Float32Array (copy to JS)
      */
@@ -1976,11 +1985,13 @@ export interface InitOutput {
     readonly meshdatajs_color: (a: number, b: number) => void;
     readonly meshdatajs_expressId: (a: number) => number;
     readonly meshdatajs_geometryClass: (a: number) => number;
+    readonly meshdatajs_geometryItemId: (a: number) => number;
     readonly meshdatajs_hasTexture: (a: number) => number;
     readonly meshdatajs_ifcType: (a: number, b: number) => void;
     readonly meshdatajs_indices: (a: number) => number;
     readonly meshdatajs_localBounds: (a: number, b: number) => void;
     readonly meshdatajs_localToWorld: (a: number, b: number) => void;
+    readonly meshdatajs_materialLayerId: (a: number) => number;
     readonly meshdatajs_normals: (a: number) => number;
     readonly meshdatajs_origin: (a: number) => number;
     readonly meshdatajs_positions: (a: number) => number;

--- a/packages/wasm/pkg/ifc-lite.d.ts
+++ b/packages/wasm/pkg/ifc-lite.d.ts
@@ -1036,7 +1036,7 @@ export class MeshDataJs {
     readonly geometryClass: number;
     /**
      * Source `IfcRepresentationItem`, or `undefined` where identity is merged
-     * away. Never set alongside `materialLayerId` (#3199).
+     * away. Never set alongside `materialId` (#3199).
      */
     readonly geometryItemId: number | undefined;
     /**
@@ -1066,7 +1066,7 @@ export class MeshDataJs {
     /**
      * `IfcMaterial` layer sliced, or `undefined` (#3199).
      */
-    readonly materialLayerId: number | undefined;
+    readonly materialId: number | undefined;
     /**
      * Get normals as Float32Array (copy to JS)
      */
@@ -1991,7 +1991,7 @@ export interface InitOutput {
     readonly meshdatajs_indices: (a: number) => number;
     readonly meshdatajs_localBounds: (a: number, b: number) => void;
     readonly meshdatajs_localToWorld: (a: number, b: number) => void;
-    readonly meshdatajs_materialLayerId: (a: number) => number;
+    readonly meshdatajs_materialId: (a: number) => number;
     readonly meshdatajs_normals: (a: number) => number;
     readonly meshdatajs_origin: (a: number) => number;
     readonly meshdatajs_positions: (a: number) => number;

--- a/rust/export/src/usd/tests.rs
+++ b/rust/export/src/usd/tests.rs
@@ -431,7 +431,7 @@ fn mesh_emittable_rejects_bad_index_and_origin() {
         color: [0.5, 0.5, 0.5, 1.0],
         material_name: None,
         geometry_item_id: None,
-        material_layer_id: None,
+        material_id: None,
         properties: None,
         uvs: None,
         texture: None,

--- a/rust/export/src/usd/tests.rs
+++ b/rust/export/src/usd/tests.rs
@@ -431,6 +431,7 @@ fn mesh_emittable_rejects_bad_index_and_origin() {
         color: [0.5, 0.5, 0.5, 1.0],
         material_name: None,
         geometry_item_id: None,
+        material_layer_id: None,
         properties: None,
         uvs: None,
         texture: None,

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -124,23 +124,23 @@ pub struct SubMeshCollection {
     /// static check made BEFORE the geometry runs, while
     /// `try_layered_sub_meshes` can still return `None` and fall through to the
     /// rep-item path — so rep-item ids can carry class 3 (#3199).
-    pub ids_are_material_layers: bool,
+    /// SCOPE: it decides only which FIELD `emit_sub_meshes` emits the id under —
+    /// five style lookups in `element.rs` still read `geometry_id` as a rep item
+    /// on BOTH paths, safe only by express-id uniqueness (#3211).
+    pub ids_are_materials: bool,
 }
 
 impl SubMeshCollection {
     /// Create a new empty collection
     pub fn new() -> Self {
-        Self {
-            sub_meshes: Vec::new(),
-            ids_are_material_layers: false,
-        }
+        Self::default()
     }
 
     /// `geometry_id`s are `IfcMaterial` ids. Only `layers.rs` builds these.
-    pub fn of_material_layers() -> Self {
+    pub fn of_materials() -> Self {
         Self {
-            sub_meshes: Vec::new(),
-            ids_are_material_layers: true,
+            ids_are_materials: true,
+            ..Self::default()
         }
     }
 

--- a/rust/geometry/src/mesh.rs
+++ b/rust/geometry/src/mesh.rs
@@ -115,6 +115,16 @@ impl SubMesh {
 #[derive(Debug, Clone, Default)]
 pub struct SubMeshCollection {
     pub sub_meshes: Vec<SubMesh>,
+    /// What `SubMesh::geometry_id` MEANS here: `false` (default) an
+    /// `IfcRepresentationItem`, `true` an `IfcMaterial` (only `layers.rs` builds
+    /// those). Uniform across the collection, which is why it lives on it.
+    ///
+    /// Deliberately NOT `geometry_class == GEOM_CLASS_LAYER_SLICE`, which cannot
+    /// answer it: that class is stamped from `is_material_layer_sliceable`, a
+    /// static check made BEFORE the geometry runs, while
+    /// `try_layered_sub_meshes` can still return `None` and fall through to the
+    /// rep-item path — so rep-item ids can carry class 3 (#3199).
+    pub ids_are_material_layers: bool,
 }
 
 impl SubMeshCollection {
@@ -122,6 +132,15 @@ impl SubMeshCollection {
     pub fn new() -> Self {
         Self {
             sub_meshes: Vec::new(),
+            ids_are_material_layers: false,
+        }
+    }
+
+    /// `geometry_id`s are `IfcMaterial` ids. Only `layers.rs` builds these.
+    pub fn of_material_layers() -> Self {
+        Self {
+            sub_meshes: Vec::new(),
+            ids_are_material_layers: true,
         }
     }
 

--- a/rust/geometry/src/router/layers.rs
+++ b/rust/geometry/src/router/layers.rs
@@ -562,7 +562,7 @@ fn slice_mesh_into_layers(
 
     let clipper = ClippingProcessor::new();
     // Material-layer ids, not representation items -- see the flag's doc (#3199).
-    let mut out = SubMeshCollection::of_material_layers();
+    let mut out = SubMeshCollection::of_materials();
 
     // Carve each layer's band off a running REMAINDER at the interface planes,
     // and DO NOT cap the cut. Two design choices, one fix:

--- a/rust/geometry/src/router/layers.rs
+++ b/rust/geometry/src/router/layers.rs
@@ -561,7 +561,8 @@ fn slice_mesh_into_layers(
     debug_assert_eq!(planes.len() + 1, visual_layers.len());
 
     let clipper = ClippingProcessor::new();
-    let mut out = SubMeshCollection::new();
+    // Material-layer ids, not representation items -- see the flag's doc (#3199).
+    let mut out = SubMeshCollection::of_material_layers();
 
     // Carve each layer's band off a running REMAINDER at the interface planes,
     // and DO NOT cap the cut. Two design choices, one fix:

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -2038,7 +2038,7 @@ impl GeometryRouter {
         // items, which is the exact confusion #3199 removes.
         let mut voided = SubMeshCollection {
             sub_meshes: Vec::new(),
-            ids_are_material_layers: sub_meshes.ids_are_material_layers,
+            ids_are_materials: sub_meshes.ids_are_materials,
         };
         for sub in sub_meshes.sub_meshes {
             let geometry_id = sub.geometry_id;

--- a/rust/geometry/src/router/voids/mod.rs
+++ b/rust/geometry/src/router/voids/mod.rs
@@ -2031,7 +2031,15 @@ impl GeometryRouter {
         // path targets (multi-layer walls with windows).
         let ctx = self.build_void_context(element, &opening_ids, decoder);
 
-        let mut voided = SubMeshCollection::new();
+        // INHERIT the discriminator rather than assuming rep-item ids. This path
+        // is reached only when `try_layered_sub_meshes` declined above, so the
+        // flag is false today -- but hard-coding that would make a future
+        // layered producer silently relabel material ids as representation
+        // items, which is the exact confusion #3199 removes.
+        let mut voided = SubMeshCollection {
+            sub_meshes: Vec::new(),
+            ids_are_material_layers: sub_meshes.ids_are_material_layers,
+        };
         for sub in sub_meshes.sub_meshes {
             let geometry_id = sub.geometry_id;
             let mut voided_mesh = self.apply_void_context(sub.mesh, &ctx, element.id);

--- a/rust/geometry/tests/material_layers_test.rs
+++ b/rust/geometry/tests/material_layers_test.rs
@@ -235,7 +235,7 @@ fn process_element_with_material_layers_splits_wall_by_material() {
     // it is the only thing that tells a caller whether `geometry_id` is a
     // material or a representation item.
     assert!(
-        layered.ids_are_material_layers,
+        layered.ids_are_materials,
         "the slicer's collection must declare its ids are material layers"
     );
     // Two outer finishes share material #200, core is #201.
@@ -404,9 +404,19 @@ fn layers_compose_with_voids_every_layer_loses_triangles() {
 
 /// #3199: the flag has to survive the entry the mesh producer actually calls
 /// for a voided element (`process_element_with_submeshes_and_voids`), not just
-/// the slicer it wraps. That entry is also the one place a collection gets
-/// rebuilt sub-mesh by sub-mesh, so it is where the flag can be silently
-/// dropped and every layer slab start claiming to be a representation item.
+/// the slicer it wraps.
+///
+/// WHAT THIS DOES NOT COVER, stated because an earlier version of this comment
+/// claimed it did: the sub-mesh-by-sub-mesh REBUILD further down that function.
+/// A layered wall returns at the `try_layered_sub_meshes` early exit and never
+/// reaches it, so the `ids_are_materials` inheritance on the rebuilt collection
+/// is unreachable for a material-layer collection today and no fixture can make
+/// this test distinguish it — replacing that expression with a hard-coded
+/// `false` leaves both `ifc-lite-geometry` and `ifc-lite-processing` green.
+/// It is written as an inheritance anyway, deliberately: hard-coding would let
+/// a future layered producer on that path silently relabel material ids as
+/// representation items. Defensive, and honestly untested rather than
+/// dishonestly claimed.
 #[test]
 fn voided_submesh_entry_reports_layer_ids_as_material_ids() {
     let content = three_layer_wall_with_opening_ifc();
@@ -424,7 +434,7 @@ fn voided_submesh_entry_reports_layer_ids_as_material_ids() {
         .expect("submesh voids path");
 
     assert!(
-        cut.ids_are_material_layers,
+        cut.ids_are_materials,
         "a sliced layered wall must still declare material-layer ids after void subtraction"
     );
     let ids: Vec<u32> = cut.sub_meshes.iter().map(|s| s.geometry_id).collect();

--- a/rust/geometry/tests/material_layers_test.rs
+++ b/rust/geometry/tests/material_layers_test.rs
@@ -231,6 +231,13 @@ fn process_element_with_material_layers_splits_wall_by_material() {
         3,
         "expected one sub-mesh per layer"
     );
+    // #3199: the ids below are IfcMaterials, and the collection has to SAY so —
+    // it is the only thing that tells a caller whether `geometry_id` is a
+    // material or a representation item.
+    assert!(
+        layered.ids_are_material_layers,
+        "the slicer's collection must declare its ids are material layers"
+    );
     // Two outer finishes share material #200, core is #201.
     let ids: Vec<u32> = layered.sub_meshes.iter().map(|s| s.geometry_id).collect();
     assert_eq!(ids, vec![200, 201, 200]);
@@ -393,6 +400,35 @@ fn layers_compose_with_voids_every_layer_loses_triangles() {
         uncut_total,
         cut_total
     );
+}
+
+/// #3199: the flag has to survive the entry the mesh producer actually calls
+/// for a voided element (`process_element_with_submeshes_and_voids`), not just
+/// the slicer it wraps. That entry is also the one place a collection gets
+/// rebuilt sub-mesh by sub-mesh, so it is where the flag can be silently
+/// dropped and every layer slab start claiming to be a representation item.
+#[test]
+fn voided_submesh_entry_reports_layer_ids_as_material_ids() {
+    let content = three_layer_wall_with_opening_ifc();
+    let mut decoder = EntityDecoder::new(&content);
+    let mut router = GeometryRouter::with_units(&content, &mut decoder);
+    let index = MaterialLayerIndex::from_content(&content, &mut decoder);
+    router.set_material_layer_index(std::sync::Arc::new(index));
+
+    let wall = decoder.decode_by_id(100).expect("decode wall");
+    let mut void_index: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    void_index.insert(100, vec![150]);
+
+    let cut = router
+        .process_element_with_submeshes_and_voids(&wall, &mut decoder, &void_index)
+        .expect("submesh voids path");
+
+    assert!(
+        cut.ids_are_material_layers,
+        "a sliced layered wall must still declare material-layer ids after void subtraction"
+    );
+    let ids: Vec<u32> = cut.sub_meshes.iter().map(|s| s.geometry_id).collect();
+    assert_eq!(ids, vec![200, 201, 200], "slabs must name their IfcMaterials");
 }
 
 #[test]

--- a/rust/geometry/tests/voids_submesh_test.rs
+++ b/rust/geometry/tests/voids_submesh_test.rs
@@ -52,6 +52,20 @@ fn check_submesh_ids_preserved_and_triangles_removed(
         "[{name}] sub-mesh geometry_ids must match extrusion IDs"
     );
 
+    // #3199: those ids are representation items, so the flag that says what
+    // `geometry_id` MEANS must stay false — through the voids rebuild as well
+    // as before it, which is the one place a collection is reconstructed
+    // element-by-element and could lose the flag. This wall is "multi-layer" by
+    // modelling (three stacked extrusions), NOT by `IfcMaterialLayerSetUsage`;
+    // the layer slicer never runs on it. Flip this to true and every one of its
+    // meshes would report an IfcMaterial id it does not have.
+    for (label, collection) in [("uncut", uncut), ("cut", cut)] {
+        assert!(
+            !collection.ids_are_material_layers,
+            "[{name}] {label} sub-meshes are IfcExtrudedAreaSolids, not material layers"
+        );
+    }
+
     for sub in &cut.sub_meshes {
         assert!(
             !sub.mesh.is_empty(),

--- a/rust/geometry/tests/voids_submesh_test.rs
+++ b/rust/geometry/tests/voids_submesh_test.rs
@@ -61,7 +61,7 @@ fn check_submesh_ids_preserved_and_triangles_removed(
     // meshes would report an IfcMaterial id it does not have.
     for (label, collection) in [("uncut", uncut), ("cut", cut)] {
         assert!(
-            !collection.ids_are_material_layers,
+            !collection.ids_are_materials,
             "[{name}] {label} sub-meshes are IfcExtrudedAreaSolids, not material layers"
         );
     }

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -498,7 +498,7 @@ fn emit_sub_meshes(
 ) -> (Vec<MeshData>, Vec<RawInstanceOccurrence>) {
     // Read ONCE, before the loop consumes the collection: what the ids MEAN is
     // a property of the collection, not of any individual sub-mesh (#3199).
-    let ids_are_material_layers = sub_meshes.ids_are_material_layers;
+    let ids_are_materials = sub_meshes.ids_are_materials;
     let mut out: Vec<MeshData> = Vec::with_capacity(sub_meshes.len());
     let mut occurrences: Vec<RawInstanceOccurrence> = Vec::new();
     // Material colours for this element, used when a sub-mesh has no direct
@@ -584,7 +584,7 @@ fn emit_sub_meshes(
                     color,
                     material_name,
                     Some(sub.geometry_id),
-                    ids_are_material_layers,
+                    ids_are_materials,
                     slice_class,
                     ctx,
                     Some(uvs),
@@ -611,7 +611,7 @@ fn emit_sub_meshes(
                         rgba.to_array(),
                         None,
                         Some(sub.geometry_id),
-                        ids_are_material_layers,
+                        ids_are_materials,
                         slice_class,
                         ctx,
                         None,
@@ -627,7 +627,7 @@ fn emit_sub_meshes(
             color,
             material_name,
             Some(sub.geometry_id),
-            ids_are_material_layers,
+            ids_are_materials,
             slice_class,
             ctx,
             None,
@@ -711,9 +711,9 @@ fn build_mesh_data(
     color: [f32; 4],
     material_name: Option<String>,
     // The sub-mesh's source id, plus WHAT IT IS. Routed to `geometry_item_id`
-    // or `material_layer_id` by `with_style_metadata`, never both (#3199).
+    // or `material_id` by `with_style_metadata`, never both (#3199).
     source_id: Option<u32>,
-    id_is_material_layer: bool,
+    id_is_material: bool,
     geometry_class: u8,
     ctx: &MeshProductionContext<'_>,
     // Per-vertex texture coordinates (2 per vertex, 1:1 with `mesh.positions`),
@@ -788,7 +788,7 @@ fn build_mesh_data(
     }
     if material_name.is_some() || source_id.is_some() {
         mesh_data =
-            mesh_data.with_style_metadata(material_name, source_id, id_is_material_layer);
+            mesh_data.with_style_metadata(material_name, source_id, id_is_material);
     }
     if geometry_class != 0 {
         mesh_data = mesh_data.with_geometry_class(geometry_class);

--- a/rust/processing/src/element.rs
+++ b/rust/processing/src/element.rs
@@ -455,6 +455,7 @@ fn produce_inner(
                         color.to_array(),
                         None,
                         Some(geometry_id),
+                        false,
                         0,
                         ctx,
                         None,
@@ -474,7 +475,7 @@ fn produce_inner(
         h.add_oriented_mesh(&mesh.positions, &mesh.indices, mesh.origin, verdict);
     }
     (
-        vec![build_mesh_data(job, mesh, element_color, None, None, 0, ctx, None)],
+        vec![build_mesh_data(job, mesh, element_color, None, None, false, 0, ctx, None)],
         Vec::new(),
     )
 }
@@ -495,6 +496,9 @@ fn emit_sub_meshes(
     // wall renders as one solid) but the 2D/section cut consumes.
     slice_class: u8,
 ) -> (Vec<MeshData>, Vec<RawInstanceOccurrence>) {
+    // Read ONCE, before the loop consumes the collection: what the ids MEAN is
+    // a property of the collection, not of any individual sub-mesh (#3199).
+    let ids_are_material_layers = sub_meshes.ids_are_material_layers;
     let mut out: Vec<MeshData> = Vec::with_capacity(sub_meshes.len());
     let mut occurrences: Vec<RawInstanceOccurrence> = Vec::new();
     // Material colours for this element, used when a sub-mesh has no direct
@@ -580,6 +584,7 @@ fn emit_sub_meshes(
                     color,
                     material_name,
                     Some(sub.geometry_id),
+                    ids_are_material_layers,
                     slice_class,
                     ctx,
                     Some(uvs),
@@ -606,6 +611,7 @@ fn emit_sub_meshes(
                         rgba.to_array(),
                         None,
                         Some(sub.geometry_id),
+                        ids_are_material_layers,
                         slice_class,
                         ctx,
                         None,
@@ -621,6 +627,7 @@ fn emit_sub_meshes(
             color,
             material_name,
             Some(sub.geometry_id),
+            ids_are_material_layers,
             slice_class,
             ctx,
             None,
@@ -680,7 +687,7 @@ fn produce_type_geometry(
             // `None` and get the full position+normal weld.
             let part_uvs = if texture.is_some() { Some(uvs) } else { None };
             let mut mesh_data =
-                build_mesh_data(job, mesh, color, None, None, geometry_class, ctx, part_uvs);
+                build_mesh_data(job, mesh, color, None, None, false, geometry_class, ctx, part_uvs);
             if let Some(tex) = texture {
                 // UVs were already welded onto `mesh_data`; attach only the
                 // texture (decoded image or #1781 external reference) here.
@@ -703,7 +710,10 @@ fn build_mesh_data(
     mut mesh: Mesh,
     color: [f32; 4],
     material_name: Option<String>,
-    geometry_item_id: Option<u32>,
+    // The sub-mesh's source id, plus WHAT IT IS. Routed to `geometry_item_id`
+    // or `material_layer_id` by `with_style_metadata`, never both (#3199).
+    source_id: Option<u32>,
+    id_is_material_layer: bool,
     geometry_class: u8,
     ctx: &MeshProductionContext<'_>,
     // Per-vertex texture coordinates (2 per vertex, 1:1 with `mesh.positions`),
@@ -776,8 +786,9 @@ fn build_mesh_data(
             )
             .with_properties(meta.space_zone_properties.clone());
     }
-    if material_name.is_some() || geometry_item_id.is_some() {
-        mesh_data = mesh_data.with_style_metadata(material_name, geometry_item_id);
+    if material_name.is_some() || source_id.is_some() {
+        mesh_data =
+            mesh_data.with_style_metadata(material_name, source_id, id_is_material_layer);
     }
     if geometry_class != 0 {
         mesh_data = mesh_data.with_geometry_class(geometry_class);

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -92,9 +92,28 @@ pub struct MeshData {
     /// Optional material/style name resolved from per-item IFC styling.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub material_name: Option<String>,
-    /// Optional source geometry item id for submesh outputs.
+    /// The `IfcRepresentationItem` this mesh was tessellated from.
+    ///
+    /// ALWAYS a representation item, and never a material — a host can follow
+    /// it to source and land on the entity that produced the geometry. Before
+    /// #3199 this field also carried the `IfcMaterial` id for material-layered
+    /// walls and slabs, so following it landed on the wrong entity with nothing
+    /// to warn the caller.
+    ///
+    /// `None` where the identity is genuinely merged away: the single-mesh
+    /// fallback, the cached `IfcMappedItem` path, and GPU-instanced
+    /// occurrences. A boolean result reports the `IfcBooleanResult` id, which
+    /// is a real entity.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub geometry_item_id: Option<u32>,
+    /// The `IfcMaterial` whose layer this mesh is a slice of.
+    ///
+    /// ALWAYS a material, and never a representation item. Set only on the
+    /// material-layer path (`router/layers.rs`), and DISJOINT from
+    /// [`Self::geometry_item_id`] — never both, so a consumer that ignores the
+    /// distinction still cannot read one as the other (#3199).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub material_layer_id: Option<u32>,
     /// Optional IFC property set values keyed by IFC property names.
     /// Primarily attached for IfcSpace/IfcZone so downstream tools can build room attribute UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -172,6 +191,7 @@ impl MeshData {
             color,
             material_name: None,
             geometry_item_id: None,
+            material_layer_id: None,
             properties: None,
             uvs: None,
             texture: None,
@@ -226,14 +246,27 @@ impl MeshData {
         self
     }
 
-    /// Set material name and source geometry item id metadata.
+    /// Set material name and the source id, routed to whichever of the two
+    /// disjoint fields the id actually IS.
+    ///
+    /// Takes the discriminator rather than the destination field so a caller
+    /// cannot put a material id in `geometry_item_id` by picking the wrong
+    /// setter — the confusion #3199 removes is exactly that, and a two-setter
+    /// API would leave it one typo away.
     pub fn with_style_metadata(
         mut self,
         material_name: Option<String>,
-        geometry_item_id: Option<u32>,
+        source_id: Option<u32>,
+        id_is_material_layer: bool,
     ) -> Self {
         self.material_name = material_name;
-        self.geometry_item_id = geometry_item_id;
+        if id_is_material_layer {
+            self.material_layer_id = source_id;
+            self.geometry_item_id = None;
+        } else {
+            self.geometry_item_id = source_id;
+            self.material_layer_id = None;
+        }
         self
     }
 

--- a/rust/processing/src/types/mesh.rs
+++ b/rust/processing/src/types/mesh.rs
@@ -113,7 +113,7 @@ pub struct MeshData {
     /// [`Self::geometry_item_id`] — never both, so a consumer that ignores the
     /// distinction still cannot read one as the other (#3199).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub material_layer_id: Option<u32>,
+    pub material_id: Option<u32>,
     /// Optional IFC property set values keyed by IFC property names.
     /// Primarily attached for IfcSpace/IfcZone so downstream tools can build room attribute UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -191,7 +191,7 @@ impl MeshData {
             color,
             material_name: None,
             geometry_item_id: None,
-            material_layer_id: None,
+            material_id: None,
             properties: None,
             uvs: None,
             texture: None,
@@ -253,19 +253,32 @@ impl MeshData {
     /// cannot put a material id in `geometry_item_id` by picking the wrong
     /// setter — the confusion #3199 removes is exactly that, and a two-setter
     /// API would leave it one typo away.
+    ///
+    /// **A source id of `0` becomes `None`, on BOTH fields.** STEP instance
+    /// names start at `#1`, so `0` is never an entity; every producer that
+    /// hands one here is passing its own "no reference" sentinel through.
+    /// `material_layer_index.rs` is the live case: `IfcMaterialLayer.Material`
+    /// is OPTIONAL and the layer's `material_id` is `get_ref(0).unwrap_or(0)`,
+    /// so an air gap or ventilated cavity arrives as `0`. Storing that would
+    /// make `material_id` say "a slice of `IfcMaterial #0`", and a host that
+    /// followed it — the one thing this field exists for — would land on
+    /// nothing. That is the defect #3199 fixes, one field over, so the filter
+    /// lives HERE rather than at each producer, where the next producer would
+    /// have to remember it.
     pub fn with_style_metadata(
         mut self,
         material_name: Option<String>,
         source_id: Option<u32>,
-        id_is_material_layer: bool,
+        id_is_material: bool,
     ) -> Self {
         self.material_name = material_name;
-        if id_is_material_layer {
-            self.material_layer_id = source_id;
+        let source_id = source_id.filter(|&id| id != 0);
+        if id_is_material {
+            self.material_id = source_id;
             self.geometry_item_id = None;
         } else {
             self.geometry_item_id = source_id;
-            self.material_layer_id = None;
+            self.material_id = None;
         }
         self
     }

--- a/rust/processing/tests/mesh_id_provenance.rs
+++ b/rust/processing/tests/mesh_id_provenance.rs
@@ -5,7 +5,7 @@
 //! #3199 — which entity a [`MeshData`] names, and how a host can trust it.
 //!
 //! A mesh carries EITHER `geometry_item_id` (the `IfcRepresentationItem` it was
-//! tessellated from) OR `material_layer_id` (the `IfcMaterial` whose layer it is
+//! tessellated from) OR `material_id` (the `IfcMaterial` whose layer it is
 //! a slice of), never both. Before #3199 the material id rode in
 //! `geometry_item_id`, so following the field on a layered wall landed on an
 //! `IfcMaterial` with nothing to warn the caller.
@@ -21,16 +21,13 @@
 use ifc_lite_core::{EntityDecoder, IfcType};
 use ifc_lite_geometry::{GeometryRouter, MaterialLayerIndex};
 use ifc_lite_processing::element::{
+    GEOM_CLASS_LAYER_SLICE,
     produce_element_meshes, ElementJobKind, ElementMeshJob, MeshProductionContext,
     MeshProductionOptions,
 };
 use ifc_lite_processing::{process_geometry, MeshData};
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
-
-/// `GEOM_CLASS_LAYER_SLICE` — the value the mesh producer stamps on any element
-/// whose buildup the layer index calls sliceable.
-const LAYER_SLICE: u8 = 3;
 
 /// A three-layer wall (50 mm finish / 200 mm core / 50 mm finish, materials
 /// #200/#201/#200) whose body representation holds `items`.
@@ -91,6 +88,26 @@ END-ISO-10303-21;
     )
 }
 
+/// The same wall with its MIDDLE layer turned into an AIR GAP: `#211`'s
+/// `Material` reference is `$`, which the schema permits —
+/// `IfcMaterialLayer.Material` is OPTIONAL and a ventilated cavity is the
+/// canonical reason to leave it out.
+///
+/// `material_layer_index.rs` reads it as `layer.get_ref(0).unwrap_or(0)`, so
+/// that layer reaches the slicer with `material_id == 0`. `0` is that
+/// function's "no reference" sentinel, NOT an entity: STEP instance names start
+/// at `#1`. Emitting it would make the slab claim to be a slice of
+/// `IfcMaterial #0` and send a host following the id to nothing at all.
+fn three_layer_wall_with_air_gap(items: &str) -> String {
+    let s = three_layer_wall(items);
+    let with_gap = s.replace(
+        "#211=IFCMATERIALLAYER(#201,0.2,$,'Core',$,$,$);",
+        "#211=IFCMATERIALLAYER($,0.2,$,'AirGap',$,$,$);",
+    );
+    assert_ne!(with_gap, s, "the air-gap substitution did not apply");
+    with_gap
+}
+
 /// Mesh wall #100 through `produce_element_meshes` with the router's
 /// `MaterialLayerIndex` wired — the arming the native pipeline
 /// (`processor/mod.rs`) and the wasm batch path both do. Returns the meshes and
@@ -139,37 +156,37 @@ fn produce_wall(content: &str) -> (Vec<MeshData>, bool) {
 fn assert_ids_disjoint(meshes: &[MeshData], what: &str) {
     for m in meshes {
         assert!(
-            !(m.geometry_item_id.is_some() && m.material_layer_id.is_some()),
-            "[{what}] mesh of #{} carries BOTH geometry_item_id {:?} and material_layer_id {:?}",
+            !(m.geometry_item_id.is_some() && m.material_id.is_some()),
+            "[{what}] mesh of #{} carries BOTH geometry_item_id {:?} and material_id {:?}",
             m.express_id,
             m.geometry_item_id,
-            m.material_layer_id
+            m.material_id
         );
     }
 }
 
-fn geometry_fixture(name: &str) -> Option<String> {
-    let path = format!(
-        "{}/../geometry/tests/fixtures/{name}",
-        env!("CARGO_MANIFEST_DIR")
-    );
-    match std::fs::read_to_string(&path) {
-        Ok(s) => Some(s),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!(
-                "skipping #3199 mapped-item id test: fixture missing at {path} — \
-                 it is tracked in git, so restore it with `git checkout -- {path}` \
-                 (`pnpm fixtures` fetches the downloaded corpus, not this file)"
-            );
-            None
-        }
-        Err(e) => panic!("failed to read fixture {path}: {e}"),
-    }
+fn geometry_fixture(name: &str) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../geometry/tests/fixtures")
+        .join(name);
+    // PANIC rather than skip. These fixtures are TRACKED IN GIT -- `pnpm
+    // fixtures` does not fetch them and nothing else can remove them -- so a
+    // missing one is a broken checkout, not an unavailable corpus. Returning
+    // `Option` and letting the caller `return` turned that into a test that
+    // passed by asserting nothing, in the one file whose whole job is pinning
+    // provenance. Absence must not read as success (#3199).
+    std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "fixture {} is tracked in git; restore it with `git checkout -- {}`: {e}",
+            path.display(),
+            path.display()
+        )
+    })
 }
 
 /// Every slab of a sliced layered wall names its `IfcMaterial` and nothing else.
 ///
-/// Regresses to the pre-#3199 lie if `material_layer_id` stops being routed:
+/// Regresses to the pre-#3199 lie if `material_id` stops being routed:
 /// the material ids would reappear in `geometry_item_id`, where a host following
 /// the field to source lands on `IfcMaterial` #200 instead of a geometry item.
 #[test]
@@ -181,7 +198,7 @@ fn layered_wall_slices_name_their_material_not_a_representation_item() {
 
     assert_eq!(meshes.len(), 3, "expected one mesh per layer");
     for m in &meshes {
-        assert_eq!(m.geometry_class, LAYER_SLICE);
+        assert_eq!(m.geometry_class, GEOM_CLASS_LAYER_SLICE);
         assert_eq!(
             m.geometry_item_id, None,
             "a layer slab is not a representation item, got {:?}",
@@ -192,7 +209,7 @@ fn layered_wall_slices_name_their_material_not_a_representation_item() {
     // #200 Finish, #201 Core, #200 Finish — in stack order, the two outer
     // finishes sharing one material. Named, not `is_some()`: a slab pointing at
     // the wrong material is the failure a presence check would pass.
-    let materials: Vec<Option<u32>> = meshes.iter().map(|m| m.material_layer_id).collect();
+    let materials: Vec<Option<u32>> = meshes.iter().map(|m| m.material_id).collect();
     assert_eq!(
         materials,
         vec![Some(200), Some(201), Some(200)],
@@ -228,11 +245,11 @@ fn sliceable_wall_that_did_not_slice_keeps_representation_item_ids() {
     );
     for m in &meshes {
         assert_eq!(
-            m.geometry_class, LAYER_SLICE,
+            m.geometry_class, GEOM_CLASS_LAYER_SLICE,
             "the class is stamped before the geometry runs, so it must still be 3 here"
         );
         assert_eq!(
-            m.material_layer_id, None,
+            m.material_id, None,
             "no layer was cut, so nothing may claim to be a material slice"
         );
     }
@@ -255,9 +272,7 @@ fn sliceable_wall_that_did_not_slice_keeps_representation_item_ids() {
 /// to per-occurrence ids should be deliberate, and this fails when it is not.
 #[test]
 fn mapped_item_meshes_name_the_solid_inside_the_map() {
-    let Some(content) = geometry_fixture("mapped_instances_multi_item.ifc") else {
-        return;
-    };
+    let content = geometry_fixture("mapped_instances_multi_item.ifc");
     let result = process_geometry(&content);
     assert_ids_disjoint(&result.meshes, "mapped_instances_multi_item");
 
@@ -287,7 +302,7 @@ fn mapped_item_meshes_name_the_solid_inside_the_map() {
             m.express_id,
             m.geometry_item_id
         );
-        assert_eq!(m.material_layer_id, None, "no material layers in this file");
+        assert_eq!(m.material_id, None, "no material layers in this file");
     }
 }
 
@@ -297,9 +312,7 @@ fn mapped_item_meshes_name_the_solid_inside_the_map() {
 /// or either `IfcRepresentationMap` (#14, #21).
 #[test]
 fn nested_mapped_item_meshes_name_the_innermost_solids() {
-    let Some(content) = geometry_fixture("nested_mapped_item.ifc") else {
-        return;
-    };
+    let content = geometry_fixture("nested_mapped_item.ifc");
     let result = process_geometry(&content);
     assert_ids_disjoint(&result.meshes, "nested_mapped_item");
 
@@ -323,6 +336,126 @@ fn nested_mapped_item_meshes_name_the_innermost_solids() {
             m.express_id,
             m.geometry_item_id
         );
-        assert_eq!(m.material_layer_id, None, "no material layers in this file");
+        assert_eq!(m.material_id, None, "no material layers in this file");
     }
+}
+
+/// #3199 — the REST wire names, pinned.
+///
+/// `apps/server/src/types/mesh.rs` re-exports this very struct, so whatever
+/// serde spells here is what a REST consumer reads, and
+/// `packages/server-client/src/types.ts` declares those names by hand. Nothing
+/// mechanical holds the two together — the TS mirror is a hand-written copy —
+/// so this test pins the half that a Rust-side rename would silently move.
+///
+/// It also pins the ABSENT encoding, which is the part a `field?: number`
+/// mirror gets wrong most easily: both fields carry
+/// `skip_serializing_if = "Option::is_none"`, so `None` is a MISSING KEY and
+/// never `null`. A TS optional means absent, not nullable, so the two agree
+/// only while that attribute stays on. Drop it and the mirror becomes wrong
+/// without a single line of TS changing.
+#[test]
+fn the_two_id_fields_serialize_under_the_names_the_rest_mirror_declares() {
+    let mut mesh = MeshData::new(
+        1,
+        "IfcWall".to_string(),
+        vec![0.0; 9],
+        vec![0.0; 9],
+        vec![0, 1, 2],
+        [1.0, 1.0, 1.0, 1.0],
+    );
+
+    // Rep-item side: the name is present, the material name is not.
+    mesh = mesh.with_style_metadata(None, Some(42), false);
+    let v = serde_json::to_value(&mesh).expect("MeshData serializes");
+    assert_eq!(
+        v.get("geometry_item_id").and_then(|x| x.as_u64()),
+        Some(42),
+        "the REST mirror declares `geometry_item_id`"
+    );
+    assert!(
+        v.get("material_id").is_none(),
+        "an absent material layer must be a MISSING KEY, not null — \
+         `material_id?: number` in the TS mirror means absent, and a \
+         `null` would type-error there: got {:?}",
+        v.get("material_id")
+    );
+
+    // Material side: the same two names, the other way round.
+    let mesh = mesh.with_style_metadata(None, Some(7), true);
+    let v = serde_json::to_value(&mesh).expect("MeshData serializes");
+    assert_eq!(
+        v.get("material_id").and_then(|x| x.as_u64()),
+        Some(7),
+        "the REST mirror declares `material_id`"
+    );
+    assert!(
+        v.get("geometry_item_id").is_none(),
+        "the setter must CLEAR the other field, or the wire carries both and \
+         the disjointness the mirror documents is false over REST: got {:?}",
+        v.get("geometry_item_id")
+    );
+}
+
+
+/// #3199 follow-up — an AIR GAP layer must not be reported as `IfcMaterial #0`.
+///
+/// The middle layer omits its `Material`, so the slicer receives `material_id
+/// == 0` for it. Before the `source_id.filter(|&id| id != 0)` in
+/// `with_style_metadata`, that slab came back carrying `material_id: Some(0)`.
+/// The disjointness was airtight and the navigability was not: `#0` is not an
+/// entity, and following it is the one thing this field exists for.
+///
+/// This is the pre-#3199 defect one field over — an id that a host cannot
+/// follow, with nothing in the payload to say so — so it is pinned here rather
+/// than left to the reviewer who noticed it.
+#[test]
+fn an_air_gap_layer_reports_no_material_rather_than_material_zero() {
+    let (meshes, sliceable) = produce_wall(&three_layer_wall_with_air_gap("#40"));
+    assert!(
+        sliceable,
+        "the fixture must still slice, or this test proves nothing about the slice path"
+    );
+    assert_ids_disjoint(&meshes, "air_gap_wall");
+
+    // Non-vacuity FIRST: the real materials must still come through, otherwise
+    // "no mesh carries 0" is satisfied by no mesh carrying anything.
+    let materials: Vec<u32> = meshes.iter().filter_map(|m| m.material_id).collect();
+    assert!(
+        materials.contains(&200),
+        "the two Finish layers still name IfcMaterial #200: got {materials:?}"
+    );
+    assert!(
+        !materials.contains(&201),
+        "#201 is no longer referenced by any layer in this fixture: got {materials:?}"
+    );
+
+    // The air-gap slab itself: present as geometry, absent as a material.
+    assert!(
+        !materials.contains(&0),
+        "an air gap reported `IfcMaterial #0`, which is not an entity: got {materials:?}"
+    );
+    for m in &meshes {
+        assert_ne!(
+            m.material_id,
+            Some(0),
+            "mesh of #{} carries material_id 0",
+            m.express_id
+        );
+        assert_ne!(
+            m.geometry_item_id,
+            Some(0),
+            "mesh of #{} carries geometry_item_id 0 — 0 is not a STEP instance name",
+            m.express_id
+        );
+    }
+
+    // And the gap did produce a slab: three layers in, three slabs out. If the
+    // filter had instead DROPPED the mesh, this count would fall to 2 and the
+    // assertions above would pass for the wrong reason.
+    let slabs = meshes.len();
+    assert_eq!(
+        slabs, 3,
+        "the air-gap layer must still be MESHED, only unattributed — got {slabs} slabs"
+    );
 }

--- a/rust/processing/tests/mesh_id_provenance.rs
+++ b/rust/processing/tests/mesh_id_provenance.rs
@@ -1,0 +1,328 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! #3199 — which entity a [`MeshData`] names, and how a host can trust it.
+//!
+//! A mesh carries EITHER `geometry_item_id` (the `IfcRepresentationItem` it was
+//! tessellated from) OR `material_layer_id` (the `IfcMaterial` whose layer it is
+//! a slice of), never both. Before #3199 the material id rode in
+//! `geometry_item_id`, so following the field on a layered wall landed on an
+//! `IfcMaterial` with nothing to warn the caller.
+//!
+//! The sharp edge these tests exist for is
+//! [`sliceable_wall_that_did_not_slice_keeps_representation_item_ids`]:
+//! `geometry_class == 3` is stamped from `is_material_layer_sliceable`, a static
+//! index lookup, BEFORE the geometry runs. The slicer can still bail, and then
+//! the element emits ordinary representation-item sub-meshes under class 3. So
+//! the class cannot answer which id a mesh carries, and anything that derives
+//! the answer from it re-creates exactly the lie #3199 removed.
+
+use ifc_lite_core::{EntityDecoder, IfcType};
+use ifc_lite_geometry::{GeometryRouter, MaterialLayerIndex};
+use ifc_lite_processing::element::{
+    produce_element_meshes, ElementJobKind, ElementMeshJob, MeshProductionContext,
+    MeshProductionOptions,
+};
+use ifc_lite_processing::{process_geometry, MeshData};
+use rustc_hash::FxHashMap;
+use std::sync::Arc;
+
+/// `GEOM_CLASS_LAYER_SLICE` — the value the mesh producer stamps on any element
+/// whose buildup the layer index calls sliceable.
+const LAYER_SLICE: u8 = 3;
+
+/// A three-layer wall (50 mm finish / 200 mm core / 50 mm finish, materials
+/// #200/#201/#200) whose body representation holds `items`.
+///
+/// One item slices; two items do not — `try_layered_sub_meshes` requires a
+/// single unshifted item, because the layer planes are built from the element
+/// placement alone and would otherwise sit in a different frame than the mesh.
+/// Everything else about the two files is identical, so the two tests below
+/// differ in exactly the thing under test.
+fn three_layer_wall(items: &str) -> String {
+    format!(
+        r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-3199 layered wall'),'2;1');
+FILE_NAME('wall.ifc','2026-08-25T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1234567890123456789012',$,'Test',$,$,$,$,(#10),#7);
+#7=IFCUNITASSIGNMENT((#8));
+#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#10=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#11,$);
+#11=IFCAXIS2PLACEMENT3D(#12,$,$);
+#12=IFCCARTESIANPOINT((0.,0.,0.));
+#13=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#10,$,.MODEL_VIEW.,$);
+#20=IFCLOCALPLACEMENT($,#21);
+#21=IFCAXIS2PLACEMENT3D(#22,#23,#24);
+#22=IFCCARTESIANPOINT((0.,0.,0.));
+#23=IFCDIRECTION((0.,0.,1.));
+#24=IFCDIRECTION((1.,0.,0.));
+#30=IFCRECTANGLEPROFILEDEF(.AREA.,'WallA',#31,4.0,0.3);
+#31=IFCAXIS2PLACEMENT2D(#32,#33);
+#32=IFCCARTESIANPOINT((0.,0.));
+#33=IFCDIRECTION((1.,0.));
+#40=IFCEXTRUDEDAREASOLID(#30,#41,#42,3.0);
+#41=IFCAXIS2PLACEMENT3D(#43,$,$);
+#42=IFCDIRECTION((0.,0.,1.));
+#43=IFCCARTESIANPOINT((0.,0.,0.));
+#44=IFCRECTANGLEPROFILEDEF(.AREA.,'WallB',#45,2.0,0.3);
+#45=IFCAXIS2PLACEMENT2D(#46,#47);
+#46=IFCCARTESIANPOINT((5.,0.));
+#47=IFCDIRECTION((1.,0.));
+#48=IFCEXTRUDEDAREASOLID(#44,#41,#42,3.0);
+#50=IFCSHAPEREPRESENTATION(#13,'Body','SweptSolid',({items}));
+#51=IFCPRODUCTDEFINITIONSHAPE($,$,(#50));
+#100=IFCWALL('0001234567890123456789',$,'TestWall',$,$,#20,#51,'Test',$);
+#200=IFCMATERIAL('Finish',$,$);
+#201=IFCMATERIAL('Core',$,$);
+#210=IFCMATERIALLAYER(#200,0.05,$,'FinishOuter',$,$,$);
+#211=IFCMATERIALLAYER(#201,0.2,$,'Core',$,$,$);
+#212=IFCMATERIALLAYER(#200,0.05,$,'FinishInner',$,$,$);
+#220=IFCMATERIALLAYERSET((#210,#211,#212),'3LayerBuildup',$);
+#221=IFCMATERIALLAYERSETUSAGE(#220,.AXIS2.,.POSITIVE.,-0.15,$);
+#300=IFCRELASSOCIATESMATERIAL('0001234567890123456790',$,$,$,(#100),#221);
+ENDSEC;
+END-ISO-10303-21;
+"#
+    )
+}
+
+/// Mesh wall #100 through `produce_element_meshes` with the router's
+/// `MaterialLayerIndex` wired — the arming the native pipeline
+/// (`processor/mod.rs`) and the wasm batch path both do. Returns the meshes and
+/// whether the index called the wall sliceable.
+fn produce_wall(content: &str) -> (Vec<MeshData>, bool) {
+    let mut decoder = EntityDecoder::new(content);
+    let mut router = GeometryRouter::with_units(content, &mut decoder);
+    let index = MaterialLayerIndex::from_content(content, &mut decoder);
+    let sliceable = index.is_sliceable(100);
+    router.set_material_layer_index(Arc::new(index));
+
+    let wall = decoder.decode_by_id(100).expect("decode wall #100");
+    let void_index = FxHashMap::default();
+    let geometry_style_index = FxHashMap::default();
+    let indexed_colour_full = FxHashMap::default();
+    let element_material_colors = FxHashMap::default();
+    let texture_index = FxHashMap::default();
+    let ctx = MeshProductionContext {
+        void_index: &void_index,
+        geometry_style_index: &geometry_style_index,
+        indexed_colour_full: &indexed_colour_full,
+        element_material_colors: &element_material_colors,
+        texture_index: &texture_index,
+        site_local_rotation: None,
+    };
+    let job = ElementMeshJob {
+        id: 100,
+        ifc_type: IfcType::IfcWall,
+        entity: &wall,
+        kind: ElementJobKind::Product,
+        element_color: None,
+        metadata: None,
+    };
+
+    let produced = produce_element_meshes(
+        &job,
+        &ctx,
+        &MeshProductionOptions::default(),
+        &mut decoder,
+        &router,
+    );
+    (produced.meshes, sliceable)
+}
+
+/// The contract's one unconditional rule, checked wherever meshes are produced.
+fn assert_ids_disjoint(meshes: &[MeshData], what: &str) {
+    for m in meshes {
+        assert!(
+            !(m.geometry_item_id.is_some() && m.material_layer_id.is_some()),
+            "[{what}] mesh of #{} carries BOTH geometry_item_id {:?} and material_layer_id {:?}",
+            m.express_id,
+            m.geometry_item_id,
+            m.material_layer_id
+        );
+    }
+}
+
+fn geometry_fixture(name: &str) -> Option<String> {
+    let path = format!(
+        "{}/../geometry/tests/fixtures/{name}",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    match std::fs::read_to_string(&path) {
+        Ok(s) => Some(s),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            eprintln!(
+                "skipping #3199 mapped-item id test: fixture missing at {path} — \
+                 it is tracked in git, so restore it with `git checkout -- {path}` \
+                 (`pnpm fixtures` fetches the downloaded corpus, not this file)"
+            );
+            None
+        }
+        Err(e) => panic!("failed to read fixture {path}: {e}"),
+    }
+}
+
+/// Every slab of a sliced layered wall names its `IfcMaterial` and nothing else.
+///
+/// Regresses to the pre-#3199 lie if `material_layer_id` stops being routed:
+/// the material ids would reappear in `geometry_item_id`, where a host following
+/// the field to source lands on `IfcMaterial` #200 instead of a geometry item.
+#[test]
+fn layered_wall_slices_name_their_material_not_a_representation_item() {
+    let content = three_layer_wall("#40");
+    let (meshes, sliceable) = produce_wall(&content);
+    assert!(sliceable, "the layer index must call this wall sliceable");
+    assert_ids_disjoint(&meshes, "sliced layered wall");
+
+    assert_eq!(meshes.len(), 3, "expected one mesh per layer");
+    for m in &meshes {
+        assert_eq!(m.geometry_class, LAYER_SLICE);
+        assert_eq!(
+            m.geometry_item_id, None,
+            "a layer slab is not a representation item, got {:?}",
+            m.geometry_item_id
+        );
+    }
+
+    // #200 Finish, #201 Core, #200 Finish — in stack order, the two outer
+    // finishes sharing one material. Named, not `is_some()`: a slab pointing at
+    // the wrong material is the failure a presence check would pass.
+    let materials: Vec<Option<u32>> = meshes.iter().map(|m| m.material_layer_id).collect();
+    assert_eq!(
+        materials,
+        vec![Some(200), Some(201), Some(200)],
+        "layer slabs must name the buildup's materials in stack order"
+    );
+}
+
+/// THE #3199 sharp edge: `geometry_class == 3` on meshes that are representation
+/// items, because the class is stamped from the static
+/// `is_material_layer_sliceable` lookup while the slicer bails at runtime.
+///
+/// Same wall, same layer set, one extra body item — which
+/// `element_is_single_unshifted_item` refuses, so the element falls through to
+/// the ordinary sub-mesh path and emits #40 and #48.
+///
+/// This is the test that catches deriving the item-vs-layer answer from
+/// `geometry_class` (or from `is_material_layer_sliceable`): both say "layer"
+/// here, and both are wrong. Without it, such a change looks green.
+#[test]
+fn sliceable_wall_that_did_not_slice_keeps_representation_item_ids() {
+    let content = three_layer_wall("#40,#48");
+    let (meshes, sliceable) = produce_wall(&content);
+    assert!(
+        sliceable,
+        "the static index must still call this wall sliceable — that is the trap"
+    );
+    assert_ids_disjoint(&meshes, "sliceable wall that did not slice");
+
+    assert_eq!(
+        meshes.len(),
+        2,
+        "expected the two body items, not layer slabs"
+    );
+    for m in &meshes {
+        assert_eq!(
+            m.geometry_class, LAYER_SLICE,
+            "the class is stamped before the geometry runs, so it must still be 3 here"
+        );
+        assert_eq!(
+            m.material_layer_id, None,
+            "no layer was cut, so nothing may claim to be a material slice"
+        );
+    }
+
+    let mut items: Vec<Option<u32>> = meshes.iter().map(|m| m.geometry_item_id).collect();
+    items.sort();
+    assert_eq!(
+        items,
+        vec![Some(40), Some(48)],
+        "each mesh must name the IfcExtrudedAreaSolid it came from"
+    );
+}
+
+/// #3199 — pins WHICH id a mapped item's meshes carry: the solid inside the
+/// `IfcRepresentationMap`, not the `IfcMappedItem` and not the map.
+///
+/// Four occurrences share map #18 over solids #11 and #15. Each occurrence
+/// emits both solid ids, so the id identifies the SOURCE geometry and repeats
+/// across occurrences — it is not an occurrence-unique handle. A future change
+/// to per-occurrence ids should be deliberate, and this fails when it is not.
+#[test]
+fn mapped_item_meshes_name_the_solid_inside_the_map() {
+    let Some(content) = geometry_fixture("mapped_instances_multi_item.ifc") else {
+        return;
+    };
+    let result = process_geometry(&content);
+    assert_ids_disjoint(&result.meshes, "mapped_instances_multi_item");
+
+    // The four IfcBuildingElementProxy occurrences.
+    for occurrence in [40u32, 47, 54, 61] {
+        let mut ids: Vec<Option<u32>> = result
+            .meshes
+            .iter()
+            .filter(|m| m.express_id == occurrence)
+            .map(|m| m.geometry_item_id)
+            .collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec![Some(11), Some(15)],
+            "#{occurrence} must name the two IfcExtrudedAreaSolids inside map #18, \
+             not its IfcMappedItem or the map itself"
+        );
+    }
+
+    // Nothing may name a wrapper: #18 is the IfcRepresentationMap, #34/#41/#48/
+    // #55 are the per-occurrence IfcMappedItems.
+    for m in &result.meshes {
+        assert!(
+            !matches!(m.geometry_item_id, Some(18 | 34 | 41 | 48 | 55)),
+            "mesh of #{} names wrapper entity {:?}, not a geometry item",
+            m.express_id,
+            m.geometry_item_id
+        );
+        assert_eq!(m.material_layer_id, None, "no material layers in this file");
+    }
+}
+
+/// #3199 — same pin one level deeper: a map that itself contains an
+/// `IfcMappedItem` yields the INNERMOST solids, #16 (the outer map's own solid)
+/// and #12 (the inner map's), not the nested item #19, the occurrence item #31,
+/// or either `IfcRepresentationMap` (#14, #21).
+#[test]
+fn nested_mapped_item_meshes_name_the_innermost_solids() {
+    let Some(content) = geometry_fixture("nested_mapped_item.ifc") else {
+        return;
+    };
+    let result = process_geometry(&content);
+    assert_ids_disjoint(&result.meshes, "nested_mapped_item");
+
+    let mut ids: Vec<Option<u32>> = result
+        .meshes
+        .iter()
+        .filter(|m| m.express_id == 35)
+        .map(|m| m.geometry_item_id)
+        .collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![Some(12), Some(16)],
+        "the proxy must name the solid in each map it reaches, through the nesting"
+    );
+
+    for m in &result.meshes {
+        assert!(
+            !matches!(m.geometry_item_id, Some(14 | 19 | 21 | 31)),
+            "mesh of #{} names a map or mapped-item wrapper {:?}",
+            m.express_id,
+            m.geometry_item_id
+        );
+        assert_eq!(m.material_layer_id, None, "no material layers in this file");
+    }
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -97,7 +97,7 @@
          438 rust/geometry/src/kernel/retriangulate_recover.rs
 # new row: adds from_spans (build the index from pre-collected IfcRelAssociatesMaterial spans, no re-walk) + the MaterialLayerFlat wire codec (to_flat/from_flat) + round-trip tests, so the streaming pre-pass ships the index to workers once instead of each worker re-scanning the file (perf/single-scan #563).
      563 rust/geometry/src/material_layer_index.rs
-# +14: SubMeshCollection gains `ids_are_material_layers` + `of_material_layers()` so a material-layer id can never be read as a representation item (#3199).
+# +14: SubMeshCollection gains `ids_are_materials` + `of_materials()` so a material-layer id can never be read as a representation item (#3199).
     1543 rust/geometry/src/mesh.rs
 # +86: #2866 — Boolean and CSG are mutually recursive over file references
 # (IfcBooleanResult operand -> IfcCsgSolid -> TreeRootExpression -> that same
@@ -349,7 +349,7 @@
 # +3: #2049 — `set_texture` was the one 8-arg fn in this crate missing the
 # `#[allow(clippy::too_many_arguments)]` its 21 peers carry. The crate's lint
 # has never run in CI (`--exclude ifc-lite-wasm`), which is how it drifted.
-# +37: geometry_item_id/material_layer_id cross the boundary -- 2 fields, 2 getters, a paired setter, and propagation at all THREE MeshDataJs clone sites (defaulting them there would have made the field inert at collection.get(i)) (#3199).
+# +37: geometry_item_id/material_id cross the boundary -- 2 fields, 2 getters, a paired setter, and propagation at all THREE MeshDataJs clone sites (defaulting them there would have made the field inert at collection.get(i)) (#3199).
      764 rust/wasm-bindings/src/zero_copy/mesh.rs
 # symbolic.rs +14 (743 -> 757): carries SymbolicData::truncated across the WASM
 # boundary as `truncatedAt` (#2938). A raise rather than a split because the

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -97,7 +97,8 @@
          438 rust/geometry/src/kernel/retriangulate_recover.rs
 # new row: adds from_spans (build the index from pre-collected IfcRelAssociatesMaterial spans, no re-walk) + the MaterialLayerFlat wire codec (to_flat/from_flat) + round-trip tests, so the streaming pre-pass ships the index to workers once instead of each worker re-scanning the file (perf/single-scan #563).
      563 rust/geometry/src/material_layer_index.rs
-    1529 rust/geometry/src/mesh.rs
+# +14: SubMeshCollection gains `ids_are_material_layers` + `of_material_layers()` so a material-layer id can never be read as a representation item (#3199).
+    1543 rust/geometry/src/mesh.rs
 # +86: #2866 — Boolean and CSG are mutually recursive over file references
 # (IfcBooleanResult operand -> IfcCsgSolid -> TreeRootExpression -> that same
 # IfcBooleanResult). CsgSolidProcessor built a FRESH BooleanClippingProcessor,
@@ -172,7 +173,8 @@
 # A repeat returns false, which is this function's existing "anything exotic
 # bails safely" contract rather than a new special case. Tests are in a sibling
 # layers_cycle_tests.rs.
-     685 rust/geometry/src/router/layers.rs
+# +1: the layered builder now marks its collection as carrying material ids (#3199).
+     686 rust/geometry/src/router/layers.rs
 # +1: unify body-rep predicate — added is_direct_body_representation + docs; net removes ~60 lines from processing.rs and ~12 from layers.rs (crate trends down).
 # +65: promote the per-router IfcMappedItem source cache to a model-wide SharedMappedItemCache (type alias + field + new_/enable_ setters + unique-count diagnostic), meshing each source once model-wide (#1623).
 # +38: #1623 Phase 2 don't-bake — MappedInstancePlan type alias + output_instancing_plan field + enable_/getter + `mod instancing` decl.
@@ -203,7 +205,8 @@
 # call site with residual composition and cut-effect diagnostics parity.
 # +27: #129 coaxial-union prepass wiring — module decl + feature-gated stats
 # re-export + the pre-batch `coaxial_union_prepass` call and its consumed-skip.
-     2054 rust/geometry/src/router/voids/mod.rs
+# +6: the voided rebuild INHERITS the id discriminator instead of hard-coding rep-item, so a future layered producer cannot be silently relabelled (#3199).
+     2060 rust/geometry/src/router/voids/mod.rs
 # NEW: analytic prism (stepped-extrusion) subtraction on the host mesh — the
 # CSG-heavy-corpus lever (ISSUE_098/129: exact void booleans are ~75-82% of
 # geometry time; rebated masonry openings on brep/clipped hosts had no fast
@@ -295,7 +298,8 @@
 # the DEPTH of each visit: a plain set combined with the cap silently LOSES a
 # colour, because an item first reached near the limit is cut before its
 # subtree is searched yet stays marked, so a later shorter branch is skipped.
-     961 rust/processing/src/element.rs
+# +5: thread the discriminator into build_mesh_data so the source id is routed to whichever of the two disjoint MeshData fields it actually is (#3199).
+     966 rust/processing/src/element.rs
 # +9: #2019 — canonicalise each host's opening order so the world geometry
 # hash stops depending on IFCRELVOIDSELEMENT statement order (sequential void
 # cuts are not associative). Three lines of code plus the why.
@@ -345,7 +349,8 @@
 # +3: #2049 — `set_texture` was the one 8-arg fn in this crate missing the
 # `#[allow(clippy::too_many_arguments)]` its 21 peers carry. The crate's lint
 # has never run in CI (`--exclude ifc-lite-wasm`), which is how it drifted.
-     727 rust/wasm-bindings/src/zero_copy/mesh.rs
+# +37: geometry_item_id/material_layer_id cross the boundary -- 2 fields, 2 getters, a paired setter, and propagation at all THREE MeshDataJs clone sites (defaulting them there would have made the field inert at collection.get(i)) (#3199).
+     764 rust/wasm-bindings/src/zero_copy/mesh.rs
 # symbolic.rs +14 (743 -> 757): carries SymbolicData::truncated across the WASM
 # boundary as `truncatedAt` (#2938). A raise rather than a split because the
 # addition is one field, one assignment in `from_data` and one getter -- the

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -41,7 +41,7 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// FNV-1a over the sorted rows rather than `DefaultHasher`, whose output is
 /// explicitly NOT guaranteed stable across Rust releases - a toolchain bump
 /// would rewrite the digest and fail CI for no reason.
-const ALLOWLIST_DIGEST: u64 = 4241476374134085635;
+const ALLOWLIST_DIGEST: u64 = 2635552733029908705;
 
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).

--- a/rust/processing/tests/styling_submesh_split.rs
+++ b/rust/processing/tests/styling_submesh_split.rs
@@ -100,7 +100,7 @@ fn window_splits_frame_and_glass_across_submeshes() {
 /// the colour test above still passes, because colour is resolved separately.
 /// If the item/layer split is routed by anything other than what built the
 /// collection, this window (two items, no layer set, no `IfcMaterialLayerSet`
-/// anywhere in the file) is where a stray `material_layer_id` shows up.
+/// anywhere in the file) is where a stray `material_id` shows up.
 #[test]
 fn window_submeshes_name_their_own_face_sets() {
     let result = process_geometry(WINDOW_IFC);
@@ -118,7 +118,7 @@ fn window_submeshes_name_their_own_face_sets() {
 
     for part in &parts {
         assert_eq!(
-            part.material_layer_id, None,
+            part.material_id, None,
             "the window has no material layers, so nothing may carry a layer id"
         );
     }

--- a/rust/processing/tests/styling_submesh_split.rs
+++ b/rust/processing/tests/styling_submesh_split.rs
@@ -89,3 +89,37 @@ fn window_splits_frame_and_glass_across_submeshes() {
         parts.iter().map(|m| m.color).collect::<Vec<_>>()
     );
 }
+
+/// Discussion #2985 / #3199: a host that gets two sub-meshes for one window has
+/// to be able to tell which item each came from. The two parts must name the
+/// two `IfcTriangulatedFaceSet`s, #14 and #16, and neither may claim to be a
+/// material-layer slice.
+///
+/// Catches two regressions. If `geometry_item_id` stops being stamped on the
+/// sub-mesh path, both ids go `None` and the parts become indistinguishable —
+/// the colour test above still passes, because colour is resolved separately.
+/// If the item/layer split is routed by anything other than what built the
+/// collection, this window (two items, no layer set, no `IfcMaterialLayerSet`
+/// anywhere in the file) is where a stray `material_layer_id` shows up.
+#[test]
+fn window_submeshes_name_their_own_face_sets() {
+    let result = process_geometry(WINDOW_IFC);
+
+    let parts: Vec<&_> = result.meshes.iter().filter(|m| m.express_id == 10).collect();
+    assert_eq!(parts.len(), 2, "expected one sub-mesh per window item");
+
+    let mut ids: Vec<Option<u32>> = parts.iter().map(|m| m.geometry_item_id).collect();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![Some(14), Some(16)],
+        "sub-meshes must name the frame and glass face sets"
+    );
+
+    for part in &parts {
+        assert_eq!(
+            part.material_layer_id, None,
+            "the window has no material layers, so nothing may carry a layer id"
+        );
+    }
+}

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -48,6 +48,10 @@ pub struct MeshDataJs {
     /// via IfcRelDefinesByType — the type-library shape, hidden in Model mode to
     /// avoid double-rendering, shown in Types mode). See #957 follow-up.
     geometry_class: u8,
+    /// Source ids, DISJOINT — never both. See `ifc_lite_processing::MeshData`
+    /// for what each means and when each is absent (#3199).
+    geometry_item_id: Option<u32>,
+    material_layer_id: Option<u32>,
     /// Per-element local-frame origin (f64), in the SAME (WebGL Y-up) frame as
     /// `positions`: world position of vertex i = `origin + positions[3i..]`.
     /// Default `[0,0,0]` means positions are absolute (legacy). Carries the
@@ -185,6 +189,19 @@ impl MeshDataJs {
         self.geometry_class
     }
 
+    /// Source `IfcRepresentationItem`, or `undefined` where identity is merged
+    /// away. Never set alongside `materialLayerId` (#3199).
+    #[wasm_bindgen(getter, js_name = geometryItemId)]
+    pub fn geometry_item_id(&self) -> Option<u32> {
+        self.geometry_item_id
+    }
+
+    /// `IfcMaterial` layer sliced, or `undefined` (#3199).
+    #[wasm_bindgen(getter, js_name = materialLayerId)]
+    pub fn material_layer_id(&self) -> Option<u32> {
+        self.material_layer_id
+    }
+
     /// Per-element local-frame origin (Float64Array[3], WebGL Y-up, metres):
     /// world position of vertex i = `origin + positions[3i..3i+3]`. Returns
     /// [0,0,0] when positions are absolute (legacy / local frame off).
@@ -273,6 +290,8 @@ impl MeshDataJs {
             texture_id: 0,
             texture_url: None,
             geometry_class: 0,
+            geometry_item_id: None,
+            material_layer_id: None,
             origin,
             local_bounds,
             local_to_world,
@@ -283,6 +302,17 @@ impl MeshDataJs {
     /// (0 = occurrence, 1 = orphan type, 2 = instanced type). Call after `new`.
     pub fn set_geometry_class(&mut self, class: u8) {
         self.geometry_class = class;
+    }
+
+    /// Both DISJOINT ids at once, so a caller cannot set one without
+    /// considering the other (#3199).
+    pub fn set_source_ids(&mut self, geometry_item_id: Option<u32>, material_layer_id: Option<u32>) {
+        debug_assert!(
+            geometry_item_id.is_none() || material_layer_id.is_none(),
+            "disjoint; never both"
+        );
+        self.geometry_item_id = geometry_item_id;
+        self.material_layer_id = material_layer_id;
     }
 
     /// Attach an optional SurfaceColour for the GLB exporter's "Shading"
@@ -362,6 +392,7 @@ impl MeshDataJs {
         };
         let mut js = Self::new(m.express_id, m.ifc_type, mesh, m.color);
         js.set_geometry_class(m.geometry_class);
+        js.set_source_ids(m.geometry_item_id, m.material_layer_id);
         if let (Some(uvs), Some(tex)) = (m.uvs, m.texture) {
             if let Some(rgba) = tex.rgba {
                 // Rust-decoded blob/pixel texture (#961): the Arc is shared
@@ -457,6 +488,8 @@ impl MeshCollection {
             texture_id: m.texture_id,
             texture_url: m.texture_url.clone(),
             geometry_class: m.geometry_class,
+            geometry_item_id: m.geometry_item_id,
+            material_layer_id: m.material_layer_id,
             origin: m.origin,
             local_bounds: m.local_bounds,
             local_to_world: m.local_to_world,
@@ -488,6 +521,8 @@ impl MeshCollection {
             texture_id: m.texture_id,
             texture_url: m.texture_url.take(),
             geometry_class: m.geometry_class,
+            geometry_item_id: m.geometry_item_id,
+            material_layer_id: m.material_layer_id,
             origin: m.origin,
             local_bounds: m.local_bounds,
             local_to_world: m.local_to_world,
@@ -691,6 +726,8 @@ impl Clone for MeshCollection {
                     texture_id: m.texture_id,
                     texture_url: m.texture_url.clone(),
                     geometry_class: m.geometry_class,
+                    geometry_item_id: m.geometry_item_id,
+                    material_layer_id: m.material_layer_id,
                     origin: m.origin,
                     local_bounds: m.local_bounds,
                     local_to_world: m.local_to_world,

--- a/rust/wasm-bindings/src/zero_copy/mesh.rs
+++ b/rust/wasm-bindings/src/zero_copy/mesh.rs
@@ -51,7 +51,7 @@ pub struct MeshDataJs {
     /// Source ids, DISJOINT — never both. See `ifc_lite_processing::MeshData`
     /// for what each means and when each is absent (#3199).
     geometry_item_id: Option<u32>,
-    material_layer_id: Option<u32>,
+    material_id: Option<u32>,
     /// Per-element local-frame origin (f64), in the SAME (WebGL Y-up) frame as
     /// `positions`: world position of vertex i = `origin + positions[3i..]`.
     /// Default `[0,0,0]` means positions are absolute (legacy). Carries the
@@ -190,16 +190,16 @@ impl MeshDataJs {
     }
 
     /// Source `IfcRepresentationItem`, or `undefined` where identity is merged
-    /// away. Never set alongside `materialLayerId` (#3199).
+    /// away. Never set alongside `materialId` (#3199).
     #[wasm_bindgen(getter, js_name = geometryItemId)]
     pub fn geometry_item_id(&self) -> Option<u32> {
         self.geometry_item_id
     }
 
     /// `IfcMaterial` layer sliced, or `undefined` (#3199).
-    #[wasm_bindgen(getter, js_name = materialLayerId)]
-    pub fn material_layer_id(&self) -> Option<u32> {
-        self.material_layer_id
+    #[wasm_bindgen(getter, js_name = materialId)]
+    pub fn material_id(&self) -> Option<u32> {
+        self.material_id
     }
 
     /// Per-element local-frame origin (Float64Array[3], WebGL Y-up, metres):
@@ -291,7 +291,7 @@ impl MeshDataJs {
             texture_url: None,
             geometry_class: 0,
             geometry_item_id: None,
-            material_layer_id: None,
+            material_id: None,
             origin,
             local_bounds,
             local_to_world,
@@ -306,13 +306,13 @@ impl MeshDataJs {
 
     /// Both DISJOINT ids at once, so a caller cannot set one without
     /// considering the other (#3199).
-    pub fn set_source_ids(&mut self, geometry_item_id: Option<u32>, material_layer_id: Option<u32>) {
+    pub fn set_source_ids(&mut self, geometry_item_id: Option<u32>, material_id: Option<u32>) {
         debug_assert!(
-            geometry_item_id.is_none() || material_layer_id.is_none(),
+            geometry_item_id.is_none() || material_id.is_none(),
             "disjoint; never both"
         );
         self.geometry_item_id = geometry_item_id;
-        self.material_layer_id = material_layer_id;
+        self.material_id = material_id;
     }
 
     /// Attach an optional SurfaceColour for the GLB exporter's "Shading"
@@ -392,7 +392,7 @@ impl MeshDataJs {
         };
         let mut js = Self::new(m.express_id, m.ifc_type, mesh, m.color);
         js.set_geometry_class(m.geometry_class);
-        js.set_source_ids(m.geometry_item_id, m.material_layer_id);
+        js.set_source_ids(m.geometry_item_id, m.material_id);
         if let (Some(uvs), Some(tex)) = (m.uvs, m.texture) {
             if let Some(rgba) = tex.rgba {
                 // Rust-decoded blob/pixel texture (#961): the Arc is shared
@@ -489,7 +489,7 @@ impl MeshCollection {
             texture_url: m.texture_url.clone(),
             geometry_class: m.geometry_class,
             geometry_item_id: m.geometry_item_id,
-            material_layer_id: m.material_layer_id,
+            material_id: m.material_id,
             origin: m.origin,
             local_bounds: m.local_bounds,
             local_to_world: m.local_to_world,
@@ -522,7 +522,7 @@ impl MeshCollection {
             texture_url: m.texture_url.take(),
             geometry_class: m.geometry_class,
             geometry_item_id: m.geometry_item_id,
-            material_layer_id: m.material_layer_id,
+            material_id: m.material_id,
             origin: m.origin,
             local_bounds: m.local_bounds,
             local_to_world: m.local_to_world,
@@ -727,7 +727,7 @@ impl Clone for MeshCollection {
                     texture_url: m.texture_url.clone(),
                     geometry_class: m.geometry_class,
                     geometry_item_id: m.geometry_item_id,
-                    material_layer_id: m.material_layer_id,
+                    material_id: m.material_id,
                     origin: m.origin,
                     local_bounds: m.local_bounds,
                     local_to_world: m.local_to_world,

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -135,7 +135,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * failure message. Either way do it at the moment you finalise the change — it
  * moves if anything else touched the allowlist first.
  */
-const ALLOWLIST_DIGEST = '5215539587396622478';
+const ALLOWLIST_DIGEST = '674100036802546405';
 
 function parseArgs(argv) {
   const out = {

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -135,7 +135,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * failure message. Either way do it at the moment you finalise the change — it
  * moves if anything else touched the allowlist first.
  */
-const ALLOWLIST_DIGEST = '1125203688214438683';
+const ALLOWLIST_DIGEST = '5215539587396622478';
 
 function parseArgs(argv) {
   const out = {

--- a/scripts/lib/mesh-via-prepass.mjs
+++ b/scripts/lib/mesh-via-prepass.mjs
@@ -58,7 +58,7 @@ export function parseMeshesViaPrePass(api, content) {
             // a field the real converter carries and this one drops is
             // invisible to every script that reads through it.
             geometryItemId: m.geometryItemId,
-            materialLayerId: m.materialLayerId,
+            materialId: m.materialId,
             // Per-element local-frame origin (world = origin + position). Present
             // on the wasm local-frame path; consumers fold it to recover world.
             origin: m.origin ? Array.from(m.origin) : undefined,

--- a/scripts/lib/mesh-via-prepass.mjs
+++ b/scripts/lib/mesh-via-prepass.mjs
@@ -53,6 +53,12 @@ export function parseMeshesViaPrePass(api, content) {
             vertexCount: m.vertexCount,
             triangleCount: m.triangleCount,
             geometryClass: m.geometryClass,
+            // #3199: the two DISJOINT source ids. Copied here because this
+            // facade mirrors `convertMeshCollectionToBatch` field by field --
+            // a field the real converter carries and this one drops is
+            // invisible to every script that reads through it.
+            geometryItemId: m.geometryItemId,
+            materialLayerId: m.materialLayerId,
             // Per-element local-frame origin (world = origin + position). Present
             // on the wasm local-frame path; consumers fold it to recover world.
             origin: m.origin ? Array.from(m.origin) : undefined,

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -321,7 +321,7 @@
   1082 packages/server-client/src/client.ts
    775 packages/server-client/src/data-model-decoder.ts
    517 packages/server-client/src/parquet-tables.ts
-   772 packages/server-client/src/types.ts
+   627 packages/server-client/src/types.ts
    411 packages/source-dalux/src/http-client.ts
    406 packages/source-dalux/src/provider.ts
    432 packages/source-dropbox/src/provider.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -240,7 +240,6 @@
    937 packages/geometry/src/ifc-lite-bridge.ts
   1551 packages/geometry/src/index.ts
    730 packages/geometry/src/native-bridge.ts
-   449 packages/geometry/src/types.ts
    469 packages/ids/src/audit/coherence/index.ts
    904 packages/ids/src/audit/ifc-schema/index.ts
    566 packages/ids/src/audit/structural/index.ts

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -890,57 +890,6 @@ if (COLUMN_AVAILABLE_FOR_LEGACY) {
   });
 }
 
-// ===== representation-item identity crosses the boundary, DISJOINT (#3199) =====
-//
-// The router already kept each representation item's STEP id and it already
-// reached the server REST payload; `MeshDataJs::from_mesh_data` simply did not
-// copy it, so the browser never saw it and a host could not drill from a
-// rendered piece to the entity that produced it (#2985).
-//
-// The half that needs pinning here rather than in Rust is the DISJOINTNESS.
-// For material-layered walls the same field used to carry the `IfcMaterial`
-// id, so following it to source landed on the wrong entity with nothing to warn
-// the caller. Two fields fix that only if they are never both set — a consumer
-// that ignores the distinction must still be unable to read one as the other.
-//
-// `geometryClass === 3` cannot substitute for the discriminator: it is stamped
-// from a static material-index check made BEFORE the geometry runs, while the
-// layered path can bail at runtime and emit representation-item submeshes under
-// that class. So this asserts the FIELDS, not the class.
-if (LAYERED_AVAILABLE) {
-  console.log('\n📋 representation-item identity (Rust → JS, #3199)');
-
-  test('every mesh carries at most ONE source id, and layered walls carry material ids', () => {
-    const collection = parseMeshesViaPrePass(api, readFileSync(LAYERED_IFC, 'utf-8'));
-    let items = 0, layers = 0, both = 0, neither = 0;
-    for (let i = 0; i < collection.length; i++) {
-      const m = collection.get(i);
-      if (!m) continue;
-      const hasItem = m.geometryItemId !== undefined && m.geometryItemId !== null;
-      const hasLayer = m.materialLayerId !== undefined && m.materialLayerId !== null;
-      if (hasItem && hasLayer) both++;
-      else if (hasItem) items++;
-      else if (hasLayer) layers++;
-      else neither++;
-      m.free();
-    }
-    collection.free();
-
-    // THE invariant. Two fields that can both be set are one field with extra
-    // steps, and the confusion this change removes would survive.
-    assert.equal(both, 0, `${both} meshes carried BOTH a geometryItemId and a materialLayerId`);
-
-    // Non-vacuity, in both directions: the fixture must actually exercise each
-    // field, or "never both" is satisfied by never setting either.
-    assert.ok(items > 0, 'no mesh carried a geometryItemId — the identity is not crossing at all');
-    assert.ok(
-      layers > 0,
-      `no mesh carried a materialLayerId; duplex.ifc has multi-layer walls, so the layered ` +
-        `path should produce some (items=${items}, neither=${neither})`,
-    );
-  });
-}
-
 // ===== geometryClass ordinals, pinned at the real boundary =====
 //
 // `packages/geometry/src/geometry-class.ts` names these ordinals for the
@@ -990,15 +939,20 @@ if (LAYERED_AVAILABLE) {
 //
 // A mesh carries EITHER the `IfcRepresentationItem` it was tessellated from
 // (`geometryItemId`) OR the `IfcMaterial` whose layer it slices
-// (`materialLayerId`), never both. Before #3199 both arrived in one field, so
+// (`materialId`), never both. Before #3199 both arrived in one field, so
 // following it to source landed on an IfcMaterial for layered walls with
 // nothing to warn the caller.
 //
-// These read the RAW `MeshCollection` rather than `parseMeshesViaPrePass`. The
-// facade copies a fixed list of fields out of each `MeshDataJs`, and that list
-// does not include either id — through it every mesh reads as carrying
-// neither, which is indistinguishable from wasm not emitting them at all. A
-// contract test that cannot tell those apart pins nothing.
+// These read the RAW `MeshCollection` rather than `parseMeshesViaPrePass`,
+// because `takeMesh` and `get` build their `MeshDataJs` separately and only the
+// raw handle can be read both ways.
+//
+// The facade is pinned too, separately and deliberately: it mirrors
+// `convertMeshCollectionToBatch` field by field, and it DID silently drop both
+// ids when they were added — my first probe read zeros through it and reported
+// the boundary broken when the boundary was fine. A field the real converter
+// carries and that facade drops is invisible to every script that reads through
+// it, so one test below reads through the facade on purpose.
 //
 // Wrong ids here are silent in the usual way: geometry renders identically and
 // only a host that follows the id to source sees it land on the wrong entity.
@@ -1034,7 +988,7 @@ if (LAYERED_AVAILABLE) {
             expressId: m.expressId,
             geometryClass: m.geometryClass,
             geometryItemId: m.geometryItemId,
-            materialLayerId: m.materialLayerId,
+            materialId: m.materialId,
           });
         } finally {
           m.free();
@@ -1046,11 +1000,19 @@ if (LAYERED_AVAILABLE) {
     return rows;
   };
 
+  // The unedited fixture is read ONCE and shared: `readIds` is deterministic
+  // and every test below that passes `layeredContent` was re-running the whole
+  // pre-pass + geometry batch over a 2.4 MB file to get the same rows back.
+  // Tests that MUTATE the fixture still take their own run, since that is the
+  // variable they are measuring.
+  let layeredRowsMemo = null;
+  const layeredRows = () => (layeredRowsMemo ??= readIds(layeredContent));
+
   test('every mesh carries exactly one source id, never both and never neither', () => {
-    const rows = readIds(layeredContent);
+    const rows = layeredRows();
     assert.ok(rows.length > 0, 'the fixture produced no meshes, so nothing below is pinned');
-    const both = rows.filter((r) => r.geometryItemId !== undefined && r.materialLayerId !== undefined);
-    const neither = rows.filter((r) => r.geometryItemId === undefined && r.materialLayerId === undefined);
+    const both = rows.filter((r) => r.geometryItemId !== undefined && r.materialId !== undefined);
+    const neither = rows.filter((r) => r.geometryItemId === undefined && r.materialId === undefined);
     assert.equal(both.length, 0, `${both.length} mesh(es) carry BOTH ids, e.g. #${both[0]?.expressId}`);
     // "Neither" is a legitimate state elsewhere (the single-mesh fallback, the
     // cached mapped-item path). It must not happen on THIS fixture, whose
@@ -1060,7 +1022,7 @@ if (LAYERED_AVAILABLE) {
   });
 
   test('a two-item element carries a distinct geometryItemId per piece, and no material id', () => {
-    const rows = readIds(layeredContent);
+    const rows = layeredRows();
     const byElement = new Map();
     for (const r of rows) {
       if (r.geometryItemId === undefined) continue;
@@ -1083,21 +1045,21 @@ if (LAYERED_AVAILABLE) {
     // The pieces of a multi-item element are representation items, so none of
     // them may also claim to be a material layer.
     const multiIds = new Set(multi.map(([expressId]) => expressId));
-    const stray = rows.filter((r) => multiIds.has(r.expressId) && r.materialLayerId !== undefined);
-    assert.equal(stray.length, 0, `a multi-item element also reported a materialLayerId: #${stray[0]?.expressId}`);
+    const stray = rows.filter((r) => multiIds.has(r.expressId) && r.materialId !== undefined);
+    assert.equal(stray.length, 0, `a multi-item element also reported a materialId: #${stray[0]?.expressId}`);
   });
 
-  test('a material-layered wall reports materialLayerId, and geometryItemId undefined', () => {
-    const rows = readIds(layeredContent);
-    const sliced = rows.filter((r) => r.materialLayerId !== undefined);
-    assert.ok(sliced.length > 0, 'no mesh carried a materialLayerId — the layer slicer did not run');
+  test('a material-layered wall reports materialId, and geometryItemId undefined', () => {
+    const rows = layeredRows();
+    const sliced = rows.filter((r) => r.materialId !== undefined);
+    assert.ok(sliced.length > 0, 'no mesh carried a materialId — the layer slicer did not run');
     for (const r of sliced) {
       assert.equal(
         r.geometryItemId, undefined,
-        `#${r.expressId} carries a materialLayerId AND a geometryItemId`,
+        `#${r.expressId} carries a materialId AND a geometryItemId`,
       );
       // A slice is layer geometry, so it must also be tagged class 3.
-      assert.equal(r.geometryClass, 3, `#${r.expressId} carries a materialLayerId at class ${r.geometryClass}`);
+      assert.equal(r.geometryClass, 3, `#${r.expressId} carries a materialId at class ${r.geometryClass}`);
     }
   });
 
@@ -1113,28 +1075,35 @@ if (LAYERED_AVAILABLE) {
     // carries from geometryClass would therefore hand back an IfcMaterial id
     // for meshes whose id is an IfcRepresentationItem: the exact confusion
     // #3199 removed, reintroduced one refactor later.
-    const rows = readIds(layeredContent);
+    const rows = layeredRows();
     const classThree = rows.filter((r) => r.geometryClass === 3);
     assert.ok(classThree.length > 0, 'no class-3 meshes at all — this pins nothing');
     const bailed = classThree.filter((r) => r.geometryItemId !== undefined);
     assert.ok(
       bailed.length > 0,
-      'every class-3 mesh carried a materialLayerId, so this fixture can no longer ' +
+      'every class-3 mesh carried a materialId, so this fixture can no longer ' +
         'distinguish "the flag comes from the collection" from "the flag is derived ' +
         'from geometryClass" — find a fixture whose layer slicing bails at runtime',
     );
     for (const r of bailed) {
-      assert.equal(r.materialLayerId, undefined, `#${r.expressId} carries both ids`);
+      assert.equal(r.materialId, undefined, `#${r.expressId} carries both ids`);
     }
   });
 
-  test('an air-gap layer crosses as materialLayerId 0, which is a value and not a hole', () => {
-    // IfcMaterialLayer.Material is OPTIONAL, and an absent one decodes to
-    // material_id 0. Dropping the Material ref from one layer of the fixture
-    // changes ONE token and nothing else, so the id is the only variable.
+  test('an air-gap layer reports NO material, not IfcMaterial #0', () => {
+    // `IfcMaterialLayer.Material` is OPTIONAL, and `material_layer_index.rs`
+    // decodes an absent one as `get_ref(0).unwrap_or(0)` -- so 0 is that
+    // function's "no reference" SENTINEL, not an entity. STEP instance names
+    // start at #1, so `#0` is not navigable, and following it is the one thing
+    // this field exists for.
     //
-    // 0 is falsy. Any consumer that tests truthiness, or any encoding that
-    // uses 0 to mean "absent", silently loses the air-gap layer.
+    // Dropping the Material ref from one layer of the real fixture changes ONE
+    // token and nothing else, so the id is the only variable.
+    //
+    // The first version of #3199 shipped this as `materialId: 0` on the theory
+    // that 0 was a real value which must round trip. It is not; preserving a
+    // producer's absence sentinel as data is the same defect the change exists
+    // to remove, one field over.
     const withMaterial = /IFCMATERIALLAYER\(#3876,/g;
     assert.ok(
       withMaterial.test(layeredContent),
@@ -1142,29 +1111,94 @@ if (LAYERED_AVAILABLE) {
     );
     const airGap = layeredContent.replace(withMaterial, 'IFCMATERIALLAYER($,');
 
-    const before = readIds(layeredContent).filter((r) => r.materialLayerId === 3876);
+    const before = layeredRows().filter((r) => r.materialId === 3876);
     assert.ok(before.length > 0, 'material #3876 sliced no layers, so the edit below proves nothing');
 
     const after = readIds(airGap).filter((r) => r.geometryClass === 3);
-    const zeros = after.filter((r) => r.materialLayerId === 0);
-    assert.equal(
-      zeros.length, before.length,
-      `dropping the material ref should turn ${before.length} slices into materialLayerId 0, saw ${zeros.length}`,
-    );
+
+    // 1. The removed material is gone.
     assert.ok(
-      !after.some((r) => r.materialLayerId === 3876),
+      !after.some((r) => r.materialId === 3876),
       'a slice still reports the material id that was removed from the file',
     );
-    for (const r of zeros) {
-      assert.equal(r.geometryItemId, undefined, `air-gap slice #${r.expressId} also carries a geometryItemId`);
+
+    // 2. It did not come back as 0. This is the assertion the fix is about, and
+    //    it fails loudly against the pre-fix build: those same slices carried
+    //    `materialId: 0` there.
+    const zeros = after.filter((r) => r.materialId === 0);
+    assert.equal(
+      zeros.length, 0,
+      `${zeros.length} air-gap slice(s) reported IfcMaterial #0, which is not an entity ` +
+        `(e.g. #${zeros[0]?.expressId})`,
+    );
+
+    // 3. And the slices still EXIST, unattributed rather than dropped —
+    //    otherwise 1 and 2 are satisfied by the geometry disappearing, which
+    //    would be a far worse bug wearing this test as cover.
+    const unattributed = after.filter(
+      (r) => r.materialId === undefined && r.geometryItemId === undefined,
+    );
+    assert.ok(
+      unattributed.length >= before.length,
+      `dropping the material ref should leave ${before.length} slice(s) present but ` +
+        `unattributed, saw ${unattributed.length}`,
+    );
+
+    // 4. And nothing silently migrated to the other field.
+    for (const r of unattributed) {
+      assert.equal(
+        r.geometryItemId, undefined,
+        `air-gap slice #${r.expressId} adopted a geometryItemId instead of reporting nothing`,
+      );
     }
+  });
+
+  test('the prepass FACADE carries both ids, not just the raw collection', () => {
+    // This is the test the block header promises, and it exists because the
+    // facade is where this actually went wrong: `scripts/lib/mesh-via-prepass.mjs`
+    // mirrors `convertMeshCollectionToBatch` field by field, it did NOT copy the
+    // new ids, and my first probe read zeros through it and reported the wasm
+    // boundary broken when the boundary was fine.
+    //
+    // Every other test in this block reads the raw `MeshCollection`, which is
+    // UPSTREAM of the facade — so without this one the facade edit ships with no
+    // coverage at all, and a future field dropped there is invisible to every
+    // script that reads through it.
+    const meshes = parseMeshesViaPrePass(api, layeredContent);
+    let items = 0, materials = 0, both = 0;
+    for (let i = 0; i < meshes.length; i++) {
+      const m = meshes.get(i);
+      if (!m) continue;
+      const hasItem = m.geometryItemId !== undefined && m.geometryItemId !== null;
+      const hasMaterial = m.materialId !== undefined && m.materialId !== null;
+      if (hasItem && hasMaterial) both++;
+      else if (hasItem) items++;
+      else if (hasMaterial) materials++;
+      if (m.free) m.free();
+    }
+    if (meshes.free) meshes.free();
+
+    // Cross-check against the raw collection rather than against a fixed number:
+    // this asserts the facade agrees with the boundary, which is the actual
+    // contract, and it cannot go vacuous if the fixture changes.
+    const raw = layeredRows();
+    assert.equal(
+      items, raw.filter((r) => r.geometryItemId !== undefined).length,
+      'the facade dropped or invented geometryItemId relative to the raw collection',
+    );
+    assert.equal(
+      materials, raw.filter((r) => r.materialId !== undefined).length,
+      'the facade dropped or invented materialId relative to the raw collection',
+    );
+    assert.equal(both, 0, `${both} mesh(es) carried BOTH ids through the facade`);
+    assert.ok(items > 0 && materials > 0, `non-vacuity: items=${items} materials=${materials}`);
   });
 
   test('takeMesh reports the same ids as get, and stays read-once', () => {
     // The worker reads meshes with takeMesh and the main thread with get. They
     // build MeshDataJs separately, so a field added to one and forgotten in the
     // other is invisible until a browser session disagrees with a node one.
-    const viaGet = readIds(layeredContent);
+    const viaGet = layeredRows();
 
     const col = rawCollection(layeredContent);
     const viaTake = [];
@@ -1176,7 +1210,7 @@ if (LAYERED_AVAILABLE) {
           viaTake.push({
             expressId: m.expressId,
             geometryItemId: m.geometryItemId,
-            materialLayerId: m.materialLayerId,
+            materialId: m.materialId,
             vertexCount: m.vertexCount,
           });
         } finally {
@@ -1192,8 +1226,8 @@ if (LAYERED_AVAILABLE) {
           `mesh ${i} (#${viaGet[i].expressId}): takeMesh geometryItemId disagrees with get`,
         );
         assert.equal(
-          viaTake[i].materialLayerId, viaGet[i].materialLayerId,
-          `mesh ${i} (#${viaGet[i].expressId}): takeMesh materialLayerId disagrees with get`,
+          viaTake[i].materialId, viaGet[i].materialId,
+          `mesh ${i} (#${viaGet[i].expressId}): takeMesh materialId disagrees with get`,
         );
       }
       assert.ok(viaTake.some((r) => r.vertexCount > 0), 'the first take returned no geometry at all');
@@ -1208,7 +1242,7 @@ if (LAYERED_AVAILABLE) {
       assert.ok(again, 'a second takeMesh returned nothing at all');
       try {
         assert.equal(again.vertexCount, 0, 'a second takeMesh still returned vertex data');
-        for (const field of ['geometryItemId', 'materialLayerId']) {
+        for (const field of ['geometryItemId', 'materialId']) {
           const first = viaTake[0][field];
           assert.ok(
             again[field] === undefined || again[field] === first,

--- a/scripts/test-wasm-contract.mjs
+++ b/scripts/test-wasm-contract.mjs
@@ -890,6 +890,57 @@ if (COLUMN_AVAILABLE_FOR_LEGACY) {
   });
 }
 
+// ===== representation-item identity crosses the boundary, DISJOINT (#3199) =====
+//
+// The router already kept each representation item's STEP id and it already
+// reached the server REST payload; `MeshDataJs::from_mesh_data` simply did not
+// copy it, so the browser never saw it and a host could not drill from a
+// rendered piece to the entity that produced it (#2985).
+//
+// The half that needs pinning here rather than in Rust is the DISJOINTNESS.
+// For material-layered walls the same field used to carry the `IfcMaterial`
+// id, so following it to source landed on the wrong entity with nothing to warn
+// the caller. Two fields fix that only if they are never both set — a consumer
+// that ignores the distinction must still be unable to read one as the other.
+//
+// `geometryClass === 3` cannot substitute for the discriminator: it is stamped
+// from a static material-index check made BEFORE the geometry runs, while the
+// layered path can bail at runtime and emit representation-item submeshes under
+// that class. So this asserts the FIELDS, not the class.
+if (LAYERED_AVAILABLE) {
+  console.log('\n📋 representation-item identity (Rust → JS, #3199)');
+
+  test('every mesh carries at most ONE source id, and layered walls carry material ids', () => {
+    const collection = parseMeshesViaPrePass(api, readFileSync(LAYERED_IFC, 'utf-8'));
+    let items = 0, layers = 0, both = 0, neither = 0;
+    for (let i = 0; i < collection.length; i++) {
+      const m = collection.get(i);
+      if (!m) continue;
+      const hasItem = m.geometryItemId !== undefined && m.geometryItemId !== null;
+      const hasLayer = m.materialLayerId !== undefined && m.materialLayerId !== null;
+      if (hasItem && hasLayer) both++;
+      else if (hasItem) items++;
+      else if (hasLayer) layers++;
+      else neither++;
+      m.free();
+    }
+    collection.free();
+
+    // THE invariant. Two fields that can both be set are one field with extra
+    // steps, and the confusion this change removes would survive.
+    assert.equal(both, 0, `${both} meshes carried BOTH a geometryItemId and a materialLayerId`);
+
+    // Non-vacuity, in both directions: the fixture must actually exercise each
+    // field, or "never both" is satisfied by never setting either.
+    assert.ok(items > 0, 'no mesh carried a geometryItemId — the identity is not crossing at all');
+    assert.ok(
+      layers > 0,
+      `no mesh carried a materialLayerId; duplex.ifc has multi-layer walls, so the layered ` +
+        `path should produce some (items=${items}, neither=${neither})`,
+    );
+  });
+}
+
 // ===== geometryClass ordinals, pinned at the real boundary =====
 //
 // `packages/geometry/src/geometry-class.ts` names these ordinals for the
@@ -932,6 +983,244 @@ if (LAYERED_AVAILABLE) {
       classes.has(0),
       `expected placed occurrences tagged 0; saw classes ${[...classes].sort().join(', ')}`,
     );
+  });
+}
+
+// ===== source ids: representation item vs material layer (#3199) =====
+//
+// A mesh carries EITHER the `IfcRepresentationItem` it was tessellated from
+// (`geometryItemId`) OR the `IfcMaterial` whose layer it slices
+// (`materialLayerId`), never both. Before #3199 both arrived in one field, so
+// following it to source landed on an IfcMaterial for layered walls with
+// nothing to warn the caller.
+//
+// These read the RAW `MeshCollection` rather than `parseMeshesViaPrePass`. The
+// facade copies a fixed list of fields out of each `MeshDataJs`, and that list
+// does not include either id — through it every mesh reads as carrying
+// neither, which is indistinguishable from wasm not emitting them at all. A
+// contract test that cannot tell those apart pins nothing.
+//
+// Wrong ids here are silent in the usual way: geometry renders identically and
+// only a host that follows the id to source sees it land on the wrong entity.
+if (LAYERED_AVAILABLE) {
+  console.log('\n📋 source ids: representation item vs material layer (#3199)');
+  const layeredContent = readFileSync(LAYERED_IFC, 'utf-8');
+
+  // The real `MeshCollection`, handles and all. Callers must free.
+  const rawCollection = (content) => {
+    const bytes = new TextEncoder().encode(content);
+    const pre = api.buildPrePassOnce(bytes);
+    const rtc = (pre && pre.rtcOffset) || [0, 0, 0];
+    try {
+      return api.processGeometryBatch(
+        bytes, pre.jobs, pre.unitScale, rtc[0] || 0, rtc[1] || 0, rtc[2] || 0, pre.needsShift,
+        pre.voidKeys, pre.voidCounts, pre.voidValues, pre.styleIds, pre.styleColors,
+      );
+    } finally {
+      if (api.clearPrePassCache) api.clearPrePassCache();
+    }
+  };
+
+  /** Read every mesh's ids out of a fresh collection, freeing as we go. */
+  const readIds = (content) => {
+    const col = rawCollection(content);
+    const rows = [];
+    try {
+      for (let i = 0; i < col.length; i++) {
+        const m = col.get(i);
+        if (!m) continue;
+        try {
+          rows.push({
+            expressId: m.expressId,
+            geometryClass: m.geometryClass,
+            geometryItemId: m.geometryItemId,
+            materialLayerId: m.materialLayerId,
+          });
+        } finally {
+          m.free();
+        }
+      }
+    } finally {
+      col.free();
+    }
+    return rows;
+  };
+
+  test('every mesh carries exactly one source id, never both and never neither', () => {
+    const rows = readIds(layeredContent);
+    assert.ok(rows.length > 0, 'the fixture produced no meshes, so nothing below is pinned');
+    const both = rows.filter((r) => r.geometryItemId !== undefined && r.materialLayerId !== undefined);
+    const neither = rows.filter((r) => r.geometryItemId === undefined && r.materialLayerId === undefined);
+    assert.equal(both.length, 0, `${both.length} mesh(es) carry BOTH ids, e.g. #${both[0]?.expressId}`);
+    // "Neither" is a legitimate state elsewhere (the single-mesh fallback, the
+    // cached mapped-item path). It must not happen on THIS fixture, whose
+    // elements all go through the submesh channel — if it starts happening,
+    // the ids stopped crossing the boundary and the checks below go vacuous.
+    assert.equal(neither.length, 0, `${neither.length} mesh(es) carry NO id, e.g. #${neither[0]?.expressId}`);
+  });
+
+  test('a two-item element carries a distinct geometryItemId per piece, and no material id', () => {
+    const rows = readIds(layeredContent);
+    const byElement = new Map();
+    for (const r of rows) {
+      if (r.geometryItemId === undefined) continue;
+      let ids = byElement.get(r.expressId);
+      if (!ids) byElement.set(r.expressId, (ids = new Set()));
+      ids.add(r.geometryItemId);
+    }
+    const multi = [...byElement.entries()].filter(([, ids]) => ids.size >= 2);
+    assert.ok(
+      multi.length > 0,
+      'no element produced two distinct geometryItemIds — either the fixture stopped ' +
+        'producing multi-item elements, or every piece is being stamped with the same id',
+    );
+    // An express id, not a slot index: 0 is never a valid STEP instance name.
+    for (const [, ids] of byElement) {
+      for (const id of ids) {
+        assert.ok(Number.isInteger(id) && id > 0, `geometryItemId ${id} is not a plausible express id`);
+      }
+    }
+    // The pieces of a multi-item element are representation items, so none of
+    // them may also claim to be a material layer.
+    const multiIds = new Set(multi.map(([expressId]) => expressId));
+    const stray = rows.filter((r) => multiIds.has(r.expressId) && r.materialLayerId !== undefined);
+    assert.equal(stray.length, 0, `a multi-item element also reported a materialLayerId: #${stray[0]?.expressId}`);
+  });
+
+  test('a material-layered wall reports materialLayerId, and geometryItemId undefined', () => {
+    const rows = readIds(layeredContent);
+    const sliced = rows.filter((r) => r.materialLayerId !== undefined);
+    assert.ok(sliced.length > 0, 'no mesh carried a materialLayerId — the layer slicer did not run');
+    for (const r of sliced) {
+      assert.equal(
+        r.geometryItemId, undefined,
+        `#${r.expressId} carries a materialLayerId AND a geometryItemId`,
+      );
+      // A slice is layer geometry, so it must also be tagged class 3.
+      assert.equal(r.geometryClass, 3, `#${r.expressId} carries a materialLayerId at class ${r.geometryClass}`);
+    }
+  });
+
+  test('geometryClass 3 does NOT imply a material id: a bailed slice keeps its item id', () => {
+    // The contract clause most likely to be "simplified" away later, so it gets
+    // its own executable pin.
+    //
+    // geometryClass is stamped from `is_material_layer_sliceable`, a STATIC
+    // check on the material index made before any geometry runs.
+    // `try_layered_sub_meshes` can still bail at runtime (the cut produced
+    // fewer than two slabs, a void CSG errored) and fall through to the
+    // representation-item path — under class 3. Deriving which id a mesh
+    // carries from geometryClass would therefore hand back an IfcMaterial id
+    // for meshes whose id is an IfcRepresentationItem: the exact confusion
+    // #3199 removed, reintroduced one refactor later.
+    const rows = readIds(layeredContent);
+    const classThree = rows.filter((r) => r.geometryClass === 3);
+    assert.ok(classThree.length > 0, 'no class-3 meshes at all — this pins nothing');
+    const bailed = classThree.filter((r) => r.geometryItemId !== undefined);
+    assert.ok(
+      bailed.length > 0,
+      'every class-3 mesh carried a materialLayerId, so this fixture can no longer ' +
+        'distinguish "the flag comes from the collection" from "the flag is derived ' +
+        'from geometryClass" — find a fixture whose layer slicing bails at runtime',
+    );
+    for (const r of bailed) {
+      assert.equal(r.materialLayerId, undefined, `#${r.expressId} carries both ids`);
+    }
+  });
+
+  test('an air-gap layer crosses as materialLayerId 0, which is a value and not a hole', () => {
+    // IfcMaterialLayer.Material is OPTIONAL, and an absent one decodes to
+    // material_id 0. Dropping the Material ref from one layer of the fixture
+    // changes ONE token and nothing else, so the id is the only variable.
+    //
+    // 0 is falsy. Any consumer that tests truthiness, or any encoding that
+    // uses 0 to mean "absent", silently loses the air-gap layer.
+    const withMaterial = /IFCMATERIALLAYER\(#3876,/g;
+    assert.ok(
+      withMaterial.test(layeredContent),
+      'the fixture no longer has the layer this test edits — pick another IFCMATERIALLAYER',
+    );
+    const airGap = layeredContent.replace(withMaterial, 'IFCMATERIALLAYER($,');
+
+    const before = readIds(layeredContent).filter((r) => r.materialLayerId === 3876);
+    assert.ok(before.length > 0, 'material #3876 sliced no layers, so the edit below proves nothing');
+
+    const after = readIds(airGap).filter((r) => r.geometryClass === 3);
+    const zeros = after.filter((r) => r.materialLayerId === 0);
+    assert.equal(
+      zeros.length, before.length,
+      `dropping the material ref should turn ${before.length} slices into materialLayerId 0, saw ${zeros.length}`,
+    );
+    assert.ok(
+      !after.some((r) => r.materialLayerId === 3876),
+      'a slice still reports the material id that was removed from the file',
+    );
+    for (const r of zeros) {
+      assert.equal(r.geometryItemId, undefined, `air-gap slice #${r.expressId} also carries a geometryItemId`);
+    }
+  });
+
+  test('takeMesh reports the same ids as get, and stays read-once', () => {
+    // The worker reads meshes with takeMesh and the main thread with get. They
+    // build MeshDataJs separately, so a field added to one and forgotten in the
+    // other is invisible until a browser session disagrees with a node one.
+    const viaGet = readIds(layeredContent);
+
+    const col = rawCollection(layeredContent);
+    const viaTake = [];
+    try {
+      for (let i = 0; i < col.length; i++) {
+        const m = col.takeMesh(i);
+        if (!m) continue;
+        try {
+          viaTake.push({
+            expressId: m.expressId,
+            geometryItemId: m.geometryItemId,
+            materialLayerId: m.materialLayerId,
+            vertexCount: m.vertexCount,
+          });
+        } finally {
+          m.free();
+        }
+      }
+
+      assert.equal(viaTake.length, viaGet.length, 'takeMesh and get disagree on how many meshes there are');
+      for (let i = 0; i < viaTake.length; i++) {
+        assert.equal(viaTake[i].expressId, viaGet[i].expressId, `mesh ${i}: express ids diverged`);
+        assert.equal(
+          viaTake[i].geometryItemId, viaGet[i].geometryItemId,
+          `mesh ${i} (#${viaGet[i].expressId}): takeMesh geometryItemId disagrees with get`,
+        );
+        assert.equal(
+          viaTake[i].materialLayerId, viaGet[i].materialLayerId,
+          `mesh ${i} (#${viaGet[i].expressId}): takeMesh materialLayerId disagrees with get`,
+        );
+      }
+      assert.ok(viaTake.some((r) => r.vertexCount > 0), 'the first take returned no geometry at all');
+
+      // Read-once: takeMesh MOVES the vertex data out, so a second call for the
+      // same index yields an empty mesh. Pinned because the ids are Copy and
+      // ride along by field assignment today — a switch to `mem::take` on the
+      // whole struct would change what a second call reports, and this suite
+      // should be the thing that notices rather than a viewer that renders a
+      // mesh twice.
+      const again = col.takeMesh(0);
+      assert.ok(again, 'a second takeMesh returned nothing at all');
+      try {
+        assert.equal(again.vertexCount, 0, 'a second takeMesh still returned vertex data');
+        for (const field of ['geometryItemId', 'materialLayerId']) {
+          const first = viaTake[0][field];
+          assert.ok(
+            again[field] === undefined || again[field] === first,
+            `a second takeMesh reported a DIFFERENT ${field} (${again[field]} vs ${first})`,
+          );
+        }
+      } finally {
+        again.free();
+      }
+    } finally {
+      col.free();
+    }
   });
 }
 


### PR DESCRIPTION
Closes #3199. Raised by #2985.

The router already keeps each representation item's STEP id, and it already reaches the server REST payload. `MeshDataJs::from_mesh_data` did not copy it — so the browser never saw it, and a host could not drill from a rendered piece into an `IfcWindow`'s pane or frame and navigate to that entity in source.

**And it was wrong for layered walls.** `router/layers.rs` pushes `SubMesh::new(layer.material_id, slab)`, so for material-layered walls and slabs the same field carried an `IfcMaterial` id. Following it to source landed on the wrong entity, with nothing to tell the caller which kind of id it had.

## Two disjoint fields

`geometryItemId` is always a representation item. `materialLayerId` is always an `IfcMaterial`. **Never both** — so a consumer that ignores the distinction still cannot read one as the other.

`with_style_metadata` takes the **discriminator** rather than the destination field. A two-setter API would leave the confusion one typo away.

**The discriminator lives on `SubMeshCollection`**, set where the layered slabs are built, because it is a property of how the collection was built and uniform across it. `geometryClass === 3` cannot answer it, and I checked rather than assumed: that class is stamped in `element.rs` from `is_material_layer_sliceable` — a static material-index check made *before* the geometry runs — while `try_layered_sub_meshes` can still return `None` at several points and fall through to the representation-item path. Rep-item ids can carry class 3.

The voided rebuild in `voids/mod.rs` **inherits** the flag rather than hard-coding rep-item. It's false there today, but hard-coding would let a future layered producer be silently relabelled.

## Cache format v14

`sections/geometry.ts` writes `MeshData` field by field, so without this a cache-restored session loses the identity.

Bumped rather than read leniently: the record is positional, so a v13 reader handed a v14 record would take the origin's first f64 out of the two new u32 and everything after it would be garbage. A v14 reader still reads v13 records — the fields are version-gated and degrade to `undefined`, the same state the runtime uses where identity is genuinely merged away. **An old cache degrades to "unknown", never to a wrong id.**

**The absent sentinel is `0xFFFFFFFF`, not `0` — and a test caught me getting this wrong.** `layers.rs` uses `0` for a layer with no material, an air gap, so 0 is a real value that must round trip. The first version treated it as absent, which is the valid-but-falsy trap, and it would have dropped exactly the layers that are hardest to notice missing. Every read now compares against the sentinel or `undefined`; nothing tests these ids for truthiness.

## Verified at the real boundary

```
duplex.ifc through processGeometryBatch:
  436 meshes with geometryItemId
  186 meshes with materialLayerId
  BOTH = 0        neither = 0
```

**Paired probe:** conflating the two fields (setting both, as before the fix) turns the new contract test red with `186 meshes carried BOTH`.

The contract test asserts non-vacuity in **both** directions — some mesh must carry each field — because "never both" is satisfied trivially by never setting either.

## Module size

Five Rust rows are raised with a per-row justification and the digest re-pinned. Adding a field to a boundary struct necessarily grows the boundary file, and `zero_copy/mesh.rs` cannot absorb 2 fields + 2 getters + a paired setter + propagation at three clone sites within its budget.

The TS allowlist forbids raises outright — *"budgets ratchet DOWN only"* — so `types.ts` was **split** instead: the self-contained symbolic-representation family moves to `symbolic-types.ts`, re-exported so the public surface is unchanged. That takes `types.ts` from 459 to 381 and lets its row be **deleted**, which is what the gate asks for. The worker is back to exactly its budget.

## One instrument bug found on the way

`scripts/lib/mesh-via-prepass.mjs` mirrors `convertMeshCollectionToBatch` field by field, so it silently dropped the new ids and my first probe read zeros through it. A field the real converter carries and that facade drops is invisible to every script reading through it — fixed here.

## Verification

2162 Rust tests · clippy `-D warnings` clean · 621 script tests · 106 cache tests · 73 wasm-contract assertions · typecheck clean · module-size gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meshes now preserve separate representation-item and material identifiers across processing, WASM, server, and viewer workflows.
  * Added public symbolic representation types, including primitives, collections, annotations, and truncation metadata.
  * Air-gap geometry remains available without emitting invalid material identifiers.

* **Bug Fixes**
  * Improved provenance tracking for layered, mapped, nested, styled, and void-processed geometry.
  * Cache format updated to version 14, with support for reading version 13 records.

* **Tests**
  * Added coverage for identifier preservation, zero values, exclusivity, air gaps, and legacy cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->