### PR TITLE
fix(export): visible-only export dropped every IFC2X3-only product (#3252)

### DIFF
--- a/.changeset/visible-only-export-2x3-products.md
+++ b/.changeset/visible-only-export-2x3-products.md
@@ -1,0 +1,11 @@
+---
+"@ifc-lite/export": patch
+---
+
+Stop dropping IFC2X3-only elements from a visible-only export.
+
+`reference-collector`'s `PRODUCT_TYPES` decides which entities become roots of the reference closure under `visibleOnly`. Its doc comment described it as "the complete set of all IfcProduct subtypes", but it was hand-written from IFC4 and IFC4X3 only. Seven concrete IFC2X3 products were absent: `IfcElectricDistributionPoint`, `IfcElectricalElement`, `IfcEquipmentElement`, `IfcChamferEdgeFeature`, `IfcRoundedEdgeFeature`, `IfcStructuralLinearActionVarying` and `IfcStructuralPlanarActionVarying`.
+
+An entity of a missing type matched neither the infrastructure, spatial, `IFCREL*` nor product branch. The `hiddenIds` fallback below them only catches an entity the user explicitly hid, so a **visible** one fell through to "not a root" and never entered the closure — the element and the geometry only it referenced were silently absent from the written file, with no warning. Legacy IFC2X3 MEP models, where `IfcElectricDistributionPoint` carries switchboards and distribution panels, lost that equipment on every `--visible-only` STEP export and on every federated merge export with visibility filtering.
+
+The set is now derived at module load from `@ifc-lite/data`'s generated `ENTITIES_IFC2X3` / `ENTITIES_IFC4` / `ENTITIES_IFC4X3` tables by walking each entity's parent chain to `IfcProduct`, so regenerating the schema tables can no longer leave this classifier behind. IFC4 and IFC4X3 classification is unchanged — the diff that found this reported those two schemas complete.

--- a/packages/export/src/reference-collector.test.ts
+++ b/packages/export/src/reference-collector.test.ts
@@ -3,9 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import { describe, it, expect } from 'vitest';
-import { collectReferencedEntityIds, getVisibleEntityIds } from './reference-collector.js';
+import {
+  PRODUCT_TYPES,
+  collectReferencedEntityIds,
+  getVisibleEntityIds,
+} from './reference-collector.js';
 import { EMPTY_SOURCE_BYTES, type IfcDataStore } from '@ifc-lite/parser';
 import type { EffectiveEntityIndex } from './effective-index.js';
+import {
+  ENTITIES_IFC2X3,
+  ENTITIES_IFC4,
+  ENTITIES_IFC4X3,
+  type IfcEntityInfo,
+} from '@ifc-lite/data';
 
 /**
  * Helper: encode a set of STEP entity lines into a source buffer + entity index.
@@ -558,5 +568,145 @@ describe('propagateOpeningExclusions without a source (#2339)', () => {
     const store = sourcelessStore();
     const { hiddenProductIds } = getVisibleEntityIds(store, new Set(), null, overlayIndex(store));
     expect(hiddenProductIds.has(OPENING)).toBe(false);
+  });
+});
+
+/**
+ * The product-type classification must agree with the bundled IFC schema
+ * tables, in BOTH directions:
+ *   - every concrete IfcProduct subtype the schema declares is classified as a
+ *     product root (otherwise a visible-only export silently drops it);
+ *   - every name the classifier treats as a product really is an IfcProduct
+ *     subtype in some schema (otherwise the classifier over-roots).
+ *
+ * The expectation is derived from `@ifc-lite/data`'s generated entity tables,
+ * never from a hand-copied list — a hand copy would drift with the table it is
+ * meant to check.
+ */
+describe('product-type classification vs the generated IFC schema', () => {
+  function mockStore(entries: Array<[number, string]>): IfcDataStore {
+    const byId = new Map<number, { expressId: number; type: string; byteOffset: number; byteLength: number; lineNumber: number }>();
+    const byType = new Map<string, number[]>();
+    for (const [id, type] of entries) {
+      byId.set(id, { expressId: id, type, byteOffset: 0, byteLength: 0, lineNumber: 0 });
+      const upper = type.toUpperCase();
+      if (!byType.has(upper)) byType.set(upper, []);
+      byType.get(upper)!.push(id);
+    }
+    return { entityIndex: { byId, byType }, source: new Uint8Array(0) } as unknown as IfcDataStore;
+  }
+
+  /** Concrete (instantiable) IfcProduct subtypes declared by one schema table. */
+  function concreteProducts(table: readonly IfcEntityInfo[]): string[] {
+    const parent = new Map(table.map(e => [e.name, e.parent]));
+    const isProduct = (name: string): boolean => {
+      let cursor: string | null | undefined = name;
+      for (let guard = 0; cursor && guard < 64; guard++) {
+        if (cursor === 'IfcProduct') return true;
+        cursor = parent.get(cursor);
+      }
+      return false;
+    };
+    return table.filter(e => !e.abstract && e.name !== 'IfcProduct' && isProduct(e.name)).map(e => e.name);
+  }
+
+  const SCHEMA_TABLES: Array<[string, readonly IfcEntityInfo[]]> = [
+    ['IFC2X3', ENTITIES_IFC2X3],
+    ['IFC4', ENTITIES_IFC4],
+    ['IFC4X3', ENTITIES_IFC4X3],
+  ];
+
+  /**
+   * Anti-vacuity: named entities that must appear in the derived enumeration.
+   * A count floor would go green on benign growth and stay silent on exactly
+   * the schema whose types went missing, so the guard names them instead.
+   * The IFC2X3-only entries are the ones the hand-written table omitted.
+   */
+  const REQUIRED_IN_ENUMERATION: Record<string, string[]> = {
+    IFC2X3: [
+      'IfcElectricDistributionPoint',
+      'IfcElectricalElement',
+      'IfcEquipmentElement',
+      'IfcChamferEdgeFeature',
+      'IfcRoundedEdgeFeature',
+      'IfcStructuralLinearActionVarying',
+      'IfcStructuralPlanarActionVarying',
+      'IfcWall',
+    ],
+    IFC4: ['IfcWall', 'IfcFurniture', 'IfcShadingDevice'],
+    IFC4X3: ['IfcWall', 'IfcKerb', 'IfcSign'],
+  };
+
+  for (const [version, table] of SCHEMA_TABLES) {
+    it(`enumerates the ${version} products it is about to assert on`, () => {
+      const products = new Set(concreteProducts(table));
+      for (const required of REQUIRED_IN_ENUMERATION[version]) {
+        expect(products.has(required), `${required} missing from the ${version} enumeration`).toBe(true);
+      }
+    });
+
+    it(`roots every concrete ${version} IfcProduct subtype when nothing is hidden`, () => {
+      const products = concreteProducts(table);
+      const entries: Array<[number, string]> = products.map((name, i) => [i + 100, name.toUpperCase()]);
+      const store = mockStore(entries);
+      const { roots } = getVisibleEntityIds(store, new Set(), null);
+
+      const dropped = entries.filter(([id]) => !roots.has(id)).map(([, type]) => type);
+      expect(dropped, `${version} products dropped from a visible-only export`).toEqual([]);
+    });
+  }
+
+  it('classifies nothing the schema does not declare as an IfcProduct subtype', () => {
+    const declared = new Set<string>();
+    for (const [, table] of SCHEMA_TABLES) {
+      const parent = new Map(table.map(e => [e.name, e.parent]));
+      for (const entity of table) {
+        let cursor: string | null | undefined = parent.get(entity.name);
+        for (let guard = 0; cursor && guard < 64; guard++) {
+          if (cursor === 'IfcProduct') {
+            declared.add(entity.name.toUpperCase());
+            break;
+          }
+          cursor = parent.get(cursor);
+        }
+      }
+    }
+
+    expect(declared.size, 'schema enumeration is empty — the diff below would be vacuous').toBeGreaterThan(0);
+    const strays = [...PRODUCT_TYPES].filter(name => !declared.has(name));
+    expect(strays, 'classified as products but not IfcProduct subtypes in any bundled schema').toEqual([]);
+  });
+
+  it('does not root non-product entities (control)', () => {
+    const controls: Array<[number, string]> = [
+      [1, 'IFCCARTESIANPOINT'],
+      [2, 'IFCPROPERTYSET'],
+      [3, 'IFCPROPERTYSINGLEVALUE'],
+      [4, 'IFCMATERIAL'],
+      [5, 'IFCWALLTYPE'],
+      [6, 'IFCLOCALPLACEMENT'],
+      [7, 'IFCSHAPEREPRESENTATION'],
+    ];
+    const { roots } = getVisibleEntityIds(mockStore(controls), new Set(), null);
+    const rooted = controls.filter(([id]) => roots.has(id)).map(([, type]) => type);
+    expect(rooted, 'non-product entities must be reached through the closure, not rooted').toEqual([]);
+  });
+
+  it('drops an IFC2X3 electrical element only when it is actually hidden', () => {
+    const store = mockStore([
+      [1, 'IFCPROJECT'],
+      [2, 'IFCBUILDINGSTOREY'],
+      [3, 'IFCELECTRICDISTRIBUTIONPOINT'],
+      [4, 'IFCELECTRICALELEMENT'],
+    ]);
+
+    const visible = getVisibleEntityIds(store, new Set(), null);
+    expect(visible.roots.has(3)).toBe(true);
+    expect(visible.roots.has(4)).toBe(true);
+
+    const hidden = getVisibleEntityIds(store, new Set([3]), null);
+    expect(hidden.roots.has(3)).toBe(false);
+    expect(hidden.hiddenProductIds.has(3)).toBe(true);
+    expect(hidden.roots.has(4)).toBe(true);
   });
 });

--- a/packages/export/src/reference-collector.ts
+++ b/packages/export/src/reference-collector.ts
@@ -29,6 +29,12 @@
 
 import type { IfcDataStore, IfcSourceBytes } from '@ifc-lite/parser';
 import { asSourceBytes } from '@ifc-lite/parser';
+import {
+  ENTITIES_IFC2X3,
+  ENTITIES_IFC4,
+  ENTITIES_IFC4X3,
+  type IfcEntityInfo,
+} from '@ifc-lite/data';
 import type { EffectiveEntityIndex } from './effective-index.js';
 import { splitTopLevelArgs } from './step-argument-parser.js';
 
@@ -90,120 +96,54 @@ const SPATIAL_STRUCTURE_TYPES = new Set([
 ]);
 
 /**
- * Complete set of all IfcProduct subtypes from the IFC4 + IFC4X3 schemas,
- * excluding spatial structure types (handled above). Generated from the
- * schema registry's inheritanceChain metadata.
+ * Every IfcProduct subtype in every schema this package can export, derived
+ * from `@ifc-lite/data`'s generated entity tables rather than hand-listed.
  *
- * 202 types — full IFC schema coverage. The hiddenIds fallback below
- * catches any types that may exist in future schema versions.
+ * A product type missing from this set is not classified as a product, so under
+ * `visibleOnly` it never becomes a root: the element — and the geometry only it
+ * references — is silently absent from the exported file even though the user
+ * never hid it. The hand-written predecessor was derived from IFC4 + IFC4X3
+ * alone and therefore dropped every IFC2X3-only product
+ * (`IfcElectricDistributionPoint`, `IfcElectricalElement`,
+ * `IfcEquipmentElement`, the edge features, the varying structural actions)
+ * from a visible-only export of a legacy model.
+ *
+ * Deriving it means a schema-table regeneration cannot leave this classifier
+ * behind. Spatial structure and infrastructure are matched before this set, so
+ * its overlap with `SPATIAL_STRUCTURE_TYPES` is harmless. The `hiddenIds`
+ * fallback below still catches types no bundled schema declares.
  */
-const PRODUCT_TYPES = new Set([
-  // IfcElement > IfcBuildingElement
-  'IFCBEAM', 'IFCBEAMSTANDARDCASE', 'IFCBUILDINGELEMENT',
-  'IFCBUILDINGELEMENTPART', 'IFCBUILDINGELEMENTPROXY', 'IFCBUILTELEMENT',
-  'IFCCHIMNEY', 'IFCCOLUMN', 'IFCCOLUMNSTANDARDCASE',
-  'IFCCOVERING', 'IFCCURTAINWALL',
-  'IFCDEEPFOUNDATION', 'IFCDOOR', 'IFCDOORSTANDARDCASE',
-  'IFCFOOTING', 'IFCMEMBER', 'IFCMEMBERSTANDARDCASE',
-  'IFCPILE', 'IFCPLATE', 'IFCPLATESTANDARDCASE',
-  'IFCRAILING', 'IFCRAMP', 'IFCRAMPFLIGHT',
-  'IFCROOF', 'IFCSHADINGDEVICE',
-  'IFCSLAB', 'IFCSLABELEMENTEDCASE', 'IFCSLABSTANDARDCASE',
-  'IFCSTAIR', 'IFCSTAIRFLIGHT',
-  'IFCWALL', 'IFCWALLELEMENTEDCASE', 'IFCWALLSTANDARDCASE',
-  'IFCWINDOW', 'IFCWINDOWSTANDARDCASE',
-  // IfcElement > IfcDistributionElement
-  'IFCDISTRIBUTIONELEMENT', 'IFCDISTRIBUTIONCONTROLELEMENT',
-  'IFCDISTRIBUTIONFLOWELEMENT', 'IFCDISTRIBUTIONCHAMBERELEMENT',
-  'IFCDISTRIBUTIONPORT', 'IFCDISTRIBUTIONBOARD',
-  // IfcDistributionControlElement subtypes
-  'IFCACTUATOR', 'IFCALARM', 'IFCCONTROLLER',
-  'IFCFLOWINSTRUMENT', 'IFCPROTECTIVEDEVICETRIPPINGUNIT',
-  'IFCSENSOR', 'IFCUNITARYCONTROLELEMENT',
-  // IfcFlowController subtypes
-  'IFCAIRTERMINALBOX', 'IFCDAMPER', 'IFCELECTRICDISTRIBUTIONBOARD',
-  'IFCELECTRICTIMECONTROL', 'IFCFLOWCONTROLLER', 'IFCFLOWMETER',
-  'IFCPROTECTIVEDEVICE', 'IFCSWITCHINGDEVICE', 'IFCVALVE',
-  // IfcFlowFitting subtypes
-  'IFCCABLECARRIERFITTING', 'IFCCABLEFITTING',
-  'IFCDUCTFITTING', 'IFCFLOWFITTING', 'IFCJUNCTIONBOX', 'IFCPIPEFITTING',
-  // IfcFlowMovingDevice subtypes
-  'IFCCOMPRESSOR', 'IFCFAN', 'IFCFLOWMOVINGDEVICE', 'IFCPUMP',
-  // IfcFlowSegment subtypes
-  'IFCCABLECARRIERSEGMENT', 'IFCCABLESEGMENT', 'IFCCONVEYORSEGMENT',
-  'IFCDUCTSEGMENT', 'IFCFLOWSEGMENT', 'IFCPIPESEGMENT',
-  // IfcFlowStorageDevice subtypes
-  'IFCELECTRICFLOWSTORAGEDEVICE', 'IFCFLOWSTORAGEDEVICE', 'IFCTANK',
-  // IfcFlowTerminal subtypes
-  'IFCAIRTERMINAL', 'IFCAUDIOVISUALAPPLIANCE', 'IFCCOMMUNICATIONSAPPLIANCE',
-  'IFCELECTRICAPPLIANCE', 'IFCFIRESUPPRESSIONTERMINAL', 'IFCFLOWTERMINAL',
-  'IFCLAMP', 'IFCLIGHTFIXTURE', 'IFCLIQUIDTERMINAL',
-  'IFCMEDICALDEVICE', 'IFCMOBILETELECOMMUNICATIONSAPPLIANCE',
-  'IFCOUTLET', 'IFCSANITARYTERMINAL', 'IFCSPACEHEATER',
-  'IFCSTACKTERMINAL', 'IFCWASTETERMINAL',
-  // IfcFlowTreatmentDevice subtypes
-  'IFCDUCTSILENCER', 'IFCELECTRICFLOWTREATMENTDEVICE',
-  'IFCFILTER', 'IFCFLOWTREATMENTDEVICE', 'IFCINTERCEPTOR',
-  // IfcEnergyConversionDevice subtypes
-  'IFCAIRTOAIRHEATRECOVERY', 'IFCBOILER', 'IFCBURNER',
-  'IFCCHILLER', 'IFCCOIL', 'IFCCONDENSER',
-  'IFCCOOLEDBEAM', 'IFCCOOLINGTOWER',
-  'IFCELECTRICGENERATOR', 'IFCELECTRICMOTOR',
-  'IFCENERGYCONVERSIONDEVICE', 'IFCENGINE',
-  'IFCEVAPORATIVECOOLER', 'IFCEVAPORATOR',
-  'IFCHEATEXCHANGER', 'IFCHUMIDIFIER', 'IFCMOTORCONNECTION',
-  'IFCSOLARDEVICE', 'IFCTRANSFORMER', 'IFCTUBEBUNDLE',
-  'IFCUNITARYEQUIPMENT',
-  // IfcElement > IfcElementAssembly
-  'IFCELEMENT', 'IFCELEMENTASSEMBLY',
-  // IfcElement > IfcElementComponent
-  'IFCELEMENTCOMPONENT', 'IFCFASTENER',
-  'IFCMECHANICALFASTENER', 'IFCDISCRETEACCESSORY',
-  'IFCVIBRATIONDAMPER', 'IFCVIBRATIONISOLATOR',
-  'IFCIMPACTPROTECTIONDEVICE',
-  // IfcElement > IfcFeatureElement
-  'IFCFEATUREELEMENT', 'IFCFEATUREELEMENTADDITION', 'IFCFEATUREELEMENTSUBTRACTION',
-  'IFCOPENINGELEMENT', 'IFCOPENINGSTANDARDCASE',
-  'IFCPROJECTIONELEMENT', 'IFCSURFACEFEATURE', 'IFCVOIDINGFEATURE',
-  // IfcElement > IfcFurnishingElement
-  'IFCFURNISHINGELEMENT', 'IFCFURNITURE', 'IFCSYSTEMFURNITUREELEMENT',
-  // IfcElement > IfcGeographicElement / IfcCivilElement
-  'IFCGEOGRAPHICELEMENT', 'IFCCIVILELEMENT',
-  // IfcElement > IfcTransportElement / IfcTransportationDevice / IfcVehicle
-  'IFCTRANSPORTELEMENT', 'IFCTRANSPORTATIONDEVICE', 'IFCVEHICLE',
-  // IfcElement > IfcReinforcingElement
-  'IFCREINFORCINGELEMENT', 'IFCREINFORCINGBAR', 'IFCREINFORCINGMESH',
-  'IFCTENDON', 'IFCTENDONANCHOR', 'IFCTENDONCONDUIT',
-  // IfcElement > IFC4X3 additions
-  'IFCBEARING', 'IFCCAISSONFOUNDATION', 'IFCCOURSE',
-  'IFCEARTHWORKSCUT', 'IFCEARTHWORKSELEMENT', 'IFCEARTHWORKSFILL',
-  'IFCKERB', 'IFCMOORINGDEVICE', 'IFCNAVIGATIONELEMENT',
-  'IFCPAVEMENT', 'IFCRAIL', 'IFCREINFORCEDSOIL', 'IFCSIGN', 'IFCSIGNAL',
-  'IFCTRACKELEMENT',
-  // IFC4X3 alignment and positioning
-  'IFCALIGNMENT', 'IFCALIGNMENTCANT', 'IFCALIGNMENTHORIZONTAL',
-  'IFCALIGNMENTSEGMENT', 'IFCALIGNMENTVERTICAL',
-  'IFCLINEARELEMENT', 'IFCLINEARPOSITIONINGELEMENT',
-  'IFCPOSITIONINGELEMENT', 'IFCREFERENT',
-  // IFC4X3 geotechnical
-  'IFCBOREHOLE', 'IFCGEOMODEL', 'IFCGEOSLICE',
-  'IFCGEOTECHNICALASSEMBLY', 'IFCGEOTECHNICALELEMENT', 'IFCGEOTECHNICALSTRATUM',
-  // IfcProduct (non-element)
-  'IFCANNOTATION', 'IFCGRID', 'IFCPORT', 'IFCPROXY',
-  'IFCSPACE', 'IFCVIRTUALELEMENT',
-  // IfcStructuralItem / IfcStructuralActivity
-  'IFCSTRUCTURALACTION', 'IFCSTRUCTURALACTIVITY',
-  'IFCSTRUCTURALCONNECTION', 'IFCSTRUCTURALCURVEACTION',
-  'IFCSTRUCTURALCURVECONNECTION', 'IFCSTRUCTURALCURVEMEMBER',
-  'IFCSTRUCTURALCURVEMEMBERVARYING', 'IFCSTRUCTURALCURVEREACTION',
-  'IFCSTRUCTURALITEM', 'IFCSTRUCTURALLINEARACTION',
-  'IFCSTRUCTURALMEMBER', 'IFCSTRUCTURALPLANARACTION',
-  'IFCSTRUCTURALPOINTACTION', 'IFCSTRUCTURALPOINTCONNECTION',
-  'IFCSTRUCTURALPOINTREACTION', 'IFCSTRUCTURALREACTION',
-  'IFCSTRUCTURALSURFACEACTION', 'IFCSTRUCTURALSURFACECONNECTION',
-  'IFCSTRUCTURALSURFACEMEMBER', 'IFCSTRUCTURALSURFACEMEMBERVARYING',
-  'IFCSTRUCTURALSURFACEREACTION',
-]);
+/** Exported for the drift test that diffs it against the schema tables. */
+export const PRODUCT_TYPES: ReadonlySet<string> = buildProductTypes();
+
+function buildProductTypes(): Set<string> {
+  const products = new Set<string>();
+  for (const table of [ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3]) {
+    collectProductNames(table, products);
+  }
+  return products;
+}
+
+/** Add the upper-cased name of every `IfcProduct` descendant declared in `table`. */
+function collectProductNames(table: readonly IfcEntityInfo[], out: Set<string>): void {
+  const parentOf = new Map<string, string | null | undefined>();
+  for (const entity of table) parentOf.set(entity.name, entity.parent);
+
+  for (const entity of table) {
+    // The walk starts at the parent, so `IfcProduct` itself — abstract, and
+    // never instantiated — is not added, while every descendant is.
+    let cursor = parentOf.get(entity.name) ?? null;
+    // Depth-bounded so a malformed table cannot spin here; the deepest IFC
+    // inheritance chain is far under this bound.
+    for (let depth = 0; cursor !== null && depth < 64; depth++) {
+      if (cursor === 'IfcProduct') {
+        out.add(entity.name.toUpperCase());
+        break;
+      }
+      cursor = parentOf.get(cursor) ?? null;
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Byte-level #ID reference extraction


### PR DESCRIPTION
Refs #3252

## What was wrong

`reference-collector`'s `PRODUCT_TYPES` decides which entities become roots of the reference closure under `visibleOnly`. Its doc comment called it "the complete set of all IfcProduct subtypes", but it was hand-written from IFC4 and IFC4X3 only — and this package exports IFC2X3 files too.

An entity of an unlisted type matches no branch in `getVisibleEntityIds`. The `hiddenIds` fallback below the branches only catches an entity the user **hid**, so a **visible** one fell through to "not a root": the element, and the geometry only it referenced, never entered the closure and were silently absent from the written file. A legacy IFC2X3 MEP model lost its switchboards and distribution panels (`IfcElectricDistributionPoint`) on every `--visible-only` STEP export and every federated merge export with visibility filtering.

## The mechanical diff

Walking each entity's parent chain to `IfcProduct` in `@ifc-lite/data`'s generated tables and diffing against the classifier:

| schema | products declared | missing |
| --- | --- | --- |
| IFC2X3 | 90 | 9 (7 concrete) |
| IFC4 | 177 | 0 |
| IFC4X3 | 214 | 0 |

IFC4 and IFC4X3 come back clean, which is what makes this a scoped IFC2X3 gap rather than a widening of a curated list. The reverse diff is also clean: nothing in the old set was a non-product.

## RED

```
FAIL src/reference-collector.test.ts > product-type classification vs the generated IFC schema
     > roots every concrete IFC2X3 IfcProduct subtype when nothing is hidden
AssertionError: IFC2X3 products dropped from a visible-only export: expected [ …(7) ] to deeply equal []

- []
+ [
+   "IFCSTRUCTURALLINEARACTIONVARYING",
+   "IFCSTRUCTURALPLANARACTIONVARYING",
+   "IFCCHAMFEREDGEFEATURE",
+   "IFCROUNDEDEDGEFEATURE",
+   "IFCELECTRICALELEMENT",
+   "IFCEQUIPMENTELEMENT",
+   "IFCELECTRICDISTRIBUTIONPOINT",
+ ]

FAIL src/reference-collector.test.ts > product-type classification vs the generated IFC schema
     > drops an IFC2X3 electrical element only when it is actually hidden
AssertionError: expected false to be true

 Test Files  1 failed | 63 passed | 2 skipped (66)
      Tests  2 failed | 869 passed | 30 skipped (901)
```

The IFC4 and IFC4X3 cases of the same parametrised test passed on the unfixed code — the RED is specific to the schema that was left out.

## Fix

`PRODUCT_TYPES` is derived at module load from `ENTITIES_IFC2X3` / `ENTITIES_IFC4` / `ENTITIES_IFC4X3` by walking each entity's parent chain to `IfcProduct`, so a schema-table regeneration cannot leave this classifier behind. One linear pass over the three tables, once per process. IFC4 / IFC4X3 classification is byte-for-byte the same membership as before.

## Tests

- **Both directions.** Every concrete `IfcProduct` subtype each schema declares must be rooted; and every name the classifier treats as a product must be an `IfcProduct` subtype in some bundled schema.
- **Anti-vacuity, named not counted.** Each schema's enumeration must contain a named required list (the seven IFC2X3 types that were missing, plus `IfcWall` / `IfcFurniture` / `IfcKerb` / `IfcSign` per schema). A count floor would go green on benign schema growth and stay silent on exactly the schema whose types went missing.
- **Control.** `IFCCARTESIANPOINT`, `IFCPROPERTYSET`, `IFCWALLTYPE`, `IFCMATERIAL`, `IFCLOCALPLACEMENT`, `IFCSHAPEREPRESENTATION` must still **not** be rooted — the fix must not turn the classifier into "root everything".
- **Behavioural.** An IFC2X3 store with an `IfcElectricDistributionPoint` roots it when nothing is hidden, and drops it into `hiddenProductIds` only when it is actually hidden.

The expectations are computed from the generated tables at test time, never from a hand-typed copy of the list under test.

## GREEN

```
 Test Files  64 passed | 2 skipped (66)
      Tests  872 passed | 30 skipped (902)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
