### PR TITLE
fix(cli): CSV and JSON exports named the coalesced IFC class, not the declared one

### DIFF
--- a/.changeset/export-csv-json-exact-class.md
+++ b/.changeset/export-csv-json-exact-class.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`ifc-lite export --format csv` and `--format json` now name the IFC class the file declares in the `Type` column, instead of the class its `IfcTypeEnum` value coalesces to.
+
+`IfcTypeEnum` maps several STEP class names onto one value on purpose, so the viewer's scope chips show one chip per family: `IfcDoorStandardCase` shares `IfcDoor`, `IfcSlabStandardCase` shares `IfcSlab`, and `IfcDistributionFlowElement` and `IfcDistributionControlElement` both share `IfcDistributionElement`. `EntityTable.getTypeName` resolves through that enum and only falls back to the parsed name when the enum says `Unknown`, so a known-but-coalesced class never reached the fallback. A CSV of the seven-element model in `export.exact-type.test.ts` named an `IFCDOORSTANDARDCASE` line `IfcDoor`, an `IFCSLABSTANDARDCASE` `IfcSlab`, and two different distribution classes `IfcDistributionElement` — while `IfcWallStandardCase` came through intact, because it happens to hold its own enum value. That last one is what made the loss hard to notice: a consumer had no rule for which classes were trustworthy. The class is unrecoverable once written, and the export disagreed with the Parquet exporter and with `StepExporter`, which re-emit every class verbatim.
+
+The `Type` column now reads through `exactTypeName` from `@ifc-lite/data`, the accessor the Parquet exporter already uses, so all three exporters answer the same class for the same line. A class no IFC schema declares still degrades to `Unknown` and is never invented into a name.
+
+Selection is unchanged: `--type IfcDoor` still returns the `IFCDOORSTANDARDCASE` line — `--type` expands through `IFC_SUBTYPES`, not through the type enum — and `getTypeName` itself is untouched, so saved filters and the scope chips keep matching on the coalesced family name.
+
+CSV and JSON also stop keeping two row builders for one column list. They used to delegate to the SDK's `bim.export.csv`/`.json` when every requested column was a native attribute and resolve columns locally only when a quantity or property column was asked for — which is how the `Type` column came to be wrong in both, by two separate routes. Rows are now built one way, through the resolver that already answered a strict superset of the SDK's columns, over the same entities and the same CSV escaper.

--- a/packages/cli/src/commands/export.exact-type.test.ts
+++ b/packages/cli/src/commands/export.exact-type.test.ts
@@ -1,0 +1,208 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The `Type` column of a CSV or JSON export names the class the STEP line
+ * DECLARES, not the class the viewer groups it under.
+ *
+ * `IfcTypeEnum` coalesces several spellings onto one value so the scope chips
+ * render one chip per family, and `EntityTable.getTypeName` resolves through
+ * that enum — so an `IFCDOORSTANDARDCASE` line exported as `IfcDoor`, an
+ * `IFCSLABSTANDARDCASE` as `IfcSlab`, and both `IFCDISTRIBUTIONFLOWELEMENT`
+ * and `IFCDISTRIBUTIONCONTROLELEMENT` as `IfcDistributionElement`, while
+ * `IFCWALLSTANDARDCASE` survived only because it happens to hold its own enum
+ * value. The Parquet exporter was fixed to use `exactTypeName`; CSV and JSON
+ * shared the same lossy resolver and were not.
+ *
+ * The inconsistency was the real damage: a consumer had no rule for which
+ * classes were trustworthy, so this pins BOTH directions —
+ *
+ *  - every coalesced class exports under its own name, by name, not by count;
+ *  - selection is UNCHANGED. `--type IfcDoor` still returns the
+ *    `IFCDOORSTANDARDCASE` line, and `EntityTable.getTypeName` still answers
+ *    the coalesced family name — saved filters, the scope chips and
+ *    `filter-evaluate.ts` all match on that answer.
+ *
+ * All four export paths are covered: CSV and JSON each build their rows one
+ * way for the default columns and another way for custom (quantity/property)
+ * columns, and the defect was in both.
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { exactTypeName } from '@ifc-lite/data';
+import { exportCommand } from './export.js';
+import { createHeadlessContext } from '../loader.js';
+
+/**
+ * One STEP line per class under test. Written out rather than read from a
+ * committed sample so the classes being asserted are visible beside the
+ * assertions, and so this never depends on `pnpm fixtures`.
+ */
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition[DesignTransferView]'),'2;1');
+FILE_NAME('exact-type.ifc','2026-01-01T00:00:00',$,$,'ifc-lite','ifc-lite','Nobody');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('0KhR8hr7H8eewFRKm6V1bJ',$,'Exact Type Project',$,$,$,$,(#14),#9);
+#2=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#3=IFCSIUNIT(*,.AREAUNIT.,$,.SQUARE_METRE.);
+#4=IFCSIUNIT(*,.VOLUMEUNIT.,$,.CUBIC_METRE.);
+#9=IFCUNITASSIGNMENT((#2,#3,#4));
+#10=IFCCARTESIANPOINT((0.,0.,0.));
+#11=IFCDIRECTION((0.,0.,1.));
+#12=IFCDIRECTION((1.,0.,0.));
+#13=IFCAXIS2PLACEMENT3D(#10,#11,#12);
+#14=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-05,#13,$);
+#20=IFCLOCALPLACEMENT($,#13);
+#30=IFCSITE('3WWqaXu9L0y8XqF6lHx6cU',$,'My Site',$,$,#20,$,$,.ELEMENT.,$,$,$,$,$);
+#36=IFCBUILDING('3eJSUU$fr7WPzBLDr3NCgH',$,'My Building',$,$,#20,$,$,.ELEMENT.,$,$,$);
+#42=IFCBUILDINGSTOREY('14hpMBCM10Oug9g6WpN$Er',$,'My Storey',$,$,#20,$,$,.ELEMENT.,0.);
+#48=IFCRELAGGREGATES('3B4BOU0cfA28tnsk$BqNU5',$,$,$,#1,(#30));
+#49=IFCRELAGGREGATES('3B4BOU0cfA28tnsk$BqNU6',$,$,$,#30,(#36));
+#50=IFCRELAGGREGATES('3B4BOU0cfA28tnsk$BqNU7',$,$,$,#36,(#42));
+#100=IFCWALLSTANDARDCASE('1WWqaXu9L0y8XqF6lHx601',$,'Wall SC',$,$,#20,$,$,$);
+#101=IFCDOORSTANDARDCASE('1WWqaXu9L0y8XqF6lHx602',$,'Door SC',$,$,#20,$,$,$,$,$,$,$);
+#102=IFCSLABSTANDARDCASE('1WWqaXu9L0y8XqF6lHx603',$,'Slab SC',$,$,#20,$,$,$);
+#103=IFCDISTRIBUTIONFLOWELEMENT('1WWqaXu9L0y8XqF6lHx604',$,'Flow El',$,$,#20,$,$);
+#104=IFCDISTRIBUTIONCONTROLELEMENT('1WWqaXu9L0y8XqF6lHx605',$,'Control El',$,$,#20,$,$);
+#105=IFCWALL('1WWqaXu9L0y8XqF6lHx606',$,'Plain Wall',$,$,#20,$,$,$);
+#106=IFCFICTIONALWIDGET('1WWqaXu9L0y8XqF6lHx607',$,'Not A Class',$,$,#20,$,$);
+#110=IFCRELCONTAINEDINSPATIALSTRUCTURE('3B4BOU0cfA28tnsk$BqNU8',$,$,$,(#100,#101,#102,#103,#104,#105,#106),#42);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+/**
+ * The required entities, by GlobalId — a NAMED list, not a row count, so a
+ * regression that drops or renames one row fails on that row's name instead
+ * of passing under a floor some other row happens to satisfy.
+ */
+const EXPECTED = new Map<string, string>([
+  ['1WWqaXu9L0y8XqF6lHx601', 'IfcWallStandardCase'],
+  ['1WWqaXu9L0y8XqF6lHx602', 'IfcDoorStandardCase'],
+  ['1WWqaXu9L0y8XqF6lHx603', 'IfcSlabStandardCase'],
+  ['1WWqaXu9L0y8XqF6lHx604', 'IfcDistributionFlowElement'],
+  ['1WWqaXu9L0y8XqF6lHx605', 'IfcDistributionControlElement'],
+  ['1WWqaXu9L0y8XqF6lHx606', 'IfcWall'],
+]);
+
+/** The class no IFC schema declares. Its GlobalId must never carry a name. */
+const UNDECLARED_GLOBAL_ID = '1WWqaXu9L0y8XqF6lHx607';
+
+const dir = mkdtempSync(join(tmpdir(), 'ifclite-export-exact-type-'));
+const SRC = join(dir, 'exact-type.ifc');
+writeFileSync(SRC, IFC);
+
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+let seq = 0;
+function outFile(ext: string): string {
+  return join(dir, `out-${seq++}.${ext}`);
+}
+
+/** Parse a CSV export into GlobalId → Type. */
+function csvTypes(text: string): Map<string, string> {
+  const lines = text.split('\n').filter(Boolean);
+  const header = lines[0].split(',');
+  const typeCol = header.indexOf('Type');
+  const idCol = header.indexOf('GlobalId');
+  expect(typeCol).toBeGreaterThanOrEqual(0);
+  expect(idCol).toBeGreaterThanOrEqual(0);
+  const out = new Map<string, string>();
+  for (const line of lines.slice(1)) {
+    const cells = line.split(',');
+    out.set(cells[idCol], cells[typeCol]);
+  }
+  return out;
+}
+
+/** Parse a JSON export into GlobalId → Type. */
+function jsonTypes(text: string): Map<string, string> {
+  const rows = JSON.parse(text) as Record<string, string>[];
+  return new Map(rows.map((r) => [r.GlobalId, r.Type]));
+}
+
+/**
+ * Every named entity must be present with its declared class — and the
+ * anti-vacuity half: a shape that exported nothing, or that dropped the rows
+ * being asserted, fails here rather than passing an empty forEach.
+ */
+function expectExactTypes(actual: Map<string, string>): void {
+  for (const [globalId, expected] of EXPECTED) {
+    expect(actual.get(globalId), `Type for ${globalId}`).toBe(expected);
+  }
+  expect(actual.size).toBeGreaterThanOrEqual(EXPECTED.size);
+}
+
+describe('CSV/JSON export names the declared IFC class', () => {
+  it('CSV, default columns', async () => {
+    const out = outFile('csv');
+    await exportCommand([SRC, '--format', 'csv', '--out', out]);
+    expectExactTypes(csvTypes(readFileSync(out, 'utf8')));
+  });
+
+  it('CSV, custom columns', async () => {
+    const out = outFile('csv');
+    await exportCommand([SRC, '--format', 'csv', '--columns', 'GlobalId,Type,Tag', '--out', out]);
+    expectExactTypes(csvTypes(readFileSync(out, 'utf8')));
+  });
+
+  it('JSON, default columns', async () => {
+    const out = outFile('json');
+    await exportCommand([SRC, '--format', 'json', '--out', out]);
+    expectExactTypes(jsonTypes(readFileSync(out, 'utf8')));
+  });
+
+  it('JSON, custom columns', async () => {
+    const out = outFile('json');
+    await exportCommand([SRC, '--format', 'json', '--columns', 'GlobalId,Type,Tag', '--out', out]);
+    expectExactTypes(jsonTypes(readFileSync(out, 'utf8')));
+  });
+
+  it('a class no schema declares degrades to Unknown, and is not invented into a name', async () => {
+    const { store } = await createHeadlessContext(SRC);
+    expect(exactTypeName(store.entities, 106)).toBe('Unknown');
+
+    const out = outFile('json');
+    await exportCommand([SRC, '--format', 'json', '--out', out]);
+    const text = readFileSync(out, 'utf8');
+    expect(jsonTypes(text).has(UNDECLARED_GLOBAL_ID)).toBe(false);
+    // Not merely absent as a row: the invented spellings must appear nowhere.
+    expect(text).not.toContain('FictionalWidget');
+    expect(text).not.toContain('FICTIONALWIDGET');
+  });
+});
+
+describe('grouping is unchanged: --type still selects by the coalesced family', () => {
+  it('--type IfcDoor still selects the IfcDoorStandardCase line, and prints its declared class', async () => {
+    const out = outFile('json');
+    await exportCommand([SRC, '--format', 'json', '--type', 'IfcDoor', '--out', out]);
+    const types = jsonTypes(readFileSync(out, 'utf8'));
+    expect([...types.keys()]).toEqual(['1WWqaXu9L0y8XqF6lHx602']);
+    expect(types.get('1WWqaXu9L0y8XqF6lHx602')).toBe('IfcDoorStandardCase');
+  });
+
+  it('the declared class round-trips as a --type selector', async () => {
+    const out = outFile('json');
+    await exportCommand([SRC, '--format', 'json', '--type', 'IfcDistributionFlowElement', '--out', out]);
+    const types = jsonTypes(readFileSync(out, 'utf8'));
+    expect([...types.entries()]).toEqual([
+      ['1WWqaXu9L0y8XqF6lHx604', 'IfcDistributionFlowElement'],
+    ]);
+  });
+
+  it('the store still groups by the coalesced class', async () => {
+    const { store } = await createHeadlessContext(SRC);
+    // The seam this fix deliberately does NOT move: `getTypeName` is what
+    // saved filters and the scope chips match on.
+    expect(store.entities.getTypeName(101)).toBe('IfcDoor');
+    expect(store.entities.getTypeName(103)).toBe('IfcDistributionElement');
+    expect(store.entities.getTypeName(104)).toBe('IfcDistributionElement');
+  });
+});

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -14,6 +14,7 @@ import { writeFile, readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { GeometryProcessor, isNoRenderGeometryError } from '@ifc-lite/geometry';
 import { countGlbMeshes, escapeCsvCell } from '@ifc-lite/export';
+import { exactTypeName } from '@ifc-lite/data';
 import { createHeadlessContext } from '../loader.js';
 import { getFlag, hasFlag, fatal, writeOutput, validateLimit } from '../output.js';
 import { logger } from '../logger.js';
@@ -62,17 +63,30 @@ function normalizeTypeName(typeStr: string): string {
 }
 
 /**
- * B5: Resolve a column value from an entity, searching entity attributes,
- * property sets, AND quantity sets (by bare quantity name or QsetName.QuantityName).
+ * Resolve a column value from an entity — entity attributes, property sets AND
+ * quantity sets (bare name or `SetName.ValueName`) — returning the raw value
+ * (number, boolean, string, or null) so JSON preserves types.
+ *
+ * The `Type` column is the class the STEP line DECLARES: `exactTypeName`, not
+ * `entity.type`. `EntityData.type` is `EntityTable.getTypeName`, which resolves
+ * through `IfcTypeEnum`, and that enum coalesces class names on purpose so the
+ * viewer's scope chips render one chip per family — so this column named an
+ * `IFCDOORSTANDARDCASE` line `IfcDoor`, an `IFCSLABSTANDARDCASE` `IfcSlab`, and
+ * both `IFCDISTRIBUTIONFLOWELEMENT` and `IFCDISTRIBUTIONCONTROLELEMENT`
+ * `IfcDistributionElement`, while `IfcWallStandardCase` came through intact
+ * only because it happens to hold its own enum value. The class is
+ * unrecoverable once written, and disagreed with the Parquet exporter and with
+ * `StepExporter`, which re-emit every class verbatim.
+ *
+ * Only the exported VALUE moves. `EntityData.type` is public API other
+ * consumers legitimately want the grouping answer from, `--type` selection
+ * expands through `IFC_SUBTYPES`, and saved filters match `getTypeName` — none
+ * of those are touched here.
  */
-/**
- * Resolve a column value from an entity, returning the raw value
- * (number, boolean, string, or null) to preserve types in JSON output.
- */
-function resolveColumnValue(entity: any, col: string, bim: any): unknown {
+function resolveColumnValue(entity: any, col: string, bim: any, store: IfcDataStore): unknown {
   // Native entity attributes
   if (col === 'Name' || col === 'name') return entity.name ?? null;
-  if (col === 'Type' || col === 'type') return entity.type ?? null;
+  if (col === 'Type' || col === 'type') return exactTypeName(store.entities, entity.ref.expressId);
   if (col === 'GlobalId' || col === 'globalId') return entity.globalId ?? null;
   if (col === 'Description' || col === 'description') return entity.description ?? null;
   if (col === 'ObjectType' || col === 'objectType') return entity.objectType ?? null;
@@ -242,10 +256,6 @@ export async function exportCommand(args: string[]): Promise<void> {
     ? columnsStr.split(',')
     : ['Type', 'Name', 'GlobalId', 'Description', 'ObjectType'];
 
-  // Check if any columns need quantity/property resolution (non-native columns)
-  const nativeColumns = new Set(['Name', 'name', 'Type', 'type', 'GlobalId', 'globalId', 'Description', 'description', 'ObjectType', 'objectType']);
-  const hasCustomColumns = columns.some(c => !nativeColumns.has(c));
-
   // A filter on a whole-model format is ignored, not an error. Reported once here
   // rather than inside a single case, so every whole-model format says so — the
   // energy exporters used to accept `--type`/`--where`/`--limit` in silence.
@@ -254,38 +264,26 @@ export async function exportCommand(args: string[]): Promise<void> {
   }
 
   switch (format) {
-    case 'csv': {
-      if (hasCustomColumns) {
-        // B5: Use our own CSV generation that supports quantity columns
-        const rows: string[][] = [columns];
-        for (const entity of entities) {
-          rows.push(columns.map(col => columnValueToCsv(resolveColumnValue(entity, col, bim))));
-        }
+    // CSV and JSON build their rows HERE, for every column set. They used to
+    // delegate to `bim.export.csv`/`.json` when every column was a native
+    // attribute and resolve locally only for a quantity/property column — two
+    // row builders over one column list, which is how the `Type` column came to
+    // be wrong by two separate routes. `resolveColumnValue` answers a strict
+    // superset of the SDK's columns (bare quantity/property names too), escapes
+    // through the same `escapeCsvCell`, and walks the same `entities` the refs
+    // come from, so the rows are the same rows.
+    case 'csv':
+    case 'json': {
+      const table: unknown[][] = entities.map((entity: any) =>
+        columns.map(col => resolveColumnValue(entity, col, bim, store)));
+      if (format === 'csv') {
+        const rows = [columns, ...table.map(r => r.map(columnValueToCsv))];
         const csv = rows.map(r => r.map(cell => escapeCsv(cell, separator)).join(separator)).join('\n');
         await writeOutput(csv, outPath);
       } else {
-        const csv = bim.export.csv(refs, { columns, separator });
-        await writeOutput(csv, outPath);
-      }
-      break;
-    }
-    case 'json': {
-      if (hasCustomColumns) {
-        // B5: Use our own JSON generation that supports quantity columns (raw values preserved)
-        const result: Record<string, unknown>[] = [];
-        for (const entity of entities) {
-          const row: Record<string, unknown> = {};
-          for (const col of columns) {
-            row[col] = resolveColumnValue(entity, col, bim);
-          }
-          result.push(row);
-        }
-        const content = JSON.stringify(result, null, 2);
-        await writeOutput(content, outPath);
-      } else {
-        const json = bim.export.json(refs, columns);
-        const content = JSON.stringify(json, null, 2);
-        await writeOutput(content, outPath);
+        // Raw values, not strings: a quantity column stays a number in JSON.
+        const result = table.map(r => Object.fromEntries(columns.map((col, i) => [col, r[i]])));
+        await writeOutput(JSON.stringify(result, null, 2), outPath);
       }
       break;
     }

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -165,7 +165,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/bcf': '9733284863521991257',
   'packages/cache': '14926850005686407910',
   'packages/clash': '781065910217740673',
-  'packages/cli': '11939142867866651937',
+  'packages/cli': '18095568320687894335',
   'packages/codegen': '18074740064258807121',
   'packages/collab': '10345031293646670667',
   'packages/collab-server': '6370800919640161263',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -179,7 +179,7 @@
    433 packages/clash/src/duplicates.ts
    546 packages/cli/src/commands/ask.ts
    495 packages/cli/src/commands/create.ts
-   436 packages/cli/src/commands/export.ts
+   434 packages/cli/src/commands/export.ts
    518 packages/cli/src/commands/extract-entities.ts
    609 packages/cli/src/commands/query.ts
    752 packages/cli/src/headless-backend.ts


### PR DESCRIPTION
Stacked on #3325 — it introduces `exactTypeName`, which this PR consumes, so it cannot build against `main` today. **Base is `export-parquet-exact-class`, not `main`.**

> [!WARNING]
> **The CI test lanes have not run on this PR, and their absence looks identical to a pass.** `.github/workflows/test.yml` triggers on `pull_request: branches: [main]` only, and CodeRabbit reports `Review skipped: reviews are disabled for this base branch`. The green ticks above are Vercel build-skips, nothing more. Retarget to `main` once #3325 lands to get a real run; the gates listed at the bottom were run locally in the meantime.

## The defect, reproduced before changing anything

`ifc-lite export` on a seven-element IFC4 file, all four CSV/JSON paths (default columns go through `bim.export.csv`/`.json`, custom columns through the command's own resolver — both were wrong):

```
Type,Name,GlobalId,Description,ObjectType
IfcWallStandardCase,Wall SC,1WWqaXu9L0y8XqF6lHx601,,
IfcDoor,Door SC,1WWqaXu9L0y8XqF6lHx602,,
IfcSlab,Slab SC,1WWqaXu9L0y8XqF6lHx603,,
IfcDistributionElement,Flow El,1WWqaXu9L0y8XqF6lHx604,,
IfcDistributionElement,Control El,1WWqaXu9L0y8XqF6lHx605,,
IfcWall,Plain Wall,1WWqaXu9L0y8XqF6lHx606,,
```

Per entity, on the same parse:

```
#100 step=IFCWALLSTANDARDCASE           getTypeName=IfcWallStandardCase    getExactTypeName=IfcWallStandardCase
#101 step=IFCDOORSTANDARDCASE           getTypeName=IfcDoor                getExactTypeName=IfcDoorStandardCase
#102 step=IFCSLABSTANDARDCASE           getTypeName=IfcSlab                getExactTypeName=IfcSlabStandardCase
#103 step=IFCDISTRIBUTIONFLOWELEMENT    getTypeName=IfcDistributionElement getExactTypeName=IfcDistributionFlowElement
#104 step=IFCDISTRIBUTIONCONTROLELEMENT getTypeName=IfcDistributionElement getExactTypeName=IfcDistributionControlElement
#105 step=IFCWALL                       getTypeName=IfcWall                getExactTypeName=IfcWall
#106 step=IFCFICTIONALWIDGET            getTypeName=Unknown                getExactTypeName=Unknown
```

`IfcWallStandardCase` surviving is what made this hard to notice: a consumer had no rule for which classes were trustworthy, and the class is unrecoverable once written.

## The fix

The `Type` column reads `exactTypeName(store.entities, expressId)` — the accessor #3325 added and the Parquet exporter already uses — so all three exporters answer the same class for the same line. A class no schema declares still degrades to `Unknown`, never to an invented name.

## Why the export call site, and not `EntityNode.type` / `EntityData.type`

Both are public API, and other consumers legitimately want the grouping answer. `packages/query/src/fluent-api.ts` filters on `entity.type === type`, and `filter-evaluate.ts` matches saved filters against `getTypeName`; making either exact would stop `IfcDoor` matching an `IFCDOORSTANDARDCASE` line. Only the exported value moves. `--type IfcDoor` still returns that line — selection expands through `IFC_SUBTYPES`, untouched — and `getTypeName` is unchanged.

`getExactTypeName` is optional on `EntityTable` on purpose (118 sites reach it through `as unknown as EntityTable`), so this calls it through `exactTypeName`, whose single shared degradation falls back to `getTypeName` when the accessor is absent. No second fallback is invented here.

## Two row builders collapsed into one

CSV and JSON delegated to `bim.export.csv`/`.json` when every column was a native attribute and resolved columns locally only when a quantity/property column was asked for — which is how one `Type` column came to be wrong by two separate routes. Rows are now built once, by the resolver that already answered a strict superset of the SDK's columns (bare quantity and property names too), over the same `entities` the refs come from and through the same `escapeCsvCell`.

## Tests

`packages/cli/src/commands/export.exact-type.test.ts`, 8 tests over all four paths, asserting a **named** entity list keyed by GlobalId rather than a row count. Both directions: the declared class is exported, AND selection/grouping is unchanged (`--type IfcDoor` still returns the StandardCase line; `getTypeName` still answers `IfcDoor`/`IfcDistributionElement`). Negative control: `IFCFICTIONALWIDGET` resolves to `Unknown`, produces no row, and neither spelling appears anywhere in the output.

RED before the fix: 6 of 8 failed with `expected 'IfcDoor' to be 'IfcDoorStandardCase'`. GREEN after.

Mutation check on the anti-vacuity guard — replacing the row loop's source with an empty array turned every named assertion into `expected undefined to be 'IfcWallStandardCase'` (the absence-only negative control still passed, which is exactly why the named list is there). Restored by the inverse edit; `diff` against the pre-mutation copy is byte-identical.

One assertion in the first draft pinned behaviour that never existed — `--type IfcDistributionElement` selects nothing, because selection goes through `IFC_SUBTYPES`, which has no entry for that family. That is pre-existing and untouched here; the test now pins what actually happens.

## Module size

`export.ts` shrank to 434 lines. Its budget ratchets **436 -> 434** (down, never up), with the `packages/cli` `ALLOWLIST_DIGESTS` entry re-pinned in the same commit.

## Gates run

`check:module-size` OK · `check:api-surface` OK (42 packages, 4252 exports; no surface change) · `pnpm lint` no errors · `@ifc-lite/cli` typecheck OK · `@ifc-lite/cli` tests 526 passed / 8 skipped, 50 files · `check-test-wiring`, `check-source-text-assertions`, `check-ci-path-coverage` OK.

Grouping proof, run locally against this branch: `apps/viewer/src/lib/search/*.test.ts` + `apps/viewer/src/lib/lists/*.test.ts` (which includes `scope-types.test.ts` and both `filter-evaluate` suites) — 234 tests, 52 suites, 0 fail; plus `serverDataModel.exactType.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

