### PR TITLE
fix(viewer): classify a server-hydrated IfcQuantityNumber as Number, not Count

### DIFF
--- a/apps/server/src/services/data_model/quantities.rs
+++ b/apps/server/src/services/data_model/quantities.rs
@@ -65,7 +65,8 @@ pub(super) fn extract_quantities(
 
 /// Extract a single quantity value from IfcPhysicalQuantity entity.
 /// Supports: IfcQuantityLength, IfcQuantityArea, IfcQuantityVolume,
-///           IfcQuantityCount, IfcQuantityWeight, IfcQuantityTime
+///           IfcQuantityCount, IfcQuantityWeight, IfcQuantityTime,
+///           IfcQuantityNumber
 fn extract_quantity_value(entity: &DecodedEntity) -> Option<Quantity> {
     // PERF: Use eq_ignore_ascii_case to avoid string allocation per comparison
     let ifc_type = entity.ifc_type.as_str();
@@ -83,6 +84,8 @@ fn extract_quantity_value(entity: &DecodedEntity) -> Option<Quantity> {
         "weight"
     } else if ifc_type.eq_ignore_ascii_case("IFCQUANTITYTIME") {
         "time"
+    } else if ifc_type.eq_ignore_ascii_case("IFCQUANTITYNUMBER") {
+        "number"
     } else {
         return None; // Not a recognized quantity type
     };

--- a/apps/server/src/services/data_model/tests.rs
+++ b/apps/server/src/services/data_model/tests.rs
@@ -540,23 +540,27 @@ fn backfills_only_missing_document_reference_fields_from_referenced_document() {
 
 /// One quantity of EACH `IfcPhysicalQuantity` subtype the extractor supports,
 /// on a single Qto. Only `IFCQUANTITYLENGTH` was previously exercised (via
-/// `Qto_WallBaseQuantities.Width` in `TYPE_PARITY_IFC`) — the other five
-/// match arms in `extract_quantity_value`'s `quantity_type` mapping had no
+/// `Qto_WallBaseQuantities.Width` in `TYPE_PARITY_IFC`) — the other match
+/// arms in `extract_quantity_value`'s `quantity_type` mapping had no
 /// coverage, so e.g. "area" and "volume" could be silently swapped.
+/// `IFCQUANTITYNUMBER` was worse than swapped: unrecognised, so `#3266`'s
+/// subtype was dropped from the quantity set entirely. It is IFC4X3-only,
+/// hence this fixture's schema header.
 const ALL_QUANTITY_KINDS_IFC: &str = r#"ISO-10303-21;
 HEADER;
-FILE_SCHEMA(('IFC4'));
+FILE_SCHEMA(('IFC4X3'));
 ENDSEC;
 DATA;
 #1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,$,$);
 #10=IFCWALL('Wall00000000000000001',$,'W1',$,$,$,$,$,$);
-#20=IFCELEMENTQUANTITY('Qset00000000000000001',$,'Qto_All',$,$,(#21,#22,#23,#24,#25,#26));
+#20=IFCELEMENTQUANTITY('Qset00000000000000001',$,'Qto_All',$,$,(#21,#22,#23,#24,#25,#26,#27));
 #21=IFCQUANTITYLENGTH('QLen',$,$,111.);
 #22=IFCQUANTITYAREA('QArea',$,$,222.);
 #23=IFCQUANTITYVOLUME('QVol',$,$,333.);
 #24=IFCQUANTITYCOUNT('QCount',$,$,444.);
 #25=IFCQUANTITYWEIGHT('QWeight',$,$,555.);
 #26=IFCQUANTITYTIME('QTime',$,$,666.);
+#27=IFCQUANTITYNUMBER('QNumber',$,$,777.);
 #30=IFCRELDEFINESBYPROPERTIES('Rdbp0000000000000001',$,$,$,(#10),#20);
 ENDSEC;
 END-ISO-10303-21;
@@ -588,6 +592,8 @@ fn maps_every_physical_quantity_subtype_to_its_own_quantity_type_string() {
     assert_eq!(q("QWeight").quantity_value, 555.0);
     assert_eq!(q("QTime").quantity_type, "time");
     assert_eq!(q("QTime").quantity_value, 666.0);
+    assert_eq!(q("QNumber").quantity_type, "number");
+    assert_eq!(q("QNumber").quantity_value, 777.0);
 }
 
 /// A wall associated DIRECTLY with an `IfcMaterial` (no layer set / usage

--- a/apps/viewer/src/utils/serverDataModel.test.ts
+++ b/apps/viewer/src/utils/serverDataModel.test.ts
@@ -5,7 +5,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { ServerEntityIndex, type DataModel } from '@ifc-lite/server-client';
-import { IfcTypeEnum, RelationshipType, STOREY_ELEVATION_MATCH_TOLERANCE_M } from '@ifc-lite/data';
+import { IfcTypeEnum, QuantityType, RelationshipType, STOREY_ELEVATION_MATCH_TOLERANCE_M } from '@ifc-lite/data';
 import { EntityQuery } from '@ifc-lite/query';
 import { convertServerDataModel, type ServerParseResult } from './serverDataModel';
 
@@ -188,6 +188,45 @@ describe('convertServerDataModel', () => {
     // TYPEHASPROPERTYSETS must NOT become a graph edge.
     assert.deepEqual(store.relationships.getRelated(20, RelationshipType.DefinesByProperties, 'forward'), []);
   });
+  it('classifies IfcQuantityNumber as QuantityType.Number, not Count (#3266 sibling)', () => {
+    // IFC4X3 added `IfcQuantityNumber`. The columnar parser's own
+    // QUANTITY_TYPE_MAP already carries it (packages/parser's
+    // columnar-parser-indexes.ts, fixed by #3266); this pins the server-hydrated
+    // path's INDEPENDENT `mapQuantityType` switch, which must classify the
+    // server's "number" quantity_type string the same way — not silently fall
+    // through its `default` to Count, which is exactly the #3266 defect this
+    // pins for the second, un-fixed implementation of the same mapping.
+    const dataModel: DataModel = {
+      entities: ServerEntityIndex.fromRows([
+        { entity_id: 10, type_name: 'IFCREINFORCINGBAR', global_id: 'r', name: 'Bar', has_geometry: false },
+      ]),
+      propertySets: new Map(),
+      quantitySets: new Map([
+        [30, {
+          qset_id: 30,
+          qset_name: 'Qto_ReinforcingBarBaseQuantities',
+          quantities: [
+            { quantity_name: 'BarCount', quantity_value: 12, quantity_type: 'number' },
+          ],
+        }],
+      ]),
+      relationships: [
+        { rel_type: 'IFCRELDEFINESBYPROPERTIES', relating_id: 30, related_id: 10 },
+      ],
+      spatialHierarchy: {
+        nodes: [{ entity_id: 1, parent_id: 0, level: 0, path: 'P', type_name: 'IFCPROJECT', name: 'P', children_ids: [], element_ids: [] }],
+        project_id: 1,
+        element_to_storey: new Map(), element_to_building: new Map(), element_to_site: new Map(), element_to_space: new Map(),
+      },
+    } as unknown as DataModel;
+
+    const store = convertServerDataModel(dataModel, parseResult, { size: 1 }, []);
+    const qsets = store.quantities.getForEntity(10);
+    assert.equal(qsets.length, 1);
+    assert.equal(qsets[0].quantities[0].name, 'BarCount');
+    assert.equal(qsets[0].quantities[0].type, QuantityType.Number, 'must classify as Number, not fall through to Count');
+  });
+
   it('resolves storey by elevation with the same tolerance as the parser path (#1841)', () => {
     // Two storeys at 0m and 3m. The server-loaded path used to always snap to
     // the nearest storey, so a Z far above the building still resolved to the

--- a/apps/viewer/src/utils/serverDataModel.ts
+++ b/apps/viewer/src/utils/serverDataModel.ts
@@ -546,8 +546,7 @@ export function convertServerDataModel(
     },
   };
 
-  /** Map server quantity type strings to QuantityType enum */
-  const mapQuantityType = (type: string): QuantityType => {
+  const mapQuantityType = (type: string): QuantityType => { // server quantity type string -> QuantityType
     switch (type.toLowerCase()) {
       case 'length': return QuantityType.Length;
       case 'area': return QuantityType.Area;
@@ -555,6 +554,7 @@ export function convertServerDataModel(
       case 'count': return QuantityType.Count;
       case 'weight': return QuantityType.Weight;
       case 'time': return QuantityType.Time;
+      case 'number': return QuantityType.Number; // IfcQuantityNumber, #3266's sibling here
       default: return QuantityType.Count;
     }
   };


### PR DESCRIPTION
## Summary

- `apps/viewer/src/utils/serverDataModel.ts` has its own `quantity_type` string -> `QuantityType` classifier for models loaded from the collab/embed server. It is independent of `packages/parser`'s `QUANTITY_TYPE_MAP`.
- #3266 added `QuantityType.Number` and the `IFCQUANTITYNUMBER` case to the parser-side map, but never touched this second, server-side implementation.
- A server-hydrated IFC4X3 model carrying an `IfcQuantityNumber` therefore fell through this switch's `default` and was silently relabelled `QuantityType.Count` — the exact defect #3266 fixed, reproduced in the one path that fix didn't reach.
- Fix: add the missing `case 'number': return QuantityType.Number;`.

## How this was found

Hunting for a test that exercises a buggy path but asserts too narrowly, `serverDataModel.ts`'s `mapQuantityType` had no test coverage at all for its quantity-type classification (only the type-name/rawTypeName paths have dedicated, narrow test files). Reading it against the already-merged #3266 fix in the sibling (local-parse) path showed the `number` case was never added here.

## Siblings (not fixed here)

Two more implementations of the same `quantity_type` string -> `QuantityType` mapping are also missing a `Number` case, both in packages under other active work per this task's scope, so left alone:
- `packages/mutations/src/store-editor.ts` (name -> enum map, missing `NUMBER`)
- `packages/query/src/duckdb-integration.ts` (enum -> string map, missing `QuantityType.Number`)

## Test plan

- [x] Added `apps/viewer/src/utils/serverDataModel.test.ts`: a server data model with one `IFCREINFORCINGBAR` carrying a quantity whose `quantity_type` is `"number"`. Before the fix: `qsets[0].quantities[0].type` read `3` (`QuantityType.Count`). After: `6` (`QuantityType.Number`).
- [x] `apps/viewer/src/utils/serverDataModel*.test.ts` (14 tests) pass.
- [x] Full `apps/viewer/src/utils/*.test.ts` suite (179 tests) passes.
- [x] `node scripts/check-module-size.mjs` passes.
- [x] `tsc --noEmit` clean on the touched file.
- No changeset: `@ifc-lite/viewer` is `"private": true`.

Refs #3266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436