### PR TITLE
fix(cache): carry the raw IFC class name through a cache round-trip

### DIFF
--- a/.changeset/cache-raw-type-name-column.md
+++ b/.changeset/cache-raw-type-name-column.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/cache': patch
+---
+
+A cache load no longer renames an element to "Unknown" when its IFC class has no `IfcTypeEnum` member.
+
+`EntityTable` carries a `rawTypeName` string column so `getTypeName()` can name a class the hand-maintained `IfcTypeEnum` does not cover — 101 of the 157 concrete `IfcProduct` subtypes in the bundled IFC4 registry, `IfcPump`, `IfcValve`, `IfcAirTerminal`, `IfcBoiler` and `IfcSurfaceFeature` among them. The cache writer never serialized that column and the reader's hand-rolled `EntityTable` had no fallback for it, so every such element came back from a cache hit as "Unknown" while the same model parsed from source named it correctly.
+
+The column is now written (cache format v15, appended after the type-range triples so a v14 section stays readable and version-gated on the way in), and `readEntities` builds its table through `entityTableFromColumns` — the same constructor the parser path uses — instead of keeping a second copy of the accessor closures. That duplicate is what let the fallback go missing on one side only.

--- a/packages/cache/src/cache.test.ts
+++ b/packages/cache/src/cache.test.ts
@@ -17,6 +17,8 @@ import {
   QuantityType,
   RelationshipType,
   isSpatialStructureTypeName,
+  IfcTypeEnum,
+  IfcTypeEnumFromString,
 } from '@ifc-lite/data';
 import { BinaryCacheWriter, BinaryCacheReader, xxhash64, SchemaVersion, FORMAT_VERSION } from './index.js';
 import type { CacheDataStore } from './types.js';
@@ -482,6 +484,65 @@ describe('BinaryCacheWriter and BinaryCacheReader', () => {
 
     expect(entities.getTypeName(4)).toBe('IfcBuildingStorey');
     expect(isSpatialStructureTypeName(entities.getTypeName(4))).toBe(true);
+  });
+
+  // Most concrete IFC product classes are absent from the hand-maintained
+  // `IfcTypeEnum` (101 of the 157 concrete `IfcProduct` subtypes in the
+  // generated IFC4 registry). The live parser table carries a `rawTypeName`
+  // string column so `getTypeName` can fall back to the real class for those;
+  // the cache writer/reader pair must carry the same column, or every such
+  // element comes back as 'Unknown' after a cache load.
+  //
+  // Both directions, over a NAMED list rather than a count: classes that are
+  // in the enum must keep working (negative control), and classes that are
+  // not must come back with their real name (the regression).
+  it('preserves the class name of every named IFC4 class through a cache round-trip', async () => {
+    // Every name here is a concrete entity of the generated IFC4 registry.
+    const IN_ENUM = ['IfcWall', 'IfcSpace', 'IfcBuildingStorey'] as const;
+    const NOT_IN_ENUM = [
+      'IfcPump',
+      'IfcValve',
+      'IfcAirTerminal',
+      'IfcSanitaryTerminal',
+      'IfcLightFixture',
+      'IfcSurfaceFeature',
+      'IfcBoiler',
+      'IfcStructuralCurveMember',
+    ] as const;
+
+    // Anti-vacuity, both halves: the split must really be a split, and each
+    // name must really sit on the side of `IfcTypeEnum` this test claims.
+    // If a class is ever added to the enum it moves lists, it is not dropped.
+    expect(IN_ENUM.length).toBeGreaterThan(0);
+    expect(NOT_IN_ENUM.length).toBeGreaterThan(0);
+    for (const n of IN_ENUM) expect([n, IfcTypeEnumFromString(n)]).not.toEqual([n, IfcTypeEnum.Unknown]);
+    for (const n of NOT_IN_ENUM) expect([n, IfcTypeEnumFromString(n)]).toEqual([n, IfcTypeEnum.Unknown]);
+
+    const all = [...IN_ENUM, ...NOT_IN_ENUM];
+    const builder = new EntityTableBuilder(all.length, dataStore.strings);
+    all.forEach((cls, i) => {
+      builder.add(i + 1, cls.toUpperCase(), `guid-${i + 1}`, `Entity ${i + 1}`, '', '', false, false);
+    });
+    const entities = builder.build();
+
+    // Anti-vacuity: the pre-cache table already answers correctly for every
+    // name, so a failure below is the cache losing it and nothing else.
+    const before = all.map((cls, i) => [cls, entities.getTypeName(i + 1)]);
+    expect(before).toEqual(all.map((cls) => [cls, cls]));
+
+    const writer = new BinaryCacheWriter();
+    const cacheBuffer = await writer.write(
+      { ...dataStore, entities, entityCount: entities.count },
+      undefined,
+      sourceBuffer,
+      { includeGeometry: false },
+    );
+
+    const reader = new BinaryCacheReader();
+    const result = await reader.read(cacheBuffer);
+
+    const after = all.map((cls, i) => [cls, result.dataStore.entities.getTypeName(i + 1)]);
+    expect(after).toEqual(all.map((cls) => [cls, cls]));
   });
 
   it('should preserve property data through round-trip', async () => {

--- a/packages/cache/src/reader.ts
+++ b/packages/cache/src/reader.ts
@@ -99,7 +99,7 @@ export class BinaryCacheReader {
       throw new Error('Missing required Entities section');
     }
     reader.position = entitiesSection.offset;
-    const entities = readEntities(reader, strings);
+    const entities = readEntities(reader, strings, header.version);
 
     // Read properties
     const propertiesSection = sectionMap.get(SectionType.Properties);

--- a/packages/cache/src/sections/entities.test.ts
+++ b/packages/cache/src/sections/entities.test.ts
@@ -201,6 +201,37 @@ describe('readEntities derives typeRanges instead of trusting the stored triples
     expect([...table.typeRanges.keys()]).toEqual([IfcTypeEnum.IfcWall, IfcTypeEnum.IfcSpace]);
   });
 
+  it('reads a v14 section, which has no rawTypeName column, without running past its end', () => {
+    // A v15 payload is a v14 payload plus a trailing Uint32Array[count], so
+    // dropping those bytes reproduces exactly what an old writer emitted.
+    const strings = new StringTable();
+    const columns = columnsFor(INTERLEAVED_TYPES, strings);
+    const source = entityTableFromColumns({ ...columns, typeRanges: newSpans() }, strings);
+    const writer = new BufferWriter();
+    writeEntities(writer, source);
+    const v15 = new Uint8Array(writer.build());
+    const v14Length = v15.byteLength - INTERLEAVED_TYPES.length * 4;
+
+    // Anti-vacuity: the column really is the only difference, and it is not
+    // zero-width — otherwise this test would pass against an unchanged writer.
+    expect(v15.byteLength - v14Length).toBe(INTERLEAVED_TYPES.length * 4);
+    expect(v14Length).toBeGreaterThan(0);
+
+    // Trailing bytes the reader must not touch. Reading the absent column
+    // would consume them (and a shorter buffer would run off the end).
+    const withTrailer = new Uint8Array(v14Length + 64);
+    withTrailer.set(v15.subarray(0, v14Length), 0);
+    withTrailer.fill(0xab, v14Length);
+
+    const reader = new BufferReader(withTrailer.buffer);
+    const table = readEntities(reader, strings, 14);
+
+    expect(reader.position).toBe(v14Length);
+    expect(table.count).toBe(INTERLEAVED_TYPES.length);
+    expect(table.getTypeName(10)).toBe('IfcWall');
+    expect(table.getTypeName(20)).toBe('IfcSpace');
+  });
+
   it('round-trips the derived spans through a second write', () => {
     const { table: first, strings } = hydrate(INTERLEAVED_TYPES, oldStartPlusCount());
     const writer = new BufferWriter();

--- a/packages/cache/src/sections/entities.ts
+++ b/packages/cache/src/sections/entities.ts
@@ -7,8 +7,9 @@
  */
 
 import type { EntityTable, StringTable } from '@ifc-lite/data';
-import { IfcTypeEnum, IfcTypeEnumToString, IfcTypeEnumFromString, IFC_ENTITY_NAMES } from '@ifc-lite/data';
+import { entityTableFromColumns } from '@ifc-lite/data';
 import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import { FORMAT_VERSION } from '../types.js';
 
 /**
  * Write EntityTable to buffer
@@ -26,11 +27,16 @@ import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
  *   - geometryIndex: Int32Array[count]
  *   - typeRangeCount: uint16
  *   - typeRanges: [type:uint16, start:uint32, end:uint32][]
+ *   - rawTypeName: Uint32Array[count] (string indices; v15+ only)
  *
  * The typeRanges triples are vestigial on read: `readEntities` derives the
  * spans from the typeEnum column instead, because pre-#3101 caches stored
  * `start + count` here and the format version does not distinguish them.
  * They are still written so the section layout is unchanged.
+ *
+ * `rawTypeName` is appended AFTER the typeRanges triples rather than beside
+ * the other columns so the v14 prefix stays byte-identical; a v15 reader
+ * handed a v14 section simply stops where the old section ended.
  */
 export function writeEntities(writer: BufferWriter, entities: EntityTable): void {
   const count = entities.count;
@@ -59,12 +65,29 @@ export function writeEntities(writer: BufferWriter, entities: EntityTable): void
     writer.writeUint32(range.start);
     writer.writeUint32(range.end);
   }
+
+  // Raw IFC class names (v15+). Most concrete IFC product classes have no
+  // `IfcTypeEnum` member, so without this column `getTypeName` can only
+  // answer 'Unknown' for them after a cache load, while the live parser
+  // table answers with the real class. A table built without the column
+  // (server hydration) writes zeroes, which read back as the empty string
+  // and degrade to the same enum-only answer as before.
+  const raw = entities.rawTypeName;
+  writer.writeTypedArray(raw && raw.length >= count ? raw.subarray(0, count) : new Uint32Array(count));
 }
 
 /**
- * Read EntityTable from buffer
+ * Read EntityTable from buffer.
+ *
+ * `version` is the cache header's FORMAT_VERSION. v15+ sections carry a
+ * trailing `rawTypeName` column; older ones stop after the typeRanges
+ * triples and must not be read past.
  */
-export function readEntities(reader: BufferReader, strings: StringTable): EntityTable {
+export function readEntities(
+  reader: BufferReader,
+  strings: StringTable,
+  version: number = FORMAT_VERSION,
+): EntityTable {
   const count = reader.readUint32();
 
   // Read columnar arrays
@@ -84,8 +107,9 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
   // caches written before #3101 hold `start + count`, later ones hold a
   // `[firstRow, lastRow + 1]` span, and FORMAT_VERSION was deliberately not
   // bumped (header.ts accepts any version <= FORMAT_VERSION by design), so
-  // both vintages arrive here indistinguishable. The spans are derived from
-  // the live typeEnum column below instead.
+  // both vintages arrive here indistinguishable. `entityTableFromColumns`
+  // derives the spans from the live typeEnum column instead, which is why
+  // `typeRanges` is deliberately left off the columns object below.
   const typeRangeCount = reader.readUint16();
 
   for (let i = 0; i < typeRangeCount; i++) {
@@ -94,120 +118,30 @@ export function readEntities(reader: BufferReader, strings: StringTable): Entity
     reader.readUint32(); // end (or count, for a pre-#3101 cache)
   }
 
-  // Build EntityTable with methods
-  const HAS_GEOMETRY = 0b00000001;
+  // Raw IFC class names, v15+ only (see writeEntities). Left undefined for
+  // older sections, where the bytes are simply not there — reading them
+  // would consume whatever section follows.
+  const rawTypeName = version >= 15 ? reader.readUint32Array(count) : undefined;
 
-  // Build correct per-type index arrays. Every row of a type is listed, so
-  // this survives IFC files that interleave types — unlike the serialized
-  // typeRanges, which cannot express more than one contiguous run per type.
-  const typeIndices = new Map<IfcTypeEnum, number[]>();
-  for (let i = 0; i < count; i++) {
-    const t = typeEnum[i] as IfcTypeEnum;
-    let arr = typeIndices.get(t);
-    if (!arr) {
-      arr = [];
-      typeIndices.set(t, arr);
-    }
-    arr.push(i);
-  }
-
-  // Derive the spans from the same index arrays, so the one structure that
-  // survives interleaving feeds both getByType() and the public typeRanges.
-  const typeRanges = new Map<IfcTypeEnum, { start: number; end: number }>();
-  for (const [type, indices] of typeIndices) {
-    typeRanges.set(type, { start: indices[0], end: indices[indices.length - 1] + 1 });
-  }
-
-  // PRE-BUILD INDEX MAP: O(n) once, then O(1) lookups
-  // This eliminates O(n²) when getName/hasGeometry are called for every entity
-  const idToIndex = new Map<number, number>();
-  for (let i = 0; i < count; i++) {
-    idToIndex.set(expressId[i], i);
-  }
-
-  const indexOfId = (id: number): number => {
-    return idToIndex.get(id) ?? -1;
-  };
-
-  // Build GlobalId → expressId map for BCF integration
-  const globalIdToExpressId = new Map<string, number>();
-  for (let i = 0; i < count; i++) {
-    const gidString = strings.get(globalId[i]);
-    if (gidString) {
-      globalIdToExpressId.set(gidString, expressId[i]);
-    }
-  }
-
-  // Additive display-class overrides (UI retype). See entity-table.ts.
-  const typeOverrides = new Map<number, string>();
-
-  return {
-    count,
-    expressId,
-    typeEnum,
-    globalId,
-    name,
-    description,
-    objectType,
-    flags,
-    containedInStorey,
-    definedByType,
-    geometryIndex,
-    typeRanges,
-
-    getGlobalId: (id) => {
-      const idx = indexOfId(id);
-      return idx >= 0 ? strings.get(globalId[idx]) : '';
+  // One shared implementation with the live parser table. Keeping a second
+  // copy here is what let the `rawTypeName` fallback go missing from cache
+  // loads while the parser had it: every entity of a class absent from
+  // `IfcTypeEnum` came back as 'Unknown'.
+  return entityTableFromColumns(
+    {
+      count,
+      expressId,
+      typeEnum,
+      globalId,
+      name,
+      description,
+      objectType,
+      flags,
+      containedInStorey,
+      definedByType,
+      geometryIndex,
+      rawTypeName,
     },
-    getName: (id) => {
-      const idx = indexOfId(id);
-      return idx >= 0 ? strings.get(name[idx]) : '';
-    },
-    getDescription: (id) => {
-      const idx = indexOfId(id);
-      return idx >= 0 ? strings.get(description[idx]) : '';
-    },
-    getObjectType: (id) => {
-      const idx = indexOfId(id);
-      return idx >= 0 ? strings.get(objectType[idx]) : '';
-    },
-    getTypeName: (id) => {
-      const override = typeOverrides.get(id);
-      if (override !== undefined) return override;
-      const idx = indexOfId(id);
-      return idx >= 0 ? IfcTypeEnumToString(typeEnum[idx]) : 'Unknown';
-    },
-    hasGeometry: (id) => {
-      const idx = indexOfId(id);
-      return idx >= 0 ? (flags[idx] & HAS_GEOMETRY) !== 0 : false;
-    },
-    getByType: (type) => {
-      const indices = typeIndices.get(type);
-      if (!indices) return [];
-      const ids: number[] = new Array(indices.length);
-      for (let i = 0; i < indices.length; i++) {
-        ids[i] = expressId[indices[i]];
-      }
-      return ids;
-    },
-    getTypeEnum: (id) => {
-      const override = typeOverrides.get(id);
-      if (override !== undefined) return IfcTypeEnumFromString(override);
-      const idx = indexOfId(id);
-      return idx >= 0 ? typeEnum[idx] as IfcTypeEnum : IfcTypeEnum.Unknown;
-    },
-    setTypeOverride: (id, typeName) => {
-      if (typeName === null) typeOverrides.delete(id);
-      // Canonicalise on the way in, matching `entityTableFromColumns`
-      // (packages/data/src/entity-table.ts). `getTypeName` echoes the
-      // override back verbatim and consumers like
-      // `isSpatialStructureTypeName` match the PascalCase form, so storing
-      // the caller's raw UPPERCASE token makes a retyped entity invisible to
-      // them. All three EntityTable implementations must agree here.
-      else typeOverrides.set(id, IFC_ENTITY_NAMES[typeName.toUpperCase()] ?? typeName.toUpperCase());
-    },
-    getExpressIdByGlobalId: (gid) => {
-      return globalIdToExpressId.get(gid) ?? -1;
-    },
-  };
+    strings,
+  );
 }

--- a/packages/cache/src/sections/header.test.ts
+++ b/packages/cache/src/sections/header.test.ts
@@ -70,8 +70,9 @@ describe('writeHeader', () => {
     expect(Array.from(buf.subarray(0, 4))).toEqual([0x49, 0x46, 0x43, 0x4c]);
 
     // version: uint16 LE at byte 4. Moved 13 -> 14 with the #3199 mesh-record
-    // change; update this literal only alongside a types.ts ledger entry.
-    expect(view.getUint16(4, true)).toBe(14);
+    // change, 14 -> 15 with the Entities `rawTypeName` column; update this
+    // literal only alongside a types.ts ledger entry.
+    expect(view.getUint16(4, true)).toBe(15);
   });
 
   it('writes each section-table entry field at its documented byte offset within the 16-byte entry', () => {

--- a/packages/cache/src/types.ts
+++ b/packages/cache/src/types.ts
@@ -101,8 +101,21 @@ export const MAGIC = 0x4C434649; // "IFCL" in little-endian
  *   `undefined`, which is the same state the runtime uses where the identity is
  *   genuinely merged away, so an old cache degrades to "unknown" and never to a
  *   WRONG id.
+ *
+ * v15: the Entities section gains a trailing `rawTypeName: Uint32Array[count]`
+ *   of interned-string indices, appended after the typeRanges triples. Only
+ *   ~1/4 of the concrete IFC product classes in the generated schema registry
+ *   have an `IfcTypeEnum` member, so the enum column alone cannot name the
+ *   rest; the live parser table has carried a raw-name column for that
+ *   fallback all along and the cache did not, which turned every such element
+ *   into 'Unknown' on a cache load. Bumped rather than sniffed because the
+ *   section is positional: a v14 section has nothing after the triples, so a
+ *   reader that read the column unconditionally would consume whatever
+ *   follows. A v15 reader still reads v14 sections — the column is
+ *   version-gated and degrades to the enum-only name, exactly the pre-v15
+ *   behaviour.
  */
-export const FORMAT_VERSION = 14;
+export const FORMAT_VERSION = 15;
 
 /** Geometry chunking parameters (v13+). Grouping is a WRITE-side layout
  *  policy: readers only trust the directory, so these can change without a


### PR DESCRIPTION
## What

`EntityTable` carries a `rawTypeName` string column so `getTypeName()` can name an IFC class that the hand-maintained `IfcTypeEnum` does not cover. Diffing that enum against the generated registry `packages/data/src/ifc-schema/generated/entities-ifc4.ts`, **101 of the 157 concrete `IfcProduct` subtypes have no enum member** — `IfcPump`, `IfcValve`, `IfcAirTerminal`, `IfcSanitaryTerminal`, `IfcLightFixture`, `IfcBoiler`, `IfcSurfaceFeature`, `IfcStructuralCurveMember` and so on. (IFC2X3: 27 of 72. IFC4X3: 116 of 192.)

`writeEntities` never serialized that column, and `readEntities` kept its own copy of the accessor closures whose `getTypeName` had no fallback:

```ts
getTypeName: (id) => {
  const override = typeOverrides.get(id);
  if (override !== undefined) return override;
  const idx = indexOfId(id);
  return idx >= 0 ? IfcTypeEnumToString(typeEnum[idx]) : 'Unknown';
},
```

So a model loaded from a cache hit named every one of those elements `Unknown`, while the same model parsed from source named it correctly. Two paths that must agree, diverging in one direction only.

## Fix

- `writeEntities` appends `rawTypeName: Uint32Array[count]` **after** the type-range triples, so the v14 prefix is byte-identical and the new bytes are purely a tail. `FORMAT_VERSION` 14 → 15 with a ledger entry.
- `readEntities` takes the header version and reads the column only for v15+; a v14 section stops exactly where it always did.
- `readEntities` now builds its table with `entityTableFromColumns` from `@ifc-lite/data` — the same constructor the parser path uses — instead of a second copy of the closures. Keeping that duplicate is what let the fallback exist on one side only. Net −60 lines in `sections/entities.ts`.

## Tests

`preserves the class name of every named IFC4 class through a cache round-trip` — a **named** list of IFC4 classes, split by enum membership, checked in **both directions**:

- `IN_ENUM` (`IfcWall`, `IfcSpace`, `IfcBuildingStorey`) is the negative control: these must keep working.
- `NOT_IN_ENUM` (`IfcPump`, `IfcValve`, `IfcAirTerminal`, `IfcSanitaryTerminal`, `IfcLightFixture`, `IfcSurfaceFeature`, `IfcBoiler`, `IfcStructuralCurveMember`) is the regression.
- Anti-vacuity: each name's side of `IfcTypeEnum` is asserted before use, so if a class is ever added to the enum the test fails loudly and the name moves lists rather than being silently dropped. The pre-cache table is asserted correct first, so a failure below can only be the cache losing the name.

`reads a v14 section, which has no rawTypeName column, without running past its end` — the v14 payload is the v15 payload minus the trailing `count * 4` bytes, followed by 64 sentinel bytes; the reader must land exactly on the old boundary.

### RED on `upstream/main`

```
AssertionError: expected 'Unknown' to be 'IfcPump' // Object.is equality
Expected: "IfcPump"
Received: "Unknown"
```

with the in-enum negative control (`IfcWall`) passing in the same run.

### GREEN

`Test Files 12 passed (12) / Tests 108 passed (108)` for `@ifc-lite/cache`; `@ifc-lite/data` 212/212 and `@ifc-lite/parser` 846/846 unaffected.

### Mutation checks

- `version >= 15` → `version >= 14`: `AssertionError: expected 221 to be 201` on the v14 boundary assertion (the reader consumed the sentinel bytes).
- writer column → `new Uint32Array(count)`: the round-trip test fails with eight `"Unknown"` rows.

Both reverted by the inverse edit and proved byte-identical with `diff`.

## CI

GitHub Actions has not been dispatching runs repo-wide since 16:13 UTC, so expect **zero Actions checks** on this PR. Everything above was run locally: `@ifc-lite/cache` tests + typecheck, `@ifc-lite/data` and `@ifc-lite/parser` tests, and `check-module-size`, `check-test-wiring`, `check-test-glob-coverage`, `check-source-text-assertions` (all OK).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache format v15 preserves concrete IFC type names, including classes not represented in the standard type list.
  * Existing version 14 caches remain readable.

* **Bug Fixes**
  * Prevented unsupported IFC classes from being displayed as “Unknown” after cache reloads.
  * Improved safe handling of older cache data without consuming adjacent sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->