### PR TITLE
fix(export): stop MergedExporter unifying a wrong-kind IfcGeometricRepresentationSubContext

### DIFF
--- a/.changeset/merged-exporter-subcontext-kind-match.md
+++ b/.changeset/merged-exporter-subcontext-kind-match.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/export': patch
+---
+
+`MergedExporter` no longer unifies a model's `IfcGeometricRepresentationSubContext` (`'Body'`, `'Axis'`, …) onto the primary model's by array position. Two exporters don't guarantee the same subcontext emission order, so a positionally-matched second model's `'Body'` subcontext could get unified onto the primary model's `'Axis'` subcontext (or vice versa): every `IfcShapeRepresentation.ContextOfItems` that pointed at the dropped subcontext now resolved to a surviving one of the wrong kind, which many viewers filter out of the 3D view entirely — geometry silently vanishing, with no dangling reference to reveal it. Subcontexts are now matched by kind (`ContextIdentifier`, falling back to `TargetView`) before being deduplicated; a subcontext with no same-kind match in the primary model keeps its own (offset-only) copy instead of being merged onto an unrelated one.

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1433,5 +1433,44 @@ describe('MergedExporter', () => {
       expect(contextDefMatch).not.toBeNull();
       expect(contextDefMatch![1]).toBe('Body');
     });
+
+    // A second-model subcontext kind with NO counterpart in the primary model
+    // (e.g. 'FootPrint', which the primary never declares) must survive as
+    // its OWN subcontext, offset-only — never silently unified onto whatever
+    // happened to sit at that array index under the old positional pairing.
+    it("keeps a no-counterpart subcontext kind ('FootPrint') as its own entity, with its reference intact", () => {
+      const footprintModel2 = () => buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('subctxProjD')}',$,'D',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+        [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [5, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#5=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Axis',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        // 'FootPrint' — a kind the primary model (Axis/Body only) never declares.
+        [11, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#11=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('FootPrint',$,*,*,*,*,#3,$,.PLAN_VIEW.,$);"],
+        [6, 'IFCWALL', `#6=IFCWALL('${guid('subctxWallD')}',$,'W',$,$,$,#7,$);`],
+        [7, 'IFCPRODUCTDEFINITIONSHAPE', '#7=IFCPRODUCTDEFINITIONSHAPE($,$,(#10));'],
+        // ContextOfItems (attr 0) = #11, this model's own 'FootPrint' subcontext.
+        [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#11,'FootPrint','GeometricCurveSet',$);"],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+      ]);
+
+      const content = decode(new MergedExporter([model1(), footprintModel2()])
+        .export({ schema: 'IFC4' }).content);
+
+      expect(findDanglingRefs(content)).toEqual([]);
+
+      // The 'FootPrint' subcontext survives in the output (not dropped).
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\('FootPrint'/g)?.length).toBe(1);
+
+      // The representation naming it still resolves to that surviving 'FootPrint' subcontext.
+      const shapeRepMatch = content.match(/#(\d+)=IFCSHAPEREPRESENTATION\(#(\d+),'FootPrint'/);
+      expect(shapeRepMatch).not.toBeNull();
+      const contextDefMatch2 = content.match(
+        new RegExp(`#${shapeRepMatch![2]}=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\\('([^']*)'`),
+      );
+      expect(contextDefMatch2).not.toBeNull();
+      expect(contextDefMatch2![1]).toBe('FootPrint');
+    });
   });
 });

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1337,4 +1337,101 @@ describe('MergedExporter', () => {
       expect(findDanglingRefs(content)).toEqual([]);
     });
   });
+
+  // Merge invariant lens pass 3, item 1: `IfcShapeRepresentation.ContextOfItems`
+  // must point at a SURVIVING sub-context of the right kind ('Body'/'Axis'), not
+  // at the wrong kind. `MergedExporter` deduplicates each unit-compatible
+  // model's IFCGEOMETRICREPRESENTATIONSUBCONTEXT entities against the primary
+  // model's by taking the two models' subcontext lists positionally
+  // (`thisIds[0]` unified onto `firstIds[0]`), with no check that the two
+  // subcontexts are the same kind (ContextIdentifier). Real exporters do not
+  // guarantee subcontext emission order, so a second model whose subcontexts
+  // happen to be ordered differently than the first model's gets its 'Body'
+  // subcontext silently unified onto the first model's 'Axis' subcontext (or
+  // vice versa) — every representation in that subcontext is now tagged with
+  // the wrong kind, which many viewers filter out entirely (geometry
+  // vanishes), a wrong result no dangling-ref check catches.
+  describe('sub-context kind matching', () => {
+    // Model1's subcontexts are ordered [Axis, Body] (#4, #5); Model2's are
+    // ordered [Body, Axis] (#4, #5) — the same two kinds, reversed order, a
+    // realistic case (exporters differ in subcontext emission order).
+    const model1 = () => buildModel('m1', 'Arch', [
+      [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('subctxProjA')}',$,'A',$,$,$,$,(#3),#2);`],
+      [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+      [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+      [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Axis',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      [5, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#5=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+    ]);
+
+    const model2 = () => buildModel('m2', 'Struct', [
+      [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('subctxProjB')}',$,'B',$,$,$,$,(#3),#2);`],
+      [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+      [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+      [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      [5, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#5=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Axis',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+      [6, 'IFCWALL', `#6=IFCWALL('${guid('subctxWallB')}',$,'W',$,$,$,#7,$);`],
+      [7, 'IFCPRODUCTDEFINITIONSHAPE', '#7=IFCPRODUCTDEFINITIONSHAPE($,$,(#10));'],
+      // ContextOfItems (attr 0) = #4, this model's OWN 'Body' subcontext.
+      [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#4,'Body','SweptSolid',$);"],
+      [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+      [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+    ]);
+
+    it("keeps a unified IfcShapeRepresentation's ContextOfItems on a same-kind subcontext, never a differently-ordered one", () => {
+      const content = decode(new MergedExporter([model1(), model2()])
+        .export({ schema: 'IFC4' }).content);
+
+      expect(findDanglingRefs(content)).toEqual([]);
+
+      // Find #10's (model2's IFCSHAPEREPRESENTATION) final ContextOfItems ref.
+      const shapeRepMatch = content.match(/#(\d+)=IFCSHAPEREPRESENTATION\(#(\d+),'Body'/);
+      expect(shapeRepMatch).not.toBeNull();
+      const contextRef = shapeRepMatch![2];
+
+      // The referenced context's own defining line must be the 'Body' kind —
+      // never 'Axis' (model1's #4), which is what a positional (index-0)
+      // match would have wrongly unified it onto.
+      const contextDefRegex = new RegExp(`#${contextRef}=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\\('([^']*)'`);
+      const contextDefMatch = content.match(contextDefRegex);
+      expect(contextDefMatch).not.toBeNull();
+      expect(contextDefMatch![1]).toBe('Body');
+    });
+
+    // Control: the pre-existing behaviour this fix must not regress — two
+    // models whose subcontexts share the SAME order still dedup down to one
+    // surviving subcontext per kind (kind matching, not merely "no longer
+    // positional", still performs the intended unification).
+    it('still dedups same-kind subcontexts when both models order them identically', () => {
+      const sameOrderModel2 = () => buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('subctxProjC')}',$,'C',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+        [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Axis',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [5, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#5=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [6, 'IFCWALL', `#6=IFCWALL('${guid('subctxWallC')}',$,'W',$,$,$,#7,$);`],
+        [7, 'IFCPRODUCTDEFINITIONSHAPE', '#7=IFCPRODUCTDEFINITIONSHAPE($,$,(#10));'],
+        [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#5,'Body','SweptSolid',$);"],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+      ]);
+
+      const content = decode(new MergedExporter([model1(), sameOrderModel2()])
+        .export({ schema: 'IFC4' }).content);
+
+      expect(findDanglingRefs(content)).toEqual([]);
+      // Only ONE 'Axis' and ONE 'Body' subcontext should survive.
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\('Axis'/g)?.length).toBe(1);
+      expect(content.match(/=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\('Body'/g)?.length).toBe(1);
+
+      const shapeRepMatch = content.match(/#(\d+)=IFCSHAPEREPRESENTATION\(#(\d+),'Body'/);
+      expect(shapeRepMatch).not.toBeNull();
+      const contextDefMatch = content.match(
+        new RegExp(`#${shapeRepMatch![2]}=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\\('([^']*)'`),
+      );
+      expect(contextDefMatch).not.toBeNull();
+      expect(contextDefMatch![1]).toBe('Body');
+    });
+  });
 });

--- a/packages/export/src/merged-exporter.test.ts
+++ b/packages/export/src/merged-exporter.test.ts
@@ -1472,5 +1472,39 @@ describe('MergedExporter', () => {
       expect(contextDefMatch2).not.toBeNull();
       expect(contextDefMatch2![1]).toBe('FootPrint');
     });
+
+    it('keeps same-named subcontexts with different TargetView values separate', () => {
+      const planViewModel1 = () => buildModel('m1', 'Arch', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('subctxTargetViewProjA')}',$,'A',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+        [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.MODEL_VIEW.,$);"],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+      ]);
+      const planViewModel2 = () => buildModel('m2', 'Struct', [
+        [1, 'IFCPROJECT', `#1=IFCPROJECT('${guid('subctxTargetViewProjB')}',$,'B',$,$,$,$,(#3),#2);`],
+        [2, 'IFCUNITASSIGNMENT', '#2=IFCUNITASSIGNMENT((#8));'],
+        [3, 'IFCGEOMETRICREPRESENTATIONCONTEXT', "#3=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.E-5,#9,$);"],
+        [4, 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT', "#4=IFCGEOMETRICREPRESENTATIONSUBCONTEXT('Body',$,*,*,*,*,#3,$,.PLAN_VIEW.,$);"],
+        [6, 'IFCWALL', `#6=IFCWALL('${guid('subctxTargetViewWall')}',$,'W',$,$,$,#7,$);`],
+        [7, 'IFCPRODUCTDEFINITIONSHAPE', '#7=IFCPRODUCTDEFINITIONSHAPE($,$,(#10));'],
+        [10, 'IFCSHAPEREPRESENTATION', "#10=IFCSHAPEREPRESENTATION(#4,'Body','GeometricCurveSet',$);"],
+        [8, 'IFCSIUNIT', '#8=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);'],
+        [9, 'IFCCARTESIANPOINT', '#9=IFCCARTESIANPOINT((0.,0.,0.));'],
+      ]);
+
+      const content = decode(new MergedExporter([planViewModel1(), planViewModel2()])
+        .export({ schema: 'IFC4' }).content);
+
+      expect(findDanglingRefs(content)).toEqual([]);
+      const shapeRepMatch = content.match(/#(\d+)=IFCSHAPEREPRESENTATION\(#(\d+),'Body','GeometricCurveSet'/);
+      expect(shapeRepMatch).not.toBeNull();
+      const contextDefMatch = content.match(
+        new RegExp(`#${shapeRepMatch![2]}=IFCGEOMETRICREPRESENTATIONSUBCONTEXT\\('Body',\\$,\\*,\\*,\\*,\\*,#\\d+,\\$,(\\.[A-Z_]+\\.)`),
+      );
+      expect(contextDefMatch).not.toBeNull();
+      expect(contextDefMatch![1]).toBe('.PLAN_VIEW.');
+    });
   });
 });

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -31,6 +31,7 @@ import { assembleStepBytes, assembleStepBlob } from './step-file-assembly.js';
 import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type ExportEntityRef } from './entity-iteration.js';
 import { StepExporter } from './step-exporter.js';
 import { rescaleEntityLengths, computeNormalizeFactor } from './unit-normalize.js';
+import { groupSubContextsByKind, planInfrastructureUnify } from './merged-subcontext.js';
 
 /**
  * UTF-8 decode of `[start, end)` of a model's source, accepting either the raw
@@ -120,6 +121,8 @@ interface MergeSetup {
   firstModelOffset: number;
   /** Infrastructure entities (units, contexts) of the primary model. */
   firstModelInfraMap: Map<string, number[]>;
+  /** Primary model's subcontexts grouped by kind — see `merged-subcontext.ts`. */
+  firstModelSubContextsByKind: Map<string, number[]>;
   /** IfcProject express ids of the primary model. */
   firstProjectIds: number[];
   /** Spatial lookup built from the primary model. */
@@ -818,10 +821,12 @@ export class MergedExporter {
 
     const firstModel = models[0];
     const primaryScale = this.resolveUnitScale(firstModel);
+    const firstModelInfraMap = this.findInfrastructureEntities(firstModel.dataStore);
     return {
       modelOffsets,
       firstModelOffset: modelOffsets.get(firstModel.id)!,
-      firstModelInfraMap: this.findInfrastructureEntities(firstModel.dataStore),
+      firstModelInfraMap,
+      firstModelSubContextsByKind: groupSubContextsByKind(firstModel.dataStore, firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? []),
       firstProjectIds: this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT'),
       spatialLookup: this.buildSpatialLookup(firstModel.dataStore),
       primaryScale,
@@ -1044,15 +1049,8 @@ export class MergedExporter {
         }
       }
 
-      // Remap and skip duplicate infrastructure (units, contexts).
-      const modelInfra = this.findInfrastructureEntities(model.dataStore);
-      for (const [type, firstIds] of setup.firstModelInfraMap) {
-        const thisIds = modelInfra.get(type);
-        if (thisIds && firstIds.length > 0 && thisIds.length > 0) {
-          sharedRemap.set(thisIds[0], firstIds[0] + setup.firstModelOffset);
-          skipEntityIds.add(thisIds[0]);
-        }
-      }
+      // Remap and skip duplicate infrastructure (units, contexts) — subcontexts kind-matched, see merged-subcontext.ts.
+      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKind, setup.firstModelOffset, sharedRemap, skipEntityIds);
 
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
       // Under normalize, this model's raw elevations are in its own unit, so the

--- a/packages/export/src/merged-exporter.ts
+++ b/packages/export/src/merged-exporter.ts
@@ -31,7 +31,7 @@ import { assembleStepBytes, assembleStepBlob } from './step-file-assembly.js';
 import { getCompleteEntityIndex, getMaxExpressId, type CompleteEntityIndex, type ExportEntityRef } from './entity-iteration.js';
 import { StepExporter } from './step-exporter.js';
 import { rescaleEntityLengths, computeNormalizeFactor } from './unit-normalize.js';
-import { groupSubContextsByKind, planInfrastructureUnify } from './merged-subcontext.js';
+import { groupSubContextsByKey, planInfrastructureUnify } from './merged-subcontext.js';
 
 /**
  * UTF-8 decode of `[start, end)` of a model's source, accepting either the raw
@@ -121,8 +121,8 @@ interface MergeSetup {
   firstModelOffset: number;
   /** Infrastructure entities (units, contexts) of the primary model. */
   firstModelInfraMap: Map<string, number[]>;
-  /** Primary model's subcontexts grouped by kind — see `merged-subcontext.ts`. */
-  firstModelSubContextsByKind: Map<string, number[]>;
+  /** Primary model's subcontexts grouped by matching key — see `merged-subcontext.ts`. */
+  firstModelSubContextsByKey: Map<string, number[]>;
   /** IfcProject express ids of the primary model. */
   firstProjectIds: number[];
   /** Spatial lookup built from the primary model. */
@@ -826,7 +826,7 @@ export class MergedExporter {
       modelOffsets,
       firstModelOffset: modelOffsets.get(firstModel.id)!,
       firstModelInfraMap,
-      firstModelSubContextsByKind: groupSubContextsByKind(firstModel.dataStore, firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? []),
+      firstModelSubContextsByKey: groupSubContextsByKey(firstModel.dataStore, firstModelInfraMap.get('IFCGEOMETRICREPRESENTATIONSUBCONTEXT') ?? []),
       firstProjectIds: this.findEntitiesByType(firstModel.dataStore, 'IFCPROJECT'),
       spatialLookup: this.buildSpatialLookup(firstModel.dataStore),
       primaryScale,
@@ -1050,7 +1050,7 @@ export class MergedExporter {
       }
 
       // Remap and skip duplicate infrastructure (units, contexts) — subcontexts kind-matched, see merged-subcontext.ts.
-      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKind, setup.firstModelOffset, sharedRemap, skipEntityIds);
+      planInfrastructureUnify(model.dataStore, this.findInfrastructureEntities(model.dataStore), setup.firstModelInfraMap, setup.firstModelSubContextsByKey, setup.firstModelOffset, sharedRemap, skipEntityIds);
 
       // Unify spatial hierarchy: match Site, Building, Storey to first model.
       // Under normalize, this model's raw elevations are in its own unit, so the
@@ -1662,4 +1662,3 @@ export class MergedExporter {
   }
 
 }
-

--- a/packages/export/src/merged-subcontext.ts
+++ b/packages/export/src/merged-subcontext.ts
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Kind-aware `IfcGeometricRepresentationSubContext` matching for
+ * {@link MergedExporter} (merge invariant lens pass 3, item 1).
+ *
+ * `MergedExporter` deduplicates a unit-compatible model's shared
+ * infrastructure — `IfcUnitAssignment`, `IfcGeometricRepresentationContext`
+ * and subcontexts — onto the primary model's instance. For subcontexts that
+ * used to mean taking the two models' subcontext id lists **positionally**:
+ * this model's first subcontext (in whatever order `entityIndex.byType`
+ * returns them) was unified onto the primary model's first subcontext, with
+ * no check that the two are the same kind.
+ *
+ * A model normally declares more than one subcontext ('Body' for solid
+ * geometry, 'Axis' for centreline geometry, sometimes 'FootPrint'/'Box'), and
+ * nothing in the IFC schema or common exporter behaviour guarantees they are
+ * always written in the same order across two different authoring tools. A
+ * positional match can therefore unify this model's 'Body' subcontext onto
+ * the primary model's 'Axis' subcontext (or vice versa): every
+ * `IfcShapeRepresentation.ContextOfItems` that pointed at the dropped 'Body'
+ * subcontext now resolves, after the remap, to a context tagged 'Axis' — the
+ * wrong kind, which many viewers filter out of the 3D view entirely (the
+ * geometry silently vanishes), with no dangling reference to reveal it.
+ *
+ * `planSubContextUnify` fixes this by matching on the subcontext's *kind*
+ * (its `ContextIdentifier`, e.g. 'Body'/'Axis' — falling back to
+ * `TargetView` when the identifier is unset, and finally to positional
+ * matching only within same-kind buckets) rather than on raw array position.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { asSourceBytes } from '@ifc-lite/parser';
+import { splitTopLevelStepArguments } from './step-argument-parser.js';
+
+/** 0-based attribute index of `IfcGeometricRepresentationSubContext.ContextIdentifier`. */
+const CONTEXT_IDENTIFIER_ATTR = 0;
+/** 0-based attribute index of `IfcGeometricRepresentationSubContext.TargetView`. */
+const TARGET_VIEW_ATTR = 8;
+
+function decodeEntity(dataStore: IfcDataStore, expressId: number): string | null {
+  const source = dataStore.source;
+  if (!source) return null;
+  const ref = dataStore.entityIndex.byId.get(expressId);
+  if (!ref) return null;
+  return asSourceBytes(source).decodeUtf8(ref.byteOffset, ref.byteOffset + ref.byteLength);
+}
+
+/** Extract one 0-based STEP attribute of `expressId`'s entity, or null if unreadable. */
+function getStepAttr(dataStore: IfcDataStore, expressId: number, index: number): string | null {
+  const text = decodeEntity(dataStore, expressId);
+  const match = text?.match(/^#\d+\s*=\s*\w+\(([\s\S]*)\)\s*;?\s*$/);
+  if (!match) return null;
+  const args = splitTopLevelStepArguments(match[1]);
+  const raw = args?.[index];
+  return raw === undefined ? null : raw.trim();
+}
+
+/** Normalize a STEP string/enum token to a comparison key; `''` for unset/unreadable. */
+function normalizeLabel(raw: string | null): string {
+  if (!raw || raw === '$' || raw === '*') return '';
+  const quoted = raw.match(/^'([\s\S]*)'$/);
+  const inner = quoted ? quoted[1] : raw;
+  return inner.replace(/\./g, '').trim().toUpperCase();
+}
+
+/**
+ * The matching "kind" of one `IfcGeometricRepresentationSubContext`:
+ * `ContextIdentifier` when set (the conventional 'BODY'/'AXIS'/'FOOTPRINT'/…
+ * discriminator), else `TargetView` (its enum, e.g. 'MODEL_VIEW'), else `''`
+ * — a model's identifier-less subcontexts still bucket together so the
+ * common single-subcontext-per-model case keeps matching exactly as before.
+ */
+function subContextKind(dataStore: IfcDataStore, expressId: number): string {
+  const identifier = normalizeLabel(getStepAttr(dataStore, expressId, CONTEXT_IDENTIFIER_ATTR));
+  if (identifier) return identifier;
+  return normalizeLabel(getStepAttr(dataStore, expressId, TARGET_VIEW_ATTR));
+}
+
+/** Group `ids` (a model's subcontext express ids) by {@link subContextKind}. */
+export function groupSubContextsByKind(dataStore: IfcDataStore, ids: readonly number[]): Map<string, number[]> {
+  const map = new Map<string, number[]>();
+  for (const id of ids) {
+    const key = subContextKind(dataStore, id);
+    const bucket = map.get(key);
+    if (bucket) bucket.push(id); else map.set(key, [id]);
+  }
+  return map;
+}
+
+/**
+ * Plan this model's subcontext dedup against the primary model, kind by
+ * kind: a subcontext in `thisIds` is remapped+skipped only against an
+ * unclaimed primary-model subcontext of the SAME kind (never a differently
+ * ordered one of a different kind). A subcontext with no same-kind match in
+ * the primary model is left un-remapped — kept as its own (offset-only)
+ * entity, exactly like today's "no shared infrastructure of this type"
+ * fallback. Mutates `sharedRemap`/`skipEntityIds`.
+ */
+export function planSubContextUnify(
+  dataStore: IfcDataStore,
+  thisIds: readonly number[],
+  firstModelSubContextsByKind: ReadonlyMap<string, number[]>,
+  firstModelOffset: number,
+  sharedRemap: Map<number, number>,
+  skipEntityIds: Set<number>,
+): void {
+  const nextIndex = new Map<string, number>();
+  for (const id of thisIds) {
+    const key = subContextKind(dataStore, id);
+    const pool = firstModelSubContextsByKind.get(key);
+    if (!pool || pool.length === 0) continue;
+    const idx = nextIndex.get(key) ?? 0;
+    if (idx >= pool.length) continue; // every same-kind primary target already claimed
+    nextIndex.set(key, idx + 1);
+    sharedRemap.set(id, pool[idx] + firstModelOffset);
+    skipEntityIds.add(id);
+  }
+}
+
+/**
+ * Plan the whole shared-infrastructure dedup for one model — `MergedExporter`
+ * delegates its entire "remap and skip duplicate infrastructure" step here so
+ * the kind-vs-position distinction lives in one place. Every
+ * {@link SHARED_INFRASTRUCTURE_TYPES}-listed type is unified by position
+ * EXCEPT `IFCGEOMETRICREPRESENTATIONSUBCONTEXT`, which goes through
+ * {@link planSubContextUnify} instead (kind-matched). Mutates
+ * `sharedRemap`/`skipEntityIds`.
+ */
+export function planInfrastructureUnify(
+  dataStore: IfcDataStore,
+  modelInfra: ReadonlyMap<string, number[]>,
+  firstModelInfraMap: ReadonlyMap<string, number[]>,
+  firstModelSubContextsByKind: ReadonlyMap<string, number[]>,
+  firstModelOffset: number,
+  sharedRemap: Map<number, number>,
+  skipEntityIds: Set<number>,
+): void {
+  for (const [type, firstIds] of firstModelInfraMap) {
+    const thisIds = modelInfra.get(type);
+    if (!thisIds || firstIds.length === 0 || thisIds.length === 0) continue;
+    if (type === 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT') {
+      planSubContextUnify(dataStore, thisIds, firstModelSubContextsByKind, firstModelOffset, sharedRemap, skipEntityIds);
+      continue;
+    }
+    sharedRemap.set(thisIds[0], firstIds[0] + firstModelOffset);
+    skipEntityIds.add(thisIds[0]);
+  }
+}

--- a/packages/export/src/merged-subcontext.ts
+++ b/packages/export/src/merged-subcontext.ts
@@ -26,9 +26,8 @@
  * geometry silently vanishes), with no dangling reference to reveal it.
  *
  * `planSubContextUnify` fixes this by matching on the subcontext's *kind*
- * (its `ContextIdentifier`, e.g. 'Body'/'Axis' — falling back to
- * `TargetView` when the identifier is unset, and finally to positional
- * matching only within same-kind buckets) rather than on raw array position.
+ * (its `ContextIdentifier` *and* `TargetView`, plus `UserDefinedTargetView`
+ * where applicable) rather than on raw array position.
  */
 
 import type { IfcDataStore } from '@ifc-lite/parser';
@@ -39,6 +38,8 @@ import { splitTopLevelStepArguments } from './step-argument-parser.js';
 const CONTEXT_IDENTIFIER_ATTR = 0;
 /** 0-based attribute index of `IfcGeometricRepresentationSubContext.TargetView`. */
 const TARGET_VIEW_ATTR = 8;
+/** 0-based attribute index of `IfcGeometricRepresentationSubContext.UserDefinedTargetView`. */
+const USER_DEFINED_TARGET_VIEW_ATTR = 9;
 
 function decodeEntity(dataStore: IfcDataStore, expressId: number): string | null {
   const source = dataStore.source;
@@ -67,23 +68,26 @@ function normalizeLabel(raw: string | null): string {
 }
 
 /**
- * The matching "kind" of one `IfcGeometricRepresentationSubContext`:
- * `ContextIdentifier` when set (the conventional 'BODY'/'AXIS'/'FOOTPRINT'/…
- * discriminator), else `TargetView` (its enum, e.g. 'MODEL_VIEW'), else `''`
- * — a model's identifier-less subcontexts still bucket together so the
- * common single-subcontext-per-model case keeps matching exactly as before.
+ * The matching key of one `IfcGeometricRepresentationSubContext` combines its
+ * `ContextIdentifier` and `TargetView`: a Body representation for MODEL_VIEW
+ * is not interchangeable with one for PLAN_VIEW. `UserDefinedTargetView`
+ * distinguishes two USERDEFINED views. Empty pieces deliberately remain part
+ * of the key so identifier-less subcontexts still group by their view.
  */
-function subContextKind(dataStore: IfcDataStore, expressId: number): string {
+function subContextKey(dataStore: IfcDataStore, expressId: number): string {
   const identifier = normalizeLabel(getStepAttr(dataStore, expressId, CONTEXT_IDENTIFIER_ATTR));
-  if (identifier) return identifier;
-  return normalizeLabel(getStepAttr(dataStore, expressId, TARGET_VIEW_ATTR));
+  const targetView = normalizeLabel(getStepAttr(dataStore, expressId, TARGET_VIEW_ATTR));
+  const userDefinedTargetView = targetView === 'USERDEFINED'
+    ? normalizeLabel(getStepAttr(dataStore, expressId, USER_DEFINED_TARGET_VIEW_ATTR))
+    : '';
+  return `${identifier}\u0000${targetView}\u0000${userDefinedTargetView}`;
 }
 
-/** Group `ids` (a model's subcontext express ids) by {@link subContextKind}. */
-export function groupSubContextsByKind(dataStore: IfcDataStore, ids: readonly number[]): Map<string, number[]> {
+/** Group `ids` (a model's subcontext express ids) by {@link subContextKey}. */
+export function groupSubContextsByKey(dataStore: IfcDataStore, ids: readonly number[]): Map<string, number[]> {
   const map = new Map<string, number[]>();
   for (const id of ids) {
-    const key = subContextKind(dataStore, id);
+    const key = subContextKey(dataStore, id);
     const bucket = map.get(key);
     if (bucket) bucket.push(id); else map.set(key, [id]);
   }
@@ -91,10 +95,10 @@ export function groupSubContextsByKind(dataStore: IfcDataStore, ids: readonly nu
 }
 
 /**
- * Plan this model's subcontext dedup against the primary model, kind by
- * kind: a subcontext in `thisIds` is remapped+skipped only against an
- * unclaimed primary-model subcontext of the SAME kind (never a differently
- * ordered one of a different kind). A subcontext with no same-kind match in
+ * Plan this model's subcontext dedup against the primary model, key by key:
+ * a subcontext in `thisIds` is remapped+skipped only against an unclaimed
+ * primary-model subcontext with the SAME key (never a differently ordered one
+ * of a different kind or TargetView). A subcontext with no same-key match in
  * the primary model is left un-remapped — kept as its own (offset-only)
  * entity, exactly like today's "no shared infrastructure of this type"
  * fallback. Mutates `sharedRemap`/`skipEntityIds`.
@@ -102,15 +106,15 @@ export function groupSubContextsByKind(dataStore: IfcDataStore, ids: readonly nu
 export function planSubContextUnify(
   dataStore: IfcDataStore,
   thisIds: readonly number[],
-  firstModelSubContextsByKind: ReadonlyMap<string, number[]>,
+  firstModelSubContextsByKey: ReadonlyMap<string, number[]>,
   firstModelOffset: number,
   sharedRemap: Map<number, number>,
   skipEntityIds: Set<number>,
 ): void {
   const nextIndex = new Map<string, number>();
   for (const id of thisIds) {
-    const key = subContextKind(dataStore, id);
-    const pool = firstModelSubContextsByKind.get(key);
+    const key = subContextKey(dataStore, id);
+    const pool = firstModelSubContextsByKey.get(key);
     if (!pool || pool.length === 0) continue;
     const idx = nextIndex.get(key) ?? 0;
     if (idx >= pool.length) continue; // every same-kind primary target already claimed
@@ -126,14 +130,14 @@ export function planSubContextUnify(
  * the kind-vs-position distinction lives in one place. Every
  * {@link SHARED_INFRASTRUCTURE_TYPES}-listed type is unified by position
  * EXCEPT `IFCGEOMETRICREPRESENTATIONSUBCONTEXT`, which goes through
- * {@link planSubContextUnify} instead (kind-matched). Mutates
+ * {@link planSubContextUnify} instead (key-matched). Mutates
  * `sharedRemap`/`skipEntityIds`.
  */
 export function planInfrastructureUnify(
   dataStore: IfcDataStore,
   modelInfra: ReadonlyMap<string, number[]>,
   firstModelInfraMap: ReadonlyMap<string, number[]>,
-  firstModelSubContextsByKind: ReadonlyMap<string, number[]>,
+  firstModelSubContextsByKey: ReadonlyMap<string, number[]>,
   firstModelOffset: number,
   sharedRemap: Map<number, number>,
   skipEntityIds: Set<number>,
@@ -142,7 +146,7 @@ export function planInfrastructureUnify(
     const thisIds = modelInfra.get(type);
     if (!thisIds || firstIds.length === 0 || thisIds.length === 0) continue;
     if (type === 'IFCGEOMETRICREPRESENTATIONSUBCONTEXT') {
-      planSubContextUnify(dataStore, thisIds, firstModelSubContextsByKind, firstModelOffset, sharedRemap, skipEntityIds);
+      planSubContextUnify(dataStore, thisIds, firstModelSubContextsByKey, firstModelOffset, sharedRemap, skipEntityIds);
       continue;
     }
     sharedRemap.set(thisIds[0], firstIds[0] + firstModelOffset);


### PR DESCRIPTION
## Invariant violated

Merge invariant lens pass 3, item 1 (reference integrity after singleton collapse): `IfcShapeRepresentation.ContextOfItems` must point at a SURVIVING sub-context of the right kind ('Body'/'Axis'), not at the wrong kind.

`MergedExporter` deduplicates each unit-compatible model's shared infrastructure (`IfcUnitAssignment`, `IfcGeometricRepresentationContext`, `IfcGeometricRepresentationSubContext`) onto the primary model's instance. For subcontexts, the old code took the two models' subcontext-id lists **positionally**: `thisIds[0]` (this model's first subcontext, in whatever order `entityIndex.byType` happened to return them) was unified onto `firstIds[0]` (the primary model's first subcontext) — with no check that the two subcontexts are the same kind.

A model normally declares more than one subcontext (`'Body'` for solid geometry, `'Axis'` for centreline geometry, sometimes `'FootPrint'`/`'Box'`), and nothing guarantees two different authoring tools emit them in the same order. A positional match can therefore unify this model's `'Body'` subcontext onto the primary model's `'Axis'` subcontext (or vice versa): every `IfcShapeRepresentation.ContextOfItems` that pointed at the dropped subcontext now resolves, after the remap, to a surviving one of the wrong kind. Many viewers filter representations by kind, so the geometry silently vanishes from the 3D view — a wrong result no dangling-reference check catches (the reference still resolves, just to the wrong entity).

This is a distinct defect from open PR #3550 (partial `IfcRelAggregates` redundancy) and PR #3551 (context unification not checking `WorldCoordinateSystem`) — neither touches subcontext *kind* matching, and this fix does not depend on either.

## Reproduction

RED test added: `sub-context kind matching > keeps a unified IfcShapeRepresentation's ContextOfItems on a same-kind subcontext, never a differently-ordered one` (`packages/export/src/merged-exporter.test.ts`). Two same-length-unit models whose subcontexts are declared in reversed order — model1: `[Axis(#4), Body(#5)]`, model2: `[Body(#4), Axis(#5)]`. Model2's `IfcShapeRepresentation` names its own `#4` (`'Body'`) as `ContextOfItems`. Before the fix, the positional match unified model2's `#4` onto model1's `#4` (`'Axis'`) — after the merge, the shape representation's `ContextOfItems` resolves to a subcontext whose `ContextIdentifier` is `'Axis'`, not the `'Body'` it named (`expected 'Axis' to be 'Body'`).

## Fix

New sibling module `packages/export/src/merged-subcontext.ts` (kept out of `merged-exporter.ts`, which sat at exactly its 1667-line size-check budget with zero headroom):

- `groupSubContextsByKind` buckets a model's subcontext ids by kind: `ContextIdentifier` when set (the conventional `'BODY'`/`'AXIS'`/… discriminator), falling back to `TargetView`, else `''` — so a model's identifier-less subcontexts still bucket together, keeping the common single-subcontext-per-model case matching exactly as before.
- `planSubContextUnify` matches this model's subcontexts against the primary model's, kind by kind, only remapping+skipping an unclaimed same-kind primary target. A subcontext with no same-kind match in the primary model keeps its own (offset-only) copy instead of being merged onto an unrelated one.
- `planInfrastructureUnify` is the plan step `MergedExporter.planModel` now delegates its entire "remap and skip duplicate infrastructure" loop to: units and the top-level context still unify by position (unchanged — there is normally exactly one of each), subcontexts go through `planSubContextUnify`. Consolidating the whole loop into one sibling-module call nets `merged-exporter.ts` **-2 lines** (1665/1667) despite the new field and import.

## Verification

- `pnpm --filter @ifc-lite/export... build` then `pnpm exec tsc --noEmit` in `packages/export`: clean.
- `pnpm exec vitest run` in `packages/export`: 78 files, 1034 passed, 0 regressions (including the new RED-turned-GREEN test and its control).
- `pnpm exec tsc --noEmit --noUnusedLocals` in `packages/export`: clean.
- `node scripts/check-module-size.mjs`: `check-module-size: OK (2031 files measured, 306 allowlisted, 0 new over 400)` — `merged-exporter.ts` is 1665/1667 lines; `merged-subcontext.ts` is a new 151-line file, well under the 400-line split threshold.
- `node scripts/check-test-wiring.mjs`: OK.
- `pnpm run check:vitest-timeout-audit`: unchanged summary shape, no new unprotected/unknown.
- No public API surface change: `merged-subcontext.ts` is not re-exported from `packages/export/src/index.ts`; changeset added (`patch`, `@ifc-lite/export`).

## Control (invariant that already held)

`still dedups same-kind subcontexts when both models order them identically` — two models whose subcontexts happen to share the SAME order still dedup down to one surviving subcontext per kind, exactly as before (this only narrows the *matching rule*, it doesn't stop the existing dedup from working in the common case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

## Follow-up (review)

**Q: what happens to a second-model subcontext kind with no counterpart in the primary (e.g. the second model has 'FootPrint', the primary doesn't)?** It survives as its own subcontext, offset-only, with every reference to it still resolving correctly — `planSubContextUnify`'s `continue` on a kind with no matching pool in the primary model leaves the entity out of both `sharedRemap` and `skipEntityIds`, the same path the pre-existing "no shared infrastructure of this type" fallback already took for units/contexts, so no code change was needed here; a named test (`sub-context kind matching > keeps a no-counterpart subcontext kind ('FootPrint') as its own entity, with its reference intact`) now pins it: a second model with a 'FootPrint' subcontext the primary lacks produces a merged output containing exactly one 'FootPrint' subcontext, and the `IfcShapeRepresentation` naming it still resolves to that surviving entity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merged IFC exports by matching geometric representation subcontexts by kind instead of list position.
  * Prevented mismatched contexts from causing geometry to disappear in viewers.
  * Preserved separate, unmatched subcontexts and their geometry references.
  * Ensured compatible subcontexts are correctly deduplicated when merging models.

* **Tests**
  * Added regression coverage for reordered, duplicate, and unmatched representation subcontexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->