### PR TITLE
fix(ci): the gate gave up 29 seconds before the reviewer answered

### DIFF
--- a/.github/workflows/review-posted.yml
+++ b/.github/workflows/review-posted.yml
@@ -64,7 +64,7 @@ jobs:
     # restating it, because this comment was stale about both numbers once). An
     # earlier version of this file had 5 minutes against a 600s budget, which
     # would have killed the job on every PR before it could say anything.
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       # THE GATE RUNS FROM THE PR; ITS AUTHORITY COMES FROM THE BASE BRANCH.
       #
@@ -170,7 +170,7 @@ jobs:
             --pr "${{ github.event.pull_request.number }}" \
             --sha "${{ github.event.pull_request.head.sha }}" \
             --config "${{ steps.cfg.outputs.config }}" \
-            --timeout-seconds 600
+            --timeout-seconds 1500
 
       # ADDS ONLY. The clearing half runs up front, above.
       #

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -576,3 +576,46 @@ test('FAIL CLOSED: the fork check REFUSES when no repository was resolved', () =
   assert.equal(r.status, 1, `${r.stdout}${r.stderr}`);
   assert.match(`${r.stdout}${r.stderr}`, /NO_REPO/);
 });
+
+// ============================ the gate must outwait the lane it is waiting FOR
+
+test('THE RACE: the gate\'s poll budget exceeds the LANE\'s own job timeout', () => {
+  // MEASURED, on PR #3593, with the gate already enforcing:
+  //
+  //   gate gave up after 600 s   05:12:43
+  //   lane posted the marker     05:13:12   <- 29 seconds later
+  //
+  // NOT_POSTED on a PR whose review was fine. And it is structural, not a tuning
+  // miss: `claude-review.yml` may legitimately run until ITS OWN
+  // `timeout-minutes`, so any gate budget below that number can expire while the
+  // producer is still working. 600 s against a 1200 s producer was a coin flip
+  // the gate was always going to lose eventually; observed lane runs that
+  // actually reviewed took 525 s and 676 s, either side of it.
+  //
+  // The relationship lives in TWO FILES and nothing connected them, which is the
+  // matched-pair shape this repository keeps paying for. Connected here.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const wf = (n) => readFileSync(join(here, '..', '.github/workflows', n), 'utf8');
+
+  const laneCap = /^[ \t]*timeout-minutes:[ \t]*(\d+)/m.exec(wf('claude-review.yml'));
+  assert.ok(laneCap, 'claude-review.yml must carry a job timeout');
+
+  const gateText = wf('review-posted.yml');
+  const budget = /^[ \t]*--timeout-seconds[ \t]+(\d+)/m.exec(gateText);
+  const gateCap = /^[ \t]*timeout-minutes:[ \t]*(\d+)/m.exec(gateText);
+  assert.ok(budget && gateCap, 'review-posted.yml must carry both an explicit budget and a job cap');
+
+  const laneSeconds = Number(laneCap[1]) * 60;
+  const budgetSeconds = Number(budget[1]);
+  assert.ok(
+    budgetSeconds > laneSeconds,
+    `the gate waits ${budgetSeconds}s but the lane may run ${laneSeconds}s: the gate can give up ` +
+      'while the reviewer is still legitimately working, and report NOT_POSTED on a good PR',
+  );
+  // And the gate's own job must outlive its poll, or it is killed mid-wait and
+  // reports `cancelled` with no verdict at all.
+  assert.ok(
+    Number(gateCap[1]) * 60 - budgetSeconds >= 300,
+    `job cap ${gateCap[1]}min leaves ${Number(gateCap[1]) * 60 - budgetSeconds}s over a ${budgetSeconds}s budget`,
+  );
+});


### PR DESCRIPTION
Found by checking the deployed system after the rollout. The enforcing gate failed **PR #3593**, whose review was fine:

```
gate gave up after 600 s   05:12:43
lane posted the marker     05:13:12   ← 29 seconds later
```

`NOT_POSTED` on a good PR. Now that the gate enforces, that is a red row someone has to understand and clear.

## It is structural, not a tuning miss

`claude-review.yml` may legitimately run until its own `timeout-minutes: 20` — **1200 s**. The gate waited **600 s** and its job died at 900 s.

So the consumer could always expire while the producer was still working. 676 s was simply the first run slow enough to prove it. The two lane runs that actually reviewed took **525 s and 676 s** — either side of the budget. A coin flip the gate was going to lose eventually.

## The fix

Budget **600 → 1500 s**, chosen above the lane's 1200 s ceiling rather than above the slowest run seen so far. Tuning to the observation would leave the same race one slow afternoon away — which is precisely the mistake the sibling `PR review signal` budget made yesterday and had to be re-measured twice to correct.

Job cap **15 → 30 min**, keeping five minutes over the poll so the gate cannot be killed mid-wait and report `cancelled` with no verdict at all.

## The relationship is now gated, not coincidental

The two numbers lived in two files with nothing connecting them — each defensible alone, fatal together. That is the matched-pair shape this repo keeps paying for.

A test now reads **both** workflows and fails unless the gate's poll budget exceeds the lane's job timeout, and unless the gate's own job outlives its poll. Four mutations turn it red:

| mutation | caught |
|---|---|
| gate budget back to 600 | ✅ |
| gate budget equal to the lane's 1200, not greater | ✅ |
| **lane timeout raised to 30 min, gate left alone** | ✅ |
| gate job cap back to 15 min | ✅ |

The third is the one that would otherwise recur silently: someone gives the reviewer more time and quietly reintroduces the race.

46 tests, six repo gates.