### PR TITLE
test(geometry): count strict directed edge pairs beside the signed balance (#3397)

### DIFF
--- a/rust/geometry/tests/census_golden/mod.rs
+++ b/rust/geometry/tests/census_golden/mod.rs
@@ -78,8 +78,36 @@ pub struct HostRow {
     pub id: u32,
     /// `RepresentationType` of the Body representation.
     pub rep: String,
-    /// Open boundary edges on the 1 mm snapped topology.
+    /// Open boundary edges on the 1 mm snapped topology, read as a SIGNED
+    /// per-edge balance: an undirected edge counts when its forward and its
+    /// reverse use counts DIFFER.
+    ///
+    /// #3397 kept this reading rather than replacing it. [`HostRow::strict`] is
+    /// the stricter reading of the same walk, and the two are carried side by
+    /// side precisely so they can be compared per host — replacing this one
+    /// would restate every number in the golden at once and surface every
+    /// pre-existing non-manifold host as a new tear, which is a different
+    /// decision from measuring how many there are.
     pub open: usize,
+    /// Undirected edges of the SAME 1 mm snapped topology whose directed uses
+    /// are not exactly one forward and one reverse — the manifold condition
+    /// `touching_operand.rs` and the #3353 tear pin already use (#3397).
+    ///
+    /// A superset of [`HostRow::open`] by construction: `forward != reverse`
+    /// implies `(forward, reverse) != (1, 1)`. What it sees that `open` cannot
+    /// is every topology where the two directed counts grow TOGETHER, leaving
+    /// the signed net at zero: a face duplicated along with its opposite-wound
+    /// twin, a wholesale duplicated shell, a 2-forward / 2-reverse non-manifold
+    /// seam. The two DUPLICATION cases also grow `tris`, and a grown `tris`
+    /// files under `better`, so before this column the census reported a
+    /// duplicated sheet as an improvement. The seam is stated without that
+    /// claim: four triangles meeting on one edge need not have arrived by
+    /// duplication, so `tris` may not have moved at all, and then nothing in
+    /// the row moved either.
+    ///
+    /// Both readings come off ONE walk in `edge_stats`, over one snapped
+    /// topology, so they cannot drift into two measurements of two meshes.
+    pub strict: usize,
     /// Triangles in the emitted mesh. Load-bearing on its own: a host whose mesh
     /// degrades to EMPTY still returns `Ok` and still reports `open == 0`, which
     /// is indistinguishable from a perfect watertight solid under an
@@ -115,14 +143,27 @@ impl HostRow {
     /// weaker than the directed-pair rule (`forward == 1 && reverse == 1`) used
     /// by the #3353 tear pin, and the two can disagree: a mesh can be watertight
     /// by this count and non-manifold by the strict one. So a fall in `open` can
-    /// mean a face was duplicated rather than a tear repaired. The row carries
-    /// no strict count, so this cannot be gated the way the cases below are; it
-    /// is a limit of the measure, and it points at the same volume dimension the
-    /// magnitude blindness does. Raised by the #3391 review, where a signed
-    /// count and a strict one gave contradictory readings on the same mesh.
-    /// Tracked as #3397, which also notes the wider exposure: the corpus totals
-    /// `total unmatched edges` and `torn void hosts` derive from the same count,
-    /// so a duplicate-face defect is invisible to the gate in either direction.
+    /// mean a face was duplicated rather than a tear repaired. Raised by the
+    /// #3391 review, where a signed count and a strict one gave contradictory
+    /// readings on the same mesh.
+    ///
+    /// WHAT IS NOW MEASURED (#3397). The row carries [`HostRow::strict`], the
+    /// directed-pair reading of the same walk, and `classify` gates a RISE in it
+    /// as a worsened count. So the duplication hazard above is no longer
+    /// un-gated: the pair that hides it — `open` falling while `strict` rises —
+    /// files as a regression, and a worsened count outranks the re-tessellation
+    /// verdict, which is where a falling `open` would otherwise buy a friendly
+    /// message.
+    ///
+    /// WHAT IS STILL NOT. `strict` is deliberately kept out of this predicate
+    /// and out of [`Self::is_torn_solid`], so the gated defect population and
+    /// the `torn` / `torn_solid` / `total unmatched edges` totals all still read
+    /// the SIGNED count: a host that has always been non-manifold is not
+    /// reclassified into a tear by this change. `alt` and `pre` are signed
+    /// readings too, so a duplicated sheet that only ONE triangulator emits
+    /// stays invisible to [`Self::diverged`]. And neither reading sees a
+    /// self-intersection, or coincidence finer than the 1 mm snap, or anything
+    /// about a host with no `IfcRelVoidsElement` — the sweep's own scope.
     ///
     /// Not a weakening of [`Self::open_is_a_defect_count`] and not a
     /// strengthening: the two are INCOMPARABLE, because they add different
@@ -155,6 +196,14 @@ impl HostRow {
     /// Says nothing about whether the count is zero, which is why this is
     /// separate from [`Self::is_torn_solid`]: a run whose open count fell to 0
     /// is the ideal repair, not a disqualified reading.
+    ///
+    /// Reads the SIGNED `open`, not [`HostRow::strict`], and #3397 left it that
+    /// way on purpose. This predicate defines the gated defect population, so
+    /// swapping the reading would move `torn_solid` on every host that is
+    /// watertight by one rule and not the other, in one commit, with no way to
+    /// tell those hosts from geometry that actually changed. The strict reading
+    /// is gated as its OWN count instead; see [`Self::open_is_comparable`] for
+    /// what that does and does not buy.
     pub fn open_is_a_defect_count(&self) -> bool {
         self.open_is_a_reading() && !self.far
     }
@@ -182,6 +231,12 @@ pub struct Totals {
     pub hosts: usize,
     pub torn: usize,
     pub open_edges: usize,
+    /// Sum of [`HostRow::strict`]. A ceiling of its own ALONGSIDE `open_edges`,
+    /// never instead of it: the two are readings of the same corpus, and the gap
+    /// between them is how many edges the signed balance cannot see. That is a
+    /// corpus-wide EDGE figure and not #3397's headline number, which is a HOST
+    /// count (`open == 0 && strict > 0`) and is computed in the census itself.
+    pub strict_edges: usize,
     pub collapsed: usize,
     pub torn_solid: usize,
     pub non_invariant: usize,
@@ -192,6 +247,7 @@ pub fn totals<'a>(rows: impl IntoIterator<Item = &'a HostRow>) -> Totals {
         hosts: 0,
         torn: 0,
         open_edges: 0,
+        strict_edges: 0,
         collapsed: 0,
         torn_solid: 0,
         non_invariant: 0,
@@ -199,6 +255,7 @@ pub fn totals<'a>(rows: impl IntoIterator<Item = &'a HostRow>) -> Totals {
     for r in rows {
         t.hosts += 1;
         t.open_edges += r.open;
+        t.strict_edges += r.strict;
         t.torn += usize::from(r.open > 0);
         t.collapsed += usize::from(r.collapsed);
         t.torn_solid += usize::from(r.is_torn_solid());
@@ -400,6 +457,32 @@ struct Classified {
     better: Vec<String>,
 }
 
+/// How to describe a FALLING edge count, tagged for EVERY reason the fall might
+/// not be repair. `open_is_comparable` names three; caveating only the far-field
+/// one would print an unqualified "improved" next to "geometry lost" on exactly
+/// the hosts the gate just refused.
+///
+/// ONE function for both the signed and the strict arm, because the
+/// disqualifiers are properties of the host rather than of either reading: an
+/// open shell's boundary edges are structural under both rules, a failed no-void
+/// pass leaves nothing to attribute either count to, and `edge_stats` skips
+/// degenerate triangles, so a collapse depresses both. Two copies would let one
+/// arm print "(improved)" beside the other's "geometry lost".
+fn fall_note(g: &HostRow, r: &HostRow) -> &'static str {
+    if !g.open_is_comparable() || !r.open_is_comparable() {
+        // An open shell's boundary edges are structural, so deleting faces
+        // takes them along: the count falls BECAUSE geometry was lost. A
+        // failed no-void pass leaves nothing to attribute the tearing to.
+        "down, but not a repair signal: see the verdict"
+    } else if g.far || r.far {
+        // Real evidence, just noisy. The census already acts on this count
+        // in the other direction with no gate at all.
+        "improved; far-field, so the count is an f32 artifact"
+    } else {
+        "improved"
+    }
+}
+
 /// Classify one matched pair.
 fn classify(g: &HostRow, r: &HostRow) -> Classified {
     let mut c = Classified::default();
@@ -407,23 +490,30 @@ fn classify(g: &HostRow, r: &HostRow) -> Classified {
     if r.open > g.open {
         c.worse_counts.push(format!("open edges {} -> {}", g.open, r.open));
     } else if r.open < g.open {
-        // Tagged, not gated, and tagged for EVERY reason the count might not be
-        // repair. `open_is_comparable` names three; caveating only the
-        // far-field one would print an unqualified "improved" next to
-        // "geometry lost" on exactly the hosts the gate just refused.
-        let note = if !g.open_is_comparable() || !r.open_is_comparable() {
-            // An open shell's boundary edges are structural, so deleting faces
-            // takes them along: the count falls BECAUSE geometry was lost. A
-            // failed no-void pass leaves nothing to attribute the tearing to.
-            "down, but not a repair signal: see the verdict"
-        } else if g.far || r.far {
-            // Real evidence, just noisy. The census already acts on this count
-            // in the other direction with no gate at all.
-            "improved; far-field, so the count is an f32 artifact"
-        } else {
-            "improved"
-        };
-        c.better.push(format!("open edges {} -> {} ({note})", g.open, r.open));
+        c.better.push(format!("open edges {} -> {} ({})", g.open, r.open, fall_note(g, r)));
+    }
+
+    // The STRICT directed-pair reading, gated in its own right (#3397). A rise
+    // here while `open` holds is the shape the signed balance cannot see at
+    // all: a face duplicated along with its opposite-wound twin nets to zero on
+    // that reading and GROWS `tris`, and a grown `tris` files under `better`, so
+    // the census used to report the defect as an improvement.
+    //
+    // It joins `worse_counts` rather than getting a bucket of its own because
+    // it answers exactly the question that field asks — a count this host
+    // carries got worse, and no relabelling makes more non-manifold edges into
+    // good news — and because outranking the re-tessellation verdict is the
+    // point: `open` falling while `strict` rises is the duplicated-face case
+    // [`HostRow::open_is_comparable`] warns a falling `open` can hide.
+    if r.strict > g.strict {
+        c.worse_counts.push(format!("strict directed-pair edges {} -> {}", g.strict, r.strict));
+    } else if r.strict < g.strict {
+        c.better.push(format!(
+            "strict directed-pair edges {} -> {} ({})",
+            g.strict,
+            r.strict,
+            fall_note(g, r)
+        ));
     }
 
     // Triangles shrinking is the loss direction ONLY when the tearing did not
@@ -622,7 +712,10 @@ const HEADER: &str = "\
 # far:   1 if |coord| is past what f32 carries mm topology at (reported, not gated).
 # alt:   open edges under the alternate triangulator, or x if that pass failed.
 # pre:   open edges with no voids applied; x if that pass failed, - if not taken.
-model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre";
+# strict: undirected edges NOT used exactly once forward and once reverse. Always
+#        >= open, and sees what open cannot: a doubled sheet nets to zero on the
+#        signed balance. Gated as its own count; the defect population is open's.
+model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict";
 
 fn pre_token(p: PreVoid) -> String {
     match p {
@@ -654,8 +747,12 @@ pub fn render(rows: &[HostRow]) -> String {
     let mut out = String::from(HEADER);
     for r in rows {
         let alt = r.alt.map(|v| v.to_string()).unwrap_or_else(|| "x".to_string());
+        // `strict` is appended LAST rather than beside `open`, so `cut -f1-9`
+        // over this file still reproduces the pre-#3397 row byte for byte. That
+        // is what made the bless diff for the commit that added it readable:
+        // every existing column had to hold, and a moved one had to be visible.
         out.push_str(&format!(
-            "\n{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            "\n{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
             r.model,
             r.id,
             r.rep,
@@ -665,6 +762,7 @@ pub fn render(rows: &[HostRow]) -> String {
             u8::from(r.far),
             alt,
             pre_token(r.pre),
+            r.strict,
         ));
     }
     out.push('\n');
@@ -680,8 +778,12 @@ pub fn parse(text: &str) -> Result<Vec<HostRow>, String> {
             continue;
         }
         let f: Vec<&str> = line.split('\t').collect();
-        if f.len() != 9 {
-            return Err(format!("line {}: expected 9 columns, got {}", n + 1, f.len()));
+        // Exactly 10. A pre-#3397 nine-column row is an ERROR, not a row with
+        // an implied strict count: accepting it would have to invent one, and a
+        // fabricated zero is a clean-looking host that was never measured. A bad
+        // merge of this golden is then loud instead of silently under-gated.
+        if f.len() != 10 {
+            return Err(format!("line {}: expected 10 columns, got {}", n + 1, f.len()));
         }
         let num = |i: usize| -> Result<usize, String> {
             f[i].parse::<usize>().map_err(|_| format!("line {}: bad number {:?}", n + 1, f[i]))
@@ -696,6 +798,7 @@ pub fn parse(text: &str) -> Result<Vec<HostRow>, String> {
             far: parse_flag(f[6]).map_err(|e| format!("line {}: {e}", n + 1))?,
             alt: if f[7] == "x" { None } else { Some(num(7)?) },
             pre: parse_pre(f[8]).map_err(|e| format!("line {}: {e}", n + 1))?,
+            strict: num(9)?,
         });
     }
     Ok(out)
@@ -711,6 +814,11 @@ mod tests {
             id,
             rep: "SweptSolid".to_string(),
             open,
+            // The clean default: every unbalanced edge is unbalanced, and
+            // nothing else is doubled. `strict >= open` always holds, so a
+            // helper that set this below `open` would build a row the sweep
+            // cannot produce. Tests that need a doubled sheet raise it.
+            strict: open,
             tris,
             collapsed: false,
             far: false,
@@ -1062,6 +1170,45 @@ mod tests {
     }
 
     #[test]
+    fn the_checked_in_golden_carries_a_strict_column_that_is_not_a_copy_of_open() {
+        // The one property no synthetic row can carry: that the sweep actually
+        // FEEDS `strict` the directed-pair reading. `strict: stats.open` in
+        // `triangulation_invariance.rs` would leave every other test in this
+        // module green, and it would leave the CENSUS green too — the golden is
+        // a per-host CEILING, so a column that only ever falls files under
+        // `improved` and requires no bless. What it cannot survive is a
+        // re-bless: the dark column lands in this file, and this test reads it.
+        //
+        // Bounds rather than exact counts, so a real geometry fix never has to
+        // edit this test. Zero on either tally is the failure: it means the
+        // column has gone dark or is echoing `open`.
+        let rows = parse(include_str!("../manifests/watertightness_census.tsv"))
+            .expect("the checked-in golden must parse");
+        assert!(rows.len() > 1000, "golden is under-populated: {} rows", rows.len());
+        for r in &rows {
+            assert!(
+                r.strict >= r.open,
+                "{} #{}: strict {} < open {} — `f != r` implies `(f, r) != (1, 1)`, so \
+                 the walk cannot produce this row",
+                r.model,
+                r.id,
+                r.strict,
+                r.open
+            );
+        }
+        assert!(
+            rows.iter().any(|r| r.strict > r.open),
+            "no golden row disagrees with the signed count, so the strict column is \
+             either dark or a copy of `open`"
+        );
+        assert!(
+            rows.iter().any(|r| r.open == 0 && r.strict > 0),
+            "no golden row is watertight by the SIGNED balance and torn by the STRICT \
+             rule — the population #3397 exists to measure has left the golden"
+        );
+    }
+
+    #[test]
     fn a_torn_host_whose_mesh_vanishes_is_loss_however_much_the_tearing_improved() {
         // The input the `r.tris == 0` clause exists for, and the only one that
         // requires it: a TORN host whose mesh disappears. Open edges fall to
@@ -1092,6 +1239,92 @@ mod tests {
         let worse = diff(&g, &[row("a.ifc", 1, 55, 600)], &swept(&["a.ifc"]));
         assert_eq!(worse.regressed.len(), 1, "open worse: still a loss");
         assert!(worse.retessellated.is_empty());
+    }
+
+    #[test]
+    fn a_doubled_sheet_regresses_even_though_open_holds_and_triangles_grow() {
+        // #3397 verbatim, and the reason the strict column is GATED rather than
+        // merely reported. A face duplicated along with its opposite-wound twin
+        // leaves the signed balance at 0 — one extra forward use and one extra
+        // reverse use cancel — and GROWS `tris`, and a grown `tris` files under
+        // `better`. So before this column the census filed the defect as an
+        // improvement, `requires_bless()` read false, and the lane stayed green.
+        let mut g = row("a.ifc", 1, 0, 12);
+        g.strict = 0;
+        let mut r = row("a.ifc", 1, 0, 14);
+        r.strict = 3;
+
+        let d = diff(std::slice::from_ref(&g), std::slice::from_ref(&r), &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1, "a doubled coincident sheet must regress");
+        assert!(d.improved.is_empty(), "and must not be filed as a triangle-count gain");
+        let reasons = d.regressed[0].reasons.join("; ");
+        assert!(reasons.contains("strict directed-pair edges 0 -> 3"), "{reasons}");
+        // The triangle growth still has to be REPORTED, or the failure text
+        // omits the evidence that the extra edges arrived with extra geometry.
+        assert!(reasons.contains("triangles 12 -> 14"), "{reasons}");
+        assert!(d.requires_bless());
+
+        // Removing the duplicate is the mirror image, and must not read as a
+        // regression. Held at the SAME triangle count as the golden so it is the
+        // strict column deciding and not the `tris` shrink that accompanies a
+        // real de-duplication.
+        let mut fixed = row("a.ifc", 1, 0, 14);
+        fixed.strict = 0;
+        let back = diff(std::slice::from_ref(&r), &[fixed], &swept(&["a.ifc"]));
+        assert!(back.regressed.is_empty(), "fewer strict violations is not a regression");
+        assert_eq!(back.improved.len(), 1);
+        assert!(back.improved[0].reasons.join("; ").contains("strict directed-pair edges 3 -> 0"));
+    }
+
+    #[test]
+    fn a_shrink_that_heals_the_signed_count_while_doubling_a_sheet_is_a_regression() {
+        // The interaction that decides where the strict arm belongs. This host
+        // shrank AND its signed count fell, which is the re-tessellation shape
+        // and would be filed under the friendly bucket — but its strict count
+        // ROSE, so some of that repair is a duplicated sheet rather than a
+        // closed tear. `open_is_comparable` documents that hazard as the reason
+        // a falling `open` cannot be trusted on its own; putting the strict rise
+        // in `worse_counts` is what makes the hazard gated, because a worsened
+        // count outranks `retessellated` in the verdict chain.
+        let mut g = row("a.ifc", 1, 40, 800);
+        g.strict = 40;
+        let mut r = row("a.ifc", 1, 12, 600);
+        r.strict = 44;
+
+        let d = diff(&[g], &[r], &swept(&["a.ifc"]));
+        assert!(d.retessellated.is_empty(), "a doubled sheet is not a re-tessellation");
+        assert_eq!(d.regressed.len(), 1, "the strict rise outranks the friendly reading");
+        let reasons = d.regressed[0].reasons.join("; ");
+        assert!(reasons.contains("strict directed-pair edges 40 -> 44"), "{reasons}");
+        // The signed fall still rides along, because it is what a reviewer would
+        // otherwise have called a repair, and the two numbers together are the
+        // whole argument for carrying both columns.
+        assert!(reasons.contains("open edges 40 -> 12"), "{reasons}");
+    }
+
+    #[test]
+    fn a_falling_strict_count_is_qualified_wherever_a_falling_open_count_is() {
+        // Both arms read `fall_note`, so a strict fall on a host the gate just
+        // called geometry loss must not print an unqualified "(improved)" next
+        // to "(geometry lost)". Splitting the note into two copies is exactly
+        // how that contradiction reappears, and the open-shell test above would
+        // stay green while it did, because it only ever inspects `open`.
+        let shell = |open, strict, tris| HostRow {
+            rep: "Tessellation".to_string(),
+            strict,
+            ..row("a.ifc", 1, open, tris)
+        };
+        let d = diff(&[shell(60, 66, 4000)], &[shell(20, 22, 1200)], &swept(&["a.ifc"]));
+        assert_eq!(d.regressed.len(), 1);
+        let reasons = &d.regressed[0].reasons;
+        assert!(
+            reasons.iter().any(|x| x.contains("strict directed-pair edges 66 -> 22")),
+            "the strict fall must be reported: {reasons:?}"
+        );
+        assert!(
+            !reasons.iter().any(|x| x.contains("(improved)")),
+            "and qualified like the signed one, not called an improvement: {reasons:?}"
+        );
     }
 
     #[test]
@@ -1276,24 +1509,36 @@ mod tests {
         let mut out = Vec::new();
         for rep in ["CSG", "SurfaceModel"] {
             for open in [0usize, 3] {
-                for tris in [0usize, 3, 5] {
-                    for collapsed in [false, true] {
-                        for far in [false, true] {
-                            for alt in [None, Some(0usize), Some(3), Some(9)] {
-                                for pre in
-                                    [PreVoid::NotTaken, PreVoid::Failed, PreVoid::Open(0), PreVoid::Open(2)]
-                                {
-                                    out.push(HostRow {
-                                        model: "a.ifc".to_string(),
-                                        id: 1,
-                                        rep: rep.to_string(),
-                                        open,
-                                        tris,
-                                        collapsed,
-                                        far,
-                                        alt,
-                                        pre,
-                                    });
+                // `open` itself (nothing doubled) and one value ABOVE it (a
+                // doubled sheet). Never below: `strict >= open` by
+                // construction, so a lower value is a row no sweep can emit.
+                // Two values are enough — the cross product pairs them both
+                // ways, so it already builds a rise with `open` unmoved, which
+                // is the #3397 shape, and its mirror.
+                for strict in [open, open + 2] {
+                    for tris in [0usize, 3, 5] {
+                        for collapsed in [false, true] {
+                            for far in [false, true] {
+                                for alt in [None, Some(0usize), Some(3), Some(9)] {
+                                    for pre in [
+                                        PreVoid::NotTaken,
+                                        PreVoid::Failed,
+                                        PreVoid::Open(0),
+                                        PreVoid::Open(2),
+                                    ] {
+                                        out.push(HostRow {
+                                            model: "a.ifc".to_string(),
+                                            id: 1,
+                                            rep: rep.to_string(),
+                                            open,
+                                            strict,
+                                            tris,
+                                            collapsed,
+                                            far,
+                                            alt,
+                                            pre,
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -1318,19 +1563,35 @@ mod tests {
         // with `[0, 5]` the only one available is `5 -> 0`, which the
         // `r.tris == 0` clause always routes back to `worse_counts`.
         //
+        // `strict` carries two values per `open` — the count itself and one
+        // above it — so the sweep can build the #3397 shape: a doubled sheet is
+        // `strict` rising while `open` holds. Never below `open`, which is a row
+        // the walk cannot emit.
+        //
         // Two different counts, because saying "re-tessellation pairs" without
-        // saying which one is how this got misread: over the 768 x 768 sweep,
-        // 576 pairs are DETECTED as a re-tessellation and 78 of those LAND in
-        // the bucket. The 498-pair gap is the population `shrank_while_healing`
-        // exists to surface, and it is most of the class.
+        // saying which one is how this got misread: over the 1536 x 1536 sweep,
+        // 2304 pairs are DETECTED as a re-tessellation and 312 of those LAND in
+        // the bucket. The gap is the population `shrank_while_healing` exists to
+        // surface, and it is most of the class.
         //
         // Both are ASSERTED below rather than left in prose, which has paid for
-        // itself four times now. The pair was 576/351 until a collapse
+        // itself five times now. The pair was 576/351 until a collapse
         // disqualified the bucket, 288/234 until `far` stopped being gated,
-        // 1152/468 until #3366 made a no-void flip a reclassification, and
+        // 1152/468 until #3366 made a no-void flip a reclassification,
         // 1152/156 until `collapsed` moved into `open_is_comparable` and so
-        // began disqualifying the GOLDEN side too. Every drift was caught by
-        // the assertion on the commit that caused it, not by a reader later.
+        // began disqualifying the GOLDEN side too, and 576/78 until #3397
+        // doubled the variant set. Every drift was caught by the assertion on
+        // the commit that caused it, not by a reader later.
+        //
+        // BOTH scaled by exactly 4 at #3397, which is a property worth naming
+        // rather than a coincidence. `shrank_while_healing` never reads
+        // `strict`, so every old pair replicates into four. And a LANDING pair
+        // needs `r.open < g.open`, which over `open` in `[0, 3]` forces
+        // `g.open = 3, r.open = 0`; every strict combination that follows is a
+        // FALL, so the new arm cannot evict a landing. `checked` is the count
+        // that did not scale: 11232 x 4 would be 44928, and the 7488 missing
+        // pairs are the equal-`open` ones whose `strict` rose, which now need a
+        // bless. That is the arm doing its job inside this very sweep.
         //
         // Be precise about what that buys HERE. The DERIVED-TOTAL invariant
         // below never sees these pairs: they all hit the `requires_bless` skip,
@@ -1367,6 +1628,7 @@ mod tests {
                 checked += 1;
                 let (want, got) = (totals([g]), totals([r]));
                 assert!(got.open_edges <= want.open_edges, "open edges: {g:?} -> {r:?}");
+                assert!(got.strict_edges <= want.strict_edges, "strict edges: {g:?} -> {r:?}");
                 assert!(got.torn <= want.torn, "torn: {g:?} -> {r:?}");
                 assert!(got.collapsed <= want.collapsed, "collapsed: {g:?} -> {r:?}");
                 assert!(got.torn_solid <= want.torn_solid, "torn solid: {g:?} -> {r:?}");
@@ -1376,12 +1638,12 @@ mod tests {
         }
         // Guard against the loop vacuously skipping everything.
         assert!(checked > vs.len(), "only {checked} clean pairs of {}", vs.len() * vs.len());
-        assert_eq!(checked, 11232, "clean pairs swept");
+        assert_eq!(checked, 37440, "clean pairs swept");
         // The two counts the comment above quotes, asserted rather than
         // recorded. The gap between them is the whole reason
         // `shrank_while_healing` exists, so it must not drift unnoticed.
-        assert_eq!(detected, 576, "pairs DETECTED as a re-tessellation");
-        assert_eq!(landed, 78, "pairs that LAND in the retessellated bucket");
+        assert_eq!(detected, 2304, "pairs DETECTED as a re-tessellation");
+        assert_eq!(landed, 312, "pairs that LAND in the retessellated bucket");
     }
 
     #[test]
@@ -1463,6 +1725,7 @@ mod tests {
                 id: 42,
                 rep: "CSG".to_string(),
                 open: 7,
+                strict: 9,
                 tris: 300,
                 collapsed: true,
                 far: false,
@@ -1474,6 +1737,11 @@ mod tests {
                 id: 7,
                 rep: "SurfaceModel".to_string(),
                 open: 0,
+                // Watertight by the signed balance and torn by the strict rule:
+                // the row shape #3397 exists to make representable, so the
+                // serializer is pinned on it rather than only on `strict ==
+                // open`.
+                strict: 4,
                 tris: 0,
                 collapsed: false,
                 far: true,
@@ -1493,9 +1761,18 @@ mod tests {
 
     #[test]
     fn a_truncated_row_is_an_error_not_a_silently_short_golden() {
-        let err = parse("model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\na.ifc\t1\tCSG\t0\t0\t0\t0\n")
+        let header = "model\tid\trep\topen\ttris\tcoll\tfar\talt\tpre\tstrict\n";
+        let err = parse(&format!("{header}a.ifc\t1\tCSG\t0\t0\t0\t0\n"))
             .expect_err("a 7-column row must not parse");
-        assert!(err.contains("expected 9 columns"), "{err}");
+        assert!(err.contains("expected 10 columns"), "{err}");
+
+        // And a COMPLETE pre-#3397 row is a truncation too, not a row with an
+        // implied strict count. Defaulting it would fabricate a clean-looking
+        // host for every line of a stale golden, which is the one way this
+        // column could go dark across the whole corpus at once.
+        let old = parse(&format!("{header}a.ifc\t1\tCSG\t0\t12\t0\t0\t0\t-\n"))
+            .expect_err("a 9-column pre-#3397 row must not parse");
+        assert!(old.contains("expected 10 columns"), "{old}");
     }
 
     #[test]

--- a/rust/geometry/tests/manifests/watertightness_census.tsv
+++ b/rust/geometry/tests/manifests/watertightness_census.tsv
@@ -12,1174 +12,1177 @@
 # far:   1 if |coord| is past what f32 carries mm topology at (reported, not gated).
 # alt:   open edges under the alternate triangulator, or x if that pass failed.
 # pre:   open edges with no voids applied; x if that pass failed, - if not taken.
-model	id	rep	open	tris	coll	far	alt	pre
-ara3d/AC20-FZK-Haus.ifc	17040	SweptSolid	0	36	0	0	0	-
-ara3d/AC20-FZK-Haus.ifc	18698	SweptSolid	0	54	0	0	0	-
-ara3d/AC20-FZK-Haus.ifc	21966	SweptSolid	0	80	0	0	0	-
-ara3d/AC20-FZK-Haus.ifc	27421	SweptSolid	0	80	0	0	0	-
-ara3d/AC20-FZK-Haus.ifc	31470	SweptSolid	0	52	0	0	0	-
-ara3d/AC20-FZK-Haus.ifc	32407	SweptSolid	0	72	0	0	0	-
-ara3d/AC20-FZK-Haus.ifc	59290	SweptSolid	0	32	0	0	0	-
-ara3d/AC20-FZK-Haus.ifc	60012	Clipping	0	204	0	0	18	-
-ara3d/AC20-FZK-Haus.ifc	67828	Clipping	0	196	0	0	18	-
-ara3d/C20-Institute-Var-2.ifc	31190	SweptSolid	0	320	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	35819	SweptSolid	0	324	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	40505	SweptSolid	0	600	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	47404	SweptSolid	0	116	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	50078	SweptSolid	0	130	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	52075	SweptSolid	0	52	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	55353	SweptSolid	0	42	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	56404	SweptSolid	0	40	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	57708	SweptSolid	0	40	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	72946	SweptSolid	0	80	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	81755	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	82662	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	83555	SweptSolid	0	320	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	87784	SweptSolid	0	70	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	90339	SweptSolid	0	320	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	94567	SweptSolid	0	324	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	99022	SweptSolid	0	100	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	100667	SweptSolid	0	72	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	101958	SweptSolid	0	120	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	104309	SweptSolid	0	64	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	107811	SweptSolid	0	328	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	112277	SweptSolid	0	36	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	113099	SweptSolid	0	42	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	114155	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	114727	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	125284	SweptSolid	0	80	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	135395	SweptSolid	0	320	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	139845	SweptSolid	0	324	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	144069	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	144635	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	145201	SweptSolid	0	948	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	154762	SweptSolid	0	116	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	157112	SweptSolid	0	120	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	159462	SweptSolid	0	192	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	165435	SweptSolid	0	34	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	166266	SweptSolid	0	40	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	167338	SweptSolid	0	40	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	178044	SweptSolid	0	64	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	188155	SweptSolid	0	320	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	192605	SweptSolid	0	324	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	196829	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	197395	SweptSolid	0	32	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	197961	SweptSolid	0	948	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	207522	SweptSolid	0	116	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	209872	SweptSolid	0	120	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	212222	SweptSolid	0	182	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	218661	SweptSolid	0	40	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	219733	SweptSolid	0	40	0	0	0	-
-ara3d/C20-Institute-Var-2.ifc	220884	SweptSolid	0	64	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	26448	SweptSolid	0	72	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	26635	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	30660	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	30826	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	31022	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	40974	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	52867	SweptSolid	0	34	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	53112	SweptSolid	0	34	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	61530	SweptSolid	0	48	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	67415	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	67562	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	67758	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	77712	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	89640	SweptSolid	0	34	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	89885	SweptSolid	0	34	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	90210	SweptSolid	0	48	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	99281	SweptSolid	0	72	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	100158	SweptSolid	0	168	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	100207	SweptSolid	0	186	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	106167	Clipping	0	48	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	106259	SweptSolid	0	40	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	106951	SweptSolid	0	100	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	136983	SweptSolid	0	80	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	137547	Clipping	0	60	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	138037	Clipping	12	301	1	0	21	0
-ara3d/FM_ARC_DigitalHub.ifc	138279	SweptSolid	0	60	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	138767	Clipping	0	80	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	139288	Clipping	9	300	1	0	9	0
-ara3d/FM_ARC_DigitalHub.ifc	139605	Clipping	9	300	1	0	9	0
-ara3d/FM_ARC_DigitalHub.ifc	139864	Clipping	0	184	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	139985	Clipping	9	300	1	0	18	0
-ara3d/FM_ARC_DigitalHub.ifc	140227	SweptSolid	0	184	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	140337	SweptSolid	0	496	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	146777	SweptSolid	0	222	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	149094	SweptSolid	0	668	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	155733	SweptSolid	0	282	0	0	11	-
-ara3d/FM_ARC_DigitalHub.ifc	187843	SweptSolid	0	172	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	188186	SweptSolid	0	32	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	188235	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	188333	SweptSolid	0	74	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	188424	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	196863	SweptSolid	0	112	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	196912	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	196961	SweptSolid	0	132	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	197010	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	197353	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	197794	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	200204	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	200253	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	200449	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	200645	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	216340	SweptSolid	0	68	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	216561	SweptSolid	0	44	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	216762	SweptSolid	0	28	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	217867	SweptSolid	0	72	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	218038	SweptSolid	0	32	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	218227	SweptSolid	0	72	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	218398	SweptSolid	0	32	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	218587	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	218718	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	219094	SweptSolid	0	52	0	0	0	-
-ara3d/FM_ARC_DigitalHub.ifc	219225	SweptSolid	0	52	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	17040	SweptSolid	0	36	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	18698	SweptSolid	0	54	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	21966	SweptSolid	0	80	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	27421	SweptSolid	0	80	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	31470	SweptSolid	0	52	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	32407	SweptSolid	0	72	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	59290	SweptSolid	0	32	0	0	0	-
-ara3d/ISSUE_005_haus.ifc	60012	Clipping	0	204	0	0	18	-
-ara3d/ISSUE_005_haus.ifc	67828	Clipping	0	196	0	0	18	-
-ara3d/ISSUE_126_model.ifc	40983	SweptSolid	0	52	0	0	0	-
-ara3d/ISSUE_126_model.ifc	43236	SweptSolid	0	20	0	0	0	-
-ara3d/ISSUE_126_model.ifc	49197	SweptSolid	0	20	0	0	0	-
-ara3d/ISSUE_126_model.ifc	49964	SweptSolid	0	20	0	0	0	-
-ara3d/ISSUE_126_model.ifc	50658	SweptSolid	0	54	0	0	0	-
-ara3d/ISSUE_126_model.ifc	50766	SweptSolid	0	58	0	0	0	-
-ara3d/ISSUE_126_model.ifc	52352	SweptSolid	0	34	0	0	0	-
-ara3d/ISSUE_126_model.ifc	56758	SweptSolid	0	30	0	0	0	-
-ara3d/ISSUE_126_model.ifc	73237	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_126_model.ifc	73349	SweptSolid	0	216	0	0	0	-
-ara3d/ISSUE_126_model.ifc	77438	SweptSolid	0	80	0	0	0	-
-ara3d/ISSUE_126_model.ifc	78232	SweptSolid	0	52	0	0	0	-
-ara3d/ISSUE_126_model.ifc	78975	SweptSolid	0	170	0	0	0	-
-ara3d/ISSUE_126_model.ifc	82108	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_126_model.ifc	82925	SweptSolid	0	34	0	0	0	-
-ara3d/ISSUE_126_model.ifc	83323	SweptSolid	0	66	0	0	0	-
-ara3d/ISSUE_126_model.ifc	83694	SweptSolid	0	20	0	0	0	-
-ara3d/ISSUE_126_model.ifc	84442	SweptSolid	0	34	0	0	0	-
-ara3d/ISSUE_126_model.ifc	86446	SweptSolid	0	54	0	0	0	-
-ara3d/ISSUE_126_model.ifc	86609	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_126_model.ifc	98282	SweptSolid	24	130	0	0	24	0
-ara3d/ISSUE_126_model.ifc	100504	SweptSolid	0	50	0	0	0	-
-ara3d/ISSUE_126_model.ifc	111997	SweptSolid	27	51	0	0	27	0
-ara3d/ISSUE_126_model.ifc	131771	SweptSolid	0	96	0	0	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	6891	Clipping	91	345	0	1	56	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	1119	1157	0	1	931	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8434	Clipping	0	44	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8756	Clipping	4	28	0	1	3	3
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	723	824	1	1	717	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	11115	Clipping	21	167	0	1	9	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	2106	2332	1	1	1811	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	260	1536	0	1	144	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	34385	SweptSolid	493	725	1	1	571	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	36735	SweptSolid	458	882	0	1	375	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57084	SweptSolid	54	109	0	1	52	12
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57776	SweptSolid	57	111	0	1	41	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57944	Clipping	23	99	0	1	23	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	58297	Clipping	67	221	0	1	19	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59111	SweptSolid	1723	1764	0	1	2008	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59957	SweptSolid	37	55	0	1	37	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60118	SweptSolid	17	123	1	1	17	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60344	SweptSolid	0	36	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	61300	Clipping	743	1429	1	1	768	3
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63146	Clipping	20	106	0	1	23	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63466	Clipping	16	164	0	1	22	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63721	SweptSolid	6	22	0	1	6	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68263	Clipping	15	71	0	1	15	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68943	Clipping	26	162	0	1	29	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69569	Clipping	7	43	0	1	7	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69961	Clipping	21	119	0	1	21	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81223	Clipping	17	135	0	1	20	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81562	Clipping	43	181	0	1	43	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81869	Clipping	0	28	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	83043	Clipping	13	41	0	1	13	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138693	Clipping	31	91	0	1	31	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138919	Clipping	11	71	0	1	11	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139190	SweptSolid	22	144	0	1	22	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139364	Clipping	35	152	0	1	35	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139571	SweptSolid	38	276	0	1	38	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	141060	SweptSolid	67	99	0	1	41	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145270	SweptSolid	46	96	0	1	50	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145756	SweptSolid	13	101	0	1	13	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145897	SweptSolid	32	70	0	1	32	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148665	SweptSolid	519	1008	0	1	388	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148864	SweptSolid	3	97	0	1	3	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149277	SweptSolid	356	562	0	1	312	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149280	SweptSolid	214	993	0	1	284	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196139	SweptSolid	148	174	0	1	129	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196326	SweptSolid	92	83	0	1	101	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	233296	SweptSolid	0	46	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	244479	SweptSolid	403	639	0	1	340	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247051	Clipping	29	164	1	1	29	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247203	Clipping	18	88	0	1	18	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247726	Clipping	38	180	0	1	38	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247953	Clipping	37	165	0	1	38	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	295370	SweptSolid	622	473	1	1	515	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	296868	SweptSolid	621	572	1	1	553	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299369	SweptSolid	0	32	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299638	SweptSolid	10	10	0	1	10	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	316547	SweptSolid	279	649	0	1	250	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332017	SweptSolid	222	387	0	1	129	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332205	SweptSolid	63	263	0	1	3	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	333923	SweptSolid	1326	1347	1	1	1209	6
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	335218	SweptSolid	1110	1095	1	1	1334	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	337691	SweptSolid	27	93	0	1	27	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359157	SweptSolid	0	52	0	1	6	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359305	SweptSolid	20	60	0	1	12	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359480	SweptSolid	18	30	0	1	18	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359627	SweptSolid	0	52	0	1	6	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359926	SweptSolid	0	52	0	1	6	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360075	SweptSolid	34	44	0	1	34	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360237	SweptSolid	57	79	0	1	57	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360384	SweptSolid	7	43	0	1	7	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360680	SweptSolid	0	32	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360821	SweptSolid	0	32	0	1	0	-
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360966	SweptSolid	10	36	0	1	10	0
-ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	361107	SweptSolid	3	35	0	1	3	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4380	SweptSolid	6	94	0	0	0	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4630	SweptSolid	0	38	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4732	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4834	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4940	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	6012	Clipping	6	144	0	0	6	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	8511	SweptSolid	0	36	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27148	SweptSolid	3	117	1	0	0	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27562	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27770	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	28290	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	34099	SweptSolid	35	259	0	0	30	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	37094	SweptSolid	0	64	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46565	SweptSolid	0	100	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46667	SweptSolid	0	32	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46769	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46871	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	47807	SweptSolid	0	168	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	49773	SweptSolid	0	36	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63308	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63516	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	64036	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	76544	SweptSolid	0	60	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78513	SweptSolid	0	156	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78918	Clipping	12	106	0	0	0	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79070	Clipping	0	50	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79197	Clipping	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79969	AdvancedBrep	0	80	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	80101	Clipping	0	80	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	81274	Clipping	12	140	0	0	12	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	83292	Clipping	0	52	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87331	Clipping	0	132	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87839	Clipping	0	44	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88116	Clipping	0	46	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88776	Clipping	0	76	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	92201	Clipping	17	141	0	0	20	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	94199	Clipping	0	66	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95188	Clipping	6	96	0	0	6	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95332	Clipping	0	44	0	0	3	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95459	Clipping	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95605	Clipping	0	80	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	96778	Clipping	12	132	0	0	12	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	98786	Clipping	0	48	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100558	Clipping	0	44	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100835	Clipping	0	46	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	101495	Clipping	0	76	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	103251	Clipping	0	78	1	0	3	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	105519	SweptSolid	0	156	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119816	SweptSolid	6	62	0	0	0	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119924	SweptSolid	3	63	1	0	0	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120028	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120132	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120448	SweptSolid	0	96	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	121490	SweptSolid	0	60	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	122695	SweptSolid	12	144	1	0	0	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123117	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123329	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123859	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	124711	SweptSolid	0	204	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	127658	SweptSolid	0	54	1	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128193	SweptSolid	3	97	1	0	0	0
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128297	SweptSolid	0	32	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128401	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128505	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	129459	SweptSolid	0	120	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	131443	SweptSolid	0	36	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132587	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132799	SweptSolid	0	28	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	133329	SweptSolid	0	44	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	134472	SweptSolid	0	60	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	135938	SweptSolid	0	128	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	137886	SweptSolid	0	112	0	0	0	-
-ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	139140	SweptSolid	0	36	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	61	SweptSolid	0	114	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	528	SweptSolid	0	64	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	733	SweptSolid	0	32	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	880	SweptSolid	0	64	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1085	SweptSolid	0	72	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1290	SweptSolid	0	58	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1512	SweptSolid	0	36	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1812	SweptSolid	0	58	0	0	0	-
-ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	2017	SweptSolid	0	68	0	0	0	-
-ara3d/IfcOpenHouse_IFC4.ifc	40	SweptSolid	0	56	0	0	0	-
-ara3d/IfcOpenHouse_IFC4.ifc	268	Clipping	0	40	0	0	0	-
-ara3d/IfcOpenHouse_IFC4.ifc	281	Clipping	0	42	0	0	0	-
-ara3d/Office_A_20110811.ifc	65	SweptSolid	0	92	0	0	0	-
-ara3d/Office_A_20110811.ifc	71	SweptSolid	0	308	0	0	0	-
-ara3d/Office_A_20110811.ifc	76	SweptSolid	0	140	0	0	0	-
-ara3d/Office_A_20110811.ifc	81	SweptSolid	0	312	0	0	0	-
-ara3d/Office_A_20110811.ifc	82	SweptSolid	0	32	0	0	0	-
-ara3d/Office_A_20110811.ifc	83	SweptSolid	0	292	0	0	0	-
-ara3d/Office_A_20110811.ifc	88	SweptSolid	0	60	0	0	0	-
-ara3d/Office_A_20110811.ifc	97	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	100	SweptSolid	0	152	0	0	0	-
-ara3d/Office_A_20110811.ifc	101	SweptSolid	0	164	0	0	0	-
-ara3d/Office_A_20110811.ifc	102	SweptSolid	0	140	0	0	0	-
-ara3d/Office_A_20110811.ifc	104	SweptSolid	0	92	0	0	0	-
-ara3d/Office_A_20110811.ifc	105	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	106	SweptSolid	0	172	0	0	0	-
-ara3d/Office_A_20110811.ifc	130	SweptSolid	0	76	0	0	0	-
-ara3d/Office_A_20110811.ifc	134	SweptSolid	0	92	0	0	0	-
-ara3d/Office_A_20110811.ifc	139	SweptSolid	0	76	0	0	0	-
-ara3d/Office_A_20110811.ifc	143	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	156	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	161	SweptSolid	0	60	0	0	0	-
-ara3d/Office_A_20110811.ifc	164	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	165	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	166	SweptSolid	0	100	0	0	0	-
-ara3d/Office_A_20110811.ifc	175	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	178	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	179	SweptSolid	0	60	0	0	0	-
-ara3d/Office_A_20110811.ifc	183	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	185	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	188	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	191	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	193	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	195	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	196	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	197	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	198	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	223	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	224	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	227	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	228	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	234	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	238	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	239	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	242	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	246	SweptSolid	0	60	0	0	0	-
-ara3d/Office_A_20110811.ifc	247	SweptSolid	0	44	0	0	0	-
-ara3d/Office_A_20110811.ifc	248	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	277	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	282	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	288	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	307	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	314	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	326	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	351	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	354	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	361	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	363	SweptSolid	0	28	0	0	0	-
-ara3d/Office_A_20110811.ifc	364	SweptSolid	0	180	0	0	0	-
-ara3d/Office_A_20110811.ifc	417	SweptSolid	0	122	0	0	0	-
-ara3d/Office_A_20110811.ifc	429	SweptSolid	0	32	0	0	0	-
-ara3d/Office_A_20110811.ifc	607	SweptSolid	0	122	0	0	0	-
-ara3d/Office_A_20110811.ifc	684	SweptSolid	0	122	0	0	0	-
-ara3d/Office_A_20110811.ifc	1028	SweptSolid	0	678	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	4172	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	5434	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	6155	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	14416	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	35182	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	36567	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	43442	SweptSolid	0	80	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	48600	SweptSolid	0	44	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	49149	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	89022	unknown	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	89141	SweptSolid	0	232	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	89264	SweptSolid	0	232	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	89384	SweptSolid	0	232	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	89504	SweptSolid	0	232	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	89624	SweptSolid	0	232	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	90617	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	91291	CSG	3	46	1	0	3	6
-ara3d/S_Office_Integrated Design Archi.ifc	91968	CSG	0	120	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	92642	CSG	12	68	1	0	13	12
-ara3d/S_Office_Integrated Design Archi.ifc	93316	CSG	0	64	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	93990	CSG	0	108	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	94664	CSG	4	160	0	0	4	4
-ara3d/S_Office_Integrated Design Archi.ifc	99549	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	368885	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	414959	SweptSolid	0	40	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	415490	unknown	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	426329	CSG	0	496	0	0	6	-
-ara3d/S_Office_Integrated Design Archi.ifc	437170	CSG	6	380	0	0	0	6
-ara3d/S_Office_Integrated Design Archi.ifc	448019	CSG	90	1034	0	0	89	164
-ara3d/S_Office_Integrated Design Archi.ifc	458857	CSG	78	1062	0	0	80	78
-ara3d/S_Office_Integrated Design Archi.ifc	469706	CSG	51	1077	0	0	61	51
-ara3d/S_Office_Integrated Design Archi.ifc	489748	SweptSolid	0	40	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	495955	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	496628	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	503263	unknown	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	503302	SweptSolid	0	172	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	503345	SweptSolid	0	172	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	503385	SweptSolid	0	172	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	503425	SweptSolid	0	172	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	503482	SweptSolid	0	172	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	543063	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	639833	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	670546	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	701210	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	704150	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	719862	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	722750	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	723436	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	724125	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	724811	CSG	3	81	0	0	3	3
-ara3d/S_Office_Integrated Design Archi.ifc	725497	CSG	7	185	0	0	7	12
-ara3d/S_Office_Integrated Design Archi.ifc	726183	CSG	0	212	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	726869	CSG	0	212	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	730647	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	753197	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	763256	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	763898	CSG	0	122	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	764543	CSG	0	124	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	765185	CSG	0	118	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	765827	CSG	0	64	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	766469	CSG	0	112	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	767111	CSG	0	108	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	767445	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	768209	CSG	0	224	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	768976	CSG	0	232	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	769740	CSG	0	280	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	770504	CSG	0	100	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	771268	CSG	0	196	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	772032	CSG	0	196	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	803290	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	832090	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	832800	CSG	0	224	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	833513	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	834223	CSG	0	200	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	834933	CSG	0	100	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	835643	CSG	0	196	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	836353	CSG	0	196	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	857637	unknown	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	857676	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	857719	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	857759	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	857799	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	857839	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	866873	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	867376	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	868018	CSG	0	122	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	868663	CSG	0	124	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	869305	CSG	0	118	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	869947	CSG	0	64	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	870589	CSG	0	108	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	871231	CSG	0	108	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	902095	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	903633	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	904243	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	904620	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	905288	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	905959	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	906627	CSG	6	82	0	0	6	6
-ara3d/S_Office_Integrated Design Archi.ifc	907295	CSG	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	907963	CSG	0	212	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	908631	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	909123	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	909362	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	909877	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	910230	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	910609	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	912366	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	918017	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	918355	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	929798	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	930704	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	951036	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	951723	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	952413	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	953100	CSG	3	137	1	0	3	3
-ara3d/S_Office_Integrated Design Archi.ifc	953787	CSG	0	116	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	954474	CSG	13	225	0	0	4	7
-ara3d/S_Office_Integrated Design Archi.ifc	955161	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	955764	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	969935	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	970645	CSG	0	224	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	971358	CSG	0	216	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	972068	CSG	0	200	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	972778	CSG	0	100	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	973488	CSG	0	196	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	974198	CSG	0	196	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	974760	unknown	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	974799	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	974842	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	974882	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	974922	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	974962	SweptSolid	0	156	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	976762	Curve2D	0	0	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	977404	CSG	0	120	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	978049	CSG	0	120	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	978691	CSG	0	112	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	979333	CSG	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	979975	CSG	0	114	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	980617	CSG	0	108	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	986525	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	987406	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	997903	SweptSolid	0	36	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	998325	SweptSolid	0	52	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	1001521	SweptSolid	0	32	0	0	0	-
-ara3d/S_Office_Integrated Design Archi.ifc	1001906	SweptSolid	0	32	0	0	0	-
-ara3d/advanced_model.ifc	552611	SweptSolid	0	158	0	0	0	-
-ara3d/advanced_model.ifc	552761	SweptSolid	0	168	0	0	0	-
-ara3d/advanced_model.ifc	552894	SweptSolid	0	104	0	0	0	-
-ara3d/advanced_model.ifc	553010	Clipping	0	82	0	0	0	-
-ara3d/advanced_model.ifc	555082	SweptSolid	0	88	0	0	0	-
-ara3d/advanced_model.ifc	555224	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	555268	SweptSolid	0	124	0	0	0	-
-ara3d/advanced_model.ifc	555433	SweptSolid	0	172	0	0	0	-
-ara3d/advanced_model.ifc	555613	Clipping	0	90	0	0	0	-
-ara3d/advanced_model.ifc	555770	Clipping	0	56	0	0	0	-
-ara3d/advanced_model.ifc	555985	SweptSolid	0	184	0	0	0	-
-ara3d/advanced_model.ifc	556264	SweptSolid	0	192	0	0	0	-
-ara3d/advanced_model.ifc	559034	SweptSolid	0	88	0	0	0	-
-ara3d/advanced_model.ifc	559171	SweptSolid	0	92	0	0	0	-
-ara3d/advanced_model.ifc	559270	SweptSolid	0	44	0	0	0	-
-ara3d/advanced_model.ifc	559314	SweptSolid	0	52	0	0	0	-
-ara3d/advanced_model.ifc	561445	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	563598	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	563980	SweptSolid	0	156	0	0	0	-
-ara3d/advanced_model.ifc	612062	SweptSolid	0	92	0	0	0	-
-ara3d/advanced_model.ifc	612150	SweptSolid	0	124	0	0	0	-
-ara3d/advanced_model.ifc	612315	SweptSolid	0	128	0	0	0	-
-ara3d/advanced_model.ifc	612436	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	632450	Clipping	0	126	0	0	0	-
-ara3d/advanced_model.ifc	636693	SweptSolid	0	92	0	0	0	-
-ara3d/advanced_model.ifc	636774	SweptSolid	0	44	0	0	0	-
-ara3d/advanced_model.ifc	636818	SweptSolid	0	52	0	0	0	-
-ara3d/advanced_model.ifc	636995	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	637271	SweptSolid	0	76	0	0	0	-
-ara3d/advanced_model.ifc	637377	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	637697	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	637785	SweptSolid	0	60	0	0	0	-
-ara3d/advanced_model.ifc	637873	SweptSolid	0	44	0	0	0	-
-ara3d/advanced_model.ifc	637917	SweptSolid	0	44	0	0	0	-
-ara3d/advanced_model.ifc	646621	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	646665	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	650657	SweptSolid	0	68	0	0	0	-
-ara3d/advanced_model.ifc	650761	SweptSolid	0	76	0	0	0	-
-ara3d/advanced_model.ifc	650893	SweptSolid	0	56	0	0	0	-
-ara3d/advanced_model.ifc	651604	SweptSolid	0	76	0	0	0	-
-ara3d/advanced_model.ifc	674148	SweptSolid	0	76	0	0	0	-
-ara3d/advanced_model.ifc	679345	SweptSolid	0	140	0	0	0	-
-ara3d/advanced_model.ifc	694436	SweptSolid	0	92	0	0	0	-
-ara3d/advanced_model.ifc	737480	SweptSolid	0	92	0	0	0	-
-ara3d/advanced_model.ifc	737716	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	737804	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	737892	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	737936	SweptSolid	0	156	0	0	0	-
-ara3d/advanced_model.ifc	738205	SweptSolid	0	92	0	0	0	-
-ara3d/advanced_model.ifc	738433	SweptSolid	0	1860	0	0	0	-
-ara3d/advanced_model.ifc	739014	SweptSolid	0	1832	0	0	0	-
-ara3d/advanced_model.ifc	797099	SweptSolid	0	192	0	0	0	-
-ara3d/advanced_model.ifc	797102	SweptSolid	0	192	0	0	0	-
-ara3d/advanced_model.ifc	797108	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	797111	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	797114	SweptSolid	0	464	0	0	0	-
-ara3d/advanced_model.ifc	797120	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	797123	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	797126	SweptSolid	0	604	0	0	0	-
-ara3d/advanced_model.ifc	797129	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	798479	SweptSolid	0	612	0	0	0	-
-ara3d/advanced_model.ifc	798926	SweptSolid	0	2900	0	0	0	-
-ara3d/advanced_model.ifc	799400	SweptSolid	0	604	0	0	0	-
-ara3d/advanced_model.ifc	799566	SweptSolid	0	604	0	0	0	-
-ara3d/advanced_model.ifc	799732	SweptSolid	0	604	0	0	0	-
-ara3d/advanced_model.ifc	800371	SweptSolid	0	604	0	0	0	-
-ara3d/advanced_model.ifc	800374	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	800377	SweptSolid	0	464	0	0	0	-
-ara3d/advanced_model.ifc	800380	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	800383	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	800389	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	800395	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	800398	SweptSolid	0	308	0	0	0	-
-ara3d/advanced_model.ifc	800410	SweptSolid	0	340	0	0	0	-
-ara3d/advanced_model.ifc	800413	SweptSolid	0	160	0	0	0	-
-ara3d/advanced_model.ifc	800416	SweptSolid	0	372	0	0	0	-
-ara3d/advanced_model.ifc	800422	SweptSolid	0	324	0	0	0	-
-ara3d/advanced_model.ifc	801940	SweptSolid	0	44	0	0	0	-
-ara3d/advanced_model.ifc	801984	SweptSolid	0	44	0	0	0	-
-ara3d/advanced_model.ifc	806064	SweptSolid	0	28	0	0	0	-
-ara3d/advanced_model.ifc	806149	SweptSolid	0	508	0	0	0	-
-ara3d/advanced_model.ifc	815104	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	94	SweptSolid	0	232	0	0	0	-
-ara3d/dental_clinic.ifc	95	SweptSolid	0	172	0	0	0	-
-ara3d/dental_clinic.ifc	101	SweptSolid	0	128	0	0	0	-
-ara3d/dental_clinic.ifc	146	SweptSolid	0	192	0	0	0	-
-ara3d/dental_clinic.ifc	156	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	157	SweptSolid	0	92	0	0	0	-
-ara3d/dental_clinic.ifc	159	SweptSolid	0	108	0	0	0	-
-ara3d/dental_clinic.ifc	163	SweptSolid	0	128	0	0	0	-
-ara3d/dental_clinic.ifc	166	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	167	Clipping	10	192	0	0	10	0
-ara3d/dental_clinic.ifc	169	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	175	Clipping	0	168	0	0	0	-
-ara3d/dental_clinic.ifc	180	Clipping	0	168	0	0	0	-
-ara3d/dental_clinic.ifc	184	SweptSolid	0	92	0	0	0	-
-ara3d/dental_clinic.ifc	195	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	196	SweptSolid	0	64	0	0	0	-
-ara3d/dental_clinic.ifc	202	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	203	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	205	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	206	SweptSolid	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	207	Clipping	8	278	0	0	8	0
-ara3d/dental_clinic.ifc	212	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	213	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	214	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	215	SweptSolid	0	68	0	0	0	-
-ara3d/dental_clinic.ifc	216	SweptSolid	0	92	0	0	0	-
-ara3d/dental_clinic.ifc	217	SweptSolid	0	26	0	0	0	-
-ara3d/dental_clinic.ifc	218	SweptSolid	0	20	0	0	0	-
-ara3d/dental_clinic.ifc	231	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	232	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	233	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	234	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	235	SweptSolid	0	112	0	0	0	-
-ara3d/dental_clinic.ifc	236	SweptSolid	0	72	0	0	0	-
-ara3d/dental_clinic.ifc	248	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	249	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	262	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	263	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	264	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	265	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	266	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	269	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	270	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	271	Clipping	0	72	0	0	0	-
-ara3d/dental_clinic.ifc	272	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	273	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	284	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	285	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	286	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	287	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	288	SweptSolid	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	297	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	298	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	299	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	300	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	301	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	302	SweptSolid	0	72	0	0	0	-
-ara3d/dental_clinic.ifc	303	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	319	Clipping	0	38	0	0	0	-
-ara3d/dental_clinic.ifc	320	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	321	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	322	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	323	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	324	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	325	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	326	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	327	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	329	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	349	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	350	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	351	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	352	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	353	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	354	SweptSolid	0	60	0	0	0	-
-ara3d/dental_clinic.ifc	355	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	356	SweptSolid	0	52	0	0	0	-
-ara3d/dental_clinic.ifc	357	SweptSolid	0	20	0	0	0	-
-ara3d/dental_clinic.ifc	360	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	361	SweptSolid	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	375	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	376	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	377	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	378	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	379	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	380	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	381	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	424	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	425	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	426	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	427	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	428	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	429	SweptSolid	0	104	0	0	0	-
-ara3d/dental_clinic.ifc	430	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	431	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	432	SweptSolid	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	434	SweptSolid	0	12	0	0	0	-
-ara3d/dental_clinic.ifc	437	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	438	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	439	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	475	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	481	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	482	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	483	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	484	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	488	SweptSolid	0	20	0	0	0	-
-ara3d/dental_clinic.ifc	490	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	491	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	507	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	522	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	523	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	524	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	525	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	526	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	527	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	528	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	529	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	530	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	531	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	532	Clipping	0	22	0	0	0	-
-ara3d/dental_clinic.ifc	542	Clipping	0	22	0	0	0	-
-ara3d/dental_clinic.ifc	545	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	584	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	590	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	591	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	592	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	593	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	594	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	595	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	596	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	597	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	598	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	599	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	600	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	601	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	627	SweptSolid	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	628	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	675	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	686	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	696	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	697	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	698	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	699	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	700	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	701	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	702	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	703	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	704	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	736	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	804	SweptSolid	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	825	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	827	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	828	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	829	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	830	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	831	Clipping	0	64	0	0	0	-
-ara3d/dental_clinic.ifc	872	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	931	SweptSolid	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	964	Clipping	0	30	0	0	0	-
-ara3d/dental_clinic.ifc	965	Clipping	0	30	0	0	0	-
-ara3d/dental_clinic.ifc	966	Clipping	0	30	0	0	0	-
-ara3d/dental_clinic.ifc	973	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	974	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	975	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	976	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	977	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	978	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	979	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	980	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	981	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	982	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	983	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	984	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	985	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	986	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	987	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	988	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	989	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	990	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	991	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	992	SweptSolid	0	54	0	0	0	-
-ara3d/dental_clinic.ifc	993	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	994	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	995	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	996	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	997	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	998	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	999	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1003	Clipping	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1022	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1085	Clipping	0	32	0	0	0	-
-ara3d/dental_clinic.ifc	1093	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1094	SweptSolid	0	36	0	0	0	-
-ara3d/dental_clinic.ifc	1096	SweptSolid	0	36	0	0	0	-
-ara3d/dental_clinic.ifc	1183	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1194	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1195	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1242	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1252	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1253	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1310	SweptSolid	0	164	0	0	0	-
-ara3d/dental_clinic.ifc	1311	Clipping	10	80	0	0	10	0
-ara3d/dental_clinic.ifc	1314	SweptSolid	0	58	0	0	0	-
-ara3d/dental_clinic.ifc	1331	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	1643	Clipping	0	30	0	0	0	-
-ara3d/dental_clinic.ifc	1673	Clipping	9	32	1	0	9	0
-ara3d/dental_clinic.ifc	1757	Clipping	3	28	1	0	3	0
-ara3d/dental_clinic.ifc	1831	SweptSolid	0	24	0	0	0	-
-ara3d/dental_clinic.ifc	1832	SweptSolid	0	24	0	0	0	-
-ara3d/dental_clinic.ifc	2093	SweptSolid	0	28	0	0	0	-
-ara3d/dental_clinic.ifc	2268	SweptSolid	0	48	0	0	0	-
-ara3d/dental_clinic.ifc	2269	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2270	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2275	SweptSolid	0	64	0	0	0	-
-ara3d/dental_clinic.ifc	2276	SweptSolid	0	76	0	0	0	-
-ara3d/dental_clinic.ifc	2278	SweptSolid	0	72	0	0	0	-
-ara3d/dental_clinic.ifc	2279	SweptSolid	0	68	0	0	0	-
-ara3d/dental_clinic.ifc	2280	SweptSolid	0	68	0	0	0	-
-ara3d/dental_clinic.ifc	2285	SweptSolid	0	548	0	0	0	-
-ara3d/dental_clinic.ifc	2286	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2287	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2288	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2289	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2290	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2291	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2292	SweptSolid	19	305	1	0	6	0
-ara3d/dental_clinic.ifc	2293	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2294	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2295	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2296	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2297	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2298	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2299	SweptSolid	0	44	0	0	0	-
-ara3d/dental_clinic.ifc	2300	SweptSolid	0	64	0	0	0	-
-ara3d/dental_clinic.ifc	2301	SweptSolid	6	634	0	0	6	0
-ara3d/dental_clinic.ifc	2302	SweptSolid	7	366	1	0	7	0
-ara3d/dental_clinic.ifc	2304	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2305	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2306	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2307	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2308	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2309	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2310	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2311	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2312	SweptSolid	0	56	0	0	0	-
-ara3d/dental_clinic.ifc	2313	SweptSolid	0	56	0	0	0	-
-ara3d/duplex.ifc	3797	SweptSolid	0	48	0	0	0	-
-ara3d/duplex.ifc	3999	SweptSolid	0	48	0	0	0	-
-ara3d/duplex.ifc	4043	SweptSolid	0	48	0	0	0	-
-ara3d/duplex.ifc	4087	SweptSolid	0	48	0	0	0	-
-ara3d/duplex.ifc	4219	SweptSolid	0	28	0	0	0	-
-ara3d/duplex.ifc	4508	SweptSolid	0	28	0	0	0	-
-ara3d/duplex.ifc	5448	SweptSolid	0	142	0	0	0	-
-ara3d/duplex.ifc	5498	SweptSolid	0	218	0	0	0	-
-ara3d/duplex.ifc	5548	SweptSolid	0	164	0	0	0	-
-ara3d/duplex.ifc	5598	SweptSolid	0	226	0	0	0	-
-ara3d/duplex.ifc	5642	SweptSolid	0	32	0	0	0	-
-ara3d/duplex.ifc	5687	SweptSolid	0	28	0	0	0	-
-ara3d/duplex.ifc	5731	SweptSolid	0	28	0	0	0	-
-ara3d/duplex.ifc	5903	SweptSolid	0	32	0	0	0	-
-ara3d/duplex.ifc	5948	SweptSolid	0	28	0	0	0	-
-ara3d/duplex.ifc	5992	SweptSolid	0	28	0	0	0	-
-ara3d/duplex.ifc	12574	SurfaceModel	89	292	0	0	89	70
-ara3d/duplex.ifc	12976	SurfaceModel	84	292	0	0	85	70
-ara3d/duplex.ifc	13331	SurfaceModel	89	292	0	0	89	70
-ara3d/duplex.ifc	13685	SurfaceModel	84	292	0	0	85	70
-ara3d/duplex.ifc	14040	SurfaceModel	89	292	0	0	89	70
-ara3d/duplex.ifc	14394	SurfaceModel	85	292	0	0	86	70
-ara3d/duplex.ifc	14749	SurfaceModel	89	292	0	0	89	70
-ara3d/duplex.ifc	15103	SurfaceModel	85	292	0	0	86	70
-ara3d/duplex.ifc	16261	SweptSolid	0	68	0	0	0	-
-ara3d/duplex.ifc	16802	SweptSolid	3	727	0	0	3	0
-ara3d/duplex.ifc	22475	unknown	0	0	0	0	0	-
-ara3d/duplex.ifc	22492	SweptSolid	0	60	0	0	0	-
-ara3d/duplex.ifc	35199	SweptSolid	0	28	0	0	0	-
-ara3d/duplex.ifc	35357	SweptSolid	0	28	0	0	0	-
-ara3d/schependomlaan.ifc	46535	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	49281	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	52348	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	72010	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	76629	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	80335	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	99074	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	101868	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	112392	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	115669	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	119854	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	125502	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	133655	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	136076	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	140907	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	143594	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	154792	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	159728	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	163917	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	169275	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	171696	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	178863	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	186163	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	188256	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	263912	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	270253	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	271891	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	311100	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	313863	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	315576	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	325984	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	338352	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	340160	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	345463	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	368479	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	401470	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	404402	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	409878	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	411995	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	415563	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	422700	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	424453	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	426206	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	435307	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	472665	SweptSolid	0	80	0	0	0	-
-ara3d/schependomlaan.ifc	534371	SweptSolid	0	12	0	0	0	-
-ara3d/schependomlaan.ifc	558010	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	562146	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	597457	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	605031	SweptSolid	0	40	0	0	0	-
-ara3d/schependomlaan.ifc	618431	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	640164	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	643860	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	668602	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	711509	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	717596	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	753581	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	766683	SweptSolid	0	12	0	0	0	-
-ara3d/schependomlaan.ifc	778605	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	783014	SweptSolid	0	40	0	0	0	-
-ara3d/schependomlaan.ifc	787207	SweptSolid	0	48	0	0	0	-
-ara3d/schependomlaan.ifc	820735	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	822589	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	826337	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	829534	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	876846	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	878050	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	879248	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	880446	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	967617	SweptSolid	0	0	0	0	0	-
-ara3d/schependomlaan.ifc	969938	SweptSolid	0	0	0	0	0	-
-ara3d/tested_sample_project.ifc	186	SweptSolid	0	192	0	0	0	-
-ara3d/tested_sample_project.ifc	294	SweptSolid	0	28	0	0	0	-
-buildingsmart/wall-with-opening-and-window.ifc	45	unknown	0	32	0	0	0	-
-ifc5/Hello_Wall_hello-wall.ifc	1222	SweptSolid	0	68	0	0	0	-
-ifcopenshell/faceted_brep_csg.ifc	1096640	CSG	0	58	0	0	0	-
-issues/1007_roof_brep_opening_winding.ifc	1112	Brep	0	98	0	0	0	-
-issues/218_IFC-test-lite.ifc	417	SweptSolid	8	72	0	0	8	8
-issues/821_TallBuilding.ifc	615	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	810	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	887	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	964	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	1297	Clipping	0	44	0	0	0	-
-issues/821_TallBuilding.ifc	1850	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	1926	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	2002	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	2078	Clipping	0	52	0	0	0	-
-issues/821_TallBuilding.ifc	2401	Clipping	0	68	0	0	0	-
-issues/821_TallBuilding.ifc	2477	Clipping	0	72	0	0	0	-
-issues/821_TallBuilding.ifc	11462	Clipping	0	44	0	0	0	-
-issues/832_opening_representations.ifc	50	SweptSolid	0	32	0	0	0	-
-issues/832_opening_representations.ifc	89	SweptSolid	0	36	0	0	0	-
-issues/832_opening_representations.ifc	128	SweptSolid	0	32	0	0	0	-
-issues/832_opening_representations.ifc	175	SweptSolid	0	28	0	0	0	-
-issues/832_opening_representations.ifc	222	SweptSolid	0	28	0	0	0	-
-issues/841_house_stack_overflow.ifc	96	SweptSolid	0	96	0	0	0	-
-issues/841_house_stack_overflow.ifc	144	SweptSolid	0	28	0	0	0	-
-issues/841_house_stack_overflow.ifc	192	SweptSolid	0	68	0	0	0	-
-issues/841_house_stack_overflow.ifc	240	SweptSolid	0	32	0	0	0	-
-issues/841_house_stack_overflow.ifc	336	SweptSolid	0	174	0	0	0	-
-issues/841_house_stack_overflow.ifc	384	SweptSolid	0	322	1	0	0	-
-issues/841_house_stack_overflow.ifc	432	SweptSolid	0	338	1	0	0	-
-issues/841_house_stack_overflow.ifc	528	SweptSolid	0	60	0	0	0	-
-issues/841_house_stack_overflow.ifc	576	SweptSolid	0	28	0	0	0	-
-issues/841_house_stack_overflow.ifc	768	SweptSolid	0	48	0	0	0	-
-issues/841_house_stack_overflow.ifc	914	SweptSolid	0	32	0	0	0	-
-issues/841_house_stack_overflow.ifc	1020	SweptSolid	0	40	0	0	0	-
-issues/841_house_stack_overflow.ifc	1070	SweptSolid	0	58	0	0	0	-
-issues/841_house_stack_overflow.ifc	1118	SweptSolid	0	60	0	0	0	-
-issues/841_house_stack_overflow.ifc	1166	SweptSolid	0	36	0	0	0	-
-issues/841_house_stack_overflow.ifc	1362	Clipping	0	92	0	0	0	-
-issues/841_house_stack_overflow.ifc	1878	Clipping	0	114	0	0	0	-
-issues/841_house_stack_overflow.ifc	2152	Clipping	55	236	1	0	6	4
-issues/841_house_stack_overflow.ifc	2797	Clipping	0	44	0	0	0	-
-issues/841_house_stack_overflow.ifc	3698	Clipping	0	68	0	0	0	-
-issues/841_house_stack_overflow.ifc	4148	Clipping	0	142	0	0	0	-
-issues/841_house_stack_overflow.ifc	4219	Clipping	0	52	0	0	0	-
-issues/841_house_stack_overflow.ifc	4267	SweptSolid	0	30	0	0	0	-
-issues/841_house_stack_overflow.ifc	4374	Clipping	0	62	0	0	0	-
-issues/841_house_stack_overflow.ifc	4897	Clipping	0	130	0	0	0	-
-issues/841_house_stack_overflow.ifc	5904	Clipping	0	124	0	0	0	-
-issues/841_house_stack_overflow.ifc	13928	SweptSolid	0	28	0	0	0	-
-issues/845_wall_elemented_case.ifc	130	SweptSolid	0	224	0	0	0	-
-issues/845_wall_elemented_case.ifc	133	SweptSolid	0	392	0	0	0	-
-issues/845_wall_elemented_case.ifc	145	SweptSolid	0	224	0	0	0	-
-issues/845_wall_elemented_case.ifc	146	SweptSolid	0	200	0	0	0	-
-issues/845_wall_elemented_case.ifc	148	unknown	0	0	0	0	0	-
-issues/853_slab_pocket.ifc	303	SweptSolid	0	260	0	0	0	-
-issues/953_trimmed_curve_cartesian_arc.ifc	1112	Brep	0	98	0	0	0	-
-issues/960_house_segmented_roof_clip.ifc	2152	Clipping	55	236	1	0	6	4
-issues/960_house_segmented_roof_clip.ifc	2797	Clipping	0	44	0	0	0	-
-issues/960_house_segmented_roof_clip.ifc	4148	Clipping	0	142	0	0	0	-
-issues/960_house_segmented_roof_clip.ifc	4374	Clipping	0	62	0	0	0	-
-issues/960_house_segmented_roof_clip.ifc	5904	Clipping	0	124	0	0	0	-
-issues/964_slab_arbitrary_profile_voids.ifc	6443	SweptSolid	111	322	0	0	113	64
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	430	SweptSolid	0	280	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	654	SweptSolid	0	284	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	857	SweptSolid	0	52	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1029	SweptSolid	0	128	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1183	SweptSolid	0	172	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1369	SweptSolid	0	204	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1536	SweptSolid	0	92	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1649	SweptSolid	0	32	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1691	SweptSolid	0	76	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1789	SweptSolid	0	496	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	1992	SweptSolid	0	32	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	2036	SweptSolid	0	588	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	2411	SweptSolid	0	1406	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	3051	SweptSolid	0	48	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	3110	SweptSolid	0	112	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	3394	Clipping	0	32	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	25758	SweptSolid	40	308	0	0	40	50
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	26830	SweptSolid	0	32	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	27921	Clipping	0	32	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	45444	SweptSolid	0	64	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	45708	SweptSolid	0	176	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	45774	Clipping	0	40	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	71367	SweptSolid	0	216	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	81962	SweptSolid	136	784	0	0	136	158
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	100256	SweptSolid	0	84	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	100536	SweptSolid	0	176	0	0	0	-
-various/01_Snowdon_Towers_Sample_Structural(1).ifc	124547	SweptSolid	0	968	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	74	SweptSolid	0	52	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	75	SweptSolid	0	76	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	77	SweptSolid	0	524	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	78	SweptSolid	0	240	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	90	SweptSolid	0	340	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	91	SweptSolid	0	84	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	92	SweptSolid	0	52	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	93	SweptSolid	0	58	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	94	SweptSolid	0	52	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	103	SweptSolid	0	32	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	104	SweptSolid	0	48	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	105	SweptSolid	0	250	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	106	SweptSolid	0	84	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	107	SweptSolid	0	32	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	108	SweptSolid	0	476	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	109	SweptSolid	0	158	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	110	SweptSolid	0	96	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	111	SweptSolid	0	28	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	112	SweptSolid	0	56	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	113	SweptSolid	0	32	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	114	SweptSolid	0	164	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	115	SweptSolid	0	32	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	116	SweptSolid	0	68	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	136	SweptSolid	0	32	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	137	SweptSolid	0	128	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	138	SweptSolid	0	180	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	139	SweptSolid	0	48	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	140	SweptSolid	0	194	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	141	SweptSolid	0	28	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	142	SweptSolid	0	56	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	143	SweptSolid	0	120	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	144	SweptSolid	0	172	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	145	SweptSolid	0	94	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	146	SweptSolid	0	40	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	179	SweptSolid	0	136	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	180	SweptSolid	0	124	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	181	SweptSolid	0	32	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	182	SweptSolid	0	128	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	183	SweptSolid	0	28	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	214	SweptSolid	0	32	0	0	0	-
-various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	276	SweptSolid	0	72	0	0	0	-
-various/issue-604-door.ifc	55	SweptSolid	0	28	0	0	0	-
-various/rvt01.ifc	5941	Tessellation	78	240	0	1	81	11
-various/rvt01.ifc	6073	Tessellation	58	213	0	1	69	0
-various/rvt01.ifc	6163	SweptSolid	19	69	0	1	19	0
-various/rvt01.ifc	6243	SweptSolid	48	118	0	1	63	8
-various/rvt01.ifc	6305	SweptSolid	104	228	0	1	97	8
-various/rvt01.ifc	6420	SweptSolid	65	143	0	1	72	6
-various/rvt01.ifc	6511	SweptSolid	70	152	0	1	61	6
-various/rvt01.ifc	6588	SweptSolid	53	113	0	1	53	0
-various/rvt01.ifc	6724	SweptSolid	50	190	0	1	51	8
-various/rvt01.ifc	6810	SweptSolid	84	198	0	1	86	27
-various/rvt01.ifc	6934	SweptSolid	23	89	0	1	29	0
-various/rvt01.ifc	7013	SweptSolid	60	167	0	1	50	8
-various/rvt01.ifc	7075	SweptSolid	78	216	0	1	67	8
-various/rvt01.ifc	7137	SweptSolid	40	149	0	1	43	0
-various/rvt01.ifc	7216	SweptSolid	39	129	0	1	37	0
-various/rvt01.ifc	7295	SweptSolid	65	100	0	1	42	6
-various/rvt01.ifc	7403	Tessellation	11	41	0	1	11	3
-various/rvt01.ifc	7544	SweptSolid	99	192	1	1	91	8
-various/rvt01.ifc	7700	SweptSolid	61	92	0	1	69	0
-various/rvt01.ifc	7834	SweptSolid	87	195	0	1	91	16
-various/rvt01.ifc	8881	SweptSolid	70	176	0	1	44	8
-various/rvt01.ifc	8997	SweptSolid	86	174	0	1	76	26
-various/rvt01.ifc	9058	SweptSolid	91	176	0	1	94	8
-various/rvt01.ifc	9229	SweptSolid	72	175	0	1	79	8
-various/rvt01.ifc	9400	SweptSolid	55	167	0	1	61	0
-various/rvt01.ifc	9730	SweptSolid	50	114	0	1	57	8
-various/rvt01.ifc	9901	SweptSolid	45	97	0	1	48	8
-various/rvt01.ifc	10191	Tessellation	13	29	0	1	14	0
-various/rvt01.ifc	10335	Tessellation	9	9	0	1	7	0
-various/rvt01.ifc	10526	Tessellation	29	59	0	1	29	0
-various/rvt01.ifc	10632	Tessellation	19	117	0	1	17	0
-various/rvt01.ifc	11110	Tessellation	0	4	0	1	3	-
-various/rvt01.ifc	11168	Tessellation	26	66	0	1	23	0
-various/rvt01.ifc	11232	Tessellation	14	56	0	1	14	6
-various/rvt01.ifc	11304	Tessellation	7	27	0	1	7	0
-various/rvt01.ifc	11477	Tessellation	0	0	0	1	7	-
-various/rvt01.ifc	11563	Tessellation	23	18	0	1	26	0
-various/rvt01.ifc	11627	Tessellation	63	63	0	1	54	3
-various/rvt01.ifc	11690	Tessellation	72	93	0	1	56	6
-various/rvt01.ifc	11753	Tessellation	10	4	0	1	16	0
-various/rvt01.ifc	11803	SweptSolid	26	52	0	1	22	0
-various/rvt01.ifc	12235	SweptSolid	13	33	0	1	13	0
-various/rvt01.ifc	12345	SweptSolid	5	67	0	1	5	0
-various/rvt01.ifc	12449	Tessellation	44	145	1	1	48	9
-various/rvt01.ifc	13735	SweptSolid	52	161	0	1	38	8
-various/rvt01.ifc	13797	Tessellation	161	374	1	1	115	42
-various/rvt01.ifc	14014	SweptSolid	49	164	0	1	41	8
-various/rvt01.ifc	14132	SweptSolid	79	156	0	1	70	8
-various/rvt01.ifc	14194	SweptSolid	64	159	0	1	68	8
-various/rvt01.ifc	14256	SweptSolid	55	173	0	1	61	0
-various/rvt01.ifc	14447	SweptSolid	47	225	0	1	50	0
-various/rvt01.ifc	14638	SweptSolid	50	140	0	1	50	8
-various/rvt01.ifc	14797	SweptSolid	40	134	0	1	40	0
-various/rvt01.ifc	15020	SweptSolid	62	156	0	1	63	8
-various/rvt01.ifc	15301	SweptSolid	69	188	0	1	72	8
-various/rvt01.ifc	15857	SweptSolid	61	178	0	1	67	12
-various/rvt01.ifc	15917	SweptSolid	64	187	0	1	83	16
-various/rvt01.ifc	16231	SweptSolid	45	100	0	1	42	0
-various/rvt01.ifc	16286	SweptSolid	53	146	1	1	66	8
-various/rvt01.ifc	16805	SweptSolid	45	95	0	1	39	8
-various/rvt01.ifc	17553	Tessellation	4	10	0	1	4	0
-various/rvt01.ifc	17615	Tessellation	20	44	0	1	20	0
-various/rvt01.ifc	17919	Tessellation	9	45	0	1	16	0
-various/rvt01.ifc	17985	Tessellation	40	52	0	1	34	0
-various/rvt01.ifc	18169	SweptSolid	78	135	1	1	73	8
-various/rvt01.ifc	21999	SweptSolid	0	40	0	1	0	-
-various/rvt01.ifc	25694	Tessellation	15	105	0	1	15	0
-various/rvt01.ifc	25914	SweptSolid	38	154	0	1	38	0
-various/rvt01.ifc	26166	Tessellation	36	96	0	1	32	0
-various/rvt01.ifc	26300	Tessellation	63	103	1	1	57	0
-various/rvt01.ifc	26610	Tessellation	18	58	0	1	18	0
-various/rvt01.ifc	26681	Tessellation	32	142	0	1	24	0
-various/rvt01.ifc	26832	Tessellation	11	17	0	1	11	0
-various/rvt01.ifc	30054	Tessellation	11	41	0	1	11	0
-various/rvt01.ifc	30125	Tessellation	13	39	0	1	6	0
-various/rvt01.ifc	30518	Tessellation	59	215	0	1	39	0
-various/rvt01.ifc	31083	Tessellation	28	42	0	1	17	0
-various/rvt01.ifc	31156	Tessellation	41	125	0	1	40	0
-various/rvt01.ifc	31323	Tessellation	0	8	0	1	0	-
-various/rvt01.ifc	31430	Tessellation	17	41	0	1	14	0
-various/rvt01.ifc	31577	Tessellation	11	41	0	1	11	0
-various/rvt01.ifc	31648	Tessellation	13	39	0	1	6	0
-various/rvt01.ifc	32081	SweptSolid	62	175	1	1	52	0
-various/rvt01.ifc	33639	SweptSolid	122	308	0	1	157	24
-various/rvt01.ifc	37278	Tessellation	4	16	0	1	5	0
-various/rvt01.ifc	37347	Tessellation	49	106	0	1	46	0
-various/rvt01.ifc	37455	Tessellation	66	145	1	1	57	3
-various/rvt01.ifc	37570	SweptSolid	3	75	0	1	3	0
-various/rvt01.ifc	38680	Tessellation	32	84	0	1	34	0
-various/rvt01.ifc	38745	SweptSolid	22	44	0	1	22	0
-various/rvt01.ifc	38800	SweptSolid	72	201	1	1	95	14
+# strict: undirected edges NOT used exactly once forward and once reverse. Always
+#        >= open, and sees what open cannot: a doubled sheet nets to zero on the
+#        signed balance. Gated as its own count; the defect population is open's.
+model	id	rep	open	tris	coll	far	alt	pre	strict
+ara3d/AC20-FZK-Haus.ifc	17040	SweptSolid	0	36	0	0	0	-	0
+ara3d/AC20-FZK-Haus.ifc	18698	SweptSolid	0	54	0	0	0	-	0
+ara3d/AC20-FZK-Haus.ifc	21966	SweptSolid	0	80	0	0	0	-	0
+ara3d/AC20-FZK-Haus.ifc	27421	SweptSolid	0	80	0	0	0	-	0
+ara3d/AC20-FZK-Haus.ifc	31470	SweptSolid	0	52	0	0	0	-	0
+ara3d/AC20-FZK-Haus.ifc	32407	SweptSolid	0	72	0	0	0	-	0
+ara3d/AC20-FZK-Haus.ifc	59290	SweptSolid	0	32	0	0	0	-	0
+ara3d/AC20-FZK-Haus.ifc	60012	Clipping	0	204	0	0	18	-	0
+ara3d/AC20-FZK-Haus.ifc	67828	Clipping	0	196	0	0	18	-	0
+ara3d/C20-Institute-Var-2.ifc	31190	SweptSolid	0	320	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	35819	SweptSolid	0	324	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	40505	SweptSolid	0	600	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	47404	SweptSolid	0	116	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	50078	SweptSolid	0	130	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	52075	SweptSolid	0	52	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	55353	SweptSolid	0	42	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	56404	SweptSolid	0	40	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	57708	SweptSolid	0	40	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	72946	SweptSolid	0	80	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	81755	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	82662	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	83555	SweptSolid	0	320	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	87784	SweptSolid	0	70	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	90339	SweptSolid	0	320	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	94567	SweptSolid	0	324	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	99022	SweptSolid	0	100	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	100667	SweptSolid	0	72	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	101958	SweptSolid	0	120	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	104309	SweptSolid	0	64	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	107811	SweptSolid	0	328	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	112277	SweptSolid	0	36	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	113099	SweptSolid	0	42	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	114155	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	114727	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	125284	SweptSolid	0	80	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	135395	SweptSolid	0	320	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	139845	SweptSolid	0	324	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	144069	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	144635	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	145201	SweptSolid	0	948	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	154762	SweptSolid	0	116	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	157112	SweptSolid	0	120	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	159462	SweptSolid	0	192	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	165435	SweptSolid	0	34	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	166266	SweptSolid	0	40	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	167338	SweptSolid	0	40	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	178044	SweptSolid	0	64	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	188155	SweptSolid	0	320	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	192605	SweptSolid	0	324	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	196829	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	197395	SweptSolid	0	32	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	197961	SweptSolid	0	948	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	207522	SweptSolid	0	116	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	209872	SweptSolid	0	120	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	212222	SweptSolid	0	182	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	218661	SweptSolid	0	40	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	219733	SweptSolid	0	40	0	0	0	-	0
+ara3d/C20-Institute-Var-2.ifc	220884	SweptSolid	0	64	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	26448	SweptSolid	0	72	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	26635	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	30660	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	30826	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	31022	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	40974	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	52867	SweptSolid	0	34	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	53112	SweptSolid	0	34	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	61530	SweptSolid	0	48	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	67415	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	67562	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	67758	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	77712	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	89640	SweptSolid	0	34	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	89885	SweptSolid	0	34	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	90210	SweptSolid	0	48	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	99281	SweptSolid	0	72	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	100158	SweptSolid	0	168	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	100207	SweptSolid	0	186	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	106167	Clipping	0	48	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	106259	SweptSolid	0	40	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	106951	SweptSolid	0	100	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	136983	SweptSolid	0	80	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	137547	Clipping	0	60	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	138037	Clipping	12	301	1	0	21	0	12
+ara3d/FM_ARC_DigitalHub.ifc	138279	SweptSolid	0	60	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	138767	Clipping	0	80	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	139288	Clipping	9	300	1	0	9	0	9
+ara3d/FM_ARC_DigitalHub.ifc	139605	Clipping	9	300	1	0	9	0	9
+ara3d/FM_ARC_DigitalHub.ifc	139864	Clipping	0	184	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	139985	Clipping	9	300	1	0	18	0	9
+ara3d/FM_ARC_DigitalHub.ifc	140227	SweptSolid	0	184	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	140337	SweptSolid	0	496	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	146777	SweptSolid	0	222	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	149094	SweptSolid	0	668	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	155733	SweptSolid	0	282	0	0	11	-	0
+ara3d/FM_ARC_DigitalHub.ifc	187843	SweptSolid	0	172	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	188186	SweptSolid	0	32	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	188235	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	188333	SweptSolid	0	74	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	188424	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	196863	SweptSolid	0	112	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	196912	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	196961	SweptSolid	0	132	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	197010	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	197353	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	197794	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	200204	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	200253	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	200449	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	200645	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	216340	SweptSolid	0	68	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	216561	SweptSolid	0	44	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	216762	SweptSolid	0	28	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	217867	SweptSolid	0	72	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	218038	SweptSolid	0	32	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	218227	SweptSolid	0	72	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	218398	SweptSolid	0	32	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	218587	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	218718	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	219094	SweptSolid	0	52	0	0	0	-	0
+ara3d/FM_ARC_DigitalHub.ifc	219225	SweptSolid	0	52	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	17040	SweptSolid	0	36	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	18698	SweptSolid	0	54	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	21966	SweptSolid	0	80	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	27421	SweptSolid	0	80	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	31470	SweptSolid	0	52	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	32407	SweptSolid	0	72	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	59290	SweptSolid	0	32	0	0	0	-	0
+ara3d/ISSUE_005_haus.ifc	60012	Clipping	0	204	0	0	18	-	0
+ara3d/ISSUE_005_haus.ifc	67828	Clipping	0	196	0	0	18	-	0
+ara3d/ISSUE_126_model.ifc	40983	SweptSolid	0	52	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	43236	SweptSolid	0	20	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	49197	SweptSolid	0	20	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	49964	SweptSolid	0	20	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	50658	SweptSolid	0	54	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	50766	SweptSolid	0	58	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	52352	SweptSolid	0	34	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	56758	SweptSolid	0	30	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	73237	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	73349	SweptSolid	0	216	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	77438	SweptSolid	0	80	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	78232	SweptSolid	0	52	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	78975	SweptSolid	0	170	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	82108	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	82925	SweptSolid	0	34	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	83323	SweptSolid	0	66	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	83694	SweptSolid	0	20	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	84442	SweptSolid	0	34	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	86446	SweptSolid	0	54	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	86609	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	98282	SweptSolid	24	130	0	0	24	0	24
+ara3d/ISSUE_126_model.ifc	100504	SweptSolid	0	50	0	0	0	-	0
+ara3d/ISSUE_126_model.ifc	111997	SweptSolid	27	51	0	0	27	0	27
+ara3d/ISSUE_126_model.ifc	131771	SweptSolid	0	96	0	0	0	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	6891	Clipping	91	345	0	1	56	6	92
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	7526	SweptSolid	1119	1157	0	1	931	0	1124
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8434	Clipping	0	44	0	1	0	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	8756	Clipping	4	28	0	1	3	3	4
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	9094	SweptSolid	723	824	1	1	717	0	774
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	11115	Clipping	21	167	0	1	9	0	21
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	12381	SweptSolid	2106	2332	1	1	1811	0	2119
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	32810	SweptSolid	260	1536	0	1	144	0	264
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	34385	SweptSolid	493	725	1	1	571	0	493
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	36735	SweptSolid	458	882	0	1	375	0	469
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57084	SweptSolid	54	109	0	1	52	12	59
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57776	SweptSolid	57	111	0	1	41	0	61
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	57944	Clipping	23	99	0	1	23	0	23
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	58297	Clipping	67	221	0	1	19	0	67
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59111	SweptSolid	1723	1764	0	1	2008	0	1730
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	59957	SweptSolid	37	55	0	1	37	0	37
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60118	SweptSolid	17	123	1	1	17	0	17
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	60344	SweptSolid	0	36	0	1	0	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	61300	Clipping	743	1429	1	1	768	3	752
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63146	Clipping	20	106	0	1	23	0	23
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63466	Clipping	16	164	0	1	22	0	18
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	63721	SweptSolid	6	22	0	1	6	0	6
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68263	Clipping	15	71	0	1	15	0	15
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	68943	Clipping	26	162	0	1	29	0	33
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69569	Clipping	7	43	0	1	7	0	7
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	69961	Clipping	21	119	0	1	21	0	30
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81223	Clipping	17	135	0	1	20	0	25
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81562	Clipping	43	181	0	1	43	0	46
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	81869	Clipping	0	28	0	1	0	-	15
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	83043	Clipping	13	41	0	1	13	0	13
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138693	Clipping	31	91	0	1	31	0	32
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	138919	Clipping	11	71	0	1	11	0	11
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139190	SweptSolid	22	144	0	1	22	0	24
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139364	Clipping	35	152	0	1	35	0	35
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	139571	SweptSolid	38	276	0	1	38	0	39
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	141060	SweptSolid	67	99	0	1	41	0	67
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145270	SweptSolid	46	96	0	1	50	6	46
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145756	SweptSolid	13	101	0	1	13	0	16
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	145897	SweptSolid	32	70	0	1	32	0	34
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148665	SweptSolid	519	1008	0	1	388	0	527
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	148864	SweptSolid	3	97	0	1	3	0	4
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149277	SweptSolid	356	562	0	1	312	0	359
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	149280	SweptSolid	214	993	0	1	284	0	240
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196139	SweptSolid	148	174	0	1	129	0	152
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	196326	SweptSolid	92	83	0	1	101	0	92
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	233296	SweptSolid	0	46	0	1	0	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	244479	SweptSolid	403	639	0	1	340	0	416
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247051	Clipping	29	164	1	1	29	0	31
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247203	Clipping	18	88	0	1	18	0	18
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247726	Clipping	38	180	0	1	38	0	39
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	247953	Clipping	37	165	0	1	38	0	39
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	295370	SweptSolid	622	473	1	1	515	0	629
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	296868	SweptSolid	621	572	1	1	553	0	633
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299369	SweptSolid	0	32	0	1	0	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	299638	SweptSolid	10	10	0	1	10	0	10
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	316547	SweptSolid	279	649	0	1	250	0	281
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332017	SweptSolid	222	387	0	1	129	0	224
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	332205	SweptSolid	63	263	0	1	3	0	63
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	333923	SweptSolid	1326	1347	1	1	1209	6	1339
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	335218	SweptSolid	1110	1095	1	1	1334	0	1115
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	337691	SweptSolid	27	93	0	1	27	0	27
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359157	SweptSolid	0	52	0	1	6	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359305	SweptSolid	20	60	0	1	12	0	20
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359480	SweptSolid	18	30	0	1	18	0	18
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359627	SweptSolid	0	52	0	1	6	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	359926	SweptSolid	0	52	0	1	6	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360075	SweptSolid	34	44	0	1	34	0	34
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360237	SweptSolid	57	79	0	1	57	0	57
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360384	SweptSolid	7	43	0	1	7	0	7
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360680	SweptSolid	0	32	0	1	0	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360821	SweptSolid	0	32	0	1	0	-	0
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	360966	SweptSolid	10	36	0	1	10	0	10
+ara3d/ISSUE_129_N1540_17_EXE_MOD_448200_02_09_11SMC_IGC_V17.ifc	361107	SweptSolid	3	35	0	1	3	0	3
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4380	SweptSolid	6	94	0	0	0	0	6
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4630	SweptSolid	0	38	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4732	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4834	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	4940	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	6012	Clipping	6	144	0	0	6	0	6
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	8511	SweptSolid	0	36	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27148	SweptSolid	3	117	1	0	0	0	3
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27562	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	27770	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	28290	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	34099	SweptSolid	35	259	0	0	30	0	35
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	37094	SweptSolid	0	64	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46565	SweptSolid	0	100	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46667	SweptSolid	0	32	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46769	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	46871	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	47807	SweptSolid	0	168	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	49773	SweptSolid	0	36	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63308	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	63516	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	64036	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	76544	SweptSolid	0	60	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78513	SweptSolid	0	156	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	78918	Clipping	12	106	0	0	0	0	12
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79070	Clipping	0	50	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79197	Clipping	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	79969	AdvancedBrep	0	80	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	80101	Clipping	0	80	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	81274	Clipping	12	140	0	0	12	0	12
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	83292	Clipping	0	52	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87331	Clipping	0	132	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	87839	Clipping	0	44	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88116	Clipping	0	46	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	88776	Clipping	0	76	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	92201	Clipping	17	141	0	0	20	0	17
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	94199	Clipping	0	66	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95188	Clipping	6	96	0	0	6	0	6
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95332	Clipping	0	44	0	0	3	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95459	Clipping	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	95605	Clipping	0	80	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	96778	Clipping	12	132	0	0	12	0	12
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	98786	Clipping	0	48	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100558	Clipping	0	44	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	100835	Clipping	0	46	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	101495	Clipping	0	76	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	103251	Clipping	0	78	1	0	3	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	105519	SweptSolid	0	156	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119816	SweptSolid	6	62	0	0	0	0	6
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	119924	SweptSolid	3	63	1	0	0	0	3
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120028	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120132	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	120448	SweptSolid	0	96	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	121490	SweptSolid	0	60	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	122695	SweptSolid	12	144	1	0	0	0	12
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123117	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123329	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	123859	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	124711	SweptSolid	0	204	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	127658	SweptSolid	0	54	1	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128193	SweptSolid	3	97	1	0	0	0	3
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128297	SweptSolid	0	32	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128401	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	128505	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	129459	SweptSolid	0	120	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	131443	SweptSolid	0	36	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132587	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	132799	SweptSolid	0	28	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	133329	SweptSolid	0	44	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	134472	SweptSolid	0	60	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	135938	SweptSolid	0	128	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	137886	SweptSolid	0	112	0	0	0	-	0
+ara3d/ISSUE_159_kleine_Wohnung_R22.ifc	139140	SweptSolid	0	36	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	61	SweptSolid	0	114	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	528	SweptSolid	0	64	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	733	SweptSolid	0	32	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	880	SweptSolid	0	64	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1085	SweptSolid	0	72	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1290	SweptSolid	0	58	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1512	SweptSolid	0	36	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	1812	SweptSolid	0	58	0	0	0	-	0
+ara3d/ISSUE_171_IfcSurfaceCurveSweptAreaSolid.ifc	2017	SweptSolid	0	68	0	0	0	-	0
+ara3d/IfcOpenHouse_IFC4.ifc	40	SweptSolid	0	56	0	0	0	-	0
+ara3d/IfcOpenHouse_IFC4.ifc	268	Clipping	0	40	0	0	0	-	0
+ara3d/IfcOpenHouse_IFC4.ifc	281	Clipping	0	42	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	65	SweptSolid	0	92	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	71	SweptSolid	0	308	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	76	SweptSolid	0	140	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	81	SweptSolid	0	312	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	82	SweptSolid	0	32	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	83	SweptSolid	0	292	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	88	SweptSolid	0	60	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	97	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	100	SweptSolid	0	152	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	101	SweptSolid	0	164	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	102	SweptSolid	0	140	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	104	SweptSolid	0	92	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	105	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	106	SweptSolid	0	172	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	130	SweptSolid	0	76	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	134	SweptSolid	0	92	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	139	SweptSolid	0	76	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	143	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	156	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	161	SweptSolid	0	60	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	164	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	165	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	166	SweptSolid	0	100	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	175	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	178	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	179	SweptSolid	0	60	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	183	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	185	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	188	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	191	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	193	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	195	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	196	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	197	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	198	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	223	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	224	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	227	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	228	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	234	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	238	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	239	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	242	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	246	SweptSolid	0	60	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	247	SweptSolid	0	44	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	248	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	277	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	282	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	288	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	307	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	314	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	326	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	351	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	354	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	361	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	363	SweptSolid	0	28	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	364	SweptSolid	0	180	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	417	SweptSolid	0	122	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	429	SweptSolid	0	32	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	607	SweptSolid	0	122	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	684	SweptSolid	0	122	0	0	0	-	0
+ara3d/Office_A_20110811.ifc	1028	SweptSolid	0	678	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	4172	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	5434	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	6155	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	14416	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	35182	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	36567	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	43442	SweptSolid	0	80	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	48600	SweptSolid	0	44	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	49149	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	89022	unknown	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	89141	SweptSolid	0	232	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	89264	SweptSolid	0	232	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	89384	SweptSolid	0	232	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	89504	SweptSolid	0	232	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	89624	SweptSolid	0	232	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	90617	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	91291	CSG	3	46	1	0	3	6	3
+ara3d/S_Office_Integrated Design Archi.ifc	91968	CSG	0	120	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	92642	CSG	12	68	1	0	13	12	13
+ara3d/S_Office_Integrated Design Archi.ifc	93316	CSG	0	64	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	93990	CSG	0	108	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	94664	CSG	4	160	0	0	4	4	4
+ara3d/S_Office_Integrated Design Archi.ifc	99549	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	368885	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	414959	SweptSolid	0	40	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	415490	unknown	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	426329	CSG	0	496	0	0	6	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	437170	CSG	6	380	0	0	0	6	6
+ara3d/S_Office_Integrated Design Archi.ifc	448019	CSG	90	1034	0	0	89	164	90
+ara3d/S_Office_Integrated Design Archi.ifc	458857	CSG	78	1062	0	0	80	78	78
+ara3d/S_Office_Integrated Design Archi.ifc	469706	CSG	51	1077	0	0	61	51	51
+ara3d/S_Office_Integrated Design Archi.ifc	489748	SweptSolid	0	40	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	495955	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	496628	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	503263	unknown	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	503302	SweptSolid	0	172	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	503345	SweptSolid	0	172	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	503385	SweptSolid	0	172	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	503425	SweptSolid	0	172	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	503482	SweptSolid	0	172	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	543063	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	639833	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	670546	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	701210	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	704150	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	719862	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	722750	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	723436	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	724125	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	724811	CSG	3	81	0	0	3	3	3
+ara3d/S_Office_Integrated Design Archi.ifc	725497	CSG	7	185	0	0	7	12	7
+ara3d/S_Office_Integrated Design Archi.ifc	726183	CSG	0	212	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	726869	CSG	0	212	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	730647	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	753197	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	763256	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	763898	CSG	0	122	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	764543	CSG	0	124	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	765185	CSG	0	118	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	765827	CSG	0	64	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	766469	CSG	0	112	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	767111	CSG	0	108	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	767445	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	768209	CSG	0	224	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	768976	CSG	0	232	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	769740	CSG	0	280	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	770504	CSG	0	100	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	771268	CSG	0	196	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	772032	CSG	0	196	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	803290	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	832090	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	832800	CSG	0	224	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	833513	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	834223	CSG	0	200	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	834933	CSG	0	100	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	835643	CSG	0	196	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	836353	CSG	0	196	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	857637	unknown	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	857676	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	857719	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	857759	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	857799	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	857839	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	866873	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	867376	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	868018	CSG	0	122	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	868663	CSG	0	124	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	869305	CSG	0	118	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	869947	CSG	0	64	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	870589	CSG	0	108	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	871231	CSG	0	108	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	902095	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	903633	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	904243	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	904620	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	905288	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	905959	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	906627	CSG	6	82	0	0	6	6	6
+ara3d/S_Office_Integrated Design Archi.ifc	907295	CSG	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	907963	CSG	0	212	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	908631	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	909123	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	909362	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	909877	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	910230	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	910609	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	912366	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	918017	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	918355	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	929798	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	930704	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	951036	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	951723	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	952413	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	953100	CSG	3	137	1	0	3	3	3
+ara3d/S_Office_Integrated Design Archi.ifc	953787	CSG	0	116	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	954474	CSG	13	225	0	0	4	7	13
+ara3d/S_Office_Integrated Design Archi.ifc	955161	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	955764	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	969935	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	970645	CSG	0	224	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	971358	CSG	0	216	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	972068	CSG	0	200	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	972778	CSG	0	100	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	973488	CSG	0	196	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	974198	CSG	0	196	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	974760	unknown	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	974799	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	974842	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	974882	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	974922	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	974962	SweptSolid	0	156	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	976762	Curve2D	0	0	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	977404	CSG	0	120	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	978049	CSG	0	120	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	978691	CSG	0	112	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	979333	CSG	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	979975	CSG	0	114	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	980617	CSG	0	108	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	986525	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	987406	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	997903	SweptSolid	0	36	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	998325	SweptSolid	0	52	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	1001521	SweptSolid	0	32	0	0	0	-	0
+ara3d/S_Office_Integrated Design Archi.ifc	1001906	SweptSolid	0	32	0	0	0	-	0
+ara3d/advanced_model.ifc	552611	SweptSolid	0	158	0	0	0	-	0
+ara3d/advanced_model.ifc	552761	SweptSolid	0	168	0	0	0	-	0
+ara3d/advanced_model.ifc	552894	SweptSolid	0	104	0	0	0	-	0
+ara3d/advanced_model.ifc	553010	Clipping	0	82	0	0	0	-	0
+ara3d/advanced_model.ifc	555082	SweptSolid	0	88	0	0	0	-	0
+ara3d/advanced_model.ifc	555224	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	555268	SweptSolid	0	124	0	0	0	-	0
+ara3d/advanced_model.ifc	555433	SweptSolid	0	172	0	0	0	-	0
+ara3d/advanced_model.ifc	555613	Clipping	0	90	0	0	0	-	0
+ara3d/advanced_model.ifc	555770	Clipping	0	56	0	0	0	-	0
+ara3d/advanced_model.ifc	555985	SweptSolid	0	184	0	0	0	-	0
+ara3d/advanced_model.ifc	556264	SweptSolid	0	192	0	0	0	-	0
+ara3d/advanced_model.ifc	559034	SweptSolid	0	88	0	0	0	-	0
+ara3d/advanced_model.ifc	559171	SweptSolid	0	92	0	0	0	-	0
+ara3d/advanced_model.ifc	559270	SweptSolid	0	44	0	0	0	-	0
+ara3d/advanced_model.ifc	559314	SweptSolid	0	52	0	0	0	-	0
+ara3d/advanced_model.ifc	561445	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	563598	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	563980	SweptSolid	0	156	0	0	0	-	0
+ara3d/advanced_model.ifc	612062	SweptSolid	0	92	0	0	0	-	0
+ara3d/advanced_model.ifc	612150	SweptSolid	0	124	0	0	0	-	0
+ara3d/advanced_model.ifc	612315	SweptSolid	0	128	0	0	0	-	0
+ara3d/advanced_model.ifc	612436	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	632450	Clipping	0	126	0	0	0	-	0
+ara3d/advanced_model.ifc	636693	SweptSolid	0	92	0	0	0	-	0
+ara3d/advanced_model.ifc	636774	SweptSolid	0	44	0	0	0	-	0
+ara3d/advanced_model.ifc	636818	SweptSolid	0	52	0	0	0	-	0
+ara3d/advanced_model.ifc	636995	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	637271	SweptSolid	0	76	0	0	0	-	0
+ara3d/advanced_model.ifc	637377	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	637697	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	637785	SweptSolid	0	60	0	0	0	-	0
+ara3d/advanced_model.ifc	637873	SweptSolid	0	44	0	0	0	-	0
+ara3d/advanced_model.ifc	637917	SweptSolid	0	44	0	0	0	-	0
+ara3d/advanced_model.ifc	646621	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	646665	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	650657	SweptSolid	0	68	0	0	0	-	0
+ara3d/advanced_model.ifc	650761	SweptSolid	0	76	0	0	0	-	0
+ara3d/advanced_model.ifc	650893	SweptSolid	0	56	0	0	0	-	0
+ara3d/advanced_model.ifc	651604	SweptSolid	0	76	0	0	0	-	0
+ara3d/advanced_model.ifc	674148	SweptSolid	0	76	0	0	0	-	0
+ara3d/advanced_model.ifc	679345	SweptSolid	0	140	0	0	0	-	0
+ara3d/advanced_model.ifc	694436	SweptSolid	0	92	0	0	0	-	0
+ara3d/advanced_model.ifc	737480	SweptSolid	0	92	0	0	0	-	0
+ara3d/advanced_model.ifc	737716	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	737804	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	737892	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	737936	SweptSolid	0	156	0	0	0	-	0
+ara3d/advanced_model.ifc	738205	SweptSolid	0	92	0	0	0	-	0
+ara3d/advanced_model.ifc	738433	SweptSolid	0	1860	0	0	0	-	0
+ara3d/advanced_model.ifc	739014	SweptSolid	0	1832	0	0	0	-	0
+ara3d/advanced_model.ifc	797099	SweptSolid	0	192	0	0	0	-	0
+ara3d/advanced_model.ifc	797102	SweptSolid	0	192	0	0	0	-	0
+ara3d/advanced_model.ifc	797108	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	797111	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	797114	SweptSolid	0	464	0	0	0	-	0
+ara3d/advanced_model.ifc	797120	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	797123	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	797126	SweptSolid	0	604	0	0	0	-	0
+ara3d/advanced_model.ifc	797129	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	798479	SweptSolid	0	612	0	0	0	-	0
+ara3d/advanced_model.ifc	798926	SweptSolid	0	2900	0	0	0	-	0
+ara3d/advanced_model.ifc	799400	SweptSolid	0	604	0	0	0	-	0
+ara3d/advanced_model.ifc	799566	SweptSolid	0	604	0	0	0	-	0
+ara3d/advanced_model.ifc	799732	SweptSolid	0	604	0	0	0	-	0
+ara3d/advanced_model.ifc	800371	SweptSolid	0	604	0	0	0	-	0
+ara3d/advanced_model.ifc	800374	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	800377	SweptSolid	0	464	0	0	0	-	0
+ara3d/advanced_model.ifc	800380	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	800383	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	800389	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	800395	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	800398	SweptSolid	0	308	0	0	0	-	0
+ara3d/advanced_model.ifc	800410	SweptSolid	0	340	0	0	0	-	0
+ara3d/advanced_model.ifc	800413	SweptSolid	0	160	0	0	0	-	0
+ara3d/advanced_model.ifc	800416	SweptSolid	0	372	0	0	0	-	0
+ara3d/advanced_model.ifc	800422	SweptSolid	0	324	0	0	0	-	0
+ara3d/advanced_model.ifc	801940	SweptSolid	0	44	0	0	0	-	0
+ara3d/advanced_model.ifc	801984	SweptSolid	0	44	0	0	0	-	0
+ara3d/advanced_model.ifc	806064	SweptSolid	0	28	0	0	0	-	0
+ara3d/advanced_model.ifc	806149	SweptSolid	0	508	0	0	0	-	0
+ara3d/advanced_model.ifc	815104	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	94	SweptSolid	0	232	0	0	0	-	0
+ara3d/dental_clinic.ifc	95	SweptSolid	0	172	0	0	0	-	0
+ara3d/dental_clinic.ifc	101	SweptSolid	0	128	0	0	0	-	0
+ara3d/dental_clinic.ifc	146	SweptSolid	0	192	0	0	0	-	0
+ara3d/dental_clinic.ifc	156	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	157	SweptSolid	0	92	0	0	0	-	0
+ara3d/dental_clinic.ifc	159	SweptSolid	0	108	0	0	0	-	0
+ara3d/dental_clinic.ifc	163	SweptSolid	0	128	0	0	0	-	0
+ara3d/dental_clinic.ifc	166	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	167	Clipping	10	192	0	0	10	0	10
+ara3d/dental_clinic.ifc	169	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	175	Clipping	0	168	0	0	0	-	0
+ara3d/dental_clinic.ifc	180	Clipping	0	168	0	0	0	-	0
+ara3d/dental_clinic.ifc	184	SweptSolid	0	92	0	0	0	-	0
+ara3d/dental_clinic.ifc	195	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	196	SweptSolid	0	64	0	0	0	-	0
+ara3d/dental_clinic.ifc	202	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	203	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	205	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	206	SweptSolid	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	207	Clipping	8	278	0	0	8	0	8
+ara3d/dental_clinic.ifc	212	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	213	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	214	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	215	SweptSolid	0	68	0	0	0	-	0
+ara3d/dental_clinic.ifc	216	SweptSolid	0	92	0	0	0	-	0
+ara3d/dental_clinic.ifc	217	SweptSolid	0	26	0	0	0	-	0
+ara3d/dental_clinic.ifc	218	SweptSolid	0	20	0	0	0	-	0
+ara3d/dental_clinic.ifc	231	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	232	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	233	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	234	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	235	SweptSolid	0	112	0	0	0	-	0
+ara3d/dental_clinic.ifc	236	SweptSolid	0	72	0	0	0	-	0
+ara3d/dental_clinic.ifc	248	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	249	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	262	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	263	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	264	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	265	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	266	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	269	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	270	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	271	Clipping	0	72	0	0	0	-	0
+ara3d/dental_clinic.ifc	272	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	273	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	284	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	285	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	286	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	287	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	288	SweptSolid	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	297	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	298	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	299	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	300	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	301	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	302	SweptSolid	0	72	0	0	0	-	0
+ara3d/dental_clinic.ifc	303	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	319	Clipping	0	38	0	0	0	-	0
+ara3d/dental_clinic.ifc	320	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	321	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	322	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	323	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	324	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	325	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	326	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	327	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	329	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	349	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	350	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	351	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	352	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	353	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	354	SweptSolid	0	60	0	0	0	-	0
+ara3d/dental_clinic.ifc	355	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	356	SweptSolid	0	52	0	0	0	-	0
+ara3d/dental_clinic.ifc	357	SweptSolid	0	20	0	0	0	-	0
+ara3d/dental_clinic.ifc	360	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	361	SweptSolid	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	375	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	376	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	377	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	378	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	379	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	380	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	381	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	424	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	425	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	426	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	427	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	428	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	429	SweptSolid	0	104	0	0	0	-	0
+ara3d/dental_clinic.ifc	430	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	431	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	432	SweptSolid	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	434	SweptSolid	0	12	0	0	0	-	0
+ara3d/dental_clinic.ifc	437	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	438	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	439	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	475	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	481	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	482	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	483	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	484	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	488	SweptSolid	0	20	0	0	0	-	0
+ara3d/dental_clinic.ifc	490	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	491	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	507	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	522	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	523	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	524	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	525	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	526	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	527	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	528	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	529	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	530	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	531	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	532	Clipping	0	22	0	0	0	-	0
+ara3d/dental_clinic.ifc	542	Clipping	0	22	0	0	0	-	0
+ara3d/dental_clinic.ifc	545	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	584	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	590	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	591	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	592	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	593	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	594	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	595	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	596	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	597	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	598	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	599	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	600	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	601	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	627	SweptSolid	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	628	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	675	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	686	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	696	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	697	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	698	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	699	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	700	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	701	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	702	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	703	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	704	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	736	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	804	SweptSolid	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	825	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	827	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	828	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	829	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	830	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	831	Clipping	0	64	0	0	0	-	0
+ara3d/dental_clinic.ifc	872	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	931	SweptSolid	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	964	Clipping	0	30	0	0	0	-	0
+ara3d/dental_clinic.ifc	965	Clipping	0	30	0	0	0	-	0
+ara3d/dental_clinic.ifc	966	Clipping	0	30	0	0	0	-	0
+ara3d/dental_clinic.ifc	973	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	974	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	975	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	976	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	977	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	978	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	979	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	980	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	981	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	982	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	983	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	984	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	985	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	986	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	987	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	988	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	989	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	990	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	991	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	992	SweptSolid	0	54	0	0	0	-	0
+ara3d/dental_clinic.ifc	993	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	994	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	995	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	996	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	997	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	998	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	999	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1003	Clipping	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1022	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1085	Clipping	0	32	0	0	0	-	0
+ara3d/dental_clinic.ifc	1093	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1094	SweptSolid	0	36	0	0	0	-	0
+ara3d/dental_clinic.ifc	1096	SweptSolid	0	36	0	0	0	-	0
+ara3d/dental_clinic.ifc	1183	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1194	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1195	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1242	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1252	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1253	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1310	SweptSolid	0	164	0	0	0	-	0
+ara3d/dental_clinic.ifc	1311	Clipping	10	80	0	0	10	0	10
+ara3d/dental_clinic.ifc	1314	SweptSolid	0	58	0	0	0	-	0
+ara3d/dental_clinic.ifc	1331	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	1643	Clipping	0	30	0	0	0	-	0
+ara3d/dental_clinic.ifc	1673	Clipping	9	32	1	0	9	0	10
+ara3d/dental_clinic.ifc	1757	Clipping	3	28	1	0	3	0	6
+ara3d/dental_clinic.ifc	1831	SweptSolid	0	24	0	0	0	-	0
+ara3d/dental_clinic.ifc	1832	SweptSolid	0	24	0	0	0	-	0
+ara3d/dental_clinic.ifc	2093	SweptSolid	0	28	0	0	0	-	0
+ara3d/dental_clinic.ifc	2268	SweptSolid	0	48	0	0	0	-	0
+ara3d/dental_clinic.ifc	2269	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2270	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2275	SweptSolid	0	64	0	0	0	-	0
+ara3d/dental_clinic.ifc	2276	SweptSolid	0	76	0	0	0	-	0
+ara3d/dental_clinic.ifc	2278	SweptSolid	0	72	0	0	0	-	0
+ara3d/dental_clinic.ifc	2279	SweptSolid	0	68	0	0	0	-	0
+ara3d/dental_clinic.ifc	2280	SweptSolid	0	68	0	0	0	-	0
+ara3d/dental_clinic.ifc	2285	SweptSolid	0	548	0	0	0	-	0
+ara3d/dental_clinic.ifc	2286	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2287	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2288	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2289	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2290	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2291	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2292	SweptSolid	19	305	1	0	6	0	19
+ara3d/dental_clinic.ifc	2293	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2294	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2295	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2296	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2297	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2298	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2299	SweptSolid	0	44	0	0	0	-	0
+ara3d/dental_clinic.ifc	2300	SweptSolid	0	64	0	0	0	-	0
+ara3d/dental_clinic.ifc	2301	SweptSolid	6	634	0	0	6	0	6
+ara3d/dental_clinic.ifc	2302	SweptSolid	7	366	1	0	7	0	7
+ara3d/dental_clinic.ifc	2304	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2305	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2306	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2307	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2308	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2309	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2310	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2311	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2312	SweptSolid	0	56	0	0	0	-	0
+ara3d/dental_clinic.ifc	2313	SweptSolid	0	56	0	0	0	-	0
+ara3d/duplex.ifc	3797	SweptSolid	0	48	0	0	0	-	0
+ara3d/duplex.ifc	3999	SweptSolid	0	48	0	0	0	-	0
+ara3d/duplex.ifc	4043	SweptSolid	0	48	0	0	0	-	0
+ara3d/duplex.ifc	4087	SweptSolid	0	48	0	0	0	-	0
+ara3d/duplex.ifc	4219	SweptSolid	0	28	0	0	0	-	0
+ara3d/duplex.ifc	4508	SweptSolid	0	28	0	0	0	-	0
+ara3d/duplex.ifc	5448	SweptSolid	0	142	0	0	0	-	0
+ara3d/duplex.ifc	5498	SweptSolid	0	218	0	0	0	-	0
+ara3d/duplex.ifc	5548	SweptSolid	0	164	0	0	0	-	0
+ara3d/duplex.ifc	5598	SweptSolid	0	226	0	0	0	-	0
+ara3d/duplex.ifc	5642	SweptSolid	0	32	0	0	0	-	0
+ara3d/duplex.ifc	5687	SweptSolid	0	28	0	0	0	-	0
+ara3d/duplex.ifc	5731	SweptSolid	0	28	0	0	0	-	0
+ara3d/duplex.ifc	5903	SweptSolid	0	32	0	0	0	-	0
+ara3d/duplex.ifc	5948	SweptSolid	0	28	0	0	0	-	0
+ara3d/duplex.ifc	5992	SweptSolid	0	28	0	0	0	-	0
+ara3d/duplex.ifc	12574	SurfaceModel	89	292	0	0	89	70	89
+ara3d/duplex.ifc	12976	SurfaceModel	84	292	0	0	85	70	84
+ara3d/duplex.ifc	13331	SurfaceModel	89	292	0	0	89	70	89
+ara3d/duplex.ifc	13685	SurfaceModel	84	292	0	0	85	70	84
+ara3d/duplex.ifc	14040	SurfaceModel	89	292	0	0	89	70	89
+ara3d/duplex.ifc	14394	SurfaceModel	85	292	0	0	86	70	85
+ara3d/duplex.ifc	14749	SurfaceModel	89	292	0	0	89	70	89
+ara3d/duplex.ifc	15103	SurfaceModel	85	292	0	0	86	70	85
+ara3d/duplex.ifc	16261	SweptSolid	0	68	0	0	0	-	0
+ara3d/duplex.ifc	16802	SweptSolid	3	727	0	0	3	0	3
+ara3d/duplex.ifc	22475	unknown	0	0	0	0	0	-	0
+ara3d/duplex.ifc	22492	SweptSolid	0	60	0	0	0	-	0
+ara3d/duplex.ifc	35199	SweptSolid	0	28	0	0	0	-	0
+ara3d/duplex.ifc	35357	SweptSolid	0	28	0	0	0	-	0
+ara3d/schependomlaan.ifc	46535	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	49281	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	52348	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	72010	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	76629	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	80335	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	99074	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	101868	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	112392	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	115669	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	119854	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	125502	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	133655	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	136076	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	140907	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	143594	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	154792	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	159728	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	163917	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	169275	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	171696	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	178863	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	186163	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	188256	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	263912	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	270253	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	271891	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	311100	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	313863	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	315576	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	325984	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	338352	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	340160	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	345463	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	368479	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	401470	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	404402	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	409878	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	411995	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	415563	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	422700	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	424453	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	426206	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	435307	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	472665	SweptSolid	0	80	0	0	0	-	0
+ara3d/schependomlaan.ifc	534371	SweptSolid	0	12	0	0	0	-	0
+ara3d/schependomlaan.ifc	558010	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	562146	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	597457	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	605031	SweptSolid	0	40	0	0	0	-	0
+ara3d/schependomlaan.ifc	618431	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	640164	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	643860	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	668602	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	711509	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	717596	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	753581	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	766683	SweptSolid	0	12	0	0	0	-	0
+ara3d/schependomlaan.ifc	778605	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	783014	SweptSolid	0	40	0	0	0	-	0
+ara3d/schependomlaan.ifc	787207	SweptSolid	0	48	0	0	0	-	0
+ara3d/schependomlaan.ifc	820735	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	822589	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	826337	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	829534	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	876846	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	878050	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	879248	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	880446	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	967617	SweptSolid	0	0	0	0	0	-	0
+ara3d/schependomlaan.ifc	969938	SweptSolid	0	0	0	0	0	-	0
+ara3d/tested_sample_project.ifc	186	SweptSolid	0	192	0	0	0	-	0
+ara3d/tested_sample_project.ifc	294	SweptSolid	0	28	0	0	0	-	0
+buildingsmart/wall-with-opening-and-window.ifc	45	unknown	0	32	0	0	0	-	0
+ifc5/Hello_Wall_hello-wall.ifc	1222	SweptSolid	0	68	0	0	0	-	0
+ifcopenshell/faceted_brep_csg.ifc	1096640	CSG	0	58	0	0	0	-	0
+issues/1007_roof_brep_opening_winding.ifc	1112	Brep	0	98	0	0	0	-	0
+issues/218_IFC-test-lite.ifc	417	SweptSolid	8	72	0	0	8	8	24
+issues/821_TallBuilding.ifc	615	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	810	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	887	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	964	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	1297	Clipping	0	44	0	0	0	-	0
+issues/821_TallBuilding.ifc	1850	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	1926	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	2002	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	2078	Clipping	0	52	0	0	0	-	0
+issues/821_TallBuilding.ifc	2401	Clipping	0	68	0	0	0	-	0
+issues/821_TallBuilding.ifc	2477	Clipping	0	72	0	0	0	-	0
+issues/821_TallBuilding.ifc	11462	Clipping	0	44	0	0	0	-	0
+issues/832_opening_representations.ifc	50	SweptSolid	0	32	0	0	0	-	0
+issues/832_opening_representations.ifc	89	SweptSolid	0	36	0	0	0	-	0
+issues/832_opening_representations.ifc	128	SweptSolid	0	32	0	0	0	-	0
+issues/832_opening_representations.ifc	175	SweptSolid	0	28	0	0	0	-	0
+issues/832_opening_representations.ifc	222	SweptSolid	0	28	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	96	SweptSolid	0	96	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	144	SweptSolid	0	28	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	192	SweptSolid	0	68	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	240	SweptSolid	0	32	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	336	SweptSolid	0	174	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	384	SweptSolid	0	322	1	0	0	-	3
+issues/841_house_stack_overflow.ifc	432	SweptSolid	0	338	1	0	0	-	0
+issues/841_house_stack_overflow.ifc	528	SweptSolid	0	60	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	576	SweptSolid	0	28	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	768	SweptSolid	0	48	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	914	SweptSolid	0	32	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	1020	SweptSolid	0	40	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	1070	SweptSolid	0	58	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	1118	SweptSolid	0	60	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	1166	SweptSolid	0	36	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	1362	Clipping	0	92	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	1878	Clipping	0	114	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	2152	Clipping	55	236	1	0	6	4	55
+issues/841_house_stack_overflow.ifc	2797	Clipping	0	44	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	3698	Clipping	0	68	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	4148	Clipping	0	142	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	4219	Clipping	0	52	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	4267	SweptSolid	0	30	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	4374	Clipping	0	62	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	4897	Clipping	0	130	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	5904	Clipping	0	124	0	0	0	-	0
+issues/841_house_stack_overflow.ifc	13928	SweptSolid	0	28	0	0	0	-	0
+issues/845_wall_elemented_case.ifc	130	SweptSolid	0	224	0	0	0	-	0
+issues/845_wall_elemented_case.ifc	133	SweptSolid	0	392	0	0	0	-	31
+issues/845_wall_elemented_case.ifc	145	SweptSolid	0	224	0	0	0	-	56
+issues/845_wall_elemented_case.ifc	146	SweptSolid	0	200	0	0	0	-	7
+issues/845_wall_elemented_case.ifc	148	unknown	0	0	0	0	0	-	0
+issues/853_slab_pocket.ifc	303	SweptSolid	0	260	0	0	0	-	0
+issues/953_trimmed_curve_cartesian_arc.ifc	1112	Brep	0	98	0	0	0	-	0
+issues/960_house_segmented_roof_clip.ifc	2152	Clipping	55	236	1	0	6	4	55
+issues/960_house_segmented_roof_clip.ifc	2797	Clipping	0	44	0	0	0	-	0
+issues/960_house_segmented_roof_clip.ifc	4148	Clipping	0	142	0	0	0	-	0
+issues/960_house_segmented_roof_clip.ifc	4374	Clipping	0	62	0	0	0	-	0
+issues/960_house_segmented_roof_clip.ifc	5904	Clipping	0	124	0	0	0	-	0
+issues/964_slab_arbitrary_profile_voids.ifc	6443	SweptSolid	111	322	0	0	113	64	111
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	430	SweptSolid	0	280	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	654	SweptSolid	0	284	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	857	SweptSolid	0	52	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1029	SweptSolid	0	128	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1183	SweptSolid	0	172	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1369	SweptSolid	0	204	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1536	SweptSolid	0	92	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1649	SweptSolid	0	32	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1691	SweptSolid	0	76	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1789	SweptSolid	0	496	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	1992	SweptSolid	0	32	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	2036	SweptSolid	0	588	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	2411	SweptSolid	0	1406	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3051	SweptSolid	0	48	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3110	SweptSolid	0	112	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	3394	Clipping	0	32	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	25758	SweptSolid	40	308	0	0	40	50	40
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	26830	SweptSolid	0	32	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	27921	Clipping	0	32	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45444	SweptSolid	0	64	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45708	SweptSolid	0	176	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	45774	Clipping	0	40	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	71367	SweptSolid	0	216	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	81962	SweptSolid	136	784	0	0	136	158	136
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	100256	SweptSolid	0	84	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	100536	SweptSolid	0	176	0	0	0	-	0
+various/01_Snowdon_Towers_Sample_Structural(1).ifc	124547	SweptSolid	0	968	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	74	SweptSolid	0	52	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	75	SweptSolid	0	76	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	77	SweptSolid	0	524	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	78	SweptSolid	0	240	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	90	SweptSolid	0	340	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	91	SweptSolid	0	84	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	92	SweptSolid	0	52	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	93	SweptSolid	0	58	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	94	SweptSolid	0	52	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	103	SweptSolid	0	32	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	104	SweptSolid	0	48	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	105	SweptSolid	0	250	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	106	SweptSolid	0	84	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	107	SweptSolid	0	32	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	108	SweptSolid	0	476	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	109	SweptSolid	0	158	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	110	SweptSolid	0	96	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	111	SweptSolid	0	28	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	112	SweptSolid	0	56	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	113	SweptSolid	0	32	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	114	SweptSolid	0	164	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	115	SweptSolid	0	32	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	116	SweptSolid	0	68	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	136	SweptSolid	0	32	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	137	SweptSolid	0	128	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	138	SweptSolid	0	180	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	139	SweptSolid	0	48	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	140	SweptSolid	0	194	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	141	SweptSolid	0	28	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	142	SweptSolid	0	56	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	143	SweptSolid	0	120	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	144	SweptSolid	0	172	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	145	SweptSolid	0	94	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	146	SweptSolid	0	40	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	179	SweptSolid	0	136	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	180	SweptSolid	0	124	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	181	SweptSolid	0	32	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	182	SweptSolid	0	128	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	183	SweptSolid	0	28	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	214	SweptSolid	0	32	0	0	0	-	0
+various/02_BIMcollab_Example_STR_random_C_ebkp.ifc	276	SweptSolid	0	72	0	0	0	-	0
+various/issue-604-door.ifc	55	SweptSolid	0	28	0	0	0	-	0
+various/rvt01.ifc	5941	Tessellation	78	240	0	1	81	11	112
+various/rvt01.ifc	6073	Tessellation	58	213	0	1	69	0	82
+various/rvt01.ifc	6163	SweptSolid	19	69	0	1	19	0	23
+various/rvt01.ifc	6243	SweptSolid	48	118	0	1	63	8	65
+various/rvt01.ifc	6305	SweptSolid	104	228	0	1	97	8	116
+various/rvt01.ifc	6420	SweptSolid	65	143	0	1	72	6	73
+various/rvt01.ifc	6511	SweptSolid	70	152	0	1	61	6	75
+various/rvt01.ifc	6588	SweptSolid	53	113	0	1	53	0	68
+various/rvt01.ifc	6724	SweptSolid	50	190	0	1	51	8	68
+various/rvt01.ifc	6810	SweptSolid	84	198	0	1	86	27	107
+various/rvt01.ifc	6934	SweptSolid	23	89	0	1	29	0	28
+various/rvt01.ifc	7013	SweptSolid	60	167	0	1	50	8	88
+various/rvt01.ifc	7075	SweptSolid	78	216	0	1	67	8	104
+various/rvt01.ifc	7137	SweptSolid	40	149	0	1	43	0	59
+various/rvt01.ifc	7216	SweptSolid	39	129	0	1	37	0	52
+various/rvt01.ifc	7295	SweptSolid	65	100	0	1	42	6	72
+various/rvt01.ifc	7403	Tessellation	11	41	0	1	11	3	18
+various/rvt01.ifc	7544	SweptSolid	99	192	1	1	91	8	125
+various/rvt01.ifc	7700	SweptSolid	61	92	0	1	69	0	63
+various/rvt01.ifc	7834	SweptSolid	87	195	0	1	91	16	125
+various/rvt01.ifc	8881	SweptSolid	70	176	0	1	44	8	95
+various/rvt01.ifc	8997	SweptSolid	86	174	0	1	76	26	104
+various/rvt01.ifc	9058	SweptSolid	91	176	0	1	94	8	104
+various/rvt01.ifc	9229	SweptSolid	72	175	0	1	79	8	89
+various/rvt01.ifc	9400	SweptSolid	55	167	0	1	61	0	66
+various/rvt01.ifc	9730	SweptSolid	50	114	0	1	57	8	62
+various/rvt01.ifc	9901	SweptSolid	45	97	0	1	48	8	62
+various/rvt01.ifc	10191	Tessellation	13	29	0	1	14	0	13
+various/rvt01.ifc	10335	Tessellation	9	9	0	1	7	0	9
+various/rvt01.ifc	10526	Tessellation	29	59	0	1	29	0	29
+various/rvt01.ifc	10632	Tessellation	19	117	0	1	17	0	23
+various/rvt01.ifc	11110	Tessellation	0	4	0	1	3	-	0
+various/rvt01.ifc	11168	Tessellation	26	66	0	1	23	0	26
+various/rvt01.ifc	11232	Tessellation	14	56	0	1	14	6	16
+various/rvt01.ifc	11304	Tessellation	7	27	0	1	7	0	7
+various/rvt01.ifc	11477	Tessellation	0	0	0	1	7	-	0
+various/rvt01.ifc	11563	Tessellation	23	18	0	1	26	0	23
+various/rvt01.ifc	11627	Tessellation	63	63	0	1	54	3	65
+various/rvt01.ifc	11690	Tessellation	72	93	0	1	56	6	73
+various/rvt01.ifc	11753	Tessellation	10	4	0	1	16	0	10
+various/rvt01.ifc	11803	SweptSolid	26	52	0	1	22	0	27
+various/rvt01.ifc	12235	SweptSolid	13	33	0	1	13	0	14
+various/rvt01.ifc	12345	SweptSolid	5	67	0	1	5	0	12
+various/rvt01.ifc	12449	Tessellation	44	145	1	1	48	9	56
+various/rvt01.ifc	13735	SweptSolid	52	161	0	1	38	8	71
+various/rvt01.ifc	13797	Tessellation	161	374	1	1	115	42	209
+various/rvt01.ifc	14014	SweptSolid	49	164	0	1	41	8	68
+various/rvt01.ifc	14132	SweptSolid	79	156	0	1	70	8	92
+various/rvt01.ifc	14194	SweptSolid	64	159	0	1	68	8	81
+various/rvt01.ifc	14256	SweptSolid	55	173	0	1	61	0	77
+various/rvt01.ifc	14447	SweptSolid	47	225	0	1	50	0	86
+various/rvt01.ifc	14638	SweptSolid	50	140	0	1	50	8	71
+various/rvt01.ifc	14797	SweptSolid	40	134	0	1	40	0	52
+various/rvt01.ifc	15020	SweptSolid	62	156	0	1	63	8	80
+various/rvt01.ifc	15301	SweptSolid	69	188	0	1	72	8	93
+various/rvt01.ifc	15857	SweptSolid	61	178	0	1	67	12	78
+various/rvt01.ifc	15917	SweptSolid	64	187	0	1	83	16	94
+various/rvt01.ifc	16231	SweptSolid	45	100	0	1	42	0	57
+various/rvt01.ifc	16286	SweptSolid	53	146	1	1	66	8	69
+various/rvt01.ifc	16805	SweptSolid	45	95	0	1	39	8	61
+various/rvt01.ifc	17553	Tessellation	4	10	0	1	4	0	7
+various/rvt01.ifc	17615	Tessellation	20	44	0	1	20	0	20
+various/rvt01.ifc	17919	Tessellation	9	45	0	1	16	0	17
+various/rvt01.ifc	17985	Tessellation	40	52	0	1	34	0	40
+various/rvt01.ifc	18169	SweptSolid	78	135	1	1	73	8	93
+various/rvt01.ifc	21999	SweptSolid	0	40	0	1	0	-	20
+various/rvt01.ifc	25694	Tessellation	15	105	0	1	15	0	15
+various/rvt01.ifc	25914	SweptSolid	38	154	0	1	38	0	57
+various/rvt01.ifc	26166	Tessellation	36	96	0	1	32	0	46
+various/rvt01.ifc	26300	Tessellation	63	103	1	1	57	0	73
+various/rvt01.ifc	26610	Tessellation	18	58	0	1	18	0	18
+various/rvt01.ifc	26681	Tessellation	32	142	0	1	24	0	38
+various/rvt01.ifc	26832	Tessellation	11	17	0	1	11	0	11
+various/rvt01.ifc	30054	Tessellation	11	41	0	1	11	0	11
+various/rvt01.ifc	30125	Tessellation	13	39	0	1	6	0	13
+various/rvt01.ifc	30518	Tessellation	59	215	0	1	39	0	64
+various/rvt01.ifc	31083	Tessellation	28	42	0	1	17	0	28
+various/rvt01.ifc	31156	Tessellation	41	125	0	1	40	0	42
+various/rvt01.ifc	31323	Tessellation	0	8	0	1	0	-	3
+various/rvt01.ifc	31430	Tessellation	17	41	0	1	14	0	19
+various/rvt01.ifc	31577	Tessellation	11	41	0	1	11	0	11
+various/rvt01.ifc	31648	Tessellation	13	39	0	1	6	0	13
+various/rvt01.ifc	32081	SweptSolid	62	175	1	1	52	0	85
+various/rvt01.ifc	33639	SweptSolid	122	308	0	1	157	24	135
+various/rvt01.ifc	37278	Tessellation	4	16	0	1	5	0	4
+various/rvt01.ifc	37347	Tessellation	49	106	0	1	46	0	66
+various/rvt01.ifc	37455	Tessellation	66	145	1	1	57	3	71
+various/rvt01.ifc	37570	SweptSolid	3	75	0	1	3	0	15
+various/rvt01.ifc	38680	Tessellation	32	84	0	1	34	0	42
+various/rvt01.ifc	38745	SweptSolid	22	44	0	1	22	0	24
+various/rvt01.ifc	38800	SweptSolid	72	201	1	1	95	14	116

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -182,18 +182,43 @@ fn process(content: &str, host_id: u32, voids: &FxHashMap<u32, Vec<u32>>) -> Opt
     router.process_element_with_voids(&entity, &mut decoder, voids).ok()
 }
 
-/// Open boundary edges on a 1 mm position-snapped topology, and separately the
-/// count of DEGENERATE edges (both endpoints snapping to one position).
+/// Two readings of watertightness plus the degenerate-triangle count, all from
+/// ONE walk over ONE 1 mm position-snapped topology.
 ///
-/// The distinction is load-bearing. A degenerate edge is a self-loop produced by
-/// a triangle that collapsed under the snap, which happens wholesale on
-/// georeferenced models: `Mesh.positions` is f32, and at UTM-scale coordinates
-/// (~5e5) the f32 step is ~3 cm, so a 200 mm wall cannot be represented at all.
-/// The pipeline's RTC offset exists to prevent that, but it is applied ABOVE
-/// `GeometryRouter::process_element`, which this harness calls directly. Counting
-/// self-loops as open boundary would therefore measure a harness artifact rather
-/// than a watertightness defect.
-fn edge_stats(mesh: &Mesh) -> (usize, usize) {
+/// Both readings off the same walk is the point of #3397 rather than a tidiness
+/// choice: two separate passes could be given two different snap tolerances, or
+/// two different degenerate-skip rules, and the per-host comparison this census
+/// now prints would silently stop comparing like with like.
+struct EdgeStats {
+    /// The SIGNED per-edge balance: undirected edges whose forward and reverse
+    /// use counts DIFFER. The census's historical reading, unchanged.
+    ///
+    /// Blind to every topology where the two counts grow together, because the
+    /// net stays zero: a face duplicated along with its opposite-wound twin, a
+    /// duplicated shell, a 2-forward / 2-reverse seam. See `strict`.
+    open: usize,
+    /// The STRICT directed-pair rule: undirected edges NOT used exactly once
+    /// forward and once reverse (#3397). This is the manifold condition the rest
+    /// of the repo already checks — `touching_operand.rs` counts the two
+    /// directions apart for this reason, and `issue_3353_boolean_tear.rs` pins
+    /// `f != 1 || r != 1` — and it is a superset of `open` by construction,
+    /// since `f != r` implies `(f, r) != (1, 1)`.
+    strict: usize,
+    /// Triangles that COLLAPSED under the snap (two of their three endpoints
+    /// landing on one position), counted and then skipped by BOTH readings.
+    ///
+    /// The distinction is load-bearing. A degenerate edge is a self-loop
+    /// produced by a triangle that collapsed under the snap, which happens
+    /// wholesale on georeferenced models: `Mesh.positions` is f32, and at
+    /// UTM-scale coordinates (~5e5) the f32 step is ~3 cm, so a 200 mm wall
+    /// cannot be represented at all. The pipeline's RTC offset exists to prevent
+    /// that, but it is applied ABOVE `GeometryRouter::process_element`, which
+    /// this harness calls directly. Counting self-loops as open boundary would
+    /// therefore measure a harness artifact rather than a watertightness defect.
+    degenerate: usize,
+}
+
+fn edge_stats(mesh: &Mesh) -> EdgeStats {
     let q = |v: f32| (v as f64 * 1.0e3).round() as i64;
     let mut vid: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
     let mut id = |i: usize| -> u32 {
@@ -205,7 +230,11 @@ fn edge_stats(mesh: &Mesh) -> (usize, usize) {
         let n = vid.len() as u32;
         *vid.entry(k).or_insert(n)
     };
-    let mut bal: FxHashMap<(u32, u32), i32> = FxHashMap::default();
+    // (forward uses, reverse uses) per undirected edge, forward meaning the
+    // low-to-high orientation. Keeping the two directions APART rather than
+    // netting them is the whole of #3397: a net of zero cannot tell 1f/1r from
+    // 2f/2r, and the second is a duplicated or non-manifold sheet.
+    let mut uses: FxHashMap<(u32, u32), (u32, u32)> = FxHashMap::default();
     let mut degenerate = 0usize;
     for tri in mesh.indices.chunks_exact(3) {
         let (a, b, c) = (id(tri[0] as usize), id(tri[1] as usize), id(tri[2] as usize));
@@ -214,15 +243,32 @@ fn edge_stats(mesh: &Mesh) -> (usize, usize) {
             continue; // a collapsed triangle has no meaningful boundary
         }
         for (x, y) in [(a, b), (b, c), (c, a)] {
-            let (k, s) = if x < y { ((x, y), 1) } else { ((y, x), -1) };
-            *bal.entry(k).or_insert(0) += s;
+            let e = uses.entry((x.min(y), x.max(y))).or_insert((0, 0));
+            if x < y {
+                e.0 += 1;
+            } else {
+                e.1 += 1;
+            }
         }
     }
-    (bal.values().filter(|&&v| v != 0).count(), degenerate)
+    EdgeStats {
+        open: uses.values().filter(|&&(f, r)| f != r).count(),
+        strict: uses.values().filter(|&&(f, r)| f != 1 || r != 1).count(),
+        degenerate,
+    }
 }
 
+/// The SIGNED reading alone, for the `alt` and `pre` columns.
+///
+/// Those two stay signed deliberately (#3397). `alt` is gated through
+/// [`HostRow::diverged`] and `pre` through `is_torn_solid`, so widening either
+/// would move `non-invariant` and `genuine defects` on every host where the two
+/// rules disagree — the same population this change exists to MEASURE, which
+/// cannot be measured and re-baselined in one step. The cost is stated on
+/// [`HostRow::open_is_comparable`]: a doubled sheet only one triangulator emits
+/// is still invisible here.
 fn open_boundary_edges(mesh: &Mesh) -> usize {
-    edge_stats(mesh).0
+    edge_stats(mesh).open
 }
 
 /// Byte offset of each entity's `#id=` line, built in ONE pass over the file.
@@ -402,8 +448,8 @@ fn fmt_deltas(ds: &[Delta]) -> String {
 
 fn fmt_host(r: &HostRow) -> String {
     format!(
-        "{} #{}  {:<14} open={} tris={}",
-        r.model, r.id, r.rep, r.open, r.tris
+        "{} #{}  {:<14} open={} strict={} tris={}",
+        r.model, r.id, r.rep, r.open, r.strict, r.tris
     )
 }
 
@@ -443,10 +489,15 @@ fn watertightness_is_invariant_to_the_triangulator() {
             let alt = process(&content, id, &voids);
             set_alt(false);
 
-            let (open, degenerate) = edge_stats(&base);
+            let stats = edge_stats(&base);
+            let open = stats.open;
             // Only taken for torn hosts: it is a full second processing pass,
             // and it is only ever read to attribute a tear to construction or
-            // to the boolean.
+            // to the boolean. Triggered on the SIGNED reading, not the strict
+            // one, for the reason `open_boundary_edges` gives: widening the
+            // trigger would move `pre` on exactly the hosts #3397 exists to
+            // count, re-baselining the population in the commit that measures
+            // it.
             let pre = if open == 0 {
                 PreVoid::NotTaken
             } else {
@@ -460,8 +511,9 @@ fn watertightness_is_invariant_to_the_triangulator() {
                 id,
                 rep: representation_type(&content, &lines, id),
                 open,
+                strict: stats.strict,
                 tris: base.indices.len() / 3,
-                collapsed: degenerate > 0,
+                collapsed: stats.degenerate > 0,
                 far: max_abs_coord(&base) >= F32_SAFE_MAGNITUDE,
                 alt: alt.as_ref().map(open_boundary_edges),
                 pre,
@@ -478,7 +530,55 @@ fn watertightness_is_invariant_to_the_triangulator() {
         "hosts with collapsed triangles (f32 precision): {}/{}",
         run.collapsed, run.hosts
     );
-    println!("TOTAL unmatched edges across corpus: {}", run.open_edges);
+    println!("TOTAL unmatched edges across corpus (signed):  {}", run.open_edges);
+    println!("TOTAL directed-pair violations (strict):        {}", run.strict_edges);
+
+    // #3397's measurement, and the reason `strict` is a SECOND column rather
+    // than a replacement for `open`: how far apart the two rules actually are on
+    // this corpus. A host listed here is certified watertight by the signed
+    // balance while carrying edges that are not a clean one-forward /
+    // one-reverse pair — a doubled sheet, a duplicated shell, or a 2f/2r seam.
+    // Under the signed reading alone that population is not merely un-gated, it
+    // is unknown, because `torn` and `total unmatched edges` both derive from
+    // the count that cannot see it.
+    let signed_only: Vec<&HostRow> = rows.iter().filter(|r| r.open == 0 && r.strict > 0).collect();
+    println!(
+        "\nwatertight by the SIGNED balance, torn by the STRICT directed-pair rule: {}/{}",
+        signed_only.len(),
+        run.hosts
+    );
+    // Two further readings, each saying only what it counts. The host tally
+    // above answers #3397's question ("watertight by one rule, not the other");
+    // these two say how far apart the rules are everywhere else, and are kept
+    // separate from it because a corpus-wide edge total is NOT a statement
+    // about the hosts listed above.
+    println!(
+        "  hosts where the two readings disagree at all (strict > open): {}/{}",
+        rows.iter().filter(|r| r.strict > r.open).count(),
+        run.hosts
+    );
+    // `strict` is a superset of `open` per host, so this subtraction cannot
+    // wrap: every edge the signed balance counts is one the strict rule counts
+    // too.
+    println!(
+        "  corpus edge totals: {} signed, {} strict — {} edges the signed balance cannot see",
+        run.open_edges,
+        run.strict_edges,
+        run.strict_edges - run.open_edges
+    );
+    if !signed_only.is_empty() {
+        println!("    rep            model / element                  strict  tris");
+        for r in signed_only.iter().take(12) {
+            println!(
+                "    {:<14} {:<32} {:>6}  {:>5}",
+                r.rep,
+                format!("{} #{}", r.model, r.id),
+                r.strict,
+                r.tris
+            );
+        }
+    }
+
     let mut by_rep: std::collections::BTreeMap<&str, usize> = Default::default();
     for r in rows.iter().filter(|r| r.open > 0) {
         *by_rep.entry(r.rep.as_str()).or_insert(0) += 1;
@@ -737,6 +837,7 @@ fn watertightness_is_invariant_to_the_triangulator() {
     println!("  void hosts        : {} vs {}", run.hosts, expected.hosts);
     println!("  torn hosts        : {} vs {}", run.torn, expected.torn);
     println!("  unmatched edges   : {} vs {}", run.open_edges, expected.open_edges);
+    println!("  strict-rule edges : {} vs {}", run.strict_edges, expected.strict_edges);
     println!("  collapsed hosts   : {} vs {}", run.collapsed, expected.collapsed);
     println!("  genuine defects   : {} vs {}", run.torn_solid, expected.torn_solid);
     println!("  non-invariant     : {} vs {}", run.non_invariant, expected.non_invariant);
@@ -828,6 +929,7 @@ fn watertightness_is_invariant_to_the_triangulator() {
     // edges to 324, and an element-count gate saw only the improvement.
     for (name, got, want) in [
         ("total unmatched edges", run.open_edges, expected.open_edges),
+        ("total strict directed-pair violations", run.strict_edges, expected.strict_edges),
         ("torn void hosts", run.torn, expected.torn),
         ("hosts with snap-collapsed triangles", run.collapsed, expected.collapsed),
         ("closed solids that are not watertight", run.torn_solid, expected.torn_solid),
@@ -835,4 +937,99 @@ fn watertightness_is_invariant_to_the_triangulator() {
     ] {
         assert!(got <= want, "{name} grew: {got} > {want} (golden-derived)");
     }
+}
+
+/// A unit cube as 8 welded vertices and 12 consistently wound triangles.
+///
+/// Every one of its 18 undirected edges is used exactly once forward and once
+/// reverse, which is what makes it a valid null case for BOTH readings at once:
+/// a fixture that were merely balanced would leave `strict` untested.
+fn unit_cube() -> Mesh {
+    let mut m = Mesh::new();
+    m.positions = vec![
+        0.0, 0.0, 0.0, // 0
+        1.0, 0.0, 0.0, // 1
+        1.0, 1.0, 0.0, // 2
+        0.0, 1.0, 0.0, // 3
+        0.0, 0.0, 1.0, // 4
+        1.0, 0.0, 1.0, // 5
+        1.0, 1.0, 1.0, // 6
+        0.0, 1.0, 1.0, // 7
+    ];
+    m.indices = vec![
+        0, 3, 2, 0, 2, 1, // z = 0
+        4, 5, 6, 4, 6, 7, // z = 1
+        0, 1, 5, 0, 5, 4, // y = 0
+        1, 2, 6, 1, 6, 5, // x = 1
+        2, 3, 7, 2, 7, 6, // y = 1
+        3, 0, 4, 3, 4, 7, // x = 0
+    ];
+    m
+}
+
+/// #3397. The census measured watertightness with a SIGNED per-edge balance, so
+/// a face duplicated along with its opposite-wound twin contributes one extra
+/// forward AND one extra reverse use of each of its edges, cancels to zero, and
+/// is certified closed. Both readings now come off the same walk, and this is
+/// the mesh they disagree on.
+#[test]
+fn a_doubled_coincident_face_is_invisible_to_the_signed_balance_but_not_the_strict_rule() {
+    let clean = edge_stats(&unit_cube());
+    assert_eq!(clean.open, 0, "a closed cube has no unbalanced edges");
+    assert_eq!(clean.strict, 0, "and every one of its edges is a clean 1f/1r pair");
+    assert_eq!(clean.degenerate, 0);
+
+    // Re-emit one existing face triangle AND its reverse. Every position is
+    // already in the mesh, so this adds no boundary at all: the three affected
+    // edges go from 1 forward / 1 reverse to 2 forward / 2 reverse.
+    let mut doubled = unit_cube();
+    doubled.indices.extend_from_slice(&[0, 3, 2, 0, 2, 3]);
+
+    let s = edge_stats(&doubled);
+    // Pins the signed column's BLIND SPOT as a measurement rather than
+    // asserting it is right. This is the reading the census still gates its
+    // defect population on, so what it cannot see has to be written down.
+    assert_eq!(s.open, 0, "the signed balance cannot see a doubled coincident sheet");
+    assert_eq!(s.strict, 3, "the strict rule sees all three of its edges");
+    assert_eq!(s.degenerate, 0);
+}
+
+/// The superset relation the two columns are compared under. A real hole moves
+/// BOTH readings, so `strict` is not merely a different number: `f != r` implies
+/// `(f, r) != (1, 1)`, and a census row with `strict < open` would be a state
+/// neither this walk nor the golden's parser should ever produce.
+#[test]
+fn a_real_hole_moves_both_readings_and_strict_is_never_below_open() {
+    let mut holed = unit_cube();
+    holed.indices.truncate(holed.indices.len() - 3); // drop one triangle
+    let s = edge_stats(&holed);
+    assert_eq!(s.open, 3, "the three edges of the missing triangle are unbalanced");
+    assert_eq!(s.strict, 3, "and the strict rule counts the same three");
+
+    for m in [unit_cube(), holed, {
+        let mut d = unit_cube();
+        d.indices.extend_from_slice(&[0, 3, 2, 0, 2, 3]);
+        d
+    }] {
+        let s = edge_stats(&m);
+        assert!(s.strict >= s.open, "strict {} < open {}", s.strict, s.open);
+    }
+}
+
+/// A triangle that collapses under the 1 mm snap is skipped by BOTH readings, so
+/// it cannot inflate the strict count the way it would if only `open` skipped
+/// it. `HostRow.collapsed` is what reports the collapse instead.
+#[test]
+fn a_snap_collapsed_triangle_is_skipped_by_both_readings() {
+    let mut m = unit_cube();
+    // Two vertices 0.1 mm apart snap to one position, so this triangle is a
+    // self-loop rather than a boundary. Positions are metres; the snap is 1 mm.
+    let base = (m.positions.len() / 3) as u32;
+    m.positions.extend_from_slice(&[5.0, 5.0, 5.0, 5.0001, 5.0, 5.0, 5.0, 6.0, 5.0]);
+    m.indices.extend_from_slice(&[base, base + 1, base + 2]);
+
+    let s = edge_stats(&m);
+    assert_eq!(s.degenerate, 1, "the collapsed triangle is counted");
+    assert_eq!(s.open, 0, "and contributes no unbalanced edge");
+    assert_eq!(s.strict, 0, "nor any strict violation, or every far-field host would gain some");
 }

--- a/rust/geometry/tests/triangulation_invariance.rs
+++ b/rust/geometry/tests/triangulation_invariance.rs
@@ -967,6 +967,22 @@ fn unit_cube() -> Mesh {
     m
 }
 
+/// [`unit_cube`] with one existing face triangle re-emitted AND its reverse.
+///
+/// Every position is already in the mesh, so this adds no boundary at all: the
+/// three affected edges go from 1 forward / 1 reverse to 2 forward / 2 reverse.
+/// That is the exact shape the signed balance cancels to zero on.
+///
+/// ONE fixture rather than a copy per test, because the six indices are what
+/// makes it a doubling rather than a hole: a copy that drifted would leave the
+/// superset test below asserting `strict >= open` over some other mesh, and
+/// passing.
+fn doubled_face_cube() -> Mesh {
+    let mut m = unit_cube();
+    m.indices.extend_from_slice(&[0, 3, 2, 0, 2, 3]);
+    m
+}
+
 /// #3397. The census measured watertightness with a SIGNED per-edge balance, so
 /// a face duplicated along with its opposite-wound twin contributes one extra
 /// forward AND one extra reverse use of each of its edges, cancels to zero, and
@@ -979,13 +995,7 @@ fn a_doubled_coincident_face_is_invisible_to_the_signed_balance_but_not_the_stri
     assert_eq!(clean.strict, 0, "and every one of its edges is a clean 1f/1r pair");
     assert_eq!(clean.degenerate, 0);
 
-    // Re-emit one existing face triangle AND its reverse. Every position is
-    // already in the mesh, so this adds no boundary at all: the three affected
-    // edges go from 1 forward / 1 reverse to 2 forward / 2 reverse.
-    let mut doubled = unit_cube();
-    doubled.indices.extend_from_slice(&[0, 3, 2, 0, 2, 3]);
-
-    let s = edge_stats(&doubled);
+    let s = edge_stats(&doubled_face_cube());
     // Pins the signed column's BLIND SPOT as a measurement rather than
     // asserting it is right. This is the reading the census still gates its
     // defect population on, so what it cannot see has to be written down.
@@ -1006,11 +1016,7 @@ fn a_real_hole_moves_both_readings_and_strict_is_never_below_open() {
     assert_eq!(s.open, 3, "the three edges of the missing triangle are unbalanced");
     assert_eq!(s.strict, 3, "and the strict rule counts the same three");
 
-    for m in [unit_cube(), holed, {
-        let mut d = unit_cube();
-        d.indices.extend_from_slice(&[0, 3, 2, 0, 2, 3]);
-        d
-    }] {
+    for m in [unit_cube(), holed, doubled_face_cube()] {
         let s = edge_stats(&m);
         assert!(s.strict >= s.open, "strict {} < open {}", s.strict, s.open);
     }


### PR DESCRIPTION
Closes #3397.

`edge_stats` measured watertightness with a SIGNED per-edge balance (+1 forward, -1
reverse, count non-zero). A duplicated face contributes one extra forward and one extra
reverse use of each edge and cancels to zero; so does a 2-forward / 2-reverse seam. Both
`total unmatched edges` and `torn void hosts` derive from that count, so a duplicate-face
defect was invisible to the gate in either direction.

The repo already held the stricter reading and said why — `touching_operand.rs` ("A
net-signed tally is not enough: an edge used twice forward and twice reverse cancels to
zero, so a non-manifold seam would be certified closed"), the bowtie fixture in
`processors/boolean/chain_cycle_tests.rs`, and #3388's pin checking `forward == 1 &&
reverse == 1` per directed edge. The census used the weaker one.

## Option 1 as filed: a SECOND column, not a replacement

`strict` is added beside `open`, both computed from the same walk over the same triangles
so they cannot drift. Replacing the signed count outright would change every number in the
golden and surface pre-existing non-manifold hosts as new tears; keeping both is what lets
the two readings be compared per host.

## The number the issue was filed to obtain

Over 1170 corpus hosts:

| | count |
|---|---|
| `strict < signed` | **0** |
| `strict == signed` | 1054 |
| `strict > signed` | **116** |
| of those, crossing the watertight boundary (`open == 0`, `strict > 0`) | **7** |

Both numbers matter and quoting either alone misleads. The two rules disagree on **116**
hosts; on 109 of them both already call the host torn and `strict` simply counts more
unmatched edges, so the signed balance was under-reporting severity without changing the
verdict. The **7** are where the census would have called a host watertight and the strict
rule does not — the population the gate could have been wrong about.

`strict < signed` on zero hosts is the sanity property: a directed-pair rule can only find
the same defects or more, never fewer, so a single host below would mean one counter is
wrong rather than merely weaker.

## The re-bless, verified rather than trusted

Regenerating a golden accepts every difference in it, including ones the change did not
cause. So the manifest was checked, not blessed and hoped for: **1170 data rows before and
after, 9 -> 10 columns, and stripping the new `strict` column reproduces `origin/main`'s
rows byte-for-byte.** No existing column moved on any host. Re-verified at the final head,
not only when first generated.

`HEADER` gained a `strict:` legend describing what it sees that `open` cannot, so #3401's
byte-for-byte golden assertion stays satisfied.

The blind-spot note on `open_is_a_defect_count` documented this exact limitation and would
otherwise have been a comment that was true when written and false afterwards; it now says
what is measured and what still is not.

Test-only: three files under `rust/geometry/tests/`. No changeset, no API surface.

Gates: `cargo test -p ifc-lite-geometry --no-fail-fast` exit 0,
`cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict directed-edge metrics to geometry quality reports and aggregate totals.
  * Census exports now include the strict-edge count for each entry.
  * Diagnostics distinguish signed edge-balance issues from strict directed-pair violations.

* **Bug Fixes**
  * Improved detection of doubled faces, holes, and snap-collapsed triangles.
  * Regression checks now flag unexpected increases in strict-edge violations while preserving repair-related exceptions.

* **Tests**
  * Expanded coverage for clean meshes, topology defects, serialization, round trips, and golden validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->