### PR TITLE
fix(viewer): HoverTooltip mis-reads a federated entity's name/type through the wrong model

### DIFF
--- a/apps/viewer/src/components/viewer/HoverTooltip.federation.test.tsx
+++ b/apps/viewer/src/components/viewer/HoverTooltip.federation.test.tsx
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `HoverTooltip` reads `hoverState.entityId` — renderer-space (global,
+ * offset-per-model — set from `pickResult.expressId` in
+ * `useMouseControls.ts`) — but looks the name/type up directly in the
+ * legacy `ifcDataStore` (`useIfc().ifcDataStore`, which tracks the ACTIVE
+ * model's store, `modelSlice.ts:202`) using that global id AS IF it were a
+ * model-space `expressId`. With a second, non-zero-offset model federated
+ * in, hovering an entity that belongs to that second model reads through
+ * the WRONG store at the WRONG id: the active model's store has no entity
+ * at that (huge, offset-shifted) id, so the lookup misses and the tooltip
+ * renders "Unknown" / blank instead of the hovered entity's real name.
+ *
+ * Uses the same federated single-model-with-offset fixture as
+ * `EntityContextMenu.federation.test.tsx`.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore } from '@/store/index.js';
+import type { FederatedModel } from '@/store/types.js';
+import { HoverTooltip } from './HoverTooltip.js';
+import { parseFixtureModel, FIXTURE_WALL_A } from './anonymized-export/anonymized-export-fixture.test-support.js';
+
+const ID_OFFSET = 1_000_000;
+const globalId = (localId: number): number => localId + ID_OFFSET;
+
+function federatedModel(id: string, ifcDataStore: FederatedModel['ifcDataStore']): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 1,
+    fileSize: 0,
+    idOffset: id === 'm2' ? ID_OFFSET : 0,
+    maxExpressId: id === 'm2' ? 100_000 + ID_OFFSET : 100_000,
+  } as FederatedModel;
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+function render(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => { root.render(<HoverTooltip />); });
+  mounted.push({ root, container });
+  return container;
+}
+function unmountAll(): void {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+}
+after(unmountAll);
+
+beforeEach(async () => {
+  unmountAll();
+  const store = await parseFixtureModel();
+  // Two models federated: m1 is the ACTIVE model (offset 0, so
+  // `state.ifcDataStore` == m1's store per `modelSlice.ts:202`); m2 carries
+  // a non-zero offset. Both are parsed from the same fixture, so m2 also has
+  // an "IfcWall" named "Wall A" at model-space expressId `FIXTURE_WALL_A`.
+  useViewerStore.setState({
+    ifcDataStore: store,
+    activeModelId: 'm1',
+    models: new Map([
+      ['m1', federatedModel('m1', store)],
+      ['m2', federatedModel('m2', store)],
+    ]),
+    hoverTooltipsEnabled: true,
+    hoverState: { entityId: globalId(FIXTURE_WALL_A), screenX: 10, screenY: 10 },
+  });
+});
+
+describe('HoverTooltip — federation-space entity lookup', () => {
+  it('resolves the hovered global id through its OWN model, not the active model store', () => {
+    const container = render();
+
+    assert.ok(
+      container.textContent?.includes('Wall A'),
+      `tooltip must show the hovered entity's real name ("Wall A") resolved via its ` +
+        `own model, not "Unknown"/blank from mis-reading the active model's store ` +
+        `with a raw (offset) global id. Got: ${JSON.stringify(container.textContent)}`,
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/HoverTooltip.tsx
+++ b/apps/viewer/src/components/viewer/HoverTooltip.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useMemo } from 'react';
-import { useViewerStore } from '@/store';
+import { useViewerStore, resolveEntityRef } from '@/store';
 import { useIfc } from '@/hooks/useIfc';
 
 // Type icons mapping
@@ -36,18 +36,30 @@ const TYPE_ICONS: Record<string, string> = {
 export function HoverTooltip() {
   const hoverState = useViewerStore((s) => s.hoverState);
   const hoverTooltipsEnabled = useViewerStore((s) => s.hoverTooltipsEnabled);
-  const { ifcDataStore } = useIfc();
+  const { ifcDataStore, models } = useIfc();
 
+  // `hoverState.entityId` is renderer-space (global, offset-per-model — set
+  // from `pickResult.expressId` in `useMouseControls.ts`). It must be
+  // resolved through `resolveEntityRef` to the entity's OWN model before
+  // looking it up — the legacy `ifcDataStore` only tracks the ACTIVE model
+  // (`modelSlice.ts`), which is the wrong store once a second, non-zero-
+  // offset model is federated in.
   const entityInfo = useMemo(() => {
-    if (!hoverState.entityId || !ifcDataStore) {
+    if (!hoverState.entityId) {
       return null;
     }
 
-    const name = ifcDataStore.entities.getName(hoverState.entityId);
-    const type = ifcDataStore.entities.getTypeName(hoverState.entityId);
+    const ref = resolveEntityRef(hoverState.entityId);
+    const dataStore = models.get(ref.modelId)?.ifcDataStore ?? ifcDataStore;
+    if (!dataStore) {
+      return null;
+    }
+
+    const name = dataStore.entities.getName(ref.expressId);
+    const type = dataStore.entities.getTypeName(ref.expressId);
 
     return { name, type };
-  }, [hoverState.entityId, ifcDataStore]);
+  }, [hoverState.entityId, ifcDataStore, models]);
 
   if (!hoverTooltipsEnabled || !hoverState.entityId || !entityInfo) {
     return null;


### PR DESCRIPTION
## Summary
- `hoverState.entityId` is renderer-space (global, offset-per-model — set from the GPU pick result in `useMouseControls.ts`). `HoverTooltip.tsx` looked it up directly in the legacy `ifcDataStore`, which only tracks the ACTIVE model (`modelSlice.ts`), passing the global id straight to `entities.getName`/`getTypeName` as if it were that model's own `expressId`.
- With a second, non-zero-offset model federated in, hovering an entity belonging to that other model missed the active model's store entirely (no entity at that huge, offset-shifted id) and rendered `Unknown`/blank instead of the entity's real name and type — same id-space-crossing bug family as #3499 and #3501.
- Fixed by resolving through `resolveEntityRef` (the canonical globalId → EntityRef bridge `EntityContextMenu` already uses) and reading the entity from its OWN model's store.

## Test plan
- [x] New federated two-model fixture test `apps/viewer/src/components/viewer/HoverTooltip.federation.test.tsx`: RED before the fix (tooltip showed `Unknown`/`#1000006`), GREEN after (shows `Wall A`).
- [x] `node scripts/check-module-size.mjs` — OK, no budgets touched.
- [x] `pnpm exec tsc --noEmit` (apps/viewer, including test files) — clean.
- [x] `apps/viewer` is `private: true` — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hover tooltips for federated models.
  - Entity names now display correctly when objects belong to models with offset IDs.
  - Added a fallback to maintain tooltip behavior for the active model.

- **Tests**
  - Added coverage verifying that federated entities display their actual names instead of “Unknown” or blank tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->