### PR TITLE
fix(sandbox): let bim.viewer.resetColors() target specific entities

### DIFF
--- a/.changeset/sandbox-reset-colors-entities.md
+++ b/.changeset/sandbox-reset-colors-entities.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/sandbox': patch
+---
+
+`bim.viewer.resetColors()` in sandbox scripts always reset every color override in the model. The SDK method it wraps (`resetColors(refs?: EntityRef[])`) already supports resetting only the given entities' colors, but the sandbox schema declared `resetColors` with zero parameters, so a script had no way to pass any — the capability was unreachable from user scripts, the editor's completions, and the LLM system prompt. `resetColors` now takes an optional `entities` argument and forwards it; calling it with no arguments still resets everything.

--- a/apps/viewer/src/lib/scripts/templates/bim-globals.d.ts
+++ b/apps/viewer/src/lib/scripts/templates/bim-globals.d.ts
@@ -412,8 +412,8 @@ declare const bim: {
     select(entities: BimEntity[]): void;
     /** Fly camera to entities */
     flyTo(entities: BimEntity[]): void;
-    /** Reset all colors */
-    resetColors(): void;
+    /** Reset colors. Omit entities (or pass none) to reset every color override; pass entities to reset only theirs. */
+    resetColors(entities?: BimEntity[]): void;
     /** Reset all visibility */
     resetVisibility(): void;
   };

--- a/packages/sandbox/src/bridge-viewer.test.ts
+++ b/packages/sandbox/src/bridge-viewer.test.ts
@@ -48,6 +48,28 @@ function mockSdk() {
   } as unknown as BimContext;
 }
 
+describe('bim.viewer.resetColors — entity-scoped reset', () => {
+  it('forwards the given entities to sdk.viewer.resetColors instead of always resetting everything', () => {
+    // sdk.viewer.resetColors(refs?: EntityRef[]) already supports resetting
+    // just the given entities (packages/sdk/src/namespaces/viewer.ts) — the
+    // streaming viewer backend (packages/viewer/src/streaming-viewer.ts)
+    // dispatches a distinct `resetColorEntities` action for a non-empty
+    // `refs`. The bridge previously declared `args: []` and always called
+    // `sdk.viewer.resetColors()` with nothing, so a script author had no way
+    // to reach that capability — every call reset the whole model.
+    const sdk = mockSdk();
+    const refA: EntityRef = { modelId: 'm1', expressId: 1 };
+    findMethod('resetColors').call(sdk, [[refA]], CTX);
+    expect(sdk.viewer.resetColors).toHaveBeenCalledWith([refA]);
+  });
+
+  it('still resets everything when called with no entities', () => {
+    const sdk = mockSdk();
+    findMethod('resetColors').call(sdk, [[]], CTX);
+    expect(sdk.viewer.resetColors).toHaveBeenCalledWith([]);
+  });
+});
+
 describe('bim.viewer.colorizeAll — batch reshape', () => {
   it('extracts .ref from wrapped entities and pairs it with the batch color', () => {
     const sdk = mockSdk();

--- a/packages/sandbox/src/bridge-viewer.ts
+++ b/packages/sandbox/src/bridge-viewer.ts
@@ -96,10 +96,12 @@ export function buildViewerNamespace(): NamespaceSchema {
       },
       {
         name: 'resetColors',
-        doc: 'Reset all colors',
-        args: [],
-        call: (sdk) => {
-          sdk.viewer.resetColors();
+        doc: 'Reset colors. Omit entities (or pass none) to reset every color override; pass entities to reset only theirs.',
+        args: ['entityRefs'],
+        paramNames: ['entities'],
+        tsParamTypes: ['BimEntity[] | undefined'],
+        call: (sdk, args) => {
+          sdk.viewer.resetColors(args[0] as EntityRef[]);
         },
         returns: 'void',
       },


### PR DESCRIPTION
## Summary

Audited `packages/sandbox/src/bridge-schema.ts`'s `NAMESPACE_SCHEMAS` (122 methods across 11 namespaces, confirmed by enumeration) against every `bridge-*.ts` implementation, looking for a declaration whose parameter or return the implementation silently ignores.

- **`bim.viewer.resetColors`** declared `args: []` and its `call:` always invoked `sdk.viewer.resetColors()` with nothing.
- `sdk.viewer.resetColors(refs?: EntityRef[])` (`packages/sdk/src/namespaces/viewer.ts`) already supports resetting just the given entities — the streaming viewer backend (`packages/viewer/src/streaming-viewer.ts`) dispatches a distinct `resetColorEntities` action for a non-empty `refs`, versus `showall` for none.
- Because the bridge schema never forwarded anything, no sandbox script, editor completion, or LLM-generated call could ever reach that capability — every `bim.viewer.resetColors()` call reset every color override in the model, with no way to scope it.

Proved by execution before fixing: calling the bridge method's `call:` handler directly with an entity array showed `sdk.viewer.resetColors` invoked with `[]` regardless (see the new `bridge-viewer.test.ts` case, RED before the fix).

## Fix

`resetColors` now takes an optional `entities` argument (`BimEntity[] | undefined`) and forwards it unchanged to `sdk.viewer.resetColors`. Calling it with no arguments still resets everything (the SDK/streaming-viewer treat an empty/undefined array the same way), so the existing built-in templates that call `bim.viewer.resetColors()` with no arguments are unaffected.

Regenerated `apps/viewer/src/lib/scripts/templates/bim-globals.d.ts` via `pnpm generate:bim-globals`; `node scripts/generate-bim-globals.mjs --check` and `pnpm check:templates` both pass.

Everything else in `NAMESPACE_SCHEMAS` — `bim.model`, `bim.query` (aside from the already-known `entity`/`mutate.delete` items), `bim.mutate`, `bim.store`, `bim.lens`, `bim.create` (auto-discovered from `IfcCreator.prototype`), `bim.create`'s scheduling methods, `bim.files`, `bim.schedule`, `bim.clash`, and `bim.export` — was checked param-by-param against its implementation and matched.

## Test plan

- [x] New RED→GREEN test in `packages/sandbox/src/bridge-viewer.test.ts` asserting `resetColors` forwards the given entities (and still resets everything when called with none)
- [x] `pnpm --filter=@ifc-lite/sandbox exec vitest run` — 208/208 passing
- [x] `pnpm --filter=@ifc-lite/sandbox exec tsc --noEmit` and `node scripts/typecheck-tests.mjs` (sandbox) clean
- [x] `node scripts/generate-bim-globals.mjs --check` — in sync
- [x] `pnpm check:templates` — clean
- [x] `node scripts/check-module-size.mjs` — 0 new over budget

Changeset: `@ifc-lite/sandbox` patch (declared-surface behaviour change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)