### PR TITLE
fix(clash): stop a NaN-vertexed triangle from poisoning contact-BVH siblings

### DIFF
--- a/.changeset/fix-contact-bvh-nan-poison.md
+++ b/.changeset/fix-contact-bvh-nan-poison.md
@@ -1,0 +1,5 @@
+---
+"@ifc-lite/clash": patch
+---
+
+Fix `unionAabb` (`contact/aabb.ts`) to fold bounds with NaN-safe comparisons instead of `Math.min`/`Math.max`. `Bvh.build` (`contact/bvh.ts`) folds `unionAabb` bottom-up over every ancestor of a leaf, so a single degenerate (NaN-vertexed) triangle — e.g. from corrupt mesh geometry — poisoned the aggregate bounds of every node above it, up to and including the tree root. `queryMeshCross` then treated the poisoned bounds as "no overlap" and pruned the whole subtree, silently dropping every other, valid triangle from contact-interface clustering (`contactClusters`) and minimum-distance queries (`minDistanceBetweenMeshes`). A NaN triangle is now simply excluded from the aggregate rather than poisoning it, matching `aabbFromPositions` in the same file and `compute_bounds` in `rust/clash/src/bvh.rs`.

--- a/packages/clash/src/contact/aabb.test.ts
+++ b/packages/clash/src/contact/aabb.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { contains, intersects, longestAxis } from "./aabb.js";
+import { contains, intersects, longestAxis, unionAabb } from "./aabb.js";
 import type { AABB } from "./types.js";
 
 describe("intersects() — closed-interval face touch (aabb.ts:16)", () => {
@@ -44,5 +44,24 @@ describe("longestAxis() — tie-break order (aabb.ts:91)", () => {
     // to the y/z comparison and return 1 instead.
     const a: AABB = { min: [0, 0, 0], max: [4, 4, 1] };
     expect(longestAxis(a)).toBe(0);
+  });
+});
+
+describe("unionAabb() — a NaN operand does not poison the other box (aabb.ts:26)", () => {
+  it("returns the valid box unchanged when unioned with a fully-NaN box", () => {
+    // `Math.min`/`Math.max` propagate NaN through any operand; `Bvh.build`
+    // (bvh.ts) folds `unionAabb` over every ancestor, so a `Math.min`-based
+    // union would NaN the aggregate bounds of every node above a single
+    // degenerate triangle, pruning valid siblings out of every later query.
+    const valid: AABB = { min: [1, 2, 3], max: [4, 5, 6] };
+    const nan: AABB = { min: [NaN, NaN, NaN], max: [NaN, NaN, NaN] };
+    expect(unionAabb(valid, nan)).toEqual(valid);
+    expect(unionAabb(nan, valid)).toEqual(valid);
+  });
+
+  it("is NaN-safe per axis, not only for a wholly-NaN box", () => {
+    const a: AABB = { min: [NaN, 2, 3], max: [4, NaN, 6] };
+    const b: AABB = { min: [1, 0, NaN], max: [NaN, 5, 9] };
+    expect(unionAabb(a, b)).toEqual({ min: [1, 0, 3], max: [4, 5, 9] });
   });
 });

--- a/packages/clash/src/contact/aabb.ts
+++ b/packages/clash/src/contact/aabb.ts
@@ -22,12 +22,48 @@ export function intersects(a: AABB, b: AABB): boolean {
   );
 }
 
-/** Smallest AABB containing both inputs. */
+/**
+ * Smallest AABB containing both inputs.
+ *
+ * Per-axis, NaN-safe (`<`/`>`) rather than `Math.min`/`Math.max`: a `Math.min`
+ * with either operand NaN returns NaN, and `Bvh.build` (`bvh.ts`) folds this
+ * over every ancestor on the way up, so ONE degenerate/NaN triangle (a corrupt
+ * mesh vertex) would NaN the aggregate bounds of every node containing it —
+ * including the tree root, since the very first fold starts from `EMPTY_AABB`.
+ * `Bvh.queryAABB`/`crossNode` (`mesh-bvh.ts`) then treat a NaN bound as "no
+ * overlap" and prune the node, silently dropping every OTHER, perfectly valid
+ * triangle in that subtree from contact clustering and min-distance queries —
+ * up to and including the whole mesh, when the poisoned node is the root. A
+ * `<`/`>` comparison instead leaves the non-NaN operand untouched, so a NaN
+ * triangle is simply excluded from the aggregate rather than poisoning it
+ * (matches `aabbFromPositions` in this same file, and `compute_bounds` in
+ * `rust/clash/src/bvh.rs`).
+ */
 export function unionAabb(a: AABB, b: AABB): AABB {
   return {
-    min: [Math.min(a.min[0], b.min[0]), Math.min(a.min[1], b.min[1]), Math.min(a.min[2], b.min[2])],
-    max: [Math.max(a.max[0], b.max[0]), Math.max(a.max[1], b.max[1]), Math.max(a.max[2], b.max[2])],
+    min: [
+      nanSafeMin(a.min[0], b.min[0]),
+      nanSafeMin(a.min[1], b.min[1]),
+      nanSafeMin(a.min[2], b.min[2]),
+    ],
+    max: [
+      nanSafeMax(a.max[0], b.max[0]),
+      nanSafeMax(a.max[1], b.max[1]),
+      nanSafeMax(a.max[2], b.max[2]),
+    ],
   };
+}
+
+function nanSafeMin(a: number, b: number): number {
+  if (Number.isNaN(a)) return b;
+  if (Number.isNaN(b)) return a;
+  return a < b ? a : b;
+}
+
+function nanSafeMax(a: number, b: number): number {
+  if (Number.isNaN(a)) return b;
+  if (Number.isNaN(b)) return a;
+  return a > b ? a : b;
 }
 
 /** Geometric centre of an AABB. */

--- a/packages/clash/src/contact/mesh-bvh.test.ts
+++ b/packages/clash/src/contact/mesh-bvh.test.ts
@@ -182,3 +182,72 @@ describe("queryMeshCross — leaves partition, so the traversal cannot emit a du
     expect([...seen].sort((x, y) => x - y)).toEqual([...Array(100).keys()]);
   });
 });
+
+/**
+ * Regression: one degenerate (NaN-vertexed) triangle in a mesh must not hide
+ * OTHER, perfectly valid triangles from `queryMeshCross` — the false-negative
+ * class fixed in `unionAabb` (`aabb.ts`). `buildNode` (`bvh.ts`) folds
+ * `unionAabb` bottom-up over every ancestor of a leaf, and with the old
+ * `Math.min`/`Math.max` implementation a single NaN leaf poisoned every
+ * ancestor's aggregate bounds up to and including the root — so
+ * `crossNode`'s `boundsOverlap(rootA.bounds, rootB.bounds)` failed and the
+ * traversal was pruned before visiting anything, silently reporting NO
+ * contact between two meshes that genuinely intersect.
+ */
+describe("queryMeshCross — a NaN-vertexed triangle does not poison sibling triangles", () => {
+  /**
+   * A mesh of `n` triangles spaced apart on a line (gap of 1 between each,
+   * so neighbours' AABBs neither touch nor overlap), one of which has NaN
+   * vertices.
+   */
+  function meshWithOneNanTriangle(id: string, n: number, nanAt: number): Mesh {
+    const positions: number[] = [];
+    const indices: number[] = [];
+    for (let i = 0; i < n; i++) {
+      if (i === nanAt) {
+        positions.push(NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN);
+      } else {
+        const x = i * 2;
+        positions.push(x, 0, 0, x + 1, 0, 0, x, 1, 0);
+      }
+      indices.push(i * 3, i * 3 + 1, i * 3 + 2);
+    }
+    return { id, positions: new Float64Array(positions), indices: new Uint32Array(indices) };
+  }
+
+  /** A single triangle exactly matching mesh index `i`'s slot from above. */
+  function overlappingTriangle(i: number): Mesh {
+    const x = i * 2;
+    return {
+      id: "B",
+      positions: new Float64Array([x, 0, 0, x + 1, 0, 0, x, 1, 0]),
+      indices: new Uint32Array([0, 1, 2]),
+    };
+  }
+
+  it("still reports a cross with a valid sibling triangle when another triangle is NaN-vertexed", () => {
+    // 12 triangles (> the default leafSize of 8) so the tree has internal
+    // nodes whose aggregate bounds is what a NaN would poison; the NaN
+    // triangle sits at index 0, the crossing triangle (index 5) is in a
+    // different subtree.
+    const meshA = meshWithOneNanTriangle("A", 12, 0);
+    const meshB = overlappingTriangle(5);
+    const bvhA = buildMeshBvh(meshA, 4);
+    const bvhB = buildMeshBvh(meshB, 4);
+
+    const pairs = queryMeshCross(bvhA, bvhB, 0);
+
+    expect(pairs).toEqual([[5, 0]]);
+  });
+
+  it("still reports a cross when the NaN triangle sits deep in the tree, not just at index 0", () => {
+    const meshA = meshWithOneNanTriangle("A", 20, 13);
+    const meshB = overlappingTriangle(2);
+    const bvhA = buildMeshBvh(meshA, 4);
+    const bvhB = buildMeshBvh(meshB, 4);
+
+    const pairs = queryMeshCross(bvhA, bvhB, 0);
+
+    expect(pairs).toEqual([[2, 0]]);
+  });
+});


### PR DESCRIPTION
## Summary
- `unionAabb` (`packages/clash/src/contact/aabb.ts`) folded AABB bounds with `Math.min`/`Math.max`, which propagate a NaN operand through the whole comparison. `Bvh.build` (`packages/clash/src/contact/bvh.ts`) folds `unionAabb` bottom-up over every ancestor of a leaf, so a single degenerate (NaN-vertexed) triangle — e.g. from corrupt mesh geometry — poisoned the aggregate `bounds` of every node above it, up to and including the tree root.
- `queryMeshCross` (`mesh-bvh.ts`) treats a NaN-bounded node as "no overlap" and prunes it, so a poisoned root silently dropped the WHOLE traversal: every other, perfectly valid triangle in the mesh vanished from the query — not just the degenerate one.
- Consumer impact: this BVH backs `contactClusters`/`narrowPhase` (the on-demand contact-interface computation for a focused clash pair) and `minDistanceBetweenMeshes`/`minDistanceBetweenBvhs` (the viewer's minimum-distance measure tool) — a corrupt triangle in either mesh could make either feature silently report no contact / no valid distance for the entire pair.
- Fix: fold with NaN-safe `<`/`>` comparisons instead, so a NaN triangle is excluded from the aggregate rather than poisoning it. This matches `aabbFromPositions` in the very same file, and `compute_bounds` in `rust/clash/src/bvh.rs` (`AGENTS.md` already flags that Rust file as the correct template for this exact bug class, per #3547 — that PR fixes the same shape of bug in `packages/spatial/src/bvh.ts`'s BVH, a different file backing the main clash broad phase; this PR fixes the same shape of bug in `packages/clash/src/contact/aabb.ts`'s independent BVH, which backs only the contact-interface/min-distance path).

## How this was found
Working the clash-pipeline oracle lens (AGENTS.md): traced every BVH aggregate-bounds fold in the clash package and checked each against `rust/clash/src/bvh.rs`'s NaN-safe template. `packages/clash/src/contact/aabb.ts`'s `unionAabb` was the one outlier using `Math.min`/`Math.max`. Minimized repro (confirmed against the unmodified code before writing the fix):

```ts
// 12 axis-spaced triangles (> the tree's leafSize), one NaN-vertexed at index 0;
// a genuinely crossing triangle at a sibling leaf (index 5).
queryMeshCross(buildMeshBvh(meshWithOneNanTriangle, 4), buildMeshBvh(crossingTriangle, 4), 0);
// main:  []        (the valid crossing at index 5 is silently dropped)
// fixed: [[5, 0]]
```

## Test plan
- [x] RED confirmed against unmodified `unionAabb`: `queryMeshCross` returns `[]` instead of the real crossing pair (2 new regression tests in `mesh-bvh.test.ts`, both failing).
- [x] GREEN with the fix; full `@ifc-lite/clash` suite: 454 passed, 1 skipped (pre-existing, unrelated).
- [x] Unit tests for `unionAabb` itself in `aabb.test.ts` (wholly-NaN box, and per-axis NaN on each side).
- [x] `node scripts/check-module-size.mjs` — OK, 0 files over budget.
- [x] `pnpm run check:vitest-timeout-audit` — no regex-literal violations introduced.
- [x] `node scripts/check-test-wiring.mjs` — OK.
- [x] `node scripts/check-unused-locals.mjs` — `packages/clash` compiles clean and is not in the non-compiling-package list (several unrelated packages are, pre-existing).
- [x] `pnpm exec tsc --noEmit` in `packages/clash` — clean.
- [x] No public export surface changed (`unionAabb` was already exported from `contact/aabb.ts` but is not re-exported from the package's public `index.ts` or `contact/index.ts`) — `scripts/api-surface.json` untouched.
- [x] Changeset added (`@ifc-lite/clash`, patch).

## Siblings checked
Grepped `packages/clash/src` for every other place that folds AABB bounds with `Math.min`/`Math.max`: `math/generated/plato.g.ts`'s `unionAabb` (used by the main engine's `broad.ts` broad phase, via `@ifc-lite/spatial`'s `BVH`) has the identical shape, but that BVH is `packages/spatial/src/bvh.ts`, which is the exact file #3547 (open) already fixes. This PR is scoped to the separate, independent BVH under `packages/clash/src/contact/` that #3547 does not touch.

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mesh contact detection when geometry contains degenerate triangles with invalid coordinates.
  * Valid triangles are no longer skipped during contact clustering or minimum-distance queries because of nearby invalid geometry.
  * Added regression coverage for invalid triangles at different positions within a mesh.

* **Tests**
  * Added coverage for safe handling of invalid values when combining bounding boxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->