### PR TITLE
test(geometry): fix #3435 T-junction classifier's collinear-merge bug

### DIFF
--- a/rust/geometry/tests/issue_068_void_ordering_probe.rs
+++ b/rust/geometry/tests/issue_068_void_ordering_probe.rs
@@ -1,0 +1,387 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Ad hoc probe for issue #3435: for EVERY torn host in ISSUE_068
+//! (`ISSUE_068_ARK_NUS_skolebygg.ifc`), apply its recorded
+//! `IfcRelVoidsElement` openings in several different orders and record the
+//! resulting `open`-edge count, to answer one question: does a single
+//! ordering rule make the tears go away, and for how many of the 29 hosts?
+//!
+//! Reuses the same machinery as `issue_053_heavy_csg_probe.rs`
+//! (`void_index`, `process`, `process_no_voids`, `edge_stats`), duplicated
+//! here rather than shared across two separate test-binary crates.
+//!
+//! Run:
+//!   cargo test -p ifc-lite-geometry --test issue_068_void_ordering_probe \
+//!     -- --ignored --nocapture void_ordering_probe
+//!
+//! `--ignored`: manual probe, not gated CI. Debug build (no `--release`) —
+//! this worktree's shared `.cargo/config.toml` collides with
+//! `panic = "abort"` under `--release`.
+
+mod census_golden;
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+
+fn crate_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn repo_root() -> std::path::PathBuf {
+    crate_dir().join("..").join("..")
+}
+
+fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, &mut decoder);
+    idx
+}
+
+fn process(content: &str, host_id: u32, voids: &FxHashMap<u32, Vec<u32>>) -> Option<Mesh> {
+    let ei = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, ei);
+    let entity = decoder.decode_by_id(host_id).ok()?;
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    router.process_element_with_voids(&entity, &mut decoder, voids).ok()
+}
+
+fn process_no_voids(content: &str, host_id: u32) -> Option<Mesh> {
+    let ei = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, ei);
+    let entity = decoder.decode_by_id(host_id).ok()?;
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    router.process_element(&entity, &mut decoder).ok()
+}
+
+struct EdgeStats {
+    open: usize,
+}
+
+fn edge_stats(mesh: &Mesh) -> EdgeStats {
+    let q = |v: f32| (v as f64 * 1.0e3).round() as i64;
+    let mut vid: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
+    let mut id = |i: usize| -> u32 {
+        let k = (
+            q(mesh.positions[i * 3]),
+            q(mesh.positions[i * 3 + 1]),
+            q(mesh.positions[i * 3 + 2]),
+        );
+        let n = vid.len() as u32;
+        *vid.entry(k).or_insert(n)
+    };
+    let mut uses: FxHashMap<(u32, u32), (u32, u32)> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (id(tri[0] as usize), id(tri[1] as usize), id(tri[2] as usize));
+        if a == b || b == c || c == a {
+            continue;
+        }
+        for (x, y) in [(a, b), (b, c), (c, a)] {
+            let e = uses.entry((x.min(y), x.max(y))).or_insert((0, 0));
+            if x < y {
+                e.0 += 1;
+            } else {
+                e.1 += 1;
+            }
+        }
+    }
+    EdgeStats { open: uses.values().filter(|&&(f, r)| f != r).count() }
+}
+
+/// Signed-tetrahedron-sum volume (divergence theorem), magnitude only. Not
+/// gated on `is_trustworthy_solid()` like `geom_closure::volume()` — this is
+/// a ranking key for an ordering heuristic, not a certified measurement, and
+/// every opening here is a simple swept/extruded solid that processes fine
+/// standalone.
+fn mesh_volume(mesh: &Mesh) -> f64 {
+    let mut sum = 0.0f64;
+    for tri in mesh.indices.chunks_exact(3) {
+        let p = |i: u32| {
+            let i = i as usize;
+            [
+                mesh.positions[i * 3] as f64,
+                mesh.positions[i * 3 + 1] as f64,
+                mesh.positions[i * 3 + 2] as f64,
+            ]
+        };
+        let [ax, ay, az] = p(tri[0]);
+        let [bx, by, bz] = p(tri[1]);
+        let [cx, cy, cz] = p(tri[2]);
+        // 6x signed volume of the tetrahedron (origin, a, b, c)
+        sum += ax * (by * cz - bz * cy) - ay * (bx * cz - bz * cx) + az * (bx * cy - by * cx);
+    }
+    (sum / 6.0).abs()
+}
+
+fn mesh_centroid(mesh: &Mesh) -> [f64; 3] {
+    let (mn, mx) = mesh.bounds();
+    [
+        (mn.x as f64 + mx.x as f64) / 2.0,
+        (mn.y as f64 + mx.y as f64) / 2.0,
+        (mn.z as f64 + mx.z as f64) / 2.0,
+    ]
+}
+
+fn mesh_aabb_min(mesh: &Mesh) -> [f64; 3] {
+    let (mn, _) = mesh.bounds();
+    [mn.x as f64, mn.y as f64, mn.z as f64]
+}
+
+/// splitmix64: tiny deterministic PRNG so permutations are seed-reproducible
+/// without pulling in the `rand` crate as a dev-dependency of a
+/// `#[ignore]`d probe.
+struct SplitMix64(u64);
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+    fn shuffle<T>(&mut self, v: &mut [T]) {
+        // Fisher-Yates
+        for i in (1..v.len()).rev() {
+            let j = (self.next() % (i as u64 + 1)) as usize;
+            v.swap(i, j);
+        }
+    }
+}
+
+/// Fixed global seed for every random permutation in this probe. Printed at
+/// the top of the run so the whole experiment reproduces byte-for-byte.
+const PROBE_SEED: u64 = 0x1235_5EED_C0FF_EE01;
+/// Random permutations tried per host, beyond declaration/reversed/canonical.
+const RANDOM_PERMS_PER_HOST: usize = 6;
+
+struct HostResult {
+    host: u32,
+    n: usize,
+    declaration: usize,
+    reversed: usize,
+    random: Vec<usize>,
+    desc_volume: usize,
+    asc_volume: usize,
+    axis: usize,
+    aabb_min: usize,
+    // determinism: declaration order re-run
+    declaration_rerun: usize,
+}
+
+#[test]
+#[ignore = "manual probe (#3435): does void-application order explain the ISSUE_068 boolean tears"]
+fn void_ordering_probe() {
+    let rel = "tests/models/ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc";
+    let path = repo_root().join(rel);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+
+    let voids = void_index(&content);
+    let mut hosts: Vec<u32> = voids.keys().copied().collect();
+    hosts.sort_unstable();
+
+    println!("PROBE_SEED = 0x{PROBE_SEED:016X}");
+    println!("random permutations per host = {RANDOM_PERMS_PER_HOST}");
+    println!("void hosts total: {}", hosts.len());
+
+    // First pass: find every torn host under DECLARATION order (the
+    // baseline / current behaviour), matching the census's definition.
+    let mut torn_hosts: Vec<(u32, usize)> = Vec::new(); // (host, declaration open)
+    for &host in &hosts {
+        let openings = voids.get(&host).unwrap();
+        let Some(mesh) = process(&content, host, &voids) else { continue };
+        let s = edge_stats(&mesh);
+        if s.open > 0 {
+            torn_hosts.push((host, s.open));
+        }
+        let _ = openings;
+    }
+    println!("torn hosts (declaration order): {}", torn_hosts.len());
+
+    let mut results: Vec<HostResult> = Vec::new();
+
+    for &(host, decl_open) in &torn_hosts {
+        let openings = voids.get(&host).unwrap().clone();
+        let n = openings.len();
+
+        let check = |subset: &[u32]| -> usize {
+            let mut m: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+            m.insert(host, subset.to_vec());
+            match process(&content, host, &m) {
+                Some(mesh) => edge_stats(&mesh).open,
+                None => usize::MAX,
+            }
+        };
+
+        // 1. declaration (already have it, but recompute via `check` for
+        // apples-to-apples with the rest, and to get a determinism re-run).
+        let declaration = check(&openings);
+        let declaration_rerun = check(&openings);
+
+        // 2. reversed
+        let reversed_order: Vec<u32> = openings.iter().rev().copied().collect();
+        let reversed = check(&reversed_order);
+
+        // 3. random permutations, seeded deterministically per host so the
+        // WHOLE experiment reproduces from PROBE_SEED + host id.
+        let mut rng = SplitMix64::new(PROBE_SEED ^ (host as u64).wrapping_mul(0x9E3779B1));
+        let mut random = Vec::with_capacity(RANDOM_PERMS_PER_HOST);
+        for _ in 0..RANDOM_PERMS_PER_HOST {
+            let mut perm = openings.clone();
+            rng.shuffle(&mut perm);
+            random.push(check(&perm));
+        }
+
+        // 4. canonical orders: geometry-derived keys per opening, computed
+        // via `process_no_voids` on the opening entity itself (unclipped,
+        // standalone solid) — same source `heavy_csg_void_ddmin_probe` uses
+        // for its AABB characterisation.
+        let mut keyed: Vec<(u32, f64, f64, [f64; 3], [f64; 3])> = Vec::new(); // (id, volume, axis_centroid, centroid, aabb_min)
+        for &op in &openings {
+            match process_no_voids(&content, op) {
+                Some(m) => {
+                    let vol = mesh_volume(&m);
+                    let c = mesh_centroid(&m);
+                    let amin = mesh_aabb_min(&m);
+                    keyed.push((op, vol, 0.0, c, amin));
+                }
+                None => keyed.push((op, 0.0, 0.0, [0.0; 3], [0.0; 3])),
+            }
+        }
+
+        // Host's own principal axis: the axis of largest extent of the
+        // UNCUT host's own bounding box. Approximation — assumes the host's
+        // local "length" axis is world-axis-aligned, which is not always
+        // true for a rotated wall; caveated in the report.
+        let axis_idx: usize = match process_no_voids(&content, host) {
+            Some(hm) => {
+                let (mn, mx) = hm.bounds();
+                let ext = [
+                    (mx.x - mn.x).abs() as f64,
+                    (mx.y - mn.y).abs() as f64,
+                    (mx.z - mn.z).abs() as f64,
+                ];
+                if ext[0] >= ext[1] && ext[0] >= ext[2] {
+                    0
+                } else if ext[1] >= ext[2] {
+                    1
+                } else {
+                    2
+                }
+            }
+            None => 0,
+        };
+        for (id, _, axis_c, c, _) in keyed.iter_mut() {
+            *axis_c = c[axis_idx];
+            let _ = id;
+        }
+
+        let mut by_desc_vol = keyed.clone();
+        by_desc_vol.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        let desc_volume = check(&by_desc_vol.iter().map(|k| k.0).collect::<Vec<_>>());
+
+        let mut by_asc_vol = keyed.clone();
+        by_asc_vol.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        let asc_volume = check(&by_asc_vol.iter().map(|k| k.0).collect::<Vec<_>>());
+
+        let mut by_axis = keyed.clone();
+        by_axis.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+        let axis = check(&by_axis.iter().map(|k| k.0).collect::<Vec<_>>());
+
+        let mut by_aabb_min = keyed.clone();
+        by_aabb_min.sort_by(|a, b| {
+            a.4.partial_cmp(&b.4).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let aabb_min = check(&by_aabb_min.iter().map(|k| k.0).collect::<Vec<_>>());
+
+        println!(
+            "HOST #{host}  n={n}  decl={declaration}(rerun={declaration_rerun})  rev={reversed}  \
+             rand={random:?}  desc_vol={desc_volume}  asc_vol={asc_volume}  axis(={})={axis}  aabb_min={aabb_min}",
+            ['x', 'y', 'z'][axis_idx]
+        );
+
+        results.push(HostResult {
+            host,
+            n,
+            declaration,
+            reversed,
+            random,
+            desc_volume,
+            asc_volume,
+            axis,
+            aabb_min,
+            declaration_rerun,
+        });
+        let _ = decl_open;
+    }
+
+    println!("\n=== SUMMARY ({} torn hosts probed) ===", results.len());
+    println!(
+        "{:<10} {:>4} {:>6} {:>6} {:>6} {:>20} {:>10} {:>10} {:>10} {:>10}",
+        "host", "n", "decl", "rerun", "rev", "random(6)", "desc_vol", "asc_vol", "axis", "aabb_min"
+    );
+    for r in &results {
+        println!(
+            "{:<10} {:>4} {:>6} {:>6} {:>6} {:>20} {:>10} {:>10} {:>10} {:>10}",
+            r.host,
+            r.n,
+            r.declaration,
+            r.declaration_rerun,
+            r.reversed,
+            format!("{:?}", r.random),
+            r.desc_volume,
+            r.asc_volume,
+            r.axis,
+            r.aabb_min
+        );
+    }
+
+    let any_clean = |r: &HostResult| -> bool {
+        r.declaration == 0
+            || r.reversed == 0
+            || r.random.iter().any(|&o| o == 0)
+            || r.desc_volume == 0
+            || r.asc_volume == 0
+            || r.axis == 0
+            || r.aabb_min == 0
+    };
+    let clean_under_some_ordering = results.iter().filter(|r| any_clean(r)).count();
+    let torn_under_every_ordering: Vec<u32> =
+        results.iter().filter(|r| !any_clean(r)).map(|r| r.host).collect();
+
+    let canon_clean = |r: &HostResult| r.desc_volume == 0;
+    let desc_vol_clean_count = results.iter().filter(|r| canon_clean(r)).count();
+    let asc_vol_clean_count = results.iter().filter(|r| r.asc_volume == 0).count();
+    let axis_clean_count = results.iter().filter(|r| r.axis == 0).count();
+    let aabb_min_clean_count = results.iter().filter(|r| r.aabb_min == 0).count();
+
+    println!("\nhosts probed                                   : {}", results.len());
+    println!("clean under AT LEAST ONE ordering tried        : {clean_under_some_ordering}");
+    println!("torn under EVERY ordering tried                : {}", torn_under_every_ordering.len());
+    println!("  -> {:?}", torn_under_every_ordering);
+    println!("clean under descending-volume order            : {desc_vol_clean_count}/{}", results.len());
+    println!("clean under ascending-volume order              : {asc_vol_clean_count}/{}", results.len());
+    println!("clean under axis-centroid order                 : {axis_clean_count}/{}", results.len());
+    println!("clean under AABB-min-lexicographic order        : {aabb_min_clean_count}/{}", results.len());
+
+    let decl_rerun_stable = results.iter().all(|r| r.declaration == r.declaration_rerun);
+    println!(
+        "\ndeclaration-order determinism (rerun == first run) for ALL probed hosts: {decl_rerun_stable}"
+    );
+}

--- a/rust/geometry/tests/issue_068_void_ordering_probe.rs
+++ b/rust/geometry/tests/issue_068_void_ordering_probe.rs
@@ -34,6 +34,28 @@ fn repo_root() -> std::path::PathBuf {
     crate_dir().join("..").join("..")
 }
 
+/// `true` when the catalogued fixture is on disk.
+///
+/// An absent fixture must SKIP, never panic (AGENTS.md "Test fixtures"); CI
+/// runs `pnpm fixtures` before tests, so it always has the full set.
+/// `try_exists`, not `exists`: `Path::exists` collapses a permission error
+/// into `false`, which would quietly skip on a broken checkout while
+/// reporting green. Only a definite "not there" skips; an undecidable answer
+/// is a broken setup and still panics.
+fn fixture_present(path: &std::path::Path) -> bool {
+    match path.try_exists() {
+        Ok(true) => true,
+        Ok(false) => {
+            eprintln!(
+                "skipping: fixture {} not present -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                path.display()
+            );
+            false
+        }
+        Err(e) => panic!("cannot determine whether fixture {} exists: {e}", path.display()),
+    }
+}
+
 fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
     let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
     let mut scanner = EntityScanner::new(content);
@@ -189,6 +211,9 @@ struct HostResult {
 fn void_ordering_probe() {
     let rel = "tests/models/ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc";
     let path = repo_root().join(rel);
+    if !fixture_present(&path) {
+        return;
+    }
     let content = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
 

--- a/rust/geometry/tests/issue_068_void_ordering_probe.rs
+++ b/rust/geometry/tests/issue_068_void_ordering_probe.rs
@@ -355,7 +355,7 @@ fn void_ordering_probe() {
     let any_clean = |r: &HostResult| -> bool {
         r.declaration == 0
             || r.reversed == 0
-            || r.random.iter().any(|&o| o == 0)
+            || r.random.contains(&0)
             || r.desc_volume == 0
             || r.asc_volume == 0
             || r.axis == 0

--- a/rust/geometry/tests/issue_3435_classify_probe.rs
+++ b/rust/geometry/tests/issue_3435_classify_probe.rs
@@ -28,17 +28,27 @@
 //!
 //! The fix (`split_by_proximity` below) is a second pass, after collinear
 //! clustering, that further splits a line-cluster wherever two consecutive
-//! edges' projected intervals are separated by more than `GAP_TOL`. Every
-//! genuine within-tear gap observed on this fixture (the sub-edges that
-//! legitimately tile one opening's long edge) is 0 or sub-millimetre —
-//! f32-mesh-export noise. Every confirmed cross-doorway separation observed
-//! (including the `#144568` 1.07 m case) is >= 1 m. `GAP_TOL = 5 cm` sits
-//! two orders of magnitude above the noise floor and more than an order of
-//! magnitude below the smallest confirmed real separation, so it cannot
-//! misclassify either side of that fixture's evidence.
+//! edges' projected intervals are separated by more than `GAP_TOL`.
 //!
-//! Anchors (must hold after the fix): host `#628727` classifies as a
-//! T-junction; hosts `#144568` and `#893133` do not.
+//! `GAP_TOL = 5 cm` is placed from this fixture's own measured gaps, obtained
+//! by printing `lo - running_hi` for every pair `split_by_proximity` compares
+//! across all 29 torn hosts. Gaps that stay together (the sub-edges that
+//! legitimately tile one opening's long edge) are 0 or negative: the largest
+//! is 0.000000 m to six decimals, i.e. f32-mesh-export noise. Gaps that do
+//! split are 0.1235 m (`#360795`), 0.2110 / 0.2639 / 0.6034 m (`#43810`),
+//! 1.0721 m (`#144568`), 3.5200 m (`#893133`) and 5.0760 m (`#53374`).
+//!
+//! So 5 cm clears the noise floor by two orders of magnitude, but the margin
+//! on the other side is a factor of 2.5, not another two orders: four of
+//! those seven separations are under a metre, and the smallest is at
+//! `#360795`, the one host whose verdict the fix changes. Raising `GAP_TOL`
+//! past 0.1235 m would re-merge `#360795` and silently undo the fix. The
+//! headroom is below this value, not above it, which is worth knowing before
+//! anyone widens it to make an unrelated host behave.
+//!
+//! Anchors (must hold after the fix): hosts `#628727` and `#360795` classify
+//! as T-junctions; hosts `#144568` and `#893133` do not. `#360795` is the one
+//! that pins the fix itself, see `ANCHOR_TJUNCTION` below.
 //!
 //! Run (needs `debug_geometry` to read the prism fast-path fire counter):
 //!   cargo test -p ifc-lite-geometry --features debug_geometry \
@@ -55,6 +65,28 @@ fn crate_dir() -> std::path::PathBuf {
 }
 fn repo_root() -> std::path::PathBuf {
     crate_dir().join("..").join("..")
+}
+
+/// `true` when the catalogued fixture is on disk.
+///
+/// An absent fixture must SKIP, never panic (AGENTS.md "Test fixtures"); CI
+/// runs `pnpm fixtures` before tests, so it always has the full set.
+/// `try_exists`, not `exists`: `Path::exists` collapses a permission error
+/// into `false`, which would quietly skip on a broken checkout while
+/// reporting green. Only a definite "not there" skips; an undecidable answer
+/// is a broken setup and still panics.
+fn fixture_present(path: &std::path::Path) -> bool {
+    match path.try_exists() {
+        Ok(true) => true,
+        Ok(false) => {
+            eprintln!(
+                "skipping: fixture {} not present -- run `pnpm fixtures` to download (sha256 in tests/models/manifest.json)",
+                path.display()
+            );
+            false
+        }
+        Err(e) => panic!("cannot determine whether fixture {} exists: {e}", path.display()),
+    }
 }
 
 fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
@@ -148,8 +180,8 @@ fn unit(a: (f64, f64, f64)) -> (f64, f64, f64) {
 /// proximity along the shared line: two edges stay together only while the
 /// gap between their projected intervals is <= `gap_tol`. See the module
 /// doc for why collinearity alone over-merges (the host `#144568`
-/// two-doorway phantom cluster) and why `gap_tol` is safe at any value
-/// between the sub-mm noise floor and the >= 1 m confirmed separations.
+/// two-doorway phantom cluster) and for the measured gaps that bracket
+/// `gap_tol` from both sides.
 fn split_by_proximity(
     edges: &[((f64, f64, f64), (f64, f64, f64))],
     group: Vec<usize>,
@@ -217,13 +249,12 @@ fn classify_open_edges(edges: &[((f64, f64, f64), (f64, f64, f64))]) -> (bool, S
     // to-line distance), anchored on the longest unclustered edge each round
     // (longest edges are the most reliable to derive a direction from).
     const DIST_TOL: f64 = 1e-3; // metres, point-to-line distance tolerance
-    // Proximity bound for the interval-adjacency split (see module doc for
-    // the phantom-merge failure mode this closes): every genuine
-    // within-tear gap on this fixture is 0 or sub-mm, every confirmed
-    // cross-doorway separation is >= 1 m, so 5 cm sits comfortably between
-    // both without being derivable from either -- it is not tuned to a
-    // specific edge, just placed in the two-orders-of-magnitude gap the
-    // evidence leaves open.
+    // Proximity bound for the interval-adjacency split. See the module doc
+    // for the phantom-merge failure mode this closes and for every gap this
+    // fixture actually produces: the gaps kept together measure 0, and the
+    // smallest gap that must split is 0.1235 m at host #360795. 5 cm is two
+    // orders of magnitude above the first and a factor of 2.5 below the
+    // second, so the headroom is below this value, not above it.
     const GAP_TOL: f64 = 0.05; // metres
 
     let mut remaining: Vec<usize> = (0..edges.len()).collect();
@@ -400,10 +431,19 @@ impl SplitMix64 {
     }
 }
 
-/// Anchor hosts pinned by the #3435 investigation: `#628727` is the
-/// original T-junction reproducer; `#144568` and `#893133` are confirmed
-/// NOT T-junctions (see module doc for `#144568`'s phantom-merge history).
-const ANCHOR_TJUNCTION: u32 = 628727;
+/// Anchor hosts pinned by the #3435 investigation.
+///
+/// `#628727` is the original T-junction reproducer. `#360795` is the anchor
+/// that pins the proximity-split fix itself: over this fixture's 29 torn
+/// hosts it is the ONLY host whose verdict the fix changes (a T-junction with
+/// `split_by_proximity`, not a T-junction without it). Without it here, every
+/// assertion in this file stays green when the second pass in
+/// `classify_open_edges` is deleted, so the file would pin the classifier's
+/// other outputs but not the fix this probe exists to land. `#144568` and
+/// `#893133` are confirmed NOT T-junctions (see module doc for `#144568`'s
+/// phantom-merge history); their verdicts are the same either way, which is
+/// exactly why they cannot pin it.
+const ANCHOR_TJUNCTION: [u32; 2] = [628727, 360795];
 const ANCHOR_NOT_TJUNCTION: [u32; 2] = [144568, 893133];
 
 /// The classifier clusters by a greedy longest-edge-first anchor pick, which
@@ -437,6 +477,9 @@ fn assert_permutation_invariant(host: u32, edges: &[((f64, f64, f64), (f64, f64,
 fn classify_probe() {
     let rel = "tests/models/ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc";
     let path = repo_root().join(rel);
+    if !fixture_present(&path) {
+        return;
+    }
     let content = std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
     let voids = void_index(&content);
@@ -487,7 +530,7 @@ fn classify_probe() {
             not_tjunction += 1;
             "NO"
         };
-        if host == ANCHOR_TJUNCTION || ANCHOR_NOT_TJUNCTION.contains(&host) {
+        if ANCHOR_TJUNCTION.contains(&host) || ANCHOR_NOT_TJUNCTION.contains(&host) {
             anchor_verdicts.insert(host, is_tj);
             assert_permutation_invariant(host, &edges);
         }
@@ -523,11 +566,13 @@ fn classify_probe() {
     // Anchors: the corrected classifier (collinearity + proximity split)
     // must reproduce these regardless of any unrelated drift elsewhere in
     // the population.
-    assert_eq!(
-        anchor_verdicts.get(&ANCHOR_TJUNCTION).copied(),
-        Some(true),
-        "host #{ANCHOR_TJUNCTION} must classify as a T-junction"
-    );
+    for &host in &ANCHOR_TJUNCTION {
+        assert_eq!(
+            anchor_verdicts.get(&host).copied(),
+            Some(true),
+            "host #{host} must classify as a T-junction"
+        );
+    }
     for &host in &ANCHOR_NOT_TJUNCTION {
         assert_eq!(
             anchor_verdicts.get(&host).copied(),

--- a/rust/geometry/tests/issue_3435_classify_probe.rs
+++ b/rust/geometry/tests/issue_3435_classify_probe.rs
@@ -446,13 +446,24 @@ impl SplitMix64 {
 const ANCHOR_TJUNCTION: [u32; 2] = [628727, 360795];
 const ANCHOR_NOT_TJUNCTION: [u32; 2] = [144568, 893133];
 
-/// The classifier clusters by a greedy longest-edge-first anchor pick, which
-/// is itself order-independent (max-by-length, not first-seen), but the
-/// input edge list order still depends on `open_edges`'s `FxHashMap`
-/// iteration order, which is NOT deterministic across runs. Reproducing the
-/// verdict under several explicit shuffles of the same edge set guards
-/// against a hidden order dependency creeping back into the clustering (the
-/// exact class of bug the collinear-merge fix above was pinned against).
+/// What the shuffles below guard is the anchor tie-break, not run-to-run
+/// hash order.
+///
+/// The input order is in fact stable: `open_edges` iterates an `FxHashMap`,
+/// and `FxBuildHasher` is a seedless unit struct (rustc-hash's randomized
+/// state is the separate, opt-in `FxRandomState`), so two runs of this probe
+/// over the same fixture print byte-identical cluster lines.
+///
+/// The order dependency that does exist is inside the clustering. Its anchor
+/// is picked with `Iterator::max_by` over edge length, and `max_by` returns
+/// the LAST maximum on ties, so equal-length edges are resolved by input
+/// position. Host `#144568` has two open edges tying exactly at
+/// 1.6199951183372845 m, and permuting its edge list really does swap which
+/// of them anchors the first cluster (its 1.6200 m clusters come out in the
+/// opposite order). Reproducing the verdict under several explicit shuffles
+/// pins that whichever tied edge wins, the classifier still concludes the
+/// same thing (the exact class of bug the collinear-merge fix above was
+/// pinned against).
 fn assert_permutation_invariant(host: u32, edges: &[((f64, f64, f64), (f64, f64, f64))]) {
     let (baseline_tj, baseline_detail) = classify_open_edges(edges);
     let mut rng = SplitMix64(0x1235_5EED_C0FF_EE03 ^ host as u64);

--- a/rust/geometry/tests/issue_3435_classify_probe.rs
+++ b/rust/geometry/tests/issue_3435_classify_probe.rs
@@ -271,10 +271,16 @@ fn classify_open_edges(edges: &[((f64, f64, f64), (f64, f64, f64))]) -> (bool, S
         .collect();
     clusters.retain(|g| !g.is_empty());
 
-    // Per cluster: T-junction covering iff the longest edge's length equals
-    // the sum of every OTHER edge in the cluster (the sub-edges partition
-    // the long edge with no gap/overlap) within LEN_TOL, and the cluster has
-    // >= 2 edges (a lone unmatched edge is not "covered" by anything).
+    // Per cluster: T-junction covering iff the OTHER edges' merged intervals
+    // exactly span the longest edge's own interval -- no gap at either end and
+    // no double coverage -- and the cluster has >= 2 edges (a lone unmatched
+    // edge is not "covered" by anything).
+    //
+    // Intervals are merged rather than lengths summed. Summing was the earlier
+    // test and it accepts a set of sub-edges that overlap each other while
+    // leaving part of the long edge bare, since the surplus in one place
+    // cancels the shortfall in another. `overlap_slack` below exists to catch
+    // exactly that, and `#640479` is the host where the two tests disagree.
     let mut all_covered = true;
     let mut parts = Vec::new();
     for g in &clusters {

--- a/rust/geometry/tests/issue_3435_classify_probe.rs
+++ b/rust/geometry/tests/issue_3435_classify_probe.rs
@@ -273,8 +273,21 @@ fn classify_open_edges(edges: &[((f64, f64, f64), (f64, f64, f64))]) -> (bool, S
 
     // Per cluster: T-junction covering iff the OTHER edges' merged intervals
     // exactly span the longest edge's own interval -- no gap at either end and
-    // no double coverage -- and the cluster has >= 2 edges (a lone unmatched
-    // edge is not "covered" by anything).
+    // no double coverage -- and the cluster has >= 3 edges.
+    //
+    // Three, not two. A T-junction is a long edge TILED by shorter sub-edges,
+    // so the smallest genuine one is the long edge plus the two pieces the
+    // junction vertex splits it into. A two-edge cluster cannot be that: the
+    // one "sub-edge" is by construction no longer than the anchor, so spanning
+    // it end to end within `rel_tol` means the two edges ARE the same edge --
+    // a coincident/duplicated boundary edge from split vertices, not a tear
+    // covered by anything. On this fixture `>= 2` would admit exactly two such
+    // clusters, both of that shape: `#43810`'s 0.3362 m edge against a
+    // 0.3361 m twin, and `#144568`'s 1.6200 m edge against a 1.6000 m one
+    // (2 cm apart, inside the 2% `rel_tol`). Neither flips its host's verdict,
+    // because both hosts have other clusters that are genuinely not covered,
+    // so the anchor assertions at the end of this file do NOT pin this bound.
+    // It is pinned by the geometry, not by the fixture.
     //
     // Intervals are merged rather than lengths summed. Summing was the earlier
     // test and it accepts a set of sub-edges that overlap each other while

--- a/rust/geometry/tests/issue_3435_classify_probe.rs
+++ b/rust/geometry/tests/issue_3435_classify_probe.rs
@@ -135,9 +135,6 @@ fn sub(a: (f64, f64, f64), b: (f64, f64, f64)) -> (f64, f64, f64) {
 fn norm(a: (f64, f64, f64)) -> f64 {
     (a.0 * a.0 + a.1 * a.1 + a.2 * a.2).sqrt()
 }
-fn cross(a: (f64, f64, f64), b: (f64, f64, f64)) -> (f64, f64, f64) {
-    (a.1 * b.2 - a.2 * b.1, a.2 * b.0 - a.0 * b.2, a.0 * b.1 - a.1 * b.0)
-}
 fn unit(a: (f64, f64, f64)) -> (f64, f64, f64) {
     let n = norm(a);
     if n < 1e-12 {
@@ -220,7 +217,6 @@ fn classify_open_edges(edges: &[((f64, f64, f64), (f64, f64, f64))]) -> (bool, S
     // to-line distance), anchored on the longest unclustered edge each round
     // (longest edges are the most reliable to derive a direction from).
     const DIST_TOL: f64 = 1e-3; // metres, point-to-line distance tolerance
-    const LEN_TOL: f64 = 2e-3; // metres, absolute length-balance tolerance
     // Proximity bound for the interval-adjacency split (see module doc for
     // the phantom-merge failure mode this closes): every genuine
     // within-tear gap on this fixture is 0 or sub-mm, every confirmed
@@ -431,8 +427,8 @@ fn classify_probe() {
     println!("void hosts total: {}", hosts.len());
 
     println!(
-        "{:>10} {:>5} {:>6} {:>12} {:>4}  {}",
-        "host", "nvoid", "open", "path", "tjnc", "detail"
+        "{:>10} {:>5} {:>6} {:>12} {:>4}  detail",
+        "host", "nvoid", "open", "path", "tjnc"
     );
 
     let dump_hosts: [u32; 0] = [];
@@ -442,7 +438,7 @@ fn classify_probe() {
     let mut general_torn = 0usize;
     let mut tjunction = 0usize;
     let mut not_tjunction = 0usize;
-    let mut unclassified = 0usize;
+    let unclassified = 0usize;
     let mut anchor_verdicts: FxHashMap<u32, bool> = FxHashMap::default();
 
     for &host in &hosts {

--- a/rust/geometry/tests/issue_3435_classify_probe.rs
+++ b/rust/geometry/tests/issue_3435_classify_probe.rs
@@ -1,0 +1,523 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Ad hoc probe for issue #3435: classify EVERY torn host in ISSUE_068
+//! (`ISSUE_068_ARK_NUS_skolebygg.ifc`) by (a) whether it was cut via the
+//! analytic prism fast path or the general/exact kernel, and (b) whether its
+//! open edges form a T-junction (collinear, a long edge covered by shorter
+//! sub-edges on the same supporting line) — the mechanism root-caused for
+//! host #628727 — or something else.
+//!
+//! ## The collinear-merge failure mode (and its fix)
+//!
+//! The first version of this classifier clustered open edges by
+//! collinearity alone (point-to-line distance, see `DIST_TOL` below) with
+//! no bound on how far apart two collinear edges could sit. That is wrong:
+//! a wall produces many co-linear open edges at the same height along its
+//! *entire* length, so "on the same line" does not mean "part of the same
+//! tear". On host `#144568` this merged two unrelated tears at two
+//! different doorways — collinear because both doorways sit on the same
+//! wall centreline, but separated by a real 1.07 m run of intact wall
+//! between them — into one phantom cluster. That cluster then showed a
+//! spurious `overlap_slack` (the two doorways' sub-edge intervals, projected
+//! onto the shared line, look like they double-cover part of the span) that
+//! obscured the real per-doorway coverage question and could just as easily
+//! have flipped a "not covered" verdict into a false "covered" one for a
+//! different edge layout.
+//!
+//! The fix (`split_by_proximity` below) is a second pass, after collinear
+//! clustering, that further splits a line-cluster wherever two consecutive
+//! edges' projected intervals are separated by more than `GAP_TOL`. Every
+//! genuine within-tear gap observed on this fixture (the sub-edges that
+//! legitimately tile one opening's long edge) is 0 or sub-millimetre —
+//! f32-mesh-export noise. Every confirmed cross-doorway separation observed
+//! (including the `#144568` 1.07 m case) is >= 1 m. `GAP_TOL = 5 cm` sits
+//! two orders of magnitude above the noise floor and more than an order of
+//! magnitude below the smallest confirmed real separation, so it cannot
+//! misclassify either side of that fixture's evidence.
+//!
+//! Anchors (must hold after the fix): host `#628727` classifies as a
+//! T-junction; hosts `#144568` and `#893133` do not.
+//!
+//! Run (needs `debug_geometry` to read the prism fast-path fire counter):
+//!   cargo test -p ifc-lite-geometry --features debug_geometry \
+//!     --test issue_3435_classify_probe -- --ignored --nocapture classify_probe
+
+mod census_golden;
+
+use ifc_lite_core::{build_entity_index, EntityDecoder, EntityScanner};
+use ifc_lite_geometry::{propagate_voids_to_parts, take_prism_stats, GeometryRouter, Mesh};
+use rustc_hash::FxHashMap;
+
+fn crate_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+fn repo_root() -> std::path::PathBuf {
+    crate_dir().join("..").join("..")
+}
+
+fn void_index(content: &str) -> FxHashMap<u32, Vec<u32>> {
+    let mut idx: FxHashMap<u32, Vec<u32>> = FxHashMap::default();
+    let mut scanner = EntityScanner::new(content);
+    let mut decoder = EntityDecoder::new(content);
+    while let Some((id, name, start, end)) = scanner.next_entity() {
+        if name == "IFCRELVOIDSELEMENT" {
+            if let Ok(entity) = decoder.decode_at_with_id(id, start, end) {
+                if let (Some(host), Some(opening)) = (entity.get_ref(4), entity.get_ref(5)) {
+                    idx.entry(host).or_default().push(opening);
+                }
+            }
+        }
+    }
+    let _ = propagate_voids_to_parts(&mut idx, content, &mut decoder);
+    idx
+}
+
+fn process(content: &str, host_id: u32, voids: &FxHashMap<u32, Vec<u32>>) -> Option<Mesh> {
+    let ei = build_entity_index(content);
+    let mut decoder = EntityDecoder::with_index(content, ei);
+    let entity = decoder.decode_by_id(host_id).ok()?;
+    let router = GeometryRouter::with_units(content, &mut decoder);
+    router.process_element_with_voids(&entity, &mut decoder, voids).ok()
+}
+
+/// Returns (unique verts, tris, open-edge endpoint pairs as world coords).
+fn open_edges(mesh: &Mesh) -> Vec<((f64, f64, f64), (f64, f64, f64))> {
+    let q = |v: f32| (v as f64 * 1.0e3).round() as i64;
+    let mut vid: FxHashMap<(i64, i64, i64), u32> = FxHashMap::default();
+    let mut pos: Vec<(f64, f64, f64)> = Vec::new();
+    let mut id = |i: usize| -> u32 {
+        let k = (
+            q(mesh.positions[i * 3]),
+            q(mesh.positions[i * 3 + 1]),
+            q(mesh.positions[i * 3 + 2]),
+        );
+        if let Some(&existing) = vid.get(&k) {
+            return existing;
+        }
+        let n = vid.len() as u32;
+        vid.insert(k, n);
+        pos.push((
+            mesh.positions[i * 3] as f64,
+            mesh.positions[i * 3 + 1] as f64,
+            mesh.positions[i * 3 + 2] as f64,
+        ));
+        n
+    };
+    let mut uses: FxHashMap<(u32, u32), (u32, u32)> = FxHashMap::default();
+    for tri in mesh.indices.chunks_exact(3) {
+        let (a, b, c) = (id(tri[0] as usize), id(tri[1] as usize), id(tri[2] as usize));
+        if a == b || b == c || c == a {
+            continue;
+        }
+        for (x, y) in [(a, b), (b, c), (c, a)] {
+            let e = uses.entry((x.min(y), x.max(y))).or_insert((0, 0));
+            if x < y {
+                e.0 += 1
+            } else {
+                e.1 += 1
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for (&(a, b), &(f, r)) in uses.iter() {
+        if f != r {
+            out.push((pos[a as usize], pos[b as usize]));
+        }
+    }
+    out
+}
+
+fn sub(a: (f64, f64, f64), b: (f64, f64, f64)) -> (f64, f64, f64) {
+    (a.0 - b.0, a.1 - b.1, a.2 - b.2)
+}
+fn norm(a: (f64, f64, f64)) -> f64 {
+    (a.0 * a.0 + a.1 * a.1 + a.2 * a.2).sqrt()
+}
+fn cross(a: (f64, f64, f64), b: (f64, f64, f64)) -> (f64, f64, f64) {
+    (a.1 * b.2 - a.2 * b.1, a.2 * b.0 - a.0 * b.2, a.0 * b.1 - a.1 * b.0)
+}
+fn unit(a: (f64, f64, f64)) -> (f64, f64, f64) {
+    let n = norm(a);
+    if n < 1e-12 {
+        (0.0, 0.0, 0.0)
+    } else {
+        (a.0 / n, a.1 / n, a.2 / n)
+    }
+}
+
+/// Split one collinear cluster of edge indices into sub-clusters by
+/// proximity along the shared line: two edges stay together only while the
+/// gap between their projected intervals is <= `gap_tol`. See the module
+/// doc for why collinearity alone over-merges (the host `#144568`
+/// two-doorway phantom cluster) and why `gap_tol` is safe at any value
+/// between the sub-mm noise floor and the >= 1 m confirmed separations.
+fn split_by_proximity(
+    edges: &[((f64, f64, f64), (f64, f64, f64))],
+    group: Vec<usize>,
+    gap_tol: f64,
+) -> Vec<Vec<usize>> {
+    if group.len() <= 1 {
+        return vec![group];
+    }
+    // Reference direction: the longest edge in the group (least sensitive
+    // to f32-quantization noise; see the identical rationale in the
+    // per-cluster coverage pass below).
+    let (long_i, _) = group
+        .iter()
+        .map(|&i| (i, norm(sub(edges[i].1, edges[i].0))))
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+        .unwrap();
+    let (la, lb) = edges[long_i];
+    let dir = unit(sub(lb, la));
+    let t = |p: (f64, f64, f64)| -> f64 {
+        let v = sub(p, la);
+        v.0 * dir.0 + v.1 * dir.1 + v.2 * dir.2
+    };
+    let mut ivals: Vec<(f64, f64, usize)> = group
+        .iter()
+        .map(|&i| {
+            let (a, b) = edges[i];
+            let (ta, tb) = (t(a), t(b));
+            (ta.min(tb), ta.max(tb), i)
+        })
+        .collect();
+    ivals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+
+    let mut out: Vec<Vec<usize>> = Vec::new();
+    let mut current: Vec<usize> = Vec::new();
+    let mut running_hi = f64::NEG_INFINITY;
+    for (lo, hi, idx) in ivals {
+        if !current.is_empty() && lo - running_hi > gap_tol {
+            out.push(std::mem::take(&mut current));
+            running_hi = f64::NEG_INFINITY;
+        }
+        current.push(idx);
+        running_hi = running_hi.max(hi);
+    }
+    if !current.is_empty() {
+        out.push(current);
+    }
+    out
+}
+
+/// Classify a set of open edges: T-junction iff every edge's direction is
+/// parallel (cross product ~0) to a single common line direction (taken from
+/// the longest edge), AND every edge's start point lies on that same line
+/// through the longest edge's start point (perpendicular offset ~0).
+/// Returns (is_t_junction, detail string).
+fn classify_open_edges(edges: &[((f64, f64, f64), (f64, f64, f64))]) -> (bool, String) {
+    if edges.is_empty() {
+        return (false, "no open edges (should not happen for a torn host)".into());
+    }
+    // POINT-based collinearity (not direction-vector-based): a T-junction's
+    // shortest sub-edge can be sub-millimetre, and dividing its (equally
+    // tiny) displacement by its own length amplifies f32-quantization noise
+    // into a direction vector that looks nowhere near parallel even though
+    // both its endpoints sit exactly on the long edge's line. So: cluster by
+    // whether each edge's OWN TWO ENDPOINTS lie on a candidate line (point-
+    // to-line distance), anchored on the longest unclustered edge each round
+    // (longest edges are the most reliable to derive a direction from).
+    const DIST_TOL: f64 = 1e-3; // metres, point-to-line distance tolerance
+    const LEN_TOL: f64 = 2e-3; // metres, absolute length-balance tolerance
+    // Proximity bound for the interval-adjacency split (see module doc for
+    // the phantom-merge failure mode this closes): every genuine
+    // within-tear gap on this fixture is 0 or sub-mm, every confirmed
+    // cross-doorway separation is >= 1 m, so 5 cm sits comfortably between
+    // both without being derivable from either -- it is not tuned to a
+    // specific edge, just placed in the two-orders-of-magnitude gap the
+    // evidence leaves open.
+    const GAP_TOL: f64 = 0.05; // metres
+
+    let mut remaining: Vec<usize> = (0..edges.len()).collect();
+    let mut clusters: Vec<Vec<usize>> = Vec::new();
+    while !remaining.is_empty() {
+        // Anchor = longest remaining edge.
+        let (pos, &anchor_i) = remaining
+            .iter()
+            .enumerate()
+            .max_by(|a, b| {
+                let la = norm(sub(edges[*a.1].1, edges[*a.1].0));
+                let lb = norm(sub(edges[*b.1].1, edges[*b.1].0));
+                la.partial_cmp(&lb).unwrap()
+            })
+            .unwrap();
+        remaining.remove(pos);
+        let (aa, ab) = edges[anchor_i];
+        let dir = unit(sub(ab, aa));
+        let mut group = vec![anchor_i];
+        remaining.retain(|&i| {
+            let (a, b) = edges[i];
+            let on_line = |p: (f64, f64, f64)| -> f64 {
+                let v = sub(p, aa);
+                let proj = v.0 * dir.0 + v.1 * dir.1 + v.2 * dir.2;
+                let perp = sub(v, (dir.0 * proj, dir.1 * proj, dir.2 * proj));
+                norm(perp)
+            };
+            if on_line(a) <= DIST_TOL && on_line(b) <= DIST_TOL {
+                group.push(i);
+                false // consumed
+            } else {
+                true // keep for a later cluster
+            }
+        });
+        clusters.push(group);
+    }
+
+    // Second pass: split each collinear cluster further by proximity along
+    // the shared line. Collinearity alone over-merges (see module doc); two
+    // edges only belong in the same tear if their projected intervals are
+    // within GAP_TOL of touching.
+    let mut clusters: Vec<Vec<usize>> = clusters
+        .into_iter()
+        .flat_map(|g| split_by_proximity(edges, g, GAP_TOL))
+        .collect();
+    clusters.retain(|g| !g.is_empty());
+
+    // Per cluster: T-junction covering iff the longest edge's length equals
+    // the sum of every OTHER edge in the cluster (the sub-edges partition
+    // the long edge with no gap/overlap) within LEN_TOL, and the cluster has
+    // >= 2 edges (a lone unmatched edge is not "covered" by anything).
+    let mut all_covered = true;
+    let mut parts = Vec::new();
+    for g in &clusters {
+        // Identify the longest edge in this cluster and use ITS direction as
+        // the line's parametrization axis (most reliable direction, since
+        // dividing by a tiny edge's own length amplifies quantization noise
+        // -- the reason a global single-reference-line test misfired on
+        // #637986's 0.4mm middle segment).
+        let (long_i, long_len) = g
+            .iter()
+            .map(|&i| (i, norm(sub(edges[i].1, edges[i].0))))
+            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+            .unwrap();
+        let (la, lb) = edges[long_i];
+        let dir = unit(sub(lb, la));
+        let t = |p: (f64, f64, f64)| -> f64 {
+            let v = sub(p, la);
+            v.0 * dir.0 + v.1 * dir.1 + v.2 * dir.2
+        };
+        // Full interval = the longest edge's own span (by construction [0, long_len]).
+        let mut full_lo = t(la).min(t(lb));
+        let mut full_hi = t(la).max(t(lb));
+        if full_lo > full_hi {
+            std::mem::swap(&mut full_lo, &mut full_hi);
+        }
+        // Every OTHER edge's interval, merged (sorted + coalesced).
+        let mut ivals: Vec<(f64, f64)> = g
+            .iter()
+            .filter(|&&i| i != long_i)
+            .map(|&i| {
+                let (a, b) = edges[i];
+                let (ta, tb) = (t(a), t(b));
+                (ta.min(tb), ta.max(tb))
+            })
+            .collect();
+        ivals.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        let mut merged: Vec<(f64, f64)> = Vec::new();
+        let mut overlap_slack = 0.0f64; // total double-covered length (indicates crossing sub-edges)
+        for iv in ivals.iter().copied() {
+            if let Some(last) = merged.last_mut() {
+                if iv.0 <= last.1 + DIST_TOL {
+                    if iv.1 < last.1 {
+                        overlap_slack += iv.1 - iv.0; // fully engulfed
+                    } else {
+                        overlap_slack += (last.1 - iv.0).max(0.0);
+                    }
+                    last.1 = last.1.max(iv.1);
+                    continue;
+                }
+            }
+            merged.push(iv);
+        }
+        let merged_len: f64 = merged.iter().map(|&(a, b)| b - a).sum();
+        let sum_others: f64 = ivals.iter().map(|&(a, b)| b - a).sum();
+        // Scale-relative tolerance: an absolute 1mm floor is >10% of a
+        // sub-cm sliver edge (#640479 has edges of a few mm), so a fixed
+        // absolute tolerance would wave through a genuine partial overlap
+        // as "noise". Use 2% of the long edge, floored at 0.1mm.
+        let rel_tol = (long_len * 0.02).max(1e-4);
+        let no_gap = merged.len() == 1
+            && (merged[0].0 - full_lo).abs() <= rel_tol
+            && (merged[0].1 - full_hi).abs() <= rel_tol;
+        let no_overlap = overlap_slack <= rel_tol;
+        let covered = g.len() >= 3 && no_gap && no_overlap;
+        if !covered {
+            all_covered = false;
+        }
+        parts.push(format!(
+            "[{} edges, long={:.4}m, sum_others={:.4}m, merged_len={:.4}m, overlap_slack={:.2e}, {}]",
+            g.len(),
+            long_len,
+            sum_others,
+            merged_len,
+            overlap_slack,
+            if covered { "covered(no-gap,no-overlap)" } else { "NOT covered" }
+        ));
+    }
+    let detail = format!("{} line-cluster(s): {}", clusters.len(), parts.join(" "));
+    (all_covered, detail)
+}
+
+fn edge_open_count(mesh: &Mesh) -> usize {
+    open_edges(mesh).len()
+}
+
+/// splitmix64: tiny deterministic PRNG so the ordering-permutation check
+/// below is seed-reproducible without pulling in the `rand` crate as a
+/// dev-dependency of a `#[ignore]`d probe (same construction as
+/// `issue_068_void_ordering_probe.rs`'s `SplitMix64`).
+struct SplitMix64(u64);
+impl SplitMix64 {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+    fn shuffle<T>(&mut self, v: &mut [T]) {
+        for i in (1..v.len()).rev() {
+            let j = (self.next() % (i as u64 + 1)) as usize;
+            v.swap(i, j);
+        }
+    }
+}
+
+/// Anchor hosts pinned by the #3435 investigation: `#628727` is the
+/// original T-junction reproducer; `#144568` and `#893133` are confirmed
+/// NOT T-junctions (see module doc for `#144568`'s phantom-merge history).
+const ANCHOR_TJUNCTION: u32 = 628727;
+const ANCHOR_NOT_TJUNCTION: [u32; 2] = [144568, 893133];
+
+/// The classifier clusters by a greedy longest-edge-first anchor pick, which
+/// is itself order-independent (max-by-length, not first-seen), but the
+/// input edge list order still depends on `open_edges`'s `FxHashMap`
+/// iteration order, which is NOT deterministic across runs. Reproducing the
+/// verdict under several explicit shuffles of the same edge set guards
+/// against a hidden order dependency creeping back into the clustering (the
+/// exact class of bug the collinear-merge fix above was pinned against).
+fn assert_permutation_invariant(host: u32, edges: &[((f64, f64, f64), (f64, f64, f64))]) {
+    let (baseline_tj, baseline_detail) = classify_open_edges(edges);
+    let mut rng = SplitMix64(0x1235_5EED_C0FF_EE03 ^ host as u64);
+    for trial in 0..8 {
+        let mut shuffled = edges.to_vec();
+        if trial == 0 {
+            shuffled.reverse();
+        } else {
+            rng.shuffle(&mut shuffled);
+        }
+        let (tj, detail) = classify_open_edges(&shuffled);
+        assert_eq!(
+            tj, baseline_tj,
+            "host #{host} trial {trial}: T-junction verdict changed under edge-order permutation \
+             (baseline={baseline_detail}, shuffled={detail})"
+        );
+    }
+}
+
+#[test]
+#[ignore = "manual probe (#3435): classify torn hosts by fast-path vs general cutter and T-junction vs other"]
+fn classify_probe() {
+    let rel = "tests/models/ara3d/ISSUE_068_ARK_NUS_skolebygg.ifc";
+    let path = repo_root().join(rel);
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    let voids = void_index(&content);
+
+    let mut hosts: Vec<u32> = voids.keys().copied().collect();
+    hosts.sort_unstable();
+    println!("void hosts total: {}", hosts.len());
+
+    println!(
+        "{:>10} {:>5} {:>6} {:>12} {:>4}  {}",
+        "host", "nvoid", "open", "path", "tjnc", "detail"
+    );
+
+    let dump_hosts: [u32; 0] = [];
+
+    let mut torn = 0usize;
+    let mut fastpath_torn = 0usize;
+    let mut general_torn = 0usize;
+    let mut tjunction = 0usize;
+    let mut not_tjunction = 0usize;
+    let mut unclassified = 0usize;
+    let mut anchor_verdicts: FxHashMap<u32, bool> = FxHashMap::default();
+
+    for &host in &hosts {
+        let openings = voids.get(&host).cloned().unwrap_or_default();
+        let _ = take_prism_stats(); // reset before this host's processing
+        let Some(mesh) = process(&content, host, &voids) else {
+            continue;
+        };
+        let (fires, _analytic, _residual) = take_prism_stats();
+        let open = edge_open_count(&mesh);
+        if open == 0 {
+            continue;
+        }
+        torn += 1;
+        let path = if fires > 0 { "PRISM_FAST" } else { "GENERAL" };
+        if fires > 0 {
+            fastpath_torn += 1;
+        } else {
+            general_torn += 1;
+        }
+        let edges = open_edges(&mesh);
+        let (is_tj, detail) = classify_open_edges(&edges);
+        let tj_str = if is_tj {
+            tjunction += 1;
+            "YES"
+        } else {
+            not_tjunction += 1;
+            "NO"
+        };
+        if host == ANCHOR_TJUNCTION || ANCHOR_NOT_TJUNCTION.contains(&host) {
+            anchor_verdicts.insert(host, is_tj);
+            assert_permutation_invariant(host, &edges);
+        }
+        println!(
+            "{:>10} {:>5} {:>6} {:>12} {:>4}  {}",
+            host,
+            openings.len(),
+            open,
+            path,
+            tj_str,
+            detail
+        );
+        if dump_hosts.contains(&host) {
+            println!("  ---- raw open edges for host {host} ----");
+            for (a, b) in &edges {
+                let d = sub(*b, *a);
+                println!(
+                    "    A=({:.4},{:.4},{:.4}) B=({:.4},{:.4},{:.4})  len={:.4} dir={:.4},{:.4},{:.4}",
+                    a.0, a.1, a.2, b.0, b.1, b.2, norm(d), d.0 / norm(d).max(1e-12), d.1 / norm(d).max(1e-12), d.2 / norm(d).max(1e-12)
+                );
+            }
+        }
+    }
+    let _ = unclassified;
+
+    println!("\n==== SUMMARY ====");
+    println!("torn hosts total     : {torn}");
+    println!("  via prism fast path: {fastpath_torn}");
+    println!("  via general cutter : {general_torn}");
+    println!("  T-junction (yes)   : {tjunction}");
+    println!("  T-junction (no)    : {not_tjunction}");
+
+    // Anchors: the corrected classifier (collinearity + proximity split)
+    // must reproduce these regardless of any unrelated drift elsewhere in
+    // the population.
+    assert_eq!(
+        anchor_verdicts.get(&ANCHOR_TJUNCTION).copied(),
+        Some(true),
+        "host #{ANCHOR_TJUNCTION} must classify as a T-junction"
+    );
+    for &host in &ANCHOR_NOT_TJUNCTION {
+        assert_eq!(
+            anchor_verdicts.get(&host).copied(),
+            Some(false),
+            "host #{host} must NOT classify as a T-junction"
+        );
+    }
+}


### PR DESCRIPTION
## What

Refs #3435. The open-edge T-junction classifier used in the #3435 torn-host investigation clustered open edges by collinearity alone, with no proximity bound. A wall produces many co-linear open edges along its whole length, so "on the same line" does not mean "part of the same tear."

On host `#144568` the unbounded classifier merged two unrelated tears at two different doorways, collinear because both sit on the same wall centreline but separated by a real **1.07 m** run of intact wall, into one phantom cluster. That fix was worked out and validated in an earlier session, but the worktree it lived in was deleted before it was committed, leaving the `GAP_TOL`-less version as the only copy anyone could find. This PR reconstructs and lands the fix so the investigation is reproducible.

## The fix

`split_by_proximity` (in `issue_3435_classify_probe.rs`) runs as a second pass after collinear clustering: it further splits a cluster wherever two edges' intervals, projected onto the shared line, are separated by more than `GAP_TOL = 5 cm`.

That threshold comes from the fixture's own measured gaps, obtained by printing `lo - running_hi` for every pair `split_by_proximity` compares across all 29 torn hosts. The gaps that stay together (the sub-edges that legitimately tile one opening's long edge) are 0 or negative; the largest is 0.000000 m to six decimals, f32 mesh-export noise. The gaps that do split are 0.1235 m (`#360795`), 0.2110 / 0.2639 / 0.6034 m (`#43810`), 1.0721 m (`#144568`), 3.5200 m (`#893133`) and 5.0760 m (`#53374`).

So 5 cm clears the noise floor by two orders of magnitude, but the margin on the other side is a factor of 2.5, not another two orders: four of those seven separations are under a metre. Raising `GAP_TOL` past 0.1235 m would re-merge `#360795` and silently undo the fix. The headroom is below this value, not above it.

## Anchors (asserted, not just printed)

- `#628727` and `#360795` classify as T-junctions
- `#144568` and `#893133` do NOT classify as T-junctions

`#360795` is the anchor that pins the fix itself: over the fixture's 29 torn hosts it is the only host whose verdict the second pass changes. Reverting only the `flat_map(split_by_proximity)` block and keeping every assertion fails on `#360795` alone; the other three anchors are unchanged by that mutation and could not have caught it.

Also added: a permutation-invariance check per anchor host. What it guards is the clustering's anchor tie-break, not hash order. `Iterator::max_by` returns the LAST maximum on ties, so equal-length edges are resolved by input position, and host `#144568` has two open edges tying exactly at 1.6199951183372845 m; permuting its edge list really does swap which of them anchors the first cluster. (The edge list order itself is stable: `FxBuildHasher` is a seedless unit struct, so `FxHashMap` iteration order does not vary run to run.)

With the fix, the T-junction count over the fixture's 29 torn hosts moves from **19 to 20**: host `#360795` was a second, smaller instance of the same phantom-merge failure, and correctly resolves into two independently-covered clusters once the proximity split is applied.

## Consolidation

Several overlapping ad hoc `#3435` probes accumulated across sessions investigating this issue, in worktrees that were never committed. This PR lands two of them: the classifier above, and `issue_068_void_ordering_probe.rs` (the void-application-order permutation check). Both are new files. Nothing is deleted: `git diff --name-status origin/main...HEAD` is two `A` lines and zero `D` lines.

## Not a product fix

This is diagnostic tooling for the #3435 investigation, not a fix to any product code path. Both probes stay `#[ignore]`d and are not gated in CI. Precedent: `wall_opening_cut_regression.rs` and the heavy-fixture lane added in #3436 already commit `#[ignore]`d expensive/manual probes.

## Test plan

- [x] `cargo test -p ifc-lite-geometry --features debug_geometry --test issue_3435_classify_probe -- --ignored --nocapture classify_probe` — passes, anchors hold, permutation checks pass
- [x] `cargo build -p ifc-lite-geometry --test issue_068_void_ordering_probe --features debug_geometry` — compiles
- [x] `cargo clippy -p ifc-lite-geometry --all-targets -- -D warnings` (without `debug_geometry`, CI's scope) — 0 warnings
- [x] Both probes skip cleanly with the fixture absent
- [x] `node scripts/check-module-size.mjs` — OK
- [x] `node scripts/check-rust-source-text-assertions.mjs` — OK (0 source-text assertions)
