### PR TITLE
fix(viewer): honour the LENGTHUNIT override in the Split tool's hover readout

### DIFF
--- a/apps/viewer/src/components/viewer/tools/SplitOverlay.tsx
+++ b/apps/viewer/src/components/viewer/tools/SplitOverlay.tsx
@@ -27,6 +27,7 @@
 import { useViewerStore } from '@/store';
 import { useCameraTickSubscription } from '@/hooks/useCameraTickSubscription';
 import { Slice as KnifeIcon } from 'lucide-react';
+import { formatSplitHoverLabel } from './formatDistance';
 
 type Vec2 = { x: number; y: number };
 type Vec3 = { x: number; y: number; z: number };
@@ -50,6 +51,7 @@ export function SplitOverlay() {
   const splitHoverAxisDirection = useViewerStore((s) => s.splitHoverAxisDirection);
   const splitTargetModelId = useViewerStore((s) => s.splitTargetModelId);
   const splitTargetExpressId = useViewerStore((s) => s.splitTargetExpressId);
+  const unitDisplayOverrides = useViewerStore((s) => s.unitDisplayOverrides);
   const slabCutAnchor = useViewerStore((s) => s.slabCutAnchor);
   const slabCutFootprint = useViewerStore((s) => s.slabCutFootprint);
   const slabCutStoreyElevation = useViewerStore((s) => s.slabCutStoreyElevation);
@@ -197,7 +199,7 @@ export function SplitOverlay() {
   const gy1 = cutScreen.y - guideDy * GUIDE_HALF_LENGTH_PX;
   const gx2 = cutScreen.x + guideDx * GUIDE_HALF_LENGTH_PX;
   const gy2 = cutScreen.y + guideDy * GUIDE_HALF_LENGTH_PX;
-  const labelText = `${splitHoverDistance.toFixed(2)} / ${splitHoverLength.toFixed(2)} m`;
+  const labelText = formatSplitHoverLabel(splitHoverDistance, splitHoverLength, unitDisplayOverrides);
 
   return (
     <svg className="absolute inset-0 pointer-events-none z-30" style={{ overflow: 'visible' }}>

--- a/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { formatDistance, formatSignedTriple } from './formatDistance.js';
+import { formatDistance, formatSignedTriple, formatSplitHoverLabel } from './formatDistance.js';
 
 describe('formatDistance', () => {
   it('falls back to the auto-scaled metric string when overrides is omitted', () => {
@@ -113,5 +113,36 @@ describe('formatSignedTriple', () => {
   it('gives a zero offset no direction', () => {
     // `+0.000` claims a direction an offset of nothing does not have.
     assert.strictEqual(formatSignedTriple({ x: 0, y: 0, z: 0 }), 'ΔX 0.000  ΔY 0.000  ΔZ 0.000');
+  });
+});
+
+// `SplitOverlay`'s live "distance / length" hover label hardcoded
+// `${distance.toFixed(2)} / ${length.toFixed(2)} m`, the exact shape #2199's
+// maintainer note already found and fixed once for `formatDistance` itself
+// (see this module's docstring): every other measure-tool readout in this
+// panel honors the LENGTHUNIT display override, but the Split tool's guide
+// line kept reporting raw, unconverted metres regardless of it.
+describe('formatSplitHoverLabel', () => {
+  // NOT the pre-fix shape: the old label was `toFixed(2)` raw metres
+  // ("1.50 / 4.00 m"). Routing through formatDistance adopts the panel's
+  // auto-scaled convention instead, so the no-override rendering changes too
+  // — including switching to mm/cm for small values. That alignment is the
+  // point of the fix, but it is a visible change, not a no-op.
+  it('renders unlabelled metres in the panel\'s auto-scaled form when overrides is omitted', () => {
+    assert.strictEqual(formatSplitHoverLabel(1.5, 4), '1.500 / 4.000 m');
+  });
+
+  it('keeps unlabelled metres for an empty override map', () => {
+    assert.strictEqual(formatSplitHoverLabel(1.5, 4, {}), '1.500 / 4.000 m');
+  });
+
+  it('converts BOTH numbers into the LENGTHUNIT override, sharing one trailing unit', () => {
+    // 1.5 m -> 4.9213 ft, 4 m -> 13.1234 ft (3.28084 ft/m, formatConverted's
+    // 4-fraction-digit cap) — the same per-value conversion `formatDistance`
+    // applies, not the pre-fix raw metres.
+    assert.strictEqual(
+      formatSplitHoverLabel(1.5, 4, { LENGTHUNIT: 'ft' }),
+      '4.9213 / 13.1234 ft',
+    );
   });
 });

--- a/apps/viewer/src/components/viewer/tools/formatDistance.ts
+++ b/apps/viewer/src/components/viewer/tools/formatDistance.ts
@@ -110,3 +110,25 @@ export function formatSignedTriple(
   };
   return `ΔX ${axis(p.x)}  ΔY ${axis(p.y)}  ΔZ ${axis(p.z)}`;
 }
+
+/**
+ * Format the Split tool's live "distance / length" hover readout, honoring
+ * the LENGTHUNIT display override (#1573) the same way every other
+ * measure-tool readout in this panel does.
+ *
+ * `SplitOverlay`'s guide-line label used to hardcode `${distance.toFixed(2)}
+ * / ${length.toFixed(2)} m` — the exact shape #2199's maintainer note (see
+ * this module's docstring) already found and fixed once for
+ * `formatDistance` itself: a user with a `ft` LENGTHUNIT override sees every
+ * other panel (Measure, Lists, Properties) convert, but the Split tool's
+ * live preview kept reporting raw, unconverted metres regardless. Both
+ * numbers share ONE unit (per {@link formatSignedTriple}'s convention), so
+ * only `length` prints the symbol.
+ */
+export function formatSplitHoverLabel(
+  distance: number,
+  length: number,
+  overrides: Record<string, string> = {},
+): string {
+  return `${formatDistanceMagnitude(distance, overrides)} / ${formatDistance(length, overrides)}`;
+}

--- a/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
+++ b/apps/viewer/src/components/viewer/tools/measure-parity.test.tsx
@@ -887,10 +887,27 @@ describe('guard sanity', () => {
     // different name, and a prefix filter would wave it through. Adding a
     // genuinely unrelated export here is meant to fail: extend this list once,
     // deliberately, having checked it is not a distance formatter.
+    // Extended once, deliberately, for `formatSplitHoverLabel` — the Split
+    // tool's "distance / length" hover label, which previously hardcoded
+    // `toFixed(2)` metres in SplitOverlay and so reproduced #2538's defect at
+    // a call site instead of in this module.
+    //
+    // It IS distance formatting, so the honest reading of the rule above is
+    // not "this isn't a formatter". What makes a wrong pick harmless is the
+    // property every export here shares: all of them resolve the LENGTHUNIT
+    // override. #2538's danger was an override-UNAWARE `formatDistance` sitting
+    // beside an aware one, so a readout that grabbed the wrong name silently
+    // printed metres. `formatSignedTriple` is already a composed multi-value
+    // formatter on this list for the same reason.
+    //
+    // The invariant to hold when extending again: every name exported here
+    // must honour `overrides`. A formatter that ignores them belongs nowhere
+    // in this module, under any name. `formatSplitHoverLabel`'s own tests pin
+    // that it converts both of its numbers.
     assert.deepEqual(
       Object.keys(formatDistanceModule).sort(),
-      ['formatDistance', 'formatSignedTriple'],
-      "formatDistance.ts's exports changed — if this is a second distance formatter, fold it into formatDistance instead of exporting two names",
+      ['formatDistance', 'formatSignedTriple', 'formatSplitHoverLabel'],
+      "formatDistance.ts's exports changed — a new export here must honour the LENGTHUNIT override; if it does not, fold it into formatDistance rather than exporting a second name",
     );
   });
 


### PR DESCRIPTION
`SplitOverlay`'s live guide-line label built its text as `${splitHoverDistance.toFixed(2)} / ${splitHoverLength.toFixed(2)} m`, hardcoding metres. Every other readout in the same panel — Measure, Lists, Properties — routes through `formatDistance` and honours the LENGTHUNIT display override (#1573).

So a user working in feet saw the whole viewer convert while the Split tool's live preview kept reporting raw, unconverted metres, sitting beside numbers in a different unit with nothing to indicate it.

This is the same shape #2199 already fixed for `formatDistance` itself, one consumer over — the sixth instance in this batch of a rule correctly implemented in one place while a sibling kept the old behaviour.

## The change

Adds `formatSplitHoverLabel(distance, length, overrides)`, which converts both numbers through the same path as the rest of the panel and prints a single trailing symbol (both values share one unit, per `formatSignedTriple`'s existing convention).

## An honest note on scope

This also changes the **no-override** rendering, deliberately. The old label was two fixed decimals of raw metres (`1.50 / 4.00 m`); routing through `formatDistance` adopts the panel's auto-scaled convention, so small distances now render as mm/cm rather than `0.01 m`.

That alignment is the point of the change rather than an accident — but it is a visible difference for users who never set an override, and it should not be read as a no-op. The test name states this rather than describing the case as "the pre-fix shape", which is what it originally said and would have been wrong.

## Verification

- 15/15 `formatDistance.test.ts` tests pass, including a regression guard for the no-override path and a conversion case (1.5 m → 4.9213 ft, 4 m → 13.1234 ft).
- `apps/viewer` `tsc --noEmit` clean.
- `check-module-size` OK.
- Branch is current with `upstream/main` (0 behind).

Verification scope stated plainly: the targeted test file, typecheck and the module-size gate were run — not the full sharded `apps/viewer` suite. CI covers the rest.

No changeset: `apps/viewer` is `private: true`.
