### PR TITLE
fix(scripts): cite the PR in the dotfile regression tests, and ignore the root tsconfig.tests.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,10 @@ tests/benchmark/benchmark-results/viewer-*.console.log
 # are rebuilt on every run rather than committed. See tsconfig.tests.base.json.
 packages/*/tsconfig.tests.json
 apps/*/tsconfig.tests.json
+# The ROOT path is here for a different reason: `audit()` only writes for
+# `packages/*` (typecheck-tests.mjs, `rel.startsWith('packages/')`), so
+# `pnpm typecheck` never produces this one. It appears from the bare-cwd mode
+# the script's own header calls a misuse (#2664). Untracked it is harmless;
+# tracked, every branch that adds or removes a test file carries a spurious
+# diff of a ~1.5k-line generated file, and those conflict between branches.
+/tsconfig.tests.json

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -343,7 +343,7 @@ export function listPackages(root, seenParents = []) {
       // a local-only file. The fix is to stop offering a dotfile as a
       // candidate, NOT to soften that refusal: every entry that could
       // plausibly be a package still goes through existsOrThrow unchanged.
-      // Same skip walk() already applies one stage later.
+      // Same skip walk() already applies one stage later. (#3350)
       if (name.startsWith('.')) continue;
       const pkgDir = join(parentDir, name);
       const pkgJsonPath = join(pkgDir, 'package.json');

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -279,7 +279,7 @@ test('an UNREADABLE package is not silently treated as an absent one', () => {
 // that: the same tree carries a dotfile AND a non-dotfile ENOTDIR candidate,
 // and the gate must ignore exactly one of them and refuse the other.
 
-test('a `.DS_Store` dotfile in packages/ or apps/ is not a candidate package', () => {
+test('a `.DS_Store` dotfile in packages/ or apps/ is not a candidate package (PR 3350)', () => {
   const dir = writeTree({
     'packages/real-one/package.json': pkgJson('vitest run'),
     'packages/real-one/src/a.test.ts': '// test a\n',
@@ -299,7 +299,7 @@ test('a `.DS_Store` dotfile in packages/ or apps/ is not a candidate package', (
   }
 });
 
-test('skipping dotfiles does not soften the refusal: a non-dotfile ENOTDIR candidate in the SAME tree still fails', () => {
+test('skipping dotfiles does not soften the refusal: a non-dotfile ENOTDIR candidate in the SAME tree still fails (PR 3350)', () => {
   const dir = writeTree({
     'packages/real-one/package.json': pkgJson('vitest run'),
     'packages/real-one/src/a.test.ts': '// test a\n',

--- a/scripts/docs/check-package-readmes.mjs
+++ b/scripts/docs/check-package-readmes.mjs
@@ -93,7 +93,7 @@ for (const dir of entries) {
   // `.DS_Store/package.json` raises ENOTDIR, which existsOrFail below refuses
   // by design. Skip the candidate rather than soften the refusal: every entry
   // that could plausibly be a package still goes through it unchanged. Same
-  // shape and same reason as check-test-glob-coverage.mjs's listPackages().
+  // shape and same reason as check-test-glob-coverage.mjs's listPackages(). (#3350)
   if (dir.startsWith('.')) continue;
   const pkgJsonPath = join(packagesDir, dir, 'package.json');
   if (!existsOrFail(pkgJsonPath, 'package manifest')) continue;

--- a/scripts/docs/check-package-readmes.test.mjs
+++ b/scripts/docs/check-package-readmes.test.mjs
@@ -139,7 +139,7 @@ test('positive control: a healthy tree at the floor passes, with its true count'
   rmSync(root, { recursive: true, force: true });
 });
 
-test('a `.DS_Store` dotfile in packages/ is not a candidate package', () => {
+test('a `.DS_Store` dotfile in packages/ is not a candidate package (PR 3350)', () => {
   const root = makeTree();
   fillToFloor(root);
   // macOS drops this into any directory Finder has opened. Before the skip,
@@ -153,7 +153,7 @@ test('a `.DS_Store` dotfile in packages/ is not a candidate package', () => {
   rmSync(root, { recursive: true, force: true });
 });
 
-test('skipping dotfiles does not soften the refusal: a non-dotfile unreadable candidate still fails', () => {
+test('skipping dotfiles does not soften the refusal: a non-dotfile unreadable candidate still fails (PR 3350)', () => {
   const root = makeTree();
   fillToFloor(root);
   // Both in the same tree, so this pins that exactly one is ignored and the

--- a/scripts/lib/rust-major-offset.mjs
+++ b/scripts/lib/rust-major-offset.mjs
@@ -289,7 +289,7 @@ export function getWorkspacePackagePaths(rootDir) {
         // `.DS_Store` into any Finder-opened directory, and the warning below
         // is load-bearing for the release version. A local-only file must not
         // emit an alarm indistinguishable from a directory that genuinely
-        // failed to be read.
+        // failed to be read. (#3350)
         if (entry.startsWith('.')) continue;
         const pkgJsonPath = join(parentDir, entry, 'package.json');
         try {

--- a/scripts/lib/rust-major-offset.test.mjs
+++ b/scripts/lib/rust-major-offset.test.mjs
@@ -230,7 +230,7 @@ test('the real root Cargo.toml still yields its workspace version', () => {
   assert.match(readWorkspaceVersion(cargo) ?? '', /^\d+\.\d+\.\d+$/);
 });
 
-test('a `.DS_Store` dotfile does not emit a version-scan warning, and does not shrink the scan', (t) => {
+test('a `.DS_Store` dotfile does not emit a version-scan warning, and does not shrink the scan (PR 3350)', (t) => {
   const root = makeTree(t, {});
   // The warning below `getWorkspacePackagePaths` is load-bearing: a directory
   // that fails to be read shrinks the scan, and a shrunken scan syncs the
@@ -259,7 +259,7 @@ test('a `.DS_Store` dotfile does not emit a version-scan warning, and does not s
   );
 });
 
-test('skipping dotfiles does not silence a REAL unreadable candidate', (t) => {
+test('skipping dotfiles does not silence a REAL unreadable candidate (PR 3350)', (t) => {
   const root = makeTree(t, {});
   // Both in one tree, so this pins that exactly one is ignored and the other
   // still warns. Widening the skip, or swallowing the stat error, would satisfy


### PR DESCRIPTION
Two things `main` is missing from #3350, which merged before either fix existed.

## 1. The six regression tests cite nothing

AGENTS.md:133 requires a regression test to cite its issue or PR number in the test name or a comment. The six `.DS_Store` cases added in #3350 cite nothing. Codex flagged it on that PR and `/simplify` had raised it independently, noting that every other comment in `check-test-glob-coverage.mjs` cites its issue (#3194, #3200).

Written as `PR 3350` rather than `#3350` in the test **names**: `node:test` emits TAP, which escapes a bare `#`, so the citation rendered as `(\#3350)` in the run output — defeating the point of a readable citation in CI logs. The gate comments are not TAP and keep the `#` form.

## 2. The root `tsconfig.tests.json` is not ignored

`.gitignore` covers `packages/*/tsconfig.tests.json` and `apps/*/tsconfig.tests.json`, but not the repo-root path. Untracked it is harmless. **Tracked, every branch that adds or removes a test file carries a spurious ~1.5k-line diff, and those conflict between branches.**

That is not hypothetical: `git add -A` swept it into a commit twice today, on two different branches, and `/code-review` caught it before either was pushed.

On where the root file comes from, because an earlier draft of this comment asserted it without checking and was wrong: `audit()` writes a program only for dirs under `packages/` (`typecheck-tests.mjs:433`, `rel.startsWith('packages/')`), so `pnpm typecheck` never produces the root one. It appears from the bare-cwd mode that script's own header documents as a misuse (#2664). Verified by deleting the file and running `audit()` to completion: 45 `packages/*` files written, zero at the root.

## Verification

46 tests across the three touched files, `check-test-wiring` and `check-changesets` clean. `git check-ignore -v` confirms the new line matches only the root path and does not shadow the tracked `tsconfig.tests.base.json`.

Review also confirmed independently that no allowlist, snapshot or gate references the six renamed test titles, so the renames are inert, and that no CI gate uses `git status --porcelain` on untracked files, so the new ignore does not blind an existing check.

## Follow-up filed

**#3362** — the ignore line removes the last visible symptom of a real hole. `node scripts/typecheck-tests.mjs` run bare with cwd = repo root treats the repository as a package and writes a 1,501-file program, and nothing refuses it; `parseCliMode` already rejects the argument form of the same #2664 mistake but not the cwd form. Before this line the stray untracked file was the only trace; after it, the misuse is silent. The durable fix is a `pkgDir === REPO_ROOT` refusal, which is out of scope for a citation commit.
