### PR TITLE
fix(embed-sdk): expose autoLoad on EmbedOptions

### DIFF
--- a/.changeset/embed-sdk-autoload-option.md
+++ b/.changeset/embed-sdk-autoload-option.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/embed-sdk': patch
+---
+
+Expose `autoLoad` on `EmbedOptions`, so an SDK host can suppress the automatic model fetch.
+
+The viewer has honoured `?autoLoad=false` since the auto-load effect gained its gate, but the SDK's typed options object never carried the field. A host building the iframe URL by hand could opt out; a host using the SDK could not express it at all — the option existed on one side of the same API and not the other.
+
+`embedUrlSearchParams` now emits `autoLoad=false` when, and only when, the caller passes `false`. This is the opposite polarity to `hideAxis`/`hideScale`, which default off and are emitted when true: `autoLoad` defaults ON, so omission and `true` are the same answer and neither is serialised. The literal string matters — the viewer parses the parameter as `autoLoad !== 'false'`, so any other value (`0`, empty) reads back as true and would load the model the host asked us not to.
+
+Not included: a round-trip test binding the serialiser to the parser. `@ifc-lite/embed-sdk` and `apps/viewer-embed` do not depend on each other, so pinning the contract end to end would mean either a new dependency edge or a shared fixture in `@ifc-lite/embed-protocol` (the pattern used for the CSV and STEP escapers). Both halves are tested independently; the seam between them is not.

--- a/packages/embed-sdk/src/options.ts
+++ b/packages/embed-sdk/src/options.ts
@@ -17,6 +17,14 @@ export interface EmbedOptions {
   container: string | HTMLElement;
   /** URL of the model to load on initialization */
   modelUrl?: string;
+  /**
+   * Set `false` to suppress the automatic fetch of `modelUrl`, leaving the
+   * viewer mounted and empty until the host loads something itself. Omitted
+   * and `true` both mean "load", matching the viewer's default — only an
+   * explicit `false` is serialised, because the parser treats every value
+   * other than the literal `'false'` as `true`.
+   */
+  autoLoad?: boolean;
   /** Color theme */
   theme?: 'light' | 'dark';
   /** Custom background color (hex without #) */
@@ -67,6 +75,7 @@ export interface EmbedOptions {
 export function embedUrlSearchParams(opts: EmbedOptions): URLSearchParams {
   const params = new URLSearchParams();
   if (opts.modelUrl) params.set('modelUrl', opts.modelUrl);
+  if (opts.autoLoad === false) params.set('autoLoad', 'false');
   if (opts.theme) params.set('theme', opts.theme);
   if (opts.bg) params.set('bg', opts.bg);
   if (opts.controls) params.set('controls', opts.controls);

--- a/packages/embed-sdk/test/iframe-url.test.ts
+++ b/packages/embed-sdk/test/iframe-url.test.ts
@@ -60,6 +60,23 @@ describe('iframe URL construction', () => {
     expect(p.has('hideScale')).toBe(false);
   });
 
+  it('serialises autoLoad only when explicitly false', () => {
+    // autoLoad is the one flag with the OPPOSITE polarity to hideAxis/hideScale
+    // above: those default off and are emitted when true, this defaults ON and is
+    // emitted only to suppress. The viewer parses it as `autoLoad !== 'false'`,
+    // so the literal string is load-bearing — `autoLoad=0` or `autoLoad=` would
+    // both read back as true and silently load the model the host asked us not to.
+    expect(urlOf({ autoLoad: false }).searchParams.get('autoLoad')).toBe('false');
+  });
+
+  it('omits autoLoad when unset or true, matching the viewer default', () => {
+    // Emitting `autoLoad=true` would be harmless today but pins a value the
+    // parser only reads as "not the string false"; omission is the same answer
+    // and keeps the URL to what the host actually chose.
+    expect(urlOf({}).searchParams.has('autoLoad')).toBe(false);
+    expect(urlOf({ autoLoad: true }).searchParams.has('autoLoad')).toBe(false);
+  });
+
   it('maps hideAxis and hideScale to their own distinct params, not each other', () => {
     // Setting only one flag distinguishes a key swap: both prior tests set
     // hideAxis and hideScale to the SAME value together, so `params.set(


### PR DESCRIPTION
## Summary

The viewer has honoured `?autoLoad=false` since the auto-load effect gained its gate:

```ts
if (!urlParams.modelUrl || urlParams.autoLoad === false || !webgpu.supported || loading) return;
```

but `EmbedOptions` never carried the field. So a host building the iframe URL by hand could opt out of the automatic model fetch, and a host using the SDK could not express it at all — the same option present on one side of the API and absent from the other. Noticed while verifying #2934; `autoLoad` is the only member of `EmbedUrlParams` missing from `EmbedOptions` (the remaining `EmbedOptions` fields — `container`, `origin`, `token`, `timeout` — are legitimately SDK-local or, for `token`, deliberately kept off the URL).

## Why a URL parameter and not the `INIT` handshake

`token` is the precedent for sending an option by postMessage instead, but that route is not available here. `EmbedViewer` reads `parseUrlParams()` synchronously in a `useState` initialiser, so the value exists on the first render, and the auto-load effect is not gated on the bridge handshake. An option delivered by `INIT` would arrive strictly later than the effect it needs to suppress — the fetch would already be in flight.

## Polarity

`autoLoad` is emitted **only** when explicitly `false`, which is the opposite of `hideAxis`/`hideScale` (default off, emitted when true). `autoLoad` defaults on, so omission and `true` are the same answer and neither is serialised.

The literal string is load-bearing. The parser reads:

```ts
if (autoLoad !== null) result.autoLoad = autoLoad !== 'false';
```

so `autoLoad=0` or `autoLoad=` would read back as **true** and load the model the host asked us not to — the silent-no-op family this issue is about. The tests pin both the exact `'false'` and the omission cases, with a comment explaining the inverted polarity so it is not "corrected" later.

## Testing

`node scripts/check-module-size.mjs` → exit 0 (2014 files, 0 new over 400).

The package tests were **not run locally** — this environment has no `node_modules` and installing was not possible under an active disk constraint, so CI is the check for them.

## Not included

A round-trip test binding the serialiser to the parser. `@ifc-lite/embed-sdk` and `apps/viewer-embed` do not depend on each other, so pinning the contract end to end needs either a new dependency edge or a shared fixture in `@ifc-lite/embed-protocol` — the pattern already used for the CSV and STEP escapers. Both halves are tested independently; the seam between them is not, and that seam is precisely what let this option go missing unnoticed. Happy to add the shared fixture if you would prefer it here rather than as a follow-up.

Refs #2934