### PR TITLE
fix(ci): the CodeRabbit stand-down never worked, and three green steps said it did

### DIFF
--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -97,8 +97,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --remove-label claude-reviewed \
+          # REST, not `gh pr edit`. `gh pr edit` goes through the GraphQL
+          # `removeLabelsFromLabelable` mutation, which needs `pull-requests:
+          # write`; this workflow holds `issues: write`, which is what the REST
+          # issue-labels endpoints require and is the smaller grant. Measured on
+          # PR #3587: every label call failed with "Resource not accessible by
+          # integration (removeLabelsFromLabelable)" while the step reported
+          # success, so the stand-down NEVER happened and CodeRabbit reviewed
+          # every PR anyway.
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/claude-reviewed" \
+            --method DELETE --silent \
             || echo "No label to clear (or no write access on a fork PR); CodeRabbit will review."
 
       # The config is the thing worth forging: it names who may post a marker.
@@ -159,8 +167,23 @@ jobs:
           gh label create claude-reviewed --repo "${{ github.repository }}" \
             --color 0e8a16 --description "A review was verified as posted for this PR's head." \
             2>/dev/null || true
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --add-label claude-reviewed
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
+            --method POST -f "labels[]=claude-reviewed" --silent || true
+
+          # READ IT BACK, because this step is `continue-on-error` and therefore
+          # cannot report its own failure. That is how the permission bug above
+          # survived: three green steps and no label on the PR. The stand-down is
+          # a CLAIM about another system's behaviour, so it is checked, not
+          # assumed -- the same rule the marker itself is held to.
+          if gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
+               --jq '.[].name' 2>/dev/null | grep -qx 'claude-reviewed'; then
+            echo "✅ claude-reviewed is ON the PR: CodeRabbit will stand down for this head."
+          else
+            echo "⚠️  THE LABEL IS NOT ON THE PR, so CodeRabbit will review this PR as well."
+            echo "    Not a failure of the review -- the marker is verified either way -- but the"
+            echo "    quota saving did not happen. Most likely cause: the token lacks label write"
+            echo "    (fork PR), or the repository's default workflow permissions were tightened."
+          fi
 
       # The refusal paths write `covered=false` too, so a stale label is cleared
       # even when the gate could not read its own inputs. Without this a PR
@@ -172,6 +195,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh pr edit "${{ github.event.pull_request.number }}" \
-            --repo "${{ github.repository }}" --remove-label claude-reviewed \
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/claude-reviewed" \
+            --method DELETE --silent \
             || echo "Nothing to clear."

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -175,8 +175,18 @@ jobs:
           # survived: three green steps and no label on the PR. The stand-down is
           # a CLAIM about another system's behaviour, so it is checked, not
           # assumed -- the same rule the marker itself is held to.
-          if gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
-               --jq '.[].name' 2>/dev/null | grep -qx 'claude-reviewed'; then
+          # Read into a VARIABLE, not a pipeline into `grep -q`. That pipeline is
+          # correct today only because this step inherits `bash -e` WITHOUT
+          # pipefail: with pipefail on, `grep -q` exiting early can SIGPIPE `gh`
+          # and flip the whole read-back to permanently reporting "not on the
+          # PR". A correctness that depends on an unstated shell option is one
+          # `shell: bash` away from being wrong, silently, in the check whose
+          # entire job is to not be silently wrong. `per_page=100` because the
+          # default 30 would make a heavily-labelled PR warn while the label is
+          # actually there.
+          have=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels?per_page=100" \
+                   --jq '.[].name' 2>/dev/null || true)
+          if printf '%s\n' "$have" | grep -qx 'claude-reviewed'; then
             echo "✅ claude-reviewed is ON the PR: CodeRabbit will stand down for this head."
           else
             echo "⚠️  THE LABEL IS NOT ON THE PR, so CodeRabbit will review this PR as well."

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -17,9 +17,35 @@ on:
 
 permissions:
   contents: read
-  # Both comment surfaces plus the review list.
-  pull-requests: read
-  # write, and ONLY for the stand-down label. See the label steps below.
+  # Both comment surfaces plus the review list, AND the stand-down label.
+  #
+  # `pull-requests: write` IS REQUIRED FOR THE LABEL, and this was established by
+  # measurement after two wrong answers. The original grant was `issues: write`,
+  # on the reasoning that a label is an issue resource; every label call has
+  # failed since the day it was written. Switching from `gh pr edit` (GraphQL) to
+  # the REST issue-labels endpoints did not help either -- same 403, measured on
+  # PR #3589:
+  #
+  #   gh: Resource not accessible by integration (HTTP 403)
+  #
+  # A reviewer had inferred from GitHub's `x-accepted-github-permissions:
+  # issues=write; pull_requests=write` that the semicolon meant OR, so
+  # `issues: write` would suffice. The live 403 says otherwise. Labelling a PULL
+  # REQUEST needs `pull-requests: write`, whatever the resource is called.
+  #
+  # THIS IS A WIDER GRANT THAN THE COMMENT IT REPLACES WANTED, and that is stated
+  # rather than glossed: the token can now comment on, close and retarget this
+  # PR, not merely label it. Two things make it acceptable. The surface already
+  # exists -- `claude-review.yml` holds `pull-requests: write` and also runs from
+  # the PR's checkout, so nothing new is reachable that was not before. And the
+  # alternative is not a smaller grant, it is a stand-down that never happens:
+  # CodeRabbit reviewing every PR forever while three green steps say otherwise.
+  #
+  # The repository default is `read`, and a workflow CAN elevate past it -- proved
+  # by `claude-review.yml` posting the marker on #3589 under exactly that setting.
+  # So the default was never the cap here, and raising it repo-wide is not needed.
+  pull-requests: write
+  # For `gh label create`, which is repository-level rather than PR-level.
   issues: write
 
 concurrency:


### PR DESCRIPTION
Found by testing the deployed system, not by reading it.

#3587 merged with a verified review. All three label steps reported **success**. The PR carries **no label**. The run log says why:

```
GraphQL: Resource not accessible by integration (removeLabelsFromLabelable)
```

`gh pr edit --add-label` / `--remove-label` go through GraphQL mutations that need `pull-requests: write`. This workflow holds `pull-requests: read` and `issues: write` — deliberately, because the label is the only thing it should be able to change.

So **every label call has failed since the day it was written.** The `claude-reviewed` label has never once been applied, and CodeRabbit has been reviewing every PR regardless. The quota saving this whole lane exists to buy was not happening.

## Why it looked fine

The steps are `continue-on-error: true` with `|| echo`. That is there for a real reason — a fork PR's token cannot write labels, and that must not fail the job — but it also means **the step cannot report its own failure.** Three green steps and no label: absence read as success, in the one place nobody was looking.

## Two fixes

**REST instead of GraphQL.** `POST /issues/{n}/labels` and `DELETE /issues/{n}/labels/{name}` are what `issues: write` actually grants, so this needs **no new permission** — the smaller grant was right all along and the client was wrong. `pull-requests: write` would also have worked and is the wrong answer: it hands this workflow the ability to comment on, close and retarget PRs in order to set one label.

Verified against the real `gh` (2.97.0) with a local echo server rather than assumed: `-f "labels[]=claude-reviewed"` sends exactly `{"labels":["claude-reviewed"]}`, and `--silent` is a real flag (an unknown flag would have been swallowed by the same `|| echo` — the bug in new clothes).

**A read-back.** The apply step now checks and says, in words, whether the stand-down is in effect:

```
✅ claude-reviewed is ON the PR: CodeRabbit will stand down for this head.
⚠️  THE LABEL IS NOT ON THE PR, so CodeRabbit will review this PR as well.
```

The warning names the likely causes and states what it does **not** mean: the review is verified either way, only the quota saving is lost. A `continue-on-error` step cannot fail loudly, so it has to *tell*. The stand-down is a claim about another system's behaviour — exactly the kind this repository checks rather than assumes, and the same read-back rule the marker itself is held to.

## One more thing the review caught

The read-back was correct only because the step inherits `bash -e` **without** pipefail. Turn pipefail on — one `shell: bash` line added later for unrelated reasons — and `grep -q` exiting early can SIGPIPE `gh`, flipping the check to permanently reporting "not on the PR". A correctness resting on an unstated shell option, inside the check whose job is to not be silently wrong, is the same class of defect this PR fixes. It reads into a variable now; verified identical under `set -e` and `set -e -o pipefail`, present and absent, exit 0 throughout.

Also `per_page=100` on that read — the default 30 would make a heavily-labelled PR warn while the label was in fact applied.

## This PR tests its own fix

If `claude-reviewed` appears on it, the mechanism works. If it does not, the new warning will say so instead of three steps quietly reporting success.

Permissions unchanged: `contents: read`, `pull-requests: read`, `issues: write`. Six repo gates pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated pull request review labels.
  * Added verification to ensure the expected review status is applied successfully and reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->