### PR TITLE
fix(data): restore step-serializers.ts to its module-size budget, unbreaking main

### DIFF
--- a/packages/data/src/step-serializers.ts
+++ b/packages/data/src/step-serializers.ts
@@ -176,26 +176,20 @@ export function serializeValue(value: StepValue): string {
  * Escape a string for STEP format.
  *
  * Backslash and single-quote are doubled per ISO-10303-21. Control characters
- * (CR/LF and other C0 codes plus DEL) are replaced by a space — ONE space per
- * control character, not one per run — so a value can never inject a physical
- * line break into the line-oriented STEP output (matching the export package's
- * escaper and `ifc_lite_export::step_text::escape`) — a raw newline in a
- * header or attribute value would otherwise split one record across two
- * lines. A run collapsed to a single space (`/[...]+/`, which this did until
- * #3284) silently loses length the Rust half preserves, so the same value
- * written by the two halves differed; neither is mandated by ISO 10303-21
- * 6.3.3.4, but preserving the count is the more faithful of the two and the
- * doc claim of parity below has to be true of one of them.
+ * (CR/LF and other C0 codes plus DEL) become ONE space EACH, not one per run,
+ * so a value cannot inject a line break and split one record across two.
+ * Collapsing a run (`/[...]+/`, which this did until #3284) loses length that
+ * `ifc_lite_export::step_text::escape` preserves, so the two halves wrote the
+ * same value differently. ISO 10303-21 6.3.3.4 mandates neither; per-character
+ * is the more faithful, and the parity claim below must be true of one.
  *
- * ISO 10303-21 6.3.3.4 restricts a string literal's plain-text bytes to the
- * "basic graphic" range 32-126; every other character is a control directive
- * (`\X\HH`, `\X2\HHHH\X0\`, `\X4\HHHHHHHH\X0\`), never a raw byte —
- * buildingSMART's IFC string-encoding guidance states the same for
- * IFC2X3/IFC4/IFC4X3. A reader that treats the file's bytes as ISO-8859-1 —
- * the byte encoding the base standard and most real consumers assume — turns
- * a raw UTF-8 multi-byte sequence into mojibake or a broken parse (reported,
- * reproduced in real IFC tooling: IfcOpenShell#699/#1016, files rejected by
- * Solibri). Matches `@ifc-lite/export`'s `escapeStepString`.
+ * ISO 10303-21 6.3.3.4 restricts a literal's plain-text bytes to the "basic
+ * graphic" range 32-126; anything else is a control directive (`\X\HH`,
+ * `\X2\HHHH\X0\`, `\X4\HHHHHHHH\X0\`), never a raw byte, and buildingSMART
+ * says the same for IFC2X3/IFC4/IFC4X3. A reader decoding as ISO-8859-1 (what
+ * the base standard and most consumers assume) turns raw UTF-8 into mojibake or
+ * a broken parse: IfcOpenShell#699/#1016, files rejected by Solibri. Matches
+ * `@ifc-lite/export`'s `escapeStepString`.
  */
 function escapeStepString(str: string): string {
   const escaped = str


### PR DESCRIPTION
**main is RED. This restores it. One file, comment-only, no functional change.**

    packages/data/src/step-serializers.ts: 465 lines, budget 459
    node scripts/check-module-size.mjs -> exit 1 on every branch cut from main

## Why main is red, and it is my fault

#3294 was one of two PRs whose `test.yml` **never fired**. It was opened against a feature branch and retargeted to `main`, and retargeting does not fire workflows retroactively. It carried **8 checks where a healthy PR carries 38** — no Typecheck, no Lint, no Node tests, no Rust tests, no Build, and crucially not the module-size gate. The gate was ABSENT rather than red, so `fail=0` was literally true and `mergeable` was true.

I found that, posted the diagnosis on the PR, then wrote a patch adding a required-lane-presence check to my merge gate. **The patch silently failed to apply** (python printed `AssertionError: anchor not found`; the next command printed `syntax OK` and I read the block as successful). I then ran that gate against #3294 to "exercise" the fix, and the unpatched gate merged it.

So the guard I was hardening performed the exact merge it was being hardened to prevent, because I exercised it against live production instead of a fixture.

**Nothing functional is wrong with #3294.** Its content is correct and its tests pass: `data` 212, `parser` 825, `export` 944, typecheck 0. Only the six comment lines it added to this file pushed the budget.

## The fix

**Shrink to the budget, not raise it** — the rule the allowlist header states, and the one I held #3249 to earlier today. Both edits compress existing prose. Every claim survives:

- one space per control character, not one per run
- the reason: a value must not inject a line break that splits a STEP record
- collapsing a run loses length that `ifc_lite_export::step_text::escape` preserves, so the two halves wrote the same value differently
- ISO 10303-21 6.3.3.4 mandates neither; per-character is more faithful
- the 32-126 basic-graphic restriction and the `\X\HH` / `\X2\` / `\X4\` directive forms
- buildingSMART saying the same for IFC2X3/IFC4/IFC4X3
- the ISO-8859-1 mojibake failure mode, with IfcOpenShell#699/#1016 and Solibri

## Verification

    file                    459 lines (budget 459)
    check-module-size       exit 0
    @ifc-lite/data          17 files, 212 tests, 0 failed
    typecheck               exit 0

Pre-flight review verified the change is comment-only three independent ways: every changed line matches JSDoc body; comment-stripped file content is **byte-identical** (7073 bytes both sides); and `escapeStepString` extracted by brace-matching is **character-identical** (831 chars). A behavioural differential over 9 fixed cases plus **30,000 fuzzed strings** reported **0 mismatches**, and the harness was proven non-vacuous — mutating the regex back to `[\x00-\x1F\x7F]+` made it report differences on 3 of 3 inputs.

The gate's pass was also checked for vacuity: lowering this row to 458 in a scratch allowlist makes it exit 1 naming this file, so the row is genuinely compared.

## Two things for whoever touches this file next

**Headroom is exactly zero.** 459 of 459. History across the last six commits here: 355, 382, 402, 427, 459, 465, 459 — five of six grew it. The next substantive change must shrink prose again or split the module, and splitting is the real fix.

**There is a better shrink available than this one, deliberately left out of a hotfix.** Lines 445 and 450 are **factually false** as of #3284: they say `escapeStepString` "never emits a directive" and "does NOT move". It emits `\X2\` at :209 and `\X4\` at :211 — I ran it. Deleting that stale paragraph frees 7 lines and removes a falsehood rather than compressing prose that was true. Following up separately, since removing wrong documentation is its own change and not something to bundle into an urgent red-main fix.
