### PR TITLE
refactor(viewer): give each store slice a teardown(scope), and collapse the four hand-written teardown paths

### DIFF
--- a/apps/viewer/src/hooks/useClash.model-teardown-ownership.test.tsx
+++ b/apps/viewer/src/hooks/useClash.model-teardown-ownership.test.tsx
@@ -15,7 +15,7 @@
  *    click) clears both channels and owns neither afterwards, but leaves
  *    `clashSelectedId` set. The next owner to install a ghost had it destroyed
  *    by an unrelated model removal — and on the `syncSourceModel` path that IS
- *    the original #2654 regression, because `purgeStaleEntityState` runs one
+ *    the original #2654 regression, because the second purge runs one
  *    line later and reads `null`.
  *  - UNDER-CLEAR: `selectElement` (the chevron expand and the per-side button)
  *    installs a NON-EMPTY clash isolation through `applyFocusMode` and never
@@ -205,7 +205,7 @@ describe('removeModel releases the visibility channel clash OWNS (#2654 third re
 
     const s = useViewerStore.getState();
     assert.ok(s.ghostExceptEntities,
-      'clash disowned the channel in highlight mode — removing an unrelated model must not destroy the ghost the next owner installed. On the syncSourceModel path this is the original #2654 regression: purgeStaleEntityState runs one line later and reads null.');
+      'clash disowned the channel in highlight mode — removing an unrelated model must not destroy the ghost the next owner installed. On the syncSourceModel path this is the original #2654 regression: the second model-removed purge runs one line later and reads null.');
     assert.deepEqual([...s.ghostExceptEntities], [1], 'and must not filter it either — that is the resync purge\'s job');
   });
 

--- a/apps/viewer/src/lib/clash/visibility-ownership.ts
+++ b/apps/viewer/src/lib/clash/visibility-ownership.ts
@@ -24,7 +24,7 @@
  *    highlight mode, let LayerDiff / Space Sketch / X-ray install a ghost, then
  *    remove a model — that owner's ghost was destroyed. On the `syncSourceModel`
  *    path this is the original #2654 regression: `removeModel` nulls the ghost
- *    and `purgeStaleEntityState` one line later reads `null` and skips its
+ *    and the second model-removed purge one line later reads `null` and skips its
  *    filter, so "Sync from source" wipes the user's X-ray.
  *  - UNDER-CLEAR. `useClash.selectElement` installs a NON-EMPTY clash-owned
  *    isolation via `applyFocusMode` and never writes `clashSelectedId` (and
@@ -181,7 +181,7 @@ export interface ClashSceneTeardown extends ClashVisibilityChannels {
  *    kept (a list the user is reading, not scene geometry; a sibling leaving
  *    does not invalidate pairs that do not involve it), and the visibility
  *    release is ownership-scoped — `syncSourceModel` calls `removeModel` and
- *    then `purgeStaleEntityState`, which KEEPS the part of a surviving model's
+ *    then a stricter second run of the same scope, which KEEPS the part of a surviving model's
  *    X-ray and drops only the ids burned with the replaced one. Clearing a
  *    channel clash does not own makes that filter dead code on its only
  *    production path.

--- a/apps/viewer/src/lib/collab/room-model-apply.test.ts
+++ b/apps/viewer/src/lib/collab/room-model-apply.test.ts
@@ -20,12 +20,12 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult } from '@ifc-lite/geometry';
-import { createModelSlice, type ModelSlice, type ModelCrossSliceState } from '../../store/slices/modelSlice.js';
+import { createModelSlice, type ModelSlice } from '../../store/slices/modelSlice.js';
 import { createDataSlice, type DataSlice, type DataCrossSliceState } from '../../store/slices/dataSlice.js';
 import type { FederatedModel } from '../../store/types.js';
 import { applyRoomModelData } from './room-model-apply.js';
 
-type TestState = ModelSlice & ModelCrossSliceState & DataSlice & DataCrossSliceState;
+type TestState = ModelSlice & DataSlice & DataCrossSliceState;
 
 /** A marker store/geometry pair per model — identity is all the test compares. */
 function markerStore(tag: string): IfcDataStore {

--- a/apps/viewer/src/lib/collab/room-model-target.test.ts
+++ b/apps/viewer/src/lib/collab/room-model-target.test.ts
@@ -32,7 +32,7 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
-import { createModelSlice, type ModelSlice, type ModelCrossSliceState } from '../../store/slices/modelSlice.js';
+import { createModelSlice, type ModelSlice } from '../../store/slices/modelSlice.js';
 import { createDataSlice, type DataSlice, type DataCrossSliceState } from '../../store/slices/dataSlice.js';
 import type { FederatedModel } from '../../store/types.js';
 import {
@@ -48,7 +48,7 @@ import { getEntityCenter } from '../../utils/viewportUtils.js';
 import { buildGeometryResultFromMeshes } from './geometry-sync.js';
 import type { MeshData } from '@ifc-lite/geometry';
 
-type TestState = ModelSlice & ModelCrossSliceState & DataSlice & DataCrossSliceState & {
+type TestState = ModelSlice & DataSlice & DataCrossSliceState & {
   collabRoomModelId: string | null;
   /** `null` off a session, set the instant `startCollab` begins — see room-model-target.ts. */
   collabRoomId: string | null;

--- a/apps/viewer/src/lib/sources/syncSourceModel.test.ts
+++ b/apps/viewer/src/lib/sources/syncSourceModel.test.ts
@@ -478,7 +478,7 @@ describe('syncSourceModel — the revision id lands on the replacement model', (
 
 describe("syncSourceModel — a resync keeps the surviving half of the user's X-ray", () => {
   // Drives the REAL `removeModel`, not the harness stub. `removeModel` runs one
-  // line before `purgeStaleEntityState`, and the stub hid that: #2654 added an
+  // line before the second model-removed purge, and the stub hid that: #2654 added an
   // unconditional `clearGhost()` to `removeModel`, which made the purge's ghost
   // and isolation filters (syncSourceModel.ts:262-271) dead code on their only
   // production path — every sync silently wiped the user's X-ray — and every

--- a/apps/viewer/src/lib/sources/syncSourceModel.test.ts
+++ b/apps/viewer/src/lib/sources/syncSourceModel.test.ts
@@ -536,4 +536,47 @@ describe("syncSourceModel — a resync keeps the surviving half of the user's X-
       'a resync must not hide the sibling by dropping the isolation wholesale',
     );
   });
+
+  it("drops a burned id even when the REPLACEMENT's fresh range covers it", async () => {
+    // The one thing that distinguishes this purge from the teardown
+    // `removeModel` ran a line earlier: the replacement is ALREADY LOADED when
+    // `removeModel` runs, so its own survivor set contains the replacement and
+    // it keeps every id the replacement's range happens to cover. Nothing can
+    // legitimately reference the replacement yet, so an id that survived only
+    // by landing inside that fresh range is still stale, and this second pass
+    // — the one that excludes the replacement — is what drops it.
+    //
+    // The two tests above cannot see that: the default harness registers the
+    // replacement with `maxExpressId: 0`, so its range owns nothing but global
+    // id 0 and both pass whether or not the replacement is excluded. Here the
+    // replacement is given a range that COVERS the burned id, which is what
+    // makes the exclusion observable — drop it and 5 survives.
+    seedStore(makeModel({ idOffset: 0, maxExpressId: 100 }));
+    useViewerStore.setState({ ghostExceptEntities: new Set([5]) });
+    const h = makeHarness({}, async (_file, options) => {
+      const id = options?.modelId ?? 'replacement';
+      useViewerStore.setState((state) => {
+        const models = new Map(state.models);
+        models.set(id, makeModel({ id, name: 'replacement', idOffset: 0, maxExpressId: 100 }));
+        return { models };
+      });
+      return id;
+    });
+
+    await syncSourceModel({
+      modelId: MODEL_ID,
+      tag: makeTag(),
+      sourceHost: h.sourceHost,
+      addModel: h.addModel,
+      removeModel: realRemoveModel,
+    });
+
+    // `null`, not an empty Set: a non-null empty ghost set still reads as
+    // "X-ray active, nothing matches" and hides the whole scene.
+    assert.equal(
+      useViewerStore.getState().ghostExceptEntities,
+      null,
+      'an id burned with the replaced model must not be rescued by the replacement occupying its range',
+    );
+  });
 });

--- a/apps/viewer/src/lib/sources/syncSourceModel.test.ts
+++ b/apps/viewer/src/lib/sources/syncSourceModel.test.ts
@@ -480,7 +480,7 @@ describe("syncSourceModel — a resync keeps the surviving half of the user's X-
   // Drives the REAL `removeModel`, not the harness stub. `removeModel` runs one
   // line before the second model-removed purge, and the stub hid that: #2654 added an
   // unconditional `clearGhost()` to `removeModel`, which made the purge's ghost
-  // and isolation filters (syncSourceModel.ts:262-271) dead code on their only
+  // and isolation filters (now visibilitySlice.teardown.ts) dead code on their only
   // production path — every sync silently wiped the user's X-ray — and every
   // test here stayed green because the stub only deletes a map entry.
   const realRemoveModel = (id: string): void => { useViewerStore.getState().removeModel(id); };

--- a/apps/viewer/src/lib/sources/syncSourceModel.ts
+++ b/apps/viewer/src/lib/sources/syncSourceModel.ts
@@ -197,15 +197,12 @@ async function doSyncSourceModel({
   //
   // This is the SAME scope `removeModel` just ran, and used to be a
   // hand-written second copy of it (`purgeStaleEntityState`). The one
-  // difference is the third argument: the replacement is already loaded and
-  // holds a fresh offset range, so it must not count as a survivor. Nothing
-  // can legitimately reference it yet, and a stale id — notably an old overlay
-  // id, which range-filtering on the removed model's own range would let
-  // escape — can land inside that new range and silently mis-highlight an
-  // unrelated entity. `removeModel`'s own dispatch a moment ago DID count the
-  // replacement as a survivor and so kept exactly those ids; this stricter run
-  // is what drops them, which is why both runs are needed and neither is
-  // redundant. Drop the third argument and
+  // difference is the third argument, whose reasoning is on
+  // `modelRemovedScope`'s `notYetASurvivor` param rather than repeated here.
+  // The short version: `removeModel`'s own dispatch a moment ago counted the
+  // replacement as a survivor and so KEPT ids pointing into its fresh range;
+  // this stricter run is what drops them, which is why both runs are needed
+  // and neither is redundant. Drop the third argument and
   // `syncSourceModel.test.ts`'s "drops a burned id even when the REPLACEMENT's
   // fresh range covers it" is the one test that goes red — measured.
   //

--- a/apps/viewer/src/lib/sources/syncSourceModel.ts
+++ b/apps/viewer/src/lib/sources/syncSourceModel.ts
@@ -3,7 +3,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { SourceFile, SourceTag } from '@ifc-lite/plugin-api';
-import { useViewerStore, stringToEntityRef } from '@/store';
+import { useViewerStore } from '@/store';
+import { viewerTeardown } from '@/store/teardown-registry';
+import { modelRemovedScope } from '@/store/teardown-scope';
 import type { SourceHost } from '@/services/sources/source-host';
 import { recordDownloadedSourceFile } from './persistence';
 import { enqueueSourceLoad } from './loadQueue';
@@ -186,7 +188,37 @@ async function doSyncSourceModel({
   // slice), purge ids that pointed into its now-burned global-id range, and
   // restore the sibling collapse states addModel just collapsed.
   removeModel(modelId);
-  purgeStaleEntityState(modelId, replacementId);
+  // Then drop every stored entity id that no longer belongs to a surviving
+  // model: ids in the removed model's now-burned global-id range, its
+  // overlay-allocated ids ABOVE that range (StoreEditor duplicates, scripted
+  // adds), and per-model entries keyed by its model id. The replacement gets a
+  // new offset range, so none of these can be remapped — they must all go, or
+  // selection / isolation state dangles forever.
+  //
+  // This is the SAME scope `removeModel` just ran, and used to be a
+  // hand-written second copy of it (`purgeStaleEntityState`). The one
+  // difference is the third argument: the replacement is already loaded and
+  // holds a fresh offset range, so it must not count as a survivor. Nothing
+  // can legitimately reference it yet, and a stale id — notably an old overlay
+  // id, which range-filtering on the removed model's own range would let
+  // escape — can land inside that new range and silently mis-highlight an
+  // unrelated entity. `removeModel`'s own dispatch a moment ago DID count the
+  // replacement as a survivor and so kept exactly those ids; this stricter run
+  // is what drops them, which is why both runs are needed and neither is
+  // redundant. Drop the third argument and
+  // `syncSourceModel.test.ts`'s "drops a burned id even when the REPLACEMENT's
+  // fresh range covers it" is the one test that goes red — measured.
+  //
+  // Re-running a scope is safe by construction: every contribution returns
+  // `{}` when nothing of its own moved (`store/teardown.ts`), so this pass
+  // writes only what the first could not see. Applied through
+  // `useViewerStore.setState`, the setter
+  // `withVisibilityOwnershipInvalidation` wraps, so the shared isolate / ghost
+  // channels are still invalidated exactly as before.
+  const postRemoval = useViewerStore.getState();
+  useViewerStore.setState(
+    viewerTeardown(modelRemovedScope(postRemoval, modelId, replacementId), postRemoval),
+  );
 
   const postStore = useViewerStore.getState();
   for (const state of otherCollapseStates) {
@@ -211,102 +243,4 @@ async function doSyncSourceModel({
     latestFile,
     sourceTag: nextTag,
   };
-}
-
-/**
- * Drops every stored entity id that no longer belongs to any surviving model:
- * ids in the removed model's burned global-id range, its overlay-allocated
- * ids ABOVE that range (StoreEditor duplicates and scripted adds — see
- * modelSlice's resolveGlobalIdFromModels), and per-model entries keyed by its
- * model id. Purged state: selection, storeys, hidden/isolated/ghost sets, and
- * the Class-tab filter. The replacement model gets a new offset range, so
- * none of these can be remapped — they must all go, or selection / isolation
- * state dangles forever.
- *
- * Runs after the swap. A survivor is any model still in the store EXCEPT the
- * just-loaded replacement: nothing can legitimately reference the replacement
- * yet, and a stale id (notably an old overlay id, which range-filtering on
- * the removed model's own range would let escape) can land inside the
- * replacement's new range and silently mis-highlight an unrelated entity. An
- * id is kept iff a survivor owns it: inside its parse-time range, or an
- * overlay-allocated entity in its mutation view (mirrors the two-pass
- * resolution in resolveGlobalIdFromModels).
- */
-function purgeStaleEntityState(modelId: string, replacementId: string): void {
-  const state = useViewerStore.getState();
-  const mutationViews = state.mutationViews;
-  const survivors = Array.from(state.models.values())
-    .filter((model) => model.id !== replacementId)
-    .map((model) => ({
-      id: model.id,
-      idOffset: model.idOffset,
-      maxExpressId: model.maxExpressId,
-    }));
-
-  const isStale = (id: number): boolean => {
-    for (const survivor of survivors) {
-      const localId = id - survivor.idOffset;
-      if (localId < 0) continue;
-      if (localId <= survivor.maxExpressId) return false;
-      if (mutationViews.get(survivor.id)?.getNewEntity(localId) != null) return false;
-    }
-    return true;
-  };
-
-  const selectedEntityIds = new Set([...state.selectedEntityIds].filter((id) => !isStale(id)));
-  const selectedStoreys = new Set([...state.selectedStoreys].filter((id) => !isStale(id)));
-  const hiddenEntities = new Set([...state.hiddenEntities].filter((id) => !isStale(id)));
-
-  let isolatedEntities = state.isolatedEntities;
-  if (isolatedEntities) {
-    const kept = new Set([...isolatedEntities].filter((id) => !isStale(id)));
-    // An isolation that only referenced the removed model must clear entirely
-    // — an empty isolate set would hide everything.
-    isolatedEntities = kept.size > 0 ? kept : null;
-  }
-  let ghostExceptEntities = state.ghostExceptEntities;
-  if (ghostExceptEntities) {
-    const kept = new Set([...ghostExceptEntities].filter((id) => !isStale(id)));
-    ghostExceptEntities = kept.size > 0 ? kept : null;
-  }
-  // The Class-tab filter intersects into the visible set: left unpurged it
-  // would hold only burned ids after a sync, matching nothing — every element
-  // of the reloaded model would disappear. An emptied filter clears entirely.
-  let classFilter = state.classFilter;
-  if (classFilter) {
-    const kept = new Set([...classFilter.ids].filter((id) => !isStale(id)));
-    classFilter = kept.size > 0 ? { ids: kept, label: classFilter.label } : null;
-  }
-
-  const selectedEntitiesSet = new Set(
-    [...state.selectedEntitiesSet].filter((key) => stringToEntityRef(key).modelId !== modelId),
-  );
-  const selectedEntities = state.selectedEntities.filter((ref) => ref.modelId !== modelId);
-  const selectedEntity = state.selectedEntity?.modelId === modelId ? null : state.selectedEntity;
-  const activeStorey = state.activeStorey?.modelId === modelId ? null : state.activeStorey;
-
-  const hiddenEntitiesByModel = new Map(state.hiddenEntitiesByModel);
-  hiddenEntitiesByModel.delete(modelId);
-  const isolatedEntitiesByModel = new Map(state.isolatedEntitiesByModel);
-  isolatedEntitiesByModel.delete(modelId);
-
-  useViewerStore.setState({
-    selectedEntityIds,
-    selectedEntityId:
-      state.selectedEntityId !== null && isStale(state.selectedEntityId)
-        ? null
-        : state.selectedEntityId,
-    selectedStoreys,
-    activeStorey,
-    selectedEntity,
-    selectedEntities,
-    selectedEntitiesSet,
-    selectedModelId: state.selectedModelId === modelId ? null : state.selectedModelId,
-    hiddenEntities,
-    isolatedEntities,
-    ghostExceptEntities,
-    classFilter,
-    hiddenEntitiesByModel,
-    isolatedEntitiesByModel,
-  });
 }

--- a/apps/viewer/src/lib/sources/syncSourceModel.ts
+++ b/apps/viewer/src/lib/sources/syncSourceModel.ts
@@ -206,9 +206,12 @@ async function doSyncSourceModel({
   // `syncSourceModel.test.ts`'s "drops a burned id even when the REPLACEMENT's
   // fresh range covers it" is the one test that goes red — measured.
   //
-  // Re-running a scope is safe by construction: every contribution returns
-  // `{}` when nothing of its own moved (`store/teardown.ts`), so this pass
-  // writes only what the first could not see. Applied through
+  // Re-running a scope is safe: a contribution whose own state did not move
+  // returns `{}` (`store/teardown.ts`), so this pass writes little. Note the
+  // granularity — the gates are per SLICE, not per key, so a slice that did
+  // move re-emits its unchanged keys as equal-but-new collections (#3346).
+  // Safe, because every consumer of these keys compares by value, but it is
+  // not the no-op the per-slice rule alone would suggest. Applied through
   // `useViewerStore.setState`, the setter
   // `withVisibilityOwnershipInvalidation` wraps, so the shared isolate / ghost
   // channels are still invalidated exactly as before.

--- a/apps/viewer/src/lib/visibility/ownership.ts
+++ b/apps/viewer/src/lib/visibility/ownership.ts
@@ -46,10 +46,15 @@ export type VisibilityOwnership =
  * would be exact, but it is destroyed by every flow that snapshots and later
  * restores the channel with equal content in a fresh `Set` — Space Sketch's
  * open/close view capture (`useSpaceSceneFraming` clones the prior sets and
- * replays them through the cloning slice setters). A source-model resync used to
- * be the second such flow; since the teardown seam it returns `{}` rather than
- * rebuilding unchanged sets (`visibilitySlice.teardown.ts`, asserted by
- * `teardown.idempotence.test.ts`), so Space Sketch now carries this alone.
+ * replays them through the cloning slice setters) and a source-model resync
+ * (`syncSourceModel` rebuilds the kept sets even when nothing was filtered).
+ *
+ * The teardown seam did NOT retire the second one, and an earlier revision of
+ * this comment wrongly said it had. `visibilitySlice.teardown.ts` gates all six
+ * of its keys on ONE `touched` flag, so a stale id in `hiddenEntities` alone
+ * still emits a fresh, equal `isolatedEntities` (measured; #3346 tracks the
+ * per-key gate). Do not simplify `sameMembers` to reference identity on the
+ * strength of this paragraph: that reopens #2662 P2 on the resync path.
  * Under reference identity those flows silently converted a feature-owned
  * focus into "user" state, so the next run replaced the result set but left
  * the old presentation isolated/ghosted (#2662 P2). Value identity survives

--- a/apps/viewer/src/lib/visibility/ownership.ts
+++ b/apps/viewer/src/lib/visibility/ownership.ts
@@ -46,8 +46,10 @@ export type VisibilityOwnership =
  * would be exact, but it is destroyed by every flow that snapshots and later
  * restores the channel with equal content in a fresh `Set` — Space Sketch's
  * open/close view capture (`useSpaceSceneFraming` clones the prior sets and
- * replays them through the cloning slice setters) and a source-model resync
- * (`syncSourceModel` rebuilds the kept sets even when nothing was filtered).
+ * replays them through the cloning slice setters). A source-model resync used to
+ * be the second such flow; since the teardown seam it returns `{}` rather than
+ * rebuilding unchanged sets (`visibilitySlice.teardown.ts`, asserted by
+ * `teardown.idempotence.test.ts`), so Space Sketch now carries this alone.
  * Under reference identity those flows silently converted a feature-owned
  * focus into "user" state, so the next run replaced the result set but left
  * the old presentation isolated/ghosted (#2662 P2). Value identity survives

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -307,10 +307,10 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
     // the two could drift with nothing to notice. Now each value is stated
     // once, beside the initial value it has to agree with.
     //
-    // Applied through the store's own `set`, deliberately: that is the setter
-    // `withVisibilityOwnershipInvalidation` wraps, so nulling the shared
-    // isolate / ghost channels still drops the ownership records it makes
-    // stale (`store/visibility-invalidation.ts`).
+    // Through the store's own `set`, but do not over-read that: `composeTeardown`
+    // omits keys equal to live state, so on the usual reset (isolate/ghost already
+    // `null`) the ownership middleware never fires. The records are cleared by
+    // `idsFocusVisibilityOwned: null` and `endClashScenePresentation` below.
     set(viewerTeardown({ kind: 'session-reset' }, get()));
 
     // Clash (#2654 review) — same stale-model-reference class as the

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -307,10 +307,10 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
     // the two could drift with nothing to notice. Now each value is stated
     // once, beside the initial value it has to agree with.
     //
-    // Through the store's own `set`, but do not over-read that: `composeTeardown`
-    // omits keys equal to live state, so on the usual reset (isolate/ghost already
-    // `null`) the ownership middleware never fires. The records are cleared by
-    // `idsFocusVisibilityOwned: null` and `endClashScenePresentation` below.
+    // Through the store's own `set`, which `withVisibilityOwnershipInvalidation`
+    // wraps. It keys on PRESENCE (`'isolatedEntities' in patch`), and both
+    // channels sit in `NEVER_DROPPED` so the filter cannot remove them, so it
+    // fires on EVERY reset as the hand-written payload did. Keep that exemption.
     set(viewerTeardown({ kind: 'session-reset' }, get()));
 
     // Clash (#2654 review) — same stale-model-reference class as the

--- a/apps/viewer/src/store/index.ts
+++ b/apps/viewer/src/store/index.ts
@@ -25,7 +25,7 @@ import { createMeasurementSlice, type MeasurementSlice } from './slices/measurem
 import { createDataSlice, type DataSlice } from './slices/dataSlice.js';
 import { createModelSlice, type ModelSlice } from './slices/modelSlice.js';
 import { createMutationSlice, type MutationSlice } from './slices/mutationSlice.js';
-import { createDrawing2DSlice, getDefaultDisplayOptions, type Drawing2DSlice } from './slices/drawing2DSlice.js';
+import { createDrawing2DSlice, type Drawing2DSlice } from './slices/drawing2DSlice.js';
 import { createSheetSlice, type SheetSlice } from './slices/sheetSlice.js';
 import { createBcfSlice, type BCFSlice } from './slices/bcfSlice.js';
 import { createIdsSlice, type IDSSlice } from './slices/idsSlice.js';
@@ -53,20 +53,22 @@ import { createCollabSlice, type CollabSlice } from './slices/collabSlice.js';
 import { createAddElementSlice, type AddElementSlice } from './slices/addElementSlice.js';
 import { createSplitToolSlice, type SplitToolSlice } from './slices/splitToolSlice.js';
 import { createLevelDisplaySlice, type LevelDisplaySlice } from './slices/levelDisplaySlice.js';
-import { createPointCloudSlice, type PointCloudSlice, POINT_CLOUD_DEFAULTS } from './slices/pointCloudSlice.js';
+import { createPointCloudSlice, type PointCloudSlice } from './slices/pointCloudSlice.js';
 import { createUnitDisplaySlice, type UnitDisplaySlice } from './slices/unitDisplaySlice.js';
 import { createSpaceMouseSlice, type SpaceMouseSlice } from './slices/spaceMouseSlice.js';
 import { createLayerStackSlice, type LayerStackSlice } from './slices/layerStackSlice.js';
 import { createZonesSlice, type ZonesSlice } from './slices/zonesSlice.js';
 import { invalidateVisibleBasketCache } from './basketVisibleSet.js';
 import { withVisibilityOwnershipInvalidation } from './visibility-invalidation.js';
+// The composed teardown `resetViewerState` dispatches. Its own module rather
+// than this file: `slices/modelSlice.ts` is another entry point and this file
+// imports that slice, so a registry declared here would be a runtime cycle.
+import { viewerTeardown } from './teardown-registry.js';
 import {
   endClashScenePresentation,
   type ClashSceneTeardown,
 } from '@/lib/clash/visibility-ownership';
 
-// Import constants for reset function
-import { CAMERA_DEFAULTS, SECTION_PLANE_DEFAULTS, UI_DEFAULTS, getPersistedTypeVisibility, getPersistedTypeViewMode } from './constants.js';
 
 // Re-export types for consumers
 export type * from './types.js';
@@ -284,314 +286,36 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
     invalidateVisibleBasketCache();
     const [set, get] = args;
     // Drop the persisted "last section mode" (localStorage, survives closing
-    // the browser) together with the in-memory sectionPlane reset below —
-    // its 'cardinal' axis/position is geometry, meaningful only relative to
-    // the model that was loaded when it was saved. Leaving it in localStorage
-    // past this reset let a NEW model inherit the OLD model's cut position
-    // the next time the section tool was opened (#2939).
+    // the browser) together with the in-memory sectionPlane reset the section
+    // slice contributes below (`slices/sectionSlice.teardown.ts`) — its
+    // 'cardinal' axis/position is geometry, meaningful only relative to the
+    // model that was loaded when it was saved. Leaving it in localStorage past
+    // this reset let a NEW model inherit the OLD model's cut position the next
+    // time the section tool was opened (#2939). It stays HERE, not in that
+    // contribution: writing localStorage is a side effect, and a teardown is
+    // pure.
     clearLastSectionMode();
     // Measurements (#2641 review): the slice owns the full list of its own
     // fields to clear on a model switch — see resetAllMeasurementState's doc
     // comment (measurementSlice.ts) for why this must not be a field list
     // duplicated here.
     get().resetAllMeasurementState();
-    set({
-      // Selection (legacy)
-      selectedEntityId: null,
-      selectedEntityIds: new Set(),
-      selectedStoreys: new Set(),
-      // Drop the shared active storey — it references the outgoing model, so a
-      // new file must not inherit a stale storey for Solo / Space Sketch.
-      activeStorey: null,
+    // The payload is composed by the slices that own the fields
+    // (`store/teardown-registry.ts`). It used to be spelled out here instead,
+    // key by key, in a file that cannot see any slice — so every reset value
+    // was a second statement of a value the owning slice already declares, and
+    // the two could drift with nothing to notice. Now each value is stated
+    // once, beside the initial value it has to agree with.
+    //
+    // Applied through the store's own `set`, deliberately: that is the setter
+    // `withVisibilityOwnershipInvalidation` wraps, so nulling the shared
+    // isolate / ghost channels still drops the ownership records it makes
+    // stale (`store/visibility-invalidation.ts`).
+    set(viewerTeardown({ kind: 'session-reset' }, get()));
 
-      // Selection (multi-model)
-      selectedEntity: null,
-      selectedEntitiesSet: new Set(),
-      selectedEntities: [],
-      selectedModelId: null,
-
-      // Visibility (legacy)
-      hiddenEntities: new Set(),
-      isolatedEntities: null,
-      ghostExceptEntities: null,
-      classFilter: null,
-      // Re-read persisted toggles on every file load so a new model never
-      // reverts the user's visibility choices (e.g. "Show Annotations").
-      typeVisibility: getPersistedTypeVisibility(),
-      typeViewMode: getPersistedTypeViewMode(),
-
-      // Visibility (multi-model)
-      hiddenEntitiesByModel: new Map(),
-      isolatedEntitiesByModel: new Map(),
-
-      // Data
-      loading: false,
-      geometryStreamingActive: false,
-      geometryUpdateTick: 0,
-      progress: null,
-      geometryProgress: null,
-      metadataProgress: null,
-      error: null,
-      pendingColorUpdates: null,
-      pendingMeshColorUpdates: null,
-      // The backup those two restore FROM. Ids collide across models, so
-      // surviving a swap made RESET_COLORS paint the old model's colours onto
-      // the new one; first-write-wins made every later reset wrong too.
-      meshColorBackup: null,
-      // Drop any undrained GPU-instancing shards from the previous model so they
-      // can't be uploaded into the new scene under a rapid model switch.
-      pendingInstancedShards: null,
-
-      // Compare (#924): drop any stale diff result — it references models by
-      // id and the loaded set is changing. Keep panel visibility + A/B/scope
-      // choices (UI prefs); the user re-runs against the new set.
-      compareResult: null,
-      compareSelectedKey: null,
-      compareRunning: false,
-      compareError: null,
-
-      // Zones (#1810): keep the user-authored zone SETS (they persist across
-      // model loads, like clash presets), but drop the computed assignments —
-      // they're keyed by the OUTGOING model's global ids, and the single-model
-      // fallback (globalId === expressId) means the incoming model's ids can
-      // collide and read the old model's zone membership until the debounced
-      // recompute fires. Same stale-model-reference class as compareResult
-      // above; `useZoneAssignmentSync` recomputes against the new scene.
-      zoneAssignments: new Map(),
-      zoneAssignmentTiming: null,
-      // ... and the apportioned cubic metres computed off those assignments
-      // (#2508). `validEntry` only checks the ZONE revision, which a model swap
-      // does not move, so an entry that survives here is served against the
-      // incoming file — and the single-model fallback (globalId === expressId)
-      // means the new model's ids collide with the old one's. Same stale-model
-      // reference as `zoneAssignments` directly above; the two are one fact and
-      // must be dropped together.
-      zoneApportionment: new Map(),
-      // ... and drop any in-flight zone-edit session: leaving `editingZone`
-      // set would hand the incoming model live gizmo handles + picking for
-      // a zone the user was editing against the outgoing model.
-      editingZone: null,
-
-      // Hover/Context
-      hoverState: { entityId: null, screenX: 0, screenY: 0 },
-      contextMenu: { isOpen: false, entityId: null, screenX: 0, screenY: 0 },
-
-      // Section plane: reset axis/position/enabled/flipped (those are
-      // model-relative and meaningless when switching files), but PRESERVE
-      // the user's cap appearance preferences (showCap, showOutlines,
-      // capStyle). Those round-trip to localStorage via the slice's
-      // persistence helpers; clobbering them here was the cause of "my
-      // hatch / colour resets to defaults every time I open a file".
-      sectionPlane: {
-        ...get().sectionPlane,
-        axis:     SECTION_PLANE_DEFAULTS.AXIS,
-        position: SECTION_PLANE_DEFAULTS.POSITION,
-        enabled:  SECTION_PLANE_DEFAULTS.ENABLED,
-        flipped:  SECTION_PLANE_DEFAULTS.FLIPPED,
-      },
-
-      // Camera
-      cameraRotation: {
-        azimuth: CAMERA_DEFAULTS.AZIMUTH,
-        elevation: CAMERA_DEFAULTS.ELEVATION,
-      },
-      projectionMode: 'perspective' as const,
-
-      // UI
-      activeTool: UI_DEFAULTS.ACTIVE_TOOL,
-      editEnabled: false,
-      // Drop any one-shot bSDD "jump to property" focus armed before the load —
-      // a new file reuses ids ('legacy' + reassigned expressIds) so a stale
-      // focus could otherwise match an unrelated entity (issue #1107).
-      pendingPropertyFocus: null,
-      visualEnhancementsEnabled: UI_DEFAULTS.VISUAL_ENHANCEMENTS_ENABLED,
-      edgeContrastEnabled: UI_DEFAULTS.EDGE_CONTRAST_ENABLED,
-      edgeContrastIntensity: UI_DEFAULTS.EDGE_CONTRAST_INTENSITY,
-      contactShadingQuality: UI_DEFAULTS.CONTACT_SHADING_QUALITY,
-      contactShadingIntensity: UI_DEFAULTS.CONTACT_SHADING_INTENSITY,
-      contactShadingRadius: UI_DEFAULTS.CONTACT_SHADING_RADIUS,
-      separationLinesEnabled: UI_DEFAULTS.SEPARATION_LINES_ENABLED,
-      separationLinesQuality: UI_DEFAULTS.SEPARATION_LINES_QUALITY,
-      separationLinesIntensity: UI_DEFAULTS.SEPARATION_LINES_INTENSITY,
-      separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
-
-      // Cesium
-      cesiumAvailable: false,
-      cesiumEnabled: false,
-      cesiumTerrainHeight: null,
-      // The snap target is model-specific terrain state; drop it with the
-      // sampled height so a new file can't reuse the old target (#1456).
-      cesiumTerrainSaveHeight: null,
-      cesiumSourceModelId: null,
-      // A new file is orthometric by default — re-arm the geoid correction
-      // so a previous file's "heights are ellipsoidal" opt-out doesn't carry
-      // over (#1355).
-      cesiumHeightsAreEllipsoidal: false,
-      cesiumTerrainClipY: null,
-      cesiumGlbLoaded: false,
-      cesiumPlacementEditMode: false,
-      cesiumPlacementDraftModelId: null,
-      cesiumPlacementDraft: null,
-
-      // Drawing 2D
-      drawing2D: null,
-      drawing2DStatus: 'idle' as const,
-      drawing2DProgress: 0,
-      drawing2DPhase: '',
-      drawing2DError: null,
-      drawing2DPanelVisible: false,
-      suppressNextSection2DPanelAutoOpen: false,
-      drawing2DSvgContent: null,
-      drawing2DDisplayOptions: getDefaultDisplayOptions(),
-      // Graphic overrides (keep presets, reset active and custom)
-      activePresetId: 'preset-3d-colors',
-      customOverrideRules: [],
-      overridesEnabled: true,
-      overridesPanelVisible: false,
-      // 2D Measure
-      measure2DMode: false,
-      measure2DStart: null,
-      measure2DCurrent: null,
-      measure2DShiftLocked: false,
-      measure2DLockedAxis: null,
-      measure2DResults: [],
-      measure2DSnapPoint: null,
-      // Annotation tools
-      annotation2DActiveTool: 'none' as const,
-      annotation2DCursorPos: null,
-      polygonArea2DPoints: [],
-      polygonArea2DResults: [],
-      textAnnotations2D: [],
-      textAnnotation2DEditing: null,
-      cloudAnnotation2DPoints: [],
-      cloudAnnotations2D: [],
-      selectedAnnotation2D: null,
-      // Drawing Sheet
-      activeSheet: null,
-      sheetEnabled: false,
-      sheetPanelVisible: false,
-      titleBlockEditorVisible: false,
-      // Keep savedSheetTemplates - don't reset user's templates
-
-      // BCF - reset panel but keep project and author
-      bcfPanelVisible: false,
-      bcfLoading: false,
-      bcfError: null,
-      activeTopicId: null,
-      activeViewpointId: null,
-      // Keep bcfProject and bcfAuthor - user's work
-
-      // IDS - reset panel but keep document and results
-      idsPanelVisible: false,
-      idsLoading: false,
-      idsProgress: null,
-      idsError: null,
-      idsActiveSpecificationId: null,
-      idsActiveEntityId: null,
-      // The per-row focus's claim on the shared isolate/ghost channels
-      // (#2867) goes with the row it belonged to. Both channels are nulled by
-      // this same `set`, so there is nothing left to release — but the RECORD
-      // must not survive: ownership is tested by value, so a record left
-      // behind starts matching again the moment another owner installs equal
-      // content, and the next release destroys that owner's presentation
-      // (#2654 fourth review).
-      idsFocusVisibilityOwned: null,
-      // Keep idsDocument, idsValidationReport, idsLocale - user's work
-
-      // Lists - reset result but keep definitions (user's saved lists)
-      listPanelVisible: false,
-      activeListId: null,
-      listResult: null,
-      listExecuting: false,
-
-      // Pinboard - clear pinned entities on new file
-      pinboardEntities: new Set<string>(),
-      basketViews: [],
-      activeBasketViewId: null,
-      basketPresentationVisible: false,
-      hierarchyBasketSelection: new Set<string>(),
-
-      // Script - reset execution state but keep saved scripts, editor content, and panel visibility
-      // (scripts that create-and-load a model should not close the panel)
-      scriptExecutionState: 'idle' as const,
-      scriptLastResult: null,
-      scriptLastError: null,
-      scriptLastDiagnostics: [],
-      scriptAssistantTurnSnapshot: null,
-      scriptDeleteConfirmId: null,
-
-      // Lens - deactivate but keep saved lenses
-      activeLensId: null,
-      lensPanelVisible: false,
-      lensColorMap: new Map<number, string>(),
-      lensHiddenIds: new Set<number>(),
-      // Ownership bookkeeping for the shared hidden/isolation channels — those
-      // channels are wiped above, so stale claims must not survive the reset.
-      lensAppliedHiddenIds: [] as number[],
-      lensRuleIsolation: null,
-      lensRuleCounts: new Map<string, number>(),
-      lensRuleEntityIds: new Map<string, number[]>(),
-
-      // Chat - keep messages and panel visible, reset streaming state
-      chatStatus: 'idle' as const,
-      chatStreamingContent: '',
-      chatError: null,
-      chatAbortController: null,
-
-      // Schedule (4D) - drop panel + data; definitions are re-extracted on
-      // next load. `playbackSpeed`, `playbackLoop`, and `ganttTimeScale` are
-      // intentionally preserved as user preferences that survive file loads.
-      ganttPanelVisible: false,
-      generateScheduleDialogOpen: false,
-      scheduleData: null,
-      scheduleRange: null,
-      activeWorkScheduleId: '',
-      expandedTaskGlobalIds: new Set<string>(),
-      hoveredTaskGlobalId: null,
-      selectedTaskGlobalIds: new Set<string>(),
-      animationEnabled: false,
-      playbackIsPlaying: false,
-      playbackTime: 0,
-
-      // Mutations - clear all mutation state so stale changes don't carry over
-      mutationViews: new Map(),
-      changeSets: new Map(),
-      activeChangeSetId: null,
-      undoStacks: new Map(),
-      redoStacks: new Map(),
-      dirtyModels: new Set(),
-      mutationVersion: get().mutationVersion + 1,
-
-      // Search - results reference the previous model's expressIds, drop them.
-      searchQuery: '',
-      searchOpen: false,
-      searchHighlightIndex: 0,
-      searchIndexes: new Map(),
-      searchVimCycle: null,
-      searchModalOpen: false,
-      searchFieldFilter: 'all',
-      searchModelFilter: null,
-      searchFilterResult: null,
-      searchFilterRunning: false,
-      searchFilterError: null,
-      searchFilter: { rules: [], combinator: 'AND', limit: 500 },
-      searchFilterSchema: new Map(),
-
-      // Annotations — drop draft + selection so a new file doesn't
-      // inherit the previous file's pin authoring state. Persisted
-      // pins themselves stay in localStorage (cross-file workspace).
-      draft: null,
-      selectedAnnotationId: null,
-
-      // Point cloud — clear runtime fields so a new file doesn't
-      // inherit the previous file's color mode / size / EDL state.
-      // Single-source-of-truth defaults shared with createPointCloudSlice.
-      ...POINT_CLOUD_DEFAULTS,
-      pointCloudFixedColor: [...POINT_CLOUD_DEFAULTS.pointCloudFixedColor] as [number, number, number, number],
-    });
-
-    // Clash (#2654 review) — same stale-model-reference class as
-    // `compareResult` and `zoneAssignments` above: a clash result is keyed by
+    // Clash (#2654 review) — same stale-model-reference class as the
+    // `compareResult` and `zoneAssignments` the composed patch above clears
+    // (`slices/compareSlice.ts`, `slices/zonesSlice.ts`): a clash result is keyed by
     // `model:expressId` pairs from the OUTGOING model, and an IFCX
     // recomposition reassigns expressIds outright, so a surviving result can
     // silently describe different entities. Worse, the on-demand intersection
@@ -603,7 +327,8 @@ const createViewerStore = () => create<ViewerState>()(withVisibilityOwnershipInv
     // Routed through `endClashScenePresentation`, the shared model-lifecycle
     // teardown, rather than calling `clearClash()` directly: this was the third
     // spelling of a teardown #2574 exists to unify, and it was incomplete. The
-    // `set` above puts `pendingColorUpdates: null`, and `null` is a NO-OP in
+    // `set` above puts `pendingColorUpdates: null` (`dataSlice.teardown.ts`,
+    // which says the same thing from the other side), and `null` is a NO-OP in
     // the effect that owns that channel (`useGeometryStreaming.ts`, "if
     // (pendingColorUpdates === null) return") — only a non-null EMPTY map
     // reaches `scene.clearColorOverrides()`. So the outgoing file's clash pair

--- a/apps/viewer/src/store/modelLifecycle.visibility-ownership.test.ts
+++ b/apps/viewer/src/store/modelLifecycle.visibility-ownership.test.ts
@@ -12,10 +12,10 @@
  * state it didn't set"), and `syncSourceModel`'s post-removal purge. The last
  * one is a hard contract, not a preference:
  *
- *     syncSourceModel.ts:188   removeModel(modelId);
- *     syncSourceModel.ts        the model-removed teardown, run a second time
+ *     syncSourceModel.ts:190   removeModel(modelId);
+ *     syncSourceModel.ts:217   the same scope again, stricter (viewerTeardown)
  *
- * `second run deliberately KEEPS the part of the user's X-ray /
+ * That second run deliberately KEEPS the part of the user's X-ray /
  * isolation that still belongs to a surviving model and drops only the ids
  * burned with the replaced one. An unconditional CLEAR (nulling the channel
  * outright) inside `removeModel` would make that filter dead code on its only
@@ -26,8 +26,8 @@
  * record, that `useClash`'s run-start release uses.
  *
  * That is only half of `removeModel`'s job on the SAME channels, though.
- * the second purge is chained after `removeModel` on exactly one
- * caller — `syncSourceModel`'s reload path (syncSourceModel.ts:188-189). The
+ * The second purge is chained after `removeModel` on exactly one
+ * caller, `syncSourceModel`'s reload path (syncSourceModel.ts:190-217). The
  * two direct callers, `HierarchyPanel`'s delete button and the collab room
  * teardown (`collabSlice.ts`), call `removeModel` alone: nothing downstream
  * ever purges the ids the deleted model owned. Left unfiltered, a stale id

--- a/apps/viewer/src/store/modelLifecycle.visibility-ownership.test.ts
+++ b/apps/viewer/src/store/modelLifecycle.visibility-ownership.test.ts
@@ -12,8 +12,8 @@
  * state it didn't set"), and `syncSourceModel`'s post-removal purge. The last
  * one is a hard contract, not a preference:
  *
- *     syncSourceModel.ts:190   removeModel(modelId);
- *     syncSourceModel.ts:217   the same scope again, stricter (viewerTeardown)
+ *     syncSourceModel.ts   removeModel(modelId)
+ *     syncSourceModel.ts   viewerTeardown(modelRemovedScope(..., replacementId))
  *
  * That second run deliberately KEEPS the part of the user's X-ray /
  * isolation that still belongs to a surviving model and drops only the ids
@@ -27,7 +27,7 @@
  *
  * That is only half of `removeModel`'s job on the SAME channels, though.
  * The second purge is chained after `removeModel` on exactly one
- * caller, `syncSourceModel`'s reload path (syncSourceModel.ts:190-217). The
+ * caller, `syncSourceModel`'s reload path. The
  * two direct callers, `HierarchyPanel`'s delete button and the collab room
  * teardown (`collabSlice.ts`), call `removeModel` alone: nothing downstream
  * ever purges the ids the deleted model owned. Left unfiltered, a stale id

--- a/apps/viewer/src/store/modelLifecycle.visibility-ownership.test.ts
+++ b/apps/viewer/src/store/modelLifecycle.visibility-ownership.test.ts
@@ -13,9 +13,9 @@
  * one is a hard contract, not a preference:
  *
  *     syncSourceModel.ts:188   removeModel(modelId);
- *     syncSourceModel.ts:189   purgeStaleEntityState(modelId, replacementId);
+ *     syncSourceModel.ts        the model-removed teardown, run a second time
  *
- * `purgeStaleEntityState` deliberately KEEPS the part of the user's X-ray /
+ * `second run deliberately KEEPS the part of the user's X-ray /
  * isolation that still belongs to a surviving model and drops only the ids
  * burned with the replaced one. An unconditional CLEAR (nulling the channel
  * outright) inside `removeModel` would make that filter dead code on its only
@@ -26,7 +26,7 @@
  * record, that `useClash`'s run-start release uses.
  *
  * That is only half of `removeModel`'s job on the SAME channels, though.
- * `purgeStaleEntityState` is chained after `removeModel` on exactly one
+ * the second purge is chained after `removeModel` on exactly one
  * caller — `syncSourceModel`'s reload path (syncSourceModel.ts:188-189). The
  * two direct callers, `HierarchyPanel`'s delete button and the collab room
  * teardown (`collabSlice.ts`), call `removeModel` alone: nothing downstream
@@ -36,9 +36,9 @@
  * reassigned to a later model either) — and if EVERY id in an isolate/ghost
  * set belonged to the removed model, the channel stays non-null while
  * matching nothing in the survivors, hiding the entire remaining scene (the
- * same "empty set is worse than stale" hazard `purgeStaleEntityState`'s own
+ * same "empty set is worse than stale" hazard the purge's own
  * comment calls out). #2832 gave `removeModel` that filtering directly,
- * mirroring `purgeStaleEntityState`'s survivor-range check. It runs AFTER the
+ * mirroring `modelRemovedScope`'s survivor-range check. It runs AFTER the
  * ownership-scoped release above (so a clash-owned channel is already gone or
  * already left alone by the time it sees the channel) and only ever DROPS ids
  * no surviving model can own — it does not blanket-clear, so it does not
@@ -108,7 +108,7 @@ describe('removeModel leaves visibility state it does not own (#2654 second revi
   it('PRUNES the id the removed model owned but KEEPS the id a surviving model owns', () => {
     // 12 belongs to modelA (removed), 10_012 to the surviving modelB. No
     // downstream purge follows a bare `removeModel` call (only the
-    // syncSourceModel reload path chains `purgeStaleEntityState` after it),
+    // syncSourceModel reload path runs the same scope a second time after it),
     // so removeModel must do this filtering itself — a deleted-model id left
     // unfiltered here never gets cleaned up.
     const ghost = new Set<number>([12, 10_012]);

--- a/apps/viewer/src/store/removeModel-selected-model-only.test.ts
+++ b/apps/viewer/src/store/removeModel-selected-model-only.test.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { useViewerStore } from './index.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+/**
+ * The one deliberate behaviour change in the teardown-seam refactor, pinned.
+ *
+ * `removeModel` used to gate `selectedModelId` behind the entity-ref checks, so
+ * removing a model that was selected in the hierarchy with NO entity selected
+ * under it left `selectedModelId` naming a model that no longer exists. The
+ * resync purge (`purgeStaleEntityState`) already cleared it unconditionally, so
+ * the two paths disagreed. Unifying them took the purge's reading.
+ *
+ * Every existing fixture sets `selectedEntity` to the removed model as well, so
+ * the old gate covers those too and deleting the clause leaves them all green
+ * (measured: 1105 tests under src/store + src/lib/sources). This is the case
+ * that separates the two readings, and nothing else exercises it.
+ */
+describe('removeModel clears selectedModelId when only the hierarchy selection names the model', () => {
+  it('drops a dangling selectedModelId with no entity selected under it', () => {
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'B',
+      // The discriminating fixture: A is selected in the hierarchy, and NOTHING
+      // else names it. Every entity-ref channel is empty or points elsewhere.
+      selectedModelId: 'A',
+      selectedEntity: null,
+      selectedEntities: [],
+      selectedEntitiesSet: new Set<string>(),
+      activeStorey: null,
+      selectedEntityIds: new Set<number>(),
+      hiddenEntities: new Set<number>(),
+    });
+
+    useViewerStore.getState().removeModel('A');
+
+    const after = useViewerStore.getState();
+    console.log('selectedModelId after removeModel:', after.selectedModelId);
+    assert.strictEqual(
+      after.selectedModelId,
+      null,
+      'selectedModelId must not survive the removal of the model it names, even when no entity ref does',
+    );
+  });
+});

--- a/apps/viewer/src/store/removeModel-selected-model-only.test.ts
+++ b/apps/viewer/src/store/removeModel-selected-model-only.test.ts
@@ -47,7 +47,6 @@ describe('removeModel clears selectedModelId when only the hierarchy selection n
     useViewerStore.getState().removeModel('A');
 
     const after = useViewerStore.getState();
-    console.log('selectedModelId after removeModel:', after.selectedModelId);
     assert.strictEqual(
       after.selectedModelId,
       null,

--- a/apps/viewer/src/store/slices/addElementSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/addElementSlice.teardown.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `addElementSlice`'s contribution to the store-wide teardown seam
+ * (`store/teardown.ts`). Split out beside the slice so the whole group has one
+ * shape; see `modelSlice.teardown.ts` for why the shape exists.
+ *
+ * Only the two model-scoped pins are owned here. The panel's form state (type,
+ * per-type dimensions, slab mode) and the in-progress click queue are NOT
+ * federation state and no teardown path has ever written them, so they are
+ * absent from `owns` as well as from the bodies (Trap A: `owns` is the list of
+ * everything this slice is willing to destroy).
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+export const addElementTeardown = defineSliceTeardown(
+  'addElementSlice',
+  ['addElementModelId', 'addElementStoreyId'],
+  (scope, state) => {
+    // `resetViewerState` has never touched these — verified against
+    // store/index.ts, which names neither. A file load leaves the panel's pin
+    // alone; only a federation change can invalidate it.
+    if (scope.kind === 'session-reset') return {};
+
+    if (scope.kind === 'all-models-cleared') {
+      // With `models` about to become empty there is no federated model left
+      // for the pin to name, so it and the model-local storey id go too.
+      return { addElementModelId: null, addElementStoreyId: null };
+    }
+
+    // The AddElement panel's "target model" pin is a dangling reference of the
+    // same shape as the selection fields, just on a different slice:
+    // `addElementModelId` names a specific federated model so the panel and the
+    // click-placement handlers (`resolveAddElementContext` in
+    // selectionHandlers.ts) stop tracking whichever model is merely active.
+    // Nothing else clears it when that model goes away, so it keeps naming a
+    // model no longer in `models` after removal — the panel's Select renders
+    // blank instead of falling back to the active model, and every subsequent
+    // placement click fails with "No model loaded for id" until the user
+    // re-picks a model by hand. `addElementStoreyId` is an express id local to
+    // that same model, so it is stale too and reset alongside it; it is left
+    // alone when the pin names a different (surviving) model, matching how the
+    // selection purge only drops entries belonging to the removed model.
+    if (state.addElementModelId !== scope.modelId) return {};
+    return { addElementModelId: null, addElementStoreyId: null };
+  },
+);

--- a/apps/viewer/src/store/slices/annotationsSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/annotationsSlice.teardown.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `annotationsSlice`'s answer to "what do I destroy under this scope".
+ *
+ * `annotations` is NOT in `owns`. The pins are a cross-file workspace that
+ * round-trips to localStorage, so they outlive every scope here — wiping them
+ * is `clearAllAnnotations`, a user action, and it is deliberately not folded
+ * into this: it also clears persisted storage, which a teardown must never do.
+ *
+ * The two values below are the slice's own initial values (`annotationsSlice.ts`,
+ * `createAnnotationsSlice`), which `store/index.ts` restated a second time.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+export const annotationsTeardown = defineSliceTeardown(
+  'annotationsSlice',
+  ['draft', 'selectedAnnotationId'],
+  (scope) =>
+    // Pin authoring is not per-model: removing one model from a federation,
+    // or clearing them all, leaves an open draft and its popover alone.
+    scope.kind !== 'session-reset'
+      ? {}
+      : {
+          // Drop draft + selection so a new file doesn't inherit the previous
+          // file's pin authoring state. Persisted pins themselves stay in
+          // localStorage (cross-file workspace).
+          draft: null,
+          selectedAnnotationId: null,
+        },
+);

--- a/apps/viewer/src/store/slices/bcfSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/bcfSlice.teardown.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The BCF slice's contribution to viewer-state teardown.
+ *
+ * A sibling module rather than a block at the bottom of `bcfSlice.ts` because
+ * that file is 381 lines and this table plus its comments would take it past
+ * the ~400-line module rule (`scripts/check-module-size.mjs`).
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+/**
+ * What a session reset clears on the BCF slice.
+ *
+ * Carried verbatim from `resetViewerState` (`store/index.ts`):
+ *   "BCF - reset panel but keep project and author"
+ *   "Keep bcfProject and bcfAuthor - user's work"
+ *
+ * A BCF project is a collaboration document, not model state — it names topics
+ * against a whole coordination job and routinely outlives any single file the
+ * user has open, so it is absent from `owns`. `bcfAuthor` is a workspace
+ * identity, likewise. `bcfOverlayVisible` is absent for the same reason
+ * `resetViewerState` never touched it: it is a display preference for the 3D
+ * markers, and the markers belong to the surviving project.
+ *
+ * `clearBcfProject()` is NOT folded in: it drops `bcfProject` itself, which
+ * this teardown must not do.
+ */
+export const bcfTeardown = defineSliceTeardown(
+  'bcfSlice',
+  ['bcfPanelVisible', 'bcfLoading', 'bcfError', 'activeTopicId', 'activeViewpointId'],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      bcfPanelVisible: false,
+      bcfLoading: false,
+      bcfError: null,
+      // The active topic and viewpoint are a reading position inside the
+      // surviving project, and a viewpoint restores a camera pose plus a
+      // visibility set expressed against the OUTGOING model. The project
+      // stays; where the user was in it does not.
+      activeTopicId: null,
+      activeViewpointId: null,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/bcfSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/bcfSlice.teardown.ts
@@ -33,8 +33,6 @@ export const bcfTeardown = defineSliceTeardown(
   'bcfSlice',
   ['bcfPanelVisible', 'bcfLoading', 'bcfError', 'activeTopicId', 'activeViewpointId'],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       bcfPanelVisible: false,

--- a/apps/viewer/src/store/slices/cameraSlice.ts
+++ b/apps/viewer/src/store/slices/cameraSlice.ts
@@ -9,6 +9,17 @@
 import type { StateCreator } from 'zustand';
 import type { CameraRotation, CameraCallbacks, ProjectionMode } from '../types.js';
 import { CAMERA_DEFAULTS } from '../constants.js';
+import { defineSliceTeardown } from '../teardown.js';
+
+/** The home orientation, in one place: the slice's initial value and the
+ *  session-reset teardown must not be able to drift apart. */
+const defaultCameraRotation = (): CameraRotation => ({
+  azimuth: CAMERA_DEFAULTS.AZIMUTH,
+  elevation: CAMERA_DEFAULTS.ELEVATION,
+});
+
+/** Likewise for the projection: `perspective` is the startup mode. */
+const DEFAULT_PROJECTION_MODE: ProjectionMode = 'perspective';
 
 export interface CameraSlice {
   // State
@@ -39,13 +50,10 @@ export interface CameraSlice {
 
 export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> = (set, get) => ({
   // Initial state
-  cameraRotation: {
-    azimuth: CAMERA_DEFAULTS.AZIMUTH,
-    elevation: CAMERA_DEFAULTS.ELEVATION,
-  },
+  cameraRotation: defaultCameraRotation(),
   pendingCameraRotation: null,
   cameraCallbacks: {},
-  projectionMode: 'perspective',
+  projectionMode: DEFAULT_PROJECTION_MODE,
   onCameraRotationChange: null,
   cameraRotationListeners: new Set(),
   onScaleChange: null,
@@ -120,3 +128,34 @@ export const createCameraSlice: StateCreator<CameraSlice, [], [], CameraSlice> =
     // Don't update store state during real-time updates
   },
 });
+
+/**
+ * What a session reset clears on the camera slice.
+ *
+ * `resetViewerState`'s "Camera" block (`store/index.ts`): a new file gets the
+ * home orientation and the default projection rather than inheriting the pose
+ * the user left on the outgoing model.
+ *
+ * PURE, like every teardown — and that matches today's behaviour exactly:
+ * `resetViewerState` writes both fields straight into `set()` without going
+ * through `setCameraRotation` / `setProjectionMode`, so the renderer actuators
+ * are NOT driven here. The reframe comes from the load path instead. Calling
+ * an actuator from a teardown would be a behaviour change, not a tidy-up.
+ *
+ * `pendingCameraRotation`, `cameraCallbacks`, the two callback slots and
+ * `cameraRotationListeners` are absent from `owns`: they are renderer/host
+ * wiring that outlives a file swap, and no teardown path touches them today.
+ */
+export const cameraTeardown = defineSliceTeardown(
+  'cameraSlice',
+  ['cameraRotation', 'projectionMode'],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      cameraRotation: defaultCameraRotation(),
+      projectionMode: DEFAULT_PROJECTION_MODE,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/cameraSlice.ts
+++ b/apps/viewer/src/store/slices/cameraSlice.ts
@@ -150,8 +150,6 @@ export const cameraTeardown = defineSliceTeardown(
   'cameraSlice',
   ['cameraRotation', 'projectionMode'],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       cameraRotation: defaultCameraRotation(),

--- a/apps/viewer/src/store/slices/cesiumSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/cesiumSlice.teardown.ts
@@ -13,7 +13,7 @@
  * raising a budget; the seam is the one this refactor exists to create.
  *
  * Everything here is session-reset only. The Cesium overlay is not touched by
- * `removeModel`, `clearAllModels` or `purgeStaleEntityState` today, so both
+ * `removeModel`, `clearAllModels` or the resync purge today, so both
  * other scopes return `{}`.
  *
  * `resetCesiumPlacementDraft()` clears two of these eleven fields and stays as

--- a/apps/viewer/src/store/slices/cesiumSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/cesiumSlice.teardown.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `cesiumSlice`'s contribution to the store teardown registry (`store/teardown.ts`).
+ *
+ * SEPARATE FILE, not the bottom of `cesiumSlice.ts`, for one reason: that file
+ * is 371 lines and the module-size ratchet (`scripts/check-module-size.mjs`,
+ * limit 400, no allowlist row) leaves 29 lines of headroom — less than this
+ * costs with its comments intact, and dropping the comments to fit is the one
+ * thing the migration rules forbid. Splitting at the teardown seam beats
+ * raising a budget; the seam is the one this refactor exists to create.
+ *
+ * Everything here is session-reset only. The Cesium overlay is not touched by
+ * `removeModel`, `clearAllModels` or `purgeStaleEntityState` today, so both
+ * other scopes return `{}`.
+ *
+ * `resetCesiumPlacementDraft()` clears two of these eleven fields and stays as
+ * it is: it is a user-facing "cancel the placement edit", not a teardown, and
+ * folding it in would tie a UI action to a scope arm that will grow fields it
+ * has no business clearing.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+export const cesiumTeardown = defineSliceTeardown(
+  'cesiumSlice',
+  [
+    'cesiumAvailable',
+    'cesiumEnabled',
+    'cesiumTerrainHeight',
+    'cesiumTerrainSaveHeight',
+    'cesiumSourceModelId',
+    'cesiumHeightsAreEllipsoidal',
+    'cesiumTerrainClipY',
+    'cesiumGlbLoaded',
+    'cesiumPlacementEditMode',
+    'cesiumPlacementDraftModelId',
+    'cesiumPlacementDraft',
+  ],
+  (scope) => scope.kind !== 'session-reset' ? {} : {
+    cesiumAvailable: false,
+    cesiumEnabled: false,
+    cesiumTerrainHeight: null,
+    // The snap target is model-specific terrain state; drop it with the
+    // sampled height so a new file can't reuse the old target (#1456).
+    cesiumTerrainSaveHeight: null,
+    cesiumSourceModelId: null,
+    // A new file is orthometric by default — re-arm the geoid correction
+    // so a previous file's "heights are ellipsoidal" opt-out doesn't carry
+    // over (#1355).
+    cesiumHeightsAreEllipsoidal: false,
+    cesiumTerrainClipY: null,
+    cesiumGlbLoaded: false,
+    cesiumPlacementEditMode: false,
+    cesiumPlacementDraftModelId: null,
+    cesiumPlacementDraft: null,
+  },
+);

--- a/apps/viewer/src/store/slices/chatSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/chatSlice.teardown.ts
@@ -32,8 +32,6 @@ export const chatTeardown = defineSliceTeardown(
   'chatSlice',
   ['chatStatus', 'chatStreamingContent', 'chatError', 'chatAbortController'],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       chatStatus: 'idle' as const,

--- a/apps/viewer/src/store/slices/chatSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/chatSlice.teardown.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The chat slice's contribution to viewer-state teardown.
+ *
+ * A sibling module rather than a block at the bottom of `chatSlice.ts` because
+ * that file sits at its recorded module-size budget (452 lines,
+ * `scripts/module-size-allowlist.txt`) and may not grow.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+/**
+ * What a session reset clears on the chat slice.
+ *
+ * Carried verbatim from `resetViewerState` (`store/index.ts`):
+ *   "Chat - keep messages and panel visible, reset streaming state"
+ *
+ * The transcript is the user's conversation and survives a file swap, so
+ * `chatMessages` and `chatPanelVisible` are absent from `owns` — as are the
+ * workspace settings (`chatActiveModel`, `chatAutoExecute`) and the compose-box
+ * contents (`chatAttachments`, `chatPendingPrompt`, `chatPendingRepairRequest`,
+ * `chatViewportScreenshot`), none of which `resetViewerState` touches.
+ *
+ * `clearChatMessages()` is NOT folded in: it empties the transcript, and it
+ * ABORTS the in-flight request first (see the note on `chatAbortController`
+ * below).
+ */
+export const chatTeardown = defineSliceTeardown(
+  'chatSlice',
+  ['chatStatus', 'chatStreamingContent', 'chatError', 'chatAbortController'],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      chatStatus: 'idle' as const,
+      chatStreamingContent: '',
+      chatError: null,
+      // Dropped WITHOUT calling `.abort()` — that is exactly what
+      // `resetViewerState` does today, and `clearChatMessages` is the
+      // only path that aborts. Adding an `abort()` here would be a
+      // behaviour change, and a side effect a teardown may not have.
+      chatAbortController: null,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/collabSlice.entry-race.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.entry-race.test.ts
@@ -32,7 +32,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { createModelSlice, type ModelSlice, type ModelCrossSliceState } from './modelSlice.js';
+import { createModelSlice, type ModelSlice } from './modelSlice.js';
 import { createDataSlice, type DataSlice, type DataCrossSliceState } from './dataSlice.js';
 import { createCollabSlice, type CollabSlice } from './collabSlice.js';
 import { roomModelIdOf } from '../../lib/collab/room-model-target.js';
@@ -40,7 +40,6 @@ import type { MutablePropertyView } from '@ifc-lite/mutations';
 import type { ViewerState } from '../index.js';
 
 type TestState = ModelSlice &
-  ModelCrossSliceState &
   DataSlice &
   DataCrossSliceState &
   CollabSlice & {

--- a/apps/viewer/src/store/slices/collabSlice.leave-after-reconstruct.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.leave-after-reconstruct.test.ts
@@ -27,13 +27,12 @@ import assert from 'node:assert/strict';
 
 register('../../test/collab-hydrate-gate-hook.mjs', import.meta.url);
 
-import type { ModelSlice, ModelCrossSliceState } from './modelSlice.js';
+import type { ModelSlice } from './modelSlice.js';
 import type { DataSlice, DataCrossSliceState } from './dataSlice.js';
 import type { CollabSlice } from './collabSlice.js';
 import type { ViewerState } from '../index.js';
 
 type TestState = ModelSlice &
-  ModelCrossSliceState &
   DataSlice &
   DataCrossSliceState &
   CollabSlice & {

--- a/apps/viewer/src/store/slices/collabSlice.leave-during-join-race.test.ts
+++ b/apps/viewer/src/store/slices/collabSlice.leave-during-join-race.test.ts
@@ -52,13 +52,12 @@ import assert from 'node:assert/strict';
 
 register('../../test/collab-session-race-hook.mjs', import.meta.url);
 
-import { createModelSlice, type ModelSlice, type ModelCrossSliceState } from './modelSlice.js';
+import { createModelSlice, type ModelSlice } from './modelSlice.js';
 import { createDataSlice, type DataSlice, type DataCrossSliceState } from './dataSlice.js';
 import { createCollabSlice, type CollabSlice } from './collabSlice.js';
 import type { ViewerState } from '../index.js';
 
 type TestState = ModelSlice &
-  ModelCrossSliceState &
   DataSlice &
   DataCrossSliceState &
   CollabSlice & {
@@ -102,9 +101,11 @@ function buildState() {
     // (role: 'admin'), but it must exist to type-check the call site.
     setEditEnabled: () => {},
     mutationViews: new Map(),
-    // `ModelCrossSliceState` — fields other slices own that `modelSlice`'s
-    // actions write to, so `TestState` requires them but no creator spread
-    // above supplies them. Same enumeration as the sibling
+    // Fields other slices own that the teardown `removeModel` dispatches
+    // reads off this stub state (`store/teardown-registry.ts`). Every
+    // contribution falls back to its own initial value when a field is
+    // absent, so these are here to make the harness store-shaped rather than
+    // to satisfy a type. Same enumeration as the sibling
     // `collabSlice.entry-race.test.ts`; keep the two in step.
     addElementModelId: null,
     addElementStoreyId: null,

--- a/apps/viewer/src/store/slices/compareSlice.ts
+++ b/apps/viewer/src/store/slices/compareSlice.ts
@@ -197,15 +197,27 @@ export interface CompareSlice {
  * (guarded on the removed model being a side of the pairing) and of
  * `clearAllModels` (unconditional); neither is a scope arm here.
  */
-export const compareTeardown = defineSliceTeardown(
-  'compareSlice',
-  ['compareResult', 'compareSelectedKey', 'compareRunning', 'compareError'],
-  (scope) => scope.kind !== 'session-reset' ? {} : {
+/**
+ * The fields `clearCompare` and a session reset both drop.
+ *
+ * Named once and consumed by both so neither can drift, the same shape
+ * `sheetSlice`'s `getClearedSheetState` uses. `compareRunSeq` is deliberately
+ * absent from both: it is a monotonic guard against a stale async result
+ * landing after a newer run, so resetting it would let exactly that through.
+ */
+function getClearedCompareState() {
+  return {
     compareResult: null,
     compareSelectedKey: null,
     compareRunning: false,
     compareError: null,
-  },
+  } as const;
+}
+
+export const compareTeardown = defineSliceTeardown(
+  'compareSlice',
+  ['compareResult', 'compareSelectedKey', 'compareRunning', 'compareError'],
+  (scope) => scope.kind !== 'session-reset' ? {} : getClearedCompareState(),
 );
 
 export const createCompareSlice: StateCreator<CompareSlice, [], [], CompareSlice> = (set) => ({
@@ -269,5 +281,5 @@ export const createCompareSlice: StateCreator<CompareSlice, [], [], CompareSlice
   setCompareError: (compareError) => set({ compareError }),
   setCompareSelectedKey: (compareSelectedKey) => set({ compareSelectedKey }),
 
-  clearCompare: () => set(compareTeardown.teardown({ kind: 'session-reset' }, {})),
+  clearCompare: () => set(getClearedCompareState()),
 });

--- a/apps/viewer/src/store/slices/compareSlice.ts
+++ b/apps/viewer/src/store/slices/compareSlice.ts
@@ -185,20 +185,11 @@ export interface CompareSlice {
 }
 
 /**
- * Compare (#924): drop any stale diff result — it references models by id and
- * the loaded set is changing. Keep panel visibility + A/B/scope choices (UI
- * prefs); the user re-runs against the new set.
- *
- * This is also the implementation of {@link CompareSlice.clearCompare}, which
- * delegates to it — the run result and the selection are the same four fields
- * either way, and one definition is what keeps them from drifting.
- *
- * `clearCompare` itself stays an entry-point side effect of `removeModel`
- * (guarded on the removed model being a side of the pairing) and of
- * `clearAllModels` (unconditional); neither is a scope arm here.
- */
-/**
  * The fields `clearCompare` and a session reset both drop.
+ *
+ * Compare (#924): a stale diff result references models by id and the loaded
+ * set is changing. Panel visibility and the A/B/scope choices are UI prefs and
+ * stay; the user re-runs against the new set.
  *
  * Named once and consumed by both so neither can drift, the same shape
  * `sheetSlice`'s `getClearedSheetState` uses. `compareRunSeq` is deliberately

--- a/apps/viewer/src/store/slices/compareSlice.ts
+++ b/apps/viewer/src/store/slices/compareSlice.ts
@@ -14,6 +14,7 @@
 import type { StateCreator } from 'zustand';
 import type { DiffScope, ModelDiff } from '@ifc-lite/diff';
 import type { CompareRef } from '@/lib/compare/buildFingerprints';
+import { defineSliceTeardown } from '../teardown.js';
 
 /** A completed comparison: the engine result plus the A/B context it ran on. */
 export interface CompareResult {
@@ -183,6 +184,30 @@ export interface CompareSlice {
   clearCompare: () => void;
 }
 
+/**
+ * Compare (#924): drop any stale diff result — it references models by id and
+ * the loaded set is changing. Keep panel visibility + A/B/scope choices (UI
+ * prefs); the user re-runs against the new set.
+ *
+ * This is also the implementation of {@link CompareSlice.clearCompare}, which
+ * delegates to it — the run result and the selection are the same four fields
+ * either way, and one definition is what keeps them from drifting.
+ *
+ * `clearCompare` itself stays an entry-point side effect of `removeModel`
+ * (guarded on the removed model being a side of the pairing) and of
+ * `clearAllModels` (unconditional); neither is a scope arm here.
+ */
+export const compareTeardown = defineSliceTeardown(
+  'compareSlice',
+  ['compareResult', 'compareSelectedKey', 'compareRunning', 'compareError'],
+  (scope) => scope.kind !== 'session-reset' ? {} : {
+    compareResult: null,
+    compareSelectedKey: null,
+    compareRunning: false,
+    compareError: null,
+  },
+);
+
 export const createCompareSlice: StateCreator<CompareSlice, [], [], CompareSlice> = (set) => ({
   comparePanelVisible: false,
   compareBaseModelId: null,
@@ -244,11 +269,5 @@ export const createCompareSlice: StateCreator<CompareSlice, [], [], CompareSlice
   setCompareError: (compareError) => set({ compareError }),
   setCompareSelectedKey: (compareSelectedKey) => set({ compareSelectedKey }),
 
-  clearCompare: () =>
-    set({
-      compareResult: null,
-      compareRunning: false,
-      compareError: null,
-      compareSelectedKey: null,
-    }),
+  clearCompare: () => set(compareTeardown.teardown({ kind: 'session-reset' }, {})),
 });

--- a/apps/viewer/src/store/slices/dataSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/dataSlice.teardown.ts
@@ -69,7 +69,7 @@ export const dataTeardown = defineSliceTeardown(
 
     const models = state.models;
     // Same guard as `modelSlice`'s arm: a removal that removes nothing writes
-    // nothing, which is also what makes the second run (`purgeStaleEntityState`
+    // nothing, which is also what makes the second run (`syncSourceModel`
     // immediately after `removeModel`) a no-op.
     if (!models?.has(scope.modelId)) return {};
 

--- a/apps/viewer/src/store/slices/dataSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/dataSlice.teardown.ts
@@ -73,13 +73,9 @@ export const dataTeardown = defineSliceTeardown(
     // immediately after `removeModel`) a no-op.
     if (!models?.has(scope.modelId)) return {};
 
-    // Follow the model that becomes active. Derived from `models` the same way
-    // `modelSlice`'s arm derives it, off the same pre-`set` state, so the two
-    // cannot disagree about which model wins.
-    const remaining = [...models.keys()].filter((id) => id !== scope.modelId);
-    const nextActiveId =
-      state.activeModelId === scope.modelId ? (remaining[0] ?? null) : state.activeModelId;
-    const activeModel = nextActiveId ? models.get(nextActiveId) : null;
+    // Follow the model that becomes active. The scope resolved it once, so this
+    // and `modelSlice`'s `activeModelId` cannot name different models.
+    const activeModel = scope.nextActiveModelId ? models.get(scope.nextActiveModelId) : null;
 
     return {
       ifcDataStore: activeModel?.ifcDataStore ?? null,

--- a/apps/viewer/src/store/slices/dataSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/dataSlice.teardown.ts
@@ -102,9 +102,15 @@ export const dataTeardown = defineSliceTeardown(
  *
  * `resolveGlobalIdInModel` is the owner-scoped resolver `modelSlice` already
  * provides for exactly this question; it shares its range and overlay
- * predicates with the unscoped one, so the two cannot drift (#2697). It is a
- * pure lookup — no `set`, no ordering — read off the state handed in, and it
- * still sees the removed model because the teardown runs before the `set`.
+ * predicates with the unscoped one, so the two cannot drift (#2697).
+ *
+ * It is NOT a pure function of the state handed in: it closes over the model
+ * slice's own `get()` (`modelSlice.ts`, `mutationViewsOf(get())`), so it reads
+ * the LIVE store. That is correct here for a reason, not by luck: every entry
+ * point builds its patch BEFORE its own `set`, so live and snapshot are the
+ * same models. An entry point that ever composed against a snapshot taken
+ * before an intervening `set` would resolve `meshColorBackup` against
+ * different data than every other contribution, with nothing to catch it.
  */
 function purgeRemovedModelsBackup(
   modelId: string,

--- a/apps/viewer/src/store/slices/dataSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/dataSlice.teardown.ts
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `dataSlice`'s contribution to the store-wide teardown seam
+ * (`store/teardown.ts`). Split out beside the slice for the reason
+ * `modelSlice.teardown.ts` documents.
+ *
+ * `clearPendingColorUpdates` / `clearInstancedShards` / `resetMeshColors` stay
+ * exactly as they are: they are the slice's own narrower actions with their own
+ * callers and their own semantics (`resetMeshColors` RESTORES colours through
+ * `pendingMeshColorUpdates` before clearing the backup, which is not what a
+ * teardown wants).
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+export const dataTeardown = defineSliceTeardown(
+  'dataSlice',
+  [
+    'ifcDataStore',
+    'geometryResult',
+    'geometryUpdateTick',
+    'pendingColorUpdates',
+    'pendingMeshColorUpdates',
+    'meshColorBackup',
+    'pendingInstancedShards',
+  ],
+  (scope, state) => {
+    if (scope.kind === 'session-reset') {
+      return {
+        geometryUpdateTick: 0,
+        // `null` here is a NO-OP at the renderer — `useGeometryStreaming`
+        // returns early on a null `pendingColorUpdates`, so only a non-null
+        // EMPTY map reaches `scene.clearColorOverrides()`. The actual release
+        // of the outgoing model's clash/lens tint is
+        // `endClashScenePresentation`'s empty Map, AFTER the set, in the entry
+        // point. This write looks redundant and is not: it stops a queued
+        // overlay from being uploaded into the new scene. Do not "improve" it
+        // into an empty Map, and do not move the helper call.
+        pendingColorUpdates: null,
+        pendingMeshColorUpdates: null,
+        // The backup those two restore FROM. Ids collide across models, so
+        // surviving a swap made RESET_COLORS paint the old model's colours onto
+        // the new one; first-write-wins made every later reset wrong too.
+        meshColorBackup: null,
+        // Drop any undrained GPU-instancing shards from the previous model so
+        // they can't be uploaded into the new scene under a rapid model switch.
+        pendingInstancedShards: null,
+        // `ifcDataStore` / `geometryResult` are deliberately absent: a session
+        // reset is a file LOAD, and the loader writes both straight after. They
+        // follow the active model on the two federation arms below.
+      };
+    }
+
+    if (scope.kind === 'all-models-cleared') {
+      return {
+        ifcDataStore: null,
+        geometryResult: null,
+        // Goes with the geometry it describes: first-write-wins, so a survivor
+        // repaints a departed model's colour onto whatever takes that id next.
+        // Unconditional here, unlike the scoped purge below:
+        // `federationRegistry.clear()` restarts offsets at 0, so ids genuinely
+        // ARE reused after this.
+        meshColorBackup: null,
+      };
+    }
+
+    const models = state.models;
+    // Same guard as `modelSlice`'s arm: a removal that removes nothing writes
+    // nothing, which is also what makes the second run (`purgeStaleEntityState`
+    // immediately after `removeModel`) a no-op.
+    if (!models?.has(scope.modelId)) return {};
+
+    // Follow the model that becomes active. Derived from `models` the same way
+    // `modelSlice`'s arm derives it, off the same pre-`set` state, so the two
+    // cannot disagree about which model wins.
+    const remaining = [...models.keys()].filter((id) => id !== scope.modelId);
+    const nextActiveId =
+      state.activeModelId === scope.modelId ? (remaining[0] ?? null) : state.activeModelId;
+    const activeModel = nextActiveId ? models.get(nextActiveId) : null;
+
+    return {
+      ifcDataStore: activeModel?.ifcDataStore ?? null,
+      geometryResult: activeModel?.geometryResult ?? null,
+      meshColorBackup: purgeRemovedModelsBackup(scope.modelId, state),
+    };
+  },
+);
+
+/**
+ * Purge only THIS model's entries from the mesh-colour backup.
+ *
+ * Dropping the map whole would take the SURVIVING models' undo with it, and it
+ * is not needed for them: `unregisterModel` BURNS the removed range rather than
+ * reclaiming it, so no later model is handed these ids.
+ *
+ * NOT `scope.isStale`, deliberately, and this is the one place in the group
+ * where the scope's predicate is the wrong question. `isStale` asks "does any
+ * SURVIVOR own this id"; the backup asks "did the REMOVED model own it". The
+ * two agree everywhere except on an id owned by no model at all — already
+ * dangling before the removal — which this KEEPS and `isStale` would drop.
+ * Keeping it is today's behaviour and this change is a restructuring, so the
+ * owner-scoped resolver is what runs here.
+ *
+ * `resolveGlobalIdInModel` is the owner-scoped resolver `modelSlice` already
+ * provides for exactly this question; it shares its range and overlay
+ * predicates with the unscoped one, so the two cannot drift (#2697). It is a
+ * pure lookup — no `set`, no ordering — read off the state handed in, and it
+ * still sees the removed model because the teardown runs before the `set`.
+ */
+function purgeRemovedModelsBackup(
+  modelId: string,
+  state: {
+    readonly meshColorBackup?: Map<number, [number, number, number, number]> | null;
+    readonly resolveGlobalIdInModel?: (modelId: string, globalId: number) => unknown;
+  },
+): Map<number, [number, number, number, number]> | null | undefined {
+  const prior = state.meshColorBackup;
+  const resolveInModel = state.resolveGlobalIdInModel;
+  // No backup, or a state without the resolver (a slice-scoped test harness):
+  // hand back what was there rather than deciding on a predicate we don't have.
+  if (!prior || !resolveInModel) return prior;
+
+  const kept = new Map([...prior].filter(([id]) => resolveInModel(modelId, id) === null));
+  // Nothing of the removed model's was in it — return the SAME map so the
+  // composition drops the key instead of re-notifying on an equal copy.
+  if (kept.size === prior.size) return prior;
+  return kept.size > 0 ? kept : null;
+}

--- a/apps/viewer/src/store/slices/drawing2DSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.teardown.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `drawing2DSlice`'s answer to "what do I destroy under this scope".
+ *
+ * Lives beside the slice rather than inside it because `drawing2DSlice.ts` is
+ * at its recorded module-size budget (`scripts/module-size-allowlist.txt`),
+ * and that ratchet only goes down. The seam is real either way: this file is
+ * the reviewable list of everything the slice is willing to lose, and the
+ * only consumer is the store's teardown registry.
+ *
+ * Every value is picked off {@link getDefaultDrawing2DState}, the slice's own
+ * initial state, so the two cannot drift — that duplication (`store/index.ts`
+ * restating each value a second time, in a file that cannot see the slice) is
+ * what `store/teardown.ts` exists to remove.
+ *
+ * ## What must SURVIVE — and why the body is a hand-written field list
+ *
+ * `graphicOverridePresets` (the built-in preset library) and `dxfUnderlays`
+ * (imported reference drawings) belong to the workspace, not to the loaded
+ * file. They are absent from `owns` and from the body, which is the whole
+ * point of naming fields one by one: this slice is confirmed bug #2 in
+ * `scripts/check-whole-state-reset.mjs`'s header (issue #2802) — `clearDrawing2D`
+ * once did `set(getDefaultState())` and destroyed custom override rules,
+ * `overridesEnabled`, text annotations and DXF underlays. A `...defaults`
+ * spread here would reintroduce exactly that, silently.
+ *
+ * `clearDrawing2D` is deliberately NOT folded into this: it is a scoped action
+ * with a DIFFERENT contract (regenerate the drawing, keep everything the user
+ * authored), and collapsing the two is the mistake #2802 records.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { getDefaultDrawing2DState } from './drawing2DSlice.js';
+
+export const drawing2DTeardown = defineSliceTeardown(
+  'drawing2DSlice',
+  [
+    'drawing2D',
+    'drawing2DStatus',
+    'drawing2DProgress',
+    'drawing2DPhase',
+    'drawing2DError',
+    'drawing2DPanelVisible',
+    'suppressNextSection2DPanelAutoOpen',
+    'drawing2DSvgContent',
+    'drawing2DDisplayOptions',
+    'activePresetId',
+    'customOverrideRules',
+    'overridesEnabled',
+    'overridesPanelVisible',
+    'measure2DMode',
+    'measure2DStart',
+    'measure2DCurrent',
+    'measure2DShiftLocked',
+    'measure2DLockedAxis',
+    'measure2DResults',
+    'measure2DSnapPoint',
+    'annotation2DActiveTool',
+    'annotation2DCursorPos',
+    'polygonArea2DPoints',
+    'polygonArea2DResults',
+    'textAnnotations2D',
+    'textAnnotation2DEditing',
+    'cloudAnnotation2DPoints',
+    'cloudAnnotations2D',
+    'selectedAnnotation2D',
+  ],
+  (scope) => {
+    // The generated drawing, its overrides and its annotations are all keyed
+    // to the file that was loaded. Removing ONE model from a federation, or
+    // clearing them all, leaves the 2D view to be regenerated on demand and
+    // must not throw away the user's markup, so both of those scopes are
+    // no-ops here.
+    if (scope.kind !== 'session-reset') return {};
+
+    const defaults = getDefaultDrawing2DState();
+    return {
+      // Drawing 2D
+      drawing2D: defaults.drawing2D,
+      drawing2DStatus: defaults.drawing2DStatus,
+      drawing2DProgress: defaults.drawing2DProgress,
+      drawing2DPhase: defaults.drawing2DPhase,
+      drawing2DError: defaults.drawing2DError,
+      drawing2DPanelVisible: defaults.drawing2DPanelVisible,
+      suppressNextSection2DPanelAutoOpen: defaults.suppressNextSection2DPanelAutoOpen,
+      drawing2DSvgContent: defaults.drawing2DSvgContent,
+      drawing2DDisplayOptions: defaults.drawing2DDisplayOptions,
+
+      // Graphic overrides (keep presets, reset active and custom)
+      activePresetId: defaults.activePresetId,
+      customOverrideRules: defaults.customOverrideRules,
+      overridesEnabled: defaults.overridesEnabled,
+      overridesPanelVisible: defaults.overridesPanelVisible,
+
+      // 2D Measure
+      measure2DMode: defaults.measure2DMode,
+      measure2DStart: defaults.measure2DStart,
+      measure2DCurrent: defaults.measure2DCurrent,
+      measure2DShiftLocked: defaults.measure2DShiftLocked,
+      measure2DLockedAxis: defaults.measure2DLockedAxis,
+      measure2DResults: defaults.measure2DResults,
+      measure2DSnapPoint: defaults.measure2DSnapPoint,
+
+      // Annotation tools
+      annotation2DActiveTool: defaults.annotation2DActiveTool,
+      annotation2DCursorPos: defaults.annotation2DCursorPos,
+      polygonArea2DPoints: defaults.polygonArea2DPoints,
+      polygonArea2DResults: defaults.polygonArea2DResults,
+      textAnnotations2D: defaults.textAnnotations2D,
+      textAnnotation2DEditing: defaults.textAnnotation2DEditing,
+      cloudAnnotation2DPoints: defaults.cloudAnnotation2DPoints,
+      cloudAnnotations2D: defaults.cloudAnnotations2D,
+      selectedAnnotation2D: defaults.selectedAnnotation2D,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -350,7 +350,7 @@ export interface Drawing2DSlice extends Drawing2DState {
  * slice initializer and `resetViewerState` (`store/index.ts`) call this so
  * the two paths can't drift — the same pattern `POINT_CLOUD_DEFAULTS` uses.
  */
-export const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOptions'] => ({
+const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOptions'] => ({
   showHiddenLines: true,
   showHatching: true,
   showAnnotations: true,

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -365,7 +365,7 @@ export const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOpti
   scanSectionIncludeInExport: true,
 });
 
-const getDefaultState = (): Drawing2DState => ({
+export const getDefaultDrawing2DState = (): Drawing2DState => ({
   drawing2D: null,
   drawing2DStatus: 'idle',
   drawing2DProgress: 0,
@@ -406,7 +406,7 @@ const getDefaultState = (): Drawing2DState => ({
 
 export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2DSlice> = (set, get) => ({
   // Initial state
-  ...getDefaultState(),
+  ...getDefaultDrawing2DState(),
 
   // Drawing Actions
   setDrawing2D: (drawing) => set({
@@ -441,8 +441,8 @@ export const createDrawing2DSlice: StateCreator<Drawing2DSlice, [], [], Drawing2
   // Only the drawing-generation fields, NOT the whole slice: this is called
   // by "View 2D" (SectionPanel.tsx) purely to force regeneration with
   // current settings, so it must leave graphic overrides, DXF underlays,
-  // and all annotation/measurement state (which `getDefaultState()` would
-  // wipe) untouched.
+  // and all annotation/measurement state (which `getDefaultDrawing2DState()`
+  // would wipe) untouched.
   clearDrawing2D: () => set({
     drawing2D: null,
     drawing2DStatus: 'idle',

--- a/apps/viewer/src/store/slices/drawing2DSlice.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.ts
@@ -347,7 +347,7 @@ export interface Drawing2DSlice extends Drawing2DState {
 
 /**
  * Single source of truth for `drawing2DDisplayOptions` defaults. Both the
- * slice initializer and `resetViewerState` (`store/index.ts`) call this so
+ * slice initializer and `drawing2DSlice.teardown.ts` call this so
  * the two paths can't drift — the same pattern `POINT_CLOUD_DEFAULTS` uses.
  */
 const getDefaultDisplayOptions = (): Drawing2DState['drawing2DDisplayOptions'] => ({

--- a/apps/viewer/src/store/slices/hoverSlice.ts
+++ b/apps/viewer/src/store/slices/hoverSlice.ts
@@ -8,6 +8,25 @@
 
 import type { StateCreator } from 'zustand';
 import type { HoverState, ContextMenuState } from '../types.js';
+import { defineSliceTeardown } from '../teardown.js';
+
+/**
+ * "Nothing is hovered", in one place.
+ *
+ * The initial state, {@link HoverSlice.clearHover} and the session-reset
+ * teardown all wrote this same four-field literal by hand; three copies of a
+ * value is three chances for them to disagree about what "cleared" means.
+ * `worldPosition` is left unset, exactly as all three did.
+ */
+function emptyHoverState(): HoverState {
+  return { entityId: null, screenX: 0, screenY: 0 };
+}
+
+/** "The context menu is closed", likewise shared by the initial state,
+ *  {@link HoverSlice.closeContextMenu} and the teardown. */
+function closedContextMenu(): ContextMenuState {
+  return { isOpen: false, entityId: null, screenX: 0, screenY: 0 };
+}
 
 export interface HoverSlice {
   // State
@@ -23,18 +42,43 @@ export interface HoverSlice {
 
 export const createHoverSlice: StateCreator<HoverSlice, [], [], HoverSlice> = (set) => ({
   // Initial state
-  hoverState: { entityId: null, screenX: 0, screenY: 0 },
-  contextMenu: { isOpen: false, entityId: null, screenX: 0, screenY: 0 },
+  hoverState: emptyHoverState(),
+  contextMenu: closedContextMenu(),
 
   // Actions
   setHoverState: (hoverState) => set({ hoverState }),
-  clearHover: () => set({ hoverState: { entityId: null, screenX: 0, screenY: 0 } }),
+  clearHover: () => set({ hoverState: emptyHoverState() }),
 
   openContextMenu: (entityId, screenX, screenY) => set({
     contextMenu: { isOpen: true, entityId, screenX, screenY },
   }),
 
-  closeContextMenu: () => set({
-    contextMenu: { isOpen: false, entityId: null, screenX: 0, screenY: 0 },
-  }),
+  closeContextMenu: () => set({ contextMenu: closedContextMenu() }),
 });
+
+/**
+ * What a session reset clears on the hover slice.
+ *
+ * `resetViewerState`'s "Hover/Context" block (`store/index.ts`). Both fields
+ * name an entity in the OUTGOING model by express id, and ids are reused
+ * across files, so a hover tooltip or an open context menu surviving a swap
+ * describes an unrelated element of the incoming one.
+ *
+ * `clearHover()` covers `hoverState` alone and stays a separate action: it is
+ * the pointer-leave path, which must not close a context menu the user opened.
+ * Both now build their value from the same helpers above, so the two paths
+ * cannot drift.
+ */
+export const hoverTeardown = defineSliceTeardown(
+  'hoverSlice',
+  ['hoverState', 'contextMenu'],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      hoverState: emptyHoverState(),
+      contextMenu: closedContextMenu(),
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/hoverSlice.ts
+++ b/apps/viewer/src/store/slices/hoverSlice.ts
@@ -73,8 +73,6 @@ export const hoverTeardown = defineSliceTeardown(
   'hoverSlice',
   ['hoverState', 'contextMenu'],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       hoverState: emptyHoverState(),

--- a/apps/viewer/src/store/slices/idsSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/idsSlice.teardown.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The IDS slice's contribution to viewer-state teardown.
+ *
+ * A sibling module rather than a block at the bottom of `idsSlice.ts` because
+ * that file sits at its recorded module-size budget (482 lines,
+ * `scripts/module-size-allowlist.txt`) and may not grow. The seam is real
+ * either way: this answers "what does IDS destroy under a scope", which is a
+ * different question from "how does IDS behave", and it has different rules —
+ * pure, no `set`, no `get`, no release call.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+/**
+ * What a session reset clears on the IDS slice.
+ *
+ * Carried verbatim from `resetViewerState` (`store/index.ts`):
+ *   "IDS - reset panel but keep document and results"
+ *   "Keep idsDocument, idsValidationReport, idsLocale - user's work"
+ *
+ * Those three are the user's work and are therefore absent from `owns` — this
+ * slice is not willing to destroy them on a file swap. So are the workspace
+ * preferences (`idsDisplayOptions`, `idsFilterMode`, `idsFocusMode`) and the
+ * report-derived caches (`idsAuditReport`, `idsAuditing`, `idsIsolationScope`,
+ * `idsIsolateMode`, `idsFailedEntityIds`, `idsPassedEntityIds`), none of which
+ * `resetViewerState` touches: they belong to the report, and the report
+ * survives.
+ *
+ * `clearIdsValidationReport()` — which `removeModel` and `clearAllModels` do
+ * call — stays an ENTRY-POINT side effect and is not folded in here. It
+ * observes a load-bearing order internally (`endIdsRowFocus` RELEASES the
+ * shared isolate/ghost channels before the `set` nulls the record), and that
+ * order is not expressible in a pure patch.
+ */
+export const idsTeardown = defineSliceTeardown(
+  'idsSlice',
+  [
+    'idsPanelVisible',
+    'idsLoading',
+    'idsProgress',
+    'idsError',
+    'idsActiveSpecificationId',
+    'idsActiveEntityId',
+    'idsFocusVisibilityOwned',
+  ],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      idsPanelVisible: false,
+      idsLoading: false,
+      idsProgress: null,
+      idsError: null,
+      idsActiveSpecificationId: null,
+      idsActiveEntityId: null,
+      // The per-row focus's claim on the shared isolate/ghost channels
+      // (#2867) goes with the row it belonged to. Both channels are nulled
+      // by the same `set` this patch is applied through, so there is
+      // nothing left to release — but the RECORD must not survive:
+      // ownership is tested by value, so a record left behind starts
+      // matching again the moment another owner installs equal content,
+      // and the next release destroys that owner's presentation (#2654
+      // fourth review).
+      idsFocusVisibilityOwned: null,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/idsSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/idsSlice.teardown.ts
@@ -48,8 +48,6 @@ export const idsTeardown = defineSliceTeardown(
     'idsFocusVisibilityOwned',
   ],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       idsPanelVisible: false,

--- a/apps/viewer/src/store/slices/lensSlice.ts
+++ b/apps/viewer/src/store/slices/lensSlice.ts
@@ -15,6 +15,7 @@ import type { Lens, LensRule, LensCriteria, AutoColorSpec, AutoColorLegendEntry,
 import { BUILTIN_LENSES } from '@ifc-lite/lens';
 import { duplicateLensConfig, mergeImportedLenses, reserveUniqueId } from '@/components/viewer/lens-editor-utils';
 import { saveJson, type SaveResult } from '@/lib/storage/save-result';
+import { defineSliceTeardown } from '../teardown.js';
 
 // Re-export types so existing consumer imports from this file still work
 export type { Lens, LensRule, LensCriteria, AutoColorSpec, AutoColorLegendEntry, DiscoveredLensData };
@@ -348,3 +349,38 @@ export const createLensSlice: StateCreator<LensSlice, [], [], LensSlice> = (set,
     return { savedLenses: next, activeLensId: lensId, lensPanelVisible: true };
   }),
 });
+
+/**
+ * Lens — deactivate but keep saved lenses.
+ *
+ * `savedLenses`, `discoveredLensData`, `lensAppliedColors` and
+ * `lensAutoColorLegend` are absent from both `owns` and the body: the first is
+ * the user's work, and the other three are not part of the session-reset
+ * payload today.
+ *
+ * `clearAllModels` drives most of these same fields through nine setters
+ * guarded on `activeLensId != null`. That block stays where it is until an
+ * `all-models-cleared` arm exists to replace it wholesale.
+ */
+export const lensTeardown = defineSliceTeardown(
+  'lensSlice',
+  [
+    'activeLensId', 'lensPanelVisible', 'lensColorMap', 'lensHiddenIds',
+    'lensAppliedHiddenIds', 'lensRuleIsolation', 'lensRuleCounts', 'lensRuleEntityIds',
+  ],
+  (scope) => scope.kind !== 'session-reset' ? {} : {
+    activeLensId: null,
+    lensPanelVisible: false,
+    lensColorMap: new Map<number, string>(),
+    lensHiddenIds: new Set<number>(),
+    // Ownership bookkeeping for the shared hidden/isolation channels — those
+    // channels are wiped by the same reset, so stale claims must not survive
+    // it: ownership is tested by VALUE, so a record left behind starts
+    // matching again the moment another owner installs equal content, and the
+    // next release destroys that owner's presentation (#2654 fourth review).
+    lensAppliedHiddenIds: [] as number[],
+    lensRuleIsolation: null,
+    lensRuleCounts: new Map<string, number>(),
+    lensRuleEntityIds: new Map<string, number[]>(),
+  },
+);

--- a/apps/viewer/src/store/slices/listSlice.ts
+++ b/apps/viewer/src/store/slices/listSlice.ts
@@ -9,6 +9,7 @@
 import type { StateCreator } from 'zustand';
 import type { ListDefinition, ListResult } from '@ifc-lite/lists';
 import { loadListDefinitions, saveListDefinitions } from '../../lib/lists/persistence.js';
+import { defineSliceTeardown } from '../teardown.js';
 
 export interface ListSlice {
   // State
@@ -78,3 +79,33 @@ export const createListSlice: StateCreator<ListSlice, [], [], ListSlice> = (set,
   setListExecuting: (listExecuting) => set({ listExecuting }),
   setPendingListDraft: (pendingListDraft) => set({ pendingListDraft }),
 });
+
+/**
+ * What a session reset clears on the list slice.
+ *
+ * Carried verbatim from `resetViewerState` (`store/index.ts`):
+ *   "Lists - reset result but keep definitions (user's saved lists)"
+ *
+ * `listDefinitions` is the user's authored work and round-trips to
+ * localStorage, so it is absent from `owns` — this slice is not willing to
+ * destroy it. `pendingListDraft` is absent for the same reason no teardown
+ * path touches it today: it is a hand-off in flight from another panel, and
+ * clearing it here would drop a list the user just asked to build.
+ */
+export const listTeardown = defineSliceTeardown(
+  'listSlice',
+  ['listPanelVisible', 'activeListId', 'listResult', 'listExecuting'],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      listPanelVisible: false,
+      activeListId: null,
+      // The rows reference the OUTGOING model's entities; the user re-runs
+      // the definition against the new one.
+      listResult: null,
+      listExecuting: false,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/listSlice.ts
+++ b/apps/viewer/src/store/slices/listSlice.ts
@@ -96,8 +96,6 @@ export const listTeardown = defineSliceTeardown(
   'listSlice',
   ['listPanelVisible', 'activeListId', 'listResult', 'listExecuting'],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       listPanelVisible: false,

--- a/apps/viewer/src/store/slices/loadingSlice.ts
+++ b/apps/viewer/src/store/slices/loadingSlice.ts
@@ -7,6 +7,7 @@
  */
 
 import type { StateCreator } from 'zustand';
+import { defineSliceTeardown } from '../teardown.js';
 
 export interface LoadingSlice {
   // State
@@ -55,3 +56,35 @@ export const createLoadingSlice: StateCreator<LoadingSlice, [], [], LoadingSlice
   setError: (error) => set({ error }),
   setActiveStreamCanceller: (activeStreamCanceller) => set({ activeStreamCanceller }),
 });
+
+/**
+ * What a session reset clears on the loading slice.
+ *
+ * `resetViewerState`'s "Data" block owns these six today (`store/index.ts`):
+ * a file swap ends whatever load was in flight as far as the UI is concerned,
+ * so the spinner, the three progress channels and the last error all go.
+ *
+ * `error` is THIS slice's field, not `chatSlice`'s — that one is `chatError`.
+ *
+ * `activeStreamCanceller` is deliberately absent from `owns`: no teardown path
+ * resets it today. It is a live cancellation hook owned by the loader hook
+ * that registered it, and dropping it here would silently orphan an in-flight
+ * stream's only stop button.
+ */
+export const loadingTeardown = defineSliceTeardown(
+  'loadingSlice',
+  ['loading', 'geometryStreamingActive', 'progress', 'geometryProgress', 'metadataProgress', 'error'],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      loading: false,
+      geometryStreamingActive: false,
+      progress: null,
+      geometryProgress: null,
+      metadataProgress: null,
+      error: null,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/loadingSlice.ts
+++ b/apps/viewer/src/store/slices/loadingSlice.ts
@@ -75,8 +75,6 @@ export const loadingTeardown = defineSliceTeardown(
   'loadingSlice',
   ['loading', 'geometryStreamingActive', 'progress', 'geometryProgress', 'metadataProgress', 'error'],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       loading: false,

--- a/apps/viewer/src/store/slices/modelSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/modelSlice.teardown.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `modelSlice`'s contribution to the store-wide teardown seam (`store/teardown.ts`).
+ *
+ * Beside the slice rather than inside it: `modelSlice.ts` carries a recorded
+ * budget in `scripts/module-size-allowlist.txt`, and that ratchet only lets a
+ * listed file shrink, never grow. Every slice in this group is split the same
+ * way so the registry imports one shape, not two.
+ *
+ * The federation registry is NOT touched here. `federationRegistry
+ * .unregisterModel` (partial removal, which BURNS the freed offset range) and
+ * `federationRegistry.clear()` (full clear, which resets the offset counter to
+ * 0 and is the reason several other slices clear unconditionally on
+ * `all-models-cleared`) are side effects, and a teardown is pure — they stay in
+ * the entry point, in today's order.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+export const modelTeardown = defineSliceTeardown(
+  'modelSlice',
+  ['models', 'activeModelId'],
+  (scope, state) => {
+    // `resetViewerState` deliberately does NOT clear models — "use
+    // clearAllModels() for that" (store/index.ts). A file load swaps the
+    // ACTIVE model; the federation itself survives it.
+    if (scope.kind === 'session-reset') return {};
+
+    if (scope.kind === 'all-models-cleared') {
+      return { models: new Map(), activeModelId: null };
+    }
+
+    const models = state.models;
+    // A removal that removes nothing must do nothing. `syncSourceModel` and the
+    // collab room teardown can both re-enter with an id that has already gone,
+    // and every cleanup below is keyed to THIS model (#2654 second review).
+    // This guard is also what makes the whole 'model-removed' composition a
+    // no-op on its second run: `purgeStaleEntityState` runs the SAME scope
+    // immediately after `removeModel` has already removed the model.
+    if (!models?.has(scope.modelId)) return {};
+
+    const nextModels = new Map(models);
+    nextModels.delete(scope.modelId);
+
+    // Reassign the active model only when the removed one held it. Insertion
+    // order decides the successor, exactly as `Array.from(newModels.keys())`
+    // did before this moved behind the seam.
+    const priorActiveId = state.activeModelId;
+    const activeModelId =
+      priorActiveId === scope.modelId
+        ? (Array.from(nextModels.keys())[0] ?? null)
+        : priorActiveId;
+
+    return { models: nextModels, activeModelId };
+  },
+);

--- a/apps/viewer/src/store/slices/modelSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/modelSlice.teardown.ts
@@ -38,7 +38,7 @@ export const modelTeardown = defineSliceTeardown(
     // collab room teardown can both re-enter with an id that has already gone,
     // and every cleanup below is keyed to THIS model (#2654 second review).
     // This guard is also what makes the whole 'model-removed' composition a
-    // no-op on its second run: `purgeStaleEntityState` runs the SAME scope
+    // no-op on its second run: `syncSourceModel` runs the SAME scope
     // immediately after `removeModel` has already removed the model.
     if (!models?.has(scope.modelId)) return {};
 

--- a/apps/viewer/src/store/slices/modelSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/modelSlice.teardown.ts
@@ -45,15 +45,9 @@ export const modelTeardown = defineSliceTeardown(
     const nextModels = new Map(models);
     nextModels.delete(scope.modelId);
 
-    // Reassign the active model only when the removed one held it. Insertion
-    // order decides the successor, exactly as `Array.from(newModels.keys())`
-    // did before this moved behind the seam.
-    const priorActiveId = state.activeModelId;
-    const activeModelId =
-      priorActiveId === scope.modelId
-        ? (Array.from(nextModels.keys())[0] ?? null)
-        : priorActiveId;
-
-    return { models: nextModels, activeModelId };
+    // The successor is resolved once by `modelRemovedScope`, not here: it is
+    // federation knowledge, and `dataSlice` has to follow the same answer to
+    // keep `ifcDataStore` / `geometryResult` pointing at the model this names.
+    return { models: nextModels, activeModelId: scope.nextActiveModelId };
   },
 );

--- a/apps/viewer/src/store/slices/modelSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/modelSlice.teardown.ts
@@ -37,9 +37,12 @@ export const modelTeardown = defineSliceTeardown(
     // A removal that removes nothing must do nothing. `syncSourceModel` and the
     // collab room teardown can both re-enter with an id that has already gone,
     // and every cleanup below is keyed to THIS model (#2654 second review).
-    // This guard is also what makes the whole 'model-removed' composition a
-    // no-op on its second run: `syncSourceModel` runs the SAME scope
-    // immediately after `removeModel` has already removed the model.
+    // This guard is what makes THIS slice's contribution a no-op on the second
+    // run: `syncSourceModel` dispatches model-removed again straight after
+    // `removeModel`, and the model is gone from `models` by then. The
+    // COMPOSITION is deliberately not a no-op there - the second scope is
+    // stricter (`notYetASurvivor`) and drops ids the first pass kept, which is
+    // the whole reason both runs exist. See `syncSourceModel`'s call site.
     if (!models?.has(scope.modelId)) return {};
 
     const nextModels = new Map(models);

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -477,7 +477,7 @@ describe('ModelSlice', () => {
     });
 
     describe('global-id state (selection sets / hidden / isolated / ghost / class filter)', () => {
-      // `syncSourceModel.ts`'s `purgeStaleEntityState` already purges these
+      // `syncSourceModel.ts`'s second model-removed purge already purges these
       // exact fields on the same-modelId resync path (comment above this
       // block's parent `describe`). `removeModel` never got the same
       // treatment for anything past the EntityRef-shaped selection fields —

--- a/apps/viewer/src/store/slices/modelSlice.test.ts
+++ b/apps/viewer/src/store/slices/modelSlice.test.ts
@@ -6,10 +6,41 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult } from '@ifc-lite/geometry';
-import { createModelSlice, type ModelSlice, type ModelCrossSliceState } from './modelSlice.js';
+import { createModelSlice, type ModelSlice } from './modelSlice.js';
 import type { FederatedModel } from '../types.js';
 
-type ModelTestState = ModelSlice & ModelCrossSliceState;
+/**
+ * Store fields other slices own that this harness has to seed.
+ *
+ * This used to be `modelSlice`'s exported `ModelCrossSliceState`. It is gone
+ * from the slice: teardown no longer reaches across, so the only cross-slice
+ * write left in production is `dataSlice`'s two active-model pointers, and the
+ * slice is typed over `ViewerState` like `collabSlice`. What remains is a
+ * HARNESS concern — `createModelSlice` is driven here with a stub `get()` that
+ * holds the model slice alone, and the teardown composition it dispatches
+ * reads these fields off that stub — so the list lives with the harness that
+ * seeds it rather than in the slice.
+ */
+interface ModelHarnessCrossState {
+  ifcDataStore: IfcDataStore | null;
+  geometryResult: GeometryResult | null;
+  meshColorBackup: Map<number, [number, number, number, number]> | null;
+  addElementModelId: string | null;
+  addElementStoreyId: number | null;
+  selectedEntityId: number | null;
+  selectedEntityIds: Set<number>;
+  selectedStoreys: Set<number>;
+  hiddenEntities: Set<number>;
+  isolatedEntities: Set<number> | null;
+  ghostExceptEntities: Set<number> | null;
+  classFilter: { ids: Set<number>; label: string } | null;
+  hiddenEntitiesByModel: Map<string, Set<number>>;
+  isolatedEntitiesByModel: Map<string, Set<number>>;
+  pinboardEntities: Set<string>;
+  hierarchyBasketSelection: Set<string>;
+}
+
+type ModelTestState = ModelSlice & ModelHarnessCrossState;
 
 /** The selection fields `removeModel` purges. They belong to another slice, so
  *  the slice under test reads them through a cast and so does this file. */

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -386,7 +386,7 @@ export const createModelSlice: StateCreator<ViewerState, [], [], ModelSlice> = (
     // the mesh-colour backup, which used to be computed here.
     // `modelRemovedScope` carries the survivor-range predicate every
     // global-id-keyed slice filters on: the loop that used to live in this
-    // function AND, verbatim, in `syncSourceModel`'s `purgeStaleEntityState`.
+    // function AND, verbatim, in `syncSourceModel`'s second purge.
     //
     // Read the state ONCE and hand the same object to both: the scope's
     // survivor set and the contributions that filter against it must not be

--- a/apps/viewer/src/store/slices/modelSlice.ts
+++ b/apps/viewer/src/store/slices/modelSlice.ts
@@ -12,11 +12,11 @@
  */
 
 import type { StateCreator } from 'zustand';
-import type { EntityRef, FederatedModel } from '../types.js';
-import { stringToEntityRef } from '../types.js';
-import type { IfcDataStore } from '@ifc-lite/parser';
-import type { GeometryResult } from '@ifc-lite/geometry';
+import type { FederatedModel } from '../types.js';
 import { federationRegistry, type GlobalIdLookup } from '@ifc-lite/renderer';
+import type { ViewerState } from '../index.js';
+import { viewerTeardown } from '../teardown-registry.js';
+import { modelRemovedScope } from '../teardown-scope.js';
 import {
   endIdsRowFocusPresentation,
   type IDSRowFocusPresentation,
@@ -25,43 +25,6 @@ import {
   endClashScenePresentation,
   type ClashSceneTeardown,
 } from '@/lib/clash/visibility-ownership';
-
-/**
- * Cross-slice fields the model actions write to. `ifcDataStore` and
- * `geometryResult` are owned by `dataSlice` but `modelSlice`'s set()
- * calls need to keep them in sync with the active model.
- */
-export interface ModelCrossSliceState {
-  ifcDataStore: IfcDataStore | null;
-  geometryResult: GeometryResult | null;
-  /** `dataSlice`'s per-element ORIGINAL colours, keyed by global express id.
-   *  Both teardown paths clear it: those ids are REUSED, so a survivor names
-   *  live elements of a model it was never taken from. */
-  meshColorBackup: Map<number, [number, number, number, number]> | null;
-  /** AddElement panel's target-model pin (addElementSlice) — cleared here on
-   *  full teardown for the same reason `removeModel` clears it when it names
-   *  the one model being removed. See that call site's comment. */
-  addElementModelId: string | null;
-  addElementStoreyId: number | null;
-  /** Global-id state `removeModel`/`clearAllModels` purge of ids the removed
-   *  model(s) owned — same shape as `syncSourceModel.ts`'s
-   *  `purgeStaleEntityState`, run here for the full-removal path it never
-   *  covered. See `removeModel`'s comment for why. */
-  selectedEntityId: number | null;
-  selectedEntityIds: Set<number>;
-  selectedStoreys: Set<number>;
-  hiddenEntities: Set<number>;
-  isolatedEntities: Set<number> | null;
-  ghostExceptEntities: Set<number> | null;
-  classFilter: { ids: Set<number>; label: string } | null;
-  hiddenEntitiesByModel: Map<string, Set<number>>;
-  isolatedEntitiesByModel: Map<string, Set<number>>;
-  /** Pinboard/basket state (pinboardSlice) `removeModel`/`clearAllModels`
-   *  purge of refs the removed model(s) owned — same entityRef-string
-   *  keying as `selectedEntitiesSet`. See `removeModel`'s comment for why. */
-  pinboardEntities: Set<string>;
-  hierarchyBasketSelection: Set<string>;
-}
 
 export interface ModelSlice {
   // State
@@ -184,7 +147,24 @@ function mutationViewsOf(
   return (state as { mutationViews?: Map<string, { getNewEntity: (id: number) => unknown }> }).mutationViews;
 }
 
-export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [], [], ModelSlice> = (set, get) => ({
+/**
+ * The model slice, typed over the WHOLE store.
+ *
+ * There used to be a `ModelCrossSliceState` here: sixteen fields owned by
+ * `dataSlice`, `selectionSlice`, `visibilitySlice`, `pinboardSlice` and
+ * `addElementSlice`, declared on this slice purely so `removeModel` and
+ * `clearAllModels` could type-check their reach into all five. Teardown no
+ * longer reaches: it returns a patch composed by the owning slices
+ * (`store/teardown-registry.ts`), so the interface is gone.
+ *
+ * What is left is real and is not teardown: `addModel`, `upsertModel`,
+ * `updateModel` and `setActiveModel` keep `dataSlice`'s `ifcDataStore` /
+ * `geometryResult` pointed at the ACTIVE model, in the same `set` that moves
+ * the model map. `ViewerState` — the same generic `collabSlice` uses — is how
+ * that is declared now: the store's own type, not a hand-listed shadow of five
+ * other slices that could silently drift from them.
+ */
+export const createModelSlice: StateCreator<ViewerState, [], [], ModelSlice> = (set, get) => ({
   // Initial state
   models: new Map(),
   activeModelId: null,
@@ -300,9 +280,9 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     // Unconditional, not "only if the
     // focused clash names this model": a clash id is `${ruleId} ${lo} ${hi}`
     // with `lo`/`hi` themselves `model:expressId`, and parsing it here would be
-    // a third, subtly different reading of a key format — the exact hazard the
-    // selection purge below calls out and routes through `stringToEntityRef`
-    // to avoid. Losing a highlight on an unrelated model's removal is cheap;
+    // a third, subtly different reading of a key format — the exact hazard
+    // `slices/selectionSlice.teardown.ts` calls out and routes through
+    // `stringToEntityRef` to avoid. Losing a highlight on an unrelated model's removal is cheap;
     // an orphaned opaque solid over the survivors is not.
     //
     // The clash RESULT is deliberately kept: it is a list the user is reading,
@@ -392,253 +372,31 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       compareCross.clearCompare?.();
     }
 
-    // Purge only THIS model's entries from `dataSlice`'s mesh-colour backup.
-    // Dropping the map whole would take the SURVIVING models' undo with it, and
-    // it is not needed for them: `unregisterModel` below burns the removed
-    // range rather than reclaiming it, so no later model is handed these ids.
-    // (`clearAllModels` is the opposite case -- it calls `federationRegistry
-    // .clear()`, offsets restart at 0, and ids genuinely are reused -- which is
-    // why the clear there is unconditional.)
+    // Unregister from the federation registry. This used to sit INSIDE the
+    // `set` updater below; it is a side effect on a singleton rather than
+    // state, and nothing between here and the `set` reads it — the survivor
+    // predicate is computed from `models`, not from the registry. Partial
+    // removal BURNS the freed offset range instead of reclaiming it
+    // (`federation-registry.ts`), which is why a teardown may purge THIS
+    // model's global ids and leave every survivor's alone.
+    federationRegistry.unregisterModel(modelId);
+
+    // One composed patch, built by the slices that own the fields
+    // (`store/teardown-registry.ts`) — including `dataSlice`'s scoped purge of
+    // the mesh-colour backup, which used to be computed here.
+    // `modelRemovedScope` carries the survivor-range predicate every
+    // global-id-keyed slice filters on: the loop that used to live in this
+    // function AND, verbatim, in `syncSourceModel`'s `purgeStaleEntityState`.
     //
-    // `resolveGlobalIdInModel` is the owner-scoped resolver this file already
-    // provides for exactly this question; it shares its range and overlay
-    // predicates with the unscoped one, so the two cannot drift.
-    const priorBackup = get().meshColorBackup;
-    const keptBackup = priorBackup
-      ? new Map([...priorBackup].filter(([id]) => get().resolveGlobalIdInModel(modelId, id) === null))
-      : null;
-
-    set((state) => {
-      const newModels = new Map(state.models);
-      newModels.delete(modelId);
-
-
-      // Unregister from federation registry
-      federationRegistry.unregisterModel(modelId);
-
-      // Update activeModelId if removed model was active
-      let newActiveId = state.activeModelId;
-      if (state.activeModelId === modelId) {
-        const remaining = Array.from(newModels.keys());
-        newActiveId = remaining.length > 0 ? remaining[0] : null;
-      }
-
-      const activeModel = newActiveId ? newModels.get(newActiveId) : null;
-
-      // Selection state keys off modelId, so anything pointing at the removed
-      // model is now dangling: `models.get(selectedEntity.modelId)` returns
-      // undefined and the properties panel silently renders nothing rather
-      // than re-resolving, leaving a ghost selection until the user clicks
-      // elsewhere. `activeStorey` likewise stays pinned to a storey in a model
-      // that no longer exists, which the Solo level display and floorplan read.
-      //
-      // `syncSourceModel`'s purgeStaleReferences already does exactly this for
-      // the same-modelId resync path; full removal needed the same treatment
-      // and never got it. Entries belonging to OTHER models are preserved —
-      // clearing wholesale would drop a federated sibling's live selection.
-      // Selection lives on selectionSlice; reached through a narrow cast the
-      // same way the mutation/IDS/source-tag actions above are reached via
-      // `cross`, since a slice's own StateCreator is typed to its own fields.
-      // Every field is optional here, not just cast: `modelSlice.test.ts`
-      // drives this action through a harness that stubs `set`/`get` with the
-      // model slice alone, so selection fields are genuinely absent there. A
-      // slice reaching across must tolerate that rather than assume the
-      // combined store.
-      const sel = state as unknown as Partial<{
-        selectedEntity: EntityRef | null;
-        activeStorey: EntityRef | null;
-        selectedEntities: EntityRef[];
-        selectedEntitiesSet: Set<string>;
-        selectedModelId: string | null;
-        addElementModelId: string | null;
-        addElementStoreyId: number | null;
-        selectedEntityId: number | null;
-        selectedEntityIds: Set<number>;
-        selectedStoreys: Set<number>;
-        hiddenEntities: Set<number>;
-        isolatedEntities: Set<number> | null;
-        ghostExceptEntities: Set<number> | null;
-        classFilter: { ids: Set<number>; label: string } | null;
-        hiddenEntitiesByModel: Map<string, Set<number>>;
-        isolatedEntitiesByModel: Map<string, Set<number>>;
-        mutationViews: Map<string, { getNewEntity: (id: number) => unknown }>;
-        pinboardEntities: Set<string>;
-        hierarchyBasketSelection: Set<string>;
-      }>;
-      const priorEntities = sel.selectedEntities ?? [];
-      const priorSet = sel.selectedEntitiesSet ?? new Set<string>();
-      const keptEntities = priorEntities.filter((e) => e.modelId !== modelId);
-      const selectionTouchedRemoved =
-        sel.selectedEntity?.modelId === modelId ||
-        sel.activeStorey?.modelId === modelId ||
-        keptEntities.length !== priorEntities.length;
-
-      // Global-id sets (selection, hidden, isolated, ghost, class filter) key
-      // off `globalId`, not `modelId` — they don't carry which model an id
-      // belongs to the way `EntityRef`-shaped state above does. A global id
-      // is "stale" once no SURVIVING model's parse range or overlay owns it
-      // (mirrors `syncSourceModel.ts`'s `purgeStaleEntityState`, the same
-      // check the resync path already runs after a model swap; full removal
-      // never got it, matching the gap `addElementModelId` had above — same
-      // dangling-reference shape, more fields). Left unpurged, an isolate or
-      // ghost set that only ever named the removed model's entities stays
-      // non-null while matching nothing in the survivors, so
-      // `effectiveIsolatedIds` keeps returning it and the entire remaining
-      // federation renders as hidden — worse than the id merely dangling.
-      const survivors = Array.from(newModels.values());
-      const mutationViews = sel.mutationViews;
-      const isStale = (id: number): boolean => {
-        for (const survivor of survivors) {
-          const localId = id - survivor.idOffset;
-          if (localId < 0) continue;
-          if (localId <= survivor.maxExpressId) return false;
-          if (mutationViews?.get(survivor.id)?.getNewEntity(localId) != null) return false;
-        }
-        return true;
-      };
-      const priorSelectedEntityIds = sel.selectedEntityIds;
-      const priorSelectedStoreys = sel.selectedStoreys;
-      const priorHiddenEntities = sel.hiddenEntities;
-      const priorIsolatedEntities = sel.isolatedEntities;
-      const priorGhostEntities = sel.ghostExceptEntities;
-      const priorClassFilter = sel.classFilter;
-      const globalIdStateTouchedRemoved =
-        (priorSelectedEntityIds && [...priorSelectedEntityIds].some(isStale)) ||
-        (priorSelectedStoreys && [...priorSelectedStoreys].some(isStale)) ||
-        (priorHiddenEntities && [...priorHiddenEntities].some(isStale)) ||
-        (priorIsolatedEntities && [...priorIsolatedEntities].some(isStale)) ||
-        (priorGhostEntities && [...priorGhostEntities].some(isStale)) ||
-        (priorClassFilter && [...priorClassFilter.ids].some(isStale)) ||
-        (sel.selectedEntityId !== undefined && sel.selectedEntityId !== null && isStale(sel.selectedEntityId)) ||
-        sel.hiddenEntitiesByModel?.has(modelId) ||
-        sel.isolatedEntitiesByModel?.has(modelId);
-
-      // The AddElement panel's "target model" pin (addElementSlice) is the
-      // same shape of dangling reference as the selection fields above, just
-      // on a different slice: `addElementModelId` names a specific federated
-      // model so the panel and the click-placement handlers
-      // (`resolveAddElementContext` in selectionHandlers.ts) stop tracking
-      // whichever model is merely active. Nothing else clears it when that
-      // model goes away, so it keeps naming a model no longer in `models`
-      // after removal — the panel's Select renders blank instead of falling
-      // back to the active model, and every subsequent placement click fails
-      // with "No model loaded for id" until the user re-picks a model by
-      // hand. `addElementStoreyId` is an express id local to that same
-      // model, so it is stale too and reset alongside it; it is left alone
-      // when the pin names a different (surviving) model, matching how
-      // `selectedEntities` above only drops entries that belong to the
-      // removed model.
-      const addElementTouchedRemoved = sel.addElementModelId === modelId;
-
-      // Pinboard/basket state (pinboardSlice) is keyed the same way as
-      // `selectedEntitiesSet` above -- Set<string> of "modelId:expressId"
-      // entityRef strings -- but was never purged here. `pinboardEntities`
-      // is documented in pinboardSlice.ts as the basket's SOURCE OF TRUTH:
-      // every basket edit (`addToBasket`/`removeFromBasket`/`showPinboard`)
-      // re-derives `isolatedEntities` from it via `toGlobalIdForRef`, and
-      // `toGlobalIdFromModels` falls back to the RAW, un-offset expressId
-      // when a ref's modelId is no longer in `models`. A stale ref surviving
-      // removal therefore doesn't just dangle inertly: the next basket
-      // operation resolves it to a bare, unscaled global id that can collide
-      // with a real entity in any surviving model whose own offset range
-      // covers that raw number (any model with idOffset 0, notably) --
-      // silently co-isolating or co-hiding an entity the user never touched.
-      const priorPinboard = sel.pinboardEntities ?? new Set<string>();
-      const priorHierarchyBasket = sel.hierarchyBasketSelection ?? new Set<string>();
-      const keptPinboard = new Set(
-        [...priorPinboard].filter((k) => stringToEntityRef(k).modelId !== modelId)
-      );
-      const keptHierarchyBasket = new Set(
-        [...priorHierarchyBasket].filter((k) => stringToEntityRef(k).modelId !== modelId)
-      );
-      const pinboardTouchedRemoved =
-        keptPinboard.size !== priorPinboard.size || keptHierarchyBasket.size !== priorHierarchyBasket.size;
-
-      return {
-        models: newModels,
-        activeModelId: newActiveId,
-        ifcDataStore: activeModel?.ifcDataStore ?? null,
-        geometryResult: activeModel?.geometryResult ?? null,
-        meshColorBackup: keptBackup && keptBackup.size > 0 ? keptBackup : null,
-        ...(selectionTouchedRemoved
-          ? {
-              selectedEntity:
-                sel.selectedEntity?.modelId === modelId ? null : sel.selectedEntity,
-              activeStorey: sel.activeStorey?.modelId === modelId ? null : sel.activeStorey,
-              selectedEntities: keptEntities,
-              // Parsed with the shared helper rather than a `${modelId}:`
-              // prefix test: `stringToEntityRef` splits on the FIRST colon, so
-              // a prefix match would also strip a sibling model whose id
-              // merely starts with this one's id plus a colon. Using the same
-              // parse every other consumer uses keeps this filter from
-              // becoming a third, subtly different reading of the same key.
-              selectedEntitiesSet: new Set(
-                [...priorSet].filter(
-                  (k) => stringToEntityRef(k).modelId !== modelId
-                )
-              ),
-              selectedModelId: sel.selectedModelId === modelId ? null : (sel.selectedModelId ?? null),
-            }
-          : {}),
-        ...(addElementTouchedRemoved
-          ? { addElementModelId: null, addElementStoreyId: null }
-          : {}),
-        ...(globalIdStateTouchedRemoved
-          ? {
-              selectedEntityId:
-                sel.selectedEntityId != null && isStale(sel.selectedEntityId) ? null : sel.selectedEntityId,
-              selectedEntityIds: priorSelectedEntityIds
-                ? new Set([...priorSelectedEntityIds].filter((id) => !isStale(id)))
-                : priorSelectedEntityIds,
-              selectedStoreys: priorSelectedStoreys
-                ? new Set([...priorSelectedStoreys].filter((id) => !isStale(id)))
-                : priorSelectedStoreys,
-              hiddenEntities: priorHiddenEntities
-                ? new Set([...priorHiddenEntities].filter((id) => !isStale(id)))
-                : priorHiddenEntities,
-              // An isolate/ghost set left with zero surviving ids must clear
-              // to `null` outright, not an empty `Set` — a non-null empty set
-              // still reads as "isolation active, nothing matches" and hides
-              // every remaining entity, same as the stale set it replaces.
-              isolatedEntities: priorIsolatedEntities
-                ? (() => {
-                    const kept = new Set([...priorIsolatedEntities].filter((id) => !isStale(id)));
-                    return kept.size > 0 ? kept : null;
-                  })()
-                : priorIsolatedEntities,
-              ghostExceptEntities: priorGhostEntities
-                ? (() => {
-                    const kept = new Set([...priorGhostEntities].filter((id) => !isStale(id)));
-                    return kept.size > 0 ? kept : null;
-                  })()
-                : priorGhostEntities,
-              classFilter: priorClassFilter
-                ? (() => {
-                    const kept = new Set([...priorClassFilter.ids].filter((id) => !isStale(id)));
-                    return kept.size > 0 ? { ids: kept, label: priorClassFilter.label } : null;
-                  })()
-                : priorClassFilter,
-              hiddenEntitiesByModel: sel.hiddenEntitiesByModel
-                ? (() => {
-                    const next = new Map(sel.hiddenEntitiesByModel);
-                    next.delete(modelId);
-                    return next;
-                  })()
-                : sel.hiddenEntitiesByModel,
-              isolatedEntitiesByModel: sel.isolatedEntitiesByModel
-                ? (() => {
-                    const next = new Map(sel.isolatedEntitiesByModel);
-                    next.delete(modelId);
-                    return next;
-                  })()
-                : sel.isolatedEntitiesByModel,
-            }
-          : {}),
-        ...(pinboardTouchedRemoved
-          ? { pinboardEntities: keptPinboard, hierarchyBasketSelection: keptHierarchyBasket }
-          : {}),
-      };
-    });
+    // Read the state ONCE and hand the same object to both: the scope's
+    // survivor set and the contributions that filter against it must not be
+    // computed off two different snapshots.
+    //
+    // Applied through the slice's own `set`, which is the store's wrapped
+    // setter, so the shared isolate / ghost channels this can null still go
+    // through `withVisibilityOwnershipInvalidation`.
+    const state = get();
+    set(viewerTeardown(modelRemovedScope(state, modelId), state));
   },
 
   clearAllModels: () => {
@@ -677,17 +435,20 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
     endIdsRowFocusPresentation(get() as unknown as IDSRowFocusPresentation);
     // Clear the federation registry
     federationRegistry.clear();
-    // Same dangling reference as `removeModel`'s `addElementModelId` cleanup
-    // above, just for every model at once: with `models` about to become
-    // empty there is no federated model left for the AddElement panel's pin
-    // to name, so it and the model-local storey id go too. Same for every
-    // global-id set `removeModel` purges by range (selection, hidden,
-    // isolated, ghost, class filter, and the per-model maps): with zero
-    // survivors every id in them is stale by definition, so this unconditionally
-    // clears them rather than repeating the range check for an always-true
-    // answer. `isolatedEntities`/`ghostExceptEntities` clear to `null` (not an
-    // empty `Set`) for the same reason `removeModel` does — an empty-but-set
-    // isolate would hide the very next model loaded, until it does.
+    // Same dangling reference as `removeModel`'s `addElementModelId` cleanup,
+    // just for every model at once: with `models` about to become empty there
+    // is no federated model left for the AddElement panel's pin to name, so it
+    // and the model-local storey id go too. Same for every global-id set
+    // `removeModel` purges by range (selection, hidden, isolated, ghost, class
+    // filter, and the per-model maps): with zero survivors every id in them is
+    // stale by definition, so the composed teardown at the end of this function
+    // clears them unconditionally rather than repeating the range check for an
+    // always-true answer. `isolatedEntities`/`ghostExceptEntities` clear to
+    // `null` (not an empty `Set`) for the same reason `removeModel` does — an
+    // empty-but-set isolate would hide the very next model loaded, until it
+    // does. Each of those clears now lives with the slice that owns the field;
+    // this note stays here because it is the reason the OVERLAY call below is
+    // unconditional too.
     // `federationRegistry.clear()` above resets the offset counter to 0, so
     // the very next model registered can be handed the exact global ids a
     // still-registered overlay layer's `hiddenIds`/`colorOverrides` name.
@@ -767,31 +528,13 @@ export const createModelSlice: StateCreator<ModelSlice & ModelCrossSliceState, [
       lensCross.setLensRuleEntityIds?.(new Map());
       lensCross.setLensAutoColorLegend?.([]);
     }
-    return set({
-      models: new Map(),
-      activeModelId: null,
-      ifcDataStore: null,
-      geometryResult: null,
-      // Goes with the geometry it describes: first-write-wins, so a survivor
-      // repaints a departed model's colour onto whatever takes that id next.
-      meshColorBackup: null,
-      addElementModelId: null,
-      addElementStoreyId: null,
-      selectedEntityId: null,
-      selectedEntityIds: new Set(),
-      selectedStoreys: new Set(),
-      hiddenEntities: new Set(),
-      isolatedEntities: null,
-      ghostExceptEntities: null,
-      classFilter: null,
-      hiddenEntitiesByModel: new Map(),
-      isolatedEntitiesByModel: new Map(),
-      // Same dangling-ref shape as `removeModel`'s pinboard purge above, for
-      // the full-teardown path: with every model gone, every basket ref is
-      // stale by definition.
-      pinboardEntities: new Set(),
-      hierarchyBasketSelection: new Set(),
-    });
+    // One composed patch, built by the slices that own the fields
+    // (`store/teardown-registry.ts`). Every 'all-models-cleared' arm clears
+    // unconditionally rather than range-checking: `federationRegistry.clear()`
+    // above restarts the offset counter at 0, so with zero survivors every
+    // stored global id is stale by definition AND the very next model loaded
+    // can be handed those exact numbers back.
+    set(viewerTeardown({ kind: 'all-models-cleared' }, get()));
   },
 
   setActiveModel: (modelId) => set((state) => {

--- a/apps/viewer/src/store/slices/mutationSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.teardown.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `mutationSlice`'s contribution to the store-wide teardown seam
+ * (`store/teardown.ts`). Split out beside the slice for the reason
+ * `modelSlice.teardown.ts` documents.
+ *
+ * Session reset ONLY. `removeModel` discards the removed model's mutation
+ * footprint through `clearMutations` / `clearMutationView`, which are existing,
+ * separately-tested, per-model actions with ordering of their own — they stay
+ * in the entry point, and `mutationViews` must NOT be added to a
+ * 'model-removed' arm here.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+export const mutationTeardown = defineSliceTeardown(
+  'mutationSlice',
+  [
+    'mutationViews',
+    'changeSets',
+    'activeChangeSetId',
+    'undoStacks',
+    'redoStacks',
+    'dirtyModels',
+    'mutationVersion',
+  ],
+  (scope, state) => {
+    // Mutations - clear all mutation state so stale changes don't carry over
+    if (scope.kind !== 'session-reset') return {};
+
+    return {
+      mutationViews: new Map(),
+      changeSets: new Map(),
+      activeChangeSetId: null,
+      undoStacks: new Map(),
+      redoStacks: new Map(),
+      dirtyModels: new Set<string>(),
+      // DELIBERATE difference from this slice's initial value (`0`): the reset
+      // BUMPS the version rather than zeroing it. It is the one derived value
+      // in the whole table — every consumer keyed on it re-reads when it moves,
+      // and rewinding to 0 could land on a number a consumer has already seen.
+      // It always differs from the current value, so the composition never
+      // drops it. Session reset only: bumping it on every model removal would
+      // be a behaviour change, not a restructuring.
+      mutationVersion: (state.mutationVersion ?? 0) + 1,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
@@ -72,7 +72,7 @@ export const pinboardTeardown = defineSliceTeardown(
     );
 
     // Nothing of ours belonged to the removed model: return {} rather than two
-    // equal-but-new Sets. `purgeStaleEntityState` runs this same scope again
+    // equal-but-new Sets. `syncSourceModel` runs this same scope again
     // straight after `removeModel`, and a fresh reference there would re-notify
     // every basket subscriber for a set that did not move.
     if (

--- a/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `pinboardSlice`'s contribution to the store-wide teardown seam
+ * (`store/teardown.ts`). Split out beside the slice for the reason
+ * `modelSlice.teardown.ts` documents.
+ *
+ * `clearPinboard` / `clearBasket` are NOT folded in and must not be: both of
+ * them also write `isolatedEntities`, which belongs to `visibilitySlice`.
+ * Ownership here is disjoint by construction (`createTeardownRegistry` proves
+ * it at module init), so the isolation channel is torn down once, by its owner.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { stringToEntityRef } from '../types.js';
+
+export const pinboardTeardown = defineSliceTeardown(
+  'pinboardSlice',
+  [
+    'pinboardEntities',
+    'hierarchyBasketSelection',
+    'basketViews',
+    'activeBasketViewId',
+    'basketPresentationVisible',
+  ],
+  (scope, state) => {
+    if (scope.kind === 'session-reset') {
+      return {
+        // Pinboard - clear pinned entities on new file
+        pinboardEntities: new Set<string>(),
+        basketViews: [],
+        activeBasketViewId: null,
+        basketPresentationVisible: false,
+        hierarchyBasketSelection: new Set<string>(),
+      };
+    }
+
+    if (scope.kind === 'all-models-cleared') {
+      // Same dangling-ref shape as the 'model-removed' purge below, for the
+      // full-teardown path: with every model gone, every basket ref is stale by
+      // definition. `basketViews` / `activeBasketViewId` /
+      // `basketPresentationVisible` are NOT in this arm — `clearAllModels` has
+      // never written them, and a saved view is a document the user authored,
+      // not scene state.
+      return {
+        pinboardEntities: new Set<string>(),
+        hierarchyBasketSelection: new Set<string>(),
+      };
+    }
+
+    // Pinboard/basket state is keyed the same way as `selectedEntitiesSet` --
+    // Set<string> of "modelId:expressId" entityRef strings. `pinboardEntities`
+    // is the basket's SOURCE OF TRUTH: every basket edit
+    // (`addToBasket`/`removeFromBasket`/`showPinboard`) re-derives
+    // `isolatedEntities` from it via `toGlobalIdForRef`, and
+    // `toGlobalIdFromModels` falls back to the RAW, un-offset expressId when a
+    // ref's modelId is no longer in `models`. A stale ref surviving removal
+    // therefore doesn't just dangle inertly: the next basket operation resolves
+    // it to a bare, unscaled global id that can collide with a real entity in
+    // any surviving model whose own offset range covers that raw number (any
+    // model with idOffset 0, notably) -- silently co-isolating or co-hiding an
+    // entity the user never touched.
+    const priorPinboard = state.pinboardEntities ?? new Set<string>();
+    const priorHierarchyBasket = state.hierarchyBasketSelection ?? new Set<string>();
+    const keptPinboard = new Set(
+      [...priorPinboard].filter((k) => stringToEntityRef(k).modelId !== scope.modelId),
+    );
+    const keptHierarchyBasket = new Set(
+      [...priorHierarchyBasket].filter((k) => stringToEntityRef(k).modelId !== scope.modelId),
+    );
+
+    // Nothing of ours belonged to the removed model: return {} rather than two
+    // equal-but-new Sets. `purgeStaleEntityState` runs this same scope again
+    // straight after `removeModel`, and a fresh reference there would re-notify
+    // every basket subscriber for a set that did not move.
+    if (
+      keptPinboard.size === priorPinboard.size &&
+      keptHierarchyBasket.size === priorHierarchyBasket.size
+    ) {
+      return {};
+    }
+
+    return { pinboardEntities: keptPinboard, hierarchyBasketSelection: keptHierarchyBasket };
+  },
+);

--- a/apps/viewer/src/store/slices/playbackSlice.ts
+++ b/apps/viewer/src/store/slices/playbackSlice.ts
@@ -23,6 +23,7 @@ import type { StateCreator } from 'zustand';
 import type { AnimationSettings } from '@/components/viewer/schedule/schedule-animator';
 import { DEFAULT_ANIMATION_SETTINGS } from '@/components/viewer/schedule/schedule-animator';
 import type { ScheduleTimeRange } from './scheduleSlice.js';
+import { defineSliceTeardown } from '../teardown.js';
 
 export interface PlaybackSlice {
   /** Animation master toggle — when false the viewer renders normally. */
@@ -126,3 +127,20 @@ export const createPlaybackSlice: StateCreator<
     set({ playbackTime: next });
   },
 });
+
+/**
+ * Schedule (4D) playback — stop the clock and rewind it on a file swap.
+ *
+ * `playbackSpeed`, `playbackLoop` and `animationSettings` are deliberately
+ * ABSENT from both `owns` and the body: they are user preferences that survive
+ * file loads, exactly as `resetViewerState`'s schedule block says.
+ */
+export const playbackTeardown = defineSliceTeardown(
+  'playbackSlice',
+  ['animationEnabled', 'playbackIsPlaying', 'playbackTime'],
+  (scope) => scope.kind !== 'session-reset' ? {} : {
+    animationEnabled: false,
+    playbackIsPlaying: false,
+    playbackTime: 0,
+  },
+);

--- a/apps/viewer/src/store/slices/pointCloudSlice.ts
+++ b/apps/viewer/src/store/slices/pointCloudSlice.ts
@@ -162,7 +162,7 @@ export interface PointCloudSlice {
  * Both the slice initializer and `resetViewerState` consume this so
  * the two paths can't drift.
  */
-export const POINT_CLOUD_DEFAULTS = {
+const POINT_CLOUD_DEFAULTS = {
   // Fixed-px is the default so the size slider feels responsive on first
   // contact. `attenuated` is nicer at extreme zooms but its "slider =
   // upper cap" semantic confuses users at typical wide views because the

--- a/apps/viewer/src/store/slices/pointCloudSlice.ts
+++ b/apps/viewer/src/store/slices/pointCloudSlice.ts
@@ -12,6 +12,8 @@
 
 import type { StateCreator } from 'zustand';
 
+import { defineSliceTeardown } from '../teardown.js';
+
 export type PointColorModeUi = 'rgb' | 'classification' | 'intensity' | 'height' | 'fixed' | 'deviation';
 export type PointSizeModeUi = 'fixed-px' | 'adaptive-world' | 'attenuated';
 
@@ -251,3 +253,48 @@ export const createPointCloudSlice: StateCreator<PointCloudSlice, [], [], PointC
   setPointCloudAlignmentAvailable: (available) => set({ pointCloudAlignmentAvailable: available }),
   setPointCloudAlignmentEnabled: (enabled) => set({ pointCloudAlignmentEnabled: enabled }),
 });
+
+/**
+ * Point cloud — clear runtime fields so a new file doesn't inherit the
+ * previous file's color mode / size / EDL state.
+ *
+ * The one place in the registry where spreading a shared defaults const IS the
+ * explicit field list Trap A asks for: `POINT_CLOUD_DEFAULTS` is this slice's
+ * own, it is not the slice's whole state (the actions are not in it), and every
+ * field in it is session-scoped — none of them round-trips to localStorage or
+ * outlives a model swap. `owns` still names all 17 by hand, so the reviewable
+ * artefact stays a list.
+ *
+ * `pointCloudDeviationComputed` is ALSO driven to false by `removeModel` and
+ * `clearAllModels` through `setPointCloudDeviationComputed(false)`. That stays
+ * an entry-point side effect: taking it into a `model-removed` arm here as well
+ * would write the field twice on the same path.
+ */
+export const pointCloudTeardown = defineSliceTeardown(
+  'pointCloudSlice',
+  [
+    'pointCloudColorMode',
+    'pointCloudFixedColor',
+    'pointCloudSizeMode',
+    'pointCloudPointSize',
+    'pointCloudWorldRadius',
+    'pointCloudRoundShape',
+    'pointCloudEdlEnabled',
+    'pointCloudEdlStrength',
+    'pointCloudClassMask',
+    'pointCloudClassCounts',
+    'pointCloudPreviewStride',
+    'pointCloudDeviationCenterOffset',
+    'pointCloudDeviationHalfRange',
+    'pointCloudDeviationComputed',
+    'pointCloudAssetCount',
+    'pointCloudAlignmentAvailable',
+    'pointCloudAlignmentEnabled',
+  ],
+  (scope) => scope.kind !== 'session-reset' ? {} : {
+    ...POINT_CLOUD_DEFAULTS,
+    // Re-spread typed-array fields so consumers get fresh references
+    // instead of the readonly literal in POINT_CLOUD_DEFAULTS.
+    pointCloudFixedColor: [...POINT_CLOUD_DEFAULTS.pointCloudFixedColor] as [number, number, number, number],
+  },
+);

--- a/apps/viewer/src/store/slices/pointCloudSlice.ts
+++ b/apps/viewer/src/store/slices/pointCloudSlice.ts
@@ -159,7 +159,7 @@ export interface PointCloudSlice {
 
 /**
  * Single source of truth for the slice's runtime field defaults.
- * Both the slice initializer and `resetViewerState` consume this so
+ * Both the slice initializer and `pointCloudTeardown` consume this so
  * the two paths can't drift.
  */
 const POINT_CLOUD_DEFAULTS = {

--- a/apps/viewer/src/store/slices/scheduleSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/scheduleSlice.teardown.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `scheduleSlice`'s contribution to the store teardown registry (`store/teardown.ts`).
+ *
+ * SEPARATE FILE, not the bottom of `scheduleSlice.ts`, because that file sits
+ * at its module-size budget exactly (1317 lines, frozen by
+ * `scripts/module-size-allowlist.txt`): a single added line fails the ratchet,
+ * and raising a budget to make room for a refactor is what the gate exists to
+ * stop. Splitting at the teardown seam is the supported answer, and
+ * `schedule-edit-helpers.ts` is the same slice's existing precedent for a
+ * sibling module of this slice.
+ *
+ * Every value below is the slice's own initial value (`scheduleSlice.ts`
+ * lines 378-385), which already matched what `resetViewerState` restated.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+/**
+ * Schedule (4D) — drop panel + data; definitions are re-extracted on next load.
+ *
+ * `ganttTimeScale` is deliberately absent from both `owns` and the body: it is
+ * a user preference that survives file loads, as are `playbackSpeed` and
+ * `playbackLoop` over in `playbackSlice`.
+ *
+ * `clearGeneratedSchedule()` is called by `removeModel` when the federation
+ * empties. That stays an entry-point side effect: it prunes generated tasks out
+ * of a surviving `scheduleData` rather than dropping the whole extraction, so
+ * it is not this teardown under another name.
+ */
+export const scheduleTeardown = defineSliceTeardown(
+  'scheduleSlice',
+  [
+    'ganttPanelVisible',
+    'generateScheduleDialogOpen',
+    'scheduleData',
+    'scheduleRange',
+    'activeWorkScheduleId',
+    'expandedTaskGlobalIds',
+    'hoveredTaskGlobalId',
+    'selectedTaskGlobalIds',
+  ],
+  (scope) => scope.kind !== 'session-reset' ? {} : {
+    ganttPanelVisible: false,
+    generateScheduleDialogOpen: false,
+    scheduleData: null,
+    scheduleRange: null,
+    activeWorkScheduleId: '',
+    expandedTaskGlobalIds: new Set<string>(),
+    hoveredTaskGlobalId: null,
+    selectedTaskGlobalIds: new Set<string>(),
+  },
+);

--- a/apps/viewer/src/store/slices/scriptSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/scriptSlice.teardown.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The script slice's contribution to viewer-state teardown.
+ *
+ * A sibling module rather than a block at the bottom of `scriptSlice.ts`
+ * because that file sits at its recorded module-size budget (536 lines,
+ * `scripts/module-size-allowlist.txt`) and may not grow.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+
+/**
+ * What a session reset clears on the script slice.
+ *
+ * Carried verbatim from `resetViewerState` (`store/index.ts`):
+ *   "Script - reset execution state but keep saved scripts, editor content,
+ *    and panel visibility (scripts that create-and-load a model should not
+ *    close the panel)"
+ *
+ * That parenthesis is the whole reason `scriptPanelVisible` is absent from
+ * `owns`: a script is a first-class way to LOAD a model, so the load it
+ * triggers must not close the panel it was run from. `savedScripts`,
+ * `activeScriptId`, `scriptEditorContent`, `scriptEditorDirty`,
+ * `scriptEditorSelection`, `scriptEditorRevision`, `scriptAppliedOpIds`, the
+ * apply adapter, the undo/redo flags and the two monotonic counters
+ * (`scriptRunSeq`, `scriptRunEpoch`) are absent for the same reason: none of
+ * them is model state, and `resetViewerState` has never touched them.
+ * `scriptRunEpoch` in particular is a supersession token compared across
+ * hook instances — resetting it would make a stale in-flight run's captured
+ * epoch match again and let it clobber a newer result.
+ *
+ * `resetScriptEditorForNewChat()` is NOT folded in: it clears a different,
+ * wider set (the editor content, the active script, the applied-op ids) and
+ * drives the editor's apply adapter, which a pure teardown may not do.
+ */
+export const scriptTeardown = defineSliceTeardown(
+  'scriptSlice',
+  [
+    'scriptExecutionState',
+    'scriptLastResult',
+    'scriptLastError',
+    'scriptLastDiagnostics',
+    'scriptAssistantTurnSnapshot',
+    'scriptDeleteConfirmId',
+  ],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      scriptExecutionState: 'idle' as const,
+      // The result, the error and the diagnostics all describe a run
+      // against the OUTGOING model's data store.
+      scriptLastResult: null,
+      scriptLastError: null,
+      scriptLastDiagnostics: [],
+      // The assistant's pre-turn snapshot is an undo point for an edit
+      // proposed against the editor as it stood before this load.
+      scriptAssistantTurnSnapshot: null,
+      // A delete confirmation armed before the load is a one-shot UI
+      // prompt; it must not still be pending afterwards.
+      scriptDeleteConfirmId: null,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/scriptSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/scriptSlice.teardown.ts
@@ -47,8 +47,6 @@ export const scriptTeardown = defineSliceTeardown(
     'scriptDeleteConfirmId',
   ],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       scriptExecutionState: 'idle' as const,

--- a/apps/viewer/src/store/slices/searchSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/searchSlice.teardown.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The search slice's contribution to viewer-state teardown.
+ *
+ * A sibling module rather than a block at the bottom of `searchSlice.ts`
+ * because that file is 380 lines and the ~400-line module rule
+ * (`scripts/check-module-size.mjs`) leaves no room for a 13-key table with its
+ * comments. The seam is real either way: this answers "what does search
+ * destroy under a scope", which is a different question from "how does search
+ * behave", has different rules (pure, no `set`/`get`), and is reviewed on its
+ * own — `owns` is the list of everything search is willing to throw away.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { emptyFilterState } from './searchSlice.js';
+
+/**
+ * What a session reset clears on the search slice.
+ *
+ * Carried verbatim from `resetViewerState` (`store/index.ts`):
+ *   "Search - results reference the previous model's expressIds, drop them."
+ *
+ * Two fields are deliberately absent from `owns`, matching today's reset:
+ *
+ *  - `searchModalTab` is remembered across opens (the slice's own doc says
+ *    so). A file swap is not the user changing tabs.
+ *  - `searchFilterAutoRunPending` is a one-shot hand-off armed by another
+ *    panel ("Create filter from this Hierarchy node") and consumed by the
+ *    Filter tab on its next render. `resetViewerState` has never touched it,
+ *    and clearing it here would silently swallow a run the user just asked
+ *    for when the hand-off crosses a load.
+ */
+export const searchTeardown = defineSliceTeardown(
+  'searchSlice',
+  [
+    'searchQuery',
+    'searchOpen',
+    'searchHighlightIndex',
+    'searchIndexes',
+    'searchVimCycle',
+    'searchModalOpen',
+    'searchFieldFilter',
+    'searchModelFilter',
+    'searchFilterResult',
+    'searchFilterRunning',
+    'searchFilterError',
+    'searchFilter',
+    'searchFilterSchema',
+  ],
+  (scope) => {
+    // A model removal or a federation clear leaves this slice alone; only a
+    // session reset (a new file taking over the viewer) does.
+    if (scope.kind !== 'session-reset') return {};
+    return {
+      // The inline field: query, popover and the frozen vim-cycle
+      // snapshot. `resetSearch()` clears exactly these four for Esc; it
+      // stays a separate, narrower action (see `searchSlice.ts`).
+      searchQuery: '',
+      searchOpen: false,
+      searchHighlightIndex: 0,
+      searchVimCycle: null,
+      // Tier-1 indexes are built per model and keyed by modelId; the
+      // incoming file rebuilds its own.
+      searchIndexes: new Map(),
+      // The advanced modal: closed, with its chip filters back at the
+      // slice's defaults ('all' fields, all models included).
+      searchModalOpen: false,
+      searchFieldFilter: 'all' as const,
+      searchModelFilter: null,
+      // Filter run state — the rows are the outgoing model's express ids.
+      searchFilterResult: null,
+      searchFilterRunning: false,
+      searchFilterError: null,
+      // The rules themselves name storeys / types / property values
+      // discovered in the outgoing model, so they go back to the slice's
+      // own empty state rather than being re-pointed at the new file.
+      searchFilter: emptyFilterState(),
+      // Per-model chip-dropdown schema cache, keyed by modelId.
+      searchFilterSchema: new Map(),
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/searchSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/searchSlice.teardown.ts
@@ -51,8 +51,6 @@ export const searchTeardown = defineSliceTeardown(
     'searchFilterSchema',
   ],
   (scope) => {
-    // A model removal or a federation clear leaves this slice alone; only a
-    // session reset (a new file taking over the viewer) does.
     if (scope.kind !== 'session-reset') return {};
     return {
       // The inline field: query, popover and the frozen vim-cycle

--- a/apps/viewer/src/store/slices/searchSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/searchSlice.teardown.ts
@@ -6,7 +6,7 @@
  * The search slice's contribution to viewer-state teardown.
  *
  * A sibling module rather than a block at the bottom of `searchSlice.ts`
- * because that file is 380 lines and the ~400-line module rule
+ * because that file is 388 lines and the ~400-line module rule
  * (`scripts/check-module-size.mjs`) leaves no room for a 13-key table with its
  * comments. The seam is real either way: this answers "what does search
  * destroy under a scope", which is a different question from "how does search

--- a/apps/viewer/src/store/slices/searchSlice.ts
+++ b/apps/viewer/src/store/slices/searchSlice.ts
@@ -146,7 +146,15 @@ export interface SearchSlice {
   setSearchHighlightIndex: (index: number) => void;
   /** Convenience: close popover and reset highlight (preserves query). */
   closeSearch: () => void;
-  /** Convenience: clear query and close popover. */
+  /**
+   * Convenience: clear query and close popover.
+   *
+   * A STRICT SUBSET of `searchTeardown` (`searchSlice.teardown.ts`), and
+   * deliberately not folded into it: this is the Esc / clear-button path on
+   * the inline field, and it must not throw away the modal's filter rules,
+   * its chip filters or the per-model Tier-1 indexes. A session reset does
+   * clear all of those; pressing Esc does not.
+   */
   resetSearch: () => void;
 
   /** Replace (or insert) the index record for a model. */

--- a/apps/viewer/src/store/slices/sectionSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.teardown.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `sectionSlice`'s answer to "what do I destroy under this scope".
+ *
+ * Beside the slice rather than inside it because `sectionSlice.ts` sits at its
+ * recorded module-size budget (`scripts/module-size-allowlist.txt`), which
+ * ratchets down only.
+ *
+ * This is the store's canonical Trap B: ONE value, `sectionPlane`, holds both
+ * session-scoped and persisted fields, so the teardown spreads the live plane
+ * instead of replacing it. See the field comment below.
+ *
+ * `sectionPickMode` and `sectionPickPreview` are NOT reset by any of today's
+ * four teardown paths, so they are absent from both `owns` and the body.
+ *
+ * `resetSectionPlane` is deliberately NOT folded into this: it means "give me
+ * the defaults back", and to do that it REMOVES the persisted cap keys from
+ * localStorage — the exact opposite of what a file swap must do. Different
+ * semantics, so it stays its own action.
+ *
+ * `clearLastSectionMode()` (localStorage, #2939) is an ordered side effect and
+ * stays at the entry point in `store/index.ts`; a teardown is pure.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { SECTION_PLANE_DEFAULTS } from '../constants.js';
+import { getDefaultSectionPlane } from './sectionSlice.js';
+
+export const sectionTeardown = defineSliceTeardown(
+  'sectionSlice',
+  ['sectionPlane'],
+  (scope, state) => {
+    // A cut plane is positioned against the whole loaded scene, not against
+    // one model, so neither removing a model nor clearing them all moves it.
+    if (scope.kind !== 'session-reset') return {};
+
+    return {
+      // Section plane: reset axis/position/enabled/flipped (those are
+      // model-relative and meaningless when switching files), but PRESERVE
+      // the user's cap appearance preferences (showCap, showOutlines,
+      // capStyle). Those round-trip to localStorage via the slice's
+      // persistence helpers; clobbering them here was the cause of "my
+      // hatch / colour resets to defaults every time I open a file".
+      //
+      // The `??` is for the partial-store harness (`TeardownState` is a
+      // `Partial<ViewerState>`): with no live plane to spread, the slice's own
+      // initial value is by definition the right answer, and it re-reads the
+      // same persisted fields.
+      sectionPlane: {
+        ...(state.sectionPlane ?? getDefaultSectionPlane()),
+        axis:     SECTION_PLANE_DEFAULTS.AXIS,
+        position: SECTION_PLANE_DEFAULTS.POSITION,
+        enabled:  SECTION_PLANE_DEFAULTS.ENABLED,
+        flipped:  SECTION_PLANE_DEFAULTS.FLIPPED,
+      },
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/sectionSlice.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.ts
@@ -309,7 +309,7 @@ function isDrawablePick(
   return point.every(Number.isFinite);
 }
 
-const getDefaultSectionPlane = (): SectionPlane => ({
+export const getDefaultSectionPlane = (): SectionPlane => ({
   axis: SECTION_PLANE_DEFAULTS.AXIS,
   position: SECTION_PLANE_DEFAULTS.POSITION,
   enabled: SECTION_PLANE_DEFAULTS.ENABLED,

--- a/apps/viewer/src/store/slices/selectionSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.teardown.ts
@@ -95,7 +95,7 @@ export const selectionTeardown = defineSliceTeardown(
       // `selectedModelId` on its own is enough. `removeModel` used to gate it
       // behind the entity-ref checks above, so a model selected in the
       // hierarchy but with no entity selected under it kept a dangling id;
-      // `purgeStaleEntityState` already cleared it unconditionally on the
+      // the resync purge already cleared it unconditionally on the
       // resync path. One implementation now, so it takes the purge's reading.
       state.selectedModelId === modelId;
 

--- a/apps/viewer/src/store/slices/selectionSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.teardown.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `selectionSlice`'s contribution to the store-wide teardown seam
+ * (`store/teardown.ts`). Split out beside the slice for the reason
+ * `modelSlice.teardown.ts` documents.
+ *
+ * Selection holds BOTH keying schemes the teardown paths distinguish, which is
+ * why it is the file where the two purge shapes are most visible:
+ *
+ *  - `EntityRef`-keyed state (`selectedEntity`, `activeStorey`,
+ *    `selectedEntities`, `selectedEntitiesSet`, `selectedModelId`) carries the
+ *    owning model, so a removal filters it on `modelId`.
+ *  - global-id state (`selectedEntityId`, `selectedEntityIds`,
+ *    `selectedStoreys`) does not, so a removal filters it on the scope's
+ *    `isStale` — "no SURVIVING model owns this id".
+ *
+ * `clearSelection` / `clearEntitySelection` / `clearStoreySelection` stay as
+ * they are: they are narrower user-facing actions, not teardown, and routing
+ * teardown through them would drag their side conditions along.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { stringToEntityRef } from '../types.js';
+
+export const selectionTeardown = defineSliceTeardown(
+  'selectionSlice',
+  [
+    'selectedEntityId',
+    'selectedEntityIds',
+    'selectedStoreys',
+    'activeStorey',
+    'selectedEntity',
+    'selectedEntitiesSet',
+    'selectedEntities',
+    'selectedModelId',
+  ],
+  (scope, state) => {
+    if (scope.kind === 'session-reset') {
+      return {
+        // Selection (legacy)
+        selectedEntityId: null,
+        selectedEntityIds: new Set<number>(),
+        selectedStoreys: new Set<number>(),
+        // Drop the shared active storey — it references the outgoing model, so
+        // a new file must not inherit a stale storey for Solo / Space Sketch.
+        activeStorey: null,
+
+        // Selection (multi-model)
+        selectedEntity: null,
+        selectedEntitiesSet: new Set<string>(),
+        selectedEntities: [],
+        selectedModelId: null,
+      };
+    }
+
+    if (scope.kind === 'all-models-cleared') {
+      // Only the global-id half, which is what `clearAllModels` has always
+      // written. The `EntityRef`-keyed half is deliberately absent: adding it
+      // here would be a behaviour change, not a restructuring, and this
+      // refactor is not the place to make one. (It is a real asymmetry —
+      // `resetViewerState` clears both halves — and is called out as a
+      // follow-up rather than smuggled in.)
+      return {
+        selectedEntityId: null,
+        selectedEntityIds: new Set<number>(),
+        selectedStoreys: new Set<number>(),
+      };
+    }
+
+    const { modelId, isStale } = scope;
+
+    // ── EntityRef-keyed half ────────────────────────────────────────────────
+    // Selection state keys off modelId, so anything pointing at the removed
+    // model is now dangling: `models.get(selectedEntity.modelId)` returns
+    // undefined and the properties panel silently renders nothing rather than
+    // re-resolving, leaving a ghost selection until the user clicks elsewhere.
+    // `activeStorey` likewise stays pinned to a storey in a model that no
+    // longer exists, which the Solo level display and floorplan read. Entries
+    // belonging to OTHER models are preserved — clearing wholesale would drop
+    // a federated sibling's live selection.
+    //
+    // Every read falls back to this slice's OWN initial value: a teardown is
+    // handed `Readonly<Partial<ViewerState>>` because `slices/modelSlice.test.ts`
+    // drives this composition against a state where other slices are absent.
+    const priorEntities = state.selectedEntities ?? [];
+    const priorSet = state.selectedEntitiesSet ?? new Set<string>();
+    const keptEntities = priorEntities.filter((e) => e.modelId !== modelId);
+    const refsTouched =
+      state.selectedEntity?.modelId === modelId ||
+      state.activeStorey?.modelId === modelId ||
+      keptEntities.length !== priorEntities.length ||
+      // `selectedModelId` on its own is enough. `removeModel` used to gate it
+      // behind the entity-ref checks above, so a model selected in the
+      // hierarchy but with no entity selected under it kept a dangling id;
+      // `purgeStaleEntityState` already cleared it unconditionally on the
+      // resync path. One implementation now, so it takes the purge's reading.
+      state.selectedModelId === modelId;
+
+    // ── Global-id half ──────────────────────────────────────────────────────
+    // These key off `globalId`, not `modelId` — they don't carry which model an
+    // id belongs to the way the `EntityRef`-shaped state above does. A global
+    // id is "stale" once no SURVIVING model's parse range or overlay owns it,
+    // which is exactly the predicate the scope carries.
+    const priorSelectedEntityIds = state.selectedEntityIds;
+    const priorSelectedStoreys = state.selectedStoreys;
+    const priorSelectedEntityId = state.selectedEntityId;
+    const idsTouched =
+      (priorSelectedEntityIds !== undefined && [...priorSelectedEntityIds].some(isStale)) ||
+      (priorSelectedStoreys !== undefined && [...priorSelectedStoreys].some(isStale)) ||
+      (priorSelectedEntityId != null && isStale(priorSelectedEntityId));
+
+    return {
+      ...(refsTouched
+        ? {
+            selectedEntity:
+              state.selectedEntity?.modelId === modelId ? null : state.selectedEntity,
+            activeStorey: state.activeStorey?.modelId === modelId ? null : state.activeStorey,
+            selectedEntities: keptEntities,
+            // Parsed with the shared helper rather than a `${modelId}:` prefix
+            // test: `stringToEntityRef` splits on the FIRST colon, so a prefix
+            // match would also strip a sibling model whose id merely starts
+            // with this one's id plus a colon. Using the same parse every other
+            // consumer uses keeps this filter from becoming a third, subtly
+            // different reading of the same key.
+            selectedEntitiesSet: new Set(
+              [...priorSet].filter((k) => stringToEntityRef(k).modelId !== modelId),
+            ),
+            selectedModelId:
+              state.selectedModelId === modelId ? null : state.selectedModelId,
+          }
+        : {}),
+      ...(idsTouched
+        ? {
+            selectedEntityId:
+              priorSelectedEntityId != null && isStale(priorSelectedEntityId)
+                ? null
+                : priorSelectedEntityId,
+            selectedEntityIds: priorSelectedEntityIds
+              ? new Set([...priorSelectedEntityIds].filter((id) => !isStale(id)))
+              : priorSelectedEntityIds,
+            selectedStoreys: priorSelectedStoreys
+              ? new Set([...priorSelectedStoreys].filter((id) => !isStale(id)))
+              : priorSelectedStoreys,
+          }
+        : {}),
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/sheetSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sheetSlice.teardown.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `sheetSlice`'s answer to "what do I destroy under this scope".
+ *
+ * Beside the slice rather than inside it because `sheetSlice.ts` sits at its
+ * recorded module-size budget (`scripts/module-size-allowlist.txt`), which
+ * ratchets down only.
+ *
+ * `savedSheetTemplates` MUST SURVIVE and is absent from both `owns` and the
+ * body. That is confirmed bug #1 in `scripts/check-whole-state-reset.mjs`'s
+ * header (issue #2802): `clearSheet` did `set(getDefaultState())` and
+ * destroyed the user's template library on every "clear" click. The values
+ * below come from {@link getClearedSheetState}, the one explicit field list
+ * `clearSheet` now also uses, so the two paths cannot drift apart again.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { getClearedSheetState } from './sheetSlice.js';
+
+export const sheetTeardown = defineSliceTeardown(
+  'sheetSlice',
+  ['activeSheet', 'sheetEnabled', 'sheetPanelVisible', 'titleBlockEditorVisible'],
+  (scope) => {
+    // A sheet is a document laid out over the drawing, not a per-model
+    // artefact: removing one model from a federation, or clearing them all,
+    // leaves it alone. Only a file swap tears it down.
+    if (scope.kind !== 'session-reset') return {};
+
+    const cleared = getClearedSheetState();
+    return {
+      activeSheet: cleared.activeSheet,
+      sheetEnabled: cleared.sheetEnabled,
+      sheetPanelVisible: cleared.sheetPanelVisible,
+      titleBlockEditorVisible: cleared.titleBlockEditorVisible,
+    };
+  },
+);

--- a/apps/viewer/src/store/slices/sheetSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sheetSlice.teardown.ts
@@ -29,12 +29,11 @@ export const sheetTeardown = defineSliceTeardown(
     // leaves it alone. Only a file swap tears it down.
     if (scope.kind !== 'session-reset') return {};
 
-    const cleared = getClearedSheetState();
-    return {
-      activeSheet: cleared.activeSheet,
-      sheetEnabled: cleared.sheetEnabled,
-      sheetPanelVisible: cleared.sheetPanelVisible,
-      titleBlockEditorVisible: cleared.titleBlockEditorVisible,
-    };
+    // `getClearedSheetState()` returns exactly these four keys — it is typed
+    // `Omit<SheetState, 'savedSheetTemplates'>`, which is what keeps the user's
+    // saved templates out of both this and `clearSheet` (#2802's first bug).
+    // Destructuring and rebuilding it here would be a second list to keep in
+    // step with the first.
+    return getClearedSheetState();
   },
 );

--- a/apps/viewer/src/store/slices/sheetSlice.ts
+++ b/apps/viewer/src/store/slices/sheetSlice.ts
@@ -141,14 +141,18 @@ function createDefaultSheet(options?: SheetCreationOptions): DrawingSheet {
   };
 }
 
+/** Active-sheet fields a clear or a session teardown destroys. `savedSheetTemplates`
+ *  is deliberately absent: the user's template library outlives both, and
+ *  `set(getDefaultState())` here once wiped it (issue #2802, confirmed bug #1). */
+export const getClearedSheetState = (): Omit<SheetState, 'savedSheetTemplates'> => ({
+  activeSheet: null,
+  sheetEnabled: false,
+  sheetPanelVisible: false,
+  titleBlockEditorVisible: false,
+});
+
 function getDefaultState(): SheetState {
-  return {
-    activeSheet: null,
-    sheetEnabled: false,
-    sheetPanelVisible: false,
-    titleBlockEditorVisible: false,
-    savedSheetTemplates: [],
-  };
+  return { ...getClearedSheetState(), savedSheetTemplates: [] };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -177,13 +181,9 @@ export const createSheetSlice: StateCreator<SheetSlice, [], [], SheetSlice> = (
     set({ activeSheet: { ...current, ...updates } });
   },
 
-  // `clearSheet` resets the *active* sheet/panel state, not the user's
-  // saved template library. `getDefaultState()` also seeds the store's
-  // initial state (which correctly starts with no templates), so it can't
-  // be reused verbatim here without wiping `savedSheetTemplates` on every
-  // "clear" click.
-  clearSheet: () =>
-    set((s) => ({ ...getDefaultState(), savedSheetTemplates: s.savedSheetTemplates })),
+  // Resets the *active* sheet/panel state, not the user's saved template
+  // library — same explicit field list `sheetSlice.teardown.ts` uses.
+  clearSheet: () => set(getClearedSheetState()),
 
   setSheetEnabled: (enabled) => {
     if (enabled && !get().activeSheet) {

--- a/apps/viewer/src/store/slices/uiSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/uiSlice.teardown.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `uiSlice`'s answer to "what do I destroy under this scope".
+ *
+ * Beside the slice rather than inside it because `uiSlice.ts` sits at its
+ * recorded module-size budget (`scripts/module-size-allowlist.txt`), which
+ * ratchets down only.
+ *
+ * `owns` is a SMALL subset of what this slice holds, on purpose. The slice
+ * also owns the panel-collapse flags, `hierarchyMode`, `theme`,
+ * `hoverTooltipsEnabled`, `toolbarStyle`, the ribbon state and the geometry
+ * load settings — workspace preferences, several of them persisted, none of
+ * which a file swap has ever touched. They are absent from both `owns` and
+ * the body, which is what a hand-written field list buys (issue #2802).
+ *
+ * Values come from `UI_DEFAULTS`, the same constants the slice's own initial
+ * state is built from, so the reset value and the initial value are one fact.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { UI_DEFAULTS } from '../constants.js';
+
+export const uiTeardown = defineSliceTeardown(
+  'uiSlice',
+  [
+    'activeTool',
+    'editEnabled',
+    'pendingPropertyFocus',
+    'visualEnhancementsEnabled',
+    'edgeContrastEnabled',
+    'edgeContrastIntensity',
+    'contactShadingQuality',
+    'contactShadingIntensity',
+    'contactShadingRadius',
+    'separationLinesEnabled',
+    'separationLinesQuality',
+    'separationLinesIntensity',
+    'separationLinesRadius',
+  ],
+  (scope) =>
+    // Removing one model from a federation, or clearing them all, leaves the
+    // chrome alone: the active tool and the render-quality toggles describe
+    // the session, not the file. Only a file swap resets them.
+    scope.kind !== 'session-reset'
+      ? {}
+      : {
+          activeTool: UI_DEFAULTS.ACTIVE_TOOL,
+          editEnabled: false,
+          // Drop any one-shot bSDD "jump to property" focus armed before the
+          // load — a new file reuses ids ('legacy' + reassigned expressIds) so
+          // a stale focus could otherwise match an unrelated entity (#1107).
+          pendingPropertyFocus: null,
+          visualEnhancementsEnabled: UI_DEFAULTS.VISUAL_ENHANCEMENTS_ENABLED,
+          edgeContrastEnabled: UI_DEFAULTS.EDGE_CONTRAST_ENABLED,
+          edgeContrastIntensity: UI_DEFAULTS.EDGE_CONTRAST_INTENSITY,
+          contactShadingQuality: UI_DEFAULTS.CONTACT_SHADING_QUALITY,
+          contactShadingIntensity: UI_DEFAULTS.CONTACT_SHADING_INTENSITY,
+          contactShadingRadius: UI_DEFAULTS.CONTACT_SHADING_RADIUS,
+          separationLinesEnabled: UI_DEFAULTS.SEPARATION_LINES_ENABLED,
+          separationLinesQuality: UI_DEFAULTS.SEPARATION_LINES_QUALITY,
+          separationLinesIntensity: UI_DEFAULTS.SEPARATION_LINES_INTENSITY,
+          separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
+        },
+);

--- a/apps/viewer/src/store/slices/visibilitySlice.teardown.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.teardown.ts
@@ -100,7 +100,7 @@ export const visibilityTeardown = defineSliceTeardown(
 
     // Nothing of ours named the removed model. Returning {} rather than a set
     // of equal-but-new collections is what keeps this scope idempotent:
-    // `purgeStaleEntityState` runs it a second time straight after
+    // `syncSourceModel` runs it a second time straight after
     // `removeModel`, and a fresh `isolatedEntities` reference would put the
     // channel through `withVisibilityOwnershipInvalidation` again for a set
     // that did not move.

--- a/apps/viewer/src/store/slices/visibilitySlice.teardown.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.teardown.ts
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `visibilitySlice`'s contribution to the store-wide teardown seam
+ * (`store/teardown.ts`). Split out beside the slice for the reason
+ * `modelSlice.teardown.ts` documents.
+ *
+ * This slice owns the two SHARED channels — `isolatedEntities` /
+ * `ghostExceptEntities` — that `store/visibility-invalidation.ts` guards. The
+ * patch this function returns must therefore reach the store through the
+ * WRAPPED `set` / `setState` every other write goes through, so the ownership
+ * invalidation fires for a teardown write exactly as it does for any other. A
+ * teardown never applies its own patch; the entry point does.
+ *
+ * Two rules the bodies below are built around:
+ *
+ *  - an isolate / ghost / class filter left with zero surviving ids clears to
+ *    `null` outright, NEVER to an empty `Set` — a non-null empty set still
+ *    reads as "isolation active, nothing matches" and hides everything;
+ *  - `typeVisibility` / `typeViewMode` are RE-READ from localStorage on a
+ *    session reset (Trap B), not zeroed, and are absent from the two
+ *    federation arms entirely.
+ */
+
+import { defineSliceTeardown } from '../teardown.js';
+import { getPersistedTypeVisibility, getPersistedTypeViewMode } from '../constants.js';
+
+export const visibilityTeardown = defineSliceTeardown(
+  'visibilitySlice',
+  [
+    'hiddenEntities',
+    'isolatedEntities',
+    'ghostExceptEntities',
+    'classFilter',
+    'typeVisibility',
+    'typeViewMode',
+    'hiddenEntitiesByModel',
+    'isolatedEntitiesByModel',
+  ],
+  (scope, state) => {
+    if (scope.kind === 'session-reset') {
+      return {
+        // Visibility (legacy)
+        hiddenEntities: new Set<number>(),
+        isolatedEntities: null,
+        ghostExceptEntities: null,
+        classFilter: null,
+        // Re-read persisted toggles on every file load so a new model never
+        // reverts the user's visibility choices (e.g. "Show Annotations").
+        typeVisibility: getPersistedTypeVisibility(),
+        typeViewMode: getPersistedTypeViewMode(),
+
+        // Visibility (multi-model)
+        hiddenEntitiesByModel: new Map(),
+        isolatedEntitiesByModel: new Map(),
+      };
+    }
+
+    if (scope.kind === 'all-models-cleared') {
+      // With zero survivors every id is stale by definition, so this clears
+      // unconditionally rather than repeating the range check for an
+      // always-true answer. `isolatedEntities` / `ghostExceptEntities` clear to
+      // `null` (not an empty `Set`) for the reason the 'model-removed' arm
+      // below spells out — an empty-but-set isolate would hide the very next
+      // model loaded, until it does. `typeVisibility` / `typeViewMode` are NOT
+      // here: they are the user's persisted preferences, not scene state, and
+      // `clearAllModels` has never touched them.
+      return {
+        hiddenEntities: new Set<number>(),
+        isolatedEntities: null,
+        ghostExceptEntities: null,
+        classFilter: null,
+        hiddenEntitiesByModel: new Map(),
+        isolatedEntitiesByModel: new Map(),
+      };
+    }
+
+    const { modelId, isStale } = scope;
+
+    // These key off `globalId`, not `modelId`. A global id is "stale" once no
+    // SURVIVING model's parse range or overlay owns it — the predicate the
+    // scope carries, computed once by the entry point. Left unpurged, an
+    // isolate or ghost set that only ever named the removed model's entities
+    // stays non-null while matching nothing in the survivors, so
+    // `effectiveIsolatedIds` keeps returning it and the entire remaining
+    // federation renders as hidden — worse than the id merely dangling.
+    const priorHidden = state.hiddenEntities;
+    const priorIsolated = state.isolatedEntities;
+    const priorGhost = state.ghostExceptEntities;
+    const priorClassFilter = state.classFilter;
+    const touched =
+      (priorHidden !== undefined && [...priorHidden].some(isStale)) ||
+      (priorIsolated != null && [...priorIsolated].some(isStale)) ||
+      (priorGhost != null && [...priorGhost].some(isStale)) ||
+      (priorClassFilter != null && [...priorClassFilter.ids].some(isStale)) ||
+      state.hiddenEntitiesByModel?.has(modelId) === true ||
+      state.isolatedEntitiesByModel?.has(modelId) === true;
+
+    // Nothing of ours named the removed model. Returning {} rather than a set
+    // of equal-but-new collections is what keeps this scope idempotent:
+    // `purgeStaleEntityState` runs it a second time straight after
+    // `removeModel`, and a fresh `isolatedEntities` reference would put the
+    // channel through `withVisibilityOwnershipInvalidation` again for a set
+    // that did not move.
+    if (!touched) return {};
+
+    return {
+      hiddenEntities: priorHidden
+        ? new Set([...priorHidden].filter((id) => !isStale(id)))
+        : priorHidden,
+      // An isolate/ghost set left with zero surviving ids must clear to `null`
+      // outright, not an empty `Set` — a non-null empty set still reads as
+      // "isolation active, nothing matches" and hides every remaining entity,
+      // same as the stale set it replaces.
+      isolatedEntities: priorIsolated ? nonEmptyOrNull(priorIsolated, isStale) : priorIsolated,
+      ghostExceptEntities: priorGhost ? nonEmptyOrNull(priorGhost, isStale) : priorGhost,
+      // The Class-tab filter intersects into the visible set: left unpurged it
+      // would hold only burned ids after a sync, matching nothing — every
+      // element of the reloaded model would disappear. An emptied filter clears
+      // entirely.
+      classFilter: priorClassFilter
+        ? (() => {
+            const kept = new Set([...priorClassFilter.ids].filter((id) => !isStale(id)));
+            return kept.size > 0 ? { ids: kept, label: priorClassFilter.label } : null;
+          })()
+        : priorClassFilter,
+      hiddenEntitiesByModel: priorMapWithout(state.hiddenEntitiesByModel, modelId),
+      isolatedEntitiesByModel: priorMapWithout(state.isolatedEntitiesByModel, modelId),
+    };
+  },
+);
+
+/** Drop every stale id; collapse an emptied set to `null` rather than `Set{}`. */
+function nonEmptyOrNull(
+  prior: ReadonlySet<number>,
+  isStale: (id: number) => boolean,
+): Set<number> | null {
+  const kept = new Set([...prior].filter((id) => !isStale(id)));
+  return kept.size > 0 ? kept : null;
+}
+
+/** A copy of `prior` without `modelId`, or `prior` itself when it is absent. */
+function priorMapWithout(
+  prior: Map<string, Set<number>> | undefined,
+  modelId: string,
+): Map<string, Set<number>> | undefined {
+  if (!prior) return prior;
+  const next = new Map(prior);
+  next.delete(modelId);
+  return next;
+}

--- a/apps/viewer/src/store/slices/zonesSlice.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.ts
@@ -311,7 +311,10 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
 
   clearAllZoneSets: () => set(() => {
     savePersistedZoneSets([]);
-    return { zoneSets: [], zoneAssignments: new Map(), zoneAssignmentTiming: null, zoneApportionment: new Map(), editingZone: null };
+    // The zone SETS are this action's own business ("the user deleted their
+    // zones"); everything downstream of them is the session-reset arm's list,
+    // spread rather than restated so a field added there lands in both.
+    return { zoneSets: [], ...zonesTeardown.teardown({ kind: 'session-reset' }, {}) };
   }),
 });
 
@@ -324,11 +327,10 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
  * stale-model-reference class as `compareResult`; `useZoneAssignmentSync`
  * recomputes against the new scene.
  *
- * `zoneSets` is therefore absent from both `owns` and the body, and
- * `clearAllZoneSets` — which does destroy them — is NOT wired to this teardown:
- * its field set is a strict superset with a different meaning ("the user
- * deleted their zones"), and one of the two would drift the moment a
- * session-scoped field that is not a zone set is added here.
+ * `zoneSets` is therefore absent from both `owns` and the body. `clearAllZoneSets`
+ * DOES destroy them, and spreads this arm for everything else: its field set is a
+ * strict superset with a different meaning, but the overlap is exact, and a
+ * session-scoped field added here has to reach both.
  */
 export const zonesTeardown = defineSliceTeardown(
   'zonesSlice',

--- a/apps/viewer/src/store/slices/zonesSlice.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.ts
@@ -22,6 +22,7 @@ import type { Zone, ZoneSet, ZoneAssignmentsByElement } from '../../lib/zones/ty
 import type { ZoneApportionmentEntry } from '../../lib/zones/apportionment-cache.js';
 import { serializeZoneSets, parseZoneSetFile } from '../../lib/zones/persistence.js';
 import { isConvexFootprint, normalizePrismBounds } from '../../lib/zones/prism.js';
+import { defineSliceTeardown } from '../teardown.js';
 
 const ZONE_SETS_STORAGE_KEY = 'ifc-lite:zone-sets';
 
@@ -313,3 +314,39 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
     return { zoneSets: [], zoneAssignments: new Map(), zoneAssignmentTiming: null, zoneApportionment: new Map(), editingZone: null };
   }),
 });
+
+/**
+ * Zones (#1810): keep the user-authored zone SETS (they persist across model
+ * loads, like clash presets), but drop the computed assignments — they're keyed
+ * by the OUTGOING model's global ids, and the single-model fallback
+ * (globalId === expressId) means the incoming model's ids can collide and read
+ * the old model's zone membership until the debounced recompute fires. Same
+ * stale-model-reference class as `compareResult`; `useZoneAssignmentSync`
+ * recomputes against the new scene.
+ *
+ * `zoneSets` is therefore absent from both `owns` and the body, and
+ * `clearAllZoneSets` — which does destroy them — is NOT wired to this teardown:
+ * its field set is a strict superset with a different meaning ("the user
+ * deleted their zones"), and one of the two would drift the moment a
+ * session-scoped field that is not a zone set is added here.
+ */
+export const zonesTeardown = defineSliceTeardown(
+  'zonesSlice',
+  ['zoneAssignments', 'zoneAssignmentTiming', 'zoneApportionment', 'editingZone'],
+  (scope) => scope.kind !== 'session-reset' ? {} : {
+    zoneAssignments: new Map(),
+    zoneAssignmentTiming: null,
+    // ... and the apportioned cubic metres computed off those assignments
+    // (#2508). `validEntry` only checks the ZONE revision, which a model swap
+    // does not move, so an entry that survives here is served against the
+    // incoming file — and the single-model fallback (globalId === expressId)
+    // means the new model's ids collide with the old one's. Same stale-model
+    // reference as `zoneAssignments` directly above; the two are one fact and
+    // must be dropped together.
+    zoneApportionment: new Map(),
+    // ... and drop any in-flight zone-edit session: leaving `editingZone`
+    // set would hand the incoming model live gizmo handles + picking for
+    // a zone the user was editing against the outgoing model.
+    editingZone: null,
+  },
+);

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -13,11 +13,80 @@ import { viewerTeardownRegistry } from './teardown-registry.js';
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 /**
- * Every key the registry tore down when this was pinned.
+ * Every key a session reset actually WRITES, measured by running the registry.
  *
- * Update deliberately, never to make a red test green: a key LEAVING this list
- * means some slice stopped tearing it down, which is the bug. A key joining it
- * is normal as slices gain fields, and the test logs those rather than failing.
+ * This is the list that matters. `owns` is a declaration; this is the emission,
+ * and the two are equal only by hand. Deleting a line from a teardown BODY
+ * while leaving its key in `owns` compiles clean (`Partial<Pick<...>>` does not
+ * require the key), passes an owns-only pin, and silently stops clearing that
+ * field on every file swap.
+ */
+const PINNED_SESSION_RESET_KEYS: readonly string[] = [
+  'activeBasketViewId', 'activeChangeSetId', 'activeLensId', 'activeListId', 'activePresetId',
+  'activeSheet', 'activeStorey', 'activeTool', 'activeTopicId', 'activeViewpointId',
+  'activeWorkScheduleId', 'animationEnabled', 'annotation2DActiveTool',
+  'annotation2DCursorPos', 'basketPresentationVisible', 'basketViews', 'bcfError',
+  'bcfLoading', 'bcfPanelVisible', 'cameraRotation', 'cesiumAvailable', 'cesiumEnabled',
+  'cesiumGlbLoaded', 'cesiumHeightsAreEllipsoidal', 'cesiumPlacementDraft',
+  'cesiumPlacementDraftModelId', 'cesiumPlacementEditMode', 'cesiumSourceModelId',
+  'cesiumTerrainClipY', 'cesiumTerrainHeight', 'cesiumTerrainSaveHeight', 'changeSets',
+  'chatAbortController', 'chatError', 'chatStatus', 'chatStreamingContent', 'classFilter',
+  'cloudAnnotation2DPoints', 'cloudAnnotations2D', 'compareError', 'compareResult',
+  'compareRunning', 'compareSelectedKey', 'contactShadingIntensity', 'contactShadingQuality',
+  'contactShadingRadius', 'contextMenu', 'customOverrideRules', 'dirtyModels', 'draft',
+  'drawing2D', 'drawing2DDisplayOptions', 'drawing2DError', 'drawing2DPanelVisible',
+  'drawing2DPhase', 'drawing2DProgress', 'drawing2DStatus', 'drawing2DSvgContent',
+  'edgeContrastEnabled', 'edgeContrastIntensity', 'editEnabled', 'editingZone', 'error',
+  'expandedTaskGlobalIds', 'ganttPanelVisible', 'generateScheduleDialogOpen',
+  'geometryProgress', 'geometryStreamingActive', 'geometryUpdateTick', 'ghostExceptEntities',
+  'hiddenEntities', 'hiddenEntitiesByModel', 'hierarchyBasketSelection', 'hoverState',
+  'hoveredTaskGlobalId', 'idsActiveEntityId', 'idsActiveSpecificationId', 'idsError',
+  'idsFocusVisibilityOwned', 'idsLoading', 'idsPanelVisible', 'idsProgress',
+  'isolatedEntities', 'isolatedEntitiesByModel', 'lensAppliedHiddenIds', 'lensColorMap',
+  'lensHiddenIds', 'lensPanelVisible', 'lensRuleCounts', 'lensRuleEntityIds',
+  'lensRuleIsolation', 'listExecuting', 'listPanelVisible', 'listResult', 'loading',
+  'measure2DCurrent', 'measure2DLockedAxis', 'measure2DMode', 'measure2DResults',
+  'measure2DShiftLocked', 'measure2DSnapPoint', 'measure2DStart', 'meshColorBackup',
+  'metadataProgress', 'mutationVersion', 'mutationViews', 'overridesEnabled',
+  'overridesPanelVisible', 'pendingColorUpdates', 'pendingInstancedShards',
+  'pendingMeshColorUpdates', 'pendingPropertyFocus', 'pinboardEntities', 'playbackIsPlaying',
+  'playbackTime', 'pointCloudAlignmentAvailable', 'pointCloudAlignmentEnabled',
+  'pointCloudAssetCount', 'pointCloudClassCounts', 'pointCloudClassMask',
+  'pointCloudColorMode', 'pointCloudDeviationCenterOffset', 'pointCloudDeviationComputed',
+  'pointCloudDeviationHalfRange', 'pointCloudEdlEnabled', 'pointCloudEdlStrength',
+  'pointCloudFixedColor', 'pointCloudPointSize', 'pointCloudPreviewStride',
+  'pointCloudRoundShape', 'pointCloudSizeMode', 'pointCloudWorldRadius', 'polygonArea2DPoints',
+  'polygonArea2DResults', 'progress', 'projectionMode', 'redoStacks', 'scheduleData',
+  'scheduleRange', 'scriptAssistantTurnSnapshot', 'scriptDeleteConfirmId',
+  'scriptExecutionState', 'scriptLastDiagnostics', 'scriptLastError', 'scriptLastResult',
+  'searchFieldFilter', 'searchFilter', 'searchFilterError', 'searchFilterResult',
+  'searchFilterRunning', 'searchFilterSchema', 'searchHighlightIndex', 'searchIndexes',
+  'searchModalOpen', 'searchModelFilter', 'searchOpen', 'searchQuery', 'searchVimCycle',
+  'sectionPlane', 'selectedAnnotation2D', 'selectedAnnotationId', 'selectedEntities',
+  'selectedEntitiesSet', 'selectedEntity', 'selectedEntityId', 'selectedEntityIds',
+  'selectedModelId', 'selectedStoreys', 'selectedTaskGlobalIds', 'separationLinesEnabled',
+  'separationLinesIntensity', 'separationLinesQuality', 'separationLinesRadius',
+  'sheetEnabled', 'sheetPanelVisible', 'suppressNextSection2DPanelAutoOpen',
+  'textAnnotation2DEditing', 'textAnnotations2D', 'titleBlockEditorVisible', 'typeViewMode',
+  'typeVisibility', 'undoStacks', 'visualEnhancementsEnabled', 'zoneApportionment',
+  'zoneAssignmentTiming', 'zoneAssignments',
+];
+
+/** The same, for `all-models-cleared`. */
+const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
+  'activeModelId', 'addElementModelId', 'addElementStoreyId', 'classFilter', 'geometryResult',
+  'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel', 'hierarchyBasketSelection',
+  'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel', 'meshColorBackup', 'models',
+  'pinboardEntities', 'selectedEntityId', 'selectedEntityIds', 'selectedStoreys',
+];
+
+/**
+ * Every key some slice DECLARES it may destroy, across all scopes.
+ *
+ * Wider than the emitted lists above by the six keys only a federation scope
+ * writes (`models`, `activeModelId`, `ifcDataStore`, `geometryResult`,
+ * `addElementModelId`, `addElementStoreyId`). Pinned so a key vanishing from an
+ * `owns` list fails even when no scope emits it under an empty state.
  */
 const PINNED_OWNED_KEYS: readonly string[] = [
   'activeBasketViewId', 'activeChangeSetId', 'activeLensId', 'activeListId', 'activeModelId',
@@ -71,6 +140,7 @@ const PINNED_OWNED_KEYS: readonly string[] = [
   'zoneAssignmentTiming', 'zoneAssignments',
 ];
 
+
 /** A `SliceTeardown` by shape, without importing the type into a runtime check. */
 function isSliceTeardown(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) return false;
@@ -89,15 +159,44 @@ function isSliceTeardown(value: unknown): boolean {
  *
  * Two ways to lose a key silently, one test each:
  *
- *   1. drop it from a slice's `owns` (or from the body, since `owns` and the
- *      emitted keys are only equal by hand),
- *   2. write the whole contribution and forget the registry import line.
+ *   1. drop the key from a teardown's BODY while leaving it in `owns` — this
+ *      compiles, because `Partial<Pick<...>>` does not require the key,
+ *   2. drop it from `owns`,
+ *   3. write the whole contribution and forget the registry import line.
  *
  * `teardownOwnedKeys` was exported for the first of these and nothing called
  * it, so the guard read as coverage while asserting nothing.
  */
 describe('the teardown registry stays complete', () => {
-  it('owns exactly the keys it owned when this was pinned, so a key dropped from an `owns` list cannot go unnoticed', () => {
+  it('still WRITES every key it wrote when this was pinned, which an `owns`-only pin does not check', () => {
+    // Run the registry, do not read its declarations. A body that stops
+    // emitting a key type-checks clean and keeps its `owns` entry, so this is
+    // the only place that failure shows up.
+    const emitted = (kind: 'session-reset' | 'all-models-cleared'): string[] => {
+      const keys = new Set<string>();
+      for (const entry of viewerTeardownRegistry) {
+        for (const key of Object.keys(entry.teardown({ kind }, {}))) keys.add(String(key));
+      }
+      return [...keys].sort();
+    };
+
+    for (const [kind, pinned] of [
+      ['session-reset', PINNED_SESSION_RESET_KEYS],
+      ['all-models-cleared', PINNED_ALL_MODELS_CLEARED_KEYS],
+    ] as const) {
+      const actual = emitted(kind);
+      const dropped = pinned.filter((key) => !actual.includes(key));
+      assert.deepStrictEqual(
+        dropped,
+        [],
+        `${kind} used to write these keys and does not any more: ${dropped.join(', ')}`,
+      );
+      const added = actual.filter((key) => !pinned.includes(key));
+      if (added.length > 0) console.log(`${kind} now also writes:`, added);
+    }
+  });
+
+  it('declares the same ownership it declared when this was pinned', () => {
     const owned = teardownOwnedKeys(viewerTeardownRegistry);
     const actual = [...owned.keys()].map(String).sort();
 
@@ -105,12 +204,12 @@ describe('the teardown registry stays complete', () => {
     assert.deepStrictEqual(
       dropped,
       [],
-      `these keys were torn down when this was pinned and are not any more: ${dropped.join(', ')}`,
+      `these keys were declared owned when this was pinned and are not any more: ${dropped.join(', ')}`,
     );
 
     const added = actual.filter((key) => !PINNED_OWNED_KEYS.includes(key));
     if (added.length > 0) {
-      console.log('new keys now torn down (update teardown-owned-keys.json):', added);
+      console.log('new keys now owned (update PINNED_OWNED_KEYS):', added);
     }
   });
 

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { teardownOwnedKeys } from './teardown.js';
+import { viewerTeardownRegistry } from './teardown-registry.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Every key the registry tore down when this was pinned.
+ *
+ * Update deliberately, never to make a red test green: a key LEAVING this list
+ * means some slice stopped tearing it down, which is the bug. A key joining it
+ * is normal as slices gain fields, and the test logs those rather than failing.
+ */
+const PINNED_OWNED_KEYS: readonly string[] = [
+  'activeBasketViewId', 'activeChangeSetId', 'activeLensId', 'activeListId', 'activeModelId',
+  'activePresetId', 'activeSheet', 'activeStorey', 'activeTool', 'activeTopicId',
+  'activeViewpointId', 'activeWorkScheduleId', 'addElementModelId', 'addElementStoreyId',
+  'animationEnabled', 'annotation2DActiveTool', 'annotation2DCursorPos',
+  'basketPresentationVisible', 'basketViews', 'bcfError', 'bcfLoading', 'bcfPanelVisible',
+  'cameraRotation', 'cesiumAvailable', 'cesiumEnabled', 'cesiumGlbLoaded',
+  'cesiumHeightsAreEllipsoidal', 'cesiumPlacementDraft', 'cesiumPlacementDraftModelId',
+  'cesiumPlacementEditMode', 'cesiumSourceModelId', 'cesiumTerrainClipY',
+  'cesiumTerrainHeight', 'cesiumTerrainSaveHeight', 'changeSets', 'chatAbortController',
+  'chatError', 'chatStatus', 'chatStreamingContent', 'classFilter', 'cloudAnnotation2DPoints',
+  'cloudAnnotations2D', 'compareError', 'compareResult', 'compareRunning',
+  'compareSelectedKey', 'contactShadingIntensity', 'contactShadingQuality',
+  'contactShadingRadius', 'contextMenu', 'customOverrideRules', 'dirtyModels', 'draft',
+  'drawing2D', 'drawing2DDisplayOptions', 'drawing2DError', 'drawing2DPanelVisible',
+  'drawing2DPhase', 'drawing2DProgress', 'drawing2DStatus', 'drawing2DSvgContent',
+  'edgeContrastEnabled', 'edgeContrastIntensity', 'editEnabled', 'editingZone', 'error',
+  'expandedTaskGlobalIds', 'ganttPanelVisible', 'generateScheduleDialogOpen',
+  'geometryProgress', 'geometryResult', 'geometryStreamingActive', 'geometryUpdateTick',
+  'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel', 'hierarchyBasketSelection',
+  'hoverState', 'hoveredTaskGlobalId', 'idsActiveEntityId', 'idsActiveSpecificationId',
+  'idsError', 'idsFocusVisibilityOwned', 'idsLoading', 'idsPanelVisible', 'idsProgress',
+  'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel', 'lensAppliedHiddenIds',
+  'lensColorMap', 'lensHiddenIds', 'lensPanelVisible', 'lensRuleCounts', 'lensRuleEntityIds',
+  'lensRuleIsolation', 'listExecuting', 'listPanelVisible', 'listResult', 'loading',
+  'measure2DCurrent', 'measure2DLockedAxis', 'measure2DMode', 'measure2DResults',
+  'measure2DShiftLocked', 'measure2DSnapPoint', 'measure2DStart', 'meshColorBackup',
+  'metadataProgress', 'models', 'mutationVersion', 'mutationViews', 'overridesEnabled',
+  'overridesPanelVisible', 'pendingColorUpdates', 'pendingInstancedShards',
+  'pendingMeshColorUpdates', 'pendingPropertyFocus', 'pinboardEntities', 'playbackIsPlaying',
+  'playbackTime', 'pointCloudAlignmentAvailable', 'pointCloudAlignmentEnabled',
+  'pointCloudAssetCount', 'pointCloudClassCounts', 'pointCloudClassMask',
+  'pointCloudColorMode', 'pointCloudDeviationCenterOffset', 'pointCloudDeviationComputed',
+  'pointCloudDeviationHalfRange', 'pointCloudEdlEnabled', 'pointCloudEdlStrength',
+  'pointCloudFixedColor', 'pointCloudPointSize', 'pointCloudPreviewStride',
+  'pointCloudRoundShape', 'pointCloudSizeMode', 'pointCloudWorldRadius', 'polygonArea2DPoints',
+  'polygonArea2DResults', 'progress', 'projectionMode', 'redoStacks', 'scheduleData',
+  'scheduleRange', 'scriptAssistantTurnSnapshot', 'scriptDeleteConfirmId',
+  'scriptExecutionState', 'scriptLastDiagnostics', 'scriptLastError', 'scriptLastResult',
+  'searchFieldFilter', 'searchFilter', 'searchFilterError', 'searchFilterResult',
+  'searchFilterRunning', 'searchFilterSchema', 'searchHighlightIndex', 'searchIndexes',
+  'searchModalOpen', 'searchModelFilter', 'searchOpen', 'searchQuery', 'searchVimCycle',
+  'sectionPlane', 'selectedAnnotation2D', 'selectedAnnotationId', 'selectedEntities',
+  'selectedEntitiesSet', 'selectedEntity', 'selectedEntityId', 'selectedEntityIds',
+  'selectedModelId', 'selectedStoreys', 'selectedTaskGlobalIds', 'separationLinesEnabled',
+  'separationLinesIntensity', 'separationLinesQuality', 'separationLinesRadius',
+  'sheetEnabled', 'sheetPanelVisible', 'suppressNextSection2DPanelAutoOpen',
+  'textAnnotation2DEditing', 'textAnnotations2D', 'titleBlockEditorVisible', 'typeViewMode',
+  'typeVisibility', 'undoStacks', 'visualEnhancementsEnabled', 'zoneApportionment',
+  'zoneAssignmentTiming', 'zoneAssignments',
+];
+
+/** A `SliceTeardown` by shape, without importing the type into a runtime check. */
+function isSliceTeardown(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as { slice?: unknown; owns?: unknown; teardown?: unknown };
+  return typeof v.slice === 'string' && Array.isArray(v.owns) && typeof v.teardown === 'function';
+}
+
+/**
+ * The two failures `createTeardownRegistry` cannot see.
+ *
+ * It proves ownership is DISJOINT — no two slices claim one key — and throws on
+ * import when they do. It proves nothing about COMPLETENESS, and completeness
+ * is the half with no smell: a key that stops being torn down does not throw,
+ * does not fail to compile, and does not fail any existing test. It just stops
+ * being cleared, which is the exact defect this seam was built to remove.
+ *
+ * Two ways to lose a key silently, one test each:
+ *
+ *   1. drop it from a slice's `owns` (or from the body, since `owns` and the
+ *      emitted keys are only equal by hand),
+ *   2. write the whole contribution and forget the registry import line.
+ *
+ * `teardownOwnedKeys` was exported for the first of these and nothing called
+ * it, so the guard read as coverage while asserting nothing.
+ */
+describe('the teardown registry stays complete', () => {
+  it('owns exactly the keys it owned when this was pinned, so a key dropped from an `owns` list cannot go unnoticed', () => {
+    const owned = teardownOwnedKeys(viewerTeardownRegistry);
+    const actual = [...owned.keys()].map(String).sort();
+
+    const dropped = PINNED_OWNED_KEYS.filter((key) => !actual.includes(key));
+    assert.deepStrictEqual(
+      dropped,
+      [],
+      `these keys were torn down when this was pinned and are not any more: ${dropped.join(', ')}`,
+    );
+
+    const added = actual.filter((key) => !PINNED_OWNED_KEYS.includes(key));
+    if (added.length > 0) {
+      console.log('new keys now torn down (update teardown-owned-keys.json):', added);
+    }
+  });
+
+  it('registers every teardown a slice exports, so a contribution cannot be written and then left out of the registry', async () => {
+    // Import every slice module and look at the VALUES it exports. Reading the
+    // directory is a filesystem question ("what slices exist"); reading their
+    // source text and grepping it would be the banned kind of assertion, and
+    // would also be weaker — this compares object identity against the
+    // registry's own contents, so a teardown renamed, re-exported or shadowed
+    // still has to be the same object the registry holds.
+    const slicesDir = join(HERE, 'slices');
+    const registered = new Set<unknown>(viewerTeardownRegistry);
+    const found: string[] = [];
+    const missing: string[] = [];
+
+    for (const file of readdirSync(slicesDir).sort()) {
+      if (!file.endsWith('.ts') || file.includes('.test.')) continue;
+      const mod = (await import(join(slicesDir, file))) as Record<string, unknown>;
+      for (const [name, value] of Object.entries(mod)) {
+        if (!isSliceTeardown(value)) continue;
+        found.push(`${file}:${name}`);
+        if (!registered.has(value)) missing.push(`${file}:${name}`);
+      }
+    }
+
+    assert.deepStrictEqual(
+      missing,
+      [],
+      `these teardowns exist but are not in viewerTeardownRegistry, so their slices are never torn down: ${missing.join(', ')}`,
+    );
+
+    // Non-vacuity: the sweep must actually find the contributions. Without this
+    // an import that stopped resolving would report "nothing missing" forever.
+    assert.ok(
+      found.length >= 20,
+      `expected the slices directory to yield at least 20 teardowns, found ${found.length} — the sweep is broken, not the registry`,
+    );
+    assert.strictEqual(
+      viewerTeardownRegistry.length,
+      found.length,
+      'the registry holds a different number of entries than the slices directory exports',
+    );
+  });
+});

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { teardownOwnedKeys } from './teardown.js';
 import { viewerTeardownRegistry } from './teardown-registry.js';
+import { modelRemovedScope } from './teardown-scope.js';
+import type { FederatedModel } from './types.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -79,6 +81,61 @@ const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
   'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel', 'meshColorBackup', 'models',
   'pinboardEntities', 'selectedEntityId', 'selectedEntityIds', 'selectedStoreys',
 ];
+
+/**
+ * Every key a `model-removed` teardown writes, for the fixture below.
+ *
+ * This scope needs a state to emit anything - its contributions return `{}`
+ * when nothing of theirs names the removed model - so it is pinned against a
+ * fixture rather than `{}`. It is also the scope with the most intricate
+ * bodies (`isStale` filtering, `nextActiveModelId` following, the two-flag
+ * gates), which is exactly why leaving it unpinned would have made this file
+ * read as covering all three scopes while covering two.
+ */
+const PINNED_MODEL_REMOVED_KEYS: readonly string[] = [
+  'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'classFilter',
+  'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
+  'hierarchyBasketSelection', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
+  'meshColorBackup', 'models', 'pinboardEntities', 'selectedEntities', 'selectedEntitiesSet',
+  'selectedEntity', 'selectedEntityId', 'selectedEntityIds', 'selectedModelId', 'selectedStoreys',
+];
+
+/**
+ * A federation where model A owns state in every channel a removal touches.
+ *
+ * B survives with a disjoint id range, so `isStale` has a real survivor to ask
+ * about rather than answering true for everything.
+ */
+function modelRemovedFixture() {
+  const model = (id: string, idOffset: number, maxExpressId: number) =>
+    ({ id, name: id, visible: true, idOffset, maxExpressId }) as unknown as FederatedModel;
+  return {
+    models: new Map([['A', model('A', 0, 100)], ['B', model('B', 1000, 1100)]]),
+    activeModelId: 'A',
+    selectedEntityId: 42,
+    selectedEntityIds: new Set([42, 1005]),
+    selectedStoreys: new Set([44]),
+    selectedEntity: { modelId: 'A', expressId: 42 },
+    selectedEntities: [{ modelId: 'A', expressId: 42 }],
+    selectedEntitiesSet: new Set(['A:42', 'B:5']),
+    selectedModelId: 'A',
+    activeStorey: { modelId: 'A', expressId: 44 },
+    hiddenEntities: new Set([43, 1006]),
+    isolatedEntities: new Set([45, 1007]),
+    ghostExceptEntities: new Set([46]),
+    classFilter: { ids: new Set([47]), label: 'walls' },
+    hiddenEntitiesByModel: new Map([['A', new Set([43])]]),
+    isolatedEntitiesByModel: new Map([['A', new Set([45])]]),
+    pinboardEntities: new Set(['A:42', 'B:5']),
+    hierarchyBasketSelection: new Set(['A:42']),
+    meshColorBackup: new Map([[42, [1, 1, 1, 1]]]),
+    addElementModelId: 'A',
+    addElementStoreyId: 44,
+    ifcDataStore: null,
+    geometryResult: null,
+    mutationViews: new Map(),
+  } as unknown as Parameters<typeof modelRemovedScope>[0];
+}
 
 /**
  * Every key some slice DECLARES it may destroy, across all scopes.
@@ -213,6 +270,31 @@ describe('the teardown registry stays complete', () => {
           'not, some slice just started destroying state it does not own.',
       );
     }
+  });
+
+  it('still writes every `model-removed` key it wrote when this was pinned, the scope the other two pins cannot reach', () => {
+    const state = modelRemovedFixture();
+    const scope = modelRemovedScope(state, 'A');
+    const keys = new Set<string>();
+    for (const entry of viewerTeardownRegistry) {
+      for (const key of Object.keys(entry.teardown(scope, state))) keys.add(String(key));
+    }
+    const actual = [...keys].sort();
+
+    const dropped = PINNED_MODEL_REMOVED_KEYS.filter((key) => !actual.includes(key));
+    assert.deepStrictEqual(
+      dropped,
+      [],
+      `model-removed used to write these keys and does not any more: ${dropped.join(', ')}`,
+    );
+
+    const added = actual.filter((key) => !PINNED_MODEL_REMOVED_KEYS.includes(key));
+    assert.deepStrictEqual(
+      added,
+      [],
+      `model-removed now writes keys it did not before: ${added.join(', ')}. Same rule as above: ` +
+        'intended widening belongs in the pinned list in the same commit.',
+    );
   });
 
   it('declares the same ownership it declared when this was pinned', () => {

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -10,6 +10,9 @@ import { dirname, join } from 'node:path';
 import { teardownOwnedKeys } from './teardown.js';
 import { viewerTeardownRegistry } from './teardown-registry.js';
 import { modelRemovedScope } from './teardown-scope.js';
+import { viewerTeardown } from './teardown-registry.js';
+import type { TeardownState } from './teardown.js';
+import { UI_DEFAULTS } from './constants.js';
 import type { FederatedModel } from './types.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -315,6 +318,35 @@ describe('the teardown registry stays complete', () => {
       [],
       `these keys are newly declared owned: ${added.join(', ')}. Widening what a slice is willing ` +
         'to destroy is a deliberate act; add them to PINNED_OWNED_KEYS in the same commit.',
+    );
+  });
+
+  it('keeps both visibility channels in a session-reset patch even when neither value changes', () => {
+    // `withVisibilityOwnershipInvalidation` keys on PRESENCE - it tests
+    // `'isolatedEntities' in patch` - not on value. The hand-written
+    // resetViewerState always carried both, so it fired on every reset.
+    // composeTeardown's Object.is filter would drop them on the common reset
+    // where both are already null, silently ending that. NEVER_DROPPED exempts
+    // them, and this is what fails if the exemption is removed.
+    const bothAlreadyNull = { isolatedEntities: null, ghostExceptEntities: null } as TeardownState;
+    const patch = viewerTeardown({ kind: 'session-reset' }, bothAlreadyNull);
+
+    assert.ok(
+      'isolatedEntities' in patch,
+      'isolatedEntities must stay in the patch or the ownership middleware stops running on a reset',
+    );
+    assert.ok(
+      'ghostExceptEntities' in patch,
+      'ghostExceptEntities must stay in the patch for the same reason',
+    );
+
+    // Non-vacuity: the filter must genuinely be dropping unchanged keys, or the
+    // two assertions above pass for the wrong reason and prove nothing.
+    const unchanged = { activeTool: UI_DEFAULTS.ACTIVE_TOOL } as TeardownState;
+    const filtered = viewerTeardown({ kind: 'session-reset' }, unchanged);
+    assert.ok(
+      !('activeTool' in filtered),
+      'the Object.is filter must drop an ordinary unchanged key, or this test is not testing an exemption',
     );
   });
 

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -157,7 +157,13 @@ function isSliceTeardown(value: unknown): boolean {
  * does not fail to compile, and does not fail any existing test. It just stops
  * being cleared, which is the exact defect this seam was built to remove.
  *
- * Two ways to lose a key silently, one test each:
+ * The pins fail in BOTH directions. A key leaving means something stopped being
+ * torn down; a key arriving means a slice started destroying state it did not
+ * before, which is Trap A and the class `check-whole-state-reset.mjs` records as
+ * three real shipped bugs. Neither direction throws, fails to compile, or
+ * breaks another test on its own.
+ *
+ * Ways to lose or gain a key silently:
  *
  *   1. drop the key from a teardown's BODY while leaving it in `owns` — this
  *      compiles, because `Partial<Pick<...>>` does not require the key,
@@ -191,8 +197,21 @@ describe('the teardown registry stays complete', () => {
         [],
         `${kind} used to write these keys and does not any more: ${dropped.join(', ')}`,
       );
+      // Fails too, and that is the point. An `added` key is Trap A: the slice
+      // now destroys something it did not before. `check-whole-state-reset.mjs`
+      // records three of those shipping in one day - sheetSlice.clearSheet
+      // wiping savedSheetTemplates, drawing2DSlice.clearDrawing2D wiping
+      // override rules, DXF underlays and text annotations. Ownership stays
+      // disjoint through all of them, so the registry does not throw and the
+      // body type-checks. A one-directional pin would pass.
       const added = actual.filter((key) => !pinned.includes(key));
-      if (added.length > 0) console.log(`${kind} now also writes:`, added);
+      assert.deepStrictEqual(
+        added,
+        [],
+        `${kind} now writes keys it did not before: ${added.join(', ')}. If that is intended, ` +
+          'add them to the pinned list IN THE SAME COMMIT so the widening is reviewable. If it is ' +
+          'not, some slice just started destroying state it does not own.',
+      );
     }
   });
 
@@ -207,10 +226,14 @@ describe('the teardown registry stays complete', () => {
       `these keys were declared owned when this was pinned and are not any more: ${dropped.join(', ')}`,
     );
 
+    // Same both-directions rule as the emission pin above.
     const added = actual.filter((key) => !PINNED_OWNED_KEYS.includes(key));
-    if (added.length > 0) {
-      console.log('new keys now owned (update PINNED_OWNED_KEYS):', added);
-    }
+    assert.deepStrictEqual(
+      added,
+      [],
+      `these keys are newly declared owned: ${added.join(', ')}. Widening what a slice is willing ` +
+        'to destroy is a deliberate act; add them to PINNED_OWNED_KEYS in the same commit.',
+    );
   });
 
   it('registers every teardown a slice exports, so a contribution cannot be written and then left out of the registry', async () => {

--- a/apps/viewer/src/store/teardown-registry.ts
+++ b/apps/viewer/src/store/teardown-registry.ts
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The store's assembled teardown: every slice's contribution, in one list.
+ *
+ * `store/teardown.ts` defines the contract; this file is the only place that
+ * says WHICH slices implement it. Both halves are exported:
+ *
+ *  - {@link viewerTeardownRegistry} — the declarations, so a test can pin the
+ *    owned-key set. A migrator quietly dropping a key from an `owns` list is
+ *    otherwise invisible: the key simply stops being cleared, and "state that
+ *    was not cleared" is a failure with no smell.
+ *  - {@link viewerTeardown} — the composed `(scope, state) => patch` the four
+ *    entry points call.
+ *
+ * ## Why this is not `store/index.ts`
+ *
+ * `slices/modelSlice.ts` is one of the entry points (`removeModel`,
+ * `clearAllModels`), and `index.ts` imports `modelSlice.ts` to build the
+ * store. Putting the registry in `index.ts` would make that import cycle a
+ * RUNTIME one — `createTeardownRegistry` runs at module init — so the registry
+ * lives on its own, below both. Nothing here imports `index.ts`; the only tie
+ * to it is `ViewerState`, a type, erased at build.
+ *
+ * ## Order
+ *
+ * Listed in the order `index.ts` spreads the slices, so the two lists can be
+ * read side by side. Order does not decide any value: ownership is disjoint
+ * and `createTeardownRegistry` proves it on import, so a key has exactly one
+ * contributor and merge order only picks insertion order, which nothing
+ * observes.
+ *
+ * ## Slices that are absent
+ *
+ * A slice with no entry is a slice no teardown path has ever written.
+ * `measurementSlice` is the one deliberate exception: `resetViewerState` tears
+ * it down by CALLING `resetAllMeasurementState()`, an action that owns the
+ * full field list itself (see its doc comment for why that must not be
+ * duplicated as a table), and an action is a side effect a pure teardown may
+ * not perform. It stays at the entry point.
+ */
+
+import { composeTeardown, createTeardownRegistry, type AnySliceTeardown } from './teardown.js';
+
+import { loadingTeardown } from './slices/loadingSlice.js';
+import { selectionTeardown } from './slices/selectionSlice.teardown.js';
+import { visibilityTeardown } from './slices/visibilitySlice.teardown.js';
+import { uiTeardown } from './slices/uiSlice.teardown.js';
+import { hoverTeardown } from './slices/hoverSlice.js';
+import { cameraTeardown } from './slices/cameraSlice.js';
+import { sectionTeardown } from './slices/sectionSlice.teardown.js';
+import { dataTeardown } from './slices/dataSlice.teardown.js';
+import { modelTeardown } from './slices/modelSlice.teardown.js';
+import { mutationTeardown } from './slices/mutationSlice.teardown.js';
+import { drawing2DTeardown } from './slices/drawing2DSlice.teardown.js';
+import { sheetTeardown } from './slices/sheetSlice.teardown.js';
+import { bcfTeardown } from './slices/bcfSlice.teardown.js';
+import { idsTeardown } from './slices/idsSlice.teardown.js';
+import { listTeardown } from './slices/listSlice.js';
+import { pinboardTeardown } from './slices/pinboardSlice.teardown.js';
+import { lensTeardown } from './slices/lensSlice.js';
+import { compareTeardown } from './slices/compareSlice.js';
+import { scriptTeardown } from './slices/scriptSlice.teardown.js';
+import { chatTeardown } from './slices/chatSlice.teardown.js';
+import { cesiumTeardown } from './slices/cesiumSlice.teardown.js';
+import { scheduleTeardown } from './slices/scheduleSlice.teardown.js';
+import { playbackTeardown } from './slices/playbackSlice.js';
+import { searchTeardown } from './slices/searchSlice.teardown.js';
+import { annotationsTeardown } from './slices/annotationsSlice.teardown.js';
+import { addElementTeardown } from './slices/addElementSlice.teardown.js';
+import { pointCloudTeardown } from './slices/pointCloudSlice.js';
+import { zonesTeardown } from './slices/zonesSlice.js';
+
+/**
+ * Every slice teardown the viewer store knows about.
+ *
+ * Building this THROWS on import if two slices claim the same key, or one
+ * lists a key twice — the exact defect this seam exists to remove, turned into
+ * a failure every test sees rather than a silent double-write.
+ */
+export const viewerTeardownRegistry: readonly AnySliceTeardown[] = createTeardownRegistry([
+  loadingTeardown,
+  selectionTeardown,
+  visibilityTeardown,
+  uiTeardown,
+  hoverTeardown,
+  cameraTeardown,
+  sectionTeardown,
+  dataTeardown,
+  modelTeardown,
+  mutationTeardown,
+  drawing2DTeardown,
+  sheetTeardown,
+  bcfTeardown,
+  idsTeardown,
+  listTeardown,
+  pinboardTeardown,
+  lensTeardown,
+  compareTeardown,
+  scriptTeardown,
+  chatTeardown,
+  cesiumTeardown,
+  scheduleTeardown,
+  playbackTeardown,
+  searchTeardown,
+  annotationsTeardown,
+  addElementTeardown,
+  pointCloudTeardown,
+  zonesTeardown,
+]);
+
+/**
+ * The one patch builder the four teardown entry points share.
+ *
+ * PURE: it returns a patch and writes nothing. The caller applies it through
+ * the store's own `set` / `setState` — both wrapped by
+ * `withVisibilityOwnershipInvalidation` — so a teardown write goes through the
+ * shared-channel invalidation exactly like every other write.
+ */
+export const viewerTeardown = composeTeardown(viewerTeardownRegistry);

--- a/apps/viewer/src/store/teardown-scope.ts
+++ b/apps/viewer/src/store/teardown-scope.ts
@@ -26,6 +26,13 @@ export type ModelRemovedScope = Extract<TeardownScope, { kind: 'model-removed' }
 /**
  * Build the scope for "this model is going away".
  *
+ * KNOWN DUPLICATION, deliberately left: the survivor predicate below is a third
+ * statement of the ownership rule that `modelSlice`'s `localIdInParseRange` /
+ * `localIdInOverlay` (#2697) and `store/globalId.ts` already carry. It cannot
+ * import `modelSlice` — that file imports this one — and `store/globalId.ts` is
+ * the cycle-free home all three should share. Consolidating them is a change of
+ * its own; until then, a boundary change has to be made in three places.
+ *
  * The predicate mirrors the two-pass resolution in `modelSlice`'s
  * `resolveGlobalIdFromModels`: a global id survives if some SURVIVING model
  * owns it, either inside its parse-time range (`idOffset` ..
@@ -70,5 +77,15 @@ export function modelRemovedScope(
     return true;
   };
 
-  return { kind: 'model-removed', modelId, isStale };
+  // Resolved here, once, because two slices owning different keys both have to
+  // follow it (see `nextActiveModelId` on TeardownScope). Insertion order picks
+  // the successor, exactly as `Array.from(newModels.keys())[0]` did before this
+  // moved behind the seam. `notYetASurvivor` is deliberately NOT excluded: a
+  // resync's replacement is a legitimate active model, it is only barred from
+  // rescuing stale ids.
+  const remaining = [...(state.models?.keys() ?? [])].filter((id) => id !== modelId);
+  const nextActiveModelId =
+    state.activeModelId === modelId ? (remaining[0] ?? null) : (state.activeModelId ?? null);
+
+  return { kind: 'model-removed', modelId, isStale, nextActiveModelId };
 }

--- a/apps/viewer/src/store/teardown-scope.ts
+++ b/apps/viewer/src/store/teardown-scope.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The one place the `model-removed` scope — and the survivor predicate it
+ * carries — is built.
+ *
+ * `store/teardown.ts` says what a scope IS; this says how the interesting one
+ * is COMPUTED, because that computation needs federation knowledge (offsets,
+ * parse ranges, overlay allocations) that the contract deliberately does not.
+ *
+ * Two call sites, one implementation, and that is the point: before this seam,
+ * `modelSlice.removeModel` and `lib/sources/syncSourceModel.ts`'s
+ * `purgeStaleEntityState` each carried their own copy of the loop below, held
+ * together by a prose comment ("same shape as `purgeStaleEntityState`", twice).
+ * They differed only in which models counted as survivors, which is exactly
+ * what {@link modelRemovedScope}'s third argument expresses.
+ */
+
+import type { TeardownScope, TeardownState } from './teardown.js';
+
+/** The `model-removed` arm, once its predicate is known. */
+export type ModelRemovedScope = Extract<TeardownScope, { kind: 'model-removed' }>;
+
+/**
+ * Build the scope for "this model is going away".
+ *
+ * The predicate mirrors the two-pass resolution in `modelSlice`'s
+ * `resolveGlobalIdFromModels`: a global id survives if some SURVIVING model
+ * owns it, either inside its parse-time range (`idOffset` ..
+ * `idOffset + maxExpressId`) or as an overlay-allocated entity above that
+ * range in its mutation view (StoreEditor duplicates, scripted adds). An id no
+ * survivor owns is stale, and every global-id-keyed slice drops it.
+ *
+ * @param state - the store as it stands BEFORE the teardown's `set`. Read-only
+ *   and partial: `slices/modelSlice.test.ts` drives `removeModel` through a
+ *   harness that stubs `get()` with the model slice alone, so `mutationViews`
+ *   is genuinely absent on a path that reaches here. An absent map simply
+ *   means no overlay ids exist to rescue.
+ * @param modelId - the model being removed. Never a survivor, whether it is
+ *   still in `models` (`removeModel` builds the scope before its own `set`) or
+ *   already gone (`syncSourceModel` builds it after).
+ * @param notYetASurvivor - a model that IS in `models` but must not count.
+ *   `syncSourceModel` loads the replacement FIRST and swaps only on success,
+ *   so by the time it purges, the replacement is loaded and holds a fresh
+ *   offset range. Nothing can legitimately reference it yet, and a stale id —
+ *   notably an old overlay id, which range-filtering on the removed model's
+ *   own range would let escape — can land inside that new range and silently
+ *   mis-highlight an unrelated entity. Omitted by `removeModel`, which has no
+ *   such incoming model.
+ */
+export function modelRemovedScope(
+  state: TeardownState,
+  modelId: string,
+  notYetASurvivor?: string,
+): ModelRemovedScope {
+  const survivors = Array.from(state.models?.values() ?? []).filter(
+    (model) => model.id !== modelId && model.id !== notYetASurvivor,
+  );
+  const mutationViews = state.mutationViews;
+
+  const isStale = (id: number): boolean => {
+    for (const survivor of survivors) {
+      const localId = id - survivor.idOffset;
+      if (localId < 0) continue;
+      if (localId <= survivor.maxExpressId) return false;
+      if (mutationViews?.get(survivor.id)?.getNewEntity(localId) != null) return false;
+    }
+    return true;
+  };
+
+  return { kind: 'model-removed', modelId, isStale };
+}

--- a/apps/viewer/src/store/teardown.idempotence.test.ts
+++ b/apps/viewer/src/store/teardown.idempotence.test.ts
@@ -85,6 +85,20 @@ describe('the model-removed teardown scope is idempotent', () => {
     // pass and only then. Without this, a regression in how `notYetASurvivor`
     // interacts with the per-slice gates would leave the file green.
     useViewerStore.setState({
+      // Reset every channel this case reads. The test above leaves
+      // selectedStoreys / hiddenEntitiesByModel / isolatedEntitiesByModel /
+      // pinboardEntities populated, and inheriting them made the patches this
+      // asserts on depend on file order.
+      selectedStoreys: new Set<number>(),
+      hiddenEntitiesByModel: new Map(),
+      isolatedEntitiesByModel: new Map(),
+      pinboardEntities: new Set<string>(),
+      hierarchyBasketSelection: new Set<string>(),
+      selectedEntities: [],
+      selectedEntitiesSet: new Set<string>(),
+      selectedEntity: null,
+      activeStorey: null,
+      selectedModelId: null,
       models: new Map([
         ['old', model('old', 5000, 5100)],
         ['repl', model('repl', 0, 100)],
@@ -102,10 +116,8 @@ describe('the model-removed teardown scope is idempotent', () => {
 
     const before = useViewerStore.getState();
     const lenient = viewerTeardown(modelRemovedScope(before, 'old'), before);
-    console.log('lenient patch keys:', Object.keys(lenient).sort());
 
     const stricter = viewerTeardown(modelRemovedScope(before, 'old', 'repl'), before);
-    console.log('stricter patch keys:', Object.keys(stricter).sort());
 
     // The whole reason both runs exist: the stricter pass must see something the
     // lenient one did not. If these ever match, `notYetASurvivor` has stopped
@@ -114,10 +126,15 @@ describe('the model-removed teardown scope is idempotent', () => {
       (stricter.selectedEntityIds as Set<number> | undefined)?.has(42) === false,
       'the stricter scope must drop an id inside the replacement\'s fresh range',
     );
+    // Measured, not hedged: the lenient scope finds nothing of selection's
+    // stale, so selectionSlice returns {} and the key is absent entirely. An
+    // earlier version of this allowed `undefined || has(42)`, which passed
+    // through the undefined branch and never exercised the path it named.
     assert.ok(
-      (lenient.selectedEntityIds as Set<number> | undefined) === undefined ||
-        (lenient.selectedEntityIds as Set<number>).has(42),
-      'the lenient scope must KEEP it, or the two runs are not different and one is redundant',
+      !('selectedEntityIds' in lenient),
+      'the lenient scope must not touch selectedEntityIds at all: 42 is inside the ' +
+        'replacement range and 1005 belongs to a survivor, so nothing of selection is stale. ' +
+        'If this key appears, the two scopes no longer differ and one run is redundant.',
     );
     assert.ok(
       (stricter.selectedEntityIds as Set<number>).has(1005),

--- a/apps/viewer/src/store/teardown.idempotence.test.ts
+++ b/apps/viewer/src/store/teardown.idempotence.test.ts
@@ -57,7 +57,6 @@ describe('the model-removed teardown scope is idempotent', () => {
     // on this state, or an empty second patch would prove nothing at all.
     const before = useViewerStore.getState();
     const firstPatch = viewerTeardown(modelRemovedScope(before, 'A'), before);
-    console.log('first patch keys:', Object.keys(firstPatch).sort());
     assert.ok(
       Object.keys(firstPatch).length > 0,
       'the fixture must give the composition something to clear, or this test cannot fail',
@@ -72,7 +71,6 @@ describe('the model-removed teardown scope is idempotent', () => {
     const after = useViewerStore.getState();
     const secondPatch = viewerTeardown(modelRemovedScope(after, 'A'), after);
 
-    console.log('second patch keys:', Object.keys(secondPatch).sort());
     assert.deepStrictEqual(
       Object.keys(secondPatch).sort(),
       [],

--- a/apps/viewer/src/store/teardown.idempotence.test.ts
+++ b/apps/viewer/src/store/teardown.idempotence.test.ts
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { useViewerStore } from './index.js';
+import { viewerTeardown } from './teardown-registry.js';
+import { modelRemovedScope } from './teardown-scope.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+/**
+ * `syncSourceModel` runs the `model-removed` composition a SECOND time, right
+ * after `removeModel` has already run it, and the comment at the call site
+ * justifies that by claiming every contribution returns `{}` once nothing of
+ * its own moved. Nothing asserted it.
+ *
+ * The claim is load-bearing rather than tidy. A contribution that rebuilds an
+ * equal-but-new `Map` or `Set` instead of returning `{}` defeats
+ * `composeTeardown`'s `Object.is` filter, so the second pass writes a fresh
+ * reference for a value that did not change. That re-renders every subscriber
+ * of that key, and for `isolatedEntities` / `ghostExceptEntities` it puts the
+ * write through `withVisibilityOwnershipInvalidation` a second time, dropping
+ * ownership records that the first pass had already settled.
+ *
+ * Neither symptom is a failing assertion anywhere else: the state ends up
+ * value-equal either way, so every existing teardown test stays green while
+ * the churn happens. This test reads the PATCH rather than the state, which is
+ * the only place the difference is visible.
+ */
+describe('the model-removed teardown scope is idempotent', () => {
+  it('re-running the same scope after removeModel produces an empty patch, which is what lets syncSourceModel run it a second time (see its call site)', () => {
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+      selectedEntityIds: new Set([42, 1005]),
+      selectedEntityId: 42,
+      hiddenEntities: new Set([43, 1006]),
+      selectedStoreys: new Set([44]),
+      isolatedEntities: new Set([45, 1007]),
+      hiddenEntitiesByModel: new Map([['A', new Set([43])], ['B', new Set([1006])]]),
+      isolatedEntitiesByModel: new Map([['A', new Set([45])], ['B', new Set([1007])]]),
+    });
+    useViewerStore.getState().setBasket([
+      { modelId: 'A', expressId: 42 },
+      { modelId: 'B', expressId: 5 },
+    ]);
+
+    // Guard against a vacuous pass: the composition must have real work to do
+    // on this state, or an empty second patch would prove nothing at all.
+    const before = useViewerStore.getState();
+    const firstPatch = viewerTeardown(modelRemovedScope(before, 'A'), before);
+    console.log('first patch keys:', Object.keys(firstPatch).sort());
+    assert.ok(
+      Object.keys(firstPatch).length > 0,
+      'the fixture must give the composition something to clear, or this test cannot fail',
+    );
+
+    useViewerStore.getState().removeModel('A');
+
+    // The identical scope. `modelRemovedScope` filters the removed model out of
+    // the survivor set by id, so it builds the same `isStale` before and after
+    // the model leaves `models` — this is the scope `removeModel` just applied,
+    // not a weaker one.
+    const after = useViewerStore.getState();
+    const secondPatch = viewerTeardown(modelRemovedScope(after, 'A'), after);
+
+    console.log('second patch keys:', Object.keys(secondPatch).sort());
+    assert.deepStrictEqual(
+      Object.keys(secondPatch).sort(),
+      [],
+      'a second run of the same scope must write nothing: any key here is a contribution rebuilding an equal-but-new value instead of returning {}',
+    );
+  });
+});

--- a/apps/viewer/src/store/teardown.idempotence.test.ts
+++ b/apps/viewer/src/store/teardown.idempotence.test.ts
@@ -77,4 +77,51 @@ describe('the model-removed teardown scope is idempotent', () => {
       'a second run of the same scope must write nothing: any key here is a contribution rebuilding an equal-but-new value instead of returning {}',
     );
   });
+
+  it('the STRICTER scope syncSourceModel actually dispatches writes only what the first pass could not see', () => {
+    // The case above re-runs the scope `removeModel` used. Production does not:
+    // `syncSourceModel` passes the just-loaded replacement as `notYetASurvivor`,
+    // so ids inside the replacement's fresh range become stale on the second
+    // pass and only then. Without this, a regression in how `notYetASurvivor`
+    // interacts with the per-slice gates would leave the file green.
+    useViewerStore.setState({
+      models: new Map([
+        ['old', model('old', 5000, 5100)],
+        ['repl', model('repl', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'repl',
+      // 42 lands inside the REPLACEMENT's fresh range, so `removeModel`'s scope
+      // (which counts `repl` as a survivor) keeps it and the stricter one drops
+      // it. 1005 belongs to B and must survive both.
+      selectedEntityIds: new Set([42, 1005]),
+      hiddenEntities: new Set([42, 1005]),
+      isolatedEntities: null,
+      ghostExceptEntities: null,
+    });
+
+    const before = useViewerStore.getState();
+    const lenient = viewerTeardown(modelRemovedScope(before, 'old'), before);
+    console.log('lenient patch keys:', Object.keys(lenient).sort());
+
+    const stricter = viewerTeardown(modelRemovedScope(before, 'old', 'repl'), before);
+    console.log('stricter patch keys:', Object.keys(stricter).sort());
+
+    // The whole reason both runs exist: the stricter pass must see something the
+    // lenient one did not. If these ever match, `notYetASurvivor` has stopped
+    // discriminating and the resync's second pass is dead weight.
+    assert.ok(
+      (stricter.selectedEntityIds as Set<number> | undefined)?.has(42) === false,
+      'the stricter scope must drop an id inside the replacement\'s fresh range',
+    );
+    assert.ok(
+      (lenient.selectedEntityIds as Set<number> | undefined) === undefined ||
+        (lenient.selectedEntityIds as Set<number>).has(42),
+      'the lenient scope must KEEP it, or the two runs are not different and one is redundant',
+    );
+    assert.ok(
+      (stricter.selectedEntityIds as Set<number>).has(1005),
+      'an id owned by a surviving model must survive the stricter pass too',
+    );
+  });
 });

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -35,7 +35,10 @@
  *
  * A `SliceTeardown` is a PURE function of `(scope, state)`. It returns a
  * patch. It does not call `set`, does not call another slice's action, and
- * does not touch the renderer, `localStorage` or the federation registry.
+ * does not touch the renderer or the federation registry, and does not WRITE
+ * `localStorage`. It may READ a persisted preference: Trap B below requires it
+ * (`visibilitySlice` re-reads `typeVisibility` / `typeViewMode`), which is why
+ * `viewerTeardown` is not a pure function of its arguments alone.
  *
  * That is not stylistic. Three of the four entry points sequence ORDERED side
  * effects around their `set()`, and the order is load-bearing and tested:
@@ -116,7 +119,7 @@ import type { ViewerState } from './index.js';
  * Which teardown is running.
  *
  * `model-removed` covers BOTH the federation removal (`modelSlice.removeModel`)
- * and the source resync purge (`syncSourceModel.purgeStaleEntityState`). That
+ * and the source resync purge in `syncSourceModel`. That
  * is the point of `isStale`: the two paths differed only in how they computed
  * the survivor set, and passing the predicate in is what collapses two
  * implementations into one.
@@ -195,7 +198,7 @@ export interface SliceTeardown<K extends keyof ViewerState = keyof ViewerState> 
    * spreads its groups conditionally (`...(selectionTouchedRemoved ? {…} : {})`)
    * precisely so an untouched group is not rewritten; keeping that habit is
    * what makes `model-removed` idempotent, which in turn is what lets
-   * `purgeStaleEntityState` run the SAME composition after `removeModel`
+   * `syncSourceModel` runs the SAME composition after `removeModel`
    * without undoing or re-allocating anything.
    *
    * {@link composeTeardown} drops `Object.is`-unchanged entries as a backstop,
@@ -313,18 +316,18 @@ export function teardownOwnedKeys(
  * subscriber is notified for a non-change, and the visibility-ownership
  * middleware does not run its invalidation for a channel nobody actually
  * moved. It also makes a `model-removed` teardown safe to run twice, which
- * `purgeStaleEntityState` does immediately after `removeModel`.
+ * `syncSourceModel` does immediately after `removeModel`.
  *
  * A key absent from `state` (the partial-store test harness) is never
  * "unchanged" — `Object.is(undefined, value)` is false unless the teardown also
  * returns `undefined`.
  *
- * Three contributions DO return `undefined`, and the rule that keeps that safe
- * is narrower than "never return it": `visibilitySlice` (`hiddenEntities`),
- * `selectionSlice` (`selectedEntityIds` / `selectedStoreys`) and `dataSlice`'s
- * `purgeRemovedModelsBackup` all pass through the value they READ from `state`,
- * so they return `undefined` only where the live value is `undefined` too and
- * the entry is dropped. Returning a SYNTHESIZED `undefined` would survive the
+ * About a dozen contributions DO return `undefined` - most of `visibilitySlice`
+ * and `selectionSlice`'s model-removed arms, plus `dataSlice`'s
+ * `purgeRemovedModelsBackup`. Do not audit that as a list; audit the RULE, which
+ * is narrower than "never return it": every one of them passes THROUGH a value
+ * read from `state`, so `undefined` appears only where the live value is
+ * `undefined` too and the entry is dropped. Returning a SYNTHESIZED `undefined` would survive the
  * filter, and `writeKey` would set it, and zustand's shallow merge would blank
  * the field.
  */

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -8,7 +8,7 @@
  * Four hand-written implementations decide today what a model switch, a model
  * removal, a full federation clear and a source resync each wipe:
  *
- *   - `store/index.ts` `resetViewerState`        186 keys, 23 slices
+ *   - `store/index.ts` `resetViewerState`        186 keys, 26 slices
  *   - `slices/modelSlice.ts` `removeModel`        24 keys
  *   - `slices/modelSlice.ts` `clearAllModels`     18 keys
  *   - `lib/sources/syncSourceModel.ts` `purgeStaleEntityState`  14 keys

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -63,10 +63,9 @@
  * Inline at the bottom of the slice, or in a sibling `<slice>.teardown.ts`. The
  * rule is the module-size ratchet and nothing else: sibling file iff the slice
  * plus its contribution would cross ~400 lines, inline otherwise. Two files
- * (`addElementSlice.teardown.ts` at 341, `annotationsSlice.teardown.ts` at 365)
- * are split despite fitting, for group uniformity; that reason does not survive
- * contact with the nine inline contributions on larger hosts, and folding those
- * two back in would make the rule exceptionless.
+ * are split despite fitting: `addElementSlice` and `annotationsSlice`, whose
+ * host PLUS contribution come to 341 and 365. Group uniformity was the reason;
+ * folding those two back inline would make the rule exceptionless.
  *
  * ## Trap A: a teardown returns an EXPLICIT field list, never a whole state
  *

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -304,6 +304,27 @@ export function teardownOwnedKeys(
 }
 
 /**
+ * Keys the `Object.is` filter below must never drop.
+ *
+ * `withVisibilityOwnershipInvalidation` keys on PRESENCE, not value:
+ * `applyOwnershipInvalidation` tests `'isolatedEntities' in patch`. The old
+ * hand-written `resetViewerState` always carried both channels, so the
+ * middleware ran on every session reset. Dropping an unchanged channel would
+ * silently stop it running on the common reset, where both are already `null`.
+ *
+ * That matters for a guarantee rather than for today's data. `lib/visibility/
+ * ownership.ts` states the middleware's purpose as making a THIRD subsystem's
+ * claim "invalidated by construction rather than by remembering to extend a
+ * list somewhere else". Today's two record fields happen to be cleared by name
+ * as well, so nothing is broken now. Add a third and the by-construction half
+ * is what catches it, so the filter must not be what takes it away.
+ */
+const NEVER_DROPPED: ReadonlySet<keyof ViewerState> = new Set([
+  'isolatedEntities',
+  'ghostExceptEntities',
+]);
+
+/**
  * Build the one patch an entry point hands to `set`.
  *
  * Contributions are merged in registry order. Ownership is disjoint (proved by
@@ -313,10 +334,12 @@ export function teardownOwnedKeys(
  * An entry whose value is already `Object.is`-identical to the live state is
  * DROPPED. That keeps a composed patch as close as possible to today's
  * conditional spreads: a key that is not in the patch is not written, so no
- * subscriber is notified for a non-change, and the visibility-ownership
- * middleware does not run its invalidation for a channel nobody actually
- * moved. It also makes a `model-removed` teardown safe to run twice, which
- * `syncSourceModel` does immediately after `removeModel`.
+ * subscriber is notified for a non-change. It also makes a `model-removed`
+ * teardown safe to run twice, which `syncSourceModel` does immediately after
+ * `removeModel`.
+ *
+ * {@link NEVER_DROPPED} is exempt, because the visibility-ownership middleware
+ * keys on a channel's PRESENCE in the patch rather than its value.
  *
  * A key absent from `state` (the partial-store test harness) is never
  * "unchanged" — `Object.is(undefined, value)` is false unless the teardown also
@@ -340,7 +363,7 @@ export function composeTeardown(
       const contribution = entry.teardown(scope, state);
       for (const key of Object.keys(contribution) as (keyof ViewerState)[]) {
         const next = contribution[key];
-        if (Object.is(state[key], next)) continue;
+        if (!NEVER_DROPPED.has(key) && Object.is(state[key], next)) continue;
         writeKey(patch, key, next);
       }
     }

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -15,9 +15,10 @@
  *
  * Every one of those keys is owned by a slice that ALREADY declares its
  * initial value one file over; the teardown paths restate the value a second
- * time, in a file that cannot see the slice. `modelSlice` even declares 16
- * fields it does not own (`ModelCrossSliceState`) purely so its teardown can
- * type-check its reach into five other slices. The four copies are held
+ * time, in a file that cannot see the slice. `modelSlice` even declared 16
+ * fields it did not own (`ModelCrossSliceState`) purely so its teardown could
+ * type-check its reach into five other slices — that interface is gone, and
+ * its disappearance is the measure of this change. The four copies were held
  * together by prose: "same shape as `purgeStaleEntityState`", twice.
  *
  * This module replaces the prose with a contract. Each slice contributes

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -316,8 +316,17 @@ export function teardownOwnedKeys(
  * `purgeStaleEntityState` does immediately after `removeModel`.
  *
  * A key absent from `state` (the partial-store test harness) is never
- * "unchanged" — `Object.is(undefined, value)` is false unless the teardown
- * genuinely returns `undefined`, which no contribution should.
+ * "unchanged" — `Object.is(undefined, value)` is false unless the teardown also
+ * returns `undefined`.
+ *
+ * Three contributions DO return `undefined`, and the rule that keeps that safe
+ * is narrower than "never return it": `visibilitySlice` (`hiddenEntities`),
+ * `selectionSlice` (`selectedEntityIds` / `selectedStoreys`) and `dataSlice`'s
+ * `purgeRemovedModelsBackup` all pass through the value they READ from `state`,
+ * so they return `undefined` only where the live value is `undefined` too and
+ * the entry is dropped. Returning a SYNTHESIZED `undefined` would survive the
+ * filter, and `writeKey` would set it, and zustand's shallow merge would blank
+ * the field.
  */
 export function composeTeardown(
   registry: readonly AnySliceTeardown[],

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -1,0 +1,321 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The seam viewer-state teardown never had.
+ *
+ * Four hand-written implementations decide today what a model switch, a model
+ * removal, a full federation clear and a source resync each wipe:
+ *
+ *   - `store/index.ts` `resetViewerState`        186 keys, 23 slices
+ *   - `slices/modelSlice.ts` `removeModel`        24 keys
+ *   - `slices/modelSlice.ts` `clearAllModels`     18 keys
+ *   - `lib/sources/syncSourceModel.ts` `purgeStaleEntityState`  14 keys
+ *
+ * Every one of those keys is owned by a slice that ALREADY declares its
+ * initial value one file over; the teardown paths restate the value a second
+ * time, in a file that cannot see the slice. `modelSlice` even declares 16
+ * fields it does not own (`ModelCrossSliceState`) purely so its teardown can
+ * type-check its reach into five other slices. The four copies are held
+ * together by prose: "same shape as `purgeStaleEntityState`", twice.
+ *
+ * This module replaces the prose with a contract. Each slice contributes
+ * ONE function that answers "what do I clear under this scope, and nothing
+ * else"; the entry points compose those contributions into a single patch and
+ * hand it to the store's `set`.
+ *
+ * ## What a teardown MAY NOT do
+ *
+ * A `SliceTeardown` is a PURE function of `(scope, state)`. It returns a
+ * patch. It does not call `set`, does not call another slice's action, and
+ * does not touch the renderer, `localStorage` or the federation registry.
+ *
+ * That is not stylistic. Three of the four entry points sequence ORDERED side
+ * effects around their `set()`, and the order is load-bearing and tested:
+ *
+ *   - `endClashScenePresentation` must RELEASE the shared visibility channels
+ *     before the clash slice's own clear nulls `clashVisibilityOwned`
+ *     (`lib/clash/visibility-ownership.ts` documents the mutation that proves
+ *     it: 8 tests across three files).
+ *   - `clearIdsValidationReport` releases before it nulls its record, for the
+ *     same reason.
+ *   - `resetViewerState` calls `clearLastSectionMode()` (localStorage),
+ *     `invalidateVisibleBasketCache()` and `get().resetAllMeasurementState()`
+ *     BEFORE its `set`, and `endClashScenePresentation` AFTER it.
+ *   - `removeModel` runs `clearMutations` / `clearMutationView` /
+ *     `removeSourceTag` / the clash + IDS releases BEFORE its `set`.
+ *
+ * Those stay exactly where they are, in the entry point, in the same order.
+ * Only the `set()` PAYLOAD moves behind this seam.
+ *
+ * ## Trap A: a teardown returns an EXPLICIT field list, never a whole state
+ *
+ * `scripts/check-whole-state-reset.mjs` (proposal, issue #2802) documents
+ * three bugs of this class that landed in one day: `sheetSlice.clearSheet`
+ * did `set(getDefaultState())` and destroyed `savedSheetTemplates`;
+ * `drawing2DSlice.clearDrawing2D` destroyed custom override rules,
+ * `overridesEnabled`, text annotations and DXF underlays.
+ *
+ * So: `owns` is a hand-written list, and the returned object names its fields
+ * one by one. `...initialState` and `...getDefaultState()` are forbidden as
+ * the body of a teardown. Fields that legitimately outlive a session reset —
+ * `savedSheetTemplates`, `graphicOverridePresets`, `dxfUnderlays`, `bcfProject`,
+ * `bcfAuthor`, `idsDocument`, `savedLenses`, clash presets, zone SETS,
+ * `playbackSpeed` / `playbackLoop` / `ganttTimeScale` — are simply absent from
+ * both `owns` and the body. `owns` is the reviewable artefact: it is the list
+ * of everything this slice is willing to destroy.
+ *
+ * ## Trap B: persisted fields survive their session-scoped neighbours
+ *
+ * `sectionPlane` is one value holding both kinds. `axis` / `position` /
+ * `enabled` / `flipped` are model-relative and meaningless after a file swap;
+ * `showCap` / `showOutlines` / `capStyle` round-trip to localStorage and are
+ * the user's cut-surface appearance. `store/index.ts` therefore SPREADS the
+ * live plane and overwrites only the first four (`sectionSlice.ts` documents
+ * why). `typeVisibility` / `typeViewMode` are the mirror image: re-READ from
+ * localStorage on every reset so a new model never reverts the user's choices.
+ *
+ * A blanket per-slice reset destroys both. The scope parameter is what encodes
+ * the distinction, and every such case must be carried over verbatim, comment
+ * included.
+ *
+ * ## The visibility-ownership middleware
+ *
+ * `store/index.ts` wraps the store in `withVisibilityOwnershipInvalidation`
+ * (`store/visibility-invalidation.ts`), which is the one place
+ * `isolatedEntities` / `ghostExceptEntities` can be written. Its own doc makes
+ * the same argument this module does — a middleware "rather than a helper each
+ * writing action remembers to call" — and it is already accepted here.
+ *
+ * Nothing below fights it: teardown produces a patch, and the ENTRY POINT
+ * applies that patch through the wrapped `set` / `setState`, so the
+ * invalidation fires for teardown writes exactly as it does for every other
+ * write. Never apply a composed patch through an unwrapped setter.
+ */
+
+import type { ViewerState } from './index.js';
+
+/**
+ * Which teardown is running.
+ *
+ * `model-removed` covers BOTH the federation removal (`modelSlice.removeModel`)
+ * and the source resync purge (`syncSourceModel.purgeStaleEntityState`). That
+ * is the point of `isStale`: the two paths differed only in how they computed
+ * the survivor set, and passing the predicate in is what collapses two
+ * implementations into one.
+ */
+export type TeardownScope =
+  | { kind: 'session-reset' }
+  | { kind: 'model-removed'; modelId: string; isStale: (id: number) => boolean }
+  | { kind: 'all-models-cleared' };
+
+/**
+ * The state a teardown reads.
+ *
+ * `Partial` is deliberate and is a compile-time gate, not pessimism:
+ * `slices/modelSlice.test.ts` drives `removeModel` through a harness that
+ * stubs `get()` with the model slice ALONE, so every other slice's fields are
+ * genuinely absent on a path that reaches this composition. Today's code
+ * handles that by hand (`sel.selectedEntities ?? []`, every field of the local
+ * cast optional); making it part of the type means a teardown cannot forget.
+ *
+ * Fall back to the slice's OWN initial value — by definition the correct
+ * answer, and the value is already in the file.
+ *
+ * `Readonly` because a teardown must not mutate what it was handed: `set` has
+ * not run yet and the object is the live state.
+ */
+export type TeardownState = Readonly<Partial<ViewerState>>;
+
+/**
+ * The patch a slice owning keys `K` is allowed to return.
+ *
+ * The second half is not decoration. `Partial<Pick<…>>` alone does NOT reject
+ * a foreign key here: excess-property checking does not reach a fresh object
+ * literal returned from a callback whose contextual type comes from an
+ * inference site, so a body returning a key outside `owns` compiled clean
+ * (measured, before this was added). Typing every OTHER key as `never` is what
+ * actually makes "return only the keys you own" a compiler error rather than a
+ * comment — which is the whole point of declaring `owns` separately.
+ */
+export type TeardownContribution<K extends keyof ViewerState> =
+  Partial<Pick<ViewerState, K>> & { [P in Exclude<keyof ViewerState, K>]?: never };
+
+/**
+ * One slice's answer to "what do I clear under this scope".
+ *
+ * `owns` is DECLARED, not inferred from the body, which is what makes
+ * ownership checkable: {@link createTeardownRegistry} proves the declarations
+ * are disjoint at module init, and `Pick<ViewerState, K>` makes the compiler
+ * reject a body that returns a key outside them.
+ */
+export interface SliceTeardown<K extends keyof ViewerState = keyof ViewerState> {
+  /** Source file basename, e.g. `'uiSlice'`. Used in conflict messages. */
+  readonly slice: string;
+  /** Every key this slice is willing to destroy. Reviewable on its own. */
+  readonly owns: readonly K[];
+  /**
+   * @returns the fields to assign, or `{}` for "this scope does not touch me".
+   *
+   * Return a key ONLY when its value actually changes. Today's `removeModel`
+   * spreads its groups conditionally (`...(selectionTouchedRemoved ? {…} : {})`)
+   * precisely so an untouched group is not rewritten; keeping that habit is
+   * what makes `model-removed` idempotent, which in turn is what lets
+   * `purgeStaleEntityState` run the SAME composition after `removeModel`
+   * without undoing or re-allocating anything.
+   *
+   * {@link composeTeardown} drops `Object.is`-unchanged entries as a backstop,
+   * but a contribution that rebuilds an equal-but-new `Map` defeats it.
+   */
+  readonly teardown: (scope: TeardownScope, state: TeardownState) => TeardownContribution<K>;
+}
+
+/** A teardown in a heterogeneous registry, where `K` is no longer known. */
+export type AnySliceTeardown = SliceTeardown<keyof ViewerState>;
+
+/**
+ * Declare a slice's teardown.
+ *
+ * The `const` type parameter infers `K` as the literal union of `owns`, so the
+ * body is checked against exactly those keys — no `as const` needed at the
+ * call site, and no way to widen `K` by accident.
+ *
+ * @example
+ * export const uiTeardown = defineSliceTeardown(
+ *   'uiSlice',
+ *   ['activeTool', 'editEnabled', 'pendingPropertyFocus'],
+ *   (scope) => scope.kind !== 'session-reset' ? {} : {
+ *     activeTool: UI_DEFAULTS.ACTIVE_TOOL,
+ *     editEnabled: false,
+ *     // Drop any one-shot bSDD "jump to property" focus armed before the
+ *     // load — a new file reuses ids, so a stale focus could match an
+ *     // unrelated entity (issue #1107).
+ *     pendingPropertyFocus: null,
+ *   },
+ * );
+ */
+export function defineSliceTeardown<const K extends keyof ViewerState>(
+  slice: string,
+  owns: readonly K[],
+  teardown: (scope: TeardownScope, state: TeardownState) => TeardownContribution<NoInfer<K>>,
+): SliceTeardown<K> {
+  return { slice, owns, teardown };
+}
+
+/**
+ * Freeze a set of slice teardowns into the store's registry, proving on the
+ * way that no two slices claim the same key.
+ *
+ * Thrown at MODULE INIT, not at teardown time. That matters: a contribution is
+ * conditional, so a runtime overlap check would fire only for particular data,
+ * in production, in the middle of removing a model. A declaration overlap is
+ * data-independent, so checking the DECLARATIONS turns "two owners for one
+ * key" — the exact defect this refactor exists to remove — into a failure
+ * every single test sees on import.
+ *
+ * @throws if any key appears in more than one slice's `owns`.
+ */
+export function createTeardownRegistry(
+  entries: readonly AnySliceTeardown[],
+): readonly AnySliceTeardown[] {
+  const owner = new Map<keyof ViewerState, string>();
+  const conflicts: string[] = [];
+  const duplicated: string[] = [];
+
+  for (const entry of entries) {
+    const seen = new Set<keyof ViewerState>();
+    for (const key of entry.owns) {
+      if (seen.has(key)) {
+        duplicated.push(`${entry.slice} lists '${String(key)}' twice`);
+        continue;
+      }
+      seen.add(key);
+      const previous = owner.get(key);
+      if (previous !== undefined) {
+        conflicts.push(`'${String(key)}' is claimed by both ${previous} and ${entry.slice}`);
+      } else {
+        owner.set(key, entry.slice);
+      }
+    }
+  }
+
+  const problems = [...conflicts, ...duplicated];
+  if (problems.length > 0) {
+    throw new Error(
+      `Teardown ownership is not disjoint — a key must have exactly one owning slice:\n  ${problems.join('\n  ')}`,
+    );
+  }
+
+  return entries;
+}
+
+/**
+ * Every key the registry is willing to destroy, and who destroys it.
+ *
+ * Exported so a test can pin the set: a migrator quietly dropping a key from
+ * `owns` is otherwise invisible — the key simply stops being cleared, and
+ * "state that was not cleared" is the failure mode with no smell.
+ */
+export function teardownOwnedKeys(
+  registry: readonly AnySliceTeardown[],
+): ReadonlyMap<keyof ViewerState, string> {
+  const owner = new Map<keyof ViewerState, string>();
+  for (const entry of registry) {
+    for (const key of entry.owns) owner.set(key, entry.slice);
+  }
+  return owner;
+}
+
+/**
+ * Build the one patch an entry point hands to `set`.
+ *
+ * Contributions are merged in registry order. Ownership is disjoint (proved by
+ * {@link createTeardownRegistry}), so the order cannot decide a value — it only
+ * decides key insertion order, which nothing observes.
+ *
+ * An entry whose value is already `Object.is`-identical to the live state is
+ * DROPPED. That keeps a composed patch as close as possible to today's
+ * conditional spreads: a key that is not in the patch is not written, so no
+ * subscriber is notified for a non-change, and the visibility-ownership
+ * middleware does not run its invalidation for a channel nobody actually
+ * moved. It also makes a `model-removed` teardown safe to run twice, which
+ * `purgeStaleEntityState` does immediately after `removeModel`.
+ *
+ * A key absent from `state` (the partial-store test harness) is never
+ * "unchanged" — `Object.is(undefined, value)` is false unless the teardown
+ * genuinely returns `undefined`, which no contribution should.
+ */
+export function composeTeardown(
+  registry: readonly AnySliceTeardown[],
+): (scope: TeardownScope, state: TeardownState) => Partial<ViewerState> {
+  return (scope, state) => {
+    const patch: Partial<ViewerState> = {};
+    for (const entry of registry) {
+      const contribution = entry.teardown(scope, state);
+      for (const key of Object.keys(contribution) as (keyof ViewerState)[]) {
+        const next = contribution[key];
+        if (Object.is(state[key], next)) continue;
+        writeKey(patch, key, next);
+      }
+    }
+    return patch;
+  };
+}
+
+/**
+ * One indexed write, with the key held as a type PARAMETER.
+ *
+ * `patch[key] = value` inline does not type-check when `key` is the full
+ * `keyof ViewerState` union: TS distributes the target over ~1000 members and
+ * narrows the assignable type to their intersection (`undefined`). Binding the
+ * key to `K` keeps target and value on the same member, which is the honest
+ * fix — the alternative here is an `as any`, which this repo does not allow.
+ */
+function writeKey<K extends keyof ViewerState>(
+  patch: Partial<ViewerState>,
+  key: K,
+  value: ViewerState[K] | undefined,
+): void {
+  patch[key] = value;
+}

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -18,7 +18,12 @@
  * time, in a file that cannot see the slice. `modelSlice` even declared 16
  * fields it did not own (`ModelCrossSliceState`) purely so its teardown could
  * type-check its reach into five other slices — that interface is gone, and
- * its disappearance is the measure of this change. The four copies were held
+ * its disappearance from PRODUCTION is the measure of this change. Be precise
+ * about the word: the same 16-field list still exists in `modelSlice.test.ts`
+ * as `ModelHarnessCrossState`, and it is the sole reason `TeardownState` below
+ * is `Partial` rather than total, which in turn is why model-removed
+ * contributions carry `?? new Set()` fallbacks. Giving that harness a real
+ * store would delete the list and the fallbacks together. The four copies were held
  * together by prose: "same shape as `purgeStaleEntityState`", twice.
  *
  * This module replaces the prose with a contract. Each slice contributes
@@ -49,6 +54,16 @@
  *
  * Those stay exactly where they are, in the entry point, in the same order.
  * Only the `set()` PAYLOAD moves behind this seam.
+ *
+ * ## Where a contribution lives
+ *
+ * Inline at the bottom of the slice, or in a sibling `<slice>.teardown.ts`. The
+ * rule is the module-size ratchet and nothing else: sibling file iff the slice
+ * plus its contribution would cross ~400 lines, inline otherwise. Two files
+ * (`addElementSlice.teardown.ts` at 341, `annotationsSlice.teardown.ts` at 365)
+ * are split despite fitting, for group uniformity; that reason does not survive
+ * contact with the nine inline contributions on larger hosts, and folding those
+ * two back in would make the rule exceptionless.
  *
  * ## Trap A: a teardown returns an EXPLICIT field list, never a whole state
  *
@@ -108,7 +123,24 @@ import type { ViewerState } from './index.js';
  */
 export type TeardownScope =
   | { kind: 'session-reset' }
-  | { kind: 'model-removed'; modelId: string; isStale: (id: number) => boolean }
+  | {
+      kind: 'model-removed';
+      modelId: string;
+      isStale: (id: number) => boolean;
+      /**
+       * Which model holds `activeModelId` once this one is gone, resolved ONCE
+       * by the entry point. Federation knowledge, so it belongs to whoever
+       * builds the scope rather than to each slice that has to follow it.
+       *
+       * Two slices need it and they own different keys, so the disjointness
+       * proof cannot see them: `modelSlice` writes `activeModelId`, `dataSlice`
+       * writes the `ifcDataStore` / `geometryResult` that must follow it. When
+       * each derived the successor for itself, changing the rule in one file
+       * left the data pointing at a model the active id did not name — a blank
+       * properties panel over a live model list, and no gate would catch it.
+       */
+      nextActiveModelId: string | null;
+    }
   | { kind: 'all-models-cleared' };
 
 /**

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -9,7 +9,7 @@
  * removal, a full federation clear and a source resync each wipe:
  *
  *   - `store/index.ts` `resetViewerState`        186 keys, 26 slices
- *   - `slices/modelSlice.ts` `removeModel`        24 keys
+ *   - `slices/modelSlice.ts` `removeModel`        23 keys
  *   - `slices/modelSlice.ts` `clearAllModels`     18 keys
  *   - `lib/sources/syncSourceModel.ts` `purgeStaleEntityState`  14 keys
  *

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -160,7 +160,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * moves if anything else touched the allowlist first.
  */
 const ALLOWLIST_DIGESTS = {
-  'apps/viewer': '7610024779687348637',
+  'apps/viewer': '16280746398706991649',
   'apps/viewer-embed': '4565652428901906968',
   'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -160,7 +160,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * moves if anything else touched the allowlist first.
  */
 const ALLOWLIST_DIGESTS = {
-  'apps/viewer': '6743872621557032076',
+  'apps/viewer': '7610024779687348637',
   'apps/viewer-embed': '4565652428901906968',
   'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -160,7 +160,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * moves if anything else touched the allowlist first.
  */
 const ALLOWLIST_DIGESTS = {
-  'apps/viewer': '16280746398706991649',
+  'apps/viewer': '5957907374972858398',
   'apps/viewer-embed': '4565652428901906968',
   'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -145,7 +145,7 @@
    561 apps/viewer/src/services/ifc-cache.ts
    581 apps/viewer/src/store/basketVisibleSet.ts
    485 apps/viewer/src/store/constants.ts
-   850 apps/viewer/src/store/index.ts
+   575 apps/viewer/src/store/index.ts
    404 apps/viewer/src/store/slices/addElementMeshes.ts
    452 apps/viewer/src/store/slices/chatSlice.ts
    994 apps/viewer/src/store/slices/clashSlice.ts
@@ -154,7 +154,7 @@
    874 apps/viewer/src/store/slices/drawing2DSlice.ts
    482 apps/viewer/src/store/slices/idsSlice.ts
    820 apps/viewer/src/store/slices/measurementSlice.ts
-   914 apps/viewer/src/store/slices/modelSlice.ts
+   657 apps/viewer/src/store/slices/modelSlice.ts
   3283 apps/viewer/src/store/slices/mutationSlice.ts
    478 apps/viewer/src/store/slices/pinboardSlice.ts
   1317 apps/viewer/src/store/slices/scheduleSlice.ts


### PR DESCRIPTION
Viewer state teardown had four hand-written implementations and no seam. This gives each slice one `teardown(scope)` and turns the four entry points into dispatch.

## What was there

| Entry point | Size | Distinct state keys assigned |
|---|---|---|
| `resetViewerState` (`store/index.ts`) | 336 lines | **186** |
| `removeModel` (`slices/modelSlice.ts`) | 396 lines, half of it comments | 24 |
| `clearAllModels` (`slices/modelSlice.ts`) | 152 lines | 18 |
| `purgeStaleEntityState` (`lib/sources/syncSourceModel.ts`) | 81 lines | 14 |

`modelSlice` declared a `ModelCrossSliceState` interface holding **16 fields it did not own**, purely so its teardown could type-check its reach into five other slices. The four copies were held together by prose: "same shape as `purgeStaleEntityState`", twice.

## What is here now

```ts
type TeardownScope =
  | { kind: 'session-reset' }
  | { kind: 'model-removed'; modelId: string; isStale: (id: number) => boolean; nextActiveModelId: string | null }
  | { kind: 'all-models-cleared' };

// each slice contributes, returning ONLY the keys it declares it owns
teardown(scope: TeardownScope, state: TeardownState): TeardownContribution<K>;
```

`isStale` is the survivor-range predicate `purgeStaleEntityState` already computed. Passing it in is what collapses the model-removal and source-resync purges into one implementation; `syncSourceModel` runs the same scope a second time with a stricter survivor set, and one test pins the case that makes both runs necessary.

| File | before | after |
|---|---|---|
| `store/index.ts` | 850 | **575** |
| `slices/modelSlice.ts` | 914 | **657** |
| `lib/sources/syncSourceModel.ts` | ~328 | **243** |

`ModelCrossSliceState` is gone. `purgeStaleEntityState` is gone.

## Behaviour is unchanged, and that was measured rather than asserted

Two independent review passes extracted the old payloads from `origin/main` and diffed them against what the registry emits: **186/186** for `session-reset`, **18/18** for `all-models-cleared`, **24/24** for `model-removed`. Zero keys added, zero dropped, values compared through every indirection. Every field the old code deliberately preserved — `savedSheetTemplates`, `graphicOverridePresets`, `dxfUnderlays`, `idsDocument`, `savedLenses`, `zoneSets`, `compareRunSeq` and the rest — is absent from the composed patch.

## What the seam makes impossible

- Two slices clearing the same key: `createTeardownRegistry` throws at module init, so every test sees it on import.
- A teardown returning a key it does not own: a compile error. `Partial<Pick<...>>` alone does **not** catch this (measured), so the type maps every other key to `never`. A spread carrying a foreign key fails too, so `...POINT_CLOUD_DEFAULTS` cannot silently widen.
- The model-removal and resync purges drifting apart: one implementation, one predicate.
- A teardown wiping a whole slice via `...initialState`: `owns` is explicit and reviewable. That is Trap A, and `scripts/check-whole-state-reset.mjs` records three real bugs of that class landing in one day.

## The guards, and how they were arrived at

`teardownOwnedKeys` shipped exported with a doc saying "a test can pin the set", and nothing called it. Fixing that took three attempts, each caught by a review rather than by re-reading:

| Version | Checked | Blind to |
|---|---|---|
| v1 | `owns` declarations | deleting a key from a **body** |
| v2 | emitted keys per scope | **adding** a key — the Trap A direction |
| v3 | both, in both directions | mutation-checked against the real historical bug |

The pins now fail on an added key too, with a message saying that widening what a slice destroys is deliberate and belongs in the same commit. Mutation-checked by making `sheetTeardown` destroy `savedSheetTemplates` — the actual bug from `check-whole-state-reset.mjs` — and it fails.

A second test imports every slice module and checks each exported teardown is in the registry **by object identity**, closing the "wrote the contribution, forgot the import line" hole. The first version of that test grepped source text and `check-source-text-assertions.mjs` rejected it, correctly: comparing identity is stronger and survives a rename.

A third pins that re-running the `model-removed` scope produces an empty patch, which is what lets `syncSourceModel` run it twice. With that guard removed, all 1099 existing store tests stayed green — the property had no coverage.

## Deferred, filed rather than dropped

- #3345 — a fourth scope would silently no-op in 22 of 28 contributions
- #3346 — `composeTeardown`'s `Object.is` gate is per slice, so one moved field rewrites the rest as equal-but-new
- #3348 — `clearAllModels` leaves `EntityRef`-keyed selection state pointing at removed models (pre-existing; this branch made it visible)

## Verification

`pnpm build` 0, `turbo typecheck --force` 0, `pnpm lint` 0, `check:module-size` 0, `check-source-text-assertions` 0, `check-test-wiring` 0, `turbo test --force` **6403 tests, 0 fail**.

`apps/viewer` is private, so no changeset. Allowlist rows moved only downward, for the two files this branch shrank.

## Review history, and what it actually found

Seven `/code-review` passes at high effort. Every one found something, and the shape of the findings is the useful part: **key parity was correct from the first pass and has since been re-measured four independent ways**, including a differential harness that ran `origin/main`'s old payload code side by side with the new composed patch. What kept being wrong was the prose asserting *why* the code was correct — and roughly a third of those errors were mine, written while fixing earlier ones.

Two findings were substantive rather than documentation, and both are now pinned by tests that fail on the exact mutation the reviewer used to prove they were unprotected:

- **The ownership middleware stopped firing on a session reset.** `withVisibilityOwnershipInvalidation` keys on a channel's *presence* in the patch, not its value. The old payload always carried both channels; `composeTeardown` drops keys equal to live state, so on the common reset (both already `null`) the middleware stopped running. No live bug — both of today's record fields are also cleared by name — but `lib/visibility/ownership.ts` states the middleware's purpose as invalidation *by construction* rather than by remembering to extend a list, and that had become invalidation by enumeration. `NEVER_DROPPED` restores it. Emptying that set now fails a test.
- **The one intentional behaviour change had no test.** `removeModel` now clears a dangling `selectedModelId` when no entity ref names the model. Deleting the clause left all 1105 store/sources tests green, because every pre-existing fixture also sets `selectedEntity` to the removed model. `removeModel-selected-model-only.test.ts` is the fixture that separates the two readings.

**Stamp note:** the final review ran on `ca77ae6b8`. The tip commit adds only comment corrections plus one `console.log` deletion — verified as exactly one executable line changed — so the stamp covers that review plus a zero-executable-change delta.
