### PR TITLE
fix(cli): honour bsdd's --json flag instead of always printing JSON

### DIFF
--- a/.changeset/bsdd-json-flag-noop.md
+++ b/.changeset/bsdd-json-flag-noop.md
@@ -1,5 +1,5 @@
 ---
-'@ifc-lite/cli': patch
+'@ifc-lite/cli': minor
 ---
 
 Fix `ifc-lite bsdd`'s `--json` flag doing nothing: every subcommand (`class`, `search`, `psets`, `qsets`) called `printJson(...)` unconditionally, so the parsed `--json` value was never read and output was identical with or without the flag. `bsdd` now prints a human-readable summary by default (matching every other CLI command's `--json` convention, e.g. `ext capabilities`) and the raw structured payload only under `--json`.

--- a/.changeset/bsdd-json-flag-noop.md
+++ b/.changeset/bsdd-json-flag-noop.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix `ifc-lite bsdd`'s `--json` flag doing nothing: every subcommand (`class`, `search`, `psets`, `qsets`) called `printJson(...)` unconditionally, so the parsed `--json` value was never read and output was identical with or without the flag. `bsdd` now prints a human-readable summary by default (matching every other CLI command's `--json` convention, e.g. `ext capabilities`) and the raw structured payload only under `--json`.
+
+Anyone piping `bsdd` output into `jq`/another JSON consumer without passing `--json` (relying on the previous always-JSON behaviour) now needs to add `--json` to keep getting structured output.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1203,7 +1203,7 @@ ifc-lite convert model.ifc --schema IFC4 --out v4.ifc
 ifc-lite diff model.ifc v4.ifc --json
 
 # Look up bSDD data for wall types
-ifc-lite bsdd psets IfcWall | jq '.["Pset_WallCommon"]'
+ifc-lite bsdd psets IfcWall --json | jq '.["Pset_WallCommon"]'
 ```
 
 ## Using with LLM Terminals

--- a/packages/cli/src/commands/bsdd.test.ts
+++ b/packages/cli/src/commands/bsdd.test.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ifc-lite bsdd` parsed `--json` into a variable it never read: every
+ * subcommand called `printJson(...)` unconditionally, so `bsdd class
+ * IfcWall` and `bsdd class IfcWall --json` produced byte-identical output
+ * and there was no human-readable mode at all, unlike every other CLI
+ * command with a `--json` flag (e.g. `ext capabilities`). This pins the
+ * observable fix: omitting `--json` now prints a human-readable summary,
+ * and `--json` still prints the raw structured payload.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+vi.mock('@ifc-lite/sdk', () => {
+  class BsddNamespace {
+    async fetchClassInfo(ifcType: string) {
+      return {
+        uri: `https://example.org/class/${ifcType}`,
+        code: ifcType,
+        name: 'Wall',
+        definition: 'A vertical construction.',
+        parentClassUri: null,
+        relatedIfcEntityNames: null,
+        classProperties: [
+          { name: 'IsExternal', uri: 'u1', description: 'Externality', dataType: 'Boolean', propertySet: 'Pset_WallCommon', allowedValues: null, units: null, isIfcStandard: true },
+        ],
+      };
+    }
+  }
+  return { BsddNamespace };
+});
+
+const { bsddCommand } = await import('./bsdd.js');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function captureStdio(): { out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    out.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    err.push(String(chunk));
+    return true;
+  });
+  return { out, err };
+}
+
+describe('bsddCommand --json', () => {
+  it('prints a human-readable summary without --json, and raw JSON with --json', async () => {
+    const withoutJson = captureStdio();
+    await bsddCommand(['class', 'IfcWall']);
+    const plainOut = withoutJson.out.join('');
+
+    const withJson = captureStdio();
+    await bsddCommand(['class', 'IfcWall', '--json']);
+    const jsonOut = withJson.out.join('');
+
+    // The two modes must differ: this is the flag's whole point.
+    expect(plainOut).not.toBe(jsonOut);
+
+    // --json output must remain a parseable structured payload.
+    expect(() => JSON.parse(jsonOut)).not.toThrow();
+
+    // Without --json, output must not just be pretty-printed JSON: it must
+    // not parse as JSON at all (it's the human summary).
+    expect(() => JSON.parse(plainOut)).toThrow();
+  });
+});

--- a/packages/cli/src/commands/bsdd.ts
+++ b/packages/cli/src/commands/bsdd.ts
@@ -15,7 +15,8 @@
  *   qsets    <IfcType>    List standard quantity sets
  */
 
-import { hasFlag, fatal, printJson } from '../output.js';
+import { hasFlag, fatal, printJson, formatTable } from '../output.js';
+import type { BsddClassInfo, BsddClassProperty, BsddSearchResult } from '@ifc-lite/sdk';
 
 export async function bsddCommand(args: string[]): Promise<void> {
   const subcommand = args.find(a => !a.startsWith('-'));
@@ -34,39 +35,75 @@ export async function bsddCommand(args: string[]): Promise<void> {
       if (!ifcType) fatal('Usage: ifc-lite bsdd class <IfcType>');
       const info = await bsdd.fetchClassInfo(ifcType);
       if (!info) fatal(`No bSDD info found for ${ifcType}`);
-      printJson(info);
+      if (jsonOutput) printJson(info);
+      else printClassInfo(info);
       break;
     }
     case 'search': {
       const query = positional[1];
       if (!query) fatal('Usage: ifc-lite bsdd search <query>');
       const results = await bsdd.search(query);
-      printJson(results);
+      if (jsonOutput) printJson(results);
+      else printSearchResults(results);
       break;
     }
     case 'psets': {
       const ifcType = positional[1];
       if (!ifcType) fatal('Usage: ifc-lite bsdd psets <IfcType>');
       const psets = await bsdd.getPropertySets(ifcType);
-      const obj: Record<string, unknown[]> = {};
-      for (const [name, props] of psets) {
-        obj[name] = props;
-      }
-      printJson(obj);
+      if (jsonOutput) printJson(Object.fromEntries(psets));
+      else printPropertySets(psets, 'property');
       break;
     }
     case 'qsets': {
       const ifcType = positional[1];
       if (!ifcType) fatal('Usage: ifc-lite bsdd qsets <IfcType>');
       const qsets = await bsdd.getQuantitySets(ifcType);
-      const obj: Record<string, unknown[]> = {};
-      for (const [name, props] of qsets) {
-        obj[name] = props;
-      }
-      printJson(obj);
+      if (jsonOutput) printJson(Object.fromEntries(qsets));
+      else printPropertySets(qsets, 'quantity');
       break;
     }
     default:
       fatal(`Unknown bsdd subcommand: ${subcommand}. Use: class, search, psets, qsets`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Human-readable output (default, no --json)
+// ---------------------------------------------------------------------------
+
+function printClassInfo(info: BsddClassInfo): void {
+  process.stdout.write(`${info.code}  ${info.name}\n`);
+  process.stdout.write(`${info.uri}\n`);
+  if (info.definition) process.stdout.write(`\n${info.definition}\n`);
+  if (info.classProperties.length > 0) {
+    process.stdout.write('\n');
+    process.stdout.write(`${formatTable(
+      ['Property', 'Set', 'Type', 'Description'],
+      info.classProperties.map((p) => [p.name, p.propertySet ?? '(attribute)', p.dataType ?? '', p.description ?? '']),
+    )}\n`);
+  }
+}
+
+function printSearchResults(results: readonly BsddSearchResult[]): void {
+  if (results.length === 0) {
+    process.stderr.write('No results.\n');
+    return;
+  }
+  process.stdout.write(`${formatTable(
+    ['Code', 'Name', 'Dictionary'],
+    results.map((r) => [r.code, r.name, r.dictionaryUri]),
+  )}\n`);
+}
+
+function printPropertySets(sets: ReadonlyMap<string, BsddClassProperty[]>, label: 'property' | 'quantity'): void {
+  if (sets.size === 0) {
+    process.stderr.write(`No ${label} sets found.\n`);
+    return;
+  }
+  const rows: string[][] = [];
+  for (const [setName, props] of sets) {
+    for (const p of props) rows.push([setName, p.name, p.dataType ?? '', p.description ?? '']);
+  }
+  process.stdout.write(`${formatTable(['Set', 'Name', 'Type', 'Description'], rows)}\n`);
 }

--- a/scripts/unused-locals-baseline.json
+++ b/scripts/unused-locals-baseline.json
@@ -8,7 +8,7 @@
   "packages/bcf": 5,
   "packages/cache": 6,
   "packages/clash": 1,
-  "packages/cli": 7,
+  "packages/cli": 6,
   "packages/codegen": 5,
   "packages/collab": 7,
   "packages/collab-server": 3,


### PR DESCRIPTION
## Summary

Following up on PR #3493 (`query --storey` dropping `--limit`/`--offset`), this audits `create`, `layer*`, `gym`, `ext`, `bsdd` for the same shape of defect: a flag parsed but never read into behaviour.

Four of the five commands (`create`, every `layer*` subcommand, `gym`, `ext`/`ext-signing`) trace every declared flag from parse site through to observable behaviour with no gaps — see the audit table below.

`bsdd` had the real defect: `--json` was parsed into `jsonOutput` and then never referenced again. Every subcommand (`class`, `search`, `psets`, `qsets`) called `printJson(...)` unconditionally, so `bsdd class IfcWall` and `bsdd class IfcWall --json` produced byte-identical output. Confirmed by running both and diffing (identical), contrasted with `ext capabilities`, whose `--json` flag does change output (human table vs JSON).

- `bsdd` now prints a human-readable summary (table via the existing `formatTable` helper, same convention as `ext capabilities`/`info`/`diff`) by default, and the raw structured payload under `--json`.
- The one documented example that relied on the old always-JSON default (`ifc-lite bsdd psets IfcWall | jq ...`) is updated to pass `--json` explicitly, since it now needs to.
- Changeset added for `@ifc-lite/cli` (patch), disclosing the behavioural change for anyone piping bsdd output into a JSON consumer without `--json`.

## Audit table

| command | flag | parsed? | read? | reaches behaviour? | documented? | verdict |
|---|---|---|---|---|---|---|
| create | --out, --viewer, --project, --storey, --elevation, --from-json, --json, --pset, --qset, --material, --color, all element-shape flags (`--height`, `--width`, ... `--xdim`/`--ydim`), --name/--description/--object-type/--tag/--long-name/--predefined-type/--operation-type/--partitioning-type/--proxy-type, --is-rectangular, --wall-id, --start/--end/--position | yes | yes | yes | yes | OK |
| layer publish/create/status | --base, --intent, --scope, --principal, --kind, --strict-scope, --check, --json | yes | yes | yes | yes | OK |
| layer diff | --against, --components, --json | yes | yes | yes | yes | OK |
| layer merge | --into, --preview, --resolve, --waive/--reason, --approved-by, --principal, --allow-unrelated, --json | yes | yes | yes | --allow-unrelated undocumented in `layer.ts` usage text | OK (doc gap only, no behaviour bug) |
| layer push | --registry, --token, --set-ref, --json | yes | yes | yes | yes | OK |
| layer log/bake/revert/rebase | --json, -o/--out, --in, --resolve, --onto, --principal | yes | yes | yes | yes | OK |
| gym | --model, --seed, --checks, --ids, --locale, --family, --corrupt/--no-corrupt, --corrupt-rate | yes | yes | yes | yes | OK |
| ext validate/init/test/capabilities | --json, --id, --name, --bail | yes | yes | yes | yes | OK |
| ext keygen/pack/sign/verify | --out, --label, --key, --sign, --force, --json | yes | yes | yes | --force undocumented in `ext.ts` usage text | OK (doc gap only, no behaviour bug) |
| **bsdd** | **--json** | **yes** | **parsed into `jsonOutput`, never referenced again** | **no — every path always called `printJson`** | not documented as accepted, but examples relied on it being the de-facto default | **DEFECT — fixed here** |

## Proof

```
$ node dist/index.js bsdd class IfcWall > /tmp/nojson.out
$ node dist/index.js bsdd class IfcWall --json > /tmp/json.out
$ diff /tmp/nojson.out /tmp/json.out
# (before the fix: no diff — byte-identical)
```

Contrast, same CLI, `--json` doing real work:
```
$ node dist/index.js ext capabilities | head -3
Capabilities (17 total):
  [GREEN ] model.read
$ node dist/index.js ext capabilities --json | head -3
[
  {
    "raw": "model.read",
```

RED → GREEN: `packages/cli/src/commands/bsdd.test.ts` asserts the flag's observable effect (human output differs from, and does not parse as, the `--json` output). Failed before the fix (`plainOut` === `jsonOut`), passes after.

## Test plan

- [x] `packages/cli/src/commands/bsdd.test.ts` — RED before the fix, GREEN after
- [x] `node scripts/check-module-size.mjs` — OK, 0 new violations
- [x] `pnpm --filter @ifc-lite/cli exec tsc --noEmit` — clean
- [x] `packages/cli` typecheck-tests (`node scripts/typecheck-tests.mjs`) — OK, 51 test files
- [x] Full `packages/cli` vitest suite — 539 passed, 8 skipped (pre-existing), 0 failed
- [x] Manual smoke test against the live bSDD API for `class`/`psets` in both modes

PR #3493 is still open (not merged) at the time of this audit; this PR does not touch `packages/cli/src/commands/query.ts`.

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436