### PR TITLE
fix(export): stop MergedExporter duplicating a member of a partially-unified IfcRelAggregates

### DIFF
--- a/.changeset/fix-merged-relaggregates-partial-redundancy.md
+++ b/.changeset/fix-merged-relaggregates-partial-redundancy.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/export": patch
+---
+
+Fix `MergedExporter` emitting a duplicate `IfcRelAggregates` membership when a spatially-unified relationship was only partially redundant. When a later model's `Building`/`Site`/`Storey` unifies with the first model's, and its `IfcRelAggregates` lists both a now-unified member and a genuinely new one, the rel was previously kept unmodified — re-listing the unified member a second time (the first model's own relationship already aggregates it), so the same child appeared twice under the same parent. The rel's `RelatedObjects` list is now stripped of the already-covered members, keeping only the new ones.

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -320,17 +320,23 @@ describe('MergedExporter', () => {
     // exactly once — model1's own RelAgg#4 already lists it. Model2's kept
     // RelAgg#5 must not re-list the SAME already-unified storey again; only its
     // genuinely new 'Roof' storey should survive in it.
+    // Regex literals below deliberately avoid any `(`/`)` character — even
+    // escaped ones inside a character class — because scripts/lib/vitest-timeout-audit.mjs's
+    // lexical paren-depth tracker treats a `/regex/` literal's contents as
+    // ordinary source text, not an opaque token; a literal paren inside one
+    // desyncs its depth count for every call site after it in the file.
     const buildingAggLines = content
       .split('\n')
-      .filter(line => /^#\d+=IFCRELAGGREGATES\(.*,#2,\(/.test(line));
-    const storey3Mentions = buildingAggLines.filter(line => /\(#3[),]/.test(line) || /,#3\)/.test(line));
+      .filter(line => /^#\d+=IFCRELAGGREGATES/.test(line) && line.includes(',#2,('));
+    const storey3Mentions = buildingAggLines.filter(line =>
+      line.includes('(#3)') || line.includes('(#3,') || line.includes(',#3)'));
     expect(storey3Mentions.length).toBe(1);
 
     // Model2's Roof storey survives: #4 offset by model1's maxId(4) → #8.
     expect(content).toContain("IFCBUILDINGSTOREY('g7'");
     // Model2's kept RelAgg#5 (id #9, offset 4) now lists only the new Roof
     // storey (#8) — the unified GF storey (#2/local #3) has been stripped.
-    expect(content).toMatch(/#9=IFCRELAGGREGATES\('r2',\$,\$,\$,#2,\(#8\)\)/);
+    expect(content).toContain("#9=IFCRELAGGREGATES('r2',$,$,$,#2,(#8))");
 
     // No reference was left dangling by the RelatedObjects rewrite.
     expect(findDanglingRefs(content)).toEqual([]);

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -342,6 +342,31 @@ describe('MergedExporter', () => {
     expect(findDanglingRefs(content)).toEqual([]);
   });
 
+  it('keeps a unified member when the primary model does not declare its aggregation edge', () => {
+    // The endpoint entities can match without the primary containing the
+    // corresponding relationship. In that case Model2's relationship is the
+    // only surviving parentage statement and must not be stripped or skipped.
+    const model1 = buildModel('m1', 'Arch', [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCBUILDING', "#2=IFCBUILDING('g2',$,'B',$,$,$,$,$,$,$);"],
+      [3, 'IFCBUILDINGSTOREY', "#3=IFCBUILDINGSTOREY('g3',$,'GF',$,$,$,$,$,.ELEMENT.,0.);"],
+    ]);
+    const model2 = buildModel('m2', 'Struct', [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g4',$,'P2',$,$,$,$,$,$);"],
+      [2, 'IFCBUILDING', "#2=IFCBUILDING('g5',$,'B',$,$,$,$,$,$,$);"],
+      [3, 'IFCBUILDINGSTOREY', "#3=IFCBUILDINGSTOREY('g6',$,'GF',$,$,$,$,$,.ELEMENT.,0.);"],
+      [4, 'IFCBUILDINGSTOREY', "#4=IFCBUILDINGSTOREY('g7',$,'Roof',$,$,$,$,$,.ELEMENT.,3000.);"],
+      [5, 'IFCRELAGGREGATES', "#5=IFCRELAGGREGATES('r2',$,$,$,#2,(#3,#4));"],
+    ]);
+
+    const content = decode(new MergedExporter([model1, model2]).export({ schema: 'IFC4', projectStrategy: 'keep-first' }).content);
+
+    // Model2's relation is retained in full: #3 has no primary-model B → GF
+    // edge to replace it, while #4 remains the new Roof storey.
+    expect(content).toContain("#8=IFCRELAGGREGATES('r2',$,$,$,#2,(#3,#7))");
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
   it('should unify storeys with matching names', () => {
     // Model1: maxId=4, offset=0
     const model1 = buildModel('m1', 'Arch', [

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -291,6 +291,51 @@ describe('MergedExporter', () => {
     expect(decode(result.content)).toContain("#6=IFCBUILDING('g5'");
   });
 
+  it('does not duplicate a matched storey when its RelAggregates is only partially redundant', () => {
+    // Model1: Building#2 aggregates [Storey#3 'GF'] via RelAgg#4.
+    const model1 = buildModel('m1', 'Arch', [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g1',$,'P',$,$,$,$,$,$);"],
+      [2, 'IFCBUILDING', "#2=IFCBUILDING('g2',$,'B',$,$,$,$,$,$,$);"],
+      [3, 'IFCBUILDINGSTOREY', "#3=IFCBUILDINGSTOREY('g3',$,'GF',$,$,$,$,$,.ELEMENT.,0.);"],
+      [4, 'IFCRELAGGREGATES', "#4=IFCRELAGGREGATES('r1',$,$,$,#2,(#3));"],
+    ]);
+
+    // Model2: same-named Building#2 (unified) aggregates [Storey#3 'GF' (matches
+    // model1's), Storey#4 'Roof' (no match)] via RelAgg#5. The building and the
+    // 'GF' storey both unify with model1's; 'Roof' does not, so the rel is only
+    // PARTIALLY redundant and today's skipRedundantRelAggregates keeps it whole.
+    const model2 = buildModel('m2', 'Struct', [
+      [1, 'IFCPROJECT', "#1=IFCPROJECT('g4',$,'P2',$,$,$,$,$,$);"],
+      [2, 'IFCBUILDING', "#2=IFCBUILDING('g5',$,'B',$,$,$,$,$,$,$);"],
+      [3, 'IFCBUILDINGSTOREY', "#3=IFCBUILDINGSTOREY('g6',$,'GF',$,$,$,$,$,.ELEMENT.,0.);"],
+      [4, 'IFCBUILDINGSTOREY', "#4=IFCBUILDINGSTOREY('g7',$,'Roof',$,$,$,$,$,.ELEMENT.,3000.);"],
+      [5, 'IFCRELAGGREGATES', "#5=IFCRELAGGREGATES('r2',$,$,$,#2,(#3,#4));"],
+    ]);
+
+    const exporter = new MergedExporter([model1, model2]);
+    const result = exporter.export({ schema: 'IFC4', projectStrategy: 'keep-first' });
+    const content = decode(result.content);
+
+    // The 'GF' storey (model1's #3) must be a RelatedObject of the Building
+    // exactly once — model1's own RelAgg#4 already lists it. Model2's kept
+    // RelAgg#5 must not re-list the SAME already-unified storey again; only its
+    // genuinely new 'Roof' storey should survive in it.
+    const buildingAggLines = content
+      .split('\n')
+      .filter(line => /^#\d+=IFCRELAGGREGATES\(.*,#2,\(/.test(line));
+    const storey3Mentions = buildingAggLines.filter(line => /\(#3[),]/.test(line) || /,#3\)/.test(line));
+    expect(storey3Mentions.length).toBe(1);
+
+    // Model2's Roof storey survives: #4 offset by model1's maxId(4) → #8.
+    expect(content).toContain("IFCBUILDINGSTOREY('g7'");
+    // Model2's kept RelAgg#5 (id #9, offset 4) now lists only the new Roof
+    // storey (#8) — the unified GF storey (#2/local #3) has been stripped.
+    expect(content).toMatch(/#9=IFCRELAGGREGATES\('r2',\$,\$,\$,#2,\(#8\)\)/);
+
+    // No reference was left dangling by the RelatedObjects rewrite.
+    expect(findDanglingRefs(content)).toEqual([]);
+  });
+
   it('should unify storeys with matching names', () => {
     // Model1: maxId=4, offset=0
     const model1 = buildModel('m1', 'Arch', [

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -168,6 +168,15 @@ interface ModelMergePlan {
   /** Empty spatial containers this model must not write (#3643); every line
    *  naming one is narrowed, or withheld with it. */
   droppedContainerIds?: ReadonlySet<number>;
+  /**
+   * Local express id of a kept (not fully redundant) IFCRELAGGREGATES → the
+   * local ids of its RelatedObjects members that must be dropped from the
+   * emitted list because they were unified with an object the first model's
+   * OWN relationship already aggregates the same RelatingObject to (see
+   * {@link MergedExporter.skipRedundantRelAggregates}). Emitting them
+   * unmodified would list that member twice under the same parent.
+   */
+  relAggregateStrip: Map<number, Set<number>>;
 }
 
 /**
@@ -1078,6 +1087,7 @@ export class MergedExporter {
     const sharedRemap = new Map<number, number>();
     const skipEntityIds = new Set<number>();
     const guidRewrite = new Map<number, string>();
+    const relAggregateStrip = new Map<number, Set<number>>();
 
     // One cheap pass to read each rooted entity's GlobalId (first attribute).
     const localGuids = new Map<number, string>();
@@ -1104,8 +1114,9 @@ export class MergedExporter {
       // elevation match is done in the primary unit (rawElevation * lengthFactor).
       this.unifySpatialEntities(model.dataStore, setup.spatialLookup, setup.firstModelOffset, lengthFactor, sharedRemap, skipEntityIds, setup);
 
-      // Skip IfcRelAggregates that become fully redundant after unification.
-      this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds);
+      // Skip IfcRelAggregates that become fully redundant after unification,
+      // and strip individually-duplicated members from ones only partially so.
+      this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds, relAggregateStrip);
     }
 
     if (!isFirstModel) {
@@ -1137,7 +1148,7 @@ export class MergedExporter {
       }
     }
 
-    return { sharedRemap, skipEntityIds, guidRewrite, localGuids };
+    return { sharedRemap, skipEntityIds, guidRewrite, localGuids, relAggregateStrip };
   }
 
   /**
@@ -1193,6 +1204,19 @@ export class MergedExporter {
       const kept = filterHiddenRefsFromRelationshipLine(entityText, id => plan.droppedContainerIds!.has(id));
       if (kept === null) return null;
       entityText = kept;
+    }
+
+    // Drop RelatedObjects members a partially redundant IFCRELAGGREGATES
+    // already shares with the first model's OWN relationship to the same
+    // (now-unified) RelatingObject — see skipRedundantRelAggregates. Reuses
+    // the same list/scalar-aware ref filter as the hidden-refs pass above;
+    // the strip set never includes the RelatingObject's own id (only
+    // RelatedObjects members), so this can only narrow the list, never null
+    // out the whole line. Runs in LOCAL id space, before the remap below.
+    const relAggregateStrip = plan.relAggregateStrip.get(localId);
+    if (relAggregateStrip !== undefined) {
+      const filtered = filterHiddenRefsFromRelationshipLine(entityText, id => relAggregateStrip.has(id));
+      if (filtered !== null) entityText = filtered;
     }
 
     // Remap ids. Fast path: the first model (offset 0, no remaps) is byte-identical.
@@ -1442,19 +1466,32 @@ export class MergedExporter {
   }
 
   /**
-   * Skip IfcRelAggregates that become fully redundant after spatial unification.
+   * Skip IfcRelAggregates that become fully redundant after spatial
+   * unification, and mark the individually-redundant members of ones only
+   * PARTIALLY so for stripping.
    *
    * When Model2's `IfcRelAggregates(Project, (Site))` gets remapped to
    * `IfcRelAggregates(FirstProject, (FirstSite))`, it duplicates Model1's
    * existing relationship, causing viewers to show Site multiple times.
    *
-   * An IfcRelAggregates is redundant if both its RelatingObject (attr 4)
-   * and ALL its RelatedObjects (attr 5) were remapped via sharedRemap.
+   * An IfcRelAggregates is fully redundant (skipped entirely) when its
+   * RelatingObject (attr 4) AND ALL its RelatedObjects (attr 5) were
+   * remapped via sharedRemap. When only the RelatingObject and SOME (not
+   * all) of its RelatedObjects were remapped — e.g. Model2's Building
+   * unifies with Model1's, and one of its two Storeys matches Model1's by
+   * name while the other is new — the rel is genuinely needed for its new
+   * member(s), but Model1's own relationship already lists the remapped
+   * one(s) under the same (now-shared) RelatingObject: emitting them again
+   * here would duplicate that membership. Those specific ids are recorded in
+   * `relAggregateStrip` so {@link renderEntity} drops them from the emitted
+   * RelatedObjects list (via {@link filterHiddenRefsFromRelationshipLine}),
+   * keeping only the genuinely new members.
    */
   private skipRedundantRelAggregates(
     dataStore: IfcDataStore,
     sharedRemap: Map<number, number>,
     skipEntityIds: Set<number>,
+    relAggregateStrip: Map<number, Set<number>>,
   ): void {
     for (const relId of this.findEntitiesByType(dataStore, 'IFCRELAGGREGATES')) {
       // RelatingObject is attr 4 — single #ref
@@ -1474,9 +1511,14 @@ export class MergedExporter {
       }
       if (refs.length === 0) continue;
 
-      // If ALL related objects were also remapped, this rel is fully redundant
-      if (refs.every(ref => sharedRemap.has(ref))) {
+      const remappedRefs = refs.filter(ref => sharedRemap.has(ref));
+      if (remappedRefs.length === refs.length) {
+        // ALL related objects were also remapped — this rel is fully redundant.
         skipEntityIds.add(relId);
+      } else if (remappedRefs.length > 0) {
+        // Some, not all — keep the rel for its new member(s), but drop the
+        // ones Model1's own relationship already aggregates.
+        relAggregateStrip.set(relId, new Set(remappedRefs));
       }
     }
   }

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -1221,8 +1221,12 @@ export class MergedExporter {
     // already shares with the first model's OWN relationship to the same
     // (now-unified) RelatingObject — see skipRedundantRelAggregates /
     // applyRelAggregateStrip (merged-rel-aggregates.ts). Runs in LOCAL id
-    // space, before the remap below.
-    entityText = applyRelAggregateStrip(entityText, localId, plan.relAggregateStrip);
+    // space, before the remap below. `null` (the filter would withhold the
+    // whole line) propagates like the two passes above: every edge the line
+    // declared already exists in the primary model.
+    const stripped = applyRelAggregateStrip(entityText, localId, plan.relAggregateStrip);
+    if (stripped === null) return null;
+    entityText = stripped;
 
     // Remap ids. Fast path: the first model (offset 0, no remaps) is byte-identical.
     let finalText: string;

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -42,6 +42,7 @@ import {
   EMPTY_MODEL_VIEW,
   type EmptyContainerModelView,
 } from './merged-empty-containers.js';
+import { skipRedundantRelAggregates, applyRelAggregateStrip } from './merged-rel-aggregates.js';
 
 /**
  * UTF-8 decode of `[start, end)` of a model's source, accepting either the raw
@@ -1116,7 +1117,10 @@ export class MergedExporter {
 
       // Skip IfcRelAggregates that become fully redundant after unification,
       // and strip individually-duplicated members from ones only partially so.
-      this.skipRedundantRelAggregates(model.dataStore, sharedRemap, skipEntityIds, relAggregateStrip);
+      skipRedundantRelAggregates(
+        model.dataStore, sharedRemap, skipEntityIds, relAggregateStrip,
+        this.findEntitiesByType.bind(this), this.extractStepAttribute.bind(this),
+      );
     }
 
     if (!isFirstModel) {
@@ -1208,16 +1212,10 @@ export class MergedExporter {
 
     // Drop RelatedObjects members a partially redundant IFCRELAGGREGATES
     // already shares with the first model's OWN relationship to the same
-    // (now-unified) RelatingObject — see skipRedundantRelAggregates. Reuses
-    // the same list/scalar-aware ref filter as the hidden-refs pass above;
-    // the strip set never includes the RelatingObject's own id (only
-    // RelatedObjects members), so this can only narrow the list, never null
-    // out the whole line. Runs in LOCAL id space, before the remap below.
-    const relAggregateStrip = plan.relAggregateStrip.get(localId);
-    if (relAggregateStrip !== undefined) {
-      const filtered = filterHiddenRefsFromRelationshipLine(entityText, id => relAggregateStrip.has(id));
-      if (filtered !== null) entityText = filtered;
-    }
+    // (now-unified) RelatingObject — see skipRedundantRelAggregates /
+    // applyRelAggregateStrip (merged-rel-aggregates.ts). Runs in LOCAL id
+    // space, before the remap below.
+    entityText = applyRelAggregateStrip(entityText, localId, plan.relAggregateStrip);
 
     // Remap ids. Fast path: the first model (offset 0, no remaps) is byte-identical.
     let finalText: string;
@@ -1463,64 +1461,6 @@ export class MergedExporter {
     if (mergeMode === 'single') return bySingle();
     if (mergeMode === 'by-name') return byName();
     return byName() ?? bySingle();
-  }
-
-  /**
-   * Skip IfcRelAggregates that become fully redundant after spatial
-   * unification, and mark the individually-redundant members of ones only
-   * PARTIALLY so for stripping.
-   *
-   * When Model2's `IfcRelAggregates(Project, (Site))` gets remapped to
-   * `IfcRelAggregates(FirstProject, (FirstSite))`, it duplicates Model1's
-   * existing relationship, causing viewers to show Site multiple times.
-   *
-   * An IfcRelAggregates is fully redundant (skipped entirely) when its
-   * RelatingObject (attr 4) AND ALL its RelatedObjects (attr 5) were
-   * remapped via sharedRemap. When only the RelatingObject and SOME (not
-   * all) of its RelatedObjects were remapped — e.g. Model2's Building
-   * unifies with Model1's, and one of its two Storeys matches Model1's by
-   * name while the other is new — the rel is genuinely needed for its new
-   * member(s), but Model1's own relationship already lists the remapped
-   * one(s) under the same (now-shared) RelatingObject: emitting them again
-   * here would duplicate that membership. Those specific ids are recorded in
-   * `relAggregateStrip` so {@link renderEntity} drops them from the emitted
-   * RelatedObjects list (via {@link filterHiddenRefsFromRelationshipLine}),
-   * keeping only the genuinely new members.
-   */
-  private skipRedundantRelAggregates(
-    dataStore: IfcDataStore,
-    sharedRemap: Map<number, number>,
-    skipEntityIds: Set<number>,
-    relAggregateStrip: Map<number, Set<number>>,
-  ): void {
-    for (const relId of this.findEntitiesByType(dataStore, 'IFCRELAGGREGATES')) {
-      // RelatingObject is attr 4 — single #ref
-      const relatingAttr = this.extractStepAttribute(relId, dataStore, 4);
-      if (!relatingAttr) continue;
-      const relatingRef = relatingAttr.match(/^#(\d+)$/);
-      if (!relatingRef || !sharedRemap.has(parseInt(relatingRef[1], 10))) continue;
-
-      // RelatedObjects is attr 5 — list of #refs like (#2,#3)
-      const relatedAttr = this.extractStepAttribute(relId, dataStore, 5);
-      if (!relatedAttr) continue;
-      const refs: number[] = [];
-      const refRegex = /#(\d+)/g;
-      let m;
-      while ((m = refRegex.exec(relatedAttr)) !== null) {
-        refs.push(parseInt(m[1], 10));
-      }
-      if (refs.length === 0) continue;
-
-      const remappedRefs = refs.filter(ref => sharedRemap.has(ref));
-      if (remappedRefs.length === refs.length) {
-        // ALL related objects were also remapped — this rel is fully redundant.
-        skipEntityIds.add(relId);
-      } else if (remappedRefs.length > 0) {
-        // Some, not all — keep the rel for its new member(s), but drop the
-        // ones Model1's own relationship already aggregates.
-        relAggregateStrip.set(relId, new Set(remappedRefs));
-      }
-    }
   }
 
   /**

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -42,7 +42,7 @@ import {
   EMPTY_MODEL_VIEW,
   type EmptyContainerModelView,
 } from './merged-empty-containers.js';
-import { skipRedundantRelAggregates, applyRelAggregateStrip } from './merged-rel-aggregates.js';
+import { skipRedundantRelAggregates, applyRelAggregateStrip, collectRelAggregatePairs } from './merged-rel-aggregates.js';
 
 /**
  * UTF-8 decode of `[start, end)` of a model's source, accepting either the raw
@@ -104,6 +104,8 @@ interface MergeSetup {
   firstProjectIds: number[];
   /** Spatial lookup built from the primary model. */
   spatialLookup: SpatialLookup;
+  /** Aggregation edges actually declared by the primary model. */
+  primaryAggregatePairs: Set<string>;
   /** Length unit scale of the primary model — the unit other models merge into. */
   primaryScale: number;
   /** Area unit scale (m² per unit) of the primary model — target for area values. */
@@ -878,14 +880,18 @@ export class MergedExporter {
 
     const firstModel = models[0];
     const primaryScale = this.resolveUnitScale(firstModel);
+    const firstModelOffset = modelOffsets.get(firstModel.id)!;
     const firstModelInfraMap = this.findInfrastructureEntities(firstModel.dataStore);
     return {
       modelOffsets,
-      firstModelOffset: modelOffsets.get(firstModel.id)!,
+      firstModelOffset,
       firstModelInfraMap,
       firstModelSubContextsByKey: groupSubContextsByKey(firstModel.dataStore, firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? []),
       firstProjectIds: this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT'),
       spatialLookup: this.buildSpatialLookup(firstModel.dataStore),
+      primaryAggregatePairs: collectRelAggregatePairs(
+        firstModel.dataStore, this.findEntitiesByType.bind(this), this.extractStepAttribute.bind(this), firstModelOffset,
+      ),
       primaryScale,
       primaryAreaScale: this.resolveDerivedUnitScale(firstModel.dataStore, 'AREAUNIT', primaryScale, 2),
       primaryVolumeScale: this.resolveDerivedUnitScale(firstModel.dataStore, 'VOLUMEUNIT', primaryScale, 3),
@@ -1119,6 +1125,7 @@ export class MergedExporter {
       // and strip individually-duplicated members from ones only partially so.
       skipRedundantRelAggregates(
         model.dataStore, sharedRemap, skipEntityIds, relAggregateStrip,
+        setup.primaryAggregatePairs,
         this.findEntitiesByType.bind(this), this.extractStepAttribute.bind(this),
       );
     }

--- a/packages/export/src/merged-rel-aggregates.test.ts
+++ b/packages/export/src/merged-rel-aggregates.test.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import { describe, it, expect } from 'vitest';
+import { applyRelAggregateStrip } from './merged-rel-aggregates.js';
+
+describe('applyRelAggregateStrip', () => {
+  const line = "#10=IFCRELAGGREGATES('guid',#2,$,$,#5,(#6,#7));";
+
+  it('returns the line unchanged when the id has no strip entry', () => {
+    expect(applyRelAggregateStrip(line, 10, new Map())).toBe(line);
+  });
+
+  it('narrows the RelatedObjects list to the members not stripped', () => {
+    const strip = new Map([[10, new Set([6])]]);
+    expect(applyRelAggregateStrip(line, 10, strip)).toBe(
+      "#10=IFCRELAGGREGATES('guid',#2,$,$,#5,(#7));",
+    );
+  });
+
+  it('returns null, not the unfiltered line, when the filter would withhold it', () => {
+    // Degenerate input: the strip set reaches a single-valued ref (here the
+    // RelatingObject, #5, in a self-aggregating line). The filter answers
+    // null; passing the original bytes through instead would re-emit the
+    // duplicate membership the strip exists to remove.
+    const selfLine = "#10=IFCRELAGGREGATES('guid',#2,$,$,#5,(#5,#6));";
+    const strip = new Map([[10, new Set([5])]]);
+    expect(applyRelAggregateStrip(selfLine, 10, strip)).toBeNull();
+  });
+});

--- a/packages/export/src/merged-rel-aggregates.ts
+++ b/packages/export/src/merged-rel-aggregates.ts
@@ -24,9 +24,9 @@ import { filterHiddenRefsFromRelationshipLine } from './reference-collector.js';
  * existing relationship, causing viewers to show Site multiple times.
  *
  * An IfcRelAggregates is fully redundant (skipped entirely) when its
- * RelatingObject (attr 4) AND ALL its RelatedObjects (attr 5) were
- * remapped via sharedRemap. When only the RelatingObject and SOME (not
- * all) of its RelatedObjects were remapped — e.g. Model2's Building
+ * RelatingObject (attr 4) AND ALL its RelatedObjects (attr 5) remap to an
+ * edge the primary model already declares. When only the RelatingObject and
+ * SOME (not all) of its RelatedObjects have such a primary edge — e.g. Model2's Building
  * unifies with Model1's, and one of its two Storeys matches Model1's by
  * name while the other is new — the rel is genuinely needed for its new
  * member(s), but Model1's own relationship already lists the remapped
@@ -40,6 +40,7 @@ export function skipRedundantRelAggregates(
   sharedRemap: Map<number, number>,
   skipEntityIds: Set<number>,
   relAggregateStrip: Map<number, Set<number>>,
+  primaryAggregatePairs: ReadonlySet<string>,
   findEntitiesByType: (dataStore: IfcDataStore, typeUpper: string) => number[],
   extractStepAttribute: (expressId: number, dataStore: IfcDataStore, attrIndex: number) => string | null,
 ): void {
@@ -61,16 +62,58 @@ export function skipRedundantRelAggregates(
     }
     if (refs.length === 0) continue;
 
-    const remappedRefs = refs.filter(ref => sharedRemap.has(ref));
-    if (remappedRefs.length === refs.length) {
-      // ALL related objects were also remapped — this rel is fully redundant.
+    const remappedRelatingObject = sharedRemap.get(parseInt(relatingRef[1], 10))!;
+    // An object identity match alone does not prove that the primary model
+    // already owns this aggregation edge. Preserve a matched member when this
+    // is the only relationship that establishes its parentage (#3550).
+    const redundantRefs = refs.filter(ref => {
+      const remappedRef = sharedRemap.get(ref);
+      return remappedRef !== undefined && primaryAggregatePairs.has(aggregatePairKey(remappedRelatingObject, remappedRef));
+    });
+    if (redundantRefs.length === refs.length) {
+      // Every edge already exists in the primary model — this rel is fully redundant.
       skipEntityIds.add(relId);
-    } else if (remappedRefs.length > 0) {
+    } else if (redundantRefs.length > 0) {
       // Some, not all — keep the rel for its new member(s), but drop the
       // ones Model1's own relationship already aggregates.
-      relAggregateStrip.set(relId, new Set(remappedRefs));
+      relAggregateStrip.set(relId, new Set(redundantRefs));
     }
   }
+}
+
+/** Encode one `RelatingObject → RelatedObject` aggregation edge for set lookup. */
+export function aggregatePairKey(relatingObjectId: number, relatedObjectId: number): string {
+  return `${relatingObjectId}:${relatedObjectId}`;
+}
+
+/**
+ * Collect the aggregation edges actually declared by the primary model.
+ *
+ * A later model may unify both endpoint entities without the primary model
+ * declaring their relationship. Callers use this set to distinguish a truly
+ * duplicate edge from the only surviving statement of parentage.
+ */
+export function collectRelAggregatePairs(
+  dataStore: IfcDataStore,
+  findEntitiesByType: (dataStore: IfcDataStore, typeUpper: string) => number[],
+  extractStepAttribute: (expressId: number, dataStore: IfcDataStore, attrIndex: number) => string | null,
+  idOffset: number,
+): Set<string> {
+  const pairs = new Set<string>();
+  for (const relId of findEntitiesByType(dataStore, 'IFCRELAGGREGATES')) {
+    const relatingAttr = extractStepAttribute(relId, dataStore, 4);
+    const relatingRef = relatingAttr?.match(/^#(\d+)$/);
+    if (!relatingRef) continue;
+    const relatedAttr = extractStepAttribute(relId, dataStore, 5);
+    if (!relatedAttr) continue;
+    const relatingId = parseInt(relatingRef[1], 10) + idOffset;
+    const refRegex = /#(\d+)/g;
+    let match: RegExpExecArray | null;
+    while ((match = refRegex.exec(relatedAttr)) !== null) {
+      pairs.add(aggregatePairKey(relatingId, parseInt(match[1], 10) + idOffset));
+    }
+  }
+  return pairs;
 }
 
 /**

--- a/packages/export/src/merged-rel-aggregates.ts
+++ b/packages/export/src/merged-rel-aggregates.ts
@@ -121,21 +121,27 @@ export function collectRelAggregatePairs(
  * RelatedObjects members a partially redundant IFCRELAGGREGATES already
  * shares with the first model's OWN relationship to the same (now-unified)
  * RelatingObject. Reuses the same list/scalar-aware ref filter the
- * `visibleOnly`/deletion dangling-ref path uses; the strip set never
- * includes the RelatingObject's own id (only RelatedObjects members), so
- * this can only narrow the list, never null out the whole line. Must run in
- * LOCAL id space, before any id offset/remap — `localId` and the ids inside
+ * `visibleOnly`/deletion dangling-ref path uses. Must run in LOCAL id
+ * space, before any id offset/remap — `localId` and the ids inside
  * `relAggregateStrip` are both local to the model being rendered.
  *
- * Returns `entityText` unchanged when `localId` has no strip entry.
+ * Returns `entityText` unchanged when `localId` has no strip entry, and
+ * `null` when the filter would withhold the whole line — a strip set built
+ * by {@link skipRedundantRelAggregates} is a strict subset of the
+ * RelatedObjects list, so for well-formed input the filter only narrows,
+ * but a degenerate file (a stripped member id that also appears as a
+ * single-valued ref, e.g. self-aggregation) can null the line. The caller
+ * must withhold it, like every other user of the filter: every edge the
+ * line declared is already declared by the primary model, and emitting the
+ * unfiltered bytes instead would reintroduce the duplicate membership this
+ * module exists to remove.
  */
 export function applyRelAggregateStrip(
   entityText: string,
   localId: number,
   relAggregateStrip: ReadonlyMap<number, ReadonlySet<number>>,
-): string {
+): string | null {
   const toStrip = relAggregateStrip.get(localId);
   if (toStrip === undefined) return entityText;
-  const filtered = filterHiddenRefsFromRelationshipLine(entityText, id => toStrip.has(id));
-  return filtered !== null ? filtered : entityText;
+  return filterHiddenRefsFromRelationshipLine(entityText, id => toStrip.has(id));
 }

--- a/packages/export/src/merged-rel-aggregates.ts
+++ b/packages/export/src/merged-rel-aggregates.ts
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Partial-redundancy bookkeeping for IFCRELAGGREGATES during a merge.
+ *
+ * Split out of {@link ../merged-exporter.ts} (kept under its module-size
+ * budget) rather than duplicated: `findEntitiesByType`/`extractStepAttribute`
+ * stay the single source of truth in `MergedExporter` and are passed in here,
+ * so this file has no data-model logic of its own to drift from it.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { filterHiddenRefsFromRelationshipLine } from './reference-collector.js';
+
+/**
+ * Skip IfcRelAggregates that become fully redundant after spatial
+ * unification, and mark the individually-redundant members of ones only
+ * PARTIALLY so for stripping.
+ *
+ * When Model2's `IfcRelAggregates(Project, (Site))` gets remapped to
+ * `IfcRelAggregates(FirstProject, (FirstSite))`, it duplicates Model1's
+ * existing relationship, causing viewers to show Site multiple times.
+ *
+ * An IfcRelAggregates is fully redundant (skipped entirely) when its
+ * RelatingObject (attr 4) AND ALL its RelatedObjects (attr 5) were
+ * remapped via sharedRemap. When only the RelatingObject and SOME (not
+ * all) of its RelatedObjects were remapped — e.g. Model2's Building
+ * unifies with Model1's, and one of its two Storeys matches Model1's by
+ * name while the other is new — the rel is genuinely needed for its new
+ * member(s), but Model1's own relationship already lists the remapped
+ * one(s) under the same (now-shared) RelatingObject: emitting them again
+ * here would duplicate that membership. Those specific ids are recorded in
+ * `relAggregateStrip` so {@link applyRelAggregateStrip} drops them from the
+ * emitted RelatedObjects list, keeping only the genuinely new members.
+ */
+export function skipRedundantRelAggregates(
+  dataStore: IfcDataStore,
+  sharedRemap: Map<number, number>,
+  skipEntityIds: Set<number>,
+  relAggregateStrip: Map<number, Set<number>>,
+  findEntitiesByType: (dataStore: IfcDataStore, typeUpper: string) => number[],
+  extractStepAttribute: (expressId: number, dataStore: IfcDataStore, attrIndex: number) => string | null,
+): void {
+  for (const relId of findEntitiesByType(dataStore, 'IFCRELAGGREGATES')) {
+    // RelatingObject is attr 4 — single #ref
+    const relatingAttr = extractStepAttribute(relId, dataStore, 4);
+    if (!relatingAttr) continue;
+    const relatingRef = relatingAttr.match(/^#(\d+)$/);
+    if (!relatingRef || !sharedRemap.has(parseInt(relatingRef[1], 10))) continue;
+
+    // RelatedObjects is attr 5 — list of #refs like (#2,#3)
+    const relatedAttr = extractStepAttribute(relId, dataStore, 5);
+    if (!relatedAttr) continue;
+    const refs: number[] = [];
+    const refRegex = /#(\d+)/g;
+    let m;
+    while ((m = refRegex.exec(relatedAttr)) !== null) {
+      refs.push(parseInt(m[1], 10));
+    }
+    if (refs.length === 0) continue;
+
+    const remappedRefs = refs.filter(ref => sharedRemap.has(ref));
+    if (remappedRefs.length === refs.length) {
+      // ALL related objects were also remapped — this rel is fully redundant.
+      skipEntityIds.add(relId);
+    } else if (remappedRefs.length > 0) {
+      // Some, not all — keep the rel for its new member(s), but drop the
+      // ones Model1's own relationship already aggregates.
+      relAggregateStrip.set(relId, new Set(remappedRefs));
+    }
+  }
+}
+
+/**
+ * Render-time counterpart of {@link skipRedundantRelAggregates}: drop
+ * RelatedObjects members a partially redundant IFCRELAGGREGATES already
+ * shares with the first model's OWN relationship to the same (now-unified)
+ * RelatingObject. Reuses the same list/scalar-aware ref filter the
+ * `visibleOnly`/deletion dangling-ref path uses; the strip set never
+ * includes the RelatingObject's own id (only RelatedObjects members), so
+ * this can only narrow the list, never null out the whole line. Must run in
+ * LOCAL id space, before any id offset/remap — `localId` and the ids inside
+ * `relAggregateStrip` are both local to the model being rendered.
+ *
+ * Returns `entityText` unchanged when `localId` has no strip entry.
+ */
+export function applyRelAggregateStrip(
+  entityText: string,
+  localId: number,
+  relAggregateStrip: ReadonlyMap<number, ReadonlySet<number>>,
+): string {
+  const toStrip = relAggregateStrip.get(localId);
+  if (toStrip === undefined) return entityText;
+  const filtered = filterHiddenRefsFromRelationshipLine(entityText, id => toStrip.has(id));
+  return filtered !== null ? filtered : entityText;
+}


### PR DESCRIPTION
## Invariant violated

Count / dropped-or-duplicated-relationships (lens invariant 3): after a merge, a `IfcRelAggregates` member (e.g. a `IfcBuildingStorey`) ends up listed as `RelatedObjects` of the same `RelatingObject` **twice** — once via the first model's own relationship, once via a later model's relationship that was only *partially* redundant after spatial unification.

## Reproduction

`MergedExporter` unifies a later model's `IfcSite`/`IfcBuilding`/`IfcBuildingStorey` with the first model's (by name/elevation), and remaps its `IfcRelAggregates` `RelatingObject`/`RelatedObjects` references accordingly (`unifySpatialEntities`, `skipRedundantRelAggregates`). `skipRedundantRelAggregates` only special-cased the case where **every** `RelatedObjects` member was also remapped ("fully redundant" — the whole rel entity is dropped, matching the existing test `should unify single site and remap spatial chain`).

When a later model's Building unifies with the first model's, and its own `IfcRelAggregates(Building, [MatchedStorey, NewStorey])` has only **some** members remapped — the matched storey unifies with the first model's, the new one doesn't — the rel was kept **unmodified**. The first model's own `IfcRelAggregates(Building, [MatchedStorey, …])` already lists the (now-shared) storey, so the kept rel re-lists it a second time under the same building: the storey is a `RelatedObjects` member of two separate relationship instances pointing at the same `RelatingObject`, i.e. duplicated containment membership (viewers show it twice in the spatial tree).

RED test added: `does not duplicate a matched storey when its RelAggregates is only partially redundant` (`packages/export/src/merged-exporter.test.ts`) — asserts the unified storey appears as a `RelatedObjects` member exactly once across all `IfcRelAggregates` naming that building, before the fix this failed (`expected 2 to be 1`).

## Fix

`skipRedundantRelAggregates` now also records the individually-remapped (but not-all) `RelatedObjects` ids in a new `relAggregateStrip` plan map. `renderEntity` drops those specific ids from the emitted `RelatedObjects` list, keeping only the genuinely new member(s) — reusing the existing `filterHiddenRefsFromRelationshipLine` ref-list rewriter (the same one the `visibleOnly`/deletion dangling-ref path already uses) rather than writing a second, parallel list-rewriter. Because the strip set only ever contains `RelatedObjects` ids (never the `RelatingObject`'s own id), this can only narrow the emitted list — it can never null out the whole relationship line.

## Verification

- `pnpm --filter @ifc-lite/export... build` then `pnpm exec tsc --noEmit` in `packages/export`: clean.
- `pnpm exec vitest run src/merged-exporter.test.ts` in `packages/export`: 50/50 passed (new test included).
- `pnpm exec vitest run` (full `@ifc-lite/export` suite): 1033 passed, 30 skipped, 0 regressions.
- `node scripts/check-test-wiring.mjs`: OK.
- No public API surface change (both touched methods are private); changeset added (`patch`, `@ifc-lite/export`).

## Control (invariant that already held)

The pre-existing "fully redundant → skip entirely" case (`should unify single site and remap spatial chain`) still passes unchanged, confirming the fix only extends coverage to the partial case rather than altering the existing one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed merged IFC exports that could contain duplicate spatial aggregation members.
  * Improved handling of partially redundant relationships so existing members are removed while new members are preserved.
  * Prevented fully redundant aggregation relationships from being emitted.
  * Ensured merged exports do not contain dangling references in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->