### PR TITLE
fix(codegen,parser): strip EXPRESS UNIQUE constraint before a collection's element type

### DIFF
--- a/.changeset/fix-codegen-unique-in-collection.md
+++ b/.changeset/fix-codegen-unique-in-collection.md
@@ -1,0 +1,36 @@
+---
+'@ifc-lite/codegen': patch
+---
+
+Fix the EXPRESS code generator dropping a `UNIQUE` collection constraint into
+the element type instead of stripping it.
+
+EXPRESS allows `UNIQUE` directly in front of a collection's element type
+(e.g. `LIST [1:?] OF UNIQUE IfcGridAxis`, real syntax from `IfcGrid.UAxes` in
+both `IFC4_ADD2_TC1.exp` and `IFC4X3.exp`) — it constrains the collection's
+elements, it is not part of the element type name. `parseNestedCollection`
+never stripped it, so the parsed attribute type carried the leftover keyword
+verbatim (`type: 'UNIQUE IfcGridAxis'`), and a collection nested one level
+under a `UNIQUE` (`LIST [1:?] OF UNIQUE LIST [1:2] OF IfcLengthMeasure`)
+fell through the "ends with Measure" heuristic entirely and lost an array
+dimension (`number[]` instead of `IfcLengthMeasure[][]`).
+
+Eight IFC4 attributes and two additional IFC4X3-only attributes were affected
+(`IfcTypeProduct.RepresentationMaps`, `IfcGrid.{UAxes,VAxes,WAxes}`,
+`IfcIndexedPolygonalFaceWithVoids.InnerCoordIndices`, `IfcPath.EdgeList`,
+`IfcPolyLoop.Polygon`, `IfcPropertyEnumeration.EnumerationValues`,
+`IfcPropertyTableValue.DefiningValues`, `IfcVirtualGridIntersection.IntersectingAxes`,
+`IfcStructuralLoadConfiguration.Locations`, plus IFC4X3's
+`IfcTriangulatedFaceSet.Faces` and `IfcIndexedPolygonalTextureMap.InnerTexCoordIndices`).
+`packages/codegen/generated/ifc4/entities.ts` and `generated/ifc4x3/entities.ts`
+carried the bug outright (invalid TypeScript, e.g. `UAxes: UNIQUE IfcGridAxis[];`);
+`packages/parser/src/generated/entities.ts` had it hand-patched to valid syntax
+in one prior commit without ever touching the generator, so
+`schema-registry.ts` — which carries the same attribute type as a plain
+string, so `tsc` never flagged it — kept shipping `type: 'UNIQUE IfcGridAxis'`
+as runtime metadata in every published `@ifc-lite/parser` release.
+
+Regenerated and committed `packages/codegen/generated/{ifc4,ifc4x3}/{entities,schema-registry}.ts`
+and `packages/parser/src/generated/{entities,schema-registry}.ts` to match the
+fixed generator; a fresh regeneration against the committed `.exp` schemas is
+now byte-identical to what's committed.

--- a/.changeset/fix-parser-generated-unique-attrs.md
+++ b/.changeset/fix-parser-generated-unique-attrs.md
@@ -1,0 +1,15 @@
+---
+'@ifc-lite/parser': patch
+---
+
+Fix eight `IfcTypeProduct`/`IfcGrid`/`IfcPath`/etc. attributes carrying a
+stray `UNIQUE` keyword (or a dropped array dimension) in `SCHEMA_REGISTRY`'s
+attribute-type metadata, from a stale `packages/codegen` regeneration.
+`entities.ts`'s TypeScript interfaces had been hand-patched to valid syntax
+in a prior commit, but `schema-registry.ts` — same bug, but a string value
+rather than a type, so `tsc` never caught it — still reported
+`type: 'UNIQUE IfcGridAxis'` for `IfcGrid.UAxes`/`VAxes`/`WAxes` and seven
+other attributes, and `type: 'number'` (missing a dimension) for
+`IfcStructuralLoadConfiguration.Locations` instead of `IfcLengthMeasure[][]`.
+See the `@ifc-lite/codegen` changeset in this release for the generator fix
+and the full attribute list.

--- a/packages/codegen/generated/ifc4/entities.ts
+++ b/packages/codegen/generated/ifc4/entities.ts
@@ -530,7 +530,7 @@ export interface IfcTypeObject extends IfcObjectDefinition {
  * @extends IfcTypeObject
  */
 export interface IfcTypeProduct extends IfcTypeObject {
-  RepresentationMaps?: UNIQUE IfcRepresentationMap[];
+  RepresentationMaps?: IfcRepresentationMap[];
   Tag?: IfcLabel;
 }
 
@@ -3492,9 +3492,9 @@ export interface IfcGeometricRepresentationSubContext extends IfcGeometricRepres
  * @extends IfcProduct
  */
 export interface IfcGrid extends IfcProduct {
-  UAxes: UNIQUE IfcGridAxis[];
-  VAxes: UNIQUE IfcGridAxis[];
-  WAxes?: UNIQUE IfcGridAxis[];
+  UAxes: IfcGridAxis[];
+  VAxes: IfcGridAxis[];
+  WAxes?: IfcGridAxis[];
   PredefinedType?: IfcGridTypeEnum;
 }
 
@@ -3619,7 +3619,7 @@ export interface IfcIndexedPolygonalFace extends IfcTessellatedItem {
  * @extends IfcIndexedPolygonalFace
  */
 export interface IfcIndexedPolygonalFaceWithVoids extends IfcIndexedPolygonalFace {
-  InnerCoordIndices: UNIQUE IfcPositiveInteger[][];
+  InnerCoordIndices: IfcPositiveInteger[][];
 }
 
 /**
@@ -4389,7 +4389,7 @@ export interface IfcOwnerHistory {
  * @extends IfcTopologicalRepresentationItem
  */
 export interface IfcPath extends IfcTopologicalRepresentationItem {
-  EdgeList: UNIQUE IfcOrientedEdge[];
+  EdgeList: IfcOrientedEdge[];
 }
 
 /**
@@ -4615,7 +4615,7 @@ export interface IfcPointOnSurface extends IfcPoint {
  * @extends IfcLoop
  */
 export interface IfcPolyLoop extends IfcLoop {
-  Polygon: UNIQUE IfcCartesianPoint[];
+  Polygon: IfcCartesianPoint[];
 }
 
 /**
@@ -4829,7 +4829,7 @@ export interface IfcPropertyEnumeratedValue extends IfcSimpleProperty {
  */
 export interface IfcPropertyEnumeration extends IfcPropertyAbstraction {
   Name: IfcLabel;
-  EnumerationValues: UNIQUE IfcValue[];
+  EnumerationValues: IfcValue[];
   Unit?: IfcUnit;
 }
 
@@ -4883,7 +4883,7 @@ export interface IfcPropertySingleValue extends IfcSimpleProperty {
  * @extends IfcSimpleProperty
  */
 export interface IfcPropertyTableValue extends IfcSimpleProperty {
-  DefiningValues?: UNIQUE IfcValue[];
+  DefiningValues?: IfcValue[];
   DefinedValues?: IfcValue[];
   Expression?: IfcText;
   DefiningUnit?: IfcUnit;
@@ -6297,7 +6297,7 @@ export interface IfcStructuralLoadCase extends IfcStructuralLoadGroup {
  */
 export interface IfcStructuralLoadConfiguration extends IfcStructuralLoad {
   Values: IfcStructuralLoadOrResult[];
-  Locations?: number[];
+  Locations?: IfcLengthMeasure[][];
 }
 
 /**
@@ -7196,7 +7196,7 @@ export interface IfcVirtualElement extends IfcElement {
  * IfcVirtualGridIntersection
  */
 export interface IfcVirtualGridIntersection {
-  IntersectingAxes: UNIQUE IfcGridAxis[];
+  IntersectingAxes: IfcGridAxis[];
   OffsetDistances: number[];
 }
 

--- a/packages/codegen/generated/ifc4/entities.ts
+++ b/packages/codegen/generated/ifc4/entities.ts
@@ -7397,4 +7397,3 @@ export interface IfcZShapeProfileDef extends IfcParameterizedProfileDef {
 export interface IfcZone extends IfcSystem {
   LongName?: IfcLabel;
 }
-

--- a/packages/codegen/generated/ifc4/schema-registry.ts
+++ b/packages/codegen/generated/ifc4/schema-registry.ts
@@ -423,7 +423,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -849,7 +849,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -949,7 +949,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -1139,7 +1139,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -1329,7 +1329,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -2642,7 +2642,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -3506,7 +3506,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -3845,7 +3845,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -4895,7 +4895,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5085,7 +5085,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5177,7 +5177,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5539,7 +5539,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5843,7 +5843,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6033,7 +6033,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6223,7 +6223,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6413,7 +6413,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7061,7 +7061,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7251,7 +7251,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7559,7 +7559,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7966,7 +7966,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -8358,7 +8358,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -8548,7 +8548,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -9079,7 +9079,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -9269,7 +9269,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -11019,7 +11019,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -11325,7 +11325,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -11515,7 +11515,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -12142,7 +12142,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -12713,7 +12713,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13293,7 +13293,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13806,7 +13806,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13996,7 +13996,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14228,7 +14228,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14386,7 +14386,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14544,7 +14544,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -15922,7 +15922,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16062,7 +16062,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16312,7 +16312,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16502,7 +16502,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16692,7 +16692,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17010,7 +17010,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17200,7 +17200,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17390,7 +17390,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17580,7 +17580,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17770,7 +17770,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17960,7 +17960,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18248,7 +18248,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18414,7 +18414,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18582,7 +18582,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18882,7 +18882,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19064,7 +19064,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19254,7 +19254,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19444,7 +19444,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -20904,7 +20904,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21094,7 +21094,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21710,7 +21710,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21900,7 +21900,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22156,7 +22156,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22314,7 +22314,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22496,7 +22496,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22686,7 +22686,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22852,7 +22852,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23010,7 +23010,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23168,7 +23168,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23326,7 +23326,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23484,7 +23484,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23666,7 +23666,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23832,7 +23832,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24022,7 +24022,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24220,7 +24220,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24530,7 +24530,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'UAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24539,7 +24539,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'VAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24548,7 +24548,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'WAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: true,
           isArray: false,
           isList: true,
@@ -24623,7 +24623,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'UAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24632,7 +24632,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'VAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24641,7 +24641,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'WAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: true,
           isArray: false,
           isList: true,
@@ -25006,7 +25006,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25196,7 +25196,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25614,7 +25614,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'InnerCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -25634,7 +25634,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'InnerCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -25904,7 +25904,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -26412,7 +26412,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -27021,7 +27021,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -27460,7 +27460,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -29874,7 +29874,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30080,7 +30080,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30352,7 +30352,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30747,7 +30747,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -31854,7 +31854,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -32074,7 +32074,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'EdgeList',
-          type: 'UNIQUE IfcOrientedEdge',
+          type: 'IfcOrientedEdge',
           optional: false,
           isArray: false,
           isList: true,
@@ -32085,7 +32085,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'EdgeList',
-          type: 'UNIQUE IfcOrientedEdge',
+          type: 'IfcOrientedEdge',
           optional: false,
           isArray: false,
           isList: true,
@@ -33008,7 +33008,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -33198,7 +33198,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -33388,7 +33388,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -33905,7 +33905,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -34056,7 +34056,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'Polygon',
-          type: 'UNIQUE IfcCartesianPoint',
+          type: 'IfcCartesianPoint',
           optional: false,
           isArray: false,
           isList: true,
@@ -34067,7 +34067,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'Polygon',
-          type: 'UNIQUE IfcCartesianPoint',
+          type: 'IfcCartesianPoint',
           optional: false,
           isArray: false,
           isList: true,
@@ -36139,7 +36139,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'EnumerationValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: false,
           isArray: false,
           isList: true,
@@ -36166,7 +36166,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'EnumerationValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: false,
           isArray: false,
           isList: true,
@@ -36561,7 +36561,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'DefiningValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: true,
           isArray: false,
           isList: true,
@@ -36629,7 +36629,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'DefiningValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: true,
           isArray: false,
           isList: true,
@@ -37010,7 +37010,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -37110,7 +37110,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -37398,7 +37398,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38026,7 +38026,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38306,7 +38306,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38406,7 +38406,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -39819,7 +39819,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -40050,7 +40050,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -40449,7 +40449,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -45542,7 +45542,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -45929,7 +45929,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -46439,7 +46439,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -46629,7 +46629,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -47546,7 +47546,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -47802,7 +47802,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48116,7 +48116,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48224,7 +48224,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48414,7 +48414,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48588,7 +48588,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48778,7 +48778,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -49044,7 +49044,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -49388,7 +49388,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -49488,7 +49488,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -50770,7 +50770,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Locations',
-          type: 'UNIQUE LIST [1:2] OF IfcLengthMeasure',
+          type: 'IfcLengthMeasure[]',
           optional: true,
           isArray: false,
           isList: true,
@@ -50798,7 +50798,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Locations',
-          type: 'UNIQUE LIST [1:2] OF IfcLengthMeasure',
+          type: 'IfcLengthMeasure[]',
           optional: true,
           isArray: false,
           isList: true,
@@ -54395,7 +54395,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -54635,7 +54635,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -55196,7 +55196,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56511,7 +56511,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56635,7 +56635,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -57853,7 +57853,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58043,7 +58043,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58513,7 +58513,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58737,7 +58737,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58805,7 +58805,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59259,7 +59259,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59449,7 +59449,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59639,7 +59639,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59933,7 +59933,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -60047,7 +60047,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'IntersectingAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -60067,7 +60067,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'IntersectingAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -60496,7 +60496,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -60686,7 +60686,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -61434,7 +61434,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -61574,7 +61574,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,

--- a/packages/codegen/generated/ifc4x3/entities.ts
+++ b/packages/codegen/generated/ifc4x3/entities.ts
@@ -569,7 +569,7 @@ export interface IfcTypeObject extends IfcObjectDefinition {
  * @extends IfcTypeObject
  */
 export interface IfcTypeProduct extends IfcTypeObject {
-  RepresentationMaps?: UNIQUE IfcRepresentationMap[];
+  RepresentationMaps?: IfcRepresentationMap[];
   Tag?: IfcLabel;
 }
 
@@ -3926,9 +3926,9 @@ export interface IfcGradientCurve extends IfcCompositeCurve {
  * @extends IfcPositioningElement
  */
 export interface IfcGrid extends IfcPositioningElement {
-  UAxes: UNIQUE IfcGridAxis[];
-  VAxes: UNIQUE IfcGridAxis[];
-  WAxes?: UNIQUE IfcGridAxis[];
+  UAxes: IfcGridAxis[];
+  VAxes: IfcGridAxis[];
+  WAxes?: IfcGridAxis[];
   PredefinedType?: IfcGridTypeEnum;
 }
 
@@ -4070,7 +4070,7 @@ export interface IfcIndexedPolygonalFace extends IfcTessellatedItem {
  * @extends IfcIndexedPolygonalFace
  */
 export interface IfcIndexedPolygonalFaceWithVoids extends IfcIndexedPolygonalFace {
-  InnerCoordIndices: UNIQUE IfcPositiveInteger[][];
+  InnerCoordIndices: IfcPositiveInteger[][];
 }
 
 /**
@@ -4976,7 +4976,7 @@ export interface IfcOwnerHistory {
  * @extends IfcTopologicalRepresentationItem
  */
 export interface IfcPath extends IfcTopologicalRepresentationItem {
-  EdgeList: UNIQUE IfcOrientedEdge[];
+  EdgeList: IfcOrientedEdge[];
 }
 
 /**
@@ -5223,7 +5223,7 @@ export interface IfcPointOnSurface extends IfcPoint {
  * @extends IfcLoop
  */
 export interface IfcPolyLoop extends IfcLoop {
-  Polygon: UNIQUE IfcCartesianPoint[];
+  Polygon: IfcCartesianPoint[];
 }
 
 /**
@@ -5250,7 +5250,7 @@ export interface IfcTessellatedFaceSet extends IfcTessellatedItem {
  */
 export interface IfcPolygonalFaceSet extends IfcTessellatedFaceSet {
   Closed?: IfcBoolean;
-  Faces: UNIQUE IfcIndexedPolygonalFace[];
+  Faces: IfcIndexedPolygonalFace[];
   PnIndex?: IfcPositiveInteger[];
 }
 
@@ -5442,7 +5442,7 @@ export interface IfcPropertyEnumeratedValue extends IfcSimpleProperty {
  */
 export interface IfcPropertyEnumeration extends IfcPropertyAbstraction {
   Name: IfcLabel;
-  EnumerationValues: UNIQUE IfcValue[];
+  EnumerationValues: IfcValue[];
   Unit?: IfcUnit;
 }
 
@@ -5496,7 +5496,7 @@ export interface IfcPropertySingleValue extends IfcSimpleProperty {
  * @extends IfcSimpleProperty
  */
 export interface IfcPropertyTableValue extends IfcSimpleProperty {
-  DefiningValues?: UNIQUE IfcValue[];
+  DefiningValues?: IfcValue[];
   DefinedValues?: IfcValue[];
   Expression?: IfcText;
   DefiningUnit?: IfcUnit;
@@ -7101,7 +7101,7 @@ export interface IfcStructuralLoadCase extends IfcStructuralLoadGroup {
  */
 export interface IfcStructuralLoadConfiguration extends IfcStructuralLoad {
   Values: IfcStructuralLoadOrResult[];
-  Locations?: number[];
+  Locations?: IfcLengthMeasure[][];
 }
 
 /**
@@ -7760,7 +7760,7 @@ export interface IfcTextureCoordinateIndices {
  * @extends IfcTextureCoordinateIndices
  */
 export interface IfcTextureCoordinateIndicesWithVoids extends IfcTextureCoordinateIndices {
-  InnerTexCoordIndices: UNIQUE IfcPositiveInteger[][];
+  InnerTexCoordIndices: IfcPositiveInteger[][];
 }
 
 /**
@@ -8113,7 +8113,7 @@ export interface IfcVirtualElement extends IfcElement {
  * IfcVirtualGridIntersection
  */
 export interface IfcVirtualGridIntersection {
-  IntersectingAxes: UNIQUE IfcGridAxis[];
+  IntersectingAxes: IfcGridAxis[];
   OffsetDistances: number[];
 }
 

--- a/packages/codegen/generated/ifc4x3/entities.ts
+++ b/packages/codegen/generated/ifc4x3/entities.ts
@@ -8297,4 +8297,3 @@ export interface IfcZShapeProfileDef extends IfcParameterizedProfileDef {
 export interface IfcZone extends IfcSystem {
   LongName?: IfcLabel;
 }
-

--- a/packages/codegen/generated/ifc4x3/schema-registry.ts
+++ b/packages/codegen/generated/ifc4x3/schema-registry.ts
@@ -423,7 +423,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -849,7 +849,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -949,7 +949,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -1139,7 +1139,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -1329,7 +1329,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -3491,7 +3491,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -4323,7 +4323,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -4513,7 +4513,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -4852,7 +4852,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6106,7 +6106,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6296,7 +6296,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6642,7 +6642,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6906,7 +6906,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7210,7 +7210,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7400,7 +7400,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7590,7 +7590,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7780,7 +7780,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7970,7 +7970,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -8654,7 +8654,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -8844,7 +8844,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -9152,7 +9152,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -9593,7 +9593,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -9903,7 +9903,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -10093,7 +10093,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -10616,7 +10616,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -10806,7 +10806,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -12556,7 +12556,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -12862,7 +12862,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13052,7 +13052,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13242,7 +13242,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13903,7 +13903,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14093,7 +14093,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14664,7 +14664,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -15326,7 +15326,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -15492,7 +15492,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16145,7 +16145,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16335,7 +16335,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16525,7 +16525,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16757,7 +16757,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16915,7 +16915,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17073,7 +17073,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18337,7 +18337,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18587,7 +18587,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18777,7 +18777,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18967,7 +18967,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19539,7 +19539,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19729,7 +19729,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19919,7 +19919,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -20109,7 +20109,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -20299,7 +20299,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -20489,7 +20489,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -20679,7 +20679,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -20967,7 +20967,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21133,7 +21133,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21301,7 +21301,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21601,7 +21601,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21783,7 +21783,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21973,7 +21973,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22163,7 +22163,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23909,7 +23909,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24099,7 +24099,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24715,7 +24715,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24905,7 +24905,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25137,7 +25137,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25295,7 +25295,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25477,7 +25477,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25667,7 +25667,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25833,7 +25833,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25991,7 +25991,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -26149,7 +26149,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -26307,7 +26307,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -26465,7 +26465,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -26647,7 +26647,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -26813,7 +26813,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -27003,7 +27003,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -27283,7 +27283,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -28038,7 +28038,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'UAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -28047,7 +28047,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'VAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -28056,7 +28056,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'WAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: true,
           isArray: false,
           isList: true,
@@ -28131,7 +28131,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'UAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -28140,7 +28140,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'VAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -28149,7 +28149,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'WAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: true,
           isArray: false,
           isList: true,
@@ -28522,7 +28522,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -28712,7 +28712,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -29115,7 +29115,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -29320,7 +29320,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'InnerCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -29340,7 +29340,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'InnerCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -29663,7 +29663,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30171,7 +30171,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30361,7 +30361,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30970,7 +30970,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -31409,7 +31409,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -32446,7 +32446,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -34513,7 +34513,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -34719,7 +34719,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -34909,7 +34909,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -35279,7 +35279,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -35494,7 +35494,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -35684,7 +35684,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -35915,7 +35915,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -37089,7 +37089,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -37309,7 +37309,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'EdgeList',
-          type: 'UNIQUE IfcOrientedEdge',
+          type: 'IfcOrientedEdge',
           optional: false,
           isArray: false,
           isList: true,
@@ -37320,7 +37320,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'EdgeList',
-          type: 'UNIQUE IfcOrientedEdge',
+          type: 'IfcOrientedEdge',
           optional: false,
           isArray: false,
           isList: true,
@@ -37486,7 +37486,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38433,7 +38433,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38623,7 +38623,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38813,7 +38813,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -39248,7 +39248,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -39489,7 +39489,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'Polygon',
-          type: 'UNIQUE IfcCartesianPoint',
+          type: 'IfcCartesianPoint',
           optional: false,
           isArray: false,
           isList: true,
@@ -39500,7 +39500,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'Polygon',
-          type: 'UNIQUE IfcCartesianPoint',
+          type: 'IfcCartesianPoint',
           optional: false,
           isArray: false,
           isList: true,
@@ -39583,7 +39583,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Faces',
-          type: 'UNIQUE IfcIndexedPolygonalFace',
+          type: 'IfcIndexedPolygonalFace',
           optional: false,
           isArray: false,
           isList: true,
@@ -39619,7 +39619,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Faces',
-          type: 'UNIQUE IfcIndexedPolygonalFace',
+          type: 'IfcIndexedPolygonalFace',
           optional: false,
           isArray: false,
           isList: true,
@@ -41699,7 +41699,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'EnumerationValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: false,
           isArray: false,
           isList: true,
@@ -41726,7 +41726,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'EnumerationValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: false,
           isArray: false,
           isList: true,
@@ -42121,7 +42121,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'DefiningValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: true,
           isArray: false,
           isList: true,
@@ -42189,7 +42189,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'DefiningValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: true,
           isArray: false,
           isList: true,
@@ -42570,7 +42570,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -42670,7 +42670,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -42860,7 +42860,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -43554,7 +43554,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -43744,7 +43744,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -44228,7 +44228,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -44328,7 +44328,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -45913,7 +45913,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -46144,7 +46144,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -46543,7 +46543,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -52149,7 +52149,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -52536,7 +52536,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -53348,7 +53348,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -53684,7 +53684,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -54079,7 +54079,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -54269,7 +54269,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -54883,7 +54883,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -55139,7 +55139,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -55453,7 +55453,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -55561,7 +55561,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -55751,7 +55751,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -55925,7 +55925,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56115,7 +56115,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56407,7 +56407,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56751,7 +56751,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56851,7 +56851,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58133,7 +58133,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Locations',
-          type: 'UNIQUE LIST [1:2] OF IfcLengthMeasure',
+          type: 'IfcLengthMeasure[]',
           optional: true,
           isArray: false,
           isList: true,
@@ -58161,7 +58161,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Locations',
-          type: 'UNIQUE LIST [1:2] OF IfcLengthMeasure',
+          type: 'IfcLengthMeasure[]',
           optional: true,
           isArray: false,
           isList: true,
@@ -61734,7 +61734,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -61974,7 +61974,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -62535,7 +62535,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -63850,7 +63850,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -64048,7 +64048,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -64172,7 +64172,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -64867,7 +64867,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'InnerTexCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -64895,7 +64895,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'InnerTexCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -65560,7 +65560,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -65750,7 +65750,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -65940,7 +65940,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -66106,7 +66106,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -66639,7 +66639,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -66863,7 +66863,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -66931,7 +66931,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -67385,7 +67385,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -67575,7 +67575,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -67765,7 +67765,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -67997,7 +67997,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -68249,7 +68249,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -68439,7 +68439,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -68569,7 +68569,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'IntersectingAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -68589,7 +68589,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'IntersectingAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -68936,7 +68936,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -69126,7 +69126,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -69801,7 +69801,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,

--- a/packages/codegen/src/express-parser.ts
+++ b/packages/codegen/src/express-parser.ts
@@ -278,23 +278,23 @@ function parseAttribute(name: string, typeStr: string, optional: boolean): Attri
 }
 
 /**
- * Parse nested collection types
- * e.g., "LIST [2:?] OF IfcCartesianPoint" -> "IfcCartesianPoint[]"
+ * Parse nested collection types, e.g. "LIST [2:?] OF IfcCartesianPoint" ->
+ * "IfcCartesianPoint[]". A leading "UNIQUE" (e.g. "LIST [1:?] OF UNIQUE
+ * IfcGridAxis") constrains the elements, not the element type — strip it.
  */
 function parseNestedCollection(typeStr: string): string {
-  // Check if this is another collection
-  if (typeStr.match(/^(LIST|ARRAY|SET)\s+\[/)) {
-    // Match: LIST|ARRAY|SET [min:max] OF <innerType>
-    const match = typeStr.match(/^(?:LIST|ARRAY|SET)\s+\[(?:\d+|\?):(?:\d+|\?)\]\s+OF\s+(.*)/);
+  const stripped = typeStr.replace(/^UNIQUE\s+/, '');
+  // Check if this is another collection: LIST|ARRAY|SET [min:max] OF <innerType>
+  if (stripped.match(/^(LIST|ARRAY|SET)\s+\[/)) {
+    const match = stripped.match(/^(?:LIST|ARRAY|SET)\s+\[(?:\d+|\?):(?:\d+|\?)\]\s+OF\s+(.*)/);
     if (match) {
       const innerType = match[1].trim();
-      // Recursively parse and wrap in array
-      return `${parseNestedCollection(innerType)}[]`;
+      return `${parseNestedCollection(innerType)}[]`; // recursively parse and wrap in array
     }
   }
 
   // Base case: return the type as-is
-  return typeStr;
+  return stripped;
 }
 
 /**

--- a/packages/codegen/src/typescript-generator.ts
+++ b/packages/codegen/src/typescript-generator.ts
@@ -84,7 +84,9 @@ function generateEntityInterfaces(schema: ExpressSchema): string {
     code += '\n\n';
   }
 
-  return code;
+  // Each entity appends its separating newline. Normalize the final separator so
+  // all generated consumers have one POSIX EOF newline rather than a blank line.
+  return `${code.trimEnd()}\n`;
 }
 
 /**

--- a/packages/codegen/src/typescript-generator.ts
+++ b/packages/codegen/src/typescript-generator.ts
@@ -84,8 +84,6 @@ function generateEntityInterfaces(schema: ExpressSchema): string {
     code += '\n\n';
   }
 
-  // Each entity appends its separating newline. Normalize the final separator so
-  // all generated consumers have one POSIX EOF newline rather than a blank line.
   return `${code.trimEnd()}\n`;
 }
 

--- a/packages/codegen/test/express-parser.test.ts
+++ b/packages/codegen/test/express-parser.test.ts
@@ -395,6 +395,79 @@ describe('EXPRESS Parser', () => {
     });
   });
 
+  describe('UNIQUE constraint inside a collection element type', () => {
+    /**
+     * EXPRESS allows a UNIQUE constraint directly in front of the element
+     * type of a LIST/ARRAY/SET, e.g. "LIST [1:?] OF UNIQUE IfcGridAxis"
+     * (real syntax from IfcGrid.UAxes in IFC4_ADD2_TC1.exp) — UNIQUE
+     * constrains the collection's elements, it is not part of the element
+     * type name. Before this fix, UNIQUE leaked into attr.type verbatim,
+     * producing the invalid TypeScript type `UNIQUE IfcGridAxis[]` in the
+     * generated entities.ts and schema-registry.ts (caught only by a
+     * hand-edit to entities.ts in one downstream package that never fixed
+     * the generator itself, so schema-registry.ts kept the bug).
+     */
+    it('strips UNIQUE from a simple collection element type', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY IfcGrid
+          SUBTYPE OF (IfcRoot);
+          UAxes : LIST [1:?] OF UNIQUE IfcGridAxis;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const attrs = getAllAttributes(schema.entities.find(e => e.name === 'IfcGrid')!, schema);
+      const uAxes = attrs.find(a => a.name === 'UAxes')!;
+      expect(uAxes.type).toBe('IfcGridAxis');
+      expect(uAxes.type).not.toContain('UNIQUE');
+    });
+
+    it('strips UNIQUE from the innermost type of a nested collection', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY IfcIndexedPolygonalFaceWithVoids
+          SUBTYPE OF (IfcRoot);
+          InnerCoordIndices : LIST [1:?] OF LIST [3:?] OF UNIQUE IfcPositiveInteger;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const attrs = getAllAttributes(
+        schema.entities.find(e => e.name === 'IfcIndexedPolygonalFaceWithVoids')!,
+        schema
+      );
+      const inner = attrs.find(a => a.name === 'InnerCoordIndices')!;
+      expect(inner.type).toBe('IfcPositiveInteger[]');
+      expect(inner.type).not.toContain('UNIQUE');
+    });
+
+    it('strips UNIQUE when it applies to a nested collection rather than a bare type', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY IfcStructuralLoadConfiguration
+          SUBTYPE OF (IfcRoot);
+          Locations : OPTIONAL LIST [1:?] OF UNIQUE LIST [1:2] OF IfcLengthMeasure;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const attrs = getAllAttributes(
+        schema.entities.find(e => e.name === 'IfcStructuralLoadConfiguration')!,
+        schema
+      );
+      const locations = attrs.find(a => a.name === 'Locations')!;
+      expect(locations.type).toBe('IfcLengthMeasure[]');
+      expect(locations.type).not.toContain('UNIQUE');
+    });
+  });
+
   describe('Real IFC schema parsing', () => {
     it('should parse IfcWall from real schema', () => {
       const schema = parseExpressSchema(`

--- a/packages/codegen/test/typescript-generator.test.ts
+++ b/packages/codegen/test/typescript-generator.test.ts
@@ -31,6 +31,21 @@ describe('TypeScript Generator', () => {
       expect(code.entities).toContain('Name?: IfcLabel;');
     });
 
+    it('ends entity output with one POSIX newline', () => {
+      const schema = parseExpressSchema(`
+        SCHEMA TEST;
+
+        ENTITY IfcRoot;
+        END_ENTITY;
+
+        END_SCHEMA;
+      `);
+
+      const code = generateTypeScript(schema);
+
+      expect(code.entities).toMatch(/[^\n]\n$/);
+    });
+
     it('should generate interface with inheritance', () => {
       const schema = parseExpressSchema(`
         SCHEMA TEST;

--- a/packages/parser/src/generated/entities.ts
+++ b/packages/parser/src/generated/entities.ts
@@ -7397,4 +7397,3 @@ export interface IfcZShapeProfileDef extends IfcParameterizedProfileDef {
 export interface IfcZone extends IfcSystem {
   LongName?: IfcLabel;
 }
-

--- a/packages/parser/src/generated/entities.ts
+++ b/packages/parser/src/generated/entities.ts
@@ -6297,7 +6297,7 @@ export interface IfcStructuralLoadCase extends IfcStructuralLoadGroup {
  */
 export interface IfcStructuralLoadConfiguration extends IfcStructuralLoad {
   Values: IfcStructuralLoadOrResult[];
-  Locations?: number[];
+  Locations?: IfcLengthMeasure[][];
 }
 
 /**
@@ -7397,3 +7397,4 @@ export interface IfcZShapeProfileDef extends IfcParameterizedProfileDef {
 export interface IfcZone extends IfcSystem {
   LongName?: IfcLabel;
 }
+

--- a/packages/parser/src/generated/schema-registry.ts
+++ b/packages/parser/src/generated/schema-registry.ts
@@ -423,7 +423,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -849,7 +849,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -949,7 +949,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -1139,7 +1139,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -1329,7 +1329,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -2642,7 +2642,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -3506,7 +3506,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -3845,7 +3845,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -4895,7 +4895,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5085,7 +5085,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5177,7 +5177,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5539,7 +5539,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -5843,7 +5843,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6033,7 +6033,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6223,7 +6223,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -6413,7 +6413,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7061,7 +7061,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7251,7 +7251,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7559,7 +7559,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -7966,7 +7966,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -8358,7 +8358,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -8548,7 +8548,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -9079,7 +9079,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -9269,7 +9269,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -11019,7 +11019,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -11325,7 +11325,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -11515,7 +11515,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -12142,7 +12142,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -12713,7 +12713,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13293,7 +13293,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13806,7 +13806,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -13996,7 +13996,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14228,7 +14228,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14386,7 +14386,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -14544,7 +14544,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -15922,7 +15922,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16062,7 +16062,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16312,7 +16312,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16502,7 +16502,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -16692,7 +16692,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17010,7 +17010,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17200,7 +17200,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17390,7 +17390,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17580,7 +17580,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17770,7 +17770,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -17960,7 +17960,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18248,7 +18248,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18414,7 +18414,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18582,7 +18582,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -18882,7 +18882,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19064,7 +19064,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19254,7 +19254,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -19444,7 +19444,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -20904,7 +20904,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21094,7 +21094,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21710,7 +21710,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -21900,7 +21900,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22156,7 +22156,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22314,7 +22314,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22496,7 +22496,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22686,7 +22686,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -22852,7 +22852,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23010,7 +23010,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23168,7 +23168,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23326,7 +23326,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23484,7 +23484,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23666,7 +23666,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -23832,7 +23832,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24022,7 +24022,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24220,7 +24220,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -24530,7 +24530,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'UAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24539,7 +24539,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'VAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24548,7 +24548,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'WAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: true,
           isArray: false,
           isList: true,
@@ -24623,7 +24623,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'UAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24632,7 +24632,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'VAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -24641,7 +24641,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'WAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: true,
           isArray: false,
           isList: true,
@@ -25006,7 +25006,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25196,7 +25196,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -25614,7 +25614,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'InnerCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -25634,7 +25634,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'InnerCoordIndices',
-          type: 'UNIQUE IfcPositiveInteger[]',
+          type: 'IfcPositiveInteger[]',
           optional: false,
           isArray: false,
           isList: true,
@@ -25904,7 +25904,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -26412,7 +26412,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -27021,7 +27021,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -27460,7 +27460,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -29874,7 +29874,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30080,7 +30080,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30352,7 +30352,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -30747,7 +30747,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -31854,7 +31854,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -32074,7 +32074,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'EdgeList',
-          type: 'UNIQUE IfcOrientedEdge',
+          type: 'IfcOrientedEdge',
           optional: false,
           isArray: false,
           isList: true,
@@ -32085,7 +32085,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'EdgeList',
-          type: 'UNIQUE IfcOrientedEdge',
+          type: 'IfcOrientedEdge',
           optional: false,
           isArray: false,
           isList: true,
@@ -33008,7 +33008,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -33198,7 +33198,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -33388,7 +33388,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -33905,7 +33905,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -34056,7 +34056,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'Polygon',
-          type: 'UNIQUE IfcCartesianPoint',
+          type: 'IfcCartesianPoint',
           optional: false,
           isArray: false,
           isList: true,
@@ -34067,7 +34067,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'Polygon',
-          type: 'UNIQUE IfcCartesianPoint',
+          type: 'IfcCartesianPoint',
           optional: false,
           isArray: false,
           isList: true,
@@ -36139,7 +36139,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'EnumerationValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: false,
           isArray: false,
           isList: true,
@@ -36166,7 +36166,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'EnumerationValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: false,
           isArray: false,
           isList: true,
@@ -36561,7 +36561,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'DefiningValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: true,
           isArray: false,
           isList: true,
@@ -36629,7 +36629,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'DefiningValues',
-          type: 'UNIQUE IfcValue',
+          type: 'IfcValue',
           optional: true,
           isArray: false,
           isList: true,
@@ -37010,7 +37010,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -37110,7 +37110,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -37398,7 +37398,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38026,7 +38026,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38306,7 +38306,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -38406,7 +38406,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -39819,7 +39819,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -40050,7 +40050,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -40449,7 +40449,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -45542,7 +45542,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -45929,7 +45929,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -46439,7 +46439,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -46629,7 +46629,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -47546,7 +47546,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -47802,7 +47802,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48116,7 +48116,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48224,7 +48224,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48414,7 +48414,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48588,7 +48588,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -48778,7 +48778,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -49044,7 +49044,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -49388,7 +49388,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -49488,7 +49488,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -50770,7 +50770,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Locations',
-          type: 'UNIQUE LIST [1:2] OF IfcLengthMeasure',
+          type: 'IfcLengthMeasure[]',
           optional: true,
           isArray: false,
           isList: true,
@@ -50798,7 +50798,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'Locations',
-          type: 'UNIQUE LIST [1:2] OF IfcLengthMeasure',
+          type: 'IfcLengthMeasure[]',
           optional: true,
           isArray: false,
           isList: true,
@@ -54395,7 +54395,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -54635,7 +54635,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -55196,7 +55196,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56511,7 +56511,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -56635,7 +56635,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -57853,7 +57853,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58043,7 +58043,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58513,7 +58513,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58737,7 +58737,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -58805,7 +58805,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59259,7 +59259,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59449,7 +59449,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59639,7 +59639,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -59933,7 +59933,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -60047,7 +60047,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       attributes: [
         {
           name: 'IntersectingAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -60067,7 +60067,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
       allAttributes: [
         {
           name: 'IntersectingAxes',
-          type: 'UNIQUE IfcGridAxis',
+          type: 'IfcGridAxis',
           optional: false,
           isArray: false,
           isList: true,
@@ -60496,7 +60496,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -60686,7 +60686,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -61434,7 +61434,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,
@@ -61574,7 +61574,7 @@ export const SCHEMA_REGISTRY: SchemaRegistry = {
         },
         {
           name: 'RepresentationMaps',
-          type: 'UNIQUE IfcRepresentationMap',
+          type: 'IfcRepresentationMap',
           optional: true,
           isArray: false,
           isList: true,


### PR DESCRIPTION
## Fix

EXPRESS permits `UNIQUE` before a collection element type, for example `LIST [1:?] OF UNIQUE IfcGridAxis`. The parser now strips that element constraint before recursively classifying the type, including nested collections.

Generated IFC4, IFC4X3, and parser artifacts were regenerated canonically; the parser mirror is byte-identical to the IFC4 output.

## Verification

- Canonical freshness check passes for all four generated-output targets.
- Module-size gate passes.
- Full PR CI is green after rebasing onto current `main`.
