### PR TITLE
fix(core): bound the express-id reference readers at u32 instead of wrapping (#3421)

### DIFF
--- a/rust/core/src/decoder.rs
+++ b/rust/core/src/decoder.rs
@@ -493,11 +493,8 @@ impl<'a> EntityDecoder<'a> {
                     i += 1;
                 }
                 if i > start {
-                    let mut id = 0u32;
-                    for &b in &bytes[start..i] {
-                        id = id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
-                    }
-                    return Some(id);
+                    // Shared checked accumulator (#3421): refuses rather than wraps.
+                    return crate::express_id::parse_express_id(&bytes[start..i]);
                 }
             }
             i += 1;
@@ -558,12 +555,10 @@ impl<'a> EntityDecoder<'a> {
                     i += 1;
                 }
                 if i > start {
-                    // Fast integer parsing directly from ASCII digits
-                    let mut id = 0u32;
-                    for &b in &bytes[start..i] {
-                        id = id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
+                    // Shared checked accumulator (#3421): an oversized id is dropped, not wrapped.
+                    if let Some(id) = crate::express_id::parse_express_id(&bytes[start..i]) {
+                        ids.push(id);
                     }
-                    ids.push(id);
                 }
             } else {
                 i += 1; // Skip unknown character
@@ -629,12 +624,10 @@ impl<'a> EntityDecoder<'a> {
                     i += 1;
                 }
                 if i > start {
-                    // Fast integer parsing directly from ASCII digits
-                    let mut id = 0u32;
-                    for &b in &bytes[start..i] {
-                        id = id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
+                    // Shared checked accumulator (#3421): an oversized id is dropped, not wrapped.
+                    if let Some(id) = crate::express_id::parse_express_id(&bytes[start..i]) {
+                        point_ids.push(id);
                     }
-                    point_ids.push(id);
                 }
             } else {
                 i += 1; // Skip unknown character
@@ -753,10 +746,10 @@ impl<'a> EntityDecoder<'a> {
         if i <= start {
             return None;
         }
-        let mut loop_id = 0u32;
-        for &b in &bytes[start..i] {
-            loop_id = loop_id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
-        }
+        // Shared checked accumulator (#3421): an oversized loop ref fails
+        // this lookup outright, like any other unresolvable reference,
+        // instead of resolving to the wrong loop.
+        let loop_id = crate::express_id::parse_express_id(&bytes[start..i])?;
 
         // Find orientation after comma - default to true (.T.)
         // Skip to comma
@@ -840,19 +833,18 @@ impl<'a> EntityDecoder<'a> {
                     i += 1;
                 }
                 if i > id_start {
-                    // Fast integer parsing directly from ASCII digits
-                    let mut point_id = 0u32;
-                    for &b in &bytes[id_start..i] {
-                        point_id = point_id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
-                    }
-
-                    // INLINE: Get cartesian point coordinates directly
-                    // This avoids the overhead of calling get_cartesian_point_fast for each point
-                    if let Some((pt_start, pt_end)) = index.lookup(point_id) {
-                        if let Some(coord) =
-                            parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
-                        {
-                            coords.push(coord);
+                    // Shared checked accumulator (#3421): an oversized ref drops this point.
+                    if let Some(point_id) =
+                        crate::express_id::parse_express_id(&bytes[id_start..i])
+                    {
+                        // INLINE: Get cartesian point coordinates directly
+                        // This avoids the overhead of calling get_cartesian_point_fast for each point
+                        if let Some((pt_start, pt_end)) = index.lookup(point_id) {
+                            if let Some(coord) =
+                                parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
+                            {
+                                coords.push(coord);
+                            }
                         }
                     }
                 }
@@ -931,25 +923,27 @@ impl<'a> EntityDecoder<'a> {
                 if i > id_start {
                     expected_count += 1; // Count every point ID we encounter
 
-                    // Fast integer parsing directly from ASCII digits
-                    let mut point_id = 0u32;
-                    for &b in &bytes[id_start..i] {
-                        point_id = point_id.wrapping_mul(10).wrapping_add((b - b'0') as u32);
-                    }
-
-                    // Check cache first
-                    if let Some(&coord) = self.point_cache.get(&point_id) {
-                        self.point_cache_hits += 1;
-                        coords.push(coord);
-                    } else {
-                        // Not in cache - parse and cache
-                        if let Some((pt_start, pt_end)) = index.lookup(point_id) {
-                            if let Some(coord) =
-                                parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
-                            {
-                                self.point_cache_misses += 1;
-                                self.point_cache.insert(point_id, coord);
-                                coords.push(coord);
+                    // Shared checked accumulator (#3421): `expected_count`
+                    // was already bumped, so a refused id here trips the
+                    // `coords.len() == expected_count` check below, same as
+                    // any other missing point.
+                    if let Some(point_id) =
+                        crate::express_id::parse_express_id(&bytes[id_start..i])
+                    {
+                        // Check cache first
+                        if let Some(&coord) = self.point_cache.get(&point_id) {
+                            self.point_cache_hits += 1;
+                            coords.push(coord);
+                        } else {
+                            // Not in cache - parse and cache
+                            if let Some((pt_start, pt_end)) = index.lookup(point_id) {
+                                if let Some(coord) =
+                                    parse_cartesian_point_inline(&bytes_full[pt_start..pt_end])
+                                {
+                                    self.point_cache_misses += 1;
+                                    self.point_cache.insert(point_id, coord);
+                                    coords.push(coord);
+                                }
                             }
                         }
                     }

--- a/rust/core/src/decoder/decoder_tests.rs
+++ b/rust/core/src/decoder/decoder_tests.rs
@@ -361,3 +361,144 @@ END-ISO-10303-21;
         "metre-authored file must still report 1.0, got {scale}"
     );
 }
+
+// --- Issue #3421: the raw-byte REFERENCE readers, not just the definition
+// scanner, must refuse a `#<digits>` above `u32::MAX` rather than wrapping it
+// onto a real low-numbered entity. #3395 fixed only the definition side
+// (`EntityScanner`, see `parser::scanner_tests`); these pin the six decoder
+// sites and the fast_parse pair have their own tests in `fast_parse_tests.rs`.
+//
+// `4294967297` is the defect value: `% 2^32 == 1`, so an unfixed reader binds
+// it to a real `#1` rather than merely erroring. `4294967295` is `u32::MAX`
+// exactly and must still resolve — the bound is inclusive.
+
+/// One fixture exercised through BOTH the definition scanner and a reference
+/// reader: `#4294967295` is a real, independently defined entity, distinct
+/// from `#1`. If the reference readers ever grew a second, disagreeing copy
+/// of the bound, this would show up as `#1`'s coordinates being served twice
+/// (aliasing) or the boundary id's own coordinates going missing — not as a
+/// bare "does it error" check.
+#[test]
+fn definition_and_reference_readers_agree_at_the_express_id_boundary() {
+    let content = "\
+#1=IFCCARTESIANPOINT((1.,1.,1.));
+#4294967295=IFCCARTESIANPOINT((9.,9.,9.));
+#2=IFCPOLYLOOP((#1,#4294967295,#4294967297));
+";
+
+    // Definition side: the scanner must see #1 and #4294967295 as distinct
+    // entities, and #4294967297 is never a definition here at all.
+    let mut scanner = EntityScanner::new(content);
+    let mut defined_ids = Vec::new();
+    while let Some((id, _type_name, _start, _end)) = scanner.next_entity() {
+        defined_ids.push(id);
+    }
+    assert_eq!(defined_ids, vec![1, u32::MAX, 2]);
+
+    // Reference side: get_polyloop_point_ids_fast reads the SAME
+    // `#4294967295` and `#4294967297` bytes out of #2's attribute list.
+    let mut decoder = EntityDecoder::new(content);
+    let point_ids = decoder
+        .get_polyloop_point_ids_fast(2)
+        .expect("polyloop with two resolvable point refs");
+    assert_eq!(
+        point_ids,
+        vec![1, u32::MAX],
+        "the oversized ref must be dropped, and u32::MAX must resolve, matching the definition side"
+    );
+}
+
+/// `get_polyloop_coords_fast` needs >= 3 resolved points to return a polygon
+/// at all, so the previous test's 2-point case always yields `None` — this
+/// isolates the "oversized ref dropped, others still resolve" behaviour with
+/// enough real points to actually get coordinates back.
+#[test]
+fn get_polyloop_coords_fast_drops_oversized_ref_but_resolves_the_rest() {
+    let content = "\
+#1=IFCCARTESIANPOINT((1.,0.,0.));
+#2=IFCCARTESIANPOINT((0.,1.,0.));
+#4294967295=IFCCARTESIANPOINT((0.,0.,1.));
+#3=IFCPOLYLOOP((#1,#2,#4294967295,#4294967297));
+";
+    let mut decoder = EntityDecoder::new(content);
+    let coords = decoder
+        .get_polyloop_coords_fast(3)
+        .expect("3 of the 4 referenced points resolve, which is >= the minimum of 3");
+    assert_eq!(
+        coords,
+        vec![(1., 0., 0.), (0., 1., 0.), (0., 0., 1.)],
+        "the oversized ref (#4294967297) must be dropped, not aliased onto #1's coordinates"
+    );
+}
+
+/// Same boundary, through the cached point-lookup path
+/// (`get_polyloop_coords_cached`): the oversized ref must fail the whole
+/// polygon's `coords.len() == expected_count` check (missing point, same as
+/// any other unresolvable reference) rather than resolve via a wrapped alias.
+#[test]
+fn get_polyloop_coords_cached_rejects_oversized_ref() {
+    let content = "\
+#1=IFCCARTESIANPOINT((1.,0.,0.));
+#2=IFCCARTESIANPOINT((0.,1.,0.));
+#3=IFCPOLYLOOP((#1,#2,#4294967297));
+";
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(
+        decoder.get_polyloop_coords_cached(3),
+        None,
+        "an oversized ref must leave the polygon short of expected_count, not resolve via alias"
+    );
+}
+
+/// `get_polyloop_point_ids_fast` (issue #3421): pins the drop-not-alias
+/// behaviour directly, independent of the combined test above.
+#[test]
+fn get_polyloop_point_ids_fast_drops_oversized_ref() {
+    let content = "#1=IFCPOLYLOOP((#2,#4294967297,#4294967295));\n";
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(
+        decoder.get_polyloop_point_ids_fast(1),
+        Some(vec![2, u32::MAX])
+    );
+}
+
+/// `get_entity_ref_list_fast` (issue #3421): same contract as
+/// `get_polyloop_point_ids_fast`, different accessor and record shape.
+#[test]
+fn get_entity_ref_list_fast_drops_oversized_ref() {
+    let content = "#1=IFCCLOSEDSHELL((#2,#4294967297,#4294967295));\n";
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(
+        decoder.get_entity_ref_list_fast(1),
+        Some(vec![2, u32::MAX])
+    );
+}
+
+/// `get_first_entity_ref_fast` (issue #3421): an oversized first reference
+/// must refuse (`None`), not resolve to `#1`.
+#[test]
+fn get_first_entity_ref_fast_refuses_oversized_ref() {
+    let content = "#1=IFCMAPPEDITEM(#4294967297,$);\n";
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(decoder.get_first_entity_ref_fast(1), None);
+
+    // Control: the same accessor resolves an ordinary reference, and the
+    // inclusive boundary (u32::MAX) still resolves too.
+    let content = "#1=IFCMAPPEDITEM(#4294967295,$);\n";
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(decoder.get_first_entity_ref_fast(1), Some(u32::MAX));
+}
+
+/// `get_face_bound_fast` (issue #3421): an oversized loop reference must
+/// refuse the whole face bound (`None`), not resolve to a real, wrong loop.
+#[test]
+fn get_face_bound_fast_refuses_oversized_loop_ref() {
+    let content = "#1=IFCFACEBOUND(#4294967297,.T.);\n";
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(decoder.get_face_bound_fast(1), None);
+
+    // Control: the inclusive boundary still resolves, with the right id.
+    let content = "#1=IFCFACEBOUND(#4294967295,.T.);\n";
+    let mut decoder = EntityDecoder::new(content);
+    assert_eq!(decoder.get_face_bound_fast(1), Some((u32::MAX, true, false)));
+}

--- a/rust/core/src/express_id.rs
+++ b/rust/core/src/express_id.rs
@@ -1,0 +1,96 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The single place in this crate that decides whether a digit run read
+//! from a raw IFC byte slice fits an express id.
+//!
+//! ISO 10303-21 writes an instance name (`#<digits>`) with no upper bound, so
+//! a file MAY legally contain `#4294967297`. Nothing downstream of this crate
+//! can hold one: every store that keys on an express id narrows it to `u32`.
+//! Accumulating with `wrapping_mul`/`wrapping_add` does not error on an
+//! oversized run, it silently maps it onto a real low-numbered id — a value
+//! collision, not a missing value (issue #3395, split for the reference
+//! readers in #3421).
+//!
+//! [`parse_express_id`] is called from both sides of that contract: the
+//! definition scanner ([`crate::parser::scanner::EntityScanner`]) and every
+//! `#<digits>` reference reader in [`crate::fast_parse`] and
+//! [`crate::decoder`]. A second, independently-written copy of this
+//! accumulation is exactly the drift #3395 was careful to avoid, so a new
+//! caller must reuse this function rather than writing its own loop.
+//!
+//! The bound is inclusive: `u32::MAX` is a legitimate express id and parses
+//! successfully. Refusal (`None`) is the only outcome for anything past it —
+//! there is no saturating variant here. A caller that saturated an oversized
+//! reference to `u32::MAX` would risk binding it to a real entity that
+//! legitimately holds that id, which is the same collision this function
+//! exists to prevent, just relocated to the sentinel value. Contrast
+//! [`crate::fast_parse::parse_indices_direct`], which deliberately
+//! *saturates* an out-of-range vertex index to `u32::MAX`: that value is a
+//! sentinel a downstream bounds check drops, not a key another value could
+//! collide with, so saturation is safe there and is not safe here.
+
+/// Parse `digits` — an already-validated, non-empty run of ASCII digit bytes
+/// — into a `u32` express id, or `None` if the value does not fit.
+///
+/// Two loops rather than one: a run of at most 9 digits is at most
+/// 999_999_999 and cannot overflow `u32`, so the common case (every real
+/// exporter's ids) keeps the unchecked instruction sequence. Only a 10+
+/// digit run — which no real exporter emits — pays for `checked_mul` /
+/// `checked_add`.
+///
+/// Callers are expected to have already located the digit run (e.g. by
+/// scanning forward while `is_ascii_digit()` holds); this function does not
+/// search for one and returns `Some(0)` for an all-zero run rather than
+/// treating it as absent — callers that treat id `0` as "no reference" must
+/// check that themselves, the same way they did before this helper existed.
+#[inline]
+pub(crate) fn parse_express_id(digits: &[u8]) -> Option<u32> {
+    debug_assert!(
+        !digits.is_empty() && digits.iter().all(u8::is_ascii_digit),
+        "parse_express_id expects a validated, non-empty digit run"
+    );
+    let mut result: u32 = 0;
+    if digits.len() <= 9 {
+        for &b in digits {
+            result = result * 10 + (b - b'0') as u32;
+        }
+        return Some(result);
+    }
+    for &b in digits {
+        result = result.checked_mul(10)?.checked_add((b - b'0') as u32)?;
+    }
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_runs_parse_without_overflow_checks() {
+        assert_eq!(parse_express_id(b"1"), Some(1));
+        assert_eq!(parse_express_id(b"999999999"), Some(999_999_999));
+    }
+
+    #[test]
+    fn max_u32_is_inclusive() {
+        assert_eq!(parse_express_id(b"4294967295"), Some(u32::MAX));
+    }
+
+    #[test]
+    fn one_past_max_is_refused_not_wrapped() {
+        // 4294967296 = 2^32: the first value that does not fit u32. A
+        // wrapping accumulator would yield 0; this must yield None.
+        assert_eq!(parse_express_id(b"4294967296"), None);
+    }
+
+    #[test]
+    fn the_defect_value_is_refused_not_aliased_to_a_real_id() {
+        // 4294967297 % 2^32 == 1: a wrapping accumulator binds this to a
+        // real #1, which is the actual defect (#3421), not merely an
+        // overflow that errors.
+        assert_eq!(parse_express_id(b"4294967297"), None);
+    }
+}

--- a/rust/core/src/fast_parse.rs
+++ b/rust/core/src/fast_parse.rs
@@ -291,16 +291,17 @@ pub fn extract_first_entity_ref(bytes: &[u8]) -> Option<u32> {
     let hash_pos = content.iter().position(|&b| b == b'#')?;
     let id_start = hash_pos + 1;
 
-    // Parse the ID number
-    let mut id: u32 = 0;
+    // Find the end of the digit run, then parse it through the single
+    // checked accumulator shared with every other reference reader and the
+    // definition scanner (issue #3421) — an id above `u32::MAX` is refused
+    // (`None`) rather than wrapped onto a real low-numbered entity.
     let mut i = id_start;
     while i < content.len() && content[i].is_ascii_digit() {
-        id = id.wrapping_mul(10).wrapping_add((content[i] - b'0') as u32);
         i += 1;
     }
 
     if i > id_start {
-        Some(id)
+        crate::express_id::parse_express_id(&content[id_start..i])
     } else {
         None
     }
@@ -366,14 +367,17 @@ pub fn extract_entity_refs_from_list(bytes: &[u8]) -> Vec<u32> {
         }
         i += 1; // Skip '#'
 
-        // Parse ID
-        let mut id: u32 = 0;
+        // Parse ID through the shared checked accumulator (issue #3421): an
+        // id above `u32::MAX` is refused (`None`, dropped from `ids`) rather
+        // than wrapped onto a real low-numbered entity.
+        let id_start = i;
         while i < len && bytes[i].is_ascii_digit() {
-            id = id.wrapping_mul(10).wrapping_add((bytes[i] - b'0') as u32);
             i += 1;
         }
-        if id > 0 {
-            ids.push(id);
+        if let Some(id) = crate::express_id::parse_express_id(&bytes[id_start..i]) {
+            if id > 0 {
+                ids.push(id);
+            }
         }
     }
 

--- a/rust/core/src/fast_parse.rs
+++ b/rust/core/src/fast_parse.rs
@@ -374,9 +374,11 @@ pub fn extract_entity_refs_from_list(bytes: &[u8]) -> Vec<u32> {
         while i < len && bytes[i].is_ascii_digit() {
             i += 1;
         }
-        if let Some(id) = crate::express_id::parse_express_id(&bytes[id_start..i]) {
-            if id > 0 {
-                ids.push(id);
+        if i > id_start {
+            if let Some(id) = crate::express_id::parse_express_id(&bytes[id_start..i]) {
+                if id > 0 {
+                    ids.push(id);
+                }
             }
         }
     }

--- a/rust/core/src/fast_parse_tests.rs
+++ b/rust/core/src/fast_parse_tests.rs
@@ -194,3 +194,51 @@ fn extract_entity_type_name_trims_and_rejects_empty() {
         );
     }
 }
+
+/// `extract_first_entity_ref` and `extract_entity_refs_from_list` are the two
+/// `#<digits>` REFERENCE readers in this file (issue #3421, split from
+/// #3395 which fixed only the definition side). Before this fix both
+/// accumulated with `wrapping_mul`/`wrapping_add`, so a reference above
+/// `u32::MAX` wrapped onto a real low-numbered entity instead of being
+/// refused — the same defect #3395 fixed one hop earlier, in the reference
+/// readers rather than the definition scanner.
+///
+/// `4294967297` is `% 2^32 == 1`: an unfixed reader binds it to a real `#1`
+/// rather than merely erroring, which is the actual defect. `4294967295` is
+/// `u32::MAX` exactly and must still resolve (the bound is inclusive).
+#[test]
+fn extract_first_entity_ref_refuses_above_u32_max_and_resolves_at_the_boundary() {
+    // The defect value: would wrap to 1 without the bound.
+    assert_eq!(
+        extract_first_entity_ref(b"#77=IFCTRIANGULATEDFACESET(#4294967297,$);"),
+        None,
+        "a reference above u32::MAX must be refused, not aliased to #1"
+    );
+    // The inclusive boundary: u32::MAX itself must still resolve.
+    assert_eq!(
+        extract_first_entity_ref(b"#77=IFCTRIANGULATEDFACESET(#4294967295,$);"),
+        Some(u32::MAX)
+    );
+    // An ordinary reference is unaffected.
+    assert_eq!(
+        extract_first_entity_ref(b"#77=IFCTRIANGULATEDFACESET(#78,$);"),
+        Some(78)
+    );
+}
+
+#[test]
+fn extract_entity_refs_from_list_refuses_above_u32_max_and_resolves_at_the_boundary() {
+    // The oversized id is dropped, not aliased to #1 — it must not appear in
+    // the result at all, and the real #1 in the same list must not be
+    // duplicated by the dropped one wrapping onto it.
+    let ids = extract_entity_refs_from_list(b"(#1,#4294967297,#2)");
+    assert_eq!(
+        ids,
+        vec![1, 2],
+        "an out-of-range reference must be dropped, not wrapped onto #1"
+    );
+
+    // The inclusive boundary: u32::MAX itself must still resolve and appear.
+    let ids = extract_entity_refs_from_list(b"(#1,#4294967295,#2)");
+    assert_eq!(ids, vec![1, u32::MAX, 2]);
+}

--- a/rust/core/src/fast_parse_tests.rs
+++ b/rust/core/src/fast_parse_tests.rs
@@ -242,3 +242,9 @@ fn extract_entity_refs_from_list_refuses_above_u32_max_and_resolves_at_the_bound
     let ids = extract_entity_refs_from_list(b"(#1,#4294967295,#2)");
     assert_eq!(ids, vec![1, u32::MAX, 2]);
 }
+
+#[test]
+fn extract_entity_refs_from_list_hash_with_no_digits_does_not_panic() {
+    let ids = extract_entity_refs_from_list(b"(#,#2)");
+    assert_eq!(ids, vec![2]);
+}

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -65,6 +65,7 @@
 pub mod columnar_index;
 pub mod decoder;
 pub mod error;
+pub(crate) mod express_id;
 pub mod fast_parse;
 pub mod generated;
 pub mod georef;

--- a/rust/core/src/parser/scanner.rs
+++ b/rust/core/src/parser/scanner.rs
@@ -239,29 +239,14 @@ impl<'a> EntityScanner<'a> {
     /// be `wrapping_mul`/`wrapping_add`, which turned `#4294967297` into `1` —
     /// a real entity's id, indistinguishable from it downstream (issue #3395).
     ///
-    /// Two loops rather than one: a run of at most 9 digits is at most
-    /// 999_999_999 and cannot overflow `u32`, so every real file keeps the
-    /// unchecked instruction sequence. Only a 10+ digit run — which no
-    /// exporter emits — pays for `checked_mul`/`checked_add`.
+    /// Delegates to [`crate::express_id::parse_express_id`], the single
+    /// checked accumulator shared with every `#<digits>` reference reader in
+    /// [`crate::fast_parse`] and [`crate::decoder`] (issue #3421) — the
+    /// definition and reference sides of an express id agree on the bound
+    /// because they call the same function, not two copies of the same rule.
     #[inline]
     fn parse_u32_fast(&self, start: usize, end: usize) -> Option<u32> {
-        debug_assert!(
-            self.bytes[start..end].iter().all(u8::is_ascii_digit),
-            "parse_u32_fast expects a validated digit run"
-        );
-        let mut result: u32 = 0;
-        if end - start <= 9 {
-            for i in start..end {
-                result = result * 10 + (self.bytes[i] - b'0') as u32;
-            }
-            return Some(result);
-        }
-        for i in start..end {
-            result = result
-                .checked_mul(10)?
-                .checked_add((self.bytes[i] - b'0') as u32)?;
-        }
-        Some(result)
+        crate::express_id::parse_express_id(&self.bytes[start..end])
     }
 
     /// Find the terminating semicolon of an entity, skipping over quoted strings.


### PR DESCRIPTION
**Stacked on #3420** (`fix-3395-express-id-above-u32`) — merges after it. The diff shown against that base is this change alone.

## The defect

#3395/#3420 fixed the **definition** side: an express id above `u32::MAX` is refused at the parse boundary instead of truncating into a real entity's key. The **reference** readers were left, and still accumulated with wrapping arithmetic:

```rust
let mut id: u32 = 0;
while i < content.len() && content[i].is_ascii_digit() {
    id = id.wrapping_mul(10).wrapping_add((content[i] - b'0') as u32);
    i += 1;
}
```

So a reference such as `#4294967297` wrapped to `#1` and bound to a real low-numbered entity. An entity now refused at definition time could still be pointed at, and the pointer resolved to the wrong thing rather than to nothing. The two sides fail differently: #3395 produces a *missing* entity with a counted, reported refusal; this produced a *wrong* entity, silently.

## One home, nine call sites

The bound now lives in `rust/core/src/express_id.rs` and nothing else decides whether a digit run is a valid express id. `EntityScanner::parse_u32_fast` was a private method, so there was nothing for the readers to import — the reason #3421 warned that a fix here would otherwise become a third copy. The scanner now delegates to the same function:

- `parser/scanner.rs` — the definition side
- `fast_parse.rs` — `extract_first_entity_ref`, `extract_entity_refs_from_list`
- `decoder.rs` — six reference sites

`git grep "wrapping_mul(10)"` over `rust/core/src` now returns only the test that reproduces the old behaviour to demonstrate the alias.

## Refuse, not saturate

A refused reference is **dangling** (`None`), not clamped. Saturating to `u32::MAX` would be wrong for a specific reason: #3420 establishes and tests `u32::MAX` as a legal, loadable express id, so a saturated reference could bind to a real entity holding that id — the same defect class relocated one hop rather than fixed. This also matches what the TypeScript readers already do (`getReference` and the extractor's reference path return `undefined`/`null`), so the two languages now agree on what a refused reference *is*, not merely on where the bound sits.

`fast_parse.rs` separately saturates a *vertex index* to `u32::MAX` on purpose — a sentinel a downstream bounds check drops, with no collision risk. That is untouched.

## Tests

The refusal case uses **`4294967297`** deliberately: `% 2^32 == 1`, so an unfixed reader binds it to a real `#1` rather than merely erroring. A test using a value that only errors would pass for the wrong reason.

```
test express_id::tests::the_defect_value_is_refused_not_aliased_to_a_real_id ... ok
test express_id::tests::one_past_max_is_refused_not_wrapped ... ok
test express_id::tests::max_u32_is_inclusive ... ok
test express_id::tests::short_runs_parse_without_overflow_checks ... ok
test parser::scanner::scanner_tests::test_entity_scanner_admits_express_id_at_u32_max ... ok
test parser::scanner::scanner_tests::test_entity_scanner_skips_express_id_above_u32 ... ok
test decoder::decoder_tests::definition_and_reference_readers_agree_at_the_express_id_boundary ... ok
```

The last one is the guard against this regressing into two copies again: it drives the definition and reference paths over one fixture and asserts they agree at the boundary, so a future divergence fails rather than merely being uncommented. `max_u32_is_inclusive` pins the other end — the bound must not become off-by-one and start dropping legal ids.

## Verification

- `cargo test -p ifc-lite-core` — **226 passed, 0 failed** across the crate.
- `cargo clippy -p ifc-lite-core --lib -- -D warnings` — clean.
- `rustfmt --check` on the touched files reports one deviation at `fast_parse.rs:274`; my hunks start at 291 and 366, so it is outside this change and pre-existing.

Refs #3421


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented oversized entity references from wrapping to incorrect valid IDs.
  - References above the supported 32-bit limit are now rejected or skipped safely.
  - Preserved correct handling of the maximum supported ID, `4294967295`.
  - Improved reliability when resolving entity references, polyloops, coordinates, and face-bound loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->