### PR TITLE
fix(cli): stop query --sum/--avg/--min/--max from silently limiting the aggregated set

### DIFF
--- a/.changeset/query-sum-ignores-limit.md
+++ b/.changeset/query-sum-ignores-limit.md
@@ -1,7 +1,7 @@
 ---
-'@ifc-lite/cli': patch
+'@ifc-lite/cli': minor
 ---
 
 Fix `ifc-lite query --sum`/`--avg`/`--min`/`--max` silently aggregating only the first `--limit` matched entities instead of the full filtered set, when used without `--where` or `--storey`.
 
-The plain (no `--where`, no `--storey`) query path built one `QueryBuilder` and applied `q.limit(rowLimit)`/`q.offset(offset)` to it unconditionally (except when `--group-by` was also given), then reused that same sliced builder for the aggregation branches. `--type IfcBeam --sum NetVolume --limit 2` returned the sum of only the first 2 matching beams and reported `matchedEntities: 2`, with no indication the total was partial — silently wrong rather than an error. The `--where` path already had an explicit rule against this ("aggregations operate on the full filtered set, no offset/limit"); the plain path now follows the same rule.
+The plain (no `--where`, no `--storey`) query path built one `QueryBuilder` and applied `q.limit(rowLimit)` (skipped only under `--group-by`) and `q.offset(offset)` (skipped under nothing) to it, then reused that same sliced builder for the aggregation branches. `--type IfcBeam --sum NetVolume --limit 2` returned the sum of only the first 2 matching beams and reported `matchedEntities: 2`, with no indication the total was partial — silently wrong rather than an error. The `--where` path already had an explicit rule against this ("aggregations operate on the full filtered set, no offset/limit"); the plain path now follows the same rule. `--group-by` combined with an aggregation also stops applying `--offset` before grouping, so group totals now cover the full filtered set the way the `--where` and `--storey` paths already do.

--- a/.changeset/query-sum-ignores-limit.md
+++ b/.changeset/query-sum-ignores-limit.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix `ifc-lite query --sum`/`--avg`/`--min`/`--max` silently aggregating only the first `--limit` matched entities instead of the full filtered set, when used without `--where` or `--storey`.
+
+The plain (no `--where`, no `--storey`) query path built one `QueryBuilder` and applied `q.limit(rowLimit)`/`q.offset(offset)` to it unconditionally (except when `--group-by` was also given), then reused that same sliced builder for the aggregation branches. `--type IfcBeam --sum NetVolume --limit 2` returned the sum of only the first 2 matching beams and reported `matchedEntities: 2`, with no indication the total was partial — silently wrong rather than an error. The `--where` path already had an explicit rule against this ("aggregations operate on the full filtered set, no offset/limit"); the plain path now follows the same rule.

--- a/packages/cli/src/commands/query-limit.test.ts
+++ b/packages/cli/src/commands/query-limit.test.ts
@@ -204,10 +204,11 @@ describe('query --storey honours --limit and --offset', () => {
  * `--sum`/`--avg`/`--min`/`--max` must aggregate over the FULL filtered set,
  * never a `--limit`/`--offset`-sliced one — the `--where` path enforces this
  * deliberately ("Aggregations operate on the full filtered set (no
- * offset/limit)"). The plain (no `--where`, no `--storey`) path builds its
- * `QueryBuilder` with `q.limit(rowLimit)` / `q.offset(offset)` applied
- * unconditionally whenever `!groupBy`, then reuses that SAME limited `q` for
- * `--sum`/`--avg`/`--min`/`--max`, which never should have been sliced in
+ * offset/limit)"). The plain (no `--where`, no `--storey`) path built its
+ * `QueryBuilder` with `q.limit(rowLimit)` applied whenever `!groupBy` and
+ * `q.offset(offset)` applied with no guard at all, then reused that SAME
+ * limited `q` for `--sum`/`--avg`/`--min`/`--max`, which never should have
+ * been sliced in
  * the first place: `--type IfcBeam --sum NetVolume --limit 2` silently sums
  * only the first two matched beams instead of every beam with the quantity,
  * with no warning that the total is partial.

--- a/packages/cli/src/commands/query-limit.test.ts
+++ b/packages/cli/src/commands/query-limit.test.ts
@@ -199,3 +199,43 @@ describe('query --storey honours --limit and --offset', () => {
     expect(await storeyCount(['--where', 'Pset_WallCommon.IsExternal', '--limit', '1'])).toBe(1);
   });
 });
+
+/**
+ * `--sum`/`--avg`/`--min`/`--max` must aggregate over the FULL filtered set,
+ * never a `--limit`/`--offset`-sliced one — the `--where` path enforces this
+ * deliberately ("Aggregations operate on the full filtered set (no
+ * offset/limit)"). The plain (no `--where`, no `--storey`) path builds its
+ * `QueryBuilder` with `q.limit(rowLimit)` / `q.offset(offset)` applied
+ * unconditionally whenever `!groupBy`, then reuses that SAME limited `q` for
+ * `--sum`/`--avg`/`--min`/`--max`, which never should have been sliced in
+ * the first place: `--type IfcBeam --sum NetVolume --limit 2` silently sums
+ * only the first two matched beams instead of every beam with the quantity,
+ * with no warning that the total is partial.
+ */
+describe('query --sum ignores --limit/--offset (plain path, no --where)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const BRIDGE_IFC = join(__dirname, '../../../../apps/viewer/public/samples/infra-bridge.ifc');
+
+  async function sumJson(extra: string[]): Promise<{ total: number; matchedEntities: number }> {
+    const stdout = captureStdout();
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    await queryCommand([BRIDGE_IFC, '--type', 'IfcBeam', '--sum', 'NetVolume', '--json', ...extra]);
+    vi.restoreAllMocks();
+    return JSON.parse(stdout.out);
+  }
+
+  it('bounding control: the unrestricted sum matches more than 2 beams', async () => {
+    const full = await sumJson([]);
+    expect(full.matchedEntities).toBeGreaterThan(2);
+  });
+
+  it('--limit does not shrink the summed set or the total', async () => {
+    const full = await sumJson([]);
+    const limited = await sumJson(['--limit', '2']);
+    expect(limited.matchedEntities).toBe(full.matchedEntities);
+    expect(limited.total).toBeCloseTo(full.total, 9);
+  });
+});

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -526,10 +526,17 @@ export async function queryCommand(args: string[]): Promise<void> {
     return;
   }
 
+  // Detect aggregation quantity and mode up front: --sum/--avg/--min/--max
+  // must run over the FULL filtered set, matching the --where and --storey
+  // paths' explicit "no offset/limit" rule for aggregations -- a partial sum
+  // over a --limit-sliced set is a silently wrong total, not a preview.
+  const aggQuantity = sumQuantity ?? avgQuantity ?? minQuantity ?? maxQuantity;
+  const aggMode: 'sum' | 'avg' | 'min' | 'max' | undefined = sumQuantity ? 'sum' : avgQuantity ? 'avg' : minQuantity ? 'min' : maxQuantity ? 'max' : undefined;
+
   // Validated, not parseInt'd -- the backend descriptor only honours the
   // limit under a `> 0` check, so a NaN --limit returned every match.
-  if (rowLimit !== undefined && !groupBy) q = q.limit(rowLimit);
-  if (offset) q = q.offset(offset);
+  if (rowLimit !== undefined && !groupBy && !aggQuantity) q = q.limit(rowLimit);
+  if (offset && !aggQuantity) q = q.offset(offset);
 
   // B11: Validate --group-by key
   if (groupBy) {
@@ -537,10 +544,6 @@ export async function queryCommand(args: string[]): Promise<void> {
       fatal(`Unknown grouping "${groupBy}". Valid options: ${VALID_GROUP_BY_KEYS.join(', ')}, or PsetName.PropName`);
     }
   }
-
-  // Detect aggregation quantity and mode for --group-by combos
-  const aggQuantity = sumQuantity ?? avgQuantity ?? minQuantity ?? maxQuantity;
-  const aggMode: 'sum' | 'avg' | 'min' | 'max' | undefined = sumQuantity ? 'sum' : avgQuantity ? 'avg' : minQuantity ? 'min' : maxQuantity ? 'max' : undefined;
 
   // --group-by + aggregation combo: aggregate per group
   if (groupBy && aggQuantity) {


### PR DESCRIPTION
## Summary

`ifc-lite query --sum`/`--avg`/`--min`/`--max` in the plain (no `--where`, no `--storey`) path silently aggregated only a `--limit`-sliced subset of the matched entities instead of the full filtered set, with no indication the total was partial.

`queryCommand` builds one shared `QueryBuilder` (`q`) and, before branching on `--sum`/`--avg`/`--min`/`--max`/`--group-by`, did:

```ts
if (rowLimit !== undefined && !groupBy) q = q.limit(rowLimit);
if (offset) q = q.offset(offset);
```

The `!groupBy` guard excludes `--group-by`, but not the other aggregation modes. The aggregation branches then call `q.toArray()` on this already-sliced builder:

```ts
if (sumQuantity) {
  const entities = q.toArray();   // already limited/offset
  outputSum(entities, sumQuantity, bim, jsonOutput);
  return;
}
```

So `--type IfcBeam --sum NetVolume --limit 2` summed only the first 2 matched beams and reported `matchedEntities: 2`, instead of summing every matched beam. The `--where` path already enforces the opposite, correct rule explicitly (comment: "Aggregations operate on the full filtered set (no offset/limit)"), and the `--storey` path follows the same rule — only the plain path diverged.

Verified by execution on `apps/viewer/public/samples/infra-bridge.ifc` (8 `IfcBeam`, 5 with `Qto_BeamBaseQuantities.NetVolume`):

```
$ query infra-bridge.ifc --type IfcBeam --sum NetVolume --json
{ "total": 2.1322256280670713, "matchedEntities": 5, "totalEntities": 8 }

$ query infra-bridge.ifc --type IfcBeam --sum NetVolume --limit 2 --json   # before fix
{ "total": 0.6922256280670667, "matchedEntities": 2, "totalEntities": 2 }  # WRONG — silent partial sum

$ query infra-bridge.ifc --type IfcBeam --sum NetVolume --limit 2 --json   # after fix
{ "total": 2.1322256280670713, "matchedEntities": 5, "totalEntities": 8 }  # matches unrestricted total
```

Reachability: reached on the normal happy path — no crafted/corrupt input needed, just `--sum`/`--avg`/`--min`/`--max` combined with `--limit` (or `--offset`) and no `--where`/`--storey`.

One-off vs. family: the same file's `--where` and `--storey` branches already apply the correct "no offset/limit for aggregations" rule; grepped for other reuses of a limited/offset `QueryBuilder` across aggregation branches within `query.ts` and `query-aggregation.ts` and found none — this was the one remaining branch missing the rule that its own siblings already document and follow.

## Fix

Compute `aggQuantity` before applying `.limit()`/`.offset()` to `q`, and skip both when an aggregation mode is active, so aggregation always runs over the full filtered `QueryBuilder` result — same rule the `--where` and `--storey` branches already apply.

## Test plan

- [x] New RED/GREEN test in `packages/cli/src/commands/query-limit.test.ts` (`query --sum ignores --limit/--offset (plain path, no --where)`): fails before the fix (`limited.matchedEntities` is 2, not 5), passes after.
- [x] `pnpm exec tsc --noEmit` in `packages/cli` — clean.
- [x] `pnpm exec vitest run` in `packages/cli` — 54 files, 557 passed, 8 skipped (all pre-existing skips).
- [x] `node scripts/check-module-size.mjs` — `query.ts` at 606/609 lines, under budget; no allowlist changes.
- [x] Changeset added (`@ifc-lite/cli` patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436