### PR TITLE
fix(clash): a void no longer clashes with the element it cuts (#3256)

### DIFF
--- a/.changeset/clash-void-features-derived.md
+++ b/.changeset/clash-void-features-derived.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/clash': patch
+---
+
+Clash detection no longer reports a void against the element it cuts.
+
+The non-clashable filter listed `IfcOpeningElement` and `IfcOpeningStandardCase` by hand — one branch of the subtraction family in its IFC4 spelling. `IfcVoidingFeature` (IFC4) and `IfcEarthworksCut` (IFC4.3) are `IfcFeatureElementSubtraction` subtypes too, are meshed like any other product, and were becoming clash candidates, so every such void collided with its host. Subtraction features are now derived from the bundled schema union instead of enumerated, so a class a later schema adds is covered without another edit.
+
+Addition features stay clashable: `IfcProjectionElement` and `IfcSurfaceFeature` are physical material, so a clash against them is a real coordination problem.

--- a/packages/clash/src/adapters/non-clashable-void-features.test.ts
+++ b/packages/clash/src/adapters/non-clashable-void-features.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A void is a void whatever the schema calls it.
+ *
+ * `NON_CLASHABLE_TAGS` listed `IfcOpeningElement` and `IfcOpeningStandardCase`
+ * by hand — one branch of the subtraction family, in its IFC4 spelling. IFC4
+ * also has `IfcVoidingFeature` and IFC4.3 adds `IfcEarthworksCut`; both are
+ * `IfcFeatureElementSubtraction` subtypes, both are meshed like any other
+ * product, and both were clash candidates. A void that clashes with the
+ * element it cuts is the exact phantom-clash symptom #1464 was filed for,
+ * surviving under a class name the list had not heard of.
+ *
+ * The assertions below are DERIVED from the schema registry rather than from a
+ * second hand-typed list of the same names: a test that restates the table it
+ * guards can only ever confirm the copy. The enumeration walks the parser's
+ * IFC4 registry; the IFC4.3-only leaves are named, and their membership of the
+ * family is itself derived through `getInheritanceChainAcrossSchemas` — the
+ * same walk the production predicate uses — so neither half is asserted from a
+ * copy.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getInheritanceChainAcrossSchemas, SCHEMA_REGISTRY } from '@ifc-lite/parser';
+import { isNonClashableTag } from './shared.js';
+
+/** Classes whose inheritance chain reaches `ancestor` in any bundled schema. */
+function descendantsOf(ancestor: string, extra: readonly string[] = []): string[] {
+  const candidates = new Set([...Object.keys(SCHEMA_REGISTRY.entities), ...extra]);
+  return [...candidates]
+    .filter((name) => getInheritanceChainAcrossSchemas(name).includes(ancestor))
+    .sort();
+}
+
+/**
+ * IFC4.3 subtraction leaves, named rather than counted. They are outside the
+ * parser's IFC4 codegen pin, so the registry walk cannot enumerate them — but
+ * `descendantsOf` still has to CONFIRM each one descends from the family
+ * before it is asserted on, which is what keeps this from being a hand-copy.
+ */
+const IFC4X3_SUBTRACTION_LEAVES = ['IfcEarthworksCut'] as const;
+
+const VOIDS = descendantsOf('IfcFeatureElementSubtraction', IFC4X3_SUBTRACTION_LEAVES);
+const ADDITIONS = descendantsOf('IfcFeatureElementAddition');
+
+describe('every subtraction feature is dropped before it can become a clash candidate', () => {
+  it('finds the subtraction family in the bundled schemas (anti-vacuity)', () => {
+    // An empty derivation would let the per-name loop below report success over
+    // a set it never examined. Named, not counted: a count floor reds on benign
+    // schema growth and stays silent in the case that matters.
+    expect(VOIDS).toEqual(
+      expect.arrayContaining([
+        'IfcFeatureElementSubtraction',
+        'IfcOpeningElement',
+        'IfcOpeningStandardCase',
+        'IfcVoidingFeature',
+        'IfcEarthworksCut',
+      ]),
+    );
+  });
+
+  it.each(VOIDS)('%s is not a clash candidate', (tag) => {
+    expect(isNonClashableTag(tag)).toBe(true);
+  });
+
+  it('keeps real building elements clashable (control fixture)', () => {
+    // Without this, a predicate that answered `true` unconditionally would
+    // satisfy every assertion above.
+    for (const tag of ['IfcWall', 'IfcSlab', 'IfcColumn', 'IfcBeam', 'IfcPipeSegment']) {
+      expect(isNonClashableTag(tag), `${tag} must stay clashable`).toBe(false);
+    }
+  });
+
+  it('keeps ADDITION features clashable — they are physical material', () => {
+    // `IfcProjectionElement` (a corbel) and `IfcSurfaceFeature` descend from
+    // `IfcFeatureElementAddition`, not Subtraction. They occupy space, so a
+    // clash against them is a real coordination problem; widening the filter
+    // to the whole `IfcFeatureElement` tree would hide it.
+    expect(ADDITIONS).toEqual(expect.arrayContaining(['IfcProjectionElement']));
+    for (const tag of ADDITIONS) {
+      expect(isNonClashableTag(tag), `${tag} must stay clashable`).toBe(false);
+    }
+    // `IfcSurfaceFeature` hangs off `IfcFeatureElement` directly rather than
+    // off either branch — a surface treatment, still physical. It is named
+    // here because no derivation puts it in a family; the point of the case is
+    // that the filter must not swallow it along with the voids.
+    expect(getInheritanceChainAcrossSchemas('IfcSurfaceFeature')).toContain('IfcFeatureElement');
+    expect(isNonClashableTag('IfcSurfaceFeature')).toBe(false);
+  });
+});

--- a/packages/clash/src/adapters/shared.ts
+++ b/packages/clash/src/adapters/shared.ts
@@ -50,11 +50,12 @@ import { getInheritanceChainAcrossSchemas, isIfcTypeLikeEntity } from '@ifc-lite
  * ever consider real building elements. (#1464)
  *
  * Spatial containers are handled separately by {@link isSpatialContainerTag},
- * which derives them from the schema rather than from a list.
+ * and voids by {@link isVoidFeatureTag} — both derive from the schema rather
+ * than from a list. `IfcOpeningElement` / `IfcOpeningStandardCase` were
+ * listed here by hand and are now covered by that walk, which also catches
+ * the subtraction classes the list had never heard of.
  */
 export const NON_CLASHABLE_TAGS: ReadonlySet<string> = new Set([
-  'IfcOpeningElement',
-  'IfcOpeningStandardCase',
   'IfcVirtualElement',
   'IfcGrid',
   'IfcGridAxis',
@@ -95,6 +96,34 @@ export function isSpatialContainerTag(tag: string): boolean {
   return spatial;
 }
 
+/** Memoizes the void-feature walk below, like `spatialContainerByTag`. */
+const voidFeatureByTag = new Map<string, boolean>();
+
+/**
+ * True for SUBTRACTION features — the classes whose geometry describes a hole
+ * rather than material: `IfcOpeningElement`, `IfcOpeningStandardCase`,
+ * `IfcVoidingFeature` and IFC4.3's `IfcEarthworksCut`. A void is meshed like
+ * any other product, so every one that reached the candidate set clashed with
+ * the very element it cuts — the phantom-clash symptom of #1464, under a class
+ * name the hand-written list did not carry.
+ *
+ * Derived, not enumerated: `getInheritanceChainAcrossSchemas` walks the
+ * bundled IFC2X3 + IFC4 + IFC4X3 union, so a subtraction class added by a
+ * later schema is covered the day the bundled schemas learn it.
+ *
+ * Deliberately the SUBTRACTION branch and not the whole `IfcFeatureElement`
+ * tree: `IfcFeatureElementAddition` (`IfcProjectionElement`, a corbel) and
+ * `IfcSurfaceFeature` are physical material that occupies space, so a clash
+ * against them is a real coordination problem and must keep being reported.
+ */
+export function isVoidFeatureTag(tag: string): boolean {
+  const cached = voidFeatureByTag.get(tag);
+  if (cached !== undefined) return cached;
+  const isVoid = getInheritanceChainAcrossSchemas(tag).includes('IfcFeatureElementSubtraction');
+  voidFeatureByTag.set(tag, isVoid);
+  return isVoid;
+}
+
 /**
  * Whether an element carrying this IFC class `tag` should never become a
  * clash candidate: non-physical/reference geometry, a spatial container, or
@@ -105,6 +134,7 @@ export function isSpatialContainerTag(tag: string): boolean {
 export function isNonClashableTag(tag: string): boolean {
   return (
     NON_CLASHABLE_TAGS.has(tag) ||
+    isVoidFeatureTag(tag) ||
     isSpatialContainerTag(tag) ||
     isIfcTypeLikeEntity(tag.toUpperCase())
   );


### PR DESCRIPTION
Refs #3256

## The defect

`NON_CLASHABLE_TAGS` hand-listed the subtraction family as `IfcOpeningElement` + `IfcOpeningStandardCase` — one branch, in its IFC4 spelling. `IfcVoidingFeature` (IFC4) and `IfcEarthworksCut` (IFC4.3) are `IfcFeatureElementSubtraction` subtypes too, are meshed like any other product, and were reaching the candidate set. Each one then clashed with the element it cuts: the phantom-clash symptom #1464 was filed for, under a class name the list had never heard of.

RED on `upstream/main`:

    × IfcEarthworksCut is not a clash candidate
    × IfcFeatureElementSubtraction is not a clash candidate
    × IfcVoidingFeature is not a clash candidate
    AssertionError: expected false to be true // Object.is equality

## The fix

`isVoidFeatureTag` derives the family from the bundled IFC2X3 + IFC4 + IFC4X3 union via `getInheritanceChainAcrossSchemas` — the same walk `isSpatialContainerTag` next door already uses so IFC4.3 leaves resolve — and the two hand entries come out of the list. A subtraction class a later schema adds is covered the day the bundled schemas learn it.

The **subtraction** branch only, not the whole `IfcFeatureElement` tree. `IfcProjectionElement` (a corbel, under `IfcFeatureElementAddition`) and `IfcSurfaceFeature` are physical material that occupies space, so a clash against them is a real coordination problem; widening the filter to the parent would hide it. Both are asserted to stay clashable.

## The test

Written against the class of defect this came out of: a test that restates the table it guards can only ever confirm the copy. So the expectation is derived from the schema registry in both directions — everything the registry calls a subtraction feature must be filtered, everything filtered must be real — with

- a **named required-entity list** rather than a count floor (a floor reds on benign schema growth and stays silent in the case that matters),
- an anti-vacuity guard so an empty derivation cannot report success over a region it never examined,
- a control fixture of real building elements, without which a predicate answering `true` unconditionally would pass every other assertion.

GREEN: `pnpm exec turbo run test --filter=@ifc-lite/clash` → 33 files, 450 passed, 1 skipped. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)