### PR TITLE
fix(ids): four measures mapped to an XSD type their EXPRESS base contradicts (#3267)

### DIFF
--- a/.changeset/ids-measure-xsd-express-base.md
+++ b/.changeset/ids-measure-xsd-express-base.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/ids": patch
+---
+
+An IDS property facet on an `IfcDescriptiveMeasure` property can pass again.
+`ifcMeasureToXsdTypes` decides which XSD types an IDS literal must cast under
+before the value comparison runs, and it reached that answer through a
+`*MEASURE` / `*RATIO` suffix heuristic. `IfcDescriptiveMeasure` ends in
+`MEASURE` but is `TYPE IfcDescriptiveMeasure = STRING;` in both IFC4 and
+IFC4X3 — the descriptive-text member of `IfcMeasureValue` — so its literal was
+run through a numeric cast that any descriptive text fails, and the facet
+reported a mismatch even when the stored value equalled the requested one
+character for character.
+
+Three more measures disagreed with their EXPRESS base in the other direction:
+`IfcIntegerCountRateMeasure` is `INTEGER`, not `REAL`, so the gate accepted
+`3.0`; `IfcParameterValue` (`REAL`) and `IfcPositiveInteger` (`INTEGER`) end in
+neither suffix and so got no cast gate at all. All four are now named
+explicitly, and a test re-derives the expectation for every measure the
+`IfcValue` SELECT can reach directly from the EXPRESS schemas, so the table
+cannot drift from them again.

--- a/packages/ids/src/constraints/xsd-cast-express.test.ts
+++ b/packages/ids/src/constraints/xsd-cast-express.test.ts
@@ -1,0 +1,197 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Derives the IFC-measure → XSD-type expectation from the EXPRESS
+ * schemas instead of hand-copying it, so the mapping in `xsd-cast.ts`
+ * cannot silently drift from `TYPE <name> = <base>;`.
+ *
+ * `IfcTimeStamp` was mapped to `xs:duration` though it is `INTEGER` in
+ * every schema — an IDS property facet on it could never pass. A
+ * hand-written table cannot notice that; a re-derivation can.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ifcMeasureToXsdTypes } from './xsd-cast.js';
+
+const SCHEMA_FILES = ['IFC4_ADD2_TC1.exp', 'IFC4X3.exp'] as const;
+
+// Vitest runs with `packages/ids` as the working directory. `import.meta.url`
+// is not usable here: Vite serves the module under a `/@fs` prefix, so a URL
+// relative to it resolves to a path that does not exist on disk.
+const SCHEMA_DIR = resolve(process.cwd(), '../codegen/schemas');
+
+function schemaText(name: string): string {
+  return readFileSync(resolve(SCHEMA_DIR, name), 'utf8');
+}
+
+/** `TYPE IfcFoo = REAL;` → `{ IFCFOO: 'REAL' }`, per schema file. */
+function parseDefinedTypes(text: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const re = /^\s*TYPE\s+(\w+)\s*=\s*([\s\S]*?);/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    out.set(m[1]!.toUpperCase(), m[2]!.trim().split(/\s+/)[0]!.toUpperCase());
+  }
+  return out;
+}
+
+/**
+ * A defined type may be declared over another defined type —
+ * `TYPE IfcPositiveInteger = IfcInteger;` — so follow the chain down to
+ * the EXPRESS primitive. Bounded so a malformed schema cannot spin.
+ */
+function resolveBase(types: Map<string, string>, name: string): string | undefined {
+  let base = types.get(name);
+  for (let hops = 0; base !== undefined && types.has(base) && hops < 16; hops++) {
+    base = types.get(base);
+  }
+  return base;
+}
+
+/** Members of `TYPE <sel> = SELECT (...);`, upper-cased. */
+function selectMembers(text: string, sel: string): string[] {
+  const m = new RegExp(`TYPE\\s+${sel}\\s*=\\s*SELECT\\s*\\(([\\s\\S]*?)\\)\\s*;`, 'i').exec(
+    text
+  );
+  if (!m) return [];
+  return m[1]!
+    .split(',')
+    .map((n) => n.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+/**
+ * Measures whose XSD mapping is deliberately NOT the EXPRESS base:
+ * IFC stores these as `STRING`, but their lexical space is ISO-8601 and
+ * the IDS specification maps them to the corresponding XSD date types.
+ */
+const LEXICAL_OVERRIDES: Record<string, readonly string[]> = {
+  IFCDATE: ['xs:date'],
+  IFCDATETIME: ['xs:dateTime'],
+  IFCDURATION: ['xs:duration'],
+};
+
+/**
+ * `IfcCountMeasure` is `NUMBER` in IFC4 but `INTEGER` in IFC4X3, and the
+ * mapping carries no schema version, so no single answer agrees with
+ * both. It keeps the stricter `xs:integer`; this test does not police it.
+ */
+const SCHEMA_DIVERGENT = new Set(['IFCCOUNTMEASURE']);
+
+/**
+ * `IfcTimeStamp` (`INTEGER`, mapped to `xs:duration`) is corrected by a
+ * separate change already in review for #3250. It is excluded here only
+ * so the two do not collide in the same lines; delete this set once
+ * that lands and the sweep below covers it like every other measure.
+ */
+const PENDING_ELSEWHERE = new Set(['IFCTIMESTAMP']);
+
+function expectedFor(name: string, base: string): readonly string[] | null {
+  if (name in LEXICAL_OVERRIDES) return LEXICAL_OVERRIDES[name]!;
+  switch (base) {
+    case 'INTEGER':
+      return ['xs:integer'];
+    case 'REAL':
+    case 'NUMBER':
+      return ['xs:double'];
+    case 'BOOLEAN':
+      return ['xs:boolean'];
+    case 'LOGICAL':
+      return ['xs:boolean', 'xs:string'];
+    case 'STRING':
+      return ['xs:string'];
+    default:
+      // SELECT / ENUMERATION / ARRAY / BINARY — not a scalar literal.
+      return null;
+  }
+}
+
+/**
+ * The value space an IFC property can actually carry: the closure of the
+ * `IfcValue` SELECT. A measure outside it is unreachable by the property
+ * facet, so a mapping gap there would be inert.
+ */
+function reachableMeasures(): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const file of SCHEMA_FILES) {
+    const text = schemaText(file);
+    const types = parseDefinedTypes(text);
+    for (const sel of ['IfcMeasureValue', 'IfcSimpleValue', 'IfcDerivedMeasureValue']) {
+      for (const member of selectMembers(text, sel)) {
+        const base = resolveBase(types, member);
+        if (base) out.set(member, base);
+      }
+    }
+  }
+  return out;
+}
+
+describe('ifcMeasureToXsdTypes vs the EXPRESS schemas', () => {
+  const measures = reachableMeasures();
+
+  it('reaches the schemas and derives the IfcValue closure', () => {
+    // Anti-vacuity: a silent parse failure would make every assertion
+    // below trivially true. Name what MUST be there, in each branch of
+    // the SELECT, rather than trusting a count floor.
+    for (const [name, base] of [
+      ['IFCLENGTHMEASURE', 'REAL'], // IfcMeasureValue
+      ['IFCDESCRIPTIVEMEASURE', 'STRING'], // IfcMeasureValue, non-numeric
+      ['IFCINTEGER', 'INTEGER'], // IfcSimpleValue
+      ['IFCTIMESTAMP', 'INTEGER'], // IfcSimpleValue, the #3250 shape
+      ['IFCPARAMETERVALUE', 'REAL'], // IfcMeasureValue, no MEASURE suffix
+      ['IFCPOSITIVEINTEGER', 'INTEGER'], // IfcSimpleValue, no suffix
+      ['IFCINTEGERCOUNTRATEMEASURE', 'INTEGER'], // IfcDerivedMeasureValue
+      ['IFCTHERMALTRANSMITTANCEMEASURE', 'REAL'], // IfcDerivedMeasureValue
+    ] as const) {
+      expect(measures.get(name), `${name} missing from derived closure`).toBe(base);
+    }
+  });
+
+  it('maps every reachable scalar measure to the XSD types its EXPRESS base implies', () => {
+    const disagreements: string[] = [];
+    for (const [name, base] of [...measures].sort()) {
+      if (SCHEMA_DIVERGENT.has(name) || PENDING_ELSEWHERE.has(name)) continue;
+      const expected = expectedFor(name, base);
+      if (expected === null) continue;
+      const actual = [...ifcMeasureToXsdTypes(name)];
+      if (actual.length === 0) {
+        disagreements.push(`${name} (EXPRESS ${base}): no cast gate at all`);
+        continue;
+      }
+      if ([...actual].sort().join(',') !== [...expected].sort().join(',')) {
+        disagreements.push(
+          `${name} (EXPRESS ${base}): got [${actual}], expected [${expected}]`
+        );
+      }
+    }
+    expect(disagreements).toEqual([]);
+  });
+
+  it('the derivation can fail — a deliberately wrong mapping is caught', () => {
+    // Negative control: the check above only means something if the
+    // comparison it performs actually rejects a contradicting answer.
+    expect(expectedFor('IFCDESCRIPTIVEMEASURE', 'STRING')).toEqual(['xs:string']);
+    expect(expectedFor('IFCTIMESTAMP', 'INTEGER')).not.toEqual(['xs:duration']);
+    expect(expectedFor('IFCINTEGERCOUNTRATEMEASURE', 'INTEGER')).not.toEqual(['xs:double']);
+  });
+});
+
+describe('the corrected measures, through the cast gate', () => {
+  it('accepts a descriptive text literal for IfcDescriptiveMeasure', () => {
+    expect(ifcMeasureToXsdTypes('IFCDESCRIPTIVEMEASURE')).toEqual(['xs:string']);
+  });
+
+  it('rejects a decimal literal for IfcIntegerCountRateMeasure, accepts an integer', () => {
+    expect(ifcMeasureToXsdTypes('IFCINTEGERCOUNTRATEMEASURE')).toEqual(['xs:integer']);
+  });
+
+  it('still gates the measures that were already correct', () => {
+    expect(ifcMeasureToXsdTypes('IFCLENGTHMEASURE')).toEqual(['xs:double']);
+    expect(ifcMeasureToXsdTypes('IFCBOOLEAN')).toEqual(['xs:boolean']);
+    expect(ifcMeasureToXsdTypes('IFCLABEL')).toEqual(['xs:string']);
+    expect(ifcMeasureToXsdTypes('IFCDATE')).toEqual(['xs:date']);
+  });
+});

--- a/packages/ids/src/constraints/xsd-cast.ts
+++ b/packages/ids/src/constraints/xsd-cast.ts
@@ -114,9 +114,38 @@ export function isBooleanXsdBase(base: string | undefined): boolean {
   return baseLocalName(base) === 'boolean';
 }
 
+/**
+ * Measures whose EXPRESS base contradicts the `*MEASURE` / `*RATIO`
+ * suffix heuristic below, or that the heuristic does not reach at all.
+ * Derived from `TYPE <name> = <base>;` in
+ * `packages/codegen/schemas/IFC4_ADD2_TC1.exp` and `IFC4X3.exp`, over
+ * the closure of the `IfcValue` SELECT (the value space an IFC property
+ * can actually carry); `xsd-cast-express.test.ts` re-derives that diff
+ * and fails if this table drifts from the schemas.
+ *
+ * - `IfcDescriptiveMeasure` is `STRING`, not a number, despite the name.
+ * - `IfcIntegerCountRateMeasure` is `INTEGER`, not `REAL`.
+ * - `IfcParameterValue` (`REAL`) and `IfcPositiveInteger` (`INTEGER`)
+ *   end in neither suffix, so they previously got no cast gate at all.
+ * - `IfcTime` and `IfcUriReference` are `STRING`. `xs:string` accepts
+ *   every literal, so naming them changes no verdict; they are listed
+ *   so the re-derivation covers the whole reachable value space rather
+ *   than carrying a second exception list of its own.
+ */
+const MEASURE_XSD_OVERRIDES: ReadonlyMap<string, readonly string[]> = new Map([
+  ['IFCDESCRIPTIVEMEASURE', ['xs:string']],
+  ['IFCINTEGERCOUNTRATEMEASURE', ['xs:integer']],
+  ['IFCPARAMETERVALUE', ['xs:double']],
+  ['IFCPOSITIVEINTEGER', ['xs:integer']],
+  ['IFCTIME', ['xs:string']],
+  ['IFCURIREFERENCE', ['xs:string']],
+]);
+
 export function ifcMeasureToXsdTypes(measure: string | undefined): readonly string[] {
   if (!measure) return [];
   const m = measure.toUpperCase();
+  const override = MEASURE_XSD_OVERRIDES.get(m);
+  if (override) return override;
   if (m === 'IFCINTEGER' || m === 'IFCCOUNTMEASURE') return ['xs:integer'];
   if (m === 'IFCBOOLEAN') return ['xs:boolean'];
   if (m === 'IFCLOGICAL') return ['xs:boolean', 'xs:string'];

--- a/packages/ids/src/facets/facets.test.ts
+++ b/packages/ids/src/facets/facets.test.ts
@@ -447,6 +447,79 @@ describe('checkAttributeFacet — XSD strict-cast gate', () => {
 });
 
 // ============================================================================
+// Property Facet — strict XSD-cast gate against the EXPRESS base
+// ============================================================================
+
+describe('checkPropertyFacet — XSD strict-cast gate follows the EXPRESS base', () => {
+  const accessor = createMockAccessor([
+    {
+      expressId: 1,
+      type: 'IfcWall',
+      properties: [
+        {
+          psetName: 'Pset_Custom',
+          propName: 'Roughness',
+          value: 'Rough',
+          dataType: 'IFCDESCRIPTIVEMEASURE',
+        },
+        {
+          psetName: 'Pset_Custom',
+          propName: 'Rate',
+          value: 3,
+          dataType: 'IFCINTEGERCOUNTRATEMEASURE',
+        },
+        {
+          psetName: 'Pset_Custom',
+          propName: 'Ratio',
+          value: 0.5,
+          dataType: 'IFCPARAMETERVALUE',
+        },
+      ],
+    },
+  ]);
+
+  const check = (propName: string, literal: string) =>
+    checkPropertyFacet(
+      {
+        type: 'property',
+        propertySet: sv('Pset_Custom'),
+        baseName: sv(propName),
+        value: sv(literal),
+      },
+      1,
+      accessor
+    );
+
+  it('accepts a text literal for IfcDescriptiveMeasure — EXPRESS says STRING', () => {
+    // `IfcDescriptiveMeasure` ends in `MEASURE` but is `TYPE
+    // IfcDescriptiveMeasure = STRING;`. Gating it as `xs:double` made a
+    // matching text value report as a failure — a false FAIL.
+    expect(check('Roughness', 'Rough').passed).toBe(true);
+  });
+
+  it('still fails IfcDescriptiveMeasure when the text genuinely differs', () => {
+    // Negative control: the fix must not turn the gate into a blanket pass.
+    const result = check('Roughness', 'Smooth');
+    expect(result.passed).toBe(false);
+    expect(result.failure?.type).toBe('PROPERTY_VALUE_MISMATCH');
+  });
+
+  it('rejects a decimal literal for IfcIntegerCountRateMeasure — EXPRESS says INTEGER', () => {
+    expect(check('Rate', '3.0').passed).toBe(false);
+  });
+
+  it('accepts an integer literal for IfcIntegerCountRateMeasure', () => {
+    expect(check('Rate', '3').passed).toBe(true);
+  });
+
+  it('gates IfcParameterValue, which the MEASURE/RATIO suffix rule never reached', () => {
+    expect(check('Ratio', '0.5').passed).toBe(true);
+    expect(check('Ratio', 'half').passed).toBe(false);
+  });
+});
+
+
+// ============================================================================
 // Property Facet
 // ============================================================================
 


### PR DESCRIPTION
`Refs #3267`

## What was wrong

`ifcMeasureToXsdTypes` (`packages/ids/src/constraints/xsd-cast.ts`) decides which
XSD types an IDS literal must cast under before `checkPropertyFacet` compares
values. It answered through a suffix heuristic — `m.endsWith('MEASURE') ||
m.endsWith('RATIO')` → `xs:double` — plus a hand-written list. Diffing that
mapping mechanically against `TYPE <name> = <base>;` in
`packages/codegen/schemas/IFC4_ADD2_TC1.exp` and `IFC4X3.exp`, over the 109
measures reachable from the `IfcValue` SELECT, found four disagreements:

| measure | EXPRESS base | was | now | effect |
| --- | --- | --- | --- | --- |
| `IfcDescriptiveMeasure` | `STRING` | `xs:double` | `xs:string` | **false FAIL** |
| `IfcIntegerCountRateMeasure` | `INTEGER` | `xs:double` | `xs:integer` | false PASS |
| `IfcParameterValue` | `REAL` | *(no gate)* | `xs:double` | no gate |
| `IfcPositiveInteger` | `INTEGER` | *(no gate)* | `xs:integer` | no gate |

`IfcDescriptiveMeasure` is the one a user sees. It ends in `MEASURE` but is the
descriptive-text member of `IfcMeasureValue`, so gating its literal as
`xs:double` ran text through a numeric cast it can never survive — the facet
returned `passed: false` for a property whose stored value equalled the requested
one character for character. No IDS property facet on a descriptive measure could
pass.

## RED, on `upstream/main` (08cbf72db)

With the override lookup removed, the two new facet-level tests fail:

```
FAIL src/facets/facets.test.ts > checkPropertyFacet — XSD strict-cast gate follows the EXPRESS base > accepts a text literal for IfcDescriptiveMeasure — EXPRESS says STRING
AssertionError: expected false to be true // Object.is equality

FAIL src/facets/facets.test.ts > checkPropertyFacet — XSD strict-cast gate follows the EXPRESS base > rejects a decimal literal for IfcIntegerCountRateMeasure — EXPRESS says INTEGER
AssertionError: expected true to be false // Object.is equality
```

and the derived sweep reports the whole set at once:

```
FAIL src/constraints/xsd-cast-express.test.ts > ifcMeasureToXsdTypes vs the EXPRESS schemas > maps every reachable scalar measure to the XSD types its EXPRESS base implies
AssertionError: expected [ …(6) ] to deeply equal []
+   "IFCDESCRIPTIVEMEASURE (EXPRESS STRING): got [xs:double], expected [xs:string]",
+   "IFCINTEGERCOUNTRATEMEASURE (EXPRESS INTEGER): got [xs:double], expected [xs:integer]",
+   "IFCPARAMETERVALUE (EXPRESS REAL): no cast gate at all",
+   "IFCPOSITIVEINTEGER (EXPRESS INTEGER): no cast gate at all",
+   "IFCTIME (EXPRESS STRING): no cast gate at all",
+   "IFCURIREFERENCE (EXPRESS STRING): no cast gate at all",
```

## GREEN

```
Test Files  21 passed (21)
     Tests  766 passed (766)
```

## How the table is kept honest

Rather than hand-copy a second list into a test, `xsd-cast-express.test.ts`
re-derives the expectation: it parses `TYPE ... = ...;` out of both `.exp` files,
follows defined-type chains down to the EXPRESS primitive
(`TYPE IfcPositiveInteger = IfcInteger;` needs one hop), walks the closure of
`IfcValue`, and asserts the mapping agrees for every reachable scalar measure.

- **Anti-vacuity guard**: a named list of measures that must appear in the derived
  closure, one from each branch of the SELECT, rather than a count floor. It fired
  during development and caught `IfcPositiveInteger` resolving to `IFCINTEGER`
  instead of `INTEGER` — the sweep had been passing only because the unresolved
  base fell through to "not a scalar".
- **Negative control**: asserts the derivation rejects the contradicting answers,
  so the comparison is known to be capable of failing.
- **Both directions at the facet level**: `IfcDescriptiveMeasure` now passes for a
  matching text value *and still fails* for `'Smooth'` against a stored `'Rough'`;
  `IfcIntegerCountRateMeasure` accepts `3` and rejects `3.0`.

## Deliberately not changed

- `IfcDate` / `IfcDateTime` / `IfcDuration` are `STRING` in EXPRESS, but their
  lexical space is ISO-8601 and the IDS specification maps them to the XSD date
  types. The existing mapping is correct; the test documents them as exceptions.
- `IfcCountMeasure` is `NUMBER` in IFC4 and `INTEGER` in IFC4X3. The mapping
  carries no schema version, so no single answer agrees with both; it keeps the
  stricter `xs:integer` and the test excludes it with that reason stated.
- `IfcTime` and `IfcUriReference` are named as `xs:string` only so the sweep covers
  the whole reachable space — `xs:string` accepts every literal, so no verdict
  changes.
- `IfcTimeStamp` is the fifth disagreement and is fixed by #3251; it is excluded
  here so the two changes do not collide in the same lines. Once that lands, drop
  the `PENDING_ELSEWHERE` set and the sweep covers it like the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IDS validation for IFC measure types and their corresponding XSD data types.
  * Corrected handling of descriptive text, integer count rates, parameter values, and positive integers.
  * Ensured property facets accept or reject values according to their EXPRESS base types.

* **Tests**
  * Added comprehensive coverage across IFC4 and IFC4X3 schemas for measure-to-XSD mappings and property validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->