### PR TITLE
fix(collab): stop createGeometry dropping an explicit empty-string blobHash

### DIFF
--- a/.changeset/collab-geometry-empty-blobhash.md
+++ b/.changeset/collab-geometry-empty-blobhash.md
@@ -1,0 +1,5 @@
+---
+'@ifc-lite/collab': patch
+---
+
+`createGeometry` no longer drops an explicit empty-string `blobHash` (`if (opts.blobHash)` was a truthiness check, so `blobHash: ''` never made it into the Y.Doc — the value was lost before there was anything to snapshot or seed back). `createGeometry` now checks `!== undefined`, matching the contract `upsertGeometry` already used.

--- a/packages/collab/src/doc/geometry.ts
+++ b/packages/collab/src/doc/geometry.ts
@@ -62,7 +62,12 @@ export function createGeometry(
   const node = new Y.Map<unknown>();
   node.set(GEOMETRY_KEY.TYPE, opts.type);
   node.set(GEOMETRY_KEY.SOURCE, opts.source);
-  if (opts.blobHash) node.set(GEOMETRY_KEY.BLOB_HASH, opts.blobHash);
+  // `!== undefined`, not a truthiness check: an explicit `blobHash: ''`
+  // is a value the caller supplied and must survive, the same contract
+  // `upsertGeometry` already honours below. A truthy guard here silently
+  // drops it before the doc even exists to round-trip from (#1031-adjacent —
+  // see round-trip.test.ts).
+  if (opts.blobHash !== undefined) node.set(GEOMETRY_KEY.BLOB_HASH, opts.blobHash);
 
   const params = new Y.Map<unknown>();
   if (opts.params) {

--- a/packages/collab/test/round-trip.test.ts
+++ b/packages/collab/test/round-trip.test.ts
@@ -202,6 +202,35 @@ describe('structured branches across snapshot → seed (#1031)', () => {
     expect(snapshotToIfcx(docB).data).toEqual(ifcx.data);
   });
 
+  // `createGeometry` used to gate `blobHash` on truthiness (`if
+  // (opts.blobHash)`), so an explicit empty-string hash never made it
+  // into the doc in the first place — the value was lost before there
+  // was anything to snapshot or seed. `upsertGeometry` already used the
+  // correct `!== undefined` check (see upsert-geometry.test.ts); this
+  // pins `createGeometry` to the same contract end-to-end.
+  it('an explicit empty-string blobHash survives snapshot -> seed', () => {
+    const doc = createCollabDoc();
+    createEntity(doc, 'wall');
+    createGeometry(doc, 'geom-9', { type: 'mesh', source: 'mesh-blob', blobHash: '' });
+    setGeometryRef(doc, 'wall', { geomIds: ['geom-9'] });
+
+    // The write itself must keep the value, before any snapshot happens.
+    expect(getGeometry(doc, 'geom-9')?.get('blobHash')).toBe('');
+
+    const ifcx = snapshotToIfcx(doc);
+    const node = ifcx.data.find((n) => n.path === 'wall')!;
+    expect(node.attributes?.['ifclite::geometryRef']).toEqual({
+      geomId: 'geom-9',
+      type: 'mesh',
+      source: 'mesh-blob',
+      blobHash: '',
+    });
+
+    const docB = createCollabDoc();
+    seedFromIfcx(docB, ifcx);
+    expect(getGeometry(docB, 'geom-9')?.get('blobHash')).toBe('');
+  });
+
   it('typed records under Qto_* sets inflate into quantities, not psets', () => {
     const doc = createCollabDoc();
     createEntity(doc, 'wall');


### PR DESCRIPTION
## Summary

`packages/collab`'s snapshot round-trip (`seedFromIfcx` → `snapshotToIfcx` → `seedFromIfcx`) is expected to preserve every field, including falsy scalar values. Probing the geometry-reference branch found one: `createGeometry` (`packages/collab/src/doc/geometry.ts`) gated `blobHash` on truthiness —

```ts
if (opts.blobHash) node.set(GEOMETRY_KEY.BLOB_HASH, opts.blobHash);
```

— so an explicit `blobHash: ''` was dropped at write time, before there was ever anything to snapshot or seed back. Every entry point that can create a new geometry record (`createGeometry` directly, and `upsertGeometry`'s create-if-absent fallback) went through this gate, so the value was structurally unreachable, not merely lossy on one path.

`upsertGeometry` right below it already used the correct contract (`opts.blobHash !== undefined`) — see the comment in `upsert-geometry.test.ts` explaining why that check matters for the overlay path. `createGeometry` now matches it.

## Fidelity matrix (this probe)

| Field | Falsy value tried | Verdict before | Verdict after |
|---|---|---|---|
| geometry `blobHash` (via `createGeometry`) | `''` | dropped silently | survives write + snapshot → seed |
| geometry `blobHash` (via `upsertGeometry`, existing record) | `''` | survives (already correct) | unchanged (control) |
| pset property value (`IfcBoolean`) | `false` | survives (`isTypedPropertyValue` uses `'value' in record`, not truthiness) | unchanged (control, already covered by `round-trip.test.ts`) |
| quantity value | `0` | survives (`typeof === 'number' && Number.isFinite`, no truthiness) | unchanged (control) |
| explicitly-empty `classifications`/`materials` array | `[]` | survives (#1031 regression test already pins this) | unchanged (control) |

## Test plan
- [x] RED on unmodified `packages/collab/src/doc/geometry.ts`: `getGeometry(doc, id)?.get('blobHash')` is `undefined` after `createGeometry(doc, id, { ..., blobHash: '' })`, and the wire form (`snapshotToIfcx`) never carries `blobHash` at all.
- [x] GREEN after the one-line fix: the value survives the write, the wire form, and a fresh `seedFromIfcx`.
- [x] Control: the existing non-empty `blobHash` round-trip test (`round-trip.test.ts` — "geometry refs carry their record...") and `upsert-geometry.test.ts` still pass unchanged.
- [x] `pnpm --filter @ifc-lite/collab exec tsc --noEmit`
- [x] `pnpm test:collab` (both `@ifc-lite/collab` and `@ifc-lite/collab-server`) — 262/262 + 186/186 passing
- [x] `node scripts/check-module-size.mjs` — OK
- [x] `node scripts/check-test-wiring.mjs` — OK
- [x] `node scripts/check-unused-locals.mjs` — no regression in `packages/collab`
- [x] Changeset added (`@ifc-lite/collab`, patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPHChk3Ve9N519A4kY7436