### PR TITLE
fix(ci): close the path-filter holes, and gate the class that made them (#3312)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,8 +134,8 @@ jobs:
               # EVERY workflow, not just this one and server-binaries.yml.
               # `scripts/check-swallowed-push.mjs` declares its SCOPE to be
               # `.github/workflows/**` and runs in the Node tests job, so with
-              # only two workflows named here the gate was unreachable on 11 of
-              # the 13 files it guards -- PR #3118 edited release.yml and
+              # only two workflows named here the gate was unreachable on 13 of
+              # the 15 files it guards -- PR #3118 edited release.yml and
               # docker.yml and Node tests SKIPPED. `server-binaries.yml` (the
               # server-bin platform-parity check's input, issue #2619) and
               # `test.yml` are subsumed by this glob; test.yml stays named

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,14 +117,35 @@ jobs:
               - 'server/**'
               - 'api/**'
               - 'tests/api/**'
+              # `pnpm test:integration` runs THIS EXACT FILE in the Node tests
+              # job. Without it here the test cannot trigger its own execution:
+              # a PR editing only the integration harness skips the only lane
+              # that runs it.
+              - 'tests/integration.test.ts'
+              # The tsconfig BOTH `pnpm test:integration` and `pnpm test:api`
+              # compile against (`tsx --tsconfig tests/tsconfig.json`). Same
+              # trap as `.oxlintrc.json` above: a PR editing only the config a
+              # lane reads must not be able to skip that lane.
+              - 'tests/tsconfig.json'
               # The lint CONFIG, so a PR that only edits it cannot skip the
               # Lint job that reads it. Absent CI reads as green here, and a
               # guard cannot fire in a job that never runs.
               - '.oxlintrc.json'
-              # The server-bin platform-parity check reads this workflow's
-              # release matrix, so a PR that only edits the matrix cannot
-              # skip the job that checks it (issue #2619).
-              - '.github/workflows/server-binaries.yml'
+              # EVERY workflow, not just this one and server-binaries.yml.
+              # `scripts/check-swallowed-push.mjs` declares its SCOPE to be
+              # `.github/workflows/**` and runs in the Node tests job, so with
+              # only two workflows named here the gate was unreachable on 11 of
+              # the 13 files it guards -- PR #3118 edited release.yml and
+              # docker.yml and Node tests SKIPPED. `server-binaries.yml` (the
+              # server-bin platform-parity check's input, issue #2619) and
+              # `test.yml` are subsumed by this glob; test.yml stays named
+              # individually in the OTHER filters below, which this does not
+              # cover. COST: a workflow-only PR now runs the JS lane. Every job
+              # it adds is on a FREE ubuntu-latest runner except `build`, which
+              # only reaches Depot when the WASM source has drifted from the
+              # published release tag -- the same condition every frontend PR
+              # already pays. Workflow-only PRs are rare (dependabot bumps).
+              - '.github/workflows/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -154,6 +175,19 @@ jobs:
               - 'mkdocs.yml'
               - 'README.md'
               - 'packages/*/README.md'
+              # The two SOURCES `scripts/docs/generate-docs-sections.mjs`
+              # regenerates its sections from. They belong in `docs` rather
+              # than `frontend` on purpose: `docs` reaches the freshness check
+              # through the Docs-checks job -- one free ubuntu-latest runner,
+              # three node scripts, no build artifact and no Depot -- which is
+              # the CHEAPEST job that runs this gate. `frontend` would drag a
+              # landing-copy edit through build + typecheck + lint + the viewer
+              # shards for no added signal. Coverage holds either way: when a
+              # PR also touches frontend/rust, Docs checks skips itself and
+              # Node tests runs the same `--check`. PR #1817 changed only
+              # apps/landing/bench-data.json, and BOTH lanes skipped.
+              - 'apps/landing/**'
+              - 'tests/benchmark/baseline.json'
               - 'scripts/docs/**'
               - '.github/workflows/test.yml'
 
@@ -744,6 +778,19 @@ jobs:
       # its first run.
       - name: Check swallowed-push gate regressions
         run: node --test scripts/check-swallowed-push.test.mjs
+      # The class the swallowed-push gate above was itself an instance of: a
+      # gate is only as good as the job that runs it, and the job only runs
+      # when the path filter says so. This derives each gate's INPUTS from the
+      # gate's own source and fails when one of them cannot trigger the job
+      # that reads it -- an unreachable gate reports success, because a skipped
+      # job counts as success in the aggregate `test` gate below (#3312).
+      - name: Check CI path coverage
+        run: node scripts/check-ci-path-coverage.mjs
+      # Executable proof it cannot pass vacuously: reintroducing a real hole
+      # must name that hole, and an empty workflow dir / unparseable filter
+      # block / zero derived inputs must FAIL rather than report clean.
+      - name: Check CI path-coverage gate regressions
+        run: node --test scripts/check-ci-path-coverage.test.mjs
       # The CSV cell escaper reached NINE hand-rolled copies and no two were
       # identical: some tested the formula trigger anchored at offset 0 (so a
       # BOM/ZWSP/LRM/NBSP/U+2028 in front of `=` bypassed the CWE-1236 guard),

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,13 @@ jobs:
               - 'turbo.json'
               - 'tsconfig*.json'
               - 'scripts/**'
+              # `check-ci-path-coverage` reads .gitignore to decide which paths
+              # are committed source and which are build output it must not
+              # walk. That makes .gitignore an INPUT to the gate: an edit to it
+              # can turn a covered path into an uncovered one. Without this
+              # line a gitignore-only PR skips Node tests and the gate never
+              # sees the change that moved its own verdict.
+              - '.gitignore'
               - 'tests/models/manifest.json'
               - '.github/workflows/test.yml'
             geometry:

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:wasm-contract": "node scripts/test-wasm-contract.mjs",
     "test:snap-edges": "node scripts/test-snap-edges.mjs",
     "check:test-wiring": "node scripts/check-test-wiring.mjs",
+    "check:ci-path-coverage": "node scripts/check-ci-path-coverage.mjs",
     "check:test-glob-coverage": "node scripts/check-test-glob-coverage.mjs",
     "check:source-text-assertions": "node scripts/check-source-text-assertions.mjs",
     "check:rust-source-text-assertions": "node scripts/check-rust-source-text-assertions.mjs",

--- a/scripts/check-ci-path-coverage.mjs
+++ b/scripts/check-ci-path-coverage.mjs
@@ -197,10 +197,22 @@ for (const file of workflowFiles) {
     process.exit(1);
   }
 
-  const { triggersOnPr, paths: prPaths } = parseWorkflowPrPaths(text);
-  if (!triggersOnPr) continue; // release/cron-only workflows gate nothing on a PR
+  // Named, with the workflow that caused it. These parsers throw on a shape
+  // they cannot read rather than returning a wider answer, so the throw IS the
+  // check firing -- reporting it as an uncaught stack trace would leave the
+  // reader to work out which of 26 workflows it came from.
+  let triggersOnPr;
+  let prPaths;
+  let jobs;
+  try {
+    ({ triggersOnPr, paths: prPaths } = parseWorkflowPrPaths(text));
+    if (!triggersOnPr) continue; // release/cron-only workflows gate nothing on a PR
+    jobs = splitJobs(text);
+  } catch (err) {
+    console.error(`❌ check-ci-path-coverage: cannot read the triggers of ${rel} -- ${err.message}`);
+    process.exit(1);
+  }
 
-  const jobs = splitJobs(text);
   if (jobs.length === 0) {
     console.error(`❌ check-ci-path-coverage: ${rel} triggers on PRs but parsed to zero jobs.`);
     process.exit(1);

--- a/scripts/check-ci-path-coverage.mjs
+++ b/scripts/check-ci-path-coverage.mjs
@@ -15,7 +15,7 @@
  * written:
  *
  *   - `scripts/check-swallowed-push.mjs` declares its SCOPE to be
- *     `.github/workflows/**` and ran in a job that only 2 of the 13 workflow
+ *     `.github/workflows/**` and ran in a job that only 2 of the 15 workflow
  *     files could trigger. PR #3118 edited `release.yml` and `docker.yml`;
  *     Node tests SKIPPED.
  *   - `pnpm test:integration` runs `tests/integration.test.ts`, which was in no
@@ -37,6 +37,18 @@
  *       source (path literals and `join(ROOT, ...)` chains that resolve to
  *       something real).
  * Then it reports every file that a gate reads and no glob can trigger it on.
+ *
+ * WHAT THE CENSUS DOES NOT SEE, STATED PLAINLY. Step (a) matches only a literal
+ * `node scripts/*.mjs` in a step's `run:`, so a gate invoked through a package
+ * script is invisible to it: `pnpm lint` runs four gates
+ * (`check-changesets`, `check-test-glob-coverage`, `check-unused-locals`,
+ * `check-lint-ran`), and `check:vitest-timeout-audit` and `fixtures:check` each
+ * run one more. All six were walked by hand when this check was written and
+ * none is outside its own trigger today, so this is a KNOWN LIMIT of the
+ * census, not a hole it is hiding: those six are not covered by anything here,
+ * and a future path filter change could open a hole in one without this check
+ * noticing. Teaching it to resolve `pnpm <script>` through package.json is the
+ * fix, and is deliberately not part of this change.
  *
  * FAILS CLOSED. No workflows, no jobs, no gates, a filter block that parses to
  * nothing, an unreadable workflow, zero derived inputs, or an allowlist entry

--- a/scripts/check-ci-path-coverage.mjs
+++ b/scripts/check-ci-path-coverage.mjs
@@ -81,6 +81,7 @@ import {
   parseWorkflowPrPaths,
   deriveInputs,
   matchesAny,
+  gitignoreToGlobs,
 } from './lib/ci-path-coverage.mjs';
 
 const rootFlag = process.argv.indexOf('--root');
@@ -117,6 +118,22 @@ function fail(reason) {
 
 const abs = (p) => join(ROOT, p);
 const exists = (p) => existsSync(abs(p));
+
+/**
+ * Everything `.gitignore` excludes, as globs.
+ *
+ * The walk must see COMMITTED content and nothing else. Untracked output --
+ * `node_modules` after an install, a package's `dist` after a build, the
+ * fetched `.ifc` corpus under `tests/models` -- can never be what a `paths:`
+ * filter matches, but while the walk could see it the verdict moved with the
+ * state of the working tree: this check passed on a clean checkout and failed
+ * in CI on the identical commit. A check whose answer depends on what was
+ * built last is not evidence about the commit.
+ */
+const IGNORED = exists('.gitignore')
+  ? gitignoreToGlobs(readFileSync(abs('.gitignore'), 'utf8'))
+  : [];
+const isIgnored = (rel) => IGNORED.length > 0 && matchesAny(rel, IGNORED);
 
 // ---------------------------------------------------------------------------
 // 1. The filter block.
@@ -253,7 +270,11 @@ for (const [gate, info] of gates) {
     );
     process.exit(1);
   }
-  const derived = deriveInputs(readFileSync(abs(gate), 'utf8'), exists);
+  // An ignored path is not a source input: it cannot be committed, so it can
+  // never be what a `paths:` filter matches. Dropping it HERE as well as in
+  // the walk keeps the reported input COUNT a function of the commit too --
+  // otherwise a warmed fixture cache silently moves the number in the summary.
+  const derived = deriveInputs(readFileSync(abs(gate), 'utf8'), (q) => exists(q) && !isIgnored(q));
   // A gate's own source file is trivially an input; keep it, it is the
   // self-coverage case and it must hold for every gate, not just this one.
   const inputs = [...new Set([gate, ...derived])].sort();
@@ -307,6 +328,14 @@ function filesUnder(rel) {
 }
 
 function walkUncached(rel) {
+  // Asked about an ignored node directly: it is not committed, so it
+  // contributes no files. Belt and braces -- the derivation above already
+  // declines to hand an ignored path to the walk, so nothing observable
+  // depends on this line today. It is here because the old skip set filtered
+  // only a walk's CHILDREN and never the root it was asked about, which is the
+  // shape that let `node_modules` be enumerated once the derivation admitted
+  // it; a future change to the derivation must not be able to reopen it.
+  if (isIgnored(rel)) return [];
   const target = abs(rel);
   let st;
   try {
@@ -316,14 +345,14 @@ function walkUncached(rel) {
   }
   if (!st.isDirectory()) return [rel];
   const out = [];
-  const skip = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', 'target']);
   const walk = (dir) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       if (entry.name.startsWith('.') && dir === target && rel !== WORKFLOW_DIR) continue;
-      if (skip.has(entry.name)) continue;
       const full = join(dir, entry.name);
+      const child = relative(ROOT, full).split(sep).join('/');
+      if (isIgnored(child)) continue;
       if (entry.isDirectory()) walk(full);
-      else out.push(relative(ROOT, full).split(sep).join('/'));
+      else out.push(child);
     }
   };
   walk(target);

--- a/scripts/check-ci-path-coverage.mjs
+++ b/scripts/check-ci-path-coverage.mjs
@@ -1,0 +1,470 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ratchet: a CI gate may not read a path that cannot trigger it.
+ *
+ * THE DEFECT CLASS. A gate script is only as good as the job that runs it, and
+ * that job only runs when the path filter says so. When a gate's INPUT is
+ * outside its own TRIGGER the gate is not weak, it is unreachable: the PR that
+ * introduces the very mistake it guards against is the PR on which it does not
+ * run, and the aggregate `test` gate reports success because a skipped job
+ * counts as success. Four real instances, all reproduced before this check was
+ * written:
+ *
+ *   - `scripts/check-swallowed-push.mjs` declares its SCOPE to be
+ *     `.github/workflows/**` and ran in a job that only 2 of the 13 workflow
+ *     files could trigger. PR #3118 edited `release.yml` and `docker.yml`;
+ *     Node tests SKIPPED.
+ *   - `pnpm test:integration` runs `tests/integration.test.ts`, which was in no
+ *     filter -- the test could not trigger its own execution.
+ *   - `scripts/docs/generate-docs-sections.mjs --check` regenerates from
+ *     `tests/benchmark/baseline.json` and `apps/landing/app.jsx`, neither of
+ *     which was in any filter. PR #1817 changed only
+ *     `apps/landing/bench-data.json`; Node tests AND Docs checks both skipped
+ *     and the required check went green.
+ *   - `apps/landing/**` appeared in no filter at all while four gates walk
+ *     `apps/`.
+ *
+ * WHAT THIS DOES. For every workflow under `.github/workflows`, it derives
+ *   (a) which `node scripts/...` gates each job runs,
+ *   (b) the globs that can trigger that job -- the workflow's own
+ *       `on.pull_request.paths`, or, for `test.yml`, the union of the
+ *       `changes` filters its `if:` names, and
+ *   (c) the repo paths each gate script READS, read out of the gate's own
+ *       source (path literals and `join(ROOT, ...)` chains that resolve to
+ *       something real).
+ * Then it reports every file that a gate reads and no glob can trigger it on.
+ *
+ * FAILS CLOSED. No workflows, no jobs, no gates, a filter block that parses to
+ * nothing, an unreadable workflow, zero derived inputs, or an allowlist entry
+ * that no longer matches anything -- each is a NAMED failure, never a pass.
+ * "Found nothing" and "nothing to find" are different answers and this refuses
+ * to conflate them.
+ *
+ * REQUIRED BY NAME. `REQUIRED_COVERAGE` below pins the four specific facts
+ * above. A count floor would survive dropping the one entry that matters; a
+ * named assertion does not.
+ *
+ * ITS OWN CONFIG IS INSIDE ITS OWN TRIGGER -- the defect it detects. This file
+ * and `scripts/ci-path-coverage-allowlist.txt` both live under `scripts/`,
+ * which the `frontend` filter carries, and `assertSelfCoverage` proves it
+ * rather than asserting it in prose.
+ *
+ * Run via `node scripts/check-ci-path-coverage.mjs` (CI Node tests job).
+ * `--root <dir>` points it at a mutated copy of the tree; that is how
+ * `check-ci-path-coverage.test.mjs` proves it fires.
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join, dirname, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  parseFilterBlock,
+  splitJobs,
+  gatingFilters,
+  parseWorkflowPrPaths,
+  deriveInputs,
+  matchesAny,
+} from './lib/ci-path-coverage.mjs';
+
+const rootFlag = process.argv.indexOf('--root');
+const ROOT =
+  rootFlag !== -1 && process.argv[rootFlag + 1]
+    ? process.argv[rootFlag + 1]
+    : join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const WORKFLOW_DIR = '.github/workflows';
+const FILTER_WORKFLOW = '.github/workflows/test.yml';
+const ALLOWLIST = 'scripts/ci-path-coverage-allowlist.txt';
+const SELF = 'scripts/check-ci-path-coverage.mjs';
+
+/**
+ * The facts this check exists to hold, asserted by NAME.
+ *
+ * Each entry is `[gate script, an input file of that gate]`. The check proves
+ * the gate is reachable from that exact file. Dropping any of these from the
+ * filters is the regression; a count of covered inputs would not notice.
+ */
+const REQUIRED_COVERAGE = [
+  ['scripts/check-swallowed-push.mjs', '.github/workflows/release.yml'],
+  ['scripts/check-swallowed-push.mjs', '.github/workflows/docker.yml'],
+  ['scripts/check-test-wiring.mjs', 'tests/integration.test.ts'],
+  ['scripts/docs/generate-docs-sections.mjs', 'tests/benchmark/baseline.json'],
+  ['scripts/docs/generate-docs-sections.mjs', 'apps/landing/app.jsx'],
+  ['scripts/docs/generate-docs-sections.mjs', 'apps/landing/bench-data.json'],
+];
+
+const failures = [];
+function fail(reason) {
+  failures.push(reason);
+}
+
+const abs = (p) => join(ROOT, p);
+const exists = (p) => existsSync(abs(p));
+
+// ---------------------------------------------------------------------------
+// 1. The filter block.
+// ---------------------------------------------------------------------------
+
+if (!exists(FILTER_WORKFLOW)) {
+  console.error(`❌ check-ci-path-coverage: ${FILTER_WORKFLOW} is missing.`);
+  process.exit(1);
+}
+
+let filters;
+try {
+  filters = parseFilterBlock(readFileSync(abs(FILTER_WORKFLOW), 'utf8'));
+} catch (err) {
+  console.error(`❌ check-ci-path-coverage: cannot parse the path filters -- ${err.message}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Workflows -> jobs -> gates, with the globs that can trigger each.
+//    `null` glob set means "no path filter", i.e. every path triggers it.
+// ---------------------------------------------------------------------------
+
+let workflowFiles;
+try {
+  workflowFiles = readdirSync(abs(WORKFLOW_DIR))
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort();
+} catch (err) {
+  console.error(`❌ check-ci-path-coverage: cannot read ${WORKFLOW_DIR} -- ${err.message}`);
+  process.exit(1);
+}
+if (workflowFiles.length === 0) {
+  console.error(`❌ check-ci-path-coverage: no workflow files under ${WORKFLOW_DIR}.`);
+  process.exit(1);
+}
+
+/** gate script -> { globs: string[] | null, sites: string[] } */
+const gates = new Map();
+let jobCount = 0;
+
+function recordGate(gate, globs, site) {
+  const prev = gates.get(gate);
+  if (!prev) {
+    gates.set(gate, { globs, sites: [site] });
+    return;
+  }
+  prev.sites.push(site);
+  // A gate reachable from ANY job with no path filter is fully reachable.
+  if (prev.globs === null || globs === null) prev.globs = null;
+  else prev.globs = [...new Set([...prev.globs, ...globs])];
+}
+
+for (const file of workflowFiles) {
+  const rel = `${WORKFLOW_DIR}/${file}`;
+  let text;
+  try {
+    text = readFileSync(abs(rel), 'utf8');
+  } catch (err) {
+    console.error(`❌ check-ci-path-coverage: cannot read ${rel} -- ${err.message}`);
+    process.exit(1);
+  }
+
+  const { triggersOnPr, paths: prPaths } = parseWorkflowPrPaths(text);
+  if (!triggersOnPr) continue; // release/cron-only workflows gate nothing on a PR
+
+  const jobs = splitJobs(text);
+  if (jobs.length === 0) {
+    console.error(`❌ check-ci-path-coverage: ${rel} triggers on PRs but parsed to zero jobs.`);
+    process.exit(1);
+  }
+  jobCount += jobs.length;
+
+  for (const job of jobs) {
+    const named = gatingFilters(job.text);
+    let globs;
+    if (rel === FILTER_WORKFLOW) {
+      if (named === null) {
+        globs = prPaths; // may itself be null = everything
+      } else {
+        const unknown = named.filter((n) => !filters.has(n));
+        if (unknown.length > 0) {
+          console.error(
+            `❌ check-ci-path-coverage: job ${job.id} gates on unknown filter(s) ` +
+              `${unknown.join(', ')} -- the filter block and the job wiring disagree.`,
+          );
+          process.exit(1);
+        }
+        globs = named.flatMap((n) => filters.get(n));
+        if (prPaths !== null) {
+          console.error(
+            `❌ check-ci-path-coverage: ${rel} has BOTH on.pull_request.paths and ` +
+              `a changes-filter job gate; this check cannot intersect them safely.`,
+          );
+          process.exit(1);
+        }
+      }
+    } else {
+      globs = prPaths;
+    }
+
+    for (const m of job.text.matchAll(/\bnode\s+(?:--test\s+)?((?:scripts\/[\w./-]+\.mjs\s*)+)/g)) {
+      for (const script of m[1].trim().split(/\s+/)) {
+        recordGate(script, globs, `${rel}:${job.id}`);
+      }
+    }
+  }
+}
+
+if (jobCount === 0) {
+  console.error('❌ check-ci-path-coverage: no PR-triggered jobs found in any workflow.');
+  process.exit(1);
+}
+if (gates.size === 0) {
+  console.error(
+    '❌ check-ci-path-coverage: no `node scripts/*.mjs` gates found in any workflow. ' +
+      'Either the workflows stopped running gate scripts, or the step-parsing regex no longer matches them.',
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Derive each gate's inputs from its own source.
+// ---------------------------------------------------------------------------
+
+/** gate -> input paths */
+const gateInputs = new Map();
+let totalInputs = 0;
+
+for (const [gate, info] of gates) {
+  if (!exists(gate)) {
+    console.error(
+      `❌ check-ci-path-coverage: a workflow runs ${gate}, which does not exist in the tree.`,
+    );
+    process.exit(1);
+  }
+  const derived = deriveInputs(readFileSync(abs(gate), 'utf8'), exists);
+  // A gate's own source file is trivially an input; keep it, it is the
+  // self-coverage case and it must hold for every gate, not just this one.
+  const inputs = [...new Set([gate, ...derived])].sort();
+  gateInputs.set(gate, { inputs, globs: info.globs, sites: info.sites });
+  totalInputs += inputs.length;
+}
+
+if (totalInputs === 0) {
+  console.error(
+    '❌ check-ci-path-coverage: derived zero input paths from every gate script. ' +
+      'The literal-extraction in scripts/lib/ci-path-coverage.mjs has stopped working.',
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Allowlist.
+// ---------------------------------------------------------------------------
+
+if (!exists(ALLOWLIST)) {
+  console.error(`❌ check-ci-path-coverage: ${ALLOWLIST} is missing.`);
+  process.exit(1);
+}
+const allow = [];
+for (const [n, raw] of readFileSync(abs(ALLOWLIST), 'utf8').split('\n').entries()) {
+  const line = raw.trim();
+  if (line === '' || line.startsWith('#')) continue;
+  const m = line.match(/^(\S+)\s+(\S+)\s+#\s*(.+)$/);
+  if (!m) {
+    console.error(
+      `❌ check-ci-path-coverage: ${ALLOWLIST}:${n + 1} is not ` +
+        '`<gate> <path-glob> # <reason>`. Every exemption needs a written reason.',
+    );
+    process.exit(1);
+  }
+  allow.push({ gate: m[1], glob: m[2], reason: m[3], used: false, line: n + 1 });
+}
+
+// ---------------------------------------------------------------------------
+// 5. The mechanical diff.
+// ---------------------------------------------------------------------------
+
+/** Files under a repo-relative path. Only walked when no glob covers the subtree. */
+const walkCache = new Map();
+function filesUnder(rel) {
+  const hit = walkCache.get(rel);
+  if (hit) return hit;
+  const out = walkUncached(rel);
+  walkCache.set(rel, out);
+  return out;
+}
+
+function walkUncached(rel) {
+  const target = abs(rel);
+  let st;
+  try {
+    st = statSync(target);
+  } catch {
+    return [];
+  }
+  if (!st.isDirectory()) return [rel];
+  const out = [];
+  const skip = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', 'target']);
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith('.') && dir === target && rel !== WORKFLOW_DIR) continue;
+      if (skip.has(entry.name)) continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else out.push(relative(ROOT, full).split(sep).join('/'));
+    }
+  };
+  walk(target);
+  return out;
+}
+
+/**
+ * The SHALLOWEST uncovered nodes under `rel` -- a whole directory when nothing
+ * inside it is reachable, individual files when only some of it is.
+ *
+ * Granularity is the difference between a usable report and an unusable one:
+ * `apps` un-reduced yields 27 file lines that all say the same thing, and the
+ * one line worth reading (`apps/landing`) is buried among the favicons. It is
+ * also the granularity an exemption should be written at.
+ */
+function uncoveredNodes(rel, globs) {
+  if (matchesAny(rel, globs)) return [];
+  const files = filesUnder(rel);
+  if (files.length === 0) return [];
+  if (files.length === 1 && files[0] === rel) return [rel];
+  if (files.every((f) => !matchesAny(f, globs))) return [rel];
+
+  const byChild = new Map();
+  for (const f of files) {
+    if (matchesAny(f, globs)) continue;
+    const slash = f.indexOf('/', rel.length + 1);
+    // No further separator: `f` is a FILE directly in `rel`, so it is its own
+    // node. Slicing at -1 here silently truncated the last character and
+    // reported paths that do not exist.
+    const key = slash === -1 ? f : f.slice(0, slash);
+    if (!byChild.has(key)) byChild.set(key, []);
+    byChild.get(key).push(f);
+  }
+  const out = [];
+  for (const [child, uncovered] of byChild) {
+    if (child === rel) continue;
+    const all = filesUnder(child);
+    if (all.length === uncovered.length) out.push(child);
+    else out.push(...uncoveredNodes(child, globs));
+  }
+  return out;
+}
+
+const violations = [];
+
+for (const [gate, info] of gateInputs) {
+  if (info.globs === null) continue; // job has no path filter: everything reaches it
+  for (const input of info.inputs) {
+    for (const node of uncoveredNodes(input, info.globs)) {
+      const hit = allow.find((a) => a.gate === gate && matchesAny(node, [a.glob]));
+      if (hit) {
+        hit.used = true;
+        continue;
+      }
+      if (!violations.some((v) => v.gate === gate && v.file === node)) {
+        violations.push({ gate, file: node, sites: [...new Set(info.sites)] });
+      }
+    }
+  }
+}
+
+const unused = allow.filter((a) => !a.used);
+if (unused.length > 0) {
+  for (const a of unused) {
+    fail(
+      `${ALLOWLIST}:${a.line} exempts ${a.gate} / ${a.glob}, which is now covered (or gone). ` +
+        'Delete the line -- a stale exemption hides the next hole.',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Required-by-name, and self-coverage.
+// ---------------------------------------------------------------------------
+
+for (const [gate, file] of REQUIRED_COVERAGE) {
+  const info = gateInputs.get(gate);
+  if (!info) {
+    // Only a claim about THIS repo. A tree that does not run the gate at all
+    // (the synthetic fixtures in check-ci-path-coverage.test.mjs) is not a
+    // regression; a tree that HAS the gate and stopped running it is.
+    if (exists(gate)) fail(`REQUIRED_COVERAGE names ${gate}, which no workflow runs any more.`);
+    continue;
+  }
+  if (!exists(file)) {
+    fail(`REQUIRED_COVERAGE names ${file}, which is not in the tree.`);
+    continue;
+  }
+  if (info.globs === null) continue;
+  if (!matchesAny(file, info.globs)) {
+    fail(
+      `${file} cannot trigger ${gate}. The gate runs in ${info.sites.join(', ')}, ` +
+        'and no glob in that job’s filters matches this file.',
+    );
+  }
+}
+
+function assertSelfCoverage() {
+  const info = gateInputs.get(SELF);
+  if (!info) {
+    fail(`${SELF} is not run by any workflow job -- this check cannot check itself.`);
+    return;
+  }
+  if (info.globs === null) return;
+  for (const own of [SELF, ALLOWLIST, 'scripts/lib/ci-path-coverage.mjs']) {
+    if (!matchesAny(own, info.globs)) {
+      fail(
+        `${own} is this check’s own config and cannot trigger it -- the exact defect ` +
+          'this check detects. Add it to a filter that reaches ' +
+          `${info.sites.join(', ')}.`,
+      );
+    }
+  }
+}
+assertSelfCoverage();
+
+// ---------------------------------------------------------------------------
+// 7. Report.
+// ---------------------------------------------------------------------------
+
+if (violations.length > 0) {
+  const byGate = new Map();
+  for (const v of violations) {
+    if (!byGate.has(v.gate)) byGate.set(v.gate, { sites: v.sites, files: [] });
+    byGate.get(v.gate).files.push(v.file);
+  }
+  for (const [gate, { sites, files }] of byGate) {
+    const shown = files.slice(0, 8);
+    fail(
+      `${gate} (runs in ${sites.join(', ')}) reads ${files.length} file(s) that cannot trigger it:\n` +
+        shown.map((f) => `      - ${f}`).join('\n') +
+        (files.length > shown.length ? `\n      ... and ${files.length - shown.length} more` : ''),
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    `\n❌ check-ci-path-coverage: ${failures.length} gate input(s) outside their own trigger.\n`,
+  );
+  for (const f of failures) console.error(`  • ${f}`);
+  console.error(
+    '\nA gate that cannot run on the files it guards is not a weak gate, it is an absent one:\n' +
+      'the PR introducing the mistake is exactly the PR the job skips, and a skipped job\n' +
+      "counts as success in the aggregate `test` gate. Fix by adding the path to the CHEAPEST\n" +
+      `filter in ${FILTER_WORKFLOW} that reaches the job, or record a reasoned exemption in\n` +
+      `${ALLOWLIST}.\n`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✅ check-ci-path-coverage: ${gates.size} gate(s) across ${jobCount} PR-triggered job(s); ` +
+    `${totalInputs} derived input path(s), all inside their own trigger ` +
+    `(${allow.length} reasoned exemption(s)).`,
+);

--- a/scripts/check-ci-path-coverage.test.mjs
+++ b/scripts/check-ci-path-coverage.test.mjs
@@ -43,6 +43,7 @@ import {
   parseWorkflowPrPaths,
   deriveInputs,
   dropSubsumed,
+  gitignoreToGlobs,
 } from './lib/ci-path-coverage.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -391,8 +392,13 @@ function mirrorRepo() {
   const root = mkdtempSync(join(tmpdir(), 'ci-path-coverage-mirror-'));
   for (const entry of readdirSync(REPO)) {
     if (entry === '.git' || entry === 'node_modules') continue;
-    if (entry === '.github') cpSync(join(REPO, entry), join(root, entry), { recursive: true });
-    else symlinkSync(join(REPO, entry), join(root, entry));
+    // `.github` is copied because the hole tests mutate test.yml. `tests` is
+    // copied because the fixture-cache test plants a fetched `.ifc` under
+    // `tests/models`, and writing through a symlink would land it in the real
+    // tree. Both are small; everything else stays a symlink.
+    if (entry === '.github' || entry === 'tests') {
+      cpSync(join(REPO, entry), join(root, entry), { recursive: true });
+    } else symlinkSync(join(REPO, entry), join(root, entry));
   }
   return root;
 }
@@ -436,3 +442,101 @@ for (const [glob, expected] of [
     }
   });
 }
+
+
+// ---------------------------------------------------------------------------
+// The verdict is a function of the COMMIT, not of the working tree.
+// ---------------------------------------------------------------------------
+
+test('gitignoreToGlobs: a bare name is ignored at every depth, and so is its subtree', () => {
+  const g = gitignoreToGlobs('node_modules\n');
+  for (const p of ['node_modules', 'node_modules/x/a.js', 'packages/cli/node_modules/y.js']) {
+    assert.ok(matchesAny(p, g), `${p} must be ignored`);
+  }
+  assert.equal(matchesAny('packages/cli/src/node_modules_helper.ts', g), false);
+});
+
+test('gitignoreToGlobs: a slash anywhere but the end anchors the pattern to the root', () => {
+  const g = gitignoreToGlobs('tests/models/local\n');
+  assert.ok(matchesAny('tests/models/local', g));
+  assert.ok(matchesAny('tests/models/local/a.ifc', g));
+  // Anchored: the same name deeper in the tree is NOT covered.
+  assert.equal(matchesAny('packages/tests/models/local', g), false);
+});
+
+test('gitignoreToGlobs: `a/**/b` covers ZERO intervening directories, as git does', () => {
+  // The case that let the fetched corpus stay visible: `tests/models/AB22.ifc`
+  // sits directly under the directory, with no directory between the `**` and
+  // the file, and a `**` rendered as `.*` needs the separators on both sides.
+  const g = gitignoreToGlobs('tests/models/**/*.ifc\n');
+  assert.ok(matchesAny('tests/models/AB22.ifc', g), 'zero-directory case');
+  assert.ok(matchesAny('tests/models/ara3d/duplex.ifc', g), 'one-directory case');
+  assert.equal(matchesAny('tests/models/manifest.json', g), false);
+});
+
+test('gitignoreToGlobs: a trailing slash still names the directory itself', () => {
+  const g = gitignoreToGlobs('dist/\n');
+  assert.ok(matchesAny('packages/cli/dist', g));
+  assert.ok(matchesAny('packages/cli/dist/loader.js', g));
+});
+
+test('gitignoreToGlobs: a negation is REFUSED rather than silently dropped', () => {
+  // A dropped `!` line means the walk wanders back into a tree the union said
+  // was excluded -- the failure this whole exclusion exists to prevent.
+  assert.throws(() => gitignoreToGlobs('dist/\n!dist/keep.js\n'), /negation/);
+});
+
+test('the real ignore file is translatable -- the exclusion cannot go silently empty', () => {
+  const globs = gitignoreToGlobs(readFileSync(join(REPO, '.gitignore'), 'utf8'));
+  assert.ok(globs.length > 0);
+  // Spot-check the three trees whose presence in CI, and absence on a clean
+  // checkout, made this check disagree with itself on one commit.
+  assert.ok(matchesAny('node_modules', globs));
+  assert.ok(matchesAny('packages/cli/dist/loader.js', globs));
+  assert.ok(matchesAny('tests/models/ara3d/duplex.ifc', globs));
+  // And the committed inputs under the same roots must SURVIVE it.
+  assert.equal(matchesAny('tests/models/manifest.json', globs), false);
+  assert.equal(matchesAny('packages/data/src/step-serializers.ts', globs), false);
+});
+
+test('an installed node_modules does not change the verdict -- the live #3314 CI failure', () => {
+  // Ran green on a clean checkout and red in CI on the IDENTICAL commit: the
+  // walk's skip set filtered a walk's CHILDREN but never the ROOT it was asked
+  // about, so `node_modules` as a derived input enumerated the whole install
+  // and reported it, once per gate, as a path outside its own trigger.
+  const root = mirrorRepo();
+  const before = run(root);
+  assert.equal(before.status, 0, before.out);
+
+  mkdirSync(join(root, 'node_modules/some-package'), { recursive: true });
+  writeFileSync(join(root, 'node_modules/some-package/index.js'), 'export default 1;\n');
+  const after = run(root);
+
+  assert.equal(after.status, before.status, after.out);
+  assert.equal(
+    after.out,
+    before.out,
+    'the report must be byte-identical: an install is not a change to the commit',
+  );
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('a warmed fixture cache does not change the verdict either', () => {
+  // `tests/models` holds two COMMITTED files and, after the fixture step runs,
+  // several hundred fetched `.ifc` files that git ignores. The walk is asked
+  // about the directory (which is a real input -- `manifest.json` lives there),
+  // so the exclusion has to hold on the walk's CHILDREN, not only on the node
+  // it was asked about.
+  const root = mirrorRepo();
+  const before = run(root);
+  assert.equal(before.status, 0, before.out);
+
+  mkdirSync(join(root, 'tests/models/ara3d'), { recursive: true });
+  writeFileSync(join(root, 'tests/models/ara3d/duplex.ifc'), 'ISO-10303-21;\n');
+  writeFileSync(join(root, 'tests/models/AB22.ifc'), 'ISO-10303-21;\n');
+  const after = run(root);
+
+  assert.equal(after.status, before.status, after.out);
+  assert.equal(after.out, before.out, 'a fetched corpus is not a change to the commit');
+  rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/check-ci-path-coverage.test.mjs
+++ b/scripts/check-ci-path-coverage.test.mjs
@@ -540,3 +540,63 @@ test('a warmed fixture cache does not change the verdict either', () => {
   assert.equal(after.out, before.out, 'a fetched corpus is not a change to the commit');
   rmSync(root, { recursive: true, force: true });
 });
+
+
+// ---------------------------------------------------------------------------
+// The trigger parser fails closed on shapes it cannot read.
+// ---------------------------------------------------------------------------
+
+const PR_BLOCK = "on:\n  pull_request:\n    paths:\n      - 'rust/**'\n";
+
+test('parseWorkflowPrPaths still reads the block form it was written for', () => {
+  // The refusals below must not have been bought by refusing everything.
+  assert.deepEqual(parseWorkflowPrPaths(PR_BLOCK), { triggersOnPr: true, paths: ['rust/**'] });
+  assert.deepEqual(parseWorkflowPrPaths("on:\n  pull_request:\n    paths-ignore:\n      - 'docs/**'\n"), {
+    triggersOnPr: true,
+    paths: null,
+  });
+  // No `paths:` at all is genuinely "every path", and must stay null.
+  assert.deepEqual(parseWorkflowPrPaths('on:\n  pull_request:\n'), {
+    triggersOnPr: true,
+    paths: null,
+  });
+});
+
+test('an INLINE paths list is refused, not read as "triggers on everything"', () => {
+  // The dangerous direction: the block matcher required an empty tail after
+  // the colon, so `paths: ['rust/**']` fell through and left paths at null --
+  // the widest coverage claim there is, asserted about a workflow that is in
+  // fact narrowly filtered. Every gate input under it would look reachable.
+  assert.throws(
+    () => parseWorkflowPrPaths("on:\n  pull_request:\n    paths: ['rust/**']\n"),
+    /written inline/,
+  );
+  assert.throws(
+    () => parseWorkflowPrPaths("on:\n  pull_request:\n    paths-ignore: ['docs/**']\n"),
+    /written inline/,
+  );
+});
+
+test('an unquoted list entry is refused, not silently dropped', () => {
+  // Errs the safe way -- a short trigger list over-reports violations -- but a
+  // finding derived from a truncated list is indistinguishable from a real one.
+  assert.throws(
+    () => parseWorkflowPrPaths('on:\n  pull_request:\n    paths:\n      - rust/**\n'),
+    /unparseable entry/,
+  );
+});
+
+test('the checker NAMES the workflow it could not parse, rather than throwing a stack', () => {
+  const root = mirrorRepo();
+  writeFileSync(
+    join(root, '.github/workflows/zz-inline-paths.yml'),
+    "name: Inline\non:\n  pull_request:\n    paths: ['rust/**']\njobs:\n  a:\n    name: A\n" +
+      '    runs-on: ubuntu-latest\n    steps:\n      - run: node scripts/check-module-size.mjs\n',
+  );
+  const r = run(root);
+  assert.equal(r.status, 1, r.out);
+  assert.match(r.out, /zz-inline-paths\.yml/, 'the report must name the workflow');
+  assert.match(r.out, /written inline/);
+  assert.doesNotMatch(r.out, /at parseWorkflowPrPaths/, 'not an uncaught stack trace');
+  rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/check-ci-path-coverage.test.mjs
+++ b/scripts/check-ci-path-coverage.test.mjs
@@ -1,0 +1,438 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Executable proof that `scripts/check-ci-path-coverage.mjs` cannot pass
+ * vacuously.
+ *
+ * "No gate input is outside its trigger" is equally true of a repo with no
+ * holes and of a check that found no gates, parsed no filters, or derived no
+ * inputs. Every one of those must be a NAMED failure, and each is exercised
+ * here against a synthetic tree so the assertions do not move when the real
+ * workflows do.
+ *
+ * The firing half is checked by REINTRODUCING a hole -- the synthetic twin of
+ * the four real ones (#3312) -- and asserting the report names the specific
+ * file, not just that the exit code moved.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+  readdirSync,
+  cpSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  globToRegExp,
+  matchesAny,
+  parseFilterBlock,
+  splitJobs,
+  gatingFilters,
+  parseWorkflowPrPaths,
+  deriveInputs,
+  dropSubsumed,
+} from './lib/ci-path-coverage.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHECK = join(HERE, 'check-ci-path-coverage.mjs');
+const REPO = join(HERE, '..');
+
+/** Run the check against `root`; returns `{ status, out }` with stdout+stderr merged. */
+function run(root) {
+  try {
+    const out = execFileSync(process.execPath, [CHECK, '--root', root], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, out };
+  } catch (err) {
+    return { status: err.status ?? 1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+const WORKFLOW = (filters, steps) => `name: Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+${filters}
+
+  gated:
+    name: Gated
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+${steps}
+`;
+
+const DEFAULT_FILTERS = [
+  '            frontend:',
+  "              - 'src/**'",
+  "              - 'scripts/**'",
+  // The check genuinely reads the workflow directory, so a fixture that does
+  // not carry it is not a clean tree.
+  "              - '.github/workflows/**'",
+].join('\n');
+
+const DEFAULT_STEPS = [
+  '      - run: node scripts/gate.mjs',
+  '      - run: node scripts/check-ci-path-coverage.mjs',
+].join('\n');
+
+/**
+ * A minimal repo where the check is GREEN, so every later case can change one
+ * thing and attribute the failure to it.
+ */
+function makeTree(overrides = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'ci-path-coverage-'));
+  mkdirSync(join(root, '.github/workflows'), { recursive: true });
+  mkdirSync(join(root, 'scripts/lib'), { recursive: true });
+  mkdirSync(join(root, 'src/covered'), { recursive: true });
+
+  writeFileSync(
+    join(root, '.github/workflows/test.yml'),
+    overrides.workflow ?? WORKFLOW(overrides.filters ?? DEFAULT_FILTERS, overrides.steps ?? DEFAULT_STEPS),
+  );
+  writeFileSync(join(root, 'src/covered/thing.ts'), 'export const x = 1;\n');
+  if (overrides.gate !== null) {
+    writeFileSync(join(root, 'scripts/gate.mjs'), overrides.gate ?? "const dir = 'src/covered';\n");
+  }
+  // The check reads its own source and its own lib out of the tree it is
+  // pointed at, so the fixture must carry both for self-coverage to resolve.
+  writeFileSync(join(root, 'scripts/check-ci-path-coverage.mjs'), readFileSync(CHECK, 'utf8'));
+  writeFileSync(
+    join(root, 'scripts/lib/ci-path-coverage.mjs'),
+    readFileSync(join(HERE, 'lib/ci-path-coverage.mjs'), 'utf8'),
+  );
+  writeFileSync(
+    join(root, 'scripts/ci-path-coverage-allowlist.txt'),
+    overrides.allowlist ?? '# none\n',
+  );
+  return root;
+}
+
+function withTree(overrides, fn) {
+  const root = makeTree(overrides);
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Baseline: the synthetic tree is clean, so every failure below is attributable.
+// ---------------------------------------------------------------------------
+
+test('a tree with no holes passes', () => {
+  withTree({}, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 0, out);
+    assert.match(out, /all inside their own trigger/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// It FIRES: the synthetic twin of the four real holes.
+// ---------------------------------------------------------------------------
+
+test('names the specific file when a gate input is outside its trigger', () => {
+  withTree(
+    { gate: "const scan = 'src';\n" }, // walks all of src/, filter only carries src/**... so add an uncovered sibling
+    (root) => {
+      mkdirSync(join(root, 'unfiltered'), { recursive: true });
+      writeFileSync(join(root, 'unfiltered/input.json'), '{}\n');
+      writeFileSync(join(root, 'scripts/gate.mjs'), "const input = 'unfiltered/input.json';\n");
+      const { status, out } = run(root);
+      assert.equal(status, 1);
+      assert.match(out, /unfiltered\/input\.json/);
+      assert.match(out, /cannot trigger it/);
+    },
+  );
+});
+
+test('reports the shallowest uncovered subtree, not every file under it', () => {
+  withTree({ gate: "const scan = 'src';\n" }, (root) => {
+    mkdirSync(join(root, 'src2/deep'), { recursive: true });
+    for (const n of ['a', 'b', 'c']) writeFileSync(join(root, `src2/deep/${n}.ts`), '\n');
+    writeFileSync(join(root, 'scripts/gate.mjs'), "const scan = 'src2';\n");
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /- src2\b/);
+    assert.doesNotMatch(out, /src2\/deep\/a\.ts/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// It FAILS CLOSED. Each of these would otherwise report "no holes found".
+// ---------------------------------------------------------------------------
+
+test('an empty workflow directory fails rather than reporting clean', () => {
+  withTree({}, (root) => {
+    rmSync(join(root, '.github/workflows/test.yml'));
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /test\.yml is missing/);
+  });
+});
+
+test('an unparseable filter block fails with a named reason', () => {
+  withTree({ workflow: 'name: Test\non:\n  pull_request:\n\njobs:\n  a:\n    runs-on: x\n' }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /cannot parse the path filters/);
+  });
+});
+
+test('a filter block that parses to zero filters fails', () => {
+  withTree({ filters: '            # nothing here' }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /zero filters|cannot parse the path filters/);
+  });
+});
+
+test('a workflow that runs no gate scripts fails rather than passing', () => {
+  withTree({ steps: '      - run: echo hello' }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /no `node scripts\/\*\.mjs` gates found/);
+  });
+});
+
+test('a workflow referencing a gate script that does not exist fails', () => {
+  withTree({ gate: null }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /which does not exist in the tree/);
+  });
+});
+
+test('a job gating on a filter the block does not define fails', () => {
+  withTree({ filters: "            backend:\n              - 'src/**'" }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /unknown filter/);
+  });
+});
+
+test('a missing allowlist fails', () => {
+  withTree({}, (root) => {
+    rmSync(join(root, 'scripts/ci-path-coverage-allowlist.txt'));
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /allowlist\.txt is missing/);
+  });
+});
+
+test('an allowlist entry with no written reason is refused', () => {
+  withTree({ allowlist: 'scripts/gate.mjs src/covered\n' }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /Every exemption needs a written reason/);
+  });
+});
+
+test('an allowlist entry that no longer matches anything fails', () => {
+  withTree({ allowlist: 'scripts/gate.mjs gone/** # stale\n' }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /which is now covered \(or gone\)/);
+  });
+});
+
+test("the check's own config being outside its own trigger is itself a failure", () => {
+  // The very defect the check detects, aimed at the check: drop `scripts/**`
+  // from the filter, and the check must name its own files.
+  withTree({ filters: "            frontend:\n              - 'src/**'" }, (root) => {
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /scripts\/ci-path-coverage-allowlist\.txt is this check.s own config/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit level: the parsing and glob semantics the whole thing rests on.
+// ---------------------------------------------------------------------------
+
+test('globToRegExp follows picomatch separator rules', () => {
+  assert.ok(globToRegExp('rust/**').test('rust/core/src/lib.rs'));
+  assert.ok(globToRegExp('rust/**').test('rust'), '`a/**` must cover the bare directory');
+  assert.ok(globToRegExp('packages/*/README.md').test('packages/parser/README.md'));
+  assert.ok(
+    !globToRegExp('packages/*/README.md').test('packages/parser/src/README.md'),
+    '`*` must not cross a separator',
+  );
+  assert.ok(globToRegExp('tsconfig*.json').test('tsconfig.build.json'));
+  assert.ok(!globToRegExp('tsconfig*.json').test('apps/tsconfig.json'));
+  assert.ok(!globToRegExp('.github/workflows/test.yml').test('.github/workflows/testXyml'));
+});
+
+test('globToRegExp refuses syntax it cannot translate rather than matching loosely', () => {
+  assert.throws(() => globToRegExp('src/{a,b}/**'), /unsupported glob syntax/);
+  assert.throws(() => globToRegExp(''), /empty glob/);
+});
+
+test('parseFilterBlock rejects a line it does not understand', () => {
+  assert.throws(
+    () => parseFilterBlock('        filters: |\n          rust:\n            - unquoted/glob\n'),
+    /unrecognised line/,
+  );
+  assert.throws(() => parseFilterBlock('nothing here'), /no `filters: \|` block/);
+  assert.throws(
+    () => parseFilterBlock('        filters: |\n          rust:\n          frontend:\n'),
+    /has no globs/,
+  );
+});
+
+test('splitJobs drops comment lines so a mention is not read as an invocation', () => {
+  const jobs = splitJobs(
+    'jobs:\n  a:\n    runs-on: x\n    steps:\n      # node scripts/mentioned.mjs\n      - run: node scripts/real.mjs\n',
+  );
+  assert.equal(jobs.length, 1);
+  assert.ok(jobs[0].text.includes('scripts/real.mjs'));
+  assert.ok(!jobs[0].text.includes('scripts/mentioned.mjs'));
+});
+
+test('gatingFilters reads positive terms only', () => {
+  assert.deepEqual(gatingFilters("    if: needs.changes.outputs.frontend == 'true'"), ['frontend']);
+  assert.deepEqual(
+    gatingFilters(
+      "    if: needs.changes.outputs.docs == 'true' && needs.changes.outputs.rust != 'true'",
+    ),
+    ['docs'],
+    'a `!=` term narrows the job and cannot widen coverage',
+  );
+  assert.equal(gatingFilters('    if: always()'), null);
+  assert.equal(gatingFilters('    runs-on: x'), null);
+});
+
+test('parseWorkflowPrPaths distinguishes no-paths from a paths list', () => {
+  assert.deepEqual(
+    parseWorkflowPrPaths("on:\n  pull_request:\n    branches: [main]\n    paths:\n      - 'a/**'\n"),
+    { triggersOnPr: true, paths: ['a/**'] },
+  );
+  assert.deepEqual(parseWorkflowPrPaths('on:\n  pull_request:\n    branches: [main]\n'), {
+    triggersOnPr: true,
+    paths: null,
+  });
+  assert.equal(parseWorkflowPrPaths('on:\n  schedule:\n    - cron: "0 0 * * *"\n').triggersOnPr, false);
+});
+
+test('deriveInputs keeps only literals that resolve, and never escapes the repo', () => {
+  const exists = (p) => ['apps', 'apps/landing/app.jsx', 'tests/benchmark/baseline.json'].includes(p);
+  const src = `
+    const SEARCH_DIRS = ['apps'];
+    const file = 'apps/landing/app.jsx';
+    const base = join(ROOT, 'tests', 'benchmark', 'baseline.json');
+    const escape = join(ROOT, '..', '..', 'secrets');
+    const prose = 'this is not a path';
+    const templated = \`\${ROOT}/nope\`;
+  `;
+  const got = deriveInputs(src, exists);
+  // `apps/landing/app.jsx` is subsumed by the `apps` walk and collapses into
+  // it -- see dropSubsumed. Coverage of that exact file is held instead by
+  // REQUIRED_COVERAGE in the check, which is why the by-name floor exists.
+  assert.deepEqual(got, ['apps', 'tests/benchmark/baseline.json']);
+  assert.ok(!got.some((p) => p.includes('secrets')), 'a `..` segment must never survive');
+  assert.ok(!got.includes('this is not a path'));
+});
+
+test('dropSubsumed keeps the parent, which is the safe direction', () => {
+  // Preferring the most specific literal would have dropped `apps` in favour of
+  // `apps/viewer`, and `apps/landing` -- the real defect -- would never surface.
+  assert.deepEqual(dropSubsumed(['apps', 'apps/viewer', 'packages']), ['apps', 'packages']);
+});
+
+test('matchesAny is false for a sibling that merely shares a prefix', () => {
+  assert.ok(!matchesAny('apps/landing/app.jsx', ['apps/viewer/**', 'apps/viewer-embed/**']));
+  assert.ok(matchesAny('apps/viewer/src/main.ts', ['apps/viewer/**']));
+});
+
+// ---------------------------------------------------------------------------
+// The real tree, and the four real holes reintroduced in it.
+// ---------------------------------------------------------------------------
+
+test('the real repository has no gate input outside its trigger', () => {
+  const { status, out } = run(REPO);
+  assert.equal(status, 0, out);
+});
+
+/**
+ * A mirror of the real repo whose `.github/` is a real copy and whose other
+ * top-level entries are symlinks, so a mutation of `test.yml` costs a few
+ * kilobytes instead of a full tree copy. The check resolves symlinked
+ * directories through `statSync`, so the walk sees the real files.
+ */
+function mirrorRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'ci-path-coverage-mirror-'));
+  for (const entry of readdirSync(REPO)) {
+    if (entry === '.git' || entry === 'node_modules') continue;
+    if (entry === '.github') cpSync(join(REPO, entry), join(root, entry), { recursive: true });
+    else symlinkSync(join(REPO, entry), join(root, entry));
+  }
+  return root;
+}
+
+/** Delete one `- '<glob>'` line from the mirror's filter block. */
+function dropFilterEntry(root, glob) {
+  const file = join(root, '.github/workflows/test.yml');
+  const before = readFileSync(file, 'utf8');
+  const after = before
+    .split('\n')
+    .filter((l) => l.trim() !== `- '${glob}'`)
+    .join('\n');
+  assert.notEqual(after, before, `filter entry '${glob}' was not found to remove`);
+  writeFileSync(file, after);
+}
+
+// The four holes this check was written for. Each asserts the report names the
+// SPECIFIC file, which is what a count floor would not have caught.
+for (const [glob, expected] of [
+  ['.github/workflows/**', /\.github\/workflows\/release\.yml cannot trigger scripts\/check-swallowed-push\.mjs/],
+  ['tests/integration.test.ts', /tests\/integration\.test\.ts cannot trigger scripts\/check-test-wiring\.mjs/],
+  [
+    'tests/benchmark/baseline.json',
+    /tests\/benchmark\/baseline\.json cannot trigger scripts\/docs\/generate-docs-sections\.mjs/,
+  ],
+  [
+    'apps/landing/**',
+    /apps\/landing\/app\.jsx cannot trigger scripts\/docs\/generate-docs-sections\.mjs/,
+  ],
+]) {
+  test(`removing '${glob}' from the filters reopens a real hole and is named`, () => {
+    const root = mirrorRepo();
+    try {
+      assert.equal(run(root).status, 0, 'the mirror must be green before the mutation');
+      dropFilterEntry(root, glob);
+      const { status, out } = run(root);
+      assert.equal(status, 1, out);
+      assert.match(out, expected);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/scripts/ci-path-coverage-allowlist.txt
+++ b/scripts/ci-path-coverage-allowlist.txt
@@ -1,0 +1,95 @@
+# Exemptions for scripts/check-ci-path-coverage.mjs.
+#
+# Format:  <gate script>  <path glob>  # <reason>
+#
+# An entry says: this gate names this path, the path cannot trigger the job that
+# runs the gate, AND that is acceptable for the written reason. A REASON IS
+# MANDATORY -- a bare path is refused. Entries that stop matching anything are a
+# FAILURE, not a no-op: a stale exemption is exactly how the next hole hides.
+#
+# Before adding a line, try the other fix first: add the path to the CHEAPEST
+# filter in .github/workflows/test.yml that reaches the job.
+#
+# ---------------------------------------------------------------------------
+# 1. PREFIX FRAGMENTS. The input derivation reads path literals out of a gate's
+#    own source, so `join(ROOT, 'tests', 'benchmark', 'baseline.json')` yields
+#    the composed path AND the bare `'tests'` it was composed from. The bare
+#    segment is a fragment, not a tree the gate walks. The derivation keeps it
+#    on purpose -- over-reporting is the safe direction for a reachability
+#    check, and the alternative (prefer the most specific literal) would have
+#    hidden `apps/landing`, which is the defect that prompted all of this.
+# ---------------------------------------------------------------------------
+scripts/check-test-wiring.mjs .github/* # `.github` is a prefix fragment; the walk is `.github/workflows`, which the frontend filter now carries
+scripts/check-test-wiring.test.mjs .github/* # same fragment, in the harness that mutates a copy of the tree
+scripts/release-version-changed.test.mjs .github/* # same fragment; the gate reads .github/workflows/release.yml only
+scripts/lib/module-size-ratchet.test.mjs tests/* # `tests` fragment from a fixture path; the ratchet walks packages/ and apps/
+scripts/fixtures/fetch-fixtures.test.mjs tests/* # `tests` fragment; the fetcher targets tests/models from its manifest
+scripts/docs/generate-docs-sections.mjs tests/benchmark/* # `tests` prefix fragment; the one input under tests/benchmark is baseline.json, now in the docs filter and pinned by REQUIRED_COVERAGE
+scripts/docs/generate-docs-sections.mjs tests/extensions # `tests` prefix fragment; sdk-canary.yml carries tests/extensions/canaries/** in its own paths
+scripts/docs/generate-docs-sections.mjs tests/models # `tests` prefix fragment; the corpus input tests/models/manifest.json is in the rust, geometry and frontend filters
+scripts/docs/check-package-readmes.test.mjs docs # `docs` fragment; the gate reads packages/*/README.md
+scripts/docs/check-package-readmes.test.mjs README.md # root README fragment; the gate reads per-package READMEs
+scripts/check-swallowed-push.test.mjs README.md # fragment from the harness's fixture root, not an input
+scripts/typecheck-tests.test.mjs README.md # same fragment
+scripts/typecheck-tests.test.mjs demo # `demo` is not a typecheck target; the gate reads tsconfig project references
+scripts/generate-plato-clash.mjs tools/* # `tools` fragment; the generator reads tools/plato, which the plato filter carries
+scripts/moonshot/ci/assert-b35-golden.mjs scripts/build-wasm.sh # named in prose as the build the golden came from, not read
+
+# ---------------------------------------------------------------------------
+# 2. apps/landing AND THE FOUR TREE-WALKERS. `check-module-size`,
+#    `check-wasm-disposal`, `check-source-text-assertions`,
+#    `check-loader-hook-specifier-match` and `check-test-wiring` all walk
+#    `apps/`, and all run in the Node tests job, which only `frontend` and
+#    `rust` reach. THE TRADE, written out rather than silently taken: closing
+#    this would mean `apps/landing/**` in `frontend`, which drags every
+#    landing-copy edit through build + typecheck + lint + the viewer shards +
+#    E2E. The filter block already declines to broaden `apps/**` for exactly
+#    that reason. What is NOT exempted is the input that actually exists today:
+#    `generate-docs-sections` reads apps/landing/app.jsx and bench-data.json,
+#    and those are now in the `docs` filter, which reaches the same check
+#    through the free Docs-checks job. The residue is a tree walk that matches
+#    zero files -- apps/landing ships unbuilt .jsx/.html/.css and contains no
+#    TypeScript, no test file and no WASM handle. If TypeScript ever lands
+#    there, DELETE THESE LINES and pay the frontend cost.
+# ---------------------------------------------------------------------------
+scripts/check-module-size.mjs apps/landing # walks apps/ for .ts/.tsx; apps/landing has none -- see the trade above
+scripts/check-module-size.test.mjs apps/landing # same walk, in the harness
+scripts/check-wasm-disposal.mjs apps/landing # walks apps/ for WASM handles; apps/landing holds none
+scripts/check-source-text-assertions.mjs apps/landing # walks apps/ for test files; apps/landing has none
+scripts/check-loader-hook-specifier-match.mjs apps/landing # walks apps/ for loader hooks; apps/landing has none
+scripts/check-loader-hook-specifier-match.test.mjs apps/landing # same walk, in the harness
+scripts/check-tla-chunk-await.test.mjs apps/landing # same walk, in the harness
+scripts/check-test-wiring.mjs apps/landing # walks apps/ for test suites; apps/landing has none
+scripts/typecheck-tests.test.mjs apps/landing # apps/landing is not a tsconfig project
+
+# ---------------------------------------------------------------------------
+# 3. OTHER WORKFLOWS. Real holes, in workflows this change does not own.
+#    Recorded rather than fixed so they are visible and attributable, and so
+#    the check goes green on the state it actually found.
+# ---------------------------------------------------------------------------
+scripts/moonshot/ci/check-report-numerals.mjs docs/* # moonshot.yml's own paths do not include docs/**; widening a standing-evidence workflow is a separate call
+scripts/moonshot/ci/check-report-numerals.mjs scripts/* # same workflow: moonshot.yml's paths do not include scripts/**
+scripts/fixtures/fetch-fixtures.mjs scripts/fixtures/* # the fetcher runs in rust-tests/geometry-census/benchmark, whose filters carry tests/models/manifest.json but not scripts/**
+scripts/fixtures/fetch-fixtures.mjs tests/models/README.md # the rust/geometry filters pin tests/models/manifest.json, the corpus input; the README is not one
+
+# ---------------------------------------------------------------------------
+# 4. THIS CHECK'S OWN REQUIRED_COVERAGE LITERALS. `check-ci-path-coverage.mjs`
+#    NAMES these files in order to assert about them; it does not read them.
+#    Each is asserted against the globs of the job running the gate that DOES
+#    read it, which is the whole point of REQUIRED_COVERAGE.
+# ---------------------------------------------------------------------------
+scripts/check-ci-path-coverage.mjs apps/landing/app.jsx # asserted about, not read -- REQUIRED_COVERAGE entry
+scripts/check-ci-path-coverage.mjs apps/landing/bench-data.json # asserted about, not read -- REQUIRED_COVERAGE entry
+scripts/check-ci-path-coverage.mjs tests/benchmark/baseline.json # asserted about, not read -- REQUIRED_COVERAGE entry
+
+# ---------------------------------------------------------------------------
+# 5. THIS CHECK'S OWN HARNESS. check-ci-path-coverage.test.mjs quotes real repo
+#    paths in its assertions and its prose; it reads none of them -- its
+#    fixtures are synthetic trees under os.tmpdir().
+# ---------------------------------------------------------------------------
+scripts/check-ci-path-coverage.test.mjs .github/* # `.github` prefix fragment from a fixture path, not read
+scripts/check-ci-path-coverage.test.mjs apps/landing # quoted in an assertion, not read
+scripts/check-ci-path-coverage.test.mjs docs # quoted in an assertion, not read
+scripts/check-ci-path-coverage.test.mjs tests/benchmark # quoted in an assertion, not read
+scripts/check-ci-path-coverage.test.mjs tests/extensions # quoted in an assertion, not read
+scripts/check-ci-path-coverage.test.mjs tests/models # quoted in an assertion, not read

--- a/scripts/ci-path-coverage-allowlist.txt
+++ b/scripts/ci-path-coverage-allowlist.txt
@@ -28,6 +28,14 @@ scripts/docs/generate-docs-sections.mjs tests/benchmark/* # `tests` prefix fragm
 scripts/docs/generate-docs-sections.mjs tests/extensions # `tests` prefix fragment; sdk-canary.yml carries tests/extensions/canaries/** in its own paths
 scripts/docs/generate-docs-sections.mjs tests/models # `tests` prefix fragment; the corpus input tests/models/manifest.json is in the rust, geometry and frontend filters
 scripts/docs/check-package-readmes.test.mjs docs # `docs` fragment; the gate reads packages/*/README.md
+# The two below are prefix-test literals, not walked trees: check-report-numerals.mjs
+# carries `relRaw.startsWith('scripts/') || relRaw.startsWith('docs/')`, and the
+# derivation keeps the bare `scripts` and `docs` those normalise to. Its REAL roots
+# are `const VISION_DIR = 'docs/vision'` and the bet directories under
+# scripts/moonshot, and moonshot.yml's own `on.pull_request.paths` carries
+# `docs/vision/**` AND `scripts/moonshot/**`. So this is not a hole in moonshot.yml.
+scripts/moonshot/ci/check-report-numerals.mjs docs/* # `docs` fragment from a startsWith() prefix test; the real root docs/vision is in moonshot.yml's paths
+scripts/moonshot/ci/check-report-numerals.mjs scripts/* # same fragment; the real roots under scripts/moonshot are in moonshot.yml's paths
 scripts/docs/check-package-readmes.test.mjs README.md # root README fragment; the gate reads per-package READMEs
 scripts/check-swallowed-push.test.mjs README.md # fragment from the harness's fixture root, not an input
 scripts/typecheck-tests.test.mjs README.md # same fragment
@@ -67,8 +75,6 @@ scripts/typecheck-tests.test.mjs apps/landing # apps/landing is not a tsconfig p
 #    Recorded rather than fixed so they are visible and attributable, and so
 #    the check goes green on the state it actually found.
 # ---------------------------------------------------------------------------
-scripts/moonshot/ci/check-report-numerals.mjs docs/* # moonshot.yml's own paths do not include docs/**; widening a standing-evidence workflow is a separate call
-scripts/moonshot/ci/check-report-numerals.mjs scripts/* # same workflow: moonshot.yml's paths do not include scripts/**
 scripts/fixtures/fetch-fixtures.mjs scripts/fixtures/* # the fetcher runs in rust-tests/geometry-census/benchmark, whose filters carry tests/models/manifest.json but not scripts/**
 scripts/fixtures/fetch-fixtures.mjs tests/models/README.md # the rust/geometry filters pin tests/models/manifest.json, the corpus input; the README is not one
 

--- a/scripts/lib/ci-path-coverage.mjs
+++ b/scripts/lib/ci-path-coverage.mjs
@@ -1,0 +1,296 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pure helpers for `scripts/check-ci-path-coverage.mjs`.
+ *
+ * Kept in `scripts/lib/` so the parsing and glob semantics can be unit-tested
+ * against hand-written fixtures without a checkout of the real workflows.
+ */
+
+/**
+ * Translate one `dorny/paths-filter` glob into a RegExp over repo-relative
+ * POSIX paths.
+ *
+ * paths-filter matches with picomatch, so `*` does NOT cross `/` and `**`
+ * does. `a/**` is written to also match `a` itself, because a filter entry of
+ * that shape is universally meant as "this subtree", and a caller that asks
+ * whether the DIRECTORY is covered must get `true` rather than being forced to
+ * enumerate it.
+ *
+ * ERRS TOWARD MATCHING is the wrong direction here and this deliberately does
+ * not do it: this module decides whether a gate's input can trigger the gate,
+ * so a glob translated too WIDELY hides exactly the defect being looked for.
+ * Anything it cannot translate throws instead of degrading to a loose match.
+ */
+const regexCache = new Map();
+
+export function globToRegExp(glob) {
+  const cached = regexCache.get(glob);
+  if (cached) return cached;
+  const built = compileGlob(glob);
+  regexCache.set(glob, built);
+  return built;
+}
+
+function compileGlob(glob) {
+  if (typeof glob !== 'string' || glob.length === 0) {
+    throw new Error('globToRegExp: empty glob');
+  }
+  if (/[[\]{}()+@!|]/.test(glob)) {
+    // Brace/extglob/character-class syntax is legal picomatch and none of the
+    // filters use it. Refuse rather than mistranslate.
+    throw new Error(`globToRegExp: unsupported glob syntax in ${JSON.stringify(glob)}`);
+  }
+  let out = '';
+  for (let i = 0; i < glob.length; i += 1) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        // `**` — crosses separators. `/**` at the end also matches the bare dir.
+        if (out.endsWith('/') && i + 2 === glob.length) {
+          out = `${out.slice(0, -1)}(?:/.*)?`;
+        } else {
+          out += '.*';
+        }
+        i += 1;
+      } else {
+        out += '[^/]*';
+      }
+      continue;
+    }
+    if (c === '?') {
+      out += '[^/]';
+      continue;
+    }
+    out += c.replace(/[.^$\\]/g, '\\$&');
+  }
+  return new RegExp(`^${out}$`);
+}
+
+/** True when `path` (repo-relative, POSIX) is matched by any glob in `globs`. */
+export function matchesAny(path, globs) {
+  return globs.some((g) => globToRegExp(g).test(path));
+}
+
+/**
+ * Pull the `changes` job's `filters: |` block scalar out of test.yml and return
+ * `Map<filterName, string[]>`.
+ *
+ * Hand-rolled rather than YAML-parsed because the gate scripts run with no
+ * third-party dependencies available. The block scalar is a flat two-level
+ * shape (`name:` then `- 'glob'`), so the parse is exact for it and throws on
+ * anything it does not recognise -- it never silently returns a short list,
+ * which would read as "no holes".
+ */
+export function parseFilterBlock(text) {
+  const lines = text.split('\n');
+  const start = lines.findIndex((l) => /^\s*filters:\s*\|\s*$/.test(l));
+  if (start === -1) throw new Error('parseFilterBlock: no `filters: |` block found');
+  const bodyIndent = lines[start].match(/^(\s*)/)[1].length;
+
+  const filters = new Map();
+  let current = null;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (raw.trim() === '') continue;
+    const indent = raw.match(/^(\s*)/)[1].length;
+    if (indent <= bodyIndent) break; // block scalar ended
+    const line = raw.trim();
+    if (line.startsWith('#')) continue;
+    const name = line.match(/^([A-Za-z_][A-Za-z0-9_-]*):$/);
+    if (name) {
+      current = name[1];
+      filters.set(current, []);
+      continue;
+    }
+    const entry = line.match(/^-\s*'([^']+)'$/) || line.match(/^-\s*"([^"]+)"$/);
+    if (entry) {
+      if (!current) throw new Error(`parseFilterBlock: glob before any filter name: ${line}`);
+      filters.get(current).push(entry[1]);
+      continue;
+    }
+    throw new Error(`parseFilterBlock: unrecognised line in filter block: ${JSON.stringify(line)}`);
+  }
+  if (filters.size === 0) throw new Error('parseFilterBlock: filter block parsed to zero filters');
+  for (const [name, globs] of filters) {
+    if (globs.length === 0) throw new Error(`parseFilterBlock: filter ${name} has no globs`);
+  }
+  return filters;
+}
+
+/**
+ * Split a workflow's `jobs:` mapping into `{ id, text }` slabs.
+ *
+ * `text` is the job's whole body, comments stripped -- callers regex over it
+ * for `node scripts/...` invocations. Stripping comments matters: test.yml
+ * mentions `check-module-size.test.mjs` in a comment right above the step that
+ * runs it, and a comment mention is not an invocation.
+ */
+export function splitJobs(text) {
+  const lines = text.split('\n');
+  const jobsAt = lines.findIndex((l) => /^jobs:\s*$/.test(l));
+  if (jobsAt === -1) return [];
+  const jobs = [];
+  let current = null;
+  for (let i = jobsAt + 1; i < lines.length; i += 1) {
+    const raw = lines[i];
+    const header = raw.match(/^ {2}([A-Za-z_][A-Za-z0-9_-]*):\s*$/);
+    if (header) {
+      current = { id: header[1], lines: [] };
+      jobs.push(current);
+      continue;
+    }
+    if (!current) continue;
+    if (/^\S/.test(raw)) break; // back to a top-level key
+    if (/^\s*#/.test(raw)) continue; // comment-only line
+    current.lines.push(raw);
+  }
+  return jobs.map((j) => ({ id: j.id, text: j.lines.join('\n') }));
+}
+
+/**
+ * The filter outputs that must be `true` for a job to run, read off its `if:`.
+ *
+ * POSITIVE terms only: `needs.changes.outputs.docs == 'true'` gates the job on
+ * `docs`, while the `frontend != 'true'` in the same expression only makes the
+ * job run LESS often and so cannot add coverage. Returns `null` for a job with
+ * no filter reference at all -- that job always runs, which is full coverage.
+ */
+export function gatingFilters(jobText) {
+  const ifLine = jobText.match(/^\s{4}if:\s*(.*)$/m);
+  if (!ifLine) return null;
+  const expr = ifLine[1];
+  const positives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*==\s*'true'/g)].map(
+    (m) => m[1],
+  );
+  const negatives = [...expr.matchAll(/needs\.changes\.outputs\.([A-Za-z0-9_]+)\s*!=\s*'true'/g)].map(
+    (m) => m[1],
+  );
+  if (positives.length === 0) {
+    // An `if:` that never mentions a filter output (e.g. `always()`, or an
+    // event-name guard) does not path-gate the job.
+    return negatives.length === 0 ? null : [];
+  }
+  return positives;
+}
+
+/** `on.pull_request.paths` for a workflow, or `null` when it has none (= all paths). */
+export function parseWorkflowPrPaths(text) {
+  const lines = text.split('\n');
+  const onAt = lines.findIndex((l) => /^on:\s*$/.test(l));
+  if (onAt === -1) return { triggersOnPr: false, paths: null };
+  let inPr = false;
+  let inPaths = false;
+  let paths = null;
+  for (let i = onAt + 1; i < lines.length; i += 1) {
+    const raw = lines[i];
+    if (/^\S/.test(raw)) break;
+    if (/^\s*#/.test(raw)) continue;
+    if (/^ {2}pull_request:\s*$/.test(raw)) {
+      inPr = true;
+      continue;
+    }
+    if (/^ {2}\S/.test(raw)) {
+      inPr = false;
+      inPaths = false;
+      continue;
+    }
+    if (!inPr) continue;
+    if (/^ {4}paths(-ignore)?:\s*$/.test(raw)) {
+      // `paths-ignore` is an exclusion list, not an inclusion list; a workflow
+      // using it triggers on everything else, which is full coverage.
+      if (raw.includes('paths-ignore')) return { triggersOnPr: true, paths: null };
+      inPaths = true;
+      paths = [];
+      continue;
+    }
+    if (/^ {4}\S/.test(raw)) {
+      inPaths = false;
+      continue;
+    }
+    if (inPaths) {
+      const entry = raw.trim().match(/^-\s*'([^']+)'$/) || raw.trim().match(/^-\s*"([^"]+)"$/);
+      if (entry) paths.push(entry[1]);
+    }
+  }
+  return { triggersOnPr: inPrSeen(lines, onAt), paths };
+}
+
+function inPrSeen(lines, onAt) {
+  for (let i = onAt + 1; i < lines.length; i += 1) {
+    if (/^\S/.test(lines[i])) break;
+    if (/^ {2}pull_request:/.test(lines[i])) return true;
+  }
+  return false;
+}
+
+/**
+ * Repo-relative paths a gate script READS, derived from its own source.
+ *
+ * Two literal shapes, both of which the real gates use:
+ *   - a quoted string that is itself a repo path (`'packages'`, `'apps'`,
+ *     `'.github/workflows'`, `'apps/landing/app.jsx'`)
+ *   - `join(ROOT, 'tests', 'benchmark', 'baseline.json')` and the same shape
+ *     with any root identifier
+ *
+ * A literal only survives if it resolves to something that EXISTS in the repo,
+ * which is what keeps prose and non-path strings out. `exists` is injected so
+ * this stays pure.
+ */
+/**
+ * Not a repo INPUT even though it resolves: the tree root, its parent (every
+ * gate computes ROOT as `join(dirname(...), '..')`), and git's own directory.
+ * Left in, `.` makes every gate read the whole repo and the check says nothing.
+ */
+const NOT_AN_INPUT = new Set(['.', '..', '.git', '']);
+
+function normalise(p) {
+  return p.replace(/\/+$/, '').replace(/^\.\//, '');
+}
+
+/**
+ * A `..` segment leaves the repo, so whatever it resolves to is not a repo
+ * input and no filter could ever name it. `join(ROOT, '..', '..', x)` in a
+ * gate's own test fixtures otherwise walks out of the checkout entirely.
+ */
+const escapesRepo = (p) => p.split('/').includes('..');
+
+export function deriveInputs(source, exists) {
+  const found = new Set();
+
+  for (const m of source.matchAll(/\bjoin\(\s*([A-Za-z_$][\w$]*)\s*,\s*([^)]*)\)/g)) {
+    const args = m[2];
+    if (/[^\s,'"\w./$-]/.test(args)) continue; // an expression, not a literal path
+    const parts = [...args.matchAll(/'([^']*)'|"([^"]*)"/g)].map((p) => p[1] ?? p[2]);
+    if (parts.length === 0) continue;
+    const candidate = normalise(parts.join('/').replace(/\/+/g, '/'));
+    if (!NOT_AN_INPUT.has(candidate) && !escapesRepo(candidate) && exists(candidate)) found.add(candidate);
+  }
+
+  for (const m of source.matchAll(/'([^'\n]+)'|"([^"\n]+)"/g)) {
+    const raw = m[1] ?? m[2];
+    if (!raw || raw.includes('${') || raw.includes(' ')) continue;
+    if (!/^[\w.][\w./-]*$/.test(raw)) continue;
+    const lit = normalise(raw);
+    if (NOT_AN_INPUT.has(lit) || escapesRepo(lit)) continue;
+    if (exists(lit)) found.add(lit);
+  }
+
+  return dropSubsumed([...found]);
+}
+
+/**
+ * Drop `packages/bcf` when `packages` is already in the set.
+ *
+ * Purely an economy -- a subtree cannot be covered when its parent is not, so
+ * the answer is identical. Without it, `check-module-size.mjs` names all 38
+ * workspace packages individually and each one is walked again.
+ */
+export function dropSubsumed(paths) {
+  const sorted = [...new Set(paths)].sort();
+  return sorted
+    .filter((p) => !sorted.some((q) => q !== p && p.startsWith(`${q}/`)))
+    .sort();
+}

--- a/scripts/lib/ci-path-coverage.mjs
+++ b/scripts/lib/ci-path-coverage.mjs
@@ -294,3 +294,74 @@ export function dropSubsumed(paths) {
     .filter((p) => !sorted.some((q) => q !== p && p.startsWith(`${q}/`)))
     .sort();
 }
+
+/**
+ * Translate a `.gitignore` into globs over repo-relative POSIX paths.
+ *
+ * WHY THIS EXISTS. The gate derives a job's inputs by walking the tree. A walk
+ * over the WORKING tree sees whatever happens to be on disk: `node_modules`
+ * after an install, a package's `dist` after a build, the `.ifc` corpus under
+ * `tests/models` after the fixture cache warms. None of those are committed, so none of them
+ * can ever be what a `paths:` filter matches -- but their presence changed the
+ * VERDICT. The check passed on a developer's clean checkout and failed in CI
+ * on the identical commit, which makes it not a check at all. Restricting the
+ * walk to what git tracks makes the answer a function of the commit alone.
+ *
+ * Read from the committed `.gitignore` rather than by shelling out to
+ * `git check-ignore`, so the synthetic trees in the harness -- which are not
+ * git repositories -- run the SAME exclusion the real repository runs. A
+ * fallback path for "not a repo" would be a second behaviour nothing tests.
+ *
+ * The supported subset is exactly what this repository's `.gitignore` uses.
+ * Anything else THROWS: a pattern silently dropped is a tree the walk wanders
+ * back into, which is the defect this function exists to remove.
+ *
+ * @param {string} text
+ * @returns {string[]} globs consumable by {@link matchesAny}.
+ */
+export function gitignoreToGlobs(text) {
+  const out = [];
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    if (line.startsWith('!')) {
+      // A re-inclusion means the ignore set is no longer a plain union and
+      // ordering starts to matter. Refusing is the honest answer.
+      throw new Error(`gitignoreToGlobs: negation is not supported: ${JSON.stringify(line)}`);
+    }
+    if (line.includes('\\')) {
+      throw new Error(`gitignoreToGlobs: escapes are not supported: ${JSON.stringify(line)}`);
+    }
+
+    const trailingSlash = line.endsWith('/');
+    let body = trailingSlash ? line.slice(0, -1) : line;
+    const anchored = body.startsWith('/');
+    if (anchored) body = body.slice(1);
+    if (body === '') {
+      throw new Error(`gitignoreToGlobs: empty pattern: ${JSON.stringify(line)}`);
+    }
+
+    // git anchors a pattern to the repo root as soon as it contains a slash
+    // anywhere but the end; otherwise it matches at every depth.
+    const rooted = anchored || body.includes('/');
+    const bases = rooted ? [body] : [body, `**/${body}`];
+    for (const base of bases) {
+      // Both the node itself and everything under it: git ignoring a directory
+      // ignores its whole subtree, and the walk must be able to ask either
+      // question.
+      out.push(base, `${base}/**`);
+      // `a/**/b` in git matches ZERO or more intervening directories, so
+      // `tests/models/**/*.ifc` covers `tests/models/AB22.ifc`. `globToRegExp`
+      // renders `**` as `.*`, which needs the separators on both sides and so
+      // would miss the zero-directory case -- and missing it is what left the
+      // corpus visible to the walk in the first place. Emit the collapsed form
+      // alongside rather than loosening the shared translator, which decides a
+      // different question for the filter globs.
+      if (base.includes('/**/')) {
+        const collapsed = base.replaceAll('/**/', '/');
+        out.push(collapsed, `${collapsed}/**`);
+      }
+    }
+  }
+  return out;
+}

--- a/scripts/lib/ci-path-coverage.mjs
+++ b/scripts/lib/ci-path-coverage.mjs
@@ -176,7 +176,24 @@ export function gatingFilters(jobText) {
   return positives;
 }
 
-/** `on.pull_request.paths` for a workflow, or `null` when it has none (= all paths). */
+/**
+ * `on.pull_request.paths` for a workflow, or `null` when it has none (= all
+ * paths).
+ *
+ * FAILS CLOSED ON SHAPES IT DOES NOT PARSE. `null` here means "this workflow
+ * triggers on everything", which is the widest possible coverage claim -- so a
+ * `paths:` block quietly parsed as absent is not a degraded answer, it is the
+ * opposite answer, and it hides exactly the uncovered gate input this module
+ * exists to find. Two shapes therefore throw rather than return:
+ *
+ *   - an INLINE list (`paths: ['rust/**']`). The block-scalar matcher requires
+ *     an empty tail after the colon, so an inline list fell through to the
+ *     "some other key" branch and left `paths` at `null`.
+ *   - an UNQUOTED or otherwise unrecognised entry inside a block list. That one
+ *     errs the safe way -- a short list under-claims coverage and over-reports
+ *     violations -- but a finding derived from a silently truncated trigger
+ *     list is noise a reader cannot distinguish from a real hole.
+ */
 export function parseWorkflowPrPaths(text) {
   const lines = text.split('\n');
   const onAt = lines.findIndex((l) => /^on:\s*$/.test(l));
@@ -198,10 +215,20 @@ export function parseWorkflowPrPaths(text) {
       continue;
     }
     if (!inPr) continue;
-    if (/^ {4}paths(-ignore)?:\s*$/.test(raw)) {
+    const pathsKey = raw.match(/^ {4}(paths(?:-ignore)?):(.*)$/);
+    if (pathsKey) {
+      const tail = pathsKey[2].trim();
+      if (tail !== '' && !tail.startsWith('#')) {
+        throw new Error(
+          `parseWorkflowPrPaths: on.pull_request.${pathsKey[1]} is written inline ` +
+            `(${JSON.stringify(raw.trim())}). Only the block-list form is parsed, and reading ` +
+            'this as "no path filter" would claim the workflow triggers on everything. ' +
+            'Rewrite it as a block list, or teach this parser the inline form.',
+        );
+      }
       // `paths-ignore` is an exclusion list, not an inclusion list; a workflow
       // using it triggers on everything else, which is full coverage.
-      if (raw.includes('paths-ignore')) return { triggersOnPr: true, paths: null };
+      if (pathsKey[1] === 'paths-ignore') return { triggersOnPr: true, paths: null };
       inPaths = true;
       paths = [];
       continue;
@@ -211,8 +238,17 @@ export function parseWorkflowPrPaths(text) {
       continue;
     }
     if (inPaths) {
-      const entry = raw.trim().match(/^-\s*'([^']+)'$/) || raw.trim().match(/^-\s*"([^"]+)"$/);
-      if (entry) paths.push(entry[1]);
+      const trimmed = raw.trim();
+      if (trimmed === '') continue;
+      const entry = trimmed.match(/^-\s*'([^']+)'$/) || trimmed.match(/^-\s*"([^"]+)"$/);
+      if (!entry) {
+        throw new Error(
+          `parseWorkflowPrPaths: unparseable entry in on.pull_request.paths: ` +
+            `${JSON.stringify(trimmed)}. Dropping it silently would shorten the trigger list ` +
+            'and turn a covered gate input into a reported violation.',
+        );
+      }
+      paths.push(entry[1]);
     }
   }
   return { triggersOnPr: inPrSeen(lines, onAt), paths };


### PR DESCRIPTION
## The class

A CI gate is only as good as the job that runs it, and that job only runs when the path filter says so. When a gate's **input** sits outside its own **trigger**, the gate is not weak — it is unreachable: the PR that introduces the very mistake it guards against is exactly the PR the job skips, and a skipped job counts as success in the aggregate `test` gate, so the required check goes green.

The filter block already warns about this shape three times (`.changeset/**`, `examples/**`, `server/**`/`api/**`). This PR closes four more instances and then makes the class mechanically detectable.

## Reproduced, each one

| hole | gate | evidence |
|---|---|---|
| `.github/workflows/**` — 11 of 13 files in no filter | `check-swallowed-push.mjs`, whose declared SCOPE **is** `.github/workflows/**` | **PR #3118** edited only `release.yml` + `docker.yml` → `Node tests: skipped`, aggregate gate `success`. (Also #2562, release.yml only, same result.) |
| `tests/integration.test.ts` | `pnpm test:integration` runs that exact file in Node tests | Structural: no workflow names the file. No real PR has ever touched it alone, so no natural experiment exists — reproduced by construction only. |
| `tests/benchmark/baseline.json`, `apps/landing/app.jsx` | `generate-docs-sections.mjs --check` regenerates from both | **PR #1817** changed only `apps/landing/bench-data.json` → `Node tests: skipped`, `Docs checks: skipped`, aggregate gate `success`. |
| `apps/landing/**` — in no filter anywhere | four gates walk `apps/`; `generate-docs-sections` reads `apps/landing/app.jsx` | `grep -rn "apps/landing\|apps/\*\*" .github/workflows/` returns only a comment. |

**`tests/extensions/**` did not reproduce** and is not fixed: `sdk-canary.yml` carries `tests/extensions/canaries/**` in its own `paths:`, so the canary job does trigger on it. Dropped.

## The fixes, and what each costs

```
frontend  += '.github/workflows/**'        (subsumes test.yml + server-binaries.yml there)
          += 'tests/integration.test.ts'
          += 'tests/tsconfig.json'         (found by the new check: both test:integration
                                            and test:api compile against it)
docs      += 'apps/landing/**'
          += 'tests/benchmark/baseline.json'
```

**`docs`, not `frontend`, for the last two — deliberately.** `docs` reaches the same `--check` through **Docs checks**: one free `ubuntu-latest` runner, three node scripts, no build artifact, no Depot. That is the cheapest job that runs the gate. `frontend` would drag every landing-copy edit through build + typecheck + lint + the viewer shards + E2E for no added signal. Coverage holds either way — a PR that also touches frontend/rust makes Docs checks skip itself and Node tests runs the identical `--check`.

**`.github/workflows/**` is the addition that costs.** A workflow-only PR now runs the JS lane. Every job it adds is on a free runner except `build`, which reaches Depot only when the WASM source has drifted from the published release tag — the same condition every frontend PR already pays, and never caused by a workflow edit itself. Workflow-only PRs are rare (mostly dependabot bumps). Flagging the deviation explicitly, as on #3305.

**One hole left open, with the trade written out.** `check-module-size`, `check-wasm-disposal`, `check-source-text-assertions`, `check-loader-hook-specifier-match` and `check-test-wiring` all walk `apps/` and all run in Node tests, which only `frontend`/`rust` reach. Closing that needs `apps/landing/**` in `frontend` — the broadening the filter block already declines. The walk matches **zero files** there today: `apps/landing` ships unbuilt `.jsx`/`.html`/`.css`, no TypeScript, no test file, no WASM handle. Recorded as reasoned exemptions that say "if TypeScript lands here, delete these lines and pay the frontend cost".

## The durable part

`scripts/check-ci-path-coverage.mjs` — the mechanical diff, made permanent. For every workflow it derives (a) which `node scripts/...` gates each job runs, (b) the globs that can trigger that job (the workflow's own `on.pull_request.paths`, or for `test.yml` the union of the `changes` filters its `if:` names — positive terms only), and (c) the repo paths each gate reads, out of the gate's own source. Then it reports every path a gate reads that no glob can reach, at the shallowest uncovered subtree.

**Fails closed.** No workflows · no PR-triggered jobs · no gates found · filter block parses to nothing · unreadable workflow · a referenced gate script missing from the tree · a job gating on an undefined filter · missing allowlist · an exemption with no written reason · an exemption that stopped matching anything · zero derived inputs — each a **named** failure, never a pass. `globToRegExp` throws on glob syntax it cannot translate rather than degrading to a loose match, because translating too widely hides exactly the defect being looked for.

**Its own config is inside its own trigger** — the defect it detects. `assertSelfCoverage` proves it for the script, its lib and its allowlist, rather than asserting it in prose.

**Required by name.** `REQUIRED_COVERAGE` pins the six specific facts above. A count floor survives dropping the one entry that matters; a named assertion does not. (It is load-bearing: `apps/landing/app.jsx` is subsumed by the `apps` walk in the derived set, so only the by-name floor holds it.)

## RED / GREEN / mutation

`scripts/check-ci-path-coverage.test.mjs` — **27 tests, all green**:

- every fail-closed path above, against synthetic trees
- glob semantics (`*` must not cross `/`; `a/**` covers the bare dir; a sibling sharing a prefix is not a match), the filter-block parser, `splitJobs` dropping comment mentions, `gatingFilters` ignoring `!=` terms
- **the four real holes reintroduced** against a symlink mirror of this repo — one test per filter entry, asserting the report names the specific file:
  - drop `.github/workflows/**` → `.github/workflows/release.yml cannot trigger scripts/check-swallowed-push.mjs`
  - drop `tests/integration.test.ts` → `tests/integration.test.ts cannot trigger scripts/check-test-wiring.mjs`
  - drop `tests/benchmark/baseline.json` → `tests/benchmark/baseline.json cannot trigger scripts/docs/generate-docs-sections.mjs`
  - drop `apps/landing/**` → `apps/landing/app.jsx cannot trigger scripts/docs/generate-docs-sections.mjs`
- the real repository, asserted green

Also run by hand on a scratch copy and restored by inverse edit, `diff` clean.

Current state: `73 gate(s) across 26 PR-triggered job(s); 255 derived input path(s), all inside their own trigger (37 reasoned exemption(s))`. `actionlint` clean apart from the pre-existing Depot-label warnings. No changeset — no published package's behaviour changes.

## Overlap

`.github/workflows/test.yml`'s filter block is contested. **#3305** (adds `rust-major-offset.json` to `frontend`) and **#3313** (adds a workflow with no `paths:`) were both still open at the time of writing; neither touches the lines here, and both are compatible with this change — #3313's new workflow becomes covered by `.github/workflows/**` for free. **#3311** (main-red module-size budget) is also still open, so the Node lane may abort before vitest on this PR too; that is not this change.

Refs #3312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Added automated checks to ensure repository changes are covered by the appropriate CI workflows.
  * Expanded workflow path detection for frontend, documentation, and integration test changes.
  * Added clear validation for missing, invalid, stale, or incomplete CI coverage configuration.

* **Tests**
  * Added comprehensive regression tests covering valid configurations, uncovered paths, malformed workflows, and exemption handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->