### PR TITLE
fix(viewer): ViewportOverlays storey-name pill mis-reads a federated storey through the active model

### DIFF
--- a/apps/viewer/src/components/viewer/ViewportOverlays.federation.test.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.federation.test.tsx
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `ViewportOverlays` reads `selectedStoreys` — a `Set<number>` of
+ * model-space `expressId`s written by `HierarchyPanel` from `node.expressIds`
+ * / `unified.storeys[].storeyId` (both raw, per-model local ids — see
+ * `treeDataBuilder.ts:411` and `:232`, which pair each id with its OWN
+ * `modelId`. `selectedStoreys` drops that pairing) — but looks each id up
+ * directly in the legacy `ifcDataStore` (`useIfc().ifcDataStore`, which
+ * tracks only the ACTIVE model's store, `modelSlice.ts:202`). With a second,
+ * federated model whose storey happens to reuse the SAME local expressId as
+ * something in the active model (routine for IFC files, which both start
+ * numbering at #1), the storey pill reads the ACTIVE model's entity at that
+ * id instead of the selected storey's own name.
+ *
+ * The active model's own entity table has NO entity at expressId 5 at all
+ * (a smaller, unrelated fixture) — proving a genuine cross-model lookup,
+ * not a same-id coincidence: the non-active model's storey #5 ("Storey
+ * Two") must resolve through its OWN store, since the active store can't
+ * possibly answer for that id.
+ */
+
+import '@/test/setup-dom.js';
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser } from '@ifc-lite/parser';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { useViewerStore } from '@/store/index.js';
+import type { FederatedModel } from '@/store/types.js';
+import { TooltipProvider } from '@/components/ui/tooltip.js';
+import { ViewportOverlays } from './ViewportOverlays.js';
+import { FIXTURE_MODEL, FIXTURE_STOREY_2, guid } from './anonymized-export/anonymized-export-fixture.test-support.js';
+
+const ID_OFFSET = 1_000_000;
+
+// A minimal, self-contained model with only 4 entities (ids 1-4) — no
+// entity at expressId 5, unlike `FIXTURE_MODEL` (whose id 5 is "Storey Two").
+const MINIMAL_ACTIVE_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('minimal-active-fixture.ifc','2020-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('${guid(1)}',$,'Active Project',$,$,$,$,$,$);
+#2=IFCSITE('${guid(2)}',$,'Active Site',$,$,$,$,$,.ELEMENT.,$,$,$,$,$);
+#3=IFCBUILDING('${guid(3)}',$,'Active Building',$,$,$,$,$,.ELEMENT.,$,$,$);
+#4=IFCBUILDINGSTOREY('${guid(4)}',$,'Storey One',$,$,$,$,$,$,0.);
+#10=IFCRELAGGREGATES('${guid(10)}',$,$,$,#1,(#2));
+#11=IFCRELAGGREGATES('${guid(11)}',$,$,$,#2,(#3));
+#12=IFCRELAGGREGATES('${guid(12)}',$,$,$,#3,(#4));
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function parseModel(stepText: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(stepText);
+  return new IfcParser().parseColumnar(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  );
+}
+
+function federatedModel(id: string, ifcDataStore: FederatedModel['ifcDataStore'], idOffset: number): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 1,
+    fileSize: 0,
+    idOffset,
+    maxExpressId: 100_000 + idOffset,
+  } as FederatedModel;
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+function render(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <ViewportOverlays hideViewCube hideAxis hideScale />
+      </TooltipProvider>,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+function unmountAll(): void {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+}
+after(unmountAll);
+
+beforeEach(async () => {
+  unmountAll();
+  // Active model (m1, offset 0): no entity at expressId 5 whatsoever.
+  const activeStore = await parseModel(MINIMAL_ACTIVE_MODEL);
+  // Non-active model (m2, offset 1,000,000): the REAL selected storey lives
+  // here, at local expressId 5 ("Storey Two").
+  const otherStore = await parseModel(FIXTURE_MODEL);
+
+  useViewerStore.setState({
+    ifcDataStore: activeStore,
+    activeModelId: 'm1',
+    models: new Map([
+      ['m1', federatedModel('m1', activeStore, 0)],
+      ['m2', federatedModel('m2', otherStore, ID_OFFSET)],
+    ]),
+    selectedStoreys: new Set<number>([FIXTURE_STOREY_2]),
+  });
+});
+
+describe('ViewportOverlays — federation-space storey name lookup', () => {
+  it('resolves a non-active model\'s selected storey through its OWN store', () => {
+    const container = render();
+
+    assert.ok(
+      container.textContent?.includes('Storey Two'),
+      `storey pill must show the selected storey's real name ("Storey Two"), resolved via its ` +
+        `own (non-active) model's store — not a "Storey #${FIXTURE_STOREY_2}" fallback from a ` +
+        `failed lookup against the active model's store, which has no entity at that id. ` +
+        `Got: ${JSON.stringify(container.textContent)}`,
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/ViewportOverlays.tsx
+++ b/apps/viewer/src/components/viewer/ViewportOverlays.tsx
@@ -46,7 +46,7 @@ export function ViewportOverlays({
   const isMobile = useViewerStore((s) => s.isMobile);
   const setOnCameraRotationChange = useViewerStore((s) => s.setOnCameraRotationChange);
   const setOnScaleChange = useViewerStore((s) => s.setOnScaleChange);
-  const { ifcDataStore } = useIfc();
+  const { ifcDataStore, models } = useIfc();
 
   // Cesium state
   const cesiumEnabled = useViewerStore((s) => s.cesiumEnabled);
@@ -90,11 +90,21 @@ export function ViewportOverlays({
     return () => setOnScaleChange(null);
   }, [setOnScaleChange]);
 
-  // Get names of selected storeys
-  const storeyNames = selectedStoreys.size > 0 && ifcDataStore
-    ? Array.from(selectedStoreys).map(id => 
-        ifcDataStore.entities.getName(id) || `Storey #${id}`
-      )
+  // Get names of selected storeys. `selectedStoreys` holds raw model-space
+  // expressIds (see HierarchyPanel's `setStoreysSelection`), which may belong
+  // to ANY federated model, not just the active one — `ifcDataStore` only
+  // tracks the active model (`modelSlice.ts`). Resolve each id through the
+  // model whose own spatial hierarchy actually contains it as a storey,
+  // falling back to the active store for legacy single-model mode.
+  const storeyNames = selectedStoreys.size > 0 && (ifcDataStore || models.size > 0)
+    ? Array.from(selectedStoreys).map((id) => {
+        const ownStore = models.size > 0
+          ? Array.from(models.values()).find(
+              (m) => m.ifcDataStore?.spatialHierarchy?.byStorey.has(id),
+            )?.ifcDataStore
+          : ifcDataStore;
+        return ownStore?.entities.getName(id) || `Storey #${id}`;
+      })
     : null;
 
   // Physical objects in the loaded model — the denominator. Derived from the


### PR DESCRIPTION
## Summary

Continuing the audit from #3499/#3501/#3504 (renderer-space vs model-space id crossings under federation), this PR closes the gap #3504 flagged but did not verify: `ViewportOverlays.tsx`'s storey-name pill.

`selectedStoreys` is a `Set<number>` of raw model-space `expressId`s — `HierarchyPanel` writes it from `node.expressIds` / `unified.storeys[].storeyId` (see `treeDataBuilder.ts:411` and `:232`), both per-model local ids paired with their own `modelId` at the tree-node level, but that pairing is dropped once the ids land in `selectedStoreys`.

`ViewportOverlays.tsx`'s storey-name pill looked each id up directly in the legacy `ifcDataStore` (`useIfc().ifcDataStore`, which tracks only the ACTIVE model per `modelSlice.ts:202`). With a second federated model, selecting one of ITS storeys reads the active model's (wrong) entity at that id — or, if the active model has no entity at that id at all, falls back to a bare `Storey #<id>` placeholder instead of the real name.

Fix: resolve each id through whichever federated model's own spatial hierarchy (`spatialHierarchy.byStorey`) actually contains it as a storey, falling back to the active store only in legacy single-model mode.

### Other files checked in the same pass
- `SpaceSketchOverlay.tsx` — does not read `selectedStoreys` at all; its storey list and lookups are keyed off `activeStorey` (which carries its own `modelId`) and `ifcDataStore` scoped per model. Safe.
- `useFloorplanView.ts` — already iterates `models` and reads each model's `ifcDataStore.spatialHierarchy` directly (never crosses into another model's id space). Safe.

### Same-family candidates NOT fixed here (flagged for a future pass)
`StatusBar.tsx`, `basketVisibleSet.ts`, `ViewportContainer.tsx`, and `ListResultsTable.tsx` also read `selectedStoreys` against a single/active `ifcDataStore` or iterate models with an id that may collide across models. Left out of this PR to keep it scoped and reviewable; `basketVisibleSet.ts` already has a partial (iterate-all-models) mitigation.

## Test plan
- [x] New federated-fixture test (`ViewportOverlays.federation.test.tsx`): active model has NO entity at the selected storey's expressId; RED before the fix (`"Storey #5"` fallback), GREEN after (resolves `"Storey Two"` through the non-active model's own store).
- [x] `node scripts/check-module-size.mjs` — OK, no budget change needed.
- [x] `pnpm exec tsc --noEmit` (apps/viewer, including test files) — clean.
- [x] `apps/viewer` is `private: true` — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436