### PR TITLE
fix(export): raise a prefixed SI area/volume unit's multiplier to its dimension

### DIFF
--- a/.changeset/merge-area-volume-prefix-power.md
+++ b/.changeset/merge-area-volume-prefix-power.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': patch
+---
+
+Fix `MergedExporter`'s unit normalization applying a prefixed SI area/volume unit's multiplier linearly instead of raised to the unit's dimension (a CENTI square metre is `(10⁻²)²`, not `10⁻²`). Reachable only when merging models under `unitReconciliation: 'normalize'` where a non-primary model declares an explicit prefixed `IFCSIUNIT` for `AREAUNIT`/`VOLUMEUNIT` (rare); every area/volume quantity from that model was silently rescaled by the wrong factor.

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1131,6 +1131,30 @@ describe('MergedExporter', () => {
       expect(findDanglingRefs(content)).toEqual([]);
     });
 
+    // Regression: a prefixed SI area/volume unit must scale the prefix by the
+    // unit's dimension (area = prefix², volume = prefix³), matching both
+    // `rust/core/src/project_units/symbols.rs`'s `prefix_power` and
+    // `packages/parser/src/project-units.ts`'s `siUnitSymbolAndScale` — the two
+    // implementations this repo already cross-checks by parity test. A CENTI
+    // SQUARE_METRE unit is (10⁻²)² = 1e-4 m² per unit, not 1e-2.
+    it('scales a prefixed SI area unit by the prefix squared, not linearly', () => {
+      const secondary = buildModel('centi', 'Centi', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('centiProj')}',$,'Centi',$,$,$,$,$,#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#3,#4));'],
+        [3, 'IFCSIUNIT', '#3=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);'],
+        [4, 'IFCSIUNIT', '#4=IFCSIUNIT(*,.AREAUNIT.,.CENTI.,.SQUARE_METRE.);'],
+        [5, 'IFCELEMENTQUANTITY', `#5=IFCELEMENTQUANTITY('${guid('centiQto')}',$,'Q',$,$,(#6));`],
+        [6, 'IFCQUANTITYAREA', "#6=IFCQUANTITYAREA('Area',$,$,10.,$);"],
+      ]);
+      secondary.lengthUnitScale = 0.001;
+
+      const content = decode(new MergedExporter([metreModel(), secondary])
+        .export({ schema: 'IFC4', unitReconciliation: 'normalize' }).content);
+      // 10 centi-square-metre × (10⁻²)² m²/unit = 0.001 m².
+      expect(content).toContain("IFCQUANTITYAREA('Area',$,$,0.001,$)");
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
     it('rescales in the other direction (metre model into a feet primary)', () => {
       const feet = buildModel('feet', 'Feet', [
         [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('ftProj')}',$,'Feet',$,$,$,$,$,#2);`],

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -880,8 +880,8 @@ export class MergedExporter {
    * Resolve a model's declared AREAUNIT / VOLUMEUNIT scale (SI m² / m³ per unit)
    * by walking IfcProject → IfcUnitAssignment. Falls back to the length-derived
    * unit (`lengthScale ** power`) when the model declares no explicit area/volume
-   * unit — the IFC default. A prefixed SI area/volume unit (rare) applies the
-   * prefix once (buildingSMART / IfcOpenShell convention).
+   * unit — the IFC default. A prefixed SI area/volume unit (rare) raises the
+   * prefix to `power` (area = prefix², volume = prefix³), matching `rust/core`.
    */
   private resolveDerivedUnitScale(
     dataStore: IfcDataStore,
@@ -912,8 +912,8 @@ export class MergedExporter {
         if (this.normalizeEnum(this.extractStepAttribute(uid, dataStore, 1)) !== wantType) continue;
         const prefixRaw = this.extractStepAttribute(uid, dataStore, 2);
         if (!prefixRaw || prefixRaw === '$' || prefixRaw === '*') return 1.0; // square/cubic metre
-        const mult = SI_PREFIX_MULTIPLIERS[this.normalizeEnum(prefixRaw)];
-        return mult !== undefined ? mult : 1.0;
+        const mult = SI_PREFIX_MULTIPLIERS[this.normalizeEnum(prefixRaw)]; // see doc: raised to `power`
+        return mult !== undefined ? Math.pow(mult, power) : 1.0;
       }
 
       if (utype === 'IFCCONVERSIONBASEDUNIT') {


### PR DESCRIPTION
## Summary

`MergedExporter.resolveDerivedUnitScale` (`packages/export/src/merged-exporter.ts`) resolves a merged model's declared `AREAUNIT`/`VOLUMEUNIT` scale. For an explicit `IfcSIUnit` with a prefix (e.g. `IFCSIUNIT(*,.AREAUNIT.,.CENTI.,.SQUARE_METRE.)`), it applied the prefix multiplier **linearly** for both area and volume, instead of raising it to the unit's dimension.

The correct convention — already implemented and cross-checked by parity test between `rust/core/src/project_units/symbols.rs` (`prefix_power`) and `packages/parser/src/project-units.ts` (`siUnitSymbolAndScale`) — is `base_scale * prefix_multiplier.powi(prefix_power)`, where `prefix_power` is 2 for `SQUARE_METRE` and 3 for `CUBIC_METRE` (e.g. a `CENTI` cubic metre is `(10⁻²)³`). `merged-exporter.ts` duplicates this domain logic independently and had drifted: a `CENTI SQUARE_METRE` unit resolved to `1e-2` m² per unit instead of `(10⁻²)² = 1e-4`, a 100x error.

**Consequence class: silent corruption.** Only reachable via `unitReconciliation: 'normalize'` when a non-primary model declares an explicit prefixed `AREAUNIT`/`VOLUMEUNIT` (rare in practice — most files either omit the prefix or use a conversion-based unit), but when it fires, every area/volume quantity from that model is silently rescaled by the wrong factor with no error or warning.

Also fixed a stale doc comment above the function that claimed the (buggy) linear-multiplier behaviour was the intended "buildingSMART / IfcOpenShell convention" — it wasn't; it just described what the code did.

## How I established correct behaviour

Read `rust/core/src/project_units/symbols.rs::si_unit_symbol_and_scale`, which documents and implements `scale = base_scale * prefix_mult.powi(prefix_power)` with `prefix_power` 2/3 for `SQUARE_METRE`/`CUBIC_METRE`. Cross-checked against `packages/parser/src/project-units.ts::siUnitSymbolAndScale`, which implements the identical formula (`Math.pow(pMult, base.prefixPower)`) and is pinned to the Rust side by `unit-scale.parity.test.ts` / `rust/core/tests/unit_scale_parity.rs`. `merged-exporter.ts`'s own `resolveDerivedUnitScale` re-implements the same domain rule (it even threads a `power` parameter through for its `Math.pow(lengthScale, power)` fallback) but never applied `power` to the explicit-`IfcSIUnit` branch.

## Execution proof (RED)

Added a test declaring a secondary model with `IFCSIUNIT(*,.AREAUNIT.,.CENTI.,.SQUARE_METRE.)` and an `IFCQUANTITYAREA` of `10`. Correct output: `10 * (10⁻²)² = 0.001` m². Before the fix:

```
AssertionError: expected '...' to contain 'IFCQUANTITYAREA(\'Area\',$,$,0.001,$)'
+ IFCQUANTITYAREA('Area',$,$,0.1,$)
```

`0.1` is exactly the buggy `10 * 1e-2` (linear), 100x the correct `0.001`.

## GREEN

After applying `Math.pow(mult, power)`:

```
Test Files  1 passed (1)
     Tests  49 passed (49)
```

## Why existing tests/fixtures missed it

The existing `#1475` normalization test suite covers conversion-based area units (square foot) and unprefixed SI area/volume units, but no test exercised an explicit *prefixed* `IfcSIUnit` for `AREAUNIT`/`VOLUMEUNIT` — a case the function's own code path (and its `power` parameter) clearly anticipated but the fixture set never hit.

## CI-level checks run

- `node scripts/check-module-size.mjs` — passes (`merged-exporter.ts` trimmed to stay within its 1667-line budget after the fix; no budget raised).
- `pnpm exec tsc --noEmit` in `packages/export` — clean.
- `pnpm exec vitest run` in `packages/export` — 80 files / 1057 tests passing (full package suite, not just the targeted file).

## Changeset

Added `.changeset/merge-area-volume-prefix-power.md` (`@ifc-lite/export`: patch) — `packages/export` is a published package.

Refs #1475 (the normalization feature this extends test coverage for; not closing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unit normalization for prefixed area and volume measurements when merging models.
  * Area and volume values now scale correctly according to their dimensions—for example, square and cubic prefixes are applied appropriately.
  * Prevented silently incorrect measurements during normalized model exports.

* **Tests**
  * Added coverage verifying accurate conversion of prefixed area units and clean exported references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->