### PR TITLE
fix(ci): widen sdk-canary.yml's paths: to the CLI's full transitive workspace closure

### DIFF
--- a/.github/workflows/sdk-canary.yml
+++ b/.github/workflows/sdk-canary.yml
@@ -13,12 +13,49 @@
 
 name: SDK canary
 
+# `paths:` below names every package `pnpm turbo build --filter=@ifc-lite/extensions
+# --filter=@ifc-lite/cli` transitively builds (turbo's `build` task depends on
+# `^build`, so it walks the full `dependencies` + `devDependencies` workspace
+# graph of both, in topological order) plus the canary fixtures and this file
+# itself. `scripts/check-sdk-canary-coverage.mjs` derives that closure from the
+# real package.json graph on every CI run and fails if this list falls behind
+# it -- so this is a snapshot of a derived fact, not a maintained one; if the
+# list and the gate disagree, trust the gate and regenerate the list from its
+# output. Note `@ifc-lite/viewer-core` lives in `packages/viewer`, not
+# `packages/viewer-core` -- the package NAME and its directory diverge.
 on:
   pull_request:
     branches: [main]
     paths:
-      - 'packages/extensions/**'
+      - 'packages/bcf/**'
+      - 'packages/clash/**'
       - 'packages/cli/**'
+      - 'packages/collab/**'
+      - 'packages/create/**'
+      - 'packages/data/**'
+      - 'packages/diff/**'
+      - 'packages/drawing-2d/**'
+      - 'packages/encoding/**'
+      - 'packages/export/**'
+      - 'packages/extensions/**'
+      - 'packages/geometry/**'
+      - 'packages/ids/**'
+      - 'packages/ifcx/**'
+      - 'packages/lens/**'
+      - 'packages/lists/**'
+      - 'packages/mcp/**'
+      - 'packages/merge/**'
+      - 'packages/mutations/**'
+      - 'packages/parser/**'
+      - 'packages/pointcloud/**'
+      - 'packages/query/**'
+      - 'packages/sandbox/**'
+      - 'packages/sdk/**'
+      - 'packages/spatial/**'
+      - 'packages/timing-ladder/**'
+      - 'packages/viewer/**'
+      - 'packages/wasm/**'
+      - 'packages/world-frame-fixtures/**'
       - 'tests/extensions/canaries/**'
       - '.github/workflows/sdk-canary.yml'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -826,6 +826,18 @@ jobs:
       # block / zero derived inputs must FAIL rather than report clean.
       - name: Check CI path-coverage gate regressions
         run: node --test scripts/check-ci-path-coverage.test.mjs
+      # Same class as the gate above (#3452), for a case it cannot see: its
+      # own scan only recognises gates invoked as a literal `node
+      # scripts/*.mjs` in a `run:` step, and sdk-canary.yml's job is `pnpm
+      # turbo build` + `node packages/cli/dist/index.js ext test` -- no gate
+      # script at all. This instead derives the FULL transitive
+      # workspace-dependency closure `turbo build` walks from the real
+      # package.json graph and fails when sdk-canary.yml's own `paths:`
+      # filter does not cover all of it.
+      - name: Check SDK canary path coverage
+        run: node scripts/check-sdk-canary-coverage.mjs
+      - name: Check SDK canary path-coverage gate regressions
+        run: node --test scripts/check-sdk-canary-coverage.test.mjs
       # The CSV cell escaper reached NINE hand-rolled copies and no two were
       # identical: some tested the formula trigger anchored at offset 0 (so a
       # BOM/ZWSP/LRM/NBSP/U+2028 in front of `=` bypassed the CWE-1236 guard),

--- a/scripts/check-sdk-canary-coverage.mjs
+++ b/scripts/check-sdk-canary-coverage.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Ratchet: `.github/workflows/sdk-canary.yml`'s `paths:` filter must cover
+ * every workspace package the job actually builds.
+ *
+ * THE DEFECT (#3452). The canary job runs
+ * `pnpm turbo build --filter=@ifc-lite/extensions --filter=@ifc-lite/cli`,
+ * which -- because `build` depends on `^build` in turbo.json -- builds the
+ * FULL transitive workspace-dependency closure of both packages, in
+ * topological order. The workflow's `on.pull_request.paths` named only
+ * `packages/extensions/**` and `packages/cli/**`: two of the packages the
+ * job actually builds from. A PR touching any other package in the closure
+ * (`parser`, `sdk`, `wasm`, `mcp`, `collab`, ... -- 27 more, at the time this
+ * was written) triggered no run at all: not a failure, no row, indistinguishable
+ * from a pass to anyone reading the check list.
+ *
+ * `scripts/check-ci-path-coverage.mjs` cannot see this class: it only
+ * recognises gates invoked as a literal `node scripts/*.mjs` in a `run:`
+ * step, and this job's steps are `pnpm turbo build` and
+ * `node packages/cli/dist/index.js ext test`. This gate exists to cover
+ * exactly the case that one documents as its own blind spot.
+ *
+ * WHAT THIS DOES. Parses the `--filter=<pkg>` build targets out of the
+ * workflow's own build step, walks the REAL `dependencies` +
+ * `devDependencies` workspace graph (both -- turbo's internal package graph,
+ * derived from the pnpm workspace, does not distinguish them, so a
+ * `devDependency`-only package still gets built before its dependent) from
+ * each target to the full transitive closure, and checks every package's
+ * directory against the workflow's `on.pull_request.paths`. Anything in the
+ * closure that no glob covers is a NAMED violation.
+ *
+ * DELIBERATELY NOT A HAND-MAINTAINED LIST. The obvious fix -- write out the
+ * ~29-package closure as literal `paths:` entries -- rots exactly the way the
+ * 2-of-20 list already did: nothing forces the next dependency edit to update
+ * it. This derives the closure from the same `package.json` files the build
+ * itself reads, so the two cannot drift apart without this gate noticing.
+ * A hand-edited list is still the OUTPUT (see the `paths:` block this PR
+ * writes into the workflow) -- it is verified on every run rather than
+ * trusted once. Also note `@ifc-lite/viewer-core` (a `packages/cli`
+ * dependency) lives in `packages/viewer`, not `packages/viewer-core` -- the
+ * package NAME and its directory diverge here, which is exactly the kind of
+ * detail a hand-maintained list silently gets wrong and a derived one cannot.
+ *
+ * FAILS CLOSED. A missing workflow, an unparseable trigger, no `--filter=`
+ * targets found, a closure package with no `packages/<dir>` on disk, or a
+ * dependency name the workspace scan never saw -- each is a NAMED failure,
+ * never a silent pass.
+ *
+ * Run via `node scripts/check-sdk-canary-coverage.mjs` (CI Node tests job).
+ * `--root <dir>` points it at a mutated copy of the tree; that is how
+ * `check-sdk-canary-coverage.test.mjs` proves it fires.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { matchesAny, parseWorkflowPrPaths } from './lib/ci-path-coverage.mjs';
+import { listWorkspacePackages } from './lib/list-workspace-packages.mjs';
+
+const rootFlag = process.argv.indexOf('--root');
+const ROOT =
+  rootFlag !== -1 && process.argv[rootFlag + 1]
+    ? process.argv[rootFlag + 1]
+    : join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const WORKFLOW = '.github/workflows/sdk-canary.yml';
+const abs = (p) => join(ROOT, p);
+
+class CheckFailure extends Error {}
+function fail(message) {
+  throw new CheckFailure(message);
+}
+
+function main() {
+  let text;
+  try {
+    text = readFileSync(abs(WORKFLOW), 'utf8');
+  } catch (err) {
+    fail(`cannot read ${WORKFLOW}: ${err.code || err.message}.`);
+  }
+
+  // 1. The build targets: the `--filter=<pkg>` values on the turbo build
+  //    step. This is the SAME command GitHub Actions will run, read literally
+  //    rather than assumed, so a future change to which packages get built
+  //    (e.g. dropping `--filter=@ifc-lite/extensions`) changes what this gate
+  //    checks without anyone having to remember to update it here too.
+  const buildStep = text.match(/run:\s*pnpm turbo build\b([^\n]*)/);
+  if (!buildStep) {
+    fail(
+      `${WORKFLOW}: no \`pnpm turbo build\` step found. This gate cannot determine ` +
+        'which packages the canary job actually builds.',
+    );
+  }
+  const targets = [...buildStep[1].matchAll(/--filter=(\S+)/g)].map((m) => m[1]);
+  if (targets.length === 0) {
+    fail(
+      `${WORKFLOW}: the turbo build step has no --filter=<pkg> arguments. ` +
+        'Refusing to check coverage of an empty target set as if it were correct.',
+    );
+  }
+
+  // 2. The real workspace dependency graph: every packages/* package, keyed
+  //    by its package.json `name`, with the union of its `dependencies` and
+  //    `devDependencies` that use the `workspace:` protocol.
+  const { packages } = listWorkspacePackages(ROOT, fail, ['packages']);
+  const byName = new Map();
+  for (const pkg of packages) {
+    const name = pkg.pkgJson?.name;
+    if (typeof name !== 'string' || name === '') {
+      fail(`${pkg.dir}/package.json has no string "name" -- cannot key the dependency graph.`);
+    }
+    const deps = { ...(pkg.pkgJson.dependencies || {}), ...(pkg.pkgJson.devDependencies || {}) };
+    const workspaceDeps = Object.entries(deps)
+      .filter(([, spec]) => typeof spec === 'string' && spec.startsWith('workspace:'))
+      .map(([dep]) => dep);
+    byName.set(name, { rel: pkg.rel, workspaceDeps });
+  }
+
+  // 3. BFS the transitive closure from every build target.
+  const closure = new Set();
+  const queue = [...targets];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (closure.has(name)) continue;
+    closure.add(name);
+    const info = byName.get(name);
+    if (!info) {
+      fail(
+        `${WORKFLOW} builds "${name}", which is not a package name found under packages/*. ` +
+          'Either the workspace moved it or this gate\'s package scan is stale -- either way ' +
+          'the closure below would be short, not empty, so refusing rather than proceeding.',
+      );
+    }
+    for (const dep of info.workspaceDeps) queue.push(dep);
+  }
+
+  // 4. The trigger. `triggersOnPr: false` or `paths: null` both mean "every
+  //    path reaches this job" -- the same convention check-ci-path-coverage
+  //    uses -- so there is nothing to check; a job with no path filter cannot
+  //    have this defect.
+  let triggersOnPr;
+  let paths;
+  try {
+    ({ triggersOnPr, paths } = parseWorkflowPrPaths(text));
+  } catch (err) {
+    fail(`cannot read the triggers of ${WORKFLOW}: ${err.message}`);
+  }
+  if (!triggersOnPr || paths === null) {
+    console.log(
+      `✅ check-sdk-canary-coverage: ${WORKFLOW} has no path filter (or none on pull_request) -- ` +
+        'every path reaches it, so the closure cannot be uncovered.',
+    );
+    return;
+  }
+
+  // 5. The mechanical diff: every closure package's directory must be
+  //    covered by some glob in `paths`.
+  const violations = [];
+  for (const name of [...closure].sort()) {
+    const info = byName.get(name);
+    if (!matchesAny(info.rel, paths)) {
+      violations.push({ name, rel: info.rel });
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `\n❌ check-sdk-canary-coverage: ${WORKFLOW} builds ${closure.size} package(s) ` +
+        `(transitively, from ${targets.join(', ')}) but its \`paths:\` filter covers only ` +
+        `${closure.size - violations.length} of them.\n`,
+    );
+    for (const v of violations) {
+      console.error(`  • ${v.name} (${v.rel}/**) can trigger a build that never runs.`);
+    }
+    console.error(
+      '\nA change to any of the packages above breaks the canary job without the job ever\n' +
+        `running. Add each missing directory to ${WORKFLOW}'s \`paths:\`.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `✅ check-sdk-canary-coverage: ${WORKFLOW}'s \`paths:\` covers all ${closure.size} ` +
+      `package(s) transitively built from ${targets.join(', ')}.`,
+  );
+}
+
+try {
+  main();
+} catch (err) {
+  if (err instanceof CheckFailure) {
+    console.error(`❌ check-sdk-canary-coverage: ${err.message}`);
+    process.exit(1);
+  }
+  throw err;
+}

--- a/scripts/check-sdk-canary-coverage.test.mjs
+++ b/scripts/check-sdk-canary-coverage.test.mjs
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Executable proof that `scripts/check-sdk-canary-coverage.mjs` cannot pass
+ * vacuously, and that it actually fires on the shape of #3452: a
+ * `paths:` filter that names the direct build targets but not their
+ * transitive workspace dependencies.
+ *
+ * Built against a synthetic tree (`--root`) so these assertions do not move
+ * when the real workspace graph does, and so a fixture can reintroduce the
+ * exact hole #3452 found (a `devDependency`-only transitive package left
+ * uncovered) without waiting for the real graph to grow one again.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CHECK = join(HERE, 'check-sdk-canary-coverage.mjs');
+
+function run(root) {
+  try {
+    const out = execFileSync(process.execPath, [CHECK, '--root', root], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, out };
+  } catch (err) {
+    return { status: err.status ?? 1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+function withTree(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'sdk-canary-coverage-'));
+  try {
+    return fn(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function writePkg(root, name, deps = {}, devDeps = {}) {
+  const dir = join(root, 'packages', name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({ name: `@t/${name}`, dependencies: deps, devDependencies: devDeps }),
+  );
+}
+
+const WORKFLOW = (paths, filters = '@t/cli') => `name: SDK canary
+
+on:
+  pull_request:
+    branches: [main]
+${paths === null ? '' : `    paths:\n${paths.map((p) => `      - '${p}'`).join('\n')}\n`}
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        run: pnpm turbo build ${filters
+          .split(',')
+          .map((f) => `--filter=${f}`)
+          .join(' ')}
+`;
+
+function writeWorkflow(root, text) {
+  const dir = join(root, '.github/workflows');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'sdk-canary.yml'), text);
+}
+
+test('a package reachable only through a devDependency, and left out of paths, fails by name', () => {
+  withTree((root) => {
+    // cli -> mid (dependency) -> leaf (devDependency of mid, the shape
+    // `timing-ladder`/`world-frame-fixtures` actually take in the real repo).
+    writePkg(root, 'cli', { '@t/mid': 'workspace:^' });
+    writePkg(root, 'mid', {}, { '@t/leaf': 'workspace:^' });
+    writePkg(root, 'leaf');
+    writeWorkflow(root, WORKFLOW(['packages/cli/**', 'packages/mid/**']));
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /@t\/leaf/);
+    assert.match(out, /packages\/leaf/);
+  });
+});
+
+test('widening paths to cover the full closure turns it green', () => {
+  withTree((root) => {
+    writePkg(root, 'cli', { '@t/mid': 'workspace:^' });
+    writePkg(root, 'mid', {}, { '@t/leaf': 'workspace:^' });
+    writePkg(root, 'leaf');
+    writeWorkflow(root, WORKFLOW(['packages/cli/**', 'packages/mid/**', 'packages/leaf/**']));
+    const { status, out } = run(root);
+    assert.equal(status, 0);
+    assert.match(out, /covers all 3 package/);
+  });
+});
+
+test('multiple --filter build targets are all walked', () => {
+  withTree((root) => {
+    writePkg(root, 'cli', { '@t/shared': 'workspace:^' });
+    writePkg(root, 'extensions', { '@t/other': 'workspace:^' });
+    writePkg(root, 'shared');
+    writePkg(root, 'other');
+    writeWorkflow(
+      root,
+      WORKFLOW(['packages/cli/**', 'packages/extensions/**'], '@t/cli,@t/extensions'),
+    );
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /@t\/shared/);
+    assert.match(out, /@t\/other/);
+  });
+});
+
+test('no path filter at all (paths absent) passes trivially -- everything reaches the job', () => {
+  withTree((root) => {
+    writePkg(root, 'cli', { '@t/mid': 'workspace:^' });
+    writePkg(root, 'mid');
+    writeWorkflow(root, WORKFLOW(null));
+    const { status, out } = run(root);
+    assert.equal(status, 0);
+    assert.match(out, /no path filter/);
+  });
+});
+
+test('a closure member with no matching workspace package fails closed, not silently short', () => {
+  withTree((root) => {
+    // cli depends on a package that does not exist under packages/*.
+    writePkg(root, 'cli', { '@t/ghost': 'workspace:^' });
+    writeWorkflow(root, WORKFLOW(['packages/cli/**']));
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /@t\/ghost/);
+    assert.match(out, /not a package name found/);
+  });
+});
+
+test('a missing workflow file fails closed', () => {
+  withTree((root) => {
+    writePkg(root, 'cli');
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /cannot read/);
+  });
+});
+
+test('a turbo build step with no --filter= arguments fails closed', () => {
+  withTree((root) => {
+    writePkg(root, 'cli');
+    writeWorkflow(
+      root,
+      `name: SDK canary
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/cli/**'
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        run: pnpm turbo build
+`,
+    );
+    const { status, out } = run(root);
+    assert.equal(status, 1);
+    assert.match(out, /no --filter=<pkg> arguments/);
+  });
+});


### PR DESCRIPTION
## What changed

`sdk-canary.yml`'s `paths:` filter named only 2 of the packages the job actually builds (`packages/extensions/**`, `packages/cli/**`). The job runs `pnpm turbo build --filter=@ifc-lite/extensions --filter=@ifc-lite/cli`; because turbo's `build` task depends on `^build`, that walks the full `dependencies` + `devDependencies` workspace graph of both packages, in topological order — **29 packages**, not 20 (the issue's count was `packages/cli/package.json`'s direct dependencies only; the real transitive closure through `@ifc-lite/mcp` → `@ifc-lite/collab`, `@ifc-lite/encoding` → `@ifc-lite/timing-ladder`, etc. is larger). A PR touching any package outside the filter triggered no run — not a failure, no row.

Two changes:

1. **`.github/workflows/sdk-canary.yml`** — widened `paths:` to the full derived closure (29 entries). Noted in a comment: `@ifc-lite/viewer-core` lives in `packages/viewer`, not `packages/viewer-core` — the package *name* and its directory diverge, which a hand-written list gets wrong silently.
2. **`scripts/check-sdk-canary-coverage.mjs`** (+ test) — a new CI gate, wired into the `node-tests` job of `test.yml` next to the existing `check-ci-path-coverage` step. It parses the `--filter=<pkg>` targets out of the workflow's own build step, walks the real `package.json` workspace graph (`dependencies` + `devDependencies`, since turbo's internal graph doesn't distinguish them) to the full transitive closure, and fails, naming the missing package(s), if `sdk-canary.yml`'s `paths:` doesn't cover all of it. The `paths:` list above is now a snapshot of a derived fact rather than a maintained one — if it drifts from the real graph again, this gate turns the PR that causes the drift red instead of silently skipped.

`scripts/check-ci-path-coverage.mjs` (the existing repo-wide version of this class of check) cannot see this case by its own documented design: it only recognises gates invoked as a literal `node scripts/*.mjs` in a `run:` step, and this job's steps are `pnpm turbo build` and `node packages/cli/dist/index.js ext test` — no gate script at all. `check-sdk-canary-coverage.mjs` is a purpose-built gate for exactly the case that one names as its own blind spot.

## Scope note: the `on: pull_request`-only trigger

The issue also observes that `sdk-canary.yml` triggers on `pull_request` only, so it can't be "release-blocking" in the sense `docs/architecture/ai-customization/09-implementation-plan.md` describes. That's a separate concern from the path-coverage defect this PR fixes (what triggers a release-blocking gate should have — `push`? a dedicated `release` workflow? `schedule`? — is a design question with its own tradeoffs, not a one-line fix) and is left out of this change deliberately rather than folded in.

## Verified

- `node scripts/check-sdk-canary-coverage.mjs` against the **pre-fix** workflow: RED, failing on all 27 packages outside the old `paths:` list (`@ifc-lite/bcf`, `@ifc-lite/clash`, ... `@ifc-lite/world-frame-fixtures`), exit 1.
- Same command against the **post-fix** workflow: GREEN — `covers all 29 package(s) transitively built from @ifc-lite/extensions, @ifc-lite/cli`, exit 0.
- `node --test scripts/check-sdk-canary-coverage.test.mjs` — 7/7 passing, including a synthetic reproduction of the exact #3452 shape (a package reachable only through a `devDependency`, left out of `paths:`) and fail-closed cases (missing workflow, no `--filter=` args, unresolvable dependency name).
- `node scripts/check-ci-path-coverage.mjs` — still green (84 gates, 303 derived inputs, 0 violations) with the two new steps now wired into `test.yml`'s `node-tests` job.
- `node --test scripts/check-ci-path-coverage.test.mjs` — 39/39 still passing (no regression).
- `node scripts/check-test-wiring.mjs` — confirms the new gate script and its test are correctly wired (no "orphan gate" or "orphan test" reported).
- YAML syntax of `sdk-canary.yml` validated with `Ruby`'s `YAML.load_file` (no `js-yaml`/PyYAML available in this checkout without a lockfile-mutating install).

No changeset: this is a CI-configuration-only change (workflow + `scripts/`), no publishable package's source changed.

Refs #3452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - SDK canary builds now trigger when changes affect any package in their complete dependency chain.
  - Added automated validation to detect missing package coverage in canary workflow filters.
  - Added regression tests covering dependency detection, workflow configuration, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->