### PR TITLE
refactor(viewer): unify duplicated selection-key column resolution

### DIFF
--- a/apps/viewer/src/components/viewer/SearchModal.filter.tsx
+++ b/apps/viewer/src/components/viewer/SearchModal.filter.tsx
@@ -43,6 +43,7 @@ import {
   scanFilterResultRows,
 } from '@/lib/search/isolate-filter-result';
 import { filterResultToSearchResults } from '@/lib/search/filter-result-to-search-results';
+import { selectionKeyColumnIndex } from '@/lib/search/selection-key-column';
 import type { ListDefinition } from '@/lib/lists';
 import { toast } from '@/components/ui/toast';
 import { SearchModalFilterBuilder } from './SearchModal.filter.builder';
@@ -52,10 +53,6 @@ const RESULT_ROW_HEIGHT = 28;
 const TEXT_HIT_LIMIT = 50_000;
 const FILTER_CHUNK_SIZE = 20_000;
 const DEFAULT_LIMIT = 5_000;
-
-/** Columns we treat as "selection keys" — clicking a row routes the
- *  value through the viewer's selection system. */
-const SELECTION_COLUMNS = ['express_id', 'entity_id'] as const;
 
 export function SearchModalFilter() {
   const {
@@ -278,11 +275,7 @@ export function SearchModalFilter() {
   const selectionKeyIndex = useMemo(() => {
     const cols = searchFilterResult?.columns;
     if (!cols) return -1;
-    for (const candidate of SELECTION_COLUMNS) {
-      const i = cols.indexOf(candidate);
-      if (i >= 0) return i;
-    }
-    return -1;
+    return selectionKeyColumnIndex(cols);
   }, [searchFilterResult]);
 
   // Frozen (per-run) conversion of the filter table into SearchResult-shaped

--- a/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.test.ts
@@ -131,4 +131,21 @@ describe('filterResultToSearchResults', () => {
       { modelId: 'm', expressId: 3 },
     ]);
   });
+
+  it('prefers express_id over entity_id when a result carries both, regardless of column order — this is the shared selectionKeyColumnIndex helper\'s PRIORITY-order semantics, not first-match-by-position', () => {
+    // entity_id appears BEFORE express_id here. A positional first-match
+    // (`columns.findIndex`) would pick entity_id; `selectionKeyColumnIndex`
+    // (imported from `./selection-key-column.js`, shared with
+    // `SearchModalFilter`'s own `selectionKeyIndex`) checks SELECTION_COLUMNS
+    // in priority order (express_id first) and picks express_id regardless
+    // of where either column sits. Both call sites import the same helper
+    // now, so they cannot resolve this case differently.
+    const result = {
+      columns: ['entity_id', 'express_id', 'name'],
+      rows: [[999, 42, 'Slab A']],
+    };
+    const out = filterResultToSearchResults(result, 'model-1');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].expressId, 42);
+  });
 });

--- a/apps/viewer/src/lib/search/filter-result-to-search-results.ts
+++ b/apps/viewer/src/lib/search/filter-result-to-search-results.ts
@@ -22,10 +22,7 @@
  */
 
 import type { SearchResult, MatchField } from './tier0-scan.js';
-
-/** Columns a filter row's selection key may appear under (kept in sync
- *  with `SearchModalFilter`'s own `SELECTION_COLUMNS`). */
-const SELECTION_COLUMNS: readonly string[] = ['express_id', 'entity_id'];
+import { selectionKeyColumnIndex } from './selection-key-column.js';
 
 /** Placeholder — the cycle-stepping path never reads `matchField` /
  *  `score`; only `modelId` / `expressId` drive selection + framing. */
@@ -40,14 +37,15 @@ const PLACEHOLDER_MATCH_FIELD: MatchField = 'name';
  * `null` there and rows are skipped when it's absent, rather than guessed.
  *
  * Returns `[]` (never throws) if the result has no recognised selection-key
- * column — mirrors `SearchModalFilter`'s own `selectionKeyIndex < 0` guard.
+ * column — uses the same shared `selectionKeyColumnIndex` helper as
+ * `SearchModalFilter`'s own `selectionKeyIndex`, so the two can't disagree.
  */
 export function filterResultToSearchResults(
   result: { columns: string[]; rows: unknown[][] },
   fallbackModelId: string | null,
 ): SearchResult[] {
   const { columns, rows } = result;
-  const keyIdx = columns.findIndex((c) => SELECTION_COLUMNS.includes(c));
+  const keyIdx = selectionKeyColumnIndex(columns);
   if (keyIdx < 0) return [];
 
   const modelIdx = columns.indexOf('model_id');

--- a/apps/viewer/src/lib/search/selection-key-column.test.ts
+++ b/apps/viewer/src/lib/search/selection-key-column.test.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Coverage for the shared selection-key resolution used by both
+ * `SearchModalFilter`'s row click (`selectionKeyIndex`) and
+ * `filterResultToSearchResults`'s n/N-cycle bridge. The discriminating case
+ * — both `express_id` and `entity_id` present, `entity_id` positioned
+ * first — is what previously made the two call sites' own local copies of
+ * this logic disagree (see `filter-result-to-search-results.test.ts`'s
+ * "prefers express_id over entity_id ..." test for the bridge-level pin).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { SELECTION_COLUMNS, selectionKeyColumnIndex } from './selection-key-column.js';
+
+describe('selectionKeyColumnIndex', () => {
+  it('picks express_id over entity_id when both are present, even when entity_id comes first', () => {
+    assert.equal(selectionKeyColumnIndex(['entity_id', 'express_id', 'name']), 1);
+  });
+
+  it('picks whichever SELECTION_COLUMNS candidate is present when only one is', () => {
+    assert.equal(selectionKeyColumnIndex(['express_id', 'name']), 0);
+    assert.equal(selectionKeyColumnIndex(['entity_id', 'name']), 0);
+  });
+
+  it('returns -1 when no candidate column is present', () => {
+    assert.equal(selectionKeyColumnIndex(['name', 'type']), -1);
+  });
+
+  it('SELECTION_COLUMNS is express_id before entity_id (the priority order the helper walks)', () => {
+    assert.deepEqual(SELECTION_COLUMNS, ['express_id', 'entity_id']);
+  });
+});

--- a/apps/viewer/src/lib/search/selection-key-column.ts
+++ b/apps/viewer/src/lib/search/selection-key-column.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared "which column holds the selection key" resolution for the Filter
+ * tab's two independent consumers: `SearchModalFilter` (row click) and
+ * `filterResultToSearchResults` (n/N vim-cycle stepping). Both used to
+ * declare their own `SELECTION_COLUMNS` and their own resolution loop; one
+ * iterated the priority list (first candidate PRESENT, wherever it sits in
+ * `columns`), the other iterated `columns` itself (first column POSITION
+ * that happens to be a key). With both `entity_id` and `express_id` present
+ * as columns and `entity_id` positioned before `express_id`, the two
+ * algorithms picked different columns — a row click and n/N-stepping the
+ * same row could select two different elements. Exporting one constant and
+ * one function makes that divergence structurally impossible instead of
+ * merely aligned for now.
+ */
+
+/** Columns a filter row's selection key may appear under, in priority
+ *  order — `express_id` wins over `entity_id` regardless of which comes
+ *  first in a result's `columns` array. */
+export const SELECTION_COLUMNS = ['express_id', 'entity_id'] as const;
+
+/**
+ * Resolve the selection-key column index from a result's `columns` array,
+ * checking `SELECTION_COLUMNS` in priority order and returning the index of
+ * the first candidate present — not the first column position that happens
+ * to be a key. Returns -1 if none of `SELECTION_COLUMNS` appears.
+ */
+export function selectionKeyColumnIndex(columns: readonly string[]): number {
+  for (const candidate of SELECTION_COLUMNS) {
+    const i = columns.indexOf(candidate);
+    if (i >= 0) return i;
+  }
+  return -1;
+}


### PR DESCRIPTION
## Summary

References #3476.

**#3476 status when this PR was opened: still OPEN, not merged.** `upstream/main` at the time still had `filter-result-to-search-results.ts` resolving the selection-key column by *column position* (`columns.findIndex((c) => SELECTION_COLUMNS.includes(c))`), while `SearchModal.filter.tsx` resolved it by *priority order* — the exact divergence #3476 documents and fixes on its own branch.

Because I branched from `upstream/main` (not from #3476's branch) and #3476's exact code wasn't guaranteed to be there, I incorporated #3476's priority-order alignment as part of this PR rather than assuming it. **Be aware: this PR carries #3476's behavioral fix as a side effect of the refactor** — it is not a separate, independent no-op refactor on top of already-merged code. If #3476 merges first, this PR becomes a pure refactor (no behavior change) and should be easy to rebase; if this PR merges first, it also resolves #3476's substance, and #3476 can be closed as superseded/redundant by its author or a maintainer (not by me — I'm not closing anything).

**Suggested merge order:** #3476 first (it's the smaller, focused fix and already has a review pass), then rebase/merge this one for the structural cleanup. If it's more convenient to merge this one first instead, that's fine too — the net result on `main` is the same either way.

## What changed

The core problem #3476 doesn't address: `SELECTION_COLUMNS` was declared **twice** (once per file) and the resolution logic was written twice — a rule that needs two independent implementations to independently reimplement correctly, which is exactly the kind of duplication that let the two algorithms drift apart in the first place. Aligning the algorithms (what #3476 does) makes them agree *today*; nothing stopped them from disagreeing again after the next edit to either copy.

This extracts one shared module:

- **`apps/viewer/src/lib/search/selection-key-column.ts`** (new) — exports the `SELECTION_COLUMNS` priority-list constant and one `selectionKeyColumnIndex(columns)` helper implementing priority-order resolution (walk the priority list, return the index of the first candidate present in `columns`, wherever it sits). Placed in `apps/viewer/src/lib/search/` because that's the existing home for Filter-tab search helpers — `SearchModal.filter.tsx` already imports from there (`filter-result-to-search-results`, `filter-evaluate`, `isolate-filter-result`, etc.), and it's a sibling of the two files that needed it.
- **`apps/viewer/src/components/viewer/SearchModal.filter.tsx`** — `selectionKeyIndex` (the `useMemo` that drives row-click selection) now calls the shared helper; the local `SELECTION_COLUMNS` constant and inline loop are removed.
- **`apps/viewer/src/lib/search/filter-result-to-search-results.ts`** — the n/N vim-cycle bridge now calls the same shared helper for `keyIdx`; its local `SELECTION_COLUMNS` and positional `columns.findIndex` are removed, along with the stale comment claiming to "mirror" the component (that comment predates the divergence #3476 found — replaced with a comment that's actually guaranteed true now that both call sites import the same function).

Both call sites now import the identical constant and function, so they cannot resolve this differently again without someone editing the shared module (which both depend on) rather than one private copy.

## Tests

- `apps/viewer/src/lib/search/selection-key-column.test.ts` (new) — direct coverage of the shared helper: priority order when both candidates are present, either candidate alone, no candidate, and the constant's own ordering.
- `apps/viewer/src/lib/search/filter-result-to-search-results.test.ts` — added a regression test pinning that a result carrying both `entity_id` (positioned first) and `express_id` resolves to `express_id`, using the bridge function's actual output (not source inspection) since it's a plain exported function, not a React-internal.
- `SearchModal.filter.tsx`'s own `selectionKeyIndex` is a `useMemo` inside a component and isn't unit-tested directly here; verified by reading the diff that it now calls the same `selectionKeyColumnIndex` import, plus the existing full `apps/viewer` build + typecheck passing with no other reference to the old local `SELECTION_COLUMNS` in that file (confirmed via grep after the edit).

## CI-equivalent checks run locally

- `node scripts/check-module-size.mjs` — passes, 0 files newly over budget (new files are well under 400 lines; `SearchModal.filter.tsx` shrank).
- `pnpm exec tsc --noEmit` in `apps/viewer` — clean, no errors (test files included).
- Targeted test run (`tsx --import ./src/test/vite-module-hooks.mjs --test ...`) over `apps/viewer/src/lib/search/*.test.ts` (all 13 files in that directory, 196 tests) — all pass, including the two new/modified files.

## Honesty note

This is a refactor, not a newly-found bug beyond what #3476 already documented — except for the caveat above: because #3476 hadn't merged, this PR's baseline required re-doing its priority-order alignment itself, so functionally it also fixes the divergence #3476 fixes. No other behavior changes.
