### PR TITLE
fix(export): default exportToStep to the source schema, not a hardcoded IFC4

### DIFF
--- a/.changeset/export-to-step-default-source-schema.md
+++ b/.changeset/export-to-step-default-source-schema.md
@@ -1,0 +1,16 @@
+---
+'@ifc-lite/export': minor
+---
+
+fix(export): default `exportToStep` to the source schema instead of a hardcoded `IFC4`
+
+`exportToStep(store)` called without an explicit `schema` hardcoded
+`schema: 'IFC4'`, so it silently schema-CONVERTED every non-IFC4 model: an
+IFC2X3 or IFC4X3 file came back out under a `FILE_SCHEMA(('IFC4'))` header —
+the wrong schema token, and an invalid file wherever the source used
+schema-specific entities (e.g. an IFC4X3 model's `IfcRoad` / `IfcCourse` /
+`IfcPavement`, which have no IFC4 equivalent). The default now falls back to
+`dataStore.schemaVersion`, matching `StepExporter.export()`'s own fallback and
+the `?? store.schemaVersion ?? 'IFC4'` guard every internal caller already
+spelled out, so a plain `exportToStep(store)` round-trip preserves the model's
+schema. Pass `schema` explicitly to convert, exactly as before.

--- a/docs/guide/exporting.md
+++ b/docs/guide/exporting.md
@@ -401,8 +401,9 @@ const edited = new StepExporter(dataStore, mutationView)
 ```
 
 For quick scripts there is also `exportToStep(dataStore, options?)`, which
-returns the STEP text as a string (defaults to `schema: 'IFC4'`; prefer
-`StepExporter` and its `Uint8Array` output for very large files).
+returns the STEP text as a string (defaults `schema` to the source model's own
+schema, so a round-trip preserves it; pass `schema` explicitly to convert.
+Prefer `StepExporter` and its `Uint8Array` output for very large files).
 
 ### Visible-Only Export
 

--- a/packages/export/src/step-exporter.ts
+++ b/packages/export/src/step-exporter.ts
@@ -360,7 +360,15 @@ export function exportToStep(
 ): string {
   const exporter = new StepExporter(dataStore);
   const result = exporter.export({
-    schema: 'IFC4',
+    // Default to the SOURCE schema, not a hardcoded 'IFC4'. A hardcoded
+    // default silently schema-CONVERTED every non-IFC4 file passed without an
+    // explicit `schema` (an IFC2X3 or IFC4X3 model re-emitted under a
+    // `FILE_SCHEMA(('IFC4'))` header — mislabeled, and invalid wherever the
+    // source used schema-specific entities). This matches `export()`'s own
+    // `options.schema || dataStore.schemaVersion || 'IFC4'` fallback and the
+    // `?? store.schemaVersion ?? 'IFC4'` every internal caller already spells
+    // out, so wrapper and class agree by construction.
+    schema: (dataStore.schemaVersion as IfcSchemaVersion) || 'IFC4',
     ...options,
   });
   return new TextDecoder().decode(result.content);

--- a/packages/export/src/step-roundtrip.test.ts
+++ b/packages/export/src/step-roundtrip.test.ts
@@ -22,7 +22,7 @@ import { describe, expect, it } from 'vitest';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import { IfcParser, type IfcDataStore } from '@ifc-lite/parser';
-import { StepExporter } from './step-exporter.js';
+import { StepExporter, exportToStep } from './step-exporter.js';
 
 const MODELS_DIR = resolve(__dirname, '../../../tests/models');
 
@@ -192,4 +192,56 @@ describe.skipIf(!FIXTURES_AVAILABLE)('STEP export round-trip fidelity', () => {
       });
     });
   }
+});
+
+// The `exportToStep()` convenience wrapper is the public one-call round-trip
+// path. It used to hardcode `schema: 'IFC4'` as its default, so a caller who
+// omitted `schema` silently schema-CONVERTED every non-IFC4 model: an IFC2X3
+// or IFC4X3 file came back out under a `FILE_SCHEMA(('IFC4'))` header — the
+// wrong schema token, and an invalid file wherever the source used
+// schema-specific entities (e.g. AB22's IFC4X3 IfcRoad / IfcCourse /
+// IfcPavement have no IFC4 equivalent). The wrapper must default to the SOURCE
+// schema, matching `StepExporter.export()`'s own fallback and the
+// `?? store.schemaVersion ?? 'IFC4'` every internal caller already spells out.
+const SCHEMA_FIXTURES = [
+  { name: 'various/test.ifc', schema: 'IFC2X3', token: 'IFC2X3' },
+  { name: 'AB22.ifc', schema: 'IFC4X3', token: 'IFC4X3_RC4' },
+] as const;
+const SCHEMA_FIXTURES_AVAILABLE = SCHEMA_FIXTURES.every((f) =>
+  existsSync(resolve(MODELS_DIR, f.name)),
+);
+
+function fileSchemaToken(step: string): string | undefined {
+  // FILE_SCHEMA(('IFC4X3_RC4')); -> IFC4X3_RC4
+  return step.match(/FILE_SCHEMA\s*\(\s*\(\s*'([^']+)'/)?.[1];
+}
+
+describe.skipIf(!SCHEMA_FIXTURES_AVAILABLE)('exportToStep default schema fidelity', () => {
+  for (const fixture of SCHEMA_FIXTURES) {
+    it(`preserves the source ${fixture.schema} schema when no schema option is given (${fixture.name})`, async () => {
+      const original = await parseFixture(fixture.name);
+      expect(original.schemaVersion).toBe(fixture.schema);
+
+      // No `schema` option: the default must NOT force conversion to IFC4.
+      const step = exportToStep(original);
+      expect(fileSchemaToken(step)).toBe(fixture.token);
+
+      const store = await new IfcParser().parseColumnar(
+        new TextEncoder().encode(step).buffer as ArrayBuffer,
+      );
+      expect(store.schemaVersion).toBe(fixture.schema);
+      // The whole model must still be present (no entities lost to a
+      // spurious cross-schema conversion pass).
+      expect(store.entityCount).toBe(original.entityCount);
+    });
+  }
+
+  it('still honors an EXPLICIT schema override (conversion path is unchanged)', async () => {
+    const original = await parseFixture('various/test.ifc');
+    expect(original.schemaVersion).toBe('IFC2X3');
+    // Control: an explicit target still converts, proving the fix only moved
+    // the DEFAULT and did not disable the conversion path.
+    const step = exportToStep(original, { schema: 'IFC4' });
+    expect(fileSchemaToken(step)).toBe('IFC4');
+  });
 });


### PR DESCRIPTION
## The defect

The `exportToStep(store)` convenience wrapper — the public one-call parse → STEP-write → re-parse round-trip path — hardcoded `schema: 'IFC4'` as its default. A caller who omitted `schema` therefore silently schema-**converted** every non-IFC4 model:

- an **IFC2X3** file came back out under `FILE_SCHEMA(('IFC4'))`, re-parsing as IFC4;
- an **IFC4X3** file (e.g. `AB22.ifc`, whose `IfcRoad` / `IfcCourse` / `IfcPavement` / `IfcEarthworksFill` have **no IFC4 equivalent**) was emitted under an `IFC4` header — a mislabeled, schema-invalid file.

This is a real fidelity defect: a plain round-trip lost the model's schema identity. The `StepExporter.export()` class already defaults correctly (`options.schema || dataStore.schemaVersion || 'IFC4'`), and **every** internal caller (the CLI and MCP headless backends) already worked around the wrapper by pre-computing `?? store.schemaVersion ?? 'IFC4'` before calling it — the tell that the wrapper's default was wrong.

## The fix

Default `exportToStep`'s `schema` to `dataStore.schemaVersion`, so wrapper and class agree by construction and a round-trip preserves the source schema (exact token included, e.g. `IFC4X3_RC4`). Passing `schema` explicitly still converts, exactly as before.

## Evidence (RED / GREEN / control)

A regression matrix added to `step-roundtrip.test.ts` over real fixtures:

- **RED** on unmodified `main`: `exportToStep(various/test.ifc store)` → `FILE_SCHEMA(('IFC4'))`, re-parses as `IFC4` (expected `IFC2X3`); same for `AB22.ifc` (IFC4X3 → IFC4). Both assertions fail.
- **GREEN** with the fix: schema token and re-parsed `schemaVersion` preserved; entity count unchanged.
- **Control**: `exportToStep(store, { schema: 'IFC4' })` still emits `FILE_SCHEMA(('IFC4'))` — proving only the default moved, the conversion path is untouched.

Full `@ifc-lite/export` suite: 1047 passing. Docs (`docs/guide/exporting.md`) updated to state the corrected default. Changeset: `minor`. The exported API surface is unchanged.

## Scope note

I also parsed → STEP-wrote (source schema) → re-parsed 8 real fixtures (IFC2X3 / IFC4 / IFC4X3, with psets, quantities, materials + layer sets, types, classifications, spatial containment, openings/voids) and confirmed the same-schema full-file writer is a byte-faithful pass-through with **zero** entity/attribute divergence — the one fidelity gap was this default-schema footgun in the convenience wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436