### PR TITLE
fix(processing): the fast-boot spatial tree dropped every marine and common facility part (#3275)

### DIFF
--- a/.changeset/quick-spatial-tree-derived-from-schema.md
+++ b/.changeset/quick-spatial-tree-derived-from-schema.md
@@ -1,0 +1,27 @@
+---
+'@ifc-lite/wasm': patch
+'@ifc-lite/server-client': patch
+---
+
+Derive the fast-boot spatial tree's type gate from the generated schema instead of a hand-written list of fourteen names.
+
+`is_quick_spatial_type_ci` decides which entities become nodes in the bootstrap
+spatial tree — the hierarchy the viewer shows while a file is still loading. It
+hand-listed fourteen entity names, and a hand list is only ever as complete as
+whoever last audited the schema. It was missing `IfcMarineFacility`,
+`IfcMarinePart` and `IfcFacilityPartCommon`, so an IFC4.3 harbour or a generic
+facility with common parts lost its whole branch from that tree: the facility
+was never inserted as a node, so nothing aggregated beneath it could be
+reparented either.
+
+The gate now asks `ifc_lite_core::IfcType` directly — `IfcProject`, plus
+`IfcSpatialZone`, plus the whole `IfcSpatialStructureElement` closure — the same
+move `rooted_type.rs` made for `IfcRoot`. Newly recognised as fast-boot spatial
+nodes: `IfcMarineFacility`, `IfcMarinePart`, `IfcFacilityPartCommon` and
+`IfcSpatialStructureElement` itself. Nothing previously recognised is dropped.
+
+`IfcExternalSpatialElement` stays out on purpose. It is an `IfcSpatialElement`,
+but it descends from `IfcExternalSpatialStructureElement`, carries none of the
+`WR41` aggregation rule that defines the containment hierarchy, and models a
+space *boundary* volume rather than a container — admitting it would put a
+permanently parentless node in the tree.

--- a/rust/processing/src/lib.rs
+++ b/rust/processing/src/lib.rs
@@ -62,7 +62,8 @@ pub use pipeline_diagnostics::{
 /// `ifc-lite-geometry` dependency edge for one enum.
 pub use ifc_lite_geometry::TessellationQuality;
 pub use processor::{
-    convert_mesh_to_site_local, process_geometry, process_geometry_filtered,
+    convert_mesh_to_site_local, is_quick_spatial_type_ci, process_geometry,
+    process_geometry_filtered,
     process_geometry_filtered_with_quality, process_geometry_with_index,
     process_geometry_streaming, process_geometry_streaming_filtered,
     process_geometry_streaming_filtered_with_options, process_geometry_streaming_with_options,

--- a/rust/processing/src/processor/mod.rs
+++ b/rust/processing/src/processor/mod.rs
@@ -30,6 +30,7 @@ mod properties;
 mod quick_metadata;
 mod site_local;
 
+pub use quick_metadata::is_quick_spatial_type_ci;
 pub use site_local::convert_mesh_to_site_local;
 
 use jobs::{build_color_updates_for_jobs, process_entity_job};
@@ -42,8 +43,7 @@ use opening_filter::apply_opening_filter;
 use properties::resolve_space_zone_properties_lazy;
 use quick_metadata::{
     build_quick_spatial_tree_node, extract_name_from_args, extract_storey_elevation_from_args,
-    is_quick_spatial_type_ci, parse_step_arguments, parse_step_ref, parse_step_ref_list,
-    QuickSpatialNodeEntry,
+    parse_step_arguments, parse_step_ref, parse_step_ref_list, QuickSpatialNodeEntry,
 };
 use site_local::{
     translation_is_nonidentity, MODEL_RTC_MESH_COORDINATE_SPACE, RAW_IFC_MESH_COORDINATE_SPACE,

--- a/rust/processing/src/processor/quick_metadata.rs
+++ b/rust/processing/src/processor/quick_metadata.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::types::response::{QuickMetadataEntitySummary, QuickMetadataSpatialNode};
+use ifc_lite_core::{IfcType, IFC_TYPES};
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
 
 #[derive(Clone)]
 pub(super) struct QuickSpatialNodeEntry {
@@ -16,23 +18,58 @@ pub(super) struct QuickSpatialNodeEntry {
     pub(super) parent: Option<u32>,
 }
 
+/// Which types the schema calls members of the spatial *structure* hierarchy.
+///
+/// `IfcProject` is the tree root and is an `IfcObject`, not a spatial element
+/// at all. `IfcSpatialZone` is an `IfcSpatialElement` but NOT an
+/// `IfcSpatialStructureElement`; it is carried deliberately since #1075 (Revit
+/// / Dynamo GFA volumes attached with `IfcRelContainedInSpatialStructure`).
+/// Everything else is exactly the `IfcSpatialStructureElement` closure -- the
+/// branch whose `WR41` rule requires membership in the `IfcRelAggregates`
+/// decomposition this tree is built from.
+///
+/// `IfcExternalSpatialElement` is deliberately NOT here even though it is an
+/// `IfcSpatialElement`: it descends from `IfcExternalSpatialStructureElement`,
+/// carries no `WR41`, and models a space *boundary* volume (external air,
+/// ground) rather than a container. Admitting it would put a permanently
+/// parentless node in the tree. The TypeScript half excludes it for the same
+/// reason.
+fn is_quick_spatial_type(ifc_type: IfcType) -> bool {
+    matches!(ifc_type, IfcType::IfcProject | IfcType::IfcSpatialZone)
+        || ifc_type.is_subtype_of(IfcType::IfcSpatialStructureElement)
+}
+
+/// The uppercase STEP keywords [`is_quick_spatial_type`] accepts, derived once
+/// from the generated schema catalog.
+///
+/// This used to be fourteen names typed out by hand, and it was missing
+/// `IfcMarineFacility`, `IfcMarinePart` and `IfcFacilityPartCommon` -- an IFC4.3
+/// harbour lost its entire branch from the tree shown during load, while the
+/// TypeScript builder (working from its own, differently-wrong hand list) kept
+/// part of it, so the panel visibly gained a branch part-way through (#3275).
+/// A hand list can only ever be as complete as whoever last audited the schema,
+/// and `rooted_type.rs` made exactly this move for `IfcRoot` for exactly this
+/// reason (#3015).
+///
+/// Materialised as a name slice rather than resolved per call: the gate runs
+/// once for every entity in the scan loop, and `IfcType::from_str` normalises
+/// to uppercase first, which allocates. A linear `eq_ignore_ascii_case` sweep
+/// over ~17 short names is what the hand-written chain already cost, so the
+/// derivation is free at the call site.
+static QUICK_SPATIAL_TYPE_NAMES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    IFC_TYPES
+        .iter()
+        .filter(|ifc_type| is_quick_spatial_type(**ifc_type))
+        .map(|ifc_type| ifc_type.as_str())
+        .collect()
+});
+
 /// Case-insensitive spatial-type check that avoids to_ascii_uppercase() allocation.
 #[inline]
-pub(super) fn is_quick_spatial_type_ci(type_name: &str) -> bool {
-    type_name.eq_ignore_ascii_case("IFCPROJECT")
-        || type_name.eq_ignore_ascii_case("IFCSITE")
-        || type_name.eq_ignore_ascii_case("IFCBUILDING")
-        || type_name.eq_ignore_ascii_case("IFCBUILDINGSTOREY")
-        || type_name.eq_ignore_ascii_case("IFCSPACE")
-        || type_name.eq_ignore_ascii_case("IFCSPATIALZONE")
-        || type_name.eq_ignore_ascii_case("IFCFACILITY")
-        || type_name.eq_ignore_ascii_case("IFCFACILITYPART")
-        || type_name.eq_ignore_ascii_case("IFCBRIDGE")
-        || type_name.eq_ignore_ascii_case("IFCBRIDGEPART")
-        || type_name.eq_ignore_ascii_case("IFCROAD")
-        || type_name.eq_ignore_ascii_case("IFCROADPART")
-        || type_name.eq_ignore_ascii_case("IFCRAILWAY")
-        || type_name.eq_ignore_ascii_case("IFCRAILWAYPART")
+pub fn is_quick_spatial_type_ci(type_name: &str) -> bool {
+    QUICK_SPATIAL_TYPE_NAMES
+        .iter()
+        .any(|candidate| type_name.eq_ignore_ascii_case(candidate))
 }
 
 pub(super) fn parse_step_arguments(entity_bytes: &[u8]) -> Vec<&[u8]> {

--- a/rust/processing/tests/issue_3275_quick_spatial_types.rs
+++ b/rust/processing/tests/issue_3275_quick_spatial_types.rs
@@ -1,0 +1,217 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #3275 — the fast-boot spatial tree's type gate must come from the
+//! schema, not from a hand-written list.
+//!
+//! `is_quick_spatial_type_ci` decides which entities become nodes in the
+//! bootstrap spatial tree (`processor::mod`'s scan loop). It used to hand-list
+//! fourteen names, and a hand list can only ever be as complete as whoever
+//! last audited the schema: it was missing `IfcMarineFacility`,
+//! `IfcMarinePart` and `IfcFacilityPartCommon`, so an IFC4.3 harbour lost its
+//! whole branch from the tree the user sees first.
+//!
+//! Two tests, and the second is the one that matters:
+//!
+//!   - `marine_branch_reaches_the_fast_boot_tree` is the end-to-end
+//!     reproduction from the issue, through the real bootstrap path.
+//!   - `quick_spatial_gate_matches_the_schema` re-derives the expected answer
+//!     for **every** type in `ifc_lite_core::IFC_TYPES` from the generated
+//!     inheritance table and compares name by name. It is deliberately NOT a
+//!     comparison against the TypeScript list: two hand lists agreeing with
+//!     each other is exactly what hid this defect for three releases. The
+//!     TypeScript half (`packages/data/src/spatial-types.test.ts`) is anchored
+//!     to its own generated schema table the same way, so neither side can
+//!     drift without its own gate reddening.
+
+use ifc_lite_core::{IfcType, IFC_TYPES};
+use ifc_lite_processing::{
+    is_quick_spatial_type_ci, process_geometry_streaming_with_options_and_bootstrap,
+    QuickMetadataBootstrap, QuickMetadataSpatialNode, StreamingOptions,
+};
+use std::collections::BTreeSet;
+
+const MARINE_IFC: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('issue-3275 marine facility fixture'),'2;1');
+FILE_NAME('marine.ifc','2026-08-25T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4X3'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('3Project00000000003275',$,'Harbour',$,$,$,$,(#2),#3);
+#2=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#5,$);
+#3=IFCUNITASSIGNMENT((#6));
+#4=IFCCARTESIANPOINT((0.,0.,0.));
+#5=IFCAXIS2PLACEMENT3D(#4,$,$);
+#6=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#7=IFCLOCALPLACEMENT($,#5);
+
+#20=IFCSITE('3Site0000000000003275',$,'Site',$,$,#7,$,$,.ELEMENT.,$,$,$,$,$);
+#21=IFCMARINEFACILITY('3MarineFac0000003275',$,'Port',$,$,#7,$,$,.ELEMENT.,.PORT.);
+#22=IFCMARINEPART('3MarinePart000003275',$,'Quay',$,$,#7,$,$,.PARTIAL.,.LATERAL.,.QUAY.);
+#30=IFCFACILITY('3Facility00000003275',$,'Terminal',$,$,#7,$,$,.ELEMENT.);
+#31=IFCFACILITYPARTCOMMON('3FacPartCommon003275',$,'Wing A',$,$,#7,$,$,.PARTIAL.,.LATERAL.,.SEGMENT.);
+
+#40=IFCRELAGGREGATES('3RelAggProjSite03275',$,$,$,#1,(#20));
+#41=IFCRELAGGREGATES('3RelAggSiteMar003275',$,$,$,#20,(#21,#30));
+#42=IFCRELAGGREGATES('3RelAggMarPart003275',$,$,$,#21,(#22));
+#43=IFCRELAGGREGATES('3RelAggFacPart003275',$,$,$,#30,(#31));
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn flatten(node: &QuickMetadataSpatialNode, out: &mut Vec<(u32, String)>) {
+    out.push((
+        node.summary.express_id,
+        node.summary.type_name.to_ascii_uppercase(),
+    ));
+    for child in &node.children {
+        flatten(child, out);
+    }
+}
+
+#[test]
+fn marine_branch_reaches_the_fast_boot_tree() {
+    let mut captured: Option<QuickMetadataBootstrap> = None;
+    let options = StreamingOptions {
+        emit_quick_metadata_bootstrap: true,
+        ..Default::default()
+    };
+    process_geometry_streaming_with_options_and_bootstrap(
+        MARINE_IFC.as_bytes(),
+        options,
+        |_, _, _| {},
+        |_| {},
+        |b| captured = Some(b.clone()),
+    );
+
+    let boot = captured.expect("a quick-metadata bootstrap should be emitted");
+    let tree = boot.spatial_tree.expect("a spatial tree should be built");
+
+    let mut seen = Vec::new();
+    flatten(&tree, &mut seen);
+    let ids: BTreeSet<u32> = seen.iter().map(|(id, _)| *id).collect();
+
+    // Named, not counted: a floor of "at least four nodes" survives dropping
+    // the quay, which is the entity this issue is about.
+    for (id, name) in [
+        (1u32, "IFCPROJECT"),
+        (20, "IFCSITE"),
+        (21, "IFCMARINEFACILITY"),
+        (22, "IFCMARINEPART"),
+        (30, "IFCFACILITY"),
+        (31, "IFCFACILITYPARTCOMMON"),
+    ] {
+        assert!(
+            ids.contains(&id),
+            "{name} #{id} must be a node in the fast-boot spatial tree; got {seen:?}"
+        );
+    }
+}
+
+/// The gate's answer, re-derived from the generated inheritance table.
+///
+/// `IfcProject` is the tree root and is an `IfcObject`, not a spatial element
+/// at all. `IfcSpatialZone` is an `IfcSpatialElement` but NOT an
+/// `IfcSpatialStructureElement`; it is carried deliberately (#1075, Revit/Dynamo
+/// GFA volumes). Everything else is exactly the `IfcSpatialStructureElement`
+/// closure — the branch of the schema whose `WR41` rule
+/// (`packages/codegen/schemas/IFC4X3.exp:10634-10637`) is what makes an entity
+/// a member of the aggregation hierarchy this tree is built from.
+fn schema_says_spatial(t: IfcType) -> bool {
+    matches!(t, IfcType::IfcProject | IfcType::IfcSpatialZone)
+        || t.is_subtype_of(IfcType::IfcSpatialStructureElement)
+}
+
+#[test]
+fn quick_spatial_gate_matches_the_schema() {
+    let mut expected = BTreeSet::new();
+    let mut mismatches = Vec::new();
+    for &t in IFC_TYPES {
+        let want = schema_says_spatial(t);
+        if want {
+            expected.insert(t.as_str());
+        }
+        let got = is_quick_spatial_type_ci(t.as_str());
+        if got != want {
+            mismatches.push(format!("{}: gate={got} schema={want}", t.as_str()));
+        }
+    }
+
+    // Anti-vacuity: the sweep must actually have run over the whole catalog,
+    // and the derived expectation must be non-trivial. A renamed supertype
+    // would otherwise make every assertion below pass over an empty set.
+    assert!(
+        IFC_TYPES.len() > 800,
+        "IFC_TYPES looks truncated ({} entries)",
+        IFC_TYPES.len()
+    );
+    for required in [
+        "IFCPROJECT",
+        "IFCSITE",
+        "IFCBUILDING",
+        "IFCBUILDINGSTOREY",
+        "IFCSPACE",
+        "IFCSPATIALZONE",
+        "IFCFACILITY",
+        "IFCFACILITYPART",
+        "IFCFACILITYPARTCOMMON",
+        "IFCBRIDGE",
+        "IFCBRIDGEPART",
+        "IFCROAD",
+        "IFCROADPART",
+        "IFCRAILWAY",
+        "IFCRAILWAYPART",
+        "IFCMARINEFACILITY",
+        "IFCMARINEPART",
+    ] {
+        assert!(
+            expected.contains(required),
+            "the schema-derived expectation lost {required}; the derivation, not the gate, \
+             is broken"
+        );
+    }
+
+    assert!(
+        mismatches.is_empty(),
+        "the fast-boot spatial gate disagrees with the generated schema for {} type(s): {:?}",
+        mismatches.len(),
+        mismatches
+    );
+}
+
+#[test]
+fn non_spatial_types_stay_out_of_the_tree() {
+    // The other direction. `IfcExternalSpatialElement` is the interesting one:
+    // it IS an `IfcSpatialElement`, but it sits under
+    // `IfcExternalSpatialStructureElement` (`IFC4X3.exp:6570-6574`), outside the
+    // `IfcSpatialStructureElement` branch, and carries no `WR41` aggregation
+    // rule — it is a space *boundary* volume (external air, ground), never a
+    // member of the containment hierarchy. Admitting it would add a permanently
+    // parentless node to the tree. It is excluded on both sides on purpose.
+    for name in [
+        "IFCWALL",
+        "IFCBUILDINGELEMENTPROXY",
+        "IFCZONE",
+        "IFCEXTERNALSPATIALELEMENT",
+        "IFCEXTERNALSPATIALSTRUCTUREELEMENT",
+        // The abstract supertypes themselves.
+        "IFCSPATIALELEMENT",
+        "IFCPRODUCT",
+        "IFCOBJECT",
+        "IFCROOT",
+        // Not an entity in any bundled schema.
+        "IFCNOTATHING",
+    ] {
+        assert!(
+            !is_quick_spatial_type_ci(name),
+            "{name} must not be treated as a fast-boot spatial node"
+        );
+    }
+
+    // Case-insensitivity is part of the contract — STEP keywords are uppercase
+    // by convention, not by rule.
+    assert!(is_quick_spatial_type_ci("IfcMarinePart"));
+    assert!(is_quick_spatial_type_ci("ifcbuildingstorey"));
+}


### PR DESCRIPTION
Refs #3275

## The measured state on `upstream/main` (ffe80a76a)

Mechanical symmetric difference, re-derived rather than taken from the issue — the two hand lists parsed straight out of their source files, the truth set parsed out of `packages/codegen/schemas/IFC4X3.exp`:

```
schema (IFC4X3): concrete IfcSpatialStructureElement = 14 ; concrete IfcSpatialElement = 16

rust 14, ts 15
ts-only (rust missing) : [ 'IFCMARINEFACILITY' ]
rust-only (ts missing) : []

truth \ rust (rust misses): [ 'IFCFACILITYPARTCOMMON', 'IFCMARINEFACILITY', 'IFCMARINEPART' ]
rust \ truth (rust extra) : [ 'IFCFACILITYPART' ]     <- ABSTRACT, harmless
truth \ ts   (ts misses)  : [ 'IFCFACILITYPARTCOMMON', 'IFCMARINEPART' ]
ts \ truth   (ts extra)   : [ 'IFCFACILITYPART' ]     <- ABSTRACT, harmless

concrete IfcSpatialElement NOT in the structure tree: [ 'IFCEXTERNALSPATIALELEMENT' ]
```

So the reported half — Rust missing `IfcMarineFacility` — is real, and the unreported half is worse: **both** lists also miss `IfcMarinePart` and `IfcFacilityPartCommon`. Patching one name into the Rust list would have made the two lists agree while still losing the quay.

## Which supertype the code means

`IfcSpatialStructureElement`, not `IfcSpatialElement`. The two differ by exactly two entities and both are decided here:

- `IfcSpatialZone` is an `IfcSpatialElement` and NOT a *structure* element (`IFC4X3.exp:10650-10651`), yet both lists carry it — deliberately, since #1075 (Revit/Dynamo GFA volumes attached with `IfcRelContainedInSpatialStructure`). Kept.
- `IfcExternalSpatialElement` is the other one, and it is excluded on purpose:

```
6563:ENTITY IfcExternalSpatialElement
6564- SUBTYPE OF (IfcExternalSpatialStructureElement);
...
6570:ENTITY IfcExternalSpatialStructureElement
6571- ABSTRACT SUPERTYPE OF (ONEOF
6572-	(IfcExternalSpatialElement))
6573- SUBTYPE OF (IfcSpatialElement);
```

It sits outside the `IfcSpatialStructureElement` branch, and the `WR41` rule that makes an entity a member of the `IfcRelAggregates` decomposition this tree is built from lives only on `IfcSpatialStructureElement`:

```
10625:ENTITY IfcSpatialStructureElement
10626- ABSTRACT SUPERTYPE OF (ONEOF
10627-	(IfcBuildingStorey ,IfcFacility ,IfcFacilityPart ,IfcSite ,IfcSpace))
10632- SUBTYPE OF (IfcSpatialElement);
10634- WHERE
10635-	WR41 : (HIINDEX(SELF\IfcObjectDefinition.Decomposes) = 1) AND
10637-('...IFCRELAGGREGATES' IN TYPEOF(SELF\IfcObjectDefinition.Decomposes[1]))
```

`IfcExternalSpatialElement` models a space *boundary* volume (external air, ground), never a container. Admitting it would put a permanently parentless node in the tree. It is pinned as a negative control so that decision is visible rather than accidental.

Truth set = `IfcProject` + `IfcSpatialZone` + the `IfcSpatialStructureElement` closure.

## RED, on `upstream/main`

```
running 3 tests
test non_spatial_types_stay_out_of_the_tree ... FAILED
test quick_spatial_gate_matches_the_schema ... FAILED
test marine_branch_reaches_the_fast_boot_tree ... FAILED

---- marine_branch_reaches_the_fast_boot_tree stdout ----
IFCMARINEFACILITY #21 must be a node in the fast-boot spatial tree; got [(1, "IFCPROJECT"), (20, "IFCSITE"), (30, "IFCFACILITY")]

---- quick_spatial_gate_matches_the_schema stdout ----
the fast-boot spatial gate disagrees with the generated schema for 4 type(s): ["IFCFACILITYPARTCOMMON: gate=false schema=true", "IFCMARINEFACILITY: gate=false schema=true", "IFCMARINEPART: gate=false schema=true", "IFCSPATIALSTRUCTUREELEMENT: gate=false schema=true"]

---- non_spatial_types_stay_out_of_the_tree stdout ----
assertion failed: is_quick_spatial_type_ci("IfcMarinePart")
```

GREEN after the fix: `3 passed`, and `cargo test -p ifc-lite-processing` fully green, `cargo clippy -p ifc-lite-processing --all-targets` clean.

## What changed

**Derived, not re-listed.** `is_quick_spatial_type_ci` now asks `ifc_lite_core::IfcType` — the same move `rooted_type.rs` made for `IfcRoot` (#3015):

```rust
fn is_quick_spatial_type(ifc_type: IfcType) -> bool {
    matches!(ifc_type, IfcType::IfcProject | IfcType::IfcSpatialZone)
        || ifc_type.is_subtype_of(IfcType::IfcSpatialStructureElement)
}
```

The accepted names are materialised once into a `LazyLock<Vec<&'static str>>` and matched with `eq_ignore_ascii_case`, rather than resolving the type per call. The gate runs for every entity in the streaming scan loop, and `IfcType::from_str` uppercase-normalises first, which allocates — seventeen short comparisons is what the hand-written `||` chain already cost, so the derivation is free at the call site.

Newly recognised: `IfcMarineFacility`, `IfcMarinePart`, `IfcFacilityPartCommon`, and `IfcSpatialStructureElement` itself. Nothing previously recognised is dropped.

`processor/mod.rs` grew one line for the re-export and was joined back under its ratchet budget (1661) in the same commit. No budget raised.

## The test is anchored to the schema, not to the other list

`quick_spatial_gate_matches_the_schema` sweeps every entry in `ifc_lite_core::IFC_TYPES`, re-derives the expected answer from the generated inheritance table, and reports every name-level disagreement. Deliberately **not** a comparison against the TypeScript list — two hand lists agreeing with each other is the failure that hid this defect.

Anti-vacuity is a **named required-entity list** of all seventeen, not a count floor: a floor of fifteen survives dropping the one name the issue is about. Plus `IFC_TYPES.len() > 800`, so a truncated catalog cannot make the sweep pass over nothing.

Negative controls: `IFCWALL`, `IFCBUILDINGELEMENTPROXY`, `IFCZONE`, `IFCEXTERNALSPATIALELEMENT`, `IFCEXTERNALSPATIALSTRUCTUREELEMENT`, the abstract supertypes `IFCSPATIALELEMENT` / `IFCPRODUCT` / `IFCOBJECT` / `IFCROOT`, and a name in no schema.

## Mutation check

Excluding one entity from the derivation (`IfcType::IfcMarinePart => false`) reds all three tests with a specific message, not a generic one:

```
the fast-boot spatial gate disagrees with the generated schema for 1 type(s): ["IFCMARINEPART: gate=false schema=true"]
IFCMARINEPART #22 must be a node in the fast-boot spatial tree; got [(1, "IFCPROJECT"), (20, "IFCSITE"), (21, "IFCMARINEFACILITY"), (30, "IFCFACILITY"), (31, "IFCFACILITYPARTCOMMON")]
```

Restored by the inverse edit; `diff` against a pre-mutation copy confirms the file is byte-identical.

## The TypeScript half

Not duplicated here on purpose — it is already in review as #3249, which adds `IfcMarinePart` and `IfcFacilityPartCommon` to `SPATIAL_STRUCTURE_TYPE_ENUMS` and rewrites `spatial-types.test.ts` to derive its expectation from `ENTITIES_IFC4X3` under the **identical** rule this PR uses (`!abstract && isDescendantOf(name, 'IfcSpatialStructureElement')`). Writing the same change again here would only produce a conflicting duplicate.

That list stays hand-written on the TypeScript side, and the reason is structural rather than a preference: `SPATIAL_STRUCTURE_TYPE_ENUMS` holds `IfcTypeEnum` members, and `IfcTypeEnum` is itself hand-maintained — a derivation cannot mint an enum member that does not exist. So the list stays, and its *test* derives, which is what stops it drifting again.

**Both need to land.** With only this PR merged, the Rust gate accepts `IfcMarinePart` / `IfcFacilityPartCommon` while the TypeScript builder still does not — the same divergence pointing the other way. With both, the two halves are anchored to the same schema rule in two independently generated tables, so a new spatial structure entity in a future schema is picked up automatically by Rust and reddens the TypeScript gate rather than passing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
