### PR TITLE
fix(ci): run the PR review signal gate on every base, not just main (#3429)

### DIFF
--- a/.github/workflows/pr-review-signal.yml
+++ b/.github/workflows/pr-review-signal.yml
@@ -15,29 +15,47 @@ name: PR review signal
 #    ON THE PATH THAT MERGES IT. Asserted in
 #    scripts/check-pr-review-signal.test.mjs.
 #
-#    THE SCOPE OF THAT CLAIM, stated rather than left to be discovered: the
-#    `branches: [main]` filter below means a PR based on a FEATURE branch does
-#    not run this job, so both files can change on such a PR with no gate run.
-#    That is not a hole to close by widening the filter -- the required lane set
-#    is derived from test.yml, which carries the same `branches: [main]`, so on
-#    a feature-targeted PR every required lane is legitimately absent and this
-#    gate would fail every stacked PR for a reason that is not a defect. The
-#    residue is bounded by the retarget rule the next paragraph describes:
-#    pointing such a PR at main fires `edited`, which runs this job, and it must
-#    then pass before the change reaches main.
+#    THE SCOPE OF THAT CLAIM, stated rather than left to be discovered: this job
+#    used to carry the SAME `branches: [main]` filter as test.yml, on the
+#    reasoning that widening it would fail every stacked PR "for a reason that
+#    is not a defect" -- the required lane set is derived from test.yml, which
+#    still targets `branches: [main]` only, so on a feature-targeted PR every
+#    required lane IS legitimately absent. #3429 (louistrue, BIMvoice) is the
+#    correction to that reasoning: "legitimately absent" is exactly the fact a
+#    reviewer needs surfaced, not a reason to suppress the gate that surfaces
+#    it. #3405 and #3428, both stacked on another PR's branch, ran ZERO
+#    `test.yml` lanes and their check lists showed six passes and two skips --
+#    nothing said "nothing ran". `gh pr checks` and `mergeable: MERGEABLE` gave
+#    no discriminator either. Filtering THIS job the same way test.yml is
+#    filtered reproduces the silence in the one place meant to catch it.
+#
+#    So this job now has NO `branches:` filter and fires on every base. Part 1
+#    of scripts/check-pr-review-signal.mjs already handles total absence --
+#    it is the #3294 shape it was built for -- so on a stacked PR every lane
+#    derived from test.yml comes back missing and the gate reports
+#    `MISSING_LANES` and exits non-zero, unconditionally (part 1 has no
+#    severity knob; see the script for why). That failure does not block the
+#    stacked PR from merging into its feature-branch base: GitHub's required-
+#    status-checks ruleset is configured against `main`, and only applies when
+#    a PR's base IS the ref the ruleset protects, so this job going red on a
+#    PR based on a feature branch is a visible row, not an enforced gate --
+#    exactly the "silence into a visible failure" trade #3429 asks for. It
+#    still becomes an enforced gate the moment the PR is retargeted to main,
+#    same as before.
 #
 # `edited` IS THE POINT OF THE TYPES LIST. GitHub's default `pull_request`
 # activity types are opened/synchronize/reopened. Retargeting a PR's base branch
-# fires `edited` and nothing else -- and it does NOT re-fire the workflows that
-# a `branches: [main]` filter had excluded while the PR pointed at a feature
-# branch. That is the deterministic, reproducible mechanism behind #3294 merging
-# with 8 checks and leaving main's module-size gate red. Without `edited` here,
-# this detector would miss the one case it was built for.
+# fires `edited` and nothing else. Before this job ran on all bases, that meant
+# `edited` did not re-fire the workflows that a `branches: [main]` filter had
+# excluded while the PR pointed at a feature branch -- the deterministic,
+# reproducible mechanism behind #3294 merging with 8 checks and leaving main's
+# module-size gate red. Kept now for the same retarget transition, and because
+# this job derives its required-lane list from test.yml at read time regardless
+# of which event fired it.
 #
 # `ready_for_review` covers the draft->ready transition for the same reason.
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened, edited, ready_for_review]
 
 concurrency:

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -382,7 +382,7 @@ function fetchPrState(opts) {
       'view',
       opts.pr,
       '--json',
-      'headRefOid,isCrossRepository,statusCheckRollup',
+      'headRefOid,isCrossRepository,statusCheckRollup,baseRefName',
       '--repo',
       opts.repo,
     ],
@@ -402,6 +402,7 @@ function fetchPrState(opts) {
   return {
     sha,
     isFork: data.isCrossRepository === true,
+    baseRefName: typeof data.baseRefName === 'string' ? data.baseRefName : undefined,
     // This job's own lane is dropped. It is `in_progress` for as long as it is
     // asking the question, so leaving it in would make `rollupSettled` false
     // forever and turn every run into a full-budget wait ending in a timeout.
@@ -507,9 +508,26 @@ function sleepSync(ms) {
  * harness can drive every branch -- including every fail-closed one -- without
  * a network, a token, or a real PR.
  *
+ * @param {string} [baseRefName] - the PR's base branch, if known. Distinguishes
+ *   a stacked PR (base is not `main`, so test.yml's OWN `branches: [main]`
+ *   filter means every required lane is legitimately absent right now, and
+ *   will stay absent until retargeted) from the #3294 retarget shape (base IS
+ *   `main`, workflow fired for nobody, and pushing an empty commit or
+ *   reopening genuinely helps). Optional and defaults to the retarget message
+ *   when the caller has not fetched it (`--state-file` offline mode).
  * @returns {{ ok: boolean, lines: string[] }}
  */
-export function evaluate({ required, lanes, reviewChecks, reviews, headSha, isFork, cfg, timedOut }) {
+export function evaluate({
+  required,
+  lanes,
+  reviewChecks,
+  reviews,
+  headSha,
+  isFork,
+  cfg,
+  timedOut,
+  baseRefName,
+}) {
   const lines = [];
   let ok = true;
 
@@ -540,7 +558,21 @@ export function evaluate({ required, lanes, reviewChecks, reviews, headSha, isFo
     // missing because #3298 added it to test.yml AFTER that head — not a
     // retarget at all. The discriminator is whether test.yml fired here AT ALL:
     // the #3294 retarget shape is TOTAL absence, because the workflow never ran.
-    if (missing.length === required.length) {
+    if (missing.length === required.length && baseRefName && baseRefName !== 'main') {
+      // #3429: a PR stacked on another PR's branch. test.yml's OWN
+      // `branches: [main]` filter is why nothing appeared -- there was no
+      // retarget to fail to retroactively fire, and no push here changes
+      // that, because test.yml still would not fire against this base.
+      lines.push(
+        `   NOT ONE lane from test.yml appeared, and this PR's base is \`${baseRefName}\`, not ` +
+          '`main` --',
+        '   test.yml carries the same `branches: [main]` filter this gate does not, so every ' +
+          'lane is',
+        '   genuinely absent for as long as the PR is stacked (#3429). An empty commit will not ' +
+          'fire it;',
+        '   retargeting this PR to `main` will.',
+      );
+    } else if (missing.length === required.length) {
       lines.push(
         '   NOT ONE lane from test.yml appeared, so the workflow never fired for this head. A PR ' +
           'opened against a',
@@ -713,6 +745,7 @@ function main() {
       reviews: state.reviews,
       headSha: state.headSha,
       isFork: state.isFork === true,
+      baseRefName: typeof state.baseRefName === 'string' ? state.baseRefName : undefined,
       cfg,
       timedOut: false,
     });
@@ -776,7 +809,9 @@ function main() {
   // and 2 are untouched.
   const reviews = cfg.staleReviewPolicy === 'off' ? [] : fetchReviews({ repo, pr: args.pr });
 
-  console.log(`PR #${args.pr} @ ${state.sha}${state.isFork ? ' (fork)' : ''}`);
+  console.log(
+    `PR #${args.pr} @ ${state.sha}${state.isFork ? ' (fork)' : ''} -> base \`${state.baseRefName ?? '(unknown)'}\``,
+  );
   console.log(`Required lanes derived from ${args.workflow}: ${required.length}`);
   console.log(`Rollup lanes seen: ${state.lanes.length}`);
   console.log(
@@ -793,6 +828,7 @@ function main() {
     reviews,
     headSha: state.sha,
     isFork: state.isFork,
+    baseRefName: state.baseRefName,
     cfg,
     timedOut,
   });

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -19,7 +19,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { expandJobNames } from './lib/pr-review-signal.mjs';
+import { expandJobNames, pullRequestBranchFilterKeys } from './lib/pr-review-signal.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, '..');
@@ -598,16 +598,21 @@ test('the gate carries NO base-branch filter, so a stacked PR cannot dodge it (#
   // can observe a stacked PR's total lane absence and fail loud rather than
   // being silently skipped alongside it. Pinned rather than reasoned about in
   // a comment, because the two files are edited independently.
+  //
+  // #3433: a text regex here (`/^\s*branches:\s*(\[.*\])\s*$/m`) caught the
+  // inline `branches: [main]` spelling but not the equivalent block form
+  // (`branches:\n  - main`), so the guard this test IS could itself be
+  // defeated by reformatting. Parsed structurally instead -- see
+  // `pullRequestBranchFilterKeys` for every spelling this now covers.
   const own = readFileSync(join(REPO_ROOT, '.github/workflows/pr-review-signal.yml'), 'utf8');
   const testYml = readFileSync(TEST_YML, 'utf8');
-  const branchesOf = (text) => /^\s*branches:\s*(\[.*\])\s*$/m.exec(text)?.[1];
-  assert.equal(
-    branchesOf(own),
-    undefined,
+  assert.deepEqual(
+    pullRequestBranchFilterKeys(own),
+    [],
     'pr-review-signal.yml must not declare a base-branch filter -- it has to run on stacked PRs to catch them',
   );
   assert.ok(
-    branchesOf(testYml),
+    pullRequestBranchFilterKeys(testYml).length > 0,
     'test.yml is expected to keep its own base-branch filter; this test documents the asymmetry, not test.yml\'s scope',
   );
 });

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -117,6 +117,28 @@ test('RED, the #3294 shape: a rollup with no compile lanes fails and NAMES each 
   assert.match(r.output, /retargeted to main does NOT fire test\.yml retroactively/);
 });
 
+test('RED, the #3429 shape: a PR stacked on a feature-branch base fails and names the real remedy', () => {
+  // The #3294 message above ("push an empty commit, or close and reopen")
+  // does not work here: test.yml's own `branches: [main]` filter means it
+  // will not fire against a non-main base no matter how the PR is nudged.
+  // This is the case #3429 asks the gate to surface -- a stacked PR whose
+  // lanes are absent not because of a stale retarget, but because they were
+  // never going to run against this base at all.
+  const r = run({
+    required: HEALTHY,
+    lanes: [LANE('Vercel – ifc-lite'), LANE('IfcOpenShell parity')],
+    reviewChecks: [],
+    baseRefName: 'fix-3338-isolate-expansion-gate',
+  });
+  assert.equal(r.code, 1, r.output);
+  assert.match(r.output, /MISSING_LANES: 3 of 3/);
+  assert.match(r.output, /this PR's base is `fix-3338-isolate-expansion-gate`, not `main`/);
+  assert.match(r.output, /retargeting this PR to `main` will/);
+  // Must NOT print the #3294 remedy -- pushing an empty commit fixes nothing
+  // here, and telling a stacked-PR author to do it is advice that cannot work.
+  assert.doesNotMatch(r.output, /retargeted to main does NOT fire test\.yml retroactively/);
+});
+
 test('RED, the #3305 shape: CodeRabbit passing while rate limited fails and quotes it', () => {
   const r = run(
     {
@@ -560,29 +582,33 @@ test('the resolved repo reaches the PR read, not just the commit-status reads', 
 });
 
 
-test('the gate and the workflow it derives lanes from carry the SAME base-branch filter', () => {
-  // The self-guard above ("no edit to the script or its config can dodge the
-  // job") holds only for PRs targeting main, because this job carries
-  // `branches: [main]`. That scope is SOUND only while test.yml carries the
-  // same filter: the required lane set is derived from test.yml, so if test.yml
-  // ran on feature-targeted PRs and this gate did not, the gate would be blind
-  // on PRs whose lanes genuinely did run. And if this gate ran where test.yml
-  // did not, every required lane would be legitimately absent and every stacked
-  // PR would fail for a reason that is not a defect.
+test('the gate carries NO base-branch filter, so a stacked PR cannot dodge it (#3429)', () => {
+  // #3429: this job used to carry the SAME `branches: [main]` filter as
+  // test.yml, on the reasoning that widening it would fail every stacked PR
+  // "for a reason that is not a defect" -- every lane test.yml would have
+  // published is legitimately absent on a feature-targeted PR. That reasoning
+  // is exactly backwards for what this gate exists to do: "legitimately
+  // absent" is the fact a reviewer needs surfaced, not a reason to suppress
+  // the one job that surfaces it. #3405 and #3428 (both stacked) ran ZERO
+  // test.yml lanes and their check lists showed passes and skips only --
+  // nothing said "nothing ran", because this gate did not run either.
   //
-  // Pinned rather than reasoned about in a comment, because the two files are
-  // edited independently and the failure is silent in both directions.
+  // So test.yml keeps `branches: [main]` (a stacked PR should not pay for the
+  // whole suite on every push) while THIS job must run on every base, so it
+  // can observe a stacked PR's total lane absence and fail loud rather than
+  // being silently skipped alongside it. Pinned rather than reasoned about in
+  // a comment, because the two files are edited independently.
   const own = readFileSync(join(REPO_ROOT, '.github/workflows/pr-review-signal.yml'), 'utf8');
   const testYml = readFileSync(TEST_YML, 'utf8');
   const branchesOf = (text) => /^\s*branches:\s*(\[.*\])\s*$/m.exec(text)?.[1];
-  const mine = branchesOf(own);
-  const theirs = branchesOf(testYml);
-  assert.ok(mine, 'pr-review-signal.yml must declare an explicit base-branch filter');
-  assert.ok(theirs, 'test.yml must declare an explicit base-branch filter');
   assert.equal(
-    mine,
-    theirs,
-    'the gate must run on exactly the base branches whose lanes it requires',
+    branchesOf(own),
+    undefined,
+    'pr-review-signal.yml must not declare a base-branch filter -- it has to run on stacked PRs to catch them',
+  );
+  assert.ok(
+    branchesOf(testYml),
+    'test.yml is expected to keep its own base-branch filter; this test documents the asymmetry, not test.yml\'s scope',
   );
 });
 

--- a/scripts/lib/pr-review-signal.mjs
+++ b/scripts/lib/pr-review-signal.mjs
@@ -848,3 +848,102 @@ export function flattenCheckRunPages(pages, where) {
   }
   return out;
 }
+
+// -------------------------------------------------- workflow trigger parsing
+
+/**
+ * Which base-branch filter keys, if any, sit on a workflow's `pull_request`
+ * trigger -- `branches`, `branches-ignore`, or neither. Located structurally,
+ * by indentation depth, rather than matched against one hard-coded spelling
+ * of the value.
+ *
+ * #3433 caught the previous version of this check reading `branches: [main]`
+ * (a flow sequence on one line) but not the equivalent block form:
+ *
+ *   branches:
+ *     - main
+ *
+ * GitHub Actions treats both identically, so a regex that only recognises one
+ * spelling can be defeated just by reformatting. This function never inspects
+ * the VALUE of `branches` / `branches-ignore` at all, so every spelling GitHub
+ * Actions accepts for it -- flow sequence, block sequence, a single
+ * unbracketed scalar, a quoted string, an alias -- is covered the same way:
+ * by finding the KEY at the right nesting depth under `on.pull_request` and
+ * not caring what comes after its colon.
+ *
+ * This is not a general YAML parser -- deliberately: the workflow that runs
+ * this file's own tests (`pr-review-signal.yml`) has NO `pnpm install` step,
+ * on purpose, so that a gate whose job is to notice when other jobs did not
+ * run depends on as little as possible. A `js-yaml` version of this function
+ * shipped once and broke exactly that job (`ERR_MODULE_NOT_FOUND` -- no
+ * install means no third-party import resolves). Node builtins only.
+ *
+ * @param {string} workflowYaml - a workflow file's full text.
+ * @returns {string[]} - `[]`, `['branches']`, `['branches-ignore']`, or (an
+ *   invalid but not this function's place to reject) both.
+ */
+export function pullRequestBranchFilterKeys(workflowYaml) {
+  const lines = workflowYaml.split(/\r?\n/);
+  const indentOf = (line) => /^[ ]*/.exec(line)[0].length;
+  const isBlankOrComment = (line) => {
+    const trimmed = line.trim();
+    return trimmed === '' || trimmed.startsWith('#');
+  };
+
+  // The top-level `on:` key -- column 0, so no leading whitespace.
+  const onIdx = lines.findIndex((line) => /^(?:on|'on'|"on"):/.test(line));
+  if (onIdx === -1) return [];
+
+  // Its block runs until the next column-0 key (a sibling of `on:`), or EOF.
+  let onEnd = lines.length;
+  for (let i = onIdx + 1; i < lines.length; i++) {
+    if (isBlankOrComment(lines[i])) continue;
+    if (indentOf(lines[i]) === 0) {
+      onEnd = i;
+      break;
+    }
+  }
+
+  // `pull_request:` somewhere inside the `on:` block.
+  let pullRequestIdx = -1;
+  let pullRequestIndent = -1;
+  for (let i = onIdx + 1; i < onEnd; i++) {
+    if (isBlankOrComment(lines[i])) continue;
+    const match = /^([ ]*)pull_request:/.exec(lines[i]);
+    if (match) {
+      pullRequestIdx = i;
+      pullRequestIndent = match[1].length;
+      break;
+    }
+  }
+  if (pullRequestIdx === -1) return [];
+
+  // Its body: every following line indented deeper than it, until one that
+  // is not (a sibling of `pull_request:`, e.g. `push:`), or the end of the
+  // `on:` block.
+  let bodyEnd = onEnd;
+  for (let i = pullRequestIdx + 1; i < onEnd; i++) {
+    if (isBlankOrComment(lines[i])) continue;
+    if (indentOf(lines[i]) <= pullRequestIndent) {
+      bodyEnd = i;
+      break;
+    }
+  }
+
+  // Direct children of `pull_request:` all share ONE indentation depth --
+  // the first body line's. Anything deeper belongs to a key's own value (a
+  // block sequence item, a nested flow collection continued on its own
+  // line, ...), not to a sibling key, so it is never mistaken for one.
+  let childIndent = -1;
+  const keys = [];
+  for (let i = pullRequestIdx + 1; i < bodyEnd; i++) {
+    if (isBlankOrComment(lines[i])) continue;
+    const indent = indentOf(lines[i]);
+    if (childIndent === -1) childIndent = indent;
+    if (indent !== childIndent) continue;
+    const match = /^[ ]*([A-Za-z0-9_-]+):/.exec(lines[i]);
+    if (match) keys.push(match[1]);
+  }
+
+  return ['branches', 'branches-ignore'].filter((key) => keys.includes(key));
+}

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -29,6 +29,7 @@ import {
   flattenCheckRunPages,
   STALE_REVIEW_POLICIES,
   SETTLE_HOLD_SECONDS,
+  pullRequestBranchFilterKeys,
 } from './pr-review-signal.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -1109,4 +1110,67 @@ test('FAIL CLOSED: a check-run walk that did not complete is NO_CHECK_RUNS', () 
       `pages ${JSON.stringify(bad)}`,
     );
   }
+});
+
+// ------------------------------------------- workflow base-branch filter (#3433)
+
+/**
+ * A regex over source text (`/^\s*branches:\s*(\[.*\])\s*$/m`) is what this
+ * function replaced. Measured against that regex directly, BEFORE this fix,
+ * to pin the failure it left rather than merely describe it: a `branches:`
+ * key written as a block sequence produced NO match, so a guard asserting
+ * "no base-branch filter present" stayed green over a workflow that in fact
+ * had one. #3433 measured this exact gap live on `pr-review-signal.yml` — the
+ * regression suite ran 48/48 with the filter reintroduced in block style, and
+ * only caught it (47/48) when the filter was reintroduced inline.
+ */
+const OLD_TEXT_REGEX_BRANCHES_OF = (text) => /^\s*branches:\s*(\[.*\])\s*$/m.exec(text)?.[1];
+
+test('RED: the old text-regex guard misses the block-sequence spelling (#3433)', () => {
+  const inline = 'on:\n  pull_request:\n    branches: [main]\n';
+  const block = 'on:\n  pull_request:\n    branches:\n      - main\n';
+  assert.ok(
+    OLD_TEXT_REGEX_BRANCHES_OF(inline),
+    'sanity: the old regex does catch the inline spelling it was written for',
+  );
+  assert.equal(
+    OLD_TEXT_REGEX_BRANCHES_OF(block),
+    undefined,
+    'this is the hole: the old regex reports NO filter on a workflow that has one, because the ' +
+      'value is a block sequence rather than `[...]` on the same line',
+  );
+});
+
+test('pullRequestBranchFilterKeys: every spelling GitHub Actions accepts resolves to `branches`', () => {
+  const cases = {
+    'inline flow sequence': 'on:\n  pull_request:\n    branches: [main]\njobs:\n  x: {}\n',
+    'block sequence': 'on:\n  pull_request:\n    branches:\n      - main\njobs:\n  x: {}\n',
+    'quoted flow sequence': 'on:\n  pull_request:\n    branches: ["main"]\njobs:\n  x: {}\n',
+    'single unbracketed scalar': 'on:\n  pull_request:\n    branches: main\njobs:\n  x: {}\n',
+    'reached through an alias': [
+      'anchors:',
+      '  bases: &bases [main]',
+      'on:',
+      '  pull_request:',
+      '    branches: *bases',
+      'jobs:',
+      '  x: {}',
+      '',
+    ].join('\n'),
+  };
+  for (const [label, yamlText] of Object.entries(cases)) {
+    assert.deepEqual(pullRequestBranchFilterKeys(yamlText), ['branches'], label);
+  }
+});
+
+test('pullRequestBranchFilterKeys: `branches-ignore` is its own key with the same filtering effect', () => {
+  const yamlText = 'on:\n  pull_request:\n    branches-ignore: [dev]\njobs:\n  x: {}\n';
+  assert.deepEqual(pullRequestBranchFilterKeys(yamlText), ['branches-ignore']);
+});
+
+test('pullRequestBranchFilterKeys: no filter on the trigger reports empty, not a false positive', () => {
+  const noFilter = 'on:\n  pull_request:\n    types: [opened]\njobs:\n  x: {}\n';
+  const bareTrigger = 'on:\n  pull_request:\njobs:\n  x: {}\n';
+  assert.deepEqual(pullRequestBranchFilterKeys(noFilter), []);
+  assert.deepEqual(pullRequestBranchFilterKeys(bareTrigger), []);
 });


### PR DESCRIPTION
## The defect

`test.yml` triggers on `pull_request: branches: [main]` — a **base**-branch filter — so a PR stacked on another PR's branch never runs it. Check counts from PRs open at the same moment:

| PR | base | checks |
|---|---|---|
| #3427 | `main` | **26** |
| #3405 | `fix-3338-isolate-expansion-gate` | 8 |
| #3428 | `fix/3351-anonymizer-leaks` | 8 |
| #3432 | `fix-3395-express-id-above-u32` | 6 |

On the stacked ones, Typecheck / Lint / Node tests / Rust tests appear neither as failures nor as skips. They are absent, and an absent lane contributes no row to compare against — so `gh pr checks` returns no failures and `mergeable: MERGEABLE`, with nothing distinguishing "the lanes passed" from "the lanes never ran". I reported two of my own stacked PRs as CI-clean on exactly that basis before counting the rows.

Stacking is not a rare shape here: #3383, #3405, #3410, #3428 and #3432 were all stacked within a day, several by the maintainer, because a fix depending on an unmerged fix is the natural way to sequence the work.

## The change

`pr-review-signal.yml` loses its `branches:` filter and now fires on every base. Nothing else changes about what it checks.

This job already knows how to report total absence — that is the #3294 shape it was built for. So on a stacked PR every lane it derives from `test.yml` comes back missing, and it reports `MISSING_LANES` and exits non-zero.

**Why not widen `test.yml` instead.** That pays CI minutes on every push to every stack, for coverage that is largely redundant once the PR is retargeted. The problem here is not that the lanes do not run on a stack — it is that nobody can tell they did not.

**Why a red check is the right outcome and not new noise.** The required-status-checks ruleset is configured against `main` and applies only when a PR's base *is* the protected ref. So this going red on a feature-based PR is a visible row, not an enforced gate; it becomes enforcing the moment the PR is retargeted to `main`, exactly as before. That is the trade #3429 asks for: silence converted into a visible failure.

The prior reasoning — recorded in this file's own comment — was that widening would fail every stacked PR "for a reason that is not a defect". That is true and it is the point: legitimately absent is precisely the fact a reviewer needs surfaced, not grounds for suppressing the gate that surfaces it. Filtering the detector the same way as the thing it detects reproduces the silence in the one place meant to catch it. The comment has been rewritten to say so rather than left to be rediscovered.

## Verification

- `node --test scripts/check-pr-review-signal.test.mjs` — **48 passed, 0 failed**.
- The `on:` block carries no `branches:` filter (the remaining mentions in this file are prose in the doc comment explaining the history).

**What I could not verify here:** that a real stacked PR shows the red row. That takes a live run against this workflow once merged. The mechanism is the script's existing absence path plus the removed filter, both exercised by the suite above, but the end-to-end behaviour is asserted from those parts rather than observed. This PR is itself based on `main`, so it cannot demonstrate the stacked case on its own.

Fixes #3429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull requests targeting branches other than `main` now receive accurate review-signal status reporting.
  * Missing test lanes on stacked pull requests are clearly identified, with guidance to retarget the pull request to `main`.
  * Improved handling for pull request edits and readiness changes across all target branches.
* **Tests**
  * Added regression coverage for stacked pull requests and branch-filter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->