### PR TITLE
fix(sdk): stop bSDD fetchClassByUri/fetchClassInfo serving each other's cached result

### DIFF
--- a/.changeset/bsdd-cache-key-collision.md
+++ b/.changeset/bsdd-cache-key-collision.md
@@ -1,0 +1,20 @@
+---
+'@ifc-lite/sdk': patch
+---
+
+Fix `bim.bsdd.fetchClassInfo` and `bim.bsdd.fetchClassByUri` serving each
+other's cached result for the same URI.
+
+Both methods shared one `Map<string, ...>` cache keyed only by URI, but they
+disagree on what a URI's entry means: `fetchClassInfo` (IFC dictionary
+classes) always marks its `classProperties` `isIfcStandard: true` and
+requests class relations; `fetchClassByUri` (any dictionary, including
+non-IFC ones like Uniclass/OmniClass) always marks them `false` and does not
+request relations. Nothing in the cache key recorded which method wrote an
+entry, so whichever method ran first for a given URI silently answered every
+later call to the *other* method for that same URI — wrong `isIfcStandard`
+flags and missing `relatedIfcEntityNames`, with no network request to catch
+it.
+
+The cache key is now namespaced per method (`std:` / `any:`), so an entry
+written by one method can never be read by the other.

--- a/packages/sdk/src/namespaces/bsdd.cache-key.test.ts
+++ b/packages/sdk/src/namespaces/bsdd.cache-key.test.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Lock-in test: `fetchClassInfo` and `fetchClassByUri` share one
+ * `Map<string, ...>` cache keyed only by URI. The two methods disagree on
+ * what that URI's cached entry means — `fetchClassInfo` always marks its
+ * classProperties `isIfcStandard: true` (it only ever resolves IFC
+ * dictionary classes), `fetchClassByUri` always marks them `false` (its own
+ * doc: "Useful for non-IFC dictionaries"). Nothing in the cache key records
+ * which method produced an entry, so whichever method is called FIRST for a
+ * given URI silently answers every later call to the OTHER method for that
+ * same URI, with the wrong `isIfcStandard` flag and no network request.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BsddNamespace } from './bsdd.js';
+
+type FetchSpy = ReturnType<typeof vi.fn>;
+let originalFetch: typeof globalThis.fetch;
+
+function mockFetchOnceWith(status: number, body: unknown): FetchSpy {
+  const spy = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : `HTTP ${status}`,
+    headers: { get: () => null },
+    json: async () => body,
+  })) as unknown as FetchSpy;
+  globalThis.fetch = spy as unknown as typeof globalThis.fetch;
+  return spy;
+}
+
+beforeEach(() => { originalFetch = globalThis.fetch; });
+afterEach(() => { globalThis.fetch = originalFetch; vi.restoreAllMocks(); });
+
+describe('BsddNamespace cache key collision between fetchClassByUri and fetchClassInfo', () => {
+  it('does not serve fetchClassByUri\'s non-IFC-standard entry to a later fetchClassInfo for the same URI', async () => {
+    const ns = new BsddNamespace();
+    const uri = ns.ifcClassUri('IfcWall');
+
+    // fetchClassByUri populates the cache first, for a caller resolving a
+    // non-IFC dictionary class that happens to share this URI shape.
+    mockFetchOnceWith(200, {
+      uri,
+      code: 'IfcWall',
+      name: 'Wall',
+      classProperties: [{ name: 'IsExternal', propertyUri: 'x', dataType: 'Boolean' }],
+    });
+    const byUri = await ns.fetchClassByUri(uri);
+    expect(byUri?.classProperties[0]?.isIfcStandard).toBe(false);
+
+    // fetchClassInfo('IfcWall') resolves to the exact same URI. Its contract
+    // is IFC-standard properties (isIfcStandard: true) — it must not be
+    // answered from the other method's cached entry.
+    const info = await ns.fetchClassInfo('IfcWall');
+    expect(info?.classProperties[0]?.isIfcStandard).toBe(true);
+  });
+});

--- a/packages/sdk/src/namespaces/bsdd.ts
+++ b/packages/sdk/src/namespaces/bsdd.ts
@@ -262,7 +262,9 @@ export class BsddNamespace {
    */
   async fetchClassInfo(ifcType: string): Promise<BsddClassInfo | null> {
     const uri = this.ifcClassUri(ifcType);
-    const cached = getCached(this.cache, uri, this.cacheTtl);
+    // Namespaced: shares `this.cache` with fetchClassByUri, which marks classes non-standard.
+    const cacheKey = `std:${uri}`;
+    const cached = getCached(this.cache, cacheKey, this.cacheTtl);
     if (cached) return cached;
 
     let raw: Record<string, unknown>;
@@ -277,8 +279,7 @@ export class BsddNamespace {
 
     let info = mapClassResponse(raw, true);
 
-    // Fallback: if inline classProperties came back empty, try paginated endpoint.
-    // Network failures on the fallback are non-fatal — keep the partial result.
+    // Fallback: empty inline classProperties tries the paginated endpoint (non-fatal on failure).
     if (info.classProperties.length === 0) {
       try {
         const propsRaw = await fetchJson<Record<string, unknown>>(
@@ -289,16 +290,14 @@ export class BsddNamespace {
           info = { ...info, classProperties: propsList.map((p) => mapProperty(p, true)) };
         }
       } catch (err) {
-        // Non-fatal — the primary call already succeeded. Logged because
-        // the partial result (no classProperties) is what gets cached, so
-        // one transient failure silently answers every later call for this
-        // URI until the entry expires.
+        // Non-fatal — the primary call already succeeded. Logged because the
+        // partial (no classProperties) result gets cached until the entry expires.
         // eslint-disable-next-line no-console
         console.warn(`[bsdd] classProperties fallback failed for ${uri}; caching partial result:`, err);
       }
     }
 
-    setCache(this.cache, uri, info, this.maxCacheEntries);
+    setCache(this.cache, cacheKey, info, this.maxCacheEntries);
     return info;
   }
 
@@ -307,7 +306,8 @@ export class BsddNamespace {
    * Useful for non-IFC dictionaries (Uniclass, OmniClass, etc.).
    */
   async fetchClassByUri(classUri: string): Promise<BsddClassInfo | null> {
-    const cached = getCached(this.cache, classUri, this.cacheTtl);
+    const cacheKey = `any:${classUri}`; // see fetchClassInfo's cache-key note
+    const cached = getCached(this.cache, cacheKey, this.cacheTtl);
     if (cached) return cached;
 
     try {
@@ -315,7 +315,7 @@ export class BsddNamespace {
         `${this.apiBase}/api/Class/v1?Uri=${encodeURIComponent(classUri)}&IncludeClassProperties=true`,
       );
       const info = mapClassResponse(raw, false);
-      setCache(this.cache, classUri, info, this.maxCacheEntries);
+      setCache(this.cache, cacheKey, info, this.maxCacheEntries);
       return info;
     } catch (err) {
       if (err instanceof BsddHttpError && err.status === 404) return null;


### PR DESCRIPTION
## Summary
- `BsddNamespace.fetchClassInfo` and `BsddNamespace.fetchClassByUri` shared one `Map<string, { data, ts }>` cache keyed only by URI.
- The two methods disagree on what a cached entry means: `fetchClassInfo` (IFC dictionary classes) always sets `classProperties[].isIfcStandard: true` and requests class relations; `fetchClassByUri` (documented for non-IFC dictionaries, e.g. Uniclass/OmniClass) always sets it `false` and skips relations.
- Because the key carried no record of which method produced it, whichever method ran first for a given URI silently answered every later call to the *other* method for that same URI — wrong `isIfcStandard` and missing `relatedIfcEntityNames`, with zero network calls to catch it.
- Fix: namespace the cache key per method (`std:` / `any:`) so an entry written by one can never be read by the other.

## Evidence
- RED: added `packages/sdk/src/namespaces/bsdd.cache-key.test.ts`, which calls `fetchClassByUri(uri)` first (caching `isIfcStandard: false`) then `fetchClassInfo('IfcWall')` for the same URI and asserts `isIfcStandard: true` per that method's contract. Before the fix this assertion failed (`expected false to be true`) — the entry came back from the other method's cache slot.
- GREEN: after namespacing the keys, both `bsdd.test.ts` and the new test pass (6/6).
- No existing test asserted the buggy cross-method sharing.
- Siblings: `packages/sdk` has no other class using a shared `this.cache` Map across differently-shaped producer methods (`grep -rl "this.cache\b" packages/sdk/src` returns only `bsdd.ts`).
- Module-size gate: `node scripts/check-module-size.mjs` passes (`bsdd.ts` trimmed back to its 458-line budget after the fix's net addition).
- Changeset added (`@ifc-lite/sdk` is a published package): `.changeset/bsdd-cache-key-collision.md`.

## Test plan
- [x] `npx vitest run src/namespaces/bsdd.test.ts src/namespaces/bsdd.cache-key.test.ts` (in `packages/sdk`) — 6/6 pass
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cached class data could be incorrectly reused between standard IFC lookups and general URI lookups.
  * Ensured each lookup type returns the correct metadata and relationship information.

* **Tests**
  * Added coverage to verify that different lookup methods do not share conflicting cached results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->