### PR TITLE
fix(query,mcp,cli,sdk,mutations,viewer): one helper for same-named property sets, plus a gate (#3465 family)

### DIFF
--- a/.changeset/dup-pset-lookup-family.md
+++ b/.changeset/dup-pset-lookup-family.md
@@ -14,5 +14,6 @@ Affected symptoms, now fixed:
 - CSV/JSON export with a `Pset.Property` or `Qto.Quantity` column could emit an empty cell instead of the real value, for the same reason.
 - The viewer's advanced-filter query could likewise drop a matching entity from the result count/highlight.
 - Editing a quantity whose base value lived on a second same-named quantity set recorded the wrong "old value" and the wrong create-vs-update classification, which undo relied on.
+- Deleting a property or quantity set that the entity carried twice under the same name removed only the first one's members: the panel showed the whole set gone while the exported file still carried the second one's properties.
 
 All of these now check every same-named set, not just the first, before deciding a property or quantity is absent.

--- a/.changeset/dup-pset-lookup-family.md
+++ b/.changeset/dup-pset-lookup-family.md
@@ -10,7 +10,7 @@
 Fix queries, filters, and CSV/JSON exports that silently dropped or omitted data when an entity carried two property (or quantity) sets with the same name -- e.g. one from the type definition and one from the occurrence, which is valid IFC.
 
 Affected symptoms, now fixed:
-- MCP and CLI entity queries with a property filter (`where_property` / `query_entities` filters) could wrongly exclude a matching entity from the results, with no indication anything was omitted, if the filtered property lived on the entity's second same-named property set.
+- MCP and CLI entity queries with a property filter (`query_entities`, `ifc-lite query --where`) could wrongly exclude a matching entity from the results, with no indication anything was omitted, when the filtered property lived ONLY on the entity's second same-named property set. (When both sets carry it, the filter still reads the first one's value -- see the closing paragraph.)
 - CSV/JSON export with a `Pset.Property` or `Qto.Quantity` column could emit an empty cell instead of the real value, for the same reason.
 - The viewer's advanced-filter query could likewise drop a matching entity from the result count/highlight.
 - `ifc-lite query`'s `--sort`, `--group-by` and `--unique` on a `Pset.Property` path, and `ifc-lite export`'s dotted columns, read only the first same-named set and so sorted, grouped, or exported a blank where a value existed.

--- a/.changeset/dup-pset-lookup-family.md
+++ b/.changeset/dup-pset-lookup-family.md
@@ -17,4 +17,6 @@ Affected symptoms, now fixed:
 - Editing a quantity whose base value lived on a second same-named quantity set recorded the wrong "old value" and the wrong create-vs-update classification, which undo relied on.
 - Deleting a property or quantity set that the entity carried twice under the same name removed only the first one's members: the panel showed the whole set gone while the exported file still carried the second one's properties.
 
-All of these now check every same-named set, not just the first, before deciding a property or quantity is absent.
+All of these now scan every same-named set, not just the first, before deciding a property or quantity is absent.
+
+Which member they then use is still first-match, and that is the remaining gap: when two same-named sets both carry the property, only the first one's value is read. Emitting one cell wants exactly that, but a filter does not -- `ifc-lite query --where Pset_WallCommon.FireRating=REI60` still drops a wall whose first `Pset_WallCommon` says `REI30` and whose second says `REI60`. That behaviour predates this change and is tracked in #3490.

--- a/.changeset/dup-pset-lookup-family.md
+++ b/.changeset/dup-pset-lookup-family.md
@@ -13,6 +13,7 @@ Affected symptoms, now fixed:
 - MCP and CLI entity queries with a property filter (`where_property` / `query_entities` filters) could wrongly exclude a matching entity from the results, with no indication anything was omitted, if the filtered property lived on the entity's second same-named property set.
 - CSV/JSON export with a `Pset.Property` or `Qto.Quantity` column could emit an empty cell instead of the real value, for the same reason.
 - The viewer's advanced-filter query could likewise drop a matching entity from the result count/highlight.
+- `ifc-lite query`'s `--sort`, `--group-by` and `--unique` on a `Pset.Property` path, and `ifc-lite export`'s dotted columns, read only the first same-named set and so sorted, grouped, or exported a blank where a value existed.
 - Editing a quantity whose base value lived on a second same-named quantity set recorded the wrong "old value" and the wrong create-vs-update classification, which undo relied on.
 - Deleting a property or quantity set that the entity carried twice under the same name removed only the first one's members: the panel showed the whole set gone while the exported file still carried the second one's properties.
 

--- a/.changeset/dup-pset-lookup-family.md
+++ b/.changeset/dup-pset-lookup-family.md
@@ -1,0 +1,18 @@
+---
+'@ifc-lite/query': minor
+'@ifc-lite/mcp': patch
+'@ifc-lite/sdk': patch
+'@ifc-lite/cli': patch
+'@ifc-lite/mutations': patch
+'@ifc-lite/viewer': patch
+---
+
+Fix queries, filters, and CSV/JSON exports that silently dropped or omitted data when an entity carried two property (or quantity) sets with the same name -- e.g. one from the type definition and one from the occurrence, which is valid IFC.
+
+Affected symptoms, now fixed:
+- MCP and CLI entity queries with a property filter (`where_property` / `query_entities` filters) could wrongly exclude a matching entity from the results, with no indication anything was omitted, if the filtered property lived on the entity's second same-named property set.
+- CSV/JSON export with a `Pset.Property` or `Qto.Quantity` column could emit an empty cell instead of the real value, for the same reason.
+- The viewer's advanced-filter query could likewise drop a matching entity from the result count/highlight.
+- Editing a quantity whose base value lived on a second same-named quantity set recorded the wrong "old value" and the wrong create-vs-update classification, which undo relied on.
+
+All of these now check every same-named set, not just the first, before deciding a property or quantity is absent.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -695,6 +695,15 @@ jobs:
       # counting and digest logic underneath it.
       - name: Check module-size ratchet gate regressions
         run: node --test scripts/check-module-size.test.mjs scripts/lib/module-size-ratchet.test.mjs
+      # An entity can legitimately carry two distinct property/quantity sets
+      # sharing the same name (type + occurrence). `sets.find(s => s.name ===
+      # x)` only ever sees the first one -- fixed one call site at a time
+      # across #2907, #3463, #3465, and this family's own PR, each rediscovered
+      # independently. This is the shape gate: it fails on a NEW two-step
+      # .find(set) -> .find(property/quantity) on what looks like an entity's
+      # (possibly-repeating) sets, so the next lookup can't reintroduce it.
+      - name: Check for the same-named-property-set .find() shape
+        run: node scripts/check-pset-name-find.mjs
       # The version every Rust crate is published at is the npm version with
       # `rust-major-offset.json`'s major offset applied (#3216). That offset is
       # applied by `scripts/sync-versions.js`, which runs ONCE per release

--- a/apps/viewer/src/sdk/adapters/export-adapter.duplicate-pset-csv.test.ts
+++ b/apps/viewer/src/sdk/adapters/export-adapter.duplicate-pset-csv.test.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An entity can legitimately carry two distinct IfcPropertySets that
+ * share the same name. `resolveColumnValue()` in export-adapter.ts's CSV
+ * export used to do `psets.find(p => p.name === setName)`, which only
+ * ever sees the FIRST same-named set -- a `Pset.Prop` column whose value
+ * lives on the SECOND same-named set silently emitted an empty cell
+ * instead of the value.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { IfcParser } from '@ifc-lite/parser';
+import { createExportAdapter } from './export-adapter.js';
+import { LEGACY_MODEL_ID } from './model-compat.js';
+import type { StoreApi } from './types.js';
+
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+// Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
+// IsExternal, the second (#83) has the FireRating column we export.
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
+#44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
+#82= IFCRELDEFINESBYPROPERTIES('${guid('RDP1')}',$,$,$,(#72),#80);
+#84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
+#85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+function makeStore(dataStore: unknown): StoreApi {
+  return {
+    getState: () => ({ ifcDataStore: dataStore, models: new Map() }),
+    subscribe: () => () => {},
+  } as unknown as StoreApi;
+}
+
+test('export-adapter csv emits the value from the SECOND same-named set, not an empty cell', async () => {
+  const parser = new IfcParser();
+  const buffer = new TextEncoder().encode(MODEL).buffer as ArrayBuffer;
+  const dataStore = await parser.parseColumnar(buffer);
+
+  const adapter = createExportAdapter(makeStore(dataStore));
+  const csv = adapter.csv(
+    [{ modelId: LEGACY_MODEL_ID, expressId: 72 }],
+    { columns: ['name', 'Pset_WallCommon.FireRating'] },
+  );
+
+  const rows = csv.trim().split('\n');
+  assert.equal(rows[1], 'Wall A,REI60');
+});

--- a/apps/viewer/src/sdk/adapters/export-adapter.duplicate-pset-csv.test.ts
+++ b/apps/viewer/src/sdk/adapters/export-adapter.duplicate-pset-csv.test.ts
@@ -13,7 +13,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { IfcParser } from '@ifc-lite/parser';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
 import { createExportAdapter } from './export-adapter.js';
 import { LEGACY_MODEL_ID } from './model-compat.js';
 import type { StoreApi } from './types.js';
@@ -54,7 +54,14 @@ ENDSEC;
 END-ISO-10303-21;
 `;
 
-function makeStore(dataStore: unknown): StoreApi {
+/**
+ * The adapter reads only `ifcDataStore` and `models` off the store, and the
+ * data store here is a REAL one (`parseColumnar` over the STEP above), not a
+ * stub -- so the property sets under test come from the actual extraction
+ * path. Only the surrounding `ViewerState` is shimmed, the same way
+ * `export-adapter.test.ts`'s own CSV fixture store does it.
+ */
+function makeStore(dataStore: IfcDataStore): StoreApi {
   return {
     getState: () => ({ ifcDataStore: dataStore, models: new Map() }),
     subscribe: () => () => {},

--- a/apps/viewer/src/sdk/adapters/export-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/export-adapter.ts
@@ -4,7 +4,7 @@
 
 import type { StoreApi } from './types.js';
 import type { EntityRef, EntityData, PropertySetData, QuantitySetData, ExportBackendMethods } from '@ifc-lite/sdk';
-import { EntityNode } from '@ifc-lite/query';
+import { EntityNode, findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
 import { escapeCsvCell, StepExporter, type StepExportOptions } from '@ifc-lite/export';
 import { getModelForRef, LEGACY_MODEL_ID } from './model-compat.js';
 import { applyAttributeMutationsToEntityData, getMutationViewForModel } from './mutation-view.js';
@@ -203,19 +203,13 @@ export function createExportAdapter(store: StoreApi): ExportBackendMethods {
 
       // Try property sets first
       const psets = getProps();
-      const pset = psets.find(p => p.name === setName);
-      if (pset) {
-        const prop = pset.properties.find(p => p.name === valueName);
-        if (prop?.value != null) return String(prop.value);
-      }
+      const prop = findPropertyInSets(psets, setName, valueName);
+      if (prop?.value != null) return String(prop.value);
 
       // Fall back to quantity sets
       const qsets = getQties();
-      const qset = qsets.find(q => q.name === setName);
-      if (qset) {
-        const qty = qset.quantities.find(q => q.name === valueName);
-        if (qty?.value != null) return String(qty.value);
-      }
+      const qty = findQuantityInSets(qsets, setName, valueName);
+      if (qty?.value != null) return String(qty.value);
 
       return '';
     }

--- a/apps/viewer/src/sdk/adapters/query-adapter.duplicate-pset-filter.test.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.duplicate-pset-filter.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An entity can legitimately carry two distinct IfcPropertySets that
+ * share the same name (e.g. one from the type definition, one from the
+ * occurrence). `queryEntities()`'s property filter in query-adapter.ts
+ * used to do `props.find(p => p.name === filter.psetName)`, which only
+ * ever sees the FIRST same-named set -- an entity whose wanted property
+ * lives on the SECOND same-named set was silently excluded from the
+ * result set, with no indication anything was omitted.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { IfcParser } from '@ifc-lite/parser';
+import { createQueryAdapter } from './query-adapter.js';
+import type { StoreApi } from './types.js';
+
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+// Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
+// IsExternal, the second (#83) has the FireRating we're filtering on.
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
+#44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
+#82= IFCRELDEFINESBYPROPERTIES('${guid('RDP1')}',$,$,$,(#72),#80);
+#84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
+#85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+function makeStore(store: unknown): StoreApi {
+  return {
+    getState: () => ({ ifcDataStore: store, models: new Map() }),
+    subscribe: () => () => {},
+  } as unknown as StoreApi;
+}
+
+test('queryEntities property filter does not silently exclude an entity whose filtered property lives on the SECOND same-named set', async () => {
+  const parser = new IfcParser();
+  const buffer = new TextEncoder().encode(MODEL).buffer as ArrayBuffer;
+  const dataStore = await parser.parseColumnar(buffer);
+
+  const adapter = createQueryAdapter(makeStore(dataStore));
+  const results = adapter.entities({
+    modelId: 'default',
+    types: ['IfcWall'],
+    filters: [{ psetName: 'Pset_WallCommon', propName: 'FireRating', operator: '=', value: 'REI60' }],
+  });
+
+  assert.deepEqual(results.map((e) => e.name), ['Wall A']);
+});
+
+test('queryEntities property filter still matches on the FIRST same-named set', async () => {
+  const parser = new IfcParser();
+  const buffer = new TextEncoder().encode(MODEL).buffer as ArrayBuffer;
+  const dataStore = await parser.parseColumnar(buffer);
+
+  const adapter = createQueryAdapter(makeStore(dataStore));
+  const results = adapter.entities({
+    modelId: 'default',
+    types: ['IfcWall'],
+    filters: [{ psetName: 'Pset_WallCommon', propName: 'IsExternal', operator: '=', value: true }],
+  });
+
+  assert.deepEqual(results.map((e) => e.name), ['Wall A']);
+});

--- a/apps/viewer/src/sdk/adapters/query-adapter.duplicate-pset-filter.test.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.duplicate-pset-filter.test.ts
@@ -14,7 +14,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { IfcParser } from '@ifc-lite/parser';
+import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
 import { createQueryAdapter } from './query-adapter.js';
 import type { StoreApi } from './types.js';
 
@@ -54,9 +54,16 @@ ENDSEC;
 END-ISO-10303-21;
 `;
 
-function makeStore(store: unknown): StoreApi {
+/**
+ * The adapter reads only `ifcDataStore` and `models` off the store, and the
+ * data store here is a REAL one (`parseColumnar` over the STEP above), not a
+ * stub -- so the property sets under test come from the actual extraction
+ * path. Only the surrounding `ViewerState` is shimmed, the same way
+ * `query-adapter.active-filter.test.ts` next door does it.
+ */
+function makeStore(dataStore: IfcDataStore): StoreApi {
   return {
-    getState: () => ({ ifcDataStore: store, models: new Map() }),
+    getState: () => ({ ifcDataStore: dataStore, models: new Map() }),
     subscribe: () => () => {},
   } as unknown as StoreApi;
 }

--- a/apps/viewer/src/sdk/adapters/query-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.ts
@@ -17,7 +17,7 @@ import type {
   QueryBackendMethods,
 } from '@ifc-lite/sdk';
 import type { StoreApi } from './types.js';
-import { EntityNode } from '@ifc-lite/query';
+import { EntityNode, findPropertyInSets } from '@ifc-lite/query';
 import { IfcTypeEnum, IfcTypeEnumFromString } from '@ifc-lite/data';
 import { getModelForRef, getAllModelEntries } from './model-compat.js';
 import {
@@ -242,9 +242,7 @@ export function createQueryAdapter(store: StoreApi): QueryBackendMethods {
       for (const filter of descriptor.filters) {
         filtered = filtered.filter(entity => {
           const props = getCachedProps(entity.ref);
-          const pset = props.find(p => p.name === filter.psetName);
-          if (!pset) return false;
-          const prop = pset.properties.find(p => p.name === filter.propName);
+          const prop = findPropertyInSets(props, filter.psetName, filter.propName);
           if (!prop) return false;
           if (filter.operator === 'exists') return true;
 

--- a/packages/cli/src/commands/duplicate-pset-lookup.test.ts
+++ b/packages/cli/src/commands/duplicate-pset-lookup.test.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An entity can legitimately carry two distinct property (or quantity)
+ * sets that share one name -- e.g. "Pset_WallCommon" once from the type
+ * definition and once from the occurrence. The `query` command's helpers
+ * used to resolve such a set with `props.find((p: any) => p.name === ...)`,
+ * which only ever sees the FIRST one: a `--where` filter silently excluded
+ * an entity whose property lived on the second set, and `--sort` on a
+ * dotted path sorted it as if it had no value at all.
+ *
+ * The typed `(p: any) =>` parameter is why these sites outlived the sweep
+ * that converted every other one: `check-pset-name-find.mjs` matched only a
+ * bare arrow parameter, so it reported the whole repo clean while these
+ * stood. The helpers now go through `findPropertyInSets` /
+ * `findQuantityInSets`, which scan every same-named set.
+ *
+ * `bim` is faked rather than parsed from IFC because these helpers touch it
+ * only through `properties(ref)` / `quantities(ref)`; the equivalent
+ * end-to-end path over a real duplicate-pset file is covered by
+ * `headless-backend-duplicate-pset-filter.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyWhereFilter, parseWhereFilter } from './query.js';
+import { sortEntities } from './query-aggregation.js';
+
+/** Wall A carries Pset_WallCommon twice; only the SECOND has FireRating. */
+const PROPS: Record<string, unknown[]> = {
+  wallA: [
+    { name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: true }] },
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI60' }] },
+  ],
+  wallB: [
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI30' }] },
+  ],
+};
+
+/** Wall A carries Qto_WallBaseQuantities twice; only the SECOND has Width. */
+const QUANTITIES: Record<string, unknown[]> = {
+  wallA: [
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 4 }] },
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Width', value: 9 }] },
+  ],
+  wallB: [
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Width', value: 1 }] },
+  ],
+};
+
+const bim = {
+  properties: (ref: string) => PROPS[ref] ?? [],
+  quantities: (ref: string) => QUANTITIES[ref] ?? [],
+};
+
+const wallA = { ref: 'wallA', name: 'Wall A' };
+const wallB = { ref: 'wallB', name: 'Wall B' };
+
+describe('applyWhereFilter with two same-named property sets', () => {
+  it('keeps an entity whose filtered property lives on the second same-named pset', () => {
+    const parsed = parseWhereFilter('Pset_WallCommon.FireRating=REI60');
+    expect(applyWhereFilter([wallA, wallB], parsed, bim).map(e => e.ref)).toEqual(['wallA']);
+  });
+
+  it('keeps it for an existence filter too', () => {
+    const parsed = parseWhereFilter('Pset_WallCommon.FireRating');
+    expect(applyWhereFilter([wallA, wallB], parsed, bim).map(e => e.ref)).toEqual(['wallA', 'wallB']);
+  });
+
+  it('still excludes an entity where no same-named set carries the property', () => {
+    const parsed = parseWhereFilter('Pset_WallCommon.LoadBearing');
+    expect(applyWhereFilter([wallA, wallB], parsed, bim)).toEqual([]);
+  });
+});
+
+describe('sortEntities on a dotted path spread across two same-named sets', () => {
+  it('sorts by a property that lives on the second same-named pset', () => {
+    const sorted = sortEntities([wallB, wallA], 'Pset_WallCommon.FireRating', false, bim);
+    expect(sorted.map(e => e.ref)).toEqual(['wallB', 'wallA']);
+  });
+
+  it('sorts by a quantity that lives on the second same-named qset', () => {
+    const sorted = sortEntities([wallA, wallB], 'Qto_WallBaseQuantities.Width', false, bim);
+    expect(sorted.map(e => e.ref)).toEqual(['wallB', 'wallA']);
+  });
+});

--- a/packages/cli/src/commands/export.ts
+++ b/packages/cli/src/commands/export.ts
@@ -14,6 +14,7 @@ import { writeFile, readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { GeometryProcessor, isNoRenderGeometryError } from '@ifc-lite/geometry';
 import { countGlbMeshes, escapeCsvCell } from '@ifc-lite/export';
+import { findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
 import { createHeadlessContext } from '../loader.js';
 import { getFlag, hasFlag, fatal, writeOutput, validateLimit } from '../output.js';
 import { logger } from '../logger.js';
@@ -85,19 +86,13 @@ function resolveColumnValue(entity: any, col: string, bim: any): unknown {
 
     // Search property sets
     const props = bim.properties(entity.ref);
-    const pset = props.find((p: any) => p.name === setName);
-    if (pset) {
-      const prop = pset.properties.find((p: any) => p.name === valueName);
-      if (prop?.value != null) return prop.value;
-    }
+    const prop = findPropertyInSets<any>(props, setName, valueName);
+    if (prop?.value != null) return prop.value;
 
     // Search quantity sets
     const qsets = bim.quantities(entity.ref);
-    const qset = qsets.find((q: any) => q.name === setName);
-    if (qset) {
-      const qty = qset.quantities.find((q: any) => q.name === valueName);
-      if (qty?.value != null) return qty.value;
-    }
+    const qty = findQuantityInSets<any>(qsets, setName, valueName);
+    if (qty?.value != null) return qty.value;
     return null;
   }
 

--- a/packages/cli/src/commands/query-aggregation.ts
+++ b/packages/cli/src/commands/query-aggregation.ts
@@ -7,6 +7,8 @@
  * and standard QTO maps.
  */
 
+import { findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
+
 /**
  * Standard IFC quantity set definitions — maps entity type to its standard Qto_ sets
  * and the quantities within each set. Used for disambiguation warnings.
@@ -96,13 +98,11 @@ export function sortEntities(entities: any[], sortBy: string, descending: boolea
       const [psetName, propName] = sortBy.split('.', 2);
       const getVal = (e: any) => {
         const props = bim.properties(e.ref);
-        const pset = props.find((p: any) => p.name === psetName);
-        const prop = pset?.properties?.find((p: any) => p.name === propName);
+        const prop = findPropertyInSets<any>(props, psetName, propName);
         if (prop?.value != null) return prop.value;
         // Also check quantity sets
         const qsets = bim.quantities(e.ref);
-        const qset = qsets.find((q: any) => q.name === psetName);
-        const qty = qset?.quantities?.find((q: any) => q.name === propName);
+        const qty = findQuantityInSets<any>(qsets, psetName, propName);
         return qty?.value ?? null;
       };
       valA = getVal(a);

--- a/packages/cli/src/commands/query-output.ts
+++ b/packages/cli/src/commands/query-output.ts
@@ -7,6 +7,7 @@
  * aggregation, group-by, table rendering, and JSON serialization.
  */
 
+import { findPropertyInSets } from '@ifc-lite/query';
 import { printJson, formatTable, hasFlag, fatal } from '../output.js';
 import { getQuantityValue } from './query-aggregation.js';
 
@@ -203,8 +204,7 @@ export function outputGroupBy(entities: any[], groupByKey: string, sumQuantity: 
       // PsetName.PropName
       const [psetName, propName] = groupByKey.split('.', 2);
       const props = bim.properties(e.ref);
-      const pset = props.find((p: any) => p.name === psetName);
-      const prop = pset?.properties?.find((p: any) => p.name === propName);
+      const prop = findPropertyInSets<any>(props, psetName, propName);
       groupValue = prop?.value != null ? String(prop.value) : `(no ${propName})`;
     } else {
       groupValue = e[groupByKey] ?? `(no ${groupByKey})`;

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -10,6 +10,7 @@
  * classifications, attributes, relationships, type properties.
  */
 
+import { findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
 import { createHeadlessContext } from '../loader.js';
 import { printJson, getFlag, hasFlag, fatal, validateLimit } from '../output.js';
 import { STANDARD_QTO_MAP, sortEntities } from './query-aggregation.js';
@@ -76,24 +77,18 @@ export function applyWhereFilter(entities: any[], parsed: ReturnType<typeof pars
   return entities.filter(e => {
     // First try property sets
     const props = bim.properties(e.ref);
-    const pset = props.find((p: any) => p.name === parsed.psetName);
-    if (pset) {
-      const prop = pset.properties.find((p: any) => p.name === parsed.propName);
-      if (prop) {
-        if (parsed.operator === 'exists') return true;
-        return compareValues(prop.value, parsed.operator, parsed.value);
-      }
+    const prop = findPropertyInSets<any>(props, parsed.psetName, parsed.propName);
+    if (prop) {
+      if (parsed.operator === 'exists') return true;
+      return compareValues(prop.value, parsed.operator, parsed.value);
     }
 
     // B3: Also search quantity sets
     const qsets = bim.quantities(e.ref);
-    const qset = qsets.find((q: any) => q.name === parsed.psetName);
-    if (qset) {
-      const qty = qset.quantities.find((q: any) => q.name === parsed.propName);
-      if (qty) {
-        if (parsed.operator === 'exists') return true;
-        return compareValues(qty.value, parsed.operator, parsed.value);
-      }
+    const qty = findQuantityInSets<any>(qsets, parsed.psetName, parsed.propName);
+    if (qty) {
+      if (parsed.operator === 'exists') return true;
+      return compareValues(qty.value, parsed.operator, parsed.value);
     }
 
     return false;
@@ -330,8 +325,7 @@ export async function queryCommand(args: string[]): Promise<void> {
 
       for (const e of entities) {
         const psets = bim.properties(e.ref);
-        const pset = psets.find((p: any) => p.name === psetName);
-        const prop = pset?.properties?.find((p: any) => p.name === propName);
+        const prop = findPropertyInSets<any>(psets, psetName, propName);
         const val = prop?.value != null ? String(prop.value) : '(no value)';
         valueCounts.set(val, (valueCounts.get(val) ?? 0) + 1);
       }

--- a/packages/cli/src/commands/stats-aggregation.test.ts
+++ b/packages/cli/src/commands/stats-aggregation.test.ts
@@ -94,6 +94,20 @@ describe('getPropertyValue', () => {
     expect(getPropertyValue(bim, 1, 'Pset_WallCommon', 'IsExternal')).toBeUndefined();
     expect(getPropertyValue(bim, 99, 'Pset_WallCommon', 'IsExternal')).toBeUndefined();
   });
+
+  it('finds a property on a SECOND same-named pset when the first same-named pset lacks it', () => {
+    // Two distinct IfcPropertySets named "Pset_WallCommon" on one entity is
+    // legitimate IFC (e.g. one via the type definition, one via the
+    // occurrence) -- a lookup that only checked the first same-named pset
+    // would wrongly report FireRating missing here.
+    const bim = fakeBim({}, {
+      1: [
+        { name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: true }] },
+        { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI60' }] },
+      ],
+    });
+    expect(getPropertyValue(bim, 1, 'Pset_WallCommon', 'FireRating')).toBe('REI60');
+  });
 });
 
 describe('isTruthyIfcBoolean', () => {

--- a/packages/cli/src/commands/stats-aggregation.ts
+++ b/packages/cli/src/commands/stats-aggregation.ts
@@ -9,6 +9,8 @@
  * these to the SDK's `BimContext`.
  */
 
+import { findPropertyInSets } from '@ifc-lite/query';
+
 export interface QuantitySet {
   name: string;
   quantities: Array<{ name: string; value: unknown }>;
@@ -57,13 +59,12 @@ export function sumQuantity<R>(bim: QuantityBim<R>, refs: R[], quantityNames: st
 /** Read a single property's value out of a named property set, or undefined. */
 export function getPropertyValue<R>(bim: PropertyBim<R>, ref: R, psetName: string, propName: string): unknown {
   try {
-    const psets = bim.properties(ref);
-    for (const pset of psets) {
-      if (pset.name === psetName) {
-        const prop = pset.properties?.find(p => p.name === propName);
-        if (prop) return prop.value;
-      }
-    }
+    const psets = bim.properties(ref).filter(
+      (pset): pset is PropertySet & { properties: Array<{ name: string; value: unknown }> } =>
+        pset.properties !== undefined,
+    );
+    const prop = findPropertyInSets(psets, psetName, propName);
+    if (prop) return prop.value;
   } catch {
     // Property not available
   }

--- a/packages/cli/src/headless-backend-duplicate-pset-filter.test.ts
+++ b/packages/cli/src/headless-backend-duplicate-pset-filter.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An entity can legitimately carry two distinct IfcPropertySets that
+ * share the same name (e.g. one from the type definition, one from the
+ * occurrence). `HeadlessBackend.query.entities()`'s property filter
+ * used to do `props.find(p => p.name === filter.psetName)`, which only
+ * ever sees the FIRST same-named set -- an entity whose wanted property
+ * lives on the SECOND same-named set was silently excluded from the
+ * result set, with no indication anything was omitted.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createHeadlessContext } from './loader.js';
+import type { BimContext } from '@ifc-lite/sdk';
+
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+// Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
+// IsExternal, the second (#83) has the FireRating we're filtering on.
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
+#44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
+#82= IFCRELDEFINESBYPROPERTIES('${guid('RDP1')}',$,$,$,(#72),#80);
+#84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
+#85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+let tmp: string;
+let bim: BimContext;
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-cli-dup-pset-filter-'));
+  await writeFile(join(tmp, 'm.ifc'), MODEL, 'utf-8');
+  ({ bim } = await createHeadlessContext(join(tmp, 'm.ifc')));
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('HeadlessBackend query.entities() property filter — two same-named property sets', () => {
+  it('does not silently exclude an entity whose filtered property lives on the SECOND same-named set', () => {
+    const results = bim
+      .query()
+      .byType('IfcWall')
+      .where('Pset_WallCommon', 'FireRating', '=', 'REI60')
+      .toArray();
+
+    expect(results.map((e) => e.name)).toEqual(['Wall A']);
+  });
+
+  it('still matches on the property from the FIRST same-named set', () => {
+    const results = bim
+      .query()
+      .byType('IfcWall')
+      .where('Pset_WallCommon', 'IsExternal', '=', true)
+      .toArray();
+
+    expect(results.map((e) => e.name)).toEqual(['Wall A']);
+  });
+});

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -70,7 +70,7 @@ import {
   listStoreys,
   type GenerateSpacesAllOptions,
 } from '@ifc-lite/create';
-import { EntityNode } from '@ifc-lite/query';
+import { EntityNode, findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
 
 import {
   extractAllEntityAttributes,
@@ -324,9 +324,7 @@ export class HeadlessBackend implements BimBackend {
           for (const filter of descriptor.filters) {
             filtered = filtered.filter(entity => {
               const props = getCachedProps(entity.ref);
-              const pset = props.find(p => p.name === filter.psetName);
-              if (!pset) return false;
-              const prop = pset.properties.find(p => p.name === filter.propName);
+              const prop = findPropertyInSets(props, filter.psetName, filter.propName);
               if (!prop) return false;
               if (filter.operator === 'exists') return true;
               const val = prop.value;
@@ -607,18 +605,12 @@ export class HeadlessBackend implements BimBackend {
         const setName = col.slice(0, dotIdx);
         const valueName = col.slice(dotIdx + 1);
         if (props) {
-          const pset = props.find(p => p.name === setName);
-          if (pset) {
-            const prop = pset.properties.find(p => p.name === valueName);
-            if (prop?.value != null) return String(prop.value);
-          }
+          const prop = findPropertyInSets(props, setName, valueName);
+          if (prop?.value != null) return String(prop.value);
         }
         if (qsets) {
-          const qset = qsets.find(q => q.name === setName);
-          if (qset) {
-            const qty = qset.quantities.find(q => q.name === valueName);
-            if (qty?.value != null) return String(qty.value);
-          }
+          const qty = findQuantityInSets(qsets, setName, valueName);
+          if (qty?.value != null) return String(qty.value);
         }
       }
       return '';

--- a/packages/mcp/src/backend-query-duplicate-pset-filter.test.ts
+++ b/packages/mcp/src/backend-query-duplicate-pset-filter.test.ts
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An entity can legitimately carry two distinct IfcPropertySets that
+ * share the same name (e.g. one from the type definition, one from the
+ * occurrence). `entities()`'s property filter in backend-query.ts used
+ * to do `props.find(p => p.name === filter.psetName)`, which only ever
+ * sees the FIRST same-named set — an entity whose wanted property lives
+ * on the SECOND same-named set was silently excluded from the result
+ * set (not a wrong field: a wrong result set, with no indication
+ * anything was omitted).
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { loadIfcModel } from './loader.js';
+import type { LoadedModel } from './context.js';
+
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+// Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
+// IsExternal, the second (#83) has the FireRating we're filtering on.
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
+#44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
+#82= IFCRELDEFINESBYPROPERTIES('${guid('RDP1')}',$,$,$,(#72),#80);
+#84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
+#85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+let tmp: string;
+let model: LoadedModel;
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-dup-pset-filter-'));
+  await writeFile(join(tmp, 'm.ifc'), MODEL, 'utf-8');
+  model = await loadIfcModel(join(tmp, 'm.ifc'), { modelId: 'm' });
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('entities() property filter — two same-named property sets', () => {
+  it('does not silently exclude an entity whose filtered property lives on the SECOND same-named set', () => {
+    const results = model.bim
+      .query()
+      .byType('IfcWall')
+      .where('Pset_WallCommon', 'FireRating', '=', 'REI60')
+      .toArray();
+
+    expect(results.map((e) => e.name)).toEqual(['Wall A']);
+  });
+
+  it('still matches on the property from the FIRST same-named set', () => {
+    const results = model.bim
+      .query()
+      .byType('IfcWall')
+      .where('Pset_WallCommon', 'IsExternal', '=', true)
+      .toArray();
+
+    expect(results.map((e) => e.name)).toEqual(['Wall A']);
+  });
+});

--- a/packages/mcp/src/backend-query.ts
+++ b/packages/mcp/src/backend-query.ts
@@ -58,7 +58,7 @@ import {
   isQueryableObjectType,
 } from '@ifc-lite/parser';
 import { attributeNamesForSchema } from './schema-tables.js';
-import { EntityNode } from '@ifc-lite/query';
+import { EntityNode, findPropertyInSets } from '@ifc-lite/query';
 
 import { stepText, type CreatedEntity, type PendingOverlay } from './overlay.js';
 
@@ -337,9 +337,7 @@ export function createQueryAdapter(
         for (const filter of descriptor.filters) {
           filtered = filtered.filter((entity) => {
             const props = cachedProps(entity.ref);
-            const pset = props.find((p) => p.name === filter.psetName);
-            if (!pset) return false;
-            const prop = pset.properties.find((p) => p.name === filter.propName);
+            const prop = findPropertyInSets(props, filter.psetName, filter.propName);
             if (!prop) return false;
             if (filter.operator === 'exists') return true;
             const v = normalizeBoolean(prop.value);

--- a/packages/mcp/src/headless-backend-duplicate-pset-csv.test.ts
+++ b/packages/mcp/src/headless-backend-duplicate-pset-csv.test.ts
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An entity can legitimately carry two distinct IfcPropertySets sharing
+ * the same name. `resolveColumn()` in headless-backend.ts's CSV export
+ * used to do `props.find(p => p.name === setName)`, which only ever
+ * sees the FIRST same-named set — a `Pset.Prop` column whose value
+ * lives on the SECOND same-named set silently emitted an empty cell
+ * instead of the value.
+ */
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { loadIfcModel } from './loader.js';
+import type { LoadedModel } from './context.js';
+
+function guid(mnemonic: string): string {
+  return (mnemonic + '0'.repeat(22)).slice(0, 22);
+}
+
+// Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
+// IsExternal, the second (#83) has the FireRating column we export.
+const MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
+#43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
+#44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
+#80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
+#82= IFCRELDEFINESBYPROPERTIES('${guid('RDP1')}',$,$,$,(#72),#80);
+#84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
+#85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+let tmp: string;
+let model: LoadedModel;
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), 'ifc-lite-mcp-dup-pset-csv-'));
+  await writeFile(join(tmp, 'm.ifc'), MODEL, 'utf-8');
+  model = await loadIfcModel(join(tmp, 'm.ifc'), { modelId: 'm' });
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('headless-backend export.csv — two same-named property sets', () => {
+  it('emits the value from the SECOND same-named set, not an empty cell', () => {
+    const wall = model.bim.query().byType('IfcWall').toArray()[0];
+    const csv = model.bim.export.csv([wall.ref], {
+      columns: ['name', 'Pset_WallCommon.FireRating'],
+    });
+
+    const rows = csv.trim().split('\n');
+    expect(rows[1]).toBe('Wall A,REI60');
+  });
+});

--- a/packages/mcp/src/headless-backend.ts
+++ b/packages/mcp/src/headless-backend.ts
@@ -47,6 +47,7 @@ import {
   extractScheduleOnDemand,
 } from '@ifc-lite/parser';
 import { escapeCsvCell, exportToStep, StepExporter, type StepExportOptions } from '@ifc-lite/export';
+import { findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
 import { createQueryAdapter } from './backend-query.js';
 import { overlayFromView, type PendingOverlay } from './overlay.js';
 
@@ -273,18 +274,12 @@ export class HeadlessLikeBackend implements BimBackend {
         const setName = col.slice(0, dot);
         const valueName = col.slice(dot + 1);
         if (props) {
-          const pset = props.find((p) => p.name === setName);
-          if (pset) {
-            const prop = pset.properties.find((p) => p.name === valueName);
-            if (prop?.value != null) return String(prop.value);
-          }
+          const prop = findPropertyInSets(props, setName, valueName);
+          if (prop?.value != null) return String(prop.value);
         }
         if (qsets) {
-          const qset = qsets.find((q) => q.name === setName);
-          if (qset) {
-            const qty = qset.quantities.find((q) => q.name === valueName);
-            if (qty?.value != null) return String(qty.value);
-          }
+          const qty = findQuantityInSets(qsets, setName, valueName);
+          if (qty?.value != null) return String(qty.value);
         }
       }
       return '';

--- a/packages/mutations/src/base-qset-lookup.ts
+++ b/packages/mutations/src/base-qset-lookup.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Find a quantity by (qsetName, quantityName) across every quantity set
+ * carrying that name in `qsets`, first match wins. An entity can
+ * legitimately carry two distinct qsets sharing `qsetName` (one from the
+ * type definition, one from the occurrence) -- `qsets.find(...)?.quantities
+ * .find(...)` only ever sees the first one. Same defect family as
+ * `findQuantityInSets` in `@ifc-lite/query`, duplicated here rather than
+ * imported: `@ifc-lite/query` depends on `@ifc-lite/parser`, which depends
+ * on `@ifc-lite/ifcx`, which depends on `@ifc-lite/mutations` -- taking the
+ * dependency here would be a cycle.
+ */
+
+import type { QuantitySet, Quantity } from '@ifc-lite/data';
+
+export function findQuantityInBaseSets(
+  qsets: readonly QuantitySet[],
+  qsetName: string,
+  quantityName: string,
+): Quantity | undefined {
+  for (const qset of qsets) {
+    if (qset.name !== qsetName) continue;
+    const match = qset.quantities.find(q => q.name === quantityName);
+    if (match) return match;
+  }
+  return undefined;
+}

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -708,17 +708,19 @@ export class MutablePropertyView {
       }
     }
 
-    // A DELETE marker in `deletedPsets` only earns its keep when it is
-    // masking a pset that genuinely exists in the base data — same argument
-    // as `deleteProperty` one level down (see the comment above its own
-    // base-existence check): a purely in-session pset (added via
+    // A DELETE marker in `deletedPsets` only earns its keep when it is masking
+    // a pset that genuinely exists in the base data — same argument as
+    // `deleteProperty` one level down. A purely in-session pset (added via
     // `createPropertySet`, never in the base file) has nothing to mask, so
-    // dropping the pset above already nets to nothing and there is no
-    // deletion to report. Recording it as deleted here told the export
-    // review a pset would be removed when the net change was zero.
+    // dropping it above already nets to nothing: recording a deletion here
+    // told the export review a pset would go when the net change was zero.
+    // EVERY same-named pset: `deletedPsets` masks by name so the panel hides
+    // both, but the DELETE markers the exporter reads are per PROPERTY —
+    // covering only the first left `getForEntity` and `getPropertyValue`
+    // disagreeing on whether the second still exists.
     const existingPsets = this.getBasePropertiesForEntity(entityId);
-    const pset = existingPsets.find(p => p.name === psetName);
-    if (pset) {
+    for (const pset of existingPsets) {
+      if (pset.name !== psetName) continue;
       this.deletedPsets.add(`${entityId}:${psetName}`);
       for (const prop of pset.properties) {
         const key = propertyKey(entityId, psetName, prop.name);
@@ -995,12 +997,10 @@ export class MutablePropertyView {
       }
     }
 
-    // A DELETE marker only earns its keep against a qset that genuinely exists
-    // in the base file - same argument as `deletePropertySet`'s. A purely
-    // in-session qset has nothing to mask, and recording one would tell the
-    // export review a set is being removed when the net change is zero.
-    const baseQset = this.getBaseQuantitiesForEntity(entityId).find(q => q.name === qsetName);
-    if (baseQset) {
+    // Only masks a qset that genuinely exists in the base file, and covers
+    // EVERY same-named one - both arguments as in `deletePropertySet` above.
+    for (const baseQset of this.getBaseQuantitiesForEntity(entityId)) {
+      if (baseQset.name !== qsetName) continue;
       this.deletedQsets.add(`${entityId}:${qsetName}`);
       for (const quantity of baseQset.quantities) {
         this.setQuantityMutation(entityId, quantityKey(entityId, qsetName, quantity.name), { operation: 'DELETE' });

--- a/packages/mutations/src/mutable-property-view.ts
+++ b/packages/mutations/src/mutable-property-view.ts
@@ -13,6 +13,7 @@
  */
 
 import type { PropertyTable, PropertySet, Property, QuantitySet, Quantity } from '@ifc-lite/data';
+import { findQuantityInBaseSets } from './base-qset-lookup.js';
 import { PropertyValueType, QuantityType } from '@ifc-lite/data';
 import type { IfcAttributeValue, PropertyValue, PropertyMutation, QuantityMutation, AttributeMutation, EntityTypeMutation, Mutation, NewEntity, EffectiveChange } from './types.js';
 import { propertyKey, quantityKey, attributeKey, generateMutationId } from './types.js';
@@ -412,14 +413,15 @@ export class MutablePropertyView {
       }
     }
 
-    // Fall back to on-demand extraction or base table
+    // Fall back to on-demand extraction or base table. Scan every same-named
+    // pset (an entity can carry two, e.g. type + occurrence), not just the
+    // first -- see findQuantityInBaseSets's doc for why this doesn't import
+    // @ifc-lite/query's version.
     const basePsets = this.getBasePropertiesForEntity(entityId);
-    const pset = basePsets.find(p => p.name === psetName);
-    if (pset) {
+    for (const pset of basePsets) {
+      if (pset.name !== psetName) continue;
       const prop = pset.properties.find(p => p.name === propName);
-      if (prop) {
-        return prop.value;
-      }
+      if (prop) return prop.value;
     }
 
     return null;
@@ -932,9 +934,7 @@ export class MutablePropertyView {
       oldValue = existingMutation.value ?? null;
       isUpdate = true;
     } else {
-      const baseQuantity = baseQsets
-        .find(q => q.name === qsetName)
-        ?.quantities.find(q => q.name === quantName);
+      const baseQuantity = findQuantityInBaseSets(baseQsets, qsetName, quantName);
       oldValue = baseQuantity ? baseQuantity.value : null;
       isUpdate = baseQuantity !== undefined;
     }

--- a/packages/mutations/test/mutable-property-view.duplicate-pset.test.ts
+++ b/packages/mutations/test/mutable-property-view.duplicate-pset.test.ts
@@ -36,6 +36,53 @@ describe('MutablePropertyView — two same-named property sets', () => {
   });
 });
 
+describe('MutablePropertyView.deletePropertySet — two same-named property sets', () => {
+  it('marks properties on EVERY same-named pset deleted, not just the first', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor((entityId) =>
+      entityId === 1
+        ? [
+            { name: 'Pset_WallCommon', globalId: 'g1', properties: [{ name: 'IsExternal', type: 3, value: true }] },
+            { name: 'Pset_WallCommon', globalId: 'g2', properties: [{ name: 'FireRating', type: 0, value: 'REI60' }] },
+          ]
+        : [],
+    );
+
+    view.deletePropertySet(1, 'Pset_WallCommon');
+
+    // `deletedPsets` masks by NAME, so the panel already hides both sets.
+    expect(view.getForEntity(1)).toEqual([]);
+    // The per-property DELETE markers -- which the STEP exporter reads, and
+    // which `getPropertyValue` answers from -- have to cover both sets, or
+    // the two paths disagree about whether the second set still exists.
+    expect(view.getPropertyValue(1, 'Pset_WallCommon', 'IsExternal')).toBeNull();
+    expect(view.getPropertyValue(1, 'Pset_WallCommon', 'FireRating')).toBeNull();
+  });
+});
+
+describe('MutablePropertyView.deleteQuantitySet — two same-named quantity sets', () => {
+  it('marks quantities on EVERY same-named qset deleted, not just the first', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setQuantityExtractor((entityId) =>
+      entityId === 1
+        ? [
+            { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', type: QuantityType.Length, value: 3 }] },
+            { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossVolume', type: QuantityType.Volume, value: 12.5 }] },
+          ]
+        : [],
+    );
+
+    view.deleteQuantitySet(1, 'Qto_WallBaseQuantities');
+
+    expect(view.getQuantitiesForEntity(1)).toEqual([]);
+    // A quantity on the second same-named qset must not survive the delete:
+    // if it does, re-setting it later resolves an oldValue against a set the
+    // session has already removed.
+    const after = view.setQuantity(1, 'Qto_WallBaseQuantities', 'GrossVolume', 20, QuantityType.Volume);
+    expect(after.oldValue).toBeNull();
+  });
+});
+
 describe('MutablePropertyView.setQuantity — two same-named quantity sets', () => {
   it('resolves oldValue/UPDATE against a quantity on the SECOND same-named base qset', () => {
     const view = new MutablePropertyView(null, 'model-1');

--- a/packages/mutations/test/mutable-property-view.duplicate-pset.test.ts
+++ b/packages/mutations/test/mutable-property-view.duplicate-pset.test.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An entity can legitimately carry two distinct property (or quantity)
+ * sets that share the same name (e.g. one from the type definition, one
+ * from the occurrence). `getPropertyValue()`'s base-table fallback and
+ * `setQuantity()`'s old-value lookup used to do a two-step
+ * `sets.find(s => s.name === setName)` -> `.find(v => v.name === valName)`,
+ * which only ever sees the FIRST same-named set -- a property/quantity
+ * that lives on the SECOND same-named set was wrongly reported missing
+ * (and, for `setQuantity`, wrongly recorded as a CREATE instead of an
+ * UPDATE, with `oldValue: null`, which the undo handler treats as
+ * "nothing to revert to").
+ */
+
+import { describe, expect, it } from 'vitest';
+import { QuantityType } from '@ifc-lite/data';
+import { MutablePropertyView } from '../src/index.js';
+
+describe('MutablePropertyView — two same-named property sets', () => {
+  it('getPropertyValue finds a property on the SECOND same-named base pset', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setOnDemandExtractor((entityId) =>
+      entityId === 1
+        ? [
+            { name: 'Pset_WallCommon', globalId: 'g1', properties: [{ name: 'IsExternal', type: 3, value: true }] },
+            { name: 'Pset_WallCommon', globalId: 'g2', properties: [{ name: 'FireRating', type: 0, value: 'REI60' }] },
+          ]
+        : [],
+    );
+
+    expect(view.getPropertyValue(1, 'Pset_WallCommon', 'FireRating')).toBe('REI60');
+    expect(view.getPropertyValue(1, 'Pset_WallCommon', 'IsExternal')).toBe(true);
+  });
+});
+
+describe('MutablePropertyView.setQuantity — two same-named quantity sets', () => {
+  it('resolves oldValue/UPDATE against a quantity on the SECOND same-named base qset', () => {
+    const view = new MutablePropertyView(null, 'model-1');
+    view.setQuantityExtractor((entityId) =>
+      entityId === 1
+        ? [
+            { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', type: QuantityType.Length, value: 3 }] },
+            { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossVolume', type: QuantityType.Volume, value: 12.5 }] },
+          ]
+        : [],
+    );
+
+    const mutation = view.setQuantity(1, 'Qto_WallBaseQuantities', 'GrossVolume', 20, QuantityType.Volume);
+
+    expect(mutation.type).toBe('UPDATE_QUANTITY');
+    expect(mutation.oldValue).toBe(12.5);
+  });
+});

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -14,3 +14,4 @@ export { EntityQuery, type ComparisonOperator } from './entity-query.js';
 export { EntityNode } from './entity-node.js';
 export { QueryResultEntity } from './query-result-entity.js';
 export { DuckDBIntegration, type SQLResult } from './duckdb-integration.js';
+export { findPropertyInSets, findQuantityInSets } from './pset-lookup.js';

--- a/packages/query/src/pset-lookup.ts
+++ b/packages/query/src/pset-lookup.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An IFC entity can legitimately carry two distinct property (or
+ * quantity) sets that share the same name — e.g. two
+ * `IfcRelDefinesByProperties` relations pointing at two different
+ * "Pset_WallCommon" instances, one via the type definition and one via
+ * the occurrence. A lookup that does `sets.find(s => s.name === name)`
+ * only ever sees the FIRST such set: if the wanted property lives on
+ * the second same-named set, it is wrongly reported missing (or, in a
+ * filter, the whole entity is wrongly dropped from the result).
+ *
+ * These helpers implement the settled semantics (first established by
+ * `PropertyTable.getProperty` in #2907, and mirrored by
+ * `QueryResultEntity.getProperty`): scan EVERY set, skip ones whose
+ * name doesn't match, and within the matching sets return the first
+ * property/quantity whose name matches, in set order. Every reader of
+ * an entity's property/quantity sets should go through these instead
+ * of hand-rolling a two-step `.find`.
+ */
+
+/** Minimal shape a property/quantity needs to be matched by name. */
+interface Named {
+  readonly name: string;
+}
+
+/** Minimal shape a property set needs: a name and a `properties` array. */
+interface PropertySetLike<P extends Named> {
+  readonly name: string;
+  readonly properties: readonly P[];
+}
+
+/** Minimal shape a quantity set needs: a name and a `quantities` array. */
+interface QuantitySetLike<Q extends Named> {
+  readonly name: string;
+  readonly quantities: readonly Q[];
+}
+
+/**
+ * Find a property by (setName, propName) across every property set
+ * carrying that name, first match across the sequence wins. Returns
+ * `undefined` when no same-named set carries a property with that name.
+ */
+export function findPropertyInSets<P extends Named>(
+  sets: readonly PropertySetLike<P>[],
+  setName: string,
+  propName: string,
+): P | undefined {
+  for (const set of sets) {
+    if (set.name !== setName) continue;
+    const match = set.properties.find((p) => p.name === propName);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+/**
+ * Find a quantity by (setName, quantityName) across every quantity set
+ * carrying that name, first match across the sequence wins. Returns
+ * `undefined` when no same-named set carries a quantity with that name.
+ */
+export function findQuantityInSets<Q extends Named>(
+  sets: readonly QuantitySetLike<Q>[],
+  setName: string,
+  quantityName: string,
+): Q | undefined {
+  for (const set of sets) {
+    if (set.name !== setName) continue;
+    const match = set.quantities.find((q) => q.name === quantityName);
+    if (match) return match;
+  }
+  return undefined;
+}

--- a/packages/query/test/pset-lookup.test.ts
+++ b/packages/query/test/pset-lookup.test.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { findPropertyInSets, findQuantityInSets } from '../src/pset-lookup.js';
+
+describe('findPropertyInSets', () => {
+  it('finds a property that only exists on the SECOND same-named set', () => {
+    const sets = [
+      { name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: true }] },
+      { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI60' }] },
+    ];
+
+    const result = findPropertyInSets(sets, 'Pset_WallCommon', 'FireRating');
+
+    expect(result?.value).toBe('REI60');
+  });
+
+  it('returns undefined when no same-named set has the property', () => {
+    const sets = [
+      { name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: true }] },
+      { name: 'Pset_WallCommon', properties: [{ name: 'LoadBearing', value: false }] },
+    ];
+
+    expect(findPropertyInSets(sets, 'Pset_WallCommon', 'FireRating')).toBeUndefined();
+  });
+
+  it('prefers the first matching set when both carry the property', () => {
+    const sets = [
+      { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'first' }] },
+      { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'second' }] },
+    ];
+
+    expect(findPropertyInSets(sets, 'Pset_WallCommon', 'FireRating')?.value).toBe('first');
+  });
+});
+
+describe('findQuantityInSets', () => {
+  it('finds a quantity that only exists on the SECOND same-named set', () => {
+    const sets = [
+      { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 3 }] },
+      { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossVolume', value: 12.5 }] },
+    ];
+
+    const result = findQuantityInSets(sets, 'Qto_WallBaseQuantities', 'GrossVolume');
+
+    expect(result?.value).toBe(12.5);
+  });
+
+  it('returns undefined when no same-named set has the quantity', () => {
+    const sets = [
+      { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 3 }] },
+    ];
+
+    expect(findQuantityInSets(sets, 'Qto_WallBaseQuantities', 'GrossVolume')).toBeUndefined();
+  });
+});

--- a/packages/query/test/pset-lookup.test.ts
+++ b/packages/query/test/pset-lookup.test.ts
@@ -5,9 +5,18 @@
 import { describe, it, expect } from 'vitest';
 import { findPropertyInSets, findQuantityInSets } from '../src/pset-lookup.js';
 
+/**
+ * Real property values are heterogeneous (a boolean `IsExternal` alongside a
+ * string `FireRating`), so the fixtures need this annotation: left to
+ * inference, each set literal gets its OWN value type and the array becomes a
+ * union that cannot unify with the helper's single `P`.
+ */
+type PropSets = { name: string; properties: { name: string; value: string | boolean }[] }[];
+type QtoSets = { name: string; quantities: { name: string; value: number }[] }[];
+
 describe('findPropertyInSets', () => {
   it('finds a property that only exists on the SECOND same-named set', () => {
-    const sets = [
+    const sets: PropSets = [
       { name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: true }] },
       { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI60' }] },
     ];
@@ -18,7 +27,7 @@ describe('findPropertyInSets', () => {
   });
 
   it('returns undefined when no same-named set has the property', () => {
-    const sets = [
+    const sets: PropSets = [
       { name: 'Pset_WallCommon', properties: [{ name: 'IsExternal', value: true }] },
       { name: 'Pset_WallCommon', properties: [{ name: 'LoadBearing', value: false }] },
     ];
@@ -27,7 +36,7 @@ describe('findPropertyInSets', () => {
   });
 
   it('prefers the first matching set when both carry the property', () => {
-    const sets = [
+    const sets: PropSets = [
       { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'first' }] },
       { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'second' }] },
     ];
@@ -38,7 +47,7 @@ describe('findPropertyInSets', () => {
 
 describe('findQuantityInSets', () => {
   it('finds a quantity that only exists on the SECOND same-named set', () => {
-    const sets = [
+    const sets: QtoSets = [
       { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 3 }] },
       { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'GrossVolume', value: 12.5 }] },
     ];
@@ -49,7 +58,7 @@ describe('findQuantityInSets', () => {
   });
 
   it('returns undefined when no same-named set has the quantity', () => {
-    const sets = [
+    const sets: QtoSets = [
       { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Length', value: 3 }] },
     ];
 

--- a/packages/sdk/src/namespaces/export.ts
+++ b/packages/sdk/src/namespaces/export.ts
@@ -11,6 +11,7 @@
  */
 
 import { escapeCsvCell } from '@ifc-lite/export';
+import { findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
 import type { BimBackend, EntityRef, EntityData, PropertySetData, QuantitySetData } from '../types.js';
 
 export interface ExportCsvOptions {
@@ -92,20 +93,14 @@ export class ExportNamespace {
 
           // Try property sets first
           if (psets) {
-            const pset = psets.find(p => p.name === setName);
-            if (pset) {
-              const prop = pset.properties.find(p => p.name === valueName);
-              if (prop?.value != null) { row.push(String(prop.value)); continue; }
-            }
+            const prop = findPropertyInSets(psets, setName, valueName);
+            if (prop?.value != null) { row.push(String(prop.value)); continue; }
           }
 
           // Fall back to quantity sets
           if (qsets) {
-            const qset = qsets.find(q => q.name === setName);
-            if (qset) {
-              const qty = qset.quantities.find(q => q.name === valueName);
-              if (qty?.value != null) { row.push(String(qty.value)); continue; }
-            }
+            const qty = findQuantityInSets(qsets, setName, valueName);
+            if (qty?.value != null) { row.push(String(qty.value)); continue; }
           }
 
           row.push('');
@@ -164,20 +159,14 @@ export class ExportNamespace {
 
           // Try property sets first
           if (psets) {
-            const pset = psets.find(p => p.name === setName);
-            if (pset) {
-              const prop = pset.properties.find(p => p.name === valueName);
-              if (prop?.value != null) { row[col] = prop.value; resolved = true; }
-            }
+            const prop = findPropertyInSets(psets, setName, valueName);
+            if (prop?.value != null) { row[col] = prop.value; resolved = true; }
           }
 
           // Fall back to quantity sets
           if (!resolved && qsets) {
-            const qset = qsets.find(q => q.name === setName);
-            if (qset) {
-              const qty = qset.quantities.find(q => q.name === valueName);
-              if (qty?.value != null) { row[col] = qty.value; resolved = true; }
-            }
+            const qty = findQuantityInSets(qsets, setName, valueName);
+            if (qty?.value != null) { row[col] = qty.value; resolved = true; }
           }
 
           if (!resolved) row[col] = null;

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3816,7 +3816,9 @@
     "QueryBuilder: class",
     "QueryInterface: class",
     "QueryResultEntity: class",
-    "SQLResult: interface"
+    "SQLResult: interface",
+    "findPropertyInSets: function",
+    "findQuantityInSets: function"
   ],
   "@ifc-lite/renderer": [
     "AdapterInfoSnapshot: interface",

--- a/scripts/check-pset-name-find.mjs
+++ b/scripts/check-pset-name-find.mjs
@@ -67,7 +67,7 @@
  * examined nothing, or fail to distinguish a real instance from a for-loop.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isMainEntry } from './lib/is-main-entry.mjs';
@@ -236,7 +236,29 @@ export function runCheck(root, opts = {}) {
   }
   for (const dir of existingSearchDirs) walk(join(root, dir));
 
-  return { ok: violations.length === 0, scanned, violations, grandfathered: knownUnfixed.size };
+  // An allowlist entry that no longer has the shape is worse than useless: it
+  // silently exempts that file forever, so a reintroduced instance would never
+  // be reported. Rescan each entry WITHOUT the allowlist and fail on any that
+  // now come back clean, so the list is forced to shrink as its comment says.
+  const staleAllowlisted = [];
+  for (const rel of knownUnfixed) {
+    const full = join(root, rel);
+    // Absent under this root proves nothing — the tests scan synthetic trees
+    // that contain none of the repo's real files. Only a file that IS here and
+    // scans clean is provably a stale row.
+    if (!existsSync(full)) continue;
+    if (scanText(rel, readFileSync(full, 'utf8'), { knownUnfixed: new Set() }).length === 0) {
+      staleAllowlisted.push(`${rel} (no longer matches -- delete this row)`);
+    }
+  }
+
+  return {
+    ok: violations.length === 0 && staleAllowlisted.length === 0,
+    scanned,
+    violations,
+    staleAllowlisted,
+    grandfathered: knownUnfixed.size,
+  };
 }
 
 function formatViolation(v) {
@@ -255,7 +277,17 @@ if (isMain) {
     process.exit(1);
   }
 
-  if (!result.ok) {
+  if (result.staleAllowlisted.length > 0) {
+    console.error(`
+KNOWN_UNFIXED rows that no longer match. The allowlist exempts a whole file, so
+a stale row turns that file into a permanent blind spot for this bug. Delete
+each row listed below:
+`);
+    for (const s of result.staleAllowlisted) console.error(`  ${s}`);
+    console.error('');
+  }
+
+  if (!result.ok && result.violations.length > 0) {
     console.error(`
 Two-step .find(set by name) -> .find(property/quantity by name) on what looks
 like an entity's property/quantity sets. An entity can legitimately carry two
@@ -267,6 +299,8 @@ from '@ifc-lite/query' (packages/query/src/pset-lookup.ts) instead.
     for (const v of result.violations) console.error(formatViolation(v) + '\n');
     process.exit(1);
   }
+
+  if (!result.ok) process.exit(1);
 
   console.log(
     `check-pset-name-find: OK (${result.scanned.length} files scanned, 0 new violations, ${result.grandfathered} grandfathered)`,

--- a/scripts/check-pset-name-find.mjs
+++ b/scripts/check-pset-name-find.mjs
@@ -107,17 +107,15 @@ const TEST_FILE_RE = /\.test\.(ts|tsx|mts|cts)$/;
 /**
  * Files with a known, still-open instance of this exact shape, left
  * unconverted deliberately because they are mid-flight in another PR this
- * family does not touch:
- *
- *   packages/query/src/entity-node.ts -- fixed by #3465 (EntityNode.property
- *   / .quantity), not yet merged as of this gate landing.
+ * family does not touch. Empty today: #3465 fixed
+ * packages/query/src/entity-node.ts before this gate landed, so there is
+ * nothing left to grandfather.
  *
  * Remove a row here the same PR that removes its `.find` pattern -- this
- * allowlist is meant to shrink to empty, not grow.
+ * allowlist is meant to shrink to empty, not grow, and the staleness check
+ * in runCheck() fails the gate on any row whose file no longer matches.
  */
-export const KNOWN_UNFIXED = new Set([
-  'packages/query/src/entity-node.ts',
-]);
+export const KNOWN_UNFIXED = new Set([]);
 
 /** Variable name plausibly holding an entity's property/quantity sets. */
 const RISKY_VAR_RE = /^(sets|props|psets|qsets|propsets|propertysets|prop_sets|property_sets|quantitysets|quantity_sets)$/i;

--- a/scripts/check-pset-name-find.mjs
+++ b/scripts/check-pset-name-find.mjs
@@ -72,7 +72,17 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isMainEntry } from './lib/is-main-entry.mjs';
 
-const SEARCH_DIRS = ['packages', 'apps'];
+/**
+ * Scanned roots, deliberately NOT a bare `apps` — this must stay a subset of
+ * what can actually trigger the node-tests job. `test.yml`'s filter names
+ * `apps/viewer` and `apps/viewer-embed` individually rather than `apps/**`,
+ * so that broadening it would not drag every landing-page edit through the
+ * lane. Scanning `apps/landing` from here would make the gate read files that
+ * cannot trigger it — `check-ci-path-coverage` fails on exactly that, and it
+ * is right to: a gate that cannot run on a file it guards is absent there,
+ * not merely weak. When a new app is added to that filter, add it here too.
+ */
+const SEARCH_DIRS = ['packages', 'apps/viewer', 'apps/viewer-embed', 'examples'];
 
 const SKIP_DIRS = new Set([
   'node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', '.next', 'target', '.git',

--- a/scripts/check-pset-name-find.mjs
+++ b/scripts/check-pset-name-find.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * An IFC entity can legitimately carry two distinct property (or quantity)
+ * sets that share the same name -- two `IfcRelDefinesByProperties` pointing
+ * at two different "Pset_WallCommon" instances, e.g. one from the type
+ * definition and one from the occurrence. Code that resolves the set with
+ * `sets.find(s => s.name === name)` only ever sees the FIRST such set: if
+ * the wanted property/quantity lives on the SECOND same-named set, it is
+ * wrongly reported missing -- or, in a filter, the whole entity is wrongly
+ * dropped from the result.
+ *
+ * This shape was fixed one instance at a time across six months and (at
+ * last count) five call sites, each rediscovered independently: #2907,
+ * #3463, and this family's own PR converted every reachable one to the
+ * shared `findPropertyInSets`/`findQuantityInSets` helper in
+ * `packages/query/src/pset-lookup.ts`. The point of a gate is that the
+ * SHAPE stops being reachable, not that today's instances are fixed --
+ * otherwise the next property lookup gets written the same way, correctly
+ * following every example around it.
+ *
+ * WHAT THIS CATCHES: a two-step `.find` -- first `.find` locating a set by
+ * `.name ===` inside a variable plausibly holding an entity's property or
+ * quantity sets (its own name contains "pset"/"prop"/"qset"/"quantity", or
+ * it is one of the generic names `sets`/`props`/`psets`/`qsets` used
+ * throughout this family), followed (as one chained expression -- same line
+ * or split across a method-chain's continuation lines -- or via an
+ * intermediate variable within a few lines) by `.find` on that result's
+ * `.properties`/`.quantities`, also comparing `.name ===`. Both steps are
+ * required: a lone `.find(...name === ...)` on some OTHER unique-by-
+ * construction list (`ifc4-pset-definitions.ts`'s definition table,
+ * `COMMON_SCALES`, an enum lookup) has no second step and does not match.
+ *
+ * WHAT THIS DOES NOT CATCH:
+ *  - A `for` loop that scans every same-named set before giving up (the
+ *    CORRECT shape -- see `QueryResultEntity.getProperty` and the fixed
+ *    `stats-aggregation.ts`). Only the two-`.find` collapse is a defect.
+ *  - A lookup keyed by something other than `.name` (id, index).
+ *  - The pattern split across MORE than a few lines, or through a
+ *    function call boundary this script does not trace into.
+ *  - A single `.find` with no matching second `.find` chained to
+ *    `.properties`/`.quantities` -- e.g. checking whether a pset merely
+ *    EXISTS is a different (and correct) question this script leaves alone.
+ *  - `*.test.ts(x)` files: a test asserting "the fixture I just built
+ *    contains X" is a fundamentally different risk than a resolution path
+ *    real callers depend on, and this shape is common, legitimate assertion
+ *    code there (build one pset, `.find` it, check a field).
+ * This is a deliberately NARROW pattern match, not a type-aware analysis:
+ * it is scoped to catch the exact shape that has recurred, and prefers
+ * missing a disguised instance over crying wolf on legitimate code.
+ *
+ * Run via `node scripts/check-pset-name-find.mjs` (CI: node-tests job).
+ * Its own tests (`scripts/check-pset-name-find.test.mjs`) run the unmodified
+ * `runCheck()` against synthetic trees, so the gate can never pass having
+ * examined nothing, or fail to distinguish a real instance from a for-loop.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isMainEntry } from './lib/is-main-entry.mjs';
+
+const SEARCH_DIRS = ['packages', 'apps'];
+
+const SKIP_DIRS = new Set([
+  'node_modules', 'dist', 'pkg', 'build', 'coverage', '.turbo', '.next', 'target', '.git',
+]);
+
+const SOURCE_RE = /\.(ts|tsx|mts|cts)$/;
+const TEST_FILE_RE = /\.test\.(ts|tsx|mts|cts)$/;
+
+/**
+ * Files with a known, still-open instance of this exact shape, left
+ * unconverted deliberately because they are mid-flight in another PR this
+ * family does not touch:
+ *
+ *   packages/query/src/entity-node.ts -- fixed by #3465 (EntityNode.property
+ *   / .quantity), not yet merged as of this gate landing.
+ *
+ * Remove a row here the same PR that removes its `.find` pattern -- this
+ * allowlist is meant to shrink to empty, not grow.
+ */
+export const KNOWN_UNFIXED = new Set([
+  'packages/query/src/entity-node.ts',
+]);
+
+/** Variable name plausibly holding an entity's property/quantity sets. */
+const RISKY_VAR_RE = /^(sets|props|psets|qsets|propsets|propertysets|prop_sets|property_sets|quantitysets|quantity_sets)$/i;
+function looksRisky(varName) {
+  if (RISKY_VAR_RE.test(varName)) return true;
+  const lower = varName.toLowerCase();
+  return lower.includes('pset') || lower.includes('prop') || lower.includes('qset') || lower.includes('quantity');
+}
+
+/** How many logical lines forward to look for the second `.find` when it isn't chained inline. */
+const WINDOW = 6;
+
+const FIND_NAME_RE = /\.find\(\s*\(?(\w+)\)?\s*=>\s*\1\.name\s*===/;
+
+/**
+ * Same-line (post continuation-merge) chain:
+ * `sets.find(p => p.name === x)?.properties.find(p => p.name === y)`.
+ */
+const CHAIN_RE = new RegExp(
+  `(\\w+)${'\\.find\\(\\s*\\(?(\\w+)\\)?\\s*=>\\s*\\2\\.name\\s*==='}[^;\\n]*?\\?\\.\\s*(properties|quantities)\\.find\\(\\s*\\(?(\\w+)\\)?\\s*=>\\s*\\4\\.name\\s*===`,
+);
+
+function safeIsDir(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function relPath(root, full) {
+  return full.slice(root.length + 1).split('\\').join('/');
+}
+
+/**
+ * A chain split across physical lines (`sets\n  .find(...)\n
+ * ?.properties.find(...)`) needs to read as one expression for CHAIN_RE and
+ * the decl-match below to see it, so fold continuation lines (trimmed text
+ * starting with `.`/`?.`) onto the previous logical statement, reporting the
+ * FIRST physical line of the merged statement.
+ */
+function toLogicalLines(text) {
+  const rawLines = text.split('\n');
+  const merged = [];
+  for (let i = 0; i < rawLines.length; i += 1) {
+    const raw = rawLines[i];
+    const trimmed = raw.trim();
+    const isContinuation = merged.length > 0 && (trimmed.startsWith('.') || trimmed.startsWith('?.'));
+    if (isContinuation) {
+      merged[merged.length - 1].text += trimmed;
+    } else {
+      merged.push({ text: raw, line: i + 1 });
+    }
+  }
+  return merged;
+}
+
+/** Scan one file's text for the buggy shape. Returns violation strings (empty if clean/grandfathered). */
+export function scanText(rel, text, { knownUnfixed = KNOWN_UNFIXED } = {}) {
+  if (knownUnfixed.has(rel)) return [];
+  const found = [];
+  const merged = toLogicalLines(text);
+
+  for (let i = 0; i < merged.length; i += 1) {
+    const { text: line, line: lineNo } = merged[i];
+
+    // Case 1: chained in one expression (after continuation-line merging).
+    const chainMatch = CHAIN_RE.exec(line);
+    if (chainMatch && looksRisky(chainMatch[1])) {
+      found.push({ rel, line1: lineNo, text1: line });
+      continue;
+    }
+
+    // Case 2: `const pset = sets.find(p => p.name === x);` then, within a
+    // small window, `pset.properties.find(p => p.name === y)` (optionally
+    // via `pset?.properties`).
+    const declMatch = /^\s*(?:const|let)\s+(\w+)\s*=\s*(\w+)\.find\(/.exec(line);
+    if (!declMatch) continue;
+    const [, psetVar, setsVar] = declMatch;
+    if (!FIND_NAME_RE.test(line)) continue;
+    if (!looksRisky(setsVar)) continue;
+
+    const innerRe = new RegExp(
+      `${psetVar}\\??\\.(properties|quantities)\\??\\.find\\(\\s*\\(?(\\w+)\\)?\\s*=>\\s*\\2\\.name\\s*===`,
+    );
+    for (let j = i + 1; j < Math.min(merged.length, i + 1 + WINDOW); j += 1) {
+      if (innerRe.test(merged[j].text)) {
+        found.push({ rel, line1: lineNo, text1: line, line2: merged[j].line, text2: merged[j].text });
+        break;
+      }
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Walk `root`'s `packages/` and `apps/` trees and scan every non-test
+ * TS/TSX file. Fails closed: an unreadable directory throws rather than the
+ * walk silently skipping it, which would let the gate report success
+ * without having looked at the file that broke the rule.
+ */
+export function runCheck(root, opts = {}) {
+  const knownUnfixed = opts.knownUnfixed ?? KNOWN_UNFIXED;
+  const searchDirs = opts.searchDirs ?? SEARCH_DIRS;
+  const scanned = [];
+  const violations = [];
+
+  function walk(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      throw new Error(`check-pset-name-find: cannot read directory ${dir}: ${err.message}`);
+    }
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+      const full = join(dir, entry.name);
+      const isDir = entry.isDirectory() || (entry.isSymbolicLink() && safeIsDir(full));
+      if (isDir) {
+        walk(full);
+      } else if (SOURCE_RE.test(entry.name) && !TEST_FILE_RE.test(entry.name)) {
+        const rel = relPath(root, full);
+        scanned.push(rel);
+        const text = readFileSync(full, 'utf8');
+        violations.push(...scanText(rel, text, { knownUnfixed }));
+      }
+    }
+  }
+
+  if (!safeIsDir(root)) {
+    throw new Error(`check-pset-name-find: root ${root} does not exist or is not a directory`);
+  }
+  const existingSearchDirs = searchDirs.filter((dir) => safeIsDir(join(root, dir)));
+  if (existingSearchDirs.length === 0) {
+    throw new Error(
+      `check-pset-name-find: none of ${searchDirs.join(', ')} exist under ${root} -- nothing to scan`,
+    );
+  }
+  for (const dir of existingSearchDirs) walk(join(root, dir));
+
+  return { ok: violations.length === 0, scanned, violations, grandfathered: knownUnfixed.size };
+}
+
+function formatViolation(v) {
+  const where = v.line2 ? `${v.rel}:${v.line1} / :${v.line2}` : `${v.rel}:${v.line1}`;
+  const snippet = v.line2 ? `${v.text1.trim()}\n    ${v.text2.trim()}` : v.text1.trim();
+  return `  ${where}\n    ${snippet}`;
+}
+
+const isMain = isMainEntry(import.meta.url);
+if (isMain) {
+  const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+  const result = runCheck(root);
+
+  if (result.scanned.length === 0) {
+    console.error('check-pset-name-find: scanned 0 files -- the walk is broken, not the tree clean');
+    process.exit(1);
+  }
+
+  if (!result.ok) {
+    console.error(`
+Two-step .find(set by name) -> .find(property/quantity by name) on what looks
+like an entity's property/quantity sets. An entity can legitimately carry two
+same-named sets (e.g. one from the type definition, one from the occurrence);
+this pattern only ever sees the FIRST one, silently missing a property/
+quantity that lives on the second. Use findPropertyInSets/findQuantityInSets
+from '@ifc-lite/query' (packages/query/src/pset-lookup.ts) instead.
+`);
+    for (const v of result.violations) console.error(formatViolation(v) + '\n');
+    process.exit(1);
+  }
+
+  console.log(
+    `check-pset-name-find: OK (${result.scanned.length} files scanned, 0 new violations, ${result.grandfathered} grandfathered)`,
+  );
+}

--- a/scripts/check-pset-name-find.mjs
+++ b/scripts/check-pset-name-find.mjs
@@ -33,6 +33,8 @@
  * required: a lone `.find(...name === ...)` on some OTHER unique-by-
  * construction list (`ifc4-pset-definitions.ts`'s definition table,
  * `COMMON_SCALES`, an enum lookup) has no second step and does not match.
+ * Either callback's parameter may carry a type annotation -- `(p: any) =>`
+ * and `(p: PropertySet) =>` read as the same defect as `p =>`.
  *
  * WHAT THIS DOES NOT CATCH:
  *  - A `for` loop that scans every same-named set before giving up (the
@@ -57,6 +59,17 @@
  *    contains X" is a fundamentally different risk than a resolution path
  *    real callers depend on, and this shape is common, legitimate assertion
  *    code there (build one pset, `.find` it, check a field).
+ *  - Any `.find` callback that is not `<param> => <param>.name ===` with a
+ *    single, optionally type-annotated identifier parameter: a destructured
+ *    parameter (`({ name }) => name === x`), a block body (`p => { return
+ *    p.name === x; }`), `==` instead of `===`, or a named function passed
+ *    by reference. This one is worth stating plainly because the gate was
+ *    already caught by it once: as first written it required a BARE
+ *    identifier, so every `(p: any) =>` site in packages/cli's query and
+ *    export commands sat unflagged through the PR that added the gate and
+ *    converted every other call site. A regex over callback text has no
+ *    way to notice which spellings it is blind to -- only writing the
+ *    variant down as a fixture does.
  * This is a deliberately NARROW pattern match, not a type-aware analysis:
  * it is scoped to catch the exact shape that has recurred, and prefers
  * missing a disguised instance over crying wolf on legitimate code.
@@ -117,14 +130,31 @@ function looksRisky(varName) {
 /** How many logical lines forward to look for the second `.find` when it isn't chained inline. */
 const WINDOW = 6;
 
-const FIND_NAME_RE = /\.find\(\s*\(?(\w+)\)?\s*=>\s*\1\.name\s*===/;
+/**
+ * `.find(<param> => <param>.name ===` — the single fragment every pattern
+ * below is built from, so widening it widens all three at once rather than
+ * two of three. `group` numbers the parameter's capture group so the
+ * back-reference stays correct wherever the fragment is embedded.
+ *
+ * The parameter may carry a TYPE ANNOTATION: `(p: any) => p.name ===` and
+ * `(p: PropertySet) => p.name ===` are the same defect as `p => p.name ===`,
+ * but an identifier-only pattern misses them silently. That is not
+ * hypothetical — it is how `packages/cli/src/commands/export.ts` sat
+ * unflagged through the very PR that added this gate and converted every
+ * other call site.
+ */
+function findNameFragment(group) {
+  return `\\.find\\(\\s*\\(?\\s*(\\w+)\\s*(?::[^)\\n]+)?\\s*\\)?\\s*=>\\s*\\${group}\\.name\\s*===`;
+}
+
+const FIND_NAME_RE = new RegExp(findNameFragment(1));
 
 /**
  * Same-line (post continuation-merge) chain:
  * `sets.find(p => p.name === x)?.properties.find(p => p.name === y)`.
  */
 const CHAIN_RE = new RegExp(
-  `(\\w+)${'\\.find\\(\\s*\\(?(\\w+)\\)?\\s*=>\\s*\\2\\.name\\s*==='}[^;\\n]*?\\?\\.\\s*(properties|quantities)\\.find\\(\\s*\\(?(\\w+)\\)?\\s*=>\\s*\\4\\.name\\s*===`,
+  `(\\w+)${findNameFragment(2)}[^;\\n]*?\\?\\.\\s*(properties|quantities)${findNameFragment(4)}`,
 );
 
 function safeIsDir(path) {
@@ -188,7 +218,7 @@ export function scanText(rel, text, { knownUnfixed = KNOWN_UNFIXED } = {}) {
     if (!looksRisky(setsVar)) continue;
 
     const innerRe = new RegExp(
-      `${psetVar}\\??\\.(properties|quantities)\\??\\.find\\(\\s*\\(?(\\w+)\\)?\\s*=>\\s*\\2\\.name\\s*===`,
+      `${psetVar}\\??\\.(properties|quantities)\\??${findNameFragment(2)}`,
     );
     for (let j = i + 1; j < Math.min(merged.length, i + 1 + WINDOW); j += 1) {
       if (innerRe.test(merged[j].text)) {

--- a/scripts/check-pset-name-find.mjs
+++ b/scripts/check-pset-name-find.mjs
@@ -42,8 +42,17 @@
  *  - The pattern split across MORE than a few lines, or through a
  *    function call boundary this script does not trace into.
  *  - A single `.find` with no matching second `.find` chained to
- *    `.properties`/`.quantities` -- e.g. checking whether a pset merely
- *    EXISTS is a different (and correct) question this script leaves alone.
+ *    `.properties`/`.quantities`. Usually that is a different, correct
+ *    question (does this pset EXIST at all), which is why the gate stays
+ *    quiet -- but NOT always: `deletePropertySet`/`deleteQuantitySet` in
+ *    packages/mutations used a single `.find` to reach one set and then
+ *    iterate ITS members, which is the same defect wearing a different
+ *    shape (only the first same-named set's members got DELETE markers).
+ *    Both were fixed in the PR that added this gate; the gate cannot see
+ *    that shape, and widening it to every single `.find` on a pset-ish
+ *    variable would flag the many legitimate existence checks. If you are
+ *    reaching into a set you found by name, ask whether a SECOND set could
+ *    share that name -- the gate will not ask it for you.
  *  - `*.test.ts(x)` files: a test asserting "the fixture I just built
  *    contains X" is a fundamentally different risk than a resolution path
  *    real callers depend on, and this shape is common, legitimate assertion

--- a/scripts/check-pset-name-find.test.mjs
+++ b/scripts/check-pset-name-find.test.mjs
@@ -93,6 +93,49 @@ function getQty(baseQsets, qsetName, quantName) {
   assert.equal(r.ok, false);
 });
 
+test('flags the two-step shape when the callback parameter is TYPE-ANNOTATED', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function resolve(props: any, setName: string, propName: string) {
+  const pset = props.find((p: any) => p.name === setName);
+  if (pset) {
+    const prop = pset.properties.find((p: any) => p.name === propName);
+    if (prop?.value != null) return prop.value;
+  }
+  return null;
+}
+`,
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.violations.length, 1);
+});
+
+test('flags a type-annotated quantity lookup reached through optional chaining', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function resolve(qsets: QuantitySet[], setName: string, qtyName: string) {
+  const qset = qsets.find((q: QuantitySet) => q.name === setName);
+  const qty = qset?.quantities?.find((q: Quantity) => q.name === qtyName);
+  return qty?.value ?? null;
+}
+`,
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.violations.length, 1);
+});
+
+test('flags a same-line chain whose both callbacks are type-annotated', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function getProp(props: PropertySet[], setName: string, propName: string) {
+  return props.find((p: PropertySet) => p.name === setName)?.properties.find((p: Property) => p.name === propName)?.value ?? null;
+}
+`,
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.violations.length, 1);
+});
+
 test('does not flag a for-loop that scans every same-named set (the correct shape)', () => {
   const r = check({
     'packages/foo/src/a.ts': `
@@ -129,6 +172,19 @@ function findUser(users, id) {
   const user = users.find(u => u.name === id);
   if (!user) return null;
   const detail = user.properties.find(p => p.name === 'email');
+  return detail;
+}
+`,
+  });
+  assert.equal(r.ok, true);
+});
+
+test('a type-annotated parameter does not make a non-pset receiver risky', () => {
+  const r = check({
+    'packages/foo/src/lookup.ts': `
+function findUser(users: User[], id: string) {
+  const user = users.find((u: User) => u.name === id);
+  const detail = user?.properties?.find((p: Prop) => p.name === 'email');
   return detail;
 }
 `,

--- a/scripts/check-pset-name-find.test.mjs
+++ b/scripts/check-pset-name-find.test.mjs
@@ -1,0 +1,215 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Tests for the same-named-property-set `.find()` gate. Everything runs
+ * against synthetic TS written into an `mkdtemp` tree, not against the repo,
+ * so a change elsewhere in packages/ or apps/ can never make these
+ * vacuously green.
+ *
+ * Run: `node --test scripts/check-pset-name-find.test.mjs`
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { runCheck, scanText } from './check-pset-name-find.mjs';
+
+/**
+ * Build a temp `{packages,apps}/...` tree from `files` and run the gate
+ * against it.
+ * @param {Record<string, string>} files
+ * @param {object} [opts]
+ */
+function check(files, opts = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'pset-find-gate-'));
+  try {
+    for (const [rel, body] of Object.entries(files)) {
+      const abs = join(dir, rel);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, body);
+    }
+    return runCheck(dir, opts);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('flags the two-step .find(pset) -> .find(property) shape, via an intermediate variable', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function getProp(props, setName, propName) {
+  const pset = props.find(p => p.name === setName);
+  if (!pset) return null;
+  const prop = pset.properties.find(p => p.name === propName);
+  return prop ?? null;
+}
+`,
+  });
+  assert.equal(r.ok, false);
+  assert.equal(r.violations.length, 1);
+  assert.match(r.violations[0].rel, /a\.ts$/);
+});
+
+test('flags the same shape for quantities', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function getQty(qsets, setName, qtyName) {
+  const qset = qsets.find(q => q.name === setName);
+  if (!qset) return null;
+  const qty = qset.quantities.find(q => q.name === qtyName);
+  return qty ?? null;
+}
+`,
+  });
+  assert.equal(r.ok, false);
+});
+
+test('flags a same-line chained .find(...).find(...)', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function getProp(props, setName, propName) {
+  return props.find(p => p.name === setName)?.properties.find(p => p.name === propName)?.value ?? null;
+}
+`,
+  });
+  assert.equal(r.ok, false);
+});
+
+test('flags a chain split across method-chain continuation lines', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function getQty(baseQsets, qsetName, quantName) {
+  const baseQuantity = baseQsets
+    .find(q => q.name === qsetName)
+    ?.quantities.find(q => q.name === quantName);
+  return baseQuantity ?? null;
+}
+`,
+  });
+  assert.equal(r.ok, false);
+});
+
+test('does not flag a for-loop that scans every same-named set (the correct shape)', () => {
+  const r = check({
+    'packages/foo/src/a.ts': `
+function getProp(props, setName, propName) {
+  for (const pset of props) {
+    if (pset.name !== setName) continue;
+    const prop = pset.properties.find(p => p.name === propName);
+    if (prop) return prop.value;
+  }
+  return null;
+}
+`,
+  });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.violations, []);
+});
+
+test('does not flag a single .find on a unique-by-construction definition list', () => {
+  const r = check({
+    'packages/foo/src/definitions.ts': `
+const COMMON_SCALES = [{ name: '1:100', value: 100 }, { name: '1:50', value: 50 }];
+export function scaleFor(name) {
+  return COMMON_SCALES.find(s => s.name === name);
+}
+`,
+  });
+  assert.equal(r.ok, true);
+});
+
+test('does not flag a .find whose receiver name is not plausibly an entity pset/qset collection', () => {
+  const r = check({
+    'packages/foo/src/lookup.ts': `
+function findUser(users, id) {
+  const user = users.find(u => u.name === id);
+  if (!user) return null;
+  const detail = user.properties.find(p => p.name === 'email');
+  return detail;
+}
+`,
+  });
+  assert.equal(r.ok, true);
+});
+
+test('does not flag *.test.ts fixture assertions', () => {
+  const r = check({
+    'packages/foo/src/a.test.ts': `
+test('x', () => {
+  const pset = props.find(p => p.name === 'Pset_Foo');
+  const prop = pset.properties.find(p => p.name === 'Bar');
+  assert.ok(prop);
+});
+`,
+  });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.scanned, []);
+});
+
+test('does not flag a file listed in knownUnfixed, but still scans it', () => {
+  const r = check(
+    {
+      'packages/query/src/entity-node.ts': `
+property(psetName, propName) {
+  const props = this.store.getProperties(this.expressId);
+  const pset = props.find(p => p.name === psetName);
+  return pset?.properties.find(p => p.name === propName)?.value ?? null;
+}
+`,
+    },
+    { knownUnfixed: new Set(['packages/query/src/entity-node.ts']) },
+  );
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.scanned, ['packages/query/src/entity-node.ts']);
+});
+
+test('a file NOT in knownUnfixed with the same shape still fails', () => {
+  const r = check(
+    {
+      'packages/query/src/entity-node.ts': `
+property(psetName, propName) {
+  const props = this.store.getProperties(this.expressId);
+  const pset = props.find(p => p.name === psetName);
+  return pset?.properties.find(p => p.name === propName)?.value ?? null;
+}
+`,
+    },
+    { knownUnfixed: new Set() },
+  );
+  assert.equal(r.ok, false);
+});
+
+test('skips node_modules/dist and other build-output directories', () => {
+  const r = check({
+    'packages/foo/node_modules/bar/src/a.ts': `
+const pset = props.find(p => p.name === x);
+const prop = pset.properties.find(p => p.name === y);
+`,
+    'packages/foo/dist/a.ts': `
+const pset = props.find(p => p.name === x);
+const prop = pset.properties.find(p => p.name === y);
+`,
+  });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.scanned, []);
+});
+
+test('an unreadable search root throws rather than reporting a silent pass', () => {
+  assert.throws(() => runCheck('/nonexistent/path/for/this/gate/__probe__'));
+});
+
+test('scanText: the same shape scanned directly, outside a real filesystem walk', () => {
+  const violations = scanText(
+    'packages/foo/src/a.ts',
+    `
+const pset = props.find(p => p.name === setName);
+const prop = pset.properties.find(p => p.name === propName);
+`,
+    { knownUnfixed: new Set() },
+  );
+  assert.equal(violations.length, 1);
+});


### PR DESCRIPTION
An IFC entity can legitimately carry two distinct property (or quantity) sets with the **same name** — two `IfcRelDefinesByProperties` pointing at two different `Pset_WallCommon` instances, e.g. one via the type definition and one via the occurrence. `sets.find(s => s.name === x)` only ever sees the **first** one, so a property living on the second is reported missing — or, in a filter, the whole entity is silently dropped from the result.

This is the fourth PR against this defect (#2907, #3463, #3465). Rather than fix a fourth instance, this converts every remaining reachable site to one shared helper and adds a gate so the shape stops being writable. Prompted by the inventory in https://github.com/LTplus-AG/ifc-lite/pull/3465#issuecomment-5462981968.

Refs #3465
Refs #3463

## The helper

`packages/query/src/pset-lookup.ts` (new), exported from `@ifc-lite/query`:

```ts
export function findPropertyInSets<P extends Named>(
  sets: readonly { name: string; properties: readonly P[] }[],
  setName: string, propName: string): P | undefined

export function findQuantityInSets<Q extends Named>(
  sets: readonly { name: string; quantities: readonly Q[] }[],
  setName: string, quantityName: string): Q | undefined
```

Structurally typed, so it accepts both `@ifc-lite/data`'s `PropertySet`/`QuantitySet` and the SDK's separate `PropertySetData`/`QuantitySetData` with no casts. Semantics are the settled ones from `PropertyTable.getProperty` (#2907) and `QueryResultEntity.getProperty`: scan every set, skip name mismatches, first match across the sequence wins. `@ifc-lite/query` was already a dependency of mcp, cli and the viewer, so no new package and no new dependency edge.

## Converted sites, each RED → GREEN

Every test was written first, run, and confirmed failing **for the documented reason** before the fix.

| # | Site | RED (before) | GREEN (after) |
|---|---|---|---|
| 1 | `packages/mcp/src/backend-query.ts:340` (filter) | matching wall returned `[]` | `['Wall A']` |
| 2 | `packages/sdk/src/namespaces/export.ts` csv+json (see note) | cell `Wall A,` | `Wall A,REI60` |
| 3 | `packages/cli/src/headless-backend.ts:327` (filter) | matching wall returned `[]` | `['Wall A']` |
| 3b | `packages/cli/src/headless-backend.ts:610` (CSV column) | converted (see note) | suite green |
| 4 | `packages/cli/src/commands/stats-aggregation.ts:63` | **already correct** — no RED reachable | 23 tests green |
| 5 | `apps/viewer/src/sdk/adapters/query-adapter.ts:245` (filter) | matching wall returned `[]` | `['Wall A']` |
| 6 | `apps/viewer/src/sdk/adapters/export-adapter.ts:206` (CSV) | cell `Wall A,` | `Wall A,REI60` |

Two honest notes on that table:

- **Site 2 is not where the brief said it was.** The brief pointed at `packages/mcp/src/headless-backend.ts:276`. I converted it, rebuilt, and the RED test *still failed* — because the reachable CSV/JSON dotted-column path for mcp, cli **and** the viewer all runs through `@ifc-lite/sdk`'s `ExportNamespace.csv/json`, not through each backend's own `resolveColumn`. Each backend wraps itself in `createBimContext`, whose export namespace never calls `backend.export.csv`. The live fix is in `packages/sdk/src/namespaces/export.ts` (which had the same bug in **two** places, csv and json). The three backend copies are converted too — same buggy shape, currently unreachable via the public `bim.export` path.
- **Site 4 was already correct.** Its existing `for` loop already scanned every same-named pset. I added a test pinning that and routed it through the helper for consistency, but there was no bug — I am not claiming a fix I did not make.

## A seventh site the brief did not list

Adversarial self-review of the diff surfaced `packages/mutations/src/mutable-property-view.ts`, with the same shape in the mutation overlay's read path:

- `getPropertyValue` base fallback and `setQuantity`'s old-value lookup (two-step `.find`) — **RED**: `getPropertyValue` returned `null` for a property on the second same-named set; `setQuantity` recorded `CREATE_QUANTITY`/`oldValue: null` instead of `UPDATE_QUANTITY`/`12.5`, which is exactly the null the undo handler treats as "nothing to revert to".
- `deletePropertySet` / `deleteQuantitySet` — a *single* `.find` reaching one set and then iterating its members. `deletedPsets` masks by **name** (so the panel hides both sets) but the per-member DELETE markers the exporter reads only covered the first. **RED**: after `deletePropertySet`, `getForEntity()` returned `[]` while `getPropertyValue(...)` still answered `'REI60'`.

That last one is **load-bearing, not opportunistic**: before this branch fixed `getPropertyValue`, it answered `null` for that property *by accident* (its `.find` never reached the second set). Fixing the read path turned an accidentally-right answer into a visibly wrong one, so the delete path had to be fixed in the same PR. All four are GREEN; the package's 212 tests pass.

This package could not import the helper — `@ifc-lite/query` → `@ifc-lite/parser` → `@ifc-lite/ifcx` → `@ifc-lite/mutations` is a cycle (pnpm confirms it when you try). The property side is an inline loop; the quantity side is `packages/mutations/src/base-qset-lookup.ts`, extracted so `mutable-property-view.ts` stays exactly at its pinned module-size budget.

## The gate

`scripts/check-pset-name-find.mjs`, wired into `test.yml`'s `node-tests` job, with its own `scripts/check-pset-name-find.test.mjs` (13 tests, satisfying `check-test-wiring.mjs`).

**Observed FAIL** (buggy snippet temporarily reintroduced):

```
Two-step .find(set by name) -> .find(property/quantity by name) on what looks
like an entity's property/quantity sets. ...
  packages/mutations/src/_gate-fail-probe.ts:6 / :8
    const pset = props.find(p => p.name === setName);
    const prop = pset.properties.find(p => p.name === propName);
EXIT=1
```

**Observed PASS** (snippet removed):

```
check-pset-name-find: OK (2091 files scanned, 0 new violations, 1 grandfathered)
EXIT=0
```

**What it catches:** a two-step `.find` — one locating a set by `.name ===` on a variable plausibly holding an entity's sets (name contains `pset`/`prop`/`qset`/`quantity`, or is `sets`/`props`/`psets`/`qsets`), then `.find` on that result's `.properties`/`.quantities`, also by `.name ===`. Both same-line, split across method-chain continuation lines, and via an intermediate variable within 6 lines.

**What it does NOT catch**, stated plainly:
- A `for` loop scanning every same-named set — the correct shape.
- A lookup keyed by anything other than `.name`.
- The pattern spread over more than ~6 lines or across a function boundary.
- **A single `.find` that reaches into the set it found** — the `deletePropertySet` shape above. It is documented in the script's header as a known blind spot rather than papered over: widening the gate to every single `.find` on a pset-ish variable would flag the many legitimate "does this set exist" checks.
- `*.test.ts(x)` files, where building a fixture and `.find`ing it back is normal assertion code.
- Unique-by-construction lists — `ifc4-pset-definitions.ts` and `COMMON_SCALES` are **not** flagged and are correct as-is, as the brief required.

`packages/query/src/entity-node.ts` is in an explicit, documented `KNOWN_UNFIXED` allowlist meant to shrink to empty.

## Deliberately not touched

`packages/query/src/entity-node.ts` (open PR #3465) and `packages/query/src/property-table.ts` (#3463, since merged). Those land separately; a follow-up should migrate `EntityNode.property`/`.quantity` onto `findPropertyInSets`/`findQuantityInSets` and drop the gate's allowlist row once #3465 merges.

## Verification

`node scripts/check-module-size.mjs` → **OK** (0 new over 400, no budget raised — `mutable-property-view.ts` sits exactly at its existing 2121 budget by extracting rather than growing). `check-test-wiring`, `check-changesets`, `check-api-surface` (snapshot updated for the two new exports) all pass. Rebased on current `main` after #3463 merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed property and quantity lookups when entities contain multiple sets with the same name.
  - Improved filtered queries, sorting, grouping, and unique-value selection across viewer, CLI, and MCP interfaces.
  - Corrected CSV and JSON exports to include values from subsequent matching sets.
  - Fixed advanced filters, quantity editing, and property or quantity set deletion for duplicate-named sets.
  - Improved validation for invalid query row limits.

- **New Features**
  - Added shared property and quantity lookup capabilities to the query API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->