### PR TITLE
fix(ifcx): read bsi::ifc::prop::Description back into entity.description

### DIFF
--- a/.changeset/ifcx-entity-description-round-trip.md
+++ b/.changeset/ifcx-entity-description-round-trip.md
@@ -2,8 +2,8 @@
 '@ifc-lite/ifcx': patch
 ---
 
-Fix `extractEntities` dropping `IfcEntity.description` when reading an IFCX archive.
+Fix `extractEntities` dropping entity descriptions (`EntityTable.description`, read via `entities.getDescription(id)`) when reading an IFCX archive.
 
-`IfcxWriter`'s `writeEntities` writes `EntityTable.description` out to the same `bsi::ifc::prop::Description` attribute it writes `.name` to under `bsi::ifc::prop::Name` (see its "IFC5 uses bsi::ifc::prop:: namespace for name/description" comment). `entity-extractor.ts`'s `extractEntities` read `bsi::ifc::prop::Name` back via `extractName`, but hardcoded `description` to `''` for every entity instead of reading `bsi::ifc::prop::Description` back the same way — so an entity's description survived nowhere on a round trip through an IFCX archive (write, then read back), even though the writer faithfully emitted it.
+`IfcxWriter` writes `EntityTable.description` out as `bsi::ifc::prop::Description`, alongside the name it writes as `bsi::ifc::prop::Name` (see its "IFC5 uses bsi::ifc::prop:: namespace for name/description" comment). `entity-extractor.ts`'s `extractEntities` read `bsi::ifc::prop::Name` back via `extractName`, but hardcoded `description` to `''` for every entity instead of reading `bsi::ifc::prop::Description` back the same way — so an entity's description survived nowhere on a round trip through an IFCX archive (write, then read back), even though the writer faithfully emitted it.
 
 `extractEntities` now reads `bsi::ifc::prop::Description` via a new `extractDescription`, mirroring `extractName`'s direct-attribute lookup (with no incoming-edge-name fallback, since an edge name is a plausible stand-in for a missing name but not for a missing description).

--- a/.changeset/ifcx-entity-description-round-trip.md
+++ b/.changeset/ifcx-entity-description-round-trip.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/ifcx': patch
+---
+
+Fix `extractEntities` dropping `IfcEntity.description` when reading an IFCX archive.
+
+`IfcxWriter`'s `writeEntities` writes `EntityTable.description` out to the same `bsi::ifc::prop::Description` attribute it writes `.name` to under `bsi::ifc::prop::Name` (see its "IFC5 uses bsi::ifc::prop:: namespace for name/description" comment). `entity-extractor.ts`'s `extractEntities` read `bsi::ifc::prop::Name` back via `extractName`, but hardcoded `description` to `''` for every entity instead of reading `bsi::ifc::prop::Description` back the same way — so an entity's description survived nowhere on a round trip through an IFCX archive (write, then read back), even though the writer faithfully emitted it.
+
+`extractEntities` now reads `bsi::ifc::prop::Description` via a new `extractDescription`, mirroring `extractName`'s direct-attribute lookup (with no incoming-edge-name fallback, since an edge name is a plausible stand-in for a missing name but not for a missing description).

--- a/packages/ifcx/src/entity-extractor.test.ts
+++ b/packages/ifcx/src/entity-extractor.test.ts
@@ -84,4 +84,28 @@ describe('extractEntities', () => {
     assert.strictEqual(entities.hasGeometry(expressId), true);
     assert.strictEqual(entities.getTypeName(expressId), 'Unknown');
   });
+
+  it('reads back bsi::ifc::prop::Description written by the writer, mirroring Name', () => {
+    // writer.ts's writeEntities emits `bsi::ifc::prop::Description` (and
+    // `bsi::ifc::prop::Name`) from `EntityTable.description`/`.name` — see
+    // its comment "IFC5 uses bsi::ifc::prop:: namespace for name/description".
+    // `extractName` above already reads `bsi::ifc::prop::Name` back; this
+    // pins that `Description` gets the same treatment rather than being
+    // hardcoded to `''` on every read.
+    const wall = createNode('wall');
+    wall.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));
+    wall.attributes.set('bsi::ifc::prop::Name', 'Wall-A');
+    wall.attributes.set('bsi::ifc::prop::Description', 'Exterior load-bearing wall');
+
+    const strings = new StringTable();
+    const { entities, pathToId } = extractEntities(new Map([[wall.path, wall]]), strings);
+
+    const wallId = pathToId.get(wall.path);
+    assert.ok(wallId !== undefined);
+    // Control: the sibling field (Name) already reaches the output via the
+    // same attribute-map channel — proves the extractor and this test setup
+    // both work, isolating the failure to Description specifically.
+    assert.strictEqual(entities.getName(wallId), 'Wall-A');
+    assert.strictEqual(entities.getDescription(wallId), 'Exterior load-bearing wall');
+  });
 });

--- a/packages/ifcx/src/entity-extractor.ts
+++ b/packages/ifcx/src/entity-extractor.ts
@@ -82,6 +82,13 @@ export function extractEntities(
     // Extract name from attributes
     const name = extractName(node, incomingEdgeNames.get(node.path) ?? []) ?? node.path.slice(0, 8);
 
+    // Extract description from attributes (writer.ts writes it to the same
+    // `bsi::ifc::prop::Description` attribute it writes name to under
+    // `bsi::ifc::prop::Name` — see writeEntities's "IFC5 uses bsi::ifc::prop::
+    // namespace for name/description" comment). Without this, `description`
+    // survived nowhere on a round trip through an IFCX archive.
+    const description = extractDescription(node);
+
     // Check if has geometry — points count too so the hierarchy panel
     // shows a geometry indicator for scan entries.
     const hasGeometry = (geometryIndex.get(node.path) ?? false) || isPointCloud;
@@ -95,7 +102,7 @@ export function extractEntities(
       typeCode,
       node.path, // Use path as GlobalId
       name,
-      '', // description
+      description,
       typeCode, // objectType
       hasGeometry,
       isType
@@ -135,4 +142,14 @@ function extractName(node: ComposedNode, incomingEdgeNames: string[]): string | 
   }
 
   return null;
+}
+
+/**
+ * Extract entity description from node attributes. Mirrors `extractName`'s
+ * direct-attribute lookup, but has no incoming-edge-name fallback: an edge
+ * name is a plausible stand-in for a missing *name*, not a description.
+ */
+function extractDescription(node: ComposedNode): string {
+  const description = node.attributes.get('bsi::ifc::prop::Description');
+  return typeof description === 'string' ? description : '';
 }


### PR DESCRIPTION
## Summary
- `IfcxWriter.writeEntities` writes `EntityTable.description` out to `bsi::ifc::prop::Description`, the same attribute channel it writes `.name` to under `bsi::ifc::prop::Name`.
- `entity-extractor.ts`'s `extractEntities` reads `Name` back via `extractName`, but hardcoded `description` to `''` for every entity — so an entity's description survived nowhere on a round trip through an IFCX archive, even though the writer faithfully emitted it.
- Adds `extractDescription`, mirroring `extractName`'s direct-attribute lookup (no incoming-edge-name fallback, since an edge name is a plausible stand-in for a missing *name* but not a missing *description*).

## Test plan
- [x] New test in `packages/ifcx/src/entity-extractor.test.ts`: writes `bsi::ifc::prop::Description` on a node and asserts `extractEntities` reads it back into `entities.getDescription`, with `Name` as a passing control on the same node (proves the extractor and channel work, isolating the failure to `Description`).
- [x] Confirmed RED by stashing `packages/ifcx/src/entity-extractor.ts` alone (test file kept) — control passed, new assertion failed with `actual: ''`.
- [x] Confirmed GREEN with the fix restored; full `packages/ifcx` suite (172 tests) passes.
- [x] `pnpm --filter @ifc-lite/ifcx exec tsc --noEmit` clean.
- [x] `node scripts/check-module-size.mjs` — OK, no new budget violations.
- [x] Changeset added (`patch`, `@ifc-lite/ifcx`) — surfaces a dropped value onto an existing field, no exported shape change.

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436