### PR TITLE
test(encoding,ids): make the linearity ladder's last assertion capable of failing (#3285)

### DIFF
--- a/packages/encoding/src/numeric-literal.test.ts
+++ b/packages/encoding/src/numeric-literal.test.ts
@@ -246,11 +246,19 @@ describe('deciding it is linear, not backtracking', () => {
     // scan, so the language is identical by construction and the only
     // difference is wasted work -- which is what makes it a clean probe of
     // sensitivity rather than of correctness.
+    // The precondition this control rests on, asserted BEFORE the ladder runs
+    // so a trimmed ladder fails with THIS reason instead of as a null `blown`
+    // below. What stood here -- `expect(blown).toBeLessThanOrEqual(2_560_000)`
+    // -- could not fail (#3285): `firstBlownRung` returns a member of SIZES or
+    // null, 2_560_000 IS the largest member, and null is already caught by the
+    // line above it. The property that assertion was reaching for is about the
+    // LADDER, not about `blown`: this control still decides 640k inside the
+    // budget, so a ladder that stops there would report `null` and prove
+    // nothing about sensitivity.
+    const DECIDED_INSIDE_BUDGET = 640_000;
+    expect(SIZES[SIZES.length - 1]).toBeGreaterThan(DECIDED_INSIDE_BUDGET);
     const blown = firstBlownRung(isWhollyNumericSmallConstantSuperlinear);
     expect(blown).not.toBeNull();
-    // Named, not just non-null: if a future edit trims the ladder back to
-    // 640k this fails with the reason rather than going quietly vacuous.
-    expect(blown).toBeLessThanOrEqual(2_560_000);
   });
 });
 

--- a/packages/ids/src/constraints/numeric-literal.test.ts
+++ b/packages/ids/src/constraints/numeric-literal.test.ts
@@ -322,11 +322,19 @@ describe('deciding it is linear, not backtracking (#3113)', () => {
     // scan, so the language is identical by construction and the only
     // difference is wasted work -- which is what makes it a clean probe of
     // sensitivity rather than of correctness.
+    // The precondition this control rests on, asserted BEFORE the ladder runs
+    // so a trimmed ladder fails with THIS reason instead of as a null `blown`
+    // below. What stood here -- `expect(blown).toBeLessThanOrEqual(2_560_000)`
+    // -- could not fail (#3285): `firstBlownRung` returns a member of SIZES or
+    // null, 2_560_000 IS the largest member, and null is already caught by the
+    // line above it. The property that assertion was reaching for is about the
+    // LADDER, not about `blown`: this control still decides 640k inside the
+    // budget, so a ladder that stops there would report `null` and prove
+    // nothing about sensitivity.
+    const DECIDED_INSIDE_BUDGET = 640_000;
+    expect(SIZES[SIZES.length - 1]).toBeGreaterThan(DECIDED_INSIDE_BUDGET);
     const blown = firstBlownRung(isStrictNumericLiteralSmallConstantSuperlinear);
     expect(blown).not.toBeNull();
-    // Named, not just non-null: if a future edit trims the ladder back to
-    // 640k this fails with the reason rather than going quietly vacuous.
-    expect(blown).toBeLessThanOrEqual(2_560_000);
   });
 });
 


### PR DESCRIPTION
Refs #3285. Test-only; no published package behaviour changes, so no changeset.

## Reproduced on current `main`

Both copies pass unmutated (encoding shown; ids identical):

```
✓ the ladder can fail: a superlinear scan with a small constant blows a rung  2117ms
```

Then the exact case the comment claims the last line guards — trim `SIZES` to end at `640_000`, everything else untouched:

```
× the ladder can fail: a superlinear scan with a small constant blows a rung
    AssertionError: expected null not to be null
```

It reds one line **earlier**, at `expect(blown).not.toBeNull()`. `expect(blown).toBeLessThanOrEqual(2_560_000)` never executes, and could not have failed if it had: `firstBlownRung` returns a member of `SIZES` or `null`, `2_560_000` **is** the largest member, and `null` is already caught above. The assertion written to keep the test from going quietly vacuous was the vacuous one, with a comment asserting the opposite.

## Root cause

The property is about the **ladder**, not about `blown`. This control still decides 640k inside the budget — that is why #3226's review extended the ladder past it — so a ladder stopping at 640k reports `null` and demonstrates nothing about sensitivity. Bounding `blown` from above can never express that, because `blown` is drawn from the ladder itself.

## Fix

The extent of the ladder, asserted **before** the ladder runs so a trimmed ladder fails with its own reason instead of as a null `blown` further down:

```ts
const DECIDED_INSIDE_BUDGET = 640_000;
expect(SIZES[SIZES.length - 1]).toBeGreaterThan(DECIDED_INSIDE_BUDGET);
const blown = firstBlownRung(isWhollyNumericSmallConstantSuperlinear);
expect(blown).not.toBeNull();
```

Both copies: `packages/encoding/src/numeric-literal.test.ts` and `packages/ids/src/constraints/numeric-literal.test.ts`. A fix to one is half a fix — the two files carry the same ladder for two different scans.

## Mutation check (the new assertion can fail, with the reason)

Same trim as the reproduction, now against the fixed test — both copies, separately:

```
@ifc-lite/encoding × the ladder can fail: a superlinear scan with a small constant blows a rung
    AssertionError: expected 640000 to be greater than 640000

@ifc-lite/ids      × the ladder can fail: a superlinear scan with a small constant blows a rung
    AssertionError: expected 640000 to be greater than 640000
```

Note the timing: 2ms/3ms against 2117ms green. The trimmed ladder is now rejected before any work is done, which is the point of putting the precondition first. Restored by the inverse edit; `diff` byte-identical in both files.

## Sweep

`firstBlownRung` / this ladder exists in exactly these two files (repo-wide grep), and `toBeLessThanOrEqual` bounded by the maximum of its own domain has no other occurrence.

## Verification

```
@ifc-lite/encoding: 99 tests passed (6 files)
@ifc-lite/ids:     766 tests passed (21 files)
pnpm typecheck (encoding, ids): 9 tasks successful
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436



Closes #3285
