### PR TITLE
fix(ids): the coherence audit and the strict cast now decide xs:double identically (#3336)

### DIFF
--- a/.changeset/xs-double-audit-matches-cast.md
+++ b/.changeset/xs-double-audit-matches-cast.md
@@ -1,0 +1,32 @@
+---
+'@ifc-lite/ids': patch
+---
+
+The coherence audit and the strict cast now decide `xs:double` identically.
+
+`isValidLexicalForXsType` vetoed any value containing no digit before its regex
+ran, so it rejected `NaN`, `+INF` and `-INF` even though the regex one line above
+accepts them. The same veto tested the WHOLE lexeme, so `e5` passed on the
+strength of the exponent's digit while `literalCastsUnder` rejected it.
+
+Two classes, two directions, one package:
+
+    value          audit before   cast   audit now
+    NaN/+INF/-INF  reject         accept accept
+    e5/+e5/.e5     accept         reject reject
+    ''/'+'/'.'/'-' reject         reject reject
+    1.5            accept         accept accept
+
+The digit is now required in the MANTISSA, and the three specials are exempt
+rather than swept up by the same rule. The specials list is imported from
+`constraints/xsd-cast.ts` rather than restated, so the two sites cannot drift
+apart again by editing one of them.
+
+Practical effect: an IDS document whose `xs:double` enumeration carries `NaN`,
+`+INF` or `-INF` no longer reports `E_RESTRICTION_VALUE_MISMATCH`. Those are in
+the xs:double lexical space and upstream `IDS-Audit-tool` accepts them. One whose
+enumeration carries `e5` now does report it, which upstream does not — a
+deliberate deviation shared with the cast, on the grounds that an exponent with
+no mantissa is not a number.
+
+Completes #3336; the cast half shipped in #3339.

--- a/packages/ids/src/audit/coherence/index.ts
+++ b/packages/ids/src/audit/coherence/index.ts
@@ -19,6 +19,7 @@ import type {
   IDSSpecification,
 } from '../../types.js';
 import type { IDSAuditIssue } from '../types.js';
+import { XSD_NUMERIC_SPECIALS } from '../../constraints/xsd-cast.js';
 import { compileXsdRegex } from './regex.js';
 
 export function runCoherenceAudit(doc: IDSDocument): IDSAuditIssue[] {
@@ -455,15 +456,12 @@ const XS_VALUE_REGEX: Record<string, RegExp> = {
 function isValidLexicalForXsType(value: string, base: string): boolean {
   const rx = XS_VALUE_REGEX[base];
   if (!rx) return true; // base we don't recognise → don't fabricate errors
-  // For doubles/floats/decimals, an empty lexeme is technically allowed
-  // by the regex but isn't a meaningful number — reject.
-  if (
-    (base === 'xs:double' ||
-      base === 'xs:float' ||
-      base === 'xs:decimal') &&
-    !/[0-9]/.test(value)
-  ) {
-    return false;
+  if (base === 'xs:double' || base === 'xs:float' || base === 'xs:decimal') {
+    // Digit required in the MANTISSA, specials exempt (#3336). Testing the
+    // whole lexeme accepted 'e5' on the exponent's digit and rejected the
+    // digitless specials, which is how this and `literalCastsUnder` disagreed.
+    const bare = !XSD_NUMERIC_SPECIALS.has(value);
+    if (bare && !/[0-9]/.test(value.split(/[eE]/)[0])) return false;
   }
   return rx.test(value);
 }

--- a/packages/ids/src/constraints/numeric-literal.test.ts
+++ b/packages/ids/src/constraints/numeric-literal.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect } from 'vitest';
 import { firstBlownRung as ladderFirstBlownRung, SIZES } from '@ifc-lite/timing-ladder';
 import { compareNumeric, isStrictNumericLiteral } from './comparators.js';
-import { literalCastsUnder } from './xsd-cast.js';
+import { XSD_NUMERIC_SPECIALS, literalCastsUnder } from './xsd-cast.js';
 import { runCoherenceAudit } from '../audit/coherence/index.js';
 import type { IDSDocument } from '../types.js';
 
@@ -455,18 +455,57 @@ describe('the same shape elsewhere in @ifc-lite/ids', () => {
       return [...out];
     })();
 
+    /** The decision both sites now make, modelled independently of either.
+     *
+     *  The digit must be in the MANTISSA: testing the whole lexeme accepted
+     *  `e5` on the strength of the exponent's digit, which is how the audit and
+     *  the cast came to disagree while both looked right (#3336). The specials
+     *  carry no digit at all and are valid, so they are exempt rather than
+     *  swept up by the same veto. */
+    const decidesValid = (v: string): boolean => {
+      if (!XS_DOUBLE_RE.test(v)) return false;
+      if (XSD_NUMERIC_SPECIALS.has(v)) return true;
+      return /[0-9]/.test(v.split(/[eE]/)[0]);
+    };
+
     it.each(['xs:double', 'xs:float', 'xs:decimal'])(
-      '%s accepts exactly the lexical space it did before',
+      '%s accepts the lexical space, specials included, digitless forms not',
       (base) => {
+        // This used to pin "exactly the lexical space it did before", with
+        // `before = /[0-9]/.test(v) && XS_DOUBLE_RE.test(v)`. That decision was
+        // wrong in two directions at once and #3336 changed it, so the oracle
+        // had to change too -- a characterisation test cannot outlive the
+        // behaviour it characterises without quietly asserting the old bug.
         const disagree = sample
-          .filter((v) => {
-            // The pre-existing "no digit at all" veto sits outside the regex;
-            // model the whole decision, not just the pattern.
-            const before = /[0-9]/.test(v) && XS_DOUBLE_RE.test(v);
-            return before !== accepts(v, base);
-          })
+          .filter((v) => decidesValid(v) !== accepts(v, base))
           .map((v) => JSON.stringify(v));
         expect(disagree).toEqual([]);
+      }
+    );
+
+    it('the audit and the cast decide xs:double identically', () => {
+      // The whole point of #3336: one literal, one answer. The audit judges an
+      // enumeration value and the cast gates a simpleValue -- different
+      // questions about the same language, which used to differ on the three
+      // specials AND on the exponent-only family.
+      const disagree = sample
+        .filter((v) => accepts(v, 'xs:double') !== literalCastsUnder(v, 'xs:double'))
+        .map((v) => `${JSON.stringify(v)} audit=${accepts(v, 'xs:double')} cast=${literalCastsUnder(v, 'xs:double')}`);
+      expect(disagree).toEqual([]);
+    });
+
+    it.each(['NaN', '+INF', '-INF'])('accepts %j, which upstream accepts', (v) => {
+      expect(accepts(v, 'xs:double')).toBe(true);
+      expect(literalCastsUnder(v, 'xs:double')).toBe(true);
+    });
+
+    it.each(['e5', 'E5', '+e5', '.e5', 'INF', 'Infinity'])(
+      'rejects %j in both places',
+      (v) => {
+        // `e5` is the one the audit used to accept on its own: the veto tested
+        // the whole lexeme, and the exponent supplied the digit.
+        expect(accepts(v, 'xs:double')).toBe(false);
+        expect(literalCastsUnder(v, 'xs:double')).toBe(false);
       }
     );
 

--- a/packages/ids/src/constraints/xsd-cast-specials.test.ts
+++ b/packages/ids/src/constraints/xsd-cast-specials.test.ts
@@ -46,11 +46,12 @@ describe('xs:double specials, matching upstream (#3336)', () => {
       // visible: if upstream ever tightens this, the first line fails and the
       // comment stops being true.
       //
-      // REPRESENTATIVES, not the whole family. The exponent-only rows are here
-      // because they are also a live disagreement with our own coherence audit,
-      // which ACCEPTS them: its digit veto (audit/coherence/index.ts:461) is
-      // satisfied by the digit in the exponent. That split predates this change
-      // and is part of what the audit follow-up has to reconcile.
+      // REPRESENTATIVES, not the whole family. The exponent-only rows were
+      // once a disagreement with our own coherence audit, which accepted them
+      // because its digit veto was satisfied by the digit in the exponent.
+      // That is fixed: the audit now requires the digit in the mantissa and
+      // both sites reject these. `numeric-literal.test.ts` sweeps the two for
+      // equality so they cannot part company again.
       expect(UPSTREAM_DOUBLE_RE.test(v)).toBe(true);
       expect(literalCastsUnder(v, 'xs:double')).toBe(false);
     },


### PR DESCRIPTION
Completes #3336. The cast half shipped in #3339; this is the other site, and it was wrong in two directions at once — which is why neither side looked broken on its own.

`isValidLexicalForXsType` vetoed any value containing no digit **before** its regex ran, so it rejected `NaN`, `+INF` and `-INF` that the regex one line above accepts. The same veto tested the **whole lexeme**, so `e5` passed on the strength of the exponent's digit while `literalCastsUnder` rejected it.

```
value            audit before   cast     audit now
NaN/+INF/-INF    reject         accept   accept
e5/+e5/.e5       accept         reject   reject
''/'+'/'.'/'-'   reject         reject   reject
1.5              accept         accept   accept
```

The digit is now required in the **mantissa**, and the specials are exempt rather than swept up by the same rule. `XSD_NUMERIC_SPECIALS` is imported from `constraints/xsd-cast.ts` rather than restated, so the two sites cannot drift by someone editing one.

## A characterisation test had to be rewritten

`numeric-literal.test.ts` pinned "accepts exactly the lexical space it did before" with the oracle `/[0-9]/.test(v) && XS_DOUBLE_RE.test(v)` — the old decision, veto included. It existed to assert the behaviour this fix removes: left alone it goes red, edited carelessly it re-asserts the bug.

Its oracle now models the shared decision, and a new sweep asserts audit and cast are **equal** over the generated corpus rather than each matching a hand-written list. Review diffed old oracle against new across the full 1,118-string sample: **35 differences, every one in the two intended classes** (32 exponent-only forms flipping to reject, 3 specials flipping to accept), zero unexplained.

## Verification, and one claim I had to withdraw

```
baseline                      55 passed
whole-lexeme veto restored     8 failed
specials exemption removed     7 failed
veto removed entirely          8 failed
full revert to main's code    11 failed
one-sided change to the CAST   equality sweep reddens
```

Different counts for different mistakes, and the equality sweep has real one-sided teeth — mutating only the cast reddens it.

**The upstream corpus proves nothing here.** My first draft said "334-case corpus stays green (339 assertions)", which conflated two files, and the corpus contains zero enumerations carrying a special or an exponent-only lexeme — it is green before and after by construction. It is evidence nothing else broke, not evidence this works. The new behaviour is pinned by `numeric-literal.test.ts` and nothing else. (`ids-xsd-conformance.test.ts` cannot load here at all: `xmllint-wasm` is installed nowhere on this machine, identically on main. Review staged it and ran the file — 31 pass on this branch.)

## Scope notes

`xs:float` and `xs:decimal` share this function and also flip on the specials. That is upstream parity, not XSD: upstream's `XsTypes.cs` routes `XsDouble`, `XsFloat` **and** `XsDecimal` to the same `regexDouble`, which carries `NaN|\+INF|-INF`. XSD proper excludes those from decimal, but this file's stated contract is "mirrors upstream `XsTypes.IsValid`". Neither facet ever emits those two bases in production, so no user-visible cast-vs-audit gap is created.

The comment on the veto is short because the module-size ratchet is real — the first draft pushed the file to 482 lines against a 469 budget, and the gate says shrink rather than raise.

Also corrects a comment this change falsifies: `xsd-cast-specials.test.ts` described the exponent-only disagreement as live and needing an audit follow-up. This is that follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of `xs:double`, `xs:float`, and `xs:decimal` values.
  * Valid special values such as `NaN`, `+INF`, and `-INF` remain accepted.
  * Invalid exponent-only, sign-only, empty, and digit-free mantissa forms are now rejected consistently.

* **Tests**
  * Added coverage ensuring auditing and casting apply matching numeric validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->