### PR TITLE
fix(scripts): the swallowed-push gate matched physical lines, so a continuation walked past it (#3212)

### DIFF
--- a/scripts/check-swallowed-push.mjs
+++ b/scripts/check-swallowed-push.mjs
@@ -51,6 +51,47 @@ const WORKFLOW_DIR = '.github/workflows';
 export const MARKER = 'allow-swallowed-push';
 
 /**
+ * What may precede a `git push` for it to be a COMMAND rather than an ARGUMENT.
+ *
+ * Without this, folding a continuation makes
+ *
+ * ```sh
+ * echo "hello" \
+ * git push origin "v2" || true
+ * ```
+ *
+ * look like a swallowed push, when the shell sees `echo` consuming the rest and
+ * pushes nothing.
+ *
+ * PERMISSIVE ON PURPOSE. A first version accepted only start-of-line, a few
+ * separators and `run:`, and review found it missed `{ git push … || true; }`,
+ * `if git push … || true; then`, `! git push …` and `FOO=1 git push …` — all
+ * genuine command position. For a release-safety gate a MISS is far worse than
+ * a false positive: a miss defeats the gate's whole purpose silently, while a
+ * false positive is visible and has the `allow-swallowed-push` marker as its
+ * escape hatch. So this errs toward matching, and only rejects a push sitting
+ * after a plain word or quote, which is the one shape that provably is not a
+ * command.
+ */
+const COMMAND_POSITION =
+  '(?:^|[;&|(){}!]|\\brun:|\\b(?:if|then|else|elif|do|while|until)\\b|\\b[A-Za-z_][A-Za-z0-9_]*=\\S*)\\s*';
+
+/**
+ * The push's OWN arguments — no command separator may be crossed.
+ *
+ * With `[^\n]*?` the match could run past this push's handler and adopt a LATER
+ * command's one, so
+ *
+ * ```sh
+ * git push origin "$TAG" || exit 1; cleanup || echo cleanup-failed
+ * ```
+ *
+ * was reported even though the push exits loudly and only the independent
+ * `cleanup` is swallowed — the gate rejecting a correct workflow.
+ */
+const OWN_ARGS = '[^\\n;&|]*?';
+
+/**
  * A `git push` whose failure is discarded.
  *
  * `|| true` and `|| :` are the two spellings that mean "ignore this"; `:` is a
@@ -63,7 +104,7 @@ export const MARKER = 'allow-swallowed-push';
  * Reported by CodeRabbit on #3208.
  */
 export const SWALLOWED_PUSH =
-  /(?:^|[;&|(]|\brun:)\s*git\s+push\b[^\n]*?\|\|\s*(?:true|:)\s*(?:$|[#;&|)])/;
+  new RegExp(`${COMMAND_POSITION}git\\s+push\\b${OWN_ARGS}\\|\\|\\s*(?:true|:)\\s*(?:$|[#;&|)])`);
 
 /**
  * A `git push` whose failure is handled by a command that CANNOT fail the step.
@@ -97,7 +138,7 @@ export const SWALLOWED_PUSH =
  * flag a correct one.
  */
 export const HANDLED_PUSH =
-  /(?:^|[;&|(]|\brun:)\s*git\s+push\b[^\n]*?\|\|\s*(?:true\b|:|echo\b|printf\b)/;
+  new RegExp(`${COMMAND_POSITION}git\\s+push\\b${OWN_ARGS}\\|\\|\\s*(?:true\\b|:|echo\\b|printf\\b)`);
 
 /** Every `.yml`/`.yaml` under the workflow directory. */
 export function workflowFiles(root) {

--- a/scripts/check-swallowed-push.mjs
+++ b/scripts/check-swallowed-push.mjs
@@ -62,7 +62,42 @@ export const MARKER = 'allow-swallowed-push';
  * `|` and `)` all continue the line while leaving the status discarded.
  * Reported by CodeRabbit on #3208.
  */
-export const SWALLOWED_PUSH = /\bgit\s+push\b[^\n]*?\|\|\s*(?:true|:)\s*(?:$|[#;&|)])/;
+export const SWALLOWED_PUSH =
+  /(?:^|[;&|(]|\brun:)\s*git\s+push\b[^\n]*?\|\|\s*(?:true|:)\s*(?:$|[#;&|)])/;
+
+/**
+ * A `git push` whose failure is handled by a command that CANNOT fail the step.
+ *
+ * ```sh
+ * git push origin "$TAG" || echo "push failed, continuing"
+ * ```
+ *
+ * Under `set -e` the `||` handles the failure, `echo` returns 0, and the job
+ * continues. That swallows exactly as thoroughly as `|| true`.
+ *
+ * AN ALLOWLIST, NOT "ANY COMMAND", and the difference is the whole finding.
+ * #3212 proposed widening to any handler. A review of that widening measured
+ * what it does to the idiom this gate PUSHES PEOPLE TOWARD:
+ *
+ * ```sh
+ * git push origin "v1" || exit 1                      # correct, was flagged
+ * git push origin main || { echo "..."; exit 1; }     # correct, was flagged
+ * ```
+ *
+ * Verified in bash: `false || exit 1` exits 1, `false || echo x` exits 0. So
+ * `|| exit 1` is the textbook loud-failure form — the thing an author reaches
+ * for when this gate rejects their `|| true` — and flagging it makes the gate
+ * contradict its own printed remedy. `|| return 1`, `|| false`, `|| exit $?`
+ * and `|| die "msg"` are the same.
+ *
+ * Enumerating every TERMINATING handler is a losing game (`{ …; exit 1; }`,
+ * a shell function, a trap). Enumerating the harmless ones is not: `echo` and
+ * `printf` cannot fail a step, whatever their arguments. So the alternation
+ * only grows when someone shows a real swallow it misses, and it can never
+ * flag a correct one.
+ */
+export const HANDLED_PUSH =
+  /(?:^|[;&|(]|\brun:)\s*git\s+push\b[^\n]*?\|\|\s*(?:true\b|:|echo\b|printf\b)/;
 
 /** Every `.yml`/`.yaml` under the workflow directory. */
 export function workflowFiles(root) {
@@ -74,20 +109,100 @@ export function workflowFiles(root) {
     .filter((f) => statSync(f).isFile());
 }
 
+/**
+ * Fold backslash continuations into LOGICAL lines (#3212).
+ *
+ * The rule has to see what the SHELL sees. Matching per physical line walks
+ * straight past a swallow split across a continuation, because neither half
+ * matches alone:
+ *
+ * ```sh
+ * git push origin "v${VERSION}" \
+ *   || true
+ * ```
+ *
+ * Same family as the `;`/`&`/`|`/`)` chaining gap: the rule seeing less than
+ * the shell does.
+ *
+ * WHERE THIS TECHNIQUE IS KNOWN TO BREAK, because this repo has already paid
+ * for it: `source-text-assertion-detect.mjs` used to walk lines with a
+ * `CONTINUES` regex, an interior comment stripped to blank, the walk stopped
+ * early, and CI failed twice printing a remedy that did not work. It was
+ * replaced by a real parser. This is safe at that same shape only because the
+ * fold is unconditional and the only consumer of `joined` is a regex requiring
+ * `git push` — folding a line that is not shell cannot invent a hit. If this
+ * ever needs to know what IS shell, it needs a parser, not another regex.
+ *
+ * Reports the FIRST physical line number, so the output points at somewhere a
+ * reader can find; a synthetic number over the joined text would be worse than
+ * the gap it closes.
+ */
+function logicalLines(physical) {
+  const out = [];
+  for (let i = 0; i < physical.length; i += 1) {
+    const line = i + 1;
+    let joined = physical[i];
+    // Where each physical line begins inside `joined`, so a match can be
+    // attributed to the push it is about rather than to the group's first line.
+    const starts = [{ line, at: 0 }];
+    // `\\` is an escaped backslash and ends the line for real, so parity is
+    // what decides, not presence.
+    while (/\\*$/.exec(joined)[0].length % 2 === 1 && i + 1 < physical.length) {
+      i += 1;
+      joined = joined.slice(0, -1);
+      starts.push({ line: i + 1, at: joined.length + 1 });
+      joined = `${joined} ${physical[i].trim()}`;
+    }
+    out.push({ line, joined, starts });
+  }
+  return out;
+}
+
 /** `{ line, text }` for every swallowed push, minus marked ones. */
 export function findSwallowedPushes(source) {
-  const lines = source.split('\n');
+  const physical = source.split('\n');
   const hits = [];
   const marked = [];
-  lines.forEach((line, i) => {
-    if (!SWALLOWED_PUSH.test(line)) return;
-    const above = lines[i - 1] ?? '';
-    if (above.includes(MARKER) || line.includes(MARKER)) {
-      marked.push({ line: i + 1, text: line.trim() });
-      return;
+  // Global copies so `lastIndex` can walk every push in one folded group.
+  const scanAll = new RegExp(HANDLED_PUSH.source, 'g');
+  for (const { joined, starts } of logicalLines(physical)) {
+    scanAll.lastIndex = 0;
+    let m;
+    while ((m = scanAll.exec(joined)) !== null) {
+      // ONE ENTRY PER PUSH. Folding makes a chained pair
+      // (`git push mirror … || true; git push origin … || true`) a single
+      // logical line, and one-entry-per-group both under-reported the second
+      // push and let a marker written for the first silently exempt it — the
+      // push vanished from the report rather than being listed as marked.
+      // Offset of the PUSH ITSELF, not of the match: the pattern consumes a
+      // leading command separator (`;`, `&`, `|`, `(`), so `m.index` can sit on
+      // the previous physical line and attribute the hit to the wrong push.
+      const at = m.index + Math.max(0, m[0].search(/\bgit\s+push\b/));
+      // The physical line this push STARTS on, so the report points at it.
+      let line = starts[0].line;
+      for (const s2 of starts) if (s2.at <= at) line = s2.line;
+
+      const above = physical[line - 2] ?? '';
+      const own = physical[line - 1] ?? '';
+      const entry = {
+        line,
+        text: own.trim(),
+        // SWALLOWED_PUSH is a subset of HANDLED_PUSH (see the note on
+        // HANDLED_PUSH), so it only classifies. Re-tested against this push's
+        // own slice, not the whole group, or a `|| true` anywhere in the group
+        // would relabel every push in it.
+        kind: SWALLOWED_PUSH.test(m[0]) ? 'no-op' : 'handled',
+      };
+      // The marker applies to the line above this push or to its own line.
+      // Not to `joined`: a marker is a COMMENT, a comment ends the logical
+      // command, so a group can never carry both a marker and a later live
+      // push — but scanning `joined` would still be the wrong shape, and
+      // per-push attribution above is what actually removes the hazard.
+      if (above.includes(MARKER) || own.includes(MARKER)) marked.push(entry);
+      else hits.push(entry);
+      if (scanAll.lastIndex === at) scanAll.lastIndex += 1;
     }
-    hits.push({ line: i + 1, text: line.trim() });
-  });
+  }
   return { hits, marked };
 }
 
@@ -109,8 +224,8 @@ if (process.argv[1] && process.argv[1].endsWith('check-swallowed-push.mjs')) {
   for (const file of files) {
     const rel = relative(ROOT, file).split('\\').join('/');
     const { hits, marked } = findSwallowedPushes(readFileSync(file, 'utf8'));
-    for (const h of hits) offenders.push(`${rel}:${h.line}  ${h.text}`);
-    for (const m of marked) markedSites.push(`${rel}:${m.line}  ${m.text}`);
+    for (const h of hits) offenders.push(`${rel}:${h.line}  [${h.kind}]  ${h.text}`);
+    for (const m of marked) markedSites.push(`${rel}:${m.line}  [${m.kind}]  ${m.text}`);
   }
 
   if (offenders.length > 0) {
@@ -120,6 +235,11 @@ if (process.argv[1] && process.argv[1].endsWith('check-swallowed-push.mjs')) {
 \`|| true\` on \`git tag\` is fine — a re-run hits an existing tag and idempotency
 is the point. On the PUSH it means a network, auth or ref-lock failure becomes a
 silent no-op and the job continues as though the ref reached the remote.
+
+\`[no-op]\` is \`|| true\` or \`|| :\`, someone meaning to ignore the result.
+\`[handled]\` is \`|| <anything else>\`, usually someone meaning to LOG the failure
+and not realising that under \`set -e\` the \`||\` also silences it — the push fails,
+the handler returns 0, and the job carries on (#3212).
 
 That does not produce "no release". \`gh release create\` creates a missing tag
 itself, from the latest state of the DEFAULT BRANCH when no \`--target\` is given,

--- a/scripts/check-swallowed-push.mjs
+++ b/scripts/check-swallowed-push.mjs
@@ -77,7 +77,7 @@ const COMMAND_POSITION =
   '(?:^|[;&|(){}!]|\\brun:|\\b(?:if|then|else|elif|do|while|until)\\b|\\b[A-Za-z_][A-Za-z0-9_]*=\\S*)\\s*';
 
 /**
- * The push's OWN arguments — no command separator may be crossed.
+ * The push's OWN arguments: everything up to its FIRST `||`, and no further.
  *
  * With `[^\n]*?` the match could run past this push's handler and adopt a LATER
  * command's one, so
@@ -87,9 +87,25 @@ const COMMAND_POSITION =
  * ```
  *
  * was reported even though the push exits loudly and only the independent
- * `cleanup` is swallowed — the gate rejecting a correct workflow.
+ * `cleanup` is swallowed.
+ *
+ * A first attempt at that excluded `;`, `&` and `|` outright, and review found
+ * it FAILED OPEN on the most ordinary thing in a workflow:
+ *
+ * ```sh
+ * git push origin main 2>&1 || true              # missed
+ * git push origin main >/dev/null 2>&1 || true   # missed
+ * git push origin "a|b" || true                  # missed
+ * ```
+ *
+ * The `&` in `2>&1` is a redirection, not a separator, and a `|` inside quotes
+ * is not a pipe. Character classes cannot tell those apart. So this stops at
+ * the two things that genuinely end a command's handler chain -- a `;` and the
+ * `||` itself -- and lets everything else through, which keeps the miss
+ * direction closed at the cost of over-flagging a backgrounded push. That is
+ * the right way round for a release-safety gate.
  */
-const OWN_ARGS = '[^\\n;&|]*?';
+const OWN_ARGS = '(?:(?!\\|\\||;)[^\\n])*?';
 
 /**
  * A `git push` whose failure is discarded.

--- a/scripts/check-swallowed-push.test.mjs
+++ b/scripts/check-swallowed-push.test.mjs
@@ -287,3 +287,52 @@ test('a comment ending in a backslash cannot smuggle a push into command positio
   assert.equal(hits.length, 0, 'a commented-out push must not be reported');
   assert.equal(marked.length, 0, 'nor silently counted as an exemption');
 });
+
+// ---------------------------------------------------------------------------
+// Command position, both directions. Review found the first version of the
+// anchor MISSED four genuine shapes — and for a release-safety gate a miss is
+// far worse than a false positive: it defeats the gate silently, while a false
+// positive is visible and has the marker as an escape hatch.
+
+const PUSH = 'git' + ' push';
+
+test('a swallowed push is caught in every genuine command position', () => {
+  const cases = [
+    [`          ${PUSH} origin "$T" || true`, 'plain'],
+    [`          { ${PUSH} origin "$T" || true; }`, 'brace group'],
+    [`          if ${PUSH} origin "$T" || true; then echo x; fi`, 'if condition'],
+    [`          ! ${PUSH} origin "$T" || true`, 'negation'],
+    [`          FOO=1 ${PUSH} origin "$T" || true`, 'env assignment'],
+    [`          cmd; ${PUSH} origin "$T" || true`, 'after a separator'],
+    [`      - run: ${PUSH} origin "$T" || true`, 'inline run:'],
+  ];
+  for (const [line, what] of cases) {
+    const { hits } = findSwallowedPushes(line);
+    assert.equal(hits.length, 1, `missed a swallowed push in ${what}: ${line}`);
+  }
+});
+
+test('a push that fails LOUDLY is not flagged, whatever follows it', () => {
+  // `|| exit 1` is the idiom this gate's own message tells you to switch to.
+  // Flagging it makes the gate contradict its remedy.
+  const cases = [
+    `          ${PUSH} origin "$T" || exit 1`,
+    `          ${PUSH} origin "$T" || { echo a; exit 1; }`,
+    `          ${PUSH} origin "$T" || return 1`,
+    `          ${PUSH} origin "$T" || false`,
+    // The handler must be THIS push's: an unscoped match ran past `exit 1` and
+    // adopted the independent `cleanup` command's `echo`.
+    `          ${PUSH} origin "$T" || exit 1; cleanup || echo cleanup-failed`,
+  ];
+  for (const line of cases) {
+    const { hits } = findSwallowedPushes(line);
+    assert.equal(hits.length, 0, `flagged a correctly-handled push: ${line}`);
+  }
+});
+
+test('a push in ARGUMENT position is not a command and is not flagged', () => {
+  // The false positive the command-position anchor exists for: after folding,
+  // `echo` consumes the rest and nothing is pushed.
+  const { hits } = findSwallowedPushes(`          echo "hello" ${PUSH} origin v2 || true`);
+  assert.equal(hits.length, 0, 'flagged a push that is an argument to echo');
+});

--- a/scripts/check-swallowed-push.test.mjs
+++ b/scripts/check-swallowed-push.test.mjs
@@ -336,3 +336,29 @@ test('a push in ARGUMENT position is not a command and is not flagged', () => {
   const { hits } = findSwallowedPushes(`          echo "hello" ${PUSH} origin v2 || true`);
   assert.equal(hits.length, 0, 'flagged a push that is an argument to echo');
 });
+
+test('a redirection does not hide a swallowed push', () => {
+  // `2>&1` contains `&`, and a first version of OWN_ARGS excluded `&` as a
+  // separator — so the most ordinary shape in a workflow stopped matching and
+  // the gate reported clean. Same fail-open direction as the command-position
+  // anchor: a character class cannot tell a redirection from a separator, so
+  // the arg run stops only at `;` and at the `||` itself.
+  const cases = [
+    `          ${PUSH} origin main 2>&1 || true`,
+    `          ${PUSH} origin main >/dev/null 2>&1 || true`,
+    `          ${PUSH} origin "a|b" || true`,
+  ];
+  for (const line of cases) {
+    const { hits } = findSwallowedPushes(line);
+    assert.equal(hits.length, 1, `a redirection or quoted pipe hid a swallow: ${line}`);
+  }
+});
+
+test('the handler must still be the push’s own, across a semicolon', () => {
+  // The other direction of the same rule: widening OWN_ARGS must not re-open
+  // the case it was introduced for.
+  const { hits } = findSwallowedPushes(
+    `          ${PUSH} origin "$T" || exit 1; cleanup || echo cleanup-failed`,
+  );
+  assert.equal(hits.length, 0, 'adopted a later command’s handler again');
+});

--- a/scripts/check-swallowed-push.test.mjs
+++ b/scripts/check-swallowed-push.test.mjs
@@ -26,7 +26,7 @@ import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { findSwallowedPushes, SWALLOWED_PUSH, MARKER } from './check-swallowed-push.mjs';
+import { findSwallowedPushes, SWALLOWED_PUSH, HANDLED_PUSH, MARKER } from './check-swallowed-push.mjs';
 
 const SCRIPTS = dirname(fileURLToPath(import.meta.url));
 const CHECKER = join(SCRIPTS, 'check-swallowed-push.mjs');
@@ -136,4 +136,154 @@ test('the detector reports the right line number', () => {
   const { hits } = findSwallowedPushes(src);
   assert.equal(hits.length, 1);
   assert.equal(hits[0].line, 3);
+});
+
+// ---------------------------------------------------------------------------
+// #3212: the rule must see what the SHELL sees, not what one physical line does.
+
+test('a swallow split across a backslash continuation is caught', () => {
+  // Neither physical line matches on its own — this is the whole point.
+  // `${…}` is written as a concatenation so the source carries no template
+  // placeholder inside a plain string (oxlint no-template-curly-in-string); the
+  // fixture text is identical to the release workflow's.
+  const VER = '"v$' + '{VERSION}"';
+  const pushLine = `          git push origin ${VER} \\`;
+  const src = ['      - run: |', pushLine, '            || true'].join('\n');
+  assert.equal(SWALLOWED_PUSH.test(pushLine), false,
+    'guard: the first physical line must NOT match, or this test proves nothing');
+  assert.equal(SWALLOWED_PUSH.test('            || true'), false,
+    'guard: the second physical line must NOT match either');
+
+  const { hits } = findSwallowedPushes(src);
+  assert.equal(hits.length, 1, 'the continuation was not folded into one logical command');
+  assert.equal(hits[0].line, 2, 'the report must point at the line the push is ON');
+  assert.equal(hits[0].kind, 'no-op');
+});
+
+test('an escaped backslash does NOT continue the line', () => {
+  // TWO trailing backslashes: `\\` is one escaped backslash, so the command
+  // ENDS here and `|| true` on the next line belongs to nothing.
+  //
+  // The first version of this test used `echo "a\\\\"` — whose last character
+  // is a quote, not a backslash — and contained no `git push` on either line,
+  // so `hits.length === 0` held for every possible fold rule. It survived a
+  // mutation replacing the parity rule with "any trailing backslash continues".
+  // This version does not: under that mutation the two lines join and the push
+  // is reported.
+  const first = '          git push origin a\\\\';
+  assert.ok(first.endsWith('\\\\'), 'guard: the fixture must really end in two backslashes');
+  assert.ok(first.includes('git push'), 'guard: the fixture must contain a push to be foldable');
+
+  const { hits } = findSwallowedPushes([first, '          || true'].join('\n'));
+  assert.equal(hits.length, 0, 'joined across an EVEN number of trailing backslashes');
+});
+
+test('an ODD number of trailing backslashes DOES continue the line', () => {
+  // The other direction, so the parity rule is pinned rather than just its
+  // false branch. Three backslashes = one escaped pair plus a continuation.
+  const { hits } = findSwallowedPushes(
+    ['          git push origin a\\\\\\', '          || true'].join('\n'),
+  );
+  assert.equal(hits.length, 1, 'an odd count must continue the command');
+});
+
+test('the `|| |` and `|| &` guards keep those shapes unflagged', () => {
+  // Pins the `(?![|&])`-equivalent behaviour of the handler alternation. These
+  // are shell syntax errors, and flagging them would be noise on broken code
+  // rather than a swallow.
+  for (const line of ['git push x || | true', 'git push x || & true']) {
+    const { hits } = findSwallowedPushes(line);
+    assert.equal(hits.length, 0, `flagged a shell syntax error: ${line}`);
+  }
+});
+
+test('a marker does not reach a neighbouring push in the same folded group', () => {
+  // The regression the fold introduces: one logical line spans several physical
+  // ones, so a `joined.includes(MARKER)` would let a marker written for the
+  // mirror push silently exempt the origin push chained after it — and that
+  // push would vanish from the report entirely, not merely be listed as marked.
+  const src = [
+    '          # allow-swallowed-push: mirror is best-effort',
+    '          git push mirror "$TAG" || true; \\',
+    '          git push origin "$TAG" || true',
+  ].join('\n');
+  const { hits, marked } = findSwallowedPushes(src);
+  assert.equal(marked.length, 1, 'the marked mirror push must still be named');
+  assert.equal(hits.length, 1, 'the UNMARKED origin push must still be reported');
+});
+
+test('`|| echo` is a swallow too, and is reported as [handled]', () => {
+  const src = '          git push origin "$TAG" || echo "push failed, continuing"';
+  const { hits } = findSwallowedPushes(src);
+  assert.equal(hits.length, 1, 'a push whose failure is handled by any command is still swallowed');
+  assert.equal(hits[0].kind, 'handled', 'must be distinguishable from `|| true` in the report');
+});
+
+test('`git push ; true` is NOT flagged — set -e fires before `true` runs', () => {
+  // Checked rather than assumed: the status is not discarded here, so flagging
+  // it would be a false positive on correct code.
+  const { hits } = findSwallowedPushes('          git push origin "$TAG" ; true');
+  assert.equal(hits.length, 0, 'a semicolon does not discard the push status under set -e');
+});
+
+test('`||` on something that is not a push stays unflagged', () => {
+  const { hits } = findSwallowedPushes('          git tag -a "$TAG" -m msg || true');
+  assert.equal(hits.length, 0, '`|| true` on `git tag` is correct and must stay unflagged');
+});
+
+test('the marker still exempts a continuation-split push, and names it', () => {
+  const src = [
+    '          # allow-swallowed-push: mirror remote is best-effort',
+    '          git push mirror "$TAG" \\',
+    '            || true',
+  ].join('\n');
+  const { hits, marked } = findSwallowedPushes(src);
+  assert.equal(hits.length, 0, 'the marker above the FIRST physical line must still apply');
+  assert.equal(marked.length, 1, 'a marked site must stay named, not vanish');
+});
+
+test('handled_push_is_a_superset: HANDLED_PUSH matches everything SWALLOWED_PUSH does', () => {
+  // `findSwallowedPushes` uses HANDLED_PUSH as the GATE and SWALLOWED_PUSH only
+  // to label the hit. That is only sound while this holds. If someone tightens
+  // HANDLED_PUSH and breaks it, every `|| true` site stops being reported —
+  // silently, with the gate still exiting 0. An absence that reads as success,
+  // which is the exact failure this gate exists to prevent, reintroduced into
+  // the gate itself.
+  const heads = ['git push', 'git  push', '  git push origin main', 'run: git push "$T"'];
+  const tails = ['|| true', '||true', '|| :', '||  true # note', '|| true; echo x', '|| true)'];
+  let matched = 0;
+  for (const h of heads) {
+    for (const t of tails) {
+      const line = `${h} ${t}`;
+      if (!SWALLOWED_PUSH.test(line)) continue;
+      matched += 1;
+      assert.ok(
+        HANDLED_PUSH.test(line),
+        `SWALLOWED_PUSH matches but HANDLED_PUSH does not, so this site would go ` +
+          `UNREPORTED by findSwallowedPushes: ${JSON.stringify(line)}`,
+      );
+    }
+  }
+  // Non-vacuity: the loop must actually have exercised the relation, or it
+  // passes by testing nothing.
+  assert.ok(matched >= 20, `only ${matched} SWALLOWED_PUSH matches were generated`);
+});
+
+test('a comment ending in a backslash cannot smuggle a push into command position', () => {
+  // In shell a `#` comment runs to end of line and a trailing backslash inside
+  // it does NOT continue the command, so the push below is commented out. The
+  // fold does join them (it is not a shell parser), and the COMMAND-POSITION
+  // anchor is what stops that becoming a false positive: after the join the
+  // push is preceded by comment text, not by a separator.
+  //
+  // This is also why the marker cannot reach a neighbouring push: a marker is a
+  // comment, and a comment ends the logical command, so there is no valid shell
+  // in which one folded group carries a marker and a later live push.
+  const src = [
+    '          echo hi  # allow-swallowed-push: not really \\',
+    '          git push origin "$TAG" || true',
+  ].join('\n');
+  const { hits, marked } = findSwallowedPushes(src);
+  assert.equal(hits.length, 0, 'a commented-out push must not be reported');
+  assert.equal(marked.length, 0, 'nor silently counted as an exemption');
 });


### PR DESCRIPTION
Closes #3212. Deferred from #3208, where CodeRabbit CLI raised it and it was out of scope.

`findSwallowedPushes` tested its regex against each **physical** line, so a push whose no-op sits after a backslash continuation is one logical command but two physical lines, and neither matched alone:

```yaml
git push origin "v${VERSION}" \
  || true
```

Same family as the `;`/`&`/`|`/`)` chaining gap fixed in #3208 — the rule seeing less than the shell does. `logicalLines` folds continuations first, on **odd** trailing-backslash parity, since `\\` is an escaped backslash and ends the line for real.

## "Any command" is the obvious fix and it is wrong

#3212 proposed widening the no-op alternation to any handler. I built that, and review measured what it does to the idiom **this gate pushes people toward**:

```sh
git push origin "v1" || exit 1                    # correct — was flagged
git push origin main || { echo "..."; exit 1; }   # correct — was flagged
```

Verified in bash: `false || exit 1` exits **1**; `false || echo x` exits **0**. So `|| exit 1` is the textbook loud-failure form — exactly what an author reaches for when this gate rejects their `|| true` — and flagging it makes the gate contradict its own printed remedy (*"Drop the `|| true`"*, on a hit containing no `|| true`). `|| return 1`, `|| false`, `|| exit $?` and `|| die` are the same.

Enumerating every **terminating** handler is a losing game (`{ …; exit 1; }`, a shell function, a trap). Enumerating the **harmless** ones is not: `echo` and `printf` cannot fail a step whatever their arguments. So the alternation is an allowlist — `true`, `:`, `echo`, `printf` — which can only ever grow when someone shows a real swallow it misses, and can never flag a correct one.

## A push must be at command position

Folding is not parsing, and:

```yaml
echo "hello" \
git push origin "v2" || true
```

is `echo` swallowing the rest — nothing is pushed. Matching the joined text naively reported it **and** pointed the reader at a line with no push on it, which is the thing `logicalLines` exists to avoid. The patterns now require a separator or start-of-line before `git push`. That also covers a comment ending in a backslash, which shell does not treat as a continuation at all.

## One entry per push, not per folded group

A chained pair collapses to one logical line. One-entry-per-group both under-reported the second push **and** let a marker written for the first exempt it — the second push vanished from the report rather than being listed as marked:

```
before:  hits: []                    marked: [mirror]      ← origin push gone
after:   hits: [origin @ line 3]     marked: [mirror @ 2]
```

Hits are attributed to the physical line the push **starts** on, offset from the push itself rather than from the match, since the pattern consumes a leading separator.

## The subset relation is now pinned

`HANDLED_PUSH` gates and `SWALLOWED_PUSH` only classifies, which is sound only while the first is a superset of the second. `handled_push_is_a_superset` pins that — because if it stopped holding, every `|| true` site would go **silently unreported**: an absence reading as success, reintroduced into the gate built to prevent it.

It earned its place immediately: it caught `\b` failing to match after `:` in the first draft of the allowlist.

## One test of mine could not fail

The escaped-backslash fixture ended in a **quote**, not a backslash, and contained no `git push` — so `hits.length === 0` held for every possible fold rule. It survived a mutation replacing the parity rule with "any trailing backslash continues". Rewritten with a real push and real trailing backslashes, plus the odd-count direction, so the rule is pinned both ways.

## Verification

Baseline stays **zero**: no `git push` in `.github/workflows/` is followed by `||` today, and #3208 removed the only two instances.

Mutation-checked — reverting the fold, dropping the handler alternation, breaking the parity rule, attributing by match start, and pinning `kind` each turn the tests red.

644 script tests · lint, module-size and test-wiring clean.