### PR TITLE
fix(viewer-embed): apply every field of INIT's config, not just theme (#2934)

### DIFF
--- a/.changeset/embed-init-config-fields.md
+++ b/.changeset/embed-init-config-fields.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/viewer-embed': patch
+---
+
+Apply every field of an INIT command's `config` payload, not just `theme`.
+
+`InboundPayloads['INIT']`'s `config` field is the published `EmbedConfig` type (`packages/embed-protocol`) — `theme`, `bg`, `controls`, `hideAxis`, `hideScale`, `hideTypes`. Only `theme` ever reached an actuator; the other five were declared and silently dropped for anyone driving the postMessage protocol directly (the SDK itself never populates `config` at all — it only ever sends `token`, and every one of these fields already has a `?param=` URL equivalent that IS applied). A host setting `config.controls` or `config.hideAxis` on INIT, expecting the same effect its URL-param sibling gets, got nothing.
+
+Each field now reuses the exact actuator its URL param already calls (`setInteractionMode` for `controls`, `setBackgroundColor` for `bg`), so INIT and the URL params cannot drift from each other. `hideAxis`/`hideScale`/`hideTypes` previously had no actuator at all outside the one-time URL parse — `EmbedViewer` read them from a plain object captured once in a `useState` initialiser — so this also makes those three genuinely mutable at runtime via `useEmbedRuntimeOverlays`, not just at mount.

--- a/apps/viewer-embed/src/bridge/handler.test.ts
+++ b/apps/viewer-embed/src/bridge/handler.test.ts
@@ -153,6 +153,7 @@ function makeState() {
       setPresetView: rec('setPresetView'),
     },
     setTheme: rec('setTheme'),
+    setInteractionMode: rec('setInteractionMode'),
     // Mirrors the real implementation's Map.delete semantics exactly
     // (apps/viewer/src/store/slices/modelSlice.ts ~147-213): deleting an
     // absent key is a silent no-op, no throw. The bridge is responsible for
@@ -201,6 +202,7 @@ function makeCtx(state: any, overrides: Partial<Record<string, any>> = {}) {
     addModelFromUrl: overrides.addModelFromUrl
       ?? vi.fn(async () => ({ modelId: 'default-added-id', entities: 10, triangles: 20, vertices: 30 })),
     setBackgroundColor: overrides.setBackgroundColor ?? vi.fn(),
+    setOverlays: overrides.setOverlays ?? vi.fn(),
   };
 }
 
@@ -531,6 +533,39 @@ describe('INIT', () => {
     initBridge(makeCtx(state));
     await send(fw, cmd('INIT', { config: {} }, 'r1'));
     expect(called(state, 'setTheme')).toBe(false);
+  });
+
+  // #2934 follow-up: INIT's `config` is the published `EmbedConfig` type
+  // (packages/embed-protocol), and only `.theme` ever reached an actuator.
+  // `.bg`, `.controls`, `.hideAxis`, `.hideScale` and `.hideTypes` were
+  // declared and silently dropped for a host driving the postMessage
+  // protocol directly. Each now reuses the same actuator its `?param=` URL
+  // equivalent already calls.
+  it('applies config.bg via the same setBackgroundColor actuator SET_THEME uses', async () => {
+    const ctx = makeCtx(state);
+    initBridge(ctx);
+    await send(fw, cmd('INIT', { config: { bg: 'ff0000' } }, 'r1'));
+    expect(ctx.setBackgroundColor).toHaveBeenCalledWith('ff0000');
+  });
+
+  it('applies config.controls via the same setInteractionMode actuator ?controls= uses', async () => {
+    initBridge(makeCtx(state));
+    await send(fw, cmd('INIT', { config: { controls: 'none' } }, 'r1'));
+    expect(argsOf(state, 'setInteractionMode')).toEqual(['none']);
+  });
+
+  it('applies config.hideAxis/.hideScale/.hideTypes via the merged setOverlays actuator', async () => {
+    const ctx = makeCtx(state);
+    initBridge(ctx);
+    await send(fw, cmd('INIT', { config: { hideAxis: true, hideScale: true, hideTypes: ['IfcSpace'] } }, 'r1'));
+    expect(ctx.setOverlays).toHaveBeenCalledWith({ hideAxis: true, hideScale: true, hideTypes: ['IfcSpace'] });
+  });
+
+  it('does not call setOverlays when config has none of the three overlay fields', async () => {
+    const ctx = makeCtx(state);
+    initBridge(ctx);
+    await send(fw, cmd('INIT', { config: { theme: 'dark' } }, 'r1'));
+    expect(ctx.setOverlays).not.toHaveBeenCalled();
   });
 
   it('rejects a token mismatch without applying config or ACKing', async () => {

--- a/apps/viewer-embed/src/bridge/handler.ts
+++ b/apps/viewer-embed/src/bridge/handler.ts
@@ -24,6 +24,7 @@ import {
 } from '@ifc-lite/embed-protocol';
 import { toGlobalIdFromModels, type ViewerState } from '@/store/index.js';
 import { aroundDestructiveLoad, offerHostPose } from './cameraIntent.js';
+import { applyInitConfig } from './initConfig.js';
 
 /** Reference to the store's getState / setState for imperative access */
 interface BridgeContext {
@@ -35,6 +36,7 @@ interface BridgeContext {
   // Adds a model to the federation alongside what's already loaded (unlike LOAD_MODEL); resolves the real minted model id for later REMOVE_MODEL targeting.
   addModelFromUrl: (url: string, name?: string) => Promise<{ modelId: string; entities: number; triangles: number; vertices: number }>;
   setBackgroundColor: (bg: string | undefined) => void; // set (or clear, with undefined) the embed's custom background colour
+  setOverlays: (overlays: { hideAxis?: boolean; hideScale?: boolean; hideTypes?: string[] }) => void; // hideAxis/hideScale/hideTypes, also settable from INIT's config (initConfig.ts)
 }
 
 /** Optional security knobs for the bridge (all opt-in; defaults preserve the public-widget behaviour). */
@@ -241,8 +243,7 @@ async function handleCommand(type: InboundCommandType, data: unknown, requestId?
         }
         return;
       }
-      // Apply initial config if provided
-      if (payload?.config?.theme) state.setTheme(payload.config.theme);
+      applyInitConfig(payload?.config, { setTheme: state.setTheme, setInteractionMode: state.setInteractionMode, setBackgroundColor: ctx.setBackgroundColor, setOverlays: ctx.setOverlays }); // every config field, not just theme (initConfig.ts)
       // ACK the init
       if (requestId) {
         emitToParent(createResponse(requestId));

--- a/apps/viewer-embed/src/bridge/initConfig.test.ts
+++ b/apps/viewer-embed/src/bridge/initConfig.test.ts
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * #2934 follow-up: INIT's `config` payload (the published `EmbedConfig` type)
+ * only ever applied `.theme`. `applyInitConfig` is the fix, tested here in
+ * isolation from the postMessage plumbing handler.test.ts already covers.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { applyInitConfig } from './initConfig.js';
+
+function makeActuators() {
+  return {
+    setTheme: vi.fn(),
+    setInteractionMode: vi.fn(),
+    setBackgroundColor: vi.fn(),
+    setOverlays: vi.fn(),
+  };
+}
+
+describe('applyInitConfig', () => {
+  it('does nothing when config is undefined', () => {
+    const actuators = makeActuators();
+    applyInitConfig(undefined, actuators);
+    expect(actuators.setTheme).not.toHaveBeenCalled();
+    expect(actuators.setInteractionMode).not.toHaveBeenCalled();
+    expect(actuators.setBackgroundColor).not.toHaveBeenCalled();
+    expect(actuators.setOverlays).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when config is an empty object', () => {
+    const actuators = makeActuators();
+    applyInitConfig({}, actuators);
+    expect(actuators.setTheme).not.toHaveBeenCalled();
+    expect(actuators.setInteractionMode).not.toHaveBeenCalled();
+    expect(actuators.setBackgroundColor).not.toHaveBeenCalled();
+    expect(actuators.setOverlays).not.toHaveBeenCalled();
+  });
+
+  it('applies theme via setTheme', () => {
+    const actuators = makeActuators();
+    applyInitConfig({ theme: 'dark' }, actuators);
+    expect(actuators.setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('applies bg via setBackgroundColor, the same actuator SET_THEME uses', () => {
+    const actuators = makeActuators();
+    applyInitConfig({ bg: '00ff00' }, actuators);
+    expect(actuators.setBackgroundColor).toHaveBeenCalledWith('00ff00');
+  });
+
+  it('applies controls via setInteractionMode, the same actuator ?controls= uses', () => {
+    const actuators = makeActuators();
+    applyInitConfig({ controls: 'orbit' }, actuators);
+    expect(actuators.setInteractionMode).toHaveBeenCalledWith('orbit');
+  });
+
+  it('merges hideAxis/hideScale/hideTypes into one setOverlays call', () => {
+    const actuators = makeActuators();
+    applyInitConfig({ hideAxis: true, hideScale: false, hideTypes: ['IfcSpace', 'IfcOpeningElement'] }, actuators);
+    expect(actuators.setOverlays).toHaveBeenCalledTimes(1);
+    expect(actuators.setOverlays).toHaveBeenCalledWith({
+      hideAxis: true,
+      hideScale: false,
+      hideTypes: ['IfcSpace', 'IfcOpeningElement'],
+    });
+  });
+
+  it('calls setOverlays when only ONE of the three overlay fields is present', () => {
+    const actuators = makeActuators();
+    applyInitConfig({ hideAxis: true }, actuators);
+    expect(actuators.setOverlays).toHaveBeenCalledWith({ hideAxis: true, hideScale: undefined, hideTypes: undefined });
+  });
+
+  it('applies every field of a fully-populated config in one call', () => {
+    const actuators = makeActuators();
+    applyInitConfig(
+      { theme: 'light', bg: '112233', controls: 'none', hideAxis: true, hideScale: true, hideTypes: ['IfcWall'] },
+      actuators,
+    );
+    expect(actuators.setTheme).toHaveBeenCalledWith('light');
+    expect(actuators.setBackgroundColor).toHaveBeenCalledWith('112233');
+    expect(actuators.setInteractionMode).toHaveBeenCalledWith('none');
+    expect(actuators.setOverlays).toHaveBeenCalledWith({ hideAxis: true, hideScale: true, hideTypes: ['IfcWall'] });
+  });
+});

--- a/apps/viewer-embed/src/bridge/initConfig.ts
+++ b/apps/viewer-embed/src/bridge/initConfig.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Applies an INIT command's optional `config` payload (the published
+ * `EmbedConfig` type from `@ifc-lite/embed-protocol`) to the store and bridge
+ * context.
+ *
+ * Before this, `handler.ts`'s INIT case read only `config.theme`. The other
+ * five fields — `bg`, `controls`, `hideAxis`, `hideScale`, `hideTypes` — are
+ * declared on the same exported type, mirror the `?bg=`/`?controls=`/etc. URL
+ * params exactly, and were silently dropped: a real integration driving the
+ * postMessage protocol directly (not through the SDK, which never populates
+ * `config` at all) would set them on INIT expecting the same effect the URL
+ * params get, and nothing would happen. Each case below reuses the identical
+ * actuator its URL-param equivalent already calls, so INIT and the URL params
+ * can't drift from each other.
+ */
+
+import type { EmbedConfig } from '@ifc-lite/embed-protocol';
+
+export interface InitConfigActuators {
+  setTheme: (theme: 'light' | 'dark') => void;
+  setInteractionMode: (mode: NonNullable<EmbedConfig['controls']>) => void;
+  setBackgroundColor: (bg: string | undefined) => void;
+  /** Merged sink for the three URL-only overlay params: hideAxis, hideScale, hideTypes. */
+  setOverlays: (overlays: Pick<EmbedConfig, 'hideAxis' | 'hideScale' | 'hideTypes'>) => void;
+}
+
+export function applyInitConfig(config: EmbedConfig | undefined, actuators: InitConfigActuators): void {
+  if (!config) return;
+  if (config.theme) actuators.setTheme(config.theme);
+  if (config.bg !== undefined) actuators.setBackgroundColor(config.bg);
+  if (config.controls) actuators.setInteractionMode(config.controls);
+  const { hideAxis, hideScale, hideTypes } = config;
+  if (hideAxis !== undefined || hideScale !== undefined || hideTypes !== undefined) {
+    actuators.setOverlays({ hideAxis, hideScale, hideTypes });
+  }
+}

--- a/apps/viewer-embed/src/bridge/lifecycle.test.ts
+++ b/apps/viewer-embed/src/bridge/lifecycle.test.ts
@@ -102,6 +102,7 @@ function makeCtx(state: any) {
       vertices: 0,
     }),
     setBackgroundColor: () => {},
+    setOverlays: () => {},
   };
 }
 

--- a/apps/viewer-embed/src/components/EmbedViewer.tsx
+++ b/apps/viewer-embed/src/components/EmbedViewer.tsx
@@ -26,6 +26,7 @@ import { mountBridgeLifecycle, unmountBridgeLifecycle } from '../bridge/lifecycl
 import { useEmbedBridgeEvents } from './useEmbedBridgeEvents.js';
 import { useEmbedPostLoad } from './useEmbedPostLoad.js';
 import { useEmbedUrlParams, toHiddenTypeSet, isTypeHidden } from './useEmbedUrlParams.js';
+import { useEmbedRuntimeOverlays } from './useEmbedRuntimeOverlays.js';
 import type { MeshData, CoordinateInfo } from '@ifc-lite/geometry';
 
 export function EmbedViewer() {
@@ -47,6 +48,8 @@ export function EmbedViewer() {
   // leading '#') to match the URL-param convention and normalized to CSS
   // color the same way in both places.
   const [customBgHex, setCustomBgHex] = useState<string | undefined>(urlParams.bg);
+  // Same rationale as customBgHex above, for INIT's config.hideAxis/.hideScale/.hideTypes (#2934 follow-up).
+  const { hideAxis, hideScale, hideTypes, setOverlays } = useEmbedRuntimeOverlays(urlParams);
 
   // Apply URL params on mount. Embeds default to light unless ?theme=dark
   // (the surrounding viewer-core store may bootstrap to dark based on system
@@ -144,6 +147,7 @@ export function EmbedViewer() {
           };
         },
         setBackgroundColor: (bg: string | undefined) => setCustomBgHex(bg),
+        setOverlays,
       }, {
         allowedOrigins: urlParams.allowOrigins,
         expectedParentOrigin,
@@ -252,7 +256,7 @@ export function EmbedViewer() {
   // string[]` already ships as accepting), so it cannot go through
   // `typeVisibility`, whose six semantic toggles are a fixed set — it is a
   // case-folded membership test in this same pass instead.
-  const hiddenTypes = useMemo(() => toHiddenTypeSet(urlParams.hideTypes), [urlParams.hideTypes]);
+  const hiddenTypes = useMemo(() => toHiddenTypeSet(hideTypes), [hideTypes]);
   const filteredGeometry = useMemo(() => {
     if (!mergedGeometryResult?.meshes) return null;
     let meshes = mergedGeometryResult.meshes;
@@ -387,7 +391,7 @@ export function EmbedViewer() {
             computedIsolatedIds={computedIsolatedIds}
             modelIdToIndex={modelIdToIndex}
           />
-          <ViewportOverlays hideViewCube hideAxis={urlParams.hideAxis} hideScale={urlParams.hideScale} />
+          <ViewportOverlays hideViewCube hideAxis={hideAxis} hideScale={hideScale} />
         </div>
       )}
     </div>

--- a/apps/viewer-embed/src/components/useEmbedRuntimeOverlays.ts
+++ b/apps/viewer-embed/src/components/useEmbedRuntimeOverlays.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Mutable state for the three overlay/visibility params that have no store
+ * actuator of their own: `hideAxis`, `hideScale`, `hideTypes`. Seeded from the
+ * URL params (matching every embed's behaviour up to #2934), but also
+ * writable later — an INIT command's `config` payload names the same three
+ * fields on the published `EmbedConfig` type (packages/embed-protocol), and
+ * until this hook existed there was nowhere to put a later write: `EmbedViewer`
+ * read `urlParams.hideAxis`/`.hideScale`/`.hideTypes` directly, a plain object
+ * captured once in a `useState` initialiser, so INIT's `config.hideAxis` (etc.)
+ * had a documented type and no write site — the same "declared but does
+ * nothing" shape #2934 found for the URL params themselves.
+ *
+ * `hideAxis`/`hideScale` are used as `ViewportOverlays` props; `hideTypes` is
+ * fed into `toHiddenTypeSet` — see EmbedViewer.tsx.
+ */
+
+import { useState } from 'react';
+import type { EmbedViewerUrlParams } from '../bridge/urlParams.js';
+
+export interface EmbedRuntimeOverlays {
+  hideAxis: boolean | undefined;
+  hideScale: boolean | undefined;
+  hideTypes: string[] | undefined;
+  /** Merged setter matching handler.ts's BridgeContext.setOverlays shape 1:1 — pass straight through to initBridge. */
+  setOverlays: (overlays: { hideAxis?: boolean; hideScale?: boolean; hideTypes?: string[] }) => void;
+}
+
+export function useEmbedRuntimeOverlays(urlParams: EmbedViewerUrlParams): EmbedRuntimeOverlays {
+  const [hideAxis, setHideAxis] = useState(urlParams.hideAxis);
+  const [hideScale, setHideScale] = useState(urlParams.hideScale);
+  const [hideTypes, setHideTypes] = useState(urlParams.hideTypes);
+  const setOverlays = (overlays: { hideAxis?: boolean; hideScale?: boolean; hideTypes?: string[] }) => {
+    if (overlays.hideAxis !== undefined) setHideAxis(overlays.hideAxis);
+    if (overlays.hideScale !== undefined) setHideScale(overlays.hideScale);
+    if (overlays.hideTypes !== undefined) setHideTypes(overlays.hideTypes);
+  };
+  return { hideAxis, hideScale, hideTypes, setOverlays };
+}


### PR DESCRIPTION
## Summary

Full census of the embed surface — every `EmbedOptions` field / URL param, every SDK method → protocol message → handler → effect, every protocol message's producer/consumer, every SDK event → real emit site — done to end #2934's instance-at-a-time pattern rather than add another one. One genuine finding: `INIT`'s `config` payload (a composite field on the published `EmbedConfig` type) only ever applied `.theme`; the other five fields were declared and silently dropped. Fixed, with the full census below as the record that nothing else in this surface is inert, partial, or echo-only.

## The matrix

### `EmbedOptions` / URL params (packages/embed-sdk `options.ts` → `embedUrlSearchParams` → `apps/viewer-embed/src/bridge/urlParams.ts` → applied)

| field | serialised? | parsed? | applied at | verdict |
|---|---|---|---|---|
| `container` | n/a (DOM only) | n/a | `IFCLiteEmbed` constructor, mounts iframe | APPLIED |
| `modelUrl` | yes | yes | `EmbedViewer.tsx` autoLoad effect | APPLIED |
| `autoLoad` | yes (`=false` only) | yes | `EmbedViewer.tsx` autoLoad effect gate (#3170) | APPLIED |
| `theme` | yes | yes | `EmbedViewer.tsx` mount effect → `setTheme` | APPLIED |
| `bg` | yes | yes | `EmbedViewer.tsx` `customBgHex` → background style | APPLIED |
| `controls` | yes | yes | `useEmbedUrlParams` → `setInteractionMode` → `camera-controls.ts` gesture gates (#3367) | APPLIED |
| `hideAxis` | yes | yes | `ViewportOverlays` prop (#3316) | APPLIED |
| `hideScale` | yes | yes | `ViewportOverlays` prop (#3316) | APPLIED |
| `hideTypes` | yes | yes | `hiddenTypes` membership filter, case-folded (#3189) | APPLIED |
| `select` | yes | yes | `useEmbedUrlParams` → `setSelectedEntityIds` (#3189) | APPLIED |
| `isolate` | yes | yes | `useEmbedUrlParams` → `setIsolatedEntities` (#3189) | APPLIED |
| `view` | yes | yes | `useEmbedPostLoad` preset framing | APPLIED |
| `camera` | yes | yes | `useEmbedPostLoad` → `offerHostPose`/camera actuator (#2978) | APPLIED |
| `camera.zoom` | yes | yes | deliberately NOT applied — documented "reserved", no absolute-zoom actuator exists | DOC'D NON-APPLICATION (not a bug) |
| `origin`/`token`/`timeout` | n/a (SDK-internal) | n/a | iframe src / handshake | APPLIED |

### Inbound commands (protocol `InboundCommandType` → SDK method → `handler.ts` case → actuator)

All 23 command types have exactly one SDK method and one `handler.ts` case; 22 reach a real actuator, `GET_SCREENSHOT` returns an honest `NOT_IMPLEMENTED`. Composite payloads checked field-by-field:

| command | fields checked | verdict |
|---|---|---|
| `INIT` | `token`, `config.{theme,bg,controls,hideAxis,hideScale,hideTypes}` | **PARTIAL → FIXED HERE**: only `config.theme` reached an actuator; `bg`/`controls`/`hideAxis`/`hideScale`/`hideTypes` were declared on the exported `EmbedConfig` type and silently dropped. The SDK itself never populates `config` (only `token`), so this only bit a host driving the postMessage protocol directly — still a real, documented public surface (`@ifc-lite/embed-protocol`'s `InboundPayloads['INIT']`). |
| `SET_CAMERA` | `azimuth`, `elevation`, `zoom` | APPLIED (`zoom` reserved, documented) — fixed by #2978 |
| `SET_SECTION` | `axis`, `position`, `enabled`, `flipped` | APPLIED, all four independently optional-gated |
| `SET_THEME` | `theme`, `bg` | APPLIED, both |
| `SET_TYPE_VISIBILITY` | `spaces`, `openings`, `site` | APPLIED, all three |
| `SET_COLORS`/`RESET_COLORS` | `colorMap` / (void) | APPLIED — fixed by #2978, verified backup/restore round-trips |
| every remaining command | (see protocol source) | APPLIED |

### Outbound events (`OutboundEventType` → real emit site, not just an SDK echo path)

| event | emitted at | echo-only? |
|---|---|---|
| `READY`/`INIT_ACK` | handshake | n/a |
| `MODEL_LOADING`/`MODEL_LOADED`/`MODEL_ERROR` | load pipeline (`EmbedViewer.tsx`, `useEmbedPostLoad`) | real |
| `ENTITY_SELECTED`/`ENTITY_DESELECTED` | `useEmbedBridgeEvents` on store selection change | real |
| `ENTITY_HOVERED` | `useEmbedBridgeEvents` on `hoverState.entityId` | real — fixed by #2978 (previously never emitted; SDK's own tests only proved the SDK's dispatch, not the viewer's emission) |
| `CAMERA_CHANGED` | `subscribeCameraRotation` off `updateCameraRotationRealtime`'s listener fan-out | real, fires on drag/keyboard/ViewCube, not only as an echo of a host's own `SET_CAMERA` — fixed by #3304 (the #3304 class this lens calls out by name) |
| `SECTION_CHANGED` | `useEmbedBridgeEvents` on section-plane store change | real |

## The fix

`apps/viewer-embed/src/bridge/handler.ts`'s `INIT` case now calls a new `applyInitConfig` (`bridge/initConfig.ts`) that applies every `EmbedConfig` field via the *same actuator its URL-param sibling already uses*: `setInteractionMode` for `controls`, `setBackgroundColor` for `bg`. `hideAxis`/`hideScale`/`hideTypes` had no actuator at all outside the one-time URL parse — `EmbedViewer` read them from a plain object captured once in a `useState` initialiser — so they get a new small hook, `useEmbedRuntimeOverlays`, giving them a real runtime setter (`setOverlays`) that both the initial URL parse and a later `INIT` can write to.

Both `handler.ts` (522/522) and `EmbedViewer.tsx` (399/400) were at or near their module-size budgets, so the new logic lives in two new sibling files (`initConfig.ts`, `useEmbedRuntimeOverlays.ts`) rather than growing either — no `--allow-raise`, no allowlist edit.

## Test plan

- [x] `apps/viewer-embed/src/bridge/initConfig.test.ts` (new): unit tests for `applyInitConfig` — undefined/empty config no-ops, each field's actuator individually, and the merged `setOverlays` call (including the "only one of three overlay fields present" case)
- [x] `apps/viewer-embed/src/bridge/handler.test.ts` (extended): `INIT` now asserts `config.bg`/`config.controls`/`config.{hideAxis,hideScale,hideTypes}` reach `setBackgroundColor`/`setInteractionMode`/`setOverlays`, plus a control that `setOverlays` is NOT called when no overlay field is present
- [x] `apps/viewer-embed/src/bridge/lifecycle.test.ts`: updated double to satisfy the grown `BridgeContext` interface (typecheck covers test sources)
- [x] Full `apps/viewer-embed` suite: 226/226 pass
- [x] `@ifc-lite/embed-sdk` (74/74) and `@ifc-lite/embed-protocol` (22/22) suites unaffected (neither package touched — no export/type change)
- [x] `node scripts/check-module-size.mjs` — OK (2032 files measured, 0 new over 400)
- [x] `pnpm run check:vitest-timeout-audit` — clean
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `node scripts/check-unused-locals.mjs` — clean for `apps/viewer`, `apps/viewer-embed` (built full dependency chain first); 3 pre-existing unrelated packages (`source-dalux`/`source-dropbox`/`source-msgraph`) fail to compile standalone for reasons unrelated to this change (missing sibling package builds in a fresh worktree) and are untouched by this PR
- [x] `pnpm exec tsc --noEmit` clean for `apps/viewer-embed`, `packages/embed-protocol`, `packages/embed-sdk`
- [x] Changeset: `@ifc-lite/viewer-embed` patch (private app, but ships its own `CHANGELOG.md`)
- [x] No `packages/*` public export changed → no `api-surface.json` update needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * INIT configuration now applies theme, background color, control mode, and visibility settings for axes, scale, and types.
  * Overlay visibility can be updated dynamically at runtime, without reloading the viewer.

* **Bug Fixes**
  * Fixed INIT configuration fields being ignored or applied only during initial viewer loading.
  * Ensured overlay settings are consistently merged when updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->