### PR TITLE
fix(scripts): refuse an unreadable package instead of dropping it, and refuse the repo root as a package

### DIFF
--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -261,6 +261,11 @@ function resolveVitestGlobs(pkgDir, testLooking) {
         'Its include: globs decide which of this package\'s test files count as ' +
         'reached, so the audit cannot answer for this package without it.',
     );
+    // Same rethrow the two refusals in lib/list-workspace-packages.mjs carry.
+    // Without it a `fail` that returns leaves `source` undefined and
+    // parseViteInclude throws a TypeError on it: closed, but with the
+    // diagnosis destroyed, which is the outcome this branch exists to stop.
+    throw err;
   }
   const includes = parseViteInclude(source);
   if (includes === null) return null;

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -84,9 +84,19 @@ const PACKAGE_PARENTS = ['packages', 'apps'];
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
+// Declared before any module-evaluation-time caller of `fail`. A class sits in
+// the temporal dead zone until its own line, so with this further down a `fail`
+// during module eval threw ReferenceError instead of FailError.
+export class FailError extends Error {}
+
 const rootFlagIdx = process.argv.indexOf('--root');
 if (rootFlagIdx !== -1 && !process.argv[rootFlagIdx + 1]) {
-  fail('--root requires a directory argument');
+  // console.error + exit, NOT `fail`, matching check-test-wiring.mjs. This runs
+  // during module evaluation, so a throw here escapes the entry point's
+  // try/catch at the bottom of the file and prints a raw stack on top of the
+  // message - which is precisely what this gate's own tests assert against.
+  console.error('\ncheck-test-glob-coverage: --root requires a directory argument\n');
+  process.exit(1);
 }
 const ROOT = rootFlagIdx === -1 ? join(SCRIPT_DIR, '..') : resolveArg(process.argv[rootFlagIdx + 1]);
 
@@ -99,8 +109,6 @@ export function fail(message) {
   process.exitCode = 1;
   throw new FailError(message);
 }
-
-export class FailError extends Error {}
 
 const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|js|mjs)$/;
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', 'generated']);

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -72,6 +72,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { existsOrThrow } from './lib/exists-or-throw.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -302,36 +303,11 @@ export function auditPackage(pkgDir, pkgJson) {
   return { testLooking, matched, missed };
 }
 
-/**
- * Does this path exist? Throws if the answer is UNKNOWABLE.
- *
- * `existsSync` answers false for every failure, including EACCES, so an
- * unreadable directory is indistinguishable from an absent one. That is the
- * same "absence reads as success" defect this gate was fixed for -- one stage
- * earlier, in DISCOVERY rather than in the walk. Measured before this change:
- * a `chmod 000` package carrying a real test script reported
- * `OK (1 packages audited, 0 unrun test files)` and exit 0, with the locked
- * package silently missing from the count.
- */
-function existsOrThrow(path, what) {
-  try {
-    statSync(path);
-    return true;
-  } catch (err) {
-    if (err.code === 'ENOENT') return false;
-    fail(
-      `cannot read ${what} ${path}: ${err.code || err.message}. ` +
-        'Refusing to treat an unreadable path as an absent one -- that is how a ' +
-        'package drops out of the audit without anyone noticing.',
-    );
-  }
-}
-
 export function listPackages(root, seenParents = []) {
   const out = [];
   for (const parent of PACKAGE_PARENTS) {
     const parentDir = join(root, parent);
-    if (!existsOrThrow(parentDir, 'package parent')) continue;
+    if (!existsOrThrow(parentDir, 'package parent', fail)) continue;
     seenParents.push(parent);
     for (const name of readdirSync(parentDir).sort()) {
       // A dotfile is not a candidate package and never was: pnpm-workspace.yaml
@@ -347,7 +323,7 @@ export function listPackages(root, seenParents = []) {
       if (name.startsWith('.')) continue;
       const pkgDir = join(parentDir, name);
       const pkgJsonPath = join(pkgDir, 'package.json');
-      if (!existsOrThrow(pkgJsonPath, 'package manifest')) continue;
+      if (!existsOrThrow(pkgJsonPath, 'package manifest', fail)) continue;
       let pkgJson;
       try {
         pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -72,8 +72,15 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { existsOrThrow } from './lib/exists-or-throw.mjs';
-import { listWorkspacePackages, PACKAGE_PARENTS } from './lib/list-workspace-packages.mjs';
+import { listWorkspacePackages } from './lib/list-workspace-packages.mjs';
+
+// Deliberately a literal here rather than imported from the shared walk.
+// `scripts/lib/ci-path-coverage.mjs`'s `deriveInputs` reads only THIS file's own
+// source text and does not follow imports, so these two strings are what put
+// `packages/` and `apps/` into the CI-path-coverage census for this gate. Move
+// them into the lib and the ratchet silently stops checking that this gate can
+// be triggered by the paths it reads. (#3347)
+const PACKAGE_PARENTS = ['packages', 'apps'];
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -236,12 +236,13 @@ const VITEST_CONFIG_NAMES = [
  * file by construction, nothing to check".
  */
 function resolveVitestGlobs(pkgDir, testLooking) {
-  // Deliberately `existsSync`, NOT the existsOrThrow this file uses one
-  // function up. Measured, both ways, on a chmod-000 config: `statSync`
-  // SUCCEEDS on an unreadable file (the mode bits gate open(2), not stat(2)),
-  // so existsOrThrow returns true here and the failure lands on the read
-  // below either way. Swapping it in was an inert guard - identical exit code
-  // and identical message with and without it.
+  // Deliberately `existsSync`, and deliberately NOT `existsOrThrow` from
+  // ./lib/exists-or-throw.mjs, which this file's package walk uses via
+  // listWorkspacePackages. Measured, both ways, on a chmod-000 config:
+  // `statSync` SUCCEEDS on an unreadable file (the mode bits gate open(2), not
+  // stat(2)), so existsOrThrow returns true here and the failure lands on the
+  // read below either way. Swapping it in was an inert guard - identical exit
+  // code and identical message with and without it.
   //
   // There is no silent shrink on this path to begin with: the read throws and
   // the gate exits 1. The only defect was the SHAPE of that exit, a raw

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -73,6 +73,7 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { existsOrThrow } from './lib/exists-or-throw.mjs';
+import { listWorkspacePackages, PACKAGE_PARENTS } from './lib/list-workspace-packages.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -96,7 +97,6 @@ export class FailError extends Error {}
 
 const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|js|mjs)$/;
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', 'generated']);
-const PACKAGE_PARENTS = ['packages', 'apps'];
 
 /**
  * Lower bound on how many packages must actually get audited when this runs
@@ -303,42 +303,9 @@ export function auditPackage(pkgDir, pkgJson) {
   return { testLooking, matched, missed };
 }
 
-export function listPackages(root, seenParents = []) {
-  const out = [];
-  for (const parent of PACKAGE_PARENTS) {
-    const parentDir = join(root, parent);
-    if (!existsOrThrow(parentDir, 'package parent', fail)) continue;
-    seenParents.push(parent);
-    for (const name of readdirSync(parentDir).sort()) {
-      // A dotfile is not a candidate package and never was: pnpm-workspace.yaml
-      // globs `packages/*` and `apps/*`, and a bare `*` does not match a
-      // leading dot, so no dotted entry can ever be a workspace package. macOS
-      // drops a `.DS_Store` FILE into any directory Finder has opened, and
-      // statting `.DS_Store/package.json` raises ENOTDIR — which existsOrThrow
-      // below refuses, correctly and by design, failing the whole Lint lane on
-      // a local-only file. The fix is to stop offering a dotfile as a
-      // candidate, NOT to soften that refusal: every entry that could
-      // plausibly be a package still goes through existsOrThrow unchanged.
-      // Same skip walk() already applies one stage later. (#3350)
-      if (name.startsWith('.')) continue;
-      const pkgDir = join(parentDir, name);
-      const pkgJsonPath = join(pkgDir, 'package.json');
-      if (!existsOrThrow(pkgJsonPath, 'package manifest', fail)) continue;
-      let pkgJson;
-      try {
-        pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
-      } catch (err) {
-        fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
-      }
-      out.push({ rel: `${parent}/${name}`, dir: pkgDir, pkgJson });
-    }
-  }
-  return out;
-}
-
 function main() {
   const seenParents = [];
-  const packages = listPackages(ROOT, seenParents);
+  const packages = listWorkspacePackages(ROOT, fail, PACKAGE_PARENTS, seenParents);
 
   // Anti-vacuity, structural: true of the real repo AND of every synthetic
   // fixture tree the regression harness builds, so it costs the harness

--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -236,9 +236,31 @@ const VITEST_CONFIG_NAMES = [
  * file by construction, nothing to check".
  */
 function resolveVitestGlobs(pkgDir, testLooking) {
+  // Deliberately `existsSync`, NOT the existsOrThrow this file uses one
+  // function up. Measured, both ways, on a chmod-000 config: `statSync`
+  // SUCCEEDS on an unreadable file (the mode bits gate open(2), not stat(2)),
+  // so existsOrThrow returns true here and the failure lands on the read
+  // below either way. Swapping it in was an inert guard - identical exit code
+  // and identical message with and without it.
+  //
+  // There is no silent shrink on this path to begin with: the read throws and
+  // the gate exits 1. The only defect was the SHAPE of that exit, a raw
+  // EACCES stack instead of this gate's own message, so that is all the
+  // try/catch below fixes. It buys diagnostics, not fail-closed - the path was
+  // already closed.
   const configName = VITEST_CONFIG_NAMES.find((n) => existsSync(join(pkgDir, n)));
   if (!configName) return null;
-  const source = readFileSync(join(pkgDir, configName), 'utf8');
+  const configPath = join(pkgDir, configName);
+  let source;
+  try {
+    source = readFileSync(configPath, 'utf8');
+  } catch (err) {
+    fail(
+      `cannot read vitest config ${configPath}: ${err.code || err.message}. ` +
+        'Its include: globs decide which of this package\'s test files count as ' +
+        'reached, so the audit cannot answer for this package without it.',
+    );
+  }
   const includes = parseViteInclude(source);
   if (includes === null) return null;
   if (includes.length === 0) {
@@ -311,8 +333,7 @@ export function auditPackage(pkgDir, pkgJson) {
 }
 
 function main() {
-  const seenParents = [];
-  const packages = listWorkspacePackages(ROOT, fail, PACKAGE_PARENTS, seenParents);
+  const { packages, seenParents } = listWorkspacePackages(ROOT, fail, PACKAGE_PARENTS);
 
   // Anti-vacuity, structural: true of the real repo AND of every synthetic
   // fixture tree the regression harness builds, so it costs the harness

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -375,7 +375,12 @@ test('an unreadable vitest config is reported by the gate, not as a raw stack', 
     // The point of the change. It already exited 1 before; what it did NOT do
     // was say why, and an uncaught readFileSync stack sends the reader into
     // node internals instead of at their own file mode.
-    assert.doesNotMatch(locked.out, /at readFileSync \(node:fs/, 'must not surface a raw node stack');
+    //
+    // Matched on the payload rather than a `at readFileSync (node:fs` frame:
+    // V8 names the frame after the call form, so the frame spelling is voided
+    // by a change to how this gate imports fs. See the sibling in
+    // check-test-wiring.test.mjs, which was vacuous for that exact reason.
+    assert.doesNotMatch(locked.out, /permission denied, open/, 'must not surface a raw node error');
   } finally {
     chmodSync(config, 0o644);
     rmSync(dir, { recursive: true, force: true });

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -386,3 +386,18 @@ test('an unreadable vitest config is reported by the gate, not as a raw stack', 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('--root with no argument is refused cleanly, without a raw stack', () => {
+  // This runs during MODULE EVALUATION, before the entry point's try/catch
+  // exists, so a `fail` here escapes and prints a stack on top of the message.
+  // It did exactly that, two ways at once: `class FailError` was declared below
+  // `fail`, so the throw was a ReferenceError from the temporal dead zone.
+  // check-test-wiring.test.mjs has always had this case; this file did not,
+  // which is why a gate whose own tests forbid raw stacks was printing one.
+  const r = spawnSync(process.execPath, [CHECKER, '--root'], { encoding: 'utf8' });
+  const out = `${r.stdout}${r.stderr}`;
+  assert.equal(r.status, 1, 'a missing --root argument must fail the gate');
+  assert.match(out, /--root requires a directory argument/);
+  assert.doesNotMatch(out, /ReferenceError/, 'must not die in the temporal dead zone');
+  assert.doesNotMatch(out, /\n\s+at /, 'must not surface a raw node stack');
+});

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -361,13 +361,14 @@ test('an unreadable vitest config is reported by the gate, not as a raw stack', 
   const dir = writeTree(files);
   const config = join(dir, 'packages/fixture/vitest.config.ts');
 
-  // BOTH directions. Readable first, so a fixture that fails for some unrelated
-  // reason cannot be mistaken for the refusal firing.
-  const readable = runOn(dir);
-  assert.equal(readable.status, 0, `readable config should audit cleanly:\n${readable.out}`);
-
-  chmodSync(config, 0o000);
   try {
+    // BOTH directions. Readable first, so a fixture that fails for some
+    // unrelated reason cannot be mistaken for the refusal firing. Inside the
+    // try, or a failure here leaks the tree instead of cleaning up.
+    const readable = runOn(dir);
+    assert.equal(readable.status, 0, `readable config should audit cleanly:\n${readable.out}`);
+
+    chmodSync(config, 0o000);
     const locked = runOn(dir);
     assert.equal(locked.status, 1, 'an unreadable config must fail the gate');
     assert.match(locked.out, /cannot read vitest config/);

--- a/scripts/check-test-glob-coverage.test.mjs
+++ b/scripts/check-test-glob-coverage.test.mjs
@@ -31,7 +31,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -345,4 +345,38 @@ test('parseViteInclude: reads the first top-level include array, ignoring a nest
 
 test('parseViteInclude: returns null when there is no include key (vitest default applies)', () => {
   assert.equal(parseViteInclude('export default defineConfig({ test: {} });'), null);
+});
+
+test('an unreadable vitest config is reported by the gate, not as a raw stack', (t) => {
+  // Windows chmod does not remove read permission, and root ignores the mode
+  // bits, so on either the config stays readable and the case cannot be built.
+  if (process.platform === 'win32') return t.skip('chmod does not gate reads on Windows');
+  if (process.getuid?.() === 0) return t.skip('root reads a 000 file regardless of mode');
+
+  const files = {
+    'packages/fixture/package.json': pkgJson('vitest run'),
+    'packages/fixture/src/a.test.ts': 'test("a", () => {})',
+    'packages/fixture/vitest.config.ts': 'export default { test: { include: ["src/**/*.test.ts"] } }',
+  };
+  const dir = writeTree(files);
+  const config = join(dir, 'packages/fixture/vitest.config.ts');
+
+  // BOTH directions. Readable first, so a fixture that fails for some unrelated
+  // reason cannot be mistaken for the refusal firing.
+  const readable = runOn(dir);
+  assert.equal(readable.status, 0, `readable config should audit cleanly:\n${readable.out}`);
+
+  chmodSync(config, 0o000);
+  try {
+    const locked = runOn(dir);
+    assert.equal(locked.status, 1, 'an unreadable config must fail the gate');
+    assert.match(locked.out, /cannot read vitest config/);
+    // The point of the change. It already exited 1 before; what it did NOT do
+    // was say why, and an uncaught readFileSync stack sends the reader into
+    // node internals instead of at their own file mode.
+    assert.doesNotMatch(locked.out, /at readFileSync \(node:fs/, 'must not surface a raw node stack');
+  } finally {
+    chmodSync(config, 0o644);
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -84,8 +84,15 @@ import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stripYamlComments } from './lib/server-bin-targets-parse.mjs';
-import { existsOrThrow } from './lib/exists-or-throw.mjs';
-import { listWorkspacePackages, PACKAGE_PARENTS } from './lib/list-workspace-packages.mjs';
+import { listWorkspacePackages } from './lib/list-workspace-packages.mjs';
+
+// Deliberately a literal here rather than imported from the shared walk.
+// `scripts/lib/ci-path-coverage.mjs`'s `deriveInputs` reads only THIS file's own
+// source text and does not follow imports, so these two strings are what put
+// `packages/` and `apps/` into the CI-path-coverage census for this gate. Move
+// them into the lib and the ratchet silently stops checking that this gate can
+// be triggered by the paths it reads. (#3347)
+const PACKAGE_PARENTS = ['packages', 'apps'];
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 

--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -194,6 +194,7 @@ export function readWorkflows(root) {
       source = readFileSync(join(dir, name), 'utf8');
     } catch (err) {
       fail(`${join(dir, name)} could not be read: ${err.message}`);
+      throw err;
     }
     return { name, text: stripYamlComments(source) };
   });
@@ -536,6 +537,7 @@ export function auditGateScripts(root, workflows, pkgScripts) {
       source = readFileSync(join(root, rel), 'utf8');
     } catch (err) {
       fail(`${join(root, rel)} could not be read: ${err.message}`);
+      throw err;
     }
     const reason = unwiredReason(source);
     if (reason === null) {
@@ -612,6 +614,7 @@ export function audit(root) {
     pkgScripts = JSON.parse(readFileSync(pkgJsonPath, 'utf8')).scripts ?? {};
   } catch (err) {
     fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
+    throw err;
   }
   const workflows = readWorkflows(root);
   return {

--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -153,8 +153,7 @@ function findTestFiles(dir, found = []) {
 
 export function auditPackages(root) {
   const offenders = [];
-  const seenParents = [];
-  const packages = listWorkspacePackages(root, fail, PACKAGE_PARENTS, seenParents);
+  const { packages, seenParents } = listWorkspacePackages(root, fail, PACKAGE_PARENTS);
 
   for (const { rel, dir, pkgJson } of packages) {
     if (pkgJson.scripts?.test) continue;
@@ -295,12 +294,16 @@ export function reachableTaskNames(sources) {
 /**
  * `{ [pkgRelPath]: scripts }` for every workspace package under packages/ and
  * apps/. A PROJECTION of the same `listWorkspacePackages` function the audit
- * uses — one discovery FUNCTION with two readers, though it is still called
- * once per reader, so this is a second walk at run time — see the note
- * there for what the two independent walks used to cost.
+ * uses: one discovery FUNCTION with two readers. Still called once per reader,
+ * so it is a second walk of the same tree at run time. That is deliberate and
+ * cheap at this size (two parents, ~50 entries); the thing worth keeping is
+ * that both readers now agree on WHAT a package is, not that they share a pass.
  */
 export function readWorkspaceScripts(root) {
-  return listWorkspacePackages(root, fail).map(({ rel, pkgJson }) => ({ rel, scripts: pkgJson.scripts ?? {} }));
+  return listWorkspacePackages(root, fail, PACKAGE_PARENTS).packages.map(({ rel, pkgJson }) => ({
+    rel,
+    scripts: pkgJson.scripts ?? {},
+  }));
 }
 
 /**

--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -84,6 +84,7 @@ import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stripYamlComments } from './lib/server-bin-targets-parse.mjs';
+import { existsOrThrow } from './lib/exists-or-throw.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -140,50 +141,94 @@ function findTestFiles(dir, found = []) {
 }
 
 /* ------------------------------------------------------------------ *
- * Part 1: packages/ and apps/ (unchanged behaviour)                    *
+ * Part 1: packages/ and apps/ — and the package discovery Part 2 shares  *
  * ------------------------------------------------------------------ */
 
-export function auditPackages(root) {
-  const offenders = [];
-  let examined = 0;
-  let parentsSeen = 0;
-
+/**
+ * Every workspace package under `packages/` and `apps/`, with its parsed
+ * manifest — the ONE discovery walk both readers below share.
+ *
+ * There used to be two of these loops, `auditPackages`'s and
+ * `readWorkspaceScripts`'s, and the only thing keeping them in agreement was
+ * that whoever changed one remembered the other. That is not a property, it is
+ * a habit, and #3347 is what it costs: a hardening applied to one loop leaves
+ * the other reading an unreadable manifest as an absent one. One walk, two
+ * readers, and the two cannot disagree about what a package is.
+ *
+ * DISCOVERY IS FAIL-CLOSED (#3347). `existsSync` here answered false for every
+ * failure — EACCES, ENOTDIR, EIO — so a package whose manifest could not be
+ * opened silently left the audit and this gate printed OK with a smaller
+ * count. Measured on a two-package fixture, one of them `chmod 000`:
+ * `OK (2 packages, ...)` became `OK (1 packages, ...)` at exit 0, and when the
+ * locked package was the offender (test files, no `test` script) the run that
+ * had exited 1 naming it exited 0 saying nothing. `existsOrThrow` returns false
+ * for ENOENT and ONLY for ENOENT.
+ *
+ * @param {string[]} [seenParents] filled with the parents that exist, so a
+ *   caller can tell "no packages here" from "nowhere to look for them".
+ */
+export function listPackages(root, seenParents = []) {
+  const out = [];
   for (const parent of PACKAGE_DIRS) {
     const parentDir = join(root, parent);
-    if (!existsSync(parentDir)) continue;
-    parentsSeen++;
-    for (const name of readdirSync(parentDir)) {
+    if (!existsOrThrow(parentDir, 'package parent', fail)) continue;
+    seenParents.push(parent);
+    for (const name of readdirSync(parentDir).sort()) {
+      // A dotfile is not a candidate package and never was: pnpm-workspace.yaml
+      // globs `packages/*` and `apps/*`, and a bare `*` does not match a
+      // leading dot, so no dotted entry can ever be a workspace package. macOS
+      // drops a `.DS_Store` FILE into any directory Finder has opened, and
+      // statting `.DS_Store/package.json` raises ENOTDIR — which existsOrThrow
+      // below refuses, correctly and by design, failing the whole Lint lane on
+      // a local-only file. So the skip and the refusal ship together or the
+      // refusal is a flake generator: PR #3350 fixed exactly this in two sibling
+      // gates, and adopting existsOrThrow here without the skip would have
+      // reintroduced it. The fix is to stop offering a dotfile as a candidate,
+      // NOT to soften the refusal: every entry that could plausibly be a package
+      // still goes through existsOrThrow unchanged. Same skip findTestFiles and
+      // findScriptFiles already apply one stage later. (#3350, #3347)
+      if (name.startsWith('.')) continue;
       const pkgDir = join(parentDir, name);
       const pkgJsonPath = join(pkgDir, 'package.json');
-      if (!existsSync(pkgJsonPath)) continue;
-      examined++;
+      if (!existsOrThrow(pkgJsonPath, 'package manifest', fail)) continue;
       let pkgJson;
       try {
         pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
       } catch (err) {
         fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
       }
-      if (pkgJson.scripts?.test) continue;
-      const testFiles = findTestFiles(pkgDir);
-      if (testFiles.length > 0) {
-        offenders.push({
-          name: pkgJson.name ?? `${parent}/${name}`,
-          example: relative(root, testFiles[0]).split('\\').join('/'),
-        });
-      }
+      out.push({ rel: `${parent}/${name}`, dir: pkgDir, pkgJson });
+    }
+  }
+  return out;
+}
+
+export function auditPackages(root) {
+  const offenders = [];
+  const seenParents = [];
+  const packages = listPackages(root, seenParents);
+
+  for (const { rel, dir, pkgJson } of packages) {
+    if (pkgJson.scripts?.test) continue;
+    const testFiles = findTestFiles(dir);
+    if (testFiles.length > 0) {
+      offenders.push({
+        name: pkgJson.name ?? rel,
+        example: relative(root, testFiles[0]).split('\\').join('/'),
+      });
     }
   }
 
   // Anti-vacuity: "0 offenders" must mean "looked and found none", never
   // "looked in the wrong tree". Both of these are silent greens otherwise.
-  if (parentsSeen === 0) {
+  if (seenParents.length === 0) {
     fail(`no search root found: none of ${PACKAGE_DIRS.map((d) => `${root}/${d}`).join(', ')} exists`);
   }
-  if (examined === 0) {
+  if (packages.length === 0) {
     fail(`found no package.json under ${PACKAGE_DIRS.join('/ or ')}/ in ${root} — the package scan cannot be trusted`);
   }
 
-  return { offenders, examined };
+  return { offenders, examined: packages.length };
 }
 
 /* ------------------------------------------------------------------ *
@@ -299,23 +344,13 @@ export function reachableTaskNames(sources) {
   return tasks;
 }
 
-/** `{ [pkgRelPath]: scripts }` for every workspace package under packages/ and apps/. */
+/**
+ * `{ [pkgRelPath]: scripts }` for every workspace package under packages/ and
+ * apps/. A PROJECTION of `listPackages`, not a second walk — see the note
+ * there for what the two independent walks used to cost.
+ */
 export function readWorkspaceScripts(root) {
-  const out = [];
-  for (const parent of PACKAGE_DIRS) {
-    const parentDir = join(root, parent);
-    if (!existsSync(parentDir)) continue;
-    for (const name of readdirSync(parentDir).sort()) {
-      const pkgJsonPath = join(parentDir, name, 'package.json');
-      if (!existsSync(pkgJsonPath)) continue;
-      try {
-        out.push({ rel: `${parent}/${name}`, scripts: JSON.parse(readFileSync(pkgJsonPath, 'utf8')).scripts ?? {} });
-      } catch (err) {
-        fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
-      }
-    }
-  }
-  return out;
+  return listPackages(root).map(({ rel, pkgJson }) => ({ rel, scripts: pkgJson.scripts ?? {} }));
 }
 
 /**

--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -10,7 +10,7 @@
  * silently skips it and the suite never runs in CI (this happened to
  * @ifc-lite/ifcx and @ifc-lite/renderer — 13 test files dark for months).
  *
- * Part 2 — the same absence one directory over. `PACKAGE_DIRS` is
+ * Part 2 — the same absence one directory over. `PACKAGE_PARENTS` is
  * `packages` + `apps`, and `scripts/` is neither — yet `scripts/` is where
  * this repo keeps its gates. PR #3062 shipped a gate script AND its test
  * with no workflow step, no package.json script and no turbo task, and
@@ -85,6 +85,7 @@ import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stripYamlComments } from './lib/server-bin-targets-parse.mjs';
 import { existsOrThrow } from './lib/exists-or-throw.mjs';
+import { listWorkspacePackages, PACKAGE_PARENTS } from './lib/list-workspace-packages.mjs';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -96,7 +97,6 @@ export function fail(message) {
   throw new FailError(message);
 }
 
-const PACKAGE_DIRS = ['packages', 'apps'];
 const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|mts|js|mjs)$/;
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo']);
 
@@ -144,69 +144,10 @@ function findTestFiles(dir, found = []) {
  * Part 1: packages/ and apps/ — and the package discovery Part 2 shares  *
  * ------------------------------------------------------------------ */
 
-/**
- * Every workspace package under `packages/` and `apps/`, with its parsed
- * manifest — the ONE discovery walk both readers below share.
- *
- * There used to be two of these loops, `auditPackages`'s and
- * `readWorkspaceScripts`'s, and the only thing keeping them in agreement was
- * that whoever changed one remembered the other. That is not a property, it is
- * a habit, and #3347 is what it costs: a hardening applied to one loop leaves
- * the other reading an unreadable manifest as an absent one. One walk, two
- * readers, and the two cannot disagree about what a package is.
- *
- * DISCOVERY IS FAIL-CLOSED (#3347). `existsSync` here answered false for every
- * failure — EACCES, ENOTDIR, EIO — so a package whose manifest could not be
- * opened silently left the audit and this gate printed OK with a smaller
- * count. Measured on a two-package fixture, one of them `chmod 000`:
- * `OK (2 packages, ...)` became `OK (1 packages, ...)` at exit 0, and when the
- * locked package was the offender (test files, no `test` script) the run that
- * had exited 1 naming it exited 0 saying nothing. `existsOrThrow` returns false
- * for ENOENT and ONLY for ENOENT.
- *
- * @param {string[]} [seenParents] filled with the parents that exist, so a
- *   caller can tell "no packages here" from "nowhere to look for them".
- */
-export function listPackages(root, seenParents = []) {
-  const out = [];
-  for (const parent of PACKAGE_DIRS) {
-    const parentDir = join(root, parent);
-    if (!existsOrThrow(parentDir, 'package parent', fail)) continue;
-    seenParents.push(parent);
-    for (const name of readdirSync(parentDir).sort()) {
-      // A dotfile is not a candidate package and never was: pnpm-workspace.yaml
-      // globs `packages/*` and `apps/*`, and a bare `*` does not match a
-      // leading dot, so no dotted entry can ever be a workspace package. macOS
-      // drops a `.DS_Store` FILE into any directory Finder has opened, and
-      // statting `.DS_Store/package.json` raises ENOTDIR — which existsOrThrow
-      // below refuses, correctly and by design, failing the whole Lint lane on
-      // a local-only file. So the skip and the refusal ship together or the
-      // refusal is a flake generator: PR #3350 fixed exactly this in two sibling
-      // gates, and adopting existsOrThrow here without the skip would have
-      // reintroduced it. The fix is to stop offering a dotfile as a candidate,
-      // NOT to soften the refusal: every entry that could plausibly be a package
-      // still goes through existsOrThrow unchanged. Same skip findTestFiles and
-      // findScriptFiles already apply one stage later. (#3350, #3347)
-      if (name.startsWith('.')) continue;
-      const pkgDir = join(parentDir, name);
-      const pkgJsonPath = join(pkgDir, 'package.json');
-      if (!existsOrThrow(pkgJsonPath, 'package manifest', fail)) continue;
-      let pkgJson;
-      try {
-        pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-      } catch (err) {
-        fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
-      }
-      out.push({ rel: `${parent}/${name}`, dir: pkgDir, pkgJson });
-    }
-  }
-  return out;
-}
-
 export function auditPackages(root) {
   const offenders = [];
   const seenParents = [];
-  const packages = listPackages(root, seenParents);
+  const packages = listWorkspacePackages(root, fail, PACKAGE_PARENTS, seenParents);
 
   for (const { rel, dir, pkgJson } of packages) {
     if (pkgJson.scripts?.test) continue;
@@ -222,10 +163,10 @@ export function auditPackages(root) {
   // Anti-vacuity: "0 offenders" must mean "looked and found none", never
   // "looked in the wrong tree". Both of these are silent greens otherwise.
   if (seenParents.length === 0) {
-    fail(`no search root found: none of ${PACKAGE_DIRS.map((d) => `${root}/${d}`).join(', ')} exists`);
+    fail(`no search root found: none of ${PACKAGE_PARENTS.map((d) => `${root}/${d}`).join(', ')} exists`);
   }
   if (packages.length === 0) {
-    fail(`found no package.json under ${PACKAGE_DIRS.join('/ or ')}/ in ${root} — the package scan cannot be trusted`);
+    fail(`found no package.json under ${PACKAGE_PARENTS.join('/ or ')}/ in ${root} — the package scan cannot be trusted`);
   }
 
   return { offenders, examined: packages.length };
@@ -346,11 +287,13 @@ export function reachableTaskNames(sources) {
 
 /**
  * `{ [pkgRelPath]: scripts }` for every workspace package under packages/ and
- * apps/. A PROJECTION of `listPackages`, not a second walk — see the note
+ * apps/. A PROJECTION of the same `listWorkspacePackages` function the audit
+ * uses — one discovery FUNCTION with two readers, though it is still called
+ * once per reader, so this is a second walk at run time — see the note
  * there for what the two independent walks used to cost.
  */
 export function readWorkspaceScripts(root) {
-  return listPackages(root).map(({ rel, pkgJson }) => ({ rel, scripts: pkgJson.scripts ?? {} }));
+  return listWorkspacePackages(root, fail).map(({ rel, pkgJson }) => ({ rel, scripts: pkgJson.scripts ?? {} }));
 }
 
 /**

--- a/scripts/check-test-wiring.test.mjs
+++ b/scripts/check-test-wiring.test.mjs
@@ -29,7 +29,7 @@ const CHECKER = join(dirname(fileURLToPath(import.meta.url)), 'check-test-wiring
 
 // Imported for the one case that has to drive a reader `audit()` never reaches
 // on its own; every other case below spawns the unmodified checker via `run`.
-const { readWorkspaceScripts, FailError } = await import('./check-test-wiring.mjs');
+import { readWorkspaceScripts, FailError } from './check-test-wiring.mjs';
 
 /** The catch-all step #3038 added: a bare glob, one directory level only. */
 const GLOB_CATCH_ALL = '      - name: Run every scripts/ test file (glob catch-all)\n' +

--- a/scripts/check-test-wiring.test.mjs
+++ b/scripts/check-test-wiring.test.mjs
@@ -765,7 +765,12 @@ test('an unreadable package PARENT is named, not surfaced as a raw scandir stack
       const { status, out } = run(root);
       assert.equal(status, 1, 'an unreadable package parent must fail the gate');
       assert.match(out, /cannot read package parent/);
-      assert.doesNotMatch(out, /at Object\.readdirSync/, 'must not surface a raw node stack');
+      // `at readdirSync (node:fs`, NOT `at Object.readdirSync`. V8 names the
+      // frame after how the function was INVOKED, and the gate imports it bare
+      // from an ESM module, so the `Object.` form never appears there - it is
+      // what a CJS `require('fs').readdirSync(...)` produces. The first spelling
+      // here was that one, and it matched nothing while reporting pass.
+      assert.doesNotMatch(out, /at readdirSync \(node:fs/, 'must not surface a raw node stack');
     } finally {
       chmodSync(parent, 0o755);
     }

--- a/scripts/check-test-wiring.test.mjs
+++ b/scripts/check-test-wiring.test.mjs
@@ -765,12 +765,15 @@ test('an unreadable package PARENT is named, not surfaced as a raw scandir stack
       const { status, out } = run(root);
       assert.equal(status, 1, 'an unreadable package parent must fail the gate');
       assert.match(out, /cannot read package parent/);
-      // `at readdirSync (node:fs`, NOT `at Object.readdirSync`. V8 names the
-      // frame after how the function was INVOKED, and the gate imports it bare
-      // from an ESM module, so the `Object.` form never appears there - it is
-      // what a CJS `require('fs').readdirSync(...)` produces. The first spelling
-      // here was that one, and it matched nothing while reporting pass.
-      assert.doesNotMatch(out, /at readdirSync \(node:fs/, 'must not surface a raw node stack');
+      // Anchored on the PAYLOAD, not on a V8 frame name. The frame name encodes
+      // the CALL FORM - `at readdirSync` for a bare ESM import, `at
+      // Object.readdirSync` for CJS, `at Module.readdirSync` for a namespace
+      // import - so any of those spellings is voided by a behaviour-preserving
+      // change to how the gate imports fs, and nothing in the repo pins that.
+      // This assertion has already been vacuous once for exactly that reason.
+      // The raw scandir message is what a developer would actually see, and it
+      // is the same under all three call forms.
+      assert.doesNotMatch(out, /permission denied, scandir/, 'must not surface a raw node error');
     } finally {
       chmodSync(parent, 0o755);
     }

--- a/scripts/check-test-wiring.test.mjs
+++ b/scripts/check-test-wiring.test.mjs
@@ -655,7 +655,7 @@ test('--root with no argument is rejected', () => {
  * saying nothing, purely by becoming unreadable.
  *
  * The next three are deliberately a SET, in the shape PR #3350 established for
- * the two sibling gates. Adopting the refusal on its own reintroduces #3350's
+ * the three sibling gates it hardened. Adopting the refusal on its own reintroduces #3350's
  * flake — macOS drops a `.DS_Store` FILE into any Finder-opened directory and
  * statting `.DS_Store/package.json` raises ENOTDIR — and the obvious way to
  * make that flake go away is to catch ENOTDIR and continue, which deletes the

--- a/scripts/check-test-wiring.test.mjs
+++ b/scripts/check-test-wiring.test.mjs
@@ -665,6 +665,10 @@ test('--root with no argument is rejected', () => {
  */
 
 test('an unreadable package manifest is refused, not silently dropped from the audit (issue 3347)', (t) => {
+  // Same skip as the siblings in exists-or-throw.test.mjs and
+  // check-test-glob-coverage.test.mjs: chmod does not remove directory
+  // traversal on Windows, so the gate would audit both packages and exit 0.
+  if (process.platform === 'win32') return t.skip('chmod 000 does not block traversal on Windows');
   if (process.getuid?.() === 0) return t.skip('root traverses every directory regardless of mode');
   withTree({}, (root) => {
     write(root, 'packages/beta/package.json', JSON.stringify({ name: 'beta', scripts: { test: 'vitest run' } }));
@@ -741,4 +745,61 @@ test('the workspace-script reader shares the hardened walk, so it cannot go soft
     process.exitCode = previousExitCode;
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+/* ---------------------------------------------------------------- *
+ * The two cases existsOrThrow cannot reach on its own. `statSync`     *
+ * succeeds on both a mode-000 FILE and a mode-000 DIRECTORY, because  *
+ * the mode bits gate open(2)/opendir(3) and not stat(2). Both used to *
+ * fail closed with the WRONG diagnosis: a raw scandir stack for the   *
+ * parent, and "is not valid JSON" for the manifest.                   *
+ * ---------------------------------------------------------------- */
+
+test('an unreadable package PARENT is named, not surfaced as a raw scandir stack', (t) => {
+  if (process.platform === 'win32') return t.skip('chmod 000 does not block traversal on Windows');
+  if (process.getuid?.() === 0) return t.skip('root traverses every directory regardless of mode');
+  withTree({}, (root) => {
+    const parent = join(root, 'packages');
+    chmodSync(parent, 0o000);
+    try {
+      const { status, out } = run(root);
+      assert.equal(status, 1, 'an unreadable package parent must fail the gate');
+      assert.match(out, /cannot read package parent/);
+      assert.doesNotMatch(out, /at Object\.readdirSync/, 'must not surface a raw node stack');
+    } finally {
+      chmodSync(parent, 0o755);
+    }
+  });
+});
+
+test('an unreadable package MANIFEST is not reported as a JSON syntax error', (t) => {
+  if (process.platform === 'win32') return t.skip('chmod does not gate reads on Windows');
+  if (process.getuid?.() === 0) return t.skip('root reads a 000 file regardless of mode');
+  withTree({}, (root) => {
+    const manifest = write(root, 'packages/beta/package.json', JSON.stringify({ name: 'beta' }));
+    chmodSync(manifest, 0o000);
+    try {
+      const { status, out } = run(root);
+      assert.equal(status, 1, 'an unreadable manifest must fail the gate');
+      assert.match(out, /cannot read package manifest/);
+      // The defect. EACCES arrived inside the JSON.parse catch and was
+      // reported as bad syntax, sending the reader to fix a file whose
+      // syntax is fine.
+      assert.doesNotMatch(out, /is not valid JSON/, 'must not blame the syntax of a file it could not read');
+    } finally {
+      chmodSync(manifest, 0o644);
+    }
+  });
+});
+
+test('a genuinely malformed manifest still reports a SYNTAX error', () => {
+  // Non-vacuity for the pair above: the new read/parse split must not turn
+  // every manifest failure into "cannot read".
+  withTree({}, (root) => {
+    write(root, 'packages/beta/package.json', '{oops');
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /is not valid JSON/);
+    assert.doesNotMatch(out, /cannot read package manifest/);
+  });
 });

--- a/scripts/check-test-wiring.test.mjs
+++ b/scripts/check-test-wiring.test.mjs
@@ -27,6 +27,10 @@ import { fileURLToPath } from 'node:url';
 
 const CHECKER = join(dirname(fileURLToPath(import.meta.url)), 'check-test-wiring.mjs');
 
+// Imported for the one case that has to drive a reader `audit()` never reaches
+// on its own; every other case below spawns the unmodified checker via `run`.
+const { readWorkspaceScripts, FailError } = await import('./check-test-wiring.mjs');
+
 /** The catch-all step #3038 added: a bare glob, one directory level only. */
 const GLOB_CATCH_ALL = '      - name: Run every scripts/ test file (glob catch-all)\n' +
   '        run: node --test scripts/*.test.mjs scripts/lib/*.test.mjs\n';
@@ -632,4 +636,109 @@ test('--root with no argument is rejected', () => {
   const r = spawnSync(process.execPath, [CHECKER, '--root'], { encoding: 'utf8' });
   assert.equal(r.status, 1);
   assert.match(r.stderr, /--root requires a directory argument/);
+});
+
+/* ---------------------------------------------------------------- *
+ * Package DISCOVERY is fail-closed, and dotfiles are not candidates. *
+ * ---------------------------------------------------------------- *
+ *
+ * (#3347) Discovery used `existsSync`, which answers false for EVERY failure
+ * and not only ENOENT, so a package whose manifest could not be opened left
+ * the audit with no error at all. Measured on the two-package fixture below,
+ * before the fix:
+ *
+ *   healthy:                 OK (2 packages, ...)   EXIT=0
+ *   packages/beta chmod 000: OK (1 packages, ...)   EXIT=0
+ *
+ * and the same hole hid the offender this gate exists for: a `gamma` carrying
+ * test files and no `test` script went from `EXIT=1` naming it to `EXIT=0`
+ * saying nothing, purely by becoming unreadable.
+ *
+ * The next three are deliberately a SET, in the shape PR #3350 established for
+ * the two sibling gates. Adopting the refusal on its own reintroduces #3350's
+ * flake — macOS drops a `.DS_Store` FILE into any Finder-opened directory and
+ * statting `.DS_Store/package.json` raises ENOTDIR — and the obvious way to
+ * make that flake go away is to catch ENOTDIR and continue, which deletes the
+ * refusal. The last case is the one that catches that fix: one tree carrying
+ * BOTH a dotfile and a non-dotfile ENOTDIR candidate, where the gate must
+ * ignore exactly one of them and refuse the other.
+ */
+
+test('an unreadable package manifest is refused, not silently dropped from the audit (issue 3347)', (t) => {
+  if (process.getuid?.() === 0) return t.skip('root traverses every directory regardless of mode');
+  withTree({}, (root) => {
+    write(root, 'packages/beta/package.json', JSON.stringify({ name: 'beta', scripts: { test: 'vitest run' } }));
+    write(root, 'packages/beta/src/beta.test.ts', 'test');
+    chmodSync(join(root, 'packages/beta'), 0o000);
+    try {
+      const { status, out } = run(root);
+      assert.equal(status, 1, `expected a refusal on an unreadable manifest, got ${status}: ${out}`);
+      assert.match(out, /cannot read package manifest/);
+      assert.match(out, /Refusing to treat an unreadable path as an absent one/);
+      assert.doesNotMatch(out, /OK \(/, 'must not print a success line at all');
+    } finally {
+      chmodSync(join(root, 'packages/beta'), 0o755);
+    }
+  });
+});
+
+test('a `.DS_Store` dotfile in packages/ or apps/ is not a candidate package (issue 3347)', () => {
+  withTree({}, (root) => {
+    write(root, 'apps/real-app/package.json', JSON.stringify({ name: 'real-app', scripts: { test: 'vitest run' } }));
+    write(root, 'apps/real-app/src/b.test.ts', 'test');
+    // Finder's leavings: a FILE, so `<name>/package.json` raises ENOTDIR.
+    write(root, 'packages/.DS_Store', '\x00\x01Bud1');
+    write(root, 'apps/.DS_Store', '\x00\x01Bud1');
+    const { status, out } = run(root);
+    assert.equal(status, 0, out);
+    assert.match(out, /OK \(2 packages,/);
+    assert.doesNotMatch(out, /DS_Store/, 'a dotfile must not appear in the output at all');
+  });
+});
+
+test('skipping dotfiles does not soften the refusal: a non-dotfile ENOTDIR candidate in the SAME tree still fails (issue 3347)', () => {
+  withTree({}, (root) => {
+    write(root, 'packages/.DS_Store', '\x00\x01Bud1');
+    // Not a dotfile, and not a directory: `packages/blocked/package.json`
+    // raises ENOTDIR exactly as `.DS_Store` did. This one must still be
+    // refused — that is the whole point of the guard.
+    write(root, 'packages/blocked', 'i am a file, not a package directory\n');
+    const { status, out } = run(root);
+    assert.equal(status, 1, `expected a refusal on a non-dotfile ENOTDIR candidate, got ${status}: ${out}`);
+    assert.match(out, /cannot read package manifest/);
+    assert.match(out, /packages\/blocked\/package\.json/);
+    assert.match(out, /Refusing to treat an unreadable path as an absent one/);
+    assert.doesNotMatch(out, /DS_Store/, 'the dotfile must not be what tripped it');
+    assert.doesNotMatch(out, /OK \(/, 'must not print a success line at all');
+  });
+});
+
+test('the workspace-script reader shares the hardened walk, so it cannot go soft on its own (issue 3347)', () => {
+  // This file used to carry TWO package-discovery loops, `auditPackages`'s and
+  // `readWorkspaceScripts`'s, kept in agreement only by whoever edited one
+  // remembering the other. `audit()` reaches the first loop first, so a
+  // hardening applied to that one alone looks complete end-to-end while the
+  // second still reads an unreadable manifest as an absent one. Driving the
+  // second reader directly is the only way to see it.
+  const root = baseTree();
+  const previousExitCode = process.exitCode;
+  try {
+    write(root, 'packages/blocked', 'i am a file, not a package directory\n');
+    assert.throws(
+      () => readWorkspaceScripts(root),
+      (err) => err instanceof FailError && /Refusing to treat an unreadable path as an absent one/.test(err.message),
+      'readWorkspaceScripts must refuse an unreadable manifest, not skip it',
+    );
+    // ...and the dotfile skip reaches this reader too, or the refusal above is
+    // a flake generator on every macOS checkout.
+    write(root, 'packages/.DS_Store', '\x00\x01Bud1');
+    rmSync(join(root, 'packages/blocked'));
+    assert.deepEqual(readWorkspaceScripts(root).map((p) => p.rel), ['packages/alpha']);
+  } finally {
+    // `fail()` sets process.exitCode as well as throwing, which would otherwise
+    // red-line this whole test file. Restore rather than zero it: another test
+    // may already have failed and set it.
+    process.exitCode = previousExitCode;
+    rmSync(root, { recursive: true, force: true });
+  }
 });

--- a/scripts/ci-path-coverage-allowlist.txt
+++ b/scripts/ci-path-coverage-allowlist.txt
@@ -67,7 +67,6 @@ scripts/check-source-text-assertions.mjs apps/landing # walks apps/ for test fil
 scripts/check-loader-hook-specifier-match.mjs apps/landing # walks apps/ for loader hooks; apps/landing has none
 scripts/check-loader-hook-specifier-match.test.mjs apps/landing # same walk, in the harness
 scripts/check-tla-chunk-await.test.mjs apps/landing # same walk, in the harness
-scripts/check-test-wiring.mjs apps/landing # walks apps/ for test suites; apps/landing has none
 scripts/typecheck-tests.test.mjs apps/landing # apps/landing is not a tsconfig project
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci-path-coverage-allowlist.txt
+++ b/scripts/ci-path-coverage-allowlist.txt
@@ -67,6 +67,7 @@ scripts/check-source-text-assertions.mjs apps/landing # walks apps/ for test fil
 scripts/check-loader-hook-specifier-match.mjs apps/landing # walks apps/ for loader hooks; apps/landing has none
 scripts/check-loader-hook-specifier-match.test.mjs apps/landing # same walk, in the harness
 scripts/check-tla-chunk-await.test.mjs apps/landing # same walk, in the harness
+scripts/check-test-wiring.mjs apps/landing # walks apps/ for test suites; apps/landing has none
 scripts/typecheck-tests.test.mjs apps/landing # apps/landing is not a tsconfig project
 
 # ---------------------------------------------------------------------------

--- a/scripts/docs/check-package-readmes.mjs
+++ b/scripts/docs/check-package-readmes.mjs
@@ -103,7 +103,7 @@ for (const dir of entries) {
   // `.DS_Store/package.json` raises ENOTDIR, which existsOrFail below refuses
   // by design. Skip the candidate rather than soften the refusal: every entry
   // that could plausibly be a package still goes through it unchanged. Same
-  // shape and same reason as check-test-glob-coverage.mjs's listPackages(). (#3350)
+  // shape and same reason as lib/list-workspace-packages.mjs's walk. (#3350)
   if (dir.startsWith('.')) continue;
   const pkgJsonPath = join(packagesDir, dir, 'package.json');
   if (!existsOrFail(pkgJsonPath, 'package manifest')) continue;

--- a/scripts/docs/check-package-readmes.mjs
+++ b/scripts/docs/check-package-readmes.mjs
@@ -59,6 +59,16 @@ function fail(message) {
  * so an unreadable path is indistinguishable from an absent one — and here
  * "absent" means "skip this directory", which is how a package leaves the
  * audit without leaving a trace.
+ *
+ * DELIBERATELY NOT the shared `scripts/lib/exists-or-throw.mjs`, and this is
+ * load-bearing rather than an oversight. This gate's regression harness copies
+ * THIS ONE FILE into a synthetic tree and runs it there (see the note on
+ * `packagesDir` above, and `check-package-readmes.test.mjs`'s `makeTree`), so
+ * the file must stay import-free beyond node builtins. Migrating it onto the
+ * lib was tried and turned all 9 of its tests red while the gate itself still
+ * passed against the real repo - the failure only appears in the synthetic
+ * tree, where `../lib/` does not exist. Change the harness first if you want
+ * this deduplicated. (#3347)
  */
 function existsOrFail(path, what) {
   try {

--- a/scripts/lib/exists-or-throw.mjs
+++ b/scripts/lib/exists-or-throw.mjs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { statSync } from 'node:fs';
+
 /**
  * `existsSync` with the one answer it refuses to guess.
  *
@@ -34,8 +36,6 @@
  * @param {(message: string) => never} fail the caller's own failure reporter
  * @returns {boolean} true if it exists, false ONLY if it definitely does not
  */
-import { statSync } from 'node:fs';
-
 export function existsOrThrow(path, what, fail) {
   try {
     statSync(path);

--- a/scripts/lib/exists-or-throw.mjs
+++ b/scripts/lib/exists-or-throw.mjs
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `existsSync` with the one answer it refuses to guess.
+ *
+ * `existsSync` returns false for EVERY failure, not only ENOENT: EACCES on a
+ * locked directory, ENOTDIR when a FILE sits where a directory belongs, EIO on
+ * a bad disk. A gate that discovers packages with it therefore reads "I could
+ * not open this" as "this is not here", drops the package from its audit, and
+ * prints OK — the absence-reads-as-success defect, one stage earlier than the
+ * walk it usually gets fixed in.
+ *
+ * Measured, twice, against gates carrying real packages:
+ *   check-test-glob-coverage.mjs, one `chmod 000` package with a test script:
+ *     `OK (1 packages audited, 0 unrun test files)`, exit 0 (#3194 follow-up).
+ *   check-test-wiring.mjs, two packages, one of them `chmod 000`:
+ *     `OK (2 packages, ...)` became `OK (1 packages, ...)`, exit 0 — and with
+ *     the locked package holding test files and NO `test` script, the run that
+ *     had exited 1 naming it exited 0 saying nothing (#3347).
+ *
+ * SHARED rather than copied, on the same footing as `stripYamlComments` in
+ * ./server-bin-targets-parse.mjs, which check-test-wiring.mjs and
+ * check-server-bin-targets.mjs already import from one place. The refusal is a
+ * pure filesystem predicate plus one sentence of prose, and a sentence kept in
+ * two files is held together by nothing but someone remembering to edit both.
+ *
+ * `fail` is injected because each gate prefixes its own name and throws its own
+ * FailError; nothing about the refusal itself is softened to make it shareable.
+ *
+ * @param {string} path
+ * @param {string} what human-readable role of `path`, e.g. 'package manifest'
+ * @param {(message: string) => never} fail the caller's own failure reporter
+ * @returns {boolean} true if it exists, false ONLY if it definitely does not
+ */
+import { statSync } from 'node:fs';
+
+export function existsOrThrow(path, what, fail) {
+  try {
+    statSync(path);
+    return true;
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    fail(
+      `cannot read ${what} ${path}: ${err.code || err.message}. ` +
+        'Refusing to treat an unreadable path as an absent one -- that is how a ' +
+        'package drops out of the audit without anyone noticing.',
+    );
+    // Unreachable with either gate's `fail`, which throws. Kept because the one
+    // way this helper could go soft is a caller whose `fail` returns: falling
+    // out of the catch would hand back `undefined`, the caller would read it as
+    // "absent", and the drop this exists to stop would be back with the error
+    // message still printed above it.
+    throw err;
+  }
+}

--- a/scripts/lib/exists-or-throw.test.mjs
+++ b/scripts/lib/exists-or-throw.test.mjs
@@ -73,6 +73,10 @@ test('ENOTDIR is refused, not read as absent', () => {
 });
 
 test('EACCES is refused, not read as absent', (t) => {
+  // Windows chmod does not remove directory traversal, so statSync succeeds and
+  // the refusal never fires. CI is linux-only today, but a Windows checkout
+  // would see a spurious failure here rather than a real one.
+  if (process.platform === 'win32') return t.skip('chmod 000 does not block traversal on Windows');
   if (process.getuid?.() === 0) return t.skip('root traverses every directory regardless of mode');
   withTree((root) => {
     mkdirSync(join(root, 'locked'));

--- a/scripts/lib/exists-or-throw.test.mjs
+++ b/scripts/lib/exists-or-throw.test.mjs
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The refusal itself, tested where its callers cannot reach it.
+ *
+ * check-test-glob-coverage.test.mjs and check-test-wiring.test.mjs both pin
+ * this end-to-end, through their own gates, which is the coverage that matters.
+ * Two things are only visible from here:
+ *
+ *   - The ENOENT/not-ENOENT split as a PROPERTY rather than as the two error
+ *     codes those suites happen to construct. `existsOrThrow` is one branch
+ *     away from `existsSync` at all times, and the branch is which codes fall
+ *     through to `false`.
+ *   - The soft-`fail` case. Both gates' `fail` throws, so nothing reachable
+ *     from them exercises what happens if one ever stops throwing — which is
+ *     exactly the edit that would put the silent drop back while leaving the
+ *     error message printed above it.
+ *
+ * Run: node --test scripts/lib/exists-or-throw.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { existsOrThrow } from './exists-or-throw.mjs';
+
+class TestFail extends Error {}
+const throwingFail = (message) => { throw new TestFail(message); };
+
+function withTree(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'exists-or-throw-'));
+  try {
+    fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test('a path that exists is true', () => {
+  withTree((root) => {
+    writeFileSync(join(root, 'here.json'), '{}');
+    assert.equal(existsOrThrow(join(root, 'here.json'), 'thing', throwingFail), true);
+    mkdirSync(join(root, 'dir'));
+    assert.equal(existsOrThrow(join(root, 'dir'), 'thing', throwingFail), true);
+  });
+});
+
+test('a path that is genuinely absent is false — ENOENT, and only ENOENT, means absent', () => {
+  withTree((root) => {
+    assert.equal(existsOrThrow(join(root, 'nope.json'), 'thing', throwingFail), false);
+    // A dangling symlink's target is absent in exactly the same sense.
+    assert.equal(existsOrThrow(join(root, 'a', 'b', 'nope.json'), 'thing', throwingFail), false);
+  });
+});
+
+test('ENOTDIR is refused, not read as absent', () => {
+  // A FILE where a directory belongs — what macOS `.DS_Store` produces, and
+  // what a mistyped path produces. `existsSync` answers false here.
+  withTree((root) => {
+    writeFileSync(join(root, 'file'), 'not a directory\n');
+    assert.throws(
+      () => existsOrThrow(join(root, 'file', 'package.json'), 'package manifest', throwingFail),
+      (err) => err instanceof TestFail
+        && /cannot read package manifest/.test(err.message)
+        && /ENOTDIR/.test(err.message)
+        && /Refusing to treat an unreadable path as an absent one/.test(err.message),
+    );
+  });
+});
+
+test('EACCES is refused, not read as absent', (t) => {
+  if (process.getuid?.() === 0) return t.skip('root traverses every directory regardless of mode');
+  withTree((root) => {
+    mkdirSync(join(root, 'locked'));
+    writeFileSync(join(root, 'locked', 'package.json'), '{}');
+    chmodSync(join(root, 'locked'), 0o000);
+    try {
+      assert.throws(
+        () => existsOrThrow(join(root, 'locked', 'package.json'), 'package manifest', throwingFail),
+        (err) => err instanceof TestFail && /EACCES/.test(err.message),
+      );
+    } finally {
+      chmodSync(join(root, 'locked'), 0o755);
+    }
+  });
+});
+
+test('a `fail` that RETURNS still does not yield a false: the refusal cannot go soft', () => {
+  // Neither gate can reach this — both `fail`s throw. It is here because the
+  // whole helper is one non-throwing reporter away from handing back
+  // `undefined`, which every caller reads as "absent": the printed error would
+  // stay, the package would still drop out of the audit, and the exit code
+  // would still be 0.
+  withTree((root) => {
+    writeFileSync(join(root, 'file'), 'not a directory\n');
+    const reported = [];
+    const softFail = (message) => { reported.push(message); };
+    assert.throws(
+      () => existsOrThrow(join(root, 'file', 'package.json'), 'package manifest', softFail),
+      (err) => err.code === 'ENOTDIR',
+      'it must throw the underlying error rather than return',
+    );
+    assert.equal(reported.length, 1, 'and it must still have reported through fail');
+  });
+});

--- a/scripts/lib/list-workspace-packages.mjs
+++ b/scripts/lib/list-workspace-packages.mjs
@@ -75,6 +75,11 @@ export function listWorkspacePackages(root, fail, parents) {
           'Refusing to treat an unreadable parent as an empty one -- that is how ' +
           'every package under it drops out of the audit at once.',
       );
+      // Unreachable with either gate's `fail`, which throws. Carried for the
+      // same reason exists-or-throw.mjs carries one: a caller whose `fail`
+      // RETURNS would leave `entries` undefined and the loop below would throw
+      // a TypeError, destroying the diagnosis this branch exists to produce.
+      throw err;
     }
     for (const name of entries) {
       // Skipping a dotfile is a CONSEQUENCE of a rule this code does not yet
@@ -108,6 +113,12 @@ export function listWorkspacePackages(root, fail, parents) {
           `cannot read package manifest ${pkgJsonPath}: ${err.code || err.message}. ` +
             'Refusing to treat an unreadable manifest as an absent one.',
         );
+        // The one that MATTERS, not just insurance. With a `fail` that
+        // returns, `raw` stays undefined, JSON.parse(undefined) throws a
+        // SYNTAX error, that fail returns too, and the package is pushed with
+        // `pkgJson: undefined` -- an unreadable package entering the counted
+        // population, which is the exact invariant this module protects.
+        throw err;
       }
       let pkgJson;
       try {

--- a/scripts/lib/list-workspace-packages.mjs
+++ b/scripts/lib/list-workspace-packages.mjs
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { existsOrThrow } from './exists-or-throw.mjs';
+
+/** The parents both fail-closed gates scan today. See the dotfile note below. */
+export const PACKAGE_PARENTS = ['packages', 'apps'];
+
+/**
+ * The one workspace-package walk the fail-closed gates share.
+ *
+ * `check-test-wiring.mjs` and `check-test-glob-coverage.mjs` each form a
+ * COUNTED POPULATION and then report a number about it. That is the invariant
+ * this module protects, and it is narrower than "be loud everywhere":
+ *
+ *     unreadable must never shrink a population a gate reports a count of.
+ *
+ * A refusal is one way to hold that; a calibrated floor is another, which is
+ * why `verify-npm-publish.js` and `lib/rust-major-offset.mjs` legitimately
+ * warn-and-floor instead. They are alternatives, not a hierarchy.
+ *
+ * Extracting `existsOrThrow` alone left this walk copied verbatim into both
+ * gates, differing only in a constant's name and `'utf-8'` vs `'utf8'` - the
+ * same habit #3347 charged for one layer down, two walks kept in agreement by
+ * whoever edited one remembering the other.
+ *
+ * NOT shared with the other ten enumerators, deliberately. They differ on four
+ * orthogonal axes: which parents, which filter (published-only, has-tsconfig,
+ * all), which return shape, and a per-gate calibrated floor. One function
+ * carrying four knobs is a config object with a `for` loop attached, and every
+ * caller would still have to learn every knob.
+ *
+ * Only `fail` and `parents` are injected. Both callers use the real `fs`, so
+ * threading the module through too would be indirection with a single shape.
+ *
+ * @param {string} root repo root, or an alternate tree under a `--root` flag.
+ * @param {(message: string) => never} fail the CALLER's reporter, so each gate
+ *   keeps its own prefix and its own error type. Injected rather than imported:
+ *   nothing about the refusal is softened to let it travel.
+ * @param {readonly string[]} parents which parents to scan.
+ * @param {string[]} seenParents out-param, pushed for each parent that exists.
+ *   Callers use it for their own anti-vacuity accounting; ignore it if not.
+ * @returns {{ rel: string, dir: string, pkgJson: unknown }[]}
+ */
+export function listWorkspacePackages(root, fail, parents = PACKAGE_PARENTS, seenParents = []) {
+  const out = [];
+  for (const parent of parents) {
+    const parentDir = join(root, parent);
+    if (!existsOrThrow(parentDir, 'package parent', fail)) continue;
+    seenParents.push(parent);
+    for (const name of readdirSync(parentDir).sort()) {
+      // Skipping a dotfile is a CONSEQUENCE of a rule this code does not yet
+      // read, not a rule of its own: pnpm-workspace.yaml's globs are
+      // `packages/*`, `apps/*`, `examples/*`, and a bare `*` never matches a
+      // leading dot. `check-lint-ran.mjs` already parses that block properly;
+      // moving its parser here and deriving BOTH the parents and this skip from
+      // it is the real fix. Deliberately not this change, because making the
+      // parents dynamic alters what each gate ENFORCES.
+      //
+      // The skip and the refusal ship together or the refusal is a flake
+      // generator. macOS drops a `.DS_Store` FILE into any Finder-opened
+      // directory; statting `.DS_Store/package.json` raises ENOTDIR, which
+      // `existsOrThrow` refuses correctly and by design. PR #3350 fixed exactly
+      // this in three sibling gates, and the tempting remedy - catch ENOTDIR
+      // and continue - deletes the refusal outright. (#3350, #3347)
+      if (name.startsWith('.')) continue;
+      const pkgDir = join(parentDir, name);
+      const pkgJsonPath = join(pkgDir, 'package.json');
+      if (!existsOrThrow(pkgJsonPath, 'package manifest', fail)) continue;
+      let pkgJson;
+      try {
+        pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+      } catch (err) {
+        fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
+      }
+      out.push({ rel: `${parent}/${name}`, dir: pkgDir, pkgJson });
+    }
+  }
+  return out;
+}

--- a/scripts/lib/list-workspace-packages.mjs
+++ b/scripts/lib/list-workspace-packages.mjs
@@ -6,9 +6,6 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { existsOrThrow } from './exists-or-throw.mjs';
 
-/** The parents both fail-closed gates scan today. See the dotfile note below. */
-export const PACKAGE_PARENTS = ['packages', 'apps'];
-
 /**
  * The one workspace-package walk the fail-closed gates share.
  *
@@ -27,7 +24,8 @@ export const PACKAGE_PARENTS = ['packages', 'apps'];
  * same habit #3347 charged for one layer down, two walks kept in agreement by
  * whoever edited one remembering the other.
  *
- * NOT shared with the other ten enumerators, deliberately. They differ on four
+ * NOT shared with the repo's other package enumerators, deliberately. They
+ * differ on four
  * orthogonal axes: which parents, which filter (published-only, has-tsconfig,
  * all), which return shape, and a per-gate calibrated floor. One function
  * carrying four knobs is a config object with a `for` loop attached, and every
@@ -36,17 +34,27 @@ export const PACKAGE_PARENTS = ['packages', 'apps'];
  * Only `fail` and `parents` are injected. Both callers use the real `fs`, so
  * threading the module through too would be indirection with a single shape.
  *
+ * `parents` is REQUIRED rather than defaulted. Each gate already keeps its own
+ * literal, because `check-ci-path-coverage` derives a gate's trigger paths from
+ * that gate's own source text and does not follow imports. A default here would
+ * be a third copy that nothing forces anyone to keep in step with those two,
+ * and the one caller that took it was already scanning a different list from
+ * its own file's other caller.
+ *
  * @param {string} root repo root, or an alternate tree under a `--root` flag.
  * @param {(message: string) => never} fail the CALLER's reporter, so each gate
  *   keeps its own prefix and its own error type. Injected rather than imported:
  *   nothing about the refusal is softened to let it travel.
  * @param {readonly string[]} parents which parents to scan.
- * @param {string[]} seenParents out-param, pushed for each parent that exists.
- *   Callers use it for their own anti-vacuity accounting; ignore it if not.
- * @returns {{ rel: string, dir: string, pkgJson: unknown }[]}
+ * @returns {{ packages: { rel: string, dir: string, pkgJson: unknown }[],
+ *   seenParents: string[] }} `seenParents` lists the parents that exist, for
+ *   the callers' own anti-vacuity accounting. It is returned rather than filled
+ *   through an out-param, and it is not derivable from `packages`: a parent can
+ *   exist and hold no package at all.
  */
-export function listWorkspacePackages(root, fail, parents = PACKAGE_PARENTS, seenParents = []) {
+export function listWorkspacePackages(root, fail, parents) {
   const out = [];
+  const seenParents = [];
   for (const parent of parents) {
     const parentDir = join(root, parent);
     if (!existsOrThrow(parentDir, 'package parent', fail)) continue;
@@ -79,5 +87,5 @@ export function listWorkspacePackages(root, fail, parents = PACKAGE_PARENTS, see
       out.push({ rel: `${parent}/${name}`, dir: pkgDir, pkgJson });
     }
   }
-  return out;
+  return { packages: out, seenParents };
 }

--- a/scripts/lib/list-workspace-packages.mjs
+++ b/scripts/lib/list-workspace-packages.mjs
@@ -125,6 +125,11 @@ export function listWorkspacePackages(root, fail, parents) {
         pkgJson = JSON.parse(raw);
       } catch (err) {
         fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
+        // The read branch above is not the only way in. With a `fail` that
+        // returns, a MALFORMED manifest reached this same catch and the package
+        // was pushed with `pkgJson: undefined` - the identical corruption,
+        // through the parse branch instead of the read one.
+        throw err;
       }
       out.push({ rel: `${parent}/${name}`, dir: pkgDir, pkgJson });
     }

--- a/scripts/lib/list-workspace-packages.mjs
+++ b/scripts/lib/list-workspace-packages.mjs
@@ -59,7 +59,24 @@ export function listWorkspacePackages(root, fail, parents) {
     const parentDir = join(root, parent);
     if (!existsOrThrow(parentDir, 'package parent', fail)) continue;
     seenParents.push(parent);
-    for (const name of readdirSync(parentDir).sort()) {
+    // existsOrThrow answers "is it there", and for a DIRECTORY that is all it
+    // can answer: the mode bits gate opendir(3), not stat(2), so a mode-000
+    // parent stats clean and the refusal above never fires for the case its
+    // own label names. Unguarded, the scandir below then threw a raw EACCES
+    // with no gate message at all. Both halves are needed, and neither
+    // subsumes the other: stat catches a MISSING or non-directory parent,
+    // this catches an unreadable one.
+    let entries;
+    try {
+      entries = readdirSync(parentDir).sort();
+    } catch (err) {
+      fail(
+        `cannot read package parent ${parentDir}: ${err.code || err.message}. ` +
+          'Refusing to treat an unreadable parent as an empty one -- that is how ' +
+          'every package under it drops out of the audit at once.',
+      );
+    }
+    for (const name of entries) {
       // Skipping a dotfile is a CONSEQUENCE of a rule this code does not yet
       // read, not a rule of its own: pnpm-workspace.yaml's globs are
       // `packages/*`, `apps/*`, `examples/*`, and a bare `*` never matches a
@@ -78,9 +95,23 @@ export function listWorkspacePackages(root, fail, parents) {
       const pkgDir = join(parentDir, name);
       const pkgJsonPath = join(pkgDir, 'package.json');
       if (!existsOrThrow(pkgJsonPath, 'package manifest', fail)) continue;
+      // Read and parse are separate so they cannot be reported as each other.
+      // Folded together, an unreadable manifest came back as "is not valid
+      // JSON: EACCES", sending the reader to fix syntax on a file whose syntax
+      // is fine -- and the `cannot read package manifest` message above is
+      // unreachable for a mode-000 FILE, since statSync succeeds on one.
+      let raw;
+      try {
+        raw = readFileSync(pkgJsonPath, 'utf8');
+      } catch (err) {
+        fail(
+          `cannot read package manifest ${pkgJsonPath}: ${err.code || err.message}. ` +
+            'Refusing to treat an unreadable manifest as an absent one.',
+        );
+      }
       let pkgJson;
       try {
-        pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+        pkgJson = JSON.parse(raw);
       } catch (err) {
         fail(`${pkgJsonPath} is not valid JSON: ${err.message}`);
       }

--- a/scripts/lib/list-workspace-packages.test.mjs
+++ b/scripts/lib/list-workspace-packages.test.mjs
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The shared walk's refusals, under a `fail` that RETURNS.
+ *
+ * Both gates' `fail` throws, so nothing reachable through them exercises what
+ * happens if one ever stops. That is the whole point of the rethrows in
+ * `list-workspace-packages.mjs`: without them a soft `fail` prints the message
+ * and then CONTINUES, and the package this module exists to protect enters the
+ * counted population with `pkgJson: undefined`. Measured, that is not a
+ * hypothetical - it is what the code did before those lines.
+ *
+ * Deleting any of the three rethrows left every other test in `scripts/` green,
+ * which is why this file exists rather than another case in the gate suites.
+ *
+ * Run: node --test scripts/lib/list-workspace-packages.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { listWorkspacePackages } from './list-workspace-packages.mjs';
+
+/** Prints and RETURNS, the way a gate's `fail` must never be written. */
+function softFail(messages) {
+  return (message) => { messages.push(message); };
+}
+
+function withTree(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'list-workspace-packages-'));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function seed(root, manifest = '{"name":"alpha"}') {
+  mkdirSync(join(root, 'packages/alpha'), { recursive: true });
+  writeFileSync(join(root, 'packages/alpha/package.json'), manifest);
+}
+
+test('the happy path returns the package and the parent it came from', () => {
+  withTree((root) => {
+    seed(root);
+    const messages = [];
+    const { packages, seenParents } = listWorkspacePackages(root, softFail(messages), ['packages']);
+    assert.deepEqual(packages.map((p) => p.rel), ['packages/alpha']);
+    assert.deepEqual(seenParents, ['packages']);
+    assert.deepEqual(messages, [], 'nothing should have been refused here');
+  });
+});
+
+test('an unreadable package PARENT throws rather than returning a short population', (t) => {
+  if (process.platform === 'win32') return t.skip('chmod 000 does not block traversal on Windows');
+  if (process.getuid?.() === 0) return t.skip('root traverses every directory regardless of mode');
+  withTree((root) => {
+    seed(root);
+    const parent = join(root, 'packages');
+    chmodSync(parent, 0o000);
+    try {
+      const messages = [];
+      // Asserts the ORIGINAL fs error escapes, not merely that SOMETHING did.
+      // Without the rethrow this still threw - `entries` stayed undefined and
+      // the `for...of` below died with a TypeError - so a bare assert.throws
+      // passed on the wrong error and the test could not fail. Pinning the
+      // errno is what makes it discriminate.
+      assert.throws(
+        () => listWorkspacePackages(root, softFail(messages), ['packages']),
+        (err) => err.code === 'EACCES',
+        'the fs error itself must escape, not a TypeError from undefined entries',
+      );
+      assert.match(messages[0] ?? '', /cannot read package parent/);
+    } finally {
+      chmodSync(parent, 0o755);
+    }
+  });
+});
+
+test('an unreadable MANIFEST throws rather than admitting a package with no pkgJson', (t) => {
+  if (process.platform === 'win32') return t.skip('chmod does not gate reads on Windows');
+  if (process.getuid?.() === 0) return t.skip('root reads a 000 file regardless of mode');
+  withTree((root) => {
+    seed(root);
+    const manifest = join(root, 'packages/alpha/package.json');
+    chmodSync(manifest, 0o000);
+    try {
+      const messages = [];
+      // The one that corrupts rather than merely confusing: without the rethrow
+      // this returned [{rel:'packages/alpha', pkgJson: undefined}].
+      assert.throws(
+        () => listWorkspacePackages(root, softFail(messages), ['packages']),
+        (err) => err.code === 'EACCES',
+      );
+      assert.match(messages[0] ?? '', /cannot read package manifest/);
+    } finally {
+      chmodSync(manifest, 0o644);
+    }
+  });
+});
+
+test('a MALFORMED manifest throws too, and says syntax rather than unreadable', () => {
+  withTree((root) => {
+    seed(root, '{oops');
+    const messages = [];
+    // The sibling hole: same corruption, reached through the parse branch.
+    assert.throws(
+      () => listWorkspacePackages(root, softFail(messages), ['packages']),
+      (err) => err instanceof SyntaxError,
+    );
+    assert.match(messages[0] ?? '', /is not valid JSON/);
+    assert.doesNotMatch(messages[0] ?? '', /cannot read package manifest/);
+  });
+});
+
+test('an ABSENT parent is skipped, not refused', () => {
+  withTree((root) => {
+    seed(root);
+    const messages = [];
+    const { packages, seenParents } = listWorkspacePackages(root, softFail(messages), ['packages', 'apps']);
+    assert.deepEqual(packages.map((p) => p.rel), ['packages/alpha']);
+    assert.deepEqual(seenParents, ['packages'], 'apps/ does not exist, so it is not a seen parent');
+    assert.deepEqual(messages, [], 'absent is not unreadable');
+  });
+});

--- a/scripts/lib/list-workspace-packages.test.mjs
+++ b/scripts/lib/list-workspace-packages.test.mjs
@@ -127,3 +127,32 @@ test('an ABSENT parent is skipped, not refused', () => {
     assert.deepEqual(messages, [], 'absent is not unreadable');
   });
 });
+
+test('a .DS_Store FILE is skipped, and a non-dotfile ENOTDIR is still refused', () => {
+  // The skip and the refusal have to ship together. macOS drops a `.DS_Store`
+  // FILE into any Finder-opened directory; statting `.DS_Store/package.json`
+  // raises ENOTDIR, which existsOrThrow refuses correctly and by design - so
+  // without the leading-dot skip this walk is a flake generator, and #3350
+  // fixed exactly that in three sibling gates.
+  //
+  // Both directions in ONE tree, because the tempting way to kill the flake is
+  // to catch ENOTDIR and continue, which deletes the refusal outright. That
+  // edit passes a dotfile-only test and fails this one.
+  withTree((root) => {
+    seed(root);
+    writeFileSync(join(root, 'packages/.DS_Store'), 'finder junk');
+    const messages = [];
+    const { packages } = listWorkspacePackages(root, softFail(messages), ['packages']);
+    assert.deepEqual(packages.map((p) => p.rel), ['packages/alpha'], 'the real package survives');
+    assert.deepEqual(messages, [], 'a dotfile must not be refused, it is not a package');
+
+    // Same ENOTDIR shape without the leading dot: this one MUST refuse.
+    writeFileSync(join(root, 'packages/notadir'), 'a file where a package dir should be');
+    const messages2 = [];
+    assert.throws(
+      () => listWorkspacePackages(root, softFail(messages2), ['packages']),
+      (err) => err.code === 'ENOTDIR',
+    );
+    assert.match(messages2[0] ?? '', /cannot read package manifest/);
+  });
+});

--- a/scripts/typecheck-tests.mjs
+++ b/scripts/typecheck-tests.mjs
@@ -255,14 +255,13 @@ const USAGE_LINES = [
  * Are these the same directory?
  *
  * `path.resolve` is the whole answer on every path this is actually reached
- * through. The realpath fallback is defence for platforms this was not measured
- * on, NOT a case that occurs here: four invocations were tried on macOS - cd
- * through a symlink, the same with --preserve-symlinks, invoking through the
- * link from the real directory, and that with --preserve-symlinks - and
- * `resolve` matched in all four, because getcwd(3) already returns the resolved
- * path and Node's ESM loader realpaths the module URL. The one live caller
- * passes `process.cwd()`, so `pkgDir` is a realpath by construction. Costs one
- * pair of syscalls, once per run.
+ * through, so the realpath fallback runs zero syscalls in practice. It is kept
+ * as defence for platforms this was not measured on: four invocations were
+ * tried on macOS - cd through a symlink, the same with --preserve-symlinks,
+ * invoking through the link from the real directory, and that with
+ * --preserve-symlinks - and `resolve` matched in all four, because getcwd(3)
+ * already returns the resolved path and Node's ESM loader realpaths the module
+ * URL. Only the symlink test reaches the fallback today.
  */
 function samePath(a, b) {
   if (path.resolve(a) === path.resolve(b)) return true;

--- a/scripts/typecheck-tests.mjs
+++ b/scripts/typecheck-tests.mjs
@@ -252,12 +252,17 @@ const USAGE_LINES = [
 ];
 
 /**
- * Do `a` and `b` name the same directory?
+ * Are these the same directory?
  *
- * `process.cwd()` reports the REALPATH while REPO_ROOT is derived from this
- * file's own URL, so a symlinked checkout spells one directory two ways and a
- * string compare misses — and missing here admits exactly the run the caller
- * below refuses. Same reasoning as `rootReal` in scripts/check-changesets.mjs.
+ * `path.resolve` is the whole answer on every path this is actually reached
+ * through. The realpath fallback is defence for platforms this was not measured
+ * on, NOT a case that occurs here: four invocations were tried on macOS - cd
+ * through a symlink, the same with --preserve-symlinks, invoking through the
+ * link from the real directory, and that with --preserve-symlinks - and
+ * `resolve` matched in all four, because getcwd(3) already returns the resolved
+ * path and Node's ESM loader realpaths the module URL. The one live caller
+ * passes `process.cwd()`, so `pkgDir` is a realpath by construction. Costs one
+ * pair of syscalls, once per run.
  */
 function samePath(a, b) {
   if (path.resolve(a) === path.resolve(b)) return true;

--- a/scripts/typecheck-tests.mjs
+++ b/scripts/typecheck-tests.mjs
@@ -33,7 +33,13 @@
  *
  * Usage:
  *   node ../../scripts/typecheck-tests.mjs     (cwd = a package; the per-package `typecheck` script)
+ *   node scripts/typecheck-tests.mjs --all     (cwd = repo root; every package)
  *   node scripts/typecheck-tests.mjs --audit   (cwd = repo root; the repo-wide coverage gate)
+ *
+ * The no-argument form reads the CURRENT DIRECTORY as one package, so run bare
+ * from the repo root it used to type-check the whole repository as a single
+ * program (#3362). `repoRootRefusal` below refuses that; see it for what was
+ * measured.
  *
  * ANTI-VACUITY (#3194, #3200). `--audit` used to print
  * `TOTAL 0 / 0` followed by `every test file on disk is in a typecheck
@@ -59,7 +65,7 @@
  */
 
 import { execFile } from 'node:child_process';
-import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -238,9 +244,82 @@ async function tsc(args) {
   }
 }
 
+/** The three real ways to run this, printed by every refusal below. */
+const USAGE_LINES = [
+  `    cd <package> && node ../../scripts/${SCRIPT_NAME}   (that one package)`,
+  `    node scripts/${SCRIPT_NAME} --all                   (every package)`,
+  `    node scripts/${SCRIPT_NAME} --audit                 (repo-wide coverage gate)`,
+];
+
+/**
+ * Do `a` and `b` name the same directory?
+ *
+ * `process.cwd()` reports the REALPATH while REPO_ROOT is derived from this
+ * file's own URL, so a symlinked checkout spells one directory two ways and a
+ * string compare misses — and missing here admits exactly the run the caller
+ * below refuses. Same reasoning as `rootReal` in scripts/check-changesets.mjs.
+ */
+function samePath(a, b) {
+  if (path.resolve(a) === path.resolve(b)) return true;
+  try {
+    return realpathSync(a) === realpathSync(b);
+  } catch {
+    // One of them cannot be resolved, so they are not provably the same path.
+    // Reported by the caller that actually reads it, not swallowed here.
+    return false;
+  }
+}
+
+/**
+ * Why the repo root is not a package: the message, or null when `pkgDir` is fine.
+ *
+ * `parseCliMode` already refuses the ARGUMENT form of this mistake — `node
+ * scripts/typecheck-tests.mjs packages/clash` from the root used to ignore its
+ * argument and fall through to the cwd branch. The CWD form was left open, and
+ * it is the same substitution with the argument omitted: `node
+ * scripts/typecheck-tests.mjs` run bare from the root takes zero arguments,
+ * which `parseCliMode` accepts as `package` mode, and `checkOnePackage` then
+ * reads the REPOSITORY as the package. Measured on this tree (#3362): it wrote
+ * a 1,520-line /tsconfig.tests.json naming 1,505 test files and handed the lot
+ * to one tsc invocation, printing nothing at all while it did so.
+ *
+ * #3363 added that path to .gitignore, which was right for diff noise and which
+ * also removed the last visible symptom — an untracked file someone would
+ * notice. A guard is what is left.
+ *
+ * Exported for its unit test: like `parseCliMode`, every wrong answer here is
+ * invisible at the call site, because the script runs and reports on something
+ * other than what was asked for.
+ *
+ * @param {string} pkgDir
+ * @param {string} [repoRoot]
+ * @returns {string | null}
+ */
+export function repoRootRefusal(pkgDir, repoRoot = REPO_ROOT) {
+  if (!samePath(pkgDir, repoRoot)) return null;
+  return [
+    `${SCRIPT_NAME}: refusing to treat the repository root as a package.`,
+    '',
+    '  The no-argument mode checks the CURRENT DIRECTORY as one package, and',
+    `  ${pkgDir} is the repo root. Running it there builds a single tsconfig`,
+    '  program naming every test file in the repo and type-checks them all at',
+    '  once, which is not what any caller has ever wanted (#2664, #3362).',
+    '',
+    '  You probably meant one of:',
+    ...USAGE_LINES,
+  ].join('\n');
+}
+
 /** Per-package mode: generate this package's test program and check it. */
 async function checkOnePackage(pkgDir) {
-  const name = path.relative(REPO_ROOT, pkgDir) || path.basename(pkgDir);
+  const refusal = repoRootRefusal(pkgDir);
+  if (refusal) {
+    console.error(refusal);
+    return 2;
+  }
+  // Never empty: `path.relative` returns '' only for the repo root itself, and
+  // the refusal above is the only way past this line.
+  const name = path.relative(REPO_ROOT, pkgDir);
   const program = writeTestProgram(pkgDir);
   if (!program) {
     console.log(`typecheck-tests: ${name} has no test files, nothing to check`);
@@ -586,9 +665,7 @@ if (invokedDirectly) {
     console.error(`${SCRIPT_NAME}: ${parsed.error}.`);
     console.error('');
     console.error('  This script takes no package argument. Usage:');
-    console.error(`    cd <package> && node ../../scripts/${SCRIPT_NAME}   (that one package)`);
-    console.error(`    node scripts/${SCRIPT_NAME} --all                   (every package)`);
-    console.error(`    node scripts/${SCRIPT_NAME} --audit                 (repo-wide coverage gate)`);
+    for (const line of USAGE_LINES) console.error(line);
     exitCode = 2;
   } else if (parsed.mode === 'audit') exitCode = await audit();
   else if (parsed.mode === 'all') exitCode = await checkAll();

--- a/scripts/typecheck-tests.test.mjs
+++ b/scripts/typecheck-tests.test.mjs
@@ -32,9 +32,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { relativeExtends, parseCliMode, auditVacuity, audit } from './typecheck-tests.mjs';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { relativeExtends, parseCliMode, auditVacuity, audit, repoRootRefusal } from './typecheck-tests.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 test('a sibling base config is ./-prefixed, not bare', () => {
   // The repo-root case: pkgDir and the base config are the same directory.
@@ -455,5 +459,113 @@ test('audit(): an empty tree names every parent it looked for', async () => {
     assert.match(stderr, /none of packages\/, apps\/ and examples\/ exists under/);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ---- The repo root is not a package (#3362).
+//
+// `parseCliMode` already refuses the ARGUMENT form of this mistake: `node
+// scripts/typecheck-tests.mjs packages/clash` from the root used to ignore its
+// argument and fall through to the cwd branch. The CWD form is the same
+// substitution with the argument left off, and it was still open: zero
+// arguments is a legal `package` mode, so `checkOnePackage(process.cwd())` read
+// the REPOSITORY as the package. Measured on this tree before the guard, from
+// the repo root with no arguments:
+//
+//   tsconfig.tests.json written at the repo root: 1,520 lines, 1,505 test
+//   files listed, and not one line of output while it happened.
+//
+// #3363 gitignored that path — correct for diff noise, and it removed the last
+// visible symptom, which is why the guard has to exist rather than the file
+// being noticed.
+//
+// The unit cases below pin the path arithmetic; the spawn case below them pins
+// that `checkOnePackage` actually consults it, which is the half a guard placed
+// only in `parseCliMode` would leave undone.
+
+test('the repo root itself is refused (issue 3362)', () => {
+  const message = repoRootRefusal('/repo', '/repo');
+  assert.ok(message, 'the repo root must be refused, not treated as a package');
+  assert.match(message, /refusing to treat the repository root as a package/);
+});
+
+test('the refusal says what the caller probably meant (issue 3362)', () => {
+  const message = repoRootRefusal('/repo', '/repo');
+  assert.match(message, /--audit/, 'names the repo-wide coverage gate');
+  assert.match(message, /--all/, 'names the every-package run');
+  assert.match(message, /cd <package>/, 'names the single-package run');
+});
+
+test('a trailing slash and a `.` segment are the same directory (issue 3362)', () => {
+  assert.ok(repoRootRefusal('/repo/', '/repo'), 'a trailing slash must not spell a different directory');
+  assert.ok(repoRootRefusal('/repo/./', '/repo'), 'a `.` segment must not spell a different directory');
+  assert.ok(repoRootRefusal('/repo/packages/..', '/repo'), 'a `..` segment must not spell a different directory');
+});
+
+test('a real package directory is not refused (issue 3362)', () => {
+  assert.equal(repoRootRefusal('/repo/packages/clash', '/repo'), null);
+  assert.equal(repoRootRefusal('/repo/apps/viewer', '/repo'), null);
+  // A directory whose path merely STARTS with the root is not the root.
+  assert.equal(repoRootRefusal('/repo-two', '/repo'), null);
+});
+
+test('the default root is the repo this script lives in, not a guess (issue 3362)', () => {
+  // Called with ONE argument, the way checkOnePackage calls it. If the default
+  // resolved anywhere other than the repo root, every case above would still
+  // pass while the live guard pointed at nothing.
+  assert.ok(repoRootRefusal(REPO_ROOT), 'the default repoRoot must be the repository root');
+  assert.equal(repoRootRefusal(path.join(REPO_ROOT, 'packages')), null);
+});
+
+test('a symlinked spelling of the repo root is still the repo root (issue 3362)', () => {
+  // `process.cwd()` reports the realpath while REPO_ROOT comes from this file's
+  // own URL, so a symlinked checkout spells one directory two ways. A plain
+  // string compare misses, and missing here admits the run being refused.
+  const dir = mkdtempSync(path.join(tmpdir(), 'typecheck-tests-symlink-'));
+  const link = path.join(dir, 'repo');
+  try {
+    symlinkSync(REPO_ROOT, link, 'dir');
+    assert.ok(repoRootRefusal(link), 'a symlink to the repo root must be refused too');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('running it bare from the repo root refuses and writes no program (issue 3362)', async () => {
+  // The end-to-end half. A guard that exists but that checkOnePackage never
+  // calls passes every unit case above and still writes the 1,505-file program.
+  const generated = path.join(REPO_ROOT, 'tsconfig.tests.json');
+  // Never a legitimate artifact after this guard, and the file's own header
+  // says it is generated and must not be committed, so clearing a leftover from
+  // an older run is safe.
+  rmSync(generated, { force: true });
+
+  const child = spawn(process.execPath, ['scripts/typecheck-tests.mjs'], { cwd: REPO_ROOT });
+  let out = '';
+  child.stdout.on('data', (d) => { out += d; });
+  child.stderr.on('data', (d) => { out += d; });
+
+  // Without the guard the program appears within about a second and tsc then
+  // runs for minutes. Watch for the file and for the clock, so this case FAILS
+  // rather than hangs when the guard is missing.
+  let wroteProgram = false;
+  const watcher = setInterval(() => {
+    if (existsSync(generated)) {
+      wroteProgram = true;
+      child.kill('SIGKILL');
+    }
+  }, 100);
+  const deadline = setTimeout(() => child.kill('SIGKILL'), 30_000);
+  const code = await new Promise((resolve) => child.on('exit', resolve));
+  clearInterval(watcher);
+  clearTimeout(deadline);
+
+  try {
+    assert.equal(wroteProgram, false, `it wrote ${generated}: the repository was treated as a package`);
+    assert.equal(code, 2, `expected exit 2, got ${code}: ${out}`);
+    assert.match(out, /refusing to treat the repository root as a package/);
+    assert.doesNotMatch(out, /has no test files, nothing to check/, 'it must refuse, not report a vacuous pass');
+  } finally {
+    rmSync(generated, { force: true });
   }
 });


### PR DESCRIPTION
Closes #3347. Closes #3362. Two gates that could not say no.

## #3347 — an unreadable package left the audit silently

`check-test-wiring.mjs` discovered packages with `existsSync(pkgJsonPath)`, which returns false for **every** failure, not just ENOENT. So a package whose manifest could not be read was dropped from the audit and the gate reported OK.

That gate is what fails when a package has test files but no `test` script, so `turbo test` skips it. Which means: **a package whose tests never run read exactly like a healthy package.**

Measured on a synthetic tree, and this is the damage rather than the mechanism:

```
E. package `gamma` has test files, no `test` script, readable
   EXIT=1  ❌ Packages with test files but no `test` script … gamma
F. the same package, chmod 000
   EXIT=0  ✅ OK (1 packages, ...)
```

Becoming unreadable was all it took to turn the finding off.

The refusal is now shared at `scripts/lib/exists-or-throw.mjs`, with `fail` injected so each gate keeps its own prefix and error type. `check-test-glob-coverage.mjs` moved onto it too.

## #3362 — the repository treated as a package

`node scripts/typecheck-tests.mjs` run bare from the repo root wrote a **1520-line, 1505-file** program to `/tsconfig.tests.json` in about half a second, silently. That is the #2664 misuse the script's own header documents, and `parseCliMode` already refused the *argument* form of it but not the *cwd* form.

PR #3363 had just added that path to `.gitignore` — correct for diff-noise reasons, but it removed the last visible symptom. Now it refuses, naming `--audit` / `--all` / `cd <package>`.

## The walk is shared too, not just the refusal

Extracting `existsOrThrow` alone shared 15 lines and left 32 duplicated: `listPackages` became byte-identical in both gates. `/simplify` caught that, and the first commit's own docstring had already made the argument — two walks kept in agreement by whoever remembers to edit both "is not a property, it is a habit, and #3347 is what it costs."

`scripts/lib/list-workspace-packages.mjs` now owns the walk. It also states the invariant the review distilled, which is narrower and more useful than "be loud everywhere":

> unreadable must never shrink a population a gate reports a count of

That is why a refusal and a calibrated floor are **alternatives, not a hierarchy** — `verify-npm-publish.js` and `lib/rust-major-offset.mjs` are right to warn-and-floor instead.

## Two things deliberately not done

**`scripts/docs/check-package-readmes.mjs` keeps its own copy of the refusal.** Two reviews ranked folding it in as their top finding, both noting the repo already documents it as a duplicate. Neither checked why. Its harness `copyFileSync`s **that one file** into a synthetic tree, so it must stay import-free beyond node builtins — migrating it turned all 9 of its tests red while the gate still passed against the real repo. The constraint is now written in the file.

**Each gate keeps its own `PACKAGE_PARENTS` literal.** Hoisting it shrank CI path coverage, because `deriveInputs` reads a gate's own source and does not follow imports:

```
before hoist  check-test-wiring.mjs:  .github apps node_modules package.json packages scripts
after hoist   check-test-wiring.mjs:  .github node_modules package.json scripts
```

The allowlist row that then stopped matching had not become unnecessary — the coverage it exempted had disappeared. `scripts/ci-path-coverage-allowlist.txt` is byte-identical to main (0 diff lines), and the census reads **288 derived paths against main's 287**.

## Verification

Every wrong fix breaks a test, checked explicitly:

| wrong fix | result |
|---|---|
| `existsOrThrow` catches ENOTDIR and continues | 6 tests fail, from both sides of the shared helper |
| adopt the refusal, omit the dotfile skip | reproduces #3350's trap live: `packages/.DS_Store/package.json: ENOTDIR` |
| #3362 guard on the argument form only | **1 of 37** fails — only the spawned case, which is why it exists |

1056 script tests, `check-test-wiring`, `check-test-glob-coverage`, `check-package-readmes`, `check-ci-path-coverage`, `typecheck-tests --audit` and `pnpm lint`: all green.

No changeset: `scripts/` only, no workspace member. Read from `check-changesets.mjs`'s own doctrine rather than assumed.

## Follow-ups filed

**#3362**'s sibling observation is already recorded there. The review also named three enumerators with neither a refusal nor a floor — `release-version-changed.mjs` first, then `check-api-surface.mjs` and `verify-esm-entrypoints.mjs` — under the invariant above. Worth their own PRs rather than widening this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace package discovery across application and package directories.
  - Added fail-closed handling for missing, unreadable, malformed, or invalid package metadata.
  - Prevented type-check commands from running against the repository root without a specific package.
  - Improved diagnostics for invalid command-line arguments and unreadable configuration files.

- **Tests**
  - Expanded coverage for filesystem errors, symlinks, hidden files, package discovery, and command-line validation.
  - Added safeguards confirming correct exit codes and preventing unintended configuration generation.

- **Documentation**
  - Clarified documentation for standalone package README checks and workspace package listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
