### PR TITLE
test(export,data): pin the STEP string escaper's TS and Rust halves to one shared vector fixture

### DIFF
--- a/.changeset/step-escaper-vector-fixture.md
+++ b/.changeset/step-escaper-vector-fixture.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/data': patch
+---
+
+Test-infrastructure change only, no behaviour change: `escapeStepString`'s coverage in `packages/data/src/step-serializers.test.ts` no longer carries a hand-written literal table asserting it matches the Rust escaper's (`ifc_lite_export::step_text::escape`) output on the same inputs. That table, and the Rust side's own hand-written table pinning the TypeScript output, are replaced by one shared vector fixture (`rust/export/tests/fixtures/step_escape_vectors.json`), consumed by both `packages/data/src/step-escape.parity.test.ts` and `rust/export/tests/step_escape_parity.rs`. This follows the precedent set for the CSV-cell escaper (`csv_cell_vectors.json`) — two independently hand-kept copies of the same expected behaviour can drift apart silently (#3284 shipped exactly that way), where one shared fixture cannot.
+
+A new `check:step-escapers` script (mirroring `check:csv-escapers`) fails CI if a third full implementation of the escaper appears outside the two canonical ones.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -841,6 +841,15 @@ jobs:
       - name: Check CSV escaper gate regressions
         run: node --test scripts/check-csv-escaper-copies.test.mjs
 
+      # Same precedent, for the STEP (ISO 10303-21) string-literal escaper
+      # (#3300, second half): the TypeScript and Rust implementations cannot
+      # share code, so each is pinned against the other via a shared vector
+      # fixture instead of a hand-kept copy of the other side's behaviour.
+      - name: Check for hand-rolled STEP string escapers
+        run: node scripts/check-step-escaper-copies.mjs
+      - name: Check STEP escaper gate regressions
+        run: node --test scripts/check-step-escaper-copies.test.mjs
+
       # `scripts/lib/vitest-timeout-audit.mjs` (#2948) replaced
       # `audit-test-timeouts.mjs`, which was deleted in the same change rather
       # than left beside it: two hand-written JS/TS lexers for one question is

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check:loader-hook-specifier-match": "node scripts/check-loader-hook-specifier-match.mjs",
     "check:clash-degenerate-reason-parity": "node scripts/check-clash-degenerate-reason-parity.mjs",
     "check:csv-escapers": "node scripts/check-csv-escaper-copies.mjs",
+    "check:step-escapers": "node scripts/check-step-escaper-copies.mjs",
     "check:vitest-timeout-audit": "git ls-files -z '*.test.ts' '*.test.tsx' | xargs -0 node scripts/lib/vitest-timeout-audit.mjs --summary-only",
     "check:api-surface": "node scripts/check-api-surface.mjs",
     "check:rust-semver": "node scripts/check-rust-semver.mjs",

--- a/packages/data/src/step-escape.parity.test.ts
+++ b/packages/data/src/step-escape.parity.test.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * TypeScript half of the STEP-string-escape cross-language parity pin (#3300,
+ * second half).
+ *
+ * The Rust escaper (`rust/export/src/step_text.rs`, `escape`, exercised by
+ * `rust/export/tests/step_escape_parity.rs`) is held to the SAME fixture, so
+ * the two implementations cannot drift apart silently. Mirrors
+ * `csv-cell.parity.test.ts`, which does the same for the CSV-cell escaper.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { escapeStepString } from './step-serializers.js';
+
+interface Vector {
+  name: string;
+  input: string;
+  expected: string;
+}
+
+interface Fixture {
+  cases: Vector[];
+}
+
+// The fixture lives in the Rust crate so `include_str!` can reach it; this
+// side resolves it relative to the source file. NOT guarded by `existsSync`:
+// a missing fixture means the pin is not being enforced, which must fail
+// loudly.
+const fixturePath = fileURLToPath(
+  new URL('../../../rust/export/tests/fixtures/step_escape_vectors.json', import.meta.url),
+);
+const fixture: Fixture = JSON.parse(readFileSync(fixturePath, 'utf8'));
+
+describe('escapeStepString matches the shared cross-language vectors', () => {
+  it('the fixture actually carries cases (an empty sweep proves nothing)', () => {
+    expect(fixture.cases.length).toBeGreaterThan(20);
+  });
+
+  for (const v of fixture.cases) {
+    it(`vector: ${v.name}`, () => {
+      expect(escapeStepString(v.input)).toBe(v.expected);
+    });
+  }
+});

--- a/packages/data/src/step-serializers.test.ts
+++ b/packages/data/src/step-serializers.test.ts
@@ -5,7 +5,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   enumVal,
-  escapeStepString,
   formatStepReal,
   generateHeader,
   generateStepFileWithRegistry,
@@ -233,81 +232,14 @@ describe('toStepLineWithRegistry / generateStepFileWithRegistry', () => {
 });
 
 
-/**
- * `escapeStepString` is now the ONE TypeScript implementation (#3300):
- * `@ifc-lite/export`'s `step-serialization.ts` re-exports this symbol rather
- * than keeping its own copy, so this suite is the only place TS-side coverage
- * needs to live. `ifc_lite_export::step_text::escape` stays a separate,
- * hand-kept Rust implementation — a wasm adapter to share it is out of scope
- * here — so the rule below (ONE SPACE PER CONTROL CHARACTER, not one per run,
- * #3284 item 2) is pinned against the Rust half's observed output rather than
- * shared code. Exercised through the two public funnels that use it —
- * `serializeValue` for an attribute value and `generateHeader` for a header
- * field — plus `escapeStepString` itself directly, now that it is exported.
- */
-describe('control-character runs are one space each (#3284, parity with the Rust escape)', () => {
-  const RUST_VECTORS: ReadonlyArray<readonly [string, string, string]> = [
-    ['tab run', 'a\t\t\tb', 'a   b'],
-    ['crlf', 'a\r\nb', 'a  b'],
-    ['mixed C0 + DEL', 'a\u0000\u000B\u001F\u007Fb', 'a    b'],
-    ['single control char', 'a\tb', 'a b'],
-    ['quote doubling around a run', "O'Brien\t\tx", "O''Brien  x"],
-    // Negative control: nothing to replace, byte-identical output.
-    ['no control chars', 'plain text 123', 'plain text 123'],
-  ];
-
-  it.each(RUST_VECTORS)('serializeValue escapes %s as the Rust half does', (_l, input, expected) => {
-    expect(serializeValue(input)).toBe(`'${expected}'`);
-  });
-
-  it.each(RUST_VECTORS)('generateHeader escapes %s as the Rust half does', (_l, input, expected) => {
-    const line = generateHeader({ schema: 'IFC4', author: [input], timeStamp: 'TS' })
-      .split('\n')
-      .find((l) => l.startsWith('FILE_NAME'));
-    expect(line).toContain(`('${expected}')`);
-  });
-
-  it('keeps the run length and still emits no control byte, at every length', () => {
-    // Both directions: same length as the input (one space per control char),
-    // and no control character survives — a run left intact would also keep
-    // its length, so neither assertion alone would fail the old collapse.
-    for (const n of [1, 2, 3, 8]) {
-      const serialized = serializeValue(`a${'\n'.repeat(n)}b`);
-      expect(serialized).toBe(`'a${' '.repeat(n)}b'`);
-      // eslint-disable-next-line no-control-regex
-      expect(serialized).not.toMatch(/[\u0000-\u001F\u007F]/);
-    }
-  });
-});
-
-
-/**
- * `escapeStepString` exported directly (#3300): the two TS copies of the
- * encode half collapsed into this one, re-exported by `@ifc-lite/export`.
- * Awkward inputs a caller could plausibly pass through -- a bare backslash,
- * an apostrophe, a BMP non-ASCII character, text that already looks like a
- * `\X2\` directive, and the empty string.
- */
-describe('escapeStepString direct (#3300)', () => {
-  it('doubles a lone backslash', () => {
-    expect(escapeStepString('a\\b')).toBe('a\\\\b');
-  });
-
-  it('doubles a lone apostrophe', () => {
-    expect(escapeStepString("a'b")).toBe("a''b");
-  });
-
-  it('encodes a non-ASCII character as an \\X2\\ directive', () => {
-    expect(escapeStepString('\u00C4')).toBe('\\X2\\00C4\\X0\\');
-  });
-
-  it('doubles the backslashes of text that already looks like a directive', () => {
-    // The input is literal text, not an actual directive: every backslash in
-    // it must be doubled like any other, or a reader would decode it as one.
-    expect(escapeStepString('a\\X2\\00FC\\X0\\b')).toBe('a\\\\X2\\\\00FC\\\\X0\\\\b');
-  });
-
-  it('returns the empty string unchanged', () => {
-    expect(escapeStepString('')).toBe('');
-  });
-});
+// The `escapeStepString`-vs-Rust literal-vector tests that used to live here
+// (`RUST_VECTORS`, in a `describe('control-character runs are one space each
+// (#3284, parity with the Rust escape)', ...)` block) and the
+// `describe('escapeStepString direct (#3300)', ...)` block are now the shared
+// vectors in `../../../rust/export/tests/fixtures/step_escape_vectors.json`,
+// pinned on this side by `./step-escape.parity.test.ts` and on the Rust side
+// by `rust/export/tests/step_escape_parity.rs` (#3300, second half). A
+// hand-kept copy of the other language's behaviour only resets the clock on
+// the drift it exists to catch -- the reasoning behind the CSV-cell-escaper
+// precedent this follows: `rust/export/tests/fixtures/csv_cell_vectors.json`
+// / `packages/export/src/csv-cell.parity.test.ts`.

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -53,6 +53,15 @@ mod step_json;
 mod step_text;
 mod usd;
 
+// `step_text::escape` was `pub(crate)`, so an external integration-test
+// binary (`rust/export/tests/step_escape_parity.rs`) could not reach it: it
+// now needs `pub` visibility to be pinned against the shared vectors in
+// `tests/fixtures/step_escape_vectors.json`, the same way `csv_cell::escape_csv_cell`
+// is pinned by `tests/csv_cell_parity.rs` (issue #3300, second half). Re-export
+// just the one function, not `pub mod step_text` -- `step_text`'s other items
+// stay crate-private, so this widens the public surface by exactly one symbol.
+pub use step_text::escape as escape_step_string;
+
 pub use collada::export_collada_from_meshes;
 pub use csv::{export_csv, CsvMode, CsvOptions};
 pub use dfjson::DfjsonStats;

--- a/rust/export/src/lib.rs
+++ b/rust/export/src/lib.rs
@@ -53,13 +53,7 @@ mod step_json;
 mod step_text;
 mod usd;
 
-// `step_text::escape` was `pub(crate)`, so an external integration-test
-// binary (`rust/export/tests/step_escape_parity.rs`) could not reach it: it
-// now needs `pub` visibility to be pinned against the shared vectors in
-// `tests/fixtures/step_escape_vectors.json`, the same way `csv_cell::escape_csv_cell`
-// is pinned by `tests/csv_cell_parity.rs` (issue #3300, second half). Re-export
-// just the one function, not `pub mod step_text` -- `step_text`'s other items
-// stay crate-private, so this widens the public surface by exactly one symbol.
+/// The STEP string-literal escaper; `escape`'s docs say why it is public.
 pub use step_text::escape as escape_step_string;
 
 pub use collada::export_collada_from_meshes;

--- a/rust/export/src/step_text.rs
+++ b/rust/export/src/step_text.rs
@@ -46,6 +46,15 @@ pub(crate) fn merge_edits<'a>(
 /// raw UTF-8 multi-byte sequence into mojibake or a broken parse; this exact
 /// writer shape is a reported, reproduced defect in real IFC tooling
 /// (IfcOpenShell#699/#1016; files rejected by Solibri).
+///
+/// `pub`, and re-exported from the crate root as `escape_step_string`, so the
+/// integration-test binary `tests/step_escape_parity.rs` can pin it to the
+/// shared vectors in `tests/fixtures/step_escape_vectors.json` — the same
+/// vectors the TypeScript `escapeStepString` is held to, since the two
+/// implementations cannot share code (#3300). Only this one function is
+/// re-exported, not the whole module, so the rest of `step_text` stays
+/// crate-private and the public surface widens by exactly one symbol —
+/// narrower than the `pub mod csv_cell` the CSV parity pin already relies on.
 pub fn escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {

--- a/rust/export/src/step_text.rs
+++ b/rust/export/src/step_text.rs
@@ -46,7 +46,7 @@ pub(crate) fn merge_edits<'a>(
 /// raw UTF-8 multi-byte sequence into mojibake or a broken parse; this exact
 /// writer shape is a reported, reproduced defect in real IFC tooling
 /// (IfcOpenShell#699/#1016; files rejected by Solibri).
-pub(crate) fn escape(s: &str) -> String {
+pub fn escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {

--- a/rust/export/src/step_text_tests.rs
+++ b/rust/export/src/step_text_tests.rs
@@ -38,89 +38,17 @@ fn split_top_level_args_respects_nesting() {
     assert_eq!(parts[3], "IFCBOOLEAN(.T.)");
 }
 
-/// ISO 10303-21 doubles two characters inside a string literal: the
-/// apostrophe (already handled) and the reverse solidus (the bug this
-/// pins). `escape()` is the single funnel every STEP string literal in
-/// this exporter goes through, so this test is the RED/GREEN pin for the
-/// write-side half of the doubling-escape gap.
-#[test]
-fn escape_doubles_backslash_like_apostrophe() {
-    assert_eq!(escape(r"C:\temp"), r"C:\\temp");
-    assert_eq!(escape(r"a\b\c"), r"a\\b\\c");
-}
+// The `escape()` literal-table tests that used to live here (backslash
+// doubling, apostrophe+backslash ordering, per-char control mapping, run
+// length, byte-identical plain text, non-ASCII directive encoding) are now
+// the shared vectors in `tests/fixtures/step_escape_vectors.json`, pinned by
+// `tests/step_escape_parity.rs` -- the same file the TypeScript escaper
+// (`packages/data/src/step-serializers.ts`) is pinned to via
+// `packages/data/src/step-escape.parity.test.ts` (#3300, second half). A
+// hand-kept copy of the other language's behaviour only resets the clock on
+// the drift it exists to catch (the reasoning behind the CSV-cell-escaper
+// precedent this follows: `csv_cell_vectors.json` / `csv_cell_parity.rs`).
 
-#[test]
-fn escape_doubles_both_escapes_in_the_same_string_in_source_order() {
-    // A name carrying both a literal apostrophe and a literal backslash,
-    // in each relative order, must come out with each doubled exactly
-    // where it occurred — not reordered, not merged.
-    assert_eq!(escape(r"O'Brien\Docs"), r"O''Brien\\Docs");
-    assert_eq!(escape(r"\Docs\O'Brien"), r"\\Docs\\O''Brien");
-}
-
-#[test]
-fn escape_maps_every_ascii_control_char_to_a_space() {
-    // ISO 10303-21 restricts a string literal's literal bytes to the
-    // basic graphic range 32-126; anything below that (or DEL, 127) is
-    // not a legal literal byte in the file. `escape()` already maps
-    // '\n' / '\r' / '\t' to a space; this pins that the same treatment
-    // applies to every other C0 control byte and DEL, not just those
-    // three. NUL, vertical tab (0x0B), unit separator (0x1F), and DEL
-    // (0x7F) are direct reproductions of CodeRabbit's finding on #2405.
-    for c in ['\0', '\u{0B}', '\u{1F}', '\u{7F}'] {
-        let s = format!("a{c}b");
-        assert_eq!(
-            escape(&s),
-            "a b",
-            "control char {:#04x} was not mapped to a space",
-            c as u32
-        );
-    }
-}
-
-#[test]
-fn escape_preserves_the_length_of_a_control_char_run() {
-    // The single-char cases above pass identically whether `escape` replaces
-    // per character or collapses a run, so they cannot see the difference
-    // #3284 is about, and this side's rule was never actually asserted.
-    //
-    // That mattered: the two TypeScript escapers carried `[\x00-\x1F\x7F]+`,
-    // so `"a\t\t\tb"` was written as `'a b'` there and `'a   b'` here, one
-    // nominal rule with two behaviours, and every test on both sides stayed
-    // green because none of them used a run. #3294 fixes the TypeScript half.
-    // This pins the half it is being made to agree with, so the agreement
-    // rests on a test rather than on two doc comments citing each other.
-    assert_eq!(escape("a\t\t\tb"), "a   b");
-    assert_eq!(escape("\0\0\0"), "   ");
-    // Mixed kinds in one run: still one space each, not one for the run.
-    assert_eq!(escape("a\r\n\u{0B}\u{7F}b"), "a    b");
-}
-
-#[test]
-fn escape_no_special_chars_is_byte_identical() {
-    // Bounding control: plain ASCII with no quote/backslash/control chars
-    // must pass through unchanged (no spurious allocation-visible diff).
-    for s in ["plain", "IFC4", "Pset_WallCommon", "123-abc_DEF"] {
-        assert_eq!(escape(s), s);
-    }
-}
-
-#[test]
-fn escape_encodes_non_ascii_as_x2_directive_not_raw_utf8() {
-    // ISO 10303-21 6.3.3.4 restricts a string literal's plain-text bytes to
-    // the basic graphic range 32-126 — the same clause the doc comment above
-    // `escape()` already cites for control chars. A byte outside that range
-    // must be a control directive (`\X\HH`, `\X2\HHHH\X0\`, `\X4\HHHHHHHH\X0\`),
-    // never a raw byte; buildingSMART's IFC string-encoding guidance says the
-    // same for IFC2X3/IFC4/IFC4X3. `ifc_lite_core::encode_ifc_string` already
-    // implements this correctly but was never wired into this writer, so a
-    // BMP or non-BMP character in a name/label went out as raw UTF-8 — bytes
-    // a reader that (correctly, per spec) treats the file as ISO-8859-1 turns
-    // into mojibake or a broken parse. Matches the TS-side fix in
-    // `@ifc-lite/export`'s `escapeStepString`.
-    assert_eq!(escape("Trümpler"), r"Tr\X2\00FC\X0\mpler");
-    assert_eq!(escape("😀"), r"\X4\0001F600\X0\");
-}
 /// End-to-end write-side round-trip for the ISO 10303-21 doubling escapes.
 ///
 /// ifc-lite's own reader (`ifc_lite_core::step_encoding::decode_ifc_string`

--- a/rust/export/tests/fixtures/step_escape_vectors.json
+++ b/rust/export/tests/fixtures/step_escape_vectors.json
@@ -1,0 +1,150 @@
+{
+  "//": "Shared cross-language STEP-string-escape vectors (issue #3300, second half). The TypeScript escaper (packages/data/src/step-serializers.ts, escapeStepString, via packages/data/src/step-escape.parity.test.ts) and the Rust escaper (rust/export/src/step_text.rs, escape, via rust/export/tests/step_escape_parity.rs) are BOTH pinned to this file, so the two cannot drift apart unnoticed. Before this file existed, each side pinned the OTHER side's behaviour via its own hand-written literal test table, with a comment claiming the two agreed -- exactly the arrangement issue #3300 identifies as the cause of bug #3284 (a hand-kept copy 'only resets the clock', per the CSV-cell-escaper precedent this file follows: rust/export/tests/fixtures/csv_cell_vectors.json, rust/export/tests/csv_cell_parity.rs, packages/export/src/csv-cell.parity.test.ts, scripts/check-csv-escaper-copies.mjs). This escaper takes no options, so unlike the CSV fixture a case here is only {name, input, expected}. Author cases by hand; there is no generator script for this one (the CSV fixture's swept option ranges have no equivalent here).",
+  "cases": [
+    {
+      "name": "tab run",
+      "input": "a\t\t\tb",
+      "expected": "a   b"
+    },
+    {
+      "name": "crlf",
+      "input": "a\r\nb",
+      "expected": "a  b"
+    },
+    {
+      "name": "mixed C0 and DEL",
+      "input": "a\u0000\u000b\u001f\u007fb",
+      "expected": "a    b"
+    },
+    {
+      "name": "single control char",
+      "input": "a\tb",
+      "expected": "a b"
+    },
+    {
+      "name": "quote doubling around a run",
+      "input": "O'Brien\t\tx",
+      "expected": "O''Brien  x"
+    },
+    {
+      "name": "no control chars",
+      "input": "plain text 123",
+      "expected": "plain text 123"
+    },
+    {
+      "name": "doubles a lone backslash",
+      "input": "a\\b",
+      "expected": "a\\\\b"
+    },
+    {
+      "name": "doubles a lone apostrophe",
+      "input": "a'b",
+      "expected": "a''b"
+    },
+    {
+      "name": "encodes a non-ASCII BMP character as an X2 directive",
+      "input": "Ä",
+      "expected": "\\X2\\00C4\\X0\\"
+    },
+    {
+      "name": "doubles the backslashes of text that already looks like a directive",
+      "input": "a\\X2\\00FC\\X0\\b",
+      "expected": "a\\\\X2\\\\00FC\\\\X0\\\\b"
+    },
+    {
+      "name": "empty string stays empty",
+      "input": "",
+      "expected": ""
+    },
+    {
+      "name": "rust: backslash before a path separator",
+      "input": "C:\\temp",
+      "expected": "C:\\\\temp"
+    },
+    {
+      "name": "rust: multiple backslashes in one string",
+      "input": "a\\b\\c",
+      "expected": "a\\\\b\\\\c"
+    },
+    {
+      "name": "rust: apostrophe then backslash, in that order",
+      "input": "O'Brien\\Docs",
+      "expected": "O''Brien\\\\Docs"
+    },
+    {
+      "name": "rust: backslash then apostrophe, in that order",
+      "input": "\\Docs\\O'Brien",
+      "expected": "\\\\Docs\\\\O''Brien"
+    },
+    {
+      "name": "rust control: NUL",
+      "input": "a\u0000b",
+      "expected": "a b"
+    },
+    {
+      "name": "rust control: VT 0x0B",
+      "input": "a\u000bb",
+      "expected": "a b"
+    },
+    {
+      "name": "rust control: US 0x1F",
+      "input": "a\u001fb",
+      "expected": "a b"
+    },
+    {
+      "name": "rust control: DEL 0x7F",
+      "input": "a\u007fb",
+      "expected": "a b"
+    },
+    {
+      "name": "rust: a run of three NUL bytes",
+      "input": "\u0000\u0000\u0000",
+      "expected": "   "
+    },
+    {
+      "name": "rust: a mixed-kind control run (CR LF VT DEL)",
+      "input": "a\r\n\u000b\u007fb",
+      "expected": "a    b"
+    },
+    {
+      "name": "rust plain: \"plain\"",
+      "input": "plain",
+      "expected": "plain"
+    },
+    {
+      "name": "rust plain: \"IFC4\"",
+      "input": "IFC4",
+      "expected": "IFC4"
+    },
+    {
+      "name": "rust plain: \"Pset_WallCommon\"",
+      "input": "Pset_WallCommon",
+      "expected": "Pset_WallCommon"
+    },
+    {
+      "name": "rust plain: \"123-abc_DEF\"",
+      "input": "123-abc_DEF",
+      "expected": "123-abc_DEF"
+    },
+    {
+      "name": "rust: a BMP non-ASCII character mid-string",
+      "input": "Trümpler",
+      "expected": "Tr\\X2\\00FC\\X0\\mpler"
+    },
+    {
+      "name": "rust: an astral-plane character",
+      "input": "😀",
+      "expected": "\\X4\\0001F600\\X0\\"
+    },
+    {
+      "name": "a longer control-char run (n=8) stays one space per char",
+      "input": "a\n\n\n\n\n\n\n\nb",
+      "expected": "a        b"
+    },
+    {
+      "name": "a directive-looking literal text run immediately followed by real non-ASCII",
+      "input": "\\X2\\Ä",
+      "expected": "\\\\X2\\\\\\X2\\00C4\\X0\\"
+    }
+  ]
+}

--- a/rust/export/tests/step_escape_parity.rs
+++ b/rust/export/tests/step_escape_parity.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Rust half of the STEP-string-escape cross-language parity pin (#3300,
+//! second half).
+//!
+//! Pins `ifc_lite_export::escape_step_string` (re-exported from
+//! `step_text::escape`) to the shared vectors in
+//! `tests/fixtures/step_escape_vectors.json`. The TypeScript escaper
+//! (`packages/data/src/step-serializers.ts`, `escapeStepString`, via
+//! `packages/data/src/step-escape.parity.test.ts`) is held to the SAME file,
+//! so the two cannot drift apart silently. Mirrors `csv_cell_parity.rs`,
+//! which does the same for the CSV-cell escaper.
+
+use ifc_lite_export::escape_step_string as escape;
+
+fn fixture() -> serde_json::Value {
+    let raw = include_str!("fixtures/step_escape_vectors.json");
+    serde_json::from_str(raw).expect("fixture is valid JSON")
+}
+
+#[test]
+fn rust_step_escape_matches_shared_vectors() {
+    let doc = fixture();
+    let cases = doc["cases"].as_array().expect("cases is an array");
+    assert!(
+        cases.len() > 20,
+        "an empty or near-empty vector list proves nothing; got {}",
+        cases.len()
+    );
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("<unnamed>");
+        let input = case["input"].as_str().expect("input is a string");
+        let expected = case["expected"].as_str().expect("expected is a string");
+
+        let got = escape(input);
+        assert_eq!(
+            got, expected,
+            "vector `{name}`: input {input:?} gave {got:?}, want {expected:?}"
+        );
+    }
+}

--- a/scripts/check-step-escaper-copies.mjs
+++ b/scripts/check-step-escaper-copies.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Fails the build if a STEP (ISO 10303-21) string-literal ENCODE escaper is
+ * hand-rolled anywhere outside the two canonical implementations.
+ *
+ * Issue #3300 (second half): this repo already had two TypeScript copies of
+ * the encode-side escaper (`escapeStepString`), collapsed into one in the
+ * first half of #3300 (#3378). Even after that collapse, the TWO REMAINING
+ * implementations — TypeScript `escapeStepString` and Rust `step_text::escape`
+ * — genuinely cannot share code (no wasm adapter between them), and each was
+ * pinned against the OTHER's behaviour only via its own hand-written literal
+ * test table, with a comment claiming the two agreed. That is exactly the
+ * arrangement #3300 identifies as the cause of #3284 (a control-character run
+ * collapsed to one space on one side and one space PER CHARACTER on the
+ * other, and every test on both sides stayed green because neither used a
+ * run). The two hand tables are now one shared vector fixture
+ * (`rust/export/tests/fixtures/step_escape_vectors.json`); this gate is what
+ * stops a THIRD full re-implementation of the escaper — TypeScript or Rust —
+ * from appearing next to the two canonical ones, the same way
+ * `check-csv-escaper-copies.mjs` guards the CSV-cell escaper. Unlike that
+ * gate, this repo has no known history of nine STEP-escaper copies: a search
+ * at the time this gate was written found no OTHER full implementation of
+ * this escaper's four rules (backslash doubling, apostrophe doubling,
+ * control-char-to-space, non-ASCII \X2\/\X4\ directive encoding) together in
+ * one place, so `KNOWN_REMAINING` starts empty. It is a ratchet, not a
+ * guarantee that stays true — it exists so a new one can only enter this file
+ * as a visible, reviewed exception, never as silent debt.
+ *
+ * Four rules make up the escaper; two files legitimately touch a SUBSET of
+ * them without being a copy:
+ *   - `packages/encoding/src/ifc-string.ts`'s `encodeIfcString` emits the same
+ *     `\X2\`/`\X4\` directive shape, but for a DIFFERENT byte range (it also
+ *     encodes 8-bit values as `\X\HH`, which this escaper never emits) and
+ *     WITHOUT apostrophe/backslash doubling or control-to-space mapping — a
+ *     bare backslash there becomes `\X\5C`, not `\\`. It is a different,
+ *     narrower escaper (#3300's own text says so), not a copy of this one.
+ *   - `packages/cli/src/commands/mutate.ts`, `packages/parser/src/schedule-serializer.ts`,
+ *     and `packages/create/src/ifc-creator-math.ts` each carry
+ *     `.replace(/\\/g, '\\\\').replace(/'/g, "''")` — backslash and apostrophe
+ *     doubling, the STEP quoting rule these three actually need for their own
+ *     narrow inputs (short, caller-controlled identifiers/paths). None of the
+ *     three maps a control character to a space or emits a `\X2\`/`\X4\`
+ *     directive for non-ASCII text, so none of them implements the FULL
+ *     four-rule escaper this gate exists to keep singular. They are two-ninths
+ *     of the shape, not the shape, and PATTERNS is deliberately built to need
+ *     all three signals below so it does not flag them.
+ *
+ * Three signals, ALL required in the SAME file, distinguish a full copy of
+ * this escaper from the many STEP directive DECODERS/PARSERS in this repo
+ * (which read `\X2\`/`\X4\` but never emit apostrophe+backslash doubling in
+ * the same function) and from the two narrower escapers above:
+ *
+ *   1. backslash-doubling (TS `replace(/\\/g, ...)` / Rust `'\\' => ... "\\\\"`)
+ *   2. apostrophe-doubling (TS `replace(/'/g, "''")` / Rust `'\'' => ... "''"`)
+ *   3. the `\X2\`/`\X0\` directive-emission shape (both markers, so a decoder
+ *      merely scanning for `\X2\` alone does not count)
+ *
+ * DESIGN: the scan is a raw, per-file, stateless text search — no comment or
+ * string blanking, following `check-csv-escaper-copies.mjs`'s precedent for
+ * the same reason: a classifier that decides "this text is a comment" can
+ * hide a live copy, and cannot hide a false positive in the other direction.
+ * Unlike the CSV gate (which scans per LINE, because its three single-line
+ * patterns are each individually distinctive), this gate's distinguishing
+ * signal is CO-OCCURRENCE of three patterns that a real implementation writes
+ * on separate lines (see `step_text.rs` and `step-serializers.ts` themselves),
+ * so it searches per FILE: all three regexes must match somewhere in the same
+ * file's text for a hit.
+ *
+ * Run: `node scripts/check-step-escaper-copies.mjs`
+ * Self-test: `node --test scripts/check-step-escaper-copies.test.mjs`
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join, dirname, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * The ONE implementation per language. Anything else matching all three
+ * PATTERNS is a copy. Deliberately NOT an open-ended allowlist: adding a path
+ * here is adding a third full escaper, which is the thing being prevented —
+ * the fix is to call the shared escaper instead.
+ */
+export const CANONICAL = ['packages/data/src/step-serializers.ts', 'rust/export/src/step_text.rs'];
+
+/**
+ * Files that legitimately mention all three patterns without implementing a
+ * NEW copy: the shared fixture, the parity suites, this gate plus its own
+ * test.
+ */
+export const NON_IMPLEMENTATION = [
+  'rust/export/tests/fixtures/step_escape_vectors.json',
+  'rust/export/tests/step_escape_parity.rs',
+  'packages/data/src/step-escape.parity.test.ts',
+  'scripts/check-step-escaper-copies.mjs',
+  'scripts/check-step-escaper-copies.test.mjs',
+];
+
+/**
+ * Copies that still exist and are NOT yet routed through the canonical
+ * escaper. A ratchet, like `check-csv-escaper-copies.mjs`'s: a NEW copy
+ * anywhere fails the gate (entries are matched by exact path, so this list
+ * cannot silently absorb one), and an entry whose code no longer matches all
+ * three PATTERNS ALSO fails the gate, so the list shrinks when debt is paid
+ * rather than lingering as dead config.
+ *
+ * Starts empty: the grep this gate's header describes found no OTHER file
+ * implementing all four of the escaper's rules together (see the three
+ * two-of-four files discussed above, which PATTERNS is built not to flag).
+ */
+export const KNOWN_REMAINING = [];
+
+export const PATTERNS = [
+  {
+    name: 'backslash-doubling',
+    // TS: `.replace(/\\/g, '\\\\')` (any escaping of the literal backslash
+    // inside the regex/replacement is fine — this matches the shape, not one
+    // exact spelling). Rust: a `'\\' => ...` match arm producing two
+    // backslashes.
+    re: /replace\(\s*\/\\\\\/g\s*,\s*'\\\\\\\\'\s*\)|'\\\\'\s*=>\s*[^\n]*"\\\\\\\\"/,
+    hint: 'call escapeStepString() from @ifc-lite/data, or ifc_lite_export::escape_step_string()',
+  },
+  {
+    name: 'apostrophe-doubling',
+    // TS: `.replace(/'/g, "''")`. Rust: `'\'' => out.push_str("''")` or
+    // equivalent producing a doubled apostrophe.
+    re: /replace\(\s*\/'\/g\s*,\s*"''"\s*\)|'\\''\s*=>\s*[^\n]*"''"/,
+    hint: 'call escapeStepString() from @ifc-lite/data, or ifc_lite_export::escape_step_string()',
+  },
+  {
+    name: '\\X2\\ / \\X0\\ directive emission',
+    // Both markers of the directive wrapper must appear (as literal text a
+    // template/format string would emit), not just a lone `\X2\` a decoder
+    // might scan for.
+    re: /\\\\X2\\\\[\s\S]*?\\\\X0\\\\/,
+    hint: 'call escapeStepString() from @ifc-lite/data, or ifc_lite_export::escape_step_string()',
+  },
+];
+
+/** Repository-tracked files worth scanning. */
+function candidateFiles() {
+  const out = execFileSync(
+    'git',
+    ['-C', REPO_ROOT, 'ls-files', '-z', '*.ts', '*.tsx', '*.rs', '*.mjs', '*.js'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  return out.split('\0').filter(Boolean);
+}
+
+/**
+ * Scan one file's whole text: a hit requires ALL THREE patterns to match
+ * somewhere in the file (co-occurrence, not per-line — a real implementation
+ * spreads the three rules across separate lines/match-arms).
+ */
+export function scanText(relPath, text) {
+  const normalized = relPath.split(sep).join('/');
+  const hitsPerPattern = PATTERNS.map((p) => p.re.test(text));
+  if (!hitsPerPattern.every(Boolean)) return [];
+  return [
+    {
+      file: normalized,
+      patterns: PATTERNS.map((p) => p.name),
+      hint: PATTERNS[0].hint,
+    },
+  ];
+}
+
+export function scanRepo(
+  files = candidateFiles(),
+  read = (f) => readFileSync(join(REPO_ROOT, f), 'utf8'),
+) {
+  // A tiny file list means the glob or `git ls-files` silently failed, which
+  // would make this gate pass vacuously — the one way a grep gate lies.
+  if (files.length < 100) {
+    throw new Error(
+      `refusing to pass on a suspiciously small file list (${files.length}); the scan is broken, not clean`,
+    );
+  }
+  const exempt = new Set([...CANONICAL, ...NON_IMPLEMENTATION]);
+  const hits = [];
+  for (const f of files) {
+    const normalized = f.split(sep).join('/');
+    if (exempt.has(normalized)) continue;
+    let text;
+    try {
+      text = read(f);
+    } catch {
+      continue; // deleted or unreadable in this checkout
+    }
+    hits.push(...scanText(f, text));
+  }
+
+  const known = new Set(KNOWN_REMAINING);
+  const violations = hits.filter((h) => !known.has(h.file));
+  const stillHit = new Set(hits.filter((h) => known.has(h.file)).map((h) => h.file));
+  const staleKnown = KNOWN_REMAINING.filter((k) => !stillHit.has(k));
+  return { scanned: files.length, violations, staleKnown, known: [...stillHit] };
+}
+
+function main() {
+  const { scanned, violations, staleKnown, known } = scanRepo();
+  let failed = false;
+
+  if (violations.length > 0) {
+    failed = true;
+    process.stderr.write(
+      `A hand-rolled STEP string escaper appeared in ${violations.length} place(s).\n` +
+        'There must be exactly one per language:\n' +
+        CANONICAL.map((c) => `  - ${c}\n`).join('') +
+        '\n',
+    );
+    for (const v of violations) {
+      process.stderr.write(`  ${v.file}  [${v.patterns.join(', ')}]\n      → ${v.hint}\n`);
+    }
+  }
+
+  if (staleKnown.length > 0) {
+    failed = true;
+    process.stderr.write(
+      'KNOWN_REMAINING is stale — these no longer hand-roll an escaper, so delete them\n' +
+        'from the list (it is a ratchet; it must shrink, never linger):\n' +
+        staleKnown.map((k) => `  - ${k}\n`).join(''),
+    );
+  }
+
+  if (failed) process.exit(1);
+
+  process.stdout.write(
+    `check:step-escapers — ${scanned} files scanned, no new copies` +
+      (known.length > 0 ? `; ${known.length} known outstanding: ${known.join(', ')}` : '') +
+      '.\n',
+  );
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) main();

--- a/scripts/check-step-escaper-copies.test.mjs
+++ b/scripts/check-step-escaper-copies.test.mjs
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The gate's own test. A pattern gate that does not fire is worse than no
+ * gate, because it reads as a guarantee — so each positive case below plants
+ * a synthetic escaper shaped like a real full implementation of the STEP
+ * escaper's four rules and asserts the gate catches it, paired with a
+ * negative control that is missing one of the three required signals (this
+ * repo has no known real historical THIRD copy the way the CSV gate had nine
+ * real ones, so these fixtures are synthetic, matching PATTERNS by
+ * construction).
+ *
+ * Run: `node --test scripts/check-step-escaper-copies.test.mjs`
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import * as gate from './check-step-escaper-copies.mjs';
+
+const { scanText, scanRepo, CANONICAL, KNOWN_REMAINING } = gate;
+
+/**
+ * Drive scanRepo with synthetic file contents. Real repo files not named in
+ * `overrides` read as empty; padding files satisfy the vacuous-scan guard.
+ */
+function repoWith(overrides) {
+  const pad = Array.from({ length: 120 }, (_, i) => `packages/pad/src/p${i}.ts`);
+  const files = [...new Set([...Object.keys(overrides), ...pad])];
+  return scanRepo(files, (f) => overrides[f] ?? '');
+}
+
+const TS_FULL_COPY = `
+function escapeStep(str) {
+  return str
+    .replace(/\\\\/g, '\\\\\\\\')
+    .replace(/'/g, "''")
+    .replace(/[\\x00-\\x1F\\x7F]/g, ' ')
+    .split('')
+    .map((ch) => (ch.codePointAt(0) > 126 ? \`\\\\X2\\\\\${ch.codePointAt(0).toString(16)}\\\\X0\\\\\` : ch))
+    .join('');
+}
+`;
+
+const RUST_FULL_COPY = `
+fn escape_step(s: &str) -> String {
+    let mut out = String::new();
+    for c in s.chars() {
+        match c {
+            '\\'' => out.push_str("''"),
+            '\\\\' => out.push_str("\\\\\\\\"),
+            '\\0'..='\\u{1F}' => out.push(' '),
+            _ => out.push_str(&format!("\\\\X2\\\\{:04X}\\\\X0\\\\", c as u32)),
+        }
+    }
+    out
+}
+`;
+
+test('fires on a full TypeScript copy of the escaper', () => {
+  const hits = scanText('packages/some/new-step-writer.ts', TS_FULL_COPY);
+  assert.ok(hits.length > 0, 'gate missed a full TS copy');
+  assert.equal(hits[0].file, 'packages/some/new-step-writer.ts');
+  assert.deepEqual(hits[0].patterns, [
+    'backslash-doubling',
+    'apostrophe-doubling',
+    '\\X2\\ / \\X0\\ directive emission',
+  ]);
+});
+
+test('fires on a full Rust copy of the escaper', () => {
+  const hits = scanText('rust/newcrate/src/step_write.rs', RUST_FULL_COPY);
+  assert.ok(hits.length > 0, 'gate missed a full Rust copy');
+  assert.equal(hits[0].file, 'rust/newcrate/src/step_write.rs');
+});
+
+test('the canonical implementations are exempt at repo level', () => {
+  const { violations } = repoWith({
+    [CANONICAL[0]]: TS_FULL_COPY,
+    [CANONICAL[1]]: RUST_FULL_COPY,
+  });
+  assert.deepEqual(violations, [], 'the canonical files ARE the escaper and must be allowed to contain it');
+});
+
+test('refuses to pass vacuously when the file scan returns almost nothing', () => {
+  assert.throws(
+    () => scanRepo(['a.ts'], () => ''),
+    /suspiciously small file list/,
+    'a broken scan must fail, not report clean',
+  );
+});
+
+test('the repo currently has no NEW copies, and every ratchet entry is still real', () => {
+  const { violations, staleKnown, scanned } = scanRepo();
+  assert.ok(scanned > 1000, `expected a real scan, got ${scanned} files`);
+  assert.deepEqual(violations, [], 'a new hand-rolled STEP escaper was added');
+  assert.deepEqual(
+    staleKnown,
+    [],
+    'KNOWN_REMAINING is a ratchet: an entry that no longer hand-rolls an escaper must be deleted from the list',
+  );
+});
+
+test('KNOWN_REMAINING starts empty: no known third full copy at the time this gate was written', () => {
+  assert.deepEqual(KNOWN_REMAINING, []);
+});
+
+// ---------------------------------------------------------------------------
+// Negative controls: real files in this repo that touch ONE OR TWO of the
+// three signals but not all three, and must not be flagged. Pinned by literal
+// snippet (not by reading the live file) so this test does not depend on
+// those files' current exact text, only on the SHAPE that must stay clean.
+// ---------------------------------------------------------------------------
+describe('does not fire on a partial match (missing one of the three signals)', () => {
+  test('backslash+apostrophe doubling with no directive emission (mutate.ts / schedule-serializer.ts / ifc-creator-math.ts shape)', () => {
+    const src = `
+function esc(str) {
+  return str.replace(/\\\\/g, '\\\\\\\\').replace(/'/g, "''");
+}
+`;
+    const hits = scanText('packages/some/narrow-quoter.ts', src);
+    assert.deepEqual(hits, [], 'a probe with only 2 of 3 signals must not fire the full-copy gate');
+  });
+
+  test('directive emission with no doubling (encodeIfcString / a decoder shape)', () => {
+    const src = `
+function encode(str) {
+  let out = '';
+  for (const ch of str) {
+    const cp = ch.codePointAt(0);
+    if (cp > 126) out += \`\\\\X2\\\\\${cp.toString(16)}\\\\X0\\\\\`;
+    else out += ch;
+  }
+  return out;
+}
+`;
+    const hits = scanText('packages/some/narrow-encoder.ts', src);
+    assert.deepEqual(hits, [], 'directive emission alone (no doubling) must not fire the full-copy gate');
+  });
+
+  test('a decoder that only reads \\\\X2\\\\ / \\\\X0\\\\ never fires, even with unrelated doubling elsewhere in the file', () => {
+    const src = `
+// scans for the X2 directive and decodes it back to a code point
+function decode(str) {
+  if (str.startsWith('\\\\X2\\\\')) { /* ... */ }
+  return str.replace(/''/g, "'"); // unrelated: un-doubling on the READ side
+}
+`;
+    const hits = scanText('packages/some/decoder.ts', src);
+    assert.deepEqual(hits, [], 'a decoder plus unrelated un-doubling must not fire the full-copy gate');
+  });
+
+  test('apostrophe-doubling alone (an unrelated SQL/CSV-shaped quoter) does not fire', () => {
+    const src = `function q(v) { return "'" + v.replace(/'/g, "''") + "'"; }`;
+    const hits = scanText('packages/some/sql-quote.ts', src);
+    assert.deepEqual(hits, [], 'apostrophe doubling alone is common to many quoters, not just this escaper');
+  });
+});
+
+describe('co-occurrence is per-FILE, not per-line', () => {
+  test('the three signals spread across separate lines/functions in one file still fire', () => {
+    const src = `
+function doubleBackslash(s) { return s.replace(/\\\\/g, '\\\\\\\\'); }
+function doubleQuote(s) { return s.replace(/'/g, "''"); }
+function directive(cp) { return \`\\\\X2\\\\\${cp}\\\\X0\\\\\`; }
+`;
+    const hits = scanText('packages/some/split-copy.ts', src);
+    assert.ok(hits.length > 0, 'a copy split across helpers in one file is still a copy');
+  });
+
+  test('the three signals in DIFFERENT files do not co-fire as one violation', () => {
+    const { violations } = repoWith({
+      'packages/some/a.ts': `s.replace(/\\\\/g, '\\\\\\\\');`,
+      'packages/some/b.ts': `s.replace(/'/g, "''");`,
+      'packages/some/c.ts': `\`\\\\X2\\\\\${cp}\\\\X0\\\\\`;`,
+    });
+    assert.deepEqual(violations, [], 'the three signals in three unrelated files are not one copy');
+  });
+});


### PR DESCRIPTION
The TS↔Rust half of #3300. The first half (collapsing the two TypeScript copies into one) merged as #3378; this replaces the two hand-kept literal test tables that remain.

## Why

`escapeStepString` (`packages/data/src/step-serializers.ts`) and `escape` (`rust/export/src/step_text.rs`) genuinely cannot share code — there is no wasm adapter between them. Until now each side pinned the *other* side's behaviour with its own hand-written literal table, each carrying a comment asserting the two agreed.

That is the arrangement #3284 shipped under: one nominal rule ("control characters become spaces") with two behaviours (one space per *run* on the TypeScript side, one space per *character* on the Rust side), and every test on both sides stayed green because neither table used a run.

#3300 cites the repo's own precedent for this, and that precedent's own comment is the argument: `rust/export/tests/fixtures/csv_cell_vectors.json` was written after the CSV escaper reached nine copies, and it says correcting the copies "only resets the clock."

## What changed

- **`rust/export/tests/fixtures/step_escape_vectors.json`** — the shared vectors, beside `csv_cell_vectors.json`, with a `"//"` key carrying the same kind of self-documenting rationale its siblings do.
- **`rust/export/tests/step_escape_parity.rs`** and **`packages/data/src/step-escape.parity.test.ts`** — the two consumers, mirroring `csv_cell_parity.rs` / `csv-cell.parity.test.ts`, both refusing to pass on a near-empty fixture.
- The superseded literal tables are deleted from `packages/data/src/step-serializers.test.ts` and `rust/export/src/step_text_tests.rs`, each leaving a comment pointing at the fixture. Coverage of the two public funnels (`serializeValue`, `generateHeader`) stays where it was.

### No coverage lost

The fixture carries **29 cases**: all 11 from the TypeScript table, all 17 assertions from the Rust table (the parametrised control-char and plain-text loops enumerated one case each), unioned with the single exact duplicate removed — `"a\t\t\tb"` → `"a   b"` appeared on both sides — plus two added edges: an 8-character control run, and directive-looking literal text (`\X2\`) immediately followed by a real non-ASCII character, which exercises the interaction between backslash-doubling and the later directive pass.

**No TS/Rust disagreement was found.** Every case produces byte-identical output from both implementations. Had one disagreed, it would be reported here rather than resolved by picking a side.

### Gate

`scripts/check-step-escaper-copies.mjs` mirrors `check-csv-escaper-copies.mjs` — same `CANONICAL` / `NON_IMPLEMENTATION` / `KNOWN_REMAINING` ratchet semantics, same stateless raw scan and the reasoning for it. It differs in one way, stated in its header: it matches per **file** rather than per line, because the distinguishing signal here is the *co-occurrence* of three patterns a real implementation writes on separate lines — backslash doubling, apostrophe doubling, and the `\X2\`/`\X0\` directive shape.

Requiring all three is what keeps it off the many STEP directive **decoders** in this repo (which read `\X2\` but never emit the doublings), off `encodeIfcString` (different rules, explicitly out of scope per #3300), and off `mutate.ts` / `schedule-serializer.ts` / `ifc-creator-math.ts`, which do STEP quote doubling alone. Verified empirically: both canonical files match all three signals, and each of those files matches zero. `KNOWN_REMAINING` is empty — no third full implementation exists today.

Wired in beside the CSV gate in `.github/workflows/test.yml`, with its own self-test, and exposed as `pnpm check:step-escapers`.

### One Rust visibility change

`step_text::escape` goes `pub(crate)` → `pub`, re-exported as `ifc_lite_export::escape_step_string`, so the integration-test binary can reach it. Only that one function is re-exported — not `pub mod step_text` — so the crate's public surface widens by exactly one symbol, narrower than the `pub mod csv_cell;` the CSV parity pin already relies on (whose doc comment likewise names its parity test as the reason).

## Verification

- `pnpm vitest run` in `packages/data` — **exit 0**, 21 files, 243 tests, including 30 in the new parity suite.
- `pnpm typecheck` (root) — **exit 0**.
- `node scripts/check-step-escaper-copies.mjs` — **exit 0**, 4602 files scanned.
- `node --test scripts/check-step-escaper-copies.test.mjs` — **exit 0**, 12/12.
- `node scripts/check-csv-escaper-copies.mjs` — **exit 0** (unaffected).
- `rustfmt --check` on the three touched/new Rust files individually — exit 0 each.

**`cargo test` was not run locally** (the toolchain rebuild was not affordable in this environment), so `step_escape_parity.rs` has not been compiled here. Its correctness rests on review plus a transliteration cross-check of both algorithms against all 29 vectors. CI is the real check on that file.

## Naming

#3300 asks that the parity test follow the `*.parity.test.ts` sibling convention. The file it names, `packages/export/src/step-escaper-parity.test.ts`, no longer exists — #3378 removed it when it collapsed the TypeScript copies — so there was nothing to rename. The new suite is `step-escape.parity.test.ts`, named off the fixture and inside the convention. Nothing in the repo references the old filename.

`Refs #3300` rather than `Closes`: the issue's first half shipped in #3378 and this is the second, but that is the maintainer's call to make, not this PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency between TypeScript and Rust STEP string escaping through shared cross-language validation.
  - Added coverage for control characters, quotes, backslashes, Unicode, and directive-like text.

- **Chores**
  - Added automated checks to detect unintended duplicate STEP escaper implementations.
  - Expanded CI coverage to enforce escaping parity and maintain test safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->