### PR TITLE
fix(data): stop reporting three IFC classes as a different class

### DIFF
--- a/.changeset/type-enum-non-ancestor-rows.md
+++ b/.changeset/type-enum-non-ancestor-rows.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/data': patch
+---
+
+Three IFC classes are no longer reported as a different IFC class.
+
+`IfcTypeEnum` covers a fraction of the schema, so the table behind `IfcTypeEnumFromString` deliberately coalesces some classes onto a coarser one — `IFCDOORSTANDARDCASE` resolves to `IfcDoor`, which is lossy but sound because a door standard case is a door. Three rows pointed somewhere else entirely:
+
+- `IfcTendonAnchor` → `IfcTendon` — siblings under `IfcReinforcingElement`.
+- `IfcFastener` → `IfcMechanicalFastener` — the key's own child, so a plain fastener was reported as the narrower mechanical one.
+- `IfcCableCarrierSegment` → `IfcCableSegment` — siblings under `IfcFlowSegment`; the tray was reported as the cable it holds.
+
+`entities.getTypeName()` returned the wrong class for all three, which the Parquet exporter writes into its `Type` column. The rows are removed, so those classes fall through to the raw parsed name and keep their own spelling. A new test sweeps the whole table against the bundled IFC2X3/IFC4/IFC4X3 registries and fails any row whose key is not the class it resolves to or one of that class's ancestors, so this cannot come back under a different spelling.

--- a/packages/data/src/type-enum-ancestry.test.ts
+++ b/packages/data/src/type-enum-ancestry.test.ts
@@ -90,10 +90,21 @@ describe('IfcTypeEnumFromString never resolves a class to a non-ancestor', () =>
   });
 
   it('names the three classes the rule was written for, in both directions', () => {
-    // Forward: each resolves to itself, not to the sibling/child it used to.
-    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcTendonAnchor'))).not.toBe('IfcTendon');
-    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcFastener'))).not.toBe('IfcMechanicalFastener');
-    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcCableCarrierSegment'))).not.toBe('IfcCableSegment');
+    // Forward: each is asserted POSITIVELY, against the one value the table
+    // may hold for it, rather than negatively against the single wrong value
+    // it used to hold. A `.not.toBe('IfcCableSegment')` row passes for every
+    // value except that one, so re-pointing IfcCableCarrierSegment at
+    // IfcFlowSegment would satisfy it — and the ancestry sweep above cannot
+    // catch that either, because IfcFlowSegment IS an ancestor of
+    // IfcCableCarrierSegment. The raw class name would be replaced by a
+    // coarser one again, which is the defect this file exists to pin.
+    //
+    // The enum has no member for any of the three, so `Unknown` is the only
+    // sound answer: it is the miss sentinel that sends `getTypeName` to the
+    // rawTypeName column, where the parsed class name is.
+    expect(IfcTypeEnumFromString('IfcTendonAnchor')).toBe(IfcTypeEnum.Unknown);
+    expect(IfcTypeEnumFromString('IfcFastener')).toBe(IfcTypeEnum.Unknown);
+    expect(IfcTypeEnumFromString('IfcCableCarrierSegment')).toBe(IfcTypeEnum.Unknown);
 
     // Backward: the classes they were folded into still resolve to themselves.
     // Without this, deleting the enum members entirely would pass the row above.

--- a/packages/data/src/type-enum-ancestry.test.ts
+++ b/packages/data/src/type-enum-ancestry.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `IfcTypeEnum` covers ~1/8 of the IFC schema, so the string -> enum table
+ * behind `IfcTypeEnumFromString` deliberately coalesces some classes onto a
+ * coarser one: `IFCDOORSTANDARDCASE` resolves to `IfcDoor`, and the round
+ * trip through `IfcTypeEnumToString` reports "IfcDoor" for it. That is
+ * lossy but SOUND — a door standard case IS a door.
+ *
+ * It stops being sound the moment the coarser class is not an ancestor. The
+ * table had three such rows, each pointing at a SIBLING or a CHILD:
+ *
+ *   IfcTendonAnchor        -> IfcTendon              (both IfcReinforcingElement)
+ *   IfcFastener            -> IfcMechanicalFastener  (the CHILD of the key)
+ *   IfcCableCarrierSegment -> IfcCableSegment        (both IfcFlowSegment)
+ *
+ * so `getTypeName` renamed those elements to a different IFC class, and the
+ * Parquet exporter's Type column (parquet-exporter.ts, "The unretyped name
+ * comes from `entities.getTypeName(id)`") wrote that wrong class to file.
+ *
+ * The rule is checked against the bundled schema registries rather than a
+ * list of the three, so a future row is held to it too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcTypeEnum, IfcTypeEnumFromString, IfcTypeEnumToString } from './types.js';
+import { ENTITIES_IFC2X3 } from './ifc-schema/generated/entities-ifc2x3.js';
+import { ENTITIES_IFC4 } from './ifc-schema/generated/entities-ifc4.js';
+import { ENTITIES_IFC4X3 } from './ifc-schema/generated/entities-ifc4x3.js';
+
+/** name -> parent, unioned over every schema version the package bundles. */
+const PARENT = new Map<string, string | undefined>();
+for (const registry of [ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3]) {
+  for (const e of registry) {
+    // A later registry's parent wins only when the earlier one had none, so a
+    // class re-parented across versions keeps a real edge either way.
+    if (PARENT.get(e.name) === undefined) PARENT.set(e.name, e.parent);
+  }
+}
+
+/** `[name, ...ancestors]`, cycle-guarded. */
+function chain(name: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  let cur: string | undefined = name;
+  while (cur && !seen.has(cur)) {
+    out.push(cur);
+    seen.add(cur);
+    cur = PARENT.get(cur);
+  }
+  return out;
+}
+
+/** Every class the table can resolve, paired with what it resolves to. */
+const RESOLVED = [...PARENT.keys()]
+  .map((name) => ({ name, enumValue: IfcTypeEnumFromString(name) }))
+  .filter((r) => r.enumValue !== IfcTypeEnum.Unknown)
+  .map((r) => ({ ...r, resolvesTo: IfcTypeEnumToString(r.enumValue) }));
+
+describe('IfcTypeEnumFromString never resolves a class to a non-ancestor', () => {
+  it('has a table and a schema big enough for the sweep to mean anything', () => {
+    // Anti-vacuity on both parse counts: a registry regex that stopped
+    // matching, or a table that stopped resolving, would otherwise make every
+    // assertion below pass over an empty set.
+    expect(PARENT.size).toBeGreaterThan(700);
+    expect(RESOLVED.length).toBeGreaterThan(100);
+    // The three classes the rule was written for must be in the schema the
+    // sweep walks — otherwise the sweep could never have seen them, and the
+    // rows could come back unnoticed under a different spelling.
+    for (const required of ['IfcTendonAnchor', 'IfcFastener', 'IfcCableCarrierSegment']) {
+      expect([required, PARENT.has(required)]).toEqual([required, true]);
+    }
+
+    // And the sweep must still resolve real coalescing rows, so "no
+    // violations" cannot be reached by the table resolving nothing.
+    const swept = new Set(RESOLVED.map((r) => r.name));
+    for (const required of ['IfcDoorStandardCase', 'IfcDistributionFlowElement', 'IfcWall', 'IfcSpace']) {
+      expect([required, swept.has(required)]).toEqual([required, true]);
+    }
+  });
+
+  it('resolves every schema class to itself or to one of its ancestors', () => {
+    const violations = RESOLVED.filter((r) => !chain(r.name).includes(r.resolvesTo)).map(
+      (r) => `${r.name} -> ${r.resolvesTo} (ancestry: ${chain(r.name).join(' <- ')})`,
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('names the three classes the rule was written for, in both directions', () => {
+    // Forward: each resolves to itself, not to the sibling/child it used to.
+    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcTendonAnchor'))).not.toBe('IfcTendon');
+    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcFastener'))).not.toBe('IfcMechanicalFastener');
+    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcCableCarrierSegment'))).not.toBe('IfcCableSegment');
+
+    // Backward: the classes they were folded into still resolve to themselves.
+    // Without this, deleting the enum members entirely would pass the row above.
+    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcTendon'))).toBe('IfcTendon');
+    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcMechanicalFastener'))).toBe('IfcMechanicalFastener');
+    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcCableSegment'))).toBe('IfcCableSegment');
+  });
+
+  it('still accepts the sound coalescing rows, and rejects a fabricated unsound one', () => {
+    // Negative control for the rule itself: it must not be trivially true.
+    // A standard case IS a door, so this coalescing row is allowed...
+    expect(chain('IfcDoorStandardCase')).toContain('IfcDoor');
+    expect(IfcTypeEnumToString(IfcTypeEnumFromString('IfcDoorStandardCase'))).toBe('IfcDoor');
+
+    // ...while a sibling is not, so the same predicate rejects it. If this
+    // ever passes, `chain` has stopped discriminating and the sweep above is
+    // worthless.
+    expect(chain('IfcWall')).not.toContain('IfcSpace');
+    expect(chain('IfcTendonAnchor')).not.toContain('IfcTendon');
+  });
+});

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -285,7 +285,9 @@ export interface SpatialHierarchy {
   getPath(elementId: number): SpatialNode[]; // Project → ... → Element
 }
 
-// Type conversion helpers
+// Type conversion helpers. A row may coalesce onto an ANCESTOR
+// (IFCDOORSTANDARDCASE -> IfcDoor) but never a sibling or child, which renames
+// the element to a different IFC class; `type-enum-ancestry.test.ts` sweeps it.
 const TYPE_STRING_TO_ENUM = new Map<string, IfcTypeEnum>([
   // Spatial
   ['IFCPROJECT', IfcTypeEnum.IfcProject],
@@ -347,10 +349,8 @@ const TYPE_STRING_TO_ENUM = new Map<string, IfcTypeEnum>([
   ['IFCREINFORCINGBAR', IfcTypeEnum.IfcReinforcingBar],
   ['IFCREINFORCINGMESH', IfcTypeEnum.IfcReinforcingMesh],
   ['IFCTENDON', IfcTypeEnum.IfcTendon],
-  ['IFCTENDONANCHOR', IfcTypeEnum.IfcTendon],
   ['IFCDISCRETEACCESSORY', IfcTypeEnum.IfcDiscreteAccessory],
   ['IFCMECHANICALFASTENER', IfcTypeEnum.IfcMechanicalFastener],
-  ['IFCFASTENER', IfcTypeEnum.IfcMechanicalFastener],
   // MEP
   ['IFCDISTRIBUTIONELEMENT', IfcTypeEnum.IfcDistributionElement],
   ['IFCDISTRIBUTIONFLOWELEMENT', IfcTypeEnum.IfcDistributionElement],
@@ -366,7 +366,6 @@ const TYPE_STRING_TO_ENUM = new Map<string, IfcTypeEnum>([
   ['IFCDUCTSEGMENT', IfcTypeEnum.IfcDuctSegment],
   ['IFCPIPESEGMENT', IfcTypeEnum.IfcPipeSegment],
   ['IFCCABLESEGMENT', IfcTypeEnum.IfcCableSegment],
-  ['IFCCABLECARRIERSEGMENT', IfcTypeEnum.IfcCableSegment],
   // Furnishing
   ['IFCFURNISHINGELEMENT', IfcTypeEnum.IfcFurnishingElement],
   ['IFCFURNITURE', IfcTypeEnum.IfcFurniture],


### PR DESCRIPTION
## What

`IfcTypeEnum` covers a fraction of the IFC schema, so the table behind `IfcTypeEnumFromString` deliberately coalesces some classes onto a coarser one — `IFCDOORSTANDARDCASE` resolves to `IfcDoor`, and `getTypeName` reports "IfcDoor" for it. Lossy, but **sound**: a door standard case *is* a door.

Diffing every key of that table against the bundled registries in `packages/data/src/ifc-schema/generated/`, **three rows resolved a class to something that is not one of its ancestors**:

| row | relationship |
|---|---|
| `IfcTendonAnchor -> IfcTendon` | **siblings** under `IfcReinforcingElement` |
| `IfcFastener -> IfcMechanicalFastener` | the key's own **child** — a plain fastener reported as the narrower mechanical one |
| `IfcCableCarrierSegment -> IfcCableSegment` | **siblings** under `IfcFlowSegment` — the tray reported as the cable it holds |

Verified against the built package before the fix:

```
IFCTENDONANCHOR            -> getTypeName: IfcTendon
IFCFASTENER                -> getTypeName: IfcMechanicalFastener
IFCCABLECARRIERSEGMENT     -> getTypeName: IfcCableSegment
IFCTENDON                  -> getTypeName: IfcTendon
IFCPUMP                    -> getTypeName: IfcPump
```

`getTypeName` is what the Parquet exporter writes into its `Type` column — `parquet-exporter.ts` says so in as many words ("The unretyped name comes from `entities.getTypeName(id)`, the store's own canonical answer") — so the wrong class reached an exported file. The STEP/IFC5 exporters are unaffected: they write `entity.type`, the raw parsed token.

## Fix

The three rows are removed. Those classes fall through to the raw parsed name and keep their own spelling — the same path the other ~100 concrete IFC4 product classes without an enum member already take.

## Test

`type-enum-ancestry.test.ts` does not pin the three names. It sweeps **every** entity of the bundled IFC2X3 / IFC4 / IFC4X3 registries through `IfcTypeEnumFromString` → `IfcTypeEnumToString` and fails any class that does not resolve to itself or to a proper ancestor, so a future row is held to the same rule.

- **Anti-vacuity, both parse counts**: the union registry must hold >700 classes and the table must still resolve >100 of them, and four named classes (`IfcDoorStandardCase`, `IfcDistributionFlowElement`, `IfcWall`, `IfcSpace`) must still be resolved — "no violations" cannot be reached by the table resolving nothing.
- **Named required list**: the three classes the rule was written for must be present in the schema the sweep walks.
- **Both directions**: each of the three must no longer resolve to the sibling/child, *and* the classes they were folded into must still resolve to themselves — without which deleting the enum members entirely would pass.
- **Negative control on the rule itself**: a sound coalescing row (`IfcDoorStandardCase -> IfcDoor`) is still accepted, and `chain()` is shown to reject a sibling, so the predicate is not trivially true.

### RED on `upstream/main`

```
AssertionError: expected [ …(3) ] to deeply equal []
+ "IfcFastener -> IfcMechanicalFastener (ancestry: IfcFastener <- IfcElementComponent <- IfcElement <- ...)",
+ "IfcTendonAnchor -> IfcTendon (ancestry: IfcTendonAnchor <- IfcReinforcingElement <- ...)",
+ "IfcCableCarrierSegment -> IfcCableSegment (ancestry: IfcCableCarrierSegment <- IfcFlowSegment <- ...)",
```

### GREEN

`@ifc-lite/data` 216/216. Unaffected: `parser` 846, `export` 953, `query` 221, `cache` 106.

### Mutation check

Reinstating `['IFCTENDONANCHOR', IfcTypeEnum.IfcTendon]` reproduces the sweep failure with exactly that one row, plus the both-directions assertion. Reverted by the inverse edit, proved byte-identical with `diff`.

`check-module-size` stays green **without raising a budget**: `packages/data/src/types.ts` lands back at its recorded 508 (three rows removed, a three-line note added in place of the one-line header).

## CI

GitHub Actions has not been dispatching runs repo-wide since 16:13 UTC, so expect **zero Actions checks**. All of the above was run locally, plus `check-module-size`, `check-test-wiring`, `check-test-glob-coverage`, `check-source-text-assertions` (all OK).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IFC type conversion so certain classes retain their original names instead of being incorrectly mapped to related classes.
  * Improved exported type information for tendon anchors, fasteners, and cable carrier segments.

* **Documentation**
  * Clarified that type conversions only map IFC classes to themselves or their schema ancestors.

* **Tests**
  * Added validation across supported IFC schemas to prevent invalid type mappings and preserve valid ancestor conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->