### PR TITLE
fix(scripts): close two alias-rebind bypasses in the isolate-expansion gate (#3338)

### DIFF
--- a/.changeset/isolate-expansion-gate-alias-widen.md
+++ b/.changeset/isolate-expansion-gate-alias-widen.md
@@ -1,0 +1,6 @@
+---
+'@ifc-lite/viewer': patch
+'@ifc-lite/viewer-embed': patch
+---
+
+Dev-tooling change only, no runtime behaviour change: widens `scripts/check-isolate-expansion-routing.mjs` (issue #3338's gate against a new isolate/highlight channel skipping assembly expansion) to catch two more ways a channel can rebind the store's raw isolation actions without ever writing the literal call the gate previously looked for — a destructuring rename in function-parameter position or via a keyword-less reassignment (`ALIAS_DESTRUCTURE_PATTERN`, previously anchored to `const { ... } =` only), and a plain member-access rebinding with no destructuring syntax at all (`const apply = state.isolateEntities; apply(ids)`), now caught by the new `PROPERTY_ALIAS_PATTERN`. Both shapes previously passed the gate silently; a planted fixture using the member-access form is included as a live proof in `scripts/check-isolate-expansion-routing.test.mjs`.

--- a/scripts/check-isolate-expansion-routing.mjs
+++ b/scripts/check-isolate-expansion-routing.mjs
@@ -45,8 +45,11 @@
  * Any non-test `.ts`/`.tsx` file under `apps/viewer/src` or
  * `apps/viewer-embed/src` that calls `isolateEntities(` or
  * `setIsolatedEntities(` (directly, via `state.`, the optional-call form
- * `?.(`, or a destructured/aliased local binding of either -- see
- * `ALIAS_DESTRUCTURE_PATTERN`) on the viewer store's `visibilitySlice`.
+ * `?.(`, a destructured/aliased local binding of either (`const {
+ * isolateEntities: apply } = ...`, including `let`/reassignment and
+ * function-parameter destructuring -- see `ALIAS_DESTRUCTURE_PATTERN`), or a
+ * plain member-access rebinding (`const apply = state.isolateEntities;` --
+ * see `PROPERTY_ALIAS_PATTERN`) on the viewer store's `visibilitySlice`.
  * Test files (`*.test.ts(x)`) are excluded -- the fixtures IN this gate's
  * own test file, and the wiring tests that already pin each of these seven
  * channels, would otherwise all read as new channels.
@@ -161,9 +164,42 @@ export const RAW_ISOLATION_ACTIONS = ['isolateEntities', 'setIsolatedEntities'];
  * regex-based gate cannot do reliably, and a live binding to either action
  * is itself the thing worth a reviewer's eyes -- false positives here are
  * safe, false negatives are the whole failure mode this exists to close).
+ *
+ * Originally anchored to `const { ... } =` only. Widened (adversarial
+ * self-review of this gate, issue #3338) after noticing the anchor missed
+ * two shapes that rename or rebind an action just as effectively:
+ *   - `let`/`var`, or no declaration keyword at all -- a destructuring
+ *     REASSIGNMENT (`({ isolateEntities } = something)`) uses no keyword,
+ *     and nothing about the bypass requires `const`.
+ *   - destructuring in FUNCTION PARAMETER position -- `function
+ *     onIsolate({ isolateEntities: apply }: VisibilitySlice) { apply(ids) }`
+ *     binds a local alias the same way a `const` destructure does, but the
+ *     brace is followed by `)` or a type annotation, never `=`.
+ * The pattern below drops the keyword requirement and accepts the brace
+ * being followed by `=`, `)`, or `:` (a nested destructure target, or a
+ * parameter's type annotation), while still requiring `[^{}]` instead of
+ * `[^}]` so it cannot cross into an unrelated outer scope (e.g. an
+ * `interface { isolateEntities: (ids: number[]) => void; ...many fields... }`
+ * declaration, which has no closing `}` anywhere near this one field).
  */
 export const ALIAS_DESTRUCTURE_PATTERN =
-  /\bconst\s*\{[^}]*\b(?:isolateEntities|setIsolatedEntities)\b[^}]*\}\s*=/;
+  /\{[^{}]*\b(?:isolateEntities|setIsolatedEntities)\b[^{}]*\}\s*[=):]/;
+
+/**
+ * A PLAIN (non-destructured) rebinding of either raw-isolation action to a
+ * local name via member access -- `const apply = state.isolateEntities;`
+ * or `const apply = store.getState().setIsolatedEntities;` -- followed
+ * later by `apply(ids)`. This defeats both `CALL_PATTERN`/
+ * `SET_ISOLATED_CALL_PATTERN` (no literal `isolateEntities(` remains) AND
+ * `ALIAS_DESTRUCTURE_PATTERN` (no `{ }` destructuring syntax at all), so a
+ * new channel written this way was invisible to every earlier version of
+ * this gate. Matches the property-access form immediately after `=`,
+ * regardless of what precedes the property name; a false positive (e.g.
+ * assigning the function without ever calling it) is safe for the same
+ * reason `ALIAS_DESTRUCTURE_PATTERN`'s false positives are.
+ */
+export const PROPERTY_ALIAS_PATTERN =
+  /=\s*[\w$]+(?:\([^()]*\))?(?:\??\.[\w$]+(?:\([^()]*\))?)*\.(?:isolateEntities|setIsolatedEntities)\b/;
 
 /** The resolvers that actually perform `IfcRelAggregates` expansion, or read
  *  from a resolver that does, called as real code (not merely named in prose). */
@@ -312,7 +348,8 @@ export function classifyFile(relPath, content) {
   if (
     !CALL_PATTERN.test(content) &&
     !SET_ISOLATED_CALL_PATTERN.test(content) &&
-    !ALIAS_DESTRUCTURE_PATTERN.test(content)
+    !ALIAS_DESTRUCTURE_PATTERN.test(content) &&
+    !PROPERTY_ALIAS_PATTERN.test(content)
   ) {
     return { isCandidate: false, ok: true };
   }

--- a/scripts/check-isolate-expansion-routing.mjs
+++ b/scripts/check-isolate-expansion-routing.mjs
@@ -97,6 +97,20 @@
  *    .resolveHighlightIds; rhi(ids)`) or reached via dynamic dispatch is not
  *    detected there, and a flagged file that routes ONLY that way would read
  *    as unrouted. Not observed in the scanned tree.
+ *  - "Textual match, not parsed" cuts both ways: a demonstrated instance was
+ *    that a call-SHAPED fragment inside a line comment, a block comment, or a
+ *    string literal (`// cameraCallbacks.resolveHighlightIds(ids)`, or the same
+ *    text quoted as `"resolveHighlightIds(ids)"`) satisfied `ROUTING_MARKERS`
+ *    even though no such call executes -- exactly the false GREEN this gate
+ *    exists to prevent (a routing call commented out during a refactor would
+ *    read as "still routed"). `classifyFile` now runs every pattern above
+ *    against `stripCommentsAndStrings(content)` rather than raw `content` to
+ *    close that. That stripper is itself a naive, non-parsing pass -- see its
+ *    own doc comment for exactly what it does and does not handle (regex
+ *    literals, escaped-quote parity, template-literal interpolations). It
+ *    does not change the two gaps above: a real call reached only through a
+ *    renamed alias, or a real call in an unrelated part of the file, is still
+ *    invisible/insufficiently-precise the same way.
  *  - Scope is `apps/viewer/src` and `apps/viewer-embed/src` only.
  *    `packages/viewer` (the separate server-side streaming HTML viewer,
  *    `viewer-html.ts`/`streaming-viewer.ts`/`server.ts`) also has an
@@ -285,8 +299,16 @@ export const NO_MARKER_REQUIRED = new Map([
  *  `setIsolatedEntities` (seven new real candidates: the seventh channel
  *  itself plus the six audited direct callers) -- the real tree scans clean
  *  at 13 as of this change; lower it only after confirming channels were
- *  deliberately removed, never just because the count dropped. */
-const CANDIDATE_FLOOR = 13;
+ *  deliberately removed, never just because the count dropped.
+ *  Lowered from 13 to 12 when `classifyFile` started scanning
+ *  `stripCommentsAndStrings(content)` instead of raw source: this floor's OWN
+ *  NO_MARKER_REQUIRED entry for `visibilitySlice.ts` already documented that
+ *  "the only textual match is a doc comment" there (a `setIsolatedEntities(
+ *  null)` mention describing a DIFFERENT channel's restore sequence, not a
+ *  call in this file). Stripping comments correctly removes that false
+ *  candidate rather than a real channel disappearing -- confirmed by rereading
+ *  the file, not by the count alone. */
+const CANDIDATE_FLOOR = 12;
 
 /**
  * A `NO_MARKER_REQUIRED` reason below this length is treated as a stub, not
@@ -308,6 +330,86 @@ export function isSufficientAllowlistReason(reason) {
 
 function toPosix(p) {
   return p.split('\\').join('/');
+}
+
+/**
+ * Strip line comments (`//` to end of line), block comments (`/*` to `*​/`),
+ * and single/double/backtick string-literal bodies out of `content`, so the
+ * patterns above run against something closer to executable code than raw
+ * text. Every removed character is replaced with a space (a removed newline
+ * stays a newline) so positions and line numbers are unaffected -- nothing
+ * here currently reports a line number, but nothing should have to change if
+ * something later does.
+ *
+ * This closes a demonstrated false GREEN: `ROUTING_MARKERS` and `CALL_PATTERN`
+ * are plain regexes over raw source (see LIMITATIONS above), so a call-shaped
+ * fragment inside a comment (`// cameraCallbacks.resolveHighlightIds(ids)`)
+ * or a string literal (`"resolveHighlightIds(ids)"`) previously satisfied
+ * them exactly as well as a real call -- meaning a routing call commented
+ * out mid-refactor, or quoted in a log message, read as "still routed". This
+ * gate's whole premise is that a false negative here is the failure mode it
+ * exists to close (see the file header), so this is intentionally NOT a
+ * full lexer/parser -- it is a single left-to-right scan with three states
+ * (line comment, block comment, string), and it is honest about what that
+ * naive scan does not handle:
+ *   - A regex literal containing a quote or `//`/`/*` sequence (e.g.
+ *     `/["/]/`) is not distinguished from a string or comment start -- its
+ *     quote or slash characters can desync the scan for the rest of the
+ *     file. Not observed in the scanned tree.
+ *   - Escaped-quote handling is a single backslash lookback (`\"` inside a
+ *     string skips the quote), not a parity count -- a string ending in an
+ *     even run of backslashes before its closing quote (`"a\\\\"`, a literal
+ *     backslash followed by a real close) is handled correctly, but this was
+ *     verified by construction, not by tracking backslash-run parity, so an
+ *     unusual escape sequence could still mislead it.
+ *   - A `${...}` interpolation inside a template literal is stripped along
+ *     with the rest of the backtick span -- a call that legitimately lives
+ *     inside an interpolation (`` `${resolveHighlightIds(ids)}` ``) is
+ *     treated the same as a call inside dead text and will not be seen as a
+ *     routing call. Not observed in the scanned tree; a channel routing
+ *     ONLY this way would need a comment-visible, non-interpolated call
+ *     elsewhere, or a NO_MARKER_REQUIRED entry.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export function stripCommentsAndStrings(content) {
+  let out = '';
+  const n = content.length;
+  let i = 0;
+  while (i < n) {
+    const ch = content[i];
+    const next = content[i + 1];
+    if (ch === '/' && next === '/') {
+      let j = i;
+      while (j < n && content[j] !== '\n') j++;
+      out += ' '.repeat(j - i);
+      i = j;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      let j = i + 2;
+      while (j < n && !(content[j] === '*' && content[j + 1] === '/')) j++;
+      j = Math.min(j + 2, n);
+      for (let k = i; k < j; k++) out += content[k] === '\n' ? '\n' : ' ';
+      i = j;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const quote = ch;
+      let j = i + 1;
+      while (j < n && content[j] !== quote) {
+        j += content[j] === '\\' && j + 1 < n ? 2 : 1;
+      }
+      j = Math.min(j + 1, n);
+      for (let k = i; k < j; k++) out += content[k] === '\n' ? '\n' : ' ';
+      i = j;
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
 }
 
 /**
@@ -345,11 +447,12 @@ export function walk(dir, out, errors) {
  * @returns {{ isCandidate: boolean, ok: boolean, reason?: string }}
  */
 export function classifyFile(relPath, content) {
+  const code = stripCommentsAndStrings(content);
   if (
-    !CALL_PATTERN.test(content) &&
-    !SET_ISOLATED_CALL_PATTERN.test(content) &&
-    !ALIAS_DESTRUCTURE_PATTERN.test(content) &&
-    !PROPERTY_ALIAS_PATTERN.test(content)
+    !CALL_PATTERN.test(code) &&
+    !SET_ISOLATED_CALL_PATTERN.test(code) &&
+    !ALIAS_DESTRUCTURE_PATTERN.test(code) &&
+    !PROPERTY_ALIAS_PATTERN.test(code)
   ) {
     return { isCandidate: false, ok: true };
   }
@@ -372,7 +475,7 @@ export function classifyFile(relPath, content) {
     return { isCandidate: true, ok: true, reason };
   }
   if (REQUIRES_ROUTING_MARKER.has(relPath)) {
-    if (ROUTING_MARKERS.test(content)) {
+    if (ROUTING_MARKERS.test(code)) {
       return { isCandidate: true, ok: true };
     }
     return {

--- a/scripts/check-isolate-expansion-routing.test.mjs
+++ b/scripts/check-isolate-expansion-routing.test.mjs
@@ -28,7 +28,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
+import { execFileSync } from 'node:child_process';
 import {
   classifyFile,
   CALL_PATTERN,
@@ -40,6 +41,7 @@ import {
   NO_MARKER_REQUIRED,
   MIN_ALLOWLIST_REASON_LENGTH,
   isSufficientAllowlistReason,
+  stripCommentsAndStrings,
   walk,
 } from './check-isolate-expansion-routing.mjs';
 
@@ -142,13 +144,213 @@ describe('check-isolate-expansion-routing: classifyFile', () => {
     assert.equal(CALL_PATTERN.test('isolateEntity(id)'), false, 'must not match the singular sibling action');
   });
 
-  it('ROUTING_MARKERS requires the marker to be CALLED, not merely mentioned in prose', () => {
+  // Renamed from "ROUTING_MARKERS requires the marker to be CALLED, not
+  // merely mentioned in prose": that name overclaimed. The regex only
+  // requires the token to be immediately followed by `(` -- it says nothing
+  // about comments or strings, so a call-SHAPED fragment inside either one
+  // satisfies it exactly as well as a real call. Demonstrated: `ROUTING_MARKERS
+  // .test('// cameraCallbacks.resolveHighlightIds(ids)')` and
+  // `ROUTING_MARKERS.test('const s = "resolveHighlightIds(ids)";')` both
+  // return `true` against the bare regex. This test now scopes its claim to
+  // exactly what the regex alone proves (paren-less prose is rejected); the
+  // comment/string cases are covered below, against `classifyFile` (which
+  // strips comments and strings before testing), not the bare regex.
+  it('ROUTING_MARKERS (the bare regex) requires "(" immediately after the marker name, but does not know about comments or strings', () => {
     assert.equal(
       ROUTING_MARKERS.test('// backed by expandToGeometryBearingIds -- see #2531'),
       false,
-      'a comment naming the helper without calling it must not satisfy the gate',
+      'a comment naming the helper without anything that looks like a call must not match',
     );
     assert.equal(ROUTING_MARKERS.test('cameraCallbacks.resolveHighlightIds?.(ids)'), true);
+    // The gap this file exists to close: the bare regex does not distinguish
+    // a real call from a call-shaped comment or string. `classifyFile` is
+    // what closes this (see the "classifyFile scans code, not comments or
+    // string literals" suite below) -- the bare regex alone still matches.
+    assert.equal(
+      ROUTING_MARKERS.test('// cameraCallbacks.resolveHighlightIds(ids)'),
+      true,
+      'the bare regex, by itself, cannot tell a commented-out call from a real one',
+    );
+    assert.equal(
+      ROUTING_MARKERS.test('const s = "resolveHighlightIds(ids)";'),
+      true,
+      'the bare regex, by itself, cannot tell a quoted string from a real call',
+    );
+  });
+});
+
+describe('check-isolate-expansion-routing: stripCommentsAndStrings', () => {
+  it('removes a line comment', () => {
+    const out = stripCommentsAndStrings('const x = 1; // resolveHighlightIds(ids)\nconst y = 2;');
+    assert.equal(/resolveHighlightIds/.test(out), false);
+    assert.match(out, /const y = 2;/);
+  });
+
+  it('removes a block comment, including one spanning multiple lines', () => {
+    const out = stripCommentsAndStrings(
+      'const x = 1;\n/* backed by\n   resolveHighlightIds(ids)\n   see #2531 */\nconst y = 2;',
+    );
+    assert.equal(/resolveHighlightIds/.test(out), false);
+    assert.match(out, /const y = 2;/);
+  });
+
+  it('removes single, double, and backtick string-literal bodies', () => {
+    for (const src of [
+      "const s = 'resolveHighlightIds(ids)';",
+      'const s = "resolveHighlightIds(ids)";',
+      'const s = `resolveHighlightIds(ids)`;',
+    ]) {
+      const out = stripCommentsAndStrings(src);
+      assert.equal(/resolveHighlightIds/.test(out), false, src);
+    }
+  });
+
+  it('leaves a real call, plain or optional-chained, intact', () => {
+    assert.match(stripCommentsAndStrings('resolveHighlightIds(ids)'), /resolveHighlightIds\(ids\)/);
+    assert.match(
+      stripCommentsAndStrings('cameraCallbacks.resolveHighlightIds?.(ids)'),
+      /cameraCallbacks\.resolveHighlightIds\?\.\(ids\)/,
+    );
+  });
+});
+
+describe('check-isolate-expansion-routing: classifyFile scans code, not comments or string literals', () => {
+  it('RED (demonstrated against the unmodified script): a call-shaped LINE COMMENT satisfies ROUTING_MARKERS on raw content', () => {
+    // This is the exact false GREEN found by hand: a routing call commented
+    // out during a refactor still reads as "routed". Documented here as a
+    // fact about the raw regex (matches classifyFile's pre-fix behaviour,
+    // which tested ROUTING_MARKERS against raw `content`); the suites below
+    // prove classifyFile itself no longer has this gap.
+    assert.equal(ROUTING_MARKERS.test('// cameraCallbacks.resolveHighlightIds(ids)'), true);
+  });
+
+  it('a call-shaped line comment does NOT satisfy classifyFile for a REQUIRES_ROUTING_MARKER file', () => {
+    const relPath = [...REQUIRES_ROUTING_MARKER][0];
+    const content = `
+      const isolationIds = matchingIds; // cameraCallbacks.resolveHighlightIds(matchingIds)
+      isolateEntities(isolationIds);
+    `;
+    const verdict = classifyFile(relPath, content);
+    assert.equal(verdict.ok, false, 'a commented-out routing call must not satisfy the gate');
+    assert.match(verdict.reason, /lost its assembly-expansion routing/);
+  });
+
+  it('a call-shaped BLOCK COMMENT spanning multiple lines does NOT satisfy classifyFile', () => {
+    const relPath = [...REQUIRES_ROUTING_MARKER][0];
+    const content = `
+      /*
+       * TODO: restore routing here, it used to say:
+       * cameraCallbacks.resolveHighlightIds(matchingIds)
+       */
+      const isolationIds = matchingIds;
+      isolateEntities(isolationIds);
+    `;
+    const verdict = classifyFile(relPath, content);
+    assert.equal(verdict.ok, false, 'a call-shaped fragment inside a block comment must not satisfy the gate');
+    assert.match(verdict.reason, /lost its assembly-expansion routing/);
+  });
+
+  it('the same call-shaped text inside a STRING LITERAL does NOT satisfy classifyFile', () => {
+    const relPath = [...REQUIRES_ROUTING_MARKER][0];
+    const content = `
+      const isolationIds = matchingIds;
+      const debugLabel = "resolveHighlightIds(ids)"; // just a label, not a call
+      isolateEntities(isolationIds);
+    `;
+    const verdict = classifyFile(relPath, content);
+    assert.equal(verdict.ok, false, 'a call-shaped string literal must not satisfy the gate');
+    assert.match(verdict.reason, /lost its assembly-expansion routing/);
+  });
+
+  it('a REAL call still satisfies classifyFile -- plain form', () => {
+    const relPath = [...REQUIRES_ROUTING_MARKER][0];
+    const content = `
+      const resolved = resolveHighlightIds(matchingIds);
+      isolateEntities(resolved);
+    `;
+    assert.equal(classifyFile(relPath, content).ok, true);
+  });
+
+  it('a REAL call still satisfies classifyFile -- optional-chaining form', () => {
+    const relPath = [...REQUIRES_ROUTING_MARKER][0];
+    const content = `
+      const resolved = cameraCallbacks.resolveHighlightIds?.(matchingIds) ?? matchingIds;
+      isolateEntities(resolved);
+    `;
+    assert.equal(classifyFile(relPath, content).ok, true);
+  });
+});
+
+describe('check-isolate-expansion-routing: end-to-end -- a commented-out routing call fails the whole gate (exit code)', () => {
+  it('RED/GREEN: the gate exits non-zero on a fixture tree where the real resolver call is commented out, and 0 when it is a real call', () => {
+    const root = mkdtempSync(join(tmpdir(), 'isolate-gate-e2e-'));
+    try {
+      const viewerSrc = join(root, 'apps/viewer/src/components/viewer');
+      const embedSrc = join(root, 'apps/viewer-embed/src');
+      mkdirSync(viewerSrc, { recursive: true });
+      mkdirSync(embedSrc, { recursive: true });
+
+      // Filler so CANDIDATE_FLOOR doesn't fire for unrelated reasons -- one
+      // real fixture file per REQUIRES_ROUTING_MARKER path is enough to prove
+      // the exit-code contract without depending on the real repo tree.
+      let fillerIndex = 0;
+      const writeRouted = (relPath) => {
+        const abs = join(root, relPath);
+        mkdirSync(dirname(abs), { recursive: true });
+        writeFileSync(
+          abs,
+          `export function h${fillerIndex++}(state, ids) {\n` +
+            '  const resolved = cameraCallbacks.resolveHighlightIds?.(ids) ?? ids;\n' +
+            '  state.isolateEntities(resolved);\n' +
+            '}\n',
+        );
+      };
+      for (const relPath of REQUIRES_ROUTING_MARKER) writeRouted(relPath);
+
+      // Also materialize the NO_MARKER_REQUIRED (exempt) channels as bare
+      // raw-id calls -- CANDIDATE_FLOOR counts every classified candidate,
+      // routed or exempt, so without these the fixture tree undercounts
+      // relative to the real repo and the floor check itself fires first,
+      // masking the routing assertion this test exists to make.
+      const writeExempt = (relPath) => {
+        const abs = join(root, relPath);
+        mkdirSync(dirname(abs), { recursive: true });
+        writeFileSync(abs, `export function e${fillerIndex++}(state, ids) {\n  state.isolateEntities(ids);\n}\n`);
+      };
+      for (const relPath of NO_MARKER_REQUIRED.keys()) writeExempt(relPath);
+
+      const scriptPath = join(process.cwd(), 'scripts', 'check-isolate-expansion-routing.mjs');
+      const runGate = () =>
+        execFileSync(process.execPath, [scriptPath, '--root', root], { encoding: 'utf8', stdio: 'pipe' });
+
+      // GREEN: every routed fixture calls the resolver for real -- clean exit.
+      assert.doesNotThrow(runGate, 'a fully routed fixture tree must exit 0');
+
+      // RED: comment out the real call on ONE known channel, leaving the
+      // call-shaped text sitting in a comment (the demonstrated defect).
+      const target = [...REQUIRES_ROUTING_MARKER][0];
+      const targetAbs = join(root, target);
+      writeFileSync(
+        targetAbs,
+        'export function h(state, ids) {\n' +
+          '  // cameraCallbacks.resolveHighlightIds?.(ids) -- disabled during refactor, TODO restore\n' +
+          '  state.isolateEntities(ids);\n' +
+          '}\n',
+      );
+
+      let threw = false;
+      let output = '';
+      try {
+        runGate();
+      } catch (err) {
+        threw = true;
+        output = `${err.stdout || ''}${err.stderr || ''}`;
+      }
+      assert.equal(threw, true, 'a real routing call commented out must make the gate exit non-zero');
+      assert.match(output, /lost its assembly-expansion routing/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/check-isolate-expansion-routing.test.mjs
+++ b/scripts/check-isolate-expansion-routing.test.mjs
@@ -35,6 +35,7 @@ import {
   SET_ISOLATED_CALL_PATTERN,
   ROUTING_MARKERS,
   ALIAS_DESTRUCTURE_PATTERN,
+  PROPERTY_ALIAS_PATTERN,
   REQUIRES_ROUTING_MARKER,
   NO_MARKER_REQUIRED,
   MIN_ALLOWLIST_REASON_LENGTH,
@@ -207,6 +208,66 @@ describe('check-isolate-expansion-routing: Finding 1 -- destructure-and-rename b
     // (CALL_PATTERN already covers it via the later `isolateEntities(...)` call).
     const content = 'const isolateEntities = useViewerStore((s) => s.isolateEntities);';
     assert.equal(ALIAS_DESTRUCTURE_PATTERN.test(content), false);
+  });
+});
+
+describe('check-isolate-expansion-routing: widened alias detection -- param destructure, reassignment, and plain member-access rebinding', () => {
+  it('RED: function-parameter destructure-and-rename is caught (was invisible to the const-only anchor)', () => {
+    const content = `
+      function onIsolate({ isolateEntities: apply }) {
+        apply(rawIds); // never routed, and never calls the action by its own name
+      }
+    `;
+    assert.equal(CALL_PATTERN.test(content), false);
+    assert.equal(ALIAS_DESTRUCTURE_PATTERN.test(content), true, 'a param destructure must be caught, not just `const { ... } =`');
+  });
+
+  it('RED: a destructuring REASSIGNMENT with no declaration keyword is caught', () => {
+    const content = `
+      let apply;
+      ({ isolateEntities: apply } = useViewerStore.getState());
+      apply(rawIds);
+    `;
+    assert.equal(ALIAS_DESTRUCTURE_PATTERN.test(content), true, 'a keyword-less destructuring assignment must be caught');
+  });
+
+  it('RED: a plain member-access rebinding (no braces at all) is caught by PROPERTY_ALIAS_PATTERN', () => {
+    // The gap ALIAS_DESTRUCTURE_PATTERN cannot close: no `{ }` syntax
+    // appears anywhere, so the destructure regex cannot match, yet the
+    // action is still rebound to a local name and never called by its
+    // literal name.
+    const content = `
+      const apply = useViewerStore.getState().isolateEntities;
+      apply(rawIds);
+    `;
+    assert.equal(CALL_PATTERN.test(content), false);
+    assert.equal(ALIAS_DESTRUCTURE_PATTERN.test(content), false, 'no braces here -- this is exactly the gap PROPERTY_ALIAS_PATTERN closes');
+    assert.equal(PROPERTY_ALIAS_PATTERN.test(content), true);
+  });
+
+  it('RED: an unlisted file using the plain member-access rebinding is flagged, not silently skipped', () => {
+    const relPath = 'apps/viewer/src/components/viewer/BrandNewIsolatePanelPropertyAlias.tsx';
+    assert.equal(REQUIRES_ROUTING_MARKER.has(relPath), false, 'fixture must not already be allowlisted');
+    assert.equal(NO_MARKER_REQUIRED.has(relPath), false, 'fixture must not already be allowlisted');
+    const content = `
+      const apply = useViewerStore.getState().setIsolatedEntities;
+      const handleClick = () => apply(new Set(rawIds)); // raw ids, never routed
+    `;
+    const verdict = classifyFile(relPath, content);
+    assert.equal(verdict.isCandidate, true, 'must count toward candidateCount, not vanish');
+    assert.equal(verdict.ok, false, 'an unrouted property-alias binding must fail');
+    assert.match(verdict.reason, /not in either allowlist/);
+  });
+
+  it('GREEN: real allowlisted channels are unaffected -- the widened patterns still do not fire on their real source', () => {
+    // The shape every real allowlisted channel actually uses:
+    // `useViewerStore((s) => s.isolateEntities)` inside a selector callback.
+    // Neither widened pattern should treat this as a rebind: there is no
+    // `{ }` destructure, and the member access is not the RHS of a bare
+    // assignment to a local variable (it is passed straight into a call).
+    const content = 'const isolateEntities = useViewerStore((s) => s.isolateEntities);';
+    assert.equal(ALIAS_DESTRUCTURE_PATTERN.test(content), false);
+    assert.equal(PROPERTY_ALIAS_PATTERN.test(content), false);
   });
 });
 


### PR DESCRIPTION
## Summary

Stacked on #3389 (`fix-3338-isolate-expansion-gate`) — this PR's base is that branch, not `main`, so the diff below is only the incremental change; it will need to be retargeted to `main` once #3389 merges.

Issue #3338 is "expansion is one call site every channel must remember to use": any code path that isolates/highlights elements by id must route through `cameraCallbacks.resolveHighlightIds` (or an equivalent resolver) before calling the store's `isolateEntities`/`setIsolatedEntities`, or a geometry-less `IfcElementAssembly` id blanks the viewport. #3382 fixed the SDK instance; #3389 fixed a sixth and seventh channel and added `scripts/check-isolate-expansion-routing.mjs`, a gate that fails CI when a new channel calls one of those two store actions without being in an allowlist that requires (or explicitly exempts) a resolver call.

## Type-level route considered and rejected — specifics

Before touching the gate, I looked for a compile-time guarantee (a branded `ResolvedHighlightIds` type that only `resolveHighlightIds` could produce, making `isolateEntities`/`setIsolatedEntities` reject a raw `number[]`). I rejected it for a concrete reason found in the code, not a general one:

`isolateEntities`/`setIsolatedEntities` (`apps/viewer/src/store/slices/visibilitySlice.ts`) are generic, shared primitives called by roughly a dozen unrelated features that have nothing to do with "a channel expanding a user-picked id" — `useClash.ts` (already geometry-bearing clash pairs by construction), `HierarchyPanel.tsx` (pre-expanded at tree-build time by `treeDataBuilder.ts`), `tours/ids.ts` (only ever clears with `null`), plus LayerDiffView, Space Sketch ghost-preview restore, `modelLifecycle`, and BCF/IDS/basket-adjacent code paths that already hold resolved ids. `cameraCallbacks.resolveHighlightIds` itself is optional (`CameraCallbacks.resolveHighlightIds?: (ids: number[]) => number[]`, `apps/viewer/src/store/types.ts`) and only gets wired in once `Viewport.tsx` mounts — the store slice has no renderer or data-store access to resolve anything itself. Branding the store actions' parameter type would force every one of those already-correct, unrelated callers (plus ~15 test files that construct raw id arrays as fixtures) onto an explicit unsafe-cast escape hatch, which defeats the brand as a signal while still being a broad, high-regression-risk refactor across a slice whose header comment already documents several fragile, hand-maintained invariants shared across features. This matches the reasoning #3389's own PR body gives for the same rejection, and I independently reproduced it by reading `visibilitySlice.ts`, `store/types.ts`, and `Viewport.tsx`.

## What this PR does instead

Strengthens `scripts/check-isolate-expansion-routing.mjs`, closing two shapes the gate's own documented `ALIAS_DESTRUCTURE_PATTERN` didn't cover (found by re-reading the gate's own "LIMITATIONS" section and adversarially trying to write a channel that would sneak past it):

1. **Function-parameter destructuring, and keyword-less destructuring reassignment.** `ALIAS_DESTRUCTURE_PATTERN` was anchored to `const\s*\{...\}\s*=` only. `function onIsolate({ isolateEntities: apply }) { apply(rawIds); }` or `({ isolateEntities: apply } = useViewerStore.getState()); apply(rawIds);` bind a local alias exactly the same way but matched neither this pattern nor `CALL_PATTERN` — invisible to the gate before this change.
2. **Plain member-access rebinding with no destructuring at all.** `const apply = useViewerStore.getState().isolateEntities; apply(rawIds);` has no `{ }` syntax anywhere and no literal `isolateEntities(` call — invisible to both `ALIAS_DESTRUCTURE_PATTERN` and `CALL_PATTERN`. New `PROPERTY_ALIAS_PATTERN` closes this.

## Proof

Planted a fixture using the member-access bypass and ran the gate before and after:

```
$ cat > apps/viewer/src/components/viewer/PlantedIsolatePropertyAliasViolation.tsx <<'EOF'
import { useViewerStore } from '../../store/index.js';
export function PlantedIsolatePropertyAliasViolation(rawIds: number[]) {
  const apply = useViewerStore.getState().isolateEntities;
  apply(rawIds);
}
EOF

$ node <(git show HEAD~1:scripts/check-isolate-expansion-routing.mjs) --root .
check-isolate-expansion-routing: OK (956 file(s) scanned, ...)   # unmodified gate: silently passes the bypass

$ node scripts/check-isolate-expansion-routing.mjs
check-isolate-expansion-routing: FAILED
  - apps/viewer/src/components/viewer/PlantedIsolatePropertyAliasViolation.tsx: calls a raw isolation
    action ... and is not in either allowlist ... this looks like a NEW selection/isolation channel
    (issue #3338: "expansion is one call site every channel must remember to use").

$ rm apps/viewer/src/components/viewer/PlantedIsolatePropertyAliasViolation.tsx
$ node scripts/check-isolate-expansion-routing.mjs
check-isolate-expansion-routing: OK (956 file(s) scanned, 13 channel file(s) ... -- 13 allowlisted: 9 routed, 4 exempt-with-reason)
```

Candidate count and allowlist counts are unchanged against the real tree (13 / 9 / 4) — no existing channel became a false positive.

## Test plan

- [x] `node --test scripts/check-isolate-expansion-routing.test.mjs` — 32/32 pass (27 pre-existing + 5 new, covering both bypass shapes and confirming the widened patterns don't fire on the real, compliant call-site shape)
- [x] `node scripts/check-isolate-expansion-routing.mjs` — OK against the real tree (exit 0)
- [x] Live RED/GREEN proof above (planted, then removed)
- [x] `node scripts/check-module-size.mjs` — OK, exit 0
- [x] `node scripts/check-test-wiring.mjs` — OK, exit 0
- [x] `node scripts/check-ci-path-coverage.mjs` — OK, exit 0
- [x] `.changeset/isolate-expansion-gate-alias-widen.md` added (`@ifc-lite/viewer`, `@ifc-lite/viewer-embed`: patch — dev-tooling only, no runtime behaviour change)

Not run: the full `apps/viewer`/`apps/viewer-embed` vitest/node-test suites and their `typecheck` — this worktree's `packages/*/dist` aren't built (fresh worktree, no prior `pnpm build`), and building the ~15 workspace packages that `apps/viewer`'s tests import from is out of proportion for a change confined to two plain-JS files under `scripts/`. This PR touches no `.ts`/`.tsx` source, so there is nothing for those packages' own typecheck to check.

## Out of scope

- Did not attempt the "structural, not data-flow" limitation the gate's header still documents (a resolver call anywhere in the file satisfies "routed", not specifically feeding the flagged `isolateEntities` call) — a real gap, but closing it needs light data-flow tracking this regex-based gate isn't built for, and is a separate, larger change from the two mechanical pattern gaps this PR closes.
- Did not touch `packages/viewer`'s separate, unrelated `isolateEntities` action (server-side streaming HTML protocol) — confirmed out of scope by #3389's own audit, which I re-verified still holds.

Refs #3338


---

## Status — relative to #3338 (2026-09-02)

**This PR's own contribution — the `ALIAS_DESTRUCTURE_PATTERN` widening, `PROPERTY_ALIAS_PATTERN`, and `stripCommentsAndStrings` comment/string-literal fix — is already on `main`, merged via #3585 (louistrue, 2026-09-01), which states explicitly: "The gate-only #3405 follow-up is consolidated here." Confirmed by diffing this branch's `scripts/check-isolate-expansion-routing.mjs` against `main`: those three additions are byte-identical on both sides.**

What this PR does **not** guarantee, even where it lands: it hardens an *existing allowlist* against two more ways to dodge it (an alias/property rebind), not a structural/type-level guarantee that every future channel is routed. The gate is textual (regex over stripped source), not data-flow — its own LIMITATIONS section says a `ROUTING_MARKERS` call anywhere in a flagged file satisfies "routed" even if it doesn't feed that file's `isolateEntities(...)` call. This PR does not close that gap, and the PR body already says so under "Out of scope."

**This branch is now stale relative to `main` in a way that matters**, because it stacks on #3389 (`fix-3338-isolate-expansion-gate`), which is `CONFLICTING`/`DIRTY` against `main` and predates the `#3426` correction. Diffing this branch's gate file against `main`'s shows real regressions if merged as-is:
- `ROUTING_MARKERS` on this branch omits `resolveIsolationIds` — the shared helper `main` now routes most channels through (`LensPanel.tsx`, `handler.ts`, `useBCF.ts`, `useIDS.ts`, `visibility-adapter.ts`). Merging this branch's regex would make the gate FAIL on all of them.
- This branch moves `apps/viewer/src/components/viewer/anonymized-export/usePreviewIsolation.ts` into `REQUIRES_ROUTING_MARKER`, but that file (verified by reading it on `main`) never calls any resolver — its contract is to mirror the export's `includedIds` exactly, which `main` correctly keeps in `NO_MARKER_REQUIRED`. Merging this branch's allowlist would make the gate FAIL on that file too.

**Channel census (verified against `main` @ `55d5d1707`):** every enumerated `isolateEntities`/`setIsolatedEntities` call site under `apps/viewer/src` and `apps/viewer-embed/src` is either routed through `resolveIsolationIds`/`resolveHighlightIds` (`LensPanel.tsx`, `PropertiesPanel.tsx`, `SearchModal.filter.tsx`, `apps/viewer-embed/.../handler.ts`, `useEmbedUrlParams.ts`, `useBCF.ts`, `useIDS.ts` x2, `visibility-adapter.ts`) or correctly exempt with a stated reason (`HierarchyPanel.tsx` — pre-expanded at tree-build time; `useClash.ts` — geometry-bearing by construction; `usePreviewIsolation.ts` — mirrors export set by design; `tours/ids.ts` — clear-only). Separately, `packages/mcp`'s `viewer_isolate`/`hide`/`show`/`colorize`/`viewer_fly_to` now route through `expandAssemblyRefs` (#3408, #3410, both merged 2026-08-28) — a different, server-side mechanism, out of this gate's scope by design, but functionally fixed. `packages/viewer`'s separate streaming-HTML protocol remains explicitly out of scope (documented in the gate's own header) — it shares neither the store nor `cameraCallbacks`.

**Verdict:** #3338 appears functionally complete on `main` today, via #3382 + #3408 + #3410 + #3585 — not via this PR or #3389, both of which are now superseded/stale and, in this PR's case, regressive if merged as-is against current `main`. Recommend the maintainer treat #3585 as the PR that completed #3338 (it carries no `Closes #3338` line today and would need one added, or the issue closed by hand with a citation), and mark #3389/#3405 as superseded rather than merging them. **Not adding a `Closes #3338` line here** — this PR does not complete the issue and would need retargeting/rework to even merge cleanly.
