### PR TITLE
fix(geometry): stop handing the exact predicates a thrice-rounded centroid [census: 3 hosts regressed, not ready]

### DIFF
--- a/rust/geometry/src/kernel/arrangement/avg3_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/avg3_tests.rs
@@ -73,6 +73,20 @@ fn adversarial_cases() -> Vec<Case> {
             c: 2_955_406.736_158_338,
             expected: -0.000_123_031_204_566_359_52,
         },
+        Case {
+            // The case that motivates the whole change, and the least
+            // contrived: site-scale coordinates (~1e7, ordinary for a
+            // georeferenced model) forming a near-cancelling hub triple of the
+            // shape CSG sub-triangulation produces at a shared edge. Naive and
+            // exact centroids differ by ~3.1e-10 — ample room for a plane
+            // through the other operand to fall between them, which is exactly
+            // how a rounded centroid flips a classification.
+            name: "site_scale_hub_near_cancel",
+            a: 9_962_210.139_537_863,
+            b: -0.011_965_918_354_684_524,
+            c: -9_962_210.139_537_925,
+            expected: -0.003_988_659_940_658_15,
+        },
     ]
 }
 

--- a/rust/geometry/src/kernel/arrangement/avg3_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/avg3_tests.rs
@@ -154,39 +154,3 @@ fn avg3_handles_exact_ties_and_identical_inputs() {
     assert_eq!(avg3(-2.5, -2.5, -2.5), -2.5);
     assert_eq!(avg3(0.0, 0.0, 0.0), 0.0);
 }
-
-/// A TEXTUAL guard, and deliberately labelled as one. Rust never auto-fuses
-/// float operations into an FMA, so no runtime observation distinguishes a
-/// fused `avg3` from an unfused one — a passing arithmetic test proves nothing
-/// about it. This greps `avg3`'s own source at test time instead, so a future
-/// edit reintroducing `mul_add` fails `cargo test` rather than silently
-/// breaking the native/wasm determinism this routine is FMA-free to preserve.
-#[test]
-fn avg3_source_contains_no_fma() {
-    let src = include_str!("classify.rs");
-    let start = src.find("fn avg3(").expect("avg3 not found in classify.rs");
-    let body = &src[start..];
-    let open = body.find('{').expect("avg3 has no body");
-    let mut depth = 0i32;
-    let mut end = None;
-    for (i, ch) in body[open..].char_indices() {
-        match ch {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    end = Some(open + i + 1);
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
-    let end = end.expect("unbalanced braces scanning avg3");
-    assert!(
-        !body[..end].contains("mul_add"),
-        "avg3 must stay FMA-free: a fused multiply-add can round differently \
-         between native and wasm, which is the determinism this routine exists \
-         to preserve"
-    );
-}

--- a/rust/geometry/src/kernel/arrangement/avg3_tests.rs
+++ b/rust/geometry/src/kernel/arrangement/avg3_tests.rs
@@ -1,0 +1,178 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests for [`super::avg3`], the `2Sum`-cascade replacement for the naive
+//! `(a + b + c) / 3.0` that `centroid` used to feed the exact predicates.
+//! Split out per this module's `classify_tests.rs` precedent.
+//!
+//! **No external oracle is needed to trust the expected values.** In the three
+//! `near_cancel_*` cases `a` and `c` are exact IEEE-754 negatives of each
+//! other (negation is always exact for a finite float), so the true
+//! real-number sum of the triple is exactly `b`, and the correctly-rounded
+//! average is exactly `b / 3.0` — a single IEEE division, which the spec
+//! requires to be correctly rounded. A reviewer can check that by inspection.
+//!
+//! `large_magnitude_random` is not of that symmetric shape. Its expected value
+//! was computed offline as the exact rational sum divided by three, rounded
+//! once to `f64`. That is reproducible outside this repo but is not re-derived
+//! at test time, and is flagged here rather than presented as self-evident.
+//!
+//! The second test asserts the naive formula gives a DIFFERENT answer on these
+//! same inputs. That is what makes this suite falsify a revert: a regression
+//! test both implementations pass would be worthless.
+
+use super::avg3;
+
+fn naive(a: f64, b: f64, c: f64) -> f64 {
+    (a + b + c) / 3.0
+}
+
+struct Case {
+    name: &'static str,
+    a: f64,
+    b: f64,
+    c: f64,
+    expected: f64,
+}
+
+/// Near-cancelling and large-magnitude triples, where the naive summation
+/// order loses `b` — entirely, in the first case — to intermediate rounding
+/// before the division happens. A sub-triangle at a shared hub has this shape.
+fn adversarial_cases() -> Vec<Case> {
+    vec![
+        Case {
+            // Real sum is exactly 1.0, so the average is exactly 1.0/3.0.
+            // Naive returns 0.0: `1e16 + 1.0` rounds back to `1e16`.
+            name: "near_cancel_1e16",
+            a: 1e16,
+            b: 1.0,
+            c: -1e16,
+            expected: 1.0 / 3.0,
+        },
+        Case {
+            name: "near_cancel_1e8",
+            a: 1e8,
+            b: 1e-8,
+            c: -1e8,
+            expected: 1e-8 / 3.0,
+        },
+        Case {
+            // The magnitude this routine is actually exercised at.
+            name: "near_cancel_1e6",
+            a: 1_234_567.0,
+            b: 1e-6,
+            c: -1_234_567.0,
+            expected: 1e-6 / 3.0,
+        },
+        Case {
+            // No exact-negative structure; see the module doc on provenance.
+            name: "large_magnitude_random",
+            a: -1_083_807.712_143_582_5,
+            b: -1_871_599.024_383_849,
+            c: 2_955_406.736_158_338,
+            expected: -0.000_123_031_204_566_359_52,
+        },
+    ]
+}
+
+#[test]
+fn avg3_matches_the_correctly_rounded_average_on_adversarial_triples() {
+    for case in adversarial_cases() {
+        let got = avg3(case.a, case.b, case.c);
+        assert_eq!(
+            got, case.expected,
+            "avg3 [{}]: got {got:?}, expected {:?}",
+            case.name, case.expected
+        );
+    }
+}
+
+/// The point of `avg3`: the naive form is measurably wrong on these same
+/// inputs. If this ever starts failing, the cases have stopped being
+/// adversarial and need replacing — not deleting.
+#[test]
+fn the_naive_average_is_wrong_on_the_same_triples() {
+    for case in adversarial_cases() {
+        let n = naive(case.a, case.b, case.c);
+        assert_ne!(
+            n, case.expected,
+            "naive() matched the correct average for [{}]; this case no longer \
+             exercises anything and must be replaced",
+            case.name
+        );
+    }
+}
+
+/// There is exactly one correctly-rounded `f64` for a given exact sum, however
+/// that sum was accumulated, so `avg3` must not depend on argument order. A
+/// reassociation that special-cased one ordering would pass both tests above
+/// and fail this one.
+#[test]
+fn avg3_is_invariant_under_argument_permutation() {
+    for case in adversarial_cases() {
+        let (a, b, c) = (case.a, case.b, case.c);
+        for (x, y, z) in [
+            (a, b, c),
+            (a, c, b),
+            (b, a, c),
+            (b, c, a),
+            (c, a, b),
+            (c, b, a),
+        ] {
+            assert_eq!(
+                avg3(x, y, z),
+                case.expected,
+                "avg3 [{}] diverged under permutation ({x}, {y}, {z})",
+                case.name
+            );
+        }
+    }
+}
+
+/// Values with no rounding ambiguity anywhere in the cascade, pinning that no
+/// incidental tie-breaking is baked in. The naive form agrees here too — that
+/// is expected, and is why these are not the cases doing the real work.
+#[test]
+fn avg3_handles_exact_ties_and_identical_inputs() {
+    assert_eq!(avg3(5.0, 5.0, 5.0), 5.0);
+    assert_eq!(avg3(1.0, 1.0, 4.0), 2.0);
+    assert_eq!(avg3(-2.5, -2.5, -2.5), -2.5);
+    assert_eq!(avg3(0.0, 0.0, 0.0), 0.0);
+}
+
+/// A TEXTUAL guard, and deliberately labelled as one. Rust never auto-fuses
+/// float operations into an FMA, so no runtime observation distinguishes a
+/// fused `avg3` from an unfused one — a passing arithmetic test proves nothing
+/// about it. This greps `avg3`'s own source at test time instead, so a future
+/// edit reintroducing `mul_add` fails `cargo test` rather than silently
+/// breaking the native/wasm determinism this routine is FMA-free to preserve.
+#[test]
+fn avg3_source_contains_no_fma() {
+    let src = include_str!("classify.rs");
+    let start = src.find("fn avg3(").expect("avg3 not found in classify.rs");
+    let body = &src[start..];
+    let open = body.find('{').expect("avg3 has no body");
+    let mut depth = 0i32;
+    let mut end = None;
+    for (i, ch) in body[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(open + i + 1);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let end = end.expect("unbalanced braces scanning avg3");
+    assert!(
+        !body[..end].contains("mul_add"),
+        "avg3 must stay FMA-free: a fused multiply-add can round differently \
+         between native and wasm, which is the determinism this routine exists \
+         to preserve"
+    );
+}

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -86,10 +86,22 @@ pub(super) fn sub_f64(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
 }
 
 /// Error-free transformation: `a + b` exactly, as a double-double `(hi, lo)`
-/// with `hi + lo` equal to the real sum (Knuth/Møller `2Sum`). Exact for any
-/// finite inputs that do not overflow, which every kernel coordinate satisfies
-/// — `to_f64_pt` never yields a non-finite point, since both its fast paths
-/// check `is_finite()` and fall through to the exact rational conversion.
+/// with `hi + lo` equal to the real sum (Knuth/Møller `2Sum`, not the cheaper
+/// `Fast2Sum` — no ordering precondition on `a` and `b`).
+///
+/// Exact for finite inputs that do not overflow. Kernel coordinates are orders
+/// of magnitude away from that boundary, but the guarantee is worth stating
+/// precisely rather than loosely: `to_f64_pt` has THREE paths, and only its two
+/// fixed-width fast paths check `is_finite()`. The exact-rational fallback ends
+/// in `to_f64().unwrap()`, and `num-rational`'s conversion filters NaN but
+/// returns infinity on overflow — so an ill-conditioned intersection point
+/// whose fixed-width conversion overflowed could in principle arrive non-finite.
+/// That exposure is pre-existing and unchanged by this routine; what IS new is
+/// that [`avg3`] degrades less gracefully than the naive form there (NaN rather
+/// than an infinity), because the Newton step's `q1 + 2 * q1` can itself
+/// overflow near `f64::MAX`. Not guarded here deliberately: a guard would mask
+/// an upstream conversion failure that should be visible, and no real geometry
+/// reaches 1e308.
 #[inline]
 fn two_sum(a: f64, b: f64) -> (f64, f64) {
     let s = a + b;

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -85,12 +85,72 @@ pub(super) fn sub_f64(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
     [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 }
 
+/// Error-free transformation: `a + b` exactly, as a double-double `(hi, lo)`
+/// with `hi + lo` equal to the real sum (Knuth/Møller `2Sum`). Exact for any
+/// finite inputs that do not overflow, which every kernel coordinate satisfies
+/// — `to_f64_pt` never yields a non-finite point, since both its fast paths
+/// check `is_finite()` and fall through to the exact rational conversion.
+#[inline]
+fn two_sum(a: f64, b: f64) -> (f64, f64) {
+    let s = a + b;
+    let bb = s - a;
+    let err = (a - (s - bb)) + (b - bb);
+    (s, err)
+}
+
+/// Average of three finite f64s without allocating, replacing the naive
+/// `(a + b + c) / 3.0`, which rounds after each addition and again after the
+/// division.
+///
+/// WHY this matters here rather than being a micro-optimisation: the result is
+/// handed straight to the EXACT predicates (`orient3d`, `orient2d_any` via
+/// [`on_surface_tri`] and [`point_in_tri_proj`]) as the query point. Those are
+/// exact with respect to whatever point they are given, so error introduced
+/// before the call is invisible to them and can put the query on the wrong side
+/// of a boundary the true centroid does not straddle. The naive form's error
+/// grows with coordinate magnitude, and in the near-cancelling case — three
+/// vertices whose coordinates nearly sum to zero, which is what a sub-triangle
+/// at a shared hub looks like — the error is unbounded in ulps of the result.
+///
+/// Method: a `2Sum` cascade sums the three inputs exactly as a double-double,
+/// then divides by the integer 3 with one Newton correction. The `3 * q1`
+/// product needs no Veltkamp split to be error-free because `3 * q1` is
+/// `q1 + 2 * q1` and `2 * q1` is an exact power-of-two scale, so the whole
+/// routine is `two_sum` calls and divisions.
+///
+/// Deliberately FMA-free: `mul_add` is not guaranteed bit-identical between
+/// native and wasm, and this file already relies on FMA-free f64 elsewhere for
+/// that determinism (see [`near_on_surface_normal`]). Rust does not reorder
+/// float operations, so the cascade's exactness is not at risk the way it would
+/// be under a C compiler's fast-math.
+///
+/// Measured against an exact rational oracle over ~3.85M random triples
+/// spanning magnitudes 1 to 1e6, including near-cancelling and adversarially
+/// constructed inputs: zero mismatches with the correctly-rounded result. That
+/// is a measurement, not a proof for all inputs.
+#[inline]
+fn avg3(a: f64, b: f64, c: f64) -> f64 {
+    let (s1, e1) = two_sum(a, b);
+    let (s2, e2) = two_sum(s1, c);
+    let (t, e3) = two_sum(e1, e2);
+    let (hi, lo1) = two_sum(s2, t);
+    let lo = lo1 + e3;
+
+    let q1 = hi / 3.0;
+    // Exact `q1 * 3`: `q1 + 2*q1`, where `2*q1` is an exact scale.
+    let (p_hi, p_lo) = two_sum(q1, 2.0 * q1);
+    let r = (hi - p_hi) - p_lo + lo;
+    let q2 = r / 3.0;
+    let (r_hi, r_lo) = two_sum(q1, q2);
+    r_hi + r_lo
+}
+
 fn centroid(arr: &Arrangement, tri: [Vid; 3]) -> [f64; 3] {
     let c = [to_f64_pt(arr, tri[0]), to_f64_pt(arr, tri[1]), to_f64_pt(arr, tri[2])];
     [
-        (c[0][0] + c[1][0] + c[2][0]) / 3.0,
-        (c[0][1] + c[1][1] + c[2][1]) / 3.0,
-        (c[0][2] + c[1][2] + c[2][2]) / 3.0,
+        avg3(c[0][0], c[1][0], c[2][0]),
+        avg3(c[0][1], c[1][1], c[2][1]),
+        avg3(c[0][2], c[1][2], c[2][2]),
     ]
 }
 

--- a/rust/geometry/src/kernel/arrangement/classify.rs
+++ b/rust/geometry/src/kernel/arrangement/classify.rs
@@ -676,3 +676,7 @@ mod classify_tests;
 #[cfg(test)]
 #[path = "issue_3353_vid_census_tests.rs"]
 mod issue_3353_vid_census_tests;
+
+#[cfg(test)]
+#[path = "avg3_tests.rs"]
+mod avg3_tests;


### PR DESCRIPTION
## Summary

`to_f64_pt` is careful to be exact — it reuses the interner's cached I512 lambda with a BigRational fallback so every path yields the identical f64 for a `Vid`. `centroid` then discarded that:

```rust
let c = [to_f64_pt(arr, tri[0]), to_f64_pt(arr, tri[1]), to_f64_pt(arr, tri[2])];
[
    (c[0][0] + c[1][0] + c[2][0]) / 3.0,
    ...
]
```

Each vertex is rounded to f64, then summed and divided in IEEE — rounding after each addition and again after the division. The result goes straight to `orient3d` and `orient2d_any` (via `on_surface_tri` and `point_in_tri_proj`) as the **query point**.

Those predicates are exact with respect to whatever point they are handed, so error introduced beforehand is invisible to them. The classifier ends up exact about the wrong point, and can sit on the wrong side of a boundary the true centroid does not straddle.

## Why this shape of fix

The obvious repair is to sum as `BigRational` and round once. `rational.rs` already has the helper, so it is a small diff — and it would be the wrong call. `centroid` runs once per sub-triangle **per operand** on every boolean, and this codebase has already built two caching layers specifically to keep exact-arithmetic cost off that path:

- `Arrangement.f64_cache`: *"Classification (`centroid`/`tri_normal` per sub-triangle) and the final output map all call `to_f64_pt` on the SAME heavily-shared conforming vertices many times; materialising the interned point ... is not free, so each Vid is computed once and reused."*
- `fixed.rs` names this function directly: *"Used for the classifier centroids AND the output verts (the dominant per-op cost)"*, and puts `num-rational` at *"~3ms/call"*.

Today that cost is paid only on a cache miss for an off-grid point. Making it unconditional per sub-triangle would undo the thing those caches exist for — and no CI job would catch it: there is no criterion or `#[bench]` harness in `rust/geometry`, the CSG benchmarks are manual, and the only automated gate is the advisory Viewer benchmark, which measures full-pipeline stage timings on two small fixtures against a 50% threshold.

So this uses a `2Sum` cascade instead: sum the three exactly as a double-double, then divide by 3 with one Newton correction. Allocation-free, `#[inline]`, no new dependency.

It is deliberately **FMA-free**. `mul_add` is not guaranteed bit-identical between native and wasm, and this file already relies on FMA-free f64 elsewhere for exactly that determinism.

## Accuracy

Measured against an exact rational oracle (`fractions.Fraction`) over ~3.85M random triples spanning magnitudes 1 to 1e6, including near-cancelling and adversarially constructed inputs: **zero mismatches** with the correctly-rounded result. Independently re-checked over a further 300k triples: zero mismatches.

The naive form's error grows with coordinate magnitude, and under cancellation — three vertices whose coordinates nearly sum to zero, which is what a sub-triangle at a shared hub looks like — it is unbounded in ulps of the result.

**This is a measurement, not a proof for all inputs.** The residual bound is far below half an ulp, so a divergence would need an input landing within roughly 2⁻⁵² relative distance of a rounding tie; I have not found one, and cannot rule one out by construction.

## Testing

**Not run locally** — no disk headroom for a `cargo` rebuild here, so CI is the check. `classify.rs` is now 690 lines against a recorded budget of 720, including the `avg3` tests' registration and an expanded precondition comment.

An adversarial review of this PR found two things worth recording. First, the fix is **not vacuous**: at 1e7 coordinates — ordinary for georeferenced models — a near-cancelling hub triple gives naive and exact centroids differing by ~3.1e-10, which is ample room for a plane to separate them, and across 200k random triples the naive form diverged from correctly-rounded in ~36% of cases. Second, `avg3` is **not total**: near `f64::MAX` the Newton step's `q1 + 2*q1` overflows and it returns NaN where the naive form returned a graceful infinity. That boundary is unreachable for real geometry and the underlying non-finite exposure is pre-existing, but the precondition comment now states it rather than relying on it silently.

**The census is the arbiter.** A precision correction should only move a host where the IEEE-averaged centroid was already on the wrong side of a boundary — i.e. an existing latent misclassification rather than a new one. That is an argument, not a guarantee. If `triangulation_invariance` moves, the movement is the finding and I would rather see it than not.

## Scope

**This does not claim to fix #3353.** The exactness gap stands on its own merits — it sits on the primary classification path for every boolean operation. Whether it is implicated in `sweep_261` is unmeasured; a separate diagnostic (#3414) is measuring how close the implicated centroids actually are to the other operand's surface, which is what would settle it.

Refs #3353

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved centroid coordinate accuracy, especially for values affected by floating-point cancellation.
  * Ensured three-value averages are correctly rounded and consistent regardless of input order.

* **Tests**
  * Added coverage for cancellation scenarios, exact ties, identical values, input-order invariance, and differences from naive averaging.
  * Added safeguards for reliable, consistent geometric calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
