### PR TITLE
fix(ci): bind review evidence to a dedicated App

### DIFF
--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -53,7 +53,7 @@ jobs:
       # RESIDUAL RISK, STATED: the gate's CODE still comes from the PR, so an edit
       # to MARKER_RE or to `evaluate` is not neutralised by this split. That edit
       # is visible in the diff and is what human review is for. It is a smaller
-      # surface than the config (a one-word `expectedAuthors` addition is easy to
+      # surface than the config (a one-word `expectedReviewer` identity change is easy to
       # miss in a large diff; a change to the matching logic is not), and the
       # measured population here is 100% same-repo PRs over the last 80 merges.
       # If that changes, or if this gate goes enforcing on fork PRs, pin the code

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -133,10 +133,14 @@ const PER_PAGE = 100;
 
 /**
  * The marker the reviewer writes at the END of a successful post. Anchored at
- * both ends and tolerant of surrounding whitespace only -- a loose pattern here
- * would let a contributor hand-write a passing marker into a PR comment.
+ * the terminal end and tolerant of surrounding whitespace only -- a loose
+ * pattern here would let an incomplete post carry an earlier passing record.
  */
-const MARKER_RE = /<!--\s*ifc-lite-review\s+sha=([0-9a-f]{40})\s+verdict=(clean|findings)\s+count=(\d+)\s*-->/;
+// The marker is a terminal record, not a substring.  Accepting it in the
+// middle of a comment let a later, unrelated status block make a partial post
+// look complete.  The reviewer may put prose before it, but nothing may follow
+// it except whitespace.
+const MARKER_RE = /<!--\s*ifc-lite-review\s+sha=([0-9a-f]{40})\s+verdict=(clean|findings)\s+count=(\d+)\s*-->\s*$/;
 
 /** Block the runner without a dependency. This job's whole purpose is to wait. */
 function sleepSync(ms) {
@@ -193,11 +197,21 @@ export function readConfig(path) {
         'print a stack trace instead of a remedy.',
     );
   }
-  if (!Array.isArray(cfg.expectedAuthors) || cfg.expectedAuthors.length === 0) {
+  const reviewer = cfg.expectedReviewer;
+  if (!reviewer || typeof reviewer !== 'object' || Array.isArray(reviewer)) {
     throw new ReviewPostedError(
       'BAD_CONFIG',
-      `\`expectedAuthors\` in \`${path}\` must be a non-empty array of GitHub logins. ` +
-        'Not defaulted: an empty list would make every PR pass on any comment.',
+      `\`expectedReviewer\` in \`${path}\` must name one dedicated GitHub App reviewer. ` +
+        'A shared workflow identity is not review provenance.',
+    );
+  }
+  const login = normaliseLogin(reviewer.login);
+  const appSlug = String(reviewer.appSlug ?? '').trim().toLowerCase();
+  if (!login || !appSlug) {
+    throw new ReviewPostedError(
+      'BAD_CONFIG',
+      `\`expectedReviewer\` in \`${path}\` needs non-empty \`login\` and \`appSlug\` strings. ` +
+        'Both are required: a login alone cannot distinguish a dedicated reviewer from github-actions.',
     );
   }
   if (cfg.mode !== 'advisory' && cfg.mode !== 'enforcing') {
@@ -212,8 +226,13 @@ export function readConfig(path) {
     // key validated above but omitted here reads as `undefined` at the call site
     // while validation still passes -- a knob that silently does nothing.
     mode: cfg.mode,
-    expectedAuthors: new Set(cfg.expectedAuthors.map(normaliseLogin)),
+    expectedReviewer: { login, appSlug },
   };
+}
+
+/** A review marker is trustworthy only when GitHub attributes it to the configured App. */
+function isExpectedReviewer(comment, cfg) {
+  return comment.author === cfg.expectedReviewer.login && comment.appSlug === cfg.expectedReviewer.appSlug;
 }
 
 /** @param {string[]} argv */
@@ -307,6 +326,10 @@ export function normaliseComments(payload) {
         // survived the old shape, which is why that check could not be precise.
         surface: key,
         commitId: c?.commit_id ?? null,
+        // `github-actions` is shared by every workflow.  GitHub's App
+        // provenance is the discriminator a same-repository PR cannot forge
+        // merely by posting an issue comment with its workflow token.
+        appSlug: String(c?.performed_via_github_app?.slug ?? '').trim().toLowerCase(),
       });
     }
   }
@@ -327,12 +350,12 @@ export function normaliseComments(payload) {
  */
 export function evaluate({ comments, cfg, headSha }) {
   const lines = [];
-  const mine = comments.filter((c) => cfg.expectedAuthors.has(c.author));
+  const mine = comments.filter((c) => isExpectedReviewer(c, cfg));
 
   if (mine.length === 0) {
     lines.push(
       `❌ NOT_POSTED: no comment on this PR from any expected reviewer ` +
-        `(${[...cfg.expectedAuthors].join(', ')}).`,
+        `(${cfg.expectedReviewer.login} via GitHub App ${cfg.expectedReviewer.appSlug}).`,
       '   The review job\'s exit code is NOT evidence: claude-code-action #1644 exits success after',
       '   a partial run, and #1679 exits 0 after failing to post every comment (reported as forty',
       '   consecutive runs logging `Posted 0/N`). Both are open.',
@@ -385,6 +408,15 @@ export function evaluate({ comments, cfg, headSha }) {
     return { ok: false, verdict: 'STALE_REVIEW', lines };
   }
 
+  if ((match.verdict === 'clean' && match.count !== 0) || (match.verdict === 'findings' && match.count === 0)) {
+    lines.push(
+      `❌ MARKER_MALFORMED: a ${match.verdict} marker cannot carry count=${match.count}.`,
+      '   A clean review has zero findings; a findings review names every finding it says it posted.',
+      '   REMEDY: fix the reviewer marker writer and re-run the review.',
+    );
+    return { ok: false, verdict: 'MARKER_MALFORMED', lines };
+  }
+
   // THE #1679 CROSS-CHECK. A marker claiming `verdict=findings count=N` while N
   // findings never reached the PR is precisely the shape #1679 describes: the
   // summary posts, the inline comments drop, `Posted 0/N` is logged, and the job
@@ -403,12 +435,12 @@ export function evaluate({ comments, cfg, headSha }) {
     // three findings pass with all three dropped -- the exact #1679 shape the
     // check exists to catch.
     const posted = comments.filter(
-      (c) => c.surface === 'reviewComments' && cfg.expectedAuthors.has(c.author) && c.commitId === headSha,
+      (c) => c.surface === 'reviewComments' && isExpectedReviewer(c, cfg) && c.commitId === headSha,
     ).length;
-    if (posted === 0) {
+    if (posted !== match.count) {
       lines.push(
         `❌ FINDINGS_NOT_POSTED: the marker claims ${match.count} finding(s) for ` +
-          `${headSha.slice(0, 9)}, and no inline finding from an expected reviewer is anchored to it.`,
+          `${headSha.slice(0, 9)}, but ${posted} inline finding(s) from the dedicated reviewer are anchored to it.`,
         '   This is the #1679 shape exactly: the summary posts, the inline comments drop, the run',
         '   logs `Posted 0/N`, and the job exits 0. The count in the marker is the reviewer\'s own',
         '   claim; this is the check that it is true.',
@@ -570,7 +602,7 @@ function main() {
         ReviewPostedError,
       ),
     });
-    if (!probe.some((c) => cfg.expectedAuthors.has(c.author) && MARKER_RE.test(c.body))) continue;
+    if (!probe.some((c) => isExpectedReviewer(c, cfg) && MARKER_RE.test(c.body))) continue;
     comments = normaliseComments(fetchPayload(args.repo, args.pr));
     result = evaluate({ comments, cfg, headSha: args.sha });
   }

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -31,7 +31,8 @@ let seq = 0;
 
 const SHA = 'a'.repeat(40);
 const OTHER_SHA = 'b'.repeat(40);
-const REVIEWER = 'github-actions';
+const REVIEWER = 'ifc-lite-review[bot]';
+const REVIEWER_APP = 'ifc-lite-review';
 const STRANGER = 'someone-else';
 
 const marker = (sha, verdict = 'clean', count = 0) =>
@@ -55,11 +56,18 @@ function run(payload, extra = [...ENFORCING], sha = SHA) {
   return { code: r.status, out: `${r.stdout}${r.stderr}` };
 }
 
-const comments = (...cs) => ({ issueComments: cs.map(([user, body]) => ({ user: { login: user }, body })) });
+const commentRow = ([user, body, appSlug = REVIEWER_APP]) => ({
+  user: { login: user }, body,
+  performed_via_github_app: appSlug ? { slug: appSlug } : null,
+});
+const comments = (...cs) => ({ issueComments: cs.map(commentRow) });
 
 /** Inline review comments, which is the surface a FINDING lives on and the one #1679 drops. */
 const inline = (...cs) => ({
-  reviewComments: cs.map(([user, body, commit_id = SHA]) => ({ user: { login: user }, body, commit_id })),
+  reviewComments: cs.map(([user, body, commit_id = SHA, appSlug = REVIEWER_APP]) => ({
+    user: { login: user }, body, commit_id,
+    performed_via_github_app: appSlug ? { slug: appSlug } : null,
+  })),
 });
 
 // ============================================================ the core verdicts
@@ -114,6 +122,16 @@ test('FAIL: a findings verdict with NO finding posted is the #1679 shape', () =>
   assert.match(r.out, /Posted 0\/N/);
 });
 
+test('FAIL: one of three claimed findings is partial evidence, not coverage', () => {
+  const r = run({
+    ...comments([REVIEWER, `Found 3 problems.\n${marker(SHA, 'findings', 3)}`]),
+    ...inline([REVIEWER, 'only one reached the PR']),
+  });
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /FINDINGS_NOT_POSTED/);
+  assert.match(r.out, /but 1 inline finding/);
+});
+
 test('FAIL: no comments at all -- the #1679 shape, Posted 0/N with a green job', () => {
   const r = run({ issueComments: [], reviews: [] });
   assert.equal(r.code, 1, r.out);
@@ -150,8 +168,8 @@ test('FAIL: MARKER_MALFORMED is reported separately from absence', () => {
 
 // ======================================================= identity normalisation
 
-test('the three spellings of a bot identity all resolve to one entry', () => {
-  for (const spelling of ['github-actions', 'github-actions[bot]', 'app/github-actions']) {
+test('the three spellings of a bot identity all resolve to one dedicated reviewer', () => {
+  for (const spelling of ['ifc-lite-review', 'ifc-lite-review[bot]', 'app/ifc-lite-review']) {
     const r = run(comments([spelling, marker(SHA)]));
     assert.equal(r.code, 0, `${spelling}: ${r.out}`);
   }
@@ -160,8 +178,8 @@ test('the three spellings of a bot identity all resolve to one entry', () => {
 test('normalisation is load-bearing, not covered by listing every spelling', () => {
   // Pinned independently: with the config narrowed to ONE spelling, a differently
   // spelled author must still match. Without normalisation this fails.
-  const one = cfgWith({ expectedAuthors: ['claude'] }, 'one-spelling');
-  const r = run(comments(['claude[bot]', marker(SHA)]), one);
+  const one = cfgWith({ expectedReviewer: { login: 'claude', appSlug: 'claude-review' } }, 'one-spelling');
+  const r = run(comments(['claude[bot]', marker(SHA), 'claude-review']), one);
   assert.equal(r.code, 0, r.out);
 });
 
@@ -285,15 +303,15 @@ test('a non-array page is BAD_PAYLOAD, not an empty read', () => {
 
 // =================================================================== the config
 
-test('an EMPTY expectedAuthors list is refused, not treated as "anyone"', () => {
-  const r = run(comments([STRANGER, marker(SHA)]), cfgWith({ expectedAuthors: [] }, 'empty-authors'));
+test('a reviewer without App provenance is refused, not treated as "anyone"', () => {
+  const r = run(comments([STRANGER, marker(SHA)]), cfgWith({ expectedReviewer: { login: '', appSlug: '' } }, 'empty-reviewer'));
   assert.equal(r.code, 1, r.out);
   assert.match(r.out, /BAD_CONFIG/);
-  assert.match(r.out, /every PR pass on any comment/);
+  assert.match(r.out, /login.*appSlug/);
 });
 
 test('a config that is null or an array is BAD_CONFIG, not a TypeError', () => {
-  // Reaching for `.expectedAuthors` on null throws past this file's catch and
+  // Reaching for `.expectedReviewer` on null throws past this file's catch and
   // prints a stack trace instead of the remedy the config is written to give.
   for (const body of ['null', '[]', '"a string"']) {
     const path = join(TMP, `cfg-shape-${(seq += 1)}.json`);
@@ -327,7 +345,7 @@ test('the SHIPPED config is the one the gate validates', () => {
   const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--sha', SHA, '--state-file', path], { encoding: 'utf8' });
   const out = `${r.stdout}${r.stderr}`;
   assert.doesNotMatch(out, /BAD_CONFIG/, 'the shipped config must pass its own validator');
-  assert.ok(Array.isArray(SHIPPED.expectedAuthors) && SHIPPED.expectedAuthors.length > 0);
+  assert.ok(SHIPPED.expectedReviewer?.login && SHIPPED.expectedReviewer?.appSlug);
   assert.ok(SHIPPED.mode === 'advisory' || SHIPPED.mode === 'enforcing');
 });
 
@@ -426,6 +444,18 @@ test('a hand-written marker from a NON-reviewer does not pass', () => {
   assert.match(r.out, /NOT_POSTED/);
 });
 
+test('a shared github-actions marker cannot impersonate the dedicated reviewer', () => {
+  const r = run(comments(['github-actions', marker(SHA), REVIEWER_APP]));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+});
+
+test('the right login without the configured GitHub App provenance does not pass', () => {
+  const r = run(comments([REVIEWER, marker(SHA), 'untrusted-workflow-app']));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+});
+
 test('the marker pattern does not match a loose mention of the token', () => {
   const r = run(comments([REVIEWER, 'see ifc-lite-review sha=' + SHA + ' for details']));
   assert.equal(r.code, 1, r.out);
@@ -441,4 +471,18 @@ test('a marker must be an HTML COMMENT, not bare text a contributor can type', (
   const r = run(comments([REVIEWER, `all good\n${bare}`]));
   assert.equal(r.code, 1, r.out);
   assert.match(r.out, /NOT_POSTED/);
+});
+
+test('a marker is terminal: text after it is not a completed-review record', () => {
+  const r = run(comments([REVIEWER, `${marker(SHA)}\nworkflow status: success`]));
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /MARKER_MALFORMED/);
+});
+
+test('a clean marker cannot claim findings, and findings cannot claim zero', () => {
+  for (const [verdict, count] of [['clean', 1], ['findings', 0]]) {
+    const r = run(comments([REVIEWER, marker(SHA, verdict, count)]));
+    assert.equal(r.code, 1, `${verdict}/${count}: ${r.out}`);
+    assert.match(r.out, /MARKER_MALFORMED/);
+  }
 });

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -12,21 +12,18 @@
     "num_turns: 0). None is credential-specific, so an API key does not fix them either.",
     "The job's exit code and its structured output are both satisfied on those paths."
   ],
-  "$expectedAuthorsComment": [
-    "The logins whose marker counts. NOT DEFAULTED and not allowed to be empty: an empty",
-    "list would make every PR pass on any comment, which is a gate that cannot fail.",
-    "Matched case-insensitively with `[bot]` and `app/` stripped, so all three spellings",
-    "of a bot identity resolve to one entry.",
+  "$expectedReviewerComment": [
+    "One dedicated GitHub App reviewer, identified twice: by its login and by the",
+    "`performed_via_github_app.slug` GitHub returns on its comment. Both are mandatory.",
+    "Do not use `github-actions`: that is a shared workflow identity, so any same-repo PR",
+    "workflow with issue-comment write permission can forge the old marker.",
     "",
-    "`github-actions` is listed because a workflow posting through the default GITHUB_TOKEN",
-    "comments under that identity. If the reviewer is moved to a GitHub App or a PAT, add",
-    "that login here -- the gate will start failing with NOT_POSTED until you do, which is",
-    "the correct direction to fail."
+    "ACTIVATION BLOCKER: no dedicated marker-writing reviewer App is currently configured.",
+    "A maintainer must provision one, set its login and App slug here, and make it append the",
+    "terminal ifc-lite-review marker on every completed review. Until then this advisory gate",
+    "correctly reports NOT_POSTED and never applies the CodeRabbit stand-down label."
   ],
-  "expectedAuthors": [
-    "github-actions",
-    "claude"
-  ],
+  "expectedReviewer": { "login": "ifc-lite-review", "appSlug": "ifc-lite-review" },
   "$standDownComment": [
     "THE CODERABBIT HALF IS NOT IN THIS REPOSITORY YET, and saying so matters.",
     "The workflow applies a `claude-reviewed` label when this gate verifies a review,",


### PR DESCRIPTION
## Fix

Review evidence now requires one configured dedicated GitHub App, matched both by login and GitHub's `performed_via_github_app.slug`; `github-actions` can no longer certify a review. A findings marker passes only when exactly its claimed number of inline findings is anchored to the current head. The marker must be terminal and its count agree with its verdict.

## Activation

The repository has no dedicated marker-writing reviewer configured, so the advisory gate correctly reports `NOT_POSTED` and never applies the stand-down label until a maintainer provisions it. The installed Codex connector does not emit this marker.

## Test

`node --test scripts/check-review-posted.test.mjs`
