### PR TITLE
fix(viewer): pick the Filter-tab selection-key column by priority, not position

### DIFF
--- a/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
@@ -117,6 +117,23 @@ describe('filterResultToSearchResults', () => {
     assert.equal(out[0].expressId, 55);
   });
 
+  it('prefers express_id over entity_id when a result carries both, regardless of column order — same PRIORITY order as SearchModalFilter.selectionKeyIndex, not first-match-by-position', () => {
+    // entity_id appears BEFORE express_id here. A positional first-match
+    // (`columns.findIndex`) would pick entity_id; SearchModalFilter's own
+    // `selectionKeyIndex` checks SELECTION_COLUMNS in order (express_id
+    // first) and would pick express_id regardless of where either column
+    // sits. The two id spaces are not required to agree row-to-row, so
+    // disagreeing on which one is "the" selection key means a row's
+    // n/N-cycle target can differ from what clicking that same row selects.
+    const result = {
+      columns: ['entity_id', 'express_id', 'name'],
+      rows: [[999, 42, 'Slab A']],
+    };
+    const out = filterResultToSearchResults(result, 'model-1');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].expressId, 42);
+  });
+
   it('produces entries directly consumable by enterVimCycle / applySelection: only modelId + expressId matter for stepping', () => {
     const result = {
       columns: ['express_id', 'global_id', 'name', 'type'],

--- a/apps/viewer/src/lib/search/filter-result-to-search-results.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.ts
@@ -47,7 +47,23 @@ export function filterResultToSearchResults(
   fallbackModelId: string | null,
 ): SearchResult[] {
   const { columns, rows } = result;
-  const keyIdx = columns.findIndex((c) => SELECTION_COLUMNS.includes(c));
+  // Priority order, not positional first-match: `SearchModalFilter`'s own
+  // `selectionKeyIndex` checks SELECTION_COLUMNS in order (express_id before
+  // entity_id) and takes the first candidate PRESENT, wherever it sits in
+  // `columns` — so a result carrying both picks express_id even when
+  // entity_id appears earlier in the column list. A positional
+  // `columns.findIndex` would disagree with that whenever column order and
+  // candidate priority differ, and the two id spaces are not guaranteed to
+  // agree row-to-row, so the two pickers could resolve the same row to two
+  // different elements (row click vs. n/N-cycle stepping).
+  let keyIdx = -1;
+  for (const candidate of SELECTION_COLUMNS) {
+    const i = columns.indexOf(candidate);
+    if (i >= 0) {
+      keyIdx = i;
+      break;
+    }
+  }
   if (keyIdx < 0) return [];
 
   const modelIdx = columns.indexOf('model_id');


### PR DESCRIPTION
## Summary

`filterResultToSearchResults()` (the Filter-tab → vim-cycle bridge that feeds `n`/`N` stepping) picked a result row's selection-key column with `columns.findIndex(c => SELECTION_COLUMNS.includes(c))` — the first `SELECTION_COLUMNS` member found in **column order**.

`SearchModalFilter`'s own `selectionKeyIndex` (the row-click path) checks the same `SELECTION_COLUMNS` list (`['express_id', 'entity_id']`) in **priority order** and takes the first one present, wherever it sits among the columns. The bridge's own doc comment even claims to mirror that guard ("mirrors `SearchModalFilter`'s own `selectionKeyIndex < 0` guard").

The two only agreed because `express_id` currently always precedes `entity_id` in every column set this app produces today. A result carrying both columns, with `entity_id` positioned before `express_id`, would make the two pickers disagree on which id is "the" selection key for a row. Since the two id spaces are not guaranteed to agree row-to-row, that means clicking a row (`selectionKeyIndex`) and stepping to the same row via `n`/`N` (`filterResultToSearchResults` → `enterVimCycle`) could resolve to two different elements.

Fix: switch `filterResultToSearchResults` to the same priority-order scan `selectionKeyIndex` already uses, so the two pickers can no longer diverge on column order.

## Test plan

- [x] Added a RED test reproducing the divergence (`entity_id` before `express_id`, both present) — observed it fail against the old positional lookup (picked 999/`entity_id` instead of 42/`express_id`).
- [x] Fix applied; test now GREEN.
- [x] `node --test` on the full `apps/viewer/src/lib/search/` directory: 192/192 pass.
- [x] `pnpm --filter @ifc-lite/viewer run typecheck`: clean.
- [x] `node scripts/check-module-size.mjs`: OK, no budget regressions.
- [x] `apps/viewer` is `private: true` — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result selection when both entity and express identifiers are available.
  * Ensured row selection and keyboard navigation consistently target the same result, regardless of column order.

* **Tests**
  * Added coverage for search results containing both identifier types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->