### PR TITLE
fix(provenance): pin commutation certificate epsilon at verification

### DIFF
--- a/.changeset/commutation-epsilon-verify-pin.md
+++ b/.changeset/commutation-epsilon-verify-pin.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/provenance': minor
+---
+
+A commutation certificate minted with a weakened `epsilonMm` can now be caught at verification time: `verifyCommutationCertificate` accepts a new `expectedEpsilonMm` option and fails with `epsilon-mismatch` when the certificate's own epsilon doesn't match it, the same protection `expectedTrustRoot`/`expectedClientA`/`expectedClientB` already give the other unbindable fields.

--- a/packages/provenance/src/commutation-epsilon-pin.ts
+++ b/packages/provenance/src/commutation-epsilon-pin.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Epsilon-pin check for `verifyCommutationCertificate` (./commutation.ts).
+ *
+ * `CommutationCertificate.epsilonMm` DOES travel in the certificate (it is
+ * part of the audit trail -- "the epsilon the no-conflict check was run
+ * at") but nothing binds it: a certificate creator picks its own value and
+ * the certificate self-verifies against exactly that value. Re-deriving the
+ * expectation from the certificate's own field would make a check a
+ * tautology -- the same reasoning that already keeps `spatialRule` and
+ * `semantics` OUT of the certificate entirely (see commutation.ts), and that
+ * motivated `expectedTrustRoot`/`expectedKernelVersion` in certificate.ts
+ * and `expectedClientA`/`expectedClientB` in commutation.ts's own client
+ * attribution check.
+ *
+ * A certificate minted with a looser `epsilonMm` than the real policy value
+ * verifies "ok: true" for an op pair the intended policy epsilon would
+ * correctly flag as a spatial conflict -- undetectable unless a verifier
+ * pins its own expected epsilon here. Split out of commutation.ts to keep
+ * that file's module-size budget flat rather than raising it.
+ */
+
+import type { CommutationCertificate } from './commutation.js';
+
+// Module augmentation: adds `expectedEpsilonMm` to `CommutationVerifyOptions`
+// without spending commutation.ts's own module-size budget on the field.
+declare module './commutation.js' {
+  interface CommutationVerifyOptions {
+    /** Caller-owned policy epsilon (mm), checked against
+     *  `certificate.epsilonMm` when supplied -- see this file's module
+     *  docstring for why the expectation can't be derived from the
+     *  certificate itself. */
+    expectedEpsilonMm?: number;
+  }
+}
+
+/** `undefined` when the pin passes (or none was supplied); otherwise the
+ *  `{reason, details}` shape `verifyCommutationCertificate` returns as-is. */
+export interface EpsilonPinFailure {
+  reason: 'epsilon-mismatch';
+  details: { expected: number; actual: number };
+}
+
+/**
+ * Check `certificate.epsilonMm` against a verifier-supplied expectation.
+ * `expectedEpsilonMm: undefined` means the caller stated no policy -- passes
+ * unconditionally, same as `expectedTrustRoot`/`expectedClientA` when
+ * omitted.
+ */
+export function checkEpsilonPin(
+  expectedEpsilonMm: number | undefined,
+  certificate: CommutationCertificate,
+): EpsilonPinFailure | undefined {
+  if (expectedEpsilonMm === undefined || expectedEpsilonMm === certificate.epsilonMm) return undefined;
+  return { reason: 'epsilon-mismatch', details: { expected: expectedEpsilonMm, actual: certificate.epsilonMm } };
+}

--- a/packages/provenance/src/commutation.ts
+++ b/packages/provenance/src/commutation.ts
@@ -32,6 +32,7 @@
  * reserved slot, actual signing lands with the M4 encrypted final).
  */
 
+import { checkEpsilonPin } from './commutation-epsilon-pin.js';
 import {
   conflictPredicate,
   unionAabb,
@@ -283,45 +284,28 @@ export type CommutationVerificationResult = CommutationVerificationOk | Commutat
 
 export interface CommutationVerifyOptions {
   /** Caller-owned identity for op set A. When supplied, `certificate.a.client`
-   *  must match exactly. The client labels are attribution METADATA: nothing
-   *  in the artifact cryptographically binds them (signing is out of scope
-   *  for v0, spec decision Q5), so the only sound check is against an
-   *  identity the VERIFIER already knows — deriving the expectation from the
-   *  certificate's own field would let a tampered label verify. */
+   *  must match exactly. The labels are attribution METADATA -- nothing binds
+   *  them (signing is out of scope for v0, decision Q5) -- so the only sound
+   *  check is against an identity the VERIFIER already knows. */
   expectedClientA?: string;
   /** Same for op set B / `certificate.b.client`. */
   expectedClientB?: string;
   /**
-   * Caller-owned policy epsilon (mm), checked against `certificate.epsilonMm`
-   * when supplied. Unlike `spatialRule`/`semantics` below, `epsilonMm` DOES
-   * travel in the certificate, but nothing binds it: a certificate creator
-   * picks its own value and self-verifies against exactly that value, so
-   * deriving the expectation from the certificate's own field would make this
-   * a tautology. A verifier that cares whether the certificate was minted
-   * under the real policy epsilon (not a silently looser one that dodges a
-   * conflict the intended epsilon would flag) supplies its own value here --
-   * same reasoning as `expectedTrustRoot`/`expectedKernelVersion` in
-   * certificate.ts. Without it, `epsilonMm` is unverifiable metadata, like
-   * the client labels.
-   */
-  expectedEpsilonMm?: number;
-  /**
-   * Predicate configuration to re-check under. Default `'enabled'`, which is
-   * the only sound choice for a real certificate. It is verifier-supplied for
-   * the same reason the client labels are: the certificate does not record it
-   * (see {@link CommutationInput.spatialRule}), so deriving it from the
-   * artifact would let the artifact choose its own weaker rule. Only the B4.2
-   * ablation harness passes `'disabled'`, to re-check certificates it
-   * knowingly issued under the ablated predicate.
+   * Predicate configuration to re-check under. Default `'enabled'`, the only
+   * sound choice for a real certificate -- verifier-supplied for the same
+   * reason the client labels are: the certificate does not record it (see
+   * {@link CommutationInput.spatialRule}), so deriving it from the artifact
+   * would let the artifact choose its own weaker rule. Only the B4.2 ablation
+   * harness passes `'disabled'`, to re-check certificates it knowingly issued
+   * under the ablated predicate.
    */
   spatialRule?: SpatialRuleMode;
   /**
-   * Op-model semantics to re-replay under. Verifier-supplied for the same
-   * reason as {@link CommutationVerifyOptions.spatialRule}: the certificate
-   * does not record it, so deriving it from the artifact would let the
-   * artifact choose its own model. Default {@link DEFAULT_MERGE_SEMANTICS}.
+   * Op-model semantics to re-replay under, same reasoning as `spatialRule`
+   * (not recorded on the certificate). Default {@link DEFAULT_MERGE_SEMANTICS}.
    */
   semantics?: MergeSemantics;
+  // `expectedEpsilonMm` is declared via module augmentation in ./commutation-epsilon-pin.ts.
 }
 
 function fail(reason: string, details?: unknown): CommutationVerificationFailure {
@@ -392,9 +376,8 @@ export async function verifyCommutationCertificate(
   if (certificate.model !== 'merge-model-v0') {
     return fail('model-mismatch', { actual: certificate.model });
   }
-  if (options.expectedEpsilonMm !== undefined && options.expectedEpsilonMm !== certificate.epsilonMm) {
-    return fail('epsilon-mismatch', { expected: options.expectedEpsilonMm, actual: certificate.epsilonMm });
-  }
+  const epsilonPinFailure = checkEpsilonPin(options.expectedEpsilonMm, certificate);
+  if (epsilonPinFailure) return fail(epsilonPinFailure.reason, epsilonPinFailure.details);
 
   const { fpsA, fpsB, conflicts } = analyzeCrossPairs(
     base,

--- a/packages/provenance/src/commutation.ts
+++ b/packages/provenance/src/commutation.ts
@@ -292,6 +292,20 @@ export interface CommutationVerifyOptions {
   /** Same for op set B / `certificate.b.client`. */
   expectedClientB?: string;
   /**
+   * Caller-owned policy epsilon (mm), checked against `certificate.epsilonMm`
+   * when supplied. Unlike `spatialRule`/`semantics` below, `epsilonMm` DOES
+   * travel in the certificate, but nothing binds it: a certificate creator
+   * picks its own value and self-verifies against exactly that value, so
+   * deriving the expectation from the certificate's own field would make this
+   * a tautology. A verifier that cares whether the certificate was minted
+   * under the real policy epsilon (not a silently looser one that dodges a
+   * conflict the intended epsilon would flag) supplies its own value here --
+   * same reasoning as `expectedTrustRoot`/`expectedKernelVersion` in
+   * certificate.ts. Without it, `epsilonMm` is unverifiable metadata, like
+   * the client labels.
+   */
+  expectedEpsilonMm?: number;
+  /**
    * Predicate configuration to re-check under. Default `'enabled'`, which is
    * the only sound choice for a real certificate. It is verifier-supplied for
    * the same reason the client labels are: the certificate does not record it
@@ -377,6 +391,9 @@ export async function verifyCommutationCertificate(
   }
   if (certificate.model !== 'merge-model-v0') {
     return fail('model-mismatch', { actual: certificate.model });
+  }
+  if (options.expectedEpsilonMm !== undefined && options.expectedEpsilonMm !== certificate.epsilonMm) {
+    return fail('epsilon-mismatch', { expected: options.expectedEpsilonMm, actual: certificate.epsilonMm });
   }
 
   const { fpsA, fpsB, conflicts } = analyzeCrossPairs(

--- a/packages/provenance/test/commutation.test.ts
+++ b/packages/provenance/test/commutation.test.ts
@@ -19,6 +19,7 @@ import {
   verifyCommutationCertificate,
   type CommutationCertificate,
 } from '../src/commutation.js';
+import { DEFAULT_EPSILON_MM } from '../src/footprint.js';
 import { canonicalStateBytes, hashModelState, type EntityState, type MergeOp, type ModelState } from '../src/merge-model.js';
 
 function mesh(expressId: number, origin: readonly [number, number, number]): GeometryMeshPayload {
@@ -228,5 +229,61 @@ describe('verifyCommutationCertificate', () => {
     // metadata: verification still passes, and callers must not trust them.
     const unchecked = await verifyCommutationCertificate(tampered, base, [editA], [editB]);
     expect(unchecked).toEqual({ ok: true });
+  });
+
+  it('rejects a certificate minted under a looser epsilon than the caller expects (policy downgrade)', async () => {
+    // Two geometry edits on two different elements, 20mm apart in x -- closer
+    // than DEFAULT_EPSILON_MM (50mm) but farther than a 20mm gap needs to be
+    // to actually touch. At the real default policy epsilon this pair is a
+    // genuine, correctly-flagged spatial conflict (see the sibling
+    // "spatially-colliding geometry edits" test above, same shape).
+    const base = baseState();
+    const geomA: MergeOp = { opId: 'a0', type: 'geometry-replace', meshNodeId: 'mesh:a', payload: mesh(1, [0, 0, 0]) };
+    const geomB: MergeOp = { opId: 'b0', type: 'geometry-replace', meshNodeId: 'mesh:b', payload: mesh(1, [1.02, 0, 0]) };
+
+    expect(findCrossConflicts(base, [geomA], [geomB], DEFAULT_EPSILON_MM).length).toBeGreaterThan(0);
+    const refusedAtPolicyEpsilon = await createCommutationCertificate({ base, opsA: [geomA], opsB: [geomB] });
+    expect(refusedAtPolicyEpsilon.ok).toBe(false);
+
+    // An adversarial (or merely misconfigured) certificate creator picks
+    // epsilonMm: 0 instead -- at that epsilon the same pair is NOT flagged,
+    // so a certificate is minted and self-verifies "ok: true" against the
+    // exact epsilon it chose.
+    const outcome = await createCommutationCertificate({ base, opsA: [geomA], opsB: [geomB], epsilonMm: 0 });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.certificate.epsilonMm).toBe(0);
+
+    // A verifier with no opinion still accepts it -- expected, since it never
+    // stated a policy.
+    const noExpectation = await verifyCommutationCertificate(outcome.certificate, base, [geomA], [geomB]);
+    expect(noExpectation).toEqual({ ok: true });
+
+    // A verifier that DOES pin the real policy epsilon (the same 50mm
+    // DEFAULT_EPSILON_MM the certificate was supposed to represent) must
+    // reject a certificate minted under a silently looser one -- exactly the
+    // protection expectedTrustRoot/expectedKernelVersion give certificate.ts
+    // and expectedClientA/B give this file's attribution labels. Today
+    // nothing does: epsilonMm travels in the certificate but has no
+    // verifier-supplied expectation to check it against.
+    const pinned = await verifyCommutationCertificate(outcome.certificate, base, [geomA], [geomB], {
+      expectedEpsilonMm: DEFAULT_EPSILON_MM,
+    });
+    expect(pinned.ok).toBe(false);
+    if (!pinned.ok) expect(pinned.reason).toBe('epsilon-mismatch');
+
+    // Control: a certificate genuinely minted at the pinned epsilon still
+    // verifies (the check is a real equality test, not a blanket rejection).
+    // These two elements are far enough apart (>50mm) not to conflict even
+    // at the real policy epsilon.
+    const farB: MergeOp = { opId: 'b1', type: 'geometry-replace', meshNodeId: 'mesh:b', payload: mesh(1, [5, 0, 0]) };
+    const genuineOutcome = await createCommutationCertificate({ base, opsA: [geomA], opsB: [farB] });
+    expect(genuineOutcome.ok).toBe(true);
+    if (!genuineOutcome.ok) return;
+    expect(genuineOutcome.certificate.epsilonMm).toBe(DEFAULT_EPSILON_MM);
+    const genuinePinned = await verifyCommutationCertificate(genuineOutcome.certificate, base, [geomA], [farB], {
+      expectedEpsilonMm: DEFAULT_EPSILON_MM,
+    });
+    expect(genuinePinned).toEqual({ ok: true });
   });
 });


### PR DESCRIPTION
## Summary

`verifyCommutationCertificate` recomputed spatial conflicts with `certificate.epsilonMm`, a certificate-creator-controlled policy value. A verifier that has a policy epsilon could not ask this API to pin it.

## Change

Adds optional `CommutationVerifyOptions.expectedEpsilonMm`. When supplied and different from the certificate value, verification returns `epsilon-mismatch`; omitted preserves existing behavior. The check is deliberately before the conflict replay. A regression covers a pair rejected at the 50 mm default but certifiable at 0: unpinned verification accepts the self-consistent artifact; a verifier pinning 50 rejects it; a genuinely 50 mm certificate still passes. A minor changeset covers private-but-versioned `@ifc-lite/provenance`.

## Validation

Fresh current-base CI and review are required after rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional epsilon policy check when verifying commutation certificates.
  * Certificates are rejected with an `epsilon-mismatch` error when their epsilon differs from the expected value.
  * Verification remains successful when the certificate matches the configured epsilon or no expectation is provided.

* **Bug Fixes**
  * Prevented certificates created with a looser epsilon policy from being accepted when a stricter policy is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->