### PR TITLE
fix(geometry): thread sharedRtcOffset through the synchronous (<2MB) WASM mesh path

### DIFF
--- a/.changeset/geometry-sync-shared-rtc-offset.md
+++ b/.changeset/geometry-sync-shared-rtc-offset.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/geometry': patch
+---
+
+The synchronous WASM mesh path (`processAdaptive`'s <2MB branch, via `collectMeshesViaPrePass`) now honours a caller-supplied `sharedRtcOffset` for federation alignment, matching the parallel and streaming paths (`geometry-parallel.ts`'s `useSharedRtc`).
+
+Previously only the parallel and streaming WASM paths threaded a caller-supplied `sharedRtcOffset` through to the mesh pass; the sync path silently ignored it and always used the model's own detected RTC offset, so a small (<2MB) federated model rendered at its own origin instead of the shared federation origin its siblings use. `applyPrePassMetadata` and `collectMeshesViaPrePass` now accept an optional `sharedRtcOffset` and, when present, use it (with `needsShift` forced `true`) in place of the pre-pass's own detected offset — the same rule already applied by the parallel/streaming paths.
+
+No performance impact: same code path runs either way, only which RTC offset value is selected changes.

--- a/.changeset/geometry-sync-shared-rtc-offset.md
+++ b/.changeset/geometry-sync-shared-rtc-offset.md
@@ -6,4 +6,6 @@ The synchronous WASM mesh path (`processAdaptive`'s <2MB branch, via `collectMes
 
 Previously only the parallel and streaming WASM paths threaded a caller-supplied `sharedRtcOffset` through to the mesh pass; the sync path silently ignored it and always used the model's own detected RTC offset, so a small (<2MB) federated model rendered at its own origin instead of the shared federation origin its siblings use. `applyPrePassMetadata` and `collectMeshesViaPrePass` now accept an optional `sharedRtcOffset` and, when present, use it (with `needsShift` forced `true`) in place of the pre-pass's own detected offset — the same rule already applied by the parallel/streaming paths.
 
+With #3455 having done the same for the single-threaded streaming fallback, all three WASM branches of `processAdaptive` now honour the federation origin; the native/Tauri path (`geometry-native.ts`) still does not.
+
 No performance impact: same code path runs either way, only which RTC offset value is selected changes.

--- a/packages/geometry/src/geometry-processor-sync-shared-rtc.test.ts
+++ b/packages/geometry/src/geometry-processor-sync-shared-rtc.test.ts
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const wasmMocks = vi.hoisted(() => {
+  const buildPrePassOnce = vi.fn();
+  const processGeometryBatch = vi.fn();
+  const clearPrePassCache = vi.fn();
+
+  class MockIfcAPI {
+    buildPrePassOnce(data: Uint8Array) {
+      return buildPrePassOnce(data);
+    }
+
+    processGeometryBatch(
+      data: Uint8Array,
+      jobsFlat: Uint32Array,
+      unitScale: number,
+      rtcX: number,
+      rtcY: number,
+      rtcZ: number,
+      needsShift: boolean,
+      voidKeys: Uint32Array,
+      voidCounts: Uint32Array,
+      voidValues: Uint32Array,
+      styleIds: Uint32Array,
+      styleColors: Uint8Array,
+    ) {
+      return processGeometryBatch(
+        data,
+        jobsFlat,
+        unitScale,
+        rtcX,
+        rtcY,
+        rtcZ,
+        needsShift,
+        voidKeys,
+        voidCounts,
+        voidValues,
+        styleIds,
+        styleColors,
+      );
+    }
+
+    clearPrePassCache() {
+      return clearPrePassCache();
+    }
+  }
+
+  return {
+    init: vi.fn(async () => undefined),
+    buildPrePassOnce,
+    processGeometryBatch,
+    clearPrePassCache,
+    MockIfcAPI,
+  };
+});
+
+vi.mock('@ifc-lite/wasm', () => ({
+  default: wasmMocks.init,
+  IfcAPI: wasmMocks.MockIfcAPI,
+}));
+
+import { GeometryProcessor } from './index.js';
+
+// The synchronous (<2MB) WASM mesh path (`collectMeshesViaPrePass`, reached
+// via `processAdaptive`) must honour a caller-supplied federation
+// `sharedRtcOffset` the same way `geometry-parallel.ts`'s `useSharedRtc`
+// logic and the streaming path do — a small federated model must render at
+// the shared origin, not its own per-model detected RTC offset.
+describe('GeometryProcessor sync path (<2MB) sharedRtcOffset override', () => {
+  beforeEach(() => {
+    wasmMocks.init.mockClear();
+    wasmMocks.buildPrePassOnce.mockReset();
+    wasmMocks.processGeometryBatch.mockReset();
+    wasmMocks.clearPrePassCache.mockReset();
+  });
+
+  it('uses the caller-supplied sharedRtcOffset instead of the model-detected rtcOffset', async () => {
+    wasmMocks.buildPrePassOnce.mockReturnValue({
+      jobs: new Uint32Array([11, 0, 42]),
+      totalJobs: 1,
+      unitScale: 1,
+      rtcOffset: new Float64Array([10, 20, 30]),
+      needsShift: true,
+      buildingRotation: 0,
+      voidKeys: new Uint32Array(),
+      voidCounts: new Uint32Array(),
+      voidValues: new Uint32Array(),
+      styleIds: new Uint32Array(),
+      styleColors: new Uint8Array(),
+    });
+
+    wasmMocks.processGeometryBatch.mockReturnValue({
+      length: 0,
+      get: () => undefined,
+      free: vi.fn(),
+    });
+
+    const geometry = new GeometryProcessor();
+    const buffer = new Uint8Array([65, 66, 67]);
+
+    for await (const _event of geometry.processAdaptive(buffer, {
+      sharedRtcOffset: { x: 100, y: 200, z: 300 },
+    })) {
+      // Drain the generator; assertions are on the mock call args below.
+    }
+
+    expect(wasmMocks.processGeometryBatch).toHaveBeenCalledTimes(1);
+    const call = wasmMocks.processGeometryBatch.mock.calls[0];
+    const [, , , rtcX, rtcY, rtcZ, needsShift] = call;
+    expect(rtcX).toBe(100);
+    expect(rtcY).toBe(200);
+    expect(rtcZ).toBe(300);
+    expect(needsShift).toBe(true);
+  });
+});

--- a/packages/geometry/src/geometry-processor-sync-shared-rtc.test.ts
+++ b/packages/geometry/src/geometry-processor-sync-shared-rtc.test.ts
@@ -84,7 +84,12 @@ describe('GeometryProcessor sync path (<2MB) sharedRtcOffset override', () => {
       totalJobs: 1,
       unitScale: 1,
       rtcOffset: new Float64Array([10, 20, 30]),
-      needsShift: true,
+      // false on purpose. A caller-supplied shared offset must FORCE
+      // needsShift true, and while the mock reports true this assertion
+      // holds whether or not the fix does that -- dropping `useShared ?
+      // true :` from applyPrePassMetadata leaves the test green and ships
+      // half the fix unguarded.
+      needsShift: false,
       buildingRotation: 0,
       voidKeys: new Uint32Array(),
       voidCounts: new Uint32Array(),

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -47,14 +47,12 @@ export { CoordinateHandler, NORMAL_COORD_THRESHOLD_M } from './coordinate-handle
 export { computeWorkerCount, pickWorkerCount, type WorkerCountInputs, type WorkerCountResult } from './worker-count.js';
 export { getGeometryStreamWatchdogMs, type WatchdogInputs } from './watchdog.js';
 // Cold-start prewarm: start the shared wasm fetch+compile before a file is
-// opened so the download overlaps the user's think time instead of blocking
-// first geometry. The host app decides when (idle / intent) and whether the
-// connection can afford it.
+// opened so the download overlaps think time instead of blocking first
+// geometry. The host app decides when (idle / intent) and affordability.
 export { prewarmSharedWasmModule } from './wasm-shared-module.js';
 // Stale-deployment WASM-asset detection (#1363). The host app subscribes to
-// WASM_ASSET_UNAVAILABLE_EVENT and uses `isWasmAssetUnavailableError` to reload
-// onto the current deployment. `notifyIfWasmAssetUnavailable` stays internal —
-// it is the engine-side dispatcher, imported directly where it fires.
+// WASM_ASSET_UNAVAILABLE_EVENT and uses `isWasmAssetUnavailableError` to
+// reload onto the deployment; `notifyIfWasmAssetUnavailable` stays internal.
 export {
   isWasmAssetUnavailableError,
   WASM_ASSET_UNAVAILABLE_EVENT,
@@ -281,10 +279,9 @@ export class GeometryProcessor {
 
     if (!this.isNative) {
       this.bridge = new IfcLiteBridge();
-      // Cache the merge-layers flag on the bridge eagerly — if init()
-      // hasn't run yet the bridge stores the value and replays it on
-      // the freshly-built IfcAPI. Existing call sites can opt in
-      // simply by passing { mergeLayers: true } into the constructor.
+      // Cache the merge-layers flag on the bridge eagerly — if init() hasn't
+      // run yet the bridge stores the value and replays it on the freshly-
+      // built IfcAPI. Call sites opt in via { mergeLayers: true }.
       this.bridge.setMergeLayers(this.mergeLayers);
       // Same eager cache-and-replay for the tessellation level (#976).
       this.bridge.setTessellationQuality(this.tessellationQuality);
@@ -421,28 +418,36 @@ export class GeometryProcessor {
    * no `TextDecoder` materialization of the whole file.
    */
   /**
-   * Surface the world→render metadata (unit scale + the applied RTC offset)
-   * from a pre-pass result onto the coordinate handler, so it appears on the
-   * emitted `CoordinateInfo` (issue #945). Shared by the sync and streaming
-   * WASM paths to keep the RTC transform in one place.
+   * Surface the world→render metadata (unit scale + applied RTC offset) from
+   * a pre-pass result onto the coordinate handler (issue #945). Shared by the
+   * sync and streaming WASM paths; `sharedRtcOffset` overrides the model's
+   * own detected offset for federation alignment (mirrors `useSharedRtc` in
+   * geometry-parallel.ts).
    */
-  private applyPrePassMetadata(prePass: ByteStreamingPrePassResult): void {
-    this.coordinateHandler.setWasmMetadata(
-      prePass.unitScale,
-      prePass.needsShift
-        ? { x: prePass.rtcOffset?.[0] ?? 0, y: prePass.rtcOffset?.[1] ?? 0, z: prePass.rtcOffset?.[2] ?? 0 }
-        : null,
-    );
+  private applyPrePassMetadata(
+    prePass: ByteStreamingPrePassResult,
+    sharedRtcOffset?: { x: number; y: number; z: number },
+  ): { x: number; y: number; z: number; needsShift: boolean } {
+    const useShared = sharedRtcOffset != null;
+    const x = useShared ? sharedRtcOffset.x : (prePass.rtcOffset?.[0] ?? 0);
+    const y = useShared ? sharedRtcOffset.y : (prePass.rtcOffset?.[1] ?? 0);
+    const z = useShared ? sharedRtcOffset.z : (prePass.rtcOffset?.[2] ?? 0);
+    const needsShift = useShared ? true : Boolean(prePass.needsShift);
+    this.coordinateHandler.setWasmMetadata(prePass.unitScale, needsShift ? { x, y, z } : null);
+    return { x, y, z, needsShift };
   }
 
-  private collectMeshesViaPrePass(buffer: Uint8Array): { meshes: MeshData[]; buildingRotation?: number } {
+  private collectMeshesViaPrePass(
+    buffer: Uint8Array,
+    sharedRtcOffset?: { x: number; y: number; z: number },
+  ): { meshes: MeshData[]; buildingRotation?: number } {
     if (!this.bridge) {
       throw new Error('WASM bridge not initialized');
     }
 
     const api = this.bridge.getApi();
     const prePass = api.buildPrePassOnce(buffer) as ByteStreamingPrePassResult;
-    this.applyPrePassMetadata(prePass);
+    const rtc = this.applyPrePassMetadata(prePass, sharedRtcOffset);
     try {
       const meshes: MeshData[] = [];
       const totalJobs = prePass.totalJobs ?? 0;
@@ -453,10 +458,10 @@ export class GeometryProcessor {
           buffer,
           prePass.jobs,
           prePass.unitScale,
-          prePass.rtcOffset?.[0] ?? 0,
-          prePass.rtcOffset?.[1] ?? 0,
-          prePass.rtcOffset?.[2] ?? 0,
-          prePass.needsShift,
+          rtc.x,
+          rtc.y,
+          rtc.z,
+          rtc.needsShift,
           prePass.voidKeys,
           prePass.voidCounts,
           prePass.voidValues,
@@ -469,8 +474,7 @@ export class GeometryProcessor {
         );
         // Loop, not `push(...batch)`: spreading passes one ARGUMENT per mesh,
         // and past V8's ~65k argument ceiling that throws RangeError "Maximum
-        // call stack size exceeded" — real models (Holter: ~110k meshes) hit
-        // it, killing the whole sync process() call.
+        // call stack size exceeded" — real models (~110k meshes) hit it.
         const batch = convertMeshCollectionToBatch(collection);
         for (let i = 0; i < batch.length; i++) meshes.push(batch[i]);
       }
@@ -877,14 +881,10 @@ export class GeometryProcessor {
         console.timeEnd('[GeometryProcessor] native-adaptive-sync');
       } else {
         // WASM PATH — Family-A pre-pass + job batches (SAB-safe, bytes in).
-        const collected = this.collectMeshesViaPrePass(buffer);
+        const collected = this.collectMeshesViaPrePass(buffer, options.sharedRtcOffset);
         allMeshes = collected.meshes;
         buildingRotation = collected.buildingRotation;
       }
-
-      // NOTE: The sync path (<2MB) does not support sharedRtcOffset override.
-      // Infrastructure models with large coordinates are always >2MB and use
-      // the parallel/streaming paths where shared RTC is properly threaded.
 
       // Process coordinate shifts
       this.coordinateHandler.processMeshesIncremental(allMeshes);

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -419,10 +419,10 @@ export class GeometryProcessor {
    */
   /**
    * Surface the world→render metadata (unit scale + applied RTC offset) from
-   * a pre-pass result onto the coordinate handler (issue #945). Shared by the
-   * sync and streaming WASM paths; `sharedRtcOffset` overrides the model's
-   * own detected offset for federation alignment (mirrors `useSharedRtc` in
-   * geometry-parallel.ts).
+   * a pre-pass result onto the coordinate handler (issue #945). Used by the
+   * sync WASM mesh path; `sharedRtcOffset` overrides the model's own detected
+   * offset for federation alignment (mirrors `useSharedRtc` in
+   * geometry-parallel.ts and `processStreamingBytes`).
    */
   private applyPrePassMetadata(
     prePass: ByteStreamingPrePassResult,

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -474,7 +474,7 @@ export class GeometryProcessor {
         );
         // Loop, not `push(...batch)`: spreading passes one ARGUMENT per mesh,
         // and past V8's ~65k argument ceiling that throws RangeError "Maximum
-        // call stack size exceeded" — real models (~110k meshes) hit it.
+        // call stack size exceeded" — Holter Tower (~110k meshes) hits it.
         const batch = convertMeshCollectionToBatch(collection);
         for (let i = 0; i < batch.length; i++) meshes.push(batch[i]);
       }


### PR DESCRIPTION
## Summary

The synchronous WASM mesh path (`collectMeshesViaPrePass`, reached via `processAdaptive`'s <2MB branch) ignored a caller-supplied federation `sharedRtcOffset` entirely — it always used the model's own detected RTC offset from the pre-pass. The parallel path (`geometry-parallel.ts`) and the streaming path already threaded a caller-supplied `sharedRtcOffset` through correctly. Result: a small (<2MB) federated model rendered at its own per-model RTC origin instead of the shared federation origin its siblings use.

The code carried a comment claiming this was fine because "infrastructure models with large coordinates are always >2MB" — that assumption doesn't hold in general (small federated models exist) and is the same family of assumption #3455 disproved for the streaming fallback. This PR removes the gap rather than defending the comment.

## Fix

Mirrors `geometry-parallel.ts`'s existing `useSharedRtc` pattern (around `sendStreamStartIfReady`):

```ts
const useSharedRtc = sharedRtcOffset != null;
const rtcX = useSharedRtc ? sharedRtcOffset.x : prepassMeta.rtcOffset[0];
...
const effectiveNeedsShift = useSharedRtc ? true : prepassMeta.needsShift;
```

- `applyPrePassMetadata` now takes an optional second `sharedRtcOffset` param, computes the effective `{x, y, z, needsShift}` (shared value when present, else the pre-pass's own detected offset; `needsShift` forced `true` when shared), applies it to the coordinate handler, and returns it.
- `collectMeshesViaPrePass` takes the same optional param, threads it into `applyPrePassMetadata`, and uses the returned `{x, y, z, needsShift}` (instead of the pre-pass's raw values) as the corresponding `processGeometryBatch` arguments.
- `processAdaptive`'s sync branch now passes `options.sharedRtcOffset` through, and the stale "sync path does not support sharedRtcOffset" comment is removed.

## Out of scope

`packages/geometry/src/geometry-native.ts` (the native/Tauri path) was **not touched**. It has the same class of gap but is a separate sibling issue.

## Relationship to #3455 (open, not touched)

This branch is based on `upstream/main` and does **not** include #3455's streaming-path fix. `gh pr diff 3455` shows it also modifies `packages/geometry/src/index.ts` around `applyPrePassMetadata`'s call site inside `processStreamingBytes` (adding a second parameter there too, plus capturing the return value). Both PRs touch the same function's signature and neighboring call sites, so **merging both will conflict** — merge order should be deliberate. Reconciling them would mean: take `applyPrePassMetadata`'s new signature/return-object shape from whichever PR merges first, then update the *other* PR's call site (`processStreamingBytes` for #3455, or nothing further for this PR since `processAdaptive`'s sync branch is this PR's own call site) to pass its own `sharedRtcOffset` and consume the returned `{x, y, z, needsShift}` the same way `collectMeshesViaPrePass` does here.

## Testing

RED (before fix, `geometry-processor-sync-shared-rtc.test.ts` against unmodified `index.ts`):
```
AssertionError: expected 10 to be 100 // Object.is equality
```
(the mock's `processGeometryBatch` received the model's own detected `rtcOffset` `[10, 20, 30]` instead of the caller-supplied `{x:100, y:200, z:300}`)

GREEN (after fix): `1 passed (1)`

- Sibling `geometry-processor-streaming.test.ts`: `2 passed (2)` — unaffected.
- Full geometry suite: `36 files, 365 tests passed`.
- `packages/geometry` typecheck (`node ../../scripts/typecheck-tests.mjs` + `tsc --noEmit`): clean.
- `node scripts/check-module-size.mjs`: `OK` — `packages/geometry/src/index.ts` is exactly at its pinned budget (1551 lines); the fix's net line growth was paid for by condensing a few adjacent comments in the same file (no other files' budgets touched).

Refs #3455