### PR TITLE
fix(scripts,tools): use isMainEntry for four entry-point checks that fail silently

### DIFF
--- a/scripts/check-test-glob-coverage.mjs
+++ b/scripts/check-test-glob-coverage.mjs
@@ -72,6 +72,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
 import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMainEntry } from './lib/is-main-entry.mjs';
 import { listWorkspacePackages } from './lib/list-workspace-packages.mjs';
 
 // Deliberately a literal here rather than imported from the shared walk.
@@ -413,7 +414,7 @@ if they are dead and should be deleted, delete them. Do not add a skip.
   console.log(`check-test-glob-coverage: OK (${audited} packages audited, 0 unrun test files)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainEntry(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/scripts/check-test-wiring.mjs
+++ b/scripts/check-test-wiring.mjs
@@ -85,6 +85,7 @@ import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { stripYamlComments } from './lib/server-bin-targets-parse.mjs';
 import { listWorkspacePackages } from './lib/list-workspace-packages.mjs';
+import { isMainEntry } from './lib/is-main-entry.mjs';
 
 // Deliberately a literal here rather than imported from the shared walk.
 // `scripts/lib/ci-path-coverage.mjs`'s `deriveInputs` reads only THIS file's own
@@ -686,7 +687,7 @@ function main(root) {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainEntry(import.meta.url)) {
   const rootFlagIdx = process.argv.indexOf('--root');
   if (rootFlagIdx !== -1 && !process.argv[rootFlagIdx + 1]) {
     console.error('\ncheck-test-wiring: --root requires a directory argument\n');

--- a/scripts/lib/vitest-timeout-audit.mjs
+++ b/scripts/lib/vitest-timeout-audit.mjs
@@ -186,6 +186,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve as resolvePath } from 'node:path';
+import { isMainEntry } from './is-main-entry.mjs';
 
 const CALL_KEYWORD_RE = /(?<![.\w$])(describe|it|test)(?![\w$])/g;
 
@@ -1078,7 +1079,7 @@ export function auditFile(filePath, source) {
  * single corrupted file inside a large run therefore still contributes
  * silently zero — see the regex/template erasure notes in LIMITATIONS.
  */
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainEntry(import.meta.url)) {
   const argv = process.argv.slice(2);
   // `--summary-only` keeps the error paths and the summary but drops the
   // per-call-site listing. The listing is the point of a human run; across

--- a/scripts/lib/vitest-timeout-audit.test.mjs
+++ b/scripts/lib/vitest-timeout-audit.test.mjs
@@ -526,8 +526,8 @@ test('auditFile: a second sibling test file in the same subdirectory also resolv
 // exited 0 — a tool that read nothing and said so in the same shape it uses
 // to say "all good". Same failure class as `check-tla-chunk-await.mjs`
 // printing `0 chunks…` against an unbuilt dist. These tests drive the real
-// script as a subprocess (the guard lives in its `import.meta.url ===
-// argv[1]` block, so importing the module cannot reach it) and, in keeping
+// script as a subprocess (the guard lives in its `isMainEntry(import.meta.url)`
+// block, so importing the module cannot reach it) and, in keeping
 // with this file's rule, hand it SYNTHETIC files only.
 
 const SCRIPT = fileURLToPath(new URL('./vitest-timeout-audit.mjs', import.meta.url));

--- a/tools/plato/scalar-codemod.mjs
+++ b/tools/plato/scalar-codemod.mjs
@@ -33,6 +33,7 @@
 
 import ts from 'typescript';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { isMainEntry } from '../../scripts/lib/is-main-entry.mjs';
 import { appendFlattened } from './flatten-codemod.mjs';
 
 // Scalar operator method name -> native binary operator token.
@@ -312,7 +313,7 @@ function assertArgc(name, args, expected) {
 }
 
 // --- CLI ---
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain = isMainEntry(import.meta.url);
 if (isMain) {
   const inputPath = process.argv[2];
   const outputPath = process.argv[3];


### PR DESCRIPTION
## Summary

`scripts/lib/is-main-entry.mjs` exists because the naive entry-point check is wrong in two ways that **both fail silently**, per its own doc:

> a path containing a space arrives percent-encoded in `import.meta.url` and raw in `argv[1]`, so the strings never match; a symlinked checkout resolves one side and not the other

The module falls through, the process exits 0 having done nothing, and a caller reads that as success.

@louistrue caught this in the isolate-expansion gate on #3389 and noted the same defect had already been fixed once in the release scripts. Grepping for the exact spelling turned up **four more live instances**.

## Ranked by what they cost

| file | kind | CI | why it matters |
|---|---|---|---|
| `scripts/check-test-wiring.mjs` | gate | `test.yml` runs it directly | **The worst of the four.** Its own docstring says its job is that "nothing in this repo may LOOK enforced while never executing" — and it carried the check that lets exactly that happen. |
| `scripts/check-test-glob-coverage.mjs` | gate | via `pnpm lint` | Same class, one hop further from the workflow. |
| `scripts/lib/vitest-timeout-audit.mjs` | CLI | `check:vitest-timeout-audit` | In `lib/`, so the guard looks vestigial — it is not. It is invoked as a CLI in CI, so the fix is the swap, not removal. |
| `tools/plato/scalar-codemod.mjs` | codemod | via `generate-plato-clash --check` | Lowest: the caller checks the output file's existence and size afterwards, so a silent no-op is already caught a layer up. Fixed for consistency. |

A gate that exits 0 having checked nothing is worse than no gate — CI goes green and a reviewer reads it as a pass.

## Verification

Ran each after the swap:

- `node scripts/check-test-wiring.mjs` → exit 0
- `node scripts/check-test-glob-coverage.mjs` → exit 0
- `node --test scripts/lib/vitest-timeout-audit.test.mjs` → 77 pass, 0 fail

Also updated a comment in that test file which quoted the old spelling and would have gone stale.

## Deliberately not included

**Two files carry their own local `isMainEntry()`** — `check-lint-ran.mjs` and `check-rust-source-text-assertions.mjs`. Both already do the correct `realpathSync` comparison, so they are duplication rather than defects. Consolidating them onto the shared helper is worth doing, but it needs the unused-import cleanup checked properly (`realpathSync`, `resolve`, `fileURLToPath` may or may not still be used elsewhere in each file), and I did not want to fold an unverified cleanup into a fix.

**A weaker family also exists** and is out of scope: basename `endsWith` matches, and `fileURLToPath(import.meta.url) === process.argv[1]`, which fixes the encoding half but not the symlink half. None of those are CI merge gates.

## Changeset

None. `scripts/`- and `tools/`-only changes consistently ship without one in this repo — checked several comparable recent commits on `main`.
