### PR TITLE
fix(viewer): composeTeardown's equality filter is now structural and per-key

### DIFF
--- a/apps/viewer/src/store/teardown.object-is-gate.test.ts
+++ b/apps/viewer/src/store/teardown.object-is-gate.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #3346: `composeTeardown` drops an entry with `Object.is`, which cannot
+ * see through a rebuilt `Set` / `Map` / array. `visibilitySlice.teardown.ts`
+ * and `selectionSlice.teardown.ts` gate their `model-removed` arm with ONE
+ * `touched` boolean covering several fields, so once ANY of those fields
+ * names the removed model, every field in the group is rebuilt — including
+ * the ones that, individually, did not change. A rebuilt-but-equal `Set` /
+ * array is a fresh reference, so it survives `Object.is` and lands in the
+ * composed patch, defeating any downstream `Object.is` / memo check on that
+ * key.
+ *
+ * These tests assert on PRESENCE of a key in the composed patch (the
+ * observable proxy for "a new reference was written"), which is what a
+ * subscriber keyed on `Object.is` actually sees. `deepStrictEqual` on VALUE
+ * would pass whether or not the reference moved and could not see this bug.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { useViewerStore } from './index.js';
+import { viewerTeardown } from './teardown-registry.js';
+import { modelRemovedScope } from './teardown-scope.js';
+import type { FederatedModel } from './types.js';
+
+function model(id: string, idOffset: number, maxExpressId: number): FederatedModel {
+  return { id, name: id, visible: true, idOffset, maxExpressId } as unknown as FederatedModel;
+}
+
+describe('composeTeardown does not rewrite an untouched field as equal-but-new (#3346)', () => {
+  it('visibilitySlice: hiddenEntitiesByModel naming the removed model must not rewrite isolatedEntities / ghostExceptEntities, which name only a survivor', () => {
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+      // Only this field names the removed model — it is what makes
+      // `visibilitySlice`'s `touched` boolean true.
+      hiddenEntitiesByModel: new Map([['A', new Set([1])]]),
+      isolatedEntitiesByModel: new Map(),
+      // Neither of these names anything inside A's range: both survive B's
+      // range untouched in VALUE, but `touched` still forces both through
+      // `nonEmptyOrNull`, which allocates a fresh `Set` unconditionally.
+      isolatedEntities: new Set([1050]),
+      ghostExceptEntities: new Set([1060]),
+      hiddenEntities: undefined,
+      classFilter: null,
+    });
+
+    const state = useViewerStore.getState();
+    const patch = viewerTeardown(modelRemovedScope(state, 'A'), state);
+
+    // The field that actually moved must be in the patch, or this fixture
+    // proves nothing about the mixed case.
+    assert.ok(
+      'hiddenEntitiesByModel' in patch,
+      'hiddenEntitiesByModel must be rewritten: it is the field that actually named the removed model',
+    );
+
+    assert.ok(
+      !('isolatedEntities' in patch),
+      'isolatedEntities did not change value (1050 survives in model B) and must not be rewritten ' +
+        'as an equal-but-new Set just because a sibling field in the same slice moved',
+    );
+    assert.ok(
+      !('ghostExceptEntities' in patch),
+      'ghostExceptEntities did not change value (1060 survives in model B) and must not be rewritten ' +
+        'as an equal-but-new Set just because a sibling field in the same slice moved',
+    );
+  });
+
+  it('selectionSlice: selectedModelId naming the removed model must not rewrite selectedEntities / selectedEntitiesSet, which name only a survivor', () => {
+    useViewerStore.setState({
+      models: new Map([
+        ['A', model('A', 0, 100)],
+        ['B', model('B', 1000, 1100)],
+      ]),
+      activeModelId: 'A',
+      // Only this field names the removed model — it is what makes
+      // `selectionSlice`'s `refsTouched` boolean true.
+      selectedModelId: 'A',
+      selectedEntity: null,
+      activeStorey: null,
+      // Both name only the surviving model B: their CONTENT does not change,
+      // but the filter that builds them runs unconditionally once
+      // `refsTouched` is true, allocating a fresh array / Set either way.
+      selectedEntities: [{ modelId: 'B', expressId: 5 }],
+      selectedEntitiesSet: new Set(['B:5']),
+      selectedEntityId: null,
+      selectedEntityIds: new Set(),
+      selectedStoreys: new Set(),
+    });
+
+    const state = useViewerStore.getState();
+    const patch = viewerTeardown(modelRemovedScope(state, 'A'), state);
+
+    assert.ok(
+      'selectedModelId' in patch,
+      'selectedModelId must be rewritten: it is the field that actually named the removed model',
+    );
+
+    assert.ok(
+      !('selectedEntities' in patch),
+      'selectedEntities holds only a B-owned entry and must not be rewritten as an equal-but-new ' +
+        'array just because selectedModelId, a sibling field, named the removed model',
+    );
+    assert.ok(
+      !('selectedEntitiesSet' in patch),
+      'selectedEntitiesSet holds only a B-owned entry and must not be rewritten as an equal-but-new ' +
+        'Set just because selectedModelId, a sibling field, named the removed model',
+    );
+  });
+});

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -200,8 +200,9 @@ export interface SliceTeardown<K extends keyof ViewerState = keyof ViewerState> 
    * `syncSourceModel` runs the SAME composition after `removeModel`
    * without undoing or re-allocating anything.
    *
-   * {@link composeTeardown} drops `Object.is`-unchanged entries as a backstop,
-   * but a contribution that rebuilds an equal-but-new `Map` defeats it.
+   * {@link composeTeardown} drops unchanged entries as a backstop, including a
+   * `Set` / `Map` / array rebuilt equal-but-new — a should, not a must, but
+   * still cheaper: its structural check only runs after `Object.is` fails.
    */
   readonly teardown: (scope: TeardownScope, state: TeardownState) => TeardownContribution<K>;
 }
@@ -303,25 +304,42 @@ export function teardownOwnedKeys(
 }
 
 /**
- * Keys the `Object.is` filter below must never drop.
- *
- * `withVisibilityOwnershipInvalidation` keys on PRESENCE, not value:
- * `applyOwnershipInvalidation` tests `'isolatedEntities' in patch`. The old
- * hand-written `resetViewerState` always carried both channels, so the
- * middleware ran on every session reset. Dropping an unchanged channel would
- * silently stop it running on the common reset, where both are already `null`.
- *
- * That matters for a guarantee rather than for today's data. `lib/visibility/
- * ownership.ts` states the middleware's purpose as making a THIRD subsystem's
- * claim "invalidated by construction rather than by remembering to extend a
- * list somewhere else". Today's two record fields happen to be cleared by name
- * as well, so nothing is broken now. Add a third and the by-construction half
- * is what catches it, so the filter must not be what takes it away.
+ * Keys the equality filter below must never drop, on the two scopes whose
+ * hand-written predecessor always carried both — `withVisibilityOwnershipInvalidation`
+ * keys on PRESENCE in the patch, not value (`applyOwnershipInvalidation` tests
+ * `'isolatedEntities' in patch`), so it must keep running even when both are
+ * already `null`. `model-removed` is excluded: its `visibilitySlice.teardown.ts`
+ * arm already gates presence on its own `touched` check, and forcing it here
+ * would reproduce #3346 (a channel unwritten by anything of its own, forced
+ * through because a SIBLING field's `touched` gate rebuilt it equal-but-new).
  */
-const NEVER_DROPPED: ReadonlySet<keyof ViewerState> = new Set([
-  'isolatedEntities',
-  'ghostExceptEntities',
+const FORCED_PRESENCE_SCOPES: ReadonlySet<TeardownScope['kind']> = new Set([
+  'session-reset',
+  'all-models-cleared',
 ]);
+const NEVER_DROPPED: ReadonlySet<keyof ViewerState> = new Set(['isolatedEntities', 'ghostExceptEntities']);
+
+/**
+ * Whether `a` and `b` are the same value, seeing through a `Set` / `Map` /
+ * array rebuilt with equal contents under a new reference (#3346: a per-slice
+ * `touched` gate rebuilds every field it covers once ANY one moves).
+ * `Object.is` alone otherwise — two equal-but-distinct plain objects, e.g.
+ * `classFilter`, are NOT equal here. `Map` values recurse, since e.g.
+ * `hiddenEntitiesByModel` holds `Set`s a contribution may itself rebuild.
+ */
+function isUnchanged(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a instanceof Set && b instanceof Set) {
+    return a.size === b.size && [...a].every((value) => b.has(value));
+  }
+  if (a instanceof Map && b instanceof Map) {
+    return a.size === b.size && [...a].every(([k, v]) => b.has(k) && isUnchanged(v, b.get(k)));
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((value, index) => isUnchanged(value, b[index]));
+  }
+  return false;
+}
 
 /**
  * Build the one patch an entry point hands to `set`.
@@ -330,39 +348,32 @@ const NEVER_DROPPED: ReadonlySet<keyof ViewerState> = new Set([
  * {@link createTeardownRegistry}), so the order cannot decide a value — it only
  * decides key insertion order, which nothing observes.
  *
- * An entry whose value is already `Object.is`-identical to the live state is
- * DROPPED. That keeps a composed patch as close as possible to today's
- * conditional spreads: a key that is not in the patch is not written, so no
- * subscriber is notified for a non-change. It also makes a `model-removed`
- * teardown safe to run twice, which `syncSourceModel` does immediately after
- * `removeModel`.
- *
- * {@link NEVER_DROPPED} is exempt, because the visibility-ownership middleware
- * keys on a channel's PRESENCE in the patch rather than its value.
+ * An entry whose value {@link isUnchanged} from the live state is DROPPED
+ * (structurally, not by `Object.is` alone — see {@link isUnchanged}, #3346),
+ * so a key not in the patch is not written and no subscriber is notified for
+ * a non-change. That also makes `model-removed` safe to run twice, which
+ * `syncSourceModel` does right after `removeModel`. {@link NEVER_DROPPED} is
+ * the scope-dependent exception; see its own doc.
  *
  * A key absent from `state` (the partial-store test harness) is never
- * "unchanged" — `Object.is(undefined, value)` is false unless the teardown also
- * returns `undefined`.
- *
- * About a dozen contributions DO return `undefined` - most of `visibilitySlice`
- * and `selectionSlice`'s model-removed arms, plus `dataSlice`'s
- * `purgeRemovedModelsBackup`. Do not audit that as a list; audit the RULE, which
- * is narrower than "never return it": every one of them passes THROUGH a value
- * read from `state`, so `undefined` appears only where the live value is
- * `undefined` too and the entry is dropped. Returning a SYNTHESIZED `undefined` would survive the
- * filter, and `writeKey` would set it, and zustand's shallow merge would blank
- * the field.
+ * "unchanged" — `isUnchanged(undefined, value)` is false unless the teardown
+ * also returns `undefined`. About a dozen contributions DO: most of
+ * `visibilitySlice` / `selectionSlice`'s model-removed arms, plus `dataSlice`'s
+ * `purgeRemovedModelsBackup`, each passing THROUGH a value read from `state`,
+ * so `undefined` appears only where the live value already is. A SYNTHESIZED
+ * `undefined` would survive the filter and `writeKey` would blank the field.
  */
 export function composeTeardown(
   registry: readonly AnySliceTeardown[],
 ): (scope: TeardownScope, state: TeardownState) => Partial<ViewerState> {
   return (scope, state) => {
+    const forcePresence = FORCED_PRESENCE_SCOPES.has(scope.kind);
     const patch: Partial<ViewerState> = {};
     for (const entry of registry) {
       const contribution = entry.teardown(scope, state);
       for (const key of Object.keys(contribution) as (keyof ViewerState)[]) {
         const next = contribution[key];
-        if (!NEVER_DROPPED.has(key) && Object.is(state[key], next)) continue;
+        if (!(forcePresence && NEVER_DROPPED.has(key)) && isUnchanged(state[key], next)) continue;
         writeKey(patch, key, next);
       }
     }


### PR DESCRIPTION
## Summary

Fixes #3346.

`composeTeardown` dropped a contribution's key only when `Object.is` matched the live state. `visibilitySlice.teardown.ts` and `selectionSlice.teardown.ts` gate their `model-removed` arm with one `touched` boolean over several fields, so once any single field named the removed model, every field in that group was rebuilt — including a sibling `Set`/`Map`/array whose own content did not change. The rebuilt-but-equal collection is a fresh reference, so `Object.is` could not see through it and wrote it into the composed patch anyway, defeating any `Object.is` / memo check downstream.

**Root cause, one sentence:** the equality gate that decides whether a teardown key gets written was per-slice (a single `touched` boolean covering several fields) at the contribution level and `Object.is`-only at the composition level, so neither layer could catch a sibling field being rebuilt equal-but-new.

**Fix:** `composeTeardown` (`apps/viewer/src/store/teardown.ts`) now compares structurally — `Set`/`Map`/array, recursing into `Map` values — before dropping a key, so an untouched field keeps its identity regardless of which sibling field tripped the group's `touched` gate.

One consequence needed handling: `NEVER_DROPPED` forces `isolatedEntities` / `ghostExceptEntities` into the patch so `withVisibilityOwnershipInvalidation` keeps running even when their value hasn't changed. That's a real requirement for `session-reset` / `all-models-cleared`, whose contributions declare both keys unconditionally — but `model-removed` never made that promise (its own `touched` gate already decides presence), so forcing presence there just reproduced the reported bug for exactly those two keys. `NEVER_DROPPED`'s exemption is now scoped to `session-reset` / `all-models-cleared` only (`FORCED_PRESENCE_SCOPES`).

## Proof of RED, then GREEN

New file `apps/viewer/src/store/teardown.object-is-gate.test.ts`, two cases (visibilitySlice, selectionSlice), asserting **presence in the composed patch** for an untouched field — value-equality assertions can't see a reference change, so this asserts on the same signal an `Object.is` subscriber would.

Before the fix (source unmodified, only the new test added):
```
not ok 1 - visibilitySlice: hiddenEntitiesByModel naming the removed model must not rewrite
            isolatedEntities / ghostExceptEntities, which name only a survivor
  error: 'isolatedEntities did not change value (1050 survives in model B) and must not be
          rewritten as an equal-but-new Set just because a sibling field in the same slice moved'
not ok 2 - selectionSlice: selectedModelId naming the removed model must not rewrite
            selectedEntities / selectedEntitiesSet, which name only a survivor
  error: 'selectedEntities holds only a B-owned entry and must not be rewritten as an
          equal-but-new array just because selectedModelId, a sibling field, named the removed model'
```

After the fix:
```
$ npx tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 \
    src/store/teardown-registry.test.ts src/store/teardown.idempotence.test.ts src/store/teardown.object-is-gate.test.ts
# tests 9
# suites 3
# pass 9
# fail 0
```

Wider run (visibility ownership + slice tests) also green:
```
$ npx tsx --import ./src/test/vite-module-hooks.mjs --test --test-timeout=120000 --test-concurrency=1 \
    src/store/teardown-registry.test.ts src/store/teardown.idempotence.test.ts src/store/teardown.object-is-gate.test.ts \
    src/store/visibility-channel-invalidation.test.ts src/store/slices/visibilitySlice.test.ts \
    src/store/slices/selectionSlice.test.ts src/store/slices/modelSlice.test.ts
# tests 184
# pass 184
# fail 0
```

`pnpm typecheck` (root) and `node scripts/check-module-size.mjs` both pass; `teardown.ts` is 399 lines (comments trimmed to stay under the 400-line ratchet rather than allowlisting).

## What didn't change, and why

- No `owns` list, no pin (`PINNED_SESSION_RESET_KEYS` / `PINNED_ALL_MODELS_CLEARED_KEYS` / `PINNED_MODEL_REMOVED_KEYS` / `PINNED_OWNED_KEYS`) moved. Those pins read raw `entry.teardown(scope, state)` output, bypassing `composeTeardown` entirely — this fix only changes which *unchanged* keys the composition drops, not what any contribution's body writes.
- `visibilitySlice.teardown.ts` / `selectionSlice.teardown.ts` themselves are unchanged: the issue's proposed fix (give the seam structural equality) is what's implemented, keeping the per-slice `touched` pre-check as a cheap common-case skip rather than removing it (the issue measured that removal as a net perf loss in the common case).

## #3345 — reported, not fixed

Read #3345 ("a fourth teardown scope would silently no-op in 22 of 28 slice contributions"). It's a real, separate defect: the fix there is making `TeardownScope`'s arms a required record per contribution instead of an `if (scope.kind !== 'session-reset') return {}` guard, so a fourth scope kind fails to compile in all 28 files rather than silently clearing nothing. That's a shape change to every `*.teardown.ts` file and to `SliceTeardown`'s declaration surface — not something this PR's fix touches or depends on, and not inseparable from it. Leaving it for its own PR.

## Overlap with in-flight teardown PRs

Per the task brief, checked all four open PRs against this mechanism (#3371, #3372, #3375, #3367) for textual overlap — none of them touch `apps/viewer/src/store/teardown.ts` (this PR's only source change) or the new test file, so there's no diff conflict to resolve. (#3372, #3375, #3367 all touch `teardown-registry.test.ts`, which this PR does not.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436