### PR TITLE
fix(geometry): thread sharedRtcOffset through the single-threaded WASM streaming fallback

### DIFF
--- a/.changeset/shared-rtc-streaming-fallback.md
+++ b/.changeset/shared-rtc-streaming-fallback.md
@@ -1,0 +1,11 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+Thread a federated `sharedRtcOffset` through the single-threaded WASM streaming fallback, so it stops misaligning a model that lands there.
+
+`processAdaptive` picks a `sharedRtcOffset` from the earliest-loaded model so every federated model renders in one coordinate space, and threads it correctly through `processParallel` (`sendStreamStartIfReady`'s `useSharedRtc` override). `GeometryProcessor.processStreaming` accepted the same parameter but silently dropped it: `processStreamingBytes` always used the pre-pass's own per-model RTC detection instead, contradicting the very comment beside its call site ("Infrastructure models with large coordinates are always >2MB and use the parallel/streaming paths where shared RTC is properly threaded" — the single-threaded streaming path is one of those "properly threaded" paths in name only).
+
+This path is not a corner case: `processAdaptive` falls back to it for any file at or above the 2MB threshold whenever `useParallel` is false — no `SharedArrayBuffer`/`Worker` support, or `navigator.hardwareConcurrency <= 1` — which includes any deployment missing cross-origin-isolation headers. A federated model that happened to load through that fallback would compute its own RTC origin and render offset from the rest of the federation instead of aligning with it.
+
+`processStreamingBytes` now mirrors `processParallel`'s override exactly: a caller-supplied `sharedRtcOffset` replaces the pre-pass's `rtcX`/`rtcY`/`rtcZ` and forces `needsShift`, in the `processGeometryBatch` calls, the emitted `rtcOffset` event, and the coordinate handler's metadata. The synchronous `<2MB` path (`processAdaptive`'s sync branch, `collectMeshesViaPrePass`) is unaffected — it remains a documented, separate limitation.

--- a/packages/geometry/src/geometry-processor-streaming.test.ts
+++ b/packages/geometry/src/geometry-processor-streaming.test.ts
@@ -141,6 +141,69 @@ describe('GeometryProcessor byte streaming (processStreaming, mocked WASM)', () 
     expect((completeEvent?.coordinateInfo as { buildingRotation?: number })?.buildingRotation).toBe(0.5);
   });
 
+  // Federation alignment (issue: shared RTC origin not threaded through the
+  // single-threaded WASM streaming fallback). `processAdaptive` reaches
+  // `processStreaming` — and, via it, the byte-based prepass/batch path
+  // exercised here — whenever `useParallel` is false: no `SharedArrayBuffer`/
+  // `Worker`, or `navigator.hardwareConcurrency <= 1` (e.g. Safari without
+  // cross-origin isolation headers, or a single-core sandbox). A federated
+  // model that lands here must render in the SAME coordinate space as the
+  // rest of the federation, so a caller-supplied `sharedRtcOffset` MUST
+  // override the pre-pass's own per-model RTC detection — exactly like
+  // `processParallel`'s `sendStreamStartIfReady` already does (see
+  // `geometry-parallel.ts`'s `useSharedRtc`).
+  it('overrides the pre-pass RTC offset with a caller-supplied sharedRtcOffset', async () => {
+    wasmMocks.buildPrePassOnce.mockReturnValue({
+      jobs: new Uint32Array([11, 0, 42]),
+      totalJobs: 1,
+      unitScale: 1,
+      // This model's OWN detected offset — must NOT reach processGeometryBatch
+      // or the emitted `rtcOffset` event once a shared offset is supplied.
+      rtcOffset: new Float64Array([10, 20, 30]),
+      needsShift: true,
+      buildingRotation: 0.5,
+      voidKeys: new Uint32Array(),
+      voidCounts: new Uint32Array(),
+      voidValues: new Uint32Array(),
+      styleIds: new Uint32Array([7]),
+      styleColors: new Uint8Array([255, 0, 0, 255]),
+    });
+
+    wasmMocks.processGeometryBatch.mockReturnValue({
+      length: 0,
+      get() { return undefined; },
+      free: vi.fn(),
+    });
+
+    const geometry = new GeometryProcessor();
+    const buffer = new Uint8Array([65, 66, 67]);
+    const sharedRtcOffset = { x: 1000, y: 2000, z: 300 };
+    const events: Array<{ type: string; [key: string]: unknown }> = [];
+
+    for await (const event of geometry.processStreaming(buffer, undefined, 25, sharedRtcOffset)) {
+      events.push(event as { type: string; [key: string]: unknown });
+    }
+
+    // The batch call must carry the SHARED offset, not the pre-pass's own.
+    expect(wasmMocks.processGeometryBatch).toHaveBeenCalledWith(
+      buffer,
+      expect.anything(),
+      1,
+      sharedRtcOffset.x,
+      sharedRtcOffset.y,
+      sharedRtcOffset.z,
+      true,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+
+    const rtcEvent = events.find((event) => event.type === 'rtcOffset');
+    expect(rtcEvent?.rtcOffset).toEqual(sharedRtcOffset);
+  });
+
   it('rejects overlapping WASM streaming runs before re-entering the processor', async () => {
     const firstGeometry = new GeometryProcessor();
     const secondGeometry = new GeometryProcessor();

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -496,18 +496,8 @@ export class GeometryProcessor {
   private async *processStreamingBytes(
     buffer: Uint8Array,
     batchConfig: number | DynamicBatchConfig,
-    /**
-     * Shared RTC origin from an earlier federated model. Overrides the
-     * pre-pass's own per-model RTC detection so every model in the
-     * federation renders in the SAME coordinate space —
-     * mirrors `sendStreamStartIfReady`'s `useSharedRtc` logic in
-     * `geometry-parallel.ts`. Without this override, a model that reaches
-     * this single-threaded WASM fallback (no `SharedArrayBuffer`/`Worker`,
-     * or `hardwareConcurrency` of 1 — common when cross-origin isolation
-     * headers are not set) silently used its OWN detected RTC offset even
-     * though `processAdaptive` was handed a `sharedRtcOffset`, misaligning
-     * it against the rest of the federation.
-     */
+    // Federation RTC origin, overriding the pre-pass's per-model detection so
+    // every model shares one coordinate space — mirrors `geometry-parallel.ts`.
     sharedRtcOffset?: { x: number; y: number; z: number },
   ): AsyncGenerator<StreamingGeometryEvent> {
     if (!this.bridge) {
@@ -516,28 +506,22 @@ export class GeometryProcessor {
 
     const api = this.bridge.getApi();
     const prePass = api.buildPrePassOnce(buffer) as ByteStreamingPrePassResult;
-
     const useSharedRtc = sharedRtcOffset != null;
-    const rtcX = useSharedRtc ? sharedRtcOffset.x : prePass.rtcOffset?.[0] ?? 0;
-    const rtcY = useSharedRtc ? sharedRtcOffset.y : prePass.rtcOffset?.[1] ?? 0;
-    const rtcZ = useSharedRtc ? sharedRtcOffset.z : prePass.rtcOffset?.[2] ?? 0;
-    const effectiveNeedsShift = useSharedRtc ? true : Boolean(prePass.needsShift);
+    const rtc = useSharedRtc
+      ? sharedRtcOffset
+      : { x: prePass.rtcOffset?.[0] ?? 0, y: prePass.rtcOffset?.[1] ?? 0, z: prePass.rtcOffset?.[2] ?? 0 };
+    const effectiveNeedsShift = useSharedRtc || Boolean(prePass.needsShift);
+    this.coordinateHandler.setWasmMetadata(prePass.unitScale, effectiveNeedsShift ? { ...rtc } : null);
 
-    this.coordinateHandler.setWasmMetadata(
-      prePass.unitScale,
-      effectiveNeedsShift ? { x: rtcX, y: rtcY, z: rtcZ } : null,
-    );
-
-    // try/finally so the pre-pass cache is released on every exit: the
-    // totalJobs===0 early return, a processGeometryBatch throw, or the
-    // consumer abandoning the generator (which triggers `.return()`).
+    // try/finally releases the pre-pass cache on every exit: the totalJobs===0
+    // early return, a throw, or the consumer abandoning the generator.
     try {
       yield { type: 'model-open', modelID: 0 };
 
       if (prePass.rtcOffset || useSharedRtc) {
         yield {
           type: 'rtcOffset',
-          rtcOffset: { x: rtcX, y: rtcY, z: rtcZ },
+          rtcOffset: { x: rtc.x, y: rtc.y, z: rtc.z },
           hasRtc: effectiveNeedsShift,
         };
       }
@@ -565,9 +549,9 @@ export class GeometryProcessor {
           buffer,
           jobSlice,
           prePass.unitScale,
-          rtcX,
-          rtcY,
-          rtcZ,
+          rtc.x,
+          rtc.y,
+          rtc.z,
           effectiveNeedsShift,
           prePass.voidKeys,
           prePass.voidCounts,

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -495,7 +495,20 @@ export class GeometryProcessor {
 
   private async *processStreamingBytes(
     buffer: Uint8Array,
-    batchConfig: number | DynamicBatchConfig
+    batchConfig: number | DynamicBatchConfig,
+    /**
+     * Shared RTC origin from an earlier federated model. Overrides the
+     * pre-pass's own per-model RTC detection so every model in the
+     * federation renders in the SAME coordinate space —
+     * mirrors `sendStreamStartIfReady`'s `useSharedRtc` logic in
+     * `geometry-parallel.ts`. Without this override, a model that reaches
+     * this single-threaded WASM fallback (no `SharedArrayBuffer`/`Worker`,
+     * or `hardwareConcurrency` of 1 — common when cross-origin isolation
+     * headers are not set) silently used its OWN detected RTC offset even
+     * though `processAdaptive` was handed a `sharedRtcOffset`, misaligning
+     * it against the rest of the federation.
+     */
+    sharedRtcOffset?: { x: number; y: number; z: number },
   ): AsyncGenerator<StreamingGeometryEvent> {
     if (!this.bridge) {
       throw new Error('WASM bridge not initialized');
@@ -503,7 +516,17 @@ export class GeometryProcessor {
 
     const api = this.bridge.getApi();
     const prePass = api.buildPrePassOnce(buffer) as ByteStreamingPrePassResult;
-    this.applyPrePassMetadata(prePass);
+
+    const useSharedRtc = sharedRtcOffset != null;
+    const rtcX = useSharedRtc ? sharedRtcOffset.x : prePass.rtcOffset?.[0] ?? 0;
+    const rtcY = useSharedRtc ? sharedRtcOffset.y : prePass.rtcOffset?.[1] ?? 0;
+    const rtcZ = useSharedRtc ? sharedRtcOffset.z : prePass.rtcOffset?.[2] ?? 0;
+    const effectiveNeedsShift = useSharedRtc ? true : Boolean(prePass.needsShift);
+
+    this.coordinateHandler.setWasmMetadata(
+      prePass.unitScale,
+      effectiveNeedsShift ? { x: rtcX, y: rtcY, z: rtcZ } : null,
+    );
 
     // try/finally so the pre-pass cache is released on every exit: the
     // totalJobs===0 early return, a processGeometryBatch throw, or the
@@ -511,15 +534,11 @@ export class GeometryProcessor {
     try {
       yield { type: 'model-open', modelID: 0 };
 
-      if (prePass.rtcOffset) {
+      if (prePass.rtcOffset || useSharedRtc) {
         yield {
           type: 'rtcOffset',
-          rtcOffset: {
-            x: prePass.rtcOffset[0] ?? 0,
-            y: prePass.rtcOffset[1] ?? 0,
-            z: prePass.rtcOffset[2] ?? 0,
-          },
-          hasRtc: Boolean(prePass.needsShift),
+          rtcOffset: { x: rtcX, y: rtcY, z: rtcZ },
+          hasRtc: effectiveNeedsShift,
         };
       }
 
@@ -546,10 +565,10 @@ export class GeometryProcessor {
           buffer,
           jobSlice,
           prePass.unitScale,
-          prePass.rtcOffset?.[0] ?? 0,
-          prePass.rtcOffset?.[1] ?? 0,
-          prePass.rtcOffset?.[2] ?? 0,
-          prePass.needsShift,
+          rtcX,
+          rtcY,
+          rtcZ,
+          effectiveNeedsShift,
           prePass.voidKeys,
           prePass.voidCounts,
           prePass.voidValues,
@@ -605,9 +624,6 @@ export class GeometryProcessor {
     buffer: Uint8Array,
     _entityIndex?: Map<number, any>,
     batchConfig: number | DynamicBatchConfig = 25,
-    // TODO: sharedRtcOffset is accepted but not yet threaded through to the
-    // WASM streaming collector. The WASM layer detects its own RTC offset
-    // per-model; federation-level override requires collector API changes.
     sharedRtcOffset?: { x: number; y: number; z: number },
   ): AsyncGenerator<StreamingGeometryEvent> {
     const releaseWasmOperation = this.isNative
@@ -682,7 +698,7 @@ export class GeometryProcessor {
         throw new Error('WASM bridge not initialized');
       }
 
-      yield* this.processStreamingBytes(buffer, batchConfig);
+      yield* this.processStreamingBytes(buffer, batchConfig, sharedRtcOffset);
     }
   }
 


### PR DESCRIPTION
## Summary

- `GeometryProcessor.processStreaming` accepts a `sharedRtcOffset` (the federation-alignment override `processAdaptive` picks from the earliest-loaded model), but `processStreamingBytes` silently ignored it and always used the pre-pass's own per-model RTC detection — contradicting the comment beside `processAdaptive`'s call site, which claims the streaming path "properly threads" shared RTC the way `processParallel` does.
- This fallback isn't a rare corner case: `processAdaptive` reaches it for any file at or above the 2MB threshold whenever `SharedArrayBuffer`/`Worker` support is unavailable or `navigator.hardwareConcurrency <= 1` (e.g. any deployment missing cross-origin-isolation headers). A federated model landing there computed its own RTC origin and rendered offset from the rest of the federation instead of aligning with it.
- `processStreamingBytes` now mirrors `processParallel`'s `sendStreamStartIfReady`/`useSharedRtc` override exactly: a caller-supplied `sharedRtcOffset` replaces the pre-pass's `rtcX`/`rtcY`/`rtcZ` and forces `needsShift`, in the `processGeometryBatch` calls, the emitted `rtcOffset` event, and the coordinate handler's metadata.
- The synchronous `<2MB` path (`collectMeshesViaPrePass`) is untouched — it remains a separate, already-documented limitation.

## Test plan

- [x] New regression test in `packages/geometry/src/geometry-processor-streaming.test.ts` using the existing mocked-WASM harness, asserting `processStreaming(buffer, undefined, 25, sharedRtcOffset)` passes the shared offset (not the pre-pass's own) to `processGeometryBatch` and the emitted `rtcOffset` event.
- [x] Confirmed RED against the pre-fix code (batch call received the pre-pass's `[10, 20, 30]` instead of the supplied `[1000, 2000, 300]`), then GREEN after the fix.
- [x] `pnpm exec tsc --noEmit` clean in `packages/geometry`.
- [x] Full `packages/geometry` test suite: 365/365 passing (364 pre-existing + 1 new).
- [x] Changeset added (`@ifc-lite/geometry`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming geometry processing to consistently apply a caller-provided shared coordinate offset.
  - Geometry batches, emitted offset events, and coordinate metadata now use the shared offset when supplied.
  - Preserved existing behavior for smaller files processed through the synchronous path.

- **Tests**
  - Added coverage verifying shared offset handling during streaming WASM processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->