### PR TITLE
fix(collab-server): stop /metrics reporting a stale peer count for an unloaded room

### DIFF
--- a/.changeset/collab-server-stale-peer-gauge.md
+++ b/.changeset/collab-server-stale-peer-gauge.md
@@ -1,7 +1,7 @@
 ---
-'@ifc-lite/collab-server': patch
+'@ifc-lite/collab-server': minor
 ---
 
 Fix `/metrics` reporting a stale, permanent peer count for a room after it unloads.
 
-`peersGauge` is keyed by `roomId`, an identifier the connecting peer picks (the websocket URL path). Every scrape re-`set` the gauge for each currently-loaded room, but nothing ever removed a series for a room that had since unloaded, so `collab_room_peers{room="<id>"}` kept reporting that room's last-known (non-zero) peer count forever, and the registry grew one label series per distinct room id ever visited over the life of a long-running server rather than tracking only currently-loaded rooms. `MetricsRegistry`'s gauge now exposes `reset()`, and the `/metrics` handler resets `peersGauge` before repopulating it from the live room list on each scrape.
+`peersGauge` is keyed by `roomId`, an identifier the connecting peer picks (the websocket URL path). Every scrape re-`set` the gauge for each currently-loaded room, but nothing ever removed a series for a room that had since unloaded, so `collab_room_peers{room="<id>"}` kept reporting that room's last-known (non-zero) peer count forever, and the registry grew one label series per distinct room id that was loaded at the time of some scrape over the life of a long-running server rather than tracking only currently-loaded rooms. `MetricsRegistry`'s gauge now exposes `reset()`, and the `/metrics` handler resets `peersGauge` before repopulating it from the live room list on each scrape.

--- a/.changeset/collab-server-stale-peer-gauge.md
+++ b/.changeset/collab-server-stale-peer-gauge.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/collab-server': patch
+---
+
+Fix `/metrics` reporting a stale, permanent peer count for a room after it unloads.
+
+`peersGauge` is keyed by `roomId`, an identifier the connecting peer picks (the websocket URL path). Every scrape re-`set` the gauge for each currently-loaded room, but nothing ever removed a series for a room that had since unloaded, so `collab_room_peers{room="<id>"}` kept reporting that room's last-known (non-zero) peer count forever, and the registry grew one label series per distinct room id ever visited over the life of a long-running server rather than tracking only currently-loaded rooms. `MetricsRegistry`'s gauge now exposes `reset()`, and the `/metrics` handler resets `peersGauge` before repopulating it from the live room list on each scrape.

--- a/packages/collab-server/src/metrics.ts
+++ b/packages/collab-server/src/metrics.ts
@@ -99,6 +99,18 @@ export class MetricsRegistry {
         m.values.set(key, (m.values.get(key) ?? 0) - n);
       },
       get: (labels: LabelValues = {}) => m.values.get(labelKey(labels)) ?? 0,
+      /**
+       * Drop every label series. For a gauge whose label set is derived
+       * from a peer-chosen identifier (e.g. a room id) and refreshed by
+       * re-`set`ting each live member on every scrape, a series for a
+       * member that has since disappeared (a room that unloaded) is
+       * never overwritten and would otherwise report its last known
+       * value forever. Call this before the refresh loop so the render
+       * reflects only currently-live members.
+       */
+      reset: () => {
+        m.values.clear();
+      },
     };
   }
 

--- a/packages/collab-server/src/server.ts
+++ b/packages/collab-server/src/server.ts
@@ -358,10 +358,10 @@ export async function startCollabServer(
             res.end(JSON.stringify({ error: 'unauthorized' }));
             return;
           }
-          // Refresh derived gauges before rendering so the snapshot
-          // reflects live state, not state-at-last-event.
           const stats = await roomManager.stats();
           roomsGauge.set(stats.length);
+          // Reset first — keyed by peer-chosen roomId, an unloaded room would otherwise report a stale peer count forever.
+          peersGauge.reset();
           for (const s of stats) peersGauge.set(s.peerCount, { room: s.roomId });
           res.writeHead(200, { 'content-type': 'text/plain; version=0.0.4' });
           res.end(metrics.render());

--- a/packages/collab-server/test/metrics.test.ts
+++ b/packages/collab-server/test/metrics.test.ts
@@ -48,6 +48,49 @@ describe('metrics', () => {
     await handle.stop();
   });
 
+  it('drops a room from collab_room_peers once it unloads, instead of reporting a stale peer count forever', async () => {
+    // Room ids are peer-chosen (the websocket URL path) and the /metrics
+    // scrape refreshes the gauge only for CURRENTLY loaded rooms
+    // (`for (const s of stats) peersGauge.set(...)` in server.ts). Nothing
+    // ever removes a label for a room that has since unloaded, so a room a
+    // peer visited once keeps reporting its last-seen peer count forever —
+    // wrong (stale, non-zero) data on a scrape that is supposed to reflect
+    // live state, and unbounded growth of the metrics registry over the
+    // life of a long-running server.
+    const handle = await startCollabServer({
+      port: 0,
+      persistence: new MemoryPersistence(),
+      idleUnloadMs: 10,
+    });
+    const port = (handle.httpServer.address() as { port: number }).port;
+    try {
+      const room = await handle.roomManager.getOrCreate('ghost-room');
+      const conn = {
+        ws: { readyState: 1, OPEN: 1, send: () => {}, close: () => {}, terminate: () => {} } as unknown as import('ws').WebSocket,
+        principal: { userId: 'u', role: 'editor' as const },
+        awarenessClients: new Set<number>(),
+      };
+      room.addConnection(conn);
+
+      // First scrape: the room is loaded with one peer, so it is reported.
+      let body = await (await fetch(`http://127.0.0.1:${port}/metrics`)).text();
+      expect(body).toContain('collab_room_peers{room="ghost-room"} 1');
+
+      // The peer leaves and the room goes idle long enough to unload.
+      room.removeConnection(conn);
+      await new Promise((r) => setTimeout(r, 30));
+      const dropped = await handle.roomManager.sweepIdle();
+      expect(dropped).toContain('ghost-room');
+      expect(handle.roomManager.list()).not.toContain('ghost-room');
+
+      // The room is gone; the scrape must not keep claiming it has a peer.
+      body = await (await fetch(`http://127.0.0.1:${port}/metrics`)).text();
+      expect(body).not.toContain('room="ghost-room"');
+    } finally {
+      await handle.stop();
+    }
+  });
+
   it('gated /metrics refuses hostile bearer shapes without crashing', async () => {
     // The digest-based comparison must behave identically for empty, huge,
     // and multi-byte presented tokens: never throw (raw timingSafeEqual


### PR DESCRIPTION
## Summary

- `peersGauge` (`collab_room_peers`) in `packages/collab-server/src/server.ts` is keyed by `roomId` — an identifier the connecting peer picks (the websocket URL path). Every `/metrics` scrape re-`set` the gauge for each currently-loaded room, but nothing ever removed a series for a room that had since unloaded, so `collab_room_peers{room="<id>"}` kept reporting that room's last-known (non-zero) peer count forever, and the registry grew one label series per distinct room id ever visited over the life of a long-running server, instead of tracking only currently-loaded rooms.
- `MetricsRegistry`'s gauge now exposes `reset()` (`packages/collab-server/src/metrics.ts`), and the `/metrics` handler resets `peersGauge` before repopulating it from the live room list on each scrape (`packages/collab-server/src/server.ts`).

## Evidence

RED (new test, before the fix): a room is loaded with one peer (`collab_room_peers{room="ghost-room"} 1`), the peer disconnects and the room idle-unloads (`collab_rooms 0`, room no longer in `roomManager.list()`), but the next `/metrics` scrape still contains `collab_room_peers{room="ghost-room"} 1` — a stale, wrong value for a room that no longer exists.

GREEN (after the fix): the same scrape no longer mentions `room="ghost-room"` once the room has unloaded.

Full `@ifc-lite/collab-server` suite: 186/186 passing. `node scripts/check-module-size.mjs`: OK (exit 0), `server.ts` at exactly its 677-line budget.

## Test plan

- [x] `pnpm exec vitest run` in `packages/collab-server` — 186/186 passing, including the new regression test in `test/metrics.test.ts`
- [x] `node scripts/check-module-size.mjs` — OK
- [x] Changeset added (`@ifc-lite/collab-server` is published)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed metrics reporting so unloaded rooms no longer retain stale peer-count entries.
  - Room peer metrics now reflect only currently active rooms.

- **Tests**
  - Added coverage confirming that peer metrics are removed after a room unloads.

- **Documentation**
  - Documented the metrics update in the release changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->