### PR TITLE
fix(drawing-2d): populate windowPartitioning for window openings

### DIFF
--- a/.changeset/window-partitioning-never-populated.md
+++ b/.changeset/window-partitioning-never-populated.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/drawing-2d': patch
+---
+
+Fix `OpeningInfo.windowPartitioning` never being populated for window openings, so 2D drawing generation silently rendered every window with a single-panel symbol.
+
+`OpeningRelationshipBuilder.build()` extracted `doorOperation` from the filling element's properties when `type === 'door'`, but had no equivalent extraction for `windowPartitioning` when `type === 'window'` — the field existed on `OpeningInfo` and was read by `window-symbol.ts` (`opening.windowPartitioning ?? 'SINGLE_PANEL'`), but the producer never set it, so the `?? 'SINGLE_PANEL'` fallback fired unconditionally. A window with `PartitioningType: DOUBLE_PANEL_HORIZONTAL` (or any other `IfcWindowTypePartitioningEnum` value) drew identically to a plain single-panel window in generated 2D plans/elevations — a silent, plausible-looking wrong symbol rather than a crash or an obviously-missing one.
+
+`OpeningRelationshipBuilder` now extracts `PartitioningType` from the filling element's properties (checking the direct attribute first, then `Pset_WindowCommon`, mirroring `extractDoorOperation`'s lookup for doors) and assigns it to `windowPartitioning` for window-type openings.

--- a/packages/drawing-2d/src/openings/opening-relationship-builder.test.ts
+++ b/packages/drawing-2d/src/openings/opening-relationship-builder.test.ts
@@ -94,4 +94,32 @@ describe('OpeningRelationshipBuilder', () => {
     // doorOperation must not leak onto a window-filled opening.
     expect(relationships.openingInfo.get(30)?.doorOperation).toBeUndefined();
   });
+
+  it('assigns windowPartitioning for window-type openings, mirroring doorOperation', () => {
+    const entityMetadata = new Map<number, EntityMetadata>([
+      [
+        10,
+        {
+          ifcType: 'IfcOpeningElement',
+          bounds: { min: { x: 0, y: 0, z: 0 }, max: { x: 1, y: 1, z: 2 } },
+        },
+      ],
+      [
+        20,
+        {
+          ifcType: 'IfcWindow',
+          properties: { PartitioningType: 'DOUBLE_PANEL_HORIZONTAL' },
+        },
+      ],
+    ]);
+
+    const relationships = new OpeningRelationshipBuilder(entityMetadata)
+      .addVoidRelationships([{ hostId: 1, openingId: 10 }])
+      .addFillRelationships([{ openingId: 10, elementId: 20 }])
+      .build(0);
+
+    const info = relationships.openingInfo.get(10);
+    expect(info?.type).toBe('window');
+    expect(info?.windowPartitioning).toBe('DOUBLE_PANEL_HORIZONTAL');
+  });
 });

--- a/packages/drawing-2d/src/openings/opening-relationship-builder.ts
+++ b/packages/drawing-2d/src/openings/opening-relationship-builder.ts
@@ -13,6 +13,7 @@ import type {
   FillRelationship,
   EntityMetadata,
   DoorOperationType,
+  WindowPartitioningType,
   Vec3,
 } from '../types.js';
 
@@ -95,6 +96,11 @@ export class OpeningRelationshipBuilder {
           info.doorOperation = this.extractDoorOperation(fillingMeta.properties);
         }
 
+        // Add window partitioning type if available
+        if (type === 'window' && fillingMeta?.properties) {
+          info.windowPartitioning = this.extractWindowPartitioning(fillingMeta.properties);
+        }
+
         this.openingInfo.set(openingId, info);
 
         // Also map filling element to same info for easy lookup
@@ -133,6 +139,22 @@ export class OpeningRelationshipBuilder {
     }
 
     return 'SINGLE_SWING_LEFT'; // Default
+  }
+
+  private extractWindowPartitioning(properties: Record<string, unknown>): WindowPartitioningType {
+    // Look for PartitioningType in properties (IfcWindow's own attribute)
+    const partitioningType = properties['PartitioningType'] as string | undefined;
+    if (partitioningType) {
+      return partitioningType as WindowPartitioningType;
+    }
+
+    // Look in nested property sets
+    const psets = properties['Pset_WindowCommon'] as Record<string, unknown> | undefined;
+    if (psets?.['PartitioningType']) {
+      return psets['PartitioningType'] as WindowPartitioningType;
+    }
+
+    return 'SINGLE_PANEL'; // Default
   }
 }
 


### PR DESCRIPTION
## Summary

`OpeningInfo.windowPartitioning` was never populated for window-type openings. `OpeningRelationshipBuilder.build()` (`packages/drawing-2d/src/openings/opening-relationship-builder.ts`) extracted `doorOperation` from the filling element's properties when `type === 'door'`, but had no matching extraction for `windowPartitioning` when `type === 'window'`. The field existed on `OpeningInfo`, and `window-symbol.ts` read it (`opening.windowPartitioning ?? 'SINGLE_PANEL'`) — but since the producer never set it, that fallback fired unconditionally. Any window with a real `PartitioningType` (`DOUBLE_PANEL_HORIZONTAL`, `TRIPLE_PANEL_VERTICAL`, etc.) drew identically to a plain single-panel window in generated 2D plans/elevations: a silent, plausible-looking wrong symbol.

This is the same "discriminant not load-bearing" shape as #3515's `MaterialData` fix: a `type` union with variant-specific optional fields, where one variant structurally never populates a field consumers read.

- Added `extractWindowPartitioning`, mirroring `extractDoorOperation`'s lookup order (direct `PartitioningType` attribute on the filling element, then `Pset_WindowCommon`).
- Wired it into `build()` for `type === 'window'`, alongside the existing `type === 'door'` branch.

## Test plan

- [x] Added a failing test (`assigns windowPartitioning for window-type openings, mirroring doorOperation`) in `opening-relationship-builder.test.ts`; confirmed RED by stashing the fix, confirmed the existing control test (`doorOperation must not leak onto a window-filled opening`) still passed under RED.
- [x] `pnpm exec vitest run src/openings/opening-relationship-builder.test.ts src/openings/opening-filter.test.ts` — 11/11 passing (GREEN).
- [x] `pnpm exec tsc --noEmit` in `packages/drawing-2d` — clean.
- [x] `node scripts/check-module-size.mjs` — OK, 0 new over budget.
- [x] Changeset added (`@ifc-lite/drawing-2d` patch).

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed window openings so their partitioning configuration is correctly recognized.
  * Windows with configurations such as double-panel horizontal now render with the appropriate symbol instead of appearing as single-panel windows.
  * Added coverage to verify window partitioning information is preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->