### PR TITLE
test(core): LEGACY_KEYS was a hand-copy, so a 27th arm reached neither test

### DIFF
--- a/rust/core/src/schema_helpers_tests.rs
+++ b/rust/core/src/schema_helpers_tests.rs
@@ -317,41 +317,42 @@ fn nth_attribute_reversed_boundary_is_false() {
     assert!(!nth_attribute_is_present(b"garbage)stuff(more", 0));
 }
 
-/// Every key in `legacy_entities.rs`, in one place.
+/// Every key in `legacy_entities.rs`, derived rather than copied.
 ///
-/// Two tests assert OPPOSITE directions about these names and a second copy
-/// of the list would let them drift apart:
+/// Two tests assert OPPOSITE directions about these names, and a hand-written
+/// list would let each of them silently under-cover:
 /// `every_legacy_arm_maps_onto_a_known_product` says each maps to a known base
 /// type; `every_legacy_key_is_unknown_to_the_generated_enum` says none of them
 /// is a name `IfcType::from_str` already knows.
-const LEGACY_KEYS: [&str; 26] = [
-    "IFCPRESENTATIONSTYLEASSIGNMENT",
-    "IFCBEAMSTANDARDCASE",
-    "IFCCOLUMNSTANDARDCASE",
-    "IFCMEMBERSTANDARDCASE",
-    "IFCPLATESTANDARDCASE",
-    "IFCSLABSTANDARDCASE",
-    "IFCDOORSTANDARDCASE",
-    "IFCWINDOWSTANDARDCASE",
-    "IFCOPENINGSTANDARDCASE",
-    "IFCSLABELEMENTEDCASE",
-    "IFCWALLELEMENTEDCASE",
-    "IFCDOORSTYLE",
-    "IFCWINDOWSTYLE",
-    "IFCPROXY",
-    "IFCBUILDINGELEMENT",
-    "IFCBUILDINGELEMENTTYPE",
-    "IFCEQUIPMENTELEMENT",
-    "IFCELECTRICDISTRIBUTIONPOINT",
-    "IFCELECTRICALELEMENT",
-    "IFCCHAMFEREDGEFEATURE",
-    "IFCROUNDEDEDGEFEATURE",
-    "IFCSTRUCTURALLINEARACTIONVARYING",
-    "IFCSTRUCTURALPLANARACTIONVARYING",
-    "IFCSOLIDSTRATUM",
-    "IFCVOIDSTRATUM",
-    "IFCWATERSTRATUM",
-];
+///
+/// This used to be a 26-entry copy of the arm keys, and a copy answers only
+/// for the names someone remembered to add to it. A 27th arm reached neither
+/// test -- measured, not assumed: an arm added with `has_geometry: true` and a
+/// base type that is not an `IfcProduct`, the exact thing
+/// `every_legacy_arm_maps_onto_a_known_product` exists to refuse, passed both
+/// the Rust suite and `scripts/check-legacy-entity-coverage.mjs`.
+///
+/// `LEGACY_ENTITY_NAMES` is the list to borrow because it is already held to
+/// the arms in BOTH directions by that lint, which reads the arm keys out of
+/// `legacy_entities.rs` and fails on a name in either set and not the other.
+/// So an arm that never reaches this loop cannot exist without that gate going
+/// red first, and no new mechanism -- and no `include_str!` of a sibling
+/// module, which AGENTS.md bans -- is needed here.
+const LEGACY_KEYS: &[&str] = crate::legacy_entities::LEGACY_ENTITY_NAMES;
+
+/// The borrowed list must not be empty, or both loops below iterate nothing
+/// and report success over a table they never read. The floor is deliberately
+/// far under the current count: this asks whether the const is populated, not
+/// whether it has a particular size, and a floor that tracks the exact count
+/// would have to be edited by the same hand that adds an arm.
+#[test]
+fn the_legacy_key_list_is_not_empty() {
+    assert!(
+        LEGACY_KEYS.len() >= 20,
+        "LEGACY_KEYS came back with {} names; the two loops that read it would pass vacuously",
+        LEGACY_KEYS.len()
+    );
+}
 
 /// The six IFC2X3 products #3172 added to `legacy_entities.rs`.
 ///
@@ -432,7 +433,7 @@ fn edge_features_are_subtraction_operands_not_openings() {
 /// dropped as having no arm at all, while looking handled in the table.
 #[test]
 fn every_legacy_arm_maps_onto_a_known_product() {
-    for name in LEGACY_KEYS {
+    for &name in LEGACY_KEYS {
         let info = crate::legacy_entities::get_legacy_entity_info(name)
             .unwrap_or_else(|| panic!("{name} has no arm in legacy_entities.rs"));
         assert!(
@@ -536,13 +537,15 @@ fn an_unreadable_record_changes_nothing() {
 /// This asserts the KEY is not: the opposite direction, and the one the
 /// short-circuit depends on.
 ///
-/// This is the BEHAVIOURAL half -- it calls `from_str` for real. The derived
-/// half is in `scripts/check-legacy-entity-coverage.mjs`, which reads both sets
-/// out of the source and so also catches a 27th arm added without touching
-/// `LEGACY_KEYS`, which this test cannot see.
+/// This is the BEHAVIOURAL half -- it calls `from_str` for real, where
+/// `scripts/check-legacy-entity-coverage.mjs` compares the two sets as source
+/// text. Coverage is not this test's own doing either way: `LEGACY_KEYS` is
+/// `LEGACY_ENTITY_NAMES`, which that lint holds equal to the match arms in
+/// both directions, so a 27th arm reaches this loop or the lint goes red.
+/// It did neither while this list was a hand-written copy.
 #[test]
 fn every_legacy_key_is_unknown_to_the_generated_enum() {
-    for key in LEGACY_KEYS {
+    for &key in LEGACY_KEYS {
         assert!(
             matches!(IfcType::from_str(key), IfcType::Unknown(_)),
             "{key} is now known to `IfcType::from_str`, so the `Unknown` \


### PR DESCRIPTION
## The claim

`rust/core/src/schema_helpers_tests.rs` said, above `every_legacy_key_is_unknown_to_the_generated_enum`:

> This is the BEHAVIOURAL half -- it calls `from_str` for real. The derived half is in `scripts/check-legacy-entity-coverage.mjs`, which reads both sets out of the source and so also catches a 27th arm added without touching `LEGACY_KEYS`, which this test cannot see.

That script contains no reference to `LEGACY_KEYS`. `grep -c LEGACY_KEYS scripts/check-legacy-entity-coverage.mjs` → `0`; the relaxed `grep -n LEGACY` on the same file returns 15 hits, and the same strict pattern against the Rust test file returns 4, so the zero is real and not a broken pattern. The script reads the match arms and `LEGACY_ENTITY_NAMES`. The third copy — the 26-entry `LEGACY_KEYS` array in the test file — answered to nothing.

## The gap, measured before changing anything

Added a 27th arm to `legacy_entities.rs` and to `LEGACY_ENTITY_NAMES`, but not to `LEGACY_KEYS`, with `has_geometry: true` and a base type that is not an `IfcProduct` — the exact thing `every_legacy_arm_maps_onto_a_known_product` exists to refuse:

```
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 136 filtered out
check-legacy-entity-coverage: OK (27 legacy arms, 164 concrete legacy products all resolvable, 3 keys exempt by declaration)
```

Both green. The script counted the arm and applied its own checks to it; what neither half applied was the two Rust assertions, because the list they iterate never mentioned the name. Two tests that assert opposite directions about the legacy keys were both silently under-covering, and the comment told a reader that could not happen.

## The fix

`LEGACY_KEYS` now borrows `legacy_entities::LEGACY_ENTITY_NAMES` rather than copying it.

That const is the right one to borrow because `check-legacy-entity-coverage.mjs` already holds it equal to the match arms in **both** directions — a name in the arms and not the const, or in the const and not the arms, fails the gate. So an arm that never reaches these two loops cannot exist without that gate going red first.

The alternative — teaching the lint to also parse `LEGACY_KEYS` out of a Rust test file — was rejected: it adds a third cross-file text dependency and leaves the hand-copy in place, so it makes the comment true without removing the thing that made it necessary. Deriving in-crate via an `include_str!` of the sibling module was also rejected: that is the source-text assertion AGENTS.md bans, and avoiding it is precisely why the arm/const parity check lives in the lint (see `legacy_entity_name_tests`).

A borrowed list can still be emptied, and two loops over nothing report success over a table they never read, so `the_legacy_key_list_is_not_empty` puts a floor under it. The floor is deliberately far below the current count: it asks whether the const is populated, not whether it has a particular size — a floor tracking the exact count would need editing by the same hand that adds an arm.

The doc comment is rewritten either way; it now states where coverage actually comes from.

## RED → GREEN

With the fix in place, the identical mutation fails:

```
thread '...::every_legacy_arm_maps_onto_a_known_product' panicked at rust/core/src/schema_helpers_tests.rs:444:13:
IFCEDGEFEATURE claims geometry but its base type is not an IfcProduct
test result: FAILED. 33 passed; 1 failed
```

Mutation reverted; `diff` against the pre-mutation copy of `legacy_entities.rs` is byte-identical, and `legacy_entities.rs` is untouched by this PR.

## Verification

- `cargo test -p ifc-lite-core --lib schema_helpers` — 34 passed, 0 failed
- `node scripts/check-legacy-entity-coverage.mjs` — OK (26 legacy arms)
- `node scripts/check-legacy-entity-coverage.test.mjs` — 16/16
- `cargo clippy -p ifc-lite-core --all-targets` — clean

Test-only; no published surface changes, so no changeset.

Refs #3200
