### PR TITLE
fix(lens): cover every IFC *StandardCase entity in IFC_SUBTYPE_TO_BASE

### DIFF
--- a/.changeset/lens-subtype-standardcase-coverage.md
+++ b/.changeset/lens-subtype-standardcase-coverage.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/lens": patch
+---
+
+`IFC_SUBTYPE_TO_BASE`, the map `matchesIfcType` uses so a lens rule against a base type (e.g. `IfcDoor`) also matches its StandardCase variant, only covered 4 of IFC4's 9 `*StandardCase` entities (Wall/Slab/Column/Beam). Door, Window, Member, Plate, and Opening were missing, so a rule written against those base types silently failed to match entities exported as the StandardCase variant — no error, the entity was just left unmatched and ghosted. The map now covers every `*StandardCase` entity across IFC2X3/IFC4/IFC4X3, guarded by a schema-parity test that re-derives the set from the generated entity tables.

--- a/packages/lens/package.json
+++ b/packages/lens/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@ifc-lite/data": "workspace:^",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11"
   },

--- a/packages/lens/src/matching.test.ts
+++ b/packages/lens/src/matching.test.ts
@@ -62,6 +62,46 @@ describe('matchesCriteria — ifcType', () => {
   });
 });
 
+// IFC_SUBTYPE_TO_BASE only covered 4 of IFC4's 9 `*StandardCase` entities
+// (plus the two `*Flight` types) — Door/Member/Plate/Window/Opening were
+// hand-list omissions, so a rule on the base type silently failed to match
+// files exported with those StandardCase variants (issue: lens rule
+// matching does not close over the full StandardCase family).
+describe('matchesCriteria — ifcType subtype coverage (IFC_SUBTYPE_TO_BASE)', () => {
+  const provider = createMockProvider([
+    { id: 1, type: 'IfcDoorStandardCase' },
+    { id: 2, type: 'IfcWindowStandardCase' },
+    { id: 3, type: 'IfcMemberStandardCase' },
+    { id: 4, type: 'IfcPlateStandardCase' },
+    { id: 5, type: 'IfcOpeningStandardCase' },
+  ]);
+
+  it('IfcDoorStandardCase matches an IfcDoor rule', () => {
+    const c: LensCriteria = { type: 'ifcType', ifcType: 'IfcDoor' };
+    expect(matchesCriteria(c, 1, provider)).toBe(true);
+  });
+
+  it('IfcWindowStandardCase matches an IfcWindow rule', () => {
+    const c: LensCriteria = { type: 'ifcType', ifcType: 'IfcWindow' };
+    expect(matchesCriteria(c, 2, provider)).toBe(true);
+  });
+
+  it('IfcMemberStandardCase matches an IfcMember rule', () => {
+    const c: LensCriteria = { type: 'ifcType', ifcType: 'IfcMember' };
+    expect(matchesCriteria(c, 3, provider)).toBe(true);
+  });
+
+  it('IfcPlateStandardCase matches an IfcPlate rule', () => {
+    const c: LensCriteria = { type: 'ifcType', ifcType: 'IfcPlate' };
+    expect(matchesCriteria(c, 4, provider)).toBe(true);
+  });
+
+  it('IfcOpeningStandardCase matches an IfcOpeningElement rule', () => {
+    const c: LensCriteria = { type: 'ifcType', ifcType: 'IfcOpeningElement' };
+    expect(matchesCriteria(c, 5, provider)).toBe(true);
+  });
+});
+
 describe('matchesCriteria — group (#1075)', () => {
   // Spaces 1 & 2 belong to zone "Apt-01"; space 3 belongs to "Apt-02"; entity 4
   // belongs to no group.

--- a/packages/lens/src/types.schema-parity.test.ts
+++ b/packages/lens/src/types.schema-parity.test.ts
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Schema-parity guard for `IFC_SUBTYPE_TO_BASE`.
+ *
+ * `types.ts` hand-maintains this subclass → base-class map rather than
+ * importing `@ifc-lite/data` at runtime (lens does not otherwise depend on
+ * it — used here only at test time, mirroring `feature-elements.schema-parity.test.ts`
+ * in `packages/drawing-2d`). That leaves the same drift risk: the map
+ * originally covered only 4 of IFC4's 9 `*StandardCase` entities
+ * (Wall/Slab/Column/Beam) plus the two `*Flight` types, silently missing
+ * Door/Window/Member/Plate/Opening — a lens rule written against the base
+ * type (`IfcDoor`, `IfcWindow`, ...) never matched entities exported as the
+ * StandardCase variant, and `matchesIfcType` in `matching.ts` returned
+ * `false` with no error.
+ *
+ * This test re-derives every `*StandardCase` entity from `@ifc-lite/data`'s
+ * generated entity tables (IFC2X3, IFC4, IFC4X3 — an authority independent
+ * of the one this map was hand-copied from) and asserts `IFC_SUBTYPE_TO_BASE`
+ * agrees with the schema's declared parent in both directions, so a future
+ * schema bump or hand-edit cannot quietly reopen the gap.
+ *
+ * `IfcStairFlight`/`IfcRampFlight` are deliberately excluded from the
+ * schema-derived check: the schema itself does not parent them under
+ * `IfcStair`/`IfcRamp` (both are `IfcBuiltElement` subtypes — a flight is a
+ * *component* of a stair/ramp, not an alternate representation of one), so
+ * this pair is a curated "treat as the same family for lens matching"
+ * decision, not an inheritance fact the schema can confirm or deny. They are
+ * covered instead by the fixed-membership regression guard below.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ENTITIES_IFC2X3, ENTITIES_IFC4, ENTITIES_IFC4X3 } from '@ifc-lite/data';
+import type { IfcEntityInfo } from '@ifc-lite/data';
+import { IFC_SUBTYPE_TO_BASE } from './types.js';
+
+/** Every concrete `*StandardCase` entity in one schema, mapped to its declared parent. */
+function subtypeUniverse(entities: readonly IfcEntityInfo[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const entity of entities) {
+    if (!entity.parent) continue;
+    if (entity.name.endsWith('StandardCase')) {
+      out.set(entity.name, entity.parent);
+    }
+  }
+  return out;
+}
+
+const SCHEMAS: ReadonlyArray<readonly [name: string, entities: readonly IfcEntityInfo[]]> = [
+  ['IFC2X3', ENTITIES_IFC2X3],
+  ['IFC4', ENTITIES_IFC4],
+  ['IFC4X3', ENTITIES_IFC4X3],
+];
+
+describe('IFC_SUBTYPE_TO_BASE vs generated IFC schemas', () => {
+  for (const [schemaName, entities] of SCHEMAS) {
+    const universe = subtypeUniverse(entities);
+
+    it(`derives a non-trivial *StandardCase/*Flight universe from ${schemaName} (anti-vacuity)`, () => {
+      // If the schema import failed or the naming filter broke, `universe`
+      // would collapse to empty and the assertions below would pass
+      // vacuously.
+      expect(universe.size).toBeGreaterThan(0);
+    });
+
+    it(`IFC_SUBTYPE_TO_BASE covers every ${schemaName} *StandardCase/*Flight entity with its declared parent`, () => {
+      const mismatches: string[] = [];
+      for (const [subtype, parent] of universe) {
+        const mapped = IFC_SUBTYPE_TO_BASE[subtype];
+        if (mapped !== parent) {
+          mismatches.push(`${subtype}: expected -> ${parent}, got -> ${mapped ?? '(missing)'}`);
+        }
+      }
+      expect(mismatches).toEqual([]);
+    });
+  }
+
+  // IfcStairFlight/IfcRampFlight are curated, not schema-derived (see the
+  // file-level comment) — excluded from this check.
+  const CURATED_NON_SCHEMA_ENTRIES = new Set(['IfcStairFlight', 'IfcRampFlight']);
+
+  it('does not map any *StandardCase entry to a parent other than the schema-declared one (no extras/typos)', () => {
+    const allEntities = [...ENTITIES_IFC2X3, ...ENTITIES_IFC4, ...ENTITIES_IFC4X3];
+    const byName = new Map(allEntities.map((e) => [e.name, e]));
+    const badEntries = Object.entries(IFC_SUBTYPE_TO_BASE)
+      .filter(([subtype]) => !CURATED_NON_SCHEMA_ENTRIES.has(subtype))
+      .filter(([subtype, base]) => {
+        const entity = byName.get(subtype);
+        // Every mapped subtype must exist in at least one schema, with the
+        // schema's own parent matching what we mapped it to.
+        return !entity || entity.parent !== base;
+      });
+    expect(badEntries).toEqual([]);
+  });
+
+  it('pins the two curated non-schema entries (IfcStairFlight/IfcRampFlight)', () => {
+    expect(IFC_SUBTYPE_TO_BASE['IfcStairFlight']).toBe('IfcStair');
+    expect(IFC_SUBTYPE_TO_BASE['IfcRampFlight']).toBe('IfcRamp');
+  });
+
+  // Regression guard: a fix that swallowed everything (e.g. "map every Ifc*
+  // entity to itself, or to IfcElement") would pass the coverage assertions
+  // above too — pin that unrelated, non-subtype entities are absent.
+  it('does not map unrelated base entities (regression guard)', () => {
+    expect(IFC_SUBTYPE_TO_BASE['IfcWall']).toBeUndefined();
+    expect(IFC_SUBTYPE_TO_BASE['IfcDoor']).toBeUndefined();
+    expect(IFC_SUBTYPE_TO_BASE['IfcSpace']).toBeUndefined();
+    expect(Object.keys(IFC_SUBTYPE_TO_BASE)).toHaveLength(11);
+  });
+});

--- a/packages/lens/src/types.ts
+++ b/packages/lens/src/types.ts
@@ -406,12 +406,11 @@ export const LENS_PALETTE = [
   '#EC407A', '#5C6BC0', '#26A69A', '#78909C',
 ] as const;
 
-/** IFC subclass → base class mapping for hierarchy-aware matching */
+/** IFC subclass -> base class map for hierarchy-aware matching: every `*StandardCase` entity plus the two `*Flight` types. */
 export const IFC_SUBTYPE_TO_BASE: Readonly<Record<string, string>> = {
-  IfcWallStandardCase: 'IfcWall',
-  IfcSlabStandardCase: 'IfcSlab',
-  IfcColumnStandardCase: 'IfcColumn',
-  IfcBeamStandardCase: 'IfcBeam',
-  IfcStairFlight: 'IfcStair',
-  IfcRampFlight: 'IfcRamp',
-};
+  IfcWallStandardCase: 'IfcWall', IfcSlabStandardCase: 'IfcSlab',
+  IfcColumnStandardCase: 'IfcColumn', IfcBeamStandardCase: 'IfcBeam',
+  IfcDoorStandardCase: 'IfcDoor', IfcWindowStandardCase: 'IfcWindow',
+  IfcMemberStandardCase: 'IfcMember', IfcPlateStandardCase: 'IfcPlate',
+  IfcOpeningStandardCase: 'IfcOpeningElement', IfcStairFlight: 'IfcStair',
+  IfcRampFlight: 'IfcRamp' };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1109,6 +1109,9 @@ importers:
 
   packages/lens:
     devDependencies:
+      '@ifc-lite/data':
+        specifier: workspace:^
+        version: link:../data
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

`IFC_SUBTYPE_TO_BASE` (`packages/lens/src/types.ts`) hand-maintains the IFC subclass → base class map `matchesIfcType` (`packages/lens/src/matching.ts`) uses so a lens rule against a base type (e.g. `IfcDoor`) also matches its StandardCase variant. IFC4 defines 9 `*StandardCase` entities, and the map only covered 4 of them (Wall/Slab/Column/Beam) — verified against this repo's own generated `packages/data/src/ifc-schema/generated/entities-ifc4.ts`:

```
IfcDoorStandardCase     parent: IfcDoor
IfcWindowStandardCase   parent: IfcWindow
IfcMemberStandardCase   parent: IfcMember
IfcPlateStandardCase    parent: IfcPlate
IfcOpeningStandardCase  parent: IfcOpeningElement
```

For a model containing any of these (common in IFC4 exports), a lens rule written against the base type (colorize/hide/highlight `IfcDoor`, `IfcWindow`, etc.) silently failed to match — `matchesIfcType` returned `false` with no error, the entity was just left unmatched and ghosted. IFC2X3 and IFC4X3 only reintroduce `IfcWallStandardCase` (already covered), so the fix adds exactly the five missing IFC4 entries.

- `packages/lens/src/types.ts`: adds `IfcDoorStandardCase`, `IfcWindowStandardCase`, `IfcMemberStandardCase`, `IfcPlateStandardCase`, `IfcOpeningStandardCase` to `IFC_SUBTYPE_TO_BASE`.
- `packages/lens/src/matching.test.ts`: adds the RED→GREEN unit tests for the five names.
- `packages/lens/src/types.schema-parity.test.ts` (new): mirrors the `feature-elements.schema-parity.test.ts` pattern from `packages/drawing-2d` (PR #3480) — re-derives every `*StandardCase` entity from `@ifc-lite/data`'s generated IFC2X3/IFC4/IFC4X3 entity tables (added as a `devDependency` of `lens`, used only at test time — `lens` has no runtime dependency on `@ifc-lite/data` and this doesn't change that) and asserts `IFC_SUBTYPE_TO_BASE` agrees with the schema's declared parent in both directions.
- `packages/lens/package.json`: `@ifc-lite/data` added to `devDependencies` only.

**Note on `IfcStairFlight`/`IfcRampFlight`:** these two existing entries are excluded from the schema-derived parity check and pinned instead by a fixed-membership regression test — the schema itself parents both under `IfcBuiltElement`, not `IfcStair`/`IfcRamp` (a flight is a *component* of a stair/ramp, not an alternate representation), so this pair is a deliberate "same family for lens matching" curation the schema can't confirm or deny, not an inheritance fact.

Regression guard: `IFC_SUBTYPE_TO_BASE` has no entry for `IfcWall`, `IfcDoor`, or `IfcSpace` (base types must not map to themselves), and the map's size is pinned at exactly 11 entries — catching a fix that swallowed everything instead of the specific gap.

## Test plan
- [x] RED observed: the 5 new subtype-coverage assertions failed before the fix (`expected false to be true`)
- [x] GREEN after the fix: `pnpm --filter @ifc-lite/lens exec vitest run` — 5 files, 186 tests passed
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget (kept `types.ts` under its existing budget by tightening the new comment/map formatting rather than raising it)
- [x] `pnpm exec tsc --noEmit` in `packages/lens` — clean
- [x] `node ../../scripts/typecheck-tests.mjs` in `packages/lens` (includes test files) — clean, 5 test files
- [x] Changeset added (`@ifc-lite/lens`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436