### PR TITLE
fix(export): pad the attributes a newer schema appended in the Rust converter (#3271)

### DIFF
--- a/.changeset/rust-upconvert-attribute-padding.md
+++ b/.changeset/rust-upconvert-attribute-padding.md
@@ -1,0 +1,21 @@
+---
+"@ifc-lite/wasm": patch
+---
+
+Pad the attributes a newer schema appended when the Rust STEP converter upgrades a file.
+
+`convertStepLine` in `packages/export` has padded the trailing optional attributes newer schemas ADD since #1416 — `PredefinedType` on `IfcWall` / `IfcBeam` / `IfcOpeningElement`, `IfcMaterial`'s `Description` and `Category`, and 61 more. Its Rust port never got the fix, and the Rust port is what `exportStep` runs, so `ifc-lite export --format step --schema IFC4` on an IFC2X3 source wrote entities one or more positional attributes short. That is an invalid IFC4 file, and strict readers reject it. Verbatim, before:
+
+```
+#1=IFCWALL('0aBcDeFgHiJkLmNoPqRsTu',$,'W1',$,$,$,$,'tag');
+```
+
+and after:
+
+```
+#1=IFCWALL('0aBcDeFgHiJkLmNoPqRsTu',$,'W1',$,$,$,$,'tag',$);
+```
+
+Padding applies only where the source schema's positional attribute NAME list is a strict PREFIX of the target's — the same restriction the TypeScript half enforces at run time. Entities that reorder or insert mid-list (`IfcMaterialProperties` goes from `[Material]` to `[Name, Description, Properties, Material]`) are left untouched, because a trailing `$` there would shove existing values into the wrong and type-invalid slots.
+
+The two implementations are now pinned to one shared fixture, `rust/export/tests/fixtures/schema_upconvert_sweep.json`, whose rows are derived from the generated buildingSMART attribute tables and which NAMES every padded type rather than counting them — a count floor stays silent exactly when a row is dropped.

--- a/packages/export/src/schema-upconvert-sweep.parity.test.ts
+++ b/packages/export/src/schema-upconvert-sweep.parity.test.ts
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * TypeScript half of the schema-upconversion padding parity pin.
+ *
+ * `convertStepLine` pads the trailing optional attributes a newer target
+ * schema APPENDED (#1416). The Rust port in
+ * `rust/export/src/schema_convert.rs` did not — and it is the Rust one that
+ * `ifc-lite export --format step --schema IFC4` runs, through `exportStep` in
+ * the wasm bindings — so the two halves emitted different files for the same
+ * conversion for two months. Both are now held to ONE fixture; the Rust half
+ * is `rust/export/tests/schema_upconvert_parity.rs`. Follows the
+ * `rooted-type-sweep.parity.test.ts` precedent.
+ *
+ * The fixture's padded rows are DERIVED from
+ * `packages/data/src/ifc-schema/generated/entities-*.ts` (the types whose
+ * source attribute NAME list is a strict prefix of the target's — the same
+ * relation `isStrictAttrPrefix` tests at run time), so this side is not
+ * circular: it pins the answer that generated data implies, and a regenerated
+ * schema that changes a count fails here rather than silently changing what
+ * `ifc-lite` writes.
+ *
+ * WHICH rows the fixture must contain is pinned on the Rust side only
+ * (`fixture_names_every_padded_type`), which re-derives the universe from its
+ * own tables. The count check below is a smoke test, not the coverage gate.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { convertStepLine, type IfcSchemaVersion } from './schema-converter.js';
+
+interface SweepCase {
+  why: string;
+  from: IfcSchemaVersion;
+  to: IfcSchemaVersion;
+  line: string;
+  expect: string;
+}
+
+// The fixture lives in the Rust crate so `include_str!` can reach it; this side
+// resolves it relative to the source file. NOT guarded by `existsSync`: a
+// missing fixture means the pin is not being enforced, which must fail loudly.
+const fixturePath = fileURLToPath(
+  new URL('../../../rust/export/tests/fixtures/schema_upconvert_sweep.json', import.meta.url),
+);
+const fixture: { cases: SweepCase[] } = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+describe('convertStepLine matches the shared cross-language upconversion sweep', () => {
+  it('the fixture is not empty or trivial', () => {
+    expect(fixture.cases.length).toBeGreaterThan(100);
+  });
+
+  it('every case agrees with the Rust converter', () => {
+    const mismatches = fixture.cases
+      .map((c) => ({ c, got: convertStepLine(c.line, c.from, c.to) }))
+      .filter(({ c, got }) => got !== c.expect)
+      .map(({ c, got }) => `${c.from}->${c.to} [${c.why}]\n  in     ${c.line}\n  expect ${c.expect}\n  got    ${got}`);
+    expect(mismatches).toEqual([]);
+  });
+
+  it('a reordered attribute list is never padded (negative control)', () => {
+    // IFC2X3 IfcMaterialProperties is [Material]; IFC4 is
+    // [Name, Description, Properties, Material]. Padding would read #8 as Name.
+    expect(convertStepLine('#7=IFCMATERIALPROPERTIES(#8);', 'IFC2X3', 'IFC4')).toBe(
+      '#7=IFCMATERIALPROPERTIES(#8);',
+    );
+  });
+});

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -39,6 +39,8 @@ mod parquet_bos;
 mod rooms;
 pub mod rooted_type;
 mod schema_convert;
+mod schema_pad;
+pub use schema_pad::padded_type_universe;
 mod shades;
 mod step;
 mod step_cow;

--- a/rust/export/src/schema_convert.rs
+++ b/rust/export/src/schema_convert.rs
@@ -2,7 +2,8 @@
 //! IFC **schema conversion** for STEP export (Phase 2 P2). Ports
 //! `packages/export/src/schema-converter.ts`: entity-type renames between
 //! IFC2X3 / IFC4 / IFC4X3 / IFC5 (with multi-step chaining), IFC2X3 attribute-count
-//! trimming on downgrade, and a proxy fallback for types with no target representation.
+//! trimming on downgrade, padding of the attributes a newer target schema appended
+//! (`schema_pad`), and a proxy fallback for types with no target representation.
 
 /// Canonicalize a FILE_SCHEMA label to one of the four families we convert between.
 fn canon(s: &str) -> &'static str {
@@ -232,7 +233,7 @@ pub fn convert_step_line(line: &str, from: &str, to: &str, express_id: u32) -> S
         );
     }
 
-    let final_attrs = if cto == "IFC2X3" {
+    let mut final_attrs = if cto == "IFC2X3" {
         match ifc2x3_attr_count(&new_type) {
             Some(max) => trim_attributes(attrs, max),
             None => attrs.to_string(),
@@ -240,6 +241,24 @@ pub fn convert_step_line(line: &str, from: &str, to: &str, express_id: u32) -> S
     } else {
         attrs.to_string()
     };
+
+    // Pad the trailing optional attributes a newer target schema APPENDED
+    // (#1416). Keyed on the ORIGINAL type, because the source schema is what
+    // decides how many attributes the line already has; the table's target
+    // count already accounts for the rename. Only types whose source
+    // attribute NAME list is a strict prefix of the target's are in it, so
+    // this can never shift a value into a reordered slot -- see
+    // `schema_pad`. An attribute-less line is left alone rather than
+    // fabricated from nothing, matching the TypeScript twin's
+    // `currentCount > 0` guard.
+    if let Some(target_count) = crate::schema_pad::padded_attr_count(cfrom, cto, &entity_type) {
+        let current = crate::schema_pad::count_top_level_attributes(&final_attrs);
+        if current > 0 && current < target_count {
+            for _ in current..target_count {
+                final_attrs.push_str(",$");
+            }
+        }
+    }
 
     format!("{prefix}{new_type}({final_attrs});")
 }
@@ -250,136 +269,5 @@ pub fn needs_conversion(from: &str, to: &str) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn entity_type_renames() {
-        assert_eq!(convert_entity_type("IFCBURNERTYPE", "IFC4", "IFC2X3"), "IFCGASTERMINALTYPE");
-        assert_eq!(convert_entity_type("IFCCHIMNEY", "IFC4", "IFC2X3"), "IFCBUILDINGELEMENTPROXY");
-        assert_eq!(convert_entity_type("IFCWALL", "IFC2X3", "IFC4"), "IFCWALL"); // unchanged
-        // chained 4X3 → 2X3 (via 4): IfcFacility → IfcBuilding
-        assert_eq!(convert_entity_type("IFCFACILITY", "IFC4X3", "IFC2X3"), "IFCBUILDING");
-    }
-
-    /// The UPGRADE table (`map_2x3_to_4`) had no test in this crate: the only
-    /// 2X3 → 4 case above is `IFCWALL`, a type that is unchanged in every
-    /// schema, so replacing the whole arm with a pass-through left the entire
-    /// `ifc-lite-export` suite green (confirmed by mutation). The TS twin
-    /// `packages/export/src/schema-converter.test.ts` covers this direction;
-    /// the Rust port is what the CLI, server and wasm actually run.
-    ///
-    /// Concretely, un-renamed output is an INVALID file: none of these three
-    /// type names exists in IFC4.
-    #[test]
-    fn ifc2x3_only_types_are_renamed_on_upgrade() {
-        for (from, want) in [
-            ("IFCELECTRICDISTRIBUTIONPOINT", "IFCELECTRICDISTRIBUTIONBOARD"),
-            ("IFCGASTERMINALTYPE", "IFCBURNERTYPE"),
-            ("IFCEQUIPMENTELEMENT", "IFCBUILDINGELEMENTPROXY"),
-        ] {
-            assert_eq!(convert_entity_type(from, "IFC2X3", "IFC4"), want, "2X3 → 4");
-            // 2X3 → 4X3 and 2X3 → 5 route through the same table.
-            assert_eq!(convert_entity_type(from, "IFC2X3", "IFC4X3"), want, "2X3 → 4X3");
-            assert_eq!(convert_entity_type(from, "IFC2X3", "IFC5"), want, "2X3 → 5");
-        }
-    }
-
-    /// The direct `4X3 → 4` arm was only ever reached by types it does NOT
-    /// rename: `entity_type_renames` chains through it on the way to 2X3, and
-    /// `alignment_becomes_proxy_on_downgrade` hits the proxy branch instead.
-    /// Replacing the arm with a pass-through likewise left the suite green.
-    /// `IFC5 → IFC4` shares the arm, so it is pinned here too — nothing else
-    /// in this crate exercises `canon`'s IFC5 branch at all.
-    #[test]
-    fn ifc4x3_and_ifc5_types_are_renamed_down_to_ifc4() {
-        for (from, want) in [
-            ("IFCBRIDGE", "IFCBUILDING"),
-            ("IFCBRIDGEPART", "IFCBUILDINGSTOREY"),
-            ("IFCPAVEMENT", "IFCSLAB"),
-            ("IFCCAISSONFOUNDATION", "IFCFOOTING"),
-            ("IFCDISTRIBUTIONBOARD", "IFCELECTRICDISTRIBUTIONBOARD"),
-        ] {
-            assert_eq!(convert_entity_type(from, "IFC4X3", "IFC4"), want, "4X3 → 4");
-            assert_eq!(convert_entity_type(from, "IFC5", "IFC4"), want, "5 → 4");
-        }
-        // 4 ↔ 4X3 ↔ 5 carry no renames, and IFCX* canonicalizes to IFC5.
-        assert_eq!(convert_entity_type("IFCWALL", "IFC4", "IFC5"), "IFCWALL");
-        assert_eq!(convert_entity_type("IFCBRIDGE", "IFCX", "IFC4"), "IFCBUILDING");
-        assert!(!needs_conversion("IFC5", "IFCX"));
-    }
-
-    #[test]
-    fn downgrade_trims_attributes() {
-        // IfcWall in IFC4 has 9 attrs (trailing PredefinedType); IFC2X3 keeps 8.
-        let line = "#5=IFCWALL('guid',$,'W1',$,$,#6,#7,'tag',.STANDARD.);";
-        let out = convert_step_line(line, "IFC4", "IFC2X3", 5);
-        assert!(out.starts_with("#5=IFCWALL("), "type kept");
-        assert!(!out.contains(".STANDARD."), "9th attr (PredefinedType) trimmed");
-        // 8 top-level attrs remain → 7 commas.
-        let inner = &out["#5=IFCWALL(".len()..out.len() - 2];
-        assert_eq!(inner.split(',').count(), 8, "trimmed to 8 attrs");
-    }
-
-    #[test]
-    fn nested_attrs_not_split_when_trimming() {
-        // Commas inside a nested list must not count as top-level separators.
-        let line = "#9=IFCWALL('g',$,$,$,$,(#1,#2,#3),#7,'t',.STANDARD.);";
-        let out = convert_step_line(line, "IFC4", "IFC2X3", 9);
-        assert!(out.contains("(#1,#2,#3)"), "nested list preserved intact");
-        assert!(!out.contains(".STANDARD."), "trailing attr trimmed");
-    }
-
-    #[test]
-    fn alignment_becomes_proxy_on_downgrade() {
-        let line = "#3=IFCALIGNMENTHORIZONTAL('g',$,$,$,$,#4);";
-        let out = convert_step_line(line, "IFC4X3", "IFC4", 3);
-        assert!(out.starts_with("#3=IFCPROXY("), "alignment → proxy");
-        assert!(out.contains("'IFCALIGNMENTHORIZONTAL'"), "original type recorded as name");
-    }
-
-    /// PINS the schema-downgrade proxy-GlobalId divergence between the two
-    /// exporters (#3015) AS divergence -- it does not fix it. Which side wins
-    /// is a maintainer decision, not something a test should resolve
-    /// unilaterally.
-    ///
-    /// `placeholder_guid` here derives the id purely from the express id
-    /// (`id as u64 + 0x1000_0000`, base64-stamped). The TypeScript twin
-    /// (`convertStepLine` in `packages/export/src/schema-converter.ts`)
-    /// derives it from `deterministicGlobalId` of the WHOLE source line
-    /// (`ifcproxy:{prefix}{entityType}({attrs})`) -- a different algorithm
-    /// entirely, not just a different seed to the same one. Verified by
-    /// actually running both on the byte-identical input line below;
-    /// `packages/export/src/schema-converter.test.ts`'s
-    /// `placeholder_guid_diverges_from_the_rust_mint_pinned_not_fixed` pins
-    /// the TS side of the same pair.
-    ///
-    /// If this test ever starts failing because the values converged, that
-    /// is good news -- update the doc here (and the TS twin) to say so,
-    /// don't just delete the assertion.
-    #[test]
-    fn placeholder_guid_diverges_from_the_typescript_mint_pinned_not_fixed() {
-        let line = "#42=IFCALIGNMENTSEGMENT('2K5H1$Zs9CQuKQFQKQFQKQ',#1,'A',$,$,#7,#9,$);";
-        let out = convert_step_line(line, "IFC4X3", "IFC4", 42);
-        let guid = out.split('\'').nth(1).expect("IFCPROXY line has a quoted GlobalId");
-        assert_eq!(
-            guid, "00000000000000000G000g",
-            "Rust's placeholder_guid(42) output changed -- update this pin (and check whether \
-             it now agrees with the TS twin, in which case update both docs to say so)"
-        );
-        assert_ne!(
-            guid, "3m5OyAyREn46dEymqijDwc",
-            "this is the TS side's minted value for the byte-identical input line -- if Rust \
-             now matches it, the divergence has been resolved; update both tests' docs instead \
-             of silently dropping this assertion"
-        );
-    }
-
-    #[test]
-    fn no_conversion_is_identity() {
-        let line = "#1=IFCWALL('g',$,$);";
-        assert_eq!(convert_step_line(line, "IFC4", "IFC4", 1), line);
-        assert!(!needs_conversion("IFC4", "IFC4"));
-        assert!(needs_conversion("IFC2X3", "IFC4"));
-    }
-}
+#[path = "schema_convert_tests.rs"]
+mod tests;

--- a/rust/export/src/schema_convert_tests.rs
+++ b/rust/export/src/schema_convert_tests.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Tests for [`super::schema_convert`]. Split out of `schema_convert.rs` to
+//! keep that module under the 400-line rule (AGENTS.md), matching the
+//! `schema_helpers.rs` / `schema_helpers_tests.rs` pattern.
+
+use super::*;
+
+#[test]
+fn entity_type_renames() {
+    assert_eq!(convert_entity_type("IFCBURNERTYPE", "IFC4", "IFC2X3"), "IFCGASTERMINALTYPE");
+    assert_eq!(convert_entity_type("IFCCHIMNEY", "IFC4", "IFC2X3"), "IFCBUILDINGELEMENTPROXY");
+    assert_eq!(convert_entity_type("IFCWALL", "IFC2X3", "IFC4"), "IFCWALL"); // unchanged
+    // chained 4X3 → 2X3 (via 4): IfcFacility → IfcBuilding
+    assert_eq!(convert_entity_type("IFCFACILITY", "IFC4X3", "IFC2X3"), "IFCBUILDING");
+}
+
+/// The UPGRADE table (`map_2x3_to_4`) had no test in this crate: the only
+/// 2X3 → 4 case above is `IFCWALL`, a type that is unchanged in every
+/// schema, so replacing the whole arm with a pass-through left the entire
+/// `ifc-lite-export` suite green (confirmed by mutation). The TS twin
+/// `packages/export/src/schema-converter.test.ts` covers this direction;
+/// the Rust port is what the CLI, server and wasm actually run.
+///
+/// Concretely, un-renamed output is an INVALID file: none of these three
+/// type names exists in IFC4.
+#[test]
+fn ifc2x3_only_types_are_renamed_on_upgrade() {
+    for (from, want) in [
+        ("IFCELECTRICDISTRIBUTIONPOINT", "IFCELECTRICDISTRIBUTIONBOARD"),
+        ("IFCGASTERMINALTYPE", "IFCBURNERTYPE"),
+        ("IFCEQUIPMENTELEMENT", "IFCBUILDINGELEMENTPROXY"),
+    ] {
+        assert_eq!(convert_entity_type(from, "IFC2X3", "IFC4"), want, "2X3 → 4");
+        // 2X3 → 4X3 and 2X3 → 5 route through the same table.
+        assert_eq!(convert_entity_type(from, "IFC2X3", "IFC4X3"), want, "2X3 → 4X3");
+        assert_eq!(convert_entity_type(from, "IFC2X3", "IFC5"), want, "2X3 → 5");
+    }
+}
+
+/// The direct `4X3 → 4` arm was only ever reached by types it does NOT
+/// rename: `entity_type_renames` chains through it on the way to 2X3, and
+/// `alignment_becomes_proxy_on_downgrade` hits the proxy branch instead.
+/// Replacing the arm with a pass-through likewise left the suite green.
+/// `IFC5 → IFC4` shares the arm, so it is pinned here too — nothing else
+/// in this crate exercises `canon`'s IFC5 branch at all.
+#[test]
+fn ifc4x3_and_ifc5_types_are_renamed_down_to_ifc4() {
+    for (from, want) in [
+        ("IFCBRIDGE", "IFCBUILDING"),
+        ("IFCBRIDGEPART", "IFCBUILDINGSTOREY"),
+        ("IFCPAVEMENT", "IFCSLAB"),
+        ("IFCCAISSONFOUNDATION", "IFCFOOTING"),
+        ("IFCDISTRIBUTIONBOARD", "IFCELECTRICDISTRIBUTIONBOARD"),
+    ] {
+        assert_eq!(convert_entity_type(from, "IFC4X3", "IFC4"), want, "4X3 → 4");
+        assert_eq!(convert_entity_type(from, "IFC5", "IFC4"), want, "5 → 4");
+    }
+    // 4 ↔ 4X3 ↔ 5 carry no renames, and IFCX* canonicalizes to IFC5.
+    assert_eq!(convert_entity_type("IFCWALL", "IFC4", "IFC5"), "IFCWALL");
+    assert_eq!(convert_entity_type("IFCBRIDGE", "IFCX", "IFC4"), "IFCBUILDING");
+    assert!(!needs_conversion("IFC5", "IFCX"));
+}
+
+#[test]
+fn downgrade_trims_attributes() {
+    // IfcWall in IFC4 has 9 attrs (trailing PredefinedType); IFC2X3 keeps 8.
+    let line = "#5=IFCWALL('guid',$,'W1',$,$,#6,#7,'tag',.STANDARD.);";
+    let out = convert_step_line(line, "IFC4", "IFC2X3", 5);
+    assert!(out.starts_with("#5=IFCWALL("), "type kept");
+    assert!(!out.contains(".STANDARD."), "9th attr (PredefinedType) trimmed");
+    // 8 top-level attrs remain → 7 commas.
+    let inner = &out["#5=IFCWALL(".len()..out.len() - 2];
+    assert_eq!(inner.split(',').count(), 8, "trimmed to 8 attrs");
+}
+
+#[test]
+fn nested_attrs_not_split_when_trimming() {
+    // Commas inside a nested list must not count as top-level separators.
+    let line = "#9=IFCWALL('g',$,$,$,$,(#1,#2,#3),#7,'t',.STANDARD.);";
+    let out = convert_step_line(line, "IFC4", "IFC2X3", 9);
+    assert!(out.contains("(#1,#2,#3)"), "nested list preserved intact");
+    assert!(!out.contains(".STANDARD."), "trailing attr trimmed");
+}
+
+#[test]
+fn alignment_becomes_proxy_on_downgrade() {
+    let line = "#3=IFCALIGNMENTHORIZONTAL('g',$,$,$,$,#4);";
+    let out = convert_step_line(line, "IFC4X3", "IFC4", 3);
+    assert!(out.starts_with("#3=IFCPROXY("), "alignment → proxy");
+    assert!(out.contains("'IFCALIGNMENTHORIZONTAL'"), "original type recorded as name");
+}
+
+/// PINS the schema-downgrade proxy-GlobalId divergence between the two
+/// exporters (#3015) AS divergence -- it does not fix it. Which side wins
+/// is a maintainer decision, not something a test should resolve
+/// unilaterally.
+///
+/// `placeholder_guid` here derives the id purely from the express id
+/// (`id as u64 + 0x1000_0000`, base64-stamped). The TypeScript twin
+/// (`convertStepLine` in `packages/export/src/schema-converter.ts`)
+/// derives it from `deterministicGlobalId` of the WHOLE source line
+/// (`ifcproxy:{prefix}{entityType}({attrs})`) -- a different algorithm
+/// entirely, not just a different seed to the same one. Verified by
+/// actually running both on the byte-identical input line below;
+/// `packages/export/src/schema-converter.test.ts`'s
+/// `placeholder_guid_diverges_from_the_rust_mint_pinned_not_fixed` pins
+/// the TS side of the same pair.
+///
+/// If this test ever starts failing because the values converged, that
+/// is good news -- update the doc here (and the TS twin) to say so,
+/// don't just delete the assertion.
+#[test]
+fn placeholder_guid_diverges_from_the_typescript_mint_pinned_not_fixed() {
+    let line = "#42=IFCALIGNMENTSEGMENT('2K5H1$Zs9CQuKQFQKQFQKQ',#1,'A',$,$,#7,#9,$);";
+    let out = convert_step_line(line, "IFC4X3", "IFC4", 42);
+    let guid = out.split('\'').nth(1).expect("IFCPROXY line has a quoted GlobalId");
+    assert_eq!(
+        guid, "00000000000000000G000g",
+        "Rust's placeholder_guid(42) output changed -- update this pin (and check whether \
+         it now agrees with the TS twin, in which case update both docs to say so)"
+    );
+    assert_ne!(
+        guid, "3m5OyAyREn46dEymqijDwc",
+        "this is the TS side's minted value for the byte-identical input line -- if Rust \
+         now matches it, the divergence has been resolved; update both tests' docs instead \
+         of silently dropping this assertion"
+    );
+}
+
+#[test]
+fn no_conversion_is_identity() {
+    let line = "#1=IFCWALL('g',$,$);";
+    assert_eq!(convert_step_line(line, "IFC4", "IFC4", 1), line);
+    assert!(!needs_conversion("IFC4", "IFC4"));
+    assert!(needs_conversion("IFC2X3", "IFC4"));
+}

--- a/rust/export/src/schema_pad.rs
+++ b/rust/export/src/schema_pad.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Upconversion attribute PADDING for STEP schema conversion — the half of
+//! `schema_convert` that a newer target schema's APPENDED attributes need.
+//!
+//! `schema_convert` trims trailing attributes when downgrading but, until
+//! this module, never padded the ones newer schemas added (`PredefinedType`
+//! on `IfcWall` / `IfcBeam` / `IfcOpeningElement` / …, `IfcMaterial`'s
+//! `Description` + `Category`, …). An upgraded entity was then a positional
+//! attribute short, which is an INVALID file that strict readers reject.
+//! That is #1416, fixed in the TypeScript twin
+//! (`packages/export/src/schema-converter.ts`) and never ported here — while
+//! `ifc-lite export --format step --schema IFC4` runs THIS code, through
+//! `exportStep` in the wasm bindings.
+//!
+//! Padding is only safe when the target schema APPENDED: many entities
+//! insert or reorder attributes mid-list (`IfcMaterialProperties` goes from
+//! `[Material]` to `[Name, Description, Properties, Material]`), where a
+//! trailing `$` shoves the existing values into the wrong — and
+//! type-invalid — slots. So the tables below carry exactly the source types
+//! whose positional attribute NAME list is a strict PREFIX of the target's,
+//! which is the same `isStrictAttrPrefix` test the TypeScript twin applies at
+//! run time against `ENTITIES_IFC2X3` / `ENTITIES_IFC4` / `ENTITIES_IFC4X3`.
+//!
+//! Rust has no per-schema attribute table to test that against: the generated
+//! `ifc_lite_core::IfcType` is IFC4X3 alone and carries no IFC2X3 or IFC4
+//! list. The tables are therefore DERIVED from the same generated
+//! buildingSMART tables the TypeScript side reads, and neither side is
+//! trusted to have stayed in step: `rust/export/tests/schema_upconvert_parity.rs`
+//! and `packages/export/src/schema-upconvert-sweep.parity.test.ts` run both
+//! implementations over the one shared fixture
+//! (`rust/export/tests/fixtures/schema_upconvert_sweep.json`), which names
+//! every padded type rather than counting them.
+//!
+//! IFC5 is deliberately absent. The TypeScript twin has no generated table
+//! for it and skips the count adjustment entirely, so upgrading to IFC5 pads
+//! nothing here either.
+
+/// `IFC2X3` -> `IFC4`: 64 source types whose attribute list the target
+/// schema EXTENDS by appending. `(SOURCE TYPE, target positional count)`,
+/// sorted for binary search.
+static PAD_2X3_TO_4: &[(&str, usize)] = &[
+    ("IFCAPPLIEDVALUE", 10),
+    ("IFCBEAM", 9),
+    ("IFCBUILDINGELEMENTPART", 9),
+    ("IFCCLASSIFICATION", 7),
+    ("IFCCOLUMN", 9),
+    ("IFCCONTROL", 6),
+    ("IFCCOSTITEM", 9),
+    ("IFCCURTAINWALL", 9),
+    ("IFCCURVESTYLE", 5),
+    ("IFCDISCRETEACCESSORY", 9),
+    ("IFCDISCRETEACCESSORYTYPE", 10),
+    ("IFCDISTRIBUTIONCHAMBERELEMENT", 9),
+    ("IFCDISTRIBUTIONPORT", 10),
+    ("IFCDOOR", 13),
+    ("IFCDOORLININGPROPERTIES", 17),
+    ("IFCEQUIPMENTELEMENT", 9),
+    ("IFCFASTENER", 9),
+    ("IFCFASTENERTYPE", 10),
+    ("IFCFILLAREASTYLE", 3),
+    ("IFCFURNITURETYPE", 11),
+    ("IFCGRID", 11),
+    ("IFCISHAPEPROFILEDEF", 10),
+    ("IFCMATERIAL", 3),
+    ("IFCMATERIALLAYER", 7),
+    ("IFCMATERIALLAYERSET", 3),
+    ("IFCMATERIALLAYERSETUSAGE", 5),
+    ("IFCMECHANICALFASTENER", 11),
+    ("IFCMECHANICALFASTENERTYPE", 12),
+    ("IFCMEMBER", 9),
+    ("IFCMETRIC", 11),
+    ("IFCOPENINGELEMENT", 9),
+    ("IFCPLATE", 9),
+    ("IFCPROCESS", 7),
+    ("IFCPROJECTIONELEMENT", 9),
+    ("IFCPROPERTYBOUNDEDVALUE", 6),
+    ("IFCPROPERTYTABLEVALUE", 8),
+    ("IFCQUANTITYAREA", 5),
+    ("IFCQUANTITYCOUNT", 5),
+    ("IFCQUANTITYLENGTH", 5),
+    ("IFCQUANTITYTIME", 5),
+    ("IFCQUANTITYVOLUME", 5),
+    ("IFCQUANTITYWEIGHT", 5),
+    ("IFCRAMPFLIGHT", 9),
+    ("IFCREINFORCINGMESH", 18),
+    ("IFCRELSEQUENCE", 9),
+    ("IFCRESOURCE", 7),
+    ("IFCSPACETYPE", 11),
+    ("IFCSTRUCTURALANALYSISMODEL", 10),
+    ("IFCSTRUCTURALCURVECONNECTION", 9),
+    ("IFCSTRUCTURALCURVEMEMBER", 9),
+    ("IFCSTRUCTURALCURVEMEMBERVARYING", 9),
+    ("IFCSTRUCTURALPOINTCONNECTION", 9),
+    ("IFCSURFACESTYLESHADING", 2),
+    ("IFCSYSTEMFURNITUREELEMENTTYPE", 10),
+    ("IFCTABLE", 3),
+    ("IFCTELECOMADDRESS", 9),
+    ("IFCTENDONANCHOR", 10),
+    ("IFCTEXTSTYLE", 5),
+    ("IFCTEXTURECOORDINATE", 1),
+    ("IFCWALL", 9),
+    ("IFCWALLSTANDARDCASE", 9),
+    ("IFCWINDOW", 13),
+    ("IFCWINDOWLININGPROPERTIES", 16),
+    ("IFCZONE", 6),
+];
+
+/// `IFC2X3` -> `IFC4X3`: 66 source types whose attribute list the target
+/// schema EXTENDS by appending. `(SOURCE TYPE, target positional count)`,
+/// sorted for binary search.
+static PAD_2X3_TO_4X3: &[(&str, usize)] = &[
+    ("IFCANNOTATION", 8),
+    ("IFCAPPLIEDVALUE", 10),
+    ("IFCBEAM", 9),
+    ("IFCBUILDINGELEMENTPART", 9),
+    ("IFCCLASSIFICATION", 7),
+    ("IFCCOLUMN", 9),
+    ("IFCCONTROL", 6),
+    ("IFCCOSTITEM", 9),
+    ("IFCCURTAINWALL", 9),
+    ("IFCCURVESTYLE", 5),
+    ("IFCDERIVEDUNIT", 4),
+    ("IFCDISCRETEACCESSORY", 9),
+    ("IFCDISCRETEACCESSORYTYPE", 10),
+    ("IFCDISTRIBUTIONCHAMBERELEMENT", 9),
+    ("IFCDISTRIBUTIONPORT", 10),
+    ("IFCDOOR", 13),
+    ("IFCDOORLININGPROPERTIES", 17),
+    ("IFCEQUIPMENTELEMENT", 9),
+    ("IFCFASTENER", 9),
+    ("IFCFASTENERTYPE", 10),
+    ("IFCFILLAREASTYLE", 3),
+    ("IFCFURNITURETYPE", 11),
+    ("IFCGRID", 11),
+    ("IFCISHAPEPROFILEDEF", 10),
+    ("IFCMATERIAL", 3),
+    ("IFCMATERIALLAYER", 7),
+    ("IFCMATERIALLAYERSET", 3),
+    ("IFCMATERIALLAYERSETUSAGE", 5),
+    ("IFCMECHANICALFASTENER", 11),
+    ("IFCMECHANICALFASTENERTYPE", 12),
+    ("IFCMEMBER", 9),
+    ("IFCMETRIC", 11),
+    ("IFCOBJECTPLACEMENT", 1),
+    ("IFCOPENINGELEMENT", 9),
+    ("IFCPLATE", 9),
+    ("IFCPROCESS", 7),
+    ("IFCPROJECTIONELEMENT", 9),
+    ("IFCQUANTITYAREA", 5),
+    ("IFCQUANTITYCOUNT", 5),
+    ("IFCQUANTITYLENGTH", 5),
+    ("IFCQUANTITYTIME", 5),
+    ("IFCQUANTITYVOLUME", 5),
+    ("IFCQUANTITYWEIGHT", 5),
+    ("IFCRAMPFLIGHT", 9),
+    ("IFCREINFORCINGMESH", 18),
+    ("IFCRELSEQUENCE", 9),
+    ("IFCRESOURCE", 7),
+    ("IFCSPACETYPE", 11),
+    ("IFCSTRUCTURALANALYSISMODEL", 10),
+    ("IFCSTRUCTURALCURVECONNECTION", 9),
+    ("IFCSTRUCTURALCURVEMEMBER", 9),
+    ("IFCSTRUCTURALCURVEMEMBERVARYING", 9),
+    ("IFCSTRUCTURALPOINTCONNECTION", 9),
+    ("IFCSURFACESTYLESHADING", 2),
+    ("IFCSYSTEMFURNITUREELEMENTTYPE", 10),
+    ("IFCTABLE", 3),
+    ("IFCTELECOMADDRESS", 9),
+    ("IFCTENDONANCHOR", 10),
+    ("IFCTEXTSTYLE", 5),
+    ("IFCTEXTURECOORDINATE", 1),
+    ("IFCVIRTUALELEMENT", 9),
+    ("IFCWALL", 9),
+    ("IFCWALLSTANDARDCASE", 9),
+    ("IFCWINDOW", 13),
+    ("IFCWINDOWLININGPROPERTIES", 16),
+    ("IFCZONE", 6),
+];
+
+/// `IFC4` -> `IFC4X3`: 5 source types whose attribute list the target
+/// schema EXTENDS by appending. `(SOURCE TYPE, target positional count)`,
+/// sorted for binary search.
+static PAD_4_TO_4X3: &[(&str, usize)] = &[
+    ("IFCANNOTATION", 8),
+    ("IFCDERIVEDUNIT", 4),
+    ("IFCOBJECTPLACEMENT", 1),
+    ("IFCRELINTERFERESELEMENTS", 10),
+    ("IFCVIRTUALELEMENT", 9),
+];
+
+
+/// Every `(from, to, SOURCE TYPE)` this module pads, for the cross-language
+/// parity gate to re-derive its required-coverage set from rather than trust a
+/// count floor (`rust/export/tests/schema_upconvert_parity.rs`).
+pub fn padded_type_universe() -> Vec<(&'static str, &'static str, &'static str)> {
+    [
+        ("IFC2X3", "IFC4", PAD_2X3_TO_4),
+        ("IFC2X3", "IFC4X3", PAD_2X3_TO_4X3),
+        ("IFC4", "IFC4X3", PAD_4_TO_4X3),
+    ]
+    .into_iter()
+    .flat_map(|(from, to, table)| table.iter().map(move |(name, _)| (from, to, *name)))
+    .collect()
+}
+
+/// Positional attribute count the target schema wants for `src_type`, or
+/// `None` when this conversion appends nothing to it (or is not an upgrade
+/// this module knows how to pad). `from`/`to` are already canonicalized.
+pub(crate) fn padded_attr_count(from: &str, to: &str, src_type: &str) -> Option<usize> {
+    let table = match (from, to) {
+        ("IFC2X3", "IFC4") => PAD_2X3_TO_4,
+        ("IFC2X3", "IFC4X3") => PAD_2X3_TO_4X3,
+        ("IFC4", "IFC4X3") => PAD_4_TO_4X3,
+        _ => return None,
+    };
+    table
+        .binary_search_by(|(name, _)| (*name).cmp(src_type))
+        .ok()
+        .map(|i| table[i].1)
+}
+
+/// Count top-level (comma-separated) STEP attributes, respecting nested
+/// parentheses and single-quoted strings (`''` is an escaped quote, not a
+/// terminator). An empty list is 0 attributes, not 1.
+pub(crate) fn count_top_level_attributes(attrs: &str) -> usize {
+    if attrs.trim().is_empty() {
+        return 0;
+    }
+    let bytes = attrs.as_bytes();
+    let mut count = 1usize;
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let ch = bytes[i];
+        if ch == b'\'' && !in_string {
+            in_string = true;
+        } else if ch == b'\'' && in_string {
+            if i + 1 < bytes.len() && bytes[i + 1] == b'\'' {
+                i += 2;
+                continue;
+            }
+            in_string = false;
+        } else if !in_string {
+            match ch {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                b',' if depth == 0 => count += 1,
+                _ => {}
+            }
+        }
+        i += 1;
+    }
+    count
+}

--- a/rust/export/tests/fixtures/schema_upconvert_sweep.json
+++ b/rust/export/tests/fixtures/schema_upconvert_sweep.json
@@ -1,0 +1,1006 @@
+{
+ "_comment": "Shared cross-language pin for STEP schema-conversion attribute padding (#1416 in TypeScript; the Rust port). Both halves run their own converter over every case: rust/export/tests/schema_upconvert_parity.rs and packages/export/src/schema-upconvert-sweep.parity.test.ts. Rows are derived from packages/data/src/ifc-schema/generated/entities-*.ts -- the types whose source attribute NAME list is a strict prefix of the target's -- plus hand-written negative controls. DO NOT hand-edit a row to make a test pass.",
+ "cases": [
+  {
+   "why": "appended attributes are padded (IFCAPPLIEDVALUE 6 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCAPPLIEDVALUE($,$,$,$,$,$);",
+   "expect": "#7=IFCAPPLIEDVALUE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCBEAM 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCBEAM($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCBEAM($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCBUILDINGELEMENTPART 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCBUILDINGELEMENTPART($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCBUILDINGELEMENTPART($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCLASSIFICATION 4 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCCLASSIFICATION($,$,$,$);",
+   "expect": "#7=IFCCLASSIFICATION($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCOLUMN 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCCOLUMN($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCCOLUMN($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCONTROL 5 -> 6)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCCONTROL($,$,$,$,$);",
+   "expect": "#7=IFCCONTROL($,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCOSTITEM 5 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCCOSTITEM($,$,$,$,$);",
+   "expect": "#7=IFCCOSTITEM($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCURTAINWALL 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCCURTAINWALL($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCCURTAINWALL($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCURVESTYLE 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCCURVESTYLE($,$,$,$);",
+   "expect": "#7=IFCCURVESTYLE($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISCRETEACCESSORY 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCDISCRETEACCESSORY($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISCRETEACCESSORY($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISCRETEACCESSORYTYPE 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCDISCRETEACCESSORYTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISCRETEACCESSORYTYPE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISTRIBUTIONCHAMBERELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCDISTRIBUTIONCHAMBERELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISTRIBUTIONCHAMBERELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISTRIBUTIONPORT 8 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCDISTRIBUTIONPORT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISTRIBUTIONPORT($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDOOR 10 -> 13)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCDOOR($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDOOR($,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDOORLININGPROPERTIES 15 -> 17)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCDOORLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDOORLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCEQUIPMENTELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCEQUIPMENTELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCBUILDINGELEMENTPROXY($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFASTENER 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCFASTENER($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCFASTENER($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFASTENERTYPE 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCFASTENERTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCFASTENERTYPE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFILLAREASTYLE 2 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCFILLAREASTYLE($,$);",
+   "expect": "#7=IFCFILLAREASTYLE($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFURNITURETYPE 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCFURNITURETYPE($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCFURNITURETYPE($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCGRID 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCGRID($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCGRID($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCISHAPEPROFILEDEF 8 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCISHAPEPROFILEDEF($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCISHAPEPROFILEDEF($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIAL 1 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMATERIAL($);",
+   "expect": "#7=IFCMATERIAL($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIALLAYER 3 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMATERIALLAYER($,$,$);",
+   "expect": "#7=IFCMATERIALLAYER($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIALLAYERSET 2 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMATERIALLAYERSET($,$);",
+   "expect": "#7=IFCMATERIALLAYERSET($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIALLAYERSETUSAGE 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMATERIALLAYERSETUSAGE($,$,$,$);",
+   "expect": "#7=IFCMATERIALLAYERSETUSAGE($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMECHANICALFASTENER 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMECHANICALFASTENER($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMECHANICALFASTENER($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMECHANICALFASTENERTYPE 9 -> 12)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMECHANICALFASTENERTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMECHANICALFASTENERTYPE($,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMEMBER 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMEMBER($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMEMBER($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMETRIC 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCMETRIC($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMETRIC($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCOPENINGELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCOPENINGELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCOPENINGELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPLATE 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCPLATE($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCPLATE($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPROCESS 5 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCPROCESS($,$,$,$,$);",
+   "expect": "#7=IFCPROCESS($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPROJECTIONELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCPROJECTIONELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCPROJECTIONELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPROPERTYBOUNDEDVALUE 5 -> 6)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCPROPERTYBOUNDEDVALUE($,$,$,$,$);",
+   "expect": "#7=IFCPROPERTYBOUNDEDVALUE($,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPROPERTYTABLEVALUE 7 -> 8)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCPROPERTYTABLEVALUE($,$,$,$,$,$,$);",
+   "expect": "#7=IFCPROPERTYTABLEVALUE($,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYAREA 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCQUANTITYAREA($,$,$,$);",
+   "expect": "#7=IFCQUANTITYAREA($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYCOUNT 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCQUANTITYCOUNT($,$,$,$);",
+   "expect": "#7=IFCQUANTITYCOUNT($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYLENGTH 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCQUANTITYLENGTH($,$,$,$);",
+   "expect": "#7=IFCQUANTITYLENGTH($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYTIME 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCQUANTITYTIME($,$,$,$);",
+   "expect": "#7=IFCQUANTITYTIME($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYVOLUME 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCQUANTITYVOLUME($,$,$,$);",
+   "expect": "#7=IFCQUANTITYVOLUME($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYWEIGHT 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCQUANTITYWEIGHT($,$,$,$);",
+   "expect": "#7=IFCQUANTITYWEIGHT($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCRAMPFLIGHT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCRAMPFLIGHT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCRAMPFLIGHT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCREINFORCINGMESH 17 -> 18)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCREINFORCINGMESH($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCREINFORCINGMESH($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCRELSEQUENCE 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCRELSEQUENCE($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCRELSEQUENCE($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCRESOURCE 5 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCRESOURCE($,$,$,$,$);",
+   "expect": "#7=IFCRESOURCE($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSPACETYPE 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSPACETYPE($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSPACETYPE($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALANALYSISMODEL 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSTRUCTURALANALYSISMODEL($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALANALYSISMODEL($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALCURVECONNECTION 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSTRUCTURALCURVECONNECTION($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALCURVECONNECTION($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALCURVEMEMBER 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSTRUCTURALCURVEMEMBER($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALCURVEMEMBER($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALCURVEMEMBERVARYING 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSTRUCTURALCURVEMEMBERVARYING($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALCURVEMEMBERVARYING($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALPOINTCONNECTION 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSTRUCTURALPOINTCONNECTION($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALPOINTCONNECTION($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSURFACESTYLESHADING 1 -> 2)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSURFACESTYLESHADING($);",
+   "expect": "#7=IFCSURFACESTYLESHADING($,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSYSTEMFURNITUREELEMENTTYPE 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCSYSTEMFURNITUREELEMENTTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSYSTEMFURNITUREELEMENTTYPE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTABLE 2 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCTABLE($,$);",
+   "expect": "#7=IFCTABLE($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTELECOMADDRESS 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCTELECOMADDRESS($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCTELECOMADDRESS($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTENDONANCHOR 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCTENDONANCHOR($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCTENDONANCHOR($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTEXTSTYLE 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCTEXTSTYLE($,$,$,$);",
+   "expect": "#7=IFCTEXTSTYLE($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTEXTURECOORDINATE 0 -> 1)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCTEXTURECOORDINATE($);",
+   "expect": "#7=IFCTEXTURECOORDINATE($);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWALL 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCWALL($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWALL($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWALLSTANDARDCASE 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCWALLSTANDARDCASE($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWALLSTANDARDCASE($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWINDOW 10 -> 13)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCWINDOW($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWINDOW($,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWINDOWLININGPROPERTIES 13 -> 16)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCWINDOWLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWINDOWLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCZONE 5 -> 6)",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#7=IFCZONE($,$,$,$,$);",
+   "expect": "#7=IFCZONE($,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCANNOTATION 7 -> 8)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCANNOTATION($,$,$,$,$,$,$);",
+   "expect": "#7=IFCANNOTATION($,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCAPPLIEDVALUE 6 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCAPPLIEDVALUE($,$,$,$,$,$);",
+   "expect": "#7=IFCAPPLIEDVALUE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCBEAM 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCBEAM($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCBEAM($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCBUILDINGELEMENTPART 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCBUILDINGELEMENTPART($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCBUILDINGELEMENTPART($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCLASSIFICATION 4 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCCLASSIFICATION($,$,$,$);",
+   "expect": "#7=IFCCLASSIFICATION($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCOLUMN 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCCOLUMN($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCCOLUMN($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCONTROL 5 -> 6)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCCONTROL($,$,$,$,$);",
+   "expect": "#7=IFCCONTROL($,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCOSTITEM 5 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCCOSTITEM($,$,$,$,$);",
+   "expect": "#7=IFCCOSTITEM($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCURTAINWALL 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCCURTAINWALL($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCCURTAINWALL($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCCURVESTYLE 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCCURVESTYLE($,$,$,$);",
+   "expect": "#7=IFCCURVESTYLE($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDERIVEDUNIT 3 -> 4)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCDERIVEDUNIT($,$,$);",
+   "expect": "#7=IFCDERIVEDUNIT($,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISCRETEACCESSORY 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCDISCRETEACCESSORY($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISCRETEACCESSORY($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISCRETEACCESSORYTYPE 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCDISCRETEACCESSORYTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISCRETEACCESSORYTYPE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISTRIBUTIONCHAMBERELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCDISTRIBUTIONCHAMBERELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISTRIBUTIONCHAMBERELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDISTRIBUTIONPORT 8 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCDISTRIBUTIONPORT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDISTRIBUTIONPORT($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDOOR 10 -> 13)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCDOOR($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDOOR($,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDOORLININGPROPERTIES 15 -> 17)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCDOORLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCDOORLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCEQUIPMENTELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCEQUIPMENTELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCBUILDINGELEMENTPROXY($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFASTENER 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCFASTENER($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCFASTENER($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFASTENERTYPE 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCFASTENERTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCFASTENERTYPE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFILLAREASTYLE 2 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCFILLAREASTYLE($,$);",
+   "expect": "#7=IFCFILLAREASTYLE($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCFURNITURETYPE 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCFURNITURETYPE($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCFURNITURETYPE($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCGRID 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCGRID($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCGRID($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCISHAPEPROFILEDEF 8 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCISHAPEPROFILEDEF($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCISHAPEPROFILEDEF($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIAL 1 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMATERIAL($);",
+   "expect": "#7=IFCMATERIAL($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIALLAYER 3 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMATERIALLAYER($,$,$);",
+   "expect": "#7=IFCMATERIALLAYER($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIALLAYERSET 2 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMATERIALLAYERSET($,$);",
+   "expect": "#7=IFCMATERIALLAYERSET($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMATERIALLAYERSETUSAGE 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMATERIALLAYERSETUSAGE($,$,$,$);",
+   "expect": "#7=IFCMATERIALLAYERSETUSAGE($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMECHANICALFASTENER 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMECHANICALFASTENER($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMECHANICALFASTENER($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMECHANICALFASTENERTYPE 9 -> 12)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMECHANICALFASTENERTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMECHANICALFASTENERTYPE($,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMEMBER 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMEMBER($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMEMBER($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCMETRIC 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCMETRIC($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCMETRIC($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCOBJECTPLACEMENT 0 -> 1)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCOBJECTPLACEMENT($);",
+   "expect": "#7=IFCOBJECTPLACEMENT($);"
+  },
+  {
+   "why": "appended attributes are padded (IFCOPENINGELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCOPENINGELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCOPENINGELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPLATE 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCPLATE($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCPLATE($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPROCESS 5 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCPROCESS($,$,$,$,$);",
+   "expect": "#7=IFCPROCESS($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCPROJECTIONELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCPROJECTIONELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCPROJECTIONELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYAREA 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCQUANTITYAREA($,$,$,$);",
+   "expect": "#7=IFCQUANTITYAREA($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYCOUNT 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCQUANTITYCOUNT($,$,$,$);",
+   "expect": "#7=IFCQUANTITYCOUNT($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYLENGTH 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCQUANTITYLENGTH($,$,$,$);",
+   "expect": "#7=IFCQUANTITYLENGTH($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYTIME 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCQUANTITYTIME($,$,$,$);",
+   "expect": "#7=IFCQUANTITYTIME($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYVOLUME 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCQUANTITYVOLUME($,$,$,$);",
+   "expect": "#7=IFCQUANTITYVOLUME($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCQUANTITYWEIGHT 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCQUANTITYWEIGHT($,$,$,$);",
+   "expect": "#7=IFCQUANTITYWEIGHT($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCRAMPFLIGHT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCRAMPFLIGHT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCRAMPFLIGHT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCREINFORCINGMESH 17 -> 18)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCREINFORCINGMESH($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCREINFORCINGMESH($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCRELSEQUENCE 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCRELSEQUENCE($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCRELSEQUENCE($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCRESOURCE 5 -> 7)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCRESOURCE($,$,$,$,$);",
+   "expect": "#7=IFCRESOURCE($,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSPACETYPE 10 -> 11)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSPACETYPE($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSPACETYPE($,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALANALYSISMODEL 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSTRUCTURALANALYSISMODEL($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALANALYSISMODEL($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALCURVECONNECTION 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSTRUCTURALCURVECONNECTION($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALCURVECONNECTION($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALCURVEMEMBER 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSTRUCTURALCURVEMEMBER($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALCURVEMEMBER($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALCURVEMEMBERVARYING 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSTRUCTURALCURVEMEMBERVARYING($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALCURVEMEMBERVARYING($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSTRUCTURALPOINTCONNECTION 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSTRUCTURALPOINTCONNECTION($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSTRUCTURALPOINTCONNECTION($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSURFACESTYLESHADING 1 -> 2)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSURFACESTYLESHADING($);",
+   "expect": "#7=IFCSURFACESTYLESHADING($,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCSYSTEMFURNITUREELEMENTTYPE 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCSYSTEMFURNITUREELEMENTTYPE($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCSYSTEMFURNITUREELEMENTTYPE($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTABLE 2 -> 3)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCTABLE($,$);",
+   "expect": "#7=IFCTABLE($,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTELECOMADDRESS 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCTELECOMADDRESS($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCTELECOMADDRESS($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTENDONANCHOR 9 -> 10)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCTENDONANCHOR($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCTENDONANCHOR($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTEXTSTYLE 4 -> 5)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCTEXTSTYLE($,$,$,$);",
+   "expect": "#7=IFCTEXTSTYLE($,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCTEXTURECOORDINATE 0 -> 1)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCTEXTURECOORDINATE($);",
+   "expect": "#7=IFCTEXTURECOORDINATE($);"
+  },
+  {
+   "why": "appended attributes are padded (IFCVIRTUALELEMENT 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCVIRTUALELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCVIRTUALELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWALL 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCWALL($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWALL($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWALLSTANDARDCASE 8 -> 9)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCWALLSTANDARDCASE($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWALLSTANDARDCASE($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWINDOW 10 -> 13)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCWINDOW($,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWINDOW($,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCWINDOWLININGPROPERTIES 13 -> 16)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCWINDOWLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCWINDOWLININGPROPERTIES($,$,$,$,$,$,$,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCZONE 5 -> 6)",
+   "from": "IFC2X3",
+   "to": "IFC4X3",
+   "line": "#7=IFCZONE($,$,$,$,$);",
+   "expect": "#7=IFCZONE($,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCANNOTATION 7 -> 8)",
+   "from": "IFC4",
+   "to": "IFC4X3",
+   "line": "#7=IFCANNOTATION($,$,$,$,$,$,$);",
+   "expect": "#7=IFCANNOTATION($,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCDERIVEDUNIT 3 -> 4)",
+   "from": "IFC4",
+   "to": "IFC4X3",
+   "line": "#7=IFCDERIVEDUNIT($,$,$);",
+   "expect": "#7=IFCDERIVEDUNIT($,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCOBJECTPLACEMENT 0 -> 1)",
+   "from": "IFC4",
+   "to": "IFC4X3",
+   "line": "#7=IFCOBJECTPLACEMENT($);",
+   "expect": "#7=IFCOBJECTPLACEMENT($);"
+  },
+  {
+   "why": "appended attributes are padded (IFCRELINTERFERESELEMENTS 9 -> 10)",
+   "from": "IFC4",
+   "to": "IFC4X3",
+   "line": "#7=IFCRELINTERFERESELEMENTS($,$,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCRELINTERFERESELEMENTS($,$,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "appended attributes are padded (IFCVIRTUALELEMENT 8 -> 9)",
+   "from": "IFC4",
+   "to": "IFC4X3",
+   "line": "#7=IFCVIRTUALELEMENT($,$,$,$,$,$,$,$);",
+   "expect": "#7=IFCVIRTUALELEMENT($,$,$,$,$,$,$,$,$);"
+  },
+  {
+   "why": "mid-list insertion must NOT be padded",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#5=IFCMATERIALPROPERTIES(#6);",
+   "expect": "#5=IFCMATERIALPROPERTIES(#6);"
+  },
+  {
+   "why": "equal counts are left alone",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#11=IFCSLAB('g',$,'S',$,$,#1,#2,'tag',.FLOOR.);",
+   "expect": "#11=IFCSLAB('g',$,'S',$,$,#1,#2,'tag',.FLOOR.);"
+  },
+  {
+   "why": "IFC5 target pads nothing",
+   "from": "IFC2X3",
+   "to": "IFC5",
+   "line": "#10=IFCWALL('g',$,'W',$,$,#1,#2,'tag');",
+   "expect": "#10=IFCWALL('g',$,'W',$,$,#1,#2,'tag');"
+  },
+  {
+   "why": "downgrade trims, never pads",
+   "from": "IFC4",
+   "to": "IFC2X3",
+   "line": "#5=IFCWALL('g',$,'W',$,$,$,$,'tag',.STANDARD.);",
+   "expect": "#5=IFCWALL('g',$,'W',$,$,$,$,'tag');"
+  },
+  {
+   "why": "an attribute-less line is not fabricated into one attribute",
+   "from": "IFC4",
+   "to": "IFC4X3",
+   "line": "#3=IFCOBJECTPLACEMENT();",
+   "expect": "#3=IFCOBJECTPLACEMENT();"
+  },
+  {
+   "why": "a comma inside a string is not an attribute separator",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#8=IFCCLASSIFICATION('BS, 1192','v1',$,'Name');",
+   "expect": "#8=IFCCLASSIFICATION('BS, 1192','v1',$,'Name',$,$,$);"
+  },
+  {
+   "why": "a comma inside a nested list is not an attribute separator",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#9=IFCCLASSIFICATION((1,2,3),'v1',$,'Name');",
+   "expect": "#9=IFCCLASSIFICATION((1,2,3),'v1',$,'Name',$,$,$);"
+  },
+  {
+   "why": "a renamed type is padded to its TARGET type count",
+   "from": "IFC2X3",
+   "to": "IFC4",
+   "line": "#4=IFCEQUIPMENTELEMENT('g',$,'E',$,$,#1,#2,'tag');",
+   "expect": "#4=IFCBUILDINGELEMENTPROXY('g',$,'E',$,$,#1,#2,'tag',$);"
+  }
+ ]
+}

--- a/rust/export/tests/schema_upconvert_parity.rs
+++ b/rust/export/tests/schema_upconvert_parity.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Rust half of the schema-upconversion padding pin.
+//!
+//! `packages/export/src/schema-converter.ts` pads the trailing optional
+//! attributes a newer target schema APPENDED (#1416). The Rust port in
+//! `rust/export/src/schema_convert.rs` did not, and it is the Rust one that
+//! `ifc-lite export --format step --schema IFC4` actually runs (via
+//! `exportStep` in the wasm bindings), so every upgraded IfcWall / IfcBeam /
+//! IfcOpeningElement / ... came out a positional attribute short -- an
+//! invalid file that strict readers reject.
+//!
+//! Both implementations are now held to ONE fixture
+//! (`fixtures/schema_upconvert_sweep.json`); the TypeScript half is
+//! `packages/export/src/schema-upconvert-sweep.parity.test.ts`. Following the
+//! `rooted_type_parity.rs` precedent, WHICH rows the fixture must contain is
+//! pinned here rather than by a count: `fixture_names_every_padded_type`
+//! re-derives the required names from `schema_pad`'s own tables, so a row
+//! that is deleted -- the failure a `cases.len() > N` floor sleeps through --
+//! fails loudly, while adding a type to the tables without a fixture row
+//! fails too.
+//!
+//! Exercised through the public `export_step_json`, not a private helper: the
+//! path the CLI takes, header and all.
+
+use std::collections::BTreeSet;
+
+#[derive(serde::Deserialize)]
+struct Case {
+    why: String,
+    from: String,
+    to: String,
+    line: String,
+    expect: String,
+}
+
+fn cases() -> Vec<Case> {
+    let raw = include_str!("fixtures/schema_upconvert_sweep.json");
+    let doc: serde_json::Value = serde_json::from_str(raw).expect("fixture is valid JSON");
+    serde_json::from_value(doc["cases"].clone()).expect("cases deserialize")
+}
+
+/// Wrap one entity line in a minimal STEP file declaring `schema` and run the
+/// real exporter, returning the converted entity line.
+fn convert_through_exporter(line: &str, from: &str, to: &str) -> String {
+    let src = format!(
+        "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n\
+         FILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('{from}'));\nENDSEC;\n\
+         DATA;\n{line}\nENDSEC;\nEND-ISO-10303-21;\n"
+    );
+    let out = ifc_lite_export::export_step_json(src.as_bytes(), Some(to.to_string()), None, "")
+        .expect("export_step_json");
+    out.lines()
+        .find(|l| l.starts_with('#'))
+        .unwrap_or_else(|| panic!("no entity line in output:\n{out}"))
+        .to_string()
+}
+
+#[test]
+fn every_case_agrees_with_the_shared_fixture() {
+    let cases = cases();
+    assert!(cases.len() > 100, "anti-vacuity: fixture holds {} cases", cases.len());
+    let mut bad = Vec::new();
+    for c in &cases {
+        let got = convert_through_exporter(&c.line, &c.from, &c.to);
+        if got != c.expect {
+            bad.push(format!(
+                "{} -> {} [{}]\n  in     {}\n  expect {}\n  got    {}",
+                c.from, c.to, c.why, c.line, c.expect, got
+            ));
+        }
+    }
+    assert!(bad.is_empty(), "{} mismatches:\n{}", bad.len(), bad.join("\n"));
+}
+
+/// Coverage gate: every type the padding tables act on must be NAMED by a
+/// fixture row, and every padded row must correspond to a table entry. A
+/// count floor passes both when rows are silently dropped and when a type is
+/// added to the tables with no row to pin it.
+#[test]
+fn fixture_names_every_padded_type() {
+    let required: BTreeSet<(String, String, String)> = ifc_lite_export::padded_type_universe()
+        .into_iter()
+        .map(|(f, t, n)| (f.to_string(), t.to_string(), n.to_string()))
+        .collect();
+    assert!(required.len() > 100, "anti-vacuity: universe is {}", required.len());
+
+    let named: BTreeSet<(String, String, String)> = cases()
+        .iter()
+        .filter_map(|c| {
+            let ty = c.line.split_once('=')?.1.split_once('(')?.0.to_string();
+            required
+                .contains(&(c.from.clone(), c.to.clone(), ty.clone()))
+                .then_some((c.from.clone(), c.to.clone(), ty))
+        })
+        .collect();
+
+    let missing: Vec<_> = required.difference(&named).collect();
+    assert!(missing.is_empty(), "fixture names no case for: {missing:?}");
+}
+
+/// Negative control: the padding must be a no-op wherever the target schema
+/// did not APPEND. Deleting the strict-prefix restriction and padding every
+/// short line would still pass `every_case_agrees_with_the_shared_fixture`'s
+/// positive rows; it fails here.
+#[test]
+fn a_reordered_attribute_list_is_never_padded() {
+    let got = convert_through_exporter("#7=IFCMATERIALPROPERTIES(#8);", "IFC2X3", "IFC4");
+    assert_eq!(
+        got, "#7=IFCMATERIALPROPERTIES(#8);",
+        "IFC2X3 IfcMaterialProperties is [Material]; IFC4 is \
+         [Name, Description, Properties, Material] -- padding would read #8 as the Name"
+    );
+}


### PR DESCRIPTION
Refs #3271.

## The bug

The IFC schema converter exists twice: `packages/export/src/schema-converter.ts` and its Rust port `rust/export/src/schema_convert.rs`. #1416 fixed the TypeScript one — it never padded the trailing optional attributes newer schemas APPEND, so an upgraded entity came out a positional attribute short and strict readers rejected the file. The Rust port never got that fix, and the Rust port is the one `ifc-lite export --format step --schema IFC4` runs (through `exportStep` in the wasm bindings).

Verbatim RED on `484ea61b0`, through the real entry point `export_step_json` on a minimal IFC2X3 source:

```
OUT #1=IFCWALL('0aBcDeFgHiJkLmNoPqRsTu',$,'W1',$,$,$,$,'tag');
OUT #2=IFCOPENINGELEMENT('1aBcDeFgHiJkLmNoPqRsTu',$,'O1',$,$,$,$,'tag');

thread 'upgrade_2x3_to_ifc4_pads_appended_attributes' panicked at rust/export/tests/red_probe.rs:18:5:
IFC4 IfcWall carries 9 positional attributes (PredefinedType appended)
```

GREEN after:

```
OUT #1=IFCWALL('0aBcDeFgHiJkLmNoPqRsTu',$,'W1',$,$,$,$,'tag',$);
OUT #2=IFCOPENINGELEMENT('1aBcDeFgHiJkLmNoPqRsTu',$,'O1',$,$,$,$,'tag',$);
```

Derived from the generated buildingSMART tables, the affected set is 64 types on IFC2X3 → IFC4, 66 on IFC2X3 → IFC4X3, and 5 on IFC4 → IFC4X3 — up to four missing attributes (`IfcAppliedValue` 6 → 10).

The four shared tables were diffed mechanically before writing anything, and they are NOT the problem: the three entity-rename maps and the IFC2X3 attribute-count map agree with their TypeScript twins over all 3 + 23 + 36 + 30 entries, 0 differences. What drifted is the algorithm.

## The fix

Padding is only safe where the source schema's positional attribute NAME list is a strict PREFIX of the target's. `IfcMaterialProperties` goes from `[Material]` in IFC2X3 to `[Name, Description, Properties, Material]` in IFC4; a trailing `$` there shoves the material reference into the Name slot. Rust has no per-schema attribute table to test that against at run time — the generated `ifc_lite_core::IfcType` is IFC4X3 alone and carries no IFC2X3 or IFC4 list — so the new `schema_pad` module holds the strict-prefix pairs derived from the same `entities-ifc2x3.ts` / `-ifc4.ts` / `-ifc4x3.ts` the TypeScript half reads.

IFC5 is deliberately absent: the TypeScript twin has no generated table for it and skips the adjustment entirely, so upgrading to IFC5 pads nothing here either.

## The gate

Neither half is trusted to have stayed in step. Both now run their own converter over ONE shared fixture, `rust/export/tests/fixtures/schema_upconvert_sweep.json` — `rust/export/tests/schema_upconvert_parity.rs` and `packages/export/src/schema-upconvert-sweep.parity.test.ts`, following the `rooted_type_parity.rs` / `rooted-type-sweep.parity.test.ts` precedent.

Three properties it needed and has:

- **Both directions.** The Rust half exercises the public `export_step_json`, the path the CLI takes, header and all; the TypeScript half calls `convertStepLine`.
- **A named coverage set, not a count floor.** `fixture_names_every_padded_type` re-derives the required `(from, to, type)` triples from `schema_pad`'s own tables. A count survives deleting exactly the rows that matter and stays silent on a type added to the tables with no row to pin it.
- **A negative control.** Deleting the strict-prefix restriction and padding every short line passes all 134 padded rows. It fails `a_reordered_attribute_list_is_never_padded`.

Anti-vacuity guards on both sides (`cases.len() > 100`, `required.len() > 100`), and mutation-checked: stubbing the pad condition to `false` produces `134 mismatches` rather than a silent pass.

## Also

`schema_convert.rs`'s inline `#[cfg(test)] mod tests` moves to `schema_convert_tests.rs` via the `#[path]` convention (`schema_helpers.rs`, `georef.rs`), so the module stays under the 400-line ratchet rather than earning an allowlist row.

## Verification

- `cargo test -p ifc-lite-export` — 306 + 6 + 3 + … passed, 0 failed
- `cargo test -p ifc-lite-processing --test module_size_ratchet` — 5 passed
- `pnpm --filter @ifc-lite/export exec vitest run src/schema-converter.test.ts` — 43 passed
- `pnpm --filter @ifc-lite/export exec vitest run src/schema-upconvert-sweep.parity.test.ts` — 3 passed

## Note for review

Three open PRs (#3238, #3241, #3246) are reworking the TypeScript converter's trim/pad to be schema-derived and prefix-relation-based rather than rank-gated. This PR touches none of their files — it ports what is on `main` today into Rust, which has neither half. If #3246 lands first, the Rust side will want the same "rank is not direction" correction, and the shared fixture is where that would be pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
