### PR TITLE
fix(viewer): route the F keyboard shortcut through cameraCallbacks.frameSelection

### DIFF
--- a/apps/viewer/src/components/viewer/useKeyboardControls.frameSelection.test.tsx
+++ b/apps/viewer/src/components/viewer/useKeyboardControls.frameSelection.test.tsx
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The `F` keyboard shortcut ("frame selection") reimplemented framing from
+ * scratch instead of calling the shared `cameraCallbacks.frameSelection`
+ * (Viewport.tsx) every other entry point uses — the toolbar button, the
+ * ribbon, the command palette, search, hierarchy, properties, compare and
+ * clash all go through `frameSelection`, which:
+ *
+ *   - unions the FULL multi-selection set (`selectedEntityIds`), not just the
+ *     single primary id (see `SearchInline.wiring.test.tsx` for the same
+ *     "multi-select over single" rule elsewhere), and
+ *   - resolves a geometry-less assembly (`IfcElementAssembly` et al.) to the
+ *     aggregated parts that actually carry geometry (#1133) before giving up.
+ *
+ * `useKeyboardControls.ts`'s own `f`/`F` handler skipped both: it read only
+ * `selectedEntityIdRef.current` and called `getEntityBounds` directly, which
+ * returns `null` for an id with no meshes of its own. So pressing F with a
+ * multi-selection framed only whichever id happened to be "the" selected one,
+ * and pressing F on a geometry-less assembly did nothing at all — while the
+ * toolbar's identically-labelled "Frame selection" button worked in both
+ * cases. Zero test files existed for this hook before this one.
+ */
+
+import '@/test/setup-dom.js';
+
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { useRef } from 'react';
+import { render, cleanup, press } from '@/test/render.js';
+import { useViewerStore } from '@/store';
+import { useKeyboardControls, type UseKeyboardControlsParams } from './useKeyboardControls.js';
+
+let initialState: ReturnType<typeof useViewerStore.getState>;
+
+function Harness(props: { frameCalls: string[]; frameBoundsCalls: number[] }) {
+  const rendererRef = useRef<UseKeyboardControlsParams['rendererRef']['current']>({
+    // Minimal stub: only the calls the 'f' code path can reach are needed.
+    getCamera: () => ({
+      frameBounds: () => { props.frameBoundsCalls.push(1); },
+      zoomExtent: () => {},
+      setPresetView: () => {},
+      zoom: () => {},
+      pan: () => {},
+      moveFirstPerson: () => {},
+      setRotation: () => {},
+      getRotation: () => ({ azimuth: 0, elevation: 0 }),
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+
+  useKeyboardControls({
+    rendererRef,
+    isInitialized: true,
+    keyboardHandlersRef: useRef({ handleKeyDown: null, handleKeyUp: null }),
+    firstPersonModeRef: useRef(false),
+    geometryBoundsRef: useRef({ min: { x: 0, y: 0, z: 0 }, max: { x: 10, y: 10, z: 10 } }),
+    coordinateInfoRef: useRef(undefined),
+    geometryRef: useRef([]),
+    selectedEntityIdRef: useRef(1),
+    hiddenEntitiesRef: useRef(new Set()),
+    isolatedEntitiesRef: useRef(null),
+    selectedModelIndexRef: useRef(undefined),
+    clearColorRef: useRef([0, 0, 0, 1]),
+    activeToolRef: useRef('select'),
+    sectionPlaneRef: useRef(null as never),
+    sectionRangeRef: useRef(null),
+    updateCameraRotationRealtime: () => {},
+    calculateScale: () => {},
+  });
+
+  return null;
+}
+
+describe('useKeyboardControls — F frames through the shared frameSelection callback', () => {
+  afterEach(() => {
+    cleanup();
+    useViewerStore.setState(initialState, true);
+  });
+
+  it('pressing F with a registered frameSelection callback calls it, instead of reimplementing bounds locally', () => {
+    initialState = useViewerStore.getState();
+
+    const frameCalls: string[] = [];
+    const frameBoundsCalls: number[] = [];
+    useViewerStore.getState().setCameraCallbacks({
+      frameSelection: () => { frameCalls.push('frameSelection'); },
+    });
+    // A multi-selection is live — frameSelection is the only path that
+    // unions it; the old local reimplementation only ever looked at
+    // `selectedEntityIdRef.current`.
+    useViewerStore.setState({ selectedEntityIds: new Set([1, 2, 3]) } as never);
+
+    render(<Harness frameCalls={frameCalls} frameBoundsCalls={frameBoundsCalls} />);
+
+    press(window, 'f');
+
+    assert.deepEqual(
+      frameCalls,
+      ['frameSelection'],
+      'F must delegate to cameraCallbacks.frameSelection so multi-selection and ' +
+      'geometry-less-assembly resolution (#1133) apply the same way the toolbar button does',
+    );
+    assert.equal(
+      frameBoundsCalls.length,
+      0,
+      'F must not also call camera.frameBounds directly once frameSelection handled it',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/useKeyboardControls.ts
+++ b/apps/viewer/src/components/viewer/useKeyboardControls.ts
@@ -125,18 +125,32 @@ export function useKeyboardControls(params: UseKeyboardControlsParams): void {
       if (e.key === '5') setViewAndRender('left');
       if (e.key === '6') setViewAndRender('right');
 
-      // Frame selection (F) - zoom to fit selection, or fit all if nothing selected
+      // Frame selection (F) - zoom to fit selection, or fit all if nothing
+      // selected. Delegates to `cameraCallbacks.frameSelection` — the SAME
+      // callback the toolbar/ribbon "Frame selection" button, search,
+      // hierarchy, properties, compare and clash all use — rather than
+      // reimplementing it: `frameSelection` unions the full multi-selection
+      // set (not just this hook's single `selectedEntityIdRef`) and resolves
+      // a geometry-less assembly to the aggregated parts that carry geometry
+      // (#1133) before giving up on bounds. A local reimplementation here
+      // would silently regain both bugs (Viewport.tsx documents #1133 at the
+      // `frameSelection` definition).
       if (e.key === 'f' || e.key === 'F') {
-        const selectedId = selectedEntityIdRef.current;
-        if (selectedId !== null) {
-          const bounds = getEntityBounds(geometryRef.current, selectedId);
-          if (bounds) {
-            camera.frameBounds(bounds.min, bounds.max, 300);
-          }
+        const state = useViewerStore.getState();
+        const hasSelection = state.selectedEntityIds.size > 0 || selectedEntityIdRef.current !== null;
+        if (hasSelection && state.cameraCallbacks.frameSelection) {
+          state.cameraCallbacks.frameSelection();
+        } else if (selectedEntityIdRef.current !== null) {
+          // No frameSelection callback registered (renderer not mounted) —
+          // fall back to the direct bounds lookup so the shortcut still does
+          // something rather than nothing.
+          const bounds = getEntityBounds(geometryRef.current, selectedEntityIdRef.current);
+          if (bounds) camera.frameBounds(bounds.min, bounds.max, 300);
+          calculateScale();
         } else {
           camera.zoomExtent(geometryBoundsRef.current.min, geometryBoundsRef.current.max, 300);
+          calculateScale();
         }
-        calculateScale();
       }
 
       // Home view (H) - reset to isometric

--- a/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
+++ b/apps/viewer/src/components/viewer/useSpaceMouseControls.ts
@@ -64,11 +64,22 @@ export function useSpaceMouseControls(params: UseSpaceMouseControlsParams): void
     let frameId: number | null = null;
     let lastFrameTime = 0;
 
-    // Same behaviour as the keyboard 'F' shortcut.
+    // Same behaviour as the keyboard 'F' shortcut — and, like it, delegates to
+    // `cameraCallbacks.frameSelection` rather than reimplementing framing
+    // from `selectedEntityIdRef` alone. See useKeyboardControls.ts's 'F'
+    // handler for why: `frameSelection` unions the full multi-selection set
+    // and resolves a geometry-less assembly to its aggregated parts (#1133),
+    // neither of which a local `getEntityBounds` lookup does.
     const fitView = () => {
-      const selectedId = selectedEntityIdRef.current;
-      if (selectedId !== null) {
-        const bounds = getEntityBounds(geometryRef.current, selectedId);
+      const state = useViewerStore.getState();
+      const hasSelection = state.selectedEntityIds.size > 0 || selectedEntityIdRef.current !== null;
+      if (hasSelection && state.cameraCallbacks.frameSelection) {
+        state.cameraCallbacks.frameSelection();
+        renderer.requestRender();
+        return;
+      }
+      if (selectedEntityIdRef.current !== null) {
+        const bounds = getEntityBounds(geometryRef.current, selectedEntityIdRef.current);
         if (bounds) {
           void camera.frameBounds(bounds.min, bounds.max, 300);
           renderer.requestRender();


### PR DESCRIPTION
## Bug

The `F` keyboard shortcut ("frame selection", `useKeyboardControls.ts`) reimplemented camera framing from scratch instead of calling `cameraCallbacks.frameSelection` — the single shared callback every other frame-selection entry point uses (toolbar button, ribbon, command palette, search, hierarchy panel, properties panel, compare panel, clash). The local reimplementation:

- only read the single primary `selectedEntityId`, ignoring the multi-selection set (`selectedEntityIds`), and
- called `getEntityBounds` directly, which returns `null` for a geometry-less entity (e.g. `IfcElementAssembly`) whose meshes hang off its aggregated parts — the exact bug #1133 fixed for `frameSelection` in #2531, but which never reached this sibling.

## Repro

- Select a multi-element set (Ctrl/Cmd-click two elements), press `F`. Only whichever element happens to be the "primary" `selectedEntityId` gets framed; the rest are ignored.
- Select a geometry-less assembly and press `F`: nothing happens (`getEntityBounds` returns `null`). Click the toolbar's "Frame selection" button on the same selection and it correctly frames the assembly's aggregated parts.

`useSpaceMouseControls.ts`'s fit-view button documents itself in a comment as "Same behaviour as the keyboard 'F' shortcut" and carried an identical copy of the bug, so it's fixed the same way in this PR (family, not a one-off — both fixed here).

## RED → GREEN

Added `apps/viewer/src/components/viewer/useKeyboardControls.frameSelection.test.tsx` — no test file existed for this hook before this change. It mounts `useKeyboardControls` with a fake renderer/camera, registers `cameraCallbacks.frameSelection`, sets a multi-selection in the store, and presses `F`.

- RED (before the fix): `frameSelection` was never called; the test failed with `+ [] - ['frameSelection']`.
- GREEN (after the fix): `frameSelection` is called and `camera.frameBounds` is not.

Also ran `src/utils/aggregation.test.ts` (the existing `frameSelection` assembly-resolution suite) and `src/components/viewer/toolbar/camera-commands.test.ts` — all pass unchanged, confirming the shared callback's own behaviour wasn't touched.

## Why existing tests missed it

`useKeyboardControls.ts` had zero test files. The assembly-resolution fix (#2531/#1133) and the multi-selection-over-single rule (#2403, pinned in `SearchInline.wiring.test.tsx`) were each tested only at their own call sites, with no guard asserting that every "frame selection" entry point — including the keyboard shortcut — goes through the same callback.

## Classification

- **Consequence**: visible degradation — the shortcut silently does nothing (assembly case) or frames the wrong/partial selection (multi-select case); no error surfaces.
- **Family**: two call sites shared the bug (`useKeyboardControls.ts`, `useSpaceMouseControls.ts`); both fixed here.

## Checks run

- `node scripts/check-module-size.mjs` — OK, 0 new files over budget.
- `pnpm exec tsc --noEmit` (apps/viewer, includes test files) — clean.
- `pnpm exec tsx --import ./src/test/vite-module-hooks.mjs --test` on the new test file plus `keyboard-event.test.ts`, `cameraSlice.test.ts`, `ecef-camera-frame.test.ts`, `camera-commands.test.ts`, `aggregation.test.ts` — 72/72 pass.
- `git rev-list --left-right --count HEAD...upstream/main` — 0 behind before push.
- Did not run the full apps/viewer suite (large; time-boxed to the affected area per session-efficiency practice).