### PR TITLE
fix(parser): byType missed IfcFurniture — the subtype table had no IfcFurnishingElement (#3229)

### DIFF
--- a/.changeset/query-furnishing-subtypes.md
+++ b/.changeset/query-furnishing-subtypes.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/parser": patch
+---
+
+`byType('IfcFurnishingElement')` now returns furniture. `expandTypes` widens a
+supertype to its subtypes through `IFC_SUBTYPES`, a hand-maintained table that
+covered the nine `*StandardCase` families and nothing else — so an IFC4 model
+whose furniture is `IfcFurniture` (which is what exporters write) answered a
+query for the supertype with no rows at all. `IfcFurniture` and
+`IfcSystemFurnitureElement` join the table, which fixes the CLI (`ifc-lite query
+--type IfcFurnishingElement`, the `stats` element counts), the MCP
+`query_entities` tool and the viewer's query adapter together, since all three
+call the same shared table. The table is now pinned in tests against the
+subtypes the generated `SCHEMA_REGISTRY` declares, in both directions, so it
+cannot fall behind the schema again.

--- a/packages/parser/src/query-backend-maps.ts
+++ b/packages/parser/src/query-backend-maps.ts
@@ -37,6 +37,10 @@ export const IFC_SUBTYPES: Record<string, string[]> = {
   IFCMEMBER: ['IFCMEMBERSTANDARDCASE'],
   IFCPLATE: ['IFCPLATESTANDARDCASE'],
   IFCOPENINGELEMENT: ['IFCOPENINGSTANDARDCASE'],
+  // Not a `*StandardCase` family, and absent until #3229: IFC4 exporters write
+  // furniture as IFCFURNITURE, so `byType('IfcFurnishingElement')` answered
+  // with nothing on a model that plainly contained furniture.
+  IFCFURNISHINGELEMENT: ['IFCFURNITURE', 'IFCSYSTEMFURNITUREELEMENT'],
 };
 
 /**

--- a/packages/parser/test/query-backend-maps.test.ts
+++ b/packages/parser/test/query-backend-maps.test.ts
@@ -19,6 +19,7 @@
 import { describe, it, expect } from 'vitest';
 import { IFC_SUBTYPES, expandTypes, QUERY_REL_TYPE_MAP } from '../src/query-backend-maps.js';
 import { RelationshipType } from '@ifc-lite/data';
+import { SCHEMA_REGISTRY } from '../src/generated/schema-registry.js';
 
 describe('expandTypes', () => {
   it('includes both IFC4 case subtypes of IfcWall', () => {
@@ -75,6 +76,66 @@ describe('IFC_SUBTYPES', () => {
     for (const [parent, subtypes] of Object.entries(IFC_SUBTYPES)) {
       expect(subtypes).not.toContain(parent);
     }
+  });
+});
+
+/**
+ * `IFC_SUBTYPES` states by hand a relation the generated `SCHEMA_REGISTRY`
+ * already states exactly. Two paths that must agree — and they did not: the map
+ * carried the nine `*StandardCase` families and no `IFCFURNISHINGELEMENT`, so
+ * `byType('IfcFurnishingElement')` answered with nothing on an IFC4 model whose
+ * furniture is `IfcFurniture` (#3229). This pins the hand-written map to the
+ * generated schema so it cannot fall behind again.
+ */
+describe('IFC_SUBTYPES agrees with the generated schema registry', () => {
+  /** Transitive descendants of `type`, read off the registry's inheritance chains. */
+  function registryDescendants(type: string): string[] {
+    const upper = type.toUpperCase();
+    const out: string[] = [];
+    for (const entity of Object.values(SCHEMA_REGISTRY.entities)) {
+      const self = entity.name.toUpperCase();
+      if (self === upper) continue;
+      if ((entity.inheritanceChain ?? []).some(a => a.toUpperCase() === upper)) out.push(self);
+    }
+    return out.sort();
+  }
+
+  it('has a supertype to check, and the registry declares subtypes for each', () => {
+    // Anti-vacuity. Both halves of every assertion below are derived — an empty
+    // map, or a registry that stopped reporting inheritance chains, would make
+    // the per-supertype cases pass by finding nothing to compare.
+    expect(Object.keys(IFC_SUBTYPES).length).toBeGreaterThan(0);
+    for (const supertype of Object.keys(IFC_SUBTYPES)) {
+      expect(registryDescendants(supertype).length, supertype).toBeGreaterThan(0);
+    }
+  });
+
+  it('lists every subtype the registry declares, for every supertype in the map', () => {
+    for (const supertype of Object.keys(IFC_SUBTYPES)) {
+      const expanded = expandTypes([supertype]);
+      for (const sub of registryDescendants(supertype)) {
+        expect(expanded, `${supertype} -> ${sub}`).toContain(sub);
+      }
+    }
+  });
+
+  it('lists no subtype the registry does not declare', () => {
+    // The other direction: a typo'd or retired class name in the map is a
+    // lookup that can never hit, and nothing else would notice it.
+    for (const [supertype, subtypes] of Object.entries(IFC_SUBTYPES)) {
+      const declared = registryDescendants(supertype);
+      for (const sub of subtypes) {
+        expect(declared, `${supertype} -> ${sub}`).toContain(sub);
+      }
+    }
+  });
+
+  it('expands IfcFurnishingElement to IfcFurniture and IfcSystemFurnitureElement', () => {
+    // The #3229 instance, named so the regression is legible without rerunning
+    // the derivation above.
+    const expanded = expandTypes(['IfcFurnishingElement']);
+    expect(expanded).toContain('IFCFURNITURE');
+    expect(expanded).toContain('IFCSYSTEMFURNITUREELEMENT');
   });
 });
 


### PR DESCRIPTION
Fixes the defect in #3229: `byType('IfcFurnishingElement')` returned nothing on models that plainly contain furniture.

## What was wrong

`expandTypes` widens a requested supertype to its subtypes through `IFC_SUBTYPES` in `packages/parser/src/query-backend-maps.ts`. The table carried the nine `*StandardCase` families and no `IFCFURNISHINGELEMENT`, so a query for that class asked `entityIndex.byType` for exactly one key. IFC4 exporters write furniture as `IFCFURNITURE`.

The table states by hand a relation the generated `SCHEMA_REGISTRY` in the same package already states exactly. Diffing the two over every `inheritanceChain` in the generated IFC4 registry returns one discrepancy, and the same one against IFC4X3:

```
IFCFURNISHINGELEMENT MISSING: IFCFURNITURE,IFCSYSTEMFURNITUREELEMENT
```

No entry was wrong; one was absent.

## Blast radius of the one-line fix

#3199 collapsed the viewer, CLI and MCP copies of this table into `@ifc-lite/parser`, so all three now read the same entry:

- `ifc-lite query --type IfcFurnishingElement` returns rows again.
- `ifc-lite stats` counts the class instead of dropping it from `elementCounts` and `totalElements`.
- the MCP `query_entities` tool, via `backend-query.ts`.
- the viewer's `sdk/adapters/query-adapter.ts`.

## RED, then GREEN

The `IfcFurnishingElement` case, watched failing on `upstream/main` before the table changed:

```
FAIL test/query-backend-maps.test.ts > IFC_SUBTYPES agrees with the generated schema registry > expands IfcFurnishingElement to IfcFurniture and IfcSystemFurnitureElement
AssertionError: expected [ 'IFCFURNISHINGELEMENT' ] to include 'IFCFURNITURE'

Test Files  1 failed | 71 passed (72)
     Tests  1 failed | 691 passed | 2 skipped (694)
```

After the table entry:

```
Test Files  72 passed (72)
     Tests  692 passed | 2 skipped (694)
```

`@ifc-lite/cli` (492), `@ifc-lite/mcp` (318) and `@ifc-lite/sdk` (188) are green on the change.

## What the new tests bound, and what they do not

They derive both directions from `SCHEMA_REGISTRY` rather than restating the table: every subtype the registry declares for a listed supertype must be expanded, and every subtype listed must be one the registry declares — the second direction catches a typo'd or retired class name, which is a lookup that can never hit and which nothing else would notice. An anti-vacuity case asserts the table is non-empty and that the registry reports subtypes for each entry, so an empty table or a registry that stopped emitting inheritance chains fails rather than passing over nothing.

Being explicit about the limit: these make a **listed** supertype's subtype list complete, so this class of drift cannot recur for the ten entries present. A supertype absent from the table altogether — which is exactly what this bug was — is not derivable without a policy for which classes deserve expansion, so the `IfcFurnishingElement` case is also pinned by name.

That raises a question worth deciding separately, and I have deliberately not decided it here: whether `expandTypes` should derive descendants from the registry for *any* requested type, rather than consulting a curated table. It would make the bug structurally impossible, but it also changes what `byType('IfcElement')` or `byType('IfcProduct')` answers with, which is a real behaviour decision and not a bug fix.

## Same-shape grep

Two more hand-listed type sets of the same character, left alone because each is a different mechanism and wants its own diff:

- `packages/cli/src/commands/mutate.ts` `OBJECTTYPE_TYPES` — missing `IFCFURNITURE`, `IFCWALLELEMENTEDCASE` and the non-`IfcWall` `*StandardCase` spellings. Setting `ObjectType` on an `IfcFurniture` prints `Warning: attribute "ObjectType" not applicable ... skipping`, so it is a visible false negative, not corruption.
- `packages/cli/src/commands/validate.ts` `quantifiableTypes` — same shape, drives the quantity-completeness report only.

Both are noted on #3229.

## Changeset

`@ifc-lite/parser` patch. Behaviour change on a published package: a query that returned nothing now returns rows.

Refs #3229

🤖 Generated with [Claude Code](https://claude.com/claude-code)
