### PR TITLE
fix(export): stop MergedExporter unifying a differing-WCS representation context

### DIFF
--- a/.changeset/merged-exporter-context-wcs-alignment.md
+++ b/.changeset/merged-exporter-context-wcs-alignment.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': patch
+---
+
+`MergedExporter` no longer unifies a model's `IfcGeometricRepresentationContext` onto the primary model's when the two disagree on `WorldCoordinateSystem`. The context is the root anchor of every placement in it; dropping a model's own context in favour of the primary's silently re-interpreted every one of that model's untouched coordinates against the wrong origin, a wrong-place error equal to the WCS delta. A model whose context WCS matches the primary's (including the common case of both at the identity origin) still unifies exactly as before; a mismatched context is now kept as that model's own root, the same way an incompatible length unit already keeps its own project.

--- a/packages/export/src/merged-context.ts
+++ b/packages/export/src/merged-context.ts
@@ -12,9 +12,9 @@
  * subcontexts — onto the primary model's instance whenever the model is
  * unit-compatible. `IfcUnitAssignment` unifies unconditionally (a pure unit
  * declaration), but a representation context also carries a
- * `WorldCoordinateSystem`: the root anchor every placement in that context
+ * `WorldCoordinateSystem`: the root frame (origin and orientation) every placement in that context
  * ultimately resolves against. Silently dropping a model's own context in
- * favour of the primary's — without checking the WCS origin matches — would
+ * favour of the primary's — without checking the WCS frame matches — would
  * re-interpret every one of that model's untouched coordinates against the
  * WRONG origin: a wrong-place bug, not merely a duplicate-entity one. A
  * context whose WCS disagrees keeps its own root, exactly like the
@@ -26,9 +26,11 @@
  * position, so two authoring tools that declared their subcontexts in a
  * different order never cross-wire a 'Body' representation onto an 'Axis'
  * context. That kind match is additionally gated on the parent context's WCS
- * compatibility: when the top-level context did not unify, this model's
- * subcontexts still reference its own (un-remapped) context, so unifying them
- * onto the primary's subcontexts would misplace them just the same.
+ * compatibility: a subcontext inherits its frame from `ParentContext`, so
+ * when the top-level context's frame disagrees with the primary's, this
+ * model's subcontexts still reference its own (un-remapped) context, and
+ * unifying them onto the primary's subcontexts would misplace them just the
+ * same.
  */
 
 import type { IfcDataStore } from '@ifc-lite/parser';
@@ -36,14 +38,16 @@ import { asSourceBytes } from '@ifc-lite/parser';
 import { splitTopLevelStepArguments } from './step-argument-parser.js';
 import { planSubContextUnify } from './merged-subcontext.js';
 
-/** A resolved WorldCoordinateSystem origin, in metres. */
+/** A resolved WorldCoordinateSystem frame: origin in metres and normalized axes. */
 export interface WcsSignature {
   x: number;
   y: number;
   z: number;
+  axis: [number, number, number];
+  refDirection: [number, number, number];
 }
 
-/** Tolerance (metres) for two WCS origins to be considered the same. */
+/** Tolerance for WCS origins (metres) and normalized directions. */
 const WCS_TOLERANCE_M = 1e-6;
 
 function decodeEntity(dataStore: IfcDataStore, expressId: number): string | null {
@@ -75,12 +79,28 @@ function parseCoord(raw: string | undefined): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+function parseVector(dataStore: IfcDataStore, directionId: number | null, fallback: [number, number, number]): [number, number, number] | null {
+  if (directionId === null) return fallback;
+  const raw = getStepAttr(dataStore, directionId, 0);
+  const inner = raw?.replace(/^\(|\)$/g, '');
+  const parts = inner === undefined ? null : splitTopLevelStepArguments(inner);
+  if (!parts || parts.length < 2) return null;
+  const x = parseCoord(parts[0]);
+  const y = parseCoord(parts[1]);
+  const z = parts.length > 2 ? parseCoord(parts[2]) : 0;
+  if (x === null || y === null || z === null) return null;
+  const magnitude = Math.hypot(x, y, z);
+  if (magnitude === 0) return null;
+  return [x / magnitude, y / magnitude, z / magnitude];
+}
+
 /**
- * Resolve the WorldCoordinateSystem location of `contextId` (an
+ * Resolve the WorldCoordinateSystem frame of `contextId` (an
  * `IfcGeometricRepresentationContext`), in metres.
  *
  * Attr 4 is `WorldCoordinateSystem`, an `IfcAxis2Placement` (2D/3D) whose
- * attr 0 is `Location` (an `IfcCartesianPoint`) — but tolerates a context
+ * attr 0 is `Location` (an `IfcCartesianPoint`), attrs 1/2 are `Axis` and
+ * `RefDirection` — but tolerates a context
  * pointing straight at a point (no placement wrapper), the shape this
  * package's own test fixtures use. Returns null when any hop is
  * unresolvable (missing entity, `$`, non-numeric): callers must treat null
@@ -109,7 +129,16 @@ export function resolveContextWcsMetres(
   if (x === null || y === null || z === null) return null;
 
   const scale = Number.isFinite(lengthUnitScale) && lengthUnitScale > 0 ? lengthUnitScale : 1;
-  return { x: x * scale, y: y * scale, z: z * scale };
+  // Axis2Placement defaults omitted Axis and RefDirection to +Z and +X.
+  // Treat omitted and explicit defaults identically, not as an unknown shape.
+  const axis = wcsType.includes('CARTESIANPOINT')
+    ? [0, 0, 1] as [number, number, number]
+    : parseVector(dataStore, refId(getStepAttr(dataStore, wcsRef, 1)), [0, 0, 1]);
+  const refDirection = wcsType.includes('CARTESIANPOINT')
+    ? [1, 0, 0] as [number, number, number]
+    : parseVector(dataStore, refId(getStepAttr(dataStore, wcsRef, 2)), [1, 0, 0]);
+  if (axis === null || refDirection === null) return null;
+  return { x: x * scale, y: y * scale, z: z * scale, axis, refDirection };
 }
 
 /** `resolveContextWcsMetres` for a model's first `IfcGeometricRepresentationContext`, or null if it has none. */
@@ -119,7 +148,7 @@ export function resolveModelContextWcs(dataStore: IfcDataStore, lengthUnitScale:
 }
 
 /**
- * True when two resolved WCS origins are the same within tolerance, OR
+ * True when two resolved WCS frames are the same within tolerance, OR
  * either is null (unresolvable — permissive: never block a merge on a
  * context shape this reader couldn't fully parse).
  */
@@ -127,7 +156,9 @@ function wcsSignaturesCompatible(a: WcsSignature | null, b: WcsSignature | null)
   if (a === null || b === null) return true;
   return Math.abs(a.x - b.x) <= WCS_TOLERANCE_M
     && Math.abs(a.y - b.y) <= WCS_TOLERANCE_M
-    && Math.abs(a.z - b.z) <= WCS_TOLERANCE_M;
+    && Math.abs(a.z - b.z) <= WCS_TOLERANCE_M
+    && a.axis.every((value, index) => Math.abs(value - b.axis[index]) <= WCS_TOLERANCE_M)
+    && a.refDirection.every((value, index) => Math.abs(value - b.refDirection[index]) <= WCS_TOLERANCE_M);
 }
 
 /**
@@ -136,19 +167,20 @@ function wcsSignaturesCompatible(a: WcsSignature | null, b: WcsSignature | null)
  *
  * `IfcUnitAssignment` unifies by position unconditionally. The representation
  * context (`IFCGEOMETRICREPRESENTATIONCONTEXT`) unifies only when its resolved
- * WCS origin agrees with the primary model's (in metres, so a differing length
- * unit doesn't produce a false mismatch); a mismatch leaves it un-remapped —
- * kept as this model's own root — so its untouched coordinates are never
- * re-interpreted against the wrong origin.
+ * WCS frame agrees with the primary model's (origin in metres AND
+ * axis/refDirection orientation, so a differing length unit or a rotated frame
+ * doesn't produce a false match); a mismatch leaves it un-remapped — kept as
+ * this model's own root — so its untouched coordinates are never
+ * re-interpreted against the wrong frame.
  *
  * Its subcontexts (`IFCGEOMETRICREPRESENTATIONSUBCONTEXT`) go through
  * {@link planSubContextUnify} instead of positional matching — kind-matched by
  * `ContextIdentifier`/`TargetView` so a 'Body' subcontext never unifies onto an
- * 'Axis' one (merge invariant lens pass 3, item 1) — and inherit the parent
- * context's WCS gate: when the context itself did not unify, its subcontexts
- * reference THIS model's own (un-remapped) context, so unifying them onto the
- * primary's subcontexts would point them at the wrong origin's tree just the
- * same. Mutates `sharedRemap`/`skipEntityIds`.
+ * 'Axis' one (merge invariant lens pass 3, item 1) — gated on the SAME
+ * `contextsCompatible` computed once up front: a subcontext inherits its WCS
+ * from `ParentContext`, so when the parent root's frame disagrees, retaining
+ * the parent means every child must be retained too, not just remapped in
+ * isolation. Mutates `sharedRemap`/`skipEntityIds`.
  */
 export function planInfrastructureUnify(
   dataStore: IfcDataStore,
@@ -161,23 +193,20 @@ export function planInfrastructureUnify(
   sharedRemap: Map<number, number>,
   skipEntityIds: Set<number>,
 ): void {
-  // Permissive default: if the primary model declares no representation
-  // context at all, there is nothing for a subcontext's WCS to disagree
-  // with, so subcontext kind-matching proceeds unhindered.
-  let contextWcsCompatible = true;
+  // Computed once, up front — not per type in the loop below — so its result
+  // does not depend on `IFCGEOMETRICREPRESENTATIONCONTEXT` iterating before
+  // `IFCGEOMETRICREPRESENTATIONSUBCONTEXT` in `firstModelInfraMap`.
+  const contextsCompatible = wcsSignaturesCompatible(firstModelContextWcs,
+    resolveModelContextWcs(dataStore, lengthUnitScale));
   for (const [type, firstIds] of firstModelInfraMap) {
     const thisIds = modelInfra.get(type);
     if (!thisIds || firstIds.length === 0 || thisIds.length === 0) continue;
     if (type === 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT') {
-      if (!contextWcsCompatible) continue;
+      if (!contextsCompatible) continue;
       planSubContextUnify(dataStore, thisIds, firstModelSubContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
       continue;
     }
-    if (type === 'IFCGEOMETRICREPRESENTATIONCONTEXT') {
-      const thisWcs = resolveContextWcsMetres(dataStore, thisIds[0], lengthUnitScale);
-      contextWcsCompatible = wcsSignaturesCompatible(firstModelContextWcs, thisWcs);
-      if (!contextWcsCompatible) continue;
-    }
+    if (type === 'IFCGEOMETRICREPRESENTATIONCONTEXT' && !contextsCompatible) continue;
     sharedRemap.set(thisIds[0], firstIds[0] + firstModelOffset);
     skipEntityIds.add(thisIds[0]);
   }

--- a/packages/export/src/merged-context.ts
+++ b/packages/export/src/merged-context.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shared-infrastructure unify for {@link MergedExporter} — the entry point
+ * `MergedExporter.planModel` delegates to (merge invariant lens passes 2 and
+ * 3, item 1, combined).
+ *
+ * `MergedExporter` deduplicates each model's shared infrastructure —
+ * `IfcUnitAssignment`, `IfcGeometricRepresentationContext` and its
+ * subcontexts — onto the primary model's instance whenever the model is
+ * unit-compatible. `IfcUnitAssignment` unifies unconditionally (a pure unit
+ * declaration), but a representation context also carries a
+ * `WorldCoordinateSystem`: the root anchor every placement in that context
+ * ultimately resolves against. Silently dropping a model's own context in
+ * favour of the primary's — without checking the WCS origin matches — would
+ * re-interpret every one of that model's untouched coordinates against the
+ * WRONG origin: a wrong-place bug, not merely a duplicate-entity one. A
+ * context whose WCS disagrees keeps its own root, exactly like the
+ * pre-existing "incompatible unit" federation path already does.
+ *
+ * A subcontext ('Body', 'Axis', 'FootPrint', …) does not unify positionally
+ * either: it goes through {@link planSubContextUnify} (`merged-subcontext.ts`),
+ * matched by kind (`ContextIdentifier`/`TargetView`) rather than raw array
+ * position, so two authoring tools that declared their subcontexts in a
+ * different order never cross-wire a 'Body' representation onto an 'Axis'
+ * context. That kind match is additionally gated on the parent context's WCS
+ * compatibility: when the top-level context did not unify, this model's
+ * subcontexts still reference its own (un-remapped) context, so unifying them
+ * onto the primary's subcontexts would misplace them just the same.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { asSourceBytes } from '@ifc-lite/parser';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
+import { planSubContextUnify } from './merged-subcontext.js';
+
+/** A resolved WorldCoordinateSystem origin, in metres. */
+export interface WcsSignature {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Tolerance (metres) for two WCS origins to be considered the same. */
+const WCS_TOLERANCE_M = 1e-6;
+
+function decodeEntity(dataStore: IfcDataStore, expressId: number): string | null {
+  const source = dataStore.source;
+  if (!source) return null;
+  const ref = dataStore.entityIndex.byId.get(expressId);
+  if (!ref) return null;
+  return asSourceBytes(source).decodeUtf8(ref.byteOffset, ref.byteOffset + ref.byteLength);
+}
+
+/** Extract one 0-based STEP attribute of `expressId`'s entity, or null if unreadable. */
+function getStepAttr(dataStore: IfcDataStore, expressId: number, index: number): string | null {
+  const text = decodeEntity(dataStore, expressId);
+  const match = text?.match(/^#\d+\s*=\s*\w+\(([\s\S]*)\)\s*;?\s*$/);
+  if (!match) return null;
+  const args = splitTopLevelStepArguments(match[1]);
+  const raw = args?.[index];
+  return raw === undefined ? null : raw.trim();
+}
+
+function refId(raw: string | null): number | null {
+  const m = raw?.match(/^#(\d+)$/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function parseCoord(raw: string | undefined): number | null {
+  if (raw === undefined) return null;
+  const n = Number(raw.trim());
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Resolve the WorldCoordinateSystem location of `contextId` (an
+ * `IfcGeometricRepresentationContext`), in metres.
+ *
+ * Attr 4 is `WorldCoordinateSystem`, an `IfcAxis2Placement` (2D/3D) whose
+ * attr 0 is `Location` (an `IfcCartesianPoint`) — but tolerates a context
+ * pointing straight at a point (no placement wrapper), the shape this
+ * package's own test fixtures use. Returns null when any hop is
+ * unresolvable (missing entity, `$`, non-numeric): callers must treat null
+ * permissively (compatible), never as "known to differ", so an unusual but
+ * harmless context shape never blocks a merge that used to work.
+ */
+export function resolveContextWcsMetres(
+  dataStore: IfcDataStore,
+  contextId: number,
+  lengthUnitScale: number,
+): WcsSignature | null {
+  const wcsRef = refId(getStepAttr(dataStore, contextId, 4));
+  if (wcsRef === null) return null;
+  const wcsType = (dataStore.entityIndex.byId.get(wcsRef)?.type ?? '').toUpperCase();
+  const pointId = wcsType.includes('CARTESIANPOINT') ? wcsRef : refId(getStepAttr(dataStore, wcsRef, 0));
+  if (pointId === null) return null;
+
+  const coordsRaw = getStepAttr(dataStore, pointId, 0);
+  const inner = coordsRaw?.replace(/^\(|\)$/g, '');
+  const parts = inner === undefined ? null : splitTopLevelStepArguments(inner);
+  if (!parts || parts.length < 2) return null;
+
+  const x = parseCoord(parts[0]);
+  const y = parseCoord(parts[1]);
+  const z = parts.length > 2 ? parseCoord(parts[2]) : 0;
+  if (x === null || y === null || z === null) return null;
+
+  const scale = Number.isFinite(lengthUnitScale) && lengthUnitScale > 0 ? lengthUnitScale : 1;
+  return { x: x * scale, y: y * scale, z: z * scale };
+}
+
+/** `resolveContextWcsMetres` for a model's first `IfcGeometricRepresentationContext`, or null if it has none. */
+export function resolveModelContextWcs(dataStore: IfcDataStore, lengthUnitScale: number): WcsSignature | null {
+  const contextId = (dataStore.entityIndex.byType.get('IFCGEOMETRICREPRESENTATIONCONTEXT') ?? [])[0];
+  return contextId === undefined ? null : resolveContextWcsMetres(dataStore, contextId, lengthUnitScale);
+}
+
+/**
+ * True when two resolved WCS origins are the same within tolerance, OR
+ * either is null (unresolvable — permissive: never block a merge on a
+ * context shape this reader couldn't fully parse).
+ */
+function wcsSignaturesCompatible(a: WcsSignature | null, b: WcsSignature | null): boolean {
+  if (a === null || b === null) return true;
+  return Math.abs(a.x - b.x) <= WCS_TOLERANCE_M
+    && Math.abs(a.y - b.y) <= WCS_TOLERANCE_M
+    && Math.abs(a.z - b.z) <= WCS_TOLERANCE_M;
+}
+
+/**
+ * Plan the whole shared-infrastructure dedup for one model — `MergedExporter`
+ * delegates its entire "remap and skip duplicate infrastructure" step here.
+ *
+ * `IfcUnitAssignment` unifies by position unconditionally. The representation
+ * context (`IFCGEOMETRICREPRESENTATIONCONTEXT`) unifies only when its resolved
+ * WCS origin agrees with the primary model's (in metres, so a differing length
+ * unit doesn't produce a false mismatch); a mismatch leaves it un-remapped —
+ * kept as this model's own root — so its untouched coordinates are never
+ * re-interpreted against the wrong origin.
+ *
+ * Its subcontexts (`IFCGEOMETRICREPRESENTATIONSUBCONTEXT`) go through
+ * {@link planSubContextUnify} instead of positional matching — kind-matched by
+ * `ContextIdentifier`/`TargetView` so a 'Body' subcontext never unifies onto an
+ * 'Axis' one (merge invariant lens pass 3, item 1) — and inherit the parent
+ * context's WCS gate: when the context itself did not unify, its subcontexts
+ * reference THIS model's own (un-remapped) context, so unifying them onto the
+ * primary's subcontexts would point them at the wrong origin's tree just the
+ * same. Mutates `sharedRemap`/`skipEntityIds`.
+ */
+export function planInfrastructureUnify(
+  dataStore: IfcDataStore,
+  modelInfra: ReadonlyMap<string, number[]>,
+  firstModelInfraMap: ReadonlyMap<string, number[]>,
+  firstModelSubContextsByKey: ReadonlyMap<string, number[]>,
+  firstModelOffset: number,
+  firstModelContextWcs: WcsSignature | null,
+  lengthUnitScale: number,
+  sharedRemap: Map<number, number>,
+  skipEntityIds: Set<number>,
+): void {
+  // Permissive default: if the primary model declares no representation
+  // context at all, there is nothing for a subcontext's WCS to disagree
+  // with, so subcontext kind-matching proceeds unhindered.
+  let contextWcsCompatible = true;
+  for (const [type, firstIds] of firstModelInfraMap) {
+    const thisIds = modelInfra.get(type);
+    if (!thisIds || firstIds.length === 0 || thisIds.length === 0) continue;
+    if (type === 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT') {
+      if (!contextWcsCompatible) continue;
+      planSubContextUnify(dataStore, thisIds, firstModelSubContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
+      continue;
+    }
+    if (type === 'IFCGEOMETRICREPRESENTATIONCONTEXT') {
+      const thisWcs = resolveContextWcsMetres(dataStore, thisIds[0], lengthUnitScale);
+      contextWcsCompatible = wcsSignaturesCompatible(firstModelContextWcs, thisWcs);
+      if (!contextWcsCompatible) continue;
+    }
+    sharedRemap.set(thisIds[0], firstIds[0] + firstModelOffset);
+    skipEntityIds.add(thisIds[0]);
+  }
+}

--- a/packages/export/src/merged-context.ts
+++ b/packages/export/src/merged-context.ts
@@ -36,7 +36,7 @@
 import type { IfcDataStore } from '@ifc-lite/parser';
 import { asSourceBytes } from '@ifc-lite/parser';
 import { splitTopLevelStepArguments } from './step-argument-parser.js';
-import { planSubContextUnify } from './merged-subcontext.js';
+import { groupSubContextsByKey, planSubContextUnify } from './merged-subcontext.js';
 
 /** A resolved WorldCoordinateSystem frame: origin in metres and normalized axes. */
 export interface WcsSignature {
@@ -155,6 +155,30 @@ export function resolveModelContextWcs(dataStore: IfcDataStore, lengthUnitScale:
 }
 
 /**
+ * The primary model's context state {@link planInfrastructureUnify} matches
+ * every later model against: its subcontexts grouped by kind key
+ * (`merged-subcontext.ts`) and its top-level context's WCS frame, resolved at
+ * the PRIMARY scale. Computed once per merge via
+ * {@link resolvePrimaryContextState}, not per model.
+ */
+export interface PrimaryContextState {
+  subContextsByKey: Map<string, number[]>;
+  contextWcs: WcsSignature | null;
+}
+
+/** Build the {@link PrimaryContextState} for the primary model. */
+export function resolvePrimaryContextState(
+  dataStore: IfcDataStore,
+  subContextIds: number[],
+  primaryScale: number,
+): PrimaryContextState {
+  return {
+    subContextsByKey: groupSubContextsByKey(dataStore, subContextIds),
+    contextWcs: resolveModelContextWcs(dataStore, primaryScale),
+  };
+}
+
+/**
  * True when two resolved WCS frames are the same within tolerance, OR
  * either is null (unresolvable — permissive: never block a merge on a
  * context shape this reader couldn't fully parse).
@@ -188,14 +212,22 @@ function wcsSignaturesCompatible(a: WcsSignature | null, b: WcsSignature | null)
  * from `ParentContext`, so when the parent root's frame disagrees, retaining
  * the parent means every child must be retained too, not just remapped in
  * isolation. Mutates `sharedRemap`/`skipEntityIds`.
+ *
+ * `lengthUnitScale` is the scale THIS model's raw WCS coordinates resolve
+ * under. Under assume-shared the caller asserts raw coordinates are already
+ * in the primary's unit, and they are copied verbatim — so the caller must
+ * pass the PRIMARY scale (matching how {@link PrimaryContextState.contextWcs}
+ * was computed), not the model's own declared unit, or two frames that agree
+ * raw-value-for-raw-value can compare unequal (and vice versa: differing raw
+ * origins can collide once scaled). Under auto/normalize the caller passes
+ * the model's own declared scale, comparing true metric frames.
  */
 export function planInfrastructureUnify(
   dataStore: IfcDataStore,
   modelInfra: ReadonlyMap<string, number[]>,
   firstModelInfraMap: ReadonlyMap<string, number[]>,
-  firstModelSubContextsByKey: ReadonlyMap<string, number[]>,
+  firstModelContext: PrimaryContextState,
   firstModelOffset: number,
-  firstModelContextWcs: WcsSignature | null,
   lengthUnitScale: number,
   sharedRemap: Map<number, number>,
   skipEntityIds: Set<number>,
@@ -203,7 +235,7 @@ export function planInfrastructureUnify(
   // Computed once, up front — not per type in the loop below — so its result
   // does not depend on `IFCGEOMETRICREPRESENTATIONCONTEXT` iterating before
   // `IFCGEOMETRICREPRESENTATIONSUBCONTEXT` in `firstModelInfraMap`.
-  const contextsCompatible = wcsSignaturesCompatible(firstModelContextWcs,
+  const contextsCompatible = wcsSignaturesCompatible(firstModelContext.contextWcs,
     resolveModelContextWcs(dataStore, lengthUnitScale));
   // Only the model's FIRST top-level context is (positionally) unified below;
   // any later sibling context — a model with both a 'Model' and a 'Plan'
@@ -229,7 +261,7 @@ export function planInfrastructureUnify(
         return parentId === null || parentId === unifiedContextId;
       });
       if (childIds.length > 0) {
-        planSubContextUnify(dataStore, childIds, firstModelSubContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
+        planSubContextUnify(dataStore, childIds, firstModelContext.subContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
       }
       continue;
     }

--- a/packages/export/src/merged-context.ts
+++ b/packages/export/src/merged-context.ts
@@ -131,12 +131,16 @@ export function resolveContextWcsMetres(
   const scale = Number.isFinite(lengthUnitScale) && lengthUnitScale > 0 ? lengthUnitScale : 1;
   // Axis2Placement defaults omitted Axis and RefDirection to +Z and +X.
   // Treat omitted and explicit defaults identically, not as an unknown shape.
-  const axis = wcsType.includes('CARTESIANPOINT')
+  const isPoint = wcsType.includes('CARTESIANPOINT');
+  const is2dPlacement = wcsType.includes('AXIS2PLACEMENT2D');
+  // IFC2D places its sole RefDirection at attribute 1; treating that slot as
+  // a 3D Axis loses rotations in the XY frame and can wrongly unify contexts.
+  const axis = isPoint || is2dPlacement
     ? [0, 0, 1] as [number, number, number]
     : parseVector(dataStore, refId(getStepAttr(dataStore, wcsRef, 1)), [0, 0, 1]);
-  const refDirection = wcsType.includes('CARTESIANPOINT')
+  const refDirection = isPoint
     ? [1, 0, 0] as [number, number, number]
-    : parseVector(dataStore, refId(getStepAttr(dataStore, wcsRef, 2)), [1, 0, 0]);
+    : parseVector(dataStore, refId(getStepAttr(dataStore, wcsRef, is2dPlacement ? 1 : 2)), [1, 0, 0]);
   if (axis === null || refDirection === null) return null;
   return { x: x * scale, y: y * scale, z: z * scale, axis, refDirection };
 }

--- a/packages/export/src/merged-context.ts
+++ b/packages/export/src/merged-context.ts
@@ -50,6 +50,9 @@ export interface WcsSignature {
 /** Tolerance for WCS origins (metres) and normalized directions. */
 const WCS_TOLERANCE_M = 1e-6;
 
+/** 0-based attribute index of `IfcGeometricRepresentationSubContext.ParentContext`. */
+const SUBCONTEXT_PARENT_CONTEXT_ATTR = 6;
+
 function decodeEntity(dataStore: IfcDataStore, expressId: number): string | null {
   const source = dataStore.source;
   if (!source) return null;
@@ -202,12 +205,32 @@ export function planInfrastructureUnify(
   // `IFCGEOMETRICREPRESENTATIONSUBCONTEXT` in `firstModelInfraMap`.
   const contextsCompatible = wcsSignaturesCompatible(firstModelContextWcs,
     resolveModelContextWcs(dataStore, lengthUnitScale));
+  // Only the model's FIRST top-level context is (positionally) unified below;
+  // any later sibling context — a model with both a 'Model' and a 'Plan'
+  // context, say — is always retained. A subcontext may therefore unify ONLY
+  // when its own `ParentContext` is the context actually being remapped: a
+  // child of a retained sibling must stay with its parent, or its shape
+  // representations get re-anchored onto the primary's frame while the parent
+  // keeps its own.
+  const modelContextIds = modelInfra.get('IFCGEOMETRICREPRESENTATIONCONTEXT') ?? [];
+  const firstContextIds = firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONCONTEXT') ?? [];
+  const unifiedContextId = contextsCompatible && modelContextIds.length > 0 && firstContextIds.length > 0
+    ? modelContextIds[0]
+    : null;
   for (const [type, firstIds] of firstModelInfraMap) {
     const thisIds = modelInfra.get(type);
     if (!thisIds || firstIds.length === 0 || thisIds.length === 0) continue;
     if (type === 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT') {
-      if (!contextsCompatible) continue;
-      planSubContextUnify(dataStore, thisIds, firstModelSubContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
+      if (unifiedContextId === null) continue;
+      // An unreadable ParentContext stays permissive (treated as a child of
+      // the unified context), matching this file's null-handling doctrine.
+      const childIds = thisIds.filter((id) => {
+        const parentId = refId(getStepAttr(dataStore, id, SUBCONTEXT_PARENT_CONTEXT_ATTR));
+        return parentId === null || parentId === unifiedContextId;
+      });
+      if (childIds.length > 0) {
+        planSubContextUnify(dataStore, childIds, firstModelSubContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
+      }
       continue;
     }
     if (type === 'IFCGEOMETRICREPRESENTATIONCONTEXT' && !contextsCompatible) continue;

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1555,6 +1555,14 @@ describe('MergedExporter', () => {
       // silently discarded and pasted raw into the origin model's frame.
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(2);
+      // Counting alone cannot see a cross-wired parent: each retained
+      // subcontext must still reference its OWN parent context — the offset
+      // model's 'Body' stays under the retained offset context, not the
+      // primary's.
+      const subParents = [...content.matchAll(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\('Body','Model',\*,\*,\*,\*,#(\d+)/g)].map((m) => m[1]);
+      const contextIds = [...content.matchAll(/#(\d+)=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)].map((m) => m[1]);
+      expect(subParents).toHaveLength(2);
+      expect(new Set(subParents)).toEqual(new Set(contextIds));
       expect(findDanglingRefs(content)).toEqual([]);
     });
 
@@ -1587,6 +1595,107 @@ describe('MergedExporter', () => {
         .export({ schema: 'IFC4' }).content);
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(1);
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(1);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    // Only a model's FIRST context is unified; a later sibling context is
+    // always retained. A subcontext parented to that retained sibling must
+    // stay with it — unifying the child while retaining the parent would
+    // re-anchor its shape representations onto the primary's frame.
+    it('keeps a subcontext whose parent is a retained sibling context, even when the first context unifies', () => {
+      const siblingModel = (): MergeModelInput => buildModel('sibling', 'Sibling', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjSib')}',$,'S',$,$,$,$,(#3,#12),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        // First context: identical frame to the primary — unifies.
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+        [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+        [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((0.,0.,0.));'],
+        [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
+        [7, 'IFCDIRECTION', '#7=IFCDIRECTION((1.,0.,0.));'],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        // Sibling context: 500 m offset frame — always retained.
+        [12, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#12=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Plan',3,1.E-5,#13,$);"],
+        [13, 'IFCAXIS2PLACEMENT3D', '#13=IFCAXIS2PLACEMENT3D(#14,#6,#7);'],
+        [14, 'IFCCARTESIANPOINT', '#14=IFCCARTESIANPOINT((500.,0.,0.));'],
+        // The subcontext's kind matches the primary's 'Body', but its parent
+        // is the RETAINED sibling context #12 — it must not unify.
+        [9, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#9=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#12,$,.MODEL_VIEW.,$);"],
+        [10, 'IFCWALL', `#10=IFCWALL('${guid('wcsWallSib')}',$,'W',$,$,$,#15,$);`],
+        [15, 'IFCPRODUCTDEFINITIONSHAPE', '#15=IFCPRODUCTDEFINITIONSHAPE($,$,(#16));'],
+        [16, 'IFCSHAPEREPRESENTATION', "#16=IFCSHAPEREPRESENTATION(#9,'Body','SweptSolid',$);"],
+      ]);
+
+      const content = decode(new MergedExporter([originModel(), siblingModel()])
+        .export({ schema: 'IFC4' }).content);
+
+      // Primary context unified (1 shared) + the retained sibling = 2.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
+      // The sibling's child subcontext is retained alongside the primary's.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(2);
+      // And it still references its retained parent, not the shared context.
+      const planContext = content.match(/#(\d+)=IFCGEOMETRICREPRESENTATIONCONTEXT\(\$,'Plan'/);
+      expect(planContext).not.toBeNull();
+      const siblingChild = content.match(
+        new RegExp(`=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\\('Body','Model',\\*,\\*,\\*,\\*,#${planContext![1]}`),
+      );
+      expect(siblingChild).not.toBeNull();
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    // Under assume-shared the caller asserts raw coordinates already share the
+    // primary's unit, and they are copied verbatim — so WCS frames compare by
+    // RAW value in the primary's scale, not by each model's declared unit.
+    it('assume-shared: differing raw WCS origins stay separate even when declared-unit scaling makes them collide', () => {
+      // Primary (offsetModel) declares metres, origin (500,0,0). The second declares
+      // MILLImetres with raw origin (500000,0,0): scaled by its own declared
+      // unit both are "500 m", but assume-shared copies 500000 verbatim into
+      // a metre file — a genuinely different frame that must be retained.
+      const mmModel = (): MergeModelInput => buildModel('mm', 'MM', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjMm')}',$,'B',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+        [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+        [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((500000.,0.,0.));'],
+        [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
+        [7, 'IFCDIRECTION', '#7=IFCDIRECTION((1.,0.,0.));'],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);'],
+        [9, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#9=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      ]);
+
+      const primary = offsetModel(500);
+      primary.lengthUnitScale = 1.0; // metres
+      const mm = mmModel();
+      mm.lengthUnitScale = 0.001; // millimetres — the unit assume-shared overrides
+      const content = decode(new MergedExporter([primary, mm])
+        .export({ schema: 'IFC4', unitReconciliation: 'assume-shared' }).content);
+
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('assume-shared: identical raw WCS origins unify despite differing declared units', () => {
+      // Same raw origin (500,0,0) both sides; the second model's declared
+      // MILLI prefix is exactly what assume-shared tells the merge to ignore.
+      const mmModel = (): MergeModelInput => buildModel('mm2', 'MM2', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjMm2')}',$,'B',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+        [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+        [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((500.,0.,0.));'],
+        [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
+        [7, 'IFCDIRECTION', '#7=IFCDIRECTION((1.,0.,0.));'],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);'],
+        [9, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#9=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      ]);
+
+      const primary = offsetModel(500);
+      primary.lengthUnitScale = 1.0; // metres
+      const mm = mmModel();
+      mm.lengthUnitScale = 0.001; // millimetres — the unit assume-shared overrides
+      const content = decode(new MergedExporter([primary, mm])
+        .export({ schema: 'IFC4', unitReconciliation: 'assume-shared' }).content);
+
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(1);
       expect(findDanglingRefs(content)).toEqual([]);
     });
   });

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1532,11 +1532,11 @@ describe('MergedExporter', () => {
 
     // Same length unit as originModel, but its WCS origin is offset by 500 m —
     // e.g. a discipline model authored around its own project base point.
-    const offsetModel = (origin = 500, refDirection = '(1.,0.,0.)'): MergeModelInput => buildModel('offset', 'Offset', [
+    const offsetModel = (origin = 500, refDirection = '(1.,0.,0.)', twoDimensional = false): MergeModelInput => buildModel('offset', 'Offset', [
       [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjB')}',$,'B',$,$,$,$,(#3),#2);`],
       [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
-      [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
-      [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+      [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', `#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',${twoDimensional ? 2 : 3},1.E-5,#4,$);`],
+      [4, twoDimensional ? 'IFCAXIS2PLACEMENT2D' : 'IFCAXIS2PLACEMENT3D', twoDimensional ? '#4=IFCAXIS2PLACEMENT2D(#5,#7);' : '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
       [5, 'IFCCARTESIANPOINT', `#5=IFCCARTESIANPOINT((${origin}.,0.,0.));`],
       [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
       [7, 'IFCDIRECTION', `#7=IFCDIRECTION(${refDirection});`],
@@ -1564,6 +1564,17 @@ describe('MergedExporter', () => {
 
       // Origin equality alone is insufficient: WCS orientation is part of the
       // frame. Both child subcontexts must stay with their respective parents.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('keeps 2D contexts when their RefDirection differs at the same origin', () => {
+      const content = decode(new MergedExporter([originModel(), offsetModel(0, '(0.,1.)', true)])
+        .export({ schema: 'IFC4' }).content);
+
+      // IFCAXIS2PLACEMENT2D stores RefDirection at attribute 1 (not 2).
+      // Losing that distinction would collapse a rotated drawing frame.
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(2);
       expect(findDanglingRefs(content)).toEqual([]);

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1507,4 +1507,66 @@ describe('MergedExporter', () => {
       expect(contextDefMatch![1]).toBe('.PLAN_VIEW.');
     });
   });
+
+  // Lens invariant 2 (units & coordinates): a differing WorldCoordinateSystem
+  // is the wrong-place class the unit checks don't cover. Two same-unit models
+  // whose IfcGeometricRepresentationContext declares a different WCS origin
+  // must NOT have the second model's context silently unified into the
+  // first's — the WCS is the root anchor of the whole placement tree, so
+  // dropping it re-interprets every one of the second model's untouched
+  // coordinates against the wrong origin.
+  describe('context WorldCoordinateSystem alignment', () => {
+    const originModel = (): MergeModelInput => buildModel('origin', 'Origin', [
+      [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjA')}',$,'A',$,$,$,$,(#3),#2);`],
+      [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#7));'],
+      [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+      [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((0.,0.,0.));'],
+      [5, 'IFCSITE', `#5=IFCSITE('${guid('wcsSiteA')}',$,'SiteA',$,$,$,$,$,$,$);`],
+      [6, 'IFCRELAGGREGATES', `#6=IFCRELAGGREGATES('${guid('wcsAggA')}',$,$,$,#1,(#5));`],
+      [7, 'IFCSIUNIT', '#7=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+    ]);
+
+    // Same length unit as originModel, but its WCS origin is offset by 500 m —
+    // e.g. a discipline model authored around its own project base point.
+    const offsetModel = (): MergeModelInput => buildModel('offset', 'Offset', [
+      [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjB')}',$,'B',$,$,$,$,(#3),#2);`],
+      [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+      [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+      [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((500.,0.,0.));'],
+      [5, 'IFCSITE', `#5=IFCSITE('${guid('wcsSiteB')}',$,'SiteB',$,$,$,$,$,$,$);`],
+      [6, 'IFCRELAGGREGATES', `#6=IFCRELAGGREGATES('${guid('wcsAggB')}',$,$,$,#1,(#5));`],
+      [7, 'IFCWALL', `#7=IFCWALL('${guid('wcsWallB')}',$,'W',$,$,$,$,$);`],
+      [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+    ]);
+
+    it('keeps the second model\'s own context when its WCS origin differs from the primary\'s', () => {
+      const content = decode(new MergedExporter([originModel(), offsetModel()])
+        .export({ schema: 'IFC4' }).content);
+
+      // Exactly one context would mean the offset model's own frame was
+      // silently discarded and pasted raw into the origin model's frame.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('still unifies a matching (identical-origin) context, unchanged', () => {
+      // Control: two models sharing the SAME WCS origin — the pre-existing
+      // "one shared context" behaviour must not regress.
+      const sameOriginB = (): MergeModelInput => buildModel('same', 'Same', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjC')}',$,'C',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+        [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((0.,0.,0.));'],
+        [5, 'IFCSITE', `#5=IFCSITE('${guid('wcsSiteC')}',$,'SiteC',$,$,$,$,$,$,$);`],
+        [6, 'IFCRELAGGREGATES', `#6=IFCRELAGGREGATES('${guid('wcsAggC')}',$,$,$,#1,(#5));`],
+        [7, 'IFCWALL', `#7=IFCWALL('${guid('wcsWallC')}',$,'W',$,$,$,$,$);`],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      ]);
+
+      const content = decode(new MergedExporter([originModel(), sameOriginB()])
+        .export({ schema: 'IFC4' }).content);
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(1);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+  });
 });

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1518,25 +1518,33 @@ describe('MergedExporter', () => {
   describe('context WorldCoordinateSystem alignment', () => {
     const originModel = (): MergeModelInput => buildModel('origin', 'Origin', [
       [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjA')}',$,'A',$,$,$,$,(#3),#2);`],
-      [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#7));'],
+      [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
       [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
-      [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((0.,0.,0.));'],
-      [5, 'IFCSITE', `#5=IFCSITE('${guid('wcsSiteA')}',$,'SiteA',$,$,$,$,$,$,$);`],
-      [6, 'IFCRELAGGREGATES', `#6=IFCRELAGGREGATES('${guid('wcsAggA')}',$,$,$,#1,(#5));`],
-      [7, 'IFCSIUNIT', '#7=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+      [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((0.,0.,0.));'],
+      [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
+      [7, 'IFCDIRECTION', '#7=IFCDIRECTION((1.,0.,0.));'],
+      [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      [9, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#9=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      [10, 'IFCSITE', `#10=IFCSITE('${guid('wcsSiteA')}',$,'SiteA',$,$,$,$,$,$,$);`],
+      [11, 'IFCRELAGGREGATES', `#11=IFCRELAGGREGATES('${guid('wcsAggA')}',$,$,$,#1,(#10));`],
     ]);
 
     // Same length unit as originModel, but its WCS origin is offset by 500 m —
     // e.g. a discipline model authored around its own project base point.
-    const offsetModel = (): MergeModelInput => buildModel('offset', 'Offset', [
+    const offsetModel = (origin = 500, refDirection = '(1.,0.,0.)'): MergeModelInput => buildModel('offset', 'Offset', [
       [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjB')}',$,'B',$,$,$,$,(#3),#2);`],
       [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
       [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
-      [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((500.,0.,0.));'],
-      [5, 'IFCSITE', `#5=IFCSITE('${guid('wcsSiteB')}',$,'SiteB',$,$,$,$,$,$,$);`],
-      [6, 'IFCRELAGGREGATES', `#6=IFCRELAGGREGATES('${guid('wcsAggB')}',$,$,$,#1,(#5));`],
-      [7, 'IFCWALL', `#7=IFCWALL('${guid('wcsWallB')}',$,'W',$,$,$,$,$);`],
+      [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+      [5, 'IFCCARTESIANPOINT', `#5=IFCCARTESIANPOINT((${origin}.,0.,0.));`],
+      [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
+      [7, 'IFCDIRECTION', `#7=IFCDIRECTION(${refDirection});`],
       [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      [9, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#9=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      [10, 'IFCSITE', `#10=IFCSITE('${guid('wcsSiteB')}',$,'SiteB',$,$,$,$,$,$,$);`],
+      [11, 'IFCRELAGGREGATES', `#11=IFCRELAGGREGATES('${guid('wcsAggB')}',$,$,$,#1,(#10));`],
+      [12, 'IFCWALL', `#12=IFCWALL('${guid('wcsWallB')}',$,'W',$,$,$,$,$);`],
     ]);
 
     it('keeps the second model\'s own context when its WCS origin differs from the primary\'s', () => {
@@ -1546,26 +1554,28 @@ describe('MergedExporter', () => {
       // Exactly one context would mean the offset model's own frame was
       // silently discarded and pasted raw into the origin model's frame.
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    it('keeps parent contexts and subcontexts when orientations differ at the same origin', () => {
+      const content = decode(new MergedExporter([originModel(), offsetModel(0, '(0.,1.,0.)')])
+        .export({ schema: 'IFC4' }).content);
+
+      // Origin equality alone is insufficient: WCS orientation is part of the
+      // frame. Both child subcontexts must stay with their respective parents.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(2);
       expect(findDanglingRefs(content)).toEqual([]);
     });
 
     it('still unifies a matching (identical-origin) context, unchanged', () => {
       // Control: two models sharing the SAME WCS origin — the pre-existing
       // "one shared context" behaviour must not regress.
-      const sameOriginB = (): MergeModelInput => buildModel('same', 'Same', [
-        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsProjC')}',$,'C',$,$,$,$,(#3),#2);`],
-        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
-        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
-        [4, 'IFCCARTESIANPOINT', '#4=IFCCARTESIANPOINT((0.,0.,0.));'],
-        [5, 'IFCSITE', `#5=IFCSITE('${guid('wcsSiteC')}',$,'SiteC',$,$,$,$,$,$,$);`],
-        [6, 'IFCRELAGGREGATES', `#6=IFCRELAGGREGATES('${guid('wcsAggC')}',$,$,$,#1,(#5));`],
-        [7, 'IFCWALL', `#7=IFCWALL('${guid('wcsWallC')}',$,'W',$,$,$,$,$);`],
-        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
-      ]);
-
-      const content = decode(new MergedExporter([originModel(), sameOriginB()])
+      const content = decode(new MergedExporter([originModel(), offsetModel(0)])
         .export({ schema: 'IFC4' }).content);
       expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(1);
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\(/g)?.length).toBe(1);
       expect(findDanglingRefs(content)).toEqual([]);
     });
   });

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1590,4 +1590,94 @@ describe('MergedExporter', () => {
       expect(findDanglingRefs(content)).toEqual([]);
     });
   });
+
+  // planInfrastructureUnify (merged-context.ts) is two gates layered on the
+  // same call: WCS-frame compatibility (gates the whole context/subcontext
+  // pair) and, once that gate is open, subcontext KIND matching (which of the
+  // primary's subcontexts a given one may unify onto). A rebase that combines
+  // this file's WCS fix with the kind-matching fix landed on `main`
+  // (#3552) once already threaded both through one shared function; these
+  // pin each gate firing on its OWN condition, independent of the other, so a
+  // future merge collapsing them back into one undifferentiated check would
+  // fail here first.
+  describe('planInfrastructureUnify: WCS gating and kind matching are independent', () => {
+    // WCS mismatch, kinds otherwise identical ('Body'/'Body') and in the SAME
+    // order both sides — the one case kind-matching alone would happily unify.
+    // The WCS gate must still hold both subcontexts back.
+    it('a WCS mismatch withholds a subcontext even when its kind matches exactly', () => {
+      const base = (): MergeModelInput => buildModel('wcsKindA', 'A', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsKindProjA')}',$,'A',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+        [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+        [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((0.,0.,0.));'],
+        [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
+        [7, 'IFCDIRECTION', '#7=IFCDIRECTION((1.,0.,0.));'],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#9=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      ]);
+      const offset = (): MergeModelInput => buildModel('wcsKindB', 'B', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('wcsKindProjB')}',$,'B',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#4,$);"],
+        [4, 'IFCAXIS2PLACEMENT3D', '#4=IFCAXIS2PLACEMENT3D(#5,#6,#7);'],
+        // Same kind ('Body'/MODEL_VIEW) as the base model — a 500 m origin
+        // offset is the ONLY difference.
+        [5, 'IFCCARTESIANPOINT', '#5=IFCCARTESIANPOINT((500.,0.,0.));'],
+        [6, 'IFCDIRECTION', '#6=IFCDIRECTION((0.,0.,1.));'],
+        [7, 'IFCDIRECTION', '#7=IFCDIRECTION((1.,0.,0.));'],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#9=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body','Model',*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      ]);
+
+      const content = decode(new MergedExporter([base(), offset()]).export({ schema: 'IFC4' }).content);
+      // Both models' contexts AND both models' 'Body' subcontexts survive —
+      // kind matching never got a chance to run because the WCS gate closed first.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(2);
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\('Body'/g)?.length).toBe(2);
+      expect(findDanglingRefs(content)).toEqual([]);
+    });
+
+    // WCS matches exactly (same origin, same orientation) — the gate is open —
+    // but the two models declare their subcontexts in reversed kind order.
+    // Kind matching, not raw position, must still decide the pairing.
+    it('a matching WCS still routes subcontext pairing through kind matching, not position', () => {
+      const arch = () => buildModel('kindWcsArch', 'Arch', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('kindWcsProjA')}',$,'A',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+        [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Axis',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [5, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#5=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+      ]);
+      const struct = () => buildModel('kindWcsStruct', 'Struct', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('kindWcsProjB')}',$,'B',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+        // Reversed order relative to `arch`, but the SAME WCS origin/orientation.
+        [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [5, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#5=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Axis',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [6, 'IFCWALL', `#6=IFCWALL('${guid('kindWcsWallB')}',$,'W',$,$,$,#7,$);`],
+        [7, 'IFCPRODUCTDEFINITIONSHAPE', '#7=IFCPRODUCTDEFINITIONSHAPE($,$,(#10));'],
+        [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#4,'Body','SweptSolid',$);"],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+      ]);
+
+      const content = decode(new MergedExporter([arch(), struct()]).export({ schema: 'IFC4' }).content);
+      expect(findDanglingRefs(content)).toEqual([]);
+      // One shared context (WCS matched) but the wall's representation must
+      // still resolve to a 'Body'-kind subcontext, never the primary's 'Axis'
+      // one a positional (index-0) pairing would have produced.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONCONTEXT\(/g)?.length).toBe(1);
+      const shapeRepMatch = content.match(/#(\d+)=IFCSHAPEREPRESENTATION\(#(\d+),'Body'/);
+      expect(shapeRepMatch).not.toBeNull();
+      const contextDefMatch = content.match(
+        new RegExp(`#${shapeRepMatch![2]}=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\\('([^']*)'`),
+      );
+      expect(contextDefMatch).not.toBeNull();
+      expect(contextDefMatch![1]).toBe('Body');
+    });
+  });
 });

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -29,7 +29,8 @@ import { assembleStepBytes, assembleStepBlob } from './step-file-assembly.js';
 import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type ExportEntityRef } from './entity-iteration.js';
 import { StepExporter } from './step-exporter.js';
 import { rescaleEntityLengths, computeNormalizeFactor } from './unit-normalize.js';
-import { groupSubContextsByKey, planInfrastructureUnify } from './merged-subcontext.js';
+import { groupSubContextsByKey } from './merged-subcontext.js';
+import { resolveModelContextWcs, planInfrastructureUnify, type WcsSignature } from './merged-context.js';
 import { remapEntityText } from './merged-remap.js';
 import {
   extractGlobalIdFast,
@@ -99,6 +100,8 @@ interface MergeSetup {
   firstModelInfraMap: Map<string, number[]>;
   /** Primary model's subcontexts grouped by matching key — see `merged-subcontext.ts`. */
   firstModelSubContextsByKey: Map<string, number[]>;
+  /** Primary model's representation context WCS origin (metres) — see `merged-context.ts`. */
+  firstModelContextWcs: WcsSignature | null;
   /** IfcProject express ids of the primary model. */
   firstProjectIds: number[];
   /** Spatial lookup built from the primary model. */
@@ -874,6 +877,7 @@ export class MergedExporter {
       firstModelOffset: modelOffsets.get(firstModel.id)!,
       firstModelInfraMap,
       firstModelSubContextsByKey: groupSubContextsByKey(firstModel.dataStore, firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? []),
+      firstModelContextWcs: resolveModelContextWcs(firstModel.dataStore, primaryScale),
       firstProjectIds: this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT'),
       spatialLookup: this.buildSpatialLookup(firstModel.dataStore),
       primaryScale,
@@ -1096,8 +1100,14 @@ export class MergedExporter {
         }
       }
 
-      // Remap and skip duplicate infrastructure (units, contexts) — subcontexts kind-matched, see merged-subcontext.ts.
-      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKey, setup.firstModelOffset, sharedRemap, skipEntityIds);
+      // Remap and skip duplicate infrastructure (units, contexts) — subcontexts
+      // kind-matched (merged-subcontext.ts), context/subcontext WCS-gated
+      // (merged-context.ts); a mismatched or wrong-kind pair is kept as its
+      // own model's root.
+      const modelInfra = this.findInfrastructureEntities(model.dataStore);
+      planInfrastructureUnify(model.dataStore, modelInfra, setup.firstModelInfraMap,
+        setup.firstModelSubContextsByKey, setup.firstModelOffset, setup.firstModelContextWcs,
+        this.resolveUnitScale(model), sharedRemap, skipEntityIds);
 
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
       // Under normalize, this model's raw elevations are in its own unit, so the

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -98,9 +98,8 @@ interface MergeSetup {
   firstModelOffset: number;
   /** Infrastructure entities (units, contexts) of the primary model. */
   firstModelInfraMap: Map<string, number[]>;
-  /** Primary model's subcontexts grouped by matching key — see `merged-subcontext.ts`. */
+  /** Primary model's subcontexts-by-key (`merged-subcontext.ts`) and context WCS frame (`merged-context.ts`). */
   firstModelSubContextsByKey: Map<string, number[]>;
-  /** Primary model's representation context WCS origin (metres) — see `merged-context.ts`. */
   firstModelContextWcs: WcsSignature | null;
   /** IfcProject express ids of the primary model. */
   firstProjectIds: number[];
@@ -1100,14 +1099,8 @@ export class MergedExporter {
         }
       }
 
-      // Remap and skip duplicate infrastructure (units, contexts) — subcontexts
-      // kind-matched (merged-subcontext.ts), context/subcontext WCS-gated
-      // (merged-context.ts); a mismatched or wrong-kind pair is kept as its
-      // own model's root.
-      const modelInfra = this.findInfrastructureEntities(model.dataStore);
-      planInfrastructureUnify(model.dataStore, modelInfra, setup.firstModelInfraMap,
-        setup.firstModelSubContextsByKey, setup.firstModelOffset, setup.firstModelContextWcs,
-        this.resolveUnitScale(model), sharedRemap, skipEntityIds);
+      // Remap and skip duplicate infrastructure; see merged-context.ts.
+      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKey, setup.firstModelOffset, setup.firstModelContextWcs, this.resolveUnitScale(model), sharedRemap, skipEntityIds);
 
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
       // Under normalize, this model's raw elevations are in its own unit, so the

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -1100,7 +1100,15 @@ export class MergedExporter {
       }
 
       // Remap and skip duplicate infrastructure; see merged-context.ts.
-      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKey, setup.firstModelOffset, setup.firstModelContextWcs, this.resolveUnitScale(model), sharedRemap, skipEntityIds);
+      // Under assume-shared the caller asserts raw coordinates are already in
+      // the primary's unit, and they are copied verbatim — so the WCS frame
+      // must be resolved with the PRIMARY scale (matching how
+      // firstModelContextWcs was computed), not the model's own declared
+      // unit, or two frames that agree raw-value-for-raw-value can compare
+      // unequal (and vice versa: differing raw origins can collide once
+      // scaled). auto/normalize compare true metric frames via the model's
+      // own declared scale.
+      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKey, setup.firstModelOffset, setup.firstModelContextWcs, setup.assumeShared ? setup.primaryScale : this.resolveUnitScale(model), sharedRemap, skipEntityIds);
 
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
       // Under normalize, this model's raw elevations are in its own unit, so the

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -29,8 +29,7 @@ import { assembleStepBytes, assembleStepBlob } from './step-file-assembly.js';
 import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type ExportEntityRef } from './entity-iteration.js';
 import { StepExporter } from './step-exporter.js';
 import { rescaleEntityLengths, computeNormalizeFactor } from './unit-normalize.js';
-import { groupSubContextsByKey } from './merged-subcontext.js';
-import { resolveModelContextWcs, planInfrastructureUnify, type WcsSignature } from './merged-context.js';
+import { planInfrastructureUnify, resolvePrimaryContextState, type PrimaryContextState } from './merged-context.js';
 import { remapEntityText } from './merged-remap.js';
 import {
   extractGlobalIdFast,
@@ -98,9 +97,8 @@ interface MergeSetup {
   firstModelOffset: number;
   /** Infrastructure entities (units, contexts) of the primary model. */
   firstModelInfraMap: Map<string, number[]>;
-  /** Primary model's subcontexts-by-key (`merged-subcontext.ts`) and context WCS frame (`merged-context.ts`). */
-  firstModelSubContextsByKey: Map<string, number[]>;
-  firstModelContextWcs: WcsSignature | null;
+  /** Primary model's subcontexts-by-key and context WCS frame — see `merged-context.ts`. */
+  firstModelContext: PrimaryContextState;
   /** IfcProject express ids of the primary model. */
   firstProjectIds: number[];
   /** Spatial lookup built from the primary model. */
@@ -875,8 +873,7 @@ export class MergedExporter {
       modelOffsets,
       firstModelOffset: modelOffsets.get(firstModel.id)!,
       firstModelInfraMap,
-      firstModelSubContextsByKey: groupSubContextsByKey(firstModel.dataStore, firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? []),
-      firstModelContextWcs: resolveModelContextWcs(firstModel.dataStore, primaryScale),
+      firstModelContext: resolvePrimaryContextState(firstModel.dataStore, firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? [], primaryScale),
       firstProjectIds: this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT'),
       spatialLookup: this.buildSpatialLookup(firstModel.dataStore),
       primaryScale,
@@ -1099,16 +1096,8 @@ export class MergedExporter {
         }
       }
 
-      // Remap and skip duplicate infrastructure; see merged-context.ts.
-      // Under assume-shared the caller asserts raw coordinates are already in
-      // the primary's unit, and they are copied verbatim — so the WCS frame
-      // must be resolved with the PRIMARY scale (matching how
-      // firstModelContextWcs was computed), not the model's own declared
-      // unit, or two frames that agree raw-value-for-raw-value can compare
-      // unequal (and vice versa: differing raw origins can collide once
-      // scaled). auto/normalize compare true metric frames via the model's
-      // own declared scale.
-      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKey, setup.firstModelOffset, setup.firstModelContextWcs, setup.assumeShared ? setup.primaryScale : this.resolveUnitScale(model), sharedRemap, skipEntityIds);
+      // Remap and skip duplicate infrastructure (units, contexts) — WCS-gated; scale choice documented on planInfrastructureUnify (merged-context.ts).
+      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelContext, setup.firstModelOffset, setup.assumeShared ? setup.primaryScale : this.resolveUnitScale(model), sharedRemap, skipEntityIds);
 
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
       // Under normalize, this model's raw elevations are in its own unit, so the

--- a/packages/export/src/merged-subcontext.ts
+++ b/packages/export/src/merged-subcontext.ts
@@ -123,33 +123,3 @@ export function planSubContextUnify(
     skipEntityIds.add(id);
   }
 }
-
-/**
- * Plan the whole shared-infrastructure dedup for one model — `MergedExporter`
- * delegates its entire "remap and skip duplicate infrastructure" step here so
- * the kind-vs-position distinction lives in one place. Every
- * {@link SHARED_INFRASTRUCTURE_TYPES}-listed type is unified by position
- * EXCEPT `IFCGEOMETRICREPRESENTATIONSUBCONTEXT`, which goes through
- * {@link planSubContextUnify} instead (key-matched). Mutates
- * `sharedRemap`/`skipEntityIds`.
- */
-export function planInfrastructureUnify(
-  dataStore: IfcDataStore,
-  modelInfra: ReadonlyMap<string, number[]>,
-  firstModelInfraMap: ReadonlyMap<string, number[]>,
-  firstModelSubContextsByKey: ReadonlyMap<string, number[]>,
-  firstModelOffset: number,
-  sharedRemap: Map<number, number>,
-  skipEntityIds: Set<number>,
-): void {
-  for (const [type, firstIds] of firstModelInfraMap) {
-    const thisIds = modelInfra.get(type);
-    if (!thisIds || firstIds.length === 0 || thisIds.length === 0) continue;
-    if (type === 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT') {
-      planSubContextUnify(dataStore, thisIds, firstModelSubContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
-      continue;
-    }
-    sharedRemap.set(thisIds[0], firstIds[0] + firstModelOffset);
-    skipEntityIds.add(thisIds[0]);
-  }
-}


### PR DESCRIPTION
## Invariant violated

Merge invariant lens pass 2, item 2 (units & coordinates): "different `IfcGeometricRepresentationContext.Precision` / `WorldCoordinateSystem` / `TrueNorth` between inputs — is the second model re-placed into the first's frame or pasted raw?"

It is pasted raw. `MergedExporter` deduplicates each unit-compatible model's `IfcUnitAssignment`, `IfcGeometricRepresentationContext` and subcontexts onto the primary model's instance (`SHARED_INFRASTRUCTURE_TYPES` in `merged-exporter.ts`), with no check on the context's `WorldCoordinateSystem`. The WCS is the root anchor every placement in that representation context ultimately resolves against. Dropping a second model's own context in favour of the primary's, while only rescaling coordinate *magnitudes* (never re-projecting them), silently re-interprets every one of that model's untouched coordinates against the wrong origin — a wrong-place error equal to the WCS delta, not merely a duplicate-entity issue. This is a distinct defect from the already-merged prefixed-SI-unit fix (`74d00bf6e`) and from open PR #3550 (partial `IfcRelAggregates` redundancy), neither of which touches representation-context unification.

## Reproduction

RED test added: `context WorldCoordinateSystem alignment > keeps the second model's own context when its WCS origin differs from the primary's` (`packages/export/src/merged-exporter.test.ts`). Two same-length-unit models whose `IfcGeometricRepresentationContext` declares a WCS origin 500 m apart (a realistic case — a discipline model authored around its own project base point). Before the fix, `MergedExporter` collapsed both contexts into one (`expected 1 to be 2` on the count of `IFCGEOMETRICREPRESENTATIONCONTEXT` entities in the output), meaning the second model's geometry is now interpreted under the first model's frame with no correction — a silent 500 m placement error.

## Fix

New sibling module `packages/export/src/merged-context.ts` (kept out of `merged-exporter.ts`, which sits at its 1667-line size-check budget with zero headroom):

- `resolveContextWcsMetres` reads a context's `WorldCoordinateSystem` (attr 4), follows it through an `IfcAxis2Placement2D/3D` (or tolerates a context pointing straight at a point, the shape this package's own fixtures use) to its `IfcCartesianPoint`, and returns the origin in metres.
- `planInfrastructureUnify` is the plan step `MergedExporter.planModel` now delegates to for the whole shared-infrastructure loop: unit assignments unify exactly as before; a context/subcontext only unifies when the two models' resolved WCS origins agree within a 1e-6 m tolerance — otherwise the model keeps its own context, the same way an incompatible length unit already keeps its own project (federation, not silent misplacement).
- An unresolvable WCS shape (missing entity, `$`, non-numeric) is treated **permissively** — still unified — so the fix only changes behaviour for models that actually declare a resolvable, differing origin. This is why every pre-existing context-unify test (all of which use matching origins) is unaffected.

## Verification

- `pnpm --filter @ifc-lite/export... build` then `pnpm exec tsc --noEmit` in `packages/export`: clean.
- `pnpm exec vitest run` in `packages/export`: 80 files, 1064 passed, 0 regressions (including the new RED-turned-GREEN test).
- `pnpm exec tsc --noEmit --noUnusedLocals` in `packages/export`: clean.
- `node scripts/check-module-size.mjs`: `check-module-size: OK (2031 files measured, 306 allowlisted, 0 new over 400)` — `merged-exporter.ts` is 1666/1667 lines (the fix's own lines net out to +6 there; everything else lives in the new 155-line `merged-context.ts`).
- `node scripts/check-test-wiring.mjs`: OK.
- No public API surface change: `merged-context.ts` is not re-exported from `packages/export/src/index.ts`; changeset added (`patch`, `@ifc-lite/export`).

## Control (invariant that already held)

`still unifies a matching (identical-origin) context, unchanged` — two models sharing the same WCS origin still unify into one context, exactly as before. Every other context-unify path in the existing suite (federation, unit normalization, spatial unification) also passes unchanged, confirming this only narrows the unify condition rather than altering it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Merged exports now preserve separate geometric representation contexts when models use different world-coordinate origins or orientations.
  - Prevents untouched model geometry from being incorrectly repositioned during export.
  - Matching coordinate systems continue to share contexts as expected.
  - Subcontexts are unified only when their parent contexts are compatible.
  - Improved merge reliability by ensuring exported results contain no dangling references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->