### PR TITLE
fix(export): serve Properties.parquet/Quantities.parquet through the on-demand accessor

### DIFF
--- a/.changeset/parquet-properties-quantities-on-demand.md
+++ b/.changeset/parquet-properties-quantities-on-demand.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/export': patch
+---
+
+`ParquetExporter.exportBOS()`/`exportTable('properties'|'quantities')` wrote a zero-row `Properties.parquet` and `Quantities.parquet` for every model parsed the normal way — `Entities.parquet` and `Relationships.parquet` alongside them fully populated. `IfcParser.parseColumnar` (the only parse path used by every real caller) never bulk-populates `store.properties`/`store.quantities`; it serves them lazily through `onDemandPropertyMap`/`onDemandQuantityMap` and `store.getProperties()`/`store.getQuantities()` instead. The two writers read the never-populated bulk tables directly, so the gap was silent: no error, no warning, just an empty table next to full ones. Verified independently — DuckDB opened the exported `.bos` archive and read back 0 rows from both tables against a real fixture carrying thousands of property/quantity relationships.
+
+Both writers now fall back to the on-demand path (through the same `store.getProperties()`/`store.getQuantities()` accessor every other consumer uses) when the bulk table is empty but on-demand data exists, and keep the existing bulk-table path for stores that populate it directly. `Quantities.Formula` is NULL on the on-demand path — the on-demand quantity reader carries no formula string, only the bulk-table path can populate it.

--- a/packages/export/src/parquet-exporter-ondemand.ts
+++ b/packages/export/src/parquet-exporter-ondemand.ts
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `Properties.parquet` / `Quantities.parquet` writers for the on-demand parse
+ * path, extracted from `ParquetExporter` (`parquet-exporter.ts`) to keep that
+ * file under its module-size budget.
+ *
+ * `IfcParser.parseColumnar` (`packages/parser`'s only parse path, used by
+ * every real caller) never calls `.add()` on the `PropertyTableBuilder`/
+ * `QuantityTableBuilder` it constructs — properties and quantities are served
+ * lazily through `onDemandPropertyMap`/`onDemandQuantityMap` +
+ * `store.getProperties()`/`store.getQuantities()` instead
+ * (`extractPropertiesOnDemand`/`extractQuantitiesOnDemand`, re-parsing the
+ * source buffer on access). `ParquetExporter`'s bulk-table writers read
+ * `store.properties`/`store.quantities` directly, which is only populated
+ * when a caller builds a store some other way (e.g. this package's own
+ * hand-built test fixtures) — every store from a real parse left those two
+ * tables at zero rows, silently, alongside a fully-populated
+ * `Entities.parquet`/`Relationships.parquet`. These two functions are the
+ * on-demand fallback `ParquetExporter` calls when the bulk table is empty:
+ * one flat row per property/quantity, read through the same
+ * `store.getProperties()`/`store.getQuantities()` accessor every other
+ * consumer (the query package, the viewer's property panel) uses — never a
+ * second copy of the pset/property walk.
+ */
+
+import type { IfcDataStore } from '@ifc-lite/parser';
+import { PropertyValueType, type QuantityType } from '@ifc-lite/data';
+import type { EffectiveEntityIndex } from './effective-index.js';
+import { columnsToParquet } from './columns-to-parquet.js';
+import { PARQUET_UINT32_COLUMNS } from './parquet-uint32-columns.js';
+import { propertyValueTypeToString, quantityTypeToString } from './parquet-type-strings.js';
+
+export async function writePropertiesOnDemand(
+    store: IfcDataStore,
+    effective: EffectiveEntityIndex | null,
+): Promise<Uint8Array> {
+    const entityIdCol: number[] = [];
+    const psetNameCol: string[] = [];
+    const psetGlobalIdCol: string[] = [];
+    const propNameCol: string[] = [];
+    const propTypeCol: PropertyValueType[] = [];
+    const valueStringCol: (string | null)[] = [];
+    const valueRealCol: number[] = [];
+    const valueIntCol: number[] = [];
+    const valueBoolCol: (boolean | null)[] = [];
+
+    for (const id of store.onDemandPropertyMap!.keys()) {
+        if (effective?.isDeleted(id)) continue;
+        const psets = store.getProperties(id);
+        for (const pset of psets) {
+            for (const prop of pset.properties) {
+                entityIdCol.push(id);
+                psetNameCol.push(pset.name);
+                psetGlobalIdCol.push(pset.globalId ?? '');
+                propNameCol.push(prop.name);
+                propTypeCol.push(prop.type);
+                const v = prop.value;
+                valueStringCol.push(typeof v === 'string' ? v : null);
+                valueRealCol.push(prop.type === PropertyValueType.Real && typeof v === 'number' ? v : 0);
+                valueIntCol.push(prop.type === PropertyValueType.Integer && typeof v === 'number' ? v : 0);
+                valueBoolCol.push(typeof v === 'boolean' ? v : null);
+            }
+        }
+    }
+
+    return columnsToParquet({
+        EntityId: entityIdCol,
+        PsetName: psetNameCol,
+        PsetGlobalId: psetGlobalIdCol,
+        PropName: propNameCol,
+        PropType: propTypeCol.map(t => propertyValueTypeToString(t)),
+        ValueString: valueStringCol,
+        ValueReal: valueRealCol,
+        ValueInt: valueIntCol,
+        ValueBool: valueBoolCol,
+    }, new Set(['ValueReal']), PARQUET_UINT32_COLUMNS);
+}
+
+/**
+ * `Formula` is always NULL here: the on-demand quantity reader
+ * (`readQuantitySet` in `@ifc-lite/parser`) reports only
+ * `{name, type, value}` per quantity, so there is no formula string to carry
+ * — `ParquetExporter`'s bulk-table path is the only one that can populate it.
+ */
+export async function writeQuantitiesOnDemand(
+    store: IfcDataStore,
+    effective: EffectiveEntityIndex | null,
+): Promise<Uint8Array> {
+    const entityIdCol: number[] = [];
+    const qsetNameCol: string[] = [];
+    const quantityNameCol: string[] = [];
+    const quantityTypeCol: QuantityType[] = [];
+    const valueCol: number[] = [];
+    const formulaCol: (string | null)[] = [];
+
+    for (const id of store.onDemandQuantityMap!.keys()) {
+        if (effective?.isDeleted(id)) continue;
+        const qsets = store.getQuantities(id);
+        for (const qset of qsets) {
+            for (const q of qset.quantities) {
+                entityIdCol.push(id);
+                qsetNameCol.push(qset.name);
+                quantityNameCol.push(q.name);
+                quantityTypeCol.push(q.type);
+                valueCol.push(q.value);
+                formulaCol.push(q.formula ?? null);
+            }
+        }
+    }
+
+    return columnsToParquet({
+        EntityId: entityIdCol,
+        QsetName: qsetNameCol,
+        QuantityName: quantityNameCol,
+        QuantityType: quantityTypeCol.map(t => quantityTypeToString(t)),
+        Value: valueCol,
+        Formula: formulaCol,
+    }, new Set(['Value']), PARQUET_UINT32_COLUMNS);
+}

--- a/packages/export/src/parquet-exporter-ondemand.ts
+++ b/packages/export/src/parquet-exporter-ondemand.ts
@@ -43,7 +43,10 @@ export async function writePropertiesOnDemand(
     const propNameCol: string[] = [];
     const propTypeCol: PropertyValueType[] = [];
     const valueStringCol: (string | null)[] = [];
-    const valueRealCol: number[] = [];
+    // `IfcPropertyBoundedValue` is surfaced as a display string but retains
+    // the REAL type tag. Only a scalar numeric value belongs in ValueReal;
+    // writing 0 for the display-string form fabricates a measurement.
+    const valueRealCol: (number | null)[] = [];
     const valueIntCol: number[] = [];
     const valueBoolCol: (boolean | null)[] = [];
 
@@ -59,7 +62,7 @@ export async function writePropertiesOnDemand(
                 propTypeCol.push(prop.type);
                 const v = prop.value;
                 valueStringCol.push(typeof v === 'string' ? v : null);
-                valueRealCol.push(prop.type === PropertyValueType.Real && typeof v === 'number' ? v : 0);
+                valueRealCol.push(prop.type === PropertyValueType.Real && typeof v === 'number' ? v : null);
                 valueIntCol.push(prop.type === PropertyValueType.Integer && typeof v === 'number' ? v : 0);
                 valueBoolCol.push(typeof v === 'boolean' ? v : null);
             }

--- a/packages/export/src/parquet-exporter.test.ts
+++ b/packages/export/src/parquet-exporter.test.ts
@@ -569,3 +569,131 @@ describe('ParquetExporter overlay retypes', () => {
     expect((unknownType as string).toLowerCase()).toContain('someunknown');
   });
 });
+
+// Independent-reader parity hunt: `IfcParser.parseColumnar` (`packages/parser`'s
+// only parse path, used by every real caller) never calls `.add()` on the
+// `PropertyTableBuilder`/`QuantityTableBuilder` it constructs — properties and
+// quantities are served lazily through `onDemandPropertyMap`/
+// `onDemandQuantityMap` + `store.getProperties()`/`store.getQuantities()`
+// instead. `writeProperties`/`writeQuantities` read `store.properties`/
+// `store.quantities` (the never-populated bulk table) directly, so
+// `Properties.parquet`/`Quantities.parquet` came out with zero rows for every
+// model parsed the normal way — verified independently: DuckDB opened the
+// exported `.bos` archive from `tests/models/ara3d/duplex.ifc` (a real parse,
+// not this file's hand-built fixtures) and read back 0 rows from both tables
+// despite the source file carrying 2,960 `IFCPROPERTYSET`/
+// `IFCRELDEFINESBYPROPERTIES`/`IFCELEMENTQUANTITY` lines. `Entities.parquet`
+// and `Relationships.parquet` — populated eagerly during parse, unaffected by
+// this gap — read back correctly throughout, so this test's mock leaves them
+// on the ordinary bulk-table path as the control.
+describe('ParquetExporter on-demand properties/quantities (independent-reader parity hunt)', () => {
+  function buildOnDemandDataStore(): MockDataStore {
+    const strings = new StringTable();
+
+    const entityBuilder = new EntityTableBuilder(1, strings);
+    entityBuilder.add(1, 'IFCWALL', 'wall-1-guid', 'Wall1', '', '');
+
+    const relBuilder = new RelationshipGraphBuilder();
+    relBuilder.addEdge(10, 1, RelationshipType.ContainsElements, 100);
+
+    // Empty bulk tables — exactly what `parseLite` produces: the builders
+    // exist but nothing was ever `.add()`-ed to them.
+    const emptyProperties = new PropertyTableBuilder(strings).build();
+    const emptyQuantities = new QuantityTableBuilder(strings).build();
+
+    const onDemandPropertyMap = new Map<number, number[]>([[1, [200]]]);
+    const onDemandQuantityMap = new Map<number, number[]>([[1, [300]]]);
+
+    const store = {
+      fileSize: 0,
+      schemaVersion: 'IFC4',
+      entityCount: 1,
+      parseTime: 0,
+      source: new Uint8Array(0),
+      entityIndex: { byId: new Map<number, EntityRef>(), byType: new Map<string, number[]>() },
+      strings,
+      entities: entityBuilder.build(),
+      properties: emptyProperties,
+      quantities: emptyQuantities,
+      relationships: relBuilder.build(),
+      onDemandPropertyMap,
+      onDemandQuantityMap,
+      // Stand in for `extractPropertiesOnDemand`/`extractQuantitiesOnDemand`
+      // without a real source buffer to re-parse — same shape the real
+      // accessor returns (`packages/data/src/property-table.ts`'s
+      // `PropertySet`/`packages/data/src/quantity-table.ts`'s `QuantitySet`).
+      getProperties: (expressId: number) => {
+        if (expressId !== 1) return [];
+        return [{
+          name: 'Pset_WallCommon',
+          globalId: 'pset-1-guid',
+          properties: [
+            { name: 'IsExternal', type: PropertyValueType.Boolean, value: true },
+            { name: 'Reference', type: PropertyValueType.String, value: 'Basic Wall' },
+          ],
+        }];
+      },
+      getQuantities: (expressId: number) => {
+        if (expressId !== 1) return [];
+        return [{
+          name: 'Qto_WallBaseQuantities',
+          quantities: [
+            { name: 'Length', type: QuantityType.Length, value: 4.2 },
+          ],
+        }];
+      },
+    } as unknown as MockDataStore;
+
+    return store;
+  }
+
+  it('reads Properties.parquet through onDemandPropertyMap when the bulk table is empty', async () => {
+    const dataStore = buildOnDemandDataStore();
+    const exporter = new ParquetExporter(dataStore);
+    const rows = decodeParquet(await exporter.exportTable('properties'));
+
+    expect(rows).toHaveLength(2);
+    const isExternal = rows.find((r) => r.PropName === 'IsExternal');
+    expect(isExternal?.EntityId).toBe(1);
+    expect(isExternal?.PsetName).toBe('Pset_WallCommon');
+    expect(isExternal?.ValueBool).toBe(true);
+    const reference = rows.find((r) => r.PropName === 'Reference');
+    expect(reference?.ValueString).toBe('Basic Wall');
+  });
+
+  it('reads Quantities.parquet through onDemandQuantityMap when the bulk table is empty', async () => {
+    const dataStore = buildOnDemandDataStore();
+    const exporter = new ParquetExporter(dataStore);
+    const rows = decodeParquet(await exporter.exportTable('quantities'));
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].EntityId).toBe(1);
+    expect(rows[0].QsetName).toBe('Qto_WallBaseQuantities');
+    expect(rows[0].QuantityName).toBe('Length');
+    expect(rows[0].Value).toBeCloseTo(4.2);
+  });
+
+  it('still exports Entities/Relationships (the bulk path, unaffected by this gap) alongside the on-demand tables', async () => {
+    const dataStore = buildOnDemandDataStore();
+    const exporter = new ParquetExporter(dataStore);
+
+    const entityRows = decodeParquet(await exporter.exportTable('entities'));
+    expect(entityRows.map((r) => r.Name)).toContain('Wall1');
+
+    const relRows = decodeParquet(await exporter.exportTable('relationships'));
+    expect(relRows.map((r) => r.TargetId)).toContain(1);
+  });
+
+  it('honours overlay deletions on the on-demand property/quantity path', async () => {
+    const dataStore = buildOnDemandDataStore();
+    const view = new LiveMutablePropertyView(null, 'm1');
+    view.deleteEntity(1);
+
+    const exporter = new ParquetExporter(dataStore, undefined, view);
+    const propRows = decodeParquet(await exporter.exportTable('properties'));
+    const qtyRows = decodeParquet(await exporter.exportTable('quantities'));
+
+    expect(propRows).toHaveLength(0);
+    expect(qtyRows).toHaveLength(0);
+  });
+});

--- a/packages/export/src/parquet-exporter.test.ts
+++ b/packages/export/src/parquet-exporter.test.ts
@@ -630,6 +630,10 @@ describe('ParquetExporter on-demand properties/quantities (independent-reader pa
           properties: [
             { name: 'IsExternal', type: PropertyValueType.Boolean, value: true },
             { name: 'Reference', type: PropertyValueType.String, value: 'Basic Wall' },
+            // IfcPropertyBoundedValue keeps a REAL type tag but its on-demand
+            // representation is a display string, not a scalar measurement.
+            { name: 'PermittedLength', type: PropertyValueType.Real, value: '0.25 [0.1 – 0.5]' },
+            { name: 'NominalLength', type: PropertyValueType.Real, value: 0.25 },
           ],
         }];
       },
@@ -652,13 +656,18 @@ describe('ParquetExporter on-demand properties/quantities (independent-reader pa
     const exporter = new ParquetExporter(dataStore);
     const rows = decodeParquet(await exporter.exportTable('properties'));
 
-    expect(rows).toHaveLength(2);
+    expect(rows).toHaveLength(4);
     const isExternal = rows.find((r) => r.PropName === 'IsExternal');
     expect(isExternal?.EntityId).toBe(1);
     expect(isExternal?.PsetName).toBe('Pset_WallCommon');
     expect(isExternal?.ValueBool).toBe(true);
     const reference = rows.find((r) => r.PropName === 'Reference');
     expect(reference?.ValueString).toBe('Basic Wall');
+    const bounded = rows.find((r) => r.PropName === 'PermittedLength');
+    expect(bounded?.ValueString).toBe('0.25 [0.1 – 0.5]');
+    expect(bounded?.ValueReal).toBeNull();
+    const scalar = rows.find((r) => r.PropName === 'NominalLength');
+    expect(scalar?.ValueReal).toBeCloseTo(0.25);
   });
 
   it('reads Quantities.parquet through onDemandQuantityMap when the bulk table is empty', async () => {

--- a/packages/export/src/parquet-exporter.ts
+++ b/packages/export/src/parquet-exporter.ts
@@ -7,9 +7,12 @@
 import type { IfcDataStore } from '@ifc-lite/parser';
 import type { GeometryResult } from '@ifc-lite/geometry';
 import type { MutablePropertyView } from '@ifc-lite/mutations';
-import { IfcTypeEnum, EntityFlags, PropertyValueType, QuantityType, RelationshipType, IFC_ENTITY_NAMES, exactTypeName } from '@ifc-lite/data';
+import { IfcTypeEnum, EntityFlags, RelationshipType, IFC_ENTITY_NAMES, exactTypeName } from '@ifc-lite/data';
 import { getEffectiveEntityIndex, type EffectiveEntityIndex } from './effective-index.js';
 import { columnsToParquet } from './columns-to-parquet.js';
+import { PARQUET_UINT32_COLUMNS } from './parquet-uint32-columns.js';
+import { writePropertiesOnDemand, writeQuantitiesOnDemand } from './parquet-exporter-ondemand.js';
+import { propertyValueTypeToString, quantityTypeToString } from './parquet-type-strings.js';
 
 export interface ParquetExportOptions {
     includeGeometry?: boolean;
@@ -173,6 +176,23 @@ export class ParquetExporter {
         const { properties, strings } = this.store;
         const effective = this.getEffective();
 
+        // `IfcParser.parseColumnar` (the sole parse path every real caller of
+        // this exporter goes through — `packages/parser`'s `parseLite`) never
+        // populates `store.properties`: it builds a `PropertyTableBuilder` but
+        // never calls `.add()` on it, relying instead on lazy per-entity
+        // extraction via `onDemandPropertyMap` + `store.getProperties()`
+        // (`extractPropertiesOnDemand`, re-parsing the source buffer on
+        // access). Reading `store.properties` directly here — the bulk table
+        // — silently wrote a zero-row `Properties.parquet` for every model
+        // parsed the normal way, geometry/relationships/entities tables full
+        // alongside it. `store.properties` only carries real rows when a
+        // caller builds a store some other way (e.g. hand-built fixtures in
+        // this file's own tests). Route through the on-demand path first;
+        // fall back to the bulk table when it was actually populated.
+        if (properties.entityId.length === 0 && this.store.onDemandPropertyMap && this.store.onDemandPropertyMap.size > 0) {
+            return writePropertiesOnDemand(this.store, effective);
+        }
+
         const entityId = Array.from(properties.entityId);
         // A property row belongs to the entity named in its own EntityId
         // column, not to its own row index — filter on that, not on ExpressId.
@@ -183,7 +203,7 @@ export class ParquetExporter {
             PsetName: mapTypedArray(properties.psetName, i => strings.get(i)),
             PsetGlobalId: mapTypedArray(properties.psetGlobalId, i => strings.get(i)),
             PropName: mapTypedArray(properties.propName, i => strings.get(i)),
-            PropType: mapTypedArray(properties.propType, t => PropertyValueTypeToString(t)),
+            PropType: mapTypedArray(properties.propType, t => propertyValueTypeToString(t)),
             ValueString: mapTypedArray(properties.valueString, i => i >= 0 && i < strings.count ? strings.get(i) : null),
             ValueReal: Array.from(properties.valueReal),
             ValueInt: Array.from(properties.valueInt),
@@ -195,6 +215,15 @@ export class ParquetExporter {
         const { quantities, strings } = this.store;
         const effective = this.getEffective();
 
+        // Same gap as `writeProperties`: `store.quantities` is only ever
+        // populated when a caller bulk-builds it directly (this file's own
+        // tests); the real `parseColumnar` path leaves it empty and serves
+        // quantities lazily through `onDemandQuantityMap` +
+        // `store.getQuantities()`.
+        if (quantities.entityId.length === 0 && this.store.onDemandQuantityMap && this.store.onDemandQuantityMap.size > 0) {
+            return writeQuantitiesOnDemand(this.store, effective);
+        }
+
         const entityId = Array.from(quantities.entityId);
         const keep = effective ? entityId.map((id) => !effective.isDeleted(id)) : null;
 
@@ -202,7 +231,7 @@ export class ParquetExporter {
             EntityId: entityId,
             QsetName: mapTypedArray(quantities.qsetName, i => strings.get(i)),
             QuantityName: mapTypedArray(quantities.quantityName, i => strings.get(i)),
-            QuantityType: mapTypedArray(quantities.quantityType, t => QuantityTypeToString(t)),
+            QuantityType: mapTypedArray(quantities.quantityType, t => quantityTypeToString(t)),
             Value: Array.from(quantities.value),
             Formula: mapTypedArray(quantities.formula, i => i > 0 ? strings.get(i) : null),
         }, keep), new Set(['Value']));
@@ -509,42 +538,8 @@ export class ParquetExporter {
     // UTILITIES
     // ═══════════════════════════════════════════════════════════════
 
-    /**
-     * Column names whose domain is an unsigned 32-bit integer.
-     *
-     * Every one carries an IFC EXPRESS ID or an index into a geometry buffer,
-     * and both are `u32` everywhere else in this codebase - `Uint32Array` in
-     * the parser's entity index and its transports, `u32` in the Rust crates.
-     * Arrow's content inference reaches for Int32 on any whole number, so an
-     * express id at or above 2_147_483_648 came out NEGATIVE: an id-shaped
-     * number that joins to nothing. STEP puts no upper bound on an entity id
-     * below the `u32` the readers use, so that is reachable input rather than a
-     * hypothetical.
-     */
-    private static readonly UINT32_COLUMNS: ReadonlySet<string> = new Set([
-        'ExpressId', 'EntityId', 'SourceId', 'TargetId', 'RelId',
-        'ElementId', 'StoreyId',
-        'Index0', 'Index1', 'Index2',
-        'VertexStart', 'VertexCount', 'IndexStart', 'IndexCount',
-    ]);
-
-    /**
-     * NOT in the set above, deliberately: `BuildingId`, `SiteId` and `SpaceId`
-     * in `SpatialHierarchy.parquet` carry **-1 as "none"** (see
-     * `writeSpatialHierarchy` - a storey directly under the project has no
-     * building). Declaring those unsigned turned that sentinel into
-     * 4294967295: an id-shaped number where an obviously-absent marker used to
-     * be, which is the exact failure this class of change exists to prevent.
-     *
-     * The residual gap is the narrower one: a building or site id at or above
-     * 2^31 still wraps negative in those three columns. Fixing that properly
-     * means writing NULL rather than -1 for "none", which changes what every
-     * consumer reads for an absent parent and is a separate decision from the
-     * id width.
-     */
-
     private async toParquet(columns: Record<string, any[]>, floatColumns?: Set<string>): Promise<Uint8Array> {
-        return columnsToParquet(columns, floatColumns, ParquetExporter.UINT32_COLUMNS);
+        return columnsToParquet(columns, floatColumns, PARQUET_UINT32_COLUMNS);
     }
 
     private async createZipArchive(files: Map<string, Uint8Array>): Promise<Uint8Array> {
@@ -584,36 +579,12 @@ function filterColumns<T extends Record<string, unknown[]>>(columns: T, keep: bo
     return out;
 }
 
-function PropertyValueTypeToString(type: PropertyValueType): string {
-    const names: Record<PropertyValueType, string> = {
-        [PropertyValueType.String]: 'String',
-        [PropertyValueType.Real]: 'Real',
-        [PropertyValueType.Integer]: 'Integer',
-        [PropertyValueType.Boolean]: 'Boolean',
-        [PropertyValueType.Logical]: 'Logical',
-        [PropertyValueType.Label]: 'Label',
-        [PropertyValueType.Identifier]: 'Identifier',
-        [PropertyValueType.Text]: 'Text',
-        [PropertyValueType.Enum]: 'Enum',
-        [PropertyValueType.Reference]: 'Reference',
-        [PropertyValueType.List]: 'List',
-    };
-    return names[type] || 'Unknown';
-}
-
-// Quantity type conversion - exported for future use when quantities are implemented
-export function QuantityTypeToString(type: QuantityType): string {
-    const names: Record<QuantityType, string> = {
-        [QuantityType.Length]: 'Length',
-        [QuantityType.Area]: 'Area',
-        [QuantityType.Volume]: 'Volume',
-        [QuantityType.Count]: 'Count',
-        [QuantityType.Weight]: 'Weight',
-        [QuantityType.Time]: 'Time',
-        [QuantityType.Number]: 'Number',
-    };
-    return names[type] || 'Unknown';
-}
+// Kept exported under its original name here (moved to `parquet-type-strings.ts`
+// so the on-demand writers can share it without importing this file, which
+// imports them): nothing in-repo imports it from this path — index.ts never
+// re-exported it — but it was public `export function` surface before the
+// module split, so a re-export costs nothing to keep.
+export { quantityTypeToString as QuantityTypeToString } from './parquet-type-strings.js';
 
 function RelationshipTypeToString(type: RelationshipType): string {
     const names: Record<RelationshipType, string> = {

--- a/packages/export/src/parquet-type-strings.ts
+++ b/packages/export/src/parquet-type-strings.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `PropertyValueType`/`QuantityType` enum -> Parquet column string, shared
+ * between `ParquetExporter`'s bulk-table writers (`parquet-exporter.ts`) and
+ * its on-demand fallback (`parquet-exporter-ondemand.ts`) so `Properties.
+ * PropType` and `Quantities.QuantityType` read the same strings regardless
+ * of which path produced the row.
+ */
+
+import { PropertyValueType, QuantityType } from '@ifc-lite/data';
+
+export function propertyValueTypeToString(type: PropertyValueType): string {
+    const names: Record<PropertyValueType, string> = {
+        [PropertyValueType.String]: 'String',
+        [PropertyValueType.Real]: 'Real',
+        [PropertyValueType.Integer]: 'Integer',
+        [PropertyValueType.Boolean]: 'Boolean',
+        [PropertyValueType.Logical]: 'Logical',
+        [PropertyValueType.Label]: 'Label',
+        [PropertyValueType.Identifier]: 'Identifier',
+        [PropertyValueType.Text]: 'Text',
+        [PropertyValueType.Enum]: 'Enum',
+        [PropertyValueType.Reference]: 'Reference',
+        [PropertyValueType.List]: 'List',
+    };
+    return names[type] || 'Unknown';
+}
+
+export function quantityTypeToString(type: QuantityType): string {
+    const names: Record<QuantityType, string> = {
+        [QuantityType.Length]: 'Length',
+        [QuantityType.Area]: 'Area',
+        [QuantityType.Volume]: 'Volume',
+        [QuantityType.Count]: 'Count',
+        [QuantityType.Weight]: 'Weight',
+        [QuantityType.Time]: 'Time',
+        [QuantityType.Number]: 'Number',
+    };
+    return names[type] || 'Unknown';
+}

--- a/packages/export/src/parquet-uint32-columns.ts
+++ b/packages/export/src/parquet-uint32-columns.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Column names whose domain is an unsigned 32-bit integer, shared between
+ * `ParquetExporter` (`parquet-exporter.ts`) and its on-demand property/
+ * quantity writers (`parquet-exporter-ondemand.ts`) — one list, not two that
+ * could disagree on which columns need the u32 guard.
+ *
+ * Every one carries an IFC EXPRESS ID or an index into a geometry buffer,
+ * and both are `u32` everywhere else in this codebase - `Uint32Array` in
+ * the parser's entity index and its transports, `u32` in the Rust crates.
+ * Arrow's content inference reaches for Int32 on any whole number, so an
+ * express id at or above 2_147_483_648 came out NEGATIVE: an id-shaped
+ * number that joins to nothing. STEP puts no upper bound on an entity id
+ * below the `u32` the readers use, so that is reachable input rather than a
+ * hypothetical.
+ *
+ * NOT in this set, deliberately: `BuildingId`, `SiteId` and `SpaceId` in
+ * `SpatialHierarchy.parquet` carry **-1 as "none"** (see
+ * `writeSpatialHierarchy` - a storey directly under the project has no
+ * building). Declaring those unsigned turned that sentinel into
+ * 4294967295: an id-shaped number where an obviously-absent marker used to
+ * be, which is the exact failure this class of change exists to prevent.
+ *
+ * The residual gap is the narrower one: a building or site id at or above
+ * 2^31 still wraps negative in those three columns. Fixing that properly
+ * means writing NULL rather than -1 for "none", which changes what every
+ * consumer reads for an absent parent and is a separate decision from the
+ * id width.
+ */
+export const PARQUET_UINT32_COLUMNS: ReadonlySet<string> = new Set([
+    'ExpressId', 'EntityId', 'SourceId', 'TargetId', 'RelId',
+    'ElementId', 'StoreyId',
+    'Index0', 'Index1', 'Index2',
+    'VertexStart', 'VertexCount', 'IndexStart', 'IndexCount',
+]);


### PR DESCRIPTION
## Summary

`ParquetExporter.writeProperties()`/`writeQuantities()` read `store.properties`/`store.quantities` directly. `IfcParser.parseColumnar` — the only parse path every real caller goes through (`packages/parser`'s `parseLite`) — never populates those bulk tables: it constructs a `PropertyTableBuilder`/`QuantityTableBuilder` but never calls `.add()` on either, serving properties and quantities lazily instead through `onDemandPropertyMap`/`onDemandQuantityMap` + `store.getProperties()`/`store.getQuantities()`.

Result: every model parsed the normal way exported a **zero-row `Properties.parquet` and `Quantities.parquet`**, silently — no error, no warning — sitting next to a fully populated `Entities.parquet`/`Relationships.parquet` in the same `.bos` archive.

Both writers now fall back to the on-demand path (through the same `store.getProperties()`/`store.getQuantities()` accessor every other consumer — the query package, the viewer's property panel — uses) when the bulk table is empty but on-demand data exists, and keep the existing bulk-table path unchanged for stores that populate it directly (this package's own hand-built test fixtures, and any external caller that assembles a store that way).

## Independent-reader verification (self round-trip is blind to this class of bug)

Installed `duckdb` in a scratch dir (`/tmp/pq`, not a repo dependency) and read the exported `.bos` archive's Parquet files with it directly — an independent Rust/C++ implementation, not our own `parquet-wasm` reader.

Fixture: `tests/models/ara3d/duplex.ifc` (IFC2X3, 2,960 `IFCPROPERTYSET`/`IFCRELDEFINESBYPROPERTIES`/`IFCELEMENTQUANTITY` lines in source).

| Check | Unmodified `main` (RED) | This branch (GREEN) |
|---|---|---|
| `Properties.parquet` row count (DuckDB) | 0 | 13,434 |
| `Quantities.parquet` row count (DuckDB) | 0 | 21 |
| Sample row `IsExternal` (Boolean) | — | reads back as SQL `false`/`true`, not stringified |
| Sample row `Reference` (String) | — | `"Basic Wall:Exterior - Brick on Block"` |
| `Entities.parquet` / `Relationships.parquet` (control — unaffected by this bug) | 1080 / 3200 rows | 1080 / 3200 rows (unchanged) |

Confirmed on two more fixtures, same pattern (bulk table empty on main, populated after the fix; entities/relationships identical throughout):

| Fixture | Properties (RED → GREEN) | Quantities (RED → GREEN) |
|---|---|---|
| `ara3d/AC20-FZK-Haus.ifc` (IFC4) | 0 → 4,431 | 0 → 3,284 |
| `AB22.ifc` (IFC4X3_RC4) | 0 → 336 | 0 → 0 (this fixture legitimately carries no quantities) |

The DuckDB reader stays a scratch script (not a repo dependency); the four new unit tests below use a hand-built mock store shaped like the real on-demand parse output (empty bulk tables + `onDemandPropertyMap`/`onDemandQuantityMap`) and assert through the existing `parquet-wasm` decode helper already used by this test file, which is enough to pin the regression against our own tooling.

## Changes

- `packages/export/src/parquet-exporter.ts`: `writeProperties`/`writeQuantities` check whether the bulk table is actually populated; if not (and on-demand data exists) they delegate to the new on-demand writers instead of silently emitting zero rows.
- `packages/export/src/parquet-exporter-ondemand.ts` (new): the on-demand `Properties.parquet`/`Quantities.parquet` writers, walking `onDemandPropertyMap`/`onDemandQuantityMap` through `store.getProperties()`/`store.getQuantities()`. `Quantities.Formula` is always NULL on this path — the on-demand quantity reader (`readQuantitySet`) reports only `{name, type, value}`, no formula string; only the bulk-table path can populate it.
- `packages/export/src/parquet-type-strings.ts` / `parquet-uint32-columns.ts` (new): the `PropertyValueType`/`QuantityType` → string tables and the u32-column-name set, extracted so the on-demand module and `parquet-exporter.ts` share one copy instead of two that could disagree. `QuantityTypeToString` stays re-exported from `parquet-exporter.ts` under its original name (unused in-repo, not part of the package's `index.ts` surface, but was public `export function` before the split).
- `packages/export/src/parquet-exporter.test.ts`: four new tests build a mock store shaped like the real on-demand parse path and pin the on-demand `Properties`/`Quantities` writers, the control (`Entities`/`Relationships` on the ordinary bulk path), and overlay-deletion behaviour on the on-demand path.
- Extracting the on-demand writers to sibling modules also keeps `parquet-exporter.ts` under its `check-module-size.mjs` budget (would otherwise land at 758 lines against a 639 budget).

## Test plan

- [x] `pnpm --filter @ifc-lite/export test` — 1066/1066 pass (1062 pre-existing + 4 new)
- [x] `pnpm --filter @ifc-lite/export build` / `tsc --noEmit` — clean
- [x] Independent DuckDB read of the exported `.bos` archive on 3 real fixtures — RED confirmed on unmodified `main`, GREEN confirmed on this branch, control (`Entities`/`Relationships`) unchanged
- [x] `node scripts/check-module-size.mjs` — OK (`parquet-exporter.ts` at 610/639 lines)
- [x] `pnpm run check:vitest-timeout-audit` — clean (no regex-literal-with-parens issues)
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `node scripts/check-unused-locals.mjs` — `packages/export` compiles standalone and is clean; the packages it lists as non-compiling (viewer, cli, sdk, etc.) are pre-existing and untouched by this change
- [x] Changeset added (`patch`, `@ifc-lite/export`) — no public API surface change (`index.ts` untouched, `ParquetExporter`'s public constructor/`exportBOS`/`exportTable` signatures unchanged)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


## Twin check: does the server/Rust path have the same defect?

No. Traced both Rust parquet writers' data flow:

- **`rust/export/src/parquet_bos.rs`** (`export_bos`, the native/server `.bos` writer this PR's TS fix mirrors): calls `build_export_model` (`rust/export/src/model.rs`), whose Pass 2 resolves `resolve_pset_defs(&mut decoder, &def_ids)` into `EntityRow.property_sets`/`.quantity_sets` **eagerly, per IfcProduct row, during model construction** — not deferred to an on-demand accessor the writer might skip. `properties_table`/`quantities_table` then just iterate `model.entities[].property_sets`/`.quantity_sets`, which are the same fields Pass 2 just filled in.
- **`apps/server/src/services/parquet_data_model.rs`** (the server's HTTP-streamed `DataModel` writer): `serialize_properties_table(&data_model.property_sets)` / `serialize_quantities_table(&data_model.quantity_sets)` read `DataModel.property_sets`/`.quantity_sets` (`apps/server/src/services/data_model/types.rs`), populated by `extract_data_model` (`apps/server/src/services/data_model/mod.rs:132`) via `rayon::join`, calling into `properties.rs`/`quantities.rs` unconditionally as part of building the `DataModel` — same shape: eager, not lazy.

Confirmed by running the export, not just reading the source: temporarily added a `#[test]` to `parquet_bos.rs` calling `export_bos` on `tests/models/ara3d/duplex.ifc` (same fixture as the TS RED/GREEN above) and dumping the `.bos` bytes, then read it independently with DuckDB (removed before commit — no diff left in `rust/`):

| Table | Rust `export_bos` on `duplex.ifc` |
|---|---|
| `Properties.parquet` row count | 13,434 |
| `Quantities.parquet` row count | 21 |
| Sample row | `Pset_WallCommon.Reference = "Basic Wall:Interior - Partition (92mm Stud)"`, `LoadBearing = "false"` |

Matches the TS fix's GREEN counts on the same fixture (13,434 / 21) — the Rust twin was never affected because, unlike `IfcParser.parseColumnar`'s `parseLite` in the TS parser, both Rust parse paths (`build_export_model`, `extract_data_model`) populate their property/quantity fields eagerly at model-construction time, so the parquet writers read data that is actually there. No code change needed on the Rust side.

(`Entities.parquet` reports 295 rows for `export_bos` vs. entity counts reported elsewhere in this PR for the TS path — `export_bos`'s Pass 2 only emits `IfcProduct`-subtype rows, a documented scope difference, not related to this defect.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Parquet exports that produced empty `Properties.parquet` and `Quantities.parquet` files for data loaded on demand.
  - Property and quantity records are now included correctly, including numeric, boolean, and bounded-value data.
  - Deletions are respected when exporting on-demand data.
  - Improved handling of large IFC identifiers so they retain correct unsigned values in exported Parquet files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up correction

- Non-scalar REAL values from the on-demand accessor (including `IfcPropertyBoundedValue`'s display-string representation) preserve `ValueString` and emit NULL in `ValueReal`; only scalar numeric REAL values populate `ValueReal`.
- Regression coverage asserts both the bounded REAL NULL case and the scalar REAL numeric case.
