### PR TITLE
fix(viewer): StatusBar element count mis-counts a federated storey through the active model

### DIFF
--- a/apps/viewer/src/components/viewer/StatusBar.federation.test.tsx
+++ b/apps/viewer/src/components/viewer/StatusBar.federation.test.tsx
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `StatusBar` reads `selectedStoreys` — a `Set<number>` of model-space
+ * `expressId`s (see `treeDataBuilder.ts:411` and `:232`, which pair each id
+ * with its OWN `modelId`; `selectedStoreys` drops that pairing) — but counted
+ * elements by looking each id up directly in the legacy `ifcDataStore`
+ * (`useIfc().ifcDataStore`, which tracks only the ACTIVE model's store,
+ * `modelSlice.ts:202`). With a second, federated model, selecting one of
+ * ITS storeys found nothing in the active model's hierarchy and silently
+ * fell back to the raw (here: zero) mesh-derived total instead of the
+ * selected storey's own element count.
+ *
+ * The active model's own spatial hierarchy has NO storey at expressId 5 at
+ * all (a smaller, unrelated fixture) — proving a genuine cross-model
+ * lookup, not a same-id coincidence: the non-active model's storey #5
+ * ("Storey Two", 2 elements) must resolve through its OWN store, since the
+ * active store can't possibly answer for that id. Same fixture construction
+ * as `ViewportOverlays.federation.test.tsx` (#3506).
+ */
+
+import '@/test/setup-dom.js';
+// `__APP_VERSION__` is a vite `define` (see vite.config.ts) baked in at
+// build time; under plain Node it doesn't exist, so StatusBar's footer
+// version string needs a stand-in before it renders.
+(globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = '0.0.0-test';
+import { describe, it, beforeEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { IfcParser } from '@ifc-lite/parser';
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { createBimContext } from '@ifc-lite/sdk';
+import { useViewerStore } from '@/store/index.js';
+import type { FederatedModel } from '@/store/types.js';
+import { ExtensionHostService } from '@/services/extensions/host.js';
+import { ExtensionHostContext } from '@/sdk/ExtensionHostProvider.js';
+import { StatusBar } from './StatusBar.js';
+import { FIXTURE_MODEL, FIXTURE_STOREY_2, guid } from './anonymized-export/anonymized-export-fixture.test-support.js';
+
+// StatusBar unconditionally mounts `<FlavorDialog>` / `<FlavorIndicator>`,
+// both of which call `useExtensionHost()` — stub the host rather than pull
+// in the full `<ExtensionHostProvider>` (which needs a live `<BimProvider>`).
+// Not under test here; see `FlavorDialog.unapplied-toast.test.tsx` for the
+// same stub shape.
+const stubHost = new ExtensionHostService({
+  sdk: createBimContext({
+    transport: {
+      send: () => Promise.reject(new Error('SDK transport is not exercised by this test')),
+      subscribe: () => () => {},
+      close: () => {},
+    },
+  }),
+});
+
+const ID_OFFSET = 1_000_000;
+
+// A minimal, self-contained model with only 4 entities (ids 1-4) — no
+// storey at expressId 5, unlike `FIXTURE_MODEL` (whose id 5 is "Storey Two"
+// with 2 elements).
+const MINIMAL_ACTIVE_MODEL = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('minimal-active-fixture.ifc','2020-01-01T00:00:00',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('${guid(1)}',$,'Active Project',$,$,$,$,$,$);
+#2=IFCSITE('${guid(2)}',$,'Active Site',$,$,$,$,$,.ELEMENT.,$,$,$,$,$);
+#3=IFCBUILDING('${guid(3)}',$,'Active Building',$,$,$,$,$,.ELEMENT.,$,$,$);
+#4=IFCBUILDINGSTOREY('${guid(4)}',$,'Storey One',$,$,$,$,$,$,0.);
+#10=IFCRELAGGREGATES('${guid(10)}',$,$,$,#1,(#2));
+#11=IFCRELAGGREGATES('${guid(11)}',$,$,$,#2,(#3));
+#12=IFCRELAGGREGATES('${guid(12)}',$,$,$,#3,(#4));
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function parseModel(stepText: string): Promise<IfcDataStore> {
+  const bytes = new TextEncoder().encode(stepText);
+  return new IfcParser().parseColumnar(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  );
+}
+
+function federatedModel(id: string, ifcDataStore: FederatedModel['ifcDataStore'], idOffset: number): FederatedModel {
+  return {
+    id,
+    name: `${id}.ifc`,
+    ifcDataStore,
+    geometryResult: null,
+    visible: true,
+    collapsed: false,
+    schemaVersion: 'IFC4',
+    loadedAt: 1,
+    fileSize: 0,
+    idOffset,
+    maxExpressId: 100_000 + idOffset,
+  } as FederatedModel;
+}
+
+const mounted: Array<{ root: Root; container: HTMLElement }> = [];
+function render(): HTMLElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <ExtensionHostContext.Provider value={stubHost}>
+        <StatusBar />
+      </ExtensionHostContext.Provider>,
+    );
+  });
+  mounted.push({ root, container });
+  return container;
+}
+function unmountAll(): void {
+  for (const { root, container } of mounted.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+}
+after(unmountAll);
+
+beforeEach(async () => {
+  unmountAll();
+  // Active model (m1, offset 0): no storey at expressId 5 whatsoever.
+  const activeStore = await parseModel(MINIMAL_ACTIVE_MODEL);
+  // Non-active model (m2, offset 1,000,000): the REAL selected storey lives
+  // here, at local expressId 5 ("Storey Two", 2 elements: Wall B, Wall C).
+  const otherStore = await parseModel(FIXTURE_MODEL);
+
+  useViewerStore.setState({
+    ifcDataStore: activeStore,
+    geometryResult: null,
+    activeModelId: 'm1',
+    models: new Map([
+      ['m1', federatedModel('m1', activeStore, 0)],
+      ['m2', federatedModel('m2', otherStore, ID_OFFSET)],
+    ]),
+    selectedStoreys: new Set<number>([FIXTURE_STOREY_2]),
+  });
+});
+
+describe('StatusBar — federation-space storey element count', () => {
+  it('counts a non-active model\'s selected storey through its OWN hierarchy', () => {
+    const container = render();
+
+    // No `geometryResult` is set (mesh-derived `stats.elements` is 0), so a
+    // correct resolution renders "2 / 0 elements" — the storey's own count
+    // up front, with the (irrelevant, zero) mesh total as the muted
+    // denominator. The bug produced "0 elements" outright: `count` stayed 0
+    // (nothing found in the active model's hierarchy) so `count ||
+    // stats.elements` fell through to the equally-0 total, and the two being
+    // equal suppressed the "/ N" fraction entirely.
+    assert.ok(
+      container.textContent?.includes('2 / 0 elements'),
+      `element count must reflect the selected storey's own 2 elements, resolved via its ` +
+        `own (non-active) model's spatial hierarchy — not a fallback to the active model's ` +
+        `(zero) total from a failed lookup against a hierarchy that has no storey at that id. ` +
+        `Got: ${JSON.stringify(container.textContent)}`,
+    );
+  });
+});

--- a/apps/viewer/src/components/viewer/StatusBar.tsx
+++ b/apps/viewer/src/components/viewer/StatusBar.tsx
@@ -14,7 +14,7 @@ import { FlavorDialog } from '@/components/extensions/FlavorDialog';
 import { createStatusBarStatsAccumulator } from './statusBarStats.js';
 
 export function StatusBar() {
-  const { loading, geometryResult, ifcDataStore } = useIfc();
+  const { loading, geometryResult, ifcDataStore, models } = useIfc();
   const progress = useViewerStore((s) => s.progress);
   const error = useViewerStore((s) => s.error);
   const selectedStoreys = useViewerStore((s) => s.selectedStoreys);
@@ -92,20 +92,32 @@ export function StatusBar() {
     [geometryResult],
   );
 
+  // `selectedStoreys` holds raw model-space expressIds (see HierarchyPanel's
+  // `setStoreysSelection`), which may belong to ANY federated model, not just
+  // the active one — `ifcDataStore` only tracks the active model
+  // (`modelSlice.ts`). Resolve each id through the model whose own spatial
+  // hierarchy actually contains it as a storey, falling back to the active
+  // store for legacy single-model mode. Mirrors ViewportOverlays' storey-name
+  // lookup (#3506) for the same reason: a non-active model's storey must not
+  // be counted against the active model's hierarchy.
   const visibleElements = useMemo(() => {
-    if (selectedStoreys.size === 0 || !ifcDataStore?.spatialHierarchy) {
+    if (selectedStoreys.size === 0 || (!ifcDataStore?.spatialHierarchy && models.size === 0)) {
       return stats.elements;
     }
-    // Count elements from all selected storeys
     let count = 0;
     for (const storeyId of selectedStoreys) {
-      const storeyElements = ifcDataStore.spatialHierarchy.byStorey.get(storeyId);
+      const ownHierarchy = models.size > 0
+        ? Array.from(models.values()).find(
+            (m) => m.ifcDataStore?.spatialHierarchy?.byStorey.has(storeyId),
+          )?.ifcDataStore?.spatialHierarchy
+        : ifcDataStore?.spatialHierarchy;
+      const storeyElements = ownHierarchy?.byStorey.get(storeyId);
       if (storeyElements) {
         count += storeyElements.length;
       }
     }
     return count || stats.elements;
-  }, [selectedStoreys, ifcDataStore, stats.elements]);
+  }, [selectedStoreys, ifcDataStore, models, stats.elements]);
 
   return (
     <div className="h-7 px-3 border-t bg-muted/30 flex items-center justify-between text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Continuing the audit from #3506 (which itself flagged `StatusBar.tsx`, `basketVisibleSet.ts`, `ViewportContainer.tsx`, and `ListResultsTable.tsx` as same-family risks without checking them): this resolves the genuine defect and verifies the other three safe.

`selectedStoreys` is a `Set<number>` of raw model-space `expressId`s — model-local, with no global id and no bridge that could resolve them (unlike the `resolveEntityRef` entity-id family in #3499/#3501/#3504). `StatusBar.tsx`'s `visibleElements` memo looked each selected storey id up directly in `useIfc().ifcDataStore.spatialHierarchy` — the ACTIVE model only. With a second federated model, selecting one of ITS storeys found nothing in the active model's hierarchy, `count` stayed 0, and `count || stats.elements` silently fell back to the (unrelated) mesh-derived total instead of the selected storey's own element count.

Fix: resolve each id through whichever federated model's own `spatialHierarchy.byStorey` actually contains it, falling back to the active store only in legacy single-model mode — the same approach #3506 used for `ViewportOverlays.tsx`'s storey-name pill.

### Other files checked in the same pass (all SAFE, verified with mechanism)
- `basketVisibleSet.ts` — `getSelectedStoreyElementRefs` and `computeStoreyIsolation` already iterate `state.models`, checking each model's OWN `spatialHierarchy.byStorey` (with an `idOffset` fallback), and only fall back to the legacy active store when `state.models.size === 0`. This is the correct pattern, already in place.
- `ViewportContainer.tsx` — `computedIsolatedIds` iterates `storeModels`, resolving each selected storey through that model's own hierarchy, and only reads the legacy `ifcDataStore` when `storeModels.size === 0`. Safe.
- `ListResultsTable.tsx` — never indexes into any `ifcDataStore` with a storey id itself. It filters by visibility entirely through `getVisibleBasketEntityRefsFromStore()` (`basketVisibleSet.ts`, verified safe above); `selectedStoreys` only appears as a `useMemo` dependency to trigger recompute. Safe.

### Full `selectedStoreys` consumer sweep (`git grep -n "selectedStoreys" -- apps/viewer/src | grep -v test`)
| File | Verdict | Mechanism |
|---|---|---|
| `StatusBar.tsx` | **Fixed here** | Was: active-only `ifcDataStore.spatialHierarchy` lookup |
| `basketVisibleSet.ts` | Safe | Iterates `state.models`, own hierarchy per model, legacy fallback only when no models |
| `ViewportContainer.tsx` | Safe | Iterates `storeModels`, own hierarchy per model, legacy fallback only when `storeModels.size === 0` |
| `ListResultsTable.tsx` | Safe | Delegates entirely to `getVisibleBasketEntityRefsFromStore()`; storey ids never looked up directly |
| `ViewportOverlays.tsx` | Fixed in #3506 (open, not on `main`) | — |
| `PdfViewExportDialog.tsx` | Safe | Only a `useMemo` dependency; actual work delegates to `readViewPdfSource` → `computeIsolationFilterSet` (verified safe above) |
| `useLevelDisplayEffect.ts` | Safe | Only checks `.size === 0`; never indexes by id |
| `lib/tours/snapshot.ts` | Safe | Pure (de)serialization of the raw id set; no lookup |
| `HierarchyPanel.tsx` | **Flagged, not fixed here** | The writer of `selectedStoreys`, but `computeNodeState` also *reads* it: `node.expressIds.some(id => selectedStoreys.has(id))` / `selectedStoreys.has(node.expressIds[0])` compares a node's own model-local id against the global set without checking `modelId`. Two federated models whose storeys happen to share a local expressId (routine — most IFC files start numbering at #1) could cross-highlight a tree node that wasn't actually selected. Left as a same-family risk for a future pass, matching #3506's own scoping discipline. |
| `slices/selectionSlice.ts`, `slices/selectionSlice.teardown.ts`, `store/levelDisplay.ts`, `slices/levelDisplaySlice.ts` | Safe (writers/definitions only) | No id lookup |
| `BulkPropertyEditor.tsx` | Not this family | Local `useState<number[]>` named `selectedStoreys`, unrelated to the store slice |

## Test plan
- [x] New federated-fixture test (`StatusBar.federation.test.tsx`): active model has NO storey at the selected storey's expressId; RED before the fix (`"0 elements"` — count fell through to the equally-zero mesh total), GREEN after (`"2 / 0 elements"` — resolves through the non-active model's own hierarchy).
- [x] `node scripts/check-module-size.mjs` — OK, no budget change needed.
- [x] `pnpm exec tsc --noEmit` (apps/viewer, including test files) — clean.
- [x] `apps/viewer` is `private: true` — no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436