### PR TITLE
fix(core,geometry,export): collapse three STEP comment-skip rules that disagreed on an unterminated `/*`

### DIFF
--- a/.changeset/collapse-step-comment-skip.md
+++ b/.changeset/collapse-step-comment-skip.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Three places in `rust/` hand-rolled "skip a STEP `/* ... */` comment" and answered an unterminated `/*` three different ways. The entity scanner (`rust/core`) already refused rather than read past it; the `IfcTriangulatedFaceSet` CoordIndex reader (`rust/geometry`) instead silently consumed the rest of the entity's bytes looking for a close that would never come. Neither of those two had a reason to differ from the other — both are walking already-located record bytes, not a header prescan — so this collapses them onto one shared rule, `ifc_lite_core::skip_step_comment`, which refuses. The geometry crate's CoordIndex reader now refuses the same way the scanner already did, instead of scanning past the end of a corrupt record.
+
+`rust/export`'s STEP HEADER prescan answers the same question differently on purpose (an unterminated `/*` there is treated as ordinary text, because a header prescan that swallows every later record has lost the schema, which is worse than the malformed input deserves) — see the doc comment on `source_header::Lex::skip_comment_at`. That call site now finds a *closed* comment's end via the same shared function too; only its own unterminated-comment answer stays its own.

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -96,7 +96,7 @@ pub use legacy_entities::{
     LEGACY_ENTITY_NAMES,
 };
 pub use model_bounds::{scan_model_bounds, scan_placement_bounds, ModelBounds};
-pub use parser::{entity_count, parse_entity, EntityScanner, Token};
+pub use parser::{entity_count, parse_entity, skip_step_comment, EntityScanner, Token};
 pub use project_units::{
     measure::{measure_unit, MeasureUnit},
     resolve_unit_by_ref, ProjectUnits, ResolvedUnit,

--- a/rust/core/src/parser/lexical.rs
+++ b/rust/core/src/parser/lexical.rs
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The STEP `/* ... */` comment-skip rule, shared by every scanner that has
+//! no reason to answer an unterminated comment differently from the others.
+//!
+//! [`skip_step_comment`] answers an unterminated `/*` by refusing it: it
+//! returns `None`, the same as "not a comment here" from the caller's point
+//! of view. That is correct for a scanner walking already-located,
+//! well-formed record bytes looking for structure — an unterminated comment
+//! there means the input is corrupt, and silently consuming the rest of it
+//! is worse than stopping. [`super::scanner::EntityScanner`] and
+//! `ifc-lite-geometry`'s `IfcTriangulatedFaceSet` CoordIndex walk both used
+//! to hand-roll this and disagreed with each other on exactly this case
+//! (issue #3303); both now call this one function.
+//!
+//! `ifc-lite-export`'s STEP HEADER prescan (`source_header::Lex`) answers the
+//! same question differently, on purpose, and that is not the divergence
+//! #3303 is about: a header prescan that swallows every later record has
+//! lost the schema, so it treats an unterminated `/*` as ordinary text
+//! instead of refusing. See the doc comment on `Lex::skip_comment_at` for
+//! why that call site needs its own answer. It still calls this function to
+//! find where a *closed* comment ends — only the unterminated case is
+//! handled differently, and only at that one call site.
+
+/// If a STEP `/* ... */` comment starts at `bytes[i]`, the index just past
+/// its closing `*/`.
+///
+/// Returns `None` when `bytes[i]` doesn't begin a comment, and ALSO when it
+/// does but no closing `*/` exists anywhere in `bytes` after it — an
+/// unterminated comment is refused rather than silently run to end of input.
+/// A caller that needs to tell those two `None` cases apart already knows
+/// which one it's in, from having checked `bytes[i..i + 2] == b"/*"` itself
+/// before calling (as every call site in this repo does), so the single
+/// `Option` return doesn't lose information.
+#[inline]
+pub fn skip_step_comment(bytes: &[u8], i: usize) -> Option<usize> {
+    if bytes.get(i) != Some(&b'/') || bytes.get(i + 1) != Some(&b'*') {
+        return None;
+    }
+    let len = bytes.len();
+    let mut p = i + 2;
+    while p + 1 < len {
+        // Find the next '*'; check whether it's followed by '/'.
+        let star = match memchr::memchr(b'*', &bytes[p..]) {
+            Some(off) => p + off,
+            None => return None, // unterminated comment
+        };
+        if star + 1 < len && bytes[star + 1] == b'/' {
+            return Some(star + 2);
+        }
+        p = star + 1;
+    }
+    None // unterminated comment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closed_comment_skips_to_after_close() {
+        let bytes = b"/* hello #77 */rest";
+        assert_eq!(skip_step_comment(bytes, 0), Some(15));
+        assert_eq!(&bytes[15..], b"rest");
+    }
+
+    #[test]
+    fn adjacent_asterisks_inside_a_comment_do_not_confuse_the_scan() {
+        let bytes = b"/* a ** weird *comment* */tail";
+        let end = skip_step_comment(bytes, 0).expect("comment is closed");
+        assert_eq!(&bytes[end..], b"tail");
+    }
+
+    #[test]
+    fn unterminated_comment_is_refused() {
+        assert_eq!(skip_step_comment(b"/* never closes", 0), None);
+        assert_eq!(skip_step_comment(b"/*", 0), None);
+        assert_eq!(skip_step_comment(b"/* trailing star *", 0), None);
+    }
+
+    #[test]
+    fn not_a_comment_at_all() {
+        assert_eq!(skip_step_comment(b"/x not a comment", 0), None);
+        assert_eq!(skip_step_comment(b"/", 0), None);
+        assert_eq!(skip_step_comment(b"", 0), None);
+    }
+}

--- a/rust/core/src/parser/mod.rs
+++ b/rust/core/src/parser/mod.rs
@@ -10,9 +10,16 @@
 //! - [`tokenizer`]: nom-combinator tokenization ([`Token`], [`parse_entity`]).
 //! - [`scanner`]: a byte-level SIMD fast scanner ([`EntityScanner`]) that does
 //!   its own hand-rolled parsing and never touches [`Token`] or nom.
+//!
+//! [`lexical`] holds one small piece shared by both, and by other crates:
+//! [`skip_step_comment`] is the STEP `/* ... */` comment-skip rule, in one
+//! place so every scanner that has no reason to answer "what does an
+//! unterminated comment mean" differently gives the same answer (#3303).
 
+mod lexical;
 mod scanner;
 mod tokenizer;
 
+pub use lexical::skip_step_comment;
 pub use scanner::{entity_count, EntityScanner};
 pub use tokenizer::{parse_entity, Token};

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -100,24 +100,12 @@ impl<'a> EntityScanner<'a> {
                 // past `*/`; if not, it's a STEP arithmetic '/' inside a
                 // value list (rare; just step past it).
                 if candidate + 1 < len && bytes[candidate + 1] == b'*' {
-                    let mut p = candidate + 2;
-                    while p + 1 < len {
-                        // Find next '*'; check if followed by '/'.
-                        let from = p;
-                        let star = match memchr::memchr(b'*', &bytes[from..]) {
-                            Some(off) => from + off,
-                            None => return None, // unterminated comment
-                        };
-                        if star + 1 < len && bytes[star + 1] == b'/' {
-                            self.position = star + 2;
-                            break;
-                        }
-                        p = star + 1;
-                    }
-                    if self.position <= candidate {
-                        // Comment never closed — refuse to scan further.
-                        return None;
-                    }
+                    // An unterminated `/*` here means corrupt input.
+                    // `skip_step_comment` refuses (returns `None`) rather
+                    // than silently consuming the rest of the file — see
+                    // its doc comment for why that's the right call for a
+                    // scanner (issue #3303).
+                    self.position = super::lexical::skip_step_comment(bytes, candidate)?;
                     continue;
                 }
                 // Lone '/' — not a comment. Skip past.

--- a/rust/export/src/source_header.rs
+++ b/rust/export/src/source_header.rs
@@ -107,8 +107,13 @@ impl<'a> Lex<'a> {
             return None;
         }
         self.searches += 1;
-        match self.bytes[i + 2..].windows(2).position(|w| w == b"*/") {
-            Some(close) => Some(i + 2 + close + 2),
+        // Finding where a *closed* comment ends is the same question every
+        // STEP scanner in this repo answers the same way; `skip_step_comment`
+        // is that shared answer (issue #3303). Only the unterminated case —
+        // `no_closer` below — is this call site's own, deliberately
+        // different from `EntityScanner`'s; see the type doc above.
+        match ifc_lite_core::skip_step_comment(self.bytes, i) {
+            Some(end) => Some(end),
             None => {
                 self.no_closer = true;
                 None

--- a/rust/geometry/src/processors/mod.rs
+++ b/rust/geometry/src/processors/mod.rs
@@ -91,13 +91,13 @@ fn extract_coord_index_bytes(bytes: &[u8]) -> Option<&[u8]> {
             continue;
         }
 
-        // Skip comments (/* ... */)
+        // Skip comments (/* ... */). An unterminated `/*` means the input
+        // is corrupt; refuse rather than silently reading past it and
+        // returning bogus CoordIndex bytes. Shared with
+        // `ifc_lite_core::EntityScanner`, which answers the same question
+        // the same way — the two used to disagree here (issue #3303).
         if b == b'/' && i + 1 < bytes.len() && bytes[i + 1] == b'*' {
-            i += 2;
-            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
-                i += 1;
-            }
-            i += 2;
+            i = ifc_lite_core::skip_step_comment(bytes, i)?;
             continue;
         }
 

--- a/rust/geometry/src/processors/tests.rs
+++ b/rust/geometry/src/processors/tests.rs
@@ -1274,3 +1274,51 @@ fn test_advanced_face_trimmed_bspline_respects_trim_params() {
         "samples must stay on the trimmed subspan (t <= 0.5, x >= 0), got min x = {min_x}"
     );
 }
+
+/// #3303: this crate and `ifc-lite-core`'s scanner each used to hand-roll
+/// "skip a `/* ... */` comment", and disagreed on what an unterminated `/*`
+/// means — this crate silently consumed to end of input, `EntityScanner`
+/// refused. Both now call `ifc_lite_core::skip_step_comment`, so they agree.
+///
+/// This was RED before the fix: `extract_coord_index_bytes`'s inline
+/// comment-skip ran an index strictly past the fixture's length on an
+/// unterminated comment (confirmed via a since-removed `skip_comment_lossy`
+/// probe), while `EntityScanner::next_entity` already refused. Now both
+/// paths refuse for the identical fixture text.
+#[test]
+fn unterminated_comment_geometry_and_core_scanner_agree() {
+    let fixture = b"/* this comment never closes";
+
+    // ifc-lite-core's shared primitive: refuses (`None`), not an index past
+    // the end of input.
+    assert_eq!(
+        ifc_lite_core::skip_step_comment(fixture, 0),
+        None,
+        "the shared comment-skip must refuse an unterminated comment"
+    );
+
+    // ifc-lite-core's scanner, for the same shape of input: one entity
+    // found, then refuses to scan through the unterminated comment for more.
+    let mut file = b"#1=IFCWALL($);\n".to_vec();
+    file.extend_from_slice(fixture);
+    let mut scanner = ifc_lite_core::EntityScanner::new(&file);
+    assert!(
+        scanner.next_entity().is_some(),
+        "the one well-formed entity before the comment must still be found"
+    );
+    assert!(
+        scanner.next_entity().is_none(),
+        "ifc-lite-core's scanner must refuse to scan past an unterminated comment, not consume it"
+    );
+
+    // This crate's own call site: a CoordIndex list containing an
+    // unterminated comment must be refused (`None`), the same answer, for
+    // the same reason -- via the same shared function.
+    let mut entity = b"#77=IFCTRIANGULATEDFACESET(#78,$,$,((1,2,3)".to_vec();
+    entity.extend_from_slice(fixture);
+    assert_eq!(
+        extract_coord_index_bytes(&entity),
+        None,
+        "ifc-lite-geometry must refuse a CoordIndex list containing an unterminated comment"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #3303. Three places in `rust/` hand-rolled "skip a STEP `/* ... */` comment" and answered an unterminated `/*` three different ways:

| | unterminated `/*` |
|---|---|
| `rust/core` `EntityScanner` (`scanner.rs`) | refused (returned `None`) |
| `rust/geometry` CoordIndex reader (`processors/mod.rs`) | silently consumed to end of input |
| `rust/export` header prescan (`source_header.rs`) | treated as ordinary text, costing one `/` |

- **Basis for the chosen answer**: the scanner and the geometry reader are both walking already-located, well-formed record bytes looking for structure, not doing a header prescan — an unterminated comment there means the input is corrupt, and silently consuming the rest of it is worse than refusing. Neither had a reason to differ from the other, so this collapses them onto one rule, `ifc_lite_core::skip_step_comment`, which refuses.
- **Collapsed, not pinned**: both `rust/geometry` and `rust/export` already depend on `ifc-lite-core` (checked `Cargo.toml` before touching anything), so there was no crate-dependency-direction reason to keep three copies. `rust/geometry`'s CoordIndex reader now calls the shared function and refuses, matching the scanner, instead of reading past a corrupt comment.
- **`rust/export` keeps its own different answer, on purpose**: its STEP HEADER prescan (`Lex::skip_comment_at`) treats an unterminated `/*` as ordinary text rather than refusing, because a header prescan that swallows every later record has lost the schema — worse than the malformed input deserves. That reasoning predates this change and is documented on the type. It now finds a *closed* comment's end via the same shared `skip_step_comment` too; only the unterminated case stays its own, and the doc comment says why.
- **Fourth copy**: grepped `rust/` and `packages/` for `in_string`/`unterminated`/`skip_comment`/`skipLexical` and found none. Every other STEP comment/string-skip site already delegates to one of the three: `rust/export/src/schema_detect.rs`'s `find_unquoted` already reuses `source_header::Lex::skip_lexical_at`, and the TypeScript side's `packages/parser/src/step-lexing.ts` is the only place either of `tokenizer.ts` or `source-header.ts` calls for this rule. `schema_detect.rs` does carry a comment noting a *separate*, unrelated divergence (case-sensitive `ENDSEC`/`FILE_SCHEMA` matching vs the TS side) that it says is "tracked in #3303" — that is not the comment-skip rule this issue is about and is left untouched here.

## RED before the fix

`rust/geometry/src/processors/tests.rs` gained a test comparing the CoordIndex reader's pre-fix inline comment-skip (`skip_comment_lossy`, since removed) against `ifc_lite_core::EntityScanner` on the same unterminated-comment fixture:

```
thread 'processors::tests::unterminated_comment_geometry_consumes_to_end_today' panicked at rust/geometry/src/processors/tests.rs:1322:5:
ifc-lite-geometry and ifc-lite-core must agree that an unterminated comment is refused, not silently consumed; today they do not
```

## Test plan

- [x] `cargo test -p ifc-lite-core -p ifc-lite-geometry -p ifc-lite-export` — 114 test-result blocks (unit + integration + doctests across all three crates), 0 failed, `EXIT=0`. Run twice: once that hit a shared-`target`-dir race from a concurrent build (unrelated `E0425` on a stale cached rlib, resolved by rebuilding), and once clean with an isolated `CARGO_TARGET_DIR`.
- [x] `rust/core/src/parser/lexical.rs`'s own unit tests, `rust/geometry/src/processors/tests.rs::unterminated_comment_geometry_and_core_scanner_agree`, and `rust/export`'s `source_header_comments.rs::an_unterminated_comment_does_not_swallow_the_records_after_it` all pass.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unterminated STEP block comments.
  * Geometry coordinate data now rejects malformed comments instead of reading past the end of the input.
  * Comment handling is now consistent across entity scanning, geometry processing, and header parsing.

* **Tests**
  * Added regression coverage to verify consistent rejection of unterminated comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->