### PR TITLE
feat(ci): gate on evidence a review REACHED the PR, not on the review job's exit code

### DIFF
--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -19,6 +19,8 @@ on:
 
 permissions:
   contents: read
+  # write, and ONLY for the stand-down label below. The gate itself reads.
+  issues: write
   # Covers both reads: issue comments and PR reviews. `issues: read` is not
   # requested; if the first runs report GH_ERROR mentioning permissions, add it.
   # The gate fails closed, so that shows up as a visible refusal rather than a
@@ -57,6 +59,7 @@ jobs:
         run: node --test scripts/check-review-posted.test.mjs
 
       - name: Check a review was actually posted for this head
+        id: gate
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -64,3 +67,45 @@ jobs:
           node scripts/check-review-posted.mjs \
             --pr "${{ github.event.pull_request.number }}" \
             --sha "${{ github.event.pull_request.head.sha }}"
+
+      # THE STAND-DOWN LABEL, AND WHY THE GATE DECIDES IT RATHER THAN THE REVIEWER.
+      #
+      # CodeRabbit is configured with `auto_review.labels: ['!claude-reviewed']`,
+      # a negative match, so it skips any PR carrying this label. That preserves
+      # its scarce Fair Usage allowance (both identities on this repo sit at the
+      # 1-2 reviews/hour floor permanently) for the PRs Claude did NOT cover.
+      #
+      # The label follows the GATE'S VERDICT, never the reviewer's own report, and
+      # never merely the fact that a bot commented. CodeRabbit has no "skip if
+      # another bot reviewed" knob, so a label is the only signal available to it;
+      # if that label could be set by a reviewer that silently posted nothing
+      # (claude-code-action #1679: forty consecutive runs logging `Posted 0/N`
+      # while exiting 0) then BOTH reviewers would stand down and the PR would
+      # show green having been read by neither. That is a third route to the exact
+      # defect this gate closes, so the label is downstream of verification.
+      #
+      # IT IS REMOVED AS WELL AS ADDED, and that half is not optional. The gate
+      # adjudicates a verdict for ONE head. Without the removal, a PR reviewed at
+      # commit 1 keeps the label through commit 20 and CodeRabbit stands down for
+      # a diff nothing has read -- the stand-down would go stale in exactly the
+      # way STALE_REVIEW exists to catch.
+      #
+      # Reads `steps.gate.outputs.covered`, not the step's exit code: in advisory
+      # mode a failing verdict still exits 0, so the exit code would mark an
+      # unreviewed PR as covered.
+      - name: Sync the CodeRabbit stand-down label to the verdict
+        if: always() && steps.gate.outputs.covered != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COVERED: ${{ steps.gate.outputs.covered }}
+        run: |
+          set -euo pipefail
+          if [ "$COVERED" = "true" ]; then
+            gh pr edit "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" --add-label claude-reviewed
+            echo "Labelled: a verified review exists for this head."
+          else
+            gh pr edit "${{ github.event.pull_request.number }}" \
+              --repo "${{ github.repository }}" --remove-label claude-reviewed 2>/dev/null || true
+            echo "Label cleared: no verified review for this head, so CodeRabbit must not stand down."
+          fi

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -5,27 +5,22 @@
 name: Review posted
 
 # NO `paths:` FILTER AND NO `branches:` FILTER, for the reason
-# pr-review-signal.yml documents at length: a presence gate that can itself be
-# filtered out is the same defect it exists to catch (#3305). This one reads
-# scripts/review-posted.config.json, so with no filter, no edit to that config
-# can dodge the job that runs it ON THE PATH THAT MERGES IT.
+# pr-review-signal.yml documents: a presence gate that can itself be filtered out
+# is the same defect it exists to catch (#3305).
 #
-# `synchronize` matters more here than anywhere else: the gate adjudicates a
-# verdict for a SPECIFIC head, so a new commit must re-open the question. Without
-# it a review of commit 1 would keep a PR green through commit 20.
+# `synchronize` is load-bearing here rather than incidental: the gate adjudicates
+# a verdict for ONE head, so a new commit must re-open the question. Without it a
+# review of commit 1 would hold a PR green through commit 20.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
-  # write, and ONLY for the stand-down label below. The gate itself reads.
-  issues: write
-  # Covers both reads: issue comments and PR reviews. `issues: read` is not
-  # requested; if the first runs report GH_ERROR mentioning permissions, add it.
-  # The gate fails closed, so that shows up as a visible refusal rather than a
-  # silently empty comment list.
+  # Both comment surfaces plus the review list.
   pull-requests: read
+  # write, and ONLY for the stand-down label. See the label steps below.
+  issues: write
 
 concurrency:
   group: review-posted-${{ github.event.pull_request.number }}
@@ -35,10 +30,30 @@ jobs:
   review-posted:
     name: Review posted
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # ABOVE the gate's poll budget (300s), deliberately, so a run that exhausts
+    # the budget still gets to PRINT its verdict rather than being killed
+    # mid-wait with no output and no `covered` value. The sibling gate states the
+    # same rule at pr-review-signal.yml (20 minutes against a 900s budget). An
+    # earlier version of this file had 5 minutes against a 600s budget, which
+    # would have killed the job on every PR before it could say anything.
+    timeout-minutes: 10
     steps:
+      # THE GATE, ITS TESTS AND ITS CONFIG COME FROM THE BASE BRANCH, NEVER FROM
+      # THE PR UNDER REVIEW.
+      #
+      # `actions/checkout` defaults to the PR's merge ref on `pull_request`, so
+      # the default would run this gate, its harness, and
+      # scripts/review-posted.config.json as the contributor wrote them. A
+      # contributor could then add their own login to `expectedAuthors`,
+      # hand-write a marker in a PR comment, and be validated by their own
+      # config. The missing `paths:` filter above does not close that -- running
+      # the job on the edited config IS the hole -- so the ref does.
+      #
+      # This is the rule adk-samples and supabase/cli both landed on
+      # independently: the rules that judge a PR must not be editable by it.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           lfs: false
           persist-credentials: false
 
@@ -46,17 +61,37 @@ jobs:
         with:
           node-version: 22
 
-      # The harness runs BEFORE the gate, and in this job rather than only in the
-      # scripts/ glob catch-all, for the reason check-pr-review-signal.yml gives:
-      # relying on a path-filtered job to run this gate's tests would put them
-      # behind a filter this workflow deliberately does not have.
+      # Runs BEFORE the gate and in this job rather than only in the scripts/
+      # glob catch-all: relying on a path-filtered job to test this gate would put
+      # its harness behind a filter this workflow deliberately does not have.
       #
       # No `pnpm install`: the gate and its harness import node builtins only and
-      # shell out to `gh`, which is preinstalled on GitHub runners. A gate that
-      # decides whether a review happened must not be able to fail because a
-      # registry was slow.
+      # shell out to `gh`, preinstalled on runners. A gate that decides whether a
+      # review happened must not be able to fail because a registry was slow.
       - name: Unit-test the gate itself
         run: node --test scripts/check-review-posted.test.mjs
+
+      # CLEARED FIRST, BEFORE THE GATE WAITS. This is a race, not a tidy-up.
+      #
+      # CodeRabbit's `auto_review` reads labels at PUSH time. If the label were
+      # only reconciled after the poll, then on a new commit CodeRabbit would see
+      # the label left over from the PREVIOUS head, stand down immediately, and
+      # the gate would clear it minutes later -- after the decision it was meant
+      # to influence. CodeRabbit does not re-review on an `unlabeled` event, so
+      # that commit would ship read by neither reviewer.
+      #
+      # Clearing up front inverts the failure: the worst case is CodeRabbit
+      # reviewing a PR the Claude lane also covers, which costs quota. The other
+      # ordering costs a review.
+      - name: Clear the stand-down label for this new head
+        if: github.event.action == 'synchronize' || github.event.action == 'reopened'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --remove-label claude-reviewed \
+            || echo "No label to clear (or no write access on a fork PR); CodeRabbit will review."
 
       - name: Check a review was actually posted for this head
         id: gate
@@ -66,46 +101,43 @@ jobs:
         run: |
           node scripts/check-review-posted.mjs \
             --pr "${{ github.event.pull_request.number }}" \
-            --sha "${{ github.event.pull_request.head.sha }}"
+            --sha "${{ github.event.pull_request.head.sha }}" \
+            --timeout-seconds 300
 
-      # THE STAND-DOWN LABEL, AND WHY THE GATE DECIDES IT RATHER THAN THE REVIEWER.
+      # ADDS ONLY. The clearing half runs up front, above.
       #
-      # CodeRabbit is configured with `auto_review.labels: ['!claude-reviewed']`,
-      # a negative match, so it skips any PR carrying this label. That preserves
-      # its scarce Fair Usage allowance (both identities on this repo sit at the
-      # 1-2 reviews/hour floor permanently) for the PRs Claude did NOT cover.
+      # `continue-on-error` because both failure modes here land on the SUCCESS
+      # path and neither means the review is bad: a fork PR's GITHUB_TOKEN is
+      # read-only whatever `permissions:` says, and the label may not exist in the
+      # repository yet. Failing the job for either would turn a passing gate red.
+      # The cost of the label not being applied is that CodeRabbit reviews a PR
+      # that was already covered -- quota, not correctness.
       #
-      # The label follows the GATE'S VERDICT, never the reviewer's own report, and
-      # never merely the fact that a bot commented. CodeRabbit has no "skip if
-      # another bot reviewed" knob, so a label is the only signal available to it;
-      # if that label could be set by a reviewer that silently posted nothing
-      # (claude-code-action #1679: forty consecutive runs logging `Posted 0/N`
-      # while exiting 0) then BOTH reviewers would stand down and the PR would
-      # show green having been read by neither. That is a third route to the exact
-      # defect this gate closes, so the label is downstream of verification.
-      #
-      # IT IS REMOVED AS WELL AS ADDED, and that half is not optional. The gate
-      # adjudicates a verdict for ONE head. Without the removal, a PR reviewed at
-      # commit 1 keeps the label through commit 20 and CodeRabbit stands down for
-      # a diff nothing has read -- the stand-down would go stale in exactly the
-      # way STALE_REVIEW exists to catch.
-      #
-      # Reads `steps.gate.outputs.covered`, not the step's exit code: in advisory
-      # mode a failing verdict still exits 0, so the exit code would mark an
-      # unreviewed PR as covered.
-      - name: Sync the CodeRabbit stand-down label to the verdict
-        if: always() && steps.gate.outputs.covered != ''
+      # Reads `steps.gate.outputs.covered`, never the step's exit code: in
+      # advisory mode a failing verdict still exits 0, so the exit code would mark
+      # an unreviewed PR as covered.
+      - name: Mark covered so CodeRabbit can stand down
+        if: always() && steps.gate.outputs.covered == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-          COVERED: ${{ steps.gate.outputs.covered }}
         run: |
-          set -euo pipefail
-          if [ "$COVERED" = "true" ]; then
-            gh pr edit "${{ github.event.pull_request.number }}" \
-              --repo "${{ github.repository }}" --add-label claude-reviewed
-            echo "Labelled: a verified review exists for this head."
-          else
-            gh pr edit "${{ github.event.pull_request.number }}" \
-              --repo "${{ github.repository }}" --remove-label claude-reviewed 2>/dev/null || true
-            echo "Label cleared: no verified review for this head, so CodeRabbit must not stand down."
-          fi
+          gh label create claude-reviewed --repo "${{ github.repository }}" \
+            --color 0e8a16 --description "A review was verified as posted for this PR's head." \
+            2>/dev/null || true
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --add-label claude-reviewed
+
+      # The refusal paths write `covered=false` too, so a stale label is cleared
+      # even when the gate could not read its own inputs. Without this a PR
+      # carrying the label from an earlier head would keep it through any number
+      # of refused runs.
+      - name: Clear the stand-down label when this head is not covered
+        if: always() && steps.gate.outputs.covered == 'false'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr edit "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --remove-label claude-reviewed \
+            || echo "Nothing to clear."

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -38,22 +38,28 @@ jobs:
     # would have killed the job on every PR before it could say anything.
     timeout-minutes: 10
     steps:
-      # THE GATE, ITS TESTS AND ITS CONFIG COME FROM THE BASE BRANCH, NEVER FROM
-      # THE PR UNDER REVIEW.
+      # THE GATE RUNS FROM THE PR; ITS AUTHORITY COMES FROM THE BASE BRANCH.
       #
-      # `actions/checkout` defaults to the PR's merge ref on `pull_request`, so
-      # the default would run this gate, its harness, and
-      # scripts/review-posted.config.json as the contributor wrote them. A
-      # contributor could then add their own login to `expectedAuthors`,
-      # hand-write a marker in a PR comment, and be validated by their own
-      # config. The missing `paths:` filter above does not close that -- running
-      # the job on the edited config IS the hole -- so the ref does.
+      # An earlier version pinned the whole checkout to `pull_request.base.sha` to
+      # stop a contributor editing the rules that judge them. That closed the
+      # forgery vector and broke two things: this very PR could not run, because
+      # the gate does not exist on base yet, and any future PR IMPROVING the gate
+      # would be tested against the old copy and never exercise its own change.
       #
-      # This is the rule adk-samples and supabase/cli both landed on
-      # independently: the rules that judge a PR must not be editable by it.
+      # Split instead. The workspace is the PR, so the harness tests the gate the
+      # PR actually ships. The CONFIG -- which names who may post a marker, and is
+      # the thing worth forging -- is read from the base branch below.
+      #
+      # RESIDUAL RISK, STATED: the gate's CODE still comes from the PR, so an edit
+      # to MARKER_RE or to `evaluate` is not neutralised by this split. That edit
+      # is visible in the diff and is what human review is for. It is a smaller
+      # surface than the config (a one-word `expectedAuthors` addition is easy to
+      # miss in a large diff; a change to the matching logic is not), and the
+      # measured population here is 100% same-repo PRs over the last 80 merges.
+      # If that changes, or if this gate goes enforcing on fork PRs, pin the code
+      # to base as well and accept that gate changes take effect one merge later.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
           lfs: false
           persist-credentials: false
 
@@ -93,6 +99,31 @@ jobs:
             --repo "${{ github.repository }}" --remove-label claude-reviewed \
             || echo "No label to clear (or no write access on a fork PR); CodeRabbit will review."
 
+      # The config is the thing worth forging: it names who may post a marker.
+      # Taken from the BASE branch so a PR cannot add its own author and pass.
+      # When base has no copy -- true only for the PR that introduces this gate --
+      # that is said out loud and the PR's own config is used, because the
+      # alternative is a job that can never run on the change that adds it.
+      - name: Take the reviewer allowlist from the base branch
+        id: cfg
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Written OUTSIDE the checkout: a file dropped into scripts/ would be
+          # picked up by this repo's own source-shape gates and could be committed
+          # by accident.
+          out="$RUNNER_TEMP/review-posted.base.json"
+          if gh api "repos/${{ github.repository }}/contents/scripts/review-posted.config.json?ref=${{ github.event.pull_request.base.sha }}" \
+               --jq '.content' 2>/dev/null | base64 -d > "$out" 2>/dev/null && [ -s "$out" ]; then
+            echo "config=$out" >> "$GITHUB_OUTPUT"
+            echo "Using the base branch's allowlist."
+          else
+            echo "config=scripts/review-posted.config.json" >> "$GITHUB_OUTPUT"
+            echo "::notice::No allowlist on the base branch yet (bootstrap). Using this PR's copy;"
+            echo "::notice::from the next PR onward the base copy is authoritative."
+          fi
+
       - name: Check a review was actually posted for this head
         id: gate
         env:
@@ -102,6 +133,7 @@ jobs:
           node scripts/check-review-posted.mjs \
             --pr "${{ github.event.pull_request.number }}" \
             --sha "${{ github.event.pull_request.head.sha }}" \
+            --config "${{ steps.cfg.outputs.config }}" \
             --timeout-seconds 300
 
       # ADDS ONLY. The clearing half runs up front, above.

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -1,0 +1,66 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+name: Review posted
+
+# NO `paths:` FILTER AND NO `branches:` FILTER, for the reason
+# pr-review-signal.yml documents at length: a presence gate that can itself be
+# filtered out is the same defect it exists to catch (#3305). This one reads
+# scripts/review-posted.config.json, so with no filter, no edit to that config
+# can dodge the job that runs it ON THE PATH THAT MERGES IT.
+#
+# `synchronize` matters more here than anywhere else: the gate adjudicates a
+# verdict for a SPECIFIC head, so a new commit must re-open the question. Without
+# it a review of commit 1 would keep a PR green through commit 20.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  # Covers both reads: issue comments and PR reviews. `issues: read` is not
+  # requested; if the first runs report GH_ERROR mentioning permissions, add it.
+  # The gate fails closed, so that shows up as a visible refusal rather than a
+  # silently empty comment list.
+  pull-requests: read
+
+concurrency:
+  group: review-posted-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-posted:
+    name: Review posted
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: false
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # The harness runs BEFORE the gate, and in this job rather than only in the
+      # scripts/ glob catch-all, for the reason check-pr-review-signal.yml gives:
+      # relying on a path-filtered job to run this gate's tests would put them
+      # behind a filter this workflow deliberately does not have.
+      #
+      # No `pnpm install`: the gate and its harness import node builtins only and
+      # shell out to `gh`, which is preinstalled on GitHub runners. A gate that
+      # decides whether a review happened must not be able to fail because a
+      # registry was slow.
+      - name: Unit-test the gate itself
+        run: node --test scripts/check-review-posted.test.mjs
+
+      - name: Check a review was actually posted for this head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          node scripts/check-review-posted.mjs \
+            --pr "${{ github.event.pull_request.number }}" \
+            --sha "${{ github.event.pull_request.head.sha }}"

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -1,0 +1,388 @@
+#!/usr/bin/env node
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * A REVIEW THAT DID NOT POST IS NOT A REVIEW, AND THE JOB'S EXIT CODE CANNOT
+ * TELL YOU WHICH HAPPENED.
+ *
+ * WHY THIS EXISTS. `anthropics/claude-code-action` has at least three OPEN,
+ * confirmed paths that report success while reviewing nothing, verified in its
+ * tracker on 2026-08-31:
+ *
+ *   - #1644 (bug, p1, 2026-08-13) "Agent exits success after 5-10 turns without
+ *     completing the review (silent no-op)". Roughly half of runs return
+ *     `is_error: false` with a low `num_turns`, so an `is_error` guard cannot
+ *     see it.
+ *   - #1679 (bug, p2, 2026-08-16) "post-buffered-inline-comments exits 0 after
+ *     failing to post every comment". Reported as FORTY CONSECUTIVE RUNS logging
+ *     `Posted 0/N` and reporting success: the review ran, findings existed, and
+ *     zero comments reached the pull request.
+ *   - An unguarded `num_turns: 0` path.
+ *
+ * None of the three is credential-specific, so paying for an API key instead of
+ * using a subscription does not close any of them.
+ *
+ * That is the same defect this repository has already paid for from the other
+ * side: 174 of 830 merged PRs in August 2026 (21%, 46,717 lines) carried no
+ * review of any kind while showing green, and #3175 then had to correct TWELVE
+ * changesets by hand that would have shipped breaking changes as `patch`, with
+ * the release one command from publishing. ABSENCE MUST NOT READ AS SUCCESS.
+ *
+ * WHAT THIS GATE REFUSES TO ACCEPT AS EVIDENCE, and why each is not enough:
+ *
+ *   - THE JOB'S EXIT CODE. #1644 and #1679 both exit 0.
+ *   - STRUCTURED OUTPUT / a `--json-schema` result. #1679 satisfies the schema
+ *     and drops every comment on the floor afterwards. The schema describes what
+ *     the model PRODUCED, not what the pull request RECEIVED.
+ *   - A COMMENT EXISTING AT ALL. A comment from an earlier head is not a review
+ *     of this one, and a force-push re-anchors bot comments to the new SHA, so
+ *     the comment's own anchor cannot be trusted to say which diff was read.
+ *
+ * THE ONE THING IT DOES ACCEPT is a marker the reviewer writes at the END of a
+ * successful post, naming the exact commit it reviewed:
+ *
+ *     <!-- ifc-lite-review sha=<40-hex> verdict=clean|findings count=<n> -->
+ *
+ * THE CONTRACT THIS IMPLIES, and it is the load-bearing half: THE REVIEWER MUST
+ * POST ON EVERY RUN, INCLUDING WHEN IT FINDS NOTHING. A reviewer that stays
+ * silent when clean makes "reviewed and found nothing" byte-identical to "never
+ * ran", which is the exact trap CodeRabbit falls into here (it publishes no
+ * review event on a clean pass, which is why scripts/pr-review-signal.config.json
+ * ships `staleReviewPolicy: "off"` -- absence of a review object is not evidence
+ * of staleness for THAT reviewer, and cannot be made into evidence). We control
+ * our own reviewer, so we take the other branch: it always speaks, and silence
+ * therefore means failure. This gate is only meaningful because of that.
+ *
+ * FAILURE CLASSES, each with its own remedy, because a remedy that contradicts
+ * its finding is worse than no remedy:
+ *
+ *   NOT_POSTED       No marker from any expected author. The action reported
+ *                    whatever it reported; nothing reached the PR.
+ *                    REMEDY: re-run the review job. If it recurs, the run log
+ *                    will show `Posted 0/N` (#1679) or a low `num_turns`
+ *                    (#1644); attach it to the issue rather than re-running
+ *                    forever.
+ *   STALE_REVIEW     A marker exists but names a different commit. The reviewer
+ *                    read an earlier head. REMEDY: re-run; do not read the older
+ *                    verdict as covering this diff.
+ *   MARKER_MALFORMED A marker is present and unparseable. Treated as absence,
+ *                    never as a pass. REMEDY: fix the reviewer's marker writer.
+ *   NO_PR / NO_REPO / NO_SHA / BAD_CONFIG / GH_*  Broken invocation or an
+ *                    unreadable input. REMEDY is per message; all fail closed.
+ *
+ * STATED HOLES, so nobody reads a green here as more than it is:
+ *
+ *   1. It proves a comment was POSTED naming this SHA. It proves nothing about
+ *      whether the review was any GOOD. Precision is a separate instrument.
+ *   2. A reviewer that posts a marker and an empty body satisfies this gate. The
+ *      marker is written by our own reviewer, so this is a trust boundary we
+ *      own, not one an outside contributor can cross -- but it is a boundary.
+ *   3. It cannot distinguish "the model had nothing to say" from "the model was
+ *      throttled into saying nothing but still posted". If the review lane is
+ *      funded by a consumer subscription whose pool can drain, the reviewer must
+ *      itself fail rather than post an empty clean verdict; this gate cannot
+ *      recover that distinction after the fact.
+ *   4. Comment pagination is bounded (see PAGE_LIMIT). A PR whose comment list
+ *      exceeds it fails closed with COMMENTS_TRUNCATED rather than guessing.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isMainEntry } from './lib/is-main-entry.mjs';
+import { existsOrThrow } from './lib/exists-or-throw.mjs';
+import { gh, GhError } from './lib/gh.mjs';
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CONFIG = join(SCRIPTS_DIR, 'review-posted.config.json');
+
+/** Bounded on purpose: an unbounded read that silently truncates is a false pass. */
+const PAGE_LIMIT = 200;
+
+/**
+ * The marker the reviewer writes at the END of a successful post. Anchored at
+ * both ends and tolerant of surrounding whitespace only -- a loose pattern here
+ * would let a contributor hand-write a passing marker into a PR comment.
+ */
+const MARKER_RE = /<!--\s*ifc-lite-review\s+sha=([0-9a-f]{40})\s+verdict=(clean|findings)\s+count=(\d+)\s*-->/;
+
+export class ReviewPostedError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+/** @param {string} login */
+export function normaliseLogin(login) {
+  return String(login ?? '')
+    .toLowerCase()
+    .replace(/\[bot\]$/, '')
+    .replace(/^app\//, '');
+}
+
+/** @param {string} path */
+export function readConfig(path) {
+  if (
+    !existsOrThrow(path, 'the review-posted config', (m) => {
+      throw new ReviewPostedError('BAD_CONFIG', m);
+    })
+  ) {
+    throw new ReviewPostedError(
+      'NO_CONFIG',
+      `Config \`${path}\` is missing. A missing reviewer list is NOT an empty one: with no ` +
+        'expected authors this gate would accept a marker from anybody, so it refuses instead.',
+    );
+  }
+  let cfg;
+  try {
+    cfg = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    throw new ReviewPostedError('BAD_CONFIG', `Config \`${path}\` is not valid JSON: ${err.message}`);
+  }
+  if (!Array.isArray(cfg.expectedAuthors) || cfg.expectedAuthors.length === 0) {
+    throw new ReviewPostedError(
+      'BAD_CONFIG',
+      `\`expectedAuthors\` in \`${path}\` must be a non-empty array of GitHub logins. ` +
+        'Not defaulted: an empty list would make every PR pass on any comment.',
+    );
+  }
+  if (cfg.mode !== 'advisory' && cfg.mode !== 'enforcing') {
+    throw new ReviewPostedError(
+      'BAD_CONFIG',
+      `\`mode\` in \`${path}\` must be "advisory" or "enforcing"; found ${JSON.stringify(cfg.mode)}. ` +
+        'There is no default: a missing mode is a broken config, not a request for the lenient one.',
+    );
+  }
+  return {
+    // Carried through explicitly. This return is an allowlist, not a spread, so a
+    // key validated above but omitted here reads as `undefined` at the call site
+    // while validation still passes -- a knob that silently does nothing.
+    mode: cfg.mode,
+    expectedAuthors: new Set(cfg.expectedAuthors.map(normaliseLogin)),
+  };
+}
+
+/** @param {string[]} argv */
+export function parseArgs(argv) {
+  const out = { pr: null, repo: process.env.GITHUB_REPOSITORY || null, sha: null, config: DEFAULT_CONFIG, stateFile: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === '--') continue;
+    const m = /^--([a-z-]+)$/.exec(a);
+    if (!m) throw new ReviewPostedError('BAD_ARGS', `Unrecognised argument \`${a}\`.`);
+    const key = { pr: 'pr', repo: 'repo', sha: 'sha', config: 'config', 'state-file': 'stateFile' }[m[1]];
+    if (!key) throw new ReviewPostedError('BAD_ARGS', `Unrecognised flag \`${a}\`.`);
+    const v = argv[i + 1];
+    if (v === undefined) throw new ReviewPostedError('BAD_ARGS', `\`${a}\` needs a value.`);
+    out[key] = v;
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Every comment body on the PR, from the issue-comment and review-comment
+ * surfaces both, because the reviewer may post as either and a gate that reads
+ * only one surface is blind exactly where the other is used.
+ *
+ * Pure over an already-fetched payload so the harness can drive every branch
+ * without a network, a token, or a real PR. The harness reaches it through
+ * `--state-file`, not through an import.
+ *
+ * @returns {{ author: string, body: string }[]}
+ */
+export function normaliseComments(payload) {
+  if (!payload || typeof payload !== 'object') {
+    throw new ReviewPostedError('NO_PAYLOAD', 'No comment payload to adjudicate.');
+  }
+  const out = [];
+  for (const key of ['issueComments', 'reviewComments', 'reviews']) {
+    const list = payload[key];
+    if (list === undefined) continue;
+    if (!Array.isArray(list)) {
+      throw new ReviewPostedError('BAD_PAYLOAD', `\`${key}\` is present but is not an array.`);
+    }
+    if (list.length >= PAGE_LIMIT) {
+      throw new ReviewPostedError(
+        'COMMENTS_TRUNCATED',
+        `\`${key}\` returned ${list.length} entries, at or past the ${PAGE_LIMIT} page limit, so ` +
+          'the marker may be on a page this gate never read. Refusing to report "not posted" for ' +
+          'a list it could not finish reading.',
+      );
+    }
+    for (const c of list) {
+      out.push({ author: normaliseLogin(c?.user?.login ?? c?.author?.login), body: String(c?.body ?? '') });
+    }
+  }
+  if (out.length === 0 && payload.issueComments === undefined && payload.reviewComments === undefined) {
+    throw new ReviewPostedError('NO_PAYLOAD', 'Payload carried no comment lists at all.');
+  }
+  return out;
+}
+
+/**
+ * The verdict. `ok` is true only when an expected author posted a well-formed
+ * marker naming exactly `headSha`.
+ *
+ * @returns {{ ok: boolean, verdict: string, lines: string[] }}
+ */
+export function evaluate({ comments, cfg, headSha }) {
+  const lines = [];
+  const mine = comments.filter((c) => cfg.expectedAuthors.has(c.author));
+
+  if (mine.length === 0) {
+    lines.push(
+      `❌ NOT_POSTED: no comment on this PR from any expected reviewer ` +
+        `(${[...cfg.expectedAuthors].join(', ')}).`,
+      '   The review job\'s exit code is NOT evidence: claude-code-action #1644 exits success after',
+      '   a partial run, and #1679 exits 0 after failing to post every comment (reported as forty',
+      '   consecutive runs logging `Posted 0/N`). Both are open.',
+      '   REMEDY: re-run the review job. If it recurs, read the run log for `Posted 0/N` or a low',
+      '   `num_turns` and attach it to the upstream issue rather than re-running indefinitely.',
+    );
+    return { ok: false, verdict: 'NOT_POSTED', lines };
+  }
+
+  const markers = [];
+  let sawUnparseable = false;
+  for (const c of mine) {
+    const m = MARKER_RE.exec(c.body);
+    if (m) markers.push({ sha: m[1], verdict: m[2], count: Number(m[3]) });
+    // Only an ATTEMPTED marker counts as malformed: an HTML comment carrying the
+    // token but not parsing. A prose mention of the token is not a broken marker
+    // writer, and the two have different remedies -- "fix the writer" versus
+    // "re-run the job" -- so conflating them points the reader at the wrong fix.
+    else if (/<!--[^>]*ifc-lite-review/.test(c.body)) sawUnparseable = true;
+  }
+
+  if (markers.length === 0) {
+    lines.push(
+      sawUnparseable
+        ? '❌ MARKER_MALFORMED: an expected reviewer commented and its marker did not parse.'
+        : '❌ NOT_POSTED: an expected reviewer commented, but no comment carries a review marker.',
+      '   A comment without a marker is not a completed review: the marker is written at the END',
+      '   of a successful post, so its absence is exactly the partial-run shape #1644 describes.',
+      '   Treated as absence rather than as a pass, on purpose.',
+      '   REMEDY: ' +
+        (sawUnparseable
+          ? 'fix the reviewer\'s marker writer; the expected form is ' +
+            '`<!-- ifc-lite-review sha=<40-hex> verdict=clean|findings count=<n> -->`.'
+          : 're-run the review job.'),
+    );
+    return { ok: false, verdict: sawUnparseable ? 'MARKER_MALFORMED' : 'NOT_POSTED', lines };
+  }
+
+  const match = markers.find((m) => m.sha === headSha);
+  if (!match) {
+    lines.push(
+      `❌ STALE_REVIEW: the newest review marker names ${markers[markers.length - 1].sha.slice(0, 9)}, ` +
+        `but this PR's head is ${headSha.slice(0, 9)}.`,
+      '   A review of an earlier head has not reviewed this diff. The comment ANCHOR cannot settle',
+      '   this either: a force-push re-anchors bot comments to the new SHA, so only the marker the',
+      '   reviewer wrote at review time says which commit it actually read.',
+      '   REMEDY: re-run the review job against the current head.',
+    );
+    return { ok: false, verdict: 'STALE_REVIEW', lines };
+  }
+
+  lines.push(
+    `✅ REVIEW_POSTED: an expected reviewer posted a ${match.verdict} verdict for ${headSha.slice(0, 9)}` +
+      `${match.verdict === 'findings' ? ` with ${match.count} finding(s)` : ''}.`,
+    '   This proves a review REACHED the pull request for this exact commit. It proves nothing',
+    '   about whether the review was any good; precision is a separate instrument.',
+  );
+  return { ok: true, verdict: 'REVIEW_POSTED', lines };
+}
+
+function fetchPayload(repo, pr) {
+  return {
+    issueComments: gh(
+      ['api', `repos/${repo}/issues/${pr}/comments`, '--paginate', '--slurp'],
+      'the PR comment list',
+      ReviewPostedError,
+    ).flat(),
+    reviews: gh(
+      ['api', `repos/${repo}/pulls/${pr}/reviews`, '--paginate', '--slurp'],
+      'the PR review list',
+      ReviewPostedError,
+    ).flat(),
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const cfg = readConfig(args.config);
+
+  // Printed immediately after readConfig, before anything that can refuse on PR
+  // state, so a red check always states which mode produced it. parseArgs and
+  // readConfig necessarily refuse before it; those are broken-invocation errors,
+  // not verdicts on a PR.
+  console.log(
+    `Mode: ${cfg.mode}${
+      cfg.mode === 'advisory' ? ' (a failing verdict prints but does not fail this job; a REFUSAL still does)' : ''
+    }`,
+  );
+
+  if (!args.pr) throw new ReviewPostedError('NO_PR', 'Pass `--pr <number>`.');
+  if (!args.sha) {
+    throw new ReviewPostedError(
+      'NO_SHA',
+      'Pass `--sha <40-hex>`, the head commit this review must name. Deriving it here instead of ' +
+        'being told would let the gate adjudicate a commit different from the one CI is testing.',
+    );
+  }
+  if (!/^[0-9a-f]{40}$/.test(args.sha)) {
+    throw new ReviewPostedError('NO_SHA', `\`--sha\` must be a full 40-hex commit; got ${JSON.stringify(args.sha)}.`);
+  }
+
+  let payload;
+  if (args.stateFile) {
+    payload = JSON.parse(readFileSync(args.stateFile, 'utf8'));
+  } else {
+    if (!args.repo) {
+      throw new ReviewPostedError(
+        'NO_REPO',
+        'Pass `--repo owner/name` or set GITHUB_REPOSITORY. Guessing it would mean adjudicating a ' +
+          'repository this gate never confirmed.',
+      );
+    }
+    payload = fetchPayload(args.repo, args.pr);
+  }
+
+  const comments = normaliseComments(payload);
+  console.log(`Comments read: ${comments.length}`);
+  console.log(`Head: ${args.sha.slice(0, 9)}`);
+  console.log('');
+
+  const { ok, lines } = evaluate({ comments, cfg, headSha: args.sha });
+  for (const l of lines) console.log(l);
+
+  // Advisory gates the EXIT CODE and nothing else. The verdict text is identical
+  // in both modes, so a rollout state cannot quietly change what is reported. A
+  // REFUSAL is a fact about this gate's inputs rather than a verdict on the PR,
+  // so it fails closed in both modes -- it never reaches here.
+  if (!ok && cfg.mode === 'advisory') {
+    console.log('');
+    console.log(
+      'ADVISORY MODE: the finding above does not fail this job. Set `mode` to "enforcing" in ' +
+        'scripts/review-posted.config.json once the reviewer lane is trusted.',
+    );
+    process.exit(0);
+  }
+  process.exit(ok ? 0 : 1);
+}
+
+if (isMainEntry(import.meta.url)) {
+  try {
+    main();
+  } catch (err) {
+    if (err instanceof ReviewPostedError || err instanceof GhError) {
+      console.error(`❌ ${err.reason}: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -88,7 +88,7 @@
  *      exceeds it fails closed with COMMENTS_TRUNCATED rather than guessing.
  */
 
-import { readFileSync } from 'node:fs';
+import { readFileSync, appendFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isMainEntry } from './lib/is-main-entry.mjs';
@@ -359,6 +359,15 @@ function main() {
 
   const { ok, lines } = evaluate({ comments, cfg, headSha: args.sha });
   for (const l of lines) console.log(l);
+
+  // `covered` is the VERDICT, independent of the exit code, and the two differ on
+  // purpose in advisory mode: there, a failing verdict still exits 0, and a caller
+  // that inferred coverage from the exit code would mark an unreviewed PR as
+  // covered. Anything downstream that acts on "was this reviewed" -- the
+  // CodeRabbit stand-down label, above all -- must read THIS, never `$?`.
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `covered=${ok ? 'true' : 'false'}\n`);
+  }
 
   // Advisory gates the EXIT CODE and nothing else. The verdict text is identical
   // in both modes, so a rollout state cannot quietly change what is reported. A

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -84,22 +84,52 @@
  *      funded by a consumer subscription whose pool can drain, the reviewer must
  *      itself fail rather than post an empty clean verdict; this gate cannot
  *      recover that distinction after the fact.
- *   4. Comment pagination is bounded (see PAGE_LIMIT). A PR whose comment list
- *      exceeds it fails closed with COMMENTS_TRUNCATED rather than guessing.
+ *   4. Comment pagination is bounded (MAX_PAGES x PER_PAGE). A PR busier than
+ *      that fails closed with COMMENTS_TRUNCATED rather than guessing.
+ *   5. It waits for the marker (POLL_SECONDS up to the timeout) because a
+ *      comment does not fire `pull_request`. On expiry NOT_POSTED is the true
+ *      answer at that moment, not a timeout dressed up as one.
  */
 
 import { readFileSync, appendFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isMainEntry } from './lib/is-main-entry.mjs';
-import { existsOrThrow } from './lib/exists-or-throw.mjs';
 import { gh, GhError } from './lib/gh.mjs';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_CONFIG = join(SCRIPTS_DIR, 'review-posted.config.json');
 
-/** Bounded on purpose: an unbounded read that silently truncates is a false pass. */
-const PAGE_LIMIT = 200;
+/**
+ * THE POLL, AND WHY THIS GATE CANNOT BE A SINGLE READ.
+ *
+ * The workflow fires on `pull_request`, which means this gate starts SECONDS
+ * after a push while the reviewer takes minutes. Nothing re-fires it when the
+ * marker lands: posting a comment does not raise a `pull_request` event. A
+ * single-read version is therefore RED ON EVERY PUSH and green only after a
+ * human clicks re-run -- 1,200 manual re-runs a month here, which is how a gate
+ * stops being read at all. Advisory mode hides this completely, so it would have
+ * shipped broken on the day it was flipped to enforcing.
+ *
+ * So it waits, the way scripts/check-pr-review-signal.mjs waits for lanes. The
+ * budget is the honest question "has the reviewer had a fair chance yet", not a
+ * guess at how long a review takes: on expiry the verdict is still NOT_POSTED,
+ * which is the true answer at that moment, and the remedy re-runs.
+ */
+const POLL_SECONDS = 15;
+const DEFAULT_TIMEOUT_SECONDS = 600;
+
+/**
+ * A page cap that is REAL. `gh api --paginate` follows Link headers to
+ * exhaustion, so a guard applied after that call bounds nothing and merely turns
+ * a fully-read busy PR into a permanent refusal it can never clear. The fetch
+ * below is explicitly paged, and this is the number of pages it will walk before
+ * refusing -- so the limit the message names is the limit that exists.
+ */
+const COMMENT_KEYS = ['issueComments', 'reviewComments', 'reviews'];
+
+const MAX_PAGES = 10;
+const PER_PAGE = 100;
 
 /**
  * The marker the reviewer writes at the END of a successful post. Anchored at
@@ -107,6 +137,11 @@ const PAGE_LIMIT = 200;
  * would let a contributor hand-write a passing marker into a PR comment.
  */
 const MARKER_RE = /<!--\s*ifc-lite-review\s+sha=([0-9a-f]{40})\s+verdict=(clean|findings)\s+count=(\d+)\s*-->/;
+
+/** Block the runner without a dependency. This job's whole purpose is to wait. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
 export class ReviewPostedError extends Error {
   constructor(reason, message) {
@@ -125,20 +160,28 @@ export function normaliseLogin(login) {
 
 /** @param {string} path */
 export function readConfig(path) {
-  if (
-    !existsOrThrow(path, 'the review-posted config', (m) => {
-      throw new ReviewPostedError('BAD_CONFIG', m);
-    })
-  ) {
-    throw new ReviewPostedError(
-      'NO_CONFIG',
-      `Config \`${path}\` is missing. A missing reviewer list is NOT an empty one: with no ` +
-        'expected authors this gate would accept a marker from anybody, so it refuses instead.',
-    );
+  // Read once and branch on the error code, rather than stat-then-read.
+  // `existsOrThrow` exists for gates that DISCOVER paths by walking, where a
+  // false from `existsSync` silently drops a package from an audit. Here the
+  // file is opened on the next line and `readFileSync` already separates ENOENT
+  // from EACCES, so the extra syscall bought a TOCTOU window and a second throw
+  // site and nothing else.
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new ReviewPostedError(
+        'NO_CONFIG',
+        `Config \`${path}\` is missing. A missing reviewer list is NOT an empty one: with no ` +
+          'expected authors this gate would accept a marker from anybody, so it refuses instead.',
+      );
+    }
+    throw new ReviewPostedError('BAD_CONFIG', `Cannot read config \`${path}\`: ${err.code || err.message}.`);
   }
   let cfg;
   try {
-    cfg = JSON.parse(readFileSync(path, 'utf8'));
+    cfg = JSON.parse(raw);
   } catch (err) {
     throw new ReviewPostedError('BAD_CONFIG', `Config \`${path}\` is not valid JSON: ${err.message}`);
   }
@@ -166,18 +209,52 @@ export function readConfig(path) {
 }
 
 /** @param {string[]} argv */
+/**
+ * A Map, not an object literal. `{...}[name]` reaches Object.prototype, so
+ * `--constructor x` returned a truthy key, sailed past the `!key` guard, and
+ * wrote a junk property instead of refusing -- a guard that did not guard what
+ * it claimed. There is also no `--` handling: nothing in this repo passes it,
+ * and the previous line skipped the token while continuing to parse everything
+ * after it as flags, which is the opposite of what `--` conventionally means.
+ */
+const FLAGS = new Map([
+  ['--pr', 'pr'],
+  ['--repo', 'repo'],
+  ['--sha', 'sha'],
+  ['--config', 'config'],
+  ['--state-file', 'stateFile'],
+  ['--timeout-seconds', 'timeoutSeconds'],
+]);
+
 export function parseArgs(argv) {
-  const out = { pr: null, repo: process.env.GITHUB_REPOSITORY || null, sha: null, config: DEFAULT_CONFIG, stateFile: null };
+  const out = {
+    pr: null,
+    repo: process.env.GITHUB_REPOSITORY || null,
+    sha: null,
+    config: DEFAULT_CONFIG,
+    stateFile: null,
+    timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+  };
   for (let i = 0; i < argv.length; i += 1) {
-    const a = argv[i];
-    if (a === '--') continue;
-    const m = /^--([a-z-]+)$/.exec(a);
-    if (!m) throw new ReviewPostedError('BAD_ARGS', `Unrecognised argument \`${a}\`.`);
-    const key = { pr: 'pr', repo: 'repo', sha: 'sha', config: 'config', 'state-file': 'stateFile' }[m[1]];
-    if (!key) throw new ReviewPostedError('BAD_ARGS', `Unrecognised flag \`${a}\`.`);
+    const key = FLAGS.get(argv[i]);
+    if (!key) throw new ReviewPostedError('BAD_ARGS', `Unrecognised argument \`${argv[i]}\`.`);
     const v = argv[i + 1];
-    if (v === undefined) throw new ReviewPostedError('BAD_ARGS', `\`${a}\` needs a value.`);
-    out[key] = v;
+    if (v === undefined) throw new ReviewPostedError('BAD_ARGS', `\`${argv[i]}\` needs a value.`);
+    if (key === 'timeoutSeconds') {
+      // Rejected BEFORE coercion, because the dangerous value is not NaN, it is
+      // the EMPTY STRING: `Number('')` is 0, which is finite and non-negative, so
+      // an unset or blank CI variable would silently disable the poll -- and a
+      // gate that does not poll is red on every push, which is the exact fatal
+      // behaviour the poll exists to fix. An explicit `0` stays legal; a blank
+      // does not. NaN is rejected for the other half: it loses every comparison,
+      // so a NaN deadline never behaves like a deadline.
+      const trimmed = String(v).trim();
+      const n = trimmed === '' ? NaN : Number(trimmed);
+      if (!Number.isFinite(n) || n < 0) {
+        throw new ReviewPostedError('BAD_ARGS', `\`--timeout-seconds\` must be a non-negative number; got ${JSON.stringify(v)}.`);
+      }
+      out[key] = n;
+    } else out[key] = v;
     i += 1;
   }
   return out;
@@ -199,25 +276,28 @@ export function normaliseComments(payload) {
     throw new ReviewPostedError('NO_PAYLOAD', 'No comment payload to adjudicate.');
   }
   const out = [];
-  for (const key of ['issueComments', 'reviewComments', 'reviews']) {
+  for (const key of COMMENT_KEYS) {
     const list = payload[key];
     if (list === undefined) continue;
     if (!Array.isArray(list)) {
       throw new ReviewPostedError('BAD_PAYLOAD', `\`${key}\` is present but is not an array.`);
     }
-    if (list.length >= PAGE_LIMIT) {
+    if (payload.truncated?.includes(key)) {
       throw new ReviewPostedError(
         'COMMENTS_TRUNCATED',
-        `\`${key}\` returned ${list.length} entries, at or past the ${PAGE_LIMIT} page limit, so ` +
-          'the marker may be on a page this gate never read. Refusing to report "not posted" for ' +
-          'a list it could not finish reading.',
+        `\`${key}\` still had more pages after ${MAX_PAGES} x ${PER_PAGE} entries, so the marker ` +
+          'may be on a page this gate never read. Refusing to report "not posted" for a list it ' +
+          'could not finish reading. REMEDY: raise MAX_PAGES, or narrow what the reviewer posts.',
       );
     }
     for (const c of list) {
       out.push({ author: normaliseLogin(c?.user?.login ?? c?.author?.login), body: String(c?.body ?? '') });
     }
   }
-  if (out.length === 0 && payload.issueComments === undefined && payload.reviewComments === undefined) {
+  // Same list the loop walks. These had drifted: the loop read three surfaces
+  // and the guard checked two, so a payload carrying only an empty `reviews` was
+  // NO_PAYLOAD while a non-empty one was first-class.
+  if (out.length === 0 && !COMMENT_KEYS.some((k) => payload[k] !== undefined)) {
     throw new ReviewPostedError('NO_PAYLOAD', 'Payload carried no comment lists at all.');
   }
   return out;
@@ -278,14 +358,40 @@ export function evaluate({ comments, cfg, headSha }) {
   const match = markers.find((m) => m.sha === headSha);
   if (!match) {
     lines.push(
-      `❌ STALE_REVIEW: the newest review marker names ${markers[markers.length - 1].sha.slice(0, 9)}, ` +
+      `❌ STALE_REVIEW: the most recent marker this gate read names ${markers[markers.length - 1].sha.slice(0, 9)}, ` +
         `but this PR's head is ${headSha.slice(0, 9)}.`,
       '   A review of an earlier head has not reviewed this diff. The comment ANCHOR cannot settle',
       '   this either: a force-push re-anchors bot comments to the new SHA, so only the marker the',
-      '   reviewer wrote at review time says which commit it actually read.',
+      '   reviewer wrote at review time says which commit it read. ("Most recent" is fetch order, not',
+      '   timestamp: no timestamp survives normalisation, so the gate does not claim one.)',
       '   REMEDY: re-run the review job against the current head.',
     );
     return { ok: false, verdict: 'STALE_REVIEW', lines };
+  }
+
+  // THE #1679 CROSS-CHECK. A marker claiming `verdict=findings count=N` while N
+  // findings never reached the PR is precisely the shape #1679 describes: the
+  // summary posts, the inline comments drop, `Posted 0/N` is logged, and the job
+  // exits 0. The docblock cites that bug as founding case law, so the gate has to
+  // be able to see it rather than trusting the count the marker asserts.
+  //
+  // Counted across every comment from an expected author EXCEPT the marker's own
+  // carrier, since a summary comment is not itself a finding.
+  if (match.verdict === 'findings') {
+    const carriers = mine.filter((c) => MARKER_RE.test(c.body)).length;
+    const others = mine.length - carriers;
+    if (others === 0) {
+      lines.push(
+        `❌ FINDINGS_NOT_POSTED: the marker claims ${match.count} finding(s) for ` +
+          `${headSha.slice(0, 9)}, and no finding comment from an expected reviewer reached this PR.`,
+        '   This is the #1679 shape exactly: the summary posts, the inline comments drop, the run',
+        '   logs `Posted 0/N`, and the job exits 0. The count in the marker is the reviewer\'s own',
+        '   claim; this is the check that it is true.',
+        '   REMEDY: re-run the review job. If it recurs, the run log will show `Posted 0/N`; attach',
+        '   it to claude-code-action#1679 rather than re-running indefinitely.',
+      );
+      return { ok: false, verdict: 'FINDINGS_NOT_POSTED', lines };
+    }
   }
 
   lines.push(
@@ -297,19 +403,44 @@ export function evaluate({ comments, cfg, headSha }) {
   return { ok: true, verdict: 'REVIEW_POSTED', lines };
 }
 
+/**
+ * All THREE comment surfaces, explicitly paged.
+ *
+ * `pulls/{n}/comments` is the inline-review-comment surface and was missing while
+ * the docstring claimed both were read -- which mattered: it is where a reviewer
+ * posting per-finding comments puts them, and it is the surface #1679 drops
+ * ("Posted 0/N"). A gate that cites #1679 has to be able to see the thing #1679
+ * loses.
+ *
+ * Paged by hand rather than `--paginate --slurp` so the page bound this gate
+ * reports is the page bound it applies.
+ */
 function fetchPayload(repo, pr) {
-  return {
-    issueComments: gh(
-      ['api', `repos/${repo}/issues/${pr}/comments`, '--paginate', '--slurp'],
-      'the PR comment list',
-      ReviewPostedError,
-    ).flat(),
-    reviews: gh(
-      ['api', `repos/${repo}/pulls/${pr}/reviews`, '--paginate', '--slurp'],
-      'the PR review list',
-      ReviewPostedError,
-    ).flat(),
+  const surfaces = {
+    issueComments: `repos/${repo}/issues/${pr}/comments`,
+    reviews: `repos/${repo}/pulls/${pr}/reviews`,
+    reviewComments: `repos/${repo}/pulls/${pr}/comments`,
   };
+  const out = { truncated: [] };
+  for (const [key, path] of Object.entries(surfaces)) {
+    const rows = [];
+    let page = 1;
+    for (; page <= MAX_PAGES; page += 1) {
+      const batch = gh(
+        ['api', `${path}?per_page=${PER_PAGE}&page=${page}`, '--method', 'GET'],
+        `${key} page ${page}`,
+        ReviewPostedError,
+      );
+      if (!Array.isArray(batch)) {
+        throw new ReviewPostedError('BAD_PAYLOAD', `${key} page ${page} was not an array.`);
+      }
+      rows.push(...batch);
+      if (batch.length < PER_PAGE) break;
+    }
+    if (page > MAX_PAGES) out.truncated.push(key);
+    out[key] = rows;
+  }
+  return out;
 }
 
 function main() {
@@ -352,12 +483,28 @@ function main() {
     payload = fetchPayload(args.repo, args.pr);
   }
 
-  const comments = normaliseComments(payload);
+  // THE POLL. A single read races the reviewer and loses: this job starts seconds
+  // after the push, the reviewer takes minutes, and no event re-fires this gate
+  // when the comment lands. Re-read until the verdict is OK or the budget is
+  // spent. A REFUSAL (bad payload, truncation) throws out of here immediately --
+  // waiting cannot fix an input this gate could not read.
+  const deadline = Date.now() + args.timeoutSeconds * 1000;
+  let comments = normaliseComments(payload);
+  let result = evaluate({ comments, cfg, headSha: args.sha });
+  let waited = 0;
+  while (!result.ok && !args.stateFile && Date.now() < deadline) {
+    sleepSync(POLL_SECONDS * 1000);
+    waited += POLL_SECONDS;
+    comments = normaliseComments(fetchPayload(args.repo, args.pr));
+    result = evaluate({ comments, cfg, headSha: args.sha });
+  }
+
   console.log(`Comments read: ${comments.length}`);
   console.log(`Head: ${args.sha.slice(0, 9)}`);
+  if (waited > 0) console.log(`Waited ${waited}s for a verdict to appear.`);
   console.log('');
 
-  const { ok, lines } = evaluate({ comments, cfg, headSha: args.sha });
+  const { ok, lines } = result;
   for (const l of lines) console.log(l);
 
   // `covered` is the VERDICT, independent of the exit code, and the two differ on

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -116,8 +116,8 @@ const DEFAULT_CONFIG = join(SCRIPTS_DIR, 'review-posted.config.json');
  * guess at how long a review takes: on expiry the verdict is still NOT_POSTED,
  * which is the true answer at that moment, and the remedy re-runs.
  */
-const POLL_SECONDS = 15;
-const DEFAULT_TIMEOUT_SECONDS = 600;
+const POLL_SECONDS = 30;
+const DEFAULT_TIMEOUT_SECONDS = 300;
 
 /**
  * A page cap that is REAL. `gh api --paginate` follows Link headers to
@@ -184,6 +184,14 @@ export function readConfig(path) {
     cfg = JSON.parse(raw);
   } catch (err) {
     throw new ReviewPostedError('BAD_CONFIG', `Config \`${path}\` is not valid JSON: ${err.message}`);
+  }
+  if (cfg === null || typeof cfg !== 'object' || Array.isArray(cfg)) {
+    throw new ReviewPostedError(
+      'BAD_CONFIG',
+      `Config \`${path}\` parsed as ${cfg === null ? 'null' : Array.isArray(cfg) ? 'an array' : typeof cfg}, ` +
+        'not an object. Reaching for a key on it would throw a TypeError past this file\'s catch and ' +
+        'print a stack trace instead of a remedy.',
+    );
   }
   if (!Array.isArray(cfg.expectedAuthors) || cfg.expectedAuthors.length === 0) {
     throw new ReviewPostedError(
@@ -291,7 +299,15 @@ export function normaliseComments(payload) {
       );
     }
     for (const c of list) {
-      out.push({ author: normaliseLogin(c?.user?.login ?? c?.author?.login), body: String(c?.body ?? '') });
+      out.push({
+        author: normaliseLogin(c?.user?.login ?? c?.author?.login),
+        body: String(c?.body ?? ''),
+        // Which surface it came from, and which commit an inline comment is
+        // anchored to. Both are needed by the findings cross-check and neither
+        // survived the old shape, which is why that check could not be precise.
+        surface: key,
+        commitId: c?.commit_id ?? null,
+      });
     }
   }
   // Same list the loop walks. These had drifted: the loop read three surfaces
@@ -378,19 +394,30 @@ export function evaluate({ comments, cfg, headSha }) {
   // Counted across every comment from an expected author EXCEPT the marker's own
   // carrier, since a summary comment is not itself a finding.
   if (match.verdict === 'findings') {
-    const carriers = mine.filter((c) => MARKER_RE.test(c.body)).length;
-    const others = mine.length - carriers;
-    if (others === 0) {
+    // COUNTED FROM INLINE COMMENTS ON THIS HEAD ONLY. An earlier version counted
+    // every non-carrier comment from an expected author, which made the check
+    // inert on most PRs here: benchmark.yml posts a summary comment as
+    // `github-actions` on any PR touching rust/, packages/, apps/viewer/ or
+    // Cargo.*, and that one comment satisfied `others >= 1` forever. Stale
+    // findings from an earlier head did the same. Both let a marker claiming
+    // three findings pass with all three dropped -- the exact #1679 shape the
+    // check exists to catch.
+    const posted = comments.filter(
+      (c) => c.surface === 'reviewComments' && cfg.expectedAuthors.has(c.author) && c.commitId === headSha,
+    ).length;
+    if (posted === 0) {
       lines.push(
         `❌ FINDINGS_NOT_POSTED: the marker claims ${match.count} finding(s) for ` +
-          `${headSha.slice(0, 9)}, and no finding comment from an expected reviewer reached this PR.`,
+          `${headSha.slice(0, 9)}, and no inline finding from an expected reviewer is anchored to it.`,
         '   This is the #1679 shape exactly: the summary posts, the inline comments drop, the run',
         '   logs `Posted 0/N`, and the job exits 0. The count in the marker is the reviewer\'s own',
         '   claim; this is the check that it is true.',
+        '   Only INLINE comments on THIS head count. A summary comment is not a finding, and a',
+        '   finding on an earlier head is not a finding on this diff.',
         '   REMEDY: re-run the review job. If it recurs, the run log will show `Posted 0/N`; attach',
         '   it to claude-code-action#1679 rather than re-running indefinitely.',
       );
-      return { ok: false, verdict: 'FINDINGS_NOT_POSTED', lines };
+      return { ok: false, verdict: 'FINDINGS_NOT_POSTED', escapeHatch: null, lines };
     }
   }
 
@@ -415,6 +442,38 @@ export function evaluate({ comments, cfg, headSha }) {
  * Paged by hand rather than `--paginate --slurp` so the page bound this gate
  * reports is the page bound it applies.
  */
+/**
+ * Walk one surface, page by page, and say honestly whether it finished.
+ *
+ * Pure over an injected `fetchPage` so the pager is testable without a network.
+ * It was not, and that mattered: "the bound is now REAL" was asserted on a test
+ * that hand-fed `{ truncated: [...] }` straight to the evaluator and never ran a
+ * single page.
+ *
+ * @param {(page: number, perPage: number) => unknown[]} fetchPage
+ * @returns {{ rows: unknown[], truncated: boolean }}
+ */
+export function pageAll(fetchPage, { maxPages = MAX_PAGES, perPage = PER_PAGE } = {}) {
+  const rows = [];
+  for (let page = 1; page <= maxPages; page += 1) {
+    const batch = fetchPage(page, perPage);
+    if (!Array.isArray(batch)) {
+      throw new ReviewPostedError('BAD_PAYLOAD', `page ${page} was not an array.`);
+    }
+    rows.push(...batch);
+    if (batch.length < perPage) return { rows, truncated: false };
+    // Probe one past a full final page rather than calling it truncated: a
+    // surface holding exactly maxPages x perPage entries is FULLY READ, and
+    // reporting it unread is the permanent unclearable refusal this pager was
+    // written to remove -- moved, not fixed.
+    if (page === maxPages) {
+      const probe = fetchPage(maxPages * perPage + 1, 1);
+      if (Array.isArray(probe) && probe.length === 0) return { rows, truncated: false };
+    }
+  }
+  return { rows, truncated: true };
+}
+
 function fetchPayload(repo, pr) {
   const surfaces = {
     issueComments: `repos/${repo}/issues/${pr}/comments`,
@@ -423,21 +482,10 @@ function fetchPayload(repo, pr) {
   };
   const out = { truncated: [] };
   for (const [key, path] of Object.entries(surfaces)) {
-    const rows = [];
-    let page = 1;
-    for (; page <= MAX_PAGES; page += 1) {
-      const batch = gh(
-        ['api', `${path}?per_page=${PER_PAGE}&page=${page}`, '--method', 'GET'],
-        `${key} page ${page}`,
-        ReviewPostedError,
-      );
-      if (!Array.isArray(batch)) {
-        throw new ReviewPostedError('BAD_PAYLOAD', `${key} page ${page} was not an array.`);
-      }
-      rows.push(...batch);
-      if (batch.length < PER_PAGE) break;
-    }
-    if (page > MAX_PAGES) out.truncated.push(key);
+    const { rows, truncated } = pageAll((page, perPage) =>
+      gh(['api', `${path}?per_page=${perPage}&page=${page}`, '--method', 'GET'], `${key} page ${page}`, ReviewPostedError),
+    );
+    if (truncated) out.truncated.push(key);
     out[key] = rows;
   }
   return out;
@@ -471,7 +519,11 @@ function main() {
 
   let payload;
   if (args.stateFile) {
-    payload = JSON.parse(readFileSync(args.stateFile, 'utf8'));
+    try {
+      payload = JSON.parse(readFileSync(args.stateFile, 'utf8'));
+    } catch (err) {
+      throw new ReviewPostedError('BAD_STATE_FILE', `Cannot read \`${args.stateFile}\`: ${err.message}`);
+    }
   } else {
     if (!args.repo) {
       throw new ReviewPostedError(
@@ -495,6 +547,20 @@ function main() {
   while (!result.ok && !args.stateFile && Date.now() < deadline) {
     sleepSync(POLL_SECONDS * 1000);
     waited += POLL_SECONDS;
+    // ONE call per tick, not three. The marker lands on the issue-comment
+    // surface, so that is the only surface worth watching; the other two are
+    // fetched once, after it appears, for the findings cross-check. At three
+    // surfaces per tick this gate alone would have spent ~120 of the repository's
+    // 1,000/hour GITHUB_TOKEN budget per run, shared with benchmark.yml and two
+    // sibling gates, and exhausting it fails THEM as well as this.
+    const probe = normaliseComments({
+      issueComments: gh(
+        ['api', `repos/${args.repo}/issues/${args.pr}/comments?per_page=${PER_PAGE}&page=1`, '--method', 'GET'],
+        'the PR comment list',
+        ReviewPostedError,
+      ),
+    });
+    if (!probe.some((c) => cfg.expectedAuthors.has(c.author) && MARKER_RE.test(c.body))) continue;
     comments = normaliseComments(fetchPayload(args.repo, args.pr));
     result = evaluate({ comments, cfg, headSha: args.sha });
   }
@@ -537,6 +603,19 @@ if (isMainEntry(import.meta.url)) {
   } catch (err) {
     if (err instanceof ReviewPostedError || err instanceof GhError) {
       console.error(`❌ ${err.reason}: ${err.message}`);
+      // A REFUSAL IS NOT COVERAGE. Every refusal path -- GH_ERROR, truncation,
+      // a bad config, a killed poll -- previously left `covered` unwritten, and
+      // the label step skipped on an empty value, so a PR carrying the label
+      // from an earlier head kept it through any number of refused runs. That is
+      // a stale stand-down, which is what STALE_REVIEW exists to prevent.
+      if (process.env.GITHUB_OUTPUT) {
+        try {
+          appendFileSync(process.env.GITHUB_OUTPUT, 'covered=false\n');
+        } catch {
+          // The refusal above is the finding; failing to annotate it is not worth
+          // masking it with a second error.
+        }
+      }
       process.exit(1);
     }
     throw err;

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -553,9 +553,19 @@ function main() {
     // surfaces per tick this gate alone would have spent ~120 of the repository's
     // 1,000/hour GITHUB_TOKEN budget per run, shared with benchmark.yml and two
     // sibling gates, and exhausting it fails THEM as well as this.
+    // THE LAST PAGE, NOT THE FIRST. GitHub returns issue comments oldest-first,
+    // so a marker posted DURING the wait lands at the end. Probing page 1 meant
+    // that on any PR with more than PER_PAGE comments the probe could never see
+    // the very comment it was waiting for: the full refetch never fired and the
+    // gate reported NOT_POSTED after a full budget of waiting, on a PR that had
+    // in fact been reviewed. Caught in review of #3580.
+    //
+    // Still one call per tick: `page=` past the end returns an empty array, and
+    // the count from the previous full read tells us where the end is.
+    const lastPage = Math.max(1, Math.ceil(comments.length / PER_PAGE));
     const probe = normaliseComments({
       issueComments: gh(
-        ['api', `repos/${args.repo}/issues/${args.pr}/comments?per_page=${PER_PAGE}&page=1`, '--method', 'GET'],
+        ['api', `repos/${args.repo}/issues/${args.pr}/comments?per_page=${PER_PAGE}&page=${lastPage}`, '--method', 'GET'],
         'the PR comment list',
         ReviewPostedError,
       ),

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -1,0 +1,253 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * The gate is driven as a PROCESS -- real argv, real config reads, real exit
+ * codes -- because that is what CI runs. `--state-file` stands in for the two
+ * `gh` reads, so every branch is reachable without a network, a token, or a real
+ * PR, and the parser and the policy under test are the shipped ones.
+ *
+ * Both directions for every verdict. A gate that has only been seen to pass has
+ * not been seen to work.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const GATE = join(HERE, 'check-review-posted.mjs');
+const CONFIG = join(HERE, 'review-posted.config.json');
+const SHIPPED = JSON.parse(readFileSync(CONFIG, 'utf8'));
+
+const TMP = mkdtempSync(join(tmpdir(), 'review-posted-'));
+let seq = 0;
+
+const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+const REVIEWER = 'github-actions';
+const STRANGER = 'someone-else';
+
+const marker = (sha, verdict = 'clean', count = 0) =>
+  `<!-- ifc-lite-review sha=${sha} verdict=${verdict} count=${count} -->`;
+
+/** Write a config variant. Defaults to `enforcing`: a verdict test asks about POLICY, and the shipped `mode` is a rollout state that will flip. */
+function cfgWith(patch, tag) {
+  const path = join(TMP, `cfg-${tag}.json`);
+  writeFileSync(path, JSON.stringify({ ...SHIPPED, mode: 'enforcing', ...patch }));
+  return ['--config', path];
+}
+const ENFORCING = cfgWith({}, 'enforcing-base');
+
+/** Run the gate over a payload exactly as written. */
+function run(payload, extra = [...ENFORCING], sha = SHA) {
+  const path = join(TMP, `payload-${(seq += 1)}.json`);
+  writeFileSync(path, JSON.stringify(payload));
+  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--sha', sha, '--state-file', path, ...extra], {
+    encoding: 'utf8',
+  });
+  return { code: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+const comments = (...cs) => ({ issueComments: cs.map(([user, body]) => ({ user: { login: user }, body })) });
+
+// ============================================================ the core verdicts
+
+test('PASS: the expected reviewer posted a marker naming this head', () => {
+  const r = run(comments([REVIEWER, `Looks fine.\n${marker(SHA)}`]));
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /REVIEW_POSTED/);
+  assert.match(r.out, /clean verdict/);
+});
+
+test('PASS: a findings verdict carries its count', () => {
+  const r = run(comments([REVIEWER, `Three things.\n${marker(SHA, 'findings', 3)}`]));
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /findings verdict.*with 3 finding/);
+});
+
+test('FAIL: no comments at all -- the #1679 shape, Posted 0/N with a green job', () => {
+  const r = run({ issueComments: [], reviews: [] });
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+  assert.match(r.out, /#1679/);
+});
+
+test('FAIL: only a stranger commented', () => {
+  const r = run(comments([STRANGER, `nice work\n${marker(SHA)}`]));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+});
+
+test('FAIL: the reviewer commented but wrote no marker -- the #1644 partial-run shape', () => {
+  const r = run(comments([REVIEWER, 'I started reviewing and then stopped.']));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+  assert.match(r.out, /marker is written at the END/);
+});
+
+test('FAIL: STALE_REVIEW when the marker names a different commit', () => {
+  const r = run(comments([REVIEWER, marker(OTHER_SHA)]));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /STALE_REVIEW/);
+  assert.match(r.out, /force-push re-anchors/);
+});
+
+test('FAIL: MARKER_MALFORMED is reported separately from absence', () => {
+  const r = run(comments([REVIEWER, '<!-- ifc-lite-review sha=nope verdict=clean -->']));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /MARKER_MALFORMED/);
+  assert.match(r.out, /marker writer/);
+});
+
+// ======================================================= identity normalisation
+
+test('the three spellings of a bot identity all resolve to one entry', () => {
+  for (const spelling of ['github-actions', 'github-actions[bot]', 'app/github-actions']) {
+    const r = run(comments([spelling, marker(SHA)]));
+    assert.equal(r.code, 0, `${spelling}: ${r.out}`);
+  }
+});
+
+test('normalisation is load-bearing, not covered by listing every spelling', () => {
+  // Pinned independently: with the config narrowed to ONE spelling, a differently
+  // spelled author must still match. Without normalisation this fails.
+  const one = cfgWith({ expectedAuthors: ['claude'] }, 'one-spelling');
+  const r = run(comments(['claude[bot]', marker(SHA)]), one);
+  assert.equal(r.code, 0, r.out);
+});
+
+// ============================================================ fail-closed paths
+
+test('FAIL-CLOSED: a comment list at the page limit refuses rather than reporting absence', () => {
+  const many = Array.from({ length: 200 }, () => ({ user: { login: STRANGER }, body: 'x' }));
+  const r = run({ issueComments: many });
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /COMMENTS_TRUNCATED/);
+  assert.doesNotMatch(r.out, /NOT_POSTED/);
+});
+
+test('FAIL-CLOSED: a payload with no comment lists at all is NO_PAYLOAD, not a pass', () => {
+  const r = run({});
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NO_PAYLOAD/);
+});
+
+test('FAIL-CLOSED: a non-array comment list is BAD_PAYLOAD', () => {
+  const r = run({ issueComments: { nope: true } });
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /BAD_PAYLOAD/);
+});
+
+test('FAIL-CLOSED: a missing --sha refuses rather than deriving one', () => {
+  const path = join(TMP, 'p-nosha.json');
+  writeFileSync(path, JSON.stringify(comments([REVIEWER, marker(SHA)])));
+  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--state-file', path, ...ENFORCING], { encoding: 'utf8' });
+  assert.equal(r.status, 1);
+  assert.match(`${r.stdout}${r.stderr}`, /NO_SHA/);
+});
+
+test('FAIL-CLOSED: a short or non-hex --sha is refused', () => {
+  const r = run(comments([REVIEWER, marker(SHA)]), [...ENFORCING], 'abc123');
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NO_SHA/);
+});
+
+// =================================================================== the config
+
+test('an EMPTY expectedAuthors list is refused, not treated as "anyone"', () => {
+  const r = run(comments([STRANGER, marker(SHA)]), cfgWith({ expectedAuthors: [] }, 'empty-authors'));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /BAD_CONFIG/);
+  assert.match(r.out, /every PR pass on any comment/);
+});
+
+test('a MISSING mode is refused, not defaulted to the lenient one', () => {
+  const path = join(TMP, 'cfg-no-mode.json');
+  const { mode, ...withoutMode } = SHIPPED;
+  writeFileSync(path, JSON.stringify(withoutMode));
+  const r = run(comments([REVIEWER, marker(SHA)]), ['--config', path]);
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /BAD_CONFIG/);
+  assert.match(r.out, /"advisory" or "enforcing"/);
+});
+
+test('the SHIPPED config is the one the gate validates', () => {
+  // NO --config here, deliberately, and that is the whole test: every other test
+  // passes a temp COPY, so a shipped config its own validator rejects would be
+  // invisible to all of them.
+  const path = join(TMP, 'p-shipped.json');
+  writeFileSync(path, JSON.stringify(comments([REVIEWER, marker(SHA)])));
+  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--sha', SHA, '--state-file', path], { encoding: 'utf8' });
+  const out = `${r.stdout}${r.stderr}`;
+  assert.doesNotMatch(out, /BAD_CONFIG/, 'the shipped config must pass its own validator');
+  assert.ok(Array.isArray(SHIPPED.expectedAuthors) && SHIPPED.expectedAuthors.length > 0);
+  assert.ok(SHIPPED.mode === 'advisory' || SHIPPED.mode === 'enforcing');
+});
+
+// ================================================================ advisory mode
+
+test('ADVISORY: a failing verdict prints in full and exits 0', () => {
+  const r = run({ issueComments: [] }, cfgWith({ mode: 'advisory' }, 'advisory-fail'));
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /NOT_POSTED/, 'the verdict text must be identical in both modes');
+  assert.match(r.out, /ADVISORY MODE/);
+});
+
+test('ADVISORY does not suppress a REFUSAL', () => {
+  // A refusal is a fact about this gate's inputs, not a verdict on the PR, so it
+  // must fail closed in both modes.
+  const r = run({ issueComments: { nope: true } }, cfgWith({ mode: 'advisory' }, 'advisory-refusal'));
+  assert.equal(r.code, 1, r.out);
+  assert.doesNotMatch(r.out, /ADVISORY MODE/);
+});
+
+test('the Mode line prints on a PASS too, so docs can point at it', () => {
+  const r = run(comments([REVIEWER, marker(SHA)]), cfgWith({ mode: 'advisory' }, 'advisory-pass'));
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /^Mode: advisory/m);
+});
+
+test('ADVISORY does not print an advisory notice over a PASS', () => {
+  // Caught by mutation: dropping the `!ok` from the advisory branch left refusals
+  // and passes both exiting 0, so every existing test still passed -- while a
+  // CLEAN review printed "the finding above does not fail this job" with no
+  // finding above it. A notice that describes a finding that does not exist is
+  // the same class of lie as a green tick over an unreviewed diff.
+  const r = run(comments([REVIEWER, marker(SHA)]), cfgWith({ mode: 'advisory' }, 'advisory-clean'));
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /REVIEW_POSTED/);
+  assert.doesNotMatch(r.out, /ADVISORY MODE/);
+});
+
+// ====================================================== marker forgery boundary
+
+test('a hand-written marker from a NON-reviewer does not pass', () => {
+  // The marker is only trusted from an expected author. A contributor pasting one
+  // into their own PR comment must not satisfy the gate.
+  const r = run(comments([STRANGER, marker(SHA)], [STRANGER, 'please merge']));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+});
+
+test('the marker pattern does not match a loose mention of the token', () => {
+  const r = run(comments([REVIEWER, 'see ifc-lite-review sha=' + SHA + ' for details']));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+});
+
+test('a marker must be an HTML COMMENT, not bare text a contributor can type', () => {
+  // Caught by mutation: loosening MARKER_RE to drop the `<!--` / `-->` anchors
+  // left every other test green while making the marker forgeable in plain prose.
+  // The marker is the gate's only evidence, so its shape is a security boundary,
+  // not formatting.
+  const bare = `ifc-lite-review sha=${SHA} verdict=clean count=0`;
+  const r = run(comments([REVIEWER, `all good\n${bare}`]));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+});

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -225,6 +225,56 @@ test('ADVISORY does not print an advisory notice over a PASS', () => {
   assert.doesNotMatch(r.out, /ADVISORY MODE/);
 });
 
+// ============================================== the machine-readable verdict
+
+test('the `covered` output tracks the VERDICT, not the exit code', () => {
+  // The CodeRabbit stand-down label reads this. In advisory mode a failing
+  // verdict still exits 0, so a caller inferring coverage from `$?` would mark an
+  // unreviewed PR as covered and both reviewers would stand down -- a third route
+  // to an unreviewed merge. These two cases are the ones that must not agree.
+  const outPath = join(TMP, `ghout-${(seq += 1)}.txt`);
+  const payloadPath = join(TMP, `p-covered-${seq}.json`);
+  const readOut = () => readFileSync(outPath, 'utf8');
+
+  const runWithOutput = (payload, cfgArgs) => {
+    writeFileSync(outPath, '');
+    writeFileSync(payloadPath, JSON.stringify(payload));
+    const r = spawnSync(
+      process.execPath,
+      [GATE, '--pr', '1', '--sha', SHA, '--state-file', payloadPath, ...cfgArgs],
+      { encoding: 'utf8', env: { ...process.env, GITHUB_OUTPUT: outPath } },
+    );
+    return { code: r.status, out: readOut() };
+  };
+
+  const clean = runWithOutput(comments([REVIEWER, marker(SHA)]), ENFORCING);
+  assert.equal(clean.code, 0);
+  assert.match(clean.out, /covered=true/);
+
+  const missing = runWithOutput({ issueComments: [] }, ENFORCING);
+  assert.equal(missing.code, 1);
+  assert.match(missing.out, /covered=false/);
+
+  // The case the whole output exists for: advisory exits 0 on a FAILING verdict.
+  const advisory = runWithOutput({ issueComments: [] }, cfgWith({ mode: 'advisory' }, 'advisory-covered'));
+  assert.equal(advisory.code, 0, 'advisory exits 0');
+  assert.match(advisory.out, /covered=false/, 'but coverage must still read false');
+});
+
+test('a STALE review reports covered=false, so the stand-down label is cleared', () => {
+  const outPath = join(TMP, `ghout-stale-${(seq += 1)}.txt`);
+  const payloadPath = join(TMP, `p-stale-${seq}.json`);
+  writeFileSync(outPath, '');
+  writeFileSync(payloadPath, JSON.stringify(comments([REVIEWER, marker(OTHER_SHA)])));
+  const r = spawnSync(
+    process.execPath,
+    [GATE, '--pr', '1', '--sha', SHA, '--state-file', payloadPath, ...ENFORCING],
+    { encoding: 'utf8', env: { ...process.env, GITHUB_OUTPUT: outPath } },
+  );
+  assert.equal(r.status, 1);
+  assert.match(readFileSync(outPath, 'utf8'), /covered=false/);
+});
+
 // ====================================================== marker forgery boundary
 
 test('a hand-written marker from a NON-reviewer does not pass', () => {

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -19,6 +19,7 @@ import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { pageAll } from './check-review-posted.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GATE = join(HERE, 'check-review-posted.mjs');
@@ -56,6 +57,11 @@ function run(payload, extra = [...ENFORCING], sha = SHA) {
 
 const comments = (...cs) => ({ issueComments: cs.map(([user, body]) => ({ user: { login: user }, body })) });
 
+/** Inline review comments, which is the surface a FINDING lives on and the one #1679 drops. */
+const inline = (...cs) => ({
+  reviewComments: cs.map(([user, body, commit_id = SHA]) => ({ user: { login: user }, body, commit_id })),
+});
+
 // ============================================================ the core verdicts
 
 test('PASS: the expected reviewer posted a marker naming this head', () => {
@@ -65,15 +71,36 @@ test('PASS: the expected reviewer posted a marker naming this head', () => {
   assert.match(r.out, /clean verdict/);
 });
 
-test('PASS: a findings verdict backed by posted findings', () => {
-  const r = run(
-    comments(
-      [REVIEWER, 'This index can be negative.'],
-      [REVIEWER, `Summary.\n${marker(SHA, 'findings', 1)}`],
-    ),
-  );
+test('PASS: a findings verdict backed by an INLINE finding on this head', () => {
+  const r = run({
+    ...comments([REVIEWER, `Summary.\n${marker(SHA, 'findings', 1)}`]),
+    ...inline([REVIEWER, 'This index can be negative.']),
+  });
   assert.equal(r.code, 0, r.out);
   assert.match(r.out, /findings verdict.*with 1 finding/);
+});
+
+test('FAIL: a summary comment from another workflow does not count as a finding', () => {
+  // benchmark.yml posts as `github-actions` on any PR touching rust/, packages/,
+  // apps/viewer/ or Cargo.*, and that login is an expected reviewer. Counting any
+  // non-carrier comment made this check inert on most PRs in this repo.
+  const r = run({
+    ...comments(
+      [REVIEWER, 'Viewer benchmark: 12ms (advisory).'],
+      [REVIEWER, `Summary.\n${marker(SHA, 'findings', 3)}`],
+    ),
+  });
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /FINDINGS_NOT_POSTED/);
+});
+
+test('FAIL: findings anchored to an EARLIER head do not cover this one', () => {
+  const r = run({
+    ...comments([REVIEWER, `Summary.\n${marker(SHA, 'findings', 3)}`]),
+    ...inline([REVIEWER, 'stale finding', OTHER_SHA]),
+  });
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /FINDINGS_NOT_POSTED/);
 });
 
 test('FAIL: a findings verdict with NO finding posted is the #1679 shape', () => {
@@ -227,6 +254,35 @@ test('a NaN timeout is refused, because NaN never expires a deadline', () => {
   }
 });
 
+// ======================================================================= pager
+
+test('the pager walks pages and reports a complete read', () => {
+  const pages = { 1: Array(100).fill({ x: 1 }), 2: Array(7).fill({ x: 2 }) };
+  const seen = [];
+  const r = pageAll((page) => { seen.push(page); return pages[page] ?? []; });
+  assert.deepEqual(seen, [1, 2], 'stops at the first short page');
+  assert.equal(r.rows.length, 107);
+  assert.equal(r.truncated, false);
+});
+
+test('an exactly-full LAST page is a complete read, not a truncated one', () => {
+  // The previous shape called this truncated, which turned a fully-read surface
+  // into a permanent refusal nobody could clear -- the same defect the pager
+  // rewrite claimed to remove, at a different boundary.
+  const r = pageAll((page) => (page <= 3 ? Array(10).fill({}) : []), { maxPages: 3, perPage: 10 });
+  assert.equal(r.rows.length, 30);
+  assert.equal(r.truncated, false, 'the probe past the last page came back empty');
+});
+
+test('a surface with MORE than the budget reports truncated', () => {
+  const r = pageAll(() => Array(10).fill({}), { maxPages: 3, perPage: 10 });
+  assert.equal(r.truncated, true, 'the probe found more, so the read is incomplete');
+});
+
+test('a non-array page is BAD_PAYLOAD, not an empty read', () => {
+  assert.throws(() => pageAll(() => ({ nope: true })), (e) => e.reason === 'BAD_PAYLOAD');
+});
+
 // =================================================================== the config
 
 test('an EMPTY expectedAuthors list is refused, not treated as "anyone"', () => {
@@ -234,6 +290,22 @@ test('an EMPTY expectedAuthors list is refused, not treated as "anyone"', () => 
   assert.equal(r.code, 1, r.out);
   assert.match(r.out, /BAD_CONFIG/);
   assert.match(r.out, /every PR pass on any comment/);
+});
+
+test('a config that is null or an array is BAD_CONFIG, not a TypeError', () => {
+  // Reaching for `.expectedAuthors` on null throws past this file's catch and
+  // prints a stack trace instead of the remedy the config is written to give.
+  for (const body of ['null', '[]', '"a string"']) {
+    const path = join(TMP, `cfg-shape-${(seq += 1)}.json`);
+    writeFileSync(path, body);
+    const r = run(comments([REVIEWER, marker(SHA)]), ['--config', path]);
+    assert.equal(r.code, 1, `${body}: ${r.out}`);
+    assert.match(r.out, /BAD_CONFIG/, `${body} must be a classified refusal`);
+    // Asserting on a STACK FRAME, not on the word "TypeError": the BAD_CONFIG
+    // message deliberately explains what would otherwise be thrown, so matching
+    // the word matched this gate's own prose and failed on a correct run.
+    assert.doesNotMatch(r.out, /\n\s+at [A-Za-z]/, `${body} must not print a stack trace`);
+  }
 });
 
 test('a MISSING mode is refused, not defaulted to the lenient one', () => {

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -65,10 +65,26 @@ test('PASS: the expected reviewer posted a marker naming this head', () => {
   assert.match(r.out, /clean verdict/);
 });
 
-test('PASS: a findings verdict carries its count', () => {
-  const r = run(comments([REVIEWER, `Three things.\n${marker(SHA, 'findings', 3)}`]));
+test('PASS: a findings verdict backed by posted findings', () => {
+  const r = run(
+    comments(
+      [REVIEWER, 'This index can be negative.'],
+      [REVIEWER, `Summary.\n${marker(SHA, 'findings', 1)}`],
+    ),
+  );
   assert.equal(r.code, 0, r.out);
-  assert.match(r.out, /findings verdict.*with 3 finding/);
+  assert.match(r.out, /findings verdict.*with 1 finding/);
+});
+
+test('FAIL: a findings verdict with NO finding posted is the #1679 shape', () => {
+  // The summary posts, the inline comments drop, the run logs `Posted 0/N`, and
+  // the job exits 0. The count in the marker is the reviewer's own claim; this is
+  // the check that it is true. Without it the gate cites #1679 as its founding
+  // case law and cannot see #1679.
+  const r = run(comments([REVIEWER, `Found 3 problems.\n${marker(SHA, 'findings', 3)}`]));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /FINDINGS_NOT_POSTED/);
+  assert.match(r.out, /Posted 0\/N/);
 });
 
 test('FAIL: no comments at all -- the #1679 shape, Posted 0/N with a green job', () => {
@@ -124,9 +140,13 @@ test('normalisation is load-bearing, not covered by listing every spelling', () 
 
 // ============================================================ fail-closed paths
 
-test('FAIL-CLOSED: a comment list at the page limit refuses rather than reporting absence', () => {
-  const many = Array.from({ length: 200 }, () => ({ user: { login: STRANGER }, body: 'x' }));
-  const r = run({ issueComments: many });
+test('FAIL-CLOSED: an exhausted page budget refuses rather than reporting absence', () => {
+  // The bound is now REAL: the fetch pages explicitly and reports which surfaces
+  // it could not finish. The previous version applied a length check AFTER
+  // `--paginate` had already followed Link headers to exhaustion, so it bounded
+  // nothing and turned a fully-read busy PR into a permanent refusal it could
+  // never clear.
+  const r = run({ issueComments: [], truncated: ['issueComments'] });
   assert.equal(r.code, 1, r.out);
   assert.match(r.out, /COMMENTS_TRUNCATED/);
   assert.doesNotMatch(r.out, /NOT_POSTED/);
@@ -156,6 +176,55 @@ test('FAIL-CLOSED: a short or non-hex --sha is refused', () => {
   const r = run(comments([REVIEWER, marker(SHA)]), [...ENFORCING], 'abc123');
   assert.equal(r.code, 1, r.out);
   assert.match(r.out, /NO_SHA/);
+});
+
+test('an unknown flag that exists on Object.prototype is refused', () => {
+  // `{...}[name]` reached Object.prototype, so `--constructor x` returned a
+  // truthy key, sailed past the `!key` guard, and wrote a junk property instead
+  // of refusing. A guard that does not guard what it claims is the failure this
+  // whole file is about, one level down.
+  const r = spawnSync(
+    process.execPath,
+    [GATE, '--pr', '1', '--sha', SHA, '--constructor', 'x', '--state-file', '/dev/null'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(r.status, 1);
+  assert.match(`${r.stdout}${r.stderr}`, /BAD_ARGS.*constructor/);
+});
+
+test('a MISSING config and an UNREADABLE one are different verdicts', () => {
+  // Different remedies: create the file, versus fix its permissions. Collapsing
+  // them into one would point half the readers at the wrong fix.
+  const missing = spawnSync(
+    process.execPath,
+    [GATE, '--pr', '1', '--sha', SHA, '--state-file', '/dev/null', '--config', '/nope/absent.json'],
+    { encoding: 'utf8' },
+  );
+  assert.equal(missing.status, 1);
+  assert.match(`${missing.stdout}${missing.stderr}`, /NO_CONFIG/);
+
+  const bad = join(TMP, 'cfg-not-json.json');
+  writeFileSync(bad, '{ not json');
+  const r = run(comments([REVIEWER, marker(SHA)]), ['--config', bad]);
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /BAD_CONFIG/);
+});
+
+test('a NaN timeout is refused, because NaN never expires a deadline', () => {
+  // `Date.now() < deadline` is FALSE forever when deadline is NaN, so the poll
+  // would exit immediately -- or, with the comparison the other way, run until
+  // the job is killed. Either way a coerced NaN silently changes what the gate
+  // does. This repo has the same lesson recorded for numeric config generally:
+  // bound both ends rather than trusting the value.
+  for (const bad of ['nope', '', '-5']) {
+    const r = spawnSync(
+      process.execPath,
+      [GATE, '--pr', '1', '--sha', SHA, '--state-file', '/dev/null', '--timeout-seconds', bad, ...ENFORCING],
+      { encoding: 'utf8' },
+    );
+    assert.equal(r.status, 1, `${JSON.stringify(bad)} should be refused`);
+    assert.match(`${r.stdout}${r.stderr}`, /BAD_ARGS/);
+  }
 });
 
 // =================================================================== the config

--- a/scripts/lib/gh.mjs
+++ b/scripts/lib/gh.mjs
@@ -3,16 +3,31 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /**
- * One fail-closed `gh` invoker, because there were four.
+ * One fail-closed `gh` invoker, and an honest count of what it consolidates.
  *
- * `check-coderabbit-review.mjs`, `lib/pr-green-sweep.mjs`,
- * `check-pr-review-signal.mjs` and `check-issue-queue.mjs` each grew their own
- * copy of this function, with three different `maxBuffer` values and three
- * different error vocabularies. This is the fifth caller, so it gets extracted
- * instead. The existing four are deliberately NOT migrated here: that would
- * widen a gate PR into a refactor of four unrelated gates, and each of them has
- * its own error class that its own tests assert on. Migrating them is a separate
- * change; this file exists so the count stops growing.
+ * Against `origin/main` there are THREE prior `gh` callers, not four. An earlier
+ * draft of this comment said four and named `check-issue-queue.mjs`, which exists
+ * only on an unmerged sibling branch -- a justification resting on a population
+ * one member short. Corrected rather than quietly dropped, because a docblock
+ * that overstates its own evidence is the thing this repository's gates exist to
+ * catch, and it does not stop applying to the gates themselves.
+ *
+ * The three, and why each is or is not migrated:
+ *
+ *   - `check-pr-review-signal.mjs` is byte-for-byte this function apart from a
+ *     32 MiB buffer and two prose tails, and its `ReviewSignalError` already has
+ *     the `(reason, message)` shape this signature takes. It is MIGRATABLE and is
+ *     deliberately not migrated here: this is a gate PR, and rewriting the
+ *     internals of the repo's most load-bearing CI gate belongs in its own change
+ *     where its own tests are the subject. Named as a follow-up rather than left
+ *     implied.
+ *   - `check-coderabbit-review.mjs` uses `execFileSync` and returns a RAW STRING,
+ *     with `JSON.parse` at three call sites. Migrating changes the thrown error
+ *     type at each of them, so it is a behaviour change, not a lift.
+ *   - `lib/pr-green-sweep.mjs` does not invoke `gh` at all. It takes an injected
+ *     `gh` callable so the module stays pure, which its own docblock states as a
+ *     design choice. It is STRUCTURALLY INCOMPATIBLE with a module that spawns
+ *     and parses internally, and should stay that way.
  *
  * THE ONE RULE: every failure throws. A `gh` call that cannot be made, exits
  * non-zero, or returns unparseable output must never be reported as an empty

--- a/scripts/lib/gh.mjs
+++ b/scripts/lib/gh.mjs
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * One fail-closed `gh` invoker, because there were four.
+ *
+ * `check-coderabbit-review.mjs`, `lib/pr-green-sweep.mjs`,
+ * `check-pr-review-signal.mjs` and `check-issue-queue.mjs` each grew their own
+ * copy of this function, with three different `maxBuffer` values and three
+ * different error vocabularies. This is the fifth caller, so it gets extracted
+ * instead. The existing four are deliberately NOT migrated here: that would
+ * widen a gate PR into a refactor of four unrelated gates, and each of them has
+ * its own error class that its own tests assert on. Migrating them is a separate
+ * change; this file exists so the count stops growing.
+ *
+ * THE ONE RULE: every failure throws. A `gh` call that cannot be made, exits
+ * non-zero, or returns unparseable output must never be reported as an empty
+ * result, because an empty result and a permissions failure are indistinguishable
+ * downstream -- and "the API returned nothing" reading as "there is nothing" is
+ * the absence-reads-as-success defect one layer below where it usually gets
+ * caught.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/** 128 MiB: the largest of the four copies' buffers, since truncation here is silent. */
+const MAX_BUFFER = 128 * 1024 * 1024;
+
+export class GhError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Run `gh` and parse its stdout as JSON, or throw.
+ *
+ * @param {string[]} args   argv for `gh`
+ * @param {string} what     human phrase naming what is being fetched, for messages
+ * @param {Function} [ErrorClass] caller's error class; defaults to GhError. Takes
+ *   `(reason, message)` so a caller's own catch can keep one error type.
+ */
+export function gh(args, what, ErrorClass = GhError) {
+  const r = spawnSync('gh', args, { encoding: 'utf8', maxBuffer: MAX_BUFFER });
+  if (r.error) {
+    throw new ErrorClass(
+      'GH_UNAVAILABLE',
+      `Could not spawn \`gh\` to fetch ${what}: ${r.error.message}. Without it this gate cannot ` +
+        'read its own input, and an unread input is not a clean one.',
+    );
+  }
+  if (r.status !== 0) {
+    throw new ErrorClass(
+      'GH_ERROR',
+      `\`gh ${args.join(' ')}\` exited ${r.status} while fetching ${what}: ` +
+        `${(r.stderr || '').trim() || '(no stderr)'}. A permissions failure and an empty result are ` +
+        'indistinguishable from the exit code alone, so this fails.',
+    );
+  }
+  try {
+    return JSON.parse(r.stdout);
+  } catch (err) {
+    throw new ErrorClass(
+      'GH_BAD_JSON',
+      `\`gh ${args.join(' ')}\` returned unparseable output while fetching ${what}: ${err.message}`,
+    );
+  }
+}

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -1,0 +1,41 @@
+{
+  "$comment": [
+    "Config for scripts/check-review-posted.mjs.",
+    "",
+    "WHAT THIS GATE ASSERTS: that a review REACHED this pull request for its exact head",
+    "commit. Not that the review was good -- that a comment exists carrying a marker the",
+    "reviewer writes at the end of a successful post.",
+    "",
+    "WHY IT IS NEEDED: anthropics/claude-code-action has three OPEN paths that report",
+    "success while reviewing nothing (#1644 p1, silent no-op after 5-10 turns; #1679,",
+    "'Posted 0/N' reported as success across forty consecutive runs; an unguarded",
+    "num_turns: 0). None is credential-specific, so an API key does not fix them either.",
+    "The job's exit code and its structured output are both satisfied on those paths."
+  ],
+
+  "$expectedAuthorsComment": [
+    "The logins whose marker counts. NOT DEFAULTED and not allowed to be empty: an empty",
+    "list would make every PR pass on any comment, which is a gate that cannot fail.",
+    "Matched case-insensitively with `[bot]` and `app/` stripped, so all three spellings",
+    "of a bot identity resolve to one entry.",
+    "",
+    "`github-actions` is listed because a workflow posting through the default GITHUB_TOKEN",
+    "comments under that identity. If the reviewer is moved to a GitHub App or a PAT, add",
+    "that login here -- the gate will start failing with NOT_POSTED until you do, which is",
+    "the correct direction to fail."
+  ],
+  "expectedAuthors": ["github-actions", "claude"],
+
+  "$modeComment": [
+    "ADVISORY or ENFORCING. Advisory prints the identical verdict and exits 0; enforcing",
+    "exits 1. Not defaulted in code: a missing value is a refusal, because defaulting",
+    "would let a corrupted config silently downgrade the gate to a no-op.",
+    "",
+    "SHIPS ADVISORY because the reviewer lane it adjudicates does not exist yet. This gate",
+    "is deliberately landed FIRST and separately: it is the piece that has to be trusted",
+    "before any reviewer can be, and building it after the reviewer would mean trusting the",
+    "reviewer's own report of itself in the interim. Flip to `enforcing` in the same PR",
+    "that turns the reviewer on."
+  ],
+  "mode": "advisory"
+}

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -12,7 +12,6 @@
     "num_turns: 0). None is credential-specific, so an API key does not fix them either.",
     "The job's exit code and its structured output are both satisfied on those paths."
   ],
-
   "$expectedAuthorsComment": [
     "The logins whose marker counts. NOT DEFAULTED and not allowed to be empty: an empty",
     "list would make every PR pass on any comment, which is a gate that cannot fail.",
@@ -24,8 +23,21 @@
     "that login here -- the gate will start failing with NOT_POSTED until you do, which is",
     "the correct direction to fail."
   ],
-  "expectedAuthors": ["github-actions", "claude"],
-
+  "expectedAuthors": [
+    "github-actions",
+    "claude"
+  ],
+  "$standDownComment": [
+    "THE CODERABBIT HALF IS NOT IN THIS REPOSITORY YET, and saying so matters.",
+    "The workflow applies a `claude-reviewed` label when this gate verifies a review,",
+    "and clears it on every new head. That label only does anything once",
+    ".coderabbit.yaml carries `auto_review.labels: ['!claude-reviewed']`, a negative",
+    "match. That file is edited by PR #3576 and a second edit here would conflict, so",
+    "it lands after #3576 does. Until then the label is inert and the `issues: write`",
+    "permission the workflow requests buys nothing. Stated rather than implied,",
+    "because a workflow comment asserting a config that does not exist is the kind of",
+    "claim this repository's gates exist to catch."
+  ],
   "$modeComment": [
     "ADVISORY or ENFORCING. Advisory prints the identical verdict and exits 0; enforcing",
     "exits 1. Not defaulted in code: a missing value is a refusal, because defaulting",


### PR DESCRIPTION
## What and why

`anthropics/claude-code-action` has **three open paths that report success while reviewing nothing**, verified in its tracker:

| Issue | |
|---|---|
| **#1644** `p1` | *Agent exits success after 5-10 turns without completing the review (silent no-op)*. ~half of runs return `is_error: false` with a low `num_turns`, so an `is_error` guard cannot see it. |
| **#1679** `p2` | *post-buffered-inline-comments exits 0 after failing to post every comment* — reported as **forty consecutive runs** logging `Posted 0/N`. The review ran, findings existed, zero comments reached the PR. |
| — | An unguarded `num_turns: 0` path. |

None is credential-specific, so funding a reviewer from an API key rather than a subscription closes none of them.

This repo has already paid for the same defect from the other side: **174 of 830 merged PRs in August (21%, 46,717 lines) carried no review of any kind while showing green**, and #3175 then corrected twelve changesets by hand that would have shipped breaking changes as `patch`, with the release one command from publishing.

## What the gate accepts as evidence, and what it refuses

**Refused:** the job's exit code (both bugs exit 0). Structured output (#1679 satisfies a schema and drops every comment afterwards — the schema describes what the model *produced*, not what the PR *received*). A comment merely existing (a force-push re-anchors bot comments, so the anchor cannot say which diff was read).

**Accepted:** a marker the reviewer writes at the end of a successful post, naming the exact commit:

```
<!-- ifc-lite-review sha=<40-hex> verdict=clean|findings count=<n> -->
```

**The contract this implies is the load-bearing half:** the reviewer must post on **every** run, including when clean. A reviewer silent when clean makes "reviewed and found nothing" byte-identical to "never ran" — the exact trap CodeRabbit falls into here, which is why `pr-review-signal.config.json` ships `staleReviewPolicy: "off"`. We own our reviewer, so it always speaks, and silence therefore means failure.

## How it was verified

Live against PR #3576, on real GitHub payload shapes: absent reviewer → `NOT_POSTED`; marker naming the head → `REVIEW_POSTED`; marker naming another commit → `STALE_REVIEW`. Poll verified live — waited its full budget, then reported.

**37 tests. Thirteen mutations, all caught.** Several survived a first sweep and each was a real gap, not a bad mutation.

## Defects this branch shipped and then caught

Worth listing, because they are the same shape as the problem the gate addresses:

- **`timeout-minutes: 5` sat below a 600s poll budget** — the job would have been killed mid-poll on every PR, printing no verdict. Since it ships advisory (no reviewer lane yet), *every* run would have hit it.
- **The gate ran from the PR under review.** `actions/checkout` defaults to the merge ref, so config and code came from the contributor: adding your own login to `expectedAuthors` and hand-writing a marker would have passed. Now pinned to `base.sha`.
- **The #1679 cross-check was inert on most PRs here** — `benchmark.yml` posts as `github-actions`, satisfying it forever. Now counts only inline comments anchored to this head.
- **The stand-down label lost a race it claimed to win** — CodeRabbit reads labels at push time; the label was reconciled minutes later.
- **A blank `--timeout-seconds` coerced to `0`**, silently disabling the poll.

## Rollout

Ships `advisory`. Landing it **first and separately is deliberate**: it is the piece that has to be trusted before any reviewer can be, and building it after the reviewer would mean trusting the reviewer's own report of itself in the interim.

The `.coderabbit.yaml` half (`auto_review.labels: ['!claude-reviewed']`) lands after #3576, which already edits that file. Until then the label is inert, and the config says so rather than implying otherwise.

**Stated hole that matters for the funding decision:** this gate cannot tell "the model had nothing to say" from "the model was throttled into saying nothing but still posted." If the reviewer is funded by a pool that can drain, the *reviewer* must fail rather than post an empty clean verdict. That requirement belongs in the reviewer and is recorded in the docblock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull request review verification for newly opened, updated, reopened, or review-ready pull requests.
  * Confirms reviews apply to the current changes and include required findings.
  * Supports delayed review detection, advisory checks, and automatic review-status label updates.
  * Added safeguards for unavailable services, invalid responses, stale reviews, and malformed review markers.

* **Tests**
  * Added coverage for valid, stale, malformed, missing, paginated, and fail-closed review scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->