### PR TITLE
fix: close the tail of the vacuity audit — findings 7, 9, 10 (and why 8 stays open) (#3200)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -958,6 +958,14 @@ jobs:
       # paths). Keep the docs in lockstep with the code they describe.
       - name: Check package READMEs
         run: node scripts/docs/check-package-readmes.mjs
+      # That gate printed `✅ All 0 published packages have a README.md.` over
+      # an empty packages/, and dropped an unreadable package directory out of
+      # the count in silence (#3200, finding 9). Its floors are executable, so
+      # they are run rather than trusted — and named here rather than left to
+      # the catch-all glob below, which is per-DIRECTORY and did not reach
+      # scripts/docs/ when this was written.
+      - name: Check the README gate cannot pass vacuously
+        run: node --test scripts/docs/check-package-readmes.test.mjs
       - name: Check doc code samples
         run: node scripts/docs/check-doc-samples.mjs
       - name: Check generated doc sections

--- a/scripts/ci-wasm-prebuilt-eligible.sh
+++ b/scripts/ci-wasm-prebuilt-eligible.sh
@@ -54,6 +54,33 @@ if ! _tag_present; then
   exit 0
 fi
 
+# ANTI-VACUITY (#3200, finding 10). `git diff --quiet` exits 0 for two very
+# different answers: "these paths are unchanged" and "your pathspec matched
+# nothing at either end". A single typo'd entry above therefore covers nothing,
+# silently, and moves this probe towards `true` — against the guarantee stated
+# at the top of this file that the fast path can NEVER cause a stale bundle to
+# be tested. Demonstrated on this repo:
+#
+#   $ git diff --quiet HEAD~1 HEAD -- rust Cargo.lock;      echo $?   # 1
+#   $ git diff --quiet HEAD~1 HEAD -- rustXX CargoXX.lock;  echo $?   # 0
+#
+# So every entry is required to name something real. "Real" means matching at
+# EITHER end — a path deleted since the tag still matches at the tag, and one
+# added since still matches at HEAD; only a name that exists at neither end is
+# a typo. A failure here is not fatal: it takes the same `false` route as every
+# other uncertainty, which costs a from-source build and nothing else.
+for _p in "${WASM_SRC_PATHS[@]}"; do
+  _at_tag="$(git ls-tree -r --name-only "refs/tags/${WASM_TAG}" -- "${_p}" 2>/dev/null | head -1 || true)"
+  _at_head="$(git ls-tree -r --name-only HEAD -- "${_p}" 2>/dev/null | head -1 || true)"
+  if [ -z "${_at_tag}" ] && [ -z "${_at_head}" ]; then
+    log "🛠  WASM_SRC_PATHS entry '${_p}' matches no file at ${WASM_TAG} or at HEAD —"
+    log "    it can only ever compare nothing, so the diff below would under-report."
+    log "    Build from source, and fix the list (keep it in lock-step with scripts/vercel-install.sh)."
+    echo false
+    exit 0
+  fi
+done
+
 if git diff --quiet "refs/tags/${WASM_TAG}" HEAD -- "${WASM_SRC_PATHS[@]}"; then
   log "🅰  WASM source identical to ${WASM_TAG} — prebuilt npm bundle is valid."
   echo true

--- a/scripts/ci-wasm-prebuilt-eligible.test.mjs
+++ b/scripts/ci-wasm-prebuilt-eligible.test.mjs
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for the pathspec assertion in ci-wasm-prebuilt-eligible.sh
+ * (#3200, finding 10).
+ *
+ * The probe's whole contract is that `false` is always safe and `true` is a
+ * claim: the WASM source is byte-identical to the release tag that built the
+ * published bundle, so CI may fetch that bundle instead of compiling. The
+ * claim rests on `git diff --quiet`, which exits 0 both for "unchanged" and
+ * for "your pathspec matched nothing at either end" — so one typo'd entry in
+ * WASM_SRC_PATHS made the probe answer `true` over a tree whose Rust source
+ * had demonstrably changed.
+ *
+ * Every case runs the real script against a real (tiny) git repository built
+ * here: a tagged commit, then a commit that changes the Rust source. No
+ * network — the tag exists locally, so the script's shallow fetch never runs.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, 'ci-wasm-prebuilt-eligible.sh');
+const TAG = '@ifc-lite/wasm@1.0.0';
+
+function git(cwd, ...args) {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+/**
+ * A repository shaped like the one the probe runs in: a wasm package version,
+ * every WASM_SRC_PATHS entry present, tagged, then one Rust source edit on top.
+ */
+function makeRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'wasm-eligible-'));
+  mkdirSync(join(root, 'packages', 'wasm'), { recursive: true });
+  mkdirSync(join(root, 'rust'), { recursive: true });
+  mkdirSync(join(root, 'scripts'), { recursive: true });
+  writeFileSync(join(root, 'packages', 'wasm', 'package.json'), '{"version":"1.0.0"}');
+  writeFileSync(join(root, 'rust', 'foo.rs'), 'fn main() {}\n');
+  writeFileSync(join(root, 'Cargo.lock'), 'lock v1\n');
+  writeFileSync(join(root, 'Cargo.toml'), '[workspace]\n');
+  writeFileSync(join(root, 'rust-toolchain.toml'), '[toolchain]\n');
+  writeFileSync(join(root, 'scripts', 'build-wasm.sh'), 'echo build\n');
+  git(root, 'init', '-q', '.');
+  git(root, 'config', 'user.email', 'harness@example.invalid');
+  git(root, 'config', 'user.name', 'harness');
+  git(root, 'add', '-A');
+  git(root, 'commit', '-q', '-m', 'tagged release content');
+  git(root, 'tag', TAG);
+  return root;
+}
+
+function changeRustSource(root) {
+  writeFileSync(join(root, 'rust', 'foo.rs'), 'fn main() { println!("changed"); }\n');
+  git(root, 'add', '-A');
+  git(root, 'commit', '-q', '-m', 'change the rust source since the tag');
+}
+
+/** Install the gate, optionally with one WASM_SRC_PATHS entry misspelled. */
+function installGate(root, { typo = false } = {}) {
+  let src = readFileSync(GATE, 'utf-8');
+  if (typo) {
+    const before = src;
+    src = src.replace(/^WASM_SRC_PATHS=\(rust /m, 'WASM_SRC_PATHS=(rustXX ');
+    assert.notEqual(src, before, 'the WASM_SRC_PATHS line moved — update this harness');
+  }
+  writeFileSync(join(root, 'scripts', 'ci-wasm-prebuilt-eligible.sh'), src);
+}
+
+function run(root) {
+  const res = spawnSync('bash', ['scripts/ci-wasm-prebuilt-eligible.sh'], {
+    cwd: root,
+    encoding: 'utf-8',
+  });
+  return { verdict: (res.stdout ?? '').trim(), log: res.stderr ?? '', status: res.status };
+}
+
+test('a typo in WASM_SRC_PATHS cannot buy a `true` over changed Rust source', () => {
+  const root = makeRepo();
+  changeRustSource(root);
+  installGate(root, { typo: true });
+  const { verdict, log } = run(root);
+  // Was: `🅰 WASM source identical to … — prebuilt npm bundle is valid.` and
+  // `true`, because the misspelled pathspec matched nothing at either end and
+  // `git diff --quiet` reports that as no difference.
+  assert.equal(verdict, 'false', log);
+  assert.match(log, /entry 'rustXX' matches no file at/);
+  assert.doesNotMatch(log, /prebuilt npm bundle is valid/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a typo is refused even when the sources really are unchanged', () => {
+  const root = makeRepo();
+  installGate(root, { typo: true });
+  const { verdict, log } = run(root);
+  // The answer would have been `true` legitimately here. It is still refused,
+  // because a list that cannot compare what it names has stopped being
+  // evidence — and `false` only ever costs a from-source build.
+  assert.equal(verdict, 'false', log);
+  assert.match(log, /entry 'rustXX' matches no file at/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('positive control: the fast path still answers `true` on an unchanged tree', () => {
+  const root = makeRepo();
+  installGate(root);
+  const { verdict, log } = run(root);
+  assert.equal(verdict, 'true', log);
+  assert.match(log, /prebuilt npm bundle is valid/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('negative control: a real Rust change still answers `false`, naming the file', () => {
+  const root = makeRepo();
+  changeRustSource(root);
+  installGate(root);
+  const { verdict, log } = run(root);
+  assert.equal(verdict, 'false', log);
+  assert.match(log, /Rust sources changed since/);
+  assert.match(log, /changed: rust\/foo\.rs/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a path deleted since the tag still counts as named, and still diffs', () => {
+  const root = makeRepo();
+  // rust-toolchain.toml exists at the tag and not at HEAD: it matches at one
+  // end, which is what the assertion requires, and the deletion is a real
+  // difference the probe must report.
+  rmSync(join(root, 'rust-toolchain.toml'));
+  git(root, 'add', '-A');
+  git(root, 'commit', '-q', '-m', 'delete rust-toolchain.toml');
+  installGate(root);
+  const { verdict, log } = run(root);
+  assert.equal(verdict, 'false', log);
+  assert.doesNotMatch(log, /matches no file at/);
+  assert.match(log, /changed: rust-toolchain\.toml/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('every WASM_SRC_PATHS entry in the shipped script names something in this repo', () => {
+  // The assertion above only fires in CI once the list is already wrong. This
+  // catches the same typo at review time, against the real checkout.
+  const src = readFileSync(GATE, 'utf-8');
+  const line = src.match(/^WASM_SRC_PATHS=\((.*)\)$/m);
+  assert.ok(line, 'WASM_SRC_PATHS is no longer a single-line array — update this harness');
+  const entries = line[1].split(/\s+/).filter(Boolean);
+  assert.ok(entries.length >= 5, `expected at least 5 source paths, got ${entries.length}`);
+  const repoRoot = join(HERE, '..');
+  for (const entry of entries) {
+    const listed = execFileSync('git', ['ls-tree', '-r', '--name-only', 'HEAD', '--', entry], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+    });
+    assert.ok(listed.trim().length > 0, `WASM_SRC_PATHS entry '${entry}' matches no tracked file`);
+  }
+});

--- a/scripts/docs/check-package-readmes.mjs
+++ b/scripts/docs/check-package-readmes.mjs
@@ -9,24 +9,86 @@
  * missing one is a silently shipped blank page.
  *
  * Run via `pnpm docs:check-readmes`.
+ *
+ * ANTI-VACUITY (#3200, finding 9). This was the last CI-wired gate still
+ * carrying the idiom #3197 removed from three siblings: an absence and an
+ * unreadable path answered the same way, and no floor under the count it
+ * prints. On a tree whose `packages/` existed and was empty it printed
+ * `✅ All 0 published packages have a README.md.` and exited 0 — a scan of
+ * nothing reported as a clean scan. `existsSync` made it worse than the empty
+ * case suggests: it answers false for EACCES too, so a package that could not
+ * be read dropped out of `checked` and its missing README with it.
+ *
+ * Three guards now stand between an empty input set and that success line:
+ * `packages/` not being readable is a named failure rather than a stack trace,
+ * an unreadable path is distinguished from an absent one, and CHECKED_FLOOR
+ * refuses a count that has collapsed. None of them fires on a healthy tree.
  */
 
-import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const packagesDir = join(ROOT, 'packages');
 
+/**
+ * Lower bound on how many published packages must reach the README check.
+ * Measured on a healthy tree: 45 directories under `packages/` carry a
+ * manifest, 42 of them published and 3 private. Set to 25 — a wide margin,
+ * so a package split or a few retired ones never force an edit here, while
+ * every way this gate can go blind (a wrong root, a restructured `packages/`
+ * whose manifests moved a level down, a read that stops resolving) collapses
+ * the count towards zero rather than to 24.
+ */
+const CHECKED_FLOOR = 25;
+
+function fail(message) {
+  console.error(`\n❌ ${message}\n`);
+  process.exit(1);
+}
+
+/**
+ * Does this path exist? Refuses when the answer is UNKNOWABLE.
+ *
+ * `existsSync` answers false for every failure, EACCES and ENOTDIR included,
+ * so an unreadable path is indistinguishable from an absent one — and here
+ * "absent" means "skip this directory", which is how a package leaves the
+ * audit without leaving a trace.
+ */
+function existsOrFail(path, what) {
+  try {
+    statSync(path);
+    return true;
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    fail(
+      `cannot read ${what} ${path} (${err.code || err.message}). ` +
+        'Refusing to treat an unreadable path as an absent one — that is how a ' +
+        'package drops out of this audit without anyone noticing.',
+    );
+  }
+}
+
+let entries;
+try {
+  entries = readdirSync(packagesDir).sort();
+} catch (err) {
+  fail(
+    `cannot list ${packagesDir} (${err.code || err.message}). ` +
+      'This gate exists to audit published packages and found nowhere to look for them.',
+  );
+}
+
 const missing = [];
 let checked = 0;
-for (const dir of readdirSync(packagesDir).sort()) {
+for (const dir of entries) {
   const pkgJsonPath = join(packagesDir, dir, 'package.json');
-  if (!existsSync(pkgJsonPath)) continue;
+  if (!existsOrFail(pkgJsonPath, 'package manifest')) continue;
   const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
   if (pkg.private === true) continue;
   checked += 1;
-  if (!existsSync(join(packagesDir, dir, 'README.md'))) {
+  if (!existsOrFail(join(packagesDir, dir, 'README.md'), 'README')) {
     missing.push(`${pkg.name}  (packages/${dir}/README.md)`);
   }
 }
@@ -40,6 +102,19 @@ if (missing.length > 0) {
     '\nEvery published package needs a README — it is the npm landing page.\n',
   );
   process.exit(1);
+}
+
+// Placed AFTER the missing-README verdict and before the success line: a run
+// that examined too few packages has proved nothing about the ones it never
+// opened, and saying so is the whole point of the check.
+if (checked < CHECKED_FLOOR) {
+  fail(
+    `only ${checked} published package(s) reached the README check under ${packagesDir}, ` +
+      `expected at least ${CHECKED_FLOOR}. Refusing a vacuous pass: this gate found ` +
+      'almost nothing to audit, which is a failure of discovery, not a clean tree. ' +
+      'If packages/ genuinely shrank this far, lower CHECKED_FLOOR in this file — ' +
+      'deliberately, in a reviewable diff.',
+  );
 }
 
 console.log(`✅ All ${checked} published packages have a README.md.`);

--- a/scripts/docs/check-package-readmes.test.mjs
+++ b/scripts/docs/check-package-readmes.test.mjs
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for the anti-vacuity floors in check-package-readmes.mjs
+ * (#3200, finding 9).
+ *
+ * The gate derives its root from its own location, so a copy of the one file
+ * into a synthetic tree is the whole reproduction.
+ *
+ * The unreadable-path fixture is ENOTDIR (a file where a directory belongs),
+ * not `chmod 000`: chmod does not stop root and CI containers run as root, so
+ * a permissions fixture would silently test nothing on the machine that
+ * matters. ENOTDIR takes the same branch for every user.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, 'check-package-readmes.mjs');
+
+function makeTree() {
+  const root = mkdtempSync(join(tmpdir(), 'check-package-readmes-'));
+  mkdirSync(join(root, 'scripts', 'docs'), { recursive: true });
+  copyFileSync(GATE, join(root, 'scripts', 'docs', 'check-package-readmes.mjs'));
+  mkdirSync(join(root, 'packages'), { recursive: true });
+  return root;
+}
+
+function addPackage(root, dir, { published = true, readme = true } = {}) {
+  mkdirSync(join(root, 'packages', dir), { recursive: true });
+  writeFileSync(
+    join(root, 'packages', dir, 'package.json'),
+    JSON.stringify({ name: `@x/${dir}`, version: '1.0.0', ...(published ? {} : { private: true }) }),
+  );
+  if (readme) writeFileSync(join(root, 'packages', dir, 'README.md'), `# ${dir}\n`);
+}
+
+/** CHECKED_FLOOR published packages, all with READMEs — the healthy shape. */
+function fillToFloor(root) {
+  for (let i = 0; i < 25; i++) addPackage(root, `p${i}`);
+}
+
+function run(root) {
+  const res = spawnSync(
+    process.execPath,
+    [join(root, 'scripts', 'docs', 'check-package-readmes.mjs')],
+    { encoding: 'utf-8' },
+  );
+  return { status: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+}
+
+test('an empty packages/ is refused, not reported as every package having a README', () => {
+  const root = makeTree();
+  const { status, out } = run(root);
+  // Was: `✅ All 0 published packages have a README.md.` and exit 0.
+  assert.equal(status, 1, out);
+  assert.match(out, /only 0 published package\(s\) reached the README check/);
+  assert.match(out, /expected at least 25/);
+  assert.doesNotMatch(out, /✅/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a packages/ that cannot be listed names itself instead of throwing a stack trace', () => {
+  const root = makeTree();
+  rmSync(join(root, 'packages'), { recursive: true, force: true });
+  writeFileSync(join(root, 'packages'), 'not a directory');
+  const { status, out } = run(root);
+  assert.equal(status, 1, out);
+  assert.match(out, /cannot list .*packages \(ENOTDIR\)/);
+  assert.match(out, /found nowhere to look for them/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a package that cannot be READ is fatal, not silently dropped from the count', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  // A file where a package directory belongs: statting its package.json is
+  // ENOTDIR. `existsSync` answered false here, so the package left the audit
+  // and any missing README left with it.
+  writeFileSync(join(root, 'packages', 'locked'), 'not a directory');
+  const { status, out } = run(root);
+  assert.equal(status, 1, out);
+  assert.match(out, /cannot read package manifest .*locked[/\\]package\.json \(ENOTDIR\)/);
+  assert.doesNotMatch(out, /✅/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a directory with no package.json stays ordinary and is skipped in silence', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  mkdirSync(join(root, 'packages', 'not-a-package'), { recursive: true });
+  const { status, out } = run(root);
+  assert.equal(status, 0, out);
+  assert.match(out, /All 25 published packages have a README\.md/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('private packages are still excluded, and do not count towards the floor', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  addPackage(root, 'priv', { published: false, readme: false });
+  const { status, out } = run(root);
+  assert.equal(status, 0, out);
+  assert.match(out, /All 25 published packages have a README\.md/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('negative control: the missing-README verdict still fires, and before the floor', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  addPackage(root, 'no-readme', { readme: false });
+  const { status, out } = run(root);
+  assert.equal(status, 1, out);
+  assert.match(out, /Published packages without a README\.md \(1\)/);
+  assert.match(out, /@x\/no-readme/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('positive control: a healthy tree at the floor passes, with its true count', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  const { status, out } = run(root);
+  assert.equal(status, 0, out);
+  assert.match(out, /✅ All 25 published packages have a README\.md/);
+  rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/verify-npm-publish.js
+++ b/scripts/verify-npm-publish.js
@@ -17,6 +17,24 @@
  *                   Useful after a fresh publish where npm propagation takes
  *                   a few seconds.
  *   --delay <ms>    Milliseconds to wait between retries (default: 5000).
+ *
+ * ANTI-VACUITY (#3200, finding 7). This runs in release.yml AFTER publish, so
+ * its exit code is the last thing standing between a half-published release
+ * and users. It already refused to find no package.json at all; one level in,
+ * it did not. Two ways it could report a release verified having checked less
+ * than the workspace, both reproduced on a synthetic tree:
+ *
+ *   - every discovered manifest being private printed `No publishable
+ *     packages found.` and exited 0;
+ *   - a `packages/` that could not be LISTED (an ENOTDIR/EACCES rather than an
+ *     ENOENT) printed a warning, verified whatever `apps/` held, and finished
+ *     with `All packages are published. 🎉`.
+ *
+ * Both are closed below. A parent or a manifest path that does not EXIST stays
+ * ordinary; one that cannot be READ is fatal, because those two call for
+ * different fixes and only the second means the set silently shrank. Past
+ * discovery, PUBLISHABLE_FLOOR keeps the count honest against the real
+ * workspace, where no realistic release drops it by a third.
  */
 
 import { execSync } from 'child_process';
@@ -27,6 +45,28 @@ import { dirname, join } from 'path';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const rootDir = join(__dirname, '..');
+
+/**
+ * Lower bound on how many publishable packages this gate must actually query.
+ * Measured on a healthy tree: `packages/` holds 45 manifests of which 42 are
+ * publishable, `apps/` holds 2 of which 0 are — every published package lives
+ * under `packages/`, so the floor is really a floor on that tree surviving
+ * discovery. Set to 25, a wide margin below 42: ordinary churn (a package
+ * split, a few retired or made private) never forces an edit here, while every
+ * way this script can go blind — a wrong root, a parent that will not list, a
+ * manifest read that stops matching — collapses the count towards zero, not to
+ * 24.
+ *
+ * Deliberately NOT a per-parent floor: `apps/` publishes nothing today, so
+ * `apps: at least 1` would be a floor on a number that is legitimately zero.
+ */
+const PUBLISHABLE_FLOOR = 25;
+
+/** Refuse, loudly, with the exit code release.yml reads as "nothing proved". */
+function refuse(message) {
+  console.error(`❌ ${message}`);
+  process.exit(2);
+}
 
 // ── CLI option parsing ────────────────────────────────────────────────────────
 
@@ -85,18 +125,30 @@ function getWorkspacePackages() {
           statSync(pkgJsonPath);
           packages.push(pkgJsonPath);
         } catch (error) {
-          // A directory with no package.json is ordinary; anything else means
-          // we may be skipping a package we were asked to verify.
+          // A directory with no package.json is ordinary. Anything else means
+          // this path exists in some form we could not classify, and skipping
+          // it drops a package the release may have been supposed to publish.
           if (error.code !== 'ENOENT') {
-            console.warn(`⚠️  Could not stat ${pkgJsonPath}, skipping it (${error.message})`);
+            refuse(
+              `could not stat ${pkgJsonPath} (${error.code || error.message}). ` +
+                'Refusing to treat an unreadable manifest path as an absent one — ' +
+                'that is how a package drops out of a release check unnoticed.',
+            );
           }
         }
       }
     } catch (error) {
-      // Same: an absent `apps/` or `packages/` is ordinary, but an unreadable
-      // one silently shrinks the set this release gate checks.
+      // Same distinction one level up, and it matters more here: an absent
+      // `apps/` or `packages/` is ordinary, but one that will not LIST shrinks
+      // the set this release gate checks by a whole tree while every remaining
+      // package still reports ✅. Warning about that and carrying on was the
+      // #3200 finding.
       if (error.code !== 'ENOENT') {
-        console.warn(`⚠️  Could not list ${parentDir}, skipping it (${error.message})`);
+        refuse(
+          `could not list ${parentDir} (${error.code || error.message}). ` +
+            'Refusing to verify a release against whatever else happened to be readable — ' +
+            'an unreadable workspace parent is not an empty one.',
+        );
       }
     }
   }
@@ -113,8 +165,7 @@ async function main() {
   // means the discovery step itself failed, and exiting 0 there would report a
   // release as verified having checked nothing.
   if (packagePaths.length === 0) {
-    console.error('No package.json found under packages/ or apps/ — nothing was verified.');
-    process.exit(2);
+    refuse('No package.json found under packages/ or apps/ — nothing was verified.');
   }
   const toCheck = [];
 
@@ -124,9 +175,19 @@ async function main() {
     toCheck.push({ name: pkg.name, version: pkg.version });
   }
 
-  if (toCheck.length === 0) {
-    console.log('No publishable packages found.');
-    process.exit(0);
+  // The second floor, and the one the #3200 audit found missing: discovery can
+  // succeed and still hand this loop nothing, or almost nothing, to verify.
+  // Exiting 0 there reports a release as verified on the strength of zero
+  // queries to the registry.
+  if (toCheck.length < PUBLISHABLE_FLOOR) {
+    refuse(
+      `only ${toCheck.length} publishable package(s) found among ${packagePaths.length} ` +
+        `manifest(s) under packages/ and apps/, expected at least ${PUBLISHABLE_FLOOR}. ` +
+        'Refusing a vacuous pass: this gate runs after publish, and a run that queried ' +
+        'npm about almost nothing has proved almost nothing about the release. If the ' +
+        'workspace genuinely shrank this far, lower PUBLISHABLE_FLOOR in this file — ' +
+        'deliberately, in a reviewable diff.',
+    );
   }
 
   console.log(`\nVerifying ${toCheck.length} package(s) on npm (up to ${retries} retries each)…\n`);

--- a/scripts/verify-npm-publish.test.mjs
+++ b/scripts/verify-npm-publish.test.mjs
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for the anti-vacuity floors in verify-npm-publish.js
+ * (#3200, finding 7).
+ *
+ * The gate derives its workspace root from its own location, so a copy of the
+ * one file into a synthetic tree IS the whole reproduction — no fixtures, no
+ * network. `npm` itself is stubbed on PATH for the positive controls; nothing
+ * here reaches a registry.
+ *
+ * Every case asserts the EXIT CODE and the text, because the thing being
+ * guarded is precisely a run that says nothing went wrong.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, chmodSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, 'verify-npm-publish.js');
+
+/** A synthetic workspace holding nothing but a copy of the gate. */
+function makeTree() {
+  const root = mkdtempSync(join(tmpdir(), 'verify-npm-publish-'));
+  mkdirSync(join(root, 'scripts'));
+  copyFileSync(GATE, join(root, 'scripts', 'verify-npm-publish.js'));
+  return root;
+}
+
+function addPackage(root, parent, dir, pkg) {
+  mkdirSync(join(root, parent, dir), { recursive: true });
+  writeFileSync(join(root, parent, dir, 'package.json'), JSON.stringify(pkg));
+}
+
+/**
+ * A stub `npm` answering `npm view <name>@<version> version` with the version
+ * it was asked for, so a package reads as published. `missing` names the one
+ * spec it should 404 on, for the negative control.
+ */
+function stubNpm(root, { missing = null } = {}) {
+  const bin = join(root, 'bin');
+  mkdirSync(bin, { recursive: true });
+  const npm = join(bin, 'npm');
+  const lines = ['#!/bin/sh', 'spec="$2"'];
+  if (missing) {
+    lines.push(`if [ "$spec" = "${missing}" ]; then echo "npm error code E404" >&2; exit 1; fi`);
+  }
+  lines.push('echo "${spec##*@}"', '');
+  writeFileSync(npm, lines.join('\n'));
+  chmodSync(npm, 0o755);
+  return bin;
+}
+
+function run(root, { bin = null } = {}) {
+  const env = { ...process.env };
+  if (bin) env.PATH = `${bin}:${env.PATH}`;
+  const res = spawnSync(
+    process.execPath,
+    [join(root, 'scripts', 'verify-npm-publish.js'), '--retries', '1'],
+    { encoding: 'utf-8', env },
+  );
+  return { status: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+}
+
+/** 25 publishable packages — PUBLISHABLE_FLOOR exactly, the healthy shape. */
+function fillToFloor(root) {
+  for (let i = 0; i < 25; i++) {
+    addPackage(root, 'packages', `p${i}`, { name: `@x/p${i}`, version: '1.0.0' });
+  }
+}
+
+test('a workspace with no manifests at all is refused, not reported verified', () => {
+  const root = makeTree();
+  mkdirSync(join(root, 'packages'));
+  mkdirSync(join(root, 'apps'));
+  const { status, out } = run(root);
+  assert.equal(status, 2, out);
+  assert.match(out, /nothing was verified/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('discovery that finds only private packages is refused, naming the floor it expected', () => {
+  const root = makeTree();
+  addPackage(root, 'packages', 'priv', { name: '@x/priv', version: '1.0.0', private: true });
+  const { status, out } = run(root);
+  assert.equal(status, 2, out);
+  // Was: `No publishable packages found.` and exit 0 — a release reported
+  // verified on zero registry queries.
+  assert.match(out, /only 0 publishable package\(s\) found among 1 manifest\(s\)/);
+  assert.match(out, /expected at least 25/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a workspace parent that cannot be LISTED is fatal, not a warning', () => {
+  const root = makeTree();
+  // ENOTDIR rather than a chmod: `chmod 000` does not stop root and CI
+  // containers run as root, so a permissions fixture would silently test
+  // nothing on the machine that matters. A file where a directory belongs
+  // takes the same branch for every user.
+  writeFileSync(join(root, 'packages'), 'not a directory');
+  addPackage(root, 'apps', 'pub', { name: '@x/pub', version: '2.0.0' });
+  const { status, out } = run(root, { bin: stubNpm(root) });
+  assert.equal(status, 2, out);
+  assert.match(out, /could not list .*packages \(ENOTDIR\)/);
+  assert.doesNotMatch(out, /All packages are published/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a manifest path that cannot be STATed is fatal, not skipped', () => {
+  const root = makeTree();
+  mkdirSync(join(root, 'packages'), { recursive: true });
+  // packages/broken is a FILE, so packages/broken/package.json is ENOTDIR —
+  // a path we could not classify, distinct from a directory that simply has
+  // no manifest (ENOENT), which stays ordinary.
+  writeFileSync(join(root, 'packages', 'broken'), 'not a directory');
+  const { status, out } = run(root);
+  assert.equal(status, 2, out);
+  assert.match(out, /could not stat .*broken[/\\]package\.json \(ENOTDIR\)/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a directory with no package.json is still ordinary and skipped in silence', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  mkdirSync(join(root, 'packages', 'not-a-package'), { recursive: true });
+  const { status, out } = run(root, { bin: stubNpm(root) });
+  assert.equal(status, 0, out);
+  assert.match(out, /Verifying 25 package\(s\)/);
+  assert.doesNotMatch(out, /could not stat/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('positive control: a healthy workspace at the floor still passes, with its count', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  const { status, out } = run(root, { bin: stubNpm(root) });
+  assert.equal(status, 0, out);
+  assert.match(out, /Verifying 25 package\(s\)/);
+  assert.match(out, /All packages are published/);
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('negative control: one package missing from the registry still exits 1', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  const { status, out } = run(root, { bin: stubNpm(root, { missing: '@x/p7@1.0.0' }) });
+  assert.equal(status, 1, out);
+  assert.match(out, /1 package\(s\) missing from npm after publish/);
+  assert.match(out, /@x\/p7@1\.0\.0/);
+  rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/verify-npm-publish.test.mjs
+++ b/scripts/verify-npm-publish.test.mjs
@@ -52,7 +52,9 @@ function stubNpm(root, { missing = null } = {}) {
   if (missing) {
     lines.push(`if [ "$spec" = "${missing}" ]; then echo "npm error code E404" >&2; exit 1; fi`);
   }
-  lines.push('echo "${spec##*@}"', '');
+  // `sed` rather than a `${spec##*@}` expansion: the literal `${` in a
+  // JavaScript single-quoted string trips eslint(no-template-curly-in-string).
+  lines.push('echo "$spec" | sed "s/.*@//"', '');
   writeFileSync(npm, lines.join('\n'));
   chmodSync(npm, 0o755);
   return bin;


### PR DESCRIPTION
The tail of #3200 — findings **7, 9 and 10**. Finding **8 is refuted**, with the evidence below; I would rather leave it unguarded than add a floor that fires on today's real data.

Findings 1–6 are #3201, #3213 and #3214; nothing here touches those files. One commit per finding, plus a one-line lint fixup.

Every finding was RUN before it was believed, and every guard was watched fail before it was trusted — the point of #3200.

---

## 7. `verify-npm-publish.js` — REPRODUCES, fixed

It runs in `release.yml` **after** publish, so its exit code is the last thing between a half-published release and users. The zero-`package.json` floor #3200 credits it with is real. One level in there was nothing, and the second mode is the interesting one:

```
$ cd <tree: packages/ and apps/ present, one private package> && node scripts/verify-npm-publish.js
No publishable packages found.
EXIT=0

$ # packages/ present but unlistable (ENOTDIR), apps/ holding one package
$ node scripts/verify-npm-publish.js
⚠️  Could not list …/packages, skipping it (ENOTDIR: not a directory, scandir '…/packages')

Verifying 1 package(s) on npm (up to 1 retries each)…

  ✅  @x/pub@2.0.0

All packages are published. 🎉
EXIT=0
```

A whole workspace tree dropped out and every remaining package still reported ✅. The comment above that `catch` names the hazard — *"an unreadable one silently shrinks the set this release gate checks"* — and then permits it.

**Fixed.** A parent or manifest path that does not EXIST stays ordinary; one that cannot be READ is fatal, because those call for different fixes and only the second means the set silently shrank. Past discovery, a measured `PUBLISHABLE_FLOOR`.

**Measured floor.** 45 manifests under `packages/`, 42 publishable; 2 under `apps/`, **0** publishable. Floor 25. Deliberately **not** a per-parent floor, which is what the `check-lint-ran` idiom would suggest: `apps: at least 1` would be a floor on a number that is legitimately zero.

After, the same three trees:

```
❌ No package.json found under packages/ or apps/ — nothing was verified.            EXIT=2
❌ only 1 publishable package(s) found among 2 manifest(s) under packages/ and
   apps/, expected at least 25. Refusing a vacuous pass: this gate runs after
   publish, and a run that queried npm about almost nothing has proved almost
   nothing about the release. …                                                      EXIT=2
❌ could not list …/packages (ENOTDIR). Refusing to verify a release against
   whatever else happened to be readable — an unreadable workspace parent is
   not an empty one.                                                                 EXIT=2
```

and unchanged on the real repo, with `npm` stubbed offline:

```
Verifying 42 package(s) on npm (up to 1 retries each)…
  ✅  @ifc-lite/bcf@2.0.0
  … 41 more
All packages are published. 🎉
EXIT=0
```

## 8. `check-benchmark-regression.js` — REPRODUCES, and **not fixed**. Reasoning below

Both paths reproduce exactly as recorded. I am not guarding either, and the second is the reason.

**(i) missing baseline entries.** Renaming the fixture makes every lookup miss, and the run exits 0. But it is not silent about it — it prints `⚠ No baseline entry for this model`, then `Missing baseline entries: 1`, then names the model. That is a gate saying what it did not check, which is the opposite of the #3200 shape. A **new** model legitimately has no baseline until one is recorded, so making it fatal would block the ordinary case.

**(ii) `N/A` rendering as ✅.** Real, and I agree it is wrong:

```
  - firstBatchWaitMs: N/A vs 100ms (N/A)  ✅
  … 5 more
No threshold regressions detected.
EXIT=0
```

But a floor here would fire on the real repo **today**. From the committed baseline:

| model | metrics present |
| --- | --- |
| `AC20-FZK-Haus.ifc` | all 6 |
| `01_Snowdon_Towers_Sample_Structural(1).ifc` | all 6 |
| `O-S1-BWK-BIM architectural…ifc` | 2 of 6 |
| `ISSUE_053_…Holter_Tower_10.ifc` | 2 of 6 |

Two of four entries carry neither `firstVisibleGeometryMs`, `streamCompleteMs`, `spatialReadyMs` nor `metadataCompleteMs` (they are the older, locally-recorded pair — the same two the script's own `looksCiRecorded` already flags). So "an `N/A` metric is a hard error" is a rule that reds a healthy repo, and "at least N metrics must compare" is a floor I would be setting below a number that is already 2.

And the mechanism is not available anyway: `benchmark.yml` invokes it `--advisory`, so it cannot fail the run. There is no cell (b) to show — I cannot make it refuse without changing what `--advisory` means, which is a bigger decision than this issue.

**Recommendation, not shipped:** render an `N/A` row as `⚠ not measured` instead of `✅`, in both the console report and the markdown table. It removes a false green tick without inventing a floor, it is honest about today's baseline, and it makes a metric that stops being emitted visible to a reader instead of congratulating them. Left for whoever owns the benchmark lane, since it changes what a live PR comment says.

## 9. `check-package-readmes.mjs` — REPRODUCES, fixed

Recorded as theoretical. It reproduces, and the more interesting half is not the empty tree:

```
$ cd <tree: packages/ present and empty> && node scripts/docs/check-package-readmes.mjs
✅ All 0 published packages have a README.md.
EXIT=0

$ # packages/locked replaced by a FILE, so its package.json stats ENOTDIR
$ node scripts/docs/check-package-readmes.mjs
✅ All 0 published packages have a README.md.
EXIT=0
```

`existsSync` answers false for `EACCES` and `ENOTDIR` as readily as for `ENOENT`, so a package that could not be read left the audit and its missing README left with it — and `checked` shrank to match, which is why the success line still looked plausible. This was the last CI-wired gate carrying the idiom #3197 removed from three siblings.

**Fixed:** `packages/` not being listable is a named failure rather than a raw stack trace, an unreadable path is distinguished from an absent one, and a measured `CHECKED_FLOOR` (42 published today, floor 25) refuses a collapsed count.

```
❌ only 0 published package(s) reached the README check under …/packages, expected
   at least 25. Refusing a vacuous pass: this gate found almost nothing to audit,
   which is a failure of discovery, not a clean tree. …                              EXIT=1

❌ cannot read package manifest …/packages/locked/package.json (ENOTDIR). Refusing
   to treat an unreadable path as an absent one — that is how a package drops out
   of this audit without anyone noticing.                                            EXIT=1

$ node scripts/docs/check-package-readmes.mjs        # real repo
✅ All 42 published packages have a README.md.
EXIT=0
```

## 10. `ci-wasm-prebuilt-eligible.sh` — REPRODUCES (not theoretical), fixed

Recorded as theoretical. Driven against a real, tiny repository — a tagged commit, one Rust source edit on top, one entry of `WASM_SRC_PATHS` misspelled — it is live:

```
$ # before, WASM_SRC_PATHS=(rustXX Cargo.lock Cargo.toml rust-toolchain.toml scripts/build-wasm.sh)
$ bash scripts/ci-wasm-prebuilt-eligible.sh
🅰  WASM source identical to @ifc-lite/wasm@1.0.0 — prebuilt npm bundle is valid.
STDOUT=true
```

The Rust source had demonstrably changed since the tag — with the list intact the same tree answers `false`, naming `rust/foo.rs`. `git diff --quiet` exits 0 both for "unchanged" and for "your pathspec matched nothing at either end", so one typo covers nothing and moves the probe toward `true`, against the guarantee at the top of the file that the fast path *can NEVER cause a stale bundle to be tested*.

**Fixed:** every entry must name something real, at **either** end — a path deleted since the tag still matches at the tag, one added since still matches at HEAD, and only a name matching at neither is a typo. Failing it is not fatal: it takes the same `false` route as every other uncertainty, costing a from-source build and nothing else, which is what this script's own *"any doubt → build from source"* contract asks for.

```
$ # after, same typo'd list, same tree
🛠  WASM_SRC_PATHS entry 'rustXX' matches no file at @ifc-lite/wasm@1.0.0 or at HEAD —
    it can only ever compare nothing, so the diff below would under-report.
    Build from source, and fix the list (keep it in lock-step with scripts/vercel-install.sh).
STDOUT=false

$ # after, list intact, sources identical to the tag — the fast path survives
🅰  WASM source identical to @ifc-lite/wasm@1.0.0 — prebuilt npm bundle is valid.
STDOUT=true

$ # after, real repo, list intact — verdict unchanged, no refusal logged
🛠  Rust sources changed since @ifc-lite/wasm@6.0.0 — build from source.
     changed: Cargo.lock
     changed: rust/core/src/fast_parse.rs
     … 18 more
false
```

---

## Harnesses

Three, all driving the real scripts against synthetic trees, all asserting exit codes.

Two deliberate choices, both from the #3197/#3213/#3214 reviews:

- **ENOTDIR, never `chmod`.** `chmod 000` does not stop root and CI containers run as root, so a permissions fixture silently tests nothing on the machine that matters. A file where a directory belongs takes the same branch for every user.
- **The wasm harness's last test is the cheaper half**: it asserts every entry of the *shipped* `WASM_SRC_PATHS` matches a tracked file, so the same typo is caught at review time rather than after it has already bought a `true`.

RED/GREEN on the wasm one, since it is the only new *behavioural* branch here — installing the pre-fix script reds exactly the two anti-vacuity tests and nothing else:

```
not ok 1 - a typo in WASM_SRC_PATHS cannot buy a `true` over changed Rust source
not ok 2 - a typo is refused even when the sources really are unchanged
# tests 6  # pass 4  # fail 2
```

`scripts/docs/check-package-readmes.test.mjs` gets a **named** workflow step: the `scripts/` catch-all glob is per-directory and does not reach `scripts/docs/` on `main`. #3213 extends the glob; the named step is additive either way and does not touch the same line.

## Verification

```
$ node --test scripts/*.test.mjs scripts/lib/*.test.mjs scripts/fixtures/*.test.mjs scripts/docs/*.test.mjs
# tests 663  # pass 663  # fail 0

$ node scripts/check-test-glob-coverage.mjs
check-test-glob-coverage: OK (47 packages audited, 0 unrun test files)

$ oxlint --config .oxlintrc.json <every changed file>
Found 0 warnings and 0 errors.
```

`check-changesets`, `check-unused-locals` and `check-lint-ran` need installed dependencies and a build, which this worktree does not have; CI covers them. No changeset — scripts and CI only, no published package touched, matching #3201/#3213/#3214.

Refs #3200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened release checks to detect missing, unreadable, or unexpectedly incomplete package and README discovery.
  - Prevented release validation from passing when no packages are found or when configured source paths are invalid.
  - Improved diagnostics for inaccessible directories, manifests, and source files.
  - Ensured publish verification accurately confirms all eligible packages are available after release.

- **Tests**
  - Added regression coverage for package validation, publication checks, and prebuilt WebAssembly eligibility across healthy and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->