### PR TITLE
fix(ifcx): export each entity's own IFC class, and keep IFC4.3 facility levels in the spatial tree

### DIFF
--- a/.changeset/ifcx-class-and-spatial-derived.md
+++ b/.changeset/ifcx-class-and-spatial-derived.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/ifcx': patch
+---
+
+IFCX export writes each entity's own IFC class, and the IFCX spatial tree keeps its IFC4.3 facility levels.
+
+The writer mapped an entity's `typeEnum` to the `bsi::ifc::class` code through a 26-row table written out by hand. `IfcTypeEnum` has 128 members and its numbering had moved on since the table was typed, so the table was both incomplete and shifted against the enum it claimed to decode: 14 of its 26 rows named a different class than the id actually holds. An `IfcStair` was exported as `IfcRoof`, an `IfcMember` as `IfcPile`, an `IfcDistributionElement` as `IfcOpeningElement` — a wrong class written into the file, not a display glitch — and the 102 ids with no row at all (every MEP, infrastructure and furniture class) lost their class attribute entirely. The synthesized `ifc:<Type>.<expressId>` path of a GlobalId-less entity carried the same wrong name. The class now comes from the entity table, which resolves an override, then the enum, then the raw parsed class name — so `IfcAirTerminal`, which the enum does not carry, also keeps its own name.
+
+Separately, the set deciding which classes are *levels* of the IFCX spatial tree listed the five building-storey levels and none of IFC4.3's twelve. Because the same set is the stop condition for element collection, an infrastructure model's `IfcRoad` / `IfcRoadPart` were not merely missing from the tree — they and everything beneath them were flattened into the site's element list, and an `IfcSite -> IfcRoad` edge was reported as containment rather than aggregation. Both call sites now read `SPATIAL_STRUCTURE_TYPE_ENUMS` from `@ifc-lite/data`, the same answer the parser and the viewer's hierarchy already use.

--- a/packages/ifcx/src/index.ts
+++ b/packages/ifcx/src/index.ts
@@ -10,7 +10,7 @@
  */
 
 import type { IfcxFile, ComposedNode } from './types.js';
-import { ATTR, isTypedPropertyValue, parseV5aKey } from './types.js';
+import { ATTR, SPATIAL_TYPES, isTypedPropertyValue, parseV5aKey } from './types.js';
 import { composeIfcx, findRoots } from './composition.js';
 import { extractEntities } from './entity-extractor.js';
 import { extractProperties, routesToQuantityTable } from './property-extractor.js';
@@ -327,10 +327,10 @@ function determineRelationshipType(
   return RelationshipType.ContainsElements;
 }
 
+/** The tree builder's gate, not a second copy of it: a hand-written duplicate
+ *  here decided Aggregates vs ContainsElements and had drifted from that one. */
 function isSpatialElement(typeCode: string | undefined): boolean {
-  if (!typeCode) return false;
-  const spatialTypes = ['IfcProject', 'IfcSite', 'IfcBuilding', 'IfcBuildingStorey', 'IfcSpace'];
-  return spatialTypes.includes(typeCode);
+  return typeCode ? SPATIAL_TYPES.has(typeCode) : false;
 }
 
 /**

--- a/packages/ifcx/src/spatial-types-authority.test.ts
+++ b/packages/ifcx/src/spatial-types-authority.test.ts
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Which IFC classes this package treats as spatial structure.
+ *
+ * `SPATIAL_TYPES` is the gate in `hierarchy-builder.ts`: a class it does not
+ * carry is not recursed into as a level of the spatial tree, and — because
+ * `collectElementIds` uses the same set as its stop condition — is instead
+ * flattened into its parent's *element* list along with everything beneath it.
+ * So an IFC4.3 infrastructure file (`IfcSite / IfcRoad / IfcRoadPart / ...`)
+ * lost every level below the site and listed the road itself as a piece of
+ * furniture would have been listed.
+ *
+ * `@ifc-lite/data`'s `SPATIAL_STRUCTURE_TYPE_ENUMS` is this repo's single
+ * answer to "is this entity part of the spatial tree" — the parser, the
+ * viewer's hierarchy tree and the visibility adapters all read it. This file
+ * pins that the IFCX path answers the same question the same way, in BOTH
+ * directions, so the two cannot drift apart again.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  RelationshipType,
+  SPATIAL_STRUCTURE_TYPE_ENUMS,
+  IfcTypeEnumToString,
+  isSpatialStructureTypeName,
+} from '@ifc-lite/data';
+import { buildHierarchy } from './hierarchy-builder.js';
+import { parseIfcx } from './index.js';
+import { ATTR, SPATIAL_TYPES } from './types.js';
+import type { ComposedNode } from './types.js';
+import type { SpatialNode } from '@ifc-lite/data';
+
+function node(path: string, classCode?: string): ComposedNode {
+  const attributes = new Map<string, unknown>();
+  if (classCode) {
+    attributes.set(ATTR.CLASS, { code: classCode, uri: `urn:${classCode}` });
+  }
+  return { path, attributes, children: new Map() };
+}
+
+function link(parent: ComposedNode, ...children: ComposedNode[]): void {
+  for (const child of children) parent.children.set(child.path, child);
+}
+
+describe('SPATIAL_TYPES agrees with the shared spatial-structure authority', () => {
+  it('carries exactly the authority names, neither more nor fewer', () => {
+    const authority = SPATIAL_STRUCTURE_TYPE_ENUMS.map((t) => IfcTypeEnumToString(t));
+    // Anti-vacuity: a truncated authority would make the set comparison below
+    // pass against an equally truncated SPATIAL_TYPES.
+    assert.ok(
+      authority.length >= 17,
+      `expected the full spatial vocabulary from @ifc-lite/data, got ${authority.length}`,
+    );
+    assert.ok(
+      authority.every((name) => name !== 'Unknown'),
+      `authority must not contain the enum miss sentinel: ${authority.join(', ')}`,
+    );
+
+    const missing = authority.filter((name) => !SPATIAL_TYPES.has(name));
+    const extra = [...SPATIAL_TYPES].filter((name) => !authority.includes(name));
+    assert.deepStrictEqual({ missing, extra }, { missing: [], extra: [] });
+  });
+
+  it('carries the IFC4.3 facilities and their parts by name', () => {
+    // Named, not counted: a size floor of 5 was met by the old list while
+    // every one of these was absent.
+    for (const name of [
+      'IfcProject',
+      'IfcSite',
+      'IfcBuilding',
+      'IfcBuildingStorey',
+      'IfcSpace',
+      'IfcSpatialZone',
+      'IfcFacility',
+      'IfcFacilityPart',
+      'IfcFacilityPartCommon',
+      'IfcBridge',
+      'IfcBridgePart',
+      'IfcRoad',
+      'IfcRoadPart',
+      'IfcRailway',
+      'IfcRailwayPart',
+      'IfcMarineFacility',
+      'IfcMarinePart',
+    ]) {
+      assert.ok(SPATIAL_TYPES.has(name), `${name} missing from SPATIAL_TYPES`);
+      assert.ok(isSpatialStructureTypeName(name), `${name} missing from the authority`);
+    }
+  });
+
+  it('does not swallow a physical element', () => {
+    // Negative control: the set is a gate, so a class wrongly inside it stops
+    // being collected as an element at all.
+    for (const name of ['IfcWall', 'IfcSlab', 'IfcRoof', 'IfcZone', 'IfcGroup']) {
+      assert.ok(!SPATIAL_TYPES.has(name), `${name} must not be treated as spatial structure`);
+    }
+  });
+});
+
+describe('buildHierarchy nests an IFC4.3 facility', () => {
+  it('recurses through IfcRoad / IfcRoadPart instead of flattening them into the site', () => {
+    const project = node('project', 'IfcProject');
+    const site = node('site', 'IfcSite');
+    const road = node('road', 'IfcRoad');
+    const roadPart = node('roadpart', 'IfcRoadPart');
+    const wall = node('wall', 'IfcWall');
+    link(project, site);
+    link(site, road);
+    link(road, roadPart);
+    link(roadPart, wall);
+
+    const composed = new Map<string, ComposedNode>();
+    for (const n of [project, site, road, roadPart, wall]) composed.set(n.path, n);
+    const pathToId = new Map<string, number>([
+      ['project', 1],
+      ['site', 2],
+      ['road', 3],
+      ['roadpart', 4],
+      ['wall', 10],
+    ]);
+
+    const hierarchy = buildHierarchy(composed, pathToId);
+    const siteNode = hierarchy.project.children[0] as SpatialNode | undefined;
+    assert.ok(siteNode, 'expected the site under the project');
+
+    // The road and its part are LEVELS, not contents: before the fix the site
+    // reported elements [3, 4, 10] and had no spatial children at all.
+    assert.deepStrictEqual(siteNode.elements, []);
+    const roadNode = siteNode.children[0] as SpatialNode | undefined;
+    assert.ok(roadNode, 'expected IfcRoad as a spatial child of the site');
+    assert.strictEqual(roadNode.expressId, 3);
+    const roadPartNode = roadNode.children[0] as SpatialNode | undefined;
+    assert.ok(roadPartNode, 'expected IfcRoadPart as a spatial child of the road');
+    assert.strictEqual(roadPartNode.expressId, 4);
+
+    // The wall is the only element, and it hangs off the road part.
+    assert.deepStrictEqual(roadPartNode.elements, [10]);
+    // It stays reachable from the site it sits under.
+    assert.deepStrictEqual(hierarchy.bySite.get(2), [10]);
+  });
+});
+
+describe('parseIfcx classifies a facility edge as decomposition', () => {
+  /**
+   * `determineRelationshipType` asks the same "is this spatial" question as
+   * the tree builder and used to answer it from its own copy of the list.
+   * A spatial-to-spatial edge is an AGGREGATION (IfcRelAggregates); only a
+   * spatial-to-element edge is containment. With the facilities missing, an
+   * `IfcSite -> IfcRoad` edge came back ContainsElements — the road filed as
+   * a piece of equipment standing in the site.
+   */
+  it('reports IfcSite -> IfcRoad as Aggregates, not ContainsElements', async () => {
+    const ifcClass = (code: string) => ({
+      code,
+      uri: `https://identifier.buildingsmart.org/uri/buildingsmart/ifc/5/class/${code}`,
+    });
+    const doc = {
+      header: { id: 'test/facility-edges.ifcx', ifcxVersion: 'ifcx_alpha', dataVersion: '1.0.0' },
+      imports: [],
+      schemas: {},
+      data: [
+        {
+          path: 'project-1',
+          attributes: { [ATTR.CLASS]: ifcClass('IfcProject') },
+          children: { site: 'site-1' },
+        },
+        {
+          path: 'site-1',
+          attributes: { [ATTR.CLASS]: ifcClass('IfcSite') },
+          children: { road: 'road-1' },
+        },
+        {
+          path: 'road-1',
+          attributes: { [ATTR.CLASS]: ifcClass('IfcRoad') },
+          children: { pavement: 'pavement-1' },
+        },
+        { path: 'pavement-1', attributes: { [ATTR.CLASS]: ifcClass('IfcPavement') } },
+      ],
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(doc));
+    const buffer = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer;
+
+    const result = await parseIfcx(buffer);
+    const siteId = result.pathToId.get('site-1');
+    const roadId = result.pathToId.get('road-1');
+    const pavementId = result.pathToId.get('pavement-1');
+    // Anti-vacuity: an empty getRelated() would satisfy nothing below if the
+    // nodes never became entities in the first place.
+    assert.ok(siteId !== undefined && roadId !== undefined && pavementId !== undefined);
+
+    assert.deepStrictEqual(
+      result.relationships.getRelated(siteId, RelationshipType.Aggregates, 'forward'),
+      [roadId],
+    );
+    assert.deepStrictEqual(
+      result.relationships.getRelated(siteId, RelationshipType.ContainsElements, 'forward'),
+      [],
+    );
+    // Negative control, the other direction of the same rule: a spatial ->
+    // physical-element edge must STAY containment.
+    assert.deepStrictEqual(
+      result.relationships.getRelated(roadId, RelationshipType.ContainsElements, 'forward'),
+      [pavementId],
+    );
+    assert.deepStrictEqual(
+      result.relationships.getRelated(roadId, RelationshipType.Aggregates, 'forward'),
+      [],
+    );
+  });
+});

--- a/packages/ifcx/src/types.ts
+++ b/packages/ifcx/src/types.ts
@@ -7,6 +7,8 @@
  * Based on buildingSMART IFC5-development schema
  */
 
+import { IfcTypeEnumToString, SPATIAL_STRUCTURE_TYPE_ENUMS } from '@ifc-lite/data';
+
 // ============================================================================
 // Core IFCX File Structure
 // ============================================================================
@@ -268,13 +270,24 @@ export interface IfcClass {
 // Spatial Types
 // ============================================================================
 
-export const SPATIAL_TYPES = new Set([
-  'IfcProject',
-  'IfcSite',
-  'IfcBuilding',
-  'IfcBuildingStorey',
-  'IfcSpace',
-]);
+/**
+ * The IFC classes that are LEVELS of the spatial tree rather than contents of
+ * one. `hierarchy-builder.ts` recurses into a child in this set and stops
+ * collecting elements at one, so a class missing here is not merely absent
+ * from the tree — it and everything beneath it are flattened into the
+ * parent's element list.
+ *
+ * Derived from `@ifc-lite/data`'s `SPATIAL_STRUCTURE_TYPE_ENUMS`, this repo's
+ * single answer to "is this entity part of the spatial tree", rather than
+ * listed again here. The hand-written list this replaced named the five
+ * building-storey levels and none of IFC4.3's twelve: `IfcSpatialZone` and
+ * the facility classes (`IfcRoad`, `IfcBridge`, `IfcRailway`,
+ * `IfcMarineFacility`, `IfcFacility` and their `*Part` counterparts), so an
+ * infrastructure model's whole hierarchy collapsed onto its site.
+ */
+export const SPATIAL_TYPES: Set<string> = new Set(
+  SPATIAL_STRUCTURE_TYPE_ENUMS.map((typeEnum) => IfcTypeEnumToString(typeEnum)),
+);
 
 export const BUILDING_ELEMENT_TYPES = new Set([
   'IfcWall',

--- a/packages/ifcx/src/writer-class-name.test.ts
+++ b/packages/ifcx/src/writer-class-name.test.ts
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The IFC class an IFCX export writes for each entity.
+ *
+ * `bsi::ifc::class` is the node's IFC identity in the exported file: every
+ * consumer that reads an .ifcx back — this package's own reader, the viewer's
+ * hierarchy and every other IFC5 tool — takes the class from that attribute
+ * and from nowhere else. So a wrong code here is not a display glitch, it is a
+ * wrong value written into a file that outlives the session.
+ *
+ * The writer used to map the entity's `typeEnum` to a class name through a
+ * 26-row table written out by hand. `IfcTypeEnum` has 128 members, so the
+ * table could only ever answer for a fraction of them — and because the enum's
+ * numbering had moved on since the table was typed, the rows it *did* have
+ * were shifted against it: enum 17 is `IfcStair`, the table said `IfcRoof`.
+ * Every stair in an exported model came back a roof.
+ *
+ * These tests derive the expectation from the entity table itself
+ * (`EntityTable.getTypeName`, which resolves overrides, then the enum, then
+ * the raw parsed class name) rather than restating a list, so a class added to
+ * the schema is covered the day the enum learns it. The sweep is the real
+ * guard; the named cases below it exist so a regression names the entity it
+ * broke instead of a count.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { StringTable, EntityTableBuilder, IfcTypeEnum, IfcTypeEnumToString } from '@ifc-lite/data';
+import type { EntityTable } from '@ifc-lite/data';
+import { exportToIfcx } from './writer.js';
+import type { IfcxFile, IfcxNode } from './types.js';
+
+/**
+ * Every concrete `IfcTypeEnum` member, by name. `Unknown` is the enum's own
+ * "no member holds this id" sentinel and is not an IFC class, so it is
+ * excluded here and exercised by the negative control instead.
+ */
+function enumMemberNames(): string[] {
+  return Object.entries(IfcTypeEnum)
+    .filter(([name, value]) => typeof value === 'number' && name !== 'Unknown')
+    .map(([name]) => name);
+}
+
+function exportClasses(classNames: string[]): Map<string, string | undefined> {
+  const strings = new StringTable();
+  const builder = new EntityTableBuilder(Math.max(classNames.length, 1), strings);
+  classNames.forEach((className, i) => {
+    builder.add(i + 1, className.toUpperCase(), `GID-${i + 1}`, `n${i + 1}`, '', '', false, false);
+  });
+  const entities = builder.build();
+
+  const file = JSON.parse(
+    exportToIfcx({ entities, strings }, { includeProperties: false }),
+  ) as IfcxFile;
+
+  const byPath = new Map<string, string | undefined>();
+  for (const node of file.data as IfcxNode[]) {
+    const cls = (node.attributes as Record<string, { code?: string }> | undefined)?.[
+      'bsi::ifc::class'
+    ];
+    byPath.set(node.path, cls?.code);
+  }
+  return byPath;
+}
+
+describe('IFCX export writes each entity its own IFC class', () => {
+  it('agrees with the entity table for every IfcTypeEnum member', () => {
+    const names = enumMemberNames();
+    // Anti-vacuity: an empty or truncated member list would make the sweep
+    // below pass without comparing anything.
+    assert.ok(
+      names.length >= 100,
+      `expected IfcTypeEnum to carry the full IFC class vocabulary, got ${names.length} members`,
+    );
+
+    const byPath = exportClasses(names);
+    assert.strictEqual(
+      byPath.size,
+      names.length,
+      `expected one exported node per class, got ${byPath.size} for ${names.length} classes`,
+    );
+
+    const wrong: string[] = [];
+    names.forEach((expected, i) => {
+      const actual = byPath.get(`GID-${i + 1}`);
+      if (actual !== expected) wrong.push(`${expected} -> ${actual ?? '(no class written)'}`);
+    });
+    assert.deepStrictEqual(wrong, []);
+  });
+
+  it('writes the class the hand table got wrong or never had', () => {
+    // Named, not counted: a floor on the sweep above would survive dropping
+    // any one of these. Each was observed misexported before the fix — the
+    // first group as a DIFFERENT class, the second with no class at all.
+    const required = [
+      'IfcStair',
+      'IfcRamp',
+      'IfcRoof',
+      'IfcCovering',
+      'IfcCurtainWall',
+      'IfcRailing',
+      'IfcPile',
+      'IfcMember',
+      'IfcPlate',
+      'IfcOpeningElement',
+      'IfcDistributionElement',
+      'IfcFlowSegment',
+      'IfcPipeSegment',
+      'IfcDuctSegment',
+      'IfcFurniture',
+      'IfcRoad',
+      'IfcBridge',
+      'IfcFacilityPart',
+      'IfcSpatialZone',
+      'IfcStairFlight',
+    ];
+    const byPath = exportClasses(required);
+    required.forEach((expected, i) => {
+      assert.strictEqual(
+        byPath.get(`GID-${i + 1}`),
+        expected,
+        `${expected} was exported as ${byPath.get(`GID-${i + 1}`) ?? '(no class written)'}`,
+      );
+    });
+  });
+
+  it('keeps a class the enum does not carry, from the parsed type name', () => {
+    // IfcAirTerminal has no IfcTypeEnum member; the entity table still knows
+    // its parsed class, and the export must not drop it.
+    assert.strictEqual(
+      IfcTypeEnumToString(IfcTypeEnum.Unknown),
+      'Unknown',
+      'IfcTypeEnum.Unknown must stay the enum sentinel for this test to mean anything',
+    );
+    const byPath = exportClasses(['IfcAirTerminal']);
+    assert.strictEqual(byPath.get('GID-1'), 'IfcAirTerminal');
+  });
+
+  it('writes no class, and no invented one, when the entity has none', () => {
+    // Negative control. An entity table row whose type resolves to nothing at
+    // all must leave `bsi::ifc::class` off the node rather than emit
+    // `Unknown` (not an IFC class) or fall through to some neighbouring code.
+    const entities = {
+      count: 1,
+      expressId: Uint32Array.from([1]),
+      typeEnum: Uint16Array.from([IfcTypeEnum.Unknown % 65536]),
+      globalId: Uint32Array.from([1]),
+      name: Uint32Array.from([0]),
+      description: Uint32Array.from([0]),
+      getTypeName: () => 'Unknown',
+    } as unknown as EntityTable;
+    const strings = { get: (idx: number) => (idx === 1 ? 'GID-1' : '') };
+
+    const file = JSON.parse(
+      exportToIfcx({ entities, strings }, { includeProperties: false }),
+    ) as IfcxFile;
+    const node = (file.data as IfcxNode[]).find((n) => n.path === 'GID-1');
+    assert.ok(node, 'expected the entity to be exported');
+    assert.strictEqual(
+      (node.attributes as Record<string, unknown> | undefined)?.['bsi::ifc::class'],
+      undefined,
+    );
+  });
+
+  it('names the synthesized path of a GlobalId-less entity after its real class', () => {
+    // `generatePath` shares the same class lookup, so the shifted table
+    // mislabelled the fallback path too: a stair became `ifc:IfcRoof.7`.
+    const strings = new StringTable();
+    const builder = new EntityTableBuilder(1, strings);
+    builder.add(7, 'IFCSTAIR', '', 'stair-with-no-guid', '', '', false, false);
+    const entities = builder.build();
+
+    const file = JSON.parse(
+      exportToIfcx({ entities, strings }, { includeProperties: false }),
+    ) as IfcxFile;
+    const paths = (file.data as IfcxNode[]).map((n) => n.path);
+    assert.ok(
+      paths.includes('ifc:IfcStair.7'),
+      `expected ifc:IfcStair.7 among ${JSON.stringify(paths)}`,
+    );
+  });
+});

--- a/packages/ifcx/src/writer.ts
+++ b/packages/ifcx/src/writer.ts
@@ -11,7 +11,7 @@
 import type { IfcxFile, IfcxNode, IfcxHeader, ImportNode } from './types.js';
 import type { EntityTable, PropertyTable, PropertySet, SpatialHierarchy } from '@ifc-lite/data';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
-import { IFCX_VERSION } from '@ifc-lite/data';
+import { IFCX_VERSION, IfcTypeEnum, IfcTypeEnumToString } from '@ifc-lite/data';
 
 // ============================================================================
 // Standard IFCX schema imports
@@ -181,7 +181,7 @@ export class IfcxWriter {
       const attributes: Record<string, unknown> = {};
 
       // Add IFC class (requires both code and uri per official schema)
-      const typeName = this.getTypeName(typeEnum);
+      const typeName = this.getTypeName(expressId, typeEnum);
       if (typeName) {
         attributes['bsi::ifc::class'] = {
           code: typeName,
@@ -302,40 +302,31 @@ export class IfcxWriter {
   }
 
   /**
-   * Get type name from enum
+   * The IFC class name to write as `bsi::ifc::class`, or undefined when the
+   * entity has no class to write.
+   *
+   * Derived from the entity table, not enumerated. `EntityTable.getTypeName`
+   * resolves a type override first, then the `IfcTypeEnum` member name, then
+   * the raw class name the parser read — so a class the enum has never heard
+   * of (`IfcAirTerminal`) still exports under its own name. `IfcTypeEnumToString`
+   * is the fallback for the structural table stubs that carry a `typeEnum`
+   * column but no `getTypeName`.
+   *
+   * The hand-written enum->name table this replaced was both incomplete and
+   * SHIFTED against the enum it claimed to decode: it answered for 26 of the
+   * enum's 128 members, and 14 of those 26 rows named a different class than
+   * the id actually holds (17 is `IfcStair`, the table said `IfcRoof`). So a
+   * stair exported as a roof, a member as a pile, a distribution element as an
+   * opening — and every MEP, infrastructure and furniture class fell through
+   * to `undefined` and lost its class attribute entirely.
    */
-  private getTypeName(typeEnum: number): string | undefined {
-    // Map common type enums to IFC class names
-    const typeMap: Record<number, string> = {
-      1: 'IfcProject',
-      2: 'IfcSite',
-      3: 'IfcBuilding',
-      4: 'IfcBuildingStorey',
-      5: 'IfcSpace',
-      10: 'IfcWall',
-      11: 'IfcWallStandardCase',
-      12: 'IfcDoor',
-      13: 'IfcWindow',
-      14: 'IfcSlab',
-      15: 'IfcColumn',
-      16: 'IfcBeam',
-      17: 'IfcRoof',
-      18: 'IfcStair',
-      19: 'IfcRailing',
-      20: 'IfcCurtainWall',
-      21: 'IfcCovering',
-      22: 'IfcPlate',
-      23: 'IfcMember',
-      24: 'IfcPile',
-      25: 'IfcFooting',
-      30: 'IfcFurnishingElement',
-      31: 'IfcSystemFurnitureElement',
-      32: 'IfcDistributionElement',
-      33: 'IfcBuildingElementProxy',
-      40: 'IfcOpeningElement',
-    };
-
-    return typeMap[typeEnum] || undefined;
+  private getTypeName(expressId: number, typeEnum: number): string | undefined {
+    const table = this.data.entities as Partial<Pick<EntityTable, 'getTypeName'>>;
+    const fromTable = table.getTypeName?.(expressId);
+    // 'Unknown' is the table's own miss sentinel, not an IFC class.
+    if (fromTable && fromTable !== 'Unknown') return fromTable;
+    const fromEnum = IfcTypeEnumToString(typeEnum as IfcTypeEnum);
+    return fromEnum === 'Unknown' ? undefined : fromEnum;
   }
 
   /**
@@ -358,7 +349,7 @@ export class IfcxWriter {
    */
   private generatePath(expressId: number, typeEnum: number, globalId?: string): string {
     if (globalId) return globalId;
-    const typeName = this.getTypeName(typeEnum) || 'IfcElement';
+    const typeName = this.getTypeName(expressId, typeEnum) || 'IfcElement';
     return `ifc:${typeName}.${expressId}`;
   }
 

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -178,7 +178,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/extensions': '8156044843525017433',
   'packages/geometry': '11660269484074160622',
   'packages/ids': '9562546445799669442',
-  'packages/ifcx': '1612726670485322764',
+  'packages/ifcx': '1615700849439065844',
   'packages/lens': '14019022785021391214',
   'packages/lists': '3649993370543459600',
   'packages/mcp': '5906442248422039423',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -251,7 +251,7 @@
    468 packages/ifcx/src/federated-composition.ts
    412 packages/ifcx/src/geometry-extractor.ts
    706 packages/ifcx/src/index.ts
-   424 packages/ifcx/src/writer.ts
+   415 packages/ifcx/src/writer.ts
    464 packages/lens/src/engine.ts
    426 packages/lens/src/matching.ts
    417 packages/lens/src/types.ts


### PR DESCRIPTION
Two hand-maintained tables in `@ifc-lite/ifcx` diverged from the authority they encode. Both were found by diffing them mechanically against that authority, and both are reproduced below by running the real code path.

## 1. The exported IFC class is wrong, or missing (writes a wrong value into a file)

`IfcxWriter.getTypeName` decoded an entity's `typeEnum` through a 26-row enum→class map written out by hand. `IfcTypeEnum` has 128 members and its numbering had moved on since the map was typed, so the map was both incomplete and *shifted* against the enum it claimed to decode — 14 of its 26 rows named a different class than the id actually holds.

Driving the real `exportToIfcx` over an entity table built through `EntityTableBuilder`:

```
IfcStair               -> IfcRoof
IfcMember              -> IfcPile
IfcDistributionElement -> IfcOpeningElement
IfcFlowSegment         -> (no class written)
IfcRoad                -> (no class written)
```

`bsi::ifc::class` is the node's IFC identity in an .ifcx: this package's own reader, the viewer's hierarchy and every other IFC5 tool take the class from that attribute and nowhere else. The 102 ids with no row at all — every MEP, infrastructure and furniture class — lost the attribute entirely. `generatePath` shares the lookup, so a GlobalId-less stair was filed under the path `ifc:IfcRoof.7` as well.

The class now comes from `EntityTable.getTypeName`, which resolves a type override, then the enum, then the raw parsed class name — so `IfcAirTerminal`, which the enum does not carry, keeps its own name too. `IfcTypeEnumToString` remains as the fallback for structural table stubs that have a `typeEnum` column but no `getTypeName`.

## 2. IFC4.3 facilities are not levels of the IFCX spatial tree

`SPATIAL_TYPES` held five names against the seventeen in `@ifc-lite/data`'s `SPATIAL_STRUCTURE_TYPE_ENUMS` — the answer the parser, the viewer's hierarchy tree and the visibility adapters all already use. Missing: `IfcSpatialZone`, `IfcFacility`, `IfcFacilityPart`, `IfcFacilityPartCommon`, `IfcBridge`, `IfcBridgePart`, `IfcRoad`, `IfcRoadPart`, `IfcRailway`, `IfcRailwayPart`, `IfcMarineFacility`, `IfcMarinePart`.

The set is also the stop condition in `collectElementIds`, so the facility levels were not merely absent from the tree. `buildHierarchy` over Project → Site → IfcRoad → IfcRoadPart → IfcWall, before:

```
site: children [], elements [road, roadPart, wall]
```

after:

```
site: children [road], elements []
road -> roadPart -> elements [wall]     (wall still reachable via bySite)
```

`determineRelationshipType` in `index.ts` was a second hand-written copy of the same five names, and answered `ContainsElements` for the `IfcSite -> IfcRoad` edge where the decomposition of one spatial level into another is an aggregation. Both call sites now read the shared set, so the two cannot drift apart again.

## Tests

`writer-class-name.test.ts` and `spatial-types-authority.test.ts` derive their expectations from `IfcTypeEnum` and from `SPATIAL_STRUCTURE_TYPE_ENUMS` rather than restating a list, each with an anti-vacuity floor on the source it derives from, named required classes underneath the sweep (a count floor survives dropping the one entity that matters), and negative controls in both directions: an entity with no class at all must have no `bsi::ifc::class` written and no invented one, and a spatial→physical-element edge must stay containment.

Each guard was mutation-checked — broken one at a time, the specific failing assertion observed, then restored and proved byte-identical with `diff`.

`packages/ifcx` 171 tests pass; `@ifc-lite/export`, `@ifc-lite/merge`, `@ifc-lite/collab` and `@ifc-lite/clash` (the dependents) all pass unchanged. `check-module-size` stays green: `index.ts` came back to its recorded budget by shrinking, not by raising it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436