### PR TITLE
fix(export): drop property sets reaching includedIds outside the viewer/CLI (#3351)

### DIFF
--- a/.changeset/anonymize-sdk-path-pset-leak.md
+++ b/.changeset/anonymize-sdk-path-pset-leak.md
@@ -1,5 +1,5 @@
 ---
-'@ifc-lite/export': patch
+'@ifc-lite/export': minor
 ---
 
 `exportAnonymizedSubset` no longer leaks property sets that reach `includedIds` outside the viewer's coupled toggles or the CLI's `--keep-psets` (#3351). `keepPropertySets: false` (the default) previously only cleared an `IfcTypeObject`'s `HasPropertySets` slot — a property set an `IfcRelDefinesByProperties` walk (or a hand-built `includedIds`) added directly still exported complete, values included. The orchestrator now excludes any `IfcPropertySet`/`IfcElementQuantity` id from the subset unless `keepPropertySets` is `true`, the same way the CLI already behaved, and reports what it dropped as `AnonymizeResult.stats.droppedPropertySetIds`.

--- a/.changeset/anonymize-sdk-path-pset-leak.md
+++ b/.changeset/anonymize-sdk-path-pset-leak.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': patch
+---
+
+`exportAnonymizedSubset` no longer leaks property sets that reach `includedIds` outside the viewer's coupled toggles or the CLI's `--keep-psets` (#3351). `keepPropertySets: false` (the default) previously only cleared an `IfcTypeObject`'s `HasPropertySets` slot — a property set an `IfcRelDefinesByProperties` walk (or a hand-built `includedIds`) added directly still exported complete, values included. The orchestrator now excludes any `IfcPropertySet`/`IfcElementQuantity` id from the subset unless `keepPropertySets` is `true`, the same way the CLI already behaved, and reports what it dropped as `AnonymizeResult.stats.droppedPropertySetIds`.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -540,10 +540,12 @@ intended common case:
 The authoring tool's *name* is kept by decision (it is debugging signal) but
 its version/build string is not — vendors embed the licence region there
 (`26.0.0 NOR FULL`). Property/quantity *names* are kept whenever
-`keepPropertySets` is on; property/quantity *values* are never scrubbed, kept
-or dropped — a kept pset carries them exactly as authored. Those are the
-residual leak surface; review a file before sharing it externally, and never
-name the download after the source model.
+`keepPropertySets` is on; property/quantity *values* are never scrubbed,
+whether the pset is kept or dropped — a kept pset carries them exactly as
+authored, and a dropped one takes its values out of the file with it. The
+tool name and a kept pset's values are the residual leak surface; review a
+file before sharing it externally, and never name the download after the
+source model.
 
 The `IfcPropertySet`/`IfcElementQuantity` drop holds for `includedIds`
 regardless of how it was built — `collectRelatedEntities`'s

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -540,10 +540,18 @@ intended common case:
 The authoring tool's *name* is kept by decision (it is debugging signal) but
 its version/build string is not — vendors embed the licence region there
 (`26.0.0 NOR FULL`). Property/quantity *names* are kept whenever
-`keepPropertySets` is on. Those are the residual leak surface; review a file
-before sharing it externally, and never name the download after the source
-model. The CLI equivalent is `ifc-lite anonymize` (see the
-[CLI guide](cli.md)).
+`keepPropertySets` is on; property/quantity *values* are never scrubbed, kept
+or dropped — a kept pset carries them exactly as authored. Those are the
+residual leak surface; review a file before sharing it externally, and never
+name the download after the source model.
+
+The `IfcPropertySet`/`IfcElementQuantity` drop holds for `includedIds`
+regardless of how it was built — `collectRelatedEntities`'s
+`IfcRelDefinesByProperties` walk, or an id set assembled by hand — not only
+the CLI's `--keep-psets` and the viewer's "Property sets" toggle, which
+couple the same option to their own selection step. A dropped id is reported
+in `result.stats.droppedPropertySetIds`. The CLI equivalent is
+`ifc-lite anonymize` (see the [CLI guide](cli.md)).
 
 ## IFC5 (IFCX) Export
 

--- a/packages/export/src/anonymize-export.test.ts
+++ b/packages/export/src/anonymize-export.test.ts
@@ -102,7 +102,7 @@ function lineArgs(content: string, id: number): string[] {
  * Wall A (#6, storey 1) has a geometry representation (#100/#101/#102/#103),
  * an opening (#8) filled by a window (#9), an `IfcWallType` (#10) carrying
  * its own `Pset_WallTypeCommon` (#11/#12), and shares `Pset_WallCommon`
- * (#13/#15, via #89) and a material (#40, via #44) with Wall B (#7, storey
+ * (#13/#15/#14, via #89) and a material (#40, via #44) with Wall B (#7, storey
  * 2). #88 structurally connects the two walls. #90 (`IfcElementAssembly`)
  * aggregates a plate (#91) via #92.
  */
@@ -146,8 +146,9 @@ DATA;
 #10=IFCWALLTYPE('${guid(10)}',#74,'WallType Solace',$,'Occurrence Vermilion',(#11),$,$,'ElementType Cerulean',.NOTDEFINED.);
 #11=IFCPROPERTYSET('${guid(11)}',#74,'Pset_WallTypeCommon',$,(#12));
 #12=IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.F.),$);
-#13=IFCPROPERTYSET('${guid(13)}',#74,'Pset_WallCommon',$,(#15));
+#13=IFCPROPERTYSET('${guid(13)}',#74,'Pset_WallCommon',$,(#15,#14));
 #15=IFCPROPERTYSINGLEVALUE('LoadBearing',$,IFCBOOLEAN(.T.),$);
+#14=IFCPROPERTYSINGLEVALUE('Owner',$,IFCTEXT('jane.doe@acme-corp.example'),$);
 #40=IFCMATERIAL('Concrete',$,'Category Marigold');
 #90=IFCELEMENTASSEMBLY('${guid(90)}',#74,'Assembly Cobalt',$,$,$,$,$,$,.RIGID.);
 #91=IFCPLATE('${guid(91)}',#74,'Plate Vertex',$,$,$,$,$,$);
@@ -174,7 +175,7 @@ END-ISO-10303-21;`;
  *  storeys, all three walls, the opening/window, the wall type, the shared
  *  material association, the full relationship graph connecting them, and
  *  the assembly/plate pair. Deliberately EXCLUDES the standalone
- *  `Pset_WallCommon` (#13/#15/#89) and the wall type's own pset (#11/#12) —
+ *  `Pset_WallCommon` (#13/#15/#14/#89) and the wall type's own pset (#11/#12) —
  *  psets are dropped by default, the same way a caller's own
  *  `RelatedEntityOptions.IfcRelDefinesByProperties` default (`false`) would
  *  never have added them to `includedIds` in the first place. Every id here
@@ -391,6 +392,59 @@ describe('exportAnonymizedSubset — type-owned property sets (IfcTypeObject.Has
   });
 });
 
+describe('exportAnonymizedSubset — occurrence-owned property sets reaching includedIds directly (#3351 item 2, SDK path)', () => {
+  // #13 (Pset_WallCommon) and #89 (the IfcRelDefinesByProperties naming it)
+  // land in `includedIds` here the way a direct SDK caller would produce
+  // them — e.g. `collectRelatedEntities(store, seeds, { IfcRelDefinesByProperties: true })`
+  // adds exactly the pset id and its relationship id, never the individual
+  // property entities (#14/#15 reach the export only through #13's own
+  // `HasProperties` forward closure, same as any other non-root entity) —
+  // NOT through the viewer's coupled toggles or the CLI's `--keep-psets`,
+  // which is exactly the gap #3361 left open: it only fixed the two UI
+  // entry points, not this orchestrator.
+  const includedWithPset = new Set([1, 6, 13, 89]);
+
+  it('excludes the property set entirely by default, including the identifying value it carried', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const result = exportAnonymizedSubset(store, includedWithPset, { guidRandom: seededRandom(11) });
+    const content = decode(result.content);
+
+    // The identifying VALUE (not a Name/Tag field, and not scrubbed by any
+    // pseudonymization pass — see `applyScrub`'s own doc on why values are
+    // deliberately left alone) must not survive at all: this only holds if
+    // the pset was excluded, not merely name-scrubbed.
+    expect(content).not.toContain('jane.doe@acme-corp.example');
+    expect(content).not.toContain('IFCPROPERTYSET');
+    expect(content).not.toContain('IFCRELDEFINESBYPROPERTIES');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
+  it('reports the excluded property set ids distinctly, not just a silent drop', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const result = exportAnonymizedSubset(store, includedWithPset, { guidRandom: seededRandom(11) });
+
+    expect(result.stats.droppedPropertySetIds).toEqual([13]);
+    // The relationship that named ONLY the dropped pset (a single-valued,
+    // mandatory reference) is pruned too, and reported through the existing
+    // `prunedRelationshipIds` channel — the same one #3361 already added,
+    // not a second parallel one.
+    expect(result.stats.prunedRelationshipIds).toContain(89);
+  });
+
+  it('keeps the property set, values included, when keepPropertySets is true', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const result = exportAnonymizedSubset(store, includedWithPset, {
+      keepPropertySets: true,
+      guidRandom: seededRandom(11),
+    });
+    const content = decode(result.content);
+
+    expect(result.stats.droppedPropertySetIds).toEqual([]);
+    expect(content).toContain('jane.doe@acme-corp.example');
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+});
+
 describe('exportAnonymizedSubset — relationship list trimming (partial exclusion) vs relationship pruning (total exclusion)', () => {
   it('trims an excluded member out of a SET/LIST relationship attribute rather than dropping the whole relationship', async () => {
     const store = await parse(FIXTURE_MODEL);
@@ -398,7 +452,15 @@ describe('exportAnonymizedSubset — relationship list trimming (partial exclusi
     // still has a survivor (#6), so it is never pruned — the emitted LIST
     // just loses the excluded member, the existing (unrelated to this
     // feature) `filterHiddenRefsFromRelationshipLine` behaviour.
-    const result = exportAnonymizedSubset(store, new Set([1, 6, 13, 89]), { guidRandom: seededRandom(9) });
+    // `keepPropertySets: true` keeps #13 (#89's RelatingPropertyDefinition,
+    // a single-valued reference) in the subset: this test is about SET/LIST
+    // trimming on RelatedObjects, not about the pset-drop behaviour covered
+    // in "property sets reaching includedIds directly" below, and without
+    // it #13 would itself be excluded by default, pruning #89 entirely.
+    const result = exportAnonymizedSubset(store, new Set([1, 6, 13, 89]), {
+      keepPropertySets: true,
+      guidRandom: seededRandom(9),
+    });
     const content = decode(result.content);
 
     expect(result.stats.prunedRelationshipIds).not.toContain(89);

--- a/packages/export/src/anonymize-export.ts
+++ b/packages/export/src/anonymize-export.ts
@@ -56,6 +56,62 @@ import { applyPlacementAnonymization } from './anonymize-placement.js';
 import { applyScrub } from './anonymize-scrub.js';
 import { StepExporter } from './step-exporter.js';
 import type { AnonymizeOptions, AnonymizeResult } from './anonymize-types.js';
+import { isPropertySetDefinitionClass } from './type-owned-psets.js';
+
+/**
+ * Drop every `IfcPropertySet`/`IfcElementQuantity` id out of `includedIds`
+ * unless `keepPropertySets` is on (#3351 item 2, the SDK-path half `#3361`
+ * left open): `applyScrub`'s `keepPropertySets` handling only ever clears an
+ * `IfcTypeObject`'s `HasPropertySets` SLOT, so a pset that reached
+ * `includedIds` some other way — a caller's own
+ * `collectRelatedEntities(..., { IfcRelDefinesByProperties: true })` walk, or
+ * a hand-built id set — survived complete, values included, with
+ * `keepPropertySets` at its documented `false` default.
+ *
+ * DROP means EXCLUDE, not "emit scrubbed": this pass never queues a mutation
+ * on a pset entity, it removes the id from the set the exporter's closure
+ * ever sees, the same way the CLI's `--keep-psets` already behaves (it
+ * drives both this exclusion, via `RelatedEntityOptions.IfcRelDefinesByProperties`,
+ * and `keepPropertySets` from one flag) and the same way the viewer's two
+ * toggles are now coupled (`AnonymizationOptionsPanel.tsx`). Scrubbing in
+ * place was considered and rejected: a property/quantity VALUE is left
+ * unscrubbed by design everywhere else in this module (only NAMES are
+ * pseudonymized), so a scrubbed-but-kept pset would still carry
+ * `IFCPROPERTYSINGLEVALUE('Owner',$,IFCTEXT('jane.doe@acme-corp.example'),$)`
+ * verbatim — exactly the leak this exists to close. Exclusion is the only
+ * one of the two that actually removes it.
+ *
+ * Must run BEFORE `pruneUnresolvableRelationships`: dropping a pset id here
+ * feeds straight into that pass's `getSubsetEntityIds` exclusion set, so an
+ * `IfcRelDefinesByProperties` whose `RelatingPropertyDefinition` named only a
+ * now-dropped pset is pruned the same way any other relationship with an
+ * excluded mandatory single-valued reference is — never left dangling.
+ *
+ * Returns the surviving set plus every id this pass dropped, reported
+ * distinctly (the same shape `prunedRelationshipIds` already uses on
+ * `AnonymizeResult.stats`) so a caller can tell "excluded because it is a
+ * property set" from any other reason an id might be missing, without
+ * grepping `warnings` text.
+ */
+function excludePropertySetsUnlessKept(
+  index: EffectiveEntityIndex,
+  includedIds: ReadonlySet<number>,
+  keepPropertySets: boolean,
+): { includedIds: Set<number>; droppedPropertySetIds: number[] } {
+  if (keepPropertySets) return { includedIds: new Set(includedIds), droppedPropertySetIds: [] };
+
+  const kept = new Set<number>();
+  const droppedPropertySetIds: number[] = [];
+  for (const id of includedIds) {
+    if (isPropertySetDefinitionClass(index.typeOf(id))) {
+      droppedPropertySetIds.push(id);
+    } else {
+      kept.add(id);
+    }
+  }
+  droppedPropertySetIds.sort((a, b) => a - b);
+  return { includedIds: kept, droppedPropertySetIds };
+}
 
 /**
  * Every id in `includedIds` whose EXPRESS type is an `IfcRel*` (an
@@ -145,10 +201,19 @@ export function exportAnonymizedSubset(
   const editor = new StoreEditor(store, view);
   const index = getEffectiveEntityIndex(store, view, true);
 
+  // Runs BEFORE relationship pruning — see that function's own doc for why
+  // the order matters (a dropped pset must be visible to the exclusion set
+  // relationship pruning reads).
+  const { includedIds: psetFilteredIds, droppedPropertySetIds } = excludePropertySetsUnlessKept(
+    index,
+    includedIds,
+    options.keepPropertySets ?? false,
+  );
+
   const { prunedRelationshipIds, finalIncludedIds } = pruneUnresolvableRelationships(
     store,
     index,
-    includedIds,
+    psetFilteredIds,
   );
 
   const placementResult = applyPlacementAnonymization(store, index, finalIncludedIds, editor, view, options);
@@ -184,6 +249,7 @@ export function exportAnonymizedSubset(
       entityCount: exportResult.stats.entityCount,
       includedRootEntityCount,
       prunedRelationshipIds,
+      droppedPropertySetIds,
       zeroedPlacements: placementResult.zeroedPlacements,
       warnings: [
         ...placementResult.warnings,

--- a/packages/export/src/anonymize-types.ts
+++ b/packages/export/src/anonymize-types.ts
@@ -143,7 +143,13 @@ export interface AnonymizeOptions {
    *  or `IfcApplication`. Default `true`; independent of `pseudonymizeNames`. */
   pseudonymizeAllNames?: boolean;
   /** Keep `IfcPropertySet`/`IfcElementQuantity` entities instead of dropping
-   *  them. Default `false` (i.e. psets are dropped by default). */
+   *  them. Default `false`: `exportAnonymizedSubset` excludes every such id
+   *  from `includedIds` before export, however it got there (a caller's own
+   *  `IfcRelDefinesByProperties` walk, or a hand-built id set) — the entity
+   *  never reaches the output, values included, at any `includedIds` (#3351
+   *  item 2). Property/quantity VALUES are unscrubbed by design, so setting
+   *  this `true` keeps them exactly as authored; there is no partial,
+   *  "kept but scrubbed" state. */
   keepPropertySets?: boolean;
   /** Regenerate every exported `IfcRoot`'s `GlobalId` (the old→new mapping
    *  comes back as `AnonymizeResult.guidMap`, never written into the file
@@ -208,6 +214,13 @@ export interface AnonymizeResult {
      *  reported so a caller can see WHICH associations the anonymization
      *  cost, not just that some file that changed. */
     prunedRelationshipIds: number[];
+    /** ExpressIds of `IfcPropertySet`/`IfcElementQuantity` entities excluded
+     *  from `includedIds` because `keepPropertySets` was falsy (the
+     *  default) — reported distinctly, the same way `prunedRelationshipIds`
+     *  is, so a caller can tell "this id is missing because it is a
+     *  property set" from any other exclusion reason without grepping
+     *  `warnings` text. Empty when `keepPropertySets` was `true`. */
+    droppedPropertySetIds: number[];
     /** Each root `IfcLocalPlacement` this export zeroed, and the translation
      *  it zeroed (the ORIGINAL, pre-zero coordinates) — reported because the
      *  translation was real coordinate data the caller may still want to log

--- a/packages/export/src/type-owned-psets.ts
+++ b/packages/export/src/type-owned-psets.ts
@@ -61,6 +61,37 @@ export function isTypeClass(typeUpper: string | undefined): boolean {
   return isTypeObject;
 }
 
+/** class name → is it an `IfcPropertySetDefinition`. Same caching as
+ *  {@link isTypeClass}, for the same reason. */
+const psetDefinitionByClass = new Map<string, boolean>();
+
+/**
+ * Is this the class of an `IfcPropertySetDefinition` (`IfcPropertySet`,
+ * `IfcElementQuantity`, and any other schema-declared subtype)?
+ *
+ * From the cross-schema inheritance chain, the same way {@link isTypeClass}
+ * decides its own question and for the same reason: a hand-listed pair of
+ * names would need updating by hand the day a bundled schema adds another
+ * subtype, and would silently mis-handle it in the meantime (#3351 item 2 —
+ * an occurrence-owned pset reaching `exportAnonymizedSubset`'s `includedIds`
+ * directly, rather than through an `IfcTypeObject`'s `HasPropertySets`,
+ * which {@link isTypeClass} already governs).
+ *
+ * A class no bundled schema declares is treated as NOT a pset definition —
+ * the safe direction here is the opposite of `isTypeClass`'s: silently
+ * excluding an unrecognised class from a "drop unless kept" sweep would leak
+ * it, so an unknown class is left for the ordinary `IFC_ROOT_TYPES` handling
+ * to include or exclude on its own terms instead.
+ */
+export function isPropertySetDefinitionClass(typeUpper: string | undefined): boolean {
+  if (typeUpper === undefined) return false;
+  const cached = psetDefinitionByClass.get(typeUpper);
+  if (cached !== undefined) return cached;
+  const isPsetDefinition = getInheritanceChainAcrossSchemas(typeUpper).includes('IfcPropertySetDefinition');
+  psetDefinitionByClass.set(typeUpper, isPsetDefinition);
+  return isPsetDefinition;
+}
+
 /**
  * The `HasPropertySets` list a type object should carry after export: the psets
  * it already had, with each affected one swapped for the replacement this export


### PR DESCRIPTION
**Stacked on #3361** (`fix/3351-anonymizer-leaks`) — opened against that branch so the diff shows only this change; merges after it.

## What this closes

#3351 item 2 said "Property sets → Anonymize" claims to drop psets and does not. #3361 fixed this at the two UI entry points — the viewer's coupled toggles and the CLI's `--keep-psets` — but the invariant lived there, not in `exportAnonymizedSubset` itself. `applyScrub`'s `keepPropertySets` handling only ever clears an `IfcTypeObject`'s `HasPropertySets` *slot*; a pset that reached `includedIds` some other way — a caller's own `collectRelatedEntities(store, seeds, { IfcRelDefinesByProperties: true })` walk, or a hand-built id set — still exported complete, values included, with `keepPropertySets` at its documented `false` default.

Reproduced against #3361's own code before touching anything: an `includedIds` set containing a pset id, default options, emits `IFCPROPERTYSINGLEVALUE('Owner',$,IFCTEXT('jane.doe@acme-corp.example'),$)` verbatim.

## The fix

`exportAnonymizedSubset` now excludes every `IfcPropertySet`/`IfcElementQuantity` id from `includedIds` unless `keepPropertySets` is `true`, **before** relationship pruning runs — so an `IfcRelDefinesByProperties` left naming only a now-dropped pset is pruned the same way any other relationship with an excluded mandatory single-valued reference is, rather than left dangling.

**"Drop" means exclude the entity, not emit it scrubbed.** The two are not the same, and I chose exclusion deliberately:

- Property/quantity *values* are unscrubbed by design everywhere else in this module (only names are pseudonymized) — a "kept but scrubbed" pset would still carry its identifying value verbatim, which is exactly the leak the reproduction above shows. Scrubbing in place would not have closed it.
- It's also what the other two callers already do in effect: the CLI's `--keep-psets` drives both the `IfcRelDefinesByProperties` walk and `keepPropertySets` from one flag, so a pset only ever reaches the CLI's output when it's fully kept; the viewer's two toggles are now coupled the same way. There is no "walk on, but scrubbed" state reachable from either. This PR makes the SDK path agree.

The drop is reported distinctly as `AnonymizeResult.stats.droppedPropertySetIds`, the same shape `prunedRelationshipIds` already uses, rather than folded into `warnings` text — so a caller can tell "this id is missing because it's a property set" from any other reason.

## Docs

- `keepPropertySets`'s JSDoc (`anonymize-types.ts`) corrected to describe what it actually does now.
- `docs/guide/exporting.md` corrected: the drop holds for `includedIds` however it was built, not only through the CLI/viewer's own selection step, and `droppedPropertySetIds` is documented.

## Tests

New `describe` block in `anonymize-export.test.ts` ("occurrence-owned property sets reaching includedIds directly"), plus the existing fixture's `Pset_WallCommon` now carries a real identifying value (`#14`, `IFCPROPERTYSINGLEVALUE('Owner',$,IFCTEXT('jane.doe@acme-corp.example'),$)`) instead of only a boolean — the old fixture could not have failed on this gap.

Ran against #3361's branch before any implementation change, to confirm the RED:

```
excludes the property set entirely by default, including the identifying value it carried   FAIL
reports the excluded property set ids distinctly, not just a silent drop                     FAIL
keeps the property set, values included, when keepPropertySets is true                       FAIL
```//
(all three failed — the identifying value, `IFCPROPERTYSET`, and `IFCRELDEFINESBYPROPERTIES` all survived; `droppedPropertySetIds` didn't exist yet)

GREEN after the fix, full `packages/export` suite:

```
Test Files  78 passed | 2 skipped (80)
     Tests  1037 passed | 30 skipped (1067)
```

(2 skipped are pre-existing fixture-gated cases unrelated to this change.)

One pre-existing test in this same file (`trims an excluded member out of a SET/LIST relationship attribute…`) directly included a pset id (`#13`) alongside its relationship to test SET-member trimming, unrelated to psets specifically — it now passes `keepPropertySets: true` so that scenario still exercises what it originally intended, rather than colliding with the new default-drop behaviour.

Also ran: `tsc --noEmit` (clean), `node scripts/check-module-size.mjs` (OK, 0 new over budget), `node scripts/check-changesets.mjs` (OK), `node scripts/check-source-text-assertions.mjs` (OK), `oxlint` scoped to the changed files (clean).

## Open question for review

Should `isPropertySetDefinitionClass` (new, `type-owned-psets.ts`) also govern anything upstream of `includedIds` construction — e.g. should `related-entities.ts`'s own doc comment be updated to note that including `IfcRelDefinesByProperties` now composes safely with `keepPropertySets: false`? I left `related-entities.ts` untouched since its existing behavior (never walking psets by default) was already correct; happy to adjust if you'd rather see that documented there too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anonymized exports now exclude property and quantity sets by default, including those added through relationships or custom ID lists.
  * Export results report which property and quantity sets were excluded.
  * Enabling property-set retention preserves these sets and their values.

* **Documentation**
  * Updated exporting guidance to clarify property-set retention and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->