### PR TITLE
fix(viewer): name a server-loaded class the IfcTypeEnum does not cover

### DIFF
--- a/apps/viewer/src/utils/serverDataModel.rawTypeName.test.ts
+++ b/apps/viewer/src/utils/serverDataModel.rawTypeName.test.ts
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The server-hydrated `EntityTable` must name a class that `IfcTypeEnum` does
+ * not cover, exactly as the two other `EntityTable` implementations do
+ * (`entityTableFromColumns` in packages/data, and the cache-restored table).
+ *
+ * `buildEntityTable` already receives the real class string from the server
+ * (`cols.typeName[idx]`) and hands it to `CompactEntityIndexBuilder.add`, so
+ * the correct name is in hand; answering `getTypeName` from the enum alone
+ * discards it and reports `Unknown`.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { ServerEntityIndex, type DataModel } from '@ifc-lite/server-client';
+import { IfcTypeEnum, IfcTypeEnumFromString } from '@ifc-lite/data';
+import type { CompactEntityIndex } from '@ifc-lite/parser';
+import { convertServerDataModel, type ServerParseResult } from './serverDataModel';
+import { buildTypeTree } from '../components/viewer/hierarchy/treeDataBuilder';
+
+const parseResult: ServerParseResult = {
+  cache_key: 'raw-type-name',
+  metadata: { schema_version: 'IFC4' },
+  stats: { total_time_ms: 1, parse_time_ms: 1, geometry_time_ms: 0, total_vertices: 0, total_triangles: 0 },
+};
+
+/** Classes the server can emit that `IfcTypeEnum` does not model. */
+const OUTSIDE_ENUM = [
+  { id: 100, raw: 'IFCPUMP', display: 'IfcPump' },
+  { id: 101, raw: 'IFCCHILLER', display: 'IfcChiller' },
+  { id: 102, raw: 'IFCBOREHOLE', display: 'IfcBorehole' },
+];
+
+/** A class the enum DOES cover — the negative control for the fallback. */
+const INSIDE_ENUM = { id: 200, raw: 'IFCWALL', display: 'IfcWall' };
+
+function dataModelFor(rows: { id: number; raw: string }[]): DataModel {
+  return {
+    entities: ServerEntityIndex.fromRows([
+      { entity_id: 1, type_name: 'IFCPROJECT', global_id: 'Proj00000000000000001', name: 'P', has_geometry: false },
+      ...rows.map((r, i) => ({
+        entity_id: r.id,
+        type_name: r.raw,
+        global_id: `G${i}`.padEnd(22, 'x'),
+        name: `E${r.id}`,
+        has_geometry: true,
+      })),
+    ]),
+    propertySets: new Map(),
+    quantitySets: new Map(),
+    relationships: [],
+    classifications: [],
+    materials: [],
+    documents: [],
+    spatialHierarchy: {
+      nodes: [
+        {
+          entity_id: 1,
+          parent_id: 0,
+          level: 0,
+          path: 'P',
+          type_name: 'IFCPROJECT',
+          name: 'P',
+          children_ids: [],
+          element_ids: rows.map((r) => r.id),
+        },
+      ],
+      project_id: 1,
+      element_to_storey: new Map(),
+      element_to_building: new Map(),
+      element_to_site: new Map(),
+      element_to_space: new Map(),
+    },
+  } as unknown as DataModel;
+}
+
+describe('server-hydrated EntityTable.getTypeName', () => {
+  it('anti-vacuity: the fixture classes really are outside IfcTypeEnum, and the control is inside', () => {
+    assert.ok(OUTSIDE_ENUM.length >= 3, 'fixture must exercise more than one uncovered class');
+    for (const { raw, display } of OUTSIDE_ENUM) {
+      assert.equal(
+        IfcTypeEnumFromString(raw),
+        IfcTypeEnum.Unknown,
+        `${raw} is in IfcTypeEnum — it no longer exercises the rawTypeName fallback`,
+      );
+      assert.equal(
+        IfcTypeEnumFromString(display),
+        IfcTypeEnum.Unknown,
+        `${display} is in IfcTypeEnum — it no longer exercises the rawTypeName fallback`,
+      );
+    }
+    assert.notEqual(
+      IfcTypeEnumFromString(INSIDE_ENUM.raw),
+      IfcTypeEnum.Unknown,
+      'negative control must be a class the enum covers',
+    );
+  });
+
+  it('names classes IfcTypeEnum does not cover instead of reporting Unknown', () => {
+    const store = convertServerDataModel(
+      dataModelFor([...OUTSIDE_ENUM, INSIDE_ENUM]),
+      parseResult,
+      { size: 1 },
+      [],
+    );
+
+    for (const { id, raw, display } of OUTSIDE_ENUM) {
+      // The correct name is demonstrably in hand: the same string the table
+      // was built from is already retrievable from the compact index.
+      assert.equal((store.entityIndex.byId as CompactEntityIndex).getType(id), raw, `compact index lost ${raw}`);
+      assert.equal(
+        store.entities.getTypeName(id),
+        display,
+        `getTypeName(${id}) must report ${display}, not the enum's Unknown`,
+      );
+    }
+
+    // Negative control: an enum-covered class still answers from the enum.
+    assert.equal(store.entities.getTypeName(INSIDE_ENUM.id), INSIDE_ENUM.display);
+
+    // Negative control: an id that is not in the table still says Unknown.
+    assert.equal(store.entities.getTypeName(999999), 'Unknown');
+  });
+
+  it('user-visible: the hierarchy By-Type tab groups each class separately, not into one Unknown bucket', () => {
+    const store = convertServerDataModel(
+      dataModelFor([...OUTSIDE_ENUM, INSIDE_ENUM]),
+      parseResult,
+      { size: 1 },
+      [],
+    );
+    const geometricIds = new Set([...OUTSIDE_ENUM.map((e) => e.id), INSIDE_ENUM.id]);
+    const nodes = buildTypeTree(new Map(), store, new Set(), false, geometricIds);
+
+    const groupLabels = nodes.filter((n) => n.type === 'type-group').map((n) => n.name).sort();
+    assert.deepEqual(
+      groupLabels,
+      [...OUTSIDE_ENUM.map((e) => e.display), INSIDE_ENUM.display].sort(),
+      'each IFC class must get its own tab row',
+    );
+    assert.ok(
+      !groupLabels.includes('Unknown'),
+      'no class may collapse into the Unknown bucket',
+    );
+  });
+});

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -291,6 +291,11 @@ function buildEntityTable(
   // Tag / PredefinedType from the v4 data-model payload (issue #1765).
   const tagArr = new Uint32Array(entityCount);
   const predefinedTypeArr = new Uint32Array(entityCount);
+  // Raw IFC class name per row, interned. `IfcTypeEnum` covers only a subset of
+  // the schema, so `getTypeName` falls back to this exactly as
+  // `entityTableFromColumns` (packages/data/src/entity-table.ts) does — without
+  // it an IfcPump loaded from the server reports 'Unknown'.
+  const rawTypeNameArr = new Uint32Array(entityCount);
   const flagsArr = new Uint8Array(entityCount);
   const containedInStoreyArr = new Int32Array(entityCount).fill(-1);
   const definedByTypeArr = new Int32Array(entityCount).fill(-1);
@@ -312,6 +317,9 @@ function buildEntityTable(
     const typeName = cols.typeName[idx] ?? '';
     const typeVal = IfcTypeEnumFromString(typeName);
     typeEnumArr[idx] = typeVal;
+    // Same canonicalisation as `EntityTableBuilder.add` and `setTypeOverride`
+    // below, so all three EntityTable implementations spell a class the same way.
+    rawTypeNameArr[idx] = strings.intern(IFC_ENTITY_NAMES[typeName.toUpperCase()] ?? typeName);
     const globalIdString = cols.globalId[idx] || '';
     globalIdArr[idx] = strings.intern(globalIdString);
     if (globalIdString) {
@@ -342,6 +350,12 @@ function buildEntityTable(
   // Additive display-class overrides (UI retype). See entity-table.ts.
   const typeOverrides = new Map<number, string>();
 
+  /** One interned-string column accessor, shared by every string getter. */
+  const strCol = (col: Uint32Array) => (id: number) => {
+    const i = indexOfId(id);
+    return i >= 0 ? strings.get(col[i]) : '';
+  };
+
   const entities: EntityTable = {
     count: entityCount,
     expressId,
@@ -350,40 +364,26 @@ function buildEntityTable(
     name: nameArr,
     description: descriptionArr,
     objectType: objectTypeArr,
+    rawTypeName: rawTypeNameArr,
     flags: flagsArr,
     containedInStorey: containedInStoreyArr,
     definedByType: definedByTypeArr,
     geometryIndex: geometryIndexArr,
     typeRanges: new Map(), // Deprecated - use getByType which uses typeGroups directly
-    getGlobalId: (id) => {
-      const i = indexOfId(id);
-      return i >= 0 ? strings.get(globalIdArr[i]) : '';
-    },
-    getName: (id) => {
-      const i = indexOfId(id);
-      return i >= 0 ? strings.get(nameArr[i]) : '';
-    },
-    getDescription: (id) => {
-      const i = indexOfId(id);
-      return i >= 0 ? strings.get(descriptionArr[i]) : '';
-    },
-    getObjectType: (id) => {
-      const i = indexOfId(id);
-      return i >= 0 ? strings.get(objectTypeArr[i]) : '';
-    },
-    getTag: (id) => {
-      const i = indexOfId(id);
-      return i >= 0 ? strings.get(tagArr[i]) : '';
-    },
-    getPredefinedType: (id) => {
-      const i = indexOfId(id);
-      return i >= 0 ? strings.get(predefinedTypeArr[i]) : '';
-    },
+    getGlobalId: strCol(globalIdArr),
+    getName: strCol(nameArr),
+    getDescription: strCol(descriptionArr),
+    getObjectType: strCol(objectTypeArr),
+    getTag: strCol(tagArr),
+    getPredefinedType: strCol(predefinedTypeArr),
     getTypeName: (id) => {
       const override = typeOverrides.get(id);
       if (override !== undefined) return override;
       const i = indexOfId(id);
-      return i >= 0 ? IfcTypeEnumToString(typeEnumArr[i]) : 'Unknown';
+      if (i < 0) return 'Unknown';
+      const enumName = IfcTypeEnumToString(typeEnumArr[i]);
+      if (enumName !== 'Unknown') return enumName;
+      return strings.get(rawTypeNameArr[i]) || 'Unknown';
     },
     hasGeometry: (id) => {
       const i = indexOfId(id);


### PR DESCRIPTION
## What

`buildEntityTable` in `apps/viewer/src/utils/serverDataModel.ts` answered `getTypeName` from `IfcTypeEnum` alone:

```ts
return i >= 0 ? IfcTypeEnumToString(typeEnumArr[i]) : 'Unknown';
```

`IfcTypeEnum` has 128 members; the schema has ~1160 entities. Everything outside that subset — `IfcPump`, `IfcChiller`, `IfcBorehole`, most IFC4.3-only classes — reported `'Unknown'`, even though the real class string arrives from the server on the line above (`cols.typeName[idx]`) and is handed straight to `CompactEntityIndexBuilder.add`. The correct name was in hand and then discarded.

## Observed consequence

Reproduced through the real `convertServerDataModel` path (`apps/viewer/src/utils/serverDataModel.rawTypeName.test.ts`). Before the fix:

- `store.entityIndex.byId.getType(100)` returns `'IFCPUMP'` — the string is present.
- `store.entities.getTypeName(100)` returns `'Unknown'`.
- Feeding that store to `buildTypeTree` (the hierarchy panel's By-Type tab), three distinct classes collapse into **one** `Unknown` row:

```
+ actual - expected
-   'IfcBorehole',
-   'IfcChiller',
-   'IfcPump',
+   'Unknown'
```

Server-parsed models only; the client columnar path was already correct.

## Fix

The same mechanism the other two `EntityTable` implementations use — not a fourth one. An interned `rawTypeName` column, canonicalised through `IFC_ENTITY_NAMES` exactly as `EntityTableBuilder.add` (packages/data) and the `setTypeOverride` a few lines below already do, and a `getTypeName` that falls back to it when the enum says `Unknown`. The column is also exposed on the returned table, matching `entityTableFromColumns`.

`packages/data`'s `entityTableFromColumns` already had this; the cache-restored table is the third and is being fixed separately.

## Module size

The added lines put the file 12 over its recorded budget. Rather than raise it, the six identical string getters (`getGlobalId` / `getName` / `getDescription` / `getObjectType` / `getTag` / `getPredefinedType`, four lines each, one shape) collapse onto a single shared column accessor. The file lands at exactly 819 lines — its recorded budget, unchanged.

## Tests

`apps/viewer/src/utils/serverDataModel.rawTypeName.test.ts`, three cases:

1. **Anti-vacuity** — every fixture class is asserted to be genuinely outside `IfcTypeEnum` in both spellings, and the control class genuinely inside. Mutation check: swapping `IFCBOREHOLE` for `IFCSLAB` (enum-covered) makes this case fail while the other two stay green, which is the vacuity it exists to catch.
2. **Unit** — three uncovered classes name correctly; negative controls: an enum-covered class still answers from the enum, and an id absent from the table still returns `'Unknown'`.
3. **User-visible** — `buildTypeTree` gives each class its own row and none collapses into `Unknown`.

`apps/viewer` is private, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IFC entity type recognition for classes not covered by the standard type list.
  - The hierarchy’s By-Type view now groups uncommon IFC classes under their correct names instead of “Unknown.”
  - Preserved custom type overrides and existing handling for genuinely unknown entities.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->