### PR TITLE
fix(core): correct encode_ifc_string's doc so it stops recommending unsafe literal use

### DIFF
--- a/rust/core/src/step_encoding.rs
+++ b/rust/core/src/step_encoding.rs
@@ -138,11 +138,26 @@ pub fn decode_ifc_string(s: &str) -> Cow<'_, str> {
 }
 
 /// Encode a UTF-8 string back to IFC STEP escapes. Inverse of
-/// [`decode_ifc_string`] for the canonical (non-overlong) forms; kept for STEP
-/// writers and round-trip tests.
+/// [`decode_ifc_string`] for the canonical (non-overlong) forms.
 ///
 /// Printable ASCII is preserved; everything else (and backslash) is escaped as
 /// `\X\HH`, `\X2\HHHH\X0\`, or `\X4\HHHHHHHH\X0\` by code point.
+///
+/// This is escape encoding only — it does NOT double the apostrophe (`'`,
+/// 0x27 is printable ASCII and passes through unchanged). Its output is
+/// therefore **not** safe to place directly inside a STEP single-quoted
+/// string literal: an undoubled `'` terminates the literal early and
+/// produces a file no conformant reader parses as intended (e.g. a name like
+/// `O'Brien`). A caller that writes into a literal must double `'` itself,
+/// or use `step_text::escape` in `ifc-lite-export` (re-exported as
+/// `escape_step_string`), which handles the full literal-context contract:
+/// doubling `'` and `\`, mapping control characters to a space, and encoding
+/// non-ASCII — per ISO 10303-21 6.3.3.4. The two functions do not produce
+/// the same output for the same input; do not assume they agree.
+///
+/// Kept for round-trip tests (`decode_ifc_string(encode_ifc_string(s)) ==
+/// s`), which hold regardless of apostrophe handling because doubling is a
+/// literal-context requirement, not an encoding one.
 pub fn encode_ifc_string(s: &str) -> Cow<'_, str> {
     if s.bytes().all(|b| (0x20..=0x7E).contains(&b) && b != b'\\') {
         return Cow::Borrowed(s);
@@ -263,5 +278,16 @@ mod tests {
         for s in ["plain", "Br\u{FC}cke", "\u{1F600}", "a\u{E9}b"] {
             assert_eq!(decode_ifc_string(&encode_ifc_string(s)), s);
         }
+    }
+
+    #[test]
+    fn encode_does_not_double_the_apostrophe() {
+        // Pins the documented contract: `encode_ifc_string` is escape
+        // encoding only, not literal-safe. `'` is printable ASCII and passes
+        // through unchanged (unlike `step_text::escape`, which doubles it).
+        // A behaviour change here is a deliberate decision, not a silent one
+        // (issue #3445).
+        assert_eq!(encode_ifc_string("'"), "'");
+        assert_eq!(encode_ifc_string("O'Brien"), "O'Brien");
     }
 }


### PR DESCRIPTION
## What

`encode_ifc_string` in `rust/core/src/step_encoding.rs` was documented as:

> Inverse of `decode_ifc_string` for the canonical (non-overlong) forms; kept for STEP writers and round-trip tests.

That doc actively recommends the function for a use it does not support safely. It preserves printable ASCII except backslash, so `'` (0x27) passes through undoubled in both its fast path and its escape loop. An undoubled apostrophe inside a STEP single-quoted literal terminates the literal early, so any writer that follows the doc's guidance emits malformed STEP for a string like `O'Brien`.

Measured against the export writer's `step_text::escape` (`rust/export/src/step_text.rs`) on the same inputs:

| input | `step_text::escape` | `encode_ifc_string` |
|---|---|---|
| `'` | `''` | `'` |
| TAB | `' '` | `\X\09` |
| `\` | `\\` | `\X\5C` |
| `Ä` | `\X2\00C4\X0\` | `\X\C4` |

The apostrophe row is the one that matters for correctness — the others are encoding-style differences that still round-trip. The two functions **do not produce the same output for the same input**; this fix does not claim otherwise (a previous changelog made that mistake, corrected in #3444).

## Why the doc, not the behaviour

Of the three options in #3445, this implements **option 2: correct the documentation**, not option 1 (double the apostrophe) or option 3 (add a separate literal-safe encoder):

- `encode_ifc_string` is public API (re-exported from the crate root). Changing its output could break external consumers depending on the current escape-only encoding.
- The existing round-trip test (`decode_ifc_string(encode_ifc_string(s)) == s`) passes regardless of apostrophe doubling, because doubling is a *literal-context* requirement, not an encoding one — a behaviour change here would not be caught by that test and would need its own, and is a call that turns on external dependents this repo can't see.
- A doc fix costs nothing and removes the trap immediately.

## Reachability

**No production caller exists.** `git grep encode_ifc_string -- rust/` finds only the `pub use` re-export in `lib.rs` and this module's own round-trip test. So this was a latent trap in public API, not a live bug — but it's the kind of trap that turns into one the moment someone follows the doc's advice.

## Change

- Rewrote the doc comment on `encode_ifc_string` to state plainly that it performs escape encoding only, that its output is **not** safe inside a STEP single-quoted literal, and that a caller writing into a literal must double `'` itself or use `step_text::escape` (`ifc-lite-export`, re-exported as `escape_step_string`) instead.
- Added a test, `encode_does_not_double_the_apostrophe`, pinning the current (undoubled) behaviour of `'`, so the documented contract and the test now agree and a future behaviour change is a deliberate decision, not a silent one. Asserts on the literal `'` and `O'Brien`, not on source text.
- No behaviour change to `encode_ifc_string`.

## Verification

```
$ cargo test -p ifc-lite-core --lib step_encoding
running 11 tests
test step_encoding::tests::drops_code_page_directive ... ok
test step_encoding::tests::keeps_unknown_escape ... ok
test step_encoding::tests::decodes_x_and_s ... ok
test step_encoding::tests::no_backslash_is_borrowed_and_unchanged ... ok
test step_encoding::tests::decodes_x4_astral ... ok
test step_encoding::tests::s_escape_before_multibyte_char_does_not_panic ... ok
test step_encoding::tests::encode_does_not_double_the_apostrophe ... ok
test step_encoding::tests::decodes_x2_surrogate_pair ... ok
test step_encoding::tests::decodes_x2_bmp ... ok
test step_encoding::tests::collapses_the_doubled_reverse_solidus ... ok
test step_encoding::tests::round_trips_through_encode ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 170 filtered out; finished in 0.00s
```

```
$ cargo clippy -p ifc-lite-core --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.37s
```
(clean, no warnings)

`rustfmt --check` on `rust/core/src/step_encoding.rs`: fails, but on a pre-existing line (`no_backslash_is_borrowed_and_unchanged`, untouched by this PR) that also fails at `main` before this change — confirmed by stashing this diff and re-running. Not introduced here.

```
$ node scripts/check-module-size.mjs
check-module-size: OK (2021 files measured, 306 allowlisted, 0 new over 400)
```

This is a doc-only change (plus one new unit test) — it touches no executable path reached by any current caller, so no perf verdict applies.

Fixes #3445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request review signals now run for pull requests targeting any branch.
  * Improved diagnostics distinguish stacked pull requests from retargeting issues and show the affected base branch.
  * STEP string encoding documentation and coverage now clarify apostrophe handling.

* **Tests**
  * Added coverage for stacked pull request detection and supported workflow branch-filter formats.
  * Added regression coverage for apostrophe preservation during encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->