### PR TITLE
fix(mcp): expand IfcRelAggregates containers in viewer_fly_to too

### DIFF
--- a/.changeset/mcp-viewer-flyto-assembly-expansion.md
+++ b/.changeset/mcp-viewer-flyto-assembly-expansion.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/mcp': patch
+---
+
+Fix `viewer_fly_to` resolving a `global_id`/`global_ids`/`express_id`/`express_ids` selector by direct lookup only, with no `IfcRelAggregates` expansion — the same gap already fixed in `viewer_isolate`/`viewer_hide`/`viewer_show`/`viewer_colorize`. An `IfcElementAssembly` (or any other decomposition container) carries no mesh of its own; its parts do. `packages/viewer`'s renderer computes the fly-to camera target's bounding box only from actually-rendered mesh ids, so an unexpanded container id matched nothing and the camera silently did not move.
+
+`viewer_fly_to` now expands any ref with `IfcRelAggregates` children into itself plus every decomposition descendant before it reaches the viewer, using the same `expandAssemblyRefs` helper as the other viewer tools. A plain element id with no decomposition children passes through unchanged.

--- a/packages/mcp/src/tools/viewer.test.ts
+++ b/packages/mcp/src/tools/viewer.test.ts
@@ -18,10 +18,17 @@
  * never keys is a silent no-op.
  *
  * These tests exercise `viewer_isolate`/`viewer_hide`/`viewer_show`/
- * `viewer_colorize` end to end (through the real tool handlers, with a
- * fake streaming adapter recording exactly which `EntityRef[]` reached the
- * backend) rather than unit-testing a helper in isolation, so a regression
- * in the wiring — not just the expansion logic — fails these tests too.
+ * `viewer_colorize`/`viewer_fly_to` end to end (through the real tool
+ * handlers, with a fake streaming adapter recording exactly which
+ * `EntityRef[]` reached the backend) rather than unit-testing a helper in
+ * isolation, so a regression in the wiring — not just the expansion logic
+ * — fails these tests too.
+ *
+ * `viewer_fly_to` has the same failure mode as `viewer_hide`/`show`/
+ * `colorize`: `packages/viewer`'s `viewer-html.ts` computes the camera
+ * target bounding box only from `entityMap` (rendered-mesh ids), so an
+ * unexpanded assembly id matches nothing and `getEntityBoundsForFilter`
+ * returns `null` — the camera silently does not move.
  */
 
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
@@ -94,6 +101,7 @@ let isolateCalls: EntityRef[][];
 let hideCalls: EntityRef[][];
 let showCalls: EntityRef[][];
 let colorizeCalls: EntityRef[][];
+let flyToCalls: EntityRef[][];
 
 async function load(): Promise<void> {
   const path = join(tmp, 'm.ifc');
@@ -103,12 +111,13 @@ async function load(): Promise<void> {
   hideCalls = [];
   showCalls = [];
   colorizeCalls = [];
+  flyToCalls = [];
   model.backend.attachStreamingAdapters(
     {
       colorize(refs) { colorizeCalls.push(refs); },
       colorizeAll() {},
       resetColors() {},
-      flyTo() {},
+      flyTo(refs) { flyToCalls.push(refs); },
       setSection() {},
       getSection() { return null; },
       setCamera() {},
@@ -199,5 +208,26 @@ describe('viewer_colorize — assembly expansion (#3338)', () => {
     await load();
     await tool('viewer_colorize').handler({ global_id: WALL3_GID, color: 'red' }, ctx);
     expect(expressIdsOf(colorizeCalls)).toEqual([103]);
+  });
+});
+
+describe('viewer_fly_to — assembly expansion (#3338)', () => {
+  it('flying to a geometry-less assembly reaches the backend with its geometry-bearing parts, not just the assembly id', async () => {
+    await load();
+    const result = await tool('viewer_fly_to').handler({ global_id: ASM_GID }, ctx);
+    expect(result.isError).toBeUndefined();
+    expect(expressIdsOf(flyToCalls)).toEqual([100, 101, 102]);
+  });
+
+  it('flying to a plain wall (no IfcRelAggregates children) is a no-op — passes through unchanged', async () => {
+    await load();
+    await tool('viewer_fly_to').handler({ global_id: WALL3_GID }, ctx);
+    expect(expressIdsOf(flyToCalls)).toEqual([103]);
+  });
+
+  it('flying to both the assembly and one of its own children does not double-expand', async () => {
+    await load();
+    await tool('viewer_fly_to').handler({ global_ids: [ASM_GID, WALL1_GID] }, ctx);
+    expect(expressIdsOf(flyToCalls)).toEqual([100, 101, 102]);
   });
 });

--- a/packages/mcp/src/tools/viewer.ts
+++ b/packages/mcp/src/tools/viewer.ts
@@ -296,7 +296,7 @@ const viewerFlyTo: Tool = {
     const viewer = requireViewer(ctx);
     if (!viewer.isOpen()) throw new ToolExecutionError({ code: ToolErrorCode.UNSUPPORTED_OPERATION, message: 'Viewer is not open.' });
     const m = resolveModel(ctx, input.model_id as string | undefined);
-    const refs = resolveTargetRefs(m, input);
+    const refs = expandAssemblyRefs(m, resolveTargetRefs(m, input));
     if (refs.length === 0) throw new ToolExecutionError({ code: ToolErrorCode.INVALID_INPUT, message: 'No entities matched.' });
     m.bim.viewer.flyTo(refs);
     return okResult(`Flying to ${refs.length} entit${refs.length === 1 ? 'y' : 'ies'}.`, { count: refs.length });


### PR DESCRIPTION
## Summary

`viewer_isolate`/`viewer_hide`/`viewer_show`/`viewer_colorize` in `packages/mcp` already expand a ref with `IfcRelAggregates` children into itself plus every decomposition descendant before it reaches the viewer (#3408). `viewer_fly_to` still called `resolveTargetRefs` directly, with no expansion wrapper.

Traced the actual failure mode instead of assuming the isolate fix transfers, since fly-to and isolate do different things:

- `packages/mcp/src/tools/viewer.ts`'s `viewer_fly_to` handler calls `m.bim.viewer.flyTo(refs)`.
- The SDK (`packages/sdk/src/namespaces/viewer.ts`) forwards to the backend unchanged: `this.backend.viewer.flyTo(refs)`.
- With a live viewer attached (`viewer_open`), the backend is the streaming adapter (`packages/viewer/src/streaming-viewer.ts`), which sends `{ action: 'flyto', ids: refsToIds(refs) }` over the wire.
- The browser side (`packages/viewer/src/viewer-html.ts`) handles it with:
  ```js
  case 'flyto': {
    const bounds = getEntityBoundsForFilter((eid, info) =>
      cmd.ids ? cmd.ids.includes(eid) : matchesType(info, cmd.type)
    );
    if (bounds) {
      const center = bounds.min.map((v,i) => (v + bounds.max[i]) / 2);
      const dim = Math.max(...bounds.max.map((v,i) => v - bounds.min[i]), 0.1);
      flyTo(center, dim * 1.5);
    }
    break;
  }
  ```
  and `getEntityBoundsForFilter` only iterates `entityMap` (populated from rendered mesh batches), returning `null` when nothing matches:
  ```js
  function getEntityBoundsForFilter(filterFn) {
    ...
    for (const [eid, info] of entityMap) {
      if (!filterFn(eid, info)) continue;
      found = true;
      ...
    }
    if (!found) return null;
    return { min: tMin, max: tMax };
  }
  ```

An `IfcElementAssembly` id is never a key in `entityMap` (it carries no mesh of its own — its parts do), so `bounds` is `null` and the `if (bounds)` guard never fires: **the camera silently does not move.** Same failure class as the isolate/hide/show/colorize bug from #3408, just quieter — no dimming, simply nothing happens, which an agent has no way to distinguish from "already framed."

## Fix

Wrap `resolveTargetRefs` with the existing `expandAssemblyRefs` helper (`packages/mcp/src/tools/viewer-assembly-expansion.ts`) — no new expansion logic, same helper the other four tools already use.

## Base branch

Was stacked on `fix-3338-mcp-isolate-expansion` (#3408) because `expandAssemblyRefs` lives there. **#3408 has since merged, and this PR is now based on `main`.** The rebase needed one correction worth recording: #3408 merged as a squash, so the branch's own copy of its commit conflicted with the squashed version already on `main`. Resetting to `upstream/main` and cherry-picking only this PR's own commit applied with zero conflicts, which confirmed the duplicate was the entire conflict. The diff against `main` is now exactly three files — `viewer.ts`, `viewer.test.ts` and the changeset — and re-introduces none of #3408's helper.

## Test plan

- [x] Added `viewer_fly_to` cases to `packages/mcp/src/tools/viewer.test.ts` (geometry-less assembly expands to its parts; a plain wall passes through unchanged; assembly + one of its own children does not double-expand), mirroring the existing isolate/hide/show/colorize coverage in the same file.
- [ ] Could not run `pnpm --filter @ifc-lite/mcp test` locally: this worktree has no `node_modules` and the environment's disk (3.5 GB free of 460 GB) is under a hard no-install/no-build constraint, so dependencies could not be installed. Verified the fix by reading the exact code path end-to-end (quoted above) and by inspecting `expandAssemblyRefs`'s dedup (`Set<number>` keyed on `expressId`) for idempotency. Requesting CI run the added tests.

Refs #3338
