### PR TITLE
fix(cli): fold the mutation overlay into HeadlessBackend query reads

### DIFF
--- a/.changeset/cli-headless-query-overlay-visibility.md
+++ b/.changeset/cli-headless-query-overlay-visibility.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix `HeadlessBackend.query`/`bim.query()` answering about the parsed file instead of the session: `bim.store.addEntity(...)` followed by a query in the same session did not return the new entity, and `bim.store.removeEntity(ref)` followed by a query still returned the entity it had just deleted.
+
+`StoreEditor.addEntity`/`removeEntity` deliberately never touch `store.entityIndex` (the parsed file's immutable index) — writes live only in the `MutablePropertyView` overlay, and the CLI's query adapter read `store.entityIndex` alone. `@ifc-lite/mcp`'s parallel `HeadlessLikeBackend` already folds its overlay into every read for the same reason (#2004, #2014); this ports the entity add/remove visibility half of that fix to the CLI, so a script using `@ifc-lite/cli` programmatically now sees the same read-your-own-write behaviour MCP already gives it. Property/quantity overlay folding is unaffected — this is scoped to entity visibility.

--- a/packages/cli/src/headless-backend-overlay-visibility.test.ts
+++ b/packages/cli/src/headless-backend-overlay-visibility.test.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `HeadlessBackend.query.entities()`/`entityData()` read only
+ * `store.entityIndex`, the parsed file's immutable index.
+ * `StoreEditor.addEntity()` / `removeEntity()` deliberately never touch that
+ * index (mutations/store-editor.ts) — writes live only in the
+ * `MutablePropertyView` overlay this same backend already creates for
+ * `bim.mutate.*` / `bim.export.ifc()`. So a session that did
+ * `bim.store.addEntity(...)` and then `bim.query()` to confirm was told its
+ * own write had not happened, and a session that did
+ * `bim.store.removeEntity(ref)` and then `bim.query()` still got the entity
+ * back.
+ *
+ * `@ifc-lite/mcp`'s parallel `HeadlessLikeBackend` already folds its overlay
+ * into every read for exactly this reason (#2004, #2014) — this backend did
+ * not, so the same script produced different query results depending on
+ * whether it ran under the CLI or under MCP. Fixed by reading
+ * `MutablePropertyView.getNewEntities()` / `isDeleted()` (the overlay's own
+ * public API, already imported here) alongside `store.entityIndex`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createHeadlessContext } from './loader.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SAMPLE_IFC = join(__dirname, '../../../apps/viewer/public/samples/building-architecture.ifc');
+
+describe('HeadlessBackend query overlay visibility', () => {
+  it('a newly added IfcWall is visible to bim.query() in the same session', async () => {
+    const { bim } = await createHeadlessContext(SAMPLE_IFC);
+    const before = bim.query().byType('IfcWall').toArray();
+
+    const ref = bim.store.addEntity('default', {
+      type: 'IfcWall',
+      attributes: ["2N1x3zzzzzzzzzzzzzzzzz", null, "'ProvenWall'", null, null, null, null, null, null],
+    });
+
+    const after = bim.query().byType('IfcWall').toArray();
+    expect(after.length).toBe(before.length + 1);
+    expect(after.some((e) => e.ref.expressId === ref.expressId && e.name === 'ProvenWall')).toBe(true);
+  });
+
+  it('a removed entity disappears from bim.query() in the same session', async () => {
+    const { bim } = await createHeadlessContext(SAMPLE_IFC);
+    const walls = bim.query().byType('IfcWall').toArray();
+    expect(walls.length).toBeGreaterThan(0);
+    const victim = walls[0];
+
+    bim.store.removeEntity(victim.ref);
+
+    const after = bim.query().byType('IfcWall').toArray();
+    expect(after.some((e) => e.ref.expressId === victim.ref.expressId)).toBe(false);
+    expect(after.length).toBe(walls.length - 1);
+  });
+});

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -89,6 +89,7 @@ import {
 import { escapeCsvCell, exportToStep, StepExporter, type StepExportOptions } from '@ifc-lite/export';
 import { exportHbjson, exportDfjson } from './energy-export.js';
 import { foldQueuedRelated } from './query-overlay-relations.js';
+import { overlayEntityData, foldNewEntities } from './query-overlay.js';
 
 // `expandTypes` used to be defined here; it now comes from `@ifc-lite/parser`,
 // shared with the other query backends (see `query-backend-maps.ts`). Re-exported
@@ -239,8 +240,9 @@ export class HeadlessBackend implements BimBackend {
     const getMutationView = () => this.mutationView;
 
     function getEntityData(ref: EntityRef): EntityData | null {
-      // Verify the entity actually exists in the parsed data
-      if (!store.entityIndex.byId.has(ref.expressId)) return null;
+      const overlay = overlayEntityData(getMutationView(), ref);
+      if (overlay !== undefined) return overlay;
+      if (!store.entityIndex.byId.has(ref.expressId)) return null; // not parsed either
       const node = new EntityNode(store, ref.expressId);
       const type = node.type;
       if (!type || type === 'Unknown') return null;
@@ -282,6 +284,7 @@ export class HeadlessBackend implements BimBackend {
     return {
       entities(descriptor: QueryDescriptor): EntityData[] {
         const results: EntityData[] = [];
+        const view = getMutationView();
 
         let entityIds: number[];
         if (descriptor.types && descriptor.types.length > 0) {
@@ -301,6 +304,7 @@ export class HeadlessBackend implements BimBackend {
 
         for (const expressId of entityIds) {
           if (expressId === 0) continue;
+          if (view?.isDeleted(expressId)) continue; // tombstoned this session
           const node = new EntityNode(store, expressId);
           results.push({
             ref: { modelId: MODEL_ID, expressId },
@@ -311,7 +315,7 @@ export class HeadlessBackend implements BimBackend {
             objectType: node.objectType,
           });
         }
-
+        if (view) results.push(...foldNewEntities(view, descriptor.types, expandTypes, isProductType, MODEL_ID));
         let filtered = results;
         if (descriptor.filters && descriptor.filters.length > 0) {
           const propsCache = new Map<number, PropertySetData[]>();
@@ -354,8 +358,11 @@ export class HeadlessBackend implements BimBackend {
         // comparison is false) instead of rejecting it, and by the same
         // reasoning silently ignored a deliberate `limit: 0`. Reject
         // non-finite/negative values loudly instead of quietly serving the
-        // wrong slice. `@ifc-lite/mcp`'s parallel `backend-query.ts` carries
-        // the identical fix independently — same defect shape, own tests.
+        // wrong slice. The CLI's own `--limit`/`--offset` flags are validated
+        // before reaching this descriptor, so this guards direct SDK callers
+        // (`@ifc-lite/mcp`'s parallel `backend-query.ts` ported the identical
+        // fix independently — same defect shape, own tests and release
+        // cadence).
         if (descriptor.offset != null) {
           if (!Number.isFinite(descriptor.offset) || descriptor.offset < 0) {
             throw new TypeError(`Invalid offset: ${descriptor.offset} (must be a non-negative finite number)`);

--- a/packages/cli/src/query-overlay.ts
+++ b/packages/cli/src/query-overlay.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Overlay-visibility helpers for `HeadlessBackend.query` (headless-backend.ts).
+ *
+ * `StoreEditor.addEntity`/`removeEntity` never touch `store.entityIndex` (the
+ * parsed file's immutable index) — writes live only in the
+ * `MutablePropertyView` overlay. Without folding that in, a
+ * `bim.store.addEntity`/`removeEntity` followed by `bim.query()` in the same
+ * session answered about the file as parsed, not as the session had just
+ * changed it. `@ifc-lite/mcp`'s parallel backend already folds its overlay
+ * into every read (#2004, #2014); this ports the entity add/remove
+ * visibility half of that to the CLI via the overlay's own public
+ * `getNewEntities()`/`isDeleted()`.
+ */
+
+import type { EntityData, EntityRef } from '@ifc-lite/sdk';
+import type { MutablePropertyView, NewEntity } from '@ifc-lite/mutations';
+
+function scalarAttr(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (trimmed === '' || trimmed === '$' || trimmed === '*') return '';
+  if (trimmed.length >= 2 && trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1).replace(/''/g, "'");
+  }
+  return trimmed;
+}
+
+/**
+ * Slots 0/2/3 are GlobalId/Name/Description on every IfcRoot subtype (the
+ * only classes this backend queries). Slot 4 differs by class (ObjectType vs
+ * ApplicableOccurrence), so it's left blank rather than misread.
+ */
+function createdEntityData(entity: Pick<NewEntity, 'expressId' | 'type' | 'attributes'>, modelId: string): EntityData {
+  return {
+    ref: { modelId, expressId: entity.expressId },
+    globalId: scalarAttr(entity.attributes[0]),
+    name: scalarAttr(entity.attributes[2]),
+    type: entity.type,
+    description: scalarAttr(entity.attributes[3]),
+    objectType: '',
+  };
+}
+
+/**
+ * `getEntityData(ref)`'s overlay half: `null` means deleted this session,
+ * `undefined` means "not in the overlay, fall through to the parsed store".
+ */
+export function overlayEntityData(view: MutablePropertyView | null, ref: EntityRef): EntityData | null | undefined {
+  if (!view) return undefined;
+  if (view.isDeleted(ref.expressId)) return null;
+  const created = view.getNewEntity(ref.expressId);
+  return created ? createdEntityData(created, ref.modelId) : undefined;
+}
+
+/** This session's overlay-only entities matching an `entities()` query's type criteria. */
+export function foldNewEntities(
+  view: MutablePropertyView,
+  types: string[] | undefined,
+  expandTypes: (types: string[]) => string[],
+  isProductType: (upperType: string) => boolean,
+  modelId: string,
+): EntityData[] {
+  const wantedTypes = types && types.length > 0 ? new Set(expandTypes(types)) : null;
+  const out: EntityData[] = [];
+  for (const created of view.getNewEntities()) {
+    if (view.isDeleted(created.expressId)) continue;
+    const upperType = created.type.toUpperCase();
+    const matches = wantedTypes ? wantedTypes.has(upperType) : isProductType(upperType);
+    if (matches) out.push(createdEntityData(created, modelId));
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- `HeadlessBackend.query` (`packages/cli/src/headless-backend.ts`) read only `store.entityIndex`, the parsed file's immutable index. `StoreEditor.addEntity`/`removeEntity` deliberately never touch that index — writes live only in the `MutablePropertyView` overlay. So `bim.store.addEntity(...)` followed by `bim.query()` in the same session did not return the new entity, and `bim.store.removeEntity(ref)` followed by `bim.query()` still returned the entity it had just deleted.
- `@ifc-lite/mcp`'s parallel `HeadlessLikeBackend` (`packages/mcp/src/backend-query.ts`) already folds its overlay into every read for this exact reason (#2004, #2014), so the same script produced different query results depending on whether it ran under the CLI or under MCP.
- Ports the entity add/remove visibility half of that fix to the CLI, via the overlay's own public `getNewEntities()`/`isDeleted()` (not MCP's richer `PendingOverlay` reader — property/quantity overlay folding is unchanged and out of scope here).
- Extracted the new logic into `packages/cli/src/query-overlay.ts` to keep `headless-backend.ts` under its pinned module-size budget.

## Test plan

- [x] New test `packages/cli/src/headless-backend-overlay-visibility.test.ts` — RED before the fix (`bim.query()` missing a just-added entity, 4 vs 5), GREEN after.
- [x] Second case covers the deletion direction (a removed entity disappearing from query results).
- [x] `pnpm exec tsc --noEmit` clean in `packages/cli`.
- [x] `node scripts/check-module-size.mjs` — OK, 0 new/growing files (`headless-backend.ts` shrunk under budget after extraction + trimming a stale comment).
- [x] Full `packages/cli` test suite: 540 passed, 8 skipped.
- [x] Changeset added (`@ifc-lite/cli`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queries now immediately reflect entities added during the current session.
  * Queries no longer return entities removed during the current session.
  * Added coverage to verify accurate results after entity additions and removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->