### PR TITLE
fix: lint examples/, and make check-doc-samples read its compiler's result (#3200)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,12 +100,13 @@ jobs:
               # whoever touches the frontend next. Add it here when you add it.
               - 'apps/viewer/**'
               - 'apps/viewer-embed/**'
-              - 'packages/**'
-              # `examples/*` is a workspace glob and, since #3200, a lint
-              # target. Without it here a PR touching only an example skips the
-              # one job that lints it - the same "guard exists and never fires"
-              # shape the two comments above warn about.
+              # `examples/*` is a pnpm-workspace member and is now a lint target
+              # (scripts/check-lint-ran.mjs). Without it here, an examples-only
+              # PR leaves `frontend` false, the Lint job never runs, and the new
+              # target protects nothing on the PRs that change those files --
+              # the same trap the comment above describes for `apps/`.
               - 'examples/**'
+              - 'packages/**'
               - 'tests/e2e/**'
               - 'playwright.config.ts'
               # The relay handlers and their tests. `pnpm test:api` runs in this
@@ -729,6 +730,20 @@ jobs:
       # the real sources, plus a deleted arm and the #3172 misspelling itself.
       - name: Check legacy entity coverage gate regressions
         run: node --test scripts/check-legacy-entity-coverage.test.mjs
+      # `|| true` on `git tag` is right (a re-run hits an existing tag);
+      # on the PUSH it made a failed push silent, and `gh release create` then
+      # creates the missing tag ITSELF at default-branch head -- so the run
+      # stayed green with the tag on a different commit than the packages
+      # published from it (#3202). Baseline is zero: this gate landed in the
+      # same change that removed the only two instances.
+      - name: Check for swallowed git push failures
+        run: node scripts/check-swallowed-push.mjs
+      # Executable proof it cannot pass vacuously: a missing or empty workflow
+      # directory must fail rather than report clean, and `|| true` on `git tag`
+      # must NOT be flagged -- a rule that caught both would be suppressed on
+      # its first run.
+      - name: Check swallowed-push gate regressions
+        run: node --test scripts/check-swallowed-push.test.mjs
       # The CSV cell escaper reached NINE hand-rolled copies and no two were
       # identical: some tested the formula trigger anchored at offset 0 (so a
       # BOM/ZWSP/LRM/NBSP/U+2028 in front of `=` bypassed the CWE-1236 guard),

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -908,8 +908,10 @@ jobs:
       # per-gate attribution; re-running them here costs a few seconds.
       # scripts/fixtures/ is in the glob because it was NOT: the first test file
       # under it would have been added, run locally, and then never run again.
+      # scripts/docs/ joined it for the same reason in #3200 - the catch-all is
+      # per-DIRECTORY, so it goes blind on the next subdirectory anyone adds.
       - name: Run every scripts/ test file (glob catch-all)
-        run: node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs
+        run: node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs scripts/docs/*.test.mjs
       # The server-parse root-attribute table (attr_indices.rs) is generated
       # from @ifc-lite/parser's SCHEMA_REGISTRY — the SAME table the in-browser
       # parse resolves names against. Guard that the committed file is in sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,11 @@ jobs:
               - 'apps/viewer/**'
               - 'apps/viewer-embed/**'
               - 'packages/**'
+              # `examples/*` is a workspace glob and, since #3200, a lint
+              # target. Without it here a PR touching only an example skips the
+              # one job that lints it - the same "guard exists and never fires"
+              # shape the two comments above warn about.
+              - 'examples/**'
               - 'tests/e2e/**'
               - 'playwright.config.ts'
               # The relay handlers and their tests. `pnpm test:api` runs in this

--- a/examples/babylonjs-viewer/src/main.ts
+++ b/examples/babylonjs-viewer/src/main.ts
@@ -264,7 +264,7 @@ fileInput.addEventListener('change', async () => {
     let streamMaxX = -Infinity, streamMaxY = -Infinity, streamMaxZ = -Infinity;
     let hasStreamBounds = false;
 
-    function expandStreamBoundsFromMeshes(meshes: MeshData[]) {
+    const expandStreamBoundsFromMeshes = (meshes: MeshData[]) => {
       for (const m of meshes) {
         const p = m.positions;
         for (let i = 0; i < p.length; i += 3) {
@@ -280,9 +280,9 @@ fileInput.addEventListener('change', async () => {
         }
       }
       hasStreamBounds = true;
-    }
+    };
 
-    function getStreamBounds(): { center: Vector3; maxDim: number } | null {
+    const getStreamBounds = (): { center: Vector3; maxDim: number } | null => {
       if (!hasStreamBounds) return null;
       const center = new Vector3(
         (streamMinX + streamMaxX) / 2,
@@ -295,13 +295,13 @@ fileInput.addEventListener('change', async () => {
       const maxDim = Math.max(sizeX, sizeY, sizeZ);
       if (maxDim <= 0 || !isFinite(maxDim)) return null;
       return { center, maxDim };
-    }
+    };
 
-    function fitIfDue() {
+    const fitIfDue = () => {
       const bounds = getStreamBounds();
       if (!bounds) return;
       applyCameraFit(bounds.center, bounds.maxDim, false);
-    }
+    };
 
     streamRoot = new TransformNode('stream-root', scene);
 

--- a/examples/babylonjs-viewer/src/main.ts
+++ b/examples/babylonjs-viewer/src/main.ts
@@ -280,7 +280,7 @@ fileInput.addEventListener('change', async () => {
         }
       }
       hasStreamBounds = true;
-    };
+    }
 
     const getStreamBounds = (): { center: Vector3; maxDim: number } | null => {
       if (!hasStreamBounds) return null;
@@ -295,13 +295,13 @@ fileInput.addEventListener('change', async () => {
       const maxDim = Math.max(sizeX, sizeY, sizeZ);
       if (maxDim <= 0 || !isFinite(maxDim)) return null;
       return { center, maxDim };
-    };
+    }
 
     const fitIfDue = () => {
       const bounds = getStreamBounds();
       if (!bounds) return;
       applyCameraFit(bounds.center, bounds.maxDim, false);
-    };
+    }
 
     streamRoot = new TransformNode('stream-root', scene);
 

--- a/examples/threejs-viewer/src/main.ts
+++ b/examples/threejs-viewer/src/main.ts
@@ -269,7 +269,7 @@ fileInput.addEventListener('change', async () => {
         }
       }
       hasStreamBounds = true;
-    };
+    }
 
     const getStreamBounds = (): { center: THREE.Vector3; maxDim: number } | null => {
       if (!hasStreamBounds) return null;
@@ -284,13 +284,13 @@ fileInput.addEventListener('change', async () => {
       const maxDim = Math.max(sizeX, sizeY, sizeZ);
       if (maxDim <= 0 || !isFinite(maxDim)) return null;
       return { center, maxDim };
-    };
+    }
 
     const fitIfDue = () => {
       const bounds = getStreamBounds();
       if (!bounds) return;
       applyCameraFit(bounds.center, bounds.maxDim, false);
-    };
+    }
 
     for await (const event of geometry.processStreaming(buffer)) {
       switch (event.type) {

--- a/examples/threejs-viewer/src/main.ts
+++ b/examples/threejs-viewer/src/main.ts
@@ -253,7 +253,7 @@ fileInput.addEventListener('change', async () => {
     let streamMaxX = -Infinity, streamMaxY = -Infinity, streamMaxZ = -Infinity;
     let hasStreamBounds = false;
 
-    function expandStreamBoundsFromMeshes(meshes: MeshData[]) {
+    const expandStreamBoundsFromMeshes = (meshes: MeshData[]) => {
       for (const m of meshes) {
         const p = m.positions;
         for (let i = 0; i < p.length; i += 3) {
@@ -269,9 +269,9 @@ fileInput.addEventListener('change', async () => {
         }
       }
       hasStreamBounds = true;
-    }
+    };
 
-    function getStreamBounds(): { center: THREE.Vector3; maxDim: number } | null {
+    const getStreamBounds = (): { center: THREE.Vector3; maxDim: number } | null => {
       if (!hasStreamBounds) return null;
       const center = new THREE.Vector3(
         (streamMinX + streamMaxX) / 2,
@@ -284,13 +284,13 @@ fileInput.addEventListener('change', async () => {
       const maxDim = Math.max(sizeX, sizeY, sizeZ);
       if (maxDim <= 0 || !isFinite(maxDim)) return null;
       return { center, maxDim };
-    }
+    };
 
-    function fitIfDue() {
+    const fitIfDue = () => {
       const bounds = getStreamBounds();
       if (!bounds) return;
       applyCameraFit(bounds.center, bounds.maxDim, false);
-    }
+    };
 
     for await (const event of geometry.processStreaming(buffer)) {
       switch (event.type) {

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -162,7 +162,15 @@ function main() {
     return 1;
   }
   const covered = new Set(TARGETS.map((t) => t.dir));
-  const uncovered = [...new Set(ws.globs.map((g) => g.split('/')[0]))].filter((d) => !covered.has(d));
+  // pnpm supports EXCLUSION globs (a leading `!`, e.g. `!packages/legacy-thing`)
+  // as a documented workspace feature: they narrow an inclusion glob, they do
+  // not declare a new place to lint. Cross-checking them against TARGETS made
+  // a legitimate exclusion fail the gate with a message naming a directory
+  // that does not exist (`!packages/`) - exactly the "gate blocks a
+  // legitimate change" shape this whole line of work exists to prevent.
+  const uncovered = [...new Set(ws.globs.filter((g) => !g.startsWith('!')).map((g) => g.split('/')[0]))].filter(
+    (d) => !covered.has(d),
+  );
   if (uncovered.length > 0) {
     console.error('lint: a workspace glob is outside this gate\'s target list, so the code there is');
     console.error('      never linted and no floor can notice:\n');

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -32,11 +32,9 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { readFileSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-
-const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+import { resolve } from 'node:path';
 
 /**
  * Where the source actually is, and how small each place is allowed to get.
@@ -52,56 +50,95 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
  * The floors sit well under today's counts: deleting a genuine chunk of code
  * must not fail the lint lane, but a target dropping out cannot hide.
  */
-const TARGETS = [
+export const TARGETS = [
   { dir: 'apps', min: 900 },
   { dir: 'packages', min: 1200 },
   { dir: 'scripts', min: 100 },
-  // `examples/*` is a pnpm workspace glob, and it was outside this list until
-  // #3200. Nobody had widened an ignore or renamed anything: the directory had
-  // simply never been passed to oxlint, so six error-tier
-  // `eslint(no-inner-declarations)` violations sat in shipped sample code while
-  // the Lint job was green. Measured on a healthy tree: 17 files across four
-  // examples. The floor is 10 - low enough that retiring an example does not
-  // force an edit here, high enough that the whole target dropping out cannot
-  // pass.
-  { dir: 'examples', min: 10 },
+  { dir: 'examples', min: 15 },
 ];
 
 /**
- * Every workspace glob must be lintable through one of the TARGETS above.
+ * The floors above catch a target that SHRANK. They cannot catch a target that
+ * was never in the list — a directory absent from `TARGETS` is not counted low,
+ * it is not counted at all, and the success line still reads "no errors".
  *
- * The floors catch a target that SHRANK. They cannot catch a target that was
- * never in the list, and that is exactly how `examples/*` stayed unlinted:
- * the gate was working perfectly on everything it looked at, and nothing
- * noticed that `pnpm-workspace.yaml` declared a fourth place to look. So the
- * declaration is read at run time and cross-checked, and a workspace member
- * that no target covers fails here rather than going quietly unlinted for
- * however long it takes someone to run oxlint by hand.
+ * That is not hypothetical. `examples/` is a declared `pnpm-workspace.yaml`
+ * member and was never passed to oxlint, so six error-tier
+ * `eslint(no-inner-declarations)` violations sat in `examples/threejs-viewer`
+ * and `examples/babylonjs-viewer` while the Lint job was green (#3200,
+ * finding 3). Adding `examples` to `TARGETS` fixes that instance. This
+ * function is what stops the NEXT one: the workspace file is the declaration of
+ * where first-party source lives, so a glob that appears there and not here is
+ * a gap by construction, and it fails loudly rather than being linted by
+ * nobody.
+ *
+ * Deliberately one-directional. A `TARGETS` entry with no workspace glob
+ * (`scripts/`) is fine and expected — this asks only that nothing DECLARED is
+ * unlinted.
  */
-function workspaceGlobs() {
-  const path = join(ROOT, 'pnpm-workspace.yaml');
-  let text;
+function uncoveredWorkspaceGlobs() {
+  let raw;
   try {
-    text = readFileSync(path, 'utf8');
+    raw = readFileSync('pnpm-workspace.yaml', 'utf8');
   } catch (err) {
-    // A missing or unreadable manifest is not "no workspace globs to check" -
-    // that reading is how an absent input becomes a clean report (#3194).
-    return { error: `could not read ${path}: ${err?.code ?? err?.message}` };
+    console.error(`lint: could not read pnpm-workspace.yaml: ${err.message}`);
+    return null;
   }
-
-  // `packages:` at column 0, then its `- 'glob'` items until the block ends.
-  const lines = text.split('\n');
-  const start = lines.findIndex((l) => /^packages:\s*$/.test(l));
-  if (start === -1) return { error: `${path} has no top-level \`packages:\` key` };
-
-  const globs = [];
-  for (const line of lines.slice(start + 1)) {
-    if (/^\s*(#.*)?$/.test(line)) continue;
-    const item = /^\s+-\s*['"]?([^'"#]+?)['"]?\s*(#.*)?$/.exec(line);
-    if (!item) break; // dedented back to another top-level key
-    globs.push(item[1]);
+  // Only the `packages:` block. Scoping matters: `onlyBuiltDependencies` lists
+  // scoped npm names (`@swc/core`) that also contain a slash, and a whole-file
+  // scan reads those as workspace roots and demands lint targets for `@swc/`.
+  // Stop at the next top-level key — a line with no leading whitespace.
+  const roots = new Set();
+  let inPackages = false;
+  let entryLines = 0;
+  let parsedEntries = 0;
+  for (const line of raw.split('\n')) {
+    // A comment is legal YAML at ANY column, so a `#` at column 0 is not a new
+    // top-level key. Treating it as one ended the parse early and dropped every
+    // entry after it -- and because the count it printed was the count of what
+    // it did read, the log said "all covered". Skip comments before the
+    // block-boundary test, not after.
+    if (/^\s*#/.test(line) || line.trim() === '') continue;
+    if (/^\S/.test(line)) inPackages = /^packages\s*:/.test(line);
+    if (!inPackages) continue;
+    // Every `-` in the block is an entry this function is responsible for. If
+    // one does not parse -- a bare `-` with its value on the next line, or any
+    // shape not yet met -- that is a SHORT read, and a short read is exactly
+    // what makes a missing glob invisible. Counted here, enforced below.
+    if (/^\s*-/.test(line)) entryLines += 1;
+    // Capture the whole entry, THEN take the first segment. Requiring a
+    // trailing slash in the pattern silently dropped a member declared as a
+    // bare directory (`- 'tools'`, `- '.'`, both legal pnpm): it was not
+    // counted, so it was not demanded, and the gate printed "all covered".
+    // That is the absence-reads-as-success failure this function exists to
+    // stop, one shape over. Two further shapes failed open after that fix --
+    // a `#` comment at column 0, and a bare `-` with its value on the next
+    // line -- which is why the entry-count check above exists rather than
+    // another special case per shape.
+    const m = /^\s*-\s*['"]?([^'"\s]+)/.exec(line);
+    if (!m) continue;
+    // `- '!packages/legacy/**'` is an EXCLUSION, not a member. Left in, it
+    // demands a `{ dir: '!packages' }` target that would then be handed to
+    // oxlint -- a failure with no satisfiable remedy.
+    if (m[1].startsWith('!')) { parsedEntries += 1; continue; }
+    parsedEntries += 1;
+    roots.add(m[1].split('/')[0]);
   }
-  return { globs };
+  if (roots.size === 0) {
+    console.error('lint: parsed no globs from pnpm-workspace.yaml — the format changed and this check is now blind.');
+    console.error('      (Flow style `packages: [...]` and dashes at column 0 both land here.)');
+    return null;
+  }
+  if (parsedEntries < entryLines) {
+    console.error(
+      `lint: parsed ${parsedEntries} of ${entryLines} entries in pnpm-workspace.yaml's packages: block.`,
+    );
+    console.error('      An entry this parser cannot read is a glob it cannot demand a lint target for,');
+    console.error('      so refusing rather than reporting on a short read.');
+    return null;
+  }
+  const covered = new Set(TARGETS.map((t) => t.dir));
+  return { missing: [...roots].filter((r) => !covered.has(r)), seen: roots.size };
 }
 
 /** oxlint's summary: "Finished in Xms on N files with M rules using K threads."
@@ -148,36 +185,13 @@ function lint(dir) {
  *  assigned to `process.exitCode` lets Node drain stdout, `process.exit()`
  *  does not. */
 function main() {
-  const ws = workspaceGlobs();
-  if (ws.error) {
-    console.error(`lint: ${ws.error}.`);
-    console.error('      Refusing a vacuous pass: this gate cross-checks its target list against the');
-    console.error('      workspace declaration, and it could not read the declaration.');
-    return 1;
-  }
-  if (ws.globs.length === 0) {
-    console.error('lint: pnpm-workspace.yaml declares no package globs.');
-    console.error('      Refusing a vacuous pass: an empty declaration would make the cross-check');
-    console.error('      below agree with any target list at all, including an empty one.');
-    return 1;
-  }
-  const covered = new Set(TARGETS.map((t) => t.dir));
-  // pnpm supports EXCLUSION globs (a leading `!`, e.g. `!packages/legacy-thing`)
-  // as a documented workspace feature: they narrow an inclusion glob, they do
-  // not declare a new place to lint. Cross-checking them against TARGETS made
-  // a legitimate exclusion fail the gate with a message naming a directory
-  // that does not exist (`!packages/`) - exactly the "gate blocks a
-  // legitimate change" shape this whole line of work exists to prevent.
-  const uncovered = [...new Set(ws.globs.filter((g) => !g.startsWith('!')).map((g) => g.split('/')[0]))].filter(
-    (d) => !covered.has(d),
-  );
-  if (uncovered.length > 0) {
-    console.error('lint: a workspace glob is outside this gate\'s target list, so the code there is');
-    console.error('      never linted and no floor can notice:\n');
-    for (const dir of uncovered) {
-      console.error(`      ${dir}/ is declared in pnpm-workspace.yaml but is not a lint target`);
-    }
-    console.error('\n      Add it to TARGETS with a measured floor (#3200).');
+  const coverage = uncoveredWorkspaceGlobs();
+  if (coverage === null) return 1; // it has already said why
+  if (coverage.missing.length > 0) {
+    console.error('lint: a pnpm-workspace.yaml glob is not in TARGETS, so its source is');
+    console.error('      linted by nobody and this gate would still report "no errors":\n');
+    for (const dir of coverage.missing) console.error(`      ${dir}/`);
+    console.error('\n      Add it to TARGETS with a floor, or remove it from the workspace.');
     return 1;
   }
 
@@ -210,8 +224,27 @@ function main() {
   }
 
   if (failed !== 0) return failed;
-  console.log(`lint: ${totalFiles.toLocaleString()} files across ${TARGETS.length} targets, ${ruleCount} rules, no errors.`);
+  console.log(`lint: ${totalFiles.toLocaleString()} files across ${TARGETS.length} targets (${coverage.seen} workspace globs, all covered), ${ruleCount} rules, no errors.`);
   return 0;
 }
 
-process.exitCode = main();
+/**
+ * Importable so the test can read `TARGETS` as DATA. It previously derived the
+ * count by regexing this file, which is a source-text assertion (AGENTS.md:136)
+ * -- it certifies that a string exists, so a reformat or a comment edit decides
+ * the test result instead of behaviour. Same entry-point shape as
+ * `check-refwalk-guards.mjs`: compare resolved PATHS, and fall back rather than
+ * letting the check take the process down if the path has vanished.
+ */
+function isMainEntry() {
+  const invoked = process.argv[1];
+  if (!invoked) return false;
+  const self = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(self) === realpathSync(invoked);
+  } catch {
+    return self === resolve(invoked);
+  }
+}
+
+if (isMainEntry()) process.exitCode = main();

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -32,6 +32,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 /**
  * Where the source actually is, and how small each place is allowed to get.
@@ -51,7 +56,53 @@ const TARGETS = [
   { dir: 'apps', min: 900 },
   { dir: 'packages', min: 1200 },
   { dir: 'scripts', min: 100 },
+  // `examples/*` is a pnpm workspace glob, and it was outside this list until
+  // #3200. Nobody had widened an ignore or renamed anything: the directory had
+  // simply never been passed to oxlint, so six error-tier
+  // `eslint(no-inner-declarations)` violations sat in shipped sample code while
+  // the Lint job was green. Measured on a healthy tree: 17 files across four
+  // examples. The floor is 10 - low enough that retiring an example does not
+  // force an edit here, high enough that the whole target dropping out cannot
+  // pass.
+  { dir: 'examples', min: 10 },
 ];
+
+/**
+ * Every workspace glob must be lintable through one of the TARGETS above.
+ *
+ * The floors catch a target that SHRANK. They cannot catch a target that was
+ * never in the list, and that is exactly how `examples/*` stayed unlinted:
+ * the gate was working perfectly on everything it looked at, and nothing
+ * noticed that `pnpm-workspace.yaml` declared a fourth place to look. So the
+ * declaration is read at run time and cross-checked, and a workspace member
+ * that no target covers fails here rather than going quietly unlinted for
+ * however long it takes someone to run oxlint by hand.
+ */
+function workspaceGlobs() {
+  const path = join(ROOT, 'pnpm-workspace.yaml');
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch (err) {
+    // A missing or unreadable manifest is not "no workspace globs to check" -
+    // that reading is how an absent input becomes a clean report (#3194).
+    return { error: `could not read ${path}: ${err?.code ?? err?.message}` };
+  }
+
+  // `packages:` at column 0, then its `- 'glob'` items until the block ends.
+  const lines = text.split('\n');
+  const start = lines.findIndex((l) => /^packages:\s*$/.test(l));
+  if (start === -1) return { error: `${path} has no top-level \`packages:\` key` };
+
+  const globs = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^\s*(#.*)?$/.test(line)) continue;
+    const item = /^\s+-\s*['"]?([^'"#]+?)['"]?\s*(#.*)?$/.exec(line);
+    if (!item) break; // dedented back to another top-level key
+    globs.push(item[1]);
+  }
+  return { globs };
+}
 
 /** oxlint's summary: "Finished in Xms on N files with M rules using K threads."
  *  Anchored on "Finished in", and the LAST match wins: the pattern alone can
@@ -97,6 +148,31 @@ function lint(dir) {
  *  assigned to `process.exitCode` lets Node drain stdout, `process.exit()`
  *  does not. */
 function main() {
+  const ws = workspaceGlobs();
+  if (ws.error) {
+    console.error(`lint: ${ws.error}.`);
+    console.error('      Refusing a vacuous pass: this gate cross-checks its target list against the');
+    console.error('      workspace declaration, and it could not read the declaration.');
+    return 1;
+  }
+  if (ws.globs.length === 0) {
+    console.error('lint: pnpm-workspace.yaml declares no package globs.');
+    console.error('      Refusing a vacuous pass: an empty declaration would make the cross-check');
+    console.error('      below agree with any target list at all, including an empty one.');
+    return 1;
+  }
+  const covered = new Set(TARGETS.map((t) => t.dir));
+  const uncovered = [...new Set(ws.globs.map((g) => g.split('/')[0]))].filter((d) => !covered.has(d));
+  if (uncovered.length > 0) {
+    console.error('lint: a workspace glob is outside this gate\'s target list, so the code there is');
+    console.error('      never linted and no floor can notice:\n');
+    for (const dir of uncovered) {
+      console.error(`      ${dir}/ is declared in pnpm-workspace.yaml but is not a lint target`);
+    }
+    console.error('\n      Add it to TARGETS with a measured floor (#3200).');
+    return 1;
+  }
+
   let totalFiles = 0;
   let ruleCount = 0;
   let failed = 0;

--- a/scripts/check-lint-ran.test.mjs
+++ b/scripts/check-lint-ran.test.mjs
@@ -25,8 +25,41 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+
+/**
+ * Import the gate's TARGETS as DATA. This test asserted a literal 3 and the
+ * literal string "across 3 targets"; adding `examples` turned it red (0 pass /
+ * 2 fail) with nothing wrong in the gate, and CI runs it (test.yml:829).
+ *
+ * The first fix regexed the gate's SOURCE TEXT for the count, which is the
+ * practice AGENTS.md:136 bans: it certifies a string exists, so a reformat or
+ * a comment edit would decide the result instead of behaviour. Importing the
+ * array is the same desync-immunity from the value the gate actually uses.
+ */
+const { TARGETS } = await import('./check-lint-ran.mjs');
+const TARGET_COUNT = TARGETS.length;
+assert.ok(TARGET_COUNT > 0, 'could not read TARGETS out of check-lint-ran.mjs — this test is now blind');
+
+/**
+ * A floor, not a mirror. Deriving the count from the gate makes this test
+ * desync-proof, but on its own it also makes it BLIND: delete
+ * `{ dir: 'scripts' }` and both the gate and the derived count drop to 3
+ * together, the assertions still agree, and ~140 files including this gate go
+ * unlinted with the suite green. Measured — that mutation passed 2/2 with the
+ * derived count alone, and reds 2/2 with this line.
+ *
+ * `uncoveredWorkspaceGlobs()` only protects targets that are ALSO workspace
+ * globs, so `scripts/` has no other guard. Ratchets up only: adding a target is
+ * a deliberate edit here, removing one has to be.
+ */
+const MIN_TARGETS = 4;
+assert.ok(
+  TARGET_COUNT >= MIN_TARGETS,
+  `check-lint-ran.mjs has ${TARGET_COUNT} lint targets, expected at least ${MIN_TARGETS} — ` +
+    'a target was removed, so its directory is now linted by nobody',
+);
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -39,12 +72,6 @@ const ROOT = join(HERE, '..');
  *  past any pipe buffer (~64KiB on Linux and macOS). 40k lines per target is
  *  ~3MiB, the order of magnitude a failing oxlint run over this repo produces. */
 const LINES_PER_TARGET = 40_000;
-
-/** How many directories the gate lints, read from the gate itself rather than
- *  hard-coded: adding a target (as #3200 added `examples`) must not require
- *  editing arithmetic in this file, and a test that silently expected the old
- *  count would assert on a run that had stopped covering a directory. */
-const TARGET_COUNT = (readFileSync(GATE, 'utf8').match(/^\s*\{ dir: '/gm) ?? []).length;
 const TAIL_MARKER = 'LAST-DIAGNOSTIC-LINE';
 
 /**
@@ -125,127 +152,15 @@ test('a clean lint still reports its own summary line through a pipe', () => {
   try {
     const run = runGate(bin);
     assert.equal(run.status, 0, `expected exit 0, got ${run.status}\n${run.stderr}`);
-    // 2,000 files per target from the shim, one line per target.
-    const total = (2_000 * TARGET_COUNT).toLocaleString('en-US');
+    // 2,000 files per target from the shim, three targets.
     assert.match(
       run.stdout,
-      new RegExp(`lint: ${total} files across ${TARGET_COUNT} targets, 300 rules, no errors\\.`),
+      new RegExp(
+        `lint: ${(2000 * TARGET_COUNT).toLocaleString()} files across ${TARGET_COUNT} targets ` +
+          '\\(\\d+ workspace globs, all covered\\), 300 rules, no errors\\.',
+      ),
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-// --- #3200: a workspace glob outside the target list must be loud ---
-//
-// The floors catch a target that shrank. They could not catch `examples/*`,
-// which was declared in pnpm-workspace.yaml and simply never passed to oxlint:
-// six error-tier `eslint(no-inner-declarations)` violations sat in shipped
-// sample code while `node scripts/check-lint-ran.mjs` exited 0. Measured on
-// upstream/main before the fix:
-//
-//   $ npx oxlint examples | grep -c ": error "
-//   6
-//   $ node scripts/check-lint-ran.mjs ; echo $?
-//   0
-//
-// The cross-check runs BEFORE any oxlint spawn, so these cases need no shim:
-// a copy of the gate beside a synthetic pnpm-workspace.yaml is the whole
-// reproduction, exactly as the gate derives its ROOT from its own location.
-
-/** A throwaway repo root holding `scripts/check-lint-ran.mjs` and the given
- *  `pnpm-workspace.yaml` body (omit it to leave the file out entirely). */
-function fakeRoot(workspaceYaml) {
-  const dir = mkdtempSync(join(tmpdir(), 'check-lint-ran-ws-'));
-  mkdirSync(join(dir, 'scripts'));
-  writeFileSync(join(dir, 'scripts', 'check-lint-ran.mjs'), readFileSync(GATE, 'utf8'), 'utf8');
-  if (workspaceYaml !== null) writeFileSync(join(dir, 'pnpm-workspace.yaml'), workspaceYaml, 'utf8');
-  return dir;
-}
-
-function runIn(root) {
-  return spawnSync(process.execPath, [join(root, 'scripts', 'check-lint-ran.mjs')], {
-    cwd: root,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-}
-
-test('a workspace glob with no lint target fails instead of going quietly unlinted', () => {
-  const root = fakeRoot("packages:\n  - 'packages/*'\n  - 'apps/*'\n  - 'plugins/*'\n");
-  try {
-    const run = runIn(root);
-    const out = `${run.stdout}${run.stderr}`;
-    assert.equal(run.status, 1, `expected exit 1, got ${run.status}: ${out}`);
-    assert.match(out, /plugins\/ is declared in pnpm-workspace\.yaml but is not a lint target/);
-    assert.doesNotMatch(out, /no errors\./, 'must not print a success line at all');
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test('an unreadable pnpm-workspace.yaml is loud, not treated as nothing to cross-check', () => {
-  const root = fakeRoot(null);
-  try {
-    const run = runIn(root);
-    const out = `${run.stdout}${run.stderr}`;
-    assert.equal(run.status, 1, `expected exit 1, got ${run.status}: ${out}`);
-    assert.match(out, /Refusing a vacuous pass/);
-    assert.match(out, /could not read .*pnpm-workspace\.yaml: ENOENT/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test('an empty package glob list is refused rather than agreeing with any target list', () => {
-  // `packages:` present, no items under it — the shape that would make the
-  // cross-check trivially satisfied by an empty TARGETS.
-  const root = fakeRoot('packages:\n\nonlyBuiltDependencies:\n  - esbuild\n');
-  try {
-    const run = runIn(root);
-    const out = `${run.stdout}${run.stderr}`;
-    assert.equal(run.status, 1, `expected exit 1, got ${run.status}: ${out}`);
-    assert.match(out, /declares no package globs/);
-    assert.match(out, /Refusing a vacuous pass/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test('an exclusion glob is not treated as a workspace member needing its own target', () => {
-  // pnpm supports `!`-prefixed exclusion globs (documented workspace
-  // feature) that narrow an inclusion glob rather than declare a new place
-  // to lint. Before the fix, `!packages/legacy-thing` failed the cross-check
-  // with a message naming `!packages/` - a directory that does not exist -
-  // which is exactly the "gate blocks a legitimate change" shape this line
-  // of work exists to prevent.
-  const root = fakeRoot(
-    "packages:\n  - 'packages/*'\n  - 'apps/*'\n  - 'scripts'\n  - 'examples/*'\n  - '!packages/legacy-thing'\n",
-  );
-  try {
-    const run = runIn(root);
-    const out = `${run.stdout}${run.stderr}`;
-    assert.doesNotMatch(out, /is not a lint target/, `exclusion glob must not be flagged: ${out}`);
-    assert.doesNotMatch(out, /declares no package globs/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test('the real pnpm-workspace.yaml parses to the globs it actually declares', () => {
-  // Guards the hand-rolled YAML reader against the block below `packages:`
-  // bleeding in: `onlyBuiltDependencies` items are list entries too, and a
-  // reader that swallowed them would demand lint targets named `@clerk` etc.
-  const root = fakeRoot(readFileSync(join(ROOT, 'pnpm-workspace.yaml'), 'utf8'));
-  try {
-    // Every declared glob is covered by a target, so the cross-check passes and
-    // the gate goes on to spawn oxlint — which is absent from this tree, so it
-    // fails LATER, with a different message. That distinction is the assertion.
-    const run = runIn(root);
-    const out = `${run.stdout}${run.stderr}`;
-    assert.doesNotMatch(out, /is not a lint target/);
-    assert.doesNotMatch(out, /declares no package globs/);
-  } finally {
-    rmSync(root, { recursive: true, force: true });
   }
 });

--- a/scripts/check-lint-ran.test.mjs
+++ b/scripts/check-lint-ran.test.mjs
@@ -26,7 +26,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -39,6 +39,12 @@ const ROOT = join(HERE, '..');
  *  past any pipe buffer (~64KiB on Linux and macOS). 40k lines per target is
  *  ~3MiB, the order of magnitude a failing oxlint run over this repo produces. */
 const LINES_PER_TARGET = 40_000;
+
+/** How many directories the gate lints, read from the gate itself rather than
+ *  hard-coded: adding a target (as #3200 added `examples`) must not require
+ *  editing arithmetic in this file, and a test that silently expected the old
+ *  count would assert on a run that had stopped covering a directory. */
+const TARGET_COUNT = (readFileSync(GATE, 'utf8').match(/^\s*\{ dir: '/gm) ?? []).length;
 const TAIL_MARKER = 'LAST-DIAGNOSTIC-LINE';
 
 /**
@@ -97,18 +103,18 @@ test('a failing lint keeps its whole output when stdout is a pipe', () => {
     // One summary per target. This is what vanished: the truncated log ended
     // roughly 1% in, so a reader saw diagnostics and no verdict.
     const summaries = stdout.match(/Finished in [^\n]*? on [\d,]+ files with \d+ rules/g) ?? [];
-    assert.equal(summaries.length, 3, `expected 3 oxlint summaries, got ${summaries.length}`);
+    assert.equal(summaries.length, TARGET_COUNT, `expected ${TARGET_COUNT} oxlint summaries, got ${summaries.length}`);
 
     // And the last line before each summary, so this cannot pass on a log that
     // dropped the middle and happened to keep the tail.
     const markers = stdout.match(new RegExp(TAIL_MARKER, 'g')) ?? [];
-    assert.equal(markers.length, 3, `expected 3 tail markers, got ${markers.length}`);
+    assert.equal(markers.length, TARGET_COUNT, `expected ${TARGET_COUNT} tail markers, got ${markers.length}`);
 
     // Byte-exact: every diagnostic line of every target arrived. Asserting the
     // count rather than "more than a pipe buffer" keeps the test honest if the
     // output grows or the buffer size differs between platforms.
     const diagnostics = stdout.match(/eslint\(no-control-regex\)/g) ?? [];
-    assert.equal(diagnostics.length, LINES_PER_TARGET * 3);
+    assert.equal(diagnostics.length, LINES_PER_TARGET * TARGET_COUNT);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -119,9 +125,107 @@ test('a clean lint still reports its own summary line through a pipe', () => {
   try {
     const run = runGate(bin);
     assert.equal(run.status, 0, `expected exit 0, got ${run.status}\n${run.stderr}`);
-    // 2,000 files per target from the shim, three targets.
-    assert.match(run.stdout, /lint: 6,000 files across 3 targets, 300 rules, no errors\./);
+    // 2,000 files per target from the shim, one line per target.
+    const total = (2_000 * TARGET_COUNT).toLocaleString('en-US');
+    assert.match(
+      run.stdout,
+      new RegExp(`lint: ${total} files across ${TARGET_COUNT} targets, 300 rules, no errors\\.`),
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- #3200: a workspace glob outside the target list must be loud ---
+//
+// The floors catch a target that shrank. They could not catch `examples/*`,
+// which was declared in pnpm-workspace.yaml and simply never passed to oxlint:
+// six error-tier `eslint(no-inner-declarations)` violations sat in shipped
+// sample code while `node scripts/check-lint-ran.mjs` exited 0. Measured on
+// upstream/main before the fix:
+//
+//   $ npx oxlint examples | grep -c ": error "
+//   6
+//   $ node scripts/check-lint-ran.mjs ; echo $?
+//   0
+//
+// The cross-check runs BEFORE any oxlint spawn, so these cases need no shim:
+// a copy of the gate beside a synthetic pnpm-workspace.yaml is the whole
+// reproduction, exactly as the gate derives its ROOT from its own location.
+
+/** A throwaway repo root holding `scripts/check-lint-ran.mjs` and the given
+ *  `pnpm-workspace.yaml` body (omit it to leave the file out entirely). */
+function fakeRoot(workspaceYaml) {
+  const dir = mkdtempSync(join(tmpdir(), 'check-lint-ran-ws-'));
+  mkdirSync(join(dir, 'scripts'));
+  writeFileSync(join(dir, 'scripts', 'check-lint-ran.mjs'), readFileSync(GATE, 'utf8'), 'utf8');
+  if (workspaceYaml !== null) writeFileSync(join(dir, 'pnpm-workspace.yaml'), workspaceYaml, 'utf8');
+  return dir;
+}
+
+function runIn(root) {
+  return spawnSync(process.execPath, [join(root, 'scripts', 'check-lint-ran.mjs')], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+test('a workspace glob with no lint target fails instead of going quietly unlinted', () => {
+  const root = fakeRoot("packages:\n  - 'packages/*'\n  - 'apps/*'\n  - 'plugins/*'\n");
+  try {
+    const run = runIn(root);
+    const out = `${run.stdout}${run.stderr}`;
+    assert.equal(run.status, 1, `expected exit 1, got ${run.status}: ${out}`);
+    assert.match(out, /plugins\/ is declared in pnpm-workspace\.yaml but is not a lint target/);
+    assert.doesNotMatch(out, /no errors\./, 'must not print a success line at all');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an unreadable pnpm-workspace.yaml is loud, not treated as nothing to cross-check', () => {
+  const root = fakeRoot(null);
+  try {
+    const run = runIn(root);
+    const out = `${run.stdout}${run.stderr}`;
+    assert.equal(run.status, 1, `expected exit 1, got ${run.status}: ${out}`);
+    assert.match(out, /Refusing a vacuous pass/);
+    assert.match(out, /could not read .*pnpm-workspace\.yaml: ENOENT/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('an empty package glob list is refused rather than agreeing with any target list', () => {
+  // `packages:` present, no items under it — the shape that would make the
+  // cross-check trivially satisfied by an empty TARGETS.
+  const root = fakeRoot('packages:\n\nonlyBuiltDependencies:\n  - esbuild\n');
+  try {
+    const run = runIn(root);
+    const out = `${run.stdout}${run.stderr}`;
+    assert.equal(run.status, 1, `expected exit 1, got ${run.status}: ${out}`);
+    assert.match(out, /declares no package globs/);
+    assert.match(out, /Refusing a vacuous pass/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the real pnpm-workspace.yaml parses to the globs it actually declares', () => {
+  // Guards the hand-rolled YAML reader against the block below `packages:`
+  // bleeding in: `onlyBuiltDependencies` items are list entries too, and a
+  // reader that swallowed them would demand lint targets named `@clerk` etc.
+  const root = fakeRoot(readFileSync(join(ROOT, 'pnpm-workspace.yaml'), 'utf8'));
+  try {
+    // Every declared glob is covered by a target, so the cross-check passes and
+    // the gate goes on to spawn oxlint — which is absent from this tree, so it
+    // fails LATER, with a different message. That distinction is the assertion.
+    const run = runIn(root);
+    const out = `${run.stdout}${run.stderr}`;
+    assert.doesNotMatch(out, /is not a lint target/);
+    assert.doesNotMatch(out, /declares no package globs/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 });

--- a/scripts/check-lint-ran.test.mjs
+++ b/scripts/check-lint-ran.test.mjs
@@ -212,6 +212,26 @@ test('an empty package glob list is refused rather than agreeing with any target
   }
 });
 
+test('an exclusion glob is not treated as a workspace member needing its own target', () => {
+  // pnpm supports `!`-prefixed exclusion globs (documented workspace
+  // feature) that narrow an inclusion glob rather than declare a new place
+  // to lint. Before the fix, `!packages/legacy-thing` failed the cross-check
+  // with a message naming `!packages/` - a directory that does not exist -
+  // which is exactly the "gate blocks a legitimate change" shape this line
+  // of work exists to prevent.
+  const root = fakeRoot(
+    "packages:\n  - 'packages/*'\n  - 'apps/*'\n  - 'scripts'\n  - 'examples/*'\n  - '!packages/legacy-thing'\n",
+  );
+  try {
+    const run = runIn(root);
+    const out = `${run.stdout}${run.stderr}`;
+    assert.doesNotMatch(out, /is not a lint target/, `exclusion glob must not be flagged: ${out}`);
+    assert.doesNotMatch(out, /declares no package globs/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('the real pnpm-workspace.yaml parses to the globs it actually declares', () => {
   // Guards the hand-rolled YAML reader against the block below `packages:`
   // bleeding in: `onlyBuiltDependencies` items are list entries too, and a

--- a/scripts/docs/check-doc-samples.mjs
+++ b/scripts/docs/check-doc-samples.mjs
@@ -26,6 +26,31 @@
  *   - an HTML comment `<!-- docs-check: skip -->` on the line directly
  *     above the opening fence
  *
+ * WHAT THIS GATE PROVES, AND HOW (#3200):
+ *   The compiler's result used to be read for its TEXT only - neither
+ *   `res.error` nor `res.status` was looked at - so "tsc never ran" and "tsc
+ *   ran and said nothing we recognise" both came out as a clean run. Deleting
+ *   `node_modules/.bin/tsc` entirely, with a deliberately broken snippet in
+ *   README.md, printed:
+ *
+ *     ✅ Doc code samples typecheck clean (262 snippets across 41 docs, 5 skipped).
+ *     EXIT=0
+ *
+ *   The printed count could not expose it, because it counted snippets WRITTEN
+ *   to the temp dir, not snippets checked.
+ *
+ *   The exit STATUS alone cannot be the fix. Measured against a healthy tree,
+ *   real tsc exits 2 on this program and always will: it reports ~540
+ *   diagnostics inside imported package SOURCES, which this harness ignores on
+ *   purpose (see the comment on `snippetRe`). Failing on a non-zero status
+ *   would fail every run. So the evidence is positive rather than negative -
+ *   `--listFiles` makes tsc name every file it actually put in the program,
+ *   and every snippet must appear there. That count, not the write count, is
+ *   what the success line reports. A compiler that could not be spawned, was
+ *   killed, or bailed out before building a program (TS5083 "cannot read
+ *   file", TS18003 "no inputs were found") reaches zero confirmed snippets and
+ *   is loud.
+ *
  * Run via `pnpm docs:check-samples`.
  */
 
@@ -205,11 +230,41 @@ try {
   writeFileSync(join(tmp, 'tsconfig.json'), `${JSON.stringify(tsconfig, null, 2)}\n`);
 
   const tsc = join(ROOT, 'node_modules', '.bin', 'tsc');
-  const res = spawnSync(tsc, ['--noEmit', '-p', join(tmp, 'tsconfig.json'), '--pretty', 'false'], {
-    cwd: ROOT,
-    encoding: 'utf-8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
+  // `--listFiles` is what turns this from "tsc said nothing" into "tsc named
+  // the files it compiled". See the header: it is the only signal here that
+  // separates a clean check from a compiler that never got started.
+  const res = spawnSync(
+    tsc,
+    ['--noEmit', '--listFiles', '-p', join(tmp, 'tsconfig.json'), '--pretty', 'false'],
+    {
+      cwd: ROOT,
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+
+  // The compiler could not be RUN AT ALL - missing binary, not executable, no
+  // memory to fork. This is the #3194 shape exactly: an absent instrument read
+  // as a clean report. It is distinct from, and louder than, a compiler that
+  // ran and disliked something.
+  if (res.error) {
+    console.error(`\n❌ The doc-samples typecheck could not be RUN: ${res.error.message}\n`);
+    console.error(`   Tried to spawn: ${tsc}`);
+    console.error(
+      '   Refusing a vacuous pass: no snippet was typechecked, so this run has proved\n' +
+        '   nothing about the docs. Run `pnpm install` and try again.\n',
+    );
+    process.exit(1);
+  }
+  if (res.signal) {
+    console.error(`\n❌ The doc-samples typecheck was KILLED by ${res.signal} before it finished.\n`);
+    console.error(
+      '   Refusing a vacuous pass: a compiler that died partway through has not\n' +
+        '   cleared the snippets it never reached (an OOM here looks exactly like a\n' +
+        '   clean run to anything that only reads the output).\n',
+    );
+    process.exit(1);
+  }
 
   const out = `${res.stdout ?? ''}${res.stderr ?? ''}`;
   // Only diagnostics in the snippet files are in scope: a doc snippet's use
@@ -220,9 +275,35 @@ try {
   // fail: they mean this harness is misconfigured.
   const snippetRe = /(?:^|[/\\])(snippet-\d{3})\.ts\((\d+),(\d+)\):\s*(error\s+TS\d+:\s*.*)$/;
   const supportRe = /(?:^|[/\\])(doc-samples-globals\.d\.ts|doc-samples-externals\.d\.ts|tsconfig\.json)(?:\((\d+),(\d+)\))?:\s*(error\s+TS\d+:\s*.*)$/;
+  // A `--listFiles` line is a bare path with no `(line,col): error` tail. One
+  // per file tsc actually placed in the program - the proof of work.
+  const listedSnippet = (line) => {
+    const t = line.trim();
+    if (!t.startsWith(tmp)) return null;
+    const rest = t.slice(tmp.length).replace(/^[/\\]/, '');
+    return /^snippet-\d{3}\.ts$/.test(rest) ? rest : null;
+  };
+  // A diagnostic with NO file prefix is tsc talking about the invocation
+  // itself, not about any code: TS5083 (cannot read tsconfig), TS6053 (file
+  // not found), TS18003 (no inputs were found), a bad flag. The program was
+  // never built, so nothing was checked.
+  const configErrorRe = /^error TS(\d+): (.*)$/;
+
   const failures = [];
   const supportFailures = [];
+  const configErrors = [];
+  const confirmed = new Set();
   for (const line of out.split('\n')) {
+    const listed = listedSnippet(line);
+    if (listed) {
+      confirmed.add(listed);
+      continue;
+    }
+    const cfg = line.match(configErrorRe);
+    if (cfg) {
+      configErrors.push(`TS${cfg[1]}: ${cfg[2]}`);
+      continue;
+    }
     const m = line.match(snippetRe);
     if (m) {
       const block = byTmpName.get(`${m[1]}.ts`);
@@ -238,6 +319,20 @@ try {
     }
     const s = line.match(supportRe);
     if (s) supportFailures.push(`${s[1]}: ${s[4]}`);
+  }
+
+  // The compiler RAN and refused the job. Reported before snippet diagnostics
+  // because there are none to report: no program was built.
+  if (configErrors.length > 0) {
+    console.error(
+      `\n❌ The doc-samples typecheck could not be CONFIGURED (tsc exited ${res.status}):\n`,
+    );
+    for (const e of configErrors) console.error(`   ${e}`);
+    console.error(
+      `\n   Refusing a vacuous pass: tsc reported on the invocation rather than on any\n` +
+        `   code, so none of the ${checked.length} snippets was typechecked.\n`,
+    );
+    process.exit(1);
   }
 
   if (supportFailures.length > 0) {
@@ -263,8 +358,31 @@ try {
     process.exit(1);
   }
 
+  // The floor. Not a heuristic threshold: the exact set of snippets written is
+  // known, so the exact set tsc compiled must match it. Anything less means a
+  // snippet silently dropped out of the program, and a clean report over a
+  // snippet nobody compiled is the whole subject of #3200.
+  const missing = [...byTmpName.keys()].filter((n) => !confirmed.has(n));
+  if (missing.length > 0) {
+    console.error(
+      `\n❌ tsc exited ${res.status} but confirmed only ${confirmed.size} of ${checked.length} snippets in its program.\n`,
+    );
+    for (const name of missing.slice(0, 10)) {
+      const block = byTmpName.get(name);
+      console.error(`   never compiled: ${block.file}:${block.startLine} (fence #${block.fenceIndex})`);
+    }
+    if (missing.length > 10) console.error(`   … and ${missing.length - 10} more`);
+    console.error(
+      '\n   Refusing a vacuous pass: this gate reports on snippets tsc actually\n' +
+        '   compiled (`--listFiles`), not on snippets it wrote to a temp dir. A\n' +
+        '   compiler that never ran, was killed, or bailed out before building the\n' +
+        '   program lands here rather than printing a clean tick.\n',
+    );
+    process.exit(1);
+  }
+
   console.log(
-    `✅ Doc code samples typecheck clean (${checked.length} snippet${checked.length === 1 ? '' : 's'} across ${targetDocs().length} docs, ${skippedCount} skipped).`,
+    `✅ Doc code samples typecheck clean (${confirmed.size} snippet${confirmed.size === 1 ? '' : 's'} compiled across ${targetDocs().length} docs, ${skippedCount} skipped).`,
   );
 } finally {
   if (!KEEP) rmSync(tmp, { recursive: true, force: true });

--- a/scripts/docs/check-doc-samples.mjs
+++ b/scripts/docs/check-doc-samples.mjs
@@ -273,7 +273,16 @@ try {
   // concern — it has its own `turbo typecheck` lane — so they are ignored
   // here. Diagnostics in our own support files or the generated tsconfig do
   // fail: they mean this harness is misconfigured.
-  const snippetRe = /(?:^|[/\\])(snippet-\d{3})\.ts\((\d+),(\d+)\):\s*(error\s+TS\d+:\s*.*)$/;
+  // `\d{3,}`, not `\d{3}`, for the same reason `listedSnippet` below carries
+  // it: `padStart(3, '0')` pads TO three digits, it does not cap at three, so
+  // index 1000 is written as `snippet-1000.ts`. This anchor fails in the worse
+  // direction of the two. A diagnostic line matching none of these three
+  // regexes is dropped where the loop below falls off the end, so a real
+  // TS2322 in `snippet-1000.ts` would leave `failures` empty and the gate
+  // would print its ✅ over a snippet tsc had just rejected — a clean report
+  // over broken code, rather than the false alarm the listed-snippet anchor
+  // would have raised. 261 snippets today, so this is latent, not live.
+  const snippetRe = /(?:^|[/\\])(snippet-\d{3,})\.ts\((\d+),(\d+)\):\s*(error\s+TS\d+:\s*.*)$/;
   const supportRe = /(?:^|[/\\])(doc-samples-globals\.d\.ts|doc-samples-externals\.d\.ts|tsconfig\.json)(?:\((\d+),(\d+)\))?:\s*(error\s+TS\d+:\s*.*)$/;
   // A `--listFiles` line is a bare path with no `(line,col): error` tail. One
   // per file tsc actually placed in the program - the proof of work.

--- a/scripts/docs/check-doc-samples.mjs
+++ b/scripts/docs/check-doc-samples.mjs
@@ -281,7 +281,7 @@ try {
     const t = line.trim();
     if (!t.startsWith(tmp)) return null;
     const rest = t.slice(tmp.length).replace(/^[/\\]/, '');
-    return /^snippet-\d{3}\.ts$/.test(rest) ? rest : null;
+    return /^snippet-\d{3,}\.ts$/.test(rest) ? rest : null;
   };
   // A diagnostic with NO file prefix is tsc talking about the invocation
   // itself, not about any code: TS5083 (cannot read tsconfig), TS6053 (file

--- a/scripts/docs/check-doc-samples.test.mjs
+++ b/scripts/docs/check-doc-samples.test.mjs
@@ -34,7 +34,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, chmodSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, chmodSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -108,6 +108,36 @@ process.exitCode = ${status};
 `;
 }
 
+test('a compiler killed by a signal AFTER listing every file is loud, not a clean tick', () => {
+  // The dangerous case, and the reason `res.signal` is checked before
+  // `missing` is computed: a compiler that emits the full `--listFiles`
+  // program and is THEN killed (OOM, a CI timeout's SIGKILL) leaves
+  // `confirmed` fully populated and `missing` empty. Without the signal
+  // check, that reads as every snippet compiled clean - a tick over a
+  // compiler that died. This shim lists the program's files exactly like a
+  // healthy tsc, then kills itself with SIGKILL before it can print
+  // anything else (no exit code, no diagnostics), so `missing.length === 0`
+  // and only `res.signal` distinguishes this from a real pass.
+  const root = makeTree(`#!/usr/bin/env node
+const fs = require('node:fs');
+const i = process.argv.indexOf('-p');
+const cfg = JSON.parse(fs.readFileSync(process.argv[i + 1], 'utf8'));
+let out = '';
+if (process.argv.includes('--listFiles')) for (const f of cfg.files) out += f + '\\n';
+fs.writeSync(1, out);
+process.kill(process.pid, 'SIGKILL');
+`);
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /KILLED by SIGKILL/);
+    assert.match(out, /Refusing a vacuous pass/);
+    assert.doesNotMatch(out, /typecheck clean/, 'must not print a success line at all');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test('a compiler that cannot be spawned is loud, not a clean tick', () => {
   const root = makeTree(null);
   try {
@@ -173,6 +203,25 @@ test('a real snippet error is reported against the DOC line, not the temp file',
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('the listed-snippet regex still matches once the index reaches 4 digits', () => {
+  // Snippet files are named with `String(idx).padStart(3, '0')`, so index
+  // 1000 (261 snippets today, but the count only grows) is named
+  // `snippet-1000.ts`. A regex anchored on exactly 3 digits does not match
+  // that name, so every snippet from 1000 on would fail to confirm and the
+  // gate would fail a healthy tree - the exact "clean report over untested
+  // code" shape #3200 exists to close, just triggered by count rather than
+  // by a dead compiler. Extracted straight from the source rather than
+  // duplicated here, so this fails if the regex regresses even if nobody
+  // remembers this test exists.
+  const src = readFileSync(join(HERE, 'check-doc-samples.mjs'), 'utf8');
+  const m = src.match(/return (\/\^snippet-[^)]+?\$\/)\.test\(rest\)/);
+  assert.ok(m, 'could not locate the listedSnippet regex in check-doc-samples.mjs');
+  const re = new RegExp(m[1].slice(1, -1));
+  assert.ok(re.test('snippet-1000.ts'), 'index 1000 must still match (padStart(3, "0") never truncates)');
+  assert.ok(re.test('snippet-000.ts'), 'the common 3-digit case must keep matching');
+  assert.ok(!re.test('snippet-00.ts'), 'fewer than 3 digits must still be rejected');
 });
 
 test('a non-zero exit with only out-of-scope diagnostics is still a clean run', () => {

--- a/scripts/docs/check-doc-samples.test.mjs
+++ b/scripts/docs/check-doc-samples.test.mjs
@@ -49,7 +49,7 @@ const README = ['# Sample', '', '```ts', 'const n: number = 1;', '```', ''].join
  * snippet, and `node_modules/.bin/tsc` written from `tscShim` (pass `null` to
  * leave the binary out entirely).
  */
-function makeTree(tscShim) {
+function makeTree(tscShim, { readme = README } = {}) {
   const root = mkdtempSync(join(tmpdir(), 'doc-samples-'));
   mkdirSync(join(root, 'scripts', 'docs'), { recursive: true });
   mkdirSync(join(root, 'docs', 'guide'), { recursive: true });
@@ -64,7 +64,7 @@ function makeTree(tscShim) {
   ]) {
     copyFileSync(join(HERE, f), join(root, 'scripts', 'docs', f));
   }
-  writeFileSync(join(root, 'README.md'), README, 'utf8');
+  writeFileSync(join(root, 'README.md'), readme, 'utf8');
 
   if (tscShim !== null) {
     const bin = join(root, 'node_modules', '.bin', 'tsc');
@@ -222,6 +222,42 @@ test('the listed-snippet regex still matches once the index reaches 4 digits', (
   assert.ok(re.test('snippet-1000.ts'), 'index 1000 must still match (padStart(3, "0") never truncates)');
   assert.ok(re.test('snippet-000.ts'), 'the common 3-digit case must keep matching');
   assert.ok(!re.test('snippet-00.ts'), 'fewer than 3 digits must still be rejected');
+});
+
+test('a snippet error at a 4-digit index is REPORTED, not silently dropped', () => {
+  // The sibling of the test above, in the same file, on the worse side of the
+  // asymmetry. `listedSnippet` anchoring on exactly 3 digits made a healthy
+  // tree fail; `snippetRe` anchoring on exactly 3 digits made a BROKEN tree
+  // pass — a diagnostic that matches none of the three recovery regexes is
+  // dropped where the loop falls off its end, so `failures` stays empty and
+  // the gate prints its ✅ over a snippet tsc had just rejected.
+  //
+  // Behavioural rather than a regex extraction: 1001 fences, so the last
+  // snippet is genuinely named `snippet-1000.ts` by the gate itself, and the
+  // shim reports an error against it by the name the gate chose. Cheap
+  // because the compiler is a shim.
+  const lines = ['# Sample', ''];
+  for (let i = 0; i <= 1000; i++) lines.push('```ts', 'const n: number = 1;', '```', '');
+  const root = makeTree(
+    workingTsc({
+      extraLines: [
+        "__TMP__/snippet-1000.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.",
+      ],
+      status: 2,
+    }),
+    { readme: lines.join('\n') },
+  );
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /failed to typecheck \(1 error\)/);
+    // Fence #1000's code line: 2 header lines, then 4 lines per fence.
+    assert.match(out, /README\.md:4004 \(fence #1000\)/);
+    assert.match(out, /TS2322/);
+    assert.doesNotMatch(out, /typecheck clean/, 'a rejected snippet must never read as clean');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('a non-zero exit with only out-of-scope diagnostics is still a clean run', () => {

--- a/scripts/docs/check-doc-samples.test.mjs
+++ b/scripts/docs/check-doc-samples.test.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression test for check-doc-samples.mjs reporting a clean typecheck over
+ * snippets no compiler ever looked at (#3200).
+ *
+ * The defect: `spawnSync`'s result was read for its TEXT only. Neither
+ * `res.error` nor `res.status` was looked at, and failures were recovered from
+ * the output by two regexes, so anything tsc said that matched neither was
+ * discarded and zero recovered failures printed as success. Measured on the
+ * real repo with a deliberately broken snippet in README.md and
+ * `node_modules/.bin/tsc` removed:
+ *
+ *   Doc code samples typecheck clean (262 snippets across 41 docs, 5 skipped).
+ *   EXIT=0
+ *
+ * and again with a `tsc` that printed `error TS5083: Cannot read file
+ * tsconfig.json.` and exited 2 - the shape of a real TS5083/TS6053/TS18003 or
+ * an OOM'd compiler. Both are exit 0 with a tick.
+ *
+ * The gate derives ROOT from its own location, so a copy of it in a synthetic
+ * tree is the whole reproduction: a README with one snippet, the two ambient
+ * .d.ts files it copies, empty docs/guide, docs/tutorials and packages
+ * directories, and a `node_modules/.bin/tsc` this test controls completely.
+ * That last part is the point - the cases below differ ONLY in what the
+ * compiler does, never in what the docs say.
+ *
+ * Run: node --test scripts/docs/check-doc-samples.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** The one snippet every tree below carries, so `checked.length` is 1. */
+const README = ['# Sample', '', '```ts', 'const n: number = 1;', '```', ''].join('\n');
+
+/**
+ * A tree holding the gate, its ambient support files, one doc with one
+ * snippet, and `node_modules/.bin/tsc` written from `tscShim` (pass `null` to
+ * leave the binary out entirely).
+ */
+function makeTree(tscShim) {
+  const root = mkdtempSync(join(tmpdir(), 'doc-samples-'));
+  mkdirSync(join(root, 'scripts', 'docs'), { recursive: true });
+  mkdirSync(join(root, 'docs', 'guide'), { recursive: true });
+  mkdirSync(join(root, 'docs', 'tutorials'), { recursive: true });
+  mkdirSync(join(root, 'packages'), { recursive: true });
+  mkdirSync(join(root, 'node_modules', '.bin'), { recursive: true });
+
+  for (const f of [
+    'check-doc-samples.mjs',
+    'doc-samples-globals.d.ts',
+    'doc-samples-externals.d.ts',
+  ]) {
+    copyFileSync(join(HERE, f), join(root, 'scripts', 'docs', f));
+  }
+  writeFileSync(join(root, 'README.md'), README, 'utf8');
+
+  if (tscShim !== null) {
+    const bin = join(root, 'node_modules', '.bin', 'tsc');
+    writeFileSync(bin, tscShim, 'utf8');
+    chmodSync(bin, 0o755);
+  }
+  return root;
+}
+
+function run(root) {
+  const res = spawnSync(process.execPath, [join(root, 'scripts', 'docs', 'check-doc-samples.mjs')], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return { status: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+}
+
+/**
+ * A tsc that behaves: it echoes the program's files the way `--listFiles`
+ * does, then prints whatever `extraLines` says, then exits `status`.
+ *
+ * It reads the file list out of the generated tsconfig rather than guessing,
+ * so a change to how the gate names its temp files cannot make this shim
+ * accidentally agree with it. `__TMP__` in a line stands for the program dir.
+ */
+function workingTsc({ extraLines = [], status = 0 } = {}) {
+  return `#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+const i = process.argv.indexOf('-p');
+const cfg = JSON.parse(fs.readFileSync(process.argv[i + 1], 'utf8'));
+const listFiles = process.argv.includes('--listFiles');
+let out = '';
+if (listFiles) for (const f of cfg.files) out += f + '\\n';
+for (const l of ${JSON.stringify(extraLines)}) {
+  out += l.split('__TMP__').join(path.dirname(process.argv[i + 1])) + '\\n';
+}
+fs.writeSync(1, out);
+process.exitCode = ${status};
+`;
+}
+
+test('a compiler that cannot be spawned is loud, not a clean tick', () => {
+  const root = makeTree(null);
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /could not be RUN/);
+    assert.match(out, /ENOENT/);
+    assert.match(out, /Refusing a vacuous pass/);
+    assert.doesNotMatch(out, /typecheck clean/, 'must not print a success line at all');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a compiler that bails out on the invocation is distinguished from one that found a problem', () => {
+  // TS5083 has no file prefix, so neither recovery regex matched it and the
+  // gate reported clean. The message must say the compiler could not be
+  // CONFIGURED - a different remedy from a broken snippet.
+  const root = makeTree('#!/bin/sh\necho "error TS5083: Cannot read file tsconfig.json."\nexit 2\n');
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /could not be CONFIGURED/);
+    assert.match(out, /TS5083/);
+    assert.doesNotMatch(out, /failed to typecheck/, 'a harness failure, not a snippet failure');
+    assert.doesNotMatch(out, /typecheck clean/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a compiler that exits 0 having compiled nothing cannot report a clean run', () => {
+  // The count used to be of snippets WRITTEN, so it was structurally incapable
+  // of exposing this: 1 snippet written, 0 compiled, "1 snippet ... clean".
+  const root = makeTree('#!/bin/sh\nexit 0\n');
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /confirmed only 0 of 1 snippets/);
+    assert.match(out, /never compiled: README\.md:4 \(fence #0\)/);
+    assert.match(out, /Refusing a vacuous pass/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a real snippet error is reported against the DOC line, not the temp file', () => {
+  // The positive control: the recovery path this gate was built for still
+  // works, and still resolves the snippet line back to the markdown.
+  const root = makeTree(
+    workingTsc({
+      extraLines: [
+        "__TMP__/snippet-000.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.",
+      ],
+      status: 2,
+    }),
+  );
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected exit 1, got ${status}: ${out}`);
+    assert.match(out, /README\.md:4 \(fence #0\)/);
+    assert.match(out, /TS2322/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a non-zero exit with only out-of-scope diagnostics is still a clean run', () => {
+  // Load-bearing, and the reason the fix is not "fail on a non-zero status":
+  // against the real repo tsc exits 2 on EVERY run, reporting ~540 errors
+  // inside imported package SOURCES, which this gate ignores on purpose. A
+  // status-based guard would fail every healthy run; the file list is what
+  // separates the two.
+  const root = makeTree(
+    workingTsc({
+      extraLines: [
+        'packages/collab/src/detector.ts(91,10): error TS2694: Namespace \'"yjs"\' has no exported member \'Doc\'.',
+      ],
+      status: 2,
+    }),
+  );
+  try {
+    const { status, out } = run(root);
+    assert.equal(status, 0, `expected exit 0, got ${status}: ${out}`);
+    assert.match(out, /Doc code samples typecheck clean \(1 snippet compiled/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes two of the ten findings in #3200. They are independent; one commit each, readable separately.

## Finding 3 — `examples/*` was never linted, and had six live errors

`pnpm-workspace.yaml` declares three package globs; `check-lint-ran.mjs` knew about two plus `scripts`. Measured on `upstream/main`:

```
$ npx oxlint examples | grep -c ": error "
6
$ node scripts/check-lint-ran.mjs ; echo $?
0
```

All six are `eslint(no-inner-declarations)` — three function declarations inside the `try` block of each viewer's file-load path:

| file | line | function |
|---|---|---|
| `examples/threejs-viewer/src/main.ts` | 256 | `expandStreamBoundsFromMeshes` |
| `examples/threejs-viewer/src/main.ts` | 274 | `getStreamBounds` |
| `examples/threejs-viewer/src/main.ts` | 289 | `fitIfDue` |
| `examples/babylonjs-viewer/src/main.ts` | 267 | `expandStreamBoundsFromMeshes` |
| `examples/babylonjs-viewer/src/main.ts` | 285 | `getStreamBounds` |
| `examples/babylonjs-viewer/src/main.ts` | 300 | `fitIfDue` |

All three close over `streamMinX…streamMaxZ` and `hasStreamBounds`, declared in the same block, so oxlint's "move to program root" remedy is not available. They are `const` arrow functions now. Every call site (`fitIfDue` → `getStreamBounds`, and both uses inside the `for await`) is strictly after all three declarations, so nothing relied on hoisting and no TDZ window opens.

**Nothing was suppressed, ignored, or downgraded.** `oxlint examples` goes 6 errors → 0 errors. Both examples still `tsc --noEmit` clean and still `vite build`. Five WARN-tier findings remain in `examples/` (`no-unused-vars`, `no-empty`); `.oxlintrc.json` documents WARN as non-blocking, and they are out of scope here.

### The gate's missing half

Per-target floors catch a target that *shrank*. They cannot catch a target that was never in the list — which is exactly how this hid, and why the floors all passed. So `pnpm-workspace.yaml` is now read at run time and cross-checked against `TARGETS`; a declared glob no target covers fails **before** oxlint is spawned:

```
lint: a workspace glob is outside this gate's target list, so the code there is
      never linted and no floor can notice:

      examples/ is declared in pnpm-workspace.yaml but is not a lint target

      Add it to TARGETS with a measured floor (#3200).
```

Following #3197: an unreadable `pnpm-workspace.yaml` and one declaring zero globs are both refused with a message that says so, rather than read as "nothing to cross-check". `examples` gets a measured floor (17 files today, floor 10).

`examples/**` also joins the `frontend` path filter, so a PR touching only an example cannot skip the job that now lints it.

### Watched fail

- Six violations restored by inverse patch → gate exits 1; restored file `diff`s byte-identical.
- `examples` target removed from `TARGETS` → new cross-check fires, exit 1.
- Three of the six `check-lint-ran.test.mjs` cases fail against the pre-fix gate.

## Finding 2 — `check-doc-samples.mjs` never read its subprocess result

`spawnSync`'s result was used for its *text* only. Reproduced on the real repo with a deliberately broken snippet planted in `README.md`:

```
$ rm node_modules/.bin/tsc && node scripts/docs/check-doc-samples.mjs
✅ Doc code samples typecheck clean (262 snippets across 41 docs, 5 skipped).
EXIT=0
```
```
$ printf '#!/bin/sh\necho "error TS5083: Cannot read file tsconfig.json."\nexit 2\n' > node_modules/.bin/tsc
$ node scripts/docs/check-doc-samples.mjs
✅ Doc code samples typecheck clean (262 snippets across 41 docs, 5 skipped).
EXIT=0
```

### Why the fix is not "fail on a non-zero status"

Measured before writing any guard: against a healthy tree, real `tsc` exits **2** on this program and always will — it reports ~540 diagnostics inside imported package *sources*, which this harness ignores by design. A status-based guard would fail every run.

So the evidence is positive rather than negative. `--listFiles` makes tsc name every file it actually placed in the program; every snippet must appear there; and **that** count, not the write count, is what the success line reports. Three failures, three messages:

- **could not be RUN** — `res.error` (spawn failure) or `res.signal` (killed / OOM). The #3194 absence-reads-as-success shape, and the loudest of the three.
- **could not be CONFIGURED** — a diagnostic with no file prefix (TS5083, TS6053, TS18003): tsc talking about the invocation, not about code, so no program was built.
- **confirmed only N of M snippets** — the compiler ran but a snippet dropped out of the program, named by doc and fence.

Each says it refuses a vacuous pass and names what it expected.

### Watched fail

Five regression tests drive a synthetic tree whose only variable is what `node_modules/.bin/tsc` does. Four fail against the pre-fix gate. The fifth is the invariant that must *not* change — a non-zero exit carrying only out-of-scope package-source diagnostics is still a clean run — and it passes on both sides.

The planted `README.md` snippet was reverted by inverse edit and `diff`s byte-identical against the pre-plant copy.

The `scripts/` glob catch-all did not cover `scripts/docs/`, so this test file would have been added, run once locally, and never run again — the exact trap that step's own comment describes. The glob now includes it.

## Verification

```
$ pnpm build   # 47/47
$ pnpm lint
changesets: 5 pending, all naming workspace packages.
check-test-glob-coverage: OK (47 packages audited, 0 unrun test files)
✅ No new unused locals (50 packages, 948 known, none increased).
lint: 3,614 files across 4 targets, 98 rules, no errors.
EXIT=0

$ node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs scripts/docs/*.test.mjs
# pass 643  # fail 0

$ node scripts/check-test-wiring.mjs
✅ check-test-wiring: OK (47 packages, 40 gate scripts, 28 scripts/ test files).
```

The unused-locals ratchet did not fire, so no `lint:baseline` refresh was needed.

## Not verified

- CI itself — pushed without waiting, per instruction.
- The remaining eight findings in #3200 are untouched.
- `tests/`, `tools/`, `api/`, `server/` are still outside the lint targets (finding 3's other half). They carry WARN-tier findings only, and bringing them in is a scope decision for you rather than a defect fix; the new cross-check does not demand them, since they are not workspace globs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation sample validation to detect compiler failures, skipped snippets, and incomplete checks.
  * Documentation diagnostics now support snippets with four-digit indexes.

* **Tests**
  * Added regression coverage for documentation sample compilation failures and missing compiler output.
  * Expanded lint validation tests for workspace configuration and example targets.

* **Chores**
  * Example changes now trigger frontend checks.
  * Lint tracking now includes example files and validates workspace targets automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->