### PR TITLE
fix(encoding): correct encodeIfcString's doc so it stops implying STEP-literal safety

### DIFF
--- a/.changeset/correct-encode-ifc-string-doc.md
+++ b/.changeset/correct-encode-ifc-string-doc.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/encoding': patch
+---
+
+Correction to `encodeIfcString`'s doc and the `1.14.4` changelog entry for [#357](https://github.com/louistrue/ifc-lite/pull/357), which introduced the function as being "for producing STEP-safe string escapes". That is not accurate: `encodeIfcString` emits `\X\`/`\X2\`/`\X4\` directive escapes for non-ASCII and the reverse solidus, but it does NOT double the apostrophe (`'`, code point 39, is printable ASCII and passes through unchanged). Placed directly inside a STEP single-quoted string literal, its output for a value like `O'Brien` produces `'O'Brien'`, which no conformant reader parses as intended.
+
+The doc now says plainly what the function does and does not do, and points to `escapeStepString` (`@ifc-lite/data`) for the full literal-context contract — doubling `'` and `\`, mapping control characters to a space, and encoding non-ASCII per ISO 10303-21 6.3.3.4.
+
+This corrects the documentation only; `encodeIfcString`'s behaviour is unchanged, and a test now pins the current apostrophe handling so a future change is a deliberate decision, not a silent one. Whether apostrophe-doubling belongs in `encodeIfcString` itself is an open question — see [#3445](https://github.com/LTplus-AG/ifc-lite/issues/3445).

--- a/.changeset/correct-encode-ifc-string-doc.md
+++ b/.changeset/correct-encode-ifc-string-doc.md
@@ -2,7 +2,7 @@
 '@ifc-lite/encoding': patch
 ---
 
-Correction to `encodeIfcString`'s doc and the `1.14.4` changelog entry for [#357](https://github.com/louistrue/ifc-lite/pull/357), which introduced the function as being "for producing STEP-safe string escapes". That is not accurate: `encodeIfcString` emits `\X\`/`\X2\`/`\X4\` directive escapes for non-ASCII and the reverse solidus, but it does NOT double the apostrophe (`'`, code point 39, is printable ASCII and passes through unchanged). Placed directly inside a STEP single-quoted string literal, its output for a value like `O'Brien` produces `'O'Brien'`, which no conformant reader parses as intended.
+Correction to `encodeIfcString`'s doc. The `1.14.4` changelog entry for [#357](https://github.com/louistrue/ifc-lite/pull/357) introduced the function as being "for producing STEP-safe string escapes"; that published entry is left as-is and this note is the correction to it. It is not accurate: `encodeIfcString` emits `\X\`/`\X2\`/`\X4\` directive escapes for non-ASCII and the reverse solidus, but it does NOT double the apostrophe (`'`, code point 39, is printable ASCII and passes through unchanged). Placed directly inside a STEP single-quoted string literal, its output for a value like `O'Brien` produces `'O'Brien'`, which no conformant reader parses as intended.
 
 The doc now says plainly what the function does and does not do, and points to `escapeStepString` (`@ifc-lite/data`) for the full literal-context contract — doubling `'` and `\`, mapping control characters to a space, and encoding non-ASCII per ISO 10303-21 6.3.3.4.
 

--- a/packages/encoding/src/ifc-string.test.ts
+++ b/packages/encoding/src/ifc-string.test.ts
@@ -177,6 +177,24 @@ describe('encodeIfcString', () => {
     expect(decodeIfcString(encodeIfcString('\\'))).toBe('\\');
   });
 
+  it('does NOT double the apostrophe (pins current behaviour, issue #3445)', () => {
+    // The apostrophe is code point 39, printable ASCII, so unlike the raw
+    // backslash above it passes straight through the range check untouched.
+    // The comment on the reverse-solidus test just above makes exactly the
+    // argument that transfers here: an unescaped `'` in output destined for a
+    // STEP literal terminates the literal early (`O'Brien` -> `'O'Brien'`).
+    // But that argument does NOT make this a bug in isolation, because
+    // `encodeIfcString` never claimed to be literal-safe once its doc is
+    // corrected — only that it emits directive escapes. Whether apostrophe
+    // doubling belongs here or in the caller (`escapeStepString` in
+    // `@ifc-lite/data` already does it) is an open question for #3445, not
+    // decided by this repo yet. This test pins TODAY'S behaviour so any
+    // change is a deliberate decision, not a silent one — it is not an
+    // assertion that the behaviour is correct.
+    expect(encodeIfcString("'")).toBe("'");
+    expect(encodeIfcString("O'Brien")).toBe("O'Brien");
+  });
+
   it('encodes BMP chars as \\X2\\....\\X0\\', () => {
     expect(encodeIfcString('Ω')).toBe('\\X2\\03A9\\X0\\');
   });

--- a/packages/encoding/src/ifc-string.ts
+++ b/packages/encoding/src/ifc-string.ts
@@ -138,12 +138,29 @@ export function decodeIfcString(str: string): string {
 }
 
 /**
- * Encode a Unicode string to IFC STEP string escapes.
+ * Encode a Unicode string to IFC STEP directive escapes.
  *
  * - Printable ASCII (32..126) is kept as-is.
  * - 8-bit values are encoded as \X\HH.
  * - BMP values are encoded as \X2\HHHH\X0\.
  * - Non-BMP values are encoded as \X4\HHHHHHHH\X0\.
+ *
+ * This is directive encoding only — it does NOT double the apostrophe (`'`,
+ * code point 39 is printable ASCII and passes through unchanged). Its output
+ * is therefore **not** safe to place directly inside a STEP single-quoted
+ * string literal: an undoubled `'` terminates the literal early and produces
+ * a file no conformant reader parses as intended (e.g. a name like
+ * `O'Brien`). A caller writing into a literal must double `'` itself, or use
+ * {@link https://github.com/LTplus-AG/ifc-lite `escapeStepString`} from
+ * `@ifc-lite/data`, which handles the full literal-context contract: doubling
+ * `'` and `\`, mapping control characters to a space, and encoding non-ASCII —
+ * per ISO 10303-21 6.3.3.4. The two functions do not produce the same output
+ * for the same input; do not assume they agree.
+ *
+ * Kept for round-trip use with {@link decodeIfcString}
+ * (`decodeIfcString(encodeIfcString(s)) === s`), which holds regardless of
+ * apostrophe handling because doubling is a literal-context requirement, not
+ * an encoding one. See https://github.com/LTplus-AG/ifc-lite/issues/3445.
  */
 export function encodeIfcString(str: string): string {
   if (!str || typeof str !== 'string') return str;

--- a/packages/encoding/src/ifc-string.ts
+++ b/packages/encoding/src/ifc-string.ts
@@ -140,7 +140,10 @@ export function decodeIfcString(str: string): string {
 /**
  * Encode a Unicode string to IFC STEP directive escapes.
  *
- * - Printable ASCII (32..126) is kept as-is.
+ * - Printable ASCII (32..126) is kept as-is, with ONE exception: the reverse
+ *   solidus (`\`, U+005C) is printable ASCII but goes out as `\X\5C`, because
+ *   a raw `\` in the output is what a reader takes for the start of a
+ *   directive or of a `\\` pair.
  * - 8-bit values are encoded as \X\HH.
  * - BMP values are encoded as \X2\HHHH\X0\.
  * - Non-BMP values are encoded as \X4\HHHHHHHH\X0\.
@@ -155,12 +158,28 @@ export function decodeIfcString(str: string): string {
  * literal-context contract: doubling
  * `'` and `\`, mapping control characters to a space, and encoding non-ASCII —
  * per ISO 10303-21 6.3.3.4. The two functions do not produce the same output
- * for the same input; do not assume they agree.
+ * for the same input; do not assume they agree. Sweeping U+0000..U+02FF, they
+ * disagree on exactly two of the 95 printable ASCII characters: the
+ * apostrophe (U+0027; doubled there, passed through here) and the reverse
+ * solidus (U+005C; doubled there, `\X\5C` here). They also disagree on all 32
+ * C0 controls AND on DEL (U+007F) -- a space there, `\X\HH` here, since
+ * `escape` maps `'\0'..='\u{1F}' | '\u{7F}'` to a space -- and on all 128 of
+ * U+0080..U+00FF (`\X2\HHHH\X0\` there, `\X\HH` here). That is 163
+ * disagreements in all. Above U+00FF they agree on all 512.
  *
- * Kept for round-trip use with {@link decodeIfcString}
- * (`decodeIfcString(encodeIfcString(s)) === s`), which holds regardless of
- * apostrophe handling because doubling is a literal-context requirement, not
- * an encoding one. See https://github.com/LTplus-AG/ifc-lite/issues/3445.
+ * Kept for round-trip use with {@link decodeIfcString}, within the scope the
+ * two functions actually cover: `decodeIfcString(encodeIfcString(s)) === s`
+ * for every `s` built from Unicode SCALAR values. That is not the same as
+ * every JS string. A JS string can also hold an unpaired surrogate
+ * (U+D800..U+DFFF), which is not a scalar value; this encoder writes it as a
+ * `\X2\` directive, and {@link decodeIfcString} decodes every lone surrogate
+ * to U+FFFD to stay in parity with the Rust decoder's
+ * `String::from_utf16_lossy`. Those 2048 code units are the only inputs that
+ * do not come back unchanged.
+ *
+ * Within that scope the guarantee is independent of apostrophe handling,
+ * because doubling is a literal-context requirement, not an encoding one.
+ * See https://github.com/LTplus-AG/ifc-lite/issues/3445.
  */
 export function encodeIfcString(str: string): string {
   if (!str || typeof str !== 'string') return str;

--- a/packages/encoding/src/ifc-string.ts
+++ b/packages/encoding/src/ifc-string.ts
@@ -151,8 +151,8 @@ export function decodeIfcString(str: string): string {
  * string literal: an undoubled `'` terminates the literal early and produces
  * a file no conformant reader parses as intended (e.g. a name like
  * `O'Brien`). A caller writing into a literal must double `'` itself, or use
- * {@link https://github.com/LTplus-AG/ifc-lite `escapeStepString`} from
- * `@ifc-lite/data`, which handles the full literal-context contract: doubling
+ * `escapeStepString` from `@ifc-lite/data`, which handles the full
+ * literal-context contract: doubling
  * `'` and `\`, mapping control characters to a space, and encoding non-ASCII —
  * per ISO 10303-21 6.3.3.4. The two functions do not produce the same output
  * for the same input; do not assume they agree.

--- a/packages/encoding/src/ifc-string.ts
+++ b/packages/encoding/src/ifc-string.ts
@@ -155,16 +155,16 @@ export function decodeIfcString(str: string): string {
  * a file no conformant reader parses as intended (e.g. a name like
  * `O'Brien`). A caller writing into a literal must double `'` itself, or use
  * `escapeStepString` from `@ifc-lite/data`, which handles the full
- * literal-context contract: doubling
- * `'` and `\`, mapping control characters to a space, and encoding non-ASCII —
+ * literal-context contract: doubling `'` and `\`, mapping control characters
+ * to a space, and encoding non-ASCII —
  * per ISO 10303-21 6.3.3.4. The two functions do not produce the same output
  * for the same input; do not assume they agree. Sweeping U+0000..U+02FF, they
  * disagree on exactly two of the 95 printable ASCII characters: the
  * apostrophe (U+0027; doubled there, passed through here) and the reverse
  * solidus (U+005C; doubled there, `\X\5C` here). They also disagree on all 32
  * C0 controls AND on DEL (U+007F) -- a space there, `\X\HH` here, since
- * `escape` maps `'\0'..='\u{1F}' | '\u{7F}'` to a space -- and on all 128 of
- * U+0080..U+00FF (`\X2\HHHH\X0\` there, `\X\HH` here). That is 163
+ * `escapeStepString` collapses `/[\x00-\x1F\x7F]/g` to a space -- and on all
+ * 128 of U+0080..U+00FF (`\X2\HHHH\X0\` there, `\X\HH` here). That is 163
  * disagreements in all. Above U+00FF they agree on all 512.
  *
  * Kept for round-trip use with {@link decodeIfcString}, within the scope the


### PR DESCRIPTION
## Summary

`packages/encoding/src/ifc-string.ts`'s `encodeIfcString` is published, documented public API (`packages/encoding/src/index.ts`, `scripts/api-surface.json`, `docs/api/typescript.md`, the package README). Its JSDoc said "Encode a Unicode string to IFC STEP string escapes" and the `CHANGELOG.md` entry that introduced it (#357) called it "for producing STEP-safe string escapes". Neither is accurate: the function does not double the apostrophe (`'`, code point 39, is printable ASCII and passes through the range check unchanged), so its output is not safe to drop directly into a STEP single-quoted string literal — `encodeIfcString("O'Brien")` returns `O'Brien` unchanged, and placed in `'…'` that yields `'O'Brien'`, malformed per ISO 10303-21.

This mirrors PR #3448, which corrected the equivalent doc on the Rust side (`ifc_lite_core::encode_ifc_string`) without changing behaviour — that PR is the precedent this one follows. Per the most recent comment on #3445, the TS twin is the weightier half of the two: unlike the Rust function (no production caller in-repo), `encodeIfcString` is exported, documented, and has external consumers, so a behaviour change is out of scope here; whether apostrophe-doubling belongs in the function or its caller is left for the maintainer to decide on #3445.

- Corrected the JSDoc to state plainly what the function does (directive escapes for non-ASCII and the reverse solidus) and does not do (does not double `'`), and points to `escapeStepString` (`@ifc-lite/data`) as the existing TS function that already handles the full STEP literal-context contract (doubling `'` and `\`, control chars to space, non-ASCII directives — the TS parity counterpart to Rust's `step_text::escape`).
- Added a test pinning the current apostrophe behaviour (`encodeIfcString("'") === "'"`), in the same style and directly beside the existing `encodes a literal reverse solidus as \X\5C` test — its comment explicitly notes that test's own reasoning transfers unaltered to the apostrophe. The test documents that it pins *current* behaviour pending the #3445 decision, not that the behaviour is correct.
- Added a changeset (`@ifc-lite/encoding`, patch) correcting the record on the `1.14.4` CHANGELOG entry's "STEP-safe" claim, following the precedent PR #3444 set for `packages/wasm/CHANGELOG.md`: the historical entry is left untouched, and the correction lives in a new changeset instead.
- Checked the package README and `docs/api/typescript.md`: neither makes the "STEP-safe" claim in the JSDoc's words — the README's worked example (`encodeIfcString('Tür')`) doesn't involve quoting, and its export bullet says only "STEP escape handling," which is accurate. Left both unchanged; the overclaim lived only in the JSDoc and the changelog entry.

No behaviour change. `encodeIfcString`'s output for every existing input, including `'`, is identical before and after this PR.

## Test plan

- [x] `pnpm --filter @ifc-lite/timing-ladder run build` (workspace dep needed for one unrelated test file), then `cd packages/encoding && npx vitest run` — 100/100 tests pass (6 files), including the new test.
- [x] `pnpm exec tsc --noEmit` in `packages/encoding` — clean.
- [x] Verified the new test can fail: temporarily changed its expectation to `"''"`, reran — it failed with a clear assertion diff; reverted, reran — passes again.

Refs #3445
Refs #3300

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how `encodeIfcString` handles non-ASCII characters, reverse slashes, apostrophes, Unicode values, and lone surrogates.
  * Documented the distinction between IFC string encoding and full STEP string escaping.

* **Tests**
  * Added coverage confirming that apostrophes remain unchanged, including within ordinary text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->