### PR TITLE
fix(viewer): playground IDS validation misses material facets on profile/constituent/list variants

### DIFF
--- a/apps/viewer/src/components/mcp/playground-dispatcher-materials.test.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher-materials.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The playground's own `makeIdsAccessor().getMaterials` (used by the
+ * `ids_validate` tool) is a SEPARATE reimplementation from
+ * `@ifc-lite/ids`'s `flattenMaterials` (packages/ids/src/bridge/materials.ts)
+ * — a "two paths that must agree" case. The playground copy only ever
+ * looked at `mat.layers` or the top-level `mat.name`, so an
+ * `IfcMaterialConstituentSet` (or `IfcMaterialProfileSet` / `IfcMaterialList`)
+ * association was invisible to IDS material requirements: the spec
+ * false-failed even though the model genuinely carries the required
+ * material.
+ *
+ * Fixture: an `IfcWall` associated (via `IfcRelAssociatesMaterial`) to an
+ * `IfcMaterialConstituentSet` with no set-level name — only its one
+ * constituent, whose underlying `IfcMaterial` is named 'Fireproofing'.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { dispatch, parsePlaygroundModel } from './playground-dispatcher.js';
+
+function ifc4(body: string): string {
+  return [
+    'ISO-10303-21;', 'HEADER;', "FILE_DESCRIPTION((''),'2;1');",
+    "FILE_NAME('','',(''),(''),'','','');", "FILE_SCHEMA(('IFC4'));", 'ENDSEC;',
+    'DATA;', body, 'ENDSEC;', 'END-ISO-10303-21;', '',
+  ].join('\n');
+}
+
+const CONSTITUENT_SET_WALL = ifc4(`
+#100=IFCWALL('0Wall0000000000000001',$,'Wall A',$,$,$,$,$,$);
+#200=IFCMATERIAL('Fireproofing',$,$);
+#210=IFCMATERIALCONSTITUENT($,$,#200,$,$);
+#220=IFCMATERIALCONSTITUENTSET($,$,(#210));
+#230=IFCRELASSOCIATESMATERIAL('0RelMat00000000000001',$,$,$,(#100),#220);
+`);
+
+const PLAIN_MATERIAL_WALL = ifc4(`
+#100=IFCWALL('0Wall0000000000000002',$,'Wall B',$,$,$,$,$,$);
+#200=IFCMATERIAL('Fireproofing',$,$);
+#230=IFCRELASSOCIATESMATERIAL('0RelMat00000000000002',$,$,$,(#100),#200);
+`);
+
+function materialIdsXml(materialName: string): string {
+  return `<ids xmlns="http://standards.buildingsmart.org/IDS">
+  <info><title>Material check</title></info>
+  <specifications>
+    <specification name="Fireproofing required" ifcVersion="IFC4" minOccurs="1" maxOccurs="unbounded">
+      <applicability>
+        <entity><name><simpleValue>IFCWALL</simpleValue></name></entity>
+      </applicability>
+      <requirements>
+        <material><value><simpleValue>${materialName}</simpleValue></value></material>
+      </requirements>
+    </specification>
+  </specifications>
+</ids>`;
+}
+
+async function runIdsValidate(ifc: string, materialName: string) {
+  const model = await parsePlaygroundModel(
+    new TextEncoder().encode(ifc).buffer as ArrayBuffer,
+    'fixture.ifc',
+  );
+  const result = await dispatch(model, 'ids_validate', { ids_xml: materialIdsXml(materialName) });
+  assert.equal(result.isError, false, `ids_validate should not error: ${result.text}`);
+  const structured = result.structured as { summary: { passedSpecifications: number; totalSpecifications: number } };
+  return structured.summary;
+}
+
+describe('playground ids_validate — material facet across variants', () => {
+  it('CONTROL: a plain IfcMaterial association passes the material requirement', async () => {
+    const summary = await runIdsValidate(PLAIN_MATERIAL_WALL, 'Fireproofing');
+    assert.equal(summary.passedSpecifications, 1);
+    assert.equal(summary.totalSpecifications, 1);
+  });
+
+  it('an IfcMaterialConstituentSet association passes the material requirement', async () => {
+    const summary = await runIdsValidate(CONSTITUENT_SET_WALL, 'Fireproofing');
+    assert.equal(
+      summary.passedSpecifications,
+      1,
+      'the wall genuinely carries a Fireproofing constituent material — the spec must pass',
+    );
+    assert.equal(summary.totalSpecifications, 1);
+  });
+});

--- a/apps/viewer/src/components/mcp/playground-dispatcher.ts
+++ b/apps/viewer/src/components/mcp/playground-dispatcher.ts
@@ -30,6 +30,7 @@
 import { IfcParser, type IfcDataStore, extractLengthUnitScale, extractProjectUnits } from '@ifc-lite/parser';
 import { QuantityType } from '@ifc-lite/data';
 import { formatQuantityUnit } from '@/lib/units/display';
+import { lensMaterialNames } from '@/lib/lens-material-names';
 import {
   BsddNamespace,
   createBimContext,
@@ -590,7 +591,7 @@ const IMPLS: Record<string, ToolImpl> = {
     } else if (groupBy === 'material') {
       for (const e of m.bim.query().toArray()) {
         const mat = m.bim.materials(e.ref);
-        const key = mat?.name ?? '(no material)';
+        const key = lensMaterialNames(mat)[0] ?? '(no material)';
         counts.set(key, (counts.get(key) ?? 0) + 1);
       }
     }
@@ -700,7 +701,7 @@ const IMPLS: Record<string, ToolImpl> = {
     for (const e of m.bim.query().toArray()) {
       const mat = m.bim.materials(e.ref);
       if (!mat) continue;
-      const key = mat.name ?? '(unnamed)';
+      const key = lensMaterialNames(mat)[0] ?? '(unnamed)';
       counts.set(key, (counts.get(key) ?? 0) + 1);
     }
     const list = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]).map(([name, count]) => ({ name, count }));
@@ -1875,14 +1876,11 @@ function makeIdsAccessor(m: LoadedPlaygroundModel): import('@ifc-lite/ids').IFCD
       }));
     },
     getMaterials(id) {
-      const mat = m.bim.materials(ref(id));
-      if (!mat) return [];
-      const layers = (mat as { layers?: Array<{ materialName?: string; name?: string }>; name?: string });
-      if (Array.isArray(layers.layers) && layers.layers.length > 0) {
-        return layers.layers.map((l) => ({ name: l.materialName ?? l.name ?? '' }));
-      }
-      if (layers.name) return [{ name: layers.name }];
-      return [];
+      // Every variant via the same #1366 lens collector the material
+      // filter/list panels use. Previously only `mat.layers` and the
+      // top-level `mat.name` were checked, so a profile set, constituent
+      // set, or material list was invisible to IDS material requirements.
+      return lensMaterialNames(m.bim.materials(ref(id))).map((name) => ({ name }));
     },
     getParent(id) {
       try {


### PR DESCRIPTION
## Summary

`MaterialData` (packages/sdk/src/types.ts:163, mirrored by `MaterialInfo` in packages/parser/src/material-resolver.ts) carries a `type` discriminant every field is optional under, so nothing forces a consumer to narrow before reading `.name`/`.layers`/etc. This audits every consumer of that shape and fixes the worst genuine gap found: the **viewer's own** `makeIdsAccessor().getMaterials` in `apps/viewer/src/components/mcp/playground-dispatcher.ts`, used by the browser playground's `ids_validate` tool.

That accessor is a separate reimplementation from `@ifc-lite/ids`'s `flattenMaterials` (`packages/ids/src/bridge/materials.ts`, which already switches on every variant and is covered by `packages/ids/src/bridge/multi-material.test.ts`). The playground's copy only ever checked `mat.layers` or the top-level `mat.name`:

```ts
const layers = (mat as { layers?: ...; name?: string });
if (Array.isArray(layers.layers) && layers.layers.length > 0) { ... }
if (layers.name) return [{ name: layers.name }];
return [];
```

An `IfcMaterialProfileSet`, `IfcMaterialConstituentSet`, or `IfcMaterialList` association was therefore invisible to every IDS material requirement in the browser playground — a spec requiring a material the model genuinely carries would false-FAIL (or silently under-match), with no error surfaced. The two material-grouping tools in the same file (`count_entities` groupBy=`material`, `materials_list`) had the identical "only `mat.name`" shape as the still-open PR #3515's MCP fix, but in this separate, unrelated file, so `IfcMaterialList` members were also mis-bucketed as `'(no material)'` / `'(unnamed)'`.

Fix: route all three through the existing `lensMaterialNames()` helper (`apps/viewer/src/lib/lens-material-names.ts`, #1366) which already falls back through `layers[] / constituents[] / profiles[] / materials[]` correctly and is already proven correct for the viewer's own material filter/list panels — no new fallback logic invented.

## Audit — variant × populated-fields (the oracle, from `packages/parser/src/material-resolver.ts`)

| `type` | `name` | `description` | `layers` | `profiles` | `constituents` | `materials` |
|---|---|---|---|---|---|---|
| `Material` | set (attrs[0]) | set (attrs[1]) | — | — | — | — |
| `MaterialLayerSet` | set if authored (attrs[1]) | set (attrs[2]) | set | — | — | — |
| `MaterialProfileSet` | set if authored (attrs[0]) | set (attrs[1]) | — | set | — | — |
| `MaterialConstituentSet` | set if authored (attrs[0]) | set (attrs[1]) | — | — | set | — |
| `MaterialList` | **never set** (return is `{ type, materials }` only) | **never set** | — | — | — | set |

`MaterialList` structurally never carries `name`/`description` at all — any consumer that reads `mat.name` without narrowing silently drops it.

## Consumer audit (selected; full table in session notes)

| Consumer | Narrows on `type`? | Verdict |
|---|---|---|
| `packages/ids/src/bridge/materials.ts` (`flattenMaterials`) | Yes, full switch | Safe (canonical, tested) |
| `packages/ids/src/bridge/data-accessor.ts` `getMaterials` | Delegates to `flattenMaterials` | Safe (tested by `multi-material.test.ts`) |
| `apps/viewer/src/lib/lens-material-names.ts` (`lensMaterialNames`) | No, but falls back through every array field + `name` | Safe |
| `apps/viewer/src/lib/lists/adapter.ts`, `src/lib/search/filter-match.ts` | Use/delegate to `lensMaterialNames` | Safe |
| `apps/viewer/src/components/viewer/properties/MaterialCard.tsx` | Yes, full switch per `type` in the body | Safe (collapsible header falls back to a generic type label instead of the first member name for `MaterialList` — cosmetic, not incorrect data, left as-is) |
| `packages/cli/src/commands/{query,query-output,ask,stats-aggregation}.ts` | No, but use `mat?.materials?.[0] ?? mat?.name` fallback | Safe (already the CLI's established, correct pattern, cited by #3515) |
| `packages/mcp/src/tools/query.ts:221,552` | No — `mat?.name` only | **Broken for `MaterialList`, but owned by #3515 (open PR) — not touched here** |
| `packages/mcp/src/resources/providers.ts:169` (`materials` MCP *resource*, distinct from the `query.ts` *tools*) | No — `mat.name ?? '(unnamed)'` | **Same bug class, unpatched, NOT fixed in this PR** — flagged for a follow-up, out of scope to keep this PR minimal |
| `apps/viewer/src/components/mcp/playground-dispatcher.ts` `count_entities`/`materials_list`/`getMaterials` | No (pre-fix) | **Fixed here** |
| All other `bim.materials(ref)` call sites (`packages/sdk`, `packages/mcp/src/backend-query.ts`, `packages/cli/src/headless-backend.ts`, `packages/sandbox`, remaining `mcp/tools/query.ts` / `viewer.ts` spots) | N/A — pure passthrough into JSON output, no field read | Safe |

## Discriminated-union assessment (not attempted here, per scope)

Splitting `MaterialData`/`MaterialInfo` into a real discriminated union (e.g. `MaterialList` structurally excluding `name`) would be low-risk but low-value as a mechanical migration: nearly every consumer already treats every field as optional (`mat?.name`, `mat?.materials?.[0]`), so runtime behavior is already safe in most places — a real union mainly buys *compile-time* enforcement, catching the two remaining unnarrowed sites (`packages/mcp/src/tools/query.ts` — owned by #3515 — and `packages/mcp/src/resources/providers.ts`) and any future regression.

- **Call sites needing changes:** ~2 (the two named above); everything else either already narrows in a full switch (`flattenMaterials`, `MaterialCard.tsx`) or already falls back safely through optional chaining and would just need a type-only touch-up to satisfy stricter field access.
- **Blockers:** none structural — `MaterialData`/`MaterialInfo` are two independently-declared but field-identical interfaces (sdk + parser), so the union would need to land in both, or the parser type would need to become the sole source of truth with sdk re-exporting it.
- **Incremental path:** keep the current interface as the wire/serialization shape (nothing downstream of JSON serialization needs narrowing), and introduce the union only as an internal type behind a narrowing helper — `lensMaterialNames()` and `flattenMaterials()` already play that role today in practice. A formal `asMaterialList(mat): mat is MaterialListVariant`-style helper could be added incrementally without touching working call sites.
- **Rough effort:** well under a day — add the union type + one or two narrowing helpers (~1-2 hrs), migrate/verify the ~2 genuinely-unsafe call sites (~1-2 hrs), full-suite verification across `sdk`/`ids`/`mcp`/`cli`/`viewer` (~1-2 hrs). Not attempted in this PR.

## Test plan

- New fixture (`apps/viewer/src/components/mcp/playground-dispatcher-materials.test.ts`): an `IfcWall` associated to an `IfcMaterialConstituentSet` (no set-level name, only a constituent whose underlying `IfcMaterial` is `'Fireproofing'`) via `IfcRelAssociatesMaterial`, run through `dispatch(model, 'ids_validate', ...)` with an IDS material-facet requirement.
  - RED confirmed by stashing the fix and re-running: the constituent-set case fails (`0/1` specs passed) while a plain-`IfcMaterial` CONTROL fixture still passes both before and after.
  - GREEN after the fix: both pass, `1/1` specs.
- [x] `pnpm exec tsc --noEmit` in `apps/viewer` — clean.
- [x] Targeted test: `npx tsx --import ./src/test/vite-module-hooks.mjs --test src/components/mcp/playground-dispatcher-materials.test.ts` — 2/2 passing (RED→GREEN confirmed via stash).
- [x] `node scripts/check-module-size.mjs` — clean (`playground-dispatcher.ts` at 2088/2090 lines, under budget).
- [ ] **Full `apps/viewer` test suite was NOT completed locally** — it was started but the run is long (hundreds of files) and was not waited on; only the targeted new test file and `tsc --noEmit` were run to completion before this PR was opened, per session guidance that CI is authoritative and unbuilt-workspace-dep false failures are common locally. CI will run the full suite on this PR.

## Not in scope / avoided per instructions

- Did not touch `packages/mcp/src/tools/query.ts:221,552` or `materialDisplayName()` in `packages/mcp/src/tools/util.ts` — owned by PR #3515 (currently OPEN, unmerged; its helper is not on `main`).
- Did not fix `packages/mcp/src/resources/providers.ts:169` — same bug class, separate file, flagged above for a follow-up rather than expanding this PR's scope.
- Did not attempt the discriminated-union refactor — estimate only, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved material recognition in IDS validation, including materials defined through constituent sets.
  * Updated material listings and entity grouping to consistently recognize profile sets, constituent sets, and material lists.
  * Preserved fallback labels for entities with missing or unnamed materials.

* **Tests**
  * Added coverage for validating walls associated with both direct materials and constituent-set materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->