### PR TITLE
fix(viewer): make an omitted teardown scope arm a compile error, not a silent no-op

### DIFF
--- a/.changeset/teardown-required-scope-arms.md
+++ b/.changeset/teardown-required-scope-arms.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Make the store teardown seam fail to compile when a slice omits a scope arm, instead of silently no-oping.
+
+`TeardownScope` is a three-kind union, and each of the 28 slice contributions was one `(scope, state)` function. 22 of them opened with `if (scope.kind !== 'session-reset') return {};`, which is exactly as "correct" for a scope kind that does not exist yet as for one that does — a fourth kind would have compiled clean, passed every test, and silently left those 22 slices' state uncleared.
+
+Each contribution now declares one named arm per scope kind (`'session-reset'`, `'model-removed'`, `'all-models-cleared'`) via `defineSliceTeardown`'s new `SliceTeardownArms` record. Omitting an arm — today, or for a kind added to `TeardownScope` later — is a compile error in all 28 files at once, not a `{}` nobody wrote. `notApplicable` spells the deliberate "this scope does not touch me" case.
+
+One trade-off, measured: typing every arm with the existing foreign-key rejection (a slice returning a key it does not own) tripled the checker's `Exclude<keyof ViewerState, K>` work across the 28-entry registry and crossed TypeScript's TS2590 ("union type too complex") budget. Arms are typed loosely instead, and `composeTeardown` now checks a returned key's ownership at runtime against the same map `createTeardownRegistry` already proves disjoint — a real check, just no longer a compile-time one for that specific case.

--- a/apps/viewer/src/store/slices/addElementSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/addElementSlice.teardown.ts
@@ -14,37 +14,31 @@
  * everything this slice is willing to destroy).
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
-export const addElementTeardown = defineSliceTeardown(
-  'addElementSlice',
-  ['addElementModelId', 'addElementStoreyId'],
-  (scope, state) => {
-    // `resetViewerState` has never touched these — verified against
-    // store/index.ts, which names neither. A file load leaves the panel's pin
-    // alone; only a federation change can invalidate it.
-    if (scope.kind === 'session-reset') return {};
-
-    if (scope.kind === 'all-models-cleared') {
-      // With `models` about to become empty there is no federated model left
-      // for the pin to name, so it and the model-local storey id go too.
-      return { addElementModelId: null, addElementStoreyId: null };
-    }
-
-    // The AddElement panel's "target model" pin is a dangling reference of the
-    // same shape as the selection fields, just on a different slice:
-    // `addElementModelId` names a specific federated model so the panel and the
-    // click-placement handlers (`resolveAddElementContext` in
-    // selectionHandlers.ts) stop tracking whichever model is merely active.
-    // Nothing else clears it when that model goes away, so it keeps naming a
-    // model no longer in `models` after removal — the panel's Select renders
-    // blank instead of falling back to the active model, and every subsequent
-    // placement click fails with "No model loaded for id" until the user
-    // re-picks a model by hand. `addElementStoreyId` is an express id local to
-    // that same model, so it is stale too and reset alongside it; it is left
-    // alone when the pin names a different (surviving) model, matching how the
-    // selection purge only drops entries belonging to the removed model.
+export const addElementTeardown = defineSliceTeardown('addElementSlice', ['addElementModelId', 'addElementStoreyId'], {
+  // `resetViewerState` has never touched these — verified against
+  // store/index.ts, which names neither. A file load leaves the panel's pin
+  // alone; only a federation change can invalidate it.
+  'session-reset': notApplicable,
+  // The AddElement panel's "target model" pin is a dangling reference of the
+  // same shape as the selection fields, just on a different slice:
+  // `addElementModelId` names a specific federated model so the panel and the
+  // click-placement handlers (`resolveAddElementContext` in
+  // selectionHandlers.ts) stop tracking whichever model is merely active.
+  // Nothing else clears it when that model goes away, so it keeps naming a
+  // model no longer in `models` after removal — the panel's Select renders
+  // blank instead of falling back to the active model, and every subsequent
+  // placement click fails with "No model loaded for id" until the user
+  // re-picks a model by hand. `addElementStoreyId` is an express id local to
+  // that same model, so it is stale too and reset alongside it; it is left
+  // alone when the pin names a different (surviving) model, matching how the
+  // selection purge only drops entries belonging to the removed model.
+  'model-removed': (scope, state) => {
     if (state.addElementModelId !== scope.modelId) return {};
     return { addElementModelId: null, addElementStoreyId: null };
   },
-);
+  // With `models` about to become empty there is no federated model left for
+  // the pin to name, so it and the model-local storey id go too.
+  'all-models-cleared': () => ({ addElementModelId: null, addElementStoreyId: null }),
+});

--- a/apps/viewer/src/store/slices/annotationsSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/annotationsSlice.teardown.ts
@@ -14,21 +14,18 @@
  * `createAnnotationsSlice`), which `store/index.ts` restated a second time.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
-export const annotationsTeardown = defineSliceTeardown(
-  'annotationsSlice',
-  ['draft', 'selectedAnnotationId'],
-  (scope) =>
-    // Pin authoring is not per-model: removing one model from a federation,
-    // or clearing them all, leaves an open draft and its popover alone.
-    scope.kind !== 'session-reset'
-      ? {}
-      : {
-          // Drop draft + selection so a new file doesn't inherit the previous
-          // file's pin authoring state. Persisted pins themselves stay in
-          // localStorage (cross-file workspace).
-          draft: null,
-          selectedAnnotationId: null,
-        },
-);
+export const annotationsTeardown = defineSliceTeardown('annotationsSlice', ['draft', 'selectedAnnotationId'], {
+  'session-reset': () => ({
+    // Drop draft + selection so a new file doesn't inherit the previous
+    // file's pin authoring state. Persisted pins themselves stay in
+    // localStorage (cross-file workspace).
+    draft: null,
+    selectedAnnotationId: null,
+  }),
+  // Pin authoring is not per-model: removing one model from a federation, or
+  // clearing them all, leaves an open draft and its popover alone.
+  'model-removed': notApplicable,
+  'all-models-cleared': notApplicable,
+});

--- a/apps/viewer/src/store/slices/bcfSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/bcfSlice.teardown.ts
@@ -10,7 +10,7 @@
  * the ~400-line module rule (`scripts/check-module-size.mjs`).
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /**
  * What a session reset clears on the BCF slice.
@@ -32,9 +32,8 @@ import { defineSliceTeardown } from '../teardown.js';
 export const bcfTeardown = defineSliceTeardown(
   'bcfSlice',
   ['bcfPanelVisible', 'bcfLoading', 'bcfError', 'activeTopicId', 'activeViewpointId'],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       bcfPanelVisible: false,
       bcfLoading: false,
       bcfError: null,
@@ -44,6 +43,8 @@ export const bcfTeardown = defineSliceTeardown(
       // stays; where the user was in it does not.
       activeTopicId: null,
       activeViewpointId: null,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/cameraSlice.ts
+++ b/apps/viewer/src/store/slices/cameraSlice.ts
@@ -9,7 +9,7 @@
 import type { StateCreator } from 'zustand';
 import type { CameraRotation, CameraCallbacks, ProjectionMode, ControlsMode } from '../types.js';
 import { CAMERA_DEFAULTS } from '../constants.js';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /** The home orientation, in one place: the slice's initial value and the
  *  session-reset teardown must not be able to drift apart. */
@@ -196,14 +196,15 @@ export const cameraTeardown = defineSliceTeardown(
     'interactionMode',
     'pendingInteractionMode',
   ],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       cameraRotation: defaultCameraRotation(),
       pendingCameraRotation: null,
       projectionMode: DEFAULT_PROJECTION_MODE,
       interactionMode: DEFAULT_CONTROLS_MODE,
       pendingInteractionMode: null,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/cesiumSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/cesiumSlice.teardown.ts
@@ -22,7 +22,7 @@
  * has no business clearing.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 export const cesiumTeardown = defineSliceTeardown(
   'cesiumSlice',
@@ -39,22 +39,26 @@ export const cesiumTeardown = defineSliceTeardown(
     'cesiumPlacementDraftModelId',
     'cesiumPlacementDraft',
   ],
-  (scope) => scope.kind !== 'session-reset' ? {} : {
-    cesiumAvailable: false,
-    cesiumEnabled: false,
-    cesiumTerrainHeight: null,
-    // The snap target is model-specific terrain state; drop it with the
-    // sampled height so a new file can't reuse the old target (#1456).
-    cesiumTerrainSaveHeight: null,
-    cesiumSourceModelId: null,
-    // A new file is orthometric by default — re-arm the geoid correction
-    // so a previous file's "heights are ellipsoidal" opt-out doesn't carry
-    // over (#1355).
-    cesiumHeightsAreEllipsoidal: false,
-    cesiumTerrainClipY: null,
-    cesiumGlbLoaded: false,
-    cesiumPlacementEditMode: false,
-    cesiumPlacementDraftModelId: null,
-    cesiumPlacementDraft: null,
+  {
+    'session-reset': () => ({
+      cesiumAvailable: false,
+      cesiumEnabled: false,
+      cesiumTerrainHeight: null,
+      // The snap target is model-specific terrain state; drop it with the
+      // sampled height so a new file can't reuse the old target (#1456).
+      cesiumTerrainSaveHeight: null,
+      cesiumSourceModelId: null,
+      // A new file is orthometric by default — re-arm the geoid correction
+      // so a previous file's "heights are ellipsoidal" opt-out doesn't carry
+      // over (#1355).
+      cesiumHeightsAreEllipsoidal: false,
+      cesiumTerrainClipY: null,
+      cesiumGlbLoaded: false,
+      cesiumPlacementEditMode: false,
+      cesiumPlacementDraftModelId: null,
+      cesiumPlacementDraft: null,
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/chatSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/chatSlice.teardown.ts
@@ -10,7 +10,7 @@
  * `scripts/module-size-allowlist.txt`) and may not grow.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /**
  * What a session reset clears on the chat slice.
@@ -31,9 +31,8 @@ import { defineSliceTeardown } from '../teardown.js';
 export const chatTeardown = defineSliceTeardown(
   'chatSlice',
   ['chatStatus', 'chatStreamingContent', 'chatError', 'chatAbortController'],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       chatStatus: 'idle' as const,
       chatStreamingContent: '',
       chatError: null,
@@ -42,6 +41,8 @@ export const chatTeardown = defineSliceTeardown(
       // only path that aborts. Adding an `abort()` here would be a
       // behaviour change, and a side effect a teardown may not have.
       chatAbortController: null,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/compareSlice.ts
+++ b/apps/viewer/src/store/slices/compareSlice.ts
@@ -14,7 +14,7 @@
 import type { StateCreator } from 'zustand';
 import type { DiffScope, ModelDiff } from '@ifc-lite/diff';
 import type { CompareRef } from '@/lib/compare/buildFingerprints';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /** A completed comparison: the engine result plus the A/B context it ran on. */
 export interface CompareResult {
@@ -208,7 +208,7 @@ function getClearedCompareState() {
 export const compareTeardown = defineSliceTeardown(
   'compareSlice',
   ['compareResult', 'compareSelectedKey', 'compareRunning', 'compareError'],
-  (scope) => scope.kind !== 'session-reset' ? {} : getClearedCompareState(),
+  { 'session-reset': getClearedCompareState, 'model-removed': notApplicable, 'all-models-cleared': notApplicable },
 );
 
 export const createCompareSlice: StateCreator<CompareSlice, [], [], CompareSlice> = (set) => ({

--- a/apps/viewer/src/store/slices/dataSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/dataSlice.teardown.ts
@@ -27,61 +27,57 @@ export const dataTeardown = defineSliceTeardown(
     'meshColorBackup',
     'pendingInstancedShards',
   ],
-  (scope, state) => {
-    if (scope.kind === 'session-reset') {
+  {
+    'session-reset': () => ({
+      geometryUpdateTick: 0,
+      // `null` here is a NO-OP at the renderer — `useGeometryStreaming`
+      // returns early on a null `pendingColorUpdates`, so only a non-null
+      // EMPTY map reaches `scene.clearColorOverrides()`. The actual release
+      // of the outgoing model's clash/lens tint is
+      // `endClashScenePresentation`'s empty Map, AFTER the set, in the entry
+      // point. This write looks redundant and is not: it stops a queued
+      // overlay from being uploaded into the new scene. Do not "improve" it
+      // into an empty Map, and do not move the helper call.
+      pendingColorUpdates: null,
+      pendingMeshColorUpdates: null,
+      // The backup those two restore FROM. Ids collide across models, so
+      // surviving a swap made RESET_COLORS paint the old model's colours onto
+      // the new one; first-write-wins made every later reset wrong too.
+      meshColorBackup: null,
+      // Drop any undrained GPU-instancing shards from the previous model so
+      // they can't be uploaded into the new scene under a rapid model switch.
+      pendingInstancedShards: null,
+      // `ifcDataStore` / `geometryResult` are deliberately absent: a session
+      // reset is a file LOAD, and the loader writes both straight after. They
+      // follow the active model on the two federation arms below.
+    }),
+    'all-models-cleared': () => ({
+      ifcDataStore: null,
+      geometryResult: null,
+      // Goes with the geometry it describes: first-write-wins, so a survivor
+      // repaints a departed model's colour onto whatever takes that id next.
+      // Unconditional here, unlike the scoped purge below:
+      // `federationRegistry.clear()` restarts offsets at 0, so ids genuinely
+      // ARE reused after this.
+      meshColorBackup: null,
+    }),
+    'model-removed': (scope, state) => {
+      const models = state.models;
+      // Same guard as `modelSlice`'s arm: a removal that removes nothing writes
+      // nothing, which is also what makes the second run (`syncSourceModel`
+      // immediately after `removeModel`) a no-op.
+      if (!models?.has(scope.modelId)) return {};
+
+      // Follow the model that becomes active. The scope resolved it once, so
+      // this and `modelSlice`'s `activeModelId` cannot name different models.
+      const activeModel = scope.nextActiveModelId ? models.get(scope.nextActiveModelId) : null;
+
       return {
-        geometryUpdateTick: 0,
-        // `null` here is a NO-OP at the renderer — `useGeometryStreaming`
-        // returns early on a null `pendingColorUpdates`, so only a non-null
-        // EMPTY map reaches `scene.clearColorOverrides()`. The actual release
-        // of the outgoing model's clash/lens tint is
-        // `endClashScenePresentation`'s empty Map, AFTER the set, in the entry
-        // point. This write looks redundant and is not: it stops a queued
-        // overlay from being uploaded into the new scene. Do not "improve" it
-        // into an empty Map, and do not move the helper call.
-        pendingColorUpdates: null,
-        pendingMeshColorUpdates: null,
-        // The backup those two restore FROM. Ids collide across models, so
-        // surviving a swap made RESET_COLORS paint the old model's colours onto
-        // the new one; first-write-wins made every later reset wrong too.
-        meshColorBackup: null,
-        // Drop any undrained GPU-instancing shards from the previous model so
-        // they can't be uploaded into the new scene under a rapid model switch.
-        pendingInstancedShards: null,
-        // `ifcDataStore` / `geometryResult` are deliberately absent: a session
-        // reset is a file LOAD, and the loader writes both straight after. They
-        // follow the active model on the two federation arms below.
+        ifcDataStore: activeModel?.ifcDataStore ?? null,
+        geometryResult: activeModel?.geometryResult ?? null,
+        meshColorBackup: purgeRemovedModelsBackup(scope.modelId, state),
       };
-    }
-
-    if (scope.kind === 'all-models-cleared') {
-      return {
-        ifcDataStore: null,
-        geometryResult: null,
-        // Goes with the geometry it describes: first-write-wins, so a survivor
-        // repaints a departed model's colour onto whatever takes that id next.
-        // Unconditional here, unlike the scoped purge below:
-        // `federationRegistry.clear()` restarts offsets at 0, so ids genuinely
-        // ARE reused after this.
-        meshColorBackup: null,
-      };
-    }
-
-    const models = state.models;
-    // Same guard as `modelSlice`'s arm: a removal that removes nothing writes
-    // nothing, which is also what makes the second run (`syncSourceModel`
-    // immediately after `removeModel`) a no-op.
-    if (!models?.has(scope.modelId)) return {};
-
-    // Follow the model that becomes active. The scope resolved it once, so this
-    // and `modelSlice`'s `activeModelId` cannot name different models.
-    const activeModel = scope.nextActiveModelId ? models.get(scope.nextActiveModelId) : null;
-
-    return {
-      ifcDataStore: activeModel?.ifcDataStore ?? null,
-      geometryResult: activeModel?.geometryResult ?? null,
-      meshColorBackup: purgeRemovedModelsBackup(scope.modelId, state),
-    };
+    },
   },
 );
 

--- a/apps/viewer/src/store/slices/drawing2DSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.teardown.ts
@@ -32,7 +32,7 @@
  * authored), and collapsing the two is the mistake #2802 records.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 import { getDefaultDrawing2DState } from './drawing2DSlice.js';
 
 export const drawing2DTeardown = defineSliceTeardown(
@@ -68,52 +68,54 @@ export const drawing2DTeardown = defineSliceTeardown(
     'cloudAnnotations2D',
     'selectedAnnotation2D',
   ],
-  (scope) => {
+  {
+    'session-reset': () => {
+      const defaults = getDefaultDrawing2DState();
+      return {
+        // Drawing 2D
+        drawing2D: defaults.drawing2D,
+        drawing2DStatus: defaults.drawing2DStatus,
+        drawing2DProgress: defaults.drawing2DProgress,
+        drawing2DPhase: defaults.drawing2DPhase,
+        drawing2DError: defaults.drawing2DError,
+        drawing2DPanelVisible: defaults.drawing2DPanelVisible,
+        suppressNextSection2DPanelAutoOpen: defaults.suppressNextSection2DPanelAutoOpen,
+        drawing2DSvgContent: defaults.drawing2DSvgContent,
+        drawing2DDisplayOptions: defaults.drawing2DDisplayOptions,
+
+        // Graphic overrides (keep presets, reset active and custom)
+        activePresetId: defaults.activePresetId,
+        customOverrideRules: defaults.customOverrideRules,
+        overridesEnabled: defaults.overridesEnabled,
+        overridesPanelVisible: defaults.overridesPanelVisible,
+
+        // 2D Measure
+        measure2DMode: defaults.measure2DMode,
+        measure2DStart: defaults.measure2DStart,
+        measure2DCurrent: defaults.measure2DCurrent,
+        measure2DShiftLocked: defaults.measure2DShiftLocked,
+        measure2DLockedAxis: defaults.measure2DLockedAxis,
+        measure2DResults: defaults.measure2DResults,
+        measure2DSnapPoint: defaults.measure2DSnapPoint,
+
+        // Annotation tools
+        annotation2DActiveTool: defaults.annotation2DActiveTool,
+        annotation2DCursorPos: defaults.annotation2DCursorPos,
+        polygonArea2DPoints: defaults.polygonArea2DPoints,
+        polygonArea2DResults: defaults.polygonArea2DResults,
+        textAnnotations2D: defaults.textAnnotations2D,
+        textAnnotation2DEditing: defaults.textAnnotation2DEditing,
+        cloudAnnotation2DPoints: defaults.cloudAnnotation2DPoints,
+        cloudAnnotations2D: defaults.cloudAnnotations2D,
+        selectedAnnotation2D: defaults.selectedAnnotation2D,
+      };
+    },
     // The generated drawing, its overrides and its annotations are all keyed
     // to the file that was loaded. Removing ONE model from a federation, or
     // clearing them all, leaves the 2D view to be regenerated on demand and
     // must not throw away the user's markup, so both of those scopes are
     // no-ops here.
-    if (scope.kind !== 'session-reset') return {};
-
-    const defaults = getDefaultDrawing2DState();
-    return {
-      // Drawing 2D
-      drawing2D: defaults.drawing2D,
-      drawing2DStatus: defaults.drawing2DStatus,
-      drawing2DProgress: defaults.drawing2DProgress,
-      drawing2DPhase: defaults.drawing2DPhase,
-      drawing2DError: defaults.drawing2DError,
-      drawing2DPanelVisible: defaults.drawing2DPanelVisible,
-      suppressNextSection2DPanelAutoOpen: defaults.suppressNextSection2DPanelAutoOpen,
-      drawing2DSvgContent: defaults.drawing2DSvgContent,
-      drawing2DDisplayOptions: defaults.drawing2DDisplayOptions,
-
-      // Graphic overrides (keep presets, reset active and custom)
-      activePresetId: defaults.activePresetId,
-      customOverrideRules: defaults.customOverrideRules,
-      overridesEnabled: defaults.overridesEnabled,
-      overridesPanelVisible: defaults.overridesPanelVisible,
-
-      // 2D Measure
-      measure2DMode: defaults.measure2DMode,
-      measure2DStart: defaults.measure2DStart,
-      measure2DCurrent: defaults.measure2DCurrent,
-      measure2DShiftLocked: defaults.measure2DShiftLocked,
-      measure2DLockedAxis: defaults.measure2DLockedAxis,
-      measure2DResults: defaults.measure2DResults,
-      measure2DSnapPoint: defaults.measure2DSnapPoint,
-
-      // Annotation tools
-      annotation2DActiveTool: defaults.annotation2DActiveTool,
-      annotation2DCursorPos: defaults.annotation2DCursorPos,
-      polygonArea2DPoints: defaults.polygonArea2DPoints,
-      polygonArea2DResults: defaults.polygonArea2DResults,
-      textAnnotations2D: defaults.textAnnotations2D,
-      textAnnotation2DEditing: defaults.textAnnotation2DEditing,
-      cloudAnnotation2DPoints: defaults.cloudAnnotation2DPoints,
-      cloudAnnotations2D: defaults.cloudAnnotations2D,
-      selectedAnnotation2D: defaults.selectedAnnotation2D,
-    };
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/hoverSlice.ts
+++ b/apps/viewer/src/store/slices/hoverSlice.ts
@@ -8,7 +8,7 @@
 
 import type { StateCreator } from 'zustand';
 import type { HoverState, ContextMenuState } from '../types.js';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /**
  * "Nothing is hovered", in one place.
@@ -69,14 +69,11 @@ export const createHoverSlice: StateCreator<HoverSlice, [], [], HoverSlice> = (s
  * Both now build their value from the same helpers above, so the two paths
  * cannot drift.
  */
-export const hoverTeardown = defineSliceTeardown(
-  'hoverSlice',
-  ['hoverState', 'contextMenu'],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
-      hoverState: emptyHoverState(),
-      contextMenu: closedContextMenu(),
-    };
-  },
-);
+export const hoverTeardown = defineSliceTeardown('hoverSlice', ['hoverState', 'contextMenu'], {
+  'session-reset': () => ({
+    hoverState: emptyHoverState(),
+    contextMenu: closedContextMenu(),
+  }),
+  'model-removed': notApplicable,
+  'all-models-cleared': notApplicable,
+});

--- a/apps/viewer/src/store/slices/idsSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/idsSlice.teardown.ts
@@ -13,7 +13,7 @@
  * pure, no `set`, no `get`, no release call.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /**
  * What a session reset clears on the IDS slice.
@@ -47,9 +47,8 @@ export const idsTeardown = defineSliceTeardown(
     'idsActiveEntityId',
     'idsFocusVisibilityOwned',
   ],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       idsPanelVisible: false,
       idsLoading: false,
       idsProgress: null,
@@ -65,6 +64,8 @@ export const idsTeardown = defineSliceTeardown(
       // and the next release destroys that owner's presentation (#2654
       // fourth review).
       idsFocusVisibilityOwned: null,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/lensSlice.ts
+++ b/apps/viewer/src/store/slices/lensSlice.ts
@@ -15,7 +15,7 @@ import type { Lens, LensRule, LensCriteria, AutoColorSpec, AutoColorLegendEntry,
 import { BUILTIN_LENSES } from '@ifc-lite/lens';
 import { duplicateLensConfig, mergeImportedLenses, reserveUniqueId } from '@/components/viewer/lens-editor-utils';
 import { saveJson, type SaveResult } from '@/lib/storage/save-result';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 // Re-export types so existing consumer imports from this file still work
 export type { Lens, LensRule, LensCriteria, AutoColorSpec, AutoColorLegendEntry, DiscoveredLensData };
@@ -368,19 +368,23 @@ export const lensTeardown = defineSliceTeardown(
     'activeLensId', 'lensPanelVisible', 'lensColorMap', 'lensHiddenIds',
     'lensAppliedHiddenIds', 'lensRuleIsolation', 'lensRuleCounts', 'lensRuleEntityIds',
   ],
-  (scope) => scope.kind !== 'session-reset' ? {} : {
-    activeLensId: null,
-    lensPanelVisible: false,
-    lensColorMap: new Map<number, string>(),
-    lensHiddenIds: new Set<number>(),
-    // Ownership bookkeeping for the shared hidden/isolation channels — those
-    // channels are wiped by the same reset, so stale claims must not survive
-    // it: ownership is tested by VALUE, so a record left behind starts
-    // matching again the moment another owner installs equal content, and the
-    // next release destroys that owner's presentation (#2654 fourth review).
-    lensAppliedHiddenIds: [] as number[],
-    lensRuleIsolation: null,
-    lensRuleCounts: new Map<string, number>(),
-    lensRuleEntityIds: new Map<string, number[]>(),
+  {
+    'session-reset': () => ({
+      activeLensId: null,
+      lensPanelVisible: false,
+      lensColorMap: new Map<number, string>(),
+      lensHiddenIds: new Set<number>(),
+      // Ownership bookkeeping for the shared hidden/isolation channels — those
+      // channels are wiped by the same reset, so stale claims must not survive
+      // it: ownership is tested by VALUE, so a record left behind starts
+      // matching again the moment another owner installs equal content, and the
+      // next release destroys that owner's presentation (#2654 fourth review).
+      lensAppliedHiddenIds: [] as number[],
+      lensRuleIsolation: null,
+      lensRuleCounts: new Map<string, number>(),
+      lensRuleEntityIds: new Map<string, number[]>(),
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/listSlice.ts
+++ b/apps/viewer/src/store/slices/listSlice.ts
@@ -9,7 +9,7 @@
 import type { StateCreator } from 'zustand';
 import type { ListDefinition, ListResult } from '@ifc-lite/lists';
 import { loadListDefinitions, saveListDefinitions } from '../../lib/lists/persistence.js';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 export interface ListSlice {
   // State
@@ -95,15 +95,16 @@ export const createListSlice: StateCreator<ListSlice, [], [], ListSlice> = (set,
 export const listTeardown = defineSliceTeardown(
   'listSlice',
   ['listPanelVisible', 'activeListId', 'listResult', 'listExecuting'],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       listPanelVisible: false,
       activeListId: null,
       // The rows reference the OUTGOING model's entities; the user re-runs
       // the definition against the new one.
       listResult: null,
       listExecuting: false,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/loadingSlice.ts
+++ b/apps/viewer/src/store/slices/loadingSlice.ts
@@ -7,7 +7,7 @@
  */
 
 import type { StateCreator } from 'zustand';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 export interface LoadingSlice {
   // State
@@ -74,15 +74,16 @@ export const createLoadingSlice: StateCreator<LoadingSlice, [], [], LoadingSlice
 export const loadingTeardown = defineSliceTeardown(
   'loadingSlice',
   ['loading', 'geometryStreamingActive', 'progress', 'geometryProgress', 'metadataProgress', 'error'],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       loading: false,
       geometryStreamingActive: false,
       progress: null,
       geometryProgress: null,
       metadataProgress: null,
       error: null,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/modelSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/modelSlice.teardown.ts
@@ -18,21 +18,15 @@
  * the entry point, in today's order.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
-export const modelTeardown = defineSliceTeardown(
-  'modelSlice',
-  ['models', 'activeModelId'],
-  (scope, state) => {
-    // `resetViewerState` deliberately does NOT clear models — "use
-    // clearAllModels() for that" (store/index.ts). A file load swaps the
-    // ACTIVE model; the federation itself survives it.
-    if (scope.kind === 'session-reset') return {};
-
-    if (scope.kind === 'all-models-cleared') {
-      return { models: new Map(), activeModelId: null };
-    }
-
+export const modelTeardown = defineSliceTeardown('modelSlice', ['models', 'activeModelId'], {
+  // `resetViewerState` deliberately does NOT clear models — "use
+  // clearAllModels() for that" (store/index.ts). A file load swaps the
+  // ACTIVE model; the federation itself survives it.
+  'session-reset': notApplicable,
+  'all-models-cleared': () => ({ models: new Map(), activeModelId: null }),
+  'model-removed': (scope, state) => {
     const models = state.models;
     // A removal that removes nothing must do nothing. `syncSourceModel` and the
     // collab room teardown can both re-enter with an id that has already gone,
@@ -53,4 +47,4 @@ export const modelTeardown = defineSliceTeardown(
     // keep `ifcDataStore` / `geometryResult` pointing at the model this names.
     return { models: nextModels, activeModelId: scope.nextActiveModelId };
   },
-);
+});

--- a/apps/viewer/src/store/slices/mutationSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/mutationSlice.teardown.ts
@@ -14,7 +14,7 @@
  * 'model-removed' arm here.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 export const mutationTeardown = defineSliceTeardown(
   'mutationSlice',
@@ -27,11 +27,9 @@ export const mutationTeardown = defineSliceTeardown(
     'dirtyModels',
     'mutationVersion',
   ],
-  (scope, state) => {
+  {
     // Mutations - clear all mutation state so stale changes don't carry over
-    if (scope.kind !== 'session-reset') return {};
-
-    return {
+    'session-reset': (_scope, state) => ({
       mutationViews: new Map(),
       changeSets: new Map(),
       activeChangeSetId: null,
@@ -46,6 +44,8 @@ export const mutationTeardown = defineSliceTeardown(
       // drops it. Session reset only: bumping it on every model removal would
       // be a behaviour change, not a restructuring.
       mutationVersion: (state.mutationVersion ?? 0) + 1,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/pinboardSlice.teardown.ts
@@ -25,63 +25,59 @@ export const pinboardTeardown = defineSliceTeardown(
     'activeBasketViewId',
     'basketPresentationVisible',
   ],
-  (scope, state) => {
-    if (scope.kind === 'session-reset') {
-      return {
-        // Pinboard - clear pinned entities on new file
-        pinboardEntities: new Set<string>(),
-        basketViews: [],
-        activeBasketViewId: null,
-        basketPresentationVisible: false,
-        hierarchyBasketSelection: new Set<string>(),
-      };
-    }
+  {
+    'session-reset': () => ({
+      // Pinboard - clear pinned entities on new file
+      pinboardEntities: new Set<string>(),
+      basketViews: [],
+      activeBasketViewId: null,
+      basketPresentationVisible: false,
+      hierarchyBasketSelection: new Set<string>(),
+    }),
+    // Same dangling-ref shape as the 'model-removed' purge below, for the
+    // full-teardown path: with every model gone, every basket ref is stale by
+    // definition. `basketViews` / `activeBasketViewId` /
+    // `basketPresentationVisible` are NOT in this arm — `clearAllModels` has
+    // never written them, and a saved view is a document the user authored,
+    // not scene state.
+    'all-models-cleared': () => ({
+      pinboardEntities: new Set<string>(),
+      hierarchyBasketSelection: new Set<string>(),
+    }),
+    'model-removed': (scope, state) => {
+      // Pinboard/basket state is keyed the same way as `selectedEntitiesSet` --
+      // Set<string> of "modelId:expressId" entityRef strings. `pinboardEntities`
+      // is the basket's SOURCE OF TRUTH: every basket edit
+      // (`addToBasket`/`removeFromBasket`/`showPinboard`) re-derives
+      // `isolatedEntities` from it via `toGlobalIdForRef`, and
+      // `toGlobalIdFromModels` falls back to the RAW, un-offset expressId when a
+      // ref's modelId is no longer in `models`. A stale ref surviving removal
+      // therefore doesn't just dangle inertly: the next basket operation resolves
+      // it to a bare, unscaled global id that can collide with a real entity in
+      // any surviving model whose own offset range covers that raw number (any
+      // model with idOffset 0, notably) -- silently co-isolating or co-hiding an
+      // entity the user never touched.
+      const priorPinboard = state.pinboardEntities ?? new Set<string>();
+      const priorHierarchyBasket = state.hierarchyBasketSelection ?? new Set<string>();
+      const keptPinboard = new Set(
+        [...priorPinboard].filter((k) => stringToEntityRef(k).modelId !== scope.modelId),
+      );
+      const keptHierarchyBasket = new Set(
+        [...priorHierarchyBasket].filter((k) => stringToEntityRef(k).modelId !== scope.modelId),
+      );
 
-    if (scope.kind === 'all-models-cleared') {
-      // Same dangling-ref shape as the 'model-removed' purge below, for the
-      // full-teardown path: with every model gone, every basket ref is stale by
-      // definition. `basketViews` / `activeBasketViewId` /
-      // `basketPresentationVisible` are NOT in this arm — `clearAllModels` has
-      // never written them, and a saved view is a document the user authored,
-      // not scene state.
-      return {
-        pinboardEntities: new Set<string>(),
-        hierarchyBasketSelection: new Set<string>(),
-      };
-    }
+      // Nothing of ours belonged to the removed model: return {} rather than two
+      // equal-but-new Sets. `syncSourceModel` runs this same scope again
+      // straight after `removeModel`, and a fresh reference there would re-notify
+      // every basket subscriber for a set that did not move.
+      if (
+        keptPinboard.size === priorPinboard.size &&
+        keptHierarchyBasket.size === priorHierarchyBasket.size
+      ) {
+        return {};
+      }
 
-    // Pinboard/basket state is keyed the same way as `selectedEntitiesSet` --
-    // Set<string> of "modelId:expressId" entityRef strings. `pinboardEntities`
-    // is the basket's SOURCE OF TRUTH: every basket edit
-    // (`addToBasket`/`removeFromBasket`/`showPinboard`) re-derives
-    // `isolatedEntities` from it via `toGlobalIdForRef`, and
-    // `toGlobalIdFromModels` falls back to the RAW, un-offset expressId when a
-    // ref's modelId is no longer in `models`. A stale ref surviving removal
-    // therefore doesn't just dangle inertly: the next basket operation resolves
-    // it to a bare, unscaled global id that can collide with a real entity in
-    // any surviving model whose own offset range covers that raw number (any
-    // model with idOffset 0, notably) -- silently co-isolating or co-hiding an
-    // entity the user never touched.
-    const priorPinboard = state.pinboardEntities ?? new Set<string>();
-    const priorHierarchyBasket = state.hierarchyBasketSelection ?? new Set<string>();
-    const keptPinboard = new Set(
-      [...priorPinboard].filter((k) => stringToEntityRef(k).modelId !== scope.modelId),
-    );
-    const keptHierarchyBasket = new Set(
-      [...priorHierarchyBasket].filter((k) => stringToEntityRef(k).modelId !== scope.modelId),
-    );
-
-    // Nothing of ours belonged to the removed model: return {} rather than two
-    // equal-but-new Sets. `syncSourceModel` runs this same scope again
-    // straight after `removeModel`, and a fresh reference there would re-notify
-    // every basket subscriber for a set that did not move.
-    if (
-      keptPinboard.size === priorPinboard.size &&
-      keptHierarchyBasket.size === priorHierarchyBasket.size
-    ) {
-      return {};
-    }
-
-    return { pinboardEntities: keptPinboard, hierarchyBasketSelection: keptHierarchyBasket };
+      return { pinboardEntities: keptPinboard, hierarchyBasketSelection: keptHierarchyBasket };
+    },
   },
 );

--- a/apps/viewer/src/store/slices/playbackSlice.ts
+++ b/apps/viewer/src/store/slices/playbackSlice.ts
@@ -23,7 +23,7 @@ import type { StateCreator } from 'zustand';
 import type { AnimationSettings } from '@/components/viewer/schedule/schedule-animator';
 import { DEFAULT_ANIMATION_SETTINGS } from '@/components/viewer/schedule/schedule-animator';
 import type { ScheduleTimeRange } from './scheduleSlice.js';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 export interface PlaybackSlice {
   /** Animation master toggle — when false the viewer renders normally. */
@@ -138,9 +138,13 @@ export const createPlaybackSlice: StateCreator<
 export const playbackTeardown = defineSliceTeardown(
   'playbackSlice',
   ['animationEnabled', 'playbackIsPlaying', 'playbackTime'],
-  (scope) => scope.kind !== 'session-reset' ? {} : {
-    animationEnabled: false,
-    playbackIsPlaying: false,
-    playbackTime: 0,
+  {
+    'session-reset': () => ({
+      animationEnabled: false,
+      playbackIsPlaying: false,
+      playbackTime: 0,
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/pointCloudSlice.ts
+++ b/apps/viewer/src/store/slices/pointCloudSlice.ts
@@ -12,7 +12,7 @@
 
 import type { StateCreator } from 'zustand';
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 export type PointColorModeUi = 'rgb' | 'classification' | 'intensity' | 'height' | 'fixed' | 'deviation';
 export type PointSizeModeUi = 'fixed-px' | 'adaptive-world' | 'attenuated';
@@ -291,10 +291,14 @@ export const pointCloudTeardown = defineSliceTeardown(
     'pointCloudAlignmentAvailable',
     'pointCloudAlignmentEnabled',
   ],
-  (scope) => scope.kind !== 'session-reset' ? {} : {
-    ...POINT_CLOUD_DEFAULTS,
-    // Re-spread typed-array fields so consumers get fresh references
-    // instead of the readonly literal in POINT_CLOUD_DEFAULTS.
-    pointCloudFixedColor: [...POINT_CLOUD_DEFAULTS.pointCloudFixedColor] as [number, number, number, number],
+  {
+    'session-reset': () => ({
+      ...POINT_CLOUD_DEFAULTS,
+      // Re-spread typed-array fields so consumers get fresh references
+      // instead of the readonly literal in POINT_CLOUD_DEFAULTS.
+      pointCloudFixedColor: [...POINT_CLOUD_DEFAULTS.pointCloudFixedColor] as [number, number, number, number],
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/scheduleSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/scheduleSlice.teardown.ts
@@ -17,7 +17,7 @@
  * lines 378-385), which already matched what `resetViewerState` restated.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /**
  * Schedule (4D) — drop panel + data; definitions are re-extracted on next load.
@@ -43,14 +43,18 @@ export const scheduleTeardown = defineSliceTeardown(
     'hoveredTaskGlobalId',
     'selectedTaskGlobalIds',
   ],
-  (scope) => scope.kind !== 'session-reset' ? {} : {
-    ganttPanelVisible: false,
-    generateScheduleDialogOpen: false,
-    scheduleData: null,
-    scheduleRange: null,
-    activeWorkScheduleId: '',
-    expandedTaskGlobalIds: new Set<string>(),
-    hoveredTaskGlobalId: null,
-    selectedTaskGlobalIds: new Set<string>(),
+  {
+    'session-reset': () => ({
+      ganttPanelVisible: false,
+      generateScheduleDialogOpen: false,
+      scheduleData: null,
+      scheduleRange: null,
+      activeWorkScheduleId: '',
+      expandedTaskGlobalIds: new Set<string>(),
+      hoveredTaskGlobalId: null,
+      selectedTaskGlobalIds: new Set<string>(),
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/scriptSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/scriptSlice.teardown.ts
@@ -10,7 +10,7 @@
  * `scripts/module-size-allowlist.txt`) and may not grow.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 /**
  * What a session reset clears on the script slice.
@@ -46,9 +46,8 @@ export const scriptTeardown = defineSliceTeardown(
     'scriptAssistantTurnSnapshot',
     'scriptDeleteConfirmId',
   ],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       scriptExecutionState: 'idle' as const,
       // The result, the error and the diagnostics all describe a run
       // against the OUTGOING model's data store.
@@ -61,6 +60,8 @@ export const scriptTeardown = defineSliceTeardown(
       // A delete confirmation armed before the load is a one-shot UI
       // prompt; it must not still be pending afterwards.
       scriptDeleteConfirmId: null,
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/searchSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/searchSlice.teardown.ts
@@ -14,7 +14,7 @@
  * own — `owns` is the list of everything search is willing to throw away.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 import { emptyFilterState } from './searchSlice.js';
 
 /**
@@ -50,9 +50,8 @@ export const searchTeardown = defineSliceTeardown(
     'searchFilter',
     'searchFilterSchema',
   ],
-  (scope) => {
-    if (scope.kind !== 'session-reset') return {};
-    return {
+  {
+    'session-reset': () => ({
       // The inline field: query, popover and the frozen vim-cycle
       // snapshot. `resetSearch()` clears exactly these four for Esc; it
       // stays a separate, narrower action (see `searchSlice.ts`).
@@ -78,6 +77,8 @@ export const searchTeardown = defineSliceTeardown(
       searchFilter: emptyFilterState(),
       // Per-model chip-dropdown schema cache, keyed by modelId.
       searchFilterSchema: new Map(),
-    };
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/sectionSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.teardown.ts
@@ -33,38 +33,40 @@
  * stays at the entry point in `store/index.ts`; a teardown is pure.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 import { getDefaultSectionPlane } from './sectionSlice.js';
 
 export const sectionTeardown = defineSliceTeardown(
   'sectionSlice',
   ['sectionPlane'],
-  (scope, state) => {
+  {
+    'session-reset': (_scope, state) => {
+      // The `??` is for the partial-store harness (`TeardownState` is a
+      // `Partial<ViewerState>`): with no live plane to read from, the slice's
+      // own initial value is by definition the right answer for the fields
+      // being kept too.
+      const live = state.sectionPlane ?? getDefaultSectionPlane();
+
+      return {
+        // Keep ONLY the user's cut-surface appearance preferences — showCap,
+        // showOutlines, capStyle. Those round-trip to localStorage via the
+        // slice's persistence helpers; clobbering them here was the cause of
+        // "my hatch / colour resets to defaults every time I open a file".
+        // Everything else (axis, position, enabled, flipped, custom) is
+        // model-relative and meaningless against a different model, so it
+        // comes from `getDefaultSectionPlane()` rather than being spread from
+        // `live` and then patched field by field.
+        sectionPlane: {
+          ...getDefaultSectionPlane(),
+          showCap:      live.showCap,
+          showOutlines: live.showOutlines,
+          capStyle:     live.capStyle,
+        },
+      };
+    },
     // A cut plane is positioned against the whole loaded scene, not against
     // one model, so neither removing a model nor clearing them all moves it.
-    if (scope.kind !== 'session-reset') return {};
-
-    // The `??` is for the partial-store harness (`TeardownState` is a
-    // `Partial<ViewerState>`): with no live plane to read from, the slice's
-    // own initial value is by definition the right answer for the fields
-    // being kept too.
-    const live = state.sectionPlane ?? getDefaultSectionPlane();
-
-    return {
-      // Keep ONLY the user's cut-surface appearance preferences — showCap,
-      // showOutlines, capStyle. Those round-trip to localStorage via the
-      // slice's persistence helpers; clobbering them here was the cause of
-      // "my hatch / colour resets to defaults every time I open a file".
-      // Everything else (axis, position, enabled, flipped, custom) is
-      // model-relative and meaningless against a different model, so it
-      // comes from `getDefaultSectionPlane()` rather than being spread from
-      // `live` and then patched field by field.
-      sectionPlane: {
-        ...getDefaultSectionPlane(),
-        showCap:      live.showCap,
-        showOutlines: live.showOutlines,
-        capStyle:     live.capStyle,
-      },
-    };
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/selectionSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/selectionSlice.teardown.ts
@@ -37,125 +37,121 @@ export const selectionTeardown = defineSliceTeardown(
     'selectedEntities',
     'selectedModelId',
   ],
-  (scope, state) => {
-    if (scope.kind === 'session-reset') {
+  {
+    'session-reset': () => ({
+      // Selection (legacy)
+      selectedEntityId: null,
+      selectedEntityIds: new Set<number>(),
+      selectedStoreys: new Set<number>(),
+      // Drop the shared active storey — it references the outgoing model, so
+      // a new file must not inherit a stale storey for Solo / Space Sketch.
+      activeStorey: null,
+
+      // Selection (multi-model)
+      selectedEntity: null,
+      selectedEntitiesSet: new Set<string>(),
+      selectedEntities: [],
+      selectedModelId: null,
+    }),
+    // `clearAllModels` removes EVERY model, so — unlike `model-removed`,
+    // which must filter the `EntityRef`-keyed half by `modelId` to spare a
+    // surviving federated sibling's selection — there is no survivor to
+    // preserve anything for. Both halves clear unconditionally, same as
+    // `session-reset` above: the previous version of this arm wrote only
+    // the global-id half, which left `selectedEntity`, `selectedEntities`,
+    // `selectedEntitiesSet`, `selectedModelId` and `activeStorey` pointing
+    // at removed models (#3348) — `resetViewerState` already clears both
+    // halves, so this was purely a gap in `clearAllModels`'s own path
+    // (`GeoreferencingPanel.tsx`'s `reloadModelsForAlignment`, which calls
+    // `clearAllModels()` without `resetViewerState()`).
+    'all-models-cleared': () => ({
+      selectedEntityId: null,
+      selectedEntityIds: new Set<number>(),
+      selectedStoreys: new Set<number>(),
+      activeStorey: null,
+      selectedEntity: null,
+      selectedEntitiesSet: new Set<string>(),
+      selectedEntities: [],
+      selectedModelId: null,
+    }),
+    'model-removed': (scope, state) => {
+      const { modelId, isStale } = scope;
+
+      // ── EntityRef-keyed half ────────────────────────────────────────────────
+      // Selection state keys off modelId, so anything pointing at the removed
+      // model is now dangling: `models.get(selectedEntity.modelId)` returns
+      // undefined and the properties panel silently renders nothing rather than
+      // re-resolving, leaving a ghost selection until the user clicks elsewhere.
+      // `activeStorey` likewise stays pinned to a storey in a model that no
+      // longer exists, which the Solo level display and floorplan read. Entries
+      // belonging to OTHER models are preserved — clearing wholesale would drop
+      // a federated sibling's live selection.
+      //
+      // Every read falls back to this slice's OWN initial value: a teardown is
+      // handed `Readonly<Partial<ViewerState>>` because `slices/modelSlice.test.ts`
+      // drives this composition against a state where other slices are absent.
+      const priorEntities = state.selectedEntities ?? [];
+      const priorSet = state.selectedEntitiesSet ?? new Set<string>();
+      const keptEntities = priorEntities.filter((e) => e.modelId !== modelId);
+      const refsTouched =
+        state.selectedEntity?.modelId === modelId ||
+        state.activeStorey?.modelId === modelId ||
+        keptEntities.length !== priorEntities.length ||
+        // `selectedModelId` on its own is enough. `removeModel` used to gate it
+        // behind the entity-ref checks above, so a model selected in the
+        // hierarchy but with no entity selected under it kept a dangling id;
+        // the resync purge already cleared it unconditionally on the
+        // resync path. One implementation now, so it takes the purge's reading.
+        state.selectedModelId === modelId;
+
+      // ── Global-id half ──────────────────────────────────────────────────────
+      // These key off `globalId`, not `modelId` — they don't carry which model an
+      // id belongs to the way the `EntityRef`-shaped state above does. A global
+      // id is "stale" once no SURVIVING model's parse range or overlay owns it,
+      // which is exactly the predicate the scope carries.
+      const priorSelectedEntityIds = state.selectedEntityIds;
+      const priorSelectedStoreys = state.selectedStoreys;
+      const priorSelectedEntityId = state.selectedEntityId;
+      const idsTouched =
+        (priorSelectedEntityIds !== undefined && [...priorSelectedEntityIds].some(isStale)) ||
+        (priorSelectedStoreys !== undefined && [...priorSelectedStoreys].some(isStale)) ||
+        (priorSelectedEntityId != null && isStale(priorSelectedEntityId));
+
       return {
-        // Selection (legacy)
-        selectedEntityId: null,
-        selectedEntityIds: new Set<number>(),
-        selectedStoreys: new Set<number>(),
-        // Drop the shared active storey — it references the outgoing model, so
-        // a new file must not inherit a stale storey for Solo / Space Sketch.
-        activeStorey: null,
-
-        // Selection (multi-model)
-        selectedEntity: null,
-        selectedEntitiesSet: new Set<string>(),
-        selectedEntities: [],
-        selectedModelId: null,
+        ...(refsTouched
+          ? {
+              selectedEntity:
+                state.selectedEntity?.modelId === modelId ? null : state.selectedEntity,
+              activeStorey: state.activeStorey?.modelId === modelId ? null : state.activeStorey,
+              selectedEntities: keptEntities,
+              // Parsed with the shared helper rather than a `${modelId}:` prefix
+              // test: `stringToEntityRef` splits on the FIRST colon, so a prefix
+              // match would also strip a sibling model whose id merely starts
+              // with this one's id plus a colon. Using the same parse every other
+              // consumer uses keeps this filter from becoming a third, subtly
+              // different reading of the same key.
+              selectedEntitiesSet: new Set(
+                [...priorSet].filter((k) => stringToEntityRef(k).modelId !== modelId),
+              ),
+              selectedModelId:
+                state.selectedModelId === modelId ? null : state.selectedModelId,
+            }
+          : {}),
+        ...(idsTouched
+          ? {
+              selectedEntityId:
+                priorSelectedEntityId != null && isStale(priorSelectedEntityId)
+                  ? null
+                  : priorSelectedEntityId,
+              selectedEntityIds: priorSelectedEntityIds
+                ? new Set([...priorSelectedEntityIds].filter((id) => !isStale(id)))
+                : priorSelectedEntityIds,
+              selectedStoreys: priorSelectedStoreys
+                ? new Set([...priorSelectedStoreys].filter((id) => !isStale(id)))
+                : priorSelectedStoreys,
+            }
+          : {}),
       };
-    }
-
-    if (scope.kind === 'all-models-cleared') {
-      // `clearAllModels` removes EVERY model, so — unlike `model-removed`,
-      // which must filter the `EntityRef`-keyed half by `modelId` to spare a
-      // surviving federated sibling's selection — there is no survivor to
-      // preserve anything for. Both halves clear unconditionally, same as
-      // `session-reset` above: the previous version of this arm wrote only
-      // the global-id half, which left `selectedEntity`, `selectedEntities`,
-      // `selectedEntitiesSet`, `selectedModelId` and `activeStorey` pointing
-      // at removed models (#3348) — `resetViewerState` already clears both
-      // halves, so this was purely a gap in `clearAllModels`'s own path
-      // (`GeoreferencingPanel.tsx`'s `reloadModelsForAlignment`, which calls
-      // `clearAllModels()` without `resetViewerState()`).
-      return {
-        selectedEntityId: null,
-        selectedEntityIds: new Set<number>(),
-        selectedStoreys: new Set<number>(),
-        activeStorey: null,
-        selectedEntity: null,
-        selectedEntitiesSet: new Set<string>(),
-        selectedEntities: [],
-        selectedModelId: null,
-      };
-    }
-
-    const { modelId, isStale } = scope;
-
-    // ── EntityRef-keyed half ────────────────────────────────────────────────
-    // Selection state keys off modelId, so anything pointing at the removed
-    // model is now dangling: `models.get(selectedEntity.modelId)` returns
-    // undefined and the properties panel silently renders nothing rather than
-    // re-resolving, leaving a ghost selection until the user clicks elsewhere.
-    // `activeStorey` likewise stays pinned to a storey in a model that no
-    // longer exists, which the Solo level display and floorplan read. Entries
-    // belonging to OTHER models are preserved — clearing wholesale would drop
-    // a federated sibling's live selection.
-    //
-    // Every read falls back to this slice's OWN initial value: a teardown is
-    // handed `Readonly<Partial<ViewerState>>` because `slices/modelSlice.test.ts`
-    // drives this composition against a state where other slices are absent.
-    const priorEntities = state.selectedEntities ?? [];
-    const priorSet = state.selectedEntitiesSet ?? new Set<string>();
-    const keptEntities = priorEntities.filter((e) => e.modelId !== modelId);
-    const refsTouched =
-      state.selectedEntity?.modelId === modelId ||
-      state.activeStorey?.modelId === modelId ||
-      keptEntities.length !== priorEntities.length ||
-      // `selectedModelId` on its own is enough. `removeModel` used to gate it
-      // behind the entity-ref checks above, so a model selected in the
-      // hierarchy but with no entity selected under it kept a dangling id;
-      // the resync purge already cleared it unconditionally on the
-      // resync path. One implementation now, so it takes the purge's reading.
-      state.selectedModelId === modelId;
-
-    // ── Global-id half ──────────────────────────────────────────────────────
-    // These key off `globalId`, not `modelId` — they don't carry which model an
-    // id belongs to the way the `EntityRef`-shaped state above does. A global
-    // id is "stale" once no SURVIVING model's parse range or overlay owns it,
-    // which is exactly the predicate the scope carries.
-    const priorSelectedEntityIds = state.selectedEntityIds;
-    const priorSelectedStoreys = state.selectedStoreys;
-    const priorSelectedEntityId = state.selectedEntityId;
-    const idsTouched =
-      (priorSelectedEntityIds !== undefined && [...priorSelectedEntityIds].some(isStale)) ||
-      (priorSelectedStoreys !== undefined && [...priorSelectedStoreys].some(isStale)) ||
-      (priorSelectedEntityId != null && isStale(priorSelectedEntityId));
-
-    return {
-      ...(refsTouched
-        ? {
-            selectedEntity:
-              state.selectedEntity?.modelId === modelId ? null : state.selectedEntity,
-            activeStorey: state.activeStorey?.modelId === modelId ? null : state.activeStorey,
-            selectedEntities: keptEntities,
-            // Parsed with the shared helper rather than a `${modelId}:` prefix
-            // test: `stringToEntityRef` splits on the FIRST colon, so a prefix
-            // match would also strip a sibling model whose id merely starts
-            // with this one's id plus a colon. Using the same parse every other
-            // consumer uses keeps this filter from becoming a third, subtly
-            // different reading of the same key.
-            selectedEntitiesSet: new Set(
-              [...priorSet].filter((k) => stringToEntityRef(k).modelId !== modelId),
-            ),
-            selectedModelId:
-              state.selectedModelId === modelId ? null : state.selectedModelId,
-          }
-        : {}),
-      ...(idsTouched
-        ? {
-            selectedEntityId:
-              priorSelectedEntityId != null && isStale(priorSelectedEntityId)
-                ? null
-                : priorSelectedEntityId,
-            selectedEntityIds: priorSelectedEntityIds
-              ? new Set([...priorSelectedEntityIds].filter((id) => !isStale(id)))
-              : priorSelectedEntityIds,
-            selectedStoreys: priorSelectedStoreys
-              ? new Set([...priorSelectedStoreys].filter((id) => !isStale(id)))
-              : priorSelectedStoreys,
-          }
-        : {}),
-    };
+    },
   },
 );

--- a/apps/viewer/src/store/slices/sheetSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sheetSlice.teardown.ts
@@ -17,23 +17,23 @@
  * `clearSheet` now also uses, so the two paths cannot drift apart again.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 import { getClearedSheetState } from './sheetSlice.js';
 
 export const sheetTeardown = defineSliceTeardown(
   'sheetSlice',
   ['activeSheet', 'sheetEnabled', 'sheetPanelVisible', 'titleBlockEditorVisible'],
-  (scope) => {
-    // A sheet is a document laid out over the drawing, not a per-model
-    // artefact: removing one model from a federation, or clearing them all,
-    // leaves it alone. Only a file swap tears it down.
-    if (scope.kind !== 'session-reset') return {};
-
+  {
     // `getClearedSheetState()` returns exactly these four keys — it is typed
     // `Omit<SheetState, 'savedSheetTemplates'>`, which is what keeps the user's
     // saved templates out of both this and `clearSheet` (#2802's first bug).
     // Destructuring and rebuilding it here would be a second list to keep in
     // step with the first.
-    return getClearedSheetState();
+    'session-reset': getClearedSheetState,
+    // A sheet is a document laid out over the drawing, not a per-model
+    // artefact: removing one model from a federation, or clearing them all,
+    // leaves it alone. Only a file swap tears it down.
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/slices/uiSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/uiSlice.teardown.ts
@@ -20,7 +20,7 @@
  * state is built from, so the reset value and the initial value are one fact.
  */
 
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 import { UI_DEFAULTS } from '../constants.js';
 
 export const uiTeardown = defineSliceTeardown(
@@ -40,28 +40,29 @@ export const uiTeardown = defineSliceTeardown(
     'separationLinesIntensity',
     'separationLinesRadius',
   ],
-  (scope) =>
+  {
+    'session-reset': () => ({
+      activeTool: UI_DEFAULTS.ACTIVE_TOOL,
+      editEnabled: false,
+      // Drop any one-shot bSDD "jump to property" focus armed before the
+      // load — a new file reuses ids ('legacy' + reassigned expressIds) so
+      // a stale focus could otherwise match an unrelated entity (#1107).
+      pendingPropertyFocus: null,
+      visualEnhancementsEnabled: UI_DEFAULTS.VISUAL_ENHANCEMENTS_ENABLED,
+      edgeContrastEnabled: UI_DEFAULTS.EDGE_CONTRAST_ENABLED,
+      edgeContrastIntensity: UI_DEFAULTS.EDGE_CONTRAST_INTENSITY,
+      contactShadingQuality: UI_DEFAULTS.CONTACT_SHADING_QUALITY,
+      contactShadingIntensity: UI_DEFAULTS.CONTACT_SHADING_INTENSITY,
+      contactShadingRadius: UI_DEFAULTS.CONTACT_SHADING_RADIUS,
+      separationLinesEnabled: UI_DEFAULTS.SEPARATION_LINES_ENABLED,
+      separationLinesQuality: UI_DEFAULTS.SEPARATION_LINES_QUALITY,
+      separationLinesIntensity: UI_DEFAULTS.SEPARATION_LINES_INTENSITY,
+      separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
+    }),
     // Removing one model from a federation, or clearing them all, leaves the
     // chrome alone: the active tool and the render-quality toggles describe
     // the session, not the file. Only a file swap resets them.
-    scope.kind !== 'session-reset'
-      ? {}
-      : {
-          activeTool: UI_DEFAULTS.ACTIVE_TOOL,
-          editEnabled: false,
-          // Drop any one-shot bSDD "jump to property" focus armed before the
-          // load — a new file reuses ids ('legacy' + reassigned expressIds) so
-          // a stale focus could otherwise match an unrelated entity (#1107).
-          pendingPropertyFocus: null,
-          visualEnhancementsEnabled: UI_DEFAULTS.VISUAL_ENHANCEMENTS_ENABLED,
-          edgeContrastEnabled: UI_DEFAULTS.EDGE_CONTRAST_ENABLED,
-          edgeContrastIntensity: UI_DEFAULTS.EDGE_CONTRAST_INTENSITY,
-          contactShadingQuality: UI_DEFAULTS.CONTACT_SHADING_QUALITY,
-          contactShadingIntensity: UI_DEFAULTS.CONTACT_SHADING_INTENSITY,
-          contactShadingRadius: UI_DEFAULTS.CONTACT_SHADING_RADIUS,
-          separationLinesEnabled: UI_DEFAULTS.SEPARATION_LINES_ENABLED,
-          separationLinesQuality: UI_DEFAULTS.SEPARATION_LINES_QUALITY,
-          separationLinesIntensity: UI_DEFAULTS.SEPARATION_LINES_INTENSITY,
-          separationLinesRadius: UI_DEFAULTS.SEPARATION_LINES_RADIUS,
-        },
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
+  },
 );

--- a/apps/viewer/src/store/slices/visibilitySlice.teardown.ts
+++ b/apps/viewer/src/store/slices/visibilitySlice.teardown.ts
@@ -39,96 +39,92 @@ export const visibilityTeardown = defineSliceTeardown(
     'hiddenEntitiesByModel',
     'isolatedEntitiesByModel',
   ],
-  (scope, state) => {
-    if (scope.kind === 'session-reset') {
+  {
+    'session-reset': () => ({
+      // Visibility (legacy)
+      hiddenEntities: new Set<number>(),
+      isolatedEntities: null,
+      ghostExceptEntities: null,
+      classFilter: null,
+      // Re-read persisted toggles on every file load so a new model never
+      // reverts the user's visibility choices (e.g. "Show Annotations").
+      typeVisibility: getPersistedTypeVisibility(),
+      typeViewMode: getPersistedTypeViewMode(),
+
+      // Visibility (multi-model)
+      hiddenEntitiesByModel: new Map(),
+      isolatedEntitiesByModel: new Map(),
+    }),
+    // With zero survivors every id is stale by definition, so this clears
+    // unconditionally rather than repeating the range check for an
+    // always-true answer. `isolatedEntities` / `ghostExceptEntities` clear to
+    // `null` (not an empty `Set`) for the reason the 'model-removed' arm
+    // below spells out — an empty-but-set isolate would hide the very next
+    // model loaded, until it does. `typeVisibility` / `typeViewMode` are NOT
+    // here: they are the user's persisted preferences, not scene state, and
+    // `clearAllModels` has never touched them.
+    'all-models-cleared': () => ({
+      hiddenEntities: new Set<number>(),
+      isolatedEntities: null,
+      ghostExceptEntities: null,
+      classFilter: null,
+      hiddenEntitiesByModel: new Map(),
+      isolatedEntitiesByModel: new Map(),
+    }),
+    'model-removed': (scope, state) => {
+      const { modelId, isStale } = scope;
+
+      // These key off `globalId`, not `modelId`. A global id is "stale" once no
+      // SURVIVING model's parse range or overlay owns it — the predicate the
+      // scope carries, computed once by the entry point. Left unpurged, an
+      // isolate or ghost set that only ever named the removed model's entities
+      // stays non-null while matching nothing in the survivors, so
+      // `effectiveIsolatedIds` keeps returning it and the entire remaining
+      // federation renders as hidden — worse than the id merely dangling.
+      const priorHidden = state.hiddenEntities;
+      const priorIsolated = state.isolatedEntities;
+      const priorGhost = state.ghostExceptEntities;
+      const priorClassFilter = state.classFilter;
+      const touched =
+        (priorHidden !== undefined && [...priorHidden].some(isStale)) ||
+        (priorIsolated != null && [...priorIsolated].some(isStale)) ||
+        (priorGhost != null && [...priorGhost].some(isStale)) ||
+        (priorClassFilter != null && [...priorClassFilter.ids].some(isStale)) ||
+        state.hiddenEntitiesByModel?.has(modelId) === true ||
+        state.isolatedEntitiesByModel?.has(modelId) === true;
+
+      // Nothing of ours named the removed model. Returning {} rather than a set
+      // of equal-but-new collections is what keeps this scope idempotent:
+      // `syncSourceModel` runs it a second time straight after
+      // `removeModel`, and a fresh `isolatedEntities` reference would put the
+      // channel through `withVisibilityOwnershipInvalidation` again for a set
+      // that did not move.
+      if (!touched) return {};
+
       return {
-        // Visibility (legacy)
-        hiddenEntities: new Set<number>(),
-        isolatedEntities: null,
-        ghostExceptEntities: null,
-        classFilter: null,
-        // Re-read persisted toggles on every file load so a new model never
-        // reverts the user's visibility choices (e.g. "Show Annotations").
-        typeVisibility: getPersistedTypeVisibility(),
-        typeViewMode: getPersistedTypeViewMode(),
-
-        // Visibility (multi-model)
-        hiddenEntitiesByModel: new Map(),
-        isolatedEntitiesByModel: new Map(),
+        hiddenEntities: priorHidden
+          ? new Set([...priorHidden].filter((id) => !isStale(id)))
+          : priorHidden,
+        // An isolate/ghost set left with zero surviving ids must clear to `null`
+        // outright, not an empty `Set` — a non-null empty set still reads as
+        // "isolation active, nothing matches" and hides every remaining entity,
+        // same as the stale set it replaces.
+        isolatedEntities: priorIsolated ? nonEmptyOrNull(priorIsolated, isStale) : priorIsolated,
+        ghostExceptEntities: priorGhost ? nonEmptyOrNull(priorGhost, isStale) : priorGhost,
+        // The Class-tab filter intersects into the visible set: left unpurged it
+        // would hold only burned ids after a sync, matching nothing — every
+        // element of the reloaded model would disappear. An emptied filter clears
+        // entirely.
+        classFilter: priorClassFilter
+          ? (() => {
+              const kept = new Set([...priorClassFilter.ids].filter((id) => !isStale(id)));
+              return kept.size > 0 ? { ids: kept, label: priorClassFilter.label } : null;
+            })()
+          : priorClassFilter,
+        hiddenEntitiesByModel: priorMapWithout(state.hiddenEntitiesByModel, modelId),
+        isolatedEntitiesByModel: priorMapWithout(state.isolatedEntitiesByModel, modelId),
       };
-    }
-
-    if (scope.kind === 'all-models-cleared') {
-      // With zero survivors every id is stale by definition, so this clears
-      // unconditionally rather than repeating the range check for an
-      // always-true answer. `isolatedEntities` / `ghostExceptEntities` clear to
-      // `null` (not an empty `Set`) for the reason the 'model-removed' arm
-      // below spells out — an empty-but-set isolate would hide the very next
-      // model loaded, until it does. `typeVisibility` / `typeViewMode` are NOT
-      // here: they are the user's persisted preferences, not scene state, and
-      // `clearAllModels` has never touched them.
-      return {
-        hiddenEntities: new Set<number>(),
-        isolatedEntities: null,
-        ghostExceptEntities: null,
-        classFilter: null,
-        hiddenEntitiesByModel: new Map(),
-        isolatedEntitiesByModel: new Map(),
-      };
-    }
-
-    const { modelId, isStale } = scope;
-
-    // These key off `globalId`, not `modelId`. A global id is "stale" once no
-    // SURVIVING model's parse range or overlay owns it — the predicate the
-    // scope carries, computed once by the entry point. Left unpurged, an
-    // isolate or ghost set that only ever named the removed model's entities
-    // stays non-null while matching nothing in the survivors, so
-    // `effectiveIsolatedIds` keeps returning it and the entire remaining
-    // federation renders as hidden — worse than the id merely dangling.
-    const priorHidden = state.hiddenEntities;
-    const priorIsolated = state.isolatedEntities;
-    const priorGhost = state.ghostExceptEntities;
-    const priorClassFilter = state.classFilter;
-    const touched =
-      (priorHidden !== undefined && [...priorHidden].some(isStale)) ||
-      (priorIsolated != null && [...priorIsolated].some(isStale)) ||
-      (priorGhost != null && [...priorGhost].some(isStale)) ||
-      (priorClassFilter != null && [...priorClassFilter.ids].some(isStale)) ||
-      state.hiddenEntitiesByModel?.has(modelId) === true ||
-      state.isolatedEntitiesByModel?.has(modelId) === true;
-
-    // Nothing of ours named the removed model. Returning {} rather than a set
-    // of equal-but-new collections is what keeps this scope idempotent:
-    // `syncSourceModel` runs it a second time straight after
-    // `removeModel`, and a fresh `isolatedEntities` reference would put the
-    // channel through `withVisibilityOwnershipInvalidation` again for a set
-    // that did not move.
-    if (!touched) return {};
-
-    return {
-      hiddenEntities: priorHidden
-        ? new Set([...priorHidden].filter((id) => !isStale(id)))
-        : priorHidden,
-      // An isolate/ghost set left with zero surviving ids must clear to `null`
-      // outright, not an empty `Set` — a non-null empty set still reads as
-      // "isolation active, nothing matches" and hides every remaining entity,
-      // same as the stale set it replaces.
-      isolatedEntities: priorIsolated ? nonEmptyOrNull(priorIsolated, isStale) : priorIsolated,
-      ghostExceptEntities: priorGhost ? nonEmptyOrNull(priorGhost, isStale) : priorGhost,
-      // The Class-tab filter intersects into the visible set: left unpurged it
-      // would hold only burned ids after a sync, matching nothing — every
-      // element of the reloaded model would disappear. An emptied filter clears
-      // entirely.
-      classFilter: priorClassFilter
-        ? (() => {
-            const kept = new Set([...priorClassFilter.ids].filter((id) => !isStale(id)));
-            return kept.size > 0 ? { ids: kept, label: priorClassFilter.label } : null;
-          })()
-        : priorClassFilter,
-      hiddenEntitiesByModel: priorMapWithout(state.hiddenEntitiesByModel, modelId),
-      isolatedEntitiesByModel: priorMapWithout(state.isolatedEntitiesByModel, modelId),
-    };
+    },
   },
 );
 

--- a/apps/viewer/src/store/slices/zonesSlice.ts
+++ b/apps/viewer/src/store/slices/zonesSlice.ts
@@ -22,7 +22,7 @@ import type { Zone, ZoneSet, ZoneAssignmentsByElement } from '../../lib/zones/ty
 import type { ZoneApportionmentEntry } from '../../lib/zones/apportionment-cache.js';
 import { serializeZoneSets, parseZoneSetFile } from '../../lib/zones/persistence.js';
 import { isConvexFootprint, normalizePrismBounds } from '../../lib/zones/prism.js';
-import { defineSliceTeardown } from '../teardown.js';
+import { defineSliceTeardown, notApplicable } from '../teardown.js';
 
 const ZONE_SETS_STORAGE_KEY = 'ifc-lite:zone-sets';
 
@@ -335,20 +335,24 @@ export const createZonesSlice: StateCreator<ZonesSlice, [], [], ZonesSlice> = (s
 export const zonesTeardown = defineSliceTeardown(
   'zonesSlice',
   ['zoneAssignments', 'zoneAssignmentTiming', 'zoneApportionment', 'editingZone'],
-  (scope) => scope.kind !== 'session-reset' ? {} : {
-    zoneAssignments: new Map(),
-    zoneAssignmentTiming: null,
-    // ... and the apportioned cubic metres computed off those assignments
-    // (#2508). `validEntry` only checks the ZONE revision, which a model swap
-    // does not move, so an entry that survives here is served against the
-    // incoming file — and the single-model fallback (globalId === expressId)
-    // means the new model's ids collide with the old one's. Same stale-model
-    // reference as `zoneAssignments` directly above; the two are one fact and
-    // must be dropped together.
-    zoneApportionment: new Map(),
-    // ... and drop any in-flight zone-edit session: leaving `editingZone`
-    // set would hand the incoming model live gizmo handles + picking for
-    // a zone the user was editing against the outgoing model.
-    editingZone: null,
+  {
+    'session-reset': () => ({
+      zoneAssignments: new Map(),
+      zoneAssignmentTiming: null,
+      // ... and the apportioned cubic metres computed off those assignments
+      // (#2508). `validEntry` only checks the ZONE revision, which a model swap
+      // does not move, so an entry that survives here is served against the
+      // incoming file — and the single-model fallback (globalId === expressId)
+      // means the new model's ids collide with the old one's. Same stale-model
+      // reference as `zoneAssignments` directly above; the two are one fact and
+      // must be dropped together.
+      zoneApportionment: new Map(),
+      // ... and drop any in-flight zone-edit session: leaving `editingZone`
+      // set would hand the incoming model live gizmo handles + picking for
+      // a zone the user was editing against the outgoing model.
+      editingZone: null,
+    }),
+    'model-removed': notApplicable,
+    'all-models-cleared': notApplicable,
   },
 );

--- a/apps/viewer/src/store/teardown-scope-completeness.test.ts
+++ b/apps/viewer/src/store/teardown-scope-completeness.test.ts
@@ -36,14 +36,30 @@ describe('an unrecognised teardown scope kind fails loudly, not silently (#3345)
 
     let thrown = 0;
     const silent: string[] = [];
+    const wrongError: string[] = [];
     for (const entry of viewerTeardownRegistry) {
       try {
         const result = entry.teardown(unknownScope, state);
         if (Object.keys(result).length === 0) silent.push(entry.slice);
-      } catch {
-        thrown++;
+      } catch (err) {
+        // Matched, not counted blindly: `state` is `{}`, so an arm that merely
+        // READS state can throw a TypeError, and a bare `catch` would score
+        // that as "correctly rejected the unknown kind" — the test would pass
+        // for the wrong reason. Only the dispatcher's own refusal counts.
+        if (err instanceof Error && /no teardown arm for scope kind/.test(err.message)) {
+          thrown++;
+        } else {
+          wrongError.push(`${entry.slice}: ${err instanceof Error ? err.message : String(err)}`);
+        }
       }
     }
+
+    assert.deepStrictEqual(
+      wrongError,
+      [],
+      'every throw must be the dispatcher refusing the unknown scope kind, not an ' +
+        'incidental error from inside an arm',
+    );
 
     assert.strictEqual(
       thrown,

--- a/apps/viewer/src/store/teardown-scope-completeness.test.ts
+++ b/apps/viewer/src/store/teardown-scope-completeness.test.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Issue #3345: a `TeardownScope` kind no contribution recognises used to be
+ * silent. 22 of 28 contributions opened with
+ * `if (scope.kind !== 'session-reset') return {};` — as correct for a scope
+ * that does not exist yet as for `session-reset` itself, so adding a fourth
+ * kind compiled clean, passed every existing test, and cleared none of the
+ * state those 22 slices own.
+ *
+ * `SliceTeardownArms` (`teardown.ts`) closes the type-level half: an object
+ * literal missing one of its (now four, if a kind is ever added) required
+ * keys is a compile error in all 28 contribution files at once. This test
+ * proves the runtime half — the shared switch `defineSliceTeardown` compiles
+ * every arms record into now THROWS for a scope kind it does not recognise,
+ * rather than quietly returning `{}` — which is what a contribution reached
+ * through a stale `.d.ts` or a JS caller outside the type system would still
+ * hit.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { viewerTeardownRegistry } from './teardown-registry.js';
+import type { TeardownScope, TeardownState } from './teardown.js';
+
+describe('an unrecognised teardown scope kind fails loudly, not silently (#3345)', () => {
+  it('every one of the 28 contributions throws, none silently returns {}', () => {
+    // Not a real TeardownScope member — the point is that nothing in this
+    // codebase can construct one under the type checker, so the only way to
+    // reach this is a caller outside it (untyped JS, a stale build). The cast
+    // simulates exactly that caller.
+    const unknownScope = { kind: 'workspace-closed' } as unknown as TeardownScope;
+    const state = {} as TeardownState;
+
+    let thrown = 0;
+    const silent: string[] = [];
+    for (const entry of viewerTeardownRegistry) {
+      try {
+        const result = entry.teardown(unknownScope, state);
+        if (Object.keys(result).length === 0) silent.push(entry.slice);
+      } catch {
+        thrown++;
+      }
+    }
+
+    assert.strictEqual(
+      thrown,
+      viewerTeardownRegistry.length,
+      `expected all ${viewerTeardownRegistry.length} contributions to throw for an unrecognised scope ` +
+        `kind; ${silent.length} silently returned {} instead: ${silent.join(', ')}`,
+    );
+  });
+});

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -224,13 +224,14 @@ export function defineSliceTeardown<const K extends keyof ViewerState>(
   owns: readonly K[],
   arms: SliceTeardownArms<NoInfer<K>>,
 ): SliceTeardown<K> {
+  // Indexed lookup, not a switch naming the three kinds by hand — the sync
+  // hazard `SliceTeardownArms` closes at the type level, a forgotten switch
+  // case would fall through to `default: throw`. `undefined` check keeps that
+  // thrown message for a stale/untyped caller; `teardown-scope-completeness.test.ts` pins it.
   const teardown = (scope: TeardownScope, state: TeardownState): ArmContribution<K> => {
-    switch (scope.kind) {
-      case 'session-reset': return arms['session-reset'](scope, state);
-      case 'model-removed': return arms['model-removed'](scope, state);
-      case 'all-models-cleared': return arms['all-models-cleared'](scope, state);
-      default: throw new Error(`no teardown arm for scope kind '${(scope as { kind: string }).kind}'`);
-    }
+    const arm = (arms as Record<TeardownScopeKind, Arm<TeardownScopeKind, K>>)[scope.kind];
+    if (arm === undefined) throw new Error(`no teardown arm for scope kind '${(scope as { kind: string }).kind}'`);
+    return arm(scope, state);
   };
   return { slice, owns, teardown: teardown as (scope: TeardownScope, state: TeardownState) => TeardownContribution<K> };
 }

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -177,6 +177,23 @@ export type TeardownState = Readonly<Partial<ViewerState>>;
 export type TeardownContribution<K extends keyof ViewerState> =
   Partial<Pick<ViewerState, K>> & { [P in Exclude<keyof ViewerState, K>]?: never };
 
+export type TeardownScopeKind = TeardownScope['kind'];
+type ScopeOfKind<Kind extends TeardownScopeKind> = Extract<TeardownScope, { kind: Kind }>;
+// WITHOUT TeardownContribution's excess-property trick: three per slice,
+// measured, pushes the checker over TS2590 ("union too complex") across the
+// registry. composeTeardown enforces the foreign-key guarantee at runtime.
+type ArmContribution<K extends keyof ViewerState> = Partial<Pick<ViewerState, K>>;
+type Arm<Kind extends TeardownScopeKind, K extends keyof ViewerState> = (scope: ScopeOfKind<Kind>, state: TeardownState) => ArmContribution<K>;
+
+// One slice's answer, ONE ARM PER SCOPE KIND (#3345): a plain function let 22
+// of 28 open with `if (scope.kind !== 'session-reset') return {};`, silently
+// no-op for a fourth kind. A required key per kind makes an omitted arm fail.
+export interface SliceTeardownArms<K extends keyof ViewerState> {
+  readonly 'session-reset': Arm<'session-reset', K>;
+  readonly 'model-removed': Arm<'model-removed', K>;
+  readonly 'all-models-cleared': Arm<'all-models-cleared', K>;
+}
+
 /**
  * One slice's answer to "what do I clear under this scope".
  *
@@ -210,33 +227,25 @@ export interface SliceTeardown<K extends keyof ViewerState = keyof ViewerState> 
 /** A teardown in a heterogeneous registry, where `K` is no longer known. */
 export type AnySliceTeardown = SliceTeardown<keyof ViewerState>;
 
-/**
- * Declare a slice's teardown.
- *
- * The `const` type parameter infers `K` as the literal union of `owns`, so the
- * body is checked against exactly those keys — no `as const` needed at the
- * call site, and no way to widen `K` by accident.
- *
- * @example
- * export const uiTeardown = defineSliceTeardown(
- *   'uiSlice',
- *   ['activeTool', 'editEnabled', 'pendingPropertyFocus'],
- *   (scope) => scope.kind !== 'session-reset' ? {} : {
- *     activeTool: UI_DEFAULTS.ACTIVE_TOOL,
- *     editEnabled: false,
- *     // Drop any one-shot bSDD "jump to property" focus armed before the
- *     // load — a new file reuses ids, so a stale focus could match an
- *     // unrelated entity (issue #1107).
- *     pendingPropertyFocus: null,
- *   },
- * );
- */
+/** "This scope does not touch me." */
+export function notApplicable(): TeardownContribution<never> { return {}; }
+
+// One arm per TeardownScopeKind; the cast below bridges ArmContribution to
+// TeardownContribution once per slice.
 export function defineSliceTeardown<const K extends keyof ViewerState>(
   slice: string,
   owns: readonly K[],
-  teardown: (scope: TeardownScope, state: TeardownState) => TeardownContribution<NoInfer<K>>,
+  arms: SliceTeardownArms<NoInfer<K>>,
 ): SliceTeardown<K> {
-  return { slice, owns, teardown };
+  const teardown = (scope: TeardownScope, state: TeardownState): ArmContribution<K> => {
+    switch (scope.kind) {
+      case 'session-reset': return arms['session-reset'](scope, state);
+      case 'model-removed': return arms['model-removed'](scope, state);
+      case 'all-models-cleared': return arms['all-models-cleared'](scope, state);
+      default: throw new Error(`no teardown arm for scope kind '${(scope as { kind: string }).kind}'`);
+    }
+  };
+  return { slice, owns, teardown: teardown as (scope: TeardownScope, state: TeardownState) => TeardownContribution<K> };
 }
 
 /**
@@ -366,12 +375,16 @@ function isUnchanged(a: unknown, b: unknown): boolean {
 export function composeTeardown(
   registry: readonly AnySliceTeardown[],
 ): (scope: TeardownScope, state: TeardownState) => Partial<ViewerState> {
+  // Runtime half of the foreign-key guard ArmContribution gave up at compile
+  // time: a contribution naming a key it does not own is caught here.
+  const owner = teardownOwnedKeys(registry);
   return (scope, state) => {
     const forcePresence = FORCED_PRESENCE_SCOPES.has(scope.kind);
     const patch: Partial<ViewerState> = {};
     for (const entry of registry) {
       const contribution = entry.teardown(scope, state);
       for (const key of Object.keys(contribution) as (keyof ViewerState)[]) {
+        if (owner.get(key) !== entry.slice) throw new Error(`${entry.slice} returned unowned key '${String(key)}'`);
         const next = contribution[key];
         if (!(forcePresence && NEVER_DROPPED.has(key)) && isUnchanged(state[key], next)) continue;
         writeKey(patch, key, next);

--- a/apps/viewer/src/store/teardown.ts
+++ b/apps/viewer/src/store/teardown.ts
@@ -22,9 +22,8 @@
  * about the word: the same 16-field list still exists in `modelSlice.test.ts`
  * as `ModelHarnessCrossState`, and it is the sole reason `TeardownState` below
  * is `Partial` rather than total, which in turn is why model-removed
- * contributions carry `?? new Set()` fallbacks. Giving that harness a real
- * store would delete the list and the fallbacks together. The four copies were held
- * together by prose: "same shape as `purgeStaleEntityState`", twice.
+ * contributions carry `?? new Set()` fallbacks — giving that harness a real
+ * store would delete the list and the fallbacks together.
  *
  * This module replaces the prose with a contract. Each slice contributes
  * ONE function that answers "what do I clear under this scope, and nothing
@@ -62,27 +61,25 @@
  *
  * Inline at the bottom of the slice, or in a sibling `<slice>.teardown.ts`. The
  * rule is the module-size ratchet and nothing else: sibling file iff the slice
- * plus its contribution would cross ~400 lines, inline otherwise. Two files
- * are split despite fitting: `addElementSlice` and `annotationsSlice`, whose
- * host PLUS contribution come to 341 and 365. Group uniformity was the reason;
- * folding those two back inline would make the rule exceptionless.
+ * plus its contribution would cross ~400 lines, inline otherwise. `addElementSlice`
+ * and `annotationsSlice` split despite fitting (341, 365 combined) for group
+ * uniformity; folding them back inline would make the rule exceptionless.
  *
  * ## Trap A: a teardown returns an EXPLICIT field list, never a whole state
  *
  * `scripts/check-whole-state-reset.mjs` (proposal, issue #2802) documents
- * three bugs of this class that landed in one day: `sheetSlice.clearSheet`
- * did `set(getDefaultState())` and destroyed `savedSheetTemplates`;
+ * three bugs of this class in one day: `sheetSlice.clearSheet` did
+ * `set(getDefaultState())` and destroyed `savedSheetTemplates`;
  * `drawing2DSlice.clearDrawing2D` destroyed custom override rules,
  * `overridesEnabled`, text annotations and DXF underlays.
  *
  * So: `owns` is a hand-written list, and the returned object names its fields
- * one by one. `...initialState` and `...getDefaultState()` are forbidden as
- * the body of a teardown. Fields that legitimately outlive a session reset —
+ * one by one. `...initialState` / `...getDefaultState()` are forbidden as a
+ * teardown body. Fields that legitimately outlive a session reset —
  * `savedSheetTemplates`, `graphicOverridePresets`, `dxfUnderlays`, `bcfProject`,
- * `bcfAuthor`, `idsDocument`, `savedLenses`, clash presets, zone SETS,
- * `playbackSpeed` / `playbackLoop` / `ganttTimeScale` — are simply absent from
- * both `owns` and the body. `owns` is the reviewable artefact: it is the list
- * of everything this slice is willing to destroy.
+ * clash presets, zone SETS, `playbackSpeed`/`playbackLoop`/`ganttTimeScale` —
+ * are simply absent from both `owns` and the body, which is the reviewable
+ * artefact: the list of everything this slice is willing to destroy.
  *
  * ## Trap B: persisted fields survive their session-scoped neighbours
  *
@@ -101,15 +98,11 @@
  * ## The visibility-ownership middleware
  *
  * `store/index.ts` wraps the store in `withVisibilityOwnershipInvalidation`
- * (`store/visibility-invalidation.ts`), which is the one place
- * `isolatedEntities` / `ghostExceptEntities` can be written. Its own doc makes
- * the same argument this module does — a middleware "rather than a helper each
- * writing action remembers to call" — and it is already accepted here.
- *
- * Nothing below fights it: teardown produces a patch, and the ENTRY POINT
- * applies that patch through the wrapped `set` / `setState`, so the
- * invalidation fires for teardown writes exactly as it does for every other
- * write. Never apply a composed patch through an unwrapped setter.
+ * (`store/visibility-invalidation.ts`), the one place `isolatedEntities` /
+ * `ghostExceptEntities` can be written. Nothing below fights it: teardown
+ * produces a patch, and the ENTRY POINT applies it through the wrapped `set` /
+ * `setState`, so the invalidation fires for teardown writes exactly as it does
+ * for every other write. Never apply a composed patch through an unwrapped setter.
  */
 
 import type { ViewerState } from './index.js';
@@ -131,15 +124,13 @@ export type TeardownScope =
       isStale: (id: number) => boolean;
       /**
        * Which model holds `activeModelId` once this one is gone, resolved ONCE
-       * by the entry point. Federation knowledge, so it belongs to whoever
-       * builds the scope rather than to each slice that has to follow it.
-       *
-       * Two slices need it and they own different keys, so the disjointness
-       * proof cannot see them: `modelSlice` writes `activeModelId`, `dataSlice`
-       * writes the `ifcDataStore` / `geometryResult` that must follow it. When
-       * each derived the successor for itself, changing the rule in one file
-       * left the data pointing at a model the active id did not name — a blank
-       * properties panel over a live model list, and no gate would catch it.
+       * by the entry point — federation knowledge, so it belongs to whoever
+       * builds the scope. Two slices need it and own different keys, so the
+       * disjointness proof cannot see them: `modelSlice` writes `activeModelId`,
+       * `dataSlice` writes the `ifcDataStore` / `geometryResult` that must follow
+       * it. Deriving the successor twice once left the data pointing at a model
+       * the active id did not name — a blank properties panel over a live model
+       * list, no gate would catch it.
        */
       nextActiveModelId: string | null;
     }
@@ -156,10 +147,9 @@ export type TeardownScope =
  * cast optional); making it part of the type means a teardown cannot forget.
  *
  * Fall back to the slice's OWN initial value — by definition the correct
- * answer, and the value is already in the file.
- *
- * `Readonly` because a teardown must not mutate what it was handed: `set` has
- * not run yet and the object is the live state.
+ * answer, and the value is already in the file. `Readonly` because a teardown
+ * must not mutate what it was handed: `set` has not run yet and the object is
+ * the live state.
  */
 export type TeardownState = Readonly<Partial<ViewerState>>;
 
@@ -171,28 +161,26 @@ export type TeardownState = Readonly<Partial<ViewerState>>;
  * literal returned from a callback whose contextual type comes from an
  * inference site, so a body returning a key outside `owns` compiled clean
  * (measured, before this was added). Typing every OTHER key as `never` is what
- * actually makes "return only the keys you own" a compiler error rather than a
- * comment — which is the whole point of declaring `owns` separately.
+ * makes "return only the keys you own" a compiler error, not just a comment.
  */
 export type TeardownContribution<K extends keyof ViewerState> =
   Partial<Pick<ViewerState, K>> & { [P in Exclude<keyof ViewerState, K>]?: never };
 
 export type TeardownScopeKind = TeardownScope['kind'];
 type ScopeOfKind<Kind extends TeardownScopeKind> = Extract<TeardownScope, { kind: Kind }>;
-// WITHOUT TeardownContribution's excess-property trick: three per slice,
-// measured, pushes the checker over TS2590 ("union too complex") across the
-// registry. composeTeardown enforces the foreign-key guarantee at runtime.
+// WITHOUT TeardownContribution's excess-property trick (TS2590 across the
+// registry, measured): composeTeardown enforces the foreign-key guarantee at runtime instead.
 type ArmContribution<K extends keyof ViewerState> = Partial<Pick<ViewerState, K>>;
 type Arm<Kind extends TeardownScopeKind, K extends keyof ViewerState> = (scope: ScopeOfKind<Kind>, state: TeardownState) => ArmContribution<K>;
 
-// One slice's answer, ONE ARM PER SCOPE KIND (#3345): a plain function let 22
-// of 28 open with `if (scope.kind !== 'session-reset') return {};`, silently
-// no-op for a fourth kind. A required key per kind makes an omitted arm fail.
-export interface SliceTeardownArms<K extends keyof ViewerState> {
-  readonly 'session-reset': Arm<'session-reset', K>;
-  readonly 'model-removed': Arm<'model-removed', K>;
-  readonly 'all-models-cleared': Arm<'all-models-cleared', K>;
-}
+// ONE ARM PER SCOPE KIND (#3345): a plain function let 22 of 28 open with
+// `if (scope.kind !== 'session-reset') return {};`, a silent no-op for a
+// fourth kind. Mapped over TeardownScopeKind — not a record naming the three
+// kinds by hand — so a fourth TeardownScope kind is a compile error in every
+// arms object that omits it, not just a runtime no-op.
+export type SliceTeardownArms<K extends keyof ViewerState> = {
+  readonly [Kind in TeardownScopeKind]: Arm<Kind, K>;
+};
 
 /**
  * One slice's answer to "what do I clear under this scope".
@@ -214,8 +202,8 @@ export interface SliceTeardown<K extends keyof ViewerState = keyof ViewerState> 
    * spreads its groups conditionally (`...(selectionTouchedRemoved ? {…} : {})`)
    * precisely so an untouched group is not rewritten; keeping that habit is
    * what makes `model-removed` idempotent, which in turn is what lets
-   * `syncSourceModel` runs the SAME composition after `removeModel`
-   * without undoing or re-allocating anything.
+   * `syncSourceModel` run the SAME composition after `removeModel` without
+   * undoing or re-allocating anything.
    *
    * {@link composeTeardown} drops unchanged entries as a backstop, including a
    * `Set` / `Map` / array rebuilt equal-but-new — a should, not a must, but
@@ -230,8 +218,7 @@ export type AnySliceTeardown = SliceTeardown<keyof ViewerState>;
 /** "This scope does not touch me." */
 export function notApplicable(): TeardownContribution<never> { return {}; }
 
-// One arm per TeardownScopeKind; the cast below bridges ArmContribution to
-// TeardownContribution once per slice.
+// The cast below bridges ArmContribution to TeardownContribution once per slice.
 export function defineSliceTeardown<const K extends keyof ViewerState>(
   slice: string,
   owns: readonly K[],
@@ -366,11 +353,11 @@ function isUnchanged(a: unknown, b: unknown): boolean {
  *
  * A key absent from `state` (the partial-store test harness) is never
  * "unchanged" — `isUnchanged(undefined, value)` is false unless the teardown
- * also returns `undefined`. About a dozen contributions DO: most of
- * `visibilitySlice` / `selectionSlice`'s model-removed arms, plus `dataSlice`'s
- * `purgeRemovedModelsBackup`, each passing THROUGH a value read from `state`,
- * so `undefined` appears only where the live value already is. A SYNTHESIZED
- * `undefined` would survive the filter and `writeKey` would blank the field.
+ * also returns `undefined`. About a dozen contributions DO, passing THROUGH a
+ * value read from `state` (most of `visibilitySlice` / `selectionSlice`'s
+ * model-removed arms, `dataSlice.purgeRemovedModelsBackup`), so `undefined`
+ * appears only where the live value already is — a SYNTHESIZED `undefined`
+ * would survive the filter and `writeKey` would blank the field.
  */
 export function composeTeardown(
   registry: readonly AnySliceTeardown[],


### PR DESCRIPTION
## Summary

Fixes #3345. `TeardownScope` is a three-kind union; each of the 28 slice teardown contributions was one `(scope, state)` function, and 22 of them opened with `if (scope.kind !== 'session-reset') return {};`. That guard is exactly as "correct" for a scope kind that doesn't exist yet as for `session-reset` itself — a fourth `TeardownScope` kind would have compiled clean, passed every existing test, and silently left those 22 slices' state uncleared.

**Reproduced first**: `src/store/teardown-scope-completeness.test.ts` drives an unrecognised scope kind through the real 28-entry registry. On the pre-fix code, 0 of 28 contributions threw and 26 silently returned `{}` for it — RED, proven by stashing only `teardown.ts` and restoring it by SHA. After the fix, all 28 throw.

**Fix**: `defineSliceTeardown`'s third argument is now a `SliceTeardownArms` record requiring one named arm per `TeardownScope` kind (`'session-reset'`, `'model-removed'`, `'all-models-cleared'`). Omitting an arm — today, or at any of the 28 call sites once a kind is added to `TeardownScope` later — is a **compile error**, not a runtime assertion. `notApplicable` spells the deliberate "this scope does not touch me" case. All 28 contribution files were converted; none changes what it writes for any existing scope (pinned key sets in `teardown-registry.test.ts` are unchanged).

## Trade-off, measured not assumed

Typing every arm with the pre-existing foreign-key rejection (`TeardownContribution`'s `Exclude<keyof ViewerState, K>` never-trick) tripled that computation across the 28-entry registry and crossed TypeScript's TS2590 ("union type too complex") budget — reproduced with a minimal repro, and confirmed by diffing `tsc --noEmit` output against a pristine baseline (0 new errors either way once the trick is removed). Arms are typed loosely instead (`Partial<Pick<ViewerState, K>>`), and `composeTeardown` now checks a returned key's ownership **at runtime**, against the same map `createTeardownRegistry` already proves disjoint at module init. This is real enforcement, just no longer compile-time for that one, separate guarantee — the required-arm guarantee #3345 asks for remains fully compile-time and is unaffected.

## Overlap with #3379

#3379 (issue #3346) changes `composeTeardown`'s equality gate (`isUnchanged`, `FORCED_PRESENCE_SCOPES`) in the same file. Both sets of changes are additive and are kept together here; no conflict in intent.

## Test plan
- [x] `src/store/teardown-scope-completeness.test.ts` (new): all 28 contributions throw for an unrecognised scope kind — RED proven against pristine `teardown.ts` via `git stash`, GREEN after the fix.
- [x] `src/store/teardown-registry.test.ts` — all pinned key/ownership sets unchanged, 5/5 pass.
- [x] `src/store/teardown.idempotence.test.ts` — 2/2 pass.
- [x] `pnpm --filter @ifc-lite/viewer typecheck` — 0 errors, matches pristine-baseline error count exactly (diffed).
- [x] `node scripts/check-module-size.mjs` — 0 new files over 400 (`teardown.ts` trimmed to exactly 400).
- [x] `node scripts/check-source-text-assertions.mjs` — 0 new.
- [x] `node scripts/check-unused-locals.mjs` — 0 new.
- [x] `npx oxlint` on touched files — no new warnings/errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved viewer state cleanup during session resets, model removal, and clearing all models.
  - Fixed stale selections, visibility settings, pinboard items, and related state persisting after models are removed or all models are cleared.
  - Section-plane settings now reset more consistently.
  - Invalid or unsupported cleanup events now fail clearly instead of being silently ignored.

- **Reliability**
  - Made cleanup behavior explicit for each supported event, reducing the risk of incomplete future state resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
