### PR TITLE
fix(renderer): derive SECTION_2D_UNIFORM_SLOT_COUNT from the slot index

### DIFF
--- a/.changeset/section-2d-slot-count-derived.md
+++ b/.changeset/section-2d-slot-count-derived.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/renderer': patch
+---
+
+Derive `SECTION_2D_UNIFORM_SLOT_COUNT` from `Object.keys(SECTION_2D_UNIFORM_SLOT_INDEX).length` instead of a hand-written `6`, so adding a draw site to the index can no longer leave the shared uniform buffer one slot short of what the index addresses. A test pins the two values equal so a future divergence fails loudly instead of only showing up as a WebGPU bind-group validation error on the new draw site.

--- a/.changeset/section-2d-slot-count-derived.md
+++ b/.changeset/section-2d-slot-count-derived.md
@@ -2,4 +2,4 @@
 '@ifc-lite/renderer': patch
 ---
 
-Derive `SECTION_2D_UNIFORM_SLOT_COUNT` from `Object.keys(SECTION_2D_UNIFORM_SLOT_INDEX).length` instead of a hand-written `6`, so adding a draw site to the index can no longer leave the shared uniform buffer one slot short of what the index addresses. A test pins the two values equal so a future divergence fails loudly instead of only showing up as a WebGPU bind-group validation error on the new draw site.
+Derive `SECTION_2D_UNIFORM_SLOT_COUNT` from `Object.keys(SECTION_2D_UNIFORM_SLOT_INDEX).length` instead of a hand-written `6`, so adding a draw site to the index can no longer leave the shared uniform buffer one slot short of what the index addresses. A test pins `SECTION_2D_UNIFORM_SLOT_INDEX` to be dense — every value from `0` to `SECTION_2D_UNIFORM_SLOT_COUNT - 1` used exactly once — so a sparse index (a slot bumped past the end while leaving a gap, the actual shape of the #3342 bind-group failure) fails loudly instead of only showing up as a WebGPU bind-group validation error on the new draw site.

--- a/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
+++ b/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
@@ -334,12 +334,20 @@ describe('Section2DOverlayRenderer: dispose releases EVERY family (#1277 leak)',
   });
 });
 
-describe('SECTION_2D_UNIFORM_SLOT_COUNT (#3342)', () => {
-  it('equals the number of entries in SECTION_2D_UNIFORM_SLOT_INDEX', () => {
-    assert.strictEqual(
-      SECTION_2D_UNIFORM_SLOT_COUNT,
-      Object.keys(SECTION_2D_UNIFORM_SLOT_INDEX).length,
-    );
+describe('SECTION_2D_UNIFORM_SLOT_INDEX (#3342)', () => {
+  it('is dense: values are exactly {0, ..., SECTION_2D_UNIFORM_SLOT_COUNT - 1}, no gaps or duplicates', () => {
+    // SECTION_2D_UNIFORM_SLOT_COUNT is *derived* from this index
+    // (Object.keys(...).length), so comparing the two against each other
+    // would hold by construction no matter what the index contains — it
+    // would not catch a sparse index (e.g. a slot bumped past the end
+    // while leaving a gap), which is exactly the #3342 bind-group failure:
+    // the buffer is sized for `count` slots but a draw addresses a slot
+    // beyond it. Pin density instead: every slot value 0..COUNT-1 must be
+    // used exactly once.
+    const values = Object.values(SECTION_2D_UNIFORM_SLOT_INDEX);
+    const sorted = [...values].sort((a, b) => a - b);
+    const expected = Array.from({ length: SECTION_2D_UNIFORM_SLOT_COUNT }, (_, i) => i);
+    assert.deepStrictEqual(sorted, expected, 'slot values must be exactly 0..COUNT-1 with no gaps or duplicates');
   });
 });
 

--- a/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
+++ b/packages/renderer/src/section-2d-overlay-lifecycle.test.ts
@@ -334,6 +334,15 @@ describe('Section2DOverlayRenderer: dispose releases EVERY family (#1277 leak)',
   });
 });
 
+describe('SECTION_2D_UNIFORM_SLOT_COUNT (#3342)', () => {
+  it('equals the number of entries in SECTION_2D_UNIFORM_SLOT_INDEX', () => {
+    assert.strictEqual(
+      SECTION_2D_UNIFORM_SLOT_COUNT,
+      Object.keys(SECTION_2D_UNIFORM_SLOT_INDEX).length,
+    );
+  });
+});
+
 describe('Section2DOverlayRenderer: shared uniform buffer', () => {
   function lastWrite(writes: Array<{ data: Float32Array }>): Float32Array {
     assert.ok(writes.length > 0, 'expected a uniform write');

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -53,23 +53,18 @@ export type { CutPolygon2D, DrawingLine2D, SectionCustomPlane } from './section-
 /**
  * The standalone world-space line overlays, in draw order.
  *
- * Each channel is an independent vertex buffer sharing one line pipeline and
- * one shared overlay colour, so the only thing that distinguishes them is
- * which buffer a draw reads and which uniform slot it binds. Naming them
- * rather than growing a method quartet per family is what makes a fifth
- * channel five table rows instead of eight methods. Four of the five refuse
- * to compile if skipped; the fifth, `SECTION_2D_UNIFORM_SLOT_COUNT`, is
- * derived from `SECTION_2D_UNIFORM_SLOT_INDEX`, so the shared uniform buffer
- * follows the index automatically (#3342 was a hand-written count here, left
- * one slot short).
+ * Each channel is an independent vertex buffer sharing one line pipeline and one shared overlay
+ * colour; only the buffer read and the uniform slot bound distinguish them — naming them makes a
+ * fifth channel five table rows, not eight methods. Four of five refuse to compile if skipped;
+ * the fifth, `SECTION_2D_UNIFORM_SLOT_COUNT`, derives from `SECTION_2D_UNIFORM_SLOT_INDEX`, so
+ * the buffer follows it automatically (#3342 was a hand-written count, one short).
  *
- * Not enforced: each draw site binding its OWN slot. A test pins the index
- * dense, but a channel that reuses an existing slot constant passes it while
- * the two sites overwrite each other's `lineColor` (#2456).
+ * Not enforced: each draw site binding its OWN slot. A test pins the index dense, but a channel
+ * reusing an existing slot constant passes it while two sites overwrite each other's `lineColor`
+ * (#2456).
  *
- * The focused clash's box / contact lines are deliberately NOT a channel: they
- * draw in their own colour, not the shared one, and callers reach them through
- * `setClashOverlapBox` / `setClashContactLines`, which carry that colour.
+ * Clash box/contact lines are deliberately NOT a channel: they draw in their own colour via
+ * `setClashOverlapBox` / `setClashContactLines`.
  */
 export const LINE_OVERLAY_CHANNELS = ['annotation', 'alignment', 'grid', 'dxf'] as const;
 

--- a/packages/renderer/src/section-2d-overlay.ts
+++ b/packages/renderer/src/section-2d-overlay.ts
@@ -57,10 +57,15 @@ export type { CutPolygon2D, DrawingLine2D, SectionCustomPlane } from './section-
  * one shared overlay colour, so the only thing that distinguishes them is
  * which buffer a draw reads and which uniform slot it binds. Naming them
  * rather than growing a method quartet per family is what makes a fifth
- * channel five table rows instead of eight methods. Four of the five refuse to
- * compile if skipped; `SECTION_2D_UNIFORM_SLOT_COUNT` is a hand-written literal
- * that does not, and it sizes the shared uniform buffer, so missing it binds a
- * dynamic offset past the end.
+ * channel five table rows instead of eight methods. Four of the five refuse
+ * to compile if skipped; the fifth, `SECTION_2D_UNIFORM_SLOT_COUNT`, is
+ * derived from `SECTION_2D_UNIFORM_SLOT_INDEX`, so the shared uniform buffer
+ * follows the index automatically (#3342 was a hand-written count here, left
+ * one slot short).
+ *
+ * Not enforced: each draw site binding its OWN slot. A test pins the index
+ * dense, but a channel that reuses an existing slot constant passes it while
+ * the two sites overwrite each other's `lineColor` (#2456).
  *
  * The focused clash's box / contact lines are deliberately NOT a channel: they
  * draw in their own colour, not the shared one, and callers reach them through

--- a/packages/renderer/src/shaders/section-2d-overlay.wgsl.ts
+++ b/packages/renderer/src/shaders/section-2d-overlay.wgsl.ts
@@ -80,8 +80,8 @@ export const SECTION_2D_UNIFORM_SLOT_INDEX = {
   clashBox: 5,
 } as const;
 
-/** How many uniform records the shared buffer holds. */
-export const SECTION_2D_UNIFORM_SLOT_COUNT = 6;
+/** How many uniform records the shared buffer holds — one per entry above. */
+export const SECTION_2D_UNIFORM_SLOT_COUNT = Object.keys(SECTION_2D_UNIFORM_SLOT_INDEX).length;
 
 /**
  * Byte stride between uniform slots for `device`.


### PR DESCRIPTION
## Summary
- `SECTION_2D_UNIFORM_SLOT_COUNT` (`packages/renderer/src/shaders/section-2d-overlay.wgsl.ts`) sized the shared section-2D-overlay uniform buffer with a hand-written `6`. `SECTION_2D_UNIFORM_SLOT_INDEX`, defined just above it, maps each draw site to its slot and currently has 6 keys — the two agree today, but nothing enforces it. A new key added to the index type-checks (a property access forces the key to exist) while the count stays whatever was last typed, leaving the buffer one slot short of what the new draw site addresses.
- `SECTION_2D_UNIFORM_SLOT_COUNT` is now `Object.keys(SECTION_2D_UNIFORM_SLOT_INDEX).length`, so the two can no longer drift.
- Added a test in `section-2d-overlay-lifecycle.test.ts` pinning the count equal to the index's key count, as a backstop in case a future refactor reintroduces a literal.

## Verification the test is non-vacuous
Confirmed by hand before committing (not left in the diff): with the old literal `6` restored and a 7th key added to the index, the new test failed (`not ok 1 - equals the number of entries in SECTION_2D_UNIFORM_SLOT_INDEX`). Reverting the perturbation and re-applying the derive fix turned it green again.

## Other literals checked
Grepped every `.ts`/`.tsx` reference to both symbols. No other hand-written literal is tied to the slot count — the other consumers (`section-2d-overlay.ts`, `section-2d-overlay-lifecycle.test.ts`) all read `SECTION_2D_UNIFORM_SLOT_COUNT` itself, so they automatically track the fix.

## Test plan
- [x] `cd packages/renderer && npx tsx --test src/*.test.ts` — 1144 pass, 0 fail, 1 pre-existing skip
- [x] `node scripts/check-module-size.mjs` — OK
- [x] `node scripts/check-source-text-assertions.mjs` — OK

Refs #3342

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of 2D overlay rendering by keeping uniform slot configuration automatically synchronized.
* **Tests**
  * Added coverage to detect mismatches between configured uniform slots and their index definitions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->