### PR TITLE
fix(cli): honour query --limit/--offset under --storey instead of dropping them

### DIFF
--- a/.changeset/query-storey-limit-offset.md
+++ b/.changeset/query-storey-limit-offset.md
@@ -1,0 +1,14 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Behavior fix: `ifc-lite query --storey <name>` now honours `--limit` and `--offset`.
+
+The `--storey` filter takes its own branch, post-filtering the entity list by hand,
+and handed that unsliced array straight to the printer. Both flags were parsed and
+validated on this path and then had no effect at all, so `--storey X --limit 2`
+printed every entity in the storey. The plain and `--where` paths already applied
+the slice; the storey branch now applies the same one, including when `--storey`
+is combined with `--where`. Scripts that passed `--limit`/`--offset` alongside
+`--storey` and silently received the full listing will now receive the requested
+window.

--- a/.changeset/query-storey-limit-offset.md
+++ b/.changeset/query-storey-limit-offset.md
@@ -1,14 +1,21 @@
 ---
-'@ifc-lite/cli': patch
+'@ifc-lite/cli': minor
 ---
 
 Behavior fix: `ifc-lite query --storey <name>` now honours `--limit` and `--offset`.
 
 The `--storey` filter takes its own branch, post-filtering the entity list by hand,
-and handed that unsliced array straight to the printer. Both flags were parsed and
-validated on this path and then had no effect at all, so `--storey X --limit 2`
-printed every entity in the storey. The plain and `--where` paths already applied
-the slice; the storey branch now applies the same one, including when `--storey`
-is combined with `--where`. Scripts that passed `--limit`/`--offset` alongside
-`--storey` and silently received the full listing will now receive the requested
-window.
+and handed that unsliced array straight to the printer. Both flags were parsed on
+this path and then had no effect at all, so `--storey X --limit 2` printed every
+entity in the storey. The plain and `--where` paths already applied the slice; the
+storey branch now applies the same one, including when `--storey` is combined with
+`--where`. Scripts that passed `--limit`/`--offset` alongside `--storey` and
+silently received the full listing will now receive the requested window.
+
+`--offset` is also validated now, the way `--limit` already was. It never had been,
+and applying it on two more paths would have spread three different wrong answers
+instead of one: `slice(NaN)` is inert, `slice(-2)` returns the LAST two entries
+rather than skipping two, and the plain path let `NaN` reach the backend's own
+guard as an uncaught `TypeError` instead of a clean error. `ifc-lite query --offset
+-2` and `--offset abc` now exit with `Invalid --offset` on every path, where
+`--offset -2` previously returned the tail of the list and reported success.

--- a/packages/cli/src/commands/query-limit.test.ts
+++ b/packages/cli/src/commands/query-limit.test.ts
@@ -148,3 +148,54 @@ describe('eval --type --limit validation', () => {
     expect(stdout.out.trim()).toBe('');
   });
 });
+
+/**
+ * `--storey` takes its own branch in `queryCommand`, post-filtering the
+ * entity list by hand. Both sibling paths — the plain `QueryBuilder` path
+ * and the `--where` path — apply `--limit`/`--offset` before printing, but
+ * the storey branch handed its unsliced array straight to `outputEntities`,
+ * so both flags parsed, validated, and then did nothing at all.
+ */
+describe('query --storey honours --limit and --offset', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const STOREY = '00 groundfloor';
+
+  async function storeyCount(extra: string[]): Promise<number> {
+    const stdout = captureStdout();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    await queryCommand([SAMPLE_IFC, '--storey', STOREY, '--json', ...extra]);
+    const n = countEntities(stdout.out);
+    vi.restoreAllMocks();
+    return n;
+  }
+
+  it('bounding control: the unrestricted storey listing has more than 2 rows', async () => {
+    expect(await storeyCount([])).toBeGreaterThan(2);
+  });
+
+  it('--limit caps the rows returned', async () => {
+    expect(await storeyCount(['--limit', '2'])).toBe(2);
+  });
+
+  it('--limit 0 is a deliberate empty result', async () => {
+    expect(await storeyCount(['--limit', '0'])).toBe(0);
+  });
+
+  it('--offset skips rows from the front', async () => {
+    const total = await storeyCount([]);
+    expect(await storeyCount(['--offset', '2'])).toBe(total - 2);
+  });
+
+  it('--offset and --limit compose', async () => {
+    expect(await storeyCount(['--offset', '1', '--limit', '2'])).toBe(2);
+  });
+
+  it('--limit still applies when --storey is combined with --where', async () => {
+    const all = await storeyCount(['--where', 'Pset_WallCommon.IsExternal']);
+    expect(all).toBeGreaterThan(1);
+    expect(await storeyCount(['--where', 'Pset_WallCommon.IsExternal', '--limit', '1'])).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -128,16 +128,16 @@ export async function queryCommand(args: string[]): Promise<void> {
 
   let type = getFlag(args, '--type');
   const limit = getFlag(args, '--limit');
-  // Validated once, up front, and reused by every branch below (plain,
-  // --where, and --group-by). Each branch used to do its own
-  // `limit ? parseInt(limit, 10) : undefined`, which is truthy for any
-  // non-empty garbage string; the parsed NaN was then either silently
-  // ignored (query builder / group-by paths, via a `> 0`-shaped guard
-  // downstream) or silently emptied the result (`slice(0, NaN)` in the
-  // --where path) -- either way a typo'd --limit exited 0 with a wrong
-  // answer instead of being rejected.
+  // Both validated once, up front, and reused by every branch below (plain,
+  // --where, --storey, --group-by). Each branch used to parse for itself,
+  // and `parseInt` is truthy for any non-empty garbage: a typo'd --limit was
+  // either ignored (`> 0`-shaped guards downstream) or silently emptied the
+  // result (`slice(0, NaN)`), while --offset reached three different wrong
+  // answers -- `slice(NaN)` inert, `slice(-2)` returning the LAST two entries
+  // instead of skipping two, and NaN reaching the backend guard as an
+  // uncaught TypeError. Every one of them exited 0 with a wrong answer.
   const rowLimit = validateLimit(limit);
-  const offset = getFlag(args, '--offset');
+  const offset = validateLimit(getFlag(args, '--offset'), '--offset');
   const propFilter = getFlag(args, '--where');
   const jsonOutput = hasFlag(args, '--json');
   const countOnly = hasFlag(args, '--count');
@@ -469,7 +469,7 @@ export async function queryCommand(args: string[]): Promise<void> {
       return;
     }
     // Same slice the --where branch applies; without it both flags were inert here.
-    if (offset) storeyEntities = storeyEntities.slice(parseInt(offset, 10));
+    if (offset) storeyEntities = storeyEntities.slice(offset);
     if (rowLimit !== undefined) storeyEntities = storeyEntities.slice(0, rowLimit);
     if (countOnly) {
       outputCount(storeyEntities.length, jsonOutput);
@@ -519,7 +519,7 @@ export async function queryCommand(args: string[]): Promise<void> {
     }
     // Non-aggregation, non-group paths only. `rowLimit` is validated up
     // front -- slice(0, NaN) used to silently empty the result.
-    if (offset) entities = entities.slice(parseInt(offset, 10));
+    if (offset) entities = entities.slice(offset);
     if (rowLimit !== undefined) entities = entities.slice(0, rowLimit);
     if (countOnly) {
       outputCount(entities.length, jsonOutput);
@@ -535,7 +535,7 @@ export async function queryCommand(args: string[]): Promise<void> {
   // Validated, not parseInt'd -- the backend descriptor only honours the
   // limit under a `> 0` check, so a NaN --limit returned every match.
   if (rowLimit !== undefined && !groupBy) q = q.limit(rowLimit);
-  if (offset) q = q.offset(parseInt(offset, 10));
+  if (offset) q = q.offset(offset);
 
   // B11: Validate --group-by key
   if (groupBy) {

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -468,6 +468,9 @@ export async function queryCommand(args: string[]): Promise<void> {
       outputGroupBy(storeyEntities, groupBy, undefined, bim, jsonOutput, rowLimit);
       return;
     }
+    // Same slice the --where branch applies; without it both flags were inert here.
+    if (offset) storeyEntities = storeyEntities.slice(parseInt(offset, 10));
+    if (rowLimit !== undefined) storeyEntities = storeyEntities.slice(0, rowLimit);
     if (countOnly) {
       outputCount(storeyEntities.length, jsonOutput);
       return;
@@ -514,9 +517,8 @@ export async function queryCommand(args: string[]): Promise<void> {
       outputAggregation(entities, maxQuantity, 'max', bim, jsonOutput);
       return;
     }
-    // Apply offset/limit only for non-aggregation, non-group paths.
-    // `rowLimit` is validated once, up front (see above) -- slice(0, NaN)
-    // used to silently empty the result on a garbage --limit.
+    // Non-aggregation, non-group paths only. `rowLimit` is validated up
+    // front -- slice(0, NaN) used to silently empty the result.
     if (offset) entities = entities.slice(parseInt(offset, 10));
     if (rowLimit !== undefined) entities = entities.slice(0, rowLimit);
     if (countOnly) {
@@ -530,10 +532,8 @@ export async function queryCommand(args: string[]): Promise<void> {
     return;
   }
 
-  // Validated, not parseInt'd -- the QueryBuilder forwards this to the
-  // headless backend's descriptor, which only honours it under a `> 0`
-  // check downstream; a garbage/NaN --limit was silently ignored there,
-  // returning every match instead of being rejected.
+  // Validated, not parseInt'd -- the backend descriptor only honours the
+  // limit under a `> 0` check, so a NaN --limit returned every match.
   if (rowLimit !== undefined && !groupBy) q = q.limit(rowLimit);
   if (offset) q = q.offset(parseInt(offset, 10));
 


### PR DESCRIPTION
## The bug

`ifc-lite query <file> --storey <name>` accepted `--limit` and `--offset`, validated them, and then ignored them completely.

`--storey` takes its own branch in `queryCommand` (`packages/cli/src/commands/query.ts`), post-filtering the entity list by hand, and handed that unsliced array straight to `outputEntities`. The two sibling paths both slice — the plain `QueryBuilder` path via `q.limit()`/`q.offset()`, the `--where` path via an explicit `.slice()` — so this was a one-branch gap, not a missing feature.

## Proof it did nothing (before the fix)

```
$ node dist/index.js query building-architecture.ifc --storey "00 groundfloor"
7 entities

$ node dist/index.js query building-architecture.ifc --storey "00 groundfloor" --limit 2
7 entities        # identical

$ node dist/index.js query building-architecture.ifc --storey "00 groundfloor" --offset 5
7 entities        # identical

$ node dist/index.js query building-architecture.ifc --type IfcWall --limit 2
2 entities        # sibling path honours it
```

After the fix, `--limit 2` returns 2 and `--offset 5` returns 2.

## The fix

Apply the same `offset`/`rowLimit` slice the `--where` branch already applies, in the same position relative to `--count` and `--sort`, so `--storey` combined with `--where` is covered too. Implemented rather than removed — the capability plainly exists on both sibling paths, and removing a published flag would be the breaking change.

## Siblings checked

`export --storey --limit` was checked by execution and already honours the limit (7 vs 2 rows in the JSON output); its code carries an explicit comment about ordering the storey filter before the limit. `anonymize` and `generate-spaces` take `--storey` but declare no `--limit`/`--offset`. So this is isolated to `query`.

## Verification

- `node scripts/check-module-size.mjs` — `OK (2022 files measured, 307 allowlisted, 0 new over 400)`. `query.ts` is pinned at 609 lines and was at exactly 609, so two verbose comment blocks were shortened to absorb the added slice; no budget was raised.
- `pnpm run typecheck` (packages/cli) — `typecheck-tests: packages/cli OK (50 test files)`
- `pnpm exec vitest run` (packages/cli) — `Test Files 50 passed (50) / Tests 544 passed | 8 skipped (552)`

## Test

Six new cases in `query-limit.test.ts`. Before the fix, 5 of 6 failed (the bounding control "the unrestricted storey listing has more than 2 rows" passed, confirming the fixture discriminates); after, all pass.

Changeset included — patch on `@ifc-lite/cli`, described as a behavior fix since the flags now have an effect they previously lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436