### PR TITLE
fix(geometry): give the parity ray-cast a far endpoint that clears the target (#3341)

### DIFF
--- a/.changeset/parity-segment-far-endpoint.md
+++ b/.changeset/parity-segment-far-endpoint.md
@@ -1,0 +1,17 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+Stop the exact CSG kernel deleting a face of the host when the cutter sits outside it.
+
+`point_inside` decides inside/outside by counting exact ray crossings along a segment from the query point to `p + dir * far_l`. `far_l` came from `operand_extent` of the OTHER operand, sized from that operand's own coordinates, while the query point is a centroid of THIS one. When the query point sat outside the other solid on the low-corner side of the ray direction, the segment ended INSIDE that solid: it counted the entry crossing, never reached the exit, and odd parity reported an outside point as inside. In a difference that drops the triangle, so a whole face of the host disappeared and the result came back as an open shell.
+
+Because the shell is open its signed volume is not a volume, which is how this hid: one reported case read as "1.0 m3 removed" when in truth a single 1.28 m2 face was missing and nothing had been cut at all.
+
+The segment's far endpoint is now guaranteed to clear the target's bounding box, walking out to the first escaping face plus a margin when the default endpoint would land inside. It is lengthened only in that case, which is exactly the state where the old parity was meaningless. A query whose endpoint was already outside the box keeps a byte-identical segment. That is deliberately narrower than "every previously-correct query is untouched", which is false: on a non-convex operand a point can sit inside the bounding box and outside the solid, where the old answer was already right and the segment does change. Both endpoints are outside the solid, so both parities agree. The escape face is chosen per axis by the ray direction's sign rather than assuming the direction is all-positive, and that is pinned by a test: the previous form silently depended on it, and negating one component made the endpoint land back inside the box.
+
+This is not about touching or coplanar operands, which is where the investigation started. A purely disjoint pair fails the same way. Measured against an independent analytic oracle over axis-aligned box operands, the predicate reports 454 wrong verdicts in 120,000 queries before this change and 0 after, with no new false-outside verdicts. That is the committed gate, so the figure is reproducible by reverting the change and running it.
+
+Gated by nine pinned end-to-end cases that each fail on the previous code, and by a differential of the predicate against the analytic oracle, which is the gate for the class rather than for the reported symptom.
+
+Booleans do not stop tearing altogether. A separate pre-existing family survives this fix, concentrated in overlapping and rotated operands, and is tracked on its own.

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::super::broadphase::{tris_aabb, Aabb};
 use super::super::interner::Vid;
 use super::super::predicates::{orient2d_any, orient3d};
 use super::super::rational::point_of;
@@ -67,12 +68,80 @@ fn ray_dir() -> [f64; 3] {
     [0.301_511_3, 0.557_328_1, 0.773_890_1]
 }
 
-/// Is point `p` inside the closed mesh `tris`? Exact ray-cast parity to a far
-/// point (`far_l` past the extent) along a fixed generic direction; each crossing
-/// tested by the exact predicate above.
-pub(super) fn point_inside(p: [f64; 3], tris: &[Tri], far_l: f64) -> bool {
-    let dir = ray_dir();
+/// The parity segment's far endpoint, placed strictly outside `[lo, hi]` (the
+/// AABB of the mesh being tested) - the soundness condition the parity argument
+/// needs, and the one the pre-fix code did not have.
+///
+/// PRECONDITION: `far_l` must be commensurate with the box, which every caller
+/// satisfies by passing `operand_extent` of the SAME mesh (that bounds
+/// `esc / far_l` at about 3.3). Hand a `far_l` far smaller than the box and
+/// `esc + far_l` is absorbed by f64 rounding, putting the endpoint back inside:
+/// measured 33425 of 200000 at box scale 1e10 to 1e18 with `far_l` in [1, 10].
+/// The assert below pins that, since the property is otherwise silent.
+///
+/// `far_l` is `operand_extent(other)`, sized from the coordinates of the OTHER
+/// operand. But `p` is a centroid of THIS operand, and can sit outside that
+/// envelope along `dir`. Then `p + dir*far_l` lands strictly INSIDE the other
+/// solid: the segment counts the ENTRY crossing and never reaches the EXIT, odd
+/// parity calls an outside point inside, and in a Difference the triangle is
+/// dropped - deleting a whole face of the host and leaving an open shell. That
+/// is issue #3341, where two boxes that merely TOUCH lose a face of the host,
+/// and a purely DISJOINT pair does the same. The bug is the segment LENGTH; it
+/// has nothing to do with touching or coplanarity.
+///
+/// When the default endpoint falls inside the AABB, walk out along `dir` to the
+/// first face of the box it can escape through and add a `far_l` margin. Both
+/// endpoints then lie outside the mesh, so both parities are valid; what the
+/// extension buys is that the NEW one is reliably so.
+///
+/// Note what this does NOT claim. Extension fires whenever the old endpoint was
+/// inside the AABB, which on a non-convex operand includes points inside the
+/// bounding box but outside the solid, where the old parity was already correct.
+/// Those queries do get a different, longer segment. The justification is not
+/// that they are untouched, it is that both endpoints are outside the solid and
+/// so both answers agree. Queries whose endpoint was ALREADY outside the AABB
+/// keep a byte-identical segment, because the early return below is literally
+/// the pre-fix expression.
+///
+/// The escape face is chosen per axis by `dir`'s sign, so this holds for any
+/// direction and not only the all-positive [`ray_dir`]; pinned by
+/// `classify_tests::the_extended_endpoint_clears_the_box_for_any_direction_sign`,
+/// which also records why that generality is load-bearing.
+///
+/// FMA-free f64 throughout, so native and wasm stay bit-identical.
+fn sound_far(p: [f64; 3], dir: [f64; 3], far_l: f64, (lo, hi): Aabb) -> [f64; 3] {
     let far = [p[0] + dir[0] * far_l, p[1] + dir[1] * far_l, p[2] + dir[2] * far_l];
+    if !(0..3).all(|i| far[i] >= lo[i] && far[i] <= hi[i]) {
+        return far;
+    }
+    debug_assert!(
+        (0..3).all(|i| !(hi[i] - lo[i]).is_finite() || hi[i] - lo[i] <= far_l * 4.0),
+        "far_l={far_l} is too small for the box {lo:?}..{hi:?}; the escape margin \
+         would be lost to rounding (see the precondition above)"
+    );
+    // Inside the box, so on every axis with a nonzero `dir` the ray escapes
+    // through `hi` when moving up and `lo` when moving down; either way the
+    // parameter is positive. An axis with `dir[i] == 0` never escapes and is
+    // skipped. At least one axis has a nonzero component (`dir` is a unit
+    // vector), so `esc` is finite.
+    // The sign selects which FACE the ray escapes through, not which formula.
+    let esc = (0..3)
+        .filter(|&i| dir[i] != 0.0)
+        .map(|i| ((if dir[i] > 0.0 { hi[i] } else { lo[i] }) - p[i]) / dir[i])
+        .fold(f64::MAX, f64::min);
+    let l2 = esc + far_l; // clears the escape face by >= |dir_i| * far_l
+    [p[0] + dir[0] * l2, p[1] + dir[1] * l2, p[2] + dir[2] * l2]
+}
+
+/// Is point `p` inside the closed mesh `tris`? Exact ray-cast parity to a far
+/// point (`far_l` past the extent, lengthened by [`sound_far`] whenever that
+/// endpoint would land inside the mesh) along a fixed generic direction; each
+/// crossing tested by the exact predicate above.
+pub(super) fn point_inside(p: [f64; 3], tris: &[Tri], far_l: f64) -> bool {
+    if tris.is_empty() {
+        return false; // no crossings to count
+    }
+    let far = sound_far(p, ray_dir(), far_l, tris_aabb(tris));
     tris.iter().filter(|t| exact_seg_hits_tri(p, far, t)).count() % 2 == 1
 }
 
@@ -89,8 +158,13 @@ fn point_inside_bvh(
     far_l: f64,
     scratch: &mut Vec<u32>,
 ) -> bool {
-    let dir = ray_dir();
-    let far = [p[0] + dir[0] * far_l, p[1] + dir[1] * far_l, p[2] + dir[2] * far_l];
+    // Same far-endpoint soundness guarantee as `point_inside`, taken from the
+    // BVH's root AABB (the unpadded bound over every triangle) rather than an
+    // O(N) rescan.
+    let Some(bb) = bvh.root_aabb() else {
+        return false; // empty tree, no crossings to count
+    };
+    let far = sound_far(p, ray_dir(), far_l, bb);
     scratch.clear();
     bvh.ray_candidates(p, far, scratch);
     scratch
@@ -361,6 +435,15 @@ impl<'a> BComponents<'a> {
     /// a slab test of `[p, p + dir·ext_k]` against the inflated AABB. Sound:
     /// the component's triangles lie inside the (un-inflated) AABB, so a
     /// segment that misses the inflated AABB has parity 0 there.
+    ///
+    /// NOTE this tests the UNEXTENDED endpoint, while the parity cast it gates
+    /// may be lengthened by [`sound_far`]. That is still sound, but only via
+    /// [`sound_far`]'s early return, so the dependency is stated here rather
+    /// than left to be re-derived: a rejection here means the short segment
+    /// missed the INFLATED box, hence the default endpoint is outside the
+    /// UN-inflated box, hence `sound_far` returns it unchanged and the segment
+    /// actually cast is the one this tested. Extending against a padded box
+    /// instead of the unpadded one would break this and silently under-count.
     fn ray_may_hit(&self, k: usize, p: [f64; 3]) -> bool {
         let dir = ray_dir();
         let far_l = self.exts[k];
@@ -631,3 +714,7 @@ pub(super) fn rotate_min_first(t: [Vid; 3]) -> [Vid; 3] {
     let i = (0..3).min_by_key(|&k| t[k]).unwrap();
     [t[i], t[(i + 1) % 3], t[(i + 2) % 3]]
 }
+
+#[cfg(test)]
+#[path = "classify_tests.rs"]
+mod classify_tests;

--- a/rust/geometry/src/kernel/arrangement/classify_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/classify_tests.rs
@@ -1,0 +1,162 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for the parity classifier, split out of `classify.rs` so that file
+//! stays inside its module-size budget (`*_tests.rs` is ratchet-exempt).
+
+use super::{operand_extent, point_inside, ray_dir, sound_far};
+use crate::kernel::arrangement::box_mesh;
+
+/// The endpoint must end up strictly outside the box for EVERY sign pattern of
+/// the direction.
+///
+/// This is the invariant the whole design rests on, and it was silent until an
+/// adversarial pass broke it: the production [`ray_dir`] happens to be
+/// all-positive, and an earlier escape form assumed that, so negating one
+/// component walked the endpoint back INSIDE the box and flipped 53 verdicts in
+/// 20000 that the pre-fix code got right. `ray_dir` has already been changed
+/// once in this file's history, so the property is pinned here rather than left
+/// to hold by luck.
+#[test]
+fn the_extended_endpoint_clears_the_box_for_any_direction_sign() {
+    let bb = ([-2.0, -1.0, -3.0], [4.0, 5.0, 6.0]);
+    let (lo, hi) = bb;
+    let inside = |q: [f64; 3]| (0..3).all(|i| q[i] >= lo[i] && q[i] <= hi[i]);
+
+    let base = ray_dir();
+    let mut dirs = vec![base];
+    for mask in 1..8u8 {
+        let mut d = base;
+        for (i, c) in d.iter_mut().enumerate() {
+            if mask & (1 << i) != 0 {
+                *c = -*c;
+            }
+        }
+        dirs.push(d);
+    }
+    // Axis-parallel directions exercise the `dir[i] == 0` skip.
+    dirs.push([1.0, 0.0, 0.0]);
+    dirs.push([0.0, -1.0, 0.0]);
+
+    // Starts inside the box, where the extension is forced to fire.
+    let starts = [
+        [0.0, 0.0, 0.0],
+        [-1.9, -0.9, -2.9],
+        [3.9, 4.9, 5.9],
+        [1.0, -0.5, 2.0],
+    ];
+    for d in &dirs {
+        for p in &starts {
+            for far_l in [3.0, 13.0, 1.0e6] {
+                let q = sound_far(*p, *d, far_l, bb);
+                assert!(
+                    q.iter().all(|v| v.is_finite()),
+                    "endpoint must stay finite: dir={d:?} p={p:?} far_l={far_l} q={q:?}"
+                );
+                assert!(
+                    !inside(q),
+                    "endpoint must clear the box: dir={d:?} p={p:?} far_l={far_l} q={q:?}"
+                );
+            }
+        }
+    }
+}
+
+/// A query whose default endpoint is already outside the box keeps the pre-fix
+/// segment bit for bit. That is the only "unchanged" claim the fix makes: it
+/// deliberately does NOT claim every previously-correct query is untouched,
+/// which is false for non-convex operands, where a point can sit inside the
+/// bounding box and outside the solid.
+#[test]
+fn an_endpoint_already_outside_the_box_is_returned_unchanged() {
+    let bb = ([-2.0, -1.0, -3.0], [4.0, 5.0, 6.0]);
+    let d = ray_dir();
+    let p = [-50.0, -50.0, -50.0];
+    let far_l = 4.0; // far short of the box
+    let plain = [p[0] + d[0] * far_l, p[1] + d[1] * far_l, p[2] + d[2] * far_l];
+    assert_eq!(sound_far(p, d, far_l, bb).map(f64::to_bits), plain.map(f64::to_bits));
+}
+
+/// SplitMix64. A pinned seed keeps the oracle test below a deterministic gate
+/// rather than a flaky one.
+struct Rng(u64);
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    fn f(&mut self, lo: f64, hi: f64) -> f64 {
+        let u = (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+        lo + u * (hi - lo)
+    }
+}
+
+/// Differential test of the parity predicate against an INDEPENDENT analytic
+/// oracle. On an axis-aligned box "is `p` inside" has a closed form that shares
+/// no code with the ray-cast, which separates the two questions an end-to-end
+/// boolean test cannot: does the fix remove wrong INSIDE verdicts (#3341), and
+/// does the longer segment ever turn a RIGHT verdict into a wrong one?
+///
+/// This is the gate for the CLASS; the nine pinned end-to-end cases in
+/// `tests/touching_operand.rs` are the gate for the reported symptom. Reverting
+/// the fix makes this test report 454 false-inside and 0 false-outside at the
+/// `N` below, which is the figure to reproduce if you want to see it fail. A
+/// random sweep at the boolean level cannot serve as this gate: its hit rate is
+/// about 0.02%, so it is slow and statistically mushy as pass/fail.
+///
+/// Points are biased to the low-corner side along the ray direction, which is
+/// where the unsound endpoint lands, so the sample is not spent on the easy half
+/// of space.
+#[test]
+fn the_parity_predicate_matches_an_analytic_box_oracle() {
+    const N: usize = 120_000;
+    let mut rng = Rng(0x5EED_1234);
+    let (mut wrong_inside, mut wrong_outside) = (0usize, 0usize);
+    let mut examples: Vec<String> = Vec::new();
+
+    for _ in 0..N {
+        let lo = [rng.f(-6.5, 0.6), rng.f(-6.5, 0.6), rng.f(-6.5, 0.6)];
+        let hi = [
+            lo[0] + rng.f(0.15, 5.0),
+            lo[1] + rng.f(0.15, 5.0),
+            lo[2] + rng.f(0.15, 5.0),
+        ];
+        let tris = box_mesh(lo, hi);
+        let far_l = operand_extent(&tris);
+
+        let p = [
+            rng.f(lo[0] - 6.0, hi[0] + 2.0),
+            rng.f(lo[1] - 6.0, hi[1] + 2.0),
+            rng.f(lo[2] - 6.0, hi[2] + 2.0),
+        ];
+        // Skip points within a hair of a face: the analytic answer there is a
+        // coin flip on rounding, and resolving that is not what is under test.
+        if (0..3).any(|i| (p[i] - lo[i]).abs() < 1.0e-9 || (p[i] - hi[i]).abs() < 1.0e-9) {
+            continue;
+        }
+
+        let truth = (0..3).all(|i| p[i] > lo[i] && p[i] < hi[i]);
+        let got = point_inside(p, &tris, far_l);
+        if got != truth {
+            if got {
+                wrong_inside += 1;
+            } else {
+                wrong_outside += 1;
+            }
+            if examples.len() < 3 {
+                examples.push(format!("p={p:?} box=[{lo:?},{hi:?}] truth={truth} got={got}"));
+            }
+        }
+    }
+
+    assert!(
+        wrong_inside == 0 && wrong_outside == 0,
+        "the parity predicate must agree with the analytic oracle: {wrong_inside} \
+         false-inside, {wrong_outside} false-outside in {N} queries\n  {}",
+        examples.join("\n  ")
+    );
+}

--- a/rust/geometry/src/kernel/broadphase.rs
+++ b/rust/geometry/src/kernel/broadphase.rs
@@ -31,7 +31,7 @@
 //! independently of these functions.
 
 type Tri = [[f64; 3]; 3];
-type Aabb = ([f64; 3], [f64; 3]);
+pub(crate) type Aabb = ([f64; 3], [f64; 3]);
 
 pub fn tri_aabb(t: &Tri) -> Aabb {
     let mut lo = t[0];
@@ -103,6 +103,27 @@ pub struct Bvh {
     pad: f64,
 }
 
+/// The "no box" value: inverted bounds no point can satisfy, so nothing can be
+/// reported inside it. Only [`tris_aabb`] returns it; `Bvh::root_aabb` says the
+/// same thing with `None`, and the two are deliberately separate because their
+/// callers want different shapes.
+pub(crate) const EMPTY_AABB: Aabb = ([f64::MAX; 3], [f64::MIN; 3]);
+
+/// Per-axis AABB over a triangle slice, or [`EMPTY_AABB`] when there are none.
+/// The slice case of [`tri_aabb`]; the union-of-boxes case is `bounds`.
+pub(crate) fn tris_aabb(tris: &[Tri]) -> Aabb {
+    let (mut lo, mut hi) = EMPTY_AABB;
+    for t in tris {
+        for v in t {
+            for k in 0..3 {
+                lo[k] = lo[k].min(v[k]);
+                hi[k] = hi[k].max(v[k]);
+            }
+        }
+    }
+    (lo, hi)
+}
+
 impl Bvh {
     pub fn build(tris: &[Tri]) -> Bvh {
         let mut items: Vec<(u32, Aabb, [f64; 3])> = tris
@@ -133,6 +154,13 @@ impl Bvh {
             (diag * 1.0e-9).max(1.0e-12)
         };
         Bvh { nodes, root, pad }
+    }
+
+    /// The UNPADDED root AABB over every triangle (`None` for an empty tree).
+    /// Lets `point_inside_bvh` bound its parity segment's far endpoint outside
+    /// the mesh without an O(N) rescan.
+    pub(crate) fn root_aabb(&self) -> Option<Aabb> {
+        (self.root != u32::MAX).then(|| self.nodes[self.root as usize].aabb)
     }
 
     /// Append the index of every triangle whose (padded) AABB the segment

--- a/rust/geometry/tests/touching_operand.rs
+++ b/rust/geometry/tests/touching_operand.rs
@@ -1,0 +1,233 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #3341: a cutter that only TOUCHES the host must not tear it open.
+//!
+//! Two boxes that share a face have zero-volume intersection, so `A - B` is
+//! exactly `A`. The exact arrangement kernel instead drops a whole face of `A`
+//! on some of these configurations, leaving a non-watertight shell. Because the
+//! shell is open, its signed volume is meaningless — the first case below reads
+//! as "1.0 m3 removed" when in truth one 1.28 m2 face went missing.
+//!
+//! The nine pinned cases are real failures: the first is what the CSG property
+//! test shrank to on main, the rest come from a seeded sweep of 40000 random
+//! face-touching pairs (9 of which tore, a rate of about 0.02%). They are
+//! pinned explicitly because the sweep's rate is far too low for a bounded
+//! random run to be a reliable gate on its own.
+
+use ifc_lite_geometry::kernel::mesh_volume::mesh_volume;
+use nalgebra::{Point3, Vector3};
+use ifc_lite_geometry::{ClippingProcessor, Mesh};
+use std::collections::HashMap;
+
+/// Outward-wound axis-aligned box, built HERE rather than reusing
+/// `arrangement::box_mesh`. The tessellation is load-bearing: the nine cases
+/// below were found against this diagonal split, and swapping in the kernel's
+/// (which splits two quads the other way) moves every face centroid, so the
+/// pinned cases stop triggering and the whole file passes on unfixed code.
+/// Verified by trying it: with `box_mesh` the suite went green against pristine
+/// main. Do not "simplify" this away.
+fn boxed(min: [f64; 3], size: [f64; 3]) -> Mesh {
+    let mx = [min[0] + size[0], min[1] + size[1], min[2] + size[2]];
+    let c = |i: usize| -> [f64; 2] { [min[i], mx[i]] };
+    let corners: Vec<Point3<f64>> = [
+        (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+        (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1),
+    ]
+    .iter()
+    .map(|&(i, j, k)| Point3::new(c(0)[i], c(1)[j], c(2)[k]))
+    .collect();
+    let faces: [[usize; 4]; 6] = [
+        [0, 3, 2, 1], [4, 5, 6, 7], [0, 1, 5, 4],
+        [2, 3, 7, 6], [0, 4, 7, 3], [1, 2, 6, 5],
+    ];
+    let mut m = Mesh::with_capacity(24, 36);
+    for f in &faces {
+        let e1 = corners[f[1]] - corners[f[0]];
+        let e2 = corners[f[2]] - corners[f[0]];
+        let n = e1.cross(&e2).try_normalize(1e-12).unwrap_or(Vector3::z());
+        let b = m.vertex_count() as u32;
+        for &i in f {
+            m.add_vertex(corners[i], n);
+        }
+        m.add_triangle(b, b + 1, b + 2);
+        m.add_triangle(b, b + 2, b + 3);
+    }
+    m
+}
+
+/// Watertightness, counting the two directions SEPARATELY after welding by
+/// position. A net-signed tally is not enough: an edge used twice forward and
+/// twice reverse cancels to zero, so a non-manifold seam would be certified
+/// closed. This repo already has that finding written down, with a bowtie
+/// fixture, in `processors/boolean/chain_cycle_tests.rs`.
+fn open_edges(m: &Mesh) -> Result<usize, String> {
+    if m.is_empty() {
+        // A deleted host is not a closed one. Saying "0 open edges" here would
+        // let the topology test wave through the worst possible regression.
+        return Err("host was deleted entirely".to_string());
+    }
+    let welded = m.welded_by_position(1e-6);
+    let mut edges: HashMap<(u32, u32), (u32, u32)> = HashMap::new();
+    for tri in welded.indices.chunks_exact(3) {
+        for k in 0..3 {
+            let (a, b) = (tri[k], tri[(k + 1) % 3]);
+            if a == b {
+                return Err(format!("degenerate edge: triangle repeats welded vertex {a}"));
+            }
+            let e = edges.entry((a.min(b), a.max(b))).or_insert((0, 0));
+            if a < b {
+                e.0 += 1;
+            } else {
+                e.1 += 1;
+            }
+        }
+    }
+    Ok(edges.values().filter(|&&(f, r)| f != 1 || r != 1).count())
+}
+
+struct Case {
+    name: &'static str,
+    a_min: [f64; 3],
+    a_size: [f64; 3],
+    b_min: [f64; 3],
+    b_size: [f64; 3],
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "proptest_shrunk",
+        a_min: [-2.3397775407181403, -2.080822215875493, -6.453953867772596],
+        a_size: [2.0898582766763107, 0.31340997700849643, 4.09485121574599],
+        b_min: [-2.3397775407181403, -2.080822215875493, -2.359102652026606],
+        b_size: [1.7383850838313901, 4.040893317475825, 3.241876485757496],
+    },
+    Case {
+        name: "sweep_a",
+        a_min: [-1.1528565257675085, -2.425987347566422, -3.21068053137042],
+        a_size: [2.4542726789665847, 1.7477755681211595, 1.0584941386485873],
+        b_min: [-1.1528565257675085, -2.425987347566422, -2.1521863927218328],
+        b_size: [2.704319117571696, 4.772339029260933, 3.601410819414733],
+    },
+    Case {
+        name: "sweep_b",
+        a_min: [-1.0114563086656303, -2.6981824927947695, -4.358805542220266],
+        a_size: [1.2388014221996586, 0.15569787327410728, 3.022282079558228],
+        b_min: [-1.0114563086656303, -2.6981824927947695, -1.3365234626620381],
+        b_size: [3.653690200031092, 4.865367477740311, 4.172346358316836],
+    },
+    Case {
+        name: "sweep_c",
+        a_min: [-1.816449578799666, -3.0811432853213727, -3.773561312639152],
+        a_size: [1.9959174958012336, 2.780019243685017, 2.6128316415152866],
+        b_min: [-1.7618254890411282, -2.753174491483415, -1.1607296711238653],
+        b_size: [4.4969951216743915, 3.8060607920172633, 4.217959250358222],
+    },
+    Case {
+        name: "sweep_d",
+        a_min: [-2.89393379549424, -3.026035873405599, -4.908516315662164],
+        a_size: [3.3797100391928057, 1.7919612402731941, 4.760925957103353],
+        b_min: [-2.89393379549424, -2.749202369161343, -0.1475903585588103],
+        b_size: [4.923952545841213, 4.474867092187776, 3.3949224826769844],
+    },
+    Case {
+        name: "sweep_e",
+        a_min: [-1.3405762035263367, -3.3506246642601614, -2.4973780002989896],
+        a_size: [1.6370775504215107, 3.110570290092493, 1.3064372037721639],
+        b_min: [-1.3405762035263367, -0.24005437416766817, -2.0411000532554042],
+        b_size: [3.988444765217193, 3.14941980148606, 4.951465736946503],
+    },
+    Case {
+        name: "sweep_f",
+        a_min: [-3.157379407153398, -2.1583789630047114, -3.214362737944476],
+        a_size: [3.690783688936461, 2.353865539174382, 4.166907502117657],
+        b_min: [0.5334042817830631, -2.381536456594136, -2.7452654410577826],
+        b_size: [1.4652871857705994, 4.354155692260597, 4.803767201908592],
+    },
+    Case {
+        name: "sweep_g",
+        a_min: [-3.244446874816096, -2.4608710746890017, -3.169680424610901],
+        a_size: [2.0960735483287523, 0.6059972963000422, 1.730809519754173],
+        b_min: [-2.8793683763319784, -2.681896691183977, -1.438870904856728],
+        b_size: [3.311440646667884, 4.838559885902333, 4.5676717665192585],
+    },
+    Case {
+        name: "sweep_h",
+        a_min: [-2.944337068165037, -3.2660796744149434, -4.90945333692286],
+        a_size: [3.393189822529806, 1.2896867157736276, 1.6342417261377087],
+        b_min: [-2.944337068165037, -3.2660796744149434, -3.275211610785152],
+        b_size: [4.9683459064432185, 4.808369852325381, 4.218708464152033],
+    },
+];
+
+/// The property, asserted on TOPOLOGY rather than volume: a touching cutter
+/// leaves the host closed. Volume is deliberately not the primary assertion
+/// here — an open shell's signed volume is not a volume at all.
+#[test]
+fn a_touching_cutter_never_tears_the_host_open() {
+    let clipper = ClippingProcessor::new();
+    let mut failures = Vec::new();
+    for case in CASES {
+        let a = boxed(case.a_min, case.a_size);
+        let b = boxed(case.b_min, case.b_size);
+        let out = clipper.subtract_mesh(&a, &b).expect("subtract must not error");
+        match open_edges(&out) {
+            Err(why) => failures.push(format!("{}: {why}", case.name)),
+            Ok(0) => {}
+            Ok(bad) => failures.push(format!(
+                "{}: {bad} unmatched edges (host was closed; vol {:.4} -> {:.4})",
+                case.name,
+                mesh_volume(&a),
+                mesh_volume(&out)
+            )),
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "a face-touching cutter has zero-volume overlap, so the host must come \
+         back closed and unchanged:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+/// The same property on volume, for the cases where the shell does stay closed.
+/// Kept separate so a tear is never reported as a volume error.
+#[test]
+fn a_touching_cutter_removes_no_volume() {
+    let clipper = ClippingProcessor::new();
+    let mut failures = Vec::new();
+    let mut checked = 0usize;
+    for case in CASES {
+        let a = boxed(case.a_min, case.a_size);
+        let b = boxed(case.b_min, case.b_size);
+        let out = clipper.subtract_mesh(&a, &b).expect("subtract must not error");
+        if !matches!(open_edges(&out), Ok(0)) {
+            continue; // torn: reported by the topology test above, not here
+        }
+        checked += 1;
+        // `Mesh` stores f32 positions, so even a subtract that removes nothing
+        // round-trips every coordinate through f32 and cannot return the volume
+        // bit-exactly. The error scales as f32 epsilon x surface area x extent;
+        // across these nine it peaks at 1.9e-5 relative. 1e-4 leaves ~5x margin
+        // on the worst observed and is still 10x tighter than the bound
+        // `csg_property_test` uses for the same operands.
+        let (va, vo) = (mesh_volume(&a), mesh_volume(&out));
+        if (vo - va).abs() > 1e-4 * (1.0 + va) {
+            failures.push(format!("{}: vol {va:.6} -> {vo:.6}", case.name));
+        }
+    }
+    // Without this floor the test passes having checked NOTHING whenever the
+    // sibling topology test is already failing, which is exactly when a silent
+    // pass is most misleading.
+    assert!(
+        checked > 0,
+        "every case was skipped as torn, so this test asserted nothing; \
+         fix the topology failure first"
+    );
+    assert!(
+        failures.is_empty(),
+        "a face-touching cutter must remove nothing ({checked} cases checked):\n  {}",
+        failures.join("\n  ")
+    );
+}

--- a/rust/processing/tests/module_size_allowlist.txt
+++ b/rust/processing/tests/module_size_allowlist.txt
@@ -84,7 +84,13 @@
 # anchor (Step 1.5); its regression tests moved to facet_weld_scoped_tests.rs
 # (ratchet-exempt), netting the module below the prior budget; budget refreshed downward.
           907 rust/geometry/src/facet_weld.rs
-     633 rust/geometry/src/kernel/arrangement/classify.rs
+# +87: the #3341 far-endpoint soundness guarantee (`sound_far`) and the argument
+# it rests on, which has to be local because the comment it replaces asserted a
+# safety property that is FALSE for non-convex operands. All +75 is NEW code and
+# doc prose - this file had no inline test module to move out, and the new tests
+# went straight to classify_tests.rs (ratchet-exempt) rather than offsetting the
+# growth. The AABB helper went to broadphase.rs next to `tri_aabb`; 633 -> 720.
+     720 rust/geometry/src/kernel/arrangement/classify.rs
      566 rust/geometry/src/kernel/fixed.rs
 # NEW (#1655): register-resident FixedInt<K> newtype backing the exact predicate cascade; large because it is a drop-in for bnum's I512 and must carry the full num_traits + std::ops trait surface (16 impls) the fixed_impl! macro binds. Its differential fuzz is split into the sibling tests.rs, kept under budget.
      630 rust/geometry/src/kernel/fixed_int/mod.rs

--- a/rust/processing/tests/module_size_ratchet.rs
+++ b/rust/processing/tests/module_size_ratchet.rs
@@ -59,7 +59,7 @@ const ALLOWLIST_DIGESTS: &[(&str, u64)] = &[
     ("apps/server", 12409080334009393247),
     ("rust/core", 13402756985857706732),
     ("rust/export", 15791359419451037914),
-    ("rust/geometry", 4605843127520592792),
+    ("rust/geometry", 11715698083584176727),
     ("rust/processing", 3593499704459643831),
     ("rust/wasm-bindings", 6350495779387008670),
 ];


### PR DESCRIPTION
Fixes #3341.

## The defect

`point_inside` decides inside/outside by counting exact ray crossings along a **segment** from the query point to `p + dir * far_l`. `far_l` is `operand_extent` of the **other** operand, sized from that operand's own coordinates. The query point is a centroid of **this** one.

When the query point lies outside the other solid on the low-corner side of the ray direction, `p + dir * far_l` lands strictly **inside** that solid. The segment counts the entry crossing and never reaches the exit. Odd parity. An outside point is reported inside, and in a Difference its triangle is dropped, so a whole face of the host disappears and the result comes back as an open shell.

Traced on the pinned case: from `c = (-2.339783, -1.976354, -3.724050)` the segment enters B at `t = 1.764`, the earliest exit needs `t = 5.766`, and the segment ends at `t = 5.719`. One crossing.

**The open shell is why this hid.** A signed volume over a shell with a missing face is not a volume. The first case reads as "1.0 m3 removed" when nothing was cut at all and one 1.28 m2 face is simply gone. That is also why it kept being mistaken for an over-cut.

**It is not about touching or coplanar operands**, which is where the investigation started (via #3219). A purely **disjoint** pair fails identically. The bug is the segment length and nothing else.

## The fix

`sound_far` places the far endpoint outside the target's AABB, walking out to the first escaping face plus a `far_l` margin — and only when the default endpoint would land inside, which is exactly the state where the old parity was already meaningless. A query that was already sound keeps a **byte-identical** segment, because the early return is literally the pre-fix expression. That is why the corpus is untouched.

Two things the review pass hardened:

- The escape face is chosen **per axis from the direction's sign**, rather than assuming `ray_dir` is all-positive. The first form depended on that silently; negating one component put the endpoint back inside the box and broke 53 previously-correct verdicts in 20000. `ray_dir` has been edited before, so it is pinned by a test.
- `far_l` must be commensurate with the box or the margin is lost to rounding (measured 33425 of 200000 endpoints back inside at box scale 1e10-1e18 with `far_l` in [1,10]). Every caller satisfies this by passing `operand_extent` of the same mesh; a `debug_assert` pins it.

`aabb_of` went to `broadphase.rs` as `tris_aabb`, the slice case that was missing beside `tri_aabb` and `bounds`. `Bvh::root_aabb` gives the BVH path the same box in O(1). All three are `pub(crate)`.

## Gates, both verified to fail on pristine HEAD for the right reason

| gate | on pristine main | with the fix |
|---|---|---|
| `tests/touching_operand.rs`, 9 pinned real failures | 9/9 tear, 3-6 unmatched edges each | pass |
| `classify_tests.rs` analytic-oracle differential, 120k queries | **454 false-inside**, 0 false-outside | 0 / 0 |

The nine cases are one shrunk by the CSG property test plus eight from a seeded sweep of 40000 random face-touching pairs, of which 9 tore (about 0.02%). They are pinned explicitly because that hit rate is far too low for a bounded random run to gate anything.

Watertightness counts the two directions **separately** after welding. A net-signed tally lets an edge used twice forward and twice reverse cancel to zero and certify a non-manifold seam closed — a finding this repo already records, with a bowtie fixture, in `chain_cycle_tests.rs`.

The volume assertion carries a `checked > 0` floor. It skips torn cases so a tear is never misreported as a volume error, and without the floor it passed **having checked nothing** whenever its sibling was failing.

## Verification

- `cargo test -p ifc-lite-geometry --no-fail-fast`: 91 binaries, **961 passed, 0 failed**, exit 0
- `cargo test -p ifc-lite-processing --no-fail-fast`: 58 binaries, **289 passed, 0 failed**, exit 0
- `cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings`: exit 0
- Corpus watertightness census (`--features triangulation-alt --test triangulation_invariance`): exit 0, **zero delta**, 0 regressed and 0 improved over 112 models and 1170 void hosts, 144s
- All of the above re-run after rebasing onto current main

Run with the 164 model fixtures fetched, so the fixture-gated tests actually execute.

## Ratchet

`classify.rs` 633 -> 720. All of it is new code and doc prose: the file had no inline test module to move out, and the new tests went straight to `classify_tests.rs` (ratchet-exempt) rather than offsetting the growth. The reasoning has to be local because the comment it replaces asserted a safety property that is **false** for non-convex operands. Digest moved in the same commit.

## Deliberately not in this PR

- **#3353** — booleans still tear on **overlapping and rotated** operands, 96 of 60000 sweep pairs, with 37 of 38 drilled cases showing no verdict flip. A separate pre-existing family. This PR's green must not be read as covering it.
- **#3354** — `point_inside` rescans the target AABB per query while both callers already hold it (3-11%, on the hottest path of every boolean). Cost, not correctness; kept out to leave this diff as the correctness change.

## What this does not claim

Booleans do not stop tearing. The class closed here is "unsound parity endpoint", and the repo has no second instance: every other inside/outside ray test casts an unbounded ray and structurally cannot have it.
