### PR TITLE
fix(viewer): resolve context-menu Select-similar/Select-storey through the model offset

### DIFF
--- a/apps/viewer/src/components/viewer/EntityContextMenu.federation.test.tsx
+++ b/apps/viewer/src/components/viewer/EntityContextMenu.federation.test.tsx
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `EntityContextMenu`'s "Select all <Type>" and "Select same storey" items
+ * read `activeDataStore.entities` / `spatialHierarchy`, both model-space
+ * (the right-clicked entity's OWN store), but must write their result into
+ * `selectedEntityIds` — the renderer-space, offset-per-model channel every
+ * other consumer (picking, `resolveEntityRef`, the renderer) treats as a
+ * `globalId`. With a non-zero federation offset, writing the raw model-space
+ * ids selects the WRONG entities (or none) once a second model is loaded.
+ *
+ * Uses the same federated single-model-with-offset fixture as
+ * `EntityContextMenu.anonymized-export.test.tsx`.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store/index.js';
+import type { FederatedModel } from '@/store/types.js';
+import { EntityContextMenu } from './EntityContextMenu.js';
+import {
+  parseFixtureModel,
+  FIXTURE_WALL_A,
+  FIXTURE_WALL_B,
+  FIXTURE_WALL_C,
+} from './anonymized-export/anonymized-export-fixture.test-support.js';
+
+const ID_OFFSET = 1_000_000;
+const globalId = (localId: number): number => localId + ID_OFFSET;
+
+function federatedModel(id: string, ifcDataStore: FederatedModel['ifcDataStore']): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 1,
+    fileSize: 0,
+    idOffset: ID_OFFSET,
+    maxExpressId: 100_000,
+  } as FederatedModel;
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+function render(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => { root.render(<EntityContextMenu />); });
+  mounted.push({ root, container });
+  return container;
+}
+function unmountAll(): void {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+}
+after(unmountAll);
+
+function menuItem(container: HTMLElement, label: string): HTMLButtonElement {
+  const btn = [...container.querySelectorAll('button')].find((b) => b.textContent?.trim() === label);
+  assert.ok(btn, `no menu item labelled "${label}"`);
+  return btn as HTMLButtonElement;
+}
+
+beforeEach(async () => {
+  unmountAll();
+  const store = await parseFixtureModel();
+  useViewerStore.setState({
+    models: new Map([['m1', federatedModel('m1', store)]]),
+    selectedEntityIds: new Set<number>(),
+    anonymizedExportRequested: false,
+  });
+});
+
+describe('EntityContextMenu — federation-space selection', () => {
+  it('"Select all IfcWall" resolves through the model offset', () => {
+    act(() => { useViewerStore.getState().openContextMenu(globalId(FIXTURE_WALL_A), 10, 10); });
+    const container = render();
+
+    act(() => { menuItem(container, 'Select all IfcWall').click(); });
+
+    const state = useViewerStore.getState();
+    assert.deepEqual(
+      state.selectedEntityIds,
+      new Set([globalId(FIXTURE_WALL_A), globalId(FIXTURE_WALL_B), globalId(FIXTURE_WALL_C)]),
+      'selectedEntityIds must carry renderer-space (offset) ids, not raw model-space expressIds',
+    );
+  });
+
+  it('"Select same storey" resolves through the model offset', () => {
+    act(() => { useViewerStore.getState().openContextMenu(globalId(FIXTURE_WALL_B), 10, 10); });
+    const container = render();
+
+    act(() => { menuItem(container, 'Select same storey').click(); });
+
+    const state = useViewerStore.getState();
+    assert.deepEqual(
+      state.selectedEntityIds,
+      new Set([globalId(FIXTURE_WALL_B), globalId(FIXTURE_WALL_C)]),
+      'selectedEntityIds must carry renderer-space (offset) ids, not raw model-space expressIds',
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/EntityContextMenu.tsx
+++ b/apps/viewer/src/components/viewer/EntityContextMenu.tsx
@@ -22,7 +22,7 @@ import {
   CopyPlus,
   ShieldQuestion,
 } from 'lucide-react';
-import { useViewerStore, resolveEntityRef, resolveGlobalId } from '@/store';
+import { useViewerStore, resolveEntityRef, resolveGlobalId, toGlobalIdFromModels } from '@/store';
 import type { DuplicateDirection } from '@/store/slices/mutationSlice';
 import { resetVisibilityForHomeFromStore } from '@/store/homeView';
 import {
@@ -185,19 +185,20 @@ export function EntityContextMenu() {
       }
     }
 
-    if (entityType) {
-      // Select all entities of the same type (original expressIds — for multi-model, should transform to globalIds).
+    if (entityType && contextEntityRef) {
+      // `entity.expressId` is model-space — resolve through the model
+      // offset before it reaches `selectedEntityIds` (renderer-space).
       const sameTypeIds: number[] = [];
       for (let i = 0; i < entity.count; i++) {
         if (entity.getTypeName(entity.expressId[i]) === entityType) {
-          sameTypeIds.push(entity.expressId[i]);
+          sameTypeIds.push(toGlobalIdFromModels(models, contextEntityRef.modelId, entity.expressId[i]));
         }
       }
       setSelectedEntityIds(sameTypeIds);
     }
 
     closeContextMenu();
-  }, [resolvedExpressId, activeDataStore, setSelectedEntityIds, closeContextMenu]);
+  }, [resolvedExpressId, activeDataStore, contextEntityRef, models, setSelectedEntityIds, closeContextMenu]);
 
   const handleSelectSameStorey = useCallback(() => {
     // Use resolvedExpressId (original ID) for IfcDataStore lookups
@@ -207,16 +208,18 @@ export function EntityContextMenu() {
     }
 
     const storeyId = activeDataStore.spatialHierarchy.elementToStorey.get(resolvedExpressId);
-    if (storeyId) {
+    if (storeyId && contextEntityRef) {
       const storeyElements = activeDataStore.spatialHierarchy.byStorey.get(storeyId);
       if (storeyElements) {
-        // NOTE: These are original expressIds - for multi-model, should transform to globalIds
-        setSelectedEntityIds(Array.from(storeyElements));
+        // Same model-space -> renderer-space resolution as above.
+        setSelectedEntityIds(
+          Array.from(storeyElements, (id) => toGlobalIdFromModels(models, contextEntityRef.modelId, id)),
+        );
       }
     }
 
     closeContextMenu();
-  }, [resolvedExpressId, activeDataStore, setSelectedEntityIds, closeContextMenu]);
+  }, [resolvedExpressId, activeDataStore, contextEntityRef, models, setSelectedEntityIds, closeContextMenu]);
 
   // "Export anonymized…" (#2934): seed `AnonymizedExportDialog` — whose
   // `useAnonymizedExportSet` reads `selectedEntityIds`, the multi-select


### PR DESCRIPTION
## Summary

`EntityContextMenu`'s "Select all `<Type>`" and "Select same storey" items read model-space `expressId`s off the right-clicked entity's own `IfcDataStore` (`activeDataStore.entities.expressId[i]`, `spatialHierarchy.byStorey`), then wrote them directly into `selectedEntityIds` — the renderer-space, offset-per-model channel every other consumer (`resolveEntityRef`, picking, the renderer) treats as a `globalId`.

In single-model mode the federation offset is 0, so `expressId === globalId` and both menu items happened to work. With a second federated model loaded (non-zero `idOffset`), they select the wrong entities in a second/later model, or nothing at all, instead of the intended type/storey group — a silent selection bug in a federated scene.

Both call sites already had an explicit TODO comment acknowledging the gap ("original expressIds — for multi-model, should transform to globalIds" / "NOTE: … for multi-model, should transform to globalIds").

## Fix

Resolve each id through `toGlobalIdFromModels(models, contextEntityRef.modelId, id)` before writing `selectedEntityIds` — the same bridge `HierarchyPanel` and `useGanttSelection3DHighlight` already use for this exact conversion.

## Test plan

- [x] Added `EntityContextMenu.federation.test.tsx`, reusing the federated single-model-with-`idOffset` fixture from `EntityContextMenu.anonymized-export.test.tsx` (offset `1_000_000`, three walls across two storeys).
- [x] RED: confirmed the test fails against the pre-fix code (selection came back as raw local ids `6/7/17` instead of `1000006/1000007/1000017`).
- [x] GREEN: passes after the fix.
- [x] Existing `EntityContextMenu.anonymized-export.test.tsx` still passes (no regression).
- [x] `node scripts/check-module-size.mjs` — `EntityContextMenu.tsx` is exactly at its pinned budget (583/583).
- [x] `pnpm exec tsc --noEmit` (apps/viewer) — clean.
- [x] `apps/viewer` is `private: true` — no changeset needed.

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed “Select all IfcWall” and “Select same storey” so selections work correctly in federated models with ID offsets.
  - Ensured selected elements are tracked using the correct renderer IDs, preventing incorrect or missing selections.

- **Tests**
  - Added coverage for context-menu selections in federated models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->