### PR TITLE
fix(scripts): a merged PR scored GREEN, and a populated rollup did not mean the merge gate ran

### DIFF
--- a/scripts/lib/pr-green-sweep.mjs
+++ b/scripts/lib/pr-green-sweep.mjs
@@ -47,6 +47,13 @@ import { classifyReviewState } from './coderabbit-review-state.mjs';
 export const DEFAULT_REPO = 'LTplus-AG/ifc-lite';
 
 /**
+ * The `name:` of the workflow that IS the merge gate (`.github/workflows/test.yml:5`).
+ * Matched against each CheckRun's `workflowName` in the rollup, so it is the
+ * display name and not the file path.
+ */
+export const TEST_WORKFLOW_NAME = 'Test';
+
+/**
  * Severity ranks, worst-actionable first. `NOT_OURS` is deliberately the
  * LOWEST rank even though it takes precedence as a disqualifier: it is the one
  * verdict that is not a task, so it sorts to the bottom of the report while
@@ -60,6 +67,10 @@ export const SEVERITY = {
   UNREVIEWED: 60,
   PENDING: 20,
   GREEN: 10,
+  // Not a task, like NOT_OURS, and ranked separately from it ON PURPOSE: at a
+  // shared rank the two verdicts alias under `===`, so a test asserting
+  // NOT_OPEN would pass on a NOT_OURS row and pin nothing.
+  NOT_OPEN: 1,
   NOT_OURS: 0,
 };
 
@@ -71,7 +82,9 @@ export const SEVERITY = {
  *   headRepo: string,
  *   mergeable: string | null,
  *   mergeStateStatus: string | null,
+ *   state: string | null,
  *   runCount: number,
+ *   testLaneCount: number,
  *   newestRunSha: string | null,
  *   fail: number,
  *   pending: number,
@@ -101,6 +114,26 @@ export function isStaleRun(row) {
  * @returns {{ severity: number, reason: string } | null}
  */
 export function disqualify(row, repo = DEFAULT_REPO) {
+  // FIRST, ahead of even NOT_OURS: a PR that is not open is not a merge
+  // candidate, and every count below it describes history rather than a
+  // merge. Measured on the #3315 row shape: `mergeable:'UNKNOWN'` with 39
+  // passing runs disqualifies to `null` and scores SEVERITY.GREEN, because
+  // `mergeable` reads UNKNOWN on a MERGED PR exactly as it does on one GitHub
+  // has not finished computing. Today only `--state open` at the call site
+  // keeps that row out of the report, which is the filter any `--pr N` entry
+  // point would bypass.
+  if (typeof row.state !== 'string' || row.state === '') {
+    // ABSENCE IS NOT OPENNESS. A truthiness guard here (`row.state && ...`)
+    // scores a row with no state GREEN, which is the fail-open this branch
+    // exists to close, one level up: the producer always sets the field, so the
+    // caller that arrives without it is the hand-built one this branch was
+    // written for. Same bucket as an unreadable run count -- unknown is not
+    // green.
+    return { severity: SEVERITY.NO_RUNS, reason: 'state is missing - cannot show this PR is open' };
+  }
+  if (row.state.toUpperCase() !== 'OPEN') {
+    return { severity: SEVERITY.NOT_OPEN, reason: `state=${row.state} - not an open merge candidate` };
+  }
   if (row.headRepo !== repo) {
     return { severity: SEVERITY.NOT_OURS, reason: `not ours (head repo ${row.headRepo})` };
   }
@@ -118,6 +151,26 @@ export function disqualify(row, repo = DEFAULT_REPO) {
     return {
       severity: SEVERITY.NO_RUNS,
       reason: 'zero workflow runs at head - an empty rollup, not a passing one',
+    };
+  }
+  // `runCount` counts ANY workflow at the head, and the merge gate is one
+  // specific workflow. Measured on #3315 at 66c8886b: five runs present
+  // (ifcopenshell-parity x2, python-wheels, server-binaries, xmatch-fixture)
+  // and test.yml among them ZERO times, so `runCount > 0` was true over a head
+  // the test suite never examined. That is the #3294 shape wearing a non-zero
+  // count.
+  if (typeof row.testLaneCount !== 'number') {
+    // `undefined === 0` is false, so an absent count sailed straight past the
+    // branch below while the production path went dead. Measured: deleting
+    // `testLaneCount` from the row constructor left 29 of 29 green. The sibling
+    // `state` field had the identical hole and was fixed one field at a time
+    // instead of as a class, which is how this one survived.
+    return { severity: SEVERITY.NO_RUNS, reason: 'Test-lane count could not be read' };
+  }
+  if (row.testLaneCount === 0) {
+    return {
+      severity: SEVERITY.NO_RUNS,
+      reason: 'no lane from the Test workflow at this head - the other workflows are not the merge gate',
     };
   }
   if (isStaleRun(row)) {
@@ -248,7 +301,7 @@ export function sweepPullRequests({ gh, repo = DEFAULT_REPO, author = '@me', onP
     [
       'pr', 'list', '--repo', repo, '--author', author, '--state', 'open', '--limit', '200',
       '--json',
-      'number,headRefName,headRefOid,mergeable,mergeStateStatus,isDraft,headRepository,headRepositoryOwner,statusCheckRollup',
+      'number,state,headRefName,headRefOid,mergeable,mergeStateStatus,isDraft,headRepository,headRepositoryOwner,statusCheckRollup',
     ],
     'pull-request list',
   );
@@ -291,6 +344,18 @@ export function sweepPullRequests({ gh, repo = DEFAULT_REPO, author = '@me', onP
       );
     }
     const runCount = runsAtHead.total_count;
+    // How many lanes the MERGE GATE's own workflow published at this head. Read
+    // out of the rollup `gh pr list` already returned rather than bought with a
+    // second API call per PR: every CheckRun in it carries `workflowName`, and
+    // test.yml is `name: Test` (test.yml:5).
+    //
+    // Coupled to the workflow's DISPLAY NAME. A rename makes this 0 and reports
+    // "never fired" on a head where it did, which is a false alarm rather than a
+    // false green, so it fails in the safe direction. StatusContext entries (the
+    // Vercel and bot rows) carry no workflowName and are simply not Test lanes.
+    const testLaneCount = (pr.statusCheckRollup ?? []).filter(
+      (c) => c?.workflowName === TEST_WORKFLOW_NAME,
+    ).length;
 
     const runsOnBranch = call(
       gh,
@@ -351,6 +416,12 @@ export function sweepPullRequests({ gh, repo = DEFAULT_REPO, author = '@me', onP
       mergeable: pr.mergeable ?? null,
       mergeStateStatus: pr.mergeStateStatus ?? null,
       runCount,
+      testLaneCount,
+      // Fetched AND carried. Adding `state` to the --json list without copying
+      // it here left the NOT_OPEN branch reachable only from hand-built test
+      // fixtures, which is the shape where a fix is inert exactly where it is
+      // needed and the tests still go green.
+      state: pr.state ?? null,
       newestRunSha,
       fail,
       pending,
@@ -392,6 +463,10 @@ export function formatSweep(rows, repo = DEFAULT_REPO) {
 export function actionable(rows, repo = DEFAULT_REPO) {
   return rows.filter((row) => {
     const bad = disqualify(row, repo);
-    return bad !== null && bad.severity !== SEVERITY.NOT_OURS;
+    // NOT_OPEN joins NOT_OURS as a verdict that is not a TASK: a merged or
+    // closed PR needs nothing done to it. Both still suppress every other
+    // column's claim about the row, which is why they disqualify rather than
+    // being filtered earlier.
+    return bad !== null && bad.severity !== SEVERITY.NOT_OURS && bad.severity !== SEVERITY.NOT_OPEN;
   });
 }

--- a/scripts/lib/pr-green-sweep.test.mjs
+++ b/scripts/lib/pr-green-sweep.test.mjs
@@ -25,6 +25,12 @@ const green = (overrides = {}) => ({
   branch: 'fix/example',
   head: HEAD,
   headRepo: DEFAULT_REPO,
+  // Both mirror fields sweepPullRequests populates -- verified against the row
+  // constructor, not assumed: an earlier draft added `state` to the --json list
+  // and never copied it onto the row, so the branch reading it was reachable
+  // only from fixtures like this one while being dead in production.
+  state: 'OPEN',
+  testLaneCount: 4,
   mergeable: 'MERGEABLE',
   mergeStateStatus: 'CLEAN',
   runCount: 4,
@@ -198,13 +204,21 @@ function stubGh(table) {
 const onePr = JSON.stringify([
   {
     number: 42,
+    state: 'OPEN',
     headRefName: 'fix/example',
     headRefOid: HEAD,
     mergeable: 'MERGEABLE',
     mergeStateStatus: 'CLEAN',
     headRepository: { name: 'ifc-lite' },
     headRepositoryOwner: { login: 'LTplus-AG' },
-    statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+    // A rollup entry now has to say WHICH workflow published it. This fixture
+    // carried a bare {status, conclusion} and the sweep read it as healthy,
+    // which is the state the Test-lane branch exists to refuse: a populated
+    // rollup with nothing from the merge gate in it.
+    statusCheckRollup: [
+      { __typename: 'CheckRun', workflowName: 'Test', name: 'Typecheck', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { __typename: 'StatusContext', context: 'Vercel', state: 'SUCCESS' },
+    ],
   },
 ]);
 
@@ -330,4 +344,87 @@ test('the sweep reports a stale run and a DIRTY base from real response shapes',
   // DIRTY outranks both, so that is the reason reported.
   assert.equal(disqualify(rows[0])?.severity, SEVERITY.DIRTY);
   assert.equal(actionable(rows).length, 1);
+});
+
+test('a MERGED pull request is never green, whatever its counts say', () => {
+  // The #3315 row shape, measured on origin/main before this branch existed:
+  // disqualify() returned null and severityOf() returned SEVERITY.GREEN over a
+  // pull request that was already merged. `mergeable` reads UNKNOWN on a MERGED
+  // PR exactly as it does on one GitHub has not finished computing, so nothing
+  // below this branch can tell the two apart. Only `--state open` at the call
+  // site was keeping it out of the report.
+  const row = green({
+    number: 3315,
+    state: 'MERGED',
+    mergeable: 'UNKNOWN',
+    mergeStateStatus: 'UNKNOWN',
+    runCount: 39,
+    pass: 39,
+  });
+  assert.equal(disqualify(row)?.severity, SEVERITY.NOT_OPEN);
+  assert.notEqual(SEVERITY.NOT_OPEN, SEVERITY.NOT_OURS, 'ranks must differ or this assertion pins nothing');
+  assert.match(disqualify(row).reason, /not an open merge candidate/);
+  assert.equal(actionable([row]).length, 0, 'a merged PR is not a task');
+});
+
+test('a CLOSED, unmerged pull request is disqualified the same way', () => {
+  const row = green({ state: 'CLOSED' });
+  assert.equal(disqualify(row)?.severity, SEVERITY.NOT_OPEN);
+  assert.match(disqualify(row).reason, /not an open merge candidate/);
+  assert.equal(actionable([row]).length, 0);
+});
+
+test('runs at the head do not mean the TEST workflow ran', () => {
+  // Measured on #3315 at 66c8886b: five workflow runs present
+  // (ifcopenshell-parity x2, python-wheels, server-binaries, xmatch-fixture)
+  // and test.yml among them zero times. `runCount > 0` was true over a head the
+  // test suite never examined, which is the #3294 shape with a non-zero count.
+  const bad = disqualify(green({ runCount: 5, testLaneCount: 0 }));
+  assert.ok(bad);
+  assert.equal(bad.severity, SEVERITY.NO_RUNS);
+  assert.match(bad.reason, /no lane from the Test workflow/);
+});
+
+test('the test-workflow branch can also NOT fire', () => {
+  // Anti-vacuity twin of the row above: same low runCount, but test.yml did
+  // run. Without this, a branch that disqualified unconditionally would pass
+  // the case above and nothing would notice.
+  assert.equal(disqualify(green({ runCount: 5, testLaneCount: 1 })), null);
+});
+
+test('the sweep CARRIES state onto the row, so NOT_OPEN is live in production', () => {
+  // The unit cases above build rows by hand, so every one of them passes with
+  // the row constructor dropping `state` entirely -- measured: removing
+  // `state: pr.state ?? null` leaves 28 of 28 green. That is how the first
+  // draft of this branch shipped inert, reachable only from fixtures. This
+  // case drives the real producer instead.
+  const merged = JSON.parse(onePr);
+  merged[0].state = 'MERGED';
+  const gh = stubGh([
+    ['pr list', JSON.stringify(merged)],
+    [`head_sha=${HEAD}`, '{"total_count":3}'],
+    ['branch=', `{"workflow_runs":[{"head_sha":"${HEAD}"}]}`],
+    ['graphql', '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'],
+    ['issues/', '[]'],
+  ]);
+  const rows = sweepPullRequests({ gh });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].state, 'MERGED', 'the row must carry state, not drop it');
+  assert.equal(disqualify(rows[0])?.severity, SEVERITY.NOT_OPEN);
+  // Its sibling, pinned in the same place for the same reason: the first draft
+  // fixed `state` carriage alone and left this field able to go missing with
+  // every test still green.
+  assert.equal(typeof rows[0].testLaneCount, 'number', 'the row must carry testLaneCount too');
+});
+
+test('a row missing either field is not green', () => {
+  // Both are "unknown", and unknown is not green. A truthiness guard on state
+  // and an `=== 0` on the count both let absence through, which is the fail-open
+  // these two branches exist to close.
+  const { state: _s, ...noState } = green();
+  assert.equal(disqualify(noState)?.severity, SEVERITY.NO_RUNS);
+  assert.match(disqualify(noState).reason, /state is missing/);
+  const { testLaneCount: _t, ...noCount } = green();
+  assert.equal(disqualify(noCount)?.severity, SEVERITY.NO_RUNS);
+  assert.match(disqualify(noCount).reason, /Test-lane count could not be read/);
 });


### PR DESCRIPTION
Two ways the PR-green sweep said "nothing wrong with this PR" about a pull request nobody should merge. Both measured against the real exported function on `main`, not reasoned about:

```
disqualify(mergedShapedRow)  ->  null
severityOf(mergedShapedRow)  ->  10   (SEVERITY.GREEN)
```

## 1. A PR that is not open scored GREEN

`mergeable` reads `UNKNOWN` on a MERGED pull request exactly as it does on one GitHub has not finished computing, so nothing below could separate them. Live, on #3315:

```
{"state":"MERGED","mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN"}
```

That row arrived with 39 passing runs and disqualified to `null`. The only thing keeping it out of the report is `--state open` at the call site, which is the filter any `--pr N` entry point would bypass. `state` is now the first disqualifier: once a PR is merged or closed, every count below it describes history rather than a merge.

## 2. A populated rollup did not mean the merge gate ran

Measured on #3315 at `66c8886b`: five workflow runs at the head, and `test.yml` among them zero times.

```
ifcopenshell-parity.yml  x2
python-wheels.yml         1
server-binaries.yml       1
xmatch-fixture.yml        1
test.yml                  0
```

That is the #3294 shape wearing a non-zero count. The sweep now counts lanes whose `workflowName` is the merge gate's, read out of the `statusCheckRollup` that `gh pr list` already returns.

**Confirmed on live data, not only fixtures:** #3327 is an open PR of ours, CLEAN and MERGEABLE, whose only run at the head is the parity workflow, carrying zero Test lanes. The old code scored it green.

## What review changed, and the part worth reading

The first draft bought fact 2 with a second `gh api` call per PR (+36 on a 36-PR sweep) for something already in hand, and gave `NOT_OPEN` the same numeric rank as `NOT_OURS`, which made both the new `actionable()` clause and the tests' severity assertions unable to discriminate.

Then the two that matter, and they are the same bug twice:

- `state` was added to the `--json` list and **never copied onto the row**, so branch 1 was reachable only from hand-built fixtures and dead in production, while the fixture comment claimed the opposite. Fetched-and-discarded is worse than not fetched: it reads as done.
- That was fixed for `state` and pinned with an integration case. Its sibling `testLaneCount` had the identical hole one line below and was left there, because the fix was applied to the instance rather than the class. `undefined === 0` is false, so an absent count sails past.

```
baseline                         30 pass,  0 fail
producer drops `state`           27 pass,  3 fail
producer drops `testLaneCount`   28 pass,  2 fail
state-absence guard removed      29 pass,  1 fail
count-absence guard removed      29 pass,  1 fail
```

Before the integration cases, dropping either field left every test green: the unit cases build rows by hand, so not one of them could tell whether the producer populates the field they read. A guard that cannot catch its own regression is the defect it is guarding against.

## Scope

No new script. This is the lib the sweep already uses, covered by `scripts/lib/*.test.mjs` in `test.yml`. A standalone `scripts/merge-decide.sh` was the original plan and was dropped: `.sh` is invisible to the repo's gate-name checks, so it would have been the one gate in the tree the anti-vacuity gate structurally cannot see.

Coupled to the workflow's display name (`test.yml:5` is `name: Test`), pinned in one exported constant. A rename makes the count 0 and reports "never fired" on a head where it did, which is a false alarm rather than a false green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request sweep accuracy by excluding merged, closed, or unavailable pull requests.
  * Pull requests are no longer considered actionable when required test checks or merge-gate results are missing.
  * Fork-owned pull requests continue to be excluded from actionable results.
  * Added clearer prioritization for pull requests that are not open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->