### PR TITLE
fix(ifcx): transform explicit mesh normals by inverse-transpose under non-uniform scale

### DIFF
--- a/.changeset/ifcx-nonuniform-scale-normal-transform.md
+++ b/.changeset/ifcx-nonuniform-scale-normal-transform.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/ifcx': patch
+---
+
+Fix a wrong mesh normal under a non-uniform-scale or shearing `usd::xformop`. `extractGeometry` transformed an explicit `usd::usdgeom::mesh` `normals` entry by the same matrix it uses for vertex positions; that only preserves perpendicularity to the surface when the accumulated local-to-world transform is orthogonal (pure rotation/translation). A real PCERT fixture (`tests/models/ifc5/Tunnel_Excavation_07_Invert.ifcx`) carries a `usd::xformop` with a 2x non-uniform scale on one axis composed with a rotation, so a producer that ships explicit normals under such a transform previously came out shaded wrong. Normals now transform by the inverse-transpose of the transform's linear part, per the USD/ifcx spec.

--- a/packages/ifcx/src/geometry-extractor.test.ts
+++ b/packages/ifcx/src/geometry-extractor.test.ts
@@ -295,4 +295,78 @@ describe('extractGeometry', () => {
     assert.strictEqual(meshes[0].expressId, 20);
     assert.strictEqual(meshes[0].ifcType, 'IfcRepresentation');
   });
+
+  it('transforms an explicit usd::usdgeom::mesh normal so it stays perpendicular to a sheared, non-uniformly-scaled triangle', () => {
+    // USD (and the ifcx spec) transform a normal by the inverse-transpose of
+    // the local-to-world linear map, not by the map itself: for a row-vector
+    // convention (v' = v * M, as used elsewhere in this file for positions),
+    // the correct normal transform is n' = n * inverse(M)^T. Transforming
+    // the normal by M directly (what the code did) only coincides with the
+    // correct answer when M is orthogonal (pure rotation/translation); a
+    // real PCERT fixture (tests/models/ifc5/Tunnel_Excavation_07_Invert.ifcx)
+    // carries a non-uniform-scale usd::xformop, so this is not a
+    // hypothetical shape.
+    const wall = createNode('wall');
+    wall.attributes.set(ATTR.CLASS, ifcClass('IfcWall'));
+    wall.attributes.set(ATTR.TRANSFORM, {
+      transform: [
+        [1.0, 0.0, 0.5, 0],
+        [0.0, 2.0, 0.0, 0],
+        [0.3, 0.0, 1.0, 0],
+        [0, 0, 0, 1],
+      ],
+    });
+
+    const p0: [number, number, number] = [0, 0, 0];
+    const p1: [number, number, number] = [1, 0, 0];
+    const p2: [number, number, number] = [0, 1, 1];
+    const mesh: UsdMesh = {
+      points: [p0, p1, p2],
+      faceVertexIndices: [0, 1, 2],
+      // The un-normalized geometric normal of the p0/p1/p2 triangle:
+      // cross(p1-p0, p2-p0) = (0, -1, 1), normalized below.
+      normals: [
+        [0, -Math.SQRT1_2, Math.SQRT1_2],
+        [0, -Math.SQRT1_2, Math.SQRT1_2],
+        [0, -Math.SQRT1_2, Math.SQRT1_2],
+      ],
+    };
+    wall.attributes.set(ATTR.MESH, mesh);
+
+    const composed = new Map<string, ComposedNode>([[wall.path, wall]]);
+    const pathToId = new Map([[wall.path, 1]]);
+
+    const meshes = extractGeometry(composed, pathToId);
+    assert.strictEqual(meshes.length, 1);
+
+    const { positions, normals } = meshes[0];
+    // Vertex 0 is the shared corner; check its normal against both
+    // transformed edges emanating from it (viewer output is Y-up, so
+    // reconstruct edges/normal from the already-converted positions).
+    const v = (i: number): [number, number, number] => [
+      positions[i * 3],
+      positions[i * 3 + 1],
+      positions[i * 3 + 2],
+    ];
+    const sub = (a: [number, number, number], b: [number, number, number]): [number, number, number] => [
+      a[0] - b[0],
+      a[1] - b[1],
+      a[2] - b[2],
+    ];
+    const dot = (a: [number, number, number], b: [number, number, number]) =>
+      a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+
+    const e1 = sub(v(1), v(0));
+    const e2 = sub(v(2), v(0));
+    const n0: [number, number, number] = [normals[0], normals[1], normals[2]];
+
+    assert.ok(
+      Math.abs(dot(n0, e1)) < 1e-5,
+      `transformed normal must stay perpendicular to a transformed in-plane edge (got dot=${dot(n0, e1)})`
+    );
+    assert.ok(
+      Math.abs(dot(n0, e2)) < 1e-5,
+      `transformed normal must stay perpendicular to a transformed in-plane edge (got dot=${dot(n0, e2)})`
+    );
+  });
 });

--- a/packages/ifcx/src/geometry-extractor.ts
+++ b/packages/ifcx/src/geometry-extractor.ts
@@ -15,6 +15,7 @@
 import type { ComposedNode, UsdMesh, UsdTransform } from './types.js';
 import { ATTR } from './types.js';
 import { getNodeLineage, type TraversalFrame, walkComposedFrames } from './traversal.js';
+import { computeNormalMatrix, computeNormals } from './geometry-normals.js';
 
 /**
  * MeshData interface compatible with @ifc-lite/geometry
@@ -311,66 +312,26 @@ function resolvePresentation(lineage: ComposedNode[]): [number, number, number, 
 }
 
 /**
- * Compute normals from triangle mesh.
- */
-function computeNormals(positions: Float32Array, indices: Uint32Array): Float32Array {
-  const normals = new Float32Array(positions.length);
-
-  for (let i = 0; i < indices.length; i += 3) {
-    const i0 = indices[i] * 3;
-    const i1 = indices[i + 1] * 3;
-    const i2 = indices[i + 2] * 3;
-
-    // Triangle vertices
-    const ax = positions[i0], ay = positions[i0 + 1], az = positions[i0 + 2];
-    const bx = positions[i1], by = positions[i1 + 1], bz = positions[i1 + 2];
-    const cx = positions[i2], cy = positions[i2 + 1], cz = positions[i2 + 2];
-
-    // Edge vectors
-    const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
-    const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
-
-    // Cross product
-    const nx = e1y * e2z - e1z * e2y;
-    const ny = e1z * e2x - e1x * e2z;
-    const nz = e1x * e2y - e1y * e2x;
-
-    // Accumulate (will normalize later)
-    normals[i0] += nx; normals[i0 + 1] += ny; normals[i0 + 2] += nz;
-    normals[i1] += nx; normals[i1 + 1] += ny; normals[i1 + 2] += nz;
-    normals[i2] += nx; normals[i2 + 1] += ny; normals[i2 + 2] += nz;
-  }
-
-  // Normalize
-  for (let i = 0; i < normals.length; i += 3) {
-    const len = Math.sqrt(normals[i] ** 2 + normals[i + 1] ** 2 + normals[i + 2] ** 2);
-    if (len > 0) {
-      normals[i] /= len;
-      normals[i + 1] /= len;
-      normals[i + 2] /= len;
-    }
-  }
-
-  return normals;
-}
-
-/**
  * Flatten 2D normals array to 1D, transform, and convert to Y-up.
  */
 function flattenNormals(normals: number[][], transform: Float32Array | null): Float32Array {
   const result = new Float32Array(normals.length * 3);
 
-  const hasTransform = transform !== null;
+  const normalMatrix = transform ? computeNormalMatrix(transform) : null;
 
   for (let i = 0; i < normals.length; i++) {
     // Normal in Z-up space
     let [nx, ny, nz] = normals[i];
 
-    if (hasTransform && transform) {
-      // Transform normal by upper 3x3 of matrix (rotation only)
-      const tnx = transform[0] * nx + transform[4] * ny + transform[8] * nz;
-      const tny = transform[1] * nx + transform[5] * ny + transform[9] * nz;
-      const tnz = transform[2] * nx + transform[6] * ny + transform[10] * nz;
+    if (normalMatrix) {
+      // Transform by the inverse-transpose of the local-to-world linear
+      // map (see computeNormalMatrix): using the map itself, as positions
+      // do, only preserves perpendicularity to the surface when the map
+      // is orthogonal (rotation/translation only) — a non-uniform-scale
+      // or shearing usd::xformop rotates the normal off the surface.
+      const tnx = nx * normalMatrix[0] + ny * normalMatrix[3] + nz * normalMatrix[6];
+      const tny = nx * normalMatrix[1] + ny * normalMatrix[4] + nz * normalMatrix[7];
+      const tnz = nx * normalMatrix[2] + ny * normalMatrix[5] + nz * normalMatrix[8];
 
       // Renormalize
       const len = Math.sqrt(tnx ** 2 + tny ** 2 + tnz ** 2);

--- a/packages/ifcx/src/geometry-normals.ts
+++ b/packages/ifcx/src/geometry-normals.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/**
+ * Compute the normal-transform matrix for a local-to-world affine
+ * transform: the inverse-transpose of its upper-left 3x3 linear part.
+ *
+ * Positions transform as `v' = v * M` (row vector, M row-major — see
+ * `applyTransform`/`combineTransforms` in geometry-extractor.ts). Under
+ * that convention, a vector `e` tangent to the surface (an edge)
+ * transforms as `e' = e * M`, and the transformed normal `n'` must satisfy
+ * `n' . e' = 0` whenever `n . e = 0`. Substituting shows
+ * `n' = n * inverse(M)^T`, which reduces to `n' = n * M` only when M is
+ * orthogonal (M^-1 = M^T) — true for pure rotation, false under
+ * non-uniform scale or shear (a real `usd::xformop` shape: see
+ * `tests/models/ifc5/Tunnel_Excavation_07_Invert.ifcx`).
+ *
+ * `inverse(M)^T` equals `cofactor(M) / det(M)` (the adjugate is
+ * `cofactor(M)^T`, so its transpose is `cofactor(M)` again), so this
+ * returns the cofactor matrix scaled by `1/det`, flattened row-major.
+ * Returns null for a singular or non-finite linear part (degenerate
+ * transform; callers fall back to the untransformed normal).
+ */
+export function computeNormalMatrix(m: Float32Array): Float32Array | null {
+  const a00 = m[0], a01 = m[1], a02 = m[2];
+  const a10 = m[4], a11 = m[5], a12 = m[6];
+  const a20 = m[8], a21 = m[9], a22 = m[10];
+
+  const det =
+    a00 * (a11 * a22 - a12 * a21) -
+    a01 * (a10 * a22 - a12 * a20) +
+    a02 * (a10 * a21 - a11 * a20);
+
+  if (!Number.isFinite(det) || Math.abs(det) < 1e-12) return null;
+  const invDet = 1 / det;
+
+  const result = new Float32Array(9);
+  result[0] = (a11 * a22 - a12 * a21) * invDet;
+  result[1] = -(a10 * a22 - a12 * a20) * invDet;
+  result[2] = (a10 * a21 - a11 * a20) * invDet;
+  result[3] = -(a01 * a22 - a02 * a21) * invDet;
+  result[4] = (a00 * a22 - a02 * a20) * invDet;
+  result[5] = -(a00 * a21 - a01 * a20) * invDet;
+  result[6] = (a01 * a12 - a02 * a11) * invDet;
+  result[7] = -(a00 * a12 - a02 * a10) * invDet;
+  result[8] = (a00 * a11 - a01 * a10) * invDet;
+  return result;
+}
+
+/**
+ * Compute per-vertex normals from a triangle mesh by accumulating each
+ * triangle's face normal (cross product of its edges) at its three
+ * vertices, then normalizing. Used when a `usd::usdgeom::mesh` node omits
+ * explicit `normals`.
+ */
+export function computeNormals(positions: Float32Array, indices: Uint32Array): Float32Array {
+  const normals = new Float32Array(positions.length);
+
+  for (let i = 0; i < indices.length; i += 3) {
+    const i0 = indices[i] * 3;
+    const i1 = indices[i + 1] * 3;
+    const i2 = indices[i + 2] * 3;
+
+    // Triangle vertices
+    const ax = positions[i0], ay = positions[i0 + 1], az = positions[i0 + 2];
+    const bx = positions[i1], by = positions[i1 + 1], bz = positions[i1 + 2];
+    const cx = positions[i2], cy = positions[i2 + 1], cz = positions[i2 + 2];
+
+    // Edge vectors
+    const e1x = bx - ax, e1y = by - ay, e1z = bz - az;
+    const e2x = cx - ax, e2y = cy - ay, e2z = cz - az;
+
+    // Cross product
+    const nx = e1y * e2z - e1z * e2y;
+    const ny = e1z * e2x - e1x * e2z;
+    const nz = e1x * e2y - e1y * e2x;
+
+    // Accumulate (will normalize later)
+    normals[i0] += nx; normals[i0 + 1] += ny; normals[i0 + 2] += nz;
+    normals[i1] += nx; normals[i1 + 1] += ny; normals[i1 + 2] += nz;
+    normals[i2] += nx; normals[i2 + 1] += ny; normals[i2 + 2] += nz;
+  }
+
+  // Normalize
+  for (let i = 0; i < normals.length; i += 3) {
+    const len = Math.sqrt(normals[i] ** 2 + normals[i + 1] ** 2 + normals[i + 2] ** 2);
+    if (len > 0) {
+      normals[i] /= len;
+      normals[i + 1] /= len;
+      normals[i + 2] /= len;
+    }
+  }
+
+  return normals;
+}


### PR DESCRIPTION
## Lens: ifcx (IFC5) reader vs SPEC — geometry and relationship round-trip

Territory: `packages/ifcx`. Prior merged fixes on this format were all attribute-side (#3522 Description drop, #3524 objectType fabrication, #3529 material skip) — not re-reported here. This PR's angle is GEOMETRY and RELATIONSHIP round-trip, checked against the ifcx/USD spec and the real buildingSMART PCERT fixtures (`tests/models/ifc5/PCERT-Sample-Scene_Building-*.ifcx`), not against our own writer.

### What was checked

| Area | Spec expectation | `packages/ifcx` reader | Verdict |
|---|---|---|---|
| `usd::xformop` parent/child composition | child world = point ∘ child ∘ parent | `combineTransforms`/`multiplyMatrices` in `geometry-extractor.ts` compose row-major matrices right-to-left matching the row-vector convention used for points (`v' = v * M`) | correct |
| `usd::xformop` position transform (incl. non-uniform scale, e.g. real fixtures `Tunnel_Excavation_0{1,6,7}_*.ifcx` which carry a 2x/0.5x anisotropic scale) | vertex positions transform by the full affine matrix | `applyTransform` applies the full matrix with a validated homogeneous divide | correct |
| **`usd::usdgeom::mesh` explicit `normals` transform** | a normal transforms by the **inverse-transpose** of the linear part of the local-to-world map, not by the map itself — the two coincide only when the map is orthogonal (pure rotation/translation) | `flattenNormals` applied the **same matrix used for positions** to normals | **BUG — fixed in this PR** |
| Axis convention (ifcx is Z-up, viewer is Y-up) | swap Y/Z consistently for every emitted vertex/normal | `convertUsdMesh`/`flattenNormals` apply the identical Y↔Z swap after the world transform, and `pointcloud-extractor.ts` uses the same convention | correct |
| Diamond/aliased containment (a node reachable via two `children` edges, e.g. our own exporter's storey+space containment) | emit once per distinct (path, entity context, transform, presentation) | `emitted` dedupe key in `extractGeometry` collapses true aliases, keeps genuinely different instancing/styling | correct (already covered by `PR #1041 round-trip ×4` regression test) |
| Forward-referenced `children` path (child node's JSON entry appears later in `data[]`) | resolves regardless of array order | `composeNode` recurses into `preComposed` (a path→node map built before composition), independent of array order | correct |
| Cyclic `children`/`inherits` reference | tolerate, don't crash | `composition.ts` `composeNode` and `traversal.ts` `traverse`/`markReachable` both carry a per-branch `visited` set and break the cycle with a stub node + warning | correct |
| Cross-layer composition of geometry/relationship attributes (later layer entry overrides earlier for the same path) | later wins, including `null` as a removal mask that survives flattening | `flattenNodes` in `composition.ts` does `Object.assign` in file order (later wins) for `attributes` **and** `children`, and `composeNode` resolves `null` masks after inheritance | correct |
| Spatial tree reconstruction from `children` (Project→Site→Building→Storey→Element) | recurse only into `SPATIAL_TYPES`, collect non-spatial descendants as elements | `hierarchy-builder.ts` `buildSpatialNode`/`collectElementIds` do this, with a separate path for `IfcRelSpaceBoundary`-shaped edges | correct |

### The bug

`extractGeometry`'s `flattenNormals` transformed an explicit `usd::usdgeom::mesh` `normals` entry by the **same 4x4 matrix** used for vertex positions (`transform[0]*nx + transform[4]*ny + transform[8]*nz`, etc.). That is only correct when the accumulated `usd::xformop` is orthogonal (a pure rotation/translation) — a non-uniform-scale or shearing transform rotates the resulting normal off the surface, because for a row-vector convention (`v' = v*M`, the convention this reader uses for positions), the transform that preserves `normal · tangent = 0` is `n' = n * inverse(M)^T`, which reduces to `n' = n * M` only when `M` is orthogonal.

This is not hypothetical: three real PCERT fixtures (`Tunnel_Excavation_01_TopHeading_0-1.ifcx`, `_06_Bench.ifcx`, `_07_Invert.ifcx`) carry a `usd::xformop` with anisotropic scale (2x on one axis, or 0.5x) composed with a rotation. Those particular fixtures happen to omit explicit `normals` (falling back to the correct computed-from-geometry path), but any spec-compliant producer that *does* ship explicit normals under such a transform — which the ifcx/USD spec permits — would come out shaded wrong: normals no longer perpendicular to the transformed surface, breaking lighting and (depending on renderer settings) backface culling.

### RED → GREEN

Added a unit test (`geometry-extractor.test.ts`) that builds a minimal ifcx-shaped node with an explicit `normals` array and a non-orthogonal `usd::xformop` (shear + non-uniform scale, structurally the same shape as the real Tunnel fixtures' transforms) and asserts the reader's output normal stays perpendicular to the transformed triangle edges (`n' · e' ≈ 0`), which is the spec invariant.

- **RED** on unmodified `main`: `dot=0.3546` (not perpendicular — visibly wrong).
- **GREEN** after the fix: `dot < 1e-5`.
- **Control**: existing rotation-only transform tests in the same file (dedupe/identity-xformop cases) still pass unchanged, since inverse-transpose of an orthogonal matrix equals the matrix itself.

### Fix

`flattenNormals` now transforms normals by the inverse-transpose of the transform's upper-left 3x3 linear part (`computeNormalMatrix`, extracted to a new sibling module `geometry-normals.ts` alongside the pre-existing `computeNormals` flat-shading fallback, to keep `geometry-extractor.ts` under the module-size budget). `computeNormalMatrix` returns `null` for a singular/degenerate linear part, in which case the caller falls back to the untransformed normal (same behavior as the pre-existing "no transform" path).

### Verification

- `pnpm --filter @ifc-lite/ifcx build` — clean.
- `pnpm --filter @ifc-lite/ifcx test` — 192/192 pass (0 fail).
- `pnpm exec tsc --noEmit` in `packages/ifcx` — clean.
- Loaded the real `Tunnel_Excavation_07_Invert.ifcx` PCERT-adjacent fixture through `parseIfcx` post-fix — parses without error, 1 mesh extracted (this fixture doesn't carry explicit normals, so it exercises the transform-composition path but not the normals path directly).
- `node scripts/check-module-size.mjs` — OK (0 new over 400; `geometry-extractor.ts` now measures 373 lines, under its 412-line allowlist budget — allowlist file intentionally left untouched per house rules).
- `pnpm run check:vitest-timeout-audit` — clean, no parenthesized regex literals added.
- `node scripts/check-test-wiring.mjs` — OK.
- `node scripts/check-unused-locals.mjs` — `packages/ifcx` not in the failing/flagged list (other packages fail to compile standalone in this environment due to unbuilt sibling `dist/`, pre-existing and unrelated to this change).
- No `index.ts` export changes — API surface unaffected.
- Changeset added: `@ifc-lite/ifcx` patch.

Never merged/closed — for maintainer review.
