### PR TITLE
fix(cache): reject a corrupt RelationshipGraph edge range instead of returning undefined fields

### DIFF
--- a/.changeset/cache-relationship-edge-range-guard.md
+++ b/.changeset/cache-relationship-edge-range-guard.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/cache': patch
+---
+
+Fail loudly when a cached RelationshipGraph's per-entity edge range is corrupted, instead of silently returning edges with `undefined` fields.
+
+The relationships section stores each entity's edges as an `(offset, count)` pair into a shared edge-target/type/relationshipId array. Nothing validated that pair against the array's actual length: a cache file corrupted between write and read (disk bitrot, a truncated write, a hand-edited file) could carry an `offset + count` that overruns the edge arrays. `getEdges()` would then read past the end of a `Uint32Array`/`Uint16Array`, which JavaScript resolves to `undefined` rather than throwing, and return relationship edges with `undefined` target/type/relationshipId mixed in with the real ones — silent corruption reaching callers with no signal anything went wrong.
+
+`readRelationships`/`readEdges` now validate every entity's `(offset, count)` range against the edge array length right after parsing, and throw a descriptive "Corrupt cache RelationshipGraph" error if it doesn't fit — the same fail-fast contract already applied to this cache format's other sections (StringTable offsets, entity-index typeIndex, InstancedShards lengths).

--- a/packages/cache/src/sections/relationships.test.ts
+++ b/packages/cache/src/sections/relationships.test.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `readEdges`'s per-node (offset, count) pair is a field independent of
+ * `edgeCount` (see the doc comment in relationships.ts). Nothing validated it
+ * against the actual edge-array length, so a cache file whose directory got
+ * corrupted between write and read (disk bitrot, a truncated/partial write, a
+ * hand-edited or malicious file) silently returned edges with `undefined`
+ * target/type/relationshipId mixed in with the real ones, instead of failing
+ * loudly the way every sibling section (StringTable offsets, entity-index
+ * typeIndex, InstancedShards) already does on the equivalent corruption.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RelationshipType } from '@ifc-lite/data';
+import { BufferWriter, BufferReader } from '../utils/buffer-utils.js';
+import { readRelationships } from './relationships.js';
+
+/**
+ * Hand-builds a relationships-section buffer with one forward node whose
+ * `count` overruns the edge arrays, and an empty (but well-formed) inverse
+ * half. Bypasses `writeRelationships`/`RelationshipGraphBuilder` so the
+ * corruption is explicit and doesn't depend on the writer ever producing it.
+ */
+function buildCorruptBuffer(): ArrayBuffer {
+  const w = new BufferWriter();
+
+  // --- forward: 1 node, entityId=1, offset=0, count=5, but only 1 real edge.
+  w.writeUint32(1); // nodeCount
+  w.writeUint32(1); // entityId
+  w.writeUint32(0); // offset
+  w.writeUint32(5); // count -- overruns edgeCount below
+  w.writeUint32(1); // edgeCount
+  w.writeTypedArray(new Uint32Array([42])); // edgeTargets
+  w.writeTypedArray(new Uint16Array([RelationshipType.ContainsElements])); // edgeTypes
+  w.writeTypedArray(new Uint32Array([100])); // edgeRelIds
+
+  // --- inverse: empty, well-formed.
+  w.writeUint32(0); // nodeCount
+  w.writeUint32(0); // edgeCount
+
+  return w.build();
+}
+
+describe('RelationshipGraph corrupt-cache guard', () => {
+  it('rejects a node whose (offset, count) range exceeds the edge array length', () => {
+    const reader = new BufferReader(buildCorruptBuffer());
+    expect(() => readRelationships(reader)).toThrow(/Corrupt cache RelationshipGraph/);
+  });
+
+  it('still accepts a well-formed graph whose ranges fit', () => {
+    const w = new BufferWriter();
+    // forward: 1 node, entityId=1, offset=0, count=1 -- exactly fits.
+    w.writeUint32(1);
+    w.writeUint32(1);
+    w.writeUint32(0);
+    w.writeUint32(1);
+    w.writeUint32(1);
+    w.writeTypedArray(new Uint32Array([42]));
+    w.writeTypedArray(new Uint16Array([RelationshipType.ContainsElements]));
+    w.writeTypedArray(new Uint32Array([100]));
+    // inverse: empty.
+    w.writeUint32(0);
+    w.writeUint32(0);
+
+    const reader = new BufferReader(w.build());
+    const graph = readRelationships(reader);
+    const related = graph.getRelated(1, RelationshipType.ContainsElements, 'forward');
+    expect(related).toEqual([42]);
+  });
+});

--- a/packages/cache/src/sections/relationships.ts
+++ b/packages/cache/src/sections/relationships.ts
@@ -121,6 +121,27 @@ function readEdges(reader: BufferReader): {
   const edgeTypes = reader.readUint16Array(edgeCount);
   const edgeRelIds = reader.readUint32Array(edgeCount);
 
+  // Fail fast on a corrupt cache: each node's (offset, count) pair is an
+  // independent field from `edgeCount` — `BufferReader`'s own bounds checks
+  // (see its `ensureAvailable` doc comment) only guarantee the edge arrays
+  // themselves are `edgeCount` long, they say nothing about whether a given
+  // node's range stays inside that. Without this check, `getEdges` below
+  // reads `edgeTargets[i]` for `i` past the array's end — a plain JS typed-
+  // array index-out-of-bounds, which silently yields `undefined` rather than
+  // throwing — and returns edges with an `undefined` target/type/
+  // relationshipId mixed in with the real ones instead of failing loudly.
+  // Mirrors the same-shaped guards already in `strings.ts` (offset
+  // monotonicity) and `entity-index.ts` (typeIndex range).
+  for (const [entityId, offset] of offsets) {
+    const count = counts.get(entityId) ?? 0;
+    if (offset + count > edgeCount) {
+      throw new Error(
+        `Corrupt cache RelationshipGraph: entity ${entityId}'s edge range ` +
+          `[${offset}, ${offset + count}) exceeds edge array length ${edgeCount}`,
+      );
+    }
+  }
+
   return {
     offsets,
     counts,


### PR DESCRIPTION
## Summary
- `readEdges()` (in `packages/cache/src/sections/relationships.ts`) stores each entity's edges as an `(offset, count)` pair into a shared edge-target/type/relationshipId array, but never validated that pair against the array's actual length.
- A cache file corrupted between write and read (disk bitrot, a truncated write, a hand-edited/malicious file) could carry an `offset + count` that overruns the edge arrays. `getEdges()` then reads past the end of a `Uint32Array`/`Uint16Array`, which JS resolves to `undefined` rather than throwing — silently returning relationship edges with `undefined` target/type/relationshipId mixed in with the real ones.
- `readRelationships`/`readEdges` now validate every entity's range right after parsing and throw a descriptive `Corrupt cache RelationshipGraph` error if it overruns the edge arrays — matching the fail-fast discipline this cache format already applies elsewhere (StringTable offset monotonicity, entity-index `typeIndex` bounds, InstancedShards lengths).

## Why existing tests missed it
`packages/cache/src/cache.test.ts` only round-trips a well-formed `RelationshipGraph`; there was no dedicated `relationships.test.ts` and no test exercising a corrupted edge range at all.

## RED/GREEN
`packages/cache/src/sections/relationships.test.ts` hand-builds a corrupt buffer (a node's `count` overruns `edgeCount`) and asserts `readRelationships` throws. Reverting the guard reproduces the silent-`undefined` failure (verified locally: `expect(...).toThrow()` fails with `Received: undefined` instead of an error). With the guard, `packages/cache`: 110 passed.

## Consequence class
Silent corruption — reachable via a genuinely corrupted/malformed cache file (not via the normal parser/writer round trip), where `getEdges` would previously return bad data with no signal instead of throwing.

## Test plan
- [x] `pnpm exec turbo run build --filter=@ifc-lite/cache^...` (builds `@ifc-lite/data`, `@ifc-lite/geometry`, deps)
- [x] `cd packages/cache && npx tsc --noEmit` — clean
- [x] `cd packages/cache && npx vitest run` — 110/110 passed
- [x] `node scripts/check-module-size.mjs` — OK, no new budget violations
- [x] Changeset added (`@ifc-lite/cache`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for relationship graph edge ranges when reading cached data.
  - Corrupted caches now fail fast with a descriptive error instead of returning incomplete or undefined relationship details.
  - Valid relationship ranges continue to load and return related entities correctly.

- **Tests**
  - Added coverage for detecting oversized edge ranges.
  - Added verification for valid relationship graph ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->