### PR TITLE
fix(processing): quick metadata severed marine facilities from the spatial tree (#3245)

### DIFF
--- a/.changeset/quick-spatial-marine-facility.md
+++ b/.changeset/quick-spatial-marine-facility.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/geometry": patch
+---
+
+Quick metadata: stop severing marine facilities and common facility parts from the spatial tree.
+
+`is_quick_spatial_type_ci` in `ifc-lite-processing` decides which scanned entities become nodes of the quick-metadata spatial tree (`MetadataBootstrap.spatialTree`). It was a hand-written list of 14 keywords, and it had drifted from the schema it implements: `IFCMARINEFACILITY`, `IFCMARINEPART` and `IFCFACILITYPARTCOMMON` were absent, while their siblings `IFCBRIDGE`/`IFCBRIDGEPART`, `IFCROAD`/`IFCROADPART` and `IFCRAILWAY`/`IFCRAILWAYPART` were all present.
+
+The cost is not one missing node. Tree assembly skips an `IfcRelAggregates` edge whose parent OR child is not a known spatial node, so an unrecognised facility severs the edge above it and every edge below it: a port, quay or lock model rooted at `IfcMarineFacility` lost its whole subtree — storeys, spaces and the elements contained in them — from the bootstrap hierarchy, and any element contained directly in the facility was dropped rather than reparented.
+
+The predicate now covers exactly the rule it always meant: `IfcProject`, plus the `IfcSpatialElement` branch minus the external-spatial (air volume) sub-branch, which stays excluded. A new test derives that set from the generated `IFC_TYPES` and compares it against the predicate in both directions, with an anti-vacuity floor and a control fixture, so a future schema addition cannot slip past the list again. The predicate is also now a length-keyed dispatch: at most three case-insensitive comparisons per scanned entity instead of up to fourteen.

--- a/rust/processing/src/processor/quick_metadata.rs
+++ b/rust/processing/src/processor/quick_metadata.rs
@@ -16,23 +16,46 @@ pub(super) struct QuickSpatialNodeEntry {
     pub(super) parent: Option<u32>,
 }
 
-/// Case-insensitive spatial-type check that avoids to_ascii_uppercase() allocation.
+/// Is this STEP keyword a node of the quick-metadata spatial tree?
+///
+/// The rule, against the generated schema: `IfcProject`, plus the whole
+/// `IfcSpatialElement` branch EXCEPT the external-spatial sub-branch (air
+/// volumes, which are not part of the containment hierarchy). A name this
+/// predicate misses is not just skipped — every `IfcRelAggregates` edge into or
+/// out of it is dropped too, so its entire subtree is severed from the tree.
+/// `quick_spatial_predicate_matches_the_generated_spatial_branch` holds the
+/// list to that rule in both directions, so it cannot drift silently again.
+///
+/// Written as a length-keyed dispatch: case-insensitive without allocating an
+/// uppercase copy, and at most three comparisons per scanned entity.
 #[inline]
 pub(super) fn is_quick_spatial_type_ci(type_name: &str) -> bool {
-    type_name.eq_ignore_ascii_case("IFCPROJECT")
-        || type_name.eq_ignore_ascii_case("IFCSITE")
-        || type_name.eq_ignore_ascii_case("IFCBUILDING")
-        || type_name.eq_ignore_ascii_case("IFCBUILDINGSTOREY")
-        || type_name.eq_ignore_ascii_case("IFCSPACE")
-        || type_name.eq_ignore_ascii_case("IFCSPATIALZONE")
-        || type_name.eq_ignore_ascii_case("IFCFACILITY")
-        || type_name.eq_ignore_ascii_case("IFCFACILITYPART")
-        || type_name.eq_ignore_ascii_case("IFCBRIDGE")
-        || type_name.eq_ignore_ascii_case("IFCBRIDGEPART")
-        || type_name.eq_ignore_ascii_case("IFCROAD")
-        || type_name.eq_ignore_ascii_case("IFCROADPART")
-        || type_name.eq_ignore_ascii_case("IFCRAILWAY")
-        || type_name.eq_ignore_ascii_case("IFCRAILWAYPART")
+    #[inline]
+    fn eq(a: &str, b: &str) -> bool {
+        a.eq_ignore_ascii_case(b)
+    }
+    match type_name.len() {
+        7 => eq(type_name, "IFCSITE") || eq(type_name, "IFCROAD"),
+        8 => eq(type_name, "IFCSPACE"),
+        9 => eq(type_name, "IFCBRIDGE"),
+        10 => eq(type_name, "IFCPROJECT") || eq(type_name, "IFCRAILWAY"),
+        11 => {
+            eq(type_name, "IFCBUILDING")
+                || eq(type_name, "IFCFACILITY")
+                || eq(type_name, "IFCROADPART")
+        }
+        13 => eq(type_name, "IFCBRIDGEPART") || eq(type_name, "IFCMARINEPART"),
+        14 => eq(type_name, "IFCSPATIALZONE") || eq(type_name, "IFCRAILWAYPART"),
+        15 => eq(type_name, "IFCFACILITYPART"),
+        17 => {
+            eq(type_name, "IFCBUILDINGSTOREY")
+                || eq(type_name, "IFCMARINEFACILITY")
+                || eq(type_name, "IFCSPATIALELEMENT")
+        }
+        21 => eq(type_name, "IFCFACILITYPARTCOMMON"),
+        26 => eq(type_name, "IFCSPATIALSTRUCTUREELEMENT"),
+        _ => false,
+    }
 }
 
 pub(super) fn parse_step_arguments(entity_bytes: &[u8]) -> Vec<&[u8]> {
@@ -260,5 +283,83 @@ mod tests {
             Some(7.25),
             "index 9 (the real Elevation attribute) must win over index 8"
         );
+    }
+
+    /// DRIFT GUARD. `is_quick_spatial_type_ci` decides which entities become
+    /// nodes of the quick-metadata spatial tree. It is a hand-written fast path,
+    /// so it can only be trusted while it agrees, name for name, with the rule it
+    /// implements against the GENERATED schema: `IfcProject`, plus everything in
+    /// the `IfcSpatialElement` branch except the external-spatial (air volume)
+    /// sub-branch, which is not part of the containment hierarchy.
+    ///
+    /// Checked in BOTH directions over every generated `IfcType`: a name the rule
+    /// admits and the predicate rejects severs that subtree from the tree; a name
+    /// the predicate admits and the rule rejects invents a spatial node.
+    #[test]
+    fn quick_spatial_predicate_matches_the_generated_spatial_branch() {
+        use ifc_lite_core::{IfcType, IFC_TYPES};
+
+        fn rule(ty: IfcType) -> bool {
+            ty == IfcType::IfcProject
+                || (ty.is_subtype_of(IfcType::IfcSpatialElement)
+                    && !ty.is_subtype_of(IfcType::IfcExternalSpatialStructureElement))
+        }
+
+        let mut expected_true = 0usize;
+        let mut missing = Vec::new();
+        let mut extra = Vec::new();
+        for ty in IFC_TYPES {
+            let name = ty.as_str();
+            let want = rule(*ty);
+            if want {
+                expected_true += 1;
+            }
+            let got = is_quick_spatial_type_ci(name);
+            if want && !got {
+                missing.push(name);
+            }
+            if !want && got {
+                extra.push(name);
+            }
+        }
+
+        // Anti-vacuity: the enumeration really ran over the whole schema, and the
+        // rule really selects a non-trivial slice of it. A `IFC_TYPES` that came
+        // back empty, or a rule that matched nothing, would otherwise pass.
+        assert!(
+            IFC_TYPES.len() > 800,
+            "generated IFC_TYPES looks truncated: {} entries",
+            IFC_TYPES.len()
+        );
+        assert!(
+            expected_true >= 17,
+            "the spatial branch should cover at least 17 types, got {expected_true}"
+        );
+
+        assert!(
+            missing.is_empty() && extra.is_empty(),
+            "quick-metadata spatial predicate has drifted from the generated schema\n  \
+             missing (severed from the spatial tree): {missing:?}\n  \
+             extra (invented spatial nodes): {extra:?}"
+        );
+    }
+
+    /// Control fixture for the drift guard above. A regression that made the
+    /// predicate answer `true` for everything, or that dropped its
+    /// case-insensitivity, would still satisfy a one-directional check.
+    #[test]
+    fn quick_spatial_predicate_controls() {
+        // Non-spatial products and relationships are NOT tree nodes.
+        for name in ["IFCWALL", "IFCRELAGGREGATES", "IFCPROJECTLIBRARY", "IFCZONE"] {
+            assert!(!is_quick_spatial_type_ci(name), "{name} must not be a spatial node");
+        }
+        // External spatial elements are air volumes, deliberately excluded.
+        for name in ["IFCEXTERNALSPATIALELEMENT", "IFCEXTERNALSPATIALSTRUCTUREELEMENT"] {
+            assert!(!is_quick_spatial_type_ci(name), "{name} must not be a spatial node");
+        }
+        // Both spellings a STEP file may use resolve identically.
+        for name in ["IfcMarineFacility", "IFCMARINEFACILITY", "ifcmarinefacility"] {
+            assert!(is_quick_spatial_type_ci(name), "{name} must be a spatial node");
+        }
     }
 }


### PR DESCRIPTION
Refs #3245

## The defect

`is_quick_spatial_type_ci` (`rust/processing/src/processor/quick_metadata.rs`) gates which scanned entities become nodes of the quick-metadata spatial tree. It was a hand-written list of 14 STEP keywords, and it had drifted from the generated schema:

- `IFCMARINEFACILITY`
- `IFCMARINEPART`
- `IFCFACILITYPARTCOMMON`

Every sibling of theirs was already listed — `IFCBRIDGE`/`IFCBRIDGEPART`, `IFCROAD`/`IFCROADPART`, `IFCRAILWAY`/`IFCRAILWAYPART` — so this is drift, not a curated narrowing. The TS twin `packages/data/src/spatial-types.ts` lists `IfcMarineFacility`; the Rust path did not.

## Why it costs a whole subtree, not one node

Tree assembly in `rust/processing/src/processor/mod.rs` skips an `IfcRelAggregates` edge whose parent **or** child is unknown:

```rust
for (parent_id, child_ids) in quick_aggregate_links {
    if !spatial_nodes.contains_key(&parent_id) {
        continue;
    }
    for child_id in child_ids {
        if !spatial_nodes.contains_key(&child_id) {
            continue;
        }
```

An unrecognised `IfcMarineFacility` therefore severs the edge above it (`IfcProject` -> facility) **and** every edge below it (facility -> storey). A port, quay or lock model loses its whole subtree — storeys, spaces, and their contained elements — from `MetadataBootstrap.spatialTree`. An element contained directly in the facility via `IfcRelContainedInSpatialStructure` is dropped outright rather than reparented.

## RED, verbatim, on `upstream/main`

```
running 2 tests
test processor::quick_metadata::tests::quick_spatial_predicate_matches_the_generated_spatial_branch ... FAILED
test processor::quick_metadata::tests::quick_spatial_predicate_controls ... FAILED

quick-metadata spatial predicate has drifted from the generated schema
  missing (severed from the spatial tree): ["IFCFACILITYPARTCOMMON", "IFCMARINEFACILITY", "IFCMARINEPART", "IFCSPATIALELEMENT", "IFCSPATIALSTRUCTUREELEMENT"]
  extra (invented spatial nodes): []

IfcMarineFacility must be a spatial node
```

## GREEN

```
running 5 tests
test processor::quick_metadata::tests::quick_spatial_predicate_controls ... ok
test processor::quick_metadata::tests::parse_step_string_un_doubles_exactly_once ... ok
test processor::quick_metadata::tests::quick_spatial_predicate_matches_the_generated_spatial_branch ... ok
test processor::quick_metadata::tests::cyclic_aggregate_graph_does_not_stack_overflow ... ok
test processor::quick_metadata::tests::storey_elevation_prefers_index_9_over_index_8 ... ok

test result: ok. 5 passed; 0 failed
```

`cargo clippy -p ifc-lite-processing --all-targets` is clean.

## The fix

The predicate now covers exactly the rule it always implemented: `IfcProject`, plus the `IfcSpatialElement` branch **minus** the external-spatial sub-branch (`IfcExternalSpatialElement` / `IfcExternalSpatialStructureElement` are air volumes, not containment nodes, and stay excluded). The abstract bases in that branch are admitted too, so the rule carries no exception list — they cannot appear in a conformant file, so nothing changes in practice.

Abstractness deliberately is **not** the discriminator: the generated schema marks `IfcFacilityPart` abstract (confirmed alongside `IfcSpatialElement` and `IfcSpatialStructureElement`, the other two abstract members of this branch), so none of the three can occur in a conformant file — admitting the abstract bases costs nothing and just removes the need for an exception list. A "concrete only" rule would have dropped exactly those three unreachable types, so it would have been harmless, not a regression.

`quick_spatial_predicate_matches_the_generated_spatial_branch` derives the expected set from the generated `IFC_TYPES` and compares it against the predicate in **both** directions — a name the rule admits and the predicate rejects (severed subtree), and a name the predicate admits and the rule rejects (invented node). It carries two anti-vacuity floors: `IFC_TYPES.len() > 800` proves the enumeration ran over the whole schema, and `expected_true >= 17` proves the rule selects a non-trivial slice rather than matching nothing.

`quick_spatial_predicate_controls` is the control fixture: non-spatial products and relationships stay `false`, the excluded external-spatial branch stays `false`, and `IfcMarineFacility` / `IFCMARINEFACILITY` / `ifcmarinefacility` all resolve alike — so a regression that returned `true` for everything, or that dropped case-insensitivity, cannot pass both tests.

The predicate is rewritten as a length-keyed dispatch, so the wider list costs at most three case-insensitive comparisons per scanned entity instead of up to fourteen — a net win on a per-entity hot path.

## Not fixed here

`packages/data/src/spatial-types.ts` still omitted `IfcMarinePart` and `IfcFacilityPartCommon`. That file was outside this change's scope; the gap is now closed by #3249, a complementary fix with zero file overlap with this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added marine facilities and common facility parts to the quick spatial tree.
  * Preserved aggregate subtrees for supported spatial elements, improving navigation of facility structures.

* **Bug Fixes**
  * Expanded spatial type recognition to cover additional IFC facility and spatial element types.
  * Improved handling of type-name capitalization and excluded non-spatial and external spatial types from quick spatial processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
