### PR TITLE
fix(cli): validate walked past every *StandardCase element in two rules (#3232)

### DIFF
--- a/.changeset/validate-scans-subtypes.md
+++ b/.changeset/validate-scans-subtypes.md
@@ -1,0 +1,15 @@
+---
+"@ifc-lite/cli": patch
+---
+
+`validate` walked past every `*StandardCase` and `*ElementedCase` element in two of its rules.
+
+`store.entityIndex.byType` is keyed by the raw STEP type name, so an `IfcWallStandardCase` sits in its own bucket, not under `IFCWALL`. Both element-scanning rules read that index from a hand-written list of type names, and both lists were short.
+
+`named-elements` listed thirteen base types and not one subtype, so **all ten** of `IfcWallStandardCase`, `IfcWallElementedCase`, `IfcSlabStandardCase`, `IfcSlabElementedCase`, `IfcColumnStandardCase`, `IfcBeamStandardCase`, `IfcDoorStandardCase`, `IfcWindowStandardCase`, `IfcMemberStandardCase` and `IfcPlateStandardCase` were invisible to it. An IFC4 file whose walls are all `IfcWallStandardCase` — which is what several exporters write — reported zero unnamed elements no matter how many had no Name.
+
+`quantity-completeness` did spell six subtypes out by hand, and had drifted four short: `IfcWallElementedCase`, `IfcSlabElementedCase`, `IfcMemberStandardCase` and `IfcPlateStandardCase` were left out of both the numerator and the denominator, so the reported "N/M building elements have no quantity sets" percentage was computed over the wrong population.
+
+Both lists are now `expandTypes(...)` of a base list — the same expansion `byType()` uses on all three backends — so these rules and a `byType('IfcWall')` query cannot disagree about what counts as a wall, and the tables cannot fall behind the schema again. Which *base* types each rule scans is unchanged: that is a policy choice, and the existing asymmetry (`IfcRailing` is checked for a Name but not for quantities) is preserved.
+
+Same shape as #3229, where `IFC_SUBTYPES` itself had drifted; found by the same mechanical diff against the generated schema registry.

--- a/packages/cli/src/commands/validate-subtypes.test.ts
+++ b/packages/cli/src/commands/validate-subtypes.test.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `validate`'s two element-scanning rules — `named-elements` and
+ * `quantity-completeness` — read `store.entityIndex.byType`, which is keyed by
+ * the raw STEP type name. A caller writing `IfcWallElementedCase` therefore
+ * lands in a different bucket from `IfcWall`, and a rule that lists only the
+ * base spelling walks past it.
+ *
+ * Which types the two rules cover at all is a policy choice (neither claims to
+ * cover every IfcProduct). Whether a listed type's own concrete subtypes are
+ * covered is not: `IfcWallStandardCase` is an `IfcWall`, so a rule that says it
+ * looks at walls must see it. The expansion is `expandTypes` from
+ * `@ifc-lite/parser`, the same one all three `byType()` backends use, so these
+ * rules and `byType('IfcWall')` cannot answer "is this a wall" differently.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser, IFC_SUBTYPES, expandTypes, type IfcDataStore } from '@ifc-lite/parser';
+import {
+  computeValidationIssues,
+  NAMED_ELEMENT_BASE_TYPES,
+  QUANTIFIABLE_BASE_TYPES,
+  NAMED_ELEMENT_TYPES,
+  QUANTIFIABLE_TYPES,
+} from './validate.js';
+
+function buildIfc(dataLines: string[]): string {
+  return [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('t.ifc','2026-01-01T00:00:00',(''),(''),'','','');",
+    "FILE_SCHEMA(('IFC4'));",
+    'ENDSEC;',
+    'DATA;',
+    ...dataLines,
+    'ENDSEC;',
+    'END-ISO-10303-21;',
+    '',
+  ].join('\n');
+}
+
+async function parse(content: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(content);
+  const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  return new IfcParser().parseColumnar(buffer);
+}
+
+const SPATIAL = [
+  "#1=IFCPROJECT('0Project_GUID_000001',$,'Project',$,$,$,$,$,$);",
+  "#2=IFCSITE('0Site_GUID_00000001',$,'Site',$,$,$,$,$,$,$,$,$,$,$);",
+  "#3=IFCBUILDING('0Bldg_GUID_00000001',$,'Building',$,$,$,$,$,$,$,$,$);",
+];
+
+/** One entity of `type`, unnamed and carrying no quantity set. */
+function bareElement(id: number, type: string, guid: string): string {
+  return `#${id}=${type}('${guid}',$,$,$,$,$,$,$,$);`;
+}
+
+function issueFor(store: IfcDataStore, rule: string) {
+  return computeValidationIssues(store).find((i) => i.rule === rule);
+}
+
+describe('validate covers the concrete subtypes of the types it lists', () => {
+  // The four spellings `quantity-completeness` used to miss, and the ten that
+  // `named-elements` used to miss, each expressed as the subtype of a base type
+  // both rules already list.
+  const CASES: { base: string; sub: string }[] = [];
+  for (const base of ['IFCWALL', 'IFCSLAB', 'IFCCOLUMN', 'IFCBEAM', 'IFCDOOR', 'IFCWINDOW', 'IFCMEMBER', 'IFCPLATE']) {
+    for (const sub of IFC_SUBTYPES[base] ?? []) CASES.push({ base, sub });
+  }
+
+  it('has a case for every subtype the schema declares under a listed base type', () => {
+    // Guards the loop below against silently testing nothing.
+    expect(CASES.length).toBe(10);
+  });
+
+  for (const { base, sub } of CASES) {
+    it(`counts an unnamed ${sub} under named-elements, as it does ${base}`, async () => {
+      const store = await parse(buildIfc([...SPATIAL, bareElement(10, sub, '0Sub_GUID_000000001')]));
+      const issue = issueFor(store, 'named-elements');
+      expect(issue?.message).toBe('1 building elements have no Name');
+    });
+
+    it(`counts a ${sub} with no quantity set under quantity-completeness, as it does ${base}`, async () => {
+      const store = await parse(buildIfc([...SPATIAL, bareElement(10, sub, '0Sub_GUID_000000001')]));
+      const issue = issueFor(store, 'quantity-completeness');
+      expect(issue?.message).toContain('1/1 building elements');
+    });
+  }
+});
+
+describe('the scanned type lists stay derived, not hand-copied', () => {
+  it.each([
+    ['named-elements', NAMED_ELEMENT_BASE_TYPES, NAMED_ELEMENT_TYPES],
+    ['quantity-completeness', QUANTIFIABLE_BASE_TYPES, QUANTIFIABLE_TYPES],
+  ])('%s expands exactly the subtypes the schema declares', (_rule, bases, scanned) => {
+    // Both directions: every declared subtype of a listed base is scanned, and
+    // nothing is scanned that the base list plus the schema does not imply.
+    expect([...scanned].sort()).toEqual([...new Set(expandTypes([...bases]))].sort());
+  });
+
+  it.each([
+    ['named-elements', NAMED_ELEMENT_BASE_TYPES],
+    ['quantity-completeness', QUANTIFIABLE_BASE_TYPES],
+  ])('%s lists only base types, never a subtype spelling', (_rule, bases) => {
+    // A subtype written into the base list would survive the expansion check
+    // above while re-introducing the hand-maintenance this replaces.
+    const subtypes = new Set(Object.values(IFC_SUBTYPES).flat());
+    expect([...bases].filter((t) => subtypes.has(t))).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -17,7 +17,7 @@
 import { loadIfcFile } from '../loader.js';
 import { hasFlag, fatal, printJson } from '../output.js';
 import { EntityNode } from '@ifc-lite/query';
-import { getInheritanceChainAcrossSchemas, asSourceBytes, type IfcDataStore, type EntityRef, type IfcSourceBytes } from '@ifc-lite/parser';
+import { expandTypes, getInheritanceChainAcrossSchemas, asSourceBytes, type IfcDataStore, type EntityRef, type IfcSourceBytes } from '@ifc-lite/parser';
 
 export interface ValidationIssue {
   severity: 'error' | 'warning' | 'info';
@@ -42,6 +42,41 @@ interface DanglingReference {
   /** The missing expressId being referenced. */
   target: number;
 }
+
+/**
+ * The building-element types the `named-elements` and `quantity-completeness`
+ * rules scan, as base types only.
+ *
+ * Which base types appear here is a **policy** choice and deliberately narrow:
+ * neither rule claims to cover every `IfcProduct`, and widening either list is
+ * a decision about what the report should say, not a bug fix. The two lists are
+ * not identical — `IfcRailing` is scanned for a missing Name but not for a
+ * missing quantity set — and that asymmetry is preserved here unchanged.
+ *
+ * What is *not* a policy choice is whether a listed type's own concrete
+ * subtypes are scanned. `entityIndex.byType` is keyed by the raw STEP type
+ * name, so an `IfcWallStandardCase` sits in its own bucket; a rule that says it
+ * looks at walls and reads only `IFCWALL` walks straight past it. That is why
+ * the scanned lists below are `expandTypes(...)` of these bases rather than
+ * hand-written: the quantity list used to spell six subtypes out by hand and
+ * had drifted four short (`IfcWallElementedCase`, `IfcSlabElementedCase`,
+ * `IfcMemberStandardCase`, `IfcPlateStandardCase`), and the naming list spelled
+ * out none of the ten at all. `expandTypes` is the same expansion every
+ * `byType()` backend uses, so these rules and a `byType('IfcWall')` query
+ * cannot disagree about what counts as a wall.
+ */
+export const NAMED_ELEMENT_BASE_TYPES: readonly string[] = ['IFCWALL', 'IFCSLAB', 'IFCCOLUMN', 'IFCBEAM',
+  'IFCDOOR', 'IFCWINDOW', 'IFCSTAIR', 'IFCROOF', 'IFCSPACE', 'IFCRAILING', 'IFCMEMBER', 'IFCPLATE', 'IFCFOOTING'];
+
+/** @see NAMED_ELEMENT_BASE_TYPES */
+export const QUANTIFIABLE_BASE_TYPES: readonly string[] = ['IFCWALL', 'IFCSLAB', 'IFCCOLUMN', 'IFCBEAM',
+  'IFCDOOR', 'IFCWINDOW', 'IFCSTAIR', 'IFCROOF', 'IFCSPACE', 'IFCMEMBER', 'IFCPLATE', 'IFCFOOTING'];
+
+/** `NAMED_ELEMENT_BASE_TYPES` plus every subtype the schema declares under one. */
+export const NAMED_ELEMENT_TYPES: readonly string[] = expandTypes([...NAMED_ELEMENT_BASE_TYPES]);
+
+/** `QUANTIFIABLE_BASE_TYPES` plus every subtype the schema declares under one. */
+export const QUANTIFIABLE_TYPES: readonly string[] = expandTypes([...QUANTIFIABLE_BASE_TYPES]);
 
 /** Cap on individually-reported dangling references; the remainder is rolled into one summary issue. */
 const DANGLING_REF_ISSUE_CAP = 50;
@@ -248,10 +283,8 @@ export function computeValidationIssues(store: IfcDataStore): ValidationIssue[] 
   }
 
   // 4. Check for unnamed elements
-  const productTypes = ['IFCWALL', 'IFCSLAB', 'IFCCOLUMN', 'IFCBEAM', 'IFCDOOR', 'IFCWINDOW',
-    'IFCSTAIR', 'IFCROOF', 'IFCSPACE', 'IFCRAILING', 'IFCMEMBER', 'IFCPLATE', 'IFCFOOTING'];
   let unnamedCount = 0;
-  for (const pt of productTypes) {
+  for (const pt of NAMED_ELEMENT_TYPES) {
     const ids = store.entityIndex.byType.get(pt) ?? [];
     for (const id of ids) {
       const node = new EntityNode(store, id);
@@ -268,13 +301,9 @@ export function computeValidationIssues(store: IfcDataStore): ValidationIssue[] 
   }
 
   // 6. Quantity completeness — check if product entities have quantity sets
-  const quantifiableTypes = ['IFCWALL', 'IFCSLAB', 'IFCCOLUMN', 'IFCBEAM', 'IFCDOOR', 'IFCWINDOW',
-    'IFCSTAIR', 'IFCROOF', 'IFCSPACE', 'IFCMEMBER', 'IFCPLATE', 'IFCFOOTING',
-    'IFCWALLSTANDARDCASE', 'IFCSLABSTANDARDCASE', 'IFCBEAMSTANDARDCASE',
-    'IFCCOLUMNSTANDARDCASE', 'IFCDOORSTANDARDCASE', 'IFCWINDOWSTANDARDCASE'];
   let withQuantities = 0;
   let withoutQuantities = 0;
-  for (const qt of quantifiableTypes) {
+  for (const qt of QUANTIFIABLE_TYPES) {
     const ids = store.entityIndex.byType.get(qt) ?? [];
     for (const id of ids) {
       const node = new EntityNode(store, id);


### PR DESCRIPTION
Refs #3232. Same shape as #3229, found by the same method: diff the hand-maintained table against the generated `SCHEMA_REGISTRY`, do not eyeball it.

## What was wrong

`store.entityIndex.byType` is keyed by the **raw STEP type name**. An `IfcWallStandardCase` is in its own bucket, not under `IFCWALL`. Both of `validate`'s per-element rules read that index from a hand-written list, and both lists were short.

| rule | listed subtypes | subtypes the schema declares | missed |
|---|---|---|---|
| `named-elements` | 0 | 10 | all ten |
| `quantity-completeness` | 6 | 10 | `IFCWALLELEMENTEDCASE`, `IFCSLABELEMENTEDCASE`, `IFCMEMBERSTANDARDCASE`, `IFCPLATESTANDARDCASE` |

For `named-elements` the effect is a silent zero: an IFC4 file whose walls are all `IfcWallStandardCase` reported no unnamed elements however many had no Name. For `quantity-completeness` the four missing spellings were dropped from **both** numerator and denominator, so the reported "N/M building elements (P%)" was computed over the wrong population.

## Derivation, not inspection

Every base type in both lists, diffed against every `inheritanceChain` in the generated registry (776 entities, IFC4_ADD2_TC1):

```
IfcWall   -> IfcWallElementedCase, IfcWallStandardCase    IfcStair   -> (none)
IfcSlab   -> IfcSlabElementedCase, IfcSlabStandardCase    IfcRoof    -> (none)
IfcColumn -> IfcColumnStandardCase                        IfcSpace   -> (none)
IfcBeam   -> IfcBeamStandardCase                          IfcRailing -> (none)
IfcDoor   -> IfcDoorStandardCase                          IfcFooting -> (none)
IfcWindow -> IfcWindowStandardCase
IfcMember -> IfcMemberStandardCase
IfcPlate  -> IfcPlateStandardCase
```

`IFC_SUBTYPES` already agrees with the registry on all of these, so the fix is to stop re-deriving it: both lists become `expandTypes(...)` of a base list — the same expansion all three `byType()` backends use, from a module `validate.ts` already imports.

## What this deliberately does NOT change

Which **base** types each rule scans. That is a policy choice: neither rule claims to cover every `IfcProduct`, and the two lists are not identical — `IfcRailing` is scanned for a missing Name but not for a missing quantity set. That asymmetry is preserved unchanged and documented at the declaration. Widening either policy is a separate decision about what the report should say.

## RED, verbatim

With the two lists made observable but not yet fixed, `pnpm exec turbo run test --filter=@ifc-lite/cli -- validate-subtypes`:

```
 ✓ has a case for every subtype the schema declares under a listed base type
 × counts an unnamed IFCWALLSTANDARDCASE under named-elements, as it does IFCWALL
 ✓ counts a IFCWALLSTANDARDCASE with no quantity set under quantity-completeness, as it does IFCWALL
 × counts an unnamed IFCWALLELEMENTEDCASE under named-elements, as it does IFCWALL
 × counts a IFCWALLELEMENTEDCASE with no quantity set under quantity-completeness, as it does IFCWALL
 × counts an unnamed IFCSLABSTANDARDCASE under named-elements, as it does IFCSLAB
 ✓ counts a IFCSLABSTANDARDCASE with no quantity set under quantity-completeness, as it does IFCSLAB
 × counts an unnamed IFCSLABELEMENTEDCASE under named-elements, as it does IFCSLAB
 × counts a IFCSLABELEMENTEDCASE with no quantity set under quantity-completeness, as it does IFCSLAB
 × counts an unnamed IFCCOLUMNSTANDARDCASE under named-elements, as it does IFCCOLUMN
 ✓ counts a IFCCOLUMNSTANDARDCASE with no quantity set under quantity-completeness, as it does IFCCOLUMN
 × counts an unnamed IFCBEAMSTANDARDCASE under named-elements, as it does IFCBEAM
 ✓ counts a IFCBEAMSTANDARDCASE with no quantity set under quantity-completeness, as it does IFCBEAM
 × counts an unnamed IFCDOORSTANDARDCASE under named-elements, as it does IFCDOOR
 ✓ counts a IFCDOORSTANDARDCASE with no quantity set under quantity-completeness, as it does IFCDOOR
 × counts an unnamed IFCWINDOWSTANDARDCASE under named-elements, as it does IFCWINDOW
 ✓ counts a IFCWINDOWSTANDARDCASE with no quantity set under quantity-completeness, as it does IFCWINDOW
 × counts an unnamed IFCMEMBERSTANDARDCASE under named-elements, as it does IFCMEMBER
 × counts a IFCMEMBERSTANDARDCASE with no quantity set under quantity-completeness, as it does IFCMEMBER
 × counts an unnamed IFCPLATESTANDARDCASE under named-elements, as it does IFCPLATE
 × counts a IFCPLATESTANDARDCASE with no quantity set under quantity-completeness, as it does IFCPLATE
 × named-elements expands exactly the subtypes the schema declares
 × quantity-completeness expands exactly the subtypes the schema declares
 ✓ named-elements lists only base types, never a subtype spelling
 ✓ quantity-completeness lists only base types, never a subtype spelling

 Tests  16 failed | 9 passed (25)
```

The failures land exactly where the registry diff predicted: all ten under `named-elements`, and precisely the four `*ElementedCase` / `IfcMember` / `IfcPlate` spellings under `quantity-completeness`. Message on the naming misses is `expected undefined to be '1 building elements have no Name'` — the rule produced no issue at all.

## GREEN

`pnpm exec turbo run test --filter=@ifc-lite/cli`:

```
 Test Files  48 passed (48)
      Tests  517 passed | 8 skipped (525)
```

## Why the test stops the recurrence

The expectation is derived from `IFC_SUBTYPES` in **both directions** — every declared subtype of a listed base is scanned, and nothing is scanned that the base list plus the schema does not imply — so adding a base type without expanding it fails, and so does pasting a stale spelling in. Two things guard the derivation itself: a floor asserting the generated case list has ten entries, so the loop cannot pass by testing nothing; and a check that no base list contains a subtype spelling, which would satisfy the expansion equality while quietly restoring the hand maintenance this replaces.

## Sibling checked and left alone

The reported `OBJECTTYPE_TYPES` in `packages/cli/src/commands/mutate.ts` **is already fixed** on `main` by c8e0dfeee (#3163) — and fixed the right way, replaced by `entitiesWithObjectType(schema)` reading the bundled buildingSMART schema. Nothing to do there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
