### PR TITLE
fix(viewer): the Lists Class column named the coalesced class, not the declared one

### DIFF
--- a/apps/viewer/src/lib/lists/adapter.ts
+++ b/apps/viewer/src/lib/lists/adapter.ts
@@ -22,7 +22,7 @@ import {
   extractTypeQuantitiesOnDemand,
 } from '@ifc-lite/parser';
 import type { PropertySet, QuantitySet } from '@ifc-lite/data';
-import { RelationshipType } from '@ifc-lite/data';
+import { RelationshipType, exactTypeName } from '@ifc-lite/data';
 import { ENTITY_ATTRIBUTES } from '@ifc-lite/lists';
 import type { ListDataProvider, ListClassificationRef, DiscoveredColumns } from '@ifc-lite/lists';
 import { resolveEntityPredefinedType } from '../entity-predefined-type.js';
@@ -242,7 +242,7 @@ export function createListDataProvider(
     getEntityObjectType: (id) => store.entities.getObjectType(id) || getOnDemandAttrs(id).objectType,
     getEntityPredefinedType: (id) => getPredefinedTypeFor(id),
     getEntityTag: (id) => store.entities.getTag?.(id) || getOnDemandAttrs(id).tag,
-    getEntityTypeName: (id) => store.entities.getTypeName(id),
+    getEntityTypeName: (id) => exactTypeName(store.entities, id), // declared class, not coalesced (#3325)
 
     getPropertySets: getPropertySetsFor,
     getQuantitySets: getQuantitySetsFor,

--- a/apps/viewer/src/lib/lists/class-column-exact-type.test.ts
+++ b/apps/viewer/src/lib/lists/class-column-exact-type.test.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The Lists panel's `Class` column must name the class an entity's STEP line
+ * actually DECLARED, matching `@ifc-lite/data`'s `exactTypeName()` — the same
+ * answer #3325 put in the Parquet exporter's `Type` column and #3322 put in
+ * the viewer store's export path, after both were caught naming the
+ * `IfcTypeEnum`-coalesced family instead (`IFCDOORSTANDARDCASE` reported as
+ * `IfcDoor`). `createListDataProvider` (apps/viewer/src/lib/lists/adapter.ts)
+ * is a THIRD, independent consumer of the same entity table and had its own
+ * `getEntityTypeName: (id) => store.entities.getTypeName(id)` — the coalesced
+ * accessor — so the Lists panel's `Class` column, and every CSV/XLSX export
+ * built from it, silently renamed `IfcDoorStandardCase` to `IfcDoor` with no
+ * error and no other signal.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { IfcParser } from '@ifc-lite/parser';
+import { createListDataProvider } from './adapter.js';
+
+// A door whose STEP line declares the StandardCase subtype (IfcTypeEnum
+// coalesces it onto plain IfcDoor for scope-chip grouping), plus a plain
+// IfcDoor as a negative control that must NOT change.
+const FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,$,$);
+#2=IFCDOORSTANDARDCASE('Door00000000000000001A',$,'Door-A',$,$,$,$,$,2.,0.9,$,$,$);
+#3=IFCDOOR('Door00000000000000001B',$,'Door-B',$,$,$,$,$,2.,0.9,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+describe('Lists Class column names the declared class, not the coalesced family (#3325 twin)', () => {
+  it('reports IfcDoorStandardCase for a STEP line that declares it', async () => {
+    const bytes = new TextEncoder().encode(FIXTURE);
+    const store = await new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+    const provider = createListDataProvider(store);
+
+    assert.equal(provider.getEntityTypeName(2), 'IfcDoorStandardCase');
+    // Negative control: a plain IfcDoor must still read back as IfcDoor.
+    assert.equal(provider.getEntityTypeName(3), 'IfcDoor');
+  });
+});


### PR DESCRIPTION
`apps/viewer/src/lib/lists/adapter.ts`'s `createListDataProvider` fed the Lists panel's `Class` column — and its CSV/XLSX export — from `store.entities.getTypeName(id)`, which resolves through `IfcTypeEnum` and therefore returns the *coalesced family* name. An `IFCDOORSTANDARDCASE` entity was shown and exported as `IfcDoor`, with no error or signal that a substitution had happened.

## Why this is a defect and not a preference

`@ifc-lite/data`'s `exactTypeName()` exists precisely for this, and its own doc states the rule:

> `IfcTypeEnum` coalesces several class names onto one value on purpose […] so the viewer's scope chips render one chip per family rather than one per spelling. […] For a chip label that is right. **For an export it is a silent, unrecoverable substitution**: the Parquet `Type` column named an `IFCDOORSTANDARDCASE` line `IfcDoor`, disagreeing with `StepExporter`, which re-emits every class verbatim.

That helper was introduced for the Parquet `Type` column (#3325) and used again for the viewer store export (#3322). `adapter.ts` is a **third, independent consumer of the same rule that never received the fix** — the same shape as the duplicate-property-set family (#2907 → #3463/#3465/#3468) and the quantity-type map (#3266 → #3474).

## Scope: one accessor, deliberately

Only `getEntityTypeName` changed. `adapter.ts` calls `getTypeName` in a second place — feeding `buildSpatialAncestryIndex` — and that one is left alone on purpose: grouping is exactly the case the helper's doc says the coalesced name is *correct* for. Changing both would have "fixed" the defect and broken the behaviour `scope-types.test.ts` pins.

## Verification

- **RED**: new `class-column-exact-type.test.ts` parses a fixture containing an `IFCDOORSTANDARDCASE` entity through the real `createListDataProvider` and asserts `getEntityTypeName(2) === 'IfcDoorStandardCase'` — failed with `'IfcDoor'` before the change.
- **GREEN**: passes after.
- Full `src/lib/lists` suite: **96 tests across 12 files, all passing**, including `server-type-parity.test.ts` and the scope-chip tests that pin the coalescing behaviour left untouched.
- `apps/viewer` `tsc --noEmit` clean.
- `check-module-size` OK — `adapter.ts` sits at exactly its 419-line budget (the added comment was trimmed to fit rather than raising it).

No changeset: `apps/viewer` is `private: true`.

Full `apps/viewer` suite subsequently run as well: **6498 passing, 0 failing**, 6 pre-existing skips.

Refs #3325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The Lists panel’s **Class** column now displays each entity’s exact declared IFC type instead of a broader coalesced family.

- **Tests**
  - Added coverage to verify accurate type names for StandardCase and plain door entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
