### PR TITLE
fix(export): two constrained IfcValue members were missing their WHERE rule (#3268)

### DIFF
--- a/.changeset/constrained-ifc-value-members-ph-heating.md
+++ b/.changeset/constrained-ifc-value-members-ph-heating.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/export": patch
+---
+
+Stop re-declaring an out-of-range property as `IfcPHMeasure` or `IfcHeatingValueMeasure`.
+
+Regenerating a property set writes each property back with the declared type its source line carried, unless the value falls outside that type's EXPRESS WHERE rule. The table of constrained `IfcValue` members listed six of the eight, so `IFCPHMEASURE(99.)` (`WR21 : {0.0 <= SELF <= 14.0}`) and `IFCHEATINGVALUEMEASURE(-5.)` (`WR1 : SELF > 0.`) were emitted as schema-invalid lines. Both now relax to `IFCREAL(...)`, and the drift test derives the constrained set from the bundled EXPRESS schemas instead of guessing it from the member's name.

--- a/packages/export/src/declared-nominal-value-type.test.ts
+++ b/packages/export/src/declared-nominal-value-type.test.ts
@@ -20,6 +20,7 @@
  * is a statement about the predicate rather than about the exporter.
  */
 
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { PropertyValueType } from '@ifc-lite/data';
 import {
@@ -28,6 +29,39 @@ import {
   serializeNominalValue,
 } from './declared-property-type.js';
 import { getSelectDefinedLeaves } from './select-qualification.js';
+
+/** The bundled buildingSMART EXPRESS schemas — the authority on WHERE rules. */
+const SCHEMA_FILES = ['IFC4_ADD2_TC1.exp', 'IFC4X3.exp'] as const;
+
+/**
+ * Every `IfcValue` defined-type leaf whose EXPRESS declaration carries a WHERE
+ * rule, read out of the bundled schemas.
+ *
+ * This is deliberately NOT a test that asserts on the text of its own subject:
+ * the text read here is the buildingSMART schema, the external authority the
+ * table is a transcription OF, and nothing about `declared-property-type.ts` is
+ * read. Asking the question any other way is what let #3268 happen — the
+ * previous version guessed constrained-ness from the member's NAME
+ * (`/Positive|NonNegative|Normalised/`), which is silent about `IfcPHMeasure`
+ * (`{0.0 <= SELF <= 14.0}`) and `IfcHeatingValueMeasure` (`SELF > 0.`).
+ */
+function constrainedIfcValueLeavesFromSchemas(): Set<string> {
+  const leaves = getSelectDefinedLeaves('IfcValue');
+  const constrained = new Set<string>();
+  for (const file of SCHEMA_FILES) {
+    const text = readFileSync(new URL(`../../codegen/schemas/${file}`, import.meta.url), 'utf8');
+    for (const match of text.matchAll(/\bTYPE\s+(\w+)\s*=([\s\S]*?)END_TYPE\s*;/gi)) {
+      const [, name, body] = match;
+      // Only members the serializer can actually reach: an `IfcValue` leaf the
+      // registry resolves to an EXPRESS primitive. `IfcCompoundPlaneAngleMeasure`
+      // is constrained but is a LIST, so it is no leaf here and no token this
+      // module can write.
+      if (!leaves.has(name)) continue;
+      if (/\bWHERE\b/i.test(body)) constrained.add(name);
+    }
+  }
+  return constrained;
+}
 
 describe('the constrained-member table is closed, and its boundaries are the WHERE rules', () => {
   it('the domain boundary is the WHERE rule’s, not a truthiness test', () => {
@@ -63,32 +97,101 @@ describe('the constrained-member table is closed, and its boundaries are the WHE
     // Every entry names a real leaf — a typo would silently gate nothing.
     for (const member of covered) expect(leaves.has(member)).toBe(true);
 
-    // And the registry holds no constrained leaf the table has not heard of.
-    // The name test is a coarse alarm, not the definition of a constraint: it is
-    // used ONLY here, where over-firing costs a human a look at a schema bump
-    // and under-firing is impossible for the naming IFC actually uses. It must
-    // never be moved into the serializer, where the same looseness would decide
-    // a file's contents.
-    const looksConstrained = [...leaves.keys()].filter((name) =>
-      /Positive|NonNegative|Normalised/.test(name),
-    );
-    expect(looksConstrained.length).toBeGreaterThan(0);
-    expect([...looksConstrained].sort()).toEqual([...covered].sort());
+    // And the SCHEMA holds no constrained leaf the table has not heard of.
+    // Derived from the WHERE rules, not from the member's name: a name test is
+    // silent about `IfcPHMeasure` and `IfcHeatingValueMeasure` (#3268).
+    const fromSchemas = constrainedIfcValueLeavesFromSchemas();
+    // Anti-vacuity: a broken parse or a moved schema path would produce an
+    // empty set, and an empty set agrees with an empty table.
+    expect(fromSchemas.size).toBeGreaterThan(0);
+    expect(fromSchemas.has('IfcPHMeasure')).toBe(true);
+    expect(fromSchemas.has('IfcHeatingValueMeasure')).toBe(true);
+    expect([...fromSchemas].sort()).toEqual([...covered].sort());
   });
 
-  it('every constrained member relaxes to an unconstrained IfcValue member', () => {
-    // The fallback is only better than the shape-derived primitive if it exists.
-    // A member whose chain leaves `IfcValue` would return null and quietly drop
-    // to `IFCREAL`, so assert the relaxation lands for all six.
+  it('every constrained member takes its named relaxation, or a valid IFCREAL', () => {
+    // The relaxation target of each member is NAMED, not merely asserted to be
+    // "some unconstrained member": the two whose alias chain leaves `IfcValue`
+    // in one step (`= REAL`) have no ancestor to relax to and must land on the
+    // shape-derived `IFCREAL`, which is still schema-valid. Reading that
+    // outcome as a defect — or the reverse, letting a member that DOES have an
+    // ancestor silently lose its unit semantics — is what a named table
+    // prevents and a generic "not null" check does not.
+    const RELAXES_TO: ReadonlyMap<string, string | null> = new Map([
+      ['IfcPositiveLengthMeasure', 'IfcLengthMeasure'],
+      ['IfcNonNegativeLengthMeasure', 'IfcLengthMeasure'],
+      ['IfcPositiveRatioMeasure', 'IfcRatioMeasure'],
+      ['IfcNormalisedRatioMeasure', 'IfcRatioMeasure'],
+      ['IfcPositivePlaneAngleMeasure', 'IfcPlaneAngleMeasure'],
+      ['IfcPositiveInteger', 'IfcInteger'],
+      ['IfcPHMeasure', null],
+      ['IfcHeatingValueMeasure', null],
+    ]);
+
+    // The table above must name every member and no other — otherwise a member
+    // added to `CONSTRAINED_MEMBERS` could go untested here.
+    expect([...RELAXES_TO.keys()].sort()).toEqual([...CONSTRAINED_IFC_VALUE_MEMBERS].sort());
+
     const leaves = getSelectDefinedLeaves('IfcValue');
-    for (const member of CONSTRAINED_IFC_VALUE_MEMBERS) {
+    for (const [member, expected] of RELAXES_TO) {
       const base = leaves.get(member);
-      const outOfDomain = member === 'IfcPositiveInteger' ? PropertyValueType.Integer : PropertyValueType.Real;
+      const outOfDomain =
+        member === 'IfcPositiveInteger' ? PropertyValueType.Integer : PropertyValueType.Real;
       const relaxed = declaredNominalValueType(-1, outOfDomain, member.toUpperCase());
-      expect(relaxed, `${member} must relax to an unconstrained member`).not.toBeNull();
-      expect(CONSTRAINED_IFC_VALUE_MEMBERS).not.toContain(relaxed);
-      expect(leaves.get(relaxed as string)).toBe(base);
+      expect(relaxed, `${member} relaxation target`).toBe(expected);
+      if (expected !== null) {
+        expect(CONSTRAINED_IFC_VALUE_MEMBERS).not.toContain(expected);
+        expect(leaves.get(expected)).toBe(base);
+      } else {
+        // No ancestor: the emitted token is the shape-derived primitive, and it
+        // must still be a valid `IfcValue` member rather than the member whose
+        // domain the value just violated.
+        const emitted = serializeNominalValue(-1, outOfDomain, member.toUpperCase());
+        expect(emitted).toBe('IFCREAL(-1.)');
+        expect(emitted).not.toContain(member.toUpperCase());
+      }
     }
+  });
+
+  it('a value outside IfcPHMeasure or IfcHeatingValueMeasure is never re-declared as one', () => {
+    // #3268, both directions of each rule, and both ends of the pH range.
+    // `IfcPHMeasure` WHERE WR21 : {0.0 <= SELF <= 14.0}
+    expect(serializeNominalValue(7, PropertyValueType.Real, 'IFCPHMEASURE')).toBe(
+      'IFCPHMEASURE(7.)',
+    );
+    expect(serializeNominalValue(0, PropertyValueType.Real, 'IFCPHMEASURE')).toBe(
+      'IFCPHMEASURE(0.)',
+    );
+    expect(serializeNominalValue(14, PropertyValueType.Real, 'IFCPHMEASURE')).toBe(
+      'IFCPHMEASURE(14.)',
+    );
+    expect(serializeNominalValue(-0.0001, PropertyValueType.Real, 'IFCPHMEASURE')).toBe(
+      'IFCREAL(-0.0001)',
+    );
+    expect(serializeNominalValue(14.0001, PropertyValueType.Real, 'IFCPHMEASURE')).toBe(
+      'IFCREAL(14.0001)',
+    );
+
+    // `IfcHeatingValueMeasure` WHERE WR1 : SELF > 0. — zero is out.
+    expect(serializeNominalValue(1, PropertyValueType.Real, 'IFCHEATINGVALUEMEASURE')).toBe(
+      'IFCHEATINGVALUEMEASURE(1.)',
+    );
+    expect(serializeNominalValue(0, PropertyValueType.Real, 'IFCHEATINGVALUEMEASURE')).toBe(
+      'IFCREAL(0.)',
+    );
+    expect(serializeNominalValue(-5, PropertyValueType.Real, 'IFCHEATINGVALUEMEASURE')).toBe(
+      'IFCREAL(-5.)',
+    );
+
+    // Negative control: an UNCONSTRAINED neighbour over the same base keeps its
+    // token at the same values, so the two assertions above are about the WHERE
+    // rule and not about negative numbers in general.
+    expect(serializeNominalValue(-5, PropertyValueType.Real, 'IFCPOWERMEASURE')).toBe(
+      'IFCPOWERMEASURE(-5.)',
+    );
+    expect(serializeNominalValue(99, PropertyValueType.Real, 'IFCPOWERMEASURE')).toBe(
+      'IFCPOWERMEASURE(99.)',
+    );
   });
 });
 

--- a/packages/export/src/declared-property-type.ts
+++ b/packages/export/src/declared-property-type.ts
@@ -50,7 +50,7 @@
  *    display string in a measure token.
  *
  * 4. **The VALUE must satisfy the member's own EXPRESS domain.** The base is not
- *    the whole type: six `IfcValue` members are CONSTRAINED defined types whose
+ *    the whole type: eight `IfcValue` members are CONSTRAINED defined types whose
  *    WHERE rule narrows the primitive they resolve to. `-1` is a fine REAL and
  *    not a fine `IfcPositiveLengthMeasure`; `2` is a fine REAL and not a fine
  *    `IfcNormalisedRatioMeasure`. Since `setProperty` performs no schema
@@ -60,22 +60,33 @@
  *    a valid `IFCREAL(-1.)`. A gate whose purpose is to stop the exporter
  *    writing a type it cannot justify must not itself write one.
  *
- *    A violating value does not fall all the way back to the shape-derived
- *    primitive. It RELAXES to the nearest ancestor that is itself an `IfcValue`
- *    member over the same base and carries no constraint —
+ *    A violating value RELAXES, where it can, to the nearest ancestor that is
+ *    itself an `IfcValue` member over the same base and carries no constraint —
  *    `IfcPositiveLengthMeasure` → `IfcLengthMeasure` — resolved from the
  *    registry's alias chain, not listed. `IFCLENGTHMEASURE(-1.)` is schema-valid
  *    AND keeps the unit semantics, which is the whole thing #2482 is about;
  *    dropping to `IFCREAL(-1.)` would re-inflict this PR's own defect on exactly
  *    the properties whose value went out of range.
  *
+ *    Two members have no such ancestor: `IfcPHMeasure` and
+ *    `IfcHeatingValueMeasure` are declared directly as `REAL`, so their alias
+ *    chain leaves `IfcValue` in one step. For those the relaxation returns
+ *    `null` and the shape-derived `IFCREAL` is the answer — schema-valid, and
+ *    the only valid one available. The relaxation target of every constrained
+ *    member is named in `declared-nominal-value-type.test.ts`, so which of the
+ *    two outcomes each takes is asserted rather than assumed.
+ *
  *    **Where the constraints come from.** `SCHEMA_REGISTRY.types` is a
  *    `name -> underlying type` alias map (plus STRING widths); the generator
- *    does not carry WHERE rules, so there is nothing to read. The six are
+ *    does not carry WHERE rules, so there is nothing to read. The eight are
  *    therefore written out below, which is tolerable only because the set is
- *    CLOSED and small: they are every constrained member of `IfcValue`'s 106
- *    defined-type leaves, and a test walks the live registry to fail if a schema
- *    bump adds one this table has not heard of. String widths, which the
+ *    CLOSED and small: they are every constrained member of `IfcValue`'s
+ *    defined-type leaves, and a test derives that set from the bundled
+ *    `packages/codegen/schemas/*.exp` — the WHERE rules themselves — to fail if
+ *    a schema bump adds one this table has not heard of. That test used to ask
+ *    the question by NAME (`/Positive|NonNegative|Normalised/`), which is how
+ *    `IfcPHMeasure` and `IfcHeatingValueMeasure` sat outside the table for as
+ *    long as they did (#3268). String widths, which the
  *    registry DOES carry (`IfcLabel: 'STRING(255)'`), are deliberately not
  *    gated: every fallback for a string shape is itself `IFCLABEL` /
  *    `IFCIDENTIFIER`, so rejecting an over-long label would emit the identical
@@ -175,6 +186,16 @@ const CONSTRAINED_MEMBERS: ReadonlyMap<string, (value: number) => boolean> = new
   ['IfcNormalisedRatioMeasure', (v: number) => v >= 0 && v <= 1],
   ['IfcPositivePlaneAngleMeasure', (v: number) => v > 0],
   ['IfcPositiveInteger', (v: number) => v > 0],
+  // The two the name-shaped alarm could not see (#3268). Neither carries
+  // `Positive` / `NonNegative` / `Normalised` in its name, so the drift test
+  // that was supposed to keep this table closed stayed green while the
+  // exporter re-declared `IFCPHMEASURE(99.)` and
+  // `IFCHEATINGVALUEMEASURE(-5.)` — schema-invalid lines that a source file
+  // could never have contained, written by the gate whose whole purpose is to
+  // refuse a type it cannot justify. The drift test now derives the set from
+  // the bundled EXPRESS schemas instead of guessing it from names.
+  ['IfcPHMeasure', (v: number) => v >= 0 && v <= 14],
+  ['IfcHeatingValueMeasure', (v: number) => v > 0],
 ]);
 
 /**


### PR DESCRIPTION
Refs #3268

## The defect

`declared-property-type.ts` gate 4 refuses to re-declare a regenerated property with a CONSTRAINED `IfcValue` member when the value falls outside that member's EXPRESS WHERE rule, relaxing `IFCPOSITIVELENGTHMEASURE(-1.)` to `IFCLENGTHMEASURE(-1.)` instead. The constrained members are a hand-written table of six; two `IfcValue` leaves were absent from it, so `CONSTRAINED_MEMBERS.get(name)` missed and the gate silently concluded "unconstrained".

| member | WHERE rule | in table before |
|---|---|---|
| `IfcPHMeasure` | `WR21 : {0.0 <= SELF <= 14.0}` | no |
| `IfcHeatingValueMeasure` | `WR1 : SELF > 0.` | no |

Both are `= REAL` defined types reachable through `IfcValue → IfcDerivedMeasureValue`, present in the live registry, and identical in IFC4 ADD2 TC1 and IFC4X3.

## Before

Observed on `2d5aea091` (`serializeNominalValue(v, PropertyValueType.Real, dataType)`):

```
pH 99   -> IFCPHMEASURE(99.)
pH -3   -> IFCPHMEASURE(-3.)
heat -5 -> IFCHEATINGVALUEMEASURE(-5.)
heat 0  -> IFCHEATINGVALUEMEASURE(0.)
poslen -1 (covered) -> IFCLENGTHMEASURE(-1.)
```

Four schema-invalid lines, written by the exporter itself — no source file could have contained them — from the gate whose stated purpose is that it "must not itself write" a type it cannot justify.

## After

```
IFCREAL(99.)   IFCREAL(-3.)   IFCREAL(-5.)   IFCREAL(0.)
```

and in range, unchanged: `IFCPHMEASURE(0.)`, `IFCPHMEASURE(7.)`, `IFCPHMEASURE(14.)`, `IFCHEATINGVALUEMEASURE(1.)`.

Neither member has an unconstrained `IfcValue` ancestor over the same base — both are declared directly `= REAL`, so their alias chain leaves `IfcValue` in one step — so the shape-derived `IFCREAL` is the answer, and it is the only valid one available. That is a different outcome from the other six, and the tests now name which each takes rather than accepting either.

## Why the drift test stayed green

It guessed constrained-ness from the member's NAME:

```ts
const looksConstrained = [...leaves.keys()].filter((name) =>
  /Positive|NonNegative|Normalised/.test(name),
);
```

under a comment stating that "under-firing is impossible for the naming IFC actually uses". `IfcPHMeasure` and `IfcHeatingValueMeasure` are exactly that under-firing, and the heuristic is what let them sit outside the table.

The test now derives the set from the bundled `packages/codegen/schemas/*.exp` — the WHERE rules themselves — intersected with the registry's `IfcValue` defined-type leaves, which is 8 in both bundled schemas. (`IfcCompoundPlaneAngleMeasure` is constrained but is a `LIST OF INTEGER`, so it is not a leaf here and not a token this module can write.)

## Tests

- RED on the parent commit: three assertions failing, with the bytes above printed.
- The closure test now compares against the schema-derived set, with an **anti-vacuity guard** (`fromSchemas.size > 0` plus both new names present) so a moved schema path or a broken parse cannot make an empty set agree with an empty table.
- The relaxation test carries a **named target per member** (`IfcPositiveLengthMeasure → IfcLengthMeasure`, … , `IfcPHMeasure → null`) and asserts that table's key set equals `CONSTRAINED_IFC_VALUE_MEMBERS`, so a member added to the serializer's table cannot go untested here.
- **Both directions of each rule and both ends of the pH range**: `-0.0001` and `14.0001` out, `0` / `7` / `14` in; `0` out for heating value (`> 0.`, not `>= 0.`).
- **Negative control**: `IfcPowerMeasure`, an unconstrained neighbour over the same base, keeps its token at `-5` and `99` — so the assertions above are about the WHERE rule and not about negative or large numbers in general.

`pnpm exec turbo run test --filter=@ifc-lite/export`: 864 passed, 30 skipped. `check-source-text-assertions` and `check-module-size` both OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
