### PR TITLE
fix(bcf): XML-escape project.bcfp's ProjectId attribute in the writer

### DIFF
--- a/.changeset/bcf-writer-projectid-escape.md
+++ b/.changeset/bcf-writer-projectid-escape.md
@@ -1,0 +1,9 @@
+---
+'@ifc-lite/bcf': patch
+---
+
+Escape `BCFProject.projectId` when writing `project.bcfp`.
+
+`writeProjectFile` interpolated `projectId` directly into the `<Project ProjectId="...">` attribute without XML-escaping, unlike every other free-text field the writer emits (Title, Description, Comment, Author, AssignedTo, Labels, Stage, DocumentReference names, and `project.bcfp`'s own `<Name>`). A `projectId` containing `"` broke the attribute's own quoting; a bare `&` or `<` made the whole `.bcfzip` non-well-formed XML, which a strict external reader (Solibri, BIMcollab, usBIM) rejects outright rather than opening the file.
+
+`readBCF` now also unescapes `ProjectId` on the way back in, matching the write-side fix — otherwise a read-modify-write round trip on an escaped value would double-escape it (`&` -> `&amp;` -> `&amp;amp;`) on the next write.

--- a/packages/bcf/src/reader.ts
+++ b/packages/bcf/src/reader.ts
@@ -263,7 +263,7 @@ async function readProjectFile(zip: JSZip, budget: ExpansionBudget): Promise<{
 
   const content = await readEntryCapped(projectFile, 'string', budget);
 
-  const projectIdMatch = content.match(/ProjectId="([^"]+)"/);
+  const projectIdMatch = content.match(/ProjectId="([^"]+)"/); // unescaped below, same reason as extractElement underneath
   // extractElement, not a raw regex: writeProjectFile escapes the name with
   // escapeXml, so a raw match hands back the literal entities (`A &amp; B`) and
   // the next export escapes them again. Every other element in this reader goes
@@ -271,7 +271,7 @@ async function readProjectFile(zip: JSZip, budget: ExpansionBudget): Promise<{
   const name = extractElement(content, 'Name');
 
   return {
-    projectId: projectIdMatch?.[1],
+    projectId: projectIdMatch?.[1] !== undefined ? unescapeXml(projectIdMatch[1]) : undefined,
     name,
   };
 }

--- a/packages/bcf/src/writer-projectid-escape.test.ts
+++ b/packages/bcf/src/writer-projectid-escape.test.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * `writeProjectFile` interpolates `BCFProject.projectId` directly into
+ * `project.bcfp`'s `<Project ProjectId="...">` attribute. Every other
+ * free-text field the writer emits (Title, Description, Author, Comment,
+ * AssignedTo, Labels, Stage, DocumentReference names, project.bcfp's own
+ * `<Name>`, ...) goes through `escapeXml`; `projectId` was the one
+ * exception, interpolated raw.
+ *
+ * `BCFProject.projectId` is untyped free text (`projectId?: string`), not a
+ * generated UUID: `writeBCF` is a public export that accepts caller-supplied
+ * projects directly, and `readBCF` populates it from an existing archive's
+ * `project.bcfp` via a raw attribute-value capture, so a value containing an
+ * XML metacharacter reaches the writer both from direct API use and from a
+ * read-modify-write round trip. A `"` in the value breaks the attribute's own
+ * quoting; a bare `&` or `<` makes the document non-well-formed outright --
+ * either way, `project.bcfp` fails to parse in a strict external reader
+ * (Solibri/BIMcollab/usBIM), a total interop failure for the whole `.bcfzip`.
+ *
+ * `unescapeXml` is applied on the read side to match: prior to this fix, the
+ * reader captured `ProjectId="..."` raw (consistent with the writer never
+ * escaping it), so escaping only the write side without the read side would
+ * have introduced a NEW double-escaping bug on any read-modify-write archive
+ * (`&` -> `&amp;` written, then re-read literally as `&amp;` and escaped again
+ * into `&amp;amp;` on the next write).
+ */
+
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { validateXML } from 'xmllint-wasm';
+
+import { writeBCF } from './writer.js';
+import { readBCF } from './reader.js';
+import type { BCFProject } from './types.js';
+
+/**
+ * Well-formedness only, independent of schema conformance: `xmllint --format`
+ * requires the input to parse as XML before it can reformat it, but does not
+ * apply any XSD content-model rules (2.1's `project.xsd` requires a sibling
+ * `<ExtensionSchema>` this writer deliberately omits -- see
+ * `schema-validation.test.ts`'s "known gap" test -- which is irrelevant to
+ * whether `ProjectId` was escaped correctly).
+ */
+async function assertWellFormed(xml: string): Promise<void> {
+  const { valid, errors } = await validateXML({
+    xml: [{ fileName: 'subject.xml', contents: xml }],
+    normalization: 'format',
+  });
+  expect(errors.map((e) => e.message), xml).toEqual([]);
+  expect(valid, xml).toBe(true);
+}
+
+async function writeProjectBcfp(project: BCFProject): Promise<string> {
+  const blob = await writeBCF(project);
+  const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+  const entry = zip.file('project.bcfp');
+  if (!entry) throw new Error('writeBCF did not produce project.bcfp');
+  return entry.async('string');
+}
+
+const METACHARACTER_PROJECT_ID = 'proj "quoted" & <tag> 😀 Кириллица';
+
+describe('BCF writer — project.bcfp ProjectId escaping', () => {
+  it('escapes a ProjectId containing XML metacharacters into well-formed XML', async () => {
+    const project: BCFProject = {
+      version: '2.1',
+      projectId: METACHARACTER_PROJECT_ID,
+      name: 'plain name',
+      topics: new Map(),
+    };
+    const xml = await writeProjectBcfp(project);
+    await assertWellFormed(xml);
+
+    // Round-trips exactly (not double-escaped, not mangled) via the real reader.
+    const project2 = await readBCF(await (await writeBCF(project)).arrayBuffer());
+    expect(project2.projectId).toBe(METACHARACTER_PROJECT_ID);
+  });
+
+  it('BCF 3.0: same ProjectId escaping under <ProjectInfo>', async () => {
+    const project: BCFProject = {
+      version: '3.0',
+      projectId: METACHARACTER_PROJECT_ID,
+      topics: new Map(),
+    };
+    const xml = await writeProjectBcfp(project);
+    await assertWellFormed(xml);
+  });
+
+  it('CONTROL: a plain ProjectId (no metacharacters) still writes and round-trips', async () => {
+    const project: BCFProject = {
+      version: '2.1',
+      projectId: '66666666-6666-4666-8666-666666666666',
+      name: 'plain name',
+      topics: new Map(),
+    };
+    const xml = await writeProjectBcfp(project);
+    expect(xml).toContain('ProjectId="66666666-6666-4666-8666-666666666666"');
+    await assertWellFormed(xml);
+
+    const project2 = await readBCF(await (await writeBCF(project)).arrayBuffer());
+    expect(project2.projectId).toBe('66666666-6666-4666-8666-666666666666');
+  });
+});

--- a/packages/bcf/src/writer.ts
+++ b/packages/bcf/src/writer.ts
@@ -113,7 +113,7 @@ function writeProjectFile(zip: JSZip, project: BCFProject, version: '2.1' | '3.0
 
   const content = `<?xml version="1.0" encoding="UTF-8"?>
 <${rootElement} xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Project ProjectId="${projectId}">${nameElement}
+  <Project ProjectId="${escapeXml(projectId)}">${nameElement}
   </Project>
 </${rootElement}>`;
 


### PR DESCRIPTION
## Summary

Census of the BCF **writer**'s (`packages/bcf/src/writer.ts`, `viewpoint.ts`, `writer-camera.ts`) XML-escaping of every free-text field it interpolates into `markup.bcf` / `.bcfv` / `project.bcfp` / `bcf.version`, checked against a strict external XML parser (the interop direction: a file Solibri/BIMcollab/usBIM must be able to open). `viewpoint.ts` builds plain JS data structures (no XML); `writer-camera.ts` only ever emits numbers through the `xsdDouble` guard. All free text is written in `writer.ts`.

One gap found: `project.bcfp`'s `<Project ProjectId="...">` attribute was interpolated raw (`${projectId}`), the one field that skipped `escapeXml` while every sibling field went through it. `BCFProject.projectId` is untyped free text (`projectId?: string`) reachable both from direct `writeBCF` API use and from a read-modify-write round trip (`readBCF` populates it from an existing archive's raw attribute capture). A `"` in the value broke the attribute's own quoting; a bare `&` or `<` made the document non-well-formed outright — a strict reader rejects the whole `.bcfzip`, not just that value.

### Field -> XML rule -> writer verdict

| Field | XML context | Writer verdict |
|---|---|---|
| `Topic.title` | element text | escaped (`escapeXml`) |
| `Topic.description` | element text | escaped |
| `Topic.priority` / `.stage` / `.assignedTo` / `.dueDate` | element text | escaped |
| `Topic.labels[]` | element text | escaped |
| `Topic.topicType` / `.topicStatus` | attribute | escaped |
| `Topic.creationAuthor` / `.modifiedAuthor` | element text | escaped (via `xsdRequiredString`/`escapeXml`, pre-existing) |
| `Comment.author` / `.comment` | element text | escaped |
| `Comment/Topic.guid`, viewpoint `guid`, related-topic guid | attribute | escaped |
| `BimSnippet.snippetType` / `.reference` / `.referenceSchema` | attribute / element text | escaped |
| `DocumentReference.description` / `.documentGuid` / `.url` / `.referencedDocument` / `.guid` | element text / attribute | escaped |
| `HeaderFile.ifcProject` / `.ifcSpatialStructureElement` / `.filename` / `.date` / `.reference` | attribute / element text | escaped |
| `Component.ifcGuid` / `.originatingSystem` / `.authoringToolId` | attribute / element text | escaped |
| `Coloring.color` | attribute | escaped |
| `Bitmap.reference` | element text | escaped |
| `BCFProject.name` | element text (`project.bcfp` `<Name>`) | escaped |
| **`BCFProject.projectId`** | **attribute (`project.bcfp` `<Project ProjectId>`)** | **was unescaped -- fixed here** |
| Viewpoint/snapshot filenames | zip entry name + element text | sanitized to `[A-Za-z0-9._-]` (`sanitizeZipComponent`), no metacharacters possible |
| Numeric fields (camera vectors, points, index, aspect ratio, height, ...) | element text | never free text; guarded by `xsdDouble`/`xsdInt`, not `escapeXml` |
| Boolean attributes (`DefaultVisibility`, `IsExternal`, `SpacesVisible`, ...) | attribute | typed `boolean`, not free text |

Everything else the writer emits is either correctly escaped already or is not free text (numbers, booleans, a zip-slip-sanitized filename, or a version-literal type) -- a genuine negative result for the rest of the surface, backed by the schema-validation suite (`schema-validation.test.ts`) which already runs real output through buildingSMART's XSDs via `xmllint-wasm`.

## Fix

- `writer.ts::writeProjectFile`: wrap `projectId` in `escapeXml` before interpolating it into the `ProjectId` attribute.
- `reader.ts::readProjectFile`: unescape `ProjectId` on the way back in (`unescapeXml`), matching the write-side fix -- otherwise a read-modify-write round trip on an escaped value double-escapes it (`&` -> `&amp;` -> `&amp;amp;`) on the next write, the same hazard `extractElement` already avoids for `<Name>`.

## Test plan

New `packages/bcf/src/writer-projectid-escape.test.ts`:
- [x] RED (reproduced against unmodified `writer.ts` before the fix): a `projectId` containing `"`, `&`, `<`, an emoji, and Cyrillic text produced `ProjectId="my"project&<id>"` -- non-well-formed XML.
- [x] GREEN: the same value now escapes to well-formed XML (checked with `xmllint-wasm`'s parser, independent of the pre-existing, unrelated `<ExtensionSchema>` schema-conformance gap `schema-validation.test.ts` already documents as a known gap) in both BCF 2.1 and 3.0, and round-trips through the real reader back to the exact original string (not double-escaped, not mangled).
- [x] CONTROL: a plain UUID `projectId` still writes and round-trips unchanged.
- [x] Full package suite: `pnpm exec vitest run` in `packages/bcf` -- 322/322 passing.

Foreground verification from repo root:
- [x] `node scripts/check-module-size.mjs` -> `check-module-size: OK (2044 files measured, 305 allowlisted, 0 new over 400)`
- [x] `pnpm run check:vitest-timeout-audit` -- no regex-literal-with-parens added
- [x] `node scripts/check-test-wiring.mjs` -> OK
- [x] `pnpm exec tsc --noEmit` in `packages/bcf` -- clean
- [x] `node scripts/check-unused-locals.mjs` -- `packages/bcf` standalone at its existing baseline (5), unchanged by this diff
- [x] No `index.ts` export changes, so no `scripts/api-surface.json` update needed
- [x] Changeset added: `@ifc-lite/bcf` patch