### PR TITLE
fix(lint): state skipComments on no-irregular-whitespace instead of inheriting it (#3290)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -33,7 +33,12 @@
     "no-import-assign": "error",
     "no-inner-declarations": "error",
     "no-invalid-regexp": "error",
-    "no-irregular-whitespace": "error",
+    // Stated, not inherited: oxlint <=1.78 defaulted skipComments to true and
+    // this repo relied on that; 1.79 reports four comment hits (#3290), each an
+    // invisible character the comment is DESCRIBING. Two of them are load-bearing:
+    // the ZWSP in `packages/*<ZWSP>/src/**.ts` is what stops the text reading `*/`
+    // and closing its own block comment early.
+    "no-irregular-whitespace": ["error", { "skipComments": true }],
     "no-new-native-nonconstructor": "error",
     "no-obj-calls": "error",
     "no-self-assign": "error",


### PR DESCRIPTION
Dependabot #3290 bumps oxlint 1.78 -> 1.79 and goes red on `Lint` with four `no-irregular-whitespace` errors, in a PR that changes no source. This is the config change that lets it through, and it is not "delete the weird characters".

## The bump changed a default

`.oxlintrc.json` set the rule to `"error"` and inherited `skipComments`. The schemas say what happened:

```
oxlint 1.78   NoIrregularWhitespaceConfig.skipComments   "default": true
oxlint 1.79   NoIrregularWhitespaceConfig.skipComments   "default": false
```

Stating the option restores the intended behaviour and stops the same four re-appearing on the next bump.

## Deleting the characters would break the repo

All four hits are invisible characters that a comment is DESCRIBING:

```
scripts/lib/vitest-timeout-audit.mjs:910,1070   U+200B  in `packages/*<ZWSP>/src/**.ts`
packages/parser/src/step-lexing.ts:260          U+00A0  in a comment about U+00A0
packages/cli/src/commands/export.csv-injection.test.ts:11   U+FEFF  (#1944)
```

Two are load-bearing. The ZWSPs sit between the `*` and the `/` of a glob written inside a `/** ... */` block, so following the rule's own help text ("Try to remove the irregular whitespace") makes the line read `packages/*/src/**.ts`, which contains `*/`, which closes the comment early. Measured at all four sites, because it is true at two and not the other two:

```
vitest-timeout-audit.mjs:910     strip U+200B -> line contains */:  true
vitest-timeout-audit.mjs:1070    strip U+200B -> line contains */:  true
step-lexing.ts:260               strip U+00A0 -> line contains */:  false
export.csv-injection.test.ts:11  strip U+FEFF -> line contains */:  false
```

Inline `oxlint-disable-next-line` is not an alternative here: a directive comment cannot nest inside the block comments these four sites live in.

## Verified both directions

```
1.79.0 before   exit 1, 4 no-irregular-whitespace errors
1.79.0 after    exit 0, 0 hits
control         a file with U+00A0 in CODE still errors at 1:8
1.78.0 after    exit 0  (config valid on both versions)
```

The control is the point: `skipComments` narrows the rule to comments, it does not disable it.

Review added three things I had not verified. The rule's other four skips (`skipStrings`, `skipTemplates`, `skipRegExps`, `skipJSXText`) all still default true and are unaffected by passing an explicit object, so string, template, regexp and JSX-text positions stay silent exactly as before. #3290's lockfile pins `1.79.0` precisely, so post-merge CI runs the version tested here. And the fix behaves identically on 1.42.0, 1.78.0, 1.79.0 and 1.80.0, so it is safe to land before or after the bump.

## Ordering

**This should land before #3290.** If the bump merges first, main's `Lint` lane goes red until this follows. Nothing in the code enforces that, and saying so in a comment is not a gate, which is exactly why this PR is version-independent: it is correct on the current 1.78 as well, so there is no window where landing it early hurts.

## Dismissed

Review noted that four sibling options are still inherited, the state this PR's title condemns. Dismissing deliberately: only `skipComments` changed across 1.78 -> 1.80 (verified by diffing every default in the three schemas), pinning the other four now would be speculative, and if one ever flips CI fails loudly rather than silently. That is the same signal that produced this fix.

No changeset: `.oxlintrc.json` is not a workspace member and nothing publishable changes. (`check-changesets` exiting 0 is not evidence for this, since it never requires a changeset to exist.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented comment-only whitespace, including intentional comment formatting, from causing CI failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->