### PR TITLE
fix: refuse a vacuous pass in three more gates (#3200 findings 4, 5, 6)

### DIFF
--- a/rust/processing/tests/common/mod.rs
+++ b/rust/processing/tests/common/mod.rs
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Shared helper for the source-walking CI gates in this crate
+//! (`module_size_ratchet`, `styling_parity`).
+//!
+//! Lives here rather than being copied into each test binary so the rule has
+//! ONE implementation: two copies of a gate's escape hatch are two chances to
+//! loosen one of them and not the other.
+
+/// Refuse to skip a source-walking gate when running under CI.
+///
+/// Both gates begin `let Some(root) = repo_root() else { eprintln!(…); return; }`.
+/// That early return is the widest hole the #3200 hardening left open: it
+/// happens BEFORE the walk, so it bypasses the missing-root panic, the
+/// unreadable-file panic and the scan floor all at once. Reproduced with
+/// `repo_root` stubbed to `None` — `no_module_grows_past_its_ratchet_budget`,
+/// `no_duplicate_default_color_tables` and
+/// `no_duplicate_surface_style_color_extraction` each report
+/// `ok … finished in 0.00s`: three green gates over a tree never opened.
+///
+/// It cannot simply become a panic. `tests/` is packaged into the published
+/// `.crate` (there is no `exclude` in `rust/processing/Cargo.toml`), so a
+/// downstream `cargo test` on `ifc-lite-processing` runs these files with no
+/// `rust/` or `apps/` above them, and skipping is correct there. Nor can the
+/// two situations be told apart by looking for the repo — its absence is the
+/// thing being explained.
+///
+/// `CI` is the discriminator: GitHub Actions sets it on every run, and a
+/// packaged consumer's machine does not have it. The truthiness test follows
+/// the form already used by `rust/geometry/tests/triangulation_invariance.rs`
+/// rather than inventing a second convention for the same variable.
+pub fn refuse_to_skip_in_ci(gate: &str) {
+    let ci = std::env::var_os("CI").is_some_and(|v| !v.is_empty() && v != "0" && v != "false");
+    assert!(
+        !ci,
+        "{gate}: no repo root above CARGO_MANIFEST_DIR ({}), but CI is set. Under CI \
+         this gate must scan the tree, not skip it — skipping bypasses the \
+         missing-root panic, the unreadable-file panic AND the scan floor at once, \
+         and reports success over a tree that was never opened (#3200). Either the \
+         checkout is incomplete or the walk roots are wrong; both block a release, \
+         and neither of them means 'no offenders'.",
+        env!("CARGO_MANIFEST_DIR")
+    );
+}

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -23,12 +23,16 @@
 //!
 //! ANTI-VACUITY (#3200): every offender this gate reports is produced by
 //! iterating the walked file list, so an empty walk produced an empty message
-//! and a green test - success reported over a tree that was never opened. Three
+//! and a green test - success reported over a tree that was never opened. Four
 //! guards now stand between an empty walk and that pass: a missing or unreadable
 //! scan root is a hard error instead of an empty result (and the two are told
 //! apart, because they call for different fixes), a file that cannot be read is
-//! a hard error instead of 0 lines, and the walk must reach at least
-//! `FILE_FLOOR` non-exempt files before any verdict below it counts.
+//! a hard error instead of 0 lines, the walk must reach at least `FILE_FLOOR`
+//! non-exempt files before any verdict below it counts, and under CI the
+//! no-repo-root skip is refused outright (`common::refuse_to_skip_in_ci`) - that
+//! skip returns before the walk, so it bypassed all three of the others at once.
+
+mod common;
 
 const LIMIT: usize = 400;
 const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
@@ -212,6 +216,7 @@ fn evaluate(
 #[test]
 fn no_module_grows_past_its_ratchet_budget() {
     let Some(root) = repo_root() else {
+        common::refuse_to_skip_in_ci("module-size ratchet");
         eprintln!("repo root not found (packaged context) - skipping module-size ratchet");
         return;
     };

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -20,6 +20,15 @@
 //!
 //! This runs in the required `rust-tests` lane (`cargo test --workspace`), so a
 //! violation blocks merge. Cross-crate file walking mirrors `styling_parity`.
+//!
+//! ANTI-VACUITY (#3200): every offender this gate reports is produced by
+//! iterating the walked file list, so an empty walk produced an empty message
+//! and a green test - success reported over a tree that was never opened. Three
+//! guards now stand between an empty walk and that pass: a missing or unreadable
+//! scan root is a hard error instead of an empty result (and the two are told
+//! apart, because they call for different fixes), a file that cannot be read is
+//! a hard error instead of 0 lines, and the walk must reach at least
+//! `FILE_FLOOR` non-exempt files before any verdict below it counts.
 
 const LIMIT: usize = 400;
 const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
@@ -43,6 +52,24 @@ const ALLOWLIST: &str = include_str!("module_size_allowlist.txt");
 /// would rewrite the digest and fail CI for no reason.
 const ALLOWLIST_DIGEST: u64 = 4241476374134085635;
 
+/// Lower bound on how many non-exempt `.rs` files the walk must reach before
+/// its verdict means anything. Every offender this gate can report is pushed
+/// inside `for (rel, lines) in files`, so an empty `files` produces an empty
+/// message and a green test - a pass over a region the gate never examined
+/// (#3200).
+///
+/// MEASURED, not guessed: the walk over `rust/` + `apps/` reaches 362
+/// non-exempt files on a healthy tree (raise the floor and run the test to see
+/// the real figure in the failure message). The floor below sits at roughly two
+/// thirds of that, which is the right shape of
+/// headroom here: this number only has to separate "the walk works" from "the
+/// walk went blind", and every way it can go blind - a wrong scan root, a
+/// `read_dir` that fails, a crate tree that moved - takes the count to zero or
+/// to a handful, never to a plausible-looking fraction. Deleting a whole crate
+/// is the only ordinary event that would approach it, and that is a change
+/// worth editing this line for.
+const FILE_FLOOR: usize = 240;
+
 /// Repo root = first ancestor holding both `rust/` and `apps/`. `None` in a
 /// packaged/standalone context (the test then skips, like `styling_parity`).
 fn repo_root() -> Option<std::path::PathBuf> {
@@ -57,11 +84,39 @@ fn repo_root() -> Option<std::path::PathBuf> {
     }
 }
 
+/// Walk `dir`, collecting every `.rs` file underneath it.
+///
+/// A directory this cannot list is a hard error, and the two reasons are told
+/// apart. The previous `let Ok(entries) = read_dir(dir) else { return; };`
+/// collapsed "the scan root is not there" and "the scan root cannot be opened"
+/// into the same result as "this directory holds no Rust files" - which is how
+/// this ratchet could report success over a tree it never opened (#3200). A
+/// missing directory means the walk roots are wrong; an unreadable one means
+/// the environment is. Neither means there are no offenders.
 fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => panic!(
+            "module-size ratchet: {} does not exist. Refusing to treat a missing \
+             directory as one holding no .rs files - a walk root that is not \
+             there means this gate is looking in the wrong place, not that the \
+             tree is clean.",
+            dir.display()
+        ),
+        Err(err) => panic!(
+            "module-size ratchet: {} could not be read ({err}). Refusing to treat \
+             an unreadable directory as one holding no .rs files.",
+            dir.display()
+        ),
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|err| {
+            panic!(
+                "module-size ratchet: an entry of {} could not be read ({err}). \
+                 Refusing to walk past a file this gate could not classify.",
+                dir.display()
+            )
+        });
         let path = entry.path();
         if path.is_dir() {
             let skip = matches!(
@@ -114,10 +169,19 @@ fn parse_allowlist() -> std::collections::HashMap<String, usize> {
     map
 }
 
+/// Line count for one file. An unreadable file is a hard error, not zero: 0 is
+/// under LIMIT and under every allowlist budget, so `unwrap_or(0)` made a file
+/// this gate could not open indistinguishable from a file that passes it.
 fn line_count(path: &std::path::Path) -> usize {
-    std::fs::read_to_string(path)
-        .map(|s| s.lines().count())
-        .unwrap_or(0)
+    match std::fs::read_to_string(path) {
+        Ok(s) => s.lines().count(),
+        Err(err) => panic!(
+            "module-size ratchet: {} could not be read ({err}). Refusing to count \
+             an unreadable file as 0 lines - 0 is under every budget, so the file \
+             would pass the ratchet without ever being measured.",
+            path.display()
+        ),
+    }
 }
 
 /// Pure ratchet decision: given `(relpath, line_count)` for every non-exempt
@@ -168,6 +232,20 @@ fn no_module_grows_past_its_ratchet_budget() {
         })
         .filter(|(rel, _)| !is_exempt(rel))
         .collect();
+
+    // Anti-vacuity (#3200). Placed above every verdict below, because all of
+    // them are computed by iterating `files`: zero files gives zero offenders
+    // gives a green test, which is this gate reporting success over a tree it
+    // never looked at.
+    assert!(
+        files.len() >= FILE_FLOOR,
+        "module-size ratchet walked rust/ and apps/ and reached only {} non-exempt \
+         .rs file(s); the floor is {FILE_FLOOR}. Refusing a vacuous pass: every \
+         check below iterates this list, so a count this low means the walk \
+         stopped working, not that the modules went away. If crates were \
+         genuinely removed, lower FILE_FLOOR in the same commit.",
+        files.len()
+    );
 
     // Advisory only (never fails the build, to avoid merge-order coupling): an
     // allowlisted file that dropped to <= LIMIT or vanished should have its row

--- a/rust/processing/tests/styling_parity.rs
+++ b/rust/processing/tests/styling_parity.rs
@@ -28,7 +28,11 @@
 //! (and the two are told apart), a file that cannot be read is a hard error
 //! rather than a skip, the walk must reach `SCANNED_FLOOR` files, and the
 //! detectors themselves are exercised against known-positive inputs - a file
-//! count shows the walk is alive, not that the detector still detects.
+//! count shows the walk is alive, not that the detector still detects. A fifth
+//! now closes the way around all four: under CI the no-repo-root skip at the
+//! top of each guard is refused outright (`common::refuse_to_skip_in_ci`).
+
+mod common;
 
 use ifc_lite_core::IfcType;
 use ifc_lite_processing::default_color_for_type;
@@ -368,6 +372,7 @@ fn the_detectors_still_fire_on_a_known_violation() {
 #[test]
 fn no_duplicate_default_color_tables() {
     let Some(root) = repo_root() else {
+        common::refuse_to_skip_in_ci("styling parity guard");
         eprintln!("repo root not found (packaged context) — skipping guard");
         return;
     };
@@ -430,6 +435,7 @@ fn no_duplicate_default_color_tables() {
 #[test]
 fn no_duplicate_surface_style_color_extraction() {
     let Some(root) = repo_root() else {
+        common::refuse_to_skip_in_ci("styling parity guard");
         eprintln!("repo root not found (packaged context) — skipping guard");
         return;
     };

--- a/rust/processing/tests/styling_parity.rs
+++ b/rust/processing/tests/styling_parity.rs
@@ -19,6 +19,16 @@
 //!
 //! When Phase 1 deletes the old table bodies, this file is the proof that
 //! the only behavioral change is the four documented entries.
+//!
+//! ANTI-VACUITY (#3200): the two source-grep guards at the bottom conclude from
+//! an ABSENCE - no second table, no second extractor - so a scan that examined
+//! nothing used to pass them, silently, over an empty directory and over a
+//! directory that does not exist alike. Four guards now stand in the way: a
+//! missing or unreadable scan root is a hard error rather than an empty result
+//! (and the two are told apart), a file that cannot be read is a hard error
+//! rather than a skip, the walk must reach `SCANNED_FLOOR` files, and the
+//! detectors themselves are exercised against known-positive inputs - a file
+//! count shows the walk is alive, not that the detector still detects.
 
 use ifc_lite_core::IfcType;
 use ifc_lite_processing::default_color_for_type;
@@ -211,11 +221,53 @@ fn repo_root() -> Option<std::path::PathBuf> {
     }
 }
 
+/// Lower bound on how many `.rs` files the two source-grep guards below must
+/// reach before an empty offender list means anything.
+///
+/// Both guards conclude from an ABSENCE, so a walk that reaches nothing proves
+/// nothing and passes anyway - which is what they did before #3200, over an
+/// empty directory and over a directory that does not exist alike.
+///
+/// MEASURED, not guessed: the walk over `rust/` + `apps/` reaches
+/// 659 `.rs` files on a healthy tree (raise the floor and
+/// run the test to see the real figure in the failure message). The floor sits
+/// at roughly two thirds of that. It only has to separate "the walk works" from
+/// "the walk went blind", and every way it can go blind - a wrong scan root, a
+/// `read_dir` that fails, a crate tree that moved - takes the count to zero or
+/// to a handful, never to a plausible-looking fraction.
+const SCANNED_FLOOR: usize = 440;
+
+/// Walk `dir`, collecting every `.rs` file underneath it.
+///
+/// A directory this cannot list is a hard error, and the two reasons are told
+/// apart. The previous `let Ok(entries) = read_dir(dir) else { return; };` made
+/// "the scan root is not there" and "the scan root cannot be opened" produce
+/// the same result as "this directory holds no Rust files", which for an
+/// absence guard reads as a clean bill of health (#3200). A missing directory
+/// means the walk roots are wrong; an unreadable one means the environment is.
 fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => panic!(
+            "styling parity: {} does not exist. Refusing to treat a missing \
+             directory as one holding no .rs files - these guards conclude from \
+             an absence, so a scan root that is not there would read as clean.",
+            dir.display()
+        ),
+        Err(err) => panic!(
+            "styling parity: {} could not be read ({err}). Refusing to treat an \
+             unreadable directory as one holding no .rs files.",
+            dir.display()
+        ),
     };
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry.unwrap_or_else(|err| {
+            panic!(
+                "styling parity: an entry of {} could not be read ({err}). \
+                 Refusing to walk past a file these guards could not classify.",
+                dir.display()
+            )
+        });
         let path = entry.path();
         if path.is_dir() {
             let skip = matches!(
@@ -229,6 +281,88 @@ fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
             out.push(path);
         }
     }
+}
+
+/// Read one walked file. Unreadable is a hard error, not a skip: `continue`
+/// removed the file from an absence guard's evidence without removing it from
+/// the tree, so a copy of the forbidden table sitting in a file these guards
+/// could not open would have read as "not found".
+fn read_walked(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_else(|err| {
+        panic!(
+            "styling parity: {} could not be read ({err}). Refusing to skip a \
+             file this guard could not examine - these guards prove an absence, \
+             and an unread file is not an absence.",
+            path.display()
+        )
+    })
+}
+
+/// Does `src` declare a per-consumer default-color table?
+///
+/// Matches actual function declarations only, not prose or strings that happen
+/// to mention the name (e.g. this file's own doc comments). Split out from the
+/// guard so it can be exercised against a known-positive input - a file count
+/// alone shows the walk is alive, not that the detector still detects.
+fn declares_default_color_table(src: &str) -> bool {
+    src.lines().any(|line| {
+        let line = line.trim_start();
+        line.starts_with("fn get_default_color")
+            || line.starts_with("pub fn get_default_color")
+            || line.starts_with("pub(crate) fn get_default_color")
+    })
+}
+
+/// Does `src` declare a second surface-style colour extractor? Same reasoning
+/// as `declares_default_color_table`.
+fn declares_surface_style_extractor(src: &str) -> bool {
+    src.lines().any(|line| {
+        let line = line.trim_start();
+        ["fn ", "pub fn ", "pub(crate) fn "].iter().any(|p| {
+            line.starts_with(&format!("{p}extract_color_from_rendering"))
+                || line.starts_with(&format!("{p}extract_color_rgb"))
+        })
+    })
+}
+
+/// Positive control for both detectors: a file count proves the walk reaches
+/// files, and nothing more. If the detectors themselves stopped matching - a
+/// rename, an edited prefix list, a `trim_start` that went away - the offender
+/// lists would empty out and both guards would go green over a tree full of
+/// violations. These synthetic inputs fail the moment that happens.
+#[test]
+fn the_detectors_still_fire_on_a_known_violation() {
+    assert!(
+        declares_default_color_table("    pub fn get_default_color(t: IfcType) -> Color {\n"),
+        "the default-color-table detector stopped matching a declaration it must catch"
+    );
+    assert!(
+        declares_default_color_table("fn get_default_color_for_type(t: IfcType) -> Color {\n"),
+        "the default-color-table detector must match the wasm-side name too"
+    );
+    assert!(
+        declares_surface_style_extractor(
+            "    fn extract_color_from_rendering(id: u32) -> Color {\n"
+        ),
+        "the surface-style detector stopped matching a declaration it must catch"
+    );
+    assert!(
+        declares_surface_style_extractor("pub(crate) fn extract_color_rgb(id: u32) -> Color {\n"),
+        "the surface-style detector stopped matching `extract_color_rgb`"
+    );
+
+    // And it must stay a DECLARATION detector: prose and call sites are not
+    // second tables, and a detector that fired on them would be turned off.
+    assert!(
+        !declares_default_color_table(
+            "// the historical copies were named `fn get_default_color`\n"
+        ),
+        "the default-color-table detector must not fire on prose"
+    );
+    assert!(
+        !declares_surface_style_extractor("        let c = extract_color_rgb(id, decoder)?;\n"),
+        "the surface-style detector must not fire on a call site"
+    );
 }
 
 #[test]
@@ -246,6 +380,18 @@ fn no_duplicate_default_color_tables() {
     collect_rs_files(&root.join("rust"), &mut files);
     collect_rs_files(&root.join("apps"), &mut files);
 
+    // Anti-vacuity (#3200): this guard concludes from an empty `offenders`, so
+    // the walk having reached a real tree is part of its evidence, not a
+    // precondition someone else checks.
+    assert!(
+        files.len() >= SCANNED_FLOOR,
+        "styling parity walked rust/ and apps/ and reached only {} .rs file(s); \
+         the floor is {SCANNED_FLOOR}. Refusing a vacuous pass: this guard \
+         concludes that no second default-color table exists, and a scan that \
+         examined this little has established no such thing.",
+        files.len()
+    );
+
     let mut offenders = Vec::new();
     for path in files {
         let rel = path
@@ -256,18 +402,7 @@ fn no_duplicate_default_color_tables() {
         if allow(&rel) {
             continue;
         }
-        let Ok(src) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        // Match actual function declarations only, not prose/strings that
-        // happen to mention the name (e.g. this guard's own doc comment).
-        let declares_color_table = src.lines().any(|line| {
-            let line = line.trim_start();
-            line.starts_with("fn get_default_color")
-                || line.starts_with("pub fn get_default_color")
-                || line.starts_with("pub(crate) fn get_default_color")
-        });
-        if declares_color_table {
+        if declares_default_color_table(&read_walked(&path)) {
             offenders.push(rel);
         }
     }
@@ -312,30 +447,51 @@ fn no_duplicate_surface_style_color_extraction() {
     collect_rs_files(&root.join("rust"), &mut files);
     collect_rs_files(&root.join("apps"), &mut files);
 
+    assert!(
+        files.len() >= SCANNED_FLOOR,
+        "styling parity walked rust/ and apps/ and reached only {} .rs file(s); \
+         the floor is {SCANNED_FLOOR}. Refusing a vacuous pass: this guard \
+         concludes that no second surface-style colour extractor exists, and a \
+         scan that examined this little has established no such thing.",
+        files.len()
+    );
+
+    let scanned = files.len();
     let mut offenders = Vec::new();
+    // END-TO-END positive control, one step beyond the synthetic one above:
+    // count the exempt files the detector DOES match. The allowlist exists for
+    // `rust/geometry/examples/`, which really does carry its own
+    // `fn extract_color_from_rendering`, so a healthy run always finds at
+    // least one. Zero means the walk and the detector never met a real
+    // declaration, whatever the file count says.
+    let mut allowed_hits = 0usize;
     for path in files {
         let rel = path
             .strip_prefix(&root)
             .unwrap_or(&path)
             .to_string_lossy()
             .replace('\\', "/");
+        let declares = declares_surface_style_extractor(&read_walked(&path));
         if allow(&rel) {
+            if declares {
+                allowed_hits += 1;
+            }
             continue;
         }
-        let Ok(src) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let declares = src.lines().any(|line| {
-            let line = line.trim_start();
-            ["fn ", "pub fn ", "pub(crate) fn "].iter().any(|p| {
-                line.starts_with(&format!("{p}extract_color_from_rendering"))
-                    || line.starts_with(&format!("{p}extract_color_rgb"))
-            })
-        });
         if declares {
             offenders.push(rel);
         }
     }
+
+    assert!(
+        allowed_hits >= 1,
+        "the surface-style detector matched nothing at all across {scanned} walked \
+         file(s), not even the exempt `rust/geometry/examples/` copy it is \
+         allowed to find. An absence guard that cannot find a declaration it \
+         KNOWS is there has stopped detecting, so its empty offender list means \
+         nothing. If that example was deliberately removed, retire this control \
+         in the same commit."
+    );
 
     assert!(
         offenders.is_empty(),

--- a/scripts/generate-server-attr-indices.mjs
+++ b/scripts/generate-server-attr-indices.mjs
@@ -82,9 +82,10 @@ const NAMES = ['Description', 'ObjectType', 'Tag', 'PredefinedType'];
  * not true: there is no runtime schema selection here. `SCHEMA_REGISTRY` is a
  * single committed codegen artifact pinned to IFC4_ADD2_TC1, and the
  * multi-schema union lives elsewhere — in `ifc-schema.ts`'s
- * `ENTITY_INFO_BY_UPPER`, reachable only through
- * `getAttributeNamesAcrossSchemas`, which this generator never calls (it calls
- * the pinned `getAttributeNames`). Repinning the codegen would be a
+ * `ENTITY_INFO_BY_UPPER`, read by `getAttributeNamesAcrossSchemas`,
+ * `getEntityInfoAcrossSchemas` and `getInheritanceChainFromSchemaUnion`, none
+ * of which this generator calls (it calls the pinned `getAttributeNames`).
+ * Repinning the codegen would be a
  * regenerate-and-commit event, which is exactly what the failure message below
  * already instructs. Measured on the old value: 499 rows refused and 500 rows
  * WROTE, replacing all 776 committed arms and exiting 0 — so the 500..775 band
@@ -106,10 +107,30 @@ const ROW_FLOOR = 700;
  * MEASURED, not guessed: 488 of today's 776 rows resolve at least one
  * attribute; the other 288 legitimately declare none of the four (IfcCartesianPoint
  * and friends), so this can never be "all rows". The floor is 400 — under the
- * measured 488 with ~18% headroom for schema churn, and comfortably under the
- * 444 that the ROW_FLOOR boundary itself yields, so the two floors cannot
- * contradict each other. Every way this extraction goes blind at the attribute
- * level takes the resolved count to zero, never to 399.
+ * measured 488 with ~18% headroom for schema churn, and under the 412 that the
+ * ROW_FLOOR boundary's worst case yields (a 700-row subset that keeps all 288
+ * non-resolvers still costs only 700 - 288 = 412), so the two floors still
+ * cannot contradict each other, just with a real margin of 12 rows (2.9%), not
+ * the 44 a same-proportion read of 700/776 suggests.
+ *
+ * That margin only has to cover one of this generator's two failure shapes,
+ * not both. At the generator level, `typescript-generator.ts` emits
+ * `allAttributes` for every entity unconditionally, so a failure there is
+ * all-or-nothing — it takes the resolved count to zero (see ANTI-VACUITY
+ * above), never to something in between. One level further down, inside
+ * `getAllAttributes` (`packages/codegen/src/express-parser.ts`), the
+ * inheritance walk silently stops when a supertype name isn't found in
+ * `schema.entities` — no error, no distinction from a legitimate root — so a
+ * PARTIAL loss is reachable there, scoped to whichever ancestor's subtree lost
+ * its parent link, and it is not bounded away from this floor's slack. Today's
+ * registry has no such break, but measuring what one would cost: 201 of the
+ * 488 resolved entities resolve ONLY through an inherited attribute, and the
+ * single costliest ancestor is `IfcRoot` at 70 rows (`IfcRelationship` 47,
+ * `IfcObject` 31, `IfcTypeProduct` 21, `IfcElement` 20) — every one of those
+ * comfortably inside this floor's 88-row slack, so RESOLVED_FLOOR alone would
+ * wave a loss that size through. `--check`'s semantic drift comparison against
+ * the committed table is the actual backstop for this failure mode, not a
+ * floor value.
  */
 const RESOLVED_FLOOR = 400;
 

--- a/scripts/generate-server-attr-indices.mjs
+++ b/scripts/generate-server-attr-indices.mjs
@@ -40,6 +40,19 @@
  * the way `generate-bim-globals.mjs` already refuses its own empty schema, and
  * a measured floor stands behind that (see ROW_FLOOR).
  *
+ * A row count alone does not close that hole, though — it only moves it one
+ * level down. `allAttributes` is OPTIONAL on the registry's `EntityMetadata`
+ * (`allAttributes?: AttributeMetadata[]`) and `getAllAttributesForEntity`
+ * returns `metadata?.allAttributes || []`, so a registry whose `entities` map
+ * is fully populated while `allAttributes` stops being emitted yields a
+ * healthy-looking 776 rows in which EVERY row is `[-1,-1,-1,-1]`. Measured on
+ * exactly that shape: 776 arms written, exit 0, and `--check` blessing the
+ * result from the next run on. Per the generated header, -1 means "known type
+ * that does not declare the attribute (never fall back)", so the server-parse
+ * path would report Description / ObjectType / Tag / PredefinedType as absent
+ * for every entity while the browser resolves them normally — the same parity
+ * break, reached by a different route. RESOLVED_FLOOR guards that level.
+ *
  * Output: apps/server/src/services/data_model/generated/attr_indices.rs
  */
 
@@ -62,14 +75,43 @@ const NAMES = ['Description', 'ObjectType', 'Tag', 'PredefinedType'];
  *
  * MEASURED, not guessed: a healthy `@ifc-lite/parser` build yields 776 types
  * from IFC4_ADD2_TC1 (the figure `--check` prints on a clean tree). The floor
- * is 500 — deep headroom on purpose, since it has to survive the registry
- * being pointed at a smaller schema one day (IFC2X3 declares roughly 650
- * entities) while still catching what it is for: every way this extraction can
- * go blind — a half-built dist, a renamed export, an `entities` map that
- * stopped being populated — takes the count to zero or single digits, never to
- * 499.
+ * is 700.
+ *
+ * It used to be 500, justified by needing headroom in case the registry were
+ * pointed at a smaller schema (IFC2X3, ~650 entities). That justification was
+ * not true: there is no runtime schema selection here. `SCHEMA_REGISTRY` is a
+ * single committed codegen artifact pinned to IFC4_ADD2_TC1, and the
+ * multi-schema union lives elsewhere — in `ifc-schema.ts`'s
+ * `ENTITY_INFO_BY_UPPER`, reachable only through
+ * `getAttributeNamesAcrossSchemas`, which this generator never calls (it calls
+ * the pinned `getAttributeNames`). Repinning the codegen would be a
+ * regenerate-and-commit event, which is exactly what the failure message below
+ * already instructs. Measured on the old value: 499 rows refused and 500 rows
+ * WROTE, replacing all 776 committed arms and exiting 0 — so the 500..775 band
+ * was unguarded slack that bought nothing. 700 keeps ~10% headroom under
+ * today's 776 for ordinary schema churn while shrinking that band.
  */
-const ROW_FLOOR = 500;
+const ROW_FLOOR = 700;
+
+/**
+ * Lower bound on how many of those rows must actually RESOLVE at least one of
+ * the four attributes.
+ *
+ * The row count is necessary but not sufficient (see ANTI-VACUITY above): a
+ * registry with a full `entities` map and no `allAttributes` produces 776 rows
+ * that are every one of them `[-1,-1,-1,-1]` — a table that says "no known type
+ * declares Description, ObjectType, Tag or PredefinedType", which is garbage
+ * the row floor waves through.
+ *
+ * MEASURED, not guessed: 488 of today's 776 rows resolve at least one
+ * attribute; the other 288 legitimately declare none of the four (IfcCartesianPoint
+ * and friends), so this can never be "all rows". The floor is 400 — under the
+ * measured 488 with ~18% headroom for schema churn, and comfortably under the
+ * 444 that the ROW_FLOOR boundary itself yields, so the two floors cannot
+ * contradict each other. Every way this extraction goes blind at the attribute
+ * level takes the resolved count to zero, never to 399.
+ */
+const RESOLVED_FLOOR = 400;
 
 // A stale or half-built dist imports cleanly and still exports nothing. Refuse
 // before either mode runs: in write mode an empty registry emits an armless
@@ -102,6 +144,30 @@ if (rows.length < ROW_FLOOR) {
       'break this generator exists to prevent, and `--check` would report it as in sync forever after.\n' +
       '   Rebuild with `pnpm turbo build --filter=@ifc-lite/parser` and retry. If the registry genuinely ' +
       'shrank this far, lower ROW_FLOOR in the same commit.',
+  );
+  process.exit(1);
+}
+
+// Rows are cheap; RESOLVED rows are the payload. A registry that kept its
+// `entities` map but lost `allAttributes` clears ROW_FLOOR with 776 rows of
+// `[-1,-1,-1,-1]` — see RESOLVED_FLOOR.
+const resolved = rows.filter((r) => r.idx.some((i) => i >= 0)).length;
+
+if (resolved < RESOLVED_FLOOR) {
+  console.error(
+    `❌ @ifc-lite/parser's SCHEMA_REGISTRY (${SCHEMA_REGISTRY.name}) yielded ${rows.length} entity type(s), ` +
+      `but only ${resolved} of them resolve ANY of ${NAMES.join('/')} — the floor is ${RESOLVED_FLOOR} ` +
+      `(a healthy build resolves 488 of 776). Refusing to ${CHECK ? 'compare against' : 'emit'} an ` +
+      'attribute-index table this blind.\n' +
+      '   A row count alone cannot catch this: `allAttributes` is optional on the registry\'s entity ' +
+      'metadata and `getAllAttributesForEntity` returns `metadata?.allAttributes || []`, so an `entities` ' +
+      'map that is fully populated while `allAttributes` stopped being emitted writes one arm per type ' +
+      'with every index -1. Per this table\'s own contract -1 means "known type, does not declare that ' +
+      'attribute, never fall back" — so the server-parse path would report Description/ObjectType/Tag/' +
+      'PredefinedType as absent for EVERY entity while the browser resolves them normally, and `--check` ' +
+      'would report it as in sync forever after.\n' +
+      '   Rebuild with `pnpm turbo build --filter=@ifc-lite/parser` and retry. If the registry genuinely ' +
+      'stopped declaring these attributes, lower RESOLVED_FLOOR in the same commit.',
   );
   process.exit(1);
 }

--- a/scripts/generate-server-attr-indices.mjs
+++ b/scripts/generate-server-attr-indices.mjs
@@ -25,6 +25,21 @@
  * rustfmt reflowing the single-line arms into multiple lines — no Rust
  * toolchain required in CI (issue #1780).
  *
+ * ANTI-VACUITY (#3200): a stale or half-built `packages/parser/dist` imports
+ * cleanly and exports an empty `SCHEMA_REGISTRY`, and this script used to
+ * cooperate with it in the worst possible way. `--check` correctly went red
+ * (every committed row reads as stale), but the remedy it printed says
+ * "regenerate" — and regenerating against an empty extraction writes a `match`
+ * with no arms at all. `root_attr_indices` then returns `None` for every type,
+ * which per the note above means every KNOWN type falls back to the
+ * unknown-type indices [3,4,7]: exactly the parity break this generator exists
+ * to prevent, with `--check` printing ✓ from then on. The `(0 types, …)` count
+ * in the success line was the only tell.
+ *
+ * So the registry is now checked for emptiness before EITHER mode proceeds,
+ * the way `generate-bim-globals.mjs` already refuses its own empty schema, and
+ * a measured floor stands behind that (see ROW_FLOOR).
+ *
  * Output: apps/server/src/services/data_model/generated/attr_indices.rs
  */
 
@@ -41,6 +56,35 @@ const { SCHEMA_REGISTRY, getAttributeNames } = await import(
 
 const NAMES = ['Description', 'ObjectType', 'Tag', 'PredefinedType'];
 
+/**
+ * Lower bound on how many entity types the registry must yield before this
+ * script will write or bless anything.
+ *
+ * MEASURED, not guessed: a healthy `@ifc-lite/parser` build yields 776 types
+ * from IFC4_ADD2_TC1 (the figure `--check` prints on a clean tree). The floor
+ * is 500 — deep headroom on purpose, since it has to survive the registry
+ * being pointed at a smaller schema one day (IFC2X3 declares roughly 650
+ * entities) while still catching what it is for: every way this extraction can
+ * go blind — a half-built dist, a renamed export, an `entities` map that
+ * stopped being populated — takes the count to zero or single digits, never to
+ * 499.
+ */
+const ROW_FLOOR = 500;
+
+// A stale or half-built dist imports cleanly and still exports nothing. Refuse
+// before either mode runs: in write mode an empty registry emits an armless
+// `match` (every known type silently falls back to the unknown-type indices),
+// and in check mode it would bless that file on the very next run.
+if (!SCHEMA_REGISTRY?.entities || typeof SCHEMA_REGISTRY.entities !== 'object') {
+  console.error(
+    '❌ SCHEMA_REGISTRY.entities is missing or not an object in ' +
+      'packages/parser/dist/index.js — stale or broken build; refusing to ' +
+      'derive an attribute-index table from it.\n' +
+      '   Rebuild with `pnpm turbo build --filter=@ifc-lite/parser` and retry.',
+  );
+  process.exit(1);
+}
+
 const rows = Object.keys(SCHEMA_REGISTRY.entities)
   .map((key) => {
     const names = getAttributeNames(key);
@@ -48,6 +92,19 @@ const rows = Object.keys(SCHEMA_REGISTRY.entities)
     return { upper: key.toUpperCase(), idx };
   })
   .sort((a, b) => (a.upper < b.upper ? -1 : 1));
+
+if (rows.length < ROW_FLOOR) {
+  console.error(
+    `❌ @ifc-lite/parser's SCHEMA_REGISTRY (${SCHEMA_REGISTRY.name}) yielded only ${rows.length} entity ` +
+      `type(s); the floor is ${ROW_FLOOR}. Refusing to ${CHECK ? 'compare against' : 'emit'} an ` +
+      'attribute-index table derived from an extraction this thin — a `match` with no arms (or almost ' +
+      'none) makes every known type fall back to the unknown-type indices [3,4,7], which is the parity ' +
+      'break this generator exists to prevent, and `--check` would report it as in sync forever after.\n' +
+      '   Rebuild with `pnpm turbo build --filter=@ifc-lite/parser` and retry. If the registry genuinely ' +
+      'shrank this far, lower ROW_FLOOR in the same commit.',
+  );
+  process.exit(1);
+}
 
 const arms = rows
   .map(({ upper, idx }) => `        "${upper}" => Some(RootAttrIndices { description: ${idx[0]}, object_type: ${idx[1]}, tag: ${idx[2]}, predefined_type: ${idx[3]} }),`)

--- a/scripts/generate-server-attr-indices.test.mjs
+++ b/scripts/generate-server-attr-indices.test.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Black-box regression harness for scripts/generate-server-attr-indices.mjs.
+ *
+ * Method mirrors scripts/check-module-size.test.mjs: each case builds a
+ * synthetic tree in a temp dir outside the repo — a fake
+ * `packages/parser/dist/index.js` plus a VERBATIM byte copy of the generator
+ * (it resolves the repo root from its own location, so it has to live in the
+ * tree) — runs it, and asserts the exit code AND the message. Nothing here
+ * reads the generator's source or its constants.
+ *
+ * The cases that matter are the ones where this generator could succeed having
+ * derived nothing usable. It has two such levels and they fail differently:
+ *
+ *   - no rows      — an empty or half-built dist writes a `match` with no arms,
+ *                    so every KNOWN type falls back to the unknown-type indices
+ *                    [3,4,7]. Caught by the row floor.
+ *   - no RESOLVED  — `allAttributes` is optional on the registry's entity
+ *     rows        metadata and `getAllAttributesForEntity` returns
+ *                    `metadata?.allAttributes || []`, so a fully populated
+ *                    `entities` map with no `allAttributes` writes one arm per
+ *                    type with every index -1. The row count looks healthy; the
+ *                    table says no known type declares any of the four
+ *                    attributes, and -1 means "never fall back". Measured on
+ *                    that exact shape before the resolved floor existed: 776
+ *                    arms, exit 0, and `--check` printing ✓ from then on.
+ *
+ * Both are pinned below as executable "must exit non-zero, and must not touch
+ * the committed file" cases, in BOTH modes.
+ *
+ * Run: node --test scripts/generate-server-attr-indices.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, existsSync, rmSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const GENERATOR = join(ROOT, 'scripts', 'generate-server-attr-indices.mjs');
+const OUT_REL = 'apps/server/src/services/data_model/generated/attr_indices.rs';
+
+/** The four attributes the table carries, in the generator's own order. */
+const FULL_ATTRS = ['GlobalId', 'OwnerHistory', 'Name', 'Description', 'ObjectType', 'Tag', 'PredefinedType'];
+
+const cleanup = [];
+process.on('exit', () => {
+  for (const d of cleanup) rmSync(d, { recursive: true, force: true });
+});
+
+/**
+ * Build a tree whose registry exposes `entities` entity types, of which the
+ * first `resolved` return a real attribute list and the rest return `[]` — the
+ * shape `metadata?.allAttributes || []` produces when `allAttributes` is gone.
+ *
+ * `committed` seeds the output path with that text (omit to leave it absent).
+ */
+function tree({ entities, resolved, committed, registryName = 'IFC4_ADD2_TC1' }) {
+  const dir = mkdtempSync(join(tmpdir(), 'attr-indices-'));
+  cleanup.push(dir);
+
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  mkdirSync(join(dir, 'packages/parser/dist'), { recursive: true });
+  // Verbatim copy — the generator under test, byte for byte.
+  copyFileSync(GENERATOR, join(dir, 'scripts', 'generate-server-attr-indices.mjs'));
+
+  writeFileSync(
+    join(dir, 'packages/parser/dist/index.js'),
+    `export const SCHEMA_REGISTRY = {\n` +
+      `  name: ${JSON.stringify(registryName)},\n` +
+      `  entities: Object.fromEntries(\n` +
+      `    Array.from({ length: ${entities} }, (_, i) => ['IfcProbe' + i, { name: 'IfcProbe' + i }]),\n` +
+      `  ),\n` +
+      `};\n` +
+      `const FULL = ${JSON.stringify(FULL_ATTRS)};\n` +
+      `export function getAttributeNames(type) {\n` +
+      `  const i = Number(type.slice('IfcProbe'.length));\n` +
+      // Mirrors `getAllAttributesForEntity`: `metadata?.allAttributes || []`.
+      `  return i < ${resolved} ? FULL : [];\n` +
+      `}\n`,
+  );
+
+  if (committed !== undefined) {
+    mkdirSync(join(dir, dirname(OUT_REL)), { recursive: true });
+    writeFileSync(join(dir, OUT_REL), committed);
+  }
+  return dir;
+}
+
+function run(dir, ...args) {
+  const res = spawnSync(process.execPath, [join(dir, 'scripts', 'generate-server-attr-indices.mjs'), ...args], {
+    encoding: 'utf8',
+  });
+  return { code: res.status, out: `${res.stdout}${res.stderr}` };
+}
+
+/** sha256 of the output file, or null when it does not exist. */
+function outHash(dir) {
+  const p = join(dir, OUT_REL);
+  return existsSync(p) ? createHash('sha256').update(readFileSync(p)).digest('hex') : null;
+}
+
+/** The text a healthy run would produce for this tree — used as seed content. */
+function healthyTable(dir) {
+  run(dir);
+  return readFileSync(join(dir, OUT_REL), 'utf8');
+}
+
+test('a healthy registry writes one arm per type', () => {
+  const dir = tree({ entities: 776, resolved: 488 });
+  const { code, out } = run(dir);
+  assert.equal(code, 0, out);
+  assert.match(out, /\(776 types, registry IFC4_ADD2_TC1\)/);
+  const rs = readFileSync(join(dir, OUT_REL), 'utf8');
+  assert.equal((rs.match(/=> Some\(RootAttrIndices/g) ?? []).length, 776);
+  assert.match(rs, /"IFCPROBE0" => Some\(RootAttrIndices \{ description: 3, object_type: 4, tag: 5, predefined_type: 6 \}\)/);
+});
+
+test('a full entities map with no allAttributes is refused, not written', () => {
+  // The row count is healthy — 776 — and every single row would be [-1,-1,-1,-1].
+  const seed = healthyTable(tree({ entities: 776, resolved: 488 }));
+  const dir = tree({ entities: 776, resolved: 0, committed: seed });
+  const before = outHash(dir);
+
+  const { code, out } = run(dir);
+  assert.equal(code, 1, out);
+  assert.match(out, /776 entity type\(s\), but only 0 of them resolve ANY of/);
+  assert.match(out, /Description\/ObjectType\/Tag\/PredefinedType/);
+  assert.match(out, /Refusing to emit/);
+  // A generator that half-writes on refusal is worse than one that writes garbage.
+  assert.equal(outHash(dir), before, 'refusal must leave the committed table byte-identical');
+});
+
+test('--check does not bless a table derived from an unresolvable registry', () => {
+  const seed = healthyTable(tree({ entities: 776, resolved: 488 }));
+  const dir = tree({ entities: 776, resolved: 0, committed: seed });
+  const before = outHash(dir);
+
+  const { code, out } = run(dir, '--check');
+  assert.equal(code, 1, out);
+  assert.match(out, /only 0 of them resolve ANY of/);
+  assert.match(out, /Refusing to compare against/);
+  // The success line specifically — the refusal text quotes "in sync" itself.
+  assert.doesNotMatch(out, /✓ attr_indices\.rs in sync/);
+  assert.equal(outHash(dir), before);
+});
+
+test('the resolved floor sits at 400: 399 refuses, 400 passes', () => {
+  const low = run(tree({ entities: 776, resolved: 399 }));
+  assert.equal(low.code, 1, low.out);
+  assert.match(low.out, /only 399 of them resolve ANY of/);
+
+  const dir = tree({ entities: 776, resolved: 400 });
+  const ok = run(dir);
+  assert.equal(ok.code, 0, ok.out);
+  assert.equal(outHash(dir) !== null, true);
+});
+
+test('the row floor sits at 700: 699 refuses, 700 passes', () => {
+  const low = run(tree({ entities: 699, resolved: 488 }));
+  assert.equal(low.code, 1, low.out);
+  assert.match(low.out, /yielded only 699 entity type\(s\); the floor is 700/);
+
+  const ok = run(tree({ entities: 700, resolved: 488 }));
+  assert.equal(ok.code, 0, ok.out);
+});
+
+test('an empty entities map is refused in both modes and writes nothing', () => {
+  for (const args of [[], ['--check']]) {
+    const dir = tree({ entities: 0, resolved: 0 });
+    const { code, out } = run(dir, ...args);
+    assert.equal(code, 1, out);
+    assert.match(out, /yielded only 0 entity type\(s\)/);
+    assert.equal(outHash(dir), null, 'nothing may be written when the registry is empty');
+  }
+});

--- a/scripts/generate-server-attr-indices.test.mjs
+++ b/scripts/generate-server-attr-indices.test.mjs
@@ -95,6 +95,27 @@ function tree({ entities, resolved, committed, registryName = 'IFC4_ADD2_TC1' })
   return dir;
 }
 
+/**
+ * A tree whose `SCHEMA_REGISTRY.entities` is missing entirely — distinct from
+ * `tree({ entities: 0, ... })`, which still yields `entities: {}` (a real,
+ * empty object) and is caught by ROW_FLOOR instead. This is the case the
+ * empty-registry guard (checked before either floor) exists for: a stale or
+ * broken build whose `entities` key isn't there, or isn't an object, at all.
+ */
+function brokenDist() {
+  const dir = mkdtempSync(join(tmpdir(), 'attr-indices-'));
+  cleanup.push(dir);
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  mkdirSync(join(dir, 'packages/parser/dist'), { recursive: true });
+  copyFileSync(GENERATOR, join(dir, 'scripts', 'generate-server-attr-indices.mjs'));
+  writeFileSync(
+    join(dir, 'packages/parser/dist/index.js'),
+    `export const SCHEMA_REGISTRY = { name: 'IFC4_ADD2_TC1' };\n` +
+      `export function getAttributeNames() { return []; }\n`,
+  );
+  return dir;
+}
+
 function run(dir, ...args) {
   const res = spawnSync(process.execPath, [join(dir, 'scripts', 'generate-server-attr-indices.mjs'), ...args], {
     encoding: 'utf8',
@@ -165,9 +186,17 @@ test('the resolved floor sits at 400: 399 refuses, 400 passes', () => {
 });
 
 test('the row floor sits at 700: 699 refuses, 700 passes', () => {
-  const low = run(tree({ entities: 699, resolved: 488 }));
+  // Seed a committed table (from a healthy 700-entity run) so the refusal
+  // path's byte-identity claim is actually pinned, not just asserted for the
+  // RESOLVED_FLOOR and empty-registry cases.
+  const seed = healthyTable(tree({ entities: 700, resolved: 488 }));
+  const dir = tree({ entities: 699, resolved: 488, committed: seed });
+  const before = outHash(dir);
+
+  const low = run(dir);
   assert.equal(low.code, 1, low.out);
   assert.match(low.out, /yielded only 699 entity type\(s\); the floor is 700/);
+  assert.equal(outHash(dir), before, 'refusal must leave the committed table byte-identical');
 
   const ok = run(tree({ entities: 700, resolved: 488 }));
   assert.equal(ok.code, 0, ok.out);
@@ -180,5 +209,19 @@ test('an empty entities map is refused in both modes and writes nothing', () => 
     assert.equal(code, 1, out);
     assert.match(out, /yielded only 0 entity type\(s\)/);
     assert.equal(outHash(dir), null, 'nothing may be written when the registry is empty');
+  }
+});
+
+test('a registry with no entities map at all is refused by the named guard, not ROW_FLOOR', () => {
+  for (const args of [[], ['--check']]) {
+    const dir = brokenDist();
+    const { code, out } = run(dir, ...args);
+    assert.equal(code, 1, out);
+    assert.match(out, /SCHEMA_REGISTRY\.entities is missing or not an object/);
+    // Distinct from the `entities: {}` case: this must NOT be reported as the
+    // row-floor refusal, since that would mean the guard did nothing this
+    // shape didn't already get from ROW_FLOOR.
+    assert.doesNotMatch(out, /yielded only/);
+    assert.equal(outHash(dir), null, 'nothing may be written when entities is missing');
   }
 });


### PR DESCRIPTION
Findings **4, 5 and 6** of #3200. Findings 1 (#3201), 2 and 3 are handled elsewhere and are untouched here. One commit per finding.

All three still held against current `main`. Findings 5 and 6 were recorded in the issue as READ rather than RUN, because breaking `read_dir` on a shared checkout was judged unacceptable — this was done in an isolated worktree, so they were **run**, and the vacuous pass is reproduced verbatim below. Every gate here was watched failing before it was trusted.

---

## 4. `scripts/generate-server-attr-indices.mjs`

**Still holds.** Reproduced in a synthetic tree whose `packages/parser/dist/index.js` imports cleanly and exports `SCHEMA_REGISTRY = { name: 'EMPTY', entities: {} }`.

**(a) before — the correct verdict with the ruinous remedy:**

```
$ node scripts/generate-server-attr-indices.mjs --check
✗ apps/server/.../generated/attr_indices.rs is out of sync with @ifc-lite/parser's SCHEMA_REGISTRY (EMPTY).
  Regenerate: pnpm turbo build --filter=@ifc-lite/parser && node scripts/generate-server-attr-indices.mjs && cargo fmt -p ifc-lite-server
  stale row (not in registry): IFCACTIONREQUEST
  stale row (not in registry): IFCACTOR
  stale row (not in registry): IFCACTORROLE
EXIT=1

$ node scripts/generate-server-attr-indices.mjs          # doing exactly what it just said
wrote /private/tmp/attrtree/apps/.../attr_indices.rs (0 types, registry EMPTY)
EXIT=0

$ node scripts/generate-server-attr-indices.mjs --check
✓ attr_indices.rs in sync (0 types, registry EMPTY)
EXIT=0

$ grep -n 'match upper_type_name' -A3 apps/.../attr_indices.rs
29:    match upper_type_name {
30-
31-        _ => None,
32-    }
```

An armless `match` means `root_attr_indices` returns `None` for every type, and per the file's own header every KNOWN type then falls back to the unknown-type indices `[3,4,7]` — the parity break the generator exists to prevent, green forever after.

**(b) after — both modes refuse, naming the count, the floor and what they expected:**

```
$ node scripts/generate-server-attr-indices.mjs --check
❌ @ifc-lite/parser's SCHEMA_REGISTRY (EMPTY) yielded only 0 entity type(s); the floor is 500. Refusing to compare against an attribute-index table derived from an extraction this thin — a `match` with no arms (or almost none) makes every known type fall back to the unknown-type indices [3,4,7], which is the parity break this generator exists to prevent, and `--check` would report it as in sync forever after.
   Rebuild with `pnpm turbo build --filter=@ifc-lite/parser` and retry. If the registry genuinely shrank this far, lower ROW_FLOOR in the same commit.
EXIT=1

$ node scripts/generate-server-attr-indices.mjs
❌ ... Refusing to emit an attribute-index table derived from an extraction this thin — ...
EXIT=1

$ grep -c 'Some(RootAttrIndices' apps/.../attr_indices.rs
776                                   # committed table left untouched
```

And the registry-shape guard, mirroring `generate-bim-globals.mjs`'s own two refusals — a dist whose registry lost its `entities` map:

```
$ node scripts/generate-server-attr-indices.mjs --check
❌ SCHEMA_REGISTRY.entities is missing or not an object in packages/parser/dist/index.js — stale or broken build; refusing to derive an attribute-index table from it.
   Rebuild with `pnpm turbo build --filter=@ifc-lite/parser` and retry.
EXIT=1
```

(Honest note: before this change that particular shape threw out of `Object.keys(undefined)`, i.e. it already failed loudly. The explicit branch is a message improvement, not a vacuity fix. The `rows.length` floor is the vacuity fix.)

**(c) real repo, unchanged:**

```
$ node scripts/generate-server-attr-indices.mjs --check
✓ attr_indices.rs in sync (776 types, registry IFC4_ADD2_TC1)
EXIT=0
```

**Measured count 776, floor `ROW_FLOOR = 500`.** Deliberately deep headroom rather than the usual third: this figure has to survive the registry being pointed at a smaller schema one day (IFC2X3 declares roughly 650 entities) without a spurious red, while still catching what it is for — every way this extraction can go blind (a half-built dist, a renamed export, an `entities` map that stopped being populated) takes the count to zero or single digits, never to 499.

Precedent followed rather than invented: the empty-registry refusal is placed and worded after `generate-bim-globals.mjs`, which already refuses the identical condition before emitting.

---

## 5. `rust/processing/tests/module_size_ratchet.rs`

**Still holds — and now RUN.** Method: point the walk at a directory, run the gate, restore the file and prove byte-identity (`git status` clean) before making any real change.

**(a) before — green over zero files, twice.** `for top in ["rust", "apps"]` temporarily repointed at an empty directory, then at one that does not exist:

```
$ mkdir vacuity_probe_empty        # walk repointed here
$ cargo test -p ifc-lite-processing --test module_size_ratchet
test no_module_grows_past_its_ratchet_budget ... ok
test result: ok. 5 passed; 0 failed; ...

$ ls vacuity_probe_missing         # walk repointed here
ls: vacuity_probe_missing: No such file or directory
$ cargo test -p ifc-lite-processing --test module_size_ratchet
test no_module_grows_past_its_ratchet_budget ... ok
test result: ok. 5 passed; 0 failed; ...
```

**(b) after — three separate refusals, each watched firing.**

Empty directory:

```
thread 'no_module_grows_past_its_ratchet_budget' panicked at rust/processing/tests/module_size_ratchet.rs:231:5:
module-size ratchet walked rust/ and apps/ and reached only 0 non-exempt .rs file(s); the floor is 240. Refusing a vacuous pass: every check below iterates this list, so a count this low means the walk stopped working, not that the modules went away. If crates were genuinely removed, lower FILE_FLOOR in the same commit.
test result: FAILED. 0 passed; 1 failed; ...
```

Missing directory — the swallowed `read_dir`:

```
thread 'no_module_grows_past_its_ratchet_budget' panicked at rust/processing/tests/module_size_ratchet.rs:90:67:
module-size ratchet: .../vacuity_probe_missing does not exist. Refusing to treat a missing directory as one holding no .rs files - a walk root that is not there means this gate is looking in the wrong place, not that the tree is clean.
```

A `.rs` file that cannot be read — the `unwrap_or(0)` swallow (fixture: a dangling symlink named `dangling.rs`, deterministic for every user, unlike `chmod 000` which does not stop root):

```
thread 'no_module_grows_past_its_ratchet_budget' panicked at rust/processing/tests/module_size_ratchet.rs:169:21:
module-size ratchet: .../vacuity_probe_unreadable/dangling.rs could not be read (No such file or directory (os error 2)). Refusing to count an unreadable file as 0 lines - 0 is under every budget, so the file would pass the ratchet without ever being measured.
```

**(c) real repo:**

```
$ cargo test -p ifc-lite-processing --test module_size_ratchet
running 5 tests
test evaluate_is_clean_when_within_budget ... ok
test evaluate_fires_on_new_god_file_and_over_budget ... ok
test allowlist_is_well_formed_and_over_limit ... ok
test allowlist_digest_is_pinned ... ok
test no_module_grows_past_its_ratchet_budget ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

**Measured count 362 non-exempt `.rs` files under `rust/` + `apps/` (read off the gate itself, by raising the floor to `usize::MAX` and reading its own failure message). Floor `FILE_FLOOR = 240`, roughly two thirds.** The number only has to separate "the walk works" from "the walk went blind", and every way it goes blind takes it to zero or a handful, never to a plausible fraction. Deleting a whole crate is the only ordinary event that would approach 240, and that is a change worth editing the line for.

The advisory `note:` lines, the `"Shrink or split instead of raising the budget"` remedy and `ALLOWLIST_DIGEST` are untouched — as the issue says, this needed a floor, not a redesign.

---

## 6. `rust/processing/tests/styling_parity.rs`

**Still holds — and now RUN.** Same method.

**(a) before — green over zero files, twice, with not even a `note:` on stderr:**

```
$ mkdir vacuity_probe_empty        # both walk roots repointed here
$ cargo test -p ifc-lite-processing --test styling_parity
test no_duplicate_default_color_tables ... ok
test no_duplicate_surface_style_color_extraction ... ok
test result: ok. 5 passed; 0 failed; ...

$ ls vacuity_probe_missing         # both walk roots repointed here
ls: vacuity_probe_missing: No such file or directory
$ cargo test -p ifc-lite-processing --test styling_parity
test no_duplicate_default_color_tables ... ok
test no_duplicate_surface_style_color_extraction ... ok
test result: ok. 5 passed; 0 failed; ...
```

**(b) after.** Empty directory — both guards:

```
thread 'no_duplicate_default_color_tables' panicked at rust/processing/tests/styling_parity.rs:376:5:
styling parity walked rust/ and apps/ and reached only 0 .rs file(s); the floor is 440. Refusing a vacuous pass: this guard concludes that no second default-color table exists, and a scan that examined this little has established no such thing.

thread 'no_duplicate_surface_style_color_extraction' panicked at rust/processing/tests/styling_parity.rs:440:5:
styling parity walked rust/ and apps/ and reached only 0 .rs file(s); the floor is 440. Refusing a vacuous pass: this guard concludes that no second surface-style colour extractor exists, and a scan that examined this little has established no such thing.

test result: FAILED. 0 passed; 2 failed; ...
```

Missing directory:

```
thread 'no_duplicate_surface_style_color_extraction' panicked at rust/processing/tests/styling_parity.rs:241:67:
styling parity: .../vacuity_probe_missing does not exist. Refusing to treat a missing directory as one holding no .rs files - these guards conclude from an absence, so a scan root that is not there would read as clean.
```

And the **positive control** the issue asked for, which a file count cannot give you. With `declares_surface_style_extractor` stubbed to return `false` — the walk intact, 659 files read, detector blind:

```
thread 'no_duplicate_surface_style_color_extraction' panicked at rust/processing/tests/styling_parity.rs:478:5:
the surface-style detector matched nothing at all across 659 walked file(s), not even the exempt `rust/geometry/examples/` copy it is allowed to find. An absence guard that cannot find a declaration it KNOWS is there has stopped detecting, so its empty offender list means nothing. If that example was deliberately removed, retire this control in the same commit.
```

`rust/geometry/examples/color_extraction_test.rs` really does declare `fn extract_color_from_rendering` and `fn extract_color_rgb` — it is on the allowlist for exactly that reason — so this is an end-to-end control against a real, known occurrence, not a synthetic one. The `no_duplicate_default_color_tables` half has no such live occurrence (its allowlist entry is this test file, which mentions the name only in prose), so it gets the synthetic control instead: both detectors are extracted into named functions and `the_detectors_still_fire_on_a_known_violation` asserts each fires on a real declaration and does **not** fire on prose or on a call site.

**(c) real repo:**

```
$ cargo test -p ifc-lite-processing --test styling_parity
running 6 tests
test exactly_four_types_change_per_table ... ok
test the_detectors_still_fire_on_a_known_violation ... ok
test union_agrees_with_both_tables_on_uncontested_types ... ok
test union_picks_the_documented_winner_for_contested_types ... ok
test no_duplicate_default_color_tables ... ok
test no_duplicate_surface_style_color_extraction ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

**Measured count 659 `.rs` files under `rust/` + `apps/` (this walk does not apply the ratchet's exemptions, hence the higher figure). Floor `SCANNED_FLOOR = 440`, roughly two thirds**, same justification.

---

## The swallowed directory error

The issue asked whether the two Rust gates swallow a missing/unreadable directory the way the JS gates did. **They do** — `let Ok(entries) = std::fs::read_dir(dir) else { return; };`, identical in both files, collapsing "not there", "cannot be opened" and "holds no Rust files" into one result. Both are now hard errors and the two causes are **distinguished**, because they call for different fixes: a missing scan root means the gate is looking in the wrong place, an unreadable one means the environment is broken. Two adjacent swallows went with them: `entries.flatten()` (a per-entry read error silently dropped) in both files, and in `styling_parity` the per-file `let Ok(src) = read_to_string(&path) else { continue; };` — for an absence guard, a file that could not be read is not an absence.

## Checks

- `cargo test -p ifc-lite-processing` — green, no failures. `styling_parity.rs` lives in this crate, so it is the crate that owns both Rust gates.
- `cargo clippy --workspace --exclude ifc-lite-wasm --all-targets` — clean, no warnings, no errors.
- `pnpm lint` (after `pnpm build`) — `EXIT=0`; `lint: 3,596 files across 3 targets, 98 rules, no errors.`

## No changeset

`scripts/generate-server-attr-indices.mjs` is a CI-only generator gate and the two Rust changes are test-only. Nothing ships to a published package, so no changeset — `check-changesets` passes as part of the green `pnpm lint` above.

Refs #3200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened source scans to detect missing, unreadable, or incomplete data instead of treating it as empty.
  * Added minimum scan thresholds to prevent incomplete checks from passing silently.
  * Improved diagnostics for failed scans and invalid generated attribute data.

* **Tests**
  * Added coverage for incomplete registries, unresolved attributes, unreadable files, and insufficient scan results.
  * Added positive and negative validation tests for styling and module-size checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->