### PR TITLE
fix(viewer): scope a HierarchyPanel storey filter by identity, not Name

### DIFF
--- a/.changeset/hierarchypanel-storey-filter-identity.md
+++ b/.changeset/hierarchypanel-storey-filter-identity.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Clicking a storey in the hierarchy panel (Solo, or Ctrl-click to accumulate) now mirrors the storey's identity into the search filter, not just its name — so when two storeys share a name, the filter no longer pulls in the other storey's elements. Hand-typed storey-name filters behave as before.

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -573,9 +573,7 @@ export function HierarchyPanel() {
       const storeyIds = unified
         ? unified.storeys.map(s => s.storeyId)
         : node.expressIds;
-      const storeyRefs: Array<{ modelId: string; expressId: number }> = unified
-        ? unified.storeys.map(s => ({ modelId: s.modelId, expressId: s.storeyId }))
-        : storeyIds.map((expressId, i) => ({ modelId: node.modelIds[i] ?? node.modelIds[0] ?? 'legacy', expressId }));
+      const storeyRefs: Array<{ modelId: string; expressId: number }> = unified ? unified.storeys.map(s => ({ modelId: s.modelId, expressId: s.storeyId })) : storeyIds.map((expressId, i) => ({ modelId: node.modelIds[i] ?? node.modelIds[0] ?? 'legacy', expressId }));
 
       // Update the shared active storey (model-aware) so Space Sketch, the
       // Solo level-display mode, and the floorplan all follow the storey the

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -22,7 +22,7 @@ import { useViewerStore, resolveEntityRef } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { useIfc } from '@/hooks/useIfc';
 import { useEntityListMultiSelect, type MultiSelectItem } from '@/hooks/useEntityListMultiSelect';
-import { Rule, type FilterRule } from '@/lib/search/filter-rules';
+import { Rule, mergeStoreyRefs, type FilterRule } from '@/lib/search/filter-rules';
 import { toast } from '@/components/ui/toast';
 import { useSourceHost } from '@/services/sources/SourceHostProvider';
 import { syncSourceModel } from '@/lib/sources/syncSourceModel';
@@ -573,6 +573,9 @@ export function HierarchyPanel() {
       const storeyIds = unified
         ? unified.storeys.map(s => s.storeyId)
         : node.expressIds;
+      const storeyRefs: Array<{ modelId: string; expressId: number }> = unified
+        ? unified.storeys.map(s => ({ modelId: s.modelId, expressId: s.storeyId }))
+        : storeyIds.map((expressId, i) => ({ modelId: node.modelIds[i] ?? node.modelIds[0] ?? 'legacy', expressId }));
 
       // Update the shared active storey (model-aware) so Space Sketch, the
       // Solo level-display mode, and the floorplan all follow the storey the
@@ -586,10 +589,7 @@ export function HierarchyPanel() {
       // Set entity refs for property panel display
       if (unified && unified.storeys.length > 1) {
         // Multi-model unified storey: show all storeys combined in property panel
-        const entityRefs = unified.storeys.map(s => ({
-          modelId: s.modelId,
-          expressId: s.storeyId,
-        }));
+        const entityRefs = unified.storeys.map(s => ({ modelId: s.modelId, expressId: s.storeyId }));
         setSelectedEntities(entityRefs);
         // Clear single entity selection (property panel will use selectedEntities)
         setSelectedEntityId(null);
@@ -613,7 +613,8 @@ export function HierarchyPanel() {
         // Mirror to the advanced filter — accumulate the storey name (issue #1107).
         const cur = useViewerStore.getState().searchFilter.rules.find((r) => r.kind === 'storey' && r.op === 'in');
         const names = cur && cur.kind === 'storey' ? Array.from(new Set([...cur.values, node.name])) : [node.name];
-        upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey(names, 'in'));
+        const refs = mergeStoreyRefs(cur && cur.kind === 'storey' ? (cur.refs ?? []) : [], storeyRefs);
+        upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey(names, 'in', refs));
         toast.success(`Filter → storey ${node.name}`);
       } else {
         // Single selection - toggle if already selected
@@ -637,7 +638,7 @@ export function HierarchyPanel() {
           setStoreysSelection(storeyIds);
           setLevelDisplayMode('solo');
           // Mirror to the advanced filter: one storey rule = this storey (issue #1107).
-          upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey([node.name], 'in'));
+          upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey([node.name], 'in', storeyRefs));
           // Phrase it as Solo so the storey-row to Solo link is obvious (#1265).
           toast.success(`Solo: showing only ${node.name}`);
         }

--- a/apps/viewer/src/components/viewer/HierarchyPanel.tsx
+++ b/apps/viewer/src/components/viewer/HierarchyPanel.tsx
@@ -22,7 +22,7 @@ import { useViewerStore, resolveEntityRef } from '@/store';
 import { toGlobalIdFromModels } from '@/store/globalId';
 import { useIfc } from '@/hooks/useIfc';
 import { useEntityListMultiSelect, type MultiSelectItem } from '@/hooks/useEntityListMultiSelect';
-import { Rule, mergeStoreyRefs, type FilterRule } from '@/lib/search/filter-rules';
+import { Rule, addHierarchyStoreyToRule, type FilterRule } from '@/lib/search/filter-rules';
 import { toast } from '@/components/ui/toast';
 import { useSourceHost } from '@/services/sources/SourceHostProvider';
 import { syncSourceModel } from '@/lib/sources/syncSourceModel';
@@ -612,9 +612,10 @@ export function HierarchyPanel() {
         setStoreysSelection([...Array.from(selectedStoreys), ...storeyIds]);
         // Mirror to the advanced filter — accumulate the storey name (issue #1107).
         const cur = useViewerStore.getState().searchFilter.rules.find((r) => r.kind === 'storey' && r.op === 'in');
-        const names = cur && cur.kind === 'storey' ? Array.from(new Set([...cur.values, node.name])) : [node.name];
-        const refs = mergeStoreyRefs(cur && cur.kind === 'storey' ? (cur.refs ?? []) : [], storeyRefs);
-        upsertSearchRule((r) => r.kind === 'storey' && r.op === 'in', Rule.storey(names, 'in', refs));
+        upsertSearchRule(
+          (r) => r.kind === 'storey' && r.op === 'in',
+          addHierarchyStoreyToRule(cur && cur.kind === 'storey' ? cur : undefined, node.name, storeyRefs),
+        );
         toast.success(`Filter → storey ${node.name}`);
       } else {
         // Single selection - toggle if already selected

--- a/apps/viewer/src/lib/search/filter-evaluate.test.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.test.ts
@@ -158,6 +158,48 @@ describe('evaluateFilterRules — storey & predefinedType resolvers', () => {
     ], 'AND', { predefinedTypeOf: (id) => ptByExpressId.get(id) ?? '' });
     assert.deepStrictEqual(out.map((r) => r.expressId), [10]);
   });
+
+  // `IfcBuildingStorey.Name` is optional and not unique — two distinct
+  // storeys in the SAME model routinely share a Name (duplicate "Level 1"
+  // across wings, or a copy-paste authoring slip). HierarchyPanel mirrors
+  // a storey click into a `Rule.storey` filter; before this fix it only
+  // carried the Name, so clicking one "Level 1" silently pulled in every
+  // other storey named "Level 1" too — not just the one the user clicked.
+  it('a storey rule with exact refs matches only the clicked storey, not a same-named sibling', () => {
+    const storeyRows = [
+      ...rows,
+      { expressId: 500, type: 'IFCBUILDINGSTOREY', globalId: '5abcdefghijklmnopqrstu', name: 'Level 1' },
+      { expressId: 700, type: 'IFCBUILDINGSTOREY', globalId: '7abcdefghijklmnopqrstu', name: 'Level 1' },
+    ];
+    const store = buildStore(storeyRows);
+    (store as unknown as { spatialHierarchy: unknown }).spatialHierarchy = {
+      byStorey: new Map<number, number[]>([
+        [500, [10, 30]], // Level 1 (east wing): Wall-EXT-001, Door-A-201
+        [700, [20]],     // Level 1 (west wing, distinct storey, same Name): Wall-INT-002
+      ]),
+      elementToStorey: new Map<number, number>([[10, 500], [30, 500], [20, 700]]),
+    };
+
+    // RED (pre-fix behaviour, still exercised here as the legacy/manual
+    // path): no refs -> matches by name alone -> both storeys' elements.
+    const byName = evaluateFilterRules('m1', store, [Rule.storey(['Level 1'])], 'AND');
+    assert.deepStrictEqual(byName.map((r) => r.expressId).sort(), [10, 20, 30]);
+
+    // GREEN: refs scope the match to the exact (modelId, expressId) the
+    // user clicked (storey 500), excluding storey 700's element (20)
+    // even though it shares the Name.
+    const byRef = evaluateFilterRules(
+      'm1', store, [Rule.storey(['Level 1'], 'in', [{ modelId: 'm1', expressId: 500 }])], 'AND',
+    );
+    assert.deepStrictEqual(byRef.map((r) => r.expressId).sort(), [10, 30]);
+
+    // A ref for a different model never matches here — no silent
+    // cross-model name fallback once refs are present.
+    const byOtherModelRef = evaluateFilterRules(
+      'm1', store, [Rule.storey(['Level 1'], 'in', [{ modelId: 'm2', expressId: 500 }])], 'AND',
+    );
+    assert.deepStrictEqual(byOtherModelRef.map((r) => r.expressId), []);
+  });
 });
 
 describe('evaluateFilterRulesFederated', () => {
@@ -586,6 +628,26 @@ describe('selectIterationSource — index prefilter (AND + op:in)', () => {
     const ids = Array.from(source as Iterable<number>);
     // The prefilter must pick the Level-1 bucket, not fall through to a
     // full-table scan (which would also include the two storey rows).
+    assert.deepStrictEqual(ids.sort(), [10, 30]);
+  });
+
+  it('storey refs scope the prefilter bucket to the exact ref\'d storey, even with a same-named sibling', () => {
+    const storeyRows = [
+      ...rows,
+      { expressId: 500, type: 'IFCBUILDINGSTOREY', globalId: '5abcdefghijklmnopqrstu', name: 'Level 1' },
+      { expressId: 700, type: 'IFCBUILDINGSTOREY', globalId: '7abcdefghijklmnopqrstu', name: 'Level 1' },
+    ];
+    const s2 = buildStore(storeyRows);
+    (s2 as unknown as { spatialHierarchy: unknown }).spatialHierarchy = {
+      byStorey: new Map<number, number[]>([
+        [500, [10, 30]],
+        [700, [20]],
+      ]),
+    };
+    const source = select(
+      s2, [Rule.storey(['Level 1'], 'in', [{ modelId: 'm1', expressId: 500 }])], 'AND', undefined, 'm1',
+    );
+    const ids = Array.from(source as Iterable<number>);
     assert.deepStrictEqual(ids.sort(), [10, 30]);
   });
 });

--- a/apps/viewer/src/lib/search/filter-evaluate.ts
+++ b/apps/viewer/src/lib/search/filter-evaluate.ts
@@ -64,6 +64,8 @@ import {
   matchPropertyRule,
   matchQuantityRule,
   defaultStoreyName,
+  storeyMatchesRefs,
+  unionByStorey,
   materialNamesOf,
   matchClassificationRule,
   elevationOf,
@@ -119,11 +121,12 @@ export function evaluateFilterRules(
   const limit = options.limit ?? DEFAULT_LIMIT;
   const orderedRules = orderRulesByCost(rules);
   const iterIds = toIterable(
-    selectIterationSource(store, rules, combinator, options.candidateExpressIds),
+    selectIterationSource(store, rules, combinator, options.candidateExpressIds, modelId),
   );
   const out: FilteredElement[] = [];
   const ctx: EvalContext = {
     store,
+    modelId,
     table: store.entities,
     options,
     hasPropertyRule: orderedRules.some((r) => r.kind === 'property'),
@@ -210,7 +213,7 @@ export async function evaluateFilterRulesFederated(
   for (const m of models) {
     if (!m.store) continue;
     const candidates = options.candidateExpressIdsByModel?.get(m.id);
-    const source = candidates ?? selectIterationSource(m.store, rules, combinator, undefined);
+    const source = candidates ?? selectIterationSource(m.store, rules, combinator, undefined, m.id);
     const arr = materialiseIterable(source);
     if (arr === null) {
       totalKnown = false;
@@ -229,6 +232,7 @@ export async function evaluateFilterRulesFederated(
 
     const ctx: EvalContext = {
       store: plan.store,
+      modelId: plan.modelId,
       table: plan.store.entities,
       options,
       hasPropertyRule: orderedRules.some((r) => r.kind === 'property'),
@@ -295,6 +299,7 @@ export function selectIterationSource(
   rules: readonly FilterRule[],
   combinator: Combinator,
   candidateExpressIds: Iterable<number> | undefined,
+  modelId?: string,
 ): ArrayLike<number> | Iterable<number> {
   // Caller-supplied narrowing wins (Tier-1 candidates).
   if (candidateExpressIds !== undefined) return candidateExpressIds;
@@ -315,7 +320,7 @@ export function selectIterationSource(
       const bucket = unionByType(store, rule.values);
       if (bucket && (best === null || bucket.length < best.length)) best = bucket;
     } else if (rule.kind === 'storey' && rule.op === 'in' && rule.values.length > 0) {
-      const bucket = unionByStorey(store, rule.values);
+      const bucket = unionByStorey(store, rule, modelId);
       if (bucket && (best === null || bucket.length < best.length)) best = bucket;
     }
   }
@@ -332,23 +337,6 @@ function unionByType(store: IfcDataStore, names: readonly string[]): number[] | 
   for (const name of names) {
     const bucket = byType.get(name.toUpperCase());
     if (bucket) for (const id of bucket) out.push(id);
-  }
-  return out.length > 0 ? out : null;
-}
-
-function unionByStorey(store: IfcDataStore, storeyNames: readonly string[]): number[] | null {
-  const hierarchy = store.spatialHierarchy;
-  if (!hierarchy) return null;
-  const wanted = new Set(storeyNames.map((n) => n.toLowerCase()));
-  const out: number[] = [];
-  // byStorey keys are storey expressIds; their name comes from the
-  // entity table. Models rarely have more than ~20 storeys, so this
-  // pass is essentially free.
-  for (const storeyId of hierarchy.byStorey.keys()) {
-    const name = store.entities.getName(storeyId);
-    if (!wanted.has(name.toLowerCase())) continue;
-    const elements = hierarchy.byStorey.get(storeyId);
-    if (elements) for (const id of elements) out.push(id);
   }
   return out.length > 0 ? out : null;
 }
@@ -400,6 +388,8 @@ type TypePsetList = ReturnType<typeof extractPropertiesOnDemand>;
 
 interface EvalContext {
   store: IfcDataStore;
+  /** Scopes a `StoreyRule.refs` exact match to this store's own model. */
+  modelId: string;
   table: IfcDataStore['entities'];
   options: EvaluateOptions;
   hasPropertyRule: boolean;
@@ -528,6 +518,11 @@ function evaluateRule(
 ): boolean {
   switch (rule.kind) {
     case 'storey': {
+      // Exact-identity mode (refs present): Name isn't unique.
+      if (rule.refs) {
+        const isMatch = storeyMatchesRefs(ctx.store, expressId, ctx.modelId, rule);
+        return rule.op === 'in' ? isMatch : !isMatch;
+      }
       const storeyName = ctx.options.storeyNameOf?.(expressId)
         ?? defaultStoreyName(ctx.store, expressId);
       return setOpMatches(rule.op, storeyName, rule.values);

--- a/apps/viewer/src/lib/search/filter-match.ts
+++ b/apps/viewer/src/lib/search/filter-match.ts
@@ -26,6 +26,7 @@ import {
   type PropertyRule,
   type QuantityRule,
   type ClassificationRule,
+  type StoreyRule,
 } from './filter-rules.js';
 import { lensMaterialNames } from '../lens-material-names.js';
 import { parsePropertyValue } from '@ifc-lite/encoding';
@@ -121,6 +122,39 @@ export function defaultStoreyName(store: IfcDataStore, expressId: number): strin
   const storeyId = hierarchy.elementToStorey.get(expressId);
   if (!storeyId) return '';
   return store.entities.getName(storeyId);
+}
+
+/** Does `expressId` (in `modelId`) sit in a storey ref'd by `rule.refs`?
+ *  `IfcBuildingStorey.Name` isn't unique, so once a `StoreyRule` carries
+ *  an exact (modelId, expressId) ref (mirrored from a HierarchyPanel
+ *  click), matching bypasses Name entirely. */
+export function storeyMatchesRefs(store: IfcDataStore, expressId: number, modelId: string, rule: StoreyRule): boolean {
+  const storeyId = store.spatialHierarchy?.elementToStorey.get(expressId);
+  return storeyId != null && !!rule.refs?.some((r) => r.modelId === modelId && r.expressId === storeyId);
+}
+
+/** Index-prefilter twin of {@link storeyMatchesRefs}/Name matching: the
+ *  bucket of elements a `storey op:'in'` rule narrows to for `modelId`. */
+export function unionByStorey(store: IfcDataStore, rule: StoreyRule, modelId: string | undefined): number[] | null {
+  const hierarchy = store.spatialHierarchy;
+  if (!hierarchy) return null;
+  const out: number[] = [];
+  if (rule.refs) {
+    for (const ref of rule.refs) {
+      if (ref.modelId !== modelId) continue;
+      const elements = hierarchy.byStorey.get(ref.expressId);
+      if (elements) for (const id of elements) out.push(id);
+    }
+    return out.length > 0 ? out : null;
+  }
+  const wanted = new Set(rule.values.map((n) => n.toLowerCase()));
+  for (const storeyId of hierarchy.byStorey.keys()) {
+    const name = store.entities.getName(storeyId);
+    if (!wanted.has(name.toLowerCase())) continue;
+    const elements = hierarchy.byStorey.get(storeyId);
+    if (elements) for (const id of elements) out.push(id);
+  }
+  return out.length > 0 ? out : null;
 }
 
 // ── Material / classification / elevation resolution ─────────────────────────

--- a/apps/viewer/src/lib/search/filter-rules.test.ts
+++ b/apps/viewer/src/lib/search/filter-rules.test.ts
@@ -14,6 +14,7 @@ import {
   isFilterRule,
   parseFilterRules,
   Rule,
+  addHierarchyStoreyToRule,
 } from './filter-rules.js';
 
 describe('op helpers tolerate an undefined candidate (#1195)', () => {
@@ -132,6 +133,55 @@ describe('combineRuleResults', () => {
   it('returns false on an empty list (no rule = no match)', () => {
     assert.strictEqual(combineRuleResults('AND', []), false);
     assert.strictEqual(combineRuleResults('OR', []), false);
+  });
+});
+
+describe('addHierarchyStoreyToRule', () => {
+  it('starts a hierarchy selection in exact-ref mode', () => {
+    const result = addHierarchyStoreyToRule(
+      undefined,
+      'Level 1',
+      [{ modelId: 'model-a', expressId: 100 }],
+    );
+
+    assert.deepStrictEqual(result, Rule.storey(
+      ['Level 1'],
+      'in',
+      [{ modelId: 'model-a', expressId: 100 }],
+    ));
+  });
+
+  it('keeps manual name selections in name mode when Ctrl/Cmd-click adds a storey (#3545)', () => {
+    const manual = Rule.storey(['Level 1']);
+    const result = addHierarchyStoreyToRule(
+      manual,
+      'Level 2',
+      [{ modelId: 'model-a', expressId: 200 }],
+    );
+
+    assert.deepStrictEqual(result, Rule.storey(['Level 1', 'Level 2']));
+  });
+
+  it('merges exact refs for a rule already created by the hierarchy', () => {
+    const hierarchyRule = Rule.storey(
+      ['Level 1'],
+      'in',
+      [{ modelId: 'model-a', expressId: 100 }],
+    );
+    const result = addHierarchyStoreyToRule(
+      hierarchyRule,
+      'Level 2',
+      [{ modelId: 'model-a', expressId: 200 }],
+    );
+
+    assert.deepStrictEqual(result, Rule.storey(
+      ['Level 1', 'Level 2'],
+      'in',
+      [
+        { modelId: 'model-a', expressId: 100 },
+        { modelId: 'model-a', expressId: 200 },
+      ],
+    ));
   });
 });
 

--- a/apps/viewer/src/lib/search/filter-rules.ts
+++ b/apps/viewer/src/lib/search/filter-rules.ts
@@ -262,6 +262,23 @@ export function mergeStoreyRefs(
   return merged;
 }
 
+/** Add a HierarchyPanel storey click to its mirrored `op:in` rule.
+ *
+ * A rule created by the hierarchy carries exact refs. A manually authored
+ * rule has no refs and deliberately matches by its names; changing that rule
+ * to ref mode would discard every existing manual selection. Keep it in name
+ * mode when extending it, while hierarchy-originated rules retain exact refs.
+ */
+export function addHierarchyStoreyToRule(
+  prior: StoreyRule | undefined,
+  name: string,
+  refs: ReadonlyArray<{ modelId: string; expressId: number }>,
+): StoreyRule {
+  const values = Array.from(new Set([...(prior?.values ?? []), name]));
+  if (prior && !prior.refs) return Rule.storey(values, 'in');
+  return Rule.storey(values, 'in', mergeStoreyRefs(prior?.refs ?? [], refs));
+}
+
 // ── Convenience constructors ──────────────────────────────────────────────────
 //
 // The chip UI builds rules via `set*` slice actions (see searchSlice.ts);

--- a/apps/viewer/src/lib/search/filter-rules.ts
+++ b/apps/viewer/src/lib/search/filter-rules.ts
@@ -51,6 +51,19 @@ export interface StoreyRule {
   kind: 'storey';
   values: string[];
   op: SetOp;
+  /**
+   * Optional exact storey identity, set only when the rule was mirrored
+   * from a HierarchyPanel click (which holds the real `(modelId,
+   * expressId)` of the storey the user selected). `IfcBuildingStorey.Name`
+   * is optional and not unique — two distinct storeys, even within one
+   * model, routinely share a Name (repeated "Level 1" across wings, or
+   * federated buildings). When `refs` is present, the evaluator matches
+   * an element's storey by this exact identity instead of by name, so
+   * clicking one storey never silently pulls in a same-named sibling.
+   * Undefined for manually authored/typed rules (the chip UI only offers
+   * names to type against), which keep matching by name as before.
+   */
+  refs?: ReadonlyArray<{ modelId: string; expressId: number }>;
 }
 
 export interface IfcTypeRule {
@@ -233,6 +246,22 @@ export function combineRuleResults(combinator: Combinator, results: readonly boo
   return combinator === 'AND' ? results.every((r) => r) : results.some((r) => r);
 }
 
+/** Dedupe-merge two `StoreyRule.refs` lists by (modelId, expressId), used
+ *  when a Ctrl-click accumulates another storey into an existing filter
+ *  (HierarchyPanel). */
+export function mergeStoreyRefs(
+  prior: ReadonlyArray<{ modelId: string; expressId: number }>,
+  next: ReadonlyArray<{ modelId: string; expressId: number }>,
+): Array<{ modelId: string; expressId: number }> {
+  const seen = new Set(prior.map((r) => `${r.modelId}:${r.expressId}`));
+  const merged = [...prior];
+  for (const r of next) {
+    const key = `${r.modelId}:${r.expressId}`;
+    if (!seen.has(key)) { seen.add(key); merged.push(r); }
+  }
+  return merged;
+}
+
 // ── Convenience constructors ──────────────────────────────────────────────────
 //
 // The chip UI builds rules via `set*` slice actions (see searchSlice.ts);
@@ -240,7 +269,11 @@ export function combineRuleResults(combinator: Combinator, results: readonly boo
 // rules from a different representation (URL state, presets).
 
 export const Rule = {
-  storey: (values: string[], op: SetOp = 'in'): StoreyRule => ({ kind: 'storey', values, op }),
+  storey: (
+    values: string[],
+    op: SetOp = 'in',
+    refs?: ReadonlyArray<{ modelId: string; expressId: number }>,
+  ): StoreyRule => ({ kind: 'storey', values, op, ...(refs ? { refs } : {}) }),
   ifcType: (values: string[], op: SetOp = 'in'): IfcTypeRule => ({ kind: 'ifcType', values, op }),
   predefinedType: (values: string[], op: SetOp = 'in'): PredefinedTypeRule =>
     ({ kind: 'predefinedType', values, op }),


### PR DESCRIPTION
## Summary

Fixes the highest-confidence "name-keyed operation" defect found while sweeping storey/material/type/model name-keying (see table below): `HierarchyPanel`'s storey-click filter mirror matched entities by `IfcBuildingStorey.Name` alone, and `Name` is optional and **not unique** — two distinct storeys, even within a single model, routinely share a Name (duplicate "Level 1" across wings, or a copy-paste authoring slip).

Clicking a storey (Solo / Ctrl-click accumulate) mirrors the click into the advanced search filter as `Rule.storey([node.name], 'in')`. `filter-evaluate.ts` then matches purely by Name — both the per-entity evaluator and the `unionByStorey` prefilter — so running that filter (Search modal results, export, "Isolate") could silently include a *different*, unrelated storey's elements just because it shares the label. Meanwhile the id-based `selectedStoreys` set that drives the viewport's own Solo isolation stays correct, so the two representations of "the storey I just clicked" quietly disagree — a same-click-produces-different-results defect, only visible once a project has a duplicate storey name.

### The fix

`StoreyRule` gains an optional `refs?: { modelId, expressId }[]` — the exact identity of the storey/storeys the click actually resolved to (`HierarchyPanel` already computes `storeyIds`/`unified.storeys`; the fix is not throwing that away when mirroring into the filter). `filter-evaluate.ts` matches by ref identity whenever `refs` is present, bypassing the Name resolver entirely; it falls back to Name matching only for manually typed/legacy rules (the chip UI still only offers storey *names* to type against, so hand-authored filters keep the prior, accepted-tradeoff behaviour).

Moved the storey-matching helpers (`storeyMatchesRefs`, `unionByStorey`) into `filter-match.ts` to stay under `filter-evaluate.ts`'s module-size budget (it was already living at exactly 663/663 lines before this change).

### Test plan
- [x] RED on unmodified `main`, GREEN after (`apps/viewer/src/lib/search/filter-evaluate.test.ts`): a fixture with two distinct, same-named ("Level 1") storeys in one model — the ref'd rule matches only the clicked storey's elements (`[10, 30]`, not `20`); a ref for a different model matches nothing (no silent cross-model Name fallback once `refs` is present); the legacy no-refs path is asserted unchanged (still matches both, documenting the accepted manual-filter tradeoff).
- [x] Added a matching prefilter-path test (`unionByStorey`/`selectIterationSource`) so the index-narrowing path and the per-entity path can't silently diverge again.
- [x] `pnpm exec tsc --noEmit` (apps/viewer) — clean on every touched file.
- [x] `node scripts/check-module-size.mjs` — exit 0, no budget raised (net negative line delta on `filter-evaluate.ts`: 658 vs 663 budget; `HierarchyPanel.tsx` exactly at its 1159 budget).
- [x] `node scripts/check-test-wiring.mjs` — OK.
- [x] `apps/viewer` is `private: true` — no changeset needed. No package exports changed — no `api-surface:update` needed.

## Other name-keyed candidates surveyed (this hunt), not shipped here

| Site | Verdict | Evidence |
|---|---|---|
| `HierarchyPanel` storey filter (`Rule.storey([node.name], 'in')`) → `filter-evaluate.ts` Name-only match | **Fixed here** | See above. |
| `MaterialTotalsPanel` / `buildMaterialTree` (`treeDataBuilder.ts`) grouping `IfcMaterial` entities by `u.name` into one row, merging aggregated totals/properties/isolate-set for distinct same-named materials (even within one model) | Real defect shape, **not shipped** — the hunt brief explicitly scopes out "grouping material totals by name IS the expected semantics" for this panel; flagging for a maintainer call on whether the *aggregation* (not just the display grouping) crossing material identity is in-scope for a follow-up. | `apps/viewer/src/components/viewer/hierarchy/treeDataBuilder.ts` (`buildMaterialTree`) |
| `Rule.material('eq', node.name)` — material search-filter click, same shape as the storey bug (isolates by Name, not identity) | Same-family risk, **not shipped** — smaller blast radius than storey (no id-vs-name divergence with a separate viewport isolation path the way storeys have `selectedStoreys`), left for a follow-up since this PR is scoped to one fix. | `HierarchyPanel.tsx:435-436`, `filter-evaluate.ts` `case 'material'` |
| `buildUnifiedStoreys` (`treeDataBuilder.ts`) — merges storeys **across models** by elevation (not Name); the *displayed* label picks the shortest same-elevation Name | Not a bug — elevation is the grouping key; Name is cosmetic only. | `treeDataBuilder.ts:217-266` |
| `getStoreyByElevation` / `findStoreyByElevation` (parser, ifcx, viewer) | Not a bug — elevation-tolerance lookup, unrelated to Name uniqueness. | `packages/ifcx/src/hierarchy-builder.ts`, `packages/parser/src/spatial-hierarchy-builder.ts`, `apps/viewer/src/utils/serverDataModel.ts` |
| `packages/query/src/property-table.ts` merging `PropertySet`s by `pset.name` | Not a bug — the documented IFC pset-merge convention (type + occurrence psets sharing a name are meant to merge); already covered by #3538/#3539. | `property-table.ts:81-89` |
| `packages/lens/src/discovery.ts` pset/qset name maps | Not a bug — a name-frequency index for search autocomplete, not an operation target. | `discovery.ts:101-119` |
| `BulkPropertyEditor.tsx` `enumToTypeName`/`nameToEnums` maps | Not a bug — keys on the IFC *entity class* name (`"IfcWallStandardCase"`), not an instance's editable `Name`; no `IfcWallType`/`TypeObject` instance-name keying found anywhere. | `BulkPropertyEditor.tsx:282-311` |
| `model.name` occurrences (`ExportDialog.tsx`, `AddElementPanel.tsx`, `CommandPalette.tsx`, `GeoreferencingPanel.tsx`, `useIfcFederation.ts`, `bcfHeaderFiles.ts`, `context-builder.ts`, `syncSourceModel.ts`, …) | Not a bug — every occurrence is display/labeling/filenames only; `state.models` and `FederatedModel` collections are consistently keyed by model **id**. The codebase already has an explicit defensive guard against a related identity-collision class in `playground-scene-registry.ts` (reference-identity check, not `model.id`, citing #2471). | grep across `apps/viewer/src` |
| `selectedStoreys: Set<number>` cross-**model** id collisions (a *different* non-uniqueness — bare expressId, not Name) | Out of scope for this hunt (name-keying), and already extensively covered this session by #3506/#3508/#3511. | n/a |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Storey filtering now targets the exact selected storey, preventing similarly named storeys from being included accidentally.
  * Storey filters work correctly across multiple models.
  * Combined storey selections now preserve all selected references.
  * Existing name-based storey filtering remains supported.
  * Improved filtering accuracy when selecting storeys from the hierarchy panel, including Solo and multi-selection workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->