### PR TITLE
fix(cli): fold queued relationships into HeadlessBackend.query.related()

### DIFF
--- a/.changeset/cli-related-overlay-visibility.md
+++ b/.changeset/cli-related-overlay-visibility.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix `HeadlessBackend.query.related()`/`bim.related()` (and everything built on it — `bim.storey`, `bim.path`, `bim.contains`, `bim.decomposes`) answering about the parsed file instead of the session: `bim.store.addEntity('default', { type: 'IfcRelContainedInSpatialStructure', ... })` (or `IfcRelAggregates`, `IfcRelDefinesByType`, `IfcRelVoidsElement`, `IfcRelFillsElement`) followed by a `related()` query in the same session did not see the queued relationship, from either end.
+
+`StoreEditor.addEntity` deliberately never touches `store.relationships` (the parsed file's immutable graph) — a queued `IfcRel…` record lives only in the `MutablePropertyView` overlay. `@ifc-lite/mcp`'s parallel `HeadlessLikeBackend` already folds queued relationships into `related()` for the same reason (#2014); this ports that half of the fix to the CLI, so a script using `@ifc-lite/cli` programmatically now sees the same read-your-own-write behaviour MCP already gives it for relationships. Property/quantity/attribute overlay folding, and `related()` visibility for newly-*created* entities (a gap in `entityData()`, tracked separately), remain out of scope here.

--- a/packages/cli/src/headless-backend-related-overlay.test.ts
+++ b/packages/cli/src/headless-backend-related-overlay.test.ts
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `HeadlessBackend.query.related()` read `store.relationships` alone — the
+ * parsed file's immutable graph. `bim.store.addEntity('default', { type:
+ * 'IfcRelAggregates', ... })` deliberately never touches that graph; the
+ * queued record lives only in the session's `MutablePropertyView` overlay
+ * until an export. So a script that related two entities this way and then
+ * asked `related()` to confirm — from either end — was told its own write
+ * had not happened.
+ *
+ * `@ifc-lite/mcp`'s parallel `HeadlessLikeBackend` already folds queued
+ * relationships into `related()` for exactly this reason
+ * (`packages/mcp/src/overlay.ts`, #2014) — this backend did not, so the same
+ * script produced different `related()` results depending on whether it ran
+ * under the CLI or under MCP.
+ *
+ * Exercised against `HeadlessBackend.query` directly (not `BimContext`):
+ * `BimContext.related()` maps each `EntityRef` through
+ * `backend.query.entityData()`, and `entityData()` for a newly-*created*
+ * entity is a separate, already-tracked gap (#3498). Relating two walls the
+ * *file* already defines — only the `IfcRelAggregates` record between them is
+ * queued, and this fixture aggregates no wall to another — isolates the
+ * defect this test is pinning from that one.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { loadIfcFile } from './loader.js';
+import { HeadlessBackend } from './headless-backend.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SAMPLE_IFC = join(__dirname, '../../../apps/viewer/public/samples/building-architecture.ifc');
+
+describe('HeadlessBackend query.related() overlay visibility', () => {
+  it('sees a queued IfcRelAggregates both ways in the same session', async () => {
+    const store = await loadIfcFile(SAMPLE_IFC);
+    const backend = new HeadlessBackend(store, 'building-architecture.ifc');
+
+    const [parent, child] = backend.query.entities({ types: ['IfcWall'] });
+    expect(parent).toBeDefined();
+    expect(child).toBeDefined();
+
+    // Confirm the file itself relates neither direction between these two —
+    // otherwise the fold below could pass by coincidence.
+    expect(backend.query.related(parent.ref, 'IfcRelAggregates', 'forward')).toEqual([]);
+    expect(backend.query.related(child.ref, 'IfcRelAggregates', 'inverse')).toEqual([]);
+
+    backend.store.addEntity('default', {
+      type: 'IfcRelAggregates',
+      attributes: ["'3N1x3zzzzzzzzzzzzzzzzz'", null, null, null, `#${parent.ref.expressId}`, [`#${child.ref.expressId}`]],
+    });
+
+    // forward: the parent's queued children include the child.
+    const forward = backend.query.related(parent.ref, 'IfcRelAggregates', 'forward');
+    expect(forward.some((r) => r.expressId === child.ref.expressId)).toBe(true);
+
+    // inverse: the child's queued parent resolves back to the parent.
+    const inverse = backend.query.related(child.ref, 'IfcRelAggregates', 'inverse');
+    expect(inverse.some((r) => r.expressId === parent.ref.expressId)).toBe(true);
+  });
+
+  it('a deleted entity relates to nothing, even via a queued relationship', async () => {
+    const store = await loadIfcFile(SAMPLE_IFC);
+    const backend = new HeadlessBackend(store, 'building-architecture.ifc');
+
+    const [parent, child] = backend.query.entities({ types: ['IfcWall'] });
+
+    backend.store.addEntity('default', {
+      type: 'IfcRelAggregates',
+      attributes: ["'3N1x3zzzzzzzzzzzzzzzzz'", null, null, null, `#${parent.ref.expressId}`, [`#${child.ref.expressId}`]],
+    });
+    backend.store.removeEntity(child.ref);
+
+    const forward = backend.query.related(parent.ref, 'IfcRelAggregates', 'forward');
+    expect(forward.some((r) => r.expressId === child.ref.expressId)).toBe(false);
+  });
+});

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -88,6 +88,7 @@ import {
 } from '@ifc-lite/parser';
 import { escapeCsvCell, exportToStep, StepExporter, type StepExportOptions } from '@ifc-lite/export';
 import { exportHbjson, exportDfjson } from './energy-export.js';
+import { foldQueuedRelated } from './query-overlay-relations.js';
 
 // `expandTypes` used to be defined here; it now comes from `@ifc-lite/parser`,
 // shared with the other query backends (see `query-backend-maps.ts`). Re-exported
@@ -234,6 +235,8 @@ export class HeadlessBackend implements BimBackend {
 
   private createQueryAdapter(): QueryBackendMethods {
     const store = this.dataStore;
+    // Lazy — a read-only session's `related()` stays on the store-only path.
+    const getMutationView = () => this.mutationView;
 
     function getEntityData(ref: EntityRef): EntityData | null {
       // Verify the entity actually exists in the parsed data
@@ -348,24 +351,13 @@ export class HeadlessBackend implements BimBackend {
           }
         }
 
-        // `!= null` alone lets a NaN offset/limit through (NaN is neither
-        // null nor undefined); a bare `> 0` then silently drops it (every
-        // NaN comparison is false), which used to IGNORE a garbage value
-        // instead of rejecting it -- and, by the same reasoning, silently
-        // ignored a deliberate `limit: 0`. Reject non-finite/negative
-        // values loudly instead of quietly serving the wrong slice; the
-        // The CLI's own `--limit`/`--offset` flags are validated before they
-        // reach this descriptor, so this guards callers that build one
-        // directly — and it makes `limit: 0` mean "no rows" rather than being
-        // silently ignored, matching what `--limit 0` documents.
-        //
-        // NOTE this does NOT cover @ifc-lite/mcp. That package has its own
-        // backend (`packages/mcp/src/backend-query.ts`), a parallel
-        // implementation rather than a shared import, and its equivalent lines
-        // still read `descriptor.limit && descriptor.limit > 0` — so a NaN is
-        // silently ignored there and `limit: 0` is a no-op. Same defect,
-        // different package, its own tests and release cadence; tracked as a
-        // separate change rather than folded into this CLI-scoped PR.
+        // `!= null` alone lets a NaN offset/limit through (neither null nor
+        // undefined); a bare `> 0` then silently drops it (every NaN
+        // comparison is false) instead of rejecting it, and by the same
+        // reasoning silently ignored a deliberate `limit: 0`. Reject
+        // non-finite/negative values loudly instead of quietly serving the
+        // wrong slice. `@ifc-lite/mcp`'s parallel `backend-query.ts` carries
+        // the identical fix independently — same defect shape, own tests.
         if (descriptor.offset != null) {
           if (!Number.isFinite(descriptor.offset) || descriptor.offset < 0) {
             throw new TypeError(`Invalid offset: ${descriptor.offset} (must be a non-negative finite number)`);
@@ -419,11 +411,25 @@ export class HeadlessBackend implements BimBackend {
       relationships(ref: EntityRef): EntityRelationshipsData {
         return extractRelationshipsOnDemand(store, ref.expressId);
       },
+      // Folds queued `IfcRel…` creates in (query-overlay-relations.ts, mirrors #2014).
       related(ref: EntityRef, relType: string, direction: 'forward' | 'inverse'): EntityRef[] {
         const relEnum = QUERY_REL_TYPE_MAP[relType];
         if (relEnum === undefined) return [];
-        const targets = store.relationships.getRelated(ref.expressId, relEnum, direction);
-        return targets.map((expressId: number) => ({ modelId: ref.modelId, expressId }));
+        const view = getMutationView();
+        if (view?.isDeleted(ref.expressId)) return []; // deleted relates to nothing
+        const half = direction === 'forward' ? store.relationships.forward : store.relationships.inverse;
+        const out: number[] = [];
+        const seen = new Set<number>();
+        const take = (id: number): void => {
+          if (view?.isDeleted(id) || seen.has(id)) return;
+          seen.add(id);
+          out.push(id);
+        };
+        for (const edge of half.getEdges(ref.expressId, relEnum)) {
+          if (!view?.isDeleted(edge.relationshipId)) take(edge.target);
+        }
+        if (view) for (const t of foldQueuedRelated(view.getNewEntities(), (id) => view.isDeleted(id), relType, direction, ref.expressId)) take(t);
+        return out.map((expressId: number) => ({ modelId: ref.modelId, expressId }));
       },
     };
   }
@@ -463,30 +469,23 @@ export class HeadlessBackend implements BimBackend {
   }
 
   /**
-   * The overlay every write goes through, created on first use.
-   *
-   * Built by `getOrCreateStoreEditor` so the property and quantity extractors
-   * are wired exactly once, whichever adapter writes first.
+   * The overlay every write goes through, created on first use by
+   * `getOrCreateStoreEditor` so its extractors are wired exactly once.
    */
   private getOrCreateMutationView(): MutablePropertyView {
     this.getOrCreateStoreEditor();
-    // Non-null immediately after: getOrCreateStoreEditor assigns both fields
-    // together and never clears them.
+    // Non-null immediately after: both fields are assigned together and never cleared.
     return this.mutationView as MutablePropertyView;
   }
 
   private getOrCreateStoreEditor(): StoreEditor {
     if (this.storeEditor) return this.storeEditor;
     this.mutationView = new MutablePropertyView(this.dataStore.properties || null, MODEL_ID);
-    // Give the overlay a base to merge against. The columnar parser leaves
-    // `store.properties` empty and serves properties on demand, so without these
-    // the view's *only* source is the overlay itself and `getForEntity` answers
-    // with the one edited pset and nothing else. `StepExporter` re-emits
-    // `getForEntity(id)` for every entity with a property mutation and skips the
-    // original records, so editing one property would drop every sibling
-    // property in that pset on save. Same wiring, same reason, as
-    // `packages/mcp/src/headless-backend.ts` and
-    // `apps/viewer/src/utils/configureMutationView.ts` (#2000, #2004).
+    // Give the overlay a base to merge against — the columnar parser serves
+    // properties on demand, so without this `getForEntity` would answer with
+    // only the one edited pset and `StepExporter` would drop every sibling
+    // property on save. Same wiring as `packages/mcp/src/headless-backend.ts`
+    // and `apps/viewer/src/utils/configureMutationView.ts` (#2000, #2004).
     if (this.dataStore.source?.length > 0) {
       this.mutationView.setOnDemandExtractor((entityId) => extractPropertiesOnDemand(this.dataStore, entityId));
       this.mutationView.setQuantityExtractor((entityId) => extractQuantitiesOnDemand(this.dataStore, entityId));

--- a/packages/cli/src/query-overlay-relations.ts
+++ b/packages/cli/src/query-overlay-relations.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Overlay-visibility for `HeadlessBackend.query.related()` (headless-backend.ts).
+ *
+ * `bim.store.addEntity('default', { type: 'IfcRelContainedInSpatialStructure', ... })`
+ * is how a CLI script places something — the record lives only in the session's
+ * `MutablePropertyView` overlay until an export, exactly like `addEntity` for an
+ * ordinary element (see `query-overlay.ts`). `related()` read `store.relationships`
+ * alone, so a session that queued a containment relation and then asked
+ * `bim.related(wall, 'IfcRelContainedInSpatialStructure', 'inverse')` to confirm
+ * where its own wall landed got back nothing — the query answered about the file
+ * as parsed, not as the session had just changed it.
+ *
+ * `@ifc-lite/mcp`'s parallel `HeadlessLikeBackend` already folds queued
+ * relationships into `related()` for this exact reason (`packages/mcp/src/overlay.ts`,
+ * #2014). This ports that half — reading relations back out of newly-created
+ * `IfcRel…` entities — to the CLI, via `MutablePropertyView`'s own public
+ * `getNewEntities()`/`isDeleted()`.
+ */
+
+import type { NewEntity } from '@ifc-lite/mutations';
+import { getAttributeNamesAcrossSchemas } from '@ifc-lite/parser';
+
+interface QueuedRelation {
+  relationshipId: number;
+  relating: number;
+  related: readonly number[];
+}
+
+/** Express ids from an authored `'#42'` reference or a list of them. */
+function refIds(value: unknown): number[] {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    const id = Number.parseInt(trimmed.slice(1), 10);
+    return trimmed.startsWith('#') && Number.isFinite(id) ? [id] : [];
+  }
+  if (Array.isArray(value)) return value.flatMap((item) => refIds(item));
+  return [];
+}
+
+/**
+ * Group queued `IfcRel…` creates by class, resolved to their two ends.
+ *
+ * By attribute name, never by slot — `IfcRelAggregates` puts `RelatingObject`
+ * at slot 4, while `IfcRelContainedInSpatialStructure` puts `RelatedElements`
+ * there. `getAttributeNamesAcrossSchemas` is cross-schema, so a queued IFC2X3
+ * or IFC4X3 relationship resolves too, mirroring the MCP overlay this is
+ * ported from.
+ */
+function indexQueuedRelations(created: readonly NewEntity[]): Map<string, QueuedRelation[]> {
+  const byType = new Map<string, QueuedRelation[]>();
+  for (const entity of created) {
+    const upper = entity.type.toUpperCase();
+    if (!upper.startsWith('IFCREL')) continue;
+    const names = getAttributeNamesAcrossSchemas(entity.type);
+    if (names.length === 0) continue;
+    let relating: number | undefined;
+    let related: number[] | undefined;
+    for (let i = 0; i < names.length; i++) {
+      if (names[i].startsWith('Related')) related ??= refIds(entity.attributes[i]);
+      else if (names[i].startsWith('Relating')) relating ??= refIds(entity.attributes[i])[0];
+    }
+    if (relating === undefined || related === undefined || related.length === 0) continue;
+    const relation: QueuedRelation = { relationshipId: entity.expressId, relating, related };
+    const list = byType.get(upper);
+    if (list) list.push(relation);
+    else byType.set(upper, [relation]);
+  }
+  return byType;
+}
+
+/**
+ * This session's queued `relType` relationships touching `expressId`, in the
+ * given `direction` — the overlay half of `related()`. `newEntities` and
+ * `isDeleted` come straight from `MutablePropertyView`, so a relationship
+ * whose `IfcRel…` record was itself deleted this session (or whose far end
+ * was) answers nothing, same as `related()`'s parsed-store half already does
+ * for a queued edge that never got authored in the first place.
+ */
+export function foldQueuedRelated(
+  newEntities: readonly NewEntity[],
+  isDeleted: (expressId: number) => boolean,
+  relType: string,
+  direction: 'forward' | 'inverse',
+  expressId: number,
+): number[] {
+  const byType = indexQueuedRelations(newEntities);
+  const relations = byType.get(relType.toUpperCase()) ?? [];
+  const out: number[] = [];
+  for (const relation of relations) {
+    if (isDeleted(relation.relationshipId)) continue;
+    if (direction === 'forward') {
+      if (relation.relating !== expressId) continue;
+      for (const target of relation.related) {
+        if (!isDeleted(target)) out.push(target);
+      }
+    } else {
+      if (!relation.related.includes(expressId)) continue;
+      if (!isDeleted(relation.relating)) out.push(relation.relating);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- `HeadlessBackend.query.related()` (`packages/cli/src/headless-backend.ts`) read `store.relationships` alone, the parsed file's immutable graph. `StoreEditor.addEntity` deliberately never touches that graph for a queued `IfcRel…` record — the write lives only in the session's `MutablePropertyView` overlay. So `bim.store.addEntity('default', { type: 'IfcRelContainedInSpatialStructure', ... })` followed by `bim.related(...)` in the same session answered as if the write had not happened, from either end — and everything `related()` builds (`bim.storey`, `bim.path`, `bim.contains`, `bim.decomposes`) inherited the gap.
- `@ifc-lite/mcp`'s parallel `HeadlessLikeBackend` already folds queued relationships into `related()` for exactly this reason (`packages/mcp/src/overlay.ts`, #2014), so the identical operation sequence produced contradictory results depending on which package ran it: querying `IfcRelAggregates` right after queuing one went **0 → 0 under the CLI** and **0 → 1 under MCP**.
- Ports the relationship half of that fold to the CLI, in a new `packages/cli/src/query-overlay-relations.ts` (`headless-backend.ts` is at its pinned module-size budget, so the new logic — and a couple of comment trims to make room — live there instead).
- Out of scope, same as it was for #3498 (open): `entities()`/`entityData()` visibility for a newly-*created* entity, and property/quantity/attribute overlay folding — both are the larger `PendingOverlay`-shaped feature #3498 explicitly declined to port.

## Test plan

- [x] New test `packages/cli/src/headless-backend-related-overlay.test.ts` — RED before the fix (queued `IfcRelAggregates` invisible to `related()` from both directions), GREEN after. Exercises `HeadlessBackend.query` directly (not `BimContext`) and relates two entities the *file* already defines, so the assertion isolates this defect from the separate `entityData()`-for-new-entities gap (#3498).
- [x] Second case: a deleted entity relates to nothing, even via a queued relationship.
- [x] Manually reproduced the CLI/MCP divergence by running the same `addEntity`/`related()` sequence against both backends directly (`HeadlessBackend` vs `HeadlessLikeBackend`) — CLI went 0 → 0 pre-fix, MCP was already 0 → 1.
- [x] `pnpm exec tsc --noEmit` clean in `packages/cli` and `packages/mcp`.
- [x] `node scripts/check-module-size.mjs` — OK, `headless-backend.ts` at 751/752 lines (net growth moved into the new file).
- [x] Full `packages/cli` test suite: 540 passed, 8 skipped.
- [x] Changeset added (`@ifc-lite/cli`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relationship queries now reflect relationships added during the current session.
  * Forward and inverse relationship lookups, including derived queries, return newly added connections.
  * Deleted entities and relationships are excluded from relationship results.
  * Duplicate related results are removed for more consistent query output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->