### PR TITLE
fix(scripts): a dotfile is not a candidate package (.DS_Store failed Lint eight times today)

### DIFF
--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -334,6 +334,17 @@ export function listPackages(root, seenParents = []) {
     if (!existsOrThrow(parentDir, 'package parent')) continue;
     seenParents.push(parent);
     for (const name of readdirSync(parentDir).sort()) {
+      // A dotfile is not a candidate package and never was: pnpm-workspace.yaml
+      // globs `packages/*` and `apps/*`, and a bare `*` does not match a
+      // leading dot, so no dotted entry can ever be a workspace package. macOS
+      // drops a `.DS_Store` FILE into any directory Finder has opened, and
+      // statting `.DS_Store/package.json` raises ENOTDIR — which existsOrThrow
+      // below refuses, correctly and by design, failing the whole Lint lane on
+      // a local-only file. The fix is to stop offering a dotfile as a
+      // candidate, NOT to soften that refusal: every entry that could
+      // plausibly be a package still goes through existsOrThrow unchanged.
+      // Same skip walk() already applies one stage later.
+      if (name.startsWith('.')) continue;
       const pkgDir = join(parentDir, name);
       const pkgJsonPath = join(pkgDir, 'package.json');
       if (!existsOrThrow(pkgJsonPath, 'package manifest')) continue;

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -263,6 +263,65 @@ test('an UNREADABLE package is not silently treated as an absent one', () => {
   }
 });
 
+// --- Dotfiles are not candidate packages, and skipping them must not soften
+//     the ENOTDIR refusal directly above ---
+//
+// macOS drops a `.DS_Store` FILE into `packages/` and `apps/` as soon as
+// Finder opens them. Statting `packages/.DS_Store/package.json` raises
+// ENOTDIR, so the refusal above fired on it and failed the whole Lint lane —
+// observed in four separate fresh worktrees. CI never sees this (no Finder on
+// the runners), so a green CI proves nothing about it either way; these two
+// cases are where the pairing is pinned.
+//
+// They are deliberately a PAIR. Making the flake go away is trivial and has an
+// obvious wrong fix (catch ENOTDIR and continue), which would delete the
+// refusal this gate exists for. The second case is the one that would catch
+// that: the same tree carries a dotfile AND a non-dotfile ENOTDIR candidate,
+// and the gate must ignore exactly one of them and refuse the other.
+
+test('a `.DS_Store` dotfile in packages/ or apps/ is not a candidate package', () => {
+  const dir = writeTree({
+    'packages/real-one/package.json': pkgJson('vitest run'),
+    'packages/real-one/src/a.test.ts': '// test a\n',
+    'apps/real-app/package.json': pkgJson('vitest run'),
+    'apps/real-app/src/b.test.ts': '// test b\n',
+    // Finder's leavings: a FILE, so `<name>/package.json` gives ENOTDIR.
+    'packages/.DS_Store': '\x00\x01Bud1',
+    'apps/.DS_Store': '\x00\x01Bud1',
+  });
+  try {
+    const { status, out } = runOn(dir);
+    assert.equal(status, 0, out);
+    assert.match(out, /check-test-glob-coverage: OK \(2 packages audited, 0 unrun test files\)/);
+    assert.doesNotMatch(out, /DS_Store/, 'a dotfile must not appear in the output at all');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skipping dotfiles does not soften the refusal: a non-dotfile ENOTDIR candidate in the SAME tree still fails', () => {
+  const dir = writeTree({
+    'packages/real-one/package.json': pkgJson('vitest run'),
+    'packages/real-one/src/a.test.ts': '// test a\n',
+    'packages/.DS_Store': '\x00\x01Bud1',
+    // Not a dotfile, and not a directory: `packages/blocked/package.json`
+    // raises ENOTDIR exactly as `.DS_Store` did. This one must still be
+    // refused — that is the whole point of the guard.
+    'packages/blocked': 'i am a file, not a package directory\n',
+  });
+  try {
+    const { status, out } = runOn(dir);
+    assert.equal(status, 1, `expected a non-zero exit on a non-dotfile ENOTDIR candidate, got ${status}: ${out}`);
+    assert.match(out, /cannot read package manifest/);
+    assert.match(out, /packages\/blocked\/package\.json/);
+    assert.match(out, /Refusing to treat an unreadable path as an absent one/);
+    assert.doesNotMatch(out, /DS_Store/, 'the dotfile must not be what tripped it');
+    assert.doesNotMatch(out, /OK \(/, 'must not print a success line at all');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // --- Direct unit tests on the exported glob helpers ---
 
 test('globToRegExp: ** matches zero or more path segments', () => {

--- a/scripts/docs/check-package-readmes.mjs
+++ b/scripts/docs/check-package-readmes.mjs
@@ -87,6 +87,14 @@ try {
 const missing = [];
 let checked = 0;
 for (const dir of entries) {
+  // A dotfile is not a candidate package: pnpm-workspace.yaml globs
+  // `packages/*` and a bare `*` never matches a leading dot. macOS drops a
+  // `.DS_Store` FILE into any directory Finder has opened, and statting
+  // `.DS_Store/package.json` raises ENOTDIR, which existsOrFail below refuses
+  // by design. Skip the candidate rather than soften the refusal: every entry
+  // that could plausibly be a package still goes through it unchanged. Same
+  // shape and same reason as check-test-glob-coverage.mjs's listPackages().
+  if (dir.startsWith('.')) continue;
   const pkgJsonPath = join(packagesDir, dir, 'package.json');
   if (!existsOrFail(pkgJsonPath, 'package manifest')) continue;
   const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));

--- a/scripts/docs/check-package-readmes.test.mjs
+++ b/scripts/docs/check-package-readmes.test.mjs
@@ -138,3 +138,34 @@ test('positive control: a healthy tree at the floor passes, with its true count'
   assert.match(out, /✅ All 25 published packages have a README\.md/);
   rmSync(root, { recursive: true, force: true });
 });
+
+test('a `.DS_Store` dotfile in packages/ is not a candidate package', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  // macOS drops this into any directory Finder has opened. Before the skip,
+  // statting `.DS_Store/package.json` raised ENOTDIR and existsOrFail refused
+  // it, failing the docs gate on a local-only file.
+  writeFileSync(join(root, 'packages', '.DS_Store'), '\0\0\0');
+  const { status, out } = run(root);
+  assert.equal(status, 0, out);
+  assert.match(out, /All 25 published packages have a README\.md/);
+  assert.doesNotMatch(out, /DS_Store/, 'the dotfile must not appear in the verdict at all');
+  rmSync(root, { recursive: true, force: true });
+});
+
+test('skipping dotfiles does not soften the refusal: a non-dotfile unreadable candidate still fails', () => {
+  const root = makeTree();
+  fillToFloor(root);
+  // Both in the same tree, so this pins that exactly one is ignored and the
+  // other is refused. Catching ENOTDIR and continuing would have satisfied the
+  // test above while destroying the guarantee this gate exists for, and this
+  // is the case that catches it.
+  writeFileSync(join(root, 'packages', '.DS_Store'), '\0\0\0');
+  writeFileSync(join(root, 'packages', 'not-a-dir'), 'this is a file, not a package directory');
+  const { status, out } = run(root);
+  assert.equal(status, 1, out);
+  assert.match(out, /cannot read package manifest/);
+  assert.match(out, /not-a-dir/);
+  assert.doesNotMatch(out, /DS_Store/, 'the dotfile must not be what tripped it');
+  rmSync(root, { recursive: true, force: true });
+});

--- a/scripts/lib/rust-major-offset.mjs
+++ b/scripts/lib/rust-major-offset.mjs
@@ -283,6 +283,14 @@ export function getWorkspacePackagePaths(rootDir) {
     const parentDir = join(rootDir, parent);
     try {
       for (const entry of readdirSync(parentDir)) {
+        // A dotfile is not a candidate package: pnpm-workspace.yaml globs
+        // `packages/*` / `apps/*` and a bare `*` never matches a leading dot.
+        // Skipping it matters MORE here than in a lint gate: macOS drops a
+        // `.DS_Store` into any Finder-opened directory, and the warning below
+        // is load-bearing for the release version. A local-only file must not
+        // emit an alarm indistinguishable from a directory that genuinely
+        // failed to be read.
+        if (entry.startsWith('.')) continue;
         const pkgJsonPath = join(parentDir, entry, 'package.json');
         try {
           statSync(pkgJsonPath);

--- a/scripts/lib/rust-major-offset.test.mjs
+++ b/scripts/lib/rust-major-offset.test.mjs
@@ -18,6 +18,7 @@ import { join } from 'node:path';
 
 import {
   applyMajorOffset,
+  getWorkspacePackagePaths,
   computeReleaseVersions,
   MIN_WORKSPACE_PACKAGES,
   parseSemver,
@@ -227,4 +228,55 @@ test('a non-matching manifest makes the sync-versions replace a silent no-op', (
 test('the real root Cargo.toml still yields its workspace version', () => {
   const cargo = readFileSync(join(import.meta.dirname, '..', '..', 'Cargo.toml'), 'utf8');
   assert.match(readWorkspaceVersion(cargo) ?? '', /^\d+\.\d+\.\d+$/);
+});
+
+test('a `.DS_Store` dotfile does not emit a version-scan warning, and does not shrink the scan', (t) => {
+  const root = makeTree(t, {});
+  // The warning below `getWorkspacePackagePaths` is load-bearing: a directory
+  // that fails to be read shrinks the scan, and a shrunken scan syncs the
+  // release to a version LOWER than what was published. A macOS Finder
+  // artefact must not produce an alarm indistinguishable from that.
+  writeFileSync(join(root, 'packages', '.DS_Store'), '\0\0\0');
+
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  let paths;
+  try {
+    paths = getWorkspacePackagePaths(root);
+  } finally {
+    console.warn = realWarn;
+  }
+
+  assert.deepEqual(warnings, [], `a dotfile must not warn, got: ${warnings.join(' | ')}`);
+  assert.ok(
+    paths.length >= MIN_WORKSPACE_PACKAGES,
+    `the scan must not shrink: ${paths.length} manifests found`,
+  );
+  assert.ok(
+    !paths.some((p) => p.includes('.DS_Store')),
+    'the dotfile must not be scanned as a package',
+  );
+});
+
+test('skipping dotfiles does not silence a REAL unreadable candidate', (t) => {
+  const root = makeTree(t, {});
+  // Both in one tree, so this pins that exactly one is ignored and the other
+  // still warns. Widening the skip, or swallowing the stat error, would satisfy
+  // the test above while destroying the alarm the release path depends on.
+  writeFileSync(join(root, 'packages', '.DS_Store'), '\0\0\0');
+  writeFileSync(join(root, 'packages', 'not-a-dir'), 'a file where a package directory belongs');
+
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    getWorkspacePackagePaths(root);
+  } finally {
+    console.warn = realWarn;
+  }
+
+  assert.equal(warnings.length, 1, `expected exactly one warning, got: ${warnings.join(' | ')}`);
+  assert.match(warnings[0], /not-a-dir/);
+  assert.doesNotMatch(warnings[0], /DS_Store/, 'the dotfile must not be what warned');
 });


### PR DESCRIPTION
`pnpm lint` fails in a local worktree whenever macOS has dropped a `.DS_Store` into `packages/` or `apps/`. It happened eight times while working on two unrelated branches today.

## What was wrong

`scripts/check-test-glob-coverage.mjs` enumerates workspace packages by walking the filesystem, hits the `.DS_Store` FILE, stats `packages/.DS_Store/package.json`, gets ENOTDIR, and `existsOrThrow` refuses it:

```
check-test-glob-coverage: cannot read package manifest .../packages/.DS_Store/package.json:
ENOTDIR. Refusing to treat an unreadable path as an absent one -- that is how a package
drops out of the audit without anyone noticing.
```

That refusal is correct and stays. Softening it would trade a visible flake for a silent miss, which is the exact failure it exists to prevent. The fix is to stop offering a dotfile as a candidate package: `pnpm-workspace.yaml` globs `packages/*` and `apps/*`, and a bare `*` never matches a leading dot, so no dotted entry could ever have been a workspace package.

## Three sites, not one

| Site | Behaviour | Found by |
|---|---|---|
| `check-test-glob-coverage.mjs` | fatal, in `pnpm lint` | the symptom |
| `docs/check-package-readmes.mjs` | fatal, but runs as `docs:check-readmes` so it had never bitten | `/simplify` |
| `lib/rust-major-offset.mjs` | not fatal: a warning, on the release-version path | `/code-review` |

The third is worth its line. It never crashed and returned the right 48 manifests. Its own docstring is why it is fixed anyway:

> The warnings are not decoration. This list decides the release version: a directory that silently fails to be read shrinks the scan, and a shrunken scan syncs the whole release to a version LOWER than what was published.

A Finder artefact was emitting an alarm indistinguishable from that one.

The other twenty enumeration sites were checked and are immune, either skipping dotfiles already or tolerating a non-directory entry via `existsSync` / `isDirectory()`.

## Verification

Each site has a both-directions test pair, and each was mutation-checked three ways:

```
no fix                       both new tests fail
wrong fix (swallow ENOTDIR)  the dotfile test PASSES, the real-candidate test fails
correct fix                  all pass
```

The dotfile test alone does not discriminate in any of the three. Catching ENOTDIR and continuing silences the flake and destroys the guarantee, and the second test of each pair is what separates them. In `check-package-readmes` it also trips that file's own pre-existing unreadable-package test.

The premise the whole fix rests on was verified rather than assumed: a throwaway workspace with `packages/.hidden-pkg/package.json` confirms `pnpm -r list` does not return it, so the skip cannot drop a real package.

Gates, with `.DS_Store` deliberately present for the two fatal ones: `check-test-glob-coverage` 0, `check-package-readmes` 0, 1040 script tests 0 fail, `check-test-wiring` 0, `pnpm lint` 0, `check-changesets` 0.

## Not done, deliberately

No shared `listWorkspacePackages()`. Twelve scripts enumerate these parents and they want different things (published-only, manifest paths, tsconfig pairs) and deliberately differ on failure policy between a soft `existsSync` skip and a loud throw, documented per file. A shared helper would take the policy as a parameter and collapse into a three-line loop plus a config object.

Separately noted while counting those twelve: `pnpm-workspace.yaml` declares three globs and `examples/` has four manifests that eleven of the twelve never look at. Not this PR's business, recorded so it is not lost.

No changeset: `scripts/` only, no publishable package.

Related: #3347 covers a different defect in `check-test-wiring.mjs`, which uses `existsSync` and so drops an unreadable package silently rather than crashing.

## Known imprecisions, raised in review and left as-is

- The added comments say `pnpm-workspace.yaml` globs `packages/*` and `apps/*`. It also globs `examples/*`. The load-bearing half of the claim — a bare `*` never matches a leading dot — is correct, so nothing breaks; the sentence is just narrower than the file it cites.
- `scripts/verify-npm-publish.js:141` is the release-lane sibling of these three and solves the same problem the other way: it swallows `ENOTDIR` for **every** entry and prints a note. Its own comment admits the miss window ("up to 17 could vanish this way and still report green"). The dotfile-skip idiom this PR establishes would let it skip dotfiles and then *refuse* a non-dotfile `ENOTDIR`, closing that window. Deliberately out of scope here.
