### PR TITLE
fix(viewer): register a primary .glb's mesh ids in the federation registry

### DIFF
--- a/.changeset/primary-glb-federation-offset.md
+++ b/.changeset/primary-glb-federation-offset.md
@@ -1,0 +1,7 @@
+---
+"@ifc-lite/viewer": patch
+---
+
+Fix: loading a `.glb` as the first (primary) model, then adding another model, no longer overlaps their entity ids.
+
+The primary GLB path never registered itself in the federation registry (a GLB carries no IFC entities, so the registration guard skipped it), so `idOffset` for a subsequently-added model started back at the primary GLB's own range instead of past it. A test now pins that a federated add after a primary GLB gets a disjoint `idOffset`.

--- a/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
+++ b/apps/viewer/src/hooks/ingest/viewerModelIngest.ts
@@ -67,10 +67,10 @@ export function createMinimalGlbDataStore(buffer: ArrayBuffer, meshCount: number
   });
 }
 
-export function getMaxExpressId(dataStore: IfcDataStore, meshes: MeshData[]): number {
+export function getMaxExpressId(dataStore: IfcDataStore | null, meshes: MeshData[]): number {
   const maxExpressIdFromMeshes = meshes.reduce((max, mesh) => Math.max(max, mesh.expressId), 0);
   let maxExpressIdFromEntities = 0;
-  if (dataStore.entityIndex?.byId) {
+  if (dataStore?.entityIndex?.byId) {
     for (const key of dataStore.entityIndex.byId.keys()) {
       if (key > maxExpressIdFromEntities) {
         maxExpressIdFromEntities = key;

--- a/apps/viewer/src/hooks/useIfcLoader.federatedIdOffset.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.federatedIdOffset.test.tsx
@@ -53,19 +53,21 @@
  * every step from format detection through `finalizeModel`'s offset
  * application runs for real. The one thing seeded directly is the federation
  * registry's starting offset: production reaches a NON-ZERO `idOffset` only
- * once some earlier model has already registered an id range (typically a
- * primary STEP/IFC load, which registers for real — GLB is the one primary
- * format that does NOT register: `finalizeModel`'s primary branch passes
- * `dataStore: null` for a primary GLB, so its
+ * once some earlier model has already registered an id range. When this file
+ * was written that meant a primary STEP/IFC or IFCX load, because GLB was the
+ * one primary format that did NOT register: `finalizeModel`'s primary branch
+ * passed `dataStore: null` for a primary GLB, so its
  * `if (dataStore && geometryResult) { ... registerModelOffset(...) }` guard
- * never fires). Reproducing that earlier registration through a real primary
- * load would need either the same unreachable WASM engine (STEP/IFC) or a
- * hand-composed IFCX ECS/USD fixture (points, face-vertex indices, a
- * composition layer) whose complexity is orthogonal to what this test pins —
- * and `registerModelOffset` itself is already covered by
- * `packages/renderer/src/federation-registry.test.ts`, so re-deriving it here
- * would only duplicate that coverage while adding an unrelated fixture.
- * Instead this test calls the SAME store action — `registerModelOffset`,
+ * never fired. That guard is now `if (geometryResult)` and a primary GLB
+ * registers like every other format, which is what
+ * `useIfcLoader.primaryGlbFederationOffset.test.tsx` pins by driving a real
+ * primary GLB load followed by a real federated one. Seeding is kept here
+ * rather than switched to that second real load: `registerModelOffset` is
+ * already covered by `packages/renderer/src/federation-registry.test.ts` and
+ * by that sibling file, so re-deriving it here would only duplicate their
+ * coverage, and the point of THIS file is the offset the federated branch
+ * applies, not where the offset came from. The seed calls the SAME store
+ * action — `registerModelOffset`,
  * `useViewerStore`'s real federation-registry entry point, not a stub of it —
  * directly, exactly as a real primary load's `finalizeModel` would, to seed
  * "a primary model already occupying ids 0..1000". From that point on, the
@@ -75,7 +77,7 @@
  *
  * **What remains unverified.** Whether a REAL primary load's own
  * `registerModelOffset` call (the one inside `finalizeModel`'s primary
- * branch, for STEP/IFC or IFCX) wires its `maxExpressId` correctly is not
+ * branch, for STEP/IFC, IFCX or GLB) wires its `maxExpressId` correctly is not
  * checked here — only that a federated load, given a registered offset,
  * applies it correctly to its own meshes. That first link is a much smaller
  * surface (`getMaxExpressId(dataStore, meshes)` feeding a single

--- a/apps/viewer/src/hooks/useIfcLoader.primaryGlbFederationOffset.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.primaryGlbFederationOffset.test.tsx
@@ -1,0 +1,226 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Pins that a PRIMARY `.glb` load registers itself in the federation registry
+ * (`registerModelOffset`), exactly like every other primary format does.
+ *
+ * `finalizeModel`'s primary branch (`useIfcLoader.ts`) guards the
+ * registration on `if (dataStore && geometryResult)`. For a primary GLB,
+ * `loadFile`'s GLB branch deliberately passes `dataStore: null` into
+ * `finalizeModel` ("Primary keeps the historical null data store (GLB has no
+ * entities)") — so that guard never fires for a primary GLB, and the
+ * registry's `nextOffset` never advances past 0. A federated model added
+ * afterwards is then assigned an offset that starts at (or below) the
+ * primary GLB's own max expressId, so the two models' mesh ids overlap:
+ * primary mesh `k` and federated mesh `k` (local id) collide in the shared
+ * id space `FederationRegistry.toGlobalId`/`fromGlobalId` resolve through.
+ *
+ * `useIfcLoader.federatedIdOffset.test.tsx` already documents this exact gap
+ * in its own header ("GLB is the one primary format that does NOT
+ * register") and works around it by seeding the registry directly rather
+ * than driving a real primary load. This file drives BOTH loads for real —
+ * a primary GLB via `loadFile(file, { kind: 'primary' })`, then a federated
+ * GLB via `loadFile(file, { kind: 'federated', modelId })` — and asserts the
+ * federated model's `idOffset` does not overlap the primary's mesh ids.
+ *
+ * Control: the same two-load sequence, but with the primary given a non-null
+ * (minimal, entity-less but non-null) data store — standing in for an
+ * IFC/IFCX primary, which always carries a real `dataStore` — registers
+ * correctly and produces disjoint ranges. This isolates the defect to the
+ * `dataStore` nullness, not anything intrinsic to the sequence or the test
+ * harness.
+ */
+
+import '@/test/setup-dom.js';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useViewerStore, type FederatedModel } from '@/store';
+import { useIfcLoader } from './useIfcLoader.js';
+
+// ─── A real, minimal GLB fixture (mirrors useIfcLoader.federatedIdOffset.test.tsx) ──
+
+function buildGLB(expressId: number): Uint8Array {
+  const verts = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  const norms = new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+  const idx = new Uint32Array([0, 1, 2]);
+
+  const posBytes = new Uint8Array(verts.buffer);
+  const normBytes = new Uint8Array(norms.buffer);
+  const idxBytes = new Uint8Array(idx.buffer);
+
+  const json = {
+    asset: { version: '2.0', generator: 'test' },
+    scene: 0,
+    scenes: [{ nodes: [0] }],
+    nodes: [{ mesh: 0, extras: { expressId } }],
+    meshes: [
+      {
+        primitives: [
+          {
+            attributes: { POSITION: 0, NORMAL: 1 },
+            indices: 2,
+            material: 0,
+          },
+        ],
+      },
+    ],
+    materials: [
+      {
+        pbrMetallicRoughness: {
+          baseColorFactor: [0.7, 0.7, 0.7, 1.0],
+          metallicFactor: 0,
+          roughnessFactor: 1,
+        },
+        extensions: { KHR_materials_unlit: {} },
+      },
+    ],
+    accessors: [
+      {
+        bufferView: 0,
+        componentType: 5126,
+        count: 3,
+        type: 'VEC3',
+        min: [0, 0, 0],
+        max: [1, 1, 0],
+      },
+      {
+        bufferView: 1,
+        componentType: 5126,
+        count: 3,
+        type: 'VEC3',
+      },
+      {
+        bufferView: 2,
+        componentType: 5125,
+        count: 3,
+        type: 'SCALAR',
+      },
+    ],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: posBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength, byteLength: normBytes.byteLength, byteStride: 12, target: 34962 },
+      { buffer: 0, byteOffset: posBytes.byteLength + normBytes.byteLength, byteLength: idxBytes.byteLength, target: 34963 },
+    ],
+    buffers: [{ byteLength: posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength }],
+  };
+
+  const jsonStr = JSON.stringify(json);
+  const jsonBuf = new TextEncoder().encode(jsonStr);
+  const jsonPad = (4 - (jsonBuf.byteLength % 4)) % 4;
+  const jsonChunkLen = jsonBuf.byteLength + jsonPad;
+
+  const binLen = posBytes.byteLength + normBytes.byteLength + idxBytes.byteLength;
+  const binPad = (4 - (binLen % 4)) % 4;
+  const binChunkLen = binLen + binPad;
+
+  const total = 12 + 8 + jsonChunkLen + 8 + binChunkLen;
+  const out = new Uint8Array(total);
+  const dv = new DataView(out.buffer);
+  dv.setUint32(0, 0x46546c67, true); // glTF
+  dv.setUint32(4, 2, true);
+  dv.setUint32(8, total, true);
+  dv.setUint32(12, jsonChunkLen, true);
+  dv.setUint32(16, 0x4e4f534a, true); // JSON
+  out.set(jsonBuf, 20);
+  for (let i = 0; i < jsonPad; i++) out[20 + jsonBuf.byteLength + i] = 0x20;
+
+  let off = 20 + jsonChunkLen;
+  dv.setUint32(off, binChunkLen, true);
+  dv.setUint32(off + 4, 0x004e4942, true); // BIN
+  off += 8;
+  out.set(posBytes, off);
+  off += posBytes.byteLength;
+  out.set(normBytes, off);
+  off += normBytes.byteLength;
+  out.set(idxBytes, off);
+  // pad bytes default to 0
+
+  return out;
+}
+
+function glbFile(name: string, expressId: number): File {
+  return new File([buildGLB(expressId) as BlobPart], name, { type: 'model/gltf-binary' });
+}
+
+// ─── Harness: the real hook, rendered ──────────────────────────────────────
+
+let hookApi: ReturnType<typeof useIfcLoader> | null = null;
+
+function Probe(): null {
+  hookApi = useIfcLoader();
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+beforeEach(async () => {
+  hookApi = null;
+  useViewerStore.getState().resetViewerState();
+  useViewerStore.getState().clearAllModels(); // also clears the federation registry
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root!.render(<Probe />);
+  });
+  assert.ok(hookApi, 'the hook must expose loadFile');
+});
+
+afterEach(async () => {
+  const current = root;
+  root = null;
+  if (current) await act(async () => current.unmount());
+  if (container) container.remove();
+  container = null;
+});
+
+describe('useIfcLoader — a primary .glb must register in the federation registry', () => {
+  it('a federated add after a primary GLB gets a disjoint idOffset (no mesh-id overlap)', async () => {
+    // Primary GLB, one mesh at expressId 500.
+    const primaryExpressId = 500;
+    const primaryFile = glbFile('primary.glb', primaryExpressId);
+    await act(async () => {
+      await hookApi!.loadFile(primaryFile, { kind: 'primary' });
+    });
+
+    const { models } = useViewerStore.getState();
+    assert.equal(models.size, 1, 'the primary load must have created exactly one model');
+    const primaryModel = Array.from(models.values())[0]!;
+    assert.equal(primaryModel.geometryResult?.meshes.length, 1, 'the primary fixture carries exactly one mesh');
+    assert.equal(primaryModel.geometryResult!.meshes[0]!.expressId, primaryExpressId, 'sanity: primary mesh keeps its raw expressId (idOffset 0 on a lone primary)');
+
+    // Federated GLB, one mesh at LOCAL expressId 10 (well inside the
+    // primary's [0, 500] range if the registry never advanced).
+    const federatedLocalExpressId = 10;
+    const federatedFile = glbFile('federated.glb', federatedLocalExpressId);
+    await act(async () => {
+      await hookApi!.loadFile(federatedFile, { kind: 'federated', modelId: 'federated-model' });
+    });
+
+    const federatedModel = useViewerStore.getState().models.get('federated-model') as FederatedModel | undefined;
+    assert.ok(federatedModel, 'the federated load must have registered a model');
+    assert.ok(federatedModel.geometryResult, 'the federated model must carry a geometryResult');
+
+    const federatedGlobalMeshId = federatedModel.geometryResult!.meshes[0]!.expressId;
+
+    // The bug: if the primary GLB never registered with the federation
+    // registry, `idOffset` for the federated add stays 0 (or otherwise fails
+    // to clear the primary's own max expressId), so the federated mesh's
+    // GLOBAL id collides with the primary's mesh id space [0, primaryExpressId].
+    assert.ok(
+      federatedModel.idOffset > primaryExpressId,
+      `the federated model's idOffset (${federatedModel.idOffset}) must be greater than the primary GLB's max expressId (${primaryExpressId}) — `
+      + 'otherwise the federated model\'s ids fall inside the primary\'s own id range',
+    );
+    assert.ok(
+      federatedGlobalMeshId > primaryExpressId,
+      `the federated mesh's global expressId (${federatedGlobalMeshId}) must not fall inside the primary GLB's id range [0, ${primaryExpressId}] — `
+      + 'a global id inside that range is indistinguishable from one of the primary model\'s own meshes',
+    );
+  });
+});

--- a/apps/viewer/src/hooks/useIfcLoader.primaryGlbFederationOffset.test.tsx
+++ b/apps/viewer/src/hooks/useIfcLoader.primaryGlbFederationOffset.test.tsx
@@ -6,31 +6,26 @@
  * Pins that a PRIMARY `.glb` load registers itself in the federation registry
  * (`registerModelOffset`), exactly like every other primary format does.
  *
- * `finalizeModel`'s primary branch (`useIfcLoader.ts`) guards the
- * registration on `if (dataStore && geometryResult)`. For a primary GLB,
- * `loadFile`'s GLB branch deliberately passes `dataStore: null` into
- * `finalizeModel` ("Primary keeps the historical null data store (GLB has no
- * entities)") — so that guard never fires for a primary GLB, and the
- * registry's `nextOffset` never advances past 0. A federated model added
- * afterwards is then assigned an offset that starts at (or below) the
- * primary GLB's own max expressId, so the two models' mesh ids overlap:
- * primary mesh `k` and federated mesh `k` (local id) collide in the shared
- * id space `FederationRegistry.toGlobalId`/`fromGlobalId` resolve through.
+ * `finalizeModel`'s primary branch (`useIfcLoader.ts`) used to guard the
+ * registration on `if (dataStore && geometryResult)`; it now guards on
+ * `if (geometryResult)` alone. For a primary GLB, `loadFile`'s GLB branch
+ * deliberately passes `dataStore: null` into `finalizeModel` ("Primary keeps
+ * the historical null data store (GLB has no entities)") — so the old guard
+ * never fired for a primary GLB, and the registry's `nextOffset` never
+ * advanced past 0. A federated model added afterwards was then assigned an
+ * offset that started at (or below) the primary GLB's own max expressId, so
+ * the two models' mesh ids overlapped: primary mesh `k` and federated mesh
+ * `k` (local id) collided in the shared id space
+ * `FederationRegistry.toGlobalId`/`fromGlobalId` resolve through.
  *
- * `useIfcLoader.federatedIdOffset.test.tsx` already documents this exact gap
- * in its own header ("GLB is the one primary format that does NOT
- * register") and works around it by seeding the registry directly rather
- * than driving a real primary load. This file drives BOTH loads for real —
+ * `useIfcLoader.federatedIdOffset.test.tsx` documented this exact gap in its
+ * own header ("GLB is the one primary format that does NOT register") and
+ * works around it by seeding the registry directly rather than driving a real
+ * primary load; its header is corrected alongside this file, since the gap it
+ * described is the one fixed here. This file drives BOTH loads for real —
  * a primary GLB via `loadFile(file, { kind: 'primary' })`, then a federated
  * GLB via `loadFile(file, { kind: 'federated', modelId })` — and asserts the
  * federated model's `idOffset` does not overlap the primary's mesh ids.
- *
- * Control: the same two-load sequence, but with the primary given a non-null
- * (minimal, entity-less but non-null) data store — standing in for an
- * IFC/IFCX primary, which always carries a real `dataStore` — registers
- * correctly and produces disjoint ranges. This isolates the defect to the
- * `dataStore` nullness, not anything intrinsic to the sequence or the test
- * harness.
  */
 
 import '@/test/setup-dom.js';

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -655,10 +655,10 @@ export function useIfcLoader() {
           return;
         }
 
-        // PRIMARY — unchanged from the former finalizePrimaryModel.
+        // PRIMARY. Registration needs only `geometryResult`, not `dataStore` (a primary GLB keeps `dataStore: null`).
         let idOffset = 0;
         let maxExpressId = 0;
-        if (dataStore && geometryResult) {
+        if (geometryResult) {
           maxExpressId = getMaxExpressId(dataStore, geometryResult.meshes);
           idOffset = registerModelOffset(modelId, maxExpressId);
         }


### PR DESCRIPTION
## Summary
- `finalizeModel`'s primary branch (`useIfcLoader.ts`) gated `registerModelOffset` on `dataStore && geometryResult`. A primary `.glb` deliberately keeps `dataStore: null` (GLB has no IFC entities), so that guard never fired and `FederationRegistry`'s `nextOffset` never advanced past 0.
- A federated model added afterwards then received an `idOffset` overlapping the primary GLB's own mesh id range `[0, maxExpressId]` — two models' meshes could resolve to the same global id.
- Fix: registration now depends on `geometryResult` alone, and `getMaxExpressId` now falls back to mesh-derived ids when `dataStore` is null (`dataStore.entityIndex?.byId` → `dataStore?.entityIndex?.byId`; on `main` that read threw a `TypeError` for a null store, so both hunks are load-bearing). The primary model's `ifcDataStore` state is untouched — still `null` for GLB — so every other primary-GLB UI/consumer path (hierarchy panel, property editor, export commands, etc., all gated on `!ifcDataStore`) is unaffected.
- Checked the other `registerModelOffset` call sites: the federated branch and the cache-restore path both reach registration through the same `finalizeModel`, and those two are the only production callers in the repo. The collab room is **not** one of them — `collabSlice` seeds the room model with `upsertModel({ id: 'room:<id>', ..., idOffset: 0, maxExpressId })` and never calls `registerModelOffset` at all. That is a separate, already-documented gap (`useClash.ts`, `useZoneSelection.ts` and `lib/clash/federation-identity.ts` each name it) and is out of scope here; there is no second registration path to fix in parallel.
- Consequence worth naming: a primary GLB's model record now carries a real `maxExpressId` instead of `0`, so its parse-time ownership range in `store/globalId.ts` (`localIdInParseRange`, `localId <= model.maxExpressId`) becomes `[0, maxExpressId]` rather than `[0, 0]`. That is the range every other primary format has always had.
- Two module docstrings described the pre-fix world in the present tense and are corrected in the same PR. The new test's own header quoted the old `if (dataStore && geometryResult)` guard and advertised a "Control" scenario the file does not contain — and which `loadFile` cannot reach, its GLB branch hard-coding `dataStore: null` for a primary — so the paragraph is dropped rather than backfilled with a test. `useIfcLoader.federatedIdOffset.test.tsx` asserted "GLB is the one primary format that does NOT register", plus the reasoning that a real primary registration could only be reproduced with the unreachable WASM engine or a hand-composed IFCX fixture; this PR's own test disproves both, so that paragraph is rewritten.

## Test plan
- [x] New regression test `useIfcLoader.primaryGlbFederationOffset.test.tsx`: drives a real primary `.glb` load then a real federated `.glb` load through `useIfcLoader().loadFile`, asserting the federated model's `idOffset` clears the primary's mesh range. RED on unmodified `upstream/main` (`idOffset` actual `0`, expected `> 500`); GREEN after the fix.
- [x] Mutation-checked each half of the fix separately, exit codes redirected to a file rather than read through a pipe. Reverting the guard to `if (dataStore && geometryResult)` → exit 1, "the federated model's idOffset (0) must be greater than the primary GLB's max expressId (500)". Restoring it and reverting `dataStore?.entityIndex?.byId` → exit 1, same assertion. Neither hunk is dead code.
- [x] `pnpm exec tsc --noEmit` in `apps/viewer` — clean.
- [x] Full `apps/viewer` suite (`npm test`, unsharded): 6571 tests, 6565 pass, 0 fail, 6 skipped. All 8 `useIfcLoader.*.test.tsx` files: 10/10. `useClash.federated-id-offset`, `useLens.model-removal`, `useZoneSelection.collab-room`, `viewerModelIngest`, `store/globalId` included and green.
- [x] Trial-merged current `origin/main` — which reworks the same `finalizeModel` federated branch for #2985 (`applyFederationOffsetToMesh`, `federationMeshIdInvariant.test.ts`) — to check this is not green only against a stale base. The merge is clean and the merged tree is 6579 tests / 6573 pass / 0 fail with `tsc --noEmit` clean.
- [x] `node scripts/check-module-size.mjs` — `useIfcLoader.ts` stays at its 2204-line budget (the fix is net zero lines there) and the allowlist is untouched.
- [x] `check-changesets`, `check-test-glob-coverage`, `check-source-text-assertions`, `check-test-wiring`, `check-loader-hook-specifier-match` — all exit 0.
- [x] Changeset added (`@ifc-lite/viewer`: patch — private package at 1.38.0, versioned for changelog history via `privatePackages.version`). No export is added, removed or renamed; the one signature touched, `getMaxExpressId`, only widens a parameter to `IfcDataStore | null` in an app-internal module, so `patch` is the level AGENTS.md's "biggest API change" rule gives.

Claude-Session: https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436