### PR TITLE
fix(release): bound the crates.io publish phase by the token's real lifetime, not just the budget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,23 @@ jobs:
         id: crates-auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
 
+      # Stamp the mint time immediately after the token above, NOT after the
+      # semver-gate installs or the publish-script step that consumes it
+      # (#3258). `crates-io-auth-action` exposes only the token — no expiry
+      # (see its action.yml) — so the only way to know how much of the
+      # token's claimed 30-minute lifetime is left is to record when this
+      # step ran and do the arithmetic ourselves downstream. Passed to the
+      # changesets step below as CRATES_TOKEN_MINTED_AT_MS,
+      # `scripts/release-crates.mjs` takes the publish-phase deadline as the
+      # earlier of its own release-wide budget and (mint time + 30 minutes −
+      # a margin), so time already spent on the semver gate below, the
+      # second build, `test:esm`, and the full npm publish between here and
+      # the crates loop is charged against the token's real remaining
+      # lifetime instead of escaping the bound entirely.
+      - name: Stamp crates.io token mint time
+        id: crates-auth-time
+        run: echo "minted_at_ms=$(node -e 'process.stdout.write(String(Date.now()))')" >> "$GITHUB_OUTPUT"
+
       # SEMVER GATE for the crates (issue #3216). `pnpm release` runs
       # `check:rust-semver` before it publishes anything; these two steps put
       # the tool it needs on PATH.
@@ -262,6 +279,12 @@ jobs:
           NPM_CONFIG_PROVENANCE: 'true'
           # crates.io token minted via OIDC above; expires in 30 minutes.
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
+          # When the token above was minted, so `scripts/release-crates.mjs`
+          # can bound the publish phase by the token's real remaining
+          # lifetime rather than by a budget that only starts counting once
+          # this whole step (build, test:esm, npm publish) is already done.
+          # See the comment on the "Stamp crates.io token mint time" step.
+          CRATES_TOKEN_MINTED_AT_MS: ${{ steps.crates-auth-time.outputs.minted_at_ms }}
 
       # Whether to create this version's release artifacts.
       #

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -76,6 +76,85 @@ const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const PUBLISH_POLL_INTERVAL_MS = 5000;
 const PUBLISH_POLL_TIMEOUT_MS = 660_000;
 
+// The per-crate cap above is not a bound on the RELEASE. Seven crates at 660s
+// is 77 minutes, against a CARGO_REGISTRY_TOKEN that `release.yml` documents as
+// short-lived, 30 minutes from the mint, at lines 13, 205 and 243. Spend longer
+// than the token lasts and a later `cargo publish` fails AUTHENTICATION with
+// earlier crates already on the registry: the same half-publish this poll exists
+// to prevent, wearing an error that points at auth rather than propagation.
+//
+// So the loop carries one wall-clock budget for all crates and gives each crate
+// whatever is left of it, capped by the per-crate value.
+//
+// BE EXACT ABOUT WHAT THIS BOUNDS, because it is less than it looks.
+//
+// It bounds the publish phase: everything from the first `cargo publish` to the
+// last index wait, INCLUDING the seven `cargo publish` invocations themselves,
+// which run full verification builds (no `--no-verify`) and cargo's own ~60s
+// index wait each. It does NOT bound token consumption. The token is minted at
+// `release.yml`'s auth step, and between that and this loop the changesets step
+// runs a second `pnpm build`, `test:esm`, and the entire npm publish with
+// per-tarball provenance. None of that is charged here, so total consumption is
+// (elapsed since mint) + this budget, which is not bounded above by 900s.
+//
+// Bounding the real constraint needs the mint timestamp plumbed in from the
+// workflow and the deadline taken as the earlier of the two — this is #3258,
+// closed by `tokenMintedAtMs` below. When it is supplied, the deadline is
+// whichever comes first: this budget, or the token's own claimed lifetime.
+// When it is NOT supplied (a manual/local run with no minted token), this
+// constant is the only bound, same as before #3258 — it stops the unbounded
+// 77-minute case but not total token consumption.
+//
+// For the same reason, do not read 900s as "enough for one 600s CDN TTL stall
+// plus slack". That subtraction ignores the seven verification builds inside
+// the same budget and has not been measured. Raising it to fit a worst case of
+// cap x crates is worse still: that worst case cannot be afforded at all.
+//
+// The 30-minute figure is this repo's own claim in release.yml, not something
+// read off `crates-io-auth-action`, whose action.yml says only "temporary".
+const PUBLISH_PHASE_BUDGET_MS = 900_000;
+
+// The token's claimed lifetime — same unverified 30-minute figure as above,
+// this repo's own claim (release.yml lines 13, 205, 243), not something
+// `crates-io-auth-action` exposes (its action.yml outputs only `token`, no
+// expiry).
+const CRATES_TOKEN_LIFETIME_MS = 30 * 60 * 1000;
+
+// Subtracted from CRATES_TOKEN_LIFETIME_MS before treating it as a deadline.
+// `tokenMintedAtMs` is stamped by a workflow step that runs AFTER the auth
+// action returns, not at the instant the token is actually issued, and the
+// gap between "cargo publish presents the token" and "the registry checks
+// it" is not zero either. This margin keeps that slack from being counted as
+// usable budget.
+const CRATES_TOKEN_MARGIN_MS = 60_000;
+
+/**
+ * Reads `CRATES_TOKEN_MINTED_AT_MS` from an env-like object. Returns
+ * `undefined` when unset (a manual/local run with no minted token — the
+ * budget-only deadline still applies) and THROWS when set but not a finite
+ * epoch-milliseconds number, rather than letting a malformed value silently
+ * defeat the bound: an un-validated NaN propagates through Math.min and every
+ * `<= 0` / `<` comparison below without ever being caught, which is exactly
+ * how a non-numeric budget was found to hang the release forever (see the
+ * PR/issue discussion on #3258). Validating at this boundary is what makes
+ * that latent failure mode unreachable once this value is read from
+ * `process.env` in `main()`.
+ */
+export function parseTokenMintedAtMs(env = process.env) {
+  const raw = env.CRATES_TOKEN_MINTED_AT_MS;
+  if (raw === undefined || raw === '') return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(
+      `CRATES_TOKEN_MINTED_AT_MS is set to ${JSON.stringify(raw)}, which is not a finite ` +
+        `number of milliseconds since the epoch. Refusing to start the crates.io publish ` +
+        `phase with a token-budget deadline that cannot be computed, rather than silently ` +
+        `falling back to an unbounded one.`
+    );
+  }
+  return parsed;
+}
+
 export async function publishAllCrates({
   crates = CRATES,
   version,
@@ -93,9 +172,60 @@ export async function publishAllCrates({
   indexCheckFn = isInSparseIndex,
   intervalMs = PUBLISH_POLL_INTERVAL_MS,
   timeoutMs = PUBLISH_POLL_TIMEOUT_MS,
+  totalBudgetMs = PUBLISH_PHASE_BUDGET_MS,
+  // Epoch-ms timestamp of when the CARGO_REGISTRY_TOKEN was minted, stamped
+  // by `release.yml` right after the OIDC exchange and plumbed down through
+  // `pnpm run release` as `CRATES_TOKEN_MINTED_AT_MS`. When supplied, the
+  // deadline below is capped by the token's own claimed lifetime — not just
+  // this function's own budget — so time already spent between the mint and
+  // this call (a second build, test:esm, the whole npm publish; see the
+  // header) is charged against it. `undefined` (no minted token — a
+  // manual/local run) falls back to the budget-only deadline this function
+  // has always used.
+  tokenMintedAtMs,
   sleepFn,
 } = {}) {
+  const startedAt = Date.now();
+  const budgetOnlyDeadline = startedAt + totalBudgetMs;
+  const tokenDeadline =
+    tokenMintedAtMs == null ? undefined : tokenMintedAtMs + CRATES_TOKEN_LIFETIME_MS - CRATES_TOKEN_MARGIN_MS;
+  // One deadline for the whole run, not one per crate. See the note on
+  // PUBLISH_PHASE_BUDGET_MS: the binding constraint is the registry token,
+  // which does not restart between crates. Whichever of the two candidate
+  // deadlines is EARLIER wins — a large release-wide budget must not paper
+  // over a token that is already close to (or past) its own lifetime.
+  const budgetDeadline = tokenDeadline === undefined ? budgetOnlyDeadline : Math.min(budgetOnlyDeadline, tokenDeadline);
+  const boundByToken = tokenDeadline !== undefined && tokenDeadline < budgetOnlyDeadline;
+  // Seconds-from-now this run actually has, for the messages below. Equal to
+  // `totalBudgetMs` whenever the token isn't the tighter bound, so every
+  // pre-#3258 message stays byte-identical when no token is supplied.
+  const effectiveBudgetMs = budgetDeadline - startedAt;
+
   for (const crate of crates) {
+    // BEFORE the publish, not after. Placed below it, this guard still ran
+    // `cargo publish` for the crate it then named as "not published" — one
+    // irreversible upload past the point it had decided further uploads were
+    // unsafe, which is the failure it exists to prevent.
+    const budgetLeftMs = budgetDeadline - Date.now();
+    if (budgetLeftMs <= 0) {
+      throw new Error(
+        `Ran out of publish-phase budget before ${crate}@${version}, which has NOT ` +
+          `been published. The release has spent its whole ` +
+          `${Math.round(effectiveBudgetMs / 1000)}s allowance on publishing and on waiting ` +
+          `for crates to become resolvable` +
+          (boundByToken
+            ? ` — this run is bounded by the crates.io token's own remaining lifetime ` +
+              `(minted at ${new Date(tokenMintedAtMs).toISOString()}), tighter here than the ` +
+              `${Math.round(totalBudgetMs / 1000)}s release-wide budget`
+            : '') +
+          `. The crates.io token from ` +
+          `crates-io-auth-action is short-lived (this repo's release.yml documents 30 ` +
+          `minutes from the mint), so publishing further crates now risks failing on ` +
+          `AUTHENTICATION with earlier crates already on the registry. Stopping while ` +
+          `the failure is still legible. Re-running is safe: already-published crates ` +
+          `are not re-published, and a re-run mints a fresh token.`
+      );
+    }
     // The already-published pre-check is an OPTIMISATION, not a gate: a
     // registry error here (one that outlasted `cratesIoGet`'s retry budget)
     // must not abort a release part-way down this list. Fall through to the
@@ -129,24 +259,55 @@ export async function publishAllCrates({
     // API record — skipping straight past it would re-create the original
     // failure at its first dependent if the index still has not caught up.
     console.log(`⏳ Waiting for ${crate}@${version} to appear in the crates.io index …`);
+    // Measured HERE, not reused from the guard above. `publishFn` runs a full
+    // verification build between the two points, and sizing the wait from the
+    // pre-publish remainder let that build's time escape the budget entirely:
+    // with a 900s budget and a 400s publish, the stale remainder still exceeded
+    // the 660s cap, so the cap won, the wait ran in full, the phase ended 160s
+    // past the deadline, and the message blamed the cap without mentioning the
+    // budget. The budget was silently defeated for exactly the crate whose
+    // publish had consumed it.
+    const remainingMs = budgetDeadline - Date.now();
+    // Whichever binds first. The per-crate cap keeps one stuck crate from
+    // eating the whole run; the budget keeps the run inside the token.
+    const thisWaitMs = Math.max(0, Math.min(timeoutMs, remainingMs));
     const { ok, waitedMs, attempts, lastError } = await waitUntilInIndex(crate, version, {
       checkFn: indexCheckFn,
       intervalMs,
-      timeoutMs,
+      timeoutMs: thisWaitMs,
       ...(sleepFn ? { sleepFn } : {}),
     });
     if (!ok) {
+      const boundedByBudget = remainingMs < timeoutMs;
       throw new Error(
         `${crate}@${version} did not appear in the crates.io index within ` +
-          `${Math.round(timeoutMs / 1000)}s (${attempts} checks). ` +
+          `${Math.round(thisWaitMs / 1000)}s (${attempts} checks)` +
+          (boundedByBudget
+            ? `, which was the remainder of the ${Math.round(effectiveBudgetMs / 1000)}s ` +
+              `release-wide budget rather than the ${Math.round(timeoutMs / 1000)}s ` +
+              `per-crate cap` +
+              (boundByToken ? ` (itself capped by the crates.io token's remaining lifetime)` : ``) +
+              `. `
+            : `. `) +
           `The upload succeeded (or the version was already uploaded), but the index ` +
           `cargo resolves against has not caught up — publishing the next crate now ` +
           `would fail to resolve this one. Failing the release rather than racing it. ` +
-          `Re-running is safe (already-published crates are not re-published), but if ` +
-          `the cause is a stale CDN edge rather than the origin, an immediate re-run ` +
-          `hits the same cached copy: check ` +
-          `\`curl -sI https://index.crates.io/<path>\` for last-modified and age, and ` +
-          `if the origin already has the version, wait out the remaining max-age.` +
+          // Two different causes need two different remedies. Cut short by the
+          // budget, the index may be perfectly healthy and the answer is a fresh
+          // token; stuck at the cap, the answer is to look at the CDN edge.
+          // Giving the CDN remedy for a budget stop sends the operator to
+          // inspect something that was never the problem.
+          (boundedByBudget
+            ? `The wait was cut short by the budget, not by a stuck index, so the ` +
+              `index may be fine. The crates.io token is short-lived; re-run to mint ` +
+              `a fresh one. Already-published crates are not re-published, so a ` +
+              `re-run resumes rather than repeating.`
+            : `Re-running is safe (already-published crates are not re-published), ` +
+              `but if the cause is a stale CDN edge rather than the origin, an ` +
+              `immediate re-run hits the same cached copy: check ` +
+              `\`curl -sI https://index.crates.io/<path>\` for last-modified and age, ` +
+              `and if the origin already has the version, wait out the remaining ` +
+              `max-age.`) +
           // Distinguishes "the index never caught up" from "crates.io was
           // erroring the whole time" — the same message for both would send
           // the operator hunting a propagation problem during an outage.
@@ -159,7 +320,11 @@ export async function publishAllCrates({
 
 async function main() {
   const version = readWorkspaceVersion(rootDir);
-  await publishAllCrates({ version, cwd: rootDir });
+  // Validated at this boundary, once, before anything else runs — see
+  // `parseTokenMintedAtMs`. Unset (no `release.yml` step wired it in) falls
+  // back to the budget-only deadline `publishAllCrates` has always used.
+  const tokenMintedAtMs = parseTokenMintedAtMs();
+  await publishAllCrates({ version, cwd: rootDir, tokenMintedAtMs });
 }
 
 // Only run when invoked directly (`node scripts/release-crates.mjs`), not

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -142,14 +142,26 @@ const CRATES_TOKEN_MARGIN_MS = 60_000;
  */
 export function parseTokenMintedAtMs(env = process.env) {
   const raw = env.CRATES_TOKEN_MINTED_AT_MS;
-  if (raw === undefined || raw === '') return undefined;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed)) {
+  // Trimmed before the empty-string check, not after: a whitespace-only value
+  // (e.g. a step output that came back `' '`) is not `=== ''`, so it used to
+  // fall through to `Number(' ')`, which is 0 — not NaN, so the finite check
+  // below let it pass. An epoch-ms deadline of 0 is 1970, already expired, so
+  // the run aborted the crates phase before publishing the first crate, AFTER
+  // npm had already published — manufacturing exactly the half-release this
+  // script exists to prevent.
+  const trimmed = raw === undefined ? undefined : raw.trim();
+  if (trimmed === undefined || trimmed === '') return undefined;
+  const parsed = Number(trimmed);
+  // `<= 0` alongside the finiteness check: a non-positive epoch timestamp
+  // (0, or a negative value from a misconfigured step) is not malformed in
+  // the NaN sense, but it is not a real mint time either, and treating it as
+  // one manufactures the same already-expired-deadline half-release above.
+  if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new Error(
-      `CRATES_TOKEN_MINTED_AT_MS is set to ${JSON.stringify(raw)}, which is not a finite ` +
-        `number of milliseconds since the epoch. Refusing to start the crates.io publish ` +
-        `phase with a token-budget deadline that cannot be computed, rather than silently ` +
-        `falling back to an unbounded one.`
+      `CRATES_TOKEN_MINTED_AT_MS is set to ${JSON.stringify(raw)}, which is not a positive, ` +
+        `finite number of milliseconds since the epoch. Refusing to start the crates.io ` +
+        `publish phase with a token-budget deadline that cannot be computed, rather than ` +
+        `silently falling back to an unbounded one or to an already-expired one.`
     );
   }
   return parsed;
@@ -185,6 +197,23 @@ export async function publishAllCrates({
   tokenMintedAtMs,
   sleepFn,
 } = {}) {
+  // `main()` only ever passes a value that survived `parseTokenMintedAtMs`,
+  // but this function is also called directly (every test in this file does,
+  // and so could a future internal caller), and a non-finite value here is
+  // worse than a missing one: `Math.min(x, NaN)` is `NaN`, so `tokenDeadline`
+  // going NaN would poison `budgetDeadline` too and every `<= 0` / `<`
+  // comparison against it below is false for NaN, which disarms BOTH the
+  // token bound and the pre-existing release-wide budget it is supposed to
+  // tighten. Guarding here, not just in `parseTokenMintedAtMs`, is what makes
+  // that NaN-falls-through shape unreachable regardless of caller.
+  if (tokenMintedAtMs != null && !Number.isFinite(tokenMintedAtMs)) {
+    throw new Error(
+      `tokenMintedAtMs is ${JSON.stringify(tokenMintedAtMs)}, which is not a finite number ` +
+        `of milliseconds since the epoch. Refusing to start the crates.io publish phase ` +
+        `with a token-budget deadline that cannot be computed, rather than silently ` +
+        `disarming both the token bound and the release-wide budget.`
+    );
+  }
   const startedAt = Date.now();
   const budgetOnlyDeadline = startedAt + totalBudgetMs;
   const tokenDeadline =

--- a/scripts/release-crates.mjs
+++ b/scripts/release-crates.mjs
@@ -208,7 +208,7 @@ export async function publishAllCrates({
   // that NaN-falls-through shape unreachable regardless of caller.
   if (tokenMintedAtMs != null && !Number.isFinite(tokenMintedAtMs)) {
     throw new Error(
-      `tokenMintedAtMs is ${JSON.stringify(tokenMintedAtMs)}, which is not a finite number ` +
+      `tokenMintedAtMs is ${String(tokenMintedAtMs)}, which is not a finite number ` +
         `of milliseconds since the epoch. Refusing to start the crates.io publish phase ` +
         `with a token-budget deadline that cannot be computed, rather than silently ` +
         `disarming both the token bound and the release-wide budget.`

--- a/scripts/release-crates.test.mjs
+++ b/scripts/release-crates.test.mjs
@@ -15,13 +15,16 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { publishAllCrates } from './release-crates.mjs';
+import { publishAllCrates, parseTokenMintedAtMs } from './release-crates.mjs';
 
 function fakeClock(start = 0) {
   let now = start;
   const realNow = Date.now;
   Date.now = () => now;
   return {
+    advance: (ms) => {
+      now += ms;
+    },
     sleepFn: async (ms) => {
       now += ms;
     },
@@ -166,6 +169,141 @@ test('a transient crates.io error mid-list does NOT abort the release into a par
       published,
       ['ifc-lite-core', 'ifc-lite-geometry', 'ifc-lite-clash'],
       'a blip must not leave the release stopped part-way down the list'
+    );
+  } finally {
+    clock.restore();
+  }
+});
+
+test('the budget charges cargo publish too, not only the index waits', async () => {
+  // The constant is PUBLISH_PHASE_BUDGET_MS and the comment says it covers the
+  // seven `cargo publish` invocations, which run full verification builds. No
+  // test charged anything but index waits, so that claim was unverified: an
+  // implementation accumulating only `waitedMs` passed the whole file.
+  //
+  // Here `publishFn` advances the clock. With a 500s budget and a 400s publish,
+  // only 100s of waiting may remain; charging index waits alone would allow the
+  // full 660s cap.
+  const clock = fakeClock();
+  try {
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core'],
+          version: '6.0.0',
+          publishFn: () => clock.advance(400_000),
+          preCheckFn: async () => false,
+          indexCheckFn: async () => false,
+          intervalMs: 5000,
+          timeoutMs: 660_000,
+          totalBudgetMs: 500_000,
+          sleepFn: clock.sleepFn,
+        }),
+      /within 100s[\s\S]*remainder of the 500s release-wide budget/
+    );
+  } finally {
+    clock.restore();
+  }
+});
+
+test('the index wait is bounded by ONE release-wide budget, not by the per-crate cap x crates', async () => {
+  // The defect this pins: 7 crates x a 660s per-crate cap is 77 minutes, inside
+  // a CARGO_REGISTRY_TOKEN that expires in 30. If the budget restarts per crate
+  // it enforces nothing across the run, and a later `cargo publish` fails on
+  // AUTH with earlier crates already published.
+  //
+  // The discriminating shape matters, and my first attempt at this test did not
+  // have it: with a budget barely above one cap, the run dies on the FIRST
+  // crate either way and the reset is never observed. So the first crate must
+  // SUCCEED and consume budget, and the second must show a shortened wait.
+  const clock = fakeClock();
+  try {
+    const published = [];
+    // core becomes visible only after 400s of waiting; clash never does.
+    const indexCheckFn = async (crate) => crate === 'ifc-lite-core' && Date.now() >= 400_000;
+
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core', 'ifc-lite-clash'],
+          version: '6.0.0',
+          publishFn: (c) => published.push(c),
+          preCheckFn: async () => false,
+          indexCheckFn,
+          intervalMs: 5000,
+          timeoutMs: 660_000, // per-crate cap
+          totalBudgetMs: 700_000, // one cap plus a little
+          sleepFn: clock.sleepFn,
+        }),
+      // With ONE shared budget, core's 400s leaves clash ~300s, so clash's wait
+      // is bounded by the budget and the message says so. With a per-crate
+      // reset, clash would get its full 660s cap and this phrase is absent.
+      /remainder of the 700s release-wide budget rather than the 660s per-crate cap/
+    );
+    assert.deepEqual(published, ['ifc-lite-core', 'ifc-lite-clash']);
+  } finally {
+    clock.restore();
+  }
+});
+
+test('a budget stop happens BEFORE the publish, so the crate it names is really unpublished', async () => {
+  // The guard used to sit below `publishFn`, so it ran `cargo publish` for the
+  // crate it then reported as not published: one irreversible upload past the
+  // point it had decided further uploads were unsafe. The message was false and
+  // the guard defeated its own purpose.
+  const clock = fakeClock();
+  try {
+    const published = [];
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core', 'ifc-lite-clash', 'ifc-lite-geometry'],
+          version: '6.0.0',
+          publishFn: (c) => published.push(c),
+          preCheckFn: async () => false,
+          // core becomes visible exactly as the budget runs out.
+          indexCheckFn: async (c) => c === 'ifc-lite-core' && Date.now() >= 300_000,
+          intervalMs: 5000,
+          timeoutMs: 660_000,
+          totalBudgetMs: 300_000,
+          sleepFn: clock.sleepFn,
+        }),
+      /before ifc-lite-clash@6\.0\.0, which has NOT been published/
+    );
+    // The assertion that actually catches the defect: clash must not appear.
+    assert.deepEqual(published, ['ifc-lite-core']);
+  } finally {
+    clock.restore();
+  }
+});
+
+test('a crate whose wait is cut short by the budget says so, and gives the token remedy not the CDN one', async () => {
+  // Two different failures must not read the same. "Cap exceeded" means the
+  // index is genuinely stuck; "budget exceeded" means stop before the token
+  // dies. An operator who cannot tell them apart re-runs into the wrong one.
+  const clock = fakeClock();
+  try {
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core'],
+          version: '6.0.0',
+          publishFn: () => {},
+          preCheckFn: async () => false,
+          indexCheckFn: async () => false,
+          intervalMs: 5000,
+          timeoutMs: 660_000,
+          totalBudgetMs: 30_000, // budget binds well before the cap
+          sleepFn: clock.sleepFn,
+        }),
+      // Asserts across the JOIN, not just the prefix. A stray `+ +` here coerced
+      // the tail to NaN and swallowed a whole sentence while a prefix-only
+      // assertion stayed green.
+      // Spans the join (a stray `+ +` once coerced the tail to NaN and swallowed
+      // a sentence while prefix-only assertions stayed green), and pins the
+      // budget-specific remedy: a budget stop must NOT send the operator to
+      // inspect a CDN edge that was never the problem.
+      /remainder of the 30s release-wide budget rather than the 660s per-crate cap\. The upload succeeded[\s\S]*cut short by the budget, not by a stuck index[\s\S]*mint\s+a fresh one/
     );
   } finally {
     clock.restore();
@@ -321,4 +459,123 @@ test('the DEFAULT wiring polls the sparse index and pre-checks the API — not o
     globalThis.fetch = realFetch;
     clock.restore();
   }
+});
+
+// #3258: the budget started counting only inside `publishAllCrates`, so
+// unmeasured work between the token mint and this loop (a second build,
+// test:esm, the whole npm publish) was never charged against it. Passing
+// `tokenMintedAtMs` closes that: the deadline becomes whichever is EARLIER,
+// this budget or the token's own claimed lifetime measured from the mint.
+
+test('a token minted well before the loop starts is already past its lifetime, and a large budget alone would have missed that (#3258)', async () => {
+  const clock = fakeClock(); // "now" = 0
+  try {
+    // Simulates the real defect: by the time this loop runs, the token was
+    // already minted 2,000,000ms (~33min) ago — standing in for the
+    // unmeasured second build + test:esm + full npm publish that happens
+    // between the mint and here. The 30-minute token (minus the 60s margin)
+    // is therefore already expired, even though the release-wide budget
+    // below is generous and has never been touched.
+    const mintedAtMs = -2_000_000;
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core'],
+          version: '6.0.0',
+          publishFn: () => {
+            throw new Error('must not publish: the crates.io token is already past its lifetime');
+          },
+          preCheckFn: async () => false,
+          indexCheckFn: async () => false,
+          intervalMs: 5000,
+          timeoutMs: 660_000,
+          totalBudgetMs: 900_000, // plenty of budget-only headroom
+          tokenMintedAtMs: mintedAtMs,
+          sleepFn: clock.sleepFn,
+        }),
+      /Ran out of publish-phase budget before ifc-lite-core@6\.0\.0[\s\S]*crates\.io token's own remaining lifetime/
+    );
+  } finally {
+    clock.restore();
+  }
+});
+
+test('the token bound charges the SAME publish-phase work as the release-wide budget, so a stall it alone would have allowed is now caught', async () => {
+  // With no token, the budget is 3,000,000ms and would not bind here at all.
+  // With the token, the 30-minute (minus 60s margin) lifetime from the mint
+  // is the tighter deadline, so the same publish + index-wait sequence must
+  // now fail against it instead of sailing through on the oversized budget.
+  const clock = fakeClock();
+  try {
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core'],
+          version: '6.0.0',
+          // Mint happens at the same instant this loop starts (the best
+          // case for the old, unfixed code — even here it must now bind).
+          tokenMintedAtMs: 0,
+          publishFn: () => clock.advance(1_700_000), // 28m20s of build+verify
+          preCheckFn: async () => false,
+          indexCheckFn: async () => false,
+          intervalMs: 5000,
+          timeoutMs: 660_000,
+          totalBudgetMs: 3_000_000, // deliberately far looser than the token
+          sleepFn: clock.sleepFn,
+        }),
+      /did not appear in the crates\.io index within 40s[\s\S]*remainder of the 1740s release-wide budget[\s\S]*capped by the crates\.io token/
+    );
+  } finally {
+    clock.restore();
+  }
+});
+
+test('without a minted-token timestamp, the deadline falls back to the release-wide budget only (manual/local run)', async () => {
+  // Pins the pre-#3258 fallback: `tokenMintedAtMs` omitted must reproduce the
+  // exact old message, unchanged, so a local `node scripts/release-crates.mjs`
+  // run (no minted token to bound against) is not newly and needlessly
+  // stricter.
+  const clock = fakeClock();
+  try {
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core'],
+          version: '6.0.0',
+          publishFn: () => clock.advance(400_000),
+          preCheckFn: async () => false,
+          indexCheckFn: async () => false,
+          intervalMs: 5000,
+          timeoutMs: 660_000,
+          totalBudgetMs: 500_000,
+          sleepFn: clock.sleepFn,
+        }),
+      /within 100s[\s\S]*remainder of the 500s release-wide budget rather than the 660s per-crate cap\. /
+    );
+  } finally {
+    clock.restore();
+  }
+});
+
+test('parseTokenMintedAtMs returns undefined when CRATES_TOKEN_MINTED_AT_MS is unset', () => {
+  assert.equal(parseTokenMintedAtMs({}), undefined);
+});
+
+test('parseTokenMintedAtMs returns undefined when CRATES_TOKEN_MINTED_AT_MS is the empty string', () => {
+  assert.equal(parseTokenMintedAtMs({ CRATES_TOKEN_MINTED_AT_MS: '' }), undefined);
+});
+
+test('parseTokenMintedAtMs parses a valid numeric string', () => {
+  assert.equal(parseTokenMintedAtMs({ CRATES_TOKEN_MINTED_AT_MS: '1735689600000' }), 1735689600000);
+});
+
+test('parseTokenMintedAtMs REFUSES a non-numeric value instead of letting NaN silently defeat the bound', () => {
+  // A NaN deadline would propagate through Math.min and every `<=`/`<`
+  // comparison in `publishAllCrates` without ever tripping — the exact "hangs
+  // the release forever" shape flagged on #3258 for an unvalidated budget
+  // read from the environment.
+  assert.throws(
+    () => parseTokenMintedAtMs({ CRATES_TOKEN_MINTED_AT_MS: 'not-a-number' }),
+    /CRATES_TOKEN_MINTED_AT_MS.*not-a-number/
+  );
 });

--- a/scripts/release-crates.test.mjs
+++ b/scripts/release-crates.test.mjs
@@ -579,3 +579,59 @@ test('parseTokenMintedAtMs REFUSES a non-numeric value instead of letting NaN si
     /CRATES_TOKEN_MINTED_AT_MS.*not-a-number/
   );
 });
+
+test('parseTokenMintedAtMs treats a whitespace-only value as unset, not as epoch 0', () => {
+  // `' '` is not `=== ''`, so it used to fall through to `Number(' ')`,
+  // which is 0 — finite, so the old check let it pass. An epoch-ms deadline
+  // of 0 is 1970: already expired, so the run aborted the crates phase
+  // before the first publish, AFTER npm had already published — the exact
+  // half-release this script exists to prevent. Trimming first makes a
+  // whitespace value behave like an unset one (budget-only fallback)
+  // instead of manufacturing that already-expired deadline.
+  assert.equal(parseTokenMintedAtMs({ CRATES_TOKEN_MINTED_AT_MS: '   ' }), undefined);
+});
+
+test('parseTokenMintedAtMs REFUSES a non-positive timestamp', () => {
+  // Not a NaN-shaped malformation, but not a real mint time either: 0 or a
+  // negative value produces the same already-expired-deadline half-release
+  // as the whitespace case above, just via a value that IS finite.
+  assert.throws(
+    () => parseTokenMintedAtMs({ CRATES_TOKEN_MINTED_AT_MS: '0' }),
+    /CRATES_TOKEN_MINTED_AT_MS/
+  );
+  assert.throws(
+    () => parseTokenMintedAtMs({ CRATES_TOKEN_MINTED_AT_MS: '-5' }),
+    /CRATES_TOKEN_MINTED_AT_MS/
+  );
+});
+
+test('publishAllCrates REFUSES a non-finite tokenMintedAtMs passed directly, instead of disarming both bounds', async () => {
+  // parseTokenMintedAtMs validates the env-var path, but publishAllCrates is
+  // also callable directly with tokenMintedAtMs bypassing it entirely. A NaN
+  // there poisons budgetDeadline via Math.min(x, NaN) === NaN, and every
+  // `<=`/`<` comparison against NaN is false — so with totalBudgetMs: 0 (an
+  // already-exhausted release-wide budget) the run would otherwise publish
+  // anyway, because NEITHER bound can trip on a NaN deadline.
+  const clock = fakeClock();
+  try {
+    const published = [];
+    await assert.rejects(
+      () =>
+        publishAllCrates({
+          crates: ['ifc-lite-core'],
+          version: '6.0.0',
+          publishFn: (c) => published.push(c),
+          preCheckFn: async () => false,
+          indexCheckFn: async () => true,
+          totalBudgetMs: 0,
+          tokenMintedAtMs: NaN,
+          sleepFn: clock.sleepFn,
+        }),
+      /tokenMintedAtMs is NaN, which is not a finite number/
+    );
+    // The assertion that actually catches the defect: nothing published.
+    assert.deepEqual(published, []);
+  } finally {
+    clock.restore();
+  }
+});


### PR DESCRIPTION
## Summary

#3258: `PUBLISH_PHASE_BUDGET_MS` in `scripts/release-crates.mjs` (on `relfix/crates-poll-budget`, #3188's line of work) starts its clock only inside `publishAllCrates`. Everything between minting `CARGO_REGISTRY_TOKEN` and reaching that loop — a second `pnpm build`, `test:esm`, and the entire npm publish with per-tarball OIDC provenance — was never charged against it, so a large release-wide budget could pass even when the 30-minute token was already close to (or past) its claimed lifetime by the time the crates loop started.

## The ordering, quoted

Mint (`.github/workflows/release.yml:213-215`, unchanged):
```yaml
      - name: Authenticate to crates.io (OIDC)
        id: crates-auth
        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
```

Unrelated work runs next, inside the changesets step (`release.yml:217-244`, `publish-script: pnpm run release`), which `package.json` defines as:
```
pnpm build && pnpm test:esm && node scripts/release-all.mjs
```
and `scripts/release-all.mjs` runs npm first, crates second.

The clock previously started only here, `scripts/release-crates.mjs`:
```js
const budgetDeadline = Date.now() + totalBudgetMs;
```
— i.e. after the second build, `test:esm`, and the whole npm publish had already run and consumed an unmeasured, unbounded amount of the 30-minute token.

## Worst-case gap

Unbounded before this change: a slow second build + `test:esm` + npm publish (many packages, provenance attached to each) could consume most or all of the token before `publishAllCrates` ever took its first timestamp, and a budget sized only against the crates work would not notice.

## Fix

`release.yml` now stamps the mint time immediately after the OIDC exchange (`Stamp crates.io token mint time`, a single `Date.now()` — no secret touched or logged) and passes it to the changesets step as `CRATES_TOKEN_MINTED_AT_MS`. `publishAllCrates` takes the deadline as whichever is **earlier**: its own `totalBudgetMs`, or `tokenMintedAtMs + 30min − a 60s margin`. Time spent before the loop is now charged against the token's real remaining lifetime instead of escaping the bound.

`main()` validates the env value at the boundary (`parseTokenMintedAtMs`) and throws on a non-numeric value rather than letting a `NaN` deadline silently defeat every comparison downstream — the same failure shape flagged in the issue for an unvalidated numeric env input. Omitting the env var (a manual/local run) reproduces the exact previous budget-only behavior — pinned by a regression test.

## Could this be unit-tested? Yes.

The workflow ordering itself (mint → unrelated work → clock) is YAML and isn't unit-testable, so I read it directly and quoted it above. The arithmetic bug — the clock not accounting for the token's real remaining lifetime — lives entirely in `scripts/release-crates.mjs`, which already has `scripts/release-crates.test.mjs` with a fake-clock harness. Added there:

- a token minted well before the loop starts is already past its lifetime, even with a large, untouched release-wide budget (reproduces the defect)
- the token bound catches a stall that the release-wide budget alone would have allowed through
- omitting the mint timestamp falls back to the exact pre-fix budget-only behavior (regression pin, byte-identical message)
- `parseTokenMintedAtMs` boundary validation: unset → `undefined`, valid numeric string → parsed, non-numeric → throws (guards the NaN-hangs-forever shape)

```
$ node --test scripts/release-crates.test.mjs
# tests 19
# pass 19
# fail 0

$ node --test scripts/*.test.mjs scripts/lib/*.test.mjs
# tests 661
# pass 661
# fail 0

$ node scripts/check-module-size.mjs
check-module-size: OK (1936 files measured, 314 allowlisted, 0 new over 400)

$ node scripts/check-source-text-assertions.mjs
check-source-text-assertions: OK (8 allowlisted, 0 marked, 0 new)

$ actionlint .github/workflows/release.yml
# same 9 pre-existing shellcheck findings as the base branch; none on the new step
```

Confirmed RED against the pre-fix code: reverting `scripts/release-crates.mjs` alone while keeping the new tests fails immediately (`parseTokenMintedAtMs` isn't exported yet), and restoring the fix turns the suite green again.

## Same-shape grep elsewhere

Searched `.github/workflows/` and `scripts/` for another mint-then-unrelated-work-then-clock sequence. The only other OIDC/trusted-publish flow is PyPI (`python-wheels.yml`, `pypa/gh-action-pypi-publish`), which performs the OIDC exchange and the publish inside one self-contained action step — no separate script-side budget/poll loop of ours sits between a mint and a clock there, so this issue's family doesn't recur. No other occurrence found; nothing else changed.

## Base branch

This PR targets `relfix/crates-poll-budget` (not `main`) because the budget code #3258 describes was introduced there and hasn't merged yet — `PUBLISH_PHASE_BUDGET_MS` doesn't exist on `main`.

Refs #3258