### PR TITLE
fix(renderer): gate CameraAnimator's inertia loop on whether CameraControls applied (#2934)

### DIFF
--- a/.changeset/camera-animator-inertia-mode-flip.md
+++ b/.changeset/camera-animator-inertia-mode-flip.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/renderer': patch
+---
+
+Fix `CameraAnimator`'s inertia loop half-applying a decaying orbit/pan/zoom gesture once `interactionMode` restricts it mid-decay.
+
+`Camera.orbit`/`pan`/`zoom` already gate `resetPresetTracking()` and inertia-queueing on whether the underlying `CameraControls` call applied (a rejected gesture, e.g. under an embed `?controls=none`, must not half-apply). But `CameraAnimator.update()`'s own inertia loop calls the same `CameraControls` methods directly on every decay tick and discarded the boolean result, so it bypassed the gate a second time, one level down. The bug was invisible when a gesture was refused from the start (no velocity is ever queued), and only showed up when `interactionMode` flipped to a restricting value *while inertia from an already-applied gesture was still decaying*: every remaining tick still reset ViewCube preset-view tracking and reported `isAnimating: true`, keeping the render loop alive around a camera that was supposed to be frozen.
+
+Each of the three inertia blocks now only runs its side effects when `CameraControls.orbit`/`pan`/`zoom` reports it applied. On refusal, that channel's velocity is also zeroed instead of left to decay — otherwise it would survive the frozen ticks and get spent in one jump the moment `interactionMode` is lifted back to `'all'`, even though the gesture that produced it was already rejected while frozen.

--- a/packages/renderer/src/camera-animation.ts
+++ b/packages/renderer/src/camera-animation.ts
@@ -66,14 +66,10 @@ export class CameraAnimator {
 
   // --- Velocity management (called by Camera class) ---
 
-  // Every one of these accumulates **in place**, and the inertia loop spends a
-  // velocity only while `Math.abs(v) > minVelocity` — false for NaN. So a
-  // single non-finite gesture argument does not cost one frame of inertia: it
-  // latches the channel dead for the rest of the session, and the value never
-  // decays back under the threshold either. That is the same latch
-  // `moveFirstPerson`'s `walkVelocity` had (#2441), reached from the argument
-  // side rather than the pose side (#2473). Skip the contribution instead;
-  // the gesture itself has already been rejected by the same test downstream.
+  // Each accumulates **in place**; the inertia loop spends a velocity only
+  // while `Math.abs(v) > minVelocity` — false for NaN forever, so one
+  // non-finite delta latches the channel dead for the session instead of one
+  // frame (same latch as `moveFirstPerson`'s `walkVelocity`, #2441/#2473).
 
   addOrbitVelocity(deltaX: number, deltaY: number): void {
     if (!areFiniteNumbers(deltaX, deltaY)) return;
@@ -124,12 +120,9 @@ export class CameraAnimator {
         this.state.camera.target.y = this.animationStartTarget.y + (this.animationEndTarget.y - this.animationStartTarget.y) * t;
         this.state.camera.target.z = this.animationStartTarget.z + (this.animationEndTarget.z - this.animationStartTarget.z) * t;
 
-        // Interpolate orthoSize if animating orthographic zoom.
-        // The animator is the second writer that bypasses `Camera.setOrthoSize`
-        // (#2461): the read-site backstop in `updateCameraMatrices` keeps the
-        // projection matrix finite but not the state, and `getOrthoSize()`
-        // reads the state — which is what a saved viewpoint persists. Keep the
-        // previous half-height when the interpolation yields nothing usable.
+        // Interpolate orthoSize if animating orthographic zoom. Bypasses
+        // `Camera.setOrthoSize` (#2461), so keep the previous half-height
+        // rather than a NaN one when the interpolation yields nothing usable.
         if (this.animationStartOrthoSize !== null && this.animationEndOrthoSize !== null) {
           const next = usableOrthoSize(
             this.animationStartOrthoSize + (this.animationEndOrthoSize - this.animationStartOrthoSize) * t,
@@ -191,26 +184,40 @@ export class CameraAnimator {
       }
     }
 
-    // Apply inertia
+    // Apply inertia, gated like `Camera`'s own wrappers (#2934 review): a
+    // refused tick (`interactionMode` can flip mid-decay) skips the side
+    // effects and zeroes that channel's velocity instead of letting it decay,
+    // so it can't survive frozen ticks and jump once the mode lifts back.
     if (Math.abs(this.velocity.orbit.x) > this.minVelocity || Math.abs(this.velocity.orbit.y) > this.minVelocity) {
-      this.resetPresetTracking();
-      this.controls.orbit(this.velocity.orbit.x * 100, this.velocity.orbit.y * 100);
-      this.velocity.orbit.x *= this.damping;
-      this.velocity.orbit.y *= this.damping;
-      isAnimating = true;
+      if (this.controls.orbit(this.velocity.orbit.x * 100, this.velocity.orbit.y * 100)) {
+        this.resetPresetTracking();
+        this.velocity.orbit.x *= this.damping;
+        this.velocity.orbit.y *= this.damping;
+        isAnimating = true;
+      } else {
+        this.velocity.orbit.x = 0;
+        this.velocity.orbit.y = 0;
+      }
     }
 
     if (Math.abs(this.velocity.pan.x) > this.minVelocity || Math.abs(this.velocity.pan.y) > this.minVelocity) {
-      this.controls.pan(this.velocity.pan.x * 1000, this.velocity.pan.y * 1000);
-      this.velocity.pan.x *= this.damping;
-      this.velocity.pan.y *= this.damping;
-      isAnimating = true;
+      if (this.controls.pan(this.velocity.pan.x * 1000, this.velocity.pan.y * 1000)) {
+        this.velocity.pan.x *= this.damping;
+        this.velocity.pan.y *= this.damping;
+        isAnimating = true;
+      } else {
+        this.velocity.pan.x = 0;
+        this.velocity.pan.y = 0;
+      }
     }
 
     if (Math.abs(this.velocity.zoom) > this.minVelocity) {
-      this.controls.zoom(this.velocity.zoom * 1000);
-      this.velocity.zoom *= this.damping;
-      isAnimating = true;
+      if (this.controls.zoom(this.velocity.zoom * 1000)) {
+        this.velocity.zoom *= this.damping;
+        isAnimating = true;
+      } else {
+        this.velocity.zoom = 0;
+      }
     }
 
     return isAnimating;

--- a/packages/renderer/src/camera-animator-inertia-mode-flip.test.ts
+++ b/packages/renderer/src/camera-animator-inertia-mode-flip.test.ts
@@ -38,7 +38,6 @@ import assert from 'node:assert';
 
 import { Camera } from './camera.js';
 import type { Vec3 } from './types.js';
-import type { FramingBounds } from './camera-framing.js';
 
 function poseOf(camera: Camera): { position: Vec3; target: Vec3; up: Vec3 } {
   return { position: camera.getPosition(), target: camera.getTarget(), up: camera.getUp() };
@@ -50,32 +49,6 @@ function freshCamera(): Camera {
   camera.setPosition(20, 20, 20);
   camera.setTarget(0, 0, 0);
   return camera;
-}
-
-const PRESET_BOUNDS: FramingBounds = { min: { x: -5, y: -5, z: -5 }, max: { x: 5, y: 5, z: 5 } };
-
-/** Runs a preset transition to completion so its end pose is directly readable. */
-function finishPreset(camera: Camera, view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right'): void {
-  const originalNow = Date.now;
-  const hadRaf = Object.prototype.hasOwnProperty.call(globalThis, 'requestAnimationFrame');
-  const originalRaf = Reflect.get(globalThis, 'requestAnimationFrame');
-  let now = 1_000;
-
-  Date.now = () => now;
-  Reflect.set(globalThis, 'requestAnimationFrame', () => 0);
-
-  try {
-    camera.setPresetView(view, PRESET_BOUNDS);
-    now += 400;
-    camera.update(0);
-  } finally {
-    Date.now = originalNow;
-    if (hadRaf) {
-      Reflect.set(globalThis, 'requestAnimationFrame', originalRaf);
-    } else {
-      Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
-    }
-  }
 }
 
 describe('CameraAnimator inertia loop gates on CameraControls applying, mid-decay (#2934)', () => {

--- a/packages/renderer/src/camera-animator-inertia-mode-flip.test.ts
+++ b/packages/renderer/src/camera-animator-inertia-mode-flip.test.ts
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `Camera.orbit`/`pan`/`zoom` already gate `resetPresetTracking()` and
+ * inertia-queueing on whether `CameraControls.orbit`/`pan`/`zoom` applied
+ * (see `camera-interaction-gate-side-effects.test.ts`, #2934 review). But
+ * `CameraAnimator.update()`'s own inertia loop calls the same
+ * `CameraControls` methods directly, on every tick of the decay, and
+ * discards their boolean result -- so it bypasses the gate a second time,
+ * one level down.
+ *
+ * That bypass is invisible when a gesture is refused from the start (no
+ * velocity is ever queued, so the inertia loop's `Math.abs(velocity) >
+ * minVelocity` guard never even opens the block). It only shows up
+ * mid-decay: a gesture applies while `interactionMode` is `'all'` (queuing
+ * real velocity), then `interactionMode` flips to a restricting value
+ * *while inertia is still decaying* -- an embed host can do this at any
+ * time via a live `?controls=`/`SET_CAMERA`-style config update. On every
+ * tick after that, `CameraControls.orbit`/`pan`/`zoom` correctly refuses to
+ * move the pose, but the inertia loop still (a) resets ViewCube preset
+ * tracking on a refused orbit tick, and (b) reports `isAnimating: true`
+ * unconditionally, keeping the render loop alive around a camera that is
+ * frozen.
+ *
+ * The fix mirrors `Camera`'s own gate one level down: each of the three
+ * inertia blocks only runs `resetPresetTracking()`/sets `isAnimating` when
+ * the underlying `CameraControls` call reports it applied. On refusal, the
+ * refused channel's velocity is also zeroed (not just left to decay) --
+ * otherwise the queued velocity survives the frozen ticks and gets spent in
+ * one jump the moment `interactionMode` is lifted back to `'all'`, even
+ * though the gesture that produced it was already rejected while frozen.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { Camera } from './camera.js';
+import type { Vec3 } from './types.js';
+import type { FramingBounds } from './camera-framing.js';
+
+function poseOf(camera: Camera): { position: Vec3; target: Vec3; up: Vec3 } {
+  return { position: camera.getPosition(), target: camera.getTarget(), up: camera.getUp() };
+}
+
+function freshCamera(): Camera {
+  const camera = new Camera();
+  camera.setAspect(16 / 9);
+  camera.setPosition(20, 20, 20);
+  camera.setTarget(0, 0, 0);
+  return camera;
+}
+
+const PRESET_BOUNDS: FramingBounds = { min: { x: -5, y: -5, z: -5 }, max: { x: 5, y: 5, z: 5 } };
+
+/** Runs a preset transition to completion so its end pose is directly readable. */
+function finishPreset(camera: Camera, view: 'top' | 'bottom' | 'front' | 'back' | 'left' | 'right'): void {
+  const originalNow = Date.now;
+  const hadRaf = Object.prototype.hasOwnProperty.call(globalThis, 'requestAnimationFrame');
+  const originalRaf = Reflect.get(globalThis, 'requestAnimationFrame');
+  let now = 1_000;
+
+  Date.now = () => now;
+  Reflect.set(globalThis, 'requestAnimationFrame', () => 0);
+
+  try {
+    camera.setPresetView(view, PRESET_BOUNDS);
+    now += 400;
+    camera.update(0);
+  } finally {
+    Date.now = originalNow;
+    if (hadRaf) {
+      Reflect.set(globalThis, 'requestAnimationFrame', originalRaf);
+    } else {
+      Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
+    }
+  }
+}
+
+describe('CameraAnimator inertia loop gates on CameraControls applying, mid-decay (#2934)', () => {
+  it('orbit: mode flips to refusing mid-decay -- update() stops reporting isAnimating', () => {
+    const camera = freshCamera();
+    camera.setInteractionMode('all');
+    camera.orbit(50, 0, true); // queues real inertia while unrestricted
+    camera.setInteractionMode('none'); // embed host restricts mid-decay
+
+    assert.strictEqual(
+      camera.update(16),
+      false,
+      'a decaying orbit refused by interactionMode must not keep the animator reporting isAnimating',
+    );
+  });
+
+  it('orbit: mode flips to refusing mid-decay -- a refused tick does not reset preset tracking', () => {
+    // Reaching this precondition (nonzero orbit velocity *and* a live preset
+    // tracking value) through the public API is not possible: every path
+    // that queues orbit velocity (`Camera.orbit` with `addVelocity`) also
+    // resets tracking as part of its own gate, and the only path that sets
+    // tracking (`setPresetView`) zeroes all velocity first (`animateToWithUp`,
+    // "Clear all velocities to prevent inertia from interfering with
+    // animation"). So in this codebase the inertia loop's own
+    // `resetPresetTracking()` call is currently always a no-op in practice --
+    // but the gate is still the correct defensive fix (mirrors `Camera`'s own
+    // gate one level up) and this test pins it directly against the private
+    // field, the only way to construct the state at all.
+    const camera = freshCamera();
+    camera.setInteractionMode('all');
+    camera.orbit(50, 0, true); // queues inertia (also resets tracking, harmlessly, since it applied)
+
+    const animator = (camera as unknown as { animator: { lastPresetView: string | null; presetViewRotation: number } }).animator;
+    animator.lastPresetView = 'top';
+    animator.presetViewRotation = 2;
+
+    camera.setInteractionMode('none'); // now every inertia tick is refused
+    camera.update(16); // a refused inertia tick must not reset tracking
+
+    assert.strictEqual(animator.lastPresetView, 'top', 'a refused inertia tick must not clear the tracked preset view');
+    assert.strictEqual(animator.presetViewRotation, 2, 'a refused inertia tick must not restart the preset rotation cycle');
+  });
+
+  it('orbit: mode flips to refusing mid-decay -- lifting the mode back does not jump the camera', () => {
+    const camera = freshCamera();
+    camera.setInteractionMode('all');
+    camera.orbit(50, 0, true);
+    camera.setInteractionMode('none');
+    camera.update(16); // one or more frozen ticks while refused
+    camera.update(16);
+    const frozenPose = poseOf(camera);
+
+    camera.setInteractionMode('all'); // host re-enables mid-decay
+    camera.update(16);
+    assert.deepStrictEqual(
+      poseOf(camera),
+      frozenPose,
+      'a rejected orbit\'s leftover velocity must not survive to jump the camera once the mode is lifted',
+    );
+  });
+
+  it('pan: mode flips to refusing mid-decay -- update() stops reporting isAnimating and does not jump on re-enable', () => {
+    const camera = freshCamera();
+    camera.setInteractionMode('all');
+    camera.pan(50, 0, true);
+    camera.setInteractionMode('none');
+
+    assert.strictEqual(
+      camera.update(16),
+      false,
+      'a decaying pan refused by interactionMode must not keep the animator reporting isAnimating',
+    );
+    const frozenPose = poseOf(camera);
+
+    camera.setInteractionMode('all');
+    camera.update(16);
+    assert.deepStrictEqual(
+      poseOf(camera),
+      frozenPose,
+      'a rejected pan\'s leftover velocity must not survive to jump the camera once the mode is lifted',
+    );
+  });
+
+  it("zoom: mode flips to refusing (not 'all') mid-decay -- update() stops reporting isAnimating and does not jump on re-enable", () => {
+    const camera = freshCamera();
+    camera.setInteractionMode('all');
+    camera.zoom(-50, true);
+    camera.setInteractionMode('orbit'); // zoom requires exactly 'all'
+
+    assert.strictEqual(
+      camera.update(16),
+      false,
+      'a decaying zoom refused by interactionMode must not keep the animator reporting isAnimating',
+    );
+    const frozenPose = poseOf(camera);
+
+    camera.setInteractionMode('all');
+    camera.update(16);
+    assert.deepStrictEqual(
+      poseOf(camera),
+      frozenPose,
+      'a rejected zoom\'s leftover velocity must not survive to jump the camera once the mode is lifted',
+    );
+  });
+
+  it('all three gestures decaying at once: mode flips to none -- a single tick reports not-animating', () => {
+    const camera = freshCamera();
+    camera.setInteractionMode('all');
+    camera.orbit(50, 0, true);
+    camera.pan(50, 0, true);
+    camera.zoom(-50, true);
+    camera.setInteractionMode('none');
+
+    assert.strictEqual(
+      camera.update(16),
+      false,
+      'with every channel refused, a single tick must report isAnimating: false',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Refs #2934. Completes #3367's interaction-mode gating at the `CameraAnimator` level.

`Camera.orbit`/`pan`/`zoom` already gate `resetPresetTracking()` and inertia-queueing on whether the underlying `CameraControls.orbit`/`pan`/`zoom` call actually applied — a gesture refused by `interactionMode` (e.g. an embed `?controls=none`) does not half-apply. But `CameraAnimator.update()`'s own inertia loop calls the same `CameraControls` methods directly on every decay tick and discarded the returned boolean, bypassing that gate a second time, one level down.

The bug is invisible when a gesture is refused from the start (no velocity is ever queued, so the inertia block's `Math.abs(velocity) > minVelocity` guard never opens). It only shows up **mid-decay**: a gesture applies while `interactionMode` is `'all'` (queuing real velocity), then `interactionMode` flips to a restricting value while that velocity is still decaying — a live embed config update can do this at any time. On every remaining tick, `CameraControls` correctly refused to move the pose, but the inertia loop still (a) reset ViewCube preset-view tracking on a refused orbit tick, and (b) reported `isAnimating: true` unconditionally, keeping the render loop alive around a camera that was supposed to be frozen.

## Fix and the velocity-on-refusal decision

Each of the three inertia blocks (orbit/pan/zoom) now only runs its side effects (`resetPresetTracking()`, decaying the velocity further, setting `isAnimating`) when the `CameraControls` call reports it applied.

On refusal, I chose to **zero that channel's velocity immediately** rather than leave it to decay silently in the background. Justification: leaving it to decay means it stays nonzero (just shrinking) for as long as `interactionMode` keeps refusing it. If a host flips `interactionMode` back to `'all'` mid-decay, that leftover velocity would immediately be spent, jumping the camera from a gesture that was already rejected while the camera was supposed to be frozen. Zeroing on refusal instead means re-enabling controls always resumes from a genuinely at-rest state — matching the intent of the gate (a refused gesture changes nothing) rather than merely delaying its effect.

## Other CameraControls.orbit/pan/zoom callers

Grepped the whole repo for direct `controls.orbit(`/`controls.pan(`/`controls.zoom(` calls. Only two call sites exist:
- `packages/renderer/src/camera.ts` (`Camera`'s own wrappers) — this **is** the gate; already correctly checks the boolean return (from #3367).
- `packages/renderer/src/camera-animation.ts` (`CameraAnimator.update()`'s inertia loop) — fixed here.

No other bypass found.

## Test plan
- [x] New test file `packages/renderer/src/camera-animator-inertia-mode-flip.test.ts`: RED confirmed against the unfixed animator (6/6 new tests failed, each on `isAnimating: true !== false`), GREEN after the fix (6/6 pass). Covers: orbit/pan/zoom each refused mid-decay (not-animating + no camera jump on re-enable), the preset-tracking gate (seeded directly against the private field, since no public-API path can produce nonzero velocity alongside live preset tracking — every path that queues velocity also resets tracking, and every path that sets tracking zeroes velocity), and all three gestures refused simultaneously in one tick.
- [x] `node --import tsx --test src/camera*.test.ts` in `packages/renderer`: 169/169 pass.
- [x] Full renderer suite (`node --import tsx --test src/*.test.ts`): 1094/1098 pass, 3 pre-existing failures (`renderer-device-loss-latch`, `renderer-init-reentry`, `renderer-render-paths`) confirmed identical on unmodified `upstream/main` — unrelated to this change (environment/WebGPU dependency, not camera code).
- [x] `node ../../scripts/typecheck-tests.mjs` in `packages/renderer`: same 40 pre-existing errors present on unmodified `upstream/main` (missing built `@ifc-lite/geometry`/`@ifc-lite/spatial` type declarations — those packages weren't rebuilt to keep disk usage down in this session); zero errors touch `camera.ts`, `camera-animation.ts`, or the new test file.
- [x] `node scripts/check-module-size.mjs`: OK, 0 new files over 400 lines. `camera-animation.ts` crossed 400 with the fix + comments; trimmed existing and new comments in that file (not the allowlist) to land at exactly 400.
