### PR TITLE
fix(embed): apply a host SET_CAMERA to the model the load is bringing in (#3390)

### DIFF
--- a/apps/viewer-embed/src/bridge/cameraIntent.test.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.test.ts
@@ -38,13 +38,23 @@ function makeCameraState({ renderer = true }: { renderer?: boolean } = {}) {
     state = { ...state, ...updates };
   };
   state = createCameraSlice(set, () => state, undefined as never);
+  // The store's own answer to "has a model ever been on screen here". A
+  // session reset deliberately leaves it alone (`dataSlice.teardown.ts`), so at
+  // a load's entry it still names the OUTGOING model.
+  set({ geometryResult: null });
   const registerRenderer = () => {
     state.setCameraCallbacks({
       setCameraRotation: (rotation: CameraRotation) => { driven.push(rotation); },
     });
   };
   if (renderer) registerRenderer();
-  return { driven, getState: () => state, registerRenderer };
+  return {
+    driven,
+    getState: () => state,
+    registerRenderer,
+    /** What `loadFile` leaves behind. Only `meshes.length` is read from it. */
+    publishModel: () => set({ geometryResult: { meshes: [{ expressId: 1 }] } }),
+  };
 }
 
 beforeEach(() => {
@@ -80,6 +90,31 @@ describe('offerHostPose', () => {
       { azimuth: 99, elevation: 40 },
       { azimuth: 12, elevation: 3 },
     ]);
+  });
+
+  it('still resolves the ACK for a pose the host itself superseded mid-load', async () => {
+    // Two `SET_CAMERA`s inside one load: the second overwrites the first in the
+    // queue, so the first pose never reaches the camera. Its promise is still
+    // owed — a host awaiting it would otherwise hang forever on a command the
+    // bridge accepted.
+    const store = makeCameraState();
+
+    let releaseFetch!: () => void;
+    const fetched = new Promise<void>((resolve) => { releaseFetch = resolve; });
+    const load = aroundDestructiveLoad(store.getState, () => fetched);
+
+    const settled: string[] = [];
+    const first = offerHostPose({ azimuth: 1, elevation: 1 }, store.getState)
+      .then(() => { settled.push('first'); });
+    const second = offerHostPose({ azimuth: 2, elevation: 2 }, store.getState)
+      .then(() => { settled.push('second'); });
+
+    releaseFetch();
+    await load;
+    await Promise.all([first, second]);
+
+    expect(settled.sort()).toEqual(['first', 'second']);
+    expect(store.driven).toEqual([{ azimuth: 2, elevation: 2 }]);
   });
 });
 
@@ -182,6 +217,61 @@ describe('aroundDestructiveLoad', () => {
 
     expect(store.driven).toEqual([{ azimuth: 2, elevation: 2 }]);
     expect(hostPoseAppliedToCurrentModel()).toBe(true);
+  });
+
+  it('lifts a pose actuated against an EMPTY scene, and drops it once a model has worn it', async () => {
+    // One fixture, both directions. The renderer is live in both halves, so the
+    // pose is actuated immediately and the store records nothing either time —
+    // `pendingCameraRotation` cannot tell these apart. What separates them is
+    // whether there was an outgoing model for the pose to have been shown on.
+    const empty = makeCameraState();
+    offerHostPose({ azimuth: 137, elevation: 61 }, empty.getState);
+    await aroundDestructiveLoad(empty.getState, () => Promise.resolve());
+    expect(empty.driven).toEqual([
+      { azimuth: 137, elevation: 61 },
+      { azimuth: 137, elevation: 61 },
+    ]);
+    expect(hostPoseAppliedToCurrentModel()).toBe(true);
+
+    resetCameraIntent();
+
+    const showing = makeCameraState();
+    showing.publishModel();
+    offerHostPose({ azimuth: 137, elevation: 61 }, showing.getState);
+    await aroundDestructiveLoad(showing.getState, () => Promise.resolve());
+    // #3364: shown on the model that is leaving, so it leaves with it.
+    expect(showing.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
+  });
+
+  it('does not resurface a superseded empty-scene pose at the NEXT load', async () => {
+    // The empty-scene lift keeps its own copy of the last pose that went
+    // straight through, and a pose queued DURING a load never updates that copy
+    // — `offerHostPose` takes its other branch. So a copy left behind after the
+    // load that consumed it is strictly older than what the host asked for
+    // last, and re-lifting it at the next load ends the camera on a command the
+    // host had already replaced. Same failure as the store-side re-lift above,
+    // reached through the module's own record instead of the store's.
+    const store = makeCameraState();
+
+    // Nothing on screen yet, so this is the case the lift exists for.
+    offerHostPose({ azimuth: 1, elevation: 1 }, store.getState);
+
+    let releaseFirst!: () => void;
+    const firstFetch = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const first = aroundDestructiveLoad(store.getState, () => firstFetch);
+    offerHostPose({ azimuth: 2, elevation: 2 }, store.getState);
+    releaseFirst();
+    await first;
+
+    // That load delivered no geometry, so the scene is still empty — the one
+    // state in which the next load consults the record again.
+    await aroundDestructiveLoad(store.getState, () => Promise.resolve());
+
+    expect(store.driven).toEqual([
+      { azimuth: 1, elevation: 1 },
+      { azimuth: 2, elevation: 2 },
+    ]);
   });
 
   it('clears the framing bit when the next load carries no host pose', async () => {

--- a/apps/viewer-embed/src/bridge/cameraIntent.test.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.test.ts
@@ -52,8 +52,12 @@ function makeCameraState({ renderer = true }: { renderer?: boolean } = {}) {
     driven,
     getState: () => state,
     registerRenderer,
-    /** What `loadFile` leaves behind. Only `meshes.length` is read from it. */
+    /** What `loadFile` leaves behind. Only the field's NULLNESS is read --
+     *  `aroundDestructiveLoad` asks whether a model ever loaded, not whether it
+     *  has geometry, so `meshes` is incidental here. */
     publishModel: () => set({ geometryResult: { meshes: [{ expressId: 1 }] } }),
+    /** A spatial-only IFC: non-null result, ZERO meshes. Reads as SHOWN. */
+    publishModelWithNoMeshes: () => set({ geometryResult: { meshes: [] } }),
   };
 }
 
@@ -241,6 +245,20 @@ describe('aroundDestructiveLoad', () => {
     await aroundDestructiveLoad(showing.getState, () => Promise.resolve());
     // #3364: shown on the model that is leaving, so it leaves with it.
     expect(showing.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
+
+    resetCameraIntent();
+
+    // A spatial-only IFC is SHOWN even though it has no geometry: non-null
+    // result, zero meshes. Reading `meshes.length` here would call it an empty
+    // scene, re-lift the pose the user watched it at, and replay it onto the
+    // next file — #3364 re-opened for the model class least likely to be
+    // tested. Same assertions as the case above; only the mesh list differs.
+    const spatialOnly = makeCameraState();
+    spatialOnly.publishModelWithNoMeshes();
+    offerHostPose({ azimuth: 137, elevation: 61 }, spatialOnly.getState);
+    await aroundDestructiveLoad(spatialOnly.getState, () => Promise.resolve());
+    expect(spatialOnly.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
     expect(hostPoseAppliedToCurrentModel()).toBe(false);
   });
 

--- a/apps/viewer-embed/src/bridge/cameraIntent.test.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.test.ts
@@ -22,8 +22,15 @@ import {
   resetCameraIntent,
 } from './cameraIntent.js';
 
-/** The real camera slice with a recording renderer actuator registered. */
-function makeCameraState() {
+/**
+ * The real camera slice with a recording renderer actuator.
+ *
+ * `registerRenderer` is deferred with `{ renderer: false }` for the tests that
+ * need the store's OTHER branch: with no actuator registered
+ * `setCameraRotation` arms `pendingCameraRotation` instead of driving
+ * anything, which is the field this module lifts.
+ */
+function makeCameraState({ renderer = true }: { renderer?: boolean } = {}) {
   const driven: CameraRotation[] = [];
   let state: any;
   const set = (partial: any) => {
@@ -31,10 +38,13 @@ function makeCameraState() {
     state = { ...state, ...updates };
   };
   state = createCameraSlice(set, () => state, undefined as never);
-  state.setCameraCallbacks({
-    setCameraRotation: (rotation: CameraRotation) => { driven.push(rotation); },
-  });
-  return { driven, getState: () => state };
+  const registerRenderer = () => {
+    state.setCameraCallbacks({
+      setCameraRotation: (rotation: CameraRotation) => { driven.push(rotation); },
+    });
+  };
+  if (renderer) registerRenderer();
+  return { driven, getState: () => state, registerRenderer };
 }
 
 beforeEach(() => {
@@ -132,6 +142,46 @@ describe('aroundDestructiveLoad', () => {
     releaseSecond();
     await later;
     expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+  });
+
+  it('does not re-lift a superseded store pose when loads overlap (#3390)', async () => {
+    // The lift at load entry reads `pendingCameraRotation`, and the reset that
+    // clears that field runs inside `loadFile`, well after the load starts. So
+    // a second LOAD_MODEL posted before the first one's reset sees the FIRST
+    // pose still armed in the store — and re-lifting it would overwrite the
+    // newer pose the host queued in between, ending the camera on a command
+    // the host had already replaced. `offerHostPose`'s no-load path clears the
+    // queue before it arms the store, so a queued pose at load entry is always
+    // the newer of the two.
+    const store = makeCameraState({ renderer: false });
+
+    // No renderer registered yet, so this arms the store's replay buffer.
+    offerHostPose({ azimuth: 1, elevation: 1 }, store.getState);
+    expect(store.getState().pendingCameraRotation).toEqual({ azimuth: 1, elevation: 1 });
+
+    let releaseFirst!: () => void;
+    const firstFetch = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const first = aroundDestructiveLoad(store.getState, () => firstFetch);
+
+    // The host changes its mind while the first fetch is still outstanding.
+    offerHostPose({ azimuth: 2, elevation: 2 }, store.getState);
+
+    // ...and starts a second destructive load before the first has reset.
+    let releaseSecond!: () => void;
+    const secondFetch = new Promise<void>((resolve) => { releaseSecond = resolve; });
+    const second = aroundDestructiveLoad(store.getState, () => secondFetch);
+    expect(store.getState().pendingCameraRotation).toEqual({ azimuth: 1, elevation: 1 });
+
+    releaseFirst();
+    await first;
+    releaseSecond();
+    await second;
+
+    // The incoming model's renderer registers and replays what is armed.
+    store.registerRenderer();
+
+    expect(store.driven).toEqual([{ azimuth: 2, elevation: 2 }]);
+    expect(hostPoseAppliedToCurrentModel()).toBe(true);
   });
 
   it('clears the framing bit when the next load carries no host pose', async () => {

--- a/apps/viewer-embed/src/bridge/cameraIntent.test.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.test.ts
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The #3390 cases the bridge-level tests cannot reach: when the queue releases,
+ * what happens when a load does NOT deliver a model, and how long the framing
+ * bit the embed reads stays true.
+ *
+ * Driven against the real `createCameraSlice`, so "applied" means the pose
+ * actually reached the renderer actuator rather than a recorded call.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { createCameraSlice } from '@/store/slices/cameraSlice.js';
+import type { CameraRotation } from '@/store/types.js';
+import {
+  aroundDestructiveLoad,
+  hostPoseAppliedToCurrentModel,
+  offerHostPose,
+  resetCameraIntent,
+} from './cameraIntent.js';
+
+/** The real camera slice with a recording renderer actuator registered. */
+function makeCameraState() {
+  const driven: CameraRotation[] = [];
+  let state: any;
+  const set = (partial: any) => {
+    const updates = typeof partial === 'function' ? partial(state) : partial;
+    state = { ...state, ...updates };
+  };
+  state = createCameraSlice(set, () => state, undefined as never);
+  state.setCameraCallbacks({
+    setCameraRotation: (rotation: CameraRotation) => { driven.push(rotation); },
+  });
+  return { driven, getState: () => state };
+}
+
+beforeEach(() => {
+  resetCameraIntent();
+});
+
+describe('offerHostPose', () => {
+  it('applies straight through when no destructive load is running', () => {
+    const store = makeCameraState();
+
+    offerHostPose({ azimuth: 12, elevation: 3 }, store.getState);
+
+    expect(store.driven).toEqual([{ azimuth: 12, elevation: 3 }]);
+    // Not a load, so the framing bit stays false and the first model still
+    // gets its default framing.
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
+  });
+
+  it('supersedes a pose queued against a load that is already over', async () => {
+    const store = makeCameraState();
+
+    // A load runs with a pose queued against it; the load releases the pose on
+    // the way out, so the queue is empty by the time the host speaks again.
+    const load = aroundDestructiveLoad(store.getState, () => Promise.resolve());
+    offerHostPose({ azimuth: 99, elevation: 40 }, store.getState);
+    await load;
+
+    // The host then commands a new pose with nothing in flight. That is the
+    // live scene talking, and it is the pose the camera must end at.
+    offerHostPose({ azimuth: 12, elevation: 3 }, store.getState);
+
+    expect(store.driven).toEqual([
+      { azimuth: 99, elevation: 40 },
+      { azimuth: 12, elevation: 3 },
+    ]);
+  });
+});
+
+describe('aroundDestructiveLoad', () => {
+  it('applies a queued pose when the load fails, since nothing was reset', async () => {
+    // Before the queue existed, a pose set during a failing fetch simply
+    // survived: `resetViewerState()` never ran. Holding it for an incoming
+    // model that never arrives would be a new way to lose the same command —
+    // and worse, it would surface on some later load the host never linked it
+    // to. `loadFile` is never reached on this path, so no post-load effect
+    // runs to drain the queue either.
+    const store = makeCameraState();
+
+    const failing = aroundDestructiveLoad(store.getState, () =>
+      Promise.reject(new Error('Failed to fetch model: Not Found')));
+    offerHostPose({ azimuth: 137, elevation: 61 }, store.getState);
+    await expect(failing).rejects.toThrow('Failed to fetch model');
+
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+    // No model arrived, so there is nothing for the first-load framing to
+    // treat as host-posed.
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
+  });
+
+  it('holds the pose back until the load resolves, then applies it', async () => {
+    // The whole point: applying it while the fetch is outstanding aims the
+    // scene the session reset is about to replace.
+    const store = makeCameraState();
+
+    let releaseFetch!: () => void;
+    const fetched = new Promise<void>((resolve) => { releaseFetch = resolve; });
+    const load = aroundDestructiveLoad(store.getState, () => fetched);
+    offerHostPose({ azimuth: 137, elevation: 61 }, store.getState);
+
+    expect(store.driven).toEqual([]);
+
+    releaseFetch();
+    await load;
+
+    // Deferred, not lost.
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+    expect(hostPoseAppliedToCurrentModel()).toBe(true);
+  });
+
+  it('keeps the pose held until the LAST of two overlapping loads finishes', async () => {
+    // A host can post a second LOAD_MODEL before the first resolves. Releasing
+    // on the first completion would apply the pose with the second load's
+    // session reset still ahead of it.
+    const store = makeCameraState();
+
+    let releaseSecond!: () => void;
+    const second = new Promise<void>((resolve) => { releaseSecond = resolve; });
+    const first = aroundDestructiveLoad(store.getState, () => Promise.resolve());
+    const later = aroundDestructiveLoad(store.getState, () => second);
+    offerHostPose({ azimuth: 137, elevation: 61 }, store.getState);
+
+    await first;
+    expect(store.driven).toEqual([]);
+
+    releaseSecond();
+    await later;
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+  });
+
+  it('clears the framing bit when the next load carries no host pose', async () => {
+    // `hostPoseAppliedToCurrentModel` answers for the model on screen NOW. A
+    // stale true would make the next model's first-load framing skip `home()`
+    // for a pose nobody asked about.
+    const store = makeCameraState();
+
+    const posed = aroundDestructiveLoad(store.getState, () => Promise.resolve());
+    offerHostPose({ azimuth: 137, elevation: 61 }, store.getState);
+    await posed;
+    expect(hostPoseAppliedToCurrentModel()).toBe(true);
+
+    await aroundDestructiveLoad(store.getState, () => Promise.resolve());
+
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
+  });
+});

--- a/apps/viewer-embed/src/bridge/cameraIntent.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.ts
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Where a host camera pose waits while a destructive load is in flight (#3390).
+ *
+ * `LOAD_MODEL` is not atomic from the store's point of view. The bridge awaits
+ * `ctx.loadModelFromUrl`, which fetches the file and reads its body before it
+ * ever calls `loadFile`, and `loadFile` is where `resetViewerState()` runs. So
+ * a whole network round trip separates "the LOAD_MODEL message was handled"
+ * from "the session was reset", and any `SET_CAMERA` the host posts in that
+ * window is applied to the outgoing session and then destroyed by the reset.
+ * The reverse order fails the same way: a pose set just before LOAD_MODEL is
+ * armed as `pendingCameraRotation` and the same reset clears it. Both are
+ * ACKed, and neither moves the camera. (`LOAD_MODEL_BUFFER` has no pre-reset
+ * await, but it is routed through here too so the two commands cannot drift.)
+ *
+ * The reset itself is correct and stays: #3364/#3375 made a session reset
+ * expire `pendingCameraRotation` because a pose armed against the OUTGOING
+ * model was replaying onto the next file. What the store cannot see is which
+ * model a pose was meant for. This module can, because it is the only place
+ * that knows a destructive load is running.
+ *
+ * A readiness gate on the renderer — the other option #3390 lists — cannot
+ * make that call. With a renderer already registered (a second load into a
+ * live embed) it lets every pose straight through, so `loadModel(url)` then
+ * `setCamera(...)` still aims the outgoing scene; it only ever separates
+ * "renderer up" from "renderer down", which is not the question.
+ *
+ * The discriminator used here, and why it keeps #3364 closed:
+ *
+ *  - A pose that reached a renderer was SHOWN on the outgoing scene. It leaves
+ *    `pendingCameraRotation` null (`cameraSlice.ts`: the field is set only when
+ *    no actuator was registered, and cleared again on replay), so nothing is
+ *    lifted here and the incoming model still gets its default framing. That
+ *    is exactly #3364's case, unchanged.
+ *  - A pose sitting in `pendingCameraRotation` never reached any renderer, so
+ *    it was never on screen for any model. At the moment a destructive load
+ *    starts it can only be intent for the model arriving, and it is lifted out
+ *    of the store into this module's queue, where the reset cannot reach it.
+ *  - A pose commanded WHILE a destructive load runs is likewise intent for the
+ *    incoming model, so it is queued instead of applied.
+ *
+ * The queue is released by the load itself, not by a later render: once
+ * `aroundDestructiveLoad` resolves, `loadFile` has returned, so the session
+ * reset is already behind us and the ordinary `setCameraRotation` path is safe
+ * again — it actuates if a renderer is registered and otherwise arms a fresh
+ * replay that nothing is left in flight to clear. An earlier draft had the
+ * embed's post-load effect pull the pose out instead, which put React's flush
+ * order on the correctness path: under `act` the effect really does run before
+ * the load's own continuation, and the pose was stranded until some unrelated
+ * later load picked it up.
+ *
+ * What the component still needs is one bit, not the pose: whether the model
+ * now on screen got a host pose, so the first-load auto-fit frames it with
+ * `fitAll` instead of tweening it away with `home()`. That is a plain read
+ * ({@link hostPoseAppliedToCurrentModel}), cleared by the next destructive
+ * load, so no number of effect runs can consume it at the wrong moment.
+ *
+ * The queue is module state, like the bridge's own; `resetCameraIntent` puts
+ * it back to its initial value when the bridge is torn down.
+ */
+
+import type { CameraRotation } from '@/store/types.js';
+
+/** The slice of the store this module reads and drives. */
+interface CameraIntentState {
+  pendingCameraRotation: CameraRotation | null;
+  setCameraRotation: (rotation: CameraRotation) => void;
+}
+
+/** The pose to apply to the model currently arriving, if the host asked for one. */
+let queuedPose: CameraRotation | null = null;
+
+/**
+ * How many destructive (scene-replacing) loads are running. A counter rather
+ * than a flag so two overlapping `LOAD_MODEL`s cannot release the queue early;
+ * federated `ADD_MODEL` never resets the session and is deliberately not
+ * counted here, so a `SET_CAMERA` during one still acts on the live scene.
+ */
+let destructiveLoadsInFlight = 0;
+
+/**
+ * Whether the model currently on screen arrived with a host pose applied to it.
+ * Read (never consumed) by the embed's first-load framing; cleared when the
+ * next destructive load starts, so it always answers for the newest model.
+ */
+let poseAppliedToCurrentModel = false;
+
+/** Put the queue back to its initial state (bridge teardown, StrictMode remount, tests). */
+export function resetCameraIntent(): void {
+  queuedPose = null;
+  destructiveLoadsInFlight = 0;
+  poseAppliedToCurrentModel = false;
+}
+
+/**
+ * Did the host command the pose the current model is sitting at?
+ *
+ * `home()` would animate it away, so the embed's first-load auto-fit frames
+ * with `fitAll` instead when this is true (`useEmbedPostLoad.ts`). A read, not
+ * a take: the effect that asks can run more than once per load, and consuming
+ * the answer on the first of those runs is how the framing loses it.
+ */
+export function hostPoseAppliedToCurrentModel(): boolean {
+  return poseAppliedToCurrentModel;
+}
+
+/** Clamped, because `resetCameraIntent` can zero the counter mid-load when the
+ *  embed unmounts; a negative count would leave every later pose unqueueable. */
+function endDestructiveLoad(): void {
+  destructiveLoadsInFlight = Math.max(0, destructiveLoadsInFlight - 1);
+}
+
+/**
+ * Take the host's `SET_CAMERA` pose.
+ *
+ * With no destructive load running this is today's path exactly — straight to
+ * `setCameraRotation`, which actuates the renderer or arms the store's replay
+ * buffer if none has registered yet (#2934). With one running the pose is held
+ * until the incoming model lands, because applying it now aims the outgoing
+ * scene and the load's reset then discards it.
+ */
+export function offerHostPose(pose: CameraRotation, getState: () => CameraIntentState): void {
+  if (destructiveLoadsInFlight > 0) {
+    queuedPose = pose;
+    return;
+  }
+  // A direct command supersedes anything left queued by a load that never
+  // delivered a model, so a stale pose cannot resurface at the next load.
+  queuedPose = null;
+  getState().setCameraRotation(pose);
+}
+
+/**
+ * Run one scene-replacing load with the camera queue held open across it.
+ *
+ * Wrapping rather than exposing a begin/end pair keeps the two halves balanced
+ * at every call site: an unbalanced increment would leave every later
+ * `SET_CAMERA` queued forever.
+ *
+ * The load is taken as a function plus its arguments rather than a closure so
+ * the bridge can hand over `ctx.loadModelFromUrl` directly. `ctx` is a mutable
+ * module-level binding, so TypeScript drops its non-null narrowing inside a
+ * callback; `BridgeContext`'s members are plain function properties (its
+ * `getState` is already passed detached, right here), so forwarding one costs
+ * nothing and keeps the null check where it already is.
+ */
+export async function aroundDestructiveLoad<A extends unknown[], R>(
+  getState: () => CameraIntentState,
+  load: (...args: A) => Promise<R>,
+  ...args: A
+): Promise<R> {
+  destructiveLoadsInFlight += 1;
+  // A new model is arriving, so whatever the outgoing one was framed for stops
+  // being the answer to "did the host pose this?".
+  poseAppliedToCurrentModel = false;
+  // Lift an unactuated pose out of the store before the reset can clear it.
+  // The store copy is deliberately left alone: on a load that fails no reset
+  // runs, and the store's own replay must keep working as it did.
+  const neverShown = getState().pendingCameraRotation;
+  if (neverShown) queuedPose = neverShown;
+
+  try {
+    const result = await load(...args);
+    endDestructiveLoad();
+    // Past `loadFile`, so past `resetViewerState()`: the pose can go to the
+    // store now and nothing is left to discard it.
+    if (releaseQueuedPose(getState)) poseAppliedToCurrentModel = true;
+    return result;
+  } catch (err) {
+    endDestructiveLoad();
+    // A load that failed replaced nothing and reset nothing, so there is no
+    // incoming model for the queued pose to wait for and no reset it needed
+    // protecting from. Apply it to the scene that is still on screen, which is
+    // where it would have landed before this queue existed. Leaving it queued
+    // would be worse than losing it: it would surface on some later load and
+    // aim a model the host never asked about. The framing bit stays false —
+    // no model arrived to frame.
+    releaseQueuedPose(getState);
+    throw err;
+  }
+}
+
+/**
+ * Hand any queued pose to the store, once no destructive load is still running.
+ * Returns whether a pose was applied.
+ */
+function releaseQueuedPose(getState: () => CameraIntentState): boolean {
+  if (destructiveLoadsInFlight > 0 || !queuedPose) return false;
+  const pose = queuedPose;
+  queuedPose = null;
+  getState().setCameraRotation(pose);
+  return true;
+}

--- a/apps/viewer-embed/src/bridge/cameraIntent.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.ts
@@ -28,19 +28,36 @@
  * `setCamera(...)` still aims the outgoing scene; it only ever separates
  * "renderer up" from "renderer down", which is not the question.
  *
- * The discriminator used here, and why it keeps #3364 closed:
+ * The discriminator used here, and why it keeps #3364 closed. #3364's rule is
+ * "a pose the OUTGOING model already showed must die with it", so the question
+ * a load has to answer at its entry is whether there was an outgoing model at
+ * all — `geometryResult`, the meshes on screen at the instant the load starts,
+ * before `loadFile`'s reset is anywhere near. Given that:
  *
- *  - A pose that reached a renderer was SHOWN on the outgoing scene. It leaves
- *    `pendingCameraRotation` null (`cameraSlice.ts`: the field is set only when
- *    no actuator was registered, and cleared again on replay), so nothing is
- *    lifted here and the incoming model still gets its default framing. That
- *    is exactly #3364's case, unchanged.
+ *  - A pose that reached a renderer WHILE a model was on screen was shown on
+ *    that model. Nothing is lifted, and the incoming model gets its default
+ *    framing. That is exactly #3364's case, unchanged.
+ *  - A pose that reached a renderer with NO model on screen was actuated
+ *    against an empty scene. There was no outgoing model for it to have been
+ *    shown on, so it is still intent for the model arriving and it is lifted.
+ *    Codex found this half missing: the lift used to read only
+ *    `pendingCameraRotation`, which `cameraSlice.ts` arms solely when no
+ *    actuator was registered, so with a mounted `Viewport` a `SET_CAMERA`
+ *    posted just before the first `LOAD_MODEL` left nothing behind to lift and
+ *    the command was lost with `home()` framing over the top of it.
  *  - A pose sitting in `pendingCameraRotation` never reached any renderer, so
  *    it was never on screen for any model. At the moment a destructive load
  *    starts it can only be intent for the model arriving, and it is lifted out
  *    of the store into this module's queue, where the reset cannot reach it.
  *  - A pose commanded WHILE a destructive load runs is likewise intent for the
  *    incoming model, so it is queued instead of applied.
+ *
+ * Queuing a pose defers its EFFECT, so it has to defer the ACK with it.
+ * `offerHostPose` resolves only once the pose has reached the store, which is
+ * what makes `await v.setCamera(...); v.getScreenshot()` capture the pose the
+ * host just asked for rather than the outgoing angle. Before #3390 the
+ * actuator ran inside the SET_CAMERA handler and the ACK followed it, so the
+ * ordering was free; a queue that ACKs on receipt breaks it silently.
  *
  * The queue is released by the load itself, not by a later render: once
  * `aroundDestructiveLoad` resolves, `loadFile` has returned, so the session
@@ -67,12 +84,21 @@
  * still outstanding. `resetCameraIntent` exists for tests.
  */
 
+import type { GeometryResult } from '@ifc-lite/geometry';
+
 import type { CameraRotation } from '@/store/types.js';
 
 /** The slice of the store this module reads and drives. */
 interface CameraIntentState {
   pendingCameraRotation: CameraRotation | null;
   setCameraRotation: (rotation: CameraRotation) => void;
+  /**
+   * The geometry on screen. Read at a destructive load's ENTRY, where it still
+   * describes the OUTGOING model — `loadFile`'s `resetViewerState()` is a whole
+   * fetch away — so "empty here" means no model has ever been shown in this
+   * embed and a pose already actuated cannot have belonged to one.
+   */
+  geometryResult: GeometryResult | null;
 }
 
 /** The pose to apply to the model currently arriving, if the host asked for one. */
@@ -93,12 +119,44 @@ let destructiveLoadsInFlight = 0;
  */
 let poseAppliedToCurrentModel = false;
 
+/**
+ * The last pose `offerHostPose` sent straight to the store, kept for the case
+ * the store cannot represent: a live renderer actuates it and records nothing,
+ * so with no model on screen yet there is no `pendingCameraRotation` for the
+ * next load to lift. Only ever read when the store says no model has landed —
+ * once one has, a pose that went straight through was shown on it and #3364
+ * says it dies there.
+ */
+let poseActuatedSinceLastLoad: CameraRotation | null = null;
+
+/**
+ * Hosts still awaiting the ACK for a pose that is sitting in the queue.
+ * Resolved together the moment the queue is drained, so no `setCamera()`
+ * promise outlives the effect it is reporting — and none is left hanging by a
+ * load that failed, which releases the queue on its way out too.
+ *
+ * Non-empty only while a destructive load is running: entries are added on
+ * `offerHostPose`'s queued branch alone, and every load drains them as it
+ * leaves. That is why the only other caller is `resetCameraIntent`, which a
+ * test can reach mid-load and which would otherwise strand a promise.
+ */
+let queuedPoseWaiters: Array<() => void> = [];
+
+/** Let every held ACK go. Safe to call when there are none. */
+function settleQueuedPoseWaiters(): void {
+  const waiting = queuedPoseWaiters;
+  queuedPoseWaiters = [];
+  for (const resolve of waiting) resolve();
+}
+
 /** Put the queue back to its initial state. For tests: no production caller
  *  resets this module, see the note on ownership above. */
 export function resetCameraIntent(): void {
   queuedPose = null;
   destructiveLoadsInFlight = 0;
   poseAppliedToCurrentModel = false;
+  poseActuatedSinceLastLoad = null;
+  settleQueuedPoseWaiters();
 }
 
 /**
@@ -128,16 +186,34 @@ function endDestructiveLoad(): void {
  * buffer if none has registered yet (#2934). With one running the pose is held
  * until the incoming model lands, because applying it now aims the outgoing
  * scene and the load's reset then discards it.
+ *
+ * Resolves when the pose has reached the store — immediately on the direct
+ * path, at the end of the load on the queued one. The bridge ACKs `SET_CAMERA`
+ * on that promise, so a host awaiting `setCamera()` still gets the guarantee it
+ * had before the queue existed: the next command it sends sees the new angle.
  */
-export function offerHostPose(pose: CameraRotation, getState: () => CameraIntentState): void {
+export function offerHostPose(
+  pose: CameraRotation,
+  getState: () => CameraIntentState,
+): Promise<void> {
   if (destructiveLoadsInFlight > 0) {
     queuedPose = pose;
-    return;
+    // Held, so the ACK is held with it: the SDK's `setCamera()` promise is the
+    // host's only ordering primitive, and resolving it here would let the next
+    // awaited command run against the scene this load is replacing.
+    //
+    // It inherits the SDK's 30 s per-request timeout (`embed-sdk/src/index.ts`
+    // `request`), which is the same ceiling the `LOAD_MODEL` it is waiting on
+    // already sits under — a load slow enough to time this out has failed the
+    // host's `loadModel()` call too, so it is not a new way to fail.
+    return new Promise<void>((resolve) => { queuedPoseWaiters.push(resolve); });
   }
   // A direct command supersedes anything left queued by a load that never
   // delivered a model, so a stale pose cannot resurface at the next load.
   queuedPose = null;
   getState().setCameraRotation(pose);
+  poseActuatedSinceLastLoad = pose;
+  return Promise.resolve();
 }
 
 /**
@@ -178,7 +254,17 @@ export async function aroundDestructiveLoad<A extends unknown[], R>(
   // A queued pose here is always the newer of the two: `offerHostPose` reaches
   // the store only on its no-load path, which clears `queuedPose` first, so
   // anything left in the queue was commanded after the store's copy was armed.
-  const neverShown = getState().pendingCameraRotation;
+  //
+  // With a renderer already up the store keeps no copy at all, so the second
+  // source is this module's own record of the last pose that went straight
+  // through — admissible only while the scene has never held a model, which is
+  // the line between "actuated against nothing" and #3364's "shown on the
+  // model that is leaving".
+  const state = getState();
+  const onScreen = state.geometryResult?.meshes.length ?? 0;
+  const neverShown = state.pendingCameraRotation
+    ?? (onScreen === 0 ? poseActuatedSinceLastLoad : null);
+  poseActuatedSinceLastLoad = null;
   if (neverShown && queuedPose === null) queuedPose = neverShown;
 
   try {
@@ -207,9 +293,12 @@ export async function aroundDestructiveLoad<A extends unknown[], R>(
  * Returns whether a pose was applied.
  */
 function releaseQueuedPose(getState: () => CameraIntentState): boolean {
-  if (destructiveLoadsInFlight > 0 || !queuedPose) return false;
+  if (destructiveLoadsInFlight > 0) return false;
   const pose = queuedPose;
   queuedPose = null;
-  getState().setCameraRotation(pose);
-  return true;
+  if (pose) getState().setCameraRotation(pose);
+  // After the actuation, never before: the ACK's whole job is to say the
+  // camera has already moved.
+  settleQueuedPoseWaiters();
+  return pose !== null;
 }

--- a/apps/viewer-embed/src/bridge/cameraIntent.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.ts
@@ -261,9 +261,17 @@ export async function aroundDestructiveLoad<A extends unknown[], R>(
   // the line between "actuated against nothing" and #3364's "shown on the
   // model that is leaving".
   const state = getState();
-  const onScreen = state.geometryResult?.meshes.length ?? 0;
+  // `geometryResult !== null`, NOT `meshes.length > 0`. A spatial-only IFC --
+  // storeys and spaces with no geometry -- loads to a non-null result holding
+  // ZERO meshes, and that is a real state in this repo rather than a
+  // pathological one. Counting meshes would call such a model "never shown",
+  // re-lift a pose the user watched it at, and replay it onto the next file:
+  // #3364 re-opened for exactly the model class least likely to be tested.
+  // The question is whether a model was ever LOADED, which is what the field's
+  // nullness answers.
+  const everLoaded = state.geometryResult != null;
   const neverShown = state.pendingCameraRotation
-    ?? (onScreen === 0 ? poseActuatedSinceLastLoad : null);
+    ?? (everLoaded ? null : poseActuatedSinceLastLoad);
   poseActuatedSinceLastLoad = null;
   if (neverShown && queuedPose === null) queuedPose = neverShown;
 

--- a/apps/viewer-embed/src/bridge/cameraIntent.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.ts
@@ -58,8 +58,13 @@
  * ({@link hostPoseAppliedToCurrentModel}), cleared by the next destructive
  * load, so no number of effect runs can consume it at the wrong moment.
  *
- * The queue is module state, like the bridge's own; `resetCameraIntent` puts
- * it back to its initial value when the bridge is torn down.
+ * The queue is module state, and its owner is the embed component rather than
+ * the bridge: the `?modelUrl=` auto-load drives `aroundDestructiveLoad` too,
+ * and the bridge never sees it. Nothing resets it in production — the embed
+ * mounts once and this state dies with the page — and deliberately so: hanging
+ * the reset off the bridge effect's cleanup meant StrictMode's dev-only
+ * mount -> cleanup -> remount zeroed the queue while the auto-load's fetch was
+ * still outstanding. `resetCameraIntent` exists for tests.
  */
 
 import type { CameraRotation } from '@/store/types.js';
@@ -88,7 +93,8 @@ let destructiveLoadsInFlight = 0;
  */
 let poseAppliedToCurrentModel = false;
 
-/** Put the queue back to its initial state (bridge teardown, StrictMode remount, tests). */
+/** Put the queue back to its initial state. For tests: no production caller
+ *  resets this module, see the note on ownership above. */
 export function resetCameraIntent(): void {
   queuedPose = null;
   destructiveLoadsInFlight = 0;
@@ -107,8 +113,9 @@ export function hostPoseAppliedToCurrentModel(): boolean {
   return poseAppliedToCurrentModel;
 }
 
-/** Clamped, because `resetCameraIntent` can zero the counter mid-load when the
- *  embed unmounts; a negative count would leave every later pose unqueueable. */
+/** Clamped, because a test can call `resetCameraIntent` between cases while a
+ *  load is still pending; a negative count would leave every later pose
+ *  unqueueable. */
 function endDestructiveLoad(): void {
   destructiveLoadsInFlight = Math.max(0, destructiveLoadsInFlight - 1);
 }

--- a/apps/viewer-embed/src/bridge/cameraIntent.ts
+++ b/apps/viewer-embed/src/bridge/cameraIntent.ts
@@ -159,8 +159,20 @@ export async function aroundDestructiveLoad<A extends unknown[], R>(
   // Lift an unactuated pose out of the store before the reset can clear it.
   // The store copy is deliberately left alone: on a load that fails no reset
   // runs, and the store's own replay must keep working as it did.
+  //
+  // Only when the queue is empty, and that guard is load-bearing rather than
+  // defensive. The reset that clears `pendingCameraRotation` runs inside
+  // `loadFile`, a whole fetch after the load starts, so a SECOND destructive
+  // load beginning in that window still reads the FIRST load's pose out of the
+  // store. Re-lifting it would overwrite whatever the host queued in between
+  // and end the camera on a command the host had already superseded — the same
+  // ACKed-but-wrong failure this module exists to close.
+  //
+  // A queued pose here is always the newer of the two: `offerHostPose` reaches
+  // the store only on its no-load path, which clears `queuedPose` first, so
+  // anything left in the queue was commanded after the store's copy was armed.
   const neverShown = getState().pendingCameraRotation;
-  if (neverShown) queuedPose = neverShown;
+  if (neverShown && queuedPose === null) queuedPose = neverShown;
 
   try {
     const result = await load(...args);

--- a/apps/viewer-embed/src/bridge/handler.effects.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.effects.test.ts
@@ -33,9 +33,10 @@ vi.mock('@/store/index.js', () => ({
 
 import { EMBED_SOURCE, PROTOCOL_VERSION } from '@ifc-lite/embed-protocol';
 import { createDataSlice } from '@/store/slices/dataSlice.js';
-import { createCameraSlice } from '@/store/slices/cameraSlice.js';
+import { createCameraSlice, cameraTeardown } from '@/store/slices/cameraSlice.js';
 import type { CameraRotation } from '@/store/types.js';
 import { initBridge, destroyBridge } from './handler.js';
+import { hostPoseAppliedToCurrentModel, resetCameraIntent } from './cameraIntent.js';
 
 // ---------------------------------------------------------------------------
 // Window double (postMessage in, postMessage out)
@@ -170,5 +171,169 @@ describe('bridge commands against the real store slices', () => {
 
       expect(store.getState().pendingColorUpdates.get(12)).toEqual([1, 1, 0, 1]);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3390: a host pose commanded around a destructive load
+// ---------------------------------------------------------------------------
+
+/**
+ * Same real-slice composition as above, but the renderer starts UNregistered —
+ * which is the state `pendingCameraRotation` exists for — and the load
+ * stand-in applies the one thing `resetViewerState()` contributes to this
+ * slice, at the point in the bridge's async chain where it really lands: after
+ * `loadModelFromUrl`'s fetch, not inside the LOAD_MODEL message task.
+ */
+function makeLoadableState() {
+  const driven: CameraRotation[] = [];
+  let state: any;
+  const set = (partial: any) => {
+    const updates = typeof partial === 'function' ? partial(state) : partial;
+    state = { ...state, ...updates };
+  };
+  const get = () => state;
+  state = { ...createCameraSlice(set, get, undefined as never), models: new Map() };
+
+  return {
+    driven,
+    /** Every url `LOAD_MODEL` actually asked the adapter to fetch. */
+    loadedUrls: [] as string[],
+    getState: () => state,
+    sessionReset: () => set(cameraTeardown.teardown({ kind: 'session-reset' }, state)),
+    registerRenderer: () => state.setCameraCallbacks({
+      setCameraRotation: (rotation: CameraRotation) => { driven.push(rotation); },
+    }),
+  };
+}
+
+describe('a host camera pose around a destructive load (#3390)', () => {
+  let win: ReturnType<typeof installWindow>;
+  let store: ReturnType<typeof makeLoadableState>;
+  let releaseFetch: () => void;
+
+  /** Let every queued microtask (and the load's own continuation) run. */
+  const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    win = installWindow();
+    store = makeLoadableState();
+    resetCameraIntent();
+    const fetched = new Promise<void>((resolve) => { releaseFetch = resolve; });
+    initBridge({
+      getState: store.getState as never,
+      loadModelFromUrl: async (url: string) => {
+        // `EmbedViewer.tsx`'s adapter: fetch, read the body, and only then
+        // `loadFile` — whose `resetViewerState()` is the reset below.
+        store.loadedUrls.push(url);
+        await fetched;
+        store.sessionReset();
+        return { entities: 0, triangles: 0, vertices: 0 };
+      },
+      loadModelFromBuffer: async () => {
+        // No pre-reset await on this path (`EmbedViewer.tsx` hands the buffer
+        // straight to `loadFile`), so the reset lands inside the message task.
+        store.sessionReset();
+        return { entities: 0, triangles: 0, vertices: 0 };
+      },
+      addModelFromUrl: vi.fn(),
+    } as never);
+  });
+
+  afterEach(() => {
+    destroyBridge();
+    resetCameraIntent();
+  });
+
+  it('applies a SET_CAMERA sent during the load fetch to the model that arrives', async () => {
+    // `v.loadModel(url); v.setCamera(137, 61);` with neither call awaited.
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/m.ifc' }));
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+
+    releaseFetch();
+    await settle();
+
+    // The wrapper forwards to the real adapter with the real payload; it is a
+    // hold, not a substitute for the load.
+    expect(store.loadedUrls).toEqual(['https://host.example/m.ifc']);
+
+    // Nothing was registered to actuate it, so it is armed for replay — and
+    // this time the session reset that just ran cannot reach it.
+    expect(store.getState().pendingCameraRotation).toEqual({ azimuth: 137, elevation: 61 });
+    expect(hostPoseAppliedToCurrentModel()).toBe(true);
+
+    store.registerRenderer();
+
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+  });
+
+  it('holds a mid-load SET_CAMERA back even when a renderer IS registered', async () => {
+    // The same ordering with a live renderer — a second load into an embed
+    // that is already showing something. Nothing here is `pending`, so the
+    // store-level replay cannot help: applying the pose now aims the OUTGOING
+    // scene, which is the half of #3390 a renderer-readiness gate cannot see.
+    store.registerRenderer();
+
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/m.ifc' }));
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+
+    // Still fetching: nothing may be driven onto the model that is leaving.
+    // Without the hold this is where the pose lands, and the reset below then
+    // makes it invisible to everything downstream.
+    expect(store.driven).toEqual([]);
+
+    releaseFetch();
+    await settle();
+
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+  });
+
+  it('carries a SET_CAMERA sent just BEFORE the load through the session reset', async () => {
+    // The reverse order. Nothing has registered a renderer, so the pose arms
+    // `pendingCameraRotation` — which the load's reset then clears.
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/m.ifc' }));
+
+    releaseFetch();
+    await settle();
+    // Re-armed AFTER the reset rather than wiped by it.
+    expect(store.getState().pendingCameraRotation).toEqual({ azimuth: 137, elevation: 61 });
+
+    store.registerRenderer();
+
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+  });
+
+  it('carries a SET_CAMERA sent before LOAD_MODEL_BUFFER, whose reset is synchronous', async () => {
+    // The buffer path has no fetch, so nothing can be commanded DURING it —
+    // but a pose armed just before it still meets the same session reset, and
+    // the queue has to lift it for the same reason.
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+    win.dispatch(cmd('LOAD_MODEL_BUFFER', new ArrayBuffer(8)));
+
+    await settle();
+    expect(store.getState().pendingCameraRotation).toEqual({ azimuth: 137, elevation: 61 });
+
+    store.registerRenderer();
+
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+  });
+
+  it('does NOT replay a pose the outgoing model already showed (#3364 stays closed)', async () => {
+    // The renderer is registered first, so this pose is actuated immediately —
+    // the user watched the outgoing model at it. It must die with that model.
+    store.registerRenderer();
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/m.ifc' }));
+    releaseFetch();
+    await settle();
+
+    // Still exactly the one call from before the load: nothing was replayed
+    // onto the incoming model, and nothing is armed to replay later.
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+    expect(store.getState().pendingCameraRotation).toBeNull();
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
   });
 });

--- a/apps/viewer-embed/src/bridge/handler.effects.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.effects.test.ts
@@ -42,7 +42,7 @@ import { hostPoseAppliedToCurrentModel, resetCameraIntent } from './cameraIntent
 // Window double (postMessage in, postMessage out)
 // ---------------------------------------------------------------------------
 
-function installWindow() {
+function installWindow(log?: (entry: string) => void) {
   const listeners = new Set<(e: unknown) => void>();
   const win: any = {
     addEventListener: (type: string, fn: (e: unknown) => void) => {
@@ -52,7 +52,15 @@ function installWindow() {
       if (type === 'message') listeners.delete(fn);
     },
   };
-  win.parent = { postMessage: () => { /* replies are not the subject here */ } };
+  // Replies are not the subject for most of this file, but WHEN a reply is
+  // posted is the whole subject of the ACK-ordering test below, so the command
+  // responses go on the caller's timeline alongside the camera actuations.
+  // Events (READY, MODEL_LOADED, ...) carry no `responseId` and are skipped.
+  win.parent = {
+    postMessage: (msg: any) => {
+      if (msg?.responseId) log?.(`ack:${msg.responseId}`);
+    },
+  };
   (globalThis as any).window = win;
   return {
     dispatch: (data: unknown) => {
@@ -61,8 +69,8 @@ function installWindow() {
   };
 }
 
-function cmd(type: string, data?: unknown) {
-  return { source: EMBED_SOURCE, version: PROTOCOL_VERSION, type, data, requestId: 'r1' };
+function cmd(type: string, data?: unknown, requestId = 'r1') {
+  return { source: EMBED_SOURCE, version: PROTOCOL_VERSION, type, data, requestId };
 }
 
 // ---------------------------------------------------------------------------
@@ -185,7 +193,7 @@ describe('bridge commands against the real store slices', () => {
  * slice, at the point in the bridge's async chain where it really lands: after
  * `loadModelFromUrl`'s fetch, not inside the LOAD_MODEL message task.
  */
-function makeLoadableState() {
+function makeLoadableState(log?: (entry: string) => void) {
   const driven: CameraRotation[] = [];
   let state: any;
   const set = (partial: any) => {
@@ -193,7 +201,16 @@ function makeLoadableState() {
     state = { ...state, ...updates };
   };
   const get = () => state;
-  state = { ...createCameraSlice(set, get, undefined as never), models: new Map() };
+  // `geometryResult` starts null, as it does in a freshly mounted embed: the
+  // store field is what says whether ANY model has ever been on screen here,
+  // and a session reset deliberately leaves it alone (`dataSlice.teardown.ts`:
+  // "the loader writes both straight after"), so it names the OUTGOING model
+  // right up to the moment the incoming one lands.
+  state = {
+    ...createCameraSlice(set, get, undefined as never),
+    models: new Map(),
+    geometryResult: null,
+  };
 
   return {
     driven,
@@ -201,8 +218,14 @@ function makeLoadableState() {
     loadedUrls: [] as string[],
     getState: () => state,
     sessionReset: () => set(cameraTeardown.teardown({ kind: 'session-reset' }, state)),
+    /** What `loadFile` does after the reset: a model appears on screen. Only
+     *  `meshes.length` is ever read from it here. */
+    publishModel: () => set({ geometryResult: { meshes: [{ expressId: 1 }] } }),
     registerRenderer: () => state.setCameraCallbacks({
-      setCameraRotation: (rotation: CameraRotation) => { driven.push(rotation); },
+      setCameraRotation: (rotation: CameraRotation) => {
+        driven.push(rotation);
+        log?.(`camera:${rotation.azimuth},${rotation.elevation}`);
+      },
     }),
   };
 }
@@ -211,15 +234,30 @@ describe('a host camera pose around a destructive load (#3390)', () => {
   let win: ReturnType<typeof installWindow>;
   let store: ReturnType<typeof makeLoadableState>;
   let releaseFetch: () => void;
+  let failFetch: (err: Error) => void;
+  /** The url adapter's in-flight fetch. Re-armed per load so a test can hold
+   *  TWO destructive loads open one after the other. */
+  let fetched: Promise<void>;
+  const rearmFetch = () => {
+    fetched = new Promise<void>((resolve, reject) => {
+      releaseFetch = resolve;
+      failFetch = reject;
+    });
+  };
+  /** Camera actuations and outbound command responses, in the order they
+   *  happened. The ACK-ordering test is about exactly that interleaving. */
+  let timeline: string[];
 
   /** Let every queued microtask (and the load's own continuation) run. */
   const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
   beforeEach(() => {
-    win = installWindow();
-    store = makeLoadableState();
+    timeline = [];
+    const log = (entry: string) => { timeline.push(entry); };
+    win = installWindow(log);
+    store = makeLoadableState(log);
     resetCameraIntent();
-    const fetched = new Promise<void>((resolve) => { releaseFetch = resolve; });
+    rearmFetch();
     initBridge({
       getState: store.getState as never,
       loadModelFromUrl: async (url: string) => {
@@ -228,12 +266,14 @@ describe('a host camera pose around a destructive load (#3390)', () => {
         store.loadedUrls.push(url);
         await fetched;
         store.sessionReset();
+        store.publishModel();
         return { entities: 0, triangles: 0, vertices: 0 };
       },
       loadModelFromBuffer: async () => {
         // No pre-reset await on this path (`EmbedViewer.tsx` hands the buffer
         // straight to `loadFile`), so the reset lands inside the message task.
         store.sessionReset();
+        store.publishModel();
         return { entities: 0, triangles: 0, vertices: 0 };
       },
       addModelFromUrl: vi.fn(),
@@ -320,9 +360,13 @@ describe('a host camera pose around a destructive load (#3390)', () => {
   });
 
   it('does NOT replay a pose the outgoing model already showed (#3364 stays closed)', async () => {
-    // The renderer is registered first, so this pose is actuated immediately —
-    // the user watched the outgoing model at it. It must die with that model.
+    // A model is on screen and the renderer is registered, so this pose is
+    // actuated immediately — the user watched the OUTGOING model at it. It must
+    // die with that model. The published model is what makes this #3364's case
+    // rather than the empty-scene one below: same renderer, same immediate
+    // actuation, opposite answer.
     store.registerRenderer();
+    store.publishModel();
     win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
     expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
 
@@ -335,5 +379,103 @@ describe('a host camera pose around a destructive load (#3390)', () => {
     expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
     expect(store.getState().pendingCameraRotation).toBeNull();
     expect(hostPoseAppliedToCurrentModel()).toBe(false);
+  });
+
+  it('carries a pose actuated on the EMPTY first scene into the load that follows', async () => {
+    // The gap Codex found. `Viewport` mounts before any model, so a host that
+    // does `setCamera(...)` then `loadModel(url)` on a fresh embed hits a LIVE
+    // actuator: the pose is applied to an empty scene and `cameraSlice` records
+    // nothing (`pendingCameraRotation` is armed only when no actuator exists).
+    // The lift used to read that field alone, found null, and the command was
+    // gone — then `home()` framed the arriving model over the top of it.
+    store.registerRenderer();
+
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+    expect(store.getState().pendingCameraRotation).toBeNull();
+
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/m.ifc' }));
+    releaseFetch();
+    await settle();
+
+    // Applied a second time, to the model that arrived — and marked, so the
+    // first-load auto-fit frames with `fitAll` instead of homing it away.
+    expect(store.driven).toEqual([
+      { azimuth: 137, elevation: 61 },
+      { azimuth: 137, elevation: 61 },
+    ]);
+    expect(hostPoseAppliedToCurrentModel()).toBe(true);
+  });
+
+  it('drops that same pose once a model HAS been shown at it (both halves, one fixture)', async () => {
+    // The pair to the test above, differing only in whether a model was on
+    // screen when the pose was actuated. Run as two real loads through the
+    // bridge so the discriminator is the store's own `geometryResult`, written
+    // by the first load, rather than a value the test placed there.
+    store.registerRenderer();
+
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/first.ifc' }, 'load1'));
+    releaseFetch();
+    await settle();
+    expect(store.driven).toEqual([]);
+
+    // Now the host aims the model it is looking at.
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+
+    // ...and then replaces it. #3364: that pose belonged to the file leaving.
+    rearmFetch();
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/second.ifc' }, 'load2'));
+    releaseFetch();
+    await settle();
+
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
+  });
+
+  it('withholds the SET_CAMERA ACK until the queued pose has reached the camera', async () => {
+    // A queue defers the EFFECT, so it has to defer the ACK with it. Before
+    // #3390 `setCameraRotation` ran inside the SET_CAMERA handler and the reply
+    // followed it, so `await v.setCamera(...); v.getScreenshot()` meant the
+    // camera had already moved. ACKing on receipt gives that host back the
+    // OUTGOING angle — an ordering regression the queue introduced, invisible
+    // to every assertion about where the pose ends up.
+    store.registerRenderer();
+    store.publishModel();
+
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/m.ifc' }, 'load1'));
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }, 'cam1'));
+    await settle();
+
+    // Still fetching: the pose is held, and so is the promise the host is
+    // sitting on. Anything it would do after that await must not run yet.
+    expect(store.driven).toEqual([]);
+    expect(timeline).not.toContain('ack:cam1');
+
+    releaseFetch();
+    await settle();
+
+    // The camera moves FIRST, then the host is told it may proceed.
+    expect(timeline.filter((e) => e.startsWith('camera:') || e === 'ack:cam1'))
+      .toEqual(['camera:137,61', 'ack:cam1']);
+  });
+
+  it('ACKs a held SET_CAMERA even when the load it was waiting on fails', async () => {
+    // An ACK that never arrives is worse than a late one: the host's
+    // `setCamera()` promise never settles and its whole command chain stalls.
+    // The failing load applies the pose to the scene still on screen (nothing
+    // was reset), so the reply is owed on that path too.
+    store.registerRenderer();
+    store.publishModel();
+
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/boom.ifc' }, 'load1'));
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }, 'cam1'));
+    await settle();
+    expect(timeline).not.toContain('ack:cam1');
+
+    failFetch(new Error('Failed to fetch model: Not Found'));
+    await settle();
+
+    expect(timeline.filter((e) => e.startsWith('camera:') || e === 'ack:cam1'))
+      .toEqual(['camera:137,61', 'ack:cam1']);
   });
 });

--- a/apps/viewer-embed/src/bridge/handler.effects.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.effects.test.ts
@@ -218,9 +218,12 @@ function makeLoadableState(log?: (entry: string) => void) {
     loadedUrls: [] as string[],
     getState: () => state,
     sessionReset: () => set(cameraTeardown.teardown({ kind: 'session-reset' }, state)),
-    /** What `loadFile` does after the reset: a model appears on screen. Only
-     *  `meshes.length` is ever read from it here. */
+    /** What `loadFile` does after the reset: a model appears on screen. */
     publishModel: () => set({ geometryResult: { meshes: [{ expressId: 1 }] } }),
+    /** A spatial-only IFC — storeys and spaces, no geometry. `geometryResult`
+     *  is non-null and `meshes` is EMPTY. A real state in this repo, not a
+     *  pathological one, and the case a mesh COUNT would misread. */
+    publishModelWithNoMeshes: () => set({ geometryResult: { meshes: [] } }),
     registerRenderer: () => state.setCameraCallbacks({
       setCameraRotation: (rotation: CameraRotation) => {
         driven.push(rotation);
@@ -376,6 +379,27 @@ describe('a host camera pose around a destructive load (#3390)', () => {
 
     // Still exactly the one call from before the load: nothing was replayed
     // onto the incoming model, and nothing is armed to replay later.
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+    expect(store.getState().pendingCameraRotation).toBeNull();
+    expect(hostPoseAppliedToCurrentModel()).toBe(false);
+  });
+
+  it('does NOT replay a pose shown on a SPATIAL-ONLY model (zero meshes is still shown)', async () => {
+    // The discriminator is whether a model was ever LOADED, not whether it has
+    // geometry. A spatial-only IFC publishes a non-null `geometryResult` with
+    // ZERO meshes, so a mesh COUNT calls it "never shown", re-lifts the pose the
+    // user watched it at, and replays it onto the next file — #3364 re-opened
+    // for the model class least likely to be tested. Same shape as the #3364
+    // case above, with the only difference being an empty mesh list.
+    store.registerRenderer();
+    store.publishModelWithNoMeshes();
+    win.dispatch(cmd('SET_CAMERA', { azimuth: 137, elevation: 61 }));
+    expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
+
+    win.dispatch(cmd('LOAD_MODEL', { url: 'https://host.example/m.ifc' }));
+    releaseFetch();
+    await settle();
+
     expect(store.driven).toEqual([{ azimuth: 137, elevation: 61 }]);
     expect(store.getState().pendingCameraRotation).toBeNull();
     expect(hostPoseAppliedToCurrentModel()).toBe(false);

--- a/apps/viewer-embed/src/bridge/handler.ts
+++ b/apps/viewer-embed/src/bridge/handler.ts
@@ -22,8 +22,8 @@ import {
   type ViewPreset,
   type SectionAxis,
 } from '@ifc-lite/embed-protocol';
-import type { ViewerState } from '@/store/index.js';
-import { toGlobalIdFromModels } from '@/store/index.js';
+import { toGlobalIdFromModels, type ViewerState } from '@/store/index.js';
+import { aroundDestructiveLoad, offerHostPose } from './cameraIntent.js';
 
 /** Reference to the store's getState / setState for imperative access */
 interface BridgeContext {
@@ -256,7 +256,7 @@ async function handleCommand(type: InboundCommandType, data: unknown, requestId?
 
     case 'LOAD_MODEL': {
       const payload = data as InboundPayloads['LOAD_MODEL'];
-      const stats = await ctx.loadModelFromUrl(payload.url);
+      const stats = await aroundDestructiveLoad(ctx.getState, ctx.loadModelFromUrl, payload.url);
       if (requestId) emitToParent(createResponse(requestId, stats));
       return;
     }
@@ -267,7 +267,7 @@ async function handleCommand(type: InboundCommandType, data: unknown, requestId?
       if (buffer.byteLength > MAX_BUFFER_SIZE) {
         throw new Error(`Model too large (${(buffer.byteLength / 1024 / 1024).toFixed(0)} MB). Max: 500 MB`);
       }
-      const stats = await ctx.loadModelFromBuffer(buffer);
+      const stats = await aroundDestructiveLoad(ctx.getState, ctx.loadModelFromBuffer, buffer);
       if (requestId) emitToParent(createResponse(requestId, stats));
       return;
     }
@@ -407,7 +407,7 @@ async function handleCommand(type: InboundCommandType, data: unknown, requestId?
 
     case 'SET_CAMERA': {
       const payload = data as InboundPayloads['SET_CAMERA'];
-      state.setCameraRotation({ azimuth: payload.azimuth, elevation: payload.elevation });
+      offerHostPose({ azimuth: payload.azimuth, elevation: payload.elevation }, ctx.getState);
       if (requestId) emitToParent(createResponse(requestId));
       return;
     }

--- a/apps/viewer-embed/src/bridge/handler.ts
+++ b/apps/viewer-embed/src/bridge/handler.ts
@@ -407,7 +407,7 @@ async function handleCommand(type: InboundCommandType, data: unknown, requestId?
 
     case 'SET_CAMERA': {
       const payload = data as InboundPayloads['SET_CAMERA'];
-      offerHostPose({ azimuth: payload.azimuth, elevation: payload.elevation }, ctx.getState);
+      await offerHostPose({ azimuth: payload.azimuth, elevation: payload.elevation }, ctx.getState);
       if (requestId) emitToParent(createResponse(requestId));
       return;
     }

--- a/apps/viewer-embed/src/components/EmbedViewer.cameraIntent.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.cameraIntent.test.ts
@@ -1,0 +1,240 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The component half of #3390.
+ *
+ * The bridge holding a host pose across a load is only half a fix if nothing
+ * in the embed ever takes it back out, and applying it is only half of THAT if
+ * the first-load auto-fit then tweens it away with `home()`. The last case
+ * covers a third limb: the `?modelUrl=` auto-load opens the same
+ * fetch-then-reset window as `LOAD_MODEL` and the bridge never sees it.
+ *
+ * None of that is visible to a store-level assertion — in the clobber case the
+ * pose really is written to `cameraRotation` — so this mounts the real
+ * component and watches the camera actuators it drives, the same harness
+ * `EmbedViewer.urlParams.test.ts` uses for `?camera=`. The load stand-in
+ * applies the REAL `cameraTeardown` session-reset patch and publishes the
+ * model from INSIDE the load, where `loadFile` does both, so a pose that is
+ * not carried across the load is genuinely destroyed rather than merely early.
+ */
+
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import type { MeshData } from '@ifc-lite/geometry';
+
+vi.mock('@/components/viewer/Viewport', () => ({ Viewport: () => null }));
+vi.mock('@/components/viewer/ViewportOverlays', () => ({ ViewportOverlays: () => null }));
+
+// happy-dom has no `navigator.gpu`; without this the `Viewport` subtree, the
+// auto-load effect and the post-load effect are all unreachable and every
+// assertion below would be vacuous.
+vi.mock('@/hooks/useWebGPU', () => ({
+  useWebGPU: () => ({ supported: true, checking: false, reason: null }),
+}));
+
+type Pose = { azimuth: number; elevation: number };
+
+const geometryResult = {
+  meshes: [{
+    expressId: 1,
+    ifcType: 'IfcWall',
+    positions: new Float32Array(0),
+    normals: new Float32Array(0),
+    indices: new Uint32Array(0),
+    color: [1, 1, 1, 1],
+  } as MeshData],
+  totalVertices: 0,
+  totalTriangles: 0,
+};
+
+/** Set by the mock below; drives `geometryResult` from test code via `act()`. */
+let setMockGeometryResult: ((value: typeof geometryResult | null) => void) | null = null;
+/** What `loadFile` contributes to the camera slice — the real teardown, wired below. */
+let sessionReset: () => void = () => {};
+
+// Both callbacks are module-level and STABLE. The bridge-init effect lists
+// `loadFile` and `addModel` in its dependency array, so a fresh `vi.fn()` per
+// render would tear the bridge down (and reset the camera queue with it) on
+// every re-render — the test would then measure its own mock, not the fix.
+const loadFile = vi.fn(async () => { sessionReset(); });
+const addModel = vi.fn(async () => 'stub-model-id');
+
+vi.mock('@/hooks/useIfc', () => ({
+  useIfc: () => {
+    const [gr, setGr] = React.useState<typeof geometryResult | null>(null);
+    setMockGeometryResult = setGr;
+    return {
+      geometryResult: gr,
+      ifcDataStore: null,
+      loadFile,
+      loading: false,
+      models: new Map(),
+      clearAllModels: vi.fn(),
+      addModel,
+    };
+  },
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const { EmbedViewer } = await import('./EmbedViewer.js');
+const { useViewerStore } = await import('@/store');
+const { cameraTeardown } = await import('@/store/slices/cameraSlice.js');
+const { aroundDestructiveLoad, offerHostPose, resetCameraIntent } =
+  await import('../bridge/cameraIntent.js');
+
+sessionReset = () => {
+  useViewerStore.setState(cameraTeardown.teardown({ kind: 'session-reset' }, useViewerStore.getState()));
+};
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+
+/** `parseUrlParams()` runs once in a `useState` initialiser, so the search
+ *  string has to be in place before the first render. */
+function setSearch(search: string): void {
+  window.history.replaceState({}, '', `/${search}`);
+}
+
+function renderEmbedViewer(): void {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => { root.render(React.createElement(EmbedViewer)); });
+  mounted.push({ root, container });
+}
+
+async function settle(): Promise<void> {
+  await act(async () => { await Promise.resolve(); });
+}
+
+/** The model lands: what flips the post-load effect from idle to "a load ended". */
+async function landModel(): Promise<void> {
+  await act(async () => { setMockGeometryResult!(geometryResult); });
+  await settle();
+}
+
+/** The post-load framing polls `requestAnimationFrame` for camera callbacks. */
+async function nextFrame(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  });
+}
+
+/**
+ * One scene-replacing load with a host `SET_CAMERA` posted while it is still
+ * fetching — driven through the real intent module rather than a stub of it,
+ * so what the component consumes is what the bridge really leaves behind.
+ */
+async function loadWithHostPose(pose: Pose): Promise<void> {
+  let releaseFetch!: () => void;
+  const fetched = new Promise<void>((resolve) => { releaseFetch = resolve; });
+  await act(async () => {
+    const load = aroundDestructiveLoad(useViewerStore.getState, async () => {
+      await fetched;
+      // `loadFile`, in order: the session reset that #3364 added, then the
+      // model itself. Both are inside the load, ahead of the point the
+      // bridge's `await` resolves.
+      sessionReset();
+      setMockGeometryResult!(geometryResult);
+    });
+    offerHostPose(pose, useViewerStore.getState);
+    releaseFetch();
+    await load;
+  });
+  await settle();
+}
+
+let calls: string[];
+let home: Mock<() => void>;
+let fitAll: Mock<() => void>;
+let setCameraRotation: Mock<(rotation: Pose) => void>;
+
+beforeEach(() => {
+  resetCameraIntent();
+  loadFile.mockClear();
+  calls = [];
+  home = vi.fn(() => { calls.push('home'); });
+  fitAll = vi.fn(() => { calls.push('fitAll'); });
+  setCameraRotation = vi.fn((r: Pose) => {
+    calls.push(`setCameraRotation:${r.azimuth},${r.elevation}`);
+  });
+  useViewerStore.setState({ cameraCallbacks: { home, fitAll, setCameraRotation } });
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(new ArrayBuffer(8), { status: 200 })));
+});
+
+afterEach(() => {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.unstubAllGlobals();
+  setSearch('');
+  resetCameraIntent();
+  useViewerStore.setState({ cameraCallbacks: {} });
+});
+
+describe('EmbedViewer: a host pose queued against the load (#3390)', () => {
+  it('drives the camera to the queued pose once the model has landed', async () => {
+    renderEmbedViewer();
+    await settle();
+
+    await loadWithHostPose({ azimuth: 137, elevation: 61 });
+    await nextFrame();
+
+    expect(setCameraRotation).toHaveBeenCalledWith({ azimuth: 137, elevation: 61 });
+  });
+
+  it('frames the model instead of homing it, so the pose is not tweened away', async () => {
+    renderEmbedViewer();
+    await settle();
+
+    await loadWithHostPose({ azimuth: 137, elevation: 61 });
+    await nextFrame();
+
+    // `home()` animates to the default orientation, which would undo the pose
+    // that was just applied — an ACKed command with no visible effect, the
+    // exact symptom #3390 reports, reached through the framing path instead of
+    // through the session reset.
+    expect(home).not.toHaveBeenCalled();
+    expect(calls).toEqual(['setCameraRotation:137,61', 'fitAll']);
+  });
+
+  it('still homes the first model when the host asked for nothing', async () => {
+    renderEmbedViewer();
+    await settle();
+
+    await landModel();
+    await nextFrame();
+
+    expect(calls).toEqual(['home']);
+  });
+
+  it('holds the pose across the ?modelUrl= auto-load, which the bridge never sees', async () => {
+    // The auto-load effect fetches and only then calls `loadFile`, exactly like
+    // the bridge's LOAD_MODEL adapter — so a SET_CAMERA arriving mid-fetch is
+    // applied to the outgoing scene and wiped by the reset unless this path is
+    // wrapped too.
+    let releaseFetch!: (response: Response) => void;
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>((resolve) => { releaseFetch = resolve; })));
+
+    setSearch('?modelUrl=https%3A%2F%2Fcdn.example%2Fa.ifc');
+    renderEmbedViewer();
+    await settle();
+
+    offerHostPose({ azimuth: 137, elevation: 61 }, useViewerStore.getState);
+    releaseFetch(new Response(new ArrayBuffer(8), { status: 200 }));
+    await settle();
+    expect(loadFile, 'the auto-load must actually have reached loadFile').toHaveBeenCalled();
+
+    await landModel();
+    await nextFrame();
+
+    expect(calls).toEqual(['setCameraRotation:137,61', 'fitAll']);
+  });
+});

--- a/apps/viewer-embed/src/components/EmbedViewer.cameraIntent.test.ts
+++ b/apps/viewer-embed/src/components/EmbedViewer.cameraIntent.test.ts
@@ -101,11 +101,14 @@ function setSearch(search: string): void {
   window.history.replaceState({}, '', `/${search}`);
 }
 
-function renderEmbedViewer(): void {
+function renderEmbedViewer({ strict = false } = {}): void {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
-  act(() => { root.render(React.createElement(EmbedViewer)); });
+  const tree = React.createElement(EmbedViewer);
+  act(() => {
+    root.render(strict ? React.createElement(React.StrictMode, null, tree) : tree);
+  });
   mounted.push({ root, container });
 }
 
@@ -225,6 +228,34 @@ describe('EmbedViewer: a host pose queued against the load (#3390)', () => {
 
     setSearch('?modelUrl=https%3A%2F%2Fcdn.example%2Fa.ifc');
     renderEmbedViewer();
+    await settle();
+
+    offerHostPose({ azimuth: 137, elevation: 61 }, useViewerStore.getState);
+    releaseFetch(new Response(new ArrayBuffer(8), { status: 200 }));
+    await settle();
+    expect(loadFile, 'the auto-load must actually have reached loadFile').toHaveBeenCalled();
+
+    await landModel();
+    await nextFrame();
+
+    expect(calls).toEqual(['setCameraRotation:137,61', 'fitAll']);
+  });
+
+  it('survives the StrictMode remount that happens mid-fetch on that auto-load', async () => {
+    // `apps/viewer-embed/src/main.tsx` renders under <React.StrictMode>, so in
+    // dev every effect is mount -> cleanup -> remount. The auto-load effect is
+    // ref-guarded and does NOT restart, so its fetch is still outstanding when
+    // the OTHER effects' cleanups run. Anything those cleanups do to the camera
+    // queue therefore lands in the middle of a live load: it drops the held
+    // pose and leaves the rest of the load uncounted, so the SET_CAMERA below
+    // takes `offerHostPose`'s no-load path, is applied to the outgoing scene,
+    // and is wiped by `loadFile`'s reset — then `home()` frames the model that
+    // arrives, which is the #3390 symptom reappearing in the dev build only.
+    let releaseFetch!: (response: Response) => void;
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>((resolve) => { releaseFetch = resolve; })));
+
+    setSearch('?modelUrl=https%3A%2F%2Fcdn.example%2Fa.ifc');
+    renderEmbedViewer({ strict: true });
     await settle();
 
     offerHostPose({ azimuth: 137, elevation: 61 }, useViewerStore.getState);

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -21,7 +21,7 @@ import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { parseUrlParams, assertFetchableUrl } from '../bridge/urlParams.js';
 import { initBridge, destroyBridge, emitEvent } from '../bridge/handler.js';
-import { aroundDestructiveLoad, resetCameraIntent } from '../bridge/cameraIntent.js';
+import { aroundDestructiveLoad } from '../bridge/cameraIntent.js';
 import { mountBridgeLifecycle, unmountBridgeLifecycle } from '../bridge/lifecycle.js';
 import { useEmbedBridgeEvents } from './useEmbedBridgeEvents.js';
 import { useEmbedPostLoad } from './useEmbedPostLoad.js';
@@ -144,7 +144,13 @@ export function EmbedViewer() {
       });
     });
 
-    return () => unmountBridgeLifecycle(bridgeInitialized, () => { destroyBridge(); resetCameraIntent(); });
+    // The bridge only. The camera queue is NOT reset here: the `?modelUrl=`
+    // auto-load below drives it without the bridge ever seeing it, and this
+    // cleanup also fires on StrictMode's dev-only remount, mid-fetch, where
+    // zeroing it drops the held pose and un-counts the rest of the load
+    // (EmbedViewer.cameraIntent.test.ts pins that case). A real unmount needs
+    // no reset: the embed mounts once and the state dies with the page.
+    return () => unmountBridgeLifecycle(bridgeInitialized, destroyBridge);
   }, [loadFile, addModel, urlParams.allowOrigins, urlParams.parentOrigin]);
 
   // Auto-load model from URL param

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -21,8 +21,10 @@ import { useViewerStore } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { parseUrlParams, assertFetchableUrl } from '../bridge/urlParams.js';
 import { initBridge, destroyBridge, emitEvent } from '../bridge/handler.js';
+import { aroundDestructiveLoad, resetCameraIntent } from '../bridge/cameraIntent.js';
 import { mountBridgeLifecycle, unmountBridgeLifecycle } from '../bridge/lifecycle.js';
 import { useEmbedBridgeEvents } from './useEmbedBridgeEvents.js';
+import { useEmbedPostLoad } from './useEmbedPostLoad.js';
 import { useEmbedUrlParams, toHiddenTypeSet, isTypeHidden } from './useEmbedUrlParams.js';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 
@@ -142,7 +144,7 @@ export function EmbedViewer() {
       });
     });
 
-    return () => unmountBridgeLifecycle(bridgeInitialized, () => destroyBridge());
+    return () => unmountBridgeLifecycle(bridgeInitialized, () => { destroyBridge(); resetCameraIntent(); });
   }, [loadFile, addModel, urlParams.allowOrigins, urlParams.parentOrigin]);
 
   // Auto-load model from URL param
@@ -156,12 +158,17 @@ export function EmbedViewer() {
     (async () => {
       try {
         emitEvent('MODEL_LOADING', { progress: 0, phase: 'Fetching model...' });
-        const response = await fetch(urlParams.modelUrl!, { signal: AbortSignal.timeout(60_000) });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const buffer = await response.arrayBuffer();
-        const filename = urlParams.modelUrl!.split('/').pop() || 'model.ifc';
-        const file = new File([buffer], filename);
-        await loadFile(file);
+        // Same scene-replacing window the bridge's LOAD_MODEL has (#3390): the
+        // fetch runs long before `loadFile`'s session reset, so a host
+        // SET_CAMERA arriving in between is held for the incoming model.
+        await aroundDestructiveLoad(useViewerStore.getState, async () => {
+          const response = await fetch(urlParams.modelUrl!, { signal: AbortSignal.timeout(60_000) });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const buffer = await response.arrayBuffer();
+          const filename = urlParams.modelUrl!.split('/').pop() || 'model.ifc';
+          const file = new File([buffer], filename);
+          await loadFile(file);
+        });
       } catch (err) {
         emitEvent('MODEL_ERROR', {
           error: {
@@ -180,72 +187,9 @@ export function EmbedViewer() {
     }
   }, [progress]);
 
-  // Emit model loaded event + auto-fit camera on the first model that lands.
-  // Unlike the full viewer (which has toolbar buttons for fit-all and a default
-  // load flow that fits), the embed has no chrome — so without an explicit fit
-  // call the camera stays at its initial position and the model renders off-frame.
-  // We only fit on the *first* successful load so host-driven SET_CAMERA / view
-  // params via the bridge aren't immediately overridden.
-  const autoFittedRef = useRef(false);
-  useEffect(() => {
-    if (loading) return;
-    const meshes = geometryResult?.meshes;
-    if (!meshes || meshes.length === 0) return;
-
-    emitEvent('MODEL_LOADED', {
-      entities: ifcDataStore?.entities?.count ?? 0,
-      triangles: geometryResult.totalTriangles,
-      vertices: geometryResult.totalVertices,
-    });
-
-    if (autoFittedRef.current) return;
-
-    // Viewport registers cameraCallbacks AFTER renderer.init() resolves (async).
-    // On a fast network + small model, geometry can land before that happens.
-    // Poll for up to ~2 s, checking each frame, then bail out so we never leak.
-    autoFittedRef.current = true;
-    const deadline = performance.now() + 2000;
-    let rafId = 0;
-    const tryFit = () => {
-      const cbs = useViewerStore.getState().cameraCallbacks;
-      const ready = Boolean(cbs.home || cbs.fitAll || cbs.setPresetView);
-      if (!ready) {
-        if (performance.now() < deadline) {
-          rafId = requestAnimationFrame(tryFit);
-        } else {
-          console.warn('[embed] auto-fit gave up — cameraCallbacks never registered');
-        }
-        return;
-      }
-      // Honour ?view= / ?camera= URL params first; only auto-fit if neither was set.
-      if (urlParams.view) {
-        cbs.setPresetView?.(urlParams.view);
-      } else if (urlParams.camera) {
-        // Orientation FIRST, then fit. `setCameraRotation` keeps the current
-        // target and orbit distance (Camera.setRotation), so on its own it
-        // aims an unframed camera at nothing; `fitAll` zooms to the model
-        // "without changing view direction", so it preserves the orientation
-        // we just asked for. The reverse order loses the rotation, because
-        // `home`/`fitAll` animate and the snap would be tweened away.
-        //
-        // The payload's `zoom` is NOT applied: there is no absolute-zoom
-        // actuator (`zoomIn`/`zoomOut` are unitless steppers) and the protocol
-        // gives the field no unit, so any mapping would be invented. Framing
-        // comes from `fitAll` instead. See #2934.
-        useViewerStore.getState().setCameraRotation({
-          azimuth: urlParams.camera.azimuth,
-          elevation: urlParams.camera.elevation,
-        });
-        cbs.fitAll?.();
-      } else if (cbs.home) {
-        cbs.home();
-      } else if (cbs.fitAll) {
-        cbs.fitAll();
-      }
-    };
-    rafId = requestAnimationFrame(tryFit);
-    return () => cancelAnimationFrame(rafId);
-  }, [loading, geometryResult, ifcDataStore, urlParams.view, urlParams.camera]);
+  // MODEL_LOADED, the camera pose a host queued against this load, and
+  // first-load framing — see useEmbedPostLoad.ts.
+  useEmbedPostLoad(loading, geometryResult, ifcDataStore, urlParams);
 
   // Outbound store-change events (ENTITY_SELECTED / ENTITY_HOVERED /
   // CAMERA_CHANGED / SECTION_CHANGED) — see useEmbedBridgeEvents.ts.

--- a/apps/viewer-embed/src/components/useEmbedPostLoad.ts
+++ b/apps/viewer-embed/src/components/useEmbedPostLoad.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * What happens when a load lands: announce it, and frame the first model.
+ *
+ * Unlike the full viewer (which has toolbar buttons for fit-all and a default
+ * load flow that fits), the embed has no chrome — so without an explicit fit
+ * call the camera stays at its initial position and the model renders
+ * off-frame. Only the FIRST successful load is framed, so host-driven
+ * SET_CAMERA / view params via the bridge aren't immediately overridden.
+ *
+ * The pose a host commanded during the load is applied by `cameraIntent.ts`,
+ * not here (#3390) — this hook only asks whether there was one, because the
+ * `home()` it would otherwise use for framing animates that pose away.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useViewerStore } from '@/store';
+import type { ViewerState } from '@/store';
+import { emitEvent } from '../bridge/handler.js';
+import { hostPoseAppliedToCurrentModel } from '../bridge/cameraIntent.js';
+import type { EmbedViewerUrlParams } from '../bridge/urlParams.js';
+
+export function useEmbedPostLoad(
+  loading: boolean,
+  geometryResult: ViewerState['geometryResult'],
+  ifcDataStore: ViewerState['ifcDataStore'],
+  urlParams: EmbedViewerUrlParams,
+): void {
+  const autoFittedRef = useRef(false);
+
+  useEffect(() => {
+    if (loading) return;
+
+    const meshes = geometryResult?.meshes;
+    if (!meshes || meshes.length === 0) return;
+
+    emitEvent('MODEL_LOADED', {
+      entities: ifcDataStore?.entities?.count ?? 0,
+      triangles: geometryResult.totalTriangles,
+      vertices: geometryResult.totalVertices,
+    });
+
+    if (autoFittedRef.current) return;
+
+    // Viewport registers cameraCallbacks AFTER renderer.init() resolves (async).
+    // On a fast network + small model, geometry can land before that happens.
+    // Poll for up to ~2 s, checking each frame, then bail out so we never leak.
+    autoFittedRef.current = true;
+    const deadline = performance.now() + 2000;
+    let rafId = 0;
+    const tryFit = () => {
+      const cbs = useViewerStore.getState().cameraCallbacks;
+      const ready = Boolean(cbs.home || cbs.fitAll || cbs.setPresetView);
+      if (!ready) {
+        if (performance.now() < deadline) {
+          rafId = requestAnimationFrame(tryFit);
+        } else {
+          console.warn('[embed] auto-fit gave up — cameraCallbacks never registered');
+        }
+        return;
+      }
+      // Orientation FIRST, then fit, wherever one was asked for.
+      // `setCameraRotation` keeps the current target and orbit distance
+      // (Camera.setRotation), so on its own it aims an unframed camera at
+      // nothing; `fitAll` zooms to the model "without changing view direction",
+      // so it preserves the orientation just asked for. The reverse order loses
+      // the rotation, because `home`/`fitAll` animate and the snap would be
+      // tweened away.
+      if (hostPoseAppliedToCurrentModel()) {
+        // The host commanded a pose for this very model while it was loading
+        // (#3390) and `aroundDestructiveLoad` has already applied it. That
+        // outranks the static URL params — and `home()` below would tween it
+        // straight out again, the same clobber #3390 reports, reached from the
+        // framing side rather than through the session reset.
+        cbs.fitAll?.();
+      } else if (urlParams.view) {
+        cbs.setPresetView?.(urlParams.view);
+      } else if (urlParams.camera) {
+        // The payload's `zoom` is NOT applied: there is no absolute-zoom
+        // actuator (`zoomIn`/`zoomOut` are unitless steppers) and the protocol
+        // gives the field no unit, so any mapping would be invented. Framing
+        // comes from `fitAll` instead. See #2934.
+        useViewerStore.getState().setCameraRotation({
+          azimuth: urlParams.camera.azimuth,
+          elevation: urlParams.camera.elevation,
+        });
+        cbs.fitAll?.();
+      } else if (cbs.home) {
+        cbs.home();
+      } else if (cbs.fitAll) {
+        cbs.fitAll();
+      }
+    };
+    rafId = requestAnimationFrame(tryFit);
+    return () => cancelAnimationFrame(rafId);
+  }, [loading, geometryResult, ifcDataStore, urlParams.view, urlParams.camera]);
+}

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -201,7 +201,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  */
 const ALLOWLIST_DIGESTS = {
   'apps/viewer': '15058997042616343155',
-  'apps/viewer-embed': '4565652428901906968',
+  'apps/viewer-embed': '12728483381622404308',
   'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',
   'packages/clash': '781065910217740673',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -32,7 +32,6 @@
 # moves ONE of its entries. Two PRs in different scopes then merge cleanly
 # unless their entries sit on ADJACENT lines, which git cannot auto-merge.
    522 apps/viewer-embed/src/bridge/handler.ts
-   439 apps/viewer-embed/src/components/EmbedViewer.tsx
    481 apps/viewer/src/components/extensions/ExtensionsPanel.tsx
    431 apps/viewer/src/components/extensions/FlavorDialog.tsx
    428 apps/viewer/src/components/extensions/widget/WidgetRenderer.tsx


### PR DESCRIPTION
Closes #3390.

A host calling `v.loadModel(url)` then `v.setCamera(az, el)` — or the reverse — got an ACK
for the camera command and no camera movement. `pendingCameraRotation` arms only when
`setCameraRotation` finds no actuator registered, and the load's `resetViewerState()` nulls
it.

**Both orderings were broken on the URL path**, not just the one originally filed. The
issue's own comment corrected that: the await sits one level up in the bridge adapter —
`handler.ts` awaits `ctx.loadModelFromUrl`, which in `EmbedViewer.tsx` awaits a fetch, an
`arrayBuffer()`, and only then `loadFile`, where `resetViewerState()` lives. So the reset
lands a network round trip after the message is handled. `LOAD_MODEL_BUFFER` is genuinely
safe, because nothing awaits before `loadFile` there.

## The constraint that shapes the fix

#3364/#3375 made a session reset expire `pendingCameraRotation` deliberately: a pose armed
against the OUTGOING model was replaying onto the next file. That is correct and must stay
closed. So the fix has to tell a pose armed for the *incoming* model apart from one armed
for the *outgoing* one, and both directions are demonstrated:

- incoming survives — `applies a SET_CAMERA sent during the load fetch to the model that
  arrives`, `carries a SET_CAMERA sent just BEFORE the load through the session reset`,
  and the same for `LOAD_MODEL_BUFFER`.
- outgoing still dies — `does NOT replay a pose the outgoing model already showed (#3364
  stays closed)`. A pose that reached a renderer leaves `pendingCameraRotation` null, so
  nothing is lifted. Mutating the queue to arm unconditionally re-opens #3364 and reds
  that test plus five others.

## Why a queue and not a readiness gate

A renderer-readiness gate only separates "renderer up" from "renderer down". With a
renderer already registered — a second load into a live embed — it lets every pose straight
through, so `loadModel(url)` then `setCamera(...)` still aims the outgoing scene. That is
the maintainer's headline repro and a readiness gate cannot see it. Pinned by
`holds a mid-load SET_CAMERA back even when a renderer IS registered`.

`aroundDestructiveLoad` wraps `LOAD_MODEL`, `LOAD_MODEL_BUFFER` and the `?modelUrl=`
auto-load: on entry it lifts a pose that never reached a renderer (so it was never on
screen for any model, and can only be intent for the one arriving), holds any `SET_CAMERA`
arriving during the load, and hands it to `setCameraRotation` after the reset.

## A defect found and fixed during review

Two overlapping loads could resurrect a **superseded** pose: host sends P1 before any
renderer registers, load A starts, host sends P2 mid-load, then load B re-reads the store
before A's reset has fired and overwrites the newer P2 with P1. An ACKed command whose
effect is silently wrong — the same family as the bug this PR fixes. Fixed in the second
commit and pinned.

An earlier draft consumed the queued pose from a post-load React effect. That put React's
flush order on the correctness path, and the mounted-component test reproduced the failure:
under `act` the effect ran before the wrapped load decremented its in-flight counter, and
the pose was stranded until some unrelated later load picked it up — a #3364-class
wrong-model replay. The load now releases the pose itself; the component reads one bit
(`hostPoseAppliedToCurrentModel()`, a read not a take) only so a first load frames with
`fitAll` instead of `home()`, which would animate the pose away. Worst case of a mistimed
read is now wrong framing, not a lost or misapplied pose.

## Module size

`EmbedViewer.tsx` would have grown past its budget, so the post-load effect moved to
`useEmbedPostLoad.ts` and `EmbedViewer.tsx` landed at 383. **Its allowlist row is DELETED,
not raised** — `git diff origin/main -- scripts/module-size-allowlist.txt` is 0 insertions
/ 1 deletion, exactly that row, no regeneration and no annexed rows.

No changeset: `apps/viewer-embed` is `private: true` and no published `packages/*` surface
moved.

Gates: `pnpm typecheck` exit 0, `pnpm test` exit 0 (96/96 tasks),
`node scripts/check-module-size.mjs` exit 0.

Not verified in a real browser — the tests drive the real store, the real `cameraSlice`
teardown and `EmbedViewer` under React, but the live `useIfcLoader`/fetch boundary was not
executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the host camera view while models load, including asynchronous, buffered, repeated, and failed loads.
  - Ensured camera poses apply to the correct model after loading and do not leak between models.
  - Improved initial camera framing, prioritizing saved views before automatic fitting or homing.
  - Prevented incorrect framing during empty-scene and remount scenarios.

- **Reliability**
  - Improved load acknowledgements and camera updates during overlapping model operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->