### PR TITLE
fix(ci): remove unsafe CodeRabbit stand-down race

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -63,29 +63,12 @@ reviews:
     enabled: true
     drafts: false
 
-    # THE STAND-DOWN, and the direction of the signal is the whole design.
-    #
-    # `!claude-reviewed` is a NEGATIVE match: CodeRabbit skips any PR carrying
-    # that label. It preserves this account's scarce Fair Usage allowance -- both
-    # identities on this repo sit at the 1-2 reviews/hour floor permanently, so
-    # roughly 444 of 1,200 monthly PRs is the ceiling whatever is paid -- for the
-    # PRs the Claude lane did NOT cover.
-    #
-    # THE LABEL IS APPLIED BY THE GATE, NEVER BY THE REVIEWER. scripts/
-    # check-review-posted.mjs sets it only after verifying a marker for the exact
-    # head, and clears it on every new head. The obvious wiring, letting the
-    # reviewer label its own PRs, would be a third route to an unreviewed merge:
-    # claude-code-action #1679 exits 0 after posting nothing, so a self-labelling
-    # reviewer that silently did nothing would suppress its own backup and the PR
-    # would show green having been read by neither.
-    #
-    # KNOWN GAP, STATED: CodeRabbit reads labels at PUSH time and does not
-    # re-review on `unlabeled`, so the gate clears the label up front on
-    # `synchronize` rather than after its poll. The worst case is therefore
-    # CodeRabbit reviewing a PR the Claude lane also covered, which costs quota;
-    # the other ordering costs a review.
-    labels:
-      - '!claude-reviewed'
+    # No review stand-down label. CodeRabbit evaluates labels at push time, whereas
+    # GitHub's pull_request workflow runs afterward. A label earned by the prior
+    # head can therefore suppress review of the new head before this repository
+    # can clear it, and CodeRabbit does not re-review after an `unlabeled` event.
+    # Until an upstream trigger orders clearing before that decision, every head
+    # receives CodeRabbit review; spending quota is safer than skipping review.
     # NO `ignore_usernames`, DELIBERATELY. Excluding dependabot was tried and
     # reverted: it saves ~21 PRs/month of allowance and buys a silent blind spot.
     # An ignored author gets no CodeRabbit CONTEXT at all, and nothing detects

--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -17,36 +17,10 @@ on:
 
 permissions:
   contents: read
-  # Both comment surfaces plus the review list, AND the stand-down label.
-  #
-  # `pull-requests: write` IS REQUIRED FOR THE LABEL, and this was established by
-  # measurement after two wrong answers. The original grant was `issues: write`,
-  # on the reasoning that a label is an issue resource; every label call has
-  # failed since the day it was written. Switching from `gh pr edit` (GraphQL) to
-  # the REST issue-labels endpoints did not help either -- same 403, measured on
-  # PR #3589:
-  #
-  #   gh: Resource not accessible by integration (HTTP 403)
-  #
-  # A reviewer had inferred from GitHub's `x-accepted-github-permissions:
-  # issues=write; pull_requests=write` that the semicolon meant OR, so
-  # `issues: write` would suffice. The live 403 says otherwise. Labelling a PULL
-  # REQUEST needs `pull-requests: write`, whatever the resource is called.
-  #
-  # THIS IS A WIDER GRANT THAN THE COMMENT IT REPLACES WANTED, and that is stated
-  # rather than glossed: the token can now comment on, close and retarget this
-  # PR, not merely label it. Two things make it acceptable. The surface already
-  # exists -- `claude-review.yml` holds `pull-requests: write` and also runs from
-  # the PR's checkout, so nothing new is reachable that was not before. And the
-  # alternative is not a smaller grant, it is a stand-down that never happens:
-  # CodeRabbit reviewing every PR forever while three green steps say otherwise.
-  #
-  # The repository default is `read`, and a workflow CAN elevate past it -- proved
-  # by `claude-review.yml` posting the marker on #3589 under exactly that setting.
-  # So the default was never the cap here, and raising it repo-wide is not needed.
-  pull-requests: write
-  # For `gh label create`, which is repository-level rather than PR-level.
-  issues: write
+  # The review and comment surfaces are read only. This workflow deliberately
+  # does not mutate labels: a pull_request job runs after CodeRabbit's push-time
+  # label decision, so it cannot safely clear a label from the preceding head.
+  pull-requests: read
 
 concurrency:
   group: review-posted-${{ github.event.pull_request.number }}
@@ -56,7 +30,7 @@ jobs:
   review-posted:
     name: Review posted
     runs-on: ubuntu-latest
-    # ABOVE the gate's poll budget (600s), deliberately, so a run that exhausts
+    # ABOVE the gate's poll budget (1500s), deliberately, so a run that exhausts
     # the budget still gets to PRINT its verdict rather than being killed
     # mid-wait with no output and no `covered` value. The sibling gate states the
     # same rule at pr-review-signal.yml (a job cap comfortably over its own poll
@@ -105,36 +79,6 @@ jobs:
       - name: Unit-test the gate itself
         run: node --test scripts/check-review-posted.test.mjs
 
-      # CLEARED FIRST, BEFORE THE GATE WAITS. This is a race, not a tidy-up.
-      #
-      # CodeRabbit's `auto_review` reads labels at PUSH time. If the label were
-      # only reconciled after the poll, then on a new commit CodeRabbit would see
-      # the label left over from the PREVIOUS head, stand down immediately, and
-      # the gate would clear it minutes later -- after the decision it was meant
-      # to influence. CodeRabbit does not re-review on an `unlabeled` event, so
-      # that commit would ship read by neither reviewer.
-      #
-      # Clearing up front inverts the failure: the worst case is CodeRabbit
-      # reviewing a PR the Claude lane also covers, which costs quota. The other
-      # ordering costs a review.
-      - name: Clear the stand-down label for this new head
-        if: github.event.action == 'synchronize' || github.event.action == 'reopened'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # REST, not `gh pr edit`. `gh pr edit` goes through the GraphQL
-          # `removeLabelsFromLabelable` mutation, which needs `pull-requests:
-          # write`; this workflow holds `issues: write`, which is what the REST
-          # issue-labels endpoints require and is the smaller grant. Measured on
-          # PR #3587: every label call failed with "Resource not accessible by
-          # integration (removeLabelsFromLabelable)" while the step reported
-          # success, so the stand-down NEVER happened and CodeRabbit reviewed
-          # every PR anyway.
-          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/claude-reviewed" \
-            --method DELETE --silent \
-            || echo "No label to clear (or no write access on a fork PR); CodeRabbit will review."
-
       # The config is the thing worth forging: it names who may post a marker.
       # Taken from the BASE branch so a PR cannot add its own author and pass.
       # When base has no copy -- true only for the PR that introduces this gate --
@@ -171,66 +115,3 @@ jobs:
             --sha "${{ github.event.pull_request.head.sha }}" \
             --config "${{ steps.cfg.outputs.config }}" \
             --timeout-seconds 1500
-
-      # ADDS ONLY. The clearing half runs up front, above.
-      #
-      # `continue-on-error` because both failure modes here land on the SUCCESS
-      # path and neither means the review is bad: a fork PR's GITHUB_TOKEN is
-      # read-only whatever `permissions:` says, and the label may not exist in the
-      # repository yet. Failing the job for either would turn a passing gate red.
-      # The cost of the label not being applied is that CodeRabbit reviews a PR
-      # that was already covered -- quota, not correctness.
-      #
-      # Reads `steps.gate.outputs.covered`, never the step's exit code: in
-      # advisory mode a failing verdict still exits 0, so the exit code would mark
-      # an unreviewed PR as covered.
-      - name: Mark covered so CodeRabbit can stand down
-        if: always() && steps.gate.outputs.covered == 'true'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh label create claude-reviewed --repo "${{ github.repository }}" \
-            --color 0e8a16 --description "A review was verified as posted for this PR's head." \
-            2>/dev/null || true
-          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" \
-            --method POST -f "labels[]=claude-reviewed" --silent || true
-
-          # READ IT BACK, because this step is `continue-on-error` and therefore
-          # cannot report its own failure. That is how the permission bug above
-          # survived: three green steps and no label on the PR. The stand-down is
-          # a CLAIM about another system's behaviour, so it is checked, not
-          # assumed -- the same rule the marker itself is held to.
-          # Read into a VARIABLE, not a pipeline into `grep -q`. That pipeline is
-          # correct today only because this step inherits `bash -e` WITHOUT
-          # pipefail: with pipefail on, `grep -q` exiting early can SIGPIPE `gh`
-          # and flip the whole read-back to permanently reporting "not on the
-          # PR". A correctness that depends on an unstated shell option is one
-          # `shell: bash` away from being wrong, silently, in the check whose
-          # entire job is to not be silently wrong. `per_page=100` because the
-          # default 30 would make a heavily-labelled PR warn while the label is
-          # actually there.
-          have=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels?per_page=100" \
-                   --jq '.[].name' 2>/dev/null || true)
-          if printf '%s\n' "$have" | grep -qx 'claude-reviewed'; then
-            echo "✅ claude-reviewed is ON the PR: CodeRabbit will stand down for this head."
-          else
-            echo "⚠️  THE LABEL IS NOT ON THE PR, so CodeRabbit will review this PR as well."
-            echo "    Not a failure of the review -- the marker is verified either way -- but the"
-            echo "    quota saving did not happen. Most likely cause: the token lacks label write"
-            echo "    (fork PR), or the repository's default workflow permissions were tightened."
-          fi
-
-      # The refusal paths write `covered=false` too, so a stale label is cleared
-      # even when the gate could not read its own inputs. Without this a PR
-      # carrying the label from an earlier head would keep it through any number
-      # of refused runs.
-      - name: Clear the stand-down label when this head is not covered
-        if: always() && steps.gate.outputs.covered == 'false'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/claude-reviewed" \
-            --method DELETE --silent \
-            || echo "Nothing to clear."

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -325,9 +325,10 @@ export function normaliseComments(payload) {
  *
  * @returns {{ ok: boolean, covered: boolean, verdict: string, lines: string[] }}
  *   `ok` is "should this check go red"; `covered` is "has this head been
- *   REVIEWED", which is what the workflow turns into the `claude-reviewed` label
- *   and what CodeRabbit reads to stand down. They differ on exactly one verdict:
- *   `nothing-to-review` is ok and NOT covered, because nothing read the diff.
+ *   REVIEWED". They differ on exactly one verdict: `nothing-to-review` is ok
+ *   and NOT covered, because nothing read the diff. The workflow records this
+ *   distinction but does not turn it into a label: post-push label mutation
+ *   cannot safely control CodeRabbit's push-time decision.
  */
 export function evaluate({ comments, cfg, headSha }) {
   const lines = [];
@@ -435,17 +436,16 @@ export function evaluate({ comments, cfg, headSha }) {
       : `✅ REVIEW_POSTED: an expected reviewer posted a ${match.verdict} verdict for ${headSha.slice(0, 9)}` +
         `${match.verdict === 'findings' ? ` with ${match.count} finding(s)` : ''}.`,
     match.verdict === 'nothing-to-review'
-      ? '   COVERED=FALSE, though: nobody read this diff, so CodeRabbit must NOT stand down on it.'
+      ? '   COVERED=FALSE, though: nobody read this diff.'
       : '   This proves a review REACHED the pull request for this exact commit.',
     '   It proves nothing about whether the review was any good; precision is a separate',
     '   instrument.',
   );
   // `ok` AND `covered` ARE DIFFERENT QUESTIONS, and conflating them was a hole.
-  // `ok` is "should this check go red"; `covered` is "has this head been REVIEWED",
-  // which is what `review-posted.yml` turns into the `claude-reviewed` label and
-  // what `.coderabbit.yaml` reads to stand down. A `nothing-to-review` head has
-  // NOT been reviewed -- the model never ran -- so standing CodeRabbit down on it
-  // would leave the PR reviewed by NOBODY. Raised by CodeRabbit on PR #3587.
+  // A `nothing-to-review` head has NOT been read, even though it is a passing
+  // gate result. Callers retain the distinction for diagnostics; it must not be
+  // used to drive a post-push CodeRabbit stand-down, because that cannot protect
+  // the next head from a stale label.
   return { ok: true, covered: match.verdict !== 'nothing-to-review', verdict: 'REVIEW_POSTED', lines };
 }
 
@@ -659,8 +659,8 @@ function main() {
   // `covered` is the VERDICT, independent of the exit code, and the two differ on
   // purpose in advisory mode: there, a failing verdict still exits 0, and a caller
   // that inferred coverage from the exit code would mark an unreviewed PR as
-  // covered. Anything downstream that acts on "was this reviewed" -- the
-  // CodeRabbit stand-down label, above all -- must read THIS, never `$?`.
+  // covered. Downstream diagnostics that need to know whether the head was read
+  // must read THIS, never `$?`.
   if (process.env.GITHUB_OUTPUT) {
     appendFileSync(process.env.GITHUB_OUTPUT, `covered=${covered ? 'true' : 'false'}\n`);
   }
@@ -679,8 +679,7 @@ function main() {
     console.log(
       'FORK PR: the finding above does not fail this job. `claude-review.yml` excludes fork PRs, because ' +
         "a fork's GITHUB_TOKEN is read-only whatever `permissions:` says, so no marker can ever be posted " +
-        'here and enforcing would be a red nobody can clear. These PRs are covered by the CodeRabbit lane, ' +
-        'which is why the stand-down label is never applied to them.',
+        'here and enforcing would be a red nobody can clear. These PRs remain available to the CodeRabbit lane.',
     );
     process.exit(0);
   }
@@ -707,10 +706,8 @@ if (isMainEntry(import.meta.url)) {
     if (err instanceof ReviewPostedError || err instanceof GhError) {
       console.error(`❌ ${err.reason}: ${err.message}`);
       // A REFUSAL IS NOT COVERAGE. Every refusal path -- GH_ERROR, truncation,
-      // a bad config, a killed poll -- previously left `covered` unwritten, and
-      // the label step skipped on an empty value, so a PR carrying the label
-      // from an earlier head kept it through any number of refused runs. That is
-      // a stale stand-down, which is what STALE_REVIEW exists to prevent.
+      // a bad config, a killed poll -- writes that fact for diagnostics rather
+      // than leaving an absent output to be interpreted as a verdict.
       if (process.env.GITHUB_OUTPUT) {
         try {
           appendFileSync(process.env.GITHUB_OUTPUT, 'covered=false\n');

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -387,10 +387,8 @@ test('ADVISORY does not print an advisory notice over a PASS', () => {
 // ============================================== the machine-readable verdict
 
 test('the `covered` output tracks the VERDICT, not the exit code', () => {
-  // The CodeRabbit stand-down label reads this. In advisory mode a failing
-  // verdict still exits 0, so a caller inferring coverage from `$?` would mark an
-  // unreviewed PR as covered and both reviewers would stand down -- a third route
-  // to an unreviewed merge. These two cases are the ones that must not agree.
+  // In advisory mode a failing verdict still exits 0. Consumers that need the
+  // review-state diagnostic must therefore not infer it from `$?`.
   const outPath = join(TMP, `ghout-${(seq += 1)}.txt`);
   const payloadPath = join(TMP, `p-covered-${seq}.json`);
   const readOut = () => readFileSync(outPath, 'utf8');
@@ -420,7 +418,7 @@ test('the `covered` output tracks the VERDICT, not the exit code', () => {
   assert.match(advisory.out, /covered=false/, 'but coverage must still read false');
 });
 
-test('a STALE review reports covered=false, so the stand-down label is cleared', () => {
+test('a STALE review reports covered=false', () => {
   const outPath = join(TMP, `ghout-stale-${(seq += 1)}.txt`);
   const payloadPath = join(TMP, `p-stale-${seq}.json`);
   writeFileSync(outPath, '');
@@ -513,11 +511,10 @@ test('FAIL CLOSED: an unreadable head repository REFUSES rather than guessing ei
 
 // ================================ `covered` is not the same question as `ok`
 
-test('nothing-to-review PASSES but reports covered=FALSE, so CodeRabbit does not stand down', () => {
-  // The hole this closes: `review-posted.yml` turns `covered` into the
-  // `claude-reviewed` label, and `.coderabbit.yaml` skips labelled PRs. A
-  // nothing-to-review head was never READ by anything, so claiming coverage
-  // would stand CodeRabbit down too and leave the PR reviewed by NOBODY.
+test('nothing-to-review PASSES but reports covered=FALSE: nobody read the diff', () => {
+  // `ok` is a gate outcome; `covered` tells callers whether a review read the
+  // head. A nothing-to-review marker passes because the reviewer explicitly
+  // excluded every changed path, but it is not evidence of a read.
   const outPath = join(TMP, `ghout-ntr-${(seq += 1)}.txt`);
   const payloadPath = join(TMP, `p-ntr-${seq}.json`);
   writeFileSync(outPath, '');
@@ -535,9 +532,9 @@ test('nothing-to-review PASSES but reports covered=FALSE, so CodeRabbit does not
   assert.match(`${r.stdout}${r.stderr}`, /COVERED=FALSE/);
 });
 
-test('a REAL clean review reports covered=true, or the stand-down never happens at all', () => {
+test('a REAL clean review reports covered=true', () => {
   // The anti-vacuity pair: if `covered` were false for everything, the test above
-  // would pass while the whole stand-down mechanism was dead.
+  // would pass while the review-state diagnostic was dead.
   const outPath = join(TMP, `ghout-clean-${(seq += 1)}.txt`);
   const payloadPath = join(TMP, `p-clean-${seq}.json`);
   writeFileSync(outPath, '');

--- a/scripts/review-posted.config.json
+++ b/scripts/review-posted.config.json
@@ -27,19 +27,6 @@
     "github-actions",
     "claude"
   ],
-  "$standDownComment": [
-    "THE CODERABBIT HALF IS LIVE. `.coderabbit.yaml` carries",
-    "`auto_review.labels: ['!claude-reviewed']`, a negative match, since PR #3581 merged",
-    "on 2026-08-31. The workflow applies a `claude-reviewed` label when this gate verifies",
-    "a review and clears it on every new head, so CodeRabbit now stands down on exactly",
-    "the heads this lane has covered and reviews the rest.",
-    "",
-    "THIS COMMENT HAS BEEN WRONG TWICE, which is the reason it is this specific. It first",
-    "said the label was inert 'until #3576', naming the wrong PR; then it said 'until",
-    "#3581 merges', which expired the moment #3581 merged. A comment asserting the state",
-    "of a config in ANOTHER file goes stale silently -- there is nothing to fail when it",
-    "does -- so check `.coderabbit.yaml` rather than trusting this paragraph."
-  ],
   "$modeComment": [
     "ADVISORY or ENFORCING. Advisory prints the identical verdict and exits 0; enforcing",
     "exits 1. Not defaulted in code: a missing value is a refusal, because defaulting",


### PR DESCRIPTION
## Fix

#3589’s post-push label workflow cannot clear a prior-head label before CodeRabbit decides at push, and CodeRabbit does not re-review when that label is later removed. Automatic stand-down and its write permissions are removed, so CodeRabbit reviews every head.

`covered` remains a review-gate diagnostic, not a label command.

## Validation

- `node --test scripts/check-review-posted.test.mjs` — 45 passing
- Both changed workflow YAML files parse successfully
- `git diff --check` — pass

This intentionally does not claim a replacement sequencing mechanism; quota saving remains disabled until one can be proven safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Automated review coverage now applies consistently to all pull requests without label-based exclusions.
  * Review monitoring no longer modifies pull request labels.
  * Review coverage status is retained for diagnostics, including for pull requests from forks.
  * Extended review monitoring timeouts to accommodate longer-running reviews.
  * Updated related documentation and test descriptions to reflect the revised review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->