### PR TITLE
fix(release): declare the Rust-only major with majorOffset 1 (#3216)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,11 +1477,11 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ifc-lite-clash"
-version = "6.0.1"
+version = "7.0.1"
 
 [[package]]
 name = "ifc-lite-core"
-version = "6.0.1"
+version = "7.0.1"
 dependencies = [
  "fast-float2",
  "futures-core",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-export"
-version = "6.0.1"
+version = "7.0.1"
 dependencies = [
  "arrow",
  "bytemuck",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-ffi"
-version = "6.0.1"
+version = "7.0.1"
 dependencies = [
  "ifc-lite-processing",
  "mimalloc",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-geometry"
-version = "6.0.1"
+version = "7.0.1"
 dependencies = [
  "approx",
  "bnum",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-processing"
-version = "6.0.1"
+version = "7.0.1"
 dependencies = [
  "ifc-lite-core",
  "ifc-lite-geometry",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-server"
-version = "6.0.1"
+version = "7.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "ifc-lite-wasm"
-version = "6.0.1"
+version = "7.0.1"
 dependencies = [
  "console_error_panic_hook",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ members = ["rust/core", "rust/geometry", "rust/processing", "rust/clash", "rust/
 resolver = "2"
 
 [workspace.package]
-version = "6.0.1"
+version = "7.0.1"
 edition = "2021"
 authors = ["IFC-Lite Contributors"]
 license = "MPL-2.0"
 repository = "https://github.com/LTplus-AG/ifc-lite"
 
 [workspace.dependencies]
-ifc-lite-core = { version = "6.0.1", path = "rust/core" }
-ifc-lite-geometry = { version = "6.0.1", path = "rust/geometry" }
-ifc-lite-processing = { version = "6.0.1", path = "rust/processing" }
-ifc-lite-clash = { version = "6.0.1", path = "rust/clash" }
-ifc-lite-export = { version = "6.0.1", path = "rust/export" }
-ifc-lite-wasm = { version = "6.0.1", path = "rust/wasm-bindings" }
+ifc-lite-core = { version = "7.0.1", path = "rust/core" }
+ifc-lite-geometry = { version = "7.0.1", path = "rust/geometry" }
+ifc-lite-processing = { version = "7.0.1", path = "rust/processing" }
+ifc-lite-clash = { version = "7.0.1", path = "rust/clash" }
+ifc-lite-export = { version = "7.0.1", path = "rust/export" }
+ifc-lite-wasm = { version = "7.0.1", path = "rust/wasm-bindings" }
 
 # Numeric-safety policy, inherited by every member via `[lints] workspace = true`.
 # clippy must not auto-rewrite numeric literals or float comparisons: `.clamp()`,

--- a/docs/contributing/release.md
+++ b/docs/contributing/release.md
@@ -61,7 +61,7 @@ A changeset states a bump level for **npm packages**. A change can be additive i
 { "majorOffset": 1, "reason": "…which crate's public API broke…", "refs": ["#3210"] }
 ```
 
-`sync-versions.js` adds `majorOffset` to the **major** of the npm-derived version when it writes the Rust manifests. npm 6.1.0 with `majorOffset: 1` publishes the crates at 7.1.0; the npm packages, the root `package.json` and the `v*` tag stay on 6.1.0. At `majorOffset: 0` — where the repo is today — the two versions are the same string.
+`sync-versions.js` adds `majorOffset` to the **major** of the npm-derived version when it writes the Rust manifests. npm 6.1.0 with `majorOffset: 1` publishes the crates at 7.1.0; the npm packages, the root `package.json` and the `v*` tag stay on 6.1.0. At `majorOffset: 0` the two versions are the same string; the repo is at `1`, so the crates run one major ahead of the npm packages.
 
 - Minor and patch keep tracking npm, so raising the offset is a **once per Rust-only major** edit, not a per-release chore.
 - A non-zero offset without a `reason` and at least one `refs` entry is a hard failure: a permanent major-version claim about a published crate has to say what broke.

--- a/rust-major-offset.json
+++ b/rust-major-offset.json
@@ -1,6 +1,11 @@
 {
   "$comment": "How many MAJOR versions ahead of the npm packages the published Rust crates run. scripts/sync-versions.js applies it when writing the Rust manifests; scripts/check-rust-major-offset.mjs fails CI when the manifests and this file disagree. See scripts/lib/rust-major-offset.mjs for why an offset and not an absolute override, and docs/contributing/release.md for how to raise it. A non-zero offset MUST carry `reason` and `refs`.",
-  "majorOffset": 0,
-  "reason": "",
-  "refs": []
+  "majorOffset": 1,
+  "reason": "Three published crates broke their public API while npm carried only a minor, and a changeset written about the TypeScript API cannot express a Rust break. Measured with cargo-semver-checks against the published 6.0.1: ifc-lite-processing has MeshData::with_style_metadata going from 2 parameters to 3 and MeshData gaining a public material_id field; ifc-lite-geometry has SubMeshCollection gaining ids_are_materials; ifc-lite-export has StepOptions gaining filename and time_stamp, plus MergedOptions and MergedStats gaining fields. None of those structs is #[non_exhaustive], so any downstream exhaustive struct literal stops compiling, and the changed method arity breaks callers at the call site. Shipped as a minor these reach anyone on ^6.0 through an ordinary cargo update, with no opt-in and no signal.",
+  "refs": [
+    "#3199",
+    "#3210",
+    "#3216",
+    "#3227"
+  ]
 }

--- a/rust/ffi/Cargo.toml
+++ b/rust/ffi/Cargo.toml
@@ -33,7 +33,7 @@ mimalloc = { version = "0.1", optional = true }
 # A path-only dep fails publish ("dependency does not specify a version").
 # `scripts/sync-versions.js` keeps this literal aligned with the workspace
 # version on every `changeset version` bump.
-ifc-lite-processing = { version = "6.0.1", path = "../processing" }
+ifc-lite-processing = { version = "7.0.1", path = "../processing" }
 rayon = "1.10"
 serde_json = "1.0"
 

--- a/rust/processing/Cargo.toml
+++ b/rust/processing/Cargo.toml
@@ -31,11 +31,11 @@ name = "csg_scaling_bench"
 required-features = ["csg-capture"]
 
 [dependencies]
-ifc-lite-core = { version = "6.0.1", path = "../core" }
+ifc-lite-core = { version = "7.0.1", path = "../core" }
 # CSG runs on the pure-Rust exact kernel inside ifc-lite-geometry on every
 # target (the Manifold C++ kernel was removed in the kernel consolidation —
 # see docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { version = "6.0.1", path = "../geometry", default-features = false }
+ifc-lite-geometry = { version = "7.0.1", path = "../geometry", default-features = false }
 rayon = "1.10"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -48,7 +48,7 @@ tracing = "0.1"
 # deadlock regression here diagnoses a worker panic the same way the geometry
 # suites do instead of carrying its own copy of the two-arm match. Already a
 # normal dependency of this crate; the feature is test-only.
-ifc-lite-geometry = { version = "6.0.1", path = "../geometry", default-features = false, features = ["test-support"] }
+ifc-lite-geometry = { version = "7.0.1", path = "../geometry", default-features = false, features = ["test-support"] }
 
 [lints]
 workspace = true

--- a/rust/wasm-bindings/Cargo.toml
+++ b/rust/wasm-bindings/Cargo.toml
@@ -42,14 +42,14 @@ ifc-lite-core.workspace = true
 # same kernel on wasm32 and native. The Manifold C++ kernel and its
 # LLVM/emsdk build prerequisites were removed in the kernel
 # consolidation (docs/architecture/geometry-pipeline.md).
-ifc-lite-geometry = { version = "6.0.1", path = "../geometry", default-features = false, features = [] }
+ifc-lite-geometry = { version = "7.0.1", path = "../geometry", default-features = false, features = [] }
 # Canonical 2D-symbol extractor lives here; the wasm bindings just
 # delegate (issue #843 follow-up — full parity, one implementation).
-ifc-lite-processing = { version = "6.0.1", path = "../processing" }
+ifc-lite-processing = { version = "7.0.1", path = "../processing" }
 # Pure-geometry clash kernel (BVH broad phase + exact triangle narrow phase).
-ifc-lite-clash = { version = "6.0.1", path = "../clash" }
+ifc-lite-clash = { version = "7.0.1", path = "../clash" }
 # Domain-format exporters (HBJSON, OBJ, glTF/GLB, CSV, JSON, JSON-LD, STEP, IFC5, Merged).
-ifc-lite-export = { version = "6.0.1", path = "../export" }
+ifc-lite-export = { version = "7.0.1", path = "../export" }
 js-sys = "=0.3.103"
 rayon = "1.10"
 # `ifc-lite-geometry` uses rayon `par_iter` (e.g. FacetedBrep


### PR DESCRIPTION
Refs #3216. **Declares that three published crates broke their public API, so the Rust crates publish at 7.0.1 instead of 6.1.0.** Louis asked for this directly; it is his to review before it merges.

This is a permanent public claim — crates.io cannot be unpublished — so the evidence is stated in the form that can actually fail.

## The evidence, and why the run matters

Against the published 6.0.1, with `cargo +stable semver-checks check-release --release-type minor`, all three exit **100**, "semver requires new major version":

    ifc-lite-processing   MeshData::with_style_metadata      2 params -> 3
                          MeshData                           gains pub material_id
    ifc-lite-geometry     SubMeshCollection                  gains pub ids_are_materials
    ifc-lite-export       StepOptions                        gains filename, time_stamp
                          MergedOptions                      gains unit_reconciliation,
                                                             merge_sites, merge_buildings,
                                                             merge_storeys
                          MergedStats                        gains federated_model_count,
                                                             unmerged_model_count,
                                                             unit_rescale_required, warnings

**`--release-type minor` is the point, and an earlier draft of this PR got it wrong.** Once the manifests read 7.0.1, the plain `--baseline-version 6.0.1` invocation reports `(major change)` and skips every lint:

    Checking ifc-lite-export v6.0.1 -> v7.0.1 (major change)
     Checked [0.000s] 0 checks: 0 pass, 254 skip
     Summary no semver update required            exit 0

A major absorbs any change, so that run **cannot fail** and proves nothing. I cited it as evidence in the first draft. The minor form discriminates: `196 checks, 195 pass, 1 fail`.

The same caveat applies to `check-rust-semver.mjs` reporting "every Rust API change fits 7.0.1". True, and it answers *is the bump big enough*, never *was a major needed*. Please do not cite it later as proof of necessity.

## Why 1, and not more or less

One major covers any number of breaks, and semver has no two-major concept. Not too large either: none of the five structs is `#[non_exhaustive]` — which the lint firing already implies, since `constructible_struct_adds_field` only fires on structs a downstream crate can build with an exhaustive literal. All 7 crates are at 6.0.1 on crates.io, so 7.0.1 is free and strictly ahead.

Shipped as 6.1.0, these reach anyone on `^6.0` through an ordinary `cargo update`, with no opt-in and no signal.

## Why a PR to main rather than an edit on #3227

#3227's head ref **is** `changeset-release/main` — that branch is the changesets action's own output, so editing it edits a generated artifact, and every push to main regenerates it. The regeneration is a rebuild whose inputs never held the value, not a commit reverting a commit, so `git log` on the file shows exactly one commit introducing it at `0` (`35277c0f`, the #3305 merge) and a later reader concludes nobody ever set it.

I observed that branch carrying `majorOffset: 1` and then carrying `0` again after a forced update. The intermediate state is not recoverable from history, which is the argument rather than a gap in it.

## Why the manifests are here

The offset alone fails its own gate. `check-rust-major-offset.mjs` exits 1 with 15 DRIFT lines and says: *"run `node scripts/sync-versions.js` and commit the manifests"*. I tried the offset-only form first and watched it fail. `Cargo.lock` is included because sync-versions writes it and CI runs `cargo metadata --locked`.

Every manifest edit is exactly what the script produces — reproduced by taking clean `origin/main`, changing only `rust-major-offset.json`, running the script, and diffing the whole tree against this commit: no differences anywhere in the repo.

## Also in this diff

`docs/contributing/release.md` said the repo is at `majorOffset: 0` — a sentence this commit makes false, in the document that documents this file. One clause, corrected here rather than left for the next person raising an offset to read and believe.

## Verification

    check-rust-major-offset.mjs   exit 0
    check-module-size.mjs         exit 0
    check-changesets.mjs          exit 0
    cargo check -p ifc-lite-processing / cargo metadata   exit 0
    --release-type minor, all three crates                exit 100

## Deferred, pre-existing

`docs/guide/installation.md:227` pins `ifc-lite-core = "4"`, already two majors stale and becoming three. And `.changeset/rep-item-identity-across-boundary.md:20` asserts "there is no `cargo-semver-checks` anywhere in the repo", false since #3305 — and that text publishes into the CHANGELOG in this same release. Both are worth a separate fix; neither is created by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Updates**
  * Updated the Rust crate suite to version 7.0.1.
  * Synchronized internal crate dependencies with the 7.0.1 release.

* **Documentation**
  * Clarified that Rust crate versions are currently one major version ahead of npm packages.

* **Configuration**
  * Updated versioning configuration to record the Rust major-version offset and related tracking references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->