### PR TITLE
fix(source-dalux): route a different-node Dalux download link through the relay

### DIFF
--- a/.changeset/dalux-field-node-download-cors.md
+++ b/.changeset/dalux-field-node-download-cors.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/source-dalux': patch
+---
+
+Fix "Failed to fetch" downloading a Dalux Box file for an account on a node other than node1.
+
+`download()` falls back to a `downloadLink`/revision-content URL Dalux hands back when the file carries no known revision id. For an account on, say, node2, that URL points straight at `node2.field.dalux.com` — not the canonical `node1.field.dalux.com` origin every request in this provider is otherwise built against. The client only ever routed URLs matching that canonical origin through the app's same-origin relay, so this one went out as a direct cross-origin fetch to Dalux, which sends no CORS headers on any node, and the browser blocked it.
+
+`getBinary` now recognises a Dalux field-node-shaped URL that lands on a *different* node than `baseUrl` and reroutes it back onto the canonical origin with that node stamped as the relay's `daluxNode` parameter, the same way an explicit node preference is already stamped onto same-origin requests. A genuinely different host (an opaque signed CDN link) is still left byte-for-byte untouched.

--- a/packages/source-dalux/src/http-client.ts
+++ b/packages/source-dalux/src/http-client.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import type { PluginContext } from '@ifc-lite/plugin-api';
+import { canonicalFieldNodeUrl } from './node-url.js';
 
 export interface DaluxCredentials {
   readonly baseUrl: string;
@@ -171,13 +172,12 @@ export class BrowserDaluxApiClient {
     // Missing it here would send file downloads to the default node while
     // listings went to the user's own — the failure would look like "the file
     // is gone" rather than "wrong host".
-    // Only re-serialise when we actually added the selector. `new URL(x)
-    // .toString()` is NOT identity: it strips a default port, normalises `.`
-    // and `..` path segments and can re-case percent escapes, any of which
-    // changes a URL whose signature was computed over the original string.
-    // Round-tripping unconditionally would have re-broken the exact links the
-    // stamping guard above exists to protect.
-    const url = this.nodeSelectorFor(rawUrl) ?? rawUrl;
+    // Only re-serialise when we added the selector or rerouted onto the
+    // canonical origin (`canonicalFieldNodeUrl`, #3308) — `new URL(x)
+    // .toString()` is NOT identity, so doing it unconditionally would
+    // re-break the signed links the guard above protects.
+    const url =
+      this.nodeSelectorFor(rawUrl) ?? canonicalFieldNodeUrl(rawUrl, this.credentials.baseUrl) ?? rawUrl;
     this.debug('binary GET request', { url });
     const response = await this.ctx.fetch(url, {
       headers: {

--- a/packages/source-dalux/src/node-url.ts
+++ b/packages/source-dalux/src/node-url.ts
@@ -86,7 +86,13 @@ export function canonicalFieldNodeUrl(rawUrl: string, baseUrl: string): string |
   }
   const base = new URL(baseUrl);
   if (parsed.origin === base.origin) return undefined; // caller's own-origin path
-  if (!parsed.pathname.startsWith(base.pathname)) return undefined;
+  // Boundary-checked, not a bare `startsWith`: with a base path of
+  // `/service/api`, a bare prefix test also admits the SIBLING path
+  // `/service/api-v2/...`, which is a different API surface and would be
+  // rerouted through the relay as if it were ours. Match the path exactly, or
+  // at a `/` boundary.
+  const basePath = base.pathname.endsWith('/') ? base.pathname.slice(0, -1) : base.pathname;
+  if (parsed.pathname !== basePath && !parsed.pathname.startsWith(`${basePath}/`)) return undefined;
   const node = daluxFieldNode(parsed.hostname);
   if (!node) return undefined;
   parsed.protocol = base.protocol;

--- a/packages/source-dalux/src/node-url.ts
+++ b/packages/source-dalux/src/node-url.ts
@@ -46,3 +46,51 @@ export function parseDaluxNode(raw: string | undefined | null): string | undefin
   }
   return match[1] === 'node1' ? undefined : match[1];
 }
+
+/** Matches a Dalux field-node hostname exactly, e.g. `node2.field.dalux.com`. */
+const DALUX_NODE_HOST_PATTERN = /^(node[1-9][0-9]{0,2})\.field\.dalux\.com$/;
+
+/**
+ * Returns the node name if `hostname` is a Dalux field node, or `undefined`
+ * otherwise.
+ *
+ * Unlike {@link parseDaluxNode} this never throws: it is used to
+ * opportunistically recognise a Dalux-shaped URL the API itself handed back
+ * (a `downloadLink`), not to validate user input, so an unrecognised host is
+ * simply "not a Dalux field node" rather than an error.
+ */
+export function daluxFieldNode(hostname: string): string | undefined {
+  return DALUX_NODE_HOST_PATTERN.exec(hostname)?.[1];
+}
+
+/**
+ * Reroutes a `rawUrl` on a *different* Dalux field node than `baseUrl` back
+ * onto `baseUrl`'s origin, stamping that node as `daluxNode` — or
+ * `undefined` if `rawUrl` isn't field-node-shaped.
+ *
+ * A `downloadLink`/revision-content value from a non-node1 account points
+ * straight at that node using our own `/service/api` shape — not always the
+ * opaque, differently-hosted link `BrowserDaluxApiClient.nodeSelectorFor`
+ * describes. Untouched it never matches the relay's upstream, so the
+ * browser fetches Dalux directly and CORS blocks it (#3308). The node comes
+ * from `rawUrl` itself, which is authoritative; re-serialising is safe
+ * because the relay rebuilds the request from the forwarded path/query
+ * regardless of `rawUrl`'s exact bytes.
+ */
+export function canonicalFieldNodeUrl(rawUrl: string, baseUrl: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return undefined;
+  }
+  const base = new URL(baseUrl);
+  if (parsed.origin === base.origin) return undefined; // caller's own-origin path
+  if (!parsed.pathname.startsWith(base.pathname)) return undefined;
+  const node = daluxFieldNode(parsed.hostname);
+  if (!node) return undefined;
+  parsed.protocol = base.protocol;
+  parsed.host = base.host;
+  parsed.searchParams.set('daluxNode', node);
+  return parsed.toString();
+}

--- a/packages/source-dalux/test/node-url.test.ts
+++ b/packages/source-dalux/test/node-url.test.ts
@@ -223,4 +223,24 @@ describe('canonicalFieldNodeUrl', () => {
   it('returns undefined for an unparseable URL', () => {
     expect(canonicalFieldNodeUrl('not a url', baseUrl)).toBeUndefined();
   });
+
+  // A bare `startsWith(base.pathname)` also admits a SIBLING path: with a base
+  // of `/service/api`, `/service/api-v2/...` shares the prefix without being
+  // under it. That is a different API surface, and rerouting it through the
+  // relay would send a request we do not own to our own origin.
+  it('returns undefined for a sibling path that merely shares the base prefix', () => {
+    expect(
+      canonicalFieldNodeUrl('https://node2.field.dalux.com/service/api-v2/2.0/x', baseUrl),
+    ).toBeUndefined();
+    expect(
+      canonicalFieldNodeUrl('https://node2.field.dalux.com/service/apiary/x', baseUrl),
+    ).toBeUndefined();
+  });
+
+  it('still accepts the base path exactly, and a real child of it', () => {
+    expect(canonicalFieldNodeUrl('https://node2.field.dalux.com/service/api', baseUrl)).toBeDefined();
+    expect(
+      canonicalFieldNodeUrl('https://node2.field.dalux.com/service/api/2.0/x', baseUrl),
+    ).toBeDefined();
+  });
 });

--- a/packages/source-dalux/test/node-url.test.ts
+++ b/packages/source-dalux/test/node-url.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { parseDaluxNode } from '../src/node-url.js';
+import { canonicalFieldNodeUrl, daluxFieldNode, parseDaluxNode } from '../src/node-url.js';
 import { BrowserDaluxApiClient } from '../src/http-client.js';
 
 describe('parseDaluxNode', () => {
@@ -128,5 +128,99 @@ describe('node stamping is scoped to the relay', () => {
     const lookalike = 'https://node1.field.dalux.com.evil.com/service/api/2.0/x/content';
     await client.getBinary(lookalike);
     expect(seen[0]).toBe(lookalike);
+  });
+
+  it('reroutes a downloadLink pointing at a different Dalux field node through the relay origin (#3308)', async () => {
+    // A customer whose account lives on node2 (not node1) sees Dalux hand
+    // back a `downloadLink`/revision-content URL built on THEIR node, using
+    // the same `/service/api` REST shape our own requests use — this is not
+    // the opaque-CDN-link case the tests above cover. `baseUrl` is always the
+    // canonical node1 origin (see `provider.ts#createClient`), so this URL's
+    // origin never matches it. Left alone, it would never be rewritten onto
+    // the same-origin relay by the host (`applyRelay` in `host-fetch.ts`
+    // only rewrites URLs starting with the declared relay upstream, node1),
+    // and the browser would attempt a direct cross-origin fetch to Dalux —
+    // which fails, because Dalux sends no CORS headers from any node. The
+    // fix must land it back on the node1 origin with the real node stamped
+    // as `daluxNode`, exactly like the node-preference case above.
+    const seen: string[] = [];
+    const ctx = {
+      fetch: async (url: string) => {
+        seen.push(url);
+        return new Response(new ArrayBuffer(2), { status: 200 });
+      },
+      log: { debug() {}, error() {}, info() {}, warn() {} },
+    } as unknown as ConstructorParameters<typeof BrowserDaluxApiClient>[1];
+
+    // No `node` preference set — the account's node preference is
+    // irrelevant here; what matters is the node baked into the URL itself.
+    const client = new BrowserDaluxApiClient(
+      { baseUrl: 'https://node1.field.dalux.com/service/api', apiKey: 'k' },
+      ctx,
+    );
+
+    const otherNodeLink =
+      'https://node2.field.dalux.com/service/api/2.0/projects/p1/file_areas/fa1/files/f1/revisions/r1/content?Signature=abc';
+    await client.getBinary(otherNodeLink);
+
+    expect(seen[0]).not.toBe(otherNodeLink);
+    const fetched = new URL(seen[0]);
+    expect(fetched.origin).toBe('https://node1.field.dalux.com');
+    expect(fetched.pathname).toBe('/service/api/2.0/projects/p1/file_areas/fa1/files/f1/revisions/r1/content');
+    expect(fetched.searchParams.get('daluxNode')).toBe('node2');
+    expect(fetched.searchParams.get('Signature')).toBe('abc');
+  });
+});
+
+describe('daluxFieldNode', () => {
+  it('recognises a Dalux field-node hostname', () => {
+    expect(daluxFieldNode('node1.field.dalux.com')).toBe('node1');
+    expect(daluxFieldNode('node2.field.dalux.com')).toBe('node2');
+    expect(daluxFieldNode('node10.field.dalux.com')).toBe('node10');
+  });
+
+  it('rejects anything that is not exactly a Dalux field node', () => {
+    for (const host of [
+      'cdn.dalux.com',
+      'node1.field.dalux.com.evil.com',
+      'node0.field.dalux.com',
+      'field.dalux.com',
+      'evil.com',
+    ]) {
+      expect(daluxFieldNode(host), host).toBeUndefined();
+    }
+  });
+});
+
+describe('canonicalFieldNodeUrl', () => {
+  const baseUrl = 'https://node1.field.dalux.com/service/api';
+
+  it('rewrites a different-node URL onto baseUrl, stamping the real node', () => {
+    const result = canonicalFieldNodeUrl(
+      'https://node3.field.dalux.com/service/api/2.0/x/content?a=b',
+      baseUrl,
+    );
+    expect(result).toBeDefined();
+    const url = new URL(result!);
+    expect(url.origin).toBe('https://node1.field.dalux.com');
+    expect(url.pathname).toBe('/service/api/2.0/x/content');
+    expect(url.searchParams.get('daluxNode')).toBe('node3');
+    expect(url.searchParams.get('a')).toBe('b');
+  });
+
+  it('returns undefined for a URL already on baseUrl’s origin', () => {
+    expect(canonicalFieldNodeUrl('https://node1.field.dalux.com/service/api/2.0/x', baseUrl)).toBeUndefined();
+  });
+
+  it('returns undefined for a host that is not a Dalux field node', () => {
+    expect(canonicalFieldNodeUrl('https://cdn.dalux.com/files/abc?Signature=x', baseUrl)).toBeUndefined();
+  });
+
+  it('returns undefined when the path does not share the base path', () => {
+    expect(canonicalFieldNodeUrl('https://node2.field.dalux.com/other/2.0/x', baseUrl)).toBeUndefined();
+  });
+
+  it('returns undefined for an unparseable URL', () => {
+    expect(canonicalFieldNodeUrl('not a url', baseUrl)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3308 — "Dalux box integration Failed to fetch".

The reporter's console output pins the failure mode precisely:

```
Access to fetch at 'https://node2.field.dalux.com/service/api/2.0/projects/.../revisions/.../content'
from origin 'https://www.ifclite.com' has been blocked by CORS policy: ... No
'Access-Control-Allow-Origin' header is present ...
```

This is a browser-level CORS preflight failure, not a proxy/credential issue. The failing URL's path shape (`/2.0/projects/.../file_areas/.../files/.../revisions/.../content`) matches the template `download()` builds for both its `revisionId` path and its `downloadLink` fallback path — but the host is `node2`, not the canonical `node1` that every request in this provider is otherwise pinned to (`DEFAULT_BASE_URL` in `provider.ts`). That combination is only reachable through the `downloadLink` fallback: Dalux itself returns that link built on the customer's *own* field node when the account isn't on node1.

`packages/source-dalux/src/http-client.ts`'s `getBinary` deliberately leaves a URL alone when its origin doesn't match `baseUrl` — by design, so it doesn't corrupt an opaque, differently-hosted, possibly-signed link (a CDN download, say). But a Dalux field-node URL on a *different* node than node1 is not that case: it's the same `/service/api` shape our own requests use, just hosted on the account's real node. Left untouched, it never matches `apps/viewer/src/services/sources/host-fetch.ts`'s `applyRelay` (which only rewrites URLs starting with the declared relay upstream, always node1), so the browser fetches Dalux directly — and Dalux sends no CORS headers from any node, not just node1.

## Fix

`getBinary` now tries, in order:
1. `nodeSelectorFor` (existing) — stamps the account's node preference onto a same-origin (node1) URL.
2. `canonicalFieldNodeUrl` (new, `node-url.ts`) — recognises a `nodeN.field.dalux.com/service/api/...` URL on a *different* node than `baseUrl`, and rewrites it onto the canonical origin with that node stamped as `daluxNode`, so `applyRelay` picks it up. The node comes from the URL itself (authoritative), not the account's node preference.
3. Otherwise the raw URL passes through byte-for-byte unchanged (a genuinely different host, e.g. a signed CDN link).

Sibling connectors checked (`source-dropbox`, `source-msgraph`): neither uses a multi-node relay — Dropbox uses CORS-safe endpoints directly, Graph is a single global CORS-enabled host — so this class of bug doesn't apply to them.

## What's verified vs. what needs a live call

- **Verified by test**: the URL construction — that a different-node `downloadLink`/revision-content URL is now rewritten to `node1.field.dalux.com` origin with `daluxNode=<real node>` set and other query params (e.g. a signature) preserved, and that an opaque foreign-host link is still passed through unchanged.
- **Not verified here** (no live Dalux credentials available): that the app's actual deployed relay (`server/sources/dalux-relay.ts` / `api/dalux.ts`) then successfully forwards that rewritten request to the real `node2.field.dalux.com` and returns file bytes. That relay-forwarding path is unchanged by this PR and was already covered by its own tests (`tests/api/dalux-relay.test.ts`).

## Test plan

- [x] `pnpm --filter @ifc-lite/source-dalux test` — 163 passed, 12 skipped (RED before the fix: the new reroute test failed as expected against unmodified `http-client.ts`)
- [x] `pnpm --filter @ifc-lite/source-dalux typecheck` and `build` — clean
- [x] `node scripts/check-module-size.mjs` — exits 0 (`http-client.ts` trimmed back to its 411-line budget by moving the new logic into `node-url.ts`, which has headroom)
- [x] `node scripts/check-changesets.mjs` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dalux file downloads when revision information is unavailable by using the provided download link.
  * Fixed downloads from alternate Dalux field nodes by routing them through the correct origin.
  * Preserved signed CDN links without unnecessary URL changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->