### PR TITLE
fix(viewer): classify the worker-script wasm skew wrapper as recovered noise

### DIFF
--- a/.changeset/wasm-worker-script-skew-noise.md
+++ b/.changeset/wasm-worker-script-skew-noise.md
@@ -1,5 +1,5 @@
 ---
-'@ifc-lite/geometry': patch
+'@ifc-lite/geometry': minor
 '@ifc-lite/viewer': patch
 ---
 

--- a/.changeset/wasm-worker-script-skew-noise.md
+++ b/.changeset/wasm-worker-script-skew-noise.md
@@ -1,0 +1,6 @@
+---
+'@ifc-lite/geometry': patch
+'@ifc-lite/viewer': patch
+---
+
+The viewer's PostHog noise gate for auto-recovered wasm version skew (#1363) only matched the wasm-binary MIME/404 message text, so a worker-SCRIPT skew (classified separately, by `kind`, since #1680) reloaded correctly but was still captured to error tracking as if unhandled (#3533). `@ifc-lite/geometry` now exports `isWorkerScriptSkewMessage` for the worker-script wrapper signature (`"…worker script failed to load (possibly a stale deployment)"`), and the viewer's `shouldSuppressWasmSkewNoise` matches on it alongside the existing wasm-MIME matcher. Every other pre-pass/worker failure is still captured unchanged.

--- a/apps/viewer/src/lib/wasm-skew-noise.test.ts
+++ b/apps/viewer/src/lib/wasm-skew-noise.test.ts
@@ -113,6 +113,52 @@ describe('shouldSuppressWasmSkewNoise', () => {
     assert.equal(shouldSuppressWasmSkewNoise(skewEvent(HTTP_SKEW), h.deps), false);
   });
 
+  it('suppresses the worker-script skew wrapper (#3533) — recovered by kind, not by MIME text', () => {
+    // The pre-pass worker's own `onerror` handler never sees a wasm-MIME
+    // token — it wraps a synthetic detail string and dispatches
+    // `WASM_ASSET_UNAVAILABLE_EVENT` with `kind: 'worker-script'` (trusted by
+    // `recoverFromWorkerScriptSkew`, which reloads WITHOUT re-running the
+    // message matcher — see wasm-version-skew.test.ts's "pre-classified by
+    // the geometry library" suite). But by the time the exception reaches
+    // this gate, only the message text survives — `isWasmAssetUnavailableError`
+    // requires a wasm/MIME/status-code token that this message never carries,
+    // so the reload silently ran while the exception still got captured.
+    const h = harness();
+    assert.equal(
+      shouldSuppressWasmSkewNoise(
+        skewEvent('Pre-pass worker failed: worker script failed to load (possibly a stale deployment)'),
+        h.deps,
+      ),
+      true,
+    );
+  });
+
+  it('suppresses the sibling geometry-worker-pool wrapper of the same signature', () => {
+    const h = harness();
+    assert.equal(
+      shouldSuppressWasmSkewNoise(
+        skewEvent('Geometry worker failed: worker script failed to load (possibly a stale deployment)'),
+        h.deps,
+      ),
+      true,
+    );
+  });
+
+  it('control: a genuine (non-skew) worker failure is still captured', () => {
+    const h = harness();
+    assert.equal(
+      shouldSuppressWasmSkewNoise(
+        skewEvent('Pre-pass worker failed: RangeError: Maximum call stack size exceeded'),
+        h.deps,
+      ),
+      false,
+    );
+    assert.equal(
+      shouldSuppressWasmSkewNoise(skewEvent('Geometry worker failed: worker terminated unexpectedly'), h.deps),
+      false,
+    );
+  });
+
   it('reads the message from $exception_values when $exception_list is absent', () => {
     const h = harness();
     const out = shouldSuppressWasmSkewNoise(

--- a/apps/viewer/src/lib/wasm-version-skew.ts
+++ b/apps/viewer/src/lib/wasm-version-skew.ts
@@ -23,6 +23,7 @@
 
 import {
   isWasmAssetUnavailableError,
+  isWorkerScriptSkewMessage,
   WASM_ASSET_UNAVAILABLE_EVENT,
 } from '@ifc-lite/geometry';
 
@@ -233,7 +234,20 @@ export function shouldSuppressWasmSkewNoise(
   deps: SkewNoiseDeps = defaultNoiseDeps,
 ): boolean {
   const message = exceptionMessageOf(event);
-  if (message === undefined || !isWasmAssetUnavailableError(message)) return false;
+  if (message === undefined) return false;
+  // Two independent signatures, because the underlying recovery is
+  // classified two different ways (#3533). `isWasmAssetUnavailableError`
+  // matches the wasm-binary MIME/404 text (#1363). The worker-script variant
+  // (`geometry-parallel.ts`'s pre-pass/process-worker `onerror` synthesizing
+  // "…worker script failed to load (possibly a stale deployment)") carries
+  // none of those tokens — it was classified by KIND on the
+  // `WASM_ASSET_UNAVAILABLE_EVENT` the geometry library dispatched (trusted,
+  // not re-matched, by `recoverFromWorkerScriptSkew` — see its own doc
+  // comment). By the time the exception lands here only the message text
+  // survives, so we need `isWorkerScriptSkewMessage` to recognize that same
+  // recovered condition — without this, a worker-script skew reloads
+  // correctly but still gets captured as if it were unhandled.
+  if (!isWasmAssetUnavailableError(message) && !isWorkerScriptSkewMessage(message)) return false;
 
   const now = deps.now();
 

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -54,7 +54,7 @@ export { prewarmSharedWasmModule } from './wasm-shared-module.js';
 // WASM_ASSET_UNAVAILABLE_EVENT and uses `isWasmAssetUnavailableError` to
 // reload onto the deployment; `notifyIfWasmAssetUnavailable` stays internal.
 export {
-  isWasmAssetUnavailableError,
+  isWasmAssetUnavailableError, isWorkerScriptSkewMessage,
   WASM_ASSET_UNAVAILABLE_EVENT,
 } from './wasm-asset-error.js';
 // WebAssembly runtime-trap contract (#1898). A trap taken by an operation

--- a/packages/geometry/src/wasm-asset-error.test.ts
+++ b/packages/geometry/src/wasm-asset-error.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   isWasmAssetUnavailableError,
+  isWorkerScriptSkewMessage,
   notifyIfWorkerScriptUnavailable,
   notifyIfWasmAssetUnavailable,
   WASM_ASSET_UNAVAILABLE_EVENT,
@@ -75,6 +76,32 @@ describe('isWasmAssetUnavailableError', () => {
     expect(isWasmAssetUnavailableError('')).toBe(false);
     expect(isWasmAssetUnavailableError(null)).toBe(false);
     expect(isWasmAssetUnavailableError(undefined)).toBe(false);
+  });
+});
+
+describe('isWorkerScriptSkewMessage (#3533)', () => {
+  it('flags the pre-pass worker wrapper of the worker-script signature', () => {
+    expect(
+      isWorkerScriptSkewMessage(
+        'Pre-pass worker failed: worker script failed to load (possibly a stale deployment)',
+      ),
+    ).toBe(true);
+  });
+
+  it('flags the sibling geometry-worker-pool wrapper of the same signature', () => {
+    expect(
+      isWorkerScriptSkewMessage(
+        'Geometry worker failed: worker script failed to load (possibly a stale deployment)',
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT flag a genuine worker failure that merely shares the "worker" wrapper prefix', () => {
+    expect(isWorkerScriptSkewMessage('Pre-pass worker failed: RangeError: out of memory')).toBe(false);
+    expect(isWorkerScriptSkewMessage('Geometry worker failed: worker terminated unexpectedly')).toBe(false);
+    expect(isWorkerScriptSkewMessage('')).toBe(false);
+    expect(isWorkerScriptSkewMessage(null)).toBe(false);
+    expect(isWorkerScriptSkewMessage(undefined)).toBe(false);
   });
 });
 

--- a/packages/geometry/src/wasm-asset-error.ts
+++ b/packages/geometry/src/wasm-asset-error.ts
@@ -111,6 +111,40 @@ export function isWasmAssetUnavailableError(err: unknown): boolean {
   return false;
 }
 
+// The literal detail text `geometry-parallel.ts`'s worker `onerror` handlers
+// (pre-pass AND the process-worker pool — both wrap it as `Pre-pass worker
+// failed: ${detail}` / `Geometry worker failed: ${detail}`) synthesize ONLY
+// when the worker never posted a message and the ErrorEvent itself carried no
+// `.message`/`.filename` — i.e. exactly the condition under which
+// `notifyIfWorkerScriptUnavailable` below dispatches
+// `WASM_ASSET_UNAVAILABLE_EVENT` with `kind: 'worker-script'` and the host
+// reloads. It carries none of the wasm/MIME/status-code tokens
+// `isWasmAssetUnavailableError` looks for, so a caller that re-derives
+// classification from the message text alone (rather than trusting the
+// `kind` the library already assigned) misses it entirely — see
+// `isWorkerScriptSkewMessage` below.
+const WORKER_SCRIPT_SKEW_SIGNATURE = 'worker script failed to load (possibly a stale deployment)';
+
+/**
+ * True when `err`'s message is the worker-script version-skew signature
+ * synthesized by `geometry-parallel.ts`'s pre-pass or process-worker `onerror`
+ * handlers (`Pre-pass worker failed: worker script failed to load (possibly a
+ * stale deployment)` / `Geometry worker failed: …` — same suffix). This is a
+ * DIFFERENT (and deliberately narrower) test than
+ * {@link isWasmAssetUnavailableError}: that one matches the wasm-binary
+ * MIME/404 signature (#1363) and is used both to trigger a reload from an
+ * arbitrary unclassified error AND, by a host, to decide whether an already-
+ * recovered exception is safe to drop from error tracking. The worker-script
+ * variant never carries a wasm/MIME/status token (see the messageless
+ * `ErrorEvent` this wraps), so `isWasmAssetUnavailableError` structurally
+ * cannot see it; this function exists so a host-side classifier that only has
+ * the final message text (not the `kind` on the `WASM_ASSET_UNAVAILABLE_EVENT`
+ * detail) can still recognize the same recovered condition.
+ */
+export function isWorkerScriptSkewMessage(err: unknown): boolean {
+  return messageOf(err).includes(WORKER_SCRIPT_SKEW_SIGNATURE);
+}
+
 interface DomDispatcher {
   dispatchEvent: (event: Event) => boolean;
 }

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -1954,6 +1954,7 @@
     "isWasmAssetUnavailableError: function",
     "isWasmRuntimeTrap: function",
     "isWasmRuntimeUnrecoverableError: function",
+    "isWorkerScriptSkewMessage: function",
     "mergeGeometryDiagnostics: function",
     "pickWorkerCount: function",
     "prewarmSharedWasmModule: function"


### PR DESCRIPTION
## Summary

Refs #3533

Traced on `main`: after a worker-script skew (`#1680`), the recovery reload **does** run — `installWasmVersionSkewRecovery`'s listener trusts the event's `kind: 'worker-script'` directly:

```ts
window.addEventListener(WASM_ASSET_UNAVAILABLE_EVENT, (event) => {
  const detail = (event as CustomEvent<{ message?: string; kind?: string }>).detail;
  if (detail?.kind === 'worker-script') {
    recoverFromWorkerScriptSkew();
    return;
  }
  recoverFromWasmVersionSkew(detail?.message ?? '');
});
```

`recoverFromWorkerScriptSkew`'s own doc comment says why: *"re-running the message matcher here would reject exactly the case the event exists for."*

But the separate PostHog noise-suppression gate (`shouldSuppressWasmSkewNoise`, wired as `before_send` on every captured event, explicit `captureException` included) does the exact thing that comment warns against — it only has the final exception message text (not the `kind`), and re-derives classification purely via the strict `isWasmAssetUnavailableError` matcher:

```ts
export function shouldSuppressWasmSkewNoise(...): boolean {
  const message = exceptionMessageOf(event);
  if (message === undefined || !isWasmAssetUnavailableError(message)) return false;
  ...
```

`isWasmAssetUnavailableError` requires a wasm/MIME/status-code token. The worker-script wrapper's message — `"Pre-pass worker failed: worker script failed to load (possibly a stale deployment)"` (the literal string in issue #3533), and its sibling `"Geometry worker failed: worker script failed to load (possibly a stale deployment)"` from the process-worker pool — carries none of those tokens (confirmed: `isWasmAssetUnavailableError` returns `false` for both). So the reload runs, but the exception is still captured as if unhandled.

This is case **(a)**: the error is captured AND the reload happens; the report is noise for a handled condition. Fix: classify it as handled at the capture site, without touching the reload path or loosening `isWasmAssetUnavailableError` (which is also used, unrelated, by the generic `unhandledrejection`/`error` backstop listeners).

## Changes

- `packages/geometry/src/wasm-asset-error.ts`: new exported `isWorkerScriptSkewMessage`, matching the literal worker-script wrapper suffix synthesized only by `geometry-parallel.ts`'s pre-pass/process-worker `onerror` handlers when the worker never spoke.
- `apps/viewer/src/lib/wasm-version-skew.ts`: `shouldSuppressWasmSkewNoise` now matches on `isWasmAssetUnavailableError(message) || isWorkerScriptSkewMessage(message)`.
- Every other pre-pass/worker failure (a real crash, an OOM, a genuine "worker terminated unexpectedly") is still captured unchanged — covered by a control test.

## Test plan

RED (recorded on unmodified `main`, `apps/viewer/src/lib/wasm-skew-noise.test.ts`): `shouldSuppressWasmSkewNoise` returned `false` for the `#3533` message — expected `true`.

GREEN: added `isWorkerScriptSkewMessage` test coverage in `packages/geometry/src/wasm-asset-error.test.ts` (18/18 pass) and `apps/viewer/src/lib/wasm-skew-noise.test.ts` (both wrapper variants suppressed, control non-skew failure still captured — 111/111 pass in the touched test files).

- [x] `pnpm exec vitest run src/wasm-asset-error.test.ts` in `packages/geometry`
- [x] `apps/viewer`'s `node:test` runner on `wasm-skew-noise.test.ts` + `wasm-version-skew.test.ts` + `analytics.test.ts`
- [x] `pnpm exec tsc --noEmit` in `packages/geometry` and `apps/viewer` — no new errors from touched files (pre-existing `@ifc-lite/data` build-order errors in this fresh worktree are unrelated)
- [x] `node scripts/check-module-size.mjs` — OK, budget unchanged (kept the export on one line to avoid growing `packages/geometry/src/index.ts` past its pinned budget)
- [x] `node scripts/check-unused-locals.mjs` — no new complaints tied to touched files
- [x] Changeset added (`@ifc-lite/geometry` + `@ifc-lite/viewer`, patch)
- [x] `scripts/api-surface.json` updated for the new `isWorkerScriptSkewMessage` export (full `pnpm build`-gated `check-api-surface.mjs` couldn't run end-to-end in this fresh worktree without a repo-wide build, which the concurrent-agent resource note rules out; the entry was hand-verified against the actual built `packages/geometry/dist/index.d.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced false error reports caused by expected WebAssembly worker version mismatches.
  - Continued capturing genuine worker failures for reliable error monitoring.

- **New Features**
  - Added a public utility for identifying worker-script version-skew errors.

- **Tests**
  - Added coverage for worker version-skew detection, including valid and invalid error cases.

- **Documentation**
  - Added release notes for the geometry and viewer packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->