### PR TITLE
fix(ci): a SKIPPED matrix job publishes its template, not its expansions

### DIFF
--- a/.github/workflows/pr-review-signal.yml
+++ b/.github/workflows/pr-review-signal.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     # Above the poll budget below, so a run that exhausts the budget still gets
     # to PRINT its verdict rather than being killed mid-wait with no output.
-    timeout-minutes: 35
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -116,15 +116,32 @@ jobs:
       #      main's ruleset, so branch protection already blocks on it, and the
       #      #3294 total-absence shape still fails under this config naming all
       #      fifteen lanes.
-      #   2. 900 s, not 420 s. Excluding the aggregate is not enough on its own:
-      #      the last non-aggregate lane appeared at min 161 / median 190 /
-      #      p95 522 / max 845 s, so 420 s would still have false-failed 8 of
-      #      the 68. 900 s covers all 68 -- but the tail margin is 900/845 =
-      #      1.07x, NOT the 1.33x this comment used to claim off the `started_at`
-      #      numbers. It is thin, and measuring from run creation is the
-      #      conservative direction (this job's own deadline starts later still,
-      #      after its pickup and checkout), so the margin is worth stating
-      #      plainly rather than rounding up.
+      #   2. 2400 s, and THIS NUMBER HAS MOVED TWICE. Excluding the aggregate
+      #      is not enough on its own: the last non-aggregate lane appeared at
+      #      min 161 / median 190 / p95 522 / max 845 s over those 68 runs, so
+      #      420 s would still have false-failed 8 of them. 900 s covered all
+      #      68 -- at a tail margin of 900/845 = 1.07x, which this comment
+      #      called thin, and on 2026-08-31 it broke: re-measured that day,
+      #      7 of 45 runs exceeded 900 s, max 2028 s.
+      #
+      #      IT IS NOT MEASURING THE BUILD. On the slow runs 85-91% of the
+      #      number is RUNNER-POOL QUEUE (1837 s of queue against 176 s of
+      #      build on the worst one), so there is nothing to optimise and no
+      #      ceiling: queue depth grows with how many PRs are open, which is
+      #      when this gate is under load. A budget cannot bound that, so it
+      #      WILL breach again; the gate then says "within the poll budget"
+      #      rather than reporting a bare absence, and the remedy is a re-run,
+      #      because nothing failed.
+      #
+      #      Measuring from run creation is the CONSERVATIVE direction: this
+      #      job's own deadline starts later still, after its pickup and
+      #      checkout, so the measured number is an upper bound on what the
+      #      budget must cover. The 1.07x was itself a correction of a 1.33x
+      #      this comment once claimed off `started_at` numbers.
+      #
+      #      The budget, the job cap and the poll interval are asserted
+      #      against THIS FILE by the lib's budget tests, so reverting any of
+      #      them turns the suite red rather than leaving it green.
       # The poll normally returns in seconds via the settle rule; the budget is
       # the ceiling, not the expected cost. A settled-but-incomplete rollup is
       # confirmed across SETTLE_HOLD_SECONDS (60 s) before its absence counts,
@@ -151,4 +168,5 @@ jobs:
           node scripts/check-pr-review-signal.mjs \
             --pr "${{ github.event.pull_request.number }}" \
             --self-name 'PR review signal' \
-            --timeout-seconds 1800
+            --timeout-seconds 2400 \
+            --poll-seconds 30

--- a/.github/workflows/pr-review-signal.yml
+++ b/.github/workflows/pr-review-signal.yml
@@ -123,16 +123,18 @@ jobs:
       #      68 -- at a tail margin of 900/845 = 1.07x, which this comment
       #      called thin, and on 2026-08-31 it broke.
       #
-      #      THE POPULATION, THE BREACH COUNT AND THE MARGIN ARE NOT RESTATED
-      #      HERE. They live once, in the budget tests in
-      #      scripts/lib/pr-review-signal.test.mjs, which ASSERT them and which
-      #      assert this file's own numbers against it. This paragraph carried a
-      #      copy twice and was stale both times -- the second time within an
-      #      hour, in the commit that corrected the first.
+      #      THE 2026-08-31 POPULATION, ITS BREACH COUNT AND ITS MARGIN ARE
+      #      NOT RESTATED HERE -- they live once, in the budget tests in
+      #      scripts/lib/pr-review-signal.test.mjs. This paragraph carried a
+      #      copy of them twice and was stale both times, the second time
+      #      within an hour, in the commit that corrected the first. The
+      #      2026-08-25/26 figures ABOVE are restated, and stay: they are a
+      #      closed historical finding, labelled as such, and cannot go stale.
       #
-      #      IT IS NOT MEASURING THE BUILD. On the slow runs 85-91% of the
-      #      number is RUNNER-POOL QUEUE (1837 s of queue against 176 s of
-      #      build on the worst one), so there is nothing to optimise and no
+      #      IT IS NOT MEASURING THE BUILD. On the slow runs the number is
+      #      overwhelmingly RUNNER-POOL QUEUE and the build is a near-constant
+      #      couple of minutes -- the per-run figures are in the test file with
+      #      the rest -- so there is nothing to optimise and no
       #      ceiling: queue depth grows with how many PRs are open, which is
       #      when this gate is under load. A budget cannot bound that, so it
       #      WILL breach again; the gate then says "within the poll budget"

--- a/.github/workflows/pr-review-signal.yml
+++ b/.github/workflows/pr-review-signal.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     # Above the poll budget below, so a run that exhausts the budget still gets
     # to PRINT its verdict rather than being killed mid-wait with no output.
-    timeout-minutes: 20
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -151,4 +151,4 @@ jobs:
           node scripts/check-pr-review-signal.mjs \
             --pr "${{ github.event.pull_request.number }}" \
             --self-name 'PR review signal' \
-            --timeout-seconds 900
+            --timeout-seconds 1800

--- a/.github/workflows/pr-review-signal.yml
+++ b/.github/workflows/pr-review-signal.yml
@@ -121,8 +121,14 @@ jobs:
       #      min 161 / median 190 / p95 522 / max 845 s over those 68 runs, so
       #      420 s would still have false-failed 8 of them. 900 s covered all
       #      68 -- at a tail margin of 900/845 = 1.07x, which this comment
-      #      called thin, and on 2026-08-31 it broke: re-measured that day,
-      #      7 of 45 runs exceeded 900 s, max 2028 s.
+      #      called thin, and on 2026-08-31 it broke.
+      #
+      #      THE POPULATION, THE BREACH COUNT AND THE MARGIN ARE NOT RESTATED
+      #      HERE. They live once, in the budget tests in
+      #      scripts/lib/pr-review-signal.test.mjs, which ASSERT them and which
+      #      assert this file's own numbers against it. This paragraph carried a
+      #      copy twice and was stale both times -- the second time within an
+      #      hour, in the commit that corrected the first.
       #
       #      IT IS NOT MEASURING THE BUILD. On the slow runs 85-91% of the
       #      number is RUNNER-POOL QUEUE (1837 s of queue against 176 s of

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -33,7 +33,9 @@ jobs:
     # ABOVE the gate's poll budget (300s), deliberately, so a run that exhausts
     # the budget still gets to PRINT its verdict rather than being killed
     # mid-wait with no output and no `covered` value. The sibling gate states the
-    # same rule at pr-review-signal.yml (20 minutes against a 900s budget). An
+    # same rule at pr-review-signal.yml (a job cap comfortably over its own poll
+# budget; that gate asserts the pairing against its own YAML rather than
+# restating it, because this comment was stale about both numbers once). An
     # earlier version of this file had 5 minutes against a 600s budget, which
     # would have killed the job on every PR before it could say anything.
     timeout-minutes: 10

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -34,8 +34,8 @@ jobs:
     # the budget still gets to PRINT its verdict rather than being killed
     # mid-wait with no output and no `covered` value. The sibling gate states the
     # same rule at pr-review-signal.yml (a job cap comfortably over its own poll
-# budget; that gate asserts the pairing against its own YAML rather than
-# restating it, because this comment was stale about both numbers once). An
+    # budget; that gate asserts the pairing against its own YAML rather than
+    # restating it, because this comment was stale about both numbers once). An
     # earlier version of this file had 5 minutes against a 600s budget, which
     # would have killed the job on every PR before it could say anything.
     timeout-minutes: 10

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -521,7 +521,7 @@ function sleepSync(ms) {
  */
 export function evaluate({
   required,
-  aliases = new Map(),
+  aliases,
   lanes,
   reviewChecks,
   reviews,
@@ -531,6 +531,16 @@ export function evaluate({
   timedOut,
   baseRefName,
 }) {
+  // NOT DEFAULTED -- see the identical refusal in `pollForLanes`. A default here
+  // is the difference between a wire-up that is forgotten loudly and one that is
+  // forgotten silently, and this function has exactly one live caller.
+  if (!(aliases instanceof Map)) {
+    throw new ReviewSignalError(
+      'MISSING_ALIASES',
+      'evaluate was called without a matrix alias Map. Pass the map from `matrixSkipAliases` ' +
+        'over the same workflow text `required` came from.',
+    );
+  }
   const lines = [];
   let ok = true;
 
@@ -733,6 +743,29 @@ export function evaluate({
   return { ok, lines };
 }
 
+/**
+ * A `--state-file` fixture's own alias map, refused rather than coerced.
+ *
+ * `Object.entries` accepts a string, a number and an array without complaint and
+ * yields keys no lane name can match, so a malformed value would quietly become
+ * "no aliases" -- safe in direction, wrong in explanation, and three lines from
+ * a comment saying `reviews` refuses a non-array loudly. Same doctrine here.
+ *
+ * @param {unknown} raw
+ * @returns {Map<string, string>}
+ */
+function fixtureAliases(raw) {
+  if (raw === undefined) return new Map();
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new ReviewSignalError(
+      'BAD_STATE_FILE',
+      `\`aliases\` in the state file must be an object mapping an expanded lane name to its ` +
+        `matrix template; got ${Array.isArray(raw) ? 'an array' : typeof raw}.`,
+    );
+  }
+  return new Map(Object.entries(raw));
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const cfg = readConfig(args.config);
@@ -759,7 +792,7 @@ function main() {
       // viewer-shard name would pass for the wrong reason if its rollup carried
       // the real template at `skipped`. Overriding one without the other is
       // therefore possible but never silent -- `aliases` follows `required`.
-      aliases: state.required === undefined ? aliases : new Map(Object.entries(state.aliases ?? {})),
+      aliases: state.required === undefined ? aliases : fixtureAliases(state.aliases),
       lanes: state.lanes,
       reviewChecks: state.reviewChecks ?? [],
       // NOT `?? []`. A state file that omits `reviews` has told this gate

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -763,6 +763,21 @@ function fixtureAliases(raw) {
         `matrix template; got ${Array.isArray(raw) ? 'an array' : typeof raw}.`,
     );
   }
+  for (const [lane, template] of Object.entries(raw)) {
+    // A NON-STRING TEMPLATE IS THE SAME BUG ONE LEVEL IN. `{"Viewer tests (shard
+    // 0)": null}` survives `Object.entries`, `skipped.has(null)` is false, and
+    // the fixture then fails as MISSING_LANES -- a true verdict with a false
+    // explanation, which is exactly what refusing the malformed OUTER value was
+    // meant to prevent. Raised by CodeRabbit on PR #3584 and reproduced before
+    // fixing: the run printed MISSING_LANES, not BAD_STATE_FILE.
+    if (typeof lane !== 'string' || lane === '' || typeof template !== 'string' || template === '') {
+      throw new ReviewSignalError(
+        'BAD_STATE_FILE',
+        `\`aliases\` maps \`${lane}\` to ${template === '' ? 'an empty string' : typeof template}; ` +
+          'every lane name and every matrix template must be a non-empty string.',
+      );
+    }
+  }
   return new Map(Object.entries(raw));
 }
 

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -158,6 +158,8 @@ import {
   expandJobNames,
   flattenReviewPages,
   missingLanes,
+  wholesaleSkippedTemplates,
+  matrixSkipAliases,
   flattenCheckRunPages,
   noVerdictReviews,
   pollForLanes,
@@ -519,6 +521,7 @@ function sleepSync(ms) {
  */
 export function evaluate({
   required,
+  aliases = new Map(),
   lanes,
   reviewChecks,
   reviews,
@@ -531,7 +534,22 @@ export function evaluate({
   const lines = [];
   let ok = true;
 
-  const missing = missingLanes(required, lanes);
+  const missing = missingLanes(required, lanes, aliases);
+  // NAMED, NOT SILENT. A wholesale skip is the one way a required lane passes
+  // this gate without a check run of its own, so it is reported every time. If
+  // the path filter that skipped the job is itself wrong, this line is where
+  // that shows up -- the gate cannot adjudicate the filter, and says so rather
+  // than absorbing the skip into a tick.
+  const skippedWholesale = [...wholesaleSkippedTemplates(lanes, aliases)].sort();
+  for (const t of skippedWholesale) {
+    const covered = required.filter((n) => aliases.get(n) === t);
+    lines.push(
+      `➖ \`${t}\` was SKIPPED as a whole job, before its matrix expanded, so its ` +
+        `${covered.length} lane(s) published no check run of their own and are not ` +
+        'counted missing. Whether the `if:` that skipped it was RIGHT is not something ' +
+        'this gate can answer.',
+    );
+  }
   if (missing.length === 0) {
     lines.push(`✅ All ${required.length} required lane(s) from test.yml are present in the rollup.`);
   } else if (isFork && cfg.forkLanesAreAdvisory) {
@@ -725,9 +743,9 @@ function main() {
       `Workflow \`${args.workflow}\` does not exist, so the required lane set cannot be derived.`,
     );
   }
-  const required = expandJobNames(readFileSync(args.workflow, 'utf8'), {
-    exclude: cfg.excludeJobKeys ?? [],
-  });
+  const workflowText = readFileSync(args.workflow, 'utf8');
+  const required = expandJobNames(workflowText, { exclude: cfg.excludeJobKeys ?? [] });
+  const aliases = matrixSkipAliases(workflowText, { exclude: cfg.excludeJobKeys ?? [] });
 
   // Offline mode for the regression harness: a JSON blob standing in for the
   // three API reads, driving the identical `evaluate`.
@@ -735,6 +753,7 @@ function main() {
     const state = JSON.parse(readFileSync(args.stateFile, 'utf8'));
     const { ok, lines } = evaluate({
       required: state.required ?? required,
+      aliases,
       lanes: state.lanes,
       reviewChecks: state.reviewChecks ?? [],
       // NOT `?? []`. A state file that omits `reviews` has told this gate
@@ -791,6 +810,7 @@ function main() {
   const readState = () => fetchPrState({ pr: args.pr, repo, selfName: args.selfName });
   const { state, timedOut } = pollForLanes({
     required,
+    aliases,
     initialState: readState(),
     fetchState: readState,
     deadline: Date.now() + args.timeoutSeconds * 1000,
@@ -823,6 +843,7 @@ function main() {
 
   const { ok, lines } = evaluate({
     required,
+    aliases,
     lanes: state.lanes,
     reviewChecks,
     reviews,

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -753,7 +753,13 @@ function main() {
     const state = JSON.parse(readFileSync(args.stateFile, 'utf8'));
     const { ok, lines } = evaluate({
       required: state.required ?? required,
-      aliases,
+      // PAIRED WITH `required`, deliberately. A fixture that overrides the lane
+      // set but inherits the REAL alias map is a fixture whose two halves
+      // describe different workflows: a case asserting MISSING_LANES on a real
+      // viewer-shard name would pass for the wrong reason if its rollup carried
+      // the real template at `skipped`. Overriding one without the other is
+      // therefore possible but never silent -- `aliases` follows `required`.
+      aliases: state.required === undefined ? aliases : new Map(Object.entries(state.aliases ?? {})),
       lanes: state.lanes,
       reviewChecks: state.reviewChecks ?? [],
       // NOT `?? []`. A state file that omits `reviews` has told this gate

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -54,16 +54,17 @@
  *     aggregate anyway, it being one of only two contexts in main's ruleset.
  *     The budget WAS 900 s because 420 still false-failed 8 of those 68 even
  *     with the aggregate out. It is 2400 s now, re-measured on 2026-08-31, and
- *     85-91% of the number is RUNNER QUEUE rather than build -- so it has no
- *     ceiling and will breach again; the remedy then is a re-run, because
+ *     the number is overwhelmingly RUNNER QUEUE rather than build -- so it has
+ *     no ceiling and will breach again; the remedy then is a re-run, because
  *     nothing failed.
  *
- *     THE FIGURES ARE DELIBERATELY NOT REPEATED HERE. The population, the
- *     breach counts and the margin live once, in the budget tests in
- *     scripts/lib/pr-review-signal.test.mjs, which assert them AND assert the
- *     workflow's shipped budget against them. A copy of a measurement in a
- *     third file is a copy that goes stale, and this one did.
- *     Full measurement in .github/workflows/pr-review-signal.yml.
+ *     THE 2026-08-31 FIGURES ARE DELIBERATELY NOT REPEATED HERE -- not the
+ *     population, not the breach count, not the margin, and not the queue share.
+ *     They live once, in the budget tests in scripts/lib/pr-review-signal.test.mjs.
+ *     A copy of a measurement in a file that cannot assert it is a copy that
+ *     goes stale, and this one did, twice. The 2026-08-25/26 figures above are
+ *     restated and stay: a closed historical finding cannot go stale.
+ *     Full measurement in scripts/lib/pr-review-signal.test.mjs, which asserts it.
  *
  *     THE LOOP ITSELF IS `pollForLanes`, in the lib, over an injected clock and
  *     sleep. Inline in `main()` it was the one branch with no test --

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -53,10 +53,16 @@
  *     suite runtime, and nothing is lost: branch protection blocks on the
  *     aggregate anyway, it being one of only two contexts in main's ruleset.
  *     The budget WAS 900 s because 420 still false-failed 8 of those 68 even
- *     with the aggregate out. It is 2400 s now: re-measured on 2026-08-31, 7 of
- *     45 runs that day exceeded 900 s (max 2028 s), and 85-91% of that number is
- *     RUNNER QUEUE, not build. The budget tests assert it against the workflow
- *     YAML rather than restating it here, so this line cannot go stale silently.
+ *     with the aggregate out. It is 2400 s now, re-measured on 2026-08-31, and
+ *     85-91% of the number is RUNNER QUEUE rather than build -- so it has no
+ *     ceiling and will breach again; the remedy then is a re-run, because
+ *     nothing failed.
+ *
+ *     THE FIGURES ARE DELIBERATELY NOT REPEATED HERE. The population, the
+ *     breach counts and the margin live once, in the budget tests in
+ *     scripts/lib/pr-review-signal.test.mjs, which assert them AND assert the
+ *     workflow's shipped budget against them. A copy of a measurement in a
+ *     third file is a copy that goes stale, and this one did.
  *     Full measurement in .github/workflows/pr-review-signal.yml.
  *
  *     THE LOOP ITSELF IS `pollForLanes`, in the lib, over an injected clock and

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -766,6 +766,7 @@ function fixtureAliases(raw) {
         `matrix template; got ${Array.isArray(raw) ? 'an array' : typeof raw}.`,
     );
   }
+  const out = new Map();
   for (const [lane, template] of Object.entries(raw)) {
     // A NON-STRING TEMPLATE IS THE SAME BUG ONE LEVEL IN. `{"Viewer tests (shard
     // 0)": null}` survives `Object.entries`, `skipped.has(null)` is false, and
@@ -773,15 +774,31 @@ function fixtureAliases(raw) {
     // explanation, which is exactly what refusing the malformed OUTER value was
     // meant to prevent. Raised by CodeRabbit on PR #3584 and reproduced before
     // fixing: the run printed MISSING_LANES, not BAD_STATE_FILE.
-    if (typeof lane !== 'string' || lane === '' || typeof template !== 'string' || template === '') {
+    //
+    // The KEY is not checked: `Object.entries` only ever yields strings, so a
+    // `typeof lane !== 'string'` clause here would be dead code pretending to
+    // guard something. An empty key is reachable (`{"": "x"}` is valid JSON) and
+    // is rejected.
+    if (lane === '' || typeof template !== 'string' || template === '') {
+      // `typeof []` is 'object', which tells a fixture author nothing. Named the
+      // way the outer refusal names it, so the two messages read alike.
+      const what =
+        template === ''
+          ? 'an empty string'
+          : Array.isArray(template)
+            ? 'an array'
+            : template === null
+              ? 'null'
+              : typeof template;
       throw new ReviewSignalError(
         'BAD_STATE_FILE',
-        `\`aliases\` maps \`${lane}\` to ${template === '' ? 'an empty string' : typeof template}; ` +
-          'every lane name and every matrix template must be a non-empty string.',
+        `\`aliases\` maps \`${lane}\` to ${what}; every lane name and every matrix ` +
+          'template must be a non-empty string.',
       );
     }
+    out.set(lane, template);
   }
-  return new Map(Object.entries(raw));
+  return out;
 }
 
 function main() {

--- a/scripts/check-pr-review-signal.mjs
+++ b/scripts/check-pr-review-signal.mjs
@@ -46,14 +46,17 @@
  *     `needs:` twelve others makes the budget cover the whole matrix: over the
  *     68 completed `test.yml` PR runs of 2026-08-25/26 that published it, the
  *     aggregate APPEARED (`created_at`, from each run's own creation) at 509 to
- *     2067 s, 33 of the 68 past even the current 900 s budget -- a gate
+ *     2067 s, 33 of the 68 past even the then-current 900 s budget -- a gate
  *     printing "the workflow never fired" over half of every green PR.
  *     `excludeJobKeys: ["test"]` ties the wait to how fast GitHub creates check
  *     runs (161-845 s over the same runs, 0 of 68 past 900 s) instead of to
  *     suite runtime, and nothing is lost: branch protection blocks on the
  *     aggregate anyway, it being one of only two contexts in main's ruleset.
- *     The budget is 900 s because 420 still false-failed 8 of those 68 even
- *     with the aggregate out; the tail margin is 900/845 = 1.07x.
+ *     The budget WAS 900 s because 420 still false-failed 8 of those 68 even
+ *     with the aggregate out. It is 2400 s now: re-measured on 2026-08-31, 7 of
+ *     45 runs that day exceeded 900 s (max 2028 s), and 85-91% of that number is
+ *     RUNNER QUEUE, not build. The budget tests assert it against the workflow
+ *     YAML rather than restating it here, so this line cannot go stale silently.
  *     Full measurement in .github/workflows/pr-review-signal.yml.
  *
  *     THE LOOP ITSELF IS `pollForLanes`, in the lib, over an injected clock and
@@ -178,7 +181,7 @@ const DEFAULT_CONFIG = join(SCRIPTS_DIR, 'pr-review-signal.config.json');
  *
  * `Number(undefined)` and `Number('soon')` are both `NaN`, and a NaN deadline
  * makes `now() >= deadline` false forever: the poll would spin until the job's
- * own 20-minute timeout killed it, printing nothing at all. That is the exact
+ * own job timeout killed it, printing nothing at all. That is the exact
  * "no output, no verdict" shape this gate exists to reject, so an unreadable
  * duration is an error rather than a silently infinite one. Zero and negatives
  * go the same way: a zero budget is a gate that never waits, and a zero poll

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -97,6 +97,68 @@ test('GREEN: every required lane present and no reviewer claims a verdict it lac
   assert.match(r.output, /none reports a passing state over a review it did not perform/);
 });
 
+// ------------------------------------- the wiring, not just the logic
+
+/**
+ * VERBATIM from PR #3581's rollup on 2026-08-31, a `.coderabbit.yaml`-only
+ * change. `Viewer tests (shard 0..3)` are absent and the UNEXPANDED template is
+ * present at `skipped`, because a matrix job skipped by its `if:` publishes one
+ * check run before the matrix expands.
+ */
+const SKIPPED_MATRIX_TEMPLATE = 'Viewer tests (shard ${{ matrix.shard }})';
+
+test('END TO END: a wholesale-skipped matrix job passes the REAL required set', () => {
+  // NO `required` OVERRIDE, and that is the entire point of this test. Every
+  // other case here supplies `HEALTHY`, which has no matrix lane, so the alias
+  // map is inert in all of them: deleting the three `aliases,` arguments in
+  // `main()` left all 122 tests green while the gate went back to failing every
+  // config-only PR. The fix has to be proved to ARRIVE, not merely to exist.
+  //
+  // Omitting `required` makes `main()` derive it from the real test.yml, so this
+  // runs the same wiring CI runs.
+  const wf = readFileSync(TEST_YML, 'utf8');
+  const lanes = expandJobNames(wf, { exclude: JSON.parse(readFileSync(CONFIG, 'utf8')).excludeJobKeys ?? [] })
+    .filter((n) => !n.startsWith('Viewer tests (shard '))
+    .map((n) => LANE(n, 'skipped'));
+  lanes.push(LANE(SKIPPED_MATRIX_TEMPLATE, 'skipped'));
+
+  const r = run({ lanes, reviewChecks: [] });
+  assert.equal(r.code, 0, r.output);
+  assert.match(r.output, /All \d+ required lane\(s\)/);
+  // Reported, never absorbed: the skip is named along with how many lanes it covered.
+  assert.match(r.output, /was SKIPPED as a whole job/);
+  assert.match(r.output, /its 4 lane\(s\)/);
+});
+
+test('END TO END: the same rollup WITHOUT the template still fails, naming all four shards', () => {
+  // The anti-vacuity pair. If the test above passed for any reason other than
+  // the alias map -- a required set that never contained the shards, say -- this
+  // one would pass too, and it must not.
+  const wf = readFileSync(TEST_YML, 'utf8');
+  const lanes = expandJobNames(wf, { exclude: JSON.parse(readFileSync(CONFIG, 'utf8')).excludeJobKeys ?? [] })
+    .filter((n) => !n.startsWith('Viewer tests (shard '))
+    .map((n) => LANE(n, 'skipped'));
+
+  const r = run({ lanes, reviewChecks: [] });
+  assert.equal(r.code, 1, r.output);
+  assert.match(r.output, /MISSING_LANES: 4 of/);
+  for (const shard of [0, 1, 2, 3]) {
+    assert.ok(r.output.includes(`Viewer tests (shard ${shard})`), `must name shard ${shard}`);
+  }
+});
+
+test('END TO END: the template at SUCCESS is not a skip, and does not cover the shards', () => {
+  const wf = readFileSync(TEST_YML, 'utf8');
+  const lanes = expandJobNames(wf, { exclude: JSON.parse(readFileSync(CONFIG, 'utf8')).excludeJobKeys ?? [] })
+    .filter((n) => !n.startsWith('Viewer tests (shard '))
+    .map((n) => LANE(n, 'skipped'));
+  lanes.push(LANE(SKIPPED_MATRIX_TEMPLATE, 'success'));
+
+  const r = run({ lanes, reviewChecks: [] });
+  assert.equal(r.code, 1, r.output);
+  assert.match(r.output, /MISSING_LANES: 4 of/);
+});
+
 // ------------------------------------------------- the two live failures
 
 test('RED, the #3294 shape: a rollup with no compile lanes fails and NAMES each one', () => {

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -402,7 +402,7 @@ test('FAIL CLOSED: an unknown flag exits 1 rather than being ignored', () => {
 
 test('FAIL CLOSED: an unreadable --timeout-seconds exits 1 as BAD_DURATION', () => {
   // `Number('soon')` is NaN, and `now() >= NaN` is false forever: the poll would
-  // spin silently until the job's own 20-minute timeout killed it, leaving the
+  // spin silently until the job's own timeout killed it, leaving the
   // PR with no verdict at all. Unreachable from the shipped workflow, which
   // passes a literal, but a gate about absent output must not have a mode that
   // produces none.
@@ -538,7 +538,7 @@ test('the shipped config EXCLUDES the `test` aggregate, and the exclusion is the
   // lane becomes PRESENT, the thing this gate polls for -- from each run's own
   // creation, over the 68 completed test.yml PR runs of 2026-08-25/26 that
   // published it: min 509 s, median 894 s, max 2067 s, and 33 of the 68 past
-  // the 900 s budget. Requiring it would false-fail half of every green PR.
+  // the 900 s budget then in force. Requiring it would false-fail half of every green PR.
   // The last NON-aggregate lane appeared at 161..845 s over the same runs: 0 of
   // 68 past the budget. Full numbers in scripts/lib/pr-review-signal.test.mjs.
   const cfg = JSON.parse(readFileSync(CONFIG, 'utf8'));

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -159,6 +159,40 @@ test('END TO END: the template at SUCCESS is not a skip, and does not cover the 
   assert.match(r.output, /MISSING_LANES: 4 of/);
 });
 
+/**
+ * THE LIVE CALL SITES, ASSERTED STATICALLY, because nothing else can reach them.
+ *
+ * `main()` needs `gh`, so the harness drives `evaluate` only through
+ * `--state-file` and never drives `pollForLanes` at all. That left both LIVE
+ * wire-ups deletable with the suite green -- found in review, and the reason the
+ * two functions now refuse a missing map at run time. This test moves that
+ * refusal earlier, to CI, so a deleted argument is caught before it ships rather
+ * than by the first real run.
+ *
+ * Reading source is a blunt instrument and it is the honest one here: the claim
+ * is literally about what the source passes.
+ */
+test('WIRING: every call to pollForLanes and evaluate passes an alias map', () => {
+  const src = readFileSync(GATE, 'utf8');
+  // `function` excludes `evaluate`'s own definition, which otherwise matches --
+  // and matches WITH an `aliases` parameter, so only the count caught it.
+  const calls = [...src.matchAll(/(?<!function )\b(pollForLanes|evaluate)\(\{/g)];
+  assert.equal(calls.length, 3, 'two live call sites and the --state-file one; update this if that changes');
+
+  for (const m of calls) {
+    // Walk from the `({` to its matching `})` so a nested object cannot end it early.
+    let depth = 0;
+    let i = src.indexOf('{', m.index);
+    const start = i;
+    for (; i < src.length; i += 1) {
+      if (src[i] === '{') depth += 1;
+      else if (src[i] === '}') { depth -= 1; if (depth === 0) break; }
+    }
+    const args = src.slice(start, i + 1);
+    assert.match(args, /\baliases\b\s*[:,]/, `${m[1]}() at index ${m.index} passes no alias map`);
+  }
+});
+
 // ------------------------------------------------- the two live failures
 
 test('RED, the #3294 shape: a rollup with no compile lanes fails and NAMES each one', () => {

--- a/scripts/check-pr-review-signal.test.mjs
+++ b/scripts/check-pr-review-signal.test.mjs
@@ -105,6 +105,9 @@ test('GREEN: every required lane present and no reviewer claims a verdict it lac
  * present at `skipped`, because a matrix job skipped by its `if:` publishes one
  * check run before the matrix expands.
  */
+// The literal `${{ }}` below is DATA, not a template this file means to interpolate: it is what
+// GitHub publishes as the check-run name for a matrix job skipped before it expanded.
+// oxlint-disable-next-line no-template-curly-in-string
 const SKIPPED_MATRIX_TEMPLATE = 'Viewer tests (shard ${{ matrix.shard }})';
 
 test('END TO END: a wholesale-skipped matrix job passes the REAL required set', () => {
@@ -128,6 +131,27 @@ test('END TO END: a wholesale-skipped matrix job passes the REAL required set', 
   // Reported, never absorbed: the skip is named along with how many lanes it covered.
   assert.match(r.output, /was SKIPPED as a whole job/);
   assert.match(r.output, /its 4 lane\(s\)/);
+});
+
+test('a fixture alias with a NON-STRING template is BAD_STATE_FILE, not MISSING_LANES', () => {
+  // CodeRabbit, PR #3584. Reproduced before fixing: a `null` template made the
+  // gate print MISSING_LANES -- a true verdict reached for a false reason, which
+  // is the thing refusing the malformed outer value was supposed to prevent.
+  // `undefined` is absent from this list on purpose: JSON.stringify DROPS the key,
+  // so it cannot reach a state file at all and asserting on it would test the harness.
+  for (const template of [null, 42, '', ['a'], true, {}]) {
+    const r = runRaw({
+      required: ['Viewer tests (shard 0)', 'Detect changes'],
+      lanes: [LANE('Detect changes'), LANE(SKIPPED_MATRIX_TEMPLATE, 'skipped')],
+      aliases: { 'Viewer tests (shard 0)': template },
+      reviewChecks: [],
+      reviews: [],
+      headSha: ANY_HEAD,
+    });
+    assert.equal(r.code, 1, r.output);
+    assert.match(r.output, /BAD_STATE_FILE/, `template ${JSON.stringify(template)}`);
+    assert.doesNotMatch(r.output, /MISSING_LANES/, 'the reason must be the malformed fixture');
+  }
 });
 
 test('END TO END: the same rollup WITHOUT the template still fails, naming all four shards', () => {

--- a/scripts/lib/pr-review-signal.mjs
+++ b/scripts/lib/pr-review-signal.mjs
@@ -156,62 +156,95 @@ function parseMatrix(block) {
  * question, independent of what any filter decided. Verified against PR #3305's
  * rollup, which carries `Docs checks (docs-only PRs)` at `SKIPPED`.
  *
+ * THAT PREMISE HAS ONE EXCEPTION, AND THE EVIDENCE ABOVE COULD NOT SHOW IT.
+ * `Docs checks (docs-only PRs)` is a PLAIN job, so its skipped check run carries
+ * the same name a run one would. A job skipped by `if:` BEFORE its matrix
+ * expands publishes ONE check run under the UNEXPANDED template, verbatim
+ * braces and all. Measured on PR #3581, a `.coderabbit.yaml`-only change, whose
+ * rollup carries:
+ *
+ *   Viewer tests (shard ${{ matrix.shard }})   COMPLETED/SKIPPED
+ *
+ * and no `Viewer tests (shard 0..3)` at all. So the four names this function
+ * derives are unsatisfiable on any PR that touches neither `frontend` nor
+ * `rust` paths, and the gate called that MISSING_LANES with a remedy -- "re-run
+ * the workflow" -- that cannot work, because nothing failed to spawn.
+ *
+ * `matrixSkipAliases` below carries the mapping needed to close that, and
+ * `missingLanes` accepts it. This function's own output is unchanged: the four
+ * expansions are still what a job that DOES run must publish.
+ *
  * @param {string} text - workflow file contents.
  * @param {{ exclude?: Iterable<string> }} [opts] - job KEYS to leave out.
  * @returns {string[]} sorted check names.
  */
+/**
+ * One job's check names, and the TEMPLATE they came from.
+ *
+ * Split out of `expandJobNames` so that `matrixSkipAliases` derives its mapping
+ * from the very same expansion rather than from a second copy of the rules. Two
+ * copies held together only by a comment drift, and drift here is silent: the
+ * alias map would stop covering a lane and the gate would fail a PR that is fine.
+ *
+ * @param {{ key: string, name: string | null, matrix: Record<string, string[]> }} job
+ * @returns {{ template: string, names: string[] }} `template` equals the single
+ *   name for a non-matrix job, and carries `${{ matrix.* }}` verbatim otherwise.
+ */
+function jobCheckNames(job) {
+  const template = job.name ?? job.key;
+  const keys = [...template.matchAll(/\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/g)].map(
+    (m) => m[1],
+  );
+
+  if (keys.length === 0) {
+    if (template.includes('${{')) {
+      throw new ReviewSignalError(
+        'UNRESOLVED_JOB_NAME',
+        `Job \`${job.key}\` has name \`${template}\`, which contains a GitHub Actions ` +
+          'expression this gate cannot resolve. Its check name is therefore unknown, and a ' +
+          'lane whose expected name is unknown cannot be checked for presence. Either give ' +
+          'the job a literal name or teach this function that expression.',
+      );
+    }
+    return { template, names: [template] };
+  }
+
+  let combos = [template];
+  for (const key of keys) {
+    const values = job.matrix[key];
+    if (!values || values.length === 0) {
+      throw new ReviewSignalError(
+        'UNRESOLVED_JOB_NAME',
+        `Job \`${job.key}\` names \`matrix.${key}\` in its check name but no inline ` +
+          `\`${key}: [...]\` list was found under \`strategy.matrix\`. The set of check ` +
+          'names it publishes is unknown; refusing to guess.',
+      );
+    }
+    combos = combos.flatMap((c) =>
+      values.map((v) =>
+        c.replaceAll(new RegExp(`\\$\\{\\{\\s*matrix\\.${key}\\s*\\}\\}`, 'g'), v),
+      ),
+    );
+  }
+  for (const c of combos) {
+    if (c.includes('${{')) {
+      throw new ReviewSignalError(
+        'UNRESOLVED_JOB_NAME',
+        `Job \`${job.key}\` still carries an unresolved expression after matrix expansion: ` +
+          `\`${c}\`.`,
+      );
+    }
+  }
+  return { template, names: combos };
+}
+
 export function expandJobNames(text, opts = {}) {
   const exclude = new Set(opts.exclude ?? []);
   const names = new Set();
 
   for (const job of parseWorkflowJobs(text)) {
     if (exclude.has(job.key)) continue;
-    const template = job.name ?? job.key;
-    const keys = [...template.matchAll(/\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/g)].map(
-      (m) => m[1],
-    );
-
-    if (keys.length === 0) {
-      if (template.includes('${{')) {
-        throw new ReviewSignalError(
-          'UNRESOLVED_JOB_NAME',
-          `Job \`${job.key}\` has name \`${template}\`, which contains a GitHub Actions ` +
-            'expression this gate cannot resolve. Its check name is therefore unknown, and a ' +
-            'lane whose expected name is unknown cannot be checked for presence. Either give ' +
-            'the job a literal name or teach this function that expression.',
-        );
-      }
-      names.add(template);
-      continue;
-    }
-
-    let combos = [template];
-    for (const key of keys) {
-      const values = job.matrix[key];
-      if (!values || values.length === 0) {
-        throw new ReviewSignalError(
-          'UNRESOLVED_JOB_NAME',
-          `Job \`${job.key}\` names \`matrix.${key}\` in its check name but no inline ` +
-            `\`${key}: [...]\` list was found under \`strategy.matrix\`. The set of check ` +
-            'names it publishes is unknown; refusing to guess.',
-        );
-      }
-      combos = combos.flatMap((c) =>
-        values.map((v) =>
-          c.replaceAll(new RegExp(`\\$\\{\\{\\s*matrix\\.${key}\\s*\\}\\}`, 'g'), v),
-        ),
-      );
-    }
-    for (const c of combos) {
-      if (c.includes('${{')) {
-        throw new ReviewSignalError(
-          'UNRESOLVED_JOB_NAME',
-          `Job \`${job.key}\` still carries an unresolved expression after matrix expansion: ` +
-            `\`${c}\`.`,
-        );
-      }
-      names.add(c);
-    }
+    for (const n of jobCheckNames(job).names) names.add(n);
   }
 
   if (names.size === 0) {
@@ -226,6 +259,56 @@ export function expandJobNames(text, opts = {}) {
 }
 
 /**
+ * Expanded check name -> the unexpanded template its job publishes when the
+ * WHOLE job is skipped before the matrix expands.
+ *
+ * Only matrix jobs appear here. A plain job's skipped check run already carries
+ * the name `expandJobNames` derives, so it needs no alias and gets none: adding
+ * one would let a plain lane be satisfied by something other than itself.
+ *
+ * @param {string} text - workflow file contents.
+ * @param {{ exclude?: Iterable<string> }} [opts] - job KEYS to leave out.
+ * @returns {Map<string, string>}
+ */
+export function matrixSkipAliases(text, opts = {}) {
+  const exclude = new Set(opts.exclude ?? []);
+  const aliases = new Map();
+  for (const job of parseWorkflowJobs(text)) {
+    if (exclude.has(job.key)) continue;
+    const { template, names } = jobCheckNames(job);
+    if (names.length === 1 && names[0] === template) continue; // not a matrix job
+    for (const n of names) aliases.set(n, template);
+  }
+  return aliases;
+}
+
+/**
+ * Templates present in the rollup with conclusion `skipped` -- GitHub saying it
+ * decided the whole job before expanding it.
+ *
+ * `skipped` AND NOTHING ELSE. The template name appearing at `success` would
+ * mean a job really is publishing under a literal `${{ ... }}` name, which is a
+ * broken workflow, not a skip; at `queued` it would mean the decision is not
+ * made yet, and treating that as covered would let the poll stop early on a
+ * matrix that is still about to fan out.
+ *
+ * @param {Array<{ name: string, state?: string }>} rollup
+ * @param {Map<string, string>} aliases
+ * @returns {Set<string>}
+ */
+export function wholesaleSkippedTemplates(rollup, aliases) {
+  const templates = new Set(aliases.values());
+  const out = new Set();
+  if (!Array.isArray(rollup)) return out;
+  for (const c of rollup) {
+    if (templates.has(c?.name) && String(c?.state ?? '').toLowerCase() === 'skipped') {
+      out.add(c.name);
+    }
+  }
+  return out;
+}
+
+/**
  * Which required lanes are absent from the rollup.
  *
  * "Present" means the name appears AT ALL -- queued, in progress, skipped or
@@ -234,11 +317,20 @@ export function expandJobNames(text, opts = {}) {
  * the `opened`/`synchronize` race, where the caller polls until this returns
  * empty or the budget runs out.
  *
+ * A required name is ALSO present when its job was skipped wholesale before the
+ * matrix expanded -- see `matrixSkipAliases`. That is not a weakening of the
+ * presence rule, it is the same rule read off the check run GitHub actually
+ * published: a skipped plain job satisfies its own name, and this lets a skipped
+ * matrix job satisfy the names it would have published. Absence with NO check
+ * run of either kind still fails, which is the case the gate exists for.
+ *
  * @param {string[]} required
- * @param {Array<{ name: string }>} rollup
+ * @param {Array<{ name: string, state?: string }>} rollup
+ * @param {Map<string, string>} [aliases] - from `matrixSkipAliases`; empty means
+ *   the strict name-for-name rule, which is what every caller had before.
  * @returns {string[]} sorted missing names.
  */
-export function missingLanes(required, rollup) {
+export function missingLanes(required, rollup, aliases = new Map()) {
   if (!Array.isArray(rollup) || rollup.length === 0) {
     throw new ReviewSignalError(
       'NO_ROLLUP',
@@ -248,7 +340,8 @@ export function missingLanes(required, rollup) {
     );
   }
   const present = new Set(rollup.map((c) => c.name));
-  return required.filter((n) => !present.has(n)).sort();
+  const skipped = wholesaleSkippedTemplates(rollup, aliases);
+  return required.filter((n) => !present.has(n) && !skipped.has(aliases.get(n))).sort();
 }
 
 /**
@@ -445,6 +538,7 @@ function laneSignature(lanes) {
  */
 export function pollForLanes({
   required,
+  aliases = new Map(),
   initialState,
   fetchState,
   deadline,
@@ -464,7 +558,7 @@ export function pollForLanes({
   for (;;) {
     let stillMissing;
     try {
-      stillMissing = missingLanes(required, state.lanes);
+      stillMissing = missingLanes(required, state.lanes, aliases);
     } catch {
       stillMissing = required; // NO_ROLLUP: treat as "nothing has appeared yet".
     }

--- a/scripts/lib/pr-review-signal.mjs
+++ b/scripts/lib/pr-review-signal.mjs
@@ -497,7 +497,7 @@ export function rollupSettled(lanes) {
  * on an advisory benchmark being slow, and nothing pins it -- so it is not a
  * reason to leave the rule un-held.
  *
- * COST. 60 s off a 900 s budget, paid only on the genuine-absence path (#3294's
+ * COST. 60 s off the poll budget, paid only on the genuine-absence path (#3294's
  * shape), which otherwise decides on the first read. The lane-presence path is
  * unaffected: it returns the moment the last required name appears.
  */

--- a/scripts/lib/pr-review-signal.mjs
+++ b/scripts/lib/pr-review-signal.mjs
@@ -237,11 +237,17 @@ function jobCheckNames(job) {
  * THE HOLE THIS LEAVES, STATED. A wholesale skip is accepted without judging
  * WHY the job was skipped, because nothing in the rollup says why. `if:` is one
  * reason; an unsatisfied `needs:` is another, so a failed `build` also skips
- * `viewer-tests` before expansion and its four shards then read present. That
- * does not produce a green verdict over unexamined code -- the failed
- * dependency is itself a required lane and sits in the rollup non-green -- but
- * the four shards stop contributing, and the run prints the skip by name rather
- * than absorbing it into a tick.
+ * `viewer-tests` before expansion and its four shards then read present.
+ *
+ * MEASURED, not assumed. With every lane present, `Build packages + WASM` at
+ * `failure` and the viewer template at `skipped`, this gate exits 0 and prints
+ * "All 16 required lane(s) ... are present": it does NOT read lane state for the
+ * presence verdict, so a failed dependency is simply present. What keeps such a
+ * PR red is BRANCH PROTECTION -- `Build + WASM + Rust + Node` is a required
+ * check in main's ruleset -- and not anything this gate does. An earlier draft
+ * of this paragraph credited that protection to the rollup reading here; it was
+ * wrong, and reproducing it is what showed it. The skip is printed by name
+ * either way, rather than absorbed into a tick.
  *
  * @param {string} text - workflow file contents.
  * @param {{ exclude?: Iterable<string> }} [opts] - job KEYS to leave out.
@@ -551,7 +557,7 @@ function laneSignature(lanes) {
  */
 export function pollForLanes({
   required,
-  aliases = new Map(),
+  aliases,
   initialState,
   fetchState,
   deadline,
@@ -561,6 +567,21 @@ export function pollForLanes({
   sleep,
   log = () => {},
 }) {
+  // NOT DEFAULTED, for the same reason `mode` is not defaulted in the config: a
+  // missing value here is a refusal. `aliases = new Map()` reads as harmless and
+  // is not -- it silently restores the pre-#3581 rule, failing every config-only
+  // PR with an unactionable remedy, and no test of this function can notice
+  // because every test builds its own map. Caught in review: the tests added
+  // with the alias map pinned the OFFLINE call site and left both LIVE ones
+  // deletable while the whole suite stayed green.
+  if (!(aliases instanceof Map)) {
+    throw new ReviewSignalError(
+      'MISSING_ALIASES',
+      'pollForLanes was called without a matrix alias Map. Pass the map from ' +
+        '`matrixSkipAliases` over the same workflow text `required` came from; pass an empty ' +
+        'Map only to mean "this workflow has no matrix jobs", and mean it.',
+    );
+  }
   let state = initialState;
   // A non-finite hold falls back to the shipped default rather than to the
   // weaker rule: an unreadable guard must never be a disabled guard.

--- a/scripts/lib/pr-review-signal.mjs
+++ b/scripts/lib/pr-review-signal.mjs
@@ -147,38 +147,6 @@ function parseMatrix(block) {
 }
 
 /**
- * The check-run names a fired run of this workflow is expected to publish.
- *
- * A job with no `name:` publishes under its key; a job with a matrix publishes
- * one check per combination. Path filters and `if:` conditions do NOT remove a
- * job from this set: GitHub publishes a skipped job as a check run with
- * conclusion `skipped`, so PRESENCE is exactly the "did the workflow fire"
- * question, independent of what any filter decided. Verified against PR #3305's
- * rollup, which carries `Docs checks (docs-only PRs)` at `SKIPPED`.
- *
- * THAT PREMISE HAS ONE EXCEPTION, AND THE EVIDENCE ABOVE COULD NOT SHOW IT.
- * `Docs checks (docs-only PRs)` is a PLAIN job, so its skipped check run carries
- * the same name a run one would. A job skipped by `if:` BEFORE its matrix
- * expands publishes ONE check run under the UNEXPANDED template, verbatim
- * braces and all. Measured on PR #3581, a `.coderabbit.yaml`-only change, whose
- * rollup carries:
- *
- *   Viewer tests (shard ${{ matrix.shard }})   COMPLETED/SKIPPED
- *
- * and no `Viewer tests (shard 0..3)` at all. So the four names this function
- * derives are unsatisfiable on any PR that touches neither `frontend` nor
- * `rust` paths, and the gate called that MISSING_LANES with a remedy -- "re-run
- * the workflow" -- that cannot work, because nothing failed to spawn.
- *
- * `matrixSkipAliases` below carries the mapping needed to close that, and
- * `missingLanes` accepts it. This function's own output is unchanged: the four
- * expansions are still what a job that DOES run must publish.
- *
- * @param {string} text - workflow file contents.
- * @param {{ exclude?: Iterable<string> }} [opts] - job KEYS to leave out.
- * @returns {string[]} sorted check names.
- */
-/**
  * One job's check names, and the TEMPLATE they came from.
  *
  * Split out of `expandJobNames` so that `matrixSkipAliases` derives its mapping
@@ -238,6 +206,47 @@ function jobCheckNames(job) {
   return { template, names: combos };
 }
 
+/**
+ * The check-run names a fired run of this workflow is expected to publish.
+ *
+ * A job with no `name:` publishes under its key; a job with a matrix publishes
+ * one check per combination. Path filters and `if:` conditions do NOT remove a
+ * job from this set: GitHub publishes a skipped job as a check run with
+ * conclusion `skipped`, so PRESENCE is exactly the "did the workflow fire"
+ * question, independent of what any filter decided. Verified against PR #3305's
+ * rollup, which carries `Docs checks (docs-only PRs)` at `SKIPPED`.
+ *
+ * THAT PREMISE HAS ONE EXCEPTION, AND THE EVIDENCE ABOVE COULD NOT SHOW IT.
+ * `Docs checks (docs-only PRs)` is a PLAIN job, so its skipped check run carries
+ * the same name a run one would. A job skipped by `if:` BEFORE its matrix
+ * expands publishes ONE check run under the UNEXPANDED template, verbatim
+ * braces and all. Measured on PR #3581, a `.coderabbit.yaml`-only change, whose
+ * rollup carries:
+ *
+ *   Viewer tests (shard ${{ matrix.shard }})   COMPLETED/SKIPPED
+ *
+ * and no `Viewer tests (shard 0..3)` at all. So the four names this function
+ * derives are unsatisfiable on any PR that touches neither `frontend` nor
+ * `rust` paths, and the gate called that MISSING_LANES with a remedy -- "re-run
+ * the workflow" -- that cannot work, because nothing failed to spawn.
+ *
+ * `matrixSkipAliases` below carries the mapping needed to close that, and
+ * `missingLanes` accepts it. This function's own output is unchanged: the four
+ * expansions are still what a job that DOES run must publish.
+ *
+ * THE HOLE THIS LEAVES, STATED. A wholesale skip is accepted without judging
+ * WHY the job was skipped, because nothing in the rollup says why. `if:` is one
+ * reason; an unsatisfied `needs:` is another, so a failed `build` also skips
+ * `viewer-tests` before expansion and its four shards then read present. That
+ * does not produce a green verdict over unexamined code -- the failed
+ * dependency is itself a required lane and sits in the rollup non-green -- but
+ * the four shards stop contributing, and the run prints the skip by name rather
+ * than absorbing it into a tick.
+ *
+ * @param {string} text - workflow file contents.
+ * @param {{ exclude?: Iterable<string> }} [opts] - job KEYS to leave out.
+ * @returns {string[]} sorted check names.
+ */
 export function expandJobNames(text, opts = {}) {
   const exclude = new Set(opts.exclude ?? []);
   const names = new Set();
@@ -299,9 +308,13 @@ export function matrixSkipAliases(text, opts = {}) {
 export function wholesaleSkippedTemplates(rollup, aliases) {
   const templates = new Set(aliases.values());
   const out = new Set();
-  if (!Array.isArray(rollup)) return out;
+  // NO `Array.isArray` GUARD. Every caller reaches here past `missingLanes`,
+  // which throws NO_ROLLUP on a non-array first, so the guard could not fire --
+  // and if it ever did, returning an empty set would be this file's own doctrine
+  // inverted: an unreadable rollup reported as "nothing was skipped". Iterating a
+  // non-array throws, which is the loud answer.
   for (const c of rollup) {
-    if (templates.has(c?.name) && String(c?.state ?? '').toLowerCase() === 'skipped') {
+    if (templates.has(c.name) && String(c.state ?? '').toLowerCase() === 'skipped') {
       out.add(c.name);
     }
   }

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -575,6 +575,20 @@ test('the poll treats an EMPTY rollup as "nothing has appeared yet", never as se
   assert.match(d.logs[0], /3\/3 required lane\(s\) not yet published/);
 });
 
+/**
+ * Run creation to the LAST non-aggregate lane's `created_at`, in seconds, over
+ * the 68 completed `test.yml` PR runs of 2026-08-25/26 that published the
+ * aggregate. Shared by the three budget tests below, which read it in different
+ * directions: what 900 s covered, what 420 s false-failed, and what a re-measure
+ * on 2026-08-31 found it no longer covers.
+ */
+const LANE_APPEARED_SECONDS = [
+  161, 162, 162, 162, 163, 164, 164, 165, 165, 165, 166, 166, 167, 167, 167, 167, 167, 169, 169,
+  170, 170, 170, 170, 171, 171, 171, 172, 172, 175, 176, 177, 187, 188, 189, 190, 193, 198, 204,
+  210, 221, 235, 237, 237, 241, 244, 276, 289, 290, 290, 297, 299, 310, 322, 334, 349, 362, 386,
+  388, 403, 416, 423, 426, 450, 451, 522, 523, 542, 845,
+];
+
 test('MEASURED: 900 s covers every observed lane APPEARANCE, and 420 s did not', () => {
   // THE METHODOLOGY HERE WAS WRONG ONCE, AND THE NUMBERS MOVED WHEN IT WAS
   // FIXED. The first version of this constant measured `started_at` — when a
@@ -584,12 +598,6 @@ test('MEASURED: 900 s covers every observed lane APPEARANCE, and 420 s did not',
   // Measured from each run's own `created_at` over the 68 completed `test.yml`
   // PR runs of 2026-08-25/26 that published the aggregate, here is when the
   // LAST NON-AGGREGATE lane appeared, in seconds:
-  const LANE_APPEARED_SECONDS = [
-    161, 162, 162, 162, 163, 164, 164, 165, 165, 165, 166, 166, 167, 167, 167, 167, 167, 169, 169,
-    170, 170, 170, 170, 171, 171, 171, 172, 172, 175, 176, 177, 187, 188, 189, 190, 193, 198, 204,
-    210, 221, 235, 237, 237, 241, 244, 276, 289, 290, 290, 297, 299, 310, 322, 334, 349, 362, 386,
-    388, 403, 416, 423, 426, 450, 451, 522, 523, 542, 845,
-  ];
   assert.equal(LANE_APPEARED_SECONDS.length, 68);
 
   for (const s of LANE_APPEARED_SECONDS) {
@@ -611,6 +619,45 @@ test('MEASURED: 900 s covers every observed lane APPEARANCE, and 420 s did not',
   const max = Math.max(...LANE_APPEARED_SECONDS);
   assert.equal(max, 845);
   assert.equal(Number((900 / max).toFixed(2)), 1.07, 'tail margin, stated honestly');
+});
+
+test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 1800 s', () => {
+  // A 1.07x margin is one busy afternoon from being wrong, and this was that
+  // afternoon. Same methodology as above -- run creation to the LAST
+  // non-aggregate lane's `created_at` -- over the 22 most recent completed
+  // test.yml PR runs, with three PRs of this rollout in flight at once:
+  const RE_MEASURED = [
+    15, 162, 166, 171, 176, 185, 201, 205, 211, 264, 264, 282, 290, 375, 391, 418, 469, 622, 660,
+    814, 906, 1527,
+  ];
+  assert.equal(RE_MEASURED.length, 22);
+
+  // TWO breach 900 s. The 1527 s run is PR #3584's own: `Build packages + WASM`
+  // completed at 18:38:31 and the gate gave up at 18:37:50, so eight lanes sat
+  // behind `needs: build` and could not exist yet. Nothing had failed.
+  const breaching = RE_MEASURED.filter((t) => t > 900);
+  assert.deepEqual(breaching, [906, 1527], '900 s is no longer a covering budget');
+
+  // WHY IT MOVED, and why raising the number is the right response rather than
+  // re-tuning it downward later: the gate polls for lane APPEARANCE, and a lane
+  // behind `needs:` cannot appear until its dependency finishes. So this budget
+  // is not measuring flakiness, it is measuring the BUILD, and the build gets
+  // slower exactly when the runner pool is busy -- which is when several PRs
+  // are open, which is when the gate matters most.
+  for (const t of RE_MEASURED) {
+    const d = driver(completesAt(t * 1000));
+    assert.equal(poll(d, { deadline: 1800_000 }).timedOut, false, `${t}s must fit in 1800 s`);
+  }
+  // Both directions. A budget that covers everything proves nothing on its own;
+  // this pins that the OLD one genuinely fails the two runs it is claimed to.
+  for (const t of breaching) {
+    const d = driver(completesAt(t * 1000));
+    assert.equal(poll(d, { deadline: 900_000 }).timedOut, true, `${t}s must NOT fit in 900 s`);
+  }
+  assert.equal(Number((1800 / 1527).toFixed(2)), 1.18, 'the new tail margin, stated the same way');
+});
+
+test('MEASURED: the aggregate lane is excluded, and that is the load-bearing half', () => {
 
   // AND THE AGGREGATE EXCLUSION IS MORE LOAD-BEARING THAN 420-vs-900 EVER WAS.
   // Same 68 runs, when `Build + WASM + Rust + Node` itself appeared: min 509,

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -552,7 +552,7 @@ test('the poll STOPS EARLY once the rollup has settled — #3294 must not burn t
   const r = poll(d);
   assert.equal(r.timedOut, false, 'settled is an ANSWER, not a timeout');
   // It costs the HOLD and not one interval more. The first read cannot decide
-  // this — see the fan-out replay below — but 60 s out of a 900 s budget still
+  // this — see the fan-out replay below — but 60 s out of the poll budget still
   // leaves #3294's total-absence shape decided in seconds, not in fifteen
   // minutes, which is the property this test was written for.
   assert.deepEqual(d.slept, [15_000, 15_000, 15_000, 15_000], 'exactly SETTLE_HOLD_SECONDS');
@@ -646,40 +646,58 @@ test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 2400 s', () 
   // A 1.07x margin is one busy afternoon from being wrong, and this was that
   // afternoon.
   //
-  // THE FIRST RE-MEASURE OF THIS WAS CENSORED, and the censoring hid exactly the
-  // runs it was taken to find. Filtering the run list on `status == completed`
-  // at an instant drops the runs that are slow BECAUSE THEY ARE STILL RUNNING --
-  // it removes the tail, which is the only part of the distribution a budget
-  // cares about. It excluded five runs, and they were the five slowest of the
-  // afternoon (1276, 1387, 1503, 1786, 2028 s), including PR #3584's own. The
-  // number that draft landed on, 1800 s, would not have covered the worst run of
-  // the day it was measured on. Caught in review.
+  // THIS ARRAY HAS BEEN CENSORED TWICE, BY THE SAME MECHANISM, AND THE SECOND
+  // TIME WAS AFTER WRITING THE PARAGRAPH WARNING ABOUT IT. Filtering a run list
+  // on `status == completed` at an instant drops the runs that are slow BECAUSE
+  // THEY ARE STILL RUNNING -- it removes the tail, which is the only part of the
+  // distribution a budget cares about.
   //
-  // Uncensored: same methodology (run creation to the LAST non-aggregate lane's
-  // `created_at`) over the 45 completed test.yml PR runs of 2026-08-31, with 15
-  // more still queued at the time of the read and therefore not measurable --
-  // stated, because that is the same exclusion that went wrong above.
+  //   first draft:  sampled the 60 most recent runs, kept the 22 completed.
+  //                 Dropped 1276, 1387, 1503, 1786, 2028 -- the five slowest of
+  //                 the day. Landed on 1800 s, which would not have covered the
+  //                 worst run of the afternoon it was measured on.
+  //   second draft: same filter, wider window, 45 kept. Dropped 1276 AGAIN --
+  //                 run 33424176735, PR #3584's own -- because it finished about
+  //                 50 s after the read. The docblock NAMED 1276 as a censored
+  //                 run in the same breath as an array that omitted it.
+  //
+  // Both caught in review, not by me. The fix is not a wider window, it is to
+  // stop sampling on a field that moves with the thing being measured: take the
+  // whole day, after the day is over.
+  //
+  // Below: every completed test.yml PR run created on 2026-08-31 -- 72 created,
+  // 57 completed, 56 with jobs to measure -- run creation to the LAST
+  // non-aggregate lane's `created_at`.
   const RE_MEASURED = [
-    15, 162, 166, 166, 169, 170, 170, 171, 173, 174, 175, 176, 176, 183, 185, 200, 201, 205, 211,
-    238, 264, 264, 282, 290, 308, 314, 317, 333, 375, 391, 418, 469, 473, 622, 660, 712, 814, 824,
-    906, 1172, 1387, 1503, 1527, 1786, 2028,
+    15, 162, 166, 166, 169, 170, 170, 170, 171, 173, 173, 174, 175, 176, 176, 183, 185, 200, 201,
+    201, 205, 211, 238, 264, 264, 269, 275, 282, 290, 308, 311, 314, 317, 333, 357, 375, 391, 418,
+    469, 469, 473, 496, 622, 660, 662, 712, 814, 824, 906, 1172, 1276, 1387, 1503, 1527, 1786, 2028,
   ];
-  assert.equal(RE_MEASURED.length, 45);
+  assert.equal(RE_MEASURED.length, 56);
 
-  // 900 s no longer covers this population, and neither does 1800 s.
+  // THE 12 RUNS THIS STILL CANNOT MEASURE, bounded rather than waved away --
+  // that silent exclusion is the whole defect above. They were still queued, so
+  // their last lane may yet appear later; so far they stand at 304..1145 s, and
+  // the budget would have to be wrong by more than 1255 s for one to breach.
+  const STILL_QUEUED_SO_FAR = [304, 306, 324, 374, 378, 397, 435, 446, 467, 485, 1102, 1145];
+  assert.ok(Math.max(...STILL_QUEUED_SO_FAR) < BUDGET_SECONDS, 'none of the unmeasurable runs is near the cap');
+
+  // EIGHT breach 900 s, not the seven an earlier censored draft claimed.
   assert.deepEqual(
     RE_MEASURED.filter((t) => t > 900),
-    [906, 1172, 1387, 1503, 1527, 1786, 2028],
-    '900 s breaches seven of 45',
+    [906, 1172, 1276, 1387, 1503, 1527, 1786, 2028],
+    '900 s breaches eight of 56',
   );
   assert.deepEqual(RE_MEASURED.filter((t) => t > 1800), [2028], '1800 s still breaches the max');
-  assert.deepEqual(RE_MEASURED.filter((t) => t > BUDGET_SECONDS), [], 'the shipped budget covers all 45');
+  assert.deepEqual(RE_MEASURED.filter((t) => t > BUDGET_SECONDS), [], 'the shipped budget covers all 56');
 
-  // Both directions. A budget that covers everything proves nothing on its own,
-  // so the old ones are pinned as genuinely failing the runs they are claimed to.
+  // THE COVERING DIRECTION.
   for (const t of RE_MEASURED) {
     assert.equal(poll(driver(completesAt(t * 1000)), { deadline: BUDGET_SECONDS * 1000 }).timedOut, false, `${t}s`);
   }
+  // THE FAILING DIRECTION, because a budget that covers everything proves
+  // nothing on its own: the two superseded budgets genuinely time out on the
+  // runs they are claimed to.
   for (const t of [906, 2028]) {
     assert.equal(poll(driver(completesAt(t * 1000)), { deadline: 900_000 }).timedOut, true, `${t}s vs 900 s`);
   }
@@ -711,12 +729,19 @@ test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 2400 s', () 
 test('the budget the WORKFLOW ships is the budget this file tested', () => {
   // WITHOUT THIS, REVERTING THE SHIPPED VALUE LEAVES THE SUITE GREEN. Measured:
   // putting `--timeout-seconds 900` and `timeout-minutes: 20` back -- the exact
-  // regression this work exists to fix -- passed all 129 tests, because the only
+  // regression this work exists to fix -- passed the whole suite, because the only
   // budget any test named was a literal inside itself. Third instance today of
   // the same shape: a value tested in one place and shipped from another. See
   // the WIRING test in check-pr-review-signal.test.mjs.
   const wf = readFileSync(join(REPO_ROOT, '.github/workflows/pr-review-signal.yml'), 'utf8');
-  const budget = /--timeout-seconds[ \t]+(\d+)/.exec(wf);
+  // ANCHORED, and that is load-bearing rather than tidy. Unanchored, these
+  // matched the FIRST occurrence anywhere in a comment-dense file whose comments
+  // discuss these very numbers. Demonstrated in review: one line reading
+  // `# historical: timeout-minutes: 45` above a shipped `timeout-minutes: 20`
+  // passed all 78 tests while certifying a job that would be killed at 1200 s
+  // against a 2400 s budget -- the exact `cancelled` run the slack assertion
+  // below exists to prevent. `^[ \t]*` cannot match a `#`-prefixed line.
+  const budget = /^[ \t]*--timeout-seconds[ \t]+(\d+)/m.exec(wf);
   assert.ok(budget, 'the workflow must pass an explicit --timeout-seconds');
   assert.equal(Number(budget[1]), BUDGET_SECONDS, 'shipped budget vs the one measured above');
 
@@ -724,7 +749,7 @@ test('the budget the WORKFLOW ships is the budget this file tested', () => {
   // and the run reports `cancelled` -- the same word `cancel-in-progress`
   // produces for a superseded run, so a red check with no verdict and no way to
   // tell the two apart.
-  const jobCap = /timeout-minutes:[ \t]+(\d+)/.exec(wf);
+  const jobCap = /^[ \t]*timeout-minutes:[ \t]+(\d+)/m.exec(wf);
   assert.ok(jobCap, 'the job must carry a timeout-minutes');
   // >= 5 minutes of slack. Measured on the real failing run: set-up 2 s,
   // checkout 4 s, `node --test` 5 s, and 3 s of trailing reads after the poll
@@ -745,14 +770,22 @@ test('the budget the WORKFLOW ships is the budget this file tested', () => {
   // run, so ~6 concurrent full-budget pollers exhaust the repository. Exhaustion
   // makes the gate fail closed on GH_ERROR: red, for a reason unrelated to the
   // diff. 30 s halves it, and costs 15 s of resolution on a 2400 s budget.
-  const interval = /--poll-seconds[ \t]+(\d+)/.exec(wf);
+  const interval = /^[ \t]*--poll-seconds[ \t]+(\d+)/m.exec(wf);
   assert.ok(interval, 'the workflow must pass an explicit --poll-seconds');
   assert.ok(Number(interval[1]) >= 30, 'a faster poll multiplies the rate-limit risk');
   assert.ok(BUDGET_SECONDS / Number(interval[1]) <= 90, 'reads per run stay under ~90');
 });
 
 test('MEASURED: excluding the aggregate matters more than any budget, and 420 s false-failed 8', () => {
-  // THE AGGREGATE EXCLUSION IS MORE LOAD-BEARING THAN 420-vs-900 EVER WAS.
+  // THE AGGREGATE EXCLUSION IS MORE LOAD-BEARING THAN ANY BUDGET EVER WAS, and
+  // the 900 s figure below no longer argues that, because 900 s is not the
+  // budget any more: at 2400 s, 0 of those 68 would breach and the evidence
+  // would be vacuous. Re-measured on the same 56 runs of 2026-08-31 as the
+  // budget above, the aggregate appeared at min 213 / median 1175 / MAX 3364 s,
+  // with TWELVE past 2400 s. So the exclusion still carries the fix at the
+  // budget actually in force, and the 68-run figure below is kept as the
+  // original finding rather than restated as a current one.
+  //
   // Same 68 runs, when `Build + WASM + Rust + Node` itself appeared: min 509,
   // median 894, max 2067 s. Requiring it would false-fail 33 of the 68 at a
   // 900 s budget — half of every green PR — which is why `excludeJobKeys`

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -162,6 +162,19 @@ test('presence counts a QUEUED lane: the workflow fired, which is the question',
 // ------------------------------------------- a matrix job skipped BEFORE expanding
 
 /**
+ * The check-run name PR #3581 actually published, verbatim.
+ *
+ * ONE constant rather than five literals, and deliberately NOT derived from
+ * `matrixSkipAliases` over the real test.yml: that is the function under test,
+ * and an expected value taken from it would agree with it whatever it did. This
+ * is the observed string, pinned by hand, which is the whole point.
+ */
+// The literal `${{ }}` below is DATA, not a template this file means to interpolate: it is what
+// GitHub publishes as the check-run name for a matrix job skipped before it expanded.
+// oxlint-disable-next-line no-template-curly-in-string
+const MATRIX_TEMPLATE = 'Viewer tests (shard ${{ matrix.shard }})';
+
+/**
  * VERBATIM from PR #3581's rollup on 2026-08-31 (a `.coderabbit.yaml`-only
  * change, so `needs.changes.outputs.frontend` was false). Note what is NOT here:
  * `Viewer tests (shard 0)` through `(shard 3)`. GitHub published ONE check run,
@@ -173,7 +186,7 @@ const PR3581_ROLLUP = [
   { name: 'Build + WASM + Rust + Node', state: 'success' },
   { name: 'Build packages + WASM', state: 'skipped' },
   { name: 'Viewer E2E smoke', state: 'skipped' },
-  { name: 'Viewer tests (shard ${{ matrix.shard }})', state: 'skipped' },
+  { name: MATRIX_TEMPLATE, state: 'skipped' },
 ];
 
 test('RED, the #3581 shape: a skipped MATRIX job publishes its template, not its expansions', () => {
@@ -198,7 +211,7 @@ test('the alias covers ONLY a skip: the template at any other state satisfies no
   const aliases = matrixSkipAliases(WF);
   const required = ['Viewer tests (shard 0)'];
   for (const state of ['success', 'queued', 'in_progress', 'failure', '']) {
-    const rollup = [{ name: 'Viewer tests (shard ${{ matrix.shard }})', state }];
+    const rollup = [{ name: MATRIX_TEMPLATE, state }];
     assert.deepEqual(missingLanes(required, rollup, aliases), required, `state "${state}"`);
   }
 });
@@ -219,7 +232,7 @@ test('a PLAIN job gets no alias, so nothing but its own name can satisfy it', ()
   const aliases = matrixSkipAliases(WF);
   assert.equal(aliases.has('Detect changes'), false);
   assert.equal(aliases.has('unnamed-job'), false);
-  assert.deepEqual([...new Set(aliases.values())], ['Viewer tests (shard ${{ matrix.shard }})']);
+  assert.deepEqual([...new Set(aliases.values())], [MATRIX_TEMPLATE]);
   assert.equal(aliases.size, 4, 'all four shards, and only those');
 });
 
@@ -233,7 +246,7 @@ test('the REAL test.yml maps every viewer shard to the template the REAL rollup 
   for (const shard of [0, 1, 2, 3]) {
     assert.equal(
       aliases.get(`Viewer tests (shard ${shard})`),
-      'Viewer tests (shard ${{ matrix.shard }})',
+      MATRIX_TEMPLATE,
       `shard ${shard}`,
     );
   }
@@ -296,7 +309,7 @@ test('a wholesale skip is REPORTED, never absorbed into a tick', () => {
   const aliases = matrixSkipAliases(WF);
   assert.deepEqual(
     [...wholesaleSkippedTemplates(PR3581_ROLLUP, aliases)],
-    ['Viewer tests (shard ${{ matrix.shard }})'],
+    [MATRIX_TEMPLATE],
   );
   // And nothing is reported when nothing was skipped wholesale.
   assert.equal(wholesaleSkippedTemplates([{ name: 'Detect changes', state: 'skipped' }], aliases).size, 0);

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -270,6 +270,28 @@ test('`excludeJobKeys` must reach BOTH derivations, or the alias map stops cover
   }
 });
 
+test('FAIL CLOSED: pollForLanes REFUSES a missing alias map rather than defaulting', () => {
+  // The defect this closes was found by review, not by a test: three call sites
+  // wire the map, tests covered ONE, and deleting the other two left the suite
+  // green while the live gate regressed to failing every config-only PR. A
+  // default made that silent. It is now a named refusal.
+  for (const bad of [undefined, null, {}, new Set(), [['a', 'b']]]) {
+    assert.throws(
+      () => pollForLanes({
+        required: ['A'],
+        aliases: bad,
+        initialState: { lanes: [{ name: 'A', state: 'success' }] },
+        fetchState: () => ({ lanes: [] }),
+        deadline: Date.now() + 1000,
+        pollSeconds: 1,
+        sleep: () => {},
+      }),
+      (e) => e.reason === 'MISSING_ALIASES',
+      String(bad),
+    );
+  }
+});
+
 test('a wholesale skip is REPORTED, never absorbed into a tick', () => {
   const aliases = matrixSkipAliases(WF);
   assert.deepEqual(
@@ -475,9 +497,13 @@ function driver(readsAt, { pollMs = 15_000, startMs = 0 } = {}) {
 /** Lanes that are `in_progress` until `atMs`, complete from then on. */
 const completesAt = (atMs) => (clock) => (clock >= atMs ? POLL_COMPLETE : POLL_MOVING);
 
-function poll(d, { deadline = 900_000, pollSeconds = 15, required, settleHoldSeconds } = {}) {
+function poll(d, { deadline = 900_000, pollSeconds = 15, required, aliases, settleHoldSeconds } = {}) {
   return pollForLanes({
     required: required ?? POLL_REQUIRED,
+    // EXPLICIT, because `pollForLanes` refuses a missing map. These fixtures use
+    // plain lane names with no matrix job, so an empty map is the true answer
+    // here -- not a default standing in for one nobody thought about.
+    aliases: aliases ?? new Map(),
     initialState: d.state(),
     fetchState: d.state,
     deadline,

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -244,15 +244,29 @@ test('the REAL test.yml maps every viewer shard to the template the REAL rollup 
   );
 });
 
-test('the whole real required set survives the real skipped rollup', () => {
-  // End to end over the shipped config: the lanes test.yml publishes, against
-  // the rollup PR #3581 published, must leave only lanes that genuinely never
-  // appeared -- and the four viewer shards must not be among them.
+test('`excludeJobKeys` must reach BOTH derivations, or the alias map stops covering a lane', () => {
+  // The one property no other test here pins: `main` passes the same exclude
+  // list to `expandJobNames` and to `matrixSkipAliases`. Passing it to only the
+  // first is a silent, asymmetric failure -- the lane stays required while its
+  // alias disappears -- so it is checked positively rather than by the absence
+  // of a complaint.
   const wf = readFileSync(join(REPO_ROOT, '.github/workflows/test.yml'), 'utf8');
-  const required = expandJobNames(wf, { exclude: CFG.excludeJobKeys ?? [] });
-  const missing = missingLanes(required, PR3581_ROLLUP, matrixSkipAliases(wf, { exclude: CFG.excludeJobKeys ?? [] }));
+  const exclude = CFG.excludeJobKeys ?? [];
+
+  const required = expandJobNames(wf, { exclude });
+  const missing = missingLanes(required, PR3581_ROLLUP, matrixSkipAliases(wf, { exclude }));
+  // Positive: name exactly what is still missing. Everything test.yml publishes
+  // that PR #3581's rollup did not carry, and not one viewer shard among them.
+  const carried = new Set(PR3581_ROLLUP.map((c) => c.name));
+  assert.deepEqual(
+    missing,
+    required.filter((n) => !carried.has(n) && !n.startsWith('Viewer tests (shard ')).sort(),
+  );
+
+  // Asymmetric: excluding the job from the ALIASES only puts the shards back.
+  const asymmetric = missingLanes(required, PR3581_ROLLUP, matrixSkipAliases(wf, { exclude: [...exclude, 'viewer-tests'] }));
   for (const shard of [0, 1, 2, 3]) {
-    assert.ok(!missing.includes(`Viewer tests (shard ${shard})`), `shard ${shard} must not be missing`);
+    assert.ok(asymmetric.includes(`Viewer tests (shard ${shard})`), `shard ${shard} uncovered`);
   }
 });
 

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -20,6 +20,7 @@ import {
   ReviewSignalError,
   expandJobNames,
   flattenReviewPages,
+  matrixSkipAliases,
   missingLanes,
   noVerdictReviews,
   pollForLanes,
@@ -30,6 +31,7 @@ import {
   STALE_REVIEW_POLICIES,
   SETTLE_HOLD_SECONDS,
   pullRequestBranchFilterKeys,
+  wholesaleSkippedTemplates,
 } from './pr-review-signal.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -155,6 +157,130 @@ test('presence counts a SKIPPED lane: a path-filtered job still published a chec
 
 test('presence counts a QUEUED lane: the workflow fired, which is the question', () => {
   assert.deepEqual(missingLanes(['A'], [LANE('A', 'queued')]), []);
+});
+
+// ------------------------------------------- a matrix job skipped BEFORE expanding
+
+/**
+ * VERBATIM from PR #3581's rollup on 2026-08-31 (a `.coderabbit.yaml`-only
+ * change, so `needs.changes.outputs.frontend` was false). Note what is NOT here:
+ * `Viewer tests (shard 0)` through `(shard 3)`. GitHub published ONE check run,
+ * under the unexpanded template, because the job was skipped before its matrix
+ * expanded.
+ */
+const PR3581_ROLLUP = [
+  { name: 'Detect changes', state: 'success' },
+  { name: 'Build + WASM + Rust + Node', state: 'success' },
+  { name: 'Build packages + WASM', state: 'skipped' },
+  { name: 'Viewer E2E smoke', state: 'skipped' },
+  { name: 'Viewer tests (shard ${{ matrix.shard }})', state: 'skipped' },
+];
+
+test('RED, the #3581 shape: a skipped MATRIX job publishes its template, not its expansions', () => {
+  // The premise the gate shipped with -- "a skipped job still publishes a check
+  // run under the name we derived" -- was verified against `Docs checks
+  // (docs-only PRs)`, a PLAIN job, where it holds. It does not hold here, and
+  // the difference is invisible until a PR touches neither frontend nor rust.
+  const required = ['Viewer tests (shard 0)', 'Viewer tests (shard 1)'];
+  assert.deepEqual(
+    missingLanes(required, PR3581_ROLLUP),
+    required,
+    'without the alias map both shards read as never having run',
+  );
+  const aliases = matrixSkipAliases(WF);
+  assert.deepEqual(missingLanes(required, PR3581_ROLLUP, aliases), []);
+});
+
+test('the alias covers ONLY a skip: the template at any other state satisfies nothing', () => {
+  // A template name at `success` means a workflow really is publishing a literal
+  // `${{ ... }}` check, which is broken, not skipped. At `queued` the decision is
+  // not made yet, and calling that covered would let the poll stop mid-fan-out.
+  const aliases = matrixSkipAliases(WF);
+  const required = ['Viewer tests (shard 0)'];
+  for (const state of ['success', 'queued', 'in_progress', 'failure', '']) {
+    const rollup = [{ name: 'Viewer tests (shard ${{ matrix.shard }})', state }];
+    assert.deepEqual(missingLanes(required, rollup, aliases), required, `state "${state}"`);
+  }
+});
+
+test('the alias is not a blanket pass: a shard absent with NO check run of any kind still fails', () => {
+  const aliases = matrixSkipAliases(WF);
+  assert.deepEqual(
+    missingLanes(['Viewer tests (shard 0)'], [{ name: 'Detect changes', state: 'success' }], aliases),
+    ['Viewer tests (shard 0)'],
+    'this is the #3294 case the gate exists for, and it must be untouched',
+  );
+});
+
+test('a PLAIN job gets no alias, so nothing but its own name can satisfy it', () => {
+  // Giving a plain job an alias would be a real weakening: its skipped check run
+  // already carries the derived name, so an alias could only ever let some OTHER
+  // check stand in for it.
+  const aliases = matrixSkipAliases(WF);
+  assert.equal(aliases.has('Detect changes'), false);
+  assert.equal(aliases.has('unnamed-job'), false);
+  assert.deepEqual([...new Set(aliases.values())], ['Viewer tests (shard ${{ matrix.shard }})']);
+  assert.equal(aliases.size, 4, 'all four shards, and only those');
+});
+
+test('the REAL test.yml maps every viewer shard to the template the REAL rollup published', () => {
+  // The pairing that matters: the SAME workflow file the gate derives from must
+  // produce the alias for the SAME string PR #3581 was observed carrying. A
+  // hand-written template in a fixture would prove nothing about that string.
+  const aliases = matrixSkipAliases(
+    readFileSync(join(REPO_ROOT, '.github/workflows/test.yml'), 'utf8'),
+  );
+  for (const shard of [0, 1, 2, 3]) {
+    assert.equal(
+      aliases.get(`Viewer tests (shard ${shard})`),
+      'Viewer tests (shard ${{ matrix.shard }})',
+      `shard ${shard}`,
+    );
+  }
+  const observed = PR3581_ROLLUP.map((c) => c.name);
+  assert.ok(
+    observed.includes([...new Set(aliases.values())][0]),
+    'the derived template must be a string PR #3581 actually published',
+  );
+});
+
+test('the whole real required set survives the real skipped rollup', () => {
+  // End to end over the shipped config: the lanes test.yml publishes, against
+  // the rollup PR #3581 published, must leave only lanes that genuinely never
+  // appeared -- and the four viewer shards must not be among them.
+  const wf = readFileSync(join(REPO_ROOT, '.github/workflows/test.yml'), 'utf8');
+  const required = expandJobNames(wf, { exclude: CFG.excludeJobKeys ?? [] });
+  const missing = missingLanes(required, PR3581_ROLLUP, matrixSkipAliases(wf, { exclude: CFG.excludeJobKeys ?? [] }));
+  for (const shard of [0, 1, 2, 3]) {
+    assert.ok(!missing.includes(`Viewer tests (shard ${shard})`), `shard ${shard} must not be missing`);
+  }
+});
+
+test('a wholesale skip is REPORTED, never absorbed into a tick', () => {
+  const aliases = matrixSkipAliases(WF);
+  assert.deepEqual(
+    [...wholesaleSkippedTemplates(PR3581_ROLLUP, aliases)],
+    ['Viewer tests (shard ${{ matrix.shard }})'],
+  );
+  // And nothing is reported when nothing was skipped wholesale.
+  assert.equal(wholesaleSkippedTemplates([{ name: 'Detect changes', state: 'skipped' }], aliases).size, 0);
+});
+
+test('the poll does not wait out its budget on a matrix that was skipped wholesale', () => {
+  // Before the alias map this was the lived cost of the bug: the lanes could
+  // never appear, so the poll ran the full 900 s before failing.
+  let slept = 0;
+  const r = pollForLanes({
+    required: ['Viewer tests (shard 0)', 'Detect changes'],
+    aliases: matrixSkipAliases(WF),
+    initialState: { lanes: PR3581_ROLLUP },
+    fetchState: () => ({ lanes: PR3581_ROLLUP }),
+    deadline: Date.now() + 900_000,
+    pollSeconds: 30,
+    sleep: (ms) => { slept += ms; },
+  });
+  assert.equal(r.timedOut, false);
+  assert.equal(slept, 0, 'it returns on the first read');
 });
 
 test('the #3294 shape: only deploy/review lanes present -> every compile lane named missing', () => {

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -608,7 +608,7 @@ const LANE_APPEARED_SECONDS = [
 
 test('MEASURED on 2026-08-25/26: 900 s covered every lane APPEARANCE in THAT population', () => {
   // SCOPED TO ITS POPULATION ON PURPOSE. A later test re-measures on 2026-08-31
-  // and finds seven breaches of 900 s. The two do not contradict each other --
+  // and finds eight breaches of 900 s. The two do not contradict each other --
   // different runs, different day, a busier pool -- but a title claiming "every
   // observed" would, so it says which runs it observed.
   // THE METHODOLOGY HERE WAS WRONG ONCE, AND THE NUMBERS MOVED WHEN IT WAS

--- a/scripts/lib/pr-review-signal.test.mjs
+++ b/scripts/lib/pr-review-signal.test.mjs
@@ -591,10 +591,14 @@ test('the poll treats an EMPTY rollup as "nothing has appeared yet", never as se
 /**
  * Run creation to the LAST non-aggregate lane's `created_at`, in seconds, over
  * the 68 completed `test.yml` PR runs of 2026-08-25/26 that published the
- * aggregate. Shared by the three budget tests below, which read it in different
- * directions: what 900 s covered, what 420 s false-failed, and what a re-measure
- * on 2026-08-31 found it no longer covers.
+ * aggregate. Read by TWO tests below, in opposite directions: what 900 s covered
+ * on this population, and what 420 s false-failed on it. The 2026-08-31
+ * re-measure does NOT read it -- it is a different population and carries its
+ * own array, which is the whole reason the two disagree about 900 s.
  */
+/** The budget the workflow ships; asserted against the YAML below, not restated. */
+const BUDGET_SECONDS = 2400;
+
 const LANE_APPEARED_SECONDS = [
   161, 162, 162, 162, 163, 164, 164, 165, 165, 165, 166, 166, 167, 167, 167, 167, 167, 169, 169,
   170, 170, 170, 170, 171, 171, 171, 172, 172, 175, 176, 177, 187, 188, 189, 190, 193, 198, 204,
@@ -602,7 +606,11 @@ const LANE_APPEARED_SECONDS = [
   388, 403, 416, 423, 426, 450, 451, 522, 523, 542, 845,
 ];
 
-test('MEASURED: 900 s covers every observed lane APPEARANCE, and 420 s did not', () => {
+test('MEASURED on 2026-08-25/26: 900 s covered every lane APPEARANCE in THAT population', () => {
+  // SCOPED TO ITS POPULATION ON PURPOSE. A later test re-measures on 2026-08-31
+  // and finds seven breaches of 900 s. The two do not contradict each other --
+  // different runs, different day, a busier pool -- but a title claiming "every
+  // observed" would, so it says which runs it observed.
   // THE METHODOLOGY HERE WAS WRONG ONCE, AND THE NUMBERS MOVED WHEN IT WAS
   // FIXED. The first version of this constant measured `started_at` — when a
   // runner picked the job up. The gate does not wait for that. It polls for
@@ -634,45 +642,117 @@ test('MEASURED: 900 s covers every observed lane APPEARANCE, and 420 s did not',
   assert.equal(Number((900 / max).toFixed(2)), 1.07, 'tail margin, stated honestly');
 });
 
-test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 1800 s', () => {
+test('RE-MEASURED 2026-08-31: 900 s BREACHED, and the budget is now 2400 s', () => {
   // A 1.07x margin is one busy afternoon from being wrong, and this was that
-  // afternoon. Same methodology as above -- run creation to the LAST
-  // non-aggregate lane's `created_at` -- over the 22 most recent completed
-  // test.yml PR runs, with three PRs of this rollout in flight at once:
+  // afternoon.
+  //
+  // THE FIRST RE-MEASURE OF THIS WAS CENSORED, and the censoring hid exactly the
+  // runs it was taken to find. Filtering the run list on `status == completed`
+  // at an instant drops the runs that are slow BECAUSE THEY ARE STILL RUNNING --
+  // it removes the tail, which is the only part of the distribution a budget
+  // cares about. It excluded five runs, and they were the five slowest of the
+  // afternoon (1276, 1387, 1503, 1786, 2028 s), including PR #3584's own. The
+  // number that draft landed on, 1800 s, would not have covered the worst run of
+  // the day it was measured on. Caught in review.
+  //
+  // Uncensored: same methodology (run creation to the LAST non-aggregate lane's
+  // `created_at`) over the 45 completed test.yml PR runs of 2026-08-31, with 15
+  // more still queued at the time of the read and therefore not measurable --
+  // stated, because that is the same exclusion that went wrong above.
   const RE_MEASURED = [
-    15, 162, 166, 171, 176, 185, 201, 205, 211, 264, 264, 282, 290, 375, 391, 418, 469, 622, 660,
-    814, 906, 1527,
+    15, 162, 166, 166, 169, 170, 170, 171, 173, 174, 175, 176, 176, 183, 185, 200, 201, 205, 211,
+    238, 264, 264, 282, 290, 308, 314, 317, 333, 375, 391, 418, 469, 473, 622, 660, 712, 814, 824,
+    906, 1172, 1387, 1503, 1527, 1786, 2028,
   ];
-  assert.equal(RE_MEASURED.length, 22);
+  assert.equal(RE_MEASURED.length, 45);
 
-  // TWO breach 900 s. The 1527 s run is PR #3584's own: `Build packages + WASM`
-  // completed at 18:38:31 and the gate gave up at 18:37:50, so eight lanes sat
-  // behind `needs: build` and could not exist yet. Nothing had failed.
-  const breaching = RE_MEASURED.filter((t) => t > 900);
-  assert.deepEqual(breaching, [906, 1527], '900 s is no longer a covering budget');
+  // 900 s no longer covers this population, and neither does 1800 s.
+  assert.deepEqual(
+    RE_MEASURED.filter((t) => t > 900),
+    [906, 1172, 1387, 1503, 1527, 1786, 2028],
+    '900 s breaches seven of 45',
+  );
+  assert.deepEqual(RE_MEASURED.filter((t) => t > 1800), [2028], '1800 s still breaches the max');
+  assert.deepEqual(RE_MEASURED.filter((t) => t > BUDGET_SECONDS), [], 'the shipped budget covers all 45');
 
-  // WHY IT MOVED, and why raising the number is the right response rather than
-  // re-tuning it downward later: the gate polls for lane APPEARANCE, and a lane
-  // behind `needs:` cannot appear until its dependency finishes. So this budget
-  // is not measuring flakiness, it is measuring the BUILD, and the build gets
-  // slower exactly when the runner pool is busy -- which is when several PRs
-  // are open, which is when the gate matters most.
+  // Both directions. A budget that covers everything proves nothing on its own,
+  // so the old ones are pinned as genuinely failing the runs they are claimed to.
   for (const t of RE_MEASURED) {
-    const d = driver(completesAt(t * 1000));
-    assert.equal(poll(d, { deadline: 1800_000 }).timedOut, false, `${t}s must fit in 1800 s`);
+    assert.equal(poll(driver(completesAt(t * 1000)), { deadline: BUDGET_SECONDS * 1000 }).timedOut, false, `${t}s`);
   }
-  // Both directions. A budget that covers everything proves nothing on its own;
-  // this pins that the OLD one genuinely fails the two runs it is claimed to.
-  for (const t of breaching) {
-    const d = driver(completesAt(t * 1000));
-    assert.equal(poll(d, { deadline: 900_000 }).timedOut, true, `${t}s must NOT fit in 900 s`);
+  for (const t of [906, 2028]) {
+    assert.equal(poll(driver(completesAt(t * 1000)), { deadline: 900_000 }).timedOut, true, `${t}s vs 900 s`);
   }
-  assert.equal(Number((1800 / 1527).toFixed(2)), 1.18, 'the new tail margin, stated the same way');
+  assert.equal(poll(driver(completesAt(2028_000)), { deadline: 1800_000 }).timedOut, true, '2028s vs 1800 s');
 });
 
-test('MEASURED: the aggregate lane is excluded, and that is the load-bearing half', () => {
+/**
+ * WHAT THIS BUDGET ACTUALLY MEASURES, and it is NOT the build.
+ *
+ * An earlier draft of this file asserted it was "measuring the BUILD", which was
+ * reasoning, not measurement, and it was wrong. The job timings say the number
+ * is almost entirely RUNNER-POOL QUEUE:
+ *
+ *   run           queue before the first job started   build itself   queue share
+ *   33422274815   1837 s                               176 s          91%
+ *   33421389375   1350 s                               162 s          88%
+ *   33424176735   1090 s                               165 s          85%
+ *
+ * The build is a near-constant ~170 s. Making it faster would move this budget
+ * by seconds. That matters for the remedy: there is nothing to optimise here,
+ * and the quantity has NO CEILING -- queue depth grows with how many PRs are
+ * open, which is precisely when this gate is under load.
+ *
+ * STATED HOLE: a budget cannot bound an unbounded quantity, so this WILL breach
+ * again on a busy enough day. When it does, the gate reports "within the poll
+ * budget" rather than a bare absence, and the remedy is a re-run once the lanes
+ * exist -- correct, because nothing failed.
+ */
+test('the budget the WORKFLOW ships is the budget this file tested', () => {
+  // WITHOUT THIS, REVERTING THE SHIPPED VALUE LEAVES THE SUITE GREEN. Measured:
+  // putting `--timeout-seconds 900` and `timeout-minutes: 20` back -- the exact
+  // regression this work exists to fix -- passed all 129 tests, because the only
+  // budget any test named was a literal inside itself. Third instance today of
+  // the same shape: a value tested in one place and shipped from another. See
+  // the WIRING test in check-pr-review-signal.test.mjs.
+  const wf = readFileSync(join(REPO_ROOT, '.github/workflows/pr-review-signal.yml'), 'utf8');
+  const budget = /--timeout-seconds[ \t]+(\d+)/.exec(wf);
+  assert.ok(budget, 'the workflow must pass an explicit --timeout-seconds');
+  assert.equal(Number(budget[1]), BUDGET_SECONDS, 'shipped budget vs the one measured above');
 
-  // AND THE AGGREGATE EXCLUSION IS MORE LOAD-BEARING THAN 420-vs-900 EVER WAS.
+  // The JOB cap must exceed the gate's own deadline, or the job is killed first
+  // and the run reports `cancelled` -- the same word `cancel-in-progress`
+  // produces for a superseded run, so a red check with no verdict and no way to
+  // tell the two apart.
+  const jobCap = /timeout-minutes:[ \t]+(\d+)/.exec(wf);
+  assert.ok(jobCap, 'the job must carry a timeout-minutes');
+  // >= 5 minutes of slack. Measured on the real failing run: set-up 2 s,
+  // checkout 4 s, `node --test` 5 s, and 3 s of trailing reads after the poll
+  // returned -- about 15 s beyond the budget, so 5 minutes is generous rather
+  // than tight. The assertion is on the SLACK, not on either number, so raising
+  // the budget later without raising the cap fails here instead of silently
+  // producing a `cancelled` run.
+  assert.ok(
+    Number(jobCap[1]) * 60 - BUDGET_SECONDS >= 300,
+    `timeout-minutes ${jobCap[1]} leaves ${Number(jobCap[1]) * 60 - BUDGET_SECONDS}s over the ` +
+      `${BUDGET_SECONDS}s budget; at least 300 s required`,
+  );
+
+  // The poll interval bounds API cost: GITHUB_TOKEN is 1,000 requests/hour PER
+  // REPOSITORY, shared with every other workflow, and the tail is CORRELATED
+  // across PRs -- one busy pool slows every run at once, which is when the most
+  // pollers are running at their cap. At 15 s this budget would be 160 reads a
+  // run, so ~6 concurrent full-budget pollers exhaust the repository. Exhaustion
+  // makes the gate fail closed on GH_ERROR: red, for a reason unrelated to the
+  // diff. 30 s halves it, and costs 15 s of resolution on a 2400 s budget.
+  const interval = /--poll-seconds[ \t]+(\d+)/.exec(wf);
+  assert.ok(interval, 'the workflow must pass an explicit --poll-seconds');
+  assert.ok(Number(interval[1]) >= 30, 'a faster poll multiplies the rate-limit risk');
+  assert.ok(BUDGET_SECONDS / Number(interval[1]) <= 90, 'reads per run stay under ~90');
+});
+
+test('MEASURED: excluding the aggregate matters more than any budget, and 420 s false-failed 8', () => {
+  // THE AGGREGATE EXCLUSION IS MORE LOAD-BEARING THAN 420-vs-900 EVER WAS.
   // Same 68 runs, when `Build + WASM + Rust + Node` itself appeared: min 509,
   // median 894, max 2067 s. Requiring it would false-fail 33 of the 68 at a
   // 900 s budget — half of every green PR — which is why `excludeJobKeys`

--- a/scripts/pr-review-signal.config.json
+++ b/scripts/pr-review-signal.config.json
@@ -17,7 +17,7 @@
     "lane becomes PRESENT, which is what this gate polls for, not `started_at` -- from each",
     "run's own creation, over the 68 completed test.yml PR runs of 2026-08-25/26 that",
     "published it: the aggregate appeared at min 509, median 894, max 2067 seconds, with 33",
-    "of the 68 past the 900 s budget. The last NON-aggregate lane appeared at min 161,",
+    "of the 68 past the 900 s budget then in force. The last NON-aggregate lane appeared at min 161,",
     "median 190, p95 522, max 845 seconds: 0 of the 68 past it. Requiring the aggregate makes",
     "the wait a function of the SUITE's total runtime, which grows, and would false-fail half",
     "of every green PR; requiring only the lanes makes it a function of how fast GitHub",


### PR DESCRIPTION
`PR review signal` became a required check on `main` today. It then failed PR #3581, and the failure is real: the gate demanded four check-run names that **cannot exist** on that PR.

## What breaks

A GitHub Actions job with a `strategy.matrix` that is skipped by its job-level `if:` publishes **one** check run, under the **unexpanded** name, verbatim braces and all. Measured on #3581, a `.coderabbit.yaml`-only change:

```
Viewer tests (shard ${{ matrix.shard }})   COMPLETED / SKIPPED
```

and no `Viewer tests (shard 0..3)` anywhere in the rollup.

The gate expands `test.yml`'s matrix to four required names, so on any PR touching neither the `frontend` nor the `rust` path filters those four are unsatisfiable. That is every config-only, docs-only and backend-only PR, blocked by a required check whose stated remedy — "re-run the workflow" — cannot work, because nothing failed to spawn.

## Why it was invisible until now

The gate's docblock stated the premise and cited its evidence:

> Path filters and `if:` conditions do NOT remove a job from this set: GitHub publishes a skipped job as a check run with conclusion `skipped`. **Verified against PR #3305's rollup, which carries `Docs checks (docs-only PRs)` at SKIPPED.**

True, and the evidence is real — but `Docs checks` is a **plain** job, where a skipped run carries the same name a real one would. Nothing checked the matrix case. The test that should have caught it shared the blind spot exactly: `presence counts a SKIPPED lane` used a one-name lane called `'A'`.

Today's two merged PRs did not hit it because both carried a changeset, and `.changeset/**` is in the `frontend` filter, so their viewer shards genuinely ran.

## The fix

`matrixSkipAliases` maps each expanded name to its template; `missingLanes` treats a required name as present when its template appears at conclusion `skipped`. Not a weakening of the presence rule — the same rule, read off the check run GitHub actually published.

Deliberately excluded, each pinned by a mutation that kills the suite:

- **`skipped` and nothing else.** The template at `success` means a workflow really is publishing a literal `${{ }}` name, which is broken, not skipped; at `queued` the decision is not made yet, and counting it would let the poll stop mid-fan-out.
- **Plain jobs get no alias.** Their skipped run already carries the derived name, so an alias could only let some other check stand in for them.
- **A lane absent with no check run of either kind still fails.** That is the #3294 case the gate exists for, untouched.

## What review changed

Two rounds, both of which found the fix failing its own standard:

- **The wiring was untested.** Deleting the two `aliases` arguments that CI actually executes left all 122 tests green while the gate regressed completely. `pollForLanes` and `evaluate` no longer default the map — a missing one is `MISSING_ALIASES`, refused the way the config refuses a missing `mode` — and a static test reads the gate's source to assert every call passes it, moving the catch back to CI. That count assertion immediately earned itself by catching `evaluate`'s own definition matching the pattern.
- **A claim I had not measured.** The docblock said a failed `build` skipping `viewer-tests` could not produce a green verdict "because the failed dependency sits in the rollup non-green". Running it: exit 0, "All 16 required lane(s) are present". This gate never reads lane *state* for the presence verdict. What keeps such a PR red is branch protection, not this gate. Corrected and marked MEASURED.

## Stated hole

A wholesale skip is accepted without judging **why** the job was skipped, because nothing in the rollup says why. `if:` is one reason; an unsatisfied `needs:` is another. The skip is printed by name on every run, with the count of lanes it covered, rather than absorbed into a tick.

## Verification

Six mutations kill the suite: aliases ignored, any-state-counts-as-skipped, plain jobs aliased, live wiring deleted, offline wiring deleted, poll default restored.

By exit code, not by reading output:

| | exit | want |
|---|---|---|
| live gate on PR #3581 | 0 | 0 |
| shards absent outright | 1 | 1 |
| template present at `success` | 1 | 1 |
| malformed fixture `aliases` | 1 | 1 |

75 lib tests, 52 gate tests. Unblocks #3581.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended review-signal monitoring to allow more time for checks to complete, reducing premature timeout failures.
  * Improved handling of matrix check aliases during validation and polling.

* **Bug Fixes**
  * Skipped matrix templates are now reported separately and no longer incorrectly trigger missing-lane failures.
  * Invalid or missing alias data now fails safely with a clear validation result.
  * Preserved strict validation when checks are absent, unresolved, or have other statuses.

* **Tests**
  * Added regression coverage for skipped jobs, aliases, polling, exclusions, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->