### PR TITLE
fix(diff): scale Qto_ Length/Area/Volume quantities to base SI before hashing

### DIFF
--- a/.changeset/diff-qto-length-unit-scale.md
+++ b/.changeset/diff-qto-length-unit-scale.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/cli': patch
+---
+
+Fix `ifc-lite diff` reporting a `Qto_` `IfcElementQuantity` (Length/Area/Volume) as `modified` when a model is re-authored in a different project length unit but no physical quantity actually changed.
+
+`buildFileFingerprints`' data input built each quantity's `dataHash` contribution from the raw parser value — the project's own author-unit number, exactly like an untyped `IfcPropertySingleValue`. A wall re-exported from a metre-authored file (`IfcQuantityLength` `2`) into a millimetre-authored one (`2000`), with no edit to the design, therefore hashed to two different values and the entity classified as `modified · data`. Quantities are now scaled to base SI with `quantitySiScale` (`@ifc-lite/parser`) before rounding and hashing, mirroring the base-SI conversion `#3458` already applied on the IDS comparison path.

--- a/.changeset/mcp-diff-qto-length-unit-scale.md
+++ b/.changeset/mcp-diff-qto-length-unit-scale.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/mcp': patch
+---
+
+Fix `model_diff` reporting a `Qto_` `IfcElementQuantity` (Length/Area/Volume) as `modified` when a model is re-authored in a different project length unit but no physical quantity actually changed — the same false positive `#3458`-adjacent fix closed on the CLI's `ifc-lite diff` (see the `@ifc-lite/cli` changeset). `buildModelFingerprints`' `buildDataInput`/`createdFingerprint` now scale a Qto_ value to base SI with `quantitySiScale` (`@ifc-lite/parser`) before rounding and hashing, for both a stored and an overlay-queued quantity, keeping this adapter's fingerprints identical to the CLI's — the invariant `diff-fingerprints.test.ts`'s parity suite enforces.

--- a/.changeset/parser-quantity-si-scale.md
+++ b/.changeset/parser-quantity-si-scale.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/parser': minor
+---
+
+Add `quantitySiScale(quantityType, units)`: the SI scale factor for an `IfcElementQuantity` (`Qto_*`) Length/Area/Volume value, resolved against a file's declared `ProjectUnits`. A `Qto_` value is stored in the project's raw author unit, exactly like a length-typed property, and this is the single place a consumer converts it to base SI before comparing or hashing it — used by the model-diff CLI adapter to fix a false "modified" on a re-authored-unit re-export (see the `@ifc-lite/cli` changeset), and mirrors the conversion `#3458` already applies on the IDS path.

--- a/.changeset/viewer-diff-qto-length-unit-scale.md
+++ b/.changeset/viewer-diff-qto-length-unit-scale.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+Fix the compare panel reporting every quantified element as modified when the two files simply declare different project length units. Qto_ Length/Area/Volume quantities are now compared in base SI rather than the raw author-unit value.

--- a/apps/viewer/src/lib/compare/buildFingerprints.ts
+++ b/apps/viewer/src/lib/compare/buildFingerprints.ts
@@ -400,7 +400,7 @@ function buildDataInput(
       quantities: set.quantities
         .filter((quantity) => !isGeometricDataName(quantity.name))
         // Scaled to base SI, then rounded (`quantitySiScale`/`roundQuantity`).
-        .map((quantity) => ({ name: quantity.name, value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)) })),
+        .map((quantity) => ({ name: quantity.name, value: roundQuantity(quantity.value * quantitySiScale(quantity, units)) })),
     }))
     .filter((set) => set.quantities.length > 0);
 

--- a/apps/viewer/src/lib/compare/buildFingerprints.ts
+++ b/apps/viewer/src/lib/compare/buildFingerprints.ts
@@ -27,32 +27,29 @@
  * the federation anchored on.
  *
  * The proved enclosed volume (#1993) rides on `MeshData.geometryVolume` from
- * that same pass, and is the one fingerprint that does NOT survive that trip:
- * the alignment rescales, and no re-measurement is available on this side. It
- * is therefore withheld for a re-baked model rather than re-derived — see
- * `geometryVolumesSurviveAlignment`.
+ * that same pass, and is the one fingerprint that does NOT survive a federation
+ * re-bake (the alignment rescales, and there is no re-measurement on this side),
+ * so it is withheld rather than re-derived — see `geometryVolumesSurviveAlignment`.
  *
  * Scope: every entity that produced at least one mesh, PLUS every `IfcProduct`
  * with a GlobalId — see `compareScope.ts` for why that second half exists and
  * where its line is drawn. The mesh-only enumeration this widens made "did it
  * change?" quietly mean "did a renderable thing change?", so a geometry-less
- * `IfcElementAssembly` could have its attributes rewritten, and a geometry-less
- * `IfcSite` could be deleted outright, with the panel reporting neither.
- * Data-only edits on meshed entities were, and remain, detected via the data
- * hash.
+ * `IfcElementAssembly` could have its attributes rewritten, or a geometry-less
+ * `IfcSite` deleted outright, with the panel reporting neither.
  *
  * A product with no mesh carries, in place of a WASM geometry hash, a
- * fingerprint of its COMPOSED WORLD PLACEMENT (`worldPlacement.ts`). Leaving it
- * with no geometry hash at all made the whole geometry channel silent for that
- * population, and an entire re-georeferenced `IfcSite` — moved 40 m, turned 60
- * degrees, subtree and all — was reported as unchanged. It must be the composed
- * transform rather than the local placement: re-georeferencing rewrites the
- * placement *expression* of objects that did not move, and flagging those cries
- * wolf on every corrected model.
+ * fingerprint of its COMPOSED WORLD PLACEMENT (`worldPlacement.ts`) — leaving it
+ * with none at all silenced the whole geometry channel for that population (a
+ * re-georeferenced `IfcSite`, moved and rotated, read as unchanged). It must be
+ * the composed transform, not the local one: re-georeferencing rewrites the
+ * placement *expression* of objects that did not move.
  *
- * The data fingerprint also carries the entity's RESOLVED MATERIAL NAMES,
- * through every `IfcMaterial*` indirection. Material was in no channel at all,
- * so re-specifying an element moved nothing.
+ * The data fingerprint also carries the entity's RESOLVED MATERIAL NAMES
+ * (through every `IfcMaterial*` indirection) and, for a Qto_ Length/Area/Volume
+ * quantity, the value SCALED TO BASE SI (`quantitySiScale`) rather than the raw
+ * project-unit number — so a model re-authored in a different length unit, with
+ * no physical quantity actually changed, does not read as modified.
  */
 
 import {
@@ -65,9 +62,11 @@ import { RelationshipType } from '@ifc-lite/data';
 import {
   extractAllEntityAttributes,
   extractAllMaterialsOnDemand,
+  extractProjectUnits,
   extractPropertiesOnDemand,
   extractQuantitiesOnDemand,
-  type IfcDataStore,
+  quantitySiScale,
+  type IfcDataStore, type ProjectUnits,
 } from '@ifc-lite/parser';
 import { lensMaterialNames } from '../lens-material-names.js';
 import type { EntityWorldAabb, MeshData } from '@ifc-lite/geometry';
@@ -97,14 +96,12 @@ export interface CompareRef {
    * `setColorOverrides` on this id is a no-op and hiding it suppresses nothing.
    * The overlay needs that distinction: its rule for a modified element is
    * "colour the head copy, hide the base copy so the two do not z-fight", and
-   * that rests on the head copy being drawable. See `overlay.ts`.
-   *
-   * Distinct from `geometryHash === undefined`, which is also what a meshed
-   * entity carries when hashing is off — that entity is still drawn.
+   * that rests on the head copy being drawable (`overlay.ts`). Distinct from
+   * `geometryHash === undefined`, also true of a meshed entity when hashing is
+   * off — that entity is still drawn.
    *
    * OPTIONAL and read as "drawable unless explicitly `false`": a hand-built
-   * ref (tests, older call sites) keeps the pre-existing behaviour rather than
-   * being demoted to invisible by omission.
+   * ref (tests, older call sites) keeps the pre-existing behaviour.
    */
   meshed?: boolean;
 }
@@ -194,6 +191,7 @@ export async function buildEntityFingerprints(
   // alignment is a caller whose model was never re-baked, and defaulting to
   // "believe them" keeps the flag a statement about the one case that needs it.
   const volumesTrusted = model.geometryVolumesTrusted !== false;
+  const units = extractProjectUnits(store.source, store.entityIndex); // for quantitySiScale
 
   // local express id → first geometry hash seen for it (may be undefined when
   // hashing was disabled or the WASM build predates it — data diff still works)
@@ -310,7 +308,7 @@ export async function buildEntityFingerprints(
     // the 64-bit data hash cannot. Both are computed from the SAME input
     // object - a sub-hash over a different projection would stop being a
     // collision guard and start rejecting genuine re-export matches.
-    const dataInput = buildDataInput(store, localId, ifcType);
+    const dataInput = buildDataInput(store, localId, ifcType, units);
 
     // The box goes on ONLY when the pass produced one: the engine's contract is
     // that a missing box is `undefined`, and a NaN-bearing object would pass
@@ -356,6 +354,7 @@ function buildDataInput(
   store: IfcDataStore,
   localId: number,
   ifcType: string,
+  units: ProjectUnits, // scales Qto_ Length/Area/Volume values to base SI
 ): DataFingerprintInput {
   const predefinedType = extractAllEntityAttributes(store, localId).find(
     (attribute) => attribute.name === 'PredefinedType',
@@ -400,7 +399,8 @@ function buildDataInput(
       name: set.name,
       quantities: set.quantities
         .filter((quantity) => !isGeometricDataName(quantity.name))
-        .map((quantity) => ({ name: quantity.name, value: roundQuantity(quantity.value) })),
+        // Scaled to base SI, then rounded (`quantitySiScale`/`roundQuantity`).
+        .map((quantity) => ({ name: quantity.name, value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)) })),
     }))
     .filter((set) => set.quantities.length > 0);
 

--- a/packages/cli/src/commands/diff-engine.ts
+++ b/packages/cli/src/commands/diff-engine.ts
@@ -39,10 +39,13 @@ import { RelationshipType } from '@ifc-lite/data';
 import {
   EntityExtractor,
   extractAllEntityAttributes,
+  extractProjectUnits,
   extractPropertiesOnDemand,
   extractQuantitiesOnDemand,
   getAttributeNamesAcrossSchemas,
+  quantitySiScale,
   type IfcDataStore,
+  type ProjectUnits,
 } from '@ifc-lite/parser';
 import { comparableEntities, type RootAttributes } from './diff-scope.js';
 
@@ -71,9 +74,16 @@ export function modelIdentityOf(path: string, bytes: Uint8Array): ModelIdentity 
  * section of `docs/guide/model-diff.md`).
  */
 export function buildFileFingerprints(store: IfcDataStore): EntityFingerprint<DiffRef>[] {
+  // Resolved once per file: an IfcQuantityLength/Area/Volume is stored in the
+  // project's raw author unit, exactly like a length-typed property, so it
+  // needs the same base-SI conversion before it can be hashed — otherwise a
+  // model re-authored in a different project length unit, with no physical
+  // quantity actually changed, reports every quantified entity as `modified`
+  // (see `quantitySiScale`).
+  const units = extractProjectUnits(store.source, store.entityIndex);
   const fingerprints: EntityFingerprint<DiffRef>[] = [];
   for (const { expressId, globalId, ifcType, source, isTypeObject } of comparableEntities(store)) {
-    const input = buildDataInput(store, expressId, ifcType, source, isTypeObject);
+    const input = buildDataInput(store, expressId, ifcType, source, isTypeObject, units);
     fingerprints.push({
       key: globalId,
       ifcType,
@@ -103,6 +113,9 @@ function buildDataInput(
   source: RootAttributes | undefined,
   /** `IfcTypeObject` subtype? Gates `Tag` into the fingerprint (issue #2021). */
   isTypeObject: boolean,
+  /** The file's declared units, for scaling Qto_ Length/Area/Volume values to
+   *  base SI before hashing (see {@link buildFileFingerprints}). */
+  units: ProjectUnits,
 ): DataFingerprintInput {
   const predefinedType = extractAllEntityAttributes(store, expressId).find(
     (attribute) => attribute.name === 'PredefinedType',
@@ -124,10 +137,12 @@ function buildDataInput(
     name: set.name,
     quantities: set.quantities.map((quantity) => ({
       name: quantity.name,
-      // Rounded to 4 dp, matching the viewer: re-exporting a model with
-      // sub-tolerance float jitter must not flip the data hash on an otherwise
-      // identical element, which on this path would cost the pair its match.
-      value: roundQuantity(quantity.value),
+      // Scaled to base SI first (a Qto_ value is stored in the project's raw
+      // author unit, see `quantitySiScale`), then rounded to 4 dp, matching
+      // the viewer: re-exporting a model with sub-tolerance float jitter must
+      // not flip the data hash on an otherwise identical element, which on
+      // this path would cost the pair its match.
+      value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)),
     })),
   }));
 

--- a/packages/cli/src/commands/diff-engine.ts
+++ b/packages/cli/src/commands/diff-engine.ts
@@ -142,7 +142,7 @@ function buildDataInput(
       // the viewer: re-exporting a model with sub-tolerance float jitter must
       // not flip the data hash on an otherwise identical element, which on
       // this path would cost the pair its match.
-      value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)),
+      value: roundQuantity(quantity.value * quantitySiScale(quantity, units)),
     })),
   }));
 

--- a/packages/cli/src/commands/diff-oracle.test.ts
+++ b/packages/cli/src/commands/diff-oracle.test.ts
@@ -68,4 +68,20 @@ describe('oracle: quantity unit-of-measure', () => {
     const wall = diff.byKey.get(guid('WALL'));
     expect(wall?.state).toBe('modified');
   });
+
+  it('uses a quantity member’s explicit Unit before the project unit assignment', async () => {
+    // Both projects declare metres. The head quantity overrides that with
+    // millimetres, so its raw 2000 is still the base quantity’s physical 2 m.
+    const baseStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('METRE', 2)),
+      'base',
+    );
+    const headStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('METRE', 2000, 'MILLIMETRE')),
+      'head',
+    );
+
+    const diff = diffModels(buildFileFingerprints(baseStore), buildFileFingerprints(headStore));
+    expect(diff.byKey.get(guid('WALL'))?.state).toBe('unchanged');
+  });
 });

--- a/packages/cli/src/commands/diff-oracle.test.ts
+++ b/packages/cli/src/commands/diff-oracle.test.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Oracle harness: a known, minimal edit through a real STEP fixture, run
+ * through the real `@ifc-lite/diff` engine via the CLI adapter
+ * (`buildFileFingerprints`), and checked against the exactly-that-edit
+ * expectation. See the mutation-diff-sweep test (#3130-style) for the sibling
+ * convention; this file covers unit-of-measure cases that sweep did not.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { diffModels } from '@ifc-lite/diff';
+import { buildFileFingerprints } from './diff-engine.js';
+import { loadIfcBytes } from '../loader.js';
+import { guid, quantityModel } from './diff-test-helpers.js';
+
+describe('oracle: quantity unit-of-measure', () => {
+  it('a Qto_ length quantity re-authored in a different project length unit, same physical length, classifies as unchanged', async () => {
+    // Base: 2 metres, project unit METRE, raw value 2.0.
+    const baseStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('METRE', 2)),
+      'base',
+    );
+    // Head: same 2 metres, project unit MILLIMETRE, raw value 2000.0 — same
+    // building, nothing an author or coordinator would call an edit.
+    const headStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('MILLIMETRE', 2000)),
+      'head',
+    );
+
+    const diff = diffModels(buildFileFingerprints(baseStore), buildFileFingerprints(headStore));
+    const wall = diff.byKey.get(guid('WALL'));
+    expect(wall?.state).toBe('unchanged');
+  });
+
+  it('control: a genuine quantity edit within one project unit still classifies as modified', async () => {
+    const baseStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('METRE', 2)),
+      'base',
+    );
+    // Same unit, a real 2 m -> 3 m edit.
+    const headStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('METRE', 3)),
+      'head',
+    );
+
+    const diff = diffModels(buildFileFingerprints(baseStore), buildFileFingerprints(headStore));
+    const wall = diff.byKey.get(guid('WALL'));
+    expect(wall?.state).toBe('modified');
+    expect(wall?.changeKinds).toEqual(['data']);
+  });
+
+  it('a genuinely different physical length across a unit change still classifies as modified', async () => {
+    // Base: 2 metres. Head: re-authored in millimetres AND changed to 3 m
+    // (raw 3000) — a real edit riding along with the unit change.
+    const baseStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('METRE', 2)),
+      'base',
+    );
+    const headStore = await loadIfcBytes(
+      new TextEncoder().encode(quantityModel('MILLIMETRE', 3000)),
+      'head',
+    );
+
+    const diff = diffModels(buildFileFingerprints(baseStore), buildFileFingerprints(headStore));
+    const wall = diff.byKey.get(guid('WALL'));
+    expect(wall?.state).toBe('modified');
+  });
+});

--- a/packages/cli/src/commands/diff-test-helpers.ts
+++ b/packages/cli/src/commands/diff-test-helpers.ts
@@ -272,11 +272,19 @@ export const HEAD_MODEL = model(guid('NEWA'), guid('NEWB'));
  *  chosen project length unit and a chosen raw quantity value — for the
  *  unit-of-measure oracle case (a Qto_ value is stored in the project's raw
  *  author unit, not base SI; see `quantitySiScale`). */
-export function quantityModel(lengthUnit: 'METRE' | 'MILLIMETRE', qtyValue: number): string {
+export function quantityModel(
+  lengthUnit: 'METRE' | 'MILLIMETRE',
+  qtyValue: number,
+  explicitQuantityUnit?: 'METRE' | 'MILLIMETRE',
+): string {
   const unitDecl =
     lengthUnit === 'METRE'
       ? `#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);`
       : `#31= IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);`;
+  const quantityUnitDecl = explicitQuantityUnit
+    ? `#32= IFCSIUNIT(*,.LENGTHUNIT.,${explicitQuantityUnit === 'METRE' ? '$' : '.MILLI.'},.METRE.);`
+    : '';
+  const quantityUnitRef = explicitQuantityUnit ? '#32' : '$';
   return `ISO-10303-21;
 HEADER;
 FILE_DESCRIPTION((''),'2;1');
@@ -290,11 +298,12 @@ DATA;
 #22= IFCCARTESIANPOINT((0.,0.,0.));
 #30= IFCUNITASSIGNMENT((#31));
 ${unitDecl}
+${quantityUnitDecl}
 #40= IFCLOCALPLACEMENT($,#21);
 #41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
 #70= IFCWALL('${guid('WALL')}',$,'Wall A',$,$,#40,$,'tagA',$);
 #80= IFCELEMENTQUANTITY('${guid('QSET')}',$,'Qto_WallBaseQuantities',$,$,(#81));
-#81= IFCQUANTITYLENGTH('Length',$,$,${qtyValue.toFixed(3)});
+#81= IFCQUANTITYLENGTH('Length',$,${quantityUnitRef},${qtyValue.toFixed(3)});
 #82= IFCRELDEFINESBYPROPERTIES('${guid('RELQ')}',$,$,$,(#70),#80);
 #96= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#70),#41);
 ENDSEC;

--- a/packages/cli/src/commands/diff-test-helpers.ts
+++ b/packages/cli/src/commands/diff-test-helpers.ts
@@ -267,3 +267,37 @@ END-ISO-10303-21;
 export const BASE_MODEL = model(guid('OLDA'), guid('OLDB'));
 /** Same building, re-exported: the two walls carry brand-new GlobalIds. */
 export const HEAD_MODEL = model(guid('NEWA'), guid('NEWB'));
+
+/** A minimal model with one wall carrying one `Qto_` length quantity, under a
+ *  chosen project length unit and a chosen raw quantity value — for the
+ *  unit-of-measure oracle case (a Qto_ value is stored in the project's raw
+ *  author unit, not base SI; see `quantitySiScale`). */
+export function quantityModel(lengthUnit: 'METRE' | 'MILLIMETRE', qtyValue: number): string {
+  const unitDecl =
+    lengthUnit === 'METRE'
+      ? `#31= IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);`
+      : `#31= IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);`;
+  return `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('m','2026',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1= IFCPROJECT('${guid('PROJ')}',$,'Proj',$,$,$,$,(#20),#30);
+#20= IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#21,$);
+#21= IFCAXIS2PLACEMENT3D(#22,$,$);
+#22= IFCCARTESIANPOINT((0.,0.,0.));
+#30= IFCUNITASSIGNMENT((#31));
+${unitDecl}
+#40= IFCLOCALPLACEMENT($,#21);
+#41= IFCBUILDINGSTOREY('${guid('STOR')}',$,'L01',$,$,#40,$,$,.ELEMENT.,0.);
+#70= IFCWALL('${guid('WALL')}',$,'Wall A',$,$,#40,$,'tagA',$);
+#80= IFCELEMENTQUANTITY('${guid('QSET')}',$,'Qto_WallBaseQuantities',$,$,(#81));
+#81= IFCQUANTITYLENGTH('Length',$,$,${qtyValue.toFixed(3)});
+#82= IFCRELDEFINESBYPROPERTIES('${guid('RELQ')}',$,$,$,(#70),#80);
+#96= IFCRELCONTAINEDINSPATIALSTRUCTURE('${guid('RELC')}',$,$,$,(#70),#41);
+ENDSEC;
+END-ISO-10303-21;
+`;
+}

--- a/packages/mcp/src/tools/diff-fingerprints.test.ts
+++ b/packages/mcp/src/tools/diff-fingerprints.test.ts
@@ -34,6 +34,7 @@ import {
   guid,
   legacyScheduleModel,
   model,
+  quantityModel,
   railTypeModel,
   scheduleModel,
   typeTagModel,
@@ -99,6 +100,7 @@ beforeAll(async () => {
   await load('walls', model(guid('OLDA'), guid('OLDB')));
   await load('type-tags', typeTagModel());
   await load('rail-types', railTypeModel());
+  await load('qty-mm', quantityModel('MILLIMETRE', 2000));
 }, 60_000);
 
 afterAll(async () => {
@@ -188,7 +190,7 @@ describe('fingerprint parity with the CLI copy', () => {
   // codegen pin silently reads no Tag at all while every IFC2X3 and IFC4
   // fixture above still agrees. Without this row, fixing one copy's attribute
   // lookup and not the other's would pass.
-  it.each(['legacy-base', 'sched', 'walls', 'type-tags', 'rail-types'])(
+  it.each(['legacy-base', 'sched', 'walls', 'type-tags', 'rail-types', 'qty-mm'])(
     'answers as the CLI does on %s',
     (id) => {
       const mcp = new Map(

--- a/packages/mcp/src/tools/diff-fingerprints.ts
+++ b/packages/mcp/src/tools/diff-fingerprints.ts
@@ -314,7 +314,7 @@ function createdFingerprint(
       name: set.name,
       quantities: set.quantities.map((quantity) => ({
         name: quantity.name,
-        value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)),
+        value: roundQuantity(quantity.value * quantitySiScale(quantity, units)),
       })),
     })),
     typeAssignments: [],
@@ -393,7 +393,7 @@ function buildDataInput(
     name: set.name,
     // Scaled to base SI, then rounded — both stored and overlaid values, a
     // queued edit being authored in the project unit same as a parsed one.
-    quantities: set.quantities.map((quantity) => ({ name: quantity.name, value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)) })),
+    quantities: set.quantities.map((quantity) => ({ name: quantity.name, value: roundQuantity(quantity.value * quantitySiScale(quantity, units)) })),
   }));
 
   const typeAssignments = store.relationships

--- a/packages/mcp/src/tools/diff-fingerprints.ts
+++ b/packages/mcp/src/tools/diff-fingerprints.ts
@@ -101,12 +101,14 @@ import { RelationshipType } from '@ifc-lite/data';
 import {
   EntityExtractor,
   extractAllEntityAttributes,
+  extractProjectUnits,
   extractPropertiesOnDemand,
   extractQuantitiesOnDemand,
   extractRootAttributesFromEntity,
   getAttributeNamesAcrossSchemas,
   getInheritanceChainAcrossSchemas,
-  type IfcDataStore,
+  quantitySiScale,
+  type IfcDataStore, type ProjectUnits,
 } from '@ifc-lite/parser';
 import type { CreatedEntity, PendingOverlay } from '../overlay.js';
 
@@ -204,10 +206,10 @@ export function buildModelFingerprints(
 ): EntityFingerprint<DiffRef>[] {
   const fingerprints: EntityFingerprint<DiffRef>[] = [];
   const seen = new Set<number>();
-  // One extractor for the whole model: it holds a buffer reference, and the
-  // source read below only fires for the (small) set of object types the
-  // EntityTable declines to hold.
+  // One extractor for the whole model: the source read below only fires for
+  // the (small) set of object types the EntityTable declines to hold.
   const extractor = new EntityExtractor(store.source);
+  const units = extractProjectUnits(store.source, store.entityIndex); // for quantitySiScale
 
   for (const [typeKey, ids] of store.entityIndex.byType) {
     // Classified once per type rather than once per entity — the geometry
@@ -241,7 +243,7 @@ export function buildModelFingerprints(
       // type name: `ifcType` is hashed into the fingerprint and cross-checked
       // on every content match, so 'Unknown' would pair a task with an actor.
       const ifcType = source && (!tableType || tableType === 'Unknown') ? type.name : tableType;
-      const input = buildDataInput(store, expressId, ifcType, source, type.typeObject, overlay);
+      const input = buildDataInput(store, expressId, ifcType, source, type.typeObject, overlay, units);
       fingerprints.push({
         key: globalId,
         ifcType,
@@ -253,7 +255,7 @@ export function buildModelFingerprints(
   }
 
   for (const entity of overlay?.created ?? []) {
-    const fingerprint = createdFingerprint(entity, overlay as PendingOverlay);
+    const fingerprint = createdFingerprint(entity, overlay as PendingOverlay, units);
     if (fingerprint) fingerprints.push(fingerprint);
   }
 
@@ -293,6 +295,7 @@ export function buildModelFingerprints(
 function createdFingerprint(
   entity: CreatedEntity,
   overlay: PendingOverlay,
+  units: ProjectUnits, // scales Qto_ Length/Area/Volume values to base SI
 ): EntityFingerprint<DiffRef> | null {
   const type = classifyType(entity.ifcType);
   if (type.role === 'dependent') return null;
@@ -311,7 +314,7 @@ function createdFingerprint(
       name: set.name,
       quantities: set.quantities.map((quantity) => ({
         name: quantity.name,
-        value: roundQuantity(quantity.value),
+        value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)),
       })),
     })),
     typeAssignments: [],
@@ -359,6 +362,7 @@ function buildDataInput(
   /** Set when the session has queued edits; its reads are base-merged, so it
    *  replaces the store read rather than being layered on top of it. */
   overlay: PendingOverlay | null | undefined,
+  units: ProjectUnits, // scales Qto_ Length/Area/Volume values to base SI
 ): DataFingerprintInput {
   const predefinedType = extractAllEntityAttributes(store, expressId).find(
     (attribute) => attribute.name === 'PredefinedType',
@@ -387,13 +391,9 @@ function buildDataInput(
     : extractQuantitiesOnDemand(store, expressId)
   ).map((set) => ({
     name: set.name,
-    quantities: set.quantities.map((quantity) => ({
-      name: quantity.name,
-      // Rounded to 4 dp, matching the viewer: re-exporting a model with
-      // sub-tolerance float jitter must not flip the data hash on an otherwise
-      // identical element, which on this path would cost the pair its match.
-      value: roundQuantity(quantity.value),
-    })),
+    // Scaled to base SI, then rounded — both stored and overlaid values, a
+    // queued edit being authored in the project unit same as a parsed one.
+    quantities: set.quantities.map((quantity) => ({ name: quantity.name, value: roundQuantity(quantity.value * quantitySiScale(quantity.type, units)) })),
   }));
 
   const typeAssignments = store.relationships

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -64,6 +64,7 @@ export {
   type ResolvedUnit,
   type MeasureUnit,
 } from './project-units.js';
+export { quantitySiScale } from './quantity-collect.js';
 export { ColumnarParser, type IfcDataStore, type EntityByIdIndex, extractPropertiesOnDemand, extractQuantitiesOnDemand, extractEntityAttributesOnDemand, extractAllEntityAttributes, getRawNamedAttributes, extractRootAttributesFromEntity, extractClassificationsOnDemand, extractClassificationSystemsOnDemand, extractMaterialsOnDemand, extractAllMaterialsOnDemand, extractMaterialPropertiesOnDemand, extractMaterialPropertiesForMaterialId, resolveMaterialDefId, resolveAllMaterialDefIds, collectMaterialLeaves, buildMaterialUsageIndex, getMaterialDisplay, extractTypePropertiesOnDemand, extractTypeEntityOwnProperties, extractTypeQuantitiesOnDemand, mergeInheritedPropertySets, extractDocumentsOnDemand, extractRelationshipsOnDemand, extractGroupMembersOnDemand, extractGeoreferencingOnDemand, type ClassificationInfo, type MaterialInfo, type MaterialLayerInfo, type MaterialProfileInfo, type MaterialConstituentInfo, type MaterialPsetGroup, type MaterialLeaf, type MaterialUsage, type TypePropertyInfo, type TypeQuantityInfo, type DocumentInfo, type EntityRelationships, type GroupMember } from './columnar-parser.js';
 export type { IfcStoreBase, IfcSourceHeader, SpatialHierarchy, EntityTable } from '@ifc-lite/data';
 export { parseSourceHeader } from './source-header.js';

--- a/packages/parser/src/project-units-symbols.ts
+++ b/packages/parser/src/project-units-symbols.ts
@@ -1,0 +1,284 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Symbol tables + composition helpers for {@link ../project-units.ts}: the
+ * SI prefix/unit-name tables (mirror `project_units/symbols.rs`), the
+ * `IfcConversionBasedUnit`/currency symbol lookups, derived-unit symbol
+ * composition, and the measure-value-type → unit-type table (mirror
+ * `project_units/measure.rs`). Split out of `project-units.ts` to stay
+ * under the module-size budget; no behavioral boundary is implied, this is
+ * purely `project-units.ts`'s private lookup-table half.
+ */
+
+/** How a measure value type maps onto the file's declared units. */
+export type MeasureUnit =
+  | { kind: 'typed'; unitType: string; defaultSymbol: string }
+  | { kind: 'monetary' }
+  | { kind: 'dimensionless' };
+
+// ============================================================================
+// SI prefix + unit-name symbol tables (mirror project_units/symbols.rs)
+// ============================================================================
+
+const SI_PREFIX_MULTIPLIERS: Record<string, number> = {
+  ATTO: 1e-18, FEMTO: 1e-15, PICO: 1e-12, NANO: 1e-9, MICRO: 1e-6, MILLI: 1e-3,
+  CENTI: 1e-2, DECI: 1e-1, DECA: 1e1, HECTO: 1e2, KILO: 1e3, MEGA: 1e6,
+  GIGA: 1e9, TERA: 1e12, PETA: 1e15, EXA: 1e18,
+};
+
+const SI_PREFIX_SYMBOLS: Record<string, string> = {
+  EXA: 'E', PETA: 'P', TERA: 'T', GIGA: 'G', MEGA: 'M', KILO: 'k', HECTO: 'h',
+  DECA: 'da', DECI: 'd', CENTI: 'c', MILLI: 'm', MICRO: 'µ', NANO: 'n',
+  PICO: 'p', FEMTO: 'f', ATTO: 'a',
+};
+
+interface SiName {
+  symbol: string;
+  prefixPower: number;
+  baseScale: number;
+}
+
+/** Resolve an `IfcSIUnitName` token to its symbol descriptor. */
+function siUnitName(name: string): SiName | undefined {
+  const n = name.replace(/\./g, '').trim().toUpperCase();
+  const d = (symbol: string): SiName => ({ symbol, prefixPower: 1, baseScale: 1.0 });
+  switch (n) {
+    case 'METRE': return d('m');
+    case 'SQUARE_METRE': return { symbol: 'm²', prefixPower: 2, baseScale: 1.0 };
+    case 'CUBIC_METRE': return { symbol: 'm³', prefixPower: 3, baseScale: 1.0 };
+    case 'GRAM': return { symbol: 'g', prefixPower: 1, baseScale: 1e-3 };
+    case 'SECOND': return d('s');
+    case 'AMPERE': return d('A');
+    case 'KELVIN': return d('K');
+    case 'MOLE': return d('mol');
+    case 'CANDELA': return d('cd');
+    case 'RADIAN': return d('rad');
+    case 'STERADIAN': return d('sr');
+    case 'HERTZ': return d('Hz');
+    case 'NEWTON': return d('N');
+    case 'PASCAL': return d('Pa');
+    case 'JOULE': return d('J');
+    case 'WATT': return d('W');
+    case 'COULOMB': return d('C');
+    case 'VOLT': return d('V');
+    case 'FARAD': return d('F');
+    case 'OHM': return d('Ω');
+    case 'SIEMENS': return d('S');
+    case 'WEBER': return d('Wb');
+    case 'TESLA': return d('T');
+    case 'HENRY': return d('H');
+    case 'DEGREE_CELSIUS': return d('°C');
+    case 'LUMEN': return d('lm');
+    case 'LUX': return d('lx');
+    case 'BECQUEREL': return d('Bq');
+    case 'GRAY': return d('Gy');
+    case 'SIEVERT': return d('Sv');
+    default: return undefined;
+  }
+}
+
+function prefixSymbol(prefix: string): string {
+  return SI_PREFIX_SYMBOLS[prefix.replace(/\./g, '').trim().toUpperCase()] ?? '';
+}
+
+function prefixMultiplier(prefix: string): number {
+  return SI_PREFIX_MULTIPLIERS[prefix.replace(/\./g, '').trim().toUpperCase()] ?? 1.0;
+}
+
+/** Symbol + SI scale for a prefixed `IfcSIUnit`. */
+export function siUnitSymbolAndScale(name: string, prefix: string | null): { symbol: string; scale: number } | undefined {
+  const base = siUnitName(name);
+  if (!base) return undefined;
+  const cleanPrefix = prefix ? prefix.replace(/\./g, '').trim() : '';
+  const pSym = cleanPrefix ? prefixSymbol(cleanPrefix) : '';
+  const pMult = cleanPrefix ? prefixMultiplier(cleanPrefix) : 1.0;
+  return {
+    symbol: `${pSym}${base.symbol}`,
+    scale: base.baseScale * Math.pow(pMult, base.prefixPower),
+  };
+}
+
+/** Friendly symbol for a common `IfcConversionBasedUnit` name. */
+export function conversionUnitSymbol(name: string): string {
+  const clean = name.replace(/'/g, '').trim();
+  switch (clean.toUpperCase()) {
+    case 'DEGREE': return '°';
+    case 'GRAD': case 'GON': return 'gon';
+    case 'MINUTE': return '′';
+    case 'SECOND': return '″';
+    case 'FOOT': case 'FEET': return 'ft';
+    case 'INCH': return 'in';
+    case 'YARD': return 'yd';
+    case 'MILE': return 'mi';
+    case 'LITRE': case 'LITER': return 'L';
+    case 'ACRE': return 'acre';
+    case 'POUND': case 'POUND-MASS': case 'LBM': return 'lb';
+    case 'POUND-FORCE': case 'LBF': return 'lbf';
+    case 'OUNCE': return 'oz';
+    case 'TON-METRIC': case 'TONNE': return 't';
+    case 'PSI': return 'psi';
+    case 'BAR': return 'bar';
+    case 'KIP': return 'kip';
+    case 'MINUTE-TIME': case 'MIN': return 'min';
+    case 'HOUR': return 'h';
+    case 'DAY': return 'd';
+    case 'BTU': return 'Btu';
+    case '': return '';
+    default: return clean;
+  }
+}
+
+const SUPERSCRIPT_DIGITS: Record<string, string> = {
+  '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+  '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+};
+
+function superscript(mag: number): string {
+  if (mag === 1) return '';
+  return String(mag).split('').map(c => SUPERSCRIPT_DIGITS[c] ?? c).join('');
+}
+
+/** Compose a derived-unit symbol from `(symbol, exponent)` pairs. */
+export function composeDerived(elements: Array<[string, number]>): string {
+  const num: string[] = [];
+  const den: string[] = [];
+  for (const [sym, exp] of elements) {
+    if (exp === 0 || sym.length === 0) continue;
+    const piece = `${sym}${superscript(Math.abs(exp))}`;
+    if (exp > 0) num.push(piece); else den.push(piece);
+  }
+  const midDot = '·';
+  const numerator = num.length === 0 ? '1' : num.join(midDot);
+  if (den.length === 0) return num.length === 0 ? '' : numerator;
+  const denominator = den.join(midDot);
+  return den.length > 1 ? `${numerator}/(${denominator})` : `${numerator}/${denominator}`;
+}
+
+export function currencySymbol(code: string): string {
+  const c = code.replace(/['.]/g, '').trim();
+  switch (c.toUpperCase()) {
+    case 'EUR': return '€';
+    case 'USD': return '$';
+    case 'GBP': return '£';
+    case 'JPY': case 'CNY': case 'RMB': return '¥';
+    case '': return '';
+    default: return c;
+  }
+}
+
+// ============================================================================
+// Measure → unit-type table (mirror project_units/measure.rs)
+// ============================================================================
+
+const MEASURE_TABLE: Record<string, MeasureUnit> = {
+  // Length family
+  LENGTHMEASURE: { kind: 'typed', unitType: 'LENGTHUNIT', defaultSymbol: 'm' },
+  POSITIVELENGTHMEASURE: { kind: 'typed', unitType: 'LENGTHUNIT', defaultSymbol: 'm' },
+  NONNEGATIVELENGTHMEASURE: { kind: 'typed', unitType: 'LENGTHUNIT', defaultSymbol: 'm' },
+  AREAMEASURE: { kind: 'typed', unitType: 'AREAUNIT', defaultSymbol: 'm²' },
+  VOLUMEMEASURE: { kind: 'typed', unitType: 'VOLUMEUNIT', defaultSymbol: 'm³' },
+  MASSMEASURE: { kind: 'typed', unitType: 'MASSUNIT', defaultSymbol: 'kg' },
+  TIMEMEASURE: { kind: 'typed', unitType: 'TIMEUNIT', defaultSymbol: 's' },
+  PLANEANGLEMEASURE: { kind: 'typed', unitType: 'PLANEANGLEUNIT', defaultSymbol: 'rad' },
+  POSITIVEPLANEANGLEMEASURE: { kind: 'typed', unitType: 'PLANEANGLEUNIT', defaultSymbol: 'rad' },
+  SOLIDANGLEMEASURE: { kind: 'typed', unitType: 'SOLIDANGLEUNIT', defaultSymbol: 'sr' },
+  THERMODYNAMICTEMPERATUREMEASURE: { kind: 'typed', unitType: 'THERMODYNAMICTEMPERATUREUNIT', defaultSymbol: 'K' },
+  // Named SI (special-name) units
+  ELECTRICCURRENTMEASURE: { kind: 'typed', unitType: 'ELECTRICCURRENTUNIT', defaultSymbol: 'A' },
+  ELECTRICVOLTAGEMEASURE: { kind: 'typed', unitType: 'ELECTRICVOLTAGEUNIT', defaultSymbol: 'V' },
+  ELECTRICRESISTANCEMEASURE: { kind: 'typed', unitType: 'ELECTRICRESISTANCEUNIT', defaultSymbol: 'Ω' },
+  ELECTRICCAPACITANCEMEASURE: { kind: 'typed', unitType: 'ELECTRICCAPACITANCEUNIT', defaultSymbol: 'F' },
+  ELECTRICCHARGEMEASURE: { kind: 'typed', unitType: 'ELECTRICCHARGEUNIT', defaultSymbol: 'C' },
+  ELECTRICCONDUCTANCEMEASURE: { kind: 'typed', unitType: 'ELECTRICCONDUCTANCEUNIT', defaultSymbol: 'S' },
+  POWERMEASURE: { kind: 'typed', unitType: 'POWERUNIT', defaultSymbol: 'W' },
+  ENERGYMEASURE: { kind: 'typed', unitType: 'ENERGYUNIT', defaultSymbol: 'J' },
+  FORCEMEASURE: { kind: 'typed', unitType: 'FORCEUNIT', defaultSymbol: 'N' },
+  PRESSUREMEASURE: { kind: 'typed', unitType: 'PRESSUREUNIT', defaultSymbol: 'Pa' },
+  FREQUENCYMEASURE: { kind: 'typed', unitType: 'FREQUENCYUNIT', defaultSymbol: 'Hz' },
+  INDUCTANCEMEASURE: { kind: 'typed', unitType: 'INDUCTANCEUNIT', defaultSymbol: 'H' },
+  ILLUMINANCEMEASURE: { kind: 'typed', unitType: 'ILLUMINANCEUNIT', defaultSymbol: 'lx' },
+  LUMINOUSFLUXMEASURE: { kind: 'typed', unitType: 'LUMINOUSFLUXUNIT', defaultSymbol: 'lm' },
+  LUMINOUSINTENSITYMEASURE: { kind: 'typed', unitType: 'LUMINOUSINTENSITYUNIT', defaultSymbol: 'cd' },
+  MAGNETICFLUXMEASURE: { kind: 'typed', unitType: 'MAGNETICFLUXUNIT', defaultSymbol: 'Wb' },
+  MAGNETICFLUXDENSITYMEASURE: { kind: 'typed', unitType: 'MAGNETICFLUXDENSITYUNIT', defaultSymbol: 'T' },
+  AMOUNTOFSUBSTANCEMEASURE: { kind: 'typed', unitType: 'AMOUNTOFSUBSTANCEUNIT', defaultSymbol: 'mol' },
+  ABSORBEDDOSEMEASURE: { kind: 'typed', unitType: 'ABSORBEDDOSEUNIT', defaultSymbol: 'Gy' },
+  DOSEEQUIVALENTMEASURE: { kind: 'typed', unitType: 'DOSEEQUIVALENTUNIT', defaultSymbol: 'Sv' },
+  RADIOACTIVITYMEASURE: { kind: 'typed', unitType: 'RADIOACTIVITYUNIT', defaultSymbol: 'Bq' },
+  // Derived units
+  VOLUMETRICFLOWRATEMEASURE: { kind: 'typed', unitType: 'VOLUMETRICFLOWRATEUNIT', defaultSymbol: 'm³/s' },
+  MASSFLOWRATEMEASURE: { kind: 'typed', unitType: 'MASSFLOWRATEUNIT', defaultSymbol: 'kg/s' },
+  MASSDENSITYMEASURE: { kind: 'typed', unitType: 'MASSDENSITYUNIT', defaultSymbol: 'kg/m³' },
+  MASSPERLENGTHMEASURE: { kind: 'typed', unitType: 'MASSPERLENGTHUNIT', defaultSymbol: 'kg/m' },
+  LINEARVELOCITYMEASURE: { kind: 'typed', unitType: 'LINEARVELOCITYUNIT', defaultSymbol: 'm/s' },
+  ACCELERATIONMEASURE: { kind: 'typed', unitType: 'ACCELERATIONUNIT', defaultSymbol: 'm/s²' },
+  ANGULARVELOCITYMEASURE: { kind: 'typed', unitType: 'ANGULARVELOCITYUNIT', defaultSymbol: 'rad/s' },
+  ROTATIONALFREQUENCYMEASURE: { kind: 'typed', unitType: 'ROTATIONALFREQUENCYUNIT', defaultSymbol: '1/s' },
+  TORQUEMEASURE: { kind: 'typed', unitType: 'TORQUEUNIT', defaultSymbol: 'N·m' },
+  LINEARFORCEMEASURE: { kind: 'typed', unitType: 'LINEARFORCEUNIT', defaultSymbol: 'N/m' },
+  PLANARFORCEMEASURE: { kind: 'typed', unitType: 'PLANARFORCEUNIT', defaultSymbol: 'N/m²' },
+  LINEARSTIFFNESSMEASURE: { kind: 'typed', unitType: 'LINEARSTIFFNESSUNIT', defaultSymbol: 'N/m' },
+  ROTATIONALSTIFFNESSMEASURE: { kind: 'typed', unitType: 'ROTATIONALSTIFFNESSUNIT', defaultSymbol: 'N·m/rad' },
+  MODULUSOFELASTICITYMEASURE: { kind: 'typed', unitType: 'MODULUSOFELASTICITYUNIT', defaultSymbol: 'Pa' },
+  SHEARMODULUSMEASURE: { kind: 'typed', unitType: 'SHEARMODULUSUNIT', defaultSymbol: 'Pa' },
+  THERMALTRANSMITTANCEMEASURE: { kind: 'typed', unitType: 'THERMALTRANSMITTANCEUNIT', defaultSymbol: 'W/(m²·K)' },
+  THERMALCONDUCTIVITYMEASURE: { kind: 'typed', unitType: 'THERMALCONDUCTANCEUNIT', defaultSymbol: 'W/(m·K)' },
+  THERMALRESISTANCEMEASURE: { kind: 'typed', unitType: 'THERMALRESISTANCEUNIT', defaultSymbol: 'm²·K/W' },
+  THERMALADMITTANCEMEASURE: { kind: 'typed', unitType: 'THERMALADMITTANCEUNIT', defaultSymbol: 'W/(m²·K)' },
+  THERMALEXPANSIONCOEFFICIENTMEASURE: { kind: 'typed', unitType: 'THERMALEXPANSIONCOEFFICIENTUNIT', defaultSymbol: '1/K' },
+  SPECIFICHEATCAPACITYMEASURE: { kind: 'typed', unitType: 'SPECIFICHEATCAPACITYUNIT', defaultSymbol: 'J/(kg·K)' },
+  HEATFLUXDENSITYMEASURE: { kind: 'typed', unitType: 'HEATFLUXDENSITYUNIT', defaultSymbol: 'W/m²' },
+  HEATINGVALUEMEASURE: { kind: 'typed', unitType: 'HEATINGVALUEUNIT', defaultSymbol: 'J/kg' },
+  DYNAMICVISCOSITYMEASURE: { kind: 'typed', unitType: 'DYNAMICVISCOSITYUNIT', defaultSymbol: 'Pa·s' },
+  KINEMATICVISCOSITYMEASURE: { kind: 'typed', unitType: 'KINEMATICVISCOSITYUNIT', defaultSymbol: 'm²/s' },
+  MOMENTOFINERTIAMEASURE: { kind: 'typed', unitType: 'MOMENTOFINERTIAUNIT', defaultSymbol: 'm⁴' },
+  SECTIONMODULUSMEASURE: { kind: 'typed', unitType: 'SECTIONMODULUSUNIT', defaultSymbol: 'm³' },
+  SECTIONALAREAINTEGRALMEASURE: { kind: 'typed', unitType: 'SECTIONAREAINTEGRALUNIT', defaultSymbol: 'm⁵' },
+  WARPINGCONSTANTMEASURE: { kind: 'typed', unitType: 'WARPINGCONSTANTUNIT', defaultSymbol: 'm⁶' },
+  WARPINGMOMENTMEASURE: { kind: 'typed', unitType: 'WARPINGMOMENTUNIT', defaultSymbol: 'N·m²' },
+  LINEARMOMENTMEASURE: { kind: 'typed', unitType: 'LINEARMOMENTUNIT', defaultSymbol: 'N·m/m' },
+  AREADENSITYMEASURE: { kind: 'typed', unitType: 'AREADENSITYUNIT', defaultSymbol: 'kg/m²' },
+  CURVATUREMEASURE: { kind: 'typed', unitType: 'CURVATUREUNIT', defaultSymbol: '1/m' },
+  MOLECULARWEIGHTMEASURE: { kind: 'typed', unitType: 'MOLECULARWEIGHTUNIT', defaultSymbol: 'kg/mol' },
+  IONCONCENTRATIONMEASURE: { kind: 'typed', unitType: 'IONCONCENTRATIONUNIT', defaultSymbol: 'kg/m³' },
+  MOISTUREDIFFUSIVITYMEASURE: { kind: 'typed', unitType: 'MOISTUREDIFFUSIVITYUNIT', defaultSymbol: 'm²/s' },
+  VAPORPERMEABILITYMEASURE: { kind: 'typed', unitType: 'VAPORPERMEABILITYUNIT', defaultSymbol: 'kg/(s·m·Pa)' },
+  ISOTHERMALMOISTURECAPACITYMEASURE: { kind: 'typed', unitType: 'ISOTHERMALMOISTURECAPACITYUNIT', defaultSymbol: 'm³/kg' },
+  TEMPERATUREGRADIENTMEASURE: { kind: 'typed', unitType: 'TEMPERATUREGRADIENTUNIT', defaultSymbol: 'K/m' },
+  TEMPERATURERATEOFCHANGEMEASURE: { kind: 'typed', unitType: 'TEMPERATURERATEOFCHANGEUNIT', defaultSymbol: 'K/s' },
+  SOUNDPOWERMEASURE: { kind: 'typed', unitType: 'SOUNDPOWERUNIT', defaultSymbol: 'W' },
+  SOUNDPOWERLEVELMEASURE: { kind: 'typed', unitType: 'SOUNDPOWERLEVELUNIT', defaultSymbol: 'dB' },
+  SOUNDPRESSUREMEASURE: { kind: 'typed', unitType: 'SOUNDPRESSUREUNIT', defaultSymbol: 'Pa' },
+  SOUNDPRESSURELEVELMEASURE: { kind: 'typed', unitType: 'SOUNDPRESSURELEVELUNIT', defaultSymbol: 'dB' },
+  MODULUSOFSUBGRADEREACTIONMEASURE: { kind: 'typed', unitType: 'MODULUSOFSUBGRADEREACTIONUNIT', defaultSymbol: 'N/m³' },
+  MODULUSOFLINEARSUBGRADEREACTIONMEASURE: { kind: 'typed', unitType: 'MODULUSOFLINEARSUBGRADEREACTIONUNIT', defaultSymbol: 'N/m²' },
+  MODULUSOFROTATIONALSUBGRADEREACTIONMEASURE: { kind: 'typed', unitType: 'MODULUSOFROTATIONALSUBGRADEREACTIONUNIT', defaultSymbol: 'N/rad' },
+  ROTATIONALMASSMEASURE: { kind: 'typed', unitType: 'ROTATIONALMASSUNIT', defaultSymbol: 'kg·m²' },
+  INTEGERCOUNTRATEMEASURE: { kind: 'typed', unitType: 'INTEGERCOUNTRATEUNIT', defaultSymbol: '1/s' },
+  LUMINOUSINTENSITYDISTRIBUTIONMEASURE: { kind: 'typed', unitType: 'LUMINOUSINTENSITYDISTRIBUTIONUNIT', defaultSymbol: 'cd/lm' },
+  // Monetary
+  MONETARYMEASURE: { kind: 'monetary' },
+  // Dimensionless / unit-less
+  RATIOMEASURE: { kind: 'dimensionless' },
+  NORMALISEDRATIOMEASURE: { kind: 'dimensionless' },
+  POSITIVERATIOMEASURE: { kind: 'dimensionless' },
+  COUNTMEASURE: { kind: 'dimensionless' },
+  NUMERICMEASURE: { kind: 'dimensionless' },
+  DESCRIPTIVEMEASURE: { kind: 'dimensionless' },
+  CONTEXTDEPENDENTMEASURE: { kind: 'dimensionless' },
+  PHMEASURE: { kind: 'dimensionless' },
+  CURVEMEASURE: { kind: 'dimensionless' },
+  COMPOUNDPLANEANGLEMEASURE: { kind: 'dimensionless' },
+  DERIVEDMEASURE: { kind: 'dimensionless' },
+  MEASURE: { kind: 'dimensionless' },
+};
+
+/** Resolve a measure value type name (case-insensitive, with or without the
+ *  leading `IFC`) to its unit mapping. `undefined` for non-measure value types. */
+export function measureUnit(measureType: string): MeasureUnit | undefined {
+  const up = measureType.trim().toUpperCase();
+  const key = up.startsWith('IFC') ? up.slice(3) : up;
+  return MEASURE_TABLE[key];
+}

--- a/packages/parser/src/project-units.ts
+++ b/packages/parser/src/project-units.ts
@@ -36,8 +36,11 @@ export type MeasureUnit =
   | { kind: 'monetary' }
   | { kind: 'dimensionless' };
 
-interface EntityIndexLike {
+interface EntityByIdIndexLike {
   byId: { get(expressId: number): EntityRef | undefined };
+}
+
+interface EntityIndexLike extends EntityByIdIndexLike {
   byType: Map<string, number[]>;
 }
 
@@ -358,7 +361,7 @@ interface UnitEntry {
  *  for per-property / per-quantity `Unit` overrides). */
 export function resolveUnitByRef(
   extractor: EntityExtractor,
-  entityIndex: EntityIndexLike,
+  entityIndex: EntityByIdIndexLike,
   ref: number,
 ): UnitEntry | null {
   const entRef = entityIndex.byId.get(ref);
@@ -421,7 +424,7 @@ export function resolveUnitByRef(
 
 function resolveDerivedElement(
   extractor: EntityExtractor,
-  entityIndex: EntityIndexLike,
+  entityIndex: EntityByIdIndexLike,
   elemRef: number,
 ): { symbol: string; unitScale: number; exponent: number } | null {
   const ref = entityIndex.byId.get(elemRef);
@@ -439,7 +442,7 @@ function resolveDerivedElement(
 
 function conversionFactorScale(
   extractor: EntityExtractor,
-  entityIndex: EntityIndexLike,
+  entityIndex: EntityByIdIndexLike,
   measureRef: number,
 ): number | null {
   const ref = entityIndex.byId.get(measureRef);

--- a/packages/parser/src/project-units.ts
+++ b/packages/parser/src/project-units.ts
@@ -21,6 +21,17 @@
 import type { EntityRef } from './types.js';
 import { EntityExtractor } from './entity-extractor.js';
 import type { IfcSourceBytes } from './source-bytes.js';
+import {
+  composeDerived,
+  conversionUnitSymbol,
+  currencySymbol,
+  measureUnit,
+  siUnitSymbolAndScale,
+  type MeasureUnit,
+} from './project-units-symbols.js';
+
+export type { MeasureUnit };
+export { measureUnit };
 
 /** A resolved display unit: the symbol to render plus the factor that converts a
  *  value in this unit to its canonical SI base (`mm` → `1e-3`, `m³/h` → `1/3600`,
@@ -30,283 +41,12 @@ export interface ResolvedUnit {
   siScale: number;
 }
 
-/** How a measure value type maps onto the file's declared units. */
-export type MeasureUnit =
-  | { kind: 'typed'; unitType: string; defaultSymbol: string }
-  | { kind: 'monetary' }
-  | { kind: 'dimensionless' };
-
 interface EntityByIdIndexLike {
   byId: { get(expressId: number): EntityRef | undefined };
 }
 
 interface EntityIndexLike extends EntityByIdIndexLike {
   byType: Map<string, number[]>;
-}
-
-// ============================================================================
-// SI prefix + unit-name symbol tables (mirror project_units/symbols.rs)
-// ============================================================================
-
-const SI_PREFIX_MULTIPLIERS: Record<string, number> = {
-  ATTO: 1e-18, FEMTO: 1e-15, PICO: 1e-12, NANO: 1e-9, MICRO: 1e-6, MILLI: 1e-3,
-  CENTI: 1e-2, DECI: 1e-1, DECA: 1e1, HECTO: 1e2, KILO: 1e3, MEGA: 1e6,
-  GIGA: 1e9, TERA: 1e12, PETA: 1e15, EXA: 1e18,
-};
-
-const SI_PREFIX_SYMBOLS: Record<string, string> = {
-  EXA: 'E', PETA: 'P', TERA: 'T', GIGA: 'G', MEGA: 'M', KILO: 'k', HECTO: 'h',
-  DECA: 'da', DECI: 'd', CENTI: 'c', MILLI: 'm', MICRO: 'µ', NANO: 'n',
-  PICO: 'p', FEMTO: 'f', ATTO: 'a',
-};
-
-interface SiName {
-  symbol: string;
-  prefixPower: number;
-  baseScale: number;
-}
-
-/** Resolve an `IfcSIUnitName` token to its symbol descriptor. */
-function siUnitName(name: string): SiName | undefined {
-  const n = name.replace(/\./g, '').trim().toUpperCase();
-  const d = (symbol: string): SiName => ({ symbol, prefixPower: 1, baseScale: 1.0 });
-  switch (n) {
-    case 'METRE': return d('m');
-    case 'SQUARE_METRE': return { symbol: 'm²', prefixPower: 2, baseScale: 1.0 };
-    case 'CUBIC_METRE': return { symbol: 'm³', prefixPower: 3, baseScale: 1.0 };
-    case 'GRAM': return { symbol: 'g', prefixPower: 1, baseScale: 1e-3 };
-    case 'SECOND': return d('s');
-    case 'AMPERE': return d('A');
-    case 'KELVIN': return d('K');
-    case 'MOLE': return d('mol');
-    case 'CANDELA': return d('cd');
-    case 'RADIAN': return d('rad');
-    case 'STERADIAN': return d('sr');
-    case 'HERTZ': return d('Hz');
-    case 'NEWTON': return d('N');
-    case 'PASCAL': return d('Pa');
-    case 'JOULE': return d('J');
-    case 'WATT': return d('W');
-    case 'COULOMB': return d('C');
-    case 'VOLT': return d('V');
-    case 'FARAD': return d('F');
-    case 'OHM': return d('Ω');
-    case 'SIEMENS': return d('S');
-    case 'WEBER': return d('Wb');
-    case 'TESLA': return d('T');
-    case 'HENRY': return d('H');
-    case 'DEGREE_CELSIUS': return d('°C');
-    case 'LUMEN': return d('lm');
-    case 'LUX': return d('lx');
-    case 'BECQUEREL': return d('Bq');
-    case 'GRAY': return d('Gy');
-    case 'SIEVERT': return d('Sv');
-    default: return undefined;
-  }
-}
-
-function prefixSymbol(prefix: string): string {
-  return SI_PREFIX_SYMBOLS[prefix.replace(/\./g, '').trim().toUpperCase()] ?? '';
-}
-
-function prefixMultiplier(prefix: string): number {
-  return SI_PREFIX_MULTIPLIERS[prefix.replace(/\./g, '').trim().toUpperCase()] ?? 1.0;
-}
-
-/** Symbol + SI scale for a prefixed `IfcSIUnit`. */
-function siUnitSymbolAndScale(name: string, prefix: string | null): { symbol: string; scale: number } | undefined {
-  const base = siUnitName(name);
-  if (!base) return undefined;
-  const cleanPrefix = prefix ? prefix.replace(/\./g, '').trim() : '';
-  const pSym = cleanPrefix ? prefixSymbol(cleanPrefix) : '';
-  const pMult = cleanPrefix ? prefixMultiplier(cleanPrefix) : 1.0;
-  return {
-    symbol: `${pSym}${base.symbol}`,
-    scale: base.baseScale * Math.pow(pMult, base.prefixPower),
-  };
-}
-
-/** Friendly symbol for a common `IfcConversionBasedUnit` name. */
-function conversionUnitSymbol(name: string): string {
-  const clean = name.replace(/'/g, '').trim();
-  switch (clean.toUpperCase()) {
-    case 'DEGREE': return '°';
-    case 'GRAD': case 'GON': return 'gon';
-    case 'MINUTE': return '′';
-    case 'SECOND': return '″';
-    case 'FOOT': case 'FEET': return 'ft';
-    case 'INCH': return 'in';
-    case 'YARD': return 'yd';
-    case 'MILE': return 'mi';
-    case 'LITRE': case 'LITER': return 'L';
-    case 'ACRE': return 'acre';
-    case 'POUND': case 'POUND-MASS': case 'LBM': return 'lb';
-    case 'POUND-FORCE': case 'LBF': return 'lbf';
-    case 'OUNCE': return 'oz';
-    case 'TON-METRIC': case 'TONNE': return 't';
-    case 'PSI': return 'psi';
-    case 'BAR': return 'bar';
-    case 'KIP': return 'kip';
-    case 'MINUTE-TIME': case 'MIN': return 'min';
-    case 'HOUR': return 'h';
-    case 'DAY': return 'd';
-    case 'BTU': return 'Btu';
-    case '': return '';
-    default: return clean;
-  }
-}
-
-const SUPERSCRIPT_DIGITS: Record<string, string> = {
-  '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
-  '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
-};
-
-function superscript(mag: number): string {
-  if (mag === 1) return '';
-  return String(mag).split('').map(c => SUPERSCRIPT_DIGITS[c] ?? c).join('');
-}
-
-/** Compose a derived-unit symbol from `(symbol, exponent)` pairs. */
-function composeDerived(elements: Array<[string, number]>): string {
-  const num: string[] = [];
-  const den: string[] = [];
-  for (const [sym, exp] of elements) {
-    if (exp === 0 || sym.length === 0) continue;
-    const piece = `${sym}${superscript(Math.abs(exp))}`;
-    if (exp > 0) num.push(piece); else den.push(piece);
-  }
-  const midDot = '·';
-  const numerator = num.length === 0 ? '1' : num.join(midDot);
-  if (den.length === 0) return num.length === 0 ? '' : numerator;
-  const denominator = den.join(midDot);
-  return den.length > 1 ? `${numerator}/(${denominator})` : `${numerator}/${denominator}`;
-}
-
-function currencySymbol(code: string): string {
-  const c = code.replace(/['.]/g, '').trim();
-  switch (c.toUpperCase()) {
-    case 'EUR': return '€';
-    case 'USD': return '$';
-    case 'GBP': return '£';
-    case 'JPY': case 'CNY': case 'RMB': return '¥';
-    case '': return '';
-    default: return c;
-  }
-}
-
-// ============================================================================
-// Measure → unit-type table (mirror project_units/measure.rs)
-// ============================================================================
-
-const MEASURE_TABLE: Record<string, MeasureUnit> = {
-  // Length family
-  LENGTHMEASURE: { kind: 'typed', unitType: 'LENGTHUNIT', defaultSymbol: 'm' },
-  POSITIVELENGTHMEASURE: { kind: 'typed', unitType: 'LENGTHUNIT', defaultSymbol: 'm' },
-  NONNEGATIVELENGTHMEASURE: { kind: 'typed', unitType: 'LENGTHUNIT', defaultSymbol: 'm' },
-  AREAMEASURE: { kind: 'typed', unitType: 'AREAUNIT', defaultSymbol: 'm²' },
-  VOLUMEMEASURE: { kind: 'typed', unitType: 'VOLUMEUNIT', defaultSymbol: 'm³' },
-  MASSMEASURE: { kind: 'typed', unitType: 'MASSUNIT', defaultSymbol: 'kg' },
-  TIMEMEASURE: { kind: 'typed', unitType: 'TIMEUNIT', defaultSymbol: 's' },
-  PLANEANGLEMEASURE: { kind: 'typed', unitType: 'PLANEANGLEUNIT', defaultSymbol: 'rad' },
-  POSITIVEPLANEANGLEMEASURE: { kind: 'typed', unitType: 'PLANEANGLEUNIT', defaultSymbol: 'rad' },
-  SOLIDANGLEMEASURE: { kind: 'typed', unitType: 'SOLIDANGLEUNIT', defaultSymbol: 'sr' },
-  THERMODYNAMICTEMPERATUREMEASURE: { kind: 'typed', unitType: 'THERMODYNAMICTEMPERATUREUNIT', defaultSymbol: 'K' },
-  // Named SI (special-name) units
-  ELECTRICCURRENTMEASURE: { kind: 'typed', unitType: 'ELECTRICCURRENTUNIT', defaultSymbol: 'A' },
-  ELECTRICVOLTAGEMEASURE: { kind: 'typed', unitType: 'ELECTRICVOLTAGEUNIT', defaultSymbol: 'V' },
-  ELECTRICRESISTANCEMEASURE: { kind: 'typed', unitType: 'ELECTRICRESISTANCEUNIT', defaultSymbol: 'Ω' },
-  ELECTRICCAPACITANCEMEASURE: { kind: 'typed', unitType: 'ELECTRICCAPACITANCEUNIT', defaultSymbol: 'F' },
-  ELECTRICCHARGEMEASURE: { kind: 'typed', unitType: 'ELECTRICCHARGEUNIT', defaultSymbol: 'C' },
-  ELECTRICCONDUCTANCEMEASURE: { kind: 'typed', unitType: 'ELECTRICCONDUCTANCEUNIT', defaultSymbol: 'S' },
-  POWERMEASURE: { kind: 'typed', unitType: 'POWERUNIT', defaultSymbol: 'W' },
-  ENERGYMEASURE: { kind: 'typed', unitType: 'ENERGYUNIT', defaultSymbol: 'J' },
-  FORCEMEASURE: { kind: 'typed', unitType: 'FORCEUNIT', defaultSymbol: 'N' },
-  PRESSUREMEASURE: { kind: 'typed', unitType: 'PRESSUREUNIT', defaultSymbol: 'Pa' },
-  FREQUENCYMEASURE: { kind: 'typed', unitType: 'FREQUENCYUNIT', defaultSymbol: 'Hz' },
-  INDUCTANCEMEASURE: { kind: 'typed', unitType: 'INDUCTANCEUNIT', defaultSymbol: 'H' },
-  ILLUMINANCEMEASURE: { kind: 'typed', unitType: 'ILLUMINANCEUNIT', defaultSymbol: 'lx' },
-  LUMINOUSFLUXMEASURE: { kind: 'typed', unitType: 'LUMINOUSFLUXUNIT', defaultSymbol: 'lm' },
-  LUMINOUSINTENSITYMEASURE: { kind: 'typed', unitType: 'LUMINOUSINTENSITYUNIT', defaultSymbol: 'cd' },
-  MAGNETICFLUXMEASURE: { kind: 'typed', unitType: 'MAGNETICFLUXUNIT', defaultSymbol: 'Wb' },
-  MAGNETICFLUXDENSITYMEASURE: { kind: 'typed', unitType: 'MAGNETICFLUXDENSITYUNIT', defaultSymbol: 'T' },
-  AMOUNTOFSUBSTANCEMEASURE: { kind: 'typed', unitType: 'AMOUNTOFSUBSTANCEUNIT', defaultSymbol: 'mol' },
-  ABSORBEDDOSEMEASURE: { kind: 'typed', unitType: 'ABSORBEDDOSEUNIT', defaultSymbol: 'Gy' },
-  DOSEEQUIVALENTMEASURE: { kind: 'typed', unitType: 'DOSEEQUIVALENTUNIT', defaultSymbol: 'Sv' },
-  RADIOACTIVITYMEASURE: { kind: 'typed', unitType: 'RADIOACTIVITYUNIT', defaultSymbol: 'Bq' },
-  // Derived units
-  VOLUMETRICFLOWRATEMEASURE: { kind: 'typed', unitType: 'VOLUMETRICFLOWRATEUNIT', defaultSymbol: 'm³/s' },
-  MASSFLOWRATEMEASURE: { kind: 'typed', unitType: 'MASSFLOWRATEUNIT', defaultSymbol: 'kg/s' },
-  MASSDENSITYMEASURE: { kind: 'typed', unitType: 'MASSDENSITYUNIT', defaultSymbol: 'kg/m³' },
-  MASSPERLENGTHMEASURE: { kind: 'typed', unitType: 'MASSPERLENGTHUNIT', defaultSymbol: 'kg/m' },
-  LINEARVELOCITYMEASURE: { kind: 'typed', unitType: 'LINEARVELOCITYUNIT', defaultSymbol: 'm/s' },
-  ACCELERATIONMEASURE: { kind: 'typed', unitType: 'ACCELERATIONUNIT', defaultSymbol: 'm/s²' },
-  ANGULARVELOCITYMEASURE: { kind: 'typed', unitType: 'ANGULARVELOCITYUNIT', defaultSymbol: 'rad/s' },
-  ROTATIONALFREQUENCYMEASURE: { kind: 'typed', unitType: 'ROTATIONALFREQUENCYUNIT', defaultSymbol: '1/s' },
-  TORQUEMEASURE: { kind: 'typed', unitType: 'TORQUEUNIT', defaultSymbol: 'N·m' },
-  LINEARFORCEMEASURE: { kind: 'typed', unitType: 'LINEARFORCEUNIT', defaultSymbol: 'N/m' },
-  PLANARFORCEMEASURE: { kind: 'typed', unitType: 'PLANARFORCEUNIT', defaultSymbol: 'N/m²' },
-  LINEARSTIFFNESSMEASURE: { kind: 'typed', unitType: 'LINEARSTIFFNESSUNIT', defaultSymbol: 'N/m' },
-  ROTATIONALSTIFFNESSMEASURE: { kind: 'typed', unitType: 'ROTATIONALSTIFFNESSUNIT', defaultSymbol: 'N·m/rad' },
-  MODULUSOFELASTICITYMEASURE: { kind: 'typed', unitType: 'MODULUSOFELASTICITYUNIT', defaultSymbol: 'Pa' },
-  SHEARMODULUSMEASURE: { kind: 'typed', unitType: 'SHEARMODULUSUNIT', defaultSymbol: 'Pa' },
-  THERMALTRANSMITTANCEMEASURE: { kind: 'typed', unitType: 'THERMALTRANSMITTANCEUNIT', defaultSymbol: 'W/(m²·K)' },
-  THERMALCONDUCTIVITYMEASURE: { kind: 'typed', unitType: 'THERMALCONDUCTANCEUNIT', defaultSymbol: 'W/(m·K)' },
-  THERMALRESISTANCEMEASURE: { kind: 'typed', unitType: 'THERMALRESISTANCEUNIT', defaultSymbol: 'm²·K/W' },
-  THERMALADMITTANCEMEASURE: { kind: 'typed', unitType: 'THERMALADMITTANCEUNIT', defaultSymbol: 'W/(m²·K)' },
-  THERMALEXPANSIONCOEFFICIENTMEASURE: { kind: 'typed', unitType: 'THERMALEXPANSIONCOEFFICIENTUNIT', defaultSymbol: '1/K' },
-  SPECIFICHEATCAPACITYMEASURE: { kind: 'typed', unitType: 'SPECIFICHEATCAPACITYUNIT', defaultSymbol: 'J/(kg·K)' },
-  HEATFLUXDENSITYMEASURE: { kind: 'typed', unitType: 'HEATFLUXDENSITYUNIT', defaultSymbol: 'W/m²' },
-  HEATINGVALUEMEASURE: { kind: 'typed', unitType: 'HEATINGVALUEUNIT', defaultSymbol: 'J/kg' },
-  DYNAMICVISCOSITYMEASURE: { kind: 'typed', unitType: 'DYNAMICVISCOSITYUNIT', defaultSymbol: 'Pa·s' },
-  KINEMATICVISCOSITYMEASURE: { kind: 'typed', unitType: 'KINEMATICVISCOSITYUNIT', defaultSymbol: 'm²/s' },
-  MOMENTOFINERTIAMEASURE: { kind: 'typed', unitType: 'MOMENTOFINERTIAUNIT', defaultSymbol: 'm⁴' },
-  SECTIONMODULUSMEASURE: { kind: 'typed', unitType: 'SECTIONMODULUSUNIT', defaultSymbol: 'm³' },
-  SECTIONALAREAINTEGRALMEASURE: { kind: 'typed', unitType: 'SECTIONAREAINTEGRALUNIT', defaultSymbol: 'm⁵' },
-  WARPINGCONSTANTMEASURE: { kind: 'typed', unitType: 'WARPINGCONSTANTUNIT', defaultSymbol: 'm⁶' },
-  WARPINGMOMENTMEASURE: { kind: 'typed', unitType: 'WARPINGMOMENTUNIT', defaultSymbol: 'N·m²' },
-  LINEARMOMENTMEASURE: { kind: 'typed', unitType: 'LINEARMOMENTUNIT', defaultSymbol: 'N·m/m' },
-  AREADENSITYMEASURE: { kind: 'typed', unitType: 'AREADENSITYUNIT', defaultSymbol: 'kg/m²' },
-  CURVATUREMEASURE: { kind: 'typed', unitType: 'CURVATUREUNIT', defaultSymbol: '1/m' },
-  MOLECULARWEIGHTMEASURE: { kind: 'typed', unitType: 'MOLECULARWEIGHTUNIT', defaultSymbol: 'kg/mol' },
-  IONCONCENTRATIONMEASURE: { kind: 'typed', unitType: 'IONCONCENTRATIONUNIT', defaultSymbol: 'kg/m³' },
-  MOISTUREDIFFUSIVITYMEASURE: { kind: 'typed', unitType: 'MOISTUREDIFFUSIVITYUNIT', defaultSymbol: 'm²/s' },
-  VAPORPERMEABILITYMEASURE: { kind: 'typed', unitType: 'VAPORPERMEABILITYUNIT', defaultSymbol: 'kg/(s·m·Pa)' },
-  ISOTHERMALMOISTURECAPACITYMEASURE: { kind: 'typed', unitType: 'ISOTHERMALMOISTURECAPACITYUNIT', defaultSymbol: 'm³/kg' },
-  TEMPERATUREGRADIENTMEASURE: { kind: 'typed', unitType: 'TEMPERATUREGRADIENTUNIT', defaultSymbol: 'K/m' },
-  TEMPERATURERATEOFCHANGEMEASURE: { kind: 'typed', unitType: 'TEMPERATURERATEOFCHANGEUNIT', defaultSymbol: 'K/s' },
-  SOUNDPOWERMEASURE: { kind: 'typed', unitType: 'SOUNDPOWERUNIT', defaultSymbol: 'W' },
-  SOUNDPOWERLEVELMEASURE: { kind: 'typed', unitType: 'SOUNDPOWERLEVELUNIT', defaultSymbol: 'dB' },
-  SOUNDPRESSUREMEASURE: { kind: 'typed', unitType: 'SOUNDPRESSUREUNIT', defaultSymbol: 'Pa' },
-  SOUNDPRESSURELEVELMEASURE: { kind: 'typed', unitType: 'SOUNDPRESSURELEVELUNIT', defaultSymbol: 'dB' },
-  MODULUSOFSUBGRADEREACTIONMEASURE: { kind: 'typed', unitType: 'MODULUSOFSUBGRADEREACTIONUNIT', defaultSymbol: 'N/m³' },
-  MODULUSOFLINEARSUBGRADEREACTIONMEASURE: { kind: 'typed', unitType: 'MODULUSOFLINEARSUBGRADEREACTIONUNIT', defaultSymbol: 'N/m²' },
-  MODULUSOFROTATIONALSUBGRADEREACTIONMEASURE: { kind: 'typed', unitType: 'MODULUSOFROTATIONALSUBGRADEREACTIONUNIT', defaultSymbol: 'N/rad' },
-  ROTATIONALMASSMEASURE: { kind: 'typed', unitType: 'ROTATIONALMASSUNIT', defaultSymbol: 'kg·m²' },
-  INTEGERCOUNTRATEMEASURE: { kind: 'typed', unitType: 'INTEGERCOUNTRATEUNIT', defaultSymbol: '1/s' },
-  LUMINOUSINTENSITYDISTRIBUTIONMEASURE: { kind: 'typed', unitType: 'LUMINOUSINTENSITYDISTRIBUTIONUNIT', defaultSymbol: 'cd/lm' },
-  // Monetary
-  MONETARYMEASURE: { kind: 'monetary' },
-  // Dimensionless / unit-less
-  RATIOMEASURE: { kind: 'dimensionless' },
-  NORMALISEDRATIOMEASURE: { kind: 'dimensionless' },
-  POSITIVERATIOMEASURE: { kind: 'dimensionless' },
-  COUNTMEASURE: { kind: 'dimensionless' },
-  NUMERICMEASURE: { kind: 'dimensionless' },
-  DESCRIPTIVEMEASURE: { kind: 'dimensionless' },
-  CONTEXTDEPENDENTMEASURE: { kind: 'dimensionless' },
-  PHMEASURE: { kind: 'dimensionless' },
-  CURVEMEASURE: { kind: 'dimensionless' },
-  COMPOUNDPLANEANGLEMEASURE: { kind: 'dimensionless' },
-  DERIVEDMEASURE: { kind: 'dimensionless' },
-  MEASURE: { kind: 'dimensionless' },
-};
-
-/** Resolve a measure value type name (case-insensitive, with or without the
- *  leading `IFC`) to its unit mapping. `undefined` for non-measure value types. */
-export function measureUnit(measureType: string): MeasureUnit | undefined {
-  const up = measureType.trim().toUpperCase();
-  const key = up.startsWith('IFC') ? up.slice(3) : up;
-  return MEASURE_TABLE[key];
 }
 
 // ============================================================================

--- a/packages/parser/src/quantity-collect.ts
+++ b/packages/parser/src/quantity-collect.ts
@@ -16,13 +16,16 @@ import type { EntityRef } from './types.js';
 import type { EntityExtractor } from './entity-extractor.js';
 import { QUANTITY_TYPE_MAP } from './columnar-parser-indexes.js';
 import { isUnrepresentableNumericValue } from './attribute-helpers.js';
-import type { ProjectUnits } from './project-units.js';
+import { resolveUnitByRef, type ProjectUnits } from './project-units.js';
 
 /** One extracted quantity, in the shape both call sites report. */
 export interface CollectedQuantity {
     name: string;
     type: number;
     value: number;
+    /** SI factor of this quantity's explicit `Unit`, when it declares one.
+     *  An omitted unit inherits the project's unit assignment. */
+    explicitUnitSiScale?: number;
 }
 
 /**
@@ -125,6 +128,14 @@ export function collectQuantitiesFromRefs(
         if (!qtyName) continue;
 
         const qtyType = QUANTITY_TYPE_MAP[qtyTypeUpper] ?? QuantityType.Count;
+        // `IfcPhysicalSimpleQuantity.Unit` is optional, but it overrides the
+        // project assignment when present. Preserve its scale on the record so
+        // every downstream reader of this shared collection uses the same
+        // physical value rather than silently treating (say) 2000 mm as 2000 m.
+        const unitRef = qtyAttrs[2];
+        const unit = typeof unitRef === 'number'
+            ? resolveUnitByRef(extractor, store.entityIndex, unitRef)
+            : null;
         const rawValue = qtyAttrs[SIMPLE_QUANTITY_VALUE_SLOT];
 
         // A measure the double range cannot hold is dropped with a diagnostic,
@@ -162,7 +173,12 @@ export function collectQuantitiesFromRefs(
 
         const value = typeof rawValue === 'number' ? rawValue : 0;
 
-        quantities.push({ name: qtyName, type: qtyType, value });
+        quantities.push({
+            name: qtyName,
+            type: qtyType,
+            value,
+            ...(unit ? { explicitUnitSiScale: unit.resolved.siScale } : {}),
+        });
     }
 
     return quantities;
@@ -234,8 +250,8 @@ export function readQuantitySet(
 }
 
 /**
- * SI scale factor for a `Qto_` value of the given {@link QuantityType},
- * resolved against the project's declared units.
+ * SI scale factor for a `Qto_` value, preferring its explicit `Unit` and then
+ * resolving against the project's declared units.
  *
  * An `IfcQuantityLength`/`Area`/`Volume` is stored in the project's raw
  * author unit exactly like an `IfcPropertySingleValue` of the matching
@@ -254,10 +270,14 @@ export function readQuantitySet(
  * FALLBACK: `IFC` lets a project declare an explicit `AREAUNIT`/`VOLUMEUNIT`
  * with no arithmetic relationship to `LENGTHUNIT`, so the file's own
  * declaration is preferred and the length-derived power is used only when
- * the project declares none.
+ * the project declares none. An explicit member `Unit` always wins; IFC uses
+ * it specifically to let a quantity depart from its containing project's
+ * assignment.
  */
-export function quantitySiScale(quantityType: number, units: ProjectUnits): number {
-    switch (quantityType) {
+export function quantitySiScale(quantity: CollectedQuantity, units: ProjectUnits): number {
+    if (quantity.explicitUnitSiScale !== undefined) return quantity.explicitUnitSiScale;
+
+    switch (quantity.type) {
         case QuantityType.Length:
             return units.unitForMeasure('IfcLengthMeasure')?.siScale ?? 1;
         case QuantityType.Area: {

--- a/packages/parser/src/quantity-collect.ts
+++ b/packages/parser/src/quantity-collect.ts
@@ -16,6 +16,7 @@ import type { EntityRef } from './types.js';
 import type { EntityExtractor } from './entity-extractor.js';
 import { QUANTITY_TYPE_MAP } from './columnar-parser-indexes.js';
 import { isUnrepresentableNumericValue } from './attribute-helpers.js';
+import type { ProjectUnits } from './project-units.js';
 
 /** One extracted quantity, in the shape both call sites report. */
 export interface CollectedQuantity {
@@ -230,4 +231,48 @@ export function readQuantitySet(
 
     if (quantities.length === 0) return null;
     return { name: qsetName, quantities };
+}
+
+/**
+ * SI scale factor for a `Qto_` value of the given {@link QuantityType},
+ * resolved against the project's declared units.
+ *
+ * An `IfcQuantityLength`/`Area`/`Volume` is stored in the project's raw
+ * author unit exactly like an `IfcPropertySingleValue` of the matching
+ * measure type — the value is not pre-converted to SI by the exporter. A
+ * consumer that hashes or otherwise compares `CollectedQuantity.value`
+ * across two files (or against a base-SI literal) as-is therefore reads a
+ * project's choice of length unit as a change in the design itself: the
+ * same 2 m wall authored in millimetres carries the raw value `2000`
+ * instead of `2`.
+ *
+ * `1` for `Count`/`Weight`/`Time`/`Number` — this only scales the three
+ * quantity types that are themselves `IfcLengthMeasure`-family measures.
+ *
+ * Area and Volume scale by the SQUARE and CUBE of the length factor (a
+ * millimetre-authored 1 m² is stored as `1e6`, not `1e3`) — but only as a
+ * FALLBACK: `IFC` lets a project declare an explicit `AREAUNIT`/`VOLUMEUNIT`
+ * with no arithmetic relationship to `LENGTHUNIT`, so the file's own
+ * declaration is preferred and the length-derived power is used only when
+ * the project declares none.
+ */
+export function quantitySiScale(quantityType: number, units: ProjectUnits): number {
+    switch (quantityType) {
+        case QuantityType.Length:
+            return units.unitForMeasure('IfcLengthMeasure')?.siScale ?? 1;
+        case QuantityType.Area: {
+            const explicit = units.resolvedForUnitType('AREAUNIT')?.siScale;
+            if (explicit !== undefined) return explicit;
+            const length = units.unitForMeasure('IfcLengthMeasure')?.siScale ?? 1;
+            return length ** 2;
+        }
+        case QuantityType.Volume: {
+            const explicit = units.resolvedForUnitType('VOLUMEUNIT')?.siScale;
+            if (explicit !== undefined) return explicit;
+            const length = units.unitForMeasure('IfcLengthMeasure')?.siScale ?? 1;
+            return length ** 3;
+        }
+        default:
+            return 1;
+    }
 }

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3696,6 +3696,7 @@
     "parsePath: function",
     "parseSourceHeader: function",
     "parseStepValue: function",
+    "quantitySiScale: function",
     "ref: function",
     "resolveAllMaterialDefIds: function",
     "resolveEntityNameAlias: function",


### PR DESCRIPTION
## Summary

`packages/diff` is a differ against a known-edit oracle: take a fixture, apply one known edit, and the diff must report exactly that edit. Running the oracle case "change a quantity's unit but not its magnitude" (a Qto_ length quantity re-authored in millimetres instead of metres, same physical length) against the real engine turned up a real defect, present identically in all three fingerprint adapters.

An `IfcElementQuantity` (`Qto_*`) `Length`/`Area`/`Volume` value is stored in the project's raw author unit — exactly like a length-typed `IfcPropertySingleValue`. IDS's property bridge already converts a property to base SI before comparing it (`#3458` did the same for its own quantity gap), but none of `@ifc-lite/diff`'s three adapters did the equivalent for `Qto_` quantities before hashing them into `dataHash`. A wall re-exported from a metre-authored file (`IfcQuantityLength` `2`) into a millimetre-authored one (`2000`), with no edit to the design at all, hashed to two different values and classified as `modified · data` — on every quantified entity in the model, in the CLI (`ifc-lite diff`), the viewer's compare panel, and the MCP `model_diff` tool alike.

Fix: `quantitySiScale(quantityType, units)`, a new small export in `@ifc-lite/parser` resolved against the file's declared `ProjectUnits` (mirroring the fallback rule already used by the IDS bridge — prefer an explicit `AREAUNIT`/`VOLUMEUNIT`, else derive from the length scale). Each of the three adapters now scales a Qto_ value through it before rounding and hashing:

- `packages/cli/src/commands/diff-engine.ts` (`ifc-lite diff`)
- `apps/viewer/src/lib/compare/buildFingerprints.ts` (viewer compare panel)
- `packages/mcp/src/tools/diff-fingerprints.ts` (`model_diff`, both the stored-entity and the overlay-created path)

`diff-fingerprints.ts` is a documented byte-for-byte twin of the CLI's adapter, checked by `packages/mcp`'s own parity suite (`diff-fingerprints.test.ts`) — fixing one copy and not the other would have failed that suite (or, worse, silently diverged if the suite hadn't caught it), so both were fixed together and a `qty-mm` fixture was added to the parity table to keep that guard live for this shape.

## Oracle table

| Case | Expected | Actual on `main` | Actual after fix |
|---|---|---|---|
| Qto_ length re-authored in a different project length unit (2 m ↔ 2000 mm), same physical length | `unchanged` | `modified · data` (RED) | `unchanged` (GREEN) |
| Control: genuine quantity edit within one unit (2 m → 3 m) | `modified · data` | `modified · data` | `modified · data` (unaffected — control) |
| Genuine edit riding along with a unit change (2 m → 3000 mm) | `modified` | `modified` | `modified` (unaffected — the real difference still surfaces) |
| CLI ↔ MCP fingerprint parity on the `qty-mm` fixture | byte-identical `dataHash`/`components` | already agreed (both unscaled) | still agree (both scaled) |

## Test plan

- [x] New oracle suite `packages/cli/src/commands/diff-oracle.test.ts` (RED confirmed against unmodified `main`, GREEN after the fix; includes the two controls above)
- [x] `packages/mcp/src/tools/diff-fingerprints.test.ts`'s CLI-parity suite extended with a `qty-mm` fixture (shared with the CLI suite via `diff-test-helpers.ts`)
- [x] `pnpm --filter @ifc-lite/parser --filter @ifc-lite/cli --filter @ifc-lite/mcp --filter @ifc-lite/diff exec vitest run` — all green (no regressions)
- [x] `apps/viewer/src/lib/compare/buildFingerprints.test.ts` (node:test runner) — all 46 green
- [x] `pnpm exec tsc --noEmit` on `parser`, `cli`, `mcp`, `viewer` — clean
- [x] `node scripts/check-module-size.mjs` — clean (files trimmed back under their existing budgets, none raised)
- [x] `node scripts/check-test-wiring.mjs` — clean
- [x] `node scripts/check-unused-locals.mjs` — no new findings in touched packages
- [x] `node scripts/check-api-surface.mjs --update` — one new export (`quantitySiScale`), snapshot updated
- [x] Changesets: `@ifc-lite/parser` (minor, new export), `@ifc-lite/cli` (patch), `@ifc-lite/mcp` (patch). `apps/viewer` is private — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model comparisons by normalizing quantity measurements to SI units.
  * Prevented unchanged elements from being incorrectly reported as modified when models use different project length units.
  * Applied consistent handling to length, area, and volume quantities, including explicit quantity units.
  * Updated CLI, viewer comparison, and model-diff results for consistent unit-aware comparisons.
* **Tests**
  * Added coverage for unit changes, genuine quantity edits, and explicit unit overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->