### PR TITLE
fix(collab-server): enforce Principal.expiresAt after connect

### DIFF
--- a/.changeset/collab-server-expiry-recheck.md
+++ b/.changeset/collab-server-expiry-recheck.md
@@ -1,0 +1,10 @@
+---
+'@ifc-lite/collab-server': minor
+---
+
+`Principal.expiresAt` is now enforced, not just carried. It was documented in `auth.ts` as "checked again every 5 minutes per spec", populated from a room token's `exp` claim, and never read anywhere on any post-connect path (#3441): an established WebSocket session kept write access indefinitely after its credential's stated expiry, since `verifyRoomToken` only checks expiry at connect and nothing re-examined it afterward.
+
+Two enforcement paths, covering different exposure:
+
+- `Room`'s write-gate (`preCheckWriteFrame`) now denies a sync write-frame with reason `expired` once `Date.now()` passes `principal.expiresAt` (plus the same clock-skew tolerance `verifyRoomToken` applies at connect).
+- A new periodic sweep, `Room.sweepExpiredPrincipals` / `RoomManager.sweepExpiredPrincipals`, closes any connection whose principal has expired — every 5 minutes by default, matching the documented interval — so read and presence access stop too, not only writes. It reuses the same close-and-let-`ws.on('close', ...)`-clean-up path as an explicit admin kick.

--- a/packages/collab-server/src/principal-expiry.ts
+++ b/packages/collab-server/src/principal-expiry.ts
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `Principal.expiresAt` re-check (#3441).
+ *
+ * `auth.ts` documents `expiresAt` as "checked again every 5 minutes per
+ * spec" and `room-token.ts` populates it from a room token's `exp` claim,
+ * but neither is enough on its own to make an established session lose
+ * access when its credential expires — something has to actually compare
+ * it against the clock. Two call sites do, for different exposure:
+ *   - `Room.preCheckWriteFrame` (room-manager.ts) checks `isPrincipalExpired`
+ *     immediately, on every write attempt — closes the gap `sweepMs` below
+ *     leaves between sweeps.
+ *   - `RoomManager.sweepExpiredPrincipals` (room-manager.ts), driven by the
+ *     `EXPIRY_SWEEP_INTERVAL_MS` timer in `server.ts`, closes sockets whose
+ *     `expiresAt` has passed so read + presence access stops too, not only
+ *     writes.
+ */
+
+import type { WebSocket } from 'ws';
+import type { Principal } from './auth.js';
+import { DEFAULT_CLOCK_TOLERANCE_SEC } from './room-token.js';
+
+/**
+ * Clock-skew tolerance applied when comparing `Principal.expiresAt` against
+ * the current time. Reuses `verifyRoomToken`'s own tolerance (the same
+ * clock, the same `exp` claim `expiresAt` was derived from) instead of a
+ * second, potentially-drifting constant.
+ */
+export const EXPIRY_CLOCK_TOLERANCE_MS = DEFAULT_CLOCK_TOLERANCE_SEC * 1000;
+
+/**
+ * Period of the periodic re-check sweep, matching the "every 5 minutes"
+ * documented on `Principal.expiresAt`.
+ */
+export const EXPIRY_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Whether `expiresAt` (ms since epoch), if set, has passed `now` (ms). */
+export function isPrincipalExpired(principal: Principal, now: number): boolean {
+  return principal.expiresAt !== undefined && now >= principal.expiresAt + EXPIRY_CLOCK_TOLERANCE_MS;
+}
+
+/**
+ * Close every connection whose principal has expired. Shared by
+ * `Room.sweepExpiredPrincipals`; kept generic (name + ws + principal) rather
+ * than importing `PeerConnection` to avoid a cycle with room-manager.ts.
+ * Uses the same close-and-let-the-caller's-`ws.on('close', ...)`-listener
+ * clean up pattern as an explicit admin kick (`Room.kickClient`). Returns
+ * the number of connections closed.
+ */
+export function closeExpiredConnections<C extends { ws: WebSocket; principal: Principal }>(
+  conns: Iterable<C>,
+  now: number,
+): number {
+  let closed = 0;
+  for (const conn of conns) {
+    if (!isPrincipalExpired(conn.principal, now)) continue;
+    try {
+      conn.ws.close(4401, 'expired');
+    } catch {
+      /* socket may already be torn down */
+    }
+    closed++;
+  }
+  return closed;
+}
+
+/**
+ * Await + sweep every room-like value in `rooms` (a `RoomManager`'s pending
+ * `Room` promises), skipping one whose load promise rejected — a poisoned
+ * room is evicted elsewhere and must not abort the sweep for the rest.
+ * Returns the total connections closed.
+ */
+export async function sweepExpiredAcrossRooms<R extends { sweepExpiredPrincipals(now: number): number }>(
+  rooms: Iterable<Promise<R>>,
+  now: number,
+): Promise<number> {
+  let closed = 0;
+  for (const pending of rooms) {
+    let room: R;
+    try {
+      room = await pending;
+    } catch {
+      continue;
+    }
+    closed += room.sweepExpiredPrincipals(now);
+  }
+  return closed;
+}
+
+/** Start the periodic sweep; `stop()` clears it (call from `stop()` in server.ts). */
+export function startExpirySweep(roomManager: {
+  sweepExpiredPrincipals(): Promise<number>;
+}): { stop: () => void } {
+  const timer = setInterval(() => {
+    void roomManager.sweepExpiredPrincipals().catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('[collab-server] expiry sweep error:', err);
+    });
+  }, EXPIRY_SWEEP_INTERVAL_MS);
+  timer.unref?.();
+  return { stop: () => clearInterval(timer) };
+}

--- a/packages/collab-server/src/principal-expiry.ts
+++ b/packages/collab-server/src/principal-expiry.ts
@@ -37,6 +37,17 @@ export const EXPIRY_CLOCK_TOLERANCE_MS = DEFAULT_CLOCK_TOLERANCE_SEC * 1000;
  */
 export const EXPIRY_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
+/** The two failures a periodic expiry sweep can observe without aborting every other room. */
+export type ExpirySweepFailure = 'close' | 'room-load';
+
+/** Injectable so callers and behavioral tests can observe a failure rather than losing it in a catch. */
+export type ExpirySweepErrorReporter = (kind: ExpirySweepFailure, error: unknown) => void;
+
+const reportExpirySweepError: ExpirySweepErrorReporter = (kind, error) => {
+  // eslint-disable-next-line no-console
+  console.error(`[collab-server] expiry sweep ${kind} error:`, error);
+};
+
 /** Whether `expiresAt` (ms since epoch), if set, has passed `now` (ms). */
 export function isPrincipalExpired(principal: Principal, now: number): boolean {
   return principal.expiresAt !== undefined && now >= principal.expiresAt + EXPIRY_CLOCK_TOLERANCE_MS;
@@ -53,14 +64,18 @@ export function isPrincipalExpired(principal: Principal, now: number): boolean {
 export function closeExpiredConnections<C extends { ws: WebSocket; principal: Principal }>(
   conns: Iterable<C>,
   now: number,
+  reportError: ExpirySweepErrorReporter = reportExpirySweepError,
 ): number {
   let closed = 0;
   for (const conn of conns) {
     if (!isPrincipalExpired(conn.principal, now)) continue;
     try {
       conn.ws.close(4401, 'expired');
-    } catch {
-      /* socket may already be torn down */
+    } catch (err) {
+      // A synchronous close throw means the socket was NOT closed.  Do not
+      // inflate the returned count; callers use it as their expiry result.
+      reportError('close', err);
+      continue;
     }
     closed++;
   }
@@ -69,20 +84,25 @@ export function closeExpiredConnections<C extends { ws: WebSocket; principal: Pr
 
 /**
  * Await + sweep every room-like value in `rooms` (a `RoomManager`'s pending
- * `Room` promises), skipping one whose load promise rejected — a poisoned
+ * `Room` promises), reporting one whose load promise rejected — a poisoned
  * room is evicted elsewhere and must not abort the sweep for the rest.
  * Returns the total connections closed.
  */
 export async function sweepExpiredAcrossRooms<R extends { sweepExpiredPrincipals(now: number): number }>(
   rooms: Iterable<Promise<R>>,
   now: number,
+  reportError: ExpirySweepErrorReporter = reportExpirySweepError,
 ): Promise<number> {
   let closed = 0;
   for (const pending of rooms) {
     let room: R;
     try {
       room = await pending;
-    } catch {
+    } catch (err) {
+      // A room load failure does not stop other rooms being swept, but it is
+      // not a successful zero-connection result either.  Report it before
+      // continuing so operators can distinguish that state from no expiry.
+      reportError('room-load', err);
       continue;
     }
     closed += room.sweepExpiredPrincipals(now);

--- a/packages/collab-server/src/room-manager.ts
+++ b/packages/collab-server/src/room-manager.ts
@@ -31,7 +31,7 @@ import {
   type AuditOpType,
   type AuditSink,
 } from './audit-log.js';
-import { createRateLimiter, type RateLimitOptions, type RateLimiter } from './rate-limit.js';
+import { createRateLimiter, type RateLimitOptions } from './rate-limit.js';
 
 const MESSAGE_SYNC = 0;
 const MESSAGE_AWARENESS = 1;

--- a/packages/collab-server/src/room-manager.ts
+++ b/packages/collab-server/src/room-manager.ts
@@ -23,6 +23,8 @@ import type { WebSocket } from 'ws';
 import type { Persistence } from './persistence.js';
 import type { Principal } from './auth.js';
 import { canWrite } from './auth.js';
+import { closeExpiredConnections, isPrincipalExpired, sweepExpiredAcrossRooms } from './principal-expiry.js';
+import type { VerifyDecision, VerifyMessageFn, RoomOptions, PeerConnection } from './room-types.js';
 import {
   noopAuditSink,
   shortHash,
@@ -64,63 +66,9 @@ const MAX_SYNC_PAYLOAD_BYTES = 8 * 1024 * 1024;
  */
 const MAX_AWARENESS_BYTES = 128 * 1024;
 
-export interface VerifyDecision {
-  ok: boolean;
-  /** Audit-friendly reason string when ok=false. */
-  reason?: string;
-  /**
-   * Optional replacement payload to dispatch instead of the raw wire
-   * message — e.g. the anti-replay protector unwraps its signed envelope
-   * (tag + clientId + clock + hmac + inner frame) down to the inner
-   * y-protocol frame here. Without this, the envelope bytes themselves
-   * would be handed to `dispatchMessage`, which doesn't recognise them as
-   * a sync/awareness frame and silently drops them in its `default` case.
-   */
-  payload?: Uint8Array;
-}
-
-export type VerifyMessageFn = (msg: Uint8Array, conn: PeerConnection) => VerifyDecision;
-
-export interface RoomOptions {
-  persistence: Persistence;
-  /** Compact the persisted log every N updates (default 1000). */
-  compactEvery?: number;
-  /** Idle timeout before a room is unloaded (default 60s). */
-  idleUnloadMs?: number;
-  /** Audit sink for connect/update/awareness events (default = no-op). */
-  auditSink?: AuditSink;
-  /**
-   * Per-peer rate-limit knobs. Applied per connection. Service accounts
-   * (e.g. MCP agents) typically get a tighter budget than humans.
-   */
-  rateLimit?: RateLimitOptions | ((principal: Principal) => RateLimitOptions);
-  /**
-   * Optional per-message verifier. For plain sync write-frames the cheap
-   * role + rate-limit + payload-size gate (preCheckWriteFrame) runs FIRST,
-   * so a non-writer / rate-limited / oversized frame is rejected before the
-   * verifier parses it (avoids Y.Doc-parse amplification). Signed-envelope
-   * frames (e.g. the anti-replay protector's `0xff`-tagged frames) aren't
-   * recognised as sync write-frames by that first peek, so the verifier
-   * runs first for them and sees every signed frame — but if the verifier
-   * unwraps the envelope and returns `payload`, `handleMessage` re-runs
-   * `preCheckWriteFrame` on THAT payload before dispatch. The unwrapped
-   * frame is a real write frame the outer peek never saw, so it must still
-   * clear role / rate-limit / size before it reaches the doc. Returning
-   * `{ ok: false }` audits as `reject` with `reason`.
-   */
-  verifyMessage?: VerifyMessageFn;
-  /** Internal: metric counters injected by the manager. */
-  counters?: { update?: () => void; reject?: (reason: string) => void };
-}
-
-export interface PeerConnection {
-  ws: WebSocket;
-  principal: Principal;
-  /** Subscribed clientIDs that this peer's awareness has reported (for cleanup). */
-  awarenessClients: Set<number>;
-  /** Per-connection rate limiter. */
-  limiter?: RateLimiter;
-}
+// Public type surface lives in room-types.ts (module-size budget, AGENTS.md);
+// re-exported here unchanged so this split is not a public API move.
+export type { VerifyDecision, VerifyMessageFn, RoomOptions, PeerConnection };
 
 export class Room {
   readonly id: string;
@@ -221,6 +169,11 @@ export class Room {
       }
     }
     return { kicked: false };
+  }
+
+  /** #3441 periodic expiry re-check; see principal-expiry.ts. */
+  sweepExpiredPrincipals(now: number = Date.now()): number {
+    return closeExpiredConnections(this.conns, now);
   }
 
   /** Number of currently connected peers. */
@@ -365,6 +318,12 @@ export class Room {
     }
     const isWriteFrame = subtype === SYNC_UPDATE || subtype === SYNC_STEP2;
     if (!isWriteFrame) return true;
+    // Immediate half of the #3441 expiry re-check; see principal-expiry.ts.
+    if (isPrincipalExpired(conn.principal, Date.now())) {
+      this.audit(conn.principal, 'reject', shortHash(msg), { reason: 'expired' });
+      this.counters.reject?.('expired');
+      return false;
+    }
     if (!canWrite(conn.principal)) {
       this.audit(conn.principal, 'reject', shortHash(msg), { reason: 'role' });
       this.counters.reject?.('role');
@@ -714,6 +673,11 @@ export class RoomManager {
     }
     for (const roomId of candidates) await this.unload(roomId);
     return candidates;
+  }
+
+  /** Across every loaded room; see principal-expiry.ts. Timer: server.ts. */
+  sweepExpiredPrincipals(now: number = Date.now()): Promise<number> {
+    return sweepExpiredAcrossRooms(this.rooms.values(), now);
   }
 }
 

--- a/packages/collab-server/src/room-token.ts
+++ b/packages/collab-server/src/room-token.ts
@@ -31,7 +31,7 @@ const VALID_ROLES: ReadonlySet<string> = new Set([
 ]);
 
 const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
-const DEFAULT_CLOCK_TOLERANCE_SEC = 30;
+export const DEFAULT_CLOCK_TOLERANCE_SEC = 30; // sec; reused by principal-expiry.ts
 
 export interface RoomTokenClaims {
   /** Room id this token grants access to. */

--- a/packages/collab-server/src/room-types.ts
+++ b/packages/collab-server/src/room-types.ts
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Public type surface for `room-manager.ts`, split out to keep that file
+ * under its module-size budget (AGENTS.md). Re-exported from
+ * `room-manager.js` and `index.ts` unchanged, so this split is not a public
+ * API move.
+ */
+
+import type { WebSocket } from 'ws';
+import type { Persistence } from './persistence.js';
+import type { Principal } from './auth.js';
+import type { AuditSink } from './audit-log.js';
+import type { RateLimitOptions, RateLimiter } from './rate-limit.js';
+
+export interface VerifyDecision {
+  ok: boolean;
+  /** Audit-friendly reason string when ok=false. */
+  reason?: string;
+  /**
+   * Optional replacement payload to dispatch instead of the raw wire
+   * message — e.g. the anti-replay protector unwraps its signed envelope
+   * (tag + clientId + clock + hmac + inner frame) down to the inner
+   * y-protocol frame here. Without this, the envelope bytes themselves
+   * would be handed to `dispatchMessage`, which doesn't recognise them as
+   * a sync/awareness frame and silently drops them in its `default` case.
+   */
+  payload?: Uint8Array;
+}
+
+export type VerifyMessageFn = (msg: Uint8Array, conn: PeerConnection) => VerifyDecision;
+
+export interface RoomOptions {
+  persistence: Persistence;
+  /** Compact the persisted log every N updates (default 1000). */
+  compactEvery?: number;
+  /** Idle timeout before a room is unloaded (default 60s). */
+  idleUnloadMs?: number;
+  /** Audit sink for connect/update/awareness events (default = no-op). */
+  auditSink?: AuditSink;
+  /**
+   * Per-peer rate-limit knobs. Applied per connection. Service accounts
+   * (e.g. MCP agents) typically get a tighter budget than humans.
+   */
+  rateLimit?: RateLimitOptions | ((principal: Principal) => RateLimitOptions);
+  /**
+   * Optional per-message verifier. For plain sync write-frames the cheap
+   * expiry + role + rate-limit + payload-size gate (preCheckWriteFrame) runs
+   * FIRST, so a non-writer / expired / rate-limited / oversized frame is
+   * rejected before the verifier parses it (avoids Y.Doc-parse
+   * amplification). Signed-envelope frames (e.g. the anti-replay
+   * protector's `0xff`-tagged frames) aren't recognised as sync
+   * write-frames by that first peek, so the verifier runs first for them
+   * and sees every signed frame — but if the verifier unwraps the envelope
+   * and returns `payload`, `handleMessage` re-runs `preCheckWriteFrame` on
+   * THAT payload before dispatch. The unwrapped frame is a real write frame
+   * the outer peek never saw, so it must still clear expiry / role /
+   * rate-limit / size before it reaches the doc. Returning `{ ok: false }`
+   * audits as `reject` with `reason`.
+   */
+  verifyMessage?: VerifyMessageFn;
+  /** Internal: metric counters injected by the manager. */
+  counters?: { update?: () => void; reject?: (reason: string) => void };
+}
+
+export interface PeerConnection {
+  ws: WebSocket;
+  principal: Principal;
+  /** Subscribed clientIDs that this peer's awareness has reported (for cleanup). */
+  awarenessClients: Set<number>;
+  /** Per-connection rate limiter. */
+  limiter?: RateLimiter;
+}

--- a/packages/collab-server/src/server.ts
+++ b/packages/collab-server/src/server.ts
@@ -2,19 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-/**
- * Websocket sync server entry point.
- */
+/** Websocket sync server entry point. */
 
 import * as http from 'node:http';
 import { createHash, timingSafeEqual } from 'node:crypto';
 import { WebSocketServer, type WebSocket } from 'ws';
-import { RoomManager, type PeerConnection } from './room-manager.js';
+import { RoomManager, type PeerConnection, type VerifyMessageFn } from './room-manager.js';
+import { startExpirySweep } from './principal-expiry.js';
 import { FilePersistence, MemoryPersistence, type Persistence } from './persistence.js';
 import { allowAnonymousEditor, canWrite, type AuthenticateFn, type Principal } from './auth.js';
 import { type AuditSink } from './audit-log.js';
 import { type RateLimitOptions } from './rate-limit.js';
-import { type VerifyMessageFn } from './room-manager.js';
 import {
   handleBlobRequest,
   InMemoryBlobStorage,
@@ -280,6 +278,7 @@ export async function startCollabServer(
     idleUnloadMs: opts.idleUnloadMs,
     verifyMessage: opts.verifyMessage,
   });
+  const expirySweep = startExpirySweep(roomManager); // #3441; see principal-expiry.ts
 
   const blobStorage = opts.blobStorage ?? new InMemoryBlobStorage();
   // Default the blob authorizer to one that reuses the WS `authenticate`
@@ -495,6 +494,7 @@ export async function startCollabServer(
     wss,
     roomManager,
     async stop() {
+      expirySweep.stop();
       await new Promise<void>((resolve) => wss.close(() => resolve()));
       if (!opts.server) {
         await new Promise<void>((resolve) => httpServer.close(() => resolve()));

--- a/packages/collab-server/test/expiry-recheck.test.ts
+++ b/packages/collab-server/test/expiry-recheck.test.ts
@@ -22,6 +22,7 @@ import { WebsocketProvider } from 'y-websocket';
 import { MemoryPersistence, startCollabServer, type CollabServerHandle } from '../src/server.js';
 import { MemoryAuditSink } from '../src/audit-log.js';
 import type { Principal } from '../src/auth.js';
+import { closeExpiredConnections, sweepExpiredAcrossRooms } from '../src/principal-expiry.js';
 
 async function waitFor(check: () => boolean, timeoutMs: number, label: string) {
   const start = Date.now();
@@ -57,6 +58,39 @@ async function startWithPrincipal(
 }
 
 describe('Principal.expiresAt re-check', () => {
+  it('does not claim a throwing socket close succeeded and reports the failure', () => {
+    const expired: Principal = { userId: 'u-throwing-close', role: 'viewer', expiresAt: 0 };
+    const reported: Array<{ kind: string; error: unknown }> = [];
+    const closed = closeExpiredConnections(
+      [{ principal: expired, ws: { close: () => { throw new Error('already destroyed'); } } as never }],
+      Date.now(),
+      (kind, error) => reported.push({ kind, error }),
+    );
+
+    expect(closed).toBe(0);
+    expect(reported).toHaveLength(1);
+    expect(reported[0]?.kind).toBe('close');
+    expect(reported[0]?.error).toBeInstanceOf(Error);
+  });
+
+  it('reports a rejected room load while still sweeping every room that loaded', async () => {
+    const rejected = new Error('persistence unavailable');
+    const reported: Array<{ kind: string; error: unknown }> = [];
+    const swept: number[] = [];
+    const closed = await sweepExpiredAcrossRooms(
+      [
+        Promise.reject(rejected),
+        Promise.resolve({ sweepExpiredPrincipals: (now: number) => { swept.push(now); return 2; } }),
+      ],
+      123,
+      (kind, error) => reported.push({ kind, error }),
+    );
+
+    expect(closed).toBe(2);
+    expect(swept).toEqual([123]);
+    expect(reported).toEqual([{ kind: 'room-load', error: rejected }]);
+  });
+
   it('denies a write frame once expiresAt is in the past', async () => {
     const audit = new MemoryAuditSink();
     const expired: Principal = { userId: 'u-expired', role: 'editor', expiresAt: Date.now() - 60_000 };

--- a/packages/collab-server/test/expiry-recheck.test.ts
+++ b/packages/collab-server/test/expiry-recheck.test.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `Principal.expiresAt` re-check (#3441).
+ *
+ * `expiresAt` is documented in `auth.ts` as "checked again every 5 minutes
+ * per spec" and is populated from a room token's `exp` claim, but nothing
+ * ever compared it against the clock: an established session kept write
+ * (and read/presence) access indefinitely past its credential's expiry.
+ * These tests establish a session whose `Principal.expiresAt` is already in
+ * the past and assert (a) a write frame is denied and (b) the periodic
+ * sweep closes the socket. A control principal with a future — or absent —
+ * `expiresAt` still writes and stays connected.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as Y from 'yjs';
+import { WebSocket } from 'ws';
+import { WebsocketProvider } from 'y-websocket';
+import { MemoryPersistence, startCollabServer, type CollabServerHandle } from '../src/server.js';
+import { MemoryAuditSink } from '../src/audit-log.js';
+import type { Principal } from '../src/auth.js';
+
+async function waitFor(check: () => boolean, timeoutMs: number, label: string) {
+  const start = Date.now();
+  while (!check()) {
+    if (Date.now() - start > timeoutMs) throw new Error(`waitFor(${label}) timed out`);
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+function connect(url: string, room: string, doc: Y.Doc): WebsocketProvider {
+  return new WebsocketProvider(url, room, doc, {
+    WebSocketPolyfill: WebSocket as never,
+    disableBc: true,
+  });
+}
+
+function synced(p: WebsocketProvider): Promise<void> {
+  return new Promise<void>((res) => (p.synced ? res() : p.once('sync', () => res())));
+}
+
+async function startWithPrincipal(
+  audit: MemoryAuditSink,
+  principal: Principal,
+): Promise<{ handle: CollabServerHandle; url: string }> {
+  const handle = await startCollabServer({
+    port: 0,
+    persistence: new MemoryPersistence(),
+    authenticate: () => principal,
+    auditSink: audit,
+  });
+  const port = (handle.httpServer.address() as { port: number }).port;
+  return { handle, url: `ws://127.0.0.1:${port}` };
+}
+
+describe('Principal.expiresAt re-check', () => {
+  it('denies a write frame once expiresAt is in the past', async () => {
+    const audit = new MemoryAuditSink();
+    const expired: Principal = { userId: 'u-expired', role: 'editor', expiresAt: Date.now() - 60_000 };
+    const { handle, url } = await startWithPrincipal(audit, expired);
+
+    const doc = new Y.Doc();
+    const prov = connect(url, 'room-expired-write', doc);
+    await synced(prov);
+
+    doc.getMap('m').set('should-be-denied', 1);
+    await new Promise((r) => setTimeout(r, 150));
+
+    // The write must not have been accepted.
+    expect(audit.entries.some((e) => e.opType === 'update')).toBe(false);
+    const rejects = audit.entries.filter((e) => e.opType === 'reject');
+    expect(rejects.some((e) => (e.detail as { reason?: string } | undefined)?.reason === 'expired')).toBe(
+      true,
+    );
+
+    prov.destroy();
+    await handle.stop();
+  }, 10_000);
+
+  it('control: a principal with a future expiresAt still writes', async () => {
+    const audit = new MemoryAuditSink();
+    const future: Principal = { userId: 'u-future', role: 'editor', expiresAt: Date.now() + 60_000 };
+    const { handle, url } = await startWithPrincipal(audit, future);
+
+    const doc = new Y.Doc();
+    const prov = connect(url, 'room-future-write', doc);
+    await synced(prov);
+
+    doc.getMap('m').set('should-succeed', 1);
+    await waitFor(() => audit.entries.some((e) => e.opType === 'update'), 2000, 'update accepted');
+
+    const rejects = audit.entries.filter(
+      (e) => e.opType === 'reject' && (e.detail as { reason?: string } | undefined)?.reason === 'expired',
+    );
+    expect(rejects.length).toBe(0);
+
+    prov.destroy();
+    await handle.stop();
+  }, 10_000);
+
+  it('control: a principal with no expiresAt still writes', async () => {
+    const audit = new MemoryAuditSink();
+    const noExpiry: Principal = { userId: 'u-no-expiry', role: 'editor' };
+    const { handle, url } = await startWithPrincipal(audit, noExpiry);
+
+    const doc = new Y.Doc();
+    const prov = connect(url, 'room-no-expiry-write', doc);
+    await synced(prov);
+
+    doc.getMap('m').set('should-succeed', 1);
+    await waitFor(() => audit.entries.some((e) => e.opType === 'update'), 2000, 'update accepted');
+
+    prov.destroy();
+    await handle.stop();
+  }, 10_000);
+
+  it('periodic sweep closes a socket whose expiresAt has passed', async () => {
+    const audit = new MemoryAuditSink();
+    const expired: Principal = { userId: 'u-expired-sweep', role: 'viewer', expiresAt: Date.now() - 60_000 };
+    const { handle, url } = await startWithPrincipal(audit, expired);
+
+    const doc = new Y.Doc();
+    const prov = connect(url, 'room-expired-sweep', doc);
+    await synced(prov);
+    expect(prov.wsconnected).toBe(true);
+
+    // Drive the sweep directly rather than waiting the real 5-minute
+    // interval — same code path `server.ts` runs on its timer.
+    const closed = await handle.roomManager.sweepExpiredPrincipals();
+    expect(closed).toBeGreaterThanOrEqual(1);
+
+    await waitFor(() => !prov.wsconnected, 2000, 'socket closed by sweep');
+
+    prov.destroy();
+    await handle.stop();
+  }, 10_000);
+
+  it('control: the sweep leaves a not-yet-expired socket connected', async () => {
+    const audit = new MemoryAuditSink();
+    const future: Principal = { userId: 'u-future-sweep', role: 'viewer', expiresAt: Date.now() + 60_000 };
+    const { handle, url } = await startWithPrincipal(audit, future);
+
+    const doc = new Y.Doc();
+    const prov = connect(url, 'room-future-sweep', doc);
+    await synced(prov);
+
+    const closed = await handle.roomManager.sweepExpiredPrincipals();
+    expect(closed).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(prov.wsconnected).toBe(true);
+
+    prov.destroy();
+    await handle.stop();
+  }, 10_000);
+});


### PR DESCRIPTION
## Fix

Expired-session sweeping no longer hides operational failures. A synchronous socket-close failure is reported and is not counted as a disconnected peer. A rejected room-load promise is reported while the sweep continues through rooms that did load.

## Test

- Throwing socket close: reports `close`, returns zero closed.
- Rejected room load: reports `room-load` and still sweeps the healthy room.
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `node scripts/check-module-size.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic expiration enforcement for connections with expired access credentials.
  * Expired connections are rejected when submitting updates and disconnected during periodic cleanup.
  * Added clock-skew tolerance to reduce issues caused by minor time differences.
  * Cleanup continues safely when individual connection or room operations fail, with errors reported.

* **Bug Fixes**
  * Prevented expired connections from continuing to send updates after their access period ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->