### PR TITLE
fix(lens): stop an absent property/attribute matching equals/contains ""

### DIFF
--- a/.changeset/lens-empty-value-absence-match.md
+++ b/.changeset/lens-empty-value-absence-match.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/lens': patch
+---
+
+Fix `matchesCriteria` treating an absent property/attribute as if it equalled the empty string under `equals`/`contains`. `matchesProperty` and `matchesAttribute` checked `contains`/`equals` before checking whether the value was present, so `String(value ?? '')` coerced a missing property/attribute to `''`, and `''.includes('')` / `'' === ''` made a rule like `{ propertyName: 'FireRating', operator: 'equals', propertyValue: '' }` match every entity that never had `FireRating` at all — the same class of "absent value satisfies a comparison it shouldn't" that the numeric operators and `ne` already guard against. `matchesQuantity` already checked presence before any operator and never had this hole; `matchesProperty`/`matchesAttribute` now check presence first too, so absence never satisfies `equals`/`contains` either, matching `matchesQuantity`'s existing behaviour. A property/attribute whose value genuinely is the empty string is unaffected.

--- a/packages/lens/src/matching.test.ts
+++ b/packages/lens/src/matching.test.ts
@@ -1102,3 +1102,89 @@ describe('matchesCriteria — single-leaf compound ≡ plain leaf (bounding)', (
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Absence vs. empty-string criteria value
+//
+// Reference semantics (pinned by `matchesQuantity`, which already guards
+// absence before any value comparison): a property/attribute/quantity that is
+// NOT PRESENT on an entity must never satisfy `equals`/`contains` with an
+// empty-string criteria value, exactly as it never satisfies a numeric
+// comparison or `ne`. `matchesProperty`/`matchesAttribute` checked
+// `contains`/`equals` before the absence guard, so `String(undefined ?? '')`
+// coerced an absent value to `''`, and `''.includes('')` / `'' === ''` made
+// an empty-string rule match entities that never had the field at all - the
+// one criteria type (`quantity`) that already guards absence first does not
+// have this hole, which is the reference this pins the other two to.
+// ---------------------------------------------------------------------------
+describe('matchesCriteria — absence never satisfies an empty-string value comparison', () => {
+  const provider = createMockProvider([
+    { id: 1, type: 'IfcWall', properties: { Pset_WallCommon: { FireRating: '60' } } },
+    { id: 2, type: 'IfcSlab' }, // no properties at all
+  ]);
+  provider.getEntityAttribute = (id: number, attrName: string) => {
+    if (id === 1 && attrName === 'Description') return 'Load-bearing';
+    return undefined; // id 2: attribute absent
+  };
+  provider.getQuantityValue = (id: number, qset: string, qname: string) => {
+    if (id === 1 && qset === 'Qto_WallBaseQuantities' && qname === 'Length') return 5.2;
+    return undefined; // id 2: quantity absent
+  };
+
+  it('property equals "" does not match an entity missing the property', () => {
+    const c: LensCriteria = {
+      type: 'property', propertySet: 'Pset_WallCommon', propertyName: 'FireRating',
+      operator: 'equals', propertyValue: '',
+    };
+    expect(matchesCriteria(c, 2, provider)).toBe(false);
+  });
+
+  it('property contains "" does not match an entity missing the property', () => {
+    const c: LensCriteria = {
+      type: 'property', propertySet: 'Pset_WallCommon', propertyName: 'FireRating',
+      operator: 'contains', propertyValue: '',
+    };
+    expect(matchesCriteria(c, 2, provider)).toBe(false);
+  });
+
+  it('attribute equals "" does not match an entity missing the attribute', () => {
+    const c: LensCriteria = {
+      type: 'attribute', attributeName: 'Description', operator: 'equals', attributeValue: '',
+    };
+    expect(matchesCriteria(c, 2, provider)).toBe(false);
+  });
+
+  it('attribute contains "" does not match an entity missing the attribute', () => {
+    const c: LensCriteria = {
+      type: 'attribute', attributeName: 'Description', operator: 'contains', attributeValue: '',
+    };
+    expect(matchesCriteria(c, 2, provider)).toBe(false);
+  });
+
+  it('quantity equals "" does not match an entity missing the quantity (the pre-existing, correct behaviour)', () => {
+    const c: LensCriteria = {
+      type: 'quantity', quantitySet: 'Qto_WallBaseQuantities', quantityName: 'Length',
+      operator: 'equals', quantityValue: '',
+    };
+    expect(matchesCriteria(c, 2, provider)).toBe(false);
+  });
+
+  it('quantity contains "" does not match an entity missing the quantity (the pre-existing, correct behaviour)', () => {
+    const c: LensCriteria = {
+      type: 'quantity', quantitySet: 'Qto_WallBaseQuantities', quantityName: 'Length',
+      operator: 'contains', quantityValue: '',
+    };
+    expect(matchesCriteria(c, 2, provider)).toBe(false);
+  });
+
+  it('a present property still matches equals "" only when its value truly is the empty string', () => {
+    const withEmpty = createMockProvider([
+      { id: 1, type: 'IfcWall', properties: { Pset_WallCommon: { Note: '' } } },
+    ]);
+    const c: LensCriteria = {
+      type: 'property', propertySet: 'Pset_WallCommon', propertyName: 'Note',
+      operator: 'equals', propertyValue: '',
+    };
+    expect(matchesCriteria(c, 1, withEmpty)).toBe(true);
+  });
+});

--- a/packages/lens/src/matching.ts
+++ b/packages/lens/src/matching.ts
@@ -237,13 +237,7 @@ function matchesProperty(
     return value !== null && value !== undefined;
   }
 
-  // An absent property never satisfies a value comparison - not `contains`
-  // or `equals` either, even against an empty-string criteria value.
-  // Checked once, ahead of every operator below, so `String(value ?? '')`
-  // can never coerce "missing" into "present and empty" (that coercion made
-  // `contains ''` / `equals ''` match entities that never had the property -
-  // mirrors the search layer, where the rule matches over the rows that
-  // exist so a missing property fails even the negative ops).
+  // Absent never satisfies a comparison, incl. `contains ''`/`equals ''`.
   if (value === null || value === undefined) return false;
 
   if (criteria.operator === 'contains' && criteria.propertyValue !== undefined) {
@@ -319,11 +313,8 @@ function matchesAttribute(
     return value !== undefined && value !== '';
   }
 
-  // Absence for an attribute is undefined OR '' - the same test the `exists`
-  // branch above uses. Checked once, ahead of every operator below, so an
-  // absent attribute can never satisfy `contains`/`equals` against an
-  // empty-string criteria value either (see the parallel comment in
-  // matchesProperty for why that coercion was a real hole).
+  // Absence is undefined OR '' (same test as `exists` above); checked once
+  // here so `contains ''`/`equals ''` can't match it either.
   if (value === undefined || value === '') return false;
 
   if (criteria.operator === 'contains' && criteria.attributeValue !== undefined) {

--- a/packages/lens/src/matching.ts
+++ b/packages/lens/src/matching.ts
@@ -237,24 +237,29 @@ function matchesProperty(
     return value !== null && value !== undefined;
   }
 
+  // An absent property never satisfies a value comparison - not `contains`
+  // or `equals` either, even against an empty-string criteria value.
+  // Checked once, ahead of every operator below, so `String(value ?? '')`
+  // can never coerce "missing" into "present and empty" (that coercion made
+  // `contains ''` / `equals ''` match entities that never had the property -
+  // mirrors the search layer, where the rule matches over the rows that
+  // exist so a missing property fails even the negative ops).
+  if (value === null || value === undefined) return false;
+
   if (criteria.operator === 'contains' && criteria.propertyValue !== undefined) {
-    return String(value ?? '').toLowerCase().includes(criteria.propertyValue.toLowerCase());
+    return String(value).toLowerCase().includes(criteria.propertyValue.toLowerCase());
   }
 
-  // An absent property never satisfies a comparison - mirroring the search
-  // layer, where the rule matches over the rows that exist so a missing
-  // property fails even the negative ops.
   if (isComparisonOperator(criteria.operator)) {
-    if (value === null || value === undefined) return false;
     return matchesComparison(criteria.operator, value, criteria.propertyValue);
   }
 
   // Default: equals
   if (criteria.propertyValue !== undefined) {
-    return valueEquals(String(value ?? ''), criteria.propertyValue);
+    return valueEquals(String(value), criteria.propertyValue);
   }
 
-  return value !== null && value !== undefined;
+  return true;
 }
 
 /** Match by material — prefers dedicated getMaterialName, falls back to pset scan */
@@ -314,23 +319,27 @@ function matchesAttribute(
     return value !== undefined && value !== '';
   }
 
+  // Absence for an attribute is undefined OR '' - the same test the `exists`
+  // branch above uses. Checked once, ahead of every operator below, so an
+  // absent attribute can never satisfy `contains`/`equals` against an
+  // empty-string criteria value either (see the parallel comment in
+  // matchesProperty for why that coercion was a real hole).
+  if (value === undefined || value === '') return false;
+
   if (criteria.operator === 'contains' && criteria.attributeValue !== undefined) {
-    return (value ?? '').toLowerCase().includes(criteria.attributeValue.toLowerCase());
+    return value.toLowerCase().includes(criteria.attributeValue.toLowerCase());
   }
 
-  // Absence for an attribute is undefined OR '' - the same test the `exists`
-  // branch above uses.
   if (isComparisonOperator(criteria.operator)) {
-    if (value === undefined || value === '') return false;
     return matchesComparison(criteria.operator, value, criteria.attributeValue);
   }
 
   // Default: equals
   if (criteria.attributeValue !== undefined) {
-    return valueEquals(value ?? '', criteria.attributeValue);
+    return valueEquals(value, criteria.attributeValue);
   }
 
-  return value !== undefined && value !== '';
+  return true;
 }
 
 /** Match by quantity value (equals, contains, exists, ne, gt, gte, lt, lte) */


### PR DESCRIPTION
## Fix

`matchesProperty` and `matchesAttribute` evaluated `contains` and `equals` before their existing presence semantics. A missing value was coerced to `''`, causing an empty-string rule to match entities that did not have the property or attribute.

Both matchers now perform their presence check before every comparison, matching the already-correct quantity matcher:

- a missing property never satisfies `equals ''` or `contains ''`;
- an attribute whose value is `undefined` or `''` is absent, consistent with its existing `exists` semantics, and never satisfies a comparison;
- a property explicitly stored as `''` remains a present value and can satisfy `equals ''`.

## Regression coverage

The tests cover missing property/attribute values with both empty-string operators, the pre-existing quantity behavior, and the present-empty-property control.

## Verification

- Current-base full GitHub CI is green on `126c87c06` against `2edd144329`.
- In-tree parity, SDK canary, benchmark, typecheck, lint, Node, E2E, and viewer shards passed.
- Patch changeset for `@ifc-lite/lens` is included.
