### PR TITLE
fix(viewer): drop the face-picked custom section plane on a session reset

### DIFF
--- a/.changeset/section-plane-custom-reset.md
+++ b/.changeset/section-plane-custom-reset.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix a session reset (loading a new primary file) leaving the section tool's face-picked custom plane in place.
+
+`sectionSlice`'s teardown reset `axis`/`position`/`enabled`/`flipped` to their defaults but left `custom` untouched. `custom` (`normal`, `distance`, `pickedAt`, `tangent`, `bitangent`) is absolute world-space geometry read off the outgoing model's coordinate frame — strictly more model-relative than the four fields the reset already cleared. Face-picking an arbitrary-normal section plane and then loading a different file kept the old model's cut plane instead of arming face-pick mode for the new one.
+
+The teardown now rebuilds `sectionPlane` from its defaults on every session reset and carries forward only the three fields that round-trip through localStorage (`showCap`, `showOutlines`, `capStyle`), instead of spreading the live plane and overwriting individual session-scoped fields by name. A future session-scoped field on `SectionPlane` therefore defaults to cleared on reset unless it is deliberately added to that keep-list.

--- a/apps/viewer/src/store/resetViewerState.sectionMode.test.ts
+++ b/apps/viewer/src/store/resetViewerState.sectionMode.test.ts
@@ -81,4 +81,27 @@ describe('resetViewerState — drops the persisted cross-session section mode (#
     assert.strictEqual(after.capStyle.spacingPx, 12, 'cap style is a UI preference, must survive a model swap');
     assert.strictEqual(after.showCap, false, 'showCap is a UI preference, must survive a model swap');
   });
+
+  it('drops a face-picked custom plane — it is absolute world-space geometry from the outgoing model (#3365)', () => {
+    // Face-pick an arbitrary (non-cardinal) plane against "model A". Every
+    // field of `custom` — normal, distance, pickedAt, tangent, bitangent —
+    // is world-space geometry read off model A's coordinate frame, strictly
+    // MORE model-relative than the cardinal axis/position fields the reset
+    // already clears two blocks up.
+    useViewerStore.getState().setSectionPlaneFromFace([1, 2, 3], [10, 20, 30]);
+    const before = useViewerStore.getState().sectionPlane;
+    assert.notStrictEqual(before.custom, undefined, 'precondition: the face pick committed a custom plane');
+
+    // Same call every primary file load makes before loading "model B".
+    useViewerStore.getState().resetViewerState();
+
+    const after = useViewerStore.getState().sectionPlane;
+    assert.strictEqual(
+      after.custom,
+      undefined,
+      'a session reset must drop the custom plane along with axis/position/enabled/flipped — ' +
+      'it is model-relative geometry too, and the reset already treats a cardinal-axis change ' +
+      '(setSectionPlaneAxis) as invalidating it at a smaller scope',
+    );
+  });
 });

--- a/apps/viewer/src/store/slices/sectionSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.teardown.ts
@@ -10,8 +10,16 @@
  * ratchets down only.
  *
  * This is the store's canonical Trap B: ONE value, `sectionPlane`, holds both
- * session-scoped and persisted fields, so the teardown spreads the live plane
- * instead of replacing it. See the field comment below.
+ * session-scoped and persisted fields. Rather than spread the live plane and
+ * overwrite each session-scoped field by name — which is how #3365 happened,
+ * `custom` being model-relative geometry that nobody remembered to list next
+ * to `axis`/`position`/`enabled`/`flipped` — this builds the result as an
+ * ALLOWLIST: start from the slice's own defaults (every field session-scoped
+ * by construction) and carry forward only the three fields that are
+ * genuinely persisted. A future field added to `SectionPlane` therefore
+ * defaults to CLEARED on a session reset unless someone deliberately opts it
+ * into the keep-list below, instead of silently surviving the way `custom`
+ * did.
  *
  * `sectionPickMode` and `sectionPickPreview` are NOT reset by any of today's
  * four teardown paths, so they are absent from both `owns` and the body.
@@ -26,7 +34,6 @@
  */
 
 import { defineSliceTeardown } from '../teardown.js';
-import { SECTION_PLANE_DEFAULTS } from '../constants.js';
 import { getDefaultSectionPlane } from './sectionSlice.js';
 
 export const sectionTeardown = defineSliceTeardown(
@@ -37,24 +44,26 @@ export const sectionTeardown = defineSliceTeardown(
     // one model, so neither removing a model nor clearing them all moves it.
     if (scope.kind !== 'session-reset') return {};
 
+    // The `??` is for the partial-store harness (`TeardownState` is a
+    // `Partial<ViewerState>`): with no live plane to read from, the slice's
+    // own initial value is by definition the right answer for the fields
+    // being kept too.
+    const live = state.sectionPlane ?? getDefaultSectionPlane();
+
     return {
-      // Section plane: reset axis/position/enabled/flipped (those are
-      // model-relative and meaningless when switching files), but PRESERVE
-      // the user's cap appearance preferences (showCap, showOutlines,
-      // capStyle). Those round-trip to localStorage via the slice's
-      // persistence helpers; clobbering them here was the cause of "my
-      // hatch / colour resets to defaults every time I open a file".
-      //
-      // The `??` is for the partial-store harness (`TeardownState` is a
-      // `Partial<ViewerState>`): with no live plane to spread, the slice's own
-      // initial value is by definition the right answer, and it re-reads the
-      // same persisted fields.
+      // Keep ONLY the user's cut-surface appearance preferences — showCap,
+      // showOutlines, capStyle. Those round-trip to localStorage via the
+      // slice's persistence helpers; clobbering them here was the cause of
+      // "my hatch / colour resets to defaults every time I open a file".
+      // Everything else (axis, position, enabled, flipped, custom) is
+      // model-relative and meaningless against a different model, so it
+      // comes from `getDefaultSectionPlane()` rather than being spread from
+      // `live` and then patched field by field.
       sectionPlane: {
-        ...(state.sectionPlane ?? getDefaultSectionPlane()),
-        axis:     SECTION_PLANE_DEFAULTS.AXIS,
-        position: SECTION_PLANE_DEFAULTS.POSITION,
-        enabled:  SECTION_PLANE_DEFAULTS.ENABLED,
-        flipped:  SECTION_PLANE_DEFAULTS.FLIPPED,
+        ...getDefaultSectionPlane(),
+        showCap:      live.showCap,
+        showOutlines: live.showOutlines,
+        capStyle:     live.capStyle,
       },
     };
   },


### PR DESCRIPTION
## Summary
- `sectionSlice`'s teardown reset `axis`/`position`/`enabled`/`flipped` on a session reset but left `custom` untouched. `custom` (`normal`, `distance`, `pickedAt`, `tangent`, `bitangent`) is absolute world-space geometry from the outgoing model — strictly more model-relative than the four fields already cleared — so a face-picked section plane survived into the next loaded file.
- Rebuilds the teardown's `sectionPlane` as an allowlist: start from the slice's own defaults (every field session-scoped by construction) and carry forward only the three persisted fields (`showCap`, `showOutlines`, `capStyle`), instead of spreading the live plane and overwriting session-scoped fields one by one. A future session-scoped field on `SectionPlane` now defaults to cleared on reset unless it's deliberately added to the keep-list.

Refs #3365.

## Test plan
- [x] `npx tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 src/store/resetViewerState.sectionMode.test.ts` — RED against the pre-fix `sectionSlice.teardown.ts` (2 pass, 1 fail: the new `#3365` assertion), GREEN after restoring the fix (3/3 pass).
- [x] Same runner over `src/store/resetViewerState.sectionMode.test.ts`, `src/store/slices/sectionSlice.test.ts`, `src/store/teardown-registry.test.ts`, `src/store/teardown.idempotence.test.ts` — 86/86 pass.
- [x] `node scripts/check-module-size.mjs` — exit 0.
- [x] `git status --porcelain` clean before push.

## Sibling issues (report only, not fixed here)
- #3364 (`pendingCameraRotation` surviving a session reset) is the same shape: a field silently absent from a slice's session-reset teardown clear-list.
- #3348 (`clearAllModels` leaving `EntityRef`-keyed selection state) is the same general shape, in the `all-models-cleared` arm rather than `session-reset`.
- #3346 (per-slice `Object.is` idempotence gate) and #3345 (a fourth `TeardownScope` kind silently no-opping) are different failure modes — not "a field missing from a clear-list."
- With this fix plus #3364/#3348 and the already-fixed camera `interactionMode` case, that's four instances of the same shape; a structural fix (e.g. an allowlist/keep-list pattern like this PR's, or the `owns`-driven record shape #3345 proposes) is worth considering separately, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436