### PR TITLE
fix(release): gate the crates.io publish on cargo-semver-checks (#3216)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,26 @@ jobs:
           echo "sb_version=$(node -p "require('./packages/server-bin/package.json').version")" >> $GITHUB_OUTPUT
           echo "pending=$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')" >> $GITHUB_OUTPUT
 
+      # SEMVER GATE for the crates (issue #3216). `pnpm release` runs
+      # `check:rust-semver` before it publishes anything; these two steps put
+      # the tool it needs on PATH.
+      #
+      # A stable toolchain, not the dated nightly in rust-toolchain.toml:
+      # cargo-semver-checks refuses a nightly outright ("rustc version is not
+      # high enough: >=1.93.0 needed, got 1.93.0-nightly"). The gate invokes it
+      # as `cargo +stable semver-checks`, so this only has to exist; it does not
+      # become the default toolchain and nothing else in the release uses it.
+      - name: Install stable Rust for the crate semver gate
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-05
+        with:
+          toolchain: stable
+
+      # Prebuilt binary. `cargo install cargo-semver-checks --locked` compiles
+      # it from source (~5 min) on a runner that is already the slowest job in
+      # the repo.
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@4f5ee4a4759116abc6b10af05f20374e179d8ca3 # cargo-semver-checks (snapshot pinned 2026-08)
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1364,9 +1364,58 @@ jobs:
   # for the branch protection rule so we don't have to retouch settings.
   # Succeeds if every dependency succeeded or was skipped (path-filtered
   # out); fails the moment any dependency fails or is cancelled.
+  # The crate semver gate (issue #3216). It runs at release time as the
+  # crates.io half's precondition, but a release-only gate is exactly the shape
+  # `release-crates-order.test.mjs` argues against in its own header: the
+  # Release workflow runs only on main, and only on an actual publish, so a
+  # breaking API change sits latent until it fails after npm has already gone
+  # out. This runs it on every PR instead.
+  #
+  # It is cheap on an ordinary PR and expensive only where it has signal. Each
+  # crate whose version is already live on crates.io is skipped BEFORE
+  # cargo-semver-checks is invoked, which on an ordinary PR is all of them: the
+  # job is seven registry lookups and a message saying plainly that no API was
+  # compared. On the `chore: version packages` PR, where `sync-versions.js` has
+  # moved the workspace version, it does the real comparison — and that is the
+  # commit whose version the whole issue is about, reviewed before it merges
+  # and publishes.
+  rust-semver:
+    name: Rust crate semver
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+
+      # A stable toolchain, not the dated nightly in rust-toolchain.toml:
+      # cargo-semver-checks refuses a nightly outright ("rustc version is not
+      # high enough: >=1.93.0 needed, got 1.93.0-nightly"). The gate invokes it
+      # as `cargo +stable semver-checks`, so this only has to exist.
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master 2026-05
+        with:
+          toolchain: stable
+
+      # Prebuilt binary. `cargo install cargo-semver-checks --locked` compiles
+      # it from source (~5 min).
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@4f5ee4a4759116abc6b10af05f20374e179d8ca3 # cargo-semver-checks (snapshot pinned 2026-08)
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+        with:
+          prefix-key: ci-rust-semver
+
+      # No `pnpm install`: the gate imports only node builtins and
+      # scripts/lib/crates-io.mjs, which does the same.
+      - name: Check crate semver against crates.io
+        run: node scripts/check-rust-semver.mjs
+
   test:
     name: Build + WASM + Rust + Node
-    needs: [changes, build, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, geometry-census, plato-check, docs-checks]
+    needs: [changes, build, typecheck, lint, node-tests, viewer-tests, viewer-e2e, rust-tests, rust-semver, geometry-census, plato-check, docs-checks]
     if: always()
     # Free runner — the gate just inspects upstream job results.
     runs-on: ubuntu-latest
@@ -1381,6 +1430,7 @@ jobs:
             [viewer-tests]="${{ needs.viewer-tests.result }}"
             [viewer-e2e]="${{ needs.viewer-e2e.result }}"
             [rust-tests]="${{ needs.rust-tests.result }}"
+            [rust-semver]="${{ needs.rust-semver.result }}"
             [geometry-census]="${{ needs.geometry-census.result }}"
             [plato-check]="${{ needs.plato-check.result }}"
             [docs-checks]="${{ needs.docs-checks.result }}"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check:csv-escapers": "node scripts/check-csv-escaper-copies.mjs",
     "check:vitest-timeout-audit": "git ls-files -z '*.test.ts' '*.test.tsx' | xargs -0 node scripts/lib/vitest-timeout-audit.mjs --summary-only",
     "check:api-surface": "node scripts/check-api-surface.mjs",
+    "check:rust-semver": "node scripts/check-rust-semver.mjs",
     "api-surface:update": "node scripts/check-api-surface.mjs --update",
     "check:git-lfs": "node scripts/check-git-lfs.mjs",
     "check:server-bin-targets": "node scripts/check-server-bin-targets.mjs",

--- a/scripts/check-rust-semver.mjs
+++ b/scripts/check-rust-semver.mjs
@@ -53,53 +53,54 @@
  * VACUITY. Every way this gate could report success over nothing is an
  * explicit failure with a named reason (#3194/#3200): an empty crate list, a
  * crate list that shrank below CRATE_FLOOR, a crate with no release on
- * crates.io to compare against, a missing `cargo-semver-checks` binary, and a
- * run that produced no verdict line. None of those is a skip.
+ * crates.io to compare against, a missing `cargo-semver-checks` binary, an
+ * unreadable workspace version, and a run that produced no verdict line. None
+ * of those is a skip.
  *
  * Run: `node scripts/check-rust-semver.mjs`  (`pnpm check:rust-semver`)
  * Self-test: `node --test scripts/check-rust-semver.test.mjs`
  */
 
-import { readFileSync, existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { CRATES, readWorkspaceVersion } from './lib/crates-io.mjs';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
 /**
- * The gate must cover EVERY crate the release publishes, so the list is read
- * from the one place that decides that — the `CRATES` array in
- * `scripts/release-crates.mjs` — instead of being retyped here. A second copy
- * would go stale exactly when a crate is added, which is the moment this gate
- * is most needed.
- *
- * Read textually rather than by `import`, because importing that module
- * EXECUTES it, and it publishes to crates.io at top level.
- *
- * Returns null (not []) when the array cannot be found, so "the list moved"
- * cannot be mistaken for "there are no crates".
+ * The gate must cover EVERY crate the release publishes, so the list is the
+ * one the release itself uses — `CRATES` from `scripts/lib/crates-io.mjs`,
+ * which `release-crates.mjs` and `verify-crates-publish.js` already share
+ * (#3181). A second copy here would go stale exactly when a crate is added,
+ * which is the moment this gate is most needed.
  */
-export function parseCrateList(source) {
-  const block = source.match(/const CRATES = \[([\s\S]*?)\n\];/);
-  if (!block) return null;
-  return [...block[1].matchAll(/^\s*'([^']+)',/gm)].map((m) => m[1]);
-}
 
 /**
- * Floor on the crate count. A regex that half-matches (the array reformatted,
- * an entry rewritten with double quotes) yields a short list, and a gate that
- * checked two crates prints the same success line as one that checked all of
- * them. If a crate is genuinely dropped from the release, lower this in the
- * same commit.
+ * Floor on the crate count. Importing the list rather than re-typing it rules
+ * out one drift, not all of them: a filter, a conditional entry, or a partial
+ * edit still yields a short list, and a gate that checked two crates prints
+ * the same success line as one that checked all seven. If a crate is genuinely
+ * dropped from the release, lower this in the same commit.
  */
 export const CRATE_FLOOR = 7;
 
-/** `[workspace.package] version` — the version this release would publish. */
-export function parseWorkspaceVersion(cargoToml) {
-  const m = cargoToml.match(/\[workspace\.package\][^[]*?version\s*=\s*"([^"]+)"/);
-  if (!m) return null;
-  return /^\d+\.\d+\.\d+$/.test(m[1]) ? m[1] : null;
+/**
+ * The version this release would publish, or null.
+ *
+ * `readWorkspaceVersion` (shared with release-crates.mjs) THROWS when the key
+ * is missing and otherwise returns whatever string is there, semver or not.
+ * Both have to become "no usable version" here rather than a crash or a value
+ * the comparison silently mishandles.
+ */
+export function readVersionOrNull(rootDir) {
+  let version;
+  try {
+    version = readWorkspaceVersion(rootDir);
+  } catch {
+    return null;
+  }
+  return /^\d+\.\d+\.\d+$/.test(version) ? version : null;
 }
 
 /** The bump `current` carries over `baseline`: major | minor | patch | none. */
@@ -150,7 +151,7 @@ export function checkRustSemver({ crates, workspaceVersion, latestPublished, run
   const failures = [];
   const checked = [];
 
-  // The SHAPE is checked here, not only in parseWorkspaceVersion: a version
+  // The SHAPE is checked here, not only in readVersionOrNull: a version
   // that is a string but not a semver triple makes every `bumpLevel`
   // comparison NaN, which reads as "no change", which reads as "already
   // published, nothing to gate" — a vacuous pass over every crate at once.
@@ -285,23 +286,6 @@ function realRunSemverChecks(crate, baseline) {
 }
 
 function main() {
-  const listSource = join(REPO_ROOT, 'scripts', 'release-crates.mjs');
-  if (!existsSync(listSource)) {
-    console.error(
-      '❌ MISSING_LIST: scripts/release-crates.mjs is gone; nothing names the published crates'
-    );
-    process.exit(2);
-  }
-  const crates = parseCrateList(readFileSync(listSource, 'utf8'));
-  if (crates === null) {
-    console.error(
-      '❌ NO_CRATES: scripts/release-crates.mjs no longer declares a `const CRATES = [...]` ' +
-        'array. Point this gate at wherever the published crate list moved to — do not let it ' +
-        'read an empty list.'
-    );
-    process.exit(2);
-  }
-
   const probe = spawnSync('cargo', [`+${SEMVER_TOOLCHAIN}`, 'semver-checks', '--version'], {
     encoding: 'utf8',
   });
@@ -315,12 +299,9 @@ function main() {
     process.exit(2);
   }
 
-  const workspaceVersion = parseWorkspaceVersion(
-    readFileSync(join(REPO_ROOT, 'Cargo.toml'), 'utf8')
-  );
   const result = checkRustSemver({
-    crates,
-    workspaceVersion,
+    crates: CRATES,
+    workspaceVersion: readVersionOrNull(REPO_ROOT),
     latestPublished: realLatestPublished,
     runSemverChecks: realRunSemverChecks,
   });
@@ -332,7 +313,8 @@ function main() {
     process.exit(1);
   }
   console.log(
-    `✅ ${result.checked.length} crate(s) checked; every Rust API change fits ${workspaceVersion}`
+    `✅ ${result.checked.length} crate(s) checked; every Rust API change fits ` +
+      `${readVersionOrNull(REPO_ROOT)}`
   );
 }
 

--- a/scripts/check-rust-semver.mjs
+++ b/scripts/check-rust-semver.mjs
@@ -113,6 +113,30 @@ export function bumpLevel(baseline, current) {
   return 'none';
 }
 
+/**
+ * Is `current` strictly AHEAD of `baseline`?
+ *
+ * [[bumpLevel]] answers which component differs, never in which direction, so
+ * a release carrying 6.0.2 against a crates.io baseline of 7.0.0 reads as a
+ * `major` — the top rank, which no `required` verdict can exceed. Every
+ * comparison for that crate would then pass without examining anything, and
+ * the checked line would read `7.0.0 -> 6.0.2 (major; requires major)`.
+ *
+ * This is HARDENING, not a fixed live defect: the Cargo version is derived
+ * from the highest npm package version by scripts/sync-versions.js, and
+ * changesets never walk a version backwards, so no route that reaches it is
+ * known. The gate refuses it anyway — a comparison whose direction is
+ * unchecked is exactly the shape this file exists to refuse.
+ */
+export function isVersionAdvanced(baseline, current) {
+  const b = baseline.split('.').map(Number);
+  const c = current.split('.').map(Number);
+  for (let i = 0; i < 3; i += 1) {
+    if (c[i] !== b[i]) return c[i] > b[i];
+  }
+  return false;
+}
+
 const RANK = { none: 0, patch: 1, minor: 2, major: 3 };
 
 /**
@@ -203,12 +227,37 @@ export function checkRustSemver({ crates, workspaceVersion, latestPublished, run
       continue;
     }
 
+    // Every version comparison below is arithmetic on three integers, so a
+    // baseline that is not a semver triple makes each one NaN — and a NaN
+    // comparison reads as "no change", which reads as a pass.
+    if (!/^\d+\.\d+\.\d+$/.test(baseline)) {
+      failures.push(
+        `BAD_BASELINE: ${crate}'s latest release on crates.io reads ` +
+          `${JSON.stringify(baseline)}, which is not a semver triple, so there is no ` +
+          'comparable baseline to judge this release against.'
+      );
+      continue;
+    }
+
     const carried = bumpLevel(baseline, workspaceVersion);
     if (RANK[carried] === 0) {
       // Same version as the one already on crates.io: release-crates.mjs skips
       // publishing it, so there is no new version whose bump could be wrong.
       checked.push(`${crate} ${baseline} — already published at this version, not republished`);
       skipped += 1;
+      continue;
+    }
+
+    // Direction, which `bumpLevel` cannot see. Checked BEFORE the expensive
+    // run: there is nothing useful to compare a backwards version against.
+    if (!isVersionAdvanced(baseline, workspaceVersion)) {
+      failures.push(
+        `VERSION_NOT_ADVANCED: ${crate} is on crates.io at ${baseline}, but this release ` +
+          `carries ${workspaceVersion}, which is not ahead of it. \`bumpLevel\` reports which ` +
+          'component differs, not in which direction, so a backwards version reads as the ' +
+          'largest bump there is and no required verdict could ever exceed it — the crate ' +
+          'would pass this gate without its API being judged at all.'
+      );
       continue;
     }
 

--- a/scripts/check-rust-semver.mjs
+++ b/scripts/check-rust-semver.mjs
@@ -150,6 +150,10 @@ export function interpretRun({ status, output }) {
 export function checkRustSemver({ crates, workspaceVersion, latestPublished, runSemverChecks }) {
   const failures = [];
   const checked = [];
+  // Crates the release would NOT republish (their version is already live).
+  // Counted separately so the success line can never say "N crates checked"
+  // about crates whose API was never compared — see the report at the end.
+  let skipped = 0;
 
   // The SHAPE is checked here, not only in readVersionOrNull: a version
   // that is a string but not a semver triple makes every `bumpLevel`
@@ -204,6 +208,7 @@ export function checkRustSemver({ crates, workspaceVersion, latestPublished, run
       // Same version as the one already on crates.io: release-crates.mjs skips
       // publishing it, so there is no new version whose bump could be wrong.
       checked.push(`${crate} ${baseline} — already published at this version, not republished`);
+      skipped += 1;
       continue;
     }
 
@@ -232,7 +237,7 @@ export function checkRustSemver({ crates, workspaceVersion, latestPublished, run
       checked,
     };
   }
-  return { ok: failures.length === 0, failures, checked };
+  return { ok: failures.length === 0, failures, checked, compared: checked.length - skipped };
 }
 
 /* ---------- real-world wiring (the unit tests inject fakes instead) ---------- */
@@ -312,9 +317,17 @@ function main() {
     for (const f of result.failures) console.error(`  - ${f}\n`);
     process.exit(1);
   }
+  if (result.compared === 0) {
+    console.log(
+      `✅ nothing to gate: all ${result.checked.length} crate(s) are already on crates.io at ` +
+        `${readVersionOrNull(REPO_ROOT)}, so this release republishes none of them. ` +
+        'No API was compared — do not read this as a compatibility result.'
+    );
+    return;
+  }
   console.log(
-    `✅ ${result.checked.length} crate(s) checked; every Rust API change fits ` +
-      `${readVersionOrNull(REPO_ROOT)}`
+    `✅ ${result.compared} of ${result.checked.length} crate(s) compared against crates.io; ` +
+      `every Rust API change fits ${readVersionOrNull(REPO_ROOT)}`
   );
 }
 

--- a/scripts/check-rust-semver.mjs
+++ b/scripts/check-rust-semver.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Refuses a release whose Cargo version is too small for what the Rust
+ * public API actually did.
+ *
+ * WHY (issue #3216). Nothing on the Rust side chooses the crate version.
+ * `scripts/sync-versions.js` sets `[workspace.package] version` in
+ * `Cargo.toml` to the HIGHEST npm workspace package version, and that number
+ * comes from a changeset whose bump level was chosen for a TypeScript API. So
+ * a change that is additive in TS and breaking in Rust ships to crates.io as a
+ * minor or a patch, and a consumer pinned to `ifc-lite-processing = "6"`
+ * breaks on `cargo update`. There was no `cargo-semver-checks` anywhere in
+ * `.github/` or `scripts/`, so nothing compared the published crate's API
+ * against the one about to replace it.
+ *
+ * WHAT THIS GATE IS. A CHECK, not an automation. It never picks a version and
+ * never edits a manifest: it asks `cargo-semver-checks` what bump each crate's
+ * API change requires, compares that with the bump the derived version
+ * actually carries over the crate's latest release on crates.io, and FAILS
+ * when the version is the smaller of the two. A release stopped before it
+ * publishes is recoverable; a crate published under the wrong major is not.
+ *
+ * WHAT IT CATCHES: changes to the public API surface that
+ * `cargo-semver-checks`' lint set recognises — a removed or renamed `pub`
+ * item, a changed function signature or arity, a field added to a `pub` struct
+ * that callers construct literally, a variant added to a
+ * non-`#[non_exhaustive]` enum, a trait gaining a defaultless method, a `pub`
+ * item losing a trait impl.
+ *
+ * WHAT IT DOES NOT CATCH, and no version-surface tool can:
+ *   - a behaviour change under an unchanged signature (a unit, a rounding, a
+ *     tolerance, an ordering). #3089 and #3160 were that shape.
+ *   - anything reachable only with a non-default feature that
+ *     cargo-semver-checks' feature heuristic leaves off.
+ *   - the C ABI of `ifc-lite-ffi` as an ABI: the `extern "C"` functions are
+ *     compared as Rust items, so a signature change is seen, but a
+ *     `#[repr(C)]` struct's meaning changing under a stable layout is not.
+ *   - anything about the npm packages. `scripts/check-api-surface.mjs` owns
+ *     that surface, and it does NOT transfer to Rust: it diffs built `.d.ts`
+ *     exports against a snapshot committed in this repo, which can say "this
+ *     export vanished since the last commit" but not "this is breaking against
+ *     the version that is live on crates.io" — and the published version is
+ *     the only baseline a semver claim is about.
+ *
+ * So a green result here means "the public API surface did not change more
+ * than this version number admits". It does not mean the release is
+ * compatible.
+ *
+ * VACUITY. Every way this gate could report success over nothing is an
+ * explicit failure with a named reason (#3194/#3200): an empty crate list, a
+ * crate list that shrank below CRATE_FLOOR, a crate with no release on
+ * crates.io to compare against, a missing `cargo-semver-checks` binary, and a
+ * run that produced no verdict line. None of those is a skip.
+ *
+ * Run: `node scripts/check-rust-semver.mjs`  (`pnpm check:rust-semver`)
+ * Self-test: `node --test scripts/check-rust-semver.test.mjs`
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The gate must cover EVERY crate the release publishes, so the list is read
+ * from the one place that decides that — the `CRATES` array in
+ * `scripts/release-crates.mjs` — instead of being retyped here. A second copy
+ * would go stale exactly when a crate is added, which is the moment this gate
+ * is most needed.
+ *
+ * Read textually rather than by `import`, because importing that module
+ * EXECUTES it, and it publishes to crates.io at top level.
+ *
+ * Returns null (not []) when the array cannot be found, so "the list moved"
+ * cannot be mistaken for "there are no crates".
+ */
+export function parseCrateList(source) {
+  const block = source.match(/const CRATES = \[([\s\S]*?)\n\];/);
+  if (!block) return null;
+  return [...block[1].matchAll(/^\s*'([^']+)',/gm)].map((m) => m[1]);
+}
+
+/**
+ * Floor on the crate count. A regex that half-matches (the array reformatted,
+ * an entry rewritten with double quotes) yields a short list, and a gate that
+ * checked two crates prints the same success line as one that checked all of
+ * them. If a crate is genuinely dropped from the release, lower this in the
+ * same commit.
+ */
+export const CRATE_FLOOR = 7;
+
+/** `[workspace.package] version` — the version this release would publish. */
+export function parseWorkspaceVersion(cargoToml) {
+  const m = cargoToml.match(/\[workspace\.package\][^[]*?version\s*=\s*"([^"]+)"/);
+  if (!m) return null;
+  return /^\d+\.\d+\.\d+$/.test(m[1]) ? m[1] : null;
+}
+
+/** The bump `current` carries over `baseline`: major | minor | patch | none. */
+export function bumpLevel(baseline, current) {
+  const b = baseline.split('.').map(Number);
+  const c = current.split('.').map(Number);
+  if (c[0] !== b[0]) return 'major';
+  if (c[1] !== b[1]) return 'minor';
+  if (c[2] !== b[2]) return 'patch';
+  return 'none';
+}
+
+const RANK = { none: 0, patch: 1, minor: 2, major: 3 };
+
+/**
+ * The verdict of one `cargo-semver-checks` run.
+ *
+ * The exit code alone is NOT the signal: it is non-zero both for "this needs a
+ * major and you wrote a minor" and for "rustdoc failed to build". Reading the
+ * second as the first reports a semver break nobody can fix; reading it as a
+ * pass is the vacuous green this gate exists to refuse. So the summary line
+ * must be present and recognised, and anything else is NO_VERDICT, which
+ * fails.
+ */
+export function interpretRun({ status, output }) {
+  if (/Summary\s+no semver update required/.test(output)) {
+    return { required: 'patch', reason: null };
+  }
+  const requires = output.match(/Summary\s+semver requires new (major|minor) version/);
+  if (requires) return { required: requires[1], reason: null };
+  return {
+    required: null,
+    reason:
+      `NO_VERDICT: cargo-semver-checks exited ${status} without a "Summary" line — ` +
+      'it could not build or compare the crate, so nothing was checked',
+  };
+}
+
+/**
+ * @param {object} deps
+ * @param {string[]|null} deps.crates      crate names, from release-crates.mjs
+ * @param {string|null} deps.workspaceVersion  the version the release would publish
+ * @param {(crate: string) => string|null} deps.latestPublished  crates.io latest, or null
+ * @param {(crate: string, baseline: string) => {status: number, output: string}} deps.runSemverChecks
+ * @returns {{ok: boolean, failures: string[], checked: string[]}}
+ */
+export function checkRustSemver({ crates, workspaceVersion, latestPublished, runSemverChecks }) {
+  const failures = [];
+  const checked = [];
+
+  // The SHAPE is checked here, not only in parseWorkspaceVersion: a version
+  // that is a string but not a semver triple makes every `bumpLevel`
+  // comparison NaN, which reads as "no change", which reads as "already
+  // published, nothing to gate" — a vacuous pass over every crate at once.
+  if (!workspaceVersion || !/^\d+\.\d+\.\d+$/.test(workspaceVersion)) {
+    return {
+      ok: false,
+      failures: [
+        `BAD_VERSION: ${JSON.stringify(workspaceVersion)} is not a semver ` +
+          '[workspace.package] version, so there is no version to judge the API change against',
+      ],
+      checked,
+    };
+  }
+  if (!crates || crates.length === 0) {
+    return {
+      ok: false,
+      failures: [
+        'NO_CRATES: the crate list is empty, so this gate would have checked nothing. ' +
+          'The CRATES array in scripts/release-crates.mjs is what it reads; if that moved, follow it.',
+      ],
+      checked,
+    };
+  }
+  if (crates.length < CRATE_FLOOR) {
+    return {
+      ok: false,
+      failures: [
+        `CRATE_FLOOR: found ${crates.length} crate(s), fewer than the floor of ${CRATE_FLOOR}. ` +
+          'The scan is wrong, not the release — if a crate was genuinely dropped from the ' +
+          'publish list, lower CRATE_FLOOR in the same commit.',
+      ],
+      checked,
+    };
+  }
+
+  for (const crate of crates) {
+    const baseline = latestPublished(crate);
+    if (!baseline) {
+      failures.push(
+        `NO_BASELINE: ${crate} has no release on crates.io to compare against, so its semver ` +
+          'bump cannot be judged. A crate published for the first time must be bootstrapped by ' +
+          'hand (see release-crates.mjs); a crate that IS published and reads as absent here ' +
+          'means the registry lookup failed, and a failed lookup must not read as compatible.'
+      );
+      continue;
+    }
+
+    const carried = bumpLevel(baseline, workspaceVersion);
+    if (RANK[carried] === 0) {
+      // Same version as the one already on crates.io: release-crates.mjs skips
+      // publishing it, so there is no new version whose bump could be wrong.
+      checked.push(`${crate} ${baseline} — already published at this version, not republished`);
+      continue;
+    }
+
+    const { required, reason } = interpretRun(runSemverChecks(crate, baseline));
+    if (reason) {
+      failures.push(`${crate}: ${reason}`);
+      continue;
+    }
+    checked.push(`${crate} ${baseline} -> ${workspaceVersion} (${carried}; requires ${required})`);
+    if (RANK[required] > RANK[carried]) {
+      failures.push(
+        `${crate}: its public API change requires a ${required.toUpperCase()} bump, but this ` +
+          `release carries ${baseline} -> ${workspaceVersion}, which is a ${carried}. ` +
+          'The Cargo version is derived from the highest npm package version ' +
+          '(scripts/sync-versions.js), so a changeset written about the TypeScript API cannot ' +
+          'express this. Do not weaken this check: either the Rust change is reverted or made ' +
+          'additive, or the crate version is raised by hand before publishing.'
+      );
+    }
+  }
+
+  if (checked.length === 0 && failures.length === 0) {
+    return {
+      ok: false,
+      failures: ['NO_CRATES_CHECKED: every crate was passed over without a verdict'],
+      checked,
+    };
+  }
+  return { ok: failures.length === 0, failures, checked };
+}
+
+/* ---------- real-world wiring (the unit tests inject fakes instead) ---------- */
+
+function realLatestPublished(crate) {
+  const res = spawnSync(
+    'curl',
+    [
+      '-sS',
+      '-H',
+      'User-Agent: ifc-lite-release (github.com/LTplus-AG/ifc-lite)',
+      `https://crates.io/api/v1/crates/${crate}`,
+    ],
+    { encoding: 'utf8' }
+  );
+  if (res.status !== 0) return null;
+  try {
+    const body = JSON.parse(res.stdout);
+    return body?.crate?.max_stable_version || body?.crate?.max_version || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `rust-toolchain.toml` pins this workspace to a dated nightly, and
+ * cargo-semver-checks refuses it outright ("rustc version is not high enough:
+ * >=1.93.0 needed, got 1.93.0-nightly"). Left alone that produces no Summary
+ * line, so the gate would fail with NO_VERDICT on every crate — fail-closed,
+ * but for the wrong reason and with no way to act on it. So the toolchain is
+ * named explicitly, and overridable for the day stable moves under us.
+ */
+const SEMVER_TOOLCHAIN = process.env.IFC_LITE_SEMVER_TOOLCHAIN || 'stable';
+
+function realRunSemverChecks(crate, baseline) {
+  const res = spawnSync(
+    'cargo',
+    [
+      `+${SEMVER_TOOLCHAIN}`,
+      'semver-checks',
+      '--package',
+      crate,
+      '--baseline-version',
+      baseline,
+      '--color',
+      'never',
+    ],
+    { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }
+  );
+  return { status: res.status ?? -1, output: `${res.stdout || ''}${res.stderr || ''}` };
+}
+
+function main() {
+  const listSource = join(REPO_ROOT, 'scripts', 'release-crates.mjs');
+  if (!existsSync(listSource)) {
+    console.error(
+      '❌ MISSING_LIST: scripts/release-crates.mjs is gone; nothing names the published crates'
+    );
+    process.exit(2);
+  }
+  const crates = parseCrateList(readFileSync(listSource, 'utf8'));
+  if (crates === null) {
+    console.error(
+      '❌ NO_CRATES: scripts/release-crates.mjs no longer declares a `const CRATES = [...]` ' +
+        'array. Point this gate at wherever the published crate list moved to — do not let it ' +
+        'read an empty list.'
+    );
+    process.exit(2);
+  }
+
+  const probe = spawnSync('cargo', [`+${SEMVER_TOOLCHAIN}`, 'semver-checks', '--version'], {
+    encoding: 'utf8',
+  });
+  if (probe.status !== 0) {
+    console.error(
+      `❌ TOOL_MISSING: \`cargo +${SEMVER_TOOLCHAIN} semver-checks\` is not available. This gate ` +
+        'fails rather than skips: a release that could not be checked must not read as a ' +
+        'release that passed. Install it with `cargo install cargo-semver-checks --locked` ' +
+        `and make sure the \`${SEMVER_TOOLCHAIN}\` toolchain is present.`
+    );
+    process.exit(2);
+  }
+
+  const workspaceVersion = parseWorkspaceVersion(
+    readFileSync(join(REPO_ROOT, 'Cargo.toml'), 'utf8')
+  );
+  const result = checkRustSemver({
+    crates,
+    workspaceVersion,
+    latestPublished: realLatestPublished,
+    runSemverChecks: realRunSemverChecks,
+  });
+
+  for (const line of result.checked) console.log(`   ${line}`);
+  if (!result.ok) {
+    console.error('\n❌ Rust crate semver gate failed (#3216):\n');
+    for (const f of result.failures) console.error(`  - ${f}\n`);
+    process.exit(1);
+  }
+  console.log(
+    `✅ ${result.checked.length} crate(s) checked; every Rust API change fits ${workspaceVersion}`
+  );
+}
+
+if (process.argv[1] && process.argv[1].endsWith('check-rust-semver.mjs')) main();

--- a/scripts/check-rust-semver.test.mjs
+++ b/scripts/check-rust-semver.test.mjs
@@ -339,6 +339,20 @@ test('the release workflow installs what the gate needs', () => {
   assert.match(workflow, /Install stable Rust for the crate semver gate/);
 });
 
+test('the gate runs on PRs, not only at release time', () => {
+  // A release-only gate is the shape release-crates-order.test.mjs argues
+  // against in its own header: the Release workflow runs only on main, and
+  // only on an actual publish, so a breaking change sits latent until it fails
+  // after npm has already gone out.
+  const workflow = readFileSync(join(ROOT, '.github', 'workflows', 'test.yml'), 'utf8');
+  assert.match(workflow, /run: node scripts\/check-rust-semver\.mjs/);
+  assert.match(workflow, /taiki-e\/install-action@[0-9a-f]{40} # cargo-semver-checks/);
+  // …and it must be one of the jobs the required check actually gates on. A
+  // job nobody depends on is a job whose red is invisible.
+  assert.match(workflow, /needs: \[[^\]]*\brust-semver\b[^\]]*\]/);
+  assert.match(workflow, /\[rust-semver\]="\$\{\{ needs\.rust-semver\.result \}\}"/);
+});
+
 /* ------------------------------- the real CLI ------------------------------- */
 
 test('VACUITY: the CLI fails with TOOL_MISSING when cargo-semver-checks is absent', () => {

--- a/scripts/check-rust-semver.test.mjs
+++ b/scripts/check-rust-semver.test.mjs
@@ -204,11 +204,32 @@ test('VACUITY: an unreadable workspace version fails with BAD_VERSION', () => {
   }
 });
 
-test('a crate already published at this exact version is counted, not skipped silently', () => {
+test('a crate already published at this exact version is reported, and NOT counted as compared', () => {
+  // The release republishes none of them, so there is nothing to gate — but
+  // the success line must not claim seven crates were compared when zero were.
   const result = run({ workspaceVersion: '6.0.1' });
   assert.equal(result.ok, true);
   assert.equal(result.checked.length, SEVEN.length);
+  assert.equal(result.compared, 0);
   assert.match(result.checked[0], /already published at this version/);
+});
+
+test('the CLI says plainly that nothing was compared when nothing is republished', () => {
+  const res = spawnSync(process.execPath, [join(SCRIPTS, 'check-rust-semver.mjs')], {
+    encoding: 'utf8',
+    env: { ...process.env, IFC_LITE_SEMVER_TOOLCHAIN: 'stable' },
+  });
+  if (res.status !== 0) return; // a real comparison ran, or the tool is absent
+  if (!/nothing to gate/.test(res.stdout)) return;
+  assert.match(res.stdout, /No API was compared/);
+});
+
+test('a mixed run counts only the crates actually compared', () => {
+  const result = run({
+    latestPublished: (crate) => (crate === SEVEN[0] ? '6.0.2' : '6.0.1'),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.compared, SEVEN.length - 1);
 });
 
 /* ----------------------------- the pieces it parses ---------------------------- */

--- a/scripts/check-rust-semver.test.mjs
+++ b/scripts/check-rust-semver.test.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression harness for scripts/check-rust-semver.mjs (issue #3216).
+ *
+ * The gate prints "every Rust API change fits <version>". That sentence is
+ * equally true of a release whose crates really are compatible and of a run
+ * that compared nothing — so every way it could go false-green is an
+ * executable case here: no crates, a crate list that silently shrank, a crate
+ * with no baseline on crates.io, a `cargo-semver-checks` run that produced no
+ * verdict, and an unreadable workspace version. Each must FAIL, and fail with
+ * its own named reason.
+ *
+ * The expensive half (`cargo semver-checks`, minutes per crate, network for
+ * the baseline) is injected, so the decision logic is tested at unit speed and
+ * the real runner is exercised once by hand — see the PR for that transcript.
+ * The one thing the injection cannot fake, `cargo semver-checks` being absent
+ * from PATH, is covered by spawning the real CLI at the bottom of this file.
+ *
+ * Run: node --test scripts/check-rust-semver.test.mjs
+ * (also picked up by the scripts/*.test.mjs glob catch-all in test.yml).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, dirname, delimiter } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseCrateList,
+  parseWorkspaceVersion,
+  bumpLevel,
+  interpretRun,
+  checkRustSemver,
+  CRATE_FLOOR,
+} from './check-rust-semver.mjs';
+
+const SCRIPTS = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SCRIPTS, '..');
+
+/** Seven names, so a case that is not about the crate list clears CRATE_FLOOR. */
+const SEVEN = [
+  'ifc-lite-core',
+  'ifc-lite-clash',
+  'ifc-lite-geometry',
+  'ifc-lite-processing',
+  'ifc-lite-export',
+  'ifc-lite-ffi',
+  'ifc-lite-wasm',
+];
+
+/** `cargo semver-checks` output for each verdict, copied from a real run. */
+const COMPATIBLE = {
+  status: 0,
+  output: [
+    '    Checking ifc-lite-clash v6.0.1 -> v6.0.2 (patch change)',
+    '     Checked [   0.598s] 223 checks: 223 pass, 31 skip',
+    '     Summary no semver update required',
+    '    Finished [ 200.665s] ifc-lite-clash',
+  ].join('\n'),
+};
+const NEEDS_MAJOR = {
+  status: 1,
+  output: [
+    '--- failure method_parameter_count_changed: pub method parameter count changed ---',
+    '  ifc_lite_clash::Aabb::inflate takes 1 parameters ..., but now takes 2 parameters ...',
+    '     Checked [   0.007s] 223 checks: 222 pass, 1 fail, 0 warn, 31 skip',
+    '     Summary semver requires new major version: 1 major and 0 minor checks failed',
+    '    Finished [ 205.112s] ifc-lite-clash',
+  ].join('\n'),
+};
+const NEEDS_MINOR = {
+  status: 1,
+  output: '     Summary semver requires new minor version: 0 major and 1 minor checks failed',
+};
+
+/** Defaults every case starts from: all seven crates published at 6.0.1. */
+function run(overrides = {}) {
+  return checkRustSemver({
+    crates: SEVEN,
+    workspaceVersion: '6.0.2',
+    latestPublished: () => '6.0.1',
+    runSemverChecks: () => COMPATIBLE,
+    ...overrides,
+  });
+}
+
+/* ------------------------------- the gap itself ------------------------------ */
+
+test('RED: a breaking Rust change under a patch npm bump is refused', () => {
+  const result = run({
+    runSemverChecks: (crate) => (crate === 'ifc-lite-processing' ? NEEDS_MAJOR : COMPATIBLE),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /^ifc-lite-processing: /);
+  assert.match(result.failures[0], /requires a MAJOR bump/);
+  // The numbers must be in the message: a gate that says "semver violation"
+  // without saying which version it compared against is not actionable.
+  assert.match(result.failures[0], /6\.0\.1 -> 6\.0\.2/);
+  assert.match(result.failures[0], /which is a patch/);
+});
+
+test('GREEN: a compatible change under the same patch bump passes', () => {
+  const result = run();
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.checked.length, SEVEN.length);
+});
+
+test('GREEN: the same breaking change passes once the version carries a major', () => {
+  const result = run({
+    workspaceVersion: '7.0.0',
+    runSemverChecks: (crate) => (crate === 'ifc-lite-processing' ? NEEDS_MAJOR : COMPATIBLE),
+  });
+  assert.equal(result.ok, true, result.failures.join('\n'));
+});
+
+test('a minor-requiring change is refused under a patch and allowed under a minor', () => {
+  const under = run({ runSemverChecks: () => NEEDS_MINOR });
+  assert.equal(under.ok, false);
+  assert.match(under.failures[0], /requires a MINOR bump/);
+
+  const over = run({ workspaceVersion: '6.1.0', runSemverChecks: () => NEEDS_MINOR });
+  assert.equal(over.ok, true, over.failures.join('\n'));
+});
+
+test('every offending crate is named, not just the first', () => {
+  const result = run({ runSemverChecks: () => NEEDS_MAJOR });
+  assert.equal(result.failures.length, SEVEN.length);
+  for (const crate of SEVEN) {
+    assert.ok(
+      result.failures.some((f) => f.startsWith(`${crate}:`)),
+      `${crate} is missing from the failure list`
+    );
+  }
+});
+
+/* ------------------------------ vacuous passes ------------------------------ */
+
+test('VACUITY: an empty crate list fails with NO_CRATES', () => {
+  const result = run({ crates: [] });
+  assert.equal(result.ok, false);
+  assert.match(result.failures[0], /^NO_CRATES: /);
+});
+
+test('VACUITY: a crate list that could not be found fails with NO_CRATES', () => {
+  const result = run({ crates: null });
+  assert.equal(result.ok, false);
+  assert.match(result.failures[0], /^NO_CRATES: /);
+});
+
+test('VACUITY: a crate list that silently shrank fails with CRATE_FLOOR', () => {
+  const result = run({ crates: SEVEN.slice(0, 2) });
+  assert.equal(result.ok, false);
+  assert.match(result.failures[0], /^CRATE_FLOOR: found 2 crate\(s\)/);
+  // The remedy must be stated, or someone whose scan is fine gets an actively
+  // wrong instruction.
+  assert.match(result.failures[0], /lower CRATE_FLOOR in the same commit/);
+});
+
+test('VACUITY: a crate with no crates.io baseline fails with NO_BASELINE', () => {
+  const result = run({
+    latestPublished: (crate) => (crate === 'ifc-lite-ffi' ? null : '6.0.1'),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0], /^NO_BASELINE: ifc-lite-ffi /);
+});
+
+test('VACUITY: a registry lookup that fails for EVERY crate is not a pass', () => {
+  const result = run({ latestPublished: () => null });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, SEVEN.length);
+  assert.equal(result.checked.length, 0);
+});
+
+test('VACUITY: output with no Summary line fails with NO_VERDICT', () => {
+  const unreadable = {
+    status: 1,
+    output: 'error: failed to build rustdoc for crate ifc-lite-clash v6.0.1',
+  };
+  const result = run({ runSemverChecks: () => unreadable });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, SEVEN.length);
+  assert.match(result.failures[0], /NO_VERDICT: cargo-semver-checks exited 1/);
+});
+
+test('VACUITY: an empty run output is NO_VERDICT, never a pass', () => {
+  const result = run({ runSemverChecks: () => ({ status: 0, output: '' }) });
+  assert.equal(result.ok, false);
+  assert.match(result.failures[0], /NO_VERDICT/);
+});
+
+test('VACUITY: an unreadable workspace version fails with BAD_VERSION', () => {
+  for (const version of [null, '', 'workspace-inherited']) {
+    const result = checkRustSemver({
+      crates: SEVEN,
+      workspaceVersion: version,
+      latestPublished: () => '6.0.1',
+      runSemverChecks: () => COMPATIBLE,
+    });
+    assert.equal(result.ok, false, `version ${JSON.stringify(version)} passed`);
+    assert.match(result.failures[0], /^BAD_VERSION: /);
+  }
+});
+
+test('a crate already published at this exact version is counted, not skipped silently', () => {
+  const result = run({ workspaceVersion: '6.0.1' });
+  assert.equal(result.ok, true);
+  assert.equal(result.checked.length, SEVEN.length);
+  assert.match(result.checked[0], /already published at this version/);
+});
+
+/* ----------------------------- the pieces it parses ---------------------------- */
+
+test('the crate list is read from the real release-crates.mjs', () => {
+  const crates = parseCrateList(readFileSync(join(SCRIPTS, 'release-crates.mjs'), 'utf8'));
+  assert.notEqual(crates, null, 'release-crates.mjs no longer declares a CRATES array');
+  assert.ok(
+    crates.length >= CRATE_FLOOR,
+    `parsed ${crates.length} crates, below the floor of ${CRATE_FLOOR}`
+  );
+  for (const crate of crates) {
+    assert.match(crate, /^ifc-lite-/, `unexpected entry ${crate}`);
+  }
+});
+
+test('every crate the gate would check exists under rust/', () => {
+  const crates = parseCrateList(readFileSync(join(SCRIPTS, 'release-crates.mjs'), 'utf8'));
+  const names = new Set();
+  for (const dir of ['core', 'clash', 'geometry', 'processing', 'export', 'ffi', 'wasm-bindings']) {
+    const manifest = join(ROOT, 'rust', dir, 'Cargo.toml');
+    if (!existsSync(manifest)) continue;
+    const name = readFileSync(manifest, 'utf8').match(/^name\s*=\s*"([^"]+)"/m)?.[1];
+    if (name) names.add(name);
+  }
+  for (const crate of crates) {
+    assert.ok(names.has(crate), `${crate} is in CRATES but has no manifest under rust/`);
+  }
+});
+
+test('the crate list is null, never [], when the array cannot be found', () => {
+  assert.equal(parseCrateList('const OTHER = ["ifc-lite-core"];'), null);
+});
+
+test('CRATE_FLOOR catches a CRATES entry the parser cannot see', () => {
+  // One entry rewritten with double quotes: the parser drops it silently, and
+  // without the floor the gate would check six crates and report success.
+  const mangled =
+    'const CRATES = [\n' +
+    SEVEN.map((c, i) => (i === 0 ? `  "${c}",` : `  '${c}',`)).join('\n') +
+    '\n];';
+  const crates = parseCrateList(mangled);
+  assert.equal(crates.length, SEVEN.length - 1);
+  const result = run({ crates });
+  assert.equal(result.ok, false);
+  assert.match(result.failures[0], /^CRATE_FLOOR/);
+});
+
+test('the workspace version is read from the real Cargo.toml', () => {
+  const version = parseWorkspaceVersion(readFileSync(join(ROOT, 'Cargo.toml'), 'utf8'));
+  assert.match(version, /^\d+\.\d+\.\d+$/);
+});
+
+test('a non-semver workspace version reads as absent, not as a version', () => {
+  assert.equal(parseWorkspaceVersion('[workspace.package]\nversion = "nightly"\n'), null);
+  assert.equal(parseWorkspaceVersion('[package]\nversion = "1.2.3"\n'), null);
+});
+
+test('bumpLevel names the bump the version carries', () => {
+  assert.equal(bumpLevel('6.0.1', '7.0.0'), 'major');
+  assert.equal(bumpLevel('6.0.1', '6.1.0'), 'minor');
+  assert.equal(bumpLevel('6.0.1', '6.0.2'), 'patch');
+  assert.equal(bumpLevel('6.0.1', '6.0.1'), 'none');
+  // A major bump that also moves the minor is still a major, not a minor.
+  assert.equal(bumpLevel('6.0.1', '7.2.0'), 'major');
+});
+
+test('interpretRun reads the three verdicts and refuses anything else', () => {
+  assert.equal(interpretRun(COMPATIBLE).required, 'patch');
+  assert.equal(interpretRun(NEEDS_MINOR).required, 'minor');
+  assert.equal(interpretRun(NEEDS_MAJOR).required, 'major');
+  // A zero exit code with no summary is still no verdict: the exit code is not
+  // the signal.
+  assert.match(interpretRun({ status: 0, output: 'Finished' }).reason, /NO_VERDICT/);
+});
+
+/* -------------------------------- the wiring -------------------------------- */
+
+test('the gate is wired as the crates.io half’s precondition, and only that half', () => {
+  // A gate nothing runs is the same as no gate. It must also NOT gate npm: the
+  // npm bump is not what is wrong, and release-all.mjs exists precisely to stop
+  // one registry being held hostage by the other.
+  const releaseAll = readFileSync(join(SCRIPTS, 'release-all.mjs'), 'utf8');
+  const steps = [...releaseAll.matchAll(/\{\s*name: '([^']+)'[^}]*\}/g)].map((m) => m[0]);
+  assert.ok(steps.length >= 2, 'release-all.mjs no longer declares a STEPS list this test can read');
+
+  const crates = steps.find((s) => s.includes("name: 'crates.io'"));
+  assert.ok(crates, 'release-all.mjs no longer has a crates.io step');
+  assert.match(crates, /precondition: 'check:rust-semver'/);
+
+  const npm = steps.find((s) => s.includes("name: 'npm'"));
+  assert.ok(npm, 'release-all.mjs no longer has an npm step');
+  assert.ok(!npm.includes('precondition'), 'the npm half must not be gated on the Rust semver check');
+
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+  assert.equal(pkg.scripts['check:rust-semver'], 'node scripts/check-rust-semver.mjs');
+});
+
+test('the release workflow installs what the gate needs', () => {
+  // The gate fails closed when cargo-semver-checks is missing (TOOL_MISSING),
+  // so a workflow that forgot to install it would block every release rather
+  // than pass vacuously — loud, but still a release nobody can ship.
+  const workflow = readFileSync(join(ROOT, '.github', 'workflows', 'release.yml'), 'utf8');
+  assert.match(workflow, /taiki-e\/install-action@[0-9a-f]{40} # cargo-semver-checks/);
+  assert.match(workflow, /Install stable Rust for the crate semver gate/);
+});
+
+/* ------------------------------- the real CLI ------------------------------- */
+
+test('VACUITY: the CLI fails with TOOL_MISSING when cargo-semver-checks is absent', () => {
+  // Everything else is injectable; this is not. Run the real entry point with a
+  // PATH that has no `cargo` on it, and assert it refuses rather than skips.
+  const res = spawnSync(process.execPath, [join(SCRIPTS, 'check-rust-semver.mjs')], {
+    encoding: 'utf8',
+    env: { ...process.env, PATH: join(SCRIPTS, 'no-such-directory-for-path') + delimiter },
+  });
+  assert.equal(res.status, 2, `expected exit 2, got ${res.status}\n${res.stdout}${res.stderr}`);
+  assert.match(res.stderr, /TOOL_MISSING/);
+  assert.match(res.stderr, /fails rather than\s+skips/);
+});

--- a/scripts/check-rust-semver.test.mjs
+++ b/scripts/check-rust-semver.test.mjs
@@ -35,6 +35,7 @@ import {
   readVersionOrNull,
   bumpLevel,
   interpretRun,
+  isVersionAdvanced,
   checkRustSemver,
   CRATE_FLOOR,
 } from './check-rust-semver.mjs';
@@ -214,14 +215,89 @@ test('a crate already published at this exact version is reported, and NOT count
   assert.match(result.checked[0], /already published at this version/);
 });
 
-test('the CLI says plainly that nothing was compared when nothing is republished', () => {
+test('the CLI never reports a compatibility result it did not compute', () => {
+  // This test used to `return` before asserting whenever the CLI exited
+  // non-zero or printed anything other than "nothing to gate" — which is
+  // EVERY run on a machine without cargo-semver-checks, i.e. every CI runner
+  // but release.yml's. It executed no assertion at all and still reported a
+  // pass. It now classifies the outcome and asserts in each branch, and an
+  // outcome it cannot classify is a failure rather than a silent skip.
   const res = spawnSync(process.execPath, [join(SCRIPTS, 'check-rust-semver.mjs')], {
     encoding: 'utf8',
     env: { ...process.env, IFC_LITE_SEMVER_TOOLCHAIN: 'stable' },
   });
-  if (res.status !== 0) return; // a real comparison ran, or the tool is absent
-  if (!/nothing to gate/.test(res.stdout)) return;
-  assert.match(res.stdout, /No API was compared/);
+  const out = `${res.stdout || ''}${res.stderr || ''}`;
+  const CLAIMS_A_RESULT = /every Rust API change fits/;
+
+  if (res.status === 2) {
+    // cargo-semver-checks absent: refuse, and do not claim a result.
+    assert.match(out, /TOOL_MISSING/);
+    assert.doesNotMatch(out, CLAIMS_A_RESULT);
+    return;
+  }
+  if (res.status === 0 && /nothing to gate/.test(out)) {
+    assert.match(out, /No API was compared/);
+    assert.doesNotMatch(out, CLAIMS_A_RESULT);
+    return;
+  }
+  if (res.status === 0) {
+    // A real comparison ran; the success line must say how many crates it
+    // actually compared, not merely that something passed.
+    assert.match(out, /\d+ of \d+ crate\(s\) compared against crates\.io/);
+    return;
+  }
+  if (res.status === 1) {
+    assert.match(out, /Rust crate semver gate failed/);
+    return;
+  }
+  assert.fail(`the gate exited ${res.status} with output this test cannot classify:\n${out}`);
+});
+
+test('VACUITY: a release version BEHIND crates.io fails with VERSION_NOT_ADVANCED', () => {
+  // The construction that showed `bumpLevel` is direction-blind: a baseline of
+  // 7.0.0 against a release carrying 6.0.2 is reported as a `major`, the top
+  // rank, so `RANK[required] > RANK[carried]` can never fire — all seven
+  // crates requiring a major passed, printing `7.0.0 -> 6.0.2 (major;
+  // requires major)`. HARDENING, not a fixed live defect: changesets never
+  // walk a version backwards, and no route that reaches this is known.
+  const result = run({
+    workspaceVersion: '6.0.2',
+    latestPublished: () => '7.0.0',
+    runSemverChecks: () => NEEDS_MAJOR,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, SEVEN.length);
+  for (const f of result.failures) assert.match(f, /^VERSION_NOT_ADVANCED: /);
+  // And it must not have printed the reassuring comparison line for any of them.
+  assert.deepEqual(
+    result.checked.filter((line) => /7\.0\.0 -> 6\.0\.2/.test(line)),
+    []
+  );
+});
+
+test('VERSION_NOT_ADVANCED catches a single-component regression too', () => {
+  const result = run({ workspaceVersion: '6.0.1', latestPublished: () => '6.0.2' });
+  assert.equal(result.ok, false);
+  assert.match(result.failures[0], /^VERSION_NOT_ADVANCED: /);
+});
+
+test('bumpLevel is direction-blind BY DESIGN; the direction is checked separately', () => {
+  // Pinned so the two halves of the judgement stay separable: bumpLevel names
+  // the component, isVersionAdvanced names the direction.
+  assert.equal(bumpLevel('7.0.0', '6.0.2'), 'major');
+  assert.equal(bumpLevel('6.0.2', '7.0.0'), 'major');
+  assert.equal(isVersionAdvanced('7.0.0', '6.0.2'), false);
+  assert.equal(isVersionAdvanced('6.0.2', '7.0.0'), true);
+  assert.equal(isVersionAdvanced('6.0.1', '6.0.1'), false);
+});
+
+test('VACUITY: a baseline that is not a semver triple fails with BAD_BASELINE', () => {
+  // Every comparison against it is NaN, and a NaN comparison reads as
+  // "no change", which reads as a pass.
+  const result = run({ latestPublished: () => '6.0.1-alpha.1' });
+  assert.equal(result.ok, false);
+  assert.equal(result.failures.length, SEVEN.length);
+  assert.match(result.failures[0], /^BAD_BASELINE: /);
 });
 
 test('a mixed run counts only the crates actually compared', () => {

--- a/scripts/check-rust-semver.test.mjs
+++ b/scripts/check-rust-semver.test.mjs
@@ -26,32 +26,26 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { join, dirname, delimiter } from 'node:path';
+import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import {
-  parseCrateList,
-  parseWorkspaceVersion,
+  readVersionOrNull,
   bumpLevel,
   interpretRun,
   checkRustSemver,
   CRATE_FLOOR,
 } from './check-rust-semver.mjs';
+import { CRATES } from './lib/crates-io.mjs';
 
 const SCRIPTS = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(SCRIPTS, '..');
 
-/** Seven names, so a case that is not about the crate list clears CRATE_FLOOR. */
-const SEVEN = [
-  'ifc-lite-core',
-  'ifc-lite-clash',
-  'ifc-lite-geometry',
-  'ifc-lite-processing',
-  'ifc-lite-export',
-  'ifc-lite-ffi',
-  'ifc-lite-wasm',
-];
+/** The real published list, so a case that is not about the crate list clears
+ *  CRATE_FLOOR and stays honest about how many crates a release touches. */
+const SEVEN = CRATES;
 
 /** `cargo semver-checks` output for each verdict, copied from a real run. */
 const COMPATIBLE = {
@@ -219,58 +213,60 @@ test('a crate already published at this exact version is counted, not skipped si
 
 /* ----------------------------- the pieces it parses ---------------------------- */
 
-test('the crate list is read from the real release-crates.mjs', () => {
-  const crates = parseCrateList(readFileSync(join(SCRIPTS, 'release-crates.mjs'), 'utf8'));
-  assert.notEqual(crates, null, 'release-crates.mjs no longer declares a CRATES array');
+test('the crate list is the one the release actually publishes', () => {
+  // Shared with release-crates.mjs and verify-crates-publish.js via
+  // scripts/lib/crates-io.mjs (#3181) — imported, not re-typed, so a crate
+  // added to the release cannot be missing from the gate.
   assert.ok(
-    crates.length >= CRATE_FLOOR,
-    `parsed ${crates.length} crates, below the floor of ${CRATE_FLOOR}`
+    CRATES.length >= CRATE_FLOOR,
+    `the release publishes ${CRATES.length} crates, below this gate's floor of ${CRATE_FLOOR}`
   );
-  for (const crate of crates) {
+  for (const crate of CRATES) {
     assert.match(crate, /^ifc-lite-/, `unexpected entry ${crate}`);
   }
 });
 
 test('every crate the gate would check exists under rust/', () => {
-  const crates = parseCrateList(readFileSync(join(SCRIPTS, 'release-crates.mjs'), 'utf8'));
   const names = new Set();
-  for (const dir of ['core', 'clash', 'geometry', 'processing', 'export', 'ffi', 'wasm-bindings']) {
+  for (const dir of readdirSync(join(ROOT, 'rust'))) {
     const manifest = join(ROOT, 'rust', dir, 'Cargo.toml');
     if (!existsSync(manifest)) continue;
     const name = readFileSync(manifest, 'utf8').match(/^name\s*=\s*"([^"]+)"/m)?.[1];
     if (name) names.add(name);
   }
-  for (const crate of crates) {
-    assert.ok(names.has(crate), `${crate} is in CRATES but has no manifest under rust/`);
+  for (const crate of CRATES) {
+    assert.ok(names.has(crate), `${crate} is published but has no manifest under rust/`);
   }
 });
 
-test('the crate list is null, never [], when the array cannot be found', () => {
-  assert.equal(parseCrateList('const OTHER = ["ifc-lite-core"];'), null);
-});
-
-test('CRATE_FLOOR catches a CRATES entry the parser cannot see', () => {
-  // One entry rewritten with double quotes: the parser drops it silently, and
-  // without the floor the gate would check six crates and report success.
-  const mangled =
-    'const CRATES = [\n' +
-    SEVEN.map((c, i) => (i === 0 ? `  "${c}",` : `  '${c}',`)).join('\n') +
-    '\n];';
-  const crates = parseCrateList(mangled);
-  assert.equal(crates.length, SEVEN.length - 1);
-  const result = run({ crates });
+test('CRATE_FLOOR catches a crate list that shrank on the way in', () => {
+  // Importing the list rules out a stale copy, not a filtered or truncated
+  // one. Without the floor a six-crate list would report success over seven
+  // crates' worth of release.
+  const result = run({ crates: CRATES.slice(0, CRATES.length - 1) });
   assert.equal(result.ok, false);
   assert.match(result.failures[0], /^CRATE_FLOOR/);
 });
 
 test('the workspace version is read from the real Cargo.toml', () => {
-  const version = parseWorkspaceVersion(readFileSync(join(ROOT, 'Cargo.toml'), 'utf8'));
-  assert.match(version, /^\d+\.\d+\.\d+$/);
+  assert.match(readVersionOrNull(ROOT), /^\d+\.\d+\.\d+$/);
 });
 
-test('a non-semver workspace version reads as absent, not as a version', () => {
-  assert.equal(parseWorkspaceVersion('[workspace.package]\nversion = "nightly"\n'), null);
-  assert.equal(parseWorkspaceVersion('[package]\nversion = "1.2.3"\n'), null);
+test('a missing or non-semver workspace version reads as absent, not as a version', () => {
+  // readWorkspaceVersion throws on a Cargo.toml with no [workspace.package]
+  // version, and returns the raw string when it is not a semver triple.
+  // Neither may reach the comparison.
+  const dir = mkdtempSync(join(tmpdir(), 'rust-semver-'));
+  try {
+    writeFileSync(join(dir, 'Cargo.toml'), '[package]\nversion = "1.2.3"\n');
+    assert.equal(readVersionOrNull(dir), null);
+    writeFileSync(join(dir, 'Cargo.toml'), '[workspace.package]\nversion = "nightly"\n');
+    assert.equal(readVersionOrNull(dir), null);
+    writeFileSync(join(dir, 'Cargo.toml'), '[workspace.package]\nversion = "1.2.3"\n');
+    assert.equal(readVersionOrNull(dir), '1.2.3');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('bumpLevel names the bump the version carries', () => {

--- a/scripts/release-all.mjs
+++ b/scripts/release-all.mjs
@@ -40,12 +40,42 @@ const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
  *  for the published-package list. */
 const STEPS = [
   { name: 'npm', script: 'release:npm' },
-  { name: 'crates.io', script: 'release:crates' },
+  // `check:rust-semver` (issue #3216) is the crates.io half's precondition, not
+  // the release's. The Cargo version is derived from the highest npm package
+  // version, so a change that is additive in TypeScript and breaking in Rust
+  // reaches crates.io under a minor or a patch. The gate refuses THAT publish.
+  //
+  // It deliberately does not gate npm: the npm bump is not the thing that is
+  // wrong, and making npm a hostage of the Rust half is the exact defect this
+  // file exists to remove — read the header. So a semver violation strands the
+  // crates half on purpose, with a named reason, and npm goes out as versioned.
+  { name: 'crates.io', script: 'release:crates', precondition: 'check:rust-semver' },
 ];
 
 const failed = [];
 
 for (const step of STEPS) {
+  if (step.precondition) {
+    console.log(`\n🔎 release: ${step.name} precondition (pnpm ${step.precondition})`);
+    const gate = spawnSync('pnpm', [step.precondition], {
+      cwd: rootDir,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    });
+    const gateCode = gate.status ?? 1;
+    if (gateCode !== 0) {
+      failed.push({
+        name: `${step.name} (precondition ${step.precondition})`,
+        code: gateCode,
+        error: gate.error,
+      });
+      console.error(
+        `❌ release: ${step.name} SKIPPED — its precondition \`pnpm ${step.precondition}\` ` +
+          `failed (exit ${gateCode}). Nothing was published to ${step.name}.`
+      );
+      continue;
+    }
+  }
   console.log(`\n▶️  release: ${step.name} (pnpm ${step.script})`);
   const result = spawnSync('pnpm', [step.script], {
     cwd: rootDir,


### PR DESCRIPTION
Refs #3216.

## The gap, run rather than read

`scripts/sync-versions.js` picks the Cargo workspace version by taking the **highest npm package version** — nothing on the Rust side is consulted:

```
package.json:73                 "version": "changeset version && node scripts/sync-versions.js"
scripts/sync-versions.js:150    max over non-private packages/* + apps/* package.json versions
scripts/sync-versions.js:173    writes it into [workspace.package] version in Cargo.toml
release.yml                     changesets/action: version: pnpm run version, publish: pnpm run release
package.json:74 -> scripts/release-all.mjs:41 -> release:crates
scripts/release-crates.mjs      reads [workspace.package] version, publishes every crate at it
```

Constructed on `78354d960`: a patch bump of the highest npm package (`@ifc-lite/wasm` 6.0.1 -> 6.0.2), then the release's own version step:

```
$ node scripts/sync-versions.js
📦 Syncing root release version to: 6.0.2
✅ Updated Cargo.toml workspace version to 6.0.2
```

With `Aabb::inflate` — a publicly re-exported item of `ifc-lite-clash` — changed from one parameter to two, which is the same shape as #3210's `with_style_metadata`:

```
$ cargo +stable semver-checks -p ifc-lite-clash --baseline-version 6.0.1
    Checking ifc-lite-clash v6.0.1 -> v6.0.2 (patch change)
     Checked [   0.007s] 223 checks: 222 pass, 1 fail, 0 warn, 31 skip

--- failure method_parameter_count_changed: pub method parameter count changed ---
Failed in:
  ifc_lite_clash::Aabb::inflate takes 1 parameters in .../ifc-lite-clash-6.0.1/src/aabb.rs:78,
  but now takes 2 parameters in .../rust/clash/src/aabb.rs:78

     Summary semver requires new major version: 1 major and 0 minor checks failed
```

A major is required; the release carries a patch; and before this PR nothing anywhere looked:

```
$ git grep -n "semver-checks" upstream/main -- .github scripts
$ echo $?
1
```

**One correction to the issue's framing, found by running it.** The first breaking change I tried was an arity change to `pub fn signed_gap` in `rust/clash/src/aabb.rs`, and cargo-semver-checks reported **`Summary no semver update required`** — `mod aabb` is private and only `Aabb` is re-exported, so that `pub fn` is not in the public API at all. "It is `pub`" and "it is public API" are different claims, and only the second is what a semver tool sees.

## The fix is a check, not an automation

`scripts/check-rust-semver.mjs` never picks a version and never edits a manifest. Per crate in `release-crates.mjs`'s `CRATES` list it asks cargo-semver-checks what bump the API change requires, compares that with the bump the derived version actually carries over the crate's **latest crates.io release**, and fails when the version is the smaller of the two.

It is wired as the **crates.io half's precondition** in `release-all.mjs`, and deliberately **not** npm's. The npm bump is not the thing that is wrong, and making npm a hostage of the Rust half is the exact defect that file's header says it exists to remove.

**What it catches:** removed/renamed `pub` items, changed signatures and arity, a field added to a `pub` struct callers construct literally, a variant added to a non-`#[non_exhaustive]` enum, a trait gaining a defaultless method, a lost trait impl.

**What it does not catch, and I would rather say so than let the tick imply otherwise:**
- a behaviour change under an unchanged signature — a unit, a rounding, a tolerance, an ordering. #3089 and #3160 were that shape and this gate is blind to all of them.
- anything reachable only under a feature cargo-semver-checks' heuristic leaves off.
- the C ABI of `ifc-lite-ffi` **as an ABI**: the `extern "C"` fns are compared as Rust items, so a signature change is seen, but a `#[repr(C)]` struct changing meaning under a stable layout is not.
- anything about the npm packages.

**Does `api-surface.json` transfer?** No. `check-api-surface.mjs` diffs built `.d.ts` exports against a snapshot committed *in this repo*, which answers "did an export vanish since the last commit". A semver claim is about the version that is **live on the registry**, and an in-repo snapshot cannot be that baseline. What transfers is the discipline, not the mechanism: a floor on what was scanned, and a failure rather than a skip.

## Anti-vacuity

Every route to a success line over nothing is a distinct named failure — `NO_CRATES`, `CRATE_FLOOR`, `NO_BASELINE`, `NO_VERDICT`, `BAD_VERSION`, `TOOL_MISSING`, `MISSING_LIST` — each with the house remedy clause where a floor is involved. Notably the exit code is **not** the signal: cargo-semver-checks exits non-zero both for "this needs a major" and for "rustdoc failed to build", so the `Summary` line must be present and recognised, and anything else is `NO_VERDICT`.

**The vacuity test found a live hole in my own first draft.** `checkRustSemver` only tested `!workspaceVersion`, so a version that was a string but not a semver triple made every `bumpLevel` comparison `NaN`, which read as "no change", which read as "already published, nothing to gate" — a vacuous pass over **every crate at once**. The shape is now checked where it is used, not only in the parser.

## Cost

Two extra release steps (a stable toolchain, and the prebuilt cargo-semver-checks binary rather than a ~5 min `cargo install`), then rustdoc for each published crate plus its baseline. This runs once per release, and only before the crates.io half.

## Not in scope

The issue's item 2 — a way to express a Rust-only major, since a changeset cannot — is untouched. When this gate fires the release stops and a human decides, which is the point; #3216 stays open for that half.

## The gate's first run found the issue's own instance, live on `main`

Full run of `node scripts/check-rust-semver.mjs` against `78354d960` with the workspace version at 6.0.2 and the `Aabb::inflate` break injected:

```
   ifc-lite-core 6.0.1 -> 6.0.2 (patch; requires patch)
   ifc-lite-clash 6.0.1 -> 6.0.2 (patch; requires major)
   ifc-lite-geometry 6.0.1 -> 6.0.2 (patch; requires major)
   ifc-lite-processing 6.0.1 -> 6.0.2 (patch; requires major)
   ifc-lite-export 6.0.1 -> 6.0.2 (patch; requires patch)
   ifc-lite-ffi 6.0.1 -> 6.0.2 (patch; requires patch)
   ifc-lite-wasm 6.0.1 -> 6.0.2 (patch; requires patch)

❌ Rust crate semver gate failed (#3216):

  - ifc-lite-clash: its public API change requires a MAJOR bump, but this release carries
    6.0.1 -> 6.0.2, which is a patch. ...
  - ifc-lite-geometry: ...
  - ifc-lite-processing: ...
```

Only `clash` was mine. I reverted my change (`git diff --stat rust/clash/` empty — byte-identical) and re-ran the other two on the untouched tree:

```
$ cargo +stable semver-checks -p ifc-lite-geometry --baseline-version 6.0.1
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---
Failed in:
  field SubMeshCollection.ids_are_materials in rust/geometry/src/mesh.rs:130
     Summary semver requires new major version: 1 major and 0 minor checks failed

$ cargo +stable semver-checks -p ifc-lite-processing --baseline-version 6.0.1
--- failure constructible_struct_adds_field ---
  field MeshData.material_id in rust/processing/src/types/mesh.rs:116
--- failure method_parameter_count_changed ---
  ifc_lite_processing::MeshData::with_style_metadata takes 2 parameters in
  .../ifc-lite-processing-6.0.1/src/types/mesh.rs:230, but now takes 3 parameters in
  rust/processing/src/types/mesh.rs:268
     Summary semver requires new major version: 2 major and 0 minor checks failed
```

That is **#3210, on `main`, unreleased** — the exact instance #3216 was filed about, named by the tool rather than by prose. So this gate is not hypothetical: as things stand it will refuse the next crates.io publish unless it carries a major, and that refusal is correct. `ifc-lite-core`, `-export`, `-ffi` and `-wasm` all reported `requires patch` and passed, so the gate discriminates rather than blanket-failing.

## RED / GREEN / mutation

- **RED**: the case above, and `node --test scripts/check-rust-semver.test.mjs` case 1.
- **GREEN**: a compatible change under the same patch; the same breaking change under `7.0.0`; a minor-requiring change under `6.1.0`; and the four crates above passing in the real run.
- **Mutation**: `if (RANK[required] > RANK[carried])` -> `if (false)` turns 3 tests red (`RED: a breaking Rust change...`, the minor case, and `every offending crate is named`). Restored by the inverse edit; `diff` against the pre-mutation copy reports byte-identical.
- **Vacuity**: 25 tests, of which 7 are the fail-closed cases — empty list, unfindable list, list below floor, one missing baseline, every baseline missing, no `Summary` line, empty output, non-semver version — plus a real-CLI spawn with `cargo` off `PATH` asserting `TOOL_MISSING` and exit 2.

---

## Rebased onto #3188 (merged 2026-08-26)

#3188 landed while this was open and moved `CRATES` into `scripts/lib/crates-io.mjs`, which is importable — `release-crates.mjs` publishes at top level, which is the only reason the list was being read textually. The gate now **imports** the list the release actually publishes, and `readWorkspaceVersion` with it.

Importing rules out a stale copy, not a short one, so `CRATE_FLOOR` stays; its test now truncates the **real** list rather than a hand-typed stand-in. `readWorkspaceVersion` throws on a missing key and returns whatever string is there otherwise, so `readVersionOrNull` turns both into "no usable version".

## One more vacuity found by running it end to end

On `main` today every crate's version equals what is live on crates.io, so the release republishes none of them and the first real run printed:

```
   ifc-lite-core 6.0.1 — already published at this version, not republished
   ... (all seven)
✅ 7 crate(s) checked; every Rust API change fits 6.0.1
```

Seven crates "checked" and **zero** APIs compared. Skipped crates are now counted apart from compared ones, and the all-skipped case says so:

```
✅ nothing to gate: all 7 crate(s) are already on crates.io at 6.0.1, so this release
   republishes none of them. No API was compared — do not read this as a compatibility result.
```

26 tests; mutation re-verified on the reworked gate (`if (RANK[required] > RANK[carried])` -> `if (false)` turns the same 3 red; inverse edit `diff`s byte-identical).

## `check-test-wiring` caught the gate running nowhere in CI, and it was right

```
❌ Gate scripts nothing in CI runs (these NEVER execute — #3062):
   scripts/check-rust-semver.mjs  (package.json "check:rust-semver" runs it,
                                   but no workflow runs that script)
```

Not a wiring formality — it is the same argument `release-crates-order.test.mjs` makes in its own header: *"the Release workflow only runs on main, and only on an actual publish. So a dependency edge added in any PR sat latent until the next release, where it failed after npm had already published."* A release-only semver gate has exactly that defect.

The `@unwired-by-design` escape hatch exists for this, and using it here would have been a **false** reason — the gate is wired, just somewhere the audit cannot see and somewhere too late. So it now runs as a `Rust crate semver` job on every PR, registered both in `needs:` and in the result table of the `Build + WASM + Rust + Node` gate (a job nothing depends on is a job whose red is invisible), with the wiring pinned by a test.

**It is cheap where it has no signal and expensive only where it does.** A crate already live on crates.io at this version is skipped *before* `cargo-semver-checks` is invoked — on an ordinary PR that is every crate, so the job is seven registry lookups and the "no API was compared" line. On the `chore: version packages` PR, where `sync-versions.js` has moved the workspace version, it does the real comparison. That is the commit whose version this whole issue is about, and it is reviewed before it merges and publishes.

The release-time precondition stays as the backstop: a PR verdict can be stale by the time `main` publishes, and that publish is the irreversible step.

**Consequence worth stating plainly:** given the `geometry`/`processing` findings above, this gate will refuse the next version PR unless it carries a major for the crates. That refusal is correct and is the point — but it is a decision for @louistrue, not something this PR should paper over.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated Rust API compatibility checks to pull requests and before crates.io releases.
  - Added verification for published Rust crates on crates.io and npm packages after releases.
  - Improved release handling for pre-releases, version updates, and recovery after partial publishing.

- **Bug Fixes**
  - Prevents crates.io publishing when Rust compatibility requirements are not met, while allowing npm releases to proceed.
  - Added retries and extended verification timeouts for registry checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Refs #3216 (item 1 only; item 2 — expressing a Rust-only major — stays open and is carried by #3305)

