### PR TITLE
test(geometry): pin that closed_or_hairline and the undirected balance disagree on a T-junction

### DIFF
--- a/rust/geometry/src/router/voids/prism_cut_tests.rs
+++ b/rust/geometry/src/router/voids/prism_cut_tests.rs
@@ -663,6 +663,94 @@ fn hairline_true_collinear_cover_still_accepted() {
     );
 }
 
+/// The census's undirected ±1 edge balance (#3435), reimplemented here on
+/// purpose rather than imported: the real one, `edge_stats` in
+/// `rust/geometry/tests/triangulation_invariance.rs`, lives in the
+/// integration-test binary of this crate, which a `src` unit-test module
+/// cannot depend on (it is a separate compilation target, built after the
+/// library). This mirrors only the `open` field of that struct — count an
+/// undirected edge (grid-quantized like `closed_or_hairline`'s own key, so
+/// the two predicates read the identical triangle soup) as open when its
+/// forward and reverse use counts differ — and is intentionally a second copy
+/// of the same one-line rule `edge_stats` already states; that duplication is
+/// exactly the shape #3435 is about, not an accident of this test.
+fn undirected_open_edge_count(mesh: &Mesh) -> usize {
+    type K = (i64, i64, i64);
+    let key = |i: u32| -> K {
+        let b = i as usize * 3;
+        let q = |v: f32| (v as f64 / 1.0e-4).round() as i64;
+        (
+            q(mesh.positions[b]),
+            q(mesh.positions[b + 1]),
+            q(mesh.positions[b + 2]),
+        )
+    };
+    let mut uses: std::collections::HashMap<(K, K), (u32, u32)> = std::collections::HashMap::new();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (key(tri[0]), key(tri[1]), key(tri[2]));
+        if a == b || b == c || c == a {
+            continue;
+        }
+        for (x, y) in [(a, b), (b, c), (c, a)] {
+            let e = uses.entry((x.min(y), x.max(y))).or_insert((0, 0));
+            if x < y {
+                e.0 += 1;
+            } else {
+                e.1 += 1;
+            }
+        }
+    }
+    uses.values().filter(|&&(f, r)| f != r).count()
+}
+
+/// #3435: `closed_or_hairline` and the census's undirected ±1 balance are two
+/// different definitions of "closed", and this mesh is the minimal witness
+/// that they DISAGREE.
+///
+/// Three triangles, sharing points `A=(0,0,0)`, `B=(10,0,0)`, `M=(5,0,0)`
+/// (collinear) and an off-line apex `C`:
+///   - `(A, B, C)` — one face using the FULL boundary edge `A→B`.
+///   - `(M, A, C)` and `(B, M, C)` — an adjacent face using the SAME boundary,
+///     but split at `M` and wound the other way, i.e. `M→A` then `B→M`.
+///
+/// Every edge touching `C` cancels exactly (each is walked once each
+/// direction across the three triangles), so the only uncancelled directed
+/// edges are `A→B`, `M→A`, `B→M` — a T-junction: one face's full-length edge,
+/// covered by the adjacent face's two sub-edges split at an interior point.
+/// This is the exact signature #3435 measured on host `#628727` in
+/// `ISSUE_068_ARK_NUS_skolebygg.ifc` (a 336 mm pier with two openings): a
+/// full-height edge collinearly covered by two sub-edges split off-centre,
+/// read `open=3` by the census while `try_prism_cut`'s own gate passed it.
+///
+/// `closed_or_hairline` ACCEPTS this by design (own module doc: uncancelled
+/// directed edges that net to zero everywhere along their shared line). The
+/// undirected ±1 balance calls all three of `{A,B}`, `{M,A}`, `{B,M}` open,
+/// because each pair is used only once total and has no reverse partner to
+/// balance against — it has no collinear-coverage step, so it cannot see that
+/// the "reverse" is split across two edges rather than missing.
+///
+/// This test does not say which reading is right — #3435 tracks that
+/// decision — it pins that they currently disagree, so a change to either
+/// definition has to touch this assertion on purpose.
+#[test]
+fn t_junction_hairline_accepted_but_undirected_balance_reports_open() {
+    let a = [0.0, 0.0, 0.0];
+    let b = [10.0, 0.0, 0.0];
+    let m = [5.0, 0.0, 0.0];
+    let c = [0.0, 1.0, 1.0];
+    let mesh = mesh_from_tris(&[[a, b, c], [m, a, c], [b, m, c]]);
+
+    assert!(
+        closed_or_hairline(&mesh),
+        "closed_or_hairline must accept the T-junction (its own hairline contract)"
+    );
+    assert_ne!(
+        undirected_open_edge_count(&mesh),
+        0,
+        "the undirected ±1 balance must call the same mesh open (no collinear-coverage step)"
+    );
+}
+
 /// Minimal single-slab unit-square `PrismFrame`, for exercising
 /// `try_merge_prisms` directly without routing through a full mesh.
 fn square_frame(d: V3, u: V3, v: V3, d0: f64, d1: f64) -> PrismFrame {


### PR DESCRIPTION
## What this pins

Issue #3435 established that this repo has two different definitions of "closed" for a triangle mesh, and they disagree:

- `closed_or_hairline` (`rust/geometry/src/router/voids/prism_cut/closure_checks.rs`), the acceptance gate for `try_prism_cut`'s analytic fast path, deliberately **accepts** a T-junction. Its own doc comment:

  > uncancelled directed edges that, viewed as a 1-D SIGNED measure along each supporting line, net to ZERO everywhere … two adjacent faces subdividing a shared line differently.

- The census's `edge_stats` (`rust/geometry/tests/triangulation_invariance.rs`) uses a ±1 signed balance per *undirected* edge with no collinear-coverage step, so the identical mesh reads **open**.

Measured consequence (from the #3435 investigation): host `#628727` in `ISSUE_068_ARK_NUS_skolebygg.ifc`, a 336 mm pier with two non-overlapping rectangular openings, passes the prism gate and ships with `open=3`. All three open edges lie on one vertical line, a full-height edge collinearly covered by two sub-edges split at an interior point (not the midpoint).

## The test

`t_junction_hairline_accepted_but_undirected_balance_reports_open` in `rust/geometry/src/router/voids/prism_cut_tests.rs` hand-builds the minimal three-triangle T-junction: one face's full boundary edge `A→B`, and an adjacent face's two sub-edges `M→A` / `B→M` covering the same boundary split at an interior point `M`. Every other edge (touching the shared apex `C`) cancels exactly, isolating the T-junction signature.

It asserts:
1. `closed_or_hairline` returns `true` (current, deliberate behaviour).
2. A local `undirected_open_edge_count` — a ±1 undirected balance mirroring only the `open` field of `edge_stats` — returns nonzero for the same mesh.

The `open` count on this minimal mesh is 3, matching the `open=3` measured on the real host.

**This does not fix anything.** #3435 tracks which definition should win; a fix that changes which meshes the prism gate accepts needs a full census run to validate, which there was no disk budget for today. This is the durable half: the disagreement is now asserted, so a change to either definition has to touch this test on purpose instead of drifting silently.

## Why the balance is reimplemented instead of imported

`edge_stats` lives in `rust/geometry/tests/triangulation_invariance.rs`, the crate's integration-test binary — a separate compilation target that a `src` unit-test module (`prism_cut_tests.rs`) cannot depend on. `undirected_open_edge_count` mirrors only the `open` field, using the same grid-quantized key as `closed_or_hairline` itself so both predicates read the identical triangle soup. The comment on it says explicitly that this is a second copy of the same one-line rule, and that the duplication is exactly the shape #3435 is about.

## Perf verdict

Test-only addition (`_tests.rs`, exempt from the module-size ratchet); no shipped path is touched, so no perf verdict applies.

## Verify

```
cargo test -p ifc-lite-geometry --lib t_junction_hairline_accepted_but_undirected_balance_reports_open
# test router::voids::prism_cut::tests::t_junction_hairline_accepted_but_undirected_balance_reports_open ... ok

cargo test -p ifc-lite-geometry --lib hairline
# 4 passed; 0 failed

cargo test -p ifc-lite-processing --test module_size_ratchet
# 6 passed; 0 failed
```

Refs #3435