### PR TITLE
fix(viewer): the Chromium Open dialog hid .ifczip, which every other load path accepts

### DIFF
--- a/apps/viewer/src/components/viewer/ViewportContainer.tsx
+++ b/apps/viewer/src/components/viewer/ViewportContainer.tsx
@@ -42,6 +42,7 @@ import {
   openIfcFilesWithHandles,
   handlesFromDataTransfer,
 } from '@/services/file-system-access';
+import { FILE_ACCEPT, isSupportedModelFile } from '@/services/supported-model-files';
 import {
   SOURCE_DOWNLOAD_EVENT,
   type SourceDownloadEvent,
@@ -486,12 +487,7 @@ export function ViewportContainer() {
     applyDragEvent('leave');
   }, [applyDragEvent]);
 
-  const isSupportedFile = useCallback((f: File) => {
-    const n = f.name.toLowerCase();
-    return n.endsWith('.ifc') || n.endsWith('.ifcx') || n.endsWith('.ifczip') || n.endsWith('.glb')
-      || n.endsWith('.las') || n.endsWith('.laz') || n.endsWith('.ply') || n.endsWith('.pcd')
-      || n.endsWith('.e57') || n.endsWith('.pts') || n.endsWith('.xyz');
-  }, []);
+  const isSupportedFile = isSupportedModelFile;
 
   // Single routing point for every ingestion path (picker / drop / input). The
   // optional `handles` array is positionally aligned with `files` and carries a
@@ -1091,7 +1087,7 @@ export function ViewportContainer() {
         <input
           ref={fileInputRef}
           type="file"
-          accept=".ifc,.ifcx,.ifczip,.glb,.las,.laz,.ply,.pcd,.e57,.pts,.xyz,.dxf"
+          accept={FILE_ACCEPT}
           multiple
           onChange={handleFileSelect}
           className="hidden"

--- a/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
+++ b/apps/viewer/src/components/viewer/toolbar/useFileCommands.tsx
@@ -25,22 +25,19 @@ import { isCollabEnabled } from '@/lib/collab/config';
 import { ingestDxfFiles, splitDxfFiles } from '@/hooks/ingest/dxfIngest';
 import { ShareDialog } from '../ShareDialog';
 
-/** Extensions the viewer can ingest (IFC / IFCX / GLB / point clouds). */
-export function isSupportedModelFile(f: File): boolean {
-  const n = f.name.toLowerCase();
-  return n.endsWith('.ifc') || n.endsWith('.ifcx') || n.endsWith('.ifczip') || n.endsWith('.glb')
-    || n.endsWith('.las') || n.endsWith('.laz') || n.endsWith('.ply') || n.endsWith('.pcd')
-    || n.endsWith('.e57') || n.endsWith('.pts') || n.endsWith('.xyz');
-}
+import { FILE_ACCEPT, isSupportedModelFile } from '@/services/supported-model-files';
+
+// FILE_ACCEPT offers `.dxf` while `isSupportedModelFile` rejects it: DXF
+// files are 2D reference underlays, not models, and split off to the DXF
+// ingest path (issue #1782) before model routing.
+
+/** Re-exported so the toolbar's existing call sites keep their import path. */
+export { isSupportedModelFile };
 
 /** Case-insensitive IFCX check (filenames are accepted case-insensitively). */
 function isIfcxModelFile(f: File): boolean {
   return f.name.toLowerCase().endsWith('.ifcx');
 }
-
-// `.dxf` files are 2D reference underlays, not models: they split off to
-// the DXF ingest path (issue #1782) before model routing.
-const FILE_ACCEPT = '.ifc,.ifcx,.ifczip,.glb,.las,.laz,.ply,.pcd,.e57,.pts,.xyz,.dxf';
 
 export interface FileCommands {
   /**

--- a/apps/viewer/src/services/file-system-access.test.ts
+++ b/apps/viewer/src/services/file-system-access.test.ts
@@ -13,6 +13,7 @@ import {
   readFreshFile,
   supportsFileSystemAccess,
 } from './file-system-access.js';
+import { MODEL_FILE_EXTENSIONS, isSupportedModelFile } from './supported-model-files.js';
 
 type FSFileHandleLike = {
   name: string;
@@ -123,6 +124,34 @@ describe('file-system-access', () => {
       assert.ok(result);
       assert.equal(result.length, 1);
       assert.equal(result[0].file.name, 'ok.ifc');
+    });
+
+    // Boundary test: the picker's accept filter (what the Chromium Open
+    // dialog will let the user select) against the ingest guard that every
+    // load path routes through. Both ends were covered on their own — the
+    // picker's return handling above, `isSupportedModelFile` at its call
+    // sites — but nothing compared what the picker OFFERS against what the
+    // app ACCEPTS, so `.ifczip` sat in the guard and not in the filter.
+    it('offers every extension the ingest guard accepts', async () => {
+      let offered: string[] = [];
+      (window as unknown as Record<string, unknown>).showOpenFilePicker = async (
+        opts: { types?: FilePickerAcceptType[] },
+      ) => {
+        offered = (opts.types ?? []).flatMap((t) => Object.values(t.accept).flat());
+        return [fakeHandle('a.ifc')];
+      };
+      await openIfcFilesWithHandles();
+
+      for (const ext of MODEL_FILE_EXTENSIONS) {
+        assert.ok(
+          isSupportedModelFile(fakeFile(`model${ext}`)),
+          `${ext} must be accepted by the ingest guard`,
+        );
+        assert.ok(
+          offered.includes(ext),
+          `the picker hides ${ext}, which the viewer can ingest — the user cannot select it`,
+        );
+      }
     });
 
     it('returns null (not an empty array) when every picked handle fails to read', async () => {

--- a/apps/viewer/src/services/file-system-access.ts
+++ b/apps/viewer/src/services/file-system-access.ts
@@ -16,24 +16,18 @@
  * where no handle exists and Refresh is simply not offered.
  */
 
-/** Accept filter mirroring the `<input type="file">` accept list. */
+import { PICKER_FILE_EXTENSIONS } from './supported-model-files.js';
+
+/**
+ * Accept filter for the picker. Derived from the same list the
+ * `<input type="file">` accept strings and the ingest guard use, so the
+ * dialog can never hide a format the viewer would happily load.
+ */
 const IFC_ACCEPT_TYPES: FilePickerAcceptType[] = [
   {
     description: 'BIM models & point clouds',
     accept: {
-      'application/octet-stream': [
-        '.ifc',
-        '.ifcx',
-        '.glb',
-        '.las',
-        '.laz',
-        '.ply',
-        '.pcd',
-        '.e57',
-        '.pts',
-        '.xyz',
-        '.dxf',
-      ],
+      'application/octet-stream': [...PICKER_FILE_EXTENSIONS],
     },
   },
 ];

--- a/apps/viewer/src/services/supported-model-files.ts
+++ b/apps/viewer/src/services/supported-model-files.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The one list of file extensions the viewer can ingest.
+ *
+ * Every entry point that names extensions derives them from here: the
+ * `<input type="file">` accept strings, the drag/drop and picker guards
+ * (`isSupportedModelFile`), and the File System Access picker's accept
+ * filter in `./file-system-access.ts`. Keeping them derived rather than
+ * hand-copied is what stops one path from advertising a format another
+ * path silently refuses — `.ifczip` was missing from the picker filter
+ * while every other path accepted it, so a zipped IFC appeared greyed out
+ * in the Chromium Open dialog.
+ */
+
+/** Model formats routed to the model-load pipeline. */
+export const MODEL_FILE_EXTENSIONS = [
+  '.ifc',
+  '.ifcx',
+  '.ifczip',
+  '.glb',
+  '.las',
+  '.laz',
+  '.ply',
+  '.pcd',
+  '.e57',
+  '.pts',
+  '.xyz',
+] as const;
+
+/**
+ * Reference underlays. `.dxf` is offered by every picker but splits off to
+ * the 2D ingest path before model routing, so it is deliberately not part
+ * of `MODEL_FILE_EXTENSIONS` / `isSupportedModelFile`.
+ */
+export const REFERENCE_FILE_EXTENSIONS = ['.dxf'] as const;
+
+/** Everything a file picker should offer the user. */
+export const PICKER_FILE_EXTENSIONS: readonly string[] = [
+  ...MODEL_FILE_EXTENSIONS,
+  ...REFERENCE_FILE_EXTENSIONS,
+];
+
+/** `accept` attribute for the hidden `<input type="file">` elements. */
+export const FILE_ACCEPT = PICKER_FILE_EXTENSIONS.join(',');
+
+/** Extensions the viewer can ingest (IFC / IFCX / GLB / point clouds). */
+export function isSupportedModelFile(f: File): boolean {
+  const n = f.name.toLowerCase();
+  return MODEL_FILE_EXTENSIONS.some((ext) => n.endsWith(ext));
+}


### PR DESCRIPTION
## The boundary

`.ifczip` is a first-class model format in the viewer — the parser unwraps it (`unwrapIfcZip`), `isSupportedModelFile` accepts it, and every `<input type="file">` accept string offers it.

The File System Access picker's accept filter did **not** list it:

```ts
/** Accept filter mirroring the `<input type="file">` accept list. */
const IFC_ACCEPT_TYPES: FilePickerAcceptType[] = [
  { description: 'BIM models & point clouds', accept: { 'application/octet-stream': [
    '.ifc', '.ifcx', /* no .ifczip */ '.glb', '.las', '.laz', '.ply', '.pcd', '.e57', '.pts', '.xyz', '.dxf',
  ] } },
];
```

…while the input's list, and the guard every load path routes through, both include it:

```ts
const FILE_ACCEPT = '.ifc,.ifcx,.ifczip,.glb,.las,.laz,.ply,.pcd,.e57,.pts,.xyz,.dxf';
```

The doc comment claimed the two mirrored each other. They had drifted by exactly one entry.

## Consequence

Visible degradation, not corruption. On Chromium — where **File > Open** and **Add Model** both go through `showOpenFilePicker` — a zipped IFC was greyed out under the default "BIM models & point clouds" filter. It stayed reachable via the picker's "all files" option and via drag-and-drop (which never consults the filter), so the format was not blocked outright, just hidden from the primary open path on the primary desktop browser.

## Why existing tests missed it

Both ends were tested, the middle never was. `file-system-access.test.ts` covered the picker's *return* handling (cancel, unreadable handles, permissions); `isSupportedModelFile` was exercised at its call sites. Nothing compared what the picker **offers** against what the app **accepts**.

## Family, not a one-off

The extension list existed in four hand-maintained copies: the picker filter, two `accept` strings (`ViewportContainer`, `useFileCommands`), and two copies of the ingest predicate. That duplication is what allowed one copy to drift, so rather than patching the one entry, all of them now derive from a single list in `services/supported-model-files.ts`. `MobileToolbar`'s deliberately narrower list (`.ifc,.ifcx,.ifczip,.glb`) is internally consistent and left alone.

I checked the other entries while I was there: every remaining extension was present in all four copies — `.ifczip` was the only divergence.

## The test crosses the boundary

`offers every extension the ingest guard accepts` captures the `types` actually handed to `showOpenFilePicker` and asserts every extension the ingest guard accepts is among them. It would not catch this bug if it tested only one end.

RED on pre-fix code:

```
not ok 6 - offers every extension the ingest guard accepts
  error: 'the picker hides .ifczip, which the viewer can ingest — the user cannot select it'
```

GREEN after: `# pass 20  # fail 0`.

## Checks

- `apps/viewer` full suite: **6503 passed, 0 failed**, 6 skipped
- `npx tsc --noEmit` in `apps/viewer`: **0 errors** (test files included)
- `node scripts/check-module-size.mjs`: **OK** (no budget raised — `ViewportContainer.tsx` shrank)
- `node scripts/check-test-wiring.mjs`: **OK**
- Rebased on `upstream/main`, 0 behind

No changeset: `apps/viewer` is `private: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Unified supported file-type detection and file-picker filters across the viewer.
  * File extensions are now recognized consistently regardless of letter casing.
  * `.dxf` files remain available in file pickers but are excluded from model loading.
* **Tests**
  * Added coverage to ensure file-picker options match the formats accepted for model import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->