### PR TITLE
test(viewer): exercise the grid section-clip band at the pure channel seam (#3393)

### DIFF
--- a/apps/viewer/src/hooks/symbolic-grid-section-clip.test.ts
+++ b/apps/viewer/src/hooks/symbolic-grid-section-clip.test.ts
@@ -1,0 +1,264 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The grid section-clip band, issue #862, finally under test — issue #3393.
+ *
+ * Grid content is clipped to the active section slab; IfcAnnotation content
+ * deliberately is not. Both halves of that rule (`buildSymbolicLineChannels`
+ * for the line buffers, `buildSymbolicRichChannels` for the texts and fills)
+ * gate a `gridByStorey` walk on `y < lo || y > hi`, and nothing in the repo
+ * passed `gridSectionClip` outside `Viewport.tsx`, so `clipEnabled === true`
+ * had never been reached by a test.
+ *
+ * ## Why the previous attempt asserted nothing
+ *
+ * In-band / out-of-band cases were added at the HOOK level over the fixture in
+ * `useSymbolicAnnotations.gridBubbleExtent.test.tsx`. They passed, and they
+ * passed with both band checks deleted.
+ *
+ * The cause is NOT the band check and NOT the parse routing, both of which are
+ * correct. It is that the helper's way of choosing a fixture — re-install the
+ * worker stub, then mount — is not a fixture-selection mechanism at all.
+ * `symbolic-parse-cache.ts` keys its module-global cache on
+ * `source.contentKey` plus the elevation rebase, and `ensureParseFor` returns
+ * early when that key is already cached or in flight. Every fixture variant
+ * shared one `contentKey`, so the second parse of a test was answered from the
+ * first fixture and the freshly installed worker was never asked anything.
+ *
+ * With the default NaN-world-Y fixture reused, `ensureBucket`
+ * (`lib/overlay-parse/symbolic-parse.ts`, the `Number.isFinite` branch) routes
+ * every grid primitive to `gridLoose` / `gridLooseTexts` / `gridLooseFills`.
+ * `gridByStorey` is then EMPTY, the band check is a guard inside a
+ * zero-iteration loop, and the only guard that runs is the loose one,
+ * `fallbackY >= lo && fallbackY <= hi`. Deleting the band check cannot change
+ * a result it never touched.
+ *
+ * Measured, not reasoned: instrumenting the stub showed the second `sample()`
+ * of a test issuing no worker request at all, and the fixture's `contentKey`
+ * now carries the fixture so that cannot recur.
+ *
+ * ## What this file does differently
+ *
+ * 1. It builds the fixture through the REAL `buildParseResult`, then asserts
+ *    `gridByStorey` is populated DIRECTLY (first test) rather than inferring
+ *    it from a downstream buffer. That is the check whose absence let the
+ *    previous attempt ship a vacuous pair.
+ * 2. The fixture is MIXED: one grid axis at a resolvable elevation
+ *    (`BUCKET_Y`, so it lands in `gridByStorey`) and one with a NaN elevation
+ *    (so it lands in `gridLoose*` at `fallbackY`). The two guards therefore
+ *    have separate, observable populations.
+ * 3. Both clip bands admit exactly one of the two. Neither expected result is
+ *    "empty", so no case can pass by everything having been filtered out
+ *    somewhere upstream — the failure that hid inside the previous attempt.
+ * 4. It runs against the pure seams #3381 cut, so there is no React tree, no
+ *    overlay worker stub and no module-global parse cache between the fixture
+ *    and the branch under test. That removes the whole mechanism above rather
+ *    than working around it.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSymbolicLineChannels } from './symbolic-line-channels.js';
+import { buildSymbolicRichChannels } from './symbolic-rich-channels.js';
+import {
+  buildParseResult,
+  createEmptyFlatSymbolic,
+  type FlatSymbolic,
+  type ParseResult,
+} from '../lib/overlay-parse/symbolic-parse.js';
+
+/** Elevation of the grid axis that resolves to a storey bucket. */
+const BUCKET_Y = 10;
+/** World Y the hook lifts orphan (loose) content to. */
+const FALLBACK_Y = 0;
+/** X of the bucket-routed axis, so it is identifiable by coordinate. */
+const BUCKET_X = 1000;
+/** X of the loose axis. */
+const LOOSE_X = 2000;
+
+/**
+ * Two IfcGridAxis primitives of each kind (line, text, fill): one carrying a
+ * finite world-Y (→ `gridByStorey`), one carrying NaN (→ `gridLoose*`).
+ *
+ * `ensureBucket` routes on `Number.isFinite(primitiveWorldY)`, so the finite
+ * value is the whole reason the first half reaches the band check at all.
+ */
+function mixedGridFlat(): FlatSymbolic {
+  const f = createEmptyFlatSymbolic();
+  f.typeNames = ['IfcGridAxis'];
+
+  f.polyPoints = Float32Array.from([
+    BUCKET_X, 0, BUCKET_X, 1,
+    LOOSE_X, 0, LOOSE_X, 1,
+  ]);
+  f.polyStart = Uint32Array.from([0, 2, 4]);
+  f.polyOwner = Uint32Array.from([11, 12]);
+  f.polyWorldY = Float32Array.from([BUCKET_Y, NaN]);
+  f.polyFlags = Uint8Array.from([0, 0]);
+  f.polyType = Uint16Array.from([0, 0]);
+
+  f.textContent = ['BUCKET', 'LOOSE'];
+  f.textAlignment = ['center', 'center'];
+  f.textX = Float32Array.from([BUCKET_X, LOOSE_X]);
+  f.textY = Float32Array.from([0, 0]);
+  f.textDirX = Float32Array.from([1, 1]);
+  f.textDirY = Float32Array.from([0, 0]);
+  f.textHeight = Float32Array.from([1, 1]);
+  f.textTargetPx = Float32Array.from([0, 0]);
+  f.textColor = new Float32Array(8);
+  f.textOwner = Uint32Array.from([11, 12]);
+  f.textWorldY = Float32Array.from([BUCKET_Y, NaN]);
+  f.textType = Uint16Array.from([0, 0]);
+
+  // Offsets index FLOATS in fillPoints (the reader slices start[i]..start[i+1]),
+  // so three [x, z] pairs is six floats per fill.
+  f.fillPoints = Float32Array.from([
+    BUCKET_X, 0, BUCKET_X, 1, BUCKET_X + 1, 1,
+    LOOSE_X, 0, LOOSE_X, 1, LOOSE_X + 1, 1,
+  ]);
+  f.fillPointStart = Uint32Array.from([0, 6, 12]);
+  f.fillHoles = new Uint32Array(0);
+  f.fillHoleStart = Uint32Array.from([0, 0, 0]);
+  f.fillColor = new Float32Array(8);
+  f.fillHatch = new Float32Array(8);
+  f.fillOwner = Uint32Array.from([11, 12]);
+  f.fillWorldY = Float32Array.from([BUCKET_Y, NaN]);
+  f.fillFlags = Uint8Array.from([0, 0]);
+  f.fillType = Uint16Array.from([0, 0]);
+
+  return f;
+}
+
+function mixedGridParse(): ParseResult {
+  return buildParseResult(mixedGridFlat(), {});
+}
+
+/** Band that admits `BUCKET_Y` and excludes `FALLBACK_Y`. */
+const BAND_OVER_BUCKET = { clipEnabled: true, clipPos: BUCKET_Y, clipDepth: 1 };
+/** Band that admits `FALLBACK_Y` and excludes `BUCKET_Y`. */
+const BAND_OVER_FALLBACK = { clipEnabled: true, clipPos: FALLBACK_Y, clipDepth: 1 };
+
+const GRID_ONLY = { enabled: false, effectiveGridEnabled: true, fallbackY: FALLBACK_Y };
+
+/** Every x coordinate in a flat `[x, y, z, …]` line list. */
+function xs(buffer: Float32Array): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < buffer.length; i += 3) out.push(buffer[i]);
+  return out;
+}
+
+describe('the grid section-clip band filters gridByStorey buckets (issues #862, #3393)', () => {
+  it('the fixture puts grid content in gridByStorey, not only in the loose buckets', () => {
+    // Asserted DIRECTLY on the parse, not inferred from a channel buffer.
+    // The previous attempt's fixture failed exactly here and nothing said so:
+    // every primitive sat in gridLoose*, the band check guarded an empty walk,
+    // and both in-band and out-of-band came back empty either way (#3393).
+    const parsed = mixedGridParse();
+
+    assert.equal(parsed.gridByStorey.size, 1, 'one storey bucket must exist for the band check to filter');
+    const bucket = [...parsed.gridByStorey.values()][0];
+    assert.equal(bucket.storeyElevation, BUCKET_Y, 'and it must sit at the elevation the bands are built around');
+    assert.equal(bucket.lines.length, 1, 'the bucket carries the line half');
+    assert.equal(bucket.texts.length, 1, 'the bucket carries the text half');
+    assert.equal(bucket.fills.length, 1, 'the bucket carries the fill half');
+
+    // The other half of the mix, so the two guards address disjoint content.
+    assert.equal(parsed.gridLoose.length, 1);
+    assert.equal(parsed.gridLooseTexts.length, 1);
+    assert.equal(parsed.gridLooseFills.length, 1);
+
+    // Nothing may reach the IfcAnnotation collections: an axis leaking there
+    // would be lifted unclipped and the band would be bypassed entirely.
+    assert.equal(parsed.byStorey.size, 0);
+    assert.equal(parsed.loose.length, 0);
+  });
+
+  it('line channel: a band over the bucket admits the bucket axis and drops the loose one', () => {
+    const { grid } = buildSymbolicLineChannels([{ cached: mixedGridParse() }], {
+      ...GRID_ONLY,
+      ...BAND_OVER_BUCKET,
+    });
+
+    assert.deepEqual(xs(grid), [BUCKET_X, BUCKET_X], 'only the in-band bucket axis lifts');
+  });
+
+  it('line channel: a band that excludes the bucket drops it and keeps only the loose axis', () => {
+    // The discriminating case for `y < lo || y > hi`. The expected result is
+    // NON-empty on purpose: an empty expectation is satisfied by the content
+    // never arriving, which is how the previous attempt passed with the band
+    // check deleted.
+    const { grid } = buildSymbolicLineChannels([{ cached: mixedGridParse() }], {
+      ...GRID_ONLY,
+      ...BAND_OVER_FALLBACK,
+    });
+
+    assert.deepEqual(
+      xs(grid),
+      [LOOSE_X, LOOSE_X],
+      'the out-of-band bucket axis must not lift; deleting the band check puts BUCKET_X back here',
+    );
+  });
+
+  it('rich channel: a band over the bucket admits the bucket bubble and drops the loose one', () => {
+    const { texts, fills } = buildSymbolicRichChannels([{ cached: mixedGridParse() }], {
+      ...GRID_ONLY,
+      ...BAND_OVER_BUCKET,
+    });
+
+    assert.deepEqual(texts.map((t) => t.content), ['BUCKET']);
+    assert.deepEqual(texts.map((t) => t.worldPos[1]), [BUCKET_Y], 'lifted to its own storey, not the fallback');
+    assert.deepEqual(fills.map((f) => f.worldY), [BUCKET_Y]);
+  });
+
+  it('rich channel: a band that excludes the bucket drops it and keeps only the loose bubble', () => {
+    // The rich half's own copy of the band check — a separate walk from the
+    // line half above, so it needs its own red.
+    const { texts, fills } = buildSymbolicRichChannels([{ cached: mixedGridParse() }], {
+      ...GRID_ONLY,
+      ...BAND_OVER_FALLBACK,
+    });
+
+    assert.deepEqual(
+      texts.map((t) => t.content),
+      ['LOOSE'],
+      'the out-of-band bucket bubble must not lift; deleting the band check puts BUCKET back here',
+    );
+    assert.deepEqual(fills.map((f) => f.worldY), [FALLBACK_Y]);
+  });
+
+  it('with no clip active, both bands and both buckets lift — the clip is what filters', () => {
+    // Pins that the filtering above is the CLIP doing it, not the fixture:
+    // the same parse with `clipEnabled: false` yields everything.
+    const params = { ...GRID_ONLY, clipEnabled: false, clipPos: 0, clipDepth: 0 };
+    const { grid } = buildSymbolicLineChannels([{ cached: mixedGridParse() }], params);
+    const { texts } = buildSymbolicRichChannels([{ cached: mixedGridParse() }], params);
+
+    assert.deepEqual(xs(grid).sort((a, b) => a - b), [BUCKET_X, BUCKET_X, LOOSE_X, LOOSE_X]);
+    assert.deepEqual([...texts.map((t) => t.content)].sort(), ['BUCKET', 'LOOSE']);
+  });
+
+  it('IfcAnnotation content is never clipped, only grid content is (issue #862)', () => {
+    // The rule the band belongs to. An annotation bucket at the same excluded
+    // elevation still lifts, so a band check copy-pasted onto `byStorey` would
+    // fail here rather than pass quietly.
+    const flat = mixedGridFlat();
+    flat.typeNames = ['IfcAnnotation'];
+    const cached = buildParseResult(flat, {});
+    assert.equal(cached.byStorey.size, 1, 'the fixture must reach the annotation buckets for this to mean anything');
+
+    const { annotation } = buildSymbolicLineChannels([{ cached }], {
+      enabled: true,
+      effectiveGridEnabled: true,
+      fallbackY: FALLBACK_Y,
+      ...BAND_OVER_FALLBACK,
+    });
+
+    assert.deepEqual(
+      xs(annotation).sort((a, b) => a - b),
+      [BUCKET_X, BUCKET_X, LOOSE_X, LOOSE_X],
+      'the annotation channel ignores the section band entirely',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/symbolic-grid-section-clip.test.ts
+++ b/apps/viewer/src/hooks/symbolic-grid-section-clip.test.ts
@@ -243,22 +243,40 @@ describe('the grid section-clip band filters gridByStorey buckets (issues #862, 
     // The rule the band belongs to. An annotation bucket at the same excluded
     // elevation still lifts, so a band check copy-pasted onto `byStorey` would
     // fail here rather than pass quietly.
+    //
+    // Asserted on BOTH builders. Each keeps its own `byStorey` walk, so the
+    // line assertion says nothing about the rich one: pasting a band check into
+    // `symbolic-rich-channels.ts` alone hides every label and fill on an
+    // out-of-slab storey while the line channel stays green.
     const flat = mixedGridFlat();
     flat.typeNames = ['IfcAnnotation'];
     const cached = buildParseResult(flat, {});
     assert.equal(cached.byStorey.size, 1, 'the fixture must reach the annotation buckets for this to mean anything');
 
-    const { annotation } = buildSymbolicLineChannels([{ cached }], {
+    const params = {
       enabled: true,
       effectiveGridEnabled: true,
       fallbackY: FALLBACK_Y,
       ...BAND_OVER_FALLBACK,
-    });
+    };
 
+    const { annotation } = buildSymbolicLineChannels([{ cached }], params);
     assert.deepEqual(
       xs(annotation).sort((a, b) => a - b),
       [BUCKET_X, BUCKET_X, LOOSE_X, LOOSE_X],
-      'the annotation channel ignores the section band entirely',
+      'the annotation line channel ignores the section band entirely',
+    );
+
+    const { texts, fills } = buildSymbolicRichChannels([{ cached }], params);
+    assert.deepEqual(
+      [...texts.map((t) => t.content)].sort(),
+      ['BUCKET', 'LOOSE'],
+      'and so does the annotation text channel; BUCKET sits outside the band',
+    );
+    assert.deepEqual(
+      [...fills.map((f) => f.worldY)].sort((a, b) => a - b),
+      [FALLBACK_Y, BUCKET_Y],
+      'and the fill channel, on its own walk again',
     );
   });
 });

--- a/apps/viewer/src/hooks/symbolic-rich-channels.ts
+++ b/apps/viewer/src/hooks/symbolic-rich-channels.ts
@@ -6,8 +6,13 @@
  * The pure merge step behind `useSymbolicAnnotationsRichData` — the text and
  * fill twin of `symbolic-line-channels.ts`, split out for the same reason and
  * along the same seam #3381 cut: it takes already-resolved `ParseResult`s and
- * scalars, so it runs against a hand-built parse with no React, no store, no
- * overlay worker and no module-global parse cache.
+ * scalars, so a call runs against a hand-built parse with no React tree, no
+ * store subscription, no overlay worker and no parse-cache lookup.
+ *
+ * Purity of the CALL, not of the import graph: `resolveBucketY` is imported
+ * from the hook file (as the line twin does), so loading this module still
+ * loads React, the store and `symbolic-parse-cache.ts`. Nothing here reads
+ * them, which is the property the tests below rely on.
  *
  * That seam is what makes the grid section-clip band (issue #862) testable.
  * While this walk lived inside the hook, the only way to reach its band check

--- a/apps/viewer/src/hooks/symbolic-rich-channels.ts
+++ b/apps/viewer/src/hooks/symbolic-rich-channels.ts
@@ -1,0 +1,206 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The pure merge step behind `useSymbolicAnnotationsRichData` — the text and
+ * fill twin of `symbolic-line-channels.ts`, split out for the same reason and
+ * along the same seam #3381 cut: it takes already-resolved `ParseResult`s and
+ * scalars, so it runs against a hand-built parse with no React, no store, no
+ * overlay worker and no module-global parse cache.
+ *
+ * That seam is what makes the grid section-clip band (issue #862) testable.
+ * While this walk lived inside the hook, the only way to reach its band check
+ * was to mount React over a stubbed worker and the shared parse cache — and an
+ * attempt to do exactly that produced in-band / out-of-band cases that stayed
+ * green with BOTH band checks deleted: the parse cache is keyed on the
+ * source's `contentKey`, not on which fixture the stubbed worker holds, so the
+ * second parse of a test reused the first one's NaN-world-Y result, every grid
+ * primitive sat in `gridLoose*`, and the band check iterated an empty
+ * `gridByStorey` (issue #3393). `symbolic-grid-section-clip.test.ts` holds the
+ * measurement and the fixture that does reach the buckets.
+ */
+
+import type {
+  AnnotationFill2D,
+  AnnotationText2D,
+  ParseResult,
+} from '../lib/overlay-parse/symbolic-parse.js';
+import { resolveBucketY } from './useSymbolicAnnotations.js';
+
+/**
+ * A text annotation lifted into 3D world space.
+ *
+ * `worldPos[1]` is the storey Y the annotation belongs to (or `fallbackY` for
+ * orphans). `dirX / dirZ` is the baseline direction in 3D (already mirrored
+ * from the IFC frame to match the section overlay's coordinate handedness).
+ * `height` is in world units.
+ */
+export interface AnnotationText3D {
+  worldPos: [number, number, number];
+  dirX: number;
+  dirZ: number;
+  height: number;
+  content: string;
+  alignment: string;
+  /** True when the glyph quad should rebuild in camera-aligned basis (grid tags). */
+  billboard?: boolean;
+  /** sRGB straight-alpha tint, 0..1. */
+  color?: [number, number, number, number];
+  /** Per-instance target cap height in screen pixels. */
+  targetPx?: number;
+  /**
+   * False for grid bubbles: drawn, but the scene AABB must not grow to them
+   * (#3359). REQUIRED here, unlike the optional on the renderer's published
+   * `SymbolicTextInput`: this module is the only producer and every push sets
+   * it, so requiring it makes the forwarding compiler-checked rather than
+   * remembered. The published side stays optional, which is what keeps the
+   * field an additive change for outside callers.
+   */
+  definesExtent: boolean;
+}
+
+/**
+ * A filled region lifted into 3D world space. `points` is a flat
+ * `[x, z, x, z, …]` ring buffer (Y is constant = `worldY`). Holes are tracked
+ * via `holesOffsets` (vertex indices into `points`); the renderer triangulates.
+ */
+export interface AnnotationFill3D {
+  points: Float32Array;
+  holesOffsets: Uint32Array;
+  worldY: number;
+  color: [number, number, number, number];
+  hatching?: AnnotationFill2D['hatching'];
+  /** False for grid bubble fills. See [`AnnotationText3D.definesExtent`] (#3359). */
+  definesExtent: boolean;
+}
+
+export interface SymbolicRichChannels {
+  texts: readonly AnnotationText3D[];
+  fills: readonly AnnotationFill3D[];
+}
+
+/** One store's parsed buckets + hide predicate — no React/WASM dependency,
+ *  so `buildSymbolicRichChannels` runs against a hand-built `ParseResult`
+ *  in a test. */
+export interface SymbolicRichChannelsEntry {
+  cached: ParseResult;
+  isHidden?: (ownerId: number) => boolean;
+}
+
+interface SymbolicRichChannelsParams {
+  enabled: boolean;
+  effectiveGridEnabled: boolean;
+  clipEnabled: boolean;
+  clipPos: number;
+  clipDepth: number;
+  fallbackY: number;
+}
+
+/** Cheap stable empty arrays for the no-data path. */
+const EMPTY_TEXTS: readonly AnnotationText3D[] = Object.freeze([]);
+const EMPTY_FILLS: readonly AnnotationFill3D[] = Object.freeze([]);
+
+/** The "both toggles off" result. One shared frozen value so the hook's own
+ *  early return and this module's cannot drift into two different shapes. */
+export const EMPTY_RICH_CHANNELS: SymbolicRichChannels = Object.freeze({
+  texts: EMPTY_TEXTS,
+  fills: EMPTY_FILLS,
+});
+
+/** Pure merge of every store's annotation and grid texts/fills into two flat
+ *  3D-lifted lists. Exported for unit testing. */
+export function buildSymbolicRichChannels(
+  entries: readonly SymbolicRichChannelsEntry[],
+  params: SymbolicRichChannelsParams,
+): SymbolicRichChannels {
+  const { enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, fallbackY } = params;
+  if (!enabled && !effectiveGridEnabled) return EMPTY_RICH_CHANNELS;
+
+  const texts: AnnotationText3D[] = [];
+  const fills: AnnotationFill3D[] = [];
+
+  for (const { cached, isHidden } of entries) {
+    // `definesExtent`: see [`AnnotationText3D.definesExtent`] for why the
+    // channel routing does not reach bubbles (#3359).
+    const pushText = (t: AnnotationText2D, y: number, definesExtent: boolean) => {
+      if (isHidden && isHidden(t.ownerId)) return;
+      // lineYOffset stacks multi-line text downward in world-Y. Glyph
+      // upAxis is world-Y (see SymbolicTextPipeline), so subtracting
+      // here puts line 1 below line 0 on screen for any side/oblique
+      // 3D view of the floor plan.
+      texts.push({
+        worldPos: [t.x, y + (t.lineYOffset ?? 0), t.y],
+        dirX: t.dirX,
+        dirZ: t.dirY,
+        height: t.height,
+        content: t.content,
+        alignment: t.alignment,
+        billboard: t.billboard,
+        color: t.color,
+        targetPx: t.targetPx,
+        definesExtent,
+      });
+    };
+    const pushFill = (f: AnnotationFill2D, y: number, definesExtent: boolean) => {
+      if (isHidden && isHidden(f.ownerId)) return;
+      fills.push({
+        points: f.points,
+        holesOffsets: f.holesOffsets,
+        worldY: y,
+        color: f.color,
+        hatching: f.hatching,
+        definesExtent,
+      });
+    };
+
+    // Bound once per branch, not spelled at each call: twelve literal
+    // booleans is twelve chances to type `true` in the grid half.
+    const pushAnnotationText = (t: AnnotationText2D, y: number) => pushText(t, y, true);
+    const pushAnnotationFill = (f: AnnotationFill2D, y: number) => pushFill(f, y, true);
+    const pushGridText = (t: AnnotationText2D, y: number) => pushText(t, y, false);
+    const pushGridFill = (f: AnnotationFill2D, y: number) => pushFill(f, y, false);
+
+    if (enabled) {
+      for (const bucket of cached.byStorey.values()) {
+        const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+        for (const t of bucket.texts) pushAnnotationText(t, y);
+        for (const f of bucket.fills) pushAnnotationFill(f, y);
+      }
+      for (const t of cached.looseTexts) pushAnnotationText(t, fallbackY);
+      for (const f of cached.looseFills) pushAnnotationFill(f, fallbackY);
+    }
+
+    if (effectiveGridEnabled) {
+      // Issue #862: the section cut clips GRID content only — IfcAnnotation
+      // deliberately bypasses this, the same rule the line channels follow.
+      if (clipEnabled) {
+        const lo = clipPos - clipDepth;
+        const hi = clipPos + clipDepth;
+        for (const bucket of cached.gridByStorey.values()) {
+          const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+          if (y < lo || y > hi) continue;
+          for (const t of bucket.texts) pushGridText(t, y);
+          for (const f of bucket.fills) pushGridFill(f, y);
+        }
+        if (fallbackY >= lo && fallbackY <= hi) {
+          for (const t of cached.gridLooseTexts) pushGridText(t, fallbackY);
+          for (const f of cached.gridLooseFills) pushGridFill(f, fallbackY);
+        }
+      } else {
+        for (const bucket of cached.gridByStorey.values()) {
+          const y = resolveBucketY(bucket.storeyElevation, fallbackY);
+          for (const t of bucket.texts) pushGridText(t, y);
+          for (const f of bucket.fills) pushGridFill(f, y);
+        }
+        for (const t of cached.gridLooseTexts) pushGridText(t, fallbackY);
+        for (const f of cached.gridLooseFills) pushGridFill(f, fallbackY);
+      }
+    }
+  }
+
+  return {
+    texts: texts.length ? texts : EMPTY_TEXTS,
+    fills: fills.length ? fills : EMPTY_FILLS,
+  };
+}

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.gridBubbleExtent.test.tsx
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.gridBubbleExtent.test.tsx
@@ -171,6 +171,23 @@ async function sample(
   hookOpts: { fallbackY?: number; gridSectionClip?: SectionClipForGrid } = {},
 ): Promise<Sample> {
   let latest: Sample | null = null;
+
+  // Tear the previous mount down FIRST, before anything below touches the
+  // store. `root` / `container` are single slots and `afterEach` unmounts only
+  // what they point at LAST, so without this a Probe from an earlier
+  // `sample()` stays subscribed to the store and the parse cache and
+  // re-renders outside `act()` — into the tests that follow, since nothing
+  // ever unmounts it. Doing it before the `setState` below is what keeps that
+  // store write from reaching a live Probe unwrapped.
+  if (root && container) {
+    const staleRoot = root;
+    const staleContainer = container;
+    act(() => staleRoot.unmount());
+    staleContainer.remove();
+    root = null;
+    container = null;
+  }
+
   if (Number.isFinite(storeyY)) {
     restoreStoreyWorker?.();
     restoreStoreyWorker = installWorker(storeyY);
@@ -286,6 +303,46 @@ describe('grid bubbles draw without defining the model extent (issue 3359)', () 
     assert.equal(s.texts[0].definesExtent, false);
     assert.equal(s.fills.length, 1);
     assert.equal(s.fills[0].definesExtent, false);
+  });
+
+  it('only an ENABLED, DOWN cut clips — the derivation, not just the band (issues #862, #3393)', async () => {
+    // `clipEnabled` is DERIVED inside both hooks, never passed in:
+    //   !!gridSectionClip && gridSectionClip.enabled && gridSectionClip.axis === 'down'
+    // The pure-seam cases in `symbolic-grid-section-clip.test.ts` take
+    // `clipEnabled` as a literal, so they structurally cannot reach that line;
+    // rewriting it to `!!gridSectionClip` left the whole suite green.
+    //
+    // Not a live app bug today: `Viewport.tsx` is the only producer and it
+    // returns `undefined` unless the cut is enabled and `axis === 'down'`, so
+    // the two conjuncts are unreachable-false through the app. They are the
+    // hook's PUBLISHED contract for any other caller — `SectionClipForGrid`
+    // documents both — and that contract had no test.
+    //
+    // The band [2, 4] excludes the loose fixture's `fallbackY` of 0, so the
+    // clipping arm is observably EMPTY. Each non-clipping arm runs the SAME
+    // fixture and is observably non-empty, which is what rules out "the content
+    // never arrived" as the reason for the empty one — the confound that made
+    // the first attempt at #3393 vacuous.
+    const cut = { posWorld: 3, viewDepth: 1 };
+
+    const sideCut = await sample({ enabled: false, gridEnabled: true }, NaN, {
+      gridSectionClip: { ...cut, enabled: true, axis: 'front' },
+    });
+    assert.equal(sideCut.texts.length, 1, 'a front cut passes grid content through unfiltered');
+
+    const offCut = await sample({ enabled: false, gridEnabled: true }, NaN, {
+      gridSectionClip: { ...cut, enabled: false, axis: 'down' },
+    });
+    assert.equal(offCut.texts.length, 1, 'and so does a down cut that is not enabled');
+
+    const downCut = await sample({ enabled: false, gridEnabled: true }, NaN, {
+      gridSectionClip: { ...cut, enabled: true, axis: 'down' },
+    });
+    assert.equal(
+      downCut.texts.length,
+      0,
+      'only the enabled down cut clips; a truthy-only derivation makes all three of these 0',
+    );
   });
 
   it('a second source in one test is parsed on its own, not answered from the first', async () => {

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.gridBubbleExtent.test.tsx
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.gridBubbleExtent.test.tsx
@@ -106,9 +106,31 @@ function annotationAndGrid(storeyY = NaN): FlatSymbolic {
   return f;
 }
 
-function store(): IfcDataStore {
+/**
+ * The `contentKey` CARRIES the fixture, and that is load-bearing (issue #3393).
+ *
+ * `symbolic-parse-cache.ts` keys its module-global parse cache on
+ * `source.contentKey` plus the elevation rebase, and `ensureParseFor` returns
+ * early when that key is already cached or in flight. The worker stub below is
+ * the only thing that knows which fixture a `sample()` call wants, and it is
+ * NOT part of that key — so with one shared key, re-installing the worker to
+ * change fixtures does nothing once a parse for that key has started: the
+ * second call silently reads the FIRST fixture back.
+ *
+ * That is measured, not defensive. With a single shared key, two `sample()`
+ * calls in one test served the second one the first one's NaN parse, which
+ * puts every grid primitive in `gridLoose*` and leaves `gridByStorey` empty —
+ * so a section-clip band check over `gridByStorey` guards a zero-iteration
+ * loop and an out-of-band case comes back empty whether the band check exists
+ * or not. That is exactly the vacuous pair #3393 was filed for.
+ */
+function store(storeyY = NaN): IfcDataStore {
   return {
-    source: { contentKey: 'grid-channel-bytes', byteLength: 10, toTransferable: () => ({}) },
+    source: {
+      contentKey: `grid-channel-bytes-${storeyY}`,
+      byteLength: 10,
+      toTransferable: () => ({}),
+    },
   } as unknown as IfcDataStore;
 }
 
@@ -152,6 +174,9 @@ async function sample(
   if (Number.isFinite(storeyY)) {
     restoreStoreyWorker?.();
     restoreStoreyWorker = installWorker(storeyY);
+    // Point the hooks at a store whose contentKey names THIS fixture, so the
+    // parse cache cannot answer with the one installed before it. See `store`.
+    useViewerStore.setState({ ifcDataStore: store(storeyY) } as never);
   }
 
   function Probe(): null {
@@ -261,6 +286,31 @@ describe('grid bubbles draw without defining the model extent (issue 3359)', () 
     assert.equal(s.texts[0].definesExtent, false);
     assert.equal(s.fills.length, 1);
     assert.equal(s.fills[0].definesExtent, false);
+  });
+
+  it('a second source in one test is parsed on its own, not answered from the first', async () => {
+    // The trap that made #3393's first attempt vacuous, turned into a gate.
+    //
+    // `ensureParseFor` skips a store whose cache key is already cached or in
+    // flight (`symbolic-parse-cache.ts`), and the key is the source's
+    // `contentKey` plus the elevation rebase — never the worker stub that
+    // actually holds the fixture. So a second `sample()` in one test reads the
+    // FIRST fixture back unless the two sources are distinct, which is the
+    // same staleness that hid a federated model's annotations in #2183.
+    //
+    // Read on the ELEVATION rather than on presence: the NaN fixture lifts its
+    // bubble to `fallbackY` (0) and the finite one to its own storey (3), so a
+    // stale answer is a wrong NUMBER here, not an empty list that a filter
+    // somewhere upstream could also explain.
+    const loose = await sample({ enabled: false, gridEnabled: true }, NaN);
+    assert.deepEqual(loose.texts.map((t) => t.worldPos[1]), [0], 'the NaN fixture lifts to fallbackY');
+
+    const bucketed = await sample({ enabled: false, gridEnabled: true }, 3);
+    assert.deepEqual(
+      bucketed.texts.map((t) => t.worldPos[1]),
+      [3],
+      'the second fixture must reach the parse; 0 here means the first parse was reused',
+    );
   });
 
   it('the same split holds for content that RESOLVES to a storey bucket', async () => {

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -208,10 +208,12 @@ export { buildSymbolicLineChannels, type SymbolicLineChannels, type SymbolicLine
 // `symbolic-rich-channels.ts` — split out for the same two reasons as the line
 // channels above, and so the grid section-clip band it applies has a seam a
 // test can reach with no worker, no parse cache and no React (issue #3393).
-// Re-exported narrowly: `AnnotationText3D` / `AnnotationFill3D` have consumers
-// on this import path, and `SymbolicRichChannels` names the return type of the
-// hook below. The builder and its entry type have no consumer here and are
-// imported from their own module instead.
+// Re-exported narrowly: `SymbolicRichChannels` names the return type of the
+// hook below, and `AnnotationText3D` / `AnnotationFill3D` keep this import
+// path working for the callers that already used it (today only
+// `useSymbolicAnnotations.gridBubbleExtent.test.tsx`; `Viewport.tsx` consumes
+// the shapes structurally without naming them). The builder and its entry type
+// have no consumer here and are imported from their own module instead.
 export { type AnnotationFill3D, type AnnotationText3D, type SymbolicRichChannels };
 
 export function useSymbolicAnnotations(params: {

--- a/apps/viewer/src/hooks/useSymbolicAnnotations.ts
+++ b/apps/viewer/src/hooks/useSymbolicAnnotations.ts
@@ -12,7 +12,7 @@
  * lazily and is cached per model source.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { DrawingLine2D } from '@ifc-lite/renderer';
 import { useViewerStore } from '@/store';
 import { useShallow } from 'zustand/react/shallow';
@@ -29,6 +29,14 @@ import {
   type SymbolicLineChannels,
   type SymbolicLineChannelsEntry,
 } from './symbolic-line-channels.js';
+import {
+  buildSymbolicRichChannels,
+  EMPTY_RICH_CHANNELS,
+  type AnnotationFill3D,
+  type AnnotationText3D,
+  type SymbolicRichChannels,
+  type SymbolicRichChannelsEntry,
+} from './symbolic-rich-channels.js';
 
 // The parse walk itself lives in `lib/overlay-parse/symbolic-parse.ts` so a
 // worker can import it (a worker module cannot import this React hook file).
@@ -195,6 +203,17 @@ export interface SectionClipForGrid {
 // Re-exported here so existing consumers keep this import path.
 export { buildSymbolicLineChannels, type SymbolicLineChannels, type SymbolicLineChannelsEntry };
 
+// `buildSymbolicRichChannels` (the pure text/fill merge) and the
+// `AnnotationText3D` / `AnnotationFill3D` shapes it produces live in
+// `symbolic-rich-channels.ts` — split out for the same two reasons as the line
+// channels above, and so the grid section-clip band it applies has a seam a
+// test can reach with no worker, no parse cache and no React (issue #3393).
+// Re-exported narrowly: `AnnotationText3D` / `AnnotationFill3D` have consumers
+// on this import path, and `SymbolicRichChannels` names the return type of the
+// hook below. The builder and its entry type have no consumer here and are
+// imported from their own module instead.
+export { type AnnotationFill3D, type AnnotationText3D, type SymbolicRichChannels };
+
 export function useSymbolicAnnotations(params: {
   /** Enable IfcAnnotation lift (the existing default behaviour). */
   enabled: boolean;
@@ -244,57 +263,6 @@ export function useSymbolicAnnotations(params: {
     });
   }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, hiddenSets, version, fallbackY]);
 }
-
-/**
- * A text annotation lifted into 3D world space.
- *
- * `worldPos[1]` is the storey Y the annotation belongs to (or `fallbackY` for
- * orphans). `dirX / dirZ` is the baseline direction in 3D (already mirrored
- * from the IFC frame to match the section overlay's coordinate handedness).
- * `height` is in world units.
- */
-export interface AnnotationText3D {
-  worldPos: [number, number, number];
-  dirX: number;
-  dirZ: number;
-  height: number;
-  content: string;
-  alignment: string;
-  /** True when the glyph quad should rebuild in camera-aligned basis (grid tags). */
-  billboard?: boolean;
-  /** sRGB straight-alpha tint, 0..1. */
-  color?: [number, number, number, number];
-  /** Per-instance target cap height in screen pixels. */
-  targetPx?: number;
-  /**
-   * False for grid bubbles: drawn, but the scene AABB must not grow to them
-   * (#3359). REQUIRED here, unlike the optional on the renderer's published
-   * `SymbolicTextInput`: this hook is the only producer and every push sets
-   * it, so requiring it makes the forwarding compiler-checked rather than
-   * remembered. The published side stays optional, which is what keeps the
-   * field an additive change for outside callers.
-   */
-  definesExtent: boolean;
-}
-
-/**
- * A filled region lifted into 3D world space. `points` is a flat
- * `[x, z, x, z, …]` ring buffer (Y is constant = `worldY`). Holes are tracked
- * via `holesOffsets` (vertex indices into `points`); the renderer triangulates.
- */
-export interface AnnotationFill3D {
-  points: Float32Array;
-  holesOffsets: Uint32Array;
-  worldY: number;
-  color: [number, number, number, number];
-  hatching?: AnnotationFill2D['hatching'];
-  /** False for grid bubble fills. See [`AnnotationText3D.definesExtent`] (#3359). */
-  definesExtent: boolean;
-}
-
-/** Cheap stable empty arrays for the no-data path. */
-const EMPTY_TEXTS: readonly AnnotationText3D[] = Object.freeze([]);
-const EMPTY_FILLS: readonly AnnotationFill3D[] = Object.freeze([]);
 
 /**
  * Hook for the 2D Section panel: filters the shared parse cache to
@@ -489,7 +457,7 @@ export function useSymbolicAnnotationsRichData(params: {
    *  [`useSymbolicAnnotations`]. */
   gridSectionClip?: SectionClipForGrid;
   fallbackY?: number;
-}): { texts: readonly AnnotationText3D[]; fills: readonly AnnotationFill3D[] } {
+}): SymbolicRichChannels {
   const { enabled, gridEnabled, gridSectionClip, fallbackY = 0 } = params;
   const effectiveGridEnabled = gridEnabled ?? enabled;
   const stores = useActiveStores();
@@ -500,98 +468,24 @@ export function useSymbolicAnnotationsRichData(params: {
   const clipDepth = clipEnabled ? gridSectionClip!.viewDepth : 0;
 
   return useMemo(() => {
-    if (!enabled && !effectiveGridEnabled) return { texts: EMPTY_TEXTS, fills: EMPTY_FILLS };
-    void version;
+    if (!enabled && !effectiveGridEnabled) return EMPTY_RICH_CHANNELS;
+    void version; // depend on parse-completion ticks
 
-    const texts: AnnotationText3D[] = [];
-    const fills: AnnotationFill3D[] = [];
-
+    // Per-entity hide: drop text/fills whose owning annotation is hidden.
+    // Stores whose parse isn't cached yet drop out.
+    const entries: SymbolicRichChannelsEntry[] = [];
     for (const entry of stores) {
       const cached = getParseFor(entry.store);
-      if (!cached) continue;
-
-      // Per-entity hide: drop text/fills whose owning annotation is hidden.
-      const isHidden = makeHiddenOwnerPredicate(entry, hiddenSets);
-
-      // `definesExtent`: see [`AnnotationText3D.definesExtent`] for why the
-      // channel routing does not reach bubbles (#3359).
-      const pushText = (t: AnnotationText2D, y: number, definesExtent: boolean) => {
-        if (isHidden && isHidden(t.ownerId)) return;
-        // lineYOffset stacks multi-line text downward in world-Y. Glyph
-        // upAxis is world-Y (see SymbolicTextPipeline), so subtracting
-        // here puts line 1 below line 0 on screen for any side/oblique
-        // 3D view of the floor plan.
-        texts.push({
-          worldPos: [t.x, y + (t.lineYOffset ?? 0), t.y],
-          dirX: t.dirX,
-          dirZ: t.dirY,
-          height: t.height,
-          content: t.content,
-          alignment: t.alignment,
-          billboard: t.billboard,
-          color: t.color,
-          targetPx: t.targetPx,
-          definesExtent,
-        });
-      };
-      const pushFill = (f: AnnotationFill2D, y: number, definesExtent: boolean) => {
-        if (isHidden && isHidden(f.ownerId)) return;
-        fills.push({
-          points: f.points,
-          holesOffsets: f.holesOffsets,
-          worldY: y,
-          color: f.color,
-          hatching: f.hatching,
-          definesExtent,
-        });
-      };
-
-      // Bound once per branch, not spelled at each call: twelve literal
-      // booleans is twelve chances to type `true` in the grid half.
-      const pushAnnotationText = (t: AnnotationText2D, y: number) => pushText(t, y, true);
-      const pushAnnotationFill = (f: AnnotationFill2D, y: number) => pushFill(f, y, true);
-      const pushGridText = (t: AnnotationText2D, y: number) => pushText(t, y, false);
-      const pushGridFill = (f: AnnotationFill2D, y: number) => pushFill(f, y, false);
-
-      if (enabled) {
-        for (const bucket of cached.byStorey.values()) {
-          const y = resolveBucketY(bucket.storeyElevation, fallbackY);
-          for (const t of bucket.texts) pushAnnotationText(t, y);
-          for (const f of bucket.fills) pushAnnotationFill(f, y);
-        }
-        for (const t of cached.looseTexts) pushAnnotationText(t, fallbackY);
-        for (const f of cached.looseFills) pushAnnotationFill(f, fallbackY);
-      }
-
-      if (effectiveGridEnabled) {
-        if (clipEnabled) {
-          const lo = clipPos - clipDepth;
-          const hi = clipPos + clipDepth;
-          for (const bucket of cached.gridByStorey.values()) {
-            const y = resolveBucketY(bucket.storeyElevation, fallbackY);
-            if (y < lo || y > hi) continue;
-            for (const t of bucket.texts) pushGridText(t, y);
-            for (const f of bucket.fills) pushGridFill(f, y);
-          }
-          if (fallbackY >= lo && fallbackY <= hi) {
-            for (const t of cached.gridLooseTexts) pushGridText(t, fallbackY);
-            for (const f of cached.gridLooseFills) pushGridFill(f, fallbackY);
-          }
-        } else {
-          for (const bucket of cached.gridByStorey.values()) {
-            const y = resolveBucketY(bucket.storeyElevation, fallbackY);
-            for (const t of bucket.texts) pushGridText(t, y);
-            for (const f of bucket.fills) pushGridFill(f, y);
-          }
-          for (const t of cached.gridLooseTexts) pushGridText(t, fallbackY);
-          for (const f of cached.gridLooseFills) pushGridFill(f, fallbackY);
-        }
-      }
+      if (cached) entries.push({ cached, isHidden: makeHiddenOwnerPredicate(entry, hiddenSets) });
     }
 
-    return {
-      texts: texts.length ? texts : EMPTY_TEXTS,
-      fills: fills.length ? fills : EMPTY_FILLS,
-    };
+    return buildSymbolicRichChannels(entries, {
+      enabled,
+      effectiveGridEnabled,
+      clipEnabled,
+      clipPos,
+      clipDepth,
+      fallbackY,
+    });
   }, [enabled, effectiveGridEnabled, clipEnabled, clipPos, clipDepth, stores, hiddenSets, version, fallbackY]);
 }

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -160,7 +160,7 @@ const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
  * moves if anything else touched the allowlist first.
  */
 const ALLOWLIST_DIGESTS = {
-  'apps/viewer': '3789020781016602028',
+  'apps/viewer': '15058997042616343155',
   'apps/viewer-embed': '4565652428901906968',
   'packages/bcf': '10369893299996048894',
   'packages/cache': '14926850005686407910',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -114,7 +114,7 @@
   2204 apps/viewer/src/hooks/useIfcLoader.ts
    436 apps/viewer/src/hooks/useIfcServer.ts
    488 apps/viewer/src/hooks/useKeyboardShortcuts.ts
-   601 apps/viewer/src/hooks/useSymbolicAnnotations.ts
+   493 apps/viewer/src/hooks/useSymbolicAnnotations.ts
    629 apps/viewer/src/lib/analytics-scrub.ts
    651 apps/viewer/src/lib/clash/persistence.ts
    427 apps/viewer/src/lib/collab/geometry-sync.ts

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -1,6 +1,6 @@
 {
-  "apps/viewer": 345,
-  "apps/viewer-embed": 346,
+  "apps/viewer": 344,
+  "apps/viewer-embed": 345,
   "examples/babylonjs-viewer": 1,
   "examples/collab-demo": 1,
   "examples/threejs-collab": 1,


### PR DESCRIPTION
Closes #3393.

`useSymbolicAnnotations` and `useSymbolicAnnotationsRichData` filter grid content against
the active section slab, and nothing under `apps/viewer/src` passed `gridSectionClip`
except `Viewport.tsx`. So no test ever set `clipEnabled = true` and the band check had
never been exercised.

## The previous attempt is why this is a diagnosis, not a test

In-band / out-of-band tests were added before and they passed — **and they also passed with
both `if (y < lo || y > hi) continue;` band checks deleted.** They asserted nothing. With
the existing fixture and a finite `storeyY`, the out-of-band case returned an empty grid
channel whether or not the band check existed, so the content was never reaching the
`gridByStorey` walk the way the in-band case implied. The guard actually deciding the
outcome was the loose-bucket one.

Chasing that is the work. Rather than build a fixture elaborate enough to drive the whole
hook, the band logic is now extracted to a pure seam (`symbolic-rich-channels.ts`) and
tested there, where the input that reaches the walk is stated by the test rather than
inferred from a downstream result.

## Mutation-checked in both directions

Each band check was deleted **independently** — the two are separate code paths and a test
that only catches one is half a test. Every new case reds under the deletion it targets and
passes with the code intact. Nothing here repeats the earlier mistake of shipping an
assertion that survives removing the thing it claims to test.

## A structural consequence worth noting

The extraction took `useSymbolicAnnotations.ts` from 601 lines to 493, so its allowlist row
is **lowered** rather than raised: `git diff origin/main -- scripts/module-size-allowlist.txt`
is exactly that one row, `601 -> 493`, plus the one digest line for its scope. No other row
moved and nothing was regenerated repo-wide.

That is the ratchet working the direction it is supposed to: a test-coverage change that
paid for itself by making the module smaller.

## Context

#3394 and #3381 (both on `main`) recently reworked grid-line overlay ownership, and the
seam this tests at is the one #3381 created. The NaN case was already covered by
`an unclipped lift with a NaN fallbackY still emits the loose grid content`.

Second commit closes five gaps raised by `/code-review` on the first.

No changeset: `apps/viewer` is not a published package and no `packages/*` surface moved.

Gates: `pnpm typecheck` exit 0, `pnpm test` exit 0 (96/96 tasks),
`node scripts/check-module-size.mjs` exit 0.