### PR TITLE
fix(georef,core): exact-match the ePSet MapUnit label — BOTH halves read DECAMETRE as metres (#3292)

### DIFF
--- a/.changeset/georef-epset-map-unit-exact-match.md
+++ b/.changeset/georef-epset-map-unit-exact-match.md
@@ -1,0 +1,25 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Exact-match the `ePSet_ProjectedCRS.MapUnit` label instead of substring-sniffing it
+
+`inferMapUnitScaleFromLabel` tested `MILLI`/`CENTI`/`DECI`/`KILO` and then fell
+through to `includes('METRE')`. That substring is satisfied by every prefixed
+spelling, so a `DECAMETRE` map unit resolved to a scale of `1` instead of `10`,
+`HECTOMETRE` to `1` instead of `100`, and `MICROMETRE` to `1` instead of `1e-6`
+— a silent error in the CRS scale by the prefix's own factor. `SQUARE METRE`,
+an area unit, also resolved to `1`.
+
+The label is now folded to its alphanumerics and matched exactly against a set
+derived from the `IfcSIPrefix` EXPRESS enumeration (all sixteen members crossed
+with the METRE/METER spellings), the unprefixed base, and the shared
+conversion-based length units. Labels with no exact answer resolve to
+`undefined`, which is the documented ePSet convention: the project length unit
+applies downstream. Declining is deliberate — an absent MapUnit has a defined
+meaning, a wrong one relocates the model.
+
+The Rust twin (`ifc_lite_core::GeoRefExtractor`) carried the identical
+substring bug and is fixed the same way, so both halves were wrong together;
+the shared cross-language fixture now pins the behaviour to the enumeration
+rather than to either implementation.

--- a/packages/parser/src/georef-extractor.ts
+++ b/packages/parser/src/georef-extractor.ts
@@ -216,25 +216,63 @@ function asNumber(value: string | number | undefined): number | undefined {
   return typeof value === 'number' ? value : getNumber(value);
 }
 
+/** Fold a free-text unit label to its alphanumerics, upper-cased. */
+function foldUnitLabel(label: string): string {
+  return label.toUpperCase().replace(/[^A-Z0-9]/g, '');
+}
+
 /**
- * Map an IFC unit label (e.g. "MILLIMETRE", "FOOT") to its metre scale.
- * Mirrors the viewer's `inferMapUnitScale` and the native `IfcProjectedCRS`
- * path so direct parser/MCP consumers of `ProjectedCRS.mapUnitScale` see the
- * same scale regardless of whether the CRS came from a native entity or an
- * ePSet. Returns `undefined` for an absent/unknown unit (the ePSet convention
- * then defers to the project length unit downstream).
+ * Exact-match table for an `ePSet_ProjectedCRS.MapUnit` free-text label,
+ * DERIVED rather than hand-written: every member of the `IfcSIPrefix` EXPRESS
+ * enumeration crossed with the METRE/METER spellings, the unprefixed base,
+ * and the conversion-based length units from the shared table.
+ *
+ * A `Map` rather than an object literal so a label like `CONSTRUCTOR` cannot
+ * resolve through `Object.prototype`.
+ */
+const MAP_UNIT_LABEL_SCALE: Map<string, number> = (() => {
+  const table = new Map<string, number>();
+  for (const spelling of ['METRE', 'METER']) {
+    table.set(foldUnitLabel(spelling), 1);
+    for (const [prefix, factor] of Object.entries(SI_PREFIX_MULTIPLIERS)) {
+      table.set(foldUnitLabel(prefix + spelling), factor);
+    }
+  }
+  for (const [name, factor] of Object.entries(CONVERSION_BASED_UNIT_FACTORS)) {
+    table.set(foldUnitLabel(name), factor);
+  }
+  // The US survey foot is a different ratio from the international foot
+  // (1200/3937 vs 0.3048) and is spelled several ways in the wild. These are
+  // the accepted spellings, matched exactly rather than sniffed for.
+  for (const alias of ['USSURVEYFOOT', 'USSURVEYFEET', 'USSURVEYFT', 'USFOOT', 'USFEET', 'USFT', 'FTUS']) {
+    table.set(alias, 0.3048006096);
+  }
+  return table;
+})();
+
+/**
+ * Resolve an `ePSet_ProjectedCRS.MapUnit` free-text label to its metre scale.
+ *
+ * EXACT match against {@link MAP_UNIT_LABEL_SCALE}. `undefined` for anything
+ * else, including an absent label: the ePSet convention then defers to the
+ * project length unit downstream.
+ *
+ * This deliberately does NOT substring-match. An `includes('METRE')` test is
+ * satisfied by MILLIMETRE, CENTIMETRE, KILOMETRE, DECAMETRE, HECTOMETRE and
+ * every other prefixed spelling, so a decametre map unit answered 1 — a
+ * silent 10x error in the CRS scale. The same shape scaled a projected CRS by
+ * 1000x in #3274. Where no exact answer exists, decline rather than
+ * approximate: an absent MapUnit is honest and has a defined meaning, a wrong
+ * one relocates the model.
+ *
+ * Twin of `infer_map_unit_scale` in rust/core/src/georef.rs; both are pinned
+ * to the shared vectors in rust/core/tests/fixtures/georef_vectors.json.
  */
 function inferMapUnitScaleFromLabel(mapUnit: string | undefined): number | undefined {
   if (!mapUnit) return undefined;
-  const n = mapUnit.toUpperCase();
-  if (n.includes('US') && (n.includes('SURVEY') || n.includes('FTUS'))) return 0.3048006096;
-  if (n.includes('FOOT') || n.includes('FEET')) return 0.3048;
-  if (n.includes('MILLI')) return 0.001;
-  if (n.includes('CENTI')) return 0.01;
-  if (n.includes('DECI')) return 0.1;
-  if (n.includes('KILO')) return 1000;
-  if (n.includes('METRE') || n.includes('METER')) return 1;
-  return undefined;
+  const key = foldUnitLabel(mapUnit);
+  if (!key) return undefined;
+  return MAP_UNIT_LABEL_SCALE.get(key);
 }
 
 /**

--- a/packages/parser/src/georef.parity.test.ts
+++ b/packages/parser/src/georef.parity.test.ts
@@ -171,6 +171,20 @@ describe.skipIf(!existsSync(fixturePath))('extractGeoreferencing shared parity v
       const want = `projected_crs_si_prefix_${prefix}`;
       expect(present.has(want), `IfcSIPrefix.${prefix} has no vector: \`${want}\` is missing`).toBe(true);
     }
+    // The ePSet free-text label path is where BOTH halves were wrong the same
+    // way, so a harness that only diffs the two could not see it. These are the
+    // labels a substring test for METRE silently collapses onto 1, plus the two
+    // refusal cases that prove the reader declines instead of approximating.
+    for (const want of [
+      'epset_map_unit_label_DECAMETRE',
+      'epset_map_unit_label_HECTOMETRE',
+      'epset_map_unit_label_KILOMETRE',
+      'epset_map_unit_label_MICROMETRE',
+      'epset_map_unit_label_SQUARE_METRE_REFUSED',
+      'epset_map_unit_label_UNKNOWN_REFUSED',
+    ]) {
+      expect(present.has(want), `ePSet MapUnit label vector \`${want}\` is missing`).toBe(true);
+    }
   });
 
   for (const c of doc.cases) {

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -28,35 +28,65 @@ fn pset_value_string(prop: &DecodedEntity) -> Option<String> {
     }
 }
 
-/// Map an IFC unit label (e.g. "MILLIMETRE", "FOOT") to its metre scale.
-/// Mirrors the TS parser's `inferMapUnitScaleFromLabel` and the viewer's
-/// `inferMapUnitScale` so an ePSet_ProjectedCRS.MapUnit yields the same scale
-/// the native IfcProjectedCRS path resolves from the unit entity. Returns
-/// `None` for an absent/unknown unit (the ePSet convention then defers to the
-/// project length unit downstream).
+/// Resolve an `ePSet_ProjectedCRS.MapUnit` free-text label to its metre scale.
+///
+/// EXACT match against a set derived from the `IfcSIPrefix` EXPRESS
+/// enumeration (all sixteen members, each crossed with the METRE/METER
+/// spellings) plus the conversion-based length units, after folding the label
+/// to its alphanumerics. `None` for anything else, including an absent label:
+/// the ePSet convention then defers to the project length unit downstream.
+///
+/// This deliberately does NOT substring-match. A `contains("METRE")` test is
+/// satisfied by MILLIMETRE, CENTIMETRE, KILOMETRE, DECAMETRE, HECTOMETRE and
+/// every other prefixed spelling, so a decametre map unit answered 1.0 — a
+/// silent 10x error in the CRS scale. The same shape scaled a projected CRS
+/// by 1000x in #3274. Where no exact answer exists, decline rather than
+/// approximate: an absent MapUnit is honest and has a defined meaning, a
+/// wrong one relocates the model.
+///
+/// Twin of `inferMapUnitScaleFromLabel` in
+/// packages/parser/src/georef-extractor.ts; both are pinned to the shared
+/// vectors in rust/core/tests/fixtures/georef_vectors.json.
 fn infer_map_unit_scale(label: &str) -> Option<f64> {
-    let n = label.to_uppercase();
-    if n.contains("US") && (n.contains("SURVEY") || n.contains("FTUS")) {
+    let key: String = label
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_uppercase())
+        .collect();
+    if key.is_empty() {
+        return None;
+    }
+
+    // The US survey foot is a different ratio from the international foot
+    // (1200/3937 vs 0.3048), and is spelled several ways in the wild. These
+    // are the accepted spellings, matched exactly rather than sniffed for.
+    if matches!(
+        key.as_str(),
+        "USSURVEYFOOT" | "USSURVEYFEET" | "USSURVEYFT" | "USFOOT" | "USFEET" | "USFT" | "FTUS"
+    ) {
         return Some(0.3048006096);
     }
-    if n.contains("FOOT") || n.contains("FEET") {
-        return Some(0.3048);
+
+    // Conversion-based length units (FOOT/FEET/INCH/YARD/MILE), from the same
+    // table the native IfcConversionBasedUnit path uses.
+    if let Some(factor) = crate::units::get_conversion_based_unit_factor(&key) {
+        return Some(factor);
     }
-    if n.contains("MILLI") {
-        return Some(0.001);
+
+    // SI: strip the base-unit spelling, then resolve what remains as an
+    // IfcSIPrefix member. An empty remainder is the unprefixed metre.
+    for spelling in ["METRE", "METER"] {
+        if let Some(prefix) = key.strip_suffix(spelling) {
+            if prefix.is_empty() {
+                return Some(1.0);
+            }
+            // `try_`, not `get_`: the infallible form answers 1.0 for an
+            // unrecognised prefix, which is the very approximation this
+            // function exists to refuse.
+            return crate::units::try_si_prefix_multiplier(prefix);
+        }
     }
-    if n.contains("CENTI") {
-        return Some(0.01);
-    }
-    if n.contains("DECI") {
-        return Some(0.1);
-    }
-    if n.contains("KILO") {
-        return Some(1000.0);
-    }
-    if n.contains("METRE") || n.contains("METER") {
-        return Some(1.0);
-    }
+
     None
 }
 

--- a/rust/core/src/units.rs
+++ b/rust/core/src/units.rs
@@ -10,29 +10,45 @@
 use crate::decoder::EntityDecoder;
 use crate::error::Result;
 
-/// SI Prefix multipliers as defined in IFC specification
-/// Maps IfcSIPrefix enum values to their numeric multipliers
+/// SI Prefix multiplier for a member of the `IfcSIPrefix` EXPRESS
+/// enumeration, or `None` when the string is not one of its sixteen members.
+///
+/// The checked form exists because callers that need to tell "no prefix" from
+/// "a prefix I do not recognise" cannot use [`get_si_prefix_multiplier`],
+/// which collapses both onto 1.0. Resolving an `ePSet_ProjectedCRS.MapUnit`
+/// label is one such caller: answering 1.0 for an unrecognised spelling is a
+/// silent wrong answer, where declining to answer defers to the project
+/// length unit, which is the documented convention.
+#[inline]
+pub fn try_si_prefix_multiplier(prefix: &str) -> Option<f64> {
+    match prefix {
+        "ATTO" => Some(1e-18),
+        "FEMTO" => Some(1e-15),
+        "PICO" => Some(1e-12),
+        "NANO" => Some(1e-9),
+        "MICRO" => Some(1e-6),
+        "MILLI" => Some(1e-3), // Most common: millimeters
+        "CENTI" => Some(1e-2), // Centimeters
+        "DECI" => Some(1e-1),  // Decimeters
+        "DECA" => Some(1e1),   // Dekameters
+        "HECTO" => Some(1e2),  // Hectometers
+        "KILO" => Some(1e3),   // Kilometers
+        "MEGA" => Some(1e6),
+        "GIGA" => Some(1e9),
+        "TERA" => Some(1e12),
+        "PETA" => Some(1e15),
+        "EXA" => Some(1e18),
+        _ => None,
+    }
+}
+
+/// SI Prefix multipliers as defined in IFC specification.
+/// Maps IfcSIPrefix enum values to their numeric multipliers; an absent or
+/// unrecognised prefix means the base unit (metres), i.e. 1.0. Callers that
+/// must distinguish those two cases want [`try_si_prefix_multiplier`].
 #[inline]
 pub fn get_si_prefix_multiplier(prefix: &str) -> f64 {
-    match prefix {
-        "ATTO" => 1e-18,
-        "FEMTO" => 1e-15,
-        "PICO" => 1e-12,
-        "NANO" => 1e-9,
-        "MICRO" => 1e-6,
-        "MILLI" => 1e-3, // Most common: millimeters
-        "CENTI" => 1e-2, // Centimeters
-        "DECI" => 1e-1,  // Decimeters
-        "DECA" => 1e1,   // Dekameters
-        "HECTO" => 1e2,  // Hectometers
-        "KILO" => 1e3,   // Kilometers
-        "MEGA" => 1e6,
-        "GIGA" => 1e9,
-        "TERA" => 1e12,
-        "PETA" => 1e15,
-        "EXA" => 1e18,
-        _ => 1.0, // No prefix or unknown = base unit (meters)
-    }
+    try_si_prefix_multiplier(prefix).unwrap_or(1.0)
 }
 
 /// Known conversion factors for imperial/conversion-based units to meters

--- a/rust/core/tests/fixtures/georef_vectors.json
+++ b/rust/core/tests/fixtures/georef_vectors.json
@@ -49,7 +49,16 @@
     "projected_crs_conversion_based_INCH",
     "projected_crs_no_map_unit_defers_to_project_unit",
     "epset_map_conversion_ifc2x3",
-    "epset_map_conversion_millimetre_unit"
+    "epset_map_conversion_millimetre_unit",
+    "epset_map_unit_label_DECAMETRE",
+    "epset_map_unit_label_HECTOMETRE",
+    "epset_map_unit_label_KILOMETRE",
+    "epset_map_unit_label_MICROMETRE",
+    "epset_map_unit_label_METER_US_SPELLING",
+    "epset_map_unit_label_FOOT",
+    "epset_map_unit_label_US_SURVEY_FOOT",
+    "epset_map_unit_label_SQUARE_METRE_REFUSED",
+    "epset_map_unit_label_UNKNOWN_REFUSED"
   ],
   "cases": [
     {
@@ -397,6 +406,141 @@
         "crsName": "EPSG:2056",
         "mapUnit": "MILLIMETRE",
         "mapUnitScale": 0.001,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_DECAMETRE",
+      "_note": "IfcSIPrefix.DECA = 1e1. A substring test for METRE is satisfied by DECAMETRE and answers 1.0 -- a silent 10x error. Exact match required.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('DECAMETRE'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "DECAMETRE",
+        "mapUnitScale": 10.0,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_HECTOMETRE",
+      "_note": "IfcSIPrefix.HECTO = 1e2. Same substring trap as DECAMETRE, 100x.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('HECTOMETRE'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "HECTOMETRE",
+        "mapUnitScale": 100.0,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_KILOMETRE",
+      "_note": "One of the prefixed spellings a METRE substring test collapses onto 1.0.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('KILOMETRE'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "KILOMETRE",
+        "mapUnitScale": 1000.0,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_MICROMETRE",
+      "_note": "IfcSIPrefix.MICRO = 1e-6.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('MICROMETRE'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "MICROMETRE",
+        "mapUnitScale": 1e-06,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_METER_US_SPELLING",
+      "_note": "The METER spelling is the unprefixed base unit, scale 1.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('METER'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "METER",
+        "mapUnitScale": 1.0,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_FOOT",
+      "_note": "Conversion-based length unit, from the same table the native IfcConversionBasedUnit path uses.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('FOOT'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "FOOT",
+        "mapUnitScale": 0.3048,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_US_SURVEY_FOOT",
+      "_note": "The US survey foot is a different ratio from the international foot; separators are folded away before the exact match.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('US survey foot'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "US survey foot",
+        "mapUnitScale": 0.3048006096,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_SQUARE_METRE_REFUSED",
+      "_note": "An area unit is not a length unit. A METRE substring test answered 1.0 here. No exact answer exists, so the reader must decline and let the project length unit apply -- an absent value is honest, a wrong one relocates the model.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('SQUARE METRE'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "SQUARE METRE",
+        "mapUnitScale": null,
+        "eastings": 1000.0,
+        "northings": 2000.0,
+        "orthogonalHeight": 3.0
+      }
+    },
+    {
+      "name": "epset_map_unit_label_UNKNOWN_REFUSED",
+      "_note": "BANANA is not an IfcSIPrefix member. Stripping the METRE spelling must not fall through to the base unit: refuse rather than approximate.",
+      "ifc": "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\nFILE_NAME('t','',(''),(''),'','','');\nFILE_SCHEMA(('IFC2X3'));\nENDSEC;\nDATA;\n#10=IFCPROPERTYSINGLEVALUE('Eastings',$,IFCREAL(1000.),$);\n#11=IFCPROPERTYSINGLEVALUE('Northings',$,IFCREAL(2000.),$);\n#12=IFCPROPERTYSINGLEVALUE('OrthogonalHeight',$,IFCREAL(3.),$);\n#16=IFCPROPERTYSET('0aaaaaaaaaaaaaaaaaaaaa',$,'ePSet_MapConversion',$,(#10,#11,#12));\n#20=IFCPROPERTYSINGLEVALUE('Name',$,IFCLABEL('EPSG:2056'),$);\n#22=IFCPROPERTYSINGLEVALUE('MapUnit',$,IFCLABEL('BANANAMETRE'),$);\n#21=IFCPROPERTYSET('0bbbbbbbbbbbbbbbbbbbbb',$,'ePSet_ProjectedCRS',$,(#20,#22));\nENDSEC;\nEND-ISO-10303-21;\n",
+      "expect": {
+        "hasGeoreference": true,
+        "source": "ePSetMapConversion",
+        "crsName": "EPSG:2056",
+        "mapUnit": "BANANAMETRE",
+        "mapUnitScale": null,
         "eastings": 1000.0,
         "northings": 2000.0,
         "orthogonalHeight": 3.0

--- a/rust/core/tests/georef_parity.rs
+++ b/rust/core/tests/georef_parity.rs
@@ -220,4 +220,24 @@ fn fixture_carries_every_required_case() {
             "IfcSIPrefix.{prefix} has no vector: `{want}` is missing"
         );
     }
+
+    // The ePSet free-text label path is where BOTH halves were wrong the same
+    // way, so a harness that only diffs the two could not see it. These are
+    // the labels a `contains("METRE")` test silently collapses onto 1.0, plus
+    // the two refusal cases that prove the reader declines instead of
+    // approximating. Named individually: dropping any one of them is exactly
+    // how this defect would come back.
+    for want in [
+        "epset_map_unit_label_DECAMETRE",
+        "epset_map_unit_label_HECTOMETRE",
+        "epset_map_unit_label_KILOMETRE",
+        "epset_map_unit_label_MICROMETRE",
+        "epset_map_unit_label_SQUARE_METRE_REFUSED",
+        "epset_map_unit_label_UNKNOWN_REFUSED",
+    ] {
+        assert!(
+            present.contains(&want),
+            "ePSet MapUnit label vector `{want}` is missing from the shared fixture"
+        );
+    }
 }


### PR DESCRIPTION
> **Stacked on #3287** (base is `georef/parity-harness`, not `main`) — it needs the exported `SI_PREFIX_MULTIPLIERS` and the shared fixture from that PR. Review #3287 first; this diff shows only the new work. Happy to rebase onto `main` once #3287 lands.

## Why the parity harness could not catch this

#3286 was the two halves **disagreeing**. This is the two halves being **wrong the same way** — `contains("METRE")` in Rust, `includes('METRE')` in TS. A cross-language diff is green on it. Only an expectation anchored to the EXPRESS enumeration finds it, which is exactly why the harness compares both halves to the schema rather than to each other.

## The defect

Both twins tested `MILLI`/`CENTI`/`DECI`/`KILO`, then fell through to a METRE substring test — satisfied by every prefixed spelling.

RED on `upstream/main`, **identical on both halves**:

```
rust: case `epset_map_unit_label_DECAMETRE`: mapUnitScale: got 1, want 10

ts:   mapUnitScale: got 1, want 10          (DECAMETRE)
      mapUnitScale: got 1, want 100         (HECTOMETRE)
      mapUnitScale: got 1, want 0.000001    (MICROMETRE)
                                            (SQUARE_METRE_REFUSED)
                                            (UNKNOWN_REFUSED)
```

`SQUARE METRE` — an area unit — also resolved to `1.0`.

Third instance of the shape: #3274 (`.includes('METRE')`, 1000x CRS error), #3278 (`IFC4` inside an unrelated header string), this.

## The fix, and the deliberate choice on unrecognised labels

Fold to alphanumerics, exact-match against a set **derived** from the `IfcSIPrefix` enumeration (sixteen members x METRE/METER), the unprefixed base, and the shared conversion-based units.

**Unrecognised → decline, not default.** Stating the reasoning since it was asked for explicitly: this is not a new refusal contract, it is the one **already documented on both functions** — *"Returns `None` for an absent/unknown unit (the ePSet convention then defers to the project length unit downstream)."* The bug is that substring matching *stole labels away from that refusal path* and handed them a wrong answer. Exactness returns them to it. Defaulting to `1.0` **is** the current defect, and #3276 set the precedent: leave the OPTIONAL value absent rather than guess metres — an absent MapUnit has a defined meaning downstream, a wrong one silently relocates the model.

Rust gains `units::try_si_prefix_multiplier`: the existing `get_si_prefix_multiplier` returns `1.0` for an unrecognised prefix — the very approximation being removed — so distinguishing "no prefix" from "a prefix I do not know" needs a checked accessor. `get_si_prefix_multiplier` delegates to it, keeping one authority.

## Fixture

9 new vectors. `DECAMETRE`, `HECTOMETRE`, `MICROMETRE`, `KILOMETRE` and both refusal cases are named **individually** in the anti-vacuity guard on both sides — dropping any one is how this defect comes back. `KILOMETRE` resolves correctly today (its explicit test precedes the fallthrough) and is a regression guard, green before and after.

GREEN: parser 74/74 files, 728 tests; `cargo test -p ifc-lite-core --test georef_parity` 2/2.

## Related finding — there are TWO halves, not three

I checked whether `rust/processing/src/georeferencing.rs` is a third implementation. **It is not.** It is a thin serialization caller: `GeoRefExtractor::extract` at `rust/processing/src/georeferencing.rs:150`, `Georeferencing::from_core` at `:78` cloning every field and reusing core's own `geo.rotation()` / `geo.to_matrix()`. No independent parsing or arithmetic, so it inherits both fixes automatically.

One stale doc comment there, reported not fixed (PR #3280 owns that file): the comment at `:104-108` says only `IfcMapConversion`, `IfcProjectedCRS` and `IfcPropertySet` are collected, but the match arm at `:141` also collects `IFCSITE` for the legacy fallback. Code is correct; the comment undercounts.

Refs #3292