### PR TITLE
test(encoding,ids): one shared timing ladder, spent against the CPU clock (#3224)

### DIFF
--- a/packages/encoding/src/numeric-literal.test.ts
+++ b/packages/encoding/src/numeric-literal.test.ts
@@ -158,10 +158,11 @@ describe('deciding it is linear, not backtracking', () => {
 
   /**
    * The shared ladder, bound to this suite's fixture. Budget, rungs and retry
-   * policy come from @ifc-lite/timing-ladder so this suite and its twin in
-   * @ifc-lite/ids cannot drift apart again (#3224); it refuses -- loudly --
-   * any decision that ACCEPTS the hostile fixture, so a reading can never be
-   * timing an early return.
+   * policy come from @ifc-lite/timing-ladder, so the LADDER cannot drift
+   * between this suite and its twin in @ifc-lite/ids again (#3224). It is one
+   * implementation, not two agreeing ones. It refuses -- loudly --
+   * any decision that ACCEPTS the hostile fixture, so the early-ACCEPT path --
+   * the one that would make a reading meaningless -- cannot pass silently.
    */
   const ladder = (decide: (v: string) => boolean): number | null =>
     firstBlownRung(decide, { hostile });

--- a/packages/encoding/src/numeric-literal.test.ts
+++ b/packages/encoding/src/numeric-literal.test.ts
@@ -12,6 +12,7 @@
  * over an exhaustively generated corpus rather than a list anyone chose.
  */
 import { describe, it, expect } from 'vitest';
+import { firstBlownRung, SIZES } from '@ifc-lite/timing-ladder';
 import { isWhollyNumeric } from './numeric-literal.js';
 
 /**
@@ -85,21 +86,20 @@ describe('deciding it is linear, not backtracking', () => {
    * also why minimising over batches (#3159, #3165) narrowed the distribution
    * without fixing it.
    *
-   * Why the budget survives what the ratio could not: CONSECUTIVE READINGS, not
-   * headroom. The old ratio put a healthy reading at ~4 against a bound of 8,
-   * so one 2x hiccup was a failure. The 640k rung decides in ~1.2ms against a
-   * 500ms budget, and the largest rung, 2.56M, in ~3.7ms -- but that headroom
-   * is NOT what protects the test, and saying so would be false under the very
-   * load this docblock invokes: readings at the 640k rung reached 117ms at 160
-   * busy processes and 303.9ms at 480 -- a ~1.6x margin at the extreme tail.
-   * Those two tail figures are the 640k rung's, measured while 640k was still
-   * the top of the ladder; they are deliberately NOT restated as the largest
-   * rung's, which has not been measured under that load. What
-   * protects it is ATTEMPTS: a rung is blown only after 3 CONSECUTIVE
-   * over-budget readings. Contention arrives in bursts, which is what defeated
-   * the ratio, and is what three consecutive readings are chosen to survive: a
-   * burst has to cover all three. Under the same 160-process load that broke
-   * the ratio 12 times in 20, this is green 20 times in 20.
+   * Why the budget survives what the ratio could not: it is measured on the CPU
+   * clock, in @ifc-lite/timing-ladder. Headroom on the WALL clock was never
+   * what protected this test, and the version of this paragraph that said
+   * ATTEMPTS protected it was wrong (#3224). Three attempts are taken
+   * back-to-back and span ~11ms of real work at the largest rung, so a
+   * contention burst longer than that covers all three. Measured: this exact
+   * linear scan, unmodified, running the real ladder 100 times under 900 busy
+   * processes on 12 cores, blew the 2.56M rung 3 times -- readings
+   * `812.5, 968.1, 549.9` and `1226.1, 1168.2, 1137.6` against a 500ms budget.
+   * `2560000` is the value CI reported against an unrelated parser PR. On the
+   * CPU clock the same 200 readings under the same load ran p50 5.67ms, p99
+   * 8.88ms, max 9.93ms, against 7.13ms idle. ATTEMPTS is kept as a second line
+   * of defence and costs nothing on the healthy path, because `Math.min` can
+   * only fall and a reading already inside the budget is final.
    *
    * The price is real and it is not a saving. Each negative control climbs to
    * the rung it blows and then spends ATTEMPTS readings there, so the controls
@@ -111,6 +111,12 @@ describe('deciding it is linear, not backtracking', () => {
    * of a timing assertion that holds; the cheaper one reddened three unrelated
    * PRs.
    *
+   * The ladder itself -- budget, rungs, retry policy and the CPU-clock reading
+   * -- lives in @ifc-lite/timing-ladder and is shared with the twin suite in
+   * @ifc-lite/ids, which used to carry a line-for-line copy of it (#3224).
+   * Its own tests pin that it still blows a rung on a quadratic decision, still
+   * refuses a decision that accepts the fixture, and still reads the CPU clock.
+   *
    * The bound the old test used is not carried over and not raised; the
    * quantity it bounded is simply not measured any more.
    *
@@ -118,8 +124,9 @@ describe('deciding it is linear, not backtracking', () => {
    * it. A linear-but-slower implementation passed the OLD test too: a ratio of
    * two timings cancels constant factors by construction, so it never bounded
    * absolute speed at all. The absolute budget does bound it, if loosely --
-   * anything ~135x slower than the current scan at 2.56M now reds, where the
-   * ratio would not have noticed. What both forms exist to catch first is
+   * anything ~135x more WORK than the current scan at 2.56M now reds, where the
+   * ratio would not have noticed. "Work" and not "wall time" since #3224: the
+   * budget is spent against the CPU clock. What both forms exist to catch first is
    * catastrophic backtracking, which is orders of magnitude rather than
    * factors, and the negative controls below pin exactly that.
    *
@@ -132,7 +139,9 @@ describe('deciding it is linear, not backtracking', () => {
    * is exactly that implementation, so the claim is pinned rather than
    * asserted. Two more rungs cost the healthy scan ~2ms (3.70ms at 2.56M
    * against the 500ms budget, ~135x of headroom), because the extra rungs are
-   * only expensive for an implementation that is already superlinear.
+   * only expensive for an implementation that is already superlinear. That
+   * headroom is now real rather than nominal: on the CPU clock the same rung
+   * stayed at 9.93ms worst-of-200 under 900 busy processes.
    *
    * What remains knowingly out of scope after that: a superlinear regression
    * whose constant is smaller still, staying inside the budget even at 2.56M.
@@ -142,64 +151,20 @@ describe('deciding it is linear, not backtracking', () => {
    * review. #3113 was dangerous precisely because a regex LOOKED linear.
    */
 
-  /** Per-decision budget. Every size below must be decided inside it. */
-  const BUDGET_MS = 500;
-
-  /**
-   * Ascending, doubling. Ascending is what makes a quadratic implementation
-   * REPORT instead of HANG: cost rises 4x per rung, so the first rung it blows
-   * costs at most ~4x the budget, and the ladder stops there rather than
-   * carrying on to 640k where the same implementation would grind for minutes.
-   *
-   * It self-adapts to the runner in both directions. A slower machine blows a
-   * quadratic implementation at a lower rung; a faster one at a higher rung.
-   * Either way some rung fails, so the controls below need no hardware-tuned
-   * number -- the failure that the old `regexMs > 50` floor could not survive.
-   */
-  const SIZES = [
-    20_000, 40_000, 80_000, 160_000, 320_000, 640_000, 1_280_000, 2_560_000,
-  ] as const;
-
-  /**
-   * Retries only ever taken on the way to FAILING. `Math.min` can only fall, so
-   * a reading already inside the budget is final and no repeat is made -- the
-   * healthy path is one call per rung. A rung is only declared blown after
-   * ATTEMPTS consecutive readings over the budget, which a single descheduling
-   * cannot fake. This does not soften detection: the minimum of several
-   * quadratic timings is still quadratic.
-   */
-  const ATTEMPTS = 3;
-
   /** A long digit run plus one character that cannot be part of a number. The
    *  trailing non-digit is the whole point: an all-digit string of any length
    *  matches immediately, which is why plausible fixtures miss this. */
   const hostile = (n: number): string => `-${'1'.repeat(n)}x`;
 
-  type Decide = (v: string) => boolean;
-
-  /** Fastest of up to ATTEMPTS decisions, stopping as soon as one is in budget. */
-  const fastestMs = (decide: Decide, n: number): number => {
-    const v = hostile(n);
-    let best = Infinity;
-    for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
-      const t0 = performance.now();
-      const verdict = decide(v);
-      best = Math.min(best, performance.now() - t0);
-      // A decision that says "number" would mean the timing measured an early
-      // return rather than a full scan, so the reading would prove nothing.
-      expect(verdict).toBe(false);
-      if (best < BUDGET_MS) break;
-    }
-    return best;
-  };
-
-  /** The first size at which `decide` blew the budget, or null if it cleared them all. */
-  const firstBlownRung = (decide: Decide): number | null => {
-    for (const n of SIZES) {
-      if (fastestMs(decide, n) >= BUDGET_MS) return n;
-    }
-    return null;
-  };
+  /**
+   * The shared ladder, bound to this suite's fixture. Budget, rungs and retry
+   * policy come from @ifc-lite/timing-ladder so this suite and its twin in
+   * @ifc-lite/ids cannot drift apart again (#3224); it refuses -- loudly --
+   * any decision that ACCEPTS the hostile fixture, so a reading can never be
+   * timing an early return.
+   */
+  const ladder = (decide: (v: string) => boolean): number | null =>
+    firstBlownRung(decide, { hostile });
 
   it('rejects the hostile input, so the ladder times a real decision', () => {
     expect(isWhollyNumeric(hostile(20_000))).toBe(false);
@@ -209,7 +174,7 @@ describe('deciding it is linear, not backtracking', () => {
   });
 
   it('decides every size up to 2.56M characters inside the budget', { timeout: 60_000 }, () => {
-    expect(firstBlownRung(isWhollyNumeric)).toBeNull();
+    expect(ladder(isWhollyNumeric)).toBeNull();
   });
 
   /**
@@ -225,7 +190,7 @@ describe('deciding it is linear, not backtracking', () => {
     // SPEC_RE is not a strawman -- it is the implementation that shipped, and
     // the one #3113 was filed against. `\d+\.?\d*` retries at every split of
     // the digit run before the engine gives up.
-    expect(firstBlownRung((v) => SPEC_RE.test(v))).not.toBeNull();
+    expect(ladder((v) => SPEC_RE.test(v))).not.toBeNull();
   });
 
   it('the ladder can fail: a hand-written backtracking scan blows a rung', { timeout: 60_000 }, () => {
@@ -237,7 +202,7 @@ describe('deciding it is linear, not backtracking', () => {
       (v) => isWhollyNumericBacktracking(v) === isWhollyNumeric(v)
     );
     expect(alsoBacktracks).toBe(true);
-    expect(firstBlownRung(isWhollyNumericBacktracking)).not.toBeNull();
+    expect(ladder(isWhollyNumericBacktracking)).not.toBeNull();
   });
 
   it('the ladder can fail: a superlinear scan with a small constant blows a rung', { timeout: 60_000 }, () => {
@@ -257,7 +222,7 @@ describe('deciding it is linear, not backtracking', () => {
     // nothing about sensitivity.
     const DECIDED_INSIDE_BUDGET = 640_000;
     expect(SIZES[SIZES.length - 1]).toBeGreaterThan(DECIDED_INSIDE_BUDGET);
-    const blown = firstBlownRung(isWhollyNumericSmallConstantSuperlinear);
+    const blown = ladder(isWhollyNumericSmallConstantSuperlinear);
     expect(blown).not.toBeNull();
   });
 });

--- a/packages/ids/package.json
+++ b/packages/ids/package.json
@@ -29,6 +29,7 @@
     "@xmldom/xmldom": "^0.9.11"
   },
   "devDependencies": {
+    "@ifc-lite/timing-ladder": "workspace:^",
     "happy-dom": "^20.11.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",

--- a/packages/ids/src/constraints/numeric-literal.test.ts
+++ b/packages/ids/src/constraints/numeric-literal.test.ts
@@ -143,7 +143,8 @@ const hostile = (n: number): string => `-${'9'.repeat(n)}X`;
  * Budget, rungs and retry policy come from @ifc-lite/timing-ladder, shared with
  * the twin suite in @ifc-lite/encoding, which used to carry a line-for-line
  * copy of them (#3224). It refuses -- loudly -- any decision that ACCEPTS the
- * hostile fixture, so a reading can never be timing an early return.
+ * hostile fixture, so the early-ACCEPT path -- the one that would make a
+ * reading meaningless -- cannot pass silently.
  */
 const firstBlownRung = (decide: (v: string) => boolean): number | null =>
   ladderFirstBlownRung(decide, { hostile });

--- a/packages/ids/src/constraints/numeric-literal.test.ts
+++ b/packages/ids/src/constraints/numeric-literal.test.ts
@@ -17,6 +17,7 @@
  * opaque).
  */
 import { describe, it, expect } from 'vitest';
+import { firstBlownRung as ladderFirstBlownRung, SIZES } from '@ifc-lite/timing-ladder';
 import { compareNumeric, isStrictNumericLiteral } from './comparators.js';
 import { literalCastsUnder } from './xsd-cast.js';
 import { runCoherenceAudit } from '../audit/coherence/index.js';
@@ -127,71 +128,25 @@ describe('isStrictNumericLiteral accepts exactly the language it always did', ()
   });
 });
 
+/** A long digit run plus one character that cannot be part of a number.
+ *  The trailing non-digit is the whole point: an all-digit string of any
+ *  length matches immediately, which is why plausible fixtures miss this. */
+const hostile = (n: number): string => `-${'9'.repeat(n)}X`;
+
 /**
  * The ladder every timing assertion in this file runs, module-scoped because
  * four separate call sites use it: the scan itself, the per-entity
  * `compareNumeric` path, and the two IDS-file literal paths at the bottom of
  * the file. One ladder means one budget and one retry policy, so a hardening
  * applied here cannot miss a caller.
- */
-/** Per-decision budget. Every size below must be decided inside it. */
-const BUDGET_MS = 500;
-
-/**
- * Ascending, doubling. Ascending is what makes a quadratic implementation
- * REPORT instead of HANG: cost rises 4x per rung, so the first rung it blows
- * costs at most ~4x the budget, and the ladder stops there rather than
- * carrying on to 640k where the same implementation would grind for minutes.
  *
- * It self-adapts to the runner in both directions. A slower machine blows a
- * quadratic implementation at a lower rung; a faster one at a higher rung.
- * Either way some rung fails, so the controls below need no hardware-tuned
- * number -- the failure that the old `regexMs > 50` floor could not survive.
+ * Budget, rungs and retry policy come from @ifc-lite/timing-ladder, shared with
+ * the twin suite in @ifc-lite/encoding, which used to carry a line-for-line
+ * copy of them (#3224). It refuses -- loudly -- any decision that ACCEPTS the
+ * hostile fixture, so a reading can never be timing an early return.
  */
-const SIZES = [
-  20_000, 40_000, 80_000, 160_000, 320_000, 640_000, 1_280_000, 2_560_000,
-] as const;
-
-/**
- * Retries only ever taken on the way to FAILING. `Math.min` can only fall, so
- * a reading already inside the budget is final and no repeat is made -- the
- * healthy path is one call per rung. A rung is only declared blown after
- * ATTEMPTS consecutive readings over the budget, which a single descheduling
- * cannot fake. This does not soften detection: the minimum of several
- * quadratic timings is still quadratic.
- */
-const ATTEMPTS = 3;
-
-/** A long digit run plus one character that cannot be part of a number.
- *  The trailing non-digit is the whole point: an all-digit string of any
- *  length matches immediately, which is why plausible fixtures miss this. */
-const hostile = (n: number): string => `-${'9'.repeat(n)}X`;
-
-type Decide = (v: string) => boolean;
-
-/** Fastest of up to ATTEMPTS decisions, stopping as soon as one is in budget. */
-const fastestMs = (decide: Decide, n: number): number => {
-  const v = hostile(n);
-  let best = Infinity;
-  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
-    const t0 = performance.now();
-    const verdict = decide(v);
-    best = Math.min(best, performance.now() - t0);
-    // A decision that says "number" would mean the timing measured an early
-    // return rather than a full scan, so the reading would prove nothing.
-    expect(verdict).toBe(false);
-    if (best < BUDGET_MS) break;
-  }
-  return best;
-};
-
-/** The first size at which `decide` blew the budget, or null if it cleared them all. */
-const firstBlownRung = (decide: Decide): number | null => {
-  for (const n of SIZES) {
-    if (fastestMs(decide, n) >= BUDGET_MS) return n;
-  }
-  return null;
-};
+const firstBlownRung = (decide: (v: string) => boolean): number | null =>
+  ladderFirstBlownRung(decide, { hostile });
 
 describe('deciding it is linear, not backtracking (#3113)', () => {
   /**
@@ -212,21 +167,20 @@ describe('deciding it is linear, not backtracking (#3113)', () => {
    * also why minimising over batches (#3159, #3165) narrowed the distribution
    * without fixing it.
    *
-   * Why the budget survives what the ratio could not: CONSECUTIVE READINGS, not
-   * headroom. The old ratio put a healthy reading at ~4 against a bound of 8,
-   * so one 2x hiccup was a failure. The 640k rung decides in ~1.2ms against a
-   * 500ms budget, and the largest rung, 2.56M, in ~3.7ms -- but that headroom
-   * is NOT what protects the test, and saying so would be false under the very
-   * load this docblock invokes: readings at the 640k rung reached 117ms at 160
-   * busy processes and 303.9ms at 480 -- a ~1.6x margin at the extreme tail.
-   * Those two tail figures are the 640k rung's, measured while 640k was still
-   * the top of the ladder; they are deliberately NOT restated as the largest
-   * rung's, which has not been measured under that load. What
-   * protects it is ATTEMPTS: a rung is blown only after 3 CONSECUTIVE
-   * over-budget readings. Contention arrives in bursts, which is what defeated
-   * the ratio, and is what three consecutive readings are chosen to survive: a
-   * burst has to cover all three. Under the same 160-process load that broke
-   * the ratio 12 times in 20, this is green 20 times in 20.
+   * Why the budget survives what the ratio could not: it is measured on the CPU
+   * clock, in @ifc-lite/timing-ladder. Headroom on the WALL clock was never
+   * what protected this test, and the version of this paragraph that said
+   * ATTEMPTS protected it was wrong (#3224). Three attempts are taken
+   * back-to-back and span ~11ms of real work at the largest rung, so a
+   * contention burst longer than that covers all three. Measured: this exact
+   * linear scan, unmodified, running the real ladder 100 times under 900 busy
+   * processes on 12 cores, blew the 2.56M rung 3 times -- readings
+   * `812.5, 968.1, 549.9` and `1226.1, 1168.2, 1137.6` against a 500ms budget.
+   * `2560000` is the value CI reported against an unrelated parser PR. On the
+   * CPU clock the same 200 readings under the same load ran p50 5.67ms, p99
+   * 8.88ms, max 9.93ms, against 7.13ms idle. ATTEMPTS is kept as a second line
+   * of defence and costs nothing on the healthy path, because `Math.min` can
+   * only fall and a reading already inside the budget is final.
    *
    * The price is real and it is not a saving. Each negative control climbs to
    * the rung it blows and then spends ATTEMPTS readings there, so the controls
@@ -238,6 +192,12 @@ describe('deciding it is linear, not backtracking (#3113)', () => {
    * of a timing assertion that holds; the cheaper one reddened three unrelated
    * PRs.
    *
+   * The ladder itself -- budget, rungs, retry policy and the CPU-clock reading
+   * -- lives in @ifc-lite/timing-ladder and is shared with the twin suite in
+   * @ifc-lite/encoding, which used to carry a line-for-line copy of it (#3224).
+   * Its own tests pin that it still blows a rung on a quadratic decision, still
+   * refuses a decision that accepts the fixture, and still reads the CPU clock.
+   *
    * The bound the old test used is not carried over and not raised; the
    * quantity it bounded is simply not measured any more.
    *
@@ -245,8 +205,9 @@ describe('deciding it is linear, not backtracking (#3113)', () => {
    * it. A linear-but-slower implementation passed the OLD test too: a ratio of
    * two timings cancels constant factors by construction, so it never bounded
    * absolute speed at all. The absolute budget does bound it, if loosely --
-   * anything ~135x slower than the current scan at 2.56M now reds, where the
-   * ratio would not have noticed. What both forms exist to catch first is
+   * anything ~135x more WORK than the current scan at 2.56M now reds, where the
+   * ratio would not have noticed. "Work" and not "wall time" since #3224: the
+   * budget is spent against the CPU clock. What both forms exist to catch first is
    * catastrophic backtracking, which is orders of magnitude rather than
    * factors, and the negative controls below pin exactly that.
    *
@@ -259,7 +220,9 @@ describe('deciding it is linear, not backtracking (#3113)', () => {
    * is exactly that implementation, so the claim is pinned rather than
    * asserted. Two more rungs cost the healthy scan ~2ms (3.70ms at 2.56M
    * against the 500ms budget, ~135x of headroom), because the extra rungs are
-   * only expensive for an implementation that is already superlinear.
+   * only expensive for an implementation that is already superlinear. That
+   * headroom is now real rather than nominal: on the CPU clock the same rung
+   * stayed at 9.93ms worst-of-200 under 900 busy processes.
    *
    * What remains knowingly out of scope after that: a superlinear regression
    * whose constant is smaller still, staying inside the budget even at 2.56M.
@@ -420,9 +383,10 @@ describe('the same shape elsewhere in @ifc-lite/ids', () => {
       // be a single 20k reading against a 100ms bound, which is the construct
       // the ladder above exists to replace: one reading has no retry, so a
       // single descheduling reds it. Measured under 187-process load, 24 of
-      // 12,000 single 20k readings here exceeded 100ms (max 265ms) against a
-      // median of 0.058ms -- ~0.2% flake per assertion. The ladder needs
-      // ATTEMPTS consecutive over-budget readings instead.
+      // 12,000 single 20k WALL-CLOCK readings here exceeded 100ms (max 265ms)
+      // against a median of 0.058ms -- ~0.2% flake per assertion. The ladder
+      // spends its budget against the CPU clock instead, which does not tick
+      // while the operating system has chosen not to run us (#3224).
       expect(firstBlownRung((v) => literalCastsUnder(v, 'xs:double'))).toBeNull();
     });
   });
@@ -501,8 +465,8 @@ describe('the same shape elsewhere in @ifc-lite/ids', () => {
       // migration as the cast above, and for the same reason: the lone 20k
       // reading against a 100ms bound was flaky under load by construction.
       // `accepts` returning false IS the E_RESTRICTION_VALUE_MISMATCH the old
-      // assertion checked for, so the verdict is still pinned -- `fastestMs`
-      // reds if any rung ever decides the hostile input is a number.
+      // assertion checked for, so the verdict is still pinned -- the shared
+      // ladder throws if any rung ever decides the hostile input is a number.
       expect(firstBlownRung((v) => accepts(v, 'xs:double'))).toBeNull();
     });
   });

--- a/packages/timing-ladder/package.json
+++ b/packages/timing-ladder/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@ifc-lite/encoding",
-  "version": "2.1.0",
-  "description": "IFC string encoding/decoding and property value parsing for IFC-Lite",
+  "name": "@ifc-lite/timing-ladder",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The shared doubling-size timing ladder used to pin that a decision stays linear on hostile input, measured in CPU time so contention on the runner cannot fake a failure",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -19,7 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@ifc-lite/timing-ladder": "workspace:^",
+    "@types/node": "^26.2.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },
@@ -28,22 +29,15 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/LTplus-AG/ifc-lite.git",
-    "directory": "packages/encoding"
+    "directory": "packages/timing-ladder"
   },
   "homepage": "https://ifclite.dev/docs/",
   "bugs": "https://github.com/LTplus-AG/ifc-lite/issues",
   "keywords": [
     "ifc",
-    "bim",
-    "encoding",
-    "step",
-    "aec"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "files": [
-    "dist",
-    "README.md"
+    "test-fixture",
+    "timing",
+    "linearity",
+    "backtracking"
   ]
 }

--- a/packages/timing-ladder/src/index.test.ts
+++ b/packages/timing-ladder/src/index.test.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The ladder's own tests. A timing harness that cannot go red is worse than no
+ * timing harness, because it reads as protection -- and this particular ladder
+ * has a history of it: one earlier negative control was accidentally linear and
+ * proved nothing, and one earlier assertion could not fail at all (#3285). So
+ * every claim the implementation makes is pinned here rather than described:
+ * that it clears a linear decision, that it blows a quadratic one, that it
+ * refuses a decision which accepts the fixture, and -- the load-bearing one --
+ * that it is reading the CPU clock and not the wall clock.
+ */
+import { describe, it, expect } from 'vitest';
+import { firstBlownRung, SIZES, BUDGET_MS, ATTEMPTS } from './index.js';
+
+/** The fixture shape the consuming suites use: a digit run plus one non-digit. */
+const hostile = (n: number): string => `-${'9'.repeat(n)}X`;
+
+/** Linear: one pass, rejects on the trailing character. */
+const linear = (v: string): boolean => {
+  let i = 0;
+  if (i < v.length && (v[i] === '+' || v[i] === '-')) i++;
+  let digits = 0;
+  while (i < v.length && v[i] >= '0' && v[i] <= '9') { i++; digits++; }
+  return digits > 0 && i === v.length;
+};
+
+/** Quadratic on a failing input: re-scans the tail at every split point. */
+const quadratic = (v: string): boolean => {
+  let run = 0;
+  while (run < v.length && (v[run] === '+' || v[run] === '-' || (v[run] >= '0' && v[run] <= '9'))) run++;
+  for (let take = run; take >= 1; take--) {
+    let i = take;
+    while (i < v.length && v[i] >= '0' && v[i] <= '9') i++;
+    if (i === v.length) return true;
+  }
+  return false;
+};
+
+describe('the ladder is a real instrument', () => {
+  it('exposes the shape the consuming suites pin their comments to', () => {
+    // These are quoted as figures in both consumers' docblocks; changing one
+    // without re-recording those figures is meant to red here.
+    expect(BUDGET_MS).toBe(500);
+    expect(ATTEMPTS).toBe(3);
+    expect([...SIZES]).toEqual([20_000, 40_000, 80_000, 160_000, 320_000, 640_000, 1_280_000, 2_560_000]);
+  });
+
+  it('clears every rung for a linear decision', { timeout: 60_000 }, () => {
+    expect(firstBlownRung(linear, { hostile })).toBeNull();
+  });
+
+  it('can fail: a quadratic decision blows a rung', { timeout: 60_000 }, () => {
+    expect(firstBlownRung(quadratic, { hostile })).not.toBeNull();
+  });
+
+  it('refuses a decision that accepts the fixture, instead of timing an early return', () => {
+    // Without this the ladder would happily report `null` for a decision that
+    // returns immediately, which is the vacuous-instrument failure mode.
+    expect(() => firstBlownRung(() => true, { hostile, sizes: [20_000] })).toThrow(
+      /accepted the hostile fixture at n=20000/
+    );
+  });
+
+  it('measures a real cost: a decision made 100x more expensive blows a budget the cheap one clears', () => {
+    // Pins that the reading is a MEASUREMENT and not a constant. A ladder that
+    // always read zero would clear both of these.
+    const heavy = (v: string): boolean => {
+      let sink = 0;
+      for (let pass = 0; pass < 100; pass++) for (let i = 0; i < v.length; i++) if (v[i] >= '0') sink++;
+      if (sink < 0) return true;
+      return linear(v);
+    };
+    const opts = { hostile, sizes: [320_000], budgetMs: 20 } as const;
+    expect(firstBlownRung(linear, opts)).toBeNull();
+    expect(firstBlownRung(heavy, opts)).toBe(320_000);
+  });
+});
+
+describe('it reads the CPU clock, not the wall clock (#3224)', () => {
+  /**
+   * The discriminator, and the whole reason the flake is gone. `Atomics.wait`
+   * blocks the thread for a real wall-clock second while burning essentially no
+   * CPU -- which is what a descheduled process on a loaded runner looks like
+   * from the inside. Under the wall clock this decision blows a 500ms budget
+   * every single time; under the CPU clock it clears it.
+   *
+   * If someone swaps `process.cpuUsage()` back to `performance.now()`, this is
+   * the test that reds.
+   */
+  it('a decision that blocks for a wall-clock second still clears a 500ms budget', () => {
+    const lock = new Int32Array(new SharedArrayBuffer(4));
+    const blocking = (v: string): boolean => {
+      Atomics.wait(lock, 0, 0, 1_000);
+      return linear(v);
+    };
+    const t0 = performance.now();
+    const blown = firstBlownRung(blocking, { hostile, sizes: [20_000], budgetMs: BUDGET_MS });
+    const wallMs = performance.now() - t0;
+
+    // The block really happened -- otherwise the assertion below is vacuous.
+    expect(wallMs).toBeGreaterThan(900);
+    // ...and the ladder did not count it, because it is not work.
+    expect(blown).toBeNull();
+  });
+});

--- a/packages/timing-ladder/src/index.ts
+++ b/packages/timing-ladder/src/index.ts
@@ -50,6 +50,34 @@
  * being true. `process.cpuUsage()` also counts V8's background GC and compiler
  * threads, which can only push a reading up.
  *
+ * ## What `process.cpuUsage()` counts, and why that is safe HERE
+ *
+ * It is a PROCESS-wide counter, not a per-thread one: it sums every thread in
+ * the process, so a sibling `worker_threads` worker burning CPU alongside the
+ * decision is added to the decision's reading. Measured on the same machine,
+ * this exact linear scan over the 2.56M rung, 15 readings each: p50 4.57ms
+ * alone, p50 30.40ms with eight sibling workers spinning -- a 6.6x inflation
+ * of a number the ladder compares against a fixed budget.
+ *
+ * That does not bite today because the decision does not share a process with
+ * anything. Vitest runs each test file in a forked CHILD PROCESS, and the
+ * ladder runs on that child's MAIN thread -- probed in both consuming packages
+ * (`@ifc-lite/encoding`, `@ifc-lite/ids`): `isMainThread` true, `threadId` 0,
+ * and a pid distinct from the runner's. Sibling test files are separate
+ * processes, so their CPU is invisible to this counter. Neither package pins
+ * `pool` at all; `packages/parser/vitest.config.ts` is the one place in the
+ * repo that spells `pool: 'forks'` out.
+ *
+ * The dependency is on the POOL, not on anything in this file. Switching a
+ * consuming package to `pool: 'threads'` would put sibling test files in one
+ * process as workers, and every one of their busy scans would be charged to
+ * this reading -- turning a bound that has 50x of margin into a flake, with
+ * nothing in the failure message pointing at the pool. Anyone making that
+ * switch has to move this ladder's consumers back to `forks` or move the
+ * measurement to a per-thread counter. The inflation is one-directional
+ * (readings can only go up, never down), so it can produce a false RED but
+ * never a false GREEN.
+ *
  * What is knowingly given up: a regression that made the decision BLOCK --
  * sleep, or wait on I/O -- would burn wall time without burning CPU and would
  * no longer red. The decisions this ladder is pointed at are synchronous

--- a/packages/timing-ladder/src/index.ts
+++ b/packages/timing-ladder/src/index.ts
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The doubling-size timing ladder that pins "this decision does not blow up on
+ * a long hostile input".
+ *
+ * ## Why this is one package and not two copies
+ *
+ * It was two copies, near line-for-line, in
+ * `packages/encoding/src/numeric-literal.test.ts` and
+ * `packages/ids/src/constraints/numeric-literal.test.ts` (#3224). They had
+ * already diverged once: #3221 fixed an unequal-exposure bug in the ids copy
+ * and left the encoding copy carrying it, even though the measurements that
+ * justified the fix were taken against the encoding function. One
+ * implementation means a hardening applied here cannot miss a caller.
+ *
+ * Placement: a PRIVATE workspace package, following
+ * `@ifc-lite/world-frame-fixtures`. The alternative -- a subpath on
+ * `@ifc-lite/encoding`, which `@ifc-lite/ids` already depends on -- would need
+ * no new package, but it would put a test-only helper on a published package's
+ * surface, and an unused public export is permanent semver liability. This
+ * package is `private: true` and is a devDependency of both consumers, so it
+ * adds no runtime dependency edge to either.
+ *
+ * ## Why CPU time and not the wall clock
+ *
+ * The property under test is "the algorithm does a bounded amount of WORK".
+ * The wall clock does not measure work; it measures work plus however long the
+ * operating system chose not to run us. On a loaded runner those are different
+ * by two orders of magnitude, and the difference is what reddened unrelated
+ * PRs.
+ *
+ * Measured on one 12-core machine, the same linear scan over the largest rung
+ * (2.56M characters), 200 readings each:
+ *
+ *   idle          wall p50 3.87ms   p99 5.73ms    max 7.13ms
+ *                 cpu  p50 3.87ms   p99 6.99ms    max 7.13ms
+ *   900 busy      wall p50 548ms    p99 1533ms    max 1682ms
+ *   processes     cpu  p50 5.67ms   p99 8.88ms    max 9.93ms
+ *
+ * Against a 500ms budget the wall clock is a coin flip at that load and the CPU
+ * clock has 50x of margin. Idle, the two clocks agree to the last digit, which
+ * is what says the swap changes the instrument's noise and not its reading.
+ *
+ * This is a TIGHTENING, not a relaxation. For a single-threaded decision CPU
+ * time is always less than or equal to wall time, so every input this bound
+ * rejects, the wall-clock bound rejected too; the converse is what stopped
+ * being true. `process.cpuUsage()` also counts V8's background GC and compiler
+ * threads, which can only push a reading up.
+ *
+ * What is knowingly given up: a regression that made the decision BLOCK --
+ * sleep, or wait on I/O -- would burn wall time without burning CPU and would
+ * no longer red. The decisions this ladder is pointed at are synchronous
+ * character scans with no I/O in them, so that shape would have to be
+ * introduced deliberately.
+ *
+ * ## Why ATTEMPTS survives, and why it was not enough on its own
+ *
+ * `Math.min` can only fall, so a reading already inside the budget is final and
+ * no repeat is made -- the healthy path is one call per rung. It is kept as a
+ * second line of defence, and it costs nothing when nothing is wrong.
+ *
+ * It was not sufficient by itself, and the reason is worth recording because
+ * the comment it replaces claimed otherwise. Three attempts are taken
+ * BACK-TO-BACK, so at the largest rung they span about 11ms of real work. They
+ * are not independent samples of the runner's load; any contention burst
+ * lasting longer than the three readings covers all three. Reproduced: this
+ * exact linear scan, unmodified, running the real ladder 100 times under 900
+ * busy processes on 12 cores, blew the 2.56M rung 3 times, with readings such
+ * as `812.5, 968.1, 549.9` and `1226.1, 1168.2, 1137.6`. `2560000` is the value
+ * that was reported from CI against an unrelated parser PR.
+ */
+
+/** Per-decision budget, in milliseconds of CPU time. */
+export const BUDGET_MS = 500;
+
+/**
+ * Ascending, doubling. Ascending is what makes a quadratic implementation
+ * REPORT instead of HANG: cost rises 4x per rung, so the first rung it blows
+ * costs at most ~4x the budget, and the ladder stops there rather than
+ * carrying on to 2.56M where the same implementation would grind for minutes.
+ *
+ * It self-adapts to the runner in both directions. A slower machine blows a
+ * quadratic implementation at a lower rung; a faster one at a higher rung.
+ * Either way some rung fails, so the negative controls in the consuming suites
+ * need no hardware-tuned number -- the failure that a fixed `regexMs > 50`
+ * floor could not survive.
+ *
+ * It runs past 640k on purpose. The shape an absolute budget alone does not
+ * catch is a SUPERLINEAR regression with a constant small enough to stay under
+ * the budget (#3226 review): one extra full scan per 4000 characters costs
+ * ~143ms at 640k -- inside the budget, so a six-rung ladder would have missed
+ * it -- and ~572ms at 1.28M, where it blows.
+ */
+export const SIZES: readonly number[] = [
+  20_000, 40_000, 80_000, 160_000, 320_000, 640_000, 1_280_000, 2_560_000,
+];
+
+/** Readings taken at a rung before it is declared blown. See the docblock. */
+export const ATTEMPTS = 3;
+
+/** A decision under test: it must REJECT every fixture the ladder feeds it. */
+export type Decide = (v: string) => boolean;
+
+export interface LadderOptions {
+  /**
+   * Builds the hostile fixture of a given length. The trailing non-digit is
+   * the whole point for a numeric scan: an all-digit string of any length
+   * matches immediately, which is why plausible fixtures miss this.
+   */
+  readonly hostile: (n: number) => string;
+  /** Override for a self-test. Consumers should leave these alone. */
+  readonly sizes?: readonly number[];
+  readonly budgetMs?: number;
+  readonly attempts?: number;
+}
+
+/**
+ * CPU milliseconds spent inside one call, plus its verdict.
+ *
+ * `process.cpuUsage()` is checked rather than assumed: a silent fallback to the
+ * wall clock would reintroduce exactly the flake this package exists to remove,
+ * and it would do so invisibly.
+ */
+function cpuMsOf(decide: Decide, v: string): { ms: number; verdict: boolean } {
+  if (typeof process?.cpuUsage !== 'function') {
+    throw new Error(
+      'timing-ladder needs process.cpuUsage(); the wall clock is not a substitute (see the docblock in @ifc-lite/timing-ladder)'
+    );
+  }
+  const before = process.cpuUsage();
+  const verdict = decide(v);
+  const after = process.cpuUsage(before);
+  return { ms: (after.user + after.system) / 1000, verdict };
+}
+
+/** Fastest of up to `attempts` decisions, stopping as soon as one is in budget. */
+function fastestMs(decide: Decide, n: number, opts: Required<Omit<LadderOptions, 'sizes'>> & { sizes: readonly number[] }): number {
+  const v = opts.hostile(n);
+  let best = Infinity;
+  for (let attempt = 0; attempt < opts.attempts; attempt++) {
+    const { ms, verdict } = cpuMsOf(decide, v);
+    best = Math.min(best, ms);
+    // A decision that says "accepted" would mean the timing measured an early
+    // return rather than a full scan, so the reading would prove nothing. This
+    // throws rather than returning, because a ladder quietly timing the wrong
+    // thing is the failure mode this whole file is guarding against.
+    if (verdict !== false) {
+      throw new Error(
+        `timing-ladder: the decision accepted the hostile fixture at n=${n}, so the reading timed an early return rather than a full scan`
+      );
+    }
+    if (best < opts.budgetMs) break;
+  }
+  return best;
+}
+
+/**
+ * The first size at which `decide` blew the budget, or `null` if it cleared
+ * every rung.
+ *
+ * Throws if `decide` ever accepts a hostile fixture -- see `fastestMs`.
+ */
+export function firstBlownRung(decide: Decide, options: LadderOptions): number | null {
+  const opts = {
+    hostile: options.hostile,
+    sizes: options.sizes ?? SIZES,
+    budgetMs: options.budgetMs ?? BUDGET_MS,
+    attempts: options.attempts ?? ATTEMPTS,
+  };
+  for (const n of opts.sizes) {
+    if (fastestMs(decide, n, opts) >= opts.budgetMs) return n;
+  }
+  return null;
+}

--- a/packages/timing-ladder/tsconfig.json
+++ b/packages/timing-ladder/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -965,6 +965,9 @@ importers:
 
   packages/encoding:
     devDependencies:
+      '@ifc-lite/timing-ladder':
+        specifier: workspace:^
+        version: link:../timing-ladder
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1066,6 +1069,9 @@ importers:
         specifier: ^0.9.11
         version: 0.9.11
     devDependencies:
+      '@ifc-lite/timing-ladder':
+        specifier: workspace:^
+        version: link:../timing-ladder
       happy-dom:
         specifier: ^20.11.2
         version: 20.11.2
@@ -1525,6 +1531,18 @@ importers:
         specifier: workspace:^
         version: link:../geometry
     devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@26.2.0)(happy-dom@20.11.2)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+
+  packages/timing-ladder:
+    devDependencies:
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -47,6 +47,7 @@
   "packages/source-fixture": 0,
   "packages/source-msgraph": 0,
   "packages/spatial": 0,
+  "packages/timing-ladder": 0,
   "packages/viewer": 0,
   "packages/world-frame-fixtures": 0
 }


### PR DESCRIPTION
The linearity ladder existed twice, near line-for-line, in `packages/encoding/src/numeric-literal.test.ts` and `packages/ids/src/constraints/numeric-literal.test.ts` — budget, rungs, retry policy, and ~110 lines of docblock. The `ids` copy reddened #3261, a parser change that cannot affect it, reporting `firstBlownRung = 2560000`, while `main` was green on the same test.

## What the two copies actually looked like

No asymmetry left to find: by the time of this change both had already been converted to the same `ATTEMPTS = 3` absolute-budget ladder and were identical in the ladder code and in the docblock. The only differences were the `hostile` fixture (`-1…1x` vs `-9…9X`) and the number of call sites — one in `encoding`, four in `ids`. So "apply least-of-N" was already done; it is not what fixes this.

## Root cause

The budget was spent against the **wall clock**, and `ATTEMPTS` did not protect it the way the docblock claimed. The three attempts are taken back-to-back and span ~11 ms of real work at the largest rung, so they are not independent samples of the runner's load — a single contention burst covers all three. The docblock's "a burst has to cover all three" is true, and is exactly why it fails: the burst only has to last about a second and a half.

Reproduced with the ladder code unmodified, on the real linear scan, 100 runs under 900 busy processes on 12 cores:

```
  BLOWN at 2560000: readings 812.5, 968.1, 549.9
  BLOWN at 2560000: readings 1358.9, 1183.4, 925.4
  BLOWN at 2560000: readings 1226.1, 1168.2, 1137.6
```

The claimed "~135x of headroom" is an idle figure quoted as protection. Measured at the 2.56M rung, min-of-3 exactly as the ladder computes it:

| load | single reading (p50 / p99 / max) | min-of-3 worst | margin to 500 ms |
|---|---|---|---|
| idle | 3.92 / 5.01 / 5.89 ms | 4.16 ms | 120x |
| 160 procs | 79.9 / 399 / **553** ms | 163 ms | 3.06x |
| 480 procs | 137 / 788 / 949 ms | 296 ms | 1.69x |
| 900 procs | 571 / 1382 / 1642 ms | 915 ms | **fails** |

A single reading already exceeds the 500 ms budget at 160 processes.

## The fix: spend the budget against the CPU clock

The property under test is that the algorithm does bounded **work**. The wall clock does not measure work; it measures work plus however long the operating system chose not to run us. Same 200 readings, same 900-process load:

```
  wall  p50 548ms   p99 1533ms   max 1682ms
  cpu   p50 5.67ms  p99 8.88ms   max 9.93ms      (idle max 7.13ms)
```

Idle, the two clocks agree to the last digit — which is what says the swap changes the instrument's noise and not its reading.

**This is a tightening, not a relaxation.** For a single-threaded decision CPU time is always ≤ wall time, so every input the old bound rejected this one rejects too; the converse is what stopped being true. `process.cpuUsage()` also counts V8's background GC and compiler threads, which can only push a reading up. No threshold raised, no tolerance widened, no skip added. `ATTEMPTS = 3` is kept as a second line of defence and stays free on the healthy path, because `Math.min` can only fall.

Knowingly given up, and documented in the code: a regression that *blocks* — sleeps, or waits on I/O — would burn wall time without burning CPU and would no longer red. These are synchronous character scans with no I/O in them.

## Deduplication

A new **private** package, `@ifc-lite/timing-ladder`, following the `@ifc-lite/world-frame-fixtures` precedent. It is a `devDependency` of both consumers, so it adds no runtime dependency edge and `@ifc-lite/encoding` stays a package with no runtime dependencies.

The alternative #3224 floats — a subpath on `@ifc-lite/encoding`, which `@ifc-lite/ids` already depends on — needs no new package and no new edge, but it puts a test-only helper on a published package's API surface, which AGENTS.md calls permanent semver liability, and it would land in `scripts/api-surface.json` and need a changeset.

Net: −155 lines across the two test files, one shared implementation.

## The ladder now carries its own controls

This instrument has gone vacuous before — #3285, and before that a negative control that was accidentally linear and cleared the whole ladder in 9 ms. So `@ifc-lite/timing-ladder` pins its own claims:

- a quadratic decision must blow a rung;
- a decision that **accepts** the hostile fixture now throws (`the decision accepted the hostile fixture at n=20000, so the reading timed an early return rather than a full scan`) instead of silently timing an early return;
- a decision made 100x more expensive must blow a budget the cheap one clears, so the reading is pinned as a measurement rather than a constant;
- a decision that blocks for a wall-clock second (measured 1004 ms) must still clear a 500 ms budget. **That one reds if anyone puts `performance.now()` back.**

## Mutation check

All three negative controls in both suites still blow a rung on the CPU clock, and still take seconds to do it — the cost is the evidence that they climbed the ladder rather than short-circuiting:

```
  encoding:  quadratic regex 2837ms | backtracking scan 4089ms | small-constant superlinear 2151ms
  ids:       quadratic regex 6134ms | backtracking scan 4152ms | small-constant superlinear 2225ms
```

The third is the one that matters: one extra full pass per 4000 characters, the shape a pure absolute bound misses and the reason the ladder runs past 640k.

Those controls inject the defect. Stronger: the defect was also put back into the **real function**, `isWhollyNumeric` itself, and the suites run against it.

Mutation A — the quadratic regex #3113 was filed against:

```
  encoding  FAIL  decides every size up to 2.56M characters inside the budget
                  AssertionError: expected 40000 to be null
  ids       FAIL  decides every size up to 2.56M characters inside the budget
            FAIL  bounds the per-entity path too, not just the literal check
            FAIL  xs:double strict cast > decides every size ... inside the budget
                  AssertionError: expected 40000 to be null   (all three)
```

`bounds the per-entity path too` is the exact test that was flaking. It reds on a real defect and stays green under contention.

Mutation B — small-constant superlinear, one extra full pass per 4000 characters, the shape the CPU-clock switch could plausibly have blinded:

```
  encoding  FAIL  decides every size up to 2.56M characters inside the budget
                  AssertionError: expected 1280000 to be null
```

Caught at exactly the 1.28M rung the docblock predicts. Both mutations were restored by inverse edit and `diff` confirms byte-identity; the tree is clean.

And under contention, the discrimination holds. Same 160-process load, shipped ladder:

```
  MODE=superlinear  iterations=3   blown=3  rungs=1280000
  MODE=real         iterations=30  blown=0
```

Defect caught 3/3 at the same rung it finds when idle — load does not move the detection point — while the healthy scan is clean 30/30. Under the 900-process load that produced the RED above, the shipped ladder ran the real scan 100 times with **0** false reds.

## Plausibility of the numbers

Idle at 2.56M: 3.71–3.77 ms, i.e. 1.47 ns/char ≈ 680M chars/s ≈ 5–6 cycles per character for a loop doing a load, two range compares, an increment and a branch. Rung to rung: 0.46 → 0.88 → 1.81 → 3.71 ms, exactly 2x per doubling. The harness is timing a full linear scan, not an early return.

Test-only change, so no changeset.

Refs #3224
