### PR TITLE
test(ids): one oracle for one function, not two copies of one regex (#3224)

### DIFF
--- a/packages/ids/src/constraints/numeric-literal.test.ts
+++ b/packages/ids/src/constraints/numeric-literal.test.ts
@@ -33,6 +33,12 @@ import type { IDSDocument } from '../types.js';
  * table is written by whoever changed the implementation and shares their
  * blind spot, whereas the regex is a separate mechanism deciding the same
  * language, run over a generated corpus instead of a list anyone chose.
+ *
+ * One constant for both sweeps below because there is one function beneath
+ * them: `isStrictNumericLiteral` and the `xs:double` arm of `xsd-cast.ts` both
+ * `return isWhollyNumeric(value)` from `@ifc-lite/encoding`. A second copy of
+ * this regex to pin the cast would be a copy to keep in sync, not a second
+ * opinion.
  */
 const SPEC_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
 
@@ -361,12 +367,9 @@ function isStrictNumericLiteralBacktracking(v: string): boolean {
  */
 describe('the same shape elsewhere in @ifc-lite/ids', () => {
   describe('xs:double strict cast (constraints/xsd-cast.ts)', () => {
-    /** The `DOUBLE_RE` that `literalCastsUnder` used to test against. */
-    const DOUBLE_RE = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
-
-    it('accepts exactly the language DOUBLE_RE did', () => {
+    it('agrees with the spec regex, so the cast and the comparator accept one language', () => {
       const disagree = corpus()
-        .filter((v) => DOUBLE_RE.test(v) !== literalCastsUnder(v, 'xs:double'))
+        .filter((v) => SPEC_RE.test(v) !== literalCastsUnder(v, 'xs:double'))
         .map((v) => JSON.stringify(v));
       expect(disagree).toEqual([]);
     });
@@ -380,7 +383,7 @@ describe('the same shape elsewhere in @ifc-lite/ids', () => {
     });
 
     it('decides every size up to 2.56M characters inside the budget', { timeout: 60_000 }, () => {
-      // ~440ms with DOUBLE_RE at 20k, measured before the change. This used to
+      // ~440ms with the spec regex at 20k, measured before the change. This used to
       // be a single 20k reading against a 100ms bound, which is the construct
       // the ladder above exists to replace: one reading has no retry, so a
       // single descheduling reds it. Measured under 187-process load, 24 of


### PR DESCRIPTION
#3224's main ask landed in #3302. This is the leftover it listed: `SPEC_RE` and `DOUBLE_RE` were the same regex written out twice, byte for byte.

They were not two opinions. `isStrictNumericLiteral` and the `xs:double` arm of `xsd-cast.ts` both `return isWhollyNumeric(value)` — one function in `@ifc-lite/encoding` — so the two copies pinned one thing while looking like independent oracles. The duplicate is deleted and the xs:double sweep points at the survivor.

**Behaviour-neutral, and the count says so:** 45 tests before, 45 after, no assertion changed.

## Scope changed since this opened

An earlier draft also added a row asserting what `xs:double` does with `NaN`, `INF`, `+INF`, `-INF` and `Infinity`. CodeRabbit flagged that those literals are in the XSD lexical space, which sent me to check what this package is written against.

It turned out not to be XSD, and not to be `TryParse` as the file's own docblock claimed: `packages/ids` mirrors buildingSMART's IDS-Audit-tool, which generates its validator as a regex accepting `NaN`, `+INF` and `-INF` while rejecting bare `INF` and `Infinity`. Our coherence audit already carried that pattern verbatim; the cast rejected all five. That is a behaviour defect, not a test-framing question, so it moved to **#3336** with the fix and its own tests.

This PR is the dedup alone.

## Not done here

`packages/encoding/src/numeric-literal.test.ts:24` holds a similar regex, but it uses non-capturing groups, is not byte-identical, and pins `isWhollyNumeric` directly rather than through a caller. Folding it in would couple two packages to make a cosmetic point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage and documentation for numeric literal validation.
  - Standardized test expectations for comparator handling and double-value conversions.
  - Clarified timing-test context and removed redundant validation scenarios.
  - No user-facing behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->