### PR TITLE
docs(mcp,parser,create): three deferral claims that deferred to nothing

### DIFF
--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -154,18 +154,13 @@ export function extractWallSegmentsForStorey(
       // tolerance). Mirrors resolve-anchor.ts / resolve-source.ts.
       //
       // Deliberately NOT claiming the case is covered: extractLengthUnitScale
-      // returns 1.0 in band for most failures rather than throwing, so no
-      // missing IFCPROJECT, no UnitsInContext, and no malformed unit
-      // declaration reaches this catch at all — this `catch` sees only a
-      // THROWN failure.
-      //
-      // Those in-band paths are no longer silent: #2104 was closed by
-      // `warnUnknownUnit` in `packages/parser/src/unit-extractor.ts`, which
-      // warns once per model on each of them. What is still NOT supported is
-      // this caller telling "unknown" apart from "genuinely metres" — both
-      // arrive here as 1.0, and a console warning is not something code can
-      // branch on. Distinguishing them means returning null for "unknown"
-      // from a function with 7+ callers; that is not done, here or anywhere.
+      // returns 1.0 in band rather than throwing, so a missing IFCPROJECT or
+      // UnitsInContext, or a malformed unit declaration, never reaches this
+      // catch — it sees only a THROWN failure. Those paths are no longer silent
+      // (#2104: `warnUnknownUnit` in parser/src/unit-extractor.ts warns once
+      // per model). Still NOT supported: telling "unknown" from "genuinely
+      // metres" here — both arrive as 1.0, and a warning is not branchable.
+      // That needs null from a function with 7+ callers; not done, anywhere.
       console.warn(
         'extractWallSegmentsForStorey: failed to extract length unit scale; defaulting to metres',
         error,

--- a/packages/create/src/in-store/extract-walls.ts
+++ b/packages/create/src/in-store/extract-walls.ts
@@ -154,13 +154,18 @@ export function extractWallSegmentsForStorey(
       // tolerance). Mirrors resolve-anchor.ts / resolve-source.ts.
       //
       // Deliberately NOT claiming the case is covered: extractLengthUnitScale
-      // returns 1.0 in band for most failures rather than throwing — 11
-      // `return 1.0` paths against 2 warnings — so no missing IFCPROJECT, no
-      // UnitsInContext, or a malformed unit declaration reaches this catch at
-      // all. Those still read as metres, silently. Fixing that means either
-      // warning on the in-band paths or returning null for "unknown", and the
-      // function has 7+ callers, so it is tracked separately rather than
-      // widened here.
+      // returns 1.0 in band for most failures rather than throwing, so no
+      // missing IFCPROJECT, no UnitsInContext, and no malformed unit
+      // declaration reaches this catch at all — this `catch` sees only a
+      // THROWN failure.
+      //
+      // Those in-band paths are no longer silent: #2104 was closed by
+      // `warnUnknownUnit` in `packages/parser/src/unit-extractor.ts`, which
+      // warns once per model on each of them. What is still NOT supported is
+      // this caller telling "unknown" apart from "genuinely metres" — both
+      // arrive here as 1.0, and a console warning is not something code can
+      // branch on. Distinguishing them means returning null for "unknown"
+      // from a function with 7+ callers; that is not done, here or anywhere.
       console.warn(
         'extractWallSegmentsForStorey: failed to extract length unit scale; defaulting to metres',
         error,

--- a/packages/mcp/src/tools/export-init-dispose.test.ts
+++ b/packages/mcp/src/tools/export-init-dispose.test.ts
@@ -17,12 +17,17 @@
  * (`scripts/test-wasm-contract.mjs`, the e2e export specs).
  *
  * What these tests pin, stated precisely: that `dispose()` is REACHED on the
- * init-failure path. They do not pin that a WASM handle is freed, and on
- * today's code it is not — `IfcLiteBridge.init()` catches its own failures and
- * calls `reset()`, which nulls `ifcApi` without `free()`, so the recovered
- * `dispose()` optional-chains to a no-op. That leak lives in the bridge's error
- * path and is tracked separately; do not read a green run here as evidence the
- * handle was released.
+ * init-failure path. They do not pin that a WASM handle is freed here, and
+ * they cannot: `IfcLiteBridge.init()` frees its own handle on its catch path
+ * (`disposeBestEffort()` -> `dispose()` -> `ifcApi?.free()`), so by the time
+ * the recovered `gp.dispose()` runs there is no handle left and it
+ * optional-chains to a no-op. That freeing is covered where it happens, in
+ * `packages/geometry/src/ifc-lite-bridge.test.ts` ("init() failing AFTER
+ * `new IfcAPI()` must free the handle it built").
+ *
+ * So a green run here is evidence that `dispose()` was reached, and nothing
+ * more. Not supported by these tests, and not deferred to anything either:
+ * whether the handle was released. Read the bridge's own suite for that.
  */
 
 import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';

--- a/packages/parser/test/known-type-across-schemas.test.ts
+++ b/packages/parser/test/known-type-across-schemas.test.ts
@@ -227,7 +227,7 @@ describe('isKnownType across the bundled schema union (#2003)', () => {
     // classes through the pin; the union adds 19 more. Rejecting them is a
     // different predicate and belongs at the authoring boundary rather than in
     // a name-registry check — and that is where it now lives: #2035 was closed
-    // by `isInstantiableType` in `ifc-schema.ts` plus the `addEntity` guard in
+    // by `isInstantiable` in `ifc-schema.ts` plus the `addEntity` guard in
     // `packages/sdk/src/namespaces/store.ts`, which throws on an abstract type.
     // So this is not deferred work: the split is settled, and this test exists
     // so it stays a recorded decision rather than an oversight — it fails the

--- a/packages/parser/test/known-type-across-schemas.test.ts
+++ b/packages/parser/test/known-type-across-schemas.test.ts
@@ -225,10 +225,13 @@ describe('isKnownType across the bundled schema union (#2003)', () => {
   it('answers known-ness, not instantiability: abstract classes stay accepted (#2035)', () => {
     // Pre-existing and deliberately unchanged here. `main` accepts 123 abstract
     // classes through the pin; the union adds 19 more. Rejecting them is a
-    // different predicate, belongs at the authoring boundary rather than in a
-    // name-registry check, and is tracked separately — this test exists so the
-    // split is a recorded decision rather than an oversight, and it fails the
-    // day someone changes it without changing the contract.
+    // different predicate and belongs at the authoring boundary rather than in
+    // a name-registry check — and that is where it now lives: #2035 was closed
+    // by `isInstantiableType` in `ifc-schema.ts` plus the `addEntity` guard in
+    // `packages/sdk/src/namespaces/store.ts`, which throws on an abstract type.
+    // So this is not deferred work: the split is settled, and this test exists
+    // so it stays a recorded decision rather than an oversight — it fails the
+    // day someone makes `isKnownType` answer instantiability instead.
     for (const type of ['IfcProduct', 'IfcRoot', 'IfcRelationship', 'IfcObjectDefinition']) {
       expect(getEntityMetadata(type)?.isAbstract, type).toBe(true);
       expect(isKnownType(type), type).toBe(true);


### PR DESCRIPTION
Three comments claimed work was "tracked separately" while naming no issue. I verified each before touching it. Two were genuinely tracked — and **both issues are closed**, so the prose was sending readers after work that had already landed. The third described a defect the code no longer has, and nothing tracks it because nothing needs to.

Comment-only. No behaviour change, no test weakened.

## `packages/mcp/src/tools/export-init-dispose.test.ts`

Claimed: *"`IfcLiteBridge.init()` catches its own failures and calls `reset()`, which nulls `ifcApi` without `free()` … That leak lives in the bridge's error path and is tracked separately."*

Searched six phrasings (`IfcLiteBridge`, `dispose leak`, `wasm handle not freed`, `bridge init reset free`, `GeometryProcessor dispose`, `bridge reset ifcApi`) against a search that demonstrably works — nothing tracks it. And the described code is not today's code:

```ts
// packages/geometry/src/ifc-lite-bridge.ts, init()'s catch
this.disposeBestEffort();     // -> dispose() -> this.ifcApi?.free()
```

`packages/geometry/src/ifc-lite-bridge.test.ts` covers it directly: *"init() failing AFTER `new IfcAPI()` must free the handle it built"*.

The observation underneath was right — the recovered `gp.dispose()` **is** a no-op — but for the opposite reason: the handle was already freed, not leaked. Rewritten to state what these tests pin, that the freeing is pinned elsewhere, and that this is not deferred to anything.

## `packages/parser/test/known-type-across-schemas.test.ts`

Claimed: rejecting abstract classes *"belongs at the authoring boundary … and is tracked separately"*.

**Genuinely tracked** — by #2035, whose number is already in the test title two lines above. It is closed, completed by #2041: `isInstantiableType` in `packages/parser/src/ifc-schema.ts:214` and the `addEntity` guard in `packages/sdk/src/namespaces/store.ts:85`, which throws on an abstract type.

So the claim was true when written and is now stale in tense, not in substance. The test itself is correct and unchanged; the comment now says the split is settled and names where it landed, so nobody goes looking for open work.

## `packages/create/src/in-store/extract-walls.ts`

Claimed: *"no missing IFCPROJECT, no UnitsInContext, or a malformed unit declaration reaches this catch at all. **Those still read as metres, silently.** … it is tracked separately."*

**Was tracked** — #2104, closed by #2126, which added `warnUnknownUnit` to `packages/parser/src/unit-extractor.ts`. Ten call sites now cover exactly the paths this comment names:

```
113 No IFCPROJECT found                         143 UnitsInContext could not be resolved
119 IFCPROJECT reference could not be resolved  149 UnitsInContext not an IFCUNITASSIGNMENT
125 IFCPROJECT entity could not be read         155 IFCUNITASSIGNMENT has no readable attributes
136 No UnitsInContext reference                 162 IFCUNITASSIGNMENT.Units is not a list
208 Unrecognized SI prefix                      295 No LENGTHUNIT found in IFCUNITASSIGNMENT
```

So "silently" is simply false now. What remains true is narrower and is what the comment now says: those paths still return `1.0` in band, this `catch` still sees only a **thrown** failure, and **this caller still cannot tell "unknown" from "genuinely metres"** — both arrive as `1.0`, and a console warning is not something code can branch on. That is stated as unsupported rather than as deferred, since distinguishing them means returning `null` from a function with 7+ callers and that has not been done anywhere.

## Left alone

`rust/export/src/step_text_tests.rs:184` carries the same shape of claim, but it belongs to open PR #3283 and is not touched here.
