### PR TITLE
feat(ci): turn the posted-review gate to enforcing, safely

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -164,7 +164,11 @@ jobs:
             --out "$RUNNER_TEMP/review-input.json" 2>&1 | tee "$RUNNER_TEMP/build.log"
           rc=${PIPESTATUS[0]}
           if [ "$rc" -ne 0 ]; then
-            if grep -q 'NO_FILES' "$RUNNER_TEMP/build.log"; then
+            # ANCHORED. `REVIEW_TOO_LARGE` interpolates a FILE PATH into its
+            # message, so an unanchored match would let a PR containing a path
+            # with `NO_FILES` in it, and too large to review, post a
+            # nothing-to-review marker over real reviewable content.
+            if grep -q '^❌ NO_FILES:' "$RUNNER_TEMP/build.log"; then
               echo "::notice::Nothing reviewable in this PR; skipping the lane."
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -178,7 +178,7 @@ jobs:
       # than floating: a reviewer whose behaviour changes under us is a reviewer
       # whose precision measurements mean nothing.
       - name: Install the reviewer CLI
-        if: steps.head.outputs.proceed == 'true' && steps.dedup.outputs.covered != 'true'
+        if: steps.head.outputs.proceed == 'true' && steps.dedup.outputs.covered != 'true' && steps.input.outputs.skip != 'true'
         run: npm install -g @anthropic-ai/claude-code@2.0.76
 
       # The model runs here, as a pure function: no tools, no shell, no MCP, no
@@ -207,6 +207,31 @@ jobs:
             --raw "$RUNNER_TEMP/raw-review.txt" \
             --input "$RUNNER_TEMP/review-input.json" \
             --out "$RUNNER_TEMP/findings.json"
+
+      # NOTHING REVIEWABLE STILL POSTS A MARKER, and that is not a formality.
+      # Without it a lockfile-only or generated-code-only PR gets no marker at
+      # all, and `review-posted.yml` under `mode: enforcing` reports NOT_POSTED
+      # on a red row that NO re-run and NO author action can ever clear -- the
+      # lane would skip identically every time, while the gate's printed remedy
+      # says "re-run the review job". PR #3558 (a Cargo.lock-only dependabot
+      # bump) is a live instance of the class.
+      #
+      # It posts `verdict=nothing-to-review`, NOT `verdict=clean`. The model was
+      # never run here, so "there was nothing to review" and "reviewed it and
+      # found nothing" are different statements, and a `clean` marker would make
+      # an exclusion-list bug certify every PR it swallowed as reviewed.
+      - name: Say so when there was nothing to review
+        if: steps.head.outputs.proceed == 'true' && steps.dedup.outputs.covered != 'true' && steps.input.outputs.skip == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/review/post-review.mjs \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number }}" \
+            --sha "${{ github.event.pull_request.head.sha }}" \
+            --nothing-to-review \
+            --author github-actions \
+            --config "${{ steps.basecfg.outputs.path }}"
 
       # The marker is written LAST, and only after the inline comments have been
       # read back off the PR. That ordering is the whole answer to #1679.

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -339,7 +339,7 @@ export function evaluate({ comments, cfg, headSha }) {
       '   REMEDY: re-run the review job. If it recurs, read the run log for `Posted 0/N` or a low',
       '   `num_turns` and attach it to the upstream issue rather than re-running indefinitely.',
     );
-    return { ok: false, verdict: 'NOT_POSTED', lines };
+    return { ok: false, covered: false, verdict: 'NOT_POSTED', lines };
   }
 
   const markers = [];
@@ -368,7 +368,7 @@ export function evaluate({ comments, cfg, headSha }) {
             '`<!-- ifc-lite-review sha=<40-hex> verdict=clean|findings|nothing-to-review count=<n> -->`.'
           : 're-run the review job.'),
     );
-    return { ok: false, verdict: sawUnparseable ? 'MARKER_MALFORMED' : 'NOT_POSTED', lines };
+    return { ok: false, covered: false, verdict: sawUnparseable ? 'MARKER_MALFORMED' : 'NOT_POSTED', lines };
   }
 
   const match = markers.find((m) => m.sha === headSha);
@@ -382,7 +382,7 @@ export function evaluate({ comments, cfg, headSha }) {
       '   timestamp: no timestamp survives normalisation, so the gate does not claim one.)',
       '   REMEDY: re-run the review job against the current head.',
     );
-    return { ok: false, verdict: 'STALE_REVIEW', lines };
+    return { ok: false, covered: false, verdict: 'STALE_REVIEW', lines };
   }
 
   // THE #1679 CROSS-CHECK. A marker claiming `verdict=findings count=N` while N
@@ -417,7 +417,7 @@ export function evaluate({ comments, cfg, headSha }) {
         '   REMEDY: re-run the review job. If it recurs, the run log will show `Posted 0/N`; attach',
         '   it to claude-code-action#1679 rather than re-running indefinitely.',
       );
-      return { ok: false, verdict: 'FINDINGS_NOT_POSTED', escapeHatch: null, lines };
+      return { ok: false, covered: false, verdict: 'FINDINGS_NOT_POSTED', escapeHatch: null, lines };
     }
   }
 
@@ -430,10 +430,19 @@ export function evaluate({ comments, cfg, headSha }) {
         'exclusion-list bug would then do it silently for every PR it swallowed.'
       : `✅ REVIEW_POSTED: an expected reviewer posted a ${match.verdict} verdict for ${headSha.slice(0, 9)}` +
         `${match.verdict === 'findings' ? ` with ${match.count} finding(s)` : ''}.`,
-    '   This proves a review REACHED the pull request for this exact commit. It proves nothing',
-    '   about whether the review was any good; precision is a separate instrument.',
+    match.verdict === 'nothing-to-review'
+      ? '   COVERED=FALSE, though: nobody read this diff, so CodeRabbit must NOT stand down on it.'
+      : '   This proves a review REACHED the pull request for this exact commit.',
+    '   It proves nothing about whether the review was any good; precision is a separate',
+    '   instrument.',
   );
-  return { ok: true, verdict: 'REVIEW_POSTED', lines };
+  // `ok` AND `covered` ARE DIFFERENT QUESTIONS, and conflating them was a hole.
+  // `ok` is "should this check go red"; `covered` is "has this head been REVIEWED",
+  // which is what `review-posted.yml` turns into the `claude-reviewed` label and
+  // what `.coderabbit.yaml` reads to stand down. A `nothing-to-review` head has
+  // NOT been reviewed -- the model never ran -- so standing CodeRabbit down on it
+  // would leave the PR reviewed by NOBODY. Raised by CodeRabbit on PR #3587.
+  return { ok: true, covered: match.verdict !== 'nothing-to-review', verdict: 'REVIEW_POSTED', lines };
 }
 
 /**
@@ -517,6 +526,20 @@ function fetchPayload(repo, pr) {
  * execute, which is the shape this repository keeps paying for.
  */
 function isForkPr(repo, pr, override) {
+  // NO REPO, NO VERDICT. `args.repo` is only refused inside the live branch, so
+  // in `--state-file` mode it can be null -- and `headRepo !== null` is true for
+  // every value, which would excuse EVERY failing verdict. The invariant belongs
+  // here rather than in the harness's discipline of always passing `--repo`:
+  // discipline is prose holding two things together, and this gate exists
+  // because that does not hold. Raised by CodeRabbit on PR #3587.
+  if (typeof repo !== 'string' || repo === '') {
+    throw new ReviewPostedError(
+      'NO_REPO',
+      'The fork check needs a repository to compare the head against, and none was resolved. ' +
+        'Pass `--repo owner/name` or set GITHUB_REPOSITORY. Without it every failing verdict would ' +
+        'read as a fork and be excused, which is a gate that cannot fail.',
+    );
+  }
   const data =
     override === undefined
       ? gh(['api', `repos/${repo}/pulls/${pr}`, '--method', 'GET'], 'the PR head repo', ReviewPostedError)
@@ -530,7 +553,11 @@ function isForkPr(repo, pr, override) {
         'marker, and guessing "fork" would silently downgrade the gate on every PR.',
     );
   }
-  return headRepo !== repo;
+  // CASE-INSENSITIVE. GitHub repository names are case-insensitive, and `--repo`
+  // is caller-supplied: `ltplus-ag/ifc-lite` against a head repo of
+  // `LTplus-AG/ifc-lite` would otherwise read as a FORK and turn enforcement off
+  // for every PR. Same normalisation the author matching already uses.
+  return headRepo.toLowerCase() !== repo.toLowerCase();
 }
 
 function main() {
@@ -622,7 +649,7 @@ function main() {
   if (waited > 0) console.log(`Waited ${waited}s for a verdict to appear.`);
   console.log('');
 
-  const { ok, lines } = result;
+  const { ok, covered, lines } = result;
   for (const l of lines) console.log(l);
 
   // `covered` is the VERDICT, independent of the exit code, and the two differ on
@@ -631,7 +658,7 @@ function main() {
   // covered. Anything downstream that acts on "was this reviewed" -- the
   // CodeRabbit stand-down label, above all -- must read THIS, never `$?`.
   if (process.env.GITHUB_OUTPUT) {
-    appendFileSync(process.env.GITHUB_OUTPUT, `covered=${ok ? 'true' : 'false'}\n`);
+    appendFileSync(process.env.GITHUB_OUTPUT, `covered=${covered ? 'true' : 'false'}\n`);
   }
 
   // FORK PRs ARE NEVER ENFORCED, in either mode, and the reason is the same one

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -323,7 +323,11 @@ export function normaliseComments(payload) {
  * The verdict. `ok` is true only when an expected author posted a well-formed
  * marker naming exactly `headSha`.
  *
- * @returns {{ ok: boolean, verdict: string, lines: string[] }}
+ * @returns {{ ok: boolean, covered: boolean, verdict: string, lines: string[] }}
+ *   `ok` is "should this check go red"; `covered` is "has this head been
+ *   REVIEWED", which is what the workflow turns into the `claude-reviewed` label
+ *   and what CodeRabbit reads to stand down. They differ on exactly one verdict:
+ *   `nothing-to-review` is ok and NOT covered, because nothing read the diff.
  */
 export function evaluate({ comments, cfg, headSha }) {
   const lines = [];

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -43,7 +43,7 @@
  * THE ONE THING IT DOES ACCEPT is a marker the reviewer writes at the END of a
  * successful post, naming the exact commit it reviewed:
  *
- *     <!-- ifc-lite-review sha=<40-hex> verdict=clean|findings count=<n> -->
+ *     <!-- ifc-lite-review sha=<40-hex> verdict=clean|findings|nothing-to-review count=<n> -->
  *
  * THE CONTRACT THIS IMPLIES, and it is the load-bearing half: THE REVIEWER MUST
  * POST ON EVERY RUN, INCLUDING WHEN IT FINDS NOTHING. A reviewer that stays
@@ -136,7 +136,7 @@ const PER_PAGE = 100;
  * both ends and tolerant of surrounding whitespace only -- a loose pattern here
  * would let a contributor hand-write a passing marker into a PR comment.
  */
-export const MARKER_RE = /<!--\s*ifc-lite-review\s+sha=([0-9a-f]{40})\s+verdict=(clean|findings)\s+count=(\d+)\s*-->/;
+export const MARKER_RE = /<!--\s*ifc-lite-review\s+sha=([0-9a-f]{40})\s+verdict=(clean|findings|nothing-to-review)\s+count=(\d+)\s*-->/;
 
 /** Block the runner without a dependency. This job's whole purpose is to wait. */
 function sleepSync(ms) {
@@ -365,7 +365,7 @@ export function evaluate({ comments, cfg, headSha }) {
       '   REMEDY: ' +
         (sawUnparseable
           ? 'fix the reviewer\'s marker writer; the expected form is ' +
-            '`<!-- ifc-lite-review sha=<40-hex> verdict=clean|findings count=<n> -->`.'
+            '`<!-- ifc-lite-review sha=<40-hex> verdict=clean|findings|nothing-to-review count=<n> -->`.'
           : 're-run the review job.'),
     );
     return { ok: false, verdict: sawUnparseable ? 'MARKER_MALFORMED' : 'NOT_POSTED', lines };
@@ -422,8 +422,14 @@ export function evaluate({ comments, cfg, headSha }) {
   }
 
   lines.push(
-    `✅ REVIEW_POSTED: an expected reviewer posted a ${match.verdict} verdict for ${headSha.slice(0, 9)}` +
-      `${match.verdict === 'findings' ? ` with ${match.count} finding(s)` : ''}.`,
+    match.verdict === 'nothing-to-review'
+      ? `✅ REVIEW_POSTED: the reviewer reached ${headSha.slice(0, 9)} and reported NOTHING TO REVIEW — ` +
+        'every changed path is excluded (lockfiles, generated code, snapshots, fixtures, build output). ' +
+        'That is a decision the lane made and POSTED, not a statement that the diff was read and is fine. ' +
+        'The distinction is the point: a `clean` marker here would certify these PRs as reviewed, and an ' +
+        'exclusion-list bug would then do it silently for every PR it swallowed.'
+      : `✅ REVIEW_POSTED: an expected reviewer posted a ${match.verdict} verdict for ${headSha.slice(0, 9)}` +
+        `${match.verdict === 'findings' ? ` with ${match.count} finding(s)` : ''}.`,
     '   This proves a review REACHED the pull request for this exact commit. It proves nothing',
     '   about whether the review was any good; precision is a separate instrument.',
   );
@@ -489,6 +495,42 @@ function fetchPayload(repo, pr) {
     out[key] = rows;
   }
   return out;
+}
+
+/**
+ * Is this PR from a FORK? Asked of the API, never taken from the caller.
+ *
+ * It matters because the lane cannot post on a fork: claude-review.yml excludes
+ * fork PRs outright, since a fork's GITHUB_TOKEN is read-only whatever
+ * `permissions:` says. So under `mode: enforcing` every fork PR would be a
+ * NOT_POSTED red that no re-run and no contributor action could ever clear --
+ * the same unclearable-red class as a PR with nothing reviewable in it, and the
+ * worst possible greeting for an outside contributor.
+ *
+ * NOT read from the workflow. `review-posted.yml` runs from the PR's own
+ * checkout, so a flag passed there would be a flag a fork PR could edit. This
+ * asks the API.
+ *
+ * `headRepo` in a `--state-file` payload overrides the read, and ONLY there.
+ * That is what makes this branch reachable by the harness at all: gating it on
+ * `!args.stateFile` would have shipped an enforcement carve-out no test could
+ * execute, which is the shape this repository keeps paying for.
+ */
+function isForkPr(repo, pr, override) {
+  const data =
+    override === undefined
+      ? gh(['api', `repos/${repo}/pulls/${pr}`, '--method', 'GET'], 'the PR head repo', ReviewPostedError)
+      : { head: { repo: { full_name: override } } };
+  const headRepo = data?.head?.repo?.full_name;
+  if (typeof headRepo !== 'string' || headRepo === '') {
+    throw new ReviewPostedError(
+      'NO_HEAD_REPO',
+      `PR #${pr} returned no head repository, so this gate cannot tell a fork from a branch. It refuses ` +
+        'rather than guess: guessing "not a fork" would enforce against a PR that can never post a ' +
+        'marker, and guessing "fork" would silently downgrade the gate on every PR.',
+    );
+  }
+  return headRepo !== repo;
 }
 
 function main() {
@@ -601,6 +643,23 @@ function main() {
     console.log(
       'ADVISORY MODE: the finding above does not fail this job. Set `mode` to "enforcing" in ' +
         'scripts/review-posted.config.json once the reviewer lane is trusted.',
+    );
+    process.exit(0);
+  }
+
+  // FORK PRs ARE NEVER ENFORCED, in either mode, and the reason is the same one
+  // that makes an unreviewable PR post a marker rather than nothing: the lane
+  // CANNOT run here, so the red would be permanent and no contributor could
+  // clear it. Reported in full so it is not silence -- the verdict text above is
+  // unchanged -- but it does not fail the job. Checked only when the verdict is
+  // already failing, so the extra API read is not paid on the common path.
+  if (!ok && isForkPr(args.repo, args.pr, args.stateFile ? payload?.headRepo : undefined)) {
+    console.log('');
+    console.log(
+      'FORK PR: the finding above does not fail this job. `claude-review.yml` excludes fork PRs, because ' +
+        "a fork's GITHUB_TOKEN is read-only whatever `permissions:` says, so no marker can ever be posted " +
+        'here and enforcing would be a red nobody can clear. These PRs are covered by the CodeRabbit lane, ' +
+        'which is why the stand-down label is never applied to them.',
     );
     process.exit(0);
   }

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -634,6 +634,25 @@ function main() {
     appendFileSync(process.env.GITHUB_OUTPUT, `covered=${ok ? 'true' : 'false'}\n`);
   }
 
+  // FORK PRs ARE NEVER ENFORCED, in either mode, and the reason is the same one
+  // that makes an unreviewable PR post a marker rather than nothing: the lane
+  // CANNOT run here, so the red would be permanent and no contributor could
+  // clear it. Reported in full so it is not silence -- the verdict text above is
+  // unchanged -- but it does not fail the job. Checked only when the verdict is
+  // already failing, so THIS gate does not pay the extra API read on its common
+  // path. `claude-review.yml`'s dedup step is different: a failing verdict IS its
+  // common case, so once the base config is `enforcing` every lane run pays one
+  // `gh api pulls/<n>` there. One call, named rather than left to be discovered.
+  if (!ok && isForkPr(args.repo, args.pr, args.stateFile ? payload?.headRepo : undefined)) {
+    console.log('');
+    console.log(
+      'FORK PR: the finding above does not fail this job. `claude-review.yml` excludes fork PRs, because ' +
+        "a fork's GITHUB_TOKEN is read-only whatever `permissions:` says, so no marker can ever be posted " +
+        'here and enforcing would be a red nobody can clear. These PRs are covered by the CodeRabbit lane, ' +
+        'which is why the stand-down label is never applied to them.',
+    );
+    process.exit(0);
+  }
   // Advisory gates the EXIT CODE and nothing else. The verdict text is identical
   // in both modes, so a rollout state cannot quietly change what is reported. A
   // REFUSAL is a fact about this gate's inputs rather than a verdict on the PR,
@@ -647,22 +666,6 @@ function main() {
     process.exit(0);
   }
 
-  // FORK PRs ARE NEVER ENFORCED, in either mode, and the reason is the same one
-  // that makes an unreviewable PR post a marker rather than nothing: the lane
-  // CANNOT run here, so the red would be permanent and no contributor could
-  // clear it. Reported in full so it is not silence -- the verdict text above is
-  // unchanged -- but it does not fail the job. Checked only when the verdict is
-  // already failing, so the extra API read is not paid on the common path.
-  if (!ok && isForkPr(args.repo, args.pr, args.stateFile ? payload?.headRepo : undefined)) {
-    console.log('');
-    console.log(
-      'FORK PR: the finding above does not fail this job. `claude-review.yml` excludes fork PRs, because ' +
-        "a fork's GITHUB_TOKEN is read-only whatever `permissions:` says, so no marker can ever be posted " +
-        'here and enforcing would be a red nobody can clear. These PRs are covered by the CodeRabbit lane, ' +
-        'which is why the stand-down label is never applied to them.',
-    );
-    process.exit(0);
-  }
   process.exit(ok ? 0 : 1);
 }
 

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -46,10 +46,28 @@ function cfgWith(patch, tag) {
 const ENFORCING = cfgWith({}, 'enforcing-base');
 
 /** Run the gate over a payload exactly as written. */
+/**
+ * `headRepo` IS DEFAULTED HERE, and it is not cosmetic.
+ *
+ * The fork carve-out reads `head.repo.full_name` from the API when the payload
+ * does not carry one. Without this default every enforcement test made a live
+ * `gh api` call, and in CI the "Unit-test the gate itself" step has NO GH_TOKEN
+ * -- so `gh` refused, the gate exited 1, and every `assert.equal(r.code, 1)`
+ * passed on a CREDENTIAL ERROR rather than on enforcement. A regression turning
+ * `process.exit(ok ? 0 : 1)` into `exit(0)` would have been invisible. Caught in
+ * review; measured at 13 unstubbed calls in this file and 1 in post-review's.
+ *
+ * `--repo` travels with it: without one `args.repo` is null, and a defaulted
+ * `headRepo` would then read as a FORK and excuse every failing verdict.
+ * A payload that sets `headRepo` explicitly still overrides this, which is what
+ * keeps the fork and NO_HEAD_REPO cases reachable.
+ */
+const SAME_REPO = 'LTplus-AG/ifc-lite';
+
 function run(payload, extra = [...ENFORCING], sha = SHA) {
   const path = join(TMP, `payload-${(seq += 1)}.json`);
-  writeFileSync(path, JSON.stringify(payload));
-  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--sha', sha, '--state-file', path, ...extra], {
+  writeFileSync(path, JSON.stringify({ headRepo: SAME_REPO, ...payload }));
+  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--sha', sha, '--repo', SAME_REPO, '--state-file', path, ...extra], {
     encoding: 'utf8',
   });
   return { code: r.status, out: `${r.stdout}${r.stderr}` };
@@ -193,8 +211,8 @@ test('FAIL-CLOSED: a non-array comment list is BAD_PAYLOAD', () => {
 
 test('FAIL-CLOSED: a missing --sha refuses rather than deriving one', () => {
   const path = join(TMP, 'p-nosha.json');
-  writeFileSync(path, JSON.stringify(comments([REVIEWER, marker(SHA)])));
-  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--state-file', path, ...ENFORCING], { encoding: 'utf8' });
+  writeFileSync(path, JSON.stringify({ headRepo: SAME_REPO, ...comments([REVIEWER, marker(SHA)]) }));
+  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--repo', SAME_REPO, '--state-file', path, ...ENFORCING], { encoding: 'utf8' });
   assert.equal(r.status, 1);
   assert.match(`${r.stdout}${r.stderr}`, /NO_SHA/);
 });
@@ -323,8 +341,8 @@ test('the SHIPPED config is the one the gate validates', () => {
   // passes a temp COPY, so a shipped config its own validator rejects would be
   // invisible to all of them.
   const path = join(TMP, 'p-shipped.json');
-  writeFileSync(path, JSON.stringify(comments([REVIEWER, marker(SHA)])));
-  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--sha', SHA, '--state-file', path], { encoding: 'utf8' });
+  writeFileSync(path, JSON.stringify({ headRepo: SAME_REPO, ...comments([REVIEWER, marker(SHA)]) }));
+  const r = spawnSync(process.execPath, [GATE, '--pr', '1', '--sha', SHA, '--repo', SAME_REPO, '--state-file', path], { encoding: 'utf8' });
   const out = `${r.stdout}${r.stderr}`;
   assert.doesNotMatch(out, /BAD_CONFIG/, 'the shipped config must pass its own validator');
   assert.ok(Array.isArray(SHIPPED.expectedAuthors) && SHIPPED.expectedAuthors.length > 0);
@@ -379,10 +397,10 @@ test('the `covered` output tracks the VERDICT, not the exit code', () => {
 
   const runWithOutput = (payload, cfgArgs) => {
     writeFileSync(outPath, '');
-    writeFileSync(payloadPath, JSON.stringify(payload));
+    writeFileSync(payloadPath, JSON.stringify({ headRepo: SAME_REPO, ...payload }));
     const r = spawnSync(
       process.execPath,
-      [GATE, '--pr', '1', '--sha', SHA, '--state-file', payloadPath, ...cfgArgs],
+      [GATE, '--pr', '1', '--sha', SHA, '--repo', SAME_REPO, '--state-file', payloadPath, ...cfgArgs],
       { encoding: 'utf8', env: { ...process.env, GITHUB_OUTPUT: outPath } },
     );
     return { code: r.status, out: readOut() };
@@ -406,10 +424,10 @@ test('a STALE review reports covered=false, so the stand-down label is cleared',
   const outPath = join(TMP, `ghout-stale-${(seq += 1)}.txt`);
   const payloadPath = join(TMP, `p-stale-${seq}.json`);
   writeFileSync(outPath, '');
-  writeFileSync(payloadPath, JSON.stringify(comments([REVIEWER, marker(OTHER_SHA)])));
+  writeFileSync(payloadPath, JSON.stringify({ headRepo: SAME_REPO, ...comments([REVIEWER, marker(OTHER_SHA)]) }));
   const r = spawnSync(
     process.execPath,
-    [GATE, '--pr', '1', '--sha', SHA, '--state-file', payloadPath, ...ENFORCING],
+    [GATE, '--pr', '1', '--sha', SHA, '--repo', SAME_REPO, '--state-file', payloadPath, ...ENFORCING],
     { encoding: 'utf8', env: { ...process.env, GITHUB_OUTPUT: outPath } },
   );
   assert.equal(r.status, 1);
@@ -451,9 +469,7 @@ test('ENFORCING: a fork PR reports the finding in full and does NOT fail the job
   // one, and enforcing would be a permanent red no outside contributor could
   // clear -- the worst possible greeting, for a class the lane deliberately
   // does not serve.
-  const r = run({ headRepo: 'someone-else/ifc-lite', issueComments: [], reviewComments: [], reviews: [] }, [
-    ...ENFORCING, '--repo', 'LTplus-AG/ifc-lite',
-  ]);
+  const r = run({ headRepo: 'someone-else/ifc-lite', issueComments: [], reviewComments: [], reviews: [] });
   assert.equal(r.code, 0, r.out);
   assert.match(r.out, /NOT_POSTED/, 'the verdict text is unchanged: this is a carve-out, not silence');
   assert.match(r.out, /FORK PR/);
@@ -463,9 +479,7 @@ test('ENFORCING: a fork PR reports the finding in full and does NOT fail the job
 test('ENFORCING: a SAME-REPO PR with the same payload still fails', () => {
   // The anti-vacuity pair. Without it the test above would pass for any reason,
   // including the gate having stopped enforcing altogether.
-  const r = run({ headRepo: 'LTplus-AG/ifc-lite', issueComments: [], reviewComments: [], reviews: [] }, [
-    ...ENFORCING, '--repo', 'LTplus-AG/ifc-lite',
-  ]);
+  const r = run({ headRepo: 'LTplus-AG/ifc-lite', issueComments: [], reviewComments: [], reviews: [] });
   assert.equal(r.code, 1, r.out);
   assert.match(r.out, /NOT_POSTED/);
   assert.doesNotMatch(r.out, /FORK PR/);
@@ -479,7 +493,7 @@ test('a fork PR that DID somehow get a marker is a pass, not a carve-out', () =>
     issueComments: [{ user: { login: REVIEWER }, body: marker(SHA) }],
     reviewComments: [],
     reviews: [],
-  }, [...ENFORCING, '--repo', 'LTplus-AG/ifc-lite']);
+  });
   assert.equal(r.code, 0, r.out);
   assert.match(r.out, /REVIEW_POSTED/);
   assert.doesNotMatch(r.out, /FORK PR/);
@@ -491,9 +505,7 @@ test('FAIL CLOSED: an unreadable head repository REFUSES rather than guessing ei
   // PR. So it refuses, in both modes -- a refusal is a fact about this gate's
   // inputs, not a verdict on the diff.
   for (const headRepo of ['', null, 42, []]) {
-    const r = run({ headRepo, issueComments: [], reviewComments: [], reviews: [] }, [
-      ...ENFORCING, '--repo', 'LTplus-AG/ifc-lite',
-    ]);
+    const r = run({ headRepo, issueComments: [], reviewComments: [], reviews: [] });
     assert.equal(r.code, 1, `headRepo=${JSON.stringify(headRepo)}: ${r.out}`);
     assert.match(r.out, /NO_HEAD_REPO/, JSON.stringify(headRepo));
   }

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -510,3 +510,69 @@ test('FAIL CLOSED: an unreadable head repository REFUSES rather than guessing ei
     assert.match(r.out, /NO_HEAD_REPO/, JSON.stringify(headRepo));
   }
 });
+
+// ================================ `covered` is not the same question as `ok`
+
+test('nothing-to-review PASSES but reports covered=FALSE, so CodeRabbit does not stand down', () => {
+  // The hole this closes: `review-posted.yml` turns `covered` into the
+  // `claude-reviewed` label, and `.coderabbit.yaml` skips labelled PRs. A
+  // nothing-to-review head was never READ by anything, so claiming coverage
+  // would stand CodeRabbit down too and leave the PR reviewed by NOBODY.
+  const outPath = join(TMP, `ghout-ntr-${(seq += 1)}.txt`);
+  const payloadPath = join(TMP, `p-ntr-${seq}.json`);
+  writeFileSync(outPath, '');
+  writeFileSync(
+    payloadPath,
+    JSON.stringify({ headRepo: SAME_REPO, ...comments([REVIEWER, marker(SHA, 'nothing-to-review', 0)]) }),
+  );
+  const r = spawnSync(
+    process.execPath,
+    [GATE, '--pr', '1', '--sha', SHA, '--repo', SAME_REPO, '--state-file', payloadPath, ...ENFORCING],
+    { encoding: 'utf8', env: { ...process.env, GITHUB_OUTPUT: outPath } },
+  );
+  assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+  assert.match(readFileSync(outPath, 'utf8'), /covered=false/, 'nobody read this diff');
+  assert.match(`${r.stdout}${r.stderr}`, /COVERED=FALSE/);
+});
+
+test('a REAL clean review reports covered=true, or the stand-down never happens at all', () => {
+  // The anti-vacuity pair: if `covered` were false for everything, the test above
+  // would pass while the whole stand-down mechanism was dead.
+  const outPath = join(TMP, `ghout-clean-${(seq += 1)}.txt`);
+  const payloadPath = join(TMP, `p-clean-${seq}.json`);
+  writeFileSync(outPath, '');
+  writeFileSync(payloadPath, JSON.stringify({ headRepo: SAME_REPO, ...comments([REVIEWER, marker(SHA)]) }));
+  const r = spawnSync(
+    process.execPath,
+    [GATE, '--pr', '1', '--sha', SHA, '--repo', SAME_REPO, '--state-file', payloadPath, ...ENFORCING],
+    { encoding: 'utf8', env: { ...process.env, GITHUB_OUTPUT: outPath } },
+  );
+  assert.equal(r.status, 0, `${r.stdout}${r.stderr}`);
+  assert.match(readFileSync(outPath, 'utf8'), /covered=true/);
+});
+
+test('the fork comparison is CASE-INSENSITIVE, or enforcement is off for everyone', () => {
+  // GitHub repo names are case-insensitive and `--repo` is caller-supplied, so
+  // `ltplus-ag/...` against a head repo of `LTplus-AG/...` would read as a fork
+  // and excuse every failing verdict.
+  const r = run({ headRepo: 'LTplus-AG/ifc-lite', issueComments: [], reviewComments: [], reviews: [] }, [
+    ...ENFORCING, '--repo', 'ltplus-ag/IFC-Lite',
+  ]);
+  assert.equal(r.code, 1, r.out);
+  assert.doesNotMatch(r.out, /FORK PR/, 'the same repo in another case is not a fork');
+});
+
+test('FAIL CLOSED: the fork check REFUSES when no repository was resolved', () => {
+  // `args.repo` is only refused inside the live branch, so a state-file run can
+  // reach here with null -- and `headRepo !== null` is true for every value,
+  // which would excuse every failing verdict. A gate that cannot fail.
+  const path = join(TMP, `p-norepo-${(seq += 1)}.json`);
+  writeFileSync(path, JSON.stringify({ headRepo: SAME_REPO, issueComments: [], reviewComments: [], reviews: [] }));
+  const r = spawnSync(
+    process.execPath,
+    [GATE, '--pr', '1', '--sha', SHA, '--state-file', path, ...ENFORCING],
+    { encoding: 'utf8', env: { ...process.env, GITHUB_REPOSITORY: '' } },
+  );
+  assert.equal(r.status, 1, `${r.stdout}${r.stderr}`);
+  assert.match(`${r.stdout}${r.stderr}`, /NO_REPO/);
+});

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -442,3 +442,59 @@ test('a marker must be an HTML COMMENT, not bare text a contributor can type', (
   assert.equal(r.code, 1, r.out);
   assert.match(r.out, /NOT_POSTED/);
 });
+
+// ============================================== fork PRs are never enforced
+
+test('ENFORCING: a fork PR reports the finding in full and does NOT fail the job', () => {
+  // `claude-review.yml` excludes fork PRs, because a fork's GITHUB_TOKEN is
+  // read-only whatever `permissions:` says. So no marker can EVER be posted on
+  // one, and enforcing would be a permanent red no outside contributor could
+  // clear -- the worst possible greeting, for a class the lane deliberately
+  // does not serve.
+  const r = run({ headRepo: 'someone-else/ifc-lite', issueComments: [], reviewComments: [], reviews: [] }, [
+    ...ENFORCING, '--repo', 'LTplus-AG/ifc-lite',
+  ]);
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /NOT_POSTED/, 'the verdict text is unchanged: this is a carve-out, not silence');
+  assert.match(r.out, /FORK PR/);
+  assert.match(r.out, /read-only/);
+});
+
+test('ENFORCING: a SAME-REPO PR with the same payload still fails', () => {
+  // The anti-vacuity pair. Without it the test above would pass for any reason,
+  // including the gate having stopped enforcing altogether.
+  const r = run({ headRepo: 'LTplus-AG/ifc-lite', issueComments: [], reviewComments: [], reviews: [] }, [
+    ...ENFORCING, '--repo', 'LTplus-AG/ifc-lite',
+  ]);
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+  assert.doesNotMatch(r.out, /FORK PR/);
+});
+
+test('a fork PR that DID somehow get a marker is a pass, not a carve-out', () => {
+  // The carve-out only ever suppresses a FAILING verdict. A fork that is covered
+  // passes on the merits, and must not be reported as excused.
+  const r = run({
+    headRepo: 'someone-else/ifc-lite',
+    issueComments: [{ user: { login: REVIEWER }, body: marker(SHA) }],
+    reviewComments: [],
+    reviews: [],
+  }, [...ENFORCING, '--repo', 'LTplus-AG/ifc-lite']);
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /REVIEW_POSTED/);
+  assert.doesNotMatch(r.out, /FORK PR/);
+});
+
+test('FAIL CLOSED: an unreadable head repository REFUSES rather than guessing either way', () => {
+  // Both guesses are wrong in a way that matters. "Not a fork" enforces against a
+  // PR that can never post a marker; "fork" silently downgrades the gate on every
+  // PR. So it refuses, in both modes -- a refusal is a fact about this gate's
+  // inputs, not a verdict on the diff.
+  for (const headRepo of ['', null, 42, []]) {
+    const r = run({ headRepo, issueComments: [], reviewComments: [], reviews: [] }, [
+      ...ENFORCING, '--repo', 'LTplus-AG/ifc-lite',
+    ]);
+    assert.equal(r.code, 1, `headRepo=${JSON.stringify(headRepo)}: ${r.out}`);
+    assert.match(r.out, /NO_HEAD_REPO/, JSON.stringify(headRepo));
+  }
+});

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -43,11 +43,27 @@
     "exits 1. Not defaulted in code: a missing value is a refusal, because defaulting",
     "would let a corrupted config silently downgrade the gate to a no-op.",
     "",
-    "SHIPS ADVISORY because the reviewer lane it adjudicates does not exist yet. This gate",
-    "is deliberately landed FIRST and separately: it is the piece that has to be trusted",
-    "before any reviewer can be, and building it after the reviewer would mean trusting the",
-    "reviewer's own report of itself in the interim. Flip to `enforcing` in the same PR",
-    "that turns the reviewer on."
+    "IT SHIPPED ADVISORY because the reviewer lane it adjudicates did not exist yet. That",
+    "gate was landed FIRST and separately (#3580): it is the piece that has to be trusted",
+    "before any reviewer can be, and building it after the reviewer would have meant",
+    "trusting the reviewer's own report of itself in the interim.",
+    "",
+    "NOW ENFORCING, with the lane live (#3582 merged, CLAUDE_REVIEW_ENABLED=true). From",
+    "here a head with no posted review is a RED check rather than a printed note.",
+    "",
+    "WHAT THIS DOES NOT BLOCK, stated so nobody reads more into the red than is there:",
+    "`Review posted` is NOT in main's required-status-checks ruleset, so an enforcing",
+    "failure is a visible row, not a merge block. That is deliberate for the first weeks:",
+    "the lane is new, its quota is a subscription rather than a contract, and a gate that",
+    "can halt the repository on a third party's capacity should earn that power by",
+    "running quietly first. Promote it to required once it has a track record.",
+    "",
+    "THE FAILURE MODES THAT ARE NOT THE AUTHOR'S FAULT, and what each looks like:",
+    "a drained model pool fails the lane job, so no marker is written and this gate says",
+    "NOT_POSTED; a fork PR never runs the lane at all and is excluded upstream. Neither",
+    "is a statement about the diff. If NOT_POSTED becomes routine rather than rare, the",
+    "answer is to turn the lane off or put this back to `advisory` -- not to ignore it,",
+    "which is the failure mode a noisy gate actually has."
   ],
-  "mode": "advisory"
+  "mode": "enforcing"
 }

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -77,7 +77,7 @@
     "IF NOT_POSTED BECOMES ROUTINE, the remedy is to put THIS back to `advisory`. Turning the",
     "lane off alone is the WRONG move, and worth stating because it is the reflex: this gate",
     "has no kill switch of its own, so `CLAUDE_REVIEW_ENABLED=false` stops the lane, leaves",
-    "the gate enforcing, and turns EVERY pull request red. Reaching for the lane's switch",
+    "the gate enforcing, and turns every NON-FORK pull request red. Reaching for the lane's switch",
     "during an incident would be the maximal version of the problem it was reached for."
   ],
   "mode": "enforcing"

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -28,15 +28,15 @@
     "claude"
   ],
   "$standDownComment": [
-    "THE CODERABBIT HALF IS NOT IN THIS REPOSITORY YET, and saying so matters.",
-    "The workflow applies a `claude-reviewed` label when this gate verifies a review,",
-    "and clears it on every new head. That label only does anything once",
-    ".coderabbit.yaml carries `auto_review.labels: ['!claude-reviewed']`, a negative",
-    "match. That file is edited by PR #3576 and a second edit here would conflict, so",
-    "it lands after #3576 does. Until then the label is inert and the `issues: write`",
-    "permission the workflow requests buys nothing. Stated rather than implied,",
-    "because a workflow comment asserting a config that does not exist is the kind of",
-    "claim this repository's gates exist to catch."
+    "THE CODERABBIT HALF LANDS WITH PR #3581, not #3576, and this comment said #3576.",
+    "The workflow applies a `claude-reviewed` label when this gate verifies a review, and",
+    "clears it on every new head. That label only does anything once .coderabbit.yaml",
+    "carries `auto_review.labels: ['!claude-reviewed']`, a negative match. #3576 edited",
+    "that file for other reasons; the `labels:` key is added by #3581. Until #3581 merges",
+    "the label is inert and the `issues: write` permission the workflow requests buys",
+    "nothing. Stated rather than implied, because a workflow comment asserting a config",
+    "that does not exist is the kind of claim this repository's gates exist to catch --",
+    "and this one had already gone stale once by naming the wrong PR."
   ],
   "$modeComment": [
     "ADVISORY or ENFORCING. Advisory prints the identical verdict and exits 0; enforcing",
@@ -58,12 +58,25 @@
     "can halt the repository on a third party's capacity should earn that power by",
     "running quietly first. Promote it to required once it has a track record.",
     "",
-    "THE FAILURE MODES THAT ARE NOT THE AUTHOR'S FAULT, and what each looks like:",
-    "a drained model pool fails the lane job, so no marker is written and this gate says",
-    "NOT_POSTED; a fork PR never runs the lane at all and is excluded upstream. Neither",
-    "is a statement about the diff. If NOT_POSTED becomes routine rather than rare, the",
-    "answer is to turn the lane off or put this back to `advisory` -- not to ignore it,",
-    "which is the failure mode a noisy gate actually has."
+    "THE FAILURE MODES THAT ARE NOT THE AUTHOR'S FAULT, and what each does now:",
+    "",
+    "  - NOTHING REVIEWABLE (lockfiles, generated code, snapshots, fixtures, build output).",
+    "    The lane posts `verdict=nothing-to-review` and this gate PASSES. Before that marker",
+    "    existed the lane posted nothing, and enforcing would have made every such PR a red",
+    "    that no re-run and no author action could clear -- PR #3558, a Cargo.lock-only",
+    "    dependabot bump, is a live instance of the class.",
+    "  - FORK PR. The lane cannot run there (a fork's GITHUB_TOKEN is read-only whatever",
+    "    `permissions:` says), so no marker is possible. This gate reports the finding in full",
+    "    and does NOT fail the job, in either mode. Fork PRs stay on the CodeRabbit lane.",
+    "  - DRAINED MODEL POOL. The lane job fails, no marker is written, this gate says",
+    "    NOT_POSTED and goes red. That one IS a real red and it is the point of the gate: it",
+    "    is exactly the state where a review did not happen and nothing else says so.",
+    "",
+    "IF NOT_POSTED BECOMES ROUTINE, the remedy is to put THIS back to `advisory`. Turning the",
+    "lane off alone is the WRONG move, and worth stating because it is the reflex: this gate",
+    "has no kill switch of its own, so `CLAUDE_REVIEW_ENABLED=false` stops the lane, leaves",
+    "the gate enforcing, and turns EVERY pull request red. Reaching for the lane's switch",
+    "during an incident would be the maximal version of the problem it was reached for."
   ],
   "mode": "enforcing"
 }

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -28,15 +28,17 @@
     "claude"
   ],
   "$standDownComment": [
-    "THE CODERABBIT HALF LANDS WITH PR #3581, not #3576, and this comment said #3576.",
-    "The workflow applies a `claude-reviewed` label when this gate verifies a review, and",
-    "clears it on every new head. That label only does anything once .coderabbit.yaml",
-    "carries `auto_review.labels: ['!claude-reviewed']`, a negative match. #3576 edited",
-    "that file for other reasons; the `labels:` key is added by #3581. Until #3581 merges",
-    "the label is inert and the `issues: write` permission the workflow requests buys",
-    "nothing. Stated rather than implied, because a workflow comment asserting a config",
-    "that does not exist is the kind of claim this repository's gates exist to catch --",
-    "and this one had already gone stale once by naming the wrong PR."
+    "THE CODERABBIT HALF IS LIVE. `.coderabbit.yaml` carries",
+    "`auto_review.labels: ['!claude-reviewed']`, a negative match, since PR #3581 merged",
+    "on 2026-08-31. The workflow applies a `claude-reviewed` label when this gate verifies",
+    "a review and clears it on every new head, so CodeRabbit now stands down on exactly",
+    "the heads this lane has covered and reviews the rest.",
+    "",
+    "THIS COMMENT HAS BEEN WRONG TWICE, which is the reason it is this specific. It first",
+    "said the label was inert 'until #3576', naming the wrong PR; then it said 'until",
+    "#3581 merges', which expired the moment #3581 merged. A comment asserting the state",
+    "of a config in ANOTHER file goes stale silently -- there is nothing to fail when it",
+    "does -- so check `.coderabbit.yaml` rather than trusting this paragraph."
   ],
   "$modeComment": [
     "ADVISORY or ENFORCING. Advisory prints the identical verdict and exits 0; enforcing",

--- a/scripts/review/post-review.mjs
+++ b/scripts/review/post-review.mjs
@@ -592,6 +592,25 @@ function main() {
   // no inline anything. See `nothingToReviewBody` for why this is a verdict of
   // its own and not `clean`.
   if (args.nothingToReview) {
+    // A REAL VERDICT FOR THIS HEAD OUTRANKS THIS ONE. `upsertAndVerify` finds a
+    // carrier by sha alone, so without this it would PATCH an existing
+    // `verdict=findings count=3` summary into "nothing to review / count=0" --
+    // orphaning three inline comments and stepping around the
+    // FINDINGS_NOT_POSTED cross-check that exists to catch exactly that gap.
+    // Reachable only if the exclusion outcome flipped for one head, which needs
+    // dedup to have failed; narrow, and a downgrade this file must never make.
+    const existing = fetchSurface(args.repo, args.pr, `issues/${args.pr}/comments`).find((c) => {
+      const m = MARKER_RE.exec(String(c?.body ?? ''));
+      return normaliseLogin(c?.user?.login) === author && m?.[1] === args.sha && m[2] !== 'nothing-to-review';
+    });
+    if (existing) {
+      throw new PostReviewError(
+        'WOULD_DOWNGRADE_VERDICT',
+        `A \`${MARKER_RE.exec(existing.body)[2]}\` marker already stands for ${args.sha.slice(0, 9)}. ` +
+          'Overwriting it with `nothing-to-review` would retract a real verdict and orphan any inline ' +
+          'findings under it. Refused. REMEDY: this head was reviewed; nothing to do.',
+      );
+    }
     const liveHead = fetchHeadSha(args.repo, args.pr);
     if (liveHead !== args.sha) {
       console.log(

--- a/scripts/review/post-review.mjs
+++ b/scripts/review/post-review.mjs
@@ -604,12 +604,20 @@ function main() {
       return normaliseLogin(c?.user?.login) === author && m?.[1] === args.sha && m[2] !== 'nothing-to-review';
     });
     if (existing) {
-      throw new PostReviewError(
-        'WOULD_DOWNGRADE_VERDICT',
-        `A \`${MARKER_RE.exec(existing.body)[2]}\` marker already stands for ${args.sha.slice(0, 9)}. ` +
-          'Overwriting it with `nothing-to-review` would retract a real verdict and orphan any inline ' +
-          'findings under it. Refused. REMEDY: this head was reviewed; nothing to do.',
+      // REPORTED, AND EXIT 0. The refusal is right -- overwriting a real verdict
+      // would retract it and orphan any inline findings under it -- but THROWING
+      // was wrong: it reddens the lane job for a state that needs no action, the
+      // gate is already satisfied by the standing marker, and no re-run could
+      // ever clear it. That is precisely the unclearable-red class this branch
+      // exists to remove, reintroduced by its own guard. Raised by CodeRabbit on
+      // PR #3587.
+      console.log(
+        `WOULD_DOWNGRADE_VERDICT: a \`${MARKER_RE.exec(existing.body)[2]}\` marker already stands for ` +
+          `${args.sha.slice(0, 9)}. Overwriting it with \`nothing-to-review\` would retract a real ` +
+          'verdict and orphan any inline findings under it, so nothing was posted. This head IS ' +
+          'covered and the gate reads it; there is nothing to do.',
       );
+      process.exit(0);
     }
     const liveHead = fetchHeadSha(args.repo, args.pr);
     if (liveHead !== args.sha) {

--- a/scripts/review/post-review.mjs
+++ b/scripts/review/post-review.mjs
@@ -183,6 +183,9 @@ const FLAGS = new Map([
   ['--config', 'config'],
 ]);
 
+/** Flags that take NO value. Kept separate so the value-consuming loop stays strict. */
+const BOOL_FLAGS = new Map([['--nothing-to-review', 'nothingToReview']]);
+
 /** @param {string[]} argv */
 export function parseArgs(argv) {
   const out = {
@@ -192,8 +195,14 @@ export function parseArgs(argv) {
     findings: null,
     author: null,
     config: DEFAULT_CONFIG,
+    nothingToReview: false,
   };
   for (let i = 0; i < argv.length; i += 1) {
+    const boolKey = BOOL_FLAGS.get(argv[i]);
+    if (boolKey) {
+      out[boolKey] = true;
+      continue;
+    }
     const key = FLAGS.get(argv[i]);
     if (!key) throw new PostReviewError('BAD_ARGS', `Unrecognised argument \`${argv[i]}\`.`);
     const v = argv[i + 1];
@@ -294,6 +303,40 @@ export function fingerprint(path, line, body) {
 /** The marker the gate parses. Built in exactly one place; proved against the real gate by the harness. */
 export function marker(sha, verdict, count) {
   return `<!-- ifc-lite-review sha=${sha} verdict=${verdict} count=${count} -->`;
+}
+
+/**
+ * The comment for a head with NOTHING REVIEWABLE in it.
+ *
+ * WHY THIS IS NOT `verdict=clean`. A lockfile-only or generated-code-only PR
+ * makes `build-review-input.mjs` exit NO_FILES, so the model is never run. The
+ * honest statement about that head is "there was nothing to review", and it is
+ * NOT the same statement as "reviewed it and found nothing". Collapsing the two
+ * is the exact failure this whole system exists to prevent: if the exclusion
+ * list ever grows a bug that swallows real source, a `clean` marker would
+ * certify every one of those PRs as reviewed, silently, forever.
+ *
+ * So it gets its own verdict token. The gate accepts it as evidence that the
+ * LANE REACHED THIS HEAD and made a decision -- which is the question the gate
+ * actually asks -- and prints it as its own outcome rather than as a pass.
+ *
+ * The alternative was to leave these PRs with no marker at all. Under
+ * `mode: enforcing` that is a red row no re-run and no author action can ever
+ * clear, on a class that recurs (PR #3558, a Cargo.lock-only dependabot bump),
+ * with a printed remedy -- "re-run the review job" -- that cannot work.
+ */
+export function nothingToReviewBody(sha) {
+  const short = sha.slice(0, 9);
+  return [
+    `### Claude review - nothing to review for \`${short}\``,
+    '',
+    'Every changed path in this diff is excluded from review: lockfiles, generated',
+    'code, snapshots, fixtures and build output. The reviewer was NOT run, so this',
+    'is not a statement that the diff is fine -- it is a statement that there was',
+    'nothing here for it to read.',
+    '',
+    marker(sha, 'nothing-to-review', 0),
+  ].join('\n');
 }
 
 /** The one-line index entry for a finding. */
@@ -440,6 +483,57 @@ function postFinding(repo, pr, sha, f, n, total) {
   return res;
 }
 
+/**
+ * Write the marker comment and PROVE it is readable afterwards.
+ *
+ * ONE COPY, used by both the review path and the nothing-to-review path. The
+ * read-back is the whole contract this file exists to keep -- "it posted, trust
+ * me" is exactly the claim the gate refuses -- so a second path that wrote a
+ * marker without verifying it would be a hole in the shape of the bug.
+ *
+ * Idempotent by construction: a marker already written for THIS head is updated
+ * in place. Two markers for one sha would leave the gate reading whichever came
+ * first in fetch order, which is not a decision anyone made.
+ */
+function upsertAndVerify({ repo, pr, sha, author, body, want }) {
+  const carrier = fetchSurface(repo, pr, `issues/${pr}/comments`).find(
+    (c) =>
+      normaliseLogin(c?.user?.login) === author &&
+      MARKER_RE.exec(String(c?.body ?? ''))?.[1] === sha,
+  );
+  const res = carrier
+    ? gh(
+        ['api', `repos/${repo}/issues/comments/${carrier.id}`, '--method', 'PATCH', '-f', `body=${body}`],
+        'the review summary (update in place)',
+        PostReviewError,
+      )
+    : gh(
+        ['api', `repos/${repo}/issues/${pr}/comments`, '--method', 'POST', '-f', `body=${body}`],
+        'the review summary',
+        PostReviewError,
+      );
+  if (!res || res.id === undefined || res.id === null) {
+    throw new PostReviewError(
+      'SUMMARY_POST_FAILED',
+      'The marker comment returned no comment id, so the gate has nothing to read. REMEDY: check that the ' +
+        'posting workflow has write access to the pull request, then re-run.',
+    );
+  }
+  const readable = fetchSurface(repo, pr, `issues/${pr}/comments`).some(
+    (c) => normaliseLogin(c?.user?.login) === author && String(c?.body ?? '').includes(want),
+  );
+  if (!readable) {
+    throw new PostReviewError(
+      'MARKER_NOT_READ_BACK',
+      `The marker \`${want}\` is not readable on PR #${pr} one GET after it was written. A marker this ` +
+        'script cannot read is one the gate may not be able to read either, and reporting success here ' +
+        'would be the exact "it posted, trust me" claim this file exists to refuse. REMEDY: re-run; if ' +
+        '`--author` is wrong the marker is on the PR under a different login, and the gate will keep ' +
+        'reading NOT_POSTED until the login is fixed.',
+    );
+  }
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
 
@@ -460,7 +554,16 @@ function main() {
         'here would let the marker name a commit different from the one the model was shown.',
     );
   }
-  if (!args.findings) throw new PostReviewError('BAD_ARGS', 'Pass `--findings <findings.json>`.');
+  if (!args.findings && !args.nothingToReview) {
+    throw new PostReviewError('BAD_ARGS', 'Pass `--findings <findings.json>` or `--nothing-to-review`.');
+  }
+  if (args.findings && args.nothingToReview) {
+    throw new PostReviewError(
+      'BAD_ARGS',
+      '`--nothing-to-review` and `--findings` are mutually exclusive: one says the model never ran, the ' +
+        'other carries what it produced. Passing both means the caller does not know which happened.',
+    );
+  }
   if (!args.author) {
     throw new PostReviewError(
       'BAD_ARGS',
@@ -481,6 +584,31 @@ function main() {
         'REMEDY: add the login to the config on the BASE branch -- that is the copy the gate reads -- or ' +
         'fix `--author`.',
     );
+  }
+
+  // THE NOTHING-TO-REVIEW PATH, taken before any findings handling because there
+  // are none by construction. It still checks the head first -- a marker for a
+  // dead head is one the gate calls STALE_REVIEW -- and it posts ONE comment and
+  // no inline anything. See `nothingToReviewBody` for why this is a verdict of
+  // its own and not `clean`.
+  if (args.nothingToReview) {
+    const liveHead = fetchHeadSha(args.repo, args.pr);
+    if (liveHead !== args.sha) {
+      console.log(
+        `SKIPPED_STALE: this run read ${args.sha.slice(0, 9)}; the PR head is now ${liveHead.slice(0, 9)}.`,
+      );
+      process.exit(0);
+    }
+    upsertAndVerify({
+      repo: args.repo,
+      pr: args.pr,
+      sha: args.sha,
+      author,
+      body: nothingToReviewBody(args.sha),
+      want: marker(args.sha, 'nothing-to-review', 0),
+    });
+    console.log(`Posted a nothing-to-review marker for ${args.sha.slice(0, 9)}.`);
+    process.exit(0);
   }
 
   // Read BEFORE the first network call. A malformed findings file must refuse
@@ -542,51 +670,16 @@ function main() {
     );
   }
 
-  // ------------------------------------------------------------------ STEP 4
+  // ------------------------------------------------------------------ STEP 4+5
   const verdict = confirmed === 0 ? 'clean' : 'findings';
-  const body = summaryBody({ sha: args.sha, findings, count: confirmed });
-  // Idempotent by construction: a marker we already wrote for THIS head is
-  // updated in place. Two markers for one sha would leave the gate reading
-  // whichever came first in fetch order, which is not a decision anyone made.
-  const carrier = fetchSurface(args.repo, args.pr, `issues/${args.pr}/comments`).find(
-    (c) =>
-      normaliseLogin(c?.user?.login) === author &&
-      MARKER_RE.exec(String(c?.body ?? ''))?.[1] === args.sha,
-  );
-  const res = carrier
-    ? gh(
-        ['api', `repos/${args.repo}/issues/comments/${carrier.id}`, '--method', 'PATCH', '-f', `body=${body}`],
-        'the review summary (update in place)',
-        PostReviewError,
-      )
-    : gh(
-        ['api', `repos/${args.repo}/issues/${args.pr}/comments`, '--method', 'POST', '-f', `body=${body}`],
-        'the review summary',
-        PostReviewError,
-      );
-  if (!res || res.id === undefined || res.id === null) {
-    throw new PostReviewError(
-      'SUMMARY_POST_FAILED',
-      'The marker comment returned no comment id, so the gate has nothing to read. REMEDY: check that the ' +
-        'posting workflow has write access to the pull request, then re-run.',
-    );
-  }
-
-  // ------------------------------------------------------------------ STEP 5
-  const want = marker(args.sha, verdict, confirmed);
-  const readable = fetchSurface(args.repo, args.pr, `issues/${args.pr}/comments`).some(
-    (c) => normaliseLogin(c?.user?.login) === author && String(c?.body ?? '').includes(want),
-  );
-  if (!readable) {
-    throw new PostReviewError(
-      'MARKER_NOT_READ_BACK',
-      `The marker \`${want}\` is not readable on PR #${args.pr} one GET after it was written. A marker this ` +
-        'script cannot read is one the gate may not be able to read either, and reporting success here ' +
-        'would be the exact "it posted, trust me" claim this file exists to refuse. REMEDY: re-run; if ' +
-        '`--author` is wrong the marker is on the PR under a different login, and the gate will keep ' +
-        'reading NOT_POSTED until the login is fixed.',
-    );
-  }
+  upsertAndVerify({
+    repo: args.repo,
+    pr: args.pr,
+    sha: args.sha,
+    author,
+    body: summaryBody({ sha: args.sha, findings, count: confirmed }),
+    want: marker(args.sha, verdict, confirmed),
+  });
 
   console.log(`Head: ${args.sha.slice(0, 9)}`);
   console.log(`Findings: ${findings.length} (posted ${posted}, already present ${skipped})`);

--- a/scripts/review/post-review.test.mjs
+++ b/scripts/review/post-review.test.mjs
@@ -184,6 +184,34 @@ function runPoster({ state = {}, findings = [], findingsRaw, findingsPath, args 
   };
 }
 
+
+/** The poster on the NOTHING-TO-REVIEW path: no findings file at all. */
+function runNothingToReview({ state = {}, sha = SHA, args = [], author = REVIEWER } = {}) {
+  const dir = join(TMP, `ntr-${(seq += 1)}`);
+  mkdirSync(dir);
+  const statePath = join(dir, 'state.json');
+  writeFileSync(
+    statePath,
+    JSON.stringify({
+      head: sha,
+      author: REVIEWER,
+      issueComments: [],
+      reviewComments: [],
+      calls: [],
+      nextId: 1000,
+      inlinePostCount: 0,
+      dropInlinePosts: [],
+      ...state,
+    }),
+  );
+  const r = spawnSync(
+    process.execPath,
+    [SCRIPT, '--pr', PR, '--repo', REPO, '--sha', sha, '--nothing-to-review', '--author', author, ...args],
+    { encoding: 'utf8', env: { ...process.env, PATH: `${BIN}:${process.env.PATH}`, FAKE_GH_STATE: statePath } },
+  );
+  return { code: r.status, out: `${r.stdout}${r.stderr}`, state: JSON.parse(readFileSync(statePath, 'utf8')) };
+}
+
 /** Re-run the poster against a world a previous run left behind. */
 function rerunPoster(statePath, findings, sha = SHA) {
   const fPath = join(TMP, `findings-rerun-${(seq += 1)}.json`);
@@ -686,4 +714,90 @@ test('the SHIPPED config is the one the poster runs against', () => {
   const r = runPoster({ findings: [] });
   assert.equal(r.code, 0, r.out);
   assert.ok(SHIPPED.expectedAuthors.includes(REVIEWER), 'the posting identity must be an expected author');
+});
+
+// ============================================ nothing to review is its OWN verdict
+
+test('END TO END: a nothing-to-review marker satisfies the REAL gate', () => {
+  // The defect this closes: a lockfile-only PR makes build-review-input exit
+  // NO_FILES, the lane skips posting, and under `mode: enforcing` the gate
+  // reports NOT_POSTED on a row NO re-run and NO author action can clear --
+  // the lane skips identically every time. PR #3558 is a live instance.
+  const r = runNothingToReview();
+  assert.equal(r.code, 0, r.out);
+  assert.match(allBodies(r.state), /verdict=nothing-to-review count=0/);
+  assert.equal(r.state.reviewComments.length, 0, 'no inline comments: nothing was read');
+
+  const g = runGate(r.state);
+  assert.equal(g.code, 0, g.out);
+  assert.match(g.out, /REVIEW_POSTED/);
+});
+
+test('the gate PRINTS it as its own outcome, never as "reviewed and clean"', () => {
+  // If this ever reads like a clean review, the distinction has collapsed and an
+  // exclusion-list bug would certify every PR it swallowed as reviewed.
+  const g = runGate(runNothingToReview().state);
+  assert.match(g.out, /NOTHING TO REVIEW/);
+  assert.match(g.out, /not a statement that the diff was read/);
+});
+
+test('it is NOT a `clean` marker, and that is the whole point', () => {
+  const bodies = allBodies(runNothingToReview().state);
+  assert.doesNotMatch(bodies, /verdict=clean/);
+  assert.match(bodies, /The reviewer was NOT run/);
+});
+
+test('a marker for a DEAD head is not written on this path either', () => {
+  // Same rule as the review path: a marker for a superseded head is one the gate
+  // calls STALE_REVIEW, and no re-run of this commit could clear it.
+  const r = runNothingToReview({ state: { head: 'b'.repeat(40) } });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /SKIPPED_STALE/);
+  assertNoMarker(r.state, 'a dead head must leave the PR marker-less');
+});
+
+test('the read-back guards this path too: an unreadable marker REFUSES', () => {
+  // The nothing-to-review path shares `upsertAndVerify` with the review path
+  // precisely so it cannot skip the read-back. A second writer that posted
+  // without verifying would be a hole in the shape of the bug this file exists
+  // to refuse.
+  const r = runNothingToReview({ state: { dropSummaryPost: true } });
+  assert.notEqual(r.code, 0, r.out);
+  assert.match(r.out, /MARKER_NOT_READ_BACK|SUMMARY_POST_FAILED/);
+});
+
+test('`--nothing-to-review` and `--findings` together are refused', () => {
+  // One says the model never ran; the other carries what it produced. A caller
+  // passing both does not know which happened, and guessing would be the
+  // absence-reads-as-success shape at the CLI.
+  const dir = join(TMP, `both-${(seq += 1)}`);
+  mkdirSync(dir);
+  const f = join(dir, 'f.json');
+  writeFileSync(f, '[]');
+  const r = spawnSync(
+    process.execPath,
+    [SCRIPT, '--pr', PR, '--repo', REPO, '--sha', SHA, '--findings', f, '--nothing-to-review', '--author', REVIEWER],
+    { encoding: 'utf8' },
+  );
+  assert.notEqual(r.status, 0);
+  assert.match(`${r.stdout}${r.stderr}`, /mutually exclusive/);
+});
+
+test('THE WIRING: the workflow actually takes this path when the input step skips', () => {
+  // Static, because nothing else can reach it: the lane needs a runner and a
+  // token. Without the step the bug returns silently, and the whole point of
+  // this change is that a red nobody can clear must not come back.
+  const wf = readFileSync(join(HERE, '..', '..', '.github/workflows/claude-review.yml'), 'utf8');
+  const step = wf.split('- name: Say so when there was nothing to review')[1];
+  assert.ok(step, 'the nothing-to-review step must exist in claude-review.yml');
+  const guard = step.split('run:')[0];
+  assert.match(guard, /steps\.input\.outputs\.skip == 'true'/, 'it must run ONLY on the skip path');
+  assert.match(step, /--nothing-to-review/);
+  // And the reviewing steps must NOT run on that path, or the model is invoked
+  // with nothing to read.
+  for (const other of ['Run the reviewer', 'Validate the findings', 'Post the review', 'Install the reviewer CLI']) {
+    const s2 = wf.split(`- name: ${other}`)[1];
+    assert.ok(s2, `${other} must exist`);
+    assert.match(s2.split('run:')[0], /skip != 'true'/, `${other} must be excluded on the skip path`);
+  }
 });

--- a/scripts/review/post-review.test.mjs
+++ b/scripts/review/post-review.test.mjs
@@ -238,11 +238,11 @@ function runGate(state, sha = SHA) {
   const p = join(TMP, `gate-state-${(seq += 1)}.json`);
   writeFileSync(
     p,
-    JSON.stringify({ issueComments: state.issueComments, reviewComments: state.reviewComments, reviews: [] }),
+    JSON.stringify({ headRepo: 'LTplus-AG/ifc-lite', issueComments: state.issueComments, reviewComments: state.reviewComments, reviews: [] }),
   );
   const r = spawnSync(
     process.execPath,
-    [GATE, '--pr', PR, '--sha', sha, '--state-file', p, '--config', ENFORCING_CFG],
+    [GATE, '--pr', PR, '--sha', sha, '--repo', 'LTplus-AG/ifc-lite', '--state-file', p, '--config', ENFORCING_CFG],
     { encoding: 'utf8' },
   );
   return { code: r.status, out: `${r.stdout}${r.stderr}` };
@@ -832,4 +832,18 @@ test('THE MATCHED PAIR: every identity the lane posts as is one the GATE accepts
         'Change BOTH or neither.',
     );
   }
+});
+
+test('a nothing-to-review run REFUSES to overwrite a real verdict for the same head', () => {
+  // `upsertAndVerify` finds its carrier by sha alone, so without a guard this
+  // would PATCH a `findings` summary into "nothing to review", retracting a real
+  // verdict and orphaning its inline comments.
+  const first = runPoster({ findings: [{ path: 'a.ts', line: 2, body: 'x' }] });
+  assert.equal(first.code, 0, first.out);
+  assert.match(allBodies(first.state), /verdict=findings/);
+
+  const second = runNothingToReview({ state: first.state });
+  assert.notEqual(second.code, 0, second.out);
+  assert.match(second.out, /WOULD_DOWNGRADE_VERDICT/);
+  assert.match(allBodies(second.state), /verdict=findings/, 'the real verdict must still stand');
 });

--- a/scripts/review/post-review.test.mjs
+++ b/scripts/review/post-review.test.mjs
@@ -842,8 +842,14 @@ test('a nothing-to-review run REFUSES to overwrite a real verdict for the same h
   assert.equal(first.code, 0, first.out);
   assert.match(allBodies(first.state), /verdict=findings/);
 
+  // EXIT 0, not a throw. The refusal is right; reddening the lane for a state
+  // that needs no action is not -- the gate is already satisfied by the standing
+  // marker, and no re-run could clear that red. Reintroducing the unclearable-red
+  // class inside the guard that removes it was the bug.
   const second = runNothingToReview({ state: first.state });
-  assert.notEqual(second.code, 0, second.out);
+  assert.equal(second.code, 0, second.out);
   assert.match(second.out, /WOULD_DOWNGRADE_VERDICT/);
+  assert.match(second.out, /nothing to do/);
   assert.match(allBodies(second.state), /verdict=findings/, 'the real verdict must still stand');
+  assert.doesNotMatch(allBodies(second.state), /nothing-to-review/, 'and must not be overwritten');
 });

--- a/scripts/review/post-review.test.mjs
+++ b/scripts/review/post-review.test.mjs
@@ -801,3 +801,35 @@ test('THE WIRING: the workflow actually takes this path when the input step skip
     assert.match(s2.split('run:')[0], /skip != 'true'/, `${other} must be excluded on the skip path`);
   }
 });
+
+test('THE MATCHED PAIR: every identity the lane posts as is one the GATE accepts', () => {
+  // THE PAIR HAS NO OTHER GATE, and this repository has been bitten by that shape
+  // before: two changes, each green alone, fatal together. The lane names the
+  // identity it posts as in `claude-review.yml` (`--author`); the gate names the
+  // identities whose marker counts in `review-posted.config.json`. Nothing else
+  // connects them, so changing ONE is a silent break -- every marker the lane
+  // writes becomes invisible, the gate reads NOT_POSTED on every head, and under
+  // `mode: enforcing` that is the whole repository red.
+  //
+  // Live instance at the time of writing: PR #3583 replaces `expectedAuthors`
+  // with a dedicated GitHub App that does not exist yet. Its own description says
+  // the gate then "correctly reports NOT_POSTED" -- true and harmless under
+  // advisory, and the entire repository under enforcing. This test is what turns
+  // that from a surprise into a red line in whichever PR lands second.
+  const wf = readFileSync(join(HERE, '..', '..', '.github/workflows/claude-review.yml'), 'utf8');
+  const authors = [...wf.matchAll(/--author\s+(\S+)/g)].map((m) => m[1]);
+  assert.ok(authors.length > 0, 'the lane must name the identity it posts as');
+
+  const cfg = JSON.parse(readFileSync(join(HERE, '..', 'review-posted.config.json'), 'utf8'));
+  const accepted = (cfg.expectedAuthors ?? []).map((a) => String(a).toLowerCase());
+  assert.ok(accepted.length > 0, 'the gate must name at least one accepted identity');
+
+  for (const a of authors) {
+    assert.ok(
+      accepted.includes(a.toLowerCase()),
+      `the lane posts as \`${a}\`, which the gate does not accept (${accepted.join(', ')}). ` +
+        'Every marker it writes would be invisible and the gate would read NOT_POSTED on every PR. ' +
+        'Change BOTH or neither.',
+    );
+  }
+});


### PR DESCRIPTION
The last piece of the reviewer-lane rollout. #3580 landed the posted-evidence gate in **advisory** mode and named the condition for flipping it: *"Flip to `enforcing` in the same PR that turns the reviewer on."* The reviewer is on — #3582 merged the lane and `CLAUDE_REVIEW_ENABLED=true` — so this is that flip.

**What changes**, verified by exit code rather than by reading output: the same `NOT_POSTED` verdict exits 0 under advisory and 1 under enforcing. A head with no posted review is a red check from here.

## The flip was not safe as written

Pre-flight review found two classes of red that **no re-run and no author action could ever clear**. Both are fixed here; without these the flip should not merge.

**1. A PR with nothing reviewable.** A lockfile-only or generated-code-only PR makes `build-review-input.mjs` exit `NO_FILES`; the lane skips and posts nothing; the gate says `NOT_POSTED` forever — while printing "re-run the review job", a remedy that cannot work, because the lane skips identically every time. PR #3558 (a `Cargo.lock`-only dependabot bump) is a live instance from the last 100 PRs.

The obvious fix was wrong. Posting `verdict=clean count=0` would conflate *"there was nothing to review"* with *"reviewed it and found nothing"*, so a future exclusion-list bug that swallowed real source would silently certify every PR it swallowed as reviewed. The lane posts a **third verdict**, `nothing-to-review`, which the gate accepts as evidence the lane *reached* this head and made a decision — the question the gate actually asks — and prints as its own outcome rather than as a pass.

**2. Fork PRs.** `claude-review.yml` excludes them, because a fork's `GITHUB_TOKEN` is read-only whatever `permissions:` says, so a marker is impossible there. Enforcing would have made every fork PR a permanent red — the worst possible greeting for an outside contributor, on a class the lane deliberately does not serve. The gate now reports the finding in full but does not fail the job for a fork, in either mode.

It asks the **API** whether the head repo differs rather than taking a flag: `review-posted.yml` runs from the PR's own checkout, so a flag would be one a fork PR could edit. An unreadable head repo *refuses* — "not a fork" enforces against a PR that can never comply, "fork" downgrades the gate on every PR, and both guesses are wrong in a way that matters.

This also discharges a precondition `review-posted.yml` had written down for itself: *"if this gate goes enforcing on fork PRs, pin the code to base as well."* It does not go enforcing on fork PRs.

## And my own remedy text was self-defeating

The config said the answer to routine `NOT_POSTED` is "turn the lane off or put this back to advisory". Turning the lane off is the **wrong half**: this gate has no kill switch of its own, so `CLAUDE_REVIEW_ENABLED=false` stops the lane, leaves the gate enforcing, and turns every non-fork PR red. As written it invited an operator to reach for the switch during an incident and make it repo-wide. Rewritten, with each not-the-author's-fault mode named and what it now does.

## A defect this branch introduced, and how it was caught

The fork carve-out made the gate's own unit tests call the live GitHub API — 14 unstubbed calls. In CI those run in a step with **no `GH_TOKEN`**, so `gh` refused, the gate exited 1, and every `assert.equal(r.code, 1)` passed on a **credential error** rather than on enforcement.

Measured both ways: mutating `process.exit(ok ? 0 : 1)` to `exit(0)` — the regression that silently disables the entire gate — **left the suite green before the fix and turns 14 tests red after it.** A `gh` shim counts 14 calls before, **zero** after.

It is fixed in the harness, deliberately *not* by gating the branch on `!args.stateFile`: that ships an enforcement carve-out no test can execute, which is the same disease one layer up.

## The sibling-PR landmine

PR #3583 is open against three of the same four files. It is **right** that `github-actions` is a shared workflow identity any same-repo PR workflow can forge, and binding evidence to a dedicated GitHub App is the correct direction. But it names an App that does not exist yet, and its own description says the gate then "correctly reports NOT_POSTED" — harmless under advisory, *every PR in the repository red* under enforcing.

The pair had no gate. A test now reads both files and fails if the lane posts as an identity the gate will not accept. Swapping the allowlist to the App turns 33 tests red instead of turning the repository red. It takes no side on which identity is right; it refuses to let the two halves disagree.

## Verification

| | |
|---|---|
| tests | 41 gate + 41 poster |
| network calls in those suites | **0** (was 14) |
| repo gates | 6, all pass |
| oxlint | 0 errors |

Mutations that turn the suite red: `exit(0)`, fork carve-out removed, downgrade guard removed, marker saying `clean`, workflow step deleted, step ungated from `skip == 'true'`, identity pair allowed to disagree, `isForkPr` forced true, `MARKER_RE` token dropped, read-back deleted, head check dropped.

The `nothing-to-review` path is idempotent (re-running over its own marker succeeds), and refuses to overwrite a real verdict for the same head (`WOULD_DOWNGRADE_VERDICT`) — otherwise it could retract a `findings` summary and orphan its inline comments past the `FINDINGS_NOT_POSTED` cross-check.

## Known transition noise

Every currently-open PR predates the lane, so none has a marker. They will show a red `Review posted` row until their next push. It self-heals, and `Review posted` is **not** in main's required-status-checks ruleset, so it is a visible row and not a merge block — deliberately, for the first weeks. Promoting it to required is a later decision with evidence behind it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests with no reviewable files now receive a clear “nothing to review” status.
  * Review checks better support forked pull requests when automated comments cannot be posted.
* **Bug Fixes**
  * Improved detection prevents filenames containing `NO_FILES` from incorrectly skipping reviews.
  * Review status validation now distinguishes clean results, findings, and nothing-to-review outcomes.
* **Documentation**
  * Updated review-check guidance and configuration details for the new outcomes and fork behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->