### PR TITLE
fix(viewer): route command-palette JSON export through exactTypeName

### DIFF
--- a/.changeset/command-palette-json-export-exact-type.md
+++ b/.changeset/command-palette-json-export-exact-type.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+The command palette's `Export JSON` entry now names each entity's declared class instead of its `IfcTypeEnum`-coalesced family (#3503). `#3475` routed the Lists Class column and the Parquet `Type` column onto `@ifc-lite/data`'s `exactTypeName()`; the palette's `export:json` action was a third, independent caller still reading `EntityTable.getTypeName` directly, so exporting the same model via the palette named `IFCDOORSTANDARDCASE` entities `IfcDoor` while the other two export paths named them `IfcDoorStandardCase`. The row-building logic is extracted to `buildCommandPaletteJsonEntities` (`apps/viewer/src/components/viewer/commandPaletteJsonExport.ts`) so all three export paths now route through the same accessor.

--- a/apps/viewer/src/components/viewer/CommandPalette.exact-type.test.ts
+++ b/apps/viewer/src/components/viewer/CommandPalette.exact-type.test.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Three independent export paths must agree on an entity's class: the
+ * Lists panel's Class column (`apps/viewer/src/lib/lists/adapter.ts`,
+ * fixed by #3475), the Parquet `Type` column (`@ifc-lite/export`, #3325),
+ * and the command palette's `export:json` entry (`CommandPalette.tsx`,
+ * #3503). All three must name the class an entity's STEP line actually
+ * declares — `IfcTypeEnum`'s `getTypeName` coalesces several classes onto
+ * one family (`IfcDoorStandardCase` onto `IfcDoor`) for the viewer's scope
+ * chips, and that coalesced name is right for a chip but wrong for an
+ * export.
+ *
+ * #3475 pinned the first two paths against each other; the palette's JSON
+ * export was left on the old `getTypeName` call, so the same model exported
+ * two ways agreed and a third disagreed. This pins all three against one
+ * shared fixture, per the same class list `class-column-exact-type.test.ts`
+ * and `parquet-exact-type.test.ts` (`packages/export`) already use.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { IfcParser } from '@ifc-lite/parser';
+import { ParquetExporter } from '@ifc-lite/export';
+// `apps/viewer/src/apache-arrow.d.ts` declares this module with `export =`,
+// so the named import the packages/export tests use does not type-check here.
+import * as arrow from 'apache-arrow';
+import { readParquet } from 'parquet-wasm';
+import { createListDataProvider } from '../../lib/lists/adapter.js';
+import { buildCommandPaletteJsonEntities } from './commandPaletteJsonExport.js';
+
+// A StandardCase subtype (coalesced onto IfcDoor by IfcTypeEnum) plus a
+// plain IfcDoor negative control that must not change.
+const FIXTURE = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('Proj0000000000000000001',$,'P',$,$,$,$,$,$);
+#2=IFCDOORSTANDARDCASE('Door00000000000000001A',$,'Door-A',$,$,$,$,$,2.,0.9,$,$,$);
+#3=IFCDOOR('Door00000000000000001B',$,'Door-B',$,$,$,$,$,2.,0.9,$,$,$);
+ENDSEC;
+END-ISO-10303-21;
+`;
+
+async function parse() {
+  const bytes = new TextEncoder().encode(FIXTURE);
+  return new IfcParser().parseColumnar(bytes.buffer as ArrayBuffer, { disableWorkerScan: true });
+}
+
+function decodeParquet(bytes: Uint8Array): Record<string, unknown>[] {
+  const table = arrow.tableFromIPC(readParquet(bytes).intoIPCStream());
+  return (table.toArray() as { toJSON(): Record<string, unknown> }[]).map((row) => row.toJSON());
+}
+
+describe('the three export paths agree on the declared class (#3503)', () => {
+  it('Lists Class column, Parquet Type column, and command-palette JSON export all name IfcDoorStandardCase', async () => {
+    const store = await parse();
+
+    // Lists panel Class column (#3475).
+    const listProvider = createListDataProvider(store);
+    assert.equal(listProvider.getEntityTypeName(2), 'IfcDoorStandardCase');
+    assert.equal(listProvider.getEntityTypeName(3), 'IfcDoor'); // control
+
+    // Parquet Type column (#3325).
+    const rows = decodeParquet(await new ParquetExporter(store).exportTable('entities'));
+    const byId = new Map<number, string>(rows.map((r) => [Number(r.ExpressId), String(r.Type)]));
+    assert.equal(byId.get(2), 'IfcDoorStandardCase');
+    assert.equal(byId.get(3), 'IfcDoor'); // control
+
+    // Command palette export:json (#3503) — the path this issue fixes.
+    const jsonRows = buildCommandPaletteJsonEntities(store);
+    const jsonById = new Map<number, unknown>(
+      jsonRows.map((r) => [r.expressId as number, r.type]),
+    );
+    assert.equal(jsonById.get(2), 'IfcDoorStandardCase');
+    assert.equal(jsonById.get(3), 'IfcDoor'); // control
+
+    // Grouping is unaffected: getTypeName still answers the coalesced family.
+    assert.equal(store.entities.getTypeName(2), 'IfcDoor');
+  });
+});

--- a/apps/viewer/src/components/viewer/CommandPalette.tsx
+++ b/apps/viewer/src/components/viewer/CommandPalette.tsx
@@ -101,6 +101,7 @@ import { exportCsvFromBytes } from '@/lib/export/csv';
 import { downloadFile, buildExportFilename, stripExtension } from '@/lib/export/download';
 import { GeometryProcessor } from '@ifc-lite/geometry';
 import { isUsdExportableModel, resolveUsdExportBytes } from './usd-export-source';
+import { buildCommandPaletteJsonEntities } from './commandPaletteJsonExport';
 import { getRecentFiles, formatFileSize, getCachedFile, getCachedFileNames } from '@/lib/recent-files';
 import type { RecentFileEntry } from '@/lib/recent-files';
 import { closeActiveAnalysisExtension } from '@/services/analysis-extensions';
@@ -588,8 +589,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         action: () => {
           const d = useViewerStore.getState().ifcDataStore; if (!d) return;
           try {
-            const out: Record<string, unknown>[] = [];
-            for (let i = 0; i < d.entities.count; i++) { const id = d.entities.expressId[i]; out.push({ expressId: id, globalId: d.entities.getGlobalId(id), name: d.entities.getName(id), type: d.entities.getTypeName(id), properties: d.properties.getForEntity(id) }); }
+            const out = buildCommandPaletteJsonEntities(d);
             downloadFile(JSON.stringify({ entities: out }, null, 2), 'model-data.json', 'application/json');
           } catch (e) { console.error(e); }
         } },

--- a/apps/viewer/src/components/viewer/commandPaletteJsonExport.ts
+++ b/apps/viewer/src/components/viewer/commandPaletteJsonExport.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Row-building for the command palette's `export:json` entry — pulled out of
+ * `CommandPalette.tsx` (already at its module-size budget) so it can be
+ * exercised without mounting the palette's React tree.
+ *
+ * Routes `type` through `@ifc-lite/data`'s `exactTypeName()`, the same
+ * accessor #3475 put behind the Lists Class column
+ * (`apps/viewer/src/lib/lists/adapter.ts`) and the Parquet `Type` column
+ * (#3325) after both were caught naming the `IfcTypeEnum`-coalesced family
+ * instead of the class an entity's STEP line actually declares
+ * (`IFCDOORSTANDARDCASE` reporting as `IfcDoor`). This JSON export path was
+ * a third, independent caller still reading `EntityTable.getTypeName`
+ * directly (#3503).
+ */
+
+import { exactTypeName } from '@ifc-lite/data';
+import type { IfcDataStore } from '@ifc-lite/parser';
+
+export function buildCommandPaletteJsonEntities(d: IfcDataStore): Record<string, unknown>[] {
+  const out: Record<string, unknown>[] = [];
+  for (let i = 0; i < d.entities.count; i++) {
+    const id = d.entities.expressId[i];
+    out.push({
+      expressId: id,
+      globalId: d.entities.getGlobalId(id),
+      name: d.entities.getName(id),
+      type: exactTypeName(d.entities, id),
+      properties: d.properties.getForEntity(id),
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- `CommandPalette.tsx`'s `export:json` action still read `EntityTable.getTypeName` directly — the `IfcTypeEnum`-coalesced family name — while #3475 routed the Lists Class column (`apps/viewer/src/lib/lists/adapter.ts`) and the Parquet `Type` column (`@ifc-lite/export`, #3325) onto `@ifc-lite/data`'s `exactTypeName()`. Exporting the same model via the palette named an `IFCDOORSTANDARDCASE` entity `IfcDoor` while the other two export paths named it `IfcDoorStandardCase` — the same model exported two ways disagreed.
- The row-building loop is extracted from `CommandPalette.tsx` (already at its module-size budget of 849 lines, currently 846) into a sibling module, `buildCommandPaletteJsonEntities` (`apps/viewer/src/components/viewer/commandPaletteJsonExport.ts`), so it can be exercised without mounting the palette's React tree, and now routes `type` through `exactTypeName(d.entities, id)`.

Fixes #3503

## Helper reused
`exactTypeName()` from `@ifc-lite/data` (`packages/data/src/exact-type-name.ts`) — the same accessor #3475 introduced for the Lists Class column and the Parquet Type column.

## RED / GREEN
`apps/viewer/src/components/viewer/CommandPalette.exact-type.test.ts` pins all three export paths — the Lists adapter, `ParquetExporter`, and the new `buildCommandPaletteJsonEntities` — against one shared fixture (an `IFCDOORSTANDARDCASE` entity plus a plain `IFCDOOR` negative control), per the maintainer's ask for "three exports pinned together rather than two of three".

- RED (temporarily reverting the extracted helper's `type` line to `d.entities.getTypeName(id)`): the palette assertion failed — actual `'IfcDoor'`, expected `'IfcDoorStandardCase'` (the Lists and Parquet assertions in the same test already passed, confirming only the palette path was broken).
- GREEN (after routing through `exactTypeName`): all three assertions pass — Lists, Parquet, and the palette JSON export all answer `'IfcDoorStandardCase'` for the StandardCase entity and `'IfcDoor'` for the control; `store.entities.getTypeName` still answers the coalesced `'IfcDoor'`, confirming grouping is unaffected.

## Gates
- `pnpm exec tsc --noEmit` (apps/viewer): clean.
- Targeted tests (`CommandPalette.exact-type.test.ts`, `CommandPalette.anonymized-export.test.tsx`, `lib/lists/class-column-exact-type.test.ts`): all pass.
- `node scripts/check-module-size.mjs`: OK, 0 new files over 400 lines; `CommandPalette.tsx` stays at 846 lines (budget 849), unchanged.
- `node scripts/check-unused-locals.mjs`: 51 packages measured, 943 known violations, none increased — no baseline change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436
