### PR TITLE
feat(renderer): report the picked representation item, on both pick paths (#2985)

### DIFF
--- a/.changeset/olive-melons-repeat.md
+++ b/.changeset/olive-melons-repeat.md
@@ -1,0 +1,24 @@
+---
+"@ifc-lite/renderer": minor
+---
+
+`Renderer.pick()` now reports the `IfcRepresentationItem` behind the surface
+that was clicked, not only the owning product, via a new optional
+`PickResult.geometryItemId` (#2985). A host can drill from a clicked pane or
+frame back to its own entity in the IFC source.
+
+Both pick paths carry it: the flat-mesh GPU pass and the CPU raycast fallback
+that every model over the pick-mesh budget takes. `RaycastHit.geometryItemId`
+is the CPU half of the same value.
+
+The key is ABSENT, never 0, where there is no item identity to report: the
+single merged-mesh fallback, a cached `IfcMappedItem`, a colour-merged batch
+(the id would belong to no one entity), and — for now — GPU-instanced
+occurrences, for which neither pick route carries a per-occurrence item
+channel. Rectangle select still returns bare express ids.
+
+`PickResult` now lives in `pick-resolve.ts` alongside the code that builds it
+and is re-exported from `types.js`; the exported surface is unchanged.
+
+Documented in the rendering guide under "Which representation item was picked",
+including the drill-to-source step and what an absent key means.

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -456,6 +456,8 @@ class Renderer {
 
 Visibility is passed via `render()` options (`hiddenIds`, `isolatedIds`); frustum culling via `enableFrustumCulling` plus a `spatialIndex` from `@ifc-lite/spatial`.
 
+`PickResult` carries `expressId` (the product) plus the optional `modelIndex`, `worldXYZ` and `geometryItemId`. The last is the `IfcRepresentationItem` the clicked surface was built from, and the key is absent, never `0`, where the renderer has no item identity for that hit. See [Which representation item was picked](../guide/rendering.md#which-representation-item-was-picked).
+
 Other exports: `Camera`, `Picker`, `Raycaster`, `SnapDetector`, `BVH`, `RaycastEngine`, `SectionPlaneRenderer`, `PointCloudRenderer`, `FederationRegistry` (multi-model id ranges), and the section-cap / plane-basis helpers.
 
 `Scene` and `Section2DOverlayRenderer` are package-internal from 2.0: reach the scene through `getScene(): SceneContents`, and the 3D line overlays through `Renderer.setLineOverlay`. `PickingManager` is package-internal from 2.0 as well: its constructor takes the now-internal `Scene`, so an exported class nobody could construct would have been worse than no export. Pick through `Renderer.pick` / `Renderer.pickRect`.

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -441,6 +441,8 @@ canvas.addEventListener('click', async (e) => {
 
   const hit = await renderer.pick(x, y);
   if (hit) {
+    // `hit.geometryItemId` narrows this to the representation item the clicked
+    // surface came from, when the renderer has one. See the rendering guide.
     const expressId = hit.expressId;
     console.log(`Selected entity #${expressId}`);
     selectedIds = new Set([expressId]);

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -466,7 +466,14 @@ representation item. It is absent when:
 - the hit landed on a colour-merged batch, which holds many entities at once, so whatever
   item id the batch carries belongs to none of them individually.
 
-Treat the check as the contract: read `geometryItemId` and handle `undefined`, rather than
+Every case in that list is geometry whose item identity was merged away before the pick
+ran. GPU-instanced occurrences are **not** in it: they carry their own item id, because
+the instanced wire format was extended to hold one. See
+[Item ids on instanced occurrences](./geometry.md#item-ids-on-instanced-occurrences) for
+that path, including how to tell a shard that declares no ids from a piece that has none.
+
+The list is the set of merge cases known today, not a closed set. Treat the check as the
+contract: read `geometryItemId` and handle `undefined`, rather than
 deciding up front which geometry can answer.
 
 Rectangle select stays product-level. `Renderer.pickRect` resolves to a `Set<number>` of

--- a/docs/guide/rendering.md
+++ b/docs/guide/rendering.md
@@ -410,6 +410,69 @@ canvas.addEventListener('click', async (e) => {
 });
 ```
 
+### Which representation item was picked
+
+`PickResult.expressId` names the product that was clicked. `PickResult.geometryItemId`
+names the `IfcRepresentationItem` that particular surface was built from, so a host can
+drill from one pane of a curtain wall down to its own entity in the IFC source instead of
+stopping at the wall. It is the same value under the same name as `MeshData.geometryItemId`
+from `@ifc-lite/geometry`, and it is reported on both pick paths: the GPU pick pass, and
+the CPU raycast fallback that every model past the pick-mesh budget takes.
+
+```typescript
+canvas.addEventListener('click', async (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const hit = await renderer.pick(e.clientX - rect.left, e.clientY - rect.top);
+  if (!hit) return;
+
+  console.log(`Product #${hit.expressId} ${store.entities.getTypeName(hit.expressId)}`);
+
+  if (hit.geometryItemId === undefined) {
+    // No item identity available for this hit. Not the same as "this product
+    // has no representation item" - see below.
+    return;
+  }
+
+  // Drill to the item's own STEP line in the original file. `entityIndex.byId`
+  // indexes every entity the file declares, representation items included; the
+  // entity table behind `store.entities` only carries products and relations,
+  // so it cannot resolve an item id.
+  const ref = store.entityIndex.byId.get(hit.geometryItemId);
+  if (ref) {
+    console.log(`Item #${ref.expressId} is a ${ref.type}`);
+    const stepLine = store.source.decodeUtf8(ref.byteOffset, ref.byteOffset + ref.byteLength);
+    console.log(stepLine); // #4711=IFCEXTRUDEDAREASOLID(...);
+  }
+});
+```
+
+`EntityRef` carries the byte range along with the type. When you hold the index as its
+concrete `CompactEntityIndex`, `getByteRange(id)` returns `{ byteOffset, byteLength }`
+on its own, without building an `EntityRef`.
+
+#### When `geometryItemId` is absent
+
+The key is left off the result, never written as `0`. A real id of `0` cannot happen
+because STEP express ids start at `#1`, so `hit.geometryItemId === undefined` is the only
+"no answer" state and it never collides with a valid id.
+
+Absent means **no item identity is available for this hit**, not that the product has no
+representation item. It is absent when:
+
+- the element fell back to the single merged mesh path, where one mesh stands for the
+  whole product;
+- the geometry came through the cached `IfcMappedItem` path, where a representation map's
+  items really are merged into one piece;
+- the hit landed on a colour-merged batch, which holds many entities at once, so whatever
+  item id the batch carries belongs to none of them individually.
+
+Treat the check as the contract: read `geometryItemId` and handle `undefined`, rather than
+deciding up front which geometry can answer.
+
+Rectangle select stays product-level. `Renderer.pickRect` resolves to a `Set<number>` of
+express ids, which has no room for a per-item answer. Drill down with a single click on
+the piece you want.
+
 ### Multi-Selection
 
 ```typescript

--- a/docs/tutorials/building-viewer.md
+++ b/docs/tutorials/building-viewer.md
@@ -243,7 +243,9 @@ export class IfcViewer {
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
 
-      // pick() resolves to a PickResult ({ expressId, ... }) or null
+      // pick() resolves to a PickResult or null. Besides `expressId` (the
+      // product), a hit may carry `geometryItemId`, the representation item
+      // the clicked surface was built from. See the rendering guide.
       const hit = await this.renderer.pick(x, y);
       if (hit) {
         this.onSelect?.(hit.expressId);

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -128,6 +128,7 @@ import { Camera } from './camera.js';
 import { Scene, type InstancedTemplateGPU } from './scene.js';
 import type { SceneContents } from './scene-contents.js';
 import { Picker } from './picker.js';
+import { reportableItemId } from './pick-resolve.js';
 import { MathUtils, viewBasis } from './math.js';
 import type { Vec3 as Vec3Type } from './types.js';
 import { FrustumUtils } from '@ifc-lite/spatial';
@@ -1464,6 +1465,11 @@ export class Renderer {
         this.scene.addMesh({
             expressId: meshData.expressId,
             modelIndex: meshData.modelIndex,  // Preserve modelIndex for multi-model selection
+            // Source item, so a pick can report it (#2985) — via the shared rule,
+            // so this and the CPU raycaster cannot answer one click two ways.
+            // In-tree callers pre-split merged pieces (Scene.getMeshDataPieces
+            // drops the field incidentally); this is public, so it owns the rule.
+            geometryItemId: reportableItemId(meshData, meshData.expressId),
             vertexBuffer,
             indexBuffer,
             indexCount: meshData.indices.length,

--- a/packages/renderer/src/pick-item-id.test.ts
+++ b/packages/renderer/src/pick-item-id.test.ts
@@ -283,6 +283,11 @@ describe('Scene.raycast itself forwards the item id (#2985)', () => {
    */
   function instancedShardAt(z: number): DecodedInstancedShard {
     return {
+      // #2985 landed a required flag on the decoded shard: false says the
+      // encoder wrote a base-stride record, so no occurrence here names an
+      // item. This fixture exercises the express-id half of the instanced CPU
+      // route; the item-id half is pinned on the instancing side.
+      carriesItemIds: false,
       templates: [{
         positions: new Float32Array([-1, 0, -1, 1, 0, -1, 0, 0, 1]),
         normals: new Float32Array([0, -1, 0, 0, -1, 0, 0, -1, 0]),

--- a/packages/renderer/src/pick-item-id.test.ts
+++ b/packages/renderer/src/pick-item-id.test.ts
@@ -1,0 +1,358 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A pick reports the `IfcRepresentationItem` it hit, not just the owning
+ * product (#2985).
+ *
+ * Every case runs on BOTH pick paths, and asserts which one it took. `pick()`
+ * takes the GPU route only while hydrating an individual mesh per visible piece
+ * stays under `MAX_PICK_MESH_CREATION` (500); every model bigger than that
+ * falls to `Scene.raycast`. A fix that reached only the GPU path would pass a
+ * GPU-only test and stay product-level on the common case, and the caller could
+ * not tell that from geometry that genuinely has no item identity — both look
+ * like a valid PickResult with no id. The over-budget half is the load-bearing
+ * one, and the two answering DIFFERENTLY for one click is the failure the
+ * merged-piece case pins down.
+ *
+ * Fixture values are deliberately all different (product 7001, item 4638,
+ * material 99, model 3) so a mis-wiring that reports the product or the
+ * material cannot pass.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { PickingManager } from './picking-manager.js';
+import { resolvePickSample, reportableItemId } from './pick-resolve.js';
+import { decodePickSample } from './point-picker.js';
+import { Scene } from './scene.js';
+import { prepareRayDirInv, raycastTriangles, type BoundingBox } from './scene-raycaster.js';
+import type { Mesh } from './types.js';
+import type { DecodedInstancedShard, MeshData } from '@ifc-lite/geometry';
+
+// WebGPU enum globals Scene's instanced upload reads (not defined in node) —
+// the same stub the other renderer tests install.
+(globalThis as Record<string, unknown>).GPUBufferUsage = {
+  MAP_READ: 1, MAP_WRITE: 2, COPY_SRC: 4, COPY_DST: 8, INDEX: 16,
+  VERTEX: 32, UNIFORM: 64, STORAGE: 128, INDIRECT: 256, QUERY_RESOLVE: 512,
+};
+
+const PRODUCT = 7001;   // the IfcWindow a naive pick collapses to
+const ITEM = 4638;      // the IfcRepresentationItem we want back
+const MATERIAL = 99;    // the disjoint materialId, which must never be reported
+const NEIGHBOUR = 7002; // a second entity sharing one colour-merged piece
+const MODEL = 3;
+
+/** A unit triangle in the z = -5 plane, straight ahead of a ray down -Z. */
+function triangle(extra: Partial<MeshData> = {}): MeshData {
+  return {
+    expressId: PRODUCT,
+    positions: new Float32Array([-1, -1, -5, 1, -1, -5, 0, 1, -5]),
+    normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+    indices: new Uint32Array([0, 1, 2]),
+    color: [1, 1, 1, 1],
+    modelIndex: MODEL,
+    ...extra,
+  } as MeshData;
+}
+
+/** The same triangle at an arbitrary depth, so two hits can be ordered. */
+function triangleAt(z: number, extra: Partial<MeshData> = {}): MeshData {
+  return triangle({ positions: new Float32Array([-1, -1, z, 1, -1, z, 0, 1, z]), ...extra });
+}
+
+const BBOX: BoundingBox = { min: { x: -1, y: -1, z: -5 }, max: { x: 1, y: 1, z: -5 } };
+const RAY_ORIGIN = { x: 0, y: 0, z: 0 };
+const RAY_DIR = { x: 0, y: 0, z: -1 };
+
+function hydrate(piece: MeshData): Mesh {
+  // Stands in for Renderer.createMeshFromData, which needs a live GPUDevice.
+  // It copies exactly the identity fields that method copies, including the
+  // SAME shared `reportableItemId` rule — a stand-in that decided this for
+  // itself would prove nothing about the route it stands in for. That method's
+  // own call is covered against a real device in renderer-render-paths.test.ts.
+  return {
+    expressId: piece.expressId,
+    modelIndex: piece.modelIndex,
+    geometryItemId: reportableItemId(piece, piece.expressId),
+  } as Mesh;
+}
+
+/**
+ * A PickingManager wired to `pieceCount` batched pieces. Under 500 it takes the
+ * GPU route (hydrate + picker); over 500 `prepareBatchedPick` returns 'cpu' and
+ * the manager raycasts instead. The picker stub stands in for the GPU readback
+ * ONLY — the decision of what a sample means is the real `resolvePickSample`,
+ * and the CPU hit is the real `raycastTriangles`.
+ */
+function makeManager(piece: MeshData, pieceCount: number) {
+  const hydrated: Mesh[] = [];
+  const calls = { picker: 0, raycast: 0 };
+  const meshDataMap = new Map<number, MeshData[]>([[PRODUCT, [piece]]]);
+  // Filler ids pad the model past the pick-mesh budget; they own no geometry
+  // the ray can hit, so the hit is always `piece`.
+  const fillerIds = Array.from({ length: pieceCount - 1 }, (_, i) => 900_000 + i);
+  for (const id of fillerIds) meshDataMap.set(id, [{ ...piece, expressId: id } as MeshData]);
+
+  const camera = {
+    unprojectToRay: () => ({ origin: RAY_ORIGIN, direction: RAY_DIR }),
+    getViewProjMatrix: () => ({ m: new Float32Array(16) }),
+  };
+
+  const scene = {
+    getMeshes: () => hydrated,
+    getBatchedMeshes: () => [{ expressIds: [PRODUCT] }],
+    isGeometryDataReleased: () => false,
+    getAllMeshDataExpressIds: () => [...meshDataMap.keys()],
+    getMeshDataPieces: (expressId: number) => meshDataMap.get(expressId),
+    getInstancedTemplates: () => undefined,
+    raycast: () => {
+      calls.raycast += 1;
+      const { rayDirInv, rayDirSign } = prepareRayDirInv(RAY_DIR);
+      return raycastTriangles(
+        RAY_ORIGIN, RAY_DIR, rayDirInv, rayDirSign, meshDataMap,
+        (id) => (id === PRODUCT ? BBOX : null),
+      );
+    },
+  };
+
+  const picker = {
+    pick: async (
+      _x: number, _y: number, _w: number, _h: number, meshes: Mesh[],
+    ) => {
+      calls.picker += 1;
+      const index = meshes.findIndex((m) => m.expressId === PRODUCT);
+      if (index < 0) return null;
+      // A mesh sample is (index + 1) written into the r32uint pick target.
+      return resolvePickSample(decodePickSample(index + 1), meshes, undefined, null);
+    },
+  };
+
+  const canvas = {
+    width: 100,
+    height: 100,
+    getBoundingClientRect: () => ({ width: 100, height: 100 }),
+  };
+
+  const manager = new PickingManager(
+    camera as never,
+    scene as never,
+    picker as never,
+    canvas as HTMLCanvasElement,
+    (p) => hydrated.push(hydrate(p)),
+  );
+  return { manager, calls };
+}
+
+/** Which route a pick took. Asserted everywhere, because a "CPU" test that
+ *  quietly went down the GPU route would prove nothing about the fallback. */
+function assertRoute(calls: { picker: number; raycast: number }, route: 'GPU' | 'CPU'): void {
+  assert.equal(calls.picker, route === 'GPU' ? 1 : 0, `expected the ${route} route`);
+  assert.equal(calls.raycast, route === 'CPU' ? 1 : 0, `expected the ${route} route`);
+}
+
+describe('pick reports the representation item (#2985)', () => {
+  // 1 piece stays under MAX_PICK_MESH_CREATION (500) and takes the GPU route;
+  // 900 is over it, so prepareBatchedPick falls to Scene.raycast. Every case
+  // runs BOTH, because a fix on one route alone is exactly the failure mode.
+  for (const [label, count] of [['GPU', 1], ['CPU', 900]] as const) {
+    it(`${label} path: the item id comes back, and is not the product or the material id`, async () => {
+      const { manager, calls } = makeManager(triangle({ geometryItemId: ITEM, materialId: MATERIAL }), count);
+      const result = await manager.pick(50, 50);
+      assertRoute(calls, label);
+      assert.equal(result?.expressId, PRODUCT);
+      assert.equal(result?.geometryItemId, ITEM, 'the pick collapsed to the product');
+      assert.notEqual(result?.geometryItemId, PRODUCT);
+      assert.notEqual(result?.geometryItemId, MATERIAL);
+      assert.equal(result?.modelIndex, MODEL);
+    });
+
+    it(`${label} path: a piece with no item identity leaves the key ABSENT`, async () => {
+      const { manager, calls } = makeManager(triangle(), count);
+      const result = await manager.pick(50, 50);
+      assertRoute(calls, label);
+      assert.equal(result?.expressId, PRODUCT);
+      // Absent, not 0 and not present-but-undefined: a host reading
+      // `'geometryItemId' in result` must be able to tell "no item here" from
+      // an item whose id happens to be falsy.
+      assert.ok(result && !('geometryItemId' in result), 'expected the key to be absent');
+      assert.notEqual(result?.geometryItemId, 0);
+    });
+
+    it(`${label} path: a colour-merged piece reports no item id for any of its entities`, async () => {
+      // Genuinely merged: the piece's three vertices belong to TWO entities, so
+      // whatever item id it carries describes neither of them individually.
+      // Vertex 0 is PRODUCT, which is what the raycaster's per-triangle entity
+      // filter reads, so the ray still hits.
+      //
+      // The CPU route is where a real Scene hands out a raw merged piece: it
+      // raycasts `meshDataMap` directly. The GPU route in production would go
+      // through Scene.getMeshDataPieces first, which splits merged pieces per
+      // entity; the stub here does not, so this pins the shared rule on both
+      // routes rather than claiming the real GPU route sees merged geometry.
+      const merged = triangle({
+        geometryItemId: ITEM,
+        entityIds: new Uint32Array([PRODUCT, NEIGHBOUR, NEIGHBOUR]),
+      });
+      const { manager, calls } = makeManager(merged, count);
+      const result = await manager.pick(50, 50);
+      assertRoute(calls, label);
+      assert.equal(result?.expressId, PRODUCT);
+      assert.ok(result && !('geometryItemId' in result), 'a merged batch id must not be attributed');
+    });
+
+    it(`${label} path: an authored single-entity piece reports its item id despite carrying entityIds`, async () => {
+      // The counter-case to the one above, and the reason the rule scans for a
+      // FOREIGN id instead of testing whether `entityIds` exists at all: an
+      // element authored in-session tags EVERY vertex with its own id so
+      // picking can find it. All-same-id attributes unambiguously, so
+      // withholding here would be a false negative a host cannot tell from "no
+      // item on this geometry". `Scene.translateFlatMeshesForEntity` already
+      // draws the line this way, having first drawn it the other way and frozen
+      // authored elements under the gizmo.
+      const authored = triangle({
+        geometryItemId: ITEM,
+        entityIds: new Uint32Array([PRODUCT, PRODUCT, PRODUCT]),
+      });
+      const { manager, calls } = makeManager(authored, count);
+      const result = await manager.pick(50, 50);
+      assertRoute(calls, label);
+      assert.equal(result?.expressId, PRODUCT);
+      assert.equal(result?.geometryItemId, ITEM, 'an all-same-id piece is not a merge');
+    });
+  }
+
+  it('an instanced occurrence reports no item id, and says so by absence', () => {
+    // Lane A territory: the instanced pick shader writes the express id straight
+    // into the sample, so there is no per-occurrence item channel to read.
+    // INSTANCED_PICK_MARKER (bit 30) | expressId.
+    const decoded = decodePickSample(0x40000000 | PRODUCT);
+    assert.equal(decoded.kind, 'instanced');
+    const result = resolvePickSample(decoded, [], undefined, null);
+    assert.equal(result?.expressId, PRODUCT);
+    assert.ok(result && !('geometryItemId' in result));
+  });
+});
+
+/**
+ * `Scene.raycast` is the CPU route's OWN forwarding step, and until now nothing
+ * ran it: the cases above stub `scene.raycast` and drive `raycastTriangles`
+ * directly, so the one function that has to carry `geometryItemId` off a
+ * `RaycastHit` and out of the Scene was never executed by a test.
+ *
+ * That is a silent gap, not a loud one. Rewriting the tail as
+ * `return normalise(flatHit ?? instancedHit)` — the shape a "give the two
+ * branches one exit" refactor produces — rebuilds the hit as
+ * `{ expressId, distance, modelIndex }` and drops the field, and the whole
+ * renderer suite stayed green. What ships from that is every model over
+ * MAX_PICK_MESH_CREATION silently back at product level, which is exactly the
+ * failure #2985 exists to prevent and which a host cannot tell from geometry
+ * that genuinely has no item identity.
+ *
+ * So these run the REAL Scene: real `addMeshData` / `addInstancedShard`, real
+ * bounding-box cache, real `Scene.raycast`. Both of its branches, and the
+ * closest-of-two comparison between them in both directions, because that
+ * comparison is a second place a rebuild could land.
+ */
+describe('Scene.raycast itself forwards the item id (#2985)', () => {
+  const INSTANCED = 7003; // an instanced-only occurrence, absent from meshDataMap
+
+  /** `addInstancedShard` only asks the device for sized, mapped buffers, so a
+   *  stub runs the real interleave / bounds-fold / entity-map code. */
+  function fakeDevice(): GPUDevice {
+    return {
+      limits: { maxBufferSize: 1 << 30, maxStorageBufferBindingSize: 1 << 30 },
+      createBuffer: (desc: { size: number }) => {
+        const backing = new ArrayBuffer(desc.size);
+        return { size: desc.size, getMappedRange: () => backing, unmap() {}, destroy() {} };
+      },
+      queue: { writeBuffer: () => {} },
+    } as unknown as GPUDevice;
+  }
+
+  /**
+   * One occurrence of the SAME fixture triangle, at `z` in world space.
+   *
+   * Written in IFC Z-up, because a shard is decoder output: the upload converts
+   * to the viewer's Y-up ((x, y, z) -> (x, z, -y)) and applies it to template
+   * vertices and occurrence translation alike. The Z-up preimages below come
+   * back out of `getInstancedMeshDataPieces` as exactly `triangleAt(z)`, so the
+   * flat and instanced branches are compared on identical geometry.
+   */
+  function instancedShardAt(z: number): DecodedInstancedShard {
+    return {
+      templates: [{
+        positions: new Float32Array([-1, 0, -1, 1, 0, -1, 0, 0, 1]),
+        normals: new Float32Array([0, -1, 0, 0, -1, 0, 0, -1, 0]),
+        indices: new Uint32Array([0, 1, 2]),
+        origin: [0, 0, 0] as [number, number, number],
+      }],
+      instances: [{
+        templateIndex: 0,
+        entityId: INSTANCED,
+        color: [1, 1, 1, 1] as [number, number, number, number],
+        // Row-major (translation in the last column), Z-up (0, -z, 0), which
+        // converts to the Y-up (0, 0, z) the ray is aimed down.
+        transform: new Float32Array([1, 0, 0, 0, 0, 1, 0, -z, 0, 0, 1, 0, 0, 0, 0, 1]),
+      }],
+    };
+  }
+
+  it('flat branch: a hit carries its geometryItemId out of Scene.raycast', () => {
+    const scene = new Scene();
+    scene.addMeshData(triangle({ geometryItemId: ITEM, materialId: MATERIAL }));
+
+    const hit = scene.raycast(RAY_ORIGIN, RAY_DIR);
+    assert.equal(hit?.expressId, PRODUCT);
+    assert.equal(hit?.geometryItemId, ITEM, 'Scene.raycast dropped the item id');
+    assert.notEqual(hit?.geometryItemId, PRODUCT);
+    assert.notEqual(hit?.geometryItemId, MATERIAL);
+    assert.equal(hit?.modelIndex, MODEL);
+  });
+
+  it('flat branch: a piece with no item identity comes back undefined, not 0', () => {
+    const scene = new Scene();
+    scene.addMeshData(triangle());
+
+    const hit = scene.raycast(RAY_ORIGIN, RAY_DIR);
+    assert.equal(hit?.expressId, PRODUCT);
+    assert.equal(hit?.geometryItemId, undefined);
+  });
+
+  it('instanced branch: an occurrence is hit and reports no item id', () => {
+    const scene = new Scene();
+    scene.addInstancedShard(fakeDevice(), instancedShardAt(-5), MODEL);
+
+    const hit = scene.raycast(RAY_ORIGIN, RAY_DIR);
+    // The branch really ran: this id lives only in the instanced shard.
+    assert.equal(hit?.expressId, INSTANCED, 'the instanced branch did not produce the hit');
+    // Absent by construction, not by accident: getInstancedMeshDataPieces
+    // synthesises MeshData from a shared template that holds no per-occurrence
+    // item identity. Fixing the instanced pick shader does not change this.
+    assert.equal(hit?.geometryItemId, undefined);
+  });
+
+  it('closest-of-two: the nearer FLAT hit wins and keeps its item id', () => {
+    const scene = new Scene();
+    scene.addMeshData(triangleAt(-5, { geometryItemId: ITEM }));   // t = 5
+    scene.addInstancedShard(fakeDevice(), instancedShardAt(-9), MODEL); // t = 9
+
+    const hit = scene.raycast(RAY_ORIGIN, RAY_DIR);
+    assert.equal(hit?.expressId, PRODUCT, 'the nearer flat hit must win');
+    assert.equal(hit?.geometryItemId, ITEM, 'the comparison dropped the item id');
+  });
+
+  it('closest-of-two: a nearer INSTANCED hit wins, and still reports no item id', () => {
+    const scene = new Scene();
+    scene.addMeshData(triangleAt(-5, { geometryItemId: ITEM }));   // t = 5
+    scene.addInstancedShard(fakeDevice(), instancedShardAt(-2), MODEL); // t = 2
+
+    const hit = scene.raycast(RAY_ORIGIN, RAY_DIR);
+    assert.equal(hit?.expressId, INSTANCED, 'the nearer instanced hit must win');
+    // The other direction of the same comparison: the flat hit's ITEM must not
+    // leak onto the occurrence that beat it.
+    assert.equal(hit?.geometryItemId, undefined);
+  });
+});

--- a/packages/renderer/src/pick-resolve.ts
+++ b/packages/renderer/src/pick-resolve.ts
@@ -1,0 +1,194 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * What a pick resolves to, and how a decoded pick sample becomes one.
+ *
+ * Split out of `picker.ts` so this half is reachable without a GPU: everything
+ * around it (render the pick pass, read back a texel, unproject the depth)
+ * needs a device, while deciding WHICH entity — and since #2985 which
+ * representation item — a sample landed on is pure table lookup.
+ *
+ * Every import here is type-only, so nothing is emitted and the `PickResult`
+ * re-export in `types.ts` is not a runtime cycle.
+ */
+
+import type { MeshData } from '@ifc-lite/geometry';
+
+import type { DecodedPickSample, PointPickNode } from './point-picker.js';
+import type { Mesh } from './types.js';
+
+/**
+ * Result from GPU picking
+ * For multi-model support, includes both expressId and modelIndex
+ */
+export interface PickResult {
+  expressId: number;
+  modelIndex?: number;  // Index of the model this entity belongs to
+  /**
+   * World-space XYZ of the picked surface point. Optional because the
+   * pick path can skip depth readback for callers that only need the
+   * entityId (e.g. selection state). Recovered by sampling the pick
+   * pass's depth texture at the click position and unprojecting.
+   */
+  worldXYZ?: { x: number; y: number; z: number };
+  /**
+   * The `IfcRepresentationItem` the picked surface was built from (#2985), so
+   * a host can drill from a clicked pane or frame down to its own entity
+   * instead of stopping at the owning product. Same name and same value as
+   * `MeshData.geometryItemId`; it is NEVER a material id — `materialId` carries
+   * that case upstream and the two are never both set (#3199).
+   *
+   * The KEY IS ABSENT, never 0, wherever the renderer has no item identity to
+   * report, and those absences do not all mean the same thing:
+   *   - the single merged-mesh fallback and a cached `IfcMappedItem` genuinely
+   *     have none, mirroring `MeshData.geometryItemId` itself;
+   *   - a colour-merged batch holds many entities, so whatever item id it
+   *     carries belongs to none of them individually and is not reported;
+   *   - a GPU-instanced occurrence has none YET, on EITHER pick route and for
+   *     two INDEPENDENT reasons. On the GPU route the instanced pick shader
+   *     writes the express id straight into the sample, with no per-instance
+   *     item channel to look one up from. The CPU raycast never runs that
+   *     shader: it loses the field earlier, in the synthetic `MeshData` that
+   *     `Scene.getInstancedMeshDataPieces` materialises per occurrence. Fixing
+   *     the shader alone leaves the CPU half product-level. Deliberate on both
+   *     sides, not an oversight.
+   * Rectangle/marquee pick returns bare express ids and never builds a
+   * `PickResult` at all, so it cannot report this either.
+   */
+  geometryItemId?: number;
+}
+
+/**
+ * The representation item a piece of geometry may report on a pick, or
+ * `undefined` when it may not (#2985).
+ *
+ * A piece carrying per-vertex `entityIds` is registered under every entity it
+ * names (`Scene.addMeshData`), so where it genuinely holds more than
+ * `expressId` its item id describes none of them individually and is withheld.
+ *
+ * Carrying `entityIds` is NOT by itself evidence of that, which is why this
+ * scans for a FOREIGN id rather than testing the field's presence: an authored
+ * single-entity mesh (a slab/space/wall added in-session) tags every vertex
+ * with its own id for picking, so all-same-id attributes unambiguously and is
+ * reported. `Scene.translateFlatMeshesForEntity` draws the same line the same
+ * way, and got there the hard way — a "skip on any entityIds at all" test there
+ * froze authored elements under the gizmo. The two must agree about what a
+ * shared piece is.
+ *
+ * Latent, not live: no in-tree producer sets `MeshData.entityIds` at all today
+ * (`packages/`, `apps/`, and the Rust crates were all checked), so only
+ * hand-built fixtures reach the scan. It is written to match the sibling rule,
+ * not to fix an observed misattribution.
+ *
+ * ONE home, because the two pick routes reach that rule from different sides
+ * and must not answer one click two ways:
+ *   - CPU (`raycastTriangles`, every model over `MAX_PICK_MESH_CREATION`) walks
+ *     `Scene.meshDataMap` DIRECTLY, so it sees raw merged pieces and the rule
+ *     is what stops it attributing a batch's id to one entity;
+ *   - GPU (`Renderer.createMeshFromData`) is fed by `Scene.getMeshDataPieces`,
+ *     which splits a merged piece per entity first — and its rebuilt literal
+ *     happens to carry neither `entityIds` nor `geometryItemId` forward, so
+ *     today it strips the id as a SIDE EFFECT rather than by any stated rule.
+ *     `createMeshFromData` is public and applies the rule itself instead of
+ *     inheriting that accident.
+ *
+ * @param expressId - the entity the pick is about to attribute the piece to.
+ *   Not `piece.expressId`: a merged piece is looked up under every id it names,
+ *   so the raycaster's map key is the one that decides, not the piece's own.
+ */
+export function reportableItemId(
+  piece: Pick<MeshData, 'entityIds' | 'geometryItemId'>,
+  expressId: number,
+): number | undefined {
+  const ids = piece.entityIds;
+  if (ids) {
+    for (let i = 0; i < ids.length; i++) {
+      if (ids[i] !== expressId) return undefined;
+    }
+  }
+  return piece.geometryItemId;
+}
+
+/**
+ * The mesh a mesh-kind sample landed on, or `undefined` when the index is out
+ * of range. The pick shader writes (actual index + 1), and THIS is the only
+ * place that offset is spelled out.
+ */
+function meshForSample(decoded: DecodedPickSample, meshes: readonly Mesh[]): Mesh | undefined {
+  return meshes[decoded.meshIndexPlusOne - 1];
+}
+
+/**
+ * Which entity a decoded sample landed on, or `null` when it landed on nothing.
+ *
+ * The sample taxonomy lives here — the three ways a texel can name an entity,
+ * and the mesh case's (index + 1) offset via {@link meshForSample} — so single
+ * click and marquee cannot answer one texel two ways.
+ *
+ * Separate from {@link resolvePickSample} because a `PickResult` is the wrong
+ * unit for a marquee: `Picker.pickRect` wants nothing but the id, once per
+ * non-zero texel. Routing it through a full result allocated one object per
+ * texel to read `.expressId` off and drop — millions of them on a
+ * full-viewport rect over a HiDPI canvas, and the resulting GC dominated the
+ * whole rect. Keep the dispatch shared and the allocation out of the loop.
+ */
+export function resolvePickedExpressId(
+  decoded: DecodedPickSample,
+  meshes: readonly Mesh[],
+): number | null {
+  if (decoded.kind === 'none') return null;
+  // The point and instanced shaders write the express id straight into the
+  // sample (federated globalId for points), so there is no table to look up.
+  if (decoded.kind === 'point') return decoded.pointExpressId;
+  if (decoded.kind === 'instanced') return decoded.instanceExpressId;
+  return meshForSample(decoded, meshes)?.expressId ?? null;
+}
+
+/**
+ * Map one decoded pick sample onto the entity behind it, with everything a
+ * single click reports about it.
+ *
+ * `worldXYZ` is the already-unprojected hit position (null when the depth
+ * readback found nothing to unproject); `meshes` is the same array, in the same
+ * order, that the pick pass drew, because a mesh sample is an index into it.
+ */
+export function resolvePickSample(
+  decoded: DecodedPickSample,
+  meshes: readonly Mesh[],
+  pointNodes: ReadonlyArray<PointPickNode> | undefined,
+  worldXYZ: { x: number; y: number; z: number } | null,
+): PickResult | null {
+  const expressId = resolvePickedExpressId(decoded, meshes);
+  if (expressId === null) return null;
+  const world = worldXYZ ?? undefined;
+
+  if (decoded.kind === 'point') {
+    // Look up the asset for modelIndex — the only thing the id alone can't say.
+    const node = pointNodes?.find((n) => (n.expressId >>> 0) === expressId);
+    return { expressId, modelIndex: node?.modelIndex, worldXYZ: world };
+  }
+
+  if (decoded.kind === 'instanced') {
+    // Instanced occurrence. modelIndex is not tracked per occurrence yet
+    // (single-model instancing), and neither is geometryItemId: there is no
+    // per-occurrence item channel to read one out of. The CPU raycast half
+    // drops it separately, in Scene.getInstancedMeshDataPieces.
+    return { expressId, modelIndex: undefined, worldXYZ: world };
+  }
+
+  // Mesh hit. The id above already came off this entry (and range-checked it);
+  // re-reading it is what reaches the rest of the identity a bare id can't hold.
+  const mesh = meshForSample(decoded, meshes);
+  if (!mesh) return null;
+  return {
+    expressId,
+    modelIndex: mesh.modelIndex,
+    worldXYZ: world,
+    // Spread, not `geometryItemId: mesh.geometryItemId`: a mesh with no item
+    // identity must leave the key OFF, so a caller can tell "no item here" from
+    // "an item whose id is 0" and from a pick that never ran.
+    ...(mesh.geometryItemId !== undefined ? { geometryItemId: mesh.geometryItemId } : {}),
+  };
+}

--- a/packages/renderer/src/pick-resolve.ts
+++ b/packages/renderer/src/pick-resolve.ts
@@ -46,14 +46,13 @@ export interface PickResult {
    *     have none, mirroring `MeshData.geometryItemId` itself;
    *   - a colour-merged batch holds many entities, so whatever item id it
    *     carries belongs to none of them individually and is not reported;
-   *   - a GPU-instanced occurrence has none YET, on EITHER pick route and for
-   *     two INDEPENDENT reasons. On the GPU route the instanced pick shader
-   *     writes the express id straight into the sample, with no per-instance
-   *     item channel to look one up from. The CPU raycast never runs that
-   *     shader: it loses the field earlier, in the synthetic `MeshData` that
-   *     `Scene.getInstancedMeshDataPieces` materialises per occurrence. Fixing
-   *     the shader alone leaves the CPU half product-level. Deliberate on both
-   *     sides, not an oversight.
+   *   - a GPU-instanced occurrence has none on the GPU route ONLY. The
+   *     instanced pick shader writes the express id straight into the sample,
+   *     with no per-instance item channel to look one up from. The CPU raycast
+   *     never runs that shader, and since #2985 carried the id onto instanced
+   *     occurrences it DOES report one: `Scene.getInstancedMeshDataPieces`
+   *     stamps `geometryItemId` on each synthetic `MeshData` it materialises.
+   *     So the two routes disagree here, and only the shader half is open.
    * Rectangle/marquee pick returns bare express ids and never builds a
    * `PickResult` at all, so it cannot report this either.
    */
@@ -172,9 +171,11 @@ export function resolvePickSample(
 
   if (decoded.kind === 'instanced') {
     // Instanced occurrence. modelIndex is not tracked per occurrence yet
-    // (single-model instancing), and neither is geometryItemId: there is no
-    // per-occurrence item channel to read one out of. The CPU raycast half
-    // drops it separately, in Scene.getInstancedMeshDataPieces.
+    // (single-model instancing), and neither is geometryItemId: this shader
+    // has no per-occurrence item channel to read one out of. Note the CPU
+    // raycast route DOES report it for the same geometry, because
+    // Scene.getInstancedMeshDataPieces stamps it onto the pieces it
+    // materialises (#2985). This is the remaining half of that gap.
     return { expressId, modelIndex: undefined, worldXYZ: world };
   }
 

--- a/packages/renderer/src/picker.ts
+++ b/packages/renderer/src/picker.ts
@@ -8,6 +8,7 @@
 
 import { WebGPUDevice } from './device.js';
 import type { Mesh, PickResult, PickClipState } from './types.js';
+import { resolvePickSample, resolvePickedExpressId } from './pick-resolve.js';
 import type { InstancedTemplateGPU } from './scene.js';
 import { PointPicker, decodePickSample, type PointPickNode } from './point-picker.js';
 import { packPickUniforms } from './pick-uniforms.js';
@@ -486,37 +487,9 @@ export class Picker {
     // gives the world hit position directly.
     const worldXYZ = unprojectPickSample(viewProj, sampleX, sampleY, width, height, depth);
 
-    if (decoded.kind === 'point') {
-      // Look up the asset for modelIndex. expressId is already the
-      // federated globalId (vertex shader writes it from the per-point
-      // attribute, no lookup table needed).
-      const node = pointNodes?.find((n) => (n.expressId >>> 0) === decoded.pointExpressId);
-      return {
-        expressId: decoded.pointExpressId,
-        modelIndex: node?.modelIndex,
-        worldXYZ: worldXYZ ?? undefined,
-      };
-    }
-
-    if (decoded.kind === 'instanced') {
-      // Instanced occurrence — the shader wrote the express id directly into the
-      // pick value (no mesh-index lookup). modelIndex is not tracked per
-      // occurrence yet (single-model instancing).
-      return {
-        expressId: decoded.instanceExpressId,
-        modelIndex: undefined,
-        worldXYZ: worldXYZ ?? undefined,
-      };
-    }
-
-    // Mesh hit — meshIndex is (actual index + 1), already validated > 0.
-    const mesh = meshes[decoded.meshIndexPlusOne - 1];
-    if (!mesh) return null;
-    return {
-      expressId: mesh.expressId,
-      modelIndex: mesh.modelIndex,
-      worldXYZ: worldXYZ ?? undefined,
-    };
+    // Which entity (and which representation item) the sample landed on is a
+    // pure lookup — see resolvePickSample.
+    return resolvePickSample(decoded, meshes, pointNodes, worldXYZ);
   }
 
   updateUniforms(viewProj: Float32Array, clip?: PickClipState | null): void {
@@ -606,18 +579,21 @@ export class Picker {
       for (let x = 0; x < rectW; x++) {
         const sample = view[row + x];
         if (sample === 0) continue;
-        const decoded = decodePickSample(sample);
-        if (decoded.kind === 'none') continue;
-        if (decoded.kind === 'point') {
-          ids.add(decoded.pointExpressId);
-        } else if (decoded.kind === 'instanced') {
-          // Instanced samples carry the express id directly (meshIndexPlusOne === 0),
-          // so rect/shift-drag select must read it here too — not just single-click.
-          ids.add(decoded.instanceExpressId);
-        } else {
-          const mesh = meshes[decoded.meshIndexPlusOne - 1];
-          if (mesh) ids.add(mesh.expressId);
-        }
+        // Same three-way decode single-click uses — including the instanced
+        // case (the shader writes the express id straight into the sample) and
+        // the mesh case's (index + 1) offset. Both live in pick-resolve.ts and
+        // must not be re-implemented here.
+        //
+        // The bare id, not a PickResult: this returns a Set<expressId>, which
+        // has no room for a per-item result — a marquee that hits three panes
+        // of one curtain wall is one entry — and allocating a result per
+        // non-zero texel just to read `.expressId` off it dominated the rect.
+        // Single-click pick is the per-item surface.
+        //
+        // modelIndex is dropped for the same reason, which is why a point
+        // sample's owning asset (a linear scan, once per texel) is not resolved.
+        const expressId = resolvePickedExpressId(decodePickSample(sample), meshes);
+        if (expressId !== null) ids.add(expressId);
       }
     }
     readBuffer.unmap();

--- a/packages/renderer/src/picking-manager.ts
+++ b/packages/renderer/src/picking-manager.ts
@@ -190,10 +190,22 @@ export class PickingManager {
             const ray = this.camera.unprojectToRay(scaledX, scaledY, this.canvas.width, this.canvas.height);
             const hit = this.scene.raycast(ray.origin, ray.direction, options?.hiddenIds, options?.isolatedIds, clip);
             if (!hit) return null;
-            // CPU raycasting returns expressId and modelIndex
+            // The CPU fallback is the COMMON path — anything over
+            // MAX_PICK_MESH_CREATION lands here — so it must report the picked
+            // item, not just its product. Carrying expressId/modelIndex only is
+            // how a pick silently degrades to product-level on a big model
+            // while looking identical to a genuine "no item here" (#2985).
+            //
+            // NOT full parity with the GPU path: `worldXYZ` is still omitted,
+            // as it was before #2985. `Scene.raycast` returns the hit distance
+            // and the world point is rayOrigin + t*rayDir, so it is computable
+            // here, but filling it in is a behaviour change (HoverTooltip shows
+            // a world coordinate only when the key is set, so today it is blank
+            // above the pick-mesh budget) and belongs to its own issue.
             return {
                 expressId: hit.expressId,
                 modelIndex: hit.modelIndex,
+                ...(hit.geometryItemId !== undefined ? { geometryItemId: hit.geometryItemId } : {}),
             };
         }
 

--- a/packages/renderer/src/renderer-render-paths.test.ts
+++ b/packages/renderer/src/renderer-render-paths.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import { Renderer } from './index.js';
 import { Picker } from './picker.js';
 import type { MeshData } from '@ifc-lite/geometry';
-import type { RenderOptions, BatchedMesh } from './types.js';
+import type { RenderOptions, BatchedMesh, Mesh } from './types.js';
 import type { Scene } from './scene.js';
 
 /**
@@ -570,6 +570,67 @@ describe('visibility epoch drives the batched draw path', () => {
 });
 
 describe('hydrated selection meshes across renders', () => {
+    // #2985. Renderer.createMeshFromData is the only place a MeshData becomes an
+    // individual GPU Mesh, and it is what the GPU pick pass indexes into — so a
+    // representation item dropped HERE cannot be reported by any pick, however
+    // correct picker.ts is. Tested through the real render() + real Scene
+    // because the method needs a device; the rest of the pick contract lives in
+    // pick-item-id.test.ts.
+    it('hydration carries the source geometryItemId onto the individual mesh', () => {
+        const ITEM = 4638; // deliberately unlike the expressId below
+        const h = makeHarness();
+        const scene = sceneOf(h);
+        const device = h.renderer['device'].getDevice();
+        const withItem = { ...triangle(7, GREY), geometryItemId: ITEM } as MeshData;
+        scene.appendToBatches([withItem, triangle(8, RED)], device, h.renderer['pipeline'] as never, false);
+        for (const b of scene.getBatchedMeshes()) b.bounds = undefined;
+
+        h.render({ selectedId: 7 });
+        const hydrated = scene.getMeshes().filter((m) => m.hydrated && m.expressId === 7);
+        assert.strictEqual(hydrated.length, 1, 'selecting the entity hydrates its mesh');
+        assert.strictEqual(hydrated[0].geometryItemId, ITEM);
+
+        // And a piece with no item identity leaves the key readable as absent
+        // rather than as a plausible id.
+        h.render({ selectedId: 8 });
+        const plain = scene.getMeshes().filter((m) => m.hydrated && m.expressId === 8);
+        assert.strictEqual(plain.length, 1);
+        assert.strictEqual(plain[0].geometryItemId, undefined);
+    });
+
+    // A colour-merged piece's item id belongs to no single entity in it, so
+    // hydration must withhold it exactly as the CPU raycaster does — one click
+    // must not answer two ways either side of the pick-mesh budget (#2985).
+    //
+    // Called DIRECTLY, not through a render: both in-tree callers reach this
+    // method via Scene.getMeshDataPieces, which splits a merged piece per
+    // entity and — as a side effect of rebuilding the literal, not by any
+    // stated rule — carries neither entityIds nor geometryItemId forward. This
+    // method is public, so it owns the rule rather than inheriting that
+    // accident, and a raw merged MeshData is what tests the rule.
+    it('createMeshFromData withholds a colour-merged batch id, matching the CPU raycast', () => {
+        const ITEM = 4638;
+        const h = makeHarness();
+        const scene = sceneOf(h);
+        const merged = {
+            ...triangle(9, GREY),
+            geometryItemId: ITEM,
+            entityIds: new Uint32Array([9, 10, 10]),
+        } as MeshData;
+        h.renderer.createMeshFromData(merged);
+
+        const made = scene.getMeshes().filter((m) => m.expressId === 9);
+        assert.strictEqual(made.length, 1, 'the mesh was created');
+        assert.strictEqual(made[0].geometryItemId, undefined);
+
+        // Positive control: the same call on an UNMERGED piece does report it,
+        // so the assertion above is the merge rule and not a dead field.
+        h.renderer.createMeshFromData({ ...triangle(11, GREY), geometryItemId: ITEM } as MeshData);
+        const plainItem = scene.getMeshes().filter((m) => m.expressId === 11);
+        assert.strictEqual(plainItem.length, 1);
+        assert.strictEqual(plainItem[0].geometryItemId, ITEM);
+    });
+
     it('selection thrash: earlier selections are disposed, the current one is kept', () => {
         const h = makeHarness();
         seedBatches(h);
@@ -845,6 +906,72 @@ describe('pick path survives the device dying mid-readback (#1901)', () => {
         for (const buf of readbacks) {
             assert.ok(buf.destroyed > 0, 'a readback buffer survived the rethrow — leaked');
         }
+    });
+});
+
+/**
+ * The other half of #2985's GPU route: `Picker.pick` is where a decoded texel
+ * becomes the `PickResult` a host sees, and every other test of that mapping
+ * stubs `picker.pick` and calls `resolvePickSample` directly. One
+ * unconditional call, so the exposure is far smaller than `Scene.raycast`'s —
+ * but the harness already runs a REAL `Picker` against the stub GPU, so
+ * closing it costs one test rather than a browser lane.
+ *
+ * The readback is seeded by hand: the stub's pick target is zero-filled, which
+ * decodes as "no hit" and returns before the mapping runs at all. Writing
+ * (index + 1) into the parked colour readback is what the pick pass would have
+ * written for a hit on mesh 0.
+ */
+describe('Picker.pick maps a real readback onto the picked item (#2985)', () => {
+    it('carries the hit mesh\'s geometryItemId out onto the PickResult', async () => {
+        const ITEM = 4638;
+        const h = makeHarness();
+        const picker = new Picker(h.renderer['device'], 256, 256);
+        const mesh = {
+            expressId: 7,
+            modelIndex: 2,
+            geometryItemId: ITEM,
+            vertexBuffer: {},
+            indexBuffer: {},
+            indexCount: 3,
+        } as unknown as Mesh;
+
+        const before = h.stats.createdBuffers.length;
+        h.knobs.deferMaps = true;
+        const inflight = picker.pick(4, 4, 256, 256, [mesh], new Float32Array(16));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        assert.ok(h.pendingMaps() > 0, 'the pick must be parked on its readbacks');
+
+        // The colour readback is the pick's only 256-byte buffer (the depth one
+        // is a full image); `pick` reads texel 0 of it as a u32.
+        const colour = h.stats.createdBuffers.slice(before).filter((b) => b.size === 256);
+        assert.strictEqual(colour.length, 1, 'expected exactly one colour readback');
+        new Uint32Array(colour[0].getMappedRange())[0] = 1; // mesh 0, written as index + 1
+
+        h.settlePendingMaps();
+        const result = await inflight;
+        assert.strictEqual(result?.expressId, 7);
+        assert.strictEqual(result?.modelIndex, 2);
+        assert.strictEqual(result?.geometryItemId, ITEM, 'the pick collapsed to the product');
+    });
+
+    it('leaves the key absent for a mesh with no item identity', async () => {
+        const h = makeHarness();
+        const picker = new Picker(h.renderer['device'], 256, 256);
+        const mesh = {
+            expressId: 7, modelIndex: 2, vertexBuffer: {}, indexBuffer: {}, indexCount: 3,
+        } as unknown as Mesh;
+
+        const before = h.stats.createdBuffers.length;
+        h.knobs.deferMaps = true;
+        const inflight = picker.pick(4, 4, 256, 256, [mesh], new Float32Array(16));
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+        const colour = h.stats.createdBuffers.slice(before).filter((b) => b.size === 256);
+        new Uint32Array(colour[0].getMappedRange())[0] = 1;
+
+        h.settlePendingMaps();
+        const result = await inflight;
+        assert.ok(result && !('geometryItemId' in result), 'expected the key to be absent');
     });
 });
 

--- a/packages/renderer/src/scene-raycaster.ts
+++ b/packages/renderer/src/scene-raycaster.ts
@@ -9,13 +9,20 @@
  * No dependency on Scene internal state.
  */
 
+import type { MeshData } from '@ifc-lite/geometry';
 import type { Vec3, PickClipState } from './types.js';
 import { MathUtils } from './math.js';
+import { reportableItemId } from './pick-resolve.js';
 
 export interface BoundingBox {
   min: Vec3;
   max: Vec3;
 }
+
+/** The `MeshData` fields the triangle raycast reads. Taken from the real type,
+ *  never re-spelled inline: an ad-hoc structural copy is why `geometryItemId`
+ *  was invisible here in the first place (#2985), after two hand-widenings. */
+export type RaycastPiece = Pick<MeshData, 'positions' | 'indices' | 'entityIds' | 'modelIndex' | 'origin' | 'geometryItemId'>;
 
 /** True when `clip` actually clips anything (a section plane or an enabled box). */
 export function clipIsActive(clip?: PickClipState | null): boolean {
@@ -291,6 +298,13 @@ export interface RaycastHit {
   expressId: number;
   distance: number;
   modelIndex?: number;
+  /** Source `MeshData.geometryItemId` of the piece hit, so the CPU pick fallback
+   *  reports the same representation item the GPU path does rather than
+   *  collapsing to the product on any model over the pick-mesh budget (#2985).
+   *  `undefined` where there is nothing to report: this is an internal hit, so
+   *  `PickingManager` is what turns that into a missing KEY on the PickResult.
+   *  Which absences, and why: {@link PickResult.geometryItemId}. */
+  geometryItemId?: number;
 }
 
 /**
@@ -351,7 +365,7 @@ export function raycastBoundingBoxes(
  *
  * @param rayOrigin  - Ray origin in world space
  * @param rayDir     - Normalised ray direction
- * @param meshDataMap - Map expressId -> MeshData[] (positions, normals, indices, entityIds)
+ * @param meshDataMap - Map expressId -> the {@link RaycastPiece} slice of each MeshData
  * @param getEntityBoundingBox - Function to obtain/cache a bounding box per entity
  * @param hiddenIds  - Optional set of hidden expressIds to skip
  * @param isolatedIds - Optional set; when non-null only these expressIds are tested
@@ -361,7 +375,7 @@ export function raycastTriangles(
   rayDir: Vec3,
   rayDirInv: Vec3,
   rayDirSign: [number, number, number],
-  meshDataMap: Map<number, { positions: Float32Array; indices: Uint32Array; entityIds?: Uint32Array; modelIndex?: number; origin?: [number, number, number] }[]>,
+  meshDataMap: Map<number, RaycastPiece[]>,
   getEntityBoundingBox: (expressId: number) => BoundingBox | null,
   hiddenIds?: Set<number>,
   isolatedIds?: Set<number> | null,
@@ -397,6 +411,9 @@ export function raycastTriangles(
       const positions = piece.positions;
       const indices = piece.indices;
       const pieceEntityIds = piece.entityIds;
+      // A piece holding entities beyond `expressId` — the map key, who this hit
+      // attributes to — has an id belonging to none of them. Shared with hydration.
+      const pieceItemId = reportableItemId(piece, expressId);
 
       // Positions are in the element's local frame (world = origin + position).
       // Rather than offset every triangle vertex, shift the ray origin into the
@@ -435,7 +452,7 @@ export function raycastTriangles(
             rayOrigin.z + t * rayDir.z,
           )) continue;
           closestDistance = t;
-          closestHit = { expressId, distance: t, modelIndex: piece.modelIndex };
+          closestHit = { expressId, distance: t, modelIndex: piece.modelIndex, geometryItemId: pieceItemId };
         }
       }
     }

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -53,6 +53,10 @@ export interface Mesh {
    *  when their entity leaves the selection (see Scene.disposeHydratedMeshesExcept)
    *  to stop unbounded accumulation + transparent double-draw on deselect. */
   hydrated?: boolean;
+  /** Source `MeshData.geometryItemId`, carried through hydration so a pick can
+   *  report the representation item it hit. See {@link PickResult.geometryItemId}
+   *  for when it is absent. */
+  geometryItemId?: number;
 }
 
 /**
@@ -389,18 +393,6 @@ export interface PickClipState {
   clipBox?: ClipBox | null;
 }
 
-/**
- * Result from GPU picking
- * For multi-model support, includes both expressId and modelIndex
- */
-export interface PickResult {
-  expressId: number;
-  modelIndex?: number;  // Index of the model this entity belongs to
-  /**
-   * World-space XYZ of the picked surface point. Optional because the
-   * pick path can skip depth readback for callers that only need the
-   * entityId (e.g. selection state). Recovered by sampling the pick
-   * pass's depth texture at the click position and unprojecting.
-   */
-  worldXYZ?: { x: number; y: number; z: number };
-}
+// `PickResult` lives with the code that builds it (pick-resolve.ts) and is
+// re-exported here so every existing `from './types.js'` import still resolves.
+export type { PickResult } from './pick-resolve.js';

--- a/scripts/check-module-size.mjs
+++ b/scripts/check-module-size.mjs
@@ -230,7 +230,7 @@ const ALLOWLIST_DIGESTS = {
   'packages/pointcloud': '9060606210189352091',
   'packages/provenance': '17691750269289291288',
   'packages/query': '10617410983412679617',
-  'packages/renderer': '11784806359104102641',
+  'packages/renderer': '3378181057303105786',
   'packages/sandbox': '7650074321748792699',
   'packages/sdk': '885187935350689181',
   'packages/server-client': '7638729328149367977',

--- a/scripts/module-size-allowlist.txt
+++ b/scripts/module-size-allowlist.txt
@@ -307,14 +307,14 @@
    535 packages/query/src/duckdb-integration.ts
    583 packages/renderer/src/camera-controls.ts
    662 packages/renderer/src/camera.ts
-  3753 packages/renderer/src/index.ts
-   780 packages/renderer/src/picker.ts
+  3759 packages/renderer/src/index.ts
+   756 packages/renderer/src/picker.ts
    952 packages/renderer/src/pipeline.ts
    477 packages/renderer/src/pointcloud/point-cloud-renderer.ts
    758 packages/renderer/src/pointcloud/point-cloud-spatial-index.ts
    474 packages/renderer/src/raycast-engine.ts
    401 packages/renderer/src/render-section-plane.ts
-   445 packages/renderer/src/scene-raycaster.ts
+   462 packages/renderer/src/scene-raycaster.ts
   4436 packages/renderer/src/scene.ts
    639 packages/renderer/src/section-2d-overlay.ts
    514 packages/renderer/src/section-plane.ts
@@ -322,7 +322,6 @@
    454 packages/renderer/src/shadow-pass.ts
    764 packages/renderer/src/snap-detector.ts
    766 packages/renderer/src/symbolic-overlay-pipelines.ts
-   406 packages/renderer/src/types.ts
    587 packages/sandbox/src/bridge-create.ts
    421 packages/sandbox/src/bridge-query.ts
    498 packages/sandbox/src/bridge-schema.ts


### PR DESCRIPTION
Follows up #2985, but note the scope honestly: the contributor who opened that discussion said "I currently do not need per-triangle IDs or picking". This is viewer-side work I promised in the thread before that reply landed, and it serves ifc-lite's own viewer and any host that uses our picking. The instanced-occurrence work he actually needs is a separate PR.

`pick()` now reports which representation item was hit, not just the owning product. The pick pass was already per-piece granular and held the exact piece it hit; only `Mesh` had nowhere to put the id.

## What changed

`PickResult.geometryItemId`, matching the `MeshData` field that #3210 shipped. Both pick routes carry it:

- the GPU pass, through a new `pick-resolve.ts` that owns the decoded-sample taxonomy and the `meshIndexPlusOne - 1` off-by-one
- the CPU raycast fallback, which is what every model over `MAX_PICK_MESH_CREATION` (500) actually takes

Rect/marquee select stays product-level. It returns a `Set<number>`, which has no room for a per-item answer, and the comment at the call site says so.

## Why the CPU path is the point

A renderer fix that only touched `Mesh` and `Picker` would work on small models and stay silently product-level on large ones, and a caller could not tell "this geometry has no item identity" from "you exceeded a budget you did not know about". Every test asserts which route it took, verified by flipping the piece count so the assertion actually fires.

## Review notes

`/simplify` and `/code-review` both found real things:

- `Scene.raycast` had no test at all, and it is the one function that must forward the field on the CPU route. Mutating its return to `{expressId, distance, modelIndex}` passed the full suite. Five tests against a real `Scene` now fail under that exact mutation.
- Routing `pickRect` through the shared resolver cost 3.8x on the inner loop by allocating a `PickResult` per texel to read one field. Now `resolvePickedExpressId`, which keeps the dispatch single-homed without the allocation. Measured per-variant in separate processes.
- `reportableItemId` originally treated "has `entityIds`" as "holds more than one entity". `scene.ts:1543-1557` already retired that rule, because an authored single-entity mesh tags every vertex with its own id. Now a foreign-id scan, matching that site.

## Honest gaps

- `Picker.pickRect`'s own sample loop has no test. Mutating it fails zero tests, because every `pickRect` test stubs the Picker. The change there rests on typecheck and review.
- `worldXYZ` is still absent on the CPU path, as it was before this PR. Computable from the returned distance; filling it in is a behaviour change and not in scope.
- No in-tree producer sets `MeshData.entityIds` anywhere in `packages/`, `apps/`, or the Rust crates, so the colour-merged branch is exercised only by test fixtures. Latent, not firing.

## Gates

renderer 1201/1202 (1 pre-existing skip), typecheck, module-size and api-surface all clean. Module-size ends at the same five rows it started with: `types.ts` drops off the allowlist entirely and `picker.ts` goes 780 to 756.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Picking results now optionally include `geometryItemId`, identifying the selected IFC representation item.
  * Supported across GPU picking and CPU raycasting, including model and world-position metadata where available.
  * Existing picking exports remain compatible.

* **Documentation**
  * Updated API references, guides, tutorials, and rendering documentation to explain `geometryItemId` and when it may be unavailable.

* **Tests**
  * Added coverage for geometry-item reporting across merged, instanced, GPU, and CPU picking scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->