### PR TITLE
fix(viewer-embed): apply ?hideAxis= and ?hideScale= instead of only parsing them

### DIFF
--- a/apps/viewer-embed/src/components/EmbedViewer.overlays.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.overlays.test.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `?hideAxis=` and `?hideScale=` were parsed by the embed and then never read
+ * (#2934 item 5). `urlParams.test.ts` pins the PARSING; a `grep` for
+ * `urlParams.hideAxis` / `.hideScale` across `apps/viewer-embed` matched only
+ * the parser and its own test, and `ViewportOverlays` took a single
+ * `hideViewCube` prop, rendering the axis helper and the scale readout
+ * unconditionally.
+ *
+ * `hideViewCube` — the fourth sibling, and the one that WAS wired — is the
+ * pattern followed here: a prop on `ViewportOverlays` guarding the JSX, passed
+ * from `EmbedViewer`'s single `<ViewportOverlays />` call site.
+ *
+ * These render the REAL `ViewportOverlays` (deliberately NOT mocked out, as
+ * the sibling `EmbedViewer.urlParams.test.ts` does) and assert on the DOM the
+ * embed actually produces. Both directions are asserted for each param: a test
+ * that only checked the hidden case would pass an implementation that hides
+ * the overlay always, so every case also asserts the OTHER overlay is still
+ * there, and the no-param case asserts both are.
+ *
+ * The `useWebGPU` mock is load-bearing for the reason `EmbedViewer.autoLoad.test.ts`
+ * records: happy-dom has no `navigator.gpu`, so without it the whole
+ * `Viewport`/`ViewportOverlays` subtree is never rendered and every "absent"
+ * assertion below would be vacuously true. The default-case test is the guard
+ * that would catch that regressing.
+ */
+
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+
+vi.mock('@/components/viewer/Viewport', () => ({ Viewport: () => null }));
+
+vi.mock('@/hooks/useWebGPU', () => ({
+  useWebGPU: () => ({ supported: true, checking: false, reason: null }),
+}));
+
+vi.mock('@/hooks/useIfc', () => ({
+  useIfc: () => ({
+    geometryResult: { meshes: [], totalVertices: 0, totalTriangles: 0 },
+    ifcDataStore: null,
+    loadFile: vi.fn(async () => {}),
+    loading: false,
+    models: new Map(),
+    clearAllModels: vi.fn(),
+    addModel: vi.fn(async () => 'stub-model-id'),
+  }),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const { EmbedViewer } = await import('./EmbedViewer.js');
+const { useViewerStore } = await import('@/store');
+
+const AXIS = '[data-testid="viewport-axis-helper"]';
+const SCALE = '[data-testid="viewport-scale-readout"]';
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+/** `parseUrlParams()` runs in a `useState` initialiser — set the search first. */
+function setSearch(search: string): void {
+  window.history.replaceState({}, '', `/${search}`);
+}
+
+function renderEmbedViewer(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(React.createElement(EmbedViewer));
+  });
+  mounted.push({ root, container });
+  return container;
+}
+
+beforeEach(() => {
+  // The axis helper and the scale readout live inside a `!isMobile` branch of
+  // `ViewportOverlays`; a mobile store would make every "absent" assertion
+  // below pass for the wrong reason.
+  useViewerStore.setState({ isMobile: false, selectedStoreys: new Set<number>() });
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(new ArrayBuffer(8), { status: 200 })));
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.unstubAllGlobals();
+  setSearch('');
+});
+
+describe('EmbedViewer: ?hideAxis= / ?hideScale=', () => {
+  it('draws both the axis helper and the scale readout when neither param is set', () => {
+    setSearch('');
+    const container = renderEmbedViewer();
+
+    expect(container.querySelector(AXIS)).not.toBeNull();
+    expect(container.querySelector(SCALE)).not.toBeNull();
+  });
+
+  it('removes the axis helper for ?hideAxis=true, and nothing else', () => {
+    setSearch('?hideAxis=true');
+    const container = renderEmbedViewer();
+
+    expect(container.querySelector(AXIS)).toBeNull();
+    expect(container.querySelector(SCALE)).not.toBeNull();
+  });
+
+  it('removes the scale readout for ?hideScale=true, and nothing else', () => {
+    setSearch('?hideScale=true');
+    const container = renderEmbedViewer();
+
+    expect(container.querySelector(SCALE)).toBeNull();
+    expect(container.querySelector(AXIS)).not.toBeNull();
+  });
+
+  it('removes both when both params are set', () => {
+    setSearch('?hideAxis=true&hideScale=true');
+    const container = renderEmbedViewer();
+
+    expect(container.querySelector(AXIS)).toBeNull();
+    expect(container.querySelector(SCALE)).toBeNull();
+  });
+
+  it('keeps both when the params are present but not "true"', () => {
+    // `parseUrlParams` only sets the flag for the exact string "true"; this
+    // pins that the render path agrees rather than treating any value as set.
+    setSearch('?hideAxis=false&hideScale=0');
+    const container = renderEmbedViewer();
+
+    expect(container.querySelector(AXIS)).not.toBeNull();
+    expect(container.querySelector(SCALE)).not.toBeNull();
+  });
+});

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -431,7 +431,7 @@ export function EmbedViewer() {
             computedIsolatedIds={computedIsolatedIds}
             modelIdToIndex={modelIdToIndex}
           />
-          <ViewportOverlays hideViewCube />
+          <ViewportOverlays hideViewCube hideAxis={urlParams.hideAxis} hideScale={urlParams.hideScale} />
         </div>
       )}
     </div>

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -24,7 +24,18 @@ import { BasepointOverlay } from './BasepointOverlay';
 import { PointCloudPanel } from './PointCloudPanel';
 import { Crosshair } from 'lucide-react';
 
-export function ViewportOverlays({ hideViewCube = false }: { hideViewCube?: boolean } = {}) {
+/**
+ * Overlay chrome drawn on top of the 3D viewport.
+ *
+ * The three `hide*` props exist for the embed (`?hideViewCube=`, `?hideAxis=`,
+ * `?hideScale=`): a host iframe is often too small for the full chrome. They
+ * default to `false`, so the standalone viewer is unaffected.
+ */
+export function ViewportOverlays({
+  hideViewCube = false,
+  hideAxis = false,
+  hideScale = false,
+}: { hideViewCube?: boolean; hideAxis?: boolean; hideScale?: boolean } = {}) {
   const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
   const hiddenEntities = useViewerStore((s) => s.hiddenEntities);
   const isolatedEntities = useViewerStore((s) => s.isolatedEntities);
@@ -263,18 +274,26 @@ export function ViewportOverlays({ hideViewCube = false }: { hideViewCube?: bool
         </div>
       )}
 
-      {/* Basepoint toggle + Axis Helper + Scale Bar — desktop only; mobile keeps the viewport unobstructed */}
+      {/* Basepoint toggle + Axis Helper + Scale Bar — desktop only; mobile keeps the viewport unobstructed.
+          `hideScale`/`hideAxis` drop their own item only: the BasepointToggleButton stays reachable
+          even with both set, so hiding the scene-reference readouts never hides the toggle too. */}
       {!isMobile && (
         <div className="absolute bottom-4 left-4 flex flex-col-reverse items-start gap-3">
-          <div className="flex flex-col items-start gap-1">
-            <div className="h-1 w-24 bg-foreground/80 rounded-full" />
-            <span className="text-xs text-foreground/80">{formatScale(scale)}</span>
-          </div>
-          <AxisHelper
-            ref={axisHelperRef}
-            rotationX={initialRotationX}
-            rotationY={initialRotationY}
-          />
+          {!hideScale && (
+            <div className="flex flex-col items-start gap-1" data-testid="viewport-scale-readout">
+              <div className="h-1 w-24 bg-foreground/80 rounded-full" />
+              <span className="text-xs text-foreground/80">{formatScale(scale)}</span>
+            </div>
+          )}
+          {!hideAxis && (
+            <div data-testid="viewport-axis-helper">
+              <AxisHelper
+                ref={axisHelperRef}
+                rotationX={initialRotationX}
+                rotationY={initialRotationY}
+              />
+            </div>
+          )}
           <BasepointToggleButton />
         </div>
       )}


### PR DESCRIPTION
`Refs #2934` (item 5).

## The gap

Three documented embed URL params were parse-only. `parseUrlParams` writes them and nothing reads them:

| param | write site | read site (before) |
| --- | --- | --- |
| `hideAxis` | `apps/viewer-embed/src/bridge/urlParams.ts:100-101` | none |
| `hideScale` | `apps/viewer-embed/src/bridge/urlParams.ts:103-104` | none |
| `controls` | `apps/viewer-embed/src/bridge/urlParams.ts:92-94` | none |

`ViewportOverlays` took a single `hideViewCube` prop; the scale readout and the axis helper rendered unconditionally. `EmbedViewer.tsx` passed `<ViewportOverlays hideViewCube />` and nothing else. So `?hideAxis=true` parsed correctly and left the axis on screen.

An earlier comment on #2934 recorded item 5 as fixed. It was not — this was verified by running, not by reading.

## The fix

`hideViewCube` is the sibling that WAS wired, and this follows it exactly: a prop on `ViewportOverlays` guarding the JSX, passed from the embed's one call site. Both flags default to `false`, so the standalone viewer (`ViewportContainer.tsx:1520`, `<ViewportOverlays />`) is unchanged.

**What the new conditionals displace:**

- The guards drop their own item only. `BasepointToggleButton` shares the same bottom-left column and stays reachable with both flags set.
- With `hideScale` on, `setOnScaleChange` is still registered and `setScale` still runs — matching `hideViewCube`, which likewise leaves `setOnCameraRotationChange` in place. No second mechanism was introduced.
- With `hideAxis` on, `axisHelperRef.current` stays null, so the rotation callback's `axisHelperRef.current?.updateRotation(...)` becomes a no-op. That was its only reader.

## `?controls=` is deliberately still parse-only

`controls?: 'orbit' | 'pan' | 'all' | 'none'` is documented only as "Camera controls mode" (`packages/embed-sdk/src/index.ts:52`). Nothing in the repo pins what the four values mean:

- Camera input is spread across `useMouseControls.ts`, `useTouchControls.ts`, `useKeyboardControls.ts` and `useSpaceMouseControls.ts` — four independent hooks, each binding orbit and pan separately.
- `'orbit'` could mean orbit-only-no-pan, or orbit-plus-zoom. `'none'` could mean no camera movement, or no interaction at all (including selection picking). Zoom is a fifth verb the enum never names.

Picking one would be inventing protocol rather than implementing it. Left for a maintainer ruling; the parse site is unchanged and still valid.

## Proof

RED, before the fix (`apps/viewer-embed/src/components/EmbedViewer.overlays.test.ts`):

```
× removes the axis helper for ?hideAxis=true, and nothing else
× removes the scale readout for ?hideScale=true, and nothing else
× removes both when both params are set
AssertionError: expected <div …(1)><div …(2)>…(1)</div></div> to be null
Tests  3 failed | 2 passed (5)
```

GREEN, after: `Tests  5 passed (5)`; full embed suite `Test Files 9 passed (9) / Tests 180 passed (180)`.

The test renders the **real** `ViewportOverlays` inside the real `EmbedViewer` — the sibling `EmbedViewer.urlParams.test.ts` mocks the overlays out, this one deliberately does not. Every case asserts **both** directions (the other overlay is still present), and the no-param case asserts both are, so it is not vacuous and an implementation that hides them always would fail.

Mutation checks (each restored by inverse edit, byte-identity proved with `diff`):

| mutation | result |
| --- | --- |
| `{!hideAxis && (` → `{true && (` | 2 failed — `expected <div …> to be null` |
| `{!hideScale && (` → `{true && (` | 2 failed — `expected <div …> to be null` |
| both guards → `{false && (` (hide always) | 4 failed, incl. the default case — `expected null not to be null` |
| drop `hideAxis={…}` from the `EmbedViewer` call site | 2 failed |

Gates: `check-module-size` OK (the call site is kept to one line so `EmbedViewer.tsx` stays at its 439-line budget — not raised), `check-test-wiring` OK, `check-test-glob-coverage` OK, `check-source-text-assertions` OK, `tsc --noEmit` clean for both `apps/viewer` and `apps/viewer-embed`.

No changeset: both `apps/viewer` and `apps/viewer-embed` are private, and neither `@ifc-lite/embed-protocol` nor `@ifc-lite/embed-sdk` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Embedded viewers can now independently hide the axis helper and scale readout using URL options.
  - The view cube remains hidden in embedded viewers, while the basepoint toggle stays available.

- **Bug Fixes**
  - Improved overlay rendering behavior for different combinations and values of visibility options.

- **Tests**
  - Added comprehensive coverage for default, combined, independent, and invalid overlay visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->