### PR TITLE
fix(export): stop a non-finite quantity/property silently becoming JSON null

### DIFF
--- a/.changeset/json-export-nonfinite-quantity-null.md
+++ b/.changeset/json-export-nonfinite-quantity-null.md
@@ -1,0 +1,7 @@
+---
+'@ifc-lite/wasm': patch
+---
+
+The structured JSON and JSON-LD exporters (`rust/export`'s `export_json`/`export_jsonld`, reachable via `@ifc-lite/geometry`'s `GeometryProcessor.exportJson`/`exportJsonld` and the CLI's `--format jsonld`) no longer silently turn a non-finite quantity or numeric property into JSON `null`.
+
+A STEP `REAL` literal with an extreme exponent (e.g. `1.0E400`) parses to `f64::INFINITY` without erroring in the decoder, so it is reachable from real, if adversarial, input, not just a computed value. `serde_json`'s `Number::from_f64` returns `None` for a non-finite float, and `json!`/`Value::from` map that to `Value::Null` — the value silently vanished, indistinguishable in the output from the quantity being absent. `finite_json_number` now falls back to the value's `f64::to_string()` form (`"inf"`/`"-inf"`/`"NaN"`) instead, so the measurement survives as a string rather than disappearing. A plain finite value is unaffected — it still serializes as a JSON number.

--- a/rust/export/src/json.rs
+++ b/rust/export/src/json.rs
@@ -23,13 +23,26 @@ impl Default for JsonOptions {
     }
 }
 
+/// Render an `f64` as a JSON `Value`, without the silent `null` that `serde_json`
+/// substitutes for a non-finite number (`Number::from_f64` returns `None` for
+/// NaN/±Infinity, and `json!`/`Value::from` map that to `Value::Null` — RFC 8259
+/// has no NaN/Infinity literal, but collapsing a *present* out-of-range measure to
+/// `null` is indistinguishable from the value being absent). A STEP `REAL` literal
+/// with an extreme exponent (e.g. `1.0E400`) parses to `f64::INFINITY` without
+/// erroring, so this is reachable from real (if adversarial) input, not only from
+/// a computed value. Falls back to the `f64::to_string()` form (`"inf"`/`"-inf"`/
+/// `"NaN"`) so the value survives as a string instead of vanishing.
+pub(crate) fn finite_json_number(n: f64) -> Value {
+    if n.is_finite() { json!(n) } else { json!(n.to_string()) }
+}
+
 /// Coerce a rendered property value to a typed JSON value using its IFC type tag.
 pub(crate) fn typed_value(p: &PropValue) -> Value {
     match p.value_type.as_str() {
         "IFCREAL" | "IFCINTEGER" | "IFCNUMBER" | "IFCLENGTHMEASURE" | "IFCAREAMEASURE"
         | "IFCVOLUMEMEASURE" | "IFCPOSITIVELENGTHMEASURE" | "IFCCOUNTMEASURE"
         | "IFCMASSMEASURE" | "IFCRATIOMEASURE" | "IFCNORMALISEDRATIOMEASURE" => {
-            p.value.parse::<f64>().map(|n| json!(n)).unwrap_or_else(|_| json!(p.value))
+            p.value.parse::<f64>().map(finite_json_number).unwrap_or_else(|_| json!(p.value))
         }
         "IFCBOOLEAN" | "IFCLOGICAL" => match p.value.as_str() {
             "true" => json!(true),
@@ -82,7 +95,7 @@ fn entity_to_json(e: &EntityRow, opts: &JsonOptions) -> Value {
                 let quants: Vec<Value> = qs
                     .quantities
                     .iter()
-                    .map(|q| json!({ "name": q.name, "value": q.value, "type": q.kind }))
+                    .map(|q| json!({ "name": q.name, "value": finite_json_number(q.value), "type": q.kind }))
                     .collect();
                 json!({ "name": qs.name, "quantities": quants })
             })
@@ -131,5 +144,38 @@ mod tests {
             })
         });
         assert!(has_typed_number, "expected at least one typed (number/bool) property value");
+    }
+
+    /// A STEP `REAL` literal with an extreme exponent (e.g.
+    /// `1.0E400`) parses to `f64::INFINITY` without erroring in the decoder, so
+    /// it is reachable from real (if adversarial) input, not just a computed
+    /// value. Before the fix, `json!(f64::INFINITY)` silently became JSON
+    /// `null` (`serde_json::Number::from_f64` returns `None` for a non-finite
+    /// float) — indistinguishable in the output from the quantity being
+    /// absent. The value must survive as a string instead of vanishing.
+    #[test]
+    fn a_non_finite_quantity_survives_instead_of_becoming_null() {
+        let ifc = "ISO-10303-21;\n\
+HEADER;\n\
+FILE_DESCRIPTION((''),'');\n\
+FILE_NAME('','',(''),(''),'','','');\n\
+FILE_SCHEMA(('IFC4'));\n\
+ENDSEC;\n\
+DATA;\n\
+#1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\n\
+#3=IFCUNITASSIGNMENT((#1));\n\
+#4=IFCPROJECT('0PROJECT0000000000000',$,'P',$,$,$,$,$,#3);\n\
+#5=IFCWALL('0WALL000000000000000A',$,'W',$,$,$,$,$,$);\n\
+#20=IFCQUANTITYLENGTH('Length',$,$,1.0E400);\n\
+#21=IFCELEMENTQUANTITY('0QTO00000000000000A',$,'Qto_WallBaseQuantities',$,$,(#20));\n\
+#22=IFCRELDEFINESBYPROPERTIES('0REL000000000000000A',$,$,$,(#5),#21);\n\
+ENDSEC;\n\
+END-ISO-10303-21;\n";
+        let s = export_json(ifc.as_bytes(), &JsonOptions::default());
+        let v: Value = serde_json::from_str(&s).expect("valid JSON");
+        let quantities = v[0]["quantitySets"][0]["quantities"].as_array().expect("quantities array");
+        let length = quantities.iter().find(|q| q["name"] == "Length").expect("Length quantity present");
+        assert!(!length["value"].is_null(), "an out-of-range REAL must not collapse to null");
+        assert_eq!(length["value"], json!("inf"));
     }
 }

--- a/rust/export/src/jsonld.rs
+++ b/rust/export/src/jsonld.rs
@@ -5,7 +5,7 @@
 
 use serde_json::{json, Value};
 
-use crate::json::typed_value;
+use crate::json::{finite_json_number, typed_value};
 use crate::model::build_export_model;
 
 const DEFAULT_CONTEXT: &str = "https://standards.buildingsmart.org/IFC/DEV/IFC4/ADD2/OWL";
@@ -95,7 +95,7 @@ pub fn export_jsonld(content: &[u8], opts: &JsonLdOptions) -> String {
                             json!({
                                 "@type": format!("ifc:IfcQuantity{}", q.kind),
                                 "ifc:name": q.name,
-                                "ifc:value": q.value,
+                                "ifc:value": finite_json_number(q.value),
                             })
                         })
                         .collect();
@@ -161,5 +161,37 @@ mod tests {
             let id = n["ifc:expressId"].as_u64().unwrap() as u32;
             assert!(pick.contains(&id), "unexpected entity {id} in filtered graph");
         }
+    }
+
+    /// Mirrors `json::tests::a_non_finite_quantity_survives_instead_of_becoming_null`:
+    /// an out-of-range `REAL` (parses to `f64::INFINITY`) must not collapse the
+    /// `ifc:value` to JSON `null`, which reads as "quantity absent".
+    #[test]
+    fn a_non_finite_quantity_survives_instead_of_becoming_null() {
+        let ifc = "ISO-10303-21;\n\
+HEADER;\n\
+FILE_DESCRIPTION((''),'');\n\
+FILE_NAME('','',(''),(''),'','','');\n\
+FILE_SCHEMA(('IFC4'));\n\
+ENDSEC;\n\
+DATA;\n\
+#1=IFCSIUNIT(*,.LENGTHUNIT.,$,.METRE.);\n\
+#3=IFCUNITASSIGNMENT((#1));\n\
+#4=IFCPROJECT('0PROJECT0000000000000',$,'P',$,$,$,$,$,#3);\n\
+#5=IFCWALL('0WALL000000000000000A',$,'W',$,$,$,$,$,$);\n\
+#20=IFCQUANTITYLENGTH('Length',$,$,1.0E400);\n\
+#21=IFCELEMENTQUANTITY('0QTO00000000000000A',$,'Qto_WallBaseQuantities',$,$,(#20));\n\
+#22=IFCRELDEFINESBYPROPERTIES('0REL000000000000000A',$,$,$,(#5),#21);\n\
+ENDSEC;\n\
+END-ISO-10303-21;\n";
+        let opts = JsonLdOptions { include_quantities: true, ..Default::default() };
+        let s = export_jsonld(ifc.as_bytes(), &opts);
+        let v: Value = serde_json::from_str(&s).expect("valid JSON");
+        let graph = v["@graph"].as_array().expect("graph array");
+        let wall = graph.iter().find(|n| n["ifc:globalId"] == "0WALL000000000000000A").expect("wall node");
+        let quants = wall["ifc:hasQuantitySets"][0]["ifc:quantities"].as_array().expect("quantities array");
+        let length = quants.iter().find(|q| q["ifc:name"] == "Length").expect("Length quantity present");
+        assert!(!length["ifc:value"].is_null(), "an out-of-range REAL must not collapse to null");
+        assert_eq!(length["ifc:value"], json!("inf"));
     }
 }


### PR DESCRIPTION
## Summary

- The structured JSON and JSON-LD exporters (`rust/export`'s `export_json`/`export_jsonld`) silently turned a non-finite `f64` quantity or numeric property into JSON `null`, indistinguishable in the output from the value being absent.
- A STEP `REAL` literal with an extreme exponent (e.g. `1.0E400`) parses to `f64::INFINITY` without erroring anywhere in the decode path, so this is reachable from real (if adversarial) input, not only a hypothetically-computed value.
- `serde_json`'s `Number::from_f64` returns `None` for a non-finite float, and `json!`/`Value::from` map that straight to `Value::Null` — the exporters never guarded against it.
- Reachable via `@ifc-lite/geometry`'s published `GeometryProcessor.exportJson`/`exportJsonld` API, and via the CLI's `ifc-lite export --format jsonld`.

## Lens: JSON writer vs RFC 8259 / a strict independent parser

| Field / condition | RFC 8259 | Writer verdict (before) | Writer verdict (after) |
|---|---|---|---|
| Finite number (int/float) | number literal | number | number (unchanged) |
| Boolean (`IFCBOOLEAN`/`IFCLOGICAL` true/false) | `true`/`false` | real boolean | unchanged |
| Non-finite quantity/property value (STEP `REAL` overflow -> `f64::INFINITY`/`NaN`) | NaN/Infinity have no JSON literal | silently `null` -- indistinguishable from "absent" | survives as a string (`"inf"`/`"-inf"`/`"NaN"`) |
| null vs missing vs empty string | must stay distinguishable | verified: `Etikettentext: ""` stays `""`, absent psets are omitted | unchanged |
| Non-ASCII strings (Cyrillic property name, #3556) | UTF-8/`\uXXXX` | raw UTF-8, valid | unchanged |
| Quotes/backslashes/control chars | RFC 8259 section 7 escaping | handled by `serde_json`'s native serializer | unchanged |
| Duplicate keys (two same-named psets) | not applicable here -- writer is keyed by the caller's explicit set, no key collision path found | n/a | n/a |

Every other cell of this lens (checked against a real fixture, `tests/models/ara3d/AC20-FZK-Haus.ifc`, via `ifc-lite props --json`) was a valid negative: booleans, empty strings vs. `null`, and non-ASCII (German umlauts) all round-tripped correctly, because that path and both Rust exporters go through native `JSON.stringify`/`serde_json` rather than hand-rolled string building. No manual JSON-string construction was found anywhere in the scanned paths (`packages/export`, `packages/cli`, `packages/mcp`, `packages/server-client`, `rust/export`).

## Fix

`finite_json_number(n: f64) -> Value` in `rust/export/src/json.rs`, used by both `json.rs` (typed property values + quantities) and `jsonld.rs` (quantities): when `n.is_finite()` is false, falls back to `json!(n.to_string())` instead of `json!(n)`, so the measurement survives as a string rather than vanishing into `null`.

## RED -> GREEN

Added `a_non_finite_quantity_survives_instead_of_becoming_null` in both `json.rs` and `jsonld.rs`: a minimal IFC4 STEP fixture with `IFCQUANTITYLENGTH('Length',$,$,1.0E400)`. Before the fix this asserted `"value":null`; after, `"value":"inf"`.

Existing tests (`duplex_exports_json_array`, `duplex_exports_valid_jsonld`, and the rest of the 353-test `ifc-lite-export` lib suite) still pass unchanged -- a plain finite value still serializes as a JSON number.

## Test plan

- [x] `cargo test -p ifc-lite-export` -- 353 lib tests + all integration tests pass
- [x] `cargo test -p ifc-lite-processing --test module_size_ratchet` -- clean
- [x] `node scripts/check-module-size.mjs` -- OK (0 new over budget)
- [x] `pnpm run check:vitest-timeout-audit` -- clean (no TS test files touched)
- [x] `node scripts/check-test-wiring.mjs` -- OK
- [x] Manual verification: `ifc-lite props --json` on `tests/models/ara3d/AC20-FZK-Haus.ifc` confirms booleans/empty-strings/non-ASCII round-trip correctly (control)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved non-finite numeric values during JSON and JSON-LD export instead of converting them to `null`.
  - Out-of-range values such as infinity and NaN are now represented as strings, while finite values remain numeric.
  - Added safeguards for quantities and numeric properties to prevent loss of measurement data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->