### PR TITLE
fix(viewer-embed): emit CAMERA_CHANGED for real navigation, not only for a programmatic SET_CAMERA

### DIFF
--- a/apps/viewer-embed/src/components/EmbedViewer.cameraChanged.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.cameraChanged.test.ts
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * CAMERA_CHANGED must report REAL navigation, at a bounded cadence (#2934
+ * item 2).
+ *
+ * The outbound effect used to subscribe to the store's `cameraRotation`,
+ * which only `setCameraRotation` writes. Live navigation -- orbit/pan drag
+ * (`useMouseControls.ts`), keyboard (`useKeyboardControls.ts`), the ViewCube
+ * and the animation loop (`useAnimationLoop.ts`) -- deliberately bypasses
+ * store state and calls `updateCameraRotationRealtime` instead, so the
+ * effect's dependency never changed and a host watching a live drag heard
+ * nothing.
+ *
+ * These tests drive `updateCameraRotationRealtime` exactly as those call
+ * sites do (`updateCameraRotationRealtime(camera.getRotation())`) and observe
+ * what reaches `window.parent.postMessage` -- the same instrument
+ * `EmbedViewer.test.ts` uses for SECTION_CHANGED.
+ *
+ * The cadence is asserted from BOTH ends: a silent bridge fails, and so does
+ * a per-frame firehose. "At least one event" would pass both defects.
+ *
+ * Real timers throughout, deliberately: React 19's scheduler stalls under
+ * vitest's faked timer surface, so the store-subscription effects would never
+ * flush and the test would be measuring the harness. The waits are one or two
+ * throttle windows.
+ */
+
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EmbedMessageEnvelope } from '@ifc-lite/embed-protocol';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
+
+vi.mock('@/components/viewer/Viewport', () => ({ Viewport: () => null }));
+vi.mock('@/components/viewer/ViewportOverlays', () => ({ ViewportOverlays: () => null }));
+// Stable function identities across renders: EmbedViewer's bridge-init effect
+// lists `loadFile`/`addModel` in its dependency array, so a mock that mints
+// fresh vi.fn()s per render tears the bridge down and re-initializes it on
+// every re-render -- which resets the negotiated parent origin and silently
+// withholds every outbound event but READY (`emitToParent`).
+const loadFile = vi.fn(async () => {});
+const addModel = vi.fn(async () => 'stub-model-id');
+const clearAllModels = vi.fn();
+const emptyModels = new Map();
+vi.mock('@/hooks/useIfc', () => ({
+  useIfc: () => ({
+    geometryResult: null,
+    ifcDataStore: null,
+    loadFile,
+    loading: false,
+    models: emptyModels,
+    clearAllModels,
+    addModel,
+  }),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const { EmbedViewer } = await import('./EmbedViewer.js');
+const { useViewerStore } = await import('@/store/index.js');
+
+/** Mirrors CAMERA_EMIT_INTERVAL_MS in useEmbedBridgeEvents.ts. */
+const INTERVAL_MS = 100;
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+let posted: EmbedMessageEnvelope[] = [];
+
+function mount(): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(EmbedViewer));
+  });
+  mounted.push({ root, container });
+  // `emitToParent` withholds every message except READY until a concrete
+  // parent origin is known (it refuses to broadcast to '*'), so an inbound
+  // handshake is required before ANY outbound event can be observed.
+  act(() => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { source: EMBED_SOURCE, version: PROTOCOL_VERSION, type: 'INIT' },
+        origin: 'https://parent.example',
+        source: window.parent,
+      }),
+    );
+  });
+}
+
+/** The exact call every live-navigation site makes. */
+function drag(azimuth: number, elevation: number): void {
+  act(() => {
+    useViewerStore.getState().updateCameraRotationRealtime({ azimuth, elevation });
+  });
+}
+
+/** Let the throttle window elapse and any trailing flush land. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS + 20));
+  });
+}
+
+function cameraPayloads(): unknown[] {
+  return posted.filter((m) => m.type === 'CAMERA_CHANGED').map((m) => m.data);
+}
+
+beforeEach(() => {
+  posted = [];
+  Object.defineProperty(window, 'parent', {
+    configurable: true,
+    value: { postMessage: (msg: EmbedMessageEnvelope) => posted.push(msg) },
+  });
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  useViewerStore.getState().setCameraRotation({ azimuth: 0, elevation: 0 });
+});
+
+describe('CAMERA_CHANGED reports live navigation', () => {
+  it('emits while the user is dragging the camera', async () => {
+    mount();
+    await settle();
+    posted.length = 0;
+
+    drag(10, 20);
+    await settle();
+
+    expect(cameraPayloads()).toContainEqual({ azimuth: 10, elevation: 20 });
+  });
+
+  it('emits for a programmatic setCameraRotation (control)', async () => {
+    mount();
+    await settle();
+    posted.length = 0;
+
+    act(() => {
+      useViewerStore.getState().setCameraRotation({ azimuth: 33, elevation: 44 });
+    });
+    await settle();
+
+    expect(cameraPayloads()).toContainEqual({ azimuth: 33, elevation: 44 });
+  });
+
+  it('throttles a per-frame drag to the leading pose plus the settled pose', async () => {
+    mount();
+    await settle();
+    posted.length = 0;
+
+    // 30 animation frames back to back: what a real orbit drag produces
+    // inside a single throttle window. An unthrottled emitter posts 30.
+    for (let frame = 1; frame <= 30; frame += 1) {
+      drag(frame, frame * 2);
+    }
+    // Gesture ends; let the trailing flush land.
+    await settle();
+
+    const payloads = cameraPayloads();
+    // One leading emit, then one trailing emit per elapsed window. Anything
+    // approaching 30 is a firehose; fewer than 2 means the settled pose was
+    // dropped rather than deferred.
+    expect(payloads.length).toBeGreaterThanOrEqual(2);
+    expect(payloads.length).toBeLessThanOrEqual(3);
+    // The pose the camera SETTLED on must be the last thing the host hears --
+    // the old throttle dropped in-window updates instead of deferring them,
+    // so the final frame of a gesture was the one most likely to be lost.
+    expect(payloads.at(-1)).toEqual({ azimuth: 30, elevation: 60 });
+  });
+
+  it('stays silent while the camera is idle (the animation loop re-reports an unchanged pose)', async () => {
+    mount();
+    await settle();
+    drag(7, 8);
+    await settle();
+    posted.length = 0;
+
+    // useAnimationLoop.ts re-reports the current rotation on a timer even when
+    // nothing moved. An unchanged pose is not a change.
+    for (let tick = 0; tick < 4; tick += 1) {
+      drag(7, 8);
+      await settle();
+    }
+
+    expect(cameraPayloads()).toEqual([]);
+  });
+});

--- a/apps/viewer-embed/src/components/EmbedViewer.cameraChanged.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.cameraChanged.test.ts
@@ -177,6 +177,31 @@ describe('CAMERA_CHANGED reports live navigation', () => {
     expect(payloads.at(-1)).toEqual({ azimuth: 30, elevation: 60 });
   });
 
+  it('does not re-emit a pose that returns to the last-emitted value mid-window', async () => {
+    mount();
+    await settle();
+    posted.length = 0;
+
+    // {5,5} emits on the leading edge; the next two frames land INSIDE that
+    // throttle window, so neither is sent directly -- {6,6} is queued and then
+    // overwritten by {5,5}, the pose the camera came back to. An orbit drag
+    // nudged off its resting pose and released onto it does this, as does a
+    // ViewCube snap that overshoots by a frame.
+    //
+    // `report` compares the incoming pose against the QUEUED one ({6,6}), so
+    // it sees news; only the flush is in a position to notice that what it is
+    // about to send is what the host already has, and it never looked.
+    drag(5, 5);
+    drag(6, 6);
+    drag(5, 5);
+    await settle();
+
+    // The contract is "never two events for the same pose". {6,6} never
+    // reached the host, so a trailing {5,5} would be the same pose twice in a
+    // row with nothing in between.
+    expect(cameraPayloads()).toEqual([{ azimuth: 5, elevation: 5 }]);
+  });
+
   it('stays silent while the camera is idle (the animation loop re-reports an unchanged pose)', async () => {
     mount();
     await settle();

--- a/apps/viewer-embed/src/components/useEmbedBridgeEvents.ts
+++ b/apps/viewer-embed/src/components/useEmbedBridgeEvents.ts
@@ -114,6 +114,16 @@ export function useEmbedBridgeEvents(): void {
       const next = pending;
       pending = null;
       if (!next) return;
+      // Re-check against what was actually SENT, not only against what was
+      // queued. `report` compares an incoming pose to the pending one, so a
+      // camera that moves away and returns to the last-emitted pose inside a
+      // single window queues the return as news -- and the host would hear the
+      // same pose twice in a row, with the intermediate pose it never received
+      // in between. The cadence contract is "never two events for the same
+      // pose"; this is the only place left that can see it.
+      if (lastSent && lastSent.azimuth === next.azimuth && lastSent.elevation === next.elevation) {
+        return;
+      }
       lastEmitAt = Date.now();
       lastSent = next;
       emitEvent('CAMERA_CHANGED', { azimuth: next.azimuth, elevation: next.elevation });

--- a/apps/viewer-embed/src/components/useEmbedBridgeEvents.ts
+++ b/apps/viewer-embed/src/components/useEmbedBridgeEvents.ts
@@ -17,6 +17,11 @@ import { useEffect, useRef } from 'react';
 import { useViewerStore } from '@/store';
 import { emitEvent } from '../bridge/handler.js';
 
+/** Minimum spacing between two outbound CAMERA_CHANGED events (10Hz). */
+const CAMERA_EMIT_INTERVAL_MS = 100;
+
+type CameraRotationLike = { azimuth: number; elevation: number };
+
 export function useEmbedBridgeEvents(): void {
   // Emit selection events to parent
   const selectedEntityId = useViewerStore((s) => s.selectedEntityId);
@@ -64,18 +69,91 @@ export function useEmbedBridgeEvents(): void {
     });
   }, [hoveredEntityId]);
 
-  // Emit camera rotation changes to parent (throttled)
-  const cameraRotation = useViewerStore((s) => s.cameraRotation);
-  const lastCameraEmit = useRef(0);
+  // Emit camera rotation changes to parent.
+  //
+  // Cadence contract: at most one CAMERA_CHANGED per CAMERA_EMIT_INTERVAL_MS
+  // (10Hz) while the camera keeps moving, plus exactly one trailing event
+  // carrying the pose the camera settled on. Never two events for the same
+  // pose.
+  //
+  // Why not just subscribe to the store's `cameraRotation`: only
+  // `setCameraRotation` writes it, and real navigation — orbit/pan drag
+  // (useMouseControls.ts), keyboard (useKeyboardControls.ts), the ViewCube and
+  // the animation loop (useAnimationLoop.ts) — deliberately bypasses store
+  // state for performance and reports through `updateCameraRotationRealtime`.
+  // So the store subscription could only ever echo a pose the host itself had
+  // just sent, and a host watching a live drag heard nothing (#2934 item 2).
+  //
+  // Why not emit on every `updateCameraRotationRealtime`: that feed is
+  // per-animation-frame while anything is moving AND a ~2Hz heartbeat while
+  // the camera is perfectly still (useAnimationLoop.ts re-reports every 500ms
+  // when idle). Hence both the throttle and the equality check — an unchanged
+  // pose is not a change and must not be posted.
+  //
+  // The previous throttle *dropped* anything arriving inside the window
+  // instead of deferring it, so the last pose of a gesture — the one the host
+  // actually needs — was the one most likely to be lost. The trailing flush
+  // below is what replaces that dropped event; the old leading-edge emit is
+  // still the first branch here, and the mount-time emit of the initial pose
+  // still happens. The ONE case the old code posted and this does not: a
+  // `setCameraRotation` writing the pose already emitted, which used to
+  // re-post an identical CAMERA_CHANGED. That is the deliberate half of the
+  // change -- with the realtime feed now wired in, an unchanged pose would
+  // arrive as a heartbeat rather than as news.
+  const subscribeCameraRotation = useViewerStore((s) => s.subscribeCameraRotation);
+  const storeCameraRotation = useViewerStore((s) => s.cameraRotation);
+  const reportCamera = useRef<(rotation: CameraRotationLike) => void>(() => {});
   useEffect(() => {
-    const now = Date.now();
-    if (now - lastCameraEmit.current < 100) return; // throttle to 10Hz
-    lastCameraEmit.current = now;
-    emitEvent('CAMERA_CHANGED', {
-      azimuth: cameraRotation.azimuth,
-      elevation: cameraRotation.elevation,
-    });
-  }, [cameraRotation]);
+    let lastEmitAt = 0;
+    let lastSent: CameraRotationLike | null = null;
+    let pending: CameraRotationLike | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const flush = () => {
+      timer = null;
+      const next = pending;
+      pending = null;
+      if (!next) return;
+      lastEmitAt = Date.now();
+      lastSent = next;
+      emitEvent('CAMERA_CHANGED', { azimuth: next.azimuth, elevation: next.elevation });
+    };
+
+    const report = (rotation: CameraRotationLike) => {
+      const previous = pending ?? lastSent;
+      if (previous && previous.azimuth === rotation.azimuth && previous.elevation === rotation.elevation) {
+        return;
+      }
+      pending = { azimuth: rotation.azimuth, elevation: rotation.elevation };
+      const waited = Date.now() - lastEmitAt;
+      if (waited >= CAMERA_EMIT_INTERVAL_MS) {
+        if (timer !== null) clearTimeout(timer);
+        flush();
+      } else if (timer === null) {
+        timer = setTimeout(flush, CAMERA_EMIT_INTERVAL_MS - waited);
+      }
+    };
+
+    reportCamera.current = report;
+    report(useViewerStore.getState().cameraRotation);
+    const unsubscribe = subscribeCameraRotation(report);
+    return () => {
+      unsubscribe();
+      reportCamera.current = () => {};
+      if (timer !== null) clearTimeout(timer);
+      timer = null;
+      pending = null;
+    };
+  }, [subscribeCameraRotation]);
+
+  // The programmatic path. `setCameraRotation` actuates the renderer, but
+  // whether that actuation round-trips back through the realtime feed depends
+  // on a renderer being registered at all, so SET_CAMERA is reported here too
+  // -- through the SAME throttle, whose equality check collapses the duplicate
+  // if the realtime feed does echo it back.
+  useEffect(() => {
+    reportCamera.current(storeCameraRotation);
+  }, [storeCameraRotation]);
 
   // Emit section-plane changes to parent. Mirrors the CAMERA_CHANGED effect
   // above: the bridge's SET_SECTION handler (apps/viewer-embed/src/bridge/

--- a/apps/viewer/src/store/slices/cameraSlice.ts
+++ b/apps/viewer/src/store/slices/cameraSlice.ts
@@ -27,6 +27,11 @@ export interface CameraSlice {
   setProjectionMode: (mode: ProjectionMode) => void;
   toggleProjectionMode: () => void;
   setOnCameraRotationChange: (callback: ((rotation: CameraRotation) => void) | null) => void;
+  /** Additional (multi-)listeners on the same live-navigation feed as
+   *  {@link onCameraRotationChange}, whose single slot is owned by the
+   *  ViewCube. Returns an unsubscribe function. */
+  cameraRotationListeners: Set<(rotation: CameraRotation) => void>;
+  subscribeCameraRotation: (listener: (rotation: CameraRotation) => void) => () => void;
   updateCameraRotationRealtime: (rotation: CameraRotation) => void;
   setOnScaleChange: (callback: ((scale: number) => void) | null) => void;
   updateScaleRealtime: (scale: number) => void;
@@ -42,6 +47,7 @@ export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> =
   cameraCallbacks: {},
   projectionMode: 'perspective',
   onCameraRotationChange: null,
+  cameraRotationListeners: new Set(),
   onScaleChange: null,
 
   // Actions
@@ -77,11 +83,28 @@ export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> =
   },
   setOnCameraRotationChange: (onCameraRotationChange) => set({ onCameraRotationChange }),
 
+  // `onCameraRotationChange` is a single slot and the ViewCube owns it
+  // (ViewportOverlays.tsx), so anything else that needs the live feed — the
+  // embed's outbound CAMERA_CHANGED, which otherwise only ever saw
+  // programmatic `setCameraRotation` (#2934) — needs its own channel. The Set
+  // is created once and mutated in place: it is never handed to a React
+  // selector, so add/remove must not (and does not) trigger a re-render.
+  subscribeCameraRotation: (listener) => {
+    const listeners = get().cameraRotationListeners;
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  },
+
   updateCameraRotationRealtime: (rotation) => {
     const callback = get().onCameraRotationChange;
     if (callback) {
       // Use direct callback - no React state update, no re-renders
       callback(rotation);
+    }
+    for (const listener of get().cameraRotationListeners) {
+      listener(rotation);
     }
     // Don't update store state during real-time updates
   },

--- a/packages/embed-protocol/src/index.ts
+++ b/packages/embed-protocol/src/index.ts
@@ -152,11 +152,21 @@ export interface OutboundPayloads {
   ENTITY_DESELECTED: void;
   ENTITY_HOVERED: { id: number; globalId?: string; ifcType?: string };
   /**
-   * Sent for BOTH user navigation (orbit/pan drag, keyboard, ViewCube) and a
-   * programmatic SET_CAMERA. Cadence: at most one event per 100ms while the
-   * camera keeps moving, plus one trailing event carrying the pose it settled
-   * on -- never one per animation frame. A pose identical to the last one
-   * reported is not re-sent.
+   * A change of camera ORIENTATION -- `azimuth`/`elevation`, the direction from
+   * the camera's target to the camera. Fires for an orbit drag, the keyboard
+   * orbit keys, the ViewCube and the preset views, and for a programmatic
+   * SET_CAMERA.
+   *
+   * It does NOT fire for a pan or for a zoom/dolly: panning translates the
+   * camera and its target by the same offset and zooming changes only the
+   * distance between them, so in both cases the orientation this event reports
+   * is unchanged, and an unchanged pose is not re-sent. A host that needs to
+   * follow a pan or a zoom cannot use this event -- `zoom` below is optional
+   * and the embed viewer does not currently populate it.
+   *
+   * Cadence: at most one event per 100ms while the orientation keeps changing,
+   * plus one trailing event carrying the orientation it settled on -- never one
+   * per animation frame. The same pose is never reported twice in a row.
    */
   CAMERA_CHANGED: { azimuth: number; elevation: number; zoom?: number };
   SECTION_CHANGED: { axis: SectionAxis; position: number; enabled: boolean };

--- a/packages/embed-protocol/src/index.ts
+++ b/packages/embed-protocol/src/index.ts
@@ -151,6 +151,13 @@ export interface OutboundPayloads {
   ENTITY_SELECTED: { id: number; globalId?: string; modelId?: string; ifcType?: string };
   ENTITY_DESELECTED: void;
   ENTITY_HOVERED: { id: number; globalId?: string; ifcType?: string };
+  /**
+   * Sent for BOTH user navigation (orbit/pan drag, keyboard, ViewCube) and a
+   * programmatic SET_CAMERA. Cadence: at most one event per 100ms while the
+   * camera keeps moving, plus one trailing event carrying the pose it settled
+   * on -- never one per animation frame. A pose identical to the last one
+   * reported is not re-sent.
+   */
   CAMERA_CHANGED: { azimuth: number; elevation: number; zoom?: number };
   SECTION_CHANGED: { axis: SectionAxis; position: number; enabled: boolean };
 }


### PR DESCRIPTION
## What

`CAMERA_CHANGED` never fired for real camera navigation — **#2934 item 2**, the only part of that issue still open and unclaimed (items 1, 3, 4, 5 and the URL params are already fixed on `main`).

The outbound effect subscribed to the store's `cameraRotation`, which only `setCameraRotation` writes. Every live navigation path — orbit/pan drag (`useMouseControls.ts:697`), keyboard (`useKeyboardControls.ts:117`), ViewCube and the animation loop (`useAnimationLoop.ts:342`) — deliberately bypasses store state for performance and reports through `updateCameraRotationRealtime`. So the effect's dependency never changed during a drag and the host heard nothing; the event could only ever echo back a pose the host itself had just sent.

## Reproduction, through the real path

`EmbedViewer.cameraChanged.test.ts` renders the real `EmbedViewer`, does the handshake, and calls `updateCameraRotationRealtime` exactly as the drag sites do, watching `window.parent.postMessage`. Against `main`:

```
× emits while the user is dragging the camera
  AssertionError: expected [] to deep equally contain { azimuth: 10, elevation: 20 }
✓ emits for a programmatic setCameraRotation (control)
```

## The cadence contract

There was no documented contract, so this states one — and it is deliberately *not* "forward every realtime callback". That feed fires per animation frame while anything is moving **and** re-reports an unchanged pose roughly every 500ms while the camera is perfectly still (`useAnimationLoop.ts`, the `currentTime - lastRotationUpdate > 500` branch). Unthrottled that is a firehose plus an idle heartbeat.

> At most one `CAMERA_CHANGED` per 100ms while the camera keeps moving, plus one trailing event carrying the pose it settled on. Never two events for the same pose.

Documented on `OutboundPayloads.CAMERA_CHANGED` in `@ifc-lite/embed-protocol` (comment only — no behaviour change in that package, hence no changeset; `apps/viewer-embed` and `apps/viewer` are private).

## The change

`onCameraRotationChange` is a **single slot and the ViewCube owns it** (`ViewportOverlays.tsx`, and `lib/tours/events.ts` says so explicitly), so `cameraSlice` grows a second, multi-listener channel on the same feed: `subscribeCameraRotation`. No `set()` — the "don't update store state during real-time updates" invariant is untouched, and the Set is never handed to a React selector.

### What the displaced path no longer reaches

The old throttle `if (now - last < 100) return;` **dropped** in-window updates instead of deferring them, so the last pose of a gesture — the one the host actually needs — was the one most likely to be lost. The trailing flush replaces that dropped event; the old leading-edge emit is still the first branch, and the mount-time emit of the initial pose still happens.

The one case the old code posted and this one does not: a `setCameraRotation` re-writing the pose already emitted, which used to re-post an identical `CAMERA_CHANGED`. That is deliberate — with the realtime feed wired in, an unchanged pose is a heartbeat, not news.

## Proof

RED (above) → GREEN, 4 tests, and the cadence is asserted from **both** ends, so neither silence nor a firehose passes:

| mutation | failure |
|---|---|
| drop the listener fan-out in `updateCameraRotationRealtime` | `expected [] to deep equally contain { azimuth: 10, elevation: 20 }` |
| drop in-window updates instead of deferring (the old shape) | `expected 1 to be greater than or equal to 2` |
| emit every realtime frame (no throttle) | `expected 30 to be less than or equal to 3` |
| remove the unchanged-pose check | `expected [ { azimuth: 7, elevation: 8 }, …(3) ] to deeply equal []` |

Each mutation restored by inverse edit and proved byte-identical with `diff`.

`apps/viewer-embed` 174/174, `@ifc-lite/embed-sdk` 72/72, `@ifc-lite/embed-protocol`, `cameraSlice.test.ts`, `tsc --noEmit` on both apps clean, `check-module-size` / `check-test-wiring` / `check-test-glob-coverage` / `check-source-text-assertions` / `check-changesets` / `oxlint` green.

Refs #2934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Embedded viewers now report camera changes during live navigation and programmatic rotation.
  - Camera updates are throttled for smoother event delivery while preserving the final camera position.
  - Unchanged camera poses no longer produce duplicate events.

- **Bug Fixes**
  - Improved consistency of camera-change notifications across realtime and programmatic updates.

- **Documentation**
  - Clarified camera-change event behavior, including throttling and duplicate suppression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->