### PR TITLE
fix(source-dalux): surface the decoded Dalux file version in SourceFile.meta

### DIFF
--- a/.changeset/dalux-version-meta.md
+++ b/.changeset/dalux-version-meta.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/source-dalux': patch
+---
+
+`toSourceFile` now forwards Dalux's `version` field into `SourceFile.meta.version`. `decodeFile` already decoded it, but the mapper dropped it before it reached the `SourceFile` the host consumes — unlike `fileType`/`fileSize`/`lastModified`, which all reach the produced `SourceFile`, or `fileAreaId`/`folderId`, which already flow through the same `meta` bag. `SourceFile.meta` is documented as the provider-specific pass-through channel, and Dalux has no revision-history API to carry a version label through `SourceRevision` the way the msgraph/SharePoint provider does, so `meta` is the only place this value can reach a consumer.

--- a/packages/source-dalux/src/mapping.ts
+++ b/packages/source-dalux/src/mapping.ts
@@ -103,9 +103,11 @@ export function toSourceFile(fileAreaId: string, file: DaluxFile): SourceFile {
     // `version` is decoded by `decodeFile` (dalux-types.ts) but has no
     // dedicated `SourceFile` field and no revision-history API to carry it
     // via `SourceRevision` (unlike the msgraph/SharePoint provider's version
-    // label) -- `meta` is the documented "provider-specific metadata passed
-    // through opaquely" channel, so that's where it belongs. Omitted when
-    // absent rather than set to `undefined`, matching `folderId` above.
+    // label) -- `meta` is the documented channel for "provider-specific
+    // metadata the host passes through opaquely" (plugin-api types.ts), so
+    // that's where it belongs. Omitted when absent, via the conditional
+    // spread below -- unlike `folderId`, a plain shorthand property, which
+    // sits in `meta` as an explicit `undefined` when the file has no folder.
     meta: { fileAreaId, folderId, ...(file.version !== undefined ? { version: file.version } : {}) },
   };
 }

--- a/packages/source-dalux/src/mapping.ts
+++ b/packages/source-dalux/src/mapping.ts
@@ -100,7 +100,13 @@ export function toSourceFile(fileAreaId: string, file: DaluxFile): SourceFile {
     currentRevisionId: currentRevisionId(file),
     modifiedAt: orUndefined(file.lastModified ?? file.uploaded),
     modifiedBy: orUndefined(file.lastModifiedByUserId ?? file.uploadedByUserId),
-    meta: { fileAreaId, folderId },
+    // `version` is decoded by `decodeFile` (dalux-types.ts) but has no
+    // dedicated `SourceFile` field and no revision-history API to carry it
+    // via `SourceRevision` (unlike the msgraph/SharePoint provider's version
+    // label) -- `meta` is the documented "provider-specific metadata passed
+    // through opaquely" channel, so that's where it belongs. Omitted when
+    // absent rather than set to `undefined`, matching `folderId` above.
+    meta: { fileAreaId, folderId, ...(file.version !== undefined ? { version: file.version } : {}) },
   };
 }
 

--- a/packages/source-dalux/test/mapping.test.ts
+++ b/packages/source-dalux/test/mapping.test.ts
@@ -107,6 +107,26 @@ describe('toSourceFile', () => {
     const file = toSourceFile('fa1', daluxFile({ folderId: undefined }));
     expect(file.containerId).toBe(fileAreaContainerId('fa1'));
   });
+
+  // Control: fileType is decoded by decodeFile and DOES reach the produced
+  // SourceFile (as mimeType), proving the decode-to-map pipeline works.
+  it('surfaces the decoded fileType as mimeType (control: this sibling field does reach output)', () => {
+    const file = toSourceFile('fa1', daluxFile({ fileType: 'application/ifc' }));
+    expect(file.mimeType).toBe('application/ifc');
+  });
+
+  // `DaluxFile.version` is decoded by decodeFile (dalux-types.ts) at the same
+  // cost as fileAreaId/folderId, which this function already forwards via
+  // `meta`. `SourceFile.meta` is documented as "Provider-specific metadata
+  // the host passes through opaquely" (plugin-api types.ts) -- version is
+  // exactly that, and Dalux has no revision-history API to carry it via
+  // SourceRevision (unlike the msgraph/SharePoint provider's version label),
+  // so `meta` is the only channel this value has to reach a consumer. Before
+  // the fix it was decoded and silently dropped.
+  it('surfaces the decoded version in meta, mirroring how fileAreaId/folderId already pass through', () => {
+    const file = toSourceFile('fa1', daluxFile({ version: '3.2' }));
+    expect(file.meta?.version).toBe('3.2');
+  });
 });
 
 interface Thing {


### PR DESCRIPTION
## Summary
- `decodeFile` (packages/source-dalux/src/dalux-types.ts:218) decodes `File.version` from the Dalux API response.
- `toSourceFile` (packages/source-dalux/src/mapping.ts) never forwarded it into the `SourceFile` a host consumes: `fileType`/`fileSize`/`lastModified` all reach the output as `mimeType`/`sizeBytes`/`modifiedAt`, and `fileAreaId`/`folderId` already flow through `SourceFile.meta` — `version` alone was decoded and dropped.
- `SourceFile.meta` is documented (`packages/plugin-api/src/types.ts`) as "Provider-specific metadata the host passes through opaquely". Dalux has no revision-history API to carry a version label through `SourceRevision` the way the msgraph/SharePoint provider does (`packages/source-msgraph/src/mapping.ts`'s `toSourceRevision` uses `Version ${id}` as the revision label), so `meta` is the only channel this value has to reach a consumer.
- Fix: `toSourceFile` now includes `version` in the `meta` object it already builds, omitted when absent (matching the existing `folderId` handling).

## Test plan
- [x] Added a failing test (`packages/source-dalux/test/mapping.test.ts`) asserting `toSourceFile(...).meta?.version` — confirmed RED by stashing the `mapping.ts` change and re-running.
- [x] Added a control test confirming the sibling `fileType -> mimeType` path already reaches the output, proving the decode-to-map pipeline works and only `version` was dropped.
- [x] `pnpm test` in `packages/source-dalux` — 167 passed, 12 skipped.
- [x] `pnpm run typecheck` in `packages/source-dalux` (covers test files) — clean.
- [x] `node scripts/check-module-size.mjs` — OK, no new budget violations.
- [x] Changeset added (`@ifc-lite/source-dalux`: patch).

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436