### PR TITLE
fix(bcf): stop fabricating CreationDate/Date for a non-conformant markup.bcf

### DIFF
--- a/.changeset/bcf-reader-stops-fabricating-creation-date.md
+++ b/.changeset/bcf-reader-stops-fabricating-creation-date.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Stop the BCF reader from fabricating a `CreationDate`/`Date` when a `markup.bcf` omits the required element.
+
+`markup.xsd` declares `Topic/CreationDate` and `Comment/Date` as required `xs:dateTime` elements with no schema default. When a non-conformant source file omitted one, the reader substituted `new Date().toISOString()` — the wall-clock time *at read time*. That value is indistinguishable downstream from a genuinely-declared timestamp (it drives topic/comment chronological sort and the "Created on" label), and it isn't even stable across repeated reads of the same untouched archive: reading the file twice produced two different "creation" dates.
+
+`BCFTopic.creationDate` and `BCFComment.date` are now `string | undefined`; the reader leaves them undefined rather than invent a value, and the writer mirrors that omission instead of re-serializing a fabricated timestamp as if the source had declared it.

--- a/.changeset/bcf-reader-stops-fabricating-creation-date.md
+++ b/.changeset/bcf-reader-stops-fabricating-creation-date.md
@@ -1,9 +1,12 @@
 ---
-'@ifc-lite/bcf': minor
+'@ifc-lite/bcf': major
 ---
 
-Stop the BCF reader from fabricating a `CreationDate`/`Date` when a `markup.bcf` omits the required element.
+Stop the BCF reader from fabricating a `CreationDate`/`Date` when a `markup.bcf` omits the required element, and stop the writer from emitting an archive that omission makes schema-invalid.
 
 `markup.xsd` declares `Topic/CreationDate` and `Comment/Date` as required `xs:dateTime` elements with no schema default. When a non-conformant source file omitted one, the reader substituted `new Date().toISOString()` — the wall-clock time *at read time*. That value is indistinguishable downstream from a genuinely-declared timestamp (it drives topic/comment chronological sort and the "Created on" label), and it isn't even stable across repeated reads of the same untouched archive: reading the file twice produced two different "creation" dates.
 
-`BCFTopic.creationDate` and `BCFComment.date` are now `string | undefined`; the reader leaves them undefined rather than invent a value, and the writer mirrors that omission instead of re-serializing a fabricated timestamp as if the source had declared it.
+Two breaking changes, both on the read/write round trip for such a file:
+
+- `BCFTopic.creationDate` and `BCFComment.date` are now `string | undefined`. The reader passes through what the file declared and substitutes nothing. Code that assumed a `string` — `formatDate(topic.creationDate)`, `new Date(comment.date)` — has to handle the missing case.
+- `writeBCF` now rejects a topic or comment with no date instead of silently dropping the element, whose absence makes the `markup.bcf` fail `markup.xsd` in both BCF 2.1 and 3.0. This is the same rule the writer already applies to a BCF 3.0 topic with no `TopicType`: it will neither invent a value the source never stated nor hand back an archive it knows is invalid. The error names the element and the topic/comment guid, so a caller that does know the date can supply it and write again.

--- a/.changeset/bcf-reader-stops-fabricating-creation-date.md
+++ b/.changeset/bcf-reader-stops-fabricating-creation-date.md
@@ -1,5 +1,5 @@
 ---
-'@ifc-lite/bcf': patch
+'@ifc-lite/bcf': minor
 ---
 
 Stop the BCF reader from fabricating a `CreationDate`/`Date` when a `markup.bcf` omits the required element.

--- a/.changeset/bcf-viewer-creation-date-display.md
+++ b/.changeset/bcf-viewer-creation-date-display.md
@@ -2,4 +2,4 @@
 '@ifc-lite/viewer': patch
 ---
 
-BCF topics and comments read from a file that omitted `CreationDate`/`Date` no longer show the import time as their creation date. They now show no date and sort as oldest in the topic list.
+BCF topics and comments read from a file that omitted `CreationDate`/`Date` no longer show the import time as their creation date. They now show no date and sort as oldest in the topic list. Exporting a project that contains such a topic now fails with a message naming the topic, rather than writing a `.bcfzip` other BCF tools can reject.

--- a/.changeset/bcf-viewer-creation-date-display.md
+++ b/.changeset/bcf-viewer-creation-date-display.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+BCF topics and comments read from a file that omitted `CreationDate`/`Date` no longer show the import time as their creation date. They now show no date and sort as oldest in the topic list.

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -340,8 +340,7 @@ export function BCFTopicDetail({
                     <div className="flex items-center gap-2 mb-1 text-xs text-muted-foreground">
                       <User className="h-3 w-3" />
                       <span>{comment.author.split('@')[0]}</span>
-                      <span>-</span>
-                      <span>{formatDateTime(comment.date)}</span>
+                      {comment.date && <><span>-</span><span>{formatDateTime(comment.date)}</span></>}
                       {comment.viewpointGuid && (
                         <span className="flex items-center gap-0.5">
                           <Camera className="h-3 w-3" />

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -186,8 +186,8 @@ export function BCFTopicDetail({
 
             <div className="text-xs text-muted-foreground space-y-1">
               <p>
-                Created by {topic.creationAuthor} on{' '}
-                {formatDateTime(topic.creationDate)}
+                Created by {topic.creationAuthor}
+                {topic.creationDate ? <> on {formatDateTime(topic.creationDate)}</> : null}
               </p>
               {topic.assignedTo && <p>Assigned to: {topic.assignedTo}</p>}
               {topic.dueDate && <p>Due: {formatDate(topic.dueDate)}</p>}

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
@@ -75,11 +75,13 @@ export function BCFTopicList({
     );
   }, [topics, statusFilter]);
 
-  // Sort by creation date (newest first)
+  // Sort by creation date (newest first); a topic read back from a
+  // non-conformant source that omitted CreationDate has it undefined
+  // (see @ifc-lite/bcf's reader.ts) and sorts as oldest, never fabricated.
   const sortedTopics = useMemo(() => {
-    return [...filteredTopics].sort(
-      (a, b) => new Date(b.creationDate).getTime() - new Date(a.creationDate).getTime()
-    );
+    const time = (t: (typeof filteredTopics)[number]) =>
+      t.creationDate ? new Date(t.creationDate).getTime() : 0;
+    return [...filteredTopics].sort((a, b) => time(b) - time(a));
   }, [filteredTopics]);
 
   return (

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
@@ -216,10 +216,12 @@ export function BCFTopicList({
                     <User className="h-3 w-3" />
                     {topic.creationAuthor.split('@')[0]}
                   </span>
-                  <span className="flex items-center gap-1">
-                    <Calendar className="h-3 w-3" />
-                    {formatDate(topic.creationDate)}
-                  </span>
+                  {topic.creationDate && (
+                    <span className="flex items-center gap-1">
+                      <Calendar className="h-3 w-3" />
+                      {formatDate(topic.creationDate)}
+                    </span>
+                  )}
                   {topic.comments.length > 0 && (
                     <span className="flex items-center gap-1">
                       <MessageSquare className="h-3 w-3" />

--- a/apps/viewer/src/components/viewer/bcf/bcfHelpers.tsx
+++ b/apps/viewer/src/components/viewer/bcf/bcfHelpers.tsx
@@ -86,7 +86,8 @@ export function PriorityBadge({ priority }: { priority?: string }) {
 // Date Formatters
 // ============================================================================
 
-export function formatDate(isoDate: string): string {
+export function formatDate(isoDate: string | undefined): string {
+  if (!isoDate) return '';
   const date = new Date(isoDate);
   if (isNaN(date.getTime())) return isoDate;
   return date.toLocaleDateString(undefined, {
@@ -96,7 +97,8 @@ export function formatDate(isoDate: string): string {
   });
 }
 
-export function formatDateTime(isoDate: string): string {
+export function formatDateTime(isoDate: string | undefined): string {
+  if (!isoDate) return '';
   const date = new Date(isoDate);
   if (isNaN(date.getTime())) return isoDate;
   return date.toLocaleString(undefined, {

--- a/packages/bcf/src/fabricated-creation-date.test.ts
+++ b/packages/bcf/src/fabricated-creation-date.test.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `markup.xsd` declares `Topic/CreationDate` and `Comment/Date` as required
+ * `xs:dateTime` elements with no schema default (see
+ * `__fixtures__/schemas/v3_0/markup.xsd` lines ~73-74), so a `.bcfzip` that
+ * omits one is non-conformant. Before this fix, the reader tolerated the
+ * omission by substituting `new Date().toISOString()` — the wall-clock time
+ * *at read time* — which looks exactly like a genuinely-declared timestamp
+ * to every downstream consumer (topic/comment chronological sort, the
+ * `BCFTopicDetail` "Created on" label, and `writer.ts`, which re-serializes
+ * it verbatim into a new `.bcfzip` as if it had been in the source file).
+ * Because the substitute changes on every read of the same file, it isn't
+ * even self-consistent — two reads of one untouched archive would disagree
+ * with each other, which is worse than merely disagreeing with the format.
+ *
+ * Fix: leave the field undefined rather than fabricate a plausible-looking
+ * timestamp, mirroring how a missing required `Guid` is already handled
+ * (the topic-less case) rather than papering over it.
+ *
+ * `Title` includes a CONTROL assertion: it is population from real,
+ * declared XML content elsewhere in the same fixture, so it must still come
+ * through correctly — this isolates the CreationDate/Date defect rather
+ * than proving the reader broadly works.
+ */
+
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readBCF } from './reader.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_DATA_DIR = join(__dirname, '..', 'test-data');
+
+/** Take the real PerspectiveCamera.bcf fixture and edit its markup.bcf, re-zip. */
+async function archiveWithEditedMarkup(edit: (xml: string) => string): Promise<Uint8Array> {
+  const original = await readFile(join(TEST_DATA_DIR, 'PerspectiveCamera.bcf'));
+  const zip = await JSZip.loadAsync(original);
+  const markupName = Object.keys(zip.files).find((n) => n.endsWith('markup.bcf'));
+  if (!markupName) throw new Error('no markup.bcf in fixture');
+  const xml = await zip.file(markupName)!.async('string');
+  const edited = edit(xml);
+  expect(edited, 'the edit must actually change the XML').not.toBe(xml);
+  zip.file(markupName, edited);
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+describe('BCF reader — CreationDate/Date fabrication (#markup.xsd required, no default)', () => {
+  it('does not fabricate a wall-clock CreationDate when the source omits the required element', async () => {
+    const bytes = await archiveWithEditedMarkup((xml) =>
+      xml.replace(/<CreationDate>[^<]*<\/CreationDate>/, ''),
+    );
+
+    const before = Date.now();
+    const project = await readBCF(bytes);
+    const after = Date.now();
+
+    const topic = Array.from(project.topics.values())[0];
+    expect(topic).toBeDefined();
+
+    // CONTROL: Title is genuinely declared in the fixture and must still
+    // come through — isolates the defect to CreationDate, not a broken reader.
+    expect(topic.title).toBe('Perspective Camera');
+
+    // actual (pre-fix): a fresh `new Date().toISOString()` timestamp,
+    // falling inside [before, after] — indistinguishable from a real value.
+    // expected (post-fix): undefined, since the file never declared one.
+    if (topic.creationDate !== undefined) {
+      const parsed = Date.parse(topic.creationDate);
+      const isFabricatedNow = !Number.isNaN(parsed) && parsed >= before && parsed <= after;
+      expect(
+        isFabricatedNow,
+        `actual: creationDate="${topic.creationDate}" (fabricated at read time); expected: undefined`,
+      ).toBe(false);
+    }
+    expect(topic.creationDate).toBeUndefined();
+  });
+
+  it('does not fabricate a wall-clock Date when a Comment omits the required element', async () => {
+    const bytes = await archiveWithEditedMarkup((xml) =>
+      xml.replace(
+        '</Topic>',
+        '<Comment Guid="c1a2b3c4-0000-0000-0000-000000000001">' +
+          '<Author>reviewer@example.com</Author>' +
+          '<Comment>looks fine</Comment>' +
+          '</Comment>' +
+          '</Topic>',
+      ),
+    );
+
+    const before = Date.now();
+    const project = await readBCF(bytes);
+    const after = Date.now();
+
+    const topic = Array.from(project.topics.values())[0];
+    expect(topic.comments).toHaveLength(1);
+    const comment = topic.comments[0];
+
+    // CONTROL: Author is genuinely declared and must still come through.
+    expect(comment.author).toBe('reviewer@example.com');
+
+    if (comment.date !== undefined) {
+      const parsed = Date.parse(comment.date);
+      const isFabricatedNow = !Number.isNaN(parsed) && parsed >= before && parsed <= after;
+      expect(
+        isFabricatedNow,
+        `actual: date="${comment.date}" (fabricated at read time); expected: undefined`,
+      ).toBe(false);
+    }
+    expect(comment.date).toBeUndefined();
+  });
+});

--- a/packages/bcf/src/fabricated-creation-date.test.ts
+++ b/packages/bcf/src/fabricated-creation-date.test.ts
@@ -20,7 +20,7 @@
  * timestamp, mirroring how a missing required `Guid` is already handled
  * (the topic-less case) rather than papering over it.
  *
- * `Title` includes a CONTROL assertion: it is population from real,
+ * `Title` includes a CONTROL assertion: it is populated from real,
  * declared XML content elsewhere in the same fixture, so it must still come
  * through correctly — this isolates the CreationDate/Date defect rather
  * than proving the reader broadly works.
@@ -32,7 +32,10 @@ import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { validateXML } from 'xmllint-wasm';
+
 import { readBCF } from './reader.js';
+import { writeBCF } from './writer.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEST_DATA_DIR = join(__dirname, '..', 'test-data');
@@ -113,5 +116,85 @@ describe('BCF reader — CreationDate/Date fabrication (#markup.xsd required, no
       ).toBe(false);
     }
     expect(comment.date).toBeUndefined();
+  });
+});
+
+/**
+ * `markup.xsd` requires `Topic/CreationDate` and `Comment/Date`
+ * (`minOccurs="1"`, no default) in BOTH 2.1 (:67, :107) and 3.0 (:73, :155),
+ * so a writer that simply mirrors the reader's omission produces a
+ * `markup.bcf` no conforming BCF tool has to accept -- and hands it back as an
+ * ordinary Blob, with nothing to tell the caller. `writer.ts` refuses that
+ * write instead, the same way it already refuses a BCF 3.0 topic with no
+ * `TopicType`: it will neither invent a timestamp the source never stated nor
+ * emit an archive it knows fails the schema.
+ */
+describe('BCF writer — refuses a markup.bcf it knows fails markup.xsd', () => {
+  const COMMENT_NO_DATE =
+    '<Comment Guid="c1a2b3c4-0000-0000-0000-000000000001">' +
+    '<Author>reviewer@example.com</Author>' +
+    '<Comment>looks fine</Comment>' +
+    '</Comment>';
+
+  /** xmllint against the real v2_1/markup.xsd (the fixture's own version). */
+  async function markupIsSchemaValid(markup: string): Promise<{ valid: boolean; errors: string }> {
+    const xsd = await readFile(
+      join(__dirname, '__fixtures__', 'schemas', 'v2_1', 'markup.xsd'),
+      'utf8',
+    );
+    const result = await validateXML({
+      xml: [{ fileName: 'subject.xml', contents: markup }],
+      schema: [xsd],
+    });
+    return { valid: result.valid, errors: result.errors.map((e) => e.message).join(' | ') };
+  }
+
+  async function markupOf(blob: Blob): Promise<string> {
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    const name = Object.keys(zip.files).find((n) => n.endsWith('markup.bcf'))!;
+    return zip.file(name)!.async('string');
+  }
+
+  it('CONTROL: the untouched fixture round-trips to markup that validates', async () => {
+    // Same fixture, same code path, CreationDate left in place. Without this,
+    // a writer that threw on every topic would pass the two tests below.
+    const project = await readBCF(await readFile(join(TEST_DATA_DIR, 'PerspectiveCamera.bcf')));
+    const markup = await markupOf(await writeBCF(project));
+    expect(markup).toContain('<CreationDate>');
+    const { valid, errors } = await markupIsSchemaValid(markup);
+    expect(valid, `round-tripped markup.bcf failed markup.xsd: ${errors}`).toBe(true);
+  });
+
+  it('refuses to write a Topic whose CreationDate the source never declared', async () => {
+    const project = await readBCF(
+      await archiveWithEditedMarkup((xml) =>
+        xml.replace(/<CreationDate>[^<]*<\/CreationDate>/, ''),
+      ),
+    );
+    // The error has to name the element, or the caller cannot act on it.
+    await expect(writeBCF(project)).rejects.toThrow(/Topic\/CreationDate/);
+  });
+
+  it('refuses to write a Comment whose Date the source never declared', async () => {
+    const project = await readBCF(
+      await archiveWithEditedMarkup((xml) => xml.replace('</Topic>', COMMENT_NO_DATE + '</Topic>')),
+    );
+    await expect(writeBCF(project)).rejects.toThrow(/Comment\/Date/);
+  });
+
+  it('what the refusal replaces: emitting the topic without CreationDate fails markup.xsd', async () => {
+    // Pin the reason. This builds the exact markup a mirror-the-omission
+    // writer produces -- the round trip above with the one element dropped --
+    // and shows an independent authority (buildingSMART's own XSD, via
+    // xmllint) rejecting it. If that ever validated, the throw above would be
+    // pointless ceremony rather than a guard.
+    const project = await readBCF(await readFile(join(TEST_DATA_DIR, 'PerspectiveCamera.bcf')));
+    const good = await markupOf(await writeBCF(project));
+    const withoutCreationDate = good.replace(/\n?\s*<CreationDate>[^<]*<\/CreationDate>/, '');
+    expect(withoutCreationDate, 'the edit must actually drop the element').not.toBe(good);
+
+    const { valid, errors } = await markupIsSchemaValid(withoutCreationDate);
+    expect(valid).toBe(false);
+    expect(errors).toMatch(/CreationDate/);
   });
 });

--- a/packages/bcf/src/reader.test.ts
+++ b/packages/bcf/src/reader.test.ts
@@ -227,7 +227,7 @@ describe('BCF Reader - buildingSMART Test Files', () => {
       const topic = Array.from(project.topics.values())[0];
       expect(topic.creationDate).toBeDefined();
       // Should be a valid ISO date string
-      expect(new Date(topic.creationDate).toString()).not.toBe('Invalid Date');
+      expect(new Date(topic.creationDate!).toString()).not.toBe('Invalid Date');
     });
   });
 

--- a/packages/bcf/src/reader.ts
+++ b/packages/bcf/src/reader.ts
@@ -349,7 +349,7 @@ async function readTopic(zip: JSZip, topicFolder: string, budget: ExpansionBudge
   const description = extractElement(topicContent, 'Description');
   const priority = extractElement(topicContent, 'Priority');
   const index = extractElement(topicContent, 'Index');
-  const creationDate = extractElement(topicContent, 'CreationDate') || new Date().toISOString();
+  const creationDate = extractElement(topicContent, 'CreationDate'); // required no-default in markup.xsd; leave undefined, don't fabricate
   const creationAuthor = extractElement(topicContent, 'CreationAuthor') || 'Unknown';
   const modifiedDate = extractElement(topicContent, 'ModifiedDate');
   const modifiedAuthor = extractElement(topicContent, 'ModifiedAuthor');
@@ -574,7 +574,7 @@ function parseComments(markupContent: string): BCFComment[] {
     if (close < 0) continue; // malformed: no wrapper closer, skip rather than throw
     const content = span.slice(0, close);
 
-    const date = extractElement(content, 'Date') || new Date().toISOString();
+    const date = extractElement(content, 'Date'); // don't fabricate; see CreationDate above
     const author = extractElement(content, 'Author') || 'Unknown';
     const comment = extractElement(content, 'Comment') || '';
     const modifiedDate = extractElement(content, 'ModifiedDate');

--- a/packages/bcf/src/types.ts
+++ b/packages/bcf/src/types.ts
@@ -53,8 +53,15 @@ export interface BCFTopic {
   priority?: string;
   /** Index for ordering topics */
   index?: number;
-  /** Creation date (ISO 8601) */
-  creationDate: string;
+  /**
+   * Creation date (ISO 8601). `markup.xsd` declares this required with no
+   * default, but it comes through undefined when the source markup.bcf
+   * omits it — the reader never fabricates a read-time wall-clock
+   * timestamp in its place (that value would be indistinguishable from a
+   * genuinely-declared one, and isn't even stable across repeated reads of
+   * the same untouched file).
+   */
+  creationDate?: string;
   /** Author email */
   creationAuthor: string;
   /** Modification date (ISO 8601) */
@@ -119,8 +126,13 @@ export interface BCFDocumentReference {
 export interface BCFComment {
   /** Unique identifier */
   guid: string;
-  /** Comment creation date (ISO 8601) */
-  date: string;
+  /**
+   * Comment creation date (ISO 8601). `markup.xsd` declares this required
+   * with no default, but it comes through undefined when the source
+   * markup.bcf omits it — see `BCFTopic.creationDate` for why the reader
+   * never fabricates a read-time wall-clock timestamp in its place.
+   */
+  date?: string;
   /** Author email */
   author: string;
   /** Comment text */

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -131,33 +131,17 @@ function shortGuidHash(guid: string): string {
 }
 
 /**
- * Sanitize a topic GUID for use as a zip folder name (zip-slip guard).
- *
- * A topic GUID is parsed unvalidated from untrusted markup XML on read, so it
- * can carry path separators or `..`. Using it verbatim as a zip path component
- * on a read-modify-save would let a crafted GUID (`../../evil`) write outside
- * the archive root. Restrict the name to safe filename characters and collapse
- * any dot-run so it can never traverse. The real GUID is still written verbatim
- * as the markup `<Topic Guid>` attribute, which is what readers key off.
- *
- * Sanitization is lossy, so two distinct GUIDs can map to one name (`a?b` and
- * `a:b` both give `a_b`), which would silently overwrite a topic folder. Any
- * name that sanitization changed gets a hash of the original GUID appended,
- * and `usedNames` catches the remaining collisions with a counter suffix.
- */
-function sanitizeTopicFolderName(guid: string, usedNames: Set<string>): string {
-  return sanitizeZipComponent(guid, usedNames, 'topic');
-}
-
-/**
  * Sanitize an arbitrary GUID for use as a zip path component (zip-slip guard).
  *
  * Shared by both the topic-folder name and the viewpoint file base name: a
  * viewpoint GUID is parsed just as unvalidated from untrusted markup XML on
  * read (reader.ts `parseViewpointContent`) as a topic GUID is, so it carries
- * the same path-traversal hazard. Restrict the name to safe filename
- * characters and collapse any dot-run so it can never traverse. `fallback` is
- * used when sanitization strips the name to nothing.
+ * the same path-traversal hazard (`../../evil` as a topic GUID would write
+ * outside the archive root). Restrict the name to safe filename characters and
+ * collapse any dot-run so it can never traverse. `fallback` is used when
+ * sanitization strips the name to nothing. The real GUID is still written
+ * verbatim as the markup `<Topic Guid>`/`<Viewpoint Guid>` attribute, which is
+ * what readers key off.
  *
  * Sanitization is lossy, so two distinct GUIDs can map to one name, which
  * would silently overwrite an entry. Any name that sanitization changed gets
@@ -181,16 +165,14 @@ function sanitizeZipComponent(raw: string, usedNames: Set<string>, fallback: str
   return candidate;
 }
 
-/**
- * Write a topic folder with all its contents
- */
+/** Write a topic folder with all its contents. */
 async function writeTopicFolder(
   zip: JSZip,
   topic: BCFTopic,
   version: '2.1' | '3.0',
   usedFolderNames: Set<string>,
 ): Promise<void> {
-  const folder = zip.folder(sanitizeTopicFolderName(topic.guid, usedFolderNames));
+  const folder = zip.folder(sanitizeZipComponent(topic.guid, usedFolderNames, 'topic'));
   if (!folder) return;
 
   // Sanitize each viewpoint GUID once, up front, so the markup <Viewpoint>
@@ -226,17 +208,35 @@ function snapshotExt(viewpoint: BCFViewpoint): 'png' | 'jpg' {
   return 'png';
 }
 
-/**
- * Write markup.bcf file
- * Uses buildingSMART standard format
- */
 // BCF 3.0's markup.xsd types `Topic/@TopicType` and `Topic/@TopicStatus` as
 // `NonEmptyOrBlankString`: after XML whitespace (#x9, #xA, #xD, #x20) is
 // collapsed, the value must have length >= 1. A value that is present but
 // consists entirely of XML whitespace collapses to nothing and is therefore
-// as invalid as an absent one.
+// as invalid as an absent one -- which is why `xsdDateTime` reuses it below.
 const XML_WHITESPACE_ONLY = /^[\t\n\r ]*$/;
 
+/**
+ * A required `xs:dateTime` on its way into an archive, escaped -- or an error.
+ *
+ * `markup.xsd` declares `Topic/CreationDate` and `Comment/Date` `minOccurs="1"`
+ * with no default in BOTH 2.1 (:67, :107) and 3.0 (:73, :155), and reader.ts no
+ * longer invents a wall-clock timestamp when the source omits one, so either can
+ * arrive unset. Inventing one here is that same fabrication; dropping the
+ * element hands the caller an archive we already know fails the schema. So we
+ * refuse, as the TopicType/TopicStatus check below and `xsdDouble` do.
+ */
+function xsdDateTime(value: string | undefined, element: string, where: string): string {
+  if (!value || XML_WHITESPACE_ONLY.test(value)) {
+    throw new Error(
+      `BCF requires ${element} (${where} has none). markup.xsd declares it ` +
+        `minOccurs="1" with no default, and a time the source never stated is ` +
+        `not the writer's to invent. Set it before writing.`
+    );
+  }
+  return escapeXml(value);
+}
+
+/** Write markup.bcf -- buildingSMART standard format. */
 function writeMarkupFile(
   folder: JSZip,
   topic: BCFTopic,
@@ -321,7 +321,7 @@ function writeMarkupFile(
     }
   }
 
-  if (topic.creationDate) content += `\n    <CreationDate>${escapeXml(topic.creationDate)}</CreationDate>`;
+  content += `\n    <CreationDate>${xsdDateTime(topic.creationDate, 'Topic/CreationDate', `topic "${topic.guid}"`)}</CreationDate>`;
   content += `\n    <CreationAuthor>${escapeXml(topic.creationAuthor)}</CreationAuthor>`;
 
   if (topic.modifiedDate) {
@@ -384,7 +384,7 @@ function writeMarkupFile(
     topic.comments
       .map((comment) => {
         let c = `\n${indent}<Comment Guid="${escapeXml(comment.guid)}">`;
-        if (comment.date) c += `\n${indent}  <Date>${escapeXml(comment.date)}</Date>`; // mirror undefined date; see reader.ts
+        c += `\n${indent}  <Date>${xsdDateTime(comment.date, 'Comment/Date', `comment "${comment.guid}"`)}</Date>`;
         c += `\n${indent}  <Author>${escapeXml(comment.author)}</Author>`;
         c += `\n${indent}  <Comment>${escapeXml(comment.comment)}</Comment>`;
         if (comment.viewpointGuid) {

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -321,7 +321,7 @@ function writeMarkupFile(
     }
   }
 
-  content += `\n    <CreationDate>${escapeXml(topic.creationDate)}</CreationDate>`;
+  if (topic.creationDate) content += `\n    <CreationDate>${escapeXml(topic.creationDate)}</CreationDate>`;
   content += `\n    <CreationAuthor>${escapeXml(topic.creationAuthor)}</CreationAuthor>`;
 
   if (topic.modifiedDate) {
@@ -384,7 +384,7 @@ function writeMarkupFile(
     topic.comments
       .map((comment) => {
         let c = `\n${indent}<Comment Guid="${escapeXml(comment.guid)}">`;
-        c += `\n${indent}  <Date>${escapeXml(comment.date)}</Date>`;
+        if (comment.date) c += `\n${indent}  <Date>${escapeXml(comment.date)}</Date>`; // mirror undefined date; see reader.ts
         c += `\n${indent}  <Author>${escapeXml(comment.author)}</Author>`;
         c += `\n${indent}  <Comment>${escapeXml(comment.comment)}</Comment>`;
         if (comment.viewpointGuid) {

--- a/packages/clash/src/bcf-bridge.ts
+++ b/packages/clash/src/bcf-bridge.ts
@@ -245,7 +245,7 @@ function buildDescription(
  */
 function headerFilesForGroup(
   group: ClashGroup,
-  date: string,
+  date: string | undefined,
   modelNameOf?: (model: string) => string,
 ): BCFHeaderFile[] {
   const ids = unique(


### PR DESCRIPTION
## Summary
- `markup.xsd` declares `Topic/CreationDate` and `Comment/Date` as required `xs:dateTime` elements with no schema default (`minOccurs="1"` in both 2.1 and 3.0). When a source `.bcfzip` omitted one, the reader substituted `new Date().toISOString()`, the wall-clock time *at read time*, indistinguishable downstream from a genuinely-declared timestamp (topic/comment chronological sort, the "Created on" label), and not even stable across repeated reads of the same untouched file.
- `BCFTopic.creationDate` and `BCFComment.date` are now `string | undefined`. The reader passes through what the file declared and substitutes nothing.
- `writeBCF` refuses to write a topic or comment with no date. Dropping the element would produce a `markup.bcf` that fails `markup.xsd`, returned as an ordinary Blob with no error, so that trades one silent wrong for another. This is the rule `writer.ts` already applies to a BCF 3.0 topic with no `TopicType`: it will neither invent a value the source never stated nor hand back an archive it knows is invalid. The error names the element and the guid.
- Updated the small set of viewer consumers (`bcfHelpers.tsx` date formatters, `BCFTopicList` sort, `BCFTopicDetail` "Created on" label) and `packages/clash/src/bcf-bridge.ts`'s `headerFilesForGroup` to accept the now-optional field.

Known consequence, called out rather than hidden: a project holding a topic imported from such a file cannot be exported until something supplies the missing date. The viewer's export handler already catches and surfaces the message, so the user sees which topic is at fault instead of downloading an archive other BCF tools can reject. Letting the user fill it in from the topic detail panel is a sensible follow-up and is not in this PR.

## Context
Part of a repo-wide sweep for readers that fabricate a plausible value for a field the source format never declared (same bug class as #3524/#3522 in `@ifc-lite/ifcx`). Full census from the sweep, for reference. Line numbers are against this branch.

**Fixed here:** the BCF reader's `CreationDate`/`Date` fallback to `new Date().toISOString()`, and the writer's silent emission of the resulting schema-invalid markup.

**Other candidates found, not fixed in this PR (reported for visibility):**
- `packages/bcf/src/reader.ts:348,353,578`: `Title` falling back to `'Untitled'`, `CreationAuthor`/comment `Author` falling back to `'Unknown'`. Same required-no-default shape as the fix here, lower severity (deterministic, human-recognizable placeholder), worth a follow-up.
- `packages/parser/src/spatial-hierarchy-builder.ts:210`: an unnamed spatial node (`IfcSite`/`IfcBuilding`/`IfcStorey`/`IfcSpace`) gets `` `Entity #${expressId}` ``, which then flows into `packages/export/src/ifc5-exporter.ts` as a genuinely-declared `bsi::ifc::prop::Name` on IFCX export. Cross-package chain, same shape as the already-fixed `objectType` bug.
- `packages/parser/src/columnar-parser.ts:798` and `on-demand-extractors.ts:347`: a missing `IfcPropertySet` `Name` fabricated as `` `PropertySet #${psetId}` ``. `packages/parser/src/quantity-collect.ts:225` does the same for `IfcElementQuantity` as `` `QuantitySet #${qsetId}` `` (reached from `on-demand-extractors.ts:539`, which is only the `readQuantitySet` call site). `on-demand-extractors.ts:890` falls back to `'Material Properties'` for `IfcMaterialProperties`. All of these flow into Parquet's `PsetName`/`QsetName` columns.
- `packages/cache/src/glb.ts:491`: `expressId` fabricated from a raw glTF node index when a user-uploaded `.glb` lacks ifc-lite's own `extras.expressId` convention; can collide with a real entity's id.
- `packages/source-dropbox/src/mapping.ts:87`, `packages/source-msgraph/src/mapping.ts:121`: revision `createdAt` falls back to epoch (`new Date(0).toISOString()`) when even the "modified" timestamp is absent.

Packages checked and found clean under this lens: `packages/cache` (own private format, no independent "declared" comparison), `packages/encoding`, `packages/collab`/`collab-server`, `packages/source-fixture` (test fixtures, not a real-format reader), `packages/bcf/src/reader-components.ts`, most of `packages/parser/src` (`columnar-parser.ts`'s root-attribute resolver, `entity-extractor.ts`, `property-extractor.ts`, `material-extractor.ts`, `classification-extractor.ts`, `relationship-extractor.ts`, `project-units.ts`, and `georef-extractor.ts`, whose only substitution is an absent `IfcProjectedCRS` `Name` becoming `''` at :374, which is empty rather than plausible), `packages/export/src` write/derive paths.

## Test plan
- [x] New RED/GREEN tests in `packages/bcf/src/fabricated-creation-date.test.ts`, six in all. The reader half builds a real fixture archive with `CreationDate`/`Date` stripped and confirms the reader no longer stamps a value inside `[readStart, readEnd]`, with a control assertion on `Title`/`Author` (genuinely declared elsewhere in the same fixture) to isolate the defect. The writer half asserts `writeBCF` rejects for each of the two elements, with two controls: the untouched fixture still round-trips to markup that validates against `v2_1/markup.xsd`, and the archive the refusal replaces is shown failing that same XSD through `xmllint-wasm` rather than merely asserted to.
- [x] Mutation-checked both halves, redirecting to a file and reading `$?` rather than piping. Reverting only the two writer lines to the conditional-omit form turns the two "refuses to write" tests red (exit 1, `promise resolved "Blob { size: 113316, type: 'application/zip' }" instead of rejecting`). Reverting only the two reader lines to `|| new Date().toISOString()` turns four tests red on the discriminating `isFabricatedNow` clause, with two fabricated timestamps 22ms apart in a single run. The two control tests stay green under both mutations.
- [x] `packages/bcf` full suite: 319/319 passing in 12 files, exit 0
- [x] `packages/clash` full suite: 450 passed and 1 pre-existing skip, exit 0
- [x] `node scripts/typecheck-tests.mjs` OK for `packages/bcf` (12 test files) and `packages/clash` (34 test files); `pnpm turbo build` compiles both packages
- [x] `apps/viewer` `pnpm exec tsc --noEmit`: zero errors, after building its workspace deps so the imports resolve through `dist`
- [x] `node scripts/check-module-size.mjs` exits 0, and `git diff origin/main...HEAD -- scripts/module-size-allowlist.txt` is empty. `writer.ts` stays at its recorded 878-line budget: the guard was paid for by deleting `sanitizeTopicFolderName`, a single-caller one-line delegation to `sanitizeZipComponent` whose fourteen-line doc duplicated its callee's, with the one fact only it recorded moved into that doc.
- [x] `node scripts/check-changesets.mjs` exits 0
- [x] Changesets added: `@ifc-lite/bcf` **major** (2.0.1, and both the optional fields and the throwing `writeBCF` break consumers, so AGENTS.md:68's first clause applies) and `@ifc-lite/viewer` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BCF files that omit topic or comment timestamps no longer receive fabricated dates during import.
  * Missing dates are preserved and displayed appropriately; undated topics sort as the oldest.
  * Export now rejects topics or comments without required dates instead of creating invalid BCF archives.
  * Topics without dates show no date label.
* **Tests**
  * Added coverage for missing timestamps, schema validation, and export rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->