### PR TITLE
fix(scripts): derive the test-wiring remedy from the workflow, and un-binary a gate script

### DIFF
--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -32,12 +32,15 @@
  *
  *   2b. GATE TESTS. Every `*.test.mjs` under `scripts/` must be named by a
  *       workflow `node --test` invocation, literally or through a
- *       single-level `<dir>/*.test.mjs` glob. #3038 added such a catch-all
- *       for `scripts/*.test.mjs` and `scripts/lib/*.test.mjs`, so tests in
- *       those two directories are wired by construction — but only those two:
- *       a bare shell glob has no `**` behaviour, so a test landing in any
- *       other subdirectory of `scripts/` is unrun and unreported, and this is
- *       what notices. It is checked SEPARATELY from 2a on purpose: #3038's
+ *       single-level `<dir>/*.test.mjs` glob. #3038 added such a catch-all,
+ *       which has since grown to `scripts/`, `scripts/lib/`,
+ *       `scripts/fixtures/` and `scripts/docs/`, so tests in those
+ *       directories are wired by construction — but only those: a bare shell
+ *       glob has no `**` behaviour, so a test landing in any other
+ *       subdirectory of `scripts/` is unrun and unreported, and this is what
+ *       notices. The directory list is not restated in the failure message —
+ *       that message is derived from the workflow text, because the list here
+ *       drifted once already. It is checked SEPARATELY from 2a on purpose: #3038's
  *       catch-all would otherwise let a gate whose test runs, but whose
  *       script never executes, pass as "wired" — still the #3062 failure.
  *
@@ -608,7 +611,7 @@ export function auditScriptTests(root, workflows) {
     if (literals.has(rel)) return false;
     return !globDirs.has(rel.slice(0, rel.lastIndexOf('/')));
   });
-  return { offenders, examined: tests.length };
+  return { offenders, examined: tests.length, globDirs: [...globDirs].sort() };
 }
 
 /* ------------------------------------------------------------------ */
@@ -661,10 +664,20 @@ function main(root) {
     failed = true;
     console.error('\n❌ scripts/ test files no workflow runs (these NEVER execute):\n');
     for (const rel of gateTests.offenders) console.error(`   ${rel}`);
+    // Derived, not restated. This advice named `scripts/` and `scripts/lib/`
+    // as a fixed pair from #3038; the workflow glob later grew
+    // `scripts/fixtures/` and `scripts/docs/` and the sentence did not, so it
+    // was sending developers to two of the four directories that would have
+    // worked. Reading the same `globDirs` the verdict above is computed from
+    // makes the two structurally incapable of disagreeing.
+    const covered = gateTests.globDirs.map((d) => `\`${d}/*.test.mjs\``);
     console.error(
-      '\nThe glob catch-all in .github/workflows/test.yml covers `scripts/*.test.mjs` and\n' +
-        '`scripts/lib/*.test.mjs` only — a shell glob has no `**`. Move the file into one of\n' +
-        'those directories, or add a `node --test` step naming it.',
+      covered.length === 0
+        ? '\nNo workflow runs a `<dir>/*.test.mjs` catch-all at all, so every scripts/ test\n' +
+            'must be named by its own `node --test` step. Add one.'
+        : `\nThe glob catch-alls in .github/workflows/ cover ${covered.join(', ')}\n` +
+            'only — a shell glob has no `**`. Move the file into one of those directories, or\n' +
+            'add a `node --test` step naming it.',
     );
   }
 

--- a/scripts/check-test-wiring.test.mjs
+++ b/scripts/check-test-wiring.test.mjs
@@ -440,6 +440,29 @@ test('a scripts/ test in a subdirectory the single-level glob cannot reach is fl
   });
 });
 
+// The remedy line tells the developer WHICH directories the catch-all reaches.
+// It used to name `scripts/` and `scripts/lib/` as a hard-coded pair, written
+// when those were the only two; `scripts/fixtures/` (#3038 follow-up) and
+// `scripts/docs/` (#3200) were later added to the workflow glob and the advice
+// was not. Advice that lags the thing it describes sends the developer to the
+// wrong directory — so the message is DERIVED from the same `globDirs` the
+// verdict is derived from, and this pins that the two cannot drift apart.
+test('the remedy names every directory the catch-all actually covers, not a hard-coded pair', () => {
+  withTree({
+    extraSteps:
+      '      - name: Wider catch-all\n' +
+      '        run: node --test scripts/fixtures/*.test.mjs scripts/docs/*.test.mjs\n',
+  }, (root) => {
+    write(root, 'scripts/perf/bench.test.mjs', '// in none of the covered directories\n');
+    const { status, out } = run(root);
+    assert.equal(status, 1, out);
+    assert.match(out, /scripts\/perf\/bench\.test\.mjs/);
+    for (const dir of ['scripts/', 'scripts/lib/', 'scripts/fixtures/', 'scripts/docs/']) {
+      assert.ok(out.includes(`\`${dir}*.test.mjs\``), `remedy must name ${dir}, got:\n${out}`);
+    }
+  });
+});
+
 test('the same test named literally by a `node --test` step is wired', () => {
   withTree({
     extraSteps: '      - name: Doc samples\n        run: node --test scripts/docs/check-doc-samples.test.mjs\n',

--- a/scripts/moonshot/ci/check-report-numerals.mjs
+++ b/scripts/moonshot/ci/check-report-numerals.mjs
@@ -1097,7 +1097,7 @@ for (const bet of bets) {
       if (direct.kind) {
         // A marker on a numeral the artifact now backs is an excuse that has
         // outlived its reason: record it so the STALE list can report it.
-        if (markers.has(token)) usedMarkers.add(`${token} backed`);
+        if (markers.has(token)) usedMarkers.add(`${token}\0backed`);
         backed.push({ ...g, via: direct.kind, scale: direct.scale, src: direct.entry.src });
         continue;
       }
@@ -1122,7 +1122,7 @@ for (const bet of bets) {
       staleMarkers.push({
         token,
         reason,
-        why: usedMarkers.has(`${token} backed`)
+        why: usedMarkers.has(`${token}\0backed`)
           ? 'the artifact now BACKS this numeral -- delete the marker, the check covers it'
           : 'no unbacked numeral in this document matches this token -- the prose moved, delete the marker',
       });


### PR DESCRIPTION
Two small, independent fixes in `scripts/`. Both are the same shape: something that reads as fine because nobody can see the part that is wrong.

## 1. The test-wiring remedy named a stale directory list

`check-test-wiring.mjs` part 2b flags a `scripts/**/*.test.mjs` that no workflow runs. Its **verdict** is computed from the `<dir>/*.test.mjs` globs it parses out of the workflows. Its **remedy line** was a hard-coded sentence:

> The glob catch-all in .github/workflows/test.yml covers `scripts/*.test.mjs` and `scripts/lib/*.test.mjs` only

That pair was right when #3038 wrote it. The catch-all in `test.yml` has since grown `scripts/fixtures/*.test.mjs` and `scripts/docs/*.test.mjs` (both for exactly this reason, both noted in the workflow comment), and the sentence did not follow. A developer whose new test got flagged was told two of the four directories that would have fixed it.

The verdict was never wrong, only the advice — which is precisely why nothing caught it.

`auditScriptTests` now returns the `globDirs` set it already computes, and the message prints it. Advice and verdict now read the same value, so they cannot drift apart again. On the real tree:

```
The glob catch-alls in .github/workflows/ cover `scripts/*.test.mjs`,
`scripts/docs/*.test.mjs`, `scripts/fixtures/*.test.mjs`, `scripts/lib/*.test.mjs`
only — a shell glob has no `**`. ...
```

An empty set (no catch-all anywhere) gets its own remedy rather than an empty list. The header comment's directory list is marked as not being the source of truth.

**Pinned** by a regression case that gives the synthetic fixture a *wider* catch-all than the hard-coded pair and asserts every covered directory appears in the remedy. It reds against the old string with `remedy must name scripts/fixtures/`. Mutation-checked: truncating `globDirs` to two entries reds it with `remedy must name scripts/lib/`.

### Also verified while here: no `scripts/` test is actually dark

I set out from a report that eleven `scripts/**/*.test.mjs` never execute. **It does not reproduce.** Enumerating all 46 test files against every `node --test` invocation in `.github/workflows/`:

- **0** are unreachable from any workflow.
- 35 are named literally.
- 11 are reached *only* through the glob catch-all at `test.yml:997` — which is a step that runs, not a gap. That step is where the number eleven comes from: it is the count of tests not *individually* named.

All 11 were run anyway: **207 tests, 0 failures**. None were dark, and none are broken.

`check-test-wiring` already enforces the gate that would have been the proposed fix, and it fires — dropping a probe test into `scripts/perf/` reds it with exit 1 naming the file. No new gate was added, because the correct one already exists; what was wrong was only what it says when it fires.

## 2. `check-report-numerals.mjs` was the repo's only binary-classified source file

It held two **raw NUL bytes** (offsets 52355 and 53210), used as a composite-key separator in ``  `${token}\0backed` ``. Two bytes are enough for git and grep to classify a 64 KB JavaScript file as binary:

```
$ grep -c 'const' scripts/moonshot/ci/check-report-numerals.mjs
(nothing)
$ grep -ac 'const' scripts/moonshot/ci/check-report-numerals.mjs
200
```

An ordinary search of this repo silently reported "not found" for anything in this file.

Written as the two-character `\0` escape instead. `\0` in a template literal is U+0000, so the composite key is the same string.

**Proof of behavioural identity:**
- The new source, with `\0` mapped back to a NUL, is byte-identical to the old file — and only those two sites changed.
- ``  `${t}\0backed` === t + String.fromCharCode(0) + 'backed'  `` is `true`.
- Both versions run from the same path produce **byte-identical output over 1880 lines** (`diff` exit 0).
- `grep -c 'const'` now prints 200 without `-a`, and `git diff` renders it as text.

## Verification

Locally: `check-test-wiring` (48/48 regression tests, real tree exit 0), `check-source-text-assertions`, `check-test-glob-coverage`, `check-module-size` all pass, and the full `scripts/` glob catch-all runs 961 tests. Five failures in `scripts/typecheck-tests.test.mjs` are environmental in my worktree only (no `node_modules`, so `tsc` cannot resolve the fixture tsconfigs — `could not read the resolved config`); they are unrelated to this diff and reproduce on an untouched tree.

**GitHub Actions has not dispatched any run for this repository since 16:13 UTC**, repo-wide, including for fresh pushes. This branch will likely show no checks. That is the outage, not this change — every result above is local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated test-wiring guidance to cover all workflow directories.
  - Clarified remediation instructions when no catch-all workflow is configured.

- **Bug Fixes**
  - Improved validation messages so they accurately list every applicable directory.
  - Standardized marker tracking behavior without changing its results.

- **Tests**
  - Added regression coverage to ensure directory guidance remains complete and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->