### PR TITLE
fix(viewer): resolve federation global ids before broadcasting collab selection

### DIFF
--- a/apps/viewer/src/components/viewer/presence/PresenceBroadcaster.selection-federation.test.ts
+++ b/apps/viewer/src/components/viewer/presence/PresenceBroadcaster.selection-federation.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `PresenceBroadcaster`'s selection effect used to call
+ * `pathForEntity(ifcDataStore, id)` directly, where `id` came straight off
+ * `selectedEntityIds` and `ifcDataStore` was the store's ACTIVE-model field.
+ *
+ * `selectedEntityIds` holds federation GLOBAL ids (offset per model —
+ * `useModelSelection.ts`'s own doc: "selectedEntityId is a globalId ... The
+ * EntityRef.expressId is the ORIGINAL expressId"). `pathForEntity` expects the
+ * per-model LOCAL expressId. Skipping `resolveEntityRef` (the module's own
+ * doc: "every code path that needs an EntityRef from a globalId MUST use this
+ * function") meant a global id belonging to a SECOND federated model got
+ * looked up, unmodified, against the FIRST model's entity table — the two
+ * numbers only coincide when idOffset is 0, which is why a single-model room
+ * never showed the bug.
+ *
+ * This test seeds two federated models with distinct `idOffset`s (matching
+ * what `useIfcLoader` leaves after a real federated load) and drives the
+ * fixed `pathsForSelection` directly.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store';
+import type { FederatedModel } from '@/store/types';
+import { pathsForSelection } from './PresenceBroadcaster.js';
+
+/** A minimal fake store: enough for `pathForEntity`'s cache-miss fallback
+ *  (`entityIndex.byId.entries()` for the primary pass, `entities.getGlobalId`
+ *  for the guid lookup) without a real parse. */
+function fakeStore(localIdToGuid: Record<number, string>): IfcDataStore {
+  return {
+    entityIndex: { byId: new Map() },
+    entities: { getGlobalId: (id: number) => localIdToGuid[id] ?? null },
+  } as unknown as IfcDataStore;
+}
+
+function fakeModel(id: string, idOffset: number, maxExpressId: number, store: IfcDataStore): FederatedModel {
+  return {
+    id,
+    name: id,
+    ifcDataStore: store,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: Date.now(),
+    fileSize: 1024,
+    idOffset,
+    maxExpressId,
+  };
+}
+
+describe('PresenceBroadcaster selection — federated global ids (#3457-style)', () => {
+  beforeEach(() => {
+    useViewerStore.getState().resetViewerState();
+    useViewerStore.getState().clearAllModels();
+  });
+
+  afterEach(() => {
+    useViewerStore.getState().resetViewerState();
+    useViewerStore.getState().clearAllModels();
+  });
+
+  it('resolves a selected entity on the SECOND federated model to ITS guid, not a lookup on the first model', () => {
+    const storeA = fakeStore({ 5: 'GUID-A-5' });
+    const storeB = fakeStore({ 5: 'GUID-B-5' }); // same LOCAL id, different model — the trap
+    useViewerStore.getState().addModel(fakeModel('model-a', 0, 100, storeA));
+    useViewerStore.getState().addModel(fakeModel('model-b', 1000, 100, storeB));
+
+    // globalId 1005 = model-b's local expressId 5 (offset 1000).
+    const paths = pathsForSelection(useViewerStore.getState(), [1005]);
+
+    assert.deepStrictEqual(
+      paths,
+      ['/GUID-B-5'],
+      'must resolve through the model B holds this id, not model A (whose local id 5 lands on the SAME raw number)',
+    );
+  });
+
+  it('resolves multiple selections across models to their OWN guids', () => {
+    const storeA = fakeStore({ 3: 'GUID-A-3' });
+    const storeB = fakeStore({ 3: 'GUID-B-3' });
+    useViewerStore.getState().addModel(fakeModel('model-a', 0, 100, storeA));
+    useViewerStore.getState().addModel(fakeModel('model-b', 1000, 100, storeB));
+
+    const paths = pathsForSelection(useViewerStore.getState(), [3, 1003]);
+
+    assert.deepStrictEqual(paths.sort(), ['/GUID-A-3', '/GUID-B-3'].sort());
+  });
+
+  it('still resolves in single-model (legacy, no federation map) mode', () => {
+    const store = fakeStore({ 7: 'GUID-LEGACY-7' });
+    useViewerStore.setState({ ifcDataStore: store });
+
+    const paths = pathsForSelection(useViewerStore.getState(), [7]);
+
+    assert.deepStrictEqual(paths, ['/GUID-LEGACY-7']);
+  });
+});

--- a/apps/viewer/src/components/viewer/presence/PresenceBroadcaster.tsx
+++ b/apps/viewer/src/components/viewer/presence/PresenceBroadcaster.tsx
@@ -15,13 +15,42 @@
  */
 
 import { useEffect, useRef } from 'react';
-import { useViewerStore } from '@/store';
+import { useViewerStore, resolveEntityRef } from '@/store';
 import { pathForEntity } from '@/lib/collab/mutation-bridge';
+import type { IfcDataStore } from '@ifc-lite/parser';
 
 /** Cursor plane: most viewer models sit near the local-frame ground (y≈0). */
 const CURSOR_PLANE_Y = 0;
 /** Cap raycasts to ~33 Hz; presence coalesces the rest. */
 const MOVE_THROTTLE_MS = 30;
+
+/**
+ * `selectedEntityIds` are federation GLOBAL ids (renderer-space, offset per
+ * model — see `useModelSelection.ts`), not the per-model expressIds
+ * `pathForEntity` expects. Every other globalId → path/EntityRef consumer
+ * (`useModelSelection`, the basket, the context menu) resolves through the
+ * mandated `resolveEntityRef` first (its own doc: "every code path that
+ * needs an EntityRef from a globalId MUST use this function") — this one
+ * skipped that and read the raw id straight off the ACTIVE model's store.
+ * With one model loaded that coincidentally works (offset 0, globalId ===
+ * expressId), which is why it went unnoticed; federated with a second model
+ * selected it looks the id up in the wrong store's entity table (or a
+ * numeric coincidence there), broadcasting a null or wrong peer's GUID.
+ */
+export function pathsForSelection(
+  state: { models: Map<string, { ifcDataStore: IfcDataStore | null }>; ifcDataStore: IfcDataStore | null },
+  selectedEntityIds: Iterable<number>,
+): string[] {
+  const paths: string[] = [];
+  for (const id of selectedEntityIds) {
+    const ref = resolveEntityRef(id);
+    const store = state.models.get(ref.modelId)?.ifcDataStore ?? state.ifcDataStore;
+    if (!store) continue;
+    const p = pathForEntity(store, ref.expressId);
+    if (p) paths.push(p);
+  }
+  return paths;
+}
 
 export function PresenceBroadcaster() {
   const sessionActive = useViewerStore((s) => s.collabSession !== null);
@@ -69,16 +98,9 @@ export function PresenceBroadcaster() {
   const selectedEntityIds = useViewerStore((s) => s.selectedEntityIds);
   useEffect(() => {
     if (!sessionActive) return;
-    const { collabSession, ifcDataStore } = useViewerStore.getState();
-    if (!collabSession) return;
-    const paths: string[] = [];
-    if (ifcDataStore) {
-      for (const id of selectedEntityIds) {
-        const p = pathForEntity(ifcDataStore, id);
-        if (p) paths.push(p);
-      }
-    }
-    collabSession.presence.setSelection(paths);
+    const state = useViewerStore.getState();
+    if (!state.collabSession) return;
+    state.collabSession.presence.setSelection(pathsForSelection(state, selectedEntityIds));
   }, [sessionActive, selectedEntityIds]);
 
   // Camera: poll the viewpoint and broadcast on meaningful movement, so peers can


### PR DESCRIPTION
## Summary
- `PresenceBroadcaster`'s selection effect broadcast the peer's selected-entity GUID paths by calling `pathForEntity(ifcDataStore, id)` directly, where `id` came straight off `selectedEntityIds` (federation **global** ids, offset per model) and `ifcDataStore` is the store's single active-model field.
- Every other globalId consumer in the viewer (`useModelSelection`, the basket, the context menu) resolves through `resolveEntityRef` first — its own doc comment says "every code path that needs an EntityRef from a globalId **MUST** use this function." This effect skipped that, so a selection on any federated model other than the currently-active one got looked up against the wrong model's entity table: silently dropped (no path found), or — on a numeric coincidence between two models' local ids — broadcasting the **wrong peer's GUID**.
- The bug is invisible with a single loaded model (`idOffset` 0, so `globalId === expressId`), which is presumably why it shipped unnoticed.
- Fix: extract the resolution into an exported `pathsForSelection()` that resolves each id through `resolveEntityRef` and looks it up in **that** model's own `ifcDataStore`, falling back to the legacy single-model field only for the true legacy (no-federation) case.

## Test plan
- [x] New regression test `PresenceBroadcaster.selection-federation.test.ts` seeds two federated models with distinct `idOffset`s (matching what `useIfcLoader` leaves after a real federated load) and drives `pathsForSelection` directly.
- [x] Confirmed RED against the pre-fix lookup (temporarily restoring the old `pathForEntity(ifcDataStore, id)` call): 2 of 3 cases fail — a federated-model selection is silently dropped.
- [x] GREEN after the fix: all 3 cases pass.
- [x] `node scripts/check-module-size.mjs` — OK, 0 files over budget.
- [x] `pnpm exec tsc --noEmit` (apps/viewer) — clean.
- [x] `apps/viewer` is `private: true` — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436