### PR TITLE
fix(parser): resolve material-layer thickness by the entity's own project in a federated merge

### DIFF
--- a/.changeset/federated-material-layer-thickness-unit.md
+++ b/.changeset/federated-material-layer-thickness-unit.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/parser': minor
+---
+
+Fix `extractMaterialsOnDemand`/`extractAllMaterialsOnDemand` scaling an `IfcMaterialLayer.LayerThickness` by the wrong project's length unit in a multi-`IfcProject` file — the shape `MergedExporter`'s default `unitReconciliation: 'auto'` produces when it federates a model whose length unit differs from the first model's (kept in its own `IfcProject`/`IfcUnitAssignment` rather than rescaled, per that module's docs).
+
+The thickness scale came from `store.lengthUnitScale`, which `extractLengthUnitScale` resolves for the file's FIRST `IfcProject` only — correct for an ordinary single-project file, wrong for a layer belonging to a LATER project. A federated millimetre model's 300&nbsp;mm layer, read back through a merged file whose first project is metres, came back as a fabricated "300 m" one instead of 0.3 m.
+
+Adds `resolveEntityLengthUnitScale(source, entityIndex, relationships, expressId)`: for the common single-project file it is identical to `extractLengthUnitScale` (no behaviour change); for a multi-project file it walks the entity's real spatial containment (`IfcRelContainedInSpatialStructure` / `IfcRelAggregates`, and `IfcRelDefinesByType` for a type-level material assignment) up to its OWN owning `IfcProject` and answers for that project's declared unit, rather than guessing from express-id ordering.

--- a/packages/export/src/merged-exporter.federated-material-unit.test.ts
+++ b/packages/export/src/merged-exporter.federated-material-unit.test.ts
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Round-trip invariant: a merged (federated) STEP file's material-layer
+ * thickness reads back in the SAME value as reading each source model
+ * independently, GlobalId-matched — `parse(merge(A,B))` must agree with
+ * `parse(A) ∪ parse(B)`.
+ *
+ * `MergedExporter`'s default `unitReconciliation: 'auto'` FEDERATES a model
+ * whose length unit differs from the first model's: it keeps its own
+ * `IfcProject`/`IfcUnitAssignment` rather than being rescaled (see that
+ * module's docs, "the mis-scale bug, issue #1332"), so the merged STEP text
+ * for the second model's `IfcMaterialLayer.LayerThickness` is the correct,
+ * untouched raw literal in ITS OWN unit.
+ *
+ * The reader side had a matching bug: `extractMaterialsOnDemand` scaled every
+ * layer's raw thickness by `store.lengthUnitScale`, computed once per store by
+ * `extractLengthUnitScale` from the FIRST `IfcProject` found — correct for an
+ * ordinary single-project file, but wrong for a federated entity belonging to
+ * a LATER project. A 300&nbsp;mm layer in a millimetre-federated model read
+ * back as a fabricated 300&nbsp;m one (raw 300 × the first project's
+ * metre-scale 1.0).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import { IfcParser, extractMaterialsOnDemand, type IfcDataStore } from '@ifc-lite/parser';
+import { MergedExporter } from './merged-exporter.js';
+
+const MODELS_DIR = resolve(__dirname, '../../../tests/models');
+
+// Model A: inches (IfcConversionBasedUnit 'inch', 0.0254 m — #28/#27/#26),
+// IfcSlab layer thickness raw literal 6. (see #310/#292 in the source
+// fixture). Model B: millimetres, IfcWall layer thickness raw literal 300.
+// (see #63/#45). Two DIFFERENT non-metre units on purpose, so a bug that
+// merely swapped which of two units gets used could not pass by accident.
+// Both small, real-world fixtures fetched via `pnpm fixtures` (AGENTS.md);
+// skip cleanly when absent.
+const FILE_A = 'issues/856_wall_decode_failed.ifc';
+const FILE_B = 'buildingsmart/wall-with-opening-and-window.ifc';
+const GUID_A_SLAB = '20WrgxqpbDtferON_k1P2X'; // IfcSlab, model A (metres)
+const GUID_B_WALL = '3ZYW59sxj8lei475l7EhLU'; // IfcWall, model B (millimetres)
+
+const FIXTURES_AVAILABLE = [FILE_A, FILE_B].every((f) => existsSync(resolve(MODELS_DIR, f)));
+
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+async function parseFixture(name: string): Promise<IfcDataStore> {
+  const parser = new IfcParser();
+  return parser.parseColumnar(toArrayBuffer(readFileSync(resolve(MODELS_DIR, name))));
+}
+
+/** Find an entity's express id by its GlobalId, decoding straight from source
+ *  (mirrors how `MergedExporter` itself reads a rooted entity's leading
+ *  attribute — no dependency on any cache the fix under test might affect). */
+function findIdByGuid(store: IfcDataStore, guid: string): number {
+  for (const [id, ref] of store.entityIndex.byId) {
+    const text = store.source!.decodeUtf8(ref.byteOffset, ref.byteOffset + ref.byteLength);
+    if (text.includes(`'${guid}'`)) return id;
+  }
+  throw new Error(`GlobalId ${guid} not found`);
+}
+
+describe.skipIf(!FIXTURES_AVAILABLE)('MergedExporter federated material-layer unit scale', () => {
+  it('keeps a federated (different-unit) model\'s material-layer thickness correct after merge + re-parse', async () => {
+    const storeA = await parseFixture(FILE_A);
+    const storeB = await parseFixture(FILE_B);
+
+    // Sanity: the two fixtures really do declare different length units —
+    // this is the precondition for MergedExporter to federate rather than
+    // fold model B into a single unified project.
+    expect(storeA.lengthUnitScale).toBeCloseTo(0.0254, 9); // inches
+    expect(storeB.lengthUnitScale).toBe(0.001); // millimetres
+
+    // Control: each model read independently — the values this test's merged
+    // read must agree with, GlobalId-matched.
+    const slabIdA = findIdByGuid(storeA, GUID_A_SLAB);
+    const wallIdB = findIdByGuid(storeB, GUID_B_WALL);
+    const expectedSlabThicknessM = extractMaterialsOnDemand(storeA, slabIdA)?.layers?.[0]?.thickness;
+    const expectedWallThicknessM = extractMaterialsOnDemand(storeB, wallIdB)?.layers?.[0]?.thickness;
+    expect(expectedSlabThicknessM).toBeCloseTo(6 * 0.0254, 9);
+    expect(expectedWallThicknessM).toBeCloseTo(0.3, 9);
+
+    const exporter = new MergedExporter([
+      { id: 'A', name: 'ModelA', dataStore: storeA },
+      { id: 'B', name: 'ModelB', dataStore: storeB },
+    ]);
+    // Default unitReconciliation: 'auto' — model B federates (kept in its own
+    // IfcProject/IfcUnitAssignment) since its unit differs from model A's.
+    const result = exporter.export({ schema: 'IFC4' });
+    expect(result.stats.federatedModelCount).toBeGreaterThan(0);
+
+    const merged = await parseColumnarFromBytes(result.content);
+
+    const slabIdMerged = findIdByGuid(merged, GUID_A_SLAB);
+    const wallIdMerged = findIdByGuid(merged, GUID_B_WALL);
+
+    // Control: model A's own entity is unaffected (first-project fast path —
+    // already correct before this fix, must stay correct after).
+    const slabThicknessMerged = extractMaterialsOnDemand(merged, slabIdMerged)?.layers?.[0]?.thickness;
+    expect(slabThicknessMerged).toBeCloseTo(expectedSlabThicknessM!, 9);
+
+    // The invariant under test: model B's federated (millimetre) entity must
+    // read back at the SAME value as reading model B alone (0.3 m), not the
+    // fabricated 300 a first-project-only unit scale corrupts it to.
+    const wallThicknessMerged = extractMaterialsOnDemand(merged, wallIdMerged)?.layers?.[0]?.thickness;
+    expect(wallThicknessMerged).toBeCloseTo(expectedWallThicknessM!, 9);
+  });
+});
+
+async function parseColumnarFromBytes(content: Uint8Array): Promise<IfcDataStore> {
+  const parser = new IfcParser();
+  const ab = content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength) as ArrayBuffer;
+  return parser.parseColumnar(ab);
+}

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -56,7 +56,7 @@ export { PropertyExtractor } from './property-extractor.js';
 export { QuantityExtractor } from './quantity-extractor.js';
 export { RelationshipExtractor } from './relationship-extractor.js';
 export { SpatialHierarchyBuilder } from './spatial-hierarchy-builder.js';
-export { extractLengthUnitScale } from './unit-extractor.js';
+export { extractLengthUnitScale, resolveEntityLengthUnitScale } from './unit-extractor.js';
 export {
   extractProjectUnits,
   measureUnit,

--- a/packages/parser/src/material-resolver.ts
+++ b/packages/parser/src/material-resolver.ts
@@ -12,6 +12,7 @@ import { EntityExtractor } from './entity-extractor.js';
 import { RelationshipType } from '@ifc-lite/data';
 import type { IfcDataStore } from './columnar-parser.js';
 import { isIfcTypeLikeEntity } from './columnar-parser-indexes.js';
+import { resolveEntityLengthUnitScale } from './unit-extractor.js';
 
 export interface MaterialInfo {
     type: 'Material' | 'MaterialLayerSet' | 'MaterialProfileSet' | 'MaterialConstituentSet' | 'MaterialList';
@@ -136,7 +137,7 @@ export function extractAllMaterialsOnDemand(
     const extractor = new EntityExtractor(store.source);
     const out: MaterialInfo[] = [];
     for (const defId of defIds) {
-        const info = resolveMaterial(store, extractor, defId, new Set());
+        const info = resolveMaterial(store, extractor, defId, new Set(), entityId);
         if (info) out.push(info);
     }
     return out;
@@ -160,18 +161,19 @@ export function extractMaterialsOnDemand(
     if (!store.source?.length) return null;
 
     const extractor = new EntityExtractor(store.source);
-    return resolveMaterial(store, extractor, materialId, new Set());
+    return resolveMaterial(store, extractor, materialId, new Set(), entityId);
 }
 
 /**
- * Resolve a material entity by ID, handling all IFC material types.
- * Uses visited set to prevent infinite recursion on cyclic *Usage references.
+ * Resolve a material entity by ID, handling all IFC material types. `visited`
+ * guards cyclic *Usage references; `originEntityId` (the calling element/type)
+ * lets a layer's thickness resolve its own project's unit scale below.
  */
 function resolveMaterial(
     store: IfcDataStore,
     extractor: EntityExtractor,
     materialId: number,
-    visited: Set<number> = new Set()
+    visited: Set<number> = new Set(), originEntityId?: number
 ): MaterialInfo | null {
     if (visited.has(materialId)) return null;
     visited.add(materialId);
@@ -223,14 +225,12 @@ function resolveMaterial(
                     }
                 }
 
-                // Convert raw IFC value to metres so downstream UI doesn't
-                // have to guess. Files with LENGTHUNIT=MILLI (e.g. Dutch
-                // Revit / ArchiCAD exports — schependomlaan.ifc) store
-                // 60 for a 60 mm prefab slab; without this scale the
-                // properties panel rendered "60.0 m" because
-                // `formatThickness` assumes its input is metres.
+                // Convert raw IFC value to metres (a 60 mm slab must not read
+                // "60.0 m"). `store.lengthUnitScale` answers for the file's
+                // FIRST IfcProject only, wrong for a MergedExporter federated
+                // layer in a LATER project — resolve per `originEntityId`.
                 const rawThickness = typeof la[1] === 'number' ? la[1] : undefined;
-                const scale = store.lengthUnitScale ?? 1;
+                const scale = originEntityId !== undefined ? resolveEntityLengthUnitScale(store.source, store.entityIndex, store.relationships, originEntityId) : (store.lengthUnitScale ?? 1);
                 const thickness = rawThickness !== undefined ? rawThickness * scale : undefined;
                 layers.push({
                     materialName,
@@ -367,7 +367,7 @@ function resolveMaterial(
             // IfcMaterialLayerSetUsage: [ForLayerSet, LayerSetDirection, DirectionSense, OffsetFromReferenceLine, ...]
             const layerSetId = typeof attrs[0] === 'number' ? attrs[0] : undefined;
             if (layerSetId) {
-                return resolveMaterial(store, extractor, layerSetId, visited);
+                return resolveMaterial(store, extractor, layerSetId, visited, originEntityId);
             }
             return null;
         }
@@ -376,7 +376,7 @@ function resolveMaterial(
             // IfcMaterialProfileSetUsage: [ForProfileSet, ...]
             const profileSetId = typeof attrs[0] === 'number' ? attrs[0] : undefined;
             if (profileSetId) {
-                return resolveMaterial(store, extractor, profileSetId, visited);
+                return resolveMaterial(store, extractor, profileSetId, visited, originEntityId);
             }
             return null;
         }

--- a/packages/parser/src/unit-extractor.ts
+++ b/packages/parser/src/unit-extractor.ts
@@ -12,6 +12,7 @@
 import type { EntityRef } from './types.js';
 import { EntityExtractor } from './entity-extractor.js';
 import type { IfcSourceBytes } from './source-bytes.js';
+import { RelationshipType } from '@ifc-lite/data';
 
 /**
  * SI Prefix multipliers, keyed by the members of the `IfcSIPrefix` EXPRESS
@@ -114,8 +115,6 @@ export function extractLengthUnitScale(
   source: Uint8Array | IfcSourceBytes,
   entityIndex: { byId: { get(expressId: number): EntityRef | undefined }; byType: Map<string, number[]> }
 ): number {
-  const extractor = new EntityExtractor(source);
-
   // Find IFCPROJECT
   const projectIds = entityIndex.byType.get('IFCPROJECT') || [];
   if (projectIds.length === 0) {
@@ -123,7 +122,24 @@ export function extractLengthUnitScale(
     return 1.0;
   }
 
-  const projectRef = entityIndex.byId.get(projectIds[0]);
+  return extractLengthUnitScaleForProjectId(projectIds[0], source, entityIndex);
+}
+
+/**
+ * Same resolution as {@link extractLengthUnitScale}, but for an EXPLICIT
+ * `IFCPROJECT` id rather than always the first one found. Factored out so
+ * {@link resolveEntityLengthUnitScale} can resolve the scale of a specific
+ * project in a multi-project file (a {@link MergedExporter} federated
+ * output — see that module) without duplicating the unit-chain walk.
+ */
+function extractLengthUnitScaleForProjectId(
+  projectId: number,
+  source: Uint8Array | IfcSourceBytes,
+  entityIndex: { byId: { get(expressId: number): EntityRef | undefined }; byType: Map<string, number[]> }
+): number {
+  const extractor = new EntityExtractor(source);
+
+  const projectRef = entityIndex.byId.get(projectId);
   if (!projectRef) {
     warnUnknownUnit(entityIndex, 'IFCPROJECT reference could not be resolved');
     return 1.0;
@@ -303,4 +319,82 @@ export function extractLengthUnitScale(
   // No length unit found, default to meters
   warnUnknownUnit(entityIndex, 'No LENGTHUNIT found in IFCUNITASSIGNMENT');
   return 1.0;
+}
+
+/** Minimal relationship-graph surface {@link resolveEntityLengthUnitScale} needs. */
+interface RelatedLookup {
+  getRelated(entityId: number, relType: RelationshipType, direction: 'forward' | 'inverse'): number[];
+}
+
+/** Bound on the spatial-containment walk in {@link resolveEntityLengthUnitScale}
+ *  (element → storey → building → site → project is 4 hops; double it for an
+ *  unusually deep IfcSpatialZone/IfcSpace nesting, never for a real cycle). */
+const MAX_PROJECT_WALK_HOPS = 8;
+
+/**
+ * Resolve the length unit scale that applies to ONE entity, correctly for a
+ * multi-`IfcProject` file (a {@link MergedExporter} `unitReconciliation: 'auto'`
+ * federated export: a model whose length unit differs from the first model's
+ * keeps its own `IfcProject`/`IfcUnitAssignment` rather than being rescaled —
+ * see that module's docs).
+ *
+ * {@link extractLengthUnitScale} (and the `dataStore.lengthUnitScale` it feeds)
+ * answers for the FIRST `IfcProject` only. That is exactly right for the
+ * overwhelmingly common single-project file (this function's fast path below
+ * returns the identical value), but silently wrong for a federated entity that
+ * belongs to a LATER project: e.g. a material layer's `LayerThickness` is a
+ * raw literal in ITS OWN project's unit, and scaling it by the first project's
+ * factor corrupts the value by whatever ratio separates the two units (a
+ * millimetre federated model read back with the metres factor turns a 300 mm
+ * layer into a fabricated "300 m" one).
+ *
+ * Multi-project resolution walks the entity's spatial containment UP the real
+ * `IfcRelContainedInSpatialStructure` / `IfcRelAggregates` chain (never an
+ * id-ordering guess, which a federated file's per-model id-contiguous blocks
+ * would tempt but not guarantee) to find its owning `IfcProject`, then answers
+ * for THAT project. Falls back to the first project's scale when the entity
+ * (a resource-level entity like `IfcMaterial`, unreachable from any element)
+ * has no discoverable containment path, or the walk does not land on a project
+ * within {@link MAX_PROJECT_WALK_HOPS} — the same safe-miss direction
+ * {@link extractLengthUnitScale} already documents for every other ambiguous
+ * case.
+ */
+export function resolveEntityLengthUnitScale(
+  source: Uint8Array | IfcSourceBytes,
+  entityIndex: { byId: { get(expressId: number): EntityRef | undefined }; byType: Map<string, number[]> },
+  relationships: RelatedLookup,
+  expressId: number,
+): number {
+  const projectIds = entityIndex.byType.get('IFCPROJECT') || [];
+  if (projectIds.length <= 1) {
+    // Fast path, and the common case: identical to extractLengthUnitScale.
+    return extractLengthUnitScale(source, entityIndex);
+  }
+
+  const projectIdSet = new Set(projectIds);
+  let current = expressId;
+  for (let hop = 0; hop < MAX_PROJECT_WALK_HOPS; hop++) {
+    if (projectIdSet.has(current)) {
+      return extractLengthUnitScaleForProjectId(current, source, entityIndex);
+    }
+    // An element's container (IfcRelContainedInSpatialStructure, inverse), a
+    // spatial node's decomposition parent (IfcRelAggregates, inverse), or —
+    // for a TYPE object (an `IfcWallType` carries its own material/pset
+    // assignments but is never itself spatially contained) — one of the
+    // occurrences it defines (IfcRelDefinesByType, forward: RelatingType →
+    // RelatedObjects), so the walk continues from a concrete occurrence.
+    // Containment first since it is the one-hop case for the common "element
+    // straight into its storey" shape.
+    const container = relationships.getRelated(current, RelationshipType.ContainsElements, 'inverse');
+    const parent = container.length > 0 ? container
+      : relationships.getRelated(current, RelationshipType.Aggregates, 'inverse');
+    const next = parent.length > 0 ? parent
+      : relationships.getRelated(current, RelationshipType.DefinesByType, 'forward');
+    if (next.length === 0) break;
+    current = next[0];
+  }
+
+  // No discoverable containment path to any project — fall back to the first
+  // project's scale (the pre-existing, documented-safe default).
+  return extractLengthUnitScale(source, entityIndex);
 }

--- a/scripts/api-surface.json
+++ b/scripts/api-surface.json
@@ -3695,6 +3695,7 @@
     "parseStepValue: function",
     "ref: function",
     "resolveAllMaterialDefIds: function",
+    "resolveEntityLengthUnitScale: function",
     "resolveEntityNameAlias: function",
     "resolveMaterialDefId: function",
     "scanIfcEntities: function",


### PR DESCRIPTION
## Summary

Merge round-trip completeness audit (pass 5): `parse(merge(A,B))` vs `parse(A) ∪ parse(B)`, GlobalId-matched, same-schema inputs. Every category checked came back clean except one: `IfcMaterialLayer.LayerThickness` reads back at the wrong scale for a federated (different-unit) model.

**Mechanism.** `MergedExporter`'s default `unitReconciliation: 'auto'` federates a model whose length unit differs from the first model's — it keeps its own `IfcProject`/`IfcUnitAssignment` rather than rescaling raw values (intentional, see the module's own docs on issue #1332). Reading the merged file back, `extractMaterialsOnDemand` scaled every layer's raw thickness by `store.lengthUnitScale`, which `extractLengthUnitScale` resolves from the file's **first** `IfcProject` only. That's correct for an ordinary single-project file, but wrong for a layer belonging to a **later**, differently-unit'd federated project: a 300 mm layer in a millimetre-federated model read back as a fabricated "300 m" one instead of 0.3 m — quietly wrong, not absent.

The merged STEP **file** is not at fault (its raw bytes and per-project unit declarations are correct); this is a reader-side gap, reachable in practice only through a federated multi-project merge (an ordinary IFC file has at most one `IfcProject` by EXPRESS invariant).

**Fix.** Adds `resolveEntityLengthUnitScale(source, entityIndex, relationships, expressId)` in `@ifc-lite/parser`: identical to `extractLengthUnitScale` for the overwhelmingly common single-project file (fast path, zero behaviour change), and for a multi-project file walks the entity's real spatial containment (`IfcRelContainedInSpatialStructure` / `IfcRelAggregates`, and `IfcRelDefinesByType` for a type-level material assignment, e.g. `IfcWallType`) up to its own owning `IfcProject` — never an express-id-ordering guess. `extractMaterialsOnDemand`/`extractAllMaterialsOnDemand` now thread the calling element/type id through to the material-layer-thickness scale.

## Category table (input union → merged, GlobalId-matched)

Checked with real fixtures (`tests/models/ara3d/AC20-FZK-Haus.ifc` + three different second models to exercise different categories) merged via `MergedExporter`, re-parsed, and compared GlobalId-by-GlobalId against each source parsed independently.

| Category | Verdict |
|---|---|
| `IfcOpeningElement` / `IfcRelVoidsElement` / `IfcRelFillsElement` | round-trips (17+249=266 openings, 3 fixture pairs, all present) |
| `IfcWallType` + `IfcRelDefinesByType` (occurrence and type-level psets) | round-trips (up to 1057 `IfcRelDefinesByType` in one pair) |
| `IfcGroup` / `IfcSystem` / `IfcZone` + `IfcRelAssignsToGroup` | round-trips (240 `IfcSystem`/`IfcRelAssignsToGroup` in one pair) |
| `IfcGrid` / `IfcGridAxis` | round-trips |
| `IfcAnnotation` | round-trips |
| Per-entity pset/qset signature (name + property/quantity names) | round-trips — exhaustive GlobalId-matched sweep over 1307, 64996, and 118 entities across three merged pairs, zero mismatches |
| `IfcRelAssociatesMaterial` / layer-set chains — **thickness value** | **was corrupted** for a federated (different-unit) model; fixed here |
| `IfcRelAssociatesClassification` | round-trips |
| Storey unification (`by-elevation`, forced) interacting with openings/types/groups | round-trips — no drop-by-unwalked-inverse |

Also verified with `mergeStoreys: 'by-elevation'` + `mergeSites/mergeBuildings: 'single'` forced to actually exercise spatial-entity unification (the classic drop-by-unwalked-inverse risk zone) against the same categories — clean.

## RED → GREEN

`packages/export/src/merged-exporter.federated-material-unit.test.ts` — merges two small real fixtures with genuinely different, non-metre units (inches and millimetres, so a bug that merely swapped which unit applies couldn't pass by accident), re-parses the merged output, and asserts the federated model's layer thickness matches reading it standalone.

Verified RED on unmodified `main` (stashed the fix, rebuilt, reran): `expected 0.3 to be close to 0.3` → **got `7.62`** (300 mm raw × the first project's inch scale 0.0254). Restoring the fix returns the assertion to green. A control assertion in the same test (the first/primary model's own entity) passed both before and after — the fast path was never broken.

## Test plan

- [x] `node scripts/check-module-size.mjs` → `check-module-size: OK (2030 files measured, 306 allowlisted, 0 new over 400)`
- [x] `pnpm run check:vitest-timeout-audit` → exit 0, no new unprotected/config-unknown tests; no regex literals with parens in the new test file
- [x] `node scripts/check-test-wiring.mjs` → OK (48 packages, 49 gate scripts)
- [x] `node scripts/check-unused-locals.mjs` (foreground, 600s timeout) → exits 1 only for the pre-existing "does not compile standalone" package list (unrelated to this change); confirmed `pnpm exec tsc --noEmit --noUnusedLocals` clean in `packages/export`
- [x] `pnpm exec tsc --noEmit` (repo-wide `pnpm typecheck`) → 87/87 tasks successful
- [x] `packages/parser` tests: 85 files / 952 tests passed
- [x] `packages/export` tests: 81 files / 1063 tests passed (including the new RED→GREEN test)
- [x] `scripts/api-surface.json` updated (`pnpm api-surface:update`) for the new `@ifc-lite/parser` export `resolveEntityLengthUnitScale`
- [x] Changeset added: `@ifc-lite/parser` minor (bug fix + new public export)

Note: the fix lives in `@ifc-lite/parser` (`unit-extractor.ts`, `material-resolver.ts`), not `@ifc-lite/export` — the merged STEP file `MergedExporter` writes is correct; the defect is in how the standard on-demand extractors read a multi-project file back. `merged-exporter.ts` itself is untouched (still 1667/1667; module-size allowlist untouched). No dependency on/overlap with #3550, #3551, #3552, or #3553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436