### PR TITLE
fix(collab): refresh MemoryBlobStore uploadedAt on a re-put of known content

### DIFF
--- a/.changeset/memory-blob-store-stale-uploaded-at.md
+++ b/.changeset/memory-blob-store-stale-uploaded-at.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/collab': patch
+---
+
+Fix `MemoryBlobStore.put()` keeping the FIRST upload's `uploadedAt` forever on a re-put of already-known content, instead of refreshing it like `IndexedDbBlobStore` and `HttpBlobStore` already do.
+
+`put()` deduplicates by content hash and returned a fresh `meta` object either way, but only wrote it to the store on the first call for a given hash — a later `put()` of the same bytes handed the caller a meta claiming the current time while `stat()`/`get()` kept reporting the original upload time. Blob GC's grace-window check (`planBlobSweep` in `packages/collab/src/geometry/gc.ts`) reads that stored `uploadedAt` to decide whether an unreferenced-right-now blob is too young to sweep; a client re-references (and re-PUTs) a blob specifically to refresh that clock, per the race-protection this store's own sibling implementations already rely on. With the stale timestamp, a blob re-uploaded long after its original upload read back as old enough to sweep immediately.
+
+`put()` now always writes the fresh `meta` (reusing the already-stored bytes rather than copying them again), matching `IndexedDbBlobStore` and `HttpBlobStore`.

--- a/packages/collab/src/geometry/blob-store.ts
+++ b/packages/collab/src/geometry/blob-store.ts
@@ -101,10 +101,16 @@ export class MemoryBlobStore implements BlobStore {
       contentType,
       uploadedAt: new Date().toISOString(),
     };
-    if (!this.blobs.has(hash)) {
-      // Defensive copy so callers can mutate `bytes` after put().
-      this.blobs.set(hash, { bytes: new Uint8Array(bytes), meta });
-    }
+    const existing = this.blobs.get(hash);
+    // Always store the fresh meta, even on a re-put of already-known content:
+    // blob-gc's race protection (see blob-gc-worker.ts) relies on a re-PUT
+    // refreshing the upload timestamp, and both other backends (IndexedDB
+    // `put()`, and the HTTP server's own PUT semantics) already do this —
+    // only this in-memory store used to keep the FIRST put's timestamp
+    // forever, so a blob re-referenced long after its original upload read
+    // back as old enough to sweep. The bytes are identical (same hash), so
+    // reuse the already-stored copy instead of paying for another one.
+    this.blobs.set(hash, { bytes: existing ? existing.bytes : new Uint8Array(bytes), meta });
     return meta;
   }
   async get(hash: BlobHash): Promise<Uint8Array | null> {

--- a/packages/collab/test/blob-store.test.ts
+++ b/packages/collab/test/blob-store.test.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   fnv128,
   HttpBlobStore,
@@ -43,6 +43,37 @@ describe('blob store', () => {
     const b = await store.put(new Uint8Array([1, 2, 3]));
     expect(a.hash).toBe(b.hash);
     expect((await store.list()).length).toBe(1);
+  });
+
+  it('MemoryBlobStore refreshes uploadedAt on a re-put of already-known content', async () => {
+    // Order matters: put() the SAME bytes on the SAME store instance twice,
+    // months apart. blob-gc's grace-window check (planBlobSweep in gc.ts)
+    // reads stat().uploadedAt to decide whether an unreferenced-right-now
+    // blob is too young to sweep — a re-PUT is exactly how a client
+    // refreshes that clock when it re-references a blob (see the
+    // blob-gc-worker.ts race-protection comment). A store that keeps the
+    // FIRST put's timestamp forever would let the sweep condemn a blob the
+    // instant after it was legitimately re-uploaded.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+      const store = new MemoryBlobStore();
+      const bytes = new Uint8Array([1, 2, 3]);
+      const first = await store.put(bytes);
+      expect(first.uploadedAt).toBe('2020-01-01T00:00:00.000Z');
+
+      vi.setSystemTime(new Date('2020-06-01T00:00:00.000Z'));
+      const second = await store.put(bytes); // same content, re-uploaded months later
+      expect(second.hash).toBe(first.hash);
+      expect(second.uploadedAt).toBe('2020-06-01T00:00:00.000Z');
+
+      // What blob-gc actually reads on its next sweep must agree with what
+      // put() just told the caller — not the original upload time.
+      const stat = await store.stat(first.hash);
+      expect(stat?.uploadedAt).toBe('2020-06-01T00:00:00.000Z');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('LayeredBlobStore reads from local first, falls through to remote, caches on hit', async () => {


### PR DESCRIPTION
## Summary
- `MemoryBlobStore.put()` deduplicates by content hash and always returns a fresh `meta` object, but only wrote it to the store on the FIRST `put()` for a given hash. A second `put()` of identical bytes (e.g. a client re-uploading a blob to refresh it) handed the caller a `meta` claiming the current time while `stat()`/`get()` kept reporting the *original* upload timestamp forever — the returned value and the stored value disagreed from that point on.
- `packages/collab-server/src/blob-gc-worker.ts` documents that a re-PUT is exactly how a client refreshes a blob's age for GC race protection ("the client always re-PUTs a blob before referencing it ... which refreshes mtime"), and both sibling backends (`IndexedDbBlobStore`, `HttpBlobStore`) already refresh `uploadedAt` on every `put()`. `MemoryBlobStore` was the one implementation that didn't, so a blob re-referenced long after its original upload could read back as old enough for `planBlobSweep` (`packages/collab/src/geometry/gc.ts`) to condemn it immediately.
- Fixed by always writing the fresh `meta`, reusing the already-stored bytes (same hash ⇒ same content) rather than copying them again.

## Evidence
- Reproduced by executing the code directly: `put(bytes)` at T1, then `put(bytes)` (same bytes) at T2 on the *same* `MemoryBlobStore` instance — before the fix, `stat(hash).uploadedAt` still read T1 while the second `put()`'s own return value said T2. RED confirmed by running the new test against the pre-fix code; GREEN after the one-line fix.
- The existing `blob-store.test.ts` test `'MemoryBlobStore deduplicates identical bytes'` already calls `put()` twice with identical bytes on one instance, but never asserted on `uploadedAt`, so it could not have caught this — a fresh-instance-per-case suite structurally can't either, since the defect only shows up on the *second* call to a *reused* store.
- Checked the sibling implementations for the same shape: `IndexedDbBlobStore.put()` (unconditional IDB `put`) and `HttpBlobStore.put()` (always returns `new Date().toISOString()`) both already refresh on every call — no other instance of this defect found in `packages/collab`, `packages/cache`, or `packages/collab-server` (their own in-memory/disk server-side blob storages already refresh unconditionally too).

## Test plan
- [x] `pnpm --filter @ifc-lite/collab exec vitest run` — 261 passed, 2 skipped (pre-existing skips), 0 failed
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget
- [x] Changeset added (`@ifc-lite/collab` is published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436