### PR TITLE
docs(geometry): correct the closure-check comment that claims a live nondeterminism

### DIFF
--- a/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
+++ b/rust/geometry/src/router/voids/prism_cut/closure_checks.rs
@@ -76,11 +76,13 @@ pub(super) fn closed_or_hairline(mesh: &Mesh) -> bool {
     // Canonicalize to undirected segments with a net sign.
     //
     // Sorted by endpoint key, NOT left in `edges` iteration order: `FxHashMap`
-    // iterates target-dependently, and the length sort below is not a total order,
-    // so equal-length segments would seed the line grouping in an arbitrary order
-    // that differs between native and wasm32. The grouping is greedy, so a
-    // different seed can reach a different verdict. (Pre-existing; surfaced when
-    // this moved out of `prism_cut.rs`.)
+    // iterates target-dependently, and the grouping below is greedy, so an
+    // arbitrary seed order could reach a different verdict on native than on
+    // wasm32. This sort closes that: `edges` is keyed by `(K, K)`, so every
+    // `(a, b)` pushed here is unique and the sort key is tie-free -- an unstable
+    // sort with a tie-free key yields one deterministic sequence whatever order
+    // the map was walked in. The length sort that seeds the grouping is a total
+    // order too, by its own index tie-break; see the comment there.
     let mut bad: Vec<(K, K, i64)> = Vec::new();
     for (&(a, b), &c) in edges.iter() {
         if c > 0 {


### PR DESCRIPTION
## Summary

`closed_or_hairline`'s canonicalisation comment claims a live native-vs-wasm32 nondeterminism:

> `FxHashMap` iterates target-dependently, and the length sort below is not a total order, so equal-length segments would seed the line grouping in an arbitrary order that differs between native and wasm32. The grouping is greedy, so a different seed can reach a different verdict.

Both halves are wrong, and were wrong when written.

**The hazard is closed.** `edges` is an `FxHashMap` keyed by `(K, K)`, so every `(a, b)` pushed into `bad` is unique and `sort_unstable_by_key(|&(a, b, _)| (a, b))` has a tie-free key. An unstable sort with a tie-free key produces exactly one sequence regardless of the order the map was walked in. Everything downstream — `segs`, `order`, the greedy grouping, the per-line breaks, the `i64` multiplicity sum — consumes only `Vec`s built in that order, and no other hash container is iterated in the function.

**The "not a total order" claim is contradicted seventy lines below**, in the same file:

```rust
// `total_cmp` + index tie-break: a total order, so the seed sequence is a
// pure function of `bad` (already canonically sorted above).
lj.total_cmp(&li).then(i.cmp(&j))
```

Indices are always distinct, so that comparator is a genuine total order.

**Both were introduced by the same commit.** `443d819b6` added the endpoint-key sort, the index tie-break, the comment saying the hazard is live, *and* the comment saying it is closed — and its own message describes the issue as "Canonicalised". So the file has been self-contradicting since that commit landed.

## Why this is worth a PR on its own

The comment reads as a live correctness hazard in a gate that decides whether the analytic prism fast path is accepted — i.e. it implies the browser and the CLI could disagree about whether a cut succeeded. I flagged it as exactly that while investigating #3435, and it cost an investigation to establish that it is not true. Leaving it costs the next reader the same.

No behaviour change: comment only.

## Verification

`rustfmt --check` clean on the touched file, `node scripts/check-module-size.mjs` clean. No perf verdict applies — this touches no executable code.

Refs #3435


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that deterministic edge sorting and tie-breaking ensure consistent hairline grouping across native and WebAssembly environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->