### PR TITLE
fix(query): PropertyTable.getProperties drops a property set on a same-named collision

### DIFF
--- a/.changeset/query-getproperties-samename-pset-drop.md
+++ b/.changeset/query-getproperties-samename-pset-drop.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/query': patch
+---
+
+Fix `PropertyTable.getProperties` (and `QueryInterface.getProperties`, which calls through it) silently dropping a property set when an entity carries two `IfcPropertySet`s that share the same name.
+
+An entity can legitimately carry two same-named property sets — two `IfcRelDefinesByProperties` pointing at distinct `IfcPropertySet`s. `getProperty` already scans every same-named set for this exact shape (#2907). `getProperties` did not: it keyed its result by pset name alone, so the second same-named set silently overwrote the first in the returned `Map`, and every property that lived only in the overwritten set vanished with no signal that anything went missing.
+
+Same-named sets are now merged into one entry per name, with the earlier set's values winning on a key collision — matching `getProperty`'s own first-match-wins order.

--- a/packages/query/src/property-table.ts
+++ b/packages/query/src/property-table.ts
@@ -59,7 +59,16 @@ export class PropertyTable {
   }
 
   /**
-   * Get all properties for entity
+   * Get all properties for entity, one entry per distinct pset NAME.
+   *
+   * An entity can carry two same-named property sets (two
+   * `IfcRelDefinesByProperties` pointing at distinct `IfcPropertySet`s — the
+   * same shape `getProperty`, above, scans through). Keying the result
+   * `Map` by name alone would let the later same-named set overwrite the
+   * earlier one, silently dropping every property that lived only in the
+   * set that got overwritten. Merge same-named sets' properties instead —
+   * earlier-set values win on a key collision, matching `getProperty`'s own
+   * first-match-wins order above.
    */
   getProperties(entityId: number): Map<string, PropertySet> {
     const result = new Map<string, PropertySet>();
@@ -68,9 +77,16 @@ export class PropertyTable {
 
     for (const setId of propertySetIds) {
       const pset = this.propertySets.get(setId);
-      if (pset) {
+      if (!pset) continue;
+      const existing = result.get(pset.name);
+      if (!existing) {
         result.set(pset.name, pset);
+        continue;
       }
+      if (existing === pset) continue; // same pset shared across entities
+      const merged = new Map(pset.properties);
+      for (const [key, value] of existing.properties) merged.set(key, value); // earlier wins
+      result.set(pset.name, { name: pset.name, properties: merged });
     }
 
     return result;

--- a/packages/query/test/property-table.test.ts
+++ b/packages/query/test/property-table.test.ts
@@ -148,6 +148,35 @@ describe('PropertyTable', () => {
     expect(all.size).toBe(0);
   });
 
+  // getProperties keys its result Map by pset NAME. Two IfcRelDefinesByProperties
+  // pointing at distinct IfcPropertySets that happen to share a name (the same
+  // shape #2907 fixed for getProperty, immediately above) collide on that key:
+  // the second same-named set silently overwrites the first instead of both
+  // being visible, so a real property is dropped from the result with no
+  // signal that anything went missing.
+  it('should not drop a property set when the entity carries two same-named psets (#2907 shape)', () => {
+    const table = makeTable();
+    table.addPropertySet(100, makePropSet('Pset_WallCommon', new Map([
+      ['IsExternal', { type: 'boolean', value: true }],
+    ])));
+    table.addPropertySet(101, makePropSet('Pset_WallCommon', new Map([
+      ['FireRating', { type: 'string', value: '2HR' }],
+    ])));
+    table.associatePropertySet(1, 100);
+    table.associatePropertySet(1, 101);
+
+    const all = table.getProperties(1);
+    // Both property sets are associated with the entity; the properties from
+    // BOTH must be reachable from the result, not just whichever set the
+    // dedup happened to keep.
+    const allProps = new Set<string>();
+    for (const pset of all.values()) {
+      for (const key of pset.properties.keys()) allProps.add(key);
+    }
+    expect(allProps.has('IsExternal')).toBe(true);
+    expect(allProps.has('FireRating')).toBe(true);
+  });
+
   // ── findEntities ──────────────────────────────────────────────
 
   it('should find entities matching a property value', () => {


### PR DESCRIPTION
## Summary

- `PropertyTable.getProperties` (`packages/query/src/property-table.ts`) keyed its result `Map<string, PropertySet>` by pset *name* alone. An entity carrying two `IfcPropertySet`s that share a name (two `IfcRelDefinesByProperties`) — the exact shape `getProperty` was already fixed to handle in #2907 — had the second same-named set silently overwrite the first, so every property that lived only in the overwritten set vanished from the result with no signal anything was lost.
- Fix: same-named sets are now merged into one entry per name, earlier-set values winning on a key collision (matching `getProperty`'s own first-match-wins order), instead of one set replacing the other.

## Evidence

Concrete input: entity `1` associated with two `Pset_WallCommon` sets — one carrying `IsExternal`, the other `FireRating`.

- Before the fix: `getProperties(1)` returns a `Map` with one `Pset_WallCommon` entry holding only `FireRating` (the last-associated set wins) — `IsExternal` is gone, with no error or indication.
- RED: added `packages/query/test/property-table.test.ts` — "should not drop a property set when the entity carries two same-named psets (#2907 shape)" — failed against the un-fixed code (`expected false to be true`, `IsExternal` missing).
- GREEN: after the fix, both `IsExternal` and `FireRating` are reachable from `getProperties(1)`.
- No existing test asserted the buggy (lossy) behaviour — the only prior `getProperties` test used two *distinctly*-named psets, so the collision path was untested.

## Checks run

- `pnpm exec vitest run` in `packages/query`: 222/222 passing (incl. the new test and all pre-existing ones).
- `pnpm run typecheck` in `packages/query`: OK.
- `node scripts/check-module-size.mjs` from repo root: OK, 0 new files over budget.
- Changeset added: `.changeset/query-getproperties-samename-pset-drop.md` (patch, `@ifc-lite/query`).

## Siblings checked

`findEntities` (same file) already dedupes correctly across same-named psets per entity (pinned by "should report an entity once when two same-named psets both match"). `getProperty` already handles the same-name case (#2907). `getProperties` was the one sibling still lossy on this shape.

## Test plan

- [x] New unit test reproduces the bug (RED) and passes after the fix (GREEN)
- [x] Full `@ifc-lite/query` test suite green
- [x] `check-module-size.mjs` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436