### PR TITLE
fix(export): drop IfcPropertyReferenceValue references into excluded territory

### DIFF
--- a/.changeset/pset-reference-into-excluded-address.md
+++ b/.changeset/pset-reference-into-excluded-address.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/export': patch
+---
+
+Fix `exportAnonymizedSubset` emitting a dangling `IFCPROPERTYREFERENCEVALUE` reference when a kept property's `PropertyReference` pointed at an `IfcPostalAddress`/`IfcTelecomAddress` the anonymization excluded (#3439).
+
+The subset closure already refuses to walk into an excluded id, so the address itself was correctly dropped from the output — but the `IfcPropertyReferenceValue` entity naming it was still copied to the output verbatim, because the dangling-reference repair only ever rewrote `IfcRel*` lines (the same gap #3351 found for a direct `IfcSite`/`IfcBuilding` attribute slot). The result was a `#N` with no `#N=` line for that address, an invalid STEP file some readers reject outright.
+
+`exportAnonymizedSubset` now nulls `PropertyReference` on any `IfcPropertyReferenceValue` whose target the exclusion left out, before the export closure runs — `PropertyReference` is optional, so there is no relationship-style "withhold the whole entity" fallback needed. Reported as `AnonymizeResult.stats.droppedPropertyReferenceIds`. A property whose value pointed at legitimately-included territory (e.g. an included building's own address) is unaffected.
+
+Checked the rest of `IfcObjectReferenceSelect` (the type `PropertyReference` accepts) and the sibling property-value classes (`IfcPropertyBoundedValue`, `IfcPropertyEnumeratedValue`, `IfcPropertyListValue`, `IfcComplexProperty`): `IfcAddress` is the only member of that select ever excludable by this feature, and no sibling class's own reference-typed attribute (`EnumerationReference`, `Unit`, nested `HasProperties`) ever names an excludable type, so this closes the whole gap rather than one instance of a wider one.

--- a/packages/export/src/anonymize-export.test.ts
+++ b/packages/export/src/anonymize-export.test.ts
@@ -152,6 +152,9 @@ DATA;
 #40=IFCMATERIAL('Concrete',$,'Category Marigold');
 #90=IFCELEMENTASSEMBLY('${guid(90)}',#74,'Assembly Cobalt',$,$,$,$,$,$,.RIGID.);
 #91=IFCPLATE('${guid(91)}',#74,'Plate Vertex',$,$,$,$,$,$);
+#95=IFCPROPERTYSET('${guid(95)}',#74,'Pset_AddressRef',$,(#96));
+#96=IFCPROPERTYREFERENCEVALUE('AddressRef',$,$,#51);
+#97=IFCRELDEFINESBYPROPERTIES('${guid(97)}',#74,$,$,(#6),#95);
 #50=IFCPOSTALADDRESS($,$,$,$,('742 Fictitious Lane'),$,'Fictitious Falls','Fictitious Province','00000','Fictitious Country');
 #51=IFCPOSTALADDRESS($,$,$,$,('99 Imaginary Boulevard'),$,'Imaginary Heights','Imaginary Province','11111','Imaginary Country');
 #52=IFCPROJECTEDCRS('EPSG:FICTITIOUS-9999',$,$,$,$,$,$);
@@ -442,6 +445,52 @@ describe('exportAnonymizedSubset — occurrence-owned property sets reaching inc
     expect(result.stats.droppedPropertySetIds).toEqual([]);
     expect(content).toContain('jane.doe@acme-corp.example');
     expect(findDanglingRefs(content)).toEqual([]);
+  });
+});
+
+describe('exportAnonymizedSubset — IfcPropertyReferenceValue into an excluded target (#3439)', () => {
+  it('nulls a directly included property reference rather than emitting a dangling reference', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const result = exportAnonymizedSubset(store, new Set([1, 3, 95, 96]), {
+      keepPropertySets: true,
+      guidRandom: seededRandom(13),
+    });
+    const content = decode(result.content);
+
+    expect(findDanglingRefs(content)).toEqual([]);
+    expect(content).not.toContain('99 Imaginary Boulevard');
+    expect(lineArgs(content, 96)[3]).toBe('$');
+    expect(result.stats.droppedPropertyReferenceIds).toEqual([96]);
+  });
+
+  it('nulls a property value reached through an included defining relationship and property set', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const result = exportAnonymizedSubset(store, new Set([1, 3, 6, 95, 97]), {
+      keepPropertySets: true,
+      guidRandom: seededRandom(16),
+    });
+    const content = decode(result.content);
+
+    // #96 is deliberately not a caller seed. The exporter reaches it through
+    // #97 -> #95, so sanitization must run over the forward closure too.
+    expect(content).toContain('#96=IFCPROPERTYREFERENCEVALUE');
+    expect(findDanglingRefs(content)).toEqual([]);
+    expect(lineArgs(content, 96)[3]).toBe('$');
+    expect(result.stats.droppedPropertyReferenceIds).toEqual([96]);
+  });
+
+  it('leaves a property reference intact when the target is legitimately included', async () => {
+    const store = await parse(FIXTURE_MODEL);
+    const result = exportAnonymizedSubset(store, new Set([1, 3, 95, 96]), {
+      keepPropertySets: true,
+      removeGeoreferencing: false,
+      guidRandom: seededRandom(15),
+    });
+    const content = decode(result.content);
+
+    expect(findDanglingRefs(content)).toEqual([]);
+    expect(lineArgs(content, 96)[3]).toBe('#51');
+    expect(result.stats.droppedPropertyReferenceIds).toEqual([]);
   });
 });
 

--- a/packages/export/src/anonymize-export.ts
+++ b/packages/export/src/anonymize-export.ts
@@ -50,8 +50,12 @@ import { MutablePropertyView, StoreEditor } from '@ifc-lite/mutations';
 import type { IfcSchemaVersion } from './schema-converter.js';
 import { getEffectiveEntityIndex, type EffectiveEntityIndex } from './effective-index.js';
 import { getSubsetEntityIds, IFC_ROOT_TYPES, identifyingTypesFor } from './subset-roots.js';
-import { readEntityArgs } from './subset-entity-reader.js';
-import { refGroupFromArg, relationshipRefsSurviveExclusion } from './reference-collector.js';
+import { attrIndex, readEntityArgs, stepSourceSchema } from './subset-entity-reader.js';
+import {
+  collectReferencedEntityIds,
+  refGroupFromArg,
+  relationshipRefsSurviveExclusion,
+} from './reference-collector.js';
 import { applyPlacementAnonymization } from './anonymize-placement.js';
 import { applyScrub } from './anonymize-scrub.js';
 import { StepExporter } from './step-exporter.js';
@@ -111,6 +115,39 @@ function excludePropertySetsUnlessKept(
   }
   droppedPropertySetIds.sort((a, b) => a - b);
   return { includedIds: kept, droppedPropertySetIds };
+}
+
+/**
+ * Null `PropertyReference` when an emitted `IfcPropertyReferenceValue` names
+ * an entity the subset excludes. The value can be reached by the forward
+ * closure rather than appearing in the caller's seed set, hence `closureIds`.
+ */
+function dropExcludedPropertyReferences(
+  store: { readonly source: IfcSourceBytes },
+  index: EffectiveEntityIndex,
+  closureIds: ReadonlySet<number>,
+  excludedIds: ReadonlySet<number>,
+  view: MutablePropertyView,
+  schema: ReturnType<typeof stepSourceSchema>,
+): number[] {
+  const droppedIds: number[] = [];
+
+  for (const id of closureIds) {
+    if ((index.typeOf(id) ?? '') !== 'IFCPROPERTYREFERENCEVALUE') continue;
+    const record = readEntityArgs(store, index, id);
+    if (!record) continue;
+
+    const idx = attrIndex('IFCPROPERTYREFERENCEVALUE', 'PropertyReference', schema);
+    if (idx === -1 || idx >= record.args.length) continue;
+
+    const ref = refGroupFromArg(record.args[idx]);
+    if (typeof ref !== 'number' || !excludedIds.has(ref)) continue;
+
+    view.setPositionalAttribute(id, idx, null);
+    droppedIds.push(id);
+  }
+
+  return droppedIds;
 }
 
 /**
@@ -216,13 +253,30 @@ export function exportAnonymizedSubset(
     psetFilteredIds,
   );
 
+  const subsetIdentifyingTypes = identifyingTypesFor(options?.removeGeoreferencing !== false);
+  const subset = getSubsetEntityIds(index, finalIncludedIds, subsetIdentifyingTypes);
+  const exportClosure = collectReferencedEntityIds(
+    subset.roots,
+    store.source,
+    index,
+    subset.excludedIds,
+  );
+  const droppedPropertyReferenceIds = dropExcludedPropertyReferences(
+    store,
+    index,
+    exportClosure,
+    subset.excludedIds,
+    view,
+    stepSourceSchema(store.schemaVersion),
+  );
+
   const placementResult = applyPlacementAnonymization(store, index, finalIncludedIds, editor, view, options);
   const scrubResult = applyScrub(store, index, finalIncludedIds, view, options);
 
   const exportResult = new StepExporter(store, view).export({
     schema: store.schemaVersion as IfcSchemaVersion,
     subsetEntityIds: finalIncludedIds,
-    subsetIdentifyingTypes: identifyingTypesFor(options?.removeGeoreferencing !== false),
+    subsetIdentifyingTypes,
     filename: options.filename ?? 'anonymized.ifc',
     // Header scrub per the decision doc: author/organization/authorization
     // blanked outright (never inherited from the source header — an empty
@@ -250,6 +304,7 @@ export function exportAnonymizedSubset(
       includedRootEntityCount,
       prunedRelationshipIds,
       droppedPropertySetIds,
+      droppedPropertyReferenceIds,
       zeroedPlacements: placementResult.zeroedPlacements,
       warnings: [
         ...placementResult.warnings,

--- a/packages/export/src/anonymize-types.ts
+++ b/packages/export/src/anonymize-types.ts
@@ -221,6 +221,10 @@ export interface AnonymizeResult {
      *  property set" from any other exclusion reason without grepping
      *  `warnings` text. Empty when `keepPropertySets` was `true`. */
     droppedPropertySetIds: number[];
+    /** ExpressIds of emitted `IfcPropertyReferenceValue` entities whose
+     *  optional `PropertyReference` was nulled because it named an entity the
+     *  subset excluded. */
+    droppedPropertyReferenceIds: number[];
     /** Each root `IfcLocalPlacement` this export zeroed, and the translation
      *  it zeroed (the ORIGINAL, pre-zero coordinates) — reported because the
      *  translation was real coordinate data the caller may still want to log


### PR DESCRIPTION
## Fix

`exportAnonymizedSubset` already nulled an `IfcPropertyReferenceValue.PropertyReference` when the value entity itself was in the caller-supplied seed set and its target was excluded. That missed property values reached only by StepExporter’s forward closure: an included `IfcRelDefinesByProperties` can point at an included `IfcPropertySet`, which then points at an unseeded `IfcPropertyReferenceValue`. The exporter emitted that value verbatim, leaving a dangling reference to an excluded `IfcPostalAddress`.

The sanitization pass now derives the same subset closure from the final seed set that `StepExporter` uses, then scans the closure for `IfcPropertyReferenceValue` entities. A reference into excluded territory is still nulled (the EXPRESS attribute is optional), while references to retained targets remain untouched.

## Regression coverage

The regression seeds an `IfcRelDefinesByProperties` and its property set but deliberately does not seed the contained property value. It proves the exporter reaches that value through the relationship/property-set closure, emits it with `PropertyReference = $`, has no dangling references, and reports that property value in `droppedPropertyReferenceIds`.

## Validation

- `@ifc-lite/export` portion of root `pnpm test` — pass: 80 files passed, 2 skipped; 1,050 tests passed, 30 skipped.
- The complete root `pnpm test` was blocked by six unrelated `@ifc-lite/viewer-embed` suites: `localStorage` was undefined in the fresh local Node environment during module initialization. This PR does not touch viewer/embed code.
- `git diff --check` — pass.

Fresh CI is required on this rebased head.

Fixes #3439


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed anonymized exports that could contain invalid dangling property references.
  * Property references to excluded addresses are now safely cleared, preventing leaked address data and invalid STEP files.
  * References remain intact when their target entities are retained.

* **Enhancements**
  * Export results now report property-reference IDs removed during anonymization, making these adjustments easier to identify and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->