### PR TITLE
fix(viewer): route grid-only annotation content to its own line-overlay channel

### DIFF
--- a/.changeset/grid-only-annotation-channel-camera-reframe.md
+++ b/.changeset/grid-only-annotation-channel-camera-reframe.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Turning "Show IFC Annotations" off while leaving the IfcGrid toggle on no longer reframes the camera onto the grid.
+
+`useSymbolicAnnotations` lifted IfcAnnotation curves AND IfcGridAxis lines into one buffer uploaded to the renderer's `annotation` line-overlay channel. With annotations off and the grid on, that buffer carried only grid content, but `CHANNEL_EXPANDS_MODEL_BOUNDS.annotation` is `true` — the policy exists so an annotation-only model can still be framed — so the grid-only upload grew the scene bounds that `CHANNEL_EXPANDS_MODEL_BOUNDS.grid: false` exists to protect (grid axes routinely extend far past the model envelope, issue #967). Every later camera fit and every empty-space orbit gesture (whose pivot falls back to the scene-bounds centroid, `useMouseControls.ts`/`useTouchControls.ts`) then reframed around the inflated bounds instead of the model.
+
+`useSymbolicAnnotations` now returns the two content kinds separately (`{ annotation, grid }`), and the viewport uploads each to its own channel, so grid content reaches the policy it was designed for.

--- a/apps/viewer/src/components/viewer/Viewport.tsx
+++ b/apps/viewer/src/components/viewer/Viewport.tsx
@@ -66,6 +66,7 @@ import {
 } from '../../hooks/useSymbolicAnnotations.js';
 import { useAlignmentLines3D } from '../../hooks/useAlignmentLines3D.js';
 import { useGridLines3D } from '../../hooks/useGridLines3D.js';
+import { mergeGridLineChannels } from './merge-grid-line-channels.js';
 import { useDxfUnderlays3DLines } from '../../hooks/useDxfUnderlay.js';
 import { uploadDxfLines3DGuarded } from './dxf-lines-3d-upload.js';
 import { subscribeViewportHealth } from './device-loss-report.js';
@@ -1453,7 +1454,7 @@ export function Viewport({
     };
   }, [sectionPlane.enabled, sectionPlane.axis, sectionPlane.position, sectionRange]);
 
-  const annotationVertices3D = useSymbolicAnnotations({
+  const symbolicLineChannels = useSymbolicAnnotations({ // two buffers, not one (issue #3359)
     enabled: ifcAnnotationsVisible,
     gridEnabled: ifcGridVisible,
     gridSectionClip,
@@ -1468,11 +1469,9 @@ export function Viewport({
   useEffect(() => {
     const renderer = rendererRef.current;
     if (!renderer || !isInitialized) return;
-    renderer.setLineOverlay(
-      'annotation',
-      annotationVertices3D.length === 0 ? null : annotationVertices3D,
-    );
-  }, [annotationVertices3D, isInitialized]);
+    const v = symbolicLineChannels.annotation;
+    renderer.setLineOverlay('annotation', v.length === 0 ? null : v);
+  }, [symbolicLineChannels.annotation, isInitialized]);
 
   // IfcAlignment centerlines render as thin lines (not a ribbon mesh), always
   // on — see useAlignmentLines3D. Upload/clear mirrors the annotation overlay;
@@ -1487,18 +1486,19 @@ export function Viewport({
     );
   }, [alignmentVertices3D, isInitialized]);
 
-  // Structural-grid (IfcGridAxis) lines, gated by the `ifcGrid` type-visibility
-  // toggle (issue #967). Parsed once per source + cached; only the upload/clear
-  // is toggled so flipping visibility doesn't re-parse.
+  // Structural-grid (IfcGridAxis) lines (issue #967): merges `useGridLines3D`
+  // (unclipped) with the clipped grid buffer above (#3359 / pending #3368).
   const gridVertices3D = useGridLines3D();
+  const symbolicGridVertices3D = symbolicLineChannels.grid;
+  const mergedGridVertices3D = useMemo(() => mergeGridLineChannels(gridVertices3D, symbolicGridVertices3D), [gridVertices3D, symbolicGridVertices3D]);
   useEffect(() => {
     const renderer = rendererRef.current;
     if (!renderer || !isInitialized) return;
     renderer.setLineOverlay(
       'grid',
-      !ifcGridVisible || gridVertices3D.length === 0 ? null : gridVertices3D,
+      !ifcGridVisible || mergedGridVertices3D.length === 0 ? null : mergedGridVertices3D,
     );
-  }, [gridVertices3D, ifcGridVisible, isInitialized]);
+  }, [mergedGridVertices3D, ifcGridVisible, isInitialized]);
 
   // DXF reference-layer line paths in the 3D viewport (issue #2043,
   // follow-up to #1782/#1929's 2D-only DXF underlay). Gated by each

--- a/apps/viewer/src/components/viewer/merge-grid-line-channels.ts
+++ b/apps/viewer/src/components/viewer/merge-grid-line-channels.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Merge the two sources currently feeding the renderer's `grid` line-overlay
+ * channel: `useGridLines3D` (unclipped) and `useSymbolicAnnotations`'s grid
+ * buffer (clipped, issue #3359). Split out of `Viewport.tsx` so the merge is
+ * unit-testable without mounting the component. Pending #3368's dedupe,
+ * which collapses this to a single owner.
+ */
+export function mergeGridLineChannels(a: Float32Array, b: Float32Array): Float32Array {
+  if (a.length === 0) return b;
+  if (b.length === 0) return a;
+  const merged = new Float32Array(a.length + b.length);
+  merged.set(a, 0);
+  merged.set(b, a.length);
+  return merged;
+}

--- a/apps/viewer/src/hooks/symbolic-line-channels.ts
+++ b/apps/viewer/src/hooks/symbolic-line-channels.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The pure merge step behind `useSymbolicAnnotations` — split out so it can
+ * be unit-tested against a hand-built `ParseResult` with no React/store/WASM
+ * dependency, and so the hook file stays under the module-size budget.
+ *
+ * Kept SEPARATE (issue #3359): annotation/grid used to share one buffer
+ * feeding `setLineOverlay('annotation', …)`, so a grid-only session reached
+ * a channel whose `CHANNEL_EXPANDS_MODEL_BOUNDS` entry is `true` — the
+ * opposite of `grid`'s `false` (issue #967: grid axes extend past the
+ * model) — inflating the scene bounds every camera fit / empty-space orbit
+ * pivot (`useMouseControls.ts`/`useTouchControls.ts`) then reframed onto.
+ * Callers upload `annotation`/`grid` to their like-named channel.
+ */
+
+import { debugEnabled, type ParseResult } from '../lib/overlay-parse/symbolic-parse.js';
+import { liftTo3DLineList, resolveBucketY } from './useSymbolicAnnotations.js';
+
+const EMPTY_F32 = new Float32Array(0);
+
+export interface SymbolicLineChannels {
+  annotation: Float32Array;
+  grid: Float32Array;
+}
+
+/** One store's parsed buckets + hide predicate — no React/WASM dependency,
+ *  so `buildSymbolicLineChannels` runs against a hand-built `ParseResult`
+ *  in a test. */
+export interface SymbolicLineChannelsEntry {
+  cached: ParseResult;
+  isHidden?: (ownerId: number) => boolean;
+}
+
+interface SymbolicLineChannelsParams {
+  enabled: boolean;
+  effectiveGridEnabled: boolean;
+  clipEnabled: boolean;
+  clipPos: number;
+  clipDepth: number;
+  fallbackY: number;
+}
+
+/** Pure merge of every store's annotation/grid buckets into two flat 3D
+ *  line-list buffers. Exported for unit testing. */
+export function buildSymbolicLineChannels(
+  entries: readonly SymbolicLineChannelsEntry[],
+  params: SymbolicLineChannelsParams,
+): SymbolicLineChannels {
+  const { enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, fallbackY } = params;
+  if (!enabled && !effectiveGridEnabled) return { annotation: EMPTY_F32, grid: EMPTY_F32 };
+
+  const annotationVerts: number[] = [];
+  const gridVerts: number[] = [];
+  for (const { cached, isHidden } of entries) {
+    if (enabled) {
+      for (const bucket of cached.byStorey.values()) {
+        liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), annotationVerts, isHidden);
+      }
+      liftTo3DLineList(cached.loose, fallbackY, annotationVerts, isHidden);
+    }
+
+    if (effectiveGridEnabled) {
+      // Issue #862: section-clip grid buckets only — IfcAnnotation
+      // intentionally bypasses this per the feedback memory ("the
+      // user expects every storey's dimensions/grid bubbles to lift
+      // into the viewport when [the annotation toggle is] on, even
+      // while a section cut is active").
+      if (clipEnabled) {
+        const lo = clipPos - clipDepth;
+        const hi = clipPos + clipDepth;
+        for (const bucket of cached.gridByStorey.values()) {
+          const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+          if (y < lo || y > hi) continue;
+          liftTo3DLineList(bucket.lines, y, gridVerts, isHidden);
+        }
+        if (fallbackY >= lo && fallbackY <= hi) {
+          liftTo3DLineList(cached.gridLoose, fallbackY, gridVerts, isHidden);
+        }
+      } else {
+        for (const bucket of cached.gridByStorey.values()) {
+          liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), gridVerts, isHidden);
+        }
+        liftTo3DLineList(cached.gridLoose, fallbackY, gridVerts, isHidden);
+      }
+    }
+  }
+
+  if (debugEnabled()) {
+    console.log(
+      `[annotations] total 3D line vertices: ${annotationVerts.length / 3} annotation + ${gridVerts.length / 3} grid from ${entries.length} stores`,
+    );
+  }
+  return {
+    annotation: annotationVerts.length === 0 ? EMPTY_F32 : new Float32Array(annotationVerts),
+    grid: gridVerts.length === 0 ? EMPTY_F32 : new Float32Array(gridVerts),
+  };
+}

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.gridChannelSplit.test.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.gridChannelSplit.test.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #3359: the annotation overlay channel can carry only grid geometry.
+ *
+ * `useSymbolicAnnotations` used to lift IfcAnnotation curves AND IfcGridAxis
+ * lines into ONE `verts` buffer feeding `renderer.setLineOverlay('annotation',
+ * …)`. With "Show IFC Annotations" off and the IfcGrid toggle on, that buffer
+ * held only grid lines, but the renderer's `CHANNEL_EXPANDS_MODEL_BOUNDS`
+ * table treats EVERYTHING reaching the `annotation` channel as annotation
+ * content (`annotation: true`) — the opposite of `grid: false`, which exists
+ * because grid axes routinely extend past the model envelope (issue #967).
+ * See `packages/renderer/src/renderer-overlays.ts`.
+ *
+ * `buildSymbolicLineChannels` is the pure merge step behind the hook (no
+ * React/store/WASM dependency), so the split is pinned directly against a
+ * hand-built `ParseResult` — annotation buckets empty, grid buckets carrying
+ * a line that extends far past where any annotation content would be.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildSymbolicLineChannels,
+  type SymbolicLineChannelsEntry,
+} from './useSymbolicAnnotations.js';
+import { createEmptyParseResult, type AnnotationsForStorey } from '../lib/overlay-parse/symbolic-parse.js';
+
+function gridOnlyEntry(): SymbolicLineChannelsEntry {
+  const cached = createEmptyParseResult();
+  const farLine: AnnotationsForStorey = {
+    storeyId: 1,
+    storeyElevation: 0,
+    lines: [
+      {
+        line: { start: { x: -500, y: 0 }, end: { x: 500, y: 0 } },
+        category: 'grid',
+        ownerId: 42,
+      },
+    ],
+    texts: [],
+    fills: [],
+  };
+  cached.gridByStorey.set(1, farLine);
+  return { cached };
+}
+
+describe('buildSymbolicLineChannels splits annotation and grid content (issue #3359)', () => {
+  it('annotations-off / grid-on: the annotation channel is empty and the grid channel carries the lines', () => {
+    const { annotation, grid } = buildSymbolicLineChannels([gridOnlyEntry()], {
+      enabled: false,
+      effectiveGridEnabled: true,
+      clipEnabled: false,
+      clipPos: 0,
+      clipDepth: 0,
+      fallbackY: 0,
+    });
+
+    assert.strictEqual(
+      annotation.length,
+      0,
+      'a grid-only buffer must not reach the annotation channel — it would ' +
+        "carry only grid geometry into `CHANNEL_EXPANDS_MODEL_BOUNDS.annotation` " +
+        '(true), which #967/grid:false exists to prevent',
+    );
+    assert.strictEqual(grid.length, 6, 'the grid line (2 verts * 3 floats) must reach the grid channel');
+    assert.deepStrictEqual(Array.from(grid), [-500, 0, 0, 500, 0, 0]);
+  });
+
+  it('both on: annotation and grid buckets land in their own channel, not merged into one', () => {
+    const cached = createEmptyParseResult();
+    cached.loose.push({
+      line: { start: { x: 1, y: 1 }, end: { x: 2, y: 2 } },
+      category: 'annotation',
+    });
+    cached.gridLoose.push({
+      line: { start: { x: -500, y: 0 }, end: { x: 500, y: 0 } },
+      category: 'grid',
+    });
+
+    const { annotation, grid } = buildSymbolicLineChannels([{ cached }], {
+      enabled: true,
+      effectiveGridEnabled: true,
+      clipEnabled: false,
+      clipPos: 0,
+      clipDepth: 0,
+      fallbackY: 0,
+    });
+
+    assert.strictEqual(annotation.length, 6, 'annotation channel carries only the annotation line');
+    assert.strictEqual(grid.length, 6, 'grid channel carries only the grid line');
+    assert.notDeepStrictEqual(Array.from(annotation), Array.from(grid));
+  });
+});

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -24,6 +24,11 @@ import {
   type AnnotationsForStorey,
 } from '../lib/overlay-parse/symbolic-parse.js';
 import { ensureParseFor, getParseFor, subscribeToParseCache } from './symbolic-parse-cache.js';
+import {
+  buildSymbolicLineChannels,
+  type SymbolicLineChannels,
+  type SymbolicLineChannelsEntry,
+} from './symbolic-line-channels.js';
 
 // The parse walk itself lives in `lib/overlay-parse/symbolic-parse.ts` so a
 // worker can import it (a worker module cannot import this React hook file).
@@ -164,7 +169,7 @@ function makeHiddenOwnerPredicate(
  * fall back to the caller's `fallbackY` (typically the model's mid-Y). A
  * real ground floor at 0.0 keeps its authored 0 instead of being remapped.
  */
-function resolveBucketY(elevation: number | null, fallbackY: number): number {
+export function resolveBucketY(elevation: number | null, fallbackY: number): number {
   return elevation === null ? fallbackY : elevation;
 }
 
@@ -184,6 +189,12 @@ export interface SectionClipForGrid {
   axis: 'down' | 'front' | 'side';
 }
 
+// `buildSymbolicLineChannels` (the pure annotation/grid merge, issue #3359)
+// lives in `symbolic-line-channels.ts` — split out to keep this file under
+// budget and so it can be unit-tested with no React/store/WASM dependency.
+// Re-exported here so existing consumers keep this import path.
+export { buildSymbolicLineChannels, type SymbolicLineChannels, type SymbolicLineChannelsEntry };
+
 export function useSymbolicAnnotations(params: {
   /** Enable IfcAnnotation lift (the existing default behaviour). */
   enabled: boolean;
@@ -198,7 +209,7 @@ export function useSymbolicAnnotations(params: {
   gridSectionClip?: SectionClipForGrid;
   /** World Y to use for annotations with no resolvable storey. Defaults to 0. */
   fallbackY?: number;
-}): Float32Array {
+}): SymbolicLineChannels {
   const { enabled, gridEnabled, gridSectionClip, fallbackY = 0 } = params;
   const effectiveGridEnabled = gridEnabled ?? enabled;
   const stores = useActiveStores();
@@ -210,64 +221,27 @@ export function useSymbolicAnnotations(params: {
   const clipDepth = clipEnabled ? gridSectionClip!.viewDepth : 0;
 
   return useMemo(() => {
-    if (!enabled && !effectiveGridEnabled) return EMPTY_F32;
+    if (!enabled && !effectiveGridEnabled) return { annotation: EMPTY_F32, grid: EMPTY_F32 };
     void version; // depend on parse-completion ticks
 
-    const verts: number[] = [];
-    let storeIdx = 0;
+    // Per-entity hide: an annotation/grid owner hidden via the hierarchy, a
+    // lens, or a federated per-model hide drops its overlay primitives.
+    // Stores whose parse isn't cached yet drop out (logged below).
+    const entries: SymbolicLineChannelsEntry[] = [];
     for (const entry of stores) {
       const cached = getParseFor(entry.store);
-      if (!cached) {
-        if (debugEnabled()) console.log(`[annotations] store ${storeIdx}: parse not yet ready`);
-        storeIdx++;
-        continue;
-      }
-      // Per-entity hide: an annotation/grid owner hidden via the hierarchy,
-      // a lens, or a federated per-model hide drops its overlay primitives.
-      const isHidden = makeHiddenOwnerPredicate(entry, hiddenSets);
-      if (debugEnabled()) {
-        console.log(
-          `[annotations] store ${storeIdx}: annotation buckets=${cached.byStorey.size}+${cached.loose.length}loose, grid buckets=${cached.gridByStorey.size}+${cached.gridLoose.length}loose (annot=${enabled}, grid=${effectiveGridEnabled}, clip=${clipEnabled})`,
-        );
-      }
-
-      if (enabled) {
-        for (const bucket of cached.byStorey.values()) {
-          liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts, isHidden);
-        }
-        liftTo3DLineList(cached.loose, fallbackY, verts, isHidden);
-      }
-
-      if (effectiveGridEnabled) {
-        // Issue #862: section-clip grid buckets only — IfcAnnotation
-        // intentionally bypasses this per the feedback memory ("the
-        // user expects every storey's dimensions/grid bubbles to lift
-        // into the viewport when [the annotation toggle is] on, even
-        // while a section cut is active").
-        if (clipEnabled) {
-          const lo = clipPos - clipDepth;
-          const hi = clipPos + clipDepth;
-          for (const bucket of cached.gridByStorey.values()) {
-            const y = resolveBucketY(bucket.storeyElevation, fallbackY);
-            if (y < lo || y > hi) continue;
-            liftTo3DLineList(bucket.lines, y, verts, isHidden);
-          }
-          if (fallbackY >= lo && fallbackY <= hi) {
-            liftTo3DLineList(cached.gridLoose, fallbackY, verts, isHidden);
-          }
-        } else {
-          for (const bucket of cached.gridByStorey.values()) {
-            liftTo3DLineList(bucket.lines, resolveBucketY(bucket.storeyElevation, fallbackY), verts, isHidden);
-          }
-          liftTo3DLineList(cached.gridLoose, fallbackY, verts, isHidden);
-        }
-      }
-      storeIdx++;
+      if (cached) entries.push({ cached, isHidden: makeHiddenOwnerPredicate(entry, hiddenSets) });
+      else if (debugEnabled()) console.log(`[annotations] store not yet ready: ${entry.modelId}`);
     }
 
-    if (debugEnabled()) console.log(`[annotations] total 3D line vertices: ${verts.length / 3} from ${stores.length} stores`);
-    if (verts.length === 0) return EMPTY_F32;
-    return new Float32Array(verts);
+    return buildSymbolicLineChannels(entries, {
+      enabled,
+      effectiveGridEnabled,
+      clipEnabled,
+      clipPos,
+      clipDepth,
+      fallbackY,
+    });
   }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, hiddenSets, version, fallbackY]);
 }
 

--- a/packages/renderer/src/renderer-overlays-grid-channel-reframe.test.ts
+++ b/packages/renderer/src/renderer-overlays-grid-channel-reframe.test.ts
@@ -1,0 +1,146 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #3359, consequence 2: "and then it reframes the camera".
+ *
+ * `renderer-overlays-line-channels.test.ts` already pins that
+ * `RendererOverlays.setLineOverlay` applies the RIGHT policy for whichever
+ * channel it is told (`annotation`/`alignment` expand the scene bounds and
+ * re-sync the camera, `grid`/`dxf` do not). That part of the pipeline is not
+ * broken. The bug is upstream: `apps/viewer/src/hooks/useSymbolicAnnotations.ts`
+ * used to lift BOTH IfcAnnotation and IfcGridAxis content into one buffer
+ * fed to `renderer.setLineOverlay('annotation', …)`, so with annotations off
+ * and the grid on, grid-only content reached a channel whose policy is
+ * "this content defines the model's extent" — exactly wrong for grid axes,
+ * which routinely extend far past the model envelope (issue #967, the same
+ * reason `CHANNEL_EXPANDS_MODEL_BOUNDS.grid` is `false`).
+ *
+ * This test wires a REAL `Camera` + `ModelBoundsTracker` behind
+ * `RendererOverlays` (no fakes for those two) and shows the mechanism this
+ * misrouting triggers: `camera.getSceneBounds()` — the exact value
+ * `apps/viewer/src/components/viewer/useMouseControls.ts` (`anchorBounds ??
+ * camera.getSceneBounds()`, ~line 542) and `useTouchControls.ts` (~line 112)
+ * fall back to for the orbit pivot when an empty-space drag has no raycast
+ * hit, no selection and no robust anchor — swings from the model's own
+ * centre to a point dragged toward the far-away grid, silently changing what
+ * the next orbit gesture frames around. `useMouseControls.ts`'s own comment
+ * on that fallback (~line 536) names the visible symptom directly:
+ * "orbiting then swings the model out of frame".
+ *
+ * The camera starts at a pose distinct from both the real model's centre and
+ * the origin, so a pivot that silently snaps to either would be observable
+ * here — a fixture already sitting at the framing target cannot see this
+ * bug.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Camera } from './camera.js';
+import { ModelBoundsTracker } from './model-bounds-tracker.js';
+import { RendererOverlays, type OverlayHost } from './renderer-overlays.js';
+
+function centroid(b: { min: { x: number; y: number; z: number }; max: { x: number; y: number; z: number } }) {
+  return {
+    x: (b.min.x + b.max.x) / 2,
+    y: (b.min.y + b.max.y) / 2,
+    z: (b.min.z + b.max.z) / 2,
+  };
+}
+
+function dist(a: { x: number; y: number; z: number }, b: { x: number; y: number; z: number }): number {
+  return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2 + (a.z - b.z) ** 2);
+}
+
+/** Real model geometry: a compact 10x10x10 box centred at (5, 0, 5). */
+const REAL_MODEL_BOUNDS = { min: { x: 0, y: -5, z: 0 }, max: { x: 10, y: 5, z: 10 } };
+
+/** A grid axis line that — per the issue — "routinely extends well past the
+ *  model envelope": entirely outside REAL_MODEL_BOUNDS, and off to one side
+ *  (not straddling the model's centre) so folding it in visibly drags the
+ *  combined centroid rather than leaving it coincidentally unchanged. */
+const GRID_ONLY_VERTS = new Float32Array([1000, 500, 5, 1500, 500, 5]);
+
+function makeHarness() {
+    const camera = new Camera();
+    // A pose distinct from both the model's centre (5, 0, 5) and the origin,
+    // so a pivot silently snapping to either is observable.
+    camera.setPosition(-300, 120, 900);
+    camera.setTarget(40, 15, -60);
+
+    const modelBoundsTracker = new ModelBoundsTracker({
+        meshBounds: () => REAL_MODEL_BOUNDS,
+        pointCloudBounds: () => null,
+    });
+    modelBoundsTracker.recompute();
+    // Seed the camera's scene bounds the way `Renderer` does on mesh load,
+    // BEFORE any overlay upload — this is the "real model already framed"
+    // starting state the bug then disturbs.
+    camera.setSceneBounds(modelBoundsTracker.get());
+
+    const host: OverlayHost = {
+        getModelBounds: () => modelBoundsTracker.get(),
+        expandModelBoundsWithFlatVertices: (positions, stride) =>
+            modelBoundsTracker.expandWithFlatVertices(positions, stride),
+        syncCameraSceneBounds: () => {
+            const b = modelBoundsTracker.get();
+            if (b) camera.setSceneBounds(b);
+        },
+        requestRender: () => { /* no-op */ },
+    };
+
+    const overlays = new RendererOverlays(host);
+    const fakeRenderer = {
+        setLineOverlay() { /* no-op: this test only cares about bounds/camera fallout */ },
+        setOverlayLineColor() { /* no-op */ },
+    };
+    (overlays as unknown as Record<string, unknown>)['section2DOverlayRenderer'] = fakeRenderer;
+
+    return { camera, overlays };
+}
+
+describe('grid-only content reaching the wrong channel reframes the camera (issue #3359)', () => {
+    it('BUG: routed to "annotation" (today\'s wiring), grid-only content drags the orbit-pivot fallback off the real model, toward the grid', () => {
+        const { camera, overlays } = makeHarness();
+        const before = camera.getSceneBounds();
+        assert.ok(before, 'precondition: the real model already seeded scene bounds');
+        const pivotBefore = centroid(before!);
+        assert.deepStrictEqual(pivotBefore, { x: 5, y: 0, z: 5 }, 'precondition: pivot starts at the real model centre');
+
+        // Today's wiring: `useSymbolicAnnotations` puts grid content on the
+        // SAME buffer as annotations, uploaded to the 'annotation' channel.
+        overlays.setLineOverlay('annotation', GRID_ONLY_VERTS);
+
+        const after = camera.getSceneBounds();
+        assert.ok(after);
+        const pivotAfter = centroid(after!);
+
+        // The grid line's own X range is [-500, 500], centred on 0 — the
+        // scene bounds fold the model's [0,10] into it, so the combined
+        // centroid lands far from the model's own (5, 0, 5).
+        assert.ok(
+            dist(pivotBefore, pivotAfter) > 100,
+            `the empty-space orbit-pivot fallback (camera.getSceneBounds() centroid) moved from ` +
+            `(${pivotBefore.x}, ${pivotBefore.y}, ${pivotBefore.z}) to ` +
+            `(${pivotAfter.x}, ${pivotAfter.y}, ${pivotAfter.z}) — a grid-only upload on the ` +
+            `'annotation' channel reframes empty-space orbit around the grid instead of the model`,
+        );
+    });
+
+    it('FIXED: routed to "grid", the same content leaves the orbit-pivot fallback exactly on the real model', () => {
+        const { camera, overlays } = makeHarness();
+        const before = centroid(camera.getSceneBounds()!);
+
+        // The fix: `useSymbolicAnnotations` returns `{ annotation, grid }`
+        // separately, and the grid buffer is uploaded to the 'grid' channel.
+        overlays.setLineOverlay('grid', GRID_ONLY_VERTS);
+
+        const after = centroid(camera.getSceneBounds()!);
+        assert.deepStrictEqual(
+            after,
+            before,
+            'the grid channel must not move the orbit-pivot fallback at all (CHANNEL_EXPANDS_MODEL_BOUNDS.grid is false)',
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #3359. `useSymbolicAnnotations` lifted IfcAnnotation curves AND IfcGridAxis lines into ONE buffer uploaded to the renderer's `annotation` line-overlay channel. With "Show IFC Annotations" off and the IfcGrid toggle on, that buffer carried only grid content — but `CHANNEL_EXPANDS_MODEL_BOUNDS.annotation` (`packages/renderer/src/renderer-overlays.ts`) is `true`, the opposite of `grid: false`, which exists precisely because grid axes routinely extend past the model envelope (issue #967). So a grid-only upload on the `annotation` channel grew the scene bounds `grid: false` exists to protect, and any later camera fit or empty-space orbit gesture — whose pivot falls back to the scene-bounds centroid (`useMouseControls.ts`/`useTouchControls.ts`) — reframed around the inflated bounds instead of the model.

**Root cause:** the channel a buffer reached was decided by which HOOK produced it, not by what CONTENT it held — the renderer's bounds-expansion policy is keyed by channel, but `useSymbolicAnnotations` fed two content kinds into the same one.

**Relationship to #3368 / PR #3376:** that PR removes the duplicate, unclipped `useGridLines3D` upload so grid lines draw only from the symbolic (clipped) path — a dedupe on the SAME (`annotation`) channel. It does not change which channel grid content reaches, so it does not resolve this issue; this PR is complementary and still needed after #3376 lands (I merged the two buffers' `grid` channel here so it works correctly with or without #3376 merged first).

## Fix

`useSymbolicAnnotations` now returns `{ annotation, grid }` as two separate buffers instead of one. The merge logic (previously inline) is split into a new pure function, `buildSymbolicLineChannels` in `apps/viewer/src/hooks/symbolic-line-channels.ts` — split out so it is unit-testable with no React/store/WASM dependency, and to keep the hook file under the module-size budget. `Viewport.tsx` now uploads `annotation` to the `'annotation'` channel and `grid` to the `'grid'` channel (merged with the existing `useGridLines3D` output via the new `merge-grid-line-channels.ts`, pending #3368's single-owner dedupe).

## Test plan

- [x] `apps/viewer/src/hooks/useSymbolicAnnotations.gridChannelSplit.test.ts` (new): pins that a grid-only `ParseResult` (annotation buckets empty) produces an empty `annotation` buffer and a populated `grid` buffer — RED before the fix (stashed source, restored by SHA): `buildSymbolicLineChannels` did not exist, so the grid-only content had no way to avoid the single shared buffer. GREEN after.
- [x] `packages/renderer/src/renderer-overlays-grid-channel-reframe.test.ts` (new): demonstrates the reframe mechanism directly against real `Camera` + `ModelBoundsTracker` + `RendererOverlays` code (no fakes for those two), starting from a camera pose distinct from both the model centre and the origin so a spurious reframe is observable. Grid-only content uploaded to `'annotation'` (today's pre-fix wiring) drags the empty-space orbit-pivot fallback (`camera.getSceneBounds()` centroid) far from the model; the same content uploaded to `'grid'` (the fix's wiring) leaves it untouched.
- [x] Scoped run: `useSymbolicAnnotations*.test.ts`, `useSymbolicAnnotationsForDrawing.classGate.test.tsx`, `dxf-lines-3d-upload.test.ts`, `store/teardown-registry.test.ts` — 41/41 pass. `renderer-overlays-grid-channel-reframe.test.ts`, `renderer-overlays-line-channels.test.ts`, `renderer-overlays-section.test.ts`, `model-bounds-tracker.test.ts` — 46/46 pass.
- [x] `pnpm typecheck` (turbo, full workspace): clean.
- [x] `node scripts/check-module-size.mjs`: exit 0 (`Viewport.tsx` trimmed back to its existing 1840-line budget; `useSymbolicAnnotations.ts` shrunk by splitting `buildSymbolicLineChannels` into its own file).
- [x] `node scripts/check-source-text-assertions.mjs`: exit 0, no new assertions.
- [x] `git status --porcelain` clean before push.

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436