### PR TITLE
fix(query): EntityNode.property/quantity stop at the first same-named set

### DIFF
--- a/.changeset/entity-node-same-named-set.md
+++ b/.changeset/entity-node-same-named-set.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/query': patch
+---
+
+`EntityNode.property()` and `EntityNode.quantity()` dropped a property or quantity that lived only on the second of two same-named sets on an entity, returning `null` instead.
+
+Two distinct `IfcPropertySet` (or `IfcElementQuantity`) entities sharing the same `Name` is a legitimate model shape — two separate `IfcRelDefinesByProperties` relationships pointing at two different sets that happen to be named alike. The on-demand extraction path used for a raw STEP parse returns one array entry per underlying set rather than merging same-named ones (unlike the columnar `PropertyTable`'s `getForEntity`, which does merge them), so `store.getProperties()`/`store.getQuantities()` can legitimately return two entries with the same `name`.
+
+`property()` and `quantity()` both used `.find(p => p.name === setName)`, which stops at the first same-named set. If that particular set instance lacked the requested property/quantity, the method returned `null` even though a later set with the same name carried it — the same defect fixed in `PropertyTable.getProperty` (#2907), left unfixed in `EntityNode`'s own read path. Both methods now check every same-named set before giving up.

--- a/packages/query/src/entity-node.ts
+++ b/packages/query/src/entity-node.ts
@@ -254,9 +254,19 @@ export class EntityNode {
   }
 
   property(psetName: string, propName: string): PropertyValue | null {
-    const props = this.store.getProperties(this.expressId);
-    const pset = props.find(p => p.name === psetName);
-    return pset?.properties.find(p => p.name === propName)?.value ?? null;
+    // Two distinct IfcPropertySet entities sharing the same Name is a
+    // legitimate model shape, and the on-demand extraction path returns one
+    // array entry per underlying set rather than merging them. `.find()`
+    // would stop at the first same-named set and miss a property that only
+    // lives on a later one with that name (the same defect fixed in
+    // `PropertyTable.getProperty`, #2907) — so every same-named set is
+    // checked here instead.
+    for (const pset of this.store.getProperties(this.expressId)) {
+      if (pset.name !== psetName) continue;
+      const prop = pset.properties.find(p => p.name === propName);
+      if (prop) return prop.value;
+    }
+    return null;
   }
 
   quantities(): QuantitySet[] {
@@ -264,9 +274,14 @@ export class EntityNode {
   }
 
   quantity(qsetName: string, quantityName: string): number | null {
-    const qsets = this.store.getQuantities(this.expressId);
-    const qset = qsets.find(q => q.name === qsetName);
-    return qset?.quantities.find(q => q.name === quantityName)?.value ?? null;
+    // Mirrors property() above: check every same-named quantity set rather
+    // than stopping at the first one.
+    for (const qset of this.store.getQuantities(this.expressId)) {
+      if (qset.name !== qsetName) continue;
+      const quantity = qset.quantities.find(q => q.name === quantityName);
+      if (quantity) return quantity.value;
+    }
+    return null;
   }
 
   private getRelated(relType: RelationshipType, direction: 'forward' | 'inverse'): EntityNode[] {

--- a/packages/query/test/entity-node.test.ts
+++ b/packages/query/test/entity-node.test.ts
@@ -399,6 +399,34 @@ describe('EntityNode', () => {
       const project = new EntityNode(store, 1);
       expect(project.properties()).toEqual([]);
     });
+
+    // Two distinct IfcPropertySet entities sharing the same Name is a
+    // legitimate model shape (two separate IfcRelDefinesByProperties
+    // relationships pointing at two different property sets that happen to
+    // be named alike). The on-demand extraction path used for a raw STEP
+    // parse (columnar-parser.ts's extractPropertiesOnDemand) returns one
+    // array entry per underlying IfcPropertySet, so `store.getProperties`
+    // can legitimately return two entries with the same `name`, each
+    // carrying different properties -- unlike the columnar PropertyTable's
+    // `getForEntity`, which merges same-named sets into one entry (fixed for
+    // the analogous drop in `PropertyTable.getProperties`).
+    it('property() checks every same-named property set, not just the first (regression, mirrors #2907)', () => {
+      const store = buildSpatialStore();
+      const duckStore = {
+        ...store,
+        getProperties: (expressId: number) => {
+          if (expressId !== 10) return store.getProperties(expressId);
+          return [
+            { name: 'Pset_WallCommon', globalId: 'pset-a', properties: [{ name: 'IsExternal', type: PropertyValueType.Boolean, value: true }] },
+            { name: 'Pset_WallCommon', globalId: 'pset-b', properties: [{ name: 'FireRating', type: PropertyValueType.Label, value: 'REI60' }] },
+          ];
+        },
+      };
+      const wall = new EntityNode(duckStore as any, 10);
+      // FireRating only lives on the second same-named pset -- must not be
+      // dropped just because the first same-named pset was checked first.
+      expect(wall.property('Pset_WallCommon', 'FireRating')).toBe('REI60');
+    });
   });
 
   // ── Quantities ────────────────────────────────────────────────
@@ -431,6 +459,25 @@ describe('EntityNode', () => {
       const store = buildSpatialStore();
       const door = new EntityNode(store, 11);
       expect(door.quantities()).toEqual([]);
+    });
+
+    // Same shape as the property() regression above: two distinct
+    // IfcElementQuantity entities sharing the same Name, as returned
+    // unmerged by the on-demand extraction path.
+    it('quantity() checks every same-named quantity set, not just the first', () => {
+      const store = buildSpatialStore();
+      const duckStore = {
+        ...store,
+        getQuantities: (expressId: number) => {
+          if (expressId !== 10) return store.getQuantities(expressId);
+          return [
+            { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', type: QuantityType.Length, value: 5.0 }] },
+            { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'NetSideArea', type: QuantityType.Area, value: 15.0 }] },
+          ];
+        },
+      };
+      const wall = new EntityNode(duckStore as any, 10);
+      expect(wall.quantity('Qto_WallBaseQuantities', 'NetSideArea')).toBe(15.0);
     });
   });
 

--- a/packages/query/test/entity-node.test.ts
+++ b/packages/query/test/entity-node.test.ts
@@ -10,6 +10,7 @@ import {
   PropertyValueType,
   QuantityType,
 } from './mock-store.js';
+import type { IfcStoreBase } from '@ifc-lite/data';
 
 // ── Fixtures ────────────────────────────────────────────────────
 
@@ -412,7 +413,7 @@ describe('EntityNode', () => {
     // the analogous drop in `PropertyTable.getProperties`).
     it('property() checks every same-named property set, not just the first (regression, mirrors #2907)', () => {
       const store = buildSpatialStore();
-      const duckStore = {
+      const duckStore: IfcStoreBase = {
         ...store,
         getProperties: (expressId: number) => {
           if (expressId !== 10) return store.getProperties(expressId);
@@ -422,7 +423,7 @@ describe('EntityNode', () => {
           ];
         },
       };
-      const wall = new EntityNode(duckStore as any, 10);
+      const wall = new EntityNode(duckStore, 10);
       // FireRating only lives on the second same-named pset -- must not be
       // dropped just because the first same-named pset was checked first.
       expect(wall.property('Pset_WallCommon', 'FireRating')).toBe('REI60');
@@ -466,7 +467,7 @@ describe('EntityNode', () => {
     // unmerged by the on-demand extraction path.
     it('quantity() checks every same-named quantity set, not just the first', () => {
       const store = buildSpatialStore();
-      const duckStore = {
+      const duckStore: IfcStoreBase = {
         ...store,
         getQuantities: (expressId: number) => {
           if (expressId !== 10) return store.getQuantities(expressId);
@@ -476,7 +477,7 @@ describe('EntityNode', () => {
           ];
         },
       };
-      const wall = new EntityNode(duckStore as any, 10);
+      const wall = new EntityNode(duckStore, 10);
       expect(wall.quantity('Qto_WallBaseQuantities', 'NetSideArea')).toBe(15.0);
     });
   });


### PR DESCRIPTION
## Summary
- `EntityNode.property(psetName, propName)` and `EntityNode.quantity(qsetName, quantityName)` used `.find(p => p.name === setName)` to locate the named property/quantity set, then looked inside only that one set. Two distinct `IfcPropertySet`/`IfcElementQuantity` entities can legitimately share the same `Name` (two separate `IfcRelDefinesByProperties`/`IfcRelDefinesByQuantity` relationships pointing at differently-scoped sets that happen to be named alike) — the on-demand extraction path used for a raw STEP parse (`columnar-parser.ts`'s `extractPropertiesOnDemand`/`extractQuantitiesOnDemand`) returns one array entry per underlying set with no merging, so `store.getProperties()`/`store.getQuantities()` can return two entries with the same `name`.
- `.find()` stops at the *first* same-named set. If that particular instance lacked the requested member, the method returned `null` even though a *later* same-named set carried it. This is the exact defect `PropertyTable.getProperty` was fixed for in #2907 ("stops at first same-named pset") — left unfixed here in `EntityNode`'s own read path (`packages/query/src/entity-node.ts`), a different, older, thinly-tested file exported from the package's public API.
- Both methods now iterate every same-named set and return the first match found across all of them, instead of stopping at the first set by name.

Sibling check: `QueryResultEntity.getProperty` (`packages/query/src/query-result-entity.ts`) already loops over every pset with `continue`, so it was not affected. `PropertyTable.getProperty`/`getProperties` (`packages/query/src/property-table.ts`) were already fixed by #2907 and (very recently, on `fix-bughunt-3152`, currently open as #3463) — that file is active work so this PR does not touch it.

## Test plan
- [x] `packages/query/test/entity-node.test.ts`: added regression tests for `property()` and `quantity()` using a duck-typed store whose `getProperties`/`getQuantities` return two entries sharing the same set name (mirroring the real on-demand-extraction shape), each entry carrying a different member. RED before the fix (`expected null to be 'REI60'` / `expected null to be 15`), GREEN after.
- [x] `pnpm test` in `packages/query` — 15 files, 223 tests, all pass.
- [x] `pnpm exec tsc --noEmit` in `packages/query` — clean.
- [x] `node scripts/check-module-size.mjs` from repo root — OK, 0 new files over budget.

Refs #2907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property and quantity lookups when multiple sets share the same name.
  * Values are now found even when they appear in a later matching property or quantity set.
  * Preserved support for returning separate entries when distinct sets have identical names.

* **Tests**
  * Added regression coverage for duplicate-named property and quantity sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->