### PR TITLE
fix(mcp): honor include:['attributes'] in get_entities_bulk

### DIFF
--- a/.changeset/get-entities-bulk-attributes.md
+++ b/.changeset/get-entities-bulk-attributes.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/mcp': patch
+---
+
+Fix `get_entities_bulk` silently ignoring `include: ['attributes']` (its own documented default): the handler checked `include` for `properties`/`quantities`/`classifications`/`materials` but never `attributes`, so the full EXPRESS attribute list `get_entity` attaches for the same request never appeared in the bulk response — no error, just a quietly incomplete payload.

--- a/packages/mcp/src/tools/query.test.ts
+++ b/packages/mcp/src/tools/query.test.ts
@@ -289,3 +289,30 @@ describe('count_entities → group_by sort', () => {
     expect(structured.total).toBe(8);
   });
 });
+
+describe("get_entities_bulk → include: ['attributes']", () => {
+  // The schema declares `include` with `default: ['attributes']` and no enum
+  // restricting its values, matching `get_entity`'s vocabulary
+  // ('attributes','properties','quantities','classifications','materials').
+  // `get_entity` honours 'attributes' by attaching `bim.attributes(ref)`
+  // (the full EXPRESS attribute list — Tag, PredefinedType, etc. — which is
+  // NOT part of the base `EntityData` shape returned by `bim.entity(ref)`).
+  // `get_entities_bulk`'s handler checks 'properties' / 'quantities' /
+  // 'classifications' / 'materials' but never 'attributes', so the
+  // documented default silently does nothing: the field an agent asked for
+  // by name never appears, with no error and a 200-shaped success result.
+  it('attaches the full attribute list when include names it, like get_entity does', async () => {
+    const single = await call('get_entity', { model_id: 'shape', global_id: guid('WALA'), include: ['attributes'] });
+    const singleAttrs = (single.structuredContent as { attributes: unknown[] }).attributes;
+    expect(singleAttrs.length).toBeGreaterThan(0);
+
+    const bulk = await call('get_entities_bulk', {
+      model_id: 'shape',
+      global_ids: [guid('WALA')],
+      include: ['attributes'],
+    });
+    const entities = (bulk.structuredContent as { entities: Record<string, { attributes?: unknown[] }> }).entities;
+    expect(entities[guid('WALA')].attributes).toBeDefined();
+    expect((entities[guid('WALA')].attributes as unknown[]).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/mcp/src/tools/query.ts
+++ b/packages/mcp/src/tools/query.ts
@@ -378,8 +378,7 @@ const getEntitiesBulk: Tool = {
     }
 
     const entities: Record<string, unknown> = {};
-    // Every live entity this call saw per GlobalId, so a key that names more
-    // than one can be reported instead of quietly resolved.
+    // Every live entity this call saw per GlobalId, so a key naming more than one is reported, not silently resolved.
     const byGlobalId = new Map<string, number[]>(
       [...carriers].map(([globalId, list]) => [globalId, [...list]]),
     );
@@ -396,7 +395,8 @@ const getEntitiesBulk: Tool = {
       else if (!known.includes(id)) known.push(id);
       // First write wins, and the first write is the resolved one.
       if (Object.prototype.hasOwnProperty.call(entities, data.globalId)) continue;
-      const e: Record<string, unknown> = { ...data };
+      const e: Record<string, unknown> = { ...data }; // identity only; attributes need their own call, like get_entity
+      if (include.has('attributes')) e.attributes = m.bim.attributes(ref);
       if (include.has('properties')) e.properties = m.bim.properties(ref);
       if (include.has('quantities')) e.quantities = m.bim.quantities(ref);
       if (include.has('classifications')) e.classifications = m.bim.classifications(ref);


### PR DESCRIPTION
## Summary

Systematic audit of every MCP tool's declared `inputSchema.properties` against what its handler actually reads (continuing the "declared parameter, unread by the handler" lens from tonight's `viewer_set_section` / `viewer_color_by_property` findings — those two, and everything under `apps/viewer/src/components/mcp/playground-*`, were left alone per the brief).

Walked all 36 files under `packages/mcp/src/tools/*.ts` (viewer, query, mutate, export, clash, diff, bcf, bsdd, discovery, validation, layer/layer-review). Every declared parameter is consumed by its own handler or forwarded to a real consumer — with one exception:

**`get_entities_bulk`** (`packages/mcp/src/tools/query.ts`) declares `include` with `default: ['attributes']`, matching `get_entity`'s vocabulary (`attributes`/`properties`/`quantities`/`classifications`/`materials`). The handler checked `include.has(...)` for `properties`, `quantities`, `classifications`, and `materials` — but never `attributes`. The base row (`{ ...data }`, an `EntityData`) carries only identity fields (`ref`, `globalId`, `name`, `type`, `description`, `objectType`); the full EXPRESS attribute list (`Tag`, `PredefinedType`, …) is a separate call (`bim.attributes(ref)`) that `get_entity` makes when `'attributes'` is in `include`, and `get_entities_bulk` never did — for *any* value of `include`, including its own documented default.

An agent calling `get_entities_bulk` (the tool this package's own README recommends for paging past `get_entity`) got a success result with the requested field silently missing, no matter what it passed for `include`.

Proven by execution before the fix: `get_entity(..., include:['attributes'])` returns a non-empty `attributes` array; `get_entities_bulk(..., include:['attributes'])` on the same entity in the same model returns `entities[gid].attributes === undefined`.

## Fix

One line: `if (include.has('attributes')) e.attributes = m.bim.attributes(ref);`, mirroring `get_entity`'s handling.

## Test plan

- [x] New test `get_entities_bulk → include: ['attributes']` in `packages/mcp/src/tools/query.test.ts`: RED before the fix (`attributes` undefined), GREEN after — asserted against the observable field, not that a function was called.
- [x] `pnpm exec tsc --noEmit` in `packages/mcp` — clean.
- [x] `pnpm exec vitest run` in `packages/mcp` — 30 files / 330 tests pass.
- [x] `node scripts/check-module-size.mjs` — `query.ts` trimmed back to its 627-line budget (no budget raised).
- [x] Changeset added (`@ifc-lite/mcp` is published).

Base verified fresh against `upstream/main` before starting (`git rev-list --left-right --count HEAD...upstream/main` → `0 0`).

Not a duplicate of #2934 (that's the viewer-embed postMessage API; this is the MCP tool surface).

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436