### PR TITLE
fix(federation): re-home MeshData.materialId by the federation id offset

### DIFF
--- a/.changeset/materialid-federation-offset.md
+++ b/.changeset/materialid-federation-offset.md
@@ -1,0 +1,12 @@
+---
+'@ifc-lite/viewer': patch
+'@ifc-lite/geometry': patch
+---
+
+Re-home `MeshData.materialId` — the `IfcMaterial` express id a material-layer mesh slices (#3199) — by the federation id offset, alongside `expressId` and `geometryItemId` (#2985/#1781).
+
+`materialId` was the one source id `applyFederationOffsetToMesh` left unshifted, by explicit exclusion (#3199/#3525): whether to move it depended on which id space its consumers expected, and offsetting a field a consumer indexed by local id would have been a regression rather than a fix.
+
+Census of every TS-side reader of `MeshData.materialId` (`packages/geometry/src/geometry.worker.ts`, `geometry-coordinate.ts`, the binary cache round trip in `packages/cache/src/sections/geometry.ts`, `apps/viewer/src/utils/serverMesh.ts`) found none that index a store by the raw value or otherwise depend on it being model-local — every one only copies the field through. The five style-lookup sites #3211 found reading a material id as a representation item (`ctx.geometry_style_index` and siblings in `rust/processing/src/element.rs`) are a same-named but unrelated id: they run inside per-model Rust geometry production, before a federation offset exists at all.
+
+With no settled consumer expecting local space, leaving `materialId` unshifted beside an already-global `expressId` on the same mesh reproduced the exact "resolves to a real entity in the wrong model" defect #2985 fixed for `geometryItemId` — worse than a miss, because it looks like an answer. `applyFederationOffsetToMesh` now shifts `materialId` the same way, with the same absence and `0`-is-not-absent guards as the other ids on the mesh.

--- a/apps/viewer/src/hooks/federationMeshIdInvariant.test.ts
+++ b/apps/viewer/src/hooks/federationMeshIdInvariant.test.ts
@@ -151,6 +151,60 @@ describe('federation id-offset — the source item id is re-homed with the expre
     );
   });
 
+  it('flat path: the shifted materialId resolves back to its OWN model, not the primary (#3525)', () => {
+    // Same shape as geometryItemId, disjoint field (#3199): a material-layer
+    // mesh carries `materialId` instead of `geometryItemId`, never both. If
+    // this is left unshifted while `expressId` on the same mesh is global,
+    // the mesh's material resolves to a REAL entity in the WRONG model.
+    const m = mesh({ materialId: LOCAL_ITEM_ID });
+    applyFederationOffsetToMesh(m, secondaryOffset);
+
+    assert.deepEqual(
+      resolve(m.materialId!),
+      { modelId: 'secondary', expressId: LOCAL_ITEM_ID },
+      'materialId must resolve to the secondary model and back to its original local id',
+    );
+    assert.equal(
+      useViewerStore.getState().findModelForGlobalId(m.materialId!),
+      'secondary',
+      'a raw-local material id would answer "primary" here — that is the defect (#3525)',
+    );
+    assert.deepEqual(
+      useViewerStore.getState().resolveGlobalIdFromModels(m.materialId!),
+      { modelId: 'secondary', expressId: LOCAL_ITEM_ID },
+      'the store-backed resolver (the canonical one) must agree with the registry',
+    );
+    assert.equal(
+      resolve(m.expressId)?.modelId,
+      resolve(m.materialId!)?.modelId,
+      'expressId and materialId on one mesh must resolve to the same model',
+    );
+  });
+
+  it('flat path: an absent materialId stays absent — not NaN, not the bare offset (#3525)', () => {
+    const m = mesh({});
+    assert.equal('materialId' in m, false, 'sanity: the fixture must not carry the field');
+
+    applyFederationOffsetToMesh(m, secondaryOffset);
+
+    const materialId: number | undefined = m.materialId;
+    assert.equal('materialId' in m, false, 'the key must not be invented');
+    assert.equal(materialId, undefined, 'an absent material id must stay absent');
+    assert.notEqual(materialId, secondaryOffset, 'an absent material id must not become the bare offset');
+  });
+
+  it('a source materialId of 0 is shifted, not dropped by a truthiness guard (#3525)', () => {
+    const m = mesh({ materialId: 0 });
+    applyFederationOffsetToMesh(m, secondaryOffset);
+    assert.equal(m.materialId, secondaryOffset, 'a 0 material id must still be shifted');
+  });
+
+  it('materialId and geometryItemId are never both offset into the SAME resolved model incorrectly — control: primary model stays untouched at zero offset (#3525)', () => {
+    const m = mesh({ materialId: LOCAL_ITEM_ID });
+    applyFederationOffsetToMesh(m, 0);
+    assert.equal(m.materialId, LOCAL_ITEM_ID, 'a zero offset (primary model) must leave materialId untouched');
+  });
+
   it('flat path: the shifted geometryItemId resolves back to its OWN model, not the primary', () => {
     const m = mesh({ geometryItemId: LOCAL_ITEM_ID });
     applyFederationOffsetToMesh(m, secondaryOffset);

--- a/apps/viewer/src/hooks/useIfcLoader.ts
+++ b/apps/viewer/src/hooks/useIfcLoader.ts
@@ -175,9 +175,9 @@ const COMPLETE_FRAME_WAIT_MS = 1000;
  * `useZoneApportionment`), so an unshifted item id beside a shifted `expressId`
  * on one mesh is exactly the mixed-space case above.
  *
- * `materialId`, the other #3199 source id, is an `IfcMaterial` express id with
- * the same gap and is knowingly NOT shifted here — out of scope for this
- * change, and named so this list is not read as exhaustive.
+ * `materialId`, the other #3199 source id, is an `IfcMaterial` express id from
+ * the same file as `expressId`, so it moves with it too: every TS-side
+ * consumer only copies it (census: PR #3525; #3211's Rust lookups differ).
  *
  * Absence must stay absence: `geometryItemId` is legitimately absent, and both
  * naive shifts are wrong in a way a "the number changed" test accepts —
@@ -195,9 +195,8 @@ export function applyFederationOffsetToMesh(mesh: MeshData, idOffset: number): v
   if (mesh.textureRef) {
     mesh.textureRef = { ...mesh.textureRef, textureId: mesh.textureRef.textureId + idOffset };
   }
-  if (typeof mesh.geometryItemId === 'number') {
-    mesh.geometryItemId = mesh.geometryItemId + idOffset;
-  }
+  if (typeof mesh.geometryItemId === 'number') mesh.geometryItemId = mesh.geometryItemId + idOffset;
+  if (typeof mesh.materialId === 'number') mesh.materialId = mesh.materialId + idOffset;
 }
 
 /**

--- a/packages/geometry/src/types.ts
+++ b/packages/geometry/src/types.ts
@@ -62,7 +62,11 @@ export interface MeshData {
   geometryItemId?: number;
   /** The `IfcMaterial` layer this mesh slices. DISJOINT from `geometryItemId`,
    *  which used to carry it — so following that field for a layered wall landed
-   *  on the wrong entity. `geometryClass === 3` cannot substitute (#3199). */
+   *  on the wrong entity. `geometryClass === 3` cannot substitute (#3199).
+   *  Same id space as `expressId`: a federated viewer session re-homes it
+   *  alongside `expressId` and `geometryItemId` (`applyFederationOffsetToMesh`
+   *  in `apps/viewer/src/hooks/useIfcLoader.ts`), so a value read off this
+   *  field is always safe to resolve the same way as `expressId` (#3525). */
   materialId?: number;
   /** Per-vertex texture coordinates (u, v pairs, 1:1 with positions), present
    *  only for textured meshes (issue #961). */


### PR DESCRIPTION
Fixes #3525

## Consumer census

Louistrue's precondition before offsetting `materialId` blind: enumerate every consumer and determine which id space each expects.

| Consumer | File | Id space | Evidence |
|---|---|---|---|
| Batch spread | `packages/geometry/src/geometry.worker.ts:1011` | pass-through | `...(mesh.materialId !== undefined ? { materialId: mesh.materialId } : {})` — copies the WASM value, does no lookup |
| WASM-getter copy | `packages/geometry/src/geometry-coordinate.ts:95,130` | pass-through | `const sourceMaterialId = (mesh as { materialId?: number }).materialId;` then spread onto the `MeshData` object, unread and uninterpreted |
| Binary cache round trip | `packages/cache/src/sections/geometry.ts:95,211-245` | pass-through | `writer.writeUint32(mesh.materialId ?? ABSENT_SOURCE_ID)` on write, `materialId = mid` on read — pure serialize/deserialize, no id-space-sensitive use |
| Server response adapter | `apps/viewer/src/utils/serverMesh.ts:49` | pass-through | `...(m.material_id !== undefined ? { materialId: m.material_id } : {})` — snake→camel rename only |
| GLB export material index | `packages/cache/src/glb.ts:465-468` | unrelated | `materialIdx` here is the exported GLTF material array index, a different concept entirely (not an `IfcMaterial` express id) |
| "By Material" hierarchy tab | `apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts:1071-1124` (`buildMaterialTree`) | same-named, unrelated field | Built from `buildMaterialUsageIndex(dataStore)` reading the per-model `IfcDataStore` directly, resolved through `resolveTreeGlobalId(modelId, entityId, models)` — never touches `MeshData.materialId` |
| #3211 Rust style lookups | `rust/processing/src/element.rs` (`ctx.geometry_style_index.get(&sub.geometry_id)` and 4 siblings) | model-local, but a different `materialId` at a different pipeline stage | These run inside per-model Rust geometry production (`rust/wasm-bindings/src/zero_copy/mesh.rs` sets `material_id` before crossing to JS) — **before** the TS federation offset in `useIfcLoader.ts` is ever applied. The offset only exists once results leave the WASM boundary, so this is not a consumer of the field this PR touches. |
| GPU-instanced occurrences | `packages/geometry/src/packed-instanced-decoder.ts` (`DecodedInstance`) | n/a | No `materialId`-equivalent field exists on the instanced wire format (only `entityId`/`itemId`) — material-layer slicing doesn't apply to instanced (single-material, rigid-geometry) occurrences, so `applyFederationOffsetToShard` needs no change |

**Result: every settled TS-side consumer only copies the field. None indexes a store by it or otherwise depends on it being model-local.** With no consumer expecting local space, leaving `materialId` unshifted beside an already-global `expressId` on the same mesh reproduces exactly the wrong-model resolution #2985 fixed for `geometryItemId` — worse than a miss, because it looks like an answer.

## RED (on unmodified main)

Added to `apps/viewer/src/hooks/federationMeshIdInvariant.test.ts`, reusing its harness (real `applyFederationOffsetToMesh`, real store resolvers, a primary model given a wide id range so an unshifted secondary-model id lands inside it):

```
flat path: the shifted materialId resolves back to its OWN model, not the primary (#3525)
  materialId must resolve to the secondary model and back to its original local id
  + actual - expected
    {
      expressId: 4638,
  +   modelId: 'primary'
  -   modelId: 'secondary'
    }

a source materialId of 0 is shifted, not dropped by a truthiness guard (#3525)
  a 0 material id must still be shifted
  0 !== 1000000
```

Control (unaffected, passed on main): the primary model's own materials, and `geometryItemId`'s existing coverage, resolved correctly throughout.

## Fix

`apps/viewer/src/hooks/useIfcLoader.ts`, `applyFederationOffsetToMesh`:

```ts
if (typeof mesh.geometryItemId === 'number') mesh.geometryItemId = mesh.geometryItemId + idOffset;
if (typeof mesh.materialId === 'number') mesh.materialId = mesh.materialId + idOffset;
```

Same absence/`0`-is-not-absent guards as the existing `geometryItemId` shift. No other offset site needed changes: `applyFederationOffsetToShard` (instanced path) has no materialId-equivalent field to shift, and the binary cache stores local ids — `applyFederationOffsetToMesh` is the single call site reached by both the fresh-parse and cache-hit load paths (`useIfcLoader.ts` `finalizeModel`), so cache and fresh-parse agree by construction rather than by two offset implementations kept in sync.

## GREEN

All 12 tests in `federationMeshIdInvariant.test.ts` pass, plus `useIfcLoader.federatedIdOffset.test.tsx`, `useIfcLoader.federatedInstancedShardsTdz.test.tsx`, `useIfcLoader.federatedAlignStaleGuard.test.tsx`, `useClash.federated-id-offset.test.tsx`, `federationLoadGate.test.ts`, `serverMesh.test.ts` (22/22), and `packages/cache`'s `geometry.test.ts` (9/9, binary round trip unaffected).

`pnpm exec tsc --noEmit` clean in `apps/viewer` and `packages/geometry`. `node scripts/check-module-size.mjs` and `node scripts/check-unused-locals.mjs` clean (pre-existing `packages/embed-sdk` compile gap is unrelated to this diff). `node scripts/check-test-wiring.mjs` clean.

## Nothing left unsettled

Every consumer census entry above resolved to a definite id-space verdict — no open question remains for `materialId` itself. The #3211 Rust style-lookup defect (reading a material id as a representation item id inside `emit_sub_meshes`) is real but pre-existing and out of scope here; it's a Rust-internal id at a pipeline stage this PR's offset doesn't reach.

## Changesets

- `@ifc-lite/viewer` (patch) — behavior fix
- `@ifc-lite/geometry` (patch) — `MeshData.materialId` doc-comment update recording the id-space invariant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed federated model rendering so material IDs are correctly adjusted alongside other model identifiers.
  * Improved material resolution for secondary federated models, including zero-valued IDs and meshes without material IDs.
  * Preserved existing behavior when no federation offset is applied.

* **Documentation**
  * Clarified how material IDs behave in federated viewer sessions and how they relate to mesh and model identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->