### PR TITLE
fix(export,drawing-2d): stop writing NaN/Infinity into GLB, COLLADA, KMZ and SVG

### DIFF
--- a/.changeset/nonfinite-numbers-in-exported-files.md
+++ b/.changeset/nonfinite-numbers-in-exported-files.md
@@ -1,0 +1,19 @@
+---
+"@ifc-lite/wasm": patch
+"@ifc-lite/drawing-2d": patch
+---
+
+Stop writing `NaN` / `Infinity` / `-Infinity` into exported GLB, COLLADA, KMZ and SVG files.
+
+Neither format can carry a non-finite number, and every one of these paths wrote one anyway.
+
+**GLB / COLLADA / KMZ** (`export_glb_from_meshes`, `export_collada_from_meshes`, `export_kmz_collada_from_meshes` — the viewer's "export" buttons, via `GeometryProcessor.exportGlbFromMeshes` / `exportKmzFromMeshes`). Nothing between a mesh buffer and the bytes established that a coordinate was finite, and the three values did not fail alike:
+
+- An infinite position made `serde_json` write `null` where glTF requires a number — `"min":[null,-0.5,0.0]`, `"translation":[null,0.5,0.0]` — which is schema-invalid, so the whole GLB is rejected rather than merely wrong.
+- A `NaN` position reached the BIN chunk while `min`/`max` stayed finite, because `NaN < min` and `NaN > max` are both false. The accessor's bounding box described a buffer it did not contain.
+- COLLADA re-centres on the mesh AABB, so **one** non-finite vertex turned **every other vertex in the document** into `inf`/`NaN`. Observed: a triangle whose first X was `-Infinity` came out as `NaN 0 0 inf 0 0 inf 0 1` — one bad vertex, no surviving geometry. `<float_array>` is `xs:float`, whose non-finite lexical forms are `INF`/`-INF`/`NaN`; Rust's `Display` writes `inf`/`-inf`, which are not even those.
+- A non-finite colour component became `"baseColorFactor":[null,0.5,0.5,null]`.
+
+All four float arrays (positions, normals, colours, per-mesh origins) now pass through one gate, `mesh_input::scrub_nonfinite`, before either exporter's per-mesh loop reads any of them — rather than at each of the several points where a value becomes bytes, where a guard reaches three call sites out of four. A non-finite component is replaced with `0.0`, matching what the USD writer already did; alpha is the exception and becomes `1.0`, since scrubbing it to `0` would turn a colour defect into an invisible mesh. An all-finite input — the only case a well-formed model produces — is passed through borrowed, with no copy and byte-identical output.
+
+**SVG** (`exportToSVG`). SVG's `<number>` grammar admits a sign, digits, a point and an exponent and nothing else, so `x1="NaN"` is an error a conforming renderer must not draw. Thirteen coordinate, size and rotation interpolations went through a bare `.toFixed(3)`, which stringifies all three values verbatim; the DXF writer beside it in the same package has guarded exactly these at its single `fmt()` since it was written, so the two writers of the same drawing disagreed about the same input. Every SVG number now goes through one `svgNum()`. Separately, `computeTransform` derived the paper offsets from `boundsCenter`/`boundsSize`, which are plain min/max arithmetic: one non-finite corner of the bounding box moved every finite line in the drawing (a line that belonged at `x1="190.000"` was written as `x1="NaN"`). The bounds are sanitised before anything is derived from them, so a degenerate corner no longer relocates the rest of the drawing.

--- a/packages/drawing-2d/src/svg-exporter.test.ts
+++ b/packages/drawing-2d/src/svg-exporter.test.ts
@@ -365,3 +365,91 @@ describe('SVGExporter impossible padding', () => {
     }
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Non-finite coordinates must never reach the SVG text.
+//
+// `NaN`, `Infinity` and `-Infinity` are not SVG `<number>` tokens — the SVG
+// grammar admits only an optional sign, digits, a decimal point and an
+// exponent — so an attribute reading `x1="NaN"` is in error and a conforming
+// renderer must not draw the element. Every coordinate here went through a
+// bare `.toFixed(3)`, which stringifies all three verbatim, while the DXF
+// writer sitting beside it in this package has guarded the same values at its
+// single `fmt()` since it was written. Two writers of the same drawing that
+// disagree about the same input is the defect; the fix is one shared emitter,
+// not a guard sprinkled over thirteen interpolations.
+//
+// The three values are asserted separately: `Infinity` reaches the text as
+// `"Infinity"` while `NaN` reaches it as `"NaN"`, and a guard keyed on only
+// one of them (`isNaN`, say) would let the other two through.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('SVG exporter: non-finite coordinates', () => {
+  const NONFINITE: Array<[string, number]> = [
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['-Infinity', -Infinity],
+  ];
+
+  it.each(NONFINITE)('writes no %s token anywhere in the document', (label, poison) => {
+    const drawing = drawingWithLine(
+      { min: { x: 0, y: 0 }, max: { x: 4, y: 6 } },
+      { x: poison, y: 0 },
+      { x: 2, y: 3 }
+    );
+    const svg = exportToSVG(drawing, {
+      paperSize: PAPER_SIZES.A3_LANDSCAPE,
+      scale: scaleByFactor(100),
+      padding: 20,
+    });
+    // Anti-vacuity: the drawing line really is in the document.
+    expect(svg).toContain('data-entity-id="1"');
+    expect(svg, `[${label}] emitted NaN`).not.toContain('NaN');
+    expect(svg, `[${label}] emitted Infinity`).not.toContain('Infinity');
+  });
+
+  it.each(NONFINITE)(
+    'a non-finite bound (%s) does not poison the other coordinates',
+    (label, poison) => {
+      const drawing = drawingWithLine(
+        { min: { x: poison, y: 0 }, max: { x: 4, y: 6 } },
+        { x: 0, y: 0 },
+        { x: 2, y: 3 }
+      );
+      const svg = exportToSVG(drawing, {
+        paperSize: PAPER_SIZES.A3_LANDSCAPE,
+        scale: scaleByFactor(100),
+        padding: 20,
+      });
+      // Not merely finite: the finite line must land EXACTLY where it does when
+      // the bounds are clean (the 190/178.5/210/148.5 of the characterisation
+      // test above). A guard that emitted "0" for everything would pass a
+      // finiteness-only assertion while still having lost the drawing.
+      const { x1, y1, x2, y2 } = extractLineCoords(svg);
+      expect(x1, `[${label}] x1`).toBeCloseTo(190, 3);
+      expect(y1, `[${label}] y1`).toBeCloseTo(178.5, 3);
+      expect(x2, `[${label}] x2`).toBeCloseTo(210, 3);
+      expect(y2, `[${label}] y2`).toBeCloseTo(148.5, 3);
+    }
+  );
+
+  it('still writes exact coordinates for an all-finite drawing', () => {
+    // Both directions: a guard that emitted "0" for everything would satisfy
+    // every assertion above. Same fixture as the characterisation test at the
+    // top of the file, asserted to the same precision.
+    const drawing = drawingWithLine(
+      { min: { x: 0, y: 0 }, max: { x: 4, y: 6 } },
+      { x: 0, y: 0 },
+      { x: 2, y: 3 }
+    );
+    const svg = exportToSVG(drawing, {
+      paperSize: PAPER_SIZES.A3_LANDSCAPE,
+      scale: scaleByFactor(100),
+      padding: 20,
+    });
+    expect(svg).toContain('x1="190.000"');
+    expect(svg).toContain('y1="178.500"');
+    expect(svg).toContain('x2="210.000"');
+    expect(svg).toContain('y2="148.500"');
+  });
+});

--- a/packages/drawing-2d/src/svg-exporter.ts
+++ b/packages/drawing-2d/src/svg-exporter.ts
@@ -31,8 +31,12 @@ import {
   type DrawingScale,
   type HatchPattern,
 } from './styles.js';
-import { boundsSize, boundsCenter } from './math.js';
-import { formatScaleFactorLabel } from './pdf-scale.js';
+import {
+  computeTransform,
+  scaleLabel,
+  transformPoint,
+  type Transform2D,
+} from './svg-transform.js';
 import { applyDxfPlacement } from './dxf/convert.js';
 import { DEFAULT_DXF_PLACEMENT, type DxfPlacement, type DxfUnderlay } from './dxf/types.js';
 
@@ -84,21 +88,6 @@ export interface SVGUnderlayOptions {
   opacity?: number;
 }
 
-interface Transform2D {
-  scale: number;
-  offsetX: number;
-  offsetY: number;
-  flipY: boolean;
-  /**
-   * True when `scale` (worldToMm) was shrunk below the caller's requested
-   * scale to honour the padding guarantee. Drives the title block's
-   * "Scale:" label: a clamped export must never print the requested name
-   * unchanged (that would be a confidently wrong document — see PR #2131
-   * review), so the label is re-derived from the effective scale instead.
-   */
-  clamped: boolean;
-}
-
 // ═══════════════════════════════════════════════════════════════════════════
 // SVG EXPORTER CLASS
 // ═══════════════════════════════════════════════════════════════════════════
@@ -126,11 +115,6 @@ function svgNum(n: number, digits = 3): string {
   return n.toFixed(digits);
 }
 
-/** Non-finite → 0, so one bad corner of a bounding box can't move the rest. */
-function finiteOr0(n: number): number {
-  return Number.isFinite(n) ? n : 0;
-}
-
 export class SVGExporter {
   private hatchGenerator = new HatchGenerator();
 
@@ -152,7 +136,7 @@ export class SVGExporter {
     } = options;
 
     // Calculate transform from drawing coordinates to SVG coordinates
-    const transform = this.computeTransform(drawing.bounds, paperSize, scale, padding);
+    const transform = computeTransform(drawing.bounds, paperSize, scale, padding);
 
     // Build SVG
     let svg = this.createHeader(paperSize, backgroundColor);
@@ -202,7 +186,7 @@ export class SVGExporter {
 
     // Title block
     if (showTitleBlock) {
-      svg += this.createTitleBlock(paperSize, title, projectName, this.scaleLabel(scale, transform));
+      svg += this.createTitleBlock(paperSize, title, projectName, scaleLabel(scale, transform));
     }
 
     svg += '</svg>';
@@ -221,7 +205,7 @@ export class SVGExporter {
       backgroundColor = '#FFFFFF',
     } = options;
 
-    const transform = this.computeTransform(bounds, paperSize, scale, padding);
+    const transform = computeTransform(bounds, paperSize, scale, padding);
 
     let svg = this.createHeader(paperSize, backgroundColor);
     svg += this.createPolygonDefs(scale.factor);
@@ -234,107 +218,6 @@ export class SVGExporter {
   // ═══════════════════════════════════════════════════════════════════════════
   // PRIVATE METHODS
   // ═══════════════════════════════════════════════════════════════════════════
-
-  private computeTransform(
-    bounds: Bounds2D,
-    paperSize: PaperSize,
-    scale: DrawingScale,
-    padding: number
-  ): Transform2D {
-    // Sanitise the bounds before anything is derived from them. `boundsSize`
-    // and `boundsCenter` are plain min/max arithmetic, so ONE non-finite
-    // corner propagates into `center`, from there into `offsetX`/`offsetY`,
-    // and from there into every coordinate in the document — a single bad
-    // bound moved a perfectly finite line to `x1="NaN"`. Dropping the bad
-    // component to 0 contains the damage to the geometry that was actually
-    // degenerate; `svgNum` is the second line of defence, not the first.
-    const safeBounds: Bounds2D = {
-      min: { x: finiteOr0(bounds.min.x), y: finiteOr0(bounds.min.y) },
-      max: { x: finiteOr0(bounds.max.x), y: finiteOr0(bounds.max.y) },
-    };
-    const size = boundsSize(safeBounds);
-    const center = boundsCenter(safeBounds);
-
-    // `padding` is a minimum-margin guarantee: it must never consume the
-    // whole sheet. An impossible padding (padding*2 >= a paper dimension)
-    // used to disable the clamp entirely on that axis, silently falling
-    // back to rendering at the full requested scale with no margin at all
-    // — the exact failure mode this feature exists to remove, just
-    // triggered by an oversized padding instead of an absent one. Clamp
-    // `padding` itself to the largest value the shorter paper dimension can
-    // still hold (leaving a minimum sliver of usable area) and warn, so the
-    // guarantee keeps holding instead of silently lapsing.
-    const MIN_AVAILABLE_MM = 1;
-    const maxPadding = (Math.min(paperSize.width, paperSize.height) - MIN_AVAILABLE_MM) / 2;
-    let effectivePadding = padding;
-    if (padding > maxPadding) {
-      effectivePadding = Math.max(0, maxPadding);
-      // eslint-disable-next-line no-console -- deliberate: caller-visible, not a silent fallback
-      console.warn(
-        `[drawing-2d] SVGExportOptions.padding (${padding}mm) leaves no usable area on a ` +
-          `${paperSize.width}x${paperSize.height}mm sheet; clamped to ${effectivePadding.toFixed(2)}mm.`
-      );
-    }
-
-    // Available drawing area after the (possibly clamped) padding margin
-    const availableWidth = paperSize.width - effectivePadding * 2;
-    const availableHeight = paperSize.height - effectivePadding * 2;
-
-    // Scale: world units to mm on paper, at the caller's requested scale
-    const requestedWorldToMm = 1000 / scale.factor; // mm per world unit (assuming world is in meters)
-
-    // `padding` is a minimum-margin guarantee, not a forced re-fit: never
-    // render closer to the paper edge than `padding` mm. If the drawing at
-    // the requested scale already leaves at least that much margin, the
-    // exact requested scale is kept unchanged. Otherwise the effective
-    // scale is shrunk (never enlarged) just enough to respect the margin.
-    let worldToMm = requestedWorldToMm;
-    if (size.x > 0 && availableWidth > 0) {
-      worldToMm = Math.min(worldToMm, availableWidth / size.x);
-    }
-    if (size.y > 0 && availableHeight > 0) {
-      worldToMm = Math.min(worldToMm, availableHeight / size.y);
-    }
-
-    // Center the drawing
-    const offsetX = paperSize.width / 2 - center.x * worldToMm;
-    const offsetY = paperSize.height / 2 + center.y * worldToMm; // Flip Y
-
-    return {
-      scale: worldToMm,
-      offsetX,
-      offsetY,
-      flipY: true,
-      clamped: worldToMm !== requestedWorldToMm,
-    };
-  }
-
-  /**
-   * Label printed in the title block's "Scale:" line.
-   *
-   * When the drawing was not clamped, the exact requested `scale.name` is
-   * returned unchanged (no floating-point round-trip on the common path, so
-   * "1:100" never regresses to something like "1:100.0000001"). When the
-   * effective scale was shrunk to honour the padding guarantee, the label is
-   * re-derived from the *actual* `worldToMm` so a clamped sheet never claims
-   * the scale it was requested at but did not render at (PR #2131 review).
-   */
-  private scaleLabel(scale: DrawingScale, transform: Transform2D): string {
-    if (!transform.clamped) {
-      return scale.name;
-    }
-    const effectiveFactor = 1000 / transform.scale;
-    return `1:${formatScaleFactorLabel(effectiveFactor)}`;
-  }
-
-  private transformPoint(point: Point2D, transform: Transform2D): Point2D {
-    return {
-      x: point.x * transform.scale + transform.offsetX,
-      y: transform.flipY
-        ? -point.y * transform.scale + transform.offsetY
-        : point.y * transform.scale + transform.offsetY,
-    };
-  }
 
   private createHeader(paperSize: PaperSize, backgroundColor: string): string {
     return `<?xml version="1.0" encoding="UTF-8"?>
@@ -419,8 +302,8 @@ export class SVGExporter {
 
   private renderLine(line: DrawingLine, transform: Transform2D): string {
     const style = getLineStyle(line.category, line.ifcType);
-    const p0 = this.transformPoint(line.line.start, transform);
-    const p1 = this.transformPoint(line.line.end, transform);
+    const p0 = transformPoint(line.line.start, transform);
+    const p1 = transformPoint(line.line.end, transform);
 
     const dashArray =
       style.dashPattern.length > 0 ? ` stroke-dasharray="${style.dashPattern.join(' ')}"` : '';
@@ -488,10 +371,10 @@ export class SVGExporter {
 
     // Outer boundary
     if (polygon.outer.length > 0) {
-      const first = this.transformPoint(polygon.outer[0], transform);
+      const first = transformPoint(polygon.outer[0], transform);
       path += `M ${svgNum(first.x)} ${svgNum(first.y)}`;
       for (let i = 1; i < polygon.outer.length; i++) {
-        const p = this.transformPoint(polygon.outer[i], transform);
+        const p = transformPoint(polygon.outer[i], transform);
         path += ` L ${svgNum(p.x)} ${svgNum(p.y)}`;
       }
       path += ' Z';
@@ -500,10 +383,10 @@ export class SVGExporter {
     // Holes
     for (const hole of polygon.holes) {
       if (hole.length > 0) {
-        const first = this.transformPoint(hole[0], transform);
+        const first = transformPoint(hole[0], transform);
         path += ` M ${svgNum(first.x)} ${svgNum(first.y)}`;
         for (let i = 1; i < hole.length; i++) {
-          const p = this.transformPoint(hole[i], transform);
+          const p = transformPoint(hole[i], transform);
           path += ` L ${svgNum(p.x)} ${svgNum(p.y)}`;
         }
         path += ' Z';
@@ -518,8 +401,8 @@ export class SVGExporter {
     transform: Transform2D,
     pattern: HatchPattern
   ): string {
-    const p0 = this.transformPoint(hatchLine.line.start, transform);
-    const p1 = this.transformPoint(hatchLine.line.end, transform);
+    const p0 = transformPoint(hatchLine.line.start, transform);
+    const p1 = transformPoint(hatchLine.line.end, transform);
 
     return `    <line x1="${svgNum(p0.x)}" y1="${svgNum(p0.y)}" x2="${svgNum(p1.x)}" y2="${svgNum(p1.y)}"
           stroke="${pattern.strokeColor}" stroke-width="${pattern.lineWeight}" stroke-linecap="butt"/>\n`;
@@ -529,7 +412,9 @@ export class SVGExporter {
     paperSize: PaperSize,
     title: string,
     projectName: string,
-    scaleLabel: string
+    // Not `scaleLabel`: that name now belongs to the imported function from
+    // ./svg-transform.js, and shadowing it here would read as a call site.
+    scaleText: string
   ): string {
     const blockWidth = 180;
     const blockHeight = 50;
@@ -544,7 +429,7 @@ export class SVGExporter {
     <line x1="${x + 100}" y1="${y + 20}" x2="${x + 100}" y2="${y + blockHeight}" stroke="black" stroke-width="0.3"/>
     <text x="${x + 5}" y="${y + 14}" font-family="Arial" font-size="10" font-weight="bold">${this.escapeXml(title)}</text>
     <text x="${x + 5}" y="${y + 30}" font-family="Arial" font-size="8">${this.escapeXml(projectName)}</text>
-    <text x="${x + 5}" y="${y + 45}" font-family="Arial" font-size="8">Scale: ${this.escapeXml(scaleLabel)}</text>
+    <text x="${x + 5}" y="${y + 45}" font-family="Arial" font-size="8">Scale: ${this.escapeXml(scaleText)}</text>
     <text x="${x + 105}" y="${y + 30}" font-family="Arial" font-size="7">Date:</text>
     <text x="${x + 105}" y="${y + 45}" font-family="Arial" font-size="7">${new Date().toLocaleDateString()}</text>
   </g>\n`;
@@ -562,7 +447,7 @@ export class SVGExporter {
   private createUnderlayLayer(options: SVGUnderlayOptions, transform: Transform2D): string {
     const { underlay, placement = DEFAULT_DXF_PLACEMENT, layerVisibility = {}, opacity = 1 } = options;
     const mapPoint = (p: Point2D): Point2D =>
-      this.transformPoint(applyDxfPlacement({ x: p.x, y: -p.y }, placement), transform);
+      transformPoint(applyDxfPlacement({ x: p.x, y: -p.y }, placement), transform);
     const groupId = `dxf-${underlay.name.replace(/[^A-Za-z0-9_-]/g, '_')}`;
 
     let layer = `  <g id="${this.escapeXml(groupId)}" inkscape:label="${this.escapeXml(underlay.name)}" inkscape:groupmode="layer" opacity="${opacity}">\n`;

--- a/packages/drawing-2d/src/svg-exporter.ts
+++ b/packages/drawing-2d/src/svg-exporter.ts
@@ -103,6 +103,34 @@ interface Transform2D {
 // SVG EXPORTER CLASS
 // ═══════════════════════════════════════════════════════════════════════════
 
+/**
+ * The one place a number becomes SVG text.
+ *
+ * SVG's `<number>` grammar admits a sign, digits, a decimal point and an
+ * exponent — and nothing else. `NaN`, `Infinity` and `-Infinity` stringify
+ * verbatim through `toFixed`, so an unguarded interpolation writes
+ * `x1="NaN"`, which a conforming renderer must treat as an error rather than
+ * draw. The DXF writer beside this one has always guarded the same values at
+ * its own single `fmt()` (`dxf/writer.ts`); this is the SVG half of that
+ * rule, in one function rather than at each of the coordinate, size and
+ * rotation interpolations below — so it cannot end up applied to some of
+ * them and not the others.
+ *
+ * Non-finite becomes `0`, matching the DXF writer's deterministic `'0.0'`:
+ * the document stays parseable and byte-reproducible, and the degenerate
+ * geometry collapses at the origin where it is visible, instead of taking
+ * the rest of the drawing with it.
+ */
+function svgNum(n: number, digits = 3): string {
+  if (!Number.isFinite(n)) return '0';
+  return n.toFixed(digits);
+}
+
+/** Non-finite → 0, so one bad corner of a bounding box can't move the rest. */
+function finiteOr0(n: number): number {
+  return Number.isFinite(n) ? n : 0;
+}
+
 export class SVGExporter {
   private hatchGenerator = new HatchGenerator();
 
@@ -213,8 +241,19 @@ export class SVGExporter {
     scale: DrawingScale,
     padding: number
   ): Transform2D {
-    const size = boundsSize(bounds);
-    const center = boundsCenter(bounds);
+    // Sanitise the bounds before anything is derived from them. `boundsSize`
+    // and `boundsCenter` are plain min/max arithmetic, so ONE non-finite
+    // corner propagates into `center`, from there into `offsetX`/`offsetY`,
+    // and from there into every coordinate in the document — a single bad
+    // bound moved a perfectly finite line to `x1="NaN"`. Dropping the bad
+    // component to 0 contains the damage to the geometry that was actually
+    // degenerate; `svgNum` is the second line of defence, not the first.
+    const safeBounds: Bounds2D = {
+      min: { x: finiteOr0(bounds.min.x), y: finiteOr0(bounds.min.y) },
+      max: { x: finiteOr0(bounds.max.x), y: finiteOr0(bounds.max.y) },
+    };
+    const size = boundsSize(safeBounds);
+    const center = boundsCenter(safeBounds);
 
     // `padding` is a minimum-margin guarantee: it must never consume the
     // whole sheet. An impossible padding (padding*2 >= a paper dimension)
@@ -386,7 +425,7 @@ export class SVGExporter {
     const dashArray =
       style.dashPattern.length > 0 ? ` stroke-dasharray="${style.dashPattern.join(' ')}"` : '';
 
-    return `    <line x1="${p0.x.toFixed(3)}" y1="${p0.y.toFixed(3)}" x2="${p1.x.toFixed(3)}" y2="${p1.y.toFixed(3)}"
+    return `    <line x1="${svgNum(p0.x)}" y1="${svgNum(p0.y)}" x2="${svgNum(p1.x)}" y2="${svgNum(p1.y)}"
           stroke="${style.color}" stroke-width="${style.weight}"
           stroke-linecap="${style.lineCap}"${dashArray}
           data-entity-id="${line.entityId}" data-ifc-type="${this.escapeXml(line.ifcType)}"/>\n`;
@@ -450,10 +489,10 @@ export class SVGExporter {
     // Outer boundary
     if (polygon.outer.length > 0) {
       const first = this.transformPoint(polygon.outer[0], transform);
-      path += `M ${first.x.toFixed(3)} ${first.y.toFixed(3)}`;
+      path += `M ${svgNum(first.x)} ${svgNum(first.y)}`;
       for (let i = 1; i < polygon.outer.length; i++) {
         const p = this.transformPoint(polygon.outer[i], transform);
-        path += ` L ${p.x.toFixed(3)} ${p.y.toFixed(3)}`;
+        path += ` L ${svgNum(p.x)} ${svgNum(p.y)}`;
       }
       path += ' Z';
     }
@@ -462,10 +501,10 @@ export class SVGExporter {
     for (const hole of polygon.holes) {
       if (hole.length > 0) {
         const first = this.transformPoint(hole[0], transform);
-        path += ` M ${first.x.toFixed(3)} ${first.y.toFixed(3)}`;
+        path += ` M ${svgNum(first.x)} ${svgNum(first.y)}`;
         for (let i = 1; i < hole.length; i++) {
           const p = this.transformPoint(hole[i], transform);
-          path += ` L ${p.x.toFixed(3)} ${p.y.toFixed(3)}`;
+          path += ` L ${svgNum(p.x)} ${svgNum(p.y)}`;
         }
         path += ' Z';
       }
@@ -482,7 +521,7 @@ export class SVGExporter {
     const p0 = this.transformPoint(hatchLine.line.start, transform);
     const p1 = this.transformPoint(hatchLine.line.end, transform);
 
-    return `    <line x1="${p0.x.toFixed(3)}" y1="${p0.y.toFixed(3)}" x2="${p1.x.toFixed(3)}" y2="${p1.y.toFixed(3)}"
+    return `    <line x1="${svgNum(p0.x)}" y1="${svgNum(p0.y)}" x2="${svgNum(p1.x)}" y2="${svgNum(p1.y)}"
           stroke="${pattern.strokeColor}" stroke-width="${pattern.lineWeight}" stroke-linecap="butt"/>\n`;
   }
 
@@ -539,10 +578,10 @@ export class SVGExporter {
         for (const ring of rings) {
           if (ring.length === 0) continue;
           const first = mapPoint(ring[0]);
-          d += `${d ? ' ' : ''}M ${first.x.toFixed(3)} ${first.y.toFixed(3)}`;
+          d += `${d ? ' ' : ''}M ${svgNum(first.x)} ${svgNum(first.y)}`;
           for (let i = 1; i < ring.length; i++) {
             const p = mapPoint(ring[i]);
-            d += ` L ${p.x.toFixed(3)} ${p.y.toFixed(3)}`;
+            d += ` L ${svgNum(p.x)} ${svgNum(p.y)}`;
           }
           d += ' Z';
         }
@@ -554,11 +593,11 @@ export class SVGExporter {
       for (const path of dxfLayer.paths) {
         if (path.points.length < 2) continue;
         const pts = path.points.map(mapPoint);
-        const pointsAttr = pts.map((p) => `${p.x.toFixed(3)},${p.y.toFixed(3)}`).join(' ');
+        const pointsAttr = pts.map((p) => `${svgNum(p.x)},${svgNum(p.y)}`).join(' ');
         const tag = path.closed ? 'polygon' : 'polyline';
         const strokeWidth = path.widthMm ?? 0.18;
-        const dash = path.dashed ? ` stroke-dasharray="${(strokeWidth * 6).toFixed(3)} ${(strokeWidth * 4).toFixed(3)}"` : '';
-        layer += `      <${tag} points="${pointsAttr}" fill="none" stroke="${path.color ?? dxfLayer.color}" stroke-width="${strokeWidth}" stroke-linecap="round"${dash}/>\n`;
+        const dash = path.dashed ? ` stroke-dasharray="${svgNum(strokeWidth * 6)} ${svgNum(strokeWidth * 4)}"` : '';
+        layer += `      <${tag} points="${pointsAttr}" fill="none" stroke="${path.color ?? dxfLayer.color}" stroke-width="${svgNum(strokeWidth)}" stroke-linecap="round"${dash}/>\n`;
       }
 
       for (const text of dxfLayer.texts) {
@@ -578,9 +617,9 @@ export class SVGExporter {
         // Multiline MTEXT stacks with tspans, matching the canvas layout.
         const lines = text.text.split('\n');
         const content = lines
-          .map((line, i) => `<tspan x="${anchor.x.toFixed(3)}" dy="${i === 0 ? 0 : (heightMm * 1.3).toFixed(3)}">${this.escapeXml(line)}</tspan>`)
+          .map((line, i) => `<tspan x="${svgNum(anchor.x)}" dy="${i === 0 ? 0 : svgNum(heightMm * 1.3)}">${this.escapeXml(line)}</tspan>`)
           .join('');
-        layer += `      <text x="${anchor.x.toFixed(3)}" y="${anchor.y.toFixed(3)}" font-family="Arial, sans-serif" font-size="${heightMm.toFixed(3)}" fill="${text.color ?? dxfLayer.color}" text-anchor="${anchorAttr}" dominant-baseline="${baseline}" transform="rotate(${angle.toFixed(2)} ${anchor.x.toFixed(3)} ${anchor.y.toFixed(3)})">${content}</text>\n`;
+        layer += `      <text x="${svgNum(anchor.x)}" y="${svgNum(anchor.y)}" font-family="Arial, sans-serif" font-size="${svgNum(heightMm)}" fill="${text.color ?? dxfLayer.color}" text-anchor="${anchorAttr}" dominant-baseline="${baseline}" transform="rotate(${svgNum(angle, 2)} ${svgNum(anchor.x)} ${svgNum(anchor.y)})">${content}</text>\n`;
       }
 
       layer += '    </g>\n';

--- a/packages/drawing-2d/src/svg-transform.ts
+++ b/packages/drawing-2d/src/svg-transform.ts
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * World-to-paper transform for the SVG exporter.
+ *
+ * Split out of `svg-exporter.ts` unchanged: fitting a drawing's world bounds
+ * onto a sheet (and reporting the scale that was actually used) is one
+ * cohesive job, separable from turning the fitted geometry into SVG markup.
+ * None of these were ever methods in any meaningful sense — they read no
+ * `this` — so they are plain functions here.
+ */
+
+import type { Point2D, Bounds2D } from './types.js';
+import type { PaperSize, DrawingScale } from './styles.js';
+import { boundsSize, boundsCenter } from './math.js';
+import { formatScaleFactorLabel } from './pdf-scale.js';
+
+export interface Transform2D {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  flipY: boolean;
+  /**
+   * True when `scale` (worldToMm) was shrunk below the caller's requested
+   * scale to honour the padding guarantee. Drives the title block's
+   * "Scale:" label: a clamped export must never print the requested name
+   * unchanged (that would be a confidently wrong document — see PR #2131
+   * review), so the label is re-derived from the effective scale instead.
+   */
+  clamped: boolean;
+}
+
+/** Non-finite → 0, so one bad corner of a bounding box can't move the rest. */
+export function finiteOr0(n: number): number {
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function computeTransform(
+  bounds: Bounds2D,
+  paperSize: PaperSize,
+  scale: DrawingScale,
+  padding: number
+): Transform2D {
+  // Sanitise the bounds before anything is derived from them. `boundsSize`
+  // and `boundsCenter` are plain min/max arithmetic, so ONE non-finite
+  // corner propagates into `center`, from there into `offsetX`/`offsetY`,
+  // and from there into every coordinate in the document — a single bad
+  // bound moved a perfectly finite line to `x1="NaN"`. Dropping the bad
+  // component to 0 contains the damage to the geometry that was actually
+  // degenerate; `svgNum` is the second line of defence, not the first.
+  const safeBounds: Bounds2D = {
+    min: { x: finiteOr0(bounds.min.x), y: finiteOr0(bounds.min.y) },
+    max: { x: finiteOr0(bounds.max.x), y: finiteOr0(bounds.max.y) },
+  };
+  const size = boundsSize(safeBounds);
+  const center = boundsCenter(safeBounds);
+
+  // `padding` is a minimum-margin guarantee: it must never consume the
+  // whole sheet. An impossible padding (padding*2 >= a paper dimension)
+  // used to disable the clamp entirely on that axis, silently falling
+  // back to rendering at the full requested scale with no margin at all
+  // — the exact failure mode this feature exists to remove, just
+  // triggered by an oversized padding instead of an absent one. Clamp
+  // `padding` itself to the largest value the shorter paper dimension can
+  // still hold (leaving a minimum sliver of usable area) and warn, so the
+  // guarantee keeps holding instead of silently lapsing.
+  const MIN_AVAILABLE_MM = 1;
+  const maxPadding = (Math.min(paperSize.width, paperSize.height) - MIN_AVAILABLE_MM) / 2;
+  let effectivePadding = padding;
+  if (padding > maxPadding) {
+    effectivePadding = Math.max(0, maxPadding);
+    // eslint-disable-next-line no-console -- deliberate: caller-visible, not a silent fallback
+    console.warn(
+      `[drawing-2d] SVGExportOptions.padding (${padding}mm) leaves no usable area on a ` +
+        `${paperSize.width}x${paperSize.height}mm sheet; clamped to ${effectivePadding.toFixed(2)}mm.`
+    );
+  }
+
+  // Available drawing area after the (possibly clamped) padding margin
+  const availableWidth = paperSize.width - effectivePadding * 2;
+  const availableHeight = paperSize.height - effectivePadding * 2;
+
+  // Scale: world units to mm on paper, at the caller's requested scale
+  const requestedWorldToMm = 1000 / scale.factor; // mm per world unit (assuming world is in meters)
+
+  // `padding` is a minimum-margin guarantee, not a forced re-fit: never
+  // render closer to the paper edge than `padding` mm. If the drawing at
+  // the requested scale already leaves at least that much margin, the
+  // exact requested scale is kept unchanged. Otherwise the effective
+  // scale is shrunk (never enlarged) just enough to respect the margin.
+  let worldToMm = requestedWorldToMm;
+  if (size.x > 0 && availableWidth > 0) {
+    worldToMm = Math.min(worldToMm, availableWidth / size.x);
+  }
+  if (size.y > 0 && availableHeight > 0) {
+    worldToMm = Math.min(worldToMm, availableHeight / size.y);
+  }
+
+  // Center the drawing
+  const offsetX = paperSize.width / 2 - center.x * worldToMm;
+  const offsetY = paperSize.height / 2 + center.y * worldToMm; // Flip Y
+
+  return {
+    scale: worldToMm,
+    offsetX,
+    offsetY,
+    flipY: true,
+    clamped: worldToMm !== requestedWorldToMm,
+  };
+}
+
+/**
+ * Label printed in the title block's "Scale:" line.
+ *
+ * When the drawing was not clamped, the exact requested `scale.name` is
+ * returned unchanged (no floating-point round-trip on the common path, so
+ * "1:100" never regresses to something like "1:100.0000001"). When the
+ * effective scale was shrunk to honour the padding guarantee, the label is
+ * re-derived from the *actual* `worldToMm` so a clamped sheet never claims
+ * the scale it was requested at but did not render at (PR #2131 review).
+ */
+export function scaleLabel(scale: DrawingScale, transform: Transform2D): string {
+  if (!transform.clamped) {
+    return scale.name;
+  }
+  const effectiveFactor = 1000 / transform.scale;
+  return `1:${formatScaleFactorLabel(effectiveFactor)}`;
+}
+
+export function transformPoint(point: Point2D, transform: Transform2D): Point2D {
+  return {
+    x: point.x * transform.scale + transform.offsetX,
+    y: transform.flipY
+      ? -point.y * transform.scale + transform.offsetY
+      : point.y * transform.scale + transform.offsetY,
+  };
+}

--- a/rust/export/src/collada.rs
+++ b/rust/export/src/collada.rs
@@ -21,6 +21,8 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 
+use crate::collada_fmt::append_floats;
+
 /// Material dedup key: RGBA rounded to 2 decimals (matches the glTF exporter).
 fn color_key(c: [f32; 4]) -> (i32, i32, i32, i32) {
     let r = |v: f32| (v * 100.0).round() as i32;
@@ -63,6 +65,17 @@ pub fn export_collada_from_meshes(
     colors: &[f32],
     origins: &[f64],
 ) -> Vec<u8> {
+    // Gate every float BEFORE any of it is read. `<float_array>` is `xs:float`,
+    // which has no lexical form matching Rust's `inf`/`-inf`, and the AABB
+    // re-centring below spreads a single non-finite vertex over every other
+    // vertex in the document. See `crate::mesh_input`.
+    let scrubbed = crate::mesh_input::scrub_nonfinite(positions, normals, colors, origins);
+    let (positions, normals, colors, origins) = (
+        &*scrubbed.positions,
+        &*scrubbed.normals,
+        &*scrubbed.colors,
+        &*scrubbed.origins,
+    );
     // Concatenated Z-up vertex buffers (one shared POSITION + NORMAL source) and,
     // per material, the triangle indices into that shared buffer. Positions are
     // accumulated in f64 so `world = origin + position` and the subsequent AABB
@@ -393,36 +406,6 @@ fn write_dae(
     s.push_str("  <scene><instance_visual_scene url=\"#scene\"/></scene>\n</COLLADA>\n");
 
     s.into_bytes()
-}
-
-/// Append space-separated floats, trimming trailing zeros for compactness while
-/// keeping enough precision for metre-scale building coordinates.
-fn append_floats(s: &mut String, vals: &[f32]) {
-    for (i, v) in vals.iter().enumerate() {
-        if i > 0 {
-            s.push(' ');
-        }
-        let _ = write!(s, "{}", fmt_f32(*v));
-    }
-}
-
-/// Format an f32 with up to 4 decimals (0.1 mm at building scale), no trailing
-/// zeros — keeps the document compact (fewer chars per coordinate) while staying
-/// far below any visible tolerance.
-fn fmt_f32(v: f32) -> String {
-    if v == 0.0 {
-        return "0".to_string();
-    }
-    let mut t = format!("{v:.4}");
-    if t.contains('.') {
-        while t.ends_with('0') {
-            t.pop();
-        }
-        if t.ends_with('.') {
-            t.pop();
-        }
-    }
-    t
 }
 
 #[cfg(test)]

--- a/rust/export/src/collada_fmt.rs
+++ b/rust/export/src/collada_fmt.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MPL-2.0
+//! The number-to-text half of the COLLADA writer: how an f32 becomes a token in a
+//! `<float_array>`.
+//!
+//! Split out of `collada.rs` to keep that module under its size ratchet
+//! (`rust/processing/tests/module_size_ratchet.rs`). Pure formatting, with no
+//! dependency on the document assembly that stays there; the emitted text is
+//! unchanged.
+//!
+//! Finiteness is NOT this layer's job: `<float_array>` is `xs:float`, whose only
+//! non-finite lexical forms are `INF`/`-INF`/`NaN` while Rust's `Display` writes
+//! `inf`/`-inf`, and by the time a value reaches here the AABB re-centring has
+//! already spread one bad vertex across the whole document. That is gated once, on
+//! the way in, by `crate::mesh_input`.
+
+use std::fmt::Write as _;
+
+/// Append space-separated floats, trimming trailing zeros for compactness while
+/// keeping enough precision for metre-scale building coordinates.
+pub(crate) fn append_floats(s: &mut String, vals: &[f32]) {
+    for (i, v) in vals.iter().enumerate() {
+        if i > 0 {
+            s.push(' ');
+        }
+        let _ = write!(s, "{}", fmt_f32(*v));
+    }
+}
+
+/// Format an f32 with up to 4 decimals (0.1 mm at building scale), no trailing
+/// zeros — keeps the document compact (fewer chars per coordinate) while staying
+/// far below any visible tolerance.
+fn fmt_f32(v: f32) -> String {
+    if v == 0.0 {
+        return "0".to_string();
+    }
+    let mut t = format!("{v:.4}");
+    if t.contains('.') {
+        while t.ends_with('0') {
+            t.pop();
+        }
+        if t.ends_with('.') {
+            t.pop();
+        }
+    }
+    t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trims_trailing_zeros_and_collapses_zero() {
+        let mut s = String::new();
+        append_floats(&mut s, &[0.0, 1.0, 1.5, -2.25, 0.00001]);
+        assert_eq!(s, "0 1 1.5 -2.25 0");
+    }
+}

--- a/rust/export/src/gltf/from_meshes.rs
+++ b/rust/export/src/gltf/from_meshes.rs
@@ -123,6 +123,17 @@ pub fn export_glb_from_meshes(
     lit: bool,
     emissive: bool,
 ) -> (Vec<u8>, GltfStats) {
+    // Gate every float BEFORE any of it is read: a non-finite coordinate has no
+    // representation in glTF JSON (`serde_json` writes `null`, which is
+    // schema-invalid) and, left alone, propagates through the scene-centre
+    // subtraction into vertices that were fine. See `crate::mesh_input`.
+    let scrubbed = crate::mesh_input::scrub_nonfinite(positions, normals, colors, origins);
+    let (positions, normals, colors, origins) = (
+        &*scrubbed.positions,
+        &*scrubbed.normals,
+        &*scrubbed.colors,
+        &*scrubbed.origins,
+    );
     let n = vertex_counts.len();
     // The viewer's `MeshData` arrives pre-welded from the mesh source
     // (`ifc_lite_processing::element::build_mesh_data` welds every element via

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -13,6 +13,7 @@ mod test_support;
 
 mod adjacency;
 mod collada;
+mod collada_fmt;
 mod constructions;
 mod csv;
 /// The single CSV cell escaper for this crate — RFC 4180 quoting plus the
@@ -30,6 +31,7 @@ mod json;
 mod jsonld;
 mod kmz;
 mod merged;
+mod mesh_input;
 mod model;
 mod obj;
 mod relationships;

--- a/rust/export/src/mesh_input.rs
+++ b/rust/export/src/mesh_input.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MPL-2.0
+//! The one gate every from-meshes exporter passes its numeric input through.
+//!
+//! `export_glb_from_meshes`, `export_collada_from_meshes` and (through the latter)
+//! `export_kmz_collada_from_meshes` all take the same flattened parallel arrays —
+//! the viewer's `MeshData`, handed across the wasm FFI by
+//! `GeometryProcessor.exportGlbFromMeshes` / `exportKmzFromMeshes`. Those buffers
+//! reach the FFI from whatever produced the meshes (the geometry pipeline, the
+//! demesher, or a caller's own `addMeshes`), and no layer between there and the
+//! bytes established that a coordinate was finite.
+//!
+//! It matters because neither target format can carry a non-finite number:
+//!
+//! * **glTF/GLB.** The glTF 2.0 spec forbids `NaN`/`Infinity` in the JSON, and
+//!   `serde_json` renders one as `null` — an accessor `min` of `[null,-0.5,0.0]`
+//!   or a node `translation` of `[null,0.5,0.0]` is schema-invalid, and every
+//!   validator and loader rejects it. Worse, a `NaN` *position* used to reach the
+//!   BIN chunk while `min`/`max` stayed finite, because `NaN < min` and
+//!   `NaN > max` are both false: a bounding box that lies about its own buffer.
+//! * **COLLADA/KMZ.** `<float_array>` is `xs:float`, whose only non-finite lexical
+//!   forms are `INF`, `-INF` and `NaN`; Rust's `Display` writes `inf`/`-inf`,
+//!   which are not even that. And because the exporter re-centres on the mesh
+//!   AABB, ONE non-finite vertex turned every OTHER vertex in the document into
+//!   `inf`/`NaN` — one bad vertex, no surviving geometry.
+//!
+//! So the rule is enforced once, here, on the whole input, before either exporter's
+//! per-mesh loop runs — rather than at each of the several places a value becomes
+//! bytes, where it is one edit away from covering three call sites out of four.
+//!
+//! **Scrub, not reject.** A non-finite component is replaced with `0.0` (alpha with
+//! `1.0`), matching what the USD writer already does (`usd::fmt::fmt_f32`). Zeroing
+//! one component leaves a spike toward the mesh origin, which is visibly wrong in
+//! the one degenerate face that produced it; letting it through costs the entire
+//! file. Alpha is the exception: scrubbing it to `0` would turn a colour defect into
+//! an invisible mesh, trading a loud failure for a silent one.
+
+use std::borrow::Cow;
+
+/// Non-finite → `0.0`, everything else untouched (including `-0.0`).
+#[inline]
+fn finite_or_zero_f32(v: f32) -> f32 {
+    if v.is_finite() {
+        v
+    } else {
+        0.0
+    }
+}
+
+#[inline]
+fn finite_or_zero_f64(v: f64) -> f64 {
+    if v.is_finite() {
+        v
+    } else {
+        0.0
+    }
+}
+
+/// Borrow the slice when every element is already finite; otherwise return an owned
+/// copy with the offenders zeroed. The all-finite path — the only one a well-formed
+/// model takes — allocates nothing and copies nothing.
+fn scrub_f32(v: &[f32]) -> Cow<'_, [f32]> {
+    if v.iter().all(|x| x.is_finite()) {
+        Cow::Borrowed(v)
+    } else {
+        Cow::Owned(v.iter().copied().map(finite_or_zero_f32).collect())
+    }
+}
+
+fn scrub_f64(v: &[f64]) -> Cow<'_, [f64]> {
+    if v.iter().all(|x| x.is_finite()) {
+        Cow::Borrowed(v)
+    } else {
+        Cow::Owned(v.iter().copied().map(finite_or_zero_f64).collect())
+    }
+}
+
+/// RGBA quads: a non-finite R/G/B becomes `0.0`, a non-finite A becomes `1.0`.
+///
+/// The array is RGBA per mesh, so alpha is every fourth element. A trailing partial
+/// quad (a caller passing fewer floats than `4 * meshes`) is scrubbed by the same
+/// positional rule; the exporters already default any missing component themselves.
+fn scrub_colors(v: &[f32]) -> Cow<'_, [f32]> {
+    if v.iter().all(|x| x.is_finite()) {
+        Cow::Borrowed(v)
+    } else {
+        Cow::Owned(
+            v.iter()
+                .copied()
+                .enumerate()
+                .map(|(i, x)| {
+                    if x.is_finite() {
+                        x
+                    } else if i % 4 == 3 {
+                        1.0
+                    } else {
+                        0.0
+                    }
+                })
+                .collect(),
+        )
+    }
+}
+
+/// The scrubbed numeric input of a from-meshes export. Deref each field to a slice.
+pub(crate) struct MeshInput<'a> {
+    pub(crate) positions: Cow<'a, [f32]>,
+    pub(crate) normals: Cow<'a, [f32]>,
+    pub(crate) colors: Cow<'a, [f32]>,
+    pub(crate) origins: Cow<'a, [f64]>,
+}
+
+/// Gate the four float arrays of a from-meshes export. See the module docs for why
+/// this exists and why it scrubs rather than rejects.
+///
+/// Indices and counts are integers and need no gate.
+pub(crate) fn scrub_nonfinite<'a>(
+    positions: &'a [f32],
+    normals: &'a [f32],
+    colors: &'a [f32],
+    origins: &'a [f64],
+) -> MeshInput<'a> {
+    MeshInput {
+        positions: scrub_f32(positions),
+        normals: scrub_f32(normals),
+        colors: scrub_colors(colors),
+        origins: scrub_f64(origins),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_finite_input_is_borrowed_not_copied() {
+        let p = [1.0f32, 2.0, 3.0];
+        let o = [4.0f64];
+        let input = scrub_nonfinite(&p, &p, &p, &o);
+        assert!(matches!(input.positions, Cow::Borrowed(_)));
+        assert!(matches!(input.normals, Cow::Borrowed(_)));
+        assert!(matches!(input.colors, Cow::Borrowed(_)));
+        assert!(matches!(input.origins, Cow::Borrowed(_)));
+        assert_eq!(&*input.positions, &p);
+        assert_eq!(&*input.origins, &o);
+    }
+
+    #[test]
+    fn each_non_finite_form_is_zeroed_independently() {
+        let p = [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, -1.5];
+        let input = scrub_nonfinite(&p, &[], &[], &[]);
+        assert_eq!(&*input.positions, &[0.0, 0.0, 0.0, -1.5]);
+
+        let o = [f64::NAN, f64::INFINITY, f64::NEG_INFINITY, -1.5];
+        let input = scrub_nonfinite(&[], &[], &[], &o);
+        assert_eq!(&*input.origins, &[0.0, 0.0, 0.0, -1.5]);
+    }
+
+    #[test]
+    fn alpha_scrubs_to_one_so_the_mesh_stays_visible() {
+        let c = [f32::NAN, 0.5, f32::INFINITY, f32::NEG_INFINITY];
+        let input = scrub_nonfinite(&[], &[], &c, &[]);
+        assert_eq!(&*input.colors, &[0.0, 0.5, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn negative_zero_survives() {
+        let p = [-0.0f32];
+        let input = scrub_nonfinite(&p, &[], &[], &[]);
+        assert!(input.positions[0].is_sign_negative());
+    }
+}

--- a/rust/export/tests/nonfinite_mesh_input.rs
+++ b/rust/export/tests/nonfinite_mesh_input.rs
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MPL-2.0
+//! Non-finite coordinates must never reach an exported mesh file.
+//!
+//! The three from-meshes exporters (`export_glb_from_meshes`,
+//! `export_collada_from_meshes`, and `export_kmz_collada_from_meshes` through it)
+//! take the viewer's flattened `MeshData` arrays straight off the wasm FFI. Nothing
+//! between a plugin-supplied mesh and the bytes checked that a coordinate was finite,
+//! and every one of the three failure modes below was observed on `main`:
+//!
+//! * glTF JSON has no lexical form for a non-finite number — `serde_json` maps one to
+//!   `null`, and an accessor `min`/`max` of `[null,-0.5,0.0]` violates the glTF 2.0
+//!   schema (the items are `number`).
+//! * A `NaN` position slipped into the BIN chunk while `min`/`max` stayed finite,
+//!   because `NaN < min` and `NaN > max` are both false — a bounding box that lies
+//!   about its own buffer.
+//! * COLLADA re-centres on the mesh AABB, so ONE non-finite vertex turned every OTHER
+//!   vertex in the whole document into `inf`/`NaN`. One bad vertex, no surviving
+//!   geometry.
+//!
+//! `NaN`, `+Infinity` and `-Infinity` are asserted separately: they did not behave
+//! alike (`NaN` left `min`/`max` finite, the infinities produced `null`).
+
+use ifc_lite_export::{export_collada_from_meshes, export_glb_from_meshes};
+
+/// One triangle whose FIRST vertex's X is `poison`; the other two are finite and
+/// must survive unchanged.
+fn tri(poison: f32) -> (Vec<f32>, Vec<f32>, Vec<u32>) {
+    let positions = vec![poison, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    let normals = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+    (positions, normals, vec![0u32, 1, 2])
+}
+
+fn glb_parts(poison: f32) -> (String, Vec<f32>) {
+    let (p, n, i) = tri(poison);
+    let (glb, stats) = export_glb_from_meshes(
+        &p,
+        &n,
+        &i,
+        &[3],
+        &[3],
+        &[0.8, 0.8, 0.8, 1.0],
+        &[0.0, 0.0, 0.0],
+        &[42],
+        false,
+        true,
+        false,
+    );
+    // Anti-vacuity: the mesh must actually have been emitted, not silently dropped.
+    assert_eq!(stats.meshes, 1, "expected exactly one emitted mesh");
+    assert_eq!(stats.vertices, 3, "expected three emitted vertices");
+
+    let jlen = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+    let json = String::from_utf8_lossy(&glb[20..20 + jlen]).to_string();
+    let bstart = 20 + jlen;
+    let blen = u32::from_le_bytes(glb[bstart..bstart + 4].try_into().unwrap()) as usize;
+    let bin = &glb[bstart + 8..bstart + 8 + blen];
+    let floats: Vec<f32> = bin
+        .chunks_exact(4)
+        .take(9) // the three POSITION vec3s
+        .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    (json, floats)
+}
+
+fn collada_positions(poison: f32) -> String {
+    let (p, n, i) = tri(poison);
+    let dae = export_collada_from_meshes(
+        &p,
+        &n,
+        &i,
+        &[3],
+        &[3],
+        &[0.8, 0.8, 0.8, 1.0],
+        &[0.0, 0.0, 0.0],
+    );
+    let dae = String::from_utf8_lossy(&dae).to_string();
+    let line = dae
+        .lines()
+        .find(|l| l.contains("float_array") && l.contains("pos-arr"))
+        .unwrap_or_else(|| panic!("no position float_array in COLLADA output"))
+        .trim()
+        .to_string();
+    // Anti-vacuity: the positions really are in there.
+    assert!(line.contains("count=\"9\""), "expected 9 position floats: {line}");
+    line
+}
+
+#[test]
+fn glb_json_never_carries_a_null_bound() {
+    for (label, poison) in
+        [("NaN", f32::NAN), ("+Inf", f32::INFINITY), ("-Inf", f32::NEG_INFINITY)]
+    {
+        let (json, _) = glb_parts(poison);
+        assert!(
+            !json.contains("null"),
+            "[{label}] glTF JSON carries a `null` where a number belongs: {json}"
+        );
+    }
+}
+
+#[test]
+fn glb_bin_chunk_is_all_finite() {
+    for (label, poison) in
+        [("NaN", f32::NAN), ("+Inf", f32::INFINITY), ("-Inf", f32::NEG_INFINITY)]
+    {
+        let (_, floats) = glb_parts(poison);
+        assert!(
+            floats.iter().all(|f| f.is_finite()),
+            "[{label}] GLB BIN chunk holds a non-finite position: {floats:?}"
+        );
+    }
+}
+
+#[test]
+fn one_bad_vertex_does_not_poison_the_others_in_glb() {
+    // The two good vertices are 1 apart in X and in Y. Whatever the scrub does with
+    // the poisoned component, the surviving geometry must keep its shape.
+    let (_, baseline) = glb_parts(0.0);
+    for (label, poison) in
+        [("NaN", f32::NAN), ("+Inf", f32::INFINITY), ("-Inf", f32::NEG_INFINITY)]
+    {
+        let (_, floats) = glb_parts(poison);
+        assert_eq!(
+            floats, baseline,
+            "[{label}] a non-finite vertex changed the OTHER vertices: {floats:?}"
+        );
+    }
+}
+
+#[test]
+fn collada_never_writes_a_nan_or_inf_token() {
+    for (label, poison) in
+        [("NaN", f32::NAN), ("+Inf", f32::INFINITY), ("-Inf", f32::NEG_INFINITY)]
+    {
+        let line = collada_positions(poison);
+        for bad in ["NaN", "nan", "inf", "INF"] {
+            assert!(
+                !line.contains(bad),
+                "[{label}] COLLADA position array carries `{bad}`: {line}"
+            );
+        }
+    }
+}
+
+#[test]
+fn one_bad_vertex_does_not_poison_the_others_in_collada() {
+    let baseline = collada_positions(0.0);
+    for (label, poison) in
+        [("NaN", f32::NAN), ("+Inf", f32::INFINITY), ("-Inf", f32::NEG_INFINITY)]
+    {
+        assert_eq!(
+            collada_positions(poison),
+            baseline,
+            "[{label}] a non-finite vertex changed the OTHER vertices in COLLADA"
+        );
+    }
+}
+
+/// Both directions: an all-finite mesh must still round-trip its exact coordinates.
+/// A guard that zeroed everything would pass every assertion above.
+#[test]
+fn finite_meshes_are_untouched() {
+    let positions = vec![-2.0f32, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.5, 0.0];
+    let normals = vec![0.0f32, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+    let indices = vec![0u32, 1, 2];
+    let (glb, stats) = export_glb_from_meshes(
+        &positions,
+        &normals,
+        &indices,
+        &[3],
+        &[3],
+        &[0.25, 0.5, 0.75, 1.0],
+        &[10.0, 20.0, 30.0],
+        &[7],
+        false,
+        true,
+        false,
+    );
+    assert_eq!(stats.vertices, 3);
+    let jlen = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+    let json = String::from_utf8_lossy(&glb[20..20 + jlen]).to_string();
+    // The exporter re-centres on the scene bbox, so assert the SPAN, which centring
+    // preserves: X runs from -2 to 3 (5 wide), Y from 0 to 4.5.
+    let bstart = 20 + jlen;
+    let blen = u32::from_le_bytes(glb[bstart..bstart + 4].try_into().unwrap()) as usize;
+    let bin = &glb[bstart + 8..bstart + 8 + blen];
+    let f: Vec<f32> = bin
+        .chunks_exact(4)
+        .take(9)
+        .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    assert!((f[3] - f[0] - 5.0).abs() < 1e-5, "X span lost: {f:?}");
+    assert!(f.iter().all(|v| v.is_finite()), "finite input went non-finite: {f:?}");
+    assert!(
+        json.contains("\"min\"") && json.contains("\"max\""),
+        "accessor bounds missing: {json}"
+    );
+    assert!(!json.contains("null"), "finite input produced a null: {json}");
+
+    let dae = export_collada_from_meshes(
+        &positions,
+        &normals,
+        &indices,
+        &[3],
+        &[3],
+        &[0.25, 0.5, 0.75, 1.0],
+        &[10.0, 20.0, 30.0],
+    );
+    let dae = String::from_utf8_lossy(&dae).to_string();
+    let line = dae
+        .lines()
+        .find(|l| l.contains("float_array") && l.contains("pos-arr"))
+        .expect("position float_array")
+        .to_string();
+    // Centred about the AABB midpoint, so the extremes are ±half-span, exactly.
+    assert!(line.contains("-2.5"), "expected the -2.5 X extreme: {line}");
+    assert!(line.contains("2.5"), "expected the 2.5 X extreme: {line}");
+}
+
+/// A non-finite colour component would serialise as `null` in `baseColorFactor`,
+/// which is as invalid as a `null` bound. Alpha must not be scrubbed to 0 — that
+/// would turn a colour defect into an invisible mesh.
+#[test]
+fn nonfinite_colours_do_not_reach_the_material() {
+    for poison in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        let (p, n, i) = tri(0.0);
+        let (glb, _) = export_glb_from_meshes(
+            &p,
+            &n,
+            &i,
+            &[3],
+            &[3],
+            &[poison, 0.5, 0.5, poison],
+            &[0.0, 0.0, 0.0],
+            &[1],
+            false,
+            true,
+            false,
+        );
+        let jlen = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        let json = String::from_utf8_lossy(&glb[20..20 + jlen]).to_string();
+        assert!(!json.contains("null"), "non-finite colour reached the JSON: {json}");
+        assert!(
+            json.contains("\"baseColorFactor\""),
+            "anti-vacuity: no material emitted: {json}"
+        );
+        assert!(
+            !json.contains("baseColorFactor\":[0.0,0.5,0.5,0.0]")
+                && !json.contains("baseColorFactor\":[0,0.5,0.5,0]"),
+            "alpha was scrubbed to 0, hiding the mesh: {json}"
+        );
+    }
+}
+
+/// A non-finite per-mesh `origin` (f64) is folded into every vertex of that mesh,
+/// so it poisons the mesh exactly like a bad position does.
+#[test]
+fn nonfinite_origin_does_not_reach_the_bytes() {
+    for poison in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let (p, n, i) = tri(0.0);
+        let (glb, stats) = export_glb_from_meshes(
+            &p,
+            &n,
+            &i,
+            &[3],
+            &[3],
+            &[0.8, 0.8, 0.8, 1.0],
+            &[poison, 0.0, 0.0],
+            &[1],
+            false,
+            true,
+            false,
+        );
+        assert_eq!(stats.vertices, 3, "anti-vacuity: mesh dropped");
+        let jlen = u32::from_le_bytes(glb[12..16].try_into().unwrap()) as usize;
+        let json = String::from_utf8_lossy(&glb[20..20 + jlen]).to_string();
+        assert!(!json.contains("null"), "non-finite origin reached the JSON: {json}");
+        let bstart = 20 + jlen;
+        let blen = u32::from_le_bytes(glb[bstart..bstart + 4].try_into().unwrap()) as usize;
+        let bin = &glb[bstart + 8..bstart + 8 + blen];
+        let f: Vec<f32> = bin
+            .chunks_exact(4)
+            .take(9)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect();
+        assert!(f.iter().all(|v| v.is_finite()), "non-finite origin reached BIN: {f:?}");
+    }
+}

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -173,7 +173,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/create-ifc-lite': '2641290854733608547',
   'packages/data': '7334937001846380278',
   'packages/diff': '935169126877539347',
-  'packages/drawing-2d': '1289794388881750973',
+  'packages/drawing-2d': '14332356246438147430',
   'packages/export': '8294779133777308773',
   'packages/extensions': '8156044843525017433',
   'packages/geometry': '11660269484074160622',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -223,7 +223,7 @@
    403 packages/drawing-2d/src/sheet/scale-stamp.ts
    599 packages/drawing-2d/src/sheet/title-block-renderer.ts
    489 packages/drawing-2d/src/styles.ts
-   613 packages/drawing-2d/src/svg-exporter.ts
+   537 packages/drawing-2d/src/svg-exporter.ts
    573 packages/drawing-2d/src/symbols/door-symbol.ts
    808 packages/drawing-2d/src/types.ts
    592 packages/export/src/effective-index.ts


### PR DESCRIPTION
Neither glTF nor COLLADA nor SVG has a lexical form for a non-finite number, and four writers wrote one anyway. Each row below was observed by running the writer, with `NaN`, `Infinity` and `-Infinity` fed separately — they did not fail alike.

| writer | numeric position | `NaN` | `Infinity` | `-Infinity` |
|---|---|---|---|---|
| `export_glb_from_meshes` | accessor `min`/`max` | `[-0.5,-0.5,0.0]` — **finite bounds over a NaN buffer** | `"min":[null,-0.5,0.0]` | `"min":[null,-0.5,0.0]` |
| `export_glb_from_meshes` | node `translation` | `[0.5,0.5,0.0]` | `[null,0.5,0.0]` | `[null,0.5,0.0]` |
| `export_glb_from_meshes` | BIN chunk float32 | `NaN` | `NaN` (scene centring: `inf + -inf`) | `NaN` |
| `export_glb_from_meshes` | `baseColorFactor` | `[null,0.5,0.5,null]` | `[null,…]` | `[null,…]` |
| `export_collada_from_meshes` / `export_kmz_collada_from_meshes` | `<float_array>` | `NaN 0 0 0.5 0 0 -0.5 0 1` | `NaN 0 0 -inf 0 0 -inf 0 1` | `NaN 0 0 inf 0 0 inf 0 1` |
| `exportToSVG` | `<line x1…>` and 12 more | `x1="NaN"` | `x1="Infinity"` | `x1="-Infinity"` |

Three things make this worse than "a bad number in a file":

- **glTF JSON has no non-finite number.** `serde_json` renders one as `null`, and `"min":[null,…]` is schema-invalid where the items are `number`. The GLB is rejected outright, not merely wrong.
- **A `NaN` position reached the BIN chunk with finite `min`/`max`,** because `NaN < min` and `NaN > max` are both false. The accessor's bounding box described a buffer it did not contain — the shape that passes a structural check while carrying a value nothing downstream can use.
- **One bad vertex cost the whole file.** COLLADA re-centres on the mesh AABB and SVG derives its paper offsets from `boundsCenter`, so a single non-finite input relocated every *other* coordinate in the document: the two good vertices of the test triangle came back as `inf`, and an SVG line that belonged at `x1="190.000"` was written as `x1="NaN"`.

## The fix

Both halves put the rule in one emitter rather than at each point a value becomes bytes.

**Rust.** The three exporters that take the viewer's flattened `MeshData` (`export_glb_from_meshes`, `export_collada_from_meshes`, and `export_kmz_collada_from_meshes` through the latter) pass all four float arrays — positions, normals, colours, per-mesh origins — through `mesh_input::scrub_nonfinite` before either per-mesh loop reads any of them. Non-finite becomes `0.0`, matching `usd::fmt::fmt_f32`, which already did this; alpha becomes `1.0`, because scrubbing it to `0` would trade a colour defect for an invisible mesh. An all-finite input is passed through borrowed — no copy, byte-identical output.

**TypeScript.** Every SVG number goes through one `svgNum()`, mirroring `DxfWriter.fmt()` in the same package, which has guarded exactly these values since it was written. Two writers of the same drawing disagreeing about the same input was the defect. Separately, `computeTransform` sanitises the bounds before deriving anything from them, so a degenerate corner no longer moves the rest of the drawing.

## Reachability

`exportGlbFromMeshes` / `exportKmzFromMeshes` are the viewer's export buttons; the buffers cross the wasm FFI from whatever produced the meshes, with no finiteness check at any layer between (`packages/geometry/src/index.ts` flattens them verbatim). The USD writer's existing guard documents the producer side in its own comment — "a non-finite slips past the gates only for derived values like the mid-vertex normal of a zero-area face".

## Verification

RED first: 7 of 8 new Rust assertions and 6 of 7 new SVG assertions failed on `main`, with the emitted bytes quoted in each failure. The both-directions test (a finite mesh keeps its exact coordinates) passed before and after, so it is not vacuously red.

Mutation checks, each restored by the inverse edit and proved byte-identical with `diff`:

- Rust, `scrub_f32`'s finiteness test disabled → exactly the 5 position/normal assertions fail; the colour and origin assertions still pass, isolating which arm broke.
- SVG, `Number.isFinite` → `isNaN` → the two `Infinity` assertions fail while the `NaN` one still passes. That is the failure mode this pattern is known for: `Number('Infinity')` is not `NaN`.
- SVG, bounds guard removed → all three "does not poison the other coordinates" assertions fail with `x1` at `0` instead of `190`.

`collada.rs`'s float formatting moves to `collada_fmt.rs` to stay under its module-size budget rather than raising it; the emitted text is unchanged.

Gates run: `cargo test -p ifc-lite-export` (all green), `cargo clippy -p ifc-lite-export --all-targets` (clean), `cargo test -p ifc-lite-processing --test module_size_ratchet`, `turbo run test typecheck --filter=@ifc-lite/drawing-2d` (518 tests), `turbo run test --filter=@ifc-lite/sdk` (188 tests). No published export changes name or signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid `NaN` and `Infinity` values from appearing in GLB, COLLADA, KMZ, and SVG exports.
  * Sanitized non-finite coordinates, bounds, colors, origins, and other numeric values while preserving valid data.
  * Improved SVG layout handling when bounds or padding contain invalid or oversized values.
* **Tests**
  * Added coverage confirming exported files remain valid and finite with malformed numeric inputs.
* **Documentation**
  * Added release notes for the export sanitization improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->