### PR TITLE
ci: detect conflicted PRs whose pull_request CI never ran

### DIFF
--- a/.github/workflows/dirty-pr-scan.yml
+++ b/.github/workflows/dirty-pr-scan.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-name: Dirty PR CI visibility
+name: Silent PR CI visibility
 
 # DELIBERATELY NOT `pull_request` (issue #3443).
 #
@@ -21,6 +21,12 @@ name: Dirty PR CI visibility
 # changing how `pull_request` is gated. It makes the silence VISIBLE: a red
 # scheduled run in the Actions tab, on a fixed cadence, independent of any one
 # PR's state.
+#
+# It reports the OTHER cause of the same silence too, separately: `test.yml`
+# fires `pull_request` only for `branches: [main]`, so a PR stacked on a
+# feature branch has no lanes either, and a merge cannot give it any (#3429).
+# The two causes take opposite remedies -- retarget vs resolve -- so the scan
+# names which one fired rather than issuing one instruction for both.
 on:
   schedule:
     # Every 30 minutes. Cheap (two `gh` reads, no checkout of anything to
@@ -39,7 +45,7 @@ env:
 
 jobs:
   scan:
-    name: Scan open PRs for conflicted, CI-silent heads
+    name: Scan open PRs for CI-silent heads
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/dirty-pr-scan.yml
+++ b/.github/workflows/dirty-pr-scan.yml
@@ -26,7 +26,9 @@ name: Silent PR CI visibility
 # fires `pull_request` only for `branches: [main]`, so a PR stacked on a
 # feature branch has no lanes either, and a merge cannot give it any (#3429).
 # The two causes take opposite remedies -- retarget vs resolve -- so the scan
-# names which one fired rather than issuing one instruction for both.
+# names which one fired rather than issuing one instruction for both. A PR can
+# carry both at once, and then neither remedy works alone, so the scan says so
+# on that PR's own lines instead of leaving half of it for a later run.
 on:
   schedule:
     # Every 30 minutes. Cheap (two `gh` reads, no checkout of anything to
@@ -39,6 +41,16 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  # Declaring ANY `permissions:` block sets every scope not listed to `none`,
+  # and this scan's whole verdict rests on `statusCheckRollup` -- check-run and
+  # commit-status data, neither of which `pull-requests: read` covers. Without
+  # these two the job either dies with GH_ERROR or reads an empty rollup, and an
+  # empty rollup makes every conflicted PR look like it never ran a lane, which
+  # is the one false positive this gate is built to avoid (#3417/#3447 ran all
+  # 15 before going dirty). Same pair, for the same `gh --json
+  # statusCheckRollup` read, as pr-review-signal.yml.
+  checks: read
+  statuses: read
 
 env:
   ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node24

--- a/.github/workflows/dirty-pr-scan.yml
+++ b/.github/workflows/dirty-pr-scan.yml
@@ -1,0 +1,64 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Dirty PR CI visibility
+
+# DELIBERATELY NOT `pull_request` (issue #3443).
+#
+# Measured, not speculated: a PR whose `mergeable` reads `CONFLICTING` runs no
+# `pull_request` CI at all -- no red check, no message, the lanes are simply
+# absent. Pushing a new commit does not clear it; only resolving the conflict
+# does (an empty commit polled for five minutes on live PR #3389 left the
+# check count unchanged). If GitHub will not fire `pull_request` for such a
+# PR, nothing triggered BY `pull_request` can ever report on it -- that
+# includes pr-review-signal.yml, which exists for the adjacent absence defect
+# in #3312 and is blind to this one for the identical reason. The only trigger
+# that can see this is one independent of any single PR's ability to fire
+# anything: a cron that asks the API which open PRs are conflicted.
+#
+# This does not fix CI not running -- nothing in-repo can, short of GitHub
+# changing how `pull_request` is gated. It makes the silence VISIBLE: a red
+# scheduled run in the Actions tab, on a fixed cadence, independent of any one
+# PR's state.
+on:
+  schedule:
+    # Every 30 minutes. Cheap (two `gh` reads, no checkout of anything to
+    # build, no `pnpm install` -- see scripts/scan-dirty-prs.mjs), and the
+    # interval IS the detection latency: a PR that goes conflicted and is
+    # fixed between two runs is never reported, by design.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node24
+
+jobs:
+  scan:
+    name: Scan open PRs for conflicted, CI-silent heads
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+
+      # No `pnpm install`: node builtins plus `gh`, which is preinstalled on
+      # GitHub runners, and reused presence logic from
+      # scripts/lib/pr-review-signal.mjs (already dependency-free, already
+      # tested). Kept light on purpose -- this job's only edge over
+      # pr-review-signal.yml is a trigger that a dirty PR cannot suppress, and
+      # adding a real dependency here would not remove that edge, just risk it.
+      - name: Unit-test the scan itself
+        run: node --test scripts/lib/dirty-pr-scan.test.mjs scripts/scan-dirty-prs.test.mjs
+
+      - name: Scan open PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/scan-dirty-prs.mjs --repo "${{ github.repository }}"

--- a/scripts/lib/dirty-pr-scan.mjs
+++ b/scripts/lib/dirty-pr-scan.mjs
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { missingLanes as reviewSignalMissingLanes } from './pr-review-signal.mjs';
+
 /**
  * Pure classification for `scripts/scan-dirty-prs.mjs` (issue #3443).
  *
@@ -60,13 +62,42 @@ export class DirtyPrScanError extends Error {
 /**
  * Required lane names absent from a PR's status-check rollup.
  *
+ * Delegates to `pr-review-signal.mjs`'s `missingLanes`, the sibling module
+ * this file already imports `expandJobNames` from, rather than re-deriving
+ * presence with a plain name-set test. That matters for one shape a plain
+ * test cannot see: a matrix job skipped by `if:` BEFORE `strategy.matrix`
+ * expands publishes ONE check run, under the unexpanded template, never the
+ * per-shard names `expandJobNames` derives -- measured on PR #3581. Without
+ * the alias map from `matrixSkipAliases`, any conflicted PR of that shape
+ * (touching neither `frontend` nor `rust` paths, so `viewer-tests` skips
+ * wholesale) reported every shard missing and misclassified as `CONFLICTED`.
+ *
+ * TWO DIVERGENCES FROM THE SHARED FUNCTION, BOTH DELIBERATE:
+ *
+ * - An EMPTY rollup is not an error here, it is the flagship case. The
+ *   shared `missingLanes` throws `NO_ROLLUP` on `[]`, because for its own
+ *   caller an empty rollup is indistinguishable from an API failure. Here a
+ *   conflicted PR whose `pull_request` CI never fired can legitimately
+ *   publish nothing but a couple of unrelated bot checks (or none at all --
+ *   see this file's own docblock), and "every required lane is missing" is
+ *   the correct read of that, not a crash. Handled locally before delegating.
+ * - A rollup entry's name falls back to `context` for commit-status style
+ *   entries (`{ context: 'CodeRabbit' }`), which `gh pr list`'s
+ *   `statusCheckRollup` can carry alongside check-run style ones; the shared
+ *   function reads only `name`, since `pr-review-signal.mjs`'s own caller
+ *   never sees that shape.
+ *
  * @param {string[]} required
- * @param {Array<{ name?: string, context?: string }>} rollup
+ * @param {Array<{ name?: string, context?: string, state?: string }>} rollup
+ * @param {Map<string, string>} [aliases] - from `matrixSkipAliases`; empty
+ *   means the strict name-for-name rule.
  * @returns {string[]}
  */
-export function missingLanes(required, rollup) {
-  const present = new Set((Array.isArray(rollup) ? rollup : []).map((c) => c.name ?? c.context ?? ''));
-  return required.filter((n) => !present.has(n)).sort();
+export function missingLanes(required, rollup, aliases = new Map()) {
+  const list = Array.isArray(rollup) ? rollup : [];
+  if (list.length === 0) return [...required].sort();
+  const normalized = list.map((c) => ({ ...c, name: c.name ?? c.context ?? '' }));
+  return reviewSignalMissingLanes(required, normalized, aliases);
 }
 
 /**
@@ -212,12 +243,15 @@ function finishBranches(branches) {
  *
  * @param {{ number: number, title?: string, url?: string, baseRefName?: string,
  *   mergeable?: string, mergeStateStatus?: string, isDraft?: boolean,
- *   statusCheckRollup?: Array<{ name?: string, context?: string }> }} pr
+ *   statusCheckRollup?: Array<{ name?: string, context?: string, state?: string }> }} pr
  * @param {string[]} required
  * @param {string[] | null} baseBranches - from `pullRequestBaseBranches`;
  *   `null` means the workflow carries no base filter, so nothing is base-filtered.
+ * @param {Map<string, string>} [aliases] - from `pr-review-signal.mjs`'s
+ *   `matrixSkipAliases`, over the same workflow text `required` was derived
+ *   from; empty means the strict name-for-name rule.
  */
-export function classifyPr(pr, required, baseBranches) {
+export function classifyPr(pr, required, baseBranches, aliases = new Map()) {
   if (typeof pr?.number !== 'number') {
     throw new DirtyPrScanError('BAD_PR', `A PR object is missing a numeric \`number\`: ${JSON.stringify(pr)}`);
   }
@@ -246,7 +280,7 @@ export function classifyPr(pr, required, baseBranches) {
   }
 
   const rollup = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
-  const missing = missingLanes(required, rollup);
+  const missing = missingLanes(required, rollup, aliases);
   const isConflicted = pr.mergeable === 'CONFLICTING' || pr.mergeStateStatus === 'DIRTY';
   const isUnknown = pr.mergeable === 'UNKNOWN' || pr.mergeStateStatus === 'UNKNOWN';
   const isBaseFiltered = baseBranches !== null && !baseBranches.includes(pr.baseRefName);
@@ -291,8 +325,9 @@ export function classifyPr(pr, required, baseBranches) {
  * @param {unknown} prs
  * @param {string[]} required
  * @param {string[] | null} baseBranches
+ * @param {Map<string, string>} [aliases] - from `matrixSkipAliases`, see `classifyPr`.
  */
-export function scanPrs(prs, required, baseBranches) {
+export function scanPrs(prs, required, baseBranches, aliases = new Map()) {
   if (!Array.isArray(prs)) {
     throw new DirtyPrScanError(
       'BAD_INPUT',
@@ -300,7 +335,7 @@ export function scanPrs(prs, required, baseBranches) {
         'must never be read as "no open PRs".',
     );
   }
-  return prs.map((pr) => classifyPr(pr, required, baseBranches));
+  return prs.map((pr) => classifyPr(pr, required, baseBranches, aliases));
 }
 
 /**

--- a/scripts/lib/dirty-pr-scan.mjs
+++ b/scripts/lib/dirty-pr-scan.mjs
@@ -32,6 +32,14 @@
  * count alone cannot tell the two apart -- #3417 carried 40 rows, #3411 carried
  * 19 -- so this compares NAMES against the workflow's own required set rather
  * than a floor. #3411, live, was missing every one of the 15.
+ *
+ * MISSING LANES HAVE TWO CAUSES, NOT ONE. `test.yml` opens with
+ * `on: pull_request: branches: [main]`, so a PR stacked on a feature branch is
+ * silent for a reason a merge has no power over. #3411 is that shape -- its
+ * base is `fix-3353-snap-f32-invisible-floor` -- so the flagship fixture above
+ * is BOTH conflicted and base-filtered, and reporting only the conflict would
+ * hand it a remedy that provably does not restore a lane. `classifyPr` reads
+ * `baseRefName` and names which cause fired; see its docblock.
  */
 
 /** Thrown for every fail-closed condition; `reason` is the machine-readable tag. */
@@ -60,23 +68,150 @@ export function missingLanes(required, rollup) {
 }
 
 /**
- * One open PR's silence verdict.
+ * The base branches `test.yml` will fire `pull_request` for.
  *
- * `silent` is true only when BOTH hold: the PR reads as conflicted
- * (`mergeable: CONFLICTING`, or `mergeStateStatus: DIRTY` -- GitHub has shown
- * both spellings live), AND at least one lane that `test.yml` requires is
- * absent from its rollup. Either alone is not enough: `CONFLICTING` with a
- * full rollup (#3417) means the lanes ran before the PR went dirty, and a
- * missing lane with `mergeable: MERGEABLE` is a different, ordinary problem
- * (a lane still queued, a path filter, a real failure) that this gate is not
- * built to explain.
+ * WHY THIS EXISTS: a missing lane has TWO causes, not one, and they need
+ * opposite remedies. `.github/workflows/test.yml` opens with
+ * `on: pull_request: branches: [main]`, so a stacked PR based on a feature
+ * branch never fires it -- measured on #3411 (base
+ * `fix-3353-snap-f32-invisible-floor`) and #3405 (base
+ * `fix-3338-isolate-expansion-gate`), both reading MERGEABLE/CLEAN with 0 of
+ * the 15 required lanes present. Telling such a PR to resolve a merge conflict
+ * is advice that provably cannot work: the base filter still blocks the
+ * workflow afterwards. This is #3429's first case; the conflicted PR is its
+ * second.
  *
- * @param {{ number: number, title?: string, url?: string, mergeable?: string,
- *   mergeStateStatus?: string, isDraft?: boolean,
+ * Parsed from the workflow text rather than hardcoded, for the same reason the
+ * lane names are: a constant here would silently diverge the day the filter
+ * changes, and the failure mode of a diverged constant is a wrong remedy, not
+ * a loud error.
+ *
+ * @param {string} text - `.github/workflows/test.yml` contents.
+ * @returns {string[] | null} the allowed base branches, or `null` when
+ *   `pull_request` carries no `branches:` filter at all (every base fires).
+ */
+export function pullRequestBaseBranches(text) {
+  if (typeof text !== 'string' || text.trim() === '') {
+    throw new DirtyPrScanError('NO_WORKFLOW_TEXT', 'The workflow text is empty, so its `pull_request` base filter cannot be read.');
+  }
+  const lines = text.split(/\r?\n/);
+
+  let i = lines.findIndex((l) => /^on:\s*(#.*)?$/.test(l));
+  if (i === -1) {
+    throw new DirtyPrScanError('NO_ON_BLOCK', 'The workflow has no top-level `on:` block, so its triggers cannot be read.');
+  }
+
+  // Walk the `on:` block for `pull_request:`; a line starting in column 0 ends it.
+  let prIndent = -1;
+  for (i += 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() !== '' && /^\S/.test(line)) break;
+    const m = /^(\s+)pull_request:\s*(#.*)?$/.exec(line);
+    if (m) {
+      prIndent = m[1].length;
+      break;
+    }
+  }
+  if (prIndent === -1) {
+    throw new DirtyPrScanError(
+      'NO_PULL_REQUEST_TRIGGER',
+      'The workflow has no `pull_request:` trigger. This gate exists to explain why a ' +
+        '`pull_request` lane is absent; against a workflow that has no such trigger the ' +
+        'question is meaningless, and answering it anyway would be a guess.',
+    );
+  }
+
+  // Walk `pull_request:`'s own body for `branches:`; anything at or left of its
+  // indent ends it (that is `push:`, whose own `branches: [main]` must not be read here).
+  for (i += 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === '' || /^\s*#/.test(line)) continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent <= prIndent) return null; // `pull_request:` had no `branches:` filter.
+
+    const flow = /^\s*branches:\s*\[([^\]]*)\]\s*(#.*)?$/.exec(line);
+    if (flow) return finishBranches(splitFlowList(flow[1]));
+
+    if (/^\s*branches:\s*(#.*)?$/.test(line)) {
+      const items = [];
+      for (i += 1; i < lines.length; i += 1) {
+        const item = /^\s*-\s*(.+?)\s*$/.exec(lines[i]);
+        if (!item) break;
+        items.push(stripQuotes(item[1]));
+      }
+      return finishBranches(items);
+    }
+  }
+  return null;
+}
+
+/** @param {string} raw */
+function splitFlowList(raw) {
+  return raw
+    .split(',')
+    .map((v) => stripQuotes(v.trim()))
+    .filter((v) => v !== '');
+}
+
+/** @param {string} v */
+function stripQuotes(v) {
+  return v.replace(/^['"]|['"]$/g, '');
+}
+
+/** @param {string[]} branches */
+function finishBranches(branches) {
+  if (branches.length === 0) {
+    throw new DirtyPrScanError(
+      'EMPTY_BASE_BRANCHES',
+      'The workflow declares a `pull_request` `branches:` filter with no entries. Every PR ' +
+        'would read as base-filtered, which is a wrong verdict rather than a missing one.',
+    );
+  }
+  for (const b of branches) {
+    if (/[*?[\]!+]/.test(b)) {
+      throw new DirtyPrScanError(
+        'UNSUPPORTED_BRANCH_PATTERN',
+        `The \`pull_request\` \`branches:\` filter contains the glob \`${b}\`, which this gate ` +
+          'does not evaluate. Matching it wrongly would hand a PR a remedy that cannot work; ' +
+          'teach this function the pattern syntax instead of guessing.',
+      );
+    }
+  }
+  return branches;
+}
+
+/**
+ * One open PR's silence verdict, and WHICH of the two causes produced it.
+ *
+ * A required lane can be absent for two independent reasons, and they take
+ * opposite remedies -- getting the split right is most of this gate's value:
+ *
+ * - `BASE_FILTERED`: the PR's base is not a branch `test.yml` fires
+ *   `pull_request` for (`branches: [main]`). Measured on #3411 and #3405, both
+ *   stacked on a feature branch with 0 of 15 lanes. Resolving a merge conflict
+ *   does nothing here; the PR has to be retargeted (or its base landed first).
+ *   This is #3429's first case, and it is checked FIRST: when a PR is both
+ *   stacked and conflicted, the base filter is what still blocks the workflow
+ *   after the conflict is gone, so it is the cause worth reporting.
+ * - `CONFLICTED`: the base IS one `test.yml` fires for, but the PR reads
+ *   conflicted (`mergeable: CONFLICTING`, or `mergeStateStatus: DIRTY` --
+ *   GitHub has shown both spellings live), so GitHub computes no merge ref and
+ *   fires nothing. Resolving the conflict is what restores CI. This is #3443,
+ *   and #3429's second case.
+ *
+ * In both, at least one required lane must actually be missing. A conflicted
+ * PR with a full rollup (#3417) ran its lanes before going dirty; a missing
+ * lane on a clean, `main`-based PR is an ordinary problem (still queued, a
+ * path filter, a real failure) this gate is not built to explain.
+ *
+ * @param {{ number: number, title?: string, url?: string, baseRefName?: string,
+ *   mergeable?: string, mergeStateStatus?: string, isDraft?: boolean,
  *   statusCheckRollup?: Array<{ name?: string, context?: string }> }} pr
  * @param {string[]} required
+ * @param {string[] | null} baseBranches - from `pullRequestBaseBranches`;
+ *   `null` means the workflow carries no base filter, so nothing is base-filtered.
  */
-export function classifyPr(pr, required) {
+export function classifyPr(pr, required, baseBranches) {
   if (typeof pr?.number !== 'number') {
     throw new DirtyPrScanError('BAD_PR', `A PR object is missing a numeric \`number\`: ${JSON.stringify(pr)}`);
   }
@@ -87,26 +222,56 @@ export function classifyPr(pr, required) {
         'possible rollup, which is the vacuity this gate exists to reject.',
     );
   }
+  if (baseBranches !== null && (!Array.isArray(baseBranches) || baseBranches.length === 0)) {
+    throw new DirtyPrScanError(
+      'EMPTY_BASE_BRANCHES',
+      'The base-branch set must be a non-empty array, or `null` for "no filter". Passing an ' +
+        'empty one would read every PR as base-filtered.',
+    );
+  }
+  if (baseBranches !== null && typeof pr.baseRefName !== 'string') {
+    throw new DirtyPrScanError(
+      'NO_BASE_REF',
+      `PR #${pr.number} carries no \`baseRefName\`, so this gate cannot tell a stacked PR ` +
+        '(no lanes because of the base filter; retarget it) from a conflicted one (no lanes ' +
+        'because of the merge ref; resolve it). Defaulting to either hands out a remedy that ' +
+        'may not work, so it refuses instead. Add `baseRefName` to the `gh pr list --json` fields.',
+    );
+  }
 
   const rollup = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
   const missing = missingLanes(required, rollup);
   const isConflicted = pr.mergeable === 'CONFLICTING' || pr.mergeStateStatus === 'DIRTY';
   const isUnknown = pr.mergeable === 'UNKNOWN' || pr.mergeStateStatus === 'UNKNOWN';
+  const isBaseFiltered = baseBranches !== null && !baseBranches.includes(pr.baseRefName);
+
+  // Base filter first: it is the condition that still blocks the workflow once
+  // any merge conflict is resolved, so for a PR that is both, it is the cause
+  // whose remedy actually works.
+  let cause = null;
+  if (missing.length > 0) {
+    if (isBaseFiltered) cause = 'BASE_FILTERED';
+    // A conflicted PR with every required lane present already ran them
+    // before going dirty (#3417) -- not this defect.
+    else if (isConflicted) cause = 'CONFLICTED';
+  }
 
   return {
     number: pr.number,
     title: typeof pr.title === 'string' ? pr.title : '',
     url: typeof pr.url === 'string' ? pr.url : '',
+    baseRefName: pr.baseRefName ?? null,
     mergeable: pr.mergeable ?? null,
     mergeStateStatus: pr.mergeStateStatus ?? null,
     isDraft: pr.isDraft === true,
     rollupCount: rollup.length,
     missing,
-    // A conflicted PR with every required lane present already ran them
-    // before going dirty (#3417) -- not this defect.
-    silent: isConflicted && missing.length > 0,
-    // Advisory only -- see the docblock. Never folds into `silent`.
-    unknownAdvisory: isUnknown && missing.length > 0,
+    cause,
+    silent: cause !== null,
+    // Advisory only -- see the docblock. Never folds into `silent`. A
+    // base-filtered PR is a settled finding, not a pending one, so `UNKNOWN`
+    // does not soften it.
+    unknownAdvisory: isUnknown && !isBaseFiltered && missing.length > 0,
   };
 }
 
@@ -115,8 +280,9 @@ export function classifyPr(pr, required) {
  *
  * @param {unknown} prs
  * @param {string[]} required
+ * @param {string[] | null} baseBranches
  */
-export function scanPrs(prs, required) {
+export function scanPrs(prs, required, baseBranches) {
   if (!Array.isArray(prs)) {
     throw new DirtyPrScanError(
       'BAD_INPUT',
@@ -124,19 +290,39 @@ export function scanPrs(prs, required) {
         'must never be read as "no open PRs".',
     );
   }
-  return prs.map((pr) => classifyPr(pr, required));
+  return prs.map((pr) => classifyPr(pr, required, baseBranches));
 }
 
 /**
  * Render a scan into a verdict and human-readable lines.
  *
+ * The two causes are reported as SEPARATE groups with separate remedies. They
+ * are not interchangeable: telling a stacked PR to resolve its merge conflict
+ * is advice that cannot restore a single lane, because `test.yml`'s
+ * `branches:` filter still excludes its base afterwards.
+ *
  * @param {ReturnType<typeof scanPrs>} results
  * @param {string[]} required
+ * @param {string[] | null} [baseBranches]
  */
-export function report(results, required) {
+export function report(results, required, baseBranches = null) {
+  const baseFiltered = results.filter((r) => r.cause === 'BASE_FILTERED');
+  const conflicted = results.filter((r) => r.cause === 'CONFLICTED');
   const silent = results.filter((r) => r.silent);
   const unknownAdvisory = results.filter((r) => r.unknownAdvisory);
   const lines = [];
+
+  /** @param {typeof results} group */
+  const detail = (group) => {
+    for (const r of group) {
+      lines.push(
+        `   #${r.number}${r.title ? ` ${r.title}` : ''}${r.url ? ` -- ${r.url}` : ''}`,
+        `     base=${r.baseRefName} mergeable=${r.mergeable} ` +
+          `mergeStateStatus=${r.mergeStateStatus} rollup=${r.rollupCount} row(s); ` +
+          `missing ${r.missing.length}/${required.length} required lane(s): ${r.missing.join(', ')}`,
+      );
+    }
+  };
 
   lines.push(
     `Scanned ${results.length} open PR(s) against ${required.length} required lane(s) ` +
@@ -145,23 +331,30 @@ export function report(results, required) {
 
   if (silent.length === 0) {
     lines.push(
-      '✅ No open PR is CONFLICTING/DIRTY with a required lane missing -- this scan cannot see ' +
+      '✅ No open PR has a required lane missing for a reason this gate can name (a base ' +
+        '`test.yml` does not run on, or an unresolved merge conflict) -- this scan cannot see ' +
         'a lane that has not run yet, only one whose absence has already been reported.',
     );
-  } else {
+  }
+
+  if (baseFiltered.length > 0) {
+    const allowed = baseBranches ? baseBranches.map((b) => `\`${b}\``).join(', ') : '(none)';
     lines.push(
-      `❌ ${silent.length} open PR(s) are conflicted and have NOT run \`pull_request\` CI on ` +
-        'their current head. Pushing a new commit will not fix this -- only resolving the ' +
+      `❌ ${baseFiltered.length} open PR(s) target a base that \`test.yml\` does not run ` +
+        `\`pull_request\` on (it fires only for ${allowed}), so no lane can ever report on ` +
+        'them. Resolving a merge conflict will NOT fix this -- retarget the PR at a base the ' +
+        'workflow runs on, or land its base branch first.',
+    );
+    detail(baseFiltered);
+  }
+
+  if (conflicted.length > 0) {
+    lines.push(
+      `❌ ${conflicted.length} open PR(s) are conflicted and have NOT run \`pull_request\` CI ` +
+        'on their current head. Pushing a new commit will not fix this -- only resolving the ' +
         'conflict (merge/rebase from the base branch) restores CI.',
     );
-    for (const r of silent) {
-      lines.push(
-        `   #${r.number}${r.title ? ` ${r.title}` : ''}${r.url ? ` -- ${r.url}` : ''}`,
-        `     mergeable=${r.mergeable} mergeStateStatus=${r.mergeStateStatus} ` +
-          `rollup=${r.rollupCount} row(s); missing ${r.missing.length}/${required.length} ` +
-          `required lane(s): ${r.missing.join(', ')}`,
-      );
-    }
+    detail(conflicted);
   }
 
   if (unknownAdvisory.length > 0) {

--- a/scripts/lib/dirty-pr-scan.mjs
+++ b/scripts/lib/dirty-pr-scan.mjs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import { missingLanes as reviewSignalMissingLanes } from './pr-review-signal.mjs';
+import { pullRequestBaseBranches } from './workflow-base-branches.mjs';
+
+export { pullRequestBaseBranches };
 
 /**
  * Pure classification for `scripts/scan-dirty-prs.mjs` (issue #3443).
@@ -98,119 +101,6 @@ export function missingLanes(required, rollup, aliases = new Map()) {
   if (list.length === 0) return [...required].sort();
   const normalized = list.map((c) => ({ ...c, name: c.name ?? c.context ?? '' }));
   return reviewSignalMissingLanes(required, normalized, aliases);
-}
-
-/**
- * The base branches `test.yml` will fire `pull_request` for.
- *
- * WHY THIS EXISTS: a missing lane has TWO causes, not one, and they need
- * opposite remedies. `.github/workflows/test.yml` opens with
- * `on: pull_request: branches: [main]`, so a stacked PR based on a feature
- * branch never fires it -- measured on #3411 (base
- * `fix-3353-snap-f32-invisible-floor`) and #3405 (base
- * `fix-3338-isolate-expansion-gate`), both reading MERGEABLE/CLEAN with 0 of
- * the 15 required lanes present. Telling such a PR to resolve a merge conflict
- * is advice that provably cannot work: the base filter still blocks the
- * workflow afterwards. This is #3429's first case; the conflicted PR is its
- * second.
- *
- * Parsed from the workflow text rather than hardcoded, for the same reason the
- * lane names are: a constant here would silently diverge the day the filter
- * changes, and the failure mode of a diverged constant is a wrong remedy, not
- * a loud error.
- *
- * @param {string} text - `.github/workflows/test.yml` contents.
- * @returns {string[] | null} the allowed base branches, or `null` when
- *   `pull_request` carries no `branches:` filter at all (every base fires).
- */
-export function pullRequestBaseBranches(text) {
-  if (typeof text !== 'string' || text.trim() === '') {
-    throw new DirtyPrScanError('NO_WORKFLOW_TEXT', 'The workflow text is empty, so its `pull_request` base filter cannot be read.');
-  }
-  const lines = text.split(/\r?\n/);
-
-  let i = lines.findIndex((l) => /^on:\s*(#.*)?$/.test(l));
-  if (i === -1) {
-    throw new DirtyPrScanError('NO_ON_BLOCK', 'The workflow has no top-level `on:` block, so its triggers cannot be read.');
-  }
-
-  // Walk the `on:` block for `pull_request:`; a line starting in column 0 ends it.
-  let prIndent = -1;
-  for (i += 1; i < lines.length; i += 1) {
-    const line = lines[i];
-    if (line.trim() !== '' && /^\S/.test(line)) break;
-    const m = /^(\s+)pull_request:\s*(#.*)?$/.exec(line);
-    if (m) {
-      prIndent = m[1].length;
-      break;
-    }
-  }
-  if (prIndent === -1) {
-    throw new DirtyPrScanError(
-      'NO_PULL_REQUEST_TRIGGER',
-      'The workflow has no `pull_request:` trigger. This gate exists to explain why a ' +
-        '`pull_request` lane is absent; against a workflow that has no such trigger the ' +
-        'question is meaningless, and answering it anyway would be a guess.',
-    );
-  }
-
-  // Walk `pull_request:`'s own body for `branches:`; anything at or left of its
-  // indent ends it (that is `push:`, whose own `branches: [main]` must not be read here).
-  for (i += 1; i < lines.length; i += 1) {
-    const line = lines[i];
-    if (line.trim() === '' || /^\s*#/.test(line)) continue;
-    const indent = line.length - line.trimStart().length;
-    if (indent <= prIndent) return null; // `pull_request:` had no `branches:` filter.
-
-    const flow = /^\s*branches:\s*\[([^\]]*)\]\s*(#.*)?$/.exec(line);
-    if (flow) return finishBranches(splitFlowList(flow[1]));
-
-    if (/^\s*branches:\s*(#.*)?$/.test(line)) {
-      const items = [];
-      for (i += 1; i < lines.length; i += 1) {
-        const item = /^\s*-\s*(.+?)\s*$/.exec(lines[i]);
-        if (!item) break;
-        items.push(stripQuotes(item[1]));
-      }
-      return finishBranches(items);
-    }
-  }
-  return null;
-}
-
-/** @param {string} raw */
-function splitFlowList(raw) {
-  return raw
-    .split(',')
-    .map((v) => stripQuotes(v.trim()))
-    .filter((v) => v !== '');
-}
-
-/** @param {string} v */
-function stripQuotes(v) {
-  return v.replace(/^['"]|['"]$/g, '');
-}
-
-/** @param {string[]} branches */
-function finishBranches(branches) {
-  if (branches.length === 0) {
-    throw new DirtyPrScanError(
-      'EMPTY_BASE_BRANCHES',
-      'The workflow declares a `pull_request` `branches:` filter with no entries. Every PR ' +
-        'would read as base-filtered, which is a wrong verdict rather than a missing one.',
-    );
-  }
-  for (const b of branches) {
-    if (/[*?[\]!+]/.test(b)) {
-      throw new DirtyPrScanError(
-        'UNSUPPORTED_BRANCH_PATTERN',
-        `The \`pull_request\` \`branches:\` filter contains the glob \`${b}\`, which this gate ` +
-          'does not evaluate. Matching it wrongly would hand a PR a remedy that cannot work; ' +
-          'teach this function the pattern syntax instead of guessing.',
-      );
-    }
-  }
-  return branches;
 }
 
 /**

--- a/scripts/lib/dirty-pr-scan.mjs
+++ b/scripts/lib/dirty-pr-scan.mjs
@@ -37,9 +37,11 @@
  * `on: pull_request: branches: [main]`, so a PR stacked on a feature branch is
  * silent for a reason a merge has no power over. #3411 is that shape -- its
  * base is `fix-3353-snap-f32-invisible-floor` -- so the flagship fixture above
- * is BOTH conflicted and base-filtered, and reporting only the conflict would
- * hand it a remedy that provably does not restore a lane. `classifyPr` reads
- * `baseRefName` and names which cause fired; see its docblock.
+ * is BOTH conflicted and base-filtered, and either cause reported alone hands
+ * it a remedy that provably does not restore a lane -- neither retargeting a
+ * dirty PR nor merging into a feature-based one fires `pull_request`.
+ * `classifyPr` reads `baseRefName`, names the cause a merge cannot clear, and
+ * flags the both-case so the report carries both remedies; see its docblock.
  */
 
 /** Thrown for every fail-closed condition; `reason` is the machine-readable tag. */
@@ -190,9 +192,13 @@ function finishBranches(branches) {
  *   `pull_request` for (`branches: [main]`). Measured on #3411 and #3405, both
  *   stacked on a feature branch with 0 of 15 lanes. Resolving a merge conflict
  *   does nothing here; the PR has to be retargeted (or its base landed first).
- *   This is #3429's first case, and it is checked FIRST: when a PR is both
- *   stacked and conflicted, the base filter is what still blocks the workflow
- *   after the conflict is gone, so it is the cause worth reporting.
+ *   This is #3429's first case, and it is checked FIRST because it is the cause
+ *   a merge has no power over, so it is the one that names the group.
+ *
+ *   IT IS NOT THE WHOLE REMEDY WHEN A PR IS BOTH (#3411 live is that shape):
+ *   retargeting a dirty PR at `main` clears the filter and leaves the conflict,
+ *   which fires nothing on its own, so the retarget line alone buys zero lanes.
+ *   Such a PR carries `alsoConflicted` and the report names BOTH remedies.
  * - `CONFLICTED`: the base IS one `test.yml` fires for, but the PR reads
  *   conflicted (`mergeable: CONFLICTING`, or `mergeStateStatus: DIRTY` --
  *   GitHub has shown both spellings live), so GitHub computes no merge ref and
@@ -245,9 +251,10 @@ export function classifyPr(pr, required, baseBranches) {
   const isUnknown = pr.mergeable === 'UNKNOWN' || pr.mergeStateStatus === 'UNKNOWN';
   const isBaseFiltered = baseBranches !== null && !baseBranches.includes(pr.baseRefName);
 
-  // Base filter first: it is the condition that still blocks the workflow once
-  // any merge conflict is resolved, so for a PR that is both, it is the cause
-  // whose remedy actually works.
+  // Base filter first: it is the condition a merge has no power over, so it
+  // names the group. It is not the whole remedy for a PR that is both --
+  // retargeting a dirty PR leaves no merge ref, so still no lane -- which is
+  // what `alsoConflicted` below carries into the report.
   let cause = null;
   if (missing.length > 0) {
     if (isBaseFiltered) cause = 'BASE_FILTERED';
@@ -267,6 +274,9 @@ export function classifyPr(pr, required, baseBranches) {
     rollupCount: rollup.length,
     missing,
     cause,
+    // Both remedies, not the first one. Derived from the same `isConflicted`
+    // the cause ladder uses, so the two can never disagree.
+    alsoConflicted: cause === 'BASE_FILTERED' && isConflicted,
     silent: cause !== null,
     // Advisory only -- see the docblock. Never folds into `silent`. A
     // base-filtered PR is a settled finding, not a pending one, so `UNKNOWN`
@@ -301,6 +311,11 @@ export function scanPrs(prs, required, baseBranches) {
  * is advice that cannot restore a single lane, because `test.yml`'s
  * `branches:` filter still excludes its base afterwards.
  *
+ * They are not mutually exclusive either. A PR that is stacked AND conflicted
+ * is grouped under the base filter, but the retarget line alone would have a
+ * maintainer do half the work for no lane, so `alsoConflicted` puts the second
+ * remedy on that PR's own lines instead of deferring it to a later cron run.
+ *
  * @param {ReturnType<typeof scanPrs>} results
  * @param {string[]} required
  * @param {string[] | null} [baseBranches]
@@ -321,6 +336,14 @@ export function report(results, required, baseBranches = null) {
           `mergeStateStatus=${r.mergeStateStatus} rollup=${r.rollupCount} row(s); ` +
           `missing ${r.missing.length}/${required.length} required lane(s): ${r.missing.join(', ')}`,
       );
+      if (r.alsoConflicted) {
+        lines.push(
+          '     ALSO conflicted, so this one needs BOTH remedies: retargeting it clears the ' +
+            'base filter but leaves the conflict, and GitHub fires no `pull_request` for a PR ' +
+            'it cannot compute a merge ref for. Resolve the conflict as well, or the retarget ' +
+            'restores no lane.',
+        );
+      }
     }
   };
 

--- a/scripts/lib/dirty-pr-scan.mjs
+++ b/scripts/lib/dirty-pr-scan.mjs
@@ -1,0 +1,179 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * Pure classification for `scripts/scan-dirty-prs.mjs` (issue #3443).
+ *
+ * MEASURED, NOT SPECULATED: a PR whose `mergeable` reads `CONFLICTING` runs no
+ * `pull_request` CI at all -- not "may run late", not "runs a reduced set" --
+ * absent, with no red check and no message. Pushing a new commit to it does not
+ * clear this; only resolving the conflict does. Live on #3389 the night of
+ * 2026-08-27/28: `gh pr checks` showed 6 rows (Vercel + CodeRabbit only) while
+ * `mergeable: CONFLICTING` held, and an empty commit polled for five minutes
+ * left `total_count: 2` unchanged. Full writeup in issue #3443.
+ *
+ * THE CONSTRAINT THAT SHAPES THIS FILE: if GitHub does not fire `pull_request`
+ * for a conflicted PR, nothing triggered BY `pull_request` can ever report on
+ * one -- that includes `.github/workflows/pr-review-signal.yml`, which exists
+ * for exactly this shape of absence (#3312) and is blind to this one. There is
+ * no in-PR fix. What CAN observe it is a job on its own trigger --
+ * `schedule`/`workflow_dispatch` -- that asks the API which open PRs are
+ * conflicted, independent of any single PR's ability to fire anything.
+ *
+ * `CONFLICTING` IS DISTINGUISHED FROM `UNKNOWN`. GitHub computes mergeability
+ * lazily and a fresh PR briefly reads `UNKNOWN` before settling -- that is not
+ * evidence of anything and is reported separately, advisory only, never as a
+ * silent-CI finding.
+ *
+ * REQUIRED LANES ARE DERIVED FROM `test.yml`, THE SAME WAY #3312's GATE DOES
+ * IT, on purpose: a PR that went dirty AFTER its lanes already ran (measured on
+ * #3417: `mergeable: CONFLICTING` with all 15 required lanes present in the
+ * rollup, because they ran while it was still clean) is not this defect. Row
+ * count alone cannot tell the two apart -- #3417 carried 40 rows, #3411 carried
+ * 19 -- so this compares NAMES against the workflow's own required set rather
+ * than a floor. #3411, live, was missing every one of the 15.
+ */
+
+/** Thrown for every fail-closed condition; `reason` is the machine-readable tag. */
+export class DirtyPrScanError extends Error {
+  /**
+   * @param {string} reason
+   * @param {string} message
+   */
+  constructor(reason, message) {
+    super(message);
+    this.name = 'DirtyPrScanError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Required lane names absent from a PR's status-check rollup.
+ *
+ * @param {string[]} required
+ * @param {Array<{ name?: string, context?: string }>} rollup
+ * @returns {string[]}
+ */
+export function missingLanes(required, rollup) {
+  const present = new Set((Array.isArray(rollup) ? rollup : []).map((c) => c.name ?? c.context ?? ''));
+  return required.filter((n) => !present.has(n)).sort();
+}
+
+/**
+ * One open PR's silence verdict.
+ *
+ * `silent` is true only when BOTH hold: the PR reads as conflicted
+ * (`mergeable: CONFLICTING`, or `mergeStateStatus: DIRTY` -- GitHub has shown
+ * both spellings live), AND at least one lane that `test.yml` requires is
+ * absent from its rollup. Either alone is not enough: `CONFLICTING` with a
+ * full rollup (#3417) means the lanes ran before the PR went dirty, and a
+ * missing lane with `mergeable: MERGEABLE` is a different, ordinary problem
+ * (a lane still queued, a path filter, a real failure) that this gate is not
+ * built to explain.
+ *
+ * @param {{ number: number, title?: string, url?: string, mergeable?: string,
+ *   mergeStateStatus?: string, isDraft?: boolean,
+ *   statusCheckRollup?: Array<{ name?: string, context?: string }> }} pr
+ * @param {string[]} required
+ */
+export function classifyPr(pr, required) {
+  if (typeof pr?.number !== 'number') {
+    throw new DirtyPrScanError('BAD_PR', `A PR object is missing a numeric \`number\`: ${JSON.stringify(pr)}`);
+  }
+  if (!Array.isArray(required) || required.length === 0) {
+    throw new DirtyPrScanError(
+      'EMPTY_REQUIRED_SET',
+      'The required lane set is empty. A presence check against an empty set passes over every ' +
+        'possible rollup, which is the vacuity this gate exists to reject.',
+    );
+  }
+
+  const rollup = Array.isArray(pr.statusCheckRollup) ? pr.statusCheckRollup : [];
+  const missing = missingLanes(required, rollup);
+  const isConflicted = pr.mergeable === 'CONFLICTING' || pr.mergeStateStatus === 'DIRTY';
+  const isUnknown = pr.mergeable === 'UNKNOWN' || pr.mergeStateStatus === 'UNKNOWN';
+
+  return {
+    number: pr.number,
+    title: typeof pr.title === 'string' ? pr.title : '',
+    url: typeof pr.url === 'string' ? pr.url : '',
+    mergeable: pr.mergeable ?? null,
+    mergeStateStatus: pr.mergeStateStatus ?? null,
+    isDraft: pr.isDraft === true,
+    rollupCount: rollup.length,
+    missing,
+    // A conflicted PR with every required lane present already ran them
+    // before going dirty (#3417) -- not this defect.
+    silent: isConflicted && missing.length > 0,
+    // Advisory only -- see the docblock. Never folds into `silent`.
+    unknownAdvisory: isUnknown && missing.length > 0,
+  };
+}
+
+/**
+ * Classify every open PR in `prs` against `required`.
+ *
+ * @param {unknown} prs
+ * @param {string[]} required
+ */
+export function scanPrs(prs, required) {
+  if (!Array.isArray(prs)) {
+    throw new DirtyPrScanError(
+      'BAD_INPUT',
+      `Expected an array of open PRs from \`gh pr list\`; got ${typeof prs}. An unreadable list ` +
+        'must never be read as "no open PRs".',
+    );
+  }
+  return prs.map((pr) => classifyPr(pr, required));
+}
+
+/**
+ * Render a scan into a verdict and human-readable lines.
+ *
+ * @param {ReturnType<typeof scanPrs>} results
+ * @param {string[]} required
+ */
+export function report(results, required) {
+  const silent = results.filter((r) => r.silent);
+  const unknownAdvisory = results.filter((r) => r.unknownAdvisory);
+  const lines = [];
+
+  lines.push(
+    `Scanned ${results.length} open PR(s) against ${required.length} required lane(s) ` +
+      `derived from .github/workflows/test.yml.`,
+  );
+
+  if (silent.length === 0) {
+    lines.push(
+      '✅ No open PR is CONFLICTING/DIRTY with a required lane missing -- this scan cannot see ' +
+        'a lane that has not run yet, only one whose absence has already been reported.',
+    );
+  } else {
+    lines.push(
+      `❌ ${silent.length} open PR(s) are conflicted and have NOT run \`pull_request\` CI on ` +
+        'their current head. Pushing a new commit will not fix this -- only resolving the ' +
+        'conflict (merge/rebase from the base branch) restores CI.',
+    );
+    for (const r of silent) {
+      lines.push(
+        `   #${r.number}${r.title ? ` ${r.title}` : ''}${r.url ? ` -- ${r.url}` : ''}`,
+        `     mergeable=${r.mergeable} mergeStateStatus=${r.mergeStateStatus} ` +
+          `rollup=${r.rollupCount} row(s); missing ${r.missing.length}/${required.length} ` +
+          `required lane(s): ${r.missing.join(', ')}`,
+      );
+    }
+  }
+
+  if (unknownAdvisory.length > 0) {
+    lines.push(
+      `⚠️  ${unknownAdvisory.length} open PR(s) read \`mergeable: UNKNOWN\` with required lanes ` +
+        'missing -- GitHub has not finished computing mergeability. This is advisory only: it ' +
+        're-checks itself, so it is reported but does not fail this job.',
+    );
+    for (const r of unknownAdvisory) {
+      lines.push(`   #${r.number}${r.title ? ` ${r.title}` : ''}${r.url ? ` -- ${r.url}` : ''}`);
+    }
+  }
+
+  return { ok: silent.length === 0, lines };
+}

--- a/scripts/lib/dirty-pr-scan.test.mjs
+++ b/scripts/lib/dirty-pr-scan.test.mjs
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * Regression harness for the pure half of the #3443 gate.
+ *
+ * Two fixtures anchor everything else: #3411 (live, `CONFLICTING`/`DIRTY`,
+ * none of the 15 `test.yml` lanes present) must report, and #3417 (live,
+ * also `CONFLICTING`, but all 15 lanes already ran before it went dirty) must
+ * NOT -- distinguishing those two is the entire point of comparing lane NAMES
+ * rather than a row-count floor. See scripts/lib/dirty-pr-scan.mjs.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DirtyPrScanError, missingLanes, classifyPr, scanPrs, report } from './dirty-pr-scan.mjs';
+
+const REQUIRED = ['Lint', 'Node tests', 'Rust tests', 'Typecheck'];
+
+function lane(name) {
+  return { name };
+}
+
+test('missingLanes: empty rollup means every required lane is missing', () => {
+  assert.deepEqual(missingLanes(REQUIRED, []), [...REQUIRED].sort());
+});
+
+test('missingLanes: only names absent from the rollup are returned', () => {
+  assert.deepEqual(missingLanes(REQUIRED, [lane('Lint'), lane('Typecheck')]), ['Node tests', 'Rust tests']);
+});
+
+test('missingLanes: falls back to `context` for commit-status style entries', () => {
+  assert.deepEqual(missingLanes(['CodeRabbit'], [{ context: 'CodeRabbit' }]), []);
+});
+
+test('classifyPr: RED fixture -- CONFLICTING/DIRTY with no required lane present is silent', () => {
+  // Shape of live PR #3411 the night #3443 was filed: Vercel/CodeRabbit rows
+  // only, none of the compile/test lanes.
+  const pr = {
+    number: 3411,
+    title: 'fix(core): order-independence',
+    url: 'https://github.com/LTplus-AG/ifc-lite/pull/3411',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    isDraft: false,
+    statusCheckRollup: [lane('Vercel Agent Review'), lane('Vercel Preview Comments')],
+  };
+  const result = classifyPr(pr, REQUIRED);
+  assert.equal(result.silent, true);
+  assert.equal(result.rollupCount, 2);
+  assert.deepEqual(result.missing, [...REQUIRED].sort());
+});
+
+test('classifyPr: GREEN fixture -- CONFLICTING but every required lane already ran is not silent', () => {
+  // Shape of live PR #3417: went dirty AFTER its lanes ran. Row-counting alone
+  // cannot separate this from #3411 -- #3417 had 40 rows, #3411 had 19 -- so
+  // this must key off lane NAMES, not a count.
+  const pr = {
+    number: 3417,
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    isDraft: false,
+    statusCheckRollup: REQUIRED.map(lane).concat([lane('Vercel Agent Review')]),
+  };
+  const result = classifyPr(pr, REQUIRED);
+  assert.equal(result.silent, false);
+  assert.deepEqual(result.missing, []);
+});
+
+test('classifyPr: GREEN fixture -- clean, mergeable PR with lanes missing is not this gate\'s finding', () => {
+  // A missing lane on an otherwise-mergeable PR is a different problem (still
+  // queued, a path filter, a real failure) -- out of scope on purpose.
+  const pr = {
+    number: 9001,
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'BLOCKED',
+    statusCheckRollup: [],
+  };
+  const result = classifyPr(pr, REQUIRED);
+  assert.equal(result.silent, false);
+});
+
+test('classifyPr: UNKNOWN mergeable with missing lanes is advisory, never silent', () => {
+  const pr = { number: 9002, mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN', statusCheckRollup: [] };
+  const result = classifyPr(pr, REQUIRED);
+  assert.equal(result.silent, false);
+  assert.equal(result.unknownAdvisory, true);
+});
+
+test('classifyPr: fails closed on a PR object missing a numeric `number`', () => {
+  assert.throws(() => classifyPr({ mergeable: 'CONFLICTING' }, REQUIRED), (err) => {
+    assert.ok(err instanceof DirtyPrScanError);
+    assert.equal(err.reason, 'BAD_PR');
+    return true;
+  });
+});
+
+test('classifyPr: fails closed on an empty required set', () => {
+  assert.throws(() => classifyPr({ number: 1 }, []), (err) => {
+    assert.ok(err instanceof DirtyPrScanError);
+    assert.equal(err.reason, 'EMPTY_REQUIRED_SET');
+    return true;
+  });
+});
+
+test('scanPrs: fails closed on a non-array input rather than reading it as "no open PRs"', () => {
+  assert.throws(() => scanPrs({ not: 'an array' }, REQUIRED), (err) => {
+    assert.ok(err instanceof DirtyPrScanError);
+    assert.equal(err.reason, 'BAD_INPUT');
+    return true;
+  });
+});
+
+test('scanPrs + report: RED -- a scan containing the #3411 shape fails and names the PR', () => {
+  const prs = [
+    {
+      number: 3411,
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY',
+      statusCheckRollup: [lane('Vercel Agent Review')],
+    },
+    {
+      number: 3417,
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY',
+      statusCheckRollup: REQUIRED.map(lane),
+    },
+  ];
+  const results = scanPrs(prs, REQUIRED);
+  const { ok, lines } = report(results, REQUIRED);
+  assert.equal(ok, false);
+  assert.ok(lines.some((l) => l.includes('#3411')));
+  assert.ok(!lines.some((l) => l.includes('#3417 ')));
+});
+
+test('scanPrs + report: GREEN -- an all-clean scan with lanes present passes', () => {
+  const prs = [
+    { number: 1, mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', statusCheckRollup: REQUIRED.map(lane) },
+    { number: 2, mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED', statusCheckRollup: REQUIRED.map(lane) },
+  ];
+  const results = scanPrs(prs, REQUIRED);
+  const { ok, lines } = report(results, REQUIRED);
+  assert.equal(ok, true);
+  assert.ok(lines.some((l) => l.startsWith('✅')));
+});
+
+test('scanPrs + report: GREEN -- zero open PRs passes trivially', () => {
+  const { ok, lines } = report(scanPrs([], REQUIRED), REQUIRED);
+  assert.equal(ok, true);
+  assert.ok(lines[0].includes('Scanned 0 open PR'));
+});

--- a/scripts/lib/dirty-pr-scan.test.mjs
+++ b/scripts/lib/dirty-pr-scan.test.mjs
@@ -363,13 +363,11 @@ test('report: both causes present are reported as separate groups with separate 
   assert.match(text, /only resolving the conflict/i);
 });
 
-test('pullRequestBaseBranches: reads test.yml`s own filter, not `push:`s', async () => {
-  const { readFileSync } = await import('node:fs');
-  const { dirname, join } = await import('node:path');
-  const { fileURLToPath } = await import('node:url');
-  const here = dirname(fileURLToPath(import.meta.url));
-  const text = readFileSync(join(here, '../../.github/workflows/test.yml'), 'utf8');
-  assert.deepEqual(pullRequestBaseBranches(text), ['main']);
+test('pullRequestBaseBranches: reads pull_request`s filter, not push`s', () => {
+  assert.deepEqual(
+    pullRequestBaseBranches('on:\n  push:\n    branches: [dev]\n  pull_request:\n    branches: [main]\njobs:\n'),
+    ['main'],
+  );
 });
 
 test('pullRequestBaseBranches: `pull_request:` with no `branches:` means no filter', () => {

--- a/scripts/lib/dirty-pr-scan.test.mjs
+++ b/scripts/lib/dirty-pr-scan.test.mjs
@@ -9,13 +9,28 @@
  * also `CONFLICTING`, but all 15 lanes already ran before it went dirty) must
  * NOT -- distinguishing those two is the entire point of comparing lane NAMES
  * rather than a row-count floor. See scripts/lib/dirty-pr-scan.mjs.
+ *
+ * A third axis the row count cannot see either: WHY the lanes are missing.
+ * #3411's real base is `fix-3353-snap-f32-invisible-floor`, so it is silent
+ * because of `test.yml`'s `branches: [main]` filter as well as its conflict,
+ * and only the retarget remedy works on it. The fixtures below keep a
+ * `main`-based conflicted PR and a stacked one apart, and assert that each is
+ * given the remedy that can actually restore a lane.
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { DirtyPrScanError, missingLanes, classifyPr, scanPrs, report } from './dirty-pr-scan.mjs';
+import {
+  DirtyPrScanError,
+  missingLanes,
+  pullRequestBaseBranches,
+  classifyPr,
+  scanPrs,
+  report,
+} from './dirty-pr-scan.mjs';
 
 const REQUIRED = ['Lint', 'Node tests', 'Rust tests', 'Typecheck'];
+const BASES = ['main'];
 
 function lane(name) {
   return { name };
@@ -40,12 +55,13 @@ test('classifyPr: RED fixture -- CONFLICTING/DIRTY with no required lane present
     number: 3411,
     title: 'fix(core): order-independence',
     url: 'https://github.com/LTplus-AG/ifc-lite/pull/3411',
+    baseRefName: 'main',
     mergeable: 'CONFLICTING',
     mergeStateStatus: 'DIRTY',
     isDraft: false,
     statusCheckRollup: [lane('Vercel Agent Review'), lane('Vercel Preview Comments')],
   };
-  const result = classifyPr(pr, REQUIRED);
+  const result = classifyPr(pr, REQUIRED, BASES);
   assert.equal(result.silent, true);
   assert.equal(result.rollupCount, 2);
   assert.deepEqual(result.missing, [...REQUIRED].sort());
@@ -57,12 +73,13 @@ test('classifyPr: GREEN fixture -- CONFLICTING but every required lane already r
   // this must key off lane NAMES, not a count.
   const pr = {
     number: 3417,
+    baseRefName: 'main',
     mergeable: 'CONFLICTING',
     mergeStateStatus: 'DIRTY',
     isDraft: false,
     statusCheckRollup: REQUIRED.map(lane).concat([lane('Vercel Agent Review')]),
   };
-  const result = classifyPr(pr, REQUIRED);
+  const result = classifyPr(pr, REQUIRED, BASES);
   assert.equal(result.silent, false);
   assert.deepEqual(result.missing, []);
 });
@@ -72,23 +89,30 @@ test('classifyPr: GREEN fixture -- clean, mergeable PR with lanes missing is not
   // queued, a path filter, a real failure) -- out of scope on purpose.
   const pr = {
     number: 9001,
+    baseRefName: 'main',
     mergeable: 'MERGEABLE',
     mergeStateStatus: 'BLOCKED',
     statusCheckRollup: [],
   };
-  const result = classifyPr(pr, REQUIRED);
+  const result = classifyPr(pr, REQUIRED, BASES);
   assert.equal(result.silent, false);
 });
 
 test('classifyPr: UNKNOWN mergeable with missing lanes is advisory, never silent', () => {
-  const pr = { number: 9002, mergeable: 'UNKNOWN', mergeStateStatus: 'UNKNOWN', statusCheckRollup: [] };
-  const result = classifyPr(pr, REQUIRED);
+  const pr = {
+    number: 9002,
+    baseRefName: 'main',
+    mergeable: 'UNKNOWN',
+    mergeStateStatus: 'UNKNOWN',
+    statusCheckRollup: [],
+  };
+  const result = classifyPr(pr, REQUIRED, BASES);
   assert.equal(result.silent, false);
   assert.equal(result.unknownAdvisory, true);
 });
 
 test('classifyPr: fails closed on a PR object missing a numeric `number`', () => {
-  assert.throws(() => classifyPr({ mergeable: 'CONFLICTING' }, REQUIRED), (err) => {
+  assert.throws(() => classifyPr({ mergeable: 'CONFLICTING' }, REQUIRED, BASES), (err) => {
     assert.ok(err instanceof DirtyPrScanError);
     assert.equal(err.reason, 'BAD_PR');
     return true;
@@ -96,7 +120,7 @@ test('classifyPr: fails closed on a PR object missing a numeric `number`', () =>
 });
 
 test('classifyPr: fails closed on an empty required set', () => {
-  assert.throws(() => classifyPr({ number: 1 }, []), (err) => {
+  assert.throws(() => classifyPr({ number: 1 }, [], BASES), (err) => {
     assert.ok(err instanceof DirtyPrScanError);
     assert.equal(err.reason, 'EMPTY_REQUIRED_SET');
     return true;
@@ -104,7 +128,7 @@ test('classifyPr: fails closed on an empty required set', () => {
 });
 
 test('scanPrs: fails closed on a non-array input rather than reading it as "no open PRs"', () => {
-  assert.throws(() => scanPrs({ not: 'an array' }, REQUIRED), (err) => {
+  assert.throws(() => scanPrs({ not: 'an array' }, REQUIRED, BASES), (err) => {
     assert.ok(err instanceof DirtyPrScanError);
     assert.equal(err.reason, 'BAD_INPUT');
     return true;
@@ -115,19 +139,21 @@ test('scanPrs + report: RED -- a scan containing the #3411 shape fails and names
   const prs = [
     {
       number: 3411,
+      baseRefName: 'main',
       mergeable: 'CONFLICTING',
       mergeStateStatus: 'DIRTY',
       statusCheckRollup: [lane('Vercel Agent Review')],
     },
     {
       number: 3417,
+      baseRefName: 'main',
       mergeable: 'CONFLICTING',
       mergeStateStatus: 'DIRTY',
       statusCheckRollup: REQUIRED.map(lane),
     },
   ];
-  const results = scanPrs(prs, REQUIRED);
-  const { ok, lines } = report(results, REQUIRED);
+  const results = scanPrs(prs, REQUIRED, BASES);
+  const { ok, lines } = report(results, REQUIRED, BASES);
   assert.equal(ok, false);
   assert.ok(lines.some((l) => l.includes('#3411')));
   assert.ok(!lines.some((l) => l.includes('#3417 ')));
@@ -135,11 +161,23 @@ test('scanPrs + report: RED -- a scan containing the #3411 shape fails and names
 
 test('scanPrs + report: GREEN -- an all-clean scan with lanes present passes', () => {
   const prs = [
-    { number: 1, mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', statusCheckRollup: REQUIRED.map(lane) },
-    { number: 2, mergeable: 'MERGEABLE', mergeStateStatus: 'BLOCKED', statusCheckRollup: REQUIRED.map(lane) },
+    {
+      number: 1,
+      baseRefName: 'main',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      statusCheckRollup: REQUIRED.map(lane),
+    },
+    {
+      number: 2,
+      baseRefName: 'main',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'BLOCKED',
+      statusCheckRollup: REQUIRED.map(lane),
+    },
   ];
-  const results = scanPrs(prs, REQUIRED);
-  const { ok, lines } = report(results, REQUIRED);
+  const results = scanPrs(prs, REQUIRED, BASES);
+  const { ok, lines } = report(results, REQUIRED, BASES);
   assert.equal(ok, true);
   assert.ok(lines.some((l) => l.startsWith('✅')));
 });
@@ -148,4 +186,147 @@ test('scanPrs + report: GREEN -- zero open PRs passes trivially', () => {
   const { ok, lines } = report(scanPrs([], REQUIRED), REQUIRED);
   assert.equal(ok, true);
   assert.ok(lines[0].includes('Scanned 0 open PR'));
+});
+
+test('classifyPr: RED -- a stacked PR is BASE_FILTERED, not CONFLICTED, even when it is also dirty', () => {
+  // #3411's real shape: base `fix-3353-snap-f32-invisible-floor`. `test.yml`
+  // fires `pull_request` only for `main`, so resolving the conflict restores
+  // nothing -- the cause that survives the merge is the one to report.
+  const pr = {
+    number: 3411,
+    baseRefName: 'fix-3353-snap-f32-invisible-floor',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    statusCheckRollup: [lane('Vercel Agent Review')],
+  };
+  const result = classifyPr(pr, REQUIRED, BASES);
+  assert.equal(result.silent, true);
+  assert.equal(result.cause, 'BASE_FILTERED');
+});
+
+test('classifyPr: RED -- a stacked PR that is perfectly mergeable is still silent', () => {
+  // #3411 and #3405 both read MERGEABLE/CLEAN with 0 of 15 lanes: no conflict
+  // anywhere, and no CI either. The conflict clause alone would miss them.
+  const pr = {
+    number: 3405,
+    baseRefName: 'fix-3338-isolate-expansion-gate',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: [lane('Vercel Agent Review')],
+  };
+  const result = classifyPr(pr, REQUIRED, BASES);
+  assert.equal(result.silent, true);
+  assert.equal(result.cause, 'BASE_FILTERED');
+});
+
+test('classifyPr: a stacked PR whose lanes are all present is not flagged', () => {
+  const pr = {
+    number: 3406,
+    baseRefName: 'some-feature-branch',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: REQUIRED.map(lane),
+  };
+  assert.equal(classifyPr(pr, REQUIRED, BASES).cause, null);
+});
+
+test('classifyPr: a `main`-based conflicted PR is CONFLICTED, not BASE_FILTERED', () => {
+  const pr = {
+    number: 2931,
+    baseRefName: 'main',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    statusCheckRollup: [],
+  };
+  assert.equal(classifyPr(pr, REQUIRED, BASES).cause, 'CONFLICTED');
+});
+
+test('classifyPr: fails closed rather than guessing when `baseRefName` is absent', () => {
+  // Defaulting either way hands out a remedy that may not work -- which is the
+  // defect this argument exists to remove.
+  assert.throws(
+    () => classifyPr({ number: 7, mergeable: 'CONFLICTING', statusCheckRollup: [] }, REQUIRED, BASES),
+    (err) => {
+      assert.ok(err instanceof DirtyPrScanError);
+      assert.equal(err.reason, 'NO_BASE_REF');
+      return true;
+    },
+  );
+});
+
+test('classifyPr: a workflow with no base filter (null) makes nothing base-filtered', () => {
+  const pr = { number: 8, baseRefName: 'anything', mergeable: 'MERGEABLE', statusCheckRollup: [] };
+  assert.equal(classifyPr(pr, REQUIRED, null).cause, null);
+});
+
+test('report: the stacked group gets the retarget remedy and NOT the resolve-the-conflict one', () => {
+  const results = scanPrs(
+    [
+      {
+        number: 3411,
+        baseRefName: 'fix-3353-snap-f32-invisible-floor',
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        statusCheckRollup: [],
+      },
+    ],
+    REQUIRED,
+    BASES,
+  );
+  const { ok, lines } = report(results, REQUIRED, BASES);
+  const text = lines.join('\n');
+  assert.equal(ok, false);
+  assert.match(text, /#3411/);
+  assert.match(text, /retarget the PR/i);
+  assert.doesNotMatch(text, /only resolving the\s+conflict/i);
+});
+
+test('report: both causes present are reported as separate groups with separate remedies', () => {
+  const results = scanPrs(
+    [
+      { number: 3411, baseRefName: 'a-feature-branch', mergeable: 'MERGEABLE', statusCheckRollup: [] },
+      { number: 2931, baseRefName: 'main', mergeable: 'CONFLICTING', statusCheckRollup: [] },
+    ],
+    REQUIRED,
+    BASES,
+  );
+  const { ok, lines } = report(results, REQUIRED, BASES);
+  const text = lines.join('\n');
+  assert.equal(ok, false);
+  assert.match(text, /retarget the PR/i);
+  assert.match(text, /only resolving the conflict/i);
+});
+
+test('pullRequestBaseBranches: reads test.yml`s own filter, not `push:`s', async () => {
+  const { readFileSync } = await import('node:fs');
+  const { dirname, join } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+  const here = dirname(fileURLToPath(import.meta.url));
+  const text = readFileSync(join(here, '../../.github/workflows/test.yml'), 'utf8');
+  assert.deepEqual(pullRequestBaseBranches(text), ['main']);
+});
+
+test('pullRequestBaseBranches: `pull_request:` with no `branches:` means no filter', () => {
+  assert.equal(pullRequestBaseBranches('on:\n  push:\n    branches: [main]\n  pull_request:\njobs:\n'), null);
+});
+
+test('pullRequestBaseBranches: reads a block list', () => {
+  assert.deepEqual(
+    pullRequestBaseBranches('on:\n  pull_request:\n    branches:\n      - main\n      - release\n  push:\n    branches: [dev]\n'),
+    ['main', 'release'],
+  );
+});
+
+test('pullRequestBaseBranches: refuses a glob it cannot evaluate rather than guessing', () => {
+  assert.throws(() => pullRequestBaseBranches('on:\n  pull_request:\n    branches: [main, "releases/**"]\n'), (err) => {
+    assert.equal(err.reason, 'UNSUPPORTED_BRANCH_PATTERN');
+    return true;
+  });
+});
+
+test('pullRequestBaseBranches: fails closed on a workflow with no `pull_request` trigger', () => {
+  assert.throws(() => pullRequestBaseBranches('on:\n  push:\n    branches: [main]\n'), (err) => {
+    assert.equal(err.reason, 'NO_PULL_REQUEST_TRIGGER');
+    return true;
+  });
 });

--- a/scripts/lib/dirty-pr-scan.test.mjs
+++ b/scripts/lib/dirty-pr-scan.test.mjs
@@ -433,6 +433,24 @@ test('pullRequestBaseBranches: reads a block list', () => {
   );
 });
 
+test('pullRequestBaseBranches: a comment between block-list items does not truncate the list', () => {
+  // Before this, the item loop broke on the first non-item line, so a comment
+  // (or blank line) between entries silently dropped every branch after it --
+  // and a PR based on a dropped branch would be handed the retarget remedy for
+  // a filter that actually allows it.
+  assert.deepEqual(
+    pullRequestBaseBranches('on:\n  pull_request:\n    branches:\n      - main\n      # release lane\n      - release\njobs:\n'),
+    ['main', 'release'],
+  );
+});
+
+test('pullRequestBaseBranches: a blank line between block-list items does not truncate the list', () => {
+  assert.deepEqual(
+    pullRequestBaseBranches('on:\n  pull_request:\n    branches:\n      - main\n\n      - release\njobs:\n'),
+    ['main', 'release'],
+  );
+});
+
 test('pullRequestBaseBranches: refuses a glob it cannot evaluate rather than guessing', () => {
   assert.throws(() => pullRequestBaseBranches('on:\n  pull_request:\n    branches: [main, "releases/**"]\n'), (err) => {
     assert.equal(err.reason, 'UNSUPPORTED_BRANCH_PATTERN');

--- a/scripts/lib/dirty-pr-scan.test.mjs
+++ b/scripts/lib/dirty-pr-scan.test.mjs
@@ -377,6 +377,9 @@ test('report: both causes present are reported as separate groups with separate 
  * lane the workflow actually publishes had run. See
  * scripts/lib/pr-review-signal.mjs's `matrixSkipAliases`/`missingLanes`.
  */
+// The literal `${{ }}` below is DATA, not a template this file means to interpolate: it is what
+// GitHub publishes as the check-run name for a matrix job skipped before it expanded.
+// oxlint-disable-next-line no-template-curly-in-string
 const MATRIX_TEMPLATE = 'Viewer tests (shard ${{ matrix.shard }})';
 const MATRIX_WF = `on:
   pull_request:

--- a/scripts/lib/dirty-pr-scan.test.mjs
+++ b/scripts/lib/dirty-pr-scan.test.mjs
@@ -281,6 +281,72 @@ test('report: the stacked group gets the retarget remedy and NOT the resolve-the
   assert.doesNotMatch(text, /only resolving the\s+conflict/i);
 });
 
+test('classifyPr: a stacked AND conflicted PR is flagged as needing both remedies', () => {
+  const both = {
+    number: 3411,
+    baseRefName: 'fix-3353-snap-f32-invisible-floor',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    statusCheckRollup: [lane('Vercel Agent Review')],
+  };
+  assert.equal(classifyPr(both, REQUIRED, BASES).alsoConflicted, true);
+
+  // The other direction, so the flag tracks the conflict rather than just the
+  // base filter: #3405 is stacked and perfectly mergeable.
+  const stackedOnly = {
+    number: 3405,
+    baseRefName: 'fix-3338-isolate-expansion-gate',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    statusCheckRollup: [lane('Vercel Agent Review')],
+  };
+  assert.equal(classifyPr(stackedOnly, REQUIRED, BASES).alsoConflicted, false);
+
+  // And a `main`-based conflicted PR is not "also" anything -- it is the
+  // CONFLICTED group, whose header already carries the resolve remedy.
+  const conflictedOnly = {
+    number: 2931,
+    baseRefName: 'main',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    statusCheckRollup: [],
+  };
+  assert.equal(classifyPr(conflictedOnly, REQUIRED, BASES).alsoConflicted, false);
+});
+
+test('report: RED -- the stacked AND conflicted PR carries the second remedy, not just the retarget', () => {
+  // Following the retarget line alone on this shape restores no lane: the PR is
+  // still DIRTY afterwards and GitHub fires no `pull_request` for it. The
+  // stacked-only PR beside it must NOT pick the extra line up.
+  const results = scanPrs(
+    [
+      {
+        number: 3411,
+        baseRefName: 'fix-3353-snap-f32-invisible-floor',
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        statusCheckRollup: [],
+      },
+      {
+        number: 3405,
+        baseRefName: 'fix-3338-isolate-expansion-gate',
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        statusCheckRollup: [],
+      },
+    ],
+    REQUIRED,
+    BASES,
+  );
+  const { lines } = report(results, REQUIRED, BASES);
+  const text = lines.join('\n');
+  assert.match(text, /retarget the PR/i);
+  assert.equal(lines.filter((l) => /ALSO conflicted/i.test(l)).length, 1, text);
+  assert.match(text, /resolve the conflict as well/i);
+  const flagged = lines.findIndex((l) => /ALSO conflicted/i.test(l));
+  assert.ok(lines[flagged - 2].includes('#3411'), text);
+});
+
 test('report: both causes present are reported as separate groups with separate remedies', () => {
   const results = scanPrs(
     [

--- a/scripts/lib/dirty-pr-scan.test.mjs
+++ b/scripts/lib/dirty-pr-scan.test.mjs
@@ -28,6 +28,7 @@ import {
   scanPrs,
   report,
 } from './dirty-pr-scan.mjs';
+import { matrixSkipAliases } from './pr-review-signal.mjs';
 
 const REQUIRED = ['Lint', 'Node tests', 'Rust tests', 'Typecheck'];
 const BASES = ['main'];
@@ -361,6 +362,54 @@ test('report: both causes present are reported as separate groups with separate 
   assert.equal(ok, false);
   assert.match(text, /retarget the PR/i);
   assert.match(text, /only resolving the conflict/i);
+});
+
+// ------------------------------------- a matrix job skipped BEFORE expanding (#3584 shape)
+
+/**
+ * Verbatim shape of PR #3581's rollup: a matrix job skipped by `if:` before
+ * its `strategy.matrix` fanned out publishes ONE check run, under the
+ * unexpanded template, never the per-shard names. `expandJobNames` derives
+ * `Viewer tests (shard 0)`..`(shard 3)`; this file's own `missingLanes` used
+ * to compare those names against the rollup with plain Set membership, which
+ * could never find them present -- a conflicted PR touching neither
+ * `frontend` nor `rust` paths would report `CONFLICTED` even though every
+ * lane the workflow actually publishes had run. See
+ * scripts/lib/pr-review-signal.mjs's `matrixSkipAliases`/`missingLanes`.
+ */
+const MATRIX_TEMPLATE = 'Viewer tests (shard ${{ matrix.shard }})';
+const MATRIX_WF = `on:
+  pull_request:
+jobs:
+  viewer-tests:
+    name: ${MATRIX_TEMPLATE}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - run: true
+`;
+const MATRIX_REQUIRED = [0, 1, 2, 3].map((n) => `Viewer tests (shard ${n})`);
+
+test('missingLanes: a wholesale-skipped matrix job counts as present given its aliases', () => {
+  const aliases = matrixSkipAliases(MATRIX_WF);
+  const rollup = [{ name: MATRIX_TEMPLATE, state: 'skipped' }];
+  assert.deepEqual(missingLanes(MATRIX_REQUIRED, rollup, aliases), []);
+});
+
+test('classifyPr: GREEN -- a PR whose matrix job skipped wholesale before expanding is not silent', () => {
+  const pr = {
+    number: 3581,
+    baseRefName: 'main',
+    mergeable: 'CONFLICTING',
+    mergeStateStatus: 'DIRTY',
+    statusCheckRollup: [{ name: MATRIX_TEMPLATE, state: 'skipped' }],
+  };
+  const aliases = matrixSkipAliases(MATRIX_WF);
+  const result = classifyPr(pr, MATRIX_REQUIRED, BASES, aliases);
+  assert.equal(result.silent, false, 'every shard is covered by the wholesale-skip alias');
+  assert.deepEqual(result.missing, []);
 });
 
 test('pullRequestBaseBranches: reads pull_request`s filter, not push`s', () => {

--- a/scripts/lib/workflow-base-branches.mjs
+++ b/scripts/lib/workflow-base-branches.mjs
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+import { DirtyPrScanError } from './dirty-pr-scan.mjs';
+
+/**
+ * `pullRequestBaseBranches` parses `test.yml`'s `on: pull_request: branches:`
+ * filter out of the workflow's own text -- the base-branch half of the
+ * #3443/#3429 gate in `dirty-pr-scan.mjs`. Split into its own module because
+ * it is pure YAML-fragment parsing with no dependency on PR classification;
+ * `dirty-pr-scan.mjs` re-exports `pullRequestBaseBranches` so existing
+ * imports are unaffected.
+ */
+
+/**
+ * The base branches `test.yml` will fire `pull_request` for.
+ *
+ * WHY THIS EXISTS: a missing lane has TWO causes, not one, and they need
+ * opposite remedies. `.github/workflows/test.yml` opens with
+ * `on: pull_request: branches: [main]`, so a stacked PR based on a feature
+ * branch never fires it -- measured on #3411 (base
+ * `fix-3353-snap-f32-invisible-floor`) and #3405 (base
+ * `fix-3338-isolate-expansion-gate`), both reading MERGEABLE/CLEAN with 0 of
+ * the 15 required lanes present. Telling such a PR to resolve a merge conflict
+ * is advice that provably cannot work: the base filter still blocks the
+ * workflow afterwards. This is #3429's first case; the conflicted PR is its
+ * second.
+ *
+ * Parsed from the workflow text rather than hardcoded, for the same reason the
+ * lane names are: a constant here would silently diverge the day the filter
+ * changes, and the failure mode of a diverged constant is a wrong remedy, not
+ * a loud error.
+ *
+ * @param {string} text - `.github/workflows/test.yml` contents.
+ * @returns {string[] | null} the allowed base branches, or `null` when
+ *   `pull_request` carries no `branches:` filter at all (every base fires).
+ */
+export function pullRequestBaseBranches(text) {
+  if (typeof text !== 'string' || text.trim() === '') {
+    throw new DirtyPrScanError('NO_WORKFLOW_TEXT', 'The workflow text is empty, so its `pull_request` base filter cannot be read.');
+  }
+  const lines = text.split(/\r?\n/);
+
+  let i = lines.findIndex((l) => /^on:\s*(#.*)?$/.test(l));
+  if (i === -1) {
+    throw new DirtyPrScanError('NO_ON_BLOCK', 'The workflow has no top-level `on:` block, so its triggers cannot be read.');
+  }
+
+  // Walk the `on:` block for `pull_request:`; a line starting in column 0 ends it.
+  let prIndent = -1;
+  for (i += 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() !== '' && /^\S/.test(line)) break;
+    const m = /^(\s+)pull_request:\s*(#.*)?$/.exec(line);
+    if (m) {
+      prIndent = m[1].length;
+      break;
+    }
+  }
+  if (prIndent === -1) {
+    throw new DirtyPrScanError(
+      'NO_PULL_REQUEST_TRIGGER',
+      'The workflow has no `pull_request:` trigger. This gate exists to explain why a ' +
+        '`pull_request` lane is absent; against a workflow that has no such trigger the ' +
+        'question is meaningless, and answering it anyway would be a guess.',
+    );
+  }
+
+  // Walk `pull_request:`'s own body for `branches:`; anything at or left of its
+  // indent ends it (that is `push:`, whose own `branches: [main]` must not be read here).
+  for (i += 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === '' || /^\s*#/.test(line)) continue;
+    const indent = line.length - line.trimStart().length;
+    if (indent <= prIndent) return null; // `pull_request:` had no `branches:` filter.
+
+    const flow = /^\s*branches:\s*\[([^\]]*)\]\s*(#.*)?$/.exec(line);
+    if (flow) return finishBranches(splitFlowList(flow[1]));
+
+    if (/^\s*branches:\s*(#.*)?$/.test(line)) {
+      const items = [];
+      for (i += 1; i < lines.length; i += 1) {
+        const item = /^\s*-\s*(.+?)\s*$/.exec(lines[i]);
+        if (!item) break;
+        items.push(stripQuotes(item[1]));
+      }
+      return finishBranches(items);
+    }
+  }
+  return null;
+}
+
+/** @param {string} raw */
+function splitFlowList(raw) {
+  return raw
+    .split(',')
+    .map((v) => stripQuotes(v.trim()))
+    .filter((v) => v !== '');
+}
+
+/** @param {string} v */
+function stripQuotes(v) {
+  return v.replace(/^['"]|['"]$/g, '');
+}
+
+/** @param {string[]} branches */
+function finishBranches(branches) {
+  if (branches.length === 0) {
+    throw new DirtyPrScanError(
+      'EMPTY_BASE_BRANCHES',
+      'The workflow declares a `pull_request` `branches:` filter with no entries. Every PR ' +
+        'would read as base-filtered, which is a wrong verdict rather than a missing one.',
+    );
+  }
+  for (const b of branches) {
+    if (/[*?[\]!+]/.test(b)) {
+      throw new DirtyPrScanError(
+        'UNSUPPORTED_BRANCH_PATTERN',
+        `The \`pull_request\` \`branches:\` filter contains the glob \`${b}\`, which this gate ` +
+          'does not evaluate. Matching it wrongly would hand a PR a remedy that cannot work; ' +
+          'teach this function the pattern syntax instead of guessing.',
+      );
+    }
+  }
+  return branches;
+}

--- a/scripts/lib/workflow-base-branches.mjs
+++ b/scripts/lib/workflow-base-branches.mjs
@@ -80,6 +80,9 @@ export function pullRequestBaseBranches(text) {
     if (/^\s*branches:\s*(#.*)?$/.test(line)) {
       const items = [];
       for (i += 1; i < lines.length; i += 1) {
+        // Blank and comment lines are legal between YAML sequence items and do
+        // not end the list; breaking on them silently truncates it.
+        if (lines[i].trim() === '' || /^\s*#/.test(lines[i])) continue;
         const item = /^\s*-\s*(.+?)\s*$/.exec(lines[i]);
         if (!item) break;
         items.push(stripQuotes(item[1]));

--- a/scripts/scan-dirty-prs.mjs
+++ b/scripts/scan-dirty-prs.mjs
@@ -39,7 +39,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { DirtyPrScanError, pullRequestBaseBranches, scanPrs, report } from './lib/dirty-pr-scan.mjs';
-import { expandJobNames } from './lib/pr-review-signal.mjs';
+import { expandJobNames, matrixSkipAliases } from './lib/pr-review-signal.mjs';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(SCRIPTS_DIR, '..');
@@ -143,6 +143,10 @@ async function main() {
   const workflowText = readFileSync(args.workflow, 'utf8');
   const required = expandJobNames(workflowText, { exclude: EXCLUDE_JOB_KEYS });
   const baseBranches = pullRequestBaseBranches(workflowText);
+  // Same exclude list as `expandJobNames` above -- passing it to only one of
+  // the two derivations is a silent, asymmetric failure: the lane would stay
+  // required while its wholesale-skip alias disappears.
+  const aliases = matrixSkipAliases(workflowText, { exclude: EXCLUDE_JOB_KEYS });
 
   let prs;
   if (args.stateFile) {
@@ -159,7 +163,7 @@ async function main() {
     prs = fetchOpenPrs({ repo: args.repo, limit: args.limit });
   }
 
-  const results = scanPrs(prs, required, baseBranches);
+  const results = scanPrs(prs, required, baseBranches, aliases);
   const { ok, lines } = report(results, required, baseBranches);
   for (const l of lines) console.log(l);
 

--- a/scripts/scan-dirty-prs.mjs
+++ b/scripts/scan-dirty-prs.mjs
@@ -15,16 +15,22 @@
  * Only a job on an independent trigger, asking the API which open PRs are
  * conflicted, can see this. See .github/workflows/dirty-pr-scan.yml.
  *
+ * WHAT IT REPORTS: the two causes of silent `pull_request` CI, separately,
+ * because they take opposite remedies -- a base `test.yml` does not run on
+ * (#3429's first case: retarget the PR; a merge cannot help) and an unresolved
+ * merge conflict (#3443, #3429's second case: resolve it). See
+ * `classifyPr` in scripts/lib/dirty-pr-scan.mjs.
+ *
  * WHAT THIS CANNOT DETECT: a single-PR problem (this only runs against the
- * live list of open PRs, on a cron cadence -- it has no way to answer "is PR
- * #N clean right now" between runs; use `--pr` for that), a PR that has gone
- * quietly stale (GitHub's own `UNKNOWN` mergeable state is reported but not
- * failed on, since it self-resolves), and a PR whose lanes are ABSENT for a
- * DIFFERENT reason (a real failure, a path filter, #3429's base-branch filter
- * on a stacked PR) -- those aren't paired with `mergeable: CONFLICTING` and so
- * are out of scope for this specific gate on purpose. It also cannot detect
- * conflicts closed and reopened between polls; the cron interval IS the
- * detection latency.
+ * live list of open PRs, on a cron cadence, and has no way to answer "is PR #N
+ * clean right now" between runs), a PR that has gone quietly stale (GitHub's
+ * own `UNKNOWN` mergeable state is reported but not failed on, since it
+ * self-resolves), and a lane ABSENT for a reason this gate cannot name -- a
+ * real failure, a path filter, a lane still queued on an otherwise-clean PR --
+ * which is deliberately out of scope, since naming a cause it has not
+ * established is how a gate starts handing out remedies that do not work. It
+ * also cannot detect conflicts closed and reopened between polls; the cron
+ * interval IS the detection latency.
  */
 
 import { readFileSync, existsSync, appendFileSync } from 'node:fs';
@@ -32,7 +38,7 @@ import { spawnSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { DirtyPrScanError, scanPrs, report } from './lib/dirty-pr-scan.mjs';
+import { DirtyPrScanError, pullRequestBaseBranches, scanPrs, report } from './lib/dirty-pr-scan.mjs';
 import { expandJobNames } from './lib/pr-review-signal.mjs';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
@@ -113,7 +119,9 @@ function fetchOpenPrs({ repo, limit }) {
       '--state',
       'open',
       '--json',
-      'number,title,url,mergeable,mergeStateStatus,isDraft,statusCheckRollup',
+      // `baseRefName` is load-bearing, not decoration: without it `classifyPr`
+      // cannot tell a stacked PR from a conflicted one and fails closed.
+      'number,title,url,baseRefName,mergeable,mergeStateStatus,isDraft,statusCheckRollup',
       '--limit',
       String(limit),
       '--repo',
@@ -132,7 +140,9 @@ async function main() {
       `Workflow \`${args.workflow}\` does not exist, so the required lane set cannot be derived.`,
     );
   }
-  const required = expandJobNames(readFileSync(args.workflow, 'utf8'), { exclude: EXCLUDE_JOB_KEYS });
+  const workflowText = readFileSync(args.workflow, 'utf8');
+  const required = expandJobNames(workflowText, { exclude: EXCLUDE_JOB_KEYS });
+  const baseBranches = pullRequestBaseBranches(workflowText);
 
   let prs;
   if (args.stateFile) {
@@ -149,8 +159,8 @@ async function main() {
     prs = fetchOpenPrs({ repo: args.repo, limit: args.limit });
   }
 
-  const results = scanPrs(prs, required);
-  const { ok, lines } = report(results, required);
+  const results = scanPrs(prs, required, baseBranches);
+  const { ok, lines } = report(results, required, baseBranches);
   for (const l of lines) console.log(l);
 
   if (args.summaryFile) {

--- a/scripts/scan-dirty-prs.mjs
+++ b/scripts/scan-dirty-prs.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * Reports open PRs whose `pull_request` CI never ran because the PR is
+ * conflicted (issue #3443). See scripts/lib/dirty-pr-scan.mjs for the measured
+ * evidence and the classification rule; this file is the I/O half.
+ *
+ * WHY THIS RUNS ON `schedule`/`workflow_dispatch` AND NOT `pull_request`: the
+ * whole defect is that GitHub does not fire `pull_request` for a PR it cannot
+ * compute a merge ref for. A job triggered BY `pull_request` -- including
+ * `.github/workflows/pr-review-signal.yml`, built for the adjacent absence
+ * defect in #3312 -- inherits exactly the blindness it would need to report on.
+ * Only a job on an independent trigger, asking the API which open PRs are
+ * conflicted, can see this. See .github/workflows/dirty-pr-scan.yml.
+ *
+ * WHAT THIS CANNOT DETECT: a single-PR problem (this only runs against the
+ * live list of open PRs, on a cron cadence -- it has no way to answer "is PR
+ * #N clean right now" between runs; use `--pr` for that), a PR that has gone
+ * quietly stale (GitHub's own `UNKNOWN` mergeable state is reported but not
+ * failed on, since it self-resolves), and a PR whose lanes are ABSENT for a
+ * DIFFERENT reason (a real failure, a path filter, #3429's base-branch filter
+ * on a stacked PR) -- those aren't paired with `mergeable: CONFLICTING` and so
+ * are out of scope for this specific gate on purpose. It also cannot detect
+ * conflicts closed and reopened between polls; the cron interval IS the
+ * detection latency.
+ */
+
+import { readFileSync, existsSync, appendFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { DirtyPrScanError, scanPrs, report } from './lib/dirty-pr-scan.mjs';
+import { expandJobNames } from './lib/pr-review-signal.mjs';
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(SCRIPTS_DIR, '..');
+const DEFAULT_WORKFLOW = join(REPO_ROOT, '.github/workflows/test.yml');
+
+// Same exclusion as scripts/pr-review-signal.config.json's `excludeJobKeys`,
+// and the same reason: the `test` aggregate `needs:` every other job and
+// publishes no check run until all finish, so requiring it here would flag a
+// PR that is merely mid-run as though it were conflicted-and-silent. This
+// scan runs on a cron cadence rather than right after a push, so that race is
+// narrower than #3312's, but it is not zero -- a PR can go dirty seconds after
+// a push the cron catches mid-flight.
+const EXCLUDE_JOB_KEYS = ['test'];
+
+/** @param {string[]} argv */
+function parseArgs(argv) {
+  const args = {
+    workflow: DEFAULT_WORKFLOW,
+    repo: process.env.GITHUB_REPOSITORY,
+    limit: 100,
+    stateFile: null,
+    summaryFile: process.env.GITHUB_STEP_SUMMARY ?? null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--workflow') args.workflow = argv[++i];
+    else if (a === '--repo') args.repo = argv[++i];
+    else if (a === '--limit') args.limit = Number(argv[++i]);
+    else if (a === '--state-file') args.stateFile = argv[++i];
+    else if (a === '--summary-file') args.summaryFile = argv[++i];
+    else {
+      throw new DirtyPrScanError('BAD_ARGS', `Unrecognized argument \`${a}\`.`);
+    }
+  }
+  return args;
+}
+
+/**
+ * `gh` with fail-closed error handling, matching
+ * scripts/check-pr-review-signal.mjs's `gh()`: anything other than a clean
+ * exit and parseable JSON is a named error, never an empty result standing in
+ * for "no open PRs".
+ *
+ * @param {string[]} args
+ * @param {string} what
+ */
+function gh(args, what) {
+  const r = spawnSync('gh', args, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+  if (r.error) {
+    throw new DirtyPrScanError(
+      'GH_UNAVAILABLE',
+      `Could not spawn \`gh\` to fetch ${what}: ${r.error.message}.`,
+    );
+  }
+  if (r.status !== 0) {
+    throw new DirtyPrScanError(
+      'GH_ERROR',
+      `\`gh ${args.join(' ')}\` exited ${r.status} while fetching ${what}: ` +
+        `${(r.stderr || '').trim() || '(no stderr)'}`,
+    );
+  }
+  try {
+    return JSON.parse(r.stdout);
+  } catch (err) {
+    throw new DirtyPrScanError(
+      'GH_BAD_JSON',
+      `\`gh ${args.join(' ')}\` returned unparseable output while fetching ${what}: ${err.message}`,
+    );
+  }
+}
+
+function fetchOpenPrs({ repo, limit }) {
+  return gh(
+    [
+      'pr',
+      'list',
+      '--state',
+      'open',
+      '--json',
+      'number,title,url,mergeable,mergeStateStatus,isDraft,statusCheckRollup',
+      '--limit',
+      String(limit),
+      '--repo',
+      repo,
+    ],
+    'the open PR list',
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!existsSync(args.workflow)) {
+    throw new DirtyPrScanError(
+      'NO_WORKFLOW_TEXT',
+      `Workflow \`${args.workflow}\` does not exist, so the required lane set cannot be derived.`,
+    );
+  }
+  const required = expandJobNames(readFileSync(args.workflow, 'utf8'), { exclude: EXCLUDE_JOB_KEYS });
+
+  let prs;
+  if (args.stateFile) {
+    // Offline mode for the regression harness: a JSON array standing in for
+    // `gh pr list`'s output, driving the identical `scanPrs`/`report`.
+    prs = JSON.parse(readFileSync(args.stateFile, 'utf8'));
+  } else {
+    if (!args.repo) {
+      throw new DirtyPrScanError(
+        'NO_REPO',
+        'Pass `--repo owner/name` or set GITHUB_REPOSITORY (or use `--state-file` for tests).',
+      );
+    }
+    prs = fetchOpenPrs({ repo: args.repo, limit: args.limit });
+  }
+
+  const results = scanPrs(prs, required);
+  const { ok, lines } = report(results, required);
+  for (const l of lines) console.log(l);
+
+  if (args.summaryFile) {
+    try {
+      appendFileSync(args.summaryFile, `\n${lines.join('\n')}\n`);
+    } catch {
+      // A summary write failing is not itself a reason to fail the scan.
+    }
+  }
+
+  process.exit(ok ? 0 : 1);
+}
+
+if (process.argv[1] && process.argv[1].endsWith('scan-dirty-prs.mjs')) {
+  try {
+    await main();
+  } catch (err) {
+    if (err instanceof DirtyPrScanError) {
+      console.error(`❌ ${err.reason}: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -209,6 +209,9 @@ test('fails closed rather than guessing a remedy when `baseRefName` is absent', 
 
 // ------------------------------------- a matrix job skipped BEFORE expanding (#3584 shape)
 
+// The literal `${{ }}` below is DATA, not a template this file means to interpolate: it is what
+// GitHub publishes as the check-run name for a matrix job skipped before it expanded.
+// oxlint-disable-next-line no-template-curly-in-string
 const MATRIX_TEMPLATE = 'Viewer tests (shard ${{ matrix.shard }})';
 
 function matrixWorkflowFixture() {

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+/**
+ * Regression harness for the #3443 gate as a PROCESS: real argv, real workflow
+ * read, real exit codes. `scripts/lib/dirty-pr-scan.test.mjs` covers the
+ * classification; this covers `--state-file` mode, which is also how CI would
+ * drive this script offline if it ever needed to (it does not: the live
+ * workflow always calls `gh pr list`).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, 'scan-dirty-prs.mjs');
+
+const TMP = mkdtempSync(join(tmpdir(), 'dirty-pr-scan-'));
+let seq = 0;
+
+function run(prs, extra = []) {
+  const path = join(TMP, `state-${(seq += 1)}.json`);
+  writeFileSync(path, JSON.stringify(prs));
+  const r = spawnSync(process.execPath, [GATE, '--state-file', path, ...extra], { encoding: 'utf8' });
+  return { code: r.status, output: `${r.stdout}${r.stderr}` };
+}
+
+function lane(name) {
+  return { name };
+}
+
+// The workflow's own required set at time of writing -- read once here, not
+// hardcoded, so this test does not rot when test.yml's job list changes.
+async function requiredLaneNames() {
+  const { expandJobNames } = await import('./lib/pr-review-signal.mjs');
+  const { readFileSync } = await import('node:fs');
+  const text = readFileSync(join(HERE, '../.github/workflows/test.yml'), 'utf8');
+  return expandJobNames(text, { exclude: ['test'] });
+}
+
+test('RED: a #3411-shaped conflicted PR with no required lanes present fails and is named', async () => {
+  const required = await requiredLaneNames();
+  const { code, output } = run([
+    {
+      number: 3411,
+      title: 'fix(core): order-independence',
+      url: 'https://github.com/LTplus-AG/ifc-lite/pull/3411',
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY',
+      isDraft: false,
+      statusCheckRollup: [lane('Vercel Agent Review'), lane('Vercel Preview Comments')],
+    },
+  ]);
+  assert.equal(code, 1, output);
+  assert.match(output, /#3411/);
+  assert.match(output, /pushing a new commit will not fix this/i);
+  assert.ok(required.includes('Node tests'));
+  assert.match(output, /Node tests/);
+});
+
+test('GREEN: a clean PR with every required lane present passes', async () => {
+  const required = await requiredLaneNames();
+  const { code, output } = run([
+    {
+      number: 9001,
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'BLOCKED',
+      isDraft: false,
+      statusCheckRollup: required.map(lane),
+    },
+  ]);
+  assert.equal(code, 0, output);
+  assert.match(output, /✅/);
+});
+
+test('GREEN: a conflicted PR whose lanes already ran (the #3417 shape) passes', async () => {
+  const required = await requiredLaneNames();
+  const { code, output } = run([
+    {
+      number: 3417,
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY',
+      isDraft: false,
+      statusCheckRollup: required.map(lane).concat([lane('Vercel Agent Review')]),
+    },
+  ]);
+  assert.equal(code, 0, output);
+});
+
+test('zero open PRs passes trivially', () => {
+  const { code, output } = run([]);
+  assert.equal(code, 0, output);
+  assert.match(output, /Scanned 0 open PR/);
+});
+
+test('fails closed rather than silently passing when the state file is not an array', () => {
+  const { code, output } = run({ not: 'an array' });
+  assert.equal(code, 1, output);
+  assert.match(output, /BAD_INPUT/);
+});
+
+test('requires --repo or --state-file', () => {
+  const r = spawnSync(process.execPath, [GATE], { encoding: 'utf8', env: { ...process.env, GITHUB_REPOSITORY: '' } });
+  assert.equal(r.status, 1);
+  assert.match(`${r.stdout}${r.stderr}`, /NO_REPO/);
+});

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -155,6 +155,70 @@ test('RED: a stacked PR that is fully mergeable is still reported', async () => 
   assert.match(output, /retarget the PR/i, output);
 });
 
+test('RED: a stacked PR that is ALSO conflicted is told to resolve the conflict too', async () => {
+  // #3411's real shape again. Retargeting it at `main` clears the base filter
+  // and leaves it DIRTY, and GitHub fires no `pull_request` for a PR it cannot
+  // compute a merge ref for -- so the retarget line alone sends a maintainer to
+  // do half the work and get zero lanes back. Both remedies, on one run.
+  await requiredLaneNames();
+  const { code, output } = run([
+    {
+      number: 3411,
+      baseRefName: 'fix-3353-snap-f32-invisible-floor',
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY',
+      isDraft: false,
+      statusCheckRollup: [lane('Vercel Agent Review')],
+    },
+  ]);
+  assert.equal(code, 1, output);
+  assert.match(output, /retarget the PR/i, output);
+  assert.match(output, /ALSO conflicted/i, output);
+  assert.match(output, /resolve the conflict as well/i, output);
+});
+
+test('a stacked PR that is NOT conflicted gets the retarget remedy only', async () => {
+  // The other direction: #3405 is MERGEABLE/CLEAN, so telling it to resolve a
+  // conflict it does not have would be the same wrong-remedy defect inverted.
+  await requiredLaneNames();
+  const { code, output } = run([
+    {
+      number: 3405,
+      baseRefName: 'fix-3338-isolate-expansion-gate',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      isDraft: false,
+      statusCheckRollup: [lane('Vercel Agent Review')],
+    },
+  ]);
+  assert.equal(code, 1, output);
+  assert.match(output, /retarget the PR/i, output);
+  assert.doesNotMatch(output, /ALSO conflicted/i, output);
+});
+
+test('the scan workflow grants the check-run and commit-status reads its verdict rests on', async () => {
+  // Declaring ANY `permissions:` block sets every unlisted scope to `none`, and
+  // every verdict this gate reaches comes from `statusCheckRollup` -- check runs
+  // and commit statuses, neither of which `pull-requests: read` covers. With
+  // them missing the job either dies on `gh` or reads an empty rollup, and an
+  // empty rollup makes a PR that ran all 15 lanes before going dirty (#3417,
+  // #3447) indistinguishable from one that never ran any. Nothing in a local
+  // run can catch that: a developer's `gh` auth is full-scope, the Actions
+  // token is not, so the coupling is asserted here instead.
+  const { readFileSync } = await import('node:fs');
+  const text = readFileSync(join(HERE, '../.github/workflows/dirty-pr-scan.yml'), 'utf8');
+  const block = /^permissions:\n((?:[ \t]+\S.*\n|[ \t]*\n)*)/m.exec(text);
+  assert.ok(block, 'dirty-pr-scan.yml declares no top-level `permissions:` block');
+  const scopes = new Map();
+  for (const line of block[1].split('\n')) {
+    const m = /^\s+([a-z-]+):\s*(\S+)\s*$/.exec(line);
+    if (m) scopes.set(m[1], m[2]);
+  }
+  assert.equal(scopes.get('checks'), 'read', 'the rollup carries check runs');
+  assert.equal(scopes.get('statuses'), 'read', 'the rollup carries commit statuses too');
+  assert.equal(scopes.get('pull-requests'), 'read', 'the scan lists open PRs');
+});
+
 test('fails closed rather than guessing a remedy when `baseRefName` is absent', () => {
   const { code, output } = run([
     { number: 3411, mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY', statusCheckRollup: [] },

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -206,3 +206,46 @@ test('fails closed rather than guessing a remedy when `baseRefName` is absent', 
   assert.equal(code, 1, output);
   assert.match(output, /NO_BASE_REF/);
 });
+
+// ------------------------------------- a matrix job skipped BEFORE expanding (#3584 shape)
+
+const MATRIX_TEMPLATE = 'Viewer tests (shard ${{ matrix.shard }})';
+
+function matrixWorkflowFixture() {
+  const path = join(TMP, `workflow-${(seq += 1)}.yml`);
+  writeFileSync(
+    path,
+    `on:\n  pull_request:\n    branches: [main]\njobs:\n  lint:\n    name: Lint\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n  viewer-tests:\n    name: ${MATRIX_TEMPLATE}\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        shard: [0, 1, 2, 3]\n    steps:\n      - run: true\n`,
+  );
+  return path;
+}
+
+test('GREEN: a matrix job skipped wholesale before expanding is not silent CI (the #3581 shape)', () => {
+  // Measured on PR #3581: a docs/scripts/config-only change (no `frontend` or
+  // `rust` paths touched) skips `viewer-tests` via `if:` before its
+  // `strategy.matrix` fans out, so GitHub publishes ONE check run under the
+  // unexpanded template -- never `Viewer tests (shard 0)`..`(shard 3)`, the
+  // names `expandJobNames` derives. Before this scan reused
+  // `pr-review-signal.mjs`'s alias-aware `missingLanes`, its own local,
+  // plain-membership version could never match those four names against
+  // anything, so a conflicted PR of this shape misreported `CONFLICTED` even
+  // though every lane the workflow actually publishes had run.
+  const { code, output } = run(
+    [
+      {
+        number: 3581,
+        baseRefName: 'main',
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        isDraft: false,
+        statusCheckRollup: [
+          { name: 'Lint', state: 'success' },
+          { name: MATRIX_TEMPLATE, state: 'skipped' },
+        ],
+      },
+    ],
+    { workflow: matrixWorkflowFixture() },
+  );
+  assert.equal(code, 0, output);
+  assert.match(output, /✅/, output);
+});

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -49,6 +49,7 @@ test('RED: a #3411-shaped conflicted PR with no required lanes present fails and
       number: 3411,
       title: 'fix(core): order-independence',
       url: 'https://github.com/LTplus-AG/ifc-lite/pull/3411',
+      baseRefName: 'main',
       mergeable: 'CONFLICTING',
       mergeStateStatus: 'DIRTY',
       isDraft: false,
@@ -58,6 +59,7 @@ test('RED: a #3411-shaped conflicted PR with no required lanes present fails and
   assert.equal(code, 1, output);
   assert.match(output, /#3411/);
   assert.match(output, /pushing a new commit will not fix this/i);
+  assert.doesNotMatch(output, /retarget the PR/i);
   assert.ok(required.includes('Node tests'));
   assert.match(output, /Node tests/);
 });
@@ -67,6 +69,7 @@ test('GREEN: a clean PR with every required lane present passes', async () => {
   const { code, output } = run([
     {
       number: 9001,
+      baseRefName: 'main',
       mergeable: 'MERGEABLE',
       mergeStateStatus: 'BLOCKED',
       isDraft: false,
@@ -82,6 +85,7 @@ test('GREEN: a conflicted PR whose lanes already ran (the #3417 shape) passes', 
   const { code, output } = run([
     {
       number: 3417,
+      baseRefName: 'main',
       mergeable: 'CONFLICTING',
       mergeStateStatus: 'DIRTY',
       isDraft: false,
@@ -107,4 +111,54 @@ test('requires --repo or --state-file', () => {
   const r = spawnSync(process.execPath, [GATE], { encoding: 'utf8', env: { ...process.env, GITHUB_REPOSITORY: '' } });
   assert.equal(r.status, 1);
   assert.match(`${r.stdout}${r.stderr}`, /NO_REPO/);
+});
+
+test('RED: a stacked PR is named with the retarget remedy, never the resolve-the-conflict one', async () => {
+  // The failing input from the review: #3411's real base. Before this gate read
+  // `baseRefName` it printed "only resolving the conflict ... restores CI",
+  // which cannot restore a lane while `test.yml` filters on `branches: [main]`.
+  await requiredLaneNames();
+  const { code, output } = run([
+    {
+      number: 3411,
+      title: 'fix(core): order-independence',
+      url: 'https://github.com/LTplus-AG/ifc-lite/pull/3411',
+      baseRefName: 'fix-3353-snap-f32-invisible-floor',
+      mergeable: 'CONFLICTING',
+      mergeStateStatus: 'DIRTY',
+      isDraft: false,
+      statusCheckRollup: [lane('Vercel Agent Review')],
+    },
+  ]);
+  assert.equal(code, 1, output);
+  assert.match(output, /#3411/);
+  assert.match(output, /retarget the PR/i, output);
+  assert.doesNotMatch(output, /only resolving the conflict/i, output);
+});
+
+test('RED: a stacked PR that is fully mergeable is still reported', async () => {
+  // #3405's live shape: MERGEABLE/CLEAN, 0 of 15 lanes. Nothing about a merge
+  // conflict is involved, so a conflict-only gate is blind to it.
+  await requiredLaneNames();
+  const { code, output } = run([
+    {
+      number: 3405,
+      baseRefName: 'fix-3338-isolate-expansion-gate',
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+      isDraft: false,
+      statusCheckRollup: [lane('Vercel Agent Review')],
+    },
+  ]);
+  assert.equal(code, 1, output);
+  assert.match(output, /#3405/);
+  assert.match(output, /retarget the PR/i, output);
+});
+
+test('fails closed rather than guessing a remedy when `baseRefName` is absent', () => {
+  const { code, output } = run([
+    { number: 3411, mergeable: 'CONFLICTING', mergeStateStatus: 'DIRTY', statusCheckRollup: [] },
+  ]);
+  assert.equal(code, 1, output);
+  assert.match(output, /NO_BASE_REF/);
 });

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -11,7 +11,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -25,7 +25,13 @@ let seq = 0;
 function run(prs, { workflow = workflowFixture(), extra = [] } = {}) {
   const path = join(TMP, `state-${(seq += 1)}.json`);
   writeFileSync(path, JSON.stringify(prs));
-  const r = spawnSync(process.execPath, [GATE, '--workflow', workflow, '--state-file', path, ...extra], { encoding: 'utf8' });
+  // GITHUB_STEP_SUMMARY is blanked so a gate spawned under a real CI job does
+  // not append fixture findings to that job's actual step summary; the gate
+  // treats '' as "no summary file".
+  const r = spawnSync(process.execPath, [GATE, '--workflow', workflow, '--state-file', path, ...extra], {
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_STEP_SUMMARY: '' },
+  });
   return { code: r.status, output: `${r.stdout}${r.stderr}` };
 }
 
@@ -97,6 +103,24 @@ test('zero open PRs passes trivially', () => {
   const { code, output } = run([]);
   assert.equal(code, 0, output);
   assert.match(output, /Scanned 0 open PR/);
+});
+
+test('the harness does not leak fixture findings into the ambient GITHUB_STEP_SUMMARY', () => {
+  // The gate defaults its summary file from GITHUB_STEP_SUMMARY, so a `run()`
+  // that inherits the ambient environment appends every fixture's fake
+  // findings to the REAL step summary of whatever CI job runs this test file.
+  const summary = join(TMP, `ambient-summary-${(seq += 1)}.md`);
+  writeFileSync(summary, '');
+  const prev = process.env.GITHUB_STEP_SUMMARY;
+  process.env.GITHUB_STEP_SUMMARY = summary;
+  try {
+    const { code } = run([]);
+    assert.equal(code, 0);
+  } finally {
+    if (prev === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+    else process.env.GITHUB_STEP_SUMMARY = prev;
+  }
+  assert.equal(readFileSync(summary, 'utf8'), '');
 });
 
 test('fails closed rather than silently passing when the state file is not an array', () => {

--- a/scripts/scan-dirty-prs.test.mjs
+++ b/scripts/scan-dirty-prs.test.mjs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 /**
- * Regression harness for the #3443 gate as a PROCESS: real argv, real workflow
- * read, real exit codes. `scripts/lib/dirty-pr-scan.test.mjs` covers the
+ * Regression harness for the #3443 gate as a process: real argv, workflow
+ * fixtures, and real exit codes. `scripts/lib/dirty-pr-scan.test.mjs` covers
  * classification; this covers `--state-file` mode, which is also how CI would
  * drive this script offline if it ever needed to (it does not: the live
  * workflow always calls `gh pr list`).
@@ -22,10 +22,10 @@ const GATE = join(HERE, 'scan-dirty-prs.mjs');
 const TMP = mkdtempSync(join(tmpdir(), 'dirty-pr-scan-'));
 let seq = 0;
 
-function run(prs, extra = []) {
+function run(prs, { workflow = workflowFixture(), extra = [] } = {}) {
   const path = join(TMP, `state-${(seq += 1)}.json`);
   writeFileSync(path, JSON.stringify(prs));
-  const r = spawnSync(process.execPath, [GATE, '--state-file', path, ...extra], { encoding: 'utf8' });
+  const r = spawnSync(process.execPath, [GATE, '--workflow', workflow, '--state-file', path, ...extra], { encoding: 'utf8' });
   return { code: r.status, output: `${r.stdout}${r.stderr}` };
 }
 
@@ -33,17 +33,18 @@ function lane(name) {
   return { name };
 }
 
-// The workflow's own required set at time of writing -- read once here, not
-// hardcoded, so this test does not rot when test.yml's job list changes.
-async function requiredLaneNames() {
-  const { expandJobNames } = await import('./lib/pr-review-signal.mjs');
-  const { readFileSync } = await import('node:fs');
-  const text = readFileSync(join(HERE, '../.github/workflows/test.yml'), 'utf8');
-  return expandJobNames(text, { exclude: ['test'] });
+function workflowFixture({ branches = '[main]', nodeJob = 'node' } = {}) {
+  const path = join(TMP, `workflow-${(seq += 1)}.yml`);
+  writeFileSync(
+    path,
+    `on:\n  pull_request:\n    branches: ${branches}\njobs:\n  lint:\n    name: Lint\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n  ${nodeJob}:\n    name: Node tests\n    runs-on: ubuntu-latest\n    steps:\n      - run: true\n`,
+  );
+  return path;
 }
 
-test('RED: a #3411-shaped conflicted PR with no required lanes present fails and is named', async () => {
-  const required = await requiredLaneNames();
+const REQUIRED = ['Lint', 'Node tests'];
+
+test('RED: a #3411-shaped conflicted PR with no required lanes present fails and is named', () => {
   const { code, output } = run([
     {
       number: 3411,
@@ -60,12 +61,10 @@ test('RED: a #3411-shaped conflicted PR with no required lanes present fails and
   assert.match(output, /#3411/);
   assert.match(output, /pushing a new commit will not fix this/i);
   assert.doesNotMatch(output, /retarget the PR/i);
-  assert.ok(required.includes('Node tests'));
   assert.match(output, /Node tests/);
 });
 
-test('GREEN: a clean PR with every required lane present passes', async () => {
-  const required = await requiredLaneNames();
+test('GREEN: a clean PR with every required lane present passes', () => {
   const { code, output } = run([
     {
       number: 9001,
@@ -73,15 +72,14 @@ test('GREEN: a clean PR with every required lane present passes', async () => {
       mergeable: 'MERGEABLE',
       mergeStateStatus: 'BLOCKED',
       isDraft: false,
-      statusCheckRollup: required.map(lane),
+      statusCheckRollup: REQUIRED.map(lane),
     },
   ]);
   assert.equal(code, 0, output);
   assert.match(output, /✅/);
 });
 
-test('GREEN: a conflicted PR whose lanes already ran (the #3417 shape) passes', async () => {
-  const required = await requiredLaneNames();
+test('GREEN: a conflicted PR whose lanes already ran (the #3417 shape) passes', () => {
   const { code, output } = run([
     {
       number: 3417,
@@ -89,7 +87,7 @@ test('GREEN: a conflicted PR whose lanes already ran (the #3417 shape) passes', 
       mergeable: 'CONFLICTING',
       mergeStateStatus: 'DIRTY',
       isDraft: false,
-      statusCheckRollup: required.map(lane).concat([lane('Vercel Agent Review')]),
+      statusCheckRollup: REQUIRED.map(lane).concat([lane('Vercel Agent Review')]),
     },
   ]);
   assert.equal(code, 0, output);
@@ -113,11 +111,10 @@ test('requires --repo or --state-file', () => {
   assert.match(`${r.stdout}${r.stderr}`, /NO_REPO/);
 });
 
-test('RED: a stacked PR is named with the retarget remedy, never the resolve-the-conflict one', async () => {
+test('RED: a stacked PR is named with the retarget remedy, never the resolve-the-conflict one', () => {
   // The failing input from the review: #3411's real base. Before this gate read
   // `baseRefName` it printed "only resolving the conflict ... restores CI",
   // which cannot restore a lane while `test.yml` filters on `branches: [main]`.
-  await requiredLaneNames();
   const { code, output } = run([
     {
       number: 3411,
@@ -136,10 +133,9 @@ test('RED: a stacked PR is named with the retarget remedy, never the resolve-the
   assert.doesNotMatch(output, /only resolving the conflict/i, output);
 });
 
-test('RED: a stacked PR that is fully mergeable is still reported', async () => {
+test('RED: a stacked PR that is fully mergeable is still reported', () => {
   // #3405's live shape: MERGEABLE/CLEAN, 0 of 15 lanes. Nothing about a merge
   // conflict is involved, so a conflict-only gate is blind to it.
-  await requiredLaneNames();
   const { code, output } = run([
     {
       number: 3405,
@@ -155,12 +151,11 @@ test('RED: a stacked PR that is fully mergeable is still reported', async () => 
   assert.match(output, /retarget the PR/i, output);
 });
 
-test('RED: a stacked PR that is ALSO conflicted is told to resolve the conflict too', async () => {
+test('RED: a stacked PR that is ALSO conflicted is told to resolve the conflict too', () => {
   // #3411's real shape again. Retargeting it at `main` clears the base filter
   // and leaves it DIRTY, and GitHub fires no `pull_request` for a PR it cannot
   // compute a merge ref for -- so the retarget line alone sends a maintainer to
   // do half the work and get zero lanes back. Both remedies, on one run.
-  await requiredLaneNames();
   const { code, output } = run([
     {
       number: 3411,
@@ -177,10 +172,9 @@ test('RED: a stacked PR that is ALSO conflicted is told to resolve the conflict 
   assert.match(output, /resolve the conflict as well/i, output);
 });
 
-test('a stacked PR that is NOT conflicted gets the retarget remedy only', async () => {
+test('a stacked PR that is NOT conflicted gets the retarget remedy only', () => {
   // The other direction: #3405 is MERGEABLE/CLEAN, so telling it to resolve a
   // conflict it does not have would be the same wrong-remedy defect inverted.
-  await requiredLaneNames();
   const { code, output } = run([
     {
       number: 3405,
@@ -196,27 +190,13 @@ test('a stacked PR that is NOT conflicted gets the retarget remedy only', async 
   assert.doesNotMatch(output, /ALSO conflicted/i, output);
 });
 
-test('the scan workflow grants the check-run and commit-status reads its verdict rests on', async () => {
-  // Declaring ANY `permissions:` block sets every unlisted scope to `none`, and
-  // every verdict this gate reaches comes from `statusCheckRollup` -- check runs
-  // and commit statuses, neither of which `pull-requests: read` covers. With
-  // them missing the job either dies on `gh` or reads an empty rollup, and an
-  // empty rollup makes a PR that ran all 15 lanes before going dirty (#3417,
-  // #3447) indistinguishable from one that never ran any. Nothing in a local
-  // run can catch that: a developer's `gh` auth is full-scope, the Actions
-  // token is not, so the coupling is asserted here instead.
-  const { readFileSync } = await import('node:fs');
-  const text = readFileSync(join(HERE, '../.github/workflows/dirty-pr-scan.yml'), 'utf8');
-  const block = /^permissions:\n((?:[ \t]+\S.*\n|[ \t]*\n)*)/m.exec(text);
-  assert.ok(block, 'dirty-pr-scan.yml declares no top-level `permissions:` block');
-  const scopes = new Map();
-  for (const line of block[1].split('\n')) {
-    const m = /^\s+([a-z-]+):\s*(\S+)\s*$/.exec(line);
-    if (m) scopes.set(m[1], m[2]);
-  }
-  assert.equal(scopes.get('checks'), 'read', 'the rollup carries check runs');
-  assert.equal(scopes.get('statuses'), 'read', 'the rollup carries commit statuses too');
-  assert.equal(scopes.get('pull-requests'), 'read', 'the scan lists open PRs');
+test('reads required lanes and base filters from the supplied workflow fixture', () => {
+  const { code, output } = run(
+    [{ number: 3411, baseRefName: 'release', mergeable: 'MERGEABLE', mergeStateStatus: 'CLEAN', statusCheckRollup: [] }],
+    { workflow: workflowFixture({ branches: '[main, release]', nodeJob: 'web' }) },
+  );
+  assert.equal(code, 0, output);
+  assert.match(output, /Scanned 1 open PR\(s\) against 2 required lane\(s\)/);
 });
 
 test('fails closed rather than guessing a remedy when `baseRefName` is absent', () => {


### PR DESCRIPTION
## What this ships

Adds a scheduled/manual scan for open PRs whose required `pull_request` lanes are absent because the PR is either based on a branch outside `test.yml`’s filter or has an unresolved conflict. It derives required job names and the `pull_request` base-branch filter from the workflow supplied at runtime, compares them with each PR’s `statusCheckRollup`, and reports the applicable remediation. `UNKNOWN` mergeability remains advisory.

The scan is intentionally independent of `pull_request`, since a conflicted PR can lack that event’s CI entirely. It does not repair a conflict or observe a PR that becomes conflicted and is repaired between scheduled scans.

## Tests

`node --test scripts/lib/dirty-pr-scan.test.mjs scripts/scan-dirty-prs.test.mjs` (40 passing): classification fixtures plus subprocess tests that run the CLI with generated workflow/state fixtures, including base filters and derived job names. No source-text assertions.

Refs #3443.


---

**Gate-parity check (post-#3689/#3723):** verified by checking out this branch merged onto current `upstream/main` (`4787aaaf7`) and running `node scripts/check-module-size.mjs`. Unmodified `main` is green on this gate; merged, it exits 1:

```
New source file(s) over 400 lines with no allowlist row:

  scripts/lib/dirty-pr-scan.mjs: 430 lines
```

`scripts/lib/dirty-pr-scan.mjs` lands at 430 lines with no row in `scripts/module-size-allowlist.txt`, so merging this as-is would turn `main`'s module-size ratchet red (the same failure mode #3689 hit, fixed by #3723). Fix in this same PR: either split the file under 400 lines, or add a `430 scripts/lib/dirty-pr-scan.mjs` row via `node scripts/check-module-size.mjs --update` (with a written justification) and update the `ALLOWLIST_DIGESTS` entry it prints. `scripts/scan-dirty-prs.mjs` (191 lines) and both `*.test.mjs` files are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated scanning of open pull requests to identify cases where required CI checks did not run.
  - Scans can run on a schedule or manually and provide actionable reports for conflicted or incorrectly targeted pull requests.
  - Added support for detecting required checks and eligible pull-request branches from workflow configuration.

- **Reliability**
  - Added clear error handling for invalid inputs, unavailable repository data, and unsupported workflow configurations.

- **Tests**
  - Added comprehensive coverage for scanning, classification, reporting, workflow parsing, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->