### PR TITLE
fix(cli): require a full #<digits> match for an overlay relation ref

### DIFF
--- a/.changeset/cli-overlay-relation-ref-parseint.md
+++ b/.changeset/cli-overlay-relation-ref-parseint.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/cli': patch
+---
+
+`HeadlessBackend.query.related()` no longer resolves a malformed `IfcRel…` reference to a real entity id (#3502). The overlay's `'#42'` reference parser used `Number.parseInt`, which stops at the first non-digit character, so a relating/related end authored as `#42junk` or `#42.5` on a queued relationship resolved to express id `42` instead of being rejected. It now requires a full `/^#(\d+)$/` match and a `Number.isSafeInteger` id, so a malformed or out-of-range reference (past `Number.MAX_SAFE_INTEGER`) resolves to nothing.

--- a/packages/cli/src/query-overlay-relations.test.ts
+++ b/packages/cli/src/query-overlay-relations.test.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Regression for #3502: `refIds()` (the `'#42'` reference parser inside
+ * `foldQueuedRelated`, `query-overlay-relations.ts`) used
+ * `Number.parseInt(trimmed.slice(1), 10)`, which stops at the first
+ * non-digit character. A malformed relationship end — `#42junk`, `#42.5` —
+ * resolved to express id 42 instead of being rejected, so a near-miss
+ * reference silently bound to a real entity. Exercised through
+ * `HeadlessBackend.query.related()`, same as the sibling overlay test
+ * (`headless-backend-related-overlay.test.ts`), since `refIds` itself is
+ * not exported.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { loadIfcFile } from './loader.js';
+import { HeadlessBackend } from './headless-backend.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SAMPLE_IFC = join(__dirname, '../../../apps/viewer/public/samples/building-architecture.ifc');
+
+describe('foldQueuedRelated / refIds — #3502', () => {
+  it('rejects a near-miss reference with trailing garbage instead of parsing its numeric prefix', async () => {
+    const store = await loadIfcFile(SAMPLE_IFC);
+    const backend = new HeadlessBackend(store, 'building-architecture.ifc');
+    const [parent] = backend.query.entities({ types: ['IfcWall'] });
+
+    backend.store.addEntity('default', {
+      type: 'IfcRelAggregates',
+      attributes: ["'3N1x3zzzzzzzzzzzzzzzzz'", null, null, null, `#${parent.ref.expressId}`, ['#42junk']],
+    });
+
+    const forward = backend.query.related(parent.ref, 'IfcRelAggregates', 'forward');
+    expect(forward).toEqual([]); // was resolved to express id 42 under `parseInt`
+  });
+
+  it('rejects a decimal reference instead of truncating it to an integer', async () => {
+    const store = await loadIfcFile(SAMPLE_IFC);
+    const backend = new HeadlessBackend(store, 'building-architecture.ifc');
+    const [parent] = backend.query.entities({ types: ['IfcWall'] });
+
+    backend.store.addEntity('default', {
+      type: 'IfcRelAggregates',
+      attributes: ["'3N1x3zzzzzzzzzzzzzzzzz'", null, null, null, `#${parent.ref.expressId}`, ['#42.5']],
+    });
+
+    const forward = backend.query.related(parent.ref, 'IfcRelAggregates', 'forward');
+    expect(forward).toEqual([]); // was resolved to express id 42 under `parseInt`
+  });
+
+  it('rejects a bare "#" with no digits', async () => {
+    const store = await loadIfcFile(SAMPLE_IFC);
+    const backend = new HeadlessBackend(store, 'building-architecture.ifc');
+    const [parent] = backend.query.entities({ types: ['IfcWall'] });
+
+    backend.store.addEntity('default', {
+      type: 'IfcRelAggregates',
+      attributes: ["'3N1x3zzzzzzzzzzzzzzzzz'", null, null, null, `#${parent.ref.expressId}`, ['#']],
+    });
+
+    const forward = backend.query.related(parent.ref, 'IfcRelAggregates', 'forward');
+    expect(forward).toEqual([]);
+  });
+
+  it('rejects a reference past Number.MAX_SAFE_INTEGER', async () => {
+    const store = await loadIfcFile(SAMPLE_IFC);
+    const backend = new HeadlessBackend(store, 'building-architecture.ifc');
+    const [parent] = backend.query.entities({ types: ['IfcWall'] });
+    const unsafe = `#${(Number.MAX_SAFE_INTEGER + 2).toString()}`;
+
+    backend.store.addEntity('default', {
+      type: 'IfcRelAggregates',
+      attributes: ["'3N1x3zzzzzzzzzzzzzzzzz'", null, null, null, `#${parent.ref.expressId}`, [unsafe]],
+    });
+
+    const forward = backend.query.related(parent.ref, 'IfcRelAggregates', 'forward');
+    expect(forward).toEqual([]);
+  });
+
+  it('control: a well-formed reference still resolves', async () => {
+    const store = await loadIfcFile(SAMPLE_IFC);
+    const backend = new HeadlessBackend(store, 'building-architecture.ifc');
+    const [parent, child] = backend.query.entities({ types: ['IfcWall'] });
+
+    backend.store.addEntity('default', {
+      type: 'IfcRelAggregates',
+      attributes: [
+        "'3N1x3zzzzzzzzzzzzzzzzz'",
+        null,
+        null,
+        null,
+        `#${parent.ref.expressId}`,
+        [`#${child.ref.expressId}`],
+      ],
+    });
+
+    const forward = backend.query.related(parent.ref, 'IfcRelAggregates', 'forward');
+    expect(forward.some((r) => r.expressId === child.ref.expressId)).toBe(true);
+  });
+});

--- a/packages/cli/src/query-overlay-relations.ts
+++ b/packages/cli/src/query-overlay-relations.ts
@@ -34,8 +34,10 @@ interface QueuedRelation {
 function refIds(value: unknown): number[] {
   if (typeof value === 'string') {
     const trimmed = value.trim();
-    const id = Number.parseInt(trimmed.slice(1), 10);
-    return trimmed.startsWith('#') && Number.isFinite(id) ? [id] : [];
+    const match = /^#(\d+)$/.exec(trimmed);
+    if (!match) return [];
+    const id = Number(match[1]);
+    return Number.isSafeInteger(id) ? [id] : [];
   }
   if (Array.isArray(value)) return value.flatMap((item) => refIds(item));
   return [];


### PR DESCRIPTION
## Summary
- `query-overlay-relations.ts`'s `refIds()` parsed a queued `IfcRel…` relating/related end with `Number.parseInt(trimmed.slice(1), 10)`, which stops at the first non-digit character. A malformed reference — `#42junk`, `#42.5` — resolved to express id `42` instead of being rejected, so a near-miss reference on a mutation-overlay relationship silently bound to a real entity.
- Now requires a full `/^#(\d+)$/` match and a `Number.isSafeInteger` id, so a malformed reference or one past `Number.MAX_SAFE_INTEGER` resolves to `[]`.
- This also fixes the `.slice(1)` call being evaluated on a string that might not start with `#` before the `startsWith` guard ran — the regex only ever runs against the anchored pattern, so that ordering issue is gone too.

Fixes #3502

## RED / GREEN
`packages/cli/src/query-overlay-relations.test.ts`, exercised through `HeadlessBackend.query.related()` since `refIds` itself is not exported (same overlay contract as the sibling `headless-backend-related-overlay.test.ts`):

- `#42junk` — before: `[42]`, after: `[]`
- `#42.5` — before: `[42]`, after: `[]`
- a reference past `Number.MAX_SAFE_INTEGER` (`#9007199254740993`) — before: `[9007199254740992]` (precision-lossy but "finite"), after: `[]`
- `#` (bare) — before and after: `[]` (already correct, kept as a supplementary case)
- `#42` (control) — before and after: `[42]`

## Gates
- `pnpm exec tsc --noEmit` (packages/cli): clean.
- `pnpm exec vitest run` (packages/cli): 55 files / 566 passed, 8 skipped.
- `node scripts/check-unused-locals.mjs`: 51 packages measured, 943 known violations, none increased — no baseline change needed.
- `node scripts/check-module-size.mjs`: OK, 0 new files over 400 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436
