### PR TITLE
fix(scripts): the Lint gate never looked at examples/, so six errors sat green

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,12 @@ jobs:
               # whoever touches the frontend next. Add it here when you add it.
               - 'apps/viewer/**'
               - 'apps/viewer-embed/**'
+              # `examples/*` is a pnpm-workspace member and is now a lint target
+              # (scripts/check-lint-ran.mjs). Without it here, an examples-only
+              # PR leaves `frontend` false, the Lint job never runs, and the new
+              # target protects nothing on the PRs that change those files --
+              # the same trap the comment above describes for `apps/`.
+              - 'examples/**'
               - 'packages/**'
               - 'tests/e2e/**'
               - 'playwright.config.ts'

--- a/examples/babylonjs-viewer/src/main.ts
+++ b/examples/babylonjs-viewer/src/main.ts
@@ -264,7 +264,7 @@ fileInput.addEventListener('change', async () => {
     let streamMaxX = -Infinity, streamMaxY = -Infinity, streamMaxZ = -Infinity;
     let hasStreamBounds = false;
 
-    function expandStreamBoundsFromMeshes(meshes: MeshData[]) {
+    const expandStreamBoundsFromMeshes = (meshes: MeshData[]) => {
       for (const m of meshes) {
         const p = m.positions;
         for (let i = 0; i < p.length; i += 3) {
@@ -282,7 +282,7 @@ fileInput.addEventListener('change', async () => {
       hasStreamBounds = true;
     }
 
-    function getStreamBounds(): { center: Vector3; maxDim: number } | null {
+    const getStreamBounds = (): { center: Vector3; maxDim: number } | null => {
       if (!hasStreamBounds) return null;
       const center = new Vector3(
         (streamMinX + streamMaxX) / 2,
@@ -297,7 +297,7 @@ fileInput.addEventListener('change', async () => {
       return { center, maxDim };
     }
 
-    function fitIfDue() {
+    const fitIfDue = () => {
       const bounds = getStreamBounds();
       if (!bounds) return;
       applyCameraFit(bounds.center, bounds.maxDim, false);

--- a/examples/threejs-viewer/src/main.ts
+++ b/examples/threejs-viewer/src/main.ts
@@ -253,7 +253,7 @@ fileInput.addEventListener('change', async () => {
     let streamMaxX = -Infinity, streamMaxY = -Infinity, streamMaxZ = -Infinity;
     let hasStreamBounds = false;
 
-    function expandStreamBoundsFromMeshes(meshes: MeshData[]) {
+    const expandStreamBoundsFromMeshes = (meshes: MeshData[]) => {
       for (const m of meshes) {
         const p = m.positions;
         for (let i = 0; i < p.length; i += 3) {
@@ -271,7 +271,7 @@ fileInput.addEventListener('change', async () => {
       hasStreamBounds = true;
     }
 
-    function getStreamBounds(): { center: THREE.Vector3; maxDim: number } | null {
+    const getStreamBounds = (): { center: THREE.Vector3; maxDim: number } | null => {
       if (!hasStreamBounds) return null;
       const center = new THREE.Vector3(
         (streamMinX + streamMaxX) / 2,
@@ -286,7 +286,7 @@ fileInput.addEventListener('change', async () => {
       return { center, maxDim };
     }
 
-    function fitIfDue() {
+    const fitIfDue = () => {
       const bounds = getStreamBounds();
       if (!bounds) return;
       applyCameraFit(bounds.center, bounds.maxDim, false);

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -32,7 +32,9 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 
 /**
  * Where the source actually is, and how small each place is allowed to get.
@@ -48,7 +50,7 @@ import { readFileSync } from 'node:fs';
  * The floors sit well under today's counts: deleting a genuine chunk of code
  * must not fail the lint lane, but a target dropping out cannot hide.
  */
-const TARGETS = [
+export const TARGETS = [
   { dir: 'apps', min: 900 },
   { dir: 'packages', min: 1200 },
   { dir: 'scripts', min: 100 },
@@ -226,4 +228,23 @@ function main() {
   return 0;
 }
 
-process.exitCode = main();
+/**
+ * Importable so the test can read `TARGETS` as DATA. It previously derived the
+ * count by regexing this file, which is a source-text assertion (AGENTS.md:136)
+ * -- it certifies that a string exists, so a reformat or a comment edit decides
+ * the test result instead of behaviour. Same entry-point shape as
+ * `check-refwalk-guards.mjs`: compare resolved PATHS, and fall back rather than
+ * letting the check take the process down if the path has vanished.
+ */
+function isMainEntry() {
+  const invoked = process.argv[1];
+  if (!invoked) return false;
+  const self = fileURLToPath(import.meta.url);
+  try {
+    return realpathSync(self) === realpathSync(invoked);
+  } catch {
+    return self === resolve(invoked);
+  }
+}
+
+if (isMainEntry()) process.exitCode = main();

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -32,6 +32,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 
 /**
  * Where the source actually is, and how small each place is allowed to get.
@@ -51,7 +52,53 @@ const TARGETS = [
   { dir: 'apps', min: 900 },
   { dir: 'packages', min: 1200 },
   { dir: 'scripts', min: 100 },
+  { dir: 'examples', min: 10 },
 ];
+
+/**
+ * The floors above catch a target that SHRANK. They cannot catch a target that
+ * was never in the list — a directory absent from `TARGETS` is not counted low,
+ * it is not counted at all, and the success line still reads "no errors".
+ *
+ * That is not hypothetical. `examples/` is a declared `pnpm-workspace.yaml`
+ * member and was never passed to oxlint, so six error-tier
+ * `eslint(no-inner-declarations)` violations sat in `examples/threejs-viewer`
+ * and `examples/babylonjs-viewer` while the Lint job was green (#3200,
+ * finding 3). Adding `examples` to `TARGETS` fixes that instance. This
+ * function is what stops the NEXT one: the workspace file is the declaration of
+ * where first-party source lives, so a glob that appears there and not here is
+ * a gap by construction, and it fails loudly rather than being linted by
+ * nobody.
+ *
+ * Deliberately one-directional. A `TARGETS` entry with no workspace glob
+ * (`scripts/`) is fine and expected — this asks only that nothing DECLARED is
+ * unlinted.
+ */
+function uncoveredWorkspaceGlobs() {
+  let raw;
+  try {
+    raw = readFileSync('pnpm-workspace.yaml', 'utf8');
+  } catch (err) {
+    return { error: `could not read pnpm-workspace.yaml: ${err.message}` };
+  }
+  // Only the `packages:` block. Scoping matters: `onlyBuiltDependencies` lists
+  // scoped npm names (`@swc/core`) that also contain a slash, and a whole-file
+  // scan reads those as workspace roots and demands lint targets for `@swc/`.
+  // Stop at the next top-level key — a line with no leading whitespace.
+  const roots = new Set();
+  let inPackages = false;
+  for (const line of raw.split('\n')) {
+    if (/^\S/.test(line)) inPackages = /^packages\s*:/.test(line);
+    if (!inPackages) continue;
+    const m = /^\s*-\s*['"]?([^'"\s/]+)\//.exec(line);
+    if (m) roots.add(m[1]);
+  }
+  if (roots.size === 0) {
+    return { error: 'parsed no globs from pnpm-workspace.yaml — the format changed and this check is now blind' };
+  }
+  const covered = new Set(TARGETS.map((t) => t.dir));
+  return { missing: [...roots].filter((r) => !covered.has(r)), seen: roots.size };
+}
 
 /** oxlint's summary: "Finished in Xms on N files with M rules using K threads."
  *  Anchored on "Finished in", and the LAST match wins: the pattern alone can
@@ -97,6 +144,19 @@ function lint(dir) {
  *  assigned to `process.exitCode` lets Node drain stdout, `process.exit()`
  *  does not. */
 function main() {
+  const coverage = uncoveredWorkspaceGlobs();
+  if (coverage.error) {
+    console.error(`lint: ${coverage.error}`);
+    return 1;
+  }
+  if (coverage.missing.length > 0) {
+    console.error('lint: a pnpm-workspace.yaml glob is not in TARGETS, so its source is');
+    console.error('      linted by nobody and this gate would still report "no errors":\n');
+    for (const dir of coverage.missing) console.error(`      ${dir}/`);
+    console.error('\n      Add it to TARGETS with a floor, or remove it from the workspace.');
+    return 1;
+  }
+
   let totalFiles = 0;
   let ruleCount = 0;
   let failed = 0;
@@ -126,7 +186,7 @@ function main() {
   }
 
   if (failed !== 0) return failed;
-  console.log(`lint: ${totalFiles.toLocaleString()} files across ${TARGETS.length} targets, ${ruleCount} rules, no errors.`);
+  console.log(`lint: ${totalFiles.toLocaleString()} files across ${TARGETS.length} targets (${coverage.seen} workspace globs, all covered), ${ruleCount} rules, no errors.`);
   return 0;
 }
 

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -52,7 +52,7 @@ const TARGETS = [
   { dir: 'apps', min: 900 },
   { dir: 'packages', min: 1200 },
   { dir: 'scripts', min: 100 },
-  { dir: 'examples', min: 10 },
+  { dir: 'examples', min: 14 },
 ];
 
 /**
@@ -79,7 +79,8 @@ function uncoveredWorkspaceGlobs() {
   try {
     raw = readFileSync('pnpm-workspace.yaml', 'utf8');
   } catch (err) {
-    return { error: `could not read pnpm-workspace.yaml: ${err.message}` };
+    console.error(`lint: could not read pnpm-workspace.yaml: ${err.message}`);
+    return null;
   }
   // Only the `packages:` block. Scoping matters: `onlyBuiltDependencies` lists
   // scoped npm names (`@swc/core`) that also contain a slash, and a whole-file
@@ -90,11 +91,24 @@ function uncoveredWorkspaceGlobs() {
   for (const line of raw.split('\n')) {
     if (/^\S/.test(line)) inPackages = /^packages\s*:/.test(line);
     if (!inPackages) continue;
-    const m = /^\s*-\s*['"]?([^'"\s/]+)\//.exec(line);
-    if (m) roots.add(m[1]);
+    // Capture the whole entry, THEN take the first segment. Requiring a
+    // trailing slash in the pattern silently dropped a member declared as a
+    // bare directory (`- 'tools'`, `- '.'`, both legal pnpm): it was not
+    // counted, so it was not demanded, and the gate printed "all covered".
+    // That is the absence-reads-as-success failure this function exists to
+    // stop, one shape over. Measured: it was the only one of 29 yaml shapes
+    // tried that failed OPEN rather than closed.
+    const m = /^\s*-\s*['"]?([^'"\s]+)/.exec(line);
+    if (!m) continue;
+    // `- '!packages/legacy/**'` is an EXCLUSION, not a member. Left in, it
+    // demands a `{ dir: '!packages' }` target that would then be handed to
+    // oxlint -- a failure with no satisfiable remedy.
+    if (m[1].startsWith('!')) continue;
+    roots.add(m[1].split('/')[0]);
   }
   if (roots.size === 0) {
-    return { error: 'parsed no globs from pnpm-workspace.yaml — the format changed and this check is now blind' };
+    console.error('lint: parsed no globs from pnpm-workspace.yaml — the format changed and this check is now blind');
+    return null;
   }
   const covered = new Set(TARGETS.map((t) => t.dir));
   return { missing: [...roots].filter((r) => !covered.has(r)), seen: roots.size };
@@ -145,10 +159,7 @@ function lint(dir) {
  *  does not. */
 function main() {
   const coverage = uncoveredWorkspaceGlobs();
-  if (coverage.error) {
-    console.error(`lint: ${coverage.error}`);
-    return 1;
-  }
+  if (coverage === null) return 1; // it has already said why
   if (coverage.missing.length > 0) {
     console.error('lint: a pnpm-workspace.yaml glob is not in TARGETS, so its source is');
     console.error('      linted by nobody and this gate would still report "no errors":\n');

--- a/scripts/check-lint-ran.mjs
+++ b/scripts/check-lint-ran.mjs
@@ -52,7 +52,7 @@ const TARGETS = [
   { dir: 'apps', min: 900 },
   { dir: 'packages', min: 1200 },
   { dir: 'scripts', min: 100 },
-  { dir: 'examples', min: 14 },
+  { dir: 'examples', min: 15 },
 ];
 
 /**
@@ -88,26 +88,51 @@ function uncoveredWorkspaceGlobs() {
   // Stop at the next top-level key — a line with no leading whitespace.
   const roots = new Set();
   let inPackages = false;
+  let entryLines = 0;
+  let parsedEntries = 0;
   for (const line of raw.split('\n')) {
+    // A comment is legal YAML at ANY column, so a `#` at column 0 is not a new
+    // top-level key. Treating it as one ended the parse early and dropped every
+    // entry after it -- and because the count it printed was the count of what
+    // it did read, the log said "all covered". Skip comments before the
+    // block-boundary test, not after.
+    if (/^\s*#/.test(line) || line.trim() === '') continue;
     if (/^\S/.test(line)) inPackages = /^packages\s*:/.test(line);
     if (!inPackages) continue;
+    // Every `-` in the block is an entry this function is responsible for. If
+    // one does not parse -- a bare `-` with its value on the next line, or any
+    // shape not yet met -- that is a SHORT read, and a short read is exactly
+    // what makes a missing glob invisible. Counted here, enforced below.
+    if (/^\s*-/.test(line)) entryLines += 1;
     // Capture the whole entry, THEN take the first segment. Requiring a
     // trailing slash in the pattern silently dropped a member declared as a
     // bare directory (`- 'tools'`, `- '.'`, both legal pnpm): it was not
     // counted, so it was not demanded, and the gate printed "all covered".
     // That is the absence-reads-as-success failure this function exists to
-    // stop, one shape over. Measured: it was the only one of 29 yaml shapes
-    // tried that failed OPEN rather than closed.
+    // stop, one shape over. Two further shapes failed open after that fix --
+    // a `#` comment at column 0, and a bare `-` with its value on the next
+    // line -- which is why the entry-count check above exists rather than
+    // another special case per shape.
     const m = /^\s*-\s*['"]?([^'"\s]+)/.exec(line);
     if (!m) continue;
     // `- '!packages/legacy/**'` is an EXCLUSION, not a member. Left in, it
     // demands a `{ dir: '!packages' }` target that would then be handed to
     // oxlint -- a failure with no satisfiable remedy.
-    if (m[1].startsWith('!')) continue;
+    if (m[1].startsWith('!')) { parsedEntries += 1; continue; }
+    parsedEntries += 1;
     roots.add(m[1].split('/')[0]);
   }
   if (roots.size === 0) {
-    console.error('lint: parsed no globs from pnpm-workspace.yaml — the format changed and this check is now blind');
+    console.error('lint: parsed no globs from pnpm-workspace.yaml — the format changed and this check is now blind.');
+    console.error('      (Flow style `packages: [...]` and dashes at column 0 both land here.)');
+    return null;
+  }
+  if (parsedEntries < entryLines) {
+    console.error(
+      `lint: parsed ${parsedEntries} of ${entryLines} entries in pnpm-workspace.yaml's packages: block.`,
+    );
+    console.error('      An entry this parser cannot read is a glob it cannot demand a lint target for,');
+    console.error('      so refusing rather than reporting on a short read.');
     return null;
   }
   const covered = new Set(TARGETS.map((t) => t.dir));

--- a/scripts/check-lint-ran.test.mjs
+++ b/scripts/check-lint-ran.test.mjs
@@ -40,6 +40,25 @@ const TARGET_COUNT = (
     .match(/\{\s*dir:/g) ?? []
 ).length;
 assert.ok(TARGET_COUNT > 0, 'could not read TARGETS out of check-lint-ran.mjs — this test is now blind');
+
+/**
+ * A floor, not a mirror. Deriving the count from the gate makes this test
+ * desync-proof, but on its own it also makes it BLIND: delete
+ * `{ dir: 'scripts' }` and both the gate and the derived count drop to 3
+ * together, the assertions still agree, and ~140 files including this gate go
+ * unlinted with the suite green. Measured — that mutation passed 2/2 with the
+ * derived count alone, and reds 2/2 with this line.
+ *
+ * `uncoveredWorkspaceGlobs()` only protects targets that are ALSO workspace
+ * globs, so `scripts/` has no other guard. Ratchets up only: adding a target is
+ * a deliberate edit here, removing one has to be.
+ */
+const MIN_TARGETS = 4;
+assert.ok(
+  TARGET_COUNT >= MIN_TARGETS,
+  `check-lint-ran.mjs has ${TARGET_COUNT} lint targets, expected at least ${MIN_TARGETS} — ` +
+    'a target was removed, so its directory is now linted by nobody',
+);
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -137,7 +156,10 @@ test('a clean lint still reports its own summary line through a pipe', () => {
     // 2,000 files per target from the shim, three targets.
     assert.match(
       run.stdout,
-      /lint: [\d,]+ files across \d+ targets \(\d+ workspace globs, all covered\), \d+ rules, no errors\./,
+      new RegExp(
+        `lint: ${(2000 * TARGET_COUNT).toLocaleString()} files across ${TARGET_COUNT} targets ` +
+          '\\(\\d+ workspace globs, all covered\\), 300 rules, no errors\\.',
+      ),
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/scripts/check-lint-ran.test.mjs
+++ b/scripts/check-lint-ran.test.mjs
@@ -24,7 +24,22 @@
  */
 
 import { test } from 'node:test';
+import { readFileSync } from 'node:fs';
 import assert from 'node:assert/strict';
+
+/**
+ * Read the target count out of the gate itself rather than hardcoding it.
+ * This test asserted a literal 3 and the literal string "across 3 targets";
+ * adding `examples` to TARGETS turned it red (0 pass / 2 fail) with nothing
+ * wrong in the gate. A test that must be edited in lockstep with a list it
+ * does not own will desync again, and CI runs it (test.yml:829).
+ */
+const TARGET_COUNT = (
+  readFileSync(new URL('./check-lint-ran.mjs', import.meta.url), 'utf8')
+    .match(/const TARGETS = \[([\s\S]*?)\]/)?.[1]
+    .match(/\{\s*dir:/g) ?? []
+).length;
+assert.ok(TARGET_COUNT > 0, 'could not read TARGETS out of check-lint-ran.mjs — this test is now blind');
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -97,18 +112,18 @@ test('a failing lint keeps its whole output when stdout is a pipe', () => {
     // One summary per target. This is what vanished: the truncated log ended
     // roughly 1% in, so a reader saw diagnostics and no verdict.
     const summaries = stdout.match(/Finished in [^\n]*? on [\d,]+ files with \d+ rules/g) ?? [];
-    assert.equal(summaries.length, 3, `expected 3 oxlint summaries, got ${summaries.length}`);
+    assert.equal(summaries.length, TARGET_COUNT, `expected ${TARGET_COUNT} oxlint summaries, got ${summaries.length}`);
 
     // And the last line before each summary, so this cannot pass on a log that
     // dropped the middle and happened to keep the tail.
     const markers = stdout.match(new RegExp(TAIL_MARKER, 'g')) ?? [];
-    assert.equal(markers.length, 3, `expected 3 tail markers, got ${markers.length}`);
+    assert.equal(markers.length, TARGET_COUNT, `expected ${TARGET_COUNT} tail markers, got ${markers.length}`);
 
     // Byte-exact: every diagnostic line of every target arrived. Asserting the
     // count rather than "more than a pipe buffer" keeps the test honest if the
     // output grows or the buffer size differs between platforms.
     const diagnostics = stdout.match(/eslint\(no-control-regex\)/g) ?? [];
-    assert.equal(diagnostics.length, LINES_PER_TARGET * 3);
+    assert.equal(diagnostics.length, LINES_PER_TARGET * TARGET_COUNT);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -120,7 +135,10 @@ test('a clean lint still reports its own summary line through a pipe', () => {
     const run = runGate(bin);
     assert.equal(run.status, 0, `expected exit 0, got ${run.status}\n${run.stderr}`);
     // 2,000 files per target from the shim, three targets.
-    assert.match(run.stdout, /lint: 6,000 files across 3 targets, 300 rules, no errors\./);
+    assert.match(
+      run.stdout,
+      /lint: [\d,]+ files across \d+ targets \(\d+ workspace globs, all covered\), \d+ rules, no errors\./,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/check-lint-ran.test.mjs
+++ b/scripts/check-lint-ran.test.mjs
@@ -24,21 +24,20 @@
  */
 
 import { test } from 'node:test';
-import { readFileSync } from 'node:fs';
 import assert from 'node:assert/strict';
 
 /**
- * Read the target count out of the gate itself rather than hardcoding it.
- * This test asserted a literal 3 and the literal string "across 3 targets";
- * adding `examples` to TARGETS turned it red (0 pass / 2 fail) with nothing
- * wrong in the gate. A test that must be edited in lockstep with a list it
- * does not own will desync again, and CI runs it (test.yml:829).
+ * Import the gate's TARGETS as DATA. This test asserted a literal 3 and the
+ * literal string "across 3 targets"; adding `examples` turned it red (0 pass /
+ * 2 fail) with nothing wrong in the gate, and CI runs it (test.yml:829).
+ *
+ * The first fix regexed the gate's SOURCE TEXT for the count, which is the
+ * practice AGENTS.md:136 bans: it certifies a string exists, so a reformat or
+ * a comment edit would decide the result instead of behaviour. Importing the
+ * array is the same desync-immunity from the value the gate actually uses.
  */
-const TARGET_COUNT = (
-  readFileSync(new URL('./check-lint-ran.mjs', import.meta.url), 'utf8')
-    .match(/const TARGETS = \[([\s\S]*?)\]/)?.[1]
-    .match(/\{\s*dir:/g) ?? []
-).length;
+const { TARGETS } = await import('./check-lint-ran.mjs');
+const TARGET_COUNT = TARGETS.length;
 assert.ok(TARGET_COUNT > 0, 'could not read TARGETS out of check-lint-ran.mjs — this test is now blind');
 
 /**


### PR DESCRIPTION
Closes the LIVE half of #3200 finding 3.

## The defect

`pnpm-workspace.yaml` declares three globs. `scripts/check-lint-ran.mjs` had three TARGETS. They are not the same three:

```
workspace:   packages/*   apps/*   examples/*
TARGETS:     packages     apps     scripts
```

`examples/` was never passed to oxlint, so six error-tier violations sat in two workspace packages while the Lint job was green:

```
$ pnpm exec oxlint --config .oxlintrc.json tests tools api server examples
Found 15 warnings and 6 errors.

examples/threejs-viewer/src/main.ts:256,274,289    eslint(no-inner-declarations)
examples/babylonjs-viewer/src/main.ts:267,285,300  eslint(no-inner-declarations)
```

The gate was working perfectly on everything it looked at. Its floors are per target precisely so one cannot hide behind another, and its success line under-claims — `across N targets`, not "across the repo". Nothing noticed a workspace glob existed outside the list, and that is what made it invisible.

## What this does

**Fixes the six.** All are function declarations in nested blocks, each declared before first use, so `const fn = (...) => {}` has no hoisting consequence. Verified behaviour-neutral: `tsc --noEmit` error counts are **identical** before and after (threejs 27, babylonjs 15 — all pre-existing implicit-any in untouched code), and oxlint over those directories goes 6 errors → 0.

**Makes the next gap impossible.** The floors catch a target that *shrank*, never one that was never listed — an absent directory is not counted low, it is not counted at all. `uncoveredWorkspaceGlobs()` reads the `packages:` block and fails when a declared glob has no lint target. One-directional on purpose: a TARGETS entry with no glob (`scripts/`) is fine; it asks only that nothing **declared** goes unlinted.

## Both verdicts, every shape run against the real gate

```
baseline                        EXIT 0   3,621 files across 4 targets (3 globs, all covered)
uncovered plugins/*             EXIT 1   names plugins/
comment at column 0             EXIT 1   names plugins/
bare dash, value next line      EXIT 1   parsed 3 of 4
bare dir  - 'tools'             EXIT 1   names tools/
root pkg  - '.'                 EXIT 1   names ./
exclusion !packages/legacy      EXIT 0   correctly ignored
flow style packages: [...]      EXIT 1   fails closed, names the shape
reintroduce a lint error        EXIT 1   one no-inner-declarations
remove scripts/ from TARGETS    test 0 pass / 1 fail
```

## Three defects I introduced and had to be caught

Worth stating because they are the same class the PR is about.

1. **The parser required a trailing slash**, so `- 'tools'` and `- '.'` — both legal pnpm — were not counted, therefore not demanded, and it printed "all covered" and exited 0. A fail-open inside the function written to prevent fail-opens.
2. **A `#` comment at column 0 ended the parse.** Everything after it was dropped, and the count printed was the count of what it managed to read, so the log still said "all covered". Found by `/code-review`. Rather than a per-shape patch, the fix is structural: count the `-` entry lines and refuse when fewer parse than were seen. `parsed 3 of 4` is now a failure with its own message.
3. **My own desync fix removed detection.** Deriving `TARGET_COUNT` from the gate made the test desync-proof and blind at once — delete `{ dir: 'scripts' }` and gate and count drop together, assertions still agree, ~140 files including this gate go unlinted with the suite green. Measured at 2/2 passing. Added a `MIN_TARGETS` floor that ratchets up only.

A source comment claiming the first shape "was the only one of 29 yaml shapes tried that failed OPEN" was refuted by the review — two more did. The comment now says so and points at the entry-count check as the reason there is no per-shape list to maintain.

## Deferred, worth its own issue

Six sibling gates hardcode the same root lists and all miss `examples/`: `check-module-size`, `check-test-glob-coverage`, `check-loader-hook-specifier-match`, `check-wasm-disposal`, `check-test-wiring`, `check-source-text-assertions`. `examples/` holds 24 `free()`/`dispose()` sites that `check-wasm-disposal` never scans.

## Test plan

- [x] `node scripts/check-lint-ran.mjs` → exit 0, `3,621 files across 4 targets (3 workspace globs, all covered), 98 rules, no errors.`
- [x] `node --test scripts/check-lint-ran.test.mjs` → 2 pass, 0 fail
- [x] `tsc --noEmit` on both examples: error counts unchanged vs `origin/main`
- [x] Ten-shape probe matrix above, each run against the real gate
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Expanded lint validation to cover all configured workspace areas, including examples.
  * Added checks for missing, unreadable, empty, or incomplete workspace configurations.
  * Updated lint verification tests to reflect the expanded coverage.
* **Maintenance**
  * Standardized internal helper declarations in the Babylon.js and Three.js viewers without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->