### PR TITLE
fix(parser): stop reading IfcPhysicalComplexQuantity as a simple quantity (#3254)

### DIFF
--- a/.changeset/complex-quantity-phantom-count.md
+++ b/.changeset/complex-quantity-phantom-count.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/parser": patch
+---
+
+Stop reading `IfcPhysicalComplexQuantity` as if it were a simple quantity.
+
+A complex quantity groups other quantities rather than carrying a measure, so
+its `HasQuantities`/`Discrimination`/`Quality`/`Usage` attributes sit where a
+simple quantity keeps `Unit` and its value. Both quantity readers assumed the
+simple layout: the type fell through to `QuantityType.Count` and slot 3 — a
+label, not a number — settled at `0`, so every complex quantity surfaced as a
+phantom `Count = 0` bearing the complex quantity's name. That row satisfied IDS
+existence requirements, counted as "has quantities" in `validate`, entered the
+compare fingerprints and rendered as a bogus quantity card.
+
+Complex quantities are now skipped, matching what the legacy quantity extractor
+already did for a type it did not recognise. The walk over
+`IfcElementQuantity.Quantities` also moved into one shared reader, so the
+instance path and the type path can no longer drift apart.
+
+Quantities nested inside a complex quantity remain unreported, as before.

--- a/packages/parser/src/columnar-parser.ts
+++ b/packages/parser/src/columnar-parser.ts
@@ -15,6 +15,7 @@ import { EntityExtractor } from './entity-extractor.js';
 import { extractLengthUnitScale } from './unit-extractor.js';
 import { getAttributeNames, getAttributeNamesAcrossSchemas, getInheritanceChain } from './ifc-schema.js';
 import { parsePropertyValue } from './on-demand-extractors.js';
+import { collectQuantitiesFromRefs } from './quantity-collect.js';
 import { buildCompactEntityIndexAsync } from './compact-entity-index.js';
 import { yieldToEventLoop } from './yield-to-event-loop.js';
 import {
@@ -24,7 +25,6 @@ import {
     QuantityTableBuilder,
     RelationshipGraphBuilder,
     RelationshipType,
-    QuantityType,
 } from '@ifc-lite/data';
 import type { SpatialHierarchy, QuantityTable, PropertyValue, PropertySet, QuantitySet, IfcStoreBase, IfcEntity, IfcAttributeValue } from '@ifc-lite/data';
 import { BufferEntitySource } from './entity-source.js';
@@ -32,7 +32,6 @@ import { batchExtractGlobalIdAndName } from './columnar-parser-attributes.js';
 import {
     GEOMETRY_TYPES,
     REL_TYPE_MAP,
-    QUANTITY_TYPE_MAP,
     SPATIAL_TYPES,
     HIERARCHY_REL_TYPES,
     PROPERTY_REL_TYPES,
@@ -880,32 +879,7 @@ export class ColumnarParser {
             const qsetName = typeof qsetAttrs[2] === 'string' ? qsetAttrs[2] : `QuantitySet #${qsetId}`;
             const hasQuantities = qsetAttrs[5];
 
-            const quantities: Array<{ name: string; type: number; value: number }> = [];
-
-            if (Array.isArray(hasQuantities)) {
-                for (const qtyRef of hasQuantities) {
-                    if (typeof qtyRef !== 'number') continue;
-
-                    const qtyEntityRef = getEntityRefFromStore(store, qtyRef);
-                    if (!qtyEntityRef) continue;
-
-                    const qtyEntity = extractor.extractEntity(qtyEntityRef);
-                    if (!qtyEntity) continue;
-
-                    const qtyAttrs = qtyEntity.attributes || [];
-                    const qtyName = typeof qtyAttrs[0] === 'string' ? qtyAttrs[0] : '';
-                    if (!qtyName) continue;
-
-                    // Get quantity type from entity type
-                    const qtyTypeUpper = qtyEntity.type.toUpperCase();
-                    const qtyType = QUANTITY_TYPE_MAP[qtyTypeUpper] ?? QuantityType.Count;
-
-                    // Value is at index 3 for most quantity types
-                    const value = typeof qtyAttrs[3] === 'number' ? qtyAttrs[3] : 0;
-
-                    quantities.push({ name: qtyName, type: qtyType, value });
-                }
-            }
+            const quantities = collectQuantitiesFromRefs(store, extractor, hasQuantities);
 
             if (quantities.length > 0 || qsetName) {
                 result.push({ name: qsetName, quantities });

--- a/packages/parser/src/on-demand-extractors.ts
+++ b/packages/parser/src/on-demand-extractors.ts
@@ -15,11 +15,10 @@ import { EntityExtractor } from './entity-extractor.js';
 import {
     RelationshipType,
     PropertyValueType,
-    QuantityType,
 } from '@ifc-lite/data';
 import type { PropertyValue } from '@ifc-lite/data';
 import type { IfcDataStore } from './columnar-parser.js';
-import { QUANTITY_TYPE_MAP } from './columnar-parser-indexes.js';
+import { collectQuantitiesFromRefs } from './quantity-collect.js';
 import { extractGeoreferencing as extractGeorefFromEntities, type GeoreferenceInfo } from './georef-extractor.js';
 
 // Re-export classification and material resolvers
@@ -540,29 +539,7 @@ export function extractQsetsFromIds(
         const qsetName = typeof qsetAttrs[2] === 'string' ? qsetAttrs[2] : `QuantitySet #${qsetId}`;
         const hasQuantities = qsetAttrs[5];
 
-        const quantities: Array<{ name: string; type: number; value: number }> = [];
-
-        if (Array.isArray(hasQuantities)) {
-            for (const qtyRef of hasQuantities) {
-                if (typeof qtyRef !== 'number') continue;
-
-                const qtyEntityRef = store.entityIndex.byId.get(qtyRef);
-                if (!qtyEntityRef) continue;
-
-                const qtyEntity = extractor.extractEntity(qtyEntityRef);
-                if (!qtyEntity) continue;
-
-                const qtyAttrs = qtyEntity.attributes || [];
-                const qtyName = typeof qtyAttrs[0] === 'string' ? qtyAttrs[0] : '';
-                if (!qtyName) continue;
-
-                const qtyType = QUANTITY_TYPE_MAP[qtyEntity.type.toUpperCase()] ?? QuantityType.Count;
-                // Value is at index 3 for the simple IfcQuantity* subtypes.
-                const value = typeof qtyAttrs[3] === 'number' ? qtyAttrs[3] : 0;
-
-                quantities.push({ name: qtyName, type: qtyType, value });
-            }
-        }
+        const quantities = collectQuantitiesFromRefs(store, extractor, hasQuantities);
 
         // Only surface sets that actually carry quantities. An empty set would
         // add nothing to a schedule, and (because `extractTypeQuantitiesOnDemand`

--- a/packages/parser/src/quantity-collect.ts
+++ b/packages/parser/src/quantity-collect.ts
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared reader for an `IfcElementQuantity.Quantities` list (#3254).
+ *
+ * The instance path (`ColumnarParser.extractQuantitiesOnDemand`) and the type
+ * path (`extractQsetsFromIds`) both walk that list, and each used to inline its
+ * own copy of the walk — two copies that would disagree the moment either was
+ * touched. The walk lives here and both call it.
+ */
+
+import { QuantityType } from '@ifc-lite/data';
+import type { EntityRef } from './types.js';
+import type { EntityExtractor } from './entity-extractor.js';
+import { QUANTITY_TYPE_MAP } from './columnar-parser-indexes.js';
+
+/** One extracted quantity, in the shape both call sites report. */
+export interface CollectedQuantity {
+    name: string;
+    type: number;
+    value: number;
+}
+
+/**
+ * The part of `IfcDataStore` this walk needs, declared structurally so the
+ * module need not import `IfcDataStore` from `columnar-parser.ts`, which
+ * imports this file back.
+ */
+export interface QuantityLookupStore {
+    entityIndex: { byId: { get(id: number): EntityRef | undefined } };
+    deferredEntityIndex?: { get(id: number): EntityRef | undefined };
+}
+
+/**
+ * `IfcPhysicalComplexQuantity` groups other quantities instead of carrying a
+ * value of its own (`packages/codegen/schemas/IFC4_ADD2_TC1.exp`, identically
+ * in `IFC4X3.exp`):
+ *
+ *     ENTITY IfcPhysicalComplexQuantity
+ *      SUBTYPE OF (IfcPhysicalQuantity);
+ *         HasQuantities : SET [1:?] OF IfcPhysicalQuantity;
+ *         Discrimination : IfcLabel;
+ *         Quality : OPTIONAL IfcLabel;
+ *         Usage : OPTIONAL IfcLabel;
+ *
+ * With `Name` and `Description` inherited from `IfcPhysicalQuantity`, the
+ * flattened slots are HasQuantities[2], Discrimination[3], Quality[4],
+ * Usage[5]. Slot 3 — where every `IfcPhysicalSimpleQuantity` subtype keeps its
+ * measure — therefore holds a label here.
+ */
+const COMPLEX_QUANTITY_TYPE = 'IFCPHYSICALCOMPLEXQUANTITY';
+
+/**
+ * Value slot on every `IfcPhysicalSimpleQuantity` subtype: Name[0],
+ * Description[1], Unit[2], *Value[3].
+ */
+const SIMPLE_QUANTITY_VALUE_SLOT = 3;
+
+/**
+ * Read an `IfcElementQuantity.Quantities` list into flat quantity records.
+ *
+ * An `IfcPhysicalComplexQuantity` is skipped: it has no measure to report, and
+ * a `{name, type, value}` triple has nowhere to put its `HasQuantities`
+ * children. Before #3254 it fell through the simple-quantity path and surfaced
+ * as a phantom `Count = 0` — a row that satisfied IDS existence requirements,
+ * counted as "has quantities" in `validate`, entered the compare fingerprints
+ * and rendered as a bogus quantity card. Skipping matches what the legacy
+ * `quantity-extractor.ts` already does for a type it does not recognise, so all
+ * three quantity readers now agree.
+ *
+ * The nested quantities stay invisible, exactly as they are today; surfacing
+ * them is tracked separately, because flattening them into this list would feed
+ * new names to a dozen name-keyed consumers and — via the mutable property view
+ * that re-writes a touched `IfcElementQuantity` from these records — would
+ * flatten the complex structure out of the file on the next export.
+ *
+ * An entity of a type absent from {@link QUANTITY_TYPE_MAP} still reports as a
+ * `Count`, which keeps `IfcQuantityNumber` (IFC4X3) surfacing its correct value
+ * under a wrong label rather than vanishing; labelling it needs a new
+ * `QuantityType` member and is tracked separately.
+ */
+export function collectQuantitiesFromRefs(
+    store: QuantityLookupStore,
+    extractor: EntityExtractor,
+    refs: unknown,
+): CollectedQuantity[] {
+    const quantities: CollectedQuantity[] = [];
+    if (!Array.isArray(refs)) return quantities;
+
+    for (const qtyRef of refs) {
+        if (typeof qtyRef !== 'number') continue;
+
+        const qtyEntityRef = store.entityIndex.byId.get(qtyRef) ?? store.deferredEntityIndex?.get(qtyRef);
+        if (!qtyEntityRef) continue;
+
+        const qtyEntity = extractor.extractEntity(qtyEntityRef);
+        if (!qtyEntity) continue;
+
+        const qtyTypeUpper = qtyEntity.type.toUpperCase();
+        if (qtyTypeUpper === COMPLEX_QUANTITY_TYPE) continue;
+
+        const qtyAttrs = qtyEntity.attributes || [];
+        const qtyName = typeof qtyAttrs[0] === 'string' ? qtyAttrs[0] : '';
+        if (!qtyName) continue;
+
+        const qtyType = QUANTITY_TYPE_MAP[qtyTypeUpper] ?? QuantityType.Count;
+        const rawValue = qtyAttrs[SIMPLE_QUANTITY_VALUE_SLOT];
+        const value = typeof rawValue === 'number' ? rawValue : 0;
+
+        quantities.push({ name: qtyName, type: qtyType, value });
+    }
+
+    return quantities;
+}

--- a/packages/parser/test/complex-quantity.test.ts
+++ b/packages/parser/test/complex-quantity.test.ts
@@ -1,0 +1,178 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IfcPhysicalComplexQuantity handling (#3254).
+ *
+ * A complex quantity groups other quantities instead of carrying a value.
+ * `IFC4_ADD2_TC1.exp` (identically `IFC4X3.exp`):
+ *
+ *     ENTITY IfcPhysicalComplexQuantity
+ *      SUBTYPE OF (IfcPhysicalQuantity);
+ *         HasQuantities : SET [1:?] OF IfcPhysicalQuantity;
+ *         Discrimination : IfcLabel;
+ *         ...
+ *
+ * With Name[0]/Description[1] inherited, slot 3 is `Discrimination` — a label,
+ * not a measure. Both extraction paths used to read slot 3 as a value and fall
+ * back to `QuantityType.Count`, emitting a phantom `Count = 0`.
+ *
+ * Every case below carries a SIMPLE control quantity next to the complex one,
+ * so a regression that broke the whole walk equally cannot pass.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { StepTokenizer } from '../src/tokenizer.js';
+import {
+  ColumnarParser,
+  extractQuantitiesOnDemand,
+  extractTypeQuantitiesOnDemand,
+} from '../src/columnar-parser.js';
+import type { IfcDataStore } from '../src/columnar-parser.js';
+import { QuantityType, RelationshipType } from '@ifc-lite/data';
+
+/**
+ * Anti-vacuity: derive the premise from the schema rather than restating a
+ * memorised slot number, so this test fails if the premise stops holding.
+ */
+function complexQuantityAttributes(schemaFile: string): string[] {
+  const exp = readFileSync(
+    fileURLToPath(new URL(`../../codegen/schemas/${schemaFile}`, import.meta.url)),
+    'utf8',
+  );
+  const body = exp.match(/ENTITY IfcPhysicalComplexQuantity\b[\s\S]*?END_ENTITY;/)?.[0];
+  if (!body) throw new Error(`IfcPhysicalComplexQuantity not found in ${schemaFile}`);
+  const declared = [...body.matchAll(/^\t(\w+)\s*:/gm)].map((m) => m[1]);
+  // Name and Description are inherited from IfcPhysicalQuantity and take the
+  // first two flattened slots.
+  return ['Name', 'Description', ...declared];
+}
+
+const IFC = `#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#20=IFCQUANTITYLENGTH('NetWidth',$,$,0.25,$);
+#21=IFCQUANTITYAREA('SideAreaLeft',$,$,12.5,$);
+#22=IFCQUANTITYAREA('SideAreaRight',$,$,13.5,$);
+#23=IFCPHYSICALCOMPLEXQUANTITY('SideAreas',$,(#21,#22),'side','net',$);
+#30=IFCELEMENTQUANTITY('qto-guid',#1,'Qto_WallBaseQuantities',$,$,(#20,#23));
+#40=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#30);
+#50=IFCWALLTYPE('type-guid',#1,'WallType A',$,$,$,$,$,$,.STANDARD.);
+#60=IFCQUANTITYLENGTH('TypeWidth',$,$,0.3,$);
+#61=IFCQUANTITYVOLUME('PartVolume',$,$,4.0,$);
+#62=IFCPHYSICALCOMPLEXQUANTITY('TypeParts',$,(#61),'part','net',$);
+#70=IFCELEMENTQUANTITY('tqto-guid',#1,'Qto_WallTypeBase',$,$,(#60,#62));`;
+
+async function parse(ifc: string): Promise<IfcDataStore> {
+  const source = new TextEncoder().encode(ifc);
+  const tokenizer = new StepTokenizer(source);
+  const entityRefs = [...tokenizer.scanEntitiesFast()].map((ref) => ({
+    expressId: ref.expressId,
+    type: ref.type,
+    byteOffset: ref.offset,
+    byteLength: ref.length,
+    lineNumber: ref.line,
+  }));
+  const parser = new ColumnarParser();
+  return parser.parseLite(source.buffer.slice(0), entityRefs, {});
+}
+
+/** Wire up the DefinesByType relationship the type path resolves through. */
+function withTypeOf(store: IfcDataStore, elementId: number, typeId: number, qsetIds: number[]): IfcDataStore {
+  const mutable = store as unknown as Record<string, unknown>;
+  mutable.relationships = {
+    getRelated: (id: number, relType: RelationshipType, direction: string) =>
+      id === elementId && relType === RelationshipType.DefinesByType && direction === 'inverse' ? [typeId] : [],
+    hasRelationship: () => false,
+    getRelationshipsBetween: () => [],
+  };
+  mutable.onDemandQuantityMap = new Map([[typeId, qsetIds]]);
+  return store;
+}
+
+describe('IfcPhysicalComplexQuantity (#3254)', () => {
+  it.each(['IFC4_ADD2_TC1.exp', 'IFC4X3.exp'])(
+    'holds HasQuantities at slot 2 and a label at slot 3 in %s',
+    (schemaFile) => {
+      const attrs = complexQuantityAttributes(schemaFile);
+      expect(attrs.length).toBeGreaterThan(3);
+      expect(attrs[2]).toBe('HasQuantities');
+      // Slot 3 is where a simple quantity keeps its measure; here it is a
+      // label, which is why the old `typeof attrs[3] === 'number'` test failed
+      // and the value settled at 0.
+      expect(attrs[3]).toBe('Discrimination');
+    },
+  );
+
+  it('skips a complex quantity on the instance path', async () => {
+    const store = await parse(IFC);
+    const qsets = extractQuantitiesOnDemand(store, 10);
+
+    expect(qsets).toHaveLength(1);
+    expect(qsets[0].name).toBe('Qto_WallBaseQuantities');
+    // Control: the simple quantity beside it still comes through intact.
+    expect(qsets[0].quantities).toEqual([
+      { name: 'NetWidth', type: QuantityType.Length, value: 0.25 },
+    ]);
+
+    // No phantom row bearing the complex quantity's own name, and nothing
+    // zero-valued to pollute a total or satisfy an existence check.
+    expect(qsets[0].quantities.some((q) => q.name === 'SideAreas')).toBe(false);
+    expect(qsets[0].quantities.some((q) => q.value === 0)).toBe(false);
+  });
+
+  it('skips a complex quantity on the type path', async () => {
+    const store = withTypeOf(await parse(IFC), 10, 50, [70]);
+    const typeQuantities = extractTypeQuantitiesOnDemand(store, 10);
+
+    expect(typeQuantities).not.toBeNull();
+    expect(typeQuantities!.quantities).toHaveLength(1);
+    expect(typeQuantities!.quantities[0].name).toBe('Qto_WallTypeBase');
+    expect(typeQuantities!.quantities[0].quantities).toEqual([
+      { name: 'TypeWidth', type: QuantityType.Length, value: 0.3 },
+    ]);
+    expect(typeQuantities!.quantities[0].quantities.some((q) => q.name === 'TypeParts')).toBe(false);
+  });
+
+  it('does not let a complex quantity shadow a simple one of the same measure', async () => {
+    // The complex quantity is listed FIRST, so a reader that emitted a row for
+    // it would hand a name-keyed consumer the phantom before the real value.
+    const store = await parse(`#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#21=IFCQUANTITYVOLUME('Part',$,$,3.0,$);
+#22=IFCPHYSICALCOMPLEXQUANTITY('NetVolume',$,(#21),'part','net',$);
+#23=IFCQUANTITYVOLUME('GrossVolume',$,$,9.0,$);
+#30=IFCELEMENTQUANTITY('qto-guid',#1,'Qto_WallBaseQuantities',$,$,(#22,#23));
+#40=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#30);`);
+
+    const quantities = extractQuantitiesOnDemand(store, 10)[0].quantities;
+    expect(quantities).toEqual([
+      { name: 'GrossVolume', type: QuantityType.Volume, value: 9.0 },
+    ]);
+    // A summing consumer sees only the real measure.
+    expect(quantities.reduce((sum, q) => sum + q.value, 0)).toBeCloseTo(9.0);
+  });
+
+  it('still reports simple quantities when every entry in the set is complex', async () => {
+    const store = await parse(`#1=IFCOWNERHISTORY($,$,$,$,$,$,$,0);
+#10=IFCWALLSTANDARDCASE('wall-guid',#1,'Wall A',$,$,$,$,$);
+#21=IFCQUANTITYAREA('Inner',$,$,7.5,$);
+#22=IFCPHYSICALCOMPLEXQUANTITY('OnlyComplex',$,(#21),'mid','net',$);
+#30=IFCELEMENTQUANTITY('qto-guid',#1,'Qto_AllComplex',$,$,(#22));
+#31=IFCQUANTITYLENGTH('NetWidth',$,$,0.25,$);
+#32=IFCELEMENTQUANTITY('qto2-guid',#1,'Qto_WallBaseQuantities',$,$,(#31));
+#40=IFCRELDEFINESBYPROPERTIES('rel-guid',#1,$,$,(#10),#30);
+#41=IFCRELDEFINESBYPROPERTIES('rel2-guid',#1,$,$,(#10),#32);`);
+
+    const qsets = extractQuantitiesOnDemand(store, 10);
+    const byName = new Map(qsets.map((q) => [q.name, q.quantities]));
+    // The all-complex set contributes no quantities at all...
+    expect(byName.get('Qto_AllComplex')).toEqual([]);
+    // ...while the control set beside it is untouched.
+    expect(byName.get('Qto_WallBaseQuantities')).toEqual([
+      { name: 'NetWidth', type: QuantityType.Length, value: 0.25 },
+    ]);
+  });
+});


### PR DESCRIPTION
Refs #3254

## The defect

`IfcPhysicalComplexQuantity` groups other quantities instead of carrying a
measure (`packages/codegen/schemas/IFC4_ADD2_TC1.exp:7258`, identical in
`IFC4X3.exp:8424`):

```
ENTITY IfcPhysicalComplexQuantity
 SUBTYPE OF (IfcPhysicalQuantity);
	HasQuantities : SET [1:?] OF IfcPhysicalQuantity;
	Discrimination : IfcLabel;
	Quality : OPTIONAL IfcLabel;
	Usage : OPTIONAL IfcLabel;
```

With `Name`[0] and `Description`[1] inherited, the flattened slots are
`HasQuantities`[2], `Discrimination`[3], `Quality`[4], `Usage`[5]. Both quantity
readers assumed the `IfcPhysicalSimpleQuantity` layout — `Name`[0],
`Description`[1], `Unit`[2], `*Value`[3] — so they read `Discrimination`, a
label, as the value and fell back to `?? QuantityType.Count` for the type.

Verified through `ColumnarParser.parseLite`, not by reading, on `upstream/main`:

```
INSTANCE PATH: [{ "name": "Qto_WallBaseQuantities", "quantities": [
    { "name": "NetWidth",  "type": 0, "value": 0.25 },
    { "name": "SideAreas", "type": 3, "value": 0 } ] }]
TYPE PATH: { "typeName": "WallType A", "typeId": 50, "quantities": [
  { "name": "Qto_WallTypeBase", "quantities": [
    { "name": "TypeWidth", "type": 0, "value": 0.3 },
    { "name": "TypeParts", "type": 3, "value": 0 } ] }]}
```

`type: 3` is `QuantityType.Count`. The nested `SideAreaLeft` (12.5),
`SideAreaRight` (13.5) and `PartVolume` (4.0) appear nowhere.

That phantom row is not inert. It satisfies an IDS existence requirement
(`packages/ids/src/bridge/properties.ts:94`), makes an element count as "has
quantities" in `validate` (`packages/cli/src/commands/validate.ts:270`), enters
the compare fingerprints (`packages/cli/src/commands/diff-engine.ts:123`,
`apps/viewer/src/lib/compare/buildFingerprints.ts:397`), is handed to the agent
verbatim by the MCP query tools, and renders as a bogus `Count 0` line in the
quantity cards.

## What this changes

Complex quantities are skipped. The walk over `IfcElementQuantity.Quantities`
moved into one shared reader, `packages/parser/src/quantity-collect.ts`, called
by both the instance path (`ColumnarParser.extractQuantitiesOnDemand`) and the
type path (`extractQsetsFromIds`), which each carried their own copy of it.

## Why skip rather than flatten

Flattening the nested quantities into the parent set's list was the tempting
option — it recovers real data — and I rejected it after surveying the
consumers. Three call sites add several of an element's quantities into one
number, all name-filtered with no de-dup:
`stats-aggregation.ts:42` (`sumQuantity`), `query-output.ts:24`
(`query --sum`), and `stats-aggregation.ts:179` (`computeMaterialSummary`).
Several more pick a value by suffix or regex — `mcp/src/tools/diff.ts:296`
(`endsWith`), `mcp/src/tools/geometry.ts:146` (`/Volume$/i`) — and
`MaterialTotalsPanel.tsx:80` falls back to the alphabetically first name. New
names entering that list change totals in ways that depend on ordering.

The decisive one is `packages/export/src/step-property-sets.ts:772-860`: it
installs `extractQuantitiesOnDemand` as the base for
`MutablePropertyView.getQuantitiesForEntity` and regenerates a touched
`IfcElementQuantity` from those records while skipping the source set and its
atoms. Flattened children would be written back as flat siblings and the
`IfcPhysicalComplexQuantity` structure would be gone from the file
permanently — a worse defect than the one being fixed, in a package this
change does not touch.

Skipping is also what `packages/parser/src/quantity-extractor.ts:200` already
does for an unrecognised quantity type, so all three quantity readers now
agree. The nested quantities stay unreported, exactly as they are today; the
changeset says so. Surfacing them wants a field that can hold nesting and a
matching export path, which is a separate change.

## Tests

`packages/parser/test/complex-quantity.test.ts`. RED on `upstream/main` (4 of 6
failing, both call sites), GREEN here; 694 parser tests pass.

- The premise is derived from both `.exp` schemas at runtime rather than
  restated, so the test fails if `HasQuantities` ever stops sitting at slot 2 or
  slot 3 stops being a label.
- Every case carries a simple control quantity beside the complex one, so a
  regression breaking the whole walk equally cannot pass.
- One case lists the complex quantity *first*, where a phantom row would reach a
  name-keyed consumer ahead of the real measure.

## Follow-up, not fixed here

`QuantityType` (`packages/data/src/types.ts:185`) has no member for
`IfcQuantityNumber`, added in IFC4X3 (`IFC4X3.exp:9199`). Its `NumberValue`
*does* sit at slot 3, so the value is read correctly, but the same
`?? QuantityType.Count` fallback mislabels it as a Count. The rest of the
codebase already knows the entity (`rust/core/src/generated/schema.rs:467`,
`packages/codegen/generated/ifc4x3/entities.ts:5586`). Fixing it needs a new
enum member in `packages/data/src/types.ts`; the shared reader keeps the
`Count` fallback so such a quantity still surfaces its correct value rather
than vanishing. Recorded in #3254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
