### PR TITLE
fix(sandbox): route bim.query.entity's ref through toRef

### DIFF
--- a/.changeset/bridge-query-entity-toref-bypass.md
+++ b/.changeset/bridge-query-entity-toref-bypass.md
@@ -2,6 +2,6 @@
 '@ifc-lite/sandbox': patch
 ---
 
-`bim.query.entity(modelId, expressId)` built its `EntityRef` directly from the raw arguments instead of going through the shared `toRef()` helper used by every other method in `bim.query`. A wrong-typed `modelId`/`expressId` (from a loosely-typed sandbox script) reached `sdk.entity()` unchecked instead of being rejected like the same shape already is everywhere else in the namespace.
+`bim.query.entity(modelId, expressId)` built its `EntityRef` inline from the raw arguments, with type casts and no runtime check, instead of going through the shared `toRef()` helper that every other method in `bim.query` uses. A call that omitted an argument — `bim.query.entity('m1')` — therefore reached `sdk.entity()` with `expressId: undefined` instead of being rejected first.
 
-`entity()` now builds its ref via `toRef()` and returns `null` for a shape it rejects, matching the rest of `bim.query`. A script that only ever passes a real `(modelId, expressId)` pair is unaffected.
+`entity()` now builds its ref via `toRef()` and returns `null` when the ref is unusable, matching the rest of `bim.query`. A script that passes a real `(modelId, expressId)` pair is unaffected, and so is a wrong-typed one: the bridge coerces argument 0 with `getString` and argument 1 with `getNumber` before the handler runs, so `bim.query.entity(42, '7')` arrived — and still arrives — as `('42', 7)`.

--- a/.changeset/bridge-query-entity-toref-bypass.md
+++ b/.changeset/bridge-query-entity-toref-bypass.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/sandbox': patch
+---
+
+`bim.query.entity(modelId, expressId)` built its `EntityRef` directly from the raw arguments instead of going through the shared `toRef()` helper used by every other method in `bim.query`. A wrong-typed `modelId`/`expressId` (from a loosely-typed sandbox script) reached `sdk.entity()` unchecked instead of being rejected like the same shape already is everywhere else in the namespace.
+
+`entity()` now builds its ref via `toRef()` and returns `null` for a shape it rejects, matching the rest of `bim.query`. A script that only ever passes a real `(modelId, expressId)` pair is unaffected.

--- a/packages/sandbox/src/bridge-query.test.ts
+++ b/packages/sandbox/src/bridge-query.test.ts
@@ -292,9 +292,13 @@ describe('bim.query.entity', () => {
   // as a bare `{ modelId, expressId }` object literal from raw args (`as
   // string` / `as number` casts only, no runtime check) instead of going
   // through `toRef` like `attributes`, `properties`, etc. do. Routing it
-  // through `toRef` closes that shape gap: a wrong-typed arg is now
-  // rejected here exactly as it already is at the other 20+ call sites in
-  // this file, instead of being forwarded to `sdk.entity` unchecked.
+  // through `toRef` closes that shape gap at the handler boundary. The 17
+  // other `toRef` sites in bridge-query.ts are not an exact parallel: their arg 0
+  // is declared `'dump'` and reaches the handler uncoerced, while `entity`
+  // declares `['string', 'number']`, so `vm.getString` / `vm.getNumber` have
+  // already coerced its args by the time `call:` runs. The cases below
+  // therefore pin the handler's own contract, not a shape a script can send;
+  // the one difference a script can reach is an OMITTED argument.
   //
   // `toRef` on this branch only checks `typeof expressId === 'number'`, so
   // NaN/Infinity/-1/1.5 (all `typeof 'number'`) still reach `sdk.entity`
@@ -307,7 +311,7 @@ describe('bim.query.entity', () => {
   it.each([
     [42 as unknown as string, 1],
     ['m1', '7' as unknown as number],
-  ])('rejects a wrong-typed (modelId=%j, expressId=%j) pair without calling sdk.entity', (modelId, expressId) => {
+  ])('refuses a (modelId=%j, expressId=%j) pair at the handler boundary without calling sdk.entity', (modelId, expressId) => {
     const sdk = mockSdk({
       entity: vi.fn(() => {
         throw new Error('sdk.entity must not be called with an invalid ref shape');

--- a/packages/sandbox/src/bridge-query.test.ts
+++ b/packages/sandbox/src/bridge-query.test.ts
@@ -281,10 +281,47 @@ describe('bim.query.matchingActiveFilter', () => {
 });
 
 describe('bim.query.entity', () => {
-  it('returns null for an unresolved (modelId, expressId) pair without ref validation', () => {
+  it('returns null for an unresolved (modelId, expressId) pair', () => {
     const sdk = mockSdk({ entity: vi.fn(() => null) as any });
     const result = findMethod('entity').call(sdk, ['m1', 999], CTX);
     expect(sdk.entity).toHaveBeenCalledWith({ modelId: 'm1', expressId: 999 });
     expect(result).toBeNull();
+  });
+
+  // Unlike every other method in this file, `entity` used to build its ref
+  // as a bare `{ modelId, expressId }` object literal from raw args (`as
+  // string` / `as number` casts only, no runtime check) instead of going
+  // through `toRef` like `attributes`, `properties`, etc. do. Routing it
+  // through `toRef` closes that shape gap: a wrong-typed arg is now
+  // rejected here exactly as it already is at the other 20+ call sites in
+  // this file, instead of being forwarded to `sdk.entity` unchecked.
+  //
+  // `toRef` on this branch only checks `typeof expressId === 'number'`, so
+  // NaN/Infinity/-1/1.5 (all `typeof 'number'`) still reach `sdk.entity`
+  // unchanged here, exactly as they did before this fix and exactly as
+  // every other `toRef`-guarded method in this file still does — see
+  // https://github.com/LTplus-AG/ifc-lite/pull/3471, which hardens `toRef`
+  // itself to also reject those. That PR is open, not merged; once it
+  // lands, `entity` inherits the same rejection automatically because it
+  // now goes through `toRef` rather than building the ref inline.
+  it.each([
+    [42 as unknown as string, 1],
+    ['m1', '7' as unknown as number],
+  ])('rejects a wrong-typed (modelId=%j, expressId=%j) pair without calling sdk.entity', (modelId, expressId) => {
+    const sdk = mockSdk({
+      entity: vi.fn(() => {
+        throw new Error('sdk.entity must not be called with an invalid ref shape');
+      }) as any,
+    });
+    const result = findMethod('entity').call(sdk, [modelId, expressId], CTX);
+    expect(result).toBeNull();
+    expect(sdk.entity).not.toHaveBeenCalled();
+  });
+
+  it('still reaches sdk.entity unmodified for a valid expressId (regression)', () => {
+    const sdk = mockSdk({ entity: vi.fn(() => ENTITY) as any });
+    const result = findMethod('entity').call(sdk, ['m1', 7], CTX);
+    expect(sdk.entity).toHaveBeenCalledWith({ modelId: 'm1', expressId: 7 });
+    expect((result as any).Name).toBe('Basic Wall');
   });
 });

--- a/packages/sandbox/src/bridge-query.ts
+++ b/packages/sandbox/src/bridge-query.ts
@@ -58,9 +58,9 @@ export function buildQueryNamespace(): NamespaceSchema {
         paramNames: ['modelId', 'expressId'],
         tsReturn: 'BimEntity | null',
         call: (sdk, args) => {
-          const modelId = args[0] as string;
-          const expressId = args[1] as number;
-          const entity = sdk.entity({ modelId, expressId });
+          const ref = toRef({ modelId: args[0], expressId: args[1] });
+          if (!ref) return null;
+          const entity = sdk.entity(ref);
           return entity ? withAliases(entity) : null;
         },
         returns: 'value',


### PR DESCRIPTION
## Summary

This is a consistency fix, not a bugfix (details below). Base is `upstream/main`, not #3471.

`bim.query.entity(modelId, expressId)` built its `EntityRef` inline from the raw args instead of calling the shared `toRef()` helper that every other method in `bim.query` uses:

- Bypass: `packages/sandbox/src/bridge-query.ts:61-63` (before this fix) —
  ```ts
  const modelId = args[0] as string;
  const expressId = args[1] as number;
  const entity = sdk.entity({ modelId, expressId });
  ```
  Every other `bim.query` method (`attributes`, `properties`, `quantities`, `property`, `classifications`, `materials`, `typeProperties`, `documents`, `relationships`, `quantity`, `related`, `containedIn`, `contains`, `decomposedBy`, `decomposes`, `storey`, `path`) calls `toRef(args[0])` and falls back to `null`/`[]` on an unusable ref. `entity` was the one holdout, building the ref with TS-only casts (no runtime check) instead.

## What I actually observed (step 3 of the investigation)

I wrote a throwaway vitest spec calling `bridge-query.ts`'s `entity` handler directly with `NaN`, `Infinity`, `-1`, `1.5` as `expressId`, with a mocked `sdk.entity` that records its call args. On current `upstream/main`:

- All four bad values reached `sdk.entity({ modelId, expressId: <bad value> })` unchanged — no throw, no rejection.
- The real lookup underneath (`packages/parser/src/columnar-parser.ts:491/514`, `parsedEntityData.get(ref.expressId)`) is a `Map.get()` keyed by `expressId`. A `NaN`/`Infinity`/negative/fractional key simply never matches a real entry, so this returns `undefined` → the bridge returns `null` harmlessly. No corruption, no wrong result.

**Conclusion: this was not live data corruption** — it's the same class of gap as #3471 flagged (a read lookup, not a silent mutation), but not itself a "wrong answer" bug today.

## Why this PR still matters, and its relationship to #3471

Because `entity()` never called `toRef`, it *also* never inherits whatever validation lives inside `toRef` — including #3471's still-open hardening (`Number.isInteger(expressId) && expressId > 0`). Today, `toRef` only checks `typeof expressId === 'number'`, so routing `entity()` through it does not yet reject `NaN`/`Infinity`/`-1`/`1.5` (those are all `typeof 'number'` too) — it closes the *shape* gap (wrong-typed `modelId`/`expressId`, e.g. a number where a string was expected), which `toRef` already checks and which `entity()` previously ignored entirely via its `as string`/`as number` casts.

Once #3471 merges and hardens `toRef` itself, `entity()` will automatically inherit the NaN/Infinity/negative/fractional rejection too, with no further change needed here — because it now goes through `toRef` like everything else. Today, on `main` alone, #3471 not being merged means `entity()`'s behaviour for those specific bad-numeric values is unchanged by this PR (still passed to `sdk.entity`, still harmlessly returns `null`). No merge conflict expected — the two PRs touch different files (`bridge-helpers.ts` vs `bridge-query.ts`).

## Tests (RED before / GREEN after)

`packages/sandbox/src/bridge-query.test.ts`, `describe('bim.query.entity', ...)`:

- Two new `it.each` cases: `modelId` as a number, `expressId` as a string. Both call `sdk.entity` in a way that throws if invoked — confirmed RED before the fix (`sdk.entity` was called with the garbage-shaped ref) and GREEN after (rejected via `toRef`, returns `null`, `sdk.entity` never called).
- Regression test: a valid `(modelId, expressId)` pair still reaches `sdk.entity` unmodified and the entity comes back aliased correctly.
- I did **not** add a passing "NaN/Infinity/-1/1.5 rejected" assertion, since that would be false on this branch alone (see above) — doing so would have been a fabricated GREEN. The existing docblock notes this explicitly and links to #3471.

Full package suite: `208 passed (208)`.

## Sweep for other inline-ref sites in `packages/sandbox/src`

- `bridge-store.ts` (all `addColumn`/`addWall`/`addSlab`/`addBeam`/etc.): already validated via `requireStoreyId` (`Number.isInteger(id) && id > 0`, throws on failure) — not a bypass, left alone.
- `bridge-mutate.ts`: all three methods already call `toRef(args[0])` — not a bypass.
- `bridge-create.ts:473` (`setColor`, `args[1] as number` as an element id) and `bridge-create-schedule.ts` (numeric handles into the in-memory creator subsystem): **not fixed** — these operate on the in-memory IFC creator (`creatorRegistry`), not real STEP express ids from a parsed document. Different subsystem, different validation semantics (a judgement call, flagged but not touched, per #3471's own note).
- No other `{ modelId, expressId }`-shaped literal or `as number`-into-ref-shaped-object found anywhere else in `packages/sandbox/src`.

## Module size

`node scripts/check-module-size.mjs` → `OK (2021 files measured, 307 allowlisted, 0 new over 400)`.

## Changeset

`@ifc-lite/sandbox` is published (no `private` in `package.json`). Added `.changeset/bridge-query-entity-toref-bypass.md` (patch) — behaviour does change for a caller passing a wrong-typed `modelId`/`expressId` (now `null` instead of an unchecked SDK call).