### PR TITLE
fix(viewer): honour resetColors(refs) on the in-app browser host

### DIFF
--- a/apps/viewer/src/sdk/adapters/viewer-adapter.resetColors.test.ts
+++ b/apps/viewer/src/sdk/adapters/viewer-adapter.resetColors.test.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createViewerAdapter } from './viewer-adapter.js';
+import type { StoreApi } from './types.js';
+
+type ColorMap = Map<number, [number, number, number, number]>;
+
+function makeStore(): { store: StoreApi; getPending: () => ColorMap | null } {
+  let pendingColorUpdates: ColorMap | null = null;
+  const state = {
+    // idOffset: 0 so toGlobalIdForRef(state.models, ref) === ref.expressId, matching the
+    // expressId literals used by refA/refB below.
+    models: new Map([['default', { idOffset: 0 }]]),
+    get pendingColorUpdates() {
+      return pendingColorUpdates;
+    },
+    setPendingColorUpdates: (updates: ColorMap) => {
+      pendingColorUpdates = new Map(updates);
+    },
+  };
+  const store = {
+    getState: () => state,
+    subscribe: () => () => {},
+  } as unknown as StoreApi;
+  return { store, getPending: () => pendingColorUpdates };
+}
+
+const refA = { modelId: 'default', expressId: 1 };
+const refB = { modelId: 'default', expressId: 2 };
+const red: [number, number, number, number] = [1, 0, 0, 1];
+const blue: [number, number, number, number] = [0, 0, 1, 1];
+
+test('resetColors() with no argument still clears everything (regression guard)', () => {
+  const { store, getPending } = makeStore();
+  const adapter = createViewerAdapter(store);
+
+  adapter.colorize([refA, refB], red);
+  assert.equal(getPending()?.size, 2);
+
+  adapter.resetColors();
+
+  const pending = getPending();
+  assert.ok(pending !== null, 'resetColors() must still emit a map (not null) to trigger the clear effect');
+  assert.equal(pending?.size, 0, 'resetColors() with no refs must clear ALL overrides');
+});
+
+test('resetColors([a]) clears only a and leaves b intact', () => {
+  const { store, getPending } = makeStore();
+  const adapter = createViewerAdapter(store);
+
+  adapter.colorize([refA], red);
+  adapter.colorize([refB], blue);
+  assert.equal(getPending()?.size, 2);
+
+  adapter.resetColors([refA]);
+
+  const pending = getPending();
+  assert.equal(pending?.has(1), false, 'refA override must be gone');
+  assert.equal(pending?.has(2), true, 'refB override must remain');
+  assert.deepEqual(pending?.get(2), blue);
+});
+
+test('resetColors(refs) still works after the store has flushed pendingColorUpdates to null', () => {
+  const { store, getPending } = makeStore();
+  const adapter = createViewerAdapter(store);
+
+  adapter.colorize([refA, refB], red);
+  // Simulate the geometry-streaming effect flushing the update and clearing it —
+  // this is exactly what happens between renders in the real app via clearPendingColorUpdates().
+  Object.defineProperty(store.getState(), 'pendingColorUpdates', { value: null, configurable: true });
+
+  adapter.resetColors([refA]);
+
+  const pending = getPending();
+  assert.equal(pending?.has(1), false, 'refA override must be gone even after a flush');
+  assert.equal(pending?.has(2), true, 'refB override must survive the flush and the targeted reset');
+});

--- a/apps/viewer/src/sdk/adapters/viewer-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/viewer-adapter.ts
@@ -19,16 +19,25 @@ const STORE_TO_AXIS: Record<string, 'x' | 'y' | 'z'> = {
 };
 
 export function createViewerAdapter(store: StoreApi): ViewerBackendMethods {
+  // Tracks colors the SDK itself has applied. `pendingColorUpdates` in the store is a
+  // one-shot signal: the geometry-streaming effect flushes it to the renderer and then
+  // nulls it out, so it can't be read back later as "what's currently applied". This
+  // closure survives that flush, so resetColors(refs) can compute "all SDK colors minus
+  // refs" even after the effect has already run.
+  let sdkColorOverrides = new Map<number, [number, number, number, number]>();
+
   return {
     colorize(refs: EntityRef[], color: [number, number, number, number]) {
       const state = store.getState();
-      // Merge with existing pending colors (supports multiple colorize calls per script)
-      const existing = state.pendingColorUpdates;
-      const colorMap = existing ? new Map(existing) : new Map<number, [number, number, number, number]>();
+      // Merge with existing pending colors (supports multiple colorize calls per script,
+      // and survives the effect having already flushed+cleared pendingColorUpdates).
+      const existing = state.pendingColorUpdates ?? sdkColorOverrides;
+      const colorMap = new Map(existing);
       for (const ref of refs) {
         if (!getModelForRef(state, ref.modelId)) continue;
         colorMap.set(toGlobalIdForRef(state.models, ref), color);
       }
+      sdkColorOverrides = colorMap;
       state.setPendingColorUpdates(colorMap);
       return undefined;
     },
@@ -43,13 +52,28 @@ export function createViewerAdapter(store: StoreApi): ViewerBackendMethods {
           batchMap.set(toGlobalIdForRef(state.models, ref), batch.color);
         }
       }
+      sdkColorOverrides = batchMap;
       state.setPendingColorUpdates(batchMap);
       return undefined;
     },
-    resetColors() {
+    resetColors(refs?: EntityRef[]) {
       const state = store.getState();
-      // Set empty map to trigger scene.clearColorOverrides() (null skips the effect)
-      state.setPendingColorUpdates(new Map());
+      if (!refs || refs.length === 0) {
+        // Set empty map to trigger scene.clearColorOverrides() (null skips the effect)
+        sdkColorOverrides = new Map();
+        state.setPendingColorUpdates(new Map());
+        return undefined;
+      }
+      // Targeted reset: drop only the given entities from the known override set,
+      // re-emitting whatever remains (same "empty map clears everything" contract above —
+      // if nothing remains, this naturally clears everything too).
+      const existing = state.pendingColorUpdates ?? sdkColorOverrides;
+      const colorMap = new Map(existing);
+      for (const ref of refs) {
+        colorMap.delete(toGlobalIdForRef(state.models, ref));
+      }
+      sdkColorOverrides = colorMap;
+      state.setPendingColorUpdates(colorMap);
       return undefined;
     },
     flyTo() {


### PR DESCRIPTION
## Summary

- `apps/viewer/src/sdk/adapters/viewer-adapter.ts` declared `resetColors(refs?: EntityRef[])` but ignored `refs`, always clearing every color override — regardless of what was passed.
- The CLI/streaming host (`packages/viewer/src/streaming-viewer.ts:59`) already honours `refs` for a per-entity reset via `resetColorEntities`. The two hosts disagreed on a parameter that's advertised in editor completions and the LLM prompt.
- The adapter now tracks colors the SDK itself has applied in a closure that survives the geometry-streaming effect nulling out `pendingColorUpdates` after each flush (see `apps/viewer/src/components/viewer/useGeometryStreaming.ts:813-829`), so `resetColors(refs)` can compute "current SDK overrides minus refs" even after a prior `colorize()` call has already been rendered and cleared from the store.
- `resetColors()` with no argument is **unchanged**: it still emits an empty map, which the consuming effect treats as "clear everything" (`pendingColorUpdates.size === 0 → scene.clearColorOverrides()`).

## Relationship to #3496

#3496 declares the same `resetColors(refs)` parameter on `packages/sandbox/src/bridge-viewer.ts` but forwards it only to the SDK call — the browser host adapter it eventually calls into ignored the argument. Landing #3496 alone would have made `bim.viewer.resetColors([a, b])` reset only `a`/`b` under CLI while silently resetting **everything** in the browser. **This PR makes the declaration true on the browser host — merge this one first or together with #3496.** This PR does not touch `packages/sandbox/src/bridge-viewer.ts`.

## Test plan

- [x] New test `resetColors() with no argument still clears everything (regression guard)` — pins the existing clear-all behavior.
- [x] New test `resetColors([a]) clears only a and leaves b intact` — RED against the old adapter (verified by temporarily reverting the adapter change), GREEN with the fix.
- [x] New test `resetColors(refs) still works after the store has flushed pendingColorUpdates to null` — covers the realistic scripted flow (colorize → render flush → resetColors(subset)).
- [x] `pnpm exec tsc --noEmit` in `apps/viewer` (including test files) — clean.
- [x] `pnpm exec tsx --test --test-concurrency=1` over `apps/viewer/src/sdk/adapters/*.test.ts` and `apps/viewer/src/store/slices/dataSlice.test.ts` — 34 + 15 passing, 0 failing.
- [x] `apps/viewer` is `private: true` — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436