### PR TITLE
fix(release): tag the commit the version was published from (#3209)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,7 +324,23 @@ jobs:
           #
           # The backfill path added after 2026-08-12 is the one most exposed to
           # this: a backfill by definition runs after `main` has moved on.
-          git tag "v${VERSION}" || true
+          #
+          # THE COMMIT IS NAMED EXPLICITLY (#3209). `git tag <name>` with no
+          # commit-ish tags the current checkout HEAD, and this job checks out
+          # with no `ref:` — so HEAD is the commit that TRIGGERED the run. Every
+          # push to `main` triggers a Release run, so a correct tag was only ever
+          # a coincidence: it held when the trigger happened to be the version
+          # commit. On v6.0.1 it did not, and the tag landed on an unrelated
+          # test-only commit fourteen minutes later, green and unreported.
+          #
+          # The resolver also REFUSES when the tag already exists on a different
+          # commit, which is why `|| true` below is still safe: by the time it
+          # runs, any existing tag has been proven to name this same commit. The
+          # `$( )` assignment carries the script's exit status under the Actions
+          # default shell (`bash --noprofile --norc -eo pipefail`), so a refusal
+          # kills the step before anything is pushed.
+          VERSION_COMMIT=$(node scripts/release-tag-commit.mjs package.json "${VERSION}" "v${VERSION}")
+          git tag "v${VERSION}" "${VERSION_COMMIT}" || true
           git push origin "v${VERSION}"
           # Create release, skipping if it already exists
           if gh release view "v${VERSION}" > /dev/null 2>&1; then
@@ -366,7 +382,17 @@ jobs:
             # default-branch head if the push failed (#3202). Getting this wrong
             # here is worse than above -- server-binaries.yml uploads the
             # per-platform archives to whatever commit this tag names.
-            git tag "$TAG" || true
+            #
+            # Resolved from server-bin's OWN manifest, independently of the root
+            # version: the two are usually different versions and therefore
+            # different commits. `v1.16.7` is the standing proof — it points at
+            # db35b4a6, 35 commits after 44c4201e where server-bin's version was
+            # actually set, and both commits report 1.16.7, so nothing noticed
+            # for nine days (#3209). The resolver refuses rather than reusing a
+            # tag that names a different commit, which turns that damage into a
+            # red job the next time a run touches it.
+            SB_COMMIT=$(node scripts/release-tag-commit.mjs packages/server-bin/package.json "${SB_VERSION}" "$TAG")
+            git tag "$TAG" "${SB_COMMIT}" || true
             git push origin "$TAG"
             gh release create "$TAG" \
               --verify-tag \

--- a/scripts/release-tag-commit.mjs
+++ b/scripts/release-tag-commit.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * "Which commit published version X?" — the commit `.github/workflows/release.yml`
+ * must name when it creates a `v*` tag.
+ *
+ * WHY THIS EXISTS. Both `v*` tags used to be created as `git tag "v${VERSION}"`
+ * with no commit-ish, and `git tag <name>` with no object tags the CURRENT
+ * CHECKOUT HEAD. The release job checks out with no `ref:`, so HEAD is the
+ * commit that TRIGGERED the run — and every push to `main` triggers a Release
+ * run, which publishes whatever is unpublished and then tags at its own trigger
+ * commit. A correct tag was therefore only ever a coincidence: it held when the
+ * triggering commit happened to be the version commit, and not otherwise.
+ *
+ * It stopped holding twice, both verified in the repository (#3209):
+ *
+ *   v6.0.1  tagged a5ba0d80 ("test(mcp): a 627-line tool surface with no test
+ *           file") instead of the version commit 989da893 ("chore: version
+ *           packages"). The version commit's own run was cancelled by the
+ *           `concurrency:` group; a later push-run did the tagging fourteen
+ *           minutes on. Corrected by hand since.
+ *
+ *   v1.16.7 still points at db35b4a6, 35 commits after 44c4201e, which is where
+ *           `packages/server-bin`'s version was actually set. Both commits
+ *           REPORT 1.16.7 — the version did not move in between — which is
+ *           exactly why a wrong tag is invisible unless someone goes looking.
+ *
+ * The damage is not cosmetic. `packages/server-bin/src/binary.ts` builds its
+ * download URL from the `v*` tag, and `server-binaries.yml` uploads the
+ * per-platform archives against whatever commit the tag names. A tag on the
+ * wrong commit means the archives and the npm package resolving to them were
+ * built from different trees.
+ *
+ * WHY NOT `git log -S`. The obvious spelling, `git log -S'"version": "6.0.0"'`,
+ * is wrong in a way reasoning does not catch and a test does: `-S` matches
+ * commits where the string's COUNT changed, so the commit that REMOVED the
+ * 6.0.0 line — the 6.0.1 bump — qualifies exactly as much as the one that
+ * added it. On this repo it returns the NEXT release's commit.
+ *
+ * WHAT WORKS. Walk `git log -- <manifest>` newest-first and take the OLDEST
+ * commit in the newest contiguous run whose manifest reports the target
+ * version: the commit that bumped TO it, rather than the last one that
+ * happened to touch the file afterwards. Checked against real history — the
+ * run reporting 1.16.7 is `db35b4a6 … 9abf93f3, 44c4201e`, whose oldest member
+ * is 44c4201e, and the same walk yields `v6.0.1 -> 989da893`,
+ * `v6.0.0 -> ec358164` and `v5.0.0 -> b314b66c`.
+ *
+ * The walk needs real history, which the release job has: its checkout uses
+ * `fetch-depth: 0`. Under a shallow checkout the walk would end at the graft
+ * boundary, and this exits non-zero rather than answering from a truncated log.
+ *
+ * AS A CLI: `node scripts/release-tag-commit.mjs <manifest> <version> [tag]`
+ * prints the resolved commit SHA on stdout and nothing else. When `tag` is
+ * given and that tag already exists, its target is compared against the
+ * resolved commit and a MISMATCH exits non-zero — the tag is left untouched.
+ * That is deliberate: a tag that is absent is a visible problem, a tag on the
+ * wrong commit is a silent one, and everything downstream treats it as
+ * authoritative. Failing loudly is what turns the `v1.16.7` damage above into
+ * a red job instead of another quiet success.
+ *
+ * The workflow consumes this as `VERSION_COMMIT=$(node scripts/release-tag-commit.mjs …)`.
+ * Under the Actions default shell (`bash --noprofile --norc -eo pipefail`) a
+ * bare assignment from a command substitution takes the substitution's exit
+ * status, so a non-zero exit here kills the step before anything is pushed.
+ * That direction is intended, and is the opposite of the fail-OPEN wanted at
+ * the `version_changed` seam.
+ *
+ * Executable proof: `scripts/release-tag-commit.test.mjs`, which drives real
+ * throwaway git repositories and lifts the tagging lines out of `release.yml`
+ * rather than restating them.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** `git` in `repo`, trimmed stdout; throws on non-zero. */
+function git(repo, args) {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+/**
+ * The `version` field of `manifest` as of `rev`, or `null` when the file did
+ * not exist there or does not parse.
+ *
+ * `null` rather than a throw: an unreadable manifest at some ancestor commit
+ * only means that commit is not the bump, and the walk must keep going. The
+ * target version is never inferred from an absence — `resolveVersionCommit`
+ * fails outright when no commit reports it.
+ */
+export function versionAtRev(repo, rev, manifest) {
+  let text;
+  try {
+    text = execFileSync('git', ['show', `${rev}:${manifest}`], {
+      cwd: repo,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(text);
+    return typeof parsed?.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The commit that set `manifest`'s version to `version`.
+ *
+ * Newest-first over the commits that touched `manifest`; the answer is the
+ * OLDEST commit of the newest contiguous run reporting `version`. A version
+ * that was set, abandoned and set again therefore resolves to the LATEST bump
+ * to it, which is the one whose publish a tag would be recording.
+ *
+ * @throws when no commit in the walked history reports `version`.
+ */
+export function resolveVersionCommit(repo, manifest, version) {
+  const history = git(repo, ['log', '--format=%H', '--', manifest]).split('\n').filter(Boolean);
+  let bump = null;
+  for (const sha of history) {
+    if (versionAtRev(repo, sha, manifest) === version) {
+      // Still inside the run — keep walking back, so this ends on its oldest.
+      bump = sha;
+    } else if (bump !== null) {
+      // One commit past the run: the version differs here, so the commit after
+      // this one is where it was set.
+      break;
+    }
+  }
+  if (bump === null) {
+    throw new Error(
+      `No commit in the history of ${manifest} reports version ${version}. ` +
+        `Either the version was never committed, or this is a shallow checkout ` +
+        `(the release job needs \`fetch-depth: 0\`).`,
+    );
+  }
+  return bump;
+}
+
+/** The commit a tag names (peeled through an annotated tag), or `null`. */
+export function tagTarget(repo, tag) {
+  try {
+    return git(repo, ['rev-parse', '--verify', '--quiet', `refs/tags/${tag}^{commit}`]);
+  } catch {
+    return null;
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+
+if (invokedDirectly) {
+  const [manifest, version, tag] = process.argv.slice(2);
+  if (!manifest || !version) {
+    console.error('usage: node scripts/release-tag-commit.mjs <manifest> <version> [tag]');
+    process.exit(2);
+  }
+  const repo = process.cwd();
+  let commit;
+  try {
+    commit = resolveVersionCommit(repo, manifest, version);
+  } catch (err) {
+    console.error(`\n${err.message}\n`);
+    process.exit(1);
+  }
+
+  if (tag) {
+    const existing = tagTarget(repo, tag);
+    if (existing !== null && existing !== commit) {
+      console.error(
+        `\nTag ${tag} already exists and names the WRONG commit.\n\n` +
+          `  tag ${tag} -> ${existing}\n` +
+          `  ${manifest} was set to ${version} at ${commit}\n\n` +
+          `Refusing to reuse it. Downstream treats this tag as authoritative: ` +
+          `packages/server-bin/src/binary.ts builds its download URL from it and ` +
+          `server-binaries.yml uploads the per-platform archives against whatever ` +
+          `commit it names, so the archives and the package resolving to them would ` +
+          `come from different trees (#3209).\n\n` +
+          `Fix the ref deliberately, then re-run:\n\n` +
+          `  git tag -f ${tag} ${commit} && git push --force origin refs/tags/${tag}\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  process.stdout.write(`${commit}\n`);
+}

--- a/scripts/release-tag-commit.test.mjs
+++ b/scripts/release-tag-commit.test.mjs
@@ -1,0 +1,275 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Executable proof for `scripts/release-tag-commit.mjs` and for the two
+ * `git tag` call sites in `.github/workflows/release.yml` that consume it.
+ *
+ * Every case drives a REAL throwaway git repository. The defect (#3209) is
+ * "`git tag` with no object tags the checkout HEAD", so a test that stubbed
+ * git away would prove nothing about the thing that broke: on v6.0.1 the tag
+ * landed on `a5ba0d80` ("test(mcp): a 627-line tool surface with no test
+ * file") because that was the HEAD of the run that happened to reach the
+ * tagging step, fourteen minutes after the version commit `989da893`.
+ *
+ * The workflow-seam cases below LIFT the tagging lines out of `release.yml`
+ * rather than restating them, so editing the workflow back to the objectless
+ * spelling reddens this file.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, copyFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { resolveVersionCommit, tagTarget } from './release-tag-commit.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scriptPath = join(here, 'release-tag-commit.mjs');
+const releaseWorkflow = join(here, '..', '.github', 'workflows', 'release.yml');
+
+function git(repo, args) {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+function newRepo(t) {
+  const repo = mkdtempSync(join(tmpdir(), 'ifclite-tag-commit-'));
+  t.after(() => rmSync(repo, { recursive: true, force: true }));
+  git(repo, ['init', '-q', '-b', 'main']);
+  git(repo, ['config', 'user.email', 'test@example.com']);
+  git(repo, ['config', 'user.name', 'test']);
+  return repo;
+}
+
+/**
+ * Commit a manifest at `version`, optionally with extra fields so a commit can
+ * touch the file without moving the version — the `1.16.7` shape, where 35
+ * commits sit between where the tag points and where the version was set.
+ */
+function commitVersion(repo, rel, version, message, extra = {}) {
+  const abs = join(repo, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, `${JSON.stringify({ name: 'pkg', version, ...extra }, null, 2)}\n`);
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-qm', message]);
+  return git(repo, ['rev-parse', 'HEAD']);
+}
+
+function commitUnrelated(repo, message) {
+  writeFileSync(join(repo, `${message.replace(/\W/g, '_')}.txt`), `${message}\n`);
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-qm', message]);
+  return git(repo, ['rev-parse', 'HEAD']);
+}
+
+test('resolves the commit that BUMPED TO the version, not the newest commit reporting it', (t) => {
+  // The live `v1.16.7` damage, in miniature: the version is SET once, then the
+  // manifest is touched again without the version moving. The tag belongs on
+  // the bump, not on the last commit that happened to touch the file, and
+  // certainly not on HEAD.
+  const repo = newRepo(t);
+  commitVersion(repo, 'package.json', '1.16.6', 'earlier');
+  const bump = commitVersion(repo, 'package.json', '1.16.7', 'chore: version packages');
+  commitVersion(repo, 'package.json', '1.16.7', 'fix(release): publish clash before geometry', { sideEffects: false });
+  commitUnrelated(repo, 'unrelated head');
+
+  assert.equal(resolveVersionCommit(repo, 'package.json', '1.16.7'), bump);
+  assert.notEqual(resolveVersionCommit(repo, 'package.json', '1.16.7'), git(repo, ['rev-parse', 'HEAD']));
+});
+
+test('the `git log -S` trap: the string-count spelling names the NEXT bump, this one does not', (t) => {
+  // Named in #3209: `git log -S'"version": "6.0.0"'` returns the 6.0.1 bump,
+  // because `-S` matches where the string COUNT changed — the commit that
+  // REMOVED the 6.0.0 line qualifies exactly as much as the one that added it.
+  // This case exists to keep that implementation from creeping back.
+  const repo = newRepo(t);
+  const v600 = commitVersion(repo, 'package.json', '6.0.0', 'chore: version packages (6.0.0)');
+  const v601 = commitVersion(repo, 'package.json', '6.0.1', 'chore: version packages (6.0.1)');
+
+  const dashS = git(repo, ['log', '--format=%H', '-S', '"version": "6.0.0"', '--', 'package.json'])
+    .split('\n')
+    .filter(Boolean);
+  assert.ok(dashS.includes(v601), 'precondition: -S really does name the 6.0.1 bump for the 6.0.0 string');
+
+  assert.equal(resolveVersionCommit(repo, 'package.json', '6.0.0'), v600);
+  assert.equal(resolveVersionCommit(repo, 'package.json', '6.0.1'), v601);
+});
+
+test('a version set, abandoned, then set again resolves to the LATEST bump to it', (t) => {
+  const repo = newRepo(t);
+  commitVersion(repo, 'package.json', '2.0.0', 'first 2.0.0');
+  commitVersion(repo, 'package.json', '1.9.0', 'reverted');
+  const again = commitVersion(repo, 'package.json', '2.0.0', 'second 2.0.0');
+  commitUnrelated(repo, 'later');
+  assert.equal(resolveVersionCommit(repo, 'package.json', '2.0.0'), again);
+});
+
+test('a version that no commit ever carried is a hard failure, not a guess', (t) => {
+  const repo = newRepo(t);
+  commitVersion(repo, 'package.json', '1.0.0', 'only version');
+  assert.throws(() => resolveVersionCommit(repo, 'package.json', '9.9.9'), /9\.9\.9/);
+});
+
+test('server-bin resolves independently of the root manifest', (t) => {
+  // The two versions are usually different and therefore different commits;
+  // `release.yml` resolves each from its own manifest.
+  const repo = newRepo(t);
+  commitVersion(repo, 'package.json', '6.0.0', 'root 6.0.0');
+  const sb = commitVersion(repo, 'packages/server-bin/package.json', '1.16.7', 'server-bin 1.16.7');
+  const root = commitVersion(repo, 'package.json', '6.0.1', 'root 6.0.1');
+  assert.equal(resolveVersionCommit(repo, 'packages/server-bin/package.json', '1.16.7'), sb);
+  assert.equal(resolveVersionCommit(repo, 'package.json', '6.0.1'), root);
+});
+
+test('tagTarget reads the commit a tag names, and null when there is no such tag', (t) => {
+  const repo = newRepo(t);
+  const c = commitVersion(repo, 'package.json', '1.0.0', 'v1');
+  commitUnrelated(repo, 'head');
+  git(repo, ['tag', 'v1.0.0', c]);
+  assert.equal(tagTarget(repo, 'v1.0.0'), c);
+  assert.equal(tagTarget(repo, 'v9.9.9'), null);
+});
+
+/** Run the CLI in `repo`; returns `{ status, stdout, stderr }`. */
+function runCli(repo, args) {
+  try {
+    const stdout = execFileSync(process.execPath, [scriptPath, ...args], {
+      cwd: repo,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return { status: err.status ?? 1, stdout: err.stdout ?? '', stderr: err.stderr ?? '' };
+  }
+}
+
+test('the CLI prints the resolved commit and nothing else', (t) => {
+  const repo = newRepo(t);
+  const bump = commitVersion(repo, 'package.json', '1.0.0', 'bump');
+  commitUnrelated(repo, 'head');
+  const { status, stdout } = runCli(repo, ['package.json', '1.0.0', 'v1.0.0']);
+  assert.equal(status, 0);
+  assert.equal(stdout.trim(), bump);
+});
+
+test('an EXISTING tag on a different commit fails the run rather than being quietly reused', (t) => {
+  // The second half of the maintainer's ask on #3209: the live `v1.16.7`
+  // damage must surface as a red job the next time a run touches it, not be
+  // silently corrected. A tag that is absent is a visible problem; a tag on
+  // the wrong commit is a silent one, and everything downstream treats it as
+  // authoritative.
+  const repo = newRepo(t);
+  const bump = commitVersion(repo, 'package.json', '1.16.7', 'bump');
+  const wrong = commitUnrelated(repo, 'unrelated');
+  git(repo, ['tag', 'v1.16.7', wrong]);
+  const { status, stderr } = runCli(repo, ['package.json', '1.16.7', 'v1.16.7']);
+  assert.notEqual(status, 0, 'a tag on the wrong commit must fail the step');
+  assert.match(stderr, new RegExp(wrong));
+  assert.match(stderr, new RegExp(bump));
+});
+
+test('an existing tag ALREADY on the right commit is idempotent, not an error', (t) => {
+  const repo = newRepo(t);
+  const bump = commitVersion(repo, 'package.json', '1.16.7', 'bump');
+  commitUnrelated(repo, 'later');
+  git(repo, ['tag', 'v1.16.7', bump]);
+  const { status, stdout } = runCli(repo, ['package.json', '1.16.7', 'v1.16.7']);
+  assert.equal(status, 0);
+  assert.equal(stdout.trim(), bump);
+});
+
+/**
+ * The YAML seam.
+ *
+ * These lift the resolve-then-tag pair out of `release.yml` and run it
+ * verbatim under the Actions default shell (`bash --noprofile --norc -eo
+ * pipefail`) against a throwaway repository whose HEAD is deliberately NOT the
+ * version commit — the production shape of #3209.
+ */
+function taggingFragment(varName) {
+  const lines = readFileSync(releaseWorkflow, 'utf8').split('\n');
+  const start = lines.findIndex((l) =>
+    new RegExp(`^\\s*${varName}=\\$\\(node scripts/release-tag-commit\\.mjs`).test(l),
+  );
+  assert.notEqual(start, -1, `release.yml must resolve ${varName} from scripts/release-tag-commit.mjs`);
+  const end = lines.findIndex((l, i) => i >= start && /^\s*git tag\s/.test(l));
+  assert.notEqual(end, -1, `release.yml must tag right after resolving ${varName}`);
+  const indent = lines[start].match(/^\s*/)[0];
+  return lines
+    .slice(start, end + 1)
+    .map((l) => (l.startsWith(indent) ? l.slice(indent.length) : l))
+    .join('\n');
+}
+
+for (const [label, varName, manifest, versionVar] of [
+  ['root', 'VERSION_COMMIT', 'package.json', 'VERSION'],
+  ['server-bin', 'SB_COMMIT', 'packages/server-bin/package.json', 'SB_VERSION'],
+]) {
+  /** A repo carrying the script, a 6.0.1 bump, and a LATER unrelated HEAD. */
+  function seamRepo(t) {
+    const repo = newRepo(t);
+    mkdirSync(join(repo, 'scripts'), { recursive: true });
+    copyFileSync(scriptPath, join(repo, 'scripts', 'release-tag-commit.mjs'));
+    git(repo, ['add', '-A']);
+    git(repo, ['commit', '-qm', 'scripts']);
+    const bump = commitVersion(repo, manifest, '6.0.1', 'chore: version packages');
+    const head = commitUnrelated(repo, 'test(mcp): a 627-line tool surface with no test file');
+    assert.notEqual(bump, head, 'precondition: HEAD is a later, unrelated commit');
+    writeFileSync(join(repo, 'step.sh'), `${taggingFragment(varName)}\n`);
+    return { repo, bump, head };
+  }
+
+  const runStep = (repo) =>
+    execFileSync('bash', ['--noprofile', '--norc', '-eo', 'pipefail', join(repo, 'step.sh')], {
+      cwd: repo,
+      env: { ...process.env, [versionVar]: '6.0.1', TAG: 'v6.0.1' },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+  test(`release.yml's ${label} tag lands on the version commit, not on the checkout HEAD`, (t) => {
+    const { repo, bump } = seamRepo(t);
+    runStep(repo);
+    assert.equal(
+      git(repo, ['rev-list', '-n', '1', 'v6.0.1']),
+      bump,
+      `the ${label} tag must name the commit the version was published from`,
+    );
+  });
+
+  test(`release.yml's ${label} step fails loudly when the tag already names a different commit`, (t) => {
+    const { repo, head } = seamRepo(t);
+    git(repo, ['tag', 'v6.0.1', head]);
+    // `-e` must kill the STEP here: the `$( )` substitution's non-zero status
+    // is the step's status, and `|| true` on the `git tag` line must not
+    // rescue it. A wrong tag surviving into `git push` is the defect itself.
+    assert.throws(() => runStep(repo));
+    assert.equal(git(repo, ['rev-list', '-n', '1', 'v6.0.1']), head, 'the wrong tag is left alone, not rewritten');
+  });
+}
+
+test('neither `git tag` in release.yml is objectless', () => {
+  // The ratchet for #3209 itself. `git tag <name>` with no commit-ish tags the
+  // current checkout HEAD, which is the TRIGGERING commit of the run — not the
+  // commit the version was published from.
+  const lines = readFileSync(releaseWorkflow, 'utf8').split('\n');
+  const objectless = lines
+    .map((l, i) => [i + 1, l.trim()])
+    .filter(([, l]) => /^git tag\s/.test(l))
+    .filter(([, l]) => {
+      // `git tag <name> <commit-ish>` — two operands after the subcommand,
+      // ignoring a trailing `|| true` and any comment.
+      const operands = l
+        .replace(/\s*(\|\||#).*$/, '')
+        .trim()
+        .split(/\s+/)
+        .slice(2);
+      return operands.length < 2;
+    });
+  assert.deepEqual(objectless, [], 'every `git tag` in release.yml must name the commit explicitly');
+});

--- a/scripts/release-tag-commit.test.mjs
+++ b/scripts/release-tag-commit.test.mjs
@@ -211,7 +211,7 @@ for (const [label, varName, manifest, versionVar] of [
   ['server-bin', 'SB_COMMIT', 'packages/server-bin/package.json', 'SB_VERSION'],
 ]) {
   /** A repo carrying the script, a 6.0.1 bump, and a LATER unrelated HEAD. */
-  function seamRepo(t) {
+  const seamRepo = (t) => {
     const repo = newRepo(t);
     mkdirSync(join(repo, 'scripts'), { recursive: true });
     copyFileSync(scriptPath, join(repo, 'scripts', 'release-tag-commit.mjs'));
@@ -222,7 +222,7 @@ for (const [label, varName, manifest, versionVar] of [
     assert.notEqual(bump, head, 'precondition: HEAD is a later, unrelated commit');
     writeFileSync(join(repo, 'step.sh'), `${taggingFragment(varName)}\n`);
     return { repo, bump, head };
-  }
+  };
 
   const runStep = (repo) =>
     execFileSync('bash', ['--noprofile', '--norc', '-eo', 'pipefail', join(repo, 'step.sh')], {


### PR DESCRIPTION
`git tag <name>` with no commit-ish tags the **current checkout HEAD**, and the release job checks out with no `ref:` — so HEAD is the commit that **triggered** the run. Every push to `main` triggers a Release run, so a correct `v*` tag was only ever a coincidence: it held when the trigger happened to be the version commit, and not otherwise.

Both call sites now name the commit explicitly.

## What I confirmed from the code, versus took from the issue

Confirmed by reading `.github/workflows/release.yml` on `main`:

- `concurrency: ${{ github.workflow }}-${{ github.ref }}` with **no** `cancel-in-progress` — which is how the v6.0.1 version commit's own run came to be cancelled while a later push-run did the tagging.
- The release job's checkout passes `fetch-depth: 0` and **no** `ref:`. The full history is what makes the resolution below possible; the missing `ref:` is what makes the defect.
- Neither `git tag` passed an object.
- `steps.pre` reads the root version from `package.json` and the server-bin version from `packages/server-bin/package.json`. Those are the two manifests the resolver is pointed at, so the tag is keyed to the same file the gate read the version from.

Confirmed by **running** the resolver against this repository's real history — not taken on trust:

```
package.json                     6.0.1  -> 989da893
package.json                     6.0.0  -> ec358164
package.json                     5.0.0  -> b314b66c
packages/server-bin/package.json 1.16.7 -> 44c4201e
```

All four match the values verified independently in the issue thread, including `v1.16.7 -> 44c4201e` against the tag that still points at `db35b4a6` today.

Taken from the issue rather than re-derived: that `v6.0.1` was tagged at `a5ba0d80` by run 32868779546 (I did not re-read the run logs), and that the `v6.0.1` ref has since been corrected by hand.

## The resolution, and the trap

Walk `git log -- <manifest>` newest-first and take the **oldest** commit of the newest contiguous run reporting the target version — the commit that bumped *to* it, not the last one that happened to touch the file afterwards.

Explicitly **not** `git log -S'"version": "6.0.0"'`, which matches where the string's *count* changed, so the commit that **removed** the 6.0.0 line — the 6.0.1 bump — qualifies exactly as much as the one that added it. That trap has a test of its own, with a precondition assertion proving `-S` really does name the wrong commit in the fixture.

## Refusing rather than guessing

When the tag already exists on a **different** commit, the resolver exits non-zero and leaves the ref alone. This is the half that would have made v6.0.1 a red job instead of a silent success, and it will surface the standing `v1.16.7` damage the next time a run touches it. An absent tag is a visible problem; a tag on the wrong commit is a silent one, and everything downstream treats it as authoritative.

`|| true` on `git tag` stays, and stays safe: by the time it runs, any existing tag has been proven to name the same commit. Under the Actions default shell (`bash --noprofile --norc -eo pipefail`) the bare `VERSION_COMMIT=$(node …)` assignment takes the substitution's exit status, so a refusal kills the step **before** the push. That direction is deliberate and is the *opposite* of the fail-open wanted at the `version_changed` seam in #3188.

## Tests

`scripts/release-tag-commit.test.mjs`, 14 cases, every one driving a **real throwaway git repository** — the defect is about what `git tag` does with no object, so stubbing git away would prove nothing.

Four of them **lift the resolve-then-tag lines out of `release.yml`** rather than restating them, dedent them, and run them verbatim under the Actions default shell against a repo whose HEAD is deliberately a later unrelated commit. The YAML and the test cannot drift. A fifteenth-in-spirit case asserts no `git tag` anywhere in `release.yml` is objectless.

RED before the workflow edit, with the script already in place:

```
ok 1 - resolves the commit that BUMPED TO the version, not the newest commit reporting it
ok 2 - the `git log -S` trap: the string-count spelling names the NEXT bump, this one does not
...
not ok 10 - release.yml's root tag lands on the version commit, not on the checkout HEAD
not ok 11 - release.yml's root step fails loudly when the tag already names a different commit
not ok 12 - release.yml's server-bin tag lands on the version commit, not on the checkout HEAD
not ok 13 - release.yml's server-bin step fails loudly when the tag already names a different commit
not ok 14 - neither `git tag` in release.yml is objectless
    every `git tag` in release.yml must name the commit explicitly
    + actual - expected
    +   [ 'git tag "v${VERSION}" || true'
    +   [ 'git tag "$TAG" || true'
    - []
# tests 14
# pass 9
# fail 5
```

GREEN after: `# tests 14 / # pass 14 / # fail 0`.

## Other gates

- `node scripts/check-swallowed-push.mjs` — OK (15 workflow files, 0 marked). The pushes stay unguarded.
- `node scripts/check-test-wiring.mjs` — OK. `scripts/release-tag-commit.test.mjs` is covered by the existing `node --test scripts/*.test.mjs` catch-all in `test.yml`; the script itself is reached from `release.yml` directly.
- `actionlint .github/workflows/release.yml` — **10 findings before, 10 after** (all pre-existing `SC2086` info-level, none on the changed lines). No movement.

## No changeset

CI-only: `.github/workflows/release.yml` plus two files under `scripts/`. No published package's behaviour changes.

## Interaction with #3188

None in the code — that PR touches `steps.pre` and adds a `version_changed` output; this touches the two tagging steps. The only shared thing is the shell seam, and the two want opposite directions there (#3188 fails **open** so verification is never skipped; this fails **closed** so a wrong tag is never pushed). Both are stated in the respective comments so a later reader does not "unify" them.

## Not fixed here

The standing `v1.16.7` ref is left pointing at `db35b4a6`. Rewriting a published tag is a maintainer decision, and the refusal above makes it loud on the next run that touches it rather than quietly corrected — which is what the issue thread asked for. The correction command is printed in the failure message.

Refs #3209
