### PR TITLE
fix(extensions): bim.model.loadIfc under-granted model.read instead of model.create

### DIFF
--- a/.changeset/model-loadifc-capability-undergrant.md
+++ b/.changeset/model-loadifc-capability-undergrant.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/extensions': patch
+---
+
+Fix `bim.model.loadIfc` inferring the read-only `model.read` capability instead of `model.create`.
+
+The inference catalogue mapped every `bim.model.*` call, including `loadIfc`, to the namespace's `model.read` default. `loadIfc` loads a whole new IFC document into the app (dispatches `ifc-lite:load-file`), which is a document-creating operation, not a read — the same distinction `host/permissions.ts` already draws for `model.create` ("creation modifies the document").
+
+Because `inferCapabilities` and the runtime's per-method capability gate (`host/check.ts`) both read this same catalogue, the under-grant was not just a review-screen display issue: an extension granted only `model.read` could call `bim.model.loadIfc` and the gate would allow it, since the required and granted capability were identical (`model.read`). `bim.model.loadIfc` now requires `model.create`; `bim.model.list`/`active`/`activeId` are unaffected and still require `model.read`.

--- a/.changeset/model-loadifc-capability-undergrant.md
+++ b/.changeset/model-loadifc-capability-undergrant.md
@@ -1,5 +1,5 @@
 ---
-'@ifc-lite/extensions': patch
+'@ifc-lite/extensions': minor
 ---
 
 Fix `bim.model.loadIfc` inferring the read-only `model.read` capability instead of `model.create`.

--- a/packages/extensions/src/inference/capability.test.ts
+++ b/packages/extensions/src/inference/capability.test.ts
@@ -60,6 +60,18 @@ describe('inferCapabilities — mutation patterns', () => {
   it('bim.create.* → model.create', () => {
     expect(inferCapabilities('bim.create.project({});').capabilities).toContain('model.create');
   });
+
+  it('bim.model.loadIfc → model.create (loads a new document, not a read)', () => {
+    const r = inferCapabilities('bim.model.loadIfc(content, "tower.ifc");');
+    const call = r.observations.find((o) => o.call === 'bim.model.loadIfc');
+    expect(call?.capabilities).toEqual(['model.create']);
+  });
+
+  it('bim.model.list still infers model.read (regression guard)', () => {
+    const r = inferCapabilities('const models = bim.model.list();');
+    const call = r.observations.find((o) => o.call === 'bim.model.list');
+    expect(call?.capabilities).toEqual(['model.read']);
+  });
 });
 
 describe('inferCapabilities — export', () => {

--- a/packages/extensions/src/inference/catalogue.ts
+++ b/packages/extensions/src/inference/catalogue.ts
@@ -32,7 +32,13 @@ export interface NamespaceMapping {
 export const INFERENCE_CATALOGUE: Record<string, NamespaceMapping> = {
   model: {
     defaultCapabilities: ['model.read'],
+    // Differentiated: capability varies by method, so every method is
+    // listed explicitly (a differentiated namespace treats a missing
+    // method as a catalogue gap, not as an intended fall-through).
     methods: {
+      list: ['model.read'],
+      active: ['model.read'],
+      activeId: ['model.read'],
       // Loads a whole new IFC document into the app — creation, not a
       // read (see host/permissions.ts: model.create "modifies the document").
       loadIfc: ['model.create'],

--- a/packages/extensions/src/inference/catalogue.ts
+++ b/packages/extensions/src/inference/catalogue.ts
@@ -32,6 +32,11 @@ export interface NamespaceMapping {
 export const INFERENCE_CATALOGUE: Record<string, NamespaceMapping> = {
   model: {
     defaultCapabilities: ['model.read'],
+    methods: {
+      // Loads a whole new IFC document into the app — creation, not a
+      // read (see host/permissions.ts: model.create "modifies the document").
+      loadIfc: ['model.create'],
+    },
   },
   query: {
     defaultCapabilities: ['model.read'],


### PR DESCRIPTION
## Summary

Audit of `packages/extensions/src/inference/catalogue.ts` beyond the `store`/`viewer` namespaces already covered by #3487 and the recognised-method warning fixed by #3488 — reading every `bim.<namespace>.<method>` implementation in `packages/sandbox/src/bridge-*.ts` and comparing its real effect against the capability the catalogue infers.

- `bim.model.loadIfc` loads a whole new IFC document into the app (`apps/viewer/src/sdk/adapters/model-adapter.ts` dispatches `ifc-lite:load-file`) — a document-creating operation, not a read. The catalogue's `model` namespace had no per-method override, so it fell through to the namespace default `model.read`.
- `inferCapabilities` and the runtime's per-method capability gate (`packages/extensions/src/host/check.ts`) both read this same catalogue via `lookupNamespaceMethod`, so this was not just a review-screen display issue: a script granted only `model.read` could call `bim.model.loadIfc` and the gate would allow it, since required and granted capability were identical.
- Fix: `model.loadIfc` now maps to `model.create`. `model.list`/`active`/`activeId` are unaffected (regression-guarded by a new test).

## Test plan

- [x] New test in `packages/extensions/src/inference/capability.test.ts` RED against the unfixed catalogue, GREEN after the fix
- [x] Regression guard: `bim.model.list` still infers `model.read`
- [x] `pnpm turbo test --filter=@ifc-lite/extensions` — 848/848 passing
- [x] `node scripts/check-module-size.mjs` — 0 new over budget
- [x] `pnpm exec tsc --noEmit` (via `packages/extensions`'s own `typecheck` script) — clean

Other namespaces audited (`query`, `mutate`, `create`, `files`, `export`, `schedule`, `clash`, `lens`) matched their real effect; no further under-grants found. `store` and `viewer` are covered by #3487, and the recognised-method warning gap by #3488 — not restated here.

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capability checks for `bim.model.loadIfc`; it now requires `model.create`.
  * Preserved read-only access requirements for model listing and active-model information.

* **Tests**
  * Added coverage confirming document loading requires creation access.
  * Added regression coverage for read-only model operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->