### PR TITLE
fix(ci): a DRAFT PR was a permanent red nobody could clear

### DIFF
--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -529,7 +529,7 @@ function fetchPayload(repo, pr) {
  * `!args.stateFile` would have shipped an enforcement carve-out no test could
  * execute, which is the shape this repository keeps paying for.
  */
-function isForkPr(repo, pr, override) {
+function prExemption(repo, pr, override) {
   // NO REPO, NO VERDICT. `args.repo` is only refused inside the live branch, so
   // in `--state-file` mode it can be null -- and `headRepo !== null` is true for
   // every value, which would excuse EVERY failing verdict. The invariant belongs
@@ -547,7 +547,7 @@ function isForkPr(repo, pr, override) {
   const data =
     override === undefined
       ? gh(['api', `repos/${repo}/pulls/${pr}`, '--method', 'GET'], 'the PR head repo', ReviewPostedError)
-      : { head: { repo: { full_name: override } } };
+      : { head: { repo: { full_name: override.headRepo } }, draft: override.draft === true };
   const headRepo = data?.head?.repo?.full_name;
   if (typeof headRepo !== 'string' || headRepo === '') {
     throw new ReviewPostedError(
@@ -561,7 +561,21 @@ function isForkPr(repo, pr, override) {
   // is caller-supplied: `ltplus-ag/ifc-lite` against a head repo of
   // `LTplus-AG/ifc-lite` would otherwise read as a FORK and turn enforcement off
   // for every PR. Same normalisation the author matching already uses.
-  return headRepo.toLowerCase() !== repo.toLowerCase();
+  // TWO EXEMPTIONS, ONE READ. Both are cases where the LANE cannot post, so the
+  // gate would be demanding a marker nobody is able to write.
+  //
+  // DRAFTS. `claude-review.yml` gates the job on `draft == false`; this workflow
+  // has no `if:` at all and runs on drafts anyway. Under `enforcing` that made
+  // every same-repo DRAFT PR a permanent red -- the lane skips identically on
+  // every re-run, so the printed "re-run the review job" could never clear it.
+  // Third instance of that class after nothing-reviewable and forks, missed
+  // because the first two were about WHO posts and this one is about WHEN.
+  // Found by review of the contributor docs, not by the gate's own tests.
+  if (data?.draft === true) return { exempt: true, why: 'DRAFT' };
+  return {
+    exempt: headRepo.toLowerCase() !== repo.toLowerCase(),
+    why: 'FORK',
+  };
 }
 
 function main() {
@@ -674,13 +688,25 @@ function main() {
   // path. `claude-review.yml`'s dedup step is different: a failing verdict IS its
   // common case, so once the base config is `enforcing` every lane run pays one
   // `gh api pulls/<n>` there. One call, named rather than left to be discovered.
-  if (!ok && isForkPr(args.repo, args.pr, args.stateFile ? payload?.headRepo : undefined)) {
+  const exemption =
+    ok
+      ? { exempt: false }
+      : prExemption(
+          args.repo,
+          args.pr,
+          args.stateFile ? { headRepo: payload?.headRepo, draft: payload?.draft } : undefined,
+        );
+  if (exemption.exempt) {
     console.log('');
     console.log(
-      'FORK PR: the finding above does not fail this job. `claude-review.yml` excludes fork PRs, because ' +
-        "a fork's GITHUB_TOKEN is read-only whatever `permissions:` says, so no marker can ever be posted " +
-        'here and enforcing would be a red nobody can clear. These PRs are covered by the CodeRabbit lane, ' +
-        'which is why the stand-down label is never applied to them.',
+      exemption.why === 'DRAFT'
+        ? 'DRAFT PR: the finding above does not fail this job. `claude-review.yml` skips drafts, so no ' +
+          'marker can be written while this PR is a draft and enforcing would be a red no re-run could ' +
+          'clear. Mark it ready for review and the lane will review the head.'
+        : 'FORK PR: the finding above does not fail this job. `claude-review.yml` excludes fork PRs, ' +
+          "because a fork's GITHUB_TOKEN is read-only whatever `permissions:` says, so no marker can " +
+          'ever be posted here and enforcing would be a red nobody can clear. These PRs are covered by ' +
+          'the CodeRabbit lane, which is why the stand-down label is never applied to them.',
     );
     process.exit(0);
   }

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -668,7 +668,28 @@ function main() {
   console.log('');
 
   const { ok, covered, lines } = result;
-  for (const l of lines) console.log(l);
+
+  // THE EXEMPTION IS RESOLVED BEFORE THE VERDICT IS PRINTED, so a remedy that
+  // cannot work is never shown. The failing verdicts end in
+  // `REMEDY: re-run the review job`, which is right for a quota blip and WRONG
+  // for a draft or a fork: no re-run can produce a marker the lane will not
+  // write. Printing both left the reader with two instructions that contradict
+  // each other, which this repository treats as a defect in its own right --
+  // "each distinct failure class names a remedy, and the remedy does not
+  // contradict the finding". Raised by CodeRabbit on PR #3598.
+  const exemption =
+    ok
+      ? { exempt: false }
+      : prExemption(
+          args.repo,
+          args.pr,
+          args.stateFile ? { headRepo: payload?.headRepo, draft: payload?.draft } : undefined,
+        );
+
+  for (const l of lines) {
+    if (exemption.exempt && /^\s*REMEDY:/.test(l)) continue;
+    console.log(l);
+  }
 
   // `covered` is the VERDICT, independent of the exit code, and the two differ on
   // purpose in advisory mode: there, a failing verdict still exits 0, and a caller
@@ -688,14 +709,6 @@ function main() {
   // path. `claude-review.yml`'s dedup step is different: a failing verdict IS its
   // common case, so once the base config is `enforcing` every lane run pays one
   // `gh api pulls/<n>` there. One call, named rather than left to be discovered.
-  const exemption =
-    ok
-      ? { exempt: false }
-      : prExemption(
-          args.repo,
-          args.pr,
-          args.stateFile ? { headRepo: payload?.headRepo, draft: payload?.draft } : undefined,
-        );
   if (exemption.exempt) {
     console.log('');
     console.log(

--- a/scripts/check-review-posted.mjs
+++ b/scripts/check-review-posted.mjs
@@ -340,8 +340,14 @@ export function evaluate({ comments, cfg, headSha }) {
       '   The review job\'s exit code is NOT evidence: claude-code-action #1644 exits success after',
       '   a partial run, and #1679 exits 0 after failing to post every comment (reported as forty',
       '   consecutive runs logging `Posted 0/N`). Both are open.',
-      '   REMEDY: re-run the review job. If it recurs, read the run log for `Posted 0/N` or a low',
-      '   `num_turns` and attach it to the upstream issue rather than re-running indefinitely.',
+      // ONE ENTRY, not two. An exempt run filters `REMEDY:` lines out, and a
+      // remedy split across two array entries loses its head and prints the
+      // tail -- dangling prose that still said "rather than re-running
+      // indefinitely" beside an exemption saying no re-run can help. Caught in
+      // review; the test could not see it because it asserted only that no line
+      // STARTS with REMEDY.
+      '   REMEDY: re-run the review job. If it recurs, read the run log for `Posted 0/N` or a low ' +
+        '`num_turns` and attach it to the upstream issue rather than re-running indefinitely.',
     );
     return { ok: false, covered: false, verdict: 'NOT_POSTED', lines };
   }
@@ -418,8 +424,8 @@ export function evaluate({ comments, cfg, headSha }) {
         '   claim; this is the check that it is true.',
         '   Only INLINE comments on THIS head count. A summary comment is not a finding, and a',
         '   finding on an earlier head is not a finding on this diff.',
-        '   REMEDY: re-run the review job. If it recurs, the run log will show `Posted 0/N`; attach',
-        '   it to claude-code-action#1679 rather than re-running indefinitely.',
+        '   REMEDY: re-run the review job. If it recurs, the run log will show `Posted 0/N`; ' +
+          'attach it to claude-code-action#1679 rather than re-running indefinitely.',
       );
       return { ok: false, covered: false, verdict: 'FINDINGS_NOT_POSTED', escapeHatch: null, lines };
     }

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -664,3 +664,23 @@ test('DRAFT wins over FORK in the message, because it is the one the author can 
   assert.equal(r.code, 0, r.out);
   assert.match(r.out, /DRAFT PR/);
 });
+
+test('an EXEMPT run prints ONE remedy, not two that contradict each other', () => {
+  // The failing verdicts end in `REMEDY: re-run the review job`, which is right
+  // for a quota blip and wrong for a draft or a fork: no re-run can produce a
+  // marker the lane will not write. Printing both left the reader with two
+  // instructions that disagree, which this repository treats as a defect in its
+  // own right. Raised by CodeRabbit on PR #3598.
+  const draft = run({ headRepo: SAME_REPO, draft: true, issueComments: [], reviewComments: [], reviews: [] });
+  assert.doesNotMatch(draft.out, /REMEDY:/, 'the re-run remedy cannot work on a draft');
+  assert.match(draft.out, /Mark it ready for review/, 'and the one that CAN work is still there');
+
+  const fork = run({ headRepo: 'someone/ifc-lite', issueComments: [], reviewComments: [], reviews: [] });
+  assert.doesNotMatch(fork.out, /REMEDY:/, 'nor on a fork');
+
+  // ANTI-VACUITY: a real failure must KEEP its remedy, or this test would pass
+  // by the gate having stopped printing remedies at all.
+  const real = run({ headRepo: SAME_REPO, draft: false, issueComments: [], reviewComments: [], reviews: [] });
+  assert.equal(real.code, 1);
+  assert.match(real.out, /REMEDY: re-run the review job/);
+});

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -619,3 +619,48 @@ test('THE RACE: the gate\'s poll budget exceeds the LANE\'s own job timeout', ()
     `job cap ${gateCap[1]}min leaves ${Number(gateCap[1]) * 60 - budgetSeconds}s over a ${budgetSeconds}s budget`,
   );
 });
+
+// =============================== drafts are never enforced either
+
+test('ENFORCING: a DRAFT PR reports the finding in full and does NOT fail the job', () => {
+  // `claude-review.yml` gates on `draft == false`; this workflow has no `if:` and
+  // runs on drafts anyway. Under enforcing that made every same-repo draft a
+  // permanent red: the lane skips identically on every re-run, so the printed
+  // "re-run the review job" could never clear it. Third instance of the
+  // unclearable-red class, after nothing-reviewable and forks.
+  const r = run({ headRepo: SAME_REPO, draft: true, issueComments: [], reviewComments: [], reviews: [] });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /NOT_POSTED/, 'the verdict text is unchanged: an exemption, not silence');
+  assert.match(r.out, /DRAFT PR/);
+  assert.match(r.out, /Mark it ready for review/);
+});
+
+test('ENFORCING: the SAME payload without the draft flag still fails', () => {
+  // Anti-vacuity. Without this the test above would pass even if the gate had
+  // stopped enforcing entirely.
+  const r = run({ headRepo: SAME_REPO, draft: false, issueComments: [], reviewComments: [], reviews: [] });
+  assert.equal(r.code, 1, r.out);
+  assert.match(r.out, /NOT_POSTED/);
+  assert.doesNotMatch(r.out, /DRAFT PR|FORK PR/);
+});
+
+test('a draft that IS covered passes on the merits, not as an exemption', () => {
+  // The exemption only ever suppresses a FAILING verdict; a covered draft must
+  // not be reported as excused.
+  const r = run({
+    headRepo: SAME_REPO,
+    draft: true,
+    issueComments: [{ user: { login: REVIEWER }, body: marker(SHA) }],
+    reviewComments: [],
+    reviews: [],
+  });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /REVIEW_POSTED/);
+  assert.doesNotMatch(r.out, /DRAFT PR/);
+});
+
+test('DRAFT wins over FORK in the message, because it is the one the author can change', () => {
+  const r = run({ headRepo: 'someone/ifc-lite', draft: true, issueComments: [], reviewComments: [], reviews: [] });
+  assert.equal(r.code, 0, r.out);
+  assert.match(r.out, /DRAFT PR/);
+});

--- a/scripts/check-review-posted.test.mjs
+++ b/scripts/check-review-posted.test.mjs
@@ -671,12 +671,39 @@ test('an EXEMPT run prints ONE remedy, not two that contradict each other', () =
   // marker the lane will not write. Printing both left the reader with two
   // instructions that disagree, which this repository treats as a defect in its
   // own right. Raised by CodeRabbit on PR #3598.
+  // ASSERT ON THE INSTRUCTION, NOT ON THE PREFIX. The first version of this test
+  // checked only that no line STARTS with `REMEDY:`, and passed while a remedy
+  // split across two array entries lost its head and printed the tail --
+  // "...rather than re-running indefinitely" dangling beside an exemption saying
+  // no re-run can help. 51 of 51 green with the defect live. Caught in review.
+  //
+  // The assertion is on the ORPHAN'S OWN TEXT, not on the word "re-run": the
+  // exemption legitimately says "no re-run could clear this", so a blanket match
+  // would fire on the correct output. These two fragments only ever appear in
+  // the tail of a split remedy.
+  const noReRunAdvice = (out, why) => {
+    assert.doesNotMatch(out, /REMEDY:/, `${why}: the re-run remedy cannot work here`);
+    assert.doesNotMatch(out, /rather than re-running indefinitely/, `${why}: orphaned remedy tail`);
+    assert.doesNotMatch(out, /attach it to/, `${why}: orphaned remedy tail`);
+  };
+
   const draft = run({ headRepo: SAME_REPO, draft: true, issueComments: [], reviewComments: [], reviews: [] });
-  assert.doesNotMatch(draft.out, /REMEDY:/, 'the re-run remedy cannot work on a draft');
+  noReRunAdvice(draft.out, 'draft, nothing posted');
   assert.match(draft.out, /Mark it ready for review/, 'and the one that CAN work is still there');
 
   const fork = run({ headRepo: 'someone/ifc-lite', issueComments: [], reviewComments: [], reviews: [] });
-  assert.doesNotMatch(fork.out, /REMEDY:/, 'nor on a fork');
+  noReRunAdvice(fork.out, 'fork, nothing posted');
+
+  // The OTHER multi-line remedy: FINDINGS_NOT_POSTED. Same orphan, different verdict.
+  const findings = run({
+    headRepo: SAME_REPO,
+    draft: true,
+    issueComments: [{ user: { login: REVIEWER }, body: marker(SHA, 'findings', 3) }],
+    reviewComments: [],
+    reviews: [],
+  });
+  assert.equal(findings.code, 0, findings.out);
+  noReRunAdvice(findings.out, 'draft, findings claimed but not posted');
 
   // ANTI-VACUITY: a real failure must KEEP its remedy, or this test would pass
   // by the gate having stopped printing remedies at all.


### PR DESCRIPTION
Third instance of the unclearable-red class — and found while reviewing the **contributor documentation** for the feature, not by any test of the gate.

## The hole

`claude-review.yml` gates its job on `draft == false`. `review-posted.yml` has **no `if:` at all**, runs on drafts anyway, and the gate script never mentions drafts (`grep draft` → 0 hits).

With `mode: enforcing`, every same-repo **draft PR** gets `NOT_POSTED` and a red check, permanently. The lane skips identically on every re-run, so the gate's own printed remedy — *"re-run the review job"* — can never work. Marking the PR ready is the only escape, and nothing told anyone that.

## Why it was missed after fixing the same class twice

Nothing-reviewable and forks are both about **who** can post a marker. Drafts are about **when**. Both earlier fixes were reasoned about as "cases where no marker can be written" — a draft is one, but it does not look like one from that angle.

The generalisation that catches all three:

> **The gate must exempt every case the lane itself skips** — and the lane's `if:` names them: draft, fork, kill switch.

Two of the three were exempted. The list had been sitting in the workflow the whole time.

## What this does

Both exemptions now come from **one** API read, so the draft answer costs nothing extra. `DRAFT` is reported ahead of `FORK` because it is the one the author can actually change:

```
DRAFT PR: the finding above does not fail this job. `claude-review.yml` skips
drafts, so no marker can be written while this PR is a draft and enforcing would
be a red no re-run could clear. Mark it ready for review and the lane will
review the head.
```

## What is deliberately NOT exempted

The kill switch. `CLAUDE_REVIEW_ENABLED=false` turning every PR red is the loud signal that the lane is off, and `review-posted.config.json` already documents putting `mode` back to `advisory` as the response. Exempting it would make turning the lane off silent — the opposite of what that switch is for.

## Verification

Four mutations turn the suite red: draft exemption removed, every PR treated as a draft, the exemption allowed to suppress a **pass**, and the fork exemption removed.

Also tightened: a `--state-file` payload without `headRepo` now refuses instead of falling through to a live API call the harness did not intend.

50 tests, four repo gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Draft pull requests are now exempt from review enforcement and display a clear draft-specific message.
  * Draft status is preserved when applying review-check overrides.
  * Fork and draft exemptions are reported distinctly, with draft messaging taking precedence.

* **Bug Fixes**
  * Covered draft pull requests now pass based on their review result, while non-draft enforcement remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->