### PR TITLE
fix(bcf): write viewpoint cameras in the order and cardinality visinfo.xsd declares

### DIFF
--- a/.changeset/bcf-camera-choice.md
+++ b/.changeset/bcf-camera-choice.md
@@ -1,0 +1,19 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Write BCF viewpoint cameras in the order and cardinality each schema declares.
+
+`visinfo.xsd` disagrees between versions, and the writer followed neither:
+
+- BCF 2.1 lists `OrthogonalCamera` before `PerspectiveCamera` in
+  `VisualizationInfo`'s `xs:sequence`. The writer emitted the perspective
+  camera first, so a viewpoint carrying both cameras produced a `.bcfv` that
+  fails 2.1 validation ("Element 'OrthogonalCamera': This element is not
+  expected"). Both cameras are now written orthogonal-first.
+- BCF 3.0 replaced that pair with an `xs:choice` carrying no `minOccurs` and no
+  `maxOccurs` — exactly one camera, required. The writer emitted both when both
+  were set, and none when neither was; the latter is what `createBCFFromIDSReport`
+  produces for every failing entity whenever no `entityBounds` are supplied.
+  Writing a 3.0 archive now fails with an error naming the viewpoint rather than
+  producing markup no conforming reader has to accept.

--- a/.changeset/bcf-camera-choice.md
+++ b/.changeset/bcf-camera-choice.md
@@ -2,7 +2,7 @@
 '@ifc-lite/bcf': patch
 ---
 
-Write BCF viewpoint cameras in the order and cardinality each schema declares.
+Write BCF viewpoint cameras in the order and cardinality each schema declares, and refuse non-finite numbers rather than writing them.
 
 `visinfo.xsd` disagrees between versions, and the writer followed neither:
 
@@ -17,3 +17,25 @@ Write BCF viewpoint cameras in the order and cardinality each schema declares.
   produces for every failing entity whenever no `entityBounds` are supplied.
   Writing a 3.0 archive now fails with an error naming the viewpoint rather than
   producing markup no conforming reader has to accept.
+
+Separately, every number the writer emits under an XSD numeric type is now
+required to be finite. `Camera/AspectRatio` was guarded with `!(aspectRatio > 0)`,
+and `Infinity > 0` is `true`, so `Infinity` was written verbatim and xmllint
+rejected the archive: "Element 'AspectRatio': 'Infinity' is not a valid value of
+the atomic type 'PositiveDouble'". The same gap was unguarded on `FieldOfView`,
+`ViewToWorldScale`, `Bitmap/Height`, `Topic/Index` and every camera, line,
+clipping-plane and bitmap coordinate. `NaN` needs the same guard for a different
+reason: `xs:double` accepts the lexical form `"NaN"`, so those archives validate
+while carrying a number the reader drops on the way back in. All of these now
+throw, naming the field and the viewpoint or topic.
+
+**BCF 3.0 impact on `createBCFFromIDSReport`.** At `version: '3.0'` this
+function now has no working configuration. Nothing in this repository populates
+`aspectRatio` — `computeCameraFromBounds` sets `fieldOfView` but no aspect
+ratio, and `ViewerCameraState` carries none — so a report exported with
+`entityBounds` throws on the required `AspectRatio`, and one exported without
+them throws on the required camera. Before this change the second case did not
+throw; it wrote one schema-invalid `.bcfv` per topic instead. Callers at 3.0
+must supply an `aspectRatio` on the camera; BCF 2.1 export is unaffected, and
+whether the reporter should synthesise a default aspect ratio is left open
+rather than decided here.

--- a/packages/bcf/src/numeric.ts
+++ b/packages/bcf/src/numeric.ts
@@ -3,13 +3,21 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Numeric boundary helpers for BCF.
+ * Numeric boundary helpers for BCF — both directions.
  *
  * A `.bcfzip` is an untrusted file, and every number in it arrives through a
  * bare `parseFloat`. `parseFloat` has no failure value that is out of band:
  * `"NaN"` parses to `NaN`, and `"1e999"` — a perfectly well-formed decimal
  * literal — parses to `Infinity`. Both then flow into the viewer camera, which
  * stores a pose verbatim by design.
+ *
+ * The WRITE side is the same boundary seen from the other end, and it is the
+ * half that was missing: `${Infinity}` stringifies to `"Infinity"`, which is
+ * not in `xs:double`'s lexical space (XSD 1.0 spells the infinities `INF` and
+ * `-INF`), so every non-finite number the writer touched produced an archive
+ * xmllint rejects. Keeping both halves in one file is deliberate: the read
+ * guard and the write guard have to agree on what "a usable number" means, and
+ * they can only be checked against each other while they sit side by side.
  */
 
 /**
@@ -51,4 +59,90 @@ export function parseFiniteFloat(raw: string): number | undefined {
  */
 export function usableTargetDistance(distance: number | undefined, fallback: number): number {
   return distance !== undefined && Number.isFinite(distance) && distance > 0 ? distance : fallback;
+}
+
+/**
+ * A number on its way INTO an archive, as the text an XSD numeric type will
+ * accept — or an error naming what was wrong and where.
+ *
+ * FINITENESS, not sign, is the property. That distinction is the whole bug:
+ * `Infinity > 0` is `true`, so a positivity check passes it, and
+ * `Number.isNaN(Number('Infinity'))` is `false`, so an `isNaN` check passes it
+ * too. Only `Number.isFinite` rejects the pair, and each of the three
+ * non-finite values fails the schemas a different way, which is why none of
+ * them can be left to a facet:
+ *
+ * - `Infinity`/`-Infinity` stringify to `"Infinity"`/`"-Infinity"`, which
+ *   `xs:double` does not admit at all (XSD 1.0's lexical space spells the
+ *   infinities `INF` and `-INF`), so they are rejected as "not a valid value of
+ *   the atomic type" wherever they appear.
+ * - `NaN` stringifies to `"NaN"`, which `xs:double` DOES admit. A bare
+ *   `xs:double` element — every camera/line/clipping-plane/bitmap coordinate,
+ *   `ViewToWorldScale`, `Bitmap/Height` — therefore validates while carrying a
+ *   number no consumer can use, and our own reader drops it on the way back in
+ *   ({@link parseFiniteFloat}). Schema validity is not the bar here; a value
+ *   that survives the round trip is.
+ *
+ * Refusing is the same policy the rest of the writer already applies to
+ * unrepresentable input (`writer-camera.ts`'s camera-choice and AspectRatio
+ * checks, `writer.ts`'s `Topic/@TopicType` check): we do not silently
+ * substitute a number the caller never chose, and we do not emit markup a
+ * conforming reader may reject.
+ */
+export function xsdDouble(value: number, element: string, where: string): string {
+  if (!Number.isFinite(value)) {
+    throw new Error(
+      `BCF requires a finite number for ${element} (${where} has ${value}). ` +
+        `XSD numeric types cannot express Infinity, -Infinity or NaN, so writing ` +
+        `one produces an archive that fails schema validation or loses the value ` +
+        `on read. Supply a finite number before writing.`
+    );
+  }
+  return String(value);
+}
+
+/**
+ * The `<X>/<Y>/<Z>` triple shared by `Point` and `Direction`, wrapped in
+ * `tag`, with every component checked by {@link xsdDouble}.
+ *
+ * Both schemas declare `Point` and `Direction` as three `xs:double` children in
+ * that order, and both are reached from four places (camera vectors, `Line`,
+ * `ClippingPlane`, `Bitmap`). Emitting them from one function is what stops a
+ * guard from being added to three of the four.
+ */
+export function xsdPointElement(
+  tag: string,
+  point: { x: number; y: number; z: number },
+  indent: string,
+  where: string
+): string {
+  return (
+    `\n${indent}<${tag}>` +
+    `\n${indent}  <X>${xsdDouble(point.x, `${tag}/X`, where)}</X>` +
+    `\n${indent}  <Y>${xsdDouble(point.y, `${tag}/Y`, where)}</Y>` +
+    `\n${indent}  <Z>${xsdDouble(point.z, `${tag}/Z`, where)}</Z>` +
+    `\n${indent}</${tag}>`
+  );
+}
+
+/**
+ * A number on its way into an `xs:int` element (`Topic/Index` is the only one
+ * the writer emits).
+ *
+ * `xs:int` is narrower than `xs:double` in two further ways a finiteness check
+ * alone would miss: `1.5` is not an `xs:int` ("'1.5' is not a valid value of
+ * the atomic type 'xs:int'"), and the type is 32-bit, so a whole number outside
+ * [-2^31, 2^31-1] is out of range too. `Number.isInteger` is false for `NaN`
+ * and both infinities, so finiteness comes with it rather than needing its own
+ * branch.
+ */
+export function xsdInt(value: number, element: string, where: string): string {
+  if (!Number.isInteger(value) || value < -2147483648 || value > 2147483647) {
+    throw new Error(
+      `BCF requires a 32-bit integer for ${element} (${where} has ${value}). ` +
+        `xs:int admits neither a fractional value, a non-finite one, nor one ` +
+        `outside [-2147483648, 2147483647].`
+    );
+  }
+  return String(value);
 }

--- a/packages/bcf/src/schema-validation.test.ts
+++ b/packages/bcf/src/schema-validation.test.ts
@@ -407,6 +407,191 @@ describe('BCF 3.0 AspectRatio', () => {
 });
 
 /**
+ * FINITENESS is the property, not sign and not schema-conformance.
+ *
+ * `AspectRatio` was guarded with `!(aspectRatio > 0)`, and `Infinity > 0` is
+ * `true`, so `Infinity` walked straight through a check whose doc comment
+ * claimed to enforce `PositiveDouble` and was written out verbatim. The same
+ * mistake in its other disguise shipped elsewhere in this repository within
+ * the week — `Number('Infinity')` is not `NaN`, so an `isNaN` guard passes it
+ * too. Neither a positivity test nor a NaN test is a finiteness test;
+ * `Number.isFinite` is, which is why every case below is stated against it
+ * rather than against the value's sign.
+ *
+ * The XSDs punish the three non-finite values in three different ways, so no
+ * single facet catches them and "the schema will reject it" is not a defence:
+ *
+ *  - `Infinity`/`-Infinity` stringify to `"Infinity"`/`"-Infinity"`, which are
+ *    outside `xs:double`'s lexical space altogether (XSD 1.0 spells the
+ *    infinities `INF`/`-INF`). Rejected everywhere.
+ *  - `NaN` stringifies to `"NaN"`, which `xs:double` ACCEPTS. On a facet-bearing
+ *    type it still fails (`PositiveDouble`'s `minExclusive`, `FieldOfView`'s
+ *    range), but on the plain `xs:double` elements — every coordinate,
+ *    `ViewToWorldScale`, `Bitmap/Height` — a validator sees nothing wrong while
+ *    the archive carries a number no consumer can use. Two tests below pin that
+ *    asymmetry so it cannot be mistaken for coverage.
+ *  - `Topic/Index` is `xs:int`, narrower again: `1.5` is invalid there too.
+ *
+ * The sweep is the point. The reported defect was `AspectRatio`; it was the
+ * only one of these fields with any guard at all.
+ */
+describe('non-finite numbers never reach the archive', () => {
+  /**
+   * Every numeric the writer emits under an XSD numeric type, as a mutation
+   * that puts `value` in exactly that position.
+   *
+   * Anti-vacuity for the list itself is the `emits a schema-valid ...` tests
+   * above: `maximalTopic` populates the camera, lines, clipping planes and
+   * bitmaps, so each mutator below lands on markup that is really written.
+   */
+  const NUMERICS: ReadonlyArray<
+    readonly [string, (t: BCFTopic, v: number) => void, number?]
+  > = [
+    ['PerspectiveCamera/AspectRatio', (t, v) => { t.viewpoints[0].perspectiveCamera!.aspectRatio = v; }],
+    ['PerspectiveCamera/FieldOfView', (t, v) => { t.viewpoints[0].perspectiveCamera!.fieldOfView = v; }],
+    ['PerspectiveCamera/CameraViewPoint/X', (t, v) => { t.viewpoints[0].perspectiveCamera!.cameraViewPoint.x = v; }],
+    ['PerspectiveCamera/CameraDirection/Y', (t, v) => { t.viewpoints[0].perspectiveCamera!.cameraDirection.y = v; }],
+    ['PerspectiveCamera/CameraUpVector/Z', (t, v) => { t.viewpoints[0].perspectiveCamera!.cameraUpVector.z = v; }],
+    // The orthogonal camera REPLACES the perspective one: BCF 3.0 admits
+    // exactly one camera per viewpoint (see "BCF camera cardinality and order"),
+    // so setting both here would fail for that reason instead of this one.
+    ['OrthogonalCamera/ViewToWorldScale', (t, v) => { useOrthogonal(t).viewToWorldScale = v; }],
+    ['OrthogonalCamera/AspectRatio', (t, v) => { useOrthogonal(t).aspectRatio = v; }],
+    ['OrthogonalCamera/CameraViewPoint/X', (t, v) => { useOrthogonal(t).cameraViewPoint.x = v; }],
+    ['Line/StartPoint/X', (t, v) => { t.viewpoints[0].lines![0].startPoint.x = v; }],
+    ['Line/EndPoint/Z', (t, v) => { t.viewpoints[0].lines![0].endPoint.z = v; }],
+    ['ClippingPlane/Location/Y', (t, v) => { t.viewpoints[0].clippingPlanes![0].location.y = v; }],
+    ['ClippingPlane/Direction/X', (t, v) => { t.viewpoints[0].clippingPlanes![0].direction.x = v; }],
+    ['Bitmap/Location/Z', (t, v) => { t.viewpoints[0].bitmaps![0].location.z = v; }],
+    ['Bitmap/Normal/X', (t, v) => { t.viewpoints[0].bitmaps![0].normal.x = v; }],
+    ['Bitmap/Up/Y', (t, v) => { t.viewpoints[0].bitmaps![0].up.y = v; }],
+    ['Bitmap/Height', (t, v) => { t.viewpoints[0].bitmaps![0].height = v; }],
+    // The third element is the FINITE value the anti-vacuity case below uses;
+    // `Topic/Index` needs its own because 3.25 is not an xs:int.
+    ['Topic/Index', (t, v) => { t.index = v; }, 3],
+  ];
+
+  /** Swap the fixture's perspective camera for an orthogonal one and return it. */
+  function useOrthogonal(topic: BCFTopic) {
+    delete topic.viewpoints[0].perspectiveCamera;
+    topic.viewpoints[0].orthogonalCamera = {
+      cameraViewPoint: { x: 4.5, y: 5.5, z: 6.5 },
+      cameraDirection: { x: 0, y: -1, z: 0 },
+      cameraUpVector: { x: 0, y: 0, z: 1 },
+      viewToWorldScale: 12.5,
+      aspectRatio: 2.25,
+    };
+    return topic.viewpoints[0].orthogonalCamera;
+  }
+
+  function mutated(mutate: (t: BCFTopic, v: number) => void, value: number): BCFProject {
+    const topic = maximalTopic();
+    mutate(topic, value);
+    return {
+      version: '3.0',
+      projectId: '66666666-6666-4666-8666-666666666666',
+      name: 'Non-finite project',
+      topics: new Map([[TOPIC_GUID, topic]]),
+    };
+  }
+
+  for (const [field, mutate, finite = 3.25] of NUMERICS) {
+    describe(field, () => {
+      it.each([
+        ['Infinity', Infinity],
+        ['-Infinity', -Infinity],
+        ['NaN', NaN],
+      ] as const)('is refused rather than written when it is %s', async (_label, value) => {
+        await expect(writeBCF(mutated(mutate, value))).rejects.toThrow();
+      });
+
+      /**
+       * Anti-vacuity, and the half a `rejects.toThrow()` cannot state: the same
+       * mutation with a FINITE value must still produce a schema-valid archive.
+       * Without this, a guard that rejected every value — or a mutator aimed at
+       * a field the writer never emits — would pass the three cases above.
+       */
+      it('still writes a schema-valid archive for a finite value', async () => {
+        const entries = await writeAndUnzip(mutated(mutate, finite));
+        for (const [name, xml] of entries) {
+          const xsd = SCHEMA_FOR_ENTRY.find(([re]) => re.test(name))![1];
+          const { valid, messages } = await validate('3.0', xsd, xml);
+          expect(messages, `${field} -> ${name}`).toEqual([]);
+          expect(valid).toBe(true);
+        }
+      });
+    });
+  }
+
+  /**
+   * The reported symptom, pinned exactly.
+   *
+   * This is the archive the old guard produced, reconstructed by splicing
+   * `Infinity` back into a good document. It asserts the VALIDATOR's verdict,
+   * not the writer's — so it keeps working as a statement about the format
+   * however the writer is later refactored, and it names the message a
+   * reviewer would see rather than a generic "invalid".
+   */
+  it('would have failed XSD validation had Infinity been emitted (the reported defect)', async () => {
+    const entries = await writeAndUnzip(maximalProject('3.0'));
+    const good = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    expect((await validate('3.0', 'visinfo.xsd', good)).valid).toBe(true);
+
+    const broken = good.replace(
+      /<AspectRatio>[^<]*<\/AspectRatio>/,
+      '<AspectRatio>Infinity</AspectRatio>'
+    );
+    expect(broken).not.toEqual(good);
+
+    const { valid, messages } = await validate('3.0', 'visinfo.xsd', broken);
+    expect(valid).toBe(false);
+    expect(messages).toEqual([
+      "Schemas validity error : Element 'AspectRatio': 'Infinity' is not a valid value of the atomic type 'PositiveDouble'.",
+    ]);
+  });
+
+  /**
+   * Why the guard is finiteness and not "whatever the schema rejects".
+   *
+   * `"NaN"` IS in `xs:double`'s lexical space, so a `<X>NaN</X>` coordinate
+   * validates cleanly — the XSD cannot see this one at all. It is still
+   * unusable: our own reader routes every number through `parseFiniteFloat`
+   * and drops what is not finite, so a written `NaN` comes back as a camera
+   * that has lost its viewpoint. Schema validity was never the bar.
+   */
+  it('accepts NaN as a schema-valid xs:double, which is exactly why the schema cannot be the guard', async () => {
+    const entries = await writeAndUnzip(maximalProject('3.0'));
+    const good = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`)!;
+    const withNaN = good.replace('<X>1.5</X>', '<X>NaN</X>');
+    expect(withNaN).not.toEqual(good);
+
+    const { valid, messages } = await validate('3.0', 'visinfo.xsd', withNaN);
+    expect(messages).toEqual([]);
+    expect(valid).toBe(true);
+
+    // ...and the value does not survive the trip back in.
+    const readBack = await readBCF(
+      new Uint8Array(await (await writeBCF(maximalProject('3.0'))).arrayBuffer())
+    );
+    expect(readBack.topics.get(TOPIC_GUID)!.viewpoints[0].perspectiveCamera?.cameraViewPoint.x)
+      .toBe(1.5);
+  });
+
+  /**
+   * `Topic/Index` is `xs:int`, and finiteness alone is not its whole rule.
+   *
+   * A fractional index is finite, so the `Number.isFinite` test every other
+   * field uses would pass it — and `<Index>1.5</Index>` is still rejected
+   * ("'1.5' is not a valid value of the atomic type 'xs:int'"). The one field
+   * with a narrower type gets the narrower check.
+   */
+  it('refuses a fractional Topic/Index, which finiteness alone would let through', async () => {
+    expect(Number.isFinite(1.5)).toBe(true);
+    await expect(writeBCF(mutated((t, v) => { t.index = v; }, 1.5))).rejects.toThrow(/xs:int/);
+  });
+});
+
+/**
  * Schema validity is necessary, not sufficient.
  *
  * `<ViewSetupHints>` is OPTIONAL in both versions, so an archive that drops it

--- a/packages/bcf/src/schema-validation.test.ts
+++ b/packages/bcf/src/schema-validation.test.ts
@@ -32,7 +32,7 @@ import JSZip from 'jszip';
 import { validateXML } from 'xmllint-wasm';
 import { writeBCF } from './writer.js';
 import { readBCF } from './reader.js';
-import type { BCFProject, BCFTopic } from './types.js';
+import type { BCFProject, BCFTopic, BCFViewpoint } from './types.js';
 
 const DIR = path.dirname(fileURLToPath(import.meta.url));
 
@@ -344,32 +344,46 @@ describe('BCF output validates against the official buildingSMART XSDs', () => {
  */
 describe('BCF 3.0 AspectRatio', () => {
   it('survives a write/read round trip on both camera types', async () => {
-    const topic = maximalTopic();
     // Distinct values per camera, and neither is 1 — a writer or reader that
     // dropped the field and defaulted to a square viewport would still pass a
     // test that used 1, and a writer that read one camera's value while
     // writing the other's would pass a test that used the same number twice.
-    topic.viewpoints[0].perspectiveCamera!.aspectRatio = 1.7777;
-    topic.viewpoints[0].orthogonalCamera = {
-      cameraViewPoint: { x: 20, y: 21, z: 22 },
-      cameraDirection: { x: 0, y: 0, z: -1 },
-      cameraUpVector: { x: 0, y: 1, z: 0 },
-      viewToWorldScale: 12.5,
-      aspectRatio: 2.3333,
-    };
-    const project: BCFProject = {
-      version: '3.0',
-      projectId: '66666666-6666-4666-8666-666666666666',
-      name: 'Aspect ratio project',
-      topics: new Map([[TOPIC_GUID, topic]]),
-    };
+    //
+    // The two cameras go in SEPARATE 3.0 projects. They used to share one
+    // viewpoint, which round-tripped perfectly and was schema-invalid the
+    // whole time: 3.0's visinfo.xsd declares the cameras as an `xs:choice`,
+    // so a viewpoint carries exactly one. See "BCF camera cardinality and
+    // order" below.
+    async function roundTrip(mutate: (topic: BCFTopic) => void): Promise<BCFViewpoint> {
+      const topic = maximalTopic();
+      mutate(topic);
+      const project: BCFProject = {
+        version: '3.0',
+        projectId: '66666666-6666-4666-8666-666666666666',
+        name: 'Aspect ratio project',
+        topics: new Map([[TOPIC_GUID, topic]]),
+      };
+      const blob = await writeBCF(project);
+      const readBack = await readBCF(new Uint8Array(await blob.arrayBuffer()));
+      return readBack.topics.get(TOPIC_GUID)!.viewpoints[0];
+    }
 
-    const blob = await writeBCF(project);
-    const readBack = await readBCF(new Uint8Array(await blob.arrayBuffer()));
-    const viewpoint = readBack.topics.get(TOPIC_GUID)!.viewpoints[0];
+    const perspective = await roundTrip((topic) => {
+      topic.viewpoints[0].perspectiveCamera!.aspectRatio = 1.7777;
+    });
+    expect(perspective.perspectiveCamera?.aspectRatio).toBe(1.7777);
 
-    expect(viewpoint.perspectiveCamera?.aspectRatio).toBe(1.7777);
-    expect(viewpoint.orthogonalCamera?.aspectRatio).toBe(2.3333);
+    const orthogonal = await roundTrip((topic) => {
+      delete topic.viewpoints[0].perspectiveCamera;
+      topic.viewpoints[0].orthogonalCamera = {
+        cameraViewPoint: { x: 20, y: 21, z: 22 },
+        cameraDirection: { x: 0, y: 0, z: -1 },
+        cameraUpVector: { x: 0, y: 1, z: 0 },
+        viewToWorldScale: 12.5,
+        aspectRatio: 2.3333,
+      };
+    });
+    expect(orthogonal.orthogonalCamera?.aspectRatio).toBe(2.3333);
   });
 
   it('refuses to write a 3.0 camera without one rather than emitting an invalid archive', async () => {
@@ -522,5 +536,173 @@ describe('the validator can fail (mutation proof)', () => {
   it('rejects XML that is not well-formed at all', async () => {
     const { valid } = await validate('2.1', 'markup.xsd', '<Markup><unclosed>');
     expect(valid).toBe(false);
+  });
+});
+
+/**
+ * Which cameras a viewpoint may carry, and in what order.
+ *
+ * The two schemas disagree, and the writer followed neither:
+ *
+ * - v2_1/visinfo.xsd declares `OrthogonalCamera` then `PerspectiveCamera` as
+ *   two `minOccurs="0"` members of an `xs:sequence`. Both may appear, but only
+ *   in that order — and the writer emitted the perspective camera first.
+ * - v3_0/visinfo.xsd replaced the pair with an `xs:choice` carrying neither
+ *   `minOccurs` nor `maxOccurs`, i.e. EXACTLY ONE camera, required. The writer
+ *   emitted both when both were set and none when neither was, so a 3.0
+ *   viewpoint that isolated components without a camera — what
+ *   `ids-reporter.ts` produces whenever no entity bounds are supplied — was
+ *   never valid.
+ *
+ * None of this was reachable from `maximalTopic`, which sets only
+ * `perspectiveCamera`; and the one place that did set both cameras (the
+ * AspectRatio round-trip above) checks `parse(write(x)) === x` and never asks
+ * the schema. The matrix below asks the schema for every combination instead.
+ */
+describe('BCF camera cardinality and order', () => {
+  const PERSPECTIVE = {
+    cameraViewPoint: { x: 1.5, y: 2.5, z: 3.5 },
+    cameraDirection: { x: 0, y: 0, z: -1 },
+    cameraUpVector: { x: 0, y: 1, z: 0 },
+    fieldOfView: 60,
+    aspectRatio: 1.5,
+  };
+  const ORTHOGONAL = {
+    // Distinct from PERSPECTIVE's point in every component, so a writer that
+    // emitted one camera's body under the other's tag is visible.
+    cameraViewPoint: { x: 4.5, y: 5.5, z: 6.5 },
+    cameraDirection: { x: 0, y: -1, z: 0 },
+    cameraUpVector: { x: 0, y: 0, z: 1 },
+    viewToWorldScale: 12.5,
+    aspectRatio: 2.25,
+  };
+
+  /** A project holding one viewpoint with exactly the cameras asked for. */
+  function project(
+    version: '2.1' | '3.0',
+    cameras: { perspective: boolean; orthogonal: boolean }
+  ): BCFProject {
+    const topic = maximalTopic();
+    const viewpoint = topic.viewpoints[0];
+    if (cameras.perspective) viewpoint.perspectiveCamera = { ...PERSPECTIVE };
+    else delete viewpoint.perspectiveCamera;
+    if (cameras.orthogonal) viewpoint.orthogonalCamera = { ...ORTHOGONAL };
+    else delete viewpoint.orthogonalCamera;
+    return {
+      version,
+      projectId: '66666666-6666-4666-8666-666666666666',
+      name: 'Camera matrix project',
+      topics: new Map([[TOPIC_GUID, topic]]),
+    };
+  }
+
+  async function bcfv(
+    version: '2.1' | '3.0',
+    cameras: { perspective: boolean; orthogonal: boolean }
+  ): Promise<string> {
+    const entries = await writeAndUnzip(project(version, cameras));
+    const xml = entries.get(`${TOPIC_GUID}/Viewpoint_${VIEWPOINT_GUID}.bcfv`);
+    // Anti-vacuity: every assertion below reads this string, so a writer that
+    // stopped emitting the viewpoint entry must fail here, not pass silently.
+    expect(xml).toBeDefined();
+    return xml!;
+  }
+
+  /**
+   * Re-derive the premise from the schemas themselves.
+   *
+   * Everything below is written against two facts about the vendored XSDs. If
+   * buildingSMART ever changes them, this fails first and names the change,
+   * rather than leaving the rest of the block quietly testing the wrong rule.
+   */
+  it('derives the camera rule from the vendored schemas', () => {
+    const v21 = schema('2.1', 'visinfo.xsd');
+    const v30 = schema('3.0', 'visinfo.xsd');
+    // Span from VisualizationInfo's opening tag to the Lines declaration that
+    // follows the cameras — enough to see the camera declarations and nothing
+    // that comes after them.
+    const span = (xsd: string): string =>
+      xsd.slice(xsd.indexOf('name="VisualizationInfo"'), xsd.indexOf('name="Lines"'));
+    const cameraOrder = (xsd: string): string[] =>
+      [...span(xsd).matchAll(/name="(OrthogonalCamera|PerspectiveCamera)"/g)].map((m) => m[1]);
+
+    // 2.1: an ordered pair of optionals, orthogonal first, no choice.
+    expect(cameraOrder(v21)).toEqual(['OrthogonalCamera', 'PerspectiveCamera']);
+    expect(span(v21)).not.toContain('<xs:choice');
+    expect(span(v21)).toContain('name="OrthogonalCamera" type="OrthogonalCamera" minOccurs="0"');
+
+    // 3.0: an xs:choice with no minOccurs/maxOccurs, i.e. exactly one, required.
+    expect(cameraOrder(v30)).toEqual(['OrthogonalCamera', 'PerspectiveCamera']);
+    const choice = /<xs:choice([^>]*)>/.exec(span(v30));
+    expect(choice).not.toBeNull();
+    expect(choice![1].trim()).toBe('');
+  });
+
+  describe('BCF 2.1 — both cameras are allowed, in schema order', () => {
+    it('emits OrthogonalCamera before PerspectiveCamera', async () => {
+      const xml = await bcfv('2.1', { perspective: true, orthogonal: true });
+      // Named elements in the order the schema declares them, not a count:
+      // a count of 2 passes for either order.
+      expect(
+        [...xml.matchAll(/<(OrthogonalCamera|PerspectiveCamera)>/g)].map((m) => m[1])
+      ).toEqual(['OrthogonalCamera', 'PerspectiveCamera']);
+      // Each camera's own body travels with its own tag.
+      expect(xml).toContain('<ViewToWorldScale>12.5</ViewToWorldScale>');
+      expect(xml).toContain('<FieldOfView>60</FieldOfView>');
+    });
+
+    it('validates with both cameras present', async () => {
+      const xml = await bcfv('2.1', { perspective: true, orthogonal: true });
+      const { valid, messages } = await validate('2.1', 'visinfo.xsd', xml);
+      expect(messages).toEqual([]);
+      expect(valid).toBe(true);
+    });
+
+    it.each([
+      ['perspective only', { perspective: true, orthogonal: false }],
+      ['orthogonal only', { perspective: false, orthogonal: true }],
+      // 2.1 makes both optional, so a camera-less viewpoint is legal there —
+      // the negative control for the 3.0 rule below.
+      ['no camera', { perspective: false, orthogonal: false }],
+    ] as const)('validates with %s', async (_label, cameras) => {
+      const xml = await bcfv('2.1', cameras);
+      const { valid, messages } = await validate('2.1', 'visinfo.xsd', xml);
+      expect(messages).toEqual([]);
+      expect(valid).toBe(true);
+    });
+  });
+
+  describe('BCF 3.0 — exactly one camera, required', () => {
+    it.each([
+      ['perspective only', { perspective: true, orthogonal: false }, 'PerspectiveCamera'],
+      ['orthogonal only', { perspective: false, orthogonal: true }, 'OrthogonalCamera'],
+    ] as const)('validates with %s', async (_label, cameras, expected) => {
+      const xml = await bcfv('3.0', cameras);
+      // The one camera that IS emitted must be the one that was asked for.
+      expect(
+        [...xml.matchAll(/<(OrthogonalCamera|PerspectiveCamera)>/g)].map((m) => m[1])
+      ).toEqual([expected]);
+      const { valid, messages } = await validate('3.0', 'visinfo.xsd', xml);
+      expect(messages).toEqual([]);
+      expect(valid).toBe(true);
+    });
+
+    it('refuses to write both cameras rather than emitting an invalid archive', async () => {
+      await expect(
+        writeBCF(project('3.0', { perspective: true, orthogonal: true }))
+      ).rejects.toThrow(/exactly one camera/);
+    });
+
+    it('refuses to write a viewpoint with no camera at all', async () => {
+      await expect(
+        writeBCF(project('3.0', { perspective: false, orthogonal: false }))
+      ).rejects.toThrow(/exactly one camera/);
+    });
+
+    it('names the offending viewpoint so the caller can find it', async () => {
+      await expect(
+        writeBCF(project('3.0', { perspective: false, orthogonal: false }))
+      ).rejects.toThrow(new RegExp(VIEWPOINT_GUID));
+    });
   });
 });

--- a/packages/bcf/src/writer-camera.ts
+++ b/packages/bcf/src/writer-camera.ts
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Writing a viewpoint's camera.
+ *
+ * Split out of `writer.ts` because the camera is the one part of
+ * `VisualizationInfo` whose SHAPE, CARDINALITY and ORDER all differ between
+ * BCF 2.1 and BCF 3.0, and keeping the three rules in one place is what makes
+ * them checkable against the `visinfo.xsd` copies under
+ * `__fixtures__/schemas/`. The parity is
+ * pinned by `schema-validation.test.ts` > "BCF camera cardinality and order",
+ * which re-derives the rules from the vendored schemas before asserting them.
+ */
+
+import type { BCFViewpoint, BCFPerspectiveCamera, BCFOrthogonalCamera } from './types.js';
+
+/**
+ * Enforce each version's rule for how many cameras a viewpoint may carry.
+ *
+ * The two schemas differ, and the emitted ORDER matters in one of them:
+ *
+ * - v2_1/visinfo.xsd puts `OrthogonalCamera` and `PerspectiveCamera` in
+ *   `VisualizationInfo`'s `xs:sequence`, both `minOccurs="0"`. Either, both or
+ *   neither may appear -- but an `xs:sequence` fixes the order, and the
+ *   schema declares the orthogonal camera FIRST. Emitting the perspective
+ *   camera first made a two-camera 2.1 viewpoint schema-invalid
+ *   ("Element 'OrthogonalCamera': This element is not expected"), which is
+ *   why `writer.ts`'s `writeViewpointFiles` now writes orthogonal first for both
+ *   versions -- the order is required by 2.1 and harmless under 3.0's choice.
+ * - v3_0/visinfo.xsd replaced that pair with an `<xs:choice>` carrying no
+ *   `minOccurs` and no `maxOccurs`, so both default to 1: EXACTLY ONE camera,
+ *   and it is required. Two cameras and zero cameras are each invalid there.
+ *
+ * We refuse the 3.0 violations rather than guessing which camera the caller
+ * meant, or inventing one for a viewpoint that has none -- same policy as
+ * {@link requireAspectRatioElement} and the `Topic/@TopicType` checks in
+ * `writer.ts`'s `writeMarkupFile`. Silently dropping one of two cameras would discard
+ * a view the caller chose; silently emitting neither writes an archive that no
+ * conforming BCF 3.0 reader has to accept.
+ */
+export function requireCameraChoice(viewpoint: BCFViewpoint, version: '2.1' | '3.0'): void {
+  if (version !== '3.0') return;
+  const count = (viewpoint.orthogonalCamera ? 1 : 0) + (viewpoint.perspectiveCamera ? 1 : 0);
+  if (count === 1) return;
+  throw new Error(
+    `BCF 3.0 requires exactly one camera per viewpoint (viewpoint "${viewpoint.guid}" has ` +
+      `${count === 0 ? 'none' : 'both an orthogonalCamera and a perspectiveCamera'}). ` +
+      `visinfo.xsd declares OrthogonalCamera and PerspectiveCamera as an xs:choice, so ` +
+      `set exactly one before writing a 3.0 file.`
+  );
+}
+
+/**
+ * Require a positive AspectRatio for a BCF 3.0 camera and return the element
+ * to append.
+ *
+ * v3_0/visinfo.xsd adds `<AspectRatio>` (type `PositiveDouble`, i.e.
+ * `xs:double` with `minExclusive value="0"`) as a REQUIRED, no-minOccurs
+ * child of both `OrthogonalCamera` and `PerspectiveCamera`. 2.1 has no such
+ * element. We refuse to invent a value (there is no safe default aspect
+ * ratio) because that would assert a value the caller never chose; instead
+ * we fail the write so the caller supplies one -- same policy as the
+ * `Topic/@TopicType`/`Topic/@TopicStatus` checks in `writer.ts`'s `writeMarkupFile`.
+ */
+function requireAspectRatioElement(aspectRatio: number | undefined, viewpointGuid: string): string {
+  if (aspectRatio === undefined || !(aspectRatio > 0)) {
+    throw new Error(
+      `BCF 3.0 requires a positive Camera/AspectRatio (viewpoint "${viewpointGuid}" has none). ` +
+        `Set the camera's aspectRatio before writing a 3.0 file.`
+    );
+  }
+  return `\n    <AspectRatio>${aspectRatio}</AspectRatio>`;
+}
+
+/**
+ * Write perspective camera XML
+ */
+export function writePerspectiveCamera(
+  camera: BCFPerspectiveCamera,
+  version: '2.1' | '3.0',
+  viewpointGuid: string,
+): string {
+  const aspectRatioElement = version === '3.0' ? requireAspectRatioElement(camera.aspectRatio, viewpointGuid) : '';
+  return `\n  <PerspectiveCamera>
+    <CameraViewPoint>
+      <X>${camera.cameraViewPoint.x}</X>
+      <Y>${camera.cameraViewPoint.y}</Y>
+      <Z>${camera.cameraViewPoint.z}</Z>
+    </CameraViewPoint>
+    <CameraDirection>
+      <X>${camera.cameraDirection.x}</X>
+      <Y>${camera.cameraDirection.y}</Y>
+      <Z>${camera.cameraDirection.z}</Z>
+    </CameraDirection>
+    <CameraUpVector>
+      <X>${camera.cameraUpVector.x}</X>
+      <Y>${camera.cameraUpVector.y}</Y>
+      <Z>${camera.cameraUpVector.z}</Z>
+    </CameraUpVector>
+    <FieldOfView>${camera.fieldOfView}</FieldOfView>${aspectRatioElement}
+  </PerspectiveCamera>`;
+}
+
+/**
+ * Write orthogonal camera XML
+ */
+export function writeOrthogonalCamera(
+  camera: BCFOrthogonalCamera,
+  version: '2.1' | '3.0',
+  viewpointGuid: string,
+): string {
+  const aspectRatioElement = version === '3.0' ? requireAspectRatioElement(camera.aspectRatio, viewpointGuid) : '';
+  return `\n  <OrthogonalCamera>
+    <CameraViewPoint>
+      <X>${camera.cameraViewPoint.x}</X>
+      <Y>${camera.cameraViewPoint.y}</Y>
+      <Z>${camera.cameraViewPoint.z}</Z>
+    </CameraViewPoint>
+    <CameraDirection>
+      <X>${camera.cameraDirection.x}</X>
+      <Y>${camera.cameraDirection.y}</Y>
+      <Z>${camera.cameraDirection.z}</Z>
+    </CameraDirection>
+    <CameraUpVector>
+      <X>${camera.cameraUpVector.x}</X>
+      <Y>${camera.cameraUpVector.y}</Y>
+      <Z>${camera.cameraUpVector.z}</Z>
+    </CameraUpVector>
+    <ViewToWorldScale>${camera.viewToWorldScale}</ViewToWorldScale>${aspectRatioElement}
+  </OrthogonalCamera>`;
+}

--- a/packages/bcf/src/writer-camera.ts
+++ b/packages/bcf/src/writer-camera.ts
@@ -15,6 +15,7 @@
  */
 
 import type { BCFViewpoint, BCFPerspectiveCamera, BCFOrthogonalCamera } from './types.js';
+import { xsdDouble, xsdPointElement } from './numeric.js';
 
 /**
  * Enforce each version's rule for how many cameras a viewpoint may carry.
@@ -53,8 +54,8 @@ export function requireCameraChoice(viewpoint: BCFViewpoint, version: '2.1' | '3
 }
 
 /**
- * Require a positive AspectRatio for a BCF 3.0 camera and return the element
- * to append.
+ * Require a FINITE, positive AspectRatio for a BCF 3.0 camera and return the
+ * element to append.
  *
  * v3_0/visinfo.xsd adds `<AspectRatio>` (type `PositiveDouble`, i.e.
  * `xs:double` with `minExclusive value="0"`) as a REQUIRED, no-minOccurs
@@ -63,15 +64,24 @@ export function requireCameraChoice(viewpoint: BCFViewpoint, version: '2.1' | '3
  * ratio) because that would assert a value the caller never chose; instead
  * we fail the write so the caller supplies one -- same policy as the
  * `Topic/@TopicType`/`Topic/@TopicStatus` checks in `writer.ts`'s `writeMarkupFile`.
+ *
+ * BOTH halves of `PositiveDouble` are checked here, and the positivity test
+ * alone did not cover them: `Infinity > 0` is `true`, so `Infinity` walked
+ * past this guard and was emitted as `<AspectRatio>Infinity</AspectRatio>`,
+ * which xmllint rejects with "'Infinity' is not a valid value of the atomic
+ * type 'PositiveDouble'". `xsdDouble` is what makes the `xs:double` half of
+ * the claim true; the `> 0` below is the `minExclusive` facet.
  */
 function requireAspectRatioElement(aspectRatio: number | undefined, viewpointGuid: string): string {
+  const where = `viewpoint "${viewpointGuid}"`;
   if (aspectRatio === undefined || !(aspectRatio > 0)) {
     throw new Error(
-      `BCF 3.0 requires a positive Camera/AspectRatio (viewpoint "${viewpointGuid}" has none). ` +
+      `BCF 3.0 requires a positive Camera/AspectRatio (${where} has ` +
+        `${aspectRatio === undefined ? 'none' : aspectRatio}). ` +
         `Set the camera's aspectRatio before writing a 3.0 file.`
     );
   }
-  return `\n    <AspectRatio>${aspectRatio}</AspectRatio>`;
+  return `\n    <AspectRatio>${xsdDouble(aspectRatio, 'Camera/AspectRatio', where)}</AspectRatio>`;
 }
 
 /**
@@ -83,23 +93,9 @@ export function writePerspectiveCamera(
   viewpointGuid: string,
 ): string {
   const aspectRatioElement = version === '3.0' ? requireAspectRatioElement(camera.aspectRatio, viewpointGuid) : '';
-  return `\n  <PerspectiveCamera>
-    <CameraViewPoint>
-      <X>${camera.cameraViewPoint.x}</X>
-      <Y>${camera.cameraViewPoint.y}</Y>
-      <Z>${camera.cameraViewPoint.z}</Z>
-    </CameraViewPoint>
-    <CameraDirection>
-      <X>${camera.cameraDirection.x}</X>
-      <Y>${camera.cameraDirection.y}</Y>
-      <Z>${camera.cameraDirection.z}</Z>
-    </CameraDirection>
-    <CameraUpVector>
-      <X>${camera.cameraUpVector.x}</X>
-      <Y>${camera.cameraUpVector.y}</Y>
-      <Z>${camera.cameraUpVector.z}</Z>
-    </CameraUpVector>
-    <FieldOfView>${camera.fieldOfView}</FieldOfView>${aspectRatioElement}
+  const where = `viewpoint "${viewpointGuid}"`;
+  return `\n  <PerspectiveCamera>${cameraVectors(camera, where)}
+    <FieldOfView>${xsdDouble(camera.fieldOfView, 'PerspectiveCamera/FieldOfView', where)}</FieldOfView>${aspectRatioElement}
   </PerspectiveCamera>`;
 }
 
@@ -112,22 +108,28 @@ export function writeOrthogonalCamera(
   viewpointGuid: string,
 ): string {
   const aspectRatioElement = version === '3.0' ? requireAspectRatioElement(camera.aspectRatio, viewpointGuid) : '';
-  return `\n  <OrthogonalCamera>
-    <CameraViewPoint>
-      <X>${camera.cameraViewPoint.x}</X>
-      <Y>${camera.cameraViewPoint.y}</Y>
-      <Z>${camera.cameraViewPoint.z}</Z>
-    </CameraViewPoint>
-    <CameraDirection>
-      <X>${camera.cameraDirection.x}</X>
-      <Y>${camera.cameraDirection.y}</Y>
-      <Z>${camera.cameraDirection.z}</Z>
-    </CameraDirection>
-    <CameraUpVector>
-      <X>${camera.cameraUpVector.x}</X>
-      <Y>${camera.cameraUpVector.y}</Y>
-      <Z>${camera.cameraUpVector.z}</Z>
-    </CameraUpVector>
-    <ViewToWorldScale>${camera.viewToWorldScale}</ViewToWorldScale>${aspectRatioElement}
+  const where = `viewpoint "${viewpointGuid}"`;
+  return `\n  <OrthogonalCamera>${cameraVectors(camera, where)}
+    <ViewToWorldScale>${xsdDouble(camera.viewToWorldScale, 'OrthogonalCamera/ViewToWorldScale', where)}</ViewToWorldScale>${aspectRatioElement}
   </OrthogonalCamera>`;
+}
+
+/**
+ * The three vectors both camera types open with, in the order both schemas'
+ * `xs:sequence` declares them.
+ *
+ * Identical in `OrthogonalCamera` and `PerspectiveCamera` and in 2.1 and 3.0 --
+ * the cameras differ only in the single element that follows (`ViewToWorldScale`
+ * vs `FieldOfView`). Writing them once is what makes "every camera coordinate
+ * is checked" a property of the code rather than of six copied templates.
+ */
+function cameraVectors(
+  camera: BCFPerspectiveCamera | BCFOrthogonalCamera,
+  where: string
+): string {
+  return (
+    xsdPointElement('CameraViewPoint', camera.cameraViewPoint, '    ', where) +
+    xsdPointElement('CameraDirection', camera.cameraDirection, '    ', where) +
+    xsdPointElement('CameraUpVector', camera.cameraUpVector, '    ', where)
+  );
 }

--- a/packages/bcf/src/writer.test.ts
+++ b/packages/bcf/src/writer.test.ts
@@ -737,6 +737,27 @@ describe('BCF Writer', () => {
     };
   }
 
+  /**
+   * A camera valid at BOTH versions, for 3.0 fixtures whose subject is not the
+   * camera.
+   *
+   * Same reason `baseTopic` carries TopicType/TopicStatus: BCF 3.0's
+   * visinfo.xsd declares OrthogonalCamera/PerspectiveCamera as an `xs:choice`
+   * with no minOccurs, so a 3.0 viewpoint MUST have exactly one camera, and
+   * that camera must carry the 3.0-required AspectRatio. A 3.0 fixture without
+   * one is an archive no conforming reader has to accept, so the writer now
+   * refuses it -- see `schema-validation.test.ts` > "BCF camera cardinality and
+   * order". Tests below that are about markup nesting or ViewSetupHints, not
+   * cameras, attach this so their subject stays reachable.
+   */
+  const VALID_CAMERA: BCFViewpoint['perspectiveCamera'] = {
+    cameraViewPoint: { x: 1, y: 2, z: 3 },
+    cameraDirection: { x: 0, y: 0, z: -1 },
+    cameraUpVector: { x: 0, y: 1, z: 0 },
+    fieldOfView: 60,
+    aspectRatio: 1.5,
+  };
+
   it('defaults DefaultVisibility to true when a viewpoint has components but no visibility', async () => {
     // Visibility is REQUIRED inside Components, so the writer synthesises one.
     // Emitting false instead of true would tell the receiving tool to hide the
@@ -1136,7 +1157,9 @@ describe('BCF Writer', () => {
     // could never see the mismatch against a real 3.0 consumer.
     const topic = baseTopic({
       comments: [{ guid: 'c-1', date: '2026-01-01T00:00:00.000Z', author: 'a@x.com', comment: 'hi' }],
-      viewpoints: [{ guid: 'vp-1', snapshot: 'data:image/png;base64,AA==' }],
+      viewpoints: [
+        { guid: 'vp-1', snapshot: 'data:image/png;base64,AA==', perspectiveCamera: VALID_CAMERA },
+      ],
     });
 
     const markup30 = await markupFor(topic, '3.0');
@@ -1303,7 +1326,9 @@ describe('BCF Writer', () => {
       documentReferences: [{ guid: 'dr-1', documentGuid: 'doc-guid-1' }],
       relatedTopics: ['related-guid-1'],
       comments: [{ guid: 'c-1', date: '2026-01-01T00:00:00.000Z', author: 'a@x.com', comment: 'hi' }],
-      viewpoints: [{ guid: 'vp-1', snapshot: 'data:image/png;base64,AA==' }],
+      viewpoints: [
+        { guid: 'vp-1', snapshot: 'data:image/png;base64,AA==', perspectiveCamera: VALID_CAMERA },
+      ],
     });
 
     const markup = await markupFor(topic, '3.0');
@@ -1569,6 +1594,7 @@ describe('BCF Writer', () => {
     // ourselves produce would read back with every hint dropped.
     const vp: BCFViewpoint = {
       guid: generateUuid(),
+      perspectiveCamera: VALID_CAMERA,
       components: {
         selection: [{ ifcGuid: '0abc123def456789012345' }],
         visibility: {

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -19,8 +19,6 @@ import type {
   BCFVisibility,
   BCFViewSetupHints,
   BCFColoring,
-  BCFPerspectiveCamera,
-  BCFOrthogonalCamera,
   BCFLine,
   BCFClippingPlane,
   BCFBitmap,
@@ -30,6 +28,11 @@ import type {
   BCFDocumentReference,
   BCFHeaderFile,
 } from './types.js';
+import {
+  requireCameraChoice,
+  writeOrthogonalCamera,
+  writePerspectiveCamera,
+} from './writer-camera.js';
 import { generateUuid } from '@ifc-lite/encoding';
 
 /**
@@ -479,14 +482,16 @@ async function writeViewpointFiles(
     content += writeComponents(viewpoint.components, version);
   }
 
-  // Write perspective camera
-  if (viewpoint.perspectiveCamera) {
-    content += writePerspectiveCamera(viewpoint.perspectiveCamera, version, viewpoint.guid);
-  }
+  // Write the cameras. ORTHOGONAL FIRST -- see requireCameraChoice for why the
+  // order is not free, and for the 3.0 cardinality rule enforced here.
+  requireCameraChoice(viewpoint, version);
 
-  // Write orthogonal camera
   if (viewpoint.orthogonalCamera) {
     content += writeOrthogonalCamera(viewpoint.orthogonalCamera, version, viewpoint.guid);
+  }
+
+  if (viewpoint.perspectiveCamera) {
+    content += writePerspectiveCamera(viewpoint.perspectiveCamera, version, viewpoint.guid);
   }
 
   // Write lines
@@ -703,86 +708,6 @@ function writeColoringEntry(coloring: BCFColoring, version: '2.1' | '3.0'): stri
   if (version === '3.0') content += `\n        </Components>`;
   content += `\n      </Color>`;
   return content;
-}
-
-/**
- * Require a positive AspectRatio for a BCF 3.0 camera and return the element
- * to append.
- *
- * v3_0/visinfo.xsd adds `<AspectRatio>` (type `PositiveDouble`, i.e.
- * `xs:double` with `minExclusive value="0"`) as a REQUIRED, no-minOccurs
- * child of both `OrthogonalCamera` and `PerspectiveCamera`. 2.1 has no such
- * element. We refuse to invent a value (there is no safe default aspect
- * ratio) because that would assert a value the caller never chose; instead
- * we fail the write so the caller supplies one -- same policy as the
- * `Topic/@TopicType`/`Topic/@TopicStatus` checks in {@link writeMarkupFile}.
- */
-function requireAspectRatioElement(aspectRatio: number | undefined, viewpointGuid: string): string {
-  if (aspectRatio === undefined || !(aspectRatio > 0)) {
-    throw new Error(
-      `BCF 3.0 requires a positive Camera/AspectRatio (viewpoint "${viewpointGuid}" has none). ` +
-        `Set the camera's aspectRatio before writing a 3.0 file.`
-    );
-  }
-  return `\n    <AspectRatio>${aspectRatio}</AspectRatio>`;
-}
-
-/**
- * Write perspective camera XML
- */
-function writePerspectiveCamera(
-  camera: BCFPerspectiveCamera,
-  version: '2.1' | '3.0',
-  viewpointGuid: string,
-): string {
-  const aspectRatioElement = version === '3.0' ? requireAspectRatioElement(camera.aspectRatio, viewpointGuid) : '';
-  return `\n  <PerspectiveCamera>
-    <CameraViewPoint>
-      <X>${camera.cameraViewPoint.x}</X>
-      <Y>${camera.cameraViewPoint.y}</Y>
-      <Z>${camera.cameraViewPoint.z}</Z>
-    </CameraViewPoint>
-    <CameraDirection>
-      <X>${camera.cameraDirection.x}</X>
-      <Y>${camera.cameraDirection.y}</Y>
-      <Z>${camera.cameraDirection.z}</Z>
-    </CameraDirection>
-    <CameraUpVector>
-      <X>${camera.cameraUpVector.x}</X>
-      <Y>${camera.cameraUpVector.y}</Y>
-      <Z>${camera.cameraUpVector.z}</Z>
-    </CameraUpVector>
-    <FieldOfView>${camera.fieldOfView}</FieldOfView>${aspectRatioElement}
-  </PerspectiveCamera>`;
-}
-
-/**
- * Write orthogonal camera XML
- */
-function writeOrthogonalCamera(
-  camera: BCFOrthogonalCamera,
-  version: '2.1' | '3.0',
-  viewpointGuid: string,
-): string {
-  const aspectRatioElement = version === '3.0' ? requireAspectRatioElement(camera.aspectRatio, viewpointGuid) : '';
-  return `\n  <OrthogonalCamera>
-    <CameraViewPoint>
-      <X>${camera.cameraViewPoint.x}</X>
-      <Y>${camera.cameraViewPoint.y}</Y>
-      <Z>${camera.cameraViewPoint.z}</Z>
-    </CameraViewPoint>
-    <CameraDirection>
-      <X>${camera.cameraDirection.x}</X>
-      <Y>${camera.cameraDirection.y}</Y>
-      <Z>${camera.cameraDirection.z}</Z>
-    </CameraDirection>
-    <CameraUpVector>
-      <X>${camera.cameraUpVector.x}</X>
-      <Y>${camera.cameraUpVector.y}</Y>
-      <Z>${camera.cameraUpVector.z}</Z>
-    </CameraUpVector>
-    <ViewToWorldScale>${camera.viewToWorldScale}</ViewToWorldScale>${aspectRatioElement}
-  </OrthogonalCamera>`;
 }
 
 /**

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -33,6 +33,7 @@ import {
   writeOrthogonalCamera,
   writePerspectiveCamera,
 } from './writer-camera.js';
+import { xsdDouble, xsdInt, xsdPointElement } from './numeric.js';
 import { generateUuid } from '@ifc-lite/encoding';
 
 /**
@@ -296,7 +297,8 @@ function writeMarkupFile(
   }
 
   if (topic.index !== undefined) {
-    content += `\n    <Index>${topic.index}</Index>`;
+    // `Index` is the writer's only xs:int; see xsdInt for what that excludes.
+    content += `\n    <Index>${xsdInt(topic.index, 'Topic/Index', `topic "${topic.guid}"`)}</Index>`;
   }
 
   if (topic.labels && topic.labels.length > 0) {
@@ -482,6 +484,11 @@ async function writeViewpointFiles(
     content += writeComponents(viewpoint.components, version);
   }
 
+  // Every number below reaches an XSD numeric type, so each goes through
+  // `numeric.ts`'s write-side guards; `where` is what puts the offending
+  // viewpoint's guid in the error, as the camera checks already do.
+  const where = `viewpoint "${viewpoint.guid}"`;
+
   // Write the cameras. ORTHOGONAL FIRST -- see requireCameraChoice for why the
   // order is not free, and for the 3.0 cardinality rule enforced here.
   requireCameraChoice(viewpoint, version);
@@ -498,7 +505,7 @@ async function writeViewpointFiles(
   if (viewpoint.lines && viewpoint.lines.length > 0) {
     content += `\n  <Lines>`;
     for (const line of viewpoint.lines) {
-      content += writeLine(line);
+      content += writeLine(line, where);
     }
     content += `\n  </Lines>`;
   }
@@ -507,7 +514,7 @@ async function writeViewpointFiles(
   if (viewpoint.clippingPlanes && viewpoint.clippingPlanes.length > 0) {
     content += `\n  <ClippingPlanes>`;
     for (const plane of viewpoint.clippingPlanes) {
-      content += writeClippingPlane(plane);
+      content += writeClippingPlane(plane, where);
     }
     content += `\n  </ClippingPlanes>`;
   }
@@ -524,12 +531,12 @@ async function writeViewpointFiles(
     if (version === '3.0') {
       content += `\n  <Bitmaps>`;
       for (const bitmap of viewpoint.bitmaps) {
-        content += writeBitmap(bitmap, version);
+        content += writeBitmap(bitmap, version, where);
       }
       content += `\n  </Bitmaps>`;
     } else {
       for (const bitmap of viewpoint.bitmaps) {
-        content += writeBitmap(bitmap, version);
+        content += writeBitmap(bitmap, version, where);
       }
     }
   }
@@ -713,36 +720,16 @@ function writeColoringEntry(coloring: BCFColoring, version: '2.1' | '3.0'): stri
 /**
  * Write line XML
  */
-function writeLine(line: BCFLine): string {
-  return `\n    <Line>
-      <StartPoint>
-        <X>${line.startPoint.x}</X>
-        <Y>${line.startPoint.y}</Y>
-        <Z>${line.startPoint.z}</Z>
-      </StartPoint>
-      <EndPoint>
-        <X>${line.endPoint.x}</X>
-        <Y>${line.endPoint.y}</Y>
-        <Z>${line.endPoint.z}</Z>
-      </EndPoint>
+function writeLine(line: BCFLine, where: string): string {
+  return `\n    <Line>${xsdPointElement('StartPoint', line.startPoint, '      ', where)}${xsdPointElement('EndPoint', line.endPoint, '      ', where)}
     </Line>`;
 }
 
 /**
  * Write clipping plane XML
  */
-function writeClippingPlane(plane: BCFClippingPlane): string {
-  return `\n    <ClippingPlane>
-      <Location>
-        <X>${plane.location.x}</X>
-        <Y>${plane.location.y}</Y>
-        <Z>${plane.location.z}</Z>
-      </Location>
-      <Direction>
-        <X>${plane.direction.x}</X>
-        <Y>${plane.direction.y}</Y>
-        <Z>${plane.direction.z}</Z>
-      </Direction>
+function writeClippingPlane(plane: BCFClippingPlane, where: string): string {
+  return `\n    <ClippingPlane>${xsdPointElement('Location', plane.location, '      ', where)}${xsdPointElement('Direction', plane.direction, '      ', where)}
     </ClippingPlane>`;
 }
 
@@ -761,28 +748,13 @@ function writeClippingPlane(plane: BCFClippingPlane): string {
  *   otherwise. `BCFBitmap.format` stays typed `'PNG' | 'JPG'`; we only
  *   lowercase it on the wire for 3.0.
  */
-function writeBitmap(bitmap: BCFBitmap, version: '2.1' | '3.0'): string {
+function writeBitmap(bitmap: BCFBitmap, version: '2.1' | '3.0', where: string): string {
   const formatTag = version === '3.0' ? 'Format' : 'Bitmap';
   const formatValue = version === '3.0' ? bitmap.format.toLowerCase() : bitmap.format;
   return `\n    <Bitmap>
       <${formatTag}>${formatValue}</${formatTag}>
-      <Reference>${escapeXml(bitmap.reference)}</Reference>
-      <Location>
-        <X>${bitmap.location.x}</X>
-        <Y>${bitmap.location.y}</Y>
-        <Z>${bitmap.location.z}</Z>
-      </Location>
-      <Normal>
-        <X>${bitmap.normal.x}</X>
-        <Y>${bitmap.normal.y}</Y>
-        <Z>${bitmap.normal.z}</Z>
-      </Normal>
-      <Up>
-        <X>${bitmap.up.x}</X>
-        <Y>${bitmap.up.y}</Y>
-        <Z>${bitmap.up.z}</Z>
-      </Up>
-      <Height>${bitmap.height}</Height>
+      <Reference>${escapeXml(bitmap.reference)}</Reference>${xsdPointElement('Location', bitmap.location, '      ', where)}${xsdPointElement('Normal', bitmap.normal, '      ', where)}${xsdPointElement('Up', bitmap.up, '      ', where)}
+      <Height>${xsdDouble(bitmap.height, 'Bitmap/Height', where)}</Height>
     </Bitmap>`;
 }
 

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -162,7 +162,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
 const ALLOWLIST_DIGESTS = {
   'apps/viewer': '3248385113093449015',
   'apps/viewer-embed': '4565652428901906968',
-  'packages/bcf': '9733284863521991257',
+  'packages/bcf': '9741033121964480374',
   'packages/cache': '14926850005686407910',
   'packages/clash': '781065910217740673',
   'packages/cli': '11939142867866651937',

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -162,7 +162,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
 const ALLOWLIST_DIGESTS = {
   'apps/viewer': '3248385113093449015',
   'apps/viewer-embed': '4565652428901906968',
-  'packages/bcf': '9741033121964480374',
+  'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',
   'packages/clash': '781065910217740673',
   'packages/cli': '11939142867866651937',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -172,7 +172,7 @@
    495 packages/bcf/src/overlay-renderer.ts
   1058 packages/bcf/src/reader.ts
    573 packages/bcf/src/viewpoint.ts
-   908 packages/bcf/src/writer.ts
+   878 packages/bcf/src/writer.ts
    605 packages/cache/src/glb.ts
    414 packages/clash/src/adapters/step.ts
    441 packages/clash/src/bcf-bridge.ts

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -172,7 +172,7 @@
    495 packages/bcf/src/overlay-renderer.ts
   1058 packages/bcf/src/reader.ts
    573 packages/bcf/src/viewpoint.ts
-   981 packages/bcf/src/writer.ts
+   908 packages/bcf/src/writer.ts
    605 packages/cache/src/glb.ts
    414 packages/clash/src/adapters/step.ts
    441 packages/clash/src/bcf-bridge.ts


### PR DESCRIPTION
BCF 2.1 and BCF 3.0 disagree about how many cameras a viewpoint may carry and in what order, and `writer.ts` followed neither. Both defects produce `.bcfv` entries that fail validation against the buildingSMART XSDs already vendored in `packages/bcf/src/__fixtures__/schemas/`.

## What the schemas say

`v2_1/visinfo.xsd` puts the cameras in `VisualizationInfo`'s `xs:sequence`, both `minOccurs="0"`, **orthogonal declared first**:

```xml
<xs:element name="OrthogonalCamera" type="OrthogonalCamera" minOccurs="0"/>
<xs:element name="PerspectiveCamera" type="PerspectiveCamera" minOccurs="0"/>
```

`v3_0/visinfo.xsd` replaced that pair with an `xs:choice` carrying **no `minOccurs` and no `maxOccurs`**, so both default to 1 — exactly one camera, and it is required:

```xml
<xs:choice>
    <xs:element name="OrthogonalCamera" type="OrthogonalCamera"/>
    <xs:element name="PerspectiveCamera" type="PerspectiveCamera"/>
</xs:choice>
```

## What the writer did

Verbatim `xmllint-wasm` output against those schemas, before this change:

| version | cameras set | result |
| --- | --- | --- |
| 2.1 | both | `Element 'OrthogonalCamera': This element is not expected. Expected is one of ( Lines, ClippingPlanes, Bitmap ).` |
| 3.0 | both | `Element 'OrthogonalCamera': This element is not expected. Expected is one of ( Lines, ClippingPlanes, Bitmaps ).` |
| 3.0 | none | `Element 'VisualizationInfo': Missing child element(s). Expected is one of ( OrthogonalCamera, PerspectiveCamera ).` |
| 2.1 | orthogonal only | valid (control) |

The camera-less 3.0 case is not hypothetical. `ids-reporter.ts` attaches a camera only `if (bounds)`, and `entityBounds` is optional, so `createBCFFromIDSReport(report, { version: '3.0' })` without bounds writes one invalid `.bcfv` per failing entity:

```
F=<topic>/Viewpoint_<guid>.bcfv {"valid":false,"messages":["Schemas validity error : Element 'VisualizationInfo': Missing child element(s). Expected is one of ( OrthogonalCamera, PerspectiveCamera )."]}
```

## Why the existing tests were green

`schema-validation.test.ts`'s "maximal" fixture sets only `perspectiveCamera`, so no XSD run ever saw a second camera or a missing one. The one test that *did* put both cameras on a 3.0 viewpoint — the AspectRatio round-trip — checks `parse(write(x)) === x` and never asks the schema, so it round-tripped an archive that was invalid the whole time.

Three fixtures in `writer.test.ts` were likewise building camera-less BCF 3.0 viewpoints. They are about markup nesting and `ViewSetupHints`, not cameras, so they now attach a shared schema-valid camera (the same reason `baseTopic` already carries `TopicType`/`TopicStatus`). The AspectRatio round-trip now uses one camera per 3.0 project instead of two per viewpoint; its distinct-value rationale is unchanged.

## The fix

- Cameras are written **orthogonal-first** for both versions — required by 2.1's sequence, harmless under 3.0's choice.
- `requireCameraChoice` rejects a 3.0 write with zero or two cameras, naming the viewpoint, rather than emitting markup no conforming reader has to accept. Same policy as the existing `AspectRatio` and `Topic/@TopicType` checks: refuse rather than guess which camera the caller meant, or invent one for a viewpoint that has none.

## Tests

A new `BCF camera cardinality and order` block that:

- **re-derives both rules from the vendored XSDs** (camera declaration order, absence of `xs:choice` in 2.1, presence of a bare `<xs:choice>` in 3.0) before asserting anything, so a schema bump fails loudly instead of leaving the block testing a stale rule;
- validates the writer's real output for **every** camera combination at both versions, asserting the emitted elements by **name and order** rather than by count (a count of 2 passes for either order);
- has an anti-vacuity guard on the archive entry lookup, and keeps 2.1's camera-less case as the negative control for the 3.0 rule.

Mutation-checked, each restored by inverse edit and proved byte-identical with `diff`:

| mutation | failures |
| --- | --- |
| swap the camera write order back | `expected [ 'PerspectiveCamera', …(1) ] to deeply equal [ 'OrthogonalCamera', …(1) ]` + the 2.1 XSD run |
| accept two cameras at 3.0 | `promise resolved "Blob { … }" instead of rejecting` |
| accept zero cameras at 3.0 | 2 tests, same shape |
| empty the derivation span / point the entry lookup at a missing name | 8 tests, incl. `expected undefined to be defined` |

`packages/bcf` 242 tests green; `sdk`, `clash`, `mcp`, `cli` green.

The camera writers move to `writer-camera.ts` so `writer.ts` stays inside its budget; the budget ratchets **981 → 908** with its digest re-pinned in the same commit.

## Not fixed here

No producer in this repository populates `aspectRatio` (`ViewerCameraState` carries no aspect, and `computeCameraFromBounds` does not set one), so `createBCFFromIDSReport(report, { version: '3.0', entityBounds })` throws at write time:

```
E=THREW: BCF 3.0 requires a positive Camera/AspectRatio (viewpoint "…" has none). Set the camera's aspectRatio before writing a 3.0 file.
```

That is pre-existing, already documented in `schema-validation.test.ts`, and deciding whether the reporter should synthesise an aspect ratio is a separate call — flagging it rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BCF 2.1 viewpoints now write cameras in the correct schema order.
  * BCF 3.0 viewpoints now reject missing or multiple cameras with clear errors identifying the affected viewpoint.
  * BCF 3.0 cameras now require a valid, positive aspect ratio.
* **Validation**
  * Numeric values are checked during export to reject non-finite or invalid integer values.
  * Improved validation and round-trip coverage for camera combinations across BCF versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->