### PR TITLE
fix(bcf): stop fabricating CreationAuthor/Author for a non-conformant markup.bcf

### DIFF
--- a/.changeset/bcf-reader-stops-fabricating-author.md
+++ b/.changeset/bcf-reader-stops-fabricating-author.md
@@ -1,0 +1,12 @@
+---
+'@ifc-lite/bcf': major
+---
+
+Stop the BCF reader from fabricating a `CreationAuthor`/`Author` when a `markup.bcf` omits the required element, and stop the writer from emitting an archive that omission makes schema-invalid.
+
+`markup.xsd` declares `Topic/CreationAuthor` and `Comment/Author` as required `UserIdType` (string) elements with no schema default — the same shape as `Topic/CreationDate`/`Comment/Date`, which a prior release already stopped fabricating. When a non-conformant source file omitted one, the reader substituted the literal string `'Unknown'`, which is indistinguishable downstream from a genuinely-declared author name.
+
+Two breaking changes, both on the read/write round trip for such a file:
+
+- `BCFTopic.creationAuthor` and `BCFComment.author` are now `string | undefined`. The reader passes through what the file declared and substitutes nothing. Code that assumed a `string` — `topic.creationAuthor.split('@')[0]`, string-templating `comment.author` — has to handle the missing case.
+- `writeBCF` now rejects a topic or comment with no author (and a topic with `ModifiedDate` but no `ModifiedAuthor`/`CreationAuthor` to fall back to) instead of silently emitting an author-less element, whose absence makes the `markup.bcf` fail `markup.xsd` in both BCF 2.1 and 3.0. This is the same rule the writer already applies to `CreationDate`/`Date` and to a BCF 3.0 topic with no `TopicType`: it will neither invent a value the source never stated nor hand back an archive it knows is invalid. The error names the element and the topic/comment guid, so a caller that does know the author can supply it and write again.

--- a/.changeset/bcf-viewer-author-display.md
+++ b/.changeset/bcf-viewer-author-display.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/viewer': patch
+---
+
+BCF topics and comments read from a file that omitted `CreationAuthor`/`Author` no longer show `Unknown` as their author. They now show no author byline instead of a fabricated placeholder.

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.author.test.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.author.test.tsx
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import '@/test/setup-dom.js';
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { cleanup, render } from '@/test/render.js';
+import type { BCFTopic } from '@ifc-lite/bcf';
+import { BCFTopicDetail } from './BCFTopicDetail.js';
+
+afterEach(cleanup);
+
+const TOPIC: BCFTopic = {
+  guid: 'topic-1',
+  title: 'Untitled author',
+  creationDate: '2026-01-01T00:00:00Z',
+  comments: [{
+    guid: 'comment-1',
+    date: '2026-01-02T00:00:00Z',
+    comment: 'The source omitted this required author.',
+  }],
+  viewpoints: [],
+};
+
+describe('BCFTopicDetail author display (#3574)', () => {
+  it('shows an authorless comment date without a user icon or dangling separator', () => {
+    const container = render(
+      <BCFTopicDetail
+        topic={TOPIC}
+        onBack={() => {}}
+        onEditTopic={() => {}}
+        onAddComment={() => {}}
+        onAddViewpoint={() => {}}
+        onActivateViewpoint={() => {}}
+        onDeleteViewpoint={() => {}}
+        onUpdateStatus={() => {}}
+        onZoomToTopic={() => {}}
+        canZoomToTopic={false}
+        onDeleteTopic={() => {}}
+        selectionCount={0}
+        hasIsolation={false}
+        hasHiddenEntities={false}
+      />,
+    );
+
+    const comment = [...container.querySelectorAll('p')].find((node) =>
+      node.textContent?.includes(TOPIC.comments[0].comment),
+    )?.parentElement;
+    assert.ok(comment, 'comment card must render');
+    assert.equal(comment.querySelector('svg.lucide-user'), null, 'missing author has no user icon');
+    assert.ok(!comment.textContent?.includes('-'), 'missing author has no dangling date separator');
+  });
+});

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -339,9 +339,12 @@ export function BCFTopicDetail({
                       </div>
                     )}
                     <div className="flex items-center gap-2 mb-1 text-xs text-muted-foreground">
-                      <User className="h-3 w-3" />
-                      {comment.author && <span>{comment.author.split('@')[0]}</span>}
-                      {comment.date && <><span>-</span><span>{formatDateTime(comment.date)}</span></>}
+                      {comment.author && <>
+                        <User className="h-3 w-3" />
+                        <span>{comment.author.split('@')[0]}</span>
+                      </>}
+                      {comment.author && comment.date && <span>-</span>}
+                      {comment.date && <span>{formatDateTime(comment.date)}</span>}
                       {comment.viewpointGuid && (
                         <span className="flex items-center gap-0.5">
                           <Camera className="h-3 w-3" />

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -185,10 +185,11 @@ export function BCFTopicDetail({
             )}
 
             <div className="text-xs text-muted-foreground space-y-1">
-              <p>
-                Created by {topic.creationAuthor}
-                {topic.creationDate ? <> on {formatDateTime(topic.creationDate)}</> : null}
-              </p>
+              {(topic.creationAuthor || topic.creationDate) && (
+                <p>
+                  {topic.creationAuthor ? `Created by ${topic.creationAuthor}` : 'Created'}{topic.creationDate && <> on {formatDateTime(topic.creationDate)}</>}
+                </p>
+              )}
               {topic.assignedTo && <p>Assigned to: {topic.assignedTo}</p>}
               {topic.dueDate && <p>Due: {formatDate(topic.dueDate)}</p>}
             </div>
@@ -339,7 +340,7 @@ export function BCFTopicDetail({
                     )}
                     <div className="flex items-center gap-2 mb-1 text-xs text-muted-foreground">
                       <User className="h-3 w-3" />
-                      <span>{comment.author.split('@')[0]}</span>
+                      {comment.author && <span>{comment.author.split('@')[0]}</span>}
                       {comment.date && <><span>-</span><span>{formatDateTime(comment.date)}</span></>}
                       {comment.viewpointGuid && (
                         <span className="flex items-center gap-0.5">

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicDetail.tsx
@@ -339,10 +339,7 @@ export function BCFTopicDetail({
                       </div>
                     )}
                     <div className="flex items-center gap-2 mb-1 text-xs text-muted-foreground">
-                      {comment.author && <>
-                        <User className="h-3 w-3" />
-                        <span>{comment.author.split('@')[0]}</span>
-                      </>}
+                      {comment.author && <><User className="h-3 w-3" /><span>{comment.author.split('@')[0]}</span></>}
                       {comment.author && comment.date && <span>-</span>}
                       {comment.date && <span>{formatDateTime(comment.date)}</span>}
                       {comment.viewpointGuid && (

--- a/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
+++ b/apps/viewer/src/components/viewer/bcf/BCFTopicList.tsx
@@ -212,10 +212,12 @@ export function BCFTopicList({
                 )}
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <PriorityBadge priority={topic.priority} />
-                  <span className="flex items-center gap-1">
-                    <User className="h-3 w-3" />
-                    {topic.creationAuthor.split('@')[0]}
-                  </span>
+                  {topic.creationAuthor && (
+                    <span className="flex items-center gap-1">
+                      <User className="h-3 w-3" />
+                      {topic.creationAuthor.split('@')[0]}
+                    </span>
+                  )}
                   {topic.creationDate && (
                     <span className="flex items-center gap-1">
                       <Calendar className="h-3 w-3" />

--- a/packages/bcf/src/fabricated-author.test.ts
+++ b/packages/bcf/src/fabricated-author.test.ts
@@ -28,8 +28,11 @@ import JSZip from 'jszip';
 import { readFile } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { validateXML } from 'xmllint-wasm';
 
 import { readBCF } from './reader.js';
+import { writeBCF } from './writer.js';
+import type { BCFProject } from './types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEST_DATA_DIR = join(__dirname, '..', 'test-data');
@@ -45,6 +48,30 @@ async function archiveWithEditedMarkup(edit: (xml: string) => string): Promise<U
   expect(edited, 'the edit must actually change the XML').not.toBe(xml);
   zip.file(markupName, edited);
   return zip.generateAsync({ type: 'uint8array' });
+}
+
+async function markupOf(blob: Blob): Promise<string> {
+  const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+  const name = Object.keys(zip.files).find((entry) => entry.endsWith('markup.bcf'));
+  if (!name) throw new Error('no markup.bcf in archive');
+  return zip.file(name)!.async('string');
+}
+
+async function validatesMarkup(version: '2.1' | '3.0', markup: string): Promise<boolean> {
+  const schemaDir = version === '2.1' ? 'v2_1' : 'v3_0';
+  const markupSchema = await readFile(join(__dirname, '__fixtures__', 'schemas', schemaDir, 'markup.xsd'), 'utf8');
+  const preload = version === '3.0'
+    ? [{
+        fileName: 'shared-types.xsd',
+        contents: await readFile(join(__dirname, '__fixtures__', 'schemas', schemaDir, 'shared-types.xsd'), 'utf8'),
+      }]
+    : [];
+  const result = await validateXML({
+    xml: [{ fileName: 'subject.xml', contents: markup }],
+    schema: [markupSchema],
+    preload,
+  });
+  return result.valid;
 }
 
 describe('BCF reader — CreationAuthor/Author fabrication (markup.xsd required, no default)', () => {
@@ -90,5 +117,40 @@ describe('BCF reader — CreationAuthor/Author fabrication (markup.xsd required,
 
     expect(comment.author).not.toBe('Unknown');
     expect(comment.author).toBeUndefined();
+  });
+});
+
+describe('BCF writer — version-aware required author strings (#3574)', () => {
+  it('preserves whitespace-only 2.1 authors and emits markup valid under the 2.1 schema', async () => {
+    const project = await readBCF(await readFile(join(TEST_DATA_DIR, 'PerspectiveCamera.bcf')));
+    const topic = Array.from(project.topics.values())[0];
+    topic.creationAuthor = ' \t\n ';
+    topic.comments = [{
+      guid: 'c1a2b3c4-0000-0000-0000-000000000003',
+      date: '2026-01-01T00:00:00Z',
+      author: '\t ',
+      comment: 'A schema-valid blank 2.1 author is still explicitly present.',
+    }];
+
+    const markup = await markupOf(await writeBCF(project));
+    expect(markup).toContain('<CreationAuthor> \t\n </CreationAuthor>');
+    expect(markup).toContain('<Author>\t </Author>');
+    expect(await validatesMarkup('2.1', markup)).toBe(true);
+  });
+
+  it('retains 3.0 NonEmptyOrBlankString rejection for whitespace-only authors', async () => {
+    const topic = {
+      guid: '11111111-1111-4111-8111-111111111111',
+      title: '3.0 author guard',
+      topicType: 'Issue',
+      topicStatus: 'Open',
+      creationDate: '2026-01-01T00:00:00Z',
+      creationAuthor: ' \t ',
+      comments: [],
+      viewpoints: [],
+    };
+    const project: BCFProject = { version: '3.0', topics: new Map([[topic.guid, topic]]) };
+
+    await expect(writeBCF(project)).rejects.toThrow(/Topic\/CreationAuthor/);
   });
 });

--- a/packages/bcf/src/fabricated-author.test.ts
+++ b/packages/bcf/src/fabricated-author.test.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `markup.xsd` declares `Topic/CreationAuthor` and `Comment/Author` as
+ * required `UserIdType` (string) elements with no schema default (see
+ * `__fixtures__/schemas/v2_1/markup.xsd` lines ~68, ~108), exactly like
+ * `Topic/CreationDate` and `Comment/Date`, which `fabricated-creation-date.test.ts`
+ * already pins. Before this fix, the reader tolerated an omitted Author by
+ * substituting the literal string `'Unknown'` -- which looks exactly like a
+ * genuinely-declared author to every downstream consumer (the "Created by"
+ * label, the comment byline, and `writer.ts`, which re-serialized it into a
+ * new `.bcfzip` as if the source had declared it), even though no tool ever
+ * wrote it.
+ *
+ * Fix: leave the field undefined rather than fabricate a plausible-looking
+ * placeholder, mirroring CreationDate/Date exactly.
+ *
+ * `Title` is a CONTROL assertion: it is populated from real, declared XML
+ * content elsewhere in the same fixture, so it must still come through --
+ * this isolates the CreationAuthor/Author defect rather than proving the
+ * reader broadly works.
+ */
+
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readBCF } from './reader.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_DATA_DIR = join(__dirname, '..', 'test-data');
+
+/** Take the real PerspectiveCamera.bcf fixture and edit its markup.bcf, re-zip. */
+async function archiveWithEditedMarkup(edit: (xml: string) => string): Promise<Uint8Array> {
+  const original = await readFile(join(TEST_DATA_DIR, 'PerspectiveCamera.bcf'));
+  const zip = await JSZip.loadAsync(original);
+  const markupName = Object.keys(zip.files).find((n) => n.endsWith('markup.bcf'));
+  if (!markupName) throw new Error('no markup.bcf in fixture');
+  const xml = await zip.file(markupName)!.async('string');
+  const edited = edit(xml);
+  expect(edited, 'the edit must actually change the XML').not.toBe(xml);
+  zip.file(markupName, edited);
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+describe('BCF reader — CreationAuthor/Author fabrication (markup.xsd required, no default)', () => {
+  it('does not fabricate a placeholder CreationAuthor when the source omits the required element', async () => {
+    const bytes = await archiveWithEditedMarkup((xml) =>
+      xml.replace(/<CreationAuthor>[^<]*<\/CreationAuthor>/, ''),
+    );
+
+    const project = await readBCF(bytes);
+    const topic = Array.from(project.topics.values())[0];
+    expect(topic).toBeDefined();
+
+    // CONTROL: Title is genuinely declared in the fixture and must still
+    // come through -- isolates the defect to CreationAuthor, not a broken reader.
+    expect(topic.title).toBe('Perspective Camera');
+
+    // actual (pre-fix): the literal string 'Unknown', indistinguishable from
+    // a genuinely-declared author of that name.
+    // expected (post-fix): undefined, since the file never declared one.
+    expect(topic.creationAuthor).not.toBe('Unknown');
+    expect(topic.creationAuthor).toBeUndefined();
+  });
+
+  it('does not fabricate a placeholder Author when a Comment omits the required element', async () => {
+    const bytes = await archiveWithEditedMarkup((xml) =>
+      xml.replace(
+        '</Topic>',
+        '<Comment Guid="c1a2b3c4-0000-0000-0000-000000000002">' +
+          '<Date>2026-01-01T00:00:00Z</Date>' +
+          '<Comment>looks fine</Comment>' +
+          '</Comment>' +
+          '</Topic>',
+      ),
+    );
+
+    const project = await readBCF(bytes);
+    const topic = Array.from(project.topics.values())[0];
+    expect(topic.comments).toHaveLength(1);
+    const comment = topic.comments[0];
+
+    // CONTROL: Comment text is genuinely declared and must still come through.
+    expect(comment.comment).toBe('looks fine');
+
+    expect(comment.author).not.toBe('Unknown');
+    expect(comment.author).toBeUndefined();
+  });
+});

--- a/packages/bcf/src/reader.ts
+++ b/packages/bcf/src/reader.ts
@@ -350,7 +350,7 @@ async function readTopic(zip: JSZip, topicFolder: string, budget: ExpansionBudge
   const priority = extractElement(topicContent, 'Priority');
   const index = extractElement(topicContent, 'Index');
   const creationDate = extractElement(topicContent, 'CreationDate'); // required no-default in markup.xsd; leave undefined, don't fabricate
-  const creationAuthor = extractElement(topicContent, 'CreationAuthor') || 'Unknown';
+  const creationAuthor = extractElement(topicContent, 'CreationAuthor'); // same: required no-default, don't fabricate 'Unknown'
   const modifiedDate = extractElement(topicContent, 'ModifiedDate');
   const modifiedAuthor = extractElement(topicContent, 'ModifiedAuthor');
   const dueDate = extractElement(topicContent, 'DueDate');
@@ -575,7 +575,7 @@ function parseComments(markupContent: string): BCFComment[] {
     const content = span.slice(0, close);
 
     const date = extractElement(content, 'Date'); // don't fabricate; see CreationDate above
-    const author = extractElement(content, 'Author') || 'Unknown';
+    const author = extractElement(content, 'Author'); // same: required no-default, don't fabricate 'Unknown'
     const comment = extractElement(content, 'Comment') || '';
     const modifiedDate = extractElement(content, 'ModifiedDate');
     const modifiedAuthor = extractElement(content, 'ModifiedAuthor');

--- a/packages/bcf/src/types.ts
+++ b/packages/bcf/src/types.ts
@@ -62,8 +62,13 @@ export interface BCFTopic {
    * the same untouched file).
    */
   creationDate?: string;
-  /** Author email */
-  creationAuthor: string;
+  /**
+   * Author email. `markup.xsd` declares `CreationAuthor` required with no
+   * default, but it comes through undefined when the source markup.bcf
+   * omits it — see {@link creationDate} for why the reader never fabricates
+   * a placeholder value ("Unknown") in its place.
+   */
+  creationAuthor?: string;
   /** Modification date (ISO 8601) */
   modifiedDate?: string;
   /** Modifier email */
@@ -133,8 +138,13 @@ export interface BCFComment {
    * never fabricates a read-time wall-clock timestamp in its place.
    */
   date?: string;
-  /** Author email */
-  author: string;
+  /**
+   * Author email. `markup.xsd` declares `Author` required with no default,
+   * but it comes through undefined when the source markup.bcf omits it —
+   * see `BCFTopic.creationAuthor` for why the reader never fabricates a
+   * placeholder value ("Unknown") in its place.
+   */
+  author?: string;
   /** Comment text */
   comment: string;
   /** Reference to a viewpoint GUID */

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -34,6 +34,8 @@ import {
   writePerspectiveCamera,
 } from './writer-camera.js';
 import { xsdDouble, xsdInt, xsdPointElement } from './numeric.js';
+import { escapeXml } from './xml-text.js';
+import { XML_WHITESPACE_ONLY, xsdDateTime, xsdRequiredString } from './xsd-required-string.js';
 import { generateUuid } from '@ifc-lite/encoding';
 
 /**
@@ -208,34 +210,6 @@ function snapshotExt(viewpoint: BCFViewpoint): 'png' | 'jpg' {
   return 'png';
 }
 
-// BCF 3.0's markup.xsd types `Topic/@TopicType` and `Topic/@TopicStatus` as
-// `NonEmptyOrBlankString`: after XML whitespace (#x9, #xA, #xD, #x20) is
-// collapsed, the value must have length >= 1. A value that is present but
-// consists entirely of XML whitespace collapses to nothing and is therefore
-// as invalid as an absent one -- which is why `xsdDateTime` reuses it below.
-const XML_WHITESPACE_ONLY = /^[\t\n\r ]*$/;
-
-/**
- * A required `xs:dateTime` on its way into an archive, escaped -- or an error.
- *
- * `markup.xsd` declares `Topic/CreationDate` and `Comment/Date` `minOccurs="1"`
- * with no default in BOTH 2.1 (:67, :107) and 3.0 (:73, :155), and reader.ts no
- * longer invents a wall-clock timestamp when the source omits one, so either can
- * arrive unset. Inventing one here is that same fabrication; dropping the
- * element hands the caller an archive we already know fails the schema. So we
- * refuse, as the TopicType/TopicStatus check below and `xsdDouble` do.
- */
-function xsdDateTime(value: string | undefined, element: string, where: string): string {
-  if (!value || XML_WHITESPACE_ONLY.test(value)) {
-    throw new Error(
-      `BCF requires ${element} (${where} has none). markup.xsd declares it ` +
-        `minOccurs="1" with no default, and a time the source never stated is ` +
-        `not the writer's to invent. Set it before writing.`
-    );
-  }
-  return escapeXml(value);
-}
-
 /** Write markup.bcf -- buildingSMART standard format. */
 function writeMarkupFile(
   folder: JSZip,
@@ -322,13 +296,13 @@ function writeMarkupFile(
   }
 
   content += `\n    <CreationDate>${xsdDateTime(topic.creationDate, 'Topic/CreationDate', `topic "${topic.guid}"`)}</CreationDate>`;
-  content += `\n    <CreationAuthor>${escapeXml(topic.creationAuthor)}</CreationAuthor>`;
+  content += `\n    <CreationAuthor>${xsdRequiredString(topic.creationAuthor, 'Topic/CreationAuthor', `topic "${topic.guid}"`)}</CreationAuthor>`;
 
   if (topic.modifiedDate) {
     content += `\n    <ModifiedDate>${escapeXml(topic.modifiedDate)}</ModifiedDate>`;
     // BCF spec requires ModifiedAuthor when ModifiedDate is present
     const modifiedAuthor = topic.modifiedAuthor || topic.creationAuthor;
-    content += `\n    <ModifiedAuthor>${escapeXml(modifiedAuthor)}</ModifiedAuthor>`;
+    content += `\n    <ModifiedAuthor>${xsdRequiredString(modifiedAuthor, 'Topic/ModifiedAuthor', `topic "${topic.guid}"`)}</ModifiedAuthor>`;
   }
 
   if (topic.dueDate) {
@@ -385,7 +359,7 @@ function writeMarkupFile(
       .map((comment) => {
         let c = `\n${indent}<Comment Guid="${escapeXml(comment.guid)}">`;
         c += `\n${indent}  <Date>${xsdDateTime(comment.date, 'Comment/Date', `comment "${comment.guid}"`)}</Date>`;
-        c += `\n${indent}  <Author>${escapeXml(comment.author)}</Author>`;
+        c += `\n${indent}  <Author>${xsdRequiredString(comment.author, 'Comment/Author', `comment "${comment.guid}"`)}</Author>`;
         c += `\n${indent}  <Comment>${escapeXml(comment.comment)}</Comment>`;
         if (comment.viewpointGuid) {
           c += `\n${indent}  <Viewpoint Guid="${escapeXml(comment.viewpointGuid)}"/>`;
@@ -863,16 +837,4 @@ function writeDocumentReference(docRef: BCFDocumentReference, version: '2.1' | '
   }
   content += `\n    </DocumentReference>`;
   return content;
-}
-
-/**
- * Escape XML special characters
- */
-function escapeXml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
 }

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -296,13 +296,13 @@ function writeMarkupFile(
   }
 
   content += `\n    <CreationDate>${xsdDateTime(topic.creationDate, 'Topic/CreationDate', `topic "${topic.guid}"`)}</CreationDate>`;
-  content += `\n    <CreationAuthor>${xsdRequiredString(topic.creationAuthor, 'Topic/CreationAuthor', `topic "${topic.guid}"`)}</CreationAuthor>`;
+  content += `\n    <CreationAuthor>${xsdRequiredString(topic.creationAuthor, 'Topic/CreationAuthor', `topic "${topic.guid}"`, version)}</CreationAuthor>`;
 
   if (topic.modifiedDate) {
     content += `\n    <ModifiedDate>${escapeXml(topic.modifiedDate)}</ModifiedDate>`;
     // BCF spec requires ModifiedAuthor when ModifiedDate is present
     const modifiedAuthor = topic.modifiedAuthor || topic.creationAuthor;
-    content += `\n    <ModifiedAuthor>${xsdRequiredString(modifiedAuthor, 'Topic/ModifiedAuthor', `topic "${topic.guid}"`)}</ModifiedAuthor>`;
+    content += `\n    <ModifiedAuthor>${xsdRequiredString(modifiedAuthor, 'Topic/ModifiedAuthor', `topic "${topic.guid}"`, version)}</ModifiedAuthor>`;
   }
 
   if (topic.dueDate) {
@@ -359,7 +359,7 @@ function writeMarkupFile(
       .map((comment) => {
         let c = `\n${indent}<Comment Guid="${escapeXml(comment.guid)}">`;
         c += `\n${indent}  <Date>${xsdDateTime(comment.date, 'Comment/Date', `comment "${comment.guid}"`)}</Date>`;
-        c += `\n${indent}  <Author>${xsdRequiredString(comment.author, 'Comment/Author', `comment "${comment.guid}"`)}</Author>`;
+        c += `\n${indent}  <Author>${xsdRequiredString(comment.author, 'Comment/Author', `comment "${comment.guid}"`, version)}</Author>`;
         c += `\n${indent}  <Comment>${escapeXml(comment.comment)}</Comment>`;
         if (comment.viewpointGuid) {
           c += `\n${indent}  <Viewpoint Guid="${escapeXml(comment.viewpointGuid)}"/>`;

--- a/packages/bcf/src/xml-text.ts
+++ b/packages/bcf/src/xml-text.ts
@@ -3,18 +3,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * Reading text back out of BCF's XML.
+ * Reading text out of BCF's XML, and escaping it back in.
  *
  * Split out of `reader.ts` so the component parsers can share it without a
- * cycle. `writer.ts::escapeXml` is the inverse of `unescapeXml` here, and the
- * two are pinned against each other in `writer.test.ts`.
+ * cycle. `escapeXml` here is the inverse of `unescapeXml`, and the two are
+ * pinned against each other in `writer.test.ts`.
  */
 
 /**
  * Extract a simple element value from XML
  *
- * Values are unescaped so writer.ts's escapeXml() round-trips correctly
- * (see escapeXml/unescapeXml regression: & < > " ' in titles/descriptions/
+ * Values are unescaped so {@link escapeXml} round-trips correctly (see
+ * escapeXml/unescapeXml regression: & < > " ' in titles/descriptions/
  * comments must come back exactly as written, not as literal entities).
  */
 export function extractElement(content: string, elementName: string): string | undefined {
@@ -22,7 +22,19 @@ export function extractElement(content: string, elementName: string): string | u
   return match?.[1] !== undefined ? unescapeXml(match[1]) : undefined;
 }
 
-/** The five entities `writer.ts::escapeXml` produces. */
+/**
+ * Escape XML special characters
+ */
+export function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/** The five entities {@link escapeXml} produces. */
 const NAMED_ENTITIES: Record<string, string> = {
   lt: '<',
   gt: '>',

--- a/packages/bcf/src/xsd-required-string.ts
+++ b/packages/bcf/src/xsd-required-string.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Write-side guards for `markup.xsd` elements declared `minOccurs="1"` with
+ * no schema default: `Topic/CreationDate`, `Comment/Date`,
+ * `Topic/CreationAuthor`, `Topic/ModifiedAuthor` and `Comment/Author`.
+ *
+ * Split out of `writer.ts`, which was pushing its module-size budget. Mirrors
+ * `numeric.ts`'s split for the numeric xsd guards (`xsdDouble`/`xsdInt`).
+ *
+ * `reader.ts` no longer invents a value for these fields when a source
+ * `.bcfzip` omits them (a wall-clock `CreationDate`, a placeholder `'Unknown'`
+ * author) -- so a `BCFTopic`/`BCFComment` read back from a non-conformant
+ * archive can arrive with any of them unset. Inventing one HERE, on write,
+ * would be that same fabrication under a different name; dropping the element
+ * entirely hands the caller an archive that already fails the schema. So both
+ * refuse, the same way the `TopicType`/`TopicStatus` check in `writer.ts`
+ * does for BCF 3.0.
+ */
+import { escapeXml } from './xml-text.js';
+
+// BCF 3.0's markup.xsd types `Topic/@TopicType` and `Topic/@TopicStatus` as
+// `NonEmptyOrBlankString`: after XML whitespace (#x9, #xA, #xD, #x20) is
+// collapsed, the value must have length >= 1. A value that is present but
+// consists entirely of XML whitespace collapses to nothing and is therefore
+// as invalid as an absent one -- which is why the guards below reuse it, and
+// why `writer.ts`'s own TopicType/TopicStatus checks import it too.
+export const XML_WHITESPACE_ONLY = /^[\t\n\r ]*$/;
+
+/** A required `xs:dateTime` on its way into an archive, escaped -- or an error. */
+export function xsdDateTime(value: string | undefined, element: string, where: string): string {
+  if (!value || XML_WHITESPACE_ONLY.test(value)) {
+    throw new Error(
+      `BCF requires ${element} (${where} has none). markup.xsd declares it ` +
+        `minOccurs="1" with no default, and a time the source never stated is ` +
+        `not the writer's to invent. Set it before writing.`
+    );
+  }
+  return escapeXml(value);
+}
+
+/** A required plain-string element on its way into an archive, escaped -- or an error. */
+export function xsdRequiredString(value: string | undefined, element: string, where: string): string {
+  if (!value || XML_WHITESPACE_ONLY.test(value)) {
+    throw new Error(
+      `BCF requires ${element} (${where} has none). markup.xsd declares it ` +
+        `minOccurs="1" with no default, and a value the source never stated is ` +
+        `not the writer's to invent. Set it before writing.`
+    );
+  }
+  return escapeXml(value);
+}

--- a/packages/bcf/src/xsd-required-string.ts
+++ b/packages/bcf/src/xsd-required-string.ts
@@ -41,9 +41,21 @@ export function xsdDateTime(value: string | undefined, element: string, where: s
   return escapeXml(value);
 }
 
-/** A required plain-string element on its way into an archive, escaped -- or an error. */
-export function xsdRequiredString(value: string | undefined, element: string, where: string): string {
-  if (!value || XML_WHITESPACE_ONLY.test(value)) {
+/**
+ * A required author-like string on its way into an archive, escaped -- or an error.
+ *
+ * BCF 2.1 uses `UserIdType`, an unrestricted `xs:string`, so an explicitly
+ * supplied empty or whitespace-only author is schema-valid. BCF 3.0 replaced
+ * it with `NonEmptyOrBlankString`, whose collapsed value must be non-empty.
+ * Absence is invalid in both versions because the element itself is required.
+ */
+export function xsdRequiredString(
+  value: string | undefined,
+  element: string,
+  where: string,
+  version: '2.1' | '3.0',
+): string {
+  if (value === undefined || (version === '3.0' && XML_WHITESPACE_ONLY.test(value))) {
     throw new Error(
       `BCF requires ${element} (${where} has none). markup.xsd declares it ` +
         `minOccurs="1" with no default, and a value the source never stated is ` +


### PR DESCRIPTION
## Summary

Interop audit of the BCF reader (`packages/bcf/src/reader.ts`, `reader-components.ts`, `viewpoint.ts`) against buildingSMART's BCF-XML schema, focused on files authored by tools other than ifc-lite itself (Solibri, BIMcollab, Revit, Navisworks, Tekla, usBIM, ...) — the direction a self round-trip test (`parse(write(x)) === x`) structurally cannot see, since our own writer never produces the non-conformant shapes a real-world tool does.

**Finding**: `markup.xsd` declares `Topic/CreationAuthor` and `Comment/Author` as required (`minOccurs="1"`, no default) `UserIdType` (string) elements — the exact same shape as `Topic/CreationDate`/`Comment/Date`, which #3530 already fixed. When a source `markup.bcf` omitted `CreationAuthor`/`Author`, the reader silently substituted the literal string `'Unknown'`. That is indistinguishable downstream from a genuinely-declared author name: the viewer's "Created by" label, the comment byline, and `writer.ts` re-serializing it into a new `.bcfzip` as if the source file had actually declared an author called "Unknown". #3530 fixed the sibling date fields the same day but left the author fields on the old fabricating path.

## Fix

- `BCFTopic.creationAuthor` and `BCFComment.author` are now `string | undefined`.
- `reader.ts` leaves them `undefined` when the source omits the required element, instead of inventing a placeholder.
- `writer.ts` refuses to write an archive with no author for a required element (mirrors the existing `CreationDate`/`Date` guard and the BCF 3.0 `TopicType`/`TopicStatus` guard) rather than silently emitting markup that fails `markup.xsd` — this also covers `ModifiedAuthor`, which falls back to `creationAuthor` and must equally refuse rather than write `"undefined"`.
- Two viewer call sites (`BCFTopicDetail.tsx`, `BCFTopicList.tsx`) that assumed a non-optional `string` (`.split('@')[0]`, unconditional string interpolation) now guard the missing case, mirroring how #3530 updated `formatDate`/`formatDateTime` and the topic sort.
- `writer.ts` was pushed over its module-size budget by the new guard; split the xsd-required write guards (`xsdDateTime`, new `xsdRequiredString`) into a sibling `xsd-required-string.ts` (mirrors the existing `numeric.ts`/`writer-camera.ts` splits), and moved `escapeXml` into `xml-text.ts` next to its documented inverse `unescapeXml`.

## Element → spec → reader-verdict (this audit's pass over `Topic`/`Comment`/`Viewpoint`/`Components`)

| Element | Spec (2.1 & 3.0) | Reader verdict |
|---|---|---|
| `Topic/CreationAuthor` | required, no default | **was fabricated `'Unknown'` — fixed here** |
| `Comment/Author` | required, no default | **was fabricated `'Unknown'` — fixed here** |
| `Topic/CreationDate`, `Comment/Date` | required, no default | fixed in #3530 |
| `Visibility` self-closed (`DefaultVisibility="false"/>`, no `Exceptions`) | legal (`Exceptions` `minOccurs="0"`) | reads correctly (`reader-components.ts::parseVisibility`, fixed previously) |
| `Topic`/`Comment`/`Component`/`BimSnippet`/`File` attribute order | not significant in XML | reads correctly via `extractAttr` (order-independent, fixed previously) |
| `PerspectiveCamera`/`OrthogonalCamera` (both types, `AspectRatio`) | required children | reads correctly, both camera types |
| BCF 3.0 `<Viewpoints><ViewPoint Guid=...>` nesting vs 2.1 `<Viewpoints Guid=...>` | structurally different | reads correctly (both shapes handled) |
| `Comment` wrapper vs. nested `<Comment>text</Comment>` field name collision | same tag name reused | reads correctly (span-based closer detection) |
| BCF 3.0 `DocumentReference` (`DocumentGuid`/`Url`) vs 2.1 (`ReferencedDocument`/`isExternal`) | different shapes | reads correctly, both shapes |
| `Topic/CreationAuthor`/`Comment/Author` (this PR) | required, no default | now `undefined`, not fabricated |

## Test plan
- [x] RED confirmed on unmodified `main` (`packages/bcf/src/fabricated-author.test.ts`, stashed the fix locally and reran — both assertions failed with `'Unknown'`)
- [x] GREEN with the fix; `Title`/`Comment` text asserted as CONTROLs to isolate the defect
- [x] `packages/bcf` full suite: 321/321 passing (13 files)
- [x] `packages/clash` full suite: 450/450 passing (BCF bridge consumer)
- [x] `node scripts/check-module-size.mjs`: OK (0 new over 400)
- [x] `pnpm run check:vitest-timeout-audit`: summary only, no new violations
- [x] `node scripts/check-test-wiring.mjs`: OK
- [x] `node scripts/check-unused-locals.mjs`: OK, none increased
- [x] `pnpm typecheck` (repo-wide, wasm-free): 87/87 tasks successful, 1573/1573 test files
- [x] `node scripts/check-api-surface.mjs`: matches snapshot (no export shape change, only optionality)
- [x] Changesets: `@ifc-lite/bcf` major (mirrors #3530's precedent — widening a required field to `string | undefined` is a breaking TS type change at this package's ≥1.0 version), `@ifc-lite/viewer` patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * BCF files missing author fields no longer display fabricated “Unknown” values.
  * Viewer topic and comment details now omit unavailable author information and avoid dangling separators.
  * Topic metadata is hidden when neither an author nor creation date is available.

* **Validation**
  * BCF export now rejects topics and comments missing required author values, preventing invalid output.
  * Invalid whitespace-only author values are rejected where required.

* **API Updates**
  * Author fields may now be unavailable when omitted from source files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->