### PR TITLE
fix(wasm): recover a literal -0 compound-plane-angle degree in the Rust legacy-site georef path

### DIFF
--- a/.changeset/wasm-georef-negative-zero-degree.md
+++ b/.changeset/wasm-georef-negative-zero-degree.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+Close the Rust residual left by the `@ifc-lite/parser` fix for `IfcSite.RefLatitude`/`RefLongitude` silently flipping a southern/western legacy-site georeference to northern/eastern when a writer signs a zero-magnitude compound-plane-angle degree token, e.g. `(-0, 30, 0)` for 0°30'S. The TS fix matched IEEE-754 negative zero directly (`parseFloat('-0') === -0`); the bundled Rust STEP tokenizer parses `IfcCompoundPlaneAngleMeasure` components through `i64`, which has no negative-zero representation, so the sign is lost before it ever reaches `compound_plane_angle_to_degrees`. `extract_from_site` now recovers it by re-scanning the entity's raw record bytes for the literal `-0` token on the `RefLatitude`/`RefLongitude` attribute pair only, instead of reworking the shared integer tokenizer that every other STEP integer attribute goes through.

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -652,9 +652,31 @@ impl GeoRefExtractor {
             // IfcSite: RefLatitude (9), RefLongitude (10), RefElevation (11).
             let latitude = Self::compound_plane_angle_to_degrees(&site, 9);
             let longitude = Self::compound_plane_angle_to_degrees(&site, 10);
-            let (Some(latitude), Some(longitude)) = (latitude, longitude) else {
+            let (Some(mut latitude), Some(mut longitude)) = (latitude, longitude) else {
                 continue;
             };
+
+            // The `-0` leniency (TS parity, see `compoundPlaneAngleToDecimalDegrees`
+            // in `georef-extractor.ts`): a writer that signs a zero-magnitude
+            // component of the compound angle (e.g. `(-0, 30, 0)` for 0°30'S)
+            // survives here only via the entity's RAW record bytes.
+            // `compound_plane_angle_to_degrees` above already lost that sign —
+            // its components come from `AttributeValue::Integer(i64)`, and the
+            // shared tokenizer's `integer()` parses `-0` through
+            // `lexical_core::parse::<i64>`, which has no negative-zero
+            // representation, so the sign never reaches `AttributeValue` at
+            // all. Re-scanning the raw bytes for this one legacy-site
+            // attribute pair (RefLatitude/RefLongitude only, not the hot
+            // tokenizer) recovers it without touching the shared integer path.
+            if let Some(bytes) = decoder.get_raw_bytes(*id) {
+                if latitude >= 0.0 && compound_angle_has_literal_negative_zero(bytes, 9) {
+                    latitude = -latitude;
+                }
+                if longitude >= 0.0 && compound_angle_has_literal_negative_zero(bytes, 10) {
+                    longitude = -longitude;
+                }
+            }
+
             let elevation = site.get_float(11).unwrap_or(0.0);
 
             let mut georef = GeoReference::new();
@@ -700,6 +722,98 @@ impl GeoRefExtractor {
         let millionths = millionths.abs();
         Some(sign * (degrees + minutes / 60.0 + (seconds + millionths / 1_000_000.0) / 3600.0))
     }
+}
+
+/// True if any component of the compound-plane-angle list at `attr_index`
+/// (0-based, matching `DecodedEntity::get`/`get_list` indexing) is the
+/// literal negative-zero integer token `-0` in `bytes` (an entity's raw
+/// record, `#N=TYPE(attr0,attr1,...);`).
+///
+/// This walks the raw bytes rather than re-tokenizing through the shared
+/// STEP tokenizer: `-0` reaches `AttributeValue::Integer` as plain `0` (see
+/// `compound_plane_angle_to_degrees`'s doc comment), so by the time an
+/// entity is decoded the sign is already gone. Restricted to this one
+/// legacy-site attribute pair — not a general-purpose STEP attribute
+/// splitter — so it stays correct without having to handle every literal
+/// shape the real tokenizer does (typed values, nested lists, comments).
+fn compound_angle_has_literal_negative_zero(bytes: &[u8], attr_index: usize) -> bool {
+    let Some(list_bytes) = nth_top_level_attribute(bytes, attr_index) else {
+        return false;
+    };
+    let trimmed = list_bytes.trim_ascii();
+    let Some(inner) = trimmed
+        .strip_prefix(b"(")
+        .and_then(|b| b.strip_suffix(b")"))
+    else {
+        return false;
+    };
+    inner
+        .split(|&b| b == b',')
+        .any(|component| component.trim_ascii() == b"-0")
+}
+
+/// The raw byte span of the `attr_index`-th (0-based) top-level attribute in
+/// an entity's raw record bytes, i.e. between the entity's own outer
+/// parentheses, split on commas at paren-depth 1 (quote-aware, so a comma or
+/// paren inside a string literal doesn't confuse the split).
+fn nth_top_level_attribute(bytes: &[u8], attr_index: usize) -> Option<&[u8]> {
+    let len = bytes.len();
+    // Skip to the entity's own opening '(' (after "#N=TYPE").
+    let mut i = 0;
+    while i < len && bytes[i] != b'(' {
+        i += 1;
+    }
+    if i >= len {
+        return None;
+    }
+    i += 1;
+
+    let mut depth: i32 = 1;
+    let mut in_string: Option<u8> = None;
+    let mut attr_start = i;
+    let mut attr_idx = 0usize;
+
+    while i < len {
+        let b = bytes[i];
+        if let Some(q) = in_string {
+            if b == q {
+                if i + 1 < len && bytes[i + 1] == q {
+                    i += 2; // doubled-quote escape stays inside the string
+                    continue;
+                }
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => {
+                in_string = Some(b);
+                i += 1;
+            }
+            b'(' => {
+                depth += 1;
+                i += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return (attr_idx == attr_index).then(|| &bytes[attr_start..i]);
+                }
+                i += 1;
+            }
+            b',' if depth == 1 => {
+                if attr_idx == attr_index {
+                    return Some(&bytes[attr_start..i]);
+                }
+                attr_idx += 1;
+                i += 1;
+                attr_start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 /// RTC (Relative-To-Center) coordinate handler for large coordinates

--- a/rust/core/src/georef.rs
+++ b/rust/core/src/georef.rs
@@ -12,6 +12,10 @@ use crate::error::Result;
 use crate::generated::IfcType;
 use crate::schema_gen::{AttributeValue, DecodedEntity};
 
+#[path = "georef_parse.rs"]
+mod georef_parse;
+use georef_parse::{compound_angle_has_literal_negative_zero, compound_plane_angle_to_degrees};
+
 /// Read an `IfcPropertySingleValue.NominalValue` (index 2) as a string,
 /// unwrapping the typed-value wrapper `IFCLABEL('…')` / `IFCIDENTIFIER('…')`
 /// (parsed as a `List([type-name, value])`) that plain `get_string` doesn't
@@ -650,8 +654,8 @@ impl GeoRefExtractor {
             }
             let site = decoder.decode_by_id(*id)?;
             // IfcSite: RefLatitude (9), RefLongitude (10), RefElevation (11).
-            let latitude = Self::compound_plane_angle_to_degrees(&site, 9);
-            let longitude = Self::compound_plane_angle_to_degrees(&site, 10);
+            let latitude = compound_plane_angle_to_degrees(&site, 9);
+            let longitude = compound_plane_angle_to_degrees(&site, 10);
             let (Some(mut latitude), Some(mut longitude)) = (latitude, longitude) else {
                 continue;
             };
@@ -693,127 +697,6 @@ impl GeoRefExtractor {
         }
         Ok(None)
     }
-
-    /// Convert an `IfcCompoundPlaneAngleMeasure` attribute (list of 3-4
-    /// integers: degrees, minutes, seconds, optional millionth-seconds) to
-    /// decimal degrees. Same sign handling as the TS parser: any negative
-    /// component makes the whole angle negative.
-    fn compound_plane_angle_to_degrees(entity: &DecodedEntity, index: usize) -> Option<f64> {
-        let list = entity.get_list(index)?;
-        let mut numbers = Vec::with_capacity(4);
-        for value in list {
-            if let Some(v) = value.as_float() {
-                numbers.push(v);
-            }
-        }
-        if numbers.len() < 3 {
-            return None;
-        }
-        let millionths = numbers.get(3).copied().unwrap_or(0.0);
-        let sign = if numbers[0] < 0.0 || numbers[1] < 0.0 || numbers[2] < 0.0 || millionths < 0.0
-        {
-            -1.0
-        } else {
-            1.0
-        };
-        let degrees = numbers[0].abs();
-        let minutes = numbers[1].abs();
-        let seconds = numbers[2].abs();
-        let millionths = millionths.abs();
-        Some(sign * (degrees + minutes / 60.0 + (seconds + millionths / 1_000_000.0) / 3600.0))
-    }
-}
-
-/// True if any component of the compound-plane-angle list at `attr_index`
-/// (0-based, matching `DecodedEntity::get`/`get_list` indexing) is the
-/// literal negative-zero integer token `-0` in `bytes` (an entity's raw
-/// record, `#N=TYPE(attr0,attr1,...);`).
-///
-/// This walks the raw bytes rather than re-tokenizing through the shared
-/// STEP tokenizer: `-0` reaches `AttributeValue::Integer` as plain `0` (see
-/// `compound_plane_angle_to_degrees`'s doc comment), so by the time an
-/// entity is decoded the sign is already gone. Restricted to this one
-/// legacy-site attribute pair — not a general-purpose STEP attribute
-/// splitter — so it stays correct without having to handle every literal
-/// shape the real tokenizer does (typed values, nested lists, comments).
-fn compound_angle_has_literal_negative_zero(bytes: &[u8], attr_index: usize) -> bool {
-    let Some(list_bytes) = nth_top_level_attribute(bytes, attr_index) else {
-        return false;
-    };
-    let trimmed = list_bytes.trim_ascii();
-    let Some(inner) = trimmed
-        .strip_prefix(b"(")
-        .and_then(|b| b.strip_suffix(b")"))
-    else {
-        return false;
-    };
-    inner
-        .split(|&b| b == b',')
-        .any(|component| component.trim_ascii() == b"-0")
-}
-
-/// The raw byte span of the `attr_index`-th (0-based) top-level attribute in
-/// an entity's raw record bytes, i.e. between the entity's own outer
-/// parentheses, split on commas at paren-depth 1 (quote-aware, so a comma or
-/// paren inside a string literal doesn't confuse the split).
-fn nth_top_level_attribute(bytes: &[u8], attr_index: usize) -> Option<&[u8]> {
-    let len = bytes.len();
-    // Skip to the entity's own opening '(' (after "#N=TYPE").
-    let mut i = 0;
-    while i < len && bytes[i] != b'(' {
-        i += 1;
-    }
-    if i >= len {
-        return None;
-    }
-    i += 1;
-
-    let mut depth: i32 = 1;
-    let mut in_string: Option<u8> = None;
-    let mut attr_start = i;
-    let mut attr_idx = 0usize;
-
-    while i < len {
-        let b = bytes[i];
-        if let Some(q) = in_string {
-            if b == q {
-                if i + 1 < len && bytes[i + 1] == q {
-                    i += 2; // doubled-quote escape stays inside the string
-                    continue;
-                }
-                in_string = None;
-            }
-            i += 1;
-            continue;
-        }
-        match b {
-            b'\'' | b'"' => {
-                in_string = Some(b);
-                i += 1;
-            }
-            b'(' => {
-                depth += 1;
-                i += 1;
-            }
-            b')' => {
-                depth -= 1;
-                if depth == 0 {
-                    return (attr_idx == attr_index).then(|| &bytes[attr_start..i]);
-                }
-                i += 1;
-            }
-            b',' if depth == 1 => {
-                if attr_idx == attr_index {
-                    return Some(&bytes[attr_start..i]);
-                }
-                attr_idx += 1;
-                i += 1;
-                attr_start = i;
-            }
-            _ => i += 1,
-        }
-    }
-    None
 }
 
 /// RTC (Relative-To-Center) coordinate handler for large coordinates

--- a/rust/core/src/georef_parse.rs
+++ b/rust/core/src/georef_parse.rs
@@ -1,0 +1,134 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Compound-plane-angle parsing helpers for `georef.rs`'s legacy
+//! `IfcSite.RefLatitude`/`RefLongitude` fallback.
+//!
+//! Split out of `georef.rs` to keep that module inside its module-size
+//! ratchet budget (matching the `georef_tests.rs` split for test code):
+//! these three functions are cohesive (all exist to turn a STEP
+//! `IfcCompoundPlaneAngleMeasure` list into signed decimal degrees) and are
+//! only ever called from `georef.rs::extract_from_site`.
+
+use crate::schema_gen::DecodedEntity;
+
+/// Convert an `IfcCompoundPlaneAngleMeasure` attribute (list of 3-4
+/// integers: degrees, minutes, seconds, optional millionth-seconds) to
+/// decimal degrees. Same sign handling as the TS parser: any negative
+/// component makes the whole angle negative.
+pub(super) fn compound_plane_angle_to_degrees(entity: &DecodedEntity, index: usize) -> Option<f64> {
+    let list = entity.get_list(index)?;
+    let mut numbers = Vec::with_capacity(4);
+    for value in list {
+        if let Some(v) = value.as_float() {
+            numbers.push(v);
+        }
+    }
+    if numbers.len() < 3 {
+        return None;
+    }
+    let millionths = numbers.get(3).copied().unwrap_or(0.0);
+    let sign = if numbers[0] < 0.0 || numbers[1] < 0.0 || numbers[2] < 0.0 || millionths < 0.0 {
+        -1.0
+    } else {
+        1.0
+    };
+    let degrees = numbers[0].abs();
+    let minutes = numbers[1].abs();
+    let seconds = numbers[2].abs();
+    let millionths = millionths.abs();
+    Some(sign * (degrees + minutes / 60.0 + (seconds + millionths / 1_000_000.0) / 3600.0))
+}
+
+/// True if any component of the compound-plane-angle list at `attr_index`
+/// (0-based, matching `DecodedEntity::get`/`get_list` indexing) is the
+/// literal negative-zero integer token `-0` in `bytes` (an entity's raw
+/// record, `#N=TYPE(attr0,attr1,...);`).
+///
+/// This walks the raw bytes rather than re-tokenizing through the shared
+/// STEP tokenizer: `-0` reaches `AttributeValue::Integer` as plain `0` (see
+/// `compound_plane_angle_to_degrees`'s doc comment above), so by the time an
+/// entity is decoded the sign is already gone. Restricted to this one
+/// legacy-site attribute pair — not a general-purpose STEP attribute
+/// splitter — so it stays correct without having to handle every literal
+/// shape the real tokenizer does (typed values, nested lists, comments).
+pub(super) fn compound_angle_has_literal_negative_zero(bytes: &[u8], attr_index: usize) -> bool {
+    let Some(list_bytes) = nth_top_level_attribute(bytes, attr_index) else {
+        return false;
+    };
+    let trimmed = list_bytes.trim_ascii();
+    let Some(inner) = trimmed
+        .strip_prefix(b"(")
+        .and_then(|b| b.strip_suffix(b")"))
+    else {
+        return false;
+    };
+    inner
+        .split(|&b| b == b',')
+        .any(|component| component.trim_ascii() == b"-0")
+}
+
+/// The raw byte span of the `attr_index`-th (0-based) top-level attribute in
+/// an entity's raw record bytes, i.e. between the entity's own outer
+/// parentheses, split on commas at paren-depth 1 (quote-aware, so a comma or
+/// paren inside a string literal doesn't confuse the split).
+fn nth_top_level_attribute(bytes: &[u8], attr_index: usize) -> Option<&[u8]> {
+    let len = bytes.len();
+    // Skip to the entity's own opening '(' (after "#N=TYPE").
+    let mut i = 0;
+    while i < len && bytes[i] != b'(' {
+        i += 1;
+    }
+    if i >= len {
+        return None;
+    }
+    i += 1;
+
+    let mut depth: i32 = 1;
+    let mut in_string: Option<u8> = None;
+    let mut attr_start = i;
+    let mut attr_idx = 0usize;
+
+    while i < len {
+        let b = bytes[i];
+        if let Some(q) = in_string {
+            if b == q {
+                if i + 1 < len && bytes[i + 1] == q {
+                    i += 2; // doubled-quote escape stays inside the string
+                    continue;
+                }
+                in_string = None;
+            }
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => {
+                in_string = Some(b);
+                i += 1;
+            }
+            b'(' => {
+                depth += 1;
+                i += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return (attr_idx == attr_index).then(|| &bytes[attr_start..i]);
+                }
+                i += 1;
+            }
+            b',' if depth == 1 => {
+                if attr_idx == attr_index {
+                    return Some(&bytes[attr_start..i]);
+                }
+                attr_idx += 1;
+                i += 1;
+                attr_start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}

--- a/rust/core/src/georef_tests.rs
+++ b/rust/core/src/georef_tests.rs
@@ -211,6 +211,38 @@ END-ISO-10303-21;
     );
 }
 
+/// The leniency applies to every component, matching the TypeScript parser:
+/// writers which carry a hemisphere sign on a zero-magnitude minute, second,
+/// or millionth-second component must not have that sign discarded by the
+/// Rust integer tokenizer.
+#[test]
+fn test_extract_from_site_honours_negative_zero_in_each_compound_angle_component_ref3546() {
+    let cases = [
+        // A negative-zero minute signs the following non-zero seconds.
+        ("(0,-0,30)", -(30.0 / 3600.0)),
+        // A negative-zero second signs the following non-zero millionths.
+        ("(0,0,-0,30)", -(30.0 / 1_000_000.0 / 3600.0)),
+        // A negative-zero millionth-second signs the preceding non-zero seconds.
+        ("(0,0,30,-0)", -(30.0 / 3600.0)),
+    ];
+
+    for (angle, expected_northings) in cases {
+        let ifc_content = format!(
+            "ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION(('Test'),'2;1');\nFILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n#1=IFCSITE('1abc',$,'Site',$,$,$,$,$,.ELEMENT.,{angle},(14,28,0),0.,$,$);\nENDSEC;\nEND-ISO-10303-21;\n"
+        );
+        let mut decoder = EntityDecoder::new(&ifc_content);
+        let georef = GeoRefExtractor::extract(&mut decoder, &[(1, IfcType::IfcSite)])
+            .expect("decode ok")
+            .expect("legacy site georeference extracted");
+
+        assert!(
+            (georef.northings - expected_northings).abs() < 1e-12,
+            "{angle} should produce {expected_northings}, got {}",
+            georef.northings
+        );
+    }
+}
+
 /// Control: the spec-canonical encoding (sign on the first NON-ZERO
 /// component) must keep working exactly as before — the `-0` leniency must
 /// never flip an already-correct sign.

--- a/rust/core/src/georef_tests.rs
+++ b/rust/core/src/georef_tests.rs
@@ -163,3 +163,109 @@ fn test_rtc_apply_z_channel_uses_z_offset() {
     assert!((positions[1] - 180.0).abs() < 1e-5);
     assert!((positions[2] - 270.0).abs() < 1e-5);
 }
+
+/// The `-0` leniency (#3546 residual): a writer that signs a zero-magnitude
+/// degree component of `IfcSite.RefLatitude`/`RefLongitude` (e.g. `(-0, 30,
+/// 0)` for 0°30'S) must still land the site in the correct hemisphere.
+///
+/// Unlike the TS `parseFloat`-based tokenizer (which keeps IEEE-754 `-0`),
+/// the Rust STEP tokenizer's `integer()` parses `-0` through
+/// `lexical_core::parse::<i64>`, which has no negative-zero representation,
+/// so `AttributeValue::Integer` never sees the sign at all —
+/// `compound_plane_angle_to_degrees` alone cannot recover it.
+/// `extract_from_site` closes the gap by re-scanning the entity's raw
+/// record bytes for the literal `-0` token, without touching the shared
+/// tokenizer. TS parity: the equivalent fixture in
+/// `packages/parser/test/georef-extractor.test.ts`.
+#[test]
+fn test_extract_from_site_honours_negative_zero_degree_ref3546() {
+    let ifc_content = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCSITE('1abc',$,'Site',$,$,$,$,$,.ELEMENT.,(-0,30,0),(-0,45,0),0.,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    let mut decoder = EntityDecoder::new(ifc_content);
+    let entity_types = vec![(1u32, IfcType::IfcSite)];
+
+    let georef = GeoRefExtractor::extract(&mut decoder, &entity_types)
+        .expect("decode ok")
+        .expect("legacy site georeference extracted");
+
+    assert_eq!(georef.source, GeoRefSource::SiteLocation);
+    assert!(
+        (georef.northings - (-0.5)).abs() < 1e-9,
+        "expected northings -0.5 (0°30'S), got {}",
+        georef.northings
+    );
+    assert!(
+        (georef.eastings - (-0.75)).abs() < 1e-9,
+        "expected eastings -0.75 (0°45'W), got {}",
+        georef.eastings
+    );
+}
+
+/// Control: the spec-canonical encoding (sign on the first NON-ZERO
+/// component) must keep working exactly as before — the `-0` leniency must
+/// never flip an already-correct sign.
+#[test]
+fn test_extract_from_site_canonical_negative_degree_unaffected() {
+    let ifc_content = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCSITE('1abc',$,'Site',$,$,$,$,$,.ELEMENT.,(-50,2,20),(14,28,0),0.,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    let mut decoder = EntityDecoder::new(ifc_content);
+    let entity_types = vec![(1u32, IfcType::IfcSite)];
+
+    let georef = GeoRefExtractor::extract(&mut decoder, &entity_types)
+        .expect("decode ok")
+        .expect("legacy site georeference extracted");
+
+    let expected_lat = -(50.0 + 2.0 / 60.0 + 20.0 / 3600.0);
+    let expected_lon = 14.0 + 28.0 / 60.0;
+    assert!((georef.northings - expected_lat).abs() < 1e-9);
+    assert!((georef.eastings - expected_lon).abs() < 1e-9);
+}
+
+/// Adversarial: a `Name`/`Description` string containing a literal comma or
+/// parenthesis must not throw off the raw-byte attribute-index walk that
+/// recovers the `-0` sign — the walk must be quote-aware, not just counting
+/// top-level commas blindly.
+#[test]
+fn test_extract_from_site_negative_zero_scan_ignores_commas_inside_quoted_strings() {
+    let ifc_content = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Test'),'2;1');
+FILE_NAME('test.ifc','2024-01-01',(''),(''),'','','');
+FILE_SCHEMA(('IFC4'));
+ENDSEC;
+DATA;
+#1=IFCSITE('1abc',$,'Site, (annex)',$,$,$,$,$,.ELEMENT.,(-0,30,0),(-0,45,0),0.,$,$);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+    let mut decoder = EntityDecoder::new(ifc_content);
+    let entity_types = vec![(1u32, IfcType::IfcSite)];
+
+    let georef = GeoRefExtractor::extract(&mut decoder, &entity_types)
+        .expect("decode ok")
+        .expect("legacy site georeference extracted");
+
+    assert!((georef.northings - (-0.5)).abs() < 1e-9);
+    assert!((georef.eastings - (-0.75)).abs() < 1e-9);
+}

--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -311,6 +311,18 @@ SHIPPED (landed with a PR), or RE-REFUTED / NOT SHIPPABLE. Do not read the secti
   arm64 determinism harness are the stronger output evidence. Holter was not
   measured: its fixture endpoint repeatedly served a SHA-256 mismatch.
 
+- **Legacy-site georeference negative-zero recovery (#3546 residual): no
+  measurable geometry-pipeline regression.** The localized raw-record scan runs
+  only while extracting `IfcSite.RefLatitude`/`RefLongitude`; it deliberately
+  leaves the shared integer tokenizer untouched. Interleaved five-round native
+  `perf_probe` A/B (`3d9ab0e30` -> `e81f41d66`, Apple Silicon) was below the
+  harness's noise threshold: FZK-Haus total 10 -> 10 ms (mesh/vertex/triangle
+  counts 285/35,940/19,456 on both); CSG-heavy ISSUE_129 total 608 -> 609 ms
+  (+0.16%, base spread 2.96%) and geometry 591 -> 592 ms (+0.17%, base spread
+  3.38%), with identical 1,402/218,346/132,673 output counts. **Lesson:** this
+  compatibility recovery is metadata-only and too rare/small for this coarse
+  end-to-end probe to distinguish from run noise; retain the behavioral fixtures
+  rather than treating the apparent one-millisecond movement as a regression.
 - **Geometry fingerprint pass: world AABB + volume + closure verdict**
   (#1891/#1988, PR #1993, measured 2026-08-02, base = merge-base `8f139a8e`).
   The pass gained a per-triangle tetra determinant and a six-way bounds update.


### PR DESCRIPTION
## Fix

The legacy Rust georeferencing path now preserves a literal negative-zero component in a compound plane angle even though numeric tokenization normalizes `-0` to `0`. It recovers the sign from the original entity span before converting the angle.

## Regression coverage

Adds behavioral cases for literal `-0` in degree, minute, second, and millionth-second positions of the compound angle.

## Performance

Interleaved five-round native end-to-end A/B against `3d9ab0e3` found no measurable regression. FZK remained 10 ms with identical output counts; ISSUE_129 was 608→609 ms total (+0.16%) and 591→592 ms geometry (+0.17%), both inside the base spreads of 2.96% and 3.38%. The recorded ledger verdict is `tooNoisy=true`, `realChange=false`, not a speed claim.

## Validation

- `cargo test -p ifc-lite-core --lib georef` — 12 passing
- module-size gate — pass
- Fresh current-base CI and review are required before merge.
