### PR TITLE
fix(query,cli,mcp,viewer): any-match --where across same-named psets/qsets

### DIFF
--- a/.changeset/where-filter-any-match-3490.md
+++ b/.changeset/where-filter-any-match-3490.md
@@ -1,9 +1,10 @@
 ---
-'@ifc-lite/query': patch
+'@ifc-lite/query': minor
 '@ifc-lite/cli': patch
 '@ifc-lite/mcp': patch
+'@ifc-lite/viewer': patch
 ---
 
 `query --where` (and `query_entities`'s `property` filter over MCP) tested only the first same-named property or quantity set, so an entity was wrongly excluded when the value it should have matched lived on a later same-named set (#3490) — two `IfcPropertySet`/`IfcElementQuantity` entities sharing one name is legitimate (e.g. one from the type definition, one from the occurrence).
 
-A filter is a predicate over the entity, so it now passes when ANY same-named set satisfies the operator, not just the first one found — uniformly across every operator, `!=` included. `@ifc-lite/query` adds `findAllPropertiesInSets`/`findAllQuantitiesInSets` (alongside the existing first-match `findPropertyInSets`/`findQuantityInSets`, which stay correct for value extraction — export, aggregation, display); `@ifc-lite/cli`'s `query --where` and the shared `HeadlessBackend.query.entities()` filter, and `@ifc-lite/mcp`'s `query_entities` filter, all switch to the any-match lookup.
+A filter is a predicate over the entity, so it now passes when ANY same-named set satisfies the operator, not just the first one found — uniformly across every operator, `!=` included. `@ifc-lite/query` adds `findAllPropertiesInSets`/`findAllQuantitiesInSets` (alongside the existing first-match `findPropertyInSets`/`findQuantityInSets`, which stay correct for value extraction — export, aggregation, display); `@ifc-lite/cli`'s `query --where` and the shared `HeadlessBackend.query.entities()` filter, and `@ifc-lite/mcp`'s `query_entities` filter, all switch to the any-match lookup. The viewer SDK's `entities()` filter now matches a property/quantity in ANY same-named set, not only the first.

--- a/.changeset/where-filter-any-match-3490.md
+++ b/.changeset/where-filter-any-match-3490.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/query': patch
+'@ifc-lite/cli': patch
+'@ifc-lite/mcp': patch
+---
+
+`query --where` (and `query_entities`'s `property` filter over MCP) tested only the first same-named property or quantity set, so an entity was wrongly excluded when the value it should have matched lived on a later same-named set (#3490) — two `IfcPropertySet`/`IfcElementQuantity` entities sharing one name is legitimate (e.g. one from the type definition, one from the occurrence).
+
+A filter is a predicate over the entity, so it now passes when ANY same-named set satisfies the operator, not just the first one found — uniformly across every operator, `!=` included. `@ifc-lite/query` adds `findAllPropertiesInSets`/`findAllQuantitiesInSets` (alongside the existing first-match `findPropertyInSets`/`findQuantityInSets`, which stay correct for value extraction — export, aggregation, display); `@ifc-lite/cli`'s `query --where` and the shared `HeadlessBackend.query.entities()` filter, and `@ifc-lite/mcp`'s `query_entities` filter, all switch to the any-match lookup.

--- a/apps/viewer/src/sdk/adapters/query-adapter.duplicate-pset-filter.test.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.duplicate-pset-filter.test.ts
@@ -24,6 +24,16 @@ function guid(mnemonic: string): string {
 
 // Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
 // IsExternal, the second (#83) has the FireRating we're filtering on.
+//
+// Wall #90 (Wall F) carries TWO "Pset_WallCommon" sets that BOTH carry
+// FireRating, with DIFFERENT values: #92 (first) is 'REI30' (does not
+// match), #95 (second) is 'REI60' (matches). This is the shape #3490
+// actually reports — `findPropertyInSets` finds the property on the
+// FIRST set either way, so testing only that one value wrongly excludes
+// the wall when the match lives on the second set.
+//
+// Wall #100 (Wall G) carries the same two-set shape with NEITHER value
+// matching — the negative control.
 const MODEL = `ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((''),'2;1');
@@ -42,7 +52,7 @@ DATA;
 #42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
 #43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
 #44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
-#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72,#90,#100),#41);
 #72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
 #81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
 #80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
@@ -50,6 +60,20 @@ DATA;
 #84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
 #83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
 #85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+#90= IFCWALL('${guid('WALF')}',$,'Wall F',$,$,#40,$,'tagF',$);
+#91= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI30'),$);
+#92= IFCPROPERTYSET('${guid('PST3')}',$,'Pset_WallCommon',$,(#91));
+#93= IFCRELDEFINESBYPROPERTIES('${guid('RDP3')}',$,$,$,(#90),#92);
+#94= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#95= IFCPROPERTYSET('${guid('PST4')}',$,'Pset_WallCommon',$,(#94));
+#96= IFCRELDEFINESBYPROPERTIES('${guid('RDP4')}',$,$,$,(#90),#95);
+#100= IFCWALL('${guid('WALG')}',$,'Wall G',$,$,#40,$,'tagG',$);
+#101= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI30'),$);
+#102= IFCPROPERTYSET('${guid('PST5')}',$,'Pset_WallCommon',$,(#101));
+#103= IFCRELDEFINESBYPROPERTIES('${guid('RDP5')}',$,$,$,(#100),#102);
+#104= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI45'),$);
+#105= IFCPROPERTYSET('${guid('PST6')}',$,'Pset_WallCommon',$,(#104));
+#106= IFCRELDEFINESBYPROPERTIES('${guid('RDP6')}',$,$,$,(#100),#105);
 ENDSEC;
 END-ISO-10303-21;
 `;
@@ -68,7 +92,7 @@ function makeStore(dataStore: IfcDataStore): StoreApi {
   } as unknown as StoreApi;
 }
 
-test('queryEntities property filter does not silently exclude an entity whose filtered property lives on the SECOND same-named set', async () => {
+test('queryEntities property filter does not silently exclude an entity whose filtered property lives on the SECOND same-named set (Wall A: FIRST set has no FireRating at all), and any-matches an entity whose SECOND set overrides a non-matching value on the FIRST (Wall F: #3490)', async () => {
   const parser = new IfcParser();
   const buffer = new TextEncoder().encode(MODEL).buffer as ArrayBuffer;
   const dataStore = await parser.parseColumnar(buffer);
@@ -80,7 +104,7 @@ test('queryEntities property filter does not silently exclude an entity whose fi
     filters: [{ psetName: 'Pset_WallCommon', propName: 'FireRating', operator: '=', value: 'REI60' }],
   });
 
-  assert.deepEqual(results.map((e) => e.name), ['Wall A']);
+  assert.deepEqual(results.map((e) => e.name), ['Wall A', 'Wall F']);
 });
 
 test('queryEntities property filter still matches on the FIRST same-named set', async () => {
@@ -96,4 +120,19 @@ test('queryEntities property filter still matches on the FIRST same-named set', 
   });
 
   assert.deepEqual(results.map((e) => e.name), ['Wall A']);
+});
+
+test('queryEntities property filter excludes an entity where NEITHER same-named set matches', async () => {
+  const parser = new IfcParser();
+  const buffer = new TextEncoder().encode(MODEL).buffer as ArrayBuffer;
+  const dataStore = await parser.parseColumnar(buffer);
+
+  const adapter = createQueryAdapter(makeStore(dataStore));
+  const results = adapter.entities({
+    modelId: 'default',
+    types: ['IfcWall'],
+    filters: [{ psetName: 'Pset_WallCommon', propName: 'FireRating', operator: '=', value: 'REI99' }],
+  });
+
+  assert.deepEqual(results.map((e) => e.name), []);
 });

--- a/apps/viewer/src/sdk/adapters/query-adapter.ts
+++ b/apps/viewer/src/sdk/adapters/query-adapter.ts
@@ -17,7 +17,7 @@ import type {
   QueryBackendMethods,
 } from '@ifc-lite/sdk';
 import type { StoreApi } from './types.js';
-import { EntityNode, findPropertyInSets } from '@ifc-lite/query';
+import { EntityNode, findAllPropertiesInSets } from '@ifc-lite/query';
 import { IfcTypeEnum, IfcTypeEnumFromString } from '@ifc-lite/data';
 import { getModelForRef, getAllModelEntries } from './model-compat.js';
 import {
@@ -242,21 +242,27 @@ export function createQueryAdapter(store: StoreApi): QueryBackendMethods {
       for (const filter of descriptor.filters) {
         filtered = filtered.filter(entity => {
           const props = getCachedProps(entity.ref);
-          const prop = findPropertyInSets(props, filter.psetName, filter.propName);
-          if (!prop) return false;
+          // Any-match, not first-match (#3490): an entity can carry two
+          // distinct same-named property sets (type + occurrence), so a
+          // filter predicate passes when ANY of them satisfies the
+          // condition, not just the first one found.
+          const matchingProps = findAllPropertiesInSets(props, filter.psetName, filter.propName);
+          if (matchingProps.length === 0) return false;
           if (filter.operator === 'exists') return true;
 
-          const val = prop.value;
-          switch (filter.operator) {
-            case '=': return String(val) === String(filter.value);
-            case '!=': return String(val) !== String(filter.value);
-            case '>': return Number(val) > Number(filter.value);
-            case '<': return Number(val) < Number(filter.value);
-            case '>=': return Number(val) >= Number(filter.value);
-            case '<=': return Number(val) <= Number(filter.value);
-            case 'contains': return String(val).includes(String(filter.value));
-            default: return false;
-          }
+          return matchingProps.some(prop => {
+            const val = prop.value;
+            switch (filter.operator) {
+              case '=': return String(val) === String(filter.value);
+              case '!=': return String(val) !== String(filter.value);
+              case '>': return Number(val) > Number(filter.value);
+              case '<': return Number(val) < Number(filter.value);
+              case '>=': return Number(val) >= Number(filter.value);
+              case '<=': return Number(val) <= Number(filter.value);
+              case 'contains': return String(val).includes(String(filter.value));
+              default: return false;
+            }
+          });
         });
       }
     }

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -10,11 +10,14 @@
  * classifications, attributes, relationships, type properties.
  */
 
-import { findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
+import { findPropertyInSets } from '@ifc-lite/query';
 import { createHeadlessContext } from '../loader.js';
 import { printJson, getFlag, hasFlag, fatal, validateLimit } from '../output.js';
 import { STANDARD_QTO_MAP, sortEntities } from './query-aggregation.js';
 import { VALID_GROUP_BY_KEYS, outputCount, outputSum, outputAggregation, outputGroupBy, outputEntities } from './query-output.js';
+import { applyWhereFilter, parseWhereFilter, compareValues, normalizeBooleanValue } from './where-filter.js';
+
+export { applyWhereFilter, parseWhereFilter, compareValues, normalizeBooleanValue };
 
 /**
  * B9/F6: Auto-prefix Ifc for --type if user omits it.
@@ -31,90 +34,6 @@ export function normalizeTypeName(typeStr: string): string {
     process.stderr.write(`Note: Auto-corrected type "${trimmed}" → "${prefixed}"\n`);
     return prefixed;
   }).join(',');
-}
-
-/**
- * Parse a --where filter string into psetName, propName, operator, value.
- * Supported formats:
- *   PsetName.PropName=Value     (equals)
- *   PsetName.PropName!=Value    (not equals)
- *   PsetName.PropName>Value     (greater than)
- *   PsetName.PropName<Value     (less than)
- *   PsetName.PropName>=Value    (greater or equal)
- *   PsetName.PropName<=Value    (less or equal)
- *   PsetName.PropName~Value     (contains)
- *   PsetName.PropName           (exists)
- */
-export function parseWhereFilter(filter: string): { psetName: string; propName: string; operator: string; value?: string } {
-  const dotIdx = filter.indexOf('.');
-  if (dotIdx <= 0) {
-    fatal(`Invalid --where syntax: "${filter}". Expected: PsetName.PropName[=Value]`);
-  }
-
-  const psetName = filter.slice(0, dotIdx);
-  const rest = filter.slice(dotIdx + 1);
-
-  // Try multi-char operators first, then single-char
-  for (const op of ['!=', '>=', '<=', '>', '<', '=', '~']) {
-    const opIdx = rest.indexOf(op);
-    if (opIdx > 0) {
-      const propName = rest.slice(0, opIdx);
-      const value = rest.slice(opIdx + op.length);
-      const mappedOp = op === '~' ? 'contains' : op;
-      return { psetName, propName, operator: mappedOp, value };
-    }
-  }
-
-  // No operator found — exists check
-  return { psetName, propName: rest, operator: 'exists' };
-}
-
-/**
- * B3/F1: Apply --where filter to entities, searching both property sets AND quantity sets.
- * Falls back to quantity sets when a property set match is not found.
- */
-export function applyWhereFilter(entities: any[], parsed: ReturnType<typeof parseWhereFilter>, bim: any): any[] {
-  return entities.filter(e => {
-    // First try property sets
-    const props = bim.properties(e.ref);
-    const prop = findPropertyInSets<any>(props, parsed.psetName, parsed.propName);
-    if (prop) {
-      if (parsed.operator === 'exists') return true;
-      return compareValues(prop.value, parsed.operator, parsed.value);
-    }
-
-    // B3: Also search quantity sets
-    const qsets = bim.quantities(e.ref);
-    const qty = findQuantityInSets<any>(qsets, parsed.psetName, parsed.propName);
-    if (qty) {
-      if (parsed.operator === 'exists') return true;
-      return compareValues(qty.value, parsed.operator, parsed.value);
-    }
-
-    return false;
-  });
-}
-
-export function compareValues(actual: any, operator: string, expected: string | undefined): boolean {
-  if (expected === undefined) return actual != null;
-  const normActual = normalizeBooleanValue(actual);
-  const normExpected = normalizeBooleanValue(expected);
-  switch (operator) {
-    case '=': return String(normActual) === String(normExpected);
-    case '!=': return String(normActual) !== String(normExpected);
-    case '>': return Number(normActual) > Number(normExpected);
-    case '<': return Number(normActual) < Number(normExpected);
-    case '>=': return Number(normActual) >= Number(normExpected);
-    case '<=': return Number(normActual) <= Number(normExpected);
-    case 'contains': return String(normActual).toLowerCase().includes(String(normExpected).toLowerCase());
-    default: return false;
-  }
-}
-
-export function normalizeBooleanValue(value: unknown): unknown {
-  if (value === true || value === '.T.' || value === 'true' || value === 'TRUE') return 'true';
-  if (value === false || value === '.F.' || value === 'false' || value === 'FALSE') return 'false';
-  return value;
 }
 
 export async function queryCommand(args: string[]): Promise<void> {

--- a/packages/cli/src/commands/where-filter-any-match.test.ts
+++ b/packages/cli/src/commands/where-filter-any-match.test.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #3490: `applyWhereFilter` tested only the FIRST same-named property (or
+ * quantity) set. `duplicate-pset-lookup.test.ts` already covers the
+ * existence-spread case (the property only lives on the second set); this
+ * file covers the case #3490 actually reports — BOTH same-named sets carry
+ * the requested property, with DIFFERENT values, and only the value on the
+ * later set satisfies the `--where` operator. `findPropertyInSets` already
+ * finds the property in that case (existence is not the bug); it returns
+ * the FIRST same-named set's value, and `compareValues` tests only that
+ * one, so the entity is wrongly excluded.
+ *
+ * A filter is a predicate over the entity: it should pass when ANY
+ * same-named set satisfies the condition, not just the first one found.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyWhereFilter, parseWhereFilter } from './query.js';
+
+/**
+ * wallC: FIRST set REI30 (no match), SECOND set REI60 (matches) — the
+ * exact shape from the issue.
+ * wallD: neither set matches (REI30, REI45).
+ * wallE: FIRST set already matches (REI60, REI90) — must keep working.
+ */
+const PROPS: Record<string, unknown[]> = {
+  wallC: [
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI30' }] },
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI60' }] },
+  ],
+  wallD: [
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI30' }] },
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI45' }] },
+  ],
+  wallE: [
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI60' }] },
+    { name: 'Pset_WallCommon', properties: [{ name: 'FireRating', value: 'REI90' }] },
+  ],
+};
+
+/** Same shape, on the quantity side ("Also make sure --where on a qset ..."). */
+const QUANTITIES: Record<string, unknown[]> = {
+  qtyC: [
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Width', value: 5 }] },
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Width', value: 9 }] },
+  ],
+  qtyD: [
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Width', value: 5 }] },
+    { name: 'Qto_WallBaseQuantities', quantities: [{ name: 'Width', value: 6 }] },
+  ],
+};
+
+const bim = {
+  properties: (ref: string) => PROPS[ref] ?? [],
+  quantities: (ref: string) => QUANTITIES[ref] ?? [],
+};
+
+const wallC = { ref: 'wallC', name: 'Wall C' };
+const wallD = { ref: 'wallD', name: 'Wall D' };
+const wallE = { ref: 'wallE', name: 'Wall E' };
+const qtyC = { ref: 'qtyC', name: 'Qty C' };
+const qtyD = { ref: 'qtyD', name: 'Qty D' };
+
+describe('applyWhereFilter: two same-named psets carrying different values for the same property (#3490)', () => {
+  it('returns an entity whose SECOND same-named set satisfies the filter, even though the first does not', () => {
+    const parsed = parseWhereFilter('Pset_WallCommon.FireRating=REI60');
+    expect(applyWhereFilter([wallC], parsed, bim).map(e => e.ref)).toEqual(['wallC']);
+  });
+
+  it('still returns an entity whose FIRST same-named set already satisfies the filter', () => {
+    const parsed = parseWhereFilter('Pset_WallCommon.FireRating=REI60');
+    expect(applyWhereFilter([wallE], parsed, bim).map(e => e.ref)).toEqual(['wallE']);
+  });
+
+  it('excludes an entity where NEITHER same-named set satisfies the filter', () => {
+    const parsed = parseWhereFilter('Pset_WallCommon.FireRating=REI60');
+    expect(applyWhereFilter([wallD], parsed, bim)).toEqual([]);
+  });
+
+  it('runs the same any-match across all three entities in one pass', () => {
+    const parsed = parseWhereFilter('Pset_WallCommon.FireRating=REI60');
+    expect(applyWhereFilter([wallC, wallD, wallE], parsed, bim).map(e => e.ref)).toEqual(['wallC', 'wallE']);
+  });
+
+  it('applies any-match to != too: passes when ANY same-named set differs, not only when EVERY set differs', () => {
+    // wallC carries REI30 and REI60. Under any-match, the REI30 occurrence
+    // alone satisfies `!= REI60`, so the wall passes even though its
+    // second set equals REI60. This is the semantics chosen for #3490:
+    // uniform any-match across every operator, matching the ANY-match
+    // `matchesPsetFilter`/`matchesQsetFilter` already use for
+    // `EntityQuery.whereProperty` in packages/query.
+    const parsed = parseWhereFilter('Pset_WallCommon.FireRating!=REI60');
+    expect(applyWhereFilter([wallC], parsed, bim).map(e => e.ref)).toEqual(['wallC']);
+  });
+});
+
+describe('applyWhereFilter: two same-named qsets carrying different values for the same quantity (#3490)', () => {
+  it('returns an entity whose SECOND same-named qset satisfies the filter', () => {
+    const parsed = parseWhereFilter('Qto_WallBaseQuantities.Width=9');
+    expect(applyWhereFilter([qtyC], parsed, bim).map(e => e.ref)).toEqual(['qtyC']);
+  });
+
+  it('excludes an entity where NEITHER same-named qset satisfies the filter', () => {
+    const parsed = parseWhereFilter('Qto_WallBaseQuantities.Width=9');
+    expect(applyWhereFilter([qtyD], parsed, bim)).toEqual([]);
+  });
+});

--- a/packages/cli/src/commands/where-filter.ts
+++ b/packages/cli/src/commands/where-filter.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `--where` filter parsing and evaluation for `ifc-lite query`. Split out of
+ * `query.ts` (module-size ratchet) — this half is the filter language, the
+ * rest of that file is the command's flag handling and output shaping.
+ */
+
+import { findAllPropertiesInSets, findAllQuantitiesInSets } from '@ifc-lite/query';
+import { fatal } from '../output.js';
+
+/**
+ * Parse a --where filter string into psetName, propName, operator, value.
+ * Supported formats:
+ *   PsetName.PropName=Value     (equals)
+ *   PsetName.PropName!=Value    (not equals)
+ *   PsetName.PropName>Value     (greater than)
+ *   PsetName.PropName<Value     (less than)
+ *   PsetName.PropName>=Value    (greater or equal)
+ *   PsetName.PropName<=Value    (less or equal)
+ *   PsetName.PropName~Value     (contains)
+ *   PsetName.PropName           (exists)
+ */
+export function parseWhereFilter(filter: string): { psetName: string; propName: string; operator: string; value?: string } {
+  const dotIdx = filter.indexOf('.');
+  if (dotIdx <= 0) {
+    fatal(`Invalid --where syntax: "${filter}". Expected: PsetName.PropName[=Value]`);
+  }
+
+  const psetName = filter.slice(0, dotIdx);
+  const rest = filter.slice(dotIdx + 1);
+
+  // Try multi-char operators first, then single-char
+  for (const op of ['!=', '>=', '<=', '>', '<', '=', '~']) {
+    const opIdx = rest.indexOf(op);
+    if (opIdx > 0) {
+      const propName = rest.slice(0, opIdx);
+      const value = rest.slice(opIdx + op.length);
+      const mappedOp = op === '~' ? 'contains' : op;
+      return { psetName, propName, operator: mappedOp, value };
+    }
+  }
+
+  // No operator found — exists check
+  return { psetName, propName: rest, operator: 'exists' };
+}
+
+/**
+ * B3/F1: Apply --where filter to entities, searching both property sets AND quantity sets.
+ * Falls back to quantity sets when a property set match is not found.
+ *
+ * Any-match, not first-match: an entity can legitimately carry two distinct
+ * property (or quantity) sets sharing the same name — e.g. one from the type
+ * definition and one from the occurrence (see `packages/query/src/pset-lookup.ts`).
+ * A filter is a predicate over the entity, so it passes when ANY same-named
+ * set satisfies the condition, even if an earlier same-named set does not
+ * (#3490). This applies uniformly to every operator, `!=` included: `!=`
+ * asks "does some occurrence of this property have a different value", the
+ * same any-match shape `EntityQuery.whereProperty` already uses via
+ * `matchesPsetFilter`/`matchesQsetFilter`.
+ */
+export function applyWhereFilter(entities: any[], parsed: ReturnType<typeof parseWhereFilter>, bim: any): any[] {
+  return entities.filter(e => {
+    // First try property sets
+    const props = bim.properties(e.ref);
+    const matchingProps = findAllPropertiesInSets<any>(props, parsed.psetName, parsed.propName);
+    if (matchingProps.length > 0) {
+      if (parsed.operator === 'exists') return true;
+      return matchingProps.some(prop => compareValues(prop.value, parsed.operator, parsed.value));
+    }
+
+    // B3: Also search quantity sets
+    const qsets = bim.quantities(e.ref);
+    const matchingQtys = findAllQuantitiesInSets<any>(qsets, parsed.psetName, parsed.propName);
+    if (matchingQtys.length > 0) {
+      if (parsed.operator === 'exists') return true;
+      return matchingQtys.some(qty => compareValues(qty.value, parsed.operator, parsed.value));
+    }
+
+    return false;
+  });
+}
+
+export function compareValues(actual: any, operator: string, expected: string | undefined): boolean {
+  if (expected === undefined) return actual != null;
+  const normActual = normalizeBooleanValue(actual);
+  const normExpected = normalizeBooleanValue(expected);
+  switch (operator) {
+    case '=': return String(normActual) === String(normExpected);
+    case '!=': return String(normActual) !== String(normExpected);
+    case '>': return Number(normActual) > Number(normExpected);
+    case '<': return Number(normActual) < Number(normExpected);
+    case '>=': return Number(normActual) >= Number(normExpected);
+    case '<=': return Number(normActual) <= Number(normExpected);
+    case 'contains': return String(normActual).toLowerCase().includes(String(normExpected).toLowerCase());
+    default: return false;
+  }
+}
+
+export function normalizeBooleanValue(value: unknown): unknown {
+  if (value === true || value === '.T.' || value === 'true' || value === 'TRUE') return 'true';
+  if (value === false || value === '.F.' || value === 'false' || value === 'FALSE') return 'false';
+  return value;
+}

--- a/packages/cli/src/headless-backend-duplicate-pset-filter.test.ts
+++ b/packages/cli/src/headless-backend-duplicate-pset-filter.test.ts
@@ -25,6 +25,16 @@ function guid(mnemonic: string): string {
 
 // Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
 // IsExternal, the second (#83) has the FireRating we're filtering on.
+//
+// Wall #90 (Wall F) carries TWO "Pset_WallCommon" sets that BOTH carry
+// FireRating, with DIFFERENT values: #92 (first) is 'REI30' (does not
+// match), #95 (second) is 'REI60' (matches). This is the shape #3490
+// actually reports — `findPropertyInSets` finds the property on the
+// FIRST set either way, so testing only that one value wrongly excludes
+// the wall when the match lives on the second set.
+//
+// Wall #100 (Wall G) carries the same two-set shape with NEITHER value
+// matching — the negative control.
 const MODEL = `ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((''),'2;1');
@@ -43,7 +53,7 @@ DATA;
 #42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
 #43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
 #44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
-#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72,#90,#100),#41);
 #72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
 #81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
 #80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
@@ -51,6 +61,20 @@ DATA;
 #84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
 #83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
 #85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+#90= IFCWALL('${guid('WALF')}',$,'Wall F',$,$,#40,$,'tagF',$);
+#91= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI30'),$);
+#92= IFCPROPERTYSET('${guid('PST3')}',$,'Pset_WallCommon',$,(#91));
+#93= IFCRELDEFINESBYPROPERTIES('${guid('RDP3')}',$,$,$,(#90),#92);
+#94= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#95= IFCPROPERTYSET('${guid('PST4')}',$,'Pset_WallCommon',$,(#94));
+#96= IFCRELDEFINESBYPROPERTIES('${guid('RDP4')}',$,$,$,(#90),#95);
+#100= IFCWALL('${guid('WALG')}',$,'Wall G',$,$,#40,$,'tagG',$);
+#101= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI30'),$);
+#102= IFCPROPERTYSET('${guid('PST5')}',$,'Pset_WallCommon',$,(#101));
+#103= IFCRELDEFINESBYPROPERTIES('${guid('RDP5')}',$,$,$,(#100),#102);
+#104= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI45'),$);
+#105= IFCPROPERTYSET('${guid('PST6')}',$,'Pset_WallCommon',$,(#104));
+#106= IFCRELDEFINESBYPROPERTIES('${guid('RDP6')}',$,$,$,(#100),#105);
 ENDSEC;
 END-ISO-10303-21;
 `;
@@ -69,14 +93,14 @@ afterAll(async () => {
 });
 
 describe('HeadlessBackend query.entities() property filter — two same-named property sets', () => {
-  it('does not silently exclude an entity whose filtered property lives on the SECOND same-named set', () => {
+  it('does not silently exclude an entity whose filtered property lives on the SECOND same-named set (Wall A: FIRST set has no FireRating at all), and any-matches an entity whose SECOND set overrides a non-matching value on the FIRST (Wall F: #3490)', () => {
     const results = bim
       .query()
       .byType('IfcWall')
       .where('Pset_WallCommon', 'FireRating', '=', 'REI60')
       .toArray();
 
-    expect(results.map((e) => e.name)).toEqual(['Wall A']);
+    expect(results.map((e) => e.name)).toEqual(['Wall A', 'Wall F']);
   });
 
   it('still matches on the property from the FIRST same-named set', () => {
@@ -87,5 +111,15 @@ describe('HeadlessBackend query.entities() property filter — two same-named pr
       .toArray();
 
     expect(results.map((e) => e.name)).toEqual(['Wall A']);
+  });
+
+  it('excludes an entity where NEITHER same-named set matches', () => {
+    const results = bim
+      .query()
+      .byType('IfcWall')
+      .where('Pset_WallCommon', 'FireRating', '=', 'REI99')
+      .toArray();
+
+    expect(results.map((e) => e.name)).toEqual([]);
   });
 });

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -70,7 +70,7 @@ import {
   listStoreys,
   type GenerateSpacesAllOptions,
 } from '@ifc-lite/create';
-import { EntityNode, findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
+import { EntityNode, findPropertyInSets, findQuantityInSets, findAllPropertiesInSets } from '@ifc-lite/query';
 
 import {
   extractAllEntityAttributes,
@@ -331,24 +331,29 @@ export class HeadlessBackend implements BimBackend {
           for (const filter of descriptor.filters) {
             filtered = filtered.filter(entity => {
               const props = getCachedProps(entity.ref);
-              const prop = findPropertyInSets(props, filter.psetName, filter.propName);
-              if (!prop) return false;
+              // Any-match, not first-match (#3490): an entity can carry two
+              // distinct same-named property sets (type + occurrence), so a
+              // filter predicate passes when ANY of them satisfies the
+              // condition, not just the first one found.
+              const matchingProps = findAllPropertiesInSets(props, filter.psetName, filter.propName);
+              if (matchingProps.length === 0) return false;
               if (filter.operator === 'exists') return true;
-              const val = prop.value;
               const filterVal = filter.value;
-              // Normalize booleans: .T./.F./true/false all compare equally
-              const normVal = normalizeBooleanValue(val);
               const normFilterVal = normalizeBooleanValue(filterVal);
-              switch (filter.operator) {
-                case '=': return String(normVal) === String(normFilterVal);
-                case '!=': return String(normVal) !== String(normFilterVal);
-                case '>': return Number(normVal) > Number(normFilterVal);
-                case '<': return Number(normVal) < Number(normFilterVal);
-                case '>=': return Number(normVal) >= Number(normFilterVal);
-                case '<=': return Number(normVal) <= Number(normFilterVal);
-                case 'contains': return String(normVal).toLowerCase().includes(String(normFilterVal).toLowerCase());
-                default: return false;
-              }
+              return matchingProps.some(prop => {
+                // Normalize booleans: .T./.F./true/false all compare equally
+                const normVal = normalizeBooleanValue(prop.value);
+                switch (filter.operator) {
+                  case '=': return String(normVal) === String(normFilterVal);
+                  case '!=': return String(normVal) !== String(normFilterVal);
+                  case '>': return Number(normVal) > Number(normFilterVal);
+                  case '<': return Number(normVal) < Number(normFilterVal);
+                  case '>=': return Number(normVal) >= Number(normFilterVal);
+                  case '<=': return Number(normVal) <= Number(normFilterVal);
+                  case 'contains': return String(normVal).toLowerCase().includes(String(normFilterVal).toLowerCase());
+                  default: return false;
+                }
+              });
             });
           }
         }

--- a/packages/cli/src/headless-backend.ts
+++ b/packages/cli/src/headless-backend.ts
@@ -70,7 +70,7 @@ import {
   listStoreys,
   type GenerateSpacesAllOptions,
 } from '@ifc-lite/create';
-import { EntityNode, findPropertyInSets, findQuantityInSets, findAllPropertiesInSets } from '@ifc-lite/query';
+import { EntityNode, findPropertyInSets, findQuantityInSets } from '@ifc-lite/query';
 
 import {
   extractAllEntityAttributes,
@@ -90,6 +90,7 @@ import { escapeCsvCell, exportToStep, StepExporter, type StepExportOptions } fro
 import { exportHbjson, exportDfjson } from './energy-export.js';
 import { foldQueuedRelated } from './query-overlay-relations.js';
 import { overlayEntityData, foldNewEntities } from './query-overlay.js';
+import { matchesPropertyFilter } from './property-filter-match.js';
 
 // `expandTypes` used to be defined here; it now comes from `@ifc-lite/parser`,
 // shared with the other query backends (see `query-backend-maps.ts`). Re-exported
@@ -331,29 +332,7 @@ export class HeadlessBackend implements BimBackend {
           for (const filter of descriptor.filters) {
             filtered = filtered.filter(entity => {
               const props = getCachedProps(entity.ref);
-              // Any-match, not first-match (#3490): an entity can carry two
-              // distinct same-named property sets (type + occurrence), so a
-              // filter predicate passes when ANY of them satisfies the
-              // condition, not just the first one found.
-              const matchingProps = findAllPropertiesInSets(props, filter.psetName, filter.propName);
-              if (matchingProps.length === 0) return false;
-              if (filter.operator === 'exists') return true;
-              const filterVal = filter.value;
-              const normFilterVal = normalizeBooleanValue(filterVal);
-              return matchingProps.some(prop => {
-                // Normalize booleans: .T./.F./true/false all compare equally
-                const normVal = normalizeBooleanValue(prop.value);
-                switch (filter.operator) {
-                  case '=': return String(normVal) === String(normFilterVal);
-                  case '!=': return String(normVal) !== String(normFilterVal);
-                  case '>': return Number(normVal) > Number(normFilterVal);
-                  case '<': return Number(normVal) < Number(normFilterVal);
-                  case '>=': return Number(normVal) >= Number(normFilterVal);
-                  case '<=': return Number(normVal) <= Number(normFilterVal);
-                  case 'contains': return String(normVal).toLowerCase().includes(String(normFilterVal).toLowerCase());
-                  default: return false;
-                }
-              });
+              return matchesPropertyFilter(props, filter);
             });
           }
         }

--- a/packages/cli/src/property-filter-match.ts
+++ b/packages/cli/src/property-filter-match.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `entities()`'s `descriptor.filters` predicate, split out of
+ * `headless-backend.ts` (module-size ratchet).
+ *
+ * Any-match, not first-match (#3490): an entity can carry two distinct
+ * same-named property sets (type + occurrence), so a filter predicate
+ * passes when ANY of them satisfies the condition, not just the first
+ * one found. This applies uniformly to every operator, `!=` included.
+ */
+
+import type { PropertySetData, QueryFilter } from '@ifc-lite/sdk';
+import { findAllPropertiesInSets } from '@ifc-lite/query';
+
+function normalizeBoolean(value: unknown): unknown {
+  if (value === true || value === '.T.' || value === 'true' || value === 'TRUE') return 'true';
+  if (value === false || value === '.F.' || value === 'false' || value === 'FALSE') return 'false';
+  return value;
+}
+
+export function matchesPropertyFilter(props: PropertySetData[], filter: QueryFilter): boolean {
+  const matchingProps = findAllPropertiesInSets(props, filter.psetName, filter.propName);
+  if (matchingProps.length === 0) return false;
+  if (filter.operator === 'exists') return true;
+  const f = normalizeBoolean(filter.value);
+  return matchingProps.some((prop) => {
+    const v = normalizeBoolean(prop.value);
+    switch (filter.operator) {
+      case '=': return String(v) === String(f);
+      case '!=': return String(v) !== String(f);
+      case '>': return Number(v) > Number(f);
+      case '<': return Number(v) < Number(f);
+      case '>=': return Number(v) >= Number(f);
+      case '<=': return Number(v) <= Number(f);
+      case 'contains': return String(v).toLowerCase().includes(String(f).toLowerCase());
+      default: return false;
+    }
+  });
+}

--- a/packages/mcp/src/backend-query-duplicate-pset-filter.test.ts
+++ b/packages/mcp/src/backend-query-duplicate-pset-filter.test.ts
@@ -26,6 +26,16 @@ function guid(mnemonic: string): string {
 
 // Wall #72 carries TWO "Pset_WallCommon" sets: the first (#80) has only
 // IsExternal, the second (#83) has the FireRating we're filtering on.
+//
+// Wall #90 (Wall F) carries TWO "Pset_WallCommon" sets that BOTH carry
+// FireRating, with DIFFERENT values: #92 (first) is 'REI30' (does not
+// match), #95 (second) is 'REI60' (matches). This is the shape #3490
+// actually reports — `findPropertyInSets` finds the property on the
+// FIRST set either way, so testing only that one value wrongly excludes
+// the wall when the match lives on the second set.
+//
+// Wall #100 (Wall G) carries the same two-set shape with NEITHER value
+// matching — the negative control.
 const MODEL = `ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((''),'2;1');
@@ -44,7 +54,7 @@ DATA;
 #42= IFCBUILDING('${guid('BLDG')}',$,'B',$,$,#40,$,$,.ELEMENT.,$,$,$);
 #43= IFCRELAGGREGATES('${guid('AGG1')}',$,$,$,#1,(#42));
 #44= IFCRELAGGREGATES('${guid('AGG2')}',$,$,$,#42,(#41));
-#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72),#41);
+#45= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#72,#90,#100),#41);
 #72= IFCWALL('${guid('WALA')}',$,'Wall A',$,$,#40,$,'tagA',$);
 #81= IFCPROPERTYSINGLEVALUE('IsExternal',$,IFCBOOLEAN(.T.),$);
 #80= IFCPROPERTYSET('${guid('PST1')}',$,'Pset_WallCommon',$,(#81));
@@ -52,6 +62,20 @@ DATA;
 #84= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
 #83= IFCPROPERTYSET('${guid('PST2')}',$,'Pset_WallCommon',$,(#84));
 #85= IFCRELDEFINESBYPROPERTIES('${guid('RDP2')}',$,$,$,(#72),#83);
+#90= IFCWALL('${guid('WALF')}',$,'Wall F',$,$,#40,$,'tagF',$);
+#91= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI30'),$);
+#92= IFCPROPERTYSET('${guid('PST3')}',$,'Pset_WallCommon',$,(#91));
+#93= IFCRELDEFINESBYPROPERTIES('${guid('RDP3')}',$,$,$,(#90),#92);
+#94= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI60'),$);
+#95= IFCPROPERTYSET('${guid('PST4')}',$,'Pset_WallCommon',$,(#94));
+#96= IFCRELDEFINESBYPROPERTIES('${guid('RDP4')}',$,$,$,(#90),#95);
+#100= IFCWALL('${guid('WALG')}',$,'Wall G',$,$,#40,$,'tagG',$);
+#101= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI30'),$);
+#102= IFCPROPERTYSET('${guid('PST5')}',$,'Pset_WallCommon',$,(#101));
+#103= IFCRELDEFINESBYPROPERTIES('${guid('RDP5')}',$,$,$,(#100),#102);
+#104= IFCPROPERTYSINGLEVALUE('FireRating',$,IFCLABEL('REI45'),$);
+#105= IFCPROPERTYSET('${guid('PST6')}',$,'Pset_WallCommon',$,(#104));
+#106= IFCRELDEFINESBYPROPERTIES('${guid('RDP6')}',$,$,$,(#100),#105);
 ENDSEC;
 END-ISO-10303-21;
 `;
@@ -70,14 +94,14 @@ afterAll(async () => {
 });
 
 describe('entities() property filter — two same-named property sets', () => {
-  it('does not silently exclude an entity whose filtered property lives on the SECOND same-named set', () => {
+  it('does not silently exclude an entity whose filtered property lives on the SECOND same-named set (Wall A: FIRST set has no FireRating at all), and any-matches an entity whose SECOND set overrides a non-matching value on the FIRST (Wall F: #3490)', () => {
     const results = model.bim
       .query()
       .byType('IfcWall')
       .where('Pset_WallCommon', 'FireRating', '=', 'REI60')
       .toArray();
 
-    expect(results.map((e) => e.name)).toEqual(['Wall A']);
+    expect(results.map((e) => e.name)).toEqual(['Wall A', 'Wall F']);
   });
 
   it('still matches on the property from the FIRST same-named set', () => {
@@ -88,5 +112,15 @@ describe('entities() property filter — two same-named property sets', () => {
       .toArray();
 
     expect(results.map((e) => e.name)).toEqual(['Wall A']);
+  });
+
+  it('excludes an entity where NEITHER same-named set matches', () => {
+    const results = model.bim
+      .query()
+      .byType('IfcWall')
+      .where('Pset_WallCommon', 'FireRating', '=', 'REI99')
+      .toArray();
+
+    expect(results.map((e) => e.name)).toEqual([]);
   });
 });

--- a/packages/mcp/src/backend-query.ts
+++ b/packages/mcp/src/backend-query.ts
@@ -58,7 +58,8 @@ import {
   isQueryableObjectType,
 } from '@ifc-lite/parser';
 import { attributeNamesForSchema } from './schema-tables.js';
-import { EntityNode, findPropertyInSets } from '@ifc-lite/query';
+import { EntityNode } from '@ifc-lite/query';
+import { matchesPropertyFilter } from './property-filter-match.js';
 
 import { stepText, type CreatedEntity, type PendingOverlay } from './overlay.js';
 
@@ -75,12 +76,6 @@ export { expandTypes };
  * here because both packages already publish it under this name.
  */
 export const isProductType = isQueryableObjectType;
-
-function normalizeBoolean(value: unknown): unknown {
-  if (value === true || value === '.T.' || value === 'true' || value === 'TRUE') return 'true';
-  if (value === false || value === '.F.' || value === 'false' || value === 'FALSE') return 'false';
-  return value;
-}
 
 /** The overlay's answer for an entity it created, in `EntityData` shape. */
 function createdEntityData(created: CreatedEntity, ref: EntityRef): EntityData {
@@ -335,24 +330,7 @@ export function createQueryAdapter(
           return cached;
         };
         for (const filter of descriptor.filters) {
-          filtered = filtered.filter((entity) => {
-            const props = cachedProps(entity.ref);
-            const prop = findPropertyInSets(props, filter.psetName, filter.propName);
-            if (!prop) return false;
-            if (filter.operator === 'exists') return true;
-            const v = normalizeBoolean(prop.value);
-            const f = normalizeBoolean(filter.value);
-            switch (filter.operator) {
-              case '=': return String(v) === String(f);
-              case '!=': return String(v) !== String(f);
-              case '>': return Number(v) > Number(f);
-              case '<': return Number(v) < Number(f);
-              case '>=': return Number(v) >= Number(f);
-              case '<=': return Number(v) <= Number(f);
-              case 'contains': return String(v).toLowerCase().includes(String(f).toLowerCase());
-              default: return false;
-            }
-          });
+          filtered = filtered.filter((entity) => matchesPropertyFilter(cachedProps(entity.ref), filter));
         }
       }
       // `&&` alone lets a NaN offset/limit through silently: every NaN

--- a/packages/mcp/src/property-filter-match.ts
+++ b/packages/mcp/src/property-filter-match.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `entities()`'s `descriptor.filters` predicate, split out of
+ * `backend-query.ts` (module-size ratchet).
+ *
+ * Any-match, not first-match (#3490): an entity can carry two distinct
+ * same-named property sets (type + occurrence), so a filter predicate
+ * passes when ANY of them satisfies the condition, not just the first
+ * one found. This applies uniformly to every operator, `!=` included.
+ */
+
+import type { PropertySetData, QueryFilter } from '@ifc-lite/sdk';
+import { findAllPropertiesInSets } from '@ifc-lite/query';
+
+function normalizeBoolean(value: unknown): unknown {
+  if (value === true || value === '.T.' || value === 'true' || value === 'TRUE') return 'true';
+  if (value === false || value === '.F.' || value === 'false' || value === 'FALSE') return 'false';
+  return value;
+}
+
+export function matchesPropertyFilter(props: PropertySetData[], filter: QueryFilter): boolean {
+  const matchingProps = findAllPropertiesInSets(props, filter.psetName, filter.propName);
+  if (matchingProps.length === 0) return false;
+  if (filter.operator === 'exists') return true;
+  const f = normalizeBoolean(filter.value);
+  return matchingProps.some((prop) => {
+    const v = normalizeBoolean(prop.value);
+    switch (filter.operator) {
+      case '=': return String(v) === String(f);
+      case '!=': return String(v) !== String(f);
+      case '>': return Number(v) > Number(f);
+      case '<': return Number(v) < Number(f);
+      case '>=': return Number(v) >= Number(f);
+      case '<=': return Number(v) <= Number(f);
+      case 'contains': return String(v).toLowerCase().includes(String(f).toLowerCase());
+      default: return false;
+    }
+  });
+}

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -14,4 +14,4 @@ export { EntityQuery, type ComparisonOperator } from './entity-query.js';
 export { EntityNode } from './entity-node.js';
 export { QueryResultEntity } from './query-result-entity.js';
 export { DuckDBIntegration, type SQLResult } from './duckdb-integration.js';
-export { findPropertyInSets, findQuantityInSets } from './pset-lookup.js';
+export { findPropertyInSets, findQuantityInSets, findAllPropertiesInSets, findAllQuantitiesInSets } from './pset-lookup.js';

--- a/packages/query/src/pset-lookup.ts
+++ b/packages/query/src/pset-lookup.ts
@@ -73,3 +73,48 @@ export function findQuantityInSets<Q extends Named>(
   }
   return undefined;
 }
+
+/**
+ * Find EVERY property named `propName`, across EVERY same-named
+ * (setName) property set — not just the first. For a caller evaluating a
+ * predicate ("does this entity have a set with this name and value?")
+ * first-match is wrong: an entity can carry two distinct `IfcPropertySet`s
+ * named e.g. "Pset_WallCommon" (one from the type, one from the
+ * occurrence), and the wanted value may live on the second one. Use this
+ * instead of `findPropertyInSets` when the result feeds a `.some(...)`
+ * predicate rather than a single value read; keep `findPropertyInSets` for
+ * value extraction (export/aggregation/display), where picking one member
+ * is the documented, correct behaviour.
+ */
+export function findAllPropertiesInSets<P extends Named>(
+  sets: readonly PropertySetLike<P>[],
+  setName: string,
+  propName: string,
+): P[] {
+  const matches: P[] = [];
+  for (const set of sets) {
+    if (set.name !== setName) continue;
+    for (const p of set.properties) {
+      if (p.name === propName) matches.push(p);
+    }
+  }
+  return matches;
+}
+
+/**
+ * Quantity counterpart to `findAllPropertiesInSets` — see its doc comment.
+ */
+export function findAllQuantitiesInSets<Q extends Named>(
+  sets: readonly QuantitySetLike<Q>[],
+  setName: string,
+  quantityName: string,
+): Q[] {
+  const matches: Q[] = [];
+  for (const set of sets) {
+    if (set.name !== setName) continue;
+    for (const q of set.quantities) {
+      if (q.name === quantityName) matches.push(q);
+    }
+  }
+  return matches;
+}

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3820,6 +3820,8 @@
     "QueryInterface: class",
     "QueryResultEntity: class",
     "SQLResult: interface",
+    "findAllPropertiesInSets: function",
+    "findAllQuantitiesInSets: function",
     "findPropertyInSets: function",
     "findQuantityInSets: function"
   ],


### PR DESCRIPTION
## Summary

`applyWhereFilter` (CLI `query --where`) tested only the FIRST same-named property/quantity set when both same-named sets carried the requested member with different values, so `--where` wrongly excluded an entity whose match lived on a later set. Two `IfcPropertySet`/`IfcElementQuantity` entities sharing one name is legitimate (e.g. one from the type definition, one from the occurrence — see `packages/query/src/entity-node.ts`), and a filter is a predicate over the entity, not a value read: it should pass when ANY same-named set satisfies the operator.

Sites found and fixed (same repo, same "predicate over a pset-qualified lookup" shape):
- `packages/cli/src/commands/query.ts` — `applyWhereFilter` (`ifc-lite query --where`), for both property AND quantity sets.
- `packages/cli/src/headless-backend.ts` — `HeadlessBackend.query.entities()`'s `descriptor.filters` loop, shared by the CLI's `bim.query().where(...)` path and by `ifc-lite mcp` (which runs an MCP server over this same backend).
- `packages/mcp/src/backend-query.ts` — `entities()`'s `descriptor.filters` loop, used by `@ifc-lite/mcp`'s `query_entities` tool when the package is embedded directly (not via `ifc-lite mcp`).
- `apps/viewer/src/sdk/adapters/query-adapter.ts` — the browser viewer's own `entities()` filter, the same shape again.

Not touched, and correctly so:
- `findPropertyInSets`/`findQuantityInSets` (`packages/query/src/pset-lookup.ts`) stay first-match — every remaining caller (CSV/USD export, aggregation, `--unique`, `--sort`, display) is a *value read*, where picking one member is the documented, correct behaviour (see the file's own doc comment).
- `EntityQuery.whereProperty` in `packages/query/src/entity-query.ts` was already any-match (`matchesPsetFilter`/`matchesQsetFilter` in `property-filter.ts`) — its doc comment is the precedent this PR follows for the sites above.

## Semantics chosen

Any-match, applied uniformly across every operator, `!=` included: an entity passes `!=` when *some* occurrence of that property differs, not only when *every* occurrence does. This matches the ANY-match `EntityQuery.whereProperty` already uses (no operator-specific carve-out there either), so the two paths agree.

## Fix

`@ifc-lite/query` gains `findAllPropertiesInSets`/`findAllQuantitiesInSets` (returning every match across same-named sets) alongside the existing first-match helpers. Every filter site above switches its lookup to the any-match variant and OR's the operator across all matches.

`query.ts` and `mcp/backend-query.ts` crossed their module-size budgets once the fix grew them; per repo convention the budgets were not raised — the filter language moved to a sibling `where-filter.ts` (cli) and the filter predicate to a sibling `property-filter-match.ts` (mcp).

## Test plan

- [x] RED on unmodified `main`: an entity with two same-named psets/qsets, first non-matching value / second matching, wrongly excluded by every site above; verified with `git stash` before applying the fix.
- [x] GREEN after the fix, plus controls: neither-matches excluded, first-already-matches still included.
- [x] `pnpm exec tsc --noEmit` clean in `packages/query`, `packages/cli`, `packages/mcp`.
- [x] `pnpm exec vitest run` green in `packages/query` (229 tests), `packages/cli` (569 tests, 8 skipped), `packages/mcp` (338 tests); `apps/viewer`'s node:test file for the touched adapter (5 tests) run directly.
- [x] `node scripts/check-module-size.mjs`, `check-unused-locals.mjs`, `check-test-wiring.mjs` all clean.
- [x] Changeset added (`@ifc-lite/query`, `@ifc-lite/cli`, `@ifc-lite/mcp`, patch).

Fixes #3490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Property filters now match an entity when any same-named property or quantity set satisfies the filter.
  - Updated query, CLI, MCP, and viewer filtering for consistent behavior across all supported operators, including `!=`.
  - Entities are correctly excluded when none of their matching sets satisfy the filter.

- **Tests**
  - Added coverage for duplicate sets, later-set matches, quantity sets, and negative cases across supported query interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->