### PR TITLE
fix(geometry): close small boundary gaps consolidate leaves on overlapping/rotated operands

### DIFF
--- a/.changeset/close-micro-gaps-issue-3353.md
+++ b/.changeset/close-micro-gaps-issue-3353.md
@@ -1,0 +1,13 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+Close small boundary gaps the exact CSG kernel leaves on overlapping and rotated operand pairs.
+
+Issue #3353: after the #3341 parity-segment fix closed the disjoint/touching tear family, a separate family survived on overlapping and rotated operand pairs. Reproduced with a sweep of rotated-cutter / axis-aligned-host box pairs across Difference, Union and Intersection, watertightness checked by welding the output at 0.1 mm and counting directed half-edges that fail to pair one-forward/one-reverse (a net-signed tally can cancel a real non-manifold seam to zero).
+
+On one pinned case the raw kernel output is already watertight and `consolidate_coplanar`'s per-bucket independent re-triangulation is what tears it: the same boundary vertex comes out of two adjacent buckets a few hundred micrometres apart, because the bucket's own boundary within an axis-aligned plane is skewed by a rotated cutter. On another the raw arrangement output is already torn before consolidation ever runs. In both, the open edges' endpoints sit within a fraction of a millimetre of a vertex that should have been the same point.
+
+`close_micro_gaps` (`rust/geometry/src/csg/consolidate.rs`) is a bounded, last-resort weld applied to whatever `consolidate_coplanar` is about to return: it runs only when that mesh already has an open boundary edge at 0.1 mm, so a sound mesh is returned untouched. When it runs, it welds vertices within a small multiple of the exact kernel's own snap grid (comfortably above the measured gaps, comfortably below any real feature) and keeps the weld only if it strictly reduces the open-edge count without increasing spike-triangle count. This is a repair, not a gate: unlike the closed-in/closed-out enforcement already tried and rejected for `ClippingProcessor::validate_mesh` (measured to regress the corpus watertightness census), a weld that does not help is simply discarded and the mesh returned exactly as it was — no cut is ever thrown away.
+
+This does not close the whole family #3353 reports. The randomized sweep used to find it still measures a residual, smaller tear rate afterward; at least one case has open edges tens of millimetres apart that a vertex weld cannot fix, pointing at a deeper near-degenerate arrangement defect the issue's own investigation had already flagged as unproven. Two concrete cases the fix does close completely are pinned in `rust/geometry/tests/issue_3353_rotated_overlap_tearing.rs`.

--- a/rust/geometry/src/csg/consolidate.rs
+++ b/rust/geometry/src/csg/consolidate.rs
@@ -93,6 +93,47 @@ fn count_spike_triangles(mesh: &Mesh) -> usize {
     n
 }
 
+/// Issue #3353: a bounded, last-resort weld that closes small boundary gaps
+/// left by the exact kernel and its consolidation on overlapping / rotated
+/// operand pairs. Runs ONLY when `mesh` already has an open boundary edge at
+/// the 0.1 mm grid `count_open_boundary_edges_at` already uses elsewhere in
+/// this file for the cross-bucket seam conform, so a mesh that is closed at
+/// that resolution is returned byte-identical — this can only change an
+/// ALREADY-torn result, never a sound one.
+///
+/// The measured cause (traced on a reproduction of #3353, a rotated cutter
+/// against an axis-aligned host) is two vertices meant to be the same point —
+/// one bucket's earcut and its neighbour's, or two near-degenerate exact
+/// intersections in the raw arrangement itself — differing by a few hundred
+/// micrometres, well under any real feature this crate triangulates and well
+/// over the exact kernel's own snap grid (`SNAP_GRID`, ~15 µm at unit scale).
+/// The weld radius is a small multiple of that grid: comfortably above the
+/// measured gaps, comfortably below a real seam.
+///
+/// This is a REPAIR, not a gate: unlike the closed-in/closed-out enforcement
+/// tried and rejected for `ClippingProcessor::validate_mesh` (measured to
+/// regress the watertightness census), a rejected weld here falls back to the
+/// mesh exactly as it already was — no cut is ever discarded.
+fn close_micro_gaps(mesh: Mesh) -> Mesh {
+    if mesh.indices.len() < 6 || count_open_boundary_edges_at(&mesh, 1.0e4) == 0 {
+        return mesh; // already sound at 0.1 mm — untouched, no weld attempted
+    }
+    let tol = (crate::kernel::mesh_bridge::SNAP_GRID * 128.0) as f32; // ~1.95 mm at unit scale
+    let before_open = count_open_boundary_edges(&mesh);
+    let before_bad = before_open + count_spike_triangles(&mesh);
+    let welded = mesh.welded_by_position(tol);
+    let after_open = count_open_boundary_edges(&welded);
+    let after_bad = after_open + count_spike_triangles(&welded);
+    // Only keep the weld where it measurably helps: strictly fewer open edges
+    // AND no worse overall than the badness score `consolidate_coplanar`
+    // already uses to choose between raw and consolidated output.
+    if after_open < before_open && after_bad <= before_bad {
+        welded
+    } else {
+        mesh
+    }
+}
+
 impl ClippingProcessor {
     /// Re-merge the kernel's per-plane fragments via 2D polygon union, then
     /// earcut each result back to triangles. CSG over-fragments host faces
@@ -107,7 +148,20 @@ impl ClippingProcessor {
     ///
     /// Returns the input mesh unchanged if the consolidate fails or yields
     /// nothing — never worse than the raw kernel output.
+    ///
+    /// Issue #3353: a family of tears survives the #3341 parity fix on
+    /// overlapping and rotated operand pairs, some already present in the RAW
+    /// kernel output (upstream of this function) rather than introduced by the
+    /// per-bucket re-triangulation below. [`close_micro_gaps`] is a bounded,
+    /// last-resort repair applied to whichever mesh this function is about to
+    /// return: it runs ONLY when that mesh already has open boundary edges, so
+    /// it can only ever change an already-torn result and is a byte-identical
+    /// no-op on the (overwhelming majority) watertight case.
     pub(crate) fn consolidate_coplanar(mesh: Mesh) -> Mesh {
+        close_micro_gaps(Self::consolidate_coplanar_inner(mesh))
+    }
+
+    fn consolidate_coplanar_inner(mesh: Mesh) -> Mesh {
         use crate::grid::NORMAL_QUANT_F64 as NORMAL_QUANT;
         use crate::triangulation::project_to_2d_with_basis;
         use i_overlay::core::fill_rule::FillRule;

--- a/rust/geometry/tests/issue_3353_rotated_overlap_tearing.rs
+++ b/rust/geometry/tests/issue_3353_rotated_overlap_tearing.rs
@@ -1,0 +1,174 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Issue #3353: a family of boolean tears survives the #3341 parity fix on
+//! OVERLAPPING and ROTATED operand pairs (#3341 fixed the disjoint/touching
+//! family only).
+//!
+//! Both pinned cases below are real failures found by a randomized sweep of
+//! 60000 axis-aligned-host / rotated-cutter box pairs across Difference,
+//! Union and Intersection, watertightness checked by welding the OUTPUT at
+//! 0.1 mm and counting DIRECTED half-edges that do not pair 1-forward/
+//! 1-reverse (a net-signed tally can cancel a real non-manifold seam to zero,
+//! the same finding this repo already records for
+//! `processors/boolean/chain_cycle_tests.rs`).
+//!
+//! `proptest_shrunk`: raw kernel output is already watertight; the tear is
+//! introduced by `consolidate_coplanar`'s per-bucket independent
+//! re-triangulation emitting the same boundary vertex twice, a few hundred
+//! micrometres apart, on an axis-aligned host bucket whose boundary within
+//! that bucket is skewed by the rotated cutter.
+//!
+//! `sweep_261`: a larger, multi-bucket case with the same signature.
+//!
+//! This does NOT close the whole family #3353 reports (rotated + overlapping
+//! tear at 0.08-0.38% pre-fix; the sweep in this file's history still finds a
+//! residual, smaller-magnitude rate after `close_micro_gaps` — see
+//! `.changeset/close-micro-gaps-issue-3353.md`). The two cases pinned here are
+//! cases the fix in `csg/consolidate.rs::close_micro_gaps` closes completely.
+
+use ifc_lite_geometry::{ClippingProcessor, Mesh};
+use nalgebra::{Point3, Rotation3, Unit, Vector3};
+use std::collections::HashMap;
+
+/// Outward-wound axis-aligned box. Diagonal-split tessellation, matching
+/// `touching_operand.rs`'s `boxed` helper — NOT the kernel's own `box_mesh`
+/// tessellation, which splits the two quads the other way and would move
+/// every face centroid enough that these pinned cases stop reproducing.
+fn boxed(min: [f64; 3], size: [f64; 3], rot: Option<(Vector3<f64>, f64, [f64; 3])>) -> Mesh {
+    let mx = [min[0] + size[0], min[1] + size[1], min[2] + size[2]];
+    let c = |i: usize| -> [f64; 2] { [min[i], mx[i]] };
+    let mut corners: Vec<Point3<f64>> = [
+        (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0),
+        (0, 0, 1), (1, 0, 1), (1, 1, 1), (0, 1, 1),
+    ]
+    .iter()
+    .map(|&(i, j, k)| Point3::new(c(0)[i], c(1)[j], c(2)[k]))
+    .collect();
+    if let Some((axis, angle, about)) = rot {
+        let r = Rotation3::from_axis_angle(&Unit::new_normalize(axis), angle);
+        let o = Point3::new(about[0], about[1], about[2]);
+        for p in corners.iter_mut() {
+            *p = o + r * (*p - o);
+        }
+    }
+    let faces: [[usize; 4]; 6] = [
+        [0, 3, 2, 1], [4, 5, 6, 7], [0, 1, 5, 4],
+        [2, 3, 7, 6], [0, 4, 7, 3], [1, 2, 6, 5],
+    ];
+    let mut m = Mesh::with_capacity(24, 36);
+    for f in &faces {
+        let e1 = corners[f[1]] - corners[f[0]];
+        let e2 = corners[f[2]] - corners[f[0]];
+        let n = e1.cross(&e2).try_normalize(1e-12).unwrap_or(Vector3::z());
+        let b = m.vertex_count() as u32;
+        for &i in f {
+            m.add_vertex(corners[i], n);
+        }
+        m.add_triangle(b, b + 1, b + 2);
+        m.add_triangle(b, b + 2, b + 3);
+    }
+    m
+}
+
+/// Watertightness, counting the two directions SEPARATELY after welding by
+/// position at 0.1 mm. See the module doc for why a net-signed tally is not
+/// enough.
+fn open_edges(m: &Mesh) -> Result<usize, String> {
+    if m.is_empty() {
+        return Err("host was deleted entirely".to_string());
+    }
+    let welded = m.welded_by_position(1e-4);
+    let mut edges: HashMap<(u32, u32), (u32, u32)> = HashMap::new();
+    for tri in welded.indices.chunks_exact(3) {
+        for k in 0..3 {
+            let (a, b) = (tri[k], tri[(k + 1) % 3]);
+            if a == b {
+                return Err(format!("degenerate edge: triangle repeats welded vertex {a}"));
+            }
+            let e = edges.entry((a.min(b), a.max(b))).or_insert((0, 0));
+            if a < b {
+                e.0 += 1;
+            } else {
+                e.1 += 1;
+            }
+        }
+    }
+    Ok(edges.values().filter(|&&(f, r)| f != 1 || r != 1).count())
+}
+
+struct Case {
+    name: &'static str,
+    a_min: [f64; 3],
+    a_size: [f64; 3],
+    b_min: [f64; 3],
+    b_size: [f64; 3],
+    axis: [f64; 3],
+    angle: f64,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "proptest_shrunk",
+        a_min: [-1.6304261474312827, -1.3635631291487638, -0.5409381305938963],
+        a_size: [2.9769341489955012, 0.7727152845317564, 1.385780304417514],
+        b_min: [-1.635036035905773, -2.126505357416188, -1.273167972967614],
+        b_size: [3.649752006027041, 2.1022053843017137, 3.615608517082627],
+        axis: [-0.31681812426035605, 0.8964131053231463, -0.8569595303250017],
+        angle: 0.17698030735721204,
+    },
+    Case {
+        name: "sweep_261",
+        a_min: [-1.72371594746207, -0.35246108913603935, -1.2204342720208154],
+        a_size: [2.8534163464770894, 3.0795194627753784, 2.858202766048261],
+        b_min: [-2.5947221996202225, 0.7995282321488091, -1.1895637752048271],
+        b_size: [3.215043208338911, 0.9570224289084479, 3.548848436777412],
+        axis: [0.413429423622099, -0.8221765971936017, -0.6789513492042303],
+        angle: 1.3791241095493956,
+    },
+];
+
+/// The property: an overlapping, rotated cutter must not tear the host open.
+/// Checked over Difference, Union and Intersection, since #3353 found the
+/// family in all three ops.
+#[test]
+fn overlapping_rotated_operands_never_tear() {
+    let clipper = ClippingProcessor::new();
+    let mut failures = Vec::new();
+    for case in CASES {
+        let a = boxed(case.a_min, case.a_size, None);
+        let about = [
+            case.b_min[0] + case.b_size[0] / 2.0,
+            case.b_min[1] + case.b_size[1] / 2.0,
+            case.b_min[2] + case.b_size[2] / 2.0,
+        ];
+        let b = boxed(
+            case.b_min,
+            case.b_size,
+            Some((Vector3::new(case.axis[0], case.axis[1], case.axis[2]), case.angle, about)),
+        );
+        assert_eq!(open_edges(&a), Ok(0), "{}: operand A must be closed going in", case.name);
+        assert_eq!(open_edges(&b), Ok(0), "{}: operand B must be closed going in", case.name);
+
+        for (opname, out) in [
+            ("Difference", clipper.subtract_mesh(&a, &b)),
+            ("Union", clipper.union_mesh(&a, &b)),
+            ("Intersection", clipper.intersection_mesh(&a, &b)),
+        ] {
+            let out = out.expect("boolean op must not error");
+            match open_edges(&out) {
+                Err(why) => failures.push(format!("{} {opname}: {why}", case.name)),
+                Ok(0) => {}
+                Ok(bad) => {
+                    failures.push(format!("{} {opname}: {bad} unmatched edges", case.name))
+                }
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "a closed-in operand pair must come back closed-out:\n  {}",
+        failures.join("\n  ")
+    );
+}


### PR DESCRIPTION
## Summary

- Refs #3353. A family of boolean tears survives the #3341 parity-segment fix on overlapping and rotated operand pairs. Reproduced with a sweep of rotated-cutter / axis-aligned-host box pairs over Difference, Union and Intersection, watertightness checked by welding the output at 0.1 mm and counting directed half-edges that fail to pair one-forward/one-reverse.
- On one pinned case (`proptest_shrunk`) the raw kernel output is already watertight; `consolidate_coplanar`'s per-bucket independent re-triangulation is what tears it, emitting the same boundary vertex twice from adjacent buckets a few hundred micrometres apart. On another (`sweep_261`) the raw arrangement output is already torn before consolidation runs at all.
- `close_micro_gaps` (`rust/geometry/src/csg/consolidate.rs`) is a bounded, last-resort weld applied to whatever `consolidate_coplanar` is about to return: it fires only when that mesh already has an open boundary edge at 0.1 mm (a sound mesh returns byte-identical), and it keeps the weld only when it strictly reduces the open-edge count without increasing spike-triangle count. This is a repair, not a gate — unlike the closed-in/closed-out enforcement already tried and rejected for `ClippingProcessor::validate_mesh` (measured to regress the corpus watertightness census), a weld that doesn't help is simply discarded and the mesh returned exactly as it was.
- This does **not** close the whole #3353 family. The sweep still measures a residual, smaller tear rate after the fix, and at least one case has open-edge endpoints too far apart for a vertex weld to fix — pointing at a deeper near-degenerate arrangement defect the issue's own investigation had already flagged as unproven.

## Root cause

Two vertices meant to be the same point — one bucket's earcut output and its neighbour's, or two near-degenerate exact intersections in the raw arrangement itself — differ by a few hundred micrometres: well under any real feature this crate triangulates, well over the exact kernel's own snap grid.

## Test plan

- [x] New pinned regression: `rust/geometry/tests/issue_3353_rotated_overlap_tearing.rs` — two real cases from a 60000-pair sweep, checked across Difference/Union/Intersection.
- [x] RED confirmed: reverting `close_micro_gaps` locally fails the new test (`sweep_261 Union: 3 unmatched edges`); restoring it passes.
- [x] `cargo test -p ifc-lite-geometry` — full crate suite green, no failures.
- [x] `cargo test -p ifc-lite-geometry --test touching_operand --test csg_property_test --test csg_quality_regression --test issue_3353_rotated_overlap_tearing` — all pass (no regression on the #3341 gates or the existing quality/watertightness regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436