### PR TITLE
fix(scripts): scope module-size --update to the change, and stop the raise rule contradicting itself (#3398)

### DIFF
--- a/apps/viewer/src/store/slices/chatSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/chatSlice.teardown.ts
@@ -7,7 +7,8 @@
  *
  * A sibling module rather than a block at the bottom of `chatSlice.ts` because
  * that file sits at its recorded module-size budget (452 lines,
- * `scripts/module-size-allowlist.txt`) and may not grow.
+ * `scripts/module-size-allowlist.txt`), which a raise could lift but a
+ * split does not need.
  */
 
 import { defineSliceTeardown } from '../teardown.js';

--- a/apps/viewer/src/store/slices/drawing2DSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/drawing2DSlice.teardown.ts
@@ -7,8 +7,8 @@
  *
  * Lives beside the slice rather than inside it because `drawing2DSlice.ts` is
  * at its recorded module-size budget (`scripts/module-size-allowlist.txt`),
- * and that ratchet only goes down. The seam is real either way: this file is
- * the reviewable list of everything the slice is willing to lose, and the
+ * and that ratchet goes down by default. The seam is real either way: this file
+ * is the reviewable list of everything the slice is willing to lose, and the
  * only consumer is the store's teardown registry.
  *
  * Every value is picked off {@link getDefaultDrawing2DState}, the slice's own

--- a/apps/viewer/src/store/slices/idsSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/idsSlice.teardown.ts
@@ -7,7 +7,8 @@
  *
  * A sibling module rather than a block at the bottom of `idsSlice.ts` because
  * that file sits at its recorded module-size budget (482 lines,
- * `scripts/module-size-allowlist.txt`) and may not grow. The seam is real
+ * `scripts/module-size-allowlist.txt`), which a raise could lift but a
+ * split does not need. The seam is real
  * either way: this answers "what does IDS destroy under a scope", which is a
  * different question from "how does IDS behave", and it has different rules —
  * pure, no `set`, no `get`, no release call.

--- a/apps/viewer/src/store/slices/modelSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/modelSlice.teardown.ts
@@ -6,9 +6,9 @@
  * `modelSlice`'s contribution to the store-wide teardown seam (`store/teardown.ts`).
  *
  * Beside the slice rather than inside it: `modelSlice.ts` carries a recorded
- * budget in `scripts/module-size-allowlist.txt`, and that ratchet only lets a
- * listed file shrink, never grow. Every slice in this group is split the same
- * way so the registry imports one shape, not two.
+ * budget in `scripts/module-size-allowlist.txt`, and that ratchet lets a listed
+ * file shrink by default; growth is a raise, stated in the PR. Every slice in
+ * this group is split the same way so the registry imports one shape, not two.
  *
  * The federation registry is NOT touched here. `federationRegistry
  * .unregisterModel` (partial removal, which BURNS the freed offset range) and

--- a/apps/viewer/src/store/slices/scriptSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/scriptSlice.teardown.ts
@@ -7,7 +7,8 @@
  *
  * A sibling module rather than a block at the bottom of `scriptSlice.ts`
  * because that file sits at its recorded module-size budget (536 lines,
- * `scripts/module-size-allowlist.txt`) and may not grow.
+ * `scripts/module-size-allowlist.txt`), which a raise could lift but a
+ * split does not need.
  */
 
 import { defineSliceTeardown } from '../teardown.js';

--- a/apps/viewer/src/store/slices/sectionSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sectionSlice.teardown.ts
@@ -7,7 +7,7 @@
  *
  * Beside the slice rather than inside it because `sectionSlice.ts` sits at its
  * recorded module-size budget (`scripts/module-size-allowlist.txt`), which
- * ratchets down only.
+ * ratchets down by default.
  *
  * This is the store's canonical Trap B: ONE value, `sectionPlane`, holds both
  * session-scoped and persisted fields. Rather than spread the live plane and

--- a/apps/viewer/src/store/slices/sheetSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/sheetSlice.teardown.ts
@@ -7,7 +7,7 @@
  *
  * Beside the slice rather than inside it because `sheetSlice.ts` sits at its
  * recorded module-size budget (`scripts/module-size-allowlist.txt`), which
- * ratchets down only.
+ * ratchets down by default.
  *
  * `savedSheetTemplates` MUST SURVIVE and is absent from both `owns` and the
  * body. That is confirmed bug #1 in `scripts/check-whole-state-reset.mjs`'s

--- a/apps/viewer/src/store/slices/uiSlice.teardown.ts
+++ b/apps/viewer/src/store/slices/uiSlice.teardown.ts
@@ -7,7 +7,7 @@
  *
  * Beside the slice rather than inside it because `uiSlice.ts` sits at its
  * recorded module-size budget (`scripts/module-size-allowlist.txt`), which
- * ratchets down only.
+ * ratchets down by default.
  *
  * `owns` is a SMALL subset of what this slice holds, on purpose. The slice
  * also owns the panel-collapse flags, `hierarchyMode`, `theme`,

--- a/packages/export/src/step-map-unit.ts
+++ b/packages/export/src/step-map-unit.ts
@@ -11,7 +11,8 @@
  * the question it answers is a different one from "which georeferencing
  * entities does this export write", it has a second caller in
  * `step-property-sets.ts` (property units reach `findLengthUnitReference`
- * through `findUnitId`), and the module-size budget is not a thing to raise.
+ * through `findUnitId`), and raising the module-size budget instead would have
+ * wanted a per-file justification in the PR; a split does not.
  *
  * THE RULE THIS MODULE EXISTS TO KEEP: a unit name is compared WHOLE. The
  * defect it was extracted for was a substring test — `normalized.includes('METRE')`

--- a/packages/geometry/src/symbolic-types.ts
+++ b/packages/geometry/src/symbolic-types.ts
@@ -6,8 +6,9 @@
  * The symbolic-representation type family, split out of `types.ts` (#3199).
  *
  * Moved rather than trimmed: `types.ts` sat EXACTLY at its module-size budget,
- * and the TS allowlist is explicit that budgets ratchet DOWN only and are never
- * raised to make a red gate green. This family is self-contained -- nothing
+ * and the TS allowlist is explicit that budgets ratchet DOWN by default -- a
+ * raise is sanctioned but deliberate, and wants a per-file justification in the
+ * PR, which a split does not. This family is self-contained -- nothing
  * imports it from `types.ts`, and the names the package root exposes come from
  * `ifc-lite-bridge.ts` -- so it is the natural seam. `types.ts` re-exports it,
  * so the public surface is unchanged.

--- a/packages/server-client/src/parquet-columns.ts
+++ b/packages/server-client/src/parquet-columns.ts
@@ -6,10 +6,11 @@
  * The column layer shared by both Parquet decoders.
  *
  * Split out of `parquet-tables.ts` when #3215 pushed that file past its
- * module-size budget. The gate's rule is shrink or split, not raise, and this
- * is the seam that was already there: the two decoders differ in row count and
- * identity column, but resolve the SAME additive trailing block, which the
- * server builds from one `shared_trailing_fields()` in
+ * module-size budget. The gate's default is shrink or split; a raise is
+ * sanctioned but wants a per-file justification in the PR, and none was needed
+ * here, because the seam was already there: the two decoders differ in row
+ * count and identity column, but resolve the SAME additive trailing block,
+ * which the server builds from one `shared_trailing_fields()` in
  * `apps/server/src/services/parquet_schema.rs`.
  */
 

--- a/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery_tests.rs
+++ b/rust/wasm-bindings/src/api/gpu_meshes/prepass_discovery_tests.rs
@@ -1,6 +1,8 @@
 //! Tests for `prepass_discovery`, split out of it for the module-size ratchet.
 //!
-//! The rule there is shrink or split, never raise the budget, and a `_tests.rs`
+//! The rule there is shrink or split by default -- a raise is possible on both
+//! sides (see `module_size_ratchet.rs`, which records one reaching main and
+//! being undone, #2658), it is just not the move here -- and a `_tests.rs`
 //! file is exempt by the gate's own `is_exempt`. Same move as
 //! `styling/prepass_issue_3187_tests.rs`.
 use super::*;

--- a/rust/wasm-bindings/src/api/styling/prepass_issue_3187_tests.rs
+++ b/rust/wasm-bindings/src/api/styling/prepass_issue_3187_tests.rs
@@ -1,8 +1,10 @@
 //! #3187 — geometry jobs must be labelled legacy-aware.
 //!
 //! Split into its own file rather than grown inline: `prepass.rs` is on the
-//! module-size ratchet, and the rule there is shrink or split, never raise
-//! the budget. `prepass_orphan_type_tests.rs` is the same pattern.
+//! module-size ratchet, and the rule there is shrink or split by default. A
+//! raise is possible rather than forbidden (`module_size_ratchet.rs` records
+//! one reaching main and being undone, #2658); splitting is simply the better
+//! move. `prepass_orphan_type_tests.rs` is the same pattern.
 use super::combined_pre_pass;
 
 use ifc_lite_core::{legacy_aware_ifc_type, EntityDecoder, IfcType};

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -47,8 +47,10 @@
  *   touched, so the run reports success and leaves the gate red. It takes
  *   `--update --all --allow-raise`: `--all` to reach outside your scope, and
  *   `--allow-raise` because re-recording a file that grew IS a raise and the
- *   command refuses one unless asked twice. `--update --all` alone writes
- *   nothing and exits 1. It re-records every stale row in the tree on the way
+ *   command refuses one unless asked twice. Without it, `--update --all` writes
+ *   nothing and exits 1 the moment any file grew -- on a shrink-only tree it
+ *   succeeds, which is why "it always refuses" would be the wrong thing to
+ *   remember. It re-records every stale row in the tree on the way
  *   past, which is why it is a maintainer sweep in its OWN commit and its own
  *   PR rather than something to bundle into yours.
  *
@@ -77,7 +79,7 @@
  *
  * Run: node scripts/check-module-size.mjs
  * Regenerate: pnpm lint:module-size-baseline   (node scripts/check-module-size.mjs --update)
- * Repo-wide sweep, its own PR: node scripts/check-module-size.mjs --update --all
+ * Repo-wide sweep, its own PR: node scripts/check-module-size.mjs --update --all --allow-raise
  *
  * An absolute-budget ratchet fights a moving main by construction: any
  * long-lived branch accumulates a red made of files it never touched, and a

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -36,16 +36,20 @@
  *
  * The allowlist is a SNAPSHOT of the tree it was recorded from, so growth that
  * lands on main afterwards — from any PR, including ones this branch never
- * touched — makes the gate red on a long-lived branch. After any merge from
- * main, run the script; if it reports a listed file past budget or a new file
- * over 400, the allowlist needs refreshing in the same commit. Do that with
- * `pnpm lint:module-size-baseline --all` rather than by hand: the bare
- * command is SCOPED to the files your branch touched, and growth inherited from
- * main is by definition outside that scope, so it would report success and
- * leave the gate red. `--all` is the repo-wide regenerate and belongs in its own
- * commit, stated in the PR. A refresh that only
- * tracks growth already on main is a maintainer call and must be stated in the
- * PR; it is not licence to raise a budget for growth the PR itself introduced,
+ * touched — makes the gate red on a long-lived branch. That is a DIFFERENT red
+ * from the one your own change causes, and the two do not share a remedy:
+ *
+ *   Growth YOUR change caused — re-record it with
+ *   `pnpm lint:module-size-baseline`, in the same commit that grows the file.
+ *
+ *   Growth INHERITED from main, after a merge — the scoped command cannot fix
+ *   this one. That growth is by definition outside the files your change
+ *   touched, so the run reports success and leaves the gate red. Only
+ *   `--update --all` clears it, and it re-records every stale row in the tree
+ *   on the way past, which is why it is a maintainer sweep in its OWN commit
+ *   and its own PR rather than something to bundle into yours.
+ *
+ * Neither is licence to raise a budget for growth the PR itself introduced,
  * which is why the regeneration command refuses a raise unless asked twice.
  *
  * What the step breaks on afterwards, by design: any PR adding a TS/TSX file
@@ -344,7 +348,14 @@ function changedFiles(root) {
   // top to BE the scanned root stops a synthetic tree nested inside some other
   // repository from silently inheriting that repository's diff.
   const toplevel = top.stdout.trim();
-  if (safeRealpath(toplevel) !== safeRealpath(root)) {
+  // Either side unresolvable is a REFUSAL, not a pass. `safeRealpath` answers
+  // null on failure, so a bare `!==` compares null to null and lets the guard
+  // through in exactly the case where it knows least about the two paths.
+  // Fail-closed is this function's whole contract; a guard that opens when its
+  // input is unreadable is the "absence read as success" shape again.
+  const resolvedTop = safeRealpath(toplevel);
+  const resolvedRoot = safeRealpath(root);
+  if (resolvedTop === null || resolvedRoot === null || resolvedTop !== resolvedRoot) {
     return { error: `${root} is not the top of its git worktree (that is ${toplevel})` };
   }
   let base = null;

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -44,10 +44,19 @@
  *
  *   Growth INHERITED from main, after a merge — the scoped command cannot fix
  *   this one. That growth is by definition outside the files your change
- *   touched, so the run reports success and leaves the gate red. Only
- *   `--update --all` clears it, and it re-records every stale row in the tree
- *   on the way past, which is why it is a maintainer sweep in its OWN commit
- *   and its own PR rather than something to bundle into yours.
+ *   touched, so the run reports success and leaves the gate red. It takes
+ *   `--update --all --allow-raise`: `--all` to reach outside your scope, and
+ *   `--allow-raise` because re-recording a file that grew IS a raise and the
+ *   command refuses one unless asked twice. `--update --all` alone writes
+ *   nothing and exits 1. It re-records every stale row in the tree on the way
+ *   past, which is why it is a maintainer sweep in its OWN commit and its own
+ *   PR rather than something to bundle into yours.
+ *
+ *   Both spellings are pinned by tests, because this paragraph has now been
+ *   wrong three separate ways — it named a command that silently did nothing,
+ *   then one that pnpm could not even parse, then one that refuses to write.
+ *   Prose describing a command is a claim about behaviour, and the only thing
+ *   that keeps it true is a test that runs it.
  *
  * Neither is licence to raise a budget for growth the PR itself introduced,
  * which is why the regeneration command refuses a raise unless asked twice.

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -24,7 +24,11 @@
  *     debt is frozen; a listed file may stay flat or shrink, never grow.
  *
  * Shrinking a file to <= 400 lets you delete its row, and the gate says so.
- * Budgets ratchet DOWN only: shrink or split instead of raising one.
+ * Budgets ratchet DOWN by default: prefer shrinking or splitting to raising
+ * one. A raise is not forbidden, it is deliberate -- `--update --allow-raise`,
+ * justified per file in the PR -- and the allowlist header says the same. The
+ * two must keep saying the same thing: a reviewer reaches whichever copy sits
+ * in the file they are editing, and #3398 was filed because they disagreed.
  *
  * WIRED INTO CI in the node-tests job of .github/workflows/test.yml, next to
  * the other source-shape gates. The initial allowlist grandfathers 312 files

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -35,7 +35,11 @@
  * touched — makes the gate red on a long-lived branch. After any merge from
  * main, run the script; if it reports a listed file past budget or a new file
  * over 400, the allowlist needs refreshing in the same commit. Do that with
- * `pnpm lint:module-size-baseline` rather than by hand. A refresh that only
+ * `pnpm lint:module-size-baseline -- --all` rather than by hand: the bare
+ * command is SCOPED to the files your branch touched, and growth inherited from
+ * main is by definition outside that scope, so it would report success and
+ * leave the gate red. `--all` is the repo-wide regenerate and belongs in its own
+ * commit, stated in the PR. A refresh that only
  * tracks growth already on main is a maintainer call and must be stated in the
  * PR; it is not licence to raise a budget for growth the PR itself introduced,
  * which is why the regeneration command refuses a raise unless asked twice.
@@ -341,6 +345,19 @@ function changedFiles(root) {
     }
   }
   if (base === null) return { error: 'no merge base with origin/main or main' };
+  // `main` can be arbitrarily far behind `origin/main` (measured here: 147
+  // commits, widening scope from 0 files to 381, 49 of them allowlisted), which
+  // is the annexation this scoping exists to prevent. The fallback is still the
+  // right behaviour -- not every clone names its upstream `origin` -- but it
+  // must not be a routine log line.
+  if (base.ref !== 'origin/main') {
+    console.warn(
+      `check-module-size: WARNING -- no merge base with origin/main; fell back to ` +
+        `local '${base.ref}' (${base.sha.slice(0, 9)}). If that ref is stale, the scope ` +
+        `is WIDER than your change and this regenerate may annex rows you did not touch. ` +
+        `Fetch origin/main and re-run.`,
+    );
+  }
   const nulSeparated = (res) => (res.status === 0 ? res.stdout.split('\0').filter(Boolean) : null);
   // `--no-renames` so a renamed module reports BOTH paths. Rename detection
   // reports only the destination, and the source's row is exactly the one that
@@ -428,8 +445,16 @@ if (args.update) {
       );
     }
     changed = derived.changed;
+    // Report the population scoping can ACT on, not every changed path. A PR
+    // touching a lockfile, some docs and one module was printing "scoped to 200
+    // changed file(s)" next to "0 lowered, 0 removed", which reads as the
+    // scoping having silently done nothing.
+    const actionable = [...changed].filter(
+      (rel) => /\.tsx?$/.test(rel) && !isExempt(rel) && SEARCH_DIRS.some((d) => rel.startsWith(`${d}/`)),
+    ).length;
     scopeNote =
-      `check-module-size: scoped to ${changed.size} changed file(s) vs ${derived.base}; ` +
+      `check-module-size: scoped to ${actionable} changed module(s) ` +
+      `(of ${changed.size} changed path(s)) vs ${derived.base}; ` +
       `pass --all to re-record every row.`;
   }
   console.log(scopeNote);

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -462,7 +462,7 @@ if (args.update) {
     // changed file(s)" next to "0 lowered, 0 removed", which reads as the
     // scoping having silently done nothing.
     const actionable = [...changed].filter(
-      (rel) => /\.tsx?$/.test(rel) && !isExempt(rel) && SEARCH_DIRS.some((d) => rel.startsWith(`${d}/`)),
+      (rel) => SOURCE_RE.test(rel) && !isExempt(rel) && SEARCH_DIRS.some((d) => rel.startsWith(`${d}/`)),
     ).length;
     scopeNote =
       `check-module-size: scoped to ${actionable} changed module(s) ` +

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -561,6 +561,27 @@ if (args.update) {
       ? `check-module-size: ALLOWLIST_DIGESTS re-pinned in ${selfPath} (${nextDigests.size} scopes). Commit both.`
       : `check-module-size: no ALLOWLIST_DIGESTS pin found under ${args.root}; the new digests are ${nextDigest}.`,
   );
+
+  // Re-evaluate against what was actually WRITTEN, and exit on the answer.
+  // A scoped regenerate leaves inherited growth untouched by design, so it used
+  // to print "Commit both." and exit 0 while the gate stayed red -- reporting
+  // success for a run that fixed nothing the contributor was failing on. The
+  // docstring admitted this in prose and the code did not act on it, which is
+  // the same shape as the header claim this whole issue is about.
+  const after = evaluate(files, next);
+  if (after.newOffenders.length > 0 || after.grew.length > 0) {
+    console.error(`
+check-module-size: the allowlist was rewritten, but the gate is STILL RED for
+files outside this change's scope:\n
+${[...after.newOffenders, ...after.grew].join('\n')}
+
+That growth came from main, not from your change, so a scoped regenerate cannot
+reach it. Clear it with a maintainer sweep in its OWN commit and its own PR:
+
+  pnpm lint:module-size-baseline --all --allow-raise
+`);
+    process.exit(1);
+  }
   process.exit(0);
 }
 

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -35,7 +35,7 @@
  * touched — makes the gate red on a long-lived branch. After any merge from
  * main, run the script; if it reports a listed file past budget or a new file
  * over 400, the allowlist needs refreshing in the same commit. Do that with
- * `pnpm lint:module-size-baseline -- --all` rather than by hand: the bare
+ * `pnpm lint:module-size-baseline --all` rather than by hand: the bare
  * command is SCOPED to the files your branch touched, and growth inherited from
  * main is by definition outside that scope, so it would report success and
  * leave the gate red. `--all` is the repo-wide regenerate and belongs in its own

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -56,14 +56,16 @@
  *
  * Run: node scripts/check-module-size.mjs
  * Regenerate: pnpm lint:module-size-baseline   (node scripts/check-module-size.mjs --update)
+ * Repo-wide sweep, its own PR: node scripts/check-module-size.mjs --update --all
  *
  * An absolute-budget ratchet fights a moving main by construction: any
  * long-lived branch accumulates a red made of files it never touched, and a
  * contributor reading a list of unfamiliar filenames reasonably concludes the
- * gate is noise. `--update` is the supported way to re-record, so that
- * hand-editing the allowlist stops being the only one — a hand-edited ratchet
- * is one distracted afternoon from someone raising a budget instead of
- * splitting a file, which is the exact thing this gate exists to prevent.
+ * gate is noise. `--update` is the supported way to re-record the rows your
+ * change touched, so that hand-editing the allowlist stops being the only one —
+ * a hand-edited ratchet is one distracted afternoon from someone raising a
+ * budget instead of splitting a file, which is the exact thing this gate exists
+ * to prevent.
  *
  * `--update` refuses, by itself, to do the one thing that would make it a
  * loophole: it will not raise a budget or add a new exemption. Those need
@@ -71,16 +73,31 @@
  * that shows up in the shell history and still costs a reviewable line in the
  * digest pin. `check-unused-locals.mjs --update` has no such safeguard.
  *
+ * `--update` IS SCOPED to the files your change touched (#3398), derived from
+ * `git diff` against the merge base with main plus anything untracked. It used
+ * to re-record every row in the tree, which sounds harmless — it only ever
+ * TIGHTENED rows it was not asked about — and is not: `slack` and `shrunk` are
+ * advisory precisely so a shrink landing on main cannot redden an open PR, so
+ * headroom accumulates on main and the next `--update` annexes all of it.
+ * Measured on an unmodified checkout of afa717bcf: 11 rows rewritten and 5
+ * digest lines moved with a clean `git status`. Two PRs that regenerate in the
+ * same window then carry the identical hunks and conflict over changes neither
+ * of them made, which is the collision #3398 was filed for. `--all` is the
+ * deliberate repo-wide regenerate, and it belongs in its own PR.
+ *
  * Flags (development and the test harness only; CI would pass none):
  *   --root <dir>       scan this tree instead of the repo
  *   --allowlist <path> read this allowlist instead of the committed one
  *   --digests <json>   compare against this scope->digest object instead of
  *                      ALLOWLIST_DIGESTS
- *   --update           rewrite the allowlist and the digest pin from the tree
+ *   --update           re-record the rows your change touched, and re-pin
  *   --allow-raise      with --update, permit budget raises and new exemptions
+ *   --all              with --update, re-record EVERY row in the tree, not
+ *                      only the changed ones (and skip the git derivation)
  */
 
-import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -206,6 +223,7 @@ function parseArgs(argv) {
     digests: ALLOWLIST_DIGESTS,
     update: false,
     allowRaise: false,
+    all: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
     const flag = argv[i];
@@ -226,13 +244,17 @@ function parseArgs(argv) {
       out.update = true;
     } else if (flag === '--allow-raise') {
       out.allowRaise = true;
+    } else if (flag === '--all') {
+      out.all = true;
     } else {
       fail(`unknown argument: ${flag}`);
     }
   }
   // `--allow-raise` alone reads as "budgets may go up" and does nothing, which
-  // is the worst way for a safety flag to behave. Refuse it instead.
+  // is the worst way for a safety flag to behave. Refuse it instead, and refuse
+  // a bare `--all` for the same reason: it reads as "check everything".
   if (out.allowRaise && !out.update) fail('--allow-raise only means something with --update');
+  if (out.all && !out.update) fail('--all only means something with --update');
   if (out.allowlist === null) out.allowlist = join(out.root, 'scripts', 'module-size-allowlist.txt');
   return out;
 }
@@ -272,6 +294,66 @@ function safeIsDir(path) {
   } catch {
     return false;
   }
+}
+
+function safeRealpath(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The paths this worktree changed relative to its merge base with main:
+ * committed, staged, unstaged and untracked, all relative to the repo top.
+ * `{ changed: Set, base: string }` on success, `{ error }` on failure.
+ *
+ * Git is the only honest discriminator between slack THIS change created and
+ * slack inherited from main, which is why `--update` derives the scope instead
+ * of taking a `--scope` flag: a flag nobody passes is the annexation with extra
+ * steps.
+ *
+ * It FAILS CLOSED rather than falling back to repo-wide. A silent fallback is
+ * the annexation again, in the one context — a shallow clone, a detached
+ * checkout, a script — where nobody is reading the output, and "absence read as
+ * success" is the shape this family of gates exists to avoid.
+ */
+function changedFiles(root) {
+  const git = (...argv) => spawnSync('git', ['-C', root, ...argv], { encoding: 'utf8' });
+  const top = git('rev-parse', '--show-toplevel');
+  if (top.status !== 0) return { error: `${root} is not inside a git worktree` };
+  // Compare resolved paths: `git` answers with the physical path, while --root
+  // may arrive through a symlink (macOS /var -> /private/var). Requiring the
+  // top to BE the scanned root stops a synthetic tree nested inside some other
+  // repository from silently inheriting that repository's diff.
+  const toplevel = top.stdout.trim();
+  if (safeRealpath(toplevel) !== safeRealpath(root)) {
+    return { error: `${root} is not the top of its git worktree (that is ${toplevel})` };
+  }
+  let base = null;
+  for (const ref of ['origin/main', 'main']) {
+    const merged = git('merge-base', ref, 'HEAD');
+    const sha = merged.stdout.trim();
+    if (merged.status === 0 && sha !== '') {
+      base = { ref, sha };
+      break;
+    }
+  }
+  if (base === null) return { error: 'no merge base with origin/main or main' };
+  const nulSeparated = (res) => (res.status === 0 ? res.stdout.split('\0').filter(Boolean) : null);
+  // `--no-renames` so a renamed module reports BOTH paths. Rename detection
+  // reports only the destination, and the source's row is exactly the one that
+  // has to be dropped.
+  const diffed = nulSeparated(git('diff', '--name-only', '--no-renames', '-z', base.sha));
+  // Untracked too: a god file written but not yet committed is the single most
+  // likely thing a contributor is running this for.
+  const untracked = nulSeparated(git('ls-files', '--others', '--exclude-standard', '-z'));
+  if (diffed === null || untracked === null) return { error: 'git could not list the changed files' };
+  return {
+    changed: new Set([...diffed, ...untracked]),
+    base: `${base.ref} (${base.sha.slice(0, 9)})`,
+  };
 }
 
 const args = parseArgs(process.argv.slice(2));
@@ -327,7 +409,32 @@ if (files.length === 0) {
 }
 
 if (args.update) {
-  const { next, raised, added, lowered, removed } = planUpdate(files, allowlist);
+  // Scoped by default; `--all` is the deliberate act, so the annexation can
+  // only happen when someone asked for it and said so in a PR.
+  let changed = null;
+  let scopeNote =
+    'check-module-size: --all: re-recording EVERY row in the tree, ' +
+    'including rows this change never touched.';
+  if (!args.all) {
+    const derived = changedFiles(args.root);
+    if (derived.error !== undefined) {
+      fail(
+        `--update re-records only the files your change touched, and deriving those needs git.\n\n` +
+          `  ${derived.error}\n\n` +
+          `Run it at the top of a worktree with an \`origin/main\` or \`main\` base, or pass\n` +
+          `--all for a deliberate repo-wide regenerate — which also re-records every stale\n` +
+          `row in the tree, so it belongs in its own PR rather than bundled into yours.\n\n` +
+          `Nothing was written.`,
+      );
+    }
+    changed = derived.changed;
+    scopeNote =
+      `check-module-size: scoped to ${changed.size} changed file(s) vs ${derived.base}; ` +
+      `pass --all to re-record every row.`;
+  }
+  console.log(scopeNote);
+
+  const { next, raised, added, lowered, removed } = planUpdate(files, allowlist, changed);
 
   const loosening = [...raised, ...added];
   if (loosening.length > 0 && !args.allowRaise) {

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -250,6 +250,14 @@ function parseArgs(argv) {
       out.allowRaise = true;
     } else if (flag === '--all') {
       out.all = true;
+    } else if (flag === '--') {
+      // npm, yarn and pnpm each treat the conventional `--` separator
+      // differently, and pnpm forwards it to the script verbatim. Refusing it
+      // makes `pnpm lint:module-size-baseline -- --all` -- the spelling a
+      // contributor types out of habit -- die before writing anything, which
+      // is the same defect this file's own docstring is about: documented
+      // advice that does not work. Tolerate it and read the rest.
+      continue;
     } else {
       fail(`unknown argument: ${flag}`);
     }

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -650,3 +650,26 @@ test('the local-main fallback warns, and an origin/main base does not', () => {
   assert.doesNotMatch(clean.out, /WARNING/);
   assert.match(clean.out, /vs origin\/main \(/);
 });
+
+// The docstring's remedy for growth inherited from main has been wrong three
+// times: it named the scoped command (which cannot reach outside the branch's
+// own files), then `-- --all` (which pnpm forwards verbatim and parseArgs
+// rejected), then `--all` alone (which refuses to write, because re-recording a
+// grown file is a raise). Prose describing a command is a claim about
+// behaviour; these two pin the claim so the next rewrite has to agree with
+// something executable.
+test('--update --all alone refuses inherited growth rather than clearing it', () => {
+  const dir = tree({ 'packages/a/big.ts': 520 });
+  const { code, out } = run(dir, '   500 packages/a/big.ts\n', { extra: ['--update', '--all'] });
+  assert.equal(code, 1, out);
+  assert.match(out, /Nothing was written/);
+});
+
+test('--update --all --allow-raise is what actually clears inherited growth', () => {
+  const dir = tree({ 'packages/a/big.ts': 520 });
+  const { code, out, allowlistPath } = run(dir, '   500 packages/a/big.ts\n', {
+    extra: ['--update', '--all', '--allow-raise'],
+  });
+  assert.equal(code, 0, out);
+  assert.match(readFileSync(allowlistPath, 'utf8'), /520 packages\/a\/big\.ts/);
+});

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -11,6 +11,12 @@
  * against it via `--root` / `--allowlist` / `--digests`, and asserts the exit
  * code AND the message. Nothing here reads the checker's source.
  *
+ * The `--update` scoping cases (#3398) need a REAL git repository, because the
+ * scope is derived from `git diff` against the merge base with main. They
+ * `git init` inside the same temp dir; `tmpdir()` has no enclosing repository,
+ * which is asserted as its own case so the derivation cannot quietly be reading
+ * this checkout's diff instead.
+ *
  * The cases that matter most are the ones where a gate could pass having
  * measured nothing — no files, a missing search root, an unreadable or empty
  * allowlist, an absent digest pin. Three scripts in this repo have shipped
@@ -37,15 +43,21 @@ import {
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const CHECKER = join(ROOT, 'scripts', 'check-module-size.mjs');
 
+/** `lines` real lines: n-1 newlines plus a terminating one. */
+function source(lines) {
+  return `${Array.from({ length: lines }, (_, i) => `const l${i} = ${i};`).join('\n')}\n`;
+}
+
+function writeSource(dir, rel, lines) {
+  const full = join(dir, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, source(lines));
+}
+
 /** A tree of `{ 'packages/a/b.ts': <line count> }` plus an allowlist string. */
 function makeTree(files) {
   const dir = mkdtempSync(join(tmpdir(), 'module-size-'));
-  for (const [rel, lines] of Object.entries(files)) {
-    const full = join(dir, rel);
-    mkdirSync(dirname(full), { recursive: true });
-    // `lines` real lines: n-1 newlines plus a terminating one.
-    writeFileSync(full, `${Array.from({ length: lines }, (_, i) => `const l${i} = ${i};`).join('\n')}\n`);
-  }
+  for (const [rel, lines] of Object.entries(files)) writeSource(dir, rel, lines);
   for (const d of ['packages', 'apps']) mkdirSync(join(dir, d), { recursive: true });
   return dir;
 }
@@ -82,6 +94,29 @@ function tree(files) {
   const d = makeTree(files);
   cleanup.push(d);
   return d;
+}
+
+/**
+ * The same tree, but a REAL git repository with `files` committed on `main`.
+ *
+ * `--update` scopes itself to the files a change touched, and git is where that
+ * answer comes from, so these cases cannot be faked with a plain directory.
+ * `tmpdir()` has no enclosing repository (asserted below), which is what keeps
+ * the derivation hermetic rather than reading this checkout's own diff.
+ */
+function gitTree(files) {
+  const dir = tree(files);
+  const git = (...argv) => {
+    const res = spawnSync('git', ['-C', dir, ...argv], { encoding: 'utf8' });
+    assert.equal(res.status, 0, `git ${argv.join(' ')}: ${res.stdout}${res.stderr}`);
+    return res.stdout;
+  };
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'ratchet@example.invalid');
+  git('config', 'user.name', 'ratchet test');
+  git('add', '--', ...Object.keys(files));
+  git('commit', '-qm', 'base');
+  return { dir, git };
 }
 
 test('clean tree passes and says how much it measured', () => {
@@ -236,7 +271,7 @@ const HEADER = '# header line kept verbatim\n';
 test('--update refuses to raise a budget, and writes nothing', () => {
   const dir = tree({ 'packages/a/big.ts': 501 });
   const before = `${HEADER}500 packages/a/big.ts\n`;
-  const { code, out, allowlistPath } = run(dir, before, { extra: ['--update'] });
+  const { code, out, allowlistPath } = run(dir, before, { extra: ['--update', '--all'] });
   assert.equal(code, 1, out);
   assert.match(out, /refusing to loosen the ratchet/);
   assert.match(out, /packages\/a\/big\.ts: 501 lines, budget 500 \(\+1\)/);
@@ -248,7 +283,7 @@ test('--update refuses to raise a budget, and writes nothing', () => {
 test('--update refuses to add a new exemption, and writes nothing', () => {
   const dir = tree({ 'packages/a/big.ts': 500, 'apps/v/new_god.tsx': 401 });
   const before = `${HEADER}500 packages/a/big.ts\n`;
-  const { code, out, allowlistPath } = run(dir, before, { extra: ['--update'] });
+  const { code, out, allowlistPath } = run(dir, before, { extra: ['--update', '--all'] });
   assert.equal(code, 1, out);
   assert.match(out, /new exemption/);
   assert.match(out, /apps\/v\/new_god\.tsx: 401 lines/);
@@ -262,7 +297,7 @@ test('--update DOES lower a slack budget and drop a stale row', () => {
   const { code, out, allowlistPath } = run(
     dir,
     `${HEADER}500 packages/a/big.ts\n420 packages/a/small.ts\n700 packages/a/gone.ts\n`,
-    { extra: ['--update'] },
+    { extra: ['--update', '--all'] },
   );
   assert.equal(code, 0, out);
   assert.equal(
@@ -275,7 +310,7 @@ test('--update DOES lower a slack budget and drop a stale row', () => {
 test('--update --allow-raise does raise it, and says so in the output', () => {
   const dir = tree({ 'packages/a/big.ts': 501 });
   const { code, out, allowlistPath } = run(dir, `${HEADER}500 packages/a/big.ts\n`, {
-    extra: ['--update', '--allow-raise'],
+    extra: ['--update', '--allow-raise', '--all'],
   });
   assert.equal(code, 0, out);
   assert.match(out, /RAISED:\s+packages\/a\/big\.ts: 501 lines, budget 500/);
@@ -295,7 +330,7 @@ test('VACUOUS: --update refuses to write an allowlist with no rows', () => {
   // read as a clean tree.
   const dir = tree({ 'packages/a/small.ts': 100 });
   const { code, out, allowlistPath } = run(dir, `${HEADER}500 packages/a/small.ts\n`, {
-    extra: ['--update'],
+    extra: ['--update', '--all'],
   });
   assert.equal(code, 1, out);
   assert.match(out, /refusing to write an allowlist with 0 rows/);
@@ -309,7 +344,7 @@ test('what --update writes is what the gate then accepts', () => {
   const { code, out, allowlistPath } = run(
     dir,
     `${HEADER}500 packages/a/big.ts\n900 packages/a/x.ts\n`,
-    { extra: ['--update'] },
+    { extra: ['--update', '--all'] },
   );
   assert.equal(code, 0, out);
   const written = readFileSync(allowlistPath, 'utf8');
@@ -340,7 +375,7 @@ test('--update re-pins ALLOWLIST_DIGESTS in the same run, one line per scope', (
   const { code, out, allowlistPath } = run(
     dir,
     `${HEADER}500 packages/a/big.ts\n500 apps/v/huge.ts\n`,
-    { extra: ['--update'] },
+    { extra: ['--update', '--all'] },
   );
   assert.equal(code, 0, out);
 
@@ -429,7 +464,7 @@ test('regenerating the real allowlist reproduces it byte for byte', () => {
   const { code, out } = run(dir, null, {
     allowlistPath: copy,
     digest: allowlistDigests(rows),
-    extra: ['--update'],
+    extra: ['--update', '--all'],
   });
   assert.equal(code, 0, out);
   assert.equal(readFileSync(copy, 'utf8'), realText);
@@ -443,4 +478,114 @@ test('the committed gate runs green against the real repo', () => {
   const out = `${res.stdout}${res.stderr}`;
   assert.equal(res.status, 0, out);
   assert.match(out, /check-module-size: OK \(\d+ files measured, \d+ allowlisted, 0 new over 400\)/);
+});
+
+// ---------------------------------------------------------------------------
+// --update is SCOPED to the change (#3398). Repo-wide re-recording rewrote 11
+// allowlist rows and moved 5 digest lines on an unmodified checkout of
+// afa717bcf, with `git status` clean, which is the mechanism behind the
+// two-PR collision #3398 was filed for.
+// ---------------------------------------------------------------------------
+
+const SCOPED_BEFORE = `${HEADER}   500 packages/a/big.ts\n   460 packages/b/slack.ts\n`;
+
+test('the temp dir the scoping cases build in has no enclosing git repository', () => {
+  // Anti-vacuity for every case below: if tmpdir() sat inside a repository,
+  // the derivation would read THAT repository's diff and the scoped runs would
+  // pass or fail for a reason nothing here controls.
+  const res = spawnSync('git', ['-C', tmpdir(), 'rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+  assert.notEqual(res.status, 0, `tmpdir() is inside a git repo: ${res.stdout}`);
+});
+
+test('--update re-records the changed file and leaves the untouched row alone', () => {
+  const { dir, git } = gitTree({ 'packages/a/big.ts': 500, 'packages/b/slack.ts': 450 });
+  git('checkout', '-q', '-b', 'feature');
+  writeSource(dir, 'packages/a/big.ts', 520);
+
+  const { code, out, allowlistPath } = run(dir, SCOPED_BEFORE, { extra: ['--update', '--allow-raise'] });
+  assert.equal(code, 0, out);
+  // packages/b/slack.ts has 10 lines of headroom and this change never touched
+  // it. Byte-for-byte: its row keeps the committed 460, not the measured 450.
+  assert.equal(
+    readFileSync(allowlistPath, 'utf8'),
+    `${HEADER}   520 packages/a/big.ts\n   460 packages/b/slack.ts\n`,
+  );
+  assert.match(out, /scoped to \d+ changed file\(s\) vs main \([0-9a-f]{9}\)/);
+  assert.match(out, /pass --all to re-record every row/);
+});
+
+test('--update on an unchanged worktree writes the allowlist back unchanged', () => {
+  const { dir } = gitTree({ 'packages/a/big.ts': 500, 'packages/b/slack.ts': 450 });
+  const { code, out, allowlistPath } = run(dir, SCOPED_BEFORE, { extra: ['--update'] });
+  assert.equal(code, 0, out);
+  assert.equal(readFileSync(allowlistPath, 'utf8'), SCOPED_BEFORE);
+  assert.match(out, /0 lowered, 0 removed, 0 raised, 0 added/);
+});
+
+test('--all is the deliberate opt-out, and it DOES annex the untouched row', () => {
+  // The A/B against the case above, same fixture: the sweep is still available,
+  // it just has to be asked for.
+  const { dir } = gitTree({ 'packages/a/big.ts': 500, 'packages/b/slack.ts': 450 });
+  const { code, out, allowlistPath } = run(dir, SCOPED_BEFORE, { extra: ['--update', '--all'] });
+  assert.equal(code, 0, out);
+  assert.equal(
+    readFileSync(allowlistPath, 'utf8'),
+    `${HEADER}   500 packages/a/big.ts\n   450 packages/b/slack.ts\n`,
+  );
+  assert.match(out, /lowered:\s+packages\/b\/slack\.ts: 450 lines, budget 460/);
+  assert.match(out, /re-recording EVERY row in the tree/);
+});
+
+test('--update outside a git worktree fails closed and names --all', () => {
+  // Falling back to repo-wide here is the annexation again, in the one place
+  // nobody is reading the output.
+  const dir = tree({ 'packages/a/big.ts': 450, 'packages/b/slack.ts': 450 });
+  const { code, out, allowlistPath } = run(dir, SCOPED_BEFORE, { extra: ['--update'] });
+  assert.equal(code, 1, out);
+  assert.match(out, /deriving those needs git/);
+  assert.match(out, /is not inside a git worktree/);
+  assert.match(out, /pass\n--all for a deliberate repo-wide regenerate/);
+  assert.equal(readFileSync(allowlistPath, 'utf8'), SCOPED_BEFORE);
+});
+
+test('a god file the change ADDED but never committed is in scope', () => {
+  const { dir } = gitTree({ 'packages/a/big.ts': 500 });
+  writeSource(dir, 'packages/a/new_god.ts', 401);
+  const before = `${HEADER}   500 packages/a/big.ts\n`;
+
+  const refused = run(dir, before, { extra: ['--update'] });
+  assert.equal(refused.code, 1, refused.out);
+  assert.match(refused.out, /packages\/a\/new_god\.ts: 401 lines \(new exemption\)/);
+  assert.equal(readFileSync(refused.allowlistPath, 'utf8'), before);
+
+  const allowed = run(dir, before, { allowlistPath: refused.allowlistPath, extra: ['--update', '--allow-raise'] });
+  assert.equal(allowed.code, 0, allowed.out);
+  assert.equal(
+    readFileSync(allowed.allowlistPath, 'utf8'),
+    `${HEADER}   500 packages/a/big.ts\n   401 packages/a/new_god.ts\n`,
+  );
+});
+
+test('--all without --update is refused rather than silently ignored', () => {
+  const dir = tree({ 'packages/a/big.ts': 500 });
+  const { code, out } = run(dir, `${HEADER}500 packages/a/big.ts\n`, { extra: ['--all'] });
+  assert.equal(code, 1, out);
+  assert.match(out, /--all only means something with --update/);
+});
+
+test('--update refuses a --root that is not the top of its worktree', () => {
+  // A tree NESTED in some other repository must not inherit that repository's
+  // diff: git answers in paths relative to the outer top, which match nothing
+  // the walk measured, so every row would silently carry through and the run
+  // would report a scope it never actually had.
+  const { dir } = gitTree({ 'packages/a/big.ts': 500 });
+  const nested = join(dir, 'nested');
+  writeSource(nested, 'packages/a/big.ts', 500);
+  writeSource(nested, 'packages/b/slack.ts', 450);
+  mkdirSync(join(nested, 'apps'), { recursive: true });
+
+  const { code, out, allowlistPath } = run(nested, SCOPED_BEFORE, { extra: ['--update'] });
+  assert.equal(code, 1, out);
+  assert.match(out, /is not the top of its git worktree/);
+  assert.equal(readFileSync(allowlistPath, 'utf8'), SCOPED_BEFORE);
 });

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -510,7 +510,10 @@ test('--update re-records the changed file and leaves the untouched row alone', 
     readFileSync(allowlistPath, 'utf8'),
     `${HEADER}   520 packages/a/big.ts\n   460 packages/b/slack.ts\n`,
   );
-  assert.match(out, /scoped to \d+ changed file\(s\) vs main \([0-9a-f]{9}\)/);
+  // The count is the population scoping can ACT on, not every changed path:
+  // this fixture changes 2 paths and exactly 1 of them is an allowlistable
+  // module, so a bare "2 changed file(s)" would have overstated the scope.
+  assert.match(out, /scoped to 1 changed module\(s\) \(of 2 changed path\(s\)\) vs main \([0-9a-f]{9}\)/);
   assert.match(out, /pass --all to re-record every row/);
 });
 

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -592,3 +592,35 @@ test('--update refuses a --root that is not the top of its worktree', () => {
   assert.match(out, /is not the top of its git worktree/);
   assert.equal(readFileSync(allowlistPath, 'utf8'), SCOPED_BEFORE);
 });
+
+// pnpm forwards the conventional `--` separator to the script verbatim, so
+// `pnpm lint:module-size-baseline -- --all` reached parseArgs as a bare `--`
+// and died with "unknown argument" before writing anything. The docstring no
+// longer spells it that way, but a contributor typing it out of habit must not
+// hit a hard failure from a gate whose own subject is advice that works.
+test('a bare -- separator is tolerated, not a hard failure', () => {
+  const dir = tree({ 'packages/a/big.ts': 500 });
+  const { code, out } = run(dir, '500 packages/a/big.ts\n', { extra: ['--'] });
+  assert.equal(code, 0, out);
+  assert.doesNotMatch(out, /unknown argument/);
+});
+
+// `--no-renames` in changedFiles() is load-bearing and was silent when removed:
+// rename detection reports only the DESTINATION, so the source's allowlist row
+// -- the one that must be dropped, because that file no longer exists -- stays
+// out of scope and survives the regenerate. The gate then still exits 0, with
+// the stale row reported only as an advisory `missing` note.
+test('a renamed module puts BOTH paths in scope, so the source row drops', () => {
+  const { dir, git } = gitTree({ 'packages/a/big.ts': 500, 'packages/b/slack.ts': 450 });
+  git('checkout', '-q', '-b', 'feature');
+  git('mv', 'packages/a/big.ts', 'packages/a/renamed.ts');
+
+  const { code, out, allowlistPath } = run(dir, SCOPED_BEFORE, { extra: ['--update', '--allow-raise'] });
+  assert.equal(code, 0, out);
+  // The source row is GONE and the destination has one, both at 500 lines.
+  // packages/b/slack.ts is untouched, so it keeps its committed 460.
+  assert.equal(
+    readFileSync(allowlistPath, 'utf8'),
+    `${HEADER}   500 packages/a/renamed.ts\n   460 packages/b/slack.ts\n`,
+  );
+});

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -624,3 +624,29 @@ test('a renamed module puts BOTH paths in scope, so the source row drops', () =>
     `${HEADER}   500 packages/a/renamed.ts\n   460 packages/b/slack.ts\n`,
   );
 });
+
+// changedFiles() falls back from `origin/main` to a local `main`, and that ref
+// can be arbitrarily stale (changedFiles' own comment carries the measurement).
+// A stale base widens the scope, so the warning is the only thing between a
+// contributor and the annexation this whole change exists to stop -- and it was
+// as invisible as the two guards above: deleting it left the suite green, and
+// so did making it fire unconditionally. Asserted in BOTH directions, because a
+// warning that always fires is as useless as one that never does.
+test('the local-main fallback warns, and an origin/main base does not', () => {
+  const { dir, git } = gitTree({ 'packages/a/big.ts': 500, 'packages/b/slack.ts': 450 });
+  git('checkout', '-q', '-b', 'feature');
+  writeSource(dir, 'packages/a/big.ts', 480);
+
+  // No `origin/main` ref: the merge base comes from local `main`.
+  const fell = run(dir, SCOPED_BEFORE, { extra: ['--update'] });
+  assert.equal(fell.code, 0, fell.out);
+  assert.match(fell.out, /WARNING -- no merge base with origin\/main/);
+  assert.match(fell.out, /fell back to local 'main'/);
+
+  // Same tree with the remote-tracking ref present: no warning.
+  git('update-ref', 'refs/remotes/origin/main', 'main');
+  const clean = run(dir, SCOPED_BEFORE, { extra: ['--update'] });
+  assert.equal(clean.code, 0, clean.out);
+  assert.doesNotMatch(clean.out, /WARNING/);
+  assert.match(clean.out, /vs origin\/main \(/);
+});

--- a/scripts/check-module-size.test.mjs
+++ b/scripts/check-module-size.test.mjs
@@ -673,3 +673,21 @@ test('--update --all --allow-raise is what actually clears inherited growth', ()
   assert.equal(code, 0, out);
   assert.match(readFileSync(allowlistPath, 'utf8'), /520 packages\/a\/big\.ts/);
 });
+
+// A scoped regenerate used to print "Commit both." and exit 0 even when the
+// gate stayed red for growth inherited from main — reporting success for a run
+// that fixed nothing the contributor was failing on. The docstring described
+// the case; the code exited 0 before ever re-evaluating what it wrote.
+test('a scoped regenerate that leaves the gate red exits 1 and names the sweep', () => {
+  // The growth must PREDATE the branch point, or it lands in the branch's own
+  // diff and the scoped run correctly fixes it. slack.ts is committed on main
+  // already over its recorded 460 budget; the branch touches only big.ts.
+  const { dir, git } = gitTree({ 'packages/a/big.ts': 500, 'packages/b/slack.ts': 520 });
+  git('checkout', '-q', '-b', 'feature');
+  writeSource(dir, 'packages/a/big.ts', 520);
+
+  const { code, out } = run(dir, SCOPED_BEFORE, { extra: ['--update', '--allow-raise'] });
+  assert.equal(code, 1, out);
+  assert.match(out, /the gate is STILL RED for\s+files outside this change's scope/);
+  assert.match(out, /--all --allow-raise/);
+});

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -280,7 +280,15 @@ export function planUpdate(files, allowlist, changed = null) {
   for (const { rel, lines } of files) {
     const budget = allowlist.get(rel);
     if (!inScope(rel)) {
-      if (grantsNoExemption(budget)) removed.push(grantedNothing(rel, budget));
+      // `grantsNoExemption` is safe to act on out of scope only while the FILE
+      // is also under the limit. If the row is sub-limit but the file measures
+      // OVER it, dropping the row turns a stale-row failure into a
+      // `newOffenders` one -- and that one no scoped rerun can fix, because the
+      // file is out of scope by construction. Keep the row and let the
+      // stale-row check report it; a run scoped to that file resolves it
+      // properly. The earlier comment here said "safe at any scope", which was
+      // true of every case it was written against and false of this one.
+      if (grantsNoExemption(budget) && lines <= LIMIT) removed.push(grantedNothing(rel, budget));
       else if (budget !== undefined) next.set(rel, budget);
       continue;
     }

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -242,8 +242,20 @@ export function staleRows(allowlist) {
  * `next` is the whole allowlist that would be written: every measured file over
  * the limit, at its measured count. A file at or under the limit gets no row,
  * which is what deletes a stale exemption.
+ *
+ * `changed` SCOPES the re-recording to the paths a change actually touched
+ * (#3398). Pass `null` for the repo-wide behaviour; pass a Set of relative
+ * paths and every other row is carried into `next` at its COMMITTED budget and
+ * contributes to none of the four lists. Scoping is not a nicety: `slack` and
+ * `shrunk` are advisory by design (see `evaluate`), so headroom accumulates on
+ * main until some later `--update` — run by whoever, for whatever reason —
+ * re-records all of it. Measured on an unmodified checkout of afa717bcf: 11
+ * rows rewritten and 5 digest lines moved with a clean `git status`. Two PRs
+ * regenerating in one window then carry identical hunks and collide over
+ * changes neither of them made, which is the collision #3398 was filed for.
  */
-export function planUpdate(files, allowlist) {
+export function planUpdate(files, allowlist, changed = null) {
+  const inScope = (rel) => changed === null || changed.has(rel);
   const measured = new Map(files.map((f) => [f.rel, f.lines]));
   const next = new Map();
   const raised = [];
@@ -253,6 +265,10 @@ export function planUpdate(files, allowlist) {
 
   for (const { rel, lines } of files) {
     const budget = allowlist.get(rel);
+    if (!inScope(rel)) {
+      if (budget !== undefined) next.set(rel, budget);
+      continue;
+    }
     if (lines <= LIMIT) {
       if (budget !== undefined) removed.push(`  ${rel}: now ${lines} lines (row deleted)`);
       continue;
@@ -262,8 +278,13 @@ export function planUpdate(files, allowlist) {
     else if (lines > budget) raised.push(`  ${rel}: ${lines} lines, budget ${budget} (+${lines - budget})`);
     else if (lines < budget) lowered.push(`  ${rel}: ${lines} lines, budget ${budget} (-${budget - lines})`);
   }
+  // A row whose file the walk never saw: gone, renamed, or now exempt. Dropping
+  // it is only OUR call when the change touched that path; otherwise the row
+  // stays, because a row deleted here is an exemption someone else still needs.
   for (const [rel, budget] of allowlist) {
-    if (!measured.has(rel)) removed.push(`  ${rel} (budget ${budget}) no longer matches a tracked file`);
+    if (measured.has(rel)) continue;
+    if (inScope(rel)) removed.push(`  ${rel} (budget ${budget}) no longer matches a tracked file`);
+    else next.set(rel, budget);
   }
 
   raised.sort();

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -256,6 +256,12 @@ export function staleRows(allowlist) {
  */
 export function planUpdate(files, allowlist, changed = null) {
   const inScope = (rel) => changed === null || changed.has(rel);
+  // Scoping exists so a regeneration cannot delete an exemption someone else
+  // still needs. A row at or under the limit grants no exemption — `staleRows`
+  // already fails the gate on it — so it is not something anyone can need, and
+  // carrying it forward would leave the documented regeneration command unable
+  // to fix a hard failure it used to fix. Dropping it is safe at any scope.
+  const grantsNoExemption = (budget) => budget !== undefined && budget <= LIMIT;
   const measured = new Map(files.map((f) => [f.rel, f.lines]));
   const next = new Map();
   const raised = [];
@@ -266,7 +272,10 @@ export function planUpdate(files, allowlist, changed = null) {
   for (const { rel, lines } of files) {
     const budget = allowlist.get(rel);
     if (!inScope(rel)) {
-      if (budget !== undefined) next.set(rel, budget);
+      if (budget !== undefined && !grantsNoExemption(budget)) next.set(rel, budget);
+      else if (grantsNoExemption(budget)) {
+        removed.push(`  ${rel}: budget ${budget} <= ${LIMIT} granted nothing (row deleted)`);
+      }
       continue;
     }
     if (lines <= LIMIT) {
@@ -280,11 +289,14 @@ export function planUpdate(files, allowlist, changed = null) {
   }
   // A row whose file the walk never saw: gone, renamed, or now exempt. Dropping
   // it is only OUR call when the change touched that path; otherwise the row
-  // stays, because a row deleted here is an exemption someone else still needs.
+  // stays, because a row deleted here is an exemption someone else still needs
+  // — unless it grants no exemption at all, which nobody can need.
   for (const [rel, budget] of allowlist) {
     if (measured.has(rel)) continue;
     if (inScope(rel)) removed.push(`  ${rel} (budget ${budget}) no longer matches a tracked file`);
-    else next.set(rel, budget);
+    else if (grantsNoExemption(budget)) {
+      removed.push(`  ${rel}: budget ${budget} <= ${LIMIT} granted nothing (row deleted)`);
+    } else next.set(rel, budget);
   }
 
   raised.sort();

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -13,9 +13,11 @@
  * same 400-line limit, same `<budget> <path>` allowlist format, same FNV-1a
  * digest over the sorted rows, same "shrink or split" preference. Two files,
  * one rule -- with one asymmetry worth stating rather than glossing: the TS
- * side has a sanctioned escape hatch (`--update --allow-raise`) and the Rust
- * twin has none, so "never raise" is literally true there and only the default
- * here.
+ * side has a regenerate command with a sanctioned raise inside it (`--update
+ * --allow-raise`); the Rust twin has no regenerate command at all, so a raise
+ * there is a hand edit of the allowlist and its pinned digest. Neither side
+ * makes a raise impossible -- module_size_ratchet.rs records one that reached
+ * main that way (#2658) -- both make it cost a reviewable line.
  */
 
 /** AGENTS.md: "split modules over ~400 non-generated lines". */
@@ -265,6 +267,9 @@ export function planUpdate(files, allowlist, changed = null) {
   // carrying it forward would leave the documented regeneration command unable
   // to fix a hard failure it used to fix. Dropping it is safe at any scope.
   const grantsNoExemption = (budget) => budget !== undefined && budget <= LIMIT;
+  // Both loops below reach this case, and the two messages must not drift.
+  const grantedNothing = (rel, budget) =>
+    `  ${rel}: budget ${budget} <= ${LIMIT} granted nothing (row deleted)`;
   const measured = new Map(files.map((f) => [f.rel, f.lines]));
   const next = new Map();
   const raised = [];
@@ -275,10 +280,8 @@ export function planUpdate(files, allowlist, changed = null) {
   for (const { rel, lines } of files) {
     const budget = allowlist.get(rel);
     if (!inScope(rel)) {
-      if (budget !== undefined && !grantsNoExemption(budget)) next.set(rel, budget);
-      else if (grantsNoExemption(budget)) {
-        removed.push(`  ${rel}: budget ${budget} <= ${LIMIT} granted nothing (row deleted)`);
-      }
+      if (grantsNoExemption(budget)) removed.push(grantedNothing(rel, budget));
+      else if (budget !== undefined) next.set(rel, budget);
       continue;
     }
     if (lines <= LIMIT) {
@@ -297,9 +300,8 @@ export function planUpdate(files, allowlist, changed = null) {
   for (const [rel, budget] of allowlist) {
     if (measured.has(rel)) continue;
     if (inScope(rel)) removed.push(`  ${rel} (budget ${budget}) no longer matches a tracked file`);
-    else if (grantsNoExemption(budget)) {
-      removed.push(`  ${rel}: budget ${budget} <= ${LIMIT} granted nothing (row deleted)`);
-    } else next.set(rel, budget);
+    else if (grantsNoExemption(budget)) removed.push(grantedNothing(rel, budget));
+    else next.set(rel, budget);
   }
 
   raised.sort();

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -11,8 +11,11 @@
  *
  * This mirrors `rust/processing/tests/module_size_ratchet.rs` deliberately:
  * same 400-line limit, same `<budget> <path>` allowlist format, same FNV-1a
- * digest over the sorted rows, same "shrink or split, never raise" contract.
- * Two files, one rule.
+ * digest over the sorted rows, same "shrink or split" preference. Two files,
+ * one rule -- with one asymmetry worth stating rather than glossing: the TS
+ * side has a sanctioned escape hatch (`--update --allow-raise`) and the Rust
+ * twin has none, so "never raise" is literally true there and only the default
+ * here.
  */
 
 /** AGENTS.md: "split modules over ~400 non-generated lines". */

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -265,7 +265,16 @@ export function planUpdate(files, allowlist, changed = null) {
   // still needs. A row at or under the limit grants no exemption — `staleRows`
   // already fails the gate on it — so it is not something anyone can need, and
   // carrying it forward would leave the documented regeneration command unable
-  // to fix a hard failure it used to fix. Dropping it is safe at any scope.
+  // to fix a hard failure it used to fix.
+  //
+  // This predicate answers "does the ROW grant anything", nothing more. Whether
+  // dropping it is safe depends on the FILE, and the two call sites differ:
+  // the measured loop must also check `lines <= LIMIT` (dropping a sub-limit
+  // row off an over-limit file strands it as a `newOffenders` failure no scoped
+  // rerun can reach), while the vanished loop needs no such check because there
+  // is no file left to strand. An earlier version of this comment said
+  // "dropping it is safe at any scope", which was true of every case it was
+  // written against and false of the one above.
   const grantsNoExemption = (budget) => budget !== undefined && budget <= LIMIT;
   // Both loops below reach this case, and the two messages must not drift.
   const grantedNothing = (rel, budget) =>
@@ -280,14 +289,8 @@ export function planUpdate(files, allowlist, changed = null) {
   for (const { rel, lines } of files) {
     const budget = allowlist.get(rel);
     if (!inScope(rel)) {
-      // `grantsNoExemption` is safe to act on out of scope only while the FILE
-      // is also under the limit. If the row is sub-limit but the file measures
-      // OVER it, dropping the row turns a stale-row failure into a
-      // `newOffenders` one -- and that one no scoped rerun can fix, because the
-      // file is out of scope by construction. Keep the row and let the
-      // stale-row check report it; a run scoped to that file resolves it
-      // properly. The earlier comment here said "safe at any scope", which was
-      // true of every case it was written against and false of this one.
+      // The `lines <= LIMIT` half is the FILE's condition, not the row's --
+      // see `grantsNoExemption` above for why the two call sites differ.
       if (grantsNoExemption(budget) && lines <= LIMIT) removed.push(grantedNothing(rel, budget));
       else if (budget !== undefined) next.set(rel, budget);
       continue;

--- a/scripts/lib/module-size-ratchet.mjs
+++ b/scripts/lib/module-size-ratchet.mjs
@@ -251,7 +251,13 @@ export function staleRows(allowlist) {
  * `changed` SCOPES the re-recording to the paths a change actually touched
  * (#3398). Pass `null` for the repo-wide behaviour; pass a Set of relative
  * paths and every other row is carried into `next` at its COMMITTED budget and
- * contributes to none of the four lists. Scoping is not a nicety: `slack` and
+ * contributes to none of the four lists — with ONE exception, which is not a
+ * leak but the point: a STALE row is still removed out of scope. A row at or
+ * under the limit grants no exemption and is already a hard gate failure, and a
+ * row whose file the walk never saw grants an exemption to nothing, so neither
+ * is something another change can still need. A valid out-of-scope exemption is
+ * never touched; a dead one is. (`grantsNoExemption` below carries the full
+ * rule, including why the measured loop must also check the FILE.) Scoping is not a nicety: `slack` and
  * `shrunk` are advisory by design (see `evaluate`), so headroom accumulates on
  * main until some later `--update` — run by whoever, for whatever reason —
  * re-records all of it. Measured on an unmodified checkout of afa717bcf: 11

--- a/scripts/lib/module-size-ratchet.test.mjs
+++ b/scripts/lib/module-size-ratchet.test.mjs
@@ -381,3 +381,40 @@ test('planUpdate drops a row granting no exemption even out of scope, and keeps 
   assert.equal(wide.next.has('packages/d/real.ts'), false);
   assert.equal(wide.next.get('packages/a/big.ts'), 520, 'repo-wide re-records the measured count');
 });
+
+// `grantsNoExemption` drops a row that grants nothing, at any scope. That is
+// safe while the FILE is also under the limit. It is not safe when the row is
+// sub-limit but the file measures OVER it: dropping the row then converts a
+// stale-row failure into a `newOffenders` one, and that failure no scoped rerun
+// can clear, because the file is out of scope by construction. The comment that
+// shipped with the fix said "safe at any scope" — true of every case it was
+// written against, false of this one.
+test('an out-of-scope sub-limit row is KEPT when its file is over the limit', () => {
+  const files = [
+    { rel: 'packages/x/stranded.ts', lines: 450 }, // over LIMIT, row grants nothing
+    { rel: 'packages/y/touched.ts', lines: 410 },
+  ];
+  const allowlist = new Map([
+    ['packages/x/stranded.ts', 400],
+    ['packages/y/touched.ts', 415],
+  ]);
+  const scoped = planUpdate(files, allowlist, new Set(['packages/y/touched.ts']));
+
+  assert.equal(
+    scoped.next.get('packages/x/stranded.ts'),
+    400,
+    'dropping this row would make the file a newOffender no scoped run can fix',
+  );
+  assert.equal(scoped.removed.length, 0);
+
+  // The control that keeps the assertion honest: the same row IS dropped when
+  // its file is under the limit, so this is a real distinction and not the
+  // rule being disabled.
+  const under = planUpdate(
+    [{ rel: 'packages/x/stranded.ts', lines: 300 }, { rel: 'packages/y/touched.ts', lines: 410 }],
+    allowlist,
+    new Set(['packages/y/touched.ts']),
+  );
+  assert.equal(under.next.has('packages/x/stranded.ts'), false);
+  assert.equal(under.removed.length, 1);
+});

--- a/scripts/lib/module-size-ratchet.test.mjs
+++ b/scripts/lib/module-size-ratchet.test.mjs
@@ -343,3 +343,41 @@ test('planUpdate drops a vanished row only when the change touched that path', (
   assert.equal(wide.next.has('packages/d/elsewhere.ts'), false);
   assert.equal(wide.removed.length, 2);
 });
+
+// A row at or under the limit grants no exemption and is a HARD gate failure
+// (`staleRows`). Scoping must not carry it forward: the carry-forward rule
+// exists to protect an exemption someone ELSE still needs, and this row is not
+// one. Both loops in planUpdate reach it — the measured file and the vanished
+// file — so both are pinned here, each against the real exemption that must
+// survive the same call.
+test('planUpdate drops a row granting no exemption even out of scope, and keeps real ones', () => {
+  const files = [
+    { rel: 'packages/a/big.ts', lines: 520 },
+    { rel: 'packages/b/shrunk.ts', lines: 300 },
+  ];
+  const allowlist = new Map([
+    ['packages/a/big.ts', 500],
+    ['packages/b/shrunk.ts', 380], // measured: hand-edited under the limit
+    ['packages/c/vanished.ts', 390], // unmeasured: under the limit, file gone
+    ['packages/d/real.ts', 800], // unmeasured: a genuine exemption
+  ]);
+
+  // Nothing in `changed`: every row below is OUT of scope, which is the whole
+  // point — the deletions must happen anyway, the preservation must still hold.
+  const scoped = planUpdate(files, allowlist, new Set(['packages/z/unrelated.ts']));
+
+  assert.equal(scoped.next.has('packages/b/shrunk.ts'), false, 'measured loop: 380 <= 400 grants nothing');
+  assert.equal(scoped.next.has('packages/c/vanished.ts'), false, 'vanished loop: 390 <= 400 grants nothing');
+  assert.equal(scoped.next.get('packages/d/real.ts'), 800, 'a REAL out-of-scope exemption survives');
+  assert.equal(scoped.next.get('packages/a/big.ts'), 500, 'an out-of-scope row keeps its COMMITTED budget');
+  assert.deepEqual(scoped.removed.sort(), [
+    '  packages/b/shrunk.ts: budget 380 <= 400 granted nothing (row deleted)',
+    '  packages/c/vanished.ts: budget 390 <= 400 granted nothing (row deleted)',
+  ]);
+
+  // The control that makes the preservation above a real distinction: repo-wide
+  // drops packages/d/real.ts too, so `next` differs between the two calls.
+  const wide = planUpdate(files, allowlist, null);
+  assert.equal(wide.next.has('packages/d/real.ts'), false);
+  assert.equal(wide.next.get('packages/a/big.ts'), 520, 'repo-wide re-records the measured count');
+});

--- a/scripts/lib/module-size-ratchet.test.mjs
+++ b/scripts/lib/module-size-ratchet.test.mjs
@@ -31,6 +31,7 @@ import {
   allowlistScope,
   evaluate,
   staleRows,
+  planUpdate,
 } from './module-size-ratchet.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -288,4 +289,57 @@ test('the digest agrees with the Rust ratchet, byte for byte', () => {
   // that differed from the Rust one could still produce matching digests if
   // every row happened to land in one bucket.
   assert.ok(computed.size > 1, 'the Rust allowlist must span more than one scope');
+});
+
+// ---------------------------------------------------------------------------
+// planUpdate scoping (#3398). Repo-wide re-recording only ever TIGHTENED rows,
+// which is why it read as harmless — and why it silently pulled rows belonging
+// to other people's changes into whichever PR regenerated next.
+// ---------------------------------------------------------------------------
+
+test('planUpdate carries an untouched row at its COMMITTED budget', () => {
+  const files = [
+    { rel: 'packages/a/big.ts', lines: 520 },
+    { rel: 'packages/b/slack.ts', lines: 450 },
+  ];
+  const allowlist = new Map([
+    ['packages/a/big.ts', 500],
+    ['packages/b/slack.ts', 460],
+  ]);
+
+  const scoped = planUpdate(files, allowlist, new Set(['packages/a/big.ts']));
+  assert.equal(scoped.next.get('packages/a/big.ts'), 520, 'the changed file is re-recorded');
+  assert.equal(scoped.next.get('packages/b/slack.ts'), 460, 'the untouched row keeps its committed budget');
+  assert.deepEqual(scoped.raised, ['  packages/a/big.ts: 520 lines, budget 500 (+20)']);
+  assert.deepEqual(scoped.lowered, [], 'an untouched row is not this change to make');
+
+  // The control, and the reason the assertions above are a real distinction:
+  // repo-wide sees the same two files and annexes the second one.
+  const wide = planUpdate(files, allowlist, null);
+  assert.equal(wide.next.get('packages/b/slack.ts'), 450);
+  assert.deepEqual(wide.lowered, ['  packages/b/slack.ts: 450 lines, budget 460 (-10)']);
+});
+
+test('planUpdate drops a vanished row only when the change touched that path', () => {
+  const files = [{ rel: 'packages/a/big.ts', lines: 500 }];
+  const allowlist = new Map([
+    ['packages/a/big.ts', 500],
+    ['packages/c/deleted.ts', 700],
+    ['packages/d/elsewhere.ts', 800],
+  ]);
+
+  const scoped = planUpdate(files, allowlist, new Set(['packages/c/deleted.ts']));
+  assert.equal(scoped.next.has('packages/c/deleted.ts'), false, 'this change deleted it, so its row goes');
+  assert.equal(
+    scoped.next.get('packages/d/elsewhere.ts'),
+    800,
+    'a row that vanished for someone ELSE is still their exemption',
+  );
+  assert.deepEqual(scoped.removed, [
+    '  packages/c/deleted.ts (budget 700) no longer matches a tracked file',
+  ]);
+
+  const wide = planUpdate(files, allowlist, null);
+  assert.equal(wide.next.has('packages/d/elsewhere.ts'), false);
+  assert.equal(wide.removed.length, 2);
 });

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -14,7 +14,12 @@
 # DELETE its row (the gate prints a note telling you to); a stale exemption is
 # permanent slack.
 #
-# `--update` re-records only the files your change touched.
+# `--update` re-records only the files your change touched — plus one
+# deliberate exception: a STALE row is dropped wherever it is. A row at or under
+# the 400-line limit, or one whose file no longer exists, grants no exemption to
+# anybody, so leaving it would mean the regeneration command could not clear a
+# failure it is supposed to clear. A row that still exempts a real file is never
+# touched unless your change touched that file.
 # `--update --all --allow-raise` re-records every row in the tree, annexing
 # slack your change never created: a deliberate sweep, and its own PR. The
 # `--allow-raise` is not optional there — re-recording a file that GREW is a

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -14,9 +14,11 @@
 # DELETE its row (the gate prints a note telling you to); a stale exemption is
 # permanent slack.
 #
-# `--update` re-records only the files your change touched. `--update --all`
-# re-records every row in the tree, annexing slack your change never created:
-# a deliberate sweep, and its own PR.
+# `--update` re-records only the files your change touched.
+# `--update --all --allow-raise` re-records every row in the tree, annexing
+# slack your change never created: a deliberate sweep, and its own PR. The
+# `--allow-raise` is not optional there — re-recording a file that GREW is a
+# raise, so without it the sweep writes nothing and exits 1.
 #
 # Any edit here moves that row's SCOPE entry in ALLOWLIST_DIGESTS in
 # scripts/check-module-size.mjs, which must be updated in the same commit —

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -6,10 +6,17 @@
 # count at the moment it was recorded. The gate fails if any of these grows
 # PAST its budget, or if a NEW file crosses 400 without an entry.
 #
-# The rule: SHRINK OR SPLIT. Budgets ratchet DOWN only — never raise one to
-# make a red gate green. When a file drops to <= 400, DELETE its row (the gate
-# prints a note telling you to); a stale exemption is permanent slack.
-# Only ADD a row with a written justification in the PR.
+# The rule: SHRINK OR SPLIT. Budgets ratchet DOWN by default: `--update`
+# refuses to raise a budget or add a row, so the regeneration command cannot
+# quietly undo the ratchet. A raise or a new row IS sanctioned, deliberately —
+# `--update --allow-raise`, justified per file in the PR. Either way it costs
+# the reviewable digest line described below. When a file drops to <= 400,
+# DELETE its row (the gate prints a note telling you to); a stale exemption is
+# permanent slack.
+#
+# `--update` re-records only the files your change touched. `--update --all`
+# re-records every row in the tree, annexing slack your change never created:
+# a deliberate sweep, and its own PR.
 #
 # Any edit here moves that row's SCOPE entry in ALLOWLIST_DIGESTS in
 # scripts/check-module-size.mjs, which must be updated in the same commit —


### PR DESCRIPTION
Closes #3398.

Two halves. The allowlist header asserted budgets may never be raised while
`check-module-size.mjs` documents `--update --allow-raise` as the sanctioned hatch — a
CodeRabbit review of #3367 quoted the header at six deliberate, per-file-justified raises.
And `--update` re-recorded every stale row in the repo, not only the ones a change grew, so
a regenerate annexed unrelated rows: #3367 and #3330 each picked up the identical nine rows
and five digests and collided over changes neither made.

## What this actually took, and why the PR is eleven commits

The first commit fixed both halves. Everything after it is a defect **this branch
introduced or missed**, found by pre-flight review and fixed here rather than shipped:

- A **regression**: a scoped regenerate could no longer delete a `budget <= 400` row, which
  is a hard gate failure. `origin/main`'s script deleted it and went green; the new one
  kept it and exited 1. Proven by running both on one fixture.
- The **documented remedy did not run**, three separate ways: it named the scoped command
  (which by construction cannot reach growth outside the branch's files), then `-- --all`
  (pnpm forwards the separator verbatim; `unknown argument: --`), then `--all` (parses,
  then refuses to write, because re-recording a grown file *is* a raise). The working
  spelling is `--update --all --allow-raise`, and **both spellings are now pinned by tests
  that run the real command**.
- A scoped regenerate **reported success with the gate still red** — it wrote, re-pinned,
  printed "Commit both." and exited 0 before ever reaching `evaluate()`. It now
  re-evaluates what it wrote and exits 1 naming the sweep.
- The out-of-scope row drop could **strand a file nobody can fix**: dropping a sub-limit row
  off an over-limit file converts a stale-row failure into a `newOffenders` one that no
  scoped rerun can reach.
- A **fail-open** in the worktree guard: `safeRealpath(a) !== safeRealpath(b)` is false when
  both throw, so the guard passed and the run inherited the enclosing repo's diff.

## The claim lived in more places than any grep found

This is the part worth reading. Every sweep verified itself with a literal grep whose
alternatives came from the wordings it had *already* found — "never raise", "shrink or
split", "ratchets down only". Three slice files say **"may not grow"**; two said "only goes
down" and "only lets a listed file shrink, never grow". No pattern built from known
phrasings can match an unknown one, so each sweep proved only that it had found what it had
found, and then reported that as completeness. One commit here is literally titled *"the
other three homes"* — it was wrong by five, then by two more.

The final pass enumerates by **location** instead: all 19 `*.teardown.ts` in
`apps/viewer/src/store/slices/`, each checked for `module-size|allowlist|ratchet|budget`.
Twelve cite the gate, seven are silent, none now asserts an absolute. The two Rust
`_tests.rs` copies were exempted earlier on the premise that the Rust side has no hatch —
a premise this branch itself later refuted, citing `module_size_ratchet.rs:44-48`, which
records a raise reaching main and being undone (#2658). They are corrected too.

## Scope note

The diff reaches outside `scripts/`: `packages/geometry/src/symbolic-types.ts`,
`packages/export/src/step-map-unit.ts`, `packages/server-client/src/parquet-columns.ts`,
five `apps/viewer` slice teardowns, and two `rust/wasm-bindings` test files. All are
comment-only, and all cite the allowlist rule — leaving them would have left the corrected
claim wrong somewhere else, which is the defect being fixed.

## Verification

Every guard added here is mutation-checked in both directions with a mutator that asserts
its pattern matched exactly once and re-reads the file to confirm the write landed. That
was not paranoia: an earlier round used `perl -0pi -e 's/\Q...\E/'` with newlines inside
the quoted span, matched nothing, and printed four green passes.

Gates: `pnpm typecheck` 0, `pnpm test` 0 (96/96 tasks), `pnpm lint` 0,
`check-test-wiring` 0, `check-source-text-assertions` 0, `check-module-size` 0,
`cargo clippy --workspace --exclude ifc-lite-wasm --all-targets -- -D warnings` 0.
Node suite 61/61.

**Stated plainly:** the final commit applies the last review's four findings and has not
itself been re-reviewed. Given this branch found a new instance of its own defect in five
consecutive rounds, a sixth is worth a reviewer's attention — the highest-value check is
not to read the diff but to grep the claim, since the surviving copies are by definition
where the diff is not.

No changeset: `scripts/` is not published and the touched `packages/*` changes are
comments only, so no exported surface moved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Developer Experience**
  * Module-size checks now support targeted updates for changed files, with an explicit option for repository-wide regeneration.
  * Improved validation and diagnostics for worktrees, merge bases, untracked files, separators, and unresolved module-size violations.
  * Budget increases require explicit approval and justification.

* **Documentation**
  * Clarified module-size budget and allowlist behavior, including default reductions and sanctioned exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->