### PR TITLE
fix(viewer): clear hover/context-menu state on model-removed and all-models-cleared

### DIFF
--- a/.changeset/hover-teardown-model-removed.md
+++ b/.changeset/hover-teardown-model-removed.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix a hover tooltip or an open context menu surviving `removeModel` (dropping one model out of a live federation) and `clearAllModels`, so it kept naming a stale global express id that a later-loaded model could reuse.
+
+`hoverSlice`'s `model-removed` and `all-models-cleared` teardown arms were both `notApplicable`. Only `session-reset` cleared `hoverState` / `contextMenu`, whose own doc comment already explains why that matters: "ids are reused across files, so a hover tooltip or an open context menu surviving a swap describes an unrelated element of the incoming one." That hazard applies just as much to removing a single federated model (other models staying loaded) or clearing the whole federation without a full session reset — several `clearAllModels()` call sites do exactly that (`GeoreferencingPanel.tsx`'s `reloadModelsForAlignment`, a federation rebuild in `useFileCommands.tsx`).
+
+`model-removed` now clears each field only when its `entityId` is stale (no surviving model owns that global id, mirroring `selectionSlice.teardown.ts`'s global-id half); `all-models-cleared` clears both unconditionally, since with every model gone there is no survivor left to ask.

--- a/apps/viewer/src/store/slices/hoverSlice.test.ts
+++ b/apps/viewer/src/store/slices/hoverSlice.test.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { hoverTeardown } from './hoverSlice.js';
+import { modelRemovedScope } from '../teardown-scope.js';
+import type { FederatedModel } from '../types.js';
+
+/**
+ * `hoverSlice`'s `model-removed` arm must clear a hover/context-menu entity
+ * that named the removed model, the same way `selectionSlice.teardown.ts`'s
+ * global-id half does (its own doc explains why: "a global id is 'stale'
+ * once no SURVIVING model's parse range or overlay owns it").
+ *
+ * `hoverState.entityId` / `contextMenu.entityId` are federation GLOBAL ids
+ * (`store/types.ts`: `entityId: number | null`, no `modelId` alongside it) —
+ * exactly the shape `hoverSlice.ts`'s own session-reset doc comment warns
+ * about: "ids are reused across files, so a hover tooltip or an open context
+ * menu surviving a swap describes an unrelated element of the incoming one."
+ * That warning covers `session-reset`; `model-removed` (one model dropped out
+ * of a live federation, the rest staying loaded) is the same hazard and was
+ * left `notApplicable`.
+ */
+describe('hoverTeardown — model-removed', () => {
+  const model = (id: string, idOffset: number, maxExpressId: number) =>
+    ({ id, name: id, visible: true, idOffset, maxExpressId }) as unknown as FederatedModel;
+
+  it('clears a hovered entity and an open context menu that named the removed model', () => {
+    // A: global ids [0, 100]. B survives with a disjoint range [1000, 1100].
+    const models = new Map([['A', model('A', 0, 100)], ['B', model('B', 1000, 1100)]]);
+    const state = {
+      models,
+      hoverState: { entityId: 42, screenX: 10, screenY: 20 },
+      contextMenu: { isOpen: true, entityId: 42, screenX: 10, screenY: 20 },
+    } as unknown as Parameters<typeof modelRemovedScope>[0];
+
+    const scope = modelRemovedScope(state, 'A');
+    assert.equal(scope.isStale(42), true, 'global id 42 belongs to the removed model A; no survivor owns it');
+
+    const patch = hoverTeardown.teardown(scope, state);
+
+    assert.deepStrictEqual(
+      patch.hoverState,
+      { entityId: null, screenX: 0, screenY: 0 },
+      'a hover tooltip pointing at the removed model must be cleared, not left naming a stale (and reusable) global id',
+    );
+    assert.deepStrictEqual(
+      patch.contextMenu,
+      { isOpen: false, entityId: null, screenX: 0, screenY: 0 },
+      'an open context menu for the removed model must close, not stay open over an id the incoming model can reuse',
+    );
+  });
+
+  it('leaves a hover/context menu naming a SURVIVING model untouched', () => {
+    const models = new Map([['A', model('A', 0, 100)], ['B', model('B', 1000, 1100)]]);
+    const state = {
+      models,
+      hoverState: { entityId: 1005, screenX: 5, screenY: 6 },
+      contextMenu: { isOpen: true, entityId: 1005, screenX: 5, screenY: 6 },
+    } as unknown as Parameters<typeof modelRemovedScope>[0];
+
+    const scope = modelRemovedScope(state, 'A');
+    assert.equal(scope.isStale(1005), false, 'global id 1005 belongs to surviving model B');
+
+    const patch = hoverTeardown.teardown(scope, state);
+
+    assert.equal(patch.hoverState, undefined, 'a hover naming a surviving model must not be rewritten');
+    assert.equal(patch.contextMenu, undefined, 'a context menu naming a surviving model must not be rewritten');
+  });
+});
+
+/**
+ * `all-models-cleared` has no `isStale` predicate to ask (no survivor is
+ * left), so — like `selectionSlice.teardown.ts`'s equivalent arm — it must
+ * clear unconditionally rather than defer to a check it cannot make. Several
+ * `clearAllModels()` call sites (`GeoreferencingPanel.tsx`'s
+ * `reloadModelsForAlignment`, a federation rebuild in `useFileCommands.tsx`)
+ * do not also call `resetViewerState()`, so this arm is the only teardown
+ * this scope gets.
+ */
+describe('hoverTeardown — all-models-cleared', () => {
+  it('clears a hovered entity and an open context menu unconditionally', () => {
+    const state = {
+      hoverState: { entityId: 7, screenX: 1, screenY: 2 },
+      contextMenu: { isOpen: true, entityId: 7, screenX: 1, screenY: 2 },
+    } as unknown as Parameters<typeof hoverTeardown.teardown>[1];
+
+    const patch = hoverTeardown.teardown({ kind: 'all-models-cleared' }, state);
+
+    assert.deepStrictEqual(patch.hoverState, { entityId: null, screenX: 0, screenY: 0 });
+    assert.deepStrictEqual(patch.contextMenu, { isOpen: false, entityId: null, screenX: 0, screenY: 0 });
+  });
+});

--- a/apps/viewer/src/store/slices/hoverSlice.ts
+++ b/apps/viewer/src/store/slices/hoverSlice.ts
@@ -8,7 +8,7 @@
 
 import type { StateCreator } from 'zustand';
 import type { HoverState, ContextMenuState } from '../types.js';
-import { defineSliceTeardown, notApplicable } from '../teardown.js';
+import { defineSliceTeardown } from '../teardown.js';
 
 /**
  * "Nothing is hovered", in one place.
@@ -68,12 +68,46 @@ export const createHoverSlice: StateCreator<HoverSlice, [], [], HoverSlice> = (s
  * the pointer-leave path, which must not close a context menu the user opened.
  * Both now build their value from the same helpers above, so the two paths
  * cannot drift.
+ *
+ * `model-removed` clears the same two fields when the entity they name is
+ * STALE (`scope.isStale`, `store/teardown-scope.ts`) — no surviving federated
+ * model owns that global id any more. Both fields carry a bare `entityId:
+ * number`, the same global-id shape `selectionSlice.teardown.ts` calls its
+ * "global-id half" and filters with the identical predicate: they don't carry
+ * which model allocated the id, so `isStale` is the only way to tell a
+ * dangling reference from a live one. Left as `notApplicable`, a tooltip or
+ * open context menu for a model removed from a live federation (other models
+ * staying loaded — `modelSlice.removeModel`) survived the removal, and this
+ * file's own session-reset doc explains what that produces: ids are reused
+ * across files, so the leftover reference silently describes an unrelated
+ * element the next model happens to allocate at the same id.
+ *
+ * `all-models-cleared` clears both unconditionally, same as
+ * `selectionSlice.teardown.ts`'s equivalent arm: with every model gone there
+ * is no survivor left for `isStale` to ask about, so every entity id is stale
+ * by definition. This scope is not always followed by a `session-reset` — see
+ * `selectionSlice.teardown.ts`'s note on `GeoreferencingPanel.tsx`'s
+ * `reloadModelsForAlignment`, one of several `clearAllModels()` call sites
+ * that do not also call `resetViewerState()` — so this arm is the only thing
+ * standing between a federation clear and a hover/context menu left dangling
+ * indefinitely.
  */
 export const hoverTeardown = defineSliceTeardown('hoverSlice', ['hoverState', 'contextMenu'], {
   'session-reset': () => ({
     hoverState: emptyHoverState(),
     contextMenu: closedContextMenu(),
   }),
-  'model-removed': notApplicable,
-  'all-models-cleared': notApplicable,
+  'model-removed': (scope, state) => {
+    const { isStale } = scope;
+    const hoverStale = state.hoverState?.entityId != null && isStale(state.hoverState.entityId);
+    const contextMenuStale = state.contextMenu?.entityId != null && isStale(state.contextMenu.entityId);
+    return {
+      ...(hoverStale ? { hoverState: emptyHoverState() } : {}),
+      ...(contextMenuStale ? { contextMenu: closedContextMenu() } : {}),
+    };
+  },
+  'all-models-cleared': () => ({
+    hoverState: emptyHoverState(),
+    contextMenu: closedContextMenu(),
+  }),
 });

--- a/apps/viewer/src/store/teardown-registry.test.ts
+++ b/apps/viewer/src/store/teardown-registry.test.ts
@@ -82,8 +82,8 @@ const PINNED_SESSION_RESET_KEYS: readonly string[] = [
 /** The same, for `all-models-cleared`. */
 const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
   'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'classFilter',
-  'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
-  'hierarchyBasketSelection', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
+  'contextMenu', 'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
+  'hierarchyBasketSelection', 'hoverState', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
   'meshColorBackup', 'models', 'pinboardEntities', 'selectedEntities', 'selectedEntitiesSet',
   'selectedEntity', 'selectedEntityId', 'selectedEntityIds', 'selectedModelId', 'selectedStoreys',
 ];
@@ -100,8 +100,8 @@ const PINNED_ALL_MODELS_CLEARED_KEYS: readonly string[] = [
  */
 const PINNED_MODEL_REMOVED_KEYS: readonly string[] = [
   'activeModelId', 'activeStorey', 'addElementModelId', 'addElementStoreyId', 'classFilter',
-  'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
-  'hierarchyBasketSelection', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
+  'contextMenu', 'geometryResult', 'ghostExceptEntities', 'hiddenEntities', 'hiddenEntitiesByModel',
+  'hierarchyBasketSelection', 'hoverState', 'ifcDataStore', 'isolatedEntities', 'isolatedEntitiesByModel',
   'meshColorBackup', 'models', 'pinboardEntities', 'selectedEntities', 'selectedEntitiesSet',
   'selectedEntity', 'selectedEntityId', 'selectedEntityIds', 'selectedModelId', 'selectedStoreys',
 ];
@@ -137,6 +137,8 @@ function modelRemovedFixture() {
     meshColorBackup: new Map([[42, [1, 1, 1, 1]]]),
     addElementModelId: 'A',
     addElementStoreyId: 44,
+    hoverState: { entityId: 42, screenX: 1, screenY: 2 },
+    contextMenu: { isOpen: true, entityId: 42, screenX: 1, screenY: 2 },
     ifcDataStore: null,
     geometryResult: null,
     mutationViews: new Map(),


### PR DESCRIPTION
## Summary

- `hoverSlice`'s `model-removed` and `all-models-cleared` teardown arms were both `notApplicable`. Only `session-reset` cleared `hoverState` / `contextMenu`.
- Both fields carry a bare global `entityId` (no `modelId` alongside it), the same shape the file's own session-reset doc comment warns about: "ids are reused across files, so a hover tooltip or an open context menu surviving a swap describes an unrelated element of the incoming one." That hazard applies just as much to dropping one model out of a live federation (`modelSlice.removeModel`, other models staying loaded) or to `clearAllModels()` — several call sites (`GeoreferencingPanel.tsx`'s `reloadModelsForAlignment`, a federation rebuild in `useFileCommands.tsx`) invoke it without also calling `resetViewerState()`.
- `model-removed` now clears each field only when `scope.isStale` says its `entityId` belongs to no surviving model, mirroring `selectionSlice.teardown.ts`'s "global-id half". `all-models-cleared` clears both unconditionally, since with every model gone there is no survivor left for `isStale` to ask.

## Root cause

State keyed to an entity by global id, scoped to a live model, was declared "not applicable" for the two federation-teardown scopes that actually invalidate it — the same defect class recent teardown PRs have been fixing across other slices, just not yet caught here.

## Test plan

- [x] `apps/viewer/src/store/slices/hoverSlice.test.ts` (new): RED before the fix — asserted a stale `hoverState`/`contextMenu` entity survives `model-removed`, observed failing; then asserted it's cleared, observed passing. A second test pins that a surviving model's hover/context-menu is left untouched (no over-clearing). A third pins the `all-models-cleared` unconditional clear.
- [x] `apps/viewer/src/store/teardown-registry.test.ts`: added `hoverState`/`contextMenu` to `PINNED_ALL_MODELS_CLEARED_KEYS` and `PINNED_MODEL_REMOVED_KEYS`, and to the `model-removed` fixture, so the registry's own completeness pins catch a future regression of this same field.
- [x] Ran the full `apps/viewer` store test directory; all failures present are pre-existing `ERR_MODULE_NOT_FOUND` from unbuilt sibling packages (`@ifc-lite/clash`, `@ifc-lite/wasm`) in this fresh worktree, reproduced identically on `upstream/main` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436