### PR TITLE
fix(ids): scale Qto_ length quantities to base SI before an IDS comparison

### DIFF
--- a/.changeset/ids-qto-length-unit-conversion.md
+++ b/.changeset/ids-qto-length-unit-conversion.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/ids': patch
+---
+
+Fix IDS `<property>` requirements against `IfcElementQuantity` (`Qto_*`) length quantities comparing the raw author-unit value instead of the base-SI value the IDS literal is always expressed in.
+
+`collectAllPropertySets` already converted `IfcPropertySet` (`Pset_*`) length-typed values through `projectProperty`/`applyUnitConversion` before handing them to the validator, but `appendQuantitySets` built its quantity values directly from the raw parser record and skipped that step. On a millimetre-authored model, an `IfcQuantityLength` stored as `2000` (2 metres) compared against an IDS literal of `2` — which per the spec is always base SI — and the requirement false-failed even though the model complies. `appendQuantitySets` now routes every quantity through `projectProperty` with the project's `lengthUnitScale`, matching the property path.

--- a/packages/ids/src/bridge/properties.ts
+++ b/packages/ids/src/bridge/properties.ts
@@ -50,7 +50,7 @@ export function collectAllPropertySets(
   const scale = store.lengthUnitScale;
 
   appendInstancePropertySets(store, expressId, scale, own);
-  appendQuantitySets(store, expressId, own);
+  appendQuantitySets(store, expressId, scale, own);
   appendPredefinedPropertySets(store, expressId, own);
   appendMaterialOwnPropertySets(store, expressId, scale, own);
 
@@ -94,6 +94,7 @@ function appendInstancePropertySets(
 function appendQuantitySets(
   store: IfcDataStore,
   expressId: number,
+  scale: number | undefined,
   out: PropertySetInfo[]
 ): void {
   let quantities = store.quantities?.getForEntity?.(expressId);
@@ -105,11 +106,16 @@ function appendQuantitySets(
   for (const qset of quantities) {
     out.push({
       name: qset.name,
-      properties: (qset.quantities || []).map((q) => ({
-        name: q.name,
-        value: q.value,
-        dataType: idsDataTypeForQuantity(q.type),
-      })),
+      // IfcPhysicalQuantity (Qto_*) values are stored in the project's
+      // raw author unit exactly like IfcPropertySingleValue (Pset_*) —
+      // an IfcQuantityLength is just as much an IFCLENGTHMEASURE as a
+      // length-typed property, so it needs the same base-SI conversion
+      // `projectProperty` already applies there. Route through it here
+      // too rather than building the value inline, so the two paths
+      // can't drift again.
+      properties: (qset.quantities || []).map((q) =>
+        projectProperty({ name: q.name, value: q.value, type: undefined, dataType: idsDataTypeForQuantity(q.type) }, scale)
+      ),
     });
   }
 }

--- a/packages/ids/src/bridge/quantity-unit-conversion.test.ts
+++ b/packages/ids/src/bridge/quantity-unit-conversion.test.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * IDS `<property>` requirements against `IfcElementQuantity` (Qto_*) values
+ * must go through the same base-SI unit conversion as `IfcPropertySet`
+ * (Pset_*) values.
+ *
+ * Per the IDS spec (mirrored in `units.ts`'s own doc comment, and already
+ * proven for Pset_* by the vendored buildingSMART corpus case
+ * `property/pass-unit_conversions_shall_take_place_to_ids_nominated_standard_units_2_2`):
+ * IDS literal values for IFC measure types are always base SI units, while
+ * the IFC store keeps the raw author value. A millimetre-authored project's
+ * `IfcQuantityLength` of `2000` therefore means `2` metres and must compare
+ * equal to an IDS literal of `2` — exactly like a millimetre-authored
+ * `IfcPropertySingleValue` already does.
+ *
+ * `collectAllPropertySets` applied that conversion to instance/type/material
+ * property sets via `projectProperty`, but `appendQuantitySets` built its
+ * quantity values directly from the raw parser record and skipped it — so a
+ * Qto_* length quantity was compared against the IDS literal in the wrong
+ * unit space, false-failing a spec that a compliant model actually satisfies.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { IfcParser } from '@ifc-lite/parser';
+import { parseIDS } from '../parser/xml-parser.js';
+import { validateIDS } from '../validation/validator.js';
+import { createDataAccessor } from './index.js';
+
+// Millimetre-authored project (IFCSIUNIT ...MILLI.,.METRE.): a wall whose
+// Qto_WallBaseQuantities.Length is stored as the raw author value 2000 (mm),
+// i.e. 2 metres.
+const IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');
+FILE_NAME('','2022-10-07T13:48:43',(),(),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('1hqIFTRjfV6AWq_bMtnZwI',$,$,$,$,$,$,$,#6);
+#2=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);
+#3=IFCSIUNIT(*,.AREAUNIT.,.MILLI.,.SQUARE_METRE.);
+#4=IFCSIUNIT(*,.VOLUMEUNIT.,.MILLI.,.CUBIC_METRE.);
+#5=IFCSIUNIT(*,.TIMEUNIT.,$,.SECOND.);
+#6=IFCUNITASSIGNMENT((#4,#2,#5,#3));
+#7=IFCWALL('2nJrDaLQfJ1QPhdJR0o97J',$,$,$,$,$,$,$,$);
+#8=IFCELEMENTQUANTITY('16MocU_IDOF8_x3Iqllz0d',$,'Qto_WallBaseQuantities',$,$,(#10));
+#9=IFCRELDEFINESBYPROPERTIES('1xdwj8qGXK4hzoNbvMdXJW',$,$,$,(#7),#8);
+#10=IFCQUANTITYLENGTH('Length',$,$,2000.,$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+const IDS_LENGTH_IN_METRES = `<?xml version="1.0" encoding="utf-8"?>
+<ids xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.buildingsmart.org/IDS http://standards.buildingsmart.org/IDS/1.0/ids.xsd" xmlns="http://standards.buildingsmart.org/IDS">
+  <info><title>Qto length must be reported in metres</title></info>
+  <specifications>
+    <specification name="Qto length in metres" ifcVersion="IFC4">
+      <applicability maxOccurs="unbounded">
+        <entity><name><simpleValue>IFCWALL</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <property dataType="IFCLENGTHMEASURE">
+          <propertySet><simpleValue>Qto_WallBaseQuantities</simpleValue></propertySet>
+          <baseName><simpleValue>Length</simpleValue></baseName>
+          <value><simpleValue>2</simpleValue></value>
+        </property>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>
+`;
+
+async function parseIfc(source: string) {
+  const bytes = new TextEncoder().encode(source);
+  return new IfcParser().parseColumnar(bytes.buffer.slice(0) as ArrayBuffer);
+}
+
+describe('IDS quantity unit conversion (Qto_*)', () => {
+  it('scales an IfcQuantityLength by the project length unit before comparing', async () => {
+    const store = await parseIfc(IFC);
+    const accessor = createDataAccessor(store);
+    const pset = accessor
+      .getPropertySets(7)
+      .find((p) => p.name === 'Qto_WallBaseQuantities');
+    const length = pset?.properties.find((p) => p.name === 'Length');
+
+    // Raw author value is 2000 (mm); the IDS-facing value must be the
+    // base-SI conversion, 2 (m) — the same scale `projectProperty` already
+    // applies to Pset_* length properties.
+    expect(length?.value).toBe(2);
+  });
+
+  it('passes a millimetre-authored Qto_ length quantity against an IDS literal in metres', async () => {
+    const store = await parseIfc(IFC);
+    const accessor = createDataAccessor(store);
+    const doc = parseIDS(IDS_LENGTH_IN_METRES);
+    const report = await validateIDS(doc, accessor, {
+      modelId: 'm1',
+      schemaVersion: 'IFC4',
+      entityCount: 1,
+    });
+
+    const spec = report.specificationResults[0];
+    expect(spec.applicableCount).toBe(1);
+    expect(spec.status).toBe('pass');
+    expect(spec.failedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- `collectAllPropertySets` (packages/ids/src/bridge/properties.ts) already converts `IfcPropertySet` (Pset_*) length-typed values to base SI through `projectProperty`/`applyUnitConversion`, so an IDS literal (always base SI per spec) compares correctly against a millimetre-authored value.
- `appendQuantitySets` built `IfcElementQuantity` (Qto_*) values directly from the raw parser record and skipped that conversion entirely. A millimetre-authored `IfcQuantityLength` of `2000` (2 metres) compared literally against the IDS literal — false-failing a requirement the model actually satisfies.
- Fix routes quantity values through the same `projectProperty` helper the property path uses, passing the project's `lengthUnitScale`.

## Reproduction (RED before / GREEN after)

Model: `IFCWALL` with `Qto_WallBaseQuantities.Length = 2000` (raw), project length unit `MILLI.METRE` (`lengthUnitScale = 0.001`, i.e. 2 metres).
IDS requirement: `property[dataType=IFCLENGTHMEASURE]` on `Qto_WallBaseQuantities.Length` with value `2`.

- Before: verdict `fail`, `PROPERTY_VALUE_MISMATCH` (`actual: "2000"`, `expected: "2"`).
- After: verdict `pass`.

This mirrors the vendored buildingSMART corpus case `property/pass-unit_conversions_shall_take_place_to_ids_nominated_standard_units_2_2`, which pins the same rule for `Pset_*` — that fixture already passes and is untouched; this PR extends the same conversion to `Qto_*`.

New test: `packages/ids/src/bridge/quantity-unit-conversion.test.ts` (2 tests) — observed RED against the pre-fix code (`git stash` of the one-line source change), GREEN after.

## Test plan

- [x] `pnpm exec turbo run test typecheck --filter=@ifc-lite/ids` — 25 files / 811 tests passed (includes the full 318-file buildingSMART corpus), typecheck clean.
- [x] New test observed failing before the fix, passing after.

Refs #none (no existing issue found for this — searched `gh issue list`/`gh pr list` for "quantity unit", "Qto unit conversion", "IDS Qto" and found no open item covering it).