### PR TITLE
fix(parser): swapped attribute slots dropped every IfcRelAssociatesMaterial

### DIFF
--- a/.changeset/relationship-extractor-associates-material-slots.md
+++ b/.changeset/relationship-extractor-associates-material-slots.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Fix the legacy `RelationshipExtractor.extractRelationships()` silently dropping every `IfcRelAssociatesMaterial` relationship.
+
+Its "standard" attribute-slot branch assumed `RelatingObject` sits at attribute index 4 and `RelatedObjects` at index 5 — true for `IfcRelAggregates`, but backwards for `IfcRelAssociatesMaterial`: `RelatedObjects` (a list) is inherited from `IfcRelAssociates` at index 4, and `RelatingMaterial` (a single reference) is `IfcRelAssociatesMaterial`'s own attribute at index 5. Reading them swapped meant the list failed the "is this a number" check and the single reference failed the "is this an array" check, so `extractRelationship()` always returned `null` for this type — every material association vanished from the legacy `parse()` path's `relationships` array with no warning.
+
+`IfcRelAssociatesMaterial` now gets its own branch (`RelatedObjects` at 4, `RelatingMaterial` at 5), matching IFC4's `IfcRelAssociates`/`IfcRelAssociatesMaterial` schema.

--- a/packages/parser/src/relationship-extractor.test.ts
+++ b/packages/parser/src/relationship-extractor.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { EntityExtractor } from './entity-extractor.js';
+import { RelationshipExtractor } from './relationship-extractor.js';
+import type { EntityRef, IfcEntity } from './types.js';
+
+/** Build one entity map entry by extracting a single STEP record. */
+function extract(expressId: number, type: string, record: string): IfcEntity {
+  const bytes = new TextEncoder().encode(record);
+  const ref: EntityRef = {
+    expressId,
+    type,
+    byteOffset: 0,
+    byteLength: bytes.length,
+    lineNumber: 1,
+  };
+  const entity = new EntityExtractor(bytes).extractEntity(ref);
+  if (!entity) throw new Error(`failed to extract #${expressId}`);
+  return entity;
+}
+
+describe('RelationshipExtractor / IfcRelAssociatesMaterial', () => {
+  // Schema (IFC4, IFC4_ADD2_TC1.exp):
+  //   ENTITY IfcRelAssociates SUBTYPE OF (IfcRelationship);
+  //     RelatedObjects : SET [1:?] OF IfcDefinitionSelect;      -- inherited, slot [4]
+  //   ENTITY IfcRelAssociatesMaterial SUBTYPE OF (IfcRelAssociates);
+  //     RelatingMaterial : IfcMaterialSelect;                    -- own attribute, slot [5]
+  //
+  // So attribute [4] is the RELATED OBJECTS LIST and [5] is the single
+  // RELATING MATERIAL reference — the reverse of IfcRelAggregates, where [4]
+  // is the single RelatingObject and [5] is the RelatedObjects list. The
+  // extractor's "standard" branch (relatingObject=[4], relatedObjects=[5])
+  // only holds for the IfcRelAggregates shape and silently mis-reads
+  // IfcRelAssociatesMaterial.
+  it('extracts RelatedObjects (list, slot 4) and RelatingMaterial (single ref, slot 5)', () => {
+    const entities = new Map<number, IfcEntity>();
+    entities.set(
+      1,
+      extract(
+        1,
+        'IFCRELASSOCIATESMATERIAL',
+        `#1=IFCRELASSOCIATESMATERIAL('3xJf$b$MP7XLbaHy6XT9EM',$,$,$,(#10,#11),#20);`,
+      ),
+    );
+
+    const relationships = new RelationshipExtractor(entities).extractRelationships();
+    const rel = relationships.find((r) => r.type === 'IFCRELASSOCIATESMATERIAL');
+
+    expect(rel).toBeDefined();
+    expect(rel?.relatingObject).toBe(20); // the material reference, #20
+    expect(rel?.relatedObjects).toEqual([10, 11]); // the related elements
+  });
+});

--- a/packages/parser/src/relationship-extractor.ts
+++ b/packages/parser/src/relationship-extractor.ts
@@ -101,7 +101,20 @@ export class RelationshipExtractor {
       // IfcRelDefinesByProperties: RelatedObjects (4), RelatingPropertyDefinition (5)
       // IfcRelAggregates: RelatingObject (4), RelatedObjects (5)
       // IfcRelContainedInSpatialStructure: RelatedElements (4), RelatingStructure (5)
-      
+      // IfcRelAssociatesMaterial: RelatedObjects (4, inherited from IfcRelAssociates),
+      //   RelatingMaterial (5, own attribute) — the list/single-ref slots are
+      //   swapped relative to IfcRelAggregates. Schema (IFC4_ADD2_TC1.exp):
+      //     ENTITY IfcRelAssociates SUBTYPE OF (IfcRelationship);
+      //       RelatedObjects : SET [1:?] OF IfcDefinitionSelect;
+      //     ENTITY IfcRelAssociatesMaterial SUBTYPE OF (IfcRelAssociates);
+      //       RelatingMaterial : IfcMaterialSelect;
+      //   The "standard" RelatingObject-then-RelatedObjects branch below only
+      //   holds for the IfcRelAggregates shape; applying it here read the
+      //   RelatedObjects list as the (single) relatingObject and the single
+      //   RelatingMaterial reference as the relatedObjects list, so every
+      //   `typeof relatingObject !== 'number'` / `!Array.isArray(relatedObjects)`
+      //   guard below failed and the association was silently dropped (#3253).
+
       let relatingObject: any;
       let relatedObjects: any;
 
@@ -111,6 +124,10 @@ export class RelationshipExtractor {
         relatingObject = this.getAttributeValue(entity, 5);
       } else if (entityTypeUpper === 'IFCRELCONTAINEDINSPATIALSTRUCTURE') {
         // RelatedElements at 4, RelatingStructure at 5
+        relatedObjects = this.getAttributeValue(entity, 4);
+        relatingObject = this.getAttributeValue(entity, 5);
+      } else if (entityTypeUpper === 'IFCRELASSOCIATESMATERIAL') {
+        // RelatedObjects at 4, RelatingMaterial at 5
         relatedObjects = this.getAttributeValue(entity, 4);
         relatingObject = this.getAttributeValue(entity, 5);
       } else {


### PR DESCRIPTION
## Summary

`RelationshipExtractor.extractRelationship()` (the legacy eager `IfcParser.parse()` helper, still exported and wired through `packages/parser/src/index.ts`) has a "standard" branch that reads `RelatingObject` at attribute index 4 and `RelatedObjects` at index 5. That order holds for `IfcRelAggregates`, but is backwards for `IfcRelAssociatesMaterial`.

Per the vendored schema (`packages/codegen/schemas/IFC4_ADD2_TC1.exp`):

```
ENTITY IfcRelAssociates
 SUBTYPE OF (IfcRelationship);
	RelatedObjects : SET [1:?] OF IfcDefinitionSelect;   -- inherited, slot [4]
END_ENTITY;

ENTITY IfcRelAssociatesMaterial
 SUBTYPE OF (IfcRelAssociates);
	RelatingMaterial : IfcMaterialSelect;                -- own attribute, slot [5]
END_ENTITY;
```

So for this entity, attribute `[4]` is the `RelatedObjects` *list* and `[5]` is the single `RelatingMaterial` *reference* — the reverse of `IfcRelAggregates`, where `[4]` is the single `RelatingObject` and `[5]` is the `RelatedObjects` list. Falling through to the "standard" branch swapped the two: the list failed the `typeof relatingObject !== 'number'` guard and the single reference failed the `!Array.isArray(relatedObjects)` guard, so `extractRelationship()` always returned `null` for `IfcRelAssociatesMaterial` — every material association silently vanished from the legacy `parse()` path's `relationships` array, with no warning.

## Evidence

Proved by executing the real parser on a minimal STEP record:

```
#1=IFCRELASSOCIATESMATERIAL('3xJf$b$MP7XLbaHy6XT9EM',$,$,$,(#10,#11),#20);
```

- RED (before fix): `RelationshipExtractor.extractRelationships()` returns `[]` for this entity — logged `Successfully extracted: 0` even though `Relationship type counts: { IFCRELASSOCIATESMATERIAL: 1 }`.
- GREEN (after fix): returns `{ type: 'IFCRELASSOCIATESMATERIAL', relatingObject: 20, relatedObjects: [10, 11] }`.

No existing test exercised `RelationshipExtractor`/`IfcRelAssociatesMaterial`, so nothing pinned the bug.

## Siblings (not fixed here, flagged for awareness)

`IFCRELVOIDSELEMENT` and `IFCRELFILLSELEMENT` also fall through to the same "standard" branch, but their schema shape is different again — both `RelatingBuildingElement`/`RelatedOpeningElement` (and `RelatingOpeningElement`/`RelatedBuildingElement`) are *singular* references, not one-list-one-single like `IfcRelAssociatesMaterial`. `Relationship.relatedObjects` is typed `number[]`, so a single reference always fails `Array.isArray` and these two types always return `null` too — but fixing that cleanly needs a shape change to the `Relationship` interface (singular vs. list `relatedObjects`), which is a public-API-shape decision beyond a slot-index fix, so I left it alone and I'm flagging it here rather than guessing.

## Test plan

- [x] `pnpm exec turbo run build --filter=@ifc-lite/parser`
- [x] `pnpm exec turbo run test --filter=@ifc-lite/parser` — 950 passed, 2 skipped (was 1 new RED failure before the fix)
- [x] `pnpm exec turbo run typecheck --filter=@ifc-lite/parser`
- [x] `node scripts/check-module-size.mjs` — OK, 0 new files over budget

Searched `gh issue list --search` / `gh pr list --state open` for `RelAssociatesMaterial` / `relationship-extractor` before starting; no open issue or PR claims this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)