### PR TITLE
fix(geometry): only extend an opening cap the cutter actually exits through (#3219)

### DIFF
--- a/.changeset/exit-cap-orientation-precut-host.md
+++ b/.changeset/exit-cap-orientation-precut-host.md
@@ -1,0 +1,17 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+Stop widening every window when the authoring tool already cut the hole into the wall.
+
+`extend_opening_mesh_through_host` pushes an opening cutter's cap past a coincident host facet so a flush interface becomes a clean transversal crossing rather than a coplanar graze (issue #1007, host #1112). It qualified a cap on coincidence alone. On a host whose Brep already carries the hole — an Archicad wall exported with "Material Preservation: Explode where necessary", where the wall body lives on aggregated `IfcBuildingElementPart` layers and every layer's Brep has its own window — the cutter's side planes coincide with the hole's jambs, so both jambs read as caps and each was pushed 30% of the opening's span into the pier beside it. Every window came out scaled by exactly 1.600 with its centre unmoved, and the piers between them were eaten; on issue #3219's model that removed 19% to 27% of each wall layer that no authored opening ever occupied.
+
+Coincidence is now necessary but not sufficient. A cap also has to be one the opening EXITS through, decided by the area-weighted orientation of the coincident facets under the cutter's cross-section footprint: with outward winding an exit facet faces away from the host material, while a jamb faces into the hole because the host continues past it. Area weighting keeps facet scatter and stray slivers from outvoting the real surface, and the footprint restriction keeps a large coplanar facet elsewhere on a multi-body host from doing the same. Caps that genuinely exit keep the identical push, so the clearance #1007 depends on is unchanged.
+
+Orientation is read from the host's own signed volume rather than assumed. IFC winding is not reliably outward, and the host reaching this code has not been oriented yet, so an inward-wound body would otherwise lose the clearance push AND get the pier-widening back. A host whose winding is genuinely MIXED can still mis-tally at a cap; that direction is safe (the cap is skipped, costing a rim sliver, never an over-cut) and is tracked separately.
+
+The decision moved to its own module, `router/voids/synthesis/exit_cap.rs`, so the four conditions and their reasons sit together instead of inline in the cutter-synthesis pass.
+
+Verified against ifcopenshell 0.8.2 and manifold3d on the reporter's model, where the correct subtraction removes zero volume because the holes are already present: the four affected wall layers go from -18.8%, -18.6%, -27.0% and -8.3% volume error to within 0.1%. Four regression tests assert removed volume or cutter extent rather than mechanism, because the existing void tests ray-cast "the wall has a hole", which is monotone in the cut and cannot catch an over-cut. They also pin the 30% clearance from both sides for the first time; it previously had no test that could fail at either extreme.
+
+Two thin `IfcCovering` layers on the same model stay wrong for an unrelated reason (multi-opening cuts tear thin shells open, independent of this pad and unchanged by it) and are tracked separately.

--- a/rust/geometry/src/router/voids/synthesis.rs
+++ b/rust/geometry/src/router/voids/synthesis.rs
@@ -4,6 +4,8 @@
 
 //! Opening classification, merge/extend, and cutter-mesh synthesis.
 
+mod exit_cap;
+
 use super::geom::*;
 use super::{GeometryRouter, OpeningType, NORMALIZE_EPSILON};
 use crate::{Mesh, Point3, Vector3};
@@ -877,78 +879,24 @@ impl GeometryRouter {
         }
         let d = dir / len;
 
-        // Opening span along `d`.
-        let (mut omn, mut omx) = (f64::INFINITY, f64::NEG_INFINITY);
-        for c in opening_mesh.positions.chunks_exact(3) {
-            let s = c[0] as f64 * d.x + c[1] as f64 * d.y + c[2] as f64 * d.z;
-            omn = omn.min(s);
-            omx = omx.max(s);
-        }
-        let open_span = (omx - omn).abs();
+        // Cutter extents in the penetration frame, and which caps the opening
+        // actually EXITS through. Growing a cap the opening does not exit
+        // through removes host material no authored opening occupied (#3219),
+        // so the decision lives behind one call in `exit_cap`.
+        let Some(frame) = exit_cap::CutterFrame::new(opening_mesh, d) else {
+            return opening_mesh.clone();
+        };
+        let open_span = frame.span();
         if open_span < NORMALIZE_EPSILON {
             return opening_mesh.clone();
         }
-
-        // FLUSH-CAP DETECTION against the host SURFACE (not its AABB): is there a
-        // host triangle whose plane is ~parallel to a cap (normal·d ≈ ±1) and whose
-        // plane the cap's projection `omn`/`omx` sits ON (within `flush_band`)? Only
-        // then is that cap a real flush interface to extend. This is what tells a
-        // #1112 roof-opening cap (flush with a roof facet that is INTERIOR to the
-        // host's projected extent) apart from a wall #552611 horizontal slot whose
-        // caps float inside the wall (no host facet there) — extending the latter
-        // along its authored +Z extrusion would cut the wall in half.
-        let flush_band = open_span.max(1.0) * 1e-3; // 0.1% of opening depth, scale-rel
-        let (mut cap_min_flush, mut cap_max_flush) = (false, false);
-        // Farthest host surface coincident with each cap, along `d` (for the push).
-        let (mut host_at_min, mut host_at_max) = (omn, omx);
-        let vat = |i: u32| {
-            let b = i as usize * 3;
-            [
-                host_mesh.positions[b] as f64,
-                host_mesh.positions[b + 1] as f64,
-                host_mesh.positions[b + 2] as f64,
-            ]
-        };
-        let vc = host_mesh.positions.len() / 3;
-        for t in host_mesh.indices.chunks_exact(3) {
-            if (t[0] as usize) >= vc || (t[1] as usize) >= vc || (t[2] as usize) >= vc {
-                continue;
-            }
-            let (a, b, c) = (vat(t[0]), vat(t[1]), vat(t[2]));
-            let e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
-            let e2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
-            let n = [
-                e1[1] * e2[2] - e1[2] * e2[1],
-                e1[2] * e2[0] - e1[0] * e2[2],
-                e1[0] * e2[1] - e1[1] * e2[0],
-            ];
-            let nl = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
-            if nl < 1e-12 {
-                continue;
-            }
-            // |n·d| ≈ 1 ⇒ host facet parallel to the caps (normal along the
-            // penetration axis). 0.985 ≈ 10° — absorbs the ~0.1° facet scatter and
-            // a tilted roof's facet wobble without admitting a perpendicular wall.
-            let nd = (n[0] * d.x + n[1] * d.y + n[2] * d.z) / nl;
-            if nd.abs() < 0.985 {
-                continue;
-            }
-            // the facet's offset along d (any vertex; it's ~constant on the facet)
-            let s = a[0] * d.x + a[1] * d.y + a[2] * d.z;
-            if (s - omn).abs() <= flush_band {
-                cap_min_flush = true;
-                host_at_min = host_at_min.min(s);
-            }
-            if (s - omx).abs() <= flush_band {
-                cap_max_flush = true;
-                host_at_max = host_at_max.max(s);
-            }
-        }
-        if !cap_min_flush && !cap_max_flush {
-            return opening_mesh.clone(); // no flush cap ⇒ a clean transversal cut
+        let (omn, omx) = frame.caps();
+        let caps = exit_cap::detect(host_mesh, &frame);
+        if caps.min.is_none() && caps.max.is_none() {
+            return opening_mesh.clone(); // no exit cap => a clean transversal cut
         }
 
-        // Push each FLUSH cap a clearance margin PAST its coincident host facet, so
+        // Push each EXIT cap a clearance margin PAST its coincident host facet, so
         // the interface becomes a transversal crossing. The margin is NOT a hairline
         // pad: a near-grazing exit (cap a few µm past a TILTED faceted surface)
         // re-creates a coarse T-junction at the facet seam — two rim vertices a few
@@ -965,24 +913,24 @@ impl GeometryRouter {
         // chamfer), 15 % → a near-grazing 1250:1 resonance, 30–40 % → ~25:1 clean.
         // 30 % is the conservative floor of that clean band; it is still small in
         // absolute terms (a few cm on a ~1 m-deep opening, ~9 cm on a 0.3 m window),
-        // fires ONLY on a detected flush cap (a floating wall-slot cap is untouched),
+        // fires ONLY on a detected exit cap (a floating wall-slot cap is untouched),
         // pushes INTO the host away from neighbouring elements, and stays well short
         // of the engulf guard. Verified: the whole rect-opening + #1007 + #960 suite
         // stays green and `issue_1007_real_opening_no_bridge`'s footprint coverage
         // stays 0 (no bridge).
         let pad = (open_span * 0.30).max(0.01);
-        let push_back = if cap_min_flush { (omn - host_at_min).max(0.0) + pad } else { 0.0 };
-        let push_fwd = if cap_max_flush { (host_at_max - omx).max(0.0) + pad } else { 0.0 };
-        // Only the flush cap ring(s) move; interior loops are untouched (band = a
+        let push_back = caps.push_back(omn, pad);
+        let push_fwd = caps.push_fwd(omx, pad);
+        // Only the exit cap ring(s) move; interior loops are untouched (band = a
         // quarter of the opening's own depth).
         let band = (open_span * 0.25).max(1e-6);
         let mut out = opening_mesh.clone();
         for c in out.positions.chunks_exact_mut(3) {
             let p = Point3::new(c[0] as f64, c[1] as f64, c[2] as f64);
             let s = p.x * d.x + p.y * d.y + p.z * d.z;
-            let shift = if cap_min_flush && s <= omn + band {
+            let shift = if caps.min.is_some() && s <= omn + band {
                 -push_back
-            } else if cap_max_flush && s >= omx - band {
+            } else if caps.max.is_some() && s >= omx - band {
                 push_fwd
             } else {
                 0.0

--- a/rust/geometry/src/router/voids/synthesis/exit_cap.rs
+++ b/rust/geometry/src/router/voids/synthesis/exit_cap.rs
@@ -1,0 +1,201 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Which end caps of an opening cutter may be pushed through the host.
+//!
+//! `extend_opening_mesh_through_host` grows a cutter so a cap that sits flush
+//! against a host surface becomes a clean transversal crossing instead of a
+//! coplanar graze. Growing the WRONG cap removes host material no authored
+//! opening ever occupied, so the decision is isolated here, behind one call.
+
+use super::super::geom::{mesh_point, mesh_signed_volume, project_aabb_in_frame};
+use super::super::{OpeningFrame, NORMALIZE_EPSILON};
+use crate::{Mesh, Point3, Vector3};
+
+/// A facet counts as parallel to a cap at |n·d| ≥ this. 0.985 ≈ 10°: absorbs
+/// the ~0.1° facet scatter and a tilted roof's wobble without admitting a
+/// perpendicular wall.
+const CAP_PARALLEL_COS: f64 = 0.985;
+
+/// Coincidence and footprint-overlap tolerances, as a fraction of the extent
+/// they are measured against, so a large opening gets proportionally more
+/// slack than a small one. Note the `.max(1.0)` floors below: BELOW one unit
+/// of extent the tolerance stops scaling and is a flat 1e-3, so the same
+/// geometry authored in metres and in millimetres does NOT get the same
+/// relative slack.
+const BAND_FRACTION: f64 = 1.0e-3;
+
+/// A cutter's extents in the frame of its penetration axis: `lo`/`hi` hold
+/// `(u, v, d)` minima and maxima, so `.z` bounds the cutter along the axis
+/// (its two caps) and `.x`/`.y` are its cross-section footprint.
+pub(super) struct CutterFrame {
+    frame: OpeningFrame,
+    lo: Point3<f64>,
+    hi: Point3<f64>,
+}
+
+impl CutterFrame {
+    /// `None` when the axis will not normalize or the mesh projects to a
+    /// non-finite box (`project_aabb_in_frame` validates both ends: a `+inf`
+    /// coordinate lands only in `hi`, so checking `lo` alone would let a
+    /// non-finite box through, #1259).
+    pub fn new(mesh: &Mesh, d: Vector3<f64>) -> Option<Self> {
+        let frame = OpeningFrame::from_depth(d)?;
+        let (lo, hi) = project_aabb_in_frame(
+            mesh,
+            &[frame.cross_a, frame.cross_b, frame.depth],
+            Vector3::zeros(),
+        )?;
+        Some(Self { frame, lo, hi })
+    }
+
+    /// Unit penetration axis.
+    pub fn depth(&self) -> Vector3<f64> {
+        self.frame.depth
+    }
+
+    /// Cutter offsets along the axis at the min and max cap.
+    pub fn caps(&self) -> (f64, f64) {
+        (self.lo.z, self.hi.z)
+    }
+
+    /// Cutter depth along the axis.
+    pub fn span(&self) -> f64 {
+        self.hi.z - self.lo.z
+    }
+
+    /// Tolerance for "this facet lies ON a cap plane", measured along the axis.
+    fn cap_band(&self) -> f64 {
+        self.span().max(1.0) * BAND_FRACTION
+    }
+
+    /// Tolerance for "this facet lies UNDER the footprint", measured ACROSS the
+    /// axis. Kept separate from [`Self::cap_band`]: a depth-derived slack doing
+    /// duty as a lateral one is a different quantity wearing the same name, and
+    /// on these cutters the two differ by an order of magnitude (a 44 m deep,
+    /// 3.4 m tall window opening).
+    fn footprint_band(&self) -> f64 {
+        (self.hi.x - self.lo.x)
+            .max(self.hi.y - self.lo.y)
+            .max(1.0)
+            * BAND_FRACTION
+    }
+
+    /// Whether a facet's cross-section overlaps the cutter's. Touching counts
+    /// as overlapping, the conservative direction: before footprint locality
+    /// existed every coincident facet voted, so admitting a flush-against-the-
+    /// edge facet preserves that behaviour.
+    fn footprint_overlaps(&self, tri: &[Point3<f64>; 3]) -> bool {
+        let band = self.footprint_band();
+        let spans = |ax: &Vector3<f64>, lo: f64, hi: f64| {
+            let (a, b, c) = (
+                tri[0].coords.dot(ax),
+                tri[1].coords.dot(ax),
+                tri[2].coords.dot(ax),
+            );
+            a.min(b).min(c) <= hi + band && a.max(b).max(c) >= lo - band
+        };
+        spans(&self.frame.cross_a, self.lo.x, self.hi.x)
+            && spans(&self.frame.cross_b, self.lo.y, self.hi.y)
+    }
+}
+
+/// The host surface offset along the axis at each cap the opening EXITS
+/// through. `None` means the opening does not exit there, so that cap must not
+/// move. Encoding it this way makes "not an exit cap, but here is its offset"
+/// unrepresentable.
+pub(super) struct ExitCaps {
+    pub min: Option<f64>,
+    pub max: Option<f64>,
+}
+
+impl ExitCaps {
+    /// How far to push the min cap back, given the caller's clearance `pad`.
+    pub fn push_back(&self, omn: f64, pad: f64) -> f64 {
+        self.min.map_or(0.0, |h| (omn - h).max(0.0) + pad)
+    }
+
+    /// How far to push the max cap forward, given the caller's clearance `pad`.
+    pub fn push_fwd(&self, omx: f64, pad: f64) -> f64 {
+        self.max.map_or(0.0, |h| (h - omx).max(0.0) + pad)
+    }
+}
+
+/// Decide each cap against the host SURFACE (not its AABB). A cap qualifies
+/// only when a host facet is ~parallel to it, sits ON its plane, lies UNDER
+/// the cutter's footprint, and faces the way an exit faces. All four matter.
+///
+/// Parallel-and-coincident alone tells a #1112 roof-opening cap (flush with a
+/// roof facet INTERIOR to the host's projected extent) apart from a wall
+/// #552611 horizontal slot whose caps float inside the wall with no host facet
+/// there — extending the latter along its authored +Z extrusion would halve
+/// the wall.
+///
+/// Footprint locality keeps a multi-body host honest. A large coplanar facet
+/// off to one side (a plate beside the slab being pierced) would otherwise
+/// outvote the genuine cap by area and suppress a push #1007 needs.
+///
+/// Orientation is the #3219 case. When the authoring tool already cut the hole
+/// into the host — an Archicad wall exploded into layer parts, each Brep
+/// carrying its own window — the cutter's side planes coincide with the hole's
+/// JAMBS. Coincidence alone reads those as caps, and the push then drives each
+/// one into the pier beside it, widening every window by 30% of its own width
+/// per side. With outward winding an exit facet faces AWAY from the material,
+/// so `-d` at the min cap and `+d` at the max cap; a jamb faces INTO the hole,
+/// the opposite sign on both, because the host continues past it. The facing is
+/// area-weighted rather than boolean so facet scatter and stray slivers cannot
+/// outvote the real surface.
+pub(super) fn detect(host: &Mesh, f: &CutterFrame) -> ExitCaps {
+    let (omn, omx) = f.caps();
+    let (d, band) = (f.depth(), f.cap_band());
+    // "Faces away from the material" is only "-d/+d" when the host is wound
+    // OUTWARD, and IFC winding is not reliably outward: a CW profile extruded
+    // along +Z, or a faceted brep with inconsistent face loops, yields an
+    // INWARD-wound closed solid (`kernel/mesh_bridge.rs`). The host is not
+    // oriented until AFTER the cut (`processing/src/element.rs` runs
+    // `orient_mesh_outward_verdict` on the result), so read the host's own
+    // convention from the sign of its signed volume instead of assuming one.
+    // Without this an inward-wound host loses the #1007 clearance push AND
+    // gets the #3219 pier-eating back, both silently.
+    let orient = if mesh_signed_volume(host) < 0.0 { -1.0 } else { 1.0 };
+    let (mut min_facing, mut max_facing) = (0.0f64, 0.0f64);
+    let (mut host_at_min, mut host_at_max) = (omn, omx);
+    for t in host.indices.chunks_exact(3) {
+        let (Some(a), Some(b), Some(c)) = (
+            mesh_point(host, t[0]),
+            mesh_point(host, t[1]),
+            mesh_point(host, t[2]),
+        ) else {
+            continue;
+        };
+        // Unnormalized normal: its length is 2·area, so `n · d` IS the
+        // area-weighted facing with no second normalize.
+        let n = (b - a).cross(&(c - a));
+        let nl = n.norm();
+        if nl < NORMALIZE_EPSILON {
+            continue;
+        }
+        let facing = n.dot(&d);
+        if (facing / nl).abs() < CAP_PARALLEL_COS {
+            continue;
+        }
+        if !f.footprint_overlaps(&[a, b, c]) {
+            continue;
+        }
+        // the facet's offset along d (any vertex; it's ~constant on the facet)
+        let s = a.coords.dot(&d);
+        if (s - omn).abs() <= band {
+            min_facing += facing;
+            host_at_min = host_at_min.min(s);
+        }
+        if (s - omx).abs() <= band {
+            max_facing += facing;
+            host_at_max = host_at_max.max(s);
+        }
+    }
+    ExitCaps {
+        min: (min_facing * orient < 0.0).then_some(host_at_min),
+        max: (max_facing * orient > 0.0).then_some(host_at_max),
+    }
+}

--- a/rust/geometry/src/router/voids/synthesis_tests.rs
+++ b/rust/geometry/src/router/voids/synthesis_tests.rs
@@ -3,6 +3,170 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::*;
+use crate::ClippingProcessor;
+
+/// Append a quad, ordering its winding so the facet normal points along
+/// `target`. Deriving the winding instead of hand-listing corner order keeps
+/// the fixture self-checking: an outward-facing fixture cannot silently become
+/// inward-wound and quietly change what the code under test sees.
+fn push_quad(m: &mut Mesh, quad: [Point3<f64>; 4], target: Vector3<f64>) {
+    let n = (quad[1] - quad[0])
+        .cross(&(quad[2] - quad[0]))
+        .try_normalize(1e-12)
+        .expect("degenerate quad in fixture");
+    let q = if n.dot(&target) > 0.0 {
+        [quad[0], quad[1], quad[2], quad[3]]
+    } else {
+        [quad[3], quad[2], quad[1], quad[0]]
+    };
+    let nrm = target.normalize();
+    let b = m.vertex_count() as u32;
+    for p in &q {
+        m.add_vertex(*p, nrm);
+    }
+    m.add_triangle(b, b + 1, b + 2);
+    m.add_triangle(b, b + 2, b + 3);
+}
+
+/// A wall whose window hole is ALREADY cut into its Brep, the way Archicad
+/// exports a wall exploded into layer parts (issue #3219). Wall x 0..6,
+/// y 0..0.4 (thickness), z 0..3; hole x 2..4, z 0.5..2.5, straight through.
+///
+/// The hole's jamb facets at x = 2 and x = 4 face INTO the hole, because the
+/// pier of host material continues past them. That is the whole point of the
+/// fixture: those facets are coincident with a cutter that fills the hole, and
+/// coincidence alone used to qualify them for the flush-cap push.
+fn pre_cut_wall() -> Mesh {
+    let p = |x: f64, y: f64, z: f64| Point3::new(x, y, z);
+    let mut m = Mesh::with_capacity(96, 144);
+    // Front (y = 0) and back (y = 0.4) skins, each an annulus around the hole.
+    for (y, out) in [(0.0, Vector3::new(0.0, -1.0, 0.0)), (0.4, Vector3::new(0.0, 1.0, 0.0))] {
+        push_quad(&mut m, [p(0.0, y, 0.0), p(6.0, y, 0.0), p(6.0, y, 0.5), p(0.0, y, 0.5)], out);
+        push_quad(&mut m, [p(0.0, y, 2.5), p(6.0, y, 2.5), p(6.0, y, 3.0), p(0.0, y, 3.0)], out);
+        push_quad(&mut m, [p(0.0, y, 0.5), p(2.0, y, 0.5), p(2.0, y, 2.5), p(0.0, y, 2.5)], out);
+        push_quad(&mut m, [p(4.0, y, 0.5), p(6.0, y, 0.5), p(6.0, y, 2.5), p(4.0, y, 2.5)], out);
+    }
+    // Outer faces.
+    push_quad(&mut m, [p(0.0, 0.0, 0.0), p(6.0, 0.0, 0.0), p(6.0, 0.4, 0.0), p(0.0, 0.4, 0.0)], Vector3::new(0.0, 0.0, -1.0));
+    push_quad(&mut m, [p(0.0, 0.0, 3.0), p(6.0, 0.0, 3.0), p(6.0, 0.4, 3.0), p(0.0, 0.4, 3.0)], Vector3::new(0.0, 0.0, 1.0));
+    push_quad(&mut m, [p(0.0, 0.0, 0.0), p(0.0, 0.4, 0.0), p(0.0, 0.4, 3.0), p(0.0, 0.0, 3.0)], Vector3::new(-1.0, 0.0, 0.0));
+    push_quad(&mut m, [p(6.0, 0.0, 0.0), p(6.0, 0.4, 0.0), p(6.0, 0.4, 3.0), p(6.0, 0.0, 3.0)], Vector3::new(1.0, 0.0, 0.0));
+    // Hole reveals: outward normal points INTO the void.
+    push_quad(&mut m, [p(2.0, 0.0, 0.5), p(2.0, 0.4, 0.5), p(2.0, 0.4, 2.5), p(2.0, 0.0, 2.5)], Vector3::new(1.0, 0.0, 0.0));
+    push_quad(&mut m, [p(4.0, 0.0, 0.5), p(4.0, 0.4, 0.5), p(4.0, 0.4, 2.5), p(4.0, 0.0, 2.5)], Vector3::new(-1.0, 0.0, 0.0));
+    push_quad(&mut m, [p(2.0, 0.0, 0.5), p(4.0, 0.0, 0.5), p(4.0, 0.4, 0.5), p(2.0, 0.4, 0.5)], Vector3::new(0.0, 0.0, 1.0));
+    push_quad(&mut m, [p(2.0, 0.0, 2.5), p(4.0, 0.0, 2.5), p(4.0, 0.4, 2.5), p(2.0, 0.4, 2.5)], Vector3::new(0.0, 0.0, -1.0));
+    // Self-check before anyone trusts it: 6*0.4*3 minus the 2*0.4*2 hole. The
+    // SIGN is asserted, not just the magnitude - facet orientation is the
+    // property these fixtures exist to exercise, so `.abs()` here would hide
+    // exactly the mistake the check is for.
+    let vol = mesh_signed_volume(&m);
+    assert!(
+        (vol - 5.6).abs() < 1e-6,
+        "pre_cut_wall fixture is malformed or inward-wound: signed volume {vol:.6}, expected +5.6"
+    );
+    m
+}
+
+/// A coincident facet only votes on a cap if it sits UNDER the opening's
+/// footprint. On a multi-body host a large plate lying in the same plane but
+/// somewhere else entirely would otherwise outvote the real cap by area and
+/// suppress a push that #1007 needs.
+///
+/// Slab 2 x 1 x 0.4 pierced from below; a 10 x 10 plate rests in the same
+/// z = 0.4 plane but starts 3.5 m away. The plate's underside faces -z and is
+/// 50x the cap's area, so an unrestricted area tally reads the exit cap as
+/// re-entrant and skips the clearance push entirely.
+#[test]
+fn remote_coplanar_facet_does_not_outvote_a_local_exit_cap() {
+    let slab = GeometryRouter::make_box_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(2.0, 1.0, 0.4));
+    let plate = GeometryRouter::make_box_mesh(Point3::new(5.0, 0.0, 0.4), Point3::new(15.0, 10.0, 0.6));
+    let mut host = slab.clone();
+    host.merge(&plate);
+    let (inner, outer) = (-0.5, 0.4);
+    let cutter = GeometryRouter::make_box_mesh(Point3::new(0.5, 0.25, inner), Point3::new(1.5, 0.75, outer));
+    let span = outer - inner;
+
+    let extended =
+        GeometryRouter::extend_opening_mesh_through_host(&cutter, &host, Vector3::new(0.0, 0.0, 1.0));
+    let clearance = extended.bounds().1.z as f64 - outer;
+
+    assert!(
+        clearance > 0.1 * span,
+        "a remote coplanar facet must not outvote the local exit cap; the cap was \
+         pushed clear by only {clearance:.4} of a {span:.4} span"
+    );
+}
+
+/// Issue #3219. A cutter that exactly fills a hole the host ALREADY carries
+/// must remove nothing, whatever axis the frame inference handed us.
+///
+/// `dir` here is the wall RUN, which is what `infer_opening_frame` picks for
+/// the reporter's openings (they are 44 m deep and 1.21 m wide, and the
+/// no-extrusion-direction branch picks the smallest extent). Before the exit-cap
+/// sign test, both jambs read as flush caps and were each pushed `0.30 * span`
+/// into the pier beside them, removing 2 * 0.6 * 0.4 * 2.0 = 0.96 m3 of wall
+/// that no authored opening ever occupied.
+///
+/// This is the assertion shape the void suite lacked. Its existing tests
+/// ray-cast "the wall has a hole", which is monotone in the cut: it passes just
+/// as happily when the hole is far too wide. Removed-volume-equals-zero is
+/// two-sided, so it bounds the cut hole against the authored one.
+#[test]
+fn flush_cap_is_not_pushed_into_a_pre_cut_jamb() {
+    let host = pre_cut_wall();
+    let cutter = GeometryRouter::make_box_mesh(Point3::new(2.0, -10.0, 0.5), Point3::new(4.0, 10.4, 2.5));
+    let dir = Vector3::new(1.0, 0.0, 0.0);
+
+    let extended = GeometryRouter::extend_opening_mesh_through_host(&cutter, &host, dir);
+    let clipper = ClippingProcessor::new();
+    let before = mesh_signed_volume(&host).abs();
+    let cut = clipper
+        .subtract_mesh(&host, &extended)
+        .expect("subtract must not error on two closed boxes");
+    let removed = before - mesh_signed_volume(&cut).abs();
+
+    assert!(
+        removed.abs() < 1.0e-3,
+        "a cutter that exactly fills a hole the host already carries must remove \
+         nothing; removed {removed:.4} m3 (the flush-cap pad ate the piers)"
+    );
+}
+
+/// The other side of the same gate: a cap the opening genuinely EXITS through
+/// still gets its clearance push, which is what issue #1007 / host #1112 needs
+/// to avoid a high-aspect rim sliver at the exit seam. A pocket's floating
+/// inner cap still must not move, or the pocket becomes a through-hole
+/// (wall #552611).
+///
+/// The clearance is asserted as a BAND relative to the opening's own span, not
+/// as the 0.30 constant, so retuning inside the measured clean band stays legal
+/// while pad = 0 and a runaway pad both fail.
+#[test]
+fn flush_cap_on_a_genuine_exit_is_still_pushed_clear() {
+    let slab = GeometryRouter::make_box_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(2.0, 1.0, 0.4));
+    // Pocket: outer cap flush with the slab's top face, inner cap floating.
+    let (inner, outer) = (0.15, 0.4);
+    let pocket = GeometryRouter::make_box_mesh(Point3::new(0.5, 0.25, inner), Point3::new(1.5, 0.75, outer));
+    let span = outer - inner;
+
+    let extended =
+        GeometryRouter::extend_opening_mesh_through_host(&pocket, &slab, Vector3::new(0.0, 0.0, 1.0));
+    let (mn, mx) = extended.bounds();
+    let (new_inner, new_outer) = (mn.z as f64, mx.z as f64);
+
+    let clearance = new_outer - outer;
+    assert!(
+        clearance > 0.1 * span && clearance < 1.0 * span,
+        "an exit cap must be pushed clear of the surface by an opening-relative \
+         margin; clearance {clearance:.4} is outside (0.1, 1.0) x span {span:.4}"
+    );
+    assert!(
+        (new_inner - inner).abs() < 1.0e-6,
+        "the floating inner cap must not move, or the pocket becomes a through-hole; \
+         moved from {inner:.4} to {new_inner:.4}"
+    );
+}
 
 /// Non-finite file coords (e.g. `1.E999` → +inf) make the bbox-fallback's
 /// axis extents `inf - inf = NaN`; the old `partial_cmp().unwrap()` panicked
@@ -73,4 +237,66 @@ fn axis_pick_total_order_semantics() {
     assert_eq!(pick([f64::NAN, f64::NAN, f64::NAN]), 2, "all-NaN ties resolve to the last index");
     assert_eq!(pick([f64::NAN, 1.0, 2.0]), 0, "positive NaN outranks finite values");
     assert_eq!(pick([1.0, f64::INFINITY, f64::NAN]), 2, "positive NaN outranks +inf");
+}
+
+/// Reverse every facet's winding. IFC bodies are not reliably outward-wound.
+fn flip_winding(m: &Mesh) -> Mesh {
+    let mut o = m.clone();
+    for t in o.indices.chunks_exact_mut(3) {
+        t.swap(1, 2);
+    }
+    o
+}
+
+/// The exit test reads a SIGNED facet normal, so it has to know which way the
+/// host is wound. IFC winding is not reliably outward (`kernel/mesh_bridge.rs`),
+/// and the host is not oriented until AFTER the cut
+/// (`processing/src/element.rs` runs `orient_mesh_outward_verdict` on the
+/// result), so an inward-wound body reaches this code as authored.
+///
+/// Both failure modes were reproduced before the orientation term existed: an
+/// inward-wound slab lost the #1007 clearance push entirely (0.0000 of a 0.2500
+/// span), and an inward-wound pre-cut wall got the #3219 pier-eating back (the
+/// cutter grew to 1.400 .. 4.600 against an authored 2.000 .. 4.000).
+///
+/// KNOWN LIMITATION, deliberately not fixed here: this reads the host's GLOBAL
+/// convention from its signed volume, so a body whose winding is MIXED can
+/// still mis-tally at a cap. That direction is safe — the cap is demoted and
+/// the clearance push is skipped, costing a #1007 rim sliver, never an
+/// over-cut.
+#[test]
+fn an_inward_wound_host_is_read_the_same_as_an_outward_one() {
+    let up = Vector3::new(0.0, 0.0, 1.0);
+    let slab = GeometryRouter::make_box_mesh(Point3::new(0.0, 0.0, 0.0), Point3::new(2.0, 1.0, 0.4));
+    let pocket =
+        GeometryRouter::make_box_mesh(Point3::new(0.5, 0.25, 0.15), Point3::new(1.5, 0.75, 0.4));
+    let clearance = |host: &Mesh| {
+        GeometryRouter::extend_opening_mesh_through_host(&pocket, host, up)
+            .bounds()
+            .1
+            .z as f64
+            - 0.4
+    };
+    let (outward, inward) = (clearance(&slab), clearance(&flip_winding(&slab)));
+    assert!(
+        (outward - inward).abs() < 1.0e-9 && inward > 0.0,
+        "an inward-wound host must get the same exit clearance as an outward one; \
+         outward {outward:.6}, inward {inward:.6}"
+    );
+
+    let cutter =
+        GeometryRouter::make_box_mesh(Point3::new(2.0, -10.0, 0.5), Point3::new(4.0, 10.4, 2.5));
+    let ext = GeometryRouter::extend_opening_mesh_through_host(
+        &cutter,
+        &flip_winding(&pre_cut_wall()),
+        Vector3::new(1.0, 0.0, 0.0),
+    );
+    let (mn, mx) = ext.bounds();
+    assert!(
+        (mn.x as f64 - 2.0).abs() < 1.0e-6 && (mx.x as f64 - 4.0).abs() < 1.0e-6,
+        "an inward-wound pre-cut host must not have its jambs pushed into the piers; \
+         cutter spans {:.3} .. {:.3}, authored 2.000 .. 4.000",
+        mn.x,
+        mx.x
+    );
 }

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -281,7 +281,12 @@
 # (is_finite guards) so an inf depth can no longer slip past the `> 0.0` / `<= 0.0`
 # gates into the fast path.
      858 rust/geometry/src/router/voids/probe.rs
-    1002 rust/geometry/src/router/voids/synthesis.rs
+# -51: the exit-cap decision (which cutter caps may be pushed through the host)
+# moved to synthesis/exit_cap.rs, a module under the 400 budget, and gained
+# #3219's orientation + footprint conditions there rather than inline here;
+# 1002 -> 950. The move is NOT verbatim - the facing accumulation and the
+# footprint restriction are new.
+     950 rust/geometry/src/router/voids/synthesis.rs
     1472 rust/geometry/src/space_dcel/mod.rs
      525 rust/geometry/src/transform.rs
      782 rust/geometry/src/triangulation.rs

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -59,7 +59,7 @@ const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 12409080334009393247),
     ("rust/core", 13402756985857706732),
     ("rust/export", 15791359419451037914),
-    ("rust/geometry", 4605843127520592792),
+    ("rust/geometry", 15876789025813582259),
     ("rust/processing", 3593499704459643831),
     ("rust/wasm-bindings", 6350495779387008670),
 ];


### PR DESCRIPTION
Fixes #3219.

## What was wrong

`extend_opening_mesh_through_host` pushes an opening cutter's cap past a coincident host facet so a flush interface becomes a clean transversal crossing instead of a coplanar graze (#1007, host #1112). It qualified a cap on **coincidence alone**.

Archicad exports a wall with *Material Preservation: Explode where necessary* like this: the wall body lives on aggregated `IfcBuildingElementPart` layers, **every layer's Brep already carries its own window**, and all 22 `IfcRelVoidsElement` sit on the body-less parent wall. ifc-lite propagates them down, which is correct (ifcopenshell's `find_openings` walks `Decomposes()` the same way).

So the cutter's side planes coincide with the hole's **jambs**. Both read as caps, and each was pushed `0.30 * span` into the pier beside it. Every window came out scaled by exactly **1.600** with its centre unmoved:

| authored gap | after cut | widening/side | 0.30 x authored |
|---|---|---|---|
| 1.198 | 1.924 | 0.363 | 0.359 |
| 0.595 | 0.975 | 0.190 | 0.178 |
| 2.403 | 3.849 | 0.723 | 0.721 |
| 1.801 | 2.891 | 0.545 | 0.540 |

Eleven windows, 9.308 m of extra opening, 6.348 m3 implied against a measured 6.366 m3 loss. The pad accounts for the whole error.

## The correct answer, established independently

The subtraction should remove **nothing** on this model, because the holes are already there. Two independent confirmations:

- **manifold3d** puts the intersection volume of every (part, opening) pair at **0.0000 m3**.
- **ifcopenshell 0.8.2** logs `Eliminated 11 disjoint operands` / `11 touching operands` and returns identical volume with opening subtraction on and off.

## The fix

Coincidence is now necessary but not sufficient. A cap must also lie under the cutter's cross-section **footprint** and **face the way an exit faces**: an exit facet faces away from the host material, a jamb faces into the hole because the host continues past it. The facing is area-weighted so facet scatter cannot outvote the real surface.

The sign is read from the host's **own signed volume** rather than assumed. IFC winding is not reliably outward and the host is not oriented until *after* the cut (`element.rs` runs `orient_mesh_outward_verdict` on the result). Without that term an inward-wound host lost the #1007 clearance push entirely *and* got the pier-eating back.

Genuine exit caps keep the identical push, so the #1007 clearance is unchanged. The pad, its constant, the flush band and the function signature are all untouched.

| part | before | truth | after |
|---|---|---|---|
| #208380 | -18.8% | 33.8117 | -0.0% |
| #208418 | -18.6% | 42.7030 | -0.1% |
| #208435 | -27.0% | 31.3913 | +0.0% |
| #412188 | -8.3% | 41.6703 | +0.0% |

## Tests

Four, all asserting removed volume or cutter extent rather than mechanism. **The existing void tests ray-cast "the wall has a hole", which is monotone in the cut and structurally cannot catch an over-cut** — that is why this shipped.

Each was verified to fail on the code without its condition, for the right reason:

| test | without | message |
|---|---|---|
| `flush_cap_is_not_pushed_into_a_pre_cut_jamb` | orientation | `removed 0.9601 m3` |
| `remote_coplanar_facet_does_not_outvote_a_local_exit_cap` | footprint | `pushed clear by only 0.0000 of a 0.9000 span` |
| `an_inward_wound_host_is_read_the_same_as_an_outward_one` | signed-volume term | cutter `1.400 .. 4.600` vs authored `2.000 .. 4.000` |
| `flush_cap_on_a_genuine_exit_is_still_pushed_clear` | pad 0.30 | fails at pad=0 and pad=1.5 |

The last one **pins the 30% clearance for the first time**: before this PR, `pad = 0` and `pad = 1.5` both left the entire suite green.

## Structure

The decision moved to `router/voids/synthesis/exit_cap.rs`, reusing `OpeningFrame`, `project_aabb_in_frame`, `mesh_point` and `mesh_signed_volume` rather than re-deriving them. `synthesis.rs` drops 1002 -> 950, so its ratchet budget is **lowered**, not raised; the new module is under the 400 rule and needs no row.

## Gates

`cargo test -p ifc-lite-geometry --no-fail-fast`: 90 binaries, 960 passed, 0 failed, exit 0.
`cargo test -p ifc-lite-processing --no-fail-fast`: 58 binaries, 289 passed, 0 failed, exit 0.
`cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings`: exit 0.
Run with all 164 model fixtures fetched, so the fixture-gated void tests actually execute.

## Deliberately not fixed here

1. **Two thin `IfcCovering` layers on the same model come out as torn, non-watertight shells** (198 and 662 edges of degree != 2). This survives setting the pad to zero, so it is independent of this change. Follow-up issue.
2. **A host whose winding is genuinely MIXED can still mis-tally a cap.** One flipped facet in a two-triangle quad gives an exact area tie, which skips the push. The direction is safe (a rim sliver, never an over-cut) but it is a regression against main for that input class.
3. **The penetration axis itself is chosen badly.** `infer_opening_frame` picks the smallest-extent axis with no authored extrusion direction, which for these 44 m deep, 1.21 m wide cutters picks the *width*. Flipping the comparator was tried and **refuted by measurement** (+523% on one part of wall #392764). This PR makes the wrong axis harmless at the point it did damage instead.
4. **`accept_cut` in `coaxial_union.rs` asserts "the watertightness of the cut is guaranteed upstream".** Measured false: the first subtract takes a closed 188-triangle host to an open 236-triangle one.

## Coupling worth knowing

With this fix, roughly 60 remove-nothing outcomes per load of this model now flow through the #635 engulf guard and #964 redundant-void detection instead of being padded into removing real material. Weakening that guard pair would partially re-open #3219.
