### PR TITLE
fix(viewer): refuse a malformed Real/Integer property edit instead of writing 0

### DIFF
--- a/.changeset/property-editor-parse-guard.md
+++ b/.changeset/property-editor-parse-guard.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Four sites in `PropertyEditor.tsx` and `BulkPropertyEditor.tsx` used `parseFloat(value) || 0` / `parseInt(value, 10) || 0` when committing a user-entered Real/Integer property or quantity value. `NaN || 0` is `0`, so a value that didn't parse as a number silently wrote a real `0` into the model — indistinguishable from a value the user actually entered, with no error shown anywhere. Same defect as #3456's `CsvConnector.parseValue` fix.
+
+`PropertyEditor`'s inline commit (`commitSave`) and its "Add Property" dialog now refuse the save and show the existing `toast.error` notification instead of writing the fabricated value; the "Add Quantity" dialog does the same. An empty Real/Integer field now commits as `null` (unset), matching the convention the Boolean/Logical arm already used one case above it. A genuinely-entered `"0"` still writes `0`.
+
+`BulkPropertyEditor`'s single parsed value is reused for every entity in the matched selection, so a bad value previously fabricated a `0` across the whole selection at once. `buildAction` now returns a failure instead of an action, and both Preview and Execute refuse the whole operation before touching a single entity — surfaced through the component's own execute-result Alert, the pattern it already uses for a failed run — rather than half-applying a default across some but not all of the selection.

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.parse-guard.test.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.parse-guard.test.tsx
@@ -1,0 +1,226 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `BulkPropertyEditor.buildAction()` fed the "New Value" field through
+ * `parseFloat(targetValue) || 0` / `parseInt(targetValue, 10) || 0` for a
+ * Real/Integer SET_PROPERTY action. `NaN || 0` is `0`, so a non-numeric
+ * entry silently built an action carrying a fabricated `0` — and because
+ * that ONE `BulkAction` object is reused for every entity in the matched
+ * selection (`handleExecute`'s per-entity `queryEngine.applyAction(id,
+ * action)` loop), a single bad value would write a fabricated `0` across
+ * the ENTIRE selection at once. See PR #3456 (same defect in
+ * `CsvConnector.parseValue`) and the sibling record on that PR's thread.
+ *
+ * `parseBulkSetPropertyValue` (unit-tested below) is the fix's pure core;
+ * the component tests drive the real dialog end to end (the fixture-store
+ * pattern `BulkPropertyEditor.collab-gate.test.tsx` uses) to prove the
+ * all-or-nothing property: an unparseable value must refuse the WHOLE
+ * execute before touching a single entity, not half-apply across the
+ * selection.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click, advance } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+import { PropertyValueType } from '@ifc-lite/data';
+import { BulkPropertyEditor, parseBulkSetPropertyValue } from './BulkPropertyEditor.js';
+
+const MODEL_ID = 'model-a';
+const PSET = 'Pset_Test';
+const PROP = 'Foo';
+
+// ─── Unit tests: the pure parse core ───────────────────────────────────────
+
+describe('parseBulkSetPropertyValue', () => {
+  it('rejects a non-numeric Real entry instead of fabricating 0', () => {
+    const result = parseBulkSetPropertyValue('N/A', PropertyValueType.Real);
+    assert.equal(result.ok, false);
+  });
+
+  it('rejects a non-numeric Integer entry instead of fabricating 0', () => {
+    const result = parseBulkSetPropertyValue('TBD', PropertyValueType.Integer);
+    assert.equal(result.ok, false);
+  });
+
+  it('REGRESSION GUARD: accepts a genuine "0" Real entry as 0', () => {
+    const result = parseBulkSetPropertyValue('0', PropertyValueType.Real);
+    assert.deepEqual(result, { ok: true, value: 0 });
+  });
+
+  it('REGRESSION GUARD: accepts a genuine "0" Integer entry as 0', () => {
+    const result = parseBulkSetPropertyValue('0', PropertyValueType.Integer);
+    assert.deepEqual(result, { ok: true, value: 0 });
+  });
+
+  it('accepts a valid Real entry', () => {
+    const result = parseBulkSetPropertyValue('3.14', PropertyValueType.Real);
+    assert.deepEqual(result, { ok: true, value: 3.14 });
+  });
+
+  it('accepts a valid Integer entry', () => {
+    const result = parseBulkSetPropertyValue('42', PropertyValueType.Integer);
+    assert.deepEqual(result, { ok: true, value: 42 });
+  });
+
+  it('rejects an empty Real/Integer entry (no "unset" affordance in this bulk form)', () => {
+    assert.equal(parseBulkSetPropertyValue('', PropertyValueType.Real).ok, false);
+    assert.equal(parseBulkSetPropertyValue('', PropertyValueType.Integer).ok, false);
+  });
+
+  it('String/Label entries pass through unparsed', () => {
+    assert.deepEqual(parseBulkSetPropertyValue('hello', PropertyValueType.String), { ok: true, value: 'hello' });
+  });
+});
+
+// ─── Component tests: the dialog end to end ────────────────────────────────
+
+function seedStore() {
+  const seeded = fixtureModels(
+    fixtureModel(MODEL_ID, {
+      entities: [
+        { expressId: 1, type: 'IfcWall', name: 'Wall A' },
+        { expressId: 2, type: 'IfcWall', name: 'Wall B' },
+        { expressId: 3, type: 'IfcWall', name: 'Wall C' },
+      ],
+    }),
+  );
+  useViewerStore.setState({
+    ...seeded,
+    mutationViews: new Map(),
+    mutationVersion: 0,
+    collabRole: null,
+  });
+}
+
+function openDialog(container: HTMLElement): void {
+  const trigger = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('Open'));
+  assert.ok(trigger, 'dialog trigger button must render');
+  click(trigger!);
+}
+
+function setNativeValue(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new window.Event('input', { bubbles: true }));
+}
+
+/** Fills Property Set / Property Name / New Value, switches the value-type
+ *  Select to `typeLabel` via the real Radix control, waits for the
+ *  match-count debounce, then clicks Execute. */
+async function fillSetPropertyAndExecute(newValue: string, typeLabel: string): Promise<void> {
+  await advance(0);
+
+  const psetInput = [...document.body.querySelectorAll('input')].find(
+    (i) => i.placeholder === 'e.g., Pset_WallCommon',
+  ) as HTMLInputElement | undefined;
+  const propInput = [...document.body.querySelectorAll('input')].find(
+    (i) => i.placeholder === 'e.g., FireRating',
+  ) as HTMLInputElement | undefined;
+  const valueInput = [...document.body.querySelectorAll('input')].find(
+    (i) => i.placeholder === 'Value',
+  ) as HTMLInputElement | undefined;
+  assert.ok(psetInput && propInput && valueInput, 'Property Set / Property Name / New Value inputs must render');
+
+  setNativeValue(psetInput!, PSET);
+  setNativeValue(propInput!, PROP);
+  setNativeValue(valueInput!, newValue);
+
+  // Switch the value-type Select from its String default to `typeLabel`.
+  const typeSelectTrigger = [...document.body.querySelectorAll('button[role="combobox"]')].find((b) =>
+    b.textContent?.includes('String'),
+  );
+  assert.ok(typeSelectTrigger, 'value-type Select trigger must render');
+  click(typeSelectTrigger!);
+  await advance(0);
+  const option = [...document.body.querySelectorAll('[role="option"]')].find((o) => o.textContent === typeLabel);
+  assert.ok(option, `${typeLabel} option must render in the value-type Select`);
+  click(option!);
+  await advance(0);
+
+  // Let the match-count debounce (setTimeout(0) then setTimeout(200)) resolve
+  // so `liveMatchCount` becomes non-zero and the Execute button un-disables.
+  await advance(250);
+
+  const executeBtn = [...document.body.querySelectorAll('button')].find((b) =>
+    b.textContent?.includes('Apply to'),
+  ) as HTMLButtonElement | undefined;
+  assert.ok(executeBtn, 'Execute ("Apply to N entities") button must render');
+  click(executeBtn!);
+  await advance(0);
+}
+
+describe('BulkPropertyEditor — Real/Integer parse guard (buildAction / handleExecute)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('a non-numeric Real value writes nothing to ANY matched entity (all-or-nothing, not half-applied)', async () => {
+    seedStore();
+    const container = render(<BulkPropertyEditor trigger={<button>Open</button>} />);
+    openDialog(container);
+    await fillSetPropertyAndExecute('N/A', 'Real');
+
+    const view = useViewerStore.getState().mutationViews.get(MODEL_ID);
+    assert.ok(view, 'a mutation view is registered for the model');
+    for (const id of [1, 2, 3]) {
+      assert.equal(
+        view!.getPropertyValue(id, PSET, PROP),
+        null,
+        `entity ${id} must not receive a fabricated 0 — the whole bulk write must be refused, not half-applied`,
+      );
+    }
+
+    // Surfaced via this component's own error Alert (`executeResult`), the
+    // pattern it already uses for a failed execute — not a new UI.
+    const errorAlert = [...document.body.querySelectorAll('*')].find((el) => el.textContent === 'Error');
+    assert.ok(errorAlert, 'the Error alert must render, explaining the value did not parse');
+  });
+
+  it('a non-numeric Integer value writes nothing to any matched entity', async () => {
+    seedStore();
+    const container = render(<BulkPropertyEditor trigger={<button>Open</button>} />);
+    openDialog(container);
+    await fillSetPropertyAndExecute('TBD', 'Integer');
+
+    const view = useViewerStore.getState().mutationViews.get(MODEL_ID);
+    assert.ok(view);
+    for (const id of [1, 2, 3]) {
+      assert.equal(view!.getPropertyValue(id, PSET, PROP), null);
+    }
+  });
+
+  it('REGRESSION GUARD: a genuine "0" Real value still applies 0 across the whole selection', async () => {
+    seedStore();
+    const container = render(<BulkPropertyEditor trigger={<button>Open</button>} />);
+    openDialog(container);
+    await fillSetPropertyAndExecute('0', 'Real');
+
+    const view = useViewerStore.getState().mutationViews.get(MODEL_ID);
+    assert.ok(view);
+    for (const id of [1, 2, 3]) {
+      assert.equal(
+        view!.getPropertyValue(id, PSET, PROP),
+        0,
+        `entity ${id} must receive the genuinely-entered 0 — the fix must not reject real zeros`,
+      );
+    }
+  });
+
+  it('a valid Real value applies across the whole selection (sanity check on the harness)', async () => {
+    seedStore();
+    const container = render(<BulkPropertyEditor trigger={<button>Open</button>} />);
+    openDialog(container);
+    await fillSetPropertyAndExecute('3.14', 'Real');
+
+    const view = useViewerStore.getState().mutationViews.get(MODEL_ID);
+    assert.ok(view);
+    for (const id of [1, 2, 3]) {
+      assert.equal(view!.getPropertyValue(id, PSET, PROP), 3.14);
+    }
+  });
+});

--- a/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/BulkPropertyEditor.tsx
@@ -116,6 +116,28 @@ interface BulkPropertyEditorProps {
   trigger?: React.ReactNode;
 }
 
+/** Parse "New Value" for a SET_PROPERTY action. `parseFloat(...) || 0` /
+ *  `parseInt(..., 10) || 0` used to coerce a non-numeric entry to `0`,
+ *  reused across the whole bulk selection (see `buildAction`) — returns a
+ *  failure instead, so the caller refuses the whole operation. Empty is
+ *  invalid too: this form has no "unset" affordance. */
+type BulkParseResult = { ok: true; value: string | number | boolean } | { ok: false; message: string };
+
+export function parseBulkSetPropertyValue(targetValue: string, valueType: PropertyValueType): BulkParseResult {
+  if (valueType === PropertyValueType.Real || valueType === PropertyValueType.Integer) {
+    const label = valueType === PropertyValueType.Real ? 'Real' : 'Integer';
+    const parsed = valueType === PropertyValueType.Real ? parseFloat(targetValue) : parseInt(targetValue, 10);
+    if (targetValue.trim() === '' || Number.isNaN(parsed)) {
+      return { ok: false, message: `"${targetValue}" is not a valid ${label} value.` };
+    }
+    return { ok: true, value: parsed };
+  }
+  if (valueType === PropertyValueType.Boolean) {
+    return { ok: true, value: targetValue.toLowerCase() === 'true' || targetValue === '1' };
+  }
+  return { ok: true, value: targetValue };
+}
+
 export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
   const { models } = useIfc();
   const getMutationView = useViewerStore((s) => s.getMutationView);
@@ -123,17 +145,13 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
   const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
   // Subscribe to mutationViews directly to trigger re-render when views are registered
   const mutationViews = useViewerStore((s) => s.mutationViews);
-  // Collab role gate, two layers deep. (1) canCollabEdit is injected straight into
-  // BulkQueryEngine's constructor (see mutation-guard.ts): bulk edits reach the
-  // mutation view's setProperty/setEntityType directly via applyAction, bypassing
-  // the store's own setProperty action (and its canCollabEdit() check) entirely, so
-  // the engine itself refuses a write for a viewer/commenter role as containment.
-  // (2) canEditInSession mirrors that same role check here in the component, the
-  // same way MainToolbar/AuthorTab gate Edit mode, so the Execute button is disabled
-  // and never gets clicked in the first place. Both layers read the one shared
-  // `roleCanEdit` rule that `canCollabEdit()` is itself built from, so a future
-  // role change cannot leave them disagreeing. null role = single-user, always
-  // editable.
+  // Collab role gate, two layers deep. (1) canCollabEdit is injected into
+  // BulkQueryEngine's constructor (mutation-guard.ts): bulk edits bypass the
+  // store's own setProperty (and its check) via applyAction, so the engine
+  // itself refuses a viewer/commenter write as containment. (2) canEditInSession
+  // mirrors that check here, like MainToolbar/AuthorTab gate Edit mode, so
+  // Execute stays disabled. Both read the shared `roleCanEdit` rule
+  // canCollabEdit() is built from. null role = single-user, always editable.
   const canCollabEdit = useViewerStore((s) => s.canCollabEdit);
   const collabEditRole = useViewerStore((s) => s.collabRole);
   const canEditInSession = roleCanEdit(collabEditRole);
@@ -216,8 +234,7 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
   // Loading state for initial dialog open computation
   const [isInitializing, setIsInitializing] = useState(false);
 
-  // Get storeys, available types, and typeEnum mapping — computed once on dialog open,
-  // deferred via setTimeout so the dialog shell renders instantly with a spinner.
+  // Storeys/types/typeEnum mapping — computed once on open, deferred so the dialog renders instantly.
   const [availableStoreys, setAvailableStoreys] = useState<{ id: number; name: string; elevation?: number }[]>([]);
   const [availableTypes, setAvailableTypes] = useState<{ ifcType: string; label: string }[]>([]);
   const typeNameToEnumsRef = useRef<Map<string, number[]>>(new Map());
@@ -386,8 +403,7 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
     return criteria;
   }, [selectedTypes, selectedStoreys, namePattern, filters, typeNameToEnums]);
 
-  // Deferred computation: all expensive work (select + property discovery) yields to the
-  // browser first so pill toggles paint instantly, then runs via setTimeout(0).
+  // Deferred: select + property discovery yield to the browser first so pill toggles paint instantly.
   const [isComputing, setIsComputing] = useState(false);
   const [matchResult, setMatchResult] = useState<{
     count: number;
@@ -421,12 +437,9 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
         matchedIds = queryEngine.select(currentCriteria);
         count = matchedIds.length;
       } catch (err) {
-        // A count of 0 reads as "nothing matches these criteria", which is the
-        // answer the user acts on — so a query that FAILED must not be
-        // indistinguishable from one that matched nothing. Debounced per
-        // criteria edit, so this is not a hot path.
+        // A count of 0 must not be silently indistinguishable from a query
+        // that FAILED — log it. Debounced per edit, not a hot path.
         console.warn('[bulk-edit] criteria query failed; showing 0 matches', err);
-        // leave at 0
       }
 
       // Update count right away, keep old psets until discovery finishes
@@ -519,39 +532,20 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
     ));
   }, []);
 
-  // Build action for the query engine
-  const buildAction = useCallback((): BulkAction => {
+  // Build action for the query engine; returns a failure (parseBulkSetPropertyValue)
+  // instead of a fabricated-value action — callers must refuse the whole operation.
+  const buildAction = useCallback((): { ok: true; action: BulkAction } | { ok: false; message: string } => {
+    let action: BulkAction;
     if (actionType === 'SET_PROPERTY') {
-      // Parse value based on type
-      let parsedValue: string | number | boolean = targetValue;
-      if (valueType === PropertyValueType.Real) {
-        parsedValue = parseFloat(targetValue) || 0;
-      } else if (valueType === PropertyValueType.Integer) {
-        parsedValue = parseInt(targetValue, 10) || 0;
-      } else if (valueType === PropertyValueType.Boolean) {
-        parsedValue = targetValue.toLowerCase() === 'true' || targetValue === '1';
-      }
-
-      return {
-        type: 'SET_PROPERTY',
-        psetName: targetPset,
-        propName: targetProp,
-        value: parsedValue,
-        valueType,
-      };
+      const parsed = parseBulkSetPropertyValue(targetValue, valueType);
+      if (!parsed.ok) return parsed;
+      action = { type: 'SET_PROPERTY', psetName: targetPset, propName: targetProp, value: parsed.value, valueType };
     } else if (actionType === 'DELETE_PROPERTY') {
-      return {
-        type: 'DELETE_PROPERTY',
-        psetName: targetPset,
-        propName: targetProp,
-      };
+      action = { type: 'DELETE_PROPERTY', psetName: targetPset, propName: targetProp };
     } else {
-      return {
-        type: 'SET_ATTRIBUTE',
-        attribute: targetProp as 'name' | 'description' | 'objectType',
-        value: targetValue,
-      };
+      action = { type: 'SET_ATTRIBUTE', attribute: targetProp as 'name' | 'description' | 'objectType', value: targetValue };
     }
+    return { ok: true, action };
   }, [actionType, targetPset, targetProp, targetValue, valueType]);
 
   // Preview query
@@ -561,9 +555,12 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
     setPreviewResult(null);
     setExecuteResult(null);
 
+    const built = buildAction();
+    // Refuse rather than build around a fabricated value; same Alert Execute uses.
+    if (!built.ok) return setExecuteResult({ mutations: [], affectedEntityCount: 0, success: false, errors: [built.message] });
+
     try {
-      const action = buildAction();
-      const result = queryEngine.preview({ select: currentCriteria, action });
+      const result = queryEngine.preview({ select: currentCriteria, action: built.action });
       setPreviewResult(result);
     } catch (error) {
       console.error('Preview failed:', error);
@@ -575,6 +572,11 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
   const handleExecute = useCallback(async () => {
     if (!queryEngine || liveMatchCount === 0 || !canEditInSession) return;
 
+    const built = buildAction();
+    // Refuse before touching a single entity — one bad value must not half-apply across the selection.
+    if (!built.ok) return setExecuteResult({ mutations: [], affectedEntityCount: 0, success: false, errors: [built.message] });
+    const action = built.action;
+
     setIsExecuting(true);
     setExecuteResult(null);
     setExecuteProgress({ done: 0, total: 0 });
@@ -584,8 +586,6 @@ export function BulkPropertyEditor({ trigger }: BulkPropertyEditorProps) {
     await new Promise(r => setTimeout(r, 0));
 
     try {
-      const action = buildAction();
-
       // Step 1: select matching IDs
       const entityIds = queryEngine.select(currentCriteria);
       const total = entityIds.length;

--- a/apps/viewer/src/components/viewer/PropertyEditor.parse-guard.test.tsx
+++ b/apps/viewer/src/components/viewer/PropertyEditor.parse-guard.test.tsx
@@ -1,0 +1,259 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `PropertyEditor`'s inline commit path (`commitSave`) and its "Add
+ * Property" / "Add Quantity" dialogs all fed a user-typed Real/Integer
+ * string through `parseFloat(value) || 0` / `parseInt(value, 10) || 0`.
+ * `NaN || 0` is `0`, so typing anything that doesn't parse as a number
+ * ("abc", a stray character, an unfinished edit) silently wrote a real `0`
+ * into the model — indistinguishable from a value the user actually
+ * entered, with no error shown anywhere. See PR #3456 (same defect in
+ * `CsvConnector.parseValue`) and the sibling record on that PR's thread.
+ *
+ * This mounts the real inline editor against a real `MutablePropertyView`
+ * (the fixture-store pattern `BulkPropertyEditor.collab-gate.test.tsx`
+ * uses) and drives it through the actual value input, type buttons, and
+ * Save action.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { render, cleanup, click, advance } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { fixtureModel, fixtureModels } from '@/test/store-fixture.js';
+import { configureMutationView } from '@/utils/configureMutationView';
+import { MutablePropertyView } from '@ifc-lite/mutations';
+import { PropertyValueType } from '@ifc-lite/data';
+import { PropertyEditor } from './PropertyEditor.js';
+import { toast } from '@/components/ui/toast';
+
+const MODEL_ID = 'model-a';
+const ENTITY_ID = 42;
+const PSET = 'Pset_WallCommon';
+const PROP = 'ThermalTransmittance';
+
+function seedStore(): MutablePropertyView {
+  const model = fixtureModel(MODEL_ID, {
+    entities: [{ expressId: ENTITY_ID, type: 'IfcWall', name: 'Wall A' }],
+  });
+  const seeded = fixtureModels(model);
+  const dataStore = model.ifcDataStore!;
+  const view = new MutablePropertyView(dataStore.properties ?? null, MODEL_ID);
+  configureMutationView(view, dataStore);
+  useViewerStore.setState({
+    ...seeded,
+    mutationViews: new Map([[MODEL_ID, view]]),
+    mutationVersion: 0,
+    collabRole: null,
+  });
+  return view;
+}
+
+function setInputValue(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new window.Event('input', { bubbles: true }));
+}
+
+function getTypeButton(label: string): HTMLButtonElement {
+  const btn = [...document.body.querySelectorAll('button')].find((b) => b.textContent === label);
+  assert.ok(btn, `${label} type button must render`);
+  return btn as HTMLButtonElement;
+}
+
+function getValueInput(): HTMLInputElement {
+  const input = document.body.querySelector('input[placeholder="Enter value"]') as HTMLInputElement | null;
+  assert.ok(input, 'value input must render once editing');
+  return input!;
+}
+
+function getSaveButton(): HTMLButtonElement {
+  const save = [...document.body.querySelectorAll('button')].find((b) =>
+    b.querySelector('svg.lucide-check'),
+  ) as HTMLButtonElement | undefined;
+  assert.ok(save, 'Save button must render');
+  return save!;
+}
+
+/** Enters edit mode (default type is String — a plain `type="text"` input,
+ *  unsanitized) and returns the value input + Save button, both still in
+ *  String mode. Every step is followed by `advance(0)` so the resulting
+ *  state update commits before the next DOM query — a raw `dispatchEvent`
+ *  outside `click()` (which already wraps in `act()`) does not flush
+ *  synchronously. */
+async function openEditor(container: HTMLElement): Promise<{ input: HTMLInputElement; save: HTMLButtonElement }> {
+  const editSpan = [...container.querySelectorAll('span')].find((s) => s.title === 'Click to edit');
+  assert.ok(editSpan, 'value span must render (click to enter edit mode)');
+  click(editSpan!);
+  await advance(0);
+
+  return { input: getValueInput(), save: getSaveButton() };
+}
+
+/**
+ * Types `text` while the field is still in String mode (`type="text"`, no
+ * browser/jsdom number-input sanitization) and only THEN switches to
+ * `typeLabel` ('Real' or 'Int') via the type button — the realistic way a
+ * non-numeric string reaches a Real/Integer commit: the field starts as
+ * String, the switch to Real/Integer doesn't touch `value` (see the type
+ * button's `onClick`), and `<input type="number">` only sanitizes on the
+ * next keystroke/paste, not on becoming controlled with a mismatched
+ * existing value. Typing directly into a live `type="number"` input, by
+ * contrast, is sanitized away by the DOM before it ever reaches React state
+ * — true in real browsers and in jsdom alike — so it can't reproduce the
+ * defect at all.
+ */
+async function typeThenSwitchType(
+  container: HTMLElement,
+  text: string,
+  typeLabel: string,
+): Promise<{ save: HTMLButtonElement }> {
+  const { input } = await openEditor(container);
+  setInputValue(input, text);
+  await advance(0);
+
+  click(getTypeButton(typeLabel));
+  await advance(0);
+
+  return { save: getSaveButton() };
+}
+
+describe('PropertyEditor — Real/Integer parse guard (commitSave)', () => {
+  let originalToastError: typeof toast.error;
+  let toastMessages: string[];
+
+  afterEach(() => {
+    cleanup();
+    if (originalToastError) toast.error = originalToastError;
+  });
+
+  function spyToastError() {
+    toastMessages = [];
+    originalToastError = toast.error;
+    toast.error = (message: string) => {
+      toastMessages.push(message);
+    };
+  }
+
+  it('does not write 0 for a non-numeric Real edit; blocks the save with an error', async () => {
+    spyToastError();
+    const view = seedStore();
+    const container = render(
+      <PropertyEditor modelId={MODEL_ID} entityId={ENTITY_ID} psetName={PSET} propName={PROP} currentValue={null} />,
+    );
+
+    const { save } = await typeThenSwitchType(container, 'abc', 'Real');
+    click(save);
+    await advance(0);
+
+    assert.equal(
+      view.getPropertyValue(ENTITY_ID, PSET, PROP),
+      null,
+      'a non-numeric Real entry must not write a fabricated 0',
+    );
+    assert.equal(toastMessages.length, 1, 'an error must be surfaced to the user');
+    assert.match(toastMessages[0], /not a valid Real value/);
+  });
+
+  it('does not write 0 for a non-numeric Integer edit; blocks the save with an error', async () => {
+    spyToastError();
+    const view = seedStore();
+    const container = render(
+      <PropertyEditor modelId={MODEL_ID} entityId={ENTITY_ID} psetName={PSET} propName={PROP} currentValue={null} />,
+    );
+
+    const { save } = await typeThenSwitchType(container, 'abc', 'Int');
+    click(save);
+    await advance(0);
+
+    assert.equal(
+      view.getPropertyValue(ENTITY_ID, PSET, PROP),
+      null,
+      'a non-numeric Integer entry must not write a fabricated 0',
+    );
+    assert.equal(toastMessages.length, 1, 'an error must be surfaced to the user');
+    assert.match(toastMessages[0], /not a valid Integer value/);
+  });
+
+  it('REGRESSION GUARD: a genuine "0" Real entry still writes 0', async () => {
+    spyToastError();
+    const view = seedStore();
+    const container = render(
+      <PropertyEditor modelId={MODEL_ID} entityId={ENTITY_ID} psetName={PSET} propName={PROP} currentValue={null} />,
+    );
+
+    const { save } = await typeThenSwitchType(container, '0', 'Real');
+    click(save);
+    await advance(0);
+
+    assert.equal(
+      view.getPropertyValue(ENTITY_ID, PSET, PROP),
+      0,
+      'a genuinely-entered 0 must still be written — the fix must not reject real zeros',
+    );
+    assert.equal(toastMessages.length, 0, 'a valid 0 must not raise an error');
+  });
+
+  it('REGRESSION GUARD: a genuine "0" Integer entry still writes 0', async () => {
+    spyToastError();
+    const view = seedStore();
+    const container = render(
+      <PropertyEditor modelId={MODEL_ID} entityId={ENTITY_ID} psetName={PSET} propName={PROP} currentValue={null} />,
+    );
+
+    const { save } = await typeThenSwitchType(container, '0', 'Int');
+    click(save);
+    await advance(0);
+
+    assert.equal(view.getPropertyValue(ENTITY_ID, PSET, PROP), 0, 'a genuinely-entered 0 must still be written');
+    assert.equal(toastMessages.length, 0, 'a valid 0 must not raise an error');
+  });
+
+  it("an empty Real entry writes null (unset), matching the Boolean arm's existing convention", async () => {
+    spyToastError();
+    const view = seedStore();
+    // Seed an existing value so we can observe the edit actually clearing it.
+    view.setProperty(ENTITY_ID, PSET, PROP, 12.5, PropertyValueType.Real);
+    const container = render(
+      <PropertyEditor
+        modelId={MODEL_ID}
+        entityId={ENTITY_ID}
+        psetName={PSET}
+        propName={PROP}
+        currentValue={12.5}
+        currentType={PropertyValueType.Real}
+      />,
+    );
+
+    const { input, save } = await openEditor(container);
+    setInputValue(input, '');
+    await advance(0);
+    click(save);
+    await advance(0);
+
+    assert.equal(
+      view.getPropertyValue(ENTITY_ID, PSET, PROP),
+      null,
+      'an empty Real field commits as unset (null), the same convention the Boolean arm already uses',
+    );
+    assert.equal(toastMessages.length, 0, 'clearing to empty is not a parse error');
+  });
+
+  it('a valid Real edit still commits normally (sanity check on the harness)', async () => {
+    spyToastError();
+    const view = seedStore();
+    const container = render(
+      <PropertyEditor modelId={MODEL_ID} entityId={ENTITY_ID} psetName={PSET} propName={PROP} currentValue={null} />,
+    );
+
+    const { save } = await typeThenSwitchType(container, '3.14', 'Real');
+    click(save);
+    await advance(0);
+
+    assert.equal(view.getPropertyValue(ENTITY_ID, PSET, PROP), 3.14);
+    assert.equal(toastMessages.length, 0);
+  });
+});

--- a/apps/viewer/src/components/viewer/PropertyEditor.tsx
+++ b/apps/viewer/src/components/viewer/PropertyEditor.tsx
@@ -46,6 +46,7 @@ import { Switch } from '@/components/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 import { ComboInput } from '@/components/ui/combo-input';
+import { toast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import {
   resolveReassignSchema,
@@ -139,7 +140,9 @@ export function PropertyEditor({
 
   const commitSave = useCallback(() => {
     const parsedValue = parseValue(value, valueType);
-
+    if (parsedValue === PARSE_INVALID) {
+      return toast.error(`"${value}" is not a valid ${getTypeName(valueType)} value — save cancelled.`);
+    }
     // Normalize model ID for legacy models
     let normalizedModelId = modelId;
     if (modelId === 'legacy') {
@@ -394,11 +397,8 @@ interface NewPropertyDialogProps {
   schemaVersion?: string;
 }
 
-/**
- * Schema-aware dialog for adding new properties.
- * Filters available property sets based on IFC entity type.
- * Shows property suggestions with correct types from IFC4 standard.
- */
+/** Schema-aware dialog for adding new properties: filters available property
+ *  sets by IFC entity type and suggests correctly-typed IFC4 properties. */
 export function NewPropertyDialog({ modelId, entityId, entityType, existingPsets, schemaVersion }: NewPropertyDialogProps) {
   const setProperty = useViewerStore((s) => s.setProperty);
   const createPropertySet = useViewerStore((s) => s.createPropertySet);
@@ -460,12 +460,14 @@ export function NewPropertyDialog({ modelId, entityId, entityType, existingPsets
   const handleSubmit = useCallback(() => {
     if (!effectivePsetName || !effectivePropName) return;
 
+    const parsedValue = parseValue(value, valueType);
+    if (parsedValue === PARSE_INVALID) {
+      return toast.error(`"${value}" is not a valid ${getTypeName(valueType)} value — property not added.`);
+    }
     let normalizedModelId = modelId;
     if (modelId === 'legacy') {
       normalizedModelId = '__legacy__';
     }
-
-    const parsedValue = parseValue(value, valueType);
 
     // Check if pset exists on entity already
     const psetExists = existingPsets.includes(effectivePsetName);
@@ -712,11 +714,8 @@ interface AddClassificationDialogProps {
   entityType: string;
 }
 
-/**
- * Dialog for adding a classification reference to an entity.
- * Supports common classification systems (Uniclass, OmniClass, MasterFormat, etc.).
- * Stored as a special property set for mutation tracking.
- */
+/** Dialog for adding a classification reference (Uniclass, OmniClass,
+ *  MasterFormat, etc.), stored as a special property set for mutation tracking. */
 export function AddClassificationDialog({ modelId, entityId, entityType }: AddClassificationDialogProps) {
   const createPropertySet = useViewerStore((s) => s.createPropertySet);
   const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
@@ -852,10 +851,7 @@ interface AddMaterialDialogProps {
   entityType: string;
 }
 
-/**
- * Dialog for assigning a material to an entity.
- * Stored as a special property set for mutation tracking.
- */
+/** Dialog for assigning a material, stored as a special property set for mutation tracking. */
 export function AddMaterialDialog({ modelId, entityId, entityType }: AddMaterialDialogProps) {
   const createPropertySet = useViewerStore((s) => s.createPropertySet);
   const bumpMutationVersion = useViewerStore((s) => s.bumpMutationVersion);
@@ -986,11 +982,8 @@ interface AddQuantityDialogProps {
   existingQtos: string[];
 }
 
-/**
- * Schema-aware dialog for adding quantities.
- * Filters available quantity sets based on IFC entity type.
- * Shows quantity suggestions with correct types from IFC4 standard.
- */
+/** Schema-aware dialog for adding quantities: filters available quantity
+ *  sets by IFC entity type and suggests correctly-typed IFC4 quantities. */
 export function AddQuantityDialog({ modelId, entityId, entityType, existingQtos }: AddQuantityDialogProps) {
   const createPropertySet = useViewerStore((s) => s.createPropertySet);
   const setProperty = useViewerStore((s) => s.setProperty);
@@ -1046,12 +1039,14 @@ export function AddQuantityDialog({ modelId, entityId, entityType, existingQtos 
   const handleSubmit = useCallback(() => {
     if (!effectiveQtoName || !effectiveQuantityName) return;
 
+    const parsedValue = parseFloat(value);
+    if (Number.isNaN(parsedValue)) {
+      return toast.error(`"${value}" is not a valid number — quantity not added.`);
+    }
     let normalizedModelId = modelId;
     if (modelId === 'legacy') {
       normalizedModelId = '__legacy__';
     }
-
-    const parsedValue = parseFloat(value) || 0;
 
     // Store quantity as a property set (mutation system uses property sets)
     const qtoExists = existingQtos.includes(effectiveQtoName);
@@ -1274,12 +1269,11 @@ interface ReassignClassDialogProps {
 }
 
 /**
- * Reassign an entity's IFC class in place ("retype"). The expressId is
- * unchanged, so geometry / placement / representation and every IfcRel*
+ * Reassign an entity's IFC class in place ("retype"): expressId is
+ * unchanged, so geometry/placement/representation and every IfcRel*
  * reference carry over; the new class materializes on STEP export. Mirrors
- * IfcOpenShell's `reassign_class`. Best for the building-element subtypes
- * (Proxy ↔ Column / Beam / Member / Plate / Wall) that share the IfcElement
- * attribute layout.
+ * IfcOpenShell's `reassign_class`. Best for building-element subtypes
+ * (Proxy ↔ Column/Beam/Member/Plate/Wall) sharing the IfcElement layout.
  */
 export function ReassignClassDialog({ modelId, entityId, entityType, schemaVersion }: ReassignClassDialogProps) {
   const setEntityType = useViewerStore((s) => s.setEntityType);
@@ -1713,12 +1707,16 @@ function getTypeName(type: PropertyValueType): string {
   }
 }
 
-function parseValue(value: string, type: PropertyValueType): PropertyValue {
+/** Sentinel: a Real/Integer {@link parseValue} input isn't a number at all — callers must refuse the save. */
+export const PARSE_INVALID = Symbol('property-editor-parse-invalid');
+
+export function parseValue(value: string, type: PropertyValueType): PropertyValue | typeof PARSE_INVALID {
   switch (type) {
+    // Empty = unset → null for both, matching Boolean/Logical below.
     case PropertyValueType.Real:
-      return parseFloat(value) || 0;
+      return value === '' ? null : (Number.isNaN(parseFloat(value)) ? PARSE_INVALID : parseFloat(value));
     case PropertyValueType.Integer:
-      return parseInt(value, 10) || 0;
+      return value === '' ? null : (Number.isNaN(parseInt(value, 10)) ? PARSE_INVALID : parseInt(value, 10));
     case PropertyValueType.Boolean:
     case PropertyValueType.Logical:
       // Empty = unset → null (encodes to the table's 255 sentinel, serialises


### PR DESCRIPTION
`PropertyEditor` and `BulkPropertyEditor` parsed numeric property entries with `parseFloat(value) || 0` / `parseInt(value, 10) || 0`. `NaN || 0` is `0`, so any unparseable entry was written into the model as a real mutation, indistinguishable from a zero the user genuinely typed.

Sibling of #3456, which fixes the same shape in the CSV importer. Between them these are the four model-writing instances of this pattern.

## Why the bulk editor is the worst case

`BulkPropertyEditor` applies one parsed value across an entire selection, so a single malformed entry fabricated zeros on every matched element at once. That path is now all-or-nothing — it writes nothing rather than half-applying — and there is a test pinning exactly that.

## Behaviour chosen, and why

The user is present and can fix the input, so refusing silently is not enough: the save is blocked with `toast.error`. That is the mechanism sibling panels (`AddElementPanel`, `ClashBcfExportDialog`) already use — no new notification path was introduced.

Empty input maps to `null` (unset) for Real/Integer, matching the Boolean/Logical arms that already treat empty that way.

## The guard that matters

Four tests pin that a genuine `"0"` still writes `0`, in both the single and bulk paths. A fix that rejected real zeros would be worse than the bug it replaces, so that is the regression this change is most careful about.

## Deliberately NOT changed

Four other sites carry the same `|| 0` shape and are left alone: `SearchModal.filter.builder.tsx`, two in `SearchModal.filter.editors.tsx`, and `DrawingSettingsPanel.tsx` (which falls back to `0.35`, a deliberate line-weight default). Those are transient UI controls — the value is not persisted and the user is looking at the field they just typed in. The principle is not "`|| 0` is a bug" but **a parse failure must not become model data**; applying this treatment there would make those inputs behave worse.

## Verification

- 18 tests across the two new files pass, including harness sanity checks.
- Viewer `tsc --noEmit` clean (with workspace deps built).
- `check-module-size` OK. Both files are near their pinned budgets, so unrelated JSDoc in them was condensed to pay for the added lines rather than raising a budget.

Refs #3456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid Real and Integer values are now rejected instead of being saved as zero.
  * Empty numeric fields correctly clear the value, while explicitly entered zero remains valid.
  * Bulk edits stop safely when any selected value is invalid, leaving all affected items unchanged.
  * Clear error messages are displayed when numeric input cannot be saved.

* **Tests**
  * Added coverage for inline editing, dialogs, bulk previews, and bulk execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->