### PR TITLE
fix(ids): xs:double rejected NaN/+INF/-INF, which upstream accepts (#3336)

### DIFF
--- a/.changeset/xsd-double-specials-upstream-parity.md
+++ b/.changeset/xsd-double-specials-upstream-parity.md
@@ -1,0 +1,39 @@
+---
+'@ifc-lite/ids': patch
+---
+
+`xs:double` now accepts the special literals upstream IDS-Audit-tool accepts.
+
+`literalCastsUnder(value, 'xs:double')` rejected `NaN`, `+INF` and `-INF`, which
+upstream accepts.
+
+The coherence audit was NOT the counterexample this change was first written
+against. Its table carries upstream's pattern, but `isValidLexicalForXsType`
+vetoes any value with no digit before that pattern runs, and none of the three
+specials has a digit. So both sites reject the three specials and agree with each other there, while
+both diverge from upstream.
+
+They do NOT agree everywhere, and the first draft of this changeset said they
+did. Measured: upstream also accepts an exponent-only family (`e5`, `+e5`,
+`.e5`), and the audit's digit veto is SATISFIED by the digit in the exponent, so
+the audit accepts those while the cast rejects them. That split predates this
+change. The audit follow-up has to reconcile both classes, not just the
+specials.
+
+This fixes the cast.
+
+Upstream is the contract here, and it is neither .NET nor XSD. It generates the
+validator as a regex, `^([-+]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?|NaN|\+INF|-INF)$`,
+which takes `+INF` (an XSD 1.1 spelling) while rejecting bare `INF` (the 1.0
+one), and rejects `Infinity` (the .NET one). The coherence table already carried
+that pattern verbatim, behind a veto that suppresses it for these inputs.
+
+A family of deviations is kept and documented at the call site: every part of upstream's
+pattern is optional, so it also matches `""`, `"+"`, `"."`, `"-"`, `"+."` and
+the exponent-only forms. Those fall out of how the regex is written rather than
+being a decision, and accepting an empty string as a double turns a malformed
+IDS literal into a passing constraint. The cast keeps rejecting them. The test
+pins representatives rather than the whole family, and says so.
+
+The docblock claiming these arms mirror `int.TryParse` / `double.TryParse` was
+wrong and is corrected: upstream does not use `TryParse` for this.

--- a/packages/ids/src/constraints/numeric-literal.test.ts
+++ b/packages/ids/src/constraints/numeric-literal.test.ts
@@ -367,7 +367,13 @@ function isStrictNumericLiteralBacktracking(v: string): boolean {
  */
 describe('the same shape elsewhere in @ifc-lite/ids', () => {
   describe('xs:double strict cast (constraints/xsd-cast.ts)', () => {
-    it('agrees with the spec regex, so the cast and the comparator accept one language', () => {
+    it('agrees with the spec regex across the FINITE language this corpus covers', () => {
+      // Scoped to FINITE deliberately. Since #3336 the cast also accepts `NaN`,
+      // `+INF` and `-INF`, which SPEC_RE does not, so the two no longer decide
+      // one language outright. This sweep stays true because corpus() is built
+      // from an alphabet with no letters, so it cannot reach those three; the
+      // title says so rather than letting a structural gap read as equality.
+      // The specials themselves are pinned in xsd-cast-specials.test.ts.
       const disagree = corpus()
         .filter((v) => SPEC_RE.test(v) !== literalCastsUnder(v, 'xs:double'))
         .map((v) => JSON.stringify(v));

--- a/packages/ids/src/constraints/xsd-cast-specials.test.ts
+++ b/packages/ids/src/constraints/xsd-cast-specials.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * What `xs:double` accepts, against upstream IDS-Audit-tool (#3336).
+ *
+ * The contract is PARITY WITH UPSTREAM, not XSD. Upstream generates its
+ * validator as a regex (`ids-lib.codegen/XmlSchema_XsTypesGenerator.cs`):
+ *
+ *     ^([-+]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?|NaN|\+INF|-INF)$
+ *
+ * which is neither .NET nor XSD: it takes `+INF` (an XSD 1.1 spelling) while
+ * rejecting bare `INF` (the 1.0 one), and rejects `Infinity` (the .NET one).
+ * Each row below is that pattern's verdict, and each is asserted separately so
+ * a failure names the literal rather than a set.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { literalCastsUnder } from './xsd-cast.js';
+
+/** Upstream's own pattern, transcribed, as the oracle for the rows below. */
+const UPSTREAM_DOUBLE_RE = /^([-+]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?|NaN|\+INF|-INF)$/;
+
+describe('xs:double specials, matching upstream (#3336)', () => {
+  it.each(['NaN', '+INF', '-INF'])('accepts %j, which upstream accepts', (v) => {
+    expect(UPSTREAM_DOUBLE_RE.test(v)).toBe(true);
+    expect(literalCastsUnder(v, 'xs:double')).toBe(true);
+  });
+
+  it.each(['INF', 'Infinity'])('rejects %j, which upstream also rejects', (v) => {
+    // `INF` is XSD 1.0 and `Infinity` is .NET. Upstream takes neither, and the
+    // reason it takes `+INF` but not `INF` is that its pattern spells the
+    // alternative `\+INF` rather than `\+?INF`.
+    expect(UPSTREAM_DOUBLE_RE.test(v)).toBe(false);
+    expect(literalCastsUnder(v, 'xs:double')).toBe(false);
+  });
+
+  it.each(['', '+', '.', '-', '+.', '-.', 'e5', 'E5', '+e5', '.e5'])(
+    'rejects %j, a REPRESENTATIVE of the family we deviate from upstream on',
+    (v) => {
+      // Every part of upstream's pattern is optional, so it matches these. That
+      // falls out of how the regex is written rather than being a decision, and
+      // accepting an empty string as a double turns a malformed IDS literal
+      // into a passing constraint. Asserting BOTH halves so the deviation stays
+      // visible: if upstream ever tightens this, the first line fails and the
+      // comment stops being true.
+      //
+      // REPRESENTATIVES, not the whole family. The exponent-only rows are here
+      // because they are also a live disagreement with our own coherence audit,
+      // which ACCEPTS them: its digit veto (audit/coherence/index.ts:461) is
+      // satisfied by the digit in the exponent. That split predates this change
+      // and is part of what the audit follow-up has to reconcile.
+      expect(UPSTREAM_DOUBLE_RE.test(v)).toBe(true);
+      expect(literalCastsUnder(v, 'xs:double')).toBe(false);
+    },
+  );
+
+  it('still decides ordinary numbers the same way', () => {
+    for (const v of ['1', '1.5', '-2e3', '+0.0']) {
+      expect(literalCastsUnder(v, 'xs:double')).toBe(true);
+    }
+    for (const v of ['abc', '1.2.3', '1e', '12,0']) {
+      expect(literalCastsUnder(v, 'xs:double')).toBe(false);
+    }
+  });
+
+  it('leaves xs:integer alone', () => {
+    // The specials belong to the floating types. An integer slot must not start
+    // taking them just because the double arm does.
+    for (const v of ['NaN', '+INF', '-INF']) {
+      expect(literalCastsUnder(v, 'xs:integer')).toBe(false);
+    }
+    expect(literalCastsUnder('42', 'xs:integer')).toBe(true);
+  });
+});

--- a/packages/ids/src/constraints/xsd-cast.ts
+++ b/packages/ids/src/constraints/xsd-cast.ts
@@ -5,14 +5,31 @@
 /**
  * XSD strict-cast helpers shared by the attribute and property facets.
  *
- * Mirrors the `int.TryParse` / `double.TryParse` / `DateTime.TryParse`
- * rules upstream `IDS-Audit-tool` applies before doing the value
- * comparison. An IDS literal must cast successfully under at least one
+ * Mirrors what upstream `IDS-Audit-tool` accepts before doing the value
+ * comparison.
+ *
+ * NOT `TryParse`, which this said until #3336: upstream decides these with
+ * GENERATED REGEXES (`ids-lib.codegen/XmlSchema_XsTypesGenerator.cs`), and its
+ * xs:double pattern is neither .NET nor XSD. It takes `+INF` (an XSD 1.1
+ * spelling) while rejecting bare `INF` (the 1.0 one), and rejects `Infinity`
+ * (the .NET one). Parity with upstream is the contract, so that is what these
+ * arms implement. An IDS literal must cast successfully under at least one
  * of the slot's declared XSD types — `xs:integer` rejects `42.0`,
  * `xs:double` accepts either, etc.
  */
 
 import { isWhollyNumeric } from '@ifc-lite/encoding';
+
+/**
+ * The specials upstream's xs:double pattern accepts, spelled exactly as it
+ * spells them:
+ *
+ *     ^([-+]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?|NaN|\+INF|-INF)$
+ *
+ * Bare `INF` is absent because that pattern has `\+INF`, not `\+?INF`; and
+ * `Infinity` because it appears in neither upstream nor XSD.
+ */
+export const XSD_NUMERIC_SPECIALS = new Set(['NaN', '+INF', '-INF']);
 
 const INTEGER_RE = /^[+-]?\d+$/;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}(Z|[+-]\d{2}:\d{2})?$/;
@@ -40,12 +57,21 @@ export function literalCastsUnder(value: string, xsdType: string): boolean {
     case 'xs:integer':
       return INTEGER_RE.test(value);
     case 'xs:double':
-      // Same language the local `DOUBLE_RE` decided, via the shared
-      // linear scan. That regex was
-      // `/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/` — the #3113 shape,
-      // quadratic on a failing match — and an IDS literal is as
+      // The finite part goes through the shared linear scan, not a regex: the
+      // natural pattern `/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/` is the
+      // #3113 shape, quadratic on a failing match, and an IDS literal is as
       // untrusted as the file it came out of.
-      return isWhollyNumeric(value);
+      //
+      // Deliberate deviation from upstream (#3336). Every part of upstream's
+      // pattern is optional, so it accepts a family of digitless and
+      // mantissa-less forms that are not numbers: "", "+", ".", "-", "+.",
+      // "-.", and the exponent-only class "e5" / "+e5" / ".e5". Those fall out
+      // of how the regex is written rather than being a contract, and an empty
+      // string is not a double, so the finite scan keeps rejecting them.
+      //
+      // NOT an exhaustive list -- the family is larger than the rows pinned in
+      // xsd-cast-specials.test.ts, which are representatives.
+      return isWhollyNumeric(value) || XSD_NUMERIC_SPECIALS.has(value);
     case 'xs:boolean':
       return value === 'true' || value === 'false';
     case 'xs:date':


### PR DESCRIPTION
`literalCastsUnder(value, 'xs:double')` rejected `NaN`, `+INF` and `-INF`, which upstream IDS-Audit-tool accepts.

## The contract is upstream, and it is neither .NET nor XSD

Both obvious targets are wrong, which is why this was measured rather than reasoned about. Upstream generates its validator as a regex (`ids-lib.codegen/XmlSchema_XsTypesGenerator.cs` → `XsTypes.g.cs`):

```
^([-+]?[0-9]*\.?[0-9]*([eE][-+]?[0-9]+)?|NaN|\+INF|-INF)$
```

It takes `+INF`, an XSD 1.1 spelling, while rejecting bare `INF`, the XSD 1.0 one, because the alternative is spelled `\+INF` and not `\+?INF`. It rejects `Infinity`, the .NET one. Upstream's `IsValid` applies that regex bare, with no veto, so it really is the decision procedure and not just a table.

## Correcting the premise this was filed under

#3336 claimed the coherence audit **accepted** these while the cast rejected them — that the package contradicted itself. It did not. `isValidLexicalForXsType` (`audit/coherence/index.ts:461`) vetoes any value containing no digit before the pattern is reached, and none of the three specials has a digit. Both sites rejected them. The contradiction was mine, and it survived a filed issue and two drafts of this commit before review ran the audit.

## And the corrected premise was itself incomplete

The first draft then said the two sites "agreed with each other". True of the specials, false in general. Measured:

```
input     upstream   cast(new)  audit
""        accept     reject     reject
"+" "." "-" "+." "-."  accept   reject     reject
"e5" "E5" "+e5" ".e5"  accept   reject     ACCEPT   <- live cast/audit split
"NaN" "+INF" "-INF"    accept   accept     reject
"1.5"     accept     accept     accept
```

The audit's digit veto is **satisfied by the digit in the exponent**, so it accepts the exponent-only family while the cast rejects it. That split predates this change. The follow-up has to reconcile two classes, not one.

## What lands here

The cast accepts the three specials. `XSD_NUMERIC_SPECIALS` is exported so the audit follow-up imports the list rather than copying it — the veto becomes `!/[0-9]/.test(value) && !XSD_NUMERIC_SPECIALS.has(value)`.

The deviation family stays rejected: an empty string is not a double, and accepting it turns a malformed IDS literal into a passing constraint. The audit's veto exists for exactly that reason — its comment says an empty lexeme "isn't a meaningful number" — and catches the specials as collateral.

The test pins **representatives and says so**, rather than calling four rows "the full table" as the first draft did.

## Blast radius, traced

Both callers gate only `simpleValue` (`attribute-facet.ts:153`, `property-facet.ts:81`). On pass, the literal reaches `matchSimpleValue`, where `compareNumeric` is unreachable for the specials: `isCoercibleSimpleValue` requires `isStrictNumericLiteral` (false for all three) and `compareNumeric` double-guards with `isWhollyNumeric` plus a `Number.isNaN` bail. So no `parseFloat`, no bounds check, no NaN-comparison semantics. Behaviour change is: a `NaN`/`+INF`/`-INF` facet value goes from auto-failing every entity to string-matching, which is strictly closer to upstream.

The finite scan is unchanged and stays shared with `comparators.ts`: model value comparison must not start treating `NaN` as a number.

## Verification

```
baseline                                    17 passed
specials removed                             3 failed
full upstream parity (degenerate forms in)   4 failed
bare INF added to the set                    1 failed
```

Upstream's 334-case corpus green (339 assertions); ids constraints suite 130 passing. One pre-existing file-level failure is unrelated and identical on main (`xmllint-wasm` not installed in this checkout).

Also scopes a parity test this change falsifies: `numeric-literal.test.ts` claimed the cast and the comparator accept one language, which stops being true once the cast takes `NaN`. It stays green only because `corpus()` has no letters in its alphabet, so the title now says FINITE rather than letting a structural gap read as equality.

Also corrects the file docblock, which claimed these arms mirror `int.TryParse` / `double.TryParse`. Upstream does not use `TryParse` for this.
